### PR TITLE
Frame: Normalize member names

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -83,8 +83,8 @@ void CCodeWindow::Load()
     ini.GetOrCreateSection("ShowOnStart")->Get(SettingName[i], &bShowOnStart[i], false);
 
   // Get notebook affiliation
-  std::string section = "P - " + ((Parent->ActivePerspective < Parent->Perspectives.size()) ?
-                                      Parent->Perspectives[Parent->ActivePerspective].Name :
+  std::string section = "P - " + ((Parent->m_active_perspective < Parent->m_perspectives.size()) ?
+                                      Parent->m_perspectives[Parent->m_active_perspective].name :
                                       "Perspective 1");
 
   for (int i = 0; i <= IDM_CODE_WINDOW - IDM_LOG_WINDOW; i++)
@@ -92,7 +92,7 @@ void CCodeWindow::Load()
 
   // Get floating setting
   for (int i = 0; i <= IDM_CODE_WINDOW - IDM_LOG_WINDOW; i++)
-    ini.GetOrCreateSection("Float")->Get(SettingName[i], &Parent->bFloatWindow[i], false);
+    ini.GetOrCreateSection("Float")->Get(SettingName[i], &Parent->m_float_window[i], false);
 }
 
 void CCodeWindow::Save()
@@ -114,7 +114,7 @@ void CCodeWindow::Save()
         ->Set(SettingName[i - IDM_LOG_WINDOW], GetParentMenuBar()->IsChecked(i));
 
   // Save notebook affiliations
-  std::string section = "P - " + Parent->Perspectives[Parent->ActivePerspective].Name;
+  std::string section = "P - " + Parent->m_perspectives[Parent->m_active_perspective].name;
   for (int i = 0; i <= IDM_CODE_WINDOW - IDM_LOG_WINDOW; i++)
     ini.GetOrCreateSection(section)->Set(SettingName[i], iNbAffiliation[i]);
 
@@ -536,7 +536,7 @@ void CCodeWindow::TogglePanel(int id, bool show)
       panel = CreateSiblingPanel(id);
     }
     Parent->DoAddPage(panel, iNbAffiliation[id - IDM_DEBUG_WINDOW_LIST_START],
-                      Parent->bFloatWindow[id - IDM_DEBUG_WINDOW_LIST_START]);
+                      Parent->m_float_window[id - IDM_DEBUG_WINDOW_LIST_START]);
   }
   else if (panel)  // Close
   {

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -250,7 +250,7 @@ void CMemoryView::OnPopupMenu(wxCommandEvent& event)
 {
   // FIXME: This is terrible. Generate events instead.
   CFrame* cframe = wxGetApp().GetCFrame();
-  CCodeWindow* code_window = cframe->g_pCodeWindow;
+  CCodeWindow* code_window = cframe->m_code_window;
   CWatchWindow* watch_window = code_window->GetPanel<CWatchWindow>();
 
   switch (event.GetId())

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -514,7 +514,7 @@ void CRegisterView::OnPopupMenu(wxCommandEvent& event)
 {
   // FIXME: This is terrible. Generate events instead.
   CFrame* cframe = wxGetApp().GetCFrame();
-  CCodeWindow* code_window = cframe->g_pCodeWindow;
+  CCodeWindow* code_window = cframe->m_code_window;
   CWatchWindow* watch_window = code_window->GetPanel<CWatchWindow>();
   CMemoryWindow* memory_window = code_window->GetPanel<CMemoryWindow>();
 

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -277,7 +277,7 @@ void CWatchView::OnPopupMenu(wxCommandEvent& event)
 {
   // FIXME: This is terrible. Generate events instead.
   CFrame* cframe = wxGetApp().GetCFrame();
-  CCodeWindow* code_window = cframe->g_pCodeWindow;
+  CCodeWindow* code_window = cframe->m_code_window;
   CWatchWindow* watch_window = code_window->GetPanel<CWatchWindow>();
   CMemoryWindow* memory_window = code_window->GetPanel<CMemoryWindow>();
   CBreakPointWindow* breakpoint_window = code_window->GetPanel<CBreakPointWindow>();

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -318,22 +318,19 @@ static void SignalHandler(int)
 CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geometry,
                bool use_debugger, bool batch_mode, bool show_log_window, long style)
     : CRenderFrame(parent, id, title, wxDefaultPosition, wxSize(800, 600), style),
-      UseDebugger(use_debugger), m_bBatchMode(batch_mode)
+      m_use_debugger(use_debugger), m_batch_mode(batch_mode)
 {
   BindEvents();
-
-  for (int i = 0; i <= IDM_CODE_WINDOW - IDM_LOG_WINDOW; i++)
-    bFloatWindow[i] = false;
 
   if (show_log_window)
     SConfig::GetInstance().m_InterfaceLogWindow = true;
 
   // Debugger class
-  if (UseDebugger)
+  if (m_use_debugger)
   {
-    g_pCodeWindow = new CCodeWindow(this, IDM_CODE_WINDOW);
+    m_code_window = new CCodeWindow(this, IDM_CODE_WINDOW);
     LoadIniPerspectives();
-    g_pCodeWindow->Load();
+    m_code_window->Load();
   }
 
   wxFrame::CreateToolBar(wxTB_DEFAULT_STYLE | wxTB_TEXT | wxTB_FLAT)->Realize();
@@ -351,21 +348,21 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
   // ---------------
   // Main panel
   // This panel is the parent for rendering and it holds the gamelistctrl
-  m_Panel = new wxPanel(this, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
+  m_panel = new wxPanel(this, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
 
-  m_GameListCtrl = new CGameListCtrl(m_Panel, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                                     wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT);
-  m_GameListCtrl->Bind(wxEVT_LIST_ITEM_ACTIVATED, &CFrame::OnGameListCtrlItemActivated, this);
+  m_game_list_ctrl = new CGameListCtrl(m_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                                       wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT);
+  m_game_list_ctrl->Bind(wxEVT_LIST_ITEM_ACTIVATED, &CFrame::OnGameListCtrlItemActivated, this);
 
   wxBoxSizer* sizerPanel = new wxBoxSizer(wxHORIZONTAL);
-  sizerPanel->Add(m_GameListCtrl, 1, wxEXPAND | wxALL);
-  m_Panel->SetSizer(sizerPanel);
+  sizerPanel->Add(m_game_list_ctrl, 1, wxEXPAND | wxALL);
+  m_panel->SetSizer(sizerPanel);
   // ---------------
 
   // Manager
-  m_Mgr = new wxAuiManager(this, wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
+  m_mgr = new wxAuiManager(this, wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
 
-  m_Mgr->AddPane(m_Panel, wxAuiPaneInfo()
+  m_mgr->AddPane(m_panel, wxAuiPaneInfo()
                               .Name("Pane 0")
                               .Caption("Pane 0")
                               .PaneBorder(false)
@@ -373,8 +370,8 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
                               .Layer(0)
                               .Center()
                               .Show());
-  if (!g_pCodeWindow)
-    m_Mgr->AddPane(CreateEmptyNotebook(), wxAuiPaneInfo()
+  if (!m_code_window)
+    m_mgr->AddPane(CreateEmptyNotebook(), wxAuiPaneInfo()
                                               .Name("Pane 1")
                                               .Caption(_("Logging"))
                                               .CaptionVisible(true)
@@ -382,20 +379,20 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
                                               .FloatingSize(wxSize(600, 350))
                                               .CloseButton(true)
                                               .Hide());
-  AuiFullscreen = m_Mgr->SavePerspective();
+  m_aui_fullscreen_perspective = m_mgr->SavePerspective();
 
   if (!SConfig::GetInstance().m_InterfaceToolbar)
     DoToggleToolbar(false);
 
-  m_LogWindow = new CLogWindow(this, IDM_LOG_WINDOW);
-  m_LogWindow->Hide();
-  m_LogWindow->Disable();
+  m_log_window = new CLogWindow(this, IDM_LOG_WINDOW);
+  m_log_window->Hide();
+  m_log_window->Disable();
 
   InitializeTASDialogs();
   InitializeCoreCallbacks();
 
   // Setup perspectives
-  if (g_pCodeWindow)
+  if (m_code_window)
   {
     // Load perspective
     DoLoadPerspective();
@@ -415,13 +412,13 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
                                        FromDIP(wxSize(800, 600)));
 
   // Start debugging maximized (Must be after the window has been positioned)
-  if (UseDebugger)
+  if (m_use_debugger)
     Maximize(true);
 
   // Commit
-  m_Mgr->Update();
+  m_mgr->Update();
 
-  // The window must be shown for m_XRRConfig to be created (wxGTK will not allocate X11
+  // The window must be shown for m_xrr_config to be created (wxGTK will not allocate X11
   // resources until the window is shown for the first time).
   Show();
 
@@ -431,12 +428,12 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
 #endif
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
-  m_XRRConfig = new X11Utils::XRRConfiguration(X11Utils::XDisplayFromHandle(GetHandle()),
-                                               X11Utils::XWindowFromHandle(GetHandle()));
+  m_xrr_config = new X11Utils::XRRConfiguration(X11Utils::XDisplayFromHandle(GetHandle()),
+                                                X11Utils::XWindowFromHandle(GetHandle()));
 #endif
 
   // Connect event handlers
-  m_Mgr->Bind(wxEVT_AUI_RENDER, &CFrame::OnManagerResize, this);
+  m_mgr->Bind(wxEVT_AUI_RENDER, &CFrame::OnManagerResize, this);
 
   // Update controls
   UpdateGUI();
@@ -475,12 +472,12 @@ CFrame::~CFrame()
   g_controller_interface.Shutdown();
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
-  delete m_XRRConfig;
+  delete m_xrr_config;
 #endif
 
   ClosePages();
 
-  delete m_Mgr;
+  delete m_mgr;
 
   // This object is owned by us, not wxw
   m_menubar_shadow->Destroy();
@@ -533,7 +530,7 @@ bool CFrame::RendererIsFullscreen()
 
   if (Core::GetState() == Core::State::Running || Core::GetState() == Core::State::Paused)
   {
-    fullscreen = m_RenderFrame->IsFullScreen();
+    fullscreen = m_render_frame->IsFullScreen();
   }
 
   return fullscreen;
@@ -548,13 +545,13 @@ void CFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
 // Events
 void CFrame::OnActive(wxActivateEvent& event)
 {
-  m_bRendererHasFocus = (event.GetActive() && event.GetEventObject() == m_RenderFrame);
+  m_renderer_has_focus = (event.GetActive() && event.GetEventObject() == m_render_frame);
   if (Core::GetState() == Core::State::Running || Core::GetState() == Core::State::Paused)
   {
-    if (m_bRendererHasFocus)
+    if (m_renderer_has_focus)
     {
       if (SConfig::GetInstance().bRenderToMain)
-        m_RenderParent->SetFocus();
+        m_render_parent->SetFocus();
       else if (RendererIsFullscreen() && g_ActiveConfig.ExclusiveFullscreenEnabled())
         DoExclusiveFullscreen(true);  // Regain exclusive mode
 
@@ -562,7 +559,7 @@ void CFrame::OnActive(wxActivateEvent& event)
         DoPause();
 
       if (SConfig::GetInstance().bHideCursor && Core::GetState() == Core::State::Running)
-        m_RenderParent->SetCursor(wxCURSOR_BLANK);
+        m_render_parent->SetCursor(wxCURSOR_BLANK);
     }
     else
     {
@@ -570,7 +567,7 @@ void CFrame::OnActive(wxActivateEvent& event)
         DoPause();
 
       if (SConfig::GetInstance().bHideCursor)
-        m_RenderParent->SetCursor(wxNullCursor);
+        m_render_parent->SetCursor(wxNullCursor);
     }
   }
   event.Skip();
@@ -588,7 +585,7 @@ void CFrame::OnClose(wxCloseEvent& event)
       event.Veto();
     }
     // Tell OnStopped to resubmit the Close event
-    m_bClosing = true;
+    m_is_closing = true;
     return;
   }
 
@@ -600,19 +597,19 @@ void CFrame::OnClose(wxCloseEvent& event)
   event.Skip();
 
   // Save GUI settings
-  if (g_pCodeWindow)
+  if (m_code_window)
   {
     SaveIniPerspectives();
   }
   else
   {
-    m_LogWindow->SaveSettings();
+    m_log_window->SaveSettings();
   }
-  if (m_LogWindow)
-    m_LogWindow->RemoveAllListeners();
+  if (m_log_window)
+    m_log_window->RemoveAllListeners();
 
   // Uninit
-  m_Mgr->UnInit();
+  m_mgr->UnInit();
 }
 
 // Post events
@@ -620,10 +617,10 @@ void CFrame::OnClose(wxCloseEvent& event)
 // Warning: This may cause an endless loop if the event is propagated back to its parent
 void CFrame::PostEvent(wxCommandEvent& event)
 {
-  if (g_pCodeWindow && event.GetId() >= IDM_INTERPRETER && event.GetId() <= IDM_ADDRBOX)
+  if (m_code_window && event.GetId() >= IDM_INTERPRETER && event.GetId() <= IDM_ADDRBOX)
   {
     event.StopPropagation();
-    g_pCodeWindow->GetEventHandler()->AddPendingEvent(event);
+    m_code_window->GetEventHandler()->AddPendingEvent(event);
   }
   else
   {
@@ -656,10 +653,12 @@ void CFrame::OnResize(wxSizeEvent& event)
   }
 
   // Make sure the logger pane is a sane size
-  if (!g_pCodeWindow && m_LogWindow && m_Mgr->GetPane("Pane 1").IsShown() &&
-      !m_Mgr->GetPane("Pane 1").IsFloating() &&
-      (m_LogWindow->x > GetClientRect().GetWidth() || m_LogWindow->y > GetClientRect().GetHeight()))
+  if (!m_code_window && m_log_window && m_mgr->GetPane("Pane 1").IsShown() &&
+      !m_mgr->GetPane("Pane 1").IsFloating() && (m_log_window->x > GetClientRect().GetWidth() ||
+                                                 m_log_window->y > GetClientRect().GetHeight()))
+  {
     ShowResizePane();
+  }
 }
 
 // Host messages
@@ -694,12 +693,12 @@ void CFrame::UpdateTitle(const std::string& str)
   if (SConfig::GetInstance().bRenderToMain && SConfig::GetInstance().m_InterfaceStatusbar)
   {
     GetStatusBar()->SetStatusText(str, 0);
-    m_RenderFrame->SetTitle(scm_rev_str);
+    m_render_frame->SetTitle(scm_rev_str);
   }
   else
   {
     std::string titleStr = StringFromFormat("%s | %s", scm_rev_str.c_str(), str.c_str());
-    m_RenderFrame->SetTitle(titleStr);
+    m_render_frame->SetTitle(titleStr);
   }
 }
 
@@ -708,7 +707,7 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
   switch (event.GetId())
   {
   case IDM_UPDATE_DISASM_DIALOG:  // For breakpoints causing pausing
-    if (!g_pCodeWindow || Core::GetState() != Core::State::Paused)
+    if (!m_code_window || Core::GetState() != Core::State::Paused)
       return;
   // fallthrough
 
@@ -735,17 +734,17 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
 
   case WM_USER_CREATE:
     if (SConfig::GetInstance().bHideCursor)
-      m_RenderParent->SetCursor(wxCURSOR_BLANK);
+      m_render_parent->SetCursor(wxCURSOR_BLANK);
     break;
 
   case IDM_PANIC:
   {
     wxString caption = event.GetString().BeforeFirst(':');
     wxString text = event.GetString().AfterFirst(':');
-    bPanicResult =
+    m_panic_result =
         (wxYES == wxMessageBox(text, caption, wxSTAY_ON_TOP | (event.GetInt() ? wxYES_NO : wxOK),
                                wxWindow::FindFocus()));
-    panic_event.Set();
+    m_panic_event.Set();
   }
   break;
 
@@ -778,35 +777,35 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
 void CFrame::OnRenderWindowSizeRequest(int width, int height)
 {
   if (!SConfig::GetInstance().bRenderWindowAutoSize || !Core::IsRunning() ||
-      RendererIsFullscreen() || m_RenderFrame->IsMaximized())
+      RendererIsFullscreen() || m_render_frame->IsMaximized())
     return;
 
   wxSize requested_size(width, height);
   // Convert to window pixels, since the size is from the backend it will be in framebuffer px.
-  requested_size *= 1.0 / m_RenderFrame->GetContentScaleFactor();
+  requested_size *= 1.0 / m_render_frame->GetContentScaleFactor();
   wxSize old_size;
 
   if (!SConfig::GetInstance().bRenderToMain)
   {
-    old_size = m_RenderFrame->GetClientSize();
+    old_size = m_render_frame->GetClientSize();
   }
   else
   {
     // Resize for the render panel only, this implicitly retains space for everything else
     // (i.e. log panel, toolbar, statusbar, etc) without needing to compute for them.
-    old_size = m_RenderParent->GetSize();
+    old_size = m_render_parent->GetSize();
   }
 
   wxSize diff = requested_size - old_size;
   if (diff != wxSize())
-    m_RenderFrame->SetSize(m_RenderFrame->GetSize() + diff);
+    m_render_frame->SetSize(m_render_frame->GetSize() + diff);
 }
 
 bool CFrame::RendererHasFocus()
 {
-  if (m_RenderParent == nullptr)
+  if (m_render_parent == nullptr)
     return false;
-  return m_bRendererHasFocus;
+  return m_renderer_has_focus;
 }
 
 void CFrame::OnGameListCtrlItemActivated(wxListEvent& WXUNUSED(event))
@@ -818,7 +817,7 @@ void CFrame::OnGameListCtrlItemActivated(wxListEvent& WXUNUSED(event))
   // 1. Boot the selected iso
   // 2. Boot the default or last loaded iso.
   // 3. Call BrowseForDirectory if the gamelist is empty
-  if (!m_GameListCtrl->GetISO(0) && CGameListCtrl::IsHidingItems())
+  if (!m_game_list_ctrl->GetISO(0) && CGameListCtrl::IsHidingItems())
   {
     SConfig::GetInstance().m_ListGC = SConfig::GetInstance().m_ListWii =
         SConfig::GetInstance().m_ListWad = SConfig::GetInstance().m_ListElfDol =
@@ -853,9 +852,9 @@ void CFrame::OnGameListCtrlItemActivated(wxListEvent& WXUNUSED(event))
 
     UpdateGameList();
   }
-  else if (!m_GameListCtrl->GetISO(0))
+  else if (!m_game_list_ctrl->GetISO(0))
   {
-    m_GameListCtrl->BrowseForDirectory();
+    m_game_list_ctrl->BrowseForDirectory();
   }
   else
   {
@@ -1045,7 +1044,7 @@ void CFrame::OnKeyDown(wxKeyEvent& event)
   // the system beep for unhandled key events when
   // receiving pad/Wiimote keypresses which take an
   // entirely different path through the HID subsystem.
-  if (!m_bRendererHasFocus)
+  if (!m_renderer_has_focus)
   {
     // We do however want to pass events on when the
     // render window is out of focus: this allows use
@@ -1122,13 +1121,13 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
 
   if (SConfig::GetInstance().bRenderToMain)
   {
-    m_RenderFrame->ShowFullScreen(enable_fullscreen, wxFULLSCREEN_ALL);
+    m_render_frame->ShowFullScreen(enable_fullscreen, wxFULLSCREEN_ALL);
 
     if (enable_fullscreen)
     {
       // Save the current mode before going to fullscreen
-      AuiCurrent = m_Mgr->SavePerspective();
-      m_Mgr->LoadPerspective(AuiFullscreen, true);
+      m_aui_current_perspective = m_mgr->SavePerspective();
+      m_mgr->LoadPerspective(m_aui_fullscreen_perspective, true);
 
       // Hide toolbar
       DoToggleToolbar(false);
@@ -1146,7 +1145,7 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
     else
     {
       // Restore saved perspective
-      m_Mgr->LoadPerspective(AuiCurrent, true);
+      m_mgr->LoadPerspective(m_aui_current_perspective, true);
 
       // Restore toolbar to the status it was at before going fullscreen.
       DoToggleToolbar(SConfig::GetInstance().m_InterfaceToolbar);
@@ -1170,16 +1169,16 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
     if (!enable_fullscreen)
       DoExclusiveFullscreen(false);
 
-    m_RenderFrame->ShowFullScreen(enable_fullscreen, wxFULLSCREEN_ALL);
-    m_RenderFrame->Raise();
+    m_render_frame->ShowFullScreen(enable_fullscreen, wxFULLSCREEN_ALL);
+    m_render_frame->Raise();
 
     if (enable_fullscreen)
       DoExclusiveFullscreen(true);
   }
   else
   {
-    m_RenderFrame->ShowFullScreen(enable_fullscreen, wxFULLSCREEN_ALL);
-    m_RenderFrame->Raise();
+    m_render_frame->ShowFullScreen(enable_fullscreen, wxFULLSCREEN_ALL);
+    m_render_frame->Raise();
   }
 }
 
@@ -1285,7 +1284,7 @@ void CFrame::ParseHotkeys()
           IsHotkey(HK_TRIGGER_SYNC_BUTTON, true));
   }
 
-  if (UseDebugger)
+  if (m_use_debugger)
   {
     if (IsHotkey(HK_STEP))
     {
@@ -1328,7 +1327,7 @@ void CFrame::ParseHotkeys()
       if (bpDlg.ShowModal() == wxID_OK)
       {
         wxCommandEvent evt(wxEVT_HOST_COMMAND, IDM_UPDATE_BREAKPOINTS);
-        g_pCodeWindow->GetEventHandler()->AddPendingEvent(evt);
+        m_code_window->GetEventHandler()->AddPendingEvent(evt);
       }
     }
     if (IsHotkey(HK_MBP_ADD))
@@ -1337,7 +1336,7 @@ void CFrame::ParseHotkeys()
       if (memDlg.ShowModal() == wxID_OK)
       {
         wxCommandEvent evt(wxEVT_HOST_COMMAND, IDM_UPDATE_BREAKPOINTS);
-        g_pCodeWindow->GetEventHandler()->AddPendingEvent(evt);
+        m_code_window->GetEventHandler()->AddPendingEvent(evt);
       }
     }
   }
@@ -1430,11 +1429,11 @@ void CFrame::ParseHotkeys()
   }
   if (IsHotkey(HK_SAVE_STATE_SLOT_SELECTED))
   {
-    State::Save(m_saveSlot);
+    State::Save(m_save_slot);
   }
   if (IsHotkey(HK_LOAD_STATE_SLOT_SELECTED))
   {
-    State::Load(m_saveSlot);
+    State::Load(m_save_slot);
   }
 
   if (IsHotkey(HK_TOGGLE_STEREO_SBS))
@@ -1639,6 +1638,6 @@ void CFrame::HandleSignal(wxTimerEvent& event)
 {
   if (!s_shutdown_signal_received.TestAndClear())
     return;
-  m_bClosing = true;
+  m_is_closing = true;
   Close();
 }

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -77,15 +77,15 @@ public:
   void* GetRenderHandle()
   {
 #if defined(HAVE_X11) && HAVE_X11
-    return reinterpret_cast<void*>(X11Utils::XWindowFromHandle(m_RenderParent->GetHandle()));
+    return reinterpret_cast<void*>(X11Utils::XWindowFromHandle(m_render_parent->GetHandle()));
 #else
-    return reinterpret_cast<void*>(m_RenderParent->GetHandle());
+    return reinterpret_cast<void*>(m_render_parent->GetHandle());
 #endif
   }
 
   // These have to be public
-  CCodeWindow* g_pCodeWindow = nullptr;
-  NetPlaySetupFrame* g_NetPlaySetupDiag = nullptr;
+  CCodeWindow* m_code_window = nullptr;
+  NetPlaySetupFrame* m_netplay_setup_frame = nullptr;
 
   void DoStop();
   void UpdateGUI();
@@ -101,56 +101,30 @@ public:
 
   wxMenuBar* GetMenuBar() const override;
 
-  Common::Event panic_event;
-  bool bPanicResult;
-
-#ifdef __WXGTK__
-  std::recursive_mutex keystate_lock;
-#endif
+  Common::Event m_panic_event;
+  bool m_panic_result;
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
-  X11Utils::XRRConfiguration* m_XRRConfig;
+  X11Utils::XRRConfiguration* m_xrr_config;
 #endif
 
   // AUI
-  wxAuiManager* m_Mgr = nullptr;
-  bool bFloatWindow[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START] = {};
+  wxAuiManager* m_mgr = nullptr;
+  bool m_float_window[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START] = {};
 
   // Perspectives (Should find a way to make all of this private)
   void DoAddPage(wxWindow* Win, int i, bool Float);
   void DoRemovePage(wxWindow*, bool bHide = true);
   struct SPerspectives
   {
-    std::string Name;
-    wxString Perspective;
-    std::vector<int> Width, Height;
+    std::string name;
+    wxString perspective;
+    std::vector<int> width, height;
   };
-  std::vector<SPerspectives> Perspectives;
-  u32 ActivePerspective;
+  std::vector<SPerspectives> m_perspectives;
+  u32 m_active_perspective;
 
 private:
-  CGameListCtrl* m_GameListCtrl = nullptr;
-  CConfigMain* m_main_config_dialog = nullptr;
-  wxPanel* m_Panel = nullptr;
-  CRenderFrame* m_RenderFrame = nullptr;
-  wxWindow* m_RenderParent = nullptr;
-  CLogWindow* m_LogWindow = nullptr;
-  LogConfigWindow* m_LogConfigWindow = nullptr;
-  FifoPlayerDlg* m_FifoPlayerDlg = nullptr;
-  std::array<TASInputDlg*, 8> m_tas_input_dialogs{};
-  wxCheatsWindow* m_cheats_window = nullptr;
-  bool UseDebugger = false;
-  bool m_bBatchMode = false;
-  bool m_bEdit = false;
-  bool m_bTabSplit = false;
-  bool m_bNoDocking = false;
-  bool m_bGameLoading = false;
-  bool m_bClosing = false;
-  bool m_bRendererHasFocus = false;
-  bool m_confirmStop = false;
-  bool m_tried_graceful_shutdown = false;
-  int m_saveSlot = 1;
-
   enum
   {
     ADD_PANE_TOP,
@@ -160,10 +134,39 @@ private:
     ADD_PANE_CENTER
   };
 
+  CGameListCtrl* m_game_list_ctrl = nullptr;
+  CConfigMain* m_main_config_dialog = nullptr;
+  wxPanel* m_panel = nullptr;
+  CRenderFrame* m_render_frame = nullptr;
+  wxWindow* m_render_parent = nullptr;
+  CLogWindow* m_log_window = nullptr;
+  LogConfigWindow* m_log_config_window = nullptr;
+  FifoPlayerDlg* m_fifo_player_dialog = nullptr;
+  std::array<TASInputDlg*, 8> m_tas_input_dialogs{};
+  wxCheatsWindow* m_cheats_window = nullptr;
+  bool m_use_debugger = false;
+  bool m_batch_mode = false;
+  bool m_editing_perspectives = false;
+  bool m_is_split_tab_notebook = false;
+  bool m_no_panel_docking = false;
+  bool m_is_game_loading = false;
+  bool m_is_closing = false;
+  bool m_renderer_has_focus = false;
+  bool m_confirm_stop = false;
+  bool m_tried_graceful_shutdown = false;
+  int m_save_slot = 1;
+
   wxTimer m_poll_hotkey_timer;
   wxTimer m_handle_signal_timer;
 
   wxMenuBar* m_menubar_shadow = nullptr;
+
+  wxString m_aui_fullscreen_perspective;
+  wxString m_aui_current_perspective;
+
+#ifdef __WXGTK__
+  std::recursive_mutex m_keystate_lock;
+#endif
 
   void BindEvents();
   void BindMenuBarEvents();
@@ -207,7 +210,7 @@ private:
   void DoFloatNotebookPage(wxWindowID Id);
   wxFrame* CreateParentFrame(wxWindowID Id = wxID_ANY, const wxString& title = "",
                              wxWindow* = nullptr);
-  wxString AuiFullscreen, AuiCurrent;
+
   void AddPane(int dir);
   void UpdateCurrentPerspective();
   void SaveIniPerspectives();

--- a/Source/Core/DolphinWX/FrameAui.cpp
+++ b/Source/Core/DolphinWX/FrameAui.cpp
@@ -46,12 +46,12 @@
 
 void CFrame::OnManagerResize(wxAuiManagerEvent& event)
 {
-  if (!g_pCodeWindow && m_LogWindow && m_Mgr->GetPane("Pane 1").IsShown() &&
-      !m_Mgr->GetPane("Pane 1").IsFloating())
+  if (!m_code_window && m_log_window && m_mgr->GetPane("Pane 1").IsShown() &&
+      !m_mgr->GetPane("Pane 1").IsFloating())
   {
-    m_LogWindow->x = m_Mgr->GetPane("Pane 1").rect.GetWidth();
-    m_LogWindow->y = m_Mgr->GetPane("Pane 1").rect.GetHeight();
-    m_LogWindow->winpos = m_Mgr->GetPane("Pane 1").dock_direction;
+    m_log_window->x = m_mgr->GetPane("Pane 1").rect.GetWidth();
+    m_log_window->y = m_mgr->GetPane("Pane 1").rect.GetHeight();
+    m_log_window->winpos = m_mgr->GetPane("Pane 1").dock_direction;
   }
   event.Skip();
 }
@@ -64,7 +64,7 @@ void CFrame::OnPaneClose(wxAuiManagerEvent& event)
   if (!nb)
     return;
 
-  if (!g_pCodeWindow)
+  if (!m_code_window)
   {
     if (nb->GetPage(0)->GetId() == IDM_LOG_WINDOW ||
         nb->GetPage(0)->GetId() == IDM_LOG_CONFIG_WINDOW)
@@ -89,16 +89,16 @@ void CFrame::OnPaneClose(wxAuiManagerEvent& event)
     {
       // Detach and delete the empty notebook
       event.pane->DestroyOnClose(true);
-      m_Mgr->ClosePane(*event.pane);
+      m_mgr->ClosePane(*event.pane);
     }
   }
 
-  m_Mgr->Update();
+  m_mgr->Update();
 }
 
 void CFrame::ToggleLogWindow(bool bShow)
 {
-  if (!m_LogWindow)
+  if (!m_log_window)
     return;
 
   GetMenuBar()->FindItem(IDM_LOG_WINDOW)->Check(bShow);
@@ -106,25 +106,25 @@ void CFrame::ToggleLogWindow(bool bShow)
   if (bShow)
   {
     // Create a new log window if it doesn't exist.
-    if (!m_LogWindow)
+    if (!m_log_window)
     {
-      m_LogWindow = new CLogWindow(this, IDM_LOG_WINDOW);
+      m_log_window = new CLogWindow(this, IDM_LOG_WINDOW);
     }
 
-    m_LogWindow->Enable();
+    m_log_window->Enable();
 
-    DoAddPage(m_LogWindow, g_pCodeWindow ? g_pCodeWindow->iNbAffiliation[0] : 0,
-              g_pCodeWindow ? bFloatWindow[0] : false);
+    DoAddPage(m_log_window, m_code_window ? m_code_window->iNbAffiliation[0] : 0,
+              m_code_window ? m_float_window[0] : false);
   }
   else
   {
     // Hiding the log window, so disable it and remove it.
-    m_LogWindow->Disable();
-    DoRemovePage(m_LogWindow, true);
+    m_log_window->Disable();
+    DoRemovePage(m_log_window, true);
   }
 
   // Hide or Show the pane
-  if (!g_pCodeWindow)
+  if (!m_code_window)
     TogglePane();
 }
 
@@ -134,21 +134,21 @@ void CFrame::ToggleLogConfigWindow(bool bShow)
 
   if (bShow)
   {
-    if (!m_LogConfigWindow)
-      m_LogConfigWindow = new LogConfigWindow(this, IDM_LOG_CONFIG_WINDOW);
+    if (!m_log_config_window)
+      m_log_config_window = new LogConfigWindow(this, IDM_LOG_CONFIG_WINDOW);
 
     const int nbIndex = IDM_LOG_CONFIG_WINDOW - IDM_LOG_WINDOW;
-    DoAddPage(m_LogConfigWindow, g_pCodeWindow ? g_pCodeWindow->iNbAffiliation[nbIndex] : 0,
-              g_pCodeWindow ? bFloatWindow[nbIndex] : false);
+    DoAddPage(m_log_config_window, m_code_window ? m_code_window->iNbAffiliation[nbIndex] : 0,
+              m_code_window ? m_float_window[nbIndex] : false);
   }
   else
   {
-    DoRemovePage(m_LogConfigWindow, false);
-    m_LogConfigWindow = nullptr;
+    DoRemovePage(m_log_config_window, false);
+    m_log_config_window = nullptr;
   }
 
   // Hide or Show the pane
-  if (!g_pCodeWindow)
+  if (!m_code_window)
     TogglePane();
 }
 
@@ -159,17 +159,17 @@ void CFrame::OnToggleWindow(wxCommandEvent& event)
   switch (event.GetId())
   {
   case IDM_LOG_WINDOW:
-    if (!g_pCodeWindow)
+    if (!m_code_window)
       SConfig::GetInstance().m_InterfaceLogWindow = show;
     ToggleLogWindow(show);
     break;
   case IDM_LOG_CONFIG_WINDOW:
-    if (!g_pCodeWindow)
+    if (!m_code_window)
       SConfig::GetInstance().m_InterfaceLogConfigWindow = show;
     ToggleLogConfigWindow(show);
     break;
   default:
-    g_pCodeWindow->TogglePanel(event.GetId(), show);
+    m_code_window->TogglePanel(event.GetId(), show);
   }
 }
 
@@ -180,11 +180,11 @@ void CFrame::ClosePages()
   ToggleLogWindow(false);
   ToggleLogConfigWindow(false);
 
-  if (g_pCodeWindow)
+  if (m_code_window)
   {
     for (int i = IDM_REGISTER_WINDOW; i < IDM_DEBUG_WINDOW_LIST_END; ++i)
     {
-      g_pCodeWindow->TogglePanel(i, false);
+      m_code_window->TogglePanel(i, false);
     }
   }
 }
@@ -198,7 +198,7 @@ void CFrame::OnNotebookPageChanged(wxAuiNotebookEvent& event)
     return;
   }
 
-  if (!g_pCodeWindow)
+  if (!m_code_window)
     return;
 
   // Remove the blank page if any
@@ -208,7 +208,7 @@ void CFrame::OnNotebookPageChanged(wxAuiNotebookEvent& event)
   for (int i = IDM_LOG_WINDOW; i <= IDM_CODE_WINDOW; i++)
   {
     if (GetNotebookAffiliation(i) >= 0)
-      g_pCodeWindow->iNbAffiliation[i - IDM_LOG_WINDOW] = GetNotebookAffiliation(i);
+      m_code_window->iNbAffiliation[i - IDM_LOG_WINDOW] = GetNotebookAffiliation(i);
   }
 }
 
@@ -244,7 +244,7 @@ void CFrame::OnNotebookPageClose(wxAuiNotebookEvent& event)
     if (nb->GetPageText(event.GetSelection()).IsSameAs("<>"))
       break;
 
-    g_pCodeWindow->TogglePanel(page_id, false);
+    m_code_window->TogglePanel(page_id, false);
   }
 }
 
@@ -266,13 +266,13 @@ void CFrame::ToggleFloatWindow(int Id)
   if (GetNotebookPageFromId(WinId))
   {
     DoFloatNotebookPage(WinId);
-    bFloatWindow[WinId - IDM_LOG_WINDOW] = true;
+    m_float_window[WinId - IDM_LOG_WINDOW] = true;
   }
   else
   {
     if (FindWindowById(WinId))
       DoUnfloatPage(WinId - IDM_LOG_WINDOW + IDM_LOG_WINDOW_PARENT);
-    bFloatWindow[WinId - IDM_LOG_WINDOW] = false;
+    m_float_window[WinId - IDM_LOG_WINDOW] = false;
   }
 }
 
@@ -306,7 +306,7 @@ void CFrame::DoUnfloatPage(int Id)
 
   wxWindow* Child = Win->GetChildren().Item(0)->GetData();
   Child->Reparent(this);
-  DoAddPage(Child, g_pCodeWindow->iNbAffiliation[Child->GetId() - IDM_LOG_WINDOW], false);
+  DoAddPage(Child, m_code_window->iNbAffiliation[Child->GetId() - IDM_LOG_WINDOW], false);
   Win->Destroy();
 }
 
@@ -319,7 +319,7 @@ void CFrame::OnNotebookTabRightUp(wxAuiNotebookEvent& event)
     return;
   }
 
-  if (!g_pCodeWindow)
+  if (!m_code_window)
     return;
 
   // Create the popup menu
@@ -363,36 +363,36 @@ void CFrame::OnNotebookAllowDnD(wxAuiNotebookEvent& event)
   }
   // Since the destination is one of our own notebooks, make sure the source is as well.
   // If the source is some other panel, leave the event in the default reject state.
-  if (m_Mgr->GetPane(event.GetDragSource()).window)
+  if (m_mgr->GetPane(event.GetDragSource()).window)
     event.Allow();
 }
 
 void CFrame::ShowResizePane()
 {
-  if (!m_LogWindow)
+  if (!m_log_window)
     return;
 
   // Make sure the size is sane
-  if (m_LogWindow->x > GetClientRect().GetWidth())
-    m_LogWindow->x = GetClientRect().GetWidth() / 2;
-  if (m_LogWindow->y > GetClientRect().GetHeight())
-    m_LogWindow->y = GetClientRect().GetHeight() / 2;
+  if (m_log_window->x > GetClientRect().GetWidth())
+    m_log_window->x = GetClientRect().GetWidth() / 2;
+  if (m_log_window->y > GetClientRect().GetHeight())
+    m_log_window->y = GetClientRect().GetHeight() / 2;
 
-  wxAuiPaneInfo& pane = m_Mgr->GetPane("Pane 1");
+  wxAuiPaneInfo& pane = m_mgr->GetPane("Pane 1");
 
   // Hide first otherwise a resize doesn't work
   pane.Hide();
-  m_Mgr->Update();
+  m_mgr->Update();
 
-  pane.BestSize(m_LogWindow->x, m_LogWindow->y)
-      .MinSize(m_LogWindow->x, m_LogWindow->y)
-      .Direction(m_LogWindow->winpos)
+  pane.BestSize(m_log_window->x, m_log_window->y)
+      .MinSize(m_log_window->x, m_log_window->y)
+      .Direction(m_log_window->winpos)
       .Show();
-  m_Mgr->Update();
+  m_mgr->Update();
 
   // Reset the minimum size of the pane
   pane.MinSize(-1, -1);
-  m_Mgr->Update();
+  m_mgr->Update();
 }
 
 void CFrame::TogglePane()
@@ -404,8 +404,8 @@ void CFrame::TogglePane()
   {
     if (NB->GetPageCount() == 0)
     {
-      m_Mgr->GetPane("Pane 1").Hide();
-      m_Mgr->Update();
+      m_mgr->GetPane("Pane 1").Hide();
+      m_mgr->Update();
     }
     else
     {
@@ -457,7 +457,7 @@ void CFrame::DoRemovePage(wxWindow* Win, bool bHide)
     }
   }
 
-  if (g_pCodeWindow)
+  if (m_code_window)
     AddRemoveBlankPage();
 }
 
@@ -486,14 +486,14 @@ void CFrame::DoAddPage(wxWindow* Win, int i, bool Float)
 
 void CFrame::PopulateSavedPerspectives()
 {
-  std::vector<std::string> perspective_names(Perspectives.size());
+  std::vector<std::string> perspective_names(m_perspectives.size());
 
-  std::transform(Perspectives.begin(), Perspectives.end(), perspective_names.begin(),
-                 [](const auto& perspective) { return perspective.Name; });
+  std::transform(m_perspectives.begin(), m_perspectives.end(), perspective_names.begin(),
+                 [](const auto& perspective) { return perspective.name; });
 
   MainMenuBar::PopulatePerspectivesEvent event{GetId(), EVT_POPULATE_PERSPECTIVES_MENU,
                                                std::move(perspective_names),
-                                               static_cast<int>(ActivePerspective)};
+                                               static_cast<int>(m_active_perspective)};
 
   wxPostEvent(GetMenuBar(), event);
 }
@@ -505,14 +505,14 @@ void CFrame::OnPerspectiveMenu(wxCommandEvent& event)
   switch (event.GetId())
   {
   case IDM_SAVE_PERSPECTIVE:
-    if (Perspectives.size() == 0)
+    if (m_perspectives.size() == 0)
     {
       wxMessageBox(_("Please create a perspective before saving"), _("Notice"), wxOK, this);
       return;
     }
     SaveIniPerspectives();
     GetStatusBar()->SetStatusText(
-        StrToWxStr(std::string("Saved " + Perspectives[ActivePerspective].Name)), 0);
+        StrToWxStr(std::string("Saved " + m_perspectives[m_active_perspective].name)), 0);
     break;
   case IDM_PERSPECTIVES_ADD_PANE_TOP:
     AddPane(ADD_PANE_TOP);
@@ -530,14 +530,14 @@ void CFrame::OnPerspectiveMenu(wxCommandEvent& event)
     AddPane(ADD_PANE_CENTER);
     break;
   case IDM_EDIT_PERSPECTIVES:
-    m_bEdit = event.IsChecked();
-    TogglePaneStyle(m_bEdit, IDM_EDIT_PERSPECTIVES);
+    m_editing_perspectives = event.IsChecked();
+    TogglePaneStyle(m_editing_perspectives, IDM_EDIT_PERSPECTIVES);
     break;
   case IDM_ADD_PERSPECTIVE:
   {
     wxTextEntryDialog dlg(this, _("Enter a name for the new perspective:"),
                           _("Create new perspective"));
-    wxString DefaultValue = wxString::Format(_("Perspective %d"), (int)(Perspectives.size() + 1));
+    wxString DefaultValue = wxString::Format(_("Perspective %d"), (int)(m_perspectives.size() + 1));
     dlg.SetValue(DefaultValue);
 
     int Return = 0;
@@ -569,30 +569,30 @@ void CFrame::OnPerspectiveMenu(wxCommandEvent& event)
     }
 
     SPerspectives Tmp;
-    Tmp.Name = WxStrToStr(dlg.GetValue());
-    Tmp.Perspective = m_Mgr->SavePerspective();
+    Tmp.name = WxStrToStr(dlg.GetValue());
+    Tmp.perspective = m_mgr->SavePerspective();
 
-    ActivePerspective = (u32)Perspectives.size();
-    Perspectives.push_back(Tmp);
+    m_active_perspective = (u32)m_perspectives.size();
+    m_perspectives.push_back(Tmp);
 
     UpdateCurrentPerspective();
     PopulateSavedPerspectives();
   }
   break;
   case IDM_TAB_SPLIT:
-    m_bTabSplit = event.IsChecked();
-    ToggleNotebookStyle(m_bTabSplit, wxAUI_NB_TAB_SPLIT);
+    m_is_split_tab_notebook = event.IsChecked();
+    ToggleNotebookStyle(m_is_split_tab_notebook, wxAUI_NB_TAB_SPLIT);
     break;
   case IDM_NO_DOCKING:
-    m_bNoDocking = event.IsChecked();
-    TogglePaneStyle(m_bNoDocking, IDM_NO_DOCKING);
+    m_no_panel_docking = event.IsChecked();
+    TogglePaneStyle(m_no_panel_docking, IDM_NO_DOCKING);
     break;
   }
 }
 
 void CFrame::TogglePaneStyle(bool On, int EventId)
 {
-  wxAuiPaneInfoArray& AllPanes = m_Mgr->GetAllPanes();
+  wxAuiPaneInfoArray& AllPanes = m_mgr->GetAllPanes();
   for (u32 i = 0; i < AllPanes.GetCount(); ++i)
   {
     wxAuiPaneInfo& Pane = AllPanes[i];
@@ -614,16 +614,16 @@ void CFrame::TogglePaneStyle(bool On, int EventId)
         Pane.Dockable(On);
         break;
       }
-      Pane.Dockable(!m_bNoDocking);
+      Pane.Dockable(!m_no_panel_docking);
     }
   }
-  m_Mgr->GetArtProvider()->SetFont(wxAUI_DOCKART_CAPTION_FONT, DebuggerFont);
-  m_Mgr->Update();
+  m_mgr->GetArtProvider()->SetFont(wxAUI_DOCKART_CAPTION_FONT, DebuggerFont);
+  m_mgr->Update();
 }
 
 void CFrame::ToggleNotebookStyle(bool On, long Style)
 {
-  wxAuiPaneInfoArray& AllPanes = m_Mgr->GetAllPanes();
+  wxAuiPaneInfoArray& AllPanes = m_mgr->GetAllPanes();
   for (int i = 0, Count = (int)AllPanes.GetCount(); i < Count; ++i)
   {
     wxAuiPaneInfo& Pane = AllPanes[i];
@@ -644,33 +644,35 @@ void CFrame::ToggleNotebookStyle(bool On, long Style)
 void CFrame::OnSelectPerspective(wxCommandEvent& event)
 {
   u32 _Selection = event.GetId() - IDM_PERSPECTIVES_0;
-  if (Perspectives.size() <= _Selection)
+  if (m_perspectives.size() <= _Selection)
     _Selection = 0;
-  ActivePerspective = _Selection;
+  m_active_perspective = _Selection;
   DoLoadPerspective();
 }
 
 void CFrame::SetPaneSize()
 {
-  if (Perspectives.size() <= ActivePerspective)
+  if (m_perspectives.size() <= m_active_perspective)
     return;
 
   wxSize client_size = GetClientSize();
 
-  for (u32 i = 0, j = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  for (u32 i = 0, j = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (!m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiToolBar)))
+    if (!m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiToolBar)))
     {
-      if (!m_Mgr->GetAllPanes()[i].IsOk())
+      if (!m_mgr->GetAllPanes()[i].IsOk())
         return;
 
-      if (Perspectives[ActivePerspective].Width.size() <= j ||
-          Perspectives[ActivePerspective].Height.size() <= j)
+      if (m_perspectives[m_active_perspective].width.size() <= j ||
+          m_perspectives[m_active_perspective].height.size() <= j)
+      {
         continue;
+      }
 
       // Width and height of the active perspective
-      u32 W = Perspectives[ActivePerspective].Width[j],
-          H = Perspectives[ActivePerspective].Height[j];
+      u32 W = m_perspectives[m_active_perspective].width[j];
+      u32 H = m_perspectives[m_active_perspective].height[j];
 
       // Check limits
       W = MathUtil::Clamp<u32>(W, 5, 95);
@@ -679,18 +681,18 @@ void CFrame::SetPaneSize()
       // Convert percentages to pixel lengths
       W = (W * client_size.GetWidth()) / 100;
       H = (H * client_size.GetHeight()) / 100;
-      m_Mgr->GetAllPanes()[i].BestSize(W, H).MinSize(W, H);
+      m_mgr->GetAllPanes()[i].BestSize(W, H).MinSize(W, H);
 
       j++;
     }
   }
-  m_Mgr->Update();
+  m_mgr->Update();
 
-  for (u32 i = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  for (u32 i = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (!m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiToolBar)))
+    if (!m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiToolBar)))
     {
-      m_Mgr->GetAllPanes()[i].MinSize(-1, -1);
+      m_mgr->GetAllPanes()[i].MinSize(-1, -1);
     }
   }
 }
@@ -703,29 +705,29 @@ void CFrame::ReloadPanes()
   CloseAllNotebooks();
 
   // Create new panes with notebooks
-  for (u32 i = 0; i < Perspectives[ActivePerspective].Width.size() - 1; i++)
+  for (u32 i = 0; i < m_perspectives[m_active_perspective].width.size() - 1; i++)
   {
     wxString PaneName = wxString::Format("Pane %i", i + 1);
-    m_Mgr->AddPane(CreateEmptyNotebook(), wxAuiPaneInfo()
+    m_mgr->AddPane(CreateEmptyNotebook(), wxAuiPaneInfo()
                                               .Hide()
-                                              .CaptionVisible(m_bEdit)
-                                              .Dockable(!m_bNoDocking)
+                                              .CaptionVisible(m_editing_perspectives)
+                                              .Dockable(!m_no_panel_docking)
                                               .Position(i)
                                               .Name(PaneName)
                                               .Caption(PaneName));
   }
 
   // Perspectives
-  m_Mgr->LoadPerspective(Perspectives[ActivePerspective].Perspective, false);
+  m_mgr->LoadPerspective(m_perspectives[m_active_perspective].perspective, false);
   // Restore settings
-  TogglePaneStyle(m_bNoDocking, IDM_NO_DOCKING);
-  TogglePaneStyle(m_bEdit, IDM_EDIT_PERSPECTIVES);
+  TogglePaneStyle(m_no_panel_docking, IDM_NO_DOCKING);
+  TogglePaneStyle(m_editing_perspectives, IDM_EDIT_PERSPECTIVES);
 
   // Load GUI settings
-  g_pCodeWindow->Load();
+  m_code_window->Load();
   // Open notebook pages
   AddRemoveBlankPage();
-  g_pCodeWindow->OpenPages();
+  m_code_window->OpenPages();
 
   // Repopulate perspectives
   PopulateSavedPerspectives();
@@ -737,13 +739,13 @@ void CFrame::DoLoadPerspective()
   // Restore the exact window sizes, which LoadPerspective doesn't always do
   SetPaneSize();
 
-  m_Mgr->Update();
+  m_mgr->Update();
 }
 
 // Update the local perspectives array
 void CFrame::LoadIniPerspectives()
 {
-  Perspectives.clear();
+  m_perspectives.clear();
   std::vector<std::string> VPerspectives;
   std::string _Perspectives;
 
@@ -752,7 +754,7 @@ void CFrame::LoadIniPerspectives()
 
   IniFile::Section* perspectives = ini.GetOrCreateSection("Perspectives");
   perspectives->Get("Perspectives", &_Perspectives, "Perspective 1");
-  perspectives->Get("Active", &ActivePerspective, 0);
+  perspectives->Get("Active", &m_active_perspective, 0);
   SplitString(_Perspectives, ',', VPerspectives);
 
   for (auto& VPerspective : VPerspectives)
@@ -760,15 +762,15 @@ void CFrame::LoadIniPerspectives()
     SPerspectives Tmp;
     std::string _Section, _Perspective, _Widths, _Heights;
     std::vector<std::string> _SWidth, _SHeight;
-    Tmp.Name = VPerspective;
+    Tmp.name = VPerspective;
 
     // Don't save a blank perspective
-    if (Tmp.Name.empty())
+    if (Tmp.name.empty())
     {
       continue;
     }
 
-    _Section = StringFromFormat("P - %s", Tmp.Name.c_str());
+    _Section = StringFromFormat("P - %s", Tmp.name.c_str());
 
     IniFile::Section* perspec_section = ini.GetOrCreateSection(_Section);
     perspec_section->Get("Perspective", &_Perspective,
@@ -779,7 +781,7 @@ void CFrame::LoadIniPerspectives()
     perspec_section->Get("Width", &_Widths, "70,25");
     perspec_section->Get("Height", &_Heights, "80,80");
 
-    Tmp.Perspective = StrToWxStr(_Perspective);
+    Tmp.perspective = StrToWxStr(_Perspective);
 
     SplitString(_Widths, ',', _SWidth);
     SplitString(_Heights, ',', _SHeight);
@@ -787,35 +789,35 @@ void CFrame::LoadIniPerspectives()
     {
       int _Tmp;
       if (TryParse(Width, &_Tmp))
-        Tmp.Width.push_back(_Tmp);
+        Tmp.width.push_back(_Tmp);
     }
     for (auto& Height : _SHeight)
     {
       int _Tmp;
       if (TryParse(Height, &_Tmp))
-        Tmp.Height.push_back(_Tmp);
+        Tmp.height.push_back(_Tmp);
     }
-    Perspectives.push_back(Tmp);
+    m_perspectives.push_back(Tmp);
   }
 }
 
 void CFrame::UpdateCurrentPerspective()
 {
-  SPerspectives* current = &Perspectives[ActivePerspective];
-  current->Perspective = m_Mgr->SavePerspective();
+  SPerspectives* current = &m_perspectives[m_active_perspective];
+  current->perspective = m_mgr->SavePerspective();
 
   // Get client size
   wxSize client_size = GetClientSize();
-  current->Width.clear();
-  current->Height.clear();
-  for (u32 i = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  current->width.clear();
+  current->height.clear();
+  for (u32 i = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (!m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiToolBar)))
+    if (!m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiToolBar)))
     {
       // Save width and height as a percentage of the client width and height
-      current->Width.push_back((m_Mgr->GetAllPanes()[i].window->GetSize().GetX() * 100) /
+      current->width.push_back((m_mgr->GetAllPanes()[i].window->GetSize().GetX() * 100) /
                                client_size.GetWidth());
-      current->Height.push_back((m_Mgr->GetAllPanes()[i].window->GetSize().GetY() * 100) /
+      current->height.push_back((m_mgr->GetAllPanes()[i].window->GetSize().GetY() * 100) /
                                 client_size.GetHeight());
     }
   }
@@ -823,10 +825,10 @@ void CFrame::UpdateCurrentPerspective()
 
 void CFrame::SaveIniPerspectives()
 {
-  if (Perspectives.size() == 0)
+  if (m_perspectives.size() == 0)
     return;
-  if (ActivePerspective >= Perspectives.size())
-    ActivePerspective = 0;
+  if (m_active_perspective >= m_perspectives.size())
+    m_active_perspective = 0;
 
   // Turn off edit before saving
   TogglePaneStyle(false, IDM_EDIT_PERSPECTIVES);
@@ -838,28 +840,28 @@ void CFrame::SaveIniPerspectives()
 
   // Save perspective names
   std::string STmp = "";
-  for (auto& Perspective : Perspectives)
+  for (auto& Perspective : m_perspectives)
   {
-    STmp += Perspective.Name + ",";
+    STmp += Perspective.name + ",";
   }
   STmp = STmp.substr(0, STmp.length() - 1);
 
   IniFile::Section* perspectives = ini.GetOrCreateSection("Perspectives");
   perspectives->Set("Perspectives", STmp);
-  perspectives->Set("Active", ActivePerspective);
+  perspectives->Set("Active", m_active_perspective);
 
   // Save the perspectives
-  for (auto& Perspective : Perspectives)
+  for (auto& Perspective : m_perspectives)
   {
-    std::string _Section = "P - " + Perspective.Name;
+    std::string _Section = "P - " + Perspective.name;
     IniFile::Section* perspec_section = ini.GetOrCreateSection(_Section);
-    perspec_section->Set("Perspective", WxStrToStr(Perspective.Perspective));
+    perspec_section->Set("Perspective", WxStrToStr(Perspective.perspective));
 
     std::string SWidth = "", SHeight = "";
-    for (u32 j = 0; j < Perspective.Width.size(); j++)
+    for (u32 j = 0; j < Perspective.width.size(); j++)
     {
-      SWidth += StringFromFormat("%i,", Perspective.Width[j]);
-      SHeight += StringFromFormat("%i,", Perspective.Height[j]);
+      SWidth += StringFromFormat("%i,", Perspective.width[j]);
+      SHeight += StringFromFormat("%i,", Perspective.height[j]);
     }
     // Remove the ending ","
     SWidth = SWidth.substr(0, SWidth.length() - 1);
@@ -872,9 +874,9 @@ void CFrame::SaveIniPerspectives()
   ini.Save(File::GetUserPath(F_DEBUGGERCONFIG_IDX));
 
   // Save notebook affiliations
-  g_pCodeWindow->Save();
+  m_code_window->Save();
 
-  TogglePaneStyle(m_bEdit, IDM_EDIT_PERSPECTIVES);
+  TogglePaneStyle(m_editing_perspectives, IDM_EDIT_PERSPECTIVES);
 }
 
 void CFrame::AddPane(int dir)
@@ -882,8 +884,8 @@ void CFrame::AddPane(int dir)
   int PaneNum = GetNotebookCount() + 1;
   wxString PaneName = wxString::Format("Pane %i", PaneNum);
   wxAuiPaneInfo PaneInfo = wxAuiPaneInfo()
-                               .CaptionVisible(m_bEdit)
-                               .Dockable(!m_bNoDocking)
+                               .CaptionVisible(m_editing_perspectives)
+                               .Dockable(!m_no_panel_docking)
                                .Name(PaneName)
                                .Caption(PaneName)
                                .Position(GetNotebookCount());
@@ -909,20 +911,20 @@ void CFrame::AddPane(int dir)
     break;
   }
 
-  m_Mgr->AddPane(CreateEmptyNotebook(), PaneInfo);
+  m_mgr->AddPane(CreateEmptyNotebook(), PaneInfo);
 
   AddRemoveBlankPage();
-  m_Mgr->Update();
+  m_mgr->Update();
 }
 
 wxWindow* CFrame::GetNotebookPageFromId(wxWindowID Id)
 {
-  for (u32 i = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  for (u32 i = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (!m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
+    if (!m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
       continue;
 
-    wxAuiNotebook* NB = (wxAuiNotebook*)m_Mgr->GetAllPanes()[i].window;
+    wxAuiNotebook* NB = (wxAuiNotebook*)m_mgr->GetAllPanes()[i].window;
     for (u32 j = 0; j < NB->GetPageCount(); j++)
     {
       if (NB->GetPage(j)->GetId() == Id)
@@ -980,12 +982,12 @@ wxAuiNotebook* CFrame::CreateEmptyNotebook()
 
 void CFrame::AddRemoveBlankPage()
 {
-  for (u32 i = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  for (u32 i = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (!m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
+    if (!m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
       continue;
 
-    wxAuiNotebook* NB = (wxAuiNotebook*)m_Mgr->GetAllPanes()[i].window;
+    wxAuiNotebook* NB = (wxAuiNotebook*)m_mgr->GetAllPanes()[i].window;
     for (u32 j = 0; j < NB->GetPageCount(); j++)
     {
       if (NB->GetPageText(j).IsSameAs("<>") && NB->GetPageCount() > 1)
@@ -999,12 +1001,12 @@ void CFrame::AddRemoveBlankPage()
 
 int CFrame::GetNotebookAffiliation(wxWindowID Id)
 {
-  for (u32 i = 0, j = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  for (u32 i = 0, j = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (!m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
+    if (!m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
       continue;
 
-    wxAuiNotebook* NB = (wxAuiNotebook*)m_Mgr->GetAllPanes()[i].window;
+    wxAuiNotebook* NB = (wxAuiNotebook*)m_mgr->GetAllPanes()[i].window;
     for (u32 k = 0; k < NB->GetPageCount(); k++)
     {
       if (NB->GetPage(k)->GetId() == Id)
@@ -1018,13 +1020,13 @@ int CFrame::GetNotebookAffiliation(wxWindowID Id)
 // Close all panes with notebooks
 void CFrame::CloseAllNotebooks()
 {
-  wxAuiPaneInfoArray AllPanes = m_Mgr->GetAllPanes();
+  wxAuiPaneInfoArray AllPanes = m_mgr->GetAllPanes();
   for (u32 i = 0; i < AllPanes.GetCount(); i++)
   {
     if (AllPanes[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
     {
       AllPanes[i].DestroyOnClose(true);
-      m_Mgr->ClosePane(AllPanes[i]);
+      m_mgr->ClosePane(AllPanes[i]);
     }
   }
 }
@@ -1032,9 +1034,9 @@ void CFrame::CloseAllNotebooks()
 int CFrame::GetNotebookCount()
 {
   int Ret = 0;
-  for (u32 i = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  for (u32 i = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
+    if (m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
       Ret++;
   }
   return Ret;
@@ -1042,12 +1044,12 @@ int CFrame::GetNotebookCount()
 
 wxAuiNotebook* CFrame::GetNotebookFromId(u32 NBId)
 {
-  for (u32 i = 0, j = 0; i < m_Mgr->GetAllPanes().GetCount(); i++)
+  for (u32 i = 0, j = 0; i < m_mgr->GetAllPanes().GetCount(); i++)
   {
-    if (!m_Mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
+    if (!m_mgr->GetAllPanes()[i].window->IsKindOf(CLASSINFO(wxAuiNotebook)))
       continue;
     if (j == NBId)
-      return (wxAuiNotebook*)m_Mgr->GetAllPanes()[i].window;
+      return (wxAuiNotebook*)m_mgr->GetAllPanes()[i].window;
     j++;
   }
   return nullptr;

--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -174,7 +174,7 @@ void CLogWindow::SaveSettings()
   IniFile ini;
   ini.Load(File::GetUserPath(F_LOGGERCONFIG_IDX));
 
-  if (!Parent->g_pCodeWindow)
+  if (!Parent->m_code_window)
   {
     IniFile::Section* log_window = ini.GetOrCreateSection("LogWindow");
     log_window->Set("x", x);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -254,9 +254,9 @@ void DolphinApp::AfterInit()
   }
   // If we have selected Automatic Start, start the default ISO,
   // or if no default ISO exists, start the last loaded ISO
-  else if (main_frame->g_pCodeWindow)
+  else if (main_frame->m_code_window)
   {
-    if (main_frame->g_pCodeWindow->AutomaticStart())
+    if (main_frame->m_code_window->AutomaticStart())
     {
       main_frame->BootGame("");
     }
@@ -372,8 +372,8 @@ bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*
     event.SetString(StrToWxStr(caption) + ":" + StrToWxStr(text));
     event.SetInt(yes_no);
     main_frame->GetEventHandler()->AddPendingEvent(event);
-    main_frame->panic_event.Wait();
-    return main_frame->bPanicResult;
+    main_frame->m_panic_event.Wait();
+    return main_frame->m_panic_result;
   }
 }
 
@@ -412,9 +412,9 @@ void Host_NotifyMapLoaded()
   wxCommandEvent event(wxEVT_HOST_COMMAND, IDM_NOTIFY_MAP_LOADED);
   main_frame->GetEventHandler()->AddPendingEvent(event);
 
-  if (main_frame->g_pCodeWindow)
+  if (main_frame->m_code_window)
   {
-    main_frame->g_pCodeWindow->GetEventHandler()->AddPendingEvent(event);
+    main_frame->m_code_window->GetEventHandler()->AddPendingEvent(event);
   }
 }
 
@@ -423,9 +423,9 @@ void Host_UpdateDisasmDialog()
   wxCommandEvent event(wxEVT_HOST_COMMAND, IDM_UPDATE_DISASM_DIALOG);
   main_frame->GetEventHandler()->AddPendingEvent(event);
 
-  if (main_frame->g_pCodeWindow)
+  if (main_frame->m_code_window)
   {
-    main_frame->g_pCodeWindow->GetEventHandler()->AddPendingEvent(event);
+    main_frame->m_code_window->GetEventHandler()->AddPendingEvent(event);
   }
 }
 
@@ -434,9 +434,9 @@ void Host_UpdateMainFrame()
   wxCommandEvent event(wxEVT_HOST_COMMAND, IDM_UPDATE_GUI);
   main_frame->GetEventHandler()->AddPendingEvent(event);
 
-  if (main_frame->g_pCodeWindow)
+  if (main_frame->m_code_window)
   {
-    main_frame->g_pCodeWindow->GetEventHandler()->AddPendingEvent(event);
+    main_frame->m_code_window->GetEventHandler()->AddPendingEvent(event);
   }
 }
 
@@ -457,18 +457,18 @@ void Host_RequestRenderWindowSize(int width, int height)
 void Host_SetStartupDebuggingParameters()
 {
   SConfig& StartUp = SConfig::GetInstance();
-  if (main_frame->g_pCodeWindow)
+  if (main_frame->m_code_window)
   {
-    StartUp.bBootToPause = main_frame->g_pCodeWindow->BootToPause();
-    StartUp.bAutomaticStart = main_frame->g_pCodeWindow->AutomaticStart();
-    StartUp.bJITNoBlockCache = main_frame->g_pCodeWindow->JITNoBlockCache();
-    StartUp.bJITNoBlockLinking = main_frame->g_pCodeWindow->JITNoBlockLinking();
+    StartUp.bBootToPause = main_frame->m_code_window->BootToPause();
+    StartUp.bAutomaticStart = main_frame->m_code_window->AutomaticStart();
+    StartUp.bJITNoBlockCache = main_frame->m_code_window->JITNoBlockCache();
+    StartUp.bJITNoBlockLinking = main_frame->m_code_window->JITNoBlockLinking();
   }
   else
   {
     StartUp.bBootToPause = false;
   }
-  StartUp.bEnableDebugging = main_frame->g_pCodeWindow ? true : false;  // RUNNING_DEBUG
+  StartUp.bEnableDebugging = main_frame->m_code_window ? true : false;  // RUNNING_DEBUG
 }
 
 void Host_SetWiiMoteConnectionState(int _State)

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -312,7 +312,7 @@ NetPlaySetupFrame::~NetPlaySetupFrame()
 #endif
 
   inifile.Save(dolphin_ini);
-  main_frame->g_NetPlaySetupDiag = nullptr;
+  main_frame->m_netplay_setup_frame = nullptr;
 }
 
 void NetPlaySetupFrame::OnHost(wxCommandEvent&)

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -319,7 +319,7 @@ static wxArrayString GetListOfResolutions()
   }
 #elif defined(HAVE_XRANDR) && HAVE_XRANDR
   std::vector<std::string> resos;
-  main_frame->m_XRRConfig->AddResolutions(resos);
+  main_frame->m_xrr_config->AddResolutions(resos);
   for (auto res : resos)
     retlist.Add(StrToWxStr(res));
 #elif defined(__APPLE__)
@@ -1026,7 +1026,7 @@ void VideoConfigDiag::Event_DisplayResolution(wxCommandEvent& ev)
         WxStrToStr(choice_display_resolution->GetStringSelection());
   }
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
-  main_frame->m_XRRConfig->Update();
+  main_frame->m_xrr_config->Update();
 #endif
   ev.Skip();
 }


### PR DESCRIPTION
I plan to do more work on untangling some parts of the debugger code (particularly with the code window and the host interface) both behavior-wise and how it interacts with the frame. However before I do that, I want to normalize the member naming in the frame code to make it mildly less annoying to read through (and also make it conform to the coding style).