### PR TITLE
Qt: Fix platform icons

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -24,7 +24,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     switch (index.column())
     {
     case COL_PLATFORM:
-      return game->GetPlatform();
+      return static_cast<int>(game->GetPlatformID());
     case COL_BANNER:
       return game->GetBanner();
     case COL_TITLE:


### PR DESCRIPTION
Previously all items regardless of actual platform would show the Gamecube Disc Icon, now they display the appropriate icon.