### PR TITLE
Qt: Fix gamelist updating

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -90,6 +90,8 @@ void GameListModel::UpdateGame(QSharedPointer<GameFile> game)
   int entry = FindGame(path);
   if (entry < 0)
     entry = m_games.size();
+  else
+    return;
 
   beginInsertRows(QModelIndex(), entry, entry);
   m_games.insert(entry, game);

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -55,8 +55,8 @@ void GameTracker::RemoveDirectory(const QString& dir)
     QString path = QFileInfo(it.next()).canonicalFilePath();
     if (m_tracked_files.contains(path))
     {
-      m_tracked_files[path]--;
-      if (m_tracked_files[path] == 0)
+      m_tracked_files[path].remove(dir);
+      if (m_tracked_files[path].empty())
       {
         removePath(path);
         m_tracked_files.remove(path);
@@ -72,23 +72,63 @@ void GameTracker::UpdateDirectory(const QString& dir)
   while (it.hasNext())
   {
     QString path = QFileInfo(it.next()).canonicalFilePath();
+    auto& tracked_file = m_tracked_files[path];
+
     if (m_tracked_files.contains(path))
     {
-      m_tracked_files[path]++;
+      if (!tracked_file.contains(dir))
+        tracked_file.insert(dir);
     }
     else
     {
       addPath(path);
-      m_tracked_files[path] = 1;
+      m_tracked_files[path] = QSet<QString>{dir};
       emit PathChanged(path);
     }
   }
+
+  for (const auto& missing : FindMissingFiles(dir))
+  {
+    auto& tracked_file = m_tracked_files[missing];
+
+    tracked_file.remove(dir);
+    if (tracked_file.empty())
+    {
+      m_tracked_files.remove(missing);
+      GameRemoved(missing);
+    }
+  }
+}
+
+QSet<QString> GameTracker::FindMissingFiles(const QString& dir)
+{
+  QDirIterator it(dir, game_filters, QDir::NoFilter, QDirIterator::Subdirectories);
+
+  QSet<QString> missing_files;
+
+  for (const auto& key : m_tracked_files.keys())
+  {
+    if (m_tracked_files[key].contains(dir))
+      missing_files.insert(key);
+  }
+
+  while (it.hasNext())
+  {
+    QString path = QFileInfo(it.next()).canonicalFilePath();
+    if (m_tracked_files.contains(path))
+      missing_files.remove(path);
+  }
+
+  return missing_files;
 }
 
 void GameTracker::UpdateFile(const QString& file)
 {
   if (QFileInfo(file).exists())
   {
+    GameRemoved(file);
+    addPath(file);
+
     emit PathChanged(file);
   }
   else if (removePath(file))

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -6,13 +6,13 @@
 
 #include <QFileSystemWatcher>
 #include <QMap>
+#include <QSet>
 #include <QSharedPointer>
 #include <QString>
 #include <QStringList>
 #include <QThread>
 
 #include "DolphinQt2/GameList/GameFile.h"
-#include "DolphinQt2/GameList/GameTracker.h"
 
 class GameLoader;
 
@@ -42,9 +42,10 @@ signals:
 private:
   void UpdateDirectory(const QString& dir);
   void UpdateFile(const QString& path);
+  QSet<QString> FindMissingFiles(const QString& dir);
 
-  // game path -> number of directories that track it
-  QMap<QString, int> m_tracked_files;
+  // game path -> directories that track it
+  QMap<QString, QSet<QString>> m_tracked_files;
   QThread m_loader_thread;
   GameLoader* m_loader;
 };


### PR DESCRIPTION
Fixes gamelist updating in two ways:
* Detects when games are removed
* Detects when a game file is modified and reloads it