### PR TITLE
HLE: Use a proper apploader OSReport

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -111,8 +111,6 @@ bool CBoot::EmulatedBS2_GC(bool skip_app_loader)
   // HIO checks this
   // PowerPC::HostWrite_U16(0x8200,     0x000030e6); // Console type
 
-  HLE::Patch(0x81300000, "OSReport");  // HLE OSReport for Apploader
-
   if (!DVDInterface::IsDiscInside())
     return false;
 
@@ -163,6 +161,7 @@ bool CBoot::EmulatedBS2_GC(bool skip_app_loader)
 
   // iAppLoaderInit
   DEBUG_LOG(MASTER_LOG, "Call iAppLoaderInit");
+  HLE::Patch(0x81300000, "AppLoaderReport");  // HLE OSReport for Apploader
   PowerPC::ppcState.gpr[3] = 0x81300000;
   RunFunction(iAppLoaderInit);
 
@@ -191,6 +190,7 @@ bool CBoot::EmulatedBS2_GC(bool skip_app_loader)
   // iAppLoaderClose
   DEBUG_LOG(MASTER_LOG, "call iAppLoaderClose");
   RunFunction(iAppLoaderClose);
+  HLE::UnPatch("AppLoaderReport");
 
   // return
   PC = PowerPC::ppcState.gpr[3];
@@ -358,8 +358,6 @@ bool CBoot::EmulatedBS2_Wii()
   Memory::Write_U32(0x4c000064, 0x00000800);  // Write default FPU Handler:   rfi
   Memory::Write_U32(0x4c000064, 0x00000C00);  // Write default Syscall Handler: rfi
 
-  HLE::Patch(0x81300000, "OSReport");  // HLE OSReport for Apploader
-
   PowerPC::ppcState.gpr[1] = 0x816ffff0;  // StackPointer
 
   // Execute the apploader
@@ -391,6 +389,7 @@ bool CBoot::EmulatedBS2_Wii()
 
   // iAppLoaderInit
   DEBUG_LOG(BOOT, "Run iAppLoaderInit");
+  HLE::Patch(0x81300000, "AppLoaderReport");  // HLE OSReport for Apploader
   PowerPC::ppcState.gpr[3] = 0x81300000;
   RunFunction(iAppLoaderInit);
 
@@ -416,6 +415,7 @@ bool CBoot::EmulatedBS2_Wii()
   // iAppLoaderClose
   DEBUG_LOG(BOOT, "Run iAppLoaderClose");
   RunFunction(iAppLoaderClose);
+  HLE::UnPatch("AppLoaderReport");
 
   IOS::HLE::Device::ES::DIVerify(tmd, DVDInterface::GetVolume().GetTicket());
 

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -57,7 +57,7 @@ static const SPatch OSPatches[] = {
     // This needs to be put before vprintf (because vprintf is called indirectly by this)
     {"JUTWarningConsole_f",          HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
 
-    {"OSReport",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE,   HLE_TYPE_DEBUG}, // apploader needs OSReport replace hook
+    {"OSReport",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"DEBUGPrint",                   HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"WUD_DEBUGPrint",               HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"vprintf",                      HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
@@ -69,6 +69,7 @@ static const SPatch OSPatches[] = {
 
     {"GeckoCodehandler",             HLE_Misc::GeckoCodeHandlerICacheFlush, HLE_HOOK_START,   HLE_TYPE_FIXED},
     {"GeckoHandlerReturnTrampoline", HLE_Misc::GeckoReturnTrampoline,       HLE_HOOK_REPLACE, HLE_TYPE_FIXED},
+    {"AppLoaderReport",              HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_FIXED} // apploader needs OSReport-like function
 };
 
 static const SPatch OSBreakPoints[] = {


### PR DESCRIPTION
Following PR https://github.com/dolphin-emu/dolphin/pull/4469 and https://github.com/dolphin-emu/dolphin/pull/5341, this one replaces the ```HLE_HOOK_REPLACE``` with a ```HLE_HOOK_START``` for OSReport. My motivations for this are explained in the first PR. In short, ```HLE_HOOK_REPLACE``` are bad because of false-positives and weird behaviours.

To do so, I had to allocate a proper entry for the HLE apploader trick. The apploader functions are described in [YAGC - Section 18.2.3  Apploader](http://www.gc-forever.com/yagcd/chap18.html#sec18.2.3) and we are running them manually via the ```RunFunction``` and fill the registers appropriately. However, rather than passing a function pointer (of OSReport or similar)  for the ```Init``` (i.e. ```iAppLoaderInit```) function, we pass a HLE function pointer instead.

Furthermore, that HLE patch doesn't seem to be removed explicitly. The later ```HLE::PatchFunctions()``` call removes all hooks that aren't ```HLE_TYPE_FIXED``` and might be called but not in all cases. That makes me think that if the ISO is launched not in Debug Mode and without a Symbol Map the hook will still be present. In other word, jumping to the address 0x81300000 will execute Dolphin's ```HLE_OS::HLE_GeneralDebugPrint``` (that's a nice Easter egg).

Moreover, the use of a HLE fixed (address) function should use ```HLE_TYPE_FIXED``` since it's not name based as suggested by the original ```HLE::Patch``` call. The use of ```HLE_TYPE_DEBUG``` or OSReport in that case for the apploader was probably a mistake. That's why I created a new entry for the apploader's OSReport and that I unpatch manually after use.

Ready to be reviewed & merged.