### PR TITLE
Jit64: fix braces warning in Jit_Integer

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -51,7 +51,7 @@ void Jit64::GenerateOverflow()
   // We need to do this without modifying flags so as not to break stuff that assumes flags
   // aren't clobbered (carry, branch merging): speed doesn't really matter here (this is really
   // rare).
-  static const std::array<u8, 4> ovtable = {0, 0, XER_SO_MASK, XER_SO_MASK};
+  static const std::array<u8, 4> ovtable = {{0, 0, XER_SO_MASK, XER_SO_MASK}};
   MOVZX(32, 8, RSCRATCH, PPCSTATE(xer_so_ov));
   LEA(64, RSCRATCH2, MConst(ovtable));
   MOV(8, R(RSCRATCH), MRegSum(RSCRATCH, RSCRATCH2));


### PR DESCRIPTION
Fixes a warning:

```
Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp:54:45: warning: suggest braces around initialization of subobject [-Wmissing-braces]
  static const std::array<u8, 4> ovtable = {0, 0, XER_SO_MASK, XER_SO_MASK};
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                            {                             }
```