### PR TITLE
SignatureDB: fix prevented copy elision

### DIFF
--- a/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
@@ -18,8 +18,7 @@
 #include "Core/PowerPC/SignatureDB/DSYSignatureDB.h"
 #include "Core/PowerPC/SignatureDB/MEGASignatureDB.h"
 
-SignatureDB::SignatureDB(SignatureDB::HandlerType handler)
-    : m_handler(std::move(CreateFormatHandler(handler)))
+SignatureDB::SignatureDB(SignatureDB::HandlerType handler) : m_handler(CreateFormatHandler(handler))
 {
 }
 


### PR DESCRIPTION
Clang warning:

```
Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp:22:17: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    : m_handler(std::move(CreateFormatHandler(handler)))
                ^
Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp:22:17: note: remove std::move call here
    : m_handler(std::move(CreateFormatHandler(handler)))
                ^~~~~~~~~~                            ~
```