### PR TITLE
CodeView: Set Symbol Size/End Address added

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -6,6 +6,7 @@
 #include <queue>
 #include <string>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
@@ -186,6 +187,14 @@ bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
     }
     addr += 4;
   }
+}
+
+bool ReanalyzeFunction(u32 start_addr, Symbol& func, int max_size)
+{
+  _assert_msg_(OSHLE, func.analyzed, "The function wasn't previously analyzed!");
+
+  func.analyzed = false;
+  return AnalyzeFunction(start_addr, func, max_size);
 }
 
 // Second pass analysis, done after the first pass is done for all functions

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -231,5 +231,6 @@ public:
 void LogFunctionCall(u32 addr);
 void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db);
 bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size = 0);
+bool ReanalyzeFunction(u32 start_addr, Symbol& func, int max_size = 0);
 
 }  // namespace

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -405,24 +405,24 @@ void CCodeView::OnMouseUpR(wxMouseEvent& event)
   // popup menu
   wxMenu menu;
   // menu->Append(IDM_GOTOINMEMVIEW, "&Goto in mem view");
-  menu.Append(IDM_FOLLOWBRANCH, _("&Follow branch"))
+  menu.Append(IDM_FOLLOWBRANCH, _("Follow &branch"))
       ->Enable(AddrToBranch(m_selection) ? true : false);
   menu.AppendSeparator();
 #if wxUSE_CLIPBOARD
-  menu.Append(IDM_COPYADDRESS, _("Copy &address"));
+  menu.Append(IDM_COPYADDRESS, _("&Copy address"));
   menu.Append(IDM_COPYFUNCTION, _("Copy &function"))->Enable(isSymbol);
-  menu.Append(IDM_COPYCODE, _("Copy &code line"));
+  menu.Append(IDM_COPYCODE, _("Copy code &line"));
   menu.Append(IDM_COPYHEX, _("Copy &hex"));
   menu.AppendSeparator();
 #endif
-  menu.Append(IDM_RENAMESYMBOL, _("Rename &symbol"))->Enable(isSymbol);
-  menu.Append(IDM_SETSYMBOLSIZE, _("&Set symbol size"))->Enable(isSymbol);
-  menu.Append(IDM_SETSYMBOLEND, _("&Set symbol end address"))->Enable(isSymbol);
+  menu.Append(IDM_RENAMESYMBOL, _("&Rename symbol"))->Enable(isSymbol);
+  menu.Append(IDM_SETSYMBOLSIZE, _("Set symbol &size"))->Enable(isSymbol);
+  menu.Append(IDM_SETSYMBOLEND, _("Set symbol &end address"))->Enable(isSymbol);
   menu.AppendSeparator();
-  menu.Append(IDM_RUNTOHERE, _("&Run To Here"))->Enable(Core::IsRunning());
+  menu.Append(IDM_RUNTOHERE, _("Run &To Here"))->Enable(Core::IsRunning());
   menu.Append(IDM_ADDFUNCTION, _("&Add function"))->Enable(Core::IsRunning());
   menu.Append(IDM_JITRESULTS, _("PPC vs x86"))->Enable(Core::IsRunning());
-  menu.Append(IDM_INSERTBLR, _("Insert &blr"))->Enable(Core::IsRunning());
+  menu.Append(IDM_INSERTBLR, _("&Insert blr"))->Enable(Core::IsRunning());
   menu.Append(IDM_INSERTNOP, _("Insert &nop"))->Enable(Core::IsRunning());
   // menu.Append(IDM_PATCHALERT, _("Patch alert"))->Enable(Core::IsRunning());
   PopupMenu(&menu);


### PR DESCRIPTION
This PR adds two menu items when right-clicking on the code view. These allow to resize the symbol which is quite handy in cases where PPCAnalyst did mistakes. For convenience, you can choose between specifying the end address or the symbol size.

Ready to be reviewed & merged.