### PR TITLE
JitArm64: Drop ps_res instruction.

### DIFF
--- a/Source/Core/Common/Analytics.cpp
+++ b/Source/Core/Common/Analytics.cpp
@@ -10,6 +10,7 @@
 #include "Common/Analytics.h"
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
+#include "Common/Thread.h"
 
 namespace Common
 {
@@ -147,6 +148,7 @@ void AnalyticsReporter::Send(AnalyticsReportBuilder&& report)
 
 void AnalyticsReporter::ThreadProc()
 {
+  Common::SetCurrentThreadName("Analytics");
   while (true)
   {
     m_reporter_event.Wait();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -142,7 +142,6 @@ public:
   void ps_maddXX(UGeckoInstruction inst);
   void ps_mergeXX(UGeckoInstruction inst);
   void ps_mulsX(UGeckoInstruction inst);
-  void ps_res(UGeckoInstruction inst);
   void ps_sel(UGeckoInstruction inst);
   void ps_sumX(UGeckoInstruction inst);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -152,29 +152,6 @@ void JitArm64::ps_maddXX(UGeckoInstruction inst)
   fpr.Unlock(V0Q);
 }
 
-void JitArm64::ps_res(UGeckoInstruction inst)
-{
-  INSTRUCTION_START
-  JITDISABLE(bJITPairedOff);
-  FALLBACK_IF(inst.Rc);
-  FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
-
-  u32 b = inst.FB, d = inst.FD;
-
-  bool singles = fpr.IsSingle(b);
-  RegType type = singles ? REG_REG_SINGLE : REG_REG;
-  u8 size = singles ? 32 : 64;
-  ARM64Reg (*reg_encoder)(ARM64Reg) = singles ? EncodeRegToDouble : EncodeRegToQuad;
-
-  ARM64Reg VB = fpr.R(b, type);
-  ARM64Reg VD = fpr.RW(d, type);
-
-  // FIXME: implement the same LUT as in the interpreter
-  m_float_emit.FRECPE(size, reg_encoder(VD), reg_encoder(VB));
-
-  fpr.FixSinglePrecision(d);
-}
-
 void JitArm64::ps_sel(UGeckoInstruction inst)
 {
   INSTRUCTION_START

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -145,7 +145,7 @@ constexpr GekkoOPTemplate table4_2[] = {
     {20, &JitArm64::fp_arith},               // ps_sub
     {21, &JitArm64::fp_arith},               // ps_add
     {23, &JitArm64::ps_sel},                 // ps_sel
-    {24, &JitArm64::ps_res},                 // ps_res
+    {24, &JitArm64::FallBackToInterpreter},  // ps_res
     {25, &JitArm64::fp_arith},               // ps_mul
     {26, &JitArm64::FallBackToInterpreter},  // ps_rsqrte
     {28, &JitArm64::ps_maddXX},              // ps_msub

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -84,6 +84,11 @@ static void APIENTRY ErrorCallback(GLenum source, GLenum type, GLuint id, GLenum
   const char* s_source;
   const char* s_type;
 
+  // Performance - DualCore driver performance warning:
+  // DualCore application thread syncing with server thread
+  if (id == 0x200b0)
+    return;
+
   switch (source)
   {
   case GL_DEBUG_SOURCE_API_ARB:


### PR DESCRIPTION
The implementation of ps_res isn't accurate, and it lacks fp exceptions, and it isn't called as often to justify such a speedhack.

Also mute an Nvidia OpenGL warning. We know our code is bad here, no need to waste time on handling this warning.

And give the analytics thread another name, "CPU thread" sounds wrong.