### PR TITLE
Qt: Add General Pane to Settings

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRCS
   GameList/GameTracker.cpp
   GameList/ListProxyModel.cpp
   GameList/TableDelegate.cpp
+  Settings/GeneralPane.cpp
   Settings/InterfacePane.cpp
 )
 

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -68,8 +68,9 @@ void SettingsWindow::MakeUnfinishedWarning()
 
 void SettingsWindow::AddCategoryToList(const QString& title, const QString& icon)
 {
+  QString dir = Settings().GetThemeDir();
   QListWidgetItem* button = new QListWidgetItem();
-  button->setIcon(QIcon(icon));
+  button->setIcon(QIcon(dir.append(icon)));
   button->setText(title);
   button->setTextAlignment(Qt::AlignVCenter);
   button->setSizeHint(QSize(28, 28));
@@ -79,17 +80,14 @@ void SettingsWindow::AddCategoryToList(const QString& title, const QString& icon
 
 void SettingsWindow::MakeCategoryList()
 {
-  QString dir = Settings().GetThemeDir();
-
   m_categories = new QListWidget;
   m_categories->setMaximumWidth(175);
   m_categories->setIconSize(QSize(32, 32));
   m_categories->setMovement(QListView::Static);
   m_categories->setSpacing(0);
 
-  AddCategoryToList(tr("General"), dir.append(QStringLiteral("config.png")));
-  AddCategoryToList(tr("Interface"), dir.append(QStringLiteral("config.png")));
-
+  AddCategoryToList(tr("General"), QStringLiteral("config.png"));
+  AddCategoryToList(tr("Interface"), QStringLiteral("browse.png"));
   connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);
 }
 

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -4,7 +4,9 @@
 
 #include "DolphinQt2/Config/SettingsWindow.h"
 #include "DolphinQt2/Settings.h"
+#include "DolphinQt2/Settings/GeneralPane.h"
 #include "DolphinQt2/Settings/InterfacePane.h"
+
 
 SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
 {
@@ -49,6 +51,8 @@ void SettingsWindow::SetupSettingsWidget()
   m_settings_outer = new QStackedWidget;
   m_settings_outer->setCurrentIndex(0);
 
+  // Panes initalised here
+  m_settings_outer->addWidget(new GeneralPane);
   m_settings_outer->addWidget(new InterfacePane);
 }
 
@@ -83,6 +87,7 @@ void SettingsWindow::MakeCategoryList()
   m_categories->setMovement(QListView::Static);
   m_categories->setSpacing(0);
 
+  AddCategoryToList(tr("General"), dir.append(QStringLiteral("config.png")));
   AddCategoryToList(tr("Interface"), dir.append(QStringLiteral("config.png")));
 
   connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -100,6 +100,7 @@
     <QtMoc Include="MenuBar.h" />
     <QtMoc Include="RenderWidget.h" />
     <QtMoc Include="Settings.h" />
+    <QtMoc Include="Settings\GeneralPane.h" />
     <QtMoc Include="ToolBar.h" />
 
   </ItemGroup>
@@ -112,9 +113,11 @@
     <ClCompile Include="$(QtMocOutPrefix)GameList.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameListModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameTracker.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)GeneralPane.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)Host.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)InDevelopmentWarning.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)InfoWidget.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)InterfacePane.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ListProxyModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MainWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MenuBar.cpp" />
@@ -125,7 +128,7 @@
     <ClCompile Include="$(QtMocOutPrefix)SettingsWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)TableDelegate.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ToolBar.cpp" />
-    <ClCompile Include="$(QtMocOutPrefix)InterfacePane.cpp" />
+
     <ClCompile Include="AboutDialog.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
@@ -147,8 +150,9 @@
     <ClCompile Include="RenderWidget.cpp" />
     <ClCompile Include="Resources.cpp" />
     <ClCompile Include="Settings.cpp" />
+    <ClCompile Include="Settings\GeneralPane.cpp" />
+    <ClCompile Include="Settings\InterfacePane.cpp" />
     <ClCompile Include="ToolBar.cpp" />
-    <ClCompile Include="Settings/InterfacePane.cpp" />
   </ItemGroup>
   <!--Put standard C/C++ headers here-->
   <!--

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
@@ -95,11 +95,17 @@
       <Filter>Settings</Filter>
     </ClCompile>
     <ClCompile Include="$(QtMocOutPrefix)GeneralPane.cpp">
-    <ClCompile Include="Settings/InterfacePane.cpp">
-      <Filter>Settings</Filter>
+      <Filter>Generated Files</Filter>
     </ClCompile>
     <ClCompile Include="$(QtMocOutPrefix)InterfacePane.cpp">
       <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Config\ControllersWindow.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)ControllersWindow.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Settings\InterfacePane.cpp">
+      <Filter>Settings</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -134,8 +140,11 @@
     <QtMoc Include="Config\FilesystemWidget.h" />
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="InDevelopmentWarning.h" />
-    <QtMoc Include="Settings\GeneralPane.h">
+    <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Settings\InterfacePane.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
+    <QtMoc Include="Settings\GeneralPane.h">
       <Filter>Settings</Filter>
     </QtMoc>
   </ItemGroup>

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
@@ -91,6 +91,10 @@
     <ClCompile Include="$(QtMocOutPrefix)InDevelopmentWarning.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
+    <ClCompile Include="Settings\GeneralPane.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
+    <ClCompile Include="$(QtMocOutPrefix)GeneralPane.cpp">
     <ClCompile Include="Settings/InterfacePane.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
@@ -130,6 +134,7 @@
     <QtMoc Include="Config\FilesystemWidget.h" />
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="InDevelopmentWarning.h" />
+    <QtMoc Include="Settings\GeneralPane.h">
     <QtMoc Include="Settings\InterfacePane.h">
       <Filter>Settings</Filter>
     </QtMoc>

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -108,6 +108,36 @@ void Settings::SetWiiNAND(const QString& path)
   SConfig::GetInstance().SaveSettings();
 }
 
+float Settings::GetEmulationSpeed() const
+{
+  return SConfig::GetInstance().m_EmulationSpeed;
+}
+
+void Settings::SetEmulationSpeed(float val)
+{
+  SConfig::GetInstance().m_EmulationSpeed = val;
+}
+
+bool Settings::GetForceNTSCJ() const
+{
+  return SConfig::GetInstance().bForceNTSCJ;
+}
+
+void Settings::SetForceNTSCJ(bool val)
+{
+  SConfig::GetInstance().bForceNTSCJ = val;
+}
+
+bool Settings::GetAnalyticsEnabled() const
+{
+  return SConfig::GetInstance().m_analytics_enabled;
+}
+
+void Settings::SetAnalyticsEnabled(bool val)
+{
+  SConfig::GetInstance().m_analytics_enabled = val;
+}
+
 DiscIO::Language Settings::GetWiiSystemLanguage() const
 {
   return SConfig::GetInstance().GetCurrentLanguage(true);

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -50,6 +50,14 @@ public:
   bool IsWiiGameRunning() const;
   int GetStateSlot() const;
   void SetStateSlot(int);
+  float GetEmulationSpeed() const;
+  void SetEmulationSpeed(float val);
+  bool GetForceNTSCJ() const;
+  void SetForceNTSCJ(bool val);
+
+  // Analytics
+  bool GetAnalyticsEnabled() const;
+  void SetAnalyticsEnabled(bool val);
 
   // Graphics
   bool GetRenderToMain() const;

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
@@ -1,0 +1,181 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Settings/GeneralPane.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSlider>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "Core/Analytics.h"
+#include "Core/ConfigManager.h"
+#include "DolphinQt2/Settings.h"
+
+GeneralPane::GeneralPane(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+  ConnectLayout();
+
+  LoadConfig();
+}
+
+void GeneralPane::CreateLayout()
+{
+  m_main_layout = new QVBoxLayout;
+  // Create layout here
+  CreateBasic();
+
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
+  CreateAnalytics();
+#endif
+
+  CreateAdvanced();
+
+  m_main_layout->addStretch(1);
+  setLayout(m_main_layout);
+}
+
+void GeneralPane::ConnectLayout()
+{
+  connect(m_combobox_language, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
+          [this](int index) { OnSaveConfig(); });
+
+  // Advanced
+  connect(m_checkbox_force_ntsc, &QCheckBox::clicked, this, &GeneralPane::OnSaveConfig);
+  connect(m_slider_speedlimit, static_cast<void (QSlider::*)(int)>(&QSlider::valueChanged),
+          [this](int index) { OnSaveConfig(); });
+
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
+  connect(m_checkbox_enable_analytics, &QCheckBox::clicked, this, &GeneralPane::OnSaveConfig);
+  connect(m_button_generate_new_identity, &QPushButton::clicked, this,
+          &GeneralPane::GenerateNewIdentity);
+#endif
+}
+
+void GeneralPane::CreateBasic()
+{
+  auto* basic_group = new QGroupBox(tr("Basic Settings"));
+  auto* basic_group_layout = new QVBoxLayout;
+  basic_group->setLayout(basic_group_layout);
+  m_main_layout->addWidget(basic_group);
+
+  auto* language_layout = new QFormLayout;
+  basic_group_layout->addLayout(language_layout);
+
+  m_combobox_language = new QComboBox;
+  // TODO: Support more languages other then English
+  m_combobox_language->addItem(tr("English"));
+  language_layout->addRow(tr("&Language:"), m_combobox_language);
+}
+
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
+void GeneralPane::CreateAnalytics()
+{
+  auto* analytics_group = new QGroupBox(tr("Usage Statistics Reporting"));
+  auto* analytics_group_layout = new QVBoxLayout;
+  analytics_group->setLayout(analytics_group_layout);
+  m_main_layout->addWidget(analytics_group);
+
+  m_checkbox_enable_analytics = new QCheckBox(tr("Enable Usage Statistics Reporting"));
+  m_button_generate_new_identity = new QPushButton(tr("Generate a New Statistics Identity"));
+  analytics_group_layout->addWidget(m_checkbox_enable_analytics);
+  analytics_group_layout->addWidget(m_button_generate_new_identity);
+}
+#endif
+
+void GeneralPane::CreateAdvanced()
+{
+  auto* advanced_group = new QGroupBox(tr("Advanced Settings"));
+  auto* advanced_group_layout = new QVBoxLayout;
+  advanced_group->setLayout(advanced_group_layout);
+  m_main_layout->addWidget(advanced_group);
+
+  // Speed Limit
+  auto* speed_limit_layout = new QFormLayout;
+  auto* speed_limit_container = new QHBoxLayout;
+  speed_limit_container->addLayout(speed_limit_layout);
+  advanced_group_layout->addLayout(speed_limit_container);
+
+  m_slider_speedlimit = new QSlider(Qt::Orientation::Horizontal);
+  m_slider_speedlimit->setTickInterval(1);
+  m_slider_speedlimit->setMinimum(1);
+  m_slider_speedlimit->setMaximum(21);
+  m_slider_speedlimit->setTickPosition(QSlider::TicksBelow);
+  m_slider_speedlimit->setSingleStep(1);
+  speed_limit_layout->addRow(tr("&Speed Limit:"), m_slider_speedlimit);
+
+  m_label_speedlimit = new QLabel(tr("Unlimited"));
+  m_label_speedlimit->setMinimumWidth(48);
+  m_label_speedlimit->setAlignment(Qt::AlignRight | Qt::AlignCenter);
+  speed_limit_container->addWidget(m_label_speedlimit);
+
+  // NTSC-J
+  m_checkbox_force_ntsc = new QCheckBox(tr("Force Console as NTSC-J"));
+  advanced_group_layout->addWidget(m_checkbox_force_ntsc);
+}
+
+void GeneralPane::LoadConfig()
+{
+  m_checkbox_force_ntsc->setChecked(Settings().GetForceNTSCJ());
+  m_checkbox_enable_analytics->setChecked(Settings().GetAnalyticsEnabled());
+
+  int selection = qRound(Settings().GetEmulationSpeed() * 10);
+  if (selection < m_slider_speedlimit->maximum())
+  {
+    if (selection == 0)
+    {
+      m_slider_speedlimit->setValue(21);
+      m_slider_speedlimit->setToolTip(tr("Unlimited"));
+      m_label_speedlimit->setText(tr("Unlimited"));
+    }
+    else
+    {
+      m_slider_speedlimit->setValue(selection);
+
+      QString val = QString::fromStdString(std::to_string(m_slider_speedlimit->value() * 10)) +
+                    QStringLiteral("%");
+      m_slider_speedlimit->setToolTip(val);
+      m_label_speedlimit->setText(val);
+    }
+  }
+}
+
+void GeneralPane::OnSaveConfig()
+{
+  Settings().SetForceNTSCJ(m_checkbox_force_ntsc->isChecked());
+  Settings().SetAnalyticsEnabled(m_checkbox_enable_analytics->isChecked());
+  if (m_slider_speedlimit->value() < 21)
+  {
+    Settings().SetEmulationSpeed(m_slider_speedlimit->value() * 0.1f);
+    QString val = QString::fromStdString(std::to_string(m_slider_speedlimit->value() * 10)) +
+                  QStringLiteral("%");
+    m_slider_speedlimit->setToolTip(val);
+    m_label_speedlimit->setText(val);
+  }
+  else
+  {
+    Settings().SetEmulationSpeed(0);
+    m_slider_speedlimit->setToolTip(tr("Unlimited"));
+    m_label_speedlimit->setText(tr("Unlimited"));
+  }
+}
+
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
+void GeneralPane::GenerateNewIdentity()
+{
+  DolphinAnalytics::Instance()->GenerateNewIdentity();
+  QMessageBox message_box;
+  message_box.setIcon(QMessageBox::Information);
+  message_box.setWindowTitle(tr("Identity Generation"));
+  message_box.setText(tr("New identity generated."));
+  message_box.exec();
+}
+#endif

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.h
@@ -1,0 +1,46 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QSlider;
+class QVBoxLayout;
+
+class GeneralPane final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit GeneralPane(QWidget* parent = nullptr);
+
+private:
+  void CreateLayout();
+  void ConnectLayout();
+  void CreateBasic();
+  void CreateAdvanced();
+
+  void LoadConfig();
+  void OnSaveConfig();
+
+  // Widgets
+  QVBoxLayout* m_main_layout;
+  QComboBox* m_combobox_language;
+  QSlider* m_slider_speedlimit;
+  QCheckBox* m_checkbox_force_ntsc;
+  QLabel* m_label_speedlimit;
+
+// Analytics related
+#if defined(USE_ANALYTICS) && USE_ANALYTICS
+  void CreateAnalytics();
+  void GenerateNewIdentity();
+
+  QPushButton* m_button_generate_new_identity;
+  QCheckBox* m_checkbox_enable_analytics;
+#endif
+};


### PR DESCRIPTION
The Qt GUI's flaw is that nothing is configurable as of now.
This PR doesn't change that too much, but it's a good framework on how it should be done.

![image](https://cloud.githubusercontent.com/assets/866151/25763325/5bf1876a-3197-11e7-8dcb-f4bacbd08a39.png)


This PR adds the General Pane to the Settings window in the Qt GUI.

- Language selector is not implemented (no known way to enumerate languages and select one).
- Force NTSC-J works
- Speed Limit works (Unlimited, 10->200%)
- Usage Statistics Reporting works,

It also adds the new files to the VS Project, and modifies the include path to allow QtMoc to find the new files.