### PR TITLE
IOS/ES: Fix the implementation of ES_DeleteTicket

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -300,6 +300,21 @@ std::vector<u8> TicketReader::GetTitleKey() const
   return key;
 }
 
+void TicketReader::DeleteTicket(u64 ticket_id_to_delete)
+{
+  std::vector<u8> new_ticket;
+  const size_t num_tickets = GetNumberOfTickets();
+  for (size_t i = 0; i < num_tickets; ++i)
+  {
+    const auto ticket_start = m_bytes.cbegin() + sizeof(Ticket) * i;
+    const u64 ticket_id = Common::swap64(&*ticket_start + offsetof(Ticket, ticket_id));
+    if (ticket_id != ticket_id_to_delete)
+      new_ticket.insert(new_ticket.end(), ticket_start, ticket_start + sizeof(Ticket));
+  }
+
+  m_bytes = std::move(new_ticket);
+}
+
 s32 TicketReader::Unpersonalise()
 {
   const auto ticket_begin = m_bytes.begin();

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -193,6 +193,9 @@ public:
   u64 GetTitleId() const;
   std::vector<u8> GetTitleKey() const;
 
+  // Deletes a ticket with the given ticket ID from the internal buffer.
+  void DeleteTicket(u64 ticket_id);
+
   // Decrypts the title key field for a "personalised" ticket -- one that is device-specific
   // and has a title key that must be decrypted first.
   s32 Unpersonalise();

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -97,8 +97,14 @@ struct TicketView
 };
 static_assert(sizeof(TicketView) == 0xd8, "TicketView has the wrong size");
 
+// This structure is used for (signed) tickets. Technically, there are other types of tickets
+// (RSA4096, ECDSA, ...). However, only RSA2048 tickets have ever been seen and these are also
+// the only ticket type that is supported by the Wii's IOS.
 struct Ticket
 {
+  u32 signature_type;
+  u8 signature[256];
+  u8 unused[60];
   u8 signature_issuer[0x40];
   u8 server_public_key[0x3c];
   u8 version;
@@ -118,7 +124,7 @@ struct Ticket
   u8 content_access_permissions[0x40];
   TimeLimit time_limits[8];
 };
-static_assert(sizeof(Ticket) == 356, "Ticket has the wrong size");
+static_assert(sizeof(Ticket) == 0x2A4, "Ticket has the wrong size");
 #pragma pack(pop)
 
 class TMDReader final
@@ -175,8 +181,7 @@ public:
   void DoState(PointerWrap& p);
 
   const std::vector<u8>& GetRawTicket() const;
-  u32 GetNumberOfTickets() const;
-  u32 GetOffset() const;
+  size_t GetNumberOfTickets() const;
 
   // Returns a "raw" ticket view, without byte swapping. Intended for use from ES.
   // Theoretically, a ticket file can contain one or more tickets. In practice, most (all?)

--- a/Source/Core/Core/IOS/ES/Views.cpp
+++ b/Source/Core/Core/IOS/ES/Views.cpp
@@ -48,7 +48,7 @@ IPCCommandResult ES::GetTicketViewCount(const IOCtlVRequest& request)
   u64 TitleID = Memory::Read_U64(request.in_vectors[0].address);
 
   const IOS::ES::TicketReader ticket = DiscIO::FindSignedTicket(TitleID);
-  u32 view_count = ticket.IsValid() ? ticket.GetNumberOfTickets() : 0;
+  u32 view_count = ticket.IsValid() ? static_cast<u32>(ticket.GetNumberOfTickets()) : 0;
 
   if (ShouldReturnFakeViewsForIOSes(TitleID, GetTitleContext()))
   {
@@ -75,7 +75,7 @@ IPCCommandResult ES::GetTicketViews(const IOCtlVRequest& request)
 
   if (ticket.IsValid())
   {
-    u32 number_of_views = std::min(maxViews, ticket.GetNumberOfTickets());
+    u32 number_of_views = std::min(maxViews, static_cast<u32>(ticket.GetNumberOfTickets()));
     for (u32 view = 0; view < number_of_views; ++view)
     {
       const std::vector<u8> ticket_view = ticket.GetRawTicketView(view);
@@ -235,7 +235,7 @@ IPCCommandResult ES::DIGetTicketView(const IOCtlVRequest& request)
     return GetDefaultReply(ES_EINVAL);
   }
 
-  const bool has_ticket_vector = request.in_vectors[0].size == 0x2A4;
+  const bool has_ticket_vector = request.in_vectors[0].size == sizeof(IOS::ES::Ticket);
 
   // This ioctlv takes either a signed ticket or no ticket, in which case the ticket size must be 0.
   if (!has_ticket_vector && request.in_vectors[0].size != 0)


### PR DESCRIPTION
* It should take a ticket view, not a title ID.
* It's missing a lot of checks.
* It's not deleting only the ticket it needs to delete.
* It should not return -1017 when the ticket doesn't exist.
* It's not returning the proper error code when a read/write fails.
* It's not cleaning up the ticket directory if there is nothing left.

These issues result in the implementation being simply broken and nothing more than guesswork. It has never worked, and will never work in its current state.

This rewrites the ES_DeleteTicket implementation to fix all of these inaccuracies and to fix the ioctlv.
