### PR TITLE
[WIP] FIFO logs: add VI register state and move frame end logic to Video_BeginField

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
@@ -13,7 +13,7 @@
 enum
 {
   FILE_ID = 0x0d01f1f0,
-  VERSION_NUMBER = 4,
+  VERSION_NUMBER = 5,
   MIN_LOADER_VERSION = 1,
 };
 
@@ -49,7 +49,8 @@ struct FileFrameInfo
   u32 fifoEnd;
   u64 memoryUpdatesOffset;
   u32 numMemoryUpdates;
-  u8 reserved[32];
+  u64 vi_mem_offset;
+  u8 reserved[24];
 };
 static_assert(sizeof(FileFrameInfo) == 64, "FileFrameInfo should be 64 bytes");
 
@@ -73,6 +74,11 @@ FifoDataFile::~FifoDataFile() = default;
 bool FifoDataFile::HasBrokenEFBCopies() const
 {
   return m_Version < 2;
+}
+
+bool FifoDataFile::HasVideoInterfaceRegisters() const
+{
+  return m_Version >= 5;
 }
 
 void FifoDataFile::SetIsWii(bool isWii)
@@ -157,8 +163,15 @@ bool FifoDataFile::Save(const std::string& filename)
     u64 dataOffset = file.Tell();
     file.WriteBytes(srcFrame.fifoData.data(), srcFrame.fifoData.size());
 
+    // Write memory updates
     u64 memoryUpdatesOffset = WriteMemoryUpdates(srcFrame.memoryUpdates, file);
 
+    // Write VI registers
+    file.Seek(0, SEEK_END);
+    u64 vi_mem_offset = file.Tell();
+    file.WriteBytes(srcFrame.vi_mem.data(), srcFrame.vi_mem.size());
+
+    // Write frame info
     FileFrameInfo dstFrame;
     dstFrame.fifoDataSize = static_cast<u32>(srcFrame.fifoData.size());
     dstFrame.fifoDataOffset = dataOffset;
@@ -166,8 +179,8 @@ bool FifoDataFile::Save(const std::string& filename)
     dstFrame.fifoEnd = srcFrame.fifoEnd;
     dstFrame.memoryUpdatesOffset = memoryUpdatesOffset;
     dstFrame.numMemoryUpdates = static_cast<u32>(srcFrame.memoryUpdates.size());
+    dstFrame.vi_mem_offset = vi_mem_offset;
 
-    // Write frame info
     u64 frameOffset = frameListOffset + (i * sizeof(FileFrameInfo));
     file.Seek(frameOffset, SEEK_SET);
     file.WriteBytes(&dstFrame, sizeof(FileFrameInfo));
@@ -249,6 +262,13 @@ std::unique_ptr<FifoDataFile> FifoDataFile::Load(const std::string& filename, bo
 
     ReadMemoryUpdates(srcFrame.memoryUpdatesOffset, srcFrame.numMemoryUpdates,
                       dstFrame.memoryUpdates, file);
+
+    // VI register saving was added in version 5.
+    if (dataFile->HasVideoInterfaceRegisters())
+    {
+      file.Seek(srcFrame.vi_mem_offset, SEEK_SET);
+      file.ReadArray(dstFrame.vi_mem.data(), dstFrame.vi_mem.size());
+    }
 
     dataFile->AddFrame(dstFrame);
   }

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.h
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -33,6 +34,11 @@ struct MemoryUpdate
 
 struct FifoFrameInfo
 {
+  enum
+  {
+    VI_MEM_SIZE = 256,
+  };
+
   std::vector<u8> fifoData;
 
   u32 fifoStart;
@@ -40,6 +46,7 @@ struct FifoFrameInfo
 
   // Must be sorted by fifoPosition
   std::vector<MemoryUpdate> memoryUpdates;
+  std::array<u8, VI_MEM_SIZE> vi_mem;
 };
 
 class FifoDataFile
@@ -60,6 +67,7 @@ public:
   void SetIsWii(bool isWii);
   bool GetIsWii() const;
   bool HasBrokenEFBCopies() const;
+  bool HasVideoInterfaceRegisters() const;
 
   u32* GetBPMem() { return m_BPMem; }
   u32* GetCPMem() { return m_CPMem; }

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -214,6 +214,10 @@ FifoPlayer& FifoPlayer::GetInstance()
 
 void FifoPlayer::WriteFrame(const FifoFrameInfo& frame, const AnalyzedFrameInfo& info)
 {
+  // VideoInterface registers
+  if (m_File->HasVideoInterfaceRegisters())
+    VideoInterface::LoadVIRegs(frame.vi_mem.data());
+
   // Core timing information
   m_CyclesPerFrame = SystemTimers::GetTicksPerSecond() / VideoInterface::GetTargetRefreshRate();
   m_ElapsedCycles = 0;

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -13,6 +13,7 @@
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoRecordAnalyzer.h"
 #include "Core/HW/Memmap.h"
+#include "Core/HW/VideoInterface.h"
 
 static FifoRecorder instance;
 static std::recursive_mutex sMutex;
@@ -144,6 +145,8 @@ void FifoRecorder::EndFrame(u32 fifoStart, u32 fifoEnd)
 
   m_CurrentFrame.fifoStart = fifoStart;
   m_CurrentFrame.fifoEnd = fifoEnd;
+
+  VideoInterface::FillVIMemoryArray(m_CurrentFrame.vi_mem.data());
 
   if (m_WasRecording)
   {

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -74,7 +74,7 @@ static u32 s_odd_field_first_hl;   // index first halfline of the odd field
 static u32 s_even_field_last_hl;   // index last halfline of the even field
 static u32 s_odd_field_last_hl;    // index last halfline of the odd field
 
-void DoState(PointerWrap& p)
+static void DoRegisters(PointerWrap& p)
 {
   p.DoPOD(m_VerticalTimingRegister);
   p.DoPOD(m_DisplayControlRegister);
@@ -98,6 +98,25 @@ void DoState(PointerWrap& p)
   p.Do(m_DTVStatus);
   p.Do(m_FBWidth);
   p.Do(m_BorderHBlank);
+}
+
+void LoadVIRegs(const u8* readonly_memory)
+{
+  u8* memory = const_cast<u8*>(readonly_memory);
+  PointerWrap p{&memory, PointerWrap::MODE_READ};
+  DoRegisters(p);
+  UpdateParameters();
+}
+
+void FillVIMemoryArray(u8* memory)
+{
+  PointerWrap p{&memory, PointerWrap::MODE_WRITE};
+  DoRegisters(p);
+}
+
+void DoState(PointerWrap& p)
+{
+  DoRegisters(p);
   p.Do(s_target_refresh_rate);
   p.Do(s_ticks_last_line_start);
   p.Do(s_half_line_count);

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -373,4 +373,8 @@ u32 GetTicksPerField();
 // result by 1.33333..
 float GetAspectRatio();
 
+// For FIFO recording/playing
+void FillVIMemoryArray(u8* memory);
+void LoadVIRegs(const u8* memory);
+
 }  // namespace VideoInterface

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -10,6 +10,7 @@
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
+#include "Core/HW/VideoInterface.h"
 #include "Core/Host.h"
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/BPStructs.h"

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -9,6 +9,7 @@
 #include "Common/Event.h"
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
+#include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/Host.h"
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/BPStructs.h"
@@ -28,6 +29,7 @@
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoState.h"
+#include "VideoCommon/XFMemory.h"
 
 static Common::Flag s_FifoShuttingDown;
 
@@ -45,11 +47,49 @@ void VideoBackendBase::Video_ExitLoop()
   s_FifoShuttingDown.Set();
 }
 
+static void RecordVideoMemory()
+{
+  const u32* bpmem_ptr = reinterpret_cast<const u32*>(&bpmem);
+  u32 cpmem[256] = {};
+  // The FIFO recording format splits XF memory into xfmem and xfregs; follow
+  // that split here.
+  const u32* xfmem_ptr = reinterpret_cast<const u32*>(&xfmem);
+  const u32* xfregs_ptr = reinterpret_cast<const u32*>(&xfmem) + FifoDataFile::XF_MEM_SIZE;
+  u32 xfregs_size = sizeof(XFMemory) / 4 - FifoDataFile::XF_MEM_SIZE;
+
+  FillCPMemoryArray(cpmem);
+
+  FifoRecorder::GetInstance().SetVideoMemory(bpmem_ptr, cpmem, xfmem_ptr, xfregs_ptr, xfregs_size,
+                                             texMem);
+}
+
+static void CheckFifoRecording()
+{
+  bool wasRecording = g_bRecordFifoData;
+  g_bRecordFifoData = FifoRecorder::GetInstance().IsRecording();
+
+  if (g_bRecordFifoData)
+  {
+    if (!wasRecording)
+    {
+      RecordVideoMemory();
+    }
+
+    FifoRecorder::GetInstance().EndFrame(CommandProcessor::fifo.CPBase,
+                                         CommandProcessor::fifo.CPEnd);
+  }
+}
+
 // Run from the CPU thread (from VideoInterface.cpp)
 void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                                         u64 ticks)
 {
-  if (m_initialized && g_ActiveConfig.bUseXFB && g_renderer)
+  if (!m_initialized)
+    return;
+
+  CheckFifoRecording();
+
+  if (g_ActiveConfig.bUseXFB && g_renderer)
   {
     Fifo::SyncGPU(Fifo::SyncGPUReason::Swap);
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -36,15 +36,12 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
-#include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/VideoInterface.h"
 #include "Core/Host.h"
 #include "Core/Movie.h"
 
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/BPMemory.h"
-#include "VideoCommon/CPMemory.h"
-#include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/FPSCounter.h"
 #include "VideoCommon/FramebufferManagerBase.h"
@@ -108,8 +105,6 @@ Renderer::~Renderer()
 void Renderer::RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbStride, u32 fbHeight,
                            float Gamma)
 {
-  CheckFifoRecording();
-
   if (!fbStride || !fbHeight)
     return;
 
@@ -696,39 +691,6 @@ void Renderer::SetWindowSize(int width, int height)
     m_last_window_request_height = height;
     Host_RequestRenderWindowSize(width, height);
   }
-}
-
-void Renderer::CheckFifoRecording()
-{
-  bool wasRecording = g_bRecordFifoData;
-  g_bRecordFifoData = FifoRecorder::GetInstance().IsRecording();
-
-  if (g_bRecordFifoData)
-  {
-    if (!wasRecording)
-    {
-      RecordVideoMemory();
-    }
-
-    FifoRecorder::GetInstance().EndFrame(CommandProcessor::fifo.CPBase,
-                                         CommandProcessor::fifo.CPEnd);
-  }
-}
-
-void Renderer::RecordVideoMemory()
-{
-  const u32* bpmem_ptr = reinterpret_cast<const u32*>(&bpmem);
-  u32 cpmem[256] = {};
-  // The FIFO recording format splits XF memory into xfmem and xfregs; follow
-  // that split here.
-  const u32* xfmem_ptr = reinterpret_cast<const u32*>(&xfmem);
-  const u32* xfregs_ptr = reinterpret_cast<const u32*>(&xfmem) + FifoDataFile::XF_MEM_SIZE;
-  u32 xfregs_size = sizeof(XFMemory) / 4 - FifoDataFile::XF_MEM_SIZE;
-
-  FillCPMemoryArray(cpmem);
-
-  FifoRecorder::GetInstance().SetVideoMemory(bpmem_ptr, cpmem, xfmem_ptr, xfregs_ptr, xfregs_size,
-                                             texMem);
 }
 
 void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -146,9 +146,6 @@ protected:
   std::tuple<int, int> CalculateTargetScale(int x, int y) const;
   bool CalculateTargetSize();
 
-  void CheckFifoRecording();
-  void RecordVideoMemory();
-
   bool IsFrameDumping();
   void DumpFrameData(const u8* data, int w, int h, int stride, const AVIDump::Frame& state,
                      bool swap_upside_down = false);


### PR DESCRIPTION
(Formerly titled "Add VideoInterface register state to FIFO logs".)

- Marks FIFO log frames in `Video_BeginField` instead of `RenderToXFB`
- Adds VideoInterface register state to FIFO logs

This fixes a couple FIFO issues:

- FIFO logs played back at 120 FPS/VPS, which is too fast for most (all?) games. Adding VideoInterface register state throttles Dolphin to the correct VPS, and marking frames in `Video_BeginField` instead of `RenderToXFB` results in the correct FPS/VPS ratio.

    Example: a FIFO log of Godzilla: Destroy All Monsters running at 40FPS in PAL50 mode:

    
    <img width="182" alt="screen shot 2017-05-29 at 9 23 33 pm" src="https://cloud.githubusercontent.com/assets/594093/26568053/2d1feaf4-44b5-11e7-9b67-ffa588f3b88d.png">


- FIFO player didn't work in Real or Virtual XFB mode. Setting the VI registers, which contain the XFB location, properly lets this work.

- Dolphin couldn't count frames properly during direct writes to XFB (e.g. SSX Tricky intro videos) because `RenderToXFB` is never called. Marking frames in `Video_BeginField` fixes this. Admittedly, this is pointless, since FIFORecorder doesn't record anything (unless you like looking at the green color of a blank XFB).

- FIFO logs with unusual VI settings were displayed in an incorrect aspect ratio.

    Example: Super Monkey Ball 2 in "Letterbox" mode, before and after:

   
    <img width="161" alt="857f4032-30fb-11e7-9ed2-87381e39eaba" src="https://cloud.githubusercontent.com/assets/594093/26567662/d61c3116-44b1-11e7-8183-4bad3f8d094d.png"> <img width="161" alt="8797329e-30fb-11e7-83e5-b3cc58f4273d" src="https://cloud.githubusercontent.com/assets/594093/26567663/d6f06ca6-44b1-11e7-87ea-e41c714a1ab8.png">