### PR TITLE
Qt: Port help menu items over

### DIFF
--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -173,10 +173,20 @@ void MenuBar::AddViewMenu()
 void MenuBar::AddHelpMenu()
 {
   QMenu* help_menu = addMenu(tr("Help"));
+  QAction* website = help_menu->addAction(tr("Website"));
+  connect(website, &QAction::triggered, this,
+          []() { QDesktopServices::openUrl(QUrl(QStringLiteral("https://dolphin-emu.org/"))); });
   QAction* documentation = help_menu->addAction(tr("Online Documentation"));
-  connect(documentation, &QAction::triggered, this, [=]() {
+  connect(documentation, &QAction::triggered, this, []() {
     QDesktopServices::openUrl(QUrl(QStringLiteral("https://dolphin-emu.org/docs/guides")));
   });
+  QAction* github = help_menu->addAction(tr("GitHub Repository"));
+  connect(github, &QAction::triggered, this, []() {
+    QDesktopServices::openUrl(QUrl(QStringLiteral("https://github.com/dolphin-emu/dolphin")));
+  });
+
+  help_menu->addSeparator();
+
   help_menu->addAction(tr("About"), this, SIGNAL(ShowAboutDialog()));
 }
 


### PR DESCRIPTION
Add help menu items from Wx to Qt

![devenv_2017-05-05_01-23-53](https://cloud.githubusercontent.com/assets/866151/25738365/828e62aa-3131-11e7-8421-8045d465c228.png)
