### PR TITLE
[RFC] Tweaks to Zelda-HLE to allow multiple GBA connections

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -208,6 +208,8 @@ void ZeldaUCode::HandleMailDefault(u32 mail)
       switch (mail & 0xFFFF)
       {
       case 1:
+        m_cmd_can_execute = true;
+        RunPendingCommands();
         NOTICE_LOG(DSPHLE, "UCode being replaced.");
         m_upload_setup_in_progress = true;
         SetMailState(MailState::HALTED);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -212,7 +212,7 @@ void ZeldaUCode::HandleMailDefault(u32 mail)
         RunPendingCommands();
         NOTICE_LOG(DSPHLE, "UCode being replaced.");
         m_upload_setup_in_progress = true;
-        SetMailState(MailState::HALTED);
+        SetMailState(MailState::WAITING);
         break;
 
       case 2:


### PR DESCRIPTION
RFC because I have really no idea what I'm doing with DSP code, and found this fix through a combination of scattered printfs and a small dose of "well, it looks right."

This fixes two bugs when running The Legend of Zelda: Four Swords Adventures with DSP-HLE:
- Background music and some sounds stop working after connecting a GBA.
- Only one GBA can be connected at a time.

<img width="739" alt="screen shot 2017-05-05 at 2 54 41 am" src="https://cloud.githubusercontent.com/assets/594093/25741131/3f30962e-313e-11e7-957a-d6af0968a3ec.png">

I first noticed that Four Swords' background music cuts out after connecting a GBA, and Dolphin logs the following error messages:

```
55:50:162 Core/HW/DSPHLE/UCodes/Zelda.cpp:212 N[DSPHLE]: UCode being replaced.
55:50:163 Core/HW/DSPHLE/UCodes/UCodes.cpp:211 W[DSPHLE]: Trying to boot new ucode with DRAM download - not implemented
55:50:163 Core/HW/DSPHLE/UCodes/UCodes.cpp:247 I[DSPHLE]: Switching to GBA ucode
55:50:174 Core/HW/DSPHLE/UCodes/UCodes.cpp:215 W[DSPHLE]: Trying to boot new ucode with DRAM upload - not implemented
55:58:077 Core/HW/DSPHLE/UCodes/Zelda.cpp:230 N[DSPHLE]: Unknown end rendering action. Halting.
55:58:077 Core/HW/DSPHLE/UCodes/Zelda.cpp:232 N[DSPHLE]: UCode asked to halt. Stopping any processing.
55:58:077 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 807ed6c0 while we're halted.
55:58:077 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 807edb20 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 00000000 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 0000d400 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 00000000 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 00010000 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 00000000 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 00020000 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 00000000 while we're halted.
55:58:078 Core/HW/DSPHLE/UCodes/Zelda.cpp:294 W[DSPHLE]: Received mail 00030000 while we're halted.
```

The Zelda ucode gets only momentarily swapped out for the GBA one, but then stops replying to all mail! That probably shouldn't be happening.

I added some printf statements, and got the list of all mail sent to the Zelda ucode after it's swapped back in:

```
00000003 // looks like it will write 3 commands
82074000 // looks like a command
807ed6c0 // looks like a command
807edb20 // looks like a command
00000000
0000d400
00000000
00010000
00000000
00020000
00000000
00030000
```

The first few messages look like a three-command-write, which is only valid in `MailState::WAITING`, so I changed Zelda-HLE to set itself to that when swapping. That made the first few messages be accepted, but then a new error appeared:

```
00:44:526 Core/HW/DSPHLE/UCodes/Zelda.cpp:245 N[DSPHLE]: Sync mail (00000000) received when rendering was not active. Halting.
```

I was stumped here, so starting looking through the larger stream of messages Four Swords' was sending to the DSP. Every hundred messages or so, a pattern seemed to repeat itself:

```
cdd10003
00000003
82074000
807ee840
807eeca0
00000000
```

This is practically identical to the messages when a GBA is connected, except that the trigger to switch to GBA-HLE is `cdd10001`. Running the logic for `cdd10003`—which runs pending commands—before switching to GBA-HLE fixes all of the remaining errors.

