### PR TITLE
Qt: Add controller (overview) window

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRCS
   Resources.cpp
   Settings.cpp
   ToolBar.cpp
+  Config/ControllersWindow.cpp
   Config/FilesystemWidget.cpp
   Config/InfoWidget.cpp
   Config/PathDialog.cpp

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -1,0 +1,487 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QBoxLayout>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPixmap>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSpacerItem>
+#include <QVBoxLayout>
+
+#include <unordered_map>
+
+#include "Core/ConfigManager.h"
+#include "Core/HW/SI/SI.h"
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteReal/WiimoteReal.h"
+#include "Core/IOS/IOS.h"
+#include "Core/IOS/USB/Bluetooth/BTReal.h"
+#include "Core/NetPlayProto.h"
+#include "DolphinQt2/Settings.h"
+#include "UICommon/UICommon.h"
+
+#include "DolphinQt2/Config/ControllersWindow.h"
+
+static const std::unordered_map<SerialInterface::SIDevices, int> s_gc_types = {
+    {SerialInterface::SIDEVICE_NONE, 0},         {SerialInterface::SIDEVICE_GC_CONTROLLER, 1},
+    {SerialInterface::SIDEVICE_WIIU_ADAPTER, 2}, {SerialInterface::SIDEVICE_GC_STEERING, 3},
+    {SerialInterface::SIDEVICE_DANCEMAT, 4},     {SerialInterface::SIDEVICE_GC_TARUKONGA, 5},
+    {SerialInterface::SIDEVICE_GC_GBA, 6},       {SerialInterface::SIDEVICE_GC_KEYBOARD, 7}};
+
+static const std::unordered_map<int, int> s_wiimote_types = {
+    {WIIMOTE_SRC_NONE, 0}, {WIIMOTE_SRC_EMU, 1}, {WIIMOTE_SRC_REAL, 2}, {WIIMOTE_SRC_HYBRID, 3}};
+
+static int ToGCMenuIndex(const SerialInterface::SIDevices sidevice)
+{
+  return s_gc_types.at(sidevice);
+}
+
+static SerialInterface::SIDevices FromGCMenuIndex(const int menudevice)
+{
+  auto it = std::find_if(s_gc_types.begin(), s_gc_types.end(),
+                         [=](auto pair) { return pair.second == menudevice; });
+  return it->first;
+}
+
+static int ToWiimoteMenuIndex(const int device)
+{
+  return s_wiimote_types.at(device);
+}
+
+static int FromWiimoteMenuIndex(const int menudevice)
+{
+  auto it = std::find_if(s_wiimote_types.begin(), s_wiimote_types.end(),
+                         [=](auto pair) { return pair.second == menudevice; });
+  return it->first;
+}
+
+ControllersWindow::ControllersWindow(QWidget* parent)
+    : QDialog(parent),
+      m_configure_icon(Settings().GetThemeDir().append(QStringLiteral("config.png"))),
+      m_gamecube_icon(Settings().GetResourcesDir().append(QStringLiteral("Platform_Gamecube.png"))),
+      m_wii_icon(Settings().GetResourcesDir().append(QStringLiteral("Platform_Wii.png")))
+{
+  setWindowTitle(tr("Controller Settings"));
+
+  CreateGamecubeLayout();
+  CreateWiimoteLayout();
+  CreateAdvancedLayout();
+  CreateMainLayout();
+  LoadSettings();
+  ConnectWidgets();
+}
+
+void ControllersWindow::CreateGamecubeLayout()
+{
+  m_gc_box = new QGroupBox(m_gc_label);
+  m_gc_layout = new QFormLayout();
+  m_gc_label = new QLabel();
+  m_gc_label->setPixmap(QPixmap(m_gamecube_icon));
+  m_gc_label->setAlignment(Qt::AlignCenter);
+  m_gc_layout->addRow(m_gc_label);
+
+  for (size_t i = 0; i < m_gc_groups.size(); i++)
+  {
+    auto* gc_box = m_gc_controller_boxes[i] = new QComboBox();
+    auto* gc_button = m_gc_buttons[i] = new QPushButton(QIcon(m_configure_icon), QString());
+    auto* gc_group = m_gc_groups[i] = new QHBoxLayout();
+
+    gc_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    gc_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+    for (const auto& item :
+         {tr("None"), tr("Standard Controller"), tr("GameCube Adapter for Wii U"),
+          tr("Steering Wheel"), tr("Dance Mat"), tr("DK Bongos"), tr("GBA"), tr("Keyboard")})
+    {
+      gc_box->addItem(item);
+    }
+
+    gc_group->addItem(new QSpacerItem(42, 1));
+    gc_group->addWidget(gc_box);
+    gc_group->addWidget(gc_button);
+
+    m_gc_layout->addRow(tr("Controller %1").arg(i + 1), gc_group);
+  }
+  m_gc_box->setLayout(m_gc_layout);
+}
+
+static QHBoxLayout* CreateSubItem(QLabel* label, QWidget* widget)
+{
+  QHBoxLayout* hbox = new QHBoxLayout();
+  hbox->addItem(new QSpacerItem(25, 1));
+
+  if (label != nullptr)
+    hbox->addWidget(label);
+
+  hbox->addWidget(widget);
+
+  return hbox;
+}
+
+static QHBoxLayout* CreateSubItem(const QString& text, QWidget* widget)
+{
+  QLabel* label = text.isEmpty() ? nullptr : new QLabel(text);
+  return CreateSubItem(label, widget);
+}
+
+void ControllersWindow::CreateWiimoteLayout()
+{
+  m_wiimote_box = new QGroupBox();
+  m_wiimote_layout = new QFormLayout();
+  m_wiimote_passthrough = new QRadioButton(tr("Use Bluetooth Passthrough"));
+  m_wiimote_sync = new QPushButton(tr("Sync"));
+  m_wiimote_reset = new QPushButton(tr("Reset"));
+  m_wiimote_pt_labels[0] = new QLabel(tr("Sync real Wii Remotes and pair them"));
+  m_wiimote_pt_labels[1] = new QLabel(tr("Reset all saved Wii Remote pairings"));
+  m_wiimote_emu = new QRadioButton(tr("Emulate the Wii Bluetooth Adapter"));
+  m_wiimote_continuous_scanning = new QCheckBox(tr("Continuous Scanning"));
+  m_wiimote_real_balance_board = new QCheckBox(tr("Real Balance Board"));
+  m_wiimote_speaker_data = new QCheckBox(tr("Enable Speaker Data"));
+
+  m_wiimote_layout->setLabelAlignment(Qt::AlignLeft);
+
+  m_wii_label = new QLabel();
+  m_wii_label->setPixmap(QPixmap(m_wii_icon));
+  m_wii_label->setAlignment(Qt::AlignCenter);
+  m_wiimote_layout->addRow(m_wii_label);
+
+  // Passthrough BT
+
+  m_wiimote_layout->addRow(m_wiimote_passthrough);
+
+  m_wiimote_sync->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  m_wiimote_reset->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+  m_wiimote_layout->addRow(CreateSubItem(m_wiimote_pt_labels[0], m_wiimote_sync));
+  m_wiimote_layout->addRow(CreateSubItem(m_wiimote_pt_labels[1], m_wiimote_reset));
+
+  // Emulated BT
+  m_wiimote_layout->addRow(m_wiimote_emu);
+
+  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+  {
+    auto* wm_label = m_wiimote_labels[i] = new QLabel(tr("Wii Remote %1").arg(i + 1));
+    auto* wm_box = m_wiimote_boxes[i] = new QComboBox();
+    auto* wm_button = m_wiimote_buttons[i] = new QPushButton(QIcon(m_configure_icon), QString());
+    auto* wm_group = m_wiimote_groups[i] = new QHBoxLayout();
+
+    for (const auto& item :
+         {tr("None"), tr("Emulated Wii Remote"), tr("Real Wii Remote"), tr("Hybrid Wii Remote")})
+    {
+      wm_box->addItem(item);
+    }
+
+    wm_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    wm_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+    wm_group->addItem(new QSpacerItem(25, 1));
+    wm_group->addWidget(wm_label);
+    wm_group->addItem(new QSpacerItem(10, 1));
+    wm_group->addWidget(wm_box);
+    wm_group->addWidget(wm_button);
+
+    m_wiimote_layout->addRow(wm_group);
+  }
+
+  m_wiimote_layout->addRow(CreateSubItem(QStringLiteral(""), m_wiimote_continuous_scanning));
+  m_wiimote_layout->addRow(CreateSubItem(QStringLiteral(""), m_wiimote_real_balance_board));
+  m_wiimote_layout->addRow(CreateSubItem(QStringLiteral(""), m_wiimote_speaker_data));
+
+  m_wiimote_box->setLayout(m_wiimote_layout);
+}
+
+void ControllersWindow::CreateAdvancedLayout()
+{
+  m_advanced_box = new QGroupBox(tr("Advanced"));
+  m_advanced_layout = new QHBoxLayout();
+  m_advanced_bg_input = new QCheckBox(tr("Background Input"));
+
+  m_advanced_layout->addWidget(m_advanced_bg_input);
+
+  m_advanced_box->setLayout(m_advanced_layout);
+}
+
+void ControllersWindow::CreateMainLayout()
+{
+  m_main_layout = new QVBoxLayout();
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
+
+  m_main_layout->addWidget(m_gc_box);
+  m_main_layout->addWidget(m_wiimote_box);
+  m_main_layout->addWidget(m_advanced_box);
+  m_main_layout->addWidget(m_button_box);
+
+  setLayout(m_main_layout);
+}
+
+void ControllersWindow::ConnectWidgets()
+{
+  connect(m_wiimote_passthrough, &QRadioButton::toggled, this,
+          &ControllersWindow::OnWiimoteModeChanged);
+
+  connect(m_advanced_bg_input, &QCheckBox::toggled, this, &ControllersWindow::SaveSettings);
+  connect(m_wiimote_continuous_scanning, &QCheckBox::toggled, this,
+          &ControllersWindow::SaveSettings);
+  connect(m_wiimote_real_balance_board, &QCheckBox::toggled, this,
+          &ControllersWindow::SaveSettings);
+  connect(m_wiimote_speaker_data, &QCheckBox::toggled, this, &ControllersWindow::SaveSettings);
+  connect(m_wiimote_sync, &QPushButton::clicked, this,
+          &ControllersWindow::OnBluetoothPassthroughSyncPressed);
+  connect(m_wiimote_reset, &QPushButton::clicked, this,
+          &ControllersWindow::OnBluetoothPassthroughResetPressed);
+  connect(m_button_box, &QDialogButtonBox::accepted, this, &ControllersWindow::accept);
+
+  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+  {
+    connect(m_wiimote_boxes[i],
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &ControllersWindow::SaveSettings);
+    connect(m_wiimote_boxes[i],
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &ControllersWindow::OnWiimoteTypeChanged);
+    connect(m_wiimote_buttons[i], &QPushButton::clicked, this,
+            &ControllersWindow::OnWiimoteConfigure);
+
+    connect(m_gc_controller_boxes[i],
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &ControllersWindow::SaveSettings);
+    connect(m_gc_controller_boxes[i],
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &ControllersWindow::OnGCTypeChanged);
+    connect(m_gc_buttons[i], &QPushButton::clicked, this, &ControllersWindow::OnGCPadConfigure);
+  }
+}
+
+void ControllersWindow::OnWiimoteModeChanged(bool passthrough)
+{
+  SaveSettings();
+
+  m_wiimote_sync->setEnabled(passthrough);
+  m_wiimote_reset->setEnabled(passthrough);
+
+  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+  {
+    const int index = m_wiimote_boxes[i]->currentIndex();
+
+    if (i < 2)
+      m_wiimote_pt_labels[i]->setEnabled(passthrough);
+
+    m_wiimote_labels[i]->setEnabled(!passthrough);
+    m_wiimote_boxes[i]->setEnabled(!passthrough);
+    m_wiimote_buttons[i]->setEnabled(!passthrough && index != 0 && index != 2);
+  }
+
+  m_wiimote_real_balance_board->setEnabled(!passthrough);
+  m_wiimote_speaker_data->setEnabled(!passthrough);
+  m_wiimote_continuous_scanning->setEnabled(!passthrough);
+}
+
+void ControllersWindow::OnWiimoteTypeChanged(int type)
+{
+  const auto* box = static_cast<QComboBox*>(QObject::sender());
+  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+  {
+    if (m_wiimote_boxes[i] == box)
+    {
+      const int index = box->currentIndex();
+      m_wiimote_buttons[i]->setEnabled(index != 0 && index != 2);
+      return;
+    }
+  }
+}
+
+void ControllersWindow::OnGCTypeChanged(int type)
+{
+  const auto* box = static_cast<QComboBox*>(QObject::sender());
+
+  for (size_t i = 0; i < m_gc_groups.size(); i++)
+  {
+    if (m_gc_controller_boxes[i] == box)
+    {
+      const int index = box->currentIndex();
+      m_gc_buttons[i]->setEnabled(index != 0 && index != 6);
+      return;
+    }
+  }
+}
+
+void ControllersWindow::OnBluetoothPassthroughResetPressed()
+{
+  const auto ios = IOS::HLE::GetIOS();
+
+  if (!ios)
+  {
+    QMessageBox error(this);
+    error.setIcon(QMessageBox::Warning);
+    error.setText(tr("Saved Wii Remote pairings can only be reset when a Wii game is running."));
+    error.exec();
+    return;
+  }
+
+  auto device = ios->GetDeviceByName("/dev/usb/oh1/57e/305");
+  if (device != nullptr)
+  {
+    std::static_pointer_cast<IOS::HLE::Device::BluetoothBase>(device)->TriggerSyncButtonHeldEvent();
+  }
+}
+
+void ControllersWindow::OnBluetoothPassthroughSyncPressed()
+{
+  const auto ios = IOS::HLE::GetIOS();
+
+  if (!ios)
+  {
+    QMessageBox error(this);
+    error.setIcon(QMessageBox::Warning);
+    error.setText(tr("A sync can only be triggered when a Wii game is running"));
+    error.exec();
+    return;
+  }
+
+  auto device = ios->GetDeviceByName("/dev/usb/oh1/57e/305");
+
+  if (device != nullptr)
+  {
+    std::static_pointer_cast<IOS::HLE::Device::BluetoothBase>(device)
+        ->TriggerSyncButtonPressedEvent();
+  }
+}
+
+void ControllersWindow::OnEmulationStateChanged(bool running)
+{
+  if (!Settings().IsWiiGameRunning() || NetPlay::IsNetPlayRunning())
+  {
+    m_wiimote_sync->setEnabled(!running);
+    m_wiimote_reset->setEnabled(!running);
+
+    for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+      m_wiimote_boxes[i]->setEnabled(!running);
+  }
+
+  m_wiimote_emu->setEnabled(!running);
+  m_wiimote_passthrough->setEnabled(!running);
+
+  if (!Settings().IsWiiGameRunning())
+  {
+    m_wiimote_real_balance_board->setEnabled(!running);
+    m_wiimote_continuous_scanning->setEnabled(!running);
+    m_wiimote_speaker_data->setEnabled(!running);
+  }
+}
+
+void ControllersWindow::OnGCPadConfigure()
+{
+  size_t index;
+  for (index = 0; index < m_gc_groups.size(); index++)
+  {
+    if (m_gc_buttons[index] == QObject::sender())
+      break;
+  }
+
+  switch (m_gc_controller_boxes[index]->currentIndex())
+  {
+  case 0:  // None
+  case 6:  // GBA
+    return;
+  case 1:  // Standard Controller
+  case 2:  // GameCube Adapter for Wii U
+  case 3:  // Steering Wheel
+  case 4:  // Dance Mat
+  case 5:  // DK Bongos
+  case 7:  // Keyboard
+    UnimplementedButton();
+    return;
+  }
+}
+
+void ControllersWindow::OnWiimoteConfigure()
+{
+  size_t index;
+  for (index = 0; index < m_wiimote_groups.size(); index++)
+  {
+    if (m_wiimote_buttons[index] == QObject::sender())
+      break;
+  }
+
+  switch (m_wiimote_boxes[index]->currentIndex())
+  {
+  case 0:  // None
+  case 2:  // Real Wii Remote
+    return;
+  case 1:  // Emulated Wii Remote
+  case 3:  // Hybrid Wii Remote
+    UnimplementedButton();
+    return;
+  }
+}
+
+void ControllersWindow::UnimplementedButton()
+{
+  QMessageBox error_dialog(this);
+
+  error_dialog.setIcon(QMessageBox::Warning);
+  error_dialog.setText(tr("Not implemented yet."));
+  error_dialog.exec();
+}
+
+void ControllersWindow::LoadSettings()
+{
+  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+  {
+    m_gc_controller_boxes[i]->setCurrentIndex(ToGCMenuIndex(Settings().GetSIDevice(i)));
+    m_wiimote_boxes[i]->setCurrentIndex(ToWiimoteMenuIndex(g_wiimote_sources[i]));
+  }
+  m_wiimote_real_balance_board->setChecked(g_wiimote_sources[WIIMOTE_BALANCE_BOARD] ==
+                                           WIIMOTE_SRC_REAL);
+  m_wiimote_speaker_data->setChecked(Settings().IsWiimoteSpeakerEnabled());
+  m_wiimote_continuous_scanning->setChecked(Settings().IsContinuousScanningEnabled());
+
+  m_advanced_bg_input->setChecked(Settings().IsBackgroundInputEnabled());
+
+  if (Settings().IsBluetoothPassthroughEnabled())
+    m_wiimote_passthrough->setChecked(true);
+  else
+    m_wiimote_emu->setChecked(true);
+
+  OnWiimoteModeChanged(Settings().IsBluetoothPassthroughEnabled());
+}
+
+void ControllersWindow::SaveSettings()
+{
+  Settings().SetWiimoteSpeakerEnabled(m_wiimote_speaker_data->isChecked());
+  Settings().SetContinuousScanningEnabled(m_wiimote_continuous_scanning->isChecked());
+
+  Settings().SetBluetoothPassthroughEnabled(m_wiimote_passthrough->isChecked());
+  Settings().SetBackgroundInputEnabled(m_advanced_bg_input->isChecked());
+
+  WiimoteReal::ChangeWiimoteSource(WIIMOTE_BALANCE_BOARD,
+                                   m_wiimote_real_balance_board->isChecked() ? WIIMOTE_SRC_REAL :
+                                                                               WIIMOTE_SRC_NONE);
+
+  for (size_t i = 0; i < m_wiimote_groups.size(); i++)
+  {
+    const int index = m_wiimote_boxes[i]->currentIndex();
+    g_wiimote_sources[i] = FromWiimoteMenuIndex(index);
+    m_wiimote_buttons[i]->setEnabled(index != 0 && index != 2);
+  }
+
+  UICommon::SaveWiimoteSources();
+
+  for (size_t i = 0; i < m_gc_groups.size(); i++)
+  {
+    const int index = m_gc_controller_boxes[i]->currentIndex();
+    Settings().SetSIDevice(i, FromGCMenuIndex(index));
+    m_gc_buttons[i]->setEnabled(index != 0 && index != 6);
+  }
+  Settings().Save();
+}

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.h
@@ -1,0 +1,87 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include <array>
+
+class QDialogButtonBox;
+class QCheckBox;
+class QComboBox;
+class QHBoxLayout;
+class QFormLayout;
+class QGroupBox;
+class QLabel;
+class QVBoxLayout;
+class QPushButton;
+class QRadioButton;
+class QSpacerItem;
+
+class ControllersWindow final : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit ControllersWindow(QWidget* parent);
+  void OnEmulationStateChanged(bool running);
+
+private:
+  void OnWiimoteModeChanged(bool passthrough);
+  void OnWiimoteTypeChanged(int state);
+  void OnGCTypeChanged(int state);
+  void SaveSettings();
+  void UnimplementedButton();
+  void OnBluetoothPassthroughSyncPressed();
+  void OnBluetoothPassthroughResetPressed();
+  void OnGCPadConfigure();
+  void OnWiimoteConfigure();
+
+  void CreateGamecubeLayout();
+  void CreateWiimoteLayout();
+  void CreateAdvancedLayout();
+  void CreateMainLayout();
+  void ConnectWidgets();
+  void LoadSettings();
+
+  // Icons
+  QString m_configure_icon;
+  QString m_gamecube_icon;
+  QString m_wii_icon;
+
+  // Main
+  QVBoxLayout* m_main_layout;
+  QDialogButtonBox* m_button_box;
+
+  // Gamecube
+  QGroupBox* m_gc_box;
+  QLabel* m_gc_label;
+  QFormLayout* m_gc_layout;
+  std::array<QComboBox*, 4> m_gc_controller_boxes;
+  std::array<QPushButton*, 4> m_gc_buttons;
+  std::array<QHBoxLayout*, 4> m_gc_groups;
+
+  // Wii Remote
+  QGroupBox* m_wiimote_box;
+  QLabel* m_wii_label;
+  QFormLayout* m_wiimote_layout;
+  std::array<QLabel*, 4> m_wiimote_labels;
+  std::array<QComboBox*, 4> m_wiimote_boxes;
+  std::array<QPushButton*, 4> m_wiimote_buttons;
+  std::array<QHBoxLayout*, 4> m_wiimote_groups;
+  std::array<QLabel*, 2> m_wiimote_pt_labels;
+
+  QRadioButton* m_wiimote_emu;
+  QRadioButton* m_wiimote_passthrough;
+  QPushButton* m_wiimote_sync;
+  QPushButton* m_wiimote_reset;
+  QCheckBox* m_wiimote_continuous_scanning;
+  QCheckBox* m_wiimote_real_balance_board;
+  QCheckBox* m_wiimote_speaker_data;
+
+  // Advanced
+  QGroupBox* m_advanced_box;
+  QHBoxLayout* m_advanced_layout;
+  QCheckBox* m_advanced_bg_input;
+};

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -81,6 +81,7 @@
   <!--NOTE: When adding moc'd files, you must list the outputs in the following ItemGroup!-->
   <ItemGroup>
     <QtMoc Include="AboutDialog.h" />
+    <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="Config\PathDialog.h" />
@@ -103,6 +104,7 @@
   <!--TODO figure out how to get QtMoc to add outputs to ClCompile's inputs...-->
   <ItemGroup>
     <ClCompile Include="$(QtMocOutPrefix)AboutDialog.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)ControllersWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FilesystemWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameFile.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameList.cpp" />
@@ -122,6 +124,7 @@
     <ClCompile Include="$(QtMocOutPrefix)TableDelegate.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ToolBar.cpp" />
     <ClCompile Include="AboutDialog.cpp" />
+    <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
     <ClCompile Include="Config\InfoWidget.cpp" />
     <ClCompile Include="Config\PathDialog.cpp" />

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -12,9 +12,11 @@
 #include "Core/Core.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/Movie.h"
+#include "Core/NetPlayProto.h"
 #include "Core/State.h"
 
 #include "DolphinQt2/AboutDialog.h"
+#include "DolphinQt2/Config/ControllersWindow.h"
 #include "DolphinQt2/Config/PathDialog.h"
 #include "DolphinQt2/Config/SettingsWindow.h"
 #include "DolphinQt2/Host.h"
@@ -51,6 +53,7 @@ void MainWindow::CreateComponents()
   m_render_widget = new RenderWidget;
   m_stack = new QStackedWidget(this);
   m_paths_dialog = new PathDialog(this);
+  m_controllers_window = new ControllersWindow(this);
   m_settings_window = new SettingsWindow(this);
 }
 
@@ -90,6 +93,11 @@ void MainWindow::ConnectMenuBar()
   connect(this, &MainWindow::EmulationStarted, m_menu_bar, &MenuBar::EmulationStarted);
   connect(this, &MainWindow::EmulationPaused, m_menu_bar, &MenuBar::EmulationPaused);
   connect(this, &MainWindow::EmulationStopped, m_menu_bar, &MenuBar::EmulationStopped);
+
+  connect(this, &MainWindow::EmulationStarted, this,
+          [=]() { m_controllers_window->OnEmulationStateChanged(true); });
+  connect(this, &MainWindow::EmulationStopped, this,
+          [=]() { m_controllers_window->OnEmulationStateChanged(false); });
 }
 
 void MainWindow::ConnectToolBar()
@@ -103,6 +111,7 @@ void MainWindow::ConnectToolBar()
   connect(m_tool_bar, &ToolBar::ScreenShotPressed, this, &MainWindow::ScreenShot);
   connect(m_tool_bar, &ToolBar::PathsPressed, this, &MainWindow::ShowPathsDialog);
   connect(m_tool_bar, &ToolBar::SettingsPressed, this, &MainWindow::ShowSettingsWindow);
+  connect(m_tool_bar, &ToolBar::ControllersPressed, this, &MainWindow::ShowControllersWindow);
 
   connect(this, &MainWindow::EmulationStarted, m_tool_bar, &ToolBar::EmulationStarted);
   connect(this, &MainWindow::EmulationPaused, m_tool_bar, &ToolBar::EmulationPaused);
@@ -322,6 +331,13 @@ void MainWindow::ShowPathsDialog()
   m_paths_dialog->show();
   m_paths_dialog->raise();
   m_paths_dialog->activateWindow();
+}
+
+void MainWindow::ShowControllersWindow()
+{
+  m_controllers_window->show();
+  m_controllers_window->raise();
+  m_controllers_window->activateWindow();
 }
 
 void MainWindow::ShowSettingsWindow()

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -16,6 +16,7 @@
 
 class PathDialog;
 class SettingsWindow;
+class ControllersWindow;
 
 class MainWindow final : public QMainWindow
 {
@@ -70,6 +71,7 @@ private:
 
   void ShowPathsDialog();
   void ShowSettingsWindow();
+  void ShowControllersWindow();
   void ShowAboutDialog();
 
   QStackedWidget* m_stack;
@@ -81,5 +83,6 @@ private:
   int m_state_slot = 1;
 
   PathDialog* m_paths_dialog;
+  ControllersWindow* m_controllers_window;
   SettingsWindow* m_settings_window;
 };

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <QDir>
 #include <QSize>
 
 #include "Common/FileUtil.h"
@@ -21,6 +22,12 @@ QString Settings::GetThemeDir() const
 {
   QString theme_name = value(QStringLiteral("Theme"), QStringLiteral("Clean")).toString();
   return QString::fromStdString(File::GetThemeDir(theme_name.toStdString()));
+}
+
+QString Settings::GetResourcesDir() const
+{
+  return QString::fromStdString(File::GetSysDirectory().append("Resources"))
+      .append(QDir::separator());
 }
 
 bool Settings::IsInDevelopmentWarningEnabled() const
@@ -199,6 +206,61 @@ bool& Settings::SizeVisible() const
 bool& Settings::StateVisible() const
 {
   return SConfig::GetInstance().m_showStateColumn;
+}
+
+bool Settings::IsBluetoothPassthroughEnabled() const
+{
+  return SConfig::GetInstance().m_bt_passthrough_enabled;
+}
+
+void Settings::SetBluetoothPassthroughEnabled(bool enabled)
+{
+  SConfig::GetInstance().m_bt_passthrough_enabled = enabled;
+}
+
+bool Settings::IsContinuousScanningEnabled() const
+{
+  return SConfig::GetInstance().m_WiimoteContinuousScanning;
+}
+
+void Settings::SetContinuousScanningEnabled(bool enabled)
+{
+  SConfig::GetInstance().m_WiimoteContinuousScanning = enabled;
+}
+
+bool Settings::IsBackgroundInputEnabled() const
+{
+  return SConfig::GetInstance().m_BackgroundInput;
+}
+
+void Settings::SetBackgroundInputEnabled(bool enabled)
+{
+  SConfig::GetInstance().m_BackgroundInput = enabled;
+}
+
+bool Settings::IsWiimoteSpeakerEnabled() const
+{
+  return SConfig::GetInstance().m_WiimoteEnableSpeaker;
+}
+
+void Settings::SetWiimoteSpeakerEnabled(bool enabled)
+{
+  SConfig::GetInstance().m_WiimoteEnableSpeaker = enabled;
+}
+
+SerialInterface::SIDevices Settings::GetSIDevice(size_t i) const
+{
+  return SConfig::GetInstance().m_SIDevice[i];
+}
+
+void Settings::SetSIDevice(size_t i, SerialInterface::SIDevices device)
+{
+  SConfig::GetInstance().m_SIDevice[i] = device;
+}
+
+bool Settings::IsWiiGameRunning() const
+{
+  return SConfig::GetInstance().bWii;
 }
 
 void Settings::Save()

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -6,6 +6,8 @@
 
 #include <QSettings>
 
+#include "Core/HW/SI/SI.h"
+
 namespace DiscIO
 {
 enum class Language;
@@ -21,6 +23,7 @@ public:
 
   // UI
   QString GetThemeDir() const;
+  QString GetResourcesDir() const;
   bool IsInDevelopmentWarningEnabled() const;
 
   // GameList
@@ -44,6 +47,7 @@ public:
 
   // Emulation
   bool GetConfirmStop() const;
+  bool IsWiiGameRunning() const;
   int GetStateSlot() const;
   void SetStateSlot(int);
 
@@ -63,6 +67,22 @@ public:
   bool& SizeVisible() const;
   bool& StateVisible() const;
   bool& TitleVisible() const;
+
+  // Input
+  bool IsWiimoteSpeakerEnabled() const;
+  void SetWiimoteSpeakerEnabled(bool enabled);
+
+  bool IsBackgroundInputEnabled() const;
+  void SetBackgroundInputEnabled(bool enabled);
+
+  bool IsBluetoothPassthroughEnabled() const;
+  void SetBluetoothPassthroughEnabled(bool enabled);
+
+  SerialInterface::SIDevices GetSIDevice(size_t i) const;
+  void SetSIDevice(size_t i, SerialInterface::SIDevices device);
+
+  bool IsContinuousScanningEnabled() const;
+  void SetContinuousScanningEnabled(bool enabled);
 
   void Save();
 };

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -84,9 +84,9 @@ void ToolBar::MakeActions()
   m_config_action = addAction(tr("Settings"), this, SIGNAL(SettingsPressed()));
   widgetForAction(m_config_action)->setMinimumWidth(button_width);
 
-  m_controllers_action = addAction(tr("Controllers"));
+  m_controllers_action = addAction(tr("Controllers"), this, SIGNAL(ControllersPressed()));
   widgetForAction(m_controllers_action)->setMinimumWidth(button_width);
-  m_controllers_action->setEnabled(false);
+  m_controllers_action->setEnabled(true);
 }
 
 void ToolBar::UpdateIcons()

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -30,6 +30,7 @@ signals:
 
   void PathsPressed();
   void SettingsPressed();
+  void ControllersPressed();
 
 private:
   void MakeActions();

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -39,6 +39,7 @@
 #include "DolphinWX/Input/WiimoteInputConfigDiag.h"
 #include "DolphinWX/WxUtils.h"
 #include "InputCommon/GCAdapter.h"
+#include "UICommon/UICommon.h"
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 #include "UICommon/X11Utils.h"
@@ -394,7 +395,7 @@ void ControllerConfigDiag::OnClose(wxCloseEvent& event)
 {
   // Save all settings
   SConfig::GetInstance().SaveSettings();
-  SaveWiimoteSource();
+  UICommon::SaveWiimoteSources();
   EndModal(wxID_OK);
 }
 
@@ -590,27 +591,4 @@ void ControllerConfigDiag::OnWiimoteRefreshButton(wxCommandEvent&)
 void ControllerConfigDiag::OnEnableSpeaker(wxCommandEvent& event)
 {
   SConfig::GetInstance().m_WiimoteEnableSpeaker = event.IsChecked();
-}
-
-void ControllerConfigDiag::SaveWiimoteSource()
-{
-  std::string ini_filename = File::GetUserPath(D_CONFIG_IDX) + WIIMOTE_INI_NAME ".ini";
-
-  IniFile inifile;
-  inifile.Load(ini_filename);
-
-  for (unsigned int i = 0; i < MAX_WIIMOTES; ++i)
-  {
-    std::string secname("Wiimote");
-    secname += (char)('1' + i);
-    IniFile::Section& sec = *inifile.GetOrCreateSection(secname);
-
-    sec.Set("Source", (int)g_wiimote_sources[i]);
-  }
-
-  std::string secname("BalanceBoard");
-  IniFile::Section& sec = *inifile.GetOrCreateSection(secname);
-  sec.Set("Source", (int)g_wiimote_sources[WIIMOTE_BALANCE_BOARD]);
-
-  inifile.Save(ini_filename);
 }

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -38,7 +38,6 @@ private:
   void OnWiimoteSourceChanged(wxCommandEvent& event);
   void OnWiimoteConfigButton(wxCommandEvent& event);
   void OnWiimoteRefreshButton(wxCommandEvent& event);
-  void SaveWiimoteSource();
 
   void OnGameCubePortChanged(wxCommandEvent& event);
   void OnGameCubeConfigButton(wxCommandEvent& event);

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -197,4 +197,27 @@ void SetUserDirectory(const std::string& custom_path)
   File::SetUserPath(D_USER_IDX, user_path);
 }
 
+void SaveWiimoteSources()
+{
+  std::string ini_filename = File::GetUserPath(D_CONFIG_IDX) + WIIMOTE_INI_NAME ".ini";
+
+  IniFile inifile;
+  inifile.Load(ini_filename);
+
+  for (unsigned int i = 0; i < MAX_WIIMOTES; ++i)
+  {
+    std::string secname("Wiimote");
+    secname += (char)('1' + i);
+    IniFile::Section& sec = *inifile.GetOrCreateSection(secname);
+
+    sec.Set("Source", (int)g_wiimote_sources[i]);
+  }
+
+  std::string secname("BalanceBoard");
+  IniFile::Section& sec = *inifile.GetOrCreateSection(secname);
+  sec.Set("Source", (int)g_wiimote_sources[WIIMOTE_BALANCE_BOARD]);
+
+  inifile.Save(ini_filename);
+}
+
 }  // namespace UICommon

--- a/Source/Core/UICommon/UICommon.h
+++ b/Source/Core/UICommon/UICommon.h
@@ -12,4 +12,5 @@ void Shutdown();
 void CreateDirectories();
 void SetUserDirectory(const std::string& custom_path);
 
+void SaveWiimoteSources();
 }  // namespace UICommon


### PR DESCRIPTION
Mostly finished, but I want to get some Feedback before finishing this up.

TODO List:
- [x] Overview Interface
- [x] Load Settings
- [x] Save Settings
- [x] Bluetooth Passthrough Sync / Reset Buttons functional
- [x] Fix Windows build
- [x] Disable certain options while Emulation is running
~Configuration Windows~ (For Mapping etc.) Separate PR(s).

![Current "Controller Overview" Window Look](https://i.imgur.com/GMgI9j9.png)
![Current "Controller Overview" Window Look](https://i.imgur.com/fi2m3yI.png)