### PR TITLE
Qt: Add Interface Pane to Settings

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRCS
   GameList/GameTracker.cpp
   GameList/ListProxyModel.cpp
   GameList/TableDelegate.cpp
+  Settings/InterfacePane.cpp
 )
 
 list(APPEND LIBS core uicommon)

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -2,8 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "DolphinQt2/Settings.h"
 #include "DolphinQt2/Config/SettingsWindow.h"
+#include "DolphinQt2/Settings.h"
+#include "DolphinQt2/Settings/InterfacePane.h"
 
 SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
 {
@@ -47,6 +48,8 @@ void SettingsWindow::SetupSettingsWidget()
 {
   m_settings_outer = new QStackedWidget;
   m_settings_outer->setCurrentIndex(0);
+
+  m_settings_outer->addWidget(new InterfacePane);
 }
 
 void SettingsWindow::MakeUnfinishedWarning()
@@ -79,6 +82,8 @@ void SettingsWindow::MakeCategoryList()
   m_categories->setIconSize(QSize(32, 32));
   m_categories->setMovement(QListView::Static);
   m_categories->setSpacing(0);
+
+  AddCategoryToList(tr("Interface"), dir.append(QStringLiteral("config.png")));
 
   connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);
 }

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -56,7 +56,7 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/NODEFAULTLIB:libcmt</AdditionalOptions>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;$(ProjectDir)\GameList;$(ProjectDir)\Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;$(ProjectDir)\GameList;$(ProjectDir)\Settings;$(ProjectDir)\Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -94,11 +94,13 @@
     <QtMoc Include="GameList\TableDelegate.h" />
     <QtMoc Include="Host.h" />
     <QtMoc Include="InDevelopmentWarning.h" />
+    <QtMoc Include="Settings\InterfacePane.h" />
     <QtMoc Include="MainWindow.h" />
     <QtMoc Include="MenuBar.h" />
     <QtMoc Include="RenderWidget.h" />
     <QtMoc Include="Settings.h" />
     <QtMoc Include="ToolBar.h" />
+
   </ItemGroup>
   <!--TODO figure out how to get QtMoc to add outputs to ClCompile's inputs...-->
   <ItemGroup>
@@ -121,6 +123,7 @@
     <ClCompile Include="$(QtMocOutPrefix)SettingsWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)TableDelegate.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ToolBar.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)InterfacePane.cpp" />
     <ClCompile Include="AboutDialog.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
     <ClCompile Include="Config\InfoWidget.cpp" />
@@ -142,6 +145,7 @@
     <ClCompile Include="Resources.cpp" />
     <ClCompile Include="Settings.cpp" />
     <ClCompile Include="ToolBar.cpp" />
+    <ClCompile Include="Settings/InterfacePane.cpp" />
   </ItemGroup>
   <!--Put standard C/C++ headers here-->
   <!--

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
@@ -91,6 +91,12 @@
     <ClCompile Include="$(QtMocOutPrefix)InDevelopmentWarning.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
+    <ClCompile Include="Settings/InterfacePane.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
+    <ClCompile Include="$(QtMocOutPrefix)InterfacePane.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="MainWindow.h" />
@@ -124,6 +130,9 @@
     <QtMoc Include="Config\FilesystemWidget.h" />
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="InDevelopmentWarning.h" />
+    <QtMoc Include="Settings\InterfacePane.h">
+      <Filter>Settings</Filter>
+    </QtMoc>
   </ItemGroup>
   <ItemGroup>
     <QtUi Include="*.ui" />
@@ -143,6 +152,9 @@
     </Filter>
     <Filter Include="Config">
       <UniqueIdentifier>{42f8a963-563e-420d-8aca-5761657dcff5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Settings">
+      <UniqueIdentifier>{d2a31121-7903-4a66-9b42-9358e92d36ff}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -1,0 +1,139 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Settings/InterfacePane.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "Common/CommonPaths.h"
+#include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
+
+InterfacePane::InterfacePane(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+  ConnectLayout();
+  LoadConfig();
+}
+
+void InterfacePane::CreateLayout()
+{
+  m_main_layout = new QVBoxLayout;
+  // Create layout here
+  CreateUI();
+  CreateInGame();
+
+  m_main_layout->addStretch(1);
+  setLayout(m_main_layout);
+}
+
+void InterfacePane::CreateUI()
+{
+  auto* groupbox = new QGroupBox(tr("User Interface"));
+  auto* groupbox_layout = new QVBoxLayout;
+  groupbox->setLayout(groupbox_layout);
+  m_main_layout->addWidget(groupbox);
+
+  // Theme Combobox
+  auto* theme_layout = new QFormLayout;
+  m_combobox_theme = new QComboBox;
+  theme_layout->addRow(tr("&Theme:"), m_combobox_theme);
+  groupbox_layout->addLayout(theme_layout);
+
+  // List avalable themes
+  auto file_search_results = Common::DoFileSearch(
+      {""}, {File::GetUserPath(D_THEMES_IDX), File::GetSysDirectory() + THEMES_DIR},
+      /*recursive*/ false);
+  for (const std::string& filename : file_search_results)
+  {
+    std::string name, ext;
+    SplitPath(filename, nullptr, &name, &ext);
+    name += ext;
+    QString qt_name = QString::fromStdString(name);
+    m_combobox_theme->addItem(qt_name);
+  }
+
+  // Checkboxes
+  m_checkbox_auto_window = new QCheckBox(tr("Auto Adjust Window Size"));
+  m_checkbox_top_window = new QCheckBox(tr("Keep Dolphin on Top"));
+  m_checkbox_render_to_window = new QCheckBox(tr("Render to Main Window"));
+  groupbox_layout->addWidget(m_checkbox_auto_window);
+  groupbox_layout->addWidget(m_checkbox_top_window);
+  groupbox_layout->addWidget(m_checkbox_render_to_window);
+}
+
+void InterfacePane::CreateInGame()
+{
+  auto* groupbox = new QGroupBox(tr("In Game"));
+  auto* groupbox_layout = new QVBoxLayout;
+  groupbox->setLayout(groupbox_layout);
+  m_main_layout->addWidget(groupbox);
+
+  m_checkbox_confirm_on_stop = new QCheckBox(tr("Confirm on Stop"));
+  m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
+  m_checkbox_enable_osd = new QCheckBox(tr("Enable On Screen Messages"));
+  m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
+  m_checkbox_hide_mouse = new QCheckBox(tr("Hide Mouse Cursor"));
+
+  groupbox_layout->addWidget(m_checkbox_confirm_on_stop);
+  groupbox_layout->addWidget(m_checkbox_use_panic_handlers);
+  groupbox_layout->addWidget(m_checkbox_enable_osd);
+  groupbox_layout->addWidget(m_checkbox_pause_on_focus_lost);
+  groupbox_layout->addWidget(m_checkbox_hide_mouse);
+}
+
+void InterfacePane::ConnectLayout()
+{
+  connect(m_checkbox_auto_window, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_top_window, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_render_to_window, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+  connect(m_combobox_theme, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::activated),
+          [this](const QString& text) { OnSaveConfig(); });
+  connect(m_checkbox_confirm_on_stop, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_use_panic_handlers, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_enable_osd, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_pause_on_focus_lost, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_hide_mouse, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
+}
+
+void InterfacePane::LoadConfig()
+{
+  const SConfig& startup_params = SConfig::GetInstance();
+  m_checkbox_auto_window->setChecked(startup_params.bRenderWindowAutoSize);
+  m_checkbox_top_window->setChecked(startup_params.bKeepWindowOnTop);
+  m_checkbox_render_to_window->setChecked(startup_params.bRenderToMain);
+  m_combobox_theme->setCurrentIndex(
+      m_combobox_theme->findText(QString::fromStdString(SConfig::GetInstance().theme_name)));
+
+  // In Game Options
+  m_checkbox_confirm_on_stop->setChecked(startup_params.bConfirmStop);
+  m_checkbox_use_panic_handlers->setChecked(startup_params.bUsePanicHandlers);
+  m_checkbox_enable_osd->setChecked(startup_params.bOnScreenDisplayMessages);
+  m_checkbox_pause_on_focus_lost->setChecked(startup_params.m_PauseOnFocusLost);
+  m_checkbox_hide_mouse->setChecked(startup_params.bAutoHideCursor);
+}
+
+void InterfacePane::OnSaveConfig()
+{
+  SConfig& settings = SConfig::GetInstance();
+  settings.bRenderWindowAutoSize = m_checkbox_auto_window->isChecked();
+  settings.bKeepWindowOnTop = m_checkbox_top_window->isChecked();
+  settings.bRenderToMain = m_checkbox_render_to_window->isChecked();
+  settings.theme_name = m_combobox_theme->currentText().toStdString();
+
+  // In Game Options
+  settings.bConfirmStop = m_checkbox_confirm_on_stop->isChecked();
+  settings.bUsePanicHandlers = m_checkbox_use_panic_handlers->isChecked();
+  settings.bOnScreenDisplayMessages = m_checkbox_enable_osd->isChecked();
+  settings.m_PauseOnFocusLost = m_checkbox_pause_on_focus_lost->isChecked();
+  settings.bAutoHideCursor = m_checkbox_hide_mouse->isChecked();
+
+  settings.SaveSettings();
+}

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.h
@@ -1,0 +1,38 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QCheckBox;
+class QComboBox;
+class QVBoxLayout;
+
+class InterfacePane final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit InterfacePane(QWidget* parent = nullptr);
+
+private:
+  void CreateLayout();
+  void CreateUI();
+  void CreateInGame();
+  void ConnectLayout();
+  void LoadConfig();
+  void OnSaveConfig();
+
+  QVBoxLayout* m_main_layout;
+  QComboBox* m_combobox_theme;
+  QCheckBox* m_checkbox_auto_window;
+  QCheckBox* m_checkbox_top_window;
+  QCheckBox* m_checkbox_render_to_window;
+
+  QCheckBox* m_checkbox_confirm_on_stop;
+  QCheckBox* m_checkbox_use_panic_handlers;
+  QCheckBox* m_checkbox_enable_osd;
+  QCheckBox* m_checkbox_pause_on_focus_lost;
+  QCheckBox* m_checkbox_hide_mouse;
+};


### PR DESCRIPTION
Adds the interface pane to Qt Settings. 
Nothing fancy, particularly.

(Note that theme is not honored by the Qt Client yet, but the setting still can be modified and viewed in the WX Client)

![image](https://cloud.githubusercontent.com/assets/866151/25770602/5a8b5962-31ee-11e7-90f6-5f7a24077f3c.png)
