### PR TITLE
DolphinWX: Use title ID from ISOFile when possible

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1227,9 +1227,7 @@ void CFrame::OnUninstallWAD(wxCommandEvent&)
     return;
   }
 
-  const auto volume = DiscIO::CreateVolumeFromFilename(file->GetFileName());
-  u64 title_id;
-  volume->GetTitleID(&title_id);
+  u64 title_id = file->GetTitleID();
   if (!DiscIO::CNANDContentManager::Access().RemoveTitle(title_id, Common::FROM_CONFIGURED_ROOT))
   {
     PanicAlertT("Failed to remove this title from the NAND.");

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -959,15 +959,10 @@ void CGameListCtrl::OnLeftClick(wxMouseEvent& event)
   event.Skip();
 }
 
-static bool IsWADInstalled(const std::string& wad_path)
+static bool IsWADInstalled(const GameListItem& wad)
 {
-  const auto volume = DiscIO::CreateVolumeFromFilename(wad_path);
-  u64 title_id;
-  if (!volume || !volume->GetTitleID(&title_id))
-    return false;
-
   const std::string content_dir =
-      Common::GetTitleContentPath(title_id, Common::FromWhichRoot::FROM_CONFIGURED_ROOT);
+      Common::GetTitleContentPath(wad.GetTitleID(), Common::FromWhichRoot::FROM_CONFIGURED_ROOT);
 
   if (!File::IsDirectory(content_dir))
     return false;
@@ -1055,7 +1050,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
         for (auto* menu_item : {install_wad_item, uninstall_wad_item})
           menu_item->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
 
-        if (!IsWADInstalled(selected_iso->GetFileName()))
+        if (!IsWADInstalled(*selected_iso))
           uninstall_wad_item->Enable(false);
       }
 
@@ -1140,15 +1135,8 @@ void CGameListCtrl::OnOpenSaveFolder(wxCommandEvent& WXUNUSED(event))
 void CGameListCtrl::OnExportSave(wxCommandEvent& WXUNUSED(event))
 {
   const GameListItem* iso = GetSelectedISO();
-  if (!iso)
-    return;
-
-  u64 title_id;
-  std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(iso->GetFileName()));
-  if (volume && volume->GetTitleID(&title_id))
-  {
-    CWiiSaveCrypted::ExportWiiSave(title_id);
-  }
+  if (iso)
+    CWiiSaveCrypted::ExportWiiSave(iso->GetTitleID());
 }
 
 // Save this file as the default file

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -361,18 +361,11 @@ std::vector<DiscIO::Language> GameListItem::GetLanguages() const
 
 const std::string GameListItem::GetWiiFSPath() const
 {
-  std::unique_ptr<DiscIO::IVolume> iso(DiscIO::CreateVolumeFromFilename(m_FileName));
   std::string ret;
 
-  if (iso == nullptr)
-    return ret;
-
-  if (iso->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC)
+  if (m_Platform != DiscIO::Platform::GAMECUBE_DISC)
   {
-    u64 title_id = 0;
-    iso->GetTitleID(&title_id);
-
-    const std::string path = Common::GetTitleDataPath(title_id, Common::FROM_CONFIGURED_ROOT);
+    const std::string path = Common::GetTitleDataPath(m_title_id, Common::FROM_CONFIGURED_ROOT);
 
     if (!File::Exists(path))
       File::CreateFullPath(path);

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -46,6 +46,7 @@ public:
   std::string GetCompany() const { return m_company; }
   u16 GetRevision() const { return m_Revision; }
   const std::string& GetGameID() const { return m_game_id; }
+  u64 GetTitleID() const { return m_title_id; }
   const std::string GetWiiFSPath() const;
   DiscIO::Region GetRegion() const { return m_region; }
   DiscIO::Country GetCountry() const { return m_Country; }
@@ -70,7 +71,7 @@ private:
   std::string m_company;
 
   std::string m_game_id;
-  u64 m_title_id;
+  u64 m_title_id = 0;
 
   std::string m_issues;
   int m_emu_state;


### PR DESCRIPTION
This skips creating volume objects, which can take a while.