### PR TITLE
Don't duplicate code for getting paths based on title IDs

### DIFF
--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -36,20 +36,25 @@ std::string GetTicketFileName(u64 _titleID, FromWhichRoot from)
                           (u32)(_titleID >> 32), (u32)_titleID);
 }
 
+std::string GetTitlePath(u64 title_id, FromWhichRoot from)
+{
+  return StringFromFormat("%s/title/%08x/%08x/", RootUserPath(from).c_str(),
+                          static_cast<u32>(title_id >> 32), static_cast<u32>(title_id));
+}
+
 std::string GetTitleDataPath(u64 _titleID, FromWhichRoot from)
 {
-  return StringFromFormat("%s/title/%08x/%08x/data/", RootUserPath(from).c_str(),
-                          (u32)(_titleID >> 32), (u32)_titleID);
+  return GetTitlePath(_titleID, from) + "data/";
 }
 
 std::string GetTMDFileName(u64 _titleID, FromWhichRoot from)
 {
   return GetTitleContentPath(_titleID, from) + "title.tmd";
 }
+
 std::string GetTitleContentPath(u64 _titleID, FromWhichRoot from)
 {
-  return StringFromFormat("%s/title/%08x/%08x/content/", RootUserPath(from).c_str(),
-                          (u32)(_titleID >> 32), (u32)_titleID);
+  return GetTitlePath(_titleID, from) + "content/";
 }
 
 std::string EscapeFileName(const std::string& filename)

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -47,14 +47,14 @@ std::string GetTitleDataPath(u64 _titleID, FromWhichRoot from)
   return GetTitlePath(_titleID, from) + "data/";
 }
 
-std::string GetTMDFileName(u64 _titleID, FromWhichRoot from)
-{
-  return GetTitleContentPath(_titleID, from) + "title.tmd";
-}
-
 std::string GetTitleContentPath(u64 _titleID, FromWhichRoot from)
 {
   return GetTitlePath(_titleID, from) + "content/";
+}
+
+std::string GetTMDFileName(u64 _titleID, FromWhichRoot from)
+{
+  return GetTitleContentPath(_titleID, from) + "title.tmd";
 }
 
 std::string EscapeFileName(const std::string& filename)

--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -27,10 +27,10 @@ std::string RootUserPath(FromWhichRoot from);
 std::string GetImportTitlePath(u64 title_id, FromWhichRoot from = FROM_SESSION_ROOT);
 
 std::string GetTicketFileName(u64 _titleID, FromWhichRoot from);
-std::string GetTMDFileName(u64 _titleID, FromWhichRoot from);
 std::string GetTitlePath(u64 title_id, FromWhichRoot from);
 std::string GetTitleDataPath(u64 _titleID, FromWhichRoot from);
 std::string GetTitleContentPath(u64 _titleID, FromWhichRoot from);
+std::string GetTMDFileName(u64 _titleID, FromWhichRoot from);
 
 // Escapes characters that are invalid or have special meanings in the host file system
 std::string EscapeFileName(const std::string& filename);

--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -28,6 +28,7 @@ std::string GetImportTitlePath(u64 title_id, FromWhichRoot from = FROM_SESSION_R
 
 std::string GetTicketFileName(u64 _titleID, FromWhichRoot from);
 std::string GetTMDFileName(u64 _titleID, FromWhichRoot from);
+std::string GetTitlePath(u64 title_id, FromWhichRoot from);
 std::string GetTitleDataPath(u64 _titleID, FromWhichRoot from);
 std::string GetTitleContentPath(u64 _titleID, FromWhichRoot from);
 

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -58,8 +58,8 @@ IPCCommandResult ES::OpenTitleContent(u32 uid, const IOCtlVRequest& request)
 
   s32 CFD = OpenTitleContent(m_AccessIdentID++, TitleID, Index);
 
-  INFO_LOG(IOS_ES, "IOCTL_ES_OPENTITLECONTENT: TitleID: %08x/%08x  Index %i -> got CFD %x",
-           (u32)(TitleID >> 32), (u32)TitleID, Index, CFD);
+  INFO_LOG(IOS_ES, "IOCTL_ES_OPENTITLECONTENT: TitleID: %016" PRIx64 "  Index %i -> got CFD %x",
+           TitleID, Index, CFD);
 
   return GetDefaultReply(CFD);
 }

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -316,9 +316,7 @@ IPCCommandResult ES::DeleteTitle(const IOCtlVRequest& request)
   if (!CanDeleteTitle(title_id))
     return GetDefaultReply(ES_EINVAL);
 
-  const std::string title_dir =
-      StringFromFormat("%s/title/%08x/%08x/", RootUserPath(Common::FROM_SESSION_ROOT).c_str(),
-                       static_cast<u32>(title_id >> 32), static_cast<u32>(title_id));
+  const std::string title_dir = Common::GetTitlePath(title_id, Common::FROM_SESSION_ROOT);
   if (!File::IsDirectory(title_dir) ||
       !DiscIO::CNANDContentManager::Access().RemoveTitle(title_id, Common::FROM_SESSION_ROOT))
   {

--- a/Source/Core/Core/IOS/ES/Views.cpp
+++ b/Source/Core/Core/IOS/ES/Views.cpp
@@ -56,8 +56,8 @@ IPCCommandResult ES::GetTicketViewCount(const IOCtlVRequest& request)
     WARN_LOG(IOS_ES, "GetViewCount: Faking IOS title %016" PRIx64 " being present", TitleID);
   }
 
-  INFO_LOG(IOS_ES, "IOCTL_ES_GETVIEWCNT for titleID: %08x/%08x (View Count = %u)",
-           static_cast<u32>(TitleID >> 32), static_cast<u32>(TitleID), view_count);
+  INFO_LOG(IOS_ES, "IOCTL_ES_GETVIEWCNT for titleID: %016" PRIx64 " (View Count = %u)", TitleID,
+           view_count);
 
   Memory::Write_U32(view_count, request.io_vectors[0].address);
   return GetDefaultReply(IPC_SUCCESS);
@@ -89,8 +89,8 @@ IPCCommandResult ES::GetTicketViews(const IOCtlVRequest& request)
     WARN_LOG(IOS_ES, "GetViews: Faking IOS title %016" PRIx64 " being present", TitleID);
   }
 
-  INFO_LOG(IOS_ES, "IOCTL_ES_GETVIEWS for titleID: %08x/%08x (MaxViews = %i)", (u32)(TitleID >> 32),
-           (u32)TitleID, maxViews);
+  INFO_LOG(IOS_ES, "IOCTL_ES_GETVIEWS for titleID: %016" PRIx64 " (MaxViews = %i)", TitleID,
+           maxViews);
 
   return GetDefaultReply(IPC_SUCCESS);
 }

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -92,14 +92,12 @@ void ShutdownWiiRoot()
 {
   if (!s_temp_wii_root.empty())
   {
-    std::string save_path =
-        Common::GetTitleDataPath(SConfig::GetInstance().GetTitleID(), Common::FROM_SESSION_ROOT);
-    std::string user_save_path =
-        Common::GetTitleDataPath(SConfig::GetInstance().GetTitleID(), Common::FROM_CONFIGURED_ROOT);
-    std::string user_backup_path =
-        File::GetUserPath(D_BACKUP_IDX) +
-        StringFromFormat("%08x/%08x/", static_cast<u32>(SConfig::GetInstance().GetTitleID() >> 32),
-                         static_cast<u32>(SConfig::GetInstance().GetTitleID()));
+    const u64 title_id = SConfig::GetInstance().GetTitleID();
+    std::string save_path = Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT);
+    std::string user_save_path = Common::GetTitleDataPath(title_id, Common::FROM_CONFIGURED_ROOT);
+    std::string user_backup_path = File::GetUserPath(D_BACKUP_IDX) +
+                                   StringFromFormat("%08x/%08x/", static_cast<u32>(title_id >> 32),
+                                                    static_cast<u32>(title_id));
     if (File::Exists(save_path + "banner.bin") && SConfig::GetInstance().bEnableMemcardSdWriting)
     {
       // Backup the existing save just in case it's still needed.

--- a/Source/Core/Core/ec_wii.cpp
+++ b/Source/Core/Core/ec_wii.cpp
@@ -9,6 +9,7 @@
 
 #include "Core/ec_wii.h"
 
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 
@@ -107,7 +108,7 @@ void MakeAPSigAndCert(u8* sig_out, u8* ap_cert_out, u64 title_id, u8* data, u32 
   memset(ap_cert_out + 4, 0, 60);
 
   sprintf(signer, "Root-CA00000001-MS00000002-NG%08x", NG_id);
-  sprintf(name, "AP%08x%08x", (u32)(title_id >> 32), (u32)(title_id & 0xffffffff));
+  sprintf(name, "AP%016" PRIx64, title_id);
   MakeBlankSigECCert(ap_cert_out, signer, name, ap_priv, 0);
 
   mbedtls_sha1(ap_cert_out + 0x80, 0x100, hash);

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -258,7 +258,7 @@ void CNANDContentManager::ClearCache()
 void CNANDContentLoader::RemoveTitle() const
 {
   const u64 title_id = m_tmd.GetTitleId();
-  INFO_LOG(DISCIO, "RemoveTitle %08x/%08x", (u32)(title_id >> 32), (u32)title_id);
+  INFO_LOG(DISCIO, "RemoveTitle %016" PRIx64, title_id);
   if (IsValid())
   {
     // remove TMD?

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -13,6 +13,7 @@
 #include "Common/ColorUtil.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
 
@@ -30,9 +31,8 @@ std::vector<u32> IVolume::GetWiiBanner(int* width, int* height, u64 title_id)
   *width = 0;
   *height = 0;
 
-  std::string file_name = StringFromFormat("%s/title/%08x/%08x/data/banner.bin",
-                                           File::GetUserPath(D_WIIROOT_IDX).c_str(),
-                                           (u32)(title_id >> 32), (u32)title_id);
+  const std::string file_name =
+      Common::GetTitleDataPath(title_id, Common::FROM_CONFIGURED_ROOT) + "banner.bin";
   if (!File::Exists(file_name))
     return std::vector<u32>();
 

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -23,6 +23,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/IniFile.h"
+#include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Boot/Boot.h"
@@ -371,9 +372,7 @@ const std::string GameListItem::GetWiiFSPath() const
     u64 title_id = 0;
     iso->GetTitleID(&title_id);
 
-    const std::string path =
-        StringFromFormat("%s/title/%08x/%08x/data/", File::GetUserPath(D_WIIROOT_IDX).c_str(),
-                         (u32)(title_id >> 32), (u32)title_id);
+    const std::string path = Common::GetTitleDataPath(title_id, Common::FROM_CONFIGURED_ROOT);
 
     if (!File::Exists(path))
       File::CreateFullPath(path);


### PR DESCRIPTION
I've seen the expression `(u32)(title_id >> 32), (u32)title_id` a few more times in my life than I would've liked to...