### PR TITLE
ISOFile/GameFile: Correct GetWiiFSPath condition

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -336,7 +336,7 @@ bool GameFile::ExportWiiSave()
 
 QString GameFile::GetWiiFSPath() const
 {
-  _assert_(m_platform != DiscIO::Platform::GAMECUBE_DISC);
+  _assert_(m_platform == DiscIO::Platform::WII_DISC || m_platform == DiscIO::Platform::WII_WAD);
 
   const std::string path = Common::GetTitleDataPath(m_title_id, Common::FROM_CONFIGURED_ROOT);
 

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -361,20 +361,16 @@ std::vector<DiscIO::Language> GameListItem::GetLanguages() const
 
 const std::string GameListItem::GetWiiFSPath() const
 {
-  std::string ret;
+  if (m_Platform != DiscIO::Platform::WII_DISC && m_Platform != DiscIO::Platform::WII_WAD)
+    return "";
 
-  if (m_Platform == DiscIO::Platform::WII_DISC || m_Platform == DiscIO::Platform::WII_WAD)
-  {
-    const std::string path = Common::GetTitleDataPath(m_title_id, Common::FROM_CONFIGURED_ROOT);
+  const std::string path = Common::GetTitleDataPath(m_title_id, Common::FROM_CONFIGURED_ROOT);
 
-    if (!File::Exists(path))
-      File::CreateFullPath(path);
+  if (!File::Exists(path))
+    File::CreateFullPath(path);
 
-    if (path[0] == '.')
-      ret = WxStrToStr(wxGetCwd()) + path.substr(strlen(ROOT_DIR));
-    else
-      ret = path;
-  }
+  if (path[0] == '.')
+    return WxStrToStr(wxGetCwd()) + path.substr(strlen(ROOT_DIR));
 
-  return ret;
+  return path;
 }

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -363,7 +363,7 @@ const std::string GameListItem::GetWiiFSPath() const
 {
   std::string ret;
 
-  if (m_Platform != DiscIO::Platform::GAMECUBE_DISC)
+  if (m_Platform == DiscIO::Platform::WII_DISC || m_Platform == DiscIO::Platform::WII_WAD)
   {
     const std::string path = Common::GetTitleDataPath(m_title_id, Common::FROM_CONFIGURED_ROOT);
 


### PR DESCRIPTION
This code was originally written when there only were three possible volume types, but nowadays we also have the DOL/ELF type.