### PR TITLE
Fix for Emulator Issue #10267: Game list column sizes are being incorrectly calculated.

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -1461,7 +1461,7 @@ void CGameListCtrl::AutomaticColumnWidth()
         if (c.resizable)
           visible_columns.push_back(c.id);
         else
-          remaining_width -= c.default_width;
+          remaining_width -= GetColumnWidth(c.id);
       }
     }
 


### PR DESCRIPTION
There was some wonkiness created as a result of the refactor; COLUMN_SIZE had a default width of -1, which led to a bad value being used when divvying up the remaining width.