### PR TITLE
Contributing: Use constexpr for compile-time constants

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -89,8 +89,8 @@ Summary:
   - `class SomeClassName`
   - `enum IPCCommandType`
 - All compile time constants should be fully uppercased. With constants that have more than one word in them, use an underscore to separate them.
-  - `const double PI = 3.14159;`
-  - `const int MAX_PATH = 260;`
+  - `constexpr double PI = 3.14159;`
+  - `constexpr int MAX_PATH = 260;`
 - All variables should be lowercase with underscores separating the individual words in the name.
   - `int this_variable_name;`
 - Please do not use [Hungarian notation](http://en.wikipedia.org/wiki/Hungarian_notation) prefixes with variables. The only exceptions to this are the variable prefixes below.


### PR DESCRIPTION
This introduces `constexpr` usages for compile-time constants in the contributing guide, as apparently most people don't know it exists, or that it doesn't have to be used with `const` most of the time.