### PR TITLE
IOS/ES: Fix DeleteTitle to not use CNANDContentManager

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -239,7 +239,7 @@ void TicketReader::SetBytes(std::vector<u8>&& bytes)
 
 bool TicketReader::IsValid() const
 {
-  return m_bytes.size() % sizeof(Ticket) == 0;
+  return !m_bytes.empty() && m_bytes.size() % sizeof(Ticket) == 0;
 }
 
 void TicketReader::DoState(PointerWrap& p)

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -317,17 +317,16 @@ IPCCommandResult ES::DeleteTitle(const IOCtlVRequest& request)
     return GetDefaultReply(ES_EINVAL);
 
   const std::string title_dir = Common::GetTitlePath(title_id, Common::FROM_SESSION_ROOT);
-  if (!File::IsDirectory(title_dir) ||
-      !DiscIO::CNANDContentManager::Access().RemoveTitle(title_id, Common::FROM_SESSION_ROOT))
-  {
+  if (!File::IsDirectory(title_dir))
     return GetDefaultReply(FS_ENOENT);
-  }
 
   if (!File::DeleteDirRecursively(title_dir))
   {
     ERROR_LOG(IOS_ES, "DeleteTitle: Failed to delete title directory: %s", title_dir.c_str());
     return GetDefaultReply(FS_EACCESS);
   }
+  // XXX: ugly, but until we drop CNANDContentManager everywhere, this is going to be needed.
+  DiscIO::CNANDContentManager::Access().ClearCache();
 
   return GetDefaultReply(IPC_SUCCESS);
 }


### PR DESCRIPTION
* CNANDContentManager does things that are absolutely useless. In particular, it parses the ticket, the TMD, reads contents, etc. when we only need to remove the title directory.

* This means it will fail if the ticket cannot be found, when that should not be the case.

* This also obviously caused DeleteTitle to be incredibly inefficient.

* We are already removing the title directory later in the function, as CNANDContentManager does not even delete titles correctly. DeleteTitle != DeleteTitleContents.

* And while I was fixing DeleteTitle, I also noticed an oversight in the ticket validity check and fixed it.