### PR TITLE
Boot_WiiWAD: Set the UID and GID on launch

### DIFF
--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -15,6 +15,7 @@
 
 #include "Core/Boot/Boot.h"
 #include "Core/IOS/ES/ES.h"
+#include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileIO.h"
 #include "Core/IOS/IOS.h"
 #include "Core/PatchEngine.h"
@@ -88,7 +89,15 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
     return false;
 
   IOS::HLE::Device::ES::LoadWAD(_pFilename);
-  if (!IOS::HLE::GetIOS()->BootstrapPPC(ContentLoader))
+
+  // TODO: kill these manual calls and just use ES_Launch here, as soon as the direct WAD
+  //       launch hack is dropped.
+  auto* ios = IOS::HLE::GetIOS();
+  IOS::ES::UIDSys uid_map{Common::FROM_SESSION_ROOT};
+  ios->SetUidForPPC(uid_map.GetOrInsertUIDForTitle(titleID));
+  ios->SetGidForPPC(ContentLoader.GetTMD().GetGroupId());
+
+  if (!ios->BootstrapPPC(ContentLoader))
     return false;
 
   return true;


### PR DESCRIPTION
This adds code to update the PPC's UID and GID, which fixes a regression with the system menu. Ideally, we would simply rely on IOS's ES_Launch here and not duplicate the logic here, but we cannot do that properly until the direct WAD launch hack is dropped, *and* until the IOS changes that would enable internal calls are ready.

Since this fixes a semi-important regression with managing saves from the SM, and the duplication is not too terrible, I believe it is a good idea to get this fixed right now to avoid affecting users too much.

Just to be clear -- I do plan to fix this properly in the future.