### PR TITLE
IOS/ES: Implement DeleteTitleContent properly

### DIFF
--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -24,7 +24,6 @@
 #include "Core/IOS/IOS.h"
 #include "Core/Movie.h"
 #include "Core/State.h"
-#include "Core/WiiRoot.h"
 
 namespace HW
 {
@@ -50,7 +49,6 @@ void Init()
 
   if (SConfig::GetInstance().bWii)
   {
-    Core::InitializeWiiRoot(Core::WantsDeterminism());
     IOS::Init();
     IOS::HLE::Init();  // Depends on Memory
   }
@@ -61,8 +59,6 @@ void Shutdown()
   // IOS should always be shut down regardless of bWii because it can be running in GC mode (MIOS).
   IOS::HLE::Shutdown();  // Depends on Memory
   IOS::Shutdown();
-  if (SConfig::GetInstance().bWii)
-    Core::ShutdownWiiRoot();
 
   SystemTimers::Shutdown();
   CPU::Shutdown();

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -55,6 +55,8 @@ public:
   ReturnCode Close(u32 fd) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
+  ReturnCode DeleteTitleContent(u64 title_id) const;
+
 private:
   enum
   {

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -51,13 +51,14 @@
 #include "Core/IOS/WFS/WFSI.h"
 #include "Core/IOS/WFS/WFSSRV.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/WiiRoot.h"
 #include "DiscIO/NANDContentLoader.h"
 
 namespace IOS
 {
 namespace HLE
 {
-static std::unique_ptr<Kernel> s_ios;
+static std::unique_ptr<EmulationKernel> s_ios;
 
 constexpr u64 ENQUEUE_REQUEST_FLAG = 0x100000000ULL;
 constexpr u64 ENQUEUE_ACKNOWLEDGEMENT_FLAG = 0x200000000ULL;
@@ -172,29 +173,17 @@ constexpr u64 IOS80_TITLE_ID = 0x0000000100000050;
 constexpr u64 BC_TITLE_ID = 0x0000000100000100;
 constexpr u64 MIOS_TITLE_ID = 0x0000000100000101;
 
-Kernel::Kernel(u64 title_id) : m_title_id(title_id)
+Kernel::Kernel()
 {
-  INFO_LOG(IOS, "Starting IOS %016" PRIx64, title_id);
-
-  if (!SetupMemory(title_id, MemorySetupType::IOSReload))
-    WARN_LOG(IOS, "No information about this IOS -- cannot set up memory values");
-
-  if (title_id == MIOS_TITLE_ID)
-  {
-    MIOS::Load();
-    return;
-  }
-
-  // IOS re-inits IPC and sends a dummy ack during its boot process.
-  EnqueueIPCAcknowledgement(0);
-
-  AddStaticDevices();
+  // Until the Wii root and NAND path stuff is entirely managed by IOS and made non-static,
+  // using more than one IOS instance at a time is not supported.
+  _assert_(GetIOS() == nullptr);
+  Core::InitializeWiiRoot(false);
+  AddCoreDevices();
 }
 
 Kernel::~Kernel()
 {
-  CoreTiming::RemoveAllEvents(s_event_enqueue);
-
   // Close all devices that were opened
   for (auto& device : m_fdmap)
   {
@@ -207,6 +196,36 @@ Kernel::~Kernel()
     std::lock_guard<std::mutex> lock(m_device_map_mutex);
     m_device_map.clear();
   }
+
+  Core::ShutdownWiiRoot();
+}
+
+EmulationKernel::EmulationKernel(u64 title_id)
+{
+  m_title_id = title_id;
+  INFO_LOG(IOS, "Starting IOS %016" PRIx64, title_id);
+
+  if (!SetupMemory(title_id, MemorySetupType::IOSReload))
+    WARN_LOG(IOS, "No information about this IOS -- cannot set up memory values");
+
+  Core::InitializeWiiRoot(Core::WantsDeterminism());
+
+  if (title_id == MIOS_TITLE_ID)
+  {
+    MIOS::Load();
+    return;
+  }
+
+  // IOS re-inits IPC and sends a dummy ack during its boot process.
+  EnqueueIPCAcknowledgement(0);
+
+  AddCoreDevices();
+  AddStaticDevices();
+}
+
+EmulationKernel::~EmulationKernel()
+{
+  CoreTiming::RemoveAllEvents(s_event_enqueue);
 }
 
 // The title ID is a u64 where the first 32 bits are used for the title type.
@@ -215,6 +234,16 @@ Kernel::~Kernel()
 u32 Kernel::GetVersion() const
 {
   return static_cast<u32>(m_title_id);
+}
+
+std::shared_ptr<Device::FS> Kernel::GetFS()
+{
+  return std::static_pointer_cast<Device::FS>(m_device_map.at("/dev/fs"));
+}
+
+std::shared_ptr<Device::ES> Kernel::GetES()
+{
+  return std::static_pointer_cast<Device::ES>(m_device_map.at("/dev/es"));
 }
 
 // Since we don't have actual processes, we keep track of only the PPC's UID/GID.
@@ -289,7 +318,7 @@ bool Kernel::BootIOS(const u64 ios_title_id)
 
   // Shut down the active IOS first before switching to the new one.
   s_ios.reset();
-  s_ios = std::make_unique<Kernel>(ios_title_id);
+  s_ios = std::make_unique<EmulationKernel>(ios_title_id);
   return true;
 }
 
@@ -299,10 +328,16 @@ void Kernel::AddDevice(std::unique_ptr<Device::Device> device)
   m_device_map[device->GetDeviceName()] = std::move(device);
 }
 
+void Kernel::AddCoreDevices()
+{
+  std::lock_guard<std::mutex> lock(m_device_map_mutex);
+  AddDevice(std::make_unique<Device::FS>(*this, "/dev/fs"));
+  AddDevice(std::make_unique<Device::ES>(*this, "/dev/es"));
+}
+
 void Kernel::AddStaticDevices()
 {
   std::lock_guard<std::mutex> lock(m_device_map_mutex);
-  _assert_msg_(IOS, m_device_map.empty(), "Reinit called while already initialized");
 
   if (!SConfig::GetInstance().m_bt_passthrough_enabled)
     AddDevice(std::make_unique<Device::BluetoothEmu>(*this, "/dev/usb/oh1/57e/305"));
@@ -311,8 +346,6 @@ void Kernel::AddStaticDevices()
 
   AddDevice(std::make_unique<Device::STMImmediate>(*this, "/dev/stm/immediate"));
   AddDevice(std::make_unique<Device::STMEventHook>(*this, "/dev/stm/eventhook"));
-  AddDevice(std::make_unique<Device::FS>(*this, "/dev/fs"));
-  AddDevice(std::make_unique<Device::ES>(*this, "/dev/es"));
   AddDevice(std::make_unique<Device::DI>(*this, "/dev/di"));
   AddDevice(std::make_unique<Device::NetKDRequest>(*this, "/dev/net/kd/request"));
   AddDevice(std::make_unique<Device::NetKDTime>(*this, "/dev/net/kd/time"));
@@ -349,6 +382,11 @@ std::shared_ptr<Device::Device> Kernel::GetDeviceByName(const std::string& devic
   std::lock_guard<std::mutex> lock(m_device_map_mutex);
   const auto iterator = m_device_map.find(device_name);
   return iterator != m_device_map.end() ? iterator->second : nullptr;
+}
+
+std::shared_ptr<Device::Device> EmulationKernel::GetDeviceByName(const std::string& device_name)
+{
+  return Kernel::GetDeviceByName(device_name);
 }
 
 // Returns the FD for the newly opened device (on success) or an error code.
@@ -639,7 +677,7 @@ void Init()
   });
 
   // Start with IOS80 to simulate part of the Wii boot process.
-  s_ios = std::make_unique<Kernel>(IOS80_TITLE_ID);
+  s_ios = std::make_unique<EmulationKernel>(IOS80_TITLE_ID);
   // On a Wii, boot2 launches the system menu IOS, which then launches the system menu
   // (which bootstraps the PPC). Bootstrapping the PPC results in memory values being set up.
   // This means that the constants in the 0x3100 region are always set up by the time
@@ -653,7 +691,7 @@ void Shutdown()
   s_ios.reset();
 }
 
-Kernel* GetIOS()
+EmulationKernel* GetIOS()
 {
   return s_ios.get();
 }

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -45,7 +45,7 @@ OH0Device::OH0Device(Kernel& ios, const std::string& name) : Device(ios, name, D
 
 void OH0Device::DoState(PointerWrap& p)
 {
-  m_oh0 = std::static_pointer_cast<OH0>(m_ios.GetDeviceByName("/dev/usb/oh0"));
+  m_oh0 = std::static_pointer_cast<OH0>(GetIOS()->GetDeviceByName("/dev/usb/oh0"));
   p.Do(m_name);
   p.Do(m_vid);
   p.Do(m_pid);
@@ -61,7 +61,7 @@ ReturnCode OH0Device::Open(const OpenRequest& request)
   if (m_vid == 0 && m_pid == 0)
     return IPC_ENOENT;
 
-  m_oh0 = std::static_pointer_cast<OH0>(m_ios.GetDeviceByName("/dev/usb/oh0"));
+  m_oh0 = std::static_pointer_cast<OH0>(GetIOS()->GetDeviceByName("/dev/usb/oh0"));
 
   ReturnCode return_code;
   std::tie(return_code, m_device_id) = m_oh0->DeviceOpen(m_vid, m_pid);

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -109,7 +109,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
     Memory::CopyFromEmu(tmd_bytes.data(), tmd_addr, tmd_size);
     m_tmd.SetBytes(std::move(tmd_bytes));
 
-    ES::TicketReader ticket = DiscIO::FindSignedTicket(m_tmd.GetTitleId());
+    IOS::ES::TicketReader ticket = DiscIO::FindSignedTicket(m_tmd.GetTitleId());
     if (!ticket.IsValid())
     {
       return_error_code = -11028;
@@ -134,7 +134,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
 
     // Initializes the IV from the index of the content in the TMD contents.
     u32 content_id = Memory::Read_U32(request.buffer_in + 8);
-    ES::Content content_info;
+    IOS::ES::Content content_info;
     if (!m_tmd.FindContentById(content_id, &content_info))
     {
       WARN_LOG(IOS, "%s: Content id %08x not found", ioctl_name, content_id);

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -241,38 +241,9 @@ const CNANDContentLoader& CNANDContentManager::GetNANDLoader(u64 title_id,
   return GetNANDLoader(path);
 }
 
-bool CNANDContentManager::RemoveTitle(u64 title_id, Common::FromWhichRoot from)
-{
-  auto& loader = GetNANDLoader(title_id, from);
-  if (!loader.IsValid())
-    return false;
-  loader.RemoveTitle();
-  return GetNANDLoader(title_id, from).IsValid();
-}
-
 void CNANDContentManager::ClearCache()
 {
   m_map.clear();
-}
-
-void CNANDContentLoader::RemoveTitle() const
-{
-  const u64 title_id = m_tmd.GetTitleId();
-  INFO_LOG(DISCIO, "RemoveTitle %016" PRIx64, title_id);
-  if (IsValid())
-  {
-    // remove TMD?
-    for (const auto& content : m_Content)
-    {
-      if (!content.m_metadata.IsShared())
-      {
-        std::string path = StringFromFormat("%s/%08x.app", m_Path.c_str(), content.m_metadata.id);
-        INFO_LOG(DISCIO, "Delete %s", path.c_str());
-        File::Delete(path);
-      }
-    }
-    CNANDContentManager::Access().ClearCache();  // deletes 'this'
-  }
 }
 
 u64 CNANDContentManager::Install_WiiWAD(const std::string& filename)

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -79,7 +79,6 @@ public:
   ~CNANDContentLoader();
 
   bool IsValid() const;
-  void RemoveTitle() const;
   const SNANDContent* GetContentByID(u32 id) const;
   const SNANDContent* GetContentByIndex(int index) const;
   const IOS::ES::TMDReader& GetTMD() const { return m_tmd; }
@@ -111,7 +110,6 @@ public:
 
   const CNANDContentLoader& GetNANDLoader(const std::string& content_path);
   const CNANDContentLoader& GetNANDLoader(u64 title_id, Common::FromWhichRoot from);
-  bool RemoveTitle(u64 title_id, Common::FromWhichRoot from);
   void ClearCache();
 
 private:

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -13,6 +13,8 @@
 #include "Common/NandPaths.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/WiiSaveCrypted.h"
+#include "Core/IOS/ES/ES.h"
+#include "Core/IOS/IOS.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
@@ -324,9 +326,8 @@ bool GameFile::Install()
 bool GameFile::Uninstall()
 {
   _assert_(m_platform == DiscIO::Platform::WII_WAD);
-
-  return DiscIO::CNANDContentManager::Access().RemoveTitle(m_title_id,
-                                                           Common::FROM_CONFIGURED_ROOT);
+  IOS::HLE::Kernel ios;
+  return ios.GetES()->DeleteTitleContent(m_title_id) == IOS::HLE::IPC_SUCCESS;
 }
 
 bool GameFile::ExportWiiSave()

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -42,6 +42,7 @@
 #include "Core/HW/Wiimote.h"
 #include "Core/Host.h"
 #include "Core/HotkeyManager.h"
+#include "Core/IOS/ES/ES.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/STM/STM.h"
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
@@ -1228,7 +1229,8 @@ void CFrame::OnUninstallWAD(wxCommandEvent&)
   }
 
   u64 title_id = file->GetTitleID();
-  if (!DiscIO::CNANDContentManager::Access().RemoveTitle(title_id, Common::FROM_CONFIGURED_ROOT))
+  IOS::HLE::Kernel ios;
+  if (ios.GetES()->DeleteTitleContent(title_id) < 0)
   {
     PanicAlertT("Failed to remove this title from the NAND.");
     return;


### PR DESCRIPTION
Just like DeleteTitle, using CNANDContentManager is overkill, inefficient and useless. And it results in a few failures in situations where a delete should just always work.

But here it gets bonus points, because it manages to actually use the TMD for deleting contents, when IOS does none of that and just deletes files ending with .app in the title content directory. :)