### PR TITLE
WX: Don't create data dir if it is missing

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -1015,7 +1015,10 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
         // an inconsistent state; the emulated software can do *anything* to its data directory,
         // and we definitely do not want the user to touch anything in there if it's running.
         for (auto* menu_item : {open_save_folder_item, export_save_item})
-          menu_item->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
+        {
+          menu_item->Enable((!Core::IsRunning() || !SConfig::GetInstance().bWii) &&
+                            File::IsDirectory(selected_iso->GetWiiFSPath()));
+        }
       }
       popupMenu.Append(IDM_OPEN_CONTAINING_FOLDER, _("Open &containing folder"));
 

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -366,9 +366,6 @@ const std::string GameListItem::GetWiiFSPath() const
 
   const std::string path = Common::GetTitleDataPath(m_title_id, Common::FROM_CONFIGURED_ROOT);
 
-  if (!File::Exists(path))
-    File::CreateFullPath(path);
-
   if (path[0] == '.')
     return WxStrToStr(wxGetCwd()) + path.substr(strlen(ROOT_DIR));
 


### PR DESCRIPTION
This is unsafe, because the NAND should not be accessed and messed with while it is being used. In fact, this kind of inappropriate behaviour will not be possible when we get NAND image support.

And even if there were no safety issue, there is still no reason a *getter* function should *do* something that has lasting effects on user data. GetWiiFSPath() should *just* return a path!