### PR TITLE
Qt: Bring Gamelist up to Wx standards

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -216,6 +216,7 @@ void SConfig::SaveGameListSettings(IniFile& ini)
 
   gamelist->Set("ColumnPlatform", m_showSystemColumn);
   gamelist->Set("ColumnBanner", m_showBannerColumn);
+  gamelist->Set("ColumnDescription", m_showDescriptionColumn);
   gamelist->Set("ColumnTitle", m_showTitleColumn);
   gamelist->Set("ColumnNotes", m_showMakerColumn);
   gamelist->Set("ColumnFileName", m_showFileNameColumn);
@@ -536,6 +537,7 @@ void SConfig::LoadGameListSettings(IniFile& ini)
 
   // Gamelist columns toggles
   gamelist->Get("ColumnPlatform", &m_showSystemColumn, true);
+  gamelist->Get("ColumnDescription", &m_showDescriptionColumn, false);
   gamelist->Get("ColumnBanner", &m_showBannerColumn, true);
   gamelist->Get("ColumnTitle", &m_showTitleColumn, true);
   gamelist->Get("ColumnNotes", &m_showMakerColumn, true);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -293,6 +293,7 @@ struct SConfig : NonCopyable
   // Game list column toggles
   bool m_showSystemColumn;
   bool m_showBannerColumn;
+  bool m_showDescriptionColumn;
   bool m_showTitleColumn;
   bool m_showMakerColumn;
   bool m_showFileNameColumn;

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -66,18 +66,18 @@ void GameList::MakeTableView()
   m_table->setSortingEnabled(true);
   m_table->setCurrentIndex(QModelIndex());
   m_table->setContextMenuPolicy(Qt::CustomContextMenu);
+
   connect(m_table, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
 
-  // TODO load from config
-  m_table->setColumnHidden(GameListModel::COL_PLATFORM, false);
-  m_table->setColumnHidden(GameListModel::COL_ID, true);
-  m_table->setColumnHidden(GameListModel::COL_BANNER, false);
-  m_table->setColumnHidden(GameListModel::COL_TITLE, false);
-  m_table->setColumnHidden(GameListModel::COL_DESCRIPTION, true);
-  m_table->setColumnHidden(GameListModel::COL_MAKER, false);
-  m_table->setColumnHidden(GameListModel::COL_SIZE, false);
-  m_table->setColumnHidden(GameListModel::COL_COUNTRY, false);
-  m_table->setColumnHidden(GameListModel::COL_RATING, false);
+  m_table->setColumnHidden(GameListModel::COL_PLATFORM, !Settings().PlatformVisible());
+  m_table->setColumnHidden(GameListModel::COL_ID, !Settings().IDVisible());
+  m_table->setColumnHidden(GameListModel::COL_BANNER, !Settings().BannerVisible());
+  m_table->setColumnHidden(GameListModel::COL_TITLE, !Settings().TitleVisible());
+  m_table->setColumnHidden(GameListModel::COL_DESCRIPTION, !Settings().DescriptionVisible());
+  m_table->setColumnHidden(GameListModel::COL_MAKER, !Settings().MakerVisible());
+  m_table->setColumnHidden(GameListModel::COL_SIZE, !Settings().SizeVisible());
+  m_table->setColumnHidden(GameListModel::COL_COUNTRY, !Settings().CountryVisible());
+  m_table->setColumnHidden(GameListModel::COL_RATING, !Settings().StateVisible());
 
   QHeaderView* hor_header = m_table->horizontalHeader();
   hor_header->setSectionResizeMode(GameListModel::COL_PLATFORM, QHeaderView::ResizeToContents);
@@ -388,6 +388,18 @@ void GameList::keyReleaseEvent(QKeyEvent* event)
     emit GameSelected();
   else
     QStackedWidget::keyReleaseEvent(event);
+}
+
+void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)
+{
+  for (int i = 0; i < m_table->model()->columnCount(); i++)
+  {
+    if (m_table->model()->headerData(i, Qt::Horizontal).toString() == row)
+    {
+      m_table->setColumnHidden(i, !visible);
+      return;
+    }
+  }
 }
 
 static bool CompressCB(const std::string& text, float percent, void* ptr)

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -27,6 +27,8 @@ public slots:
   void SetTableView() { SetPreferredView(true); }
   void SetListView() { SetPreferredView(false); }
   void SetViewColumn(int col, bool view) { m_table->setColumnHidden(col, !view); }
+  void OnColumnVisibilityToggled(const QString& row, bool visible);
+
 private slots:
   void ShowContextMenu(const QPoint&);
   void OpenContainingFolder();

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -83,6 +83,8 @@ void MainWindow::ConnectMenuBar()
   // View
   connect(m_menu_bar, &MenuBar::ShowTable, m_game_list, &GameList::SetTableView);
   connect(m_menu_bar, &MenuBar::ShowList, m_game_list, &GameList::SetListView);
+  connect(m_menu_bar, &MenuBar::ColumnVisibilityToggled, m_game_list,
+          &GameList::OnColumnVisibilityToggled);
   connect(m_menu_bar, &MenuBar::ShowAboutDialog, this, &MainWindow::ShowAboutDialog);
 
   connect(this, &MainWindow::EmulationStarted, m_menu_bar, &MenuBar::EmulationStarted);

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -5,6 +5,7 @@
 #include <QAction>
 #include <QDesktopServices>
 #include <QFileDialog>
+#include <QMap>
 #include <QMessageBox>
 #include <QUrl>
 
@@ -210,19 +211,33 @@ void MenuBar::AddGameListTypeSection(QMenu* view_menu)
   connect(list_view, &QAction::triggered, this, &MenuBar::ShowList);
 }
 
-// TODO implement this
 void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
 {
+  static const QMap<QString, bool*> columns{{tr("Platform"), &Settings().PlatformVisible()},
+                                            {tr("ID"), &Settings().IDVisible()},
+                                            {tr("Banner"), &Settings().BannerVisible()},
+                                            {tr("Title"), &Settings().TitleVisible()},
+                                            {tr("Description"), &Settings().DescriptionVisible()},
+                                            {tr("Maker"), &Settings().MakerVisible()},
+                                            {tr("Size"), &Settings().SizeVisible()},
+                                            {tr("Country"), &Settings().CountryVisible()},
+                                            {tr("Quality"), &Settings().StateVisible()}};
+
   QActionGroup* column_group = new QActionGroup(this);
   QMenu* cols_menu = view_menu->addMenu(tr("Table Columns"));
   column_group->setExclusive(false);
 
-  QStringList col_names{tr("Platform"), tr("ID"),   tr("Banner"),  tr("Title"),  tr("Description"),
-                        tr("Maker"),    tr("Size"), tr("Country"), tr("Quality")};
-  for (int i = 0; i < col_names.count(); i++)
+  for (const auto& key : columns.keys())
   {
-    QAction* action = column_group->addAction(cols_menu->addAction(col_names[i]));
+    bool* config = columns[key];
+    QAction* action = column_group->addAction(cols_menu->addAction(key));
     action->setCheckable(true);
+    action->setChecked(*config);
+    connect(action, &QAction::toggled, [this, config, key](bool value) {
+      *config = value;
+      Settings().Save();
+      emit ColumnVisibilityToggled(key, value);
+    });
   }
 }
 

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -41,6 +41,7 @@ signals:
   // View
   void ShowTable();
   void ShowList();
+  void ColumnVisibilityToggled(const QString& row, bool visible);
 
   void ShowAboutDialog();
 

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -150,3 +150,58 @@ QSize Settings::GetRenderWindowSize() const
 {
   return value(QStringLiteral("Graphics/RenderWindowSize"), QSize(640, 480)).toSize();
 }
+
+bool& Settings::BannerVisible() const
+{
+  return SConfig::GetInstance().m_showBannerColumn;
+}
+
+bool& Settings::CountryVisible() const
+{
+  return SConfig::GetInstance().m_showRegionColumn;
+}
+
+bool& Settings::DescriptionVisible() const
+{
+  return SConfig::GetInstance().m_showDescriptionColumn;
+}
+
+bool& Settings::FilenameVisible() const
+{
+  return SConfig::GetInstance().m_showFileNameColumn;
+}
+
+bool& Settings::IDVisible() const
+{
+  return SConfig::GetInstance().m_showIDColumn;
+}
+
+bool& Settings::MakerVisible() const
+{
+  return SConfig::GetInstance().m_showMakerColumn;
+}
+
+bool& Settings::PlatformVisible() const
+{
+  return SConfig::GetInstance().m_showSystemColumn;
+}
+
+bool& Settings::TitleVisible() const
+{
+  return SConfig::GetInstance().m_showTitleColumn;
+}
+
+bool& Settings::SizeVisible() const
+{
+  return SConfig::GetInstance().m_showSizeColumn;
+}
+
+bool& Settings::StateVisible() const
+{
+  return SConfig::GetInstance().m_showStateColumn;
+}
+
+void Settings::Save()
+{
+  return SConfig::GetInstance().SaveSettings();
+}

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -51,4 +51,18 @@ public:
   bool GetRenderToMain() const;
   bool GetFullScreen() const;
   QSize GetRenderWindowSize() const;
+
+  // Columns
+  bool& BannerVisible() const;
+  bool& CountryVisible() const;
+  bool& DescriptionVisible() const;
+  bool& FilenameVisible() const;
+  bool& IDVisible() const;
+  bool& PlatformVisible() const;
+  bool& MakerVisible() const;
+  bool& SizeVisible() const;
+  bool& StateVisible() const;
+  bool& TitleVisible() const;
+
+  void Save();
 };


### PR DESCRIPTION
* Makes the View -> Table Columns menu functional
* Dynamically refresh the Gamelist when column visibilities are changed
* Allows saving and loading of columns
* Adds a new config entry for the previously missing Description column