### PR TITLE
lint: Check for newline at EOF

### DIFF
--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -4,18 +4,28 @@
 
 fail=0
 
-# Check for clang-format issues.
+# Loop through each modified file.
 for f in $(git diff --name-only --diff-filter=ACMRTUXB --cached); do
+  # Filter them.
   if ! echo "${f}" | egrep -q "[.](cpp|h|mm)$"; then
     continue
   fi
   if ! echo "${f}" | egrep -q "^Source/Core"; then
     continue
   fi
+
+  # Check for clang-format issues.
   d=$(diff -u "${f}" <(clang-format ${f}))
   if ! [ -z "${d}" ]; then
     echo "!!! ${f} not compliant to coding style, here is the fix:"
     echo "${d}"
+    fail=1
+  fi
+
+  # Check for newline at EOF.
+  if [ -n "$(tail -c 1 ${f})" ]; then
+    echo "!!! ${f} not compliant to coding style:"
+    echo "Missing newline at end of file"
     fail=1
   fi
 done


### PR DESCRIPTION
I'm not sure that's the right place to put this kind of check. This PR tends to address the lack of missing newline detection in lint.