### PR TITLE
Config/Layer: Fix accidental cast of RecursiveSection to Section

### DIFF
--- a/Source/Core/Common/Config/Layer.cpp
+++ b/Source/Core/Common/Config/Layer.cpp
@@ -57,8 +57,8 @@ bool Layer::DeleteKey(System system, const std::string& section_name, const std:
 Section* Layer::GetSection(System system, const std::string& section_name)
 {
   for (auto& section : m_sections[system])
-    if (!strcasecmp(section.m_name.c_str(), section_name.c_str()))
-      return &section;
+    if (!strcasecmp(section->m_name.c_str(), section_name.c_str()))
+      return section.get();
   return nullptr;
 }
 
@@ -68,10 +68,10 @@ Section* Layer::GetOrCreateSection(System system, const std::string& section_nam
   if (!section)
   {
     if (m_layer == LayerType::Meta)
-      m_sections[system].emplace_back(RecursiveSection(m_layer, system, section_name));
+      m_sections[system].emplace_back(std::make_unique<RecursiveSection>(m_layer, system, section_name));
     else
-      m_sections[system].emplace_back(Section(m_layer, system, section_name));
-    section = &m_sections[system].back();
+      m_sections[system].emplace_back(std::make_unique<Section>(m_layer, system, section_name));
+    section = m_sections[system].back().get();
   }
   return section;
 }
@@ -113,7 +113,7 @@ bool Layer::IsDirty() const
 {
   return std::any_of(m_sections.begin(), m_sections.end(), [](const auto& system) {
     return std::any_of(system.second.begin(), system.second.end(),
-                       [](const auto& section) { return section.IsDirty(); });
+                       [](const auto& section) { return section->IsDirty(); });
   });
 }
 
@@ -121,7 +121,7 @@ void Layer::ClearDirty()
 {
   std::for_each(m_sections.begin(), m_sections.end(), [](auto& system) {
     std::for_each(system.second.begin(), system.second.end(),
-                  [](auto& section) { section.ClearDirty(); });
+                  [](auto& section) { section->ClearDirty(); });
   });
 }
 
@@ -140,8 +140,8 @@ Section* RecursiveLayer::GetOrCreateSection(System system, const std::string& se
   Section* section = Layer::GetSection(system, section_name);
   if (!section)
   {
-    m_sections[system].emplace_back(RecursiveSection(m_layer, system, section_name));
-    section = &m_sections[system].back();
+    m_sections[system].emplace_back(std::make_unique<RecursiveSection>(m_layer, system, section_name));
+    section = m_sections[system].back().get();
   }
   return section;
 }

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -14,7 +14,7 @@
 
 namespace Config
 {
-using LayerMap = std::map<System, std::vector<Section>>;
+using LayerMap = std::map<System, std::vector<std::unique_ptr<Section>>>;
 
 class ConfigLayerLoader
 {

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -73,8 +73,8 @@ public:
 
       for (const auto& section : system.second)
       {
-        const std::string section_name = section.GetName();
-        const Config::SectionValueMap& section_values = section.GetValues();
+        const std::string section_name = section->GetName();
+        const Config::SectionValueMap& section_values = section->GetValues();
 
         IniFile::Section* ini_section = ini.GetOrCreateSection(section_name);
 

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -391,10 +391,10 @@ void INIGameConfigLayerLoader::Save(Config::Layer* config_layer)
   {
     for (const auto& section : system.second)
     {
-      for (const auto& value : section.GetValues())
+      for (const auto& value : section->GetValues())
       {
         const auto ini_location =
-            GetINILocationFromConfig({system.first, section.GetName(), value.first});
+            GetINILocationFromConfig({system.first, section->GetName(), value.first});
         if (ini_location.first.empty() && ini_location.second.empty())
           continue;
 


### PR DESCRIPTION
emplace_back was called with a RecursiveSection value [here](https://github.com/MerryMage/dolphin/blob/88a21dd2b9539292838aff32f5f29c182d4d6c39/Source/Core/Common/Config/Layer.cpp#L71). Since m_sections is a std::vector\<Section\>, this value was converted to a Section before it was stored.