### PR TITLE
Don't run EmulatedBS2_Wii with VolumeDirectory

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -354,18 +354,24 @@ bool CBoot::BootUp()
       volume = SetDisc(DiscIO::CreateVolumeFromFilename(_StartupPara.m_strDefaultISO));
     }
 
-    if (!EmulatedBS2(dolWii, volume))
+    // Poor man's bootup
+    if (dolWii)
     {
-      if (dolWii)
-        HID4.SBE = 1;
+      HID4.SBE = 1;
       SetupBAT(dolWii);
 
-      if (dolWii)
-        SetupWiiMemory(volume, 0x000000010000003a);
-
-      dolLoader.Load();
-      PC = dolLoader.GetEntryPoint();
+      // Because there is no TMD to get the requested system (IOS) version from,
+      // we default to IOS58, which is the version used by the Homebrew Channel.
+      SetupWiiMemory(volume, 0x000000010000003a);
     }
+    else
+    {
+      EmulatedBS2_GC(volume, true);
+    }
+
+    Load_FST(dolWii, volume);
+    dolLoader.Load();
+    PC = dolLoader.GetEntryPoint();
 
     if (LoadMapFromFilename())
       HLE::PatchFunctions();


### PR DESCRIPTION
VolumeDirectory doesn't support necessities like TMDs, so thanks to 5.0-2172 (18968ab), EmulatedBS2_Wii crashes when the inserted disc is a VolumeDirectory. This PR fixes that.

This PR makes our DOL booting code very similar to our ELF booting code. One exception is that the DOL booting code still always calls SetupBAT. (Note that EmulatedBS2_GC calls SetupBAT even if no disc is inserted.) I'm not sure if there's a point to the difference, but I thought I'd better avoid changing it so that I don't break anything.