### PR TITLE
[WIP] [RFC] Switch bWii to new config system

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -91,6 +91,8 @@ void Save()
 
 void Init()
 {
+  // This layer contains temporary settings and is never loaded or saved
+  s_layers[LayerType::CurrentRun] = std::make_unique<Layer>(LayerType::CurrentRun);
   // This layer always has to exist
   s_layers[LayerType::Meta] = std::make_unique<RecursiveLayer>();
 }

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -12,6 +12,7 @@
 #include "Common/Config/Enums.h"
 #include "Common/Config/Layer.h"
 #include "Common/Config/Section.h"
+#include "Common/Config/SettingInfo.h"
 
 namespace Config
 {
@@ -37,22 +38,6 @@ void InvokeConfigChangedCallbacks();
 // Explicit load and save of layers
 void Load();
 void Save();
-
-// Often used functions for getting or setting configuration on the base layer for the main system
-template <typename T>
-T Get(const std::string& section_name, const std::string& key, const T& default_value)
-{
-  auto base_layer = GetLayer(Config::LayerType::Base);
-  return base_layer->GetOrCreateSection(Config::System::Main, section_name)
-      ->Get(key, default_value);
-}
-
-template <typename T>
-void Set(const std::string& section_name, const std::string& key, const T& value)
-{
-  auto base_layer = GetLayer(Config::LayerType::Base);
-  base_layer->GetOrCreateSection(Config::System::Main, section_name)->Set(key, value);
-}
 
 void Init();
 void Shutdown();

--- a/Source/Core/Common/Config/Section.h
+++ b/Source/Core/Common/Config/Section.h
@@ -65,7 +65,7 @@ public:
   T Get(const std::string& key, const T& default_value) const
   {
     T value;
-    Get(key, value, default_value);
+    Get(key, &value, default_value);
     return value;
   }
 

--- a/Source/Core/Common/Config/SettingInfo.h
+++ b/Source/Core/Common/Config/SettingInfo.h
@@ -1,0 +1,31 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "Common/Config/Enums.h"
+
+namespace Config
+{
+
+template <typename T>
+struct SettingInfo
+{
+  System system;
+  const char* section_name;
+  const char* key;
+  T default_value;
+};
+
+template <>
+struct SettingInfo<std::string>
+{
+  System system;
+  const char* section_name;
+  const char* key;
+  const char* default_value;
+};
+}

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -30,6 +30,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/EXI/EXI.h"
@@ -166,7 +167,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
   if (bSetVolume)
     config->m_Volume = Volume;
 
-  if (config->bWii)
+  if (Config::Get(Config::WII))
   {
     for (unsigned int i = 0; i < MAX_BBMOTES; ++i)
     {
@@ -291,7 +292,7 @@ bool BootCore(const std::string& _rFilename)
     }
 
     // Wii settings
-    if (StartUp.bWii)
+    if (Config::Get(Config::WII))
     {
       IniFile::Section* wii_section = game_ini.GetOrCreateSection("Wii");
       wii_section->Get("Widescreen", &StartUp.m_wii_aspect_ratio, !!StartUp.m_wii_aspect_ratio);
@@ -332,11 +333,11 @@ bool BootCore(const std::string& _rFilename)
     StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
     StartUp.iCPUCore = Movie::GetCPUMode();
     StartUp.bSyncGPU = Movie::IsSyncGPU();
-    if (!StartUp.bWii)
+    if (!Config::Get(Config::WII))
       StartUp.SelectedLanguage = Movie::GetLanguage();
     for (int i = 0; i < 2; ++i)
     {
-      if (Movie::IsUsingMemcard(i) && Movie::IsStartingFromClearSave() && !StartUp.bWii)
+      if (Movie::IsUsingMemcard(i) && Movie::IsStartingFromClearSave() && !Config::Get(Config::WII))
       {
         if (File::Exists(File::GetUserPath(D_GCUSER_IDX) +
                          StringFromFormat("Movie%s.raw", (i == 0) ? "A" : "B")))
@@ -385,12 +386,12 @@ bool BootCore(const std::string& _rFilename)
 
   // Some NTSC Wii games such as Doc Louis's Punch-Out!! and
   // 1942 (Virtual Console) crash if the PAL60 option is enabled
-  if (StartUp.bWii && ntsc)
+  if (Config::Get(Config::WII) && ntsc)
   {
     StartUp.bPAL60 = false;
   }
 
-  if (StartUp.bWii)
+  if (Config::Get(Config::WII))
     StartUp.SaveSettingsToSysconf();
 
   // Run the game

--- a/Source/Core/Core/Config.h
+++ b/Source/Core/Core/Config.h
@@ -1,0 +1,33 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Common/Config/Config.h"
+#include "Common/Config/Enums.h"
+#include "Common/Config/SettingInfo.h"
+
+namespace Config {
+
+template <typename T>
+T Get(const SettingInfo<T>& info)
+{
+  auto meta_layer = GetLayer(LayerType::Meta);
+  return meta_layer->GetOrCreateSection(info.system, info.section_name)
+      ->template Get<T>(info.key, info.default_value);
+}
+
+template <typename T>
+void Set(LayerType layer, const SettingInfo<T>& info, const T& value)
+{
+  GetLayer(layer)->GetOrCreateSection(info.system, info.section_name)
+      ->Set(info.key, value);
+}
+
+constexpr SettingInfo<bool> WII {System::Main, "Runtime", "bWii", false};
+
+}

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -34,6 +34,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "VideoCommon/HiresTextures.h"
 
+#include "Core/Config.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
 #include "DiscIO/Volume.h"
@@ -830,7 +831,7 @@ void SConfig::LoadDefaults()
   bEnableMemcardSdWriting = true;
   SelectedLanguage = 0;
   bOverrideGCLanguage = false;
-  bWii = false;
+  Config::Set(Config::LayerType::CurrentRun, Config::WII, false);
   bDPL2Decoder = false;
   iLatency = 14;
   m_audio_stretch = false;
@@ -945,7 +946,8 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       SetRunningGameMetadata(*pVolume);
 
       // Check if we have a Wii disc
-      bWii = pVolume->GetVolumeType() == DiscIO::Platform::WII_DISC;
+      Config::Set(Config::LayerType::CurrentRun, Config::WII,
+                  pVolume->GetVolumeType() == DiscIO::Platform::WII_DISC);
 
       if (!SetRegion(pVolume->GetRegion(), &set_region_dir))
         if (!PanicYesNoT("Your GCM/ISO file seems to be invalid (invalid country)."
@@ -954,26 +956,28 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
     }
     else if (!strcasecmp(Extension.c_str(), ".elf"))
     {
-      bWii = CBoot::IsElfWii(m_strFilename);
+      Config::Set(Config::LayerType::CurrentRun, Config::WII, CBoot::IsElfWii(m_strFilename));
       // TODO: Right now GC homebrew boots in NTSC and Wii homebrew in PAL.
       // This is intentional so that Wii homebrew can boot in both 50Hz and 60Hz, without forcing
       // all GC homebrew to 50Hz.
       // In the future, it probably makes sense to add a Region setting for homebrew somewhere in
       // the emulator config.
-      SetRegion(bWii ? DiscIO::Region::PAL : DiscIO::Region::NTSC_U, &set_region_dir);
+      SetRegion(Config::Get(Config::WII) ? DiscIO::Region::PAL : DiscIO::Region::NTSC_U,
+                &set_region_dir);
       m_BootType = BOOT_ELF;
     }
     else if (!strcasecmp(Extension.c_str(), ".dol"))
     {
       CDolLoader dolfile(m_strFilename);
-      bWii = dolfile.IsWii();
+      Config::Set(Config::LayerType::CurrentRun, Config::WII, dolfile.IsWii());
       // TODO: See the ELF code above.
-      SetRegion(bWii ? DiscIO::Region::PAL : DiscIO::Region::NTSC_U, &set_region_dir);
+      SetRegion(Config::Get(Config::WII) ? DiscIO::Region::PAL : DiscIO::Region::NTSC_U,
+                &set_region_dir);
       m_BootType = BOOT_DOL;
     }
     else if (!strcasecmp(Extension.c_str(), ".dff"))
     {
-      bWii = true;
+      Config::Set(Config::LayerType::CurrentRun, Config::WII, true);
       SetRegion(DiscIO::Region::NTSC_U, &set_region_dir);
       m_BootType = BOOT_DFF;
 
@@ -981,7 +985,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
 
       if (ddfFile)
       {
-        bWii = ddfFile->GetIsWii();
+        Config::Set(Config::LayerType::CurrentRun, Config::WII, ddfFile->GetIsWii());
       }
     }
     else if (DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename).IsValid())
@@ -1002,7 +1006,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       SetRegion(tmd.GetRegion(), &set_region_dir);
       SetRunningGameMetadata(tmd);
 
-      bWii = true;
+      Config::Set(Config::LayerType::CurrentRun, Config::WII, true);
       m_BootType = BOOT_WII_NAND;
     }
     else
@@ -1033,7 +1037,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
   CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardA, set_region_dir, true);
   CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardB, set_region_dir, false);
   m_strSRAM = File::GetUserPath(F_GCSRAM_IDX);
-  if (!bWii)
+  if (!Config::Get(Config::WII))
   {
     if (!bHLE_BS2)
     {
@@ -1049,7 +1053,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       }
     }
   }
-  else if (bWii && !bHLE_BS2)
+  else if (Config::Get(Config::WII) && !bHLE_BS2)
   {
     WARN_LOG(BOOT, "GC bootrom file will not be loaded for Wii mode.");
     bHLE_BS2 = true;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -130,8 +130,6 @@ struct SConfig : NonCopyable
   int SelectedLanguage = 0;
   bool bOverrideGCLanguage = false;
 
-  bool bWii = false;
-
   // Interface settings
   bool bConfirmStop = false;
   bool bHideCursor = false, bAutoHideCursor = false;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -67,6 +67,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCAdapter.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/RenderBase.h"
@@ -239,7 +240,7 @@ bool Init()
 
   Core::UpdateWantDeterminism(/*initial*/ true);
 
-  INFO_LOG(OSREPORT, "Starting core = %s mode", SConfig::GetInstance().bWii ? "Wii" : "GameCube");
+  INFO_LOG(OSREPORT, "Starting core = %s mode", Config::Get(Config::WII) ? "Wii" : "GameCube");
   INFO_LOG(OSREPORT, "CPU Thread separate = %s", SConfig::GetInstance().bCPUThread ? "Yes" : "No");
 
   Host_UpdateMainFrame();  // Disable any menus or buttons at boot
@@ -484,7 +485,7 @@ static void EmuThread()
   else
     SConfig::GetInstance().bDSPThread = cpu_info.num_cores > 2;
 
-  if (!DSP::GetDSPEmulator()->Initialize(core_parameter.bWii, core_parameter.bDSPThread))
+  if (!DSP::GetDSPEmulator()->Initialize(Config::Get(Config::WII), core_parameter.bDSPThread))
   {
     s_is_booting.Clear();
     HW::Shutdown();
@@ -510,7 +511,7 @@ static void EmuThread()
   }
 
   // Load and Init Wiimotes - only if we are booting in Wii mode
-  if (core_parameter.bWii && !SConfig::GetInstance().m_bt_passthrough_enabled)
+  if (Config::Get(Config::WII) && !SConfig::GetInstance().m_bt_passthrough_enabled)
   {
     if (init_controllers)
       Wiimote::Initialize(!s_state_filename.empty() ?

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -308,6 +308,7 @@
     <ClInclude Include="Boot\Boot_DOL.h" />
     <ClInclude Include="Boot\ElfReader.h" />
     <ClInclude Include="Boot\ElfTypes.h" />
+    <ClInclude Include="Config.h" />
     <ClInclude Include="ConfigManager.h" />
     <ClInclude Include="Core.h" />
     <ClInclude Include="CoreTiming.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -1522,6 +1522,7 @@
     <ClInclude Include="PowerPC\Jit64Common\ConstantPool.h">
       <Filter>PowerPC\Jit64Common</Filter>
     </ClInclude>
+    <ClInclude Include="Config.h" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -1376,7 +1376,6 @@
     <ClInclude Include="Analytics.h" />
     <ClInclude Include="PowerPC\SignatureDB\CSVSignatureDB.h" />
     <ClInclude Include="PowerPC\SignatureDB\DSYSignatureDB.h" />
-    <ClCompile Include="PowerPC\SignatureDB\MEGASignatureDB.h" />
     <ClInclude Include="PowerPC\SignatureDB\SignatureDB.h" />
     <ClInclude Include="IOS\USB\Bluetooth\BTBase.h">
       <Filter>IOS\USB\Bluetooth</Filter>
@@ -1522,6 +1521,7 @@
     <ClInclude Include="PowerPC\Jit64Common\ConstantPool.h">
       <Filter>PowerPC\Jit64Common</Filter>
     </ClInclude>
+    <ClInclude Include="PowerPC\SignatureDB\MEGASignatureDB.h" />
     <ClInclude Include="Config.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/MsgHandler.h"
 #include "Common/Thread.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoRecordAnalyzer.h"
@@ -38,7 +39,7 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
   std::fill(m_Ram.begin(), m_Ram.end(), 0);
   std::fill(m_ExRam.begin(), m_ExRam.end(), 0);
 
-  m_File->SetIsWii(SConfig::GetInstance().bWii);
+  m_File->SetIsWii(Config::Get(Config::WII));
 
   if (!m_IsRecording)
   {

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -12,6 +12,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/GeckoCode.h"
 #include "Core/HW/Memmap.h"
@@ -95,7 +96,7 @@ static Installation InstallCodeHandlerLocked()
   }
 
   u8 mmio_addr = 0xCC;
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     mmio_addr = 0xCD;
   }

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -189,7 +189,7 @@ void Reinit(bool hle)
   s_dsp_emulator = CreateDSPEmulator(hle);
   s_dsp_is_lle = s_dsp_emulator->IsLLE();
 
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     s_ARAM.wii_mode = true;
     s_ARAM.size = Memory::EXRAM_SIZE;

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -6,6 +6,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Hash.h"
 #include "Common/Logging/Log.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/DSP/DSPAnalyzer.h"
 #include "Core/DSP/DSPCore.h"
@@ -47,7 +48,7 @@ bool OnThread()
 
 bool IsWiiHost()
 {
-  return SConfig::GetInstance().bWii;
+  return Config::Get(Config::WII);
 }
 
 void InterruptRequest()

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -25,6 +25,7 @@
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
 
+#include "Core/Config.h"
 #include "DiscIO/Enums.h"
 
 namespace ExpansionInterface
@@ -236,7 +237,7 @@ void CEXIIPL::SetCS(int _iCS)
 void CEXIIPL::UpdateRTC()
 {
   u32 epoch =
-      (SConfig::GetInstance().bWii || SConfig::GetInstance().m_BootType == SConfig::BOOT_MIOS) ?
+      (Config::Get(Config::WII) || SConfig::GetInstance().m_BootType == SConfig::BOOT_MIOS) ?
           WII_EPOCH :
           GC_EPOCH;
   u32 rtc = Common::swap32(GetEmulatedTime(epoch));

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -5,6 +5,7 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -48,7 +49,7 @@ void Init()
   CPU::Init(SConfig::GetInstance().iCPUCore);
   SystemTimers::Init();
 
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     Core::InitializeWiiRoot(Core::WantsDeterminism());
     IOS::Init();
@@ -61,7 +62,7 @@ void Shutdown()
   // IOS should always be shut down regardless of bWii because it can be running in GC mode (MIOS).
   IOS::HLE::Shutdown();  // Depends on Memory
   IOS::Shutdown();
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
     Core::ShutdownWiiRoot();
 
   SystemTimers::Shutdown();
@@ -98,7 +99,7 @@ void DoState(PointerWrap& p)
   AudioInterface::DoState(p);
   p.DoMarker("AudioInterface");
 
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     IOS::DoState(p);
     p.DoMarker("IOS");

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -11,6 +11,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/MMIOHandlers.h"
 
@@ -47,7 +48,7 @@ inline bool IsMMIOAddress(u32 address)
   if ((address & 0xFFFF0000) == 0x0C000000)
     return true;  // GameCube MMIOs
 
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     return ((address & 0xFFFF0000) == 0x0D000000) ||  // Wii MMIOs
            ((address & 0xFFFF0000) == 0x0D800000);    // Mirror of Wii MMIOs

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -164,7 +164,7 @@ static std::vector<LogicalMemoryView> logical_mapped_entries;
 
 void Init()
 {
-  bool wii = SConfig::GetInstance().bWii;
+  bool wii = Config::Get(Config::WII);
   bool bMMU = SConfig::GetInstance().bMMU;
   bool bFakeVMEM = false;
 #ifndef _ARCH_32
@@ -263,7 +263,7 @@ void UpdateLogicalMemory(const PowerPC::BatTable& dbat_table)
 
 void DoState(PointerWrap& p)
 {
-  bool wii = SConfig::GetInstance().bWii;
+  bool wii = Config::Get(Config::WII);
   p.DoArray(m_pRAM, RAM_SIZE);
   p.DoArray(m_pL1Cache, L1_CACHE_SIZE);
   p.DoMarker("Memory RAM");
@@ -279,7 +279,7 @@ void Shutdown()
 {
   m_IsInitialized = false;
   u32 flags = 0;
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
     flags |= PhysicalMemoryRegion::WII_ONLY;
   if (m_pFakeVMEM)
     flags |= PhysicalMemoryRegion::FAKE_VMEM;

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -49,6 +49,7 @@ IPC_HLE_PERIOD: For the Wii Remote this is the call schedule:
 #include "Common/Logging/Log.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -110,7 +111,7 @@ static void AudioDMACallback(u64 userdata, s64 cyclesLate)
 
 static void IPC_HLE_UpdateCallback(u64 userdata, s64 cyclesLate)
 {
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     IOS::HLE::GetIOS()->UpdateDevices();
     CoreTiming::ScheduleEvent(s_ipc_hle_period - cyclesLate, et_IPC_HLE);
@@ -223,7 +224,7 @@ static void ThrottleCallback(u64 last_time, s64 cyclesLate)
 // SystemTimers::Init
 void PreInit()
 {
-  ChangePPCClock(SConfig::GetInstance().bWii ? Mode::Wii : Mode::GC);
+  ChangePPCClock(Config::Get(Config::WII) ? Mode::Wii : Mode::GC);
 }
 
 void ChangePPCClock(Mode mode)
@@ -238,7 +239,7 @@ void ChangePPCClock(Mode mode)
 
 void Init()
 {
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     // AyuanX: TO BE TWEAKED
     // Now the 1500 is a pure assumption
@@ -282,7 +283,7 @@ void Init()
 
   CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerField(), et_PatchEngine);
 
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
     CoreTiming::ScheduleEvent(s_ipc_hle_period, et_IPC_HLE);
 }
 

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -19,6 +19,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/Boot/Boot_DOL.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -533,7 +534,7 @@ void Kernel::SDIO_EventNotify()
 {
   // TODO: Potential race condition: If IsRunning() becomes false after
   // it's checked, an event may be scheduled after CoreTiming shuts down.
-  if (SConfig::GetInstance().bWii && Core::IsRunning())
+  if (Config::Get(Config::WII) && Core::IsRunning())
     CoreTiming::ScheduleEvent(0, s_event_sdio_notify, 0, CoreTiming::FromThread::NON_CPU);
 }
 

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -13,6 +13,7 @@
 #include "Common/NandPaths.h"
 #include "Common/Swap.h"
 #include "Core/Boot/ElfReader.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/DSPEmulator.h"
@@ -106,7 +107,7 @@ static std::vector<u8> GetMIOSBinary()
 
 static void ReinitHardware()
 {
-  SConfig::GetInstance().bWii = false;
+  Config::Set(Config::LayerType::CurrentRun, Config::WII, false);
 
   // IOS clears mem2 and overwrites it with pseudo-random data (for security).
   std::memset(Memory::m_pEXRAM, 0, Memory::EXRAM_SIZE);
@@ -115,7 +116,7 @@ static void ReinitHardware()
   PowerPC::Reset();
   // Note: this is specific to Dolphin and is required because we initialised it in Wii mode.
   DSP::Reinit(SConfig::GetInstance().bDSPHLE);
-  DSP::GetDSPEmulator()->Initialize(SConfig::GetInstance().bWii, SConfig::GetInstance().bDSPThread);
+  DSP::GetDSPEmulator()->Initialize(Config::Get(Config::WII), SConfig::GetInstance().bDSPThread);
 
   SystemTimers::ChangePPCClock(SystemTimers::Mode::GC);
 }

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -23,6 +23,7 @@
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -1037,7 +1038,7 @@ void LoadInput(const std::string& filename)
   }
 
   ChangePads(true);
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
     ChangeWiiPads(true);
 
   u64 totalSavedBytes = t_record.GetSize() - 256;
@@ -1384,8 +1385,8 @@ void SaveRecording(const std::string& filename)
   header.filetype[2] = 'M';
   header.filetype[3] = 0x1A;
   strncpy(header.gameID, SConfig::GetInstance().GetGameID().c_str(), 6);
-  header.bWii = SConfig::GetInstance().bWii;
-  header.controllers = s_controllers & (SConfig::GetInstance().bWii ? 0xFF : 0x0F);
+  header.bWii = Config::Get(Config::WII);
+  header.controllers = s_controllers & (Config::Get(Config::WII) ? 0xFF : 0x0F);
 
   header.bFromSaveState = s_bRecordingFromSaveState;
   header.frameCount = s_totalFrames;
@@ -1490,7 +1491,7 @@ void GetSettings()
   s_bSyncGPU = SConfig::GetInstance().bSyncGPU;
   s_iCPUCore = SConfig::GetInstance().iCPUCore;
   s_bNetPlay = NetPlay::IsNetPlayRunning();
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     u64 title_id = SConfig::GetInstance().GetTitleID();
     s_bClearSave =

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -5,6 +5,7 @@
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HLE/HLE.h"
@@ -65,7 +66,7 @@ void Interpreter::bcx(UGeckoInstruction inst)
       u32 last_inst = PowerPC::HostRead_U32(PC - 4);
 
       if (last_inst == 0x28000000 /* cmplwi */ ||
-          (last_inst == 0x2C000000 /* cmpwi */ && SConfig::GetInstance().bWii))
+          (last_inst == 0x2C000000 /* cmpwi */ && Config::Get(Config::WII)))
       {
         CoreTiming::Idle();
       }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -14,6 +14,7 @@
 #include "Common/x64ABI.h"
 #include "Common/x64Emitter.h"
 
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"
@@ -122,7 +123,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
   if (!CPU::IsStepping() && inst.OPCD == 32 && CanMergeNextInstructions(2) &&
       (inst.hex & 0xFFFF0000) == 0x800D0000 &&
       (js.op[1].inst.hex == 0x28000000 ||
-       (SConfig::GetInstance().bWii && js.op[1].inst.hex == 0x2C000000)) &&
+       (Config::Get(Config::WII) && js.op[1].inst.hex == 0x2C000000)) &&
       js.op[2].inst.hex == 0x4182fff8)
   {
     s32 offset = (s32)(s16)inst.SIMM_16;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -359,8 +359,8 @@ void JitArm64::lXX(UGeckoInstruction inst)
   if (inst.OPCD == 32 && CanMergeNextInstructions(2) &&
       (inst.hex & 0xFFFF0000) == 0x800D0000 &&  // lwz r0, XXXX(r13)
       (js.op[1].inst.hex == 0x28000000 ||
-       (SConfig::GetInstance().bWii && js.op[1].inst.hex == 0x2C000000)) &&  // cmpXwi r0,0
-      js.op[2].inst.hex == 0x4182fff8)                                       // beq -8
+       (Config::Get(Config::WII) && js.op[1].inst.hex == 0x2C000000)) &&  // cmpXwi r0,0
+      js.op[2].inst.hex == 0x4182fff8)                                    // beq -8
   {
     ARM64Reg WA = gpr.GetReg();
     ARM64Reg XA = EncodeRegTo64(WA);

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 #include "Common/CommonTypes.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -148,7 +149,7 @@ void JitILBase::bcx(UGeckoInstruction inst)
   if (inst.hex == 0x4182fff8 &&
       (PowerPC::HostRead_U32(js.compilerPC - 8) & 0xFFFF0000) == 0x800D0000 &&
       (PowerPC::HostRead_U32(js.compilerPC - 4) == 0x28000000 ||
-       (SConfig::GetInstance().bWii && PowerPC::HostRead_U32(js.compilerPC - 4) == 0x2C000000)))
+       (Config::Get(Config::WII) && PowerPC::HostRead_U32(js.compilerPC - 4) == 0x2C000000)))
   {
     // Uh, Do nothing.
   }

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStore.cpp
@@ -5,6 +5,7 @@
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/CPU.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -60,7 +61,7 @@ void JitILBase::lXz(UGeckoInstruction inst)
   if (!CPU::IsStepping() && inst.OPCD == 32 &&  // Lwx
       (inst.hex & 0xFFFF0000) == 0x800D0000 &&
       (PowerPC::HostRead_U32(js.compilerPC + 4) == 0x28000000 ||
-       (SConfig::GetInstance().bWii && PowerPC::HostRead_U32(js.compilerPC + 4) == 0x2C000000)) &&
+       (Config::Get(Config::WII) && PowerPC::HostRead_U32(js.compilerPC + 4) == 0x2C000000)) &&
       PowerPC::HostRead_U32(js.compilerPC + 8) == 0x4182fff8)
   {
     val = ibuild.EmitLoad32(addr);

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1239,7 +1239,7 @@ void DBATUpdated()
 {
   dbat_table = {};
   UpdateBATs(dbat_table, SPR_DBAT0U);
-  bool extended_bats = SConfig::GetInstance().bWii && HID4.SBE;
+  bool extended_bats = Config::Get(Config::WII) && HID4.SBE;
   if (extended_bats)
     UpdateBATs(dbat_table, SPR_DBAT4U);
   if (Memory::m_pFakeVMEM)
@@ -1261,7 +1261,7 @@ void IBATUpdated()
 {
   ibat_table = {};
   UpdateBATs(ibat_table, SPR_IBAT0U);
-  bool extended_bats = SConfig::GetInstance().bWii && HID4.SBE;
+  bool extended_bats = Config::Get(Config::WII) && HID4.SBE;
   if (extended_bats)
     UpdateBATs(ibat_table, SPR_IBAT4U);
   if (Memory::m_pFakeVMEM)

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -32,6 +32,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/State.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoBackendBase.h"
@@ -156,8 +157,7 @@ static std::string DoState(PointerWrap& p)
     return version_created_by;
   }
 
-  bool is_wii =
-      SConfig::GetInstance().bWii || SConfig::GetInstance().m_BootType == SConfig::BOOT_MIOS;
+  bool is_wii = Config::Get(Config::WII) || SConfig::GetInstance().m_BootType == SConfig::BOOT_MIOS;
   const bool is_wii_currently = is_wii;
   p.Do(is_wii);
   if (is_wii != is_wii_currently)
@@ -174,7 +174,7 @@ static std::string DoState(PointerWrap& p)
   g_video_backend->DoState(p);
   p.DoMarker("video_backend");
 
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
     Wiimote::DoState(p);
   p.DoMarker("Wiimote");
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -19,6 +19,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/GCKeyboard.h"
@@ -90,7 +91,7 @@ void ControllerConfigDiag::UpdateUI()
     m_wiimote_sources[i]->Select(g_wiimote_sources[i]);
 
     const bool wii_game_started =
-        SConfig::GetInstance().bWii || Core::GetState() == Core::State::Uninitialized;
+        Config::Get(Config::WII) || Core::GetState() == Core::State::Uninitialized;
     if (Core::WantsDeterminism() || !wii_game_started)
       m_wiimote_sources[i]->Disable();
     if (!wii_game_started ||
@@ -112,7 +113,7 @@ void ControllerConfigDiag::UpdateUI()
   // Disable some controls when emulation is running
   if (Core::IsRunning())
   {
-    if (!SConfig::GetInstance().bWii || NetPlay::IsNetPlayRunning())
+    if (!Config::Get(Config::WII) || NetPlay::IsNetPlayRunning())
     {
       m_passthrough_sync_text->Disable();
       m_passthrough_sync_btn->Disable();
@@ -130,7 +131,7 @@ void ControllerConfigDiag::UpdateUI()
     m_passthrough_bt_radio->Disable();
     m_emulated_bt_radio->Disable();
 
-    if (!SConfig::GetInstance().bWii)
+    if (!Config::Get(Config::WII))
     {
       m_enable_continuous_scanning->Disable();
       m_refresh_wm_button->Disable();

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -26,6 +26,7 @@
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 #include "Common/SymbolDB.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Debugger/PPCDebugInterface.h"
 #include "Core/HW/DSP.h"
@@ -292,7 +293,7 @@ void CMemoryWindow::OnDumpMemory(wxCommandEvent& event)
 // Write exram (aram or mem2) to file
 void CMemoryWindow::OnDumpMem2(wxCommandEvent& event)
 {
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     DumpArray(File::GetUserPath(F_ARAMDUMP_IDX), Memory::m_pEXRAM, Memory::EXRAM_SIZE);
   }

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -69,6 +69,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCPadStatus.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VertexShaderManager.h"
@@ -1413,7 +1414,7 @@ void CFrame::ParseHotkeys()
     WiimoteId = 4;
 
   // Actually perform the Wiimote connection or disconnection
-  if (WiimoteId >= 0 && SConfig::GetInstance().bWii)
+  if (WiimoteId >= 0 && Config::Get(Config::WII))
   {
     wxCommandEvent evt;
     evt.SetId(IDM_CONNECT_WIIMOTE1 + WiimoteId);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -82,6 +82,7 @@
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
@@ -382,7 +383,7 @@ void CFrame::OnTASInput(wxCommandEvent& event)
     }
 
     if (g_wiimote_sources[i] == WIIMOTE_SRC_EMU &&
-        !(Core::IsRunning() && !SConfig::GetInstance().bWii))
+        !(Core::IsRunning() && !Config::Get(Config::WII)))
     {
       m_tas_input_dialogs[i + 4]->CreateWiiLayout(i);
       m_tas_input_dialogs[i + 4]->Show();
@@ -1289,7 +1290,7 @@ void CFrame::OnFifoPlayer(wxCommandEvent& WXUNUSED(event))
 
 void CFrame::ConnectWiimote(int wm_idx, bool connect)
 {
-  if (Core::IsRunning() && SConfig::GetInstance().bWii &&
+  if (Core::IsRunning() && Config::Get(Config::WII) &&
       !SConfig::GetInstance().m_bt_passthrough_enabled)
   {
     bool was_unpaused = Core::PauseAndLock(true);

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -45,6 +45,7 @@
 #include "Common/StringUtil.h"
 #include "Common/SysConf.h"
 #include "Core/Boot/Boot.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/DVD/DVDInterface.h"
@@ -1016,7 +1017,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
         // and we definitely do not want the user to touch anything in there if it's running.
         for (auto* menu_item : {open_save_folder_item, export_save_item})
         {
-          menu_item->Enable((!Core::IsRunning() || !SConfig::GetInstance().bWii) &&
+          menu_item->Enable((!Core::IsRunning() || !Config::Get(Config::WII)) &&
                             File::IsDirectory(selected_iso->GetWiiFSPath()));
         }
       }
@@ -1051,7 +1052,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
             popupMenu.Append(IDM_LIST_UNINSTALL_WAD, _("Uninstall from the NAND"));
         // These should not be allowed while emulation is running for safety reasons.
         for (auto* menu_item : {install_wad_item, uninstall_wad_item})
-          menu_item->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
+          menu_item->Enable(!Core::IsRunning() || !Config::Get(Config::WII));
 
         if (!IsWADInstalled(*selected_iso))
           uninstall_wad_item->Enable(false);

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Common/CDUtils.h"
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -563,7 +564,7 @@ void MainMenuBar::RefreshWiiToolsLabels() const
   for (const int index : {IDM_MENU_INSTALL_WAD, IDM_EXPORT_ALL_SAVE, IDM_IMPORT_SAVE,
                           IDM_IMPORT_NAND, IDM_EXTRACT_CERTIFICATES})
   {
-    FindItem(index)->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
+    FindItem(index)->Enable(!Core::IsRunning() || !Config::Get(Config::WII));
   }
 }
 

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -19,6 +19,7 @@
 #include "UICommon/UICommon.h"
 #include "UICommon/USBUtils.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 namespace UICommon
@@ -26,6 +27,7 @@ namespace UICommon
 void Init()
 {
   LogManager::Init();
+  Config::Init();
   SConfig::Init();
   VideoBackendBase::PopulateList();
   WiimoteReal::LoadSettings();
@@ -41,6 +43,7 @@ void Shutdown()
   WiimoteReal::Shutdown();
   VideoBackendBase::ClearList();
   SConfig::Shutdown();
+  Config::Shutdown();
   LogManager::Shutdown();
 }
 

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -15,6 +15,7 @@
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/BPFunctions.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/BoundingBox.h"
@@ -277,7 +278,7 @@ static void BPWritten(const BPCmd& bp)
     u32 addr = bpmem.tmem_config.tlut_src << 5;
 
     // The GameCube ignores the upper bits of this address. Some games (WW, MKDD) set them.
-    if (!SConfig::GetInstance().bWii)
+    if (!Config::Get(Config::WII))
       addr = addr & 0x01FFFFFF;
 
     Memory::CopyFromEmu(texMem + tlutTMemAddr, addr, tlutXferCount);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -41,6 +41,7 @@
 #include "Core/Host.h"
 #include "Core/Movie.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/CPMemory.h"
@@ -92,7 +93,7 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   OSDChoice = 0;
   OSDTime = 0;
 
-  if (SConfig::GetInstance().bWii)
+  if (Config::Get(Config::WII))
   {
     m_aspect_wide = SConfig::GetInstance().m_wii_aspect_ratio != 0;
   }
@@ -735,7 +736,7 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
                     u64 ticks, float Gamma)
 {
   // Heuristic to detect if a GameCube game is in 16:9 anamorphic widescreen mode.
-  if (!SConfig::GetInstance().bWii)
+  if (!Config::Get(Config::WII))
   {
     size_t flush_count_4_3, flush_count_anamorphic;
     std::tie(flush_count_4_3, flush_count_anamorphic) =

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -13,6 +13,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 
+#include "Core/Config.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/Debugger.h"
@@ -265,7 +266,7 @@ void VertexManagerBase::Flush()
   VertexShaderManager::SetConstants();
 
   // Track some stats used elsewhere by the anamorphic widescreen heuristic.
-  if (!SConfig::GetInstance().bWii)
+  if (!Config::Get(Config::WII))
   {
     float* rawProjection = xfmem.projection.rawProjection;
     bool viewport_is_4_3 = AspectIs4_3(xfmem.viewport.wd, xfmem.viewport.ht);

--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <bitset>
 
+#include "Core/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -36,6 +37,7 @@ public:
   ScopeInit()
   {
     Core::DeclareAsCPUThread();
+    Config::Init();
     SConfig::Init();
     PowerPC::Init(PowerPC::CORE_INTERPRETER);
     CoreTiming::Init();
@@ -45,6 +47,7 @@ public:
     CoreTiming::Shutdown();
     PowerPC::Shutdown();
     SConfig::Shutdown();
+    Config::Shutdown();
     Core::UndeclareAsCPUThread();
   }
 };

--- a/Source/UnitTests/Core/MMIOTest.cpp
+++ b/Source/UnitTests/Core/MMIOTest.cpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 
 #include "Common/CommonTypes.h"
+#include "Core/Config.h"
 #include "Core/HW/MMIO.h"
 
 // Tests that the UniqueID function returns a "unique enough" identifier
@@ -29,8 +30,8 @@ TEST(UniqueID, UniqueEnough)
 
 TEST(IsMMIOAddress, SpecialAddresses)
 {
-  SConfig::Init();
-  SConfig::GetInstance().bWii = true;
+  Config::Init();
+  Config::Set(Config::LayerType::CurrentRun, Config::WII, true);
 
   // WG Pipe address, should not be handled by MMIO.
   EXPECT_FALSE(MMIO::IsMMIOAddress(0x0C008000));
@@ -50,7 +51,7 @@ TEST(IsMMIOAddress, SpecialAddresses)
   EXPECT_TRUE(MMIO::IsMMIOAddress(0x0D00008C));  // Wii MMIOs
   EXPECT_TRUE(MMIO::IsMMIOAddress(0x0D800F10));  // Mirror of Wii MMIOs
 
-  SConfig::Shutdown();
+  Config::Shutdown();
 }
 
 class MappingTest : public testing::Test


### PR DESCRIPTION
Putting this up for comments early on before proceeding with more work.

What's in this PR:

* Corrected a mistake in Config::Section::Get.
* Just allocate the CurrentRun layer in Config::Init.
* Implement Config::Get and Config::Set.
* Replaced bWii as a demonstration. (Clearly the code in ConfigManager.cpp will not exist when everything is complete.)

Things not done/investigated:

* Loading settings from INI.

Questions:

* Is this approach acceptable?
* Why is bWii even part of SConfig in the first place?
* Given the potential frequency of configuration access, it seems prudent to reduce the amount of std::map lookups as possible. Flattening the structure from what's effectively a std::map<System, std::vector<std::map<Key, Value>>> into a std::map<struct{System,Section,Key}, Value> might be advisable.

(Note: There are a few obvious code formatting errors such as missing newlines and misplaced #includes I'll eventually get round to.)