### PR TITLE
Qt: Fix that some columns are not hidden properly

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -9,6 +9,7 @@
 #include <QFileInfo>
 #include <QHeaderView>
 #include <QKeyEvent>
+#include <QMap>
 #include <QMenu>
 #include <QMessageBox>
 #include <QProgressDialog>
@@ -392,14 +393,18 @@ void GameList::keyReleaseEvent(QKeyEvent* event)
 
 void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)
 {
-  for (int i = 0; i < m_table->model()->columnCount(); i++)
-  {
-    if (m_table->model()->headerData(i, Qt::Horizontal).toString() == row)
-    {
-      m_table->setColumnHidden(i, !visible);
-      return;
-    }
-  }
+  static const QMap<QString, int> rowname_to_col_index = {
+      {tr("Banner"), GameListModel::COL_BANNER},
+      {tr("Country"), GameListModel::COL_COUNTRY},
+      {tr("Description"), GameListModel::COL_DESCRIPTION},
+      {tr("ID"), GameListModel::COL_ID},
+      {tr("Maker"), GameListModel::COL_MAKER},
+      {tr("Platform"), GameListModel::COL_PLATFORM},
+      {tr("Size"), GameListModel::COL_SIZE},
+      {tr("Title"), GameListModel::COL_TITLE},
+      {tr("Quality"), GameListModel::COL_RATING}};
+
+  m_table->setColumnHidden(rowname_to_col_index[row], !visible);
 }
 
 static bool CompressCB(const std::string& text, float percent, void* ptr)


### PR DESCRIPTION
A little follow-up to my Qt gamelist commit yesterday.

I did some testing and found out that not all columns are hidden / shown properly once a menu option is changed.

This PR should fix that.