### PR TITLE
Analytics: Add missing os-type cases, and make an unset os-type an error.

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -171,8 +171,14 @@ void DolphinAnalytics::MakeBaseBuilder()
   builder.AddData("os-type", "linux");
 #elif defined(__FreeBSD__)
   builder.AddData("os-type", "freebsd");
+#elif defined(__OpenBSD__)
+  builder.AddData("os-type", "openbsd");
+#elif defined(__NetBSD__)
+  builder.AddData("os-type", "netbsd");
+#elif defined(__HAIKU__)
+  builder.AddData("os-type", "haiku");
 #else
-  builder.AddData("os-type", "unknown");
+#error os-type not set
 #endif
 
   m_base_builder = builder;


### PR DESCRIPTION
The rationale for the #error is as follows (because there was some controversy on #dolphin-dev):

 * I didn't know about this #if block when I did the initial Haiku port (#4951), and nobody reminded me
 * It should not break the build anywhere it presently works, and for future platforms it's helpful because otherwise you have to spend some time finding it (like I did) or miss it entirely (like I did, at first)

Although I don't even know where else there is to port Dolphin to. IllumOS? (lol)