### PR TITLE
Qt: Implement mapping dialogs

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -20,6 +20,17 @@ set(SRCS
   Config/ControllersWindow.cpp
   Config/FilesystemWidget.cpp
   Config/InfoWidget.cpp
+  Config/Mapping/GCKeyboardEmu.cpp
+  Config/Mapping/GCPadEmu.cpp
+  Config/Mapping/GCPadWiiU.cpp
+  Config/Mapping/MappingBool.cpp
+  Config/Mapping/MappingButton.cpp
+  Config/Mapping/MappingNumeric.cpp
+  Config/Mapping/MappingWidget.cpp
+  Config/Mapping/MappingWindow.cpp
+  Config/Mapping/WiimoteEmuExtension.cpp
+  Config/Mapping/WiimoteEmuGeneral.cpp
+  Config/Mapping/WiimoteEmuMotionControl.cpp
   Config/PathDialog.cpp
   Config/PropertiesDialog.cpp
   Config/SettingsWindow.cpp

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -27,6 +27,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/NetPlayProto.h"
+#include "DolphinQt2/Config/Mapping/MappingWindow.h"
 #include "DolphinQt2/Settings.h"
 #include "UICommon/UICommon.h"
 
@@ -79,6 +80,12 @@ ControllersWindow::ControllersWindow(QWidget* parent)
   CreateMainLayout();
   LoadSettings();
   ConnectWidgets();
+
+  for (size_t i = 0; i < m_gc_mappings.size(); i++)
+    m_gc_mappings[i] = new MappingWindow(this, static_cast<int>(i));
+
+  for (size_t i = 0; i < m_wiimote_mappings.size(); i++)
+    m_wiimote_mappings[i] = new MappingWindow(this, static_cast<int>(i));
 }
 
 void ControllersWindow::CreateGamecubeLayout()
@@ -388,20 +395,36 @@ void ControllersWindow::OnGCPadConfigure()
       break;
   }
 
+  MappingWindow::Type type;
+
   switch (m_gc_controller_boxes[index]->currentIndex())
   {
   case 0:  // None
   case 6:  // GBA
     return;
   case 1:  // Standard Controller
+    type = MappingWindow::Type::MAPPING_GCPAD;
+    break;
   case 2:  // GameCube Adapter for Wii U
+    type = MappingWindow::Type::MAPPING_GCPAD_WIIU;
+    break;
   case 3:  // Steering Wheel
+    type = MappingWindow::Type::MAPPING_GC_STEERINGWHEEL;
+    break;
   case 4:  // Dance Mat
+    type = MappingWindow::Type::MAPPING_GC_DANCEMAT;
+    break;
   case 5:  // DK Bongos
+    type = MappingWindow::Type::MAPPING_GC_BONGOS;
+    break;
   case 7:  // Keyboard
-    UnimplementedButton();
+    type = MappingWindow::Type::MAPPING_GC_KEYBOARD;
+    break;
+  default:
     return;
   }
+  m_gc_mappings[index]->ChangeMappingType(type);
+  m_gc_mappings[index]->exec();
 }
 
 void ControllersWindow::OnWiimoteConfigure()
@@ -413,16 +436,23 @@ void ControllersWindow::OnWiimoteConfigure()
       break;
   }
 
+  MappingWindow::Type type;
   switch (m_wiimote_boxes[index]->currentIndex())
   {
   case 0:  // None
   case 2:  // Real Wii Remote
     return;
   case 1:  // Emulated Wii Remote
+    type = MappingWindow::Type::MAPPING_WIIMOTE_EMU;
+    break;
   case 3:  // Hybrid Wii Remote
-    UnimplementedButton();
+    type = MappingWindow::Type::MAPPING_WIIMOTE_HYBRID;
+    break;
+  default:
     return;
   }
+  m_wiimote_mappings[index]->ChangeMappingType(type);
+  m_wiimote_mappings[index]->exec();
 }
 
 void ControllersWindow::UnimplementedButton()

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.h
@@ -8,6 +8,7 @@
 
 #include <array>
 
+class MappingWindow;
 class QDialogButtonBox;
 class QCheckBox;
 class QComboBox;
@@ -55,6 +56,7 @@ private:
   QDialogButtonBox* m_button_box;
 
   // Gamecube
+  std::array<MappingWindow*, 4> m_gc_mappings;
   QGroupBox* m_gc_box;
   QLabel* m_gc_label;
   QFormLayout* m_gc_layout;
@@ -63,6 +65,7 @@ private:
   std::array<QHBoxLayout*, 4> m_gc_groups;
 
   // Wii Remote
+  std::array<MappingWindow*, 4> m_wiimote_mappings;
   QGroupBox* m_wiimote_box;
   QLabel* m_wii_label;
   QFormLayout* m_wiimote_layout;

--- a/Source/Core/DolphinQt2/Config/Mapping/GCKeyboardEmu.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCKeyboardEmu.cpp
@@ -1,0 +1,66 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include "DolphinQt2/Config/Mapping/GCKeyboardEmu.h"
+#include "InputCommon/InputConfig.h"
+
+#include "Core/HW/GCKeyboard.h"
+#include "Core/HW/GCKeyboardEmu.h"
+
+GCKeyboardEmu::GCKeyboardEmu(MappingWindow* window) : MappingWidget(window)
+{
+  Keyboard::Initialize();
+
+  CreateMainLayout();
+}
+
+void GCKeyboardEmu::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  m_main_layout->addWidget(
+      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb0x)));
+  m_main_layout->addWidget(
+      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb1x)));
+  m_main_layout->addWidget(
+      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb2x)));
+  m_main_layout->addWidget(
+      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb3x)));
+  m_main_layout->addWidget(
+      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb4x)));
+
+  auto* vbox_layout = new QVBoxLayout();
+  auto* options_box =
+      CreateGroupBox(tr("Options"), Keyboard::GetGroup(GetPort(), KeyboardGroup::Options));
+
+  options_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+  vbox_layout->addWidget(
+      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb5x)));
+  vbox_layout->addWidget(options_box);
+
+  m_main_layout->addLayout(vbox_layout);
+
+  setLayout(m_main_layout);
+}
+
+void GCKeyboardEmu::LoadSettings()
+{
+  Keyboard::LoadConfig();
+}
+
+void GCKeyboardEmu::SaveSettings()
+{
+  Keyboard::GetConfig()->SaveConfig();
+}
+
+InputConfig* GCKeyboardEmu::GetConfig()
+{
+  return Keyboard::GetConfig();
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/GCKeyboardEmu.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCKeyboardEmu.h
@@ -1,0 +1,34 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+
+class QCheckBox;
+class QFormLayout;
+class QGroupBox;
+class QHBoxLayout;
+class QLabel;
+class QVBoxLayout;
+
+class GCKeyboardEmu final : public MappingWidget
+{
+public:
+  explicit GCKeyboardEmu(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateButtonsLayout();
+  void CreateControlstickLayout();
+  void CreateCStickLayout();
+  void CreateTriggersLayout();
+  void CreateDPadLayout();
+  void CreateMainLayout();
+  void ConnectWidgets();
+
+  // Main
+  QHBoxLayout* m_main_layout;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
@@ -1,0 +1,58 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include "DolphinQt2/Config/Mapping/GCPadEmu.h"
+#include "InputCommon/InputConfig.h"
+
+#include "Core/HW/GCPad.h"
+#include "Core/HW/GCPadEmu.h"
+
+GCPadEmu::GCPadEmu(MappingWindow* window) : MappingWidget(window)
+{
+  Pad::Initialize();
+
+  CreateMainLayout();
+}
+
+void GCPadEmu::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  auto* hbox_layout = new QVBoxLayout();
+
+  hbox_layout->addWidget(
+      CreateGroupBox(tr("Triggers"), Pad::GetGroup(GetPort(), PadGroup::Triggers)));
+  hbox_layout->addWidget(CreateGroupBox(tr("Rumble"), Pad::GetGroup(GetPort(), PadGroup::Rumble)));
+
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("Buttons"), Pad::GetGroup(GetPort(), PadGroup::Buttons)));
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("Control Stick"), Pad::GetGroup(GetPort(), PadGroup::MainStick)));
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("C-Stick"), Pad::GetGroup(GetPort(), PadGroup::CStick)));
+  m_main_layout->addWidget(CreateGroupBox(tr("D-Pad"), Pad::GetGroup(GetPort(), PadGroup::DPad)));
+  m_main_layout->addItem(hbox_layout);
+
+  setLayout(m_main_layout);
+}
+
+void GCPadEmu::LoadSettings()
+{
+  Pad::LoadConfig();
+}
+
+void GCPadEmu::SaveSettings()
+{
+  Pad::GetConfig()->SaveConfig();
+}
+
+InputConfig* GCPadEmu::GetConfig()
+{
+  return Pad::GetConfig();
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.h
@@ -1,0 +1,54 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+
+class QCheckBox;
+class QFormLayout;
+class QGroupBox;
+class QHBoxLayout;
+class QLabel;
+class QVBoxLayout;
+
+class GCPadEmu final : public MappingWidget
+{
+public:
+  explicit GCPadEmu(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateButtonsLayout();
+  void CreateControlstickLayout();
+  void CreateCStickLayout();
+  void CreateTriggersLayout();
+  void CreateDPadLayout();
+  void CreateMainLayout();
+  void ConnectWidgets();
+
+  // Main
+  QHBoxLayout* m_main_layout;
+
+  // Buttons
+  QGroupBox* m_buttons_box;
+  QFormLayout* m_buttons_layout;
+
+  // Control Stick
+  QGroupBox* m_controlstick_box;
+  QFormLayout* m_controlstick_layout;
+
+  // C Stick
+  QGroupBox* m_cstick_box;
+  QFormLayout* m_cstick_layout;
+
+  // Triggers
+  QGroupBox* m_triggers_box;
+  QFormLayout* m_triggers_layout;
+
+  // D-Pad
+  QGroupBox* m_dpad_box;
+  QFormLayout* m_dpad_layout;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.cpp
@@ -1,0 +1,64 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QCheckBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+#include "DolphinQt2/Config/Mapping/GCPadWiiU.h"
+
+#include "DolphinQt2/Settings.h"
+#include "InputCommon/GCAdapter.h"
+
+GCPadWiiU::GCPadWiiU(MappingWindow* window) : MappingWidget(window)
+{
+  CreateLayout();
+  ConnectWidgets();
+
+  LoadSettings();
+}
+
+void GCPadWiiU::CreateLayout()
+{
+  const bool detected = GCAdapter::IsDetected();
+  m_layout = new QVBoxLayout();
+  m_status_label = new QLabel(detected ? tr("Adapter Detected") : tr("No Adapter Detected"));
+  m_rumble = new QCheckBox(tr("Enable Rumble"));
+  m_simulate_bongos = new QCheckBox(tr("Simulate DK Bongos"));
+
+  m_layout->addWidget(m_status_label);
+  m_layout->addWidget(m_rumble);
+  m_layout->addWidget(m_simulate_bongos);
+
+  if (!detected)
+  {
+    m_rumble->setEnabled(false);
+    m_simulate_bongos->setEnabled(false);
+  }
+
+  setLayout(m_layout);
+}
+
+void GCPadWiiU::ConnectWidgets()
+{
+  connect(m_rumble, &QCheckBox::toggled, this, &GCPadWiiU::SaveSettings);
+  connect(m_simulate_bongos, &QCheckBox::toggled, this, &GCPadWiiU::SaveSettings);
+}
+
+void GCPadWiiU::LoadSettings()
+{
+  m_rumble->setChecked(Settings().IsGCAdapterRumbleEnabled(GetPort()));
+  m_simulate_bongos->setChecked(Settings().IsGCAdapterSimulatingDKBongos(GetPort()));
+}
+
+void GCPadWiiU::SaveSettings()
+{
+  Settings().SetGCAdapterRumbleEnabled(GetPort(), m_rumble->isChecked());
+  Settings().SetGCAdapterSimulatingDKBongos(GetPort(), m_simulate_bongos->isChecked());
+}
+
+InputConfig* GCPadWiiU::GetConfig()
+{
+  return nullptr;
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.h
@@ -1,0 +1,31 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+
+class QCheckBox;
+class QLabel;
+class QVBoxLayout;
+
+class GCPadWiiU final : public MappingWidget
+{
+public:
+  explicit GCPadWiiU(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+
+  void CreateLayout();
+  void ConnectWidgets();
+
+  QVBoxLayout* m_layout;
+  QLabel* m_status_label;
+
+  // Checkboxes
+  QCheckBox* m_rumble;
+  QCheckBox* m_simulate_bongos;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingBool.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingBool.cpp
@@ -1,0 +1,35 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingBool.h"
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+#include "InputCommon/ControllerEmu/Setting/BooleanSetting.h"
+
+MappingBool::MappingBool(MappingWidget* widget, ControllerEmu::BooleanSetting* setting)
+    : QCheckBox(QString::fromStdString(setting->m_ui_name)), m_parent(widget), m_setting(setting)
+{
+  setChecked(setting->GetValue());
+  Connect();
+}
+
+void MappingBool::Connect()
+{
+  connect(this, &QCheckBox::stateChanged, this, [this](int value) {
+    m_setting->SetValue(value);
+    Update();
+  });
+}
+
+void MappingBool::Clear()
+{
+  setChecked(false);
+  Update();
+}
+
+void MappingBool::Update()
+{
+  setChecked(m_setting->GetValue());
+  m_parent->SaveSettings();
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingBool.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingBool.h
@@ -1,0 +1,30 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QCheckBox>
+
+class MappingWidget;
+
+namespace ControllerEmu
+{
+class BooleanSetting;
+};
+
+class MappingBool : public QCheckBox
+{
+public:
+  MappingBool(MappingWidget* widget, ControllerEmu::BooleanSetting* setting);
+
+  void Clear();
+  void Update();
+
+private:
+  void Connect();
+
+  MappingWidget* m_parent;
+  ControllerEmu::BooleanSetting* m_setting;
+  double m_range;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -1,0 +1,162 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QMouseEvent>
+#include <QRegExp>
+#include <QString>
+#include <thread>
+
+#include "DolphinQt2/Config/Mapping/MappingButton.h"
+
+#include "Common/Thread.h"
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+#include "DolphinQt2/Config/Mapping/MappingWindow.h"
+#include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+
+MappingButton::MappingButton(MappingWidget* widget, ControlReference* ref)
+    : QPushButton(QString::fromStdString(ref->expression)), m_parent(widget), m_reference(ref)
+{
+  setText(QString::fromStdString(m_reference->expression));
+  Connect();
+}
+
+void MappingButton::Connect()
+{
+  connect(this, &MappingButton::clicked, this, &MappingButton::OnButtonPressed);
+}
+
+static QString
+GetExpressionForControl(const QString& control_name,
+                        const ciface::Core::DeviceQualifier* control_device = nullptr,
+                        const ciface::Core::DeviceQualifier* default_device = nullptr)
+{
+  QString expr;
+
+  // non-default device
+  if (control_device && default_device && !(*control_device == *default_device))
+  {
+    expr += QString::fromStdString(control_device->ToString());
+    expr += QStringLiteral(":");
+  }
+
+  // append the control name
+  expr += control_name;
+
+  QRegExp reg(QStringLiteral("[a-zA-Z0-9_]*"));
+  if (!reg.exactMatch(expr))
+    expr = QStringLiteral("`%1`").arg(expr);
+
+  return expr;
+}
+
+void MappingButton::OnButtonPressed()
+{
+  if (m_block)
+    return;
+
+  // Make sure that we don't block event handling
+  std::thread([this] {
+    if (m_reference->IsInput())
+    {
+      const auto dev = m_parent->GetDevice();
+
+      setText(QStringLiteral("..."));
+
+      Common::SleepCurrentThread(100);
+
+      SetBlockInputs(true);
+
+      if (m_parent->GetFirstButtonPress())
+        m_reference->Detect(10, dev.get());
+
+      // Avoid that the button press itself is registered as an event
+      Common::SleepCurrentThread(100);
+
+      ciface::Core::Device::Control* const ctrl = m_reference->Detect(5000, dev.get());
+
+      SetBlockInputs(false);
+      if (ctrl)
+      {
+        m_reference->expression =
+            GetExpressionForControl(QString::fromStdString(ctrl->GetName())).toStdString();
+        Update();
+      }
+      else
+      {
+        OnButtonTimeout();
+      }
+    }
+    else
+    {
+      // TODO: Implement Output
+    }
+  }).detach();
+}
+
+void MappingButton::OnButtonTimeout()
+{
+  setText(QStringLiteral(""));
+}
+
+void MappingButton::Clear()
+{
+  m_reference->expression.clear();
+  Update();
+}
+
+void MappingButton::Update()
+{
+  const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+  m_reference->UpdateReference(g_controller_interface, m_parent->GetParent()->GetDeviceQualifier());
+  setText(QString::fromStdString(m_reference->expression));
+  m_parent->SaveSettings();
+}
+
+void MappingButton::SetBlockInputs(const bool block)
+{
+  m_parent->SetBlockInputs(block);
+  m_block = block;
+}
+
+void MappingWindow::OnDefaultFieldsPressed()
+{
+  if (m_controller == nullptr)
+    return;
+
+  m_controller->LoadDefaults(g_controller_interface);
+  m_controller->UpdateReferences(g_controller_interface);
+  emit Update();
+}
+
+bool MappingButton::event(QEvent* event)
+{
+  return !m_block ? QPushButton::event(event) : true;
+}
+
+void MappingButton::mouseReleaseEvent(QMouseEvent* event)
+{
+  if (m_reference->IsInput())
+  {
+    switch (event->button())
+    {
+    case Qt::MouseButton::LeftButton:
+      QPushButton::mouseReleaseEvent(event);
+      break;
+    case Qt::MouseButton::MiddleButton:
+      Clear();
+      break;
+    case Qt::MouseButton::RightButton:
+      // TODO Open advanced dialog
+      break;
+    default:
+      break;
+    }
+  }
+  else
+  {
+    // TODO Open output dialog
+  }
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
@@ -1,0 +1,36 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QPoint>
+#include <QPushButton>
+#include <QString>
+
+class ControlReference;
+class MappingWidget;
+class QEvent;
+class QMouseEvent;
+
+class MappingButton : public QPushButton
+{
+public:
+  MappingButton(MappingWidget* widget, ControlReference* ref);
+
+  void Clear();
+  void Update();
+
+private:
+  bool event(QEvent* event) override;
+  void mouseReleaseEvent(QMouseEvent* event) override;
+
+  void OnButtonPressed();
+  void OnButtonTimeout();
+  void Connect();
+  void SetBlockInputs(const bool block);
+
+  MappingWidget* m_parent;
+  ControlReference* m_reference;
+  bool m_block = false;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingNumeric.cpp
@@ -1,0 +1,37 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingNumeric.h"
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
+
+MappingNumeric::MappingNumeric(MappingWidget* widget, ControllerEmu::NumericSetting* setting)
+    : m_parent(widget), m_setting(setting), m_range(setting->m_high - setting->m_low)
+{
+  setValue(setting->GetValue() * m_range);
+  setRange(setting->m_low, setting->m_high);
+  Connect();
+}
+
+void MappingNumeric::Connect()
+{
+  connect(this, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          [this](int value) {
+            m_setting->SetValue(static_cast<double>(value) / m_range);
+            Update();
+          });
+}
+
+void MappingNumeric::Clear()
+{
+  setValue((m_setting->m_low + m_setting->m_high) / 2);
+  Update();
+}
+
+void MappingNumeric::Update()
+{
+  setValue(m_setting->GetValue() * m_range);
+  m_parent->SaveSettings();
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingNumeric.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingNumeric.h
@@ -1,0 +1,31 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QSpinBox>
+#include <QString>
+
+class MappingWidget;
+
+namespace ControllerEmu
+{
+class NumericSetting;
+};
+
+class MappingNumeric : public QSpinBox
+{
+public:
+  MappingNumeric(MappingWidget* widget, ControllerEmu::NumericSetting* ref);
+
+  void Clear();
+  void Update();
+
+private:
+  void Connect();
+
+  MappingWidget* m_parent;
+  ControllerEmu::NumericSetting* m_setting;
+  double m_range;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.cpp
@@ -1,0 +1,109 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QPushButton>
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+
+#include "DolphinQt2/Config/Mapping/MappingBool.h"
+#include "DolphinQt2/Config/Mapping/MappingButton.h"
+#include "DolphinQt2/Config/Mapping/MappingNumeric.h"
+#include "DolphinQt2/Config/Mapping/MappingWindow.h"
+#include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/Setting/BooleanSetting.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
+
+MappingWidget::MappingWidget(MappingWindow* window) : m_parent(window)
+{
+  connect(window, &MappingWindow::ClearFields, this, &MappingWidget::OnClearFields);
+  connect(window, &MappingWindow::Update, this, &MappingWidget::Update);
+}
+
+MappingWindow* MappingWidget::GetParent() const
+{
+  return m_parent;
+}
+
+std::shared_ptr<ciface::Core::Device> MappingWidget::GetDevice() const
+{
+  return m_parent->GetDevice();
+}
+
+int MappingWidget::GetPort() const
+{
+  return m_parent->GetPort();
+}
+
+QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group)
+{
+  QGroupBox* group_box = new QGroupBox(name);
+  QFormLayout* form_layout = new QFormLayout();
+
+  group_box->setLayout(form_layout);
+
+  for (auto& control : group->controls)
+  {
+    auto* button = new MappingButton(this, control->control_ref.get());
+    button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    form_layout->addRow(QString::fromStdString(control->name), button);
+    m_buttons.push_back(button);
+  }
+
+  for (auto& numeric : group->numeric_settings)
+  {
+    auto* spinbox = new MappingNumeric(this, numeric.get());
+    spinbox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    form_layout->addRow(QString::fromStdString(numeric->m_name), spinbox);
+    m_numerics.push_back(spinbox);
+  }
+
+  for (auto& boolean : group->boolean_settings)
+  {
+    auto* checkbox = new MappingBool(this, boolean.get());
+    checkbox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    form_layout->addRow(checkbox);
+    m_bools.push_back(checkbox);
+  }
+
+  return group_box;
+}
+
+void MappingWidget::SetBlockInputs(const bool block)
+{
+  m_parent->SetBlockInputs(block);
+}
+
+void MappingWidget::OnClearFields()
+{
+  for (auto* button : m_buttons)
+    button->Clear();
+}
+
+void MappingWidget::Update()
+{
+  for (auto* button : m_buttons)
+    button->Update();
+
+  for (auto* spinbox : m_numerics)
+    spinbox->Update();
+
+  for (auto* checkbox : m_numerics)
+    checkbox->Update();
+
+  LoadSettings();
+}
+
+bool MappingWidget::GetFirstButtonPress()
+{
+  if (m_first)
+  {
+    m_first = false;
+    return true;
+  }
+  return false;
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.h
@@ -1,0 +1,65 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <QString>
+#include <QWidget>
+
+class ControlGroupBox;
+class InputConfig;
+class MappingBool;
+class MappingButton;
+class MappingNumeric;
+class MappingWindow;
+class QGroupBox;
+
+namespace ControllerEmu
+{
+class Control;
+class ControlGroup;
+}
+
+namespace ciface
+{
+namespace Core
+{
+class Device;
+}
+}
+
+class MappingWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit MappingWidget(MappingWindow* window);
+
+  std::shared_ptr<ciface::Core::Device> GetDevice() const;
+
+  void SetBlockInputs(const bool block);
+  MappingWindow* GetParent() const;
+
+  virtual void LoadSettings() = 0;
+  virtual void SaveSettings() = 0;
+  virtual InputConfig* GetConfig() = 0;
+
+  void Update();
+  bool GetFirstButtonPress();
+
+protected:
+  int GetPort() const;
+  QGroupBox* CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group);
+
+private:
+  void OnClearFields();
+
+  MappingWindow* m_parent;
+  bool m_first = true;
+  std::vector<MappingBool*> m_bools;
+  std::vector<MappingButton*> m_buttons;
+  std::vector<MappingNumeric*> m_numerics;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -1,0 +1,354 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include "DolphinQt2/Config/Mapping/MappingWindow.h"
+
+#include "Common/FileUtil.h"
+#include "Common/IniFile.h"
+#include "Core/Core.h"
+#include "Core/HW/GCPad.h"
+#include "DolphinQt2/Config/Mapping/GCKeyboardEmu.h"
+#include "DolphinQt2/Config/Mapping/GCPadEmu.h"
+#include "DolphinQt2/Config/Mapping/GCPadWiiU.h"
+#include "DolphinQt2/Config/Mapping/WiimoteEmuExtension.h"
+#include "DolphinQt2/Config/Mapping/WiimoteEmuGeneral.h"
+#include "DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.h"
+#include "DolphinQt2/Settings.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "InputCommon/ControllerInterface/Device.h"
+#include "InputCommon/InputConfig.h"
+
+MappingWindow::MappingWindow(QWidget* parent, int port_num) : QDialog(parent), m_port(port_num)
+{
+  setWindowTitle(tr("Port %1").arg(port_num + 1));
+
+  CreateDevicesLayout();
+  CreateProfilesLayout();
+  CreateResetLayout();
+  CreateMainLayout();
+  ConnectWidgets();
+
+  g_controller_interface.Initialize(reinterpret_cast<void*>(winId()));
+}
+
+void MappingWindow::CreateDevicesLayout()
+{
+  m_devices_layout = new QHBoxLayout();
+  m_devices_box = new QGroupBox(tr("Devices"));
+  m_devices_combo = new QComboBox();
+  m_devices_refresh = new QPushButton(tr("Refresh"));
+
+  m_devices_refresh->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  m_devices_layout->addWidget(m_devices_combo);
+  m_devices_layout->addWidget(m_devices_refresh);
+
+  m_devices_box->setLayout(m_devices_layout);
+}
+
+void MappingWindow::CreateProfilesLayout()
+{
+  m_profiles_layout = new QVBoxLayout();
+  m_profiles_box = new QGroupBox(tr("Profiles"));
+  m_profiles_combo = new QComboBox();
+  m_profiles_load = new QPushButton(tr("Load"));
+  m_profiles_save = new QPushButton(tr("Save"));
+  m_profiles_delete = new QPushButton(tr("Delete"));
+
+  auto* button_layout = new QHBoxLayout();
+
+  m_profiles_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  m_profiles_combo->setEditable(true);
+
+  m_profiles_layout->addWidget(m_profiles_combo);
+  button_layout->addWidget(m_profiles_load);
+  button_layout->addWidget(m_profiles_save);
+  button_layout->addWidget(m_profiles_delete);
+  m_profiles_layout->addItem(button_layout);
+
+  m_profiles_box->setLayout(m_profiles_layout);
+}
+
+void MappingWindow::CreateResetLayout()
+{
+  m_reset_layout = new QVBoxLayout();
+  m_reset_box = new QGroupBox(tr("Reset"));
+  m_reset_clear = new QPushButton(tr("Clear"));
+  m_reset_default = new QPushButton(tr("Default"));
+
+  m_reset_box->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+  m_reset_layout->addWidget(m_reset_clear);
+  m_reset_layout->addWidget(m_reset_default);
+
+  m_reset_box->setLayout(m_reset_layout);
+}
+
+void MappingWindow::CreateMainLayout()
+{
+  m_main_layout = new QVBoxLayout();
+  m_config_layout = new QHBoxLayout();
+  m_tab_widget = new QTabWidget();
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
+
+  m_config_layout->addWidget(m_profiles_box);
+  m_config_layout->addWidget(m_reset_box);
+
+  m_main_layout->addWidget(m_devices_box);
+  m_main_layout->addItem(m_config_layout);
+  m_main_layout->addWidget(m_tab_widget);
+  m_main_layout->addWidget(m_button_box);
+
+  setLayout(m_main_layout);
+}
+
+void MappingWindow::ConnectWidgets()
+{
+  connect(m_devices_refresh, &QPushButton::clicked, this, &MappingWindow::RefreshDevices);
+  connect(m_devices_combo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          this, &MappingWindow::OnDeviceChanged);
+  connect(m_reset_clear, &QPushButton::clicked, this, [this] { emit ClearFields(); });
+  connect(m_reset_default, &QPushButton::clicked, this, &MappingWindow::OnDefaultFieldsPressed);
+  connect(m_profiles_save, &QPushButton::clicked, this, &MappingWindow::OnSaveProfilePressed);
+  connect(m_profiles_load, &QPushButton::clicked, this, &MappingWindow::OnLoadProfilePressed);
+  connect(m_profiles_delete, &QPushButton::clicked, this, &MappingWindow::OnDeleteProfilePressed);
+  connect(m_button_box, &QDialogButtonBox::accepted, this, &MappingWindow::accept);
+}
+
+void MappingWindow::OnDeleteProfilePressed()
+{
+  const QString profile_name = m_profiles_combo->currentText();
+  if (!Settings().GetProfiles(m_config).contains(profile_name))
+  {
+    QMessageBox error;
+    error.setIcon(QMessageBox::Critical);
+    error.setText(tr("The profile '%1' does not exist").arg(profile_name));
+
+    error.exec();
+    return;
+  }
+
+  QMessageBox confirm(this);
+
+  confirm.setIcon(QMessageBox::Warning);
+  confirm.setText(tr("Are you sure that you want to delete '%1'?").arg(profile_name));
+  confirm.setInformativeText(tr("This cannot be undone!"));
+  confirm.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+
+  if (confirm.exec() != QMessageBox::Yes)
+  {
+    return;
+  }
+
+  m_profiles_combo->removeItem(m_profiles_combo->currentIndex());
+
+  QMessageBox result(this);
+
+  std::string profile_path = Settings().GetProfileINIPath(m_config, profile_name).toStdString();
+
+  File::CreateFullPath(profile_path);
+
+  File::Delete(profile_path);
+
+  result.setIcon(QMessageBox::Information);
+  result.setText(tr("Successfully deleted '%1'.").arg(profile_name));
+}
+
+void MappingWindow::OnLoadProfilePressed()
+{
+  const QString profile_name = m_profiles_combo->currentText();
+
+  if (profile_name.isEmpty())
+    return;
+
+  std::string profile_path = Settings().GetProfileINIPath(m_config, profile_name).toStdString();
+
+  File::CreateFullPath(profile_path);
+
+  IniFile ini;
+  ini.Load(profile_path);
+
+  m_controller->LoadConfig(ini.GetOrCreateSection("Profile"));
+  m_controller->UpdateReferences(g_controller_interface);
+
+  emit Update();
+
+  RefreshDevices();
+}
+
+void MappingWindow::OnSaveProfilePressed()
+{
+  const QString profile_name = m_profiles_combo->currentText();
+
+  if (profile_name.isEmpty())
+    return;
+
+  std::string profile_path = Settings().GetProfileINIPath(m_config, profile_name).toStdString();
+
+  File::CreateFullPath(profile_path);
+
+  IniFile ini;
+
+  m_controller->SaveConfig(ini.GetOrCreateSection("Profile"));
+  ini.Save(profile_path);
+
+  if (m_profiles_combo->currentIndex() == 0)
+  {
+    m_profiles_combo->addItem(profile_name);
+    m_profiles_combo->setCurrentIndex(m_profiles_combo->count() - 1);
+  }
+}
+
+void MappingWindow::OnDeviceChanged(int index)
+{
+  m_devq.FromString(m_devices_combo->currentText().toStdString());
+}
+
+void MappingWindow::RefreshDevices()
+{
+  m_devices_combo->clear();
+
+  const bool paused = Core::PauseAndLock(true);
+
+  g_controller_interface.RefreshDevices();
+  m_controller->UpdateReferences(g_controller_interface);
+  m_controller->UpdateDefaultDevice();
+
+  const auto default_device = m_controller->default_device.ToString();
+
+  m_devices_combo->addItem(QString::fromStdString(default_device));
+
+  for (const auto& name : g_controller_interface.GetAllDeviceStrings())
+  {
+    if (name != default_device)
+      m_devices_combo->addItem(QString::fromStdString(name));
+  }
+
+  Core::PauseAndLock(false, paused);
+}
+
+void MappingWindow::ChangeMappingType(MappingWindow::Type type)
+{
+  if (m_mapping_type == type)
+    return;
+
+  ClearWidgets();
+
+  m_controller = nullptr;
+
+  MappingWidget* widget;
+
+  switch (type)
+  {
+  case Type::MAPPING_GC_KEYBOARD:
+    widget = new GCKeyboardEmu(this);
+    AddWidget(tr("GameCube Keyboard"), widget);
+    setWindowTitle(tr("GameCube Keyboard at Port %1").arg(GetPort() + 1));
+    break;
+  case Type::MAPPING_GC_BONGOS:
+  case Type::MAPPING_GC_STEERINGWHEEL:
+  case Type::MAPPING_GC_DANCEMAT:
+  case Type::MAPPING_GCPAD:
+    widget = new GCPadEmu(this);
+    setWindowTitle(tr("GameCube Controller at Port %1").arg(GetPort() + 1));
+    AddWidget(tr("GameCube Controller"), widget);
+    break;
+  case Type::MAPPING_GCPAD_WIIU:
+    widget = new GCPadWiiU(this);
+    setWindowTitle(tr("GameCube Adapter for Wii U at Port %1").arg(GetPort() + 1));
+    AddWidget(tr("GameCube Adapter for Wii U"), widget);
+    break;
+  case Type::MAPPING_WIIMOTE_EMU:
+  case Type::MAPPING_WIIMOTE_HYBRID:
+  {
+    auto* extension = new WiimoteEmuExtension(this);
+    widget = new WiimoteEmuGeneral(this, extension);
+    setWindowTitle(tr("Wii Remote at Port %1").arg(GetPort() + 1));
+    AddWidget(tr("General and Options"), widget);
+    AddWidget(tr("Motion Controls and IR"), new WiimoteEmuMotionControl(this));
+    AddWidget(tr("Extension"), extension);
+    break;
+  }
+  default:
+    return;
+  }
+
+  widget->LoadSettings();
+
+  m_profiles_combo->clear();
+
+  m_config = widget->GetConfig();
+
+  if (m_config)
+  {
+    m_controller = m_config->GetController(GetPort());
+
+    m_profiles_combo->addItem(QStringLiteral(""));
+    for (const auto& item : Settings().GetProfiles(m_config))
+      m_profiles_combo->addItem(item);
+  }
+
+  SetLayoutComplex(type != Type::MAPPING_GCPAD_WIIU);
+
+  if (m_controller != nullptr)
+    RefreshDevices();
+
+  m_mapping_type = type;
+}
+
+void MappingWindow::ClearWidgets()
+{
+  m_tab_widget->clear();
+}
+
+void MappingWindow::AddWidget(const QString& name, QWidget* widget)
+{
+  m_tab_widget->addTab(widget, name);
+}
+
+void MappingWindow::SetLayoutComplex(bool is_complex)
+{
+  m_reset_box->setHidden(!is_complex);
+  m_profiles_box->setHidden(!is_complex);
+  m_devices_box->setHidden(!is_complex);
+
+  m_is_complex = is_complex;
+}
+
+int MappingWindow::GetPort() const
+{
+  return m_port;
+}
+
+const ciface::Core::DeviceQualifier& MappingWindow::GetDeviceQualifier() const
+{
+  return m_devq;
+}
+
+std::shared_ptr<ciface::Core::Device> MappingWindow::GetDevice() const
+{
+  return g_controller_interface.FindDevice(m_devq);
+}
+
+void MappingWindow::SetBlockInputs(const bool block)
+{
+  m_block = block;
+}
+
+bool MappingWindow::event(QEvent* event)
+{
+  if (!m_block)
+    return QDialog::event(event);
+
+  return false;
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
@@ -1,0 +1,117 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QString>
+#include <memory>
+
+#include "InputCommon/ControllerInterface/Device.h"
+
+namespace ControllerEmu
+{
+class EmulatedController;
+}
+
+class InputConfig;
+class QComboBox;
+class QDialogButtonBox;
+class QEvent;
+class QHBoxLayout;
+class QGroupBox;
+class QVBoxLayout;
+class QPushButton;
+class QTabWidget;
+class QWidget;
+
+class MappingWindow final : public QDialog
+{
+  Q_OBJECT
+public:
+  enum class Type
+  {
+    // GameCube
+    MAPPING_GC_BONGOS,
+    MAPPING_GC_DANCEMAT,
+    MAPPING_GC_KEYBOARD,
+    MAPPING_GCPAD,
+    MAPPING_GCPAD_WIIU,
+    MAPPING_GC_STEERINGWHEEL,
+    // Wii
+    MAPPING_WIIMOTE_EMU,
+    MAPPING_WIIMOTE_HYBRID
+  };
+
+  explicit MappingWindow(QWidget* parent, int port_num);
+  void ChangeMappingType(Type type);
+
+  int GetPort() const;
+  const ciface::Core::DeviceQualifier& GetDeviceQualifier() const;
+  std::shared_ptr<ciface::Core::Device> GetDevice() const;
+
+  void SetBlockInputs(const bool block);
+signals:
+  void Update();
+  void ClearFields();
+
+private:
+  void CreateDevicesLayout();
+  void CreateProfilesLayout();
+  void CreateResetLayout();
+  void CreateMainLayout();
+  void ConnectWidgets();
+  void LoadSettings();
+
+  void SetLayoutComplex(bool is_complex);
+  void AddWidget(const QString& name, QWidget* widget);
+  void ClearWidgets();
+
+  void RefreshDevices();
+
+  void OnDeleteProfilePressed();
+  void OnLoadProfilePressed();
+  void OnSaveProfilePressed();
+  void OnDefaultFieldsPressed();
+  void OnProfileChanged(int index);
+  void OnDeviceChanged(int index);
+
+  bool event(QEvent* event) override;
+
+  ControllerEmu::EmulatedController* m_controller = nullptr;
+
+  // Main
+  QVBoxLayout* m_main_layout;
+  QHBoxLayout* m_config_layout;
+  QDialogButtonBox* m_button_box;
+
+  // Devices
+  QGroupBox* m_devices_box;
+  QHBoxLayout* m_devices_layout;
+  QComboBox* m_devices_combo;
+  QPushButton* m_devices_refresh;
+
+  // Profiles
+  QGroupBox* m_profiles_box;
+  QVBoxLayout* m_profiles_layout;
+  QComboBox* m_profiles_combo;
+  QPushButton* m_profiles_load;
+  QPushButton* m_profiles_save;
+  QPushButton* m_profiles_delete;
+
+  // Reset
+  QGroupBox* m_reset_box;
+  QVBoxLayout* m_reset_layout;
+  QPushButton* m_reset_default;
+  QPushButton* m_reset_clear;
+
+  QTabWidget* m_tab_widget;
+
+  Type m_mapping_type;
+  const int m_port;
+  bool m_is_complex;
+  bool m_block = false;
+  InputConfig* m_config;
+  ciface::Core::DeviceQualifier m_devq;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.cpp
@@ -1,0 +1,194 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+
+#include "DolphinQt2/Config/Mapping/WiimoteEmuExtension.h"
+
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "InputCommon/InputConfig.h"
+
+WiimoteEmuExtension::WiimoteEmuExtension(MappingWindow* window) : MappingWidget(window)
+{
+  Wiimote::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
+
+  CreateClassicLayout();
+  CreateDrumsLayout();
+  CreateGuitarLayout();
+  CreateNoneLayout();
+  CreateNunchukLayout();
+  CreateTurntableLayout();
+  CreateMainLayout();
+
+  ChangeExtensionType(Type::NONE);
+}
+
+void WiimoteEmuExtension::CreateClassicLayout()
+{
+  auto* hbox = new QHBoxLayout();
+  m_classic_box = new QGroupBox(tr("Classic Controller"), this);
+
+  hbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Buttons)));
+  hbox->addWidget(CreateGroupBox(
+      tr("Left Stick"), Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::LeftStick)));
+  hbox->addWidget(
+      CreateGroupBox(tr("Right Stick"),
+                     Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::RightStick)));
+
+  auto* vbox = new QVBoxLayout();
+  vbox->addWidget(CreateGroupBox(
+      tr("D-Pad"), Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::DPad)));
+  vbox->addWidget(CreateGroupBox(
+      tr("Triggers"), Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Triggers)));
+  hbox->addItem(vbox);
+
+  m_classic_box->setLayout(hbox);
+}
+
+void WiimoteEmuExtension::CreateDrumsLayout()
+{
+  auto* hbox = new QHBoxLayout();
+  m_drums_box = new QGroupBox(tr("Drums"), this);
+
+  hbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Buttons)));
+
+  auto* vbox = new QVBoxLayout();
+  vbox->addWidget(
+      CreateGroupBox(tr("Pads"), Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Pads)));
+  vbox->addWidget(CreateGroupBox(tr("Stick"),
+                                 Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Stick)));
+  hbox->addItem(vbox);
+
+  m_drums_box->setLayout(hbox);
+}
+
+void WiimoteEmuExtension::CreateNoneLayout()
+{
+  m_none_box = new QGroupBox(this);
+  auto* hbox = new QHBoxLayout();
+  auto* label = new QLabel(tr("No extension selected."));
+
+  label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  label->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+  hbox->addWidget(label);
+  m_none_box->setLayout(hbox);
+}
+
+void WiimoteEmuExtension::CreateNunchukLayout()
+{
+  auto* hbox = new QHBoxLayout();
+  m_nunchuk_box = new QGroupBox(tr("Nunchuk"), this);
+
+  hbox->addWidget(CreateGroupBox(
+      tr("Stick"), Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Stick)));
+  hbox->addWidget(CreateGroupBox(
+      tr("Tilt"), Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Tilt)));
+  hbox->addWidget(CreateGroupBox(
+      tr("Swing"), Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Swing)));
+
+  auto* vbox = new QVBoxLayout();
+  vbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Buttons)));
+  vbox->addWidget(CreateGroupBox(
+      tr("Shake"), Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Shake)));
+  hbox->addItem(vbox);
+
+  m_nunchuk_box->setLayout(hbox);
+}
+
+void WiimoteEmuExtension::CreateGuitarLayout()
+{
+  auto* hbox = new QHBoxLayout();
+  m_guitar_box = new QGroupBox(tr("Guitar"), this);
+
+  auto* vbox = new QVBoxLayout();
+  vbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Buttons)));
+  vbox->addWidget(CreateGroupBox(
+      tr("Stick"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Stick)));
+  hbox->addItem(vbox);
+
+  auto* vbox2 = new QVBoxLayout();
+  vbox2->addWidget(CreateGroupBox(
+      tr("Strum"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Strum)));
+  vbox2->addWidget(CreateGroupBox(
+      tr("Frets"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Frets)));
+  vbox2->addWidget(CreateGroupBox(
+      tr("Whammy"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Whammy)));
+  hbox->addItem(vbox2);
+
+  m_guitar_box->setLayout(hbox);
+}
+
+void WiimoteEmuExtension::CreateTurntableLayout()
+{
+  auto* hbox = new QHBoxLayout();
+  m_turntable_box = new QGroupBox(tr("Turntable"), this);
+
+  hbox->addWidget(CreateGroupBox(
+      tr("Stick"), Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Stick)));
+  hbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Buttons)));
+
+  auto* vbox = new QVBoxLayout();
+  vbox->addWidget(CreateGroupBox(
+      tr("Effect Dial"),
+      Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::EffectDial)));
+  vbox->addWidget(
+      CreateGroupBox(tr("Left Table"),
+                     Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::LeftTable)));
+  vbox->addWidget(CreateGroupBox(
+      tr("Right Table"),
+      Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::RightTable)));
+  vbox->addWidget(
+      CreateGroupBox(tr("Crossfade"),
+                     Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Crossfade)));
+  hbox->addItem(vbox);
+
+  m_turntable_box->setLayout(hbox);
+}
+
+void WiimoteEmuExtension::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  m_main_layout->addWidget(m_classic_box);
+  m_main_layout->addWidget(m_drums_box);
+  m_main_layout->addWidget(m_guitar_box);
+  m_main_layout->addWidget(m_none_box);
+  m_main_layout->addWidget(m_nunchuk_box);
+  m_main_layout->addWidget(m_turntable_box);
+
+  setLayout(m_main_layout);
+}
+
+void WiimoteEmuExtension::LoadSettings()
+{
+  Wiimote::LoadConfig();
+}
+
+void WiimoteEmuExtension::SaveSettings()
+{
+  Wiimote::GetConfig()->SaveConfig();
+}
+
+InputConfig* WiimoteEmuExtension::GetConfig()
+{
+  return Wiimote::GetConfig();
+}
+
+void WiimoteEmuExtension::ChangeExtensionType(WiimoteEmuExtension::Type type)
+{
+  m_classic_box->setHidden(type != Type::CLASSIC_CONTROLLER);
+  m_drums_box->setHidden(type != Type::DRUMS);
+  m_guitar_box->setHidden(type != Type::GUITAR);
+  m_none_box->setHidden(type != Type::NONE);
+  m_nunchuk_box->setHidden(type != Type::NUNCHUK);
+  m_turntable_box->setHidden(type != Type::TURNTABLE);
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.h
@@ -1,0 +1,49 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+
+class QGroupBox;
+class QHBoxLayout;
+
+class WiimoteEmuExtension final : public MappingWidget
+{
+public:
+  enum class Type
+  {
+    NONE,
+    CLASSIC_CONTROLLER,
+    DRUMS,
+    GUITAR,
+    NUNCHUK,
+    TURNTABLE
+  };
+
+  explicit WiimoteEmuExtension(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+  void ChangeExtensionType(Type type);
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+
+  void CreateClassicLayout();
+  void CreateDrumsLayout();
+  void CreateGuitarLayout();
+  void CreateNoneLayout();
+  void CreateNunchukLayout();
+  void CreateTurntableLayout();
+  void CreateMainLayout();
+
+  // Main
+  QHBoxLayout* m_main_layout;
+  QGroupBox* m_classic_box;
+  QGroupBox* m_drums_box;
+  QGroupBox* m_guitar_box;
+  QGroupBox* m_none_box;
+  QGroupBox* m_nunchuk_box;
+  QGroupBox* m_turntable_box;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -1,0 +1,112 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QComboBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include "DolphinQt2/Config/Mapping/WiimoteEmuGeneral.h"
+
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "DolphinQt2/Config/Mapping/WiimoteEmuExtension.h"
+#include "InputCommon/ControllerEmu/ControlGroup/Extension.h"
+#include "InputCommon/InputConfig.h"
+
+WiimoteEmuGeneral::WiimoteEmuGeneral(MappingWindow* window, WiimoteEmuExtension* extension)
+    : MappingWidget(window), m_extension_widget(extension)
+{
+  Wiimote::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
+
+  CreateMainLayout();
+  Connect();
+}
+
+void WiimoteEmuGeneral::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  auto* vbox_layout = new QVBoxLayout();
+
+  m_main_layout->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Buttons)));
+  m_main_layout->addWidget(CreateGroupBox(
+      tr("D-Pad"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::DPad)));
+  m_main_layout->addWidget(CreateGroupBox(
+      tr("Hotkeys"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Hotkeys)));
+
+  auto* extension_group = Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Extension);
+  auto* extension = CreateGroupBox(tr("Extension"), extension_group);
+  auto* ce_extension = static_cast<ControllerEmu::Extension*>(extension_group);
+  m_extension_combo = new QComboBox();
+
+  for (const auto& attachment : ce_extension->attachments)
+  {
+    // TODO: Figure out how to localize this
+    m_extension_combo->addItem(QString::fromStdString(attachment->GetName()));
+  }
+
+  extension->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+  static_cast<QFormLayout*>(extension->layout())->addRow(m_extension_combo);
+
+  vbox_layout->addWidget(extension);
+  vbox_layout->addWidget(CreateGroupBox(
+      tr("Rumble"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Rumble)));
+  vbox_layout->addWidget(CreateGroupBox(
+      tr("Options"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Options)));
+
+  m_main_layout->addItem(vbox_layout);
+
+  setLayout(m_main_layout);
+}
+
+void WiimoteEmuGeneral::Connect()
+{
+  connect(m_extension_combo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          this, &WiimoteEmuGeneral::OnAttachmentChanged);
+}
+
+void WiimoteEmuGeneral::OnAttachmentChanged(int extension)
+{
+  const QString value = m_extension_combo->currentText();
+
+  static const QMap<QString, WiimoteEmuExtension::Type> value_map = {
+      {QStringLiteral("None"), WiimoteEmuExtension::Type::NONE},
+      {QStringLiteral("Classic"), WiimoteEmuExtension::Type::CLASSIC_CONTROLLER},
+      {QStringLiteral("Drums"), WiimoteEmuExtension::Type::DRUMS},
+      {QStringLiteral("Guitar"), WiimoteEmuExtension::Type::GUITAR},
+      {QStringLiteral("Nunchuk"), WiimoteEmuExtension::Type::NUNCHUK},
+      {QStringLiteral("Turntable"), WiimoteEmuExtension::Type::TURNTABLE}};
+
+  m_extension_widget->ChangeExtensionType(value_map[value]);
+
+  auto* ce_extension = static_cast<ControllerEmu::Extension*>(
+      Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Extension));
+  ce_extension->switch_extension = extension;
+  SaveSettings();
+}
+
+void WiimoteEmuGeneral::LoadSettings()
+{
+  auto* ce_extension = static_cast<ControllerEmu::Extension*>(
+      Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Extension));
+
+  m_extension_combo->setCurrentIndex(ce_extension->switch_extension);
+  OnAttachmentChanged(ce_extension->switch_extension);
+
+  Wiimote::LoadConfig();
+}
+
+void WiimoteEmuGeneral::SaveSettings()
+{
+  Wiimote::GetConfig()->SaveConfig();
+}
+
+InputConfig* WiimoteEmuGeneral::GetConfig()
+{
+  return Wiimote::GetConfig();
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.h
@@ -1,0 +1,31 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+
+class QComboBox;
+class WiimoteEmuExtension;
+
+class WiimoteEmuGeneral final : public MappingWidget
+{
+public:
+  explicit WiimoteEmuGeneral(MappingWindow* window, WiimoteEmuExtension* extension);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateMainLayout();
+  void Connect();
+  void OnAttachmentChanged(int index);
+
+  // Main
+  QHBoxLayout* m_main_layout;
+
+  // Extensions
+  QComboBox* m_extension_combo;
+
+  WiimoteEmuExtension* m_extension_widget;
+};

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.cpp
@@ -1,0 +1,51 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include "DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.h"
+
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "InputCommon/InputConfig.h"
+
+WiimoteEmuMotionControl::WiimoteEmuMotionControl(MappingWindow* window) : MappingWidget(window)
+{
+  Wiimote::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
+  CreateMainLayout();
+}
+
+void WiimoteEmuMotionControl::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  m_main_layout->addWidget(CreateGroupBox(
+      tr("Shake"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Shake)));
+  m_main_layout->addWidget(CreateGroupBox(
+      tr("Shake"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::IR)));
+  m_main_layout->addWidget(CreateGroupBox(
+      tr("Shake"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Tilt)));
+  m_main_layout->addWidget(CreateGroupBox(
+      tr("Shake"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Swing)));
+
+  setLayout(m_main_layout);
+}
+
+void WiimoteEmuMotionControl::LoadSettings()
+{
+  Wiimote::LoadConfig();
+}
+
+void WiimoteEmuMotionControl::SaveSettings()
+{
+  Wiimote::GetConfig()->SaveConfig();
+}
+
+InputConfig* WiimoteEmuMotionControl::GetConfig()
+{
+  return Wiimote::GetConfig();
+}

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.h
@@ -1,0 +1,28 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+
+class QCheckBox;
+class QFormLayout;
+class QGroupBox;
+class QHBoxLayout;
+class QLabel;
+class QVBoxLayout;
+
+class WiimoteEmuMotionControl final : public MappingWidget
+{
+public:
+  explicit WiimoteEmuMotionControl(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateMainLayout();
+
+  // Main
+  QHBoxLayout* m_main_layout;
+};

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -56,7 +56,7 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/NODEFAULTLIB:libcmt</AdditionalOptions>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;$(ProjectDir)\GameList;$(ProjectDir)\Settings;$(ProjectDir)\Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;$(ProjectDir)\GameList;$(ProjectDir)\Settings;$(ProjectDir)\Config;$(ProjectDir)\Config\Mapping;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -83,6 +83,8 @@
     <QtMoc Include="AboutDialog.h" />
     <QtMoc Include="Config\ControllersWindow.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
+    <QtMoc Include="Config\Mapping\MappingWidget.h" />
+    <QtMoc Include="Config\Mapping\MappingWindow.h" />
     <QtMoc Include="Config\InfoWidget.h" />
     <QtMoc Include="Config\PathDialog.h" />
     <QtMoc Include="Config\PropertiesDialog.h" />
@@ -120,6 +122,8 @@
     <ClCompile Include="$(QtMocOutPrefix)InterfacePane.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ListProxyModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MainWindow.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)MappingWidget.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)MappingWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MenuBar.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)PathDialog.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)PropertiesDialog.cpp" />
@@ -133,6 +137,17 @@
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
     <ClCompile Include="Config\InfoWidget.cpp" />
+    <ClCompile Include="Config\Mapping\GCKeyboardEmu.cpp" />
+    <ClCompile Include="Config\Mapping\GCPadEmu.cpp" />
+    <ClCompile Include="Config\Mapping\GCPadWiiU.cpp" />
+    <ClCompile Include="Config\Mapping\MappingBool.cpp" />
+    <ClCompile Include="Config\Mapping\MappingButton.cpp" />
+    <ClCompile Include="Config\Mapping\MappingNumeric.cpp" />
+    <ClCompile Include="Config\Mapping\MappingWidget.cpp" />
+    <ClCompile Include="Config\Mapping\MappingWindow.cpp" />
+    <ClCompile Include="Config\Mapping\WiimoteEmuExtension.cpp" />
+    <ClCompile Include="Config\Mapping\WiimoteEmuGeneral.cpp" />
+    <ClCompile Include="Config\Mapping\WiimoteEmuMotionControl.cpp" />
     <ClCompile Include="Config\PathDialog.cpp" />
     <ClCompile Include="Config\PropertiesDialog.cpp" />
     <ClCompile Include="Config\SettingsWindow.cpp" />

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -5,9 +5,12 @@
 #include <QDir>
 #include <QSize>
 
+#include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
+#include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "DolphinQt2/Settings.h"
+#include "InputCommon/InputConfig.h"
 
 static QString GetSettingsPath()
 {
@@ -28,6 +31,17 @@ QString Settings::GetResourcesDir() const
 {
   return QString::fromStdString(File::GetSysDirectory().append("Resources"))
       .append(QDir::separator());
+}
+
+QString Settings::GetProfilesDir() const
+{
+  return QString::fromStdString(File::GetUserPath(D_CONFIG_IDX) + "Profiles/");
+}
+
+QString Settings::GetProfileINIPath(const InputConfig* config, const QString& name) const
+{
+  return GetProfilesDir() + QString::fromStdString(config->GetProfileName()) + QDir::separator() +
+         name + QStringLiteral(".ini");
 }
 
 bool Settings::IsInDevelopmentWarningEnabled() const
@@ -293,7 +307,42 @@ bool Settings::IsWiiGameRunning() const
   return SConfig::GetInstance().bWii;
 }
 
+bool Settings::IsGCAdapterRumbleEnabled(int port) const
+{
+  return SConfig::GetInstance().m_AdapterRumble[port];
+}
+
+void Settings::SetGCAdapterRumbleEnabled(int port, bool enabled)
+{
+  SConfig::GetInstance().m_AdapterRumble[port] = enabled;
+}
+
+bool Settings::IsGCAdapterSimulatingDKBongos(int port) const
+{
+  return SConfig::GetInstance().m_AdapterKonga[port];
+}
+
+void Settings::SetGCAdapterSimulatingDKBongos(int port, bool enabled)
+{
+  SConfig::GetInstance().m_AdapterKonga[port] = enabled;
+}
+
 void Settings::Save()
 {
   return SConfig::GetInstance().SaveSettings();
+}
+
+QVector<QString> Settings::GetProfiles(const InputConfig* config) const
+{
+  const std::string path = GetProfilesDir().toStdString() + config->GetProfileName();
+  QVector<QString> vec;
+
+  for (const auto& file : Common::DoFileSearch({".ini"}, {path}))
+  {
+    std::string basename;
+    SplitPath(file, nullptr, &basename, nullptr);
+    vec.push_back(QString::fromStdString(basename));
+  }
+
+  return vec;
 }

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QSettings>
+#include <QVector>
 
 #include "Core/HW/SI/SI.h"
 
@@ -12,6 +13,8 @@ namespace DiscIO
 {
 enum class Language;
 }
+
+class InputConfig;
 
 // UI settings to be stored in the config directory.
 class Settings final : public QSettings
@@ -24,6 +27,9 @@ public:
   // UI
   QString GetThemeDir() const;
   QString GetResourcesDir() const;
+  QString GetProfilesDir() const;
+  QVector<QString> GetProfiles(const InputConfig* config) const;
+  QString GetProfileINIPath(const InputConfig* config, const QString& name) const;
   bool IsInDevelopmentWarningEnabled() const;
 
   // GameList
@@ -91,6 +97,12 @@ public:
 
   bool IsContinuousScanningEnabled() const;
   void SetContinuousScanningEnabled(bool enabled);
+
+  bool IsGCAdapterRumbleEnabled(int port) const;
+  void SetGCAdapterRumbleEnabled(int port, bool enabled);
+
+  bool IsGCAdapterSimulatingDKBongos(int port) const;
+  void SetGCAdapterSimulatingDKBongos(int port, bool enabled);
 
   void Save();
 };


### PR DESCRIPTION
Features:
- Windows
  - GameCube
    - [x] Controller (Emulated)
    - [x] Controller (Passthrough)
    - [x] Keyboard
    - [x] Bongos
    - [x] Steering Wheel
    - [x] Dance Mat
  - Wii
    - [x] Emulated
    - [x] Hybrid
      - Extensions
        - [x] Nunchuck
        - [x] Classic Controller
        - [x] Guitar
        - [x] Drums
        - [x] Turntable
- Basics
  - [x] Load Settings
  - [x] Save Settings
  - [x] Configure Mappings
  - [x] Configure Checkboxes
  - [x] Configure Numbers
  - ~~Configure Outputs~~ (Separate PR)
- Dialogs
  - ~~Advanced Input Dialogs~~ (Separate PR)
  - ~~Output Configuration Dialogs~~ (Separate PR)
- Profiles
  - [x] Deleting
  - [x] Saving
  - [x] Loading
- Devices
  - [x] Changing devices
  - [x] Remembering default device

Screenshots (Outdated):
![GC Adapter](https://i.imgur.com/YLyaLvj.png)
![Emulated Wii Remote](https://i.imgur.com/r37YXgE.png)