### PR TITLE
Qt: Fix Interface Pane

### DIFF
--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -14,6 +14,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
+#include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 
 InterfacePane::InterfacePane(QWidget* parent) : QWidget(parent)


### PR DESCRIPTION
Fixes the Interface Pane not compiling under certain conditions.
