### PR TITLE
CodeView: Assemble menu item added

### DIFF
--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SRCS
   Config/InterfaceConfigPane.cpp
   Config/PathConfigPane.cpp
   Config/WiiConfigPane.cpp
+  Debugger/AssemblerEntryDialog.cpp
   Debugger/BreakpointDlg.cpp
   Debugger/BreakpointView.cpp
   Debugger/BreakpointWindow.cpp

--- a/Source/Core/DolphinWX/Debugger/AssemblerEntryDialog.cpp
+++ b/Source/Core/DolphinWX/Debugger/AssemblerEntryDialog.cpp
@@ -1,0 +1,90 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinWX/Debugger/AssemblerEntryDialog.h"
+
+#include <string>
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/utils.h>
+
+#include "Common/GekkoDisassembler.h"
+#include "Common/StringUtil.h"
+
+AssemblerEntryDialog::AssemblerEntryDialog(u32 address, wxWindow* parent, const wxString& message,
+                                           const wxString& caption, const wxString& value,
+                                           long style, const wxPoint& pos)
+    : m_address(address)
+{
+  Create(parent, message, caption, value, style, pos);
+}
+
+bool AssemblerEntryDialog::Create(wxWindow* parent, const wxString& message,
+                                  const wxString& caption, const wxString& value, long style,
+                                  const wxPoint& pos)
+{
+  // Do not pass style to GetParentForModalDialog() as wxDIALOG_NO_PARENT
+  // has the same numeric value as wxTE_MULTILINE and so attempting to create
+  // a dialog for editing multiline text would also prevent it from having a
+  // parent which is undesirable. As it is, we can't create a text entry
+  // dialog without a parent which is not ideal neither but is a much less
+  // important problem.
+  if (!wxDialog::Create(GetParentForModalDialog(parent, 0), wxID_ANY, caption, pos, wxDefaultSize,
+                        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER))
+  {
+    return false;
+  }
+
+  m_dialogStyle = style;
+  m_value = value;
+
+  wxBeginBusyCursor();
+
+  wxBoxSizer* top_sizer = new wxBoxSizer(wxVERTICAL);
+
+  // 1) text message
+  top_sizer->Add(CreateTextSizer(message), wxSizerFlags().DoubleBorder());
+
+  // 2) text ctrl
+  m_textctrl = new wxTextCtrl(this, 3000, value, wxDefaultPosition, wxSize(300, wxDefaultCoord),
+                              style & ~wxTextEntryDialogStyle);
+  m_textctrl->Bind(wxEVT_TEXT, &AssemblerEntryDialog::OnTextChanged, this);
+
+  top_sizer->Add(
+      m_textctrl,
+      wxSizerFlags(style & wxTE_MULTILINE ? 1 : 0).Expand().TripleBorder(wxLEFT | wxRIGHT));
+
+  m_preview = new wxStaticText(this, wxID_ANY, "");
+  top_sizer->Add(m_preview, wxSizerFlags().DoubleBorder(wxUP | wxLEFT | wxRIGHT));
+
+  wxSizer* button_sizer = CreateSeparatedButtonSizer(style & (wxOK | wxCANCEL));
+  if (button_sizer)
+    top_sizer->Add(button_sizer, wxSizerFlags().DoubleBorder().Expand());
+
+  SetAutoLayout(true);
+  SetSizer(top_sizer);
+
+  top_sizer->SetSizeHints(this);
+  top_sizer->Fit(this);
+
+  if (style & wxCENTRE)
+    Centre(wxBOTH);
+
+  m_textctrl->SelectAll();
+  m_textctrl->SetFocus();
+
+  wxEndBusyCursor();
+
+  return true;
+}
+
+void AssemblerEntryDialog::OnTextChanged(wxCommandEvent& evt)
+{
+  unsigned long code;
+  std::string result = "Input text is invalid";
+  if (evt.GetString().ToULong(&code, 0) && code <= std::numeric_limits<u32>::max())
+    result = TabsToSpaces(1, GekkoDisassembler::Disassemble(code, m_address));
+  m_preview->SetLabel(wxString::Format(_("Preview: %s"), result.c_str()));
+}

--- a/Source/Core/DolphinWX/Debugger/AssemblerEntryDialog.h
+++ b/Source/Core/DolphinWX/Debugger/AssemblerEntryDialog.h
@@ -1,0 +1,32 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <wx/textdlg.h>
+
+#include "Common/CommonTypes.h"
+
+class wxStaticText;
+
+class AssemblerEntryDialog : public wxTextEntryDialog
+{
+public:
+  AssemblerEntryDialog(u32 address, wxWindow* parent, const wxString& message,
+                       const wxString& caption = wxGetTextFromUserPromptStr,
+                       const wxString& value = wxEmptyString, long style = wxTextEntryDialogStyle,
+                       const wxPoint& pos = wxDefaultPosition);
+
+  bool Create(wxWindow* parent, const wxString& message,
+              const wxString& caption = wxGetTextFromUserPromptStr,
+              const wxString& value = wxEmptyString, long style = wxTextEntryDialogStyle,
+              const wxPoint& pos = wxDefaultPosition);
+
+protected:
+  u32 m_address;
+  wxStaticText* m_preview;
+
+private:
+  void OnTextChanged(wxCommandEvent& evt);
+};

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj
@@ -71,6 +71,7 @@
     <ClCompile Include="Config\InterfaceConfigPane.cpp" />
     <ClCompile Include="Config\PathConfigPane.cpp" />
     <ClCompile Include="Config\WiiConfigPane.cpp" />
+    <ClCompile Include="Debugger\AssemblerEntryDialog.cpp" />
     <ClCompile Include="Debugger\BreakpointDlg.cpp" />
     <ClCompile Include="Debugger\BreakpointView.cpp" />
     <ClCompile Include="Debugger\BreakpointWindow.cpp" />
@@ -163,6 +164,7 @@
     <ClInclude Include="Cheats\CreateCodeDialog.h" />
     <ClInclude Include="Cheats\GeckoCodeDiag.h" />
     <ClInclude Include="Config\ConfigMain.h" />
+    <ClInclude Include="Debugger\AssemblerEntryDialog.h" />
     <ClInclude Include="Debugger\BreakpointDlg.h" />
     <ClInclude Include="Debugger\BreakpointView.h" />
     <ClInclude Include="Debugger\BreakpointWindow.h" />

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClCompile Include="Cheats\GeckoCodeDiag.cpp">
       <Filter>GUI\Cheats</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\AssemblerEntryDialog.cpp">
+      <Filter>GUI\Debugger</Filter>
+    </ClCompile>
     <ClCompile Include="Debugger\BreakpointDlg.cpp">
       <Filter>GUI\Debugger</Filter>
     </ClCompile>
@@ -278,6 +281,9 @@
     </ClInclude>
     <ClInclude Include="Cheats\GeckoCodeDiag.h">
       <Filter>GUI\Cheats</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\AssemblerEntryDialog.h">
+      <Filter>GUI\Debugger</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\BreakpointDlg.h">
       <Filter>GUI\Debugger</Filter>


### PR DESCRIPTION
This PR adds a new menu item when right clicking on the code in the CodeView. Basically, it allows to patch an instruction if you specify another instruction code.

![image](https://cloud.githubusercontent.com/assets/7890055/26021385/e0c74b68-3783-11e7-86c3-5289b7e63e32.png)

That's not a true "Assembler" but at least it's a decent replacement before adding a Gecko assembler into Dolphin.

Ready to be reviewed & merged.