### PR TITLE
VS2017 build fix after upgrading project

### DIFF
--- a/Source/Core/VideoBackends/D3D12/D3DQueuedCommandList.h
+++ b/Source/Core/VideoBackends/D3D12/D3DQueuedCommandList.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <d3d12.h>
+#include <dxgi.h>
 #include <thread>
 
 namespace DX12


### PR DESCRIPTION
IDXGISwapChain was not declared which led to a cascade of build errors starting from line 210.