### PR TITLE
IOS: Fix AddCoreDevices being called twice

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -200,9 +200,12 @@ Kernel::~Kernel()
   Core::ShutdownWiiRoot();
 }
 
-EmulationKernel::EmulationKernel(u64 title_id)
+Kernel::Kernel(u64 title_id) : m_title_id(title_id)
 {
-  m_title_id = title_id;
+}
+
+EmulationKernel::EmulationKernel(u64 title_id) : Kernel(title_id)
+{
   INFO_LOG(IOS, "Starting IOS %016" PRIx64, title_id);
 
   if (!SetupMemory(title_id, MemorySetupType::IOSReload))

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -118,6 +118,8 @@ public:
   IOSC& GetIOSC();
 
 protected:
+  explicit Kernel(u64 title_id);
+
   void ExecuteIPCCommand(u32 address);
   IPCCommandResult HandleIPCCommand(const Request& request);
   void EnqueueIPCAcknowledgement(u32 address, int cycles_in_future = 0);


### PR DESCRIPTION
Also make sure m_title_id is set as soon as possible.