### PR TITLE
VideoConfig: Port to layered configuration system

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -91,6 +91,9 @@ void Save()
 
 void Init()
 {
+  // These layers contain temporary values
+  s_layers[LayerType::CommandLine] = std::make_unique<Layer>(LayerType::CommandLine);
+  ClearCurrentRunLayer();
   // This layer always has to exist
   s_layers[LayerType::Meta] = std::make_unique<RecursiveLayer>();
 }
@@ -99,6 +102,11 @@ void Shutdown()
 {
   s_layers.clear();
   s_callbacks.clear();
+}
+
+void ClearCurrentRunLayer()
+{
+  s_layers[LayerType::CurrentRun] = std::make_unique<Layer>(LayerType::CurrentRun);
 }
 
 static const std::map<System, std::string> system_to_name = {

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -40,6 +40,7 @@ void Save();
 
 void Init();
 void Shutdown();
+void ClearCurrentRunLayer();
 
 const std::string& GetSystemName(System system);
 System GetSystemFromName(const std::string& system);

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -38,22 +38,6 @@ void InvokeConfigChangedCallbacks();
 void Load();
 void Save();
 
-// Often used functions for getting or setting configuration on the base layer for the main system
-template <typename T>
-T Get(const std::string& section_name, const std::string& key, const T& default_value)
-{
-  auto base_layer = GetLayer(Config::LayerType::Base);
-  return base_layer->GetOrCreateSection(Config::System::Main, section_name)
-      ->Get(key, default_value);
-}
-
-template <typename T>
-void Set(const std::string& section_name, const std::string& key, const T& value)
-{
-  auto base_layer = GetLayer(Config::LayerType::Base);
-  base_layer->GetOrCreateSection(Config::System::Main, section_name)->Set(key, value);
-}
-
 void Init();
 void Shutdown();
 

--- a/Source/Core/Common/Config/Enums.h
+++ b/Source/Core/Common/Config/Enums.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+
 namespace Config
 {
 enum class LayerType
@@ -29,4 +31,10 @@ enum class System
   Debugger,
   UI,
 };
+
+constexpr std::array<LayerType, 7> SEARCH_ORDER{{
+    // Skip the meta layer
+    LayerType::CurrentRun, LayerType::CommandLine, LayerType::Movie, LayerType::Netplay,
+    LayerType::LocalGame, LayerType::GlobalGame, LayerType::Base,
+}};
 }

--- a/Source/Core/Common/Config/Section.cpp
+++ b/Source/Core/Common/Config/Section.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <array>
 #include <cstddef>
 #include <map>
 #include <memory>
@@ -254,13 +253,7 @@ bool RecursiveSection::Exists(const std::string& key) const
 bool RecursiveSection::Get(const std::string& key, std::string* value,
                            const std::string& default_value) const
 {
-  static constexpr std::array<LayerType, 7> search_order = {{
-      // Skip the meta layer
-      LayerType::CurrentRun, LayerType::CommandLine, LayerType::Movie, LayerType::Netplay,
-      LayerType::LocalGame, LayerType::GlobalGame, LayerType::Base,
-  }};
-
-  for (auto layer_id : search_order)
+  for (auto layer_id : SEARCH_ORDER)
   {
     auto layers_it = Config::GetLayers()->find(layer_id);
     if (layers_it == Config::GetLayers()->end())

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -24,12 +24,16 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/Config.h"
+#include "Core/ConfigLoaders/GameConfigLoader.h"
+#include "Core/ConfigLoaders/NetPlayConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/EXI/EXI.h"
@@ -238,6 +242,12 @@ bool BootCore(const std::string& filename, SConfig::EBootBS2 type)
   // Load game specific settings
   if (type == SConfig::BOOT_DEFAULT)
   {
+    std::string game_id = SConfig::GetInstance().GetGameID();
+    u16 revision = SConfig::GetInstance().GetRevision();
+
+    Config::AddLoadLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
+    Config::AddLoadLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
+
     IniFile game_ini = StartUp.LoadGameIni();
 
     // General settings
@@ -322,6 +332,7 @@ bool BootCore(const std::string& filename, SConfig::EBootBS2 type)
   // Movie settings
   if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
   {
+    Config::AddLayer(std::make_unique<Config::Layer>(Config::LayerType::Movie));
     StartUp.bCPUThread = Movie::IsDualCore();
     StartUp.bDSPHLE = Movie::IsDSPHLE();
     StartUp.bProgressive = Movie::IsProgressive();
@@ -347,6 +358,7 @@ bool BootCore(const std::string& filename, SConfig::EBootBS2 type)
 
   if (NetPlay::IsNetPlayRunning())
   {
+    Config::AddLoadLayer(ConfigLoaders::GenerateNetPlayConfigLoader(g_NetPlaySettings));
     StartUp.bCPUThread = g_NetPlaySettings.m_CPUthread;
     StartUp.bEnableCheats = g_NetPlaySettings.m_EnableCheats;
     StartUp.bDSPHLE = g_NetPlaySettings.m_DSPHLE;
@@ -409,6 +421,10 @@ void Stop()
 
 void RestoreConfig()
 {
+  Config::RemoveLayer(Config::LayerType::Movie);
+  Config::RemoveLayer(Config::LayerType::Netplay);
+  Config::RemoveLayer(Config::LayerType::GlobalGame);
+  Config::RemoveLayer(Config::LayerType::LocalGame);
   SConfig::GetInstance().LoadSettingsFromSysconf();
   SConfig::GetInstance().ResetRunningGameMetadata();
   config_cache.RestoreConfig(&SConfig::GetInstance());

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -421,6 +421,7 @@ void Stop()
 
 void RestoreConfig()
 {
+  Config::ClearCurrentRunLayer();
   Config::RemoveLayer(Config::LayerType::Movie);
   Config::RemoveLayer(Config::LayerType::Netplay);
   Config::RemoveLayer(Config::LayerType::GlobalGame);

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SRCS
   Boot/Boot_ELF.cpp
   Boot/Boot_WiiWAD.cpp
   Boot/ElfReader.cpp
+  Config/Config.cpp
   ConfigLoaders/BaseConfigLoader.cpp
   ConfigLoaders/GameConfigLoader.cpp
   ConfigLoaders/MovieConfigLoader.cpp

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRCS
   Config/Config.cpp
   ConfigLoaders/BaseConfigLoader.cpp
   ConfigLoaders/GameConfigLoader.cpp
+  ConfigLoaders/IsSettingSaveable.cpp
   ConfigLoaders/MovieConfigLoader.cpp
   ConfigLoaders/NetPlayConfigLoader.cpp
   Debugger/Debugger_SymbolMap.cpp

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRCS
   Boot/Boot_WiiWAD.cpp
   Boot/ElfReader.cpp
   Config/Config.cpp
+  Config/GraphicsSettings.cpp
   ConfigLoaders/BaseConfigLoader.cpp
   ConfigLoaders/GameConfigLoader.cpp
   ConfigLoaders/IsSettingSaveable.cpp

--- a/Source/Core/Core/Config/Config.cpp
+++ b/Source/Core/Core/Config/Config.cpp
@@ -22,4 +22,20 @@ bool ConfigLocation::operator<(const ConfigLocation& other) const
 {
   return std::tie(system, section, key) < std::tie(other.system, other.section, other.key);
 }
+
+LayerType GetActiveLayerForConfig(const ConfigLocation& config)
+{
+  for (auto layer : SEARCH_ORDER)
+  {
+    if (!LayerExists(layer))
+      continue;
+
+    if (GetLayer(layer)->Exists(config.system, config.section, config.key))
+      return layer;
+  }
+
+  // If config is not present in any layer, base layer is considered active.
+  return LayerType::Base;
+}
+
 }  // namespace Config

--- a/Source/Core/Core/Config/Config.cpp
+++ b/Source/Core/Core/Config/Config.cpp
@@ -1,0 +1,25 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <tuple>
+
+#include "Core/Config/Config.h"
+
+namespace Config
+{
+bool ConfigLocation::operator==(const ConfigLocation& other) const
+{
+  return std::tie(system, section, key) == std::tie(other.system, other.section, other.key);
+}
+
+bool ConfigLocation::operator!=(const ConfigLocation& other) const
+{
+  return !(*this == other);
+}
+
+bool ConfigLocation::operator<(const ConfigLocation& other) const
+{
+  return std::tie(system, section, key) < std::tie(other.system, other.section, other.key);
+}
+}  // namespace Config

--- a/Source/Core/Core/Config/Config.h
+++ b/Source/Core/Core/Config/Config.h
@@ -2,8 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <string>
 
+#include "Common/Config/Config.h"
 #include "Common/Config/Enums.h"
 
 namespace Config
@@ -18,4 +21,61 @@ struct ConfigLocation
   bool operator!=(const ConfigLocation& other) const;
   bool operator<(const ConfigLocation& other) const;
 };
+
+template <typename T>
+struct ConfigInfo
+{
+  ConfigLocation location;
+  T default_value;
+};
+
+template <typename T>
+T Get(LayerType layer, const ConfigInfo<T>& info)
+{
+  return GetLayer(layer)
+      ->GetOrCreateSection(info.location.system, info.location.section)
+      ->template Get<T>(info.location.key, info.default_value);
+}
+
+template <typename T>
+T Get(const ConfigInfo<T>& info)
+{
+  return Get(LayerType::Meta, info);
+}
+
+template <typename T>
+T GetBase(const ConfigInfo<T>& info)
+{
+  return Get(LayerType::Base, info);
+}
+
+LayerType GetActiveLayerForConfig(const ConfigLocation&);
+
+template <typename T>
+LayerType GetActiveLayerForConfig(const ConfigInfo<T>& info)
+{
+  return GetActiveLayerForConfig(info.location);
+}
+
+template <typename T>
+void Set(LayerType layer, const ConfigInfo<T>& info, const T& value)
+{
+  GetLayer(layer)
+      ->GetOrCreateSection(info.location.system, info.location.section)
+      ->Set(info.location.key, value);
+  InvokeConfigChangedCallbacks();
+}
+
+template <typename T>
+void SetBase(const ConfigInfo<T>& info, const T& value)
+{
+  Set<T>(LayerType::Base, info, value);
+}
+
+template <typename T>
+void SetCurrent(const ConfigInfo<T>& info, const T& value)
+{
+  Set<T>(LayerType::CurrentRun, info, value);
+}
+
 }  // namespace Config

--- a/Source/Core/Core/Config/Config.h
+++ b/Source/Core/Core/Config/Config.h
@@ -1,0 +1,21 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <string>
+
+#include "Common/Config/Enums.h"
+
+namespace Config
+{
+struct ConfigLocation
+{
+  System system;
+  std::string section;
+  std::string key;
+
+  bool operator==(const ConfigLocation& other) const;
+  bool operator!=(const ConfigLocation& other) const;
+  bool operator<(const ConfigLocation& other) const;
+};
+}  // namespace Config

--- a/Source/Core/Core/Config/Config.h
+++ b/Source/Core/Core/Config/Config.h
@@ -78,4 +78,13 @@ void SetCurrent(const ConfigInfo<T>& info, const T& value)
   Set<T>(LayerType::CurrentRun, info, value);
 }
 
+template <typename T>
+void SetBaseOrCurrent(const ConfigInfo<T>& info, const T& value)
+{
+  if (GetActiveLayerForConfig(info) == LayerType::Base)
+    Set<T>(LayerType::Base, info, value);
+  else
+    Set<T>(LayerType::CurrentRun, info, value);
+}
+
 }  // namespace Config

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -1,0 +1,135 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <string>
+
+#include "Core/Config/Config.h"
+#include "Core/Config/GraphicsSettings.h"
+#include "VideoCommon/VideoConfig.h"
+
+namespace Config
+{
+// Configuration Information
+
+// Graphics.Hardware
+
+const ConfigInfo<bool> GFX_VSYNC{{System::GFX, "Hardware", "VSync"}, false};
+const ConfigInfo<int> GFX_ADAPTER{{System::GFX, "Hardware", "Adapter"}, 0};
+
+// Graphics.Settings
+
+const ConfigInfo<bool> GFX_WIDESCREEN_HACK{{System::GFX, "Settings", "wideScreenHack"}, false};
+const ConfigInfo<int> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"},
+                                       static_cast<int>(ASPECT_AUTO)};
+const ConfigInfo<bool> GFX_CROP{{System::GFX, "Settings", "Crop"}, false};
+const ConfigInfo<bool> GFX_USE_XFB{{System::GFX, "Settings", "UseXFB"}, false};
+const ConfigInfo<bool> GFX_USE_REAL_XFB{{System::GFX, "Settings", "UseRealXFB"}, false};
+const ConfigInfo<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES{
+    {System::GFX, "Settings", "SafeTextureCacheColorSamples"}, 128};
+const ConfigInfo<bool> GFX_SHOW_FPS{{System::GFX, "Settings", "ShowFPS"}, false};
+const ConfigInfo<bool> GFX_SHOW_NETPLAY_PING{{System::GFX, "Settings", "ShowNetPlayPing"}, false};
+const ConfigInfo<bool> GFX_SHOW_NETPLAY_MESSAGES{{System::GFX, "Settings", "ShowNetPlayMessages"},
+                                                 false};
+const ConfigInfo<bool> GFX_LOG_RENDER_TIME_TO_FILE{{System::GFX, "Settings", "LogRenderTimeToFile"},
+                                                   false};
+const ConfigInfo<bool> GFX_OVERLAY_STATS{{System::GFX, "Settings", "OverlayStats"}, false};
+const ConfigInfo<bool> GFX_OVERLAY_PROJ_STATS{{System::GFX, "Settings", "OverlayProjStats"}, false};
+const ConfigInfo<bool> GFX_DUMP_TEXTURES{{System::GFX, "Settings", "DumpTextures"}, false};
+const ConfigInfo<bool> GFX_HIRES_TEXTURES{{System::GFX, "Settings", "HiresTextures"}, false};
+const ConfigInfo<bool> GFX_CONVERT_HIRES_TEXTURES{{System::GFX, "Settings", "ConvertHiresTextures"},
+                                                  false};
+const ConfigInfo<bool> GFX_CACHE_HIRES_TEXTURES{{System::GFX, "Settings", "CacheHiresTextures"},
+                                                false};
+const ConfigInfo<bool> GFX_DUMP_EFB_TARGET{{System::GFX, "Settings", "DumpEFBTarget"}, false};
+const ConfigInfo<bool> GFX_DUMP_FRAMES_AS_IMAGES{{System::GFX, "Settings", "DumpFramesAsImages"},
+                                                 false};
+const ConfigInfo<bool> GFX_FREE_LOOK{{System::GFX, "Settings", "FreeLook"}, false};
+const ConfigInfo<bool> GFX_USE_FFV1{{System::GFX, "Settings", "UseFFV1"}, false};
+const ConfigInfo<std::string> GFX_DUMP_FORMAT{{System::GFX, "Settings", "DumpFormat"}, "avi"};
+const ConfigInfo<std::string> GFX_DUMP_CODEC{{System::GFX, "Settings", "DumpCodec"}, ""};
+const ConfigInfo<std::string> GFX_DUMP_PATH{{System::GFX, "Settings", "DumpPath"}, ""};
+const ConfigInfo<int> GFX_BITRATE_KBPS{{System::GFX, "Settings", "BitrateKbps"}, 2500};
+const ConfigInfo<bool> GFX_INTERNAL_RESOLUTION_FRAME_DUMPS{
+    {System::GFX, "Settings", "InternalResolutionFrameDumps"}, false};
+const ConfigInfo<bool> GFX_ENABLE_GPU_TEXTURE_DECODING{
+    {System::GFX, "Settings", "EnableGPUTextureDecoding"}, false};
+const ConfigInfo<bool> GFX_ENABLE_PIXEL_LIGHTING{{System::GFX, "Settings", "EnablePixelLighting"},
+                                                 false};
+const ConfigInfo<bool> GFX_FAST_DEPTH_CALC{{System::GFX, "Settings", "FastDepthCalc"}, true};
+const ConfigInfo<int> GFX_MSAA{{System::GFX, "Settings", "MSAA"}, 1};
+const ConfigInfo<bool> GFX_SSAA{{System::GFX, "Settings", "SSAA"}, false};
+const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "EFBScale"},
+                                    static_cast<int>(SCALE_1X)};
+const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_ENABLE{{System::GFX, "Settings", "TexFmtOverlayEnable"},
+                                                 false};
+const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER{{System::GFX, "Settings", "TexFmtOverlayCenter"},
+                                                 false};
+const ConfigInfo<bool> GFX_ENABLE_WIREFRAME{{System::GFX, "Settings", "WireFrame"}, false};
+const ConfigInfo<bool> GFX_DISABLE_FOG{{System::GFX, "Settings", "DisableFog"}, false};
+const ConfigInfo<bool> GFX_BORDERLESS_FULLSCREEN{{System::GFX, "Settings", "BorderlessFullscreen"},
+                                                 false};
+const ConfigInfo<bool> GFX_ENABLE_VALIDATION_LAYER{
+    {System::GFX, "Settings", "EnableValidationLayer"}, false};
+const ConfigInfo<bool> GFX_BACKEND_MULTITHREADING{
+    {System::GFX, "Settings", "BackendMultithreading"}, true};
+const ConfigInfo<int> GFX_COMMAND_BUFFER_EXECUTE_INTERVAL{
+    {System::GFX, "Settings", "CommandBufferExecuteInterval"}, 100};
+const ConfigInfo<bool> GFX_SHADER_CACHE{{System::GFX, "Settings", "ShaderCache"}, true};
+
+const ConfigInfo<bool> GFX_SW_ZCOMPLOC{{System::GFX, "Settings", "SWZComploc"}, true};
+const ConfigInfo<bool> GFX_SW_ZFREEZE{{System::GFX, "Settings", "SWZFreeze"}, true};
+const ConfigInfo<bool> GFX_SW_DUMP_OBJECTS{{System::GFX, "Settings", "SWDumpObjects"}, false};
+const ConfigInfo<bool> GFX_SW_DUMP_TEV_STAGES{{System::GFX, "Settings", "SWDumpTevStages"}, false};
+const ConfigInfo<bool> GFX_SW_DUMP_TEV_TEX_FETCHES{{System::GFX, "Settings", "SWDumpTevTexFetches"},
+                                                   false};
+const ConfigInfo<int> GFX_SW_DRAW_START{{System::GFX, "Settings", "SWDrawStart"}, 0};
+const ConfigInfo<int> GFX_SW_DRAW_END{{System::GFX, "Settings", "SWDrawEnd"}, 100000};
+
+// Graphics.Enhancements
+
+const ConfigInfo<bool> GFX_ENHANCE_FORCE_FILTERING{{System::GFX, "Enhancements", "ForceFiltering"},
+                                                   false};
+const ConfigInfo<int> GFX_ENHANCE_MAX_ANISOTROPY{{System::GFX, "Enhancements", "MaxAnisotropy"}, 0};
+const ConfigInfo<std::string> GFX_ENHANCE_POST_SHADER{
+    {System::GFX, "Enhancements", "PostProcessingShader"}, ""};
+const ConfigInfo<bool> GFX_ENHANCE_FORCE_TRUE_COLOR{{System::GFX, "Enhancements", "ForceTrueColor"},
+                                                    true};
+
+// Graphics.Stereoscopy
+
+const ConfigInfo<int> GFX_STEREO_MODE{{System::GFX, "Stereoscopy", "StereoMode"}, 0};
+const ConfigInfo<int> GFX_STEREO_DEPTH{{System::GFX, "Stereoscopy", "StereoDepth"}, 20};
+const ConfigInfo<int> GFX_STEREO_CONVERGENCE_PERCENTAGE{
+    {System::GFX, "Stereoscopy", "StereoConvergencePercentage"}, 100};
+const ConfigInfo<bool> GFX_STEREO_SWAP_EYES{{System::GFX, "Stereoscopy", "StereoSwapEyes"}, false};
+const ConfigInfo<int> GFX_STEREO_CONVERGENCE{{System::GFX, "Stereoscopy", "StereoConvergence"}, 20};
+const ConfigInfo<bool> GFX_STEREO_EFB_MONO_DEPTH{{System::GFX, "Stereoscopy", "StereoEFBMonoDepth"},
+                                                 false};
+const ConfigInfo<int> GFX_STEREO_DEPTH_PERCENTAGE{
+    {System::GFX, "Stereoscopy", "StereoDepthPercentage"}, 100};
+
+// Graphics.Hacks
+
+const ConfigInfo<bool> GFX_HACK_EFB_ACCESS_ENABLE{{System::GFX, "Hacks", "EFBAccessEnable"}, true};
+const ConfigInfo<bool> GFX_HACK_BBOX_ENABLE{{System::GFX, "Hacks", "BBoxEnable"}, false};
+const ConfigInfo<bool> GFX_HACK_BBOX_PREFER_STENCIL_IMPLEMENTATION{
+    {System::GFX, "Hacks", "BBoxPreferStencilImplementation"}, false};
+const ConfigInfo<bool> GFX_HACK_FORCE_PROGRESSIVE{{System::GFX, "Hacks", "ForceProgressive"}, true};
+const ConfigInfo<bool> GFX_HACK_SKIP_EFB_COPY_TO_RAM{{System::GFX, "Hacks", "EFBToTextureEnable"},
+                                                     true};
+const ConfigInfo<bool> GFX_HACK_COPY_EFB_ENABLED{{System::GFX, "Hacks", "EFBScaledCopy"}, true};
+const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{
+    {System::GFX, "Hacks", "EFBEmulateFormatChanges"}, false};
+const ConfigInfo<bool> GFX_HACK_VERTEX_ROUDING{{System::GFX, "Hacks", "VertexRounding"}, false};
+
+// Graphics.GameSpecific
+
+const ConfigInfo<int> GFX_PROJECTION_HACK{{System::GFX, "GameSpecific", "ProjectionHack"}, 0};
+const ConfigInfo<int> GFX_PROJECTION_HACK_SZNEAR{{System::GFX, "GameSpecific", "PH_SZNear"}, 0};
+const ConfigInfo<int> GFX_PROJECTION_HACK_SZFAR{{System::GFX, "GameSpecific", "PH_SZFar"}, 0};
+const ConfigInfo<int> GFX_PROJECTION_HACK_ZNEAR{{System::GFX, "GameSpecific", "PH_ZNear"}, 0};
+const ConfigInfo<int> GFX_PROJECTION_HACK_ZFAR{{System::GFX, "GameSpecific", "PH_ZFar"}, 0};
+const ConfigInfo<bool> GFX_PERF_QUERIES_ENABLE{{System::GFX, "GameSpecific", "PerfQueriesEnable"},
+                                               false};
+}  // namespace Config

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -1,0 +1,108 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "Core/Config/Config.h"
+
+namespace Config
+{
+// Configuration Information
+
+// Graphics.Hardware
+
+extern const ConfigInfo<bool> GFX_VSYNC;
+extern const ConfigInfo<int> GFX_ADAPTER;
+
+// Graphics.Settings
+
+extern const ConfigInfo<bool> GFX_WIDESCREEN_HACK;
+extern const ConfigInfo<int> GFX_ASPECT_RATIO;
+extern const ConfigInfo<bool> GFX_CROP;
+extern const ConfigInfo<bool> GFX_USE_XFB;
+extern const ConfigInfo<bool> GFX_USE_REAL_XFB;
+extern const ConfigInfo<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES;
+extern const ConfigInfo<bool> GFX_SHOW_FPS;
+extern const ConfigInfo<bool> GFX_SHOW_NETPLAY_PING;
+extern const ConfigInfo<bool> GFX_SHOW_NETPLAY_MESSAGES;
+extern const ConfigInfo<bool> GFX_LOG_RENDER_TIME_TO_FILE;
+extern const ConfigInfo<bool> GFX_OVERLAY_STATS;
+extern const ConfigInfo<bool> GFX_OVERLAY_PROJ_STATS;
+extern const ConfigInfo<bool> GFX_DUMP_TEXTURES;
+extern const ConfigInfo<bool> GFX_HIRES_TEXTURES;
+extern const ConfigInfo<bool> GFX_CONVERT_HIRES_TEXTURES;
+extern const ConfigInfo<bool> GFX_CACHE_HIRES_TEXTURES;
+extern const ConfigInfo<bool> GFX_DUMP_EFB_TARGET;
+extern const ConfigInfo<bool> GFX_DUMP_FRAMES_AS_IMAGES;
+extern const ConfigInfo<bool> GFX_FREE_LOOK;
+extern const ConfigInfo<bool> GFX_USE_FFV1;
+extern const ConfigInfo<std::string> GFX_DUMP_FORMAT;
+extern const ConfigInfo<std::string> GFX_DUMP_CODEC;
+extern const ConfigInfo<std::string> GFX_DUMP_PATH;
+extern const ConfigInfo<int> GFX_BITRATE_KBPS;
+extern const ConfigInfo<bool> GFX_INTERNAL_RESOLUTION_FRAME_DUMPS;
+extern const ConfigInfo<bool> GFX_ENABLE_GPU_TEXTURE_DECODING;
+extern const ConfigInfo<bool> GFX_ENABLE_PIXEL_LIGHTING;
+extern const ConfigInfo<bool> GFX_FAST_DEPTH_CALC;
+extern const ConfigInfo<int> GFX_MSAA;
+extern const ConfigInfo<bool> GFX_SSAA;
+extern const ConfigInfo<int> GFX_EFB_SCALE;
+extern const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_ENABLE;
+extern const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER;
+extern const ConfigInfo<bool> GFX_ENABLE_WIREFRAME;
+extern const ConfigInfo<bool> GFX_DISABLE_FOG;
+extern const ConfigInfo<bool> GFX_BORDERLESS_FULLSCREEN;
+extern const ConfigInfo<bool> GFX_ENABLE_VALIDATION_LAYER;
+extern const ConfigInfo<bool> GFX_BACKEND_MULTITHREADING;
+extern const ConfigInfo<int> GFX_COMMAND_BUFFER_EXECUTE_INTERVAL;
+extern const ConfigInfo<bool> GFX_SHADER_CACHE;
+
+extern const ConfigInfo<bool> GFX_SW_ZCOMPLOC;
+extern const ConfigInfo<bool> GFX_SW_ZFREEZE;
+extern const ConfigInfo<bool> GFX_SW_DUMP_OBJECTS;
+extern const ConfigInfo<bool> GFX_SW_DUMP_TEV_STAGES;
+extern const ConfigInfo<bool> GFX_SW_DUMP_TEV_TEX_FETCHES;
+extern const ConfigInfo<int> GFX_SW_DRAW_START;
+extern const ConfigInfo<int> GFX_SW_DRAW_END;
+
+// Graphics.Enhancements
+
+extern const ConfigInfo<bool> GFX_ENHANCE_FORCE_FILTERING;
+extern const ConfigInfo<int> GFX_ENHANCE_MAX_ANISOTROPY;  // NOTE - this is x in (1 << x)
+extern const ConfigInfo<std::string> GFX_ENHANCE_POST_SHADER;
+extern const ConfigInfo<bool> GFX_ENHANCE_FORCE_TRUE_COLOR;
+
+// Graphics.Stereoscopy
+
+extern const ConfigInfo<int> GFX_STEREO_MODE;
+extern const ConfigInfo<int> GFX_STEREO_DEPTH;
+extern const ConfigInfo<int> GFX_STEREO_CONVERGENCE_PERCENTAGE;
+extern const ConfigInfo<bool> GFX_STEREO_SWAP_EYES;
+extern const ConfigInfo<int> GFX_STEREO_CONVERGENCE;
+extern const ConfigInfo<bool> GFX_STEREO_EFB_MONO_DEPTH;
+extern const ConfigInfo<int> GFX_STEREO_DEPTH_PERCENTAGE;
+
+// Graphics.Hacks
+
+extern const ConfigInfo<bool> GFX_HACK_EFB_ACCESS_ENABLE;
+extern const ConfigInfo<bool> GFX_HACK_BBOX_ENABLE;
+extern const ConfigInfo<bool> GFX_HACK_BBOX_PREFER_STENCIL_IMPLEMENTATION;
+extern const ConfigInfo<bool> GFX_HACK_FORCE_PROGRESSIVE;
+extern const ConfigInfo<bool> GFX_HACK_SKIP_EFB_COPY_TO_RAM;
+extern const ConfigInfo<bool> GFX_HACK_COPY_EFB_ENABLED;
+extern const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;
+extern const ConfigInfo<bool> GFX_HACK_VERTEX_ROUDING;
+
+// Graphics.GameSpecific
+
+extern const ConfigInfo<int> GFX_PROJECTION_HACK;
+extern const ConfigInfo<int> GFX_PROJECTION_HACK_SZNEAR;
+extern const ConfigInfo<int> GFX_PROJECTION_HACK_SZFAR;
+extern const ConfigInfo<int> GFX_PROJECTION_HACK_ZNEAR;
+extern const ConfigInfo<int> GFX_PROJECTION_HACK_ZFAR;
+extern const ConfigInfo<bool> GFX_PERF_QUERIES_ENABLE;
+
+}  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -14,6 +14,7 @@
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 
+#include "Core/Config/Config.h"
 #include "Core/ConfigLoaders/BaseConfigLoader.h"
 
 namespace ConfigLoaders

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -16,6 +16,7 @@
 
 #include "Core/Config/Config.h"
 #include "Core/ConfigLoaders/BaseConfigLoader.h"
+#include "Core/ConfigLoaders/IsSettingSaveable.h"
 
 namespace ConfigLoaders
 {
@@ -80,7 +81,12 @@ public:
         IniFile::Section* ini_section = ini.GetOrCreateSection(section_name);
 
         for (const auto& value : section_values)
+        {
+          if (!IsSettingSaveable({system.first, section->GetName(), value.first}))
+            continue;
+
           ini_section->Set(value.first, value.second);
+        }
       }
 
       ini.Save(File::GetUserPath(mapping->second));

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -18,10 +18,13 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/Config.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 
 namespace ConfigLoaders
 {
+using ConfigLocation = Config::ConfigLocation;
+
 // Returns all possible filenames in ascending order of priority
 static std::vector<std::string> GetGameIniFilenames(const std::string& id, u16 revision)
 {
@@ -39,20 +42,6 @@ static std::vector<std::string> GetGameIniFilenames(const std::string& id, u16 r
 
   return filenames;
 }
-
-struct ConfigLocation
-{
-  Config::System system;
-  std::string section;
-  std::string key;
-
-  bool operator==(const ConfigLocation& other) const
-  {
-    return std::tie(system, section, key) == std::tie(other.system, other.section, other.key);
-  }
-
-  bool operator!=(const ConfigLocation& other) const { return !operator==(other); }
-};
 
 static std::map<std::pair<std::string, std::string>, ConfigLocation> ini_to_location = {
     // Core

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -19,6 +19,7 @@
 #include "Common/StringUtil.h"
 
 #include "Core/Config/Config.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 
@@ -51,7 +52,59 @@ using INIToLocationMap = std::map<std::pair<std::string, std::string>, ConfigLoc
 // See also: MapINIToRealLocation and GetINILocationFromConfig.
 static const INIToLocationMap& GetINIToLocationMap()
 {
-  static const INIToLocationMap ini_to_location{};
+  static const INIToLocationMap ini_to_location = {
+      {{"Video_Hardware", "VSync"}, {Config::GFX_VSYNC.location}},
+
+      {{"Video_Settings", "wideScreenHack"}, {Config::GFX_WIDESCREEN_HACK.location}},
+      {{"Video_Settings", "AspectRatio"}, {Config::GFX_ASPECT_RATIO.location}},
+      {{"Video_Settings", "Crop"}, {Config::GFX_CROP.location}},
+      {{"Video_Settings", "UseXFB"}, {Config::GFX_USE_XFB.location}},
+      {{"Video_Settings", "UseRealXFB"}, {Config::GFX_USE_REAL_XFB.location}},
+      {{"Video_Settings", "SafeTextureCacheColorSamples"},
+       {Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES.location}},
+      {{"Video_Settings", "HiresTextures"}, {Config::GFX_HIRES_TEXTURES.location}},
+      {{"Video_Settings", "ConvertHiresTextures"}, {Config::GFX_CONVERT_HIRES_TEXTURES.location}},
+      {{"Video_Settings", "CacheHiresTextures"}, {Config::GFX_CACHE_HIRES_TEXTURES.location}},
+      {{"Video_Settings", "EnablePixelLighting"}, {Config::GFX_ENABLE_PIXEL_LIGHTING.location}},
+      {{"Video_Settings", "FastDepthCalc"}, {Config::GFX_FAST_DEPTH_CALC.location}},
+      {{"Video_Settings", "MSAA"}, {Config::GFX_MSAA.location}},
+      {{"Video_Settings", "SSAA"}, {Config::GFX_SSAA.location}},
+      {{"Video_Settings", "ForceTrueColor"}, {Config::GFX_ENHANCE_FORCE_TRUE_COLOR.location}},
+      {{"Video_Settings", "EFBScale"}, {Config::GFX_EFB_SCALE.location}},
+      {{"Video_Settings", "DisableFog"}, {Config::GFX_DISABLE_FOG.location}},
+      {{"Video_Settings", "BackendMultithreading"}, {Config::GFX_BACKEND_MULTITHREADING.location}},
+      {{"Video_Settings", "CommandBufferExecuteInterval"},
+       {Config::GFX_COMMAND_BUFFER_EXECUTE_INTERVAL.location}},
+
+      {{"Video_Enhancements", "ForceFiltering"}, {Config::GFX_ENHANCE_FORCE_FILTERING.location}},
+      {{"Video_Enhancements", "MaxAnisotropy"}, {Config::GFX_ENHANCE_MAX_ANISOTROPY.location}},
+      {{"Video_Enhancements", "PostProcessingShader"}, {Config::GFX_ENHANCE_POST_SHADER.location}},
+
+      {{"Video_Stereoscopy", "StereoConvergence"}, {Config::GFX_STEREO_CONVERGENCE.location}},
+      {{"Video_Stereoscopy", "StereoEFBMonoDepth"}, {Config::GFX_STEREO_EFB_MONO_DEPTH.location}},
+      {{"Video_Stereoscopy", "StereoDepthPercentage"},
+       {Config::GFX_STEREO_DEPTH_PERCENTAGE.location}},
+
+      {{"Video_Stereoscopy", "StereoMode"}, {Config::GFX_STEREO_MODE.location}},
+      {{"Video_Stereoscopy", "StereoDepth"}, {Config::GFX_STEREO_DEPTH.location}},
+      {{"Video_Stereoscopy", "StereoSwapEyes"}, {Config::GFX_STEREO_SWAP_EYES.location}},
+
+      {{"Video_Hacks", "EFBAccessEnable"}, {Config::GFX_HACK_EFB_ACCESS_ENABLE.location}},
+      {{"Video_Hacks", "BBoxEnable"}, {Config::GFX_HACK_BBOX_ENABLE.location}},
+      {{"Video_Hacks", "ForceProgressive"}, {Config::GFX_HACK_FORCE_PROGRESSIVE.location}},
+      {{"Video_Hacks", "EFBToTextureEnable"}, {Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM.location}},
+      {{"Video_Hacks", "EFBScaledCopy"}, {Config::GFX_EFB_SCALE.location}},
+      {{"Video_Hacks", "EFBEmulateFormatChanges"},
+       {Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES.location}},
+      {{"Video_Hacks", "VertexRounding"}, {Config::GFX_HACK_VERTEX_ROUDING.location}},
+
+      {{"Video", "ProjectionHack"}, {Config::GFX_PROJECTION_HACK.location}},
+      {{"Video", "PH_SZNear"}, {Config::GFX_PROJECTION_HACK_SZNEAR.location}},
+      {{"Video", "PH_SZFar"}, {Config::GFX_PROJECTION_HACK_SZFAR.location}},
+      {{"Video", "PH_ZNear"}, {Config::GFX_PROJECTION_HACK_ZNEAR.location}},
+      {{"Video", "PH_ZFar"}, {Config::GFX_PROJECTION_HACK_ZFAR.location}},
+      {{"Video", "PerfQueriesEnable"}, {Config::GFX_PERF_QUERIES_ENABLE.location}},
+  };
   return ini_to_location;
 }
 

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -44,141 +44,25 @@ static std::vector<std::string> GetGameIniFilenames(const std::string& id, u16 r
   return filenames;
 }
 
-static std::map<std::pair<std::string, std::string>, ConfigLocation> ini_to_location = {
-    // Core
-    {{"Core", "CPUThread"}, {Config::System::Main, "Core", "CPUThread"}},
-    {{"Core", "SkipIdle"}, {Config::System::Main, "Core", "SkipIdle"}},
-    {{"Core", "SyncOnSkipIdle"}, {Config::System::Main, "Core", "SyncOnSkipIdle"}},
-    {{"Core", "FPRF"}, {Config::System::Main, "Core", "FPRF"}},
-    {{"Core", "AccurateNaNs"}, {Config::System::Main, "Core", "AccurateNaNs"}},
-    {{"Core", "MMU"}, {Config::System::Main, "Core", "MMU"}},
-    {{"Core", "DCBZ"}, {Config::System::Main, "Core", "DCBZ"}},
-    {{"Core", "SyncGPU"}, {Config::System::Main, "Core", "SyncGPU"}},
-    {{"Core", "FastDiscSpeed"}, {Config::System::Main, "Core", "FastDiscSpeed"}},
-    {{"Core", "DSPHLE"}, {Config::System::Main, "Core", "DSPHLE"}},
-    {{"Core", "GFXBackend"}, {Config::System::Main, "Core", "GFXBackend"}},
-    {{"Core", "CPUCore"}, {Config::System::Main, "Core", "CPUCore"}},
-    {{"Core", "HLE_BS2"}, {Config::System::Main, "Core", "HLE_BS2"}},
-    {{"Core", "EmulationSpeed"}, {Config::System::Main, "Core", "EmulationSpeed"}},
-    {{"Core", "GPUDeterminismMode"}, {Config::System::Main, "Core", "GPUDeterminismMode"}},
-    {{"Core", "ProgressiveScan"}, {Config::System::Main, "Display", "ProgressiveScan"}},
-    {{"Core", "PAL60"}, {Config::System::Main, "Display", "PAL60"}},
+using INIToLocationMap = std::map<std::pair<std::string, std::string>, ConfigLocation>;
 
-    // Action Replay cheats
-    {{"ActionReplay_Enabled", ""}, {Config::System::Main, "ActionReplay_Enabled", ""}},
-    {{"ActionReplay", ""}, {Config::System::Main, "ActionReplay", ""}},
+// This is a mapping from the legacy section-key pairs to ConfigLocations.
+// New settings do not need to be added to this mapping.
+// See also: MapINIToRealLocation and GetINILocationFromConfig.
+static const INIToLocationMap& GetINIToLocationMap()
+{
+  static const INIToLocationMap ini_to_location{};
+  return ini_to_location;
+}
 
-    // Gecko cheats
-    {{"Gecko_Enabled", ""}, {Config::System::Main, "Gecko_Enabled", ""}},
-    {{"Gecko", ""}, {Config::System::Main, "Gecko", ""}},
-
-    // OnLoad cheats
-    {{"OnLoad", ""}, {Config::System::Main, "OnLoad", ""}},
-
-    // OnFrame cheats
-    {{"OnFrame_Enabled", ""}, {Config::System::Main, "OnFrame_Enabled", ""}},
-    {{"OnFrame", ""}, {Config::System::Main, "OnFrame", ""}},
-
-    // Speedhacks
-    {{"Speedhacks", ""}, {Config::System::Main, "Speedhacks", ""}},
-
-    // Debugger values
-    {{"Watches", ""}, {Config::System::Debugger, "Watches", ""}},
-    {{"BreakPoints", ""}, {Config::System::Debugger, "BreakPoints", ""}},
-    {{"MemoryChecks", ""}, {Config::System::Debugger, "MemoryChecks", ""}},
-
-    // DSP
-    {{"DSP", "Volume"}, {Config::System::Main, "DSP", "Volume"}},
-    {{"DSP", "EnableJIT"}, {Config::System::Main, "DSP", "EnableJIT"}},
-    {{"DSP", "Backend"}, {Config::System::Main, "DSP", "Backend"}},
-
-    // Controls
-    {{"Controls", "PadType0"}, {Config::System::GCPad, "Core", "SIDevice0"}},
-    {{"Controls", "PadType1"}, {Config::System::GCPad, "Core", "SIDevice1"}},
-    {{"Controls", "PadType2"}, {Config::System::GCPad, "Core", "SIDevice2"}},
-    {{"Controls", "PadType3"}, {Config::System::GCPad, "Core", "SIDevice3"}},
-    {{"Controls", "WiimoteSource0"}, {Config::System::WiiPad, "Wiimote1", "Source"}},
-    {{"Controls", "WiimoteSource1"}, {Config::System::WiiPad, "Wiimote2", "Source"}},
-    {{"Controls", "WiimoteSource2"}, {Config::System::WiiPad, "Wiimote3", "Source"}},
-    {{"Controls", "WiimoteSource3"}, {Config::System::WiiPad, "Wiimote4", "Source"}},
-    {{"Controls", "WiimoteSourceBB"}, {Config::System::WiiPad, "BalanceBoard", "Source"}},
-
-    // Controller profiles
-    {{"Controls", "PadProfile1"}, {Config::System::GCPad, "Controls", "PadProfile1"}},
-    {{"Controls", "PadProfile2"}, {Config::System::GCPad, "Controls", "PadProfile2"}},
-    {{"Controls", "PadProfile3"}, {Config::System::GCPad, "Controls", "PadProfile3"}},
-    {{"Controls", "PadProfile4"}, {Config::System::GCPad, "Controls", "PadProfile4"}},
-    {{"Controls", "WiimoteProfile1"}, {Config::System::WiiPad, "Controls", "WiimoteProfile1"}},
-    {{"Controls", "WiimoteProfile2"}, {Config::System::WiiPad, "Controls", "WiimoteProfile2"}},
-    {{"Controls", "WiimoteProfile3"}, {Config::System::WiiPad, "Controls", "WiimoteProfile3"}},
-    {{"Controls", "WiimoteProfile4"}, {Config::System::WiiPad, "Controls", "WiimoteProfile4"}},
-
-    // Video
-    {{"Video_Hardware", "VSync"}, {Config::System::GFX, "Hardware", "VSync"}},
-    {{"Video_Settings", "wideScreenHack"}, {Config::System::GFX, "Settings", "wideScreenHack"}},
-    {{"Video_Settings", "AspectRatio"}, {Config::System::GFX, "Settings", "AspectRatio"}},
-    {{"Video_Settings", "Crop"}, {Config::System::GFX, "Settings", "Crop"}},
-    {{"Video_Settings", "UseXFB"}, {Config::System::GFX, "Settings", "UseXFB"}},
-    {{"Video_Settings", "UseRealXFB"}, {Config::System::GFX, "Settings", "UseRealXFB"}},
-    {{"Video_Settings", "SafeTextureCacheColorSamples"},
-     {Config::System::GFX, "Settings", "SafeTextureCacheColorSamples"}},
-    {{"Video_Settings", "HiresTextures"}, {Config::System::GFX, "Settings", "HiresTextures"}},
-    {{"Video_Settings", "ConvertHiresTextures"},
-     {Config::System::GFX, "Settings", "ConvertHiresTextures"}},
-    {{"Video_Settings", "CacheHiresTextures"},
-     {Config::System::GFX, "Settings", "CacheHiresTextures"}},
-    {{"Video_Settings", "EnablePixelLighting"},
-     {Config::System::GFX, "Settings", "EnablePixelLighting"}},
-    {{"Video_Settings", "ForcedSlowDepth"}, {Config::System::GFX, "Settings", "ForcedSlowDepth"}},
-    {{"Video_Settings", "MSAA"}, {Config::System::GFX, "Settings", "MSAA"}},
-    {{"Video_Settings", "SSAA"}, {Config::System::GFX, "Settings", "SSAA"}},
-    {{"Video_Settings", "EFBScale"}, {Config::System::GFX, "Settings", "EFBScale"}},
-    {{"Video_Settings", "DisableFog"}, {Config::System::GFX, "Settings", "DisableFog"}},
-
-    {{"Video_Enhancements", "ForceFiltering"},
-     {Config::System::GFX, "Enhancements", "ForceFiltering"}},
-    {{"Video_Enhancements", "MaxAnisotropy"},
-     {Config::System::GFX, "Enhancements", "MaxAnisotropy"}},
-    {{"Video_Enhancements", "PostProcessingShader"},
-     {Config::System::GFX, "Enhancements", "PostProcessingShader"}},
-
-    {{"Video_Stereoscopy", "StereoMode"}, {Config::System::GFX, "Stereoscopy", "StereoMode"}},
-    {{"Video_Stereoscopy", "StereoDepth"}, {Config::System::GFX, "Stereoscopy", "StereoDepth"}},
-    {{"Video_Stereoscopy", "StereoSwapEyes"},
-     {Config::System::GFX, "Stereoscopy", "StereoSwapEyes"}},
-
-    {{"Video_Hacks", "EFBAccessEnable"}, {Config::System::GFX, "Hacks", "EFBAccessEnable"}},
-    {{"Video_Hacks", "BBoxEnable"}, {Config::System::GFX, "Hacks", "BBoxEnable"}},
-    {{"Video_Hacks", "ForceProgressive"}, {Config::System::GFX, "Hacks", "ForceProgressive"}},
-    {{"Video_Hacks", "EFBToTextureEnable"}, {Config::System::GFX, "Hacks", "EFBToTextureEnable"}},
-    {{"Video_Hacks", "EFBScaledCopy"}, {Config::System::GFX, "Hacks", "EFBScaledCopy"}},
-    {{"Video_Hacks", "EFBEmulateFormatChanges"},
-     {Config::System::GFX, "Hacks", "EFBEmulateFormatChanges"}},
-
-    // GameINI specific video settings
-    {{"Video", "ProjectionHack"}, {Config::System::GFX, "Video", "ProjectionHack"}},
-    {{"Video", "PH_SZNear"}, {Config::System::GFX, "Video", "PH_SZNear"}},
-    {{"Video", "PH_SZFar"}, {Config::System::GFX, "Video", "PH_SZFar"}},
-    {{"Video", "PH_ZNear"}, {Config::System::GFX, "Video", "PH_ZNear"}},
-    {{"Video", "PH_ZFar"}, {Config::System::GFX, "Video", "PH_ZFar"}},
-    {{"Video", "PH_ExtraParam"}, {Config::System::GFX, "Video", "PH_ExtraParam"}},
-    {{"Video", "PerfQueriesEnable"}, {Config::System::GFX, "Video", "PerfQueriesEnable"}},
-
-    {{"Video_Stereoscopy", "StereoConvergence"},
-     {Config::System::GFX, "Stereoscopy", "StereoConvergence"}},
-    {{"Video_Stereoscopy", "StereoEFBMonoDepth"},
-     {Config::System::GFX, "Stereoscopy", "StereoEFBMonoDepth"}},
-    {{"Video_Stereoscopy", "StereoDepthPercentage"},
-     {Config::System::GFX, "Stereoscopy", "StereoDepthPercentage"}},
-
-    // UI
-    {{"EmuState", "EmulationStateId"}, {Config::System::UI, "EmuState", "EmulationStateId"}},
-    {{"EmuState", "EmulationIssues"}, {Config::System::UI, "EmuState", "EmulationIssues"}},
-    {{"EmuState", "Title"}, {Config::System::UI, "EmuState", "Title"}},
-};
-
+// Converts from a legacy GameINI section-key tuple to a ConfigLocation.
+// Also supports the following format:
+// [System.Section]
+// Key = Value
 static ConfigLocation MapINIToRealLocation(const std::string& section, const std::string& key)
 {
+  static const INIToLocationMap& ini_to_location = GetINIToLocationMap();
+
   auto it = ini_to_location.find({section, key});
   if (it == ini_to_location.end())
   {
@@ -206,11 +90,13 @@ static ConfigLocation MapINIToRealLocation(const std::string& section, const std
     return {Config::System::Main, "", ""};
   }
 
-  return ini_to_location[{section, key}];
+  return ini_to_location.at({section, key});
 }
 
 static std::pair<std::string, std::string> GetINILocationFromConfig(const ConfigLocation& location)
 {
+  static const INIToLocationMap& ini_to_location = GetINIToLocationMap();
+
   auto it = std::find_if(ini_to_location.begin(), ini_to_location.end(),
                          [&location](const auto& entry) { return entry.second == location; });
 
@@ -226,8 +112,7 @@ static std::pair<std::string, std::string> GetINILocationFromConfig(const Config
   if (it != ini_to_location.end())
     return {it->first.first, location.key};
 
-  WARN_LOG(CORE, "Unknown option: %s.%s", location.section.c_str(), location.key.c_str());
-  return {"", ""};
+  return {Config::GetSystemName(location.system) + "." + location.section, location.key};
 }
 
 // INI Game layer configuration loader

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -20,6 +20,7 @@
 
 #include "Core/Config/Config.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
+#include "Core/ConfigLoaders/IsSettingSaveable.h"
 
 namespace ConfigLoaders
 {
@@ -382,6 +383,9 @@ void INIGameConfigLayerLoader::Save(Config::Layer* config_layer)
     {
       for (const auto& value : section->GetValues())
       {
+        if (!IsSettingSaveable({system.first, section->GetName(), value.first}))
+          continue;
+
         const auto ini_location =
             GetINILocationFromConfig({system.first, section->GetName(), value.first});
         if (ini_location.first.empty() && ini_location.second.empty())

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -6,14 +6,74 @@
 #include <vector>
 
 #include "Core/Config/Config.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 
 namespace ConfigLoaders
 {
-const static std::vector<Config::ConfigLocation> s_setting_saveable{};
-
 bool IsSettingSaveable(const Config::ConfigLocation& config_location)
 {
+  const static std::vector<Config::ConfigLocation> s_setting_saveable{
+      // Graphics.Hardware
+
+      Config::GFX_VSYNC.location, Config::GFX_ADAPTER.location,
+
+      // Graphics.Settings
+
+      Config::GFX_WIDESCREEN_HACK.location, Config::GFX_ASPECT_RATIO.location,
+      Config::GFX_CROP.location, Config::GFX_USE_XFB.location, Config::GFX_USE_REAL_XFB.location,
+      Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES.location, Config::GFX_SHOW_FPS.location,
+      Config::GFX_SHOW_NETPLAY_PING.location, Config::GFX_SHOW_NETPLAY_MESSAGES.location,
+      Config::GFX_LOG_RENDER_TIME_TO_FILE.location, Config::GFX_OVERLAY_STATS.location,
+      Config::GFX_OVERLAY_PROJ_STATS.location, Config::GFX_DUMP_TEXTURES.location,
+      Config::GFX_HIRES_TEXTURES.location, Config::GFX_CONVERT_HIRES_TEXTURES.location,
+      Config::GFX_CACHE_HIRES_TEXTURES.location, Config::GFX_DUMP_EFB_TARGET.location,
+      Config::GFX_DUMP_FRAMES_AS_IMAGES.location, Config::GFX_FREE_LOOK.location,
+      Config::GFX_USE_FFV1.location, Config::GFX_DUMP_FORMAT.location,
+      Config::GFX_DUMP_CODEC.location, Config::GFX_DUMP_PATH.location,
+      Config::GFX_BITRATE_KBPS.location, Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS.location,
+      Config::GFX_ENABLE_GPU_TEXTURE_DECODING.location, Config::GFX_ENABLE_PIXEL_LIGHTING.location,
+      Config::GFX_FAST_DEPTH_CALC.location, Config::GFX_MSAA.location, Config::GFX_SSAA.location,
+      Config::GFX_EFB_SCALE.location, Config::GFX_TEXFMT_OVERLAY_ENABLE.location,
+      Config::GFX_TEXFMT_OVERLAY_CENTER.location, Config::GFX_ENABLE_WIREFRAME.location,
+      Config::GFX_DISABLE_FOG.location, Config::GFX_BORDERLESS_FULLSCREEN.location,
+      Config::GFX_ENABLE_VALIDATION_LAYER.location, Config::GFX_BACKEND_MULTITHREADING.location,
+      Config::GFX_COMMAND_BUFFER_EXECUTE_INTERVAL.location, Config::GFX_SHADER_CACHE.location,
+
+      Config::GFX_SW_ZCOMPLOC.location, Config::GFX_SW_ZFREEZE.location,
+      Config::GFX_SW_DUMP_OBJECTS.location, Config::GFX_SW_DUMP_TEV_STAGES.location,
+      Config::GFX_SW_DUMP_TEV_TEX_FETCHES.location, Config::GFX_SW_DRAW_START.location,
+      Config::GFX_SW_DRAW_END.location,
+
+      // Graphics.Enhancements
+
+      Config::GFX_ENHANCE_FORCE_FILTERING.location, Config::GFX_ENHANCE_MAX_ANISOTROPY.location,
+      Config::GFX_ENHANCE_POST_SHADER.location, Config::GFX_ENHANCE_FORCE_TRUE_COLOR.location,
+
+      // Graphics.Stereoscopy
+
+      Config::GFX_STEREO_MODE.location, Config::GFX_STEREO_DEPTH.location,
+      Config::GFX_STEREO_CONVERGENCE_PERCENTAGE.location, Config::GFX_STEREO_SWAP_EYES.location,
+      Config::GFX_STEREO_CONVERGENCE.location, Config::GFX_STEREO_EFB_MONO_DEPTH.location,
+      Config::GFX_STEREO_DEPTH_PERCENTAGE.location,
+
+      // Graphics.Hacks
+
+      Config::GFX_HACK_EFB_ACCESS_ENABLE.location, Config::GFX_HACK_BBOX_ENABLE.location,
+      Config::GFX_HACK_BBOX_PREFER_STENCIL_IMPLEMENTATION.location,
+      Config::GFX_HACK_FORCE_PROGRESSIVE.location, Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM.location,
+      Config::GFX_HACK_COPY_EFB_ENABLED.location,
+      Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES.location,
+      Config::GFX_HACK_VERTEX_ROUDING.location,
+
+      // Graphics.GameSpecific
+
+      Config::GFX_PROJECTION_HACK.location, Config::GFX_PROJECTION_HACK_SZNEAR.location,
+      Config::GFX_PROJECTION_HACK_SZFAR.location, Config::GFX_PROJECTION_HACK_ZNEAR.location,
+      Config::GFX_PROJECTION_HACK_ZFAR.location, Config::GFX_PERF_QUERIES_ENABLE.location,
+
+  };
+
   return std::find(s_setting_saveable.begin(), s_setting_saveable.end(), config_location) !=
          s_setting_saveable.end();
 }

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -1,0 +1,20 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <vector>
+
+#include "Core/Config/Config.h"
+#include "Core/ConfigLoaders/IsSettingSaveable.h"
+
+namespace ConfigLoaders
+{
+const static std::vector<Config::ConfigLocation> s_setting_saveable{};
+
+bool IsSettingSaveable(const Config::ConfigLocation& config_location)
+{
+  return std::find(s_setting_saveable.begin(), s_setting_saveable.end(), config_location) !=
+         s_setting_saveable.end();
+}
+}  // namespace ConfigLoader

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.h
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.h
@@ -1,0 +1,18 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Config
+{
+struct ConfigLocation;
+}
+
+namespace ConfigLoaders
+{
+// This is a temporary function that allows for both the new and old configuration
+// systems to co-exist without trampling on each other while saving.
+// This function shall be removed when the old configuration system retires.
+bool IsSettingSaveable(const Config::ConfigLocation& config_location);
+}  // namespace ConfigLoader

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -11,6 +11,7 @@
 #include "Common/CDUtils.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -21,6 +22,7 @@
 #include "Core/Analytics.h"
 #include "Core/Boot/Boot.h"
 #include "Core/Boot/Boot_DOL.h"
+#include "Core/Config/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
@@ -87,6 +89,8 @@ void SConfig::SaveSettings()
   SaveUSBPassthroughSettings(ini);
 
   ini.Save(File::GetUserPath(F_DOLPHINCONFIG_IDX));
+
+  Config::Save();
 }
 
 namespace
@@ -395,6 +399,8 @@ void SConfig::SaveSettingsToSysconf()
 
 void SConfig::LoadSettings()
 {
+  Config::Load();
+
   INFO_LOG(BOOT, "Loading Settings from %s", File::GetUserPath(F_DOLPHINCONFIG_IDX).c_str());
   IniFile ini;
   ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="Boot\Boot_WiiWAD.cpp" />
     <ClCompile Include="Boot\ElfReader.cpp" />
     <ClCompile Include="Config\Config.cpp" />
+    <ClCompile Include="Config\GraphicsSettings.cpp" />
     <ClCompile Include="ConfigLoaders\BaseConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\GameConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\IsSettingSaveable.cpp" />
@@ -310,6 +311,7 @@
     <ClInclude Include="Boot\ElfReader.h" />
     <ClInclude Include="Boot\ElfTypes.h" />
     <ClInclude Include="Config\Config.h" />
+    <ClInclude Include="Config\GraphicsSettings.h" />
     <ClInclude Include="ConfigLoaders\BaseConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\GameConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\IsSettingSaveable.h" />

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -59,6 +59,7 @@
     <ClCompile Include="Config\Config.cpp" />
     <ClCompile Include="ConfigLoaders\BaseConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\GameConfigLoader.cpp" />
+    <ClCompile Include="ConfigLoaders\IsSettingSaveable.cpp" />
     <ClCompile Include="ConfigLoaders\MovieConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\NetPlayConfigLoader.cpp" />
     <ClCompile Include="ConfigManager.cpp" />
@@ -311,6 +312,7 @@
     <ClInclude Include="Config\Config.h" />
     <ClInclude Include="ConfigLoaders\BaseConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\GameConfigLoader.h" />
+    <ClInclude Include="ConfigLoaders\IsSettingSaveable.h" />
     <ClInclude Include="ConfigLoaders\MovieConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\NetPlayConfigLoader.h" />
     <ClInclude Include="ConfigManager.h" />

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -35,6 +35,16 @@
     <Import Project="..\..\VSProps\PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ActionReplay.cpp" />
     <ClCompile Include="Analytics.cpp" />
@@ -46,6 +56,7 @@
     <ClCompile Include="Boot\Boot_ELF.cpp" />
     <ClCompile Include="Boot\Boot_WiiWAD.cpp" />
     <ClCompile Include="Boot\ElfReader.cpp" />
+    <ClCompile Include="Config\Config.cpp" />
     <ClCompile Include="ConfigLoaders\BaseConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\GameConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\MovieConfigLoader.cpp" />
@@ -297,6 +308,7 @@
     <ClInclude Include="Boot\Boot_DOL.h" />
     <ClInclude Include="Boot\ElfReader.h" />
     <ClInclude Include="Boot\ElfTypes.h" />
+    <ClInclude Include="Config\Config.h" />
     <ClInclude Include="ConfigLoaders\BaseConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\GameConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\MovieConfigLoader.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -853,6 +853,7 @@
     <ClCompile Include="ConfigLoaders\NetPlayConfigLoader.cpp">
       <Filter>ConfigLoader</Filter>
     </ClCompile>
+    <ClCompile Include="Config\Config.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BootManager.h" />
@@ -1486,6 +1487,7 @@
     <ClInclude Include="ConfigLoaders\NetPlayConfigLoader.h">
       <Filter>ConfigLoader</Filter>
     </ClInclude>
+    <ClInclude Include="Config\Config.h" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -853,6 +853,9 @@
     <ClCompile Include="ConfigLoaders\NetPlayConfigLoader.cpp">
       <Filter>ConfigLoader</Filter>
     </ClCompile>
+    <ClCompile Include="ConfigLoaders\IsSettingSaveable.cpp">
+      <Filter>ConfigLoader</Filter>
+    </ClCompile>
     <ClCompile Include="Config\Config.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -1488,6 +1491,9 @@
       <Filter>ConfigLoader</Filter>
     </ClInclude>
     <ClInclude Include="Config\Config.h" />
+    <ClInclude Include="ConfigLoaders\IsSettingSaveable.h">
+      <Filter>ConfigLoader</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -857,6 +857,7 @@
       <Filter>ConfigLoader</Filter>
     </ClCompile>
     <ClCompile Include="Config\Config.cpp" />
+    <ClCompile Include="Config\GraphicsSettings.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BootManager.h" />
@@ -1491,6 +1492,7 @@
       <Filter>ConfigLoader</Filter>
     </ClInclude>
     <ClInclude Include="Config\Config.h" />
+    <ClInclude Include="Config\GraphicsSettings.h" />
     <ClInclude Include="ConfigLoaders\IsSettingSaveable.h">
       <Filter>ConfigLoader</Filter>
     </ClInclude>

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -42,6 +42,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/DVD/DVDInterface.h"
@@ -1423,41 +1424,46 @@ void CFrame::ParseHotkeys()
   if (IsHotkey(HK_INCREASE_IR))
   {
     OSDChoice = 1;
-    ++g_Config.iEFBScale;
+    Config::SetCurrent(Config::GFX_EFB_SCALE, Config::Get(Config::GFX_EFB_SCALE) + 1);
   }
   if (IsHotkey(HK_DECREASE_IR))
   {
     OSDChoice = 1;
-    if (--g_Config.iEFBScale < SCALE_AUTO)
-      g_Config.iEFBScale = SCALE_AUTO;
+    if (Config::Get(Config::GFX_EFB_SCALE) > SCALE_AUTO)
+      Config::SetCurrent(Config::GFX_EFB_SCALE, Config::Get(Config::GFX_EFB_SCALE) - 1);
   }
   if (IsHotkey(HK_TOGGLE_CROP))
   {
-    g_Config.bCrop = !g_Config.bCrop;
+    Config::SetCurrent(Config::GFX_CROP, !Config::Get(Config::GFX_CROP));
   }
   if (IsHotkey(HK_TOGGLE_AR))
   {
     OSDChoice = 2;
     // Toggle aspect ratio
-    g_Config.iAspectRatio = (g_Config.iAspectRatio + 1) & 3;
+    int aspect_ratio = Config::Get(Config::GFX_ASPECT_RATIO);
+    aspect_ratio = (aspect_ratio + 1) & 3;
+    Config::SetCurrent(Config::GFX_ASPECT_RATIO, aspect_ratio);
   }
   if (IsHotkey(HK_TOGGLE_EFBCOPIES))
   {
     OSDChoice = 3;
     // Toggle EFB copies between EFB2RAM and EFB2Texture
-    g_Config.bSkipEFBCopyToRam = !g_Config.bSkipEFBCopyToRam;
+    Config::SetCurrent(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM,
+                       !Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM));
   }
   if (IsHotkey(HK_TOGGLE_FOG))
   {
     OSDChoice = 4;
-    g_Config.bDisableFog = !g_Config.bDisableFog;
+    Config::SetCurrent(Config::GFX_DISABLE_FOG, !Config::Get(Config::GFX_DISABLE_FOG));
   }
   if (IsHotkey(HK_TOGGLE_DUMPTEXTURES))
   {
-    g_Config.bDumpTextures = !g_Config.bDumpTextures;
+    Config::SetCurrent(Config::GFX_DUMP_TEXTURES, !Config::Get(Config::GFX_DUMP_TEXTURES));
   }
   if (IsHotkey(HK_TOGGLE_TEXTURES))
-    g_Config.bHiresTextures = !g_Config.bHiresTextures;
+  {
+    Config::SetCurrent(Config::GFX_HIRES_TEXTURES, !Config::Get(Config::GFX_HIRES_TEXTURES));
+  }
   Core::SetIsThrottlerTempDisabled(IsHotkey(HK_TOGGLE_THROTTLE, true));
   if (IsHotkey(HK_DECREASE_EMULATION_SPEED))
   {
@@ -1503,13 +1509,13 @@ void CFrame::ParseHotkeys()
       // turned off when selecting other stereoscopy modes.
       if (g_Config.sPostProcessingShader == "dubois")
       {
-        g_Config.sPostProcessingShader = "";
+        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
       }
-      g_Config.iStereoMode = STEREO_SBS;
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_SBS));
     }
     else
     {
-      g_Config.iStereoMode = STEREO_OFF;
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_TAB))
@@ -1518,13 +1524,13 @@ void CFrame::ParseHotkeys()
     {
       if (g_Config.sPostProcessingShader == "dubois")
       {
-        g_Config.sPostProcessingShader = "";
+        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
       }
-      g_Config.iStereoMode = STEREO_TAB;
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_TAB));
     }
     else
     {
-      g_Config.iStereoMode = STEREO_OFF;
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_ANAGLYPH))
@@ -1533,13 +1539,13 @@ void CFrame::ParseHotkeys()
     {
       // Setting the anaglyph mode also requires a specific
       // post-processing shader to be activated.
-      g_Config.iStereoMode = STEREO_ANAGLYPH;
-      g_Config.sPostProcessingShader = "dubois";
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_ANAGLYPH));
+      Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string("dubois"));
     }
     else
     {
-      g_Config.iStereoMode = STEREO_OFF;
-      g_Config.sPostProcessingShader = "";
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
+      Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_3DVISION))
@@ -1548,37 +1554,35 @@ void CFrame::ParseHotkeys()
     {
       if (g_Config.sPostProcessingShader == "dubois")
       {
-        g_Config.sPostProcessingShader = "";
+        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
       }
-      g_Config.iStereoMode = STEREO_3DVISION;
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_3DVISION));
     }
     else
     {
-      g_Config.iStereoMode = STEREO_OFF;
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
     }
   }
 
   if (IsHotkey(HK_DECREASE_DEPTH, true))
   {
-    if (--g_Config.iStereoDepth < 0)
-      g_Config.iStereoDepth = 0;
+    if (g_Config.iStereoDepth > 0)
+      Config::SetCurrent(Config::GFX_STEREO_DEPTH, g_Config.iStereoDepth - 1);
   }
   if (IsHotkey(HK_INCREASE_DEPTH, true))
   {
-    if (++g_Config.iStereoDepth > 100)
-      g_Config.iStereoDepth = 100;
+    if (g_Config.iStereoDepth < 100)
+      Config::SetCurrent(Config::GFX_STEREO_DEPTH, g_Config.iStereoDepth + 1);
   }
   if (IsHotkey(HK_DECREASE_CONVERGENCE, true))
   {
-    g_Config.iStereoConvergence -= 5;
-    if (g_Config.iStereoConvergence < 0)
-      g_Config.iStereoConvergence = 0;
+    int convergence = std::max(0, g_Config.iStereoConvergence - 5);
+    Config::SetCurrent(Config::GFX_STEREO_CONVERGENCE, convergence);
   }
   if (IsHotkey(HK_INCREASE_CONVERGENCE, true))
   {
-    g_Config.iStereoConvergence += 5;
-    if (g_Config.iStereoConvergence > 500)
-      g_Config.iStereoConvergence = 500;
+    int convergence = std::min(500, g_Config.iStereoConvergence + 5);
+    Config::SetCurrent(Config::GFX_STEREO_CONVERGENCE, convergence);
   }
 
   static float debugSpeed = 1.0f;

--- a/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
+++ b/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
@@ -15,19 +15,20 @@
 #include <wx/textctrl.h>
 
 #include "Common/FileUtil.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/Core.h"
 #include "DolphinWX/SoftwareVideoConfigDialog.h"
 #include "DolphinWX/VideoConfigDiag.h"
 #include "DolphinWX/WxUtils.h"
 
-template <typename T>
-IntegerSetting<T>::IntegerSetting(wxWindow* parent, const wxString& label, T& setting, int minVal,
-                                  int maxVal, long style)
+IntegerSetting::IntegerSetting(wxWindow* parent, const wxString& label,
+                               const Config::ConfigInfo<int>& setting, int minVal, int maxVal,
+                               long style)
     : wxSpinCtrl(parent, wxID_ANY, label, wxDefaultPosition, wxDefaultSize, style),
       m_setting(setting)
 {
   SetRange(minVal, maxVal);
-  SetValue(m_setting);
+  SetValue(Config::Get(m_setting));
   Bind(wxEVT_SPINCTRL, &IntegerSetting::UpdateValue, this);
 }
 
@@ -35,9 +36,6 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
     : wxDialog(parent, wxID_ANY,
                wxString(wxString::Format(_("Dolphin %s Graphics Configuration"), title)))
 {
-  VideoConfig& vconfig = g_Config;
-  vconfig.Load(File::GetUserPath(D_CONFIG_IDX) + "GFX.ini");
-
   wxNotebook* const notebook = new wxNotebook(this, wxID_ANY);
 
   const int space5 = FromDIP(5);
@@ -82,7 +80,7 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
 
       // xfb
       szr_rendering->Add(
-          new SettingCheckBox(page_general, _("Bypass XFB"), "", vconfig.bUseXFB, true));
+          new SettingCheckBox(page_general, _("Bypass XFB"), "", Config::GFX_USE_XFB, true));
     }
 
     // - info
@@ -95,8 +93,8 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
       group_info->Add(szr_info, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
       group_info->AddSpacer(space5);
 
-      szr_info->Add(
-          new SettingCheckBox(page_general, _("Various Statistics"), "", vconfig.bOverlayStats));
+      szr_info->Add(new SettingCheckBox(page_general, _("Various Statistics"), "",
+                                        Config::GFX_OVERLAY_STATS));
     }
 
     // - utility
@@ -110,9 +108,9 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
       group_utility->AddSpacer(space5);
 
       szr_utility->Add(
-          new SettingCheckBox(page_general, _("Dump Textures"), "", vconfig.bDumpTextures));
+          new SettingCheckBox(page_general, _("Dump Textures"), "", Config::GFX_DUMP_TEXTURES));
       szr_utility->Add(
-          new SettingCheckBox(page_general, _("Dump Objects"), "", vconfig.bDumpObjects));
+          new SettingCheckBox(page_general, _("Dump Objects"), "", Config::GFX_SW_DUMP_OBJECTS));
 
       // - debug only
       wxStaticBoxSizer* const group_debug_only_utility =
@@ -124,10 +122,10 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
       group_debug_only_utility->Add(szr_debug_only_utility, 0, wxEXPAND | wxBOTTOM, space5);
       group_debug_only_utility->AddSpacer(space5);
 
-      szr_debug_only_utility->Add(
-          new SettingCheckBox(page_general, _("Dump TEV Stages"), "", vconfig.bDumpTevStages));
+      szr_debug_only_utility->Add(new SettingCheckBox(page_general, _("Dump TEV Stages"), "",
+                                                      Config::GFX_SW_DUMP_TEV_STAGES));
       szr_debug_only_utility->Add(new SettingCheckBox(page_general, _("Dump Texture Fetches"), "",
-                                                      vconfig.bDumpTevTextureFetches));
+                                                      Config::GFX_SW_DUMP_TEV_TEX_FETCHES));
     }
 
     // - misc
@@ -141,8 +139,8 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
       group_misc->AddSpacer(space5);
 
       szr_misc->Add(
-          new IntegerSetting<int>(page_general, _("Start"), vconfig.drawStart, 0, 100000));
-      szr_misc->Add(new IntegerSetting<int>(page_general, _("End"), vconfig.drawEnd, 0, 100000));
+          new IntegerSetting(page_general, _("Start"), Config::GFX_SW_DRAW_START, 0, 100000));
+      szr_misc->Add(new IntegerSetting(page_general, _("End"), Config::GFX_SW_DRAW_END, 0, 100000));
     }
 
     szr_general->AddSpacer(space5);
@@ -168,5 +166,5 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
 
 SoftwareVideoConfigDialog::~SoftwareVideoConfigDialog()
 {
-  g_Config.Save((File::GetUserPath(D_CONFIG_IDX) + "GFX.ini").c_str());
+  Config::Save();
 }

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -7,10 +7,12 @@
 #endif
 
 #include "Common/CommonPaths.h"
+#include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
 
+#include "Core/ConfigLoaders/BaseConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Wiimote.h"
 
@@ -26,6 +28,8 @@ namespace UICommon
 void Init()
 {
   LogManager::Init();
+  Config::Init();
+  Config::AddLoadLayer(ConfigLoaders::GenerateBaseConfigLoader());
   SConfig::Init();
   VideoBackendBase::PopulateList();
   WiimoteReal::LoadSettings();
@@ -41,6 +45,7 @@ void Shutdown()
   WiimoteReal::Shutdown();
   VideoBackendBase::ClearList();
   SConfig::Shutdown();
+  Config::Shutdown();
   LogManager::Shutdown();
 }
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -8,6 +8,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DState.h"
@@ -319,7 +320,7 @@ HRESULT Create(HWND wnd)
         return desc.Count == g_Config.iMultisamples;
       }) == aa_modes.end())
   {
-    g_Config.iMultisamples = 1;
+    Config::SetCurrent(Config::GFX_MSAA, 1);
     UpdateActiveConfig();
   }
 

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -9,6 +9,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/GraphicsSettings.h"
+
 #include "VideoBackends/OGL/FramebufferManager.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/SamplerCache.h"
@@ -139,7 +141,7 @@ void OpenGLPostProcessing::ApplyShader()
   if (!ProgramShaderCache::CompileShader(m_shader, s_vertex_shader, code))
   {
     ERROR_LOG(VIDEO, "Failed to compile post-processing shader %s", m_config.GetShader().c_str());
-    g_ActiveConfig.sPostProcessingShader.clear();
+    Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
     code = m_config.LoadShader();
     ProgramShaderCache::CompileShader(m_shader, s_vertex_shader, code);
   }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -23,6 +23,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/Core.h"
 
 #include "VideoBackends/OGL/BoundingBox.h"
@@ -518,7 +519,7 @@ Renderer::Renderer()
       {
         // GLES 3.1 can't support stereo rendering and MSAA
         OSD::AddMessage("MSAA Stereo rendering isn't supported by your GPU.", 10000);
-        g_ActiveConfig.iMultisamples = 1;
+        Config::SetCurrent(Config::GFX_MSAA, 1);
       }
     }
     else

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -12,6 +12,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoBackends/Software/EfbCopy.h"
@@ -142,7 +143,9 @@ void SWRenderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
   // virtual XFB is not supported
   if (g_ActiveConfig.bUseXFB)
-    g_ActiveConfig.bUseRealXFB = true;
+  {
+    Config::SetCurrent(Config::GFX_USE_REAL_XFB, true);
+  }
 }
 
 u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -27,6 +27,7 @@
 #include "Common/Swap.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoConfig.h"
@@ -196,7 +197,7 @@ void HiresTexture::Prefetch()
 
     if (size_sum > max_mem)
     {
-      g_Config.bCacheHiresTextures = false;
+      Config::SetCurrent(Config::GFX_HIRES_TEXTURES, false);
 
       OSD::AddMessage(
           StringFromFormat(

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -190,8 +190,7 @@ void VideoBackendBase::InitializeShared()
   GeometryShaderManager::Init();
   PixelShaderManager::Init();
 
-  g_Config.Load(File::GetUserPath(D_CONFIG_IDX) + "GFX.ini");
-  g_Config.GameIniLoad();
+  g_Config.Refresh();
   g_Config.UpdateProjectionHack();
   g_Config.VerifyValidity();
   UpdateActiveConfig();

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -10,6 +10,7 @@
 #include "Common/IniFile.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Movie.h"
@@ -19,6 +20,7 @@
 
 VideoConfig g_Config;
 VideoConfig g_ActiveConfig;
+static bool s_has_registered_callback = false;
 
 void UpdateActiveConfig()
 {
@@ -47,92 +49,118 @@ VideoConfig::VideoConfig()
   bBackendMultithreading = true;
 }
 
-void VideoConfig::Load(const std::string& ini_file)
+void VideoConfig::Refresh()
 {
-  IniFile iniFile;
-  iniFile.Load(ini_file);
+  if (!s_has_registered_callback)
+  {
+    Config::AddConfigChangedCallback([]() { g_Config.Refresh(); });
+    s_has_registered_callback = true;
+  }
 
-  IniFile::Section* hardware = iniFile.GetOrCreateSection("Hardware");
-  hardware->Get("VSync", &bVSync, false);
-  hardware->Get("Adapter", &iAdapter, 0);
+  bVSync = Config::Get(Config::GFX_VSYNC);
+  iAdapter = Config::Get(Config::GFX_ADAPTER);
 
-  IniFile::Section* settings = iniFile.GetOrCreateSection("Settings");
-  settings->Get("wideScreenHack", &bWidescreenHack, false);
-  settings->Get("AspectRatio", &iAspectRatio, (int)ASPECT_AUTO);
-  settings->Get("Crop", &bCrop, false);
-  settings->Get("UseXFB", &bUseXFB, false);
-  settings->Get("UseRealXFB", &bUseRealXFB, false);
-  settings->Get("SafeTextureCacheColorSamples", &iSafeTextureCache_ColorSamples, 128);
-  settings->Get("ShowFPS", &bShowFPS, false);
-  settings->Get("ShowNetPlayPing", &bShowNetPlayPing, false);
-  settings->Get("ShowNetPlayMessages", &bShowNetPlayMessages, false);
-  settings->Get("LogRenderTimeToFile", &bLogRenderTimeToFile, false);
-  settings->Get("OverlayStats", &bOverlayStats, false);
-  settings->Get("OverlayProjStats", &bOverlayProjStats, false);
-  settings->Get("DumpTextures", &bDumpTextures, false);
-  settings->Get("HiresTextures", &bHiresTextures, false);
-  settings->Get("ConvertHiresTextures", &bConvertHiresTextures, false);
-  settings->Get("CacheHiresTextures", &bCacheHiresTextures, false);
-  settings->Get("DumpEFBTarget", &bDumpEFBTarget, false);
-  settings->Get("DumpFramesAsImages", &bDumpFramesAsImages, false);
-  settings->Get("FreeLook", &bFreeLook, false);
-  settings->Get("UseFFV1", &bUseFFV1, false);
-  settings->Get("DumpFormat", &sDumpFormat, "avi");
-  settings->Get("DumpCodec", &sDumpCodec, "");
-  settings->Get("DumpPath", &sDumpPath, "");
-  settings->Get("BitrateKbps", &iBitrateKbps, 2500);
-  settings->Get("InternalResolutionFrameDumps", &bInternalResolutionFrameDumps, false);
-  settings->Get("EnableGPUTextureDecoding", &bEnableGPUTextureDecoding, false);
-  settings->Get("EnablePixelLighting", &bEnablePixelLighting, false);
-  settings->Get("FastDepthCalc", &bFastDepthCalc, true);
-  settings->Get("MSAA", &iMultisamples, 1);
-  settings->Get("SSAA", &bSSAA, false);
-  settings->Get("EFBScale", &iEFBScale, (int)SCALE_1X);  // native
-  settings->Get("TexFmtOverlayEnable", &bTexFmtOverlayEnable, false);
-  settings->Get("TexFmtOverlayCenter", &bTexFmtOverlayCenter, false);
-  settings->Get("WireFrame", &bWireFrame, false);
-  settings->Get("DisableFog", &bDisableFog, false);
-  settings->Get("BorderlessFullscreen", &bBorderlessFullscreen, false);
-  settings->Get("EnableValidationLayer", &bEnableValidationLayer, false);
-  settings->Get("BackendMultithreading", &bBackendMultithreading, true);
-  settings->Get("CommandBufferExecuteInterval", &iCommandBufferExecuteInterval, 100);
-  settings->Get("ShaderCache", &bShaderCache, true);
+  bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
+  iAspectRatio = Config::Get(Config::GFX_ASPECT_RATIO);
+  bCrop = Config::Get(Config::GFX_CROP);
+  bUseXFB = Config::Get(Config::GFX_USE_XFB);
+  bUseRealXFB = Config::Get(Config::GFX_USE_REAL_XFB);
+  iSafeTextureCache_ColorSamples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
+  bShowFPS = Config::Get(Config::GFX_SHOW_FPS);
+  bShowNetPlayPing = Config::Get(Config::GFX_SHOW_NETPLAY_PING);
+  bShowNetPlayMessages = Config::Get(Config::GFX_SHOW_NETPLAY_MESSAGES);
+  bLogRenderTimeToFile = Config::Get(Config::GFX_LOG_RENDER_TIME_TO_FILE);
+  bOverlayStats = Config::Get(Config::GFX_OVERLAY_STATS);
+  bOverlayProjStats = Config::Get(Config::GFX_OVERLAY_PROJ_STATS);
+  bDumpTextures = Config::Get(Config::GFX_DUMP_TEXTURES);
+  bHiresTextures = Config::Get(Config::GFX_HIRES_TEXTURES);
+  bConvertHiresTextures = Config::Get(Config::GFX_CONVERT_HIRES_TEXTURES);
+  bCacheHiresTextures = Config::Get(Config::GFX_CACHE_HIRES_TEXTURES);
+  bDumpEFBTarget = Config::Get(Config::GFX_DUMP_EFB_TARGET);
+  bDumpFramesAsImages = Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
+  bFreeLook = Config::Get(Config::GFX_FREE_LOOK);
+  bUseFFV1 = Config::Get(Config::GFX_USE_FFV1);
+  sDumpFormat = Config::Get(Config::GFX_DUMP_FORMAT);
+  sDumpCodec = Config::Get(Config::GFX_DUMP_CODEC);
+  sDumpPath = Config::Get(Config::GFX_DUMP_PATH);
+  iBitrateKbps = Config::Get(Config::GFX_BITRATE_KBPS);
+  bInternalResolutionFrameDumps = Config::Get(Config::GFX_INTERNAL_RESOLUTION_FRAME_DUMPS);
+  bEnableGPUTextureDecoding = Config::Get(Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
+  bEnablePixelLighting = Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING);
+  bFastDepthCalc = Config::Get(Config::GFX_FAST_DEPTH_CALC);
+  iMultisamples = Config::Get(Config::GFX_MSAA);
+  bSSAA = Config::Get(Config::GFX_SSAA);
+  iEFBScale = Config::Get(Config::GFX_EFB_SCALE);
+  bTexFmtOverlayEnable = Config::Get(Config::GFX_TEXFMT_OVERLAY_ENABLE);
+  bTexFmtOverlayCenter = Config::Get(Config::GFX_TEXFMT_OVERLAY_CENTER);
+  bWireFrame = Config::Get(Config::GFX_ENABLE_WIREFRAME);
+  bDisableFog = Config::Get(Config::GFX_DISABLE_FOG);
+  bBorderlessFullscreen = Config::Get(Config::GFX_BORDERLESS_FULLSCREEN);
+  bEnableValidationLayer = Config::Get(Config::GFX_ENABLE_VALIDATION_LAYER);
+  bBackendMultithreading = Config::Get(Config::GFX_BACKEND_MULTITHREADING);
+  iCommandBufferExecuteInterval = Config::Get(Config::GFX_COMMAND_BUFFER_EXECUTE_INTERVAL);
+  bShaderCache = Config::Get(Config::GFX_SHADER_CACHE);
 
-  settings->Get("SWZComploc", &bZComploc, true);
-  settings->Get("SWZFreeze", &bZFreeze, true);
-  settings->Get("SWDumpObjects", &bDumpObjects, false);
-  settings->Get("SWDumpTevStages", &bDumpTevStages, false);
-  settings->Get("SWDumpTevTexFetches", &bDumpTevTextureFetches, false);
-  settings->Get("SWDrawStart", &drawStart, 0);
-  settings->Get("SWDrawEnd", &drawEnd, 100000);
+  bZComploc = Config::Get(Config::GFX_SW_ZCOMPLOC);
+  bZFreeze = Config::Get(Config::GFX_SW_ZFREEZE);
+  bDumpObjects = Config::Get(Config::GFX_SW_DUMP_OBJECTS);
+  bDumpTevStages = Config::Get(Config::GFX_SW_DUMP_TEV_STAGES);
+  bDumpTevTextureFetches = Config::Get(Config::GFX_SW_DUMP_TEV_TEX_FETCHES);
+  drawStart = Config::Get(Config::GFX_SW_DRAW_START);
+  drawEnd = Config::Get(Config::GFX_SW_DRAW_END);
 
-  IniFile::Section* enhancements = iniFile.GetOrCreateSection("Enhancements");
-  enhancements->Get("ForceFiltering", &bForceFiltering, false);
-  enhancements->Get("MaxAnisotropy", &iMaxAnisotropy, 0);  // NOTE - this is x in (1 << x)
-  enhancements->Get("PostProcessingShader", &sPostProcessingShader, "");
-  enhancements->Get("ForceTrueColor", &bForceTrueColor, true);
+  bForceFiltering = Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING);
+  iMaxAnisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
+  sPostProcessingShader = Config::Get(Config::GFX_ENHANCE_POST_SHADER);
+  bForceTrueColor = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
 
-  IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
-  stereoscopy->Get("StereoMode", &iStereoMode, 0);
-  stereoscopy->Get("StereoDepth", &iStereoDepth, 20);
-  stereoscopy->Get("StereoConvergencePercentage", &iStereoConvergencePercentage, 100);
-  stereoscopy->Get("StereoSwapEyes", &bStereoSwapEyes, false);
+  iStereoMode = Config::Get(Config::GFX_STEREO_MODE);
+  iStereoDepth = Config::Get(Config::GFX_STEREO_DEPTH);
+  iStereoConvergencePercentage = Config::Get(Config::GFX_STEREO_CONVERGENCE_PERCENTAGE);
+  bStereoSwapEyes = Config::Get(Config::GFX_STEREO_SWAP_EYES);
+  iStereoConvergence = Config::Get(Config::GFX_STEREO_CONVERGENCE);
+  bStereoEFBMonoDepth = Config::Get(Config::GFX_STEREO_EFB_MONO_DEPTH);
+  iStereoDepthPercentage = Config::Get(Config::GFX_STEREO_DEPTH_PERCENTAGE);
 
-  IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
-  hacks->Get("EFBAccessEnable", &bEFBAccessEnable, true);
-  hacks->Get("BBoxEnable", &bBBoxEnable, false);
-  hacks->Get("BBoxPreferStencilImplementation", &bBBoxPreferStencilImplementation, false);
-  hacks->Get("ForceProgressive", &bForceProgressive, true);
-  hacks->Get("EFBToTextureEnable", &bSkipEFBCopyToRam, true);
-  hacks->Get("EFBScaledCopy", &bCopyEFBScaled, true);
-  hacks->Get("EFBEmulateFormatChanges", &bEFBEmulateFormatChanges, false);
-  hacks->Get("VertexRounding", &bVertexRounding, false);
+  bEFBAccessEnable = Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
+  bBBoxEnable = Config::Get(Config::GFX_HACK_BBOX_ENABLE);
+  bBBoxPreferStencilImplementation =
+      Config::Get(Config::GFX_HACK_BBOX_PREFER_STENCIL_IMPLEMENTATION);
+  bForceProgressive = Config::Get(Config::GFX_HACK_FORCE_PROGRESSIVE);
+  bSkipEFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
+  bCopyEFBScaled = Config::Get(Config::GFX_HACK_COPY_EFB_ENABLED);
+  bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
+  bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
 
-  // hacks which are disabled by default
-  iPhackvalue[0] = 0;
-  bPerfQueriesEnable = false;
+  iPhackvalue[0] = Config::Get(Config::GFX_PROJECTION_HACK);
+  iPhackvalue[1] = Config::Get(Config::GFX_PROJECTION_HACK_SZNEAR);
+  iPhackvalue[2] = Config::Get(Config::GFX_PROJECTION_HACK_SZFAR);
+  sPhackvalue[0] = Config::Get(Config::GFX_PROJECTION_HACK_ZNEAR);
+  sPhackvalue[1] = Config::Get(Config::GFX_PROJECTION_HACK_ZFAR);
+  bPerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);
+
+  if (iEFBScale == SCALE_FORCE_INTEGRAL)
+  {
+    // Round down to multiple of native IR
+    switch (Config::GetBase(Config::GFX_EFB_SCALE))
+    {
+    case SCALE_AUTO:
+      iEFBScale = SCALE_AUTO_INTEGRAL;
+      break;
+    case SCALE_1_5X:
+      iEFBScale = SCALE_1X;
+      break;
+    case SCALE_2_5X:
+      iEFBScale = SCALE_2X;
+      break;
+    default:
+      iEFBScale = Config::GetBase(Config::GFX_EFB_SCALE);
+      break;
+    }
+  }
 
   // Load common settings
+  IniFile iniFile;
   iniFile.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
   IniFile::Section* interface = iniFile.GetOrCreateSection("Interface");
   bool bTmp;
@@ -140,109 +168,6 @@ void VideoConfig::Load(const std::string& ini_file)
   SetEnableAlert(bTmp);
 
   VerifyValidity();
-}
-
-void VideoConfig::GameIniLoad()
-{
-  bool gfx_override_exists = false;
-
-// XXX: Again, bad place to put OSD messages at (see delroth's comment above)
-// XXX: This will add an OSD message for each projection hack value... meh
-#define CHECK_SETTING(section, key, var)                                                           \
-  do                                                                                               \
-  {                                                                                                \
-    decltype(var) temp = var;                                                                      \
-    if (iniFile.GetIfExists(section, key, &var) && var != temp)                                    \
-    {                                                                                              \
-      std::string msg = StringFromFormat("Note: Option \"%s\" is overridden by game ini.", key);   \
-      OSD::AddMessage(msg, 7500);                                                                  \
-      gfx_override_exists = true;                                                                  \
-    }                                                                                              \
-  } while (0)
-
-  IniFile iniFile = SConfig::GetInstance().LoadGameIni();
-
-  CHECK_SETTING("Video_Hardware", "VSync", bVSync);
-
-  CHECK_SETTING("Video_Settings", "wideScreenHack", bWidescreenHack);
-  CHECK_SETTING("Video_Settings", "AspectRatio", iAspectRatio);
-  CHECK_SETTING("Video_Settings", "Crop", bCrop);
-  CHECK_SETTING("Video_Settings", "UseXFB", bUseXFB);
-  CHECK_SETTING("Video_Settings", "UseRealXFB", bUseRealXFB);
-  CHECK_SETTING("Video_Settings", "SafeTextureCacheColorSamples", iSafeTextureCache_ColorSamples);
-  CHECK_SETTING("Video_Settings", "HiresTextures", bHiresTextures);
-  CHECK_SETTING("Video_Settings", "ConvertHiresTextures", bConvertHiresTextures);
-  CHECK_SETTING("Video_Settings", "CacheHiresTextures", bCacheHiresTextures);
-  CHECK_SETTING("Video_Settings", "EnablePixelLighting", bEnablePixelLighting);
-  CHECK_SETTING("Video_Settings", "FastDepthCalc", bFastDepthCalc);
-  CHECK_SETTING("Video_Settings", "MSAA", iMultisamples);
-  CHECK_SETTING("Video_Settings", "SSAA", bSSAA);
-  CHECK_SETTING("Video_Settings", "ForceTrueColor", bForceTrueColor);
-
-  int tmp = -9000;
-  CHECK_SETTING("Video_Settings", "EFBScale", tmp);  // integral
-  if (tmp != -9000)
-  {
-    if (tmp != SCALE_FORCE_INTEGRAL)
-    {
-      iEFBScale = tmp;
-    }
-    else  // Round down to multiple of native IR
-    {
-      switch (iEFBScale)
-      {
-      case SCALE_AUTO:
-        iEFBScale = SCALE_AUTO_INTEGRAL;
-        break;
-      case SCALE_1_5X:
-        iEFBScale = SCALE_1X;
-        break;
-      case SCALE_2_5X:
-        iEFBScale = SCALE_2X;
-        break;
-      default:
-        break;
-      }
-    }
-  }
-
-  CHECK_SETTING("Video_Settings", "DisableFog", bDisableFog);
-  CHECK_SETTING("Video_Settings", "BackendMultithreading", bBackendMultithreading);
-  CHECK_SETTING("Video_Settings", "CommandBufferExecuteInterval", iCommandBufferExecuteInterval);
-
-  CHECK_SETTING("Video_Enhancements", "ForceFiltering", bForceFiltering);
-  CHECK_SETTING("Video_Enhancements", "MaxAnisotropy",
-                iMaxAnisotropy);  // NOTE - this is x in (1 << x)
-  CHECK_SETTING("Video_Enhancements", "PostProcessingShader", sPostProcessingShader);
-
-  // These are not overrides, they are per-game stereoscopy parameters, hence no warning
-  iniFile.GetIfExists("Video_Stereoscopy", "StereoConvergence", &iStereoConvergence, 20);
-  iniFile.GetIfExists("Video_Stereoscopy", "StereoEFBMonoDepth", &bStereoEFBMonoDepth, false);
-  iniFile.GetIfExists("Video_Stereoscopy", "StereoDepthPercentage", &iStereoDepthPercentage, 100);
-
-  CHECK_SETTING("Video_Stereoscopy", "StereoMode", iStereoMode);
-  CHECK_SETTING("Video_Stereoscopy", "StereoDepth", iStereoDepth);
-  CHECK_SETTING("Video_Stereoscopy", "StereoSwapEyes", bStereoSwapEyes);
-
-  CHECK_SETTING("Video_Hacks", "EFBAccessEnable", bEFBAccessEnable);
-  CHECK_SETTING("Video_Hacks", "BBoxEnable", bBBoxEnable);
-  CHECK_SETTING("Video_Hacks", "ForceProgressive", bForceProgressive);
-  CHECK_SETTING("Video_Hacks", "EFBToTextureEnable", bSkipEFBCopyToRam);
-  CHECK_SETTING("Video_Hacks", "EFBScaledCopy", bCopyEFBScaled);
-  CHECK_SETTING("Video_Hacks", "EFBEmulateFormatChanges", bEFBEmulateFormatChanges);
-  CHECK_SETTING("Video_Hacks", "VertexRounding", bVertexRounding);
-
-  CHECK_SETTING("Video", "ProjectionHack", iPhackvalue[0]);
-  CHECK_SETTING("Video", "PH_SZNear", iPhackvalue[1]);
-  CHECK_SETTING("Video", "PH_SZFar", iPhackvalue[2]);
-  CHECK_SETTING("Video", "PH_ZNear", sPhackvalue[0]);
-  CHECK_SETTING("Video", "PH_ZFar", sPhackvalue[1]);
-  CHECK_SETTING("Video", "PerfQueriesEnable", bPerfQueriesEnable);
-
-  if (gfx_override_exists)
-    OSD::AddMessage(
-        "Warning: Opening the graphics configuration will reset settings and might cause issues!",
-        10000);
 }
 
 void VideoConfig::VerifyValidity()
@@ -272,90 +197,6 @@ void VideoConfig::VerifyValidity()
       iStereoMode = 0;
     }
   }
-}
-
-void VideoConfig::Save(const std::string& ini_file)
-{
-  IniFile iniFile;
-  iniFile.Load(ini_file);
-
-  IniFile::Section* hardware = iniFile.GetOrCreateSection("Hardware");
-  hardware->Set("VSync", bVSync);
-  hardware->Set("Adapter", iAdapter);
-
-  IniFile::Section* settings = iniFile.GetOrCreateSection("Settings");
-  settings->Set("AspectRatio", iAspectRatio);
-  settings->Set("Crop", bCrop);
-  settings->Set("wideScreenHack", bWidescreenHack);
-  settings->Set("UseXFB", bUseXFB);
-  settings->Set("UseRealXFB", bUseRealXFB);
-  settings->Set("SafeTextureCacheColorSamples", iSafeTextureCache_ColorSamples);
-  settings->Set("ShowFPS", bShowFPS);
-  settings->Set("ShowNetPlayPing", bShowNetPlayPing);
-  settings->Set("ShowNetPlayMessages", bShowNetPlayMessages);
-  settings->Set("LogRenderTimeToFile", bLogRenderTimeToFile);
-  settings->Set("OverlayStats", bOverlayStats);
-  settings->Set("OverlayProjStats", bOverlayProjStats);
-  settings->Set("DumpTextures", bDumpTextures);
-  settings->Set("HiresTextures", bHiresTextures);
-  settings->Set("ConvertHiresTextures", bConvertHiresTextures);
-  settings->Set("CacheHiresTextures", bCacheHiresTextures);
-  settings->Set("DumpEFBTarget", bDumpEFBTarget);
-  settings->Set("DumpFramesAsImages", bDumpFramesAsImages);
-  settings->Set("FreeLook", bFreeLook);
-  settings->Set("UseFFV1", bUseFFV1);
-  settings->Set("DumpFormat", sDumpFormat);
-  settings->Set("DumpCodec", sDumpCodec);
-  settings->Set("DumpPath", sDumpPath);
-  settings->Set("BitrateKbps", iBitrateKbps);
-  settings->Set("InternalResolutionFrameDumps", bInternalResolutionFrameDumps);
-  settings->Set("EnableGPUTextureDecoding", bEnableGPUTextureDecoding);
-  settings->Set("EnablePixelLighting", bEnablePixelLighting);
-  settings->Set("FastDepthCalc", bFastDepthCalc);
-  settings->Set("MSAA", iMultisamples);
-  settings->Set("SSAA", bSSAA);
-  settings->Set("EFBScale", iEFBScale);
-  settings->Set("TexFmtOverlayEnable", bTexFmtOverlayEnable);
-  settings->Set("TexFmtOverlayCenter", bTexFmtOverlayCenter);
-  settings->Set("Wireframe", bWireFrame);
-  settings->Set("DisableFog", bDisableFog);
-  settings->Set("BorderlessFullscreen", bBorderlessFullscreen);
-  settings->Set("EnableValidationLayer", bEnableValidationLayer);
-  settings->Set("BackendMultithreading", bBackendMultithreading);
-  settings->Set("CommandBufferExecuteInterval", iCommandBufferExecuteInterval);
-  settings->Set("ShaderCache", bShaderCache);
-
-  settings->Set("SWZComploc", bZComploc);
-  settings->Set("SWZFreeze", bZFreeze);
-  settings->Set("SWDumpObjects", bDumpObjects);
-  settings->Set("SWDumpTevStages", bDumpTevStages);
-  settings->Set("SWDumpTevTexFetches", bDumpTevTextureFetches);
-  settings->Set("SWDrawStart", drawStart);
-  settings->Set("SWDrawEnd", drawEnd);
-
-  IniFile::Section* enhancements = iniFile.GetOrCreateSection("Enhancements");
-  enhancements->Set("ForceFiltering", bForceFiltering);
-  enhancements->Set("MaxAnisotropy", iMaxAnisotropy);
-  enhancements->Set("PostProcessingShader", sPostProcessingShader);
-  enhancements->Set("ForceTrueColor", bForceTrueColor);
-
-  IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
-  stereoscopy->Set("StereoMode", iStereoMode);
-  stereoscopy->Set("StereoDepth", iStereoDepth);
-  stereoscopy->Set("StereoConvergencePercentage", iStereoConvergencePercentage);
-  stereoscopy->Set("StereoSwapEyes", bStereoSwapEyes);
-
-  IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
-  hacks->Set("EFBAccessEnable", bEFBAccessEnable);
-  hacks->Set("BBoxEnable", bBBoxEnable);
-  hacks->Set("BBoxPreferStencilImplementation", bBBoxPreferStencilImplementation);
-  hacks->Set("ForceProgressive", bForceProgressive);
-  hacks->Set("EFBToTextureEnable", bSkipEFBCopyToRam);
-  hacks->Set("EFBScaledCopy", bCopyEFBScaled);
-  hacks->Set("EFBEmulateFormatChanges", bEFBEmulateFormatChanges);
-  hacks->Set("VertexRounding", bVertexRounding);
-
-  iniFile.Save(ini_file);
 }
 
 bool VideoConfig::IsVSync()

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -54,10 +54,8 @@ enum StereoMode
 struct VideoConfig final
 {
   VideoConfig();
-  void Load(const std::string& ini_file);
-  void GameIniLoad();
+  void Refresh();
   void VerifyValidity();
-  void Save(const std::string& ini_file);
   void UpdateProjectionHack();
   bool IsVSync();
 

--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <bitset>
 
+#include "Core/Config/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -36,6 +37,7 @@ public:
   ScopeInit()
   {
     Core::DeclareAsCPUThread();
+    Config::Init();
     SConfig::Init();
     PowerPC::Init(PowerPC::CORE_INTERPRETER);
     CoreTiming::Init();
@@ -45,6 +47,7 @@ public:
     CoreTiming::Shutdown();
     PowerPC::Shutdown();
     SConfig::Shutdown();
+    Config::Shutdown();
     Core::UndeclareAsCPUThread();
   }
 };

--- a/Source/UnitTests/Core/MMIOTest.cpp
+++ b/Source/UnitTests/Core/MMIOTest.cpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 
 #include "Common/CommonTypes.h"
+#include "Core/Config/Config.h"
 #include "Core/HW/MMIO.h"
 
 // Tests that the UniqueID function returns a "unique enough" identifier
@@ -29,6 +30,7 @@ TEST(UniqueID, UniqueEnough)
 
 TEST(IsMMIOAddress, SpecialAddresses)
 {
+  Config::Init();
   SConfig::Init();
   SConfig::GetInstance().bWii = true;
 
@@ -51,6 +53,7 @@ TEST(IsMMIOAddress, SpecialAddresses)
   EXPECT_TRUE(MMIO::IsMMIOAddress(0x0D800F10));  // Mirror of Wii MMIOs
 
   SConfig::Shutdown();
+  Config::Shutdown();
 }
 
 class MappingTest : public testing::Test


### PR DESCRIPTION
The is one of a series of PRs that will incrementally move us from the old configuration system to the new configuration system. The goal is to take the small steps in the right direction.

### Overview

* `Core/Config.h` has a list of `ConfigInfo` which are constant objects containing information about the location of each configuration setting and its default.
* `Core/Config.h` also contains functions that take `ConfigInfo` as arguments for manipulation of the configuration.
* In this PR we port `VideoConfig` over to the layered configuration system.

### UI Changes

* Opening the video configuration settings dialog no longer resets Game INI settings.
* Settings that have been overridden (by e.g. the Game INI) appear in bold.
* Changing a setting in video configuration setting dialog may nor may not be permanent while a game is running. If the setting was not overwritten (i.e.: it comes from the Base layer), the change is permanent. If the setting was overwritten (i.e.: it comes from another layer such as the GlobalGameINI layer), the change is temporary and lasts only for the current run.

![2017-05-18-vconfig](https://cloud.githubusercontent.com/assets/8682882/26214080/0f594684-3bf3-11e7-85f6-8168d0cdac54.png)
*In the above example, "Disable Bounding Box" is a setting overwritten by the Game INI. Changing it would only an effect for the current play-session.*

### Loose ends for future PRs

* The temporary function `IsSettingSaveable` allows the two configuration systems to co-exist without trampling over each other. This should be removed once the port is complete.
* The `ini_to_location` map in `GameConfigLoader.cpp` will fill up with other mappings as more settings are ported to the layered configuration system.
* Futher improving the UX of the video configuration dialog is left for future PRs. Ideally there should be more feedback to the user about what is going on.