### PR TITLE
IP/Top: Implement GetInterfaceOpt hardcoded cases

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -804,6 +804,10 @@ IPCCommandResult NetIPTop::HandleGetInterfaceOptRequest(const IOCtlVRequest& req
     Memory::Write_U32(1, request.io_vectors[0].address);
     break;
 
+  case 0x3001:  // hardcoded value
+    Memory::Write_U32(0x10, request.io_vectors[0].address);
+    break;
+
   case 0x4002:  // ip addr numberHandle
     Memory::Write_U32(1, request.io_vectors[0].address);
     break;
@@ -813,6 +817,26 @@ IPCCommandResult NetIPTop::HandleGetInterfaceOptRequest(const IOCtlVRequest& req
     Memory::Write_U32(10 << 24 | 1 << 8 | 30, request.io_vectors[0].address);
     Memory::Write_U32(255 << 24 | 255 << 16 | 255 << 8 | 0, request.io_vectors[0].address + 4);
     Memory::Write_U32(10 << 24 | 0 << 16 | 255 << 8 | 255, request.io_vectors[0].address + 8);
+    break;
+
+  case 0x4005:  // hardcoded value
+    Memory::Write_U32(0x20, request.io_vectors[0].address);
+    break;
+
+  case 0x6003:  // hardcoded value
+    Memory::Write_U32(0x80, request.io_vectors[0].address);
+    break;
+
+  case 0x600a:  // hardcoded value
+    Memory::Write_U32(0x80, request.io_vectors[0].address);
+    break;
+
+  case 0x600c:  // hardcoded value
+    Memory::Write_U32(0x80, request.io_vectors[0].address);
+    break;
+
+  case 0xb002:  // hardcoded value
+    Memory::Write_U32(2, request.io_vectors[0].address);
     break;
 
   default:


### PR DESCRIPTION
This PR implements missing cases of GetInterfaceOpt and are based on the [Wiibrew values](http://wiibrew.org/wiki/Socket). It seems to fix the Netflix channel crash for me. However, I don't think the channel will be working because it's still complaining about missing cases such as 0x4006.

Ready to be reviewed & merged.