### PR TITLE
Host: Get rid of Host_SetStartupDebuggingParameters()

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -36,7 +36,6 @@
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
-#include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
 
@@ -222,9 +221,6 @@ static GPUDeterminismMode ParseGPUDeterminismMode(const std::string& mode)
 bool BootCore(const std::string& _rFilename)
 {
   SConfig& StartUp = SConfig::GetInstance();
-
-  // Use custom settings for debugging mode
-  Host_SetStartupDebuggingParameters();
 
   StartUp.m_BootType = SConfig::BOOT_ISO;
   StartUp.m_strFilename = _rFilename;

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -31,7 +31,6 @@ void Host_Message(int Id);
 void Host_NotifyMapLoaded();
 void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
-void Host_SetStartupDebuggingParameters();
 void Host_SetWiiMoteConnectionState(int _State);
 void Host_UpdateDisasmDialog();
 void Host_UpdateMainFrame();

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -115,13 +115,6 @@ void Host_RequestRenderWindowSize(int width, int height)
 {
 }
 
-void Host_SetStartupDebuggingParameters()
-{
-  SConfig& StartUp = SConfig::GetInstance();
-  StartUp.bEnableDebugging = false;
-  StartUp.bBootToPause = false;
-}
-
 bool Host_UIHasFocus()
 {
   return false;

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -113,9 +113,6 @@ void Host_NotifyMapLoaded()
 void Host_UpdateDisasmDialog()
 {
 }
-void Host_SetStartupDebuggingParameters()
-{
-}
 void Host_SetWiiMoteConnectionState(int state)
 {
 }

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -481,7 +481,7 @@ void CCodeWindow::OnCPUMode(wxCommandEvent& event)
   switch (event.GetId())
   {
   case IDM_INTERPRETER:
-    PowerPC::SetMode(UseInterpreter() ? PowerPC::CoreMode::Interpreter : PowerPC::CoreMode::JIT);
+    PowerPC::SetMode(event.IsChecked() ? PowerPC::CoreMode::Interpreter : PowerPC::CoreMode::JIT);
     break;
   case IDM_BOOT_TO_PAUSE:
     SConfig::GetInstance().bBootToPause = event.IsChecked();
@@ -559,32 +559,6 @@ void CCodeWindow::OnJitMenu(wxCommandEvent& event)
     break;
   }
   }
-}
-
-// Shortcuts
-bool CCodeWindow::UseInterpreter()
-{
-  return GetParentMenuBar()->IsChecked(IDM_INTERPRETER);
-}
-
-bool CCodeWindow::BootToPause()
-{
-  return GetParentMenuBar()->IsChecked(IDM_BOOT_TO_PAUSE);
-}
-
-bool CCodeWindow::AutomaticStart()
-{
-  return GetParentMenuBar()->IsChecked(IDM_AUTOMATIC_START);
-}
-
-bool CCodeWindow::JITNoBlockCache()
-{
-  return GetParentMenuBar()->IsChecked(IDM_JIT_NO_BLOCK_CACHE);
-}
-
-bool CCodeWindow::JITNoBlockLinking()
-{
-  return GetParentMenuBar()->IsChecked(IDM_JIT_NO_BLOCK_LINKING);
 }
 
 // Update GUI

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -85,11 +85,6 @@ public:
   void Load();
   void Save();
 
-  bool UseInterpreter();
-  bool BootToPause();
-  bool AutomaticStart();
-  bool JITNoBlockCache();
-  bool JITNoBlockLinking();
   bool JumpToAddress(u32 address);
 
   void Repopulate(bool refresh_codeview = true);

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -183,6 +183,9 @@ private:
   void InitializeTASDialogs();
   void InitializeCoreCallbacks();
 
+  void StartGame(const std::string& filename);
+  void SetDebuggerStartupParameters() const;
+
   // Utility
   wxWindow* GetNotebookPageFromId(wxWindowID Id);
   wxAuiNotebook* GetNotebookFromId(u32 NBId);
@@ -338,7 +341,6 @@ private:
 
   void OnGameListCtrlItemActivated(wxListEvent& event);
   void OnRenderParentResize(wxSizeEvent& event);
-  void StartGame(const std::string& filename);
   void OnChangeColumnsVisible(wxCommandEvent& event);
 
   void OnSelectSlot(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -707,6 +707,8 @@ void CFrame::StartGame(const std::string& filename)
 
   DoFullscreen(SConfig::GetInstance().bFullscreen);
 
+  SetDebuggerStartupParameters();
+
   if (!BootManager::BootCore(filename))
   {
     DoFullscreen(false);
@@ -742,6 +744,27 @@ void CFrame::StartGame(const std::string& filename)
     wxTheApp->Bind(wxEVT_MIDDLE_UP, &CFrame::OnMouse, this);
     wxTheApp->Bind(wxEVT_MOTION, &CFrame::OnMouse, this);
     m_render_parent->Bind(wxEVT_SIZE, &CFrame::OnRenderParentResize, this);
+  }
+}
+
+void CFrame::SetDebuggerStartupParameters() const
+{
+  SConfig& config = SConfig::GetInstance();
+
+  if (m_use_debugger)
+  {
+    const wxMenuBar* const menu_bar = GetMenuBar();
+
+    config.bBootToPause = menu_bar->IsChecked(IDM_BOOT_TO_PAUSE);
+    config.bAutomaticStart = menu_bar->IsChecked(IDM_AUTOMATIC_START);
+    config.bJITNoBlockCache = menu_bar->IsChecked(IDM_JIT_NO_BLOCK_CACHE);
+    config.bJITNoBlockLinking = menu_bar->IsChecked(IDM_JIT_NO_BLOCK_LINKING);
+    config.bEnableDebugging = true;
+  }
+  else
+  {
+    config.bBootToPause = false;
+    config.bEnableDebugging = false;
   }
 }
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -16,6 +16,7 @@
 #include <wx/imagpng.h>
 #include <wx/intl.h>
 #include <wx/language.h>
+#include <wx/menu.h>
 #include <wx/msgdlg.h>
 #include <wx/thread.h>
 #include <wx/timer.h>
@@ -256,9 +257,9 @@ void DolphinApp::AfterInit()
   }
   // If we have selected Automatic Start, start the default ISO,
   // or if no default ISO exists, start the last loaded ISO
-  else if (main_frame->m_code_window)
+  else if (m_use_debugger)
   {
-    if (main_frame->m_code_window->AutomaticStart())
+    if (main_frame->GetMenuBar()->IsChecked(IDM_AUTOMATIC_START))
     {
       main_frame->BootGame("");
     }
@@ -454,23 +455,6 @@ void Host_RequestRenderWindowSize(int width, int height)
   wxCommandEvent event(wxEVT_HOST_COMMAND, IDM_WINDOW_SIZE_REQUEST);
   event.SetClientData(new std::pair<int, int>(width, height));
   main_frame->GetEventHandler()->AddPendingEvent(event);
-}
-
-void Host_SetStartupDebuggingParameters()
-{
-  SConfig& StartUp = SConfig::GetInstance();
-  if (main_frame->m_code_window)
-  {
-    StartUp.bBootToPause = main_frame->m_code_window->BootToPause();
-    StartUp.bAutomaticStart = main_frame->m_code_window->AutomaticStart();
-    StartUp.bJITNoBlockCache = main_frame->m_code_window->JITNoBlockCache();
-    StartUp.bJITNoBlockLinking = main_frame->m_code_window->JITNoBlockLinking();
-  }
-  else
-  {
-    StartUp.bBootToPause = false;
-  }
-  StartUp.bEnableDebugging = main_frame->m_code_window ? true : false;  // RUNNING_DEBUG
 }
 
 void Host_SetWiiMoteConnectionState(int _State)


### PR DESCRIPTION
This is something that should be the responsibility of the frontend booting the game. Making this part of the host 'interface' inherently requires frontends to leak internal details (much like the other UI-related functions in the interface).

This also decouples more behavior from the debugger and the initialization process in the wx frontend. This also eliminates several usages of the parent menubar in the debugger code window.