### PR TITLE
IOS/Network: Emulate socket fd table

### DIFF
--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -424,8 +424,10 @@ IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
       WII_SSL* ssl = &_SSL[sslID];
       mbedtls_ssl_setup(&ssl->ctx, &ssl->config);
       ssl->sockfd = Memory::Read_U32(BufferOut2);
+      WiiSockMan& sm = WiiSockMan::GetInstance();
+      ssl->hostfd = sm.GetHostSocket(ssl->sockfd);
       INFO_LOG(IOS_SSL, "IOCTLV_NET_SSL_CONNECT socket = %d", ssl->sockfd);
-      mbedtls_ssl_set_bio(&ssl->ctx, &ssl->sockfd, mbedtls_net_send, mbedtls_net_recv, nullptr);
+      mbedtls_ssl_set_bio(&ssl->ctx, &ssl->hostfd, mbedtls_net_send, mbedtls_net_recv, nullptr);
       Memory::Write_U32(SSL_OK, BufferIn);
     }
     else

--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -81,6 +81,7 @@ struct WII_SSL
   mbedtls_x509_crt clicert;
   mbedtls_pk_context pk;
   int sockfd;
+  int hostfd;
   std::string hostname;
   bool active;
 };

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -239,6 +239,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
       }
       case IOCTL_SO_ACCEPT:
       {
+        s32 ret;
         if (ioctl.buffer_out_size > 0)
         {
           sockaddr_in local_name;
@@ -246,18 +247,17 @@ void WiiSocket::Update(bool read, bool write, bool except)
           WiiSockMan::Convert(*wii_name, local_name);
 
           socklen_t addrlen = sizeof(sockaddr_in);
-          int ret = (s32)accept(fd, (sockaddr*)&local_name, &addrlen);
-          ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_ACCEPT", true);
+          ret = static_cast<s32>(accept(fd, (sockaddr*)&local_name, &addrlen));
 
           WiiSockMan::Convert(local_name, *wii_name, addrlen);
         }
         else
         {
-          int ret = (s32)accept(fd, nullptr, nullptr);
-          ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_ACCEPT", true);
+          ret = static_cast<s32>(accept(fd, nullptr, nullptr));
         }
 
-        WiiSockMan::GetInstance().AddSocket(ReturnValue);
+        ret = WiiSockMan::GetInstance().AddSocket(ret);
+        ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_ACCEPT", true);
 
         ioctl.Log("IOCTL_SO_ACCEPT", LogTypes::IOS_NET);
         break;
@@ -604,21 +604,33 @@ void WiiSocket::DoSock(Request request, SSL_IOCTL type)
   pending_sockops.push_back(so);
 }
 
-void WiiSockMan::AddSocket(s32 fd)
+s32 WiiSockMan::AddSocket(s32 fd)
 {
   if (fd >= 0)
   {
-    WiiSocket& sock = WiiSockets[fd];
+    s32 wii_fd = 0;
+    while (WiiSockets.count(wii_fd) > 0)
+      wii_fd += 1;
+    WiiSocket& sock = WiiSockets[wii_fd];
     sock.SetFd(fd);
+    return wii_fd;
   }
+  return fd;
 }
 
 s32 WiiSockMan::NewSocket(s32 af, s32 type, s32 protocol)
 {
-  s32 fd = (s32)socket(af, type, protocol);
-  s32 ret = GetNetErrorCode(fd, "NewSocket", false);
-  AddSocket(ret);
+  s32 fd = static_cast<s32>(socket(af, type, protocol));
+  s32 wii_fd = AddSocket(fd);
+  s32 ret = GetNetErrorCode(wii_fd, "NewSocket", false);
   return ret;
+}
+
+s32 WiiSockMan::GetHostSocket(s32 wii_fd) const
+{
+  if (WiiSockets.count(wii_fd) > 0)
+    return WiiSockets.at(wii_fd).fd;
+  return EBADF;
 }
 
 s32 WiiSockMan::DeleteSocket(s32 s)
@@ -694,7 +706,7 @@ void WiiSockMan::Convert(sockaddr_in const& from, WiiSockAddrIn& to, s32 addrlen
   to.addr.addr = from.sin_addr.s_addr;
   to.family = from.sin_family & 0xFF;
   to.port = from.sin_port;
-  if (addrlen < 0 || addrlen > (s32)sizeof(WiiSockAddrIn))
+  if (addrlen < 0 || addrlen > static_cast<s32>(sizeof(WiiSockAddrIn)))
     to.len = sizeof(WiiSockAddrIn);
   else
     to.len = addrlen;

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -663,12 +663,12 @@ s32 WiiSockMan::GetHostSocket(s32 wii_fd) const
 {
   if (WiiSockets.count(wii_fd) > 0)
     return WiiSockets.at(wii_fd).fd;
-  return EBADF;
+  return -EBADF;
 }
 
 s32 WiiSockMan::DeleteSocket(s32 s)
 {
-  s32 ReturnValue = EBADF;
+  s32 ReturnValue = -SO_EBADF;
   auto socket_entry = WiiSockets.find(s);
   if (socket_entry != WiiSockets.end())
   {

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -80,6 +80,9 @@ static s32 TranslateErrorCode(s32 native_error, bool isRW)
     return -SO_ENETUNREACH;
   case ERRORCODE(EHOSTUNREACH):
     return -SO_EHOSTUNREACH;
+  case ENOMEM:  // See man (7) ip
+  case ERRORCODE(ENOBUFS):
+    return -SO_ENOMEM;
   case EITHER(WSAEWOULDBLOCK, EAGAIN):
     if (isRW)
     {

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -620,6 +620,8 @@ s32 WiiSockMan::AddSocket(s32 fd)
 
 s32 WiiSockMan::NewSocket(s32 af, s32 type, s32 protocol)
 {
+  if (af != 2 && af != 23)  // AF_INET && AF_INET6
+    return -SO_EAFNOSUPPORT;
   s32 fd = static_cast<s32>(socket(af, type, protocol));
   s32 wii_fd = AddSocket(fd);
   s32 ret = GetNetErrorCode(wii_fd, "NewSocket", false);

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -622,6 +622,8 @@ s32 WiiSockMan::NewSocket(s32 af, s32 type, s32 protocol)
 {
   if (af != 2 && af != 23)  // AF_INET && AF_INET6
     return -SO_EAFNOSUPPORT;
+  if (protocol != 0)  // IPPROTO_IP
+    return -SO_EPROTONOSUPPORT;
   s32 fd = static_cast<s32>(socket(af, type, protocol));
   s32 wii_fd = AddSocket(fd);
   s32 ret = GetNetErrorCode(wii_fd, "NewSocket", false);

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -640,6 +640,8 @@ s32 WiiSockMan::NewSocket(s32 af, s32 type, s32 protocol)
     return -SO_EAFNOSUPPORT;
   if (protocol != 0)  // IPPROTO_IP
     return -SO_EPROTONOSUPPORT;
+  if (type != 1 && type != 2)  // SOCK_STREAM && SOCK_DGRAM
+    return -SO_EPROTOTYPE;
   s32 fd = static_cast<s32>(socket(af, type, protocol));
   return AddSocket(fd, false);
 }

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -83,6 +83,8 @@ static s32 TranslateErrorCode(s32 native_error, bool isRW)
   case ENOMEM:  // See man (7) ip
   case ERRORCODE(ENOBUFS):
     return -SO_ENOMEM;
+  case ERRORCODE(ENETRESET):
+    return -SO_ENETRESET;
   case EITHER(WSAEWOULDBLOCK, EAGAIN):
     if (isRW)
     {

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -221,7 +221,8 @@ public:
   static void Convert(sockaddr_in const& from, WiiSockAddrIn& to, s32 addrlen = -1);
   // NON-BLOCKING FUNCTIONS
   s32 NewSocket(s32 af, s32 type, s32 protocol);
-  void AddSocket(s32 fd);
+  s32 AddSocket(s32 fd);
+  s32 GetHostSocket(s32 wii_fd) const;
   s32 DeleteSocket(s32 s);
   s32 GetLastNetError() const { return errno_last; }
   void SetLastNetError(s32 error) { errno_last = error; }

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -187,11 +187,13 @@ class WiiSocket
 
 private:
   s32 fd;
+  s32 wii_fd;
   bool nonBlock;
   std::list<sockop> pending_sockops;
 
   friend class WiiSockMan;
   void SetFd(s32 s);
+  void SetWiiFd(s32 s);
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -221,7 +221,7 @@ public:
   static void Convert(sockaddr_in const& from, WiiSockAddrIn& to, s32 addrlen = -1);
   // NON-BLOCKING FUNCTIONS
   s32 NewSocket(s32 af, s32 type, s32 protocol);
-  s32 AddSocket(s32 fd);
+  s32 AddSocket(s32 fd, bool is_rw);
   s32 GetHostSocket(s32 wii_fd) const;
   s32 DeleteSocket(s32 s);
   s32 GetLastNetError() const { return errno_last; }


### PR DESCRIPTION
This PR tries to emulate a Wii fd table. Dolphin was using the host's fd when emulating sockets, while it shouldn't be a problem, it seems that in some cases (like the Netflix channel) there is a check against that fd value.

Regarding the Netflix channel, if the fd value is greater than 23 it returns a EBADF error (which consequently is sent to SO commands like CONNECT). I assume, it's probably using select/poll to monitor sockets and that it does a sanity check against a specified limit (```max_fd```?).

~Currently, the fd values are computed empirically. It will need a hardware test to confirm that it matches the Wii's behaviour. It also assumes that it has a separate table for other (non-socket) fd generated. Otherwise, the fd table will need to be implemented somewhere else in IOS code.~ Not the case anymore, thanks to @shuffle2.

## TODO
Based on @shuffle2's gist: https://gist.github.com/shuffle2/4541e4e96ba3e04a34bd36b0e07d3013#file-so_socket-c-L71
- [x] Create the socket fd table
- [x] Replace logs using host socket fd with wii fd
- [x] Handle SO_ENETRESET (39)
- [x] Handle SO_EAFNOSUPPORT (5)
- [x] Handle SO_EPROTONOSUPPORT (68)
- [x] Handle SO_EMFILE (33)
- [x] Handle SO_EPROTOTYPE (69)
- [x] Handle SO_ENOMEM (49)

Ready to be reviewed & merged.