### PR TITLE
PPCSymbolDB: Remove biased address check

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -25,7 +25,7 @@ public:
   PPCSymbolDB();
   ~PPCSymbolDB();
 
-  Symbol* AddFunction(u32 startAddr) override;
+  Symbol* AddFunction(u32 start_addr) override;
   void AddKnownSymbol(u32 startAddr, u32 size, const std::string& name,
                       Symbol::Type type = Symbol::Type::Function);
 


### PR DESCRIPTION
The previous limit prevented to add functions below the address 0x80000010. However, sometimes there are valid functions below this limit.

Ready to be reviewed & merged.