### PR TITLE
PPCAnalyst: Use the proper RAM check

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -97,7 +97,7 @@ bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
   for (u32 addr = startAddr; true; addr += 4)
   {
     func.size += 4;
-    if (func.size >= CODEBUFFER_SIZE * 4 || !PowerPC::HostIsRAMAddress(addr))  // weird
+    if (func.size >= CODEBUFFER_SIZE * 4 || !PowerPC::HostIsInstructionRAMAddress(addr))  // weird
       return false;
 
     if (max_size && func.size > max_size)


### PR DESCRIPTION
The previous check was based on DBAT instead of IBAT which could end up pretty badly.

Ready to be reviewed & merged.