### PR TITLE
NANDImporter: Fix GUI freezing + add logging

### DIFF
--- a/Source/Core/DiscIO/NANDImporter.h
+++ b/Source/Core/DiscIO/NANDImporter.h
@@ -41,6 +41,7 @@ private:
   bool ReadNANDBin(const std::string& path_to_bin);
   void FindSuperblock();
   std::string GetPath(const NANDFSTEntry& entry, const std::string& parent_path);
+  std::string FormatDebugString(const NANDFSTEntry& entry);
   void ProcessEntry(u16 entry_number, const std::string& parent_path);
   void ProcessFile(const NANDFSTEntry& entry, const std::string& parent_path);
   void ProcessDirectory(const NANDFSTEntry& entry, const std::string& parent_path);
@@ -51,5 +52,6 @@ private:
   size_t m_nand_fat_offset = 0;
   size_t m_nand_fst_offset = 0;
   std::function<void()> m_update_callback;
+  size_t m_nand_root_length = 0;
 };
 }

--- a/Source/Core/DiscIO/NANDImporter.h
+++ b/Source/Core/DiscIO/NANDImporter.h
@@ -18,8 +18,7 @@ public:
   NANDImporter();
   ~NANDImporter();
 
-  void ImportNANDBin(const std::string& path_to_bin,
-                     std::function<void(size_t, size_t)> update_callback);
+  void ImportNANDBin(const std::string& path_to_bin, std::function<void()> update_callback);
   void ExtractCertificates(const std::string& nand_root);
 
 private:
@@ -46,15 +45,11 @@ private:
   void ProcessFile(const NANDFSTEntry& entry, const std::string& parent_path);
   void ProcessDirectory(const NANDFSTEntry& entry, const std::string& parent_path);
   void ExportKeys(const std::string& nand_root);
-  void CountEntries(u16 entry_number);
-  void UpdateStatus();
 
   std::vector<u8> m_nand;
   std::vector<u8> m_nand_keys;
   size_t m_nand_fat_offset = 0;
   size_t m_nand_fst_offset = 0;
-  std::function<void(size_t, size_t)> m_update_callback;
-  size_t m_total_entries = 0;
-  size_t m_current_entry = 0;
+  std::function<void()> m_update_callback;
 };
 }

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1279,11 +1279,7 @@ void CFrame::OnImportBootMiiBackup(wxCommandEvent& WXUNUSED(event))
 
   wxProgressDialog dialog(_("Importing NAND backup"), _("Working..."), 100, this,
                           wxPD_APP_MODAL | wxPD_ELAPSED_TIME | wxPD_SMOOTH);
-  DiscIO::NANDImporter().ImportNANDBin(file_name,
-                                       [&dialog](size_t current_entry, size_t total_entries) {
-                                         dialog.SetRange(total_entries);
-                                         dialog.Update(current_entry);
-                                       });
+  DiscIO::NANDImporter().ImportNANDBin(file_name, [&dialog] { dialog.Pulse(); });
   UpdateLoadWiiMenuItem();
 }
 


### PR DESCRIPTION
Turns out when loading to memory, it freezes for a good 10 seconds on slow computers, causing windows to think it's not responding and recommend that you close it. The first commit fixes that by making the progress bar indeterminate and updating every once in a while in the loading loop.

The second commit adds a few logging commands, which should make it easier to see where it could have gone wrong. Hopefully this helps me fix [this issue](https://dolp.in/i10266)