### PR TITLE
Remove Windows 10 SDK requirement from readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ Dolphin can only be installed on devices that satisfy the above requirements. At
 Use the solution file `Source/dolphin-emu.sln` to build Dolphin on Windows.
 Visual Studio 2015 Update 2 is a hard requirement. Other compilers might be
 able to build Dolphin on Windows but have not been tested and are not
-recommended to be used. Git and Windows 10 SDK 10.0.10586.0 must be installed.
+recommended to be used. Git must be installed when building.
 
 An installer can be created by using the `Installer.nsi` script in the
 Installer directory. This will require the Nullsoft Scriptable Install System


### PR DESCRIPTION
This should thankfully not be needed anymore now that the D3D12 backend has been dropped by PR #4424.