### PR TITLE
GeckoCode: install code handler even if no codes are activated

### DIFF
--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -203,7 +203,7 @@ void RunCodeHandler()
     {
       // Don't spam retry if the install failed. The corrupt / missing disk file is not likely to be
       // fixed within 1 frame of the last error.
-      if (s_active_codes.empty() || s_code_handler_installed == Installation::Failed)
+      if (s_code_handler_installed == Installation::Failed)
         return;
       s_code_handler_installed = InstallCodeHandlerLocked();
 


### PR DESCRIPTION
This let users use the gecko code handler debugging protocol with existing
tools even when no gecko codes are enabled.