### PR TITLE
build.gradle: do not change the output filename, our CI relies on it

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -68,14 +68,6 @@ android {
             }
         }
     }
-
-    applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            def name = output.outputFile.name.replace(variant.buildType.name, "${variant.versionName}")
-            name = name.replace("app", "dolphin")
-            output.outputFile = new File(output.outputFile.parent, name)
-        }
-    }
 }
 
 ext {


### PR DESCRIPTION
Partial rollback of #5114.