### PR TITLE
Qt: Fix default device handling

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -54,7 +54,7 @@ GetExpressionForControl(const QString& control_name,
 
 void MappingButton::OnButtonPressed()
 {
-  if (m_block)
+  if (m_block || m_parent->GetDevice() == nullptr)
     return;
 
   // Make sure that we don't block event handling

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -211,7 +211,9 @@ void MappingWindow::OnSaveProfilePressed()
 
 void MappingWindow::OnDeviceChanged(int index)
 {
-  m_devq.FromString(m_devices_combo->currentText().toStdString());
+  const auto device = m_devices_combo->currentText().toStdString();
+  m_devq.FromString(device);
+  m_controller->default_device.FromString(device);
 }
 
 void MappingWindow::RefreshDevices()
@@ -233,6 +235,8 @@ void MappingWindow::RefreshDevices()
     if (name != default_device)
       m_devices_combo->addItem(QString::fromStdString(name));
   }
+
+  m_devices_combo->setCurrentIndex(0);
 
   Core::PauseAndLock(false, paused);
 }


### PR DESCRIPTION
Fixes a few minor bugs in the handling of default devices within the button mapping dialogs.