### PR TITLE
TitleDatabase: Remove unused <iostream> header

### DIFF
--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -4,7 +4,6 @@
 
 #include <fstream>
 #include <functional>
-#include <iostream>
 
 #include "Core/TitleDatabase.h"
 


### PR DESCRIPTION
Many implementations of `<iostream>` inject a static constructor into the translation unit it's included in, even if nothing from the header is used [example](https://godbolt.org/g/I1w6oH).