### PR TITLE
CodeView: Fix missing bl details

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -496,7 +496,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 
       // look for hex strings to decode branches
       std::string hex_str;
-      size_t pos = operands.find("0x8");
+      size_t pos = operands.find("0x");
       if (pos != std::string::npos)
       {
         hex_str = operands.substr(pos);


### PR DESCRIPTION
When the function address begins with something else than "0x8", bl won't be followed by the function name in the code view.

Ready to be reviewed & merged.