### PR TITLE
DolphinQt2: replace icons in controllers dialog with labels

### DIFF
--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -12,7 +12,6 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QMessageBox>
-#include <QPixmap>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QSpacerItem>
@@ -66,11 +65,7 @@ static int FromWiimoteMenuIndex(const int menudevice)
   return it->first;
 }
 
-ControllersWindow::ControllersWindow(QWidget* parent)
-    : QDialog(parent),
-      m_configure_icon(Settings().GetThemeDir().append(QStringLiteral("config.png"))),
-      m_gamecube_icon(Settings().GetResourcesDir().append(QStringLiteral("Platform_Gamecube.png"))),
-      m_wii_icon(Settings().GetResourcesDir().append(QStringLiteral("Platform_Wii.png")))
+ControllersWindow::ControllersWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Controller Settings"));
 
@@ -90,17 +85,13 @@ ControllersWindow::ControllersWindow(QWidget* parent)
 
 void ControllersWindow::CreateGamecubeLayout()
 {
-  m_gc_box = new QGroupBox();
+  m_gc_box = new QGroupBox(tr("GameCube Controllers"));
   m_gc_layout = new QFormLayout();
-  m_gc_label = new QLabel();
-  m_gc_label->setPixmap(QPixmap(m_gamecube_icon));
-  m_gc_label->setAlignment(Qt::AlignCenter);
-  m_gc_layout->addRow(m_gc_label);
 
   for (size_t i = 0; i < m_gc_groups.size(); i++)
   {
     auto* gc_box = m_gc_controller_boxes[i] = new QComboBox();
-    auto* gc_button = m_gc_buttons[i] = new QPushButton(QIcon(m_configure_icon), QString());
+    auto* gc_button = m_gc_buttons[i] = new QPushButton(tr("Configure"));
     auto* gc_group = m_gc_groups[i] = new QHBoxLayout();
 
     gc_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -152,7 +143,7 @@ static QHBoxLayout* CreateSubItem(QWidget* label, QLayoutItem* item)
 
 void ControllersWindow::CreateWiimoteLayout()
 {
-  m_wiimote_box = new QGroupBox();
+  m_wiimote_box = new QGroupBox(tr("Wii Remotes"));
   m_wiimote_layout = new QFormLayout();
   m_wiimote_passthrough = new QRadioButton(tr("Use Bluetooth Passthrough"));
   m_wiimote_sync = new QPushButton(tr("Sync"));
@@ -166,11 +157,6 @@ void ControllersWindow::CreateWiimoteLayout()
   m_wiimote_speaker_data = new QCheckBox(tr("Enable Speaker Data"));
 
   m_wiimote_layout->setLabelAlignment(Qt::AlignLeft);
-
-  m_wii_label = new QLabel();
-  m_wii_label->setPixmap(QPixmap(m_wii_icon));
-  m_wii_label->setAlignment(Qt::AlignCenter);
-  m_wiimote_layout->addRow(m_wii_label);
 
   // Passthrough BT
 
@@ -190,7 +176,7 @@ void ControllersWindow::CreateWiimoteLayout()
   {
     auto* wm_label = m_wiimote_labels[i] = new QLabel(tr("Wii Remote %1").arg(i + 1));
     auto* wm_box = m_wiimote_boxes[i] = new QComboBox();
-    auto* wm_button = m_wiimote_buttons[i] = new QPushButton(QIcon(m_configure_icon), QString());
+    auto* wm_button = m_wiimote_buttons[i] = new QPushButton(tr("Configure"));
     auto* wm_group = m_wiimote_groups[i] = new QHBoxLayout();
 
     for (const auto& item :

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.h
@@ -47,11 +47,6 @@ private:
   void ConnectWidgets();
   void LoadSettings();
 
-  // Icons
-  QString m_configure_icon;
-  QString m_gamecube_icon;
-  QString m_wii_icon;
-
   // Main
   QVBoxLayout* m_main_layout;
   QDialogButtonBox* m_button_box;
@@ -59,7 +54,6 @@ private:
   // Gamecube
   std::array<MappingWindow*, 4> m_gc_mappings;
   QGroupBox* m_gc_box;
-  QLabel* m_gc_label;
   QFormLayout* m_gc_layout;
   std::array<QComboBox*, 4> m_gc_controller_boxes;
   std::array<QPushButton*, 4> m_gc_buttons;
@@ -68,7 +62,6 @@ private:
   // Wii Remote
   std::array<MappingWindow*, 4> m_wiimote_mappings;
   QGroupBox* m_wiimote_box;
-  QLabel* m_wii_label;
   QFormLayout* m_wiimote_layout;
   std::array<QLabel*, 4> m_wiimote_labels;
   std::array<QComboBox*, 4> m_wiimote_boxes;


### PR DESCRIPTION
Icons without labels are bad for usability, so bring this back in line with how DolphinWX does it.

Some reading:

- https://www.nngroup.com/articles/icon-usability/
  > Summary: A user’s understanding of an icon is based on previous experience. Due to the absence of a standard usage for most icons, text labels are necessary to communicate the meaning and reduce ambiguity.
- http://uxmyths.com/post/715009009/myth-icons-enhance-usability
- http://edwardsanchez.me/blog/13589712
- https://uxdesign.cc/do-icons-need-labels-6cb4f4282c00

Before:

<img width="549" alt="screen shot 2017-05-26 at 7 53 45 pm" src="https://cloud.githubusercontent.com/assets/594093/26517481/56f59306-424e-11e7-86c2-db0e0d667fa5.png">

After:

<img width="563" alt="screen shot 2017-05-26 at 7 52 39 pm" src="https://cloud.githubusercontent.com/assets/594093/26517482/5de1006a-424e-11e7-88bd-a0cdbee03c68.png">
