### PR TITLE
WX: improve game list reload speed

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/MappingBool.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingBool.h
@@ -26,5 +26,4 @@ private:
 
   MappingWidget* m_parent;
   ControllerEmu::BooleanSetting* m_setting;
-  double m_range;
 };

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -52,7 +52,6 @@ void InterfacePane::CreateUI()
   combobox_layout->addRow(tr("&Language:"), m_combobox_language);
 
   // Theme Combobox
-  auto* theme_layout = new QFormLayout;
   m_combobox_theme = new QComboBox;
   m_combobox_theme->setMaximumWidth(300);
   combobox_layout->addRow(tr("&Theme:"), m_combobox_theme);

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -437,6 +437,7 @@ void CGameListCtrl::ReloadList()
     // add all items
     for (int i = 0; i < (int)m_ISOFiles.size(); i++)
       InsertItemInReportView(i);
+    SetColors();
 
     // Sort items by Title
     if (!sorted)
@@ -596,9 +597,6 @@ void CGameListCtrl::InsertItemInReportView(long index)
     if (GetColumnWidth(i) != 0)
       UpdateItemAtColumn(item_index, i);
   }
-
-  // List colors
-  SetColors();
 }
 
 static wxColour blend50(const wxColour& c1, const wxColour& c2)
@@ -626,7 +624,7 @@ void CGameListCtrl::SetColors()
     wxColour color = (i & 1) ? blend50(wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT),
                                        wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)) :
                                wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
-    CGameListCtrl::SetItemBackgroundColour(i, color);
+    SetItemBackgroundColour(i, color);
     SetItemTextColour(i, ContrastText(color));
   }
 }


### PR DESCRIPTION
When loading a big game list, this eliminates the long delay after the progress dialog disappears.