### PR TITLE
Qt: fixes to GameList sorting

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -30,6 +30,7 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent)
 {
   m_model = new GameListModel(this);
   m_table_proxy = new QSortFilterProxyModel(this);
+  m_table_proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
   m_table_proxy->setSourceModel(m_model);
   m_list_proxy = new ListProxyModel(this);
   m_list_proxy->setSourceModel(m_model);

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -31,6 +31,7 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent)
   m_model = new GameListModel(this);
   m_table_proxy = new QSortFilterProxyModel(this);
   m_table_proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
+  m_table_proxy->setSortRole(Qt::InitialSortOrderRole);
   m_table_proxy->setSourceModel(m_model);
   m_list_proxy = new ListProxyModel(this);
   m_list_proxy->setSourceModel(m_model);

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -27,14 +27,20 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_PLATFORM:
     if (role == Qt::DecorationRole)
       return Resources::GetPlatform(static_cast<int>(game->GetPlatformID()));
+    if (role == Qt::InitialSortOrderRole)
+      return static_cast<int>(game->GetPlatformID());
     break;
   case COL_COUNTRY:
     if (role == Qt::DecorationRole)
       return Resources::GetCountry(static_cast<int>(game->GetCountryID()));
+    if (role == Qt::InitialSortOrderRole)
+      return static_cast<int>(game->GetCountryID());
     break;
   case COL_RATING:
     if (role == Qt::DecorationRole)
       return Resources::GetRating(game->GetRating());
+    if (role == Qt::InitialSortOrderRole)
+      return game->GetRating();
     break;
   case COL_BANNER:
     if (role == Qt::DecorationRole)
@@ -48,24 +54,26 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     }
     break;
   case COL_TITLE:
-    if (role == Qt::DisplayRole)
+    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
       return game->GetLongName();
     break;
   case COL_ID:
-    if (role == Qt::DisplayRole)
+    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
       return game->GetGameID();
     break;
   case COL_DESCRIPTION:
-    if (role == Qt::DisplayRole)
+    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
       return game->GetDescription();
     break;
   case COL_MAKER:
-    if (role == Qt::DisplayRole)
+    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
       return game->GetMaker();
     break;
   case COL_SIZE:
     if (role == Qt::DisplayRole)
       return FormatSize(game->GetFileSize());
+    if (role == Qt::InitialSortOrderRole)
+      return game->GetFileSize();
     break;
   }
 

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -21,17 +21,24 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     return QVariant();
 
   QSharedPointer<GameFile> game = m_games[index.row()];
-  if (role == Qt::DecorationRole)
+
+  switch (index.column())
   {
-    switch (index.column())
-    {
-    case COL_PLATFORM:
+  case COL_PLATFORM:
+    if (role == Qt::DecorationRole)
       return Resources::GetPlatform(static_cast<int>(game->GetPlatformID()));
-    case COL_COUNTRY:
+    break;
+  case COL_COUNTRY:
+    if (role == Qt::DecorationRole)
       return Resources::GetCountry(static_cast<int>(game->GetCountryID()));
-    case COL_RATING:
+    break;
+  case COL_RATING:
+    if (role == Qt::DecorationRole)
       return Resources::GetRating(game->GetRating());
-    case COL_BANNER:
+    break;
+  case COL_BANNER:
+    if (role == Qt::DecorationRole)
+    {
       // GameCube banners are 96x32, but Wii banners are 192x64.
       // TODO: use custom banners from rom directory like DolphinWX?
       QPixmap banner = game->GetBanner();
@@ -39,23 +46,29 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
                                           banner.height() / GAMECUBE_BANNER_SIZE.height()));
       return banner;
     }
-  }
-  if (role == Qt::DisplayRole)
-  {
-    switch (index.column())
-    {
-    case COL_TITLE:
+    break;
+  case COL_TITLE:
+    if (role == Qt::DisplayRole)
       return game->GetLongName();
-    case COL_ID:
+    break;
+  case COL_ID:
+    if (role == Qt::DisplayRole)
       return game->GetGameID();
-    case COL_DESCRIPTION:
+    break;
+  case COL_DESCRIPTION:
+    if (role == Qt::DisplayRole)
       return game->GetDescription();
-    case COL_MAKER:
+    break;
+  case COL_MAKER:
+    if (role == Qt::DisplayRole)
       return game->GetMaker();
-    case COL_SIZE:
+    break;
+  case COL_SIZE:
+    if (role == Qt::DisplayRole)
       return FormatSize(game->GetFileSize());
-    }
+    break;
   }
+
   return QVariant();
 }
 


### PR DESCRIPTION
- Brings back the ability to sort the Platform, Country, and Ratings columns (regression caused by #5487)
- Sorts case-insensitively (it's more intuitive and how DolphinWX does it)