### PR TITLE
DolphinQt2: add ElidedButton for controller mapping buttons

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRCS
   GameList/GameListModel.cpp
   GameList/GameTracker.cpp
   GameList/ListProxyModel.cpp
+  QtUtils/ElidedButton.cpp
   Settings/GeneralPane.cpp
   Settings/InterfacePane.cpp
 )

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -19,7 +19,6 @@
 MappingButton::MappingButton(MappingWidget* widget, ControlReference* ref)
     : QPushButton(QString::fromStdString(ref->expression)), m_parent(widget), m_reference(ref)
 {
-  setText(QString::fromStdString(m_reference->expression));
   Connect();
 }
 

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -17,7 +17,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 MappingButton::MappingButton(MappingWidget* widget, ControlReference* ref)
-    : QPushButton(QString::fromStdString(ref->expression)), m_parent(widget), m_reference(ref)
+    : ElidedButton(QString::fromStdString(ref->expression)), m_parent(widget), m_reference(ref)
 {
   Connect();
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
@@ -5,15 +5,16 @@
 #pragma once
 
 #include <QPoint>
-#include <QPushButton>
 #include <QString>
+
+#include "DolphinQt2/QtUtils/ElidedButton.h"
 
 class ControlReference;
 class MappingWidget;
 class QEvent;
 class QMouseEvent;
 
-class MappingButton : public QPushButton
+class MappingButton : public ElidedButton
 {
 public:
   MappingButton(MappingWidget* widget, ControlReference* ref);

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#include <QPoint>
-#include <QString>
-
 #include "DolphinQt2/QtUtils/ElidedButton.h"
 
 class ControlReference;

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.cpp
@@ -49,6 +49,7 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   for (auto& control : group->controls)
   {
     auto* button = new MappingButton(this, control->control_ref.get());
+    button->setMinimumWidth(125);
     button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     form_layout->addRow(QString::fromStdString(control->name), button);
     m_buttons.push_back(button);

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="MenuBar.cpp" />
+    <ClCompile Include="QtUtils\ElidedButton.cpp" />
     <ClCompile Include="RenderWidget.cpp" />
     <ClCompile Include="Resources.cpp" />
     <ClCompile Include="Settings.cpp" />

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
@@ -116,6 +116,9 @@
     <ClCompile Include="Config\Mapping\WiimoteEmuExtension.cpp" />
     <ClCompile Include="Config\Mapping\WiimoteEmuGeneral.cpp" />
     <ClCompile Include="Config\Mapping\WiimoteEmuMotionControl.cpp" />
+    <ClCompile Include="QtUtils\ElidedButton.cpp">
+      <Filter>QtUtils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="MainWindow.h" />
@@ -176,6 +179,9 @@
     </Filter>
     <Filter Include="Config">
       <UniqueIdentifier>{42f8a963-563e-420d-8aca-5761657dcff5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="QtUtils">
+      <UniqueIdentifier>{fb4b5691-df66-4984-af40-fcc2b37f3622}</UniqueIdentifier>
     </Filter>
     <Filter Include="Settings">
       <UniqueIdentifier>{d2a31121-7903-4a66-9b42-9358e92d36ff}</UniqueIdentifier>

--- a/Source/Core/DolphinQt2/QtUtils/ElidedButton.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/ElidedButton.cpp
@@ -1,0 +1,40 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/QtUtils/ElidedButton.h"
+
+#include <QFontMetrics>
+#include <QStyleOptionButton>
+#include <QStylePainter>
+
+ElidedButton::ElidedButton(const QString& text, Qt::TextElideMode elide_mode)
+    : QPushButton(text, nullptr), m_elide_mode{elide_mode}
+{
+}
+
+Qt::TextElideMode ElidedButton::elideMode() const
+{
+  return m_elide_mode;
+}
+
+void ElidedButton::setElideMode(Qt::TextElideMode elide_mode)
+{
+  if (elide_mode == m_elide_mode)
+    return;
+
+  m_elide_mode = elide_mode;
+  repaint();
+}
+
+void ElidedButton::paintEvent(QPaintEvent* event)
+{
+  QStyleOptionButton option;
+  initStyleOption(&option);
+
+  option.text = fontMetrics().elidedText(
+      text(), m_elide_mode,
+      style()->subElementRect(QStyle::SE_PushButtonContents, &option, this).width());
+
+  QStylePainter{this}.drawControl(QStyle::CE_PushButton, option);
+}

--- a/Source/Core/DolphinQt2/QtUtils/ElidedButton.h
+++ b/Source/Core/DolphinQt2/QtUtils/ElidedButton.h
@@ -1,0 +1,20 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QPushButton>
+
+class ElidedButton : public QPushButton
+{
+public:
+  ElidedButton(const QString& text = QStringLiteral(""),
+               Qt::TextElideMode elide_mode = Qt::ElideRight);
+  Qt::TextElideMode elideMode() const;
+  void setElideMode(Qt::TextElideMode elide_mode);
+
+private:
+  void paintEvent(QPaintEvent* event);
+  Qt::TextElideMode m_elide_mode;
+};


### PR DESCRIPTION
It's a `QPushButton` that automatically elides it's content to fit the assigned width.

Before:

<img width="1000" alt="screen shot 2017-05-31 at 1 19 12 am" src="https://cloud.githubusercontent.com/assets/594093/26622472/63d3cd00-459f-11e7-810d-a29c6a6f4ab6.png">


After:

<img width="300" alt="screen shot 2017-05-31 at 1 20 15 am" src="https://cloud.githubusercontent.com/assets/594093/26622476/649fea98-459f-11e7-8d9b-138d402c70a6.png">