### PR TITLE
IP/Top: Fix GetAddrInfo written socket

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -919,9 +919,8 @@ IPCCommandResult NetIPTop::HandleGetAddressInfoRequest(const IOCtlVRequest& requ
       if (result_iter->ai_addr)
       {
         Memory::Write_U32(sockoffset, addr + 0x18);
-        Memory::Write_U16(((result_iter->ai_addr->sa_family & 0xFF) << 8) |
-                              (result_iter->ai_addrlen & 0xFF),
-                          sockoffset);
+        Memory::Write_U8(result_iter->ai_addr->sa_family & 0xFF, sockoffset);
+        Memory::Write_U8(result_iter->ai_addrlen & 0xFF, sockoffset + 0x01);
         Memory::CopyToEmu(sockoffset + 0x2, result_iter->ai_addr->sa_data,
                           sizeof(result_iter->ai_addr->sa_data));
         sockoffset += 0x1C;


### PR DESCRIPTION
This is the kind of PR where I'm not really sure of what I'm doing. Lately, the Netflix Channel was having issue with ```SOConnect()``` after a ```SOGetAddrInfo()``` call complaining about the socket family which was 0x10 a very odd value. I checked and it seemed that value actually was ```ai_addrlen``` so by swapping them around Netflix stopped complaining.

Maybe someone can confirm/invalidate the fact that this PR is performing the intended behaviour. @shuffle2 ?

With that, I'm able to get Netflix to its loading screen.

Ready to be reviewed & tested.