### PR TITLE
MainWindow: shutdown different input interfaces

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -52,6 +52,7 @@ MainWindow::MainWindow() : QMainWindow(nullptr)
 MainWindow::~MainWindow()
 {
   m_render_widget->deleteLater();
+  ShutdownControllers();
 }
 
 void MainWindow::InitControllers()
@@ -64,6 +65,15 @@ void MainWindow::InitControllers()
   Keyboard::Initialize();
   Wiimote::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
   HotkeyManagerEmu::Initialize();
+}
+
+void MainWindow::ShutdownControllers()
+{
+  g_controller_interface.Shutdown();
+  Pad::Shutdown();
+  Keyboard::Shutdown();
+  Wiimote::Shutdown();
+  HotkeyManagerEmu::Shutdown();
 }
 
 void MainWindow::CreateComponents()

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -66,6 +66,7 @@ private:
   void ConnectPathsDialog();
 
   void InitControllers();
+  void ShutdownControllers();
 
   void StartGame(const QString& path);
   void ShowRenderWidget();


### PR DESCRIPTION
`MainWindow` initializes a number of input interfaces but never shuts them down.

This was causing a crash-after-exit on macOS where the ControllerInterface backend stores a `std::thread` object in a static variable and only stops it when ControllerInterface::Shutdown is called.