### PR TITLE
IOS/ES: Move ImportTicket write function

### DIFF
--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -30,6 +30,21 @@ namespace HLE
 {
 namespace Device
 {
+static ReturnCode WriteTicket(const IOS::ES::TicketReader& ticket)
+{
+  const u64 title_id = ticket.GetTitleId();
+
+  const std::string ticket_path = Common::GetTicketFileName(title_id, Common::FROM_SESSION_ROOT);
+  File::CreateFullPath(ticket_path);
+
+  File::IOFile ticket_file(ticket_path, "wb");
+  if (!ticket_file)
+    return ES_EIO;
+
+  const std::vector<u8>& raw_ticket = ticket.GetRawTicket();
+  return ticket_file.WriteBytes(raw_ticket.data(), raw_ticket.size()) ? IPC_SUCCESS : ES_EIO;
+}
+
 ReturnCode ES::ImportTicket(const std::vector<u8>& ticket_bytes)
 {
   IOS::ES::TicketReader ticket{ticket_bytes};
@@ -54,8 +69,9 @@ ReturnCode ES::ImportTicket(const std::vector<u8>& ticket_bytes)
     }
   }
 
-  if (!DiscIO::AddTicket(ticket))
-    return ES_EIO;
+  const ReturnCode write_ret = WriteTicket(ticket);
+  if (write_ret != IPC_SUCCESS)
+    return write_ret;
 
   INFO_LOG(IOS_ES, "ImportTicket: Imported ticket for title %016" PRIx64, ticket.GetTitleId());
   return IPC_SUCCESS;

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -248,26 +248,6 @@ void CNANDContentManager::ClearCache()
   m_map.clear();
 }
 
-bool AddTicket(const IOS::ES::TicketReader& signed_ticket)
-{
-  if (!signed_ticket.IsValid())
-  {
-    return false;
-  }
-
-  u64 title_id = signed_ticket.GetTitleId();
-
-  std::string ticket_filename = Common::GetTicketFileName(title_id, Common::FROM_CONFIGURED_ROOT);
-  File::CreateFullPath(ticket_filename);
-
-  File::IOFile ticket_file(ticket_filename, "wb");
-  if (!ticket_file)
-    return false;
-
-  const std::vector<u8>& raw_ticket = signed_ticket.GetRawTicket();
-  return ticket_file.WriteBytes(raw_ticket.data(), raw_ticket.size());
-}
-
 IOS::ES::TicketReader FindSignedTicket(u64 title_id)
 {
   std::string ticket_filename = Common::GetTicketFileName(title_id, Common::FROM_CONFIGURED_ROOT);

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -24,7 +24,6 @@ namespace DiscIO
 enum class Region;
 
 // TODO: move some of these to Core/IOS/ES.
-bool AddTicket(const IOS::ES::TicketReader& signed_ticket);
 IOS::ES::TicketReader FindSignedTicket(u64 title_id);
 
 class CNANDContentData


### PR DESCRIPTION
This commit moves the write function to where it should be (ES), especially when ES::ImportTicket() is the only place to use it.

Prevents misusing the ticket import function, and removes one unsafe direct write to the NAND that does not go through IOS. (All NAND accesses should eventually go through it to make sure file permissions are maintained properly, to have the possibility of supporting NAND images, to prevent the PPC software from seeing inconsistent states, if the NAND is being messed with directly).

This also fixes the destination path: the session root is the one which should be used for determining the ticket path, not the configured one.