### PR TITLE
Drop m_LastFilename

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -224,7 +224,6 @@ bool BootCore(const std::string& filename, SConfig::EBootBS2 type)
 
   StartUp.m_BootType = SConfig::BOOT_ISO;
   StartUp.m_strFilename = filename;
-  StartUp.m_LastFilename = filename;
   StartUp.SaveSettings();
   StartUp.bRunCompareClient = false;
   StartUp.bRunCompareServer = false;

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -224,7 +224,6 @@ bool BootCore(const std::string& filename, SConfig::EBootBS2 type)
 
   StartUp.m_BootType = SConfig::BOOT_ISO;
   StartUp.m_strFilename = filename;
-  StartUp.SaveSettings();
   StartUp.bRunCompareClient = false;
   StartUp.bRunCompareServer = false;
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -109,7 +109,6 @@ void SConfig::SaveGeneralSettings(IniFile& ini)
   IniFile::Section* general = ini.GetOrCreateSection("General");
 
   // General
-  general->Set("LastFilename", m_LastFilename);
   general->Set("ShowLag", m_ShowLag);
   general->Set("ShowFrameCount", m_ShowFrameCount);
 
@@ -418,7 +417,6 @@ void SConfig::LoadGeneralSettings(IniFile& ini)
 {
   IniFile::Section* general = ini.GetOrCreateSection("General");
 
-  general->Get("LastFilename", &m_LastFilename);
   general->Get("ShowLag", &m_ShowLag, false);
   general->Get("ShowFrameCount", &m_ShowFrameCount, false);
 #ifdef USE_GDBSTUB

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -58,9 +58,6 @@ struct SConfig : NonCopyable
   bool m_WiimoteContinuousScanning;
   bool m_WiimoteEnableSpeaker;
 
-  // name of the last used filename
-  std::string m_LastFilename;
-
   // ISO folder
   std::vector<std::string> m_ISOFolder;
   bool m_RecursiveISOFolder;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -309,16 +309,8 @@ void CFrame::BootGame(const std::string& filename)
     }
     else
     {
-      if (!SConfig::GetInstance().m_LastFilename.empty() &&
-          File::Exists(SConfig::GetInstance().m_LastFilename))
-      {
-        bootfile = SConfig::GetInstance().m_LastFilename;
-      }
-      else
-      {
-        m_game_list_ctrl->BrowseForDirectory();
-        return;
-      }
+      m_game_list_ctrl->BrowseForDirectory();
+      return;
     }
   }
   if (!bootfile.empty())
@@ -1544,15 +1536,6 @@ void CFrame::UpdateGUI()
     {
       // Prepare to load Default ISO, enable play button
       if (!SConfig::GetInstance().m_strDefaultISO.empty())
-      {
-        GetToolBar()->EnableTool(IDM_PLAY, true);
-        GetMenuBar()->FindItem(IDM_PLAY)->Enable();
-        GetMenuBar()->FindItem(IDM_RECORD)->Enable();
-        GetMenuBar()->FindItem(IDM_PLAY_RECORD)->Enable();
-      }
-      // Prepare to load last selected file, enable play button
-      else if (!SConfig::GetInstance().m_LastFilename.empty() &&
-               File::Exists(SConfig::GetInstance().m_LastFilename))
       {
         GetToolBar()->EnableTool(IDM_PLAY, true);
         GetMenuBar()->FindItem(IDM_PLAY)->Enable();


### PR DESCRIPTION
This makes it hard to support different boot params for different boot types. We should not be making the assumption that Dolphin will always be booting directly from a file (and in particular, only using a string).

It's incompatible with future changes that will allow Dolphin to boot a NAND title properly from well, the NAND, as opposed to booting from WADs. (And no, treating the title TMD as a "bootable" path doesn't count. Especially when that approach won't work with NAND images / IOS LLE.)

And it's confusing to expose this functionality from the UI. It's pretty bad for UX to change the play button's behaviour depending on whether the user has launched something before, configured a default file to boot, added a directory to their game paths.