### PR TITLE
More reliable shutdown

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -818,7 +818,6 @@ void CFrame::DoStop()
   // don't let this function run again until it finishes, or is aborted.
   m_confirm_stop = true;
 
-  m_is_game_loading = false;
   if (Core::GetState() != Core::State::Uninitialized || m_render_parent != nullptr)
   {
 #if defined __WXGTK__
@@ -919,6 +918,7 @@ bool CFrame::TriggerSTMPowerEvent()
 void CFrame::OnStopped()
 {
   m_confirm_stop = false;
+  m_is_game_loading = false;
   m_tried_graceful_shutdown = false;
 
   UninhibitScreensaver();


### PR DESCRIPTION
Two small changes to make the shutdown process more failproof.

* Core: Use RAII for EmuThread shutdown

  This is more reliable, as this guarantees subsystems will be shut down in the same order they were initialised (iff they were initialised). It also allows us to stop keeping track of what needs to be shut down manually and just return in case of errors.
  
  This should prevent the emulator from getting totally stuck when the boot process does fail.

* WX: Clear m_is_game_loading at the proper moment 

  This should happen after the core has stopped (OnStopped), not when the user wants to stop (DoStop).