### PR TITLE
Replace {{}} with {}

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -51,7 +51,7 @@ public:
     *buffer = Common::FromBigEndian(temp);
     return true;
   }
-  virtual std::vector<Partition> GetPartitions() const { return {{}}; }
+  virtual std::vector<Partition> GetPartitions() const { return {}; }
   virtual Partition GetGamePartition() const { return PARTITION_NONE; }
   bool GetTitleID(u64* buffer) const { return GetTitleID(buffer, GetGamePartition()); }
   virtual bool GetTitleID(u64* buffer, const Partition& partition) const { return false; }
@@ -68,11 +68,11 @@ public:
   virtual u16 GetRevision(const Partition& partition) const = 0;
   std::string GetInternalName() const { return GetInternalName(GetGamePartition()); }
   virtual std::string GetInternalName(const Partition& partition) const = 0;
-  virtual std::map<Language, std::string> GetShortNames() const { return {{}}; }
-  virtual std::map<Language, std::string> GetLongNames() const { return {{}}; }
-  virtual std::map<Language, std::string> GetShortMakers() const { return {{}}; }
-  virtual std::map<Language, std::string> GetLongMakers() const { return {{}}; }
-  virtual std::map<Language, std::string> GetDescriptions() const { return {{}}; }
+  virtual std::map<Language, std::string> GetShortNames() const { return {}; }
+  virtual std::map<Language, std::string> GetLongNames() const { return {}; }
+  virtual std::map<Language, std::string> GetShortMakers() const { return {}; }
+  virtual std::map<Language, std::string> GetLongMakers() const { return {}; }
+  virtual std::map<Language, std::string> GetDescriptions() const { return {}; }
   virtual std::vector<u32> GetBanner(int* width, int* height) const = 0;
   u64 GetFSTSize() const { return GetFSTSize(GetGamePartition()); }
   virtual u64 GetFSTSize(const Partition& partition) const = 0;

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -211,7 +211,7 @@ std::map<Language, std::string> CVolumeDirectory::GetLongNames() const
 {
   std::string name = GetInternalName();
   if (name.empty())
-    return {{}};
+    return {};
   return {{Language::LANGUAGE_UNKNOWN, name}};
 }
 

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -276,7 +276,7 @@ std::map<Language, std::string> CVolumeWiiCrypted::GetLongNames() const
 {
   std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this, GetGamePartition()));
   if (!file_system)
-    return {{}};
+    return {};
 
   std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);
   size_t size = file_system->ReadFile("opening.bnr", opening_bnr.data(), opening_bnr.size(), 0x5C);


### PR DESCRIPTION
IIRC we were only using {{}} because {} used to cause errors on the FreeBSD buildbot. Let's see if {} works nowadays...