### PR TITLE
DiscIO: Use std::optional for GetTitleID instead of pointer

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -721,9 +721,10 @@ void SConfig::ResetRunningGameMetadata()
 void SConfig::SetRunningGameMetadata(const DiscIO::IVolume& volume,
                                      const DiscIO::Partition& partition)
 {
-  u64 title_id = 0;
-  volume.GetTitleID(&title_id, partition);
-  SetRunningGameMetadata(volume.GetGameID(partition), title_id, volume.GetRevision(partition),
+  const std::optional<u64> title_id = volume.GetTitleID(partition);
+  if (!title_id)
+    return;
+  SetRunningGameMetadata(volume.GetGameID(partition), *title_id, volume.GetRevision(partition),
                          Core::TitleDatabase::TitleType::Other);
 }
 

--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -219,11 +219,8 @@ bool UpdateRunningGameMetadata(const DiscIO::Partition& partition, std::optional
 
   if (title_id)
   {
-    u64 volume_title_id;
-    if (!s_disc->GetTitleID(&volume_title_id, partition))
-      return false;
-
-    if (volume_title_id != *title_id)
+    const std::optional<u64> volume_title_id = s_disc->GetTitleID(partition);
+    if (!volume_title_id || *volume_title_id != *title_id)
       return false;
   }
 

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -8,6 +8,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -53,8 +54,8 @@ public:
   }
   virtual std::vector<Partition> GetPartitions() const { return {{}}; }
   virtual Partition GetGamePartition() const { return PARTITION_NONE; }
-  bool GetTitleID(u64* buffer) const { return GetTitleID(buffer, GetGamePartition()); }
-  virtual bool GetTitleID(u64* buffer, const Partition& partition) const { return false; }
+  std::optional<u64> GetTitleID() const { return GetTitleID(GetGamePartition()); }
+  virtual std::optional<u64> GetTitleID(const Partition& partition) const { return {}; }
   virtual const IOS::ES::TicketReader& GetTicket(const Partition& partition) const
   {
     return INVALID_TICKET;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -107,9 +107,12 @@ std::string CVolumeWAD::GetMakerID(const Partition& partition) const
   return DecodeString(temp);
 }
 
-bool CVolumeWAD::GetTitleID(u64* buffer, const Partition& partition) const
+std::optional<u64> CVolumeWAD::GetTitleID(const Partition& partition) const
 {
-  return ReadSwapped(m_offset + 0x01DC, buffer, partition);
+  u64 title_id;
+  if (!ReadSwapped(m_offset + 0x01DC, &title_id, partition))
+    return {};
+  return title_id;
 }
 
 u16 CVolumeWAD::GetRevision(const Partition& partition) const
@@ -141,11 +144,11 @@ std::vector<u32> CVolumeWAD::GetBanner(int* width, int* height) const
   *width = 0;
   *height = 0;
 
-  u64 title_id;
-  if (!GetTitleID(&title_id))
+  const std::optional<u64> title_id = GetTitleID();
+  if (!title_id)
     return std::vector<u32>();
 
-  return GetWiiBanner(width, height, title_id);
+  return GetWiiBanner(width, height, *title_id);
 }
 
 BlobType CVolumeWAD::GetBlobType() const

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -33,7 +34,7 @@ public:
   ~CVolumeWAD();
   bool Read(u64 offset, u64 length, u8* buffer,
             const Partition& partition = PARTITION_NONE) const override;
-  bool GetTitleID(u64* buffer, const Partition& partition = PARTITION_NONE) const override;
+  std::optional<u64> GetTitleID(const Partition& partition = PARTITION_NONE) const override;
   const IOS::ES::TMDReader& GetTMD(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
   std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -181,13 +181,12 @@ Partition CVolumeWiiCrypted::GetGamePartition() const
   return m_game_partition;
 }
 
-bool CVolumeWiiCrypted::GetTitleID(u64* buffer, const Partition& partition) const
+std::optional<u64> CVolumeWiiCrypted::GetTitleID(const Partition& partition) const
 {
   const IOS::ES::TicketReader& ticket = GetTicket(partition);
   if (!ticket.IsValid())
-    return false;
-  *buffer = ticket.GetTitleId();
-  return true;
+    return {};
+  return ticket.GetTitleId();
 }
 
 const IOS::ES::TicketReader& CVolumeWiiCrypted::GetTicket(const Partition& partition) const
@@ -289,11 +288,11 @@ std::vector<u32> CVolumeWiiCrypted::GetBanner(int* width, int* height) const
   *width = 0;
   *height = 0;
 
-  u64 title_id;
-  if (!GetTitleID(&title_id, GetGamePartition()))
+  const std::optional<u64> title_id = GetTitleID(GetGamePartition());
+  if (!title_id)
     return std::vector<u32>();
 
-  return GetWiiBanner(width, height, title_id);
+  return GetWiiBanner(width, height, *title_id);
 }
 
 u64 CVolumeWiiCrypted::GetFSTSize(const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <mbedtls/aes.h>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -33,7 +34,7 @@ public:
   bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const override;
   std::vector<Partition> GetPartitions() const override;
   Partition GetGamePartition() const override;
-  bool GetTitleID(u64* buffer, const Partition& partition) const override;
+  std::optional<u64> GetTitleID(const Partition& partition) const override;
   const IOS::ES::TicketReader& GetTicket(const Partition& partition) const override;
   const IOS::ES::TMDReader& GetTMD(const Partition& partition) const override;
   std::string GetGameID(const Partition& partition) const override;

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -161,7 +161,8 @@ bool GameFile::TryLoadVolume()
 
   m_game_id = QString::fromStdString(volume->GetGameID());
   std::string maker_id = volume->GetMakerID();
-  volume->GetTitleID(&m_title_id);
+  if (std::optional<u64> title_id = volume->GetTitleID())
+    m_title_id = *title_id;
   m_maker = QString::fromStdString(DiscIO::GetCompanyFromID(maker_id));
   m_maker_id = QString::fromStdString(maker_id);
   m_revision = volume->GetRevision();

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -108,7 +108,8 @@ GameListItem::GameListItem(const std::string& _rFileName, const Core::TitleDatab
       m_VolumeSize = volume->GetSize();
 
       m_game_id = volume->GetGameID();
-      volume->GetTitleID(&m_title_id);
+      if (std::optional<u64> title_id = volume->GetTitleID())
+        m_title_id = *title_id;
       m_disc_number = volume->GetDiscNumber();
       m_Revision = volume->GetRevision();
 


### PR DESCRIPTION
This makes the interface slightly cleaner and a bit more consistent with the other getters. Still not fully the same, since the others don't really handle failures with std::optional; but at least the value is returned by value now, as opposed to having the function take a pointer to a u64.