### PR TITLE
Device: Provide operator!= counterparts to operator== for DeviceQualifier

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -120,9 +120,19 @@ bool DeviceQualifier::operator==(const Device* const dev) const
   return false;
 }
 
+bool DeviceQualifier::operator!=(const Device* const dev) const
+{
+  return !operator==(dev);
+}
+
 bool DeviceQualifier::operator==(const DeviceQualifier& devq) const
 {
   return std::tie(cid, name, source) == std::tie(devq.cid, devq.name, devq.source);
+}
+
+bool DeviceQualifier::operator!=(const DeviceQualifier& devq) const
+{
+  return !operator==(devq);
 }
 
 std::shared_ptr<Device> DeviceContainer::FindDevice(const DeviceQualifier& devq) const

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -136,8 +136,12 @@ public:
   void FromDevice(const Device* const dev);
   void FromString(const std::string& str);
   std::string ToString() const;
+
   bool operator==(const DeviceQualifier& devq) const;
-  bool operator==(const Device* const dev) const;
+  bool operator!=(const DeviceQualifier& devq) const;
+
+  bool operator==(const Device* dev) const;
+  bool operator!=(const Device* dev) const;
 
   std::string source;
   int cid;


### PR DESCRIPTION
Makes comparison logic symmetric