### PR TITLE
CMake: make Qt work when using a manual "-std=c++##" flag

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Qt5Widgets REQUIRED)
+set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
 message(STATUS "Found Qt version ${Qt5Core_VERSION}")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Fixes regression starting in #5388.

Based on approach in https://gitlab.kitware.com/cmake/cmake/issues/16468