### PR TITLE
msvc: use 8 byte struct member alignment instead of 16

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -79,7 +79,6 @@
       <WarningLevel>Level3</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <StructMemberAlignment>16Bytes</StructMemberAlignment>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <MinimalRebuild>false</MinimalRebuild>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>


### PR DESCRIPTION
This is an old setting which I believe now to be useless..
It should have no functional differences, but may have a very tiny perf difference (increase, hopefully).