### PR TITLE
Don't show FST size in game properties

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -75,8 +75,6 @@ public:
   virtual std::map<Language, std::string> GetLongMakers() const { return {}; }
   virtual std::map<Language, std::string> GetDescriptions() const { return {}; }
   virtual std::vector<u32> GetBanner(int* width, int* height) const = 0;
-  u64 GetFSTSize() const { return GetFSTSize(GetGamePartition()); }
-  virtual u64 GetFSTSize(const Partition& partition) const = 0;
   std::string GetApploaderDate() const { return GetApploaderDate(GetGamePartition()); }
   virtual std::string GetApploaderDate(const Partition& partition) const = 0;
   // 0 is the first disc, 1 is the second disc

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -230,12 +230,6 @@ void CVolumeDirectory::SetName(const std::string& name)
   m_disk_header[length + 0x20] = 0;
 }
 
-u64 CVolumeDirectory::GetFSTSize(const Partition& partition) const
-{
-  // Not implemented
-  return 0;
-}
-
 std::string CVolumeDirectory::GetApploaderDate(const Partition& partition) const
 {
   // Not implemented

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -54,8 +54,6 @@ public:
   std::vector<u32> GetBanner(int* width, int* height) const override;
   void SetName(const std::string&);
 
-  u64 GetFSTSize(const Partition& partition = PARTITION_NONE) const override;
-
   std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override;
   Platform GetVolumeType() const override;
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -138,15 +138,6 @@ std::vector<u32> CVolumeGC::GetBanner(int* width, int* height) const
   return m_image_buffer;
 }
 
-u64 CVolumeGC::GetFSTSize(const Partition& partition) const
-{
-  u32 size;
-  if (!Read(0x428, 0x4, (u8*)&size, partition))
-    return 0;
-
-  return Common::swap32(size);
-}
-
 std::string CVolumeGC::GetApploaderDate(const Partition& partition) const
 {
   char date[16];

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -40,7 +40,6 @@ public:
   std::map<Language, std::string> GetLongMakers() const override;
   std::map<Language, std::string> GetDescriptions() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
-  u64 GetFSTSize(const Partition& partition = PARTITION_NONE) const override;
   std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override;
   u8 GetDiscNumber(const Partition& partition = PARTITION_NONE) const override;
 

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -45,7 +45,6 @@ public:
   }
   std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
-  u64 GetFSTSize(const Partition& partition = PARTITION_NONE) const override { return 0; }
   std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override
   {
     return "";

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -295,16 +295,6 @@ std::vector<u32> CVolumeWiiCrypted::GetBanner(int* width, int* height) const
   return GetWiiBanner(width, height, *title_id);
 }
 
-u64 CVolumeWiiCrypted::GetFSTSize(const Partition& partition) const
-{
-  u32 size;
-
-  if (!Read(0x428, 0x4, (u8*)&size, partition))
-    return 0;
-
-  return (u64)Common::swap32(size) << 2;
-}
-
 std::string CVolumeWiiCrypted::GetApploaderDate(const Partition& partition) const
 {
   char date[16];

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -43,7 +43,6 @@ public:
   std::string GetInternalName(const Partition& partition) const override;
   std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
-  u64 GetFSTSize(const Partition& partition) const override;
   std::string GetApploaderDate(const Partition& partition) const override;
   u8 GetDiscNumber(const Partition& partition) const override;
 

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -179,7 +179,6 @@ void InfoPanel::LoadISODetails()
   m_maker_id->SetValue("0x" + StrToWxStr(m_opened_iso->GetMakerID()));
   m_revision->SetValue(StrToWxStr(std::to_string(m_opened_iso->GetRevision())));
   m_date->SetValue(StrToWxStr(m_opened_iso->GetApploaderDate()));
-  m_fst->SetValue(StrToWxStr(std::to_string(m_opened_iso->GetFSTSize())));
   if (m_ios_version)
   {
     const IOS::ES::TMDReader tmd = m_opened_iso->GetTMD(m_opened_iso->GetGamePartition());
@@ -221,7 +220,6 @@ wxStaticBoxSizer* InfoPanel::CreateISODetailsSizer()
       {_("Maker ID:"), m_maker_id},
       {_("Revision:"), m_revision},
       {_("Apploader Date:"), m_date},
-      {_("FST Size:"), m_fst},
   }};
   if (m_opened_iso->GetTMD(m_opened_iso->GetGamePartition()).IsValid())
     controls.emplace_back(_("IOS Version:"), m_ios_version);

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.h
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.h
@@ -61,7 +61,6 @@ private:
   wxTextCtrl* m_maker_id;
   wxTextCtrl* m_revision;
   wxTextCtrl* m_date;
-  wxTextCtrl* m_fst;
   wxTextCtrl* m_ios_version = nullptr;
   wxTextCtrl* m_md5_sum;
   wxButton* m_md5_sum_compute;


### PR DESCRIPTION
Normal users don't care about it. In fact, people care so little about it that the Wii implementation of it was broken starting from when it was implemented (eb65601) to 7 years later (e0a47c1), apparently without anyone reporting it.