### PR TITLE
Fix SetRunningGameMetadata not being called for GC titles

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -719,11 +719,8 @@ void SConfig::ResetRunningGameMetadata()
 void SConfig::SetRunningGameMetadata(const DiscIO::IVolume& volume,
                                      const DiscIO::Partition& partition)
 {
-  const std::optional<u64> title_id = volume.GetTitleID(partition);
-  if (!title_id)
-    return;
-  SetRunningGameMetadata(volume.GetGameID(partition), *title_id, volume.GetRevision(partition),
-                         Core::TitleDatabase::TitleType::Other);
+  SetRunningGameMetadata(volume.GetGameID(partition), volume.GetTitleID(partition).value_or(0),
+                         volume.GetRevision(partition), Core::TitleDatabase::TitleType::Other);
 }
 
 void SConfig::SetRunningGameMetadata(const IOS::ES::TMDReader& tmd)


### PR DESCRIPTION
GC titles don't have a title ID, so this regression would cause `SetRunningGameMetadata` to never be called for GC titles.