### PR TITLE
HLE: Prevent GetStringVA to strip newlines

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -405,6 +405,12 @@ bool StringEndsWith(const std::string& str, const std::string& end)
   return str.size() >= end.size() && std::equal(end.rbegin(), end.rend(), str.rbegin());
 }
 
+void StringPopBackIf(std::string* s, char c)
+{
+  if (!s->empty() && s->back() == c)
+    s->pop_back();
+}
+
 #ifdef _WIN32
 
 std::string UTF16ToUTF8(const std::wstring& input)

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -119,6 +119,7 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
 
 bool StringBeginsWith(const std::string& str, const std::string& begin);
 bool StringEndsWith(const std::string& str, const std::string& end);
+void StringPopBackIf(std::string* s, char c);
 
 std::string CP1252ToUTF8(const std::string& str);
 std::string SHIFTJISToUTF8(const std::string& str);

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -33,10 +33,8 @@ void HLE_OSPanic()
   std::string error = GetStringVA();
   std::string msg = GetStringVA(5);
 
-  if (!error.empty() && error.back() == '\n')
-    error.pop_back();
-  if (!msg.empty() && msg.back() == '\n')
-    msg.pop_back();
+  StringPopBackIf(&error, '\n');
+  StringPopBackIf(&msg, '\n');
 
   PanicAlert("OSPanic: %s: %s", error.c_str(), msg.c_str());
   ERROR_LOG(OSREPORT, "%08x->%08x| OSPanic: %s: %s", LR, PC, error.c_str(), msg.c_str());
@@ -77,8 +75,7 @@ void HLE_GeneralDebugPrint(ParameterType parameter_type)
     }
   }
 
-  if (!report_message.empty() && report_message.back() == '\n')
-    report_message.pop_back();
+  StringPopBackIf(&report_message, '\n');
 
   NPC = LR;
 
@@ -116,8 +113,7 @@ void HLE_write_console()
     ERROR_LOG(OSREPORT, "__write_console uses an unreachable size pointer");
   }
 
-  if (!report_message.empty() && report_message.back() == '\n')
-    report_message.pop_back();
+  StringPopBackIf(&report_message, '\n');
 
   NPC = LR;
 
@@ -133,6 +129,7 @@ void HLE_LogDPrint(ParameterType parameter_type)
     return;
 
   std::string report_message = GetStringVA(4, parameter_type);
+  StringPopBackIf(&report_message, '\n');
   NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
 }
 
@@ -172,6 +169,7 @@ void HLE_LogFPrint(ParameterType parameter_type)
     return;
 
   std::string report_message = GetStringVA(4, parameter_type);
+  StringPopBackIf(&report_message, '\n');
   NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
 }
 

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -33,6 +33,11 @@ void HLE_OSPanic()
   std::string error = GetStringVA();
   std::string msg = GetStringVA(5);
 
+  if (!error.empty() && error.back() == '\n')
+    error.pop_back();
+  if (!msg.empty() && msg.back() == '\n')
+    msg.pop_back();
+
   PanicAlert("OSPanic: %s: %s", error.c_str(), msg.c_str());
   ERROR_LOG(OSREPORT, "%08x->%08x| OSPanic: %s: %s", LR, PC, error.c_str(), msg.c_str());
 
@@ -72,6 +77,9 @@ void HLE_GeneralDebugPrint(ParameterType parameter_type)
     }
   }
 
+  if (!report_message.empty() && report_message.back() == '\n')
+    report_message.pop_back();
+
   NPC = LR;
 
   NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
@@ -107,6 +115,9 @@ void HLE_write_console()
   {
     ERROR_LOG(OSREPORT, "__write_console uses an unreachable size pointer");
   }
+
+  if (!report_message.empty() && report_message.back() == '\n')
+    report_message.pop_back();
 
   NPC = LR;
 
@@ -250,9 +261,6 @@ std::string GetStringVA(u32 str_reg, ParameterType parameter_type)
       result += string[i];
     }
   }
-
-  if (!result.empty() && result.back() == '\n')
-    result.pop_back();
 
   return result;
 }


### PR DESCRIPTION
```GetStringVA``` shouldn't alter the string it retrieves. This PR fixes ```__write_console``` warnings occurring in Zelda: Twilight Princess.

Ready to be reviewed & merged.