### PR TITLE
editorconfig: remove utf-8 setting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 [*]
-charset = utf-8
 end_of_line = lf
 indent_size = 2
 trim_trailing_whitespace = true


### PR DESCRIPTION
This causes VS to insert utf8 BOMs, which is not currently present in any dolphin sources.
Currently we use a compiler flag to enforce everything shall be treated as utf-8, anyways.

Feel free to treat this PR as a RFC on the matter.

Note: this will apparently be fixed soon(tm) https://developercommunity.visualstudio.com/content/problem/22922/editorconfig-support-interprets-charset-utf-8-as-u.html