### PR TITLE
Tools/Lint: Allow diffing against arbitrary revisions

### DIFF
--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -4,8 +4,11 @@
 
 fail=0
 
+# Default to staged files, unless a commit was passed.
+COMMIT=${1:---cached}
+
 # Loop through each modified file.
-for f in $(git diff --name-only --diff-filter=ACMRTUXB --cached); do
+for f in $(git diff --name-only --diff-filter=ACMRTUXB $COMMIT); do
   # Filter them.
   if ! echo "${f}" | egrep -q "[.](cpp|h|mm)$"; then
     continue


### PR DESCRIPTION
Instead of applying PRs as patches and leaving them as staged changes, the lint builder now checks out the PR branch, so the lint script must be able to call git diff with more than just --cached. (The buildbot will call it with "master...".)