### PR TITLE
DolphinQt2: live updates to UI theme

### DIFF
--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -2,6 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <QDialogButtonBox>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
 #include "DolphinQt2/Config/SettingsWindow.h"
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/Settings/GeneralPane.h"

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -11,6 +11,7 @@
 #include <QVBoxLayout>
 
 #include "DolphinQt2/Config/SettingsWindow.h"
+#include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/Settings/GeneralPane.h"
 #include "DolphinQt2/Settings/InterfacePane.h"
@@ -75,15 +76,18 @@ void SettingsWindow::MakeUnfinishedWarning()
   m_warning_group->setLayout(m_warning_group_layout);
 }
 
-void SettingsWindow::AddCategoryToList(const QString& title, const QString& icon)
+void SettingsWindow::AddCategoryToList(const QString& title, const std::string& icon_name)
 {
   QString dir = Settings::Instance().GetThemeDir();
   QListWidgetItem* button = new QListWidgetItem();
-  button->setIcon(QIcon(dir.append(icon)));
   button->setText(title);
   button->setTextAlignment(Qt::AlignVCenter);
   button->setSizeHint(QSize(28, 28));
   button->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+
+  auto set_icon = [=] { button->setIcon(Resources::GetScaledThemeIcon(icon_name)); };
+  QObject::connect(&Settings::Instance(), &Settings::ThemeChanged, set_icon);
+  set_icon();
   m_categories->addItem(button);
 }
 
@@ -95,9 +99,9 @@ void SettingsWindow::MakeCategoryList()
   m_categories->setMovement(QListView::Static);
   m_categories->setSpacing(0);
 
-  AddCategoryToList(tr("General"), QStringLiteral("config.png"));
-  AddCategoryToList(tr("Interface"), QStringLiteral("browse.png"));
-  AddCategoryToList(tr("Paths"), QStringLiteral("browse.png"));
+  AddCategoryToList(tr("General"), "config");
+  AddCategoryToList(tr("Interface"), "browse");
+  AddCategoryToList(tr("Paths"), "browse");
   connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);
 }
 

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -5,17 +5,11 @@
 #pragma once
 
 #include <QDialog>
-#include <QDialogButtonBox>
-#include <QGroupBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QListView>
-#include <QListWidget>
-#include <QListWidgetItem>
-#include <QStackedWidget>
-#include <QString>
-#include <QVBoxLayout>
-#include <QWidget>
+
+class QGroupBox;
+class QListWidget;
+class QListWidgetItem;
+class QStackedWidget;
 
 class SettingsWindow final : public QDialog
 {

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <QDialog>
 
 class QGroupBox;
@@ -23,7 +25,7 @@ public slots:
 private:
   void MakeCategoryList();
   void MakeUnfinishedWarning();
-  void AddCategoryToList(const QString& title, const QString& icon);
+  void AddCategoryToList(const QString& title, const std::string& icon_name);
   void SetupSettingsWidget();
   QStackedWidget* m_settings_outer;
   QListWidget* m_categories;

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -4,6 +4,7 @@
 
 #include "DolphinQt2/GameList/GameListModel.h"
 #include "DolphinQt2/Resources.h"
+#include "DolphinQt2/Settings.h"
 
 const QSize GAMECUBE_BANNER_SIZE(96, 32);
 
@@ -13,6 +14,13 @@ GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
   connect(&m_tracker, &GameTracker::GameRemoved, this, &GameListModel::RemoveGame);
   connect(this, &GameListModel::DirectoryAdded, &m_tracker, &GameTracker::AddDirectory);
   connect(this, &GameListModel::DirectoryRemoved, &m_tracker, &GameTracker::RemoveDirectory);
+
+  connect(&Settings::Instance(), &Settings::ThemeChanged, [this] {
+    // Tell the view to repaint. The signal 'dataChanged' also seems like it would work here, but
+    // unfortunately it won't cause a repaint until the view is focused.
+    emit layoutAboutToBeChanged();
+    emit layoutChanged();
+  });
 }
 
 QVariant GameListModel::data(const QModelIndex& index, int role) const

--- a/Source/Core/DolphinQt2/Resources.cpp
+++ b/Source/Core/DolphinQt2/Resources.cpp
@@ -82,12 +82,20 @@ void Resources::Init()
   {
     m_countries.append(GetScaledPixmap(country));
   }
-  for (int stars = 0; stars <= 5; stars++)
-    m_ratings.append(GetScaledThemePixmap("rating" + std::to_string(stars)));
 
   m_misc.append(GetScaledPixmap("nobanner"));
   m_misc.append(GetScaledPixmap("dolphin_logo"));
   m_misc.append(GetScaledPixmap("Dolphin"));
+
+  QObject::connect(&Settings::Instance(), &Settings::ThemeChanged, Resources::InitThemeIcons);
+  InitThemeIcons();
+}
+
+void Resources::InitThemeIcons()
+{
+  m_ratings = {GetScaledThemePixmap("rating0"), GetScaledThemePixmap("rating1"),
+               GetScaledThemePixmap("rating2"), GetScaledThemePixmap("rating3"),
+               GetScaledThemePixmap("rating4"), GetScaledThemePixmap("rating5")};
 }
 
 QPixmap Resources::GetPlatform(int platform)

--- a/Source/Core/DolphinQt2/Resources.h
+++ b/Source/Core/DolphinQt2/Resources.h
@@ -33,6 +33,7 @@ public:
 
 private:
   Resources() {}
+  static void InitThemeIcons();
   static QIcon GetIcon(const QString& name, const QString& dir);
   static QPixmap GetPixmap(const QString& name, const QString& dir);
 

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -27,6 +27,12 @@ Settings& Settings::Instance()
   return settings;
 }
 
+void Settings::SetThemeName(const QString& theme_name)
+{
+  SConfig::GetInstance().theme_name = theme_name.toStdString();
+  emit ThemeChanged();
+}
+
 QString Settings::GetThemeDir() const
 {
   return QString::fromStdString(File::GetThemeDir(SConfig::GetInstance().theme_name));

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -26,6 +26,7 @@ public:
   static Settings& Instance();
 
   // UI
+  void SetThemeName(const QString& theme_name);
   QString GetThemeDir() const;
   QString GetResourcesDir() const;
   QString GetProfilesDir() const;
@@ -109,6 +110,7 @@ public:
   void Save();
 
 signals:
+  void ThemeChanged();
   void PathAdded(const QString&);
   void PathRemoved(const QString&);
 

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -17,6 +17,8 @@
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 
+#include "DolphinQt2/Settings.h"
+
 InterfacePane::InterfacePane(QWidget* parent) : QWidget(parent)
 {
   CreateLayout();
@@ -106,7 +108,7 @@ void InterfacePane::ConnectLayout()
   connect(m_checkbox_top_window, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_render_to_window, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
   connect(m_combobox_theme, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::activated),
-          [this](const QString& text) { OnSaveConfig(); });
+          &Settings::Instance(), &Settings::SetThemeName);
   connect(m_combobox_language, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
           [this](int index) { OnSaveConfig(); });
   connect(m_checkbox_confirm_on_stop, &QCheckBox::clicked, this, &InterfacePane::OnSaveConfig);
@@ -140,7 +142,6 @@ void InterfacePane::OnSaveConfig()
   settings.bRenderWindowAutoSize = m_checkbox_auto_window->isChecked();
   settings.bKeepWindowOnTop = m_checkbox_top_window->isChecked();
   settings.bRenderToMain = m_checkbox_render_to_window->isChecked();
-  settings.theme_name = m_combobox_theme->currentText().toStdString();
 
   // In Game Options
   settings.bConfirmStop = m_checkbox_confirm_on_stop->isChecked();

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -18,6 +18,7 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   setIconSize(ICON_SIZE);
 
   MakeActions();
+  connect(&Settings::Instance(), &Settings::ThemeChanged, this, &ToolBar::UpdateIcons);
   UpdateIcons();
 
   EmulationStopped();


### PR DESCRIPTION
Depends on #5504 for the Settings magic.

Animation showing the UI updating as the theme is changed:
![](https://cloud.githubusercontent.com/assets/594093/26774445/25195bb8-4985-11e7-9468-88eb48d0747f.gif)
