### PR TITLE
Reimplement support for unencrypted Wii discs

### DIFF
--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -96,13 +96,7 @@ std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename)
   // Check for Wii
   const std::optional<u32> wii_magic = reader->ReadSwapped<u32>(0x18);
   if (wii_magic == u32(0x5D1C9EA3))
-  {
-    const std::optional<u32> wii_container_magic = reader->ReadSwapped<u32>(0x60);
-    if (wii_container_magic == u32(0))
-      return std::make_unique<CVolumeWiiCrypted>(std::move(reader));
-
-    return std::make_unique<CVolumeGC>(std::move(reader));
-  }
+    return std::make_unique<CVolumeWiiCrypted>(std::move(reader));
 
   // Check for WAD
   // 0x206962 for boot2 wads

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -36,6 +36,12 @@ CVolumeWiiCrypted::CVolumeWiiCrypted(std::unique_ptr<IBlobReader> reader)
 {
   _assert_(m_pReader);
 
+  if (m_pReader->ReadSwapped<u32>(0x60) != u32(0))
+  {
+    // No partitions - just read unencrypted data like with a GC disc
+    return;
+  }
+
   // Get tickets, TMDs, and decryption keys for all partitions
   for (u32 partition_group = 0; partition_group < 4; ++partition_group)
   {


### PR DESCRIPTION
You may want to read the PR #2047 comments before reading this.

Dolphin attempts to support an unencrypted type of Wii discs that apparently is identified by a 4-byte integer at 0x60 being non-zero. I don't know what discs (if any) would be using that format, so I haven't been able to test Dolphin's support for it, but it has probably been broken for a while.

The old implementation is very short but also strange. In CreateVolumeFromFilename, we read a 4-byte integer from 0x60, and if it's non-zero, we create a CVolumeGC object instead of a CVolumeWiiCrypted object. This might seem like it makes no sense, but it presumably worked in the past because IsVolumeWiiDisc used to check the volume type by reading the magic word for Wii straight from the disc,
meaning that CVolumeGC objects representing unencrypted Wii discs would be treated as Wii discs by pretty much all of Dolphin's code except for the volume implementation code. (It wasn't possible to simply use CVolumeWiiCrypted, because that class only handled encrypted discs, like the name says.)

However, that stopped working as intended because of ace0607. And furthermore, bb93336 made it even more broken by making parts of Dolphin expect that data read from Wii discs needed to be decrypted (rather than the volume implementation implicitly deciding whether to decrypt when Read was called). Disclaimer: Like I said before, I haven't been able to test any of this because I don't have any discs that use this unencrypted Wii disc format, so this is all theoretical.

Later, PR #2047 tried to remove Dolphin's support for the unencrypted Wii disc format because seemingly no discs used it, but the PR got closed without being merged. At the end of that PR, I said that I would make a new PR with a better implementation for the format after PR #2353 was merged. Now that PR #2353 is merged (two years later...) and PR #5521 is merged, the new implementation was easy to make, and here it is!

Untested.