### PR TITLE
Fix UB string comparisons

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -49,11 +49,12 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
 {
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (unsigned int i = 0; i < sizeof(named_buttons) / sizeof(*named_buttons); ++i)
+  for (const char* named_button : named_buttons)
   {
-    // i18n: The START/PAUSE button on GameCube controllers
-    const std::string& ui_name = (named_buttons[i] == "Start") ? _trans("START") : named_buttons[i];
-    m_buttons->controls.emplace_back(new ControllerEmu::Input(named_buttons[i], ui_name));
+    const std::string& ui_name =
+        // i18n: The START/PAUSE button on GameCube controllers
+        (named_button == std::string("Start")) ? _trans("START") : named_button;
+    m_buttons->controls.emplace_back(new ControllerEmu::Input(named_button, ui_name));
   }
 
   // sticks
@@ -64,7 +65,7 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
 
   // triggers
   groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
-  for (auto& named_trigger : named_triggers)
+  for (const char* named_trigger : named_triggers)
     m_triggers->controls.emplace_back(new ControllerEmu::Input(named_trigger));
 
   // rumble
@@ -77,7 +78,7 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
 
   // dpad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
-  for (auto& named_direction : named_directions)
+  for (const char* named_direction : named_directions)
     m_dpad->controls.emplace_back(new ControllerEmu::Input(named_direction));
 
   // options

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -63,10 +63,10 @@ Classic::Classic(ExtensionReg& reg) : Attachment(_trans("Classic"), reg)
 {
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (auto& classic_button_name : classic_button_names)
+  for (const char* button_name : classic_button_names)
   {
-    const std::string& ui_name = (classic_button_name == "Home") ? "HOME" : classic_button_name;
-    m_buttons->controls.emplace_back(new ControllerEmu::Input(classic_button_name, ui_name));
+    const std::string& ui_name = (button_name == std::string("Home")) ? "HOME" : button_name;
+    m_buttons->controls.emplace_back(new ControllerEmu::Input(button_name, ui_name));
   }
 
   // sticks
@@ -77,12 +77,12 @@ Classic::Classic(ExtensionReg& reg) : Attachment(_trans("Classic"), reg)
 
   // triggers
   groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
-  for (auto& classic_trigger_name : classic_trigger_names)
-    m_triggers->controls.emplace_back(new ControllerEmu::Input(classic_trigger_name));
+  for (const char* trigger_name : classic_trigger_names)
+    m_triggers->controls.emplace_back(new ControllerEmu::Input(trigger_name));
 
   // dpad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
-  for (auto& named_direction : named_directions)
+  for (const char* named_direction : named_directions)
     m_dpad->controls.emplace_back(new ControllerEmu::Input(named_direction));
 
   // Set up register

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -256,9 +256,9 @@ Wiimote::Wiimote(const unsigned int index)
 
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (auto& named_button : named_buttons)
+  for (const char* named_button : named_buttons)
   {
-    const std::string& ui_name = (named_button == "Home") ? "HOME" : named_button;
+    const std::string& ui_name = (named_button == std::string("Home")) ? "HOME" : named_button;
     m_buttons->controls.emplace_back(new ControllerEmu::Input(named_button, ui_name));
   }
 
@@ -299,7 +299,7 @@ Wiimote::Wiimote(const unsigned int index)
 
   // dpad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
-  for (auto& named_direction : named_directions)
+  for (const char* named_direction : named_directions)
     m_dpad->controls.emplace_back(new ControllerEmu::Input(named_direction));
 
   // options


### PR DESCRIPTION
Also replacing `auto&` with `const char*` so that it's easier to see that these strings aren't `std::string`s.