### PR TITLE
DiscIO: Remove C/I/S prefixes from class names

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -192,7 +192,7 @@ static inline u32 GetPixel(u32* buffer, unsigned int x, unsigned int y)
 
 static bool LoadBanner(std::string filename, u32* Banner)
 {
-  std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
 
   if (pVolume != nullptr)
   {
@@ -230,7 +230,7 @@ static bool LoadBanner(std::string filename, u32* Banner)
 
 static int GetCountry(std::string filename)
 {
-  std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
 
   if (pVolume != nullptr)
   {
@@ -246,7 +246,7 @@ static int GetCountry(std::string filename)
 
 static int GetPlatform(std::string filename)
 {
-  std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
 
   if (pVolume != nullptr)
   {
@@ -272,7 +272,7 @@ static std::string GetTitle(std::string filename)
   __android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting Title for file: %s",
                       filename.c_str());
 
-  std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
 
   if (pVolume != nullptr)
   {
@@ -315,7 +315,7 @@ static std::string GetDescription(std::string filename)
   __android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting Description for file: %s",
                       filename.c_str());
 
-  std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> volume(DiscIO::CreateVolumeFromFilename(filename));
 
   if (volume != nullptr)
   {
@@ -350,7 +350,7 @@ static std::string GetGameId(std::string filename)
 {
   __android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting ID for file: %s", filename.c_str());
 
-  std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> volume(DiscIO::CreateVolumeFromFilename(filename));
   if (volume == nullptr)
     return std::string();
 
@@ -364,7 +364,7 @@ static std::string GetCompany(std::string filename)
   __android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting Company for file: %s",
                       filename.c_str());
 
-  std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> volume(DiscIO::CreateVolumeFromFilename(filename));
   if (volume == nullptr)
     return std::string();
 
@@ -377,7 +377,7 @@ static u64 GetFileSize(std::string filename)
 {
   __android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting size of file: %s", filename.c_str());
 
-  std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
+  std::unique_ptr<DiscIO::Volume> volume(DiscIO::CreateVolumeFromFilename(filename));
   if (volume == nullptr)
     return -1;
 

--- a/Source/Core/Common/MD5.cpp
+++ b/Source/Core/Common/MD5.cpp
@@ -20,7 +20,7 @@ std::string MD5Sum(const std::string& file_path, std::function<bool(int)> report
   u64 read_offset = 0;
   mbedtls_md5_context ctx;
 
-  std::unique_ptr<DiscIO::IBlobReader> file(DiscIO::CreateBlobReader(file_path));
+  std::unique_ptr<DiscIO::BlobReader> file(DiscIO::CreateBlobReader(file_path));
   u64 game_size = file->GetDataSize();
 
   mbedtls_md5_starts(&ctx);

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -42,14 +42,14 @@
 // Inserts a disc into the emulated disc drive and returns a pointer to it.
 // The returned pointer must only be used while we are still booting,
 // because DVDThread can do whatever it wants to the disc after that.
-static const DiscIO::IVolume* SetDisc(std::unique_ptr<DiscIO::IVolume> volume)
+static const DiscIO::Volume* SetDisc(std::unique_ptr<DiscIO::Volume> volume)
 {
-  const DiscIO::IVolume* pointer = volume.get();
+  const DiscIO::Volume* pointer = volume.get();
   DVDInterface::SetDisc(std::move(volume));
   return pointer;
 }
 
-bool CBoot::DVDRead(const DiscIO::IVolume& volume, u64 dvd_offset, u32 output_address, u32 length,
+bool CBoot::DVDRead(const DiscIO::Volume& volume, u64 dvd_offset, u32 output_address, u32 length,
                     const DiscIO::Partition& partition)
 {
   std::vector<u8> buffer(length);
@@ -59,7 +59,7 @@ bool CBoot::DVDRead(const DiscIO::IVolume& volume, u64 dvd_offset, u32 output_ad
   return true;
 }
 
-void CBoot::Load_FST(bool is_wii, const DiscIO::IVolume* volume)
+void CBoot::Load_FST(bool is_wii, const DiscIO::Volume* volume)
 {
   if (!volume)
     return;
@@ -113,8 +113,8 @@ bool CBoot::FindMapFile(std::string* existing_map_file, std::string* writable_ma
   {
   case SConfig::BOOT_WII_NAND:
   {
-    const DiscIO::CNANDContentLoader& Loader =
-        DiscIO::CNANDContentManager::Access().GetNANDLoader(_StartupPara.m_strFilename);
+    const DiscIO::NANDContentLoader& Loader =
+        DiscIO::NANDContentManager::Access().GetNANDLoader(_StartupPara.m_strFilename);
     if (Loader.IsValid())
     {
       u64 TitleID = Loader.GetTMD().GetTitleId();
@@ -290,7 +290,7 @@ bool CBoot::BootUp()
   {
   case SConfig::BOOT_ISO:
   {
-    const DiscIO::IVolume* volume =
+    const DiscIO::Volume* volume =
         SetDisc(DiscIO::CreateVolumeFromFilename(_StartupPara.m_strFilename));
 
     if (!volume)
@@ -343,7 +343,7 @@ bool CBoot::BootUp()
       PanicAlertT("Warning - starting DOL in wrong console mode!");
     }
 
-    const DiscIO::IVolume* volume = nullptr;
+    const DiscIO::Volume* volume = nullptr;
     if (!_StartupPara.m_strDVDRoot.empty())
     {
       NOTICE_LOG(BOOT, "Setting DVDRoot %s", _StartupPara.m_strDVDRoot.c_str());
@@ -385,7 +385,7 @@ bool CBoot::BootUp()
 
   case SConfig::BOOT_ELF:
   {
-    const DiscIO::IVolume* volume = nullptr;
+    const DiscIO::Volume* volume = nullptr;
 
     // load image or create virtual drive from directory
     if (!_StartupPara.m_strDVDRoot.empty())

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -11,7 +11,7 @@
 
 namespace DiscIO
 {
-class IVolume;
+class Volume;
 struct Partition;
 }
 
@@ -46,7 +46,7 @@ public:
   static bool LoadMapFromFilename();
 
 private:
-  static bool DVDRead(const DiscIO::IVolume& volume, u64 dvd_offset, u32 output_address, u32 length,
+  static bool DVDRead(const DiscIO::Volume& volume, u64 dvd_offset, u32 output_address, u32 length,
                       const DiscIO::Partition& partition);
   static void RunFunction(u32 address);
 
@@ -57,12 +57,12 @@ private:
 
   static void SetupMSR();
   static void SetupBAT(bool is_wii);
-  static bool RunApploader(bool is_wii, const DiscIO::IVolume& volume);
-  static bool EmulatedBS2_GC(const DiscIO::IVolume* volume, bool skip_app_loader = false);
-  static bool EmulatedBS2_Wii(const DiscIO::IVolume* volume);
-  static bool EmulatedBS2(bool is_wii, const DiscIO::IVolume* volume);
+  static bool RunApploader(bool is_wii, const DiscIO::Volume& volume);
+  static bool EmulatedBS2_GC(const DiscIO::Volume* volume, bool skip_app_loader = false);
+  static bool EmulatedBS2_Wii(const DiscIO::Volume* volume);
+  static bool EmulatedBS2(bool is_wii, const DiscIO::Volume* volume);
   static bool Load_BS2(const std::string& boot_rom_filename);
-  static void Load_FST(bool is_wii, const DiscIO::IVolume* volume);
+  static void Load_FST(bool is_wii, const DiscIO::Volume* volume);
 
-  static bool SetupWiiMemory(const DiscIO::IVolume* volume, u64 ios_title_id);
+  static bool SetupWiiMemory(const DiscIO::Volume* volume, u64 ios_title_id);
 };

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -82,7 +82,7 @@ void CBoot::SetupBAT(bool is_wii)
   PowerPC::IBATUpdated();
 }
 
-bool CBoot::RunApploader(bool is_wii, const DiscIO::IVolume& volume)
+bool CBoot::RunApploader(bool is_wii, const DiscIO::Volume& volume)
 {
   const DiscIO::Partition partition = volume.GetGamePartition();
 
@@ -155,7 +155,7 @@ bool CBoot::RunApploader(bool is_wii, const DiscIO::IVolume& volume)
 // GameCube Bootstrap 2 HLE:
 // copy the apploader to 0x81200000
 // execute the apploader, function by function, using the above utility.
-bool CBoot::EmulatedBS2_GC(const DiscIO::IVolume* volume, bool skip_app_loader)
+bool CBoot::EmulatedBS2_GC(const DiscIO::Volume* volume, bool skip_app_loader)
 {
   INFO_LOG(BOOT, "Faking GC BS2...");
 
@@ -217,7 +217,7 @@ bool CBoot::EmulatedBS2_GC(const DiscIO::IVolume* volume, bool skip_app_loader)
   return RunApploader(/*is_wii*/ false, *volume);
 }
 
-bool CBoot::SetupWiiMemory(const DiscIO::IVolume* volume, u64 ios_title_id)
+bool CBoot::SetupWiiMemory(const DiscIO::Volume* volume, u64 ios_title_id)
 {
   static const std::map<DiscIO::Region, const RegionSetting> region_settings = {
       {DiscIO::Region::NTSC_J, {"JPN", "NTSC", "JP", "LJ"}},
@@ -331,7 +331,7 @@ bool CBoot::SetupWiiMemory(const DiscIO::IVolume* volume, u64 ios_title_id)
 // Wii Bootstrap 2 HLE:
 // copy the apploader to 0x81200000
 // execute the apploader
-bool CBoot::EmulatedBS2_Wii(const DiscIO::IVolume* volume)
+bool CBoot::EmulatedBS2_Wii(const DiscIO::Volume* volume)
 {
   INFO_LOG(BOOT, "Faking Wii BS2...");
   if (!volume)
@@ -374,7 +374,7 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::IVolume* volume)
 // Returns true if apploader has run successfully.
 // If is_wii is true and volume is not nullptr, the disc that volume
 // point to must currently be inserted into the emulated disc drive.
-bool CBoot::EmulatedBS2(bool is_wii, const DiscIO::IVolume* volume)
+bool CBoot::EmulatedBS2(bool is_wii, const DiscIO::Volume* volume)
 {
   return is_wii ? EmulatedBS2_Wii(volume) : EmulatedBS2_GC(volume);
 }

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -72,8 +72,8 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
     state_file.WriteBytes(&state, sizeof(StateFlags));
   }
 
-  const DiscIO::CNANDContentLoader& ContentLoader =
-      DiscIO::CNANDContentManager::Access().GetNANDLoader(_pFilename);
+  const DiscIO::NANDContentLoader& ContentLoader =
+      DiscIO::NANDContentManager::Access().GetNANDLoader(_pFilename);
   if (!ContentLoader.IsValid())
     return false;
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -721,7 +721,7 @@ void SConfig::ResetRunningGameMetadata()
   SetRunningGameMetadata("00000000", 0, 0, Core::TitleDatabase::TitleType::Other);
 }
 
-void SConfig::SetRunningGameMetadata(const DiscIO::IVolume& volume,
+void SConfig::SetRunningGameMetadata(const DiscIO::Volume& volume,
                                      const DiscIO::Partition& partition)
 {
   SetRunningGameMetadata(volume.GetGameID(partition), volume.GetTitleID(partition).value_or(0),
@@ -917,7 +917,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
         bootDrive)
     {
       m_BootType = BOOT_ISO;
-      std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(m_strFilename));
+      std::unique_ptr<DiscIO::Volume> pVolume(DiscIO::CreateVolumeFromFilename(m_strFilename));
       if (pVolume == nullptr)
       {
         if (bootDrive)
@@ -973,10 +973,10 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
         bWii = ddfFile->GetIsWii();
       }
     }
-    else if (DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename).IsValid())
+    else if (DiscIO::NANDContentManager::Access().GetNANDLoader(m_strFilename).IsValid())
     {
-      const DiscIO::CNANDContentLoader& content_loader =
-          DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename);
+      const DiscIO::NANDContentLoader& content_loader =
+          DiscIO::NANDContentManager::Access().GetNANDLoader(m_strFilename);
       const IOS::ES::TMDReader& tmd = content_loader.GetTMD();
 
       if (!IOS::ES::IsChannel(tmd.GetTitleId()))

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -22,7 +22,7 @@ namespace DiscIO
 enum class Language;
 enum class Region;
 struct Partition;
-class IVolume;
+class Volume;
 }
 namespace IOS
 {
@@ -225,7 +225,7 @@ struct SConfig : NonCopyable
   u64 GetTitleID() const { return m_title_id; }
   u16 GetRevision() const { return m_revision; }
   void ResetRunningGameMetadata();
-  void SetRunningGameMetadata(const DiscIO::IVolume& volume, const DiscIO::Partition& partition);
+  void SetRunningGameMetadata(const DiscIO::Volume& volume, const DiscIO::Partition& partition);
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd);
 
   void LoadDefaults();

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -33,7 +33,7 @@
 
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
-#include "DiscIO/VolumeWiiCrypted.h"
+#include "DiscIO/VolumeWii.h"
 
 // The minimum time it takes for the DVD drive to process a command (in
 // microseconds)
@@ -435,7 +435,7 @@ void Shutdown()
   DVDThread::Stop();
 }
 
-void SetDisc(std::unique_ptr<DiscIO::IVolume> disc)
+void SetDisc(std::unique_ptr<DiscIO::Volume> disc)
 {
   if (disc)
     s_current_partition = disc->GetGamePartition();
@@ -460,7 +460,7 @@ static void EjectDiscCallback(u64 userdata, s64 cyclesLate)
 
 static void InsertDiscCallback(u64 userdata, s64 cyclesLate)
 {
-  std::unique_ptr<DiscIO::IVolume> new_volume =
+  std::unique_ptr<DiscIO::Volume> new_volume =
       DiscIO::CreateVolumeFromFilename(s_disc_path_to_insert);
 
   if (new_volume)
@@ -1147,7 +1147,7 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
   // The variable dvd_offset tracks the actual offset on the DVD
   // that the disc drive starts reading at, which differs in two ways:
   // It's rounded to a whole ECC block and never uses Wii partition addressing.
-  u64 dvd_offset = DiscIO::CVolumeWiiCrypted::PartitionOffsetToRawOffset(offset, partition);
+  u64 dvd_offset = DiscIO::VolumeWii::PartitionOffsetToRawOffset(offset, partition);
   dvd_offset = Common::AlignDown(dvd_offset, DVD_ECC_BLOCK_SIZE);
 
   if (SConfig::GetInstance().bFastDiscSpeed)
@@ -1215,7 +1215,7 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
 
   const u32 bytes_per_chunk = partition == DiscIO::PARTITION_NONE ?
                                   DVD_ECC_BLOCK_SIZE :
-                                  DiscIO::CVolumeWiiCrypted::BLOCK_DATA_SIZE;
+                                  DiscIO::VolumeWii::BLOCK_DATA_SIZE;
 
   while (length > 0)
   {

--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -13,7 +13,7 @@
 class PointerWrap;
 namespace DiscIO
 {
-class IVolume;
+class Volume;
 struct Partition;
 }
 namespace MMIO
@@ -110,12 +110,12 @@ void DoState(PointerWrap& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
-void SetDisc(std::unique_ptr<DiscIO::IVolume> disc);
+void SetDisc(std::unique_ptr<DiscIO::Volume> disc);
 bool IsDiscInside();
 void ChangeDiscAsHost(const std::string& new_path);  // Can only be called by the host thread
 void ChangeDiscAsCPU(const std::string& new_path);   // Can only be called by the CPU thread
 
-// This function returns true and calls SConfig::SetRunningGameMetadata(IVolume&, Partition&)
+// This function returns true and calls SConfig::SetRunningGameMetadata(Volume&, Partition&)
 // if both of the following conditions are true:
 // - A disc is inserted
 // - The title_id argument doesn't contain a value, or its value matches the disc's title ID

--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -86,7 +86,7 @@ static Common::FifoQueue<ReadRequest, false> s_request_queue;
 static Common::FifoQueue<ReadResult, false> s_result_queue;
 static std::map<u64, ReadResult> s_result_map;
 
-static std::unique_ptr<DiscIO::IVolume> s_disc;
+static std::unique_ptr<DiscIO::Volume> s_disc;
 
 void Start()
 {
@@ -180,7 +180,7 @@ void DoState(PointerWrap& p)
   // was made. Handling that properly may be more effort than it's worth.
 }
 
-void SetDisc(std::unique_ptr<DiscIO::IVolume> disc)
+void SetDisc(std::unique_ptr<DiscIO::Volume> disc)
 {
   WaitUntilIdle();
   s_disc = std::move(disc);

--- a/Source/Core/Core/HW/DVD/DVDThread.h
+++ b/Source/Core/Core/HW/DVD/DVDThread.h
@@ -22,7 +22,7 @@ enum class ReplyType : u32;
 namespace DiscIO
 {
 enum class Platform;
-class IVolume;
+class Volume;
 }
 namespace IOS
 {
@@ -39,13 +39,13 @@ void Start();
 void Stop();
 void DoState(PointerWrap& p);
 
-void SetDisc(std::unique_ptr<DiscIO::IVolume> disc);
+void SetDisc(std::unique_ptr<DiscIO::Volume> disc);
 bool HasDisc();
 
 DiscIO::Platform GetDiscType();
 IOS::ES::TMDReader GetTMD(const DiscIO::Partition& partition);
 IOS::ES::TicketReader GetTicket(const DiscIO::Partition& partition);
-// This function returns true and calls SConfig::SetRunningGameMetadata(IVolume&, Partition&)
+// This function returns true and calls SConfig::SetRunningGameMetadata(Volume&, Partition&)
 // if both of the following conditions are true:
 // - A disc is inserted
 // - The title_id argument doesn't contain a value, or its value matches the disc's title ID

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -21,9 +21,9 @@
 
 namespace FileMonitor
 {
-static const DiscIO::IVolume* s_volume;
+static const DiscIO::Volume* s_volume;
 static bool s_new_volume = false;
-static std::unique_ptr<DiscIO::IFileSystem> s_filesystem;
+static std::unique_ptr<DiscIO::FileSystem> s_filesystem;
 static DiscIO::Partition s_partition;
 static std::string s_previous_file;
 
@@ -53,7 +53,7 @@ static bool IsSoundFile(const std::string& filename)
   return extensions.find(extension) != extensions.end();
 }
 
-void SetFileSystem(const DiscIO::IVolume* volume)
+void SetFileSystem(const DiscIO::Volume* volume)
 {
   // Instead of creating the file system object right away, we will let Log
   // create it later once we know that it actually will get used

--- a/Source/Core/Core/HW/DVD/FileMonitor.h
+++ b/Source/Core/Core/HW/DVD/FileMonitor.h
@@ -9,14 +9,14 @@
 namespace DiscIO
 {
 struct Partition;
-class IVolume;
+class Volume;
 }
 
 namespace FileMonitor
 {
 // Can be called with nullptr to set the file system to nothing. When not called
 // with nullptr, the volume must remain valid until the next SetFileSystem call.
-void SetFileSystem(const DiscIO::IVolume* volume);
+void SetFileSystem(const DiscIO::Volume* volume);
 // Logs access to files in the file system set by SetFileSystem
 void Log(u64 offset, const DiscIO::Partition& partition);
 }

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -18,7 +18,7 @@ class PointerWrap;
 
 namespace DiscIO
 {
-class CNANDContentLoader;
+class NANDContentLoader;
 }
 
 namespace IOS
@@ -31,7 +31,7 @@ struct TitleContext
 {
   void Clear();
   void DoState(PointerWrap& p);
-  void Update(const DiscIO::CNANDContentLoader& content_loader);
+  void Update(const DiscIO::NANDContentLoader& content_loader);
   void Update(const IOS::ES::TMDReader& tmd_, const IOS::ES::TicketReader& ticket_);
 
   IOS::ES::TicketReader ticket;
@@ -284,7 +284,7 @@ private:
   bool LaunchPPCTitle(u64 title_id, bool skip_reload);
   static TitleContext& GetTitleContext();
 
-  static const DiscIO::CNANDContentLoader& AccessContentDevice(u64 title_id);
+  static const DiscIO::NANDContentLoader& AccessContentDevice(u64 title_id);
 
   u32 OpenTitleContent(u32 CFD, u64 TitleID, u16 Index);
 

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -22,7 +22,7 @@ namespace Device
 {
 u32 ES::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
 {
-  const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
+  const DiscIO::NANDContentLoader& Loader = AccessContentDevice(TitleID);
 
   if (!Loader.IsValid() || !Loader.GetTMD().IsValid() || !Loader.GetTicket().IsValid())
   {
@@ -30,7 +30,7 @@ u32 ES::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
     return 0xffffffff;
   }
 
-  const DiscIO::SNANDContent* pContent = Loader.GetContentByIndex(Index);
+  const DiscIO::NANDContent* pContent = Loader.GetContentByIndex(Index);
 
   if (pContent == nullptr)
   {
@@ -106,11 +106,11 @@ IPCCommandResult ES::ReadContent(u32 uid, const IOCtlVRequest& request)
   {
     if (pDest)
     {
-      const DiscIO::CNANDContentLoader& ContentLoader = AccessContentDevice(rContent.m_title_id);
+      const DiscIO::NANDContentLoader& ContentLoader = AccessContentDevice(rContent.m_title_id);
       // ContentLoader should never be invalid; rContent has been created by it.
       if (ContentLoader.IsValid() && ContentLoader.GetTicket().IsValid())
       {
-        const DiscIO::SNANDContent* pContent =
+        const DiscIO::NANDContent* pContent =
             ContentLoader.GetContentByIndex(rContent.m_content.index);
         if (!pContent->m_Data->GetRange(rContent.m_position, Size, pDest))
           ERROR_LOG(IOS_ES, "ES: failed to read %u bytes from %u!", Size, rContent.m_position);
@@ -146,11 +146,11 @@ IPCCommandResult ES::CloseContent(u32 uid, const IOCtlVRequest& request)
     return GetDefaultReply(-1);
   }
 
-  const DiscIO::CNANDContentLoader& ContentLoader = AccessContentDevice(itr->second.m_title_id);
+  const DiscIO::NANDContentLoader& ContentLoader = AccessContentDevice(itr->second.m_title_id);
   // ContentLoader should never be invalid; we shouldn't be here if ES_OPENCONTENT failed before.
   if (ContentLoader.IsValid())
   {
-    const DiscIO::SNANDContent* pContent =
+    const DiscIO::NANDContent* pContent =
         ContentLoader.GetContentByIndex(itr->second.m_content.index);
     pContent->m_Data->Close();
   }

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -375,8 +375,8 @@ ReturnCode ES::DeleteTitle(u64 title_id)
     ERROR_LOG(IOS_ES, "DeleteTitle: Failed to delete title directory: %s", title_dir.c_str());
     return FS_EACCESS;
   }
-  // XXX: ugly, but until we drop CNANDContentManager everywhere, this is going to be needed.
-  DiscIO::CNANDContentManager::Access().ClearCache();
+  // XXX: ugly, but until we drop NANDContentManager everywhere, this is going to be needed.
+  DiscIO::NANDContentManager::Access().ClearCache();
 
   return IPC_SUCCESS;
 }

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -273,7 +273,7 @@ u16 Kernel::GetGidForPPC() const
 
 // This corresponds to syscall 0x41, which loads a binary from the NAND and bootstraps the PPC.
 // Unlike 0x42, IOS will set up some constants in memory before booting the PPC.
-bool Kernel::BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader)
+bool Kernel::BootstrapPPC(const DiscIO::NANDContentLoader& content_loader)
 {
   if (!content_loader.IsValid())
     return false;

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -21,7 +21,7 @@ class PointerWrap;
 
 namespace DiscIO
 {
-class CNANDContentLoader;
+class NANDContentLoader;
 }
 
 namespace IOS
@@ -111,7 +111,7 @@ public:
   void SetGidForPPC(u16 gid);
   u16 GetGidForPPC() const;
 
-  bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader);
+  bool BootstrapPPC(const DiscIO::NANDContentLoader& content_loader);
   bool BootIOS(u64 ios_title_id);
   u32 GetVersion() const;
 

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -92,7 +92,7 @@ u32 ARMBinary::GetElfSize() const
 static std::vector<u8> GetMIOSBinary()
 {
   const auto& loader =
-      DiscIO::CNANDContentManager::Access().GetNANDLoader(MIOS_TITLE_ID, Common::FROM_SESSION_ROOT);
+      DiscIO::NANDContentManager::Access().GetNANDLoader(MIOS_TITLE_ID, Common::FROM_SESSION_ROOT);
   if (!loader.IsValid())
     return {};
 

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -173,7 +173,7 @@ u32 SectorReader::ReadChunk(u8* buffer, u64 chunk_num)
   return 0;
 }
 
-std::unique_ptr<IBlobReader> CreateBlobReader(const std::string& filename)
+std::unique_ptr<BlobReader> CreateBlobReader(const std::string& filename)
 {
   if (cdio_is_cdrom(filename))
     return DriveReader::Create(filename);

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -36,10 +36,10 @@ enum class BlobType
   TGC
 };
 
-class IBlobReader
+class BlobReader
 {
 public:
-  virtual ~IBlobReader() {}
+  virtual ~BlobReader() {}
   virtual BlobType GetBlobType() const = 0;
   virtual u64 GetRawSize() const = 0;
   virtual u64 GetDataSize() const = 0;
@@ -56,13 +56,13 @@ public:
   }
 
 protected:
-  IBlobReader() {}
+  BlobReader() {}
 };
 
 // Provides caching and byte-operation-to-block-operations facilities.
 // Used for compressed blob and direct drive reading.
 // NOTE: GetDataSize() is expected to be evenly divisible by the sector size.
-class SectorReader : public IBlobReader
+class SectorReader : public BlobReader
 {
 public:
   virtual ~SectorReader() = 0;
@@ -147,8 +147,8 @@ private:
   std::array<Cache, CACHE_LINES> m_cache;
 };
 
-// Factory function - examines the path to choose the right type of IBlobReader, and returns one.
-std::unique_ptr<IBlobReader> CreateBlobReader(const std::string& filename);
+// Factory function - examines the path to choose the right type of BlobReader, and returns one.
+std::unique_ptr<BlobReader> CreateBlobReader(const std::string& filename);
 
 typedef bool (*CompressCB)(const std::string& text, float percent, void* arg);
 

--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -31,7 +31,7 @@ struct CISOHeader
   u8 map[CISO_MAP_SIZE];
 };
 
-class CISOFileReader : public IBlobReader
+class CISOFileReader : public BlobReader
 {
 public:
   static std::unique_ptr<CISOFileReader> Create(File::IOFile file);

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SRCS
   VolumeDirectory.cpp
   VolumeGC.cpp
   VolumeWad.cpp
-  VolumeWiiCrypted.cpp
+  VolumeWii.cpp
   WiiWad.cpp
 )
 

--- a/Source/Core/DiscIO/DiscIO.vcxproj
+++ b/Source/Core/DiscIO/DiscIO.vcxproj
@@ -52,7 +52,7 @@
     <ClCompile Include="VolumeDirectory.cpp" />
     <ClCompile Include="VolumeGC.cpp" />
     <ClCompile Include="VolumeWad.cpp" />
-    <ClCompile Include="VolumeWiiCrypted.cpp" />
+    <ClCompile Include="VolumeWii.cpp" />
     <ClCompile Include="WbfsBlob.cpp" />
     <ClCompile Include="WiiWad.cpp" />
   </ItemGroup>
@@ -73,7 +73,7 @@
     <ClInclude Include="VolumeDirectory.h" />
     <ClInclude Include="VolumeGC.h" />
     <ClInclude Include="VolumeWad.h" />
-    <ClInclude Include="VolumeWiiCrypted.h" />
+    <ClInclude Include="VolumeWii.h" />
     <ClInclude Include="WbfsBlob.h" />
     <ClInclude Include="WiiWad.h" />
   </ItemGroup>

--- a/Source/Core/DiscIO/DiscIO.vcxproj.filters
+++ b/Source/Core/DiscIO/DiscIO.vcxproj.filters
@@ -63,10 +63,10 @@
     <ClCompile Include="VolumeWad.cpp">
       <Filter>Volume</Filter>
     </ClCompile>
-    <ClCompile Include="VolumeWiiCrypted.cpp">
+    <ClCompile Include="Enums.cpp">
       <Filter>Volume</Filter>
     </ClCompile>
-    <ClCompile Include="Enums.cpp">
+    <ClCompile Include="VolumeWii.cpp">
       <Filter>Volume</Filter>
     </ClCompile>
     <ClCompile Include="Volume.cpp">
@@ -125,7 +125,7 @@
     <ClInclude Include="VolumeWad.h">
       <Filter>Volume</Filter>
     </ClInclude>
-    <ClInclude Include="VolumeWiiCrypted.h">
+    <ClInclude Include="VolumeWii.h">
       <Filter>Volume</Filter>
     </ClInclude>
     <ClInclude Include="Enums.h">

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -179,7 +179,7 @@ bool DiscScrubber::ParseDisc()
 // Operations dealing with encrypted space are done here
 bool DiscScrubber::ParsePartitionData(const Partition& partition, PartitionHeader* header)
 {
-  std::unique_ptr<IFileSystem> filesystem(CreateFileSystem(m_disc.get(), partition));
+  std::unique_ptr<FileSystem> filesystem(CreateFileSystem(m_disc.get(), partition));
   if (!filesystem)
   {
     ERROR_LOG(DISCIO, "Failed to read file system for the partition at 0x%" PRIx64,
@@ -219,7 +219,7 @@ bool DiscScrubber::ParsePartitionData(const Partition& partition, PartitionHeade
   MarkAsUsedE(partition_data_offset, header->fst_offset, header->fst_size);
 
   // Go through the filesystem and mark entries as used
-  for (const SFileInfo& file : filesystem->GetFileList())
+  for (const FileInfo& file : filesystem->GetFileList())
   {
     DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
     if ((file.m_NameOffset & 0x1000000) == 0)

--- a/Source/Core/DiscIO/DiscScrubber.h
+++ b/Source/Core/DiscIO/DiscScrubber.h
@@ -25,7 +25,7 @@ class IOFile;
 
 namespace DiscIO
 {
-class IVolume;
+class Volume;
 struct Partition;
 
 class DiscScrubber final
@@ -66,7 +66,7 @@ private:
   bool ParsePartitionData(const Partition& partition, PartitionHeader* header);
 
   std::string m_filename;
-  std::unique_ptr<IVolume> m_disc;
+  std::unique_ptr<Volume> m_disc;
 
   std::vector<u8> m_free_table;
   u64 m_file_size = 0;

--- a/Source/Core/DiscIO/FileBlob.h
+++ b/Source/Core/DiscIO/FileBlob.h
@@ -14,7 +14,7 @@
 
 namespace DiscIO
 {
-class PlainFileReader : public IBlobReader
+class PlainFileReader : public BlobReader
 {
 public:
   static std::unique_ptr<PlainFileReader> Create(File::IOFile file);

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -14,18 +14,18 @@
 
 namespace DiscIO
 {
-class IVolume;
+class Volume;
 struct Partition;
 
-class CFileSystemGCWii : public IFileSystem
+class FileSystemGCWii : public FileSystem
 {
 public:
-  CFileSystemGCWii(const IVolume* _rVolume, const Partition& partition);
-  virtual ~CFileSystemGCWii();
+  FileSystemGCWii(const Volume* _rVolume, const Partition& partition);
+  virtual ~FileSystemGCWii();
 
   bool IsValid() const override { return m_Valid; }
   u64 GetFileSize(const std::string& _rFullPath) override;
-  const std::vector<SFileInfo>& GetFileList() override;
+  const std::vector<FileInfo>& GetFileList() override;
   std::string GetFileName(u64 _Address) override;
   u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
                u64 _OffsetInFile) override;
@@ -39,10 +39,10 @@ private:
   bool m_Initialized;
   bool m_Valid;
   u32 m_offset_shift;
-  std::vector<SFileInfo> m_FileInfoVector;
+  std::vector<FileInfo> m_FileInfoVector;
 
   std::string GetStringFromOffset(u64 _Offset) const;
-  const SFileInfo* FindFileInfo(const std::string& _rFullPath);
+  const FileInfo* FindFileInfo(const std::string& _rFullPath);
   bool DetectFileSystem();
   void InitFileSystem();
   size_t BuildFilenames(const size_t _FirstIndex, const size_t _LastIndex,

--- a/Source/Core/DiscIO/Filesystem.cpp
+++ b/Source/Core/DiscIO/Filesystem.cpp
@@ -9,21 +9,21 @@
 
 namespace DiscIO
 {
-IFileSystem::IFileSystem(const IVolume* _rVolume, const Partition& partition)
+FileSystem::FileSystem(const Volume* _rVolume, const Partition& partition)
     : m_rVolume(_rVolume), m_partition(partition)
 {
 }
 
-IFileSystem::~IFileSystem()
+FileSystem::~FileSystem()
 {
 }
 
-std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume, const Partition& partition)
+std::unique_ptr<FileSystem> CreateFileSystem(const Volume* volume, const Partition& partition)
 {
   if (!volume)
     return nullptr;
 
-  std::unique_ptr<IFileSystem> filesystem = std::make_unique<CFileSystemGCWii>(volume, partition);
+  std::unique_ptr<FileSystem> filesystem = std::make_unique<FileSystemGCWii>(volume, partition);
 
   if (!filesystem)
     return nullptr;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -15,7 +15,7 @@
 namespace DiscIO
 {
 // file info of an FST entry
-struct SFileInfo
+struct FileInfo
 {
   u64 m_NameOffset = 0u;
   u64 m_Offset = 0u;
@@ -23,23 +23,23 @@ struct SFileInfo
   std::string m_FullPath;
 
   bool IsDirectory() const { return (m_NameOffset & 0xFF000000) != 0; }
-  SFileInfo(u64 name_offset, u64 offset, u64 filesize)
+  FileInfo(u64 name_offset, u64 offset, u64 filesize)
       : m_NameOffset(name_offset), m_Offset(offset), m_FileSize(filesize)
   {
   }
 
-  SFileInfo(SFileInfo const&) = default;
-  SFileInfo() = default;
+  FileInfo(FileInfo const&) = default;
+  FileInfo() = default;
 };
 
-class IFileSystem
+class FileSystem
 {
 public:
-  IFileSystem(const IVolume* _rVolume, const Partition& partition);
+  FileSystem(const Volume* _rVolume, const Partition& partition);
 
-  virtual ~IFileSystem();
+  virtual ~FileSystem();
   virtual bool IsValid() const = 0;
-  virtual const std::vector<SFileInfo>& GetFileList() = 0;
+  virtual const std::vector<FileInfo>& GetFileList() = 0;
   virtual u64 GetFileSize(const std::string& _rFullPath) = 0;
   virtual u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
                        u64 _OffsetInFile = 0) = 0;
@@ -52,10 +52,10 @@ public:
 
   virtual const Partition GetPartition() const { return m_partition; }
 protected:
-  const IVolume* const m_rVolume;
+  const Volume* const m_rVolume;
   const Partition m_partition;
 };
 
-std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume, const Partition& partition);
+std::unique_ptr<FileSystem> CreateFileSystem(const Volume* volume, const Partition& partition);
 
 }  // namespace

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -32,26 +32,26 @@
 
 namespace DiscIO
 {
-CNANDContentData::~CNANDContentData() = default;
+NANDContentData::~NANDContentData() = default;
 
-CNANDContentDataFile::CNANDContentDataFile(const std::string& filename) : m_filename{filename}
+NANDContentDataFile::NANDContentDataFile(const std::string& filename) : m_filename{filename}
 {
 }
 
-CNANDContentDataFile::~CNANDContentDataFile() = default;
+NANDContentDataFile::~NANDContentDataFile() = default;
 
-void CNANDContentDataFile::EnsureOpen()
+void NANDContentDataFile::EnsureOpen()
 {
   if (!m_file)
     m_file = std::make_unique<File::IOFile>(m_filename, "rb");
   else if (!m_file->IsOpen())
     m_file->Open(m_filename, "rb");
 }
-void CNANDContentDataFile::Open()
+void NANDContentDataFile::Open()
 {
   EnsureOpen();
 }
-std::vector<u8> CNANDContentDataFile::Get()
+std::vector<u8> NANDContentDataFile::Get()
 {
   EnsureOpen();
 
@@ -68,7 +68,7 @@ std::vector<u8> CNANDContentDataFile::Get()
   return result;
 }
 
-bool CNANDContentDataFile::GetRange(u32 start, u32 size, u8* buffer)
+bool NANDContentDataFile::GetRange(u32 start, u32 size, u8* buffer)
 {
   EnsureOpen();
   if (!m_file->IsGood())
@@ -79,13 +79,13 @@ bool CNANDContentDataFile::GetRange(u32 start, u32 size, u8* buffer)
 
   return m_file->ReadBytes(buffer, static_cast<size_t>(size));
 }
-void CNANDContentDataFile::Close()
+void NANDContentDataFile::Close()
 {
   if (m_file && m_file->IsOpen())
     m_file->Close();
 }
 
-bool CNANDContentDataBuffer::GetRange(u32 start, u32 size, u8* buffer)
+bool NANDContentDataBuffer::GetRange(u32 start, u32 size, u8* buffer)
 {
   if (start + size > m_buffer.size())
     return false;
@@ -94,22 +94,22 @@ bool CNANDContentDataBuffer::GetRange(u32 start, u32 size, u8* buffer)
   return true;
 }
 
-CNANDContentLoader::CNANDContentLoader(const std::string& content_name, Common::FromWhichRoot from)
+NANDContentLoader::NANDContentLoader(const std::string& content_name, Common::FromWhichRoot from)
     : m_root(from)
 {
   m_Valid = Initialize(content_name);
 }
 
-CNANDContentLoader::~CNANDContentLoader()
+NANDContentLoader::~NANDContentLoader()
 {
 }
 
-bool CNANDContentLoader::IsValid() const
+bool NANDContentLoader::IsValid() const
 {
   return m_Valid;
 }
 
-const SNANDContent* CNANDContentLoader::GetContentByID(u32 id) const
+const NANDContent* NANDContentLoader::GetContentByID(u32 id) const
 {
   const auto iterator = std::find_if(m_Content.begin(), m_Content.end(), [id](const auto& content) {
     return content.m_metadata.id == id;
@@ -117,7 +117,7 @@ const SNANDContent* CNANDContentLoader::GetContentByID(u32 id) const
   return iterator != m_Content.end() ? &*iterator : nullptr;
 }
 
-const SNANDContent* CNANDContentLoader::GetContentByIndex(int index) const
+const NANDContent* NANDContentLoader::GetContentByIndex(int index) const
 {
   for (auto& Content : m_Content)
   {
@@ -129,7 +129,7 @@ const SNANDContent* CNANDContentLoader::GetContentByIndex(int index) const
   return nullptr;
 }
 
-bool CNANDContentLoader::Initialize(const std::string& name)
+bool NANDContentLoader::Initialize(const std::string& name)
 {
   if (name.empty())
     return false;
@@ -173,7 +173,7 @@ bool CNANDContentLoader::Initialize(const std::string& name)
   return true;
 }
 
-void CNANDContentLoader::InitializeContentEntries(const std::vector<u8>& data_app)
+void NANDContentLoader::InitializeContentEntries(const std::vector<u8>& data_app)
 {
   if (!m_ticket.IsValid())
   {
@@ -201,7 +201,7 @@ void CNANDContentLoader::InitializeContentEntries(const std::vector<u8>& data_ap
 
       u32 rounded_size = Common::AlignUp(static_cast<u32>(content.size), 0x40);
 
-      m_Content[i].m_Data = std::make_unique<CNANDContentDataBuffer>(Common::AES::Decrypt(
+      m_Content[i].m_Data = std::make_unique<NANDContentDataBuffer>(Common::AES::Decrypt(
           title_key.data(), iv.data(), &data_app[data_app_offset], rounded_size));
       data_app_offset += rounded_size;
     }
@@ -213,37 +213,36 @@ void CNANDContentLoader::InitializeContentEntries(const std::vector<u8>& data_ap
       else
         filename = StringFromFormat("%s/%08x.app", m_Path.c_str(), content.id);
 
-      m_Content[i].m_Data = std::make_unique<CNANDContentDataFile>(filename);
+      m_Content[i].m_Data = std::make_unique<NANDContentDataFile>(filename);
     }
 
     m_Content[i].m_metadata = std::move(content);
   }
 }
 
-CNANDContentManager::~CNANDContentManager()
+NANDContentManager::~NANDContentManager()
 {
 }
 
-const CNANDContentLoader& CNANDContentManager::GetNANDLoader(const std::string& content_path,
-                                                             Common::FromWhichRoot from)
+const NANDContentLoader& NANDContentManager::GetNANDLoader(const std::string& content_path,
+                                                           Common::FromWhichRoot from)
 {
   auto it = m_map.find(content_path);
   if (it != m_map.end())
     return *it->second;
   return *m_map
-              .emplace_hint(it, std::make_pair(content_path, std::make_unique<CNANDContentLoader>(
+              .emplace_hint(it, std::make_pair(content_path, std::make_unique<NANDContentLoader>(
                                                                  content_path, from)))
               ->second;
 }
 
-const CNANDContentLoader& CNANDContentManager::GetNANDLoader(u64 title_id,
-                                                             Common::FromWhichRoot from)
+const NANDContentLoader& NANDContentManager::GetNANDLoader(u64 title_id, Common::FromWhichRoot from)
 {
   std::string path = Common::GetTitleContentPath(title_id, from);
   return GetNANDLoader(path, from);
 }
 
-void CNANDContentManager::ClearCache()
+void NANDContentManager::ClearCache()
 {
   m_map.clear();
 }

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -26,21 +26,21 @@ enum class Region;
 // TODO: move some of these to Core/IOS/ES.
 IOS::ES::TicketReader FindSignedTicket(u64 title_id);
 
-class CNANDContentData
+class NANDContentData
 {
 public:
-  virtual ~CNANDContentData() = 0;
+  virtual ~NANDContentData() = 0;
   virtual void Open() {}
   virtual std::vector<u8> Get() = 0;
   virtual bool GetRange(u32 start, u32 size, u8* buffer) = 0;
   virtual void Close() {}
 };
 
-class CNANDContentDataFile final : public CNANDContentData
+class NANDContentDataFile final : public NANDContentData
 {
 public:
-  explicit CNANDContentDataFile(const std::string& filename);
-  ~CNANDContentDataFile();
+  explicit NANDContentDataFile(const std::string& filename);
+  ~NANDContentDataFile();
 
   void Open() override;
   std::vector<u8> Get() override;
@@ -53,10 +53,11 @@ private:
   const std::string m_filename;
   std::unique_ptr<File::IOFile> m_file;
 };
-class CNANDContentDataBuffer final : public CNANDContentData
+
+class NANDContentDataBuffer final : public NANDContentData
 {
 public:
-  explicit CNANDContentDataBuffer(const std::vector<u8>& buffer) : m_buffer(buffer) {}
+  explicit NANDContentDataBuffer(const std::vector<u8>& buffer) : m_buffer(buffer) {}
   std::vector<u8> Get() override { return m_buffer; }
   bool GetRange(u32 start, u32 size, u8* buffer) override;
 
@@ -64,25 +65,25 @@ private:
   const std::vector<u8> m_buffer;
 };
 
-struct SNANDContent
+struct NANDContent
 {
   IOS::ES::Content m_metadata;
-  std::unique_ptr<CNANDContentData> m_Data;
+  std::unique_ptr<NANDContentData> m_Data;
 };
 
-// Instances of this class must be created by CNANDContentManager
-class CNANDContentLoader final
+// Instances of this class must be created by NANDContentManager
+class NANDContentLoader final
 {
 public:
-  explicit CNANDContentLoader(const std::string& content_name, Common::FromWhichRoot from);
-  ~CNANDContentLoader();
+  explicit NANDContentLoader(const std::string& content_name, Common::FromWhichRoot from);
+  ~NANDContentLoader();
 
   bool IsValid() const;
-  const SNANDContent* GetContentByID(u32 id) const;
-  const SNANDContent* GetContentByIndex(int index) const;
+  const NANDContent* GetContentByID(u32 id) const;
+  const NANDContent* GetContentByIndex(int index) const;
   const IOS::ES::TMDReader& GetTMD() const { return m_tmd; }
   const IOS::ES::TicketReader& GetTicket() const { return m_ticket; }
-  const std::vector<SNANDContent>& GetContent() const { return m_Content; }
+  const std::vector<NANDContent>& GetContent() const { return m_Content; }
 private:
   bool Initialize(const std::string& name);
   void InitializeContentEntries(const std::vector<u8>& data_app);
@@ -94,33 +95,33 @@ private:
   IOS::ES::TMDReader m_tmd;
   IOS::ES::TicketReader m_ticket;
 
-  std::vector<SNANDContent> m_Content;
+  std::vector<NANDContent> m_Content;
 };
 
 // we open the NAND Content files too often... let's cache them
-class CNANDContentManager
+class NANDContentManager
 {
 public:
-  static CNANDContentManager& Access()
+  static NANDContentManager& Access()
   {
-    static CNANDContentManager instance;
+    static NANDContentManager instance;
     return instance;
   }
 
-  const CNANDContentLoader&
+  const NANDContentLoader&
   GetNANDLoader(const std::string& content_path,
                 Common::FromWhichRoot from = Common::FROM_CONFIGURED_ROOT);
-  const CNANDContentLoader&
+  const NANDContentLoader&
   GetNANDLoader(u64 title_id, Common::FromWhichRoot from = Common::FROM_CONFIGURED_ROOT);
   void ClearCache();
 
 private:
-  CNANDContentManager() {}
-  ~CNANDContentManager();
+  NANDContentManager() {}
+  ~NANDContentManager();
 
-  CNANDContentManager(CNANDContentManager const&) = delete;
-  void operator=(CNANDContentManager const&) = delete;
+  NANDContentManager(NANDContentManager const&) = delete;
+  void operator=(NANDContentManager const&) = delete;
 
-  std::unordered_map<std::string, std::unique_ptr<CNANDContentLoader>> m_map;
+  std::unordered_map<std::string, std::unique_ptr<NANDContentLoader>> m_map;
 };
 }

--- a/Source/Core/DiscIO/NANDImporter.cpp
+++ b/Source/Core/DiscIO/NANDImporter.cpp
@@ -43,7 +43,7 @@ void NANDImporter::ImportNANDBin(const std::string& path_to_bin,
   ExtractCertificates(nand_root);
 
   // We have to clear the cache so the new NAND takes effect
-  DiscIO::CNANDContentManager::Access().ClearCache();
+  DiscIO::NANDContentManager::Access().ClearCache();
 }
 
 bool NANDImporter::ReadNANDBin(const std::string& path_to_bin)

--- a/Source/Core/DiscIO/TGCBlob.h
+++ b/Source/Core/DiscIO/TGCBlob.h
@@ -37,7 +37,7 @@ struct TGCHeader
   u32 unknown_important_2;
 };
 
-class TGCFileReader final : public IBlobReader
+class TGCFileReader final : public BlobReader
 {
 public:
   static std::unique_ptr<TGCFileReader> Create(File::IOFile file);

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -24,7 +24,7 @@
 #include "DiscIO/VolumeDirectory.h"
 #include "DiscIO/VolumeGC.h"
 #include "DiscIO/VolumeWad.h"
-#include "DiscIO/VolumeWiiCrypted.h"
+#include "DiscIO/VolumeWii.h"
 
 namespace DiscIO
 {
@@ -33,10 +33,10 @@ static const unsigned int WII_BANNER_HEIGHT = 64;
 static const unsigned int WII_BANNER_SIZE = WII_BANNER_WIDTH * WII_BANNER_HEIGHT * 2;
 static const unsigned int WII_BANNER_OFFSET = 0xA0;
 
-const IOS::ES::TicketReader IVolume::INVALID_TICKET{};
-const IOS::ES::TMDReader IVolume::INVALID_TMD{};
+const IOS::ES::TicketReader Volume::INVALID_TICKET{};
+const IOS::ES::TMDReader Volume::INVALID_TMD{};
 
-std::vector<u32> IVolume::GetWiiBanner(int* width, int* height, u64 title_id)
+std::vector<u32> Volume::GetWiiBanner(int* width, int* height, u64 title_id)
 {
   *width = 0;
   *height = 0;
@@ -66,7 +66,7 @@ std::vector<u32> IVolume::GetWiiBanner(int* width, int* height, u64 title_id)
   return image_buffer;
 }
 
-std::map<Language, std::string> IVolume::ReadWiiNames(const std::vector<u8>& data)
+std::map<Language, std::string> Volume::ReadWiiNames(const std::vector<u8>& data)
 {
   std::map<Language, std::string> names;
   for (size_t i = 0; i < NUMBER_OF_LANGUAGES; ++i)
@@ -87,38 +87,38 @@ std::map<Language, std::string> IVolume::ReadWiiNames(const std::vector<u8>& dat
   return names;
 }
 
-std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename)
+std::unique_ptr<Volume> CreateVolumeFromFilename(const std::string& filename)
 {
-  std::unique_ptr<IBlobReader> reader(CreateBlobReader(filename));
+  std::unique_ptr<BlobReader> reader(CreateBlobReader(filename));
   if (reader == nullptr)
     return nullptr;
 
   // Check for Wii
   const std::optional<u32> wii_magic = reader->ReadSwapped<u32>(0x18);
   if (wii_magic == u32(0x5D1C9EA3))
-    return std::make_unique<CVolumeWiiCrypted>(std::move(reader));
+    return std::make_unique<VolumeWii>(std::move(reader));
 
   // Check for WAD
   // 0x206962 for boot2 wads
   const std::optional<u32> wad_magic = reader->ReadSwapped<u32>(0x02);
   if (wad_magic == u32(0x00204973) || wad_magic == u32(0x00206962))
-    return std::make_unique<CVolumeWAD>(std::move(reader));
+    return std::make_unique<VolumeWAD>(std::move(reader));
 
   // Check for GC
   const std::optional<u32> gc_magic = reader->ReadSwapped<u32>(0x1C);
   if (gc_magic == u32(0xC2339F3D))
-    return std::make_unique<CVolumeGC>(std::move(reader));
+    return std::make_unique<VolumeGC>(std::move(reader));
 
   // No known magic words found
   return nullptr;
 }
 
-std::unique_ptr<IVolume> CreateVolumeFromDirectory(const std::string& directory, bool is_wii,
-                                                   const std::string& apploader,
-                                                   const std::string& dol)
+std::unique_ptr<Volume> CreateVolumeFromDirectory(const std::string& directory, bool is_wii,
+                                                  const std::string& apploader,
+                                                  const std::string& dol)
 {
-  if (CVolumeDirectory::IsValidDirectory(directory))
-    return std::make_unique<CVolumeDirectory>(directory, is_wii, apploader, dol);
+  if (VolumeDirectory::IsValidDirectory(directory))
+    return std::make_unique<VolumeDirectory>(directory, is_wii, apploader, dol);
 
   return nullptr;
 }

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -37,11 +37,11 @@ struct Partition final
 
 const Partition PARTITION_NONE(std::numeric_limits<u64>::max() - 1);
 
-class IVolume
+class Volume
 {
 public:
-  IVolume() {}
-  virtual ~IVolume() {}
+  Volume() {}
+  virtual ~Volume() {}
   virtual bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const = 0;
   template <typename T>
   std::optional<T> ReadSwapped(u64 offset, const Partition& partition) const
@@ -117,9 +117,9 @@ protected:
   static const IOS::ES::TMDReader INVALID_TMD;
 };
 
-std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename);
-std::unique_ptr<IVolume> CreateVolumeFromDirectory(const std::string& directory, bool is_wii,
-                                                   const std::string& apploader = "",
-                                                   const std::string& dol = "");
+std::unique_ptr<Volume> CreateVolumeFromFilename(const std::string& filename);
+std::unique_ptr<Volume> CreateVolumeFromDirectory(const std::string& directory, bool is_wii,
+                                                  const std::string& apploader = "",
+                                                  const std::string& dol = "");
 
 }  // namespace

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -30,11 +30,11 @@ static u32 ComputeNameSize(const File::FSTEntry& parent_entry);
 static std::string ASCIIToUppercase(std::string str);
 static void ConvertUTF8NamesToSHIFTJIS(File::FSTEntry& parent_entry);
 
-const size_t CVolumeDirectory::MAX_NAME_LENGTH;
-const size_t CVolumeDirectory::MAX_ID_LENGTH;
+const size_t VolumeDirectory::MAX_NAME_LENGTH;
+const size_t VolumeDirectory::MAX_ID_LENGTH;
 
-CVolumeDirectory::CVolumeDirectory(const std::string& directory, bool is_wii,
-                                   const std::string& apploader, const std::string& dol)
+VolumeDirectory::VolumeDirectory(const std::string& directory, bool is_wii,
+                                 const std::string& apploader, const std::string& dol)
     : m_data_start_address(-1), m_disk_header(DISKHEADERINFO_ADDRESS),
       m_disk_header_info(std::make_unique<SDiskHeaderInfo>()), m_fst_address(0), m_dol_address(0)
 {
@@ -56,16 +56,16 @@ CVolumeDirectory::CVolumeDirectory(const std::string& directory, bool is_wii,
   BuildFST();
 }
 
-CVolumeDirectory::~CVolumeDirectory()
+VolumeDirectory::~VolumeDirectory()
 {
 }
 
-bool CVolumeDirectory::IsValidDirectory(const std::string& directory)
+bool VolumeDirectory::IsValidDirectory(const std::string& directory)
 {
   return File::IsDirectory(ExtractDirectoryName(directory));
 }
 
-bool CVolumeDirectory::Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const
+bool VolumeDirectory::Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const
 {
   bool decrypt = partition != PARTITION_NONE;
 
@@ -160,27 +160,27 @@ bool CVolumeDirectory::Read(u64 offset, u64 length, u8* buffer, const Partition&
   return true;
 }
 
-std::vector<Partition> CVolumeDirectory::GetPartitions() const
+std::vector<Partition> VolumeDirectory::GetPartitions() const
 {
   return m_is_wii ? std::vector<Partition>{GetGamePartition()} : std::vector<Partition>();
 }
 
-Partition CVolumeDirectory::GetGamePartition() const
+Partition VolumeDirectory::GetGamePartition() const
 {
   return m_is_wii ? Partition(0x50000) : PARTITION_NONE;
 }
 
-std::string CVolumeDirectory::GetGameID(const Partition& partition) const
+std::string VolumeDirectory::GetGameID(const Partition& partition) const
 {
   return std::string(m_disk_header.begin(), m_disk_header.begin() + MAX_ID_LENGTH);
 }
 
-void CVolumeDirectory::SetGameID(const std::string& id)
+void VolumeDirectory::SetGameID(const std::string& id)
 {
   memcpy(m_disk_header.data(), id.c_str(), std::min(id.length(), MAX_ID_LENGTH));
 }
 
-Region CVolumeDirectory::GetRegion() const
+Region VolumeDirectory::GetRegion() const
 {
   if (m_is_wii)
     return RegionSwitchWii(m_disk_header[3]);
@@ -188,18 +188,18 @@ Region CVolumeDirectory::GetRegion() const
   return RegionSwitchGC(m_disk_header[3]);
 }
 
-Country CVolumeDirectory::GetCountry(const Partition& partition) const
+Country VolumeDirectory::GetCountry(const Partition& partition) const
 {
   return CountrySwitch(m_disk_header[3]);
 }
 
-std::string CVolumeDirectory::GetMakerID(const Partition& partition) const
+std::string VolumeDirectory::GetMakerID(const Partition& partition) const
 {
   // Not implemented
   return "00";
 }
 
-std::string CVolumeDirectory::GetInternalName(const Partition& partition) const
+std::string VolumeDirectory::GetInternalName(const Partition& partition) const
 {
   char name[0x60];
   if (Read(0x20, 0x60, (u8*)name, partition))
@@ -208,7 +208,7 @@ std::string CVolumeDirectory::GetInternalName(const Partition& partition) const
     return "";
 }
 
-std::map<Language, std::string> CVolumeDirectory::GetLongNames() const
+std::map<Language, std::string> VolumeDirectory::GetLongNames() const
 {
   std::string name = GetInternalName();
   if (name.empty())
@@ -216,7 +216,7 @@ std::map<Language, std::string> CVolumeDirectory::GetLongNames() const
   return {{Language::LANGUAGE_UNKNOWN, name}};
 }
 
-std::vector<u32> CVolumeDirectory::GetBanner(int* width, int* height) const
+std::vector<u32> VolumeDirectory::GetBanner(int* width, int* height) const
 {
   // Not implemented
   *width = 0;
@@ -224,25 +224,25 @@ std::vector<u32> CVolumeDirectory::GetBanner(int* width, int* height) const
   return std::vector<u32>();
 }
 
-void CVolumeDirectory::SetName(const std::string& name)
+void VolumeDirectory::SetName(const std::string& name)
 {
   size_t length = std::min(name.length(), MAX_NAME_LENGTH);
   memcpy(&m_disk_header[0x20], name.c_str(), length);
   m_disk_header[length + 0x20] = 0;
 }
 
-std::string CVolumeDirectory::GetApploaderDate(const Partition& partition) const
+std::string VolumeDirectory::GetApploaderDate(const Partition& partition) const
 {
   // Not implemented
   return "VOID";
 }
 
-Platform CVolumeDirectory::GetVolumeType() const
+Platform VolumeDirectory::GetVolumeType() const
 {
   return m_is_wii ? Platform::WII_DISC : Platform::GAMECUBE_DISC;
 }
 
-BlobType CVolumeDirectory::GetBlobType() const
+BlobType VolumeDirectory::GetBlobType() const
 {
   // VolumeDirectory isn't actually a blob, but it sort of acts
   // like one, so it makes sense that it has its own blob type.
@@ -250,19 +250,19 @@ BlobType CVolumeDirectory::GetBlobType() const
   return BlobType::DIRECTORY;
 }
 
-u64 CVolumeDirectory::GetSize() const
+u64 VolumeDirectory::GetSize() const
 {
   // Not implemented
   return 0;
 }
 
-u64 CVolumeDirectory::GetRawSize() const
+u64 VolumeDirectory::GetRawSize() const
 {
   // Not implemented
   return 0;
 }
 
-std::string CVolumeDirectory::ExtractDirectoryName(const std::string& directory)
+std::string VolumeDirectory::ExtractDirectoryName(const std::string& directory)
 {
   std::string result = directory;
 
@@ -287,7 +287,7 @@ std::string CVolumeDirectory::ExtractDirectoryName(const std::string& directory)
   return result;
 }
 
-void CVolumeDirectory::SetDiskTypeWii()
+void VolumeDirectory::SetDiskTypeWii()
 {
   Write32(0x5d1c9ea3, 0x18, &m_disk_header);
   memset(&m_disk_header[0x1c], 0, 4);
@@ -296,7 +296,7 @@ void CVolumeDirectory::SetDiskTypeWii()
   m_address_shift = 2;
 }
 
-void CVolumeDirectory::SetDiskTypeGC()
+void VolumeDirectory::SetDiskTypeGC()
 {
   memset(&m_disk_header[0x18], 0, 4);
   Write32(0xc2339f3d, 0x1c, &m_disk_header);
@@ -305,7 +305,7 @@ void CVolumeDirectory::SetDiskTypeGC()
   m_address_shift = 0;
 }
 
-bool CVolumeDirectory::SetApploader(const std::string& apploader)
+bool VolumeDirectory::SetApploader(const std::string& apploader)
 {
   if (!apploader.empty())
   {
@@ -338,7 +338,7 @@ bool CVolumeDirectory::SetApploader(const std::string& apploader)
   }
 }
 
-void CVolumeDirectory::SetDOL(const std::string& dol)
+void VolumeDirectory::SetDOL(const std::string& dol)
 {
   if (!dol.empty())
   {
@@ -354,7 +354,7 @@ void CVolumeDirectory::SetDOL(const std::string& dol)
   }
 }
 
-void CVolumeDirectory::BuildFST()
+void VolumeDirectory::BuildFST()
 {
   m_fst_data.clear();
 
@@ -394,8 +394,8 @@ void CVolumeDirectory::BuildFST()
   Write32((u32)(m_fst_data.size() >> m_address_shift), 0x042c, &m_disk_header);
 }
 
-void CVolumeDirectory::WriteToBuffer(u64 source_start_address, u64 source_length, const u8* source,
-                                     u64* address, u64* length, u8** buffer) const
+void VolumeDirectory::WriteToBuffer(u64 source_start_address, u64 source_length, const u8* source,
+                                    u64* address, u64* length, u8** buffer) const
 {
   if (*length == 0)
     return;
@@ -416,7 +416,7 @@ void CVolumeDirectory::WriteToBuffer(u64 source_start_address, u64 source_length
   }
 }
 
-void CVolumeDirectory::PadToAddress(u64 start_address, u64* address, u64* length, u8** buffer) const
+void VolumeDirectory::PadToAddress(u64 start_address, u64* address, u64* length, u8** buffer) const
 {
   if (start_address > *address && *length > 0)
   {
@@ -428,7 +428,7 @@ void CVolumeDirectory::PadToAddress(u64 start_address, u64* address, u64* length
   }
 }
 
-void CVolumeDirectory::Write32(u32 data, u32 offset, std::vector<u8>* const buffer)
+void VolumeDirectory::Write32(u32 data, u32 offset, std::vector<u8>* const buffer)
 {
   (*buffer)[offset++] = (data >> 24);
   (*buffer)[offset++] = (data >> 16) & 0xff;
@@ -436,8 +436,8 @@ void CVolumeDirectory::Write32(u32 data, u32 offset, std::vector<u8>* const buff
   (*buffer)[offset] = (data)&0xff;
 }
 
-void CVolumeDirectory::WriteEntryData(u32* entry_offset, u8 type, u32 name_offset, u64 data_offset,
-                                      u64 length, u32 address_shift)
+void VolumeDirectory::WriteEntryData(u32* entry_offset, u8 type, u32 name_offset, u64 data_offset,
+                                     u64 length, u32 address_shift)
 {
   m_fst_data[(*entry_offset)++] = type;
 
@@ -452,15 +452,15 @@ void CVolumeDirectory::WriteEntryData(u32* entry_offset, u8 type, u32 name_offse
   *entry_offset += 4;
 }
 
-void CVolumeDirectory::WriteEntryName(u32* name_offset, const std::string& name)
+void VolumeDirectory::WriteEntryName(u32* name_offset, const std::string& name)
 {
   strncpy((char*)&m_fst_data[*name_offset + m_fst_name_offset], name.c_str(), name.length() + 1);
 
   *name_offset += (u32)(name.length() + 1);
 }
 
-void CVolumeDirectory::WriteDirectory(const File::FSTEntry& parent_entry, u32* fst_offset,
-                                      u32* name_offset, u64* data_offset, u32 parent_entry_index)
+void VolumeDirectory::WriteDirectory(const File::FSTEntry& parent_entry, u32* fst_offset,
+                                     u32* name_offset, u64* data_offset, u32 parent_entry_index)
 {
   std::vector<File::FSTEntry> sorted_entries = parent_entry.children;
 

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -30,13 +30,13 @@ enum class Language;
 enum class Region;
 enum class Platform;
 
-class CVolumeDirectory : public IVolume
+class VolumeDirectory : public Volume
 {
 public:
-  CVolumeDirectory(const std::string& directory, bool is_wii, const std::string& apploader = "",
-                   const std::string& dol = "");
+  VolumeDirectory(const std::string& directory, bool is_wii, const std::string& apploader = "",
+                  const std::string& dol = "");
 
-  ~CVolumeDirectory();
+  ~VolumeDirectory();
 
   static bool IsValidDirectory(const std::string& directory);
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -24,16 +24,16 @@
 
 namespace DiscIO
 {
-CVolumeGC::CVolumeGC(std::unique_ptr<IBlobReader> reader) : m_pReader(std::move(reader))
+VolumeGC::VolumeGC(std::unique_ptr<BlobReader> reader) : m_pReader(std::move(reader))
 {
   _assert_(m_pReader);
 }
 
-CVolumeGC::~CVolumeGC()
+VolumeGC::~VolumeGC()
 {
 }
 
-bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const
+bool VolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const
 {
   if (partition != PARTITION_NONE)
     return false;
@@ -41,7 +41,7 @@ bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& pa
   return m_pReader->Read(_Offset, _Length, _pBuffer);
 }
 
-std::string CVolumeGC::GetGameID(const Partition& partition) const
+std::string VolumeGC::GetGameID(const Partition& partition) const
 {
   static const std::string NO_UID("NO_UID");
 
@@ -56,19 +56,19 @@ std::string CVolumeGC::GetGameID(const Partition& partition) const
   return DecodeString(ID);
 }
 
-Region CVolumeGC::GetRegion() const
+Region VolumeGC::GetRegion() const
 {
   const std::optional<u8> country_code = ReadSwapped<u8>(3, PARTITION_NONE);
   return country_code ? RegionSwitchGC(*country_code) : Region::UNKNOWN_REGION;
 }
 
-Country CVolumeGC::GetCountry(const Partition& partition) const
+Country VolumeGC::GetCountry(const Partition& partition) const
 {
   const std::optional<u8> country_code = ReadSwapped<u8>(3, partition);
   return country_code ? CountrySwitch(*country_code) : Country::COUNTRY_UNKNOWN;
 }
 
-std::string CVolumeGC::GetMakerID(const Partition& partition) const
+std::string VolumeGC::GetMakerID(const Partition& partition) const
 {
   char makerID[2];
   if (!Read(0x4, 0x2, (u8*)&makerID, partition))
@@ -77,13 +77,13 @@ std::string CVolumeGC::GetMakerID(const Partition& partition) const
   return DecodeString(makerID);
 }
 
-std::optional<u16> CVolumeGC::GetRevision(const Partition& partition) const
+std::optional<u16> VolumeGC::GetRevision(const Partition& partition) const
 {
   std::optional<u8> revision = ReadSwapped<u8>(7, partition);
   return revision ? *revision : std::optional<u16>();
 }
 
-std::string CVolumeGC::GetInternalName(const Partition& partition) const
+std::string VolumeGC::GetInternalName(const Partition& partition) const
 {
   char name[0x60];
   if (Read(0x20, 0x60, (u8*)name, partition))
@@ -92,37 +92,37 @@ std::string CVolumeGC::GetInternalName(const Partition& partition) const
   return "";
 }
 
-std::map<Language, std::string> CVolumeGC::GetShortNames() const
+std::map<Language, std::string> VolumeGC::GetShortNames() const
 {
   LoadBannerFile();
   return m_short_names;
 }
 
-std::map<Language, std::string> CVolumeGC::GetLongNames() const
+std::map<Language, std::string> VolumeGC::GetLongNames() const
 {
   LoadBannerFile();
   return m_long_names;
 }
 
-std::map<Language, std::string> CVolumeGC::GetShortMakers() const
+std::map<Language, std::string> VolumeGC::GetShortMakers() const
 {
   LoadBannerFile();
   return m_short_makers;
 }
 
-std::map<Language, std::string> CVolumeGC::GetLongMakers() const
+std::map<Language, std::string> VolumeGC::GetLongMakers() const
 {
   LoadBannerFile();
   return m_long_makers;
 }
 
-std::map<Language, std::string> CVolumeGC::GetDescriptions() const
+std::map<Language, std::string> VolumeGC::GetDescriptions() const
 {
   LoadBannerFile();
   return m_descriptions;
 }
 
-std::vector<u32> CVolumeGC::GetBanner(int* width, int* height) const
+std::vector<u32> VolumeGC::GetBanner(int* width, int* height) const
 {
   LoadBannerFile();
   *width = m_image_width;
@@ -130,7 +130,7 @@ std::vector<u32> CVolumeGC::GetBanner(int* width, int* height) const
   return m_image_buffer;
 }
 
-std::string CVolumeGC::GetApploaderDate(const Partition& partition) const
+std::string VolumeGC::GetApploaderDate(const Partition& partition) const
 {
   char date[16];
   if (!Read(0x2440, 0x10, (u8*)&date, partition))
@@ -139,32 +139,32 @@ std::string CVolumeGC::GetApploaderDate(const Partition& partition) const
   return DecodeString(date);
 }
 
-BlobType CVolumeGC::GetBlobType() const
+BlobType VolumeGC::GetBlobType() const
 {
   return m_pReader->GetBlobType();
 }
 
-u64 CVolumeGC::GetSize() const
+u64 VolumeGC::GetSize() const
 {
   return m_pReader->GetDataSize();
 }
 
-u64 CVolumeGC::GetRawSize() const
+u64 VolumeGC::GetRawSize() const
 {
   return m_pReader->GetRawSize();
 }
 
-std::optional<u8> CVolumeGC::GetDiscNumber(const Partition& partition) const
+std::optional<u8> VolumeGC::GetDiscNumber(const Partition& partition) const
 {
   return ReadSwapped<u8>(6, partition);
 }
 
-Platform CVolumeGC::GetVolumeType() const
+Platform VolumeGC::GetVolumeType() const
 {
   return Platform::GAMECUBE_DISC;
 }
 
-void CVolumeGC::LoadBannerFile() const
+void VolumeGC::LoadBannerFile() const
 {
   // If opening.bnr has been loaded already, return immediately
   if (m_banner_loaded)
@@ -173,7 +173,7 @@ void CVolumeGC::LoadBannerFile() const
   m_banner_loaded = true;
 
   GCBanner banner_file;
-  std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this, PARTITION_NONE));
+  std::unique_ptr<FileSystem> file_system(CreateFileSystem(this, PARTITION_NONE));
   if (!file_system)
     return;
 
@@ -206,7 +206,7 @@ void CVolumeGC::LoadBannerFile() const
   ExtractBannerInformation(banner_file, is_bnr1);
 }
 
-void CVolumeGC::ExtractBannerInformation(const GCBanner& banner_file, bool is_bnr1) const
+void VolumeGC::ExtractBannerInformation(const GCBanner& banner_file, bool is_bnr1) const
 {
   u32 number_of_languages = 0;
   Language start_language = Language::LANGUAGE_UNKNOWN;

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -17,18 +17,18 @@
 
 namespace DiscIO
 {
-class IBlobReader;
+class BlobReader;
 enum class BlobType;
 enum class Country;
 enum class Language;
 enum class Region;
 enum class Platform;
 
-class CVolumeGC : public IVolume
+class VolumeGC : public Volume
 {
 public:
-  CVolumeGC(std::unique_ptr<IBlobReader> reader);
-  ~CVolumeGC();
+  VolumeGC(std::unique_ptr<BlobReader> reader);
+  ~VolumeGC();
   bool Read(u64 _Offset, u64 _Length, u8* _pBuffer,
             const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
@@ -93,7 +93,7 @@ private:
   mutable int m_image_height = 0;
   mutable int m_image_width = 0;
 
-  std::unique_ptr<IBlobReader> m_pReader;
+  std::unique_ptr<BlobReader> m_pReader;
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -25,7 +25,7 @@
 
 namespace DiscIO
 {
-CVolumeWAD::CVolumeWAD(std::unique_ptr<IBlobReader> reader) : m_reader(std::move(reader))
+VolumeWAD::VolumeWAD(std::unique_ptr<BlobReader> reader) : m_reader(std::move(reader))
 {
   _assert_(m_reader);
 
@@ -53,11 +53,11 @@ CVolumeWAD::CVolumeWAD(std::unique_ptr<IBlobReader> reader) : m_reader(std::move
   m_tmd.SetBytes(std::move(tmd_buffer));
 }
 
-CVolumeWAD::~CVolumeWAD()
+VolumeWAD::~VolumeWAD()
 {
 }
 
-bool CVolumeWAD::Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const
+bool VolumeWAD::Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const
 {
   if (partition != PARTITION_NONE)
     return false;
@@ -65,14 +65,14 @@ bool CVolumeWAD::Read(u64 offset, u64 length, u8* buffer, const Partition& parti
   return m_reader->Read(offset, length, buffer);
 }
 
-Region CVolumeWAD::GetRegion() const
+Region VolumeWAD::GetRegion() const
 {
   if (!m_tmd.IsValid())
     return Region::UNKNOWN_REGION;
   return m_tmd.GetRegion();
 }
 
-Country CVolumeWAD::GetCountry(const Partition& partition) const
+Country VolumeWAD::GetCountry(const Partition& partition) const
 {
   if (!m_tmd.IsValid())
     return Country::COUNTRY_UNKNOWN;
@@ -84,17 +84,17 @@ Country CVolumeWAD::GetCountry(const Partition& partition) const
   return CountrySwitch(country_code);
 }
 
-const IOS::ES::TMDReader& CVolumeWAD::GetTMD(const Partition& partition) const
+const IOS::ES::TMDReader& VolumeWAD::GetTMD(const Partition& partition) const
 {
   return m_tmd;
 }
 
-std::string CVolumeWAD::GetGameID(const Partition& partition) const
+std::string VolumeWAD::GetGameID(const Partition& partition) const
 {
   return m_tmd.GetGameID();
 }
 
-std::string CVolumeWAD::GetMakerID(const Partition& partition) const
+std::string VolumeWAD::GetMakerID(const Partition& partition) const
 {
   char temp[2];
   if (!Read(0x198 + m_tmd_offset, 2, (u8*)temp, partition))
@@ -108,12 +108,12 @@ std::string CVolumeWAD::GetMakerID(const Partition& partition) const
   return DecodeString(temp);
 }
 
-std::optional<u64> CVolumeWAD::GetTitleID(const Partition& partition) const
+std::optional<u64> VolumeWAD::GetTitleID(const Partition& partition) const
 {
   return ReadSwapped<u64>(m_offset + 0x01DC, partition);
 }
 
-std::optional<u16> CVolumeWAD::GetRevision(const Partition& partition) const
+std::optional<u16> VolumeWAD::GetRevision(const Partition& partition) const
 {
   if (!m_tmd.IsValid())
     return {};
@@ -121,12 +121,12 @@ std::optional<u16> CVolumeWAD::GetRevision(const Partition& partition) const
   return m_tmd.GetTitleVersion();
 }
 
-Platform CVolumeWAD::GetVolumeType() const
+Platform VolumeWAD::GetVolumeType() const
 {
   return Platform::WII_WAD;
 }
 
-std::map<Language, std::string> CVolumeWAD::GetLongNames() const
+std::map<Language, std::string> VolumeWAD::GetLongNames() const
 {
   if (!m_tmd.IsValid() || !IOS::ES::IsChannel(m_tmd.GetTitleId()))
     return {};
@@ -137,7 +137,7 @@ std::map<Language, std::string> CVolumeWAD::GetLongNames() const
   return ReadWiiNames(name_data);
 }
 
-std::vector<u32> CVolumeWAD::GetBanner(int* width, int* height) const
+std::vector<u32> VolumeWAD::GetBanner(int* width, int* height) const
 {
   *width = 0;
   *height = 0;
@@ -149,17 +149,17 @@ std::vector<u32> CVolumeWAD::GetBanner(int* width, int* height) const
   return GetWiiBanner(width, height, *title_id);
 }
 
-BlobType CVolumeWAD::GetBlobType() const
+BlobType VolumeWAD::GetBlobType() const
 {
   return m_reader->GetBlobType();
 }
 
-u64 CVolumeWAD::GetSize() const
+u64 VolumeWAD::GetSize() const
 {
   return m_reader->GetDataSize();
 }
 
-u64 CVolumeWAD::GetRawSize() const
+u64 VolumeWAD::GetRawSize() const
 {
   return m_reader->GetRawSize();
 }

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -15,23 +15,23 @@
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for Wad files ---
-// Some of this code might look redundant with the CNANDContentLoader class, however,
+// Some of this code might look redundant with the NANDContentLoader class, however,
 // We do not do any decryption here, we do raw read, so things are -Faster-
 
 namespace DiscIO
 {
-class IBlobReader;
+class BlobReader;
 enum class BlobType;
 enum class Country;
 enum class Language;
 enum class Region;
 enum class Platform;
 
-class CVolumeWAD : public IVolume
+class VolumeWAD : public Volume
 {
 public:
-  CVolumeWAD(std::unique_ptr<IBlobReader> reader);
-  ~CVolumeWAD();
+  VolumeWAD(std::unique_ptr<BlobReader> reader);
+  ~VolumeWAD();
   bool Read(u64 offset, u64 length, u8* buffer,
             const Partition& partition = PARTITION_NONE) const override;
   std::optional<u64> GetTitleID(const Partition& partition = PARTITION_NONE) const override;
@@ -58,7 +58,7 @@ public:
   u64 GetRawSize() const override;
 
 private:
-  std::unique_ptr<IBlobReader> m_reader;
+  std::unique_ptr<BlobReader> m_reader;
   IOS::ES::TMDReader m_tmd;
   u32 m_offset = 0;
   u32 m_tmd_offset = 0;

--- a/Source/Core/DiscIO/VolumeWii.h
+++ b/Source/Core/DiscIO/VolumeWii.h
@@ -19,18 +19,18 @@
 
 namespace DiscIO
 {
-class IBlobReader;
+class BlobReader;
 enum class BlobType;
 enum class Country;
 enum class Language;
 enum class Region;
 enum class Platform;
 
-class CVolumeWiiCrypted : public IVolume
+class VolumeWii : public Volume
 {
 public:
-  CVolumeWiiCrypted(std::unique_ptr<IBlobReader> reader);
-  ~CVolumeWiiCrypted();
+  VolumeWii(std::unique_ptr<BlobReader> reader);
+  ~VolumeWii();
   bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const override;
   std::vector<Partition> GetPartitions() const override;
   Partition GetGamePartition() const override;
@@ -63,7 +63,7 @@ public:
   static constexpr unsigned int BLOCK_TOTAL_SIZE = BLOCK_HEADER_SIZE + BLOCK_DATA_SIZE;
 
 private:
-  std::unique_ptr<IBlobReader> m_pReader;
+  std::unique_ptr<BlobReader> m_pReader;
   std::map<Partition, std::unique_ptr<mbedtls_aes_context>> m_partition_keys;
   std::map<Partition, IOS::ES::TicketReader> m_partition_tickets;
   std::map<Partition, IOS::ES::TMDReader> m_partition_tmds;

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -16,7 +16,7 @@ namespace DiscIO
 {
 static constexpr u32 WBFS_MAGIC = 0x53464257;  // "WBFS" (byteswapped to little endian)
 
-class WbfsFileReader : public IBlobReader
+class WbfsFileReader : public BlobReader
 {
 public:
   ~WbfsFileReader();

--- a/Source/Core/DiscIO/WiiWad.cpp
+++ b/Source/Core/DiscIO/WiiWad.cpp
@@ -19,7 +19,7 @@ namespace DiscIO
 {
 namespace
 {
-std::vector<u8> CreateWADEntry(IBlobReader& reader, u32 size, u64 offset)
+std::vector<u8> CreateWADEntry(BlobReader& reader, u32 size, u64 offset)
 {
   if (size == 0)
     return {};
@@ -35,7 +35,7 @@ std::vector<u8> CreateWADEntry(IBlobReader& reader, u32 size, u64 offset)
   return buffer;
 }
 
-bool IsWiiWAD(IBlobReader& reader)
+bool IsWiiWAD(BlobReader& reader)
 {
   const std::optional<u32> header_size = reader.ReadSwapped<u32>(0x0);
   const std::optional<u32> header_type = reader.ReadSwapped<u32>(0x4);

--- a/Source/Core/DiscIO/WiiWad.h
+++ b/Source/Core/DiscIO/WiiWad.h
@@ -13,8 +13,7 @@
 
 namespace DiscIO
 {
-class IBlobReader;
-class CBlobBigEndianReader;
+class BlobReader;
 
 class WiiWAD
 {
@@ -35,7 +34,7 @@ private:
 
   bool m_valid;
 
-  std::unique_ptr<IBlobReader> m_reader;
+  std::unique_ptr<BlobReader> m_reader;
 
   u64 m_data_app_offset = 0;
   std::vector<u8> m_certificate_chain;

--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -168,7 +168,7 @@ void InfoWidget::ComputeChecksum()
 {
   QCryptographicHash hash(QCryptographicHash::Md5);
   hash.reset();
-  std::unique_ptr<DiscIO::IBlobReader> file(
+  std::unique_ptr<DiscIO::BlobReader> file(
       DiscIO::CreateBlobReader(m_game.GetFilePath().toStdString()));
   std::vector<u8> file_data(8 * 1080 * 1080);  // read 1MB at a time
   u64 game_size = file->GetDataSize();

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -84,7 +84,7 @@ QString GameFile::GetCacheFileName() const
   return folder + m_file_name + hash;
 }
 
-void GameFile::ReadBanner(const DiscIO::IVolume& volume)
+void GameFile::ReadBanner(const DiscIO::Volume& volume)
 {
   int width, height;
   std::vector<u32> buffer = volume.GetBanner(&width, &height);
@@ -154,7 +154,7 @@ bool GameFile::TryLoadCache()
 
 bool GameFile::TryLoadVolume()
 {
-  QSharedPointer<DiscIO::IVolume> volume(
+  QSharedPointer<DiscIO::Volume> volume(
       DiscIO::CreateVolumeFromFilename(m_path.toStdString()).release());
   if (volume == nullptr)
     return false;

--- a/Source/Core/DolphinQt2/GameList/GameFile.h
+++ b/Source/Core/DolphinQt2/GameList/GameFile.h
@@ -18,7 +18,7 @@ enum class Country;
 enum class Language;
 enum class Region;
 enum class Platform;
-class IVolume;
+class Volume;
 }
 
 // TODO cache
@@ -76,7 +76,7 @@ private:
   QString GetBannerString(const QMap<DiscIO::Language, QString>& m) const;
 
   QString GetCacheFileName() const;
-  void ReadBanner(const DiscIO::IVolume& volume);
+  void ReadBanner(const DiscIO::Volume& volume);
   bool LoadFileInfo(const QString& path);
   void LoadState();
   bool IsElfOrDol();

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -224,7 +224,7 @@ void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)
   File::SetUserPath(D_WIIROOT_IDX, nand_path);
   m_nand_root_dirpicker->SetPath(StrToWxStr(nand_path));
 
-  DiscIO::CNANDContentManager::Access().ClearCache();
+  DiscIO::NANDContentManager::Access().ClearCache();
 
   wxCommandEvent update_event{DOLPHIN_EVT_UPDATE_LOAD_WII_MENU_ITEM, GetId()};
   update_event.SetEventObject(this);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1497,7 +1497,7 @@ void CFrame::UpdateGUI()
   GetMenuBar()
       ->FindItem(IDM_LOAD_GC_IPL_EUR)
       ->Enable(!Initialized && File::Exists(SConfig::GetInstance().GetBootROMPath(EUR_DIR)));
-  if (DiscIO::CNANDContentManager::Access()
+  if (DiscIO::NANDContentManager::Access()
           .GetNANDLoader(TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT)
           .IsValid())
     GetMenuBar()->FindItem(IDM_LOAD_WII_MENU)->Enable(!Initialized);

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -79,7 +79,7 @@ GameListItem::GameListItem(const std::string& _rFileName, const Core::TitleDatab
     if (m_pImage.empty())
     {
       std::vector<u32> buffer =
-          DiscIO::IVolume::GetWiiBanner(&m_ImageWidth, &m_ImageHeight, m_title_id);
+          DiscIO::Volume::GetWiiBanner(&m_ImageWidth, &m_ImageHeight, m_title_id);
       ReadVolumeBanner(buffer, m_ImageWidth, m_ImageHeight);
       if (!m_pImage.empty())
         SaveToCache();
@@ -87,7 +87,7 @@ GameListItem::GameListItem(const std::string& _rFileName, const Core::TitleDatab
   }
   else
   {
-    std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(_rFileName));
+    std::unique_ptr<DiscIO::Volume> volume(DiscIO::CreateVolumeFromFilename(_rFileName));
 
     if (volume != nullptr)
     {

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
@@ -32,18 +32,17 @@ namespace
 class WiiPartition final : public wxTreeItemData
 {
 public:
-  WiiPartition(std::unique_ptr<DiscIO::IFileSystem> filesystem_)
-      : filesystem{std::move(filesystem_)}
+  WiiPartition(std::unique_ptr<DiscIO::FileSystem> filesystem_) : filesystem{std::move(filesystem_)}
   {
   }
 
-  std::unique_ptr<DiscIO::IFileSystem> filesystem;
+  std::unique_ptr<DiscIO::FileSystem> filesystem;
 };
 
 class IntegrityCheckThread final : public wxThread
 {
 public:
-  explicit IntegrityCheckThread(const DiscIO::IVolume* volume, DiscIO::Partition partition)
+  explicit IntegrityCheckThread(const DiscIO::Volume* volume, DiscIO::Partition partition)
       : wxThread{wxTHREAD_JOINABLE}, m_volume{volume}, m_partition{partition}
   {
     Create();
@@ -55,7 +54,7 @@ public:
   }
 
 private:
-  const DiscIO::IVolume* const m_volume;
+  const DiscIO::Volume* const m_volume;
   const DiscIO::Partition m_partition;
 };
 
@@ -85,14 +84,14 @@ wxImageList* LoadIconBitmaps(const wxWindow* context)
 }
 
 size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
-                           const std::vector<DiscIO::SFileInfo>& file_infos,
+                           const std::vector<DiscIO::FileInfo>& file_infos,
                            const size_t first_index, const size_t last_index)
 {
   size_t current_index = first_index;
 
   while (current_index < last_index)
   {
-    const DiscIO::SFileInfo& file_info = file_infos[current_index];
+    const DiscIO::FileInfo& file_info = file_infos[current_index];
     std::string file_path = file_info.m_FullPath;
 
     // Trim the trailing '/' if it exists.
@@ -127,7 +126,7 @@ size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
 }
 
 size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
-                           const std::vector<DiscIO::SFileInfo>& file_infos)
+                           const std::vector<DiscIO::FileInfo>& file_infos)
 {
   if (file_infos.empty())
     return 0;
@@ -155,7 +154,7 @@ WiiPartition* FindWiiPartition(wxTreeCtrl* tree_ctrl, const wxString& label)
 }  // Anonymous namespace
 
 FilesystemPanel::FilesystemPanel(wxWindow* parent, wxWindowID id,
-                                 const std::unique_ptr<DiscIO::IVolume>& opened_iso)
+                                 const std::unique_ptr<DiscIO::Volume>& opened_iso)
     : wxPanel{parent, id}, m_opened_iso{opened_iso}
 {
   CreateGUI();
@@ -204,7 +203,7 @@ bool FilesystemPanel::PopulateFileSystemTree()
   {
     for (size_t i = 0; i < partitions.size(); ++i)
     {
-      std::unique_ptr<DiscIO::IFileSystem> file_system(
+      std::unique_ptr<DiscIO::FileSystem> file_system(
           DiscIO::CreateFileSystem(m_opened_iso.get(), partitions[i]));
       if (file_system)
       {
@@ -310,7 +309,7 @@ void FilesystemPanel::OnExtractDirectories(wxCommandEvent& event)
 
 void FilesystemPanel::OnExtractHeaderData(wxCommandEvent& event)
 {
-  DiscIO::IFileSystem* file_system = nullptr;
+  DiscIO::FileSystem* file_system = nullptr;
   const wxString path = wxDirSelector(_("Choose the folder to extract to"));
 
   if (path.empty())
@@ -451,9 +450,9 @@ void FilesystemPanel::ExtractSingleDirectory(const wxString& output_folder)
 
 void FilesystemPanel::ExtractDirectories(const std::string& full_path,
                                          const std::string& output_folder,
-                                         DiscIO::IFileSystem* filesystem)
+                                         DiscIO::FileSystem* filesystem)
 {
-  const std::vector<DiscIO::SFileInfo>& fst = filesystem->GetFileList();
+  const std::vector<DiscIO::FileInfo>& fst = filesystem->GetFileList();
 
   u32 index = 0;
   u32 size = 0;

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.h
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.h
@@ -14,15 +14,15 @@ class wxTreeEvent;
 
 namespace DiscIO
 {
-class IFileSystem;
-class IVolume;
+class FileSystem;
+class Volume;
 }
 
 class FilesystemPanel final : public wxPanel
 {
 public:
   explicit FilesystemPanel(wxWindow* parent, wxWindowID id,
-                           const std::unique_ptr<DiscIO::IVolume>& opened_iso);
+                           const std::unique_ptr<DiscIO::Volume>& opened_iso);
   ~FilesystemPanel();
 
 private:
@@ -51,15 +51,15 @@ private:
   void ExtractSingleFile(const wxString& output_file_path) const;
   void ExtractSingleDirectory(const wxString& output_folder);
   void ExtractDirectories(const std::string& full_path, const std::string& output_folder,
-                          DiscIO::IFileSystem* filesystem);
+                          DiscIO::FileSystem* filesystem);
 
   wxString BuildFilePathFromSelection() const;
   wxString BuildDirectoryPathFromSelection() const;
 
   wxTreeCtrl* m_tree_ctrl;
 
-  const std::unique_ptr<DiscIO::IVolume>& m_opened_iso;
+  const std::unique_ptr<DiscIO::Volume>& m_opened_iso;
 
-  std::unique_ptr<DiscIO::IFileSystem> m_filesystem;
+  std::unique_ptr<DiscIO::FileSystem> m_filesystem;
   bool m_has_partitions;
 };

--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.h
@@ -30,7 +30,7 @@ class wxTextCtrl;
 
 namespace DiscIO
 {
-class IVolume;
+class Volume;
 }
 
 namespace Gecko
@@ -60,7 +60,7 @@ public:
 private:
   DECLARE_EVENT_TABLE();
 
-  std::unique_ptr<DiscIO::IVolume> m_open_iso;
+  std::unique_ptr<DiscIO::Volume> m_open_iso;
 
   std::vector<PatchEngine::Patch> onFrame;
   PHackData m_PHack_Data;

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -142,7 +142,7 @@ int FindPreferredLanguageIndex(DiscIO::Language preferred_language,
 }  // Anonymous namespace
 
 InfoPanel::InfoPanel(wxWindow* parent, wxWindowID id, const GameListItem& item,
-                     const std::unique_ptr<DiscIO::IVolume>& opened_iso)
+                     const std::unique_ptr<DiscIO::Volume>& opened_iso)
     : wxPanel{parent, id}, m_game_list_item{item}, m_opened_iso{opened_iso}
 {
   CreateGUI();

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.h
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.h
@@ -16,7 +16,7 @@ class wxTextCtrl;
 
 namespace DiscIO
 {
-class IVolume;
+class Volume;
 enum class Language;
 }
 
@@ -24,7 +24,7 @@ class InfoPanel final : public wxPanel
 {
 public:
   InfoPanel(wxWindow* parent, wxWindowID id, const GameListItem& item,
-            const std::unique_ptr<DiscIO::IVolume>& opened_iso);
+            const std::unique_ptr<DiscIO::Volume>& opened_iso);
 
 private:
   enum
@@ -53,7 +53,7 @@ private:
   void EmitTitleChangeEvent(const wxString& new_title);
 
   const GameListItem& m_game_list_item;
-  const std::unique_ptr<DiscIO::IVolume>& m_opened_iso;
+  const std::unique_ptr<DiscIO::Volume>& m_opened_iso;
 
   wxTextCtrl* m_internal_name;
   wxTextCtrl* m_game_id;

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -581,7 +581,7 @@ void MainMenuBar::RefreshWiiSystemMenuLabel() const
 {
   auto* const item = FindItem(IDM_LOAD_WII_MENU);
 
-  const auto& sys_menu_loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(
+  const auto& sys_menu_loader = DiscIO::NANDContentManager::Access().GetNANDLoader(
       TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT);
 
   if (sys_menu_loader.IsValid())

--- a/Source/Core/UICommon/WiiUtils.cpp
+++ b/Source/Core/UICommon/WiiUtils.cpp
@@ -58,7 +58,7 @@ bool InstallWAD(const std::string& wad_path)
     return false;
   }
 
-  DiscIO::CNANDContentManager::Access().ClearCache();
+  DiscIO::NANDContentManager::Access().ClearCache();
   return true;
 }
 }


### PR DESCRIPTION
These prefixes were inconsistent with the rest of Dolphin.

I'm also renaming VolumeWiiCrypted to VolumeWii because of PR #5548.