### PR TITLE
EditorConfig: Don't enforce a specific line ending

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 [*]
-end_of_line = lf
 indent_size = 2
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Resolves the discussion in #5541.

Currently waiting on a confirmation that the presence/absence of `insert_final_newline` doesn't affect Visual Studio at all.