### PR TITLE
Qt: Use TitleDatabase for better names in the game list

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include "DolphinQt2/GameList/GameListModel.h"
+
+#include "DiscIO/Enums.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 
@@ -21,6 +23,8 @@ GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
     emit layoutAboutToBeChanged();
     emit layoutChanged();
   });
+
+  // TODO: Reload m_title_database when the language changes
 }
 
 QVariant GameListModel::data(const QModelIndex& index, int role) const
@@ -63,7 +67,16 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     break;
   case COL_TITLE:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
-      return game->GetLongName();
+    {
+      QString display_name = QString::fromStdString(m_title_database.GetTitleName(
+          game->GetGameID().toStdString(), game->GetPlatformID() == DiscIO::Platform::WII_WAD ?
+                                               Core::TitleDatabase::TitleType::Channel :
+                                               Core::TitleDatabase::TitleType::Other));
+      if (display_name.isEmpty())
+        return game->GetLongName();
+
+      return display_name;
+    }
     break;
   case COL_ID:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -7,6 +7,7 @@
 #include <QAbstractTableModel>
 #include <QString>
 
+#include "Core/TitleDatabase.h"
 #include "DolphinQt2/GameList/GameFile.h"
 #include "DolphinQt2/GameList/GameTracker.h"
 
@@ -54,4 +55,5 @@ private:
 
   GameTracker m_tracker;
   QList<QSharedPointer<GameFile>> m_games;
+  Core::TitleDatabase m_title_database;
 };


### PR DESCRIPTION
This is another change to make Qt match WX

Before: 
![image](https://user-images.githubusercontent.com/4411333/26855419-0ccb19f8-4ad8-11e7-980c-c455e9ae2e2b.png)

After: 
![image](https://user-images.githubusercontent.com/4411333/26855421-13694550-4ad8-11e7-964c-366078b205c8.png)
