### PR TITLE
Core: Fix vcxproj filter

### DIFF
--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -290,7 +290,7 @@
     <ClCompile Include="HLE\HLE_OS.cpp">
       <Filter>HLE</Filter>
     </ClCompile>
-    <ClCompile Include="HLE\HLE_VarArgs.cpp" />
+    <ClCompile Include="HLE\HLE_VarArgs.cpp">
       <Filter>HLE</Filter>
     </ClCompile>
     <ClCompile Include="PowerPC\BreakPoints.cpp">


### PR DESCRIPTION
This would cause the core project to fail to load.