### PR TITLE
Boot: Make BootExecutableReader hierarchy constructors explicit

### DIFF
--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -109,8 +109,8 @@ private:
 class BootExecutableReader
 {
 public:
-  BootExecutableReader(const std::string& file_name);
-  BootExecutableReader(const std::vector<u8>& buffer);
+  explicit BootExecutableReader(const std::string& file_name);
+  explicit BootExecutableReader(const std::vector<u8>& buffer);
   virtual ~BootExecutableReader();
 
   virtual u32 GetEntryPoint() const = 0;

--- a/Source/Core/Core/Boot/DolReader.h
+++ b/Source/Core/Core/Boot/DolReader.h
@@ -13,8 +13,8 @@
 class DolReader final : public BootExecutableReader
 {
 public:
-  DolReader(const std::string& filename);
-  DolReader(const std::vector<u8>& buffer);
+  explicit DolReader(const std::string& filename);
+  explicit DolReader(const std::vector<u8>& buffer);
   ~DolReader();
 
   bool IsValid() const override { return m_is_valid; }

--- a/Source/Core/Core/Boot/ElfReader.cpp
+++ b/Source/Core/Core/Boot/ElfReader.cpp
@@ -76,6 +76,8 @@ ElfReader::ElfReader(const std::string& filename) : BootExecutableReader(filenam
   Initialize(m_bytes.data());
 }
 
+ElfReader::~ElfReader() = default;
+
 void ElfReader::Initialize(u8* ptr)
 {
   base = (char*)ptr;

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -23,7 +23,7 @@ class ElfReader final : public BootExecutableReader
 public:
   explicit ElfReader(const std::string& filename);
   explicit ElfReader(const std::vector<u8>& buffer);
-  ~ElfReader() {}
+  ~ElfReader();
   u32 Read32(int off) const { return base32[off >> 2]; }
   // Quick accessors
   ElfType GetType() const { return (ElfType)(header->e_type); }

--- a/Source/Core/Core/Boot/ElfReader.h
+++ b/Source/Core/Core/Boot/ElfReader.h
@@ -21,8 +21,8 @@ typedef int SectionID;
 class ElfReader final : public BootExecutableReader
 {
 public:
-  ElfReader(const std::string& filename);
-  ElfReader(const std::vector<u8>& buffer);
+  explicit ElfReader(const std::string& filename);
+  explicit ElfReader(const std::vector<u8>& buffer);
   ~ElfReader() {}
   u32 Read32(int off) const { return base32[off >> 2]; }
   // Quick accessors


### PR DESCRIPTION
Prevents implicit conversions. Also defaults the ElfReader destructor to be consistent with the DolReader.