### PR TITLE
Core: include what you use

### DIFF
--- a/Source/Core/Core/ARDecrypt.cpp
+++ b/Source/Core/Core/ARDecrypt.cpp
@@ -10,6 +10,8 @@
 
 #include <algorithm>
 #include <cstring>
+#include <string>
+#include <vector>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdarg>
 #include <iterator>
 #include <mutex>
 #include <string>

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -5,6 +5,7 @@
 #include "Core/Boot/Boot.h"
 
 #include <algorithm>
+#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_set>

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <list>
 #include <map>
+#include <memory>
 #include <string>
 
 #include "Common/CommonPaths.h"

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <array>
+#include <list>
 #include <map>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <memory>
 #include <string>
 
 #include "Common/CommonFuncs.h"

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <memory>
+
 #include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -6,6 +6,7 @@
 #include <climits>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <variant>
 
 #include "AudioCommon/AudioCommon.h"

--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -5,15 +5,17 @@
 
 #include "Core/DSP/DSPAssembler.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <iostream>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/DSP/DSPCaptureLogger.cpp
+++ b/Source/Core/Core/DSP/DSPCaptureLogger.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <memory>
+#include <string>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -5,6 +5,7 @@
 
 #include "Core/DSP/DSPHWInterface.h"
 
+#include <atomic>
 #include <cstddef>
 #include <cstring>
 

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -3,6 +3,10 @@
 // Refer to the license.txt file included.
 
 #include "Core/DSP/LabelMap.h"
+
+#include <string>
+#include <vector>
+
 #include "Core/DSP/DSPTables.h"
 
 namespace DSP

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstdio>
 #include <functional>
 #include <string>
 

--- a/Source/Core/Core/Debugger/RSO.cpp
+++ b/Source/Core/Core/Debugger/RSO.cpp
@@ -4,7 +4,11 @@
 
 #include "Core/Debugger/RSO.h"
 
+#include <cstddef>
+#include <list>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "Common/FileUtil.h"
 

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/FifoPlayer/FifoPlaybackAnalyzer.h"
 
+#include <vector>
+
 #include "Common/CommonTypes.h"
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoDataFile.h"

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <cstring>
 #include <mutex>
 
 #include "Core/FifoPlayer/FifoRecorder.h"

--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -5,6 +5,7 @@
 #include "Core/GeckoCodeConfig.h"
 
 #include <algorithm>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -3,6 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/DSPHLE/MailHandler.h"
+
+#include <queue>
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -5,6 +5,7 @@
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 #include <cstring>
+#include <memory>
 #include <string>
 
 #ifdef _WIN32

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -5,6 +5,7 @@
 #include "Core/HW/DSPHLE/UCodes/Zelda.h"
 
 #include <array>
+#include <map>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -3,6 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "Core/DSP/DSPHost.h"
+
+#include <string>
+
 #include "Common/CommonTypes.h"
 #include "Common/Hash.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -1214,9 +1214,8 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
   u32 buffered_blocks = 0;
   u32 unbuffered_blocks = 0;
 
-  const u32 bytes_per_chunk = partition == DiscIO::PARTITION_NONE ?
-                                  DVD_ECC_BLOCK_SIZE :
-                                  DiscIO::VolumeWii::BLOCK_DATA_SIZE;
+  const u32 bytes_per_chunk =
+      partition == DiscIO::PARTITION_NONE ? DVD_ECC_BLOCK_SIZE : DiscIO::VolumeWii::BLOCK_DATA_SIZE;
 
   while (length > 0)
   {

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "AudioCommon/AudioCommon.h"
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceAGP.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceAGP.cpp
@@ -4,8 +4,10 @@
 
 #include "Core/HW/EXI/EXI_DeviceAGP.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/HW/EXI/EXI_DeviceDummy.h"
 
+#include <string>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/HW/EXI/EXI_DeviceEthernet.h"
 
+#include <memory>
 #include <string>
 
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -5,6 +5,7 @@
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 
 #include <cstring>
+#include <string>
 
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <string>
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -2,8 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cstring>
 #include <mutex>
+
+#include <cubeb/cubeb.h>
 
 #include "AudioCommon/CubebUtils.h"
 #include "Common/Common.h"
@@ -16,8 +19,6 @@
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/SystemTimers.h"
-
-#include <cubeb/cubeb.h>
 
 namespace ExpansionInterface
 {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -4,12 +4,14 @@
 
 #include "Core/HW/GCMemcard/GCMemcardDirectory.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cinttypes>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -7,7 +7,9 @@
 #include <chrono>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/HW/GPFifo.h"
 
+#include <cstddef>
 #include <cstring>
 
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -7,6 +7,7 @@
 // However, if a JITed instruction (for example lwz) wants to access a bad memory area that call
 // may be redirected here (for example to Read_U32()).
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
 

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstdio>
+#include <memory>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -16,6 +16,7 @@
    0x30 - 0x3f   Input    This file: Update() */
 
 #include <fstream>
+#include <mutex>
 #include <queue>
 #include <string>
 #include <vector>

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -4,9 +4,11 @@
 
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <mutex>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <mutex>
 #include <queue>
 #include <unordered_set>
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/HotkeyManager.h"
 
+#include <algorithm>
+#include <array>
 #include <string>
 #include <vector>
 

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -5,10 +5,12 @@
 #include "Core/IOS/ES/Formats.h"
 
 #include <algorithm>
+#include <array>
 #include <cinttypes>
 #include <cstddef>
 #include <cstring>
 #include <locale>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -3,7 +3,10 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
 #include <cstring>
+#include <vector>
 
 #include <mbedtls/sha1.h>
 

--- a/Source/Core/Core/IOS/MemoryValues.cpp
+++ b/Source/Core/Core/IOS/MemoryValues.cpp
@@ -3,6 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "Core/IOS/MemoryValues.h"
+
+#include <array>
+
 #include "Common/CommonTypes.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <string>
 
 #include "Common/Assert.h"
 #include "Common/CommonPaths.h"

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -7,7 +7,10 @@
 #include <cstring>
 #include <iomanip>
 #include <iterator>
+#include <memory>
+#include <mutex>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -4,6 +4,9 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
+#include <set>
+#include <string>
 #include <utility>
 
 #ifdef __LIBUSB__

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -5,8 +5,12 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
+#include <functional>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <utility>
+#include <vector>
 
 #include <libusb.h>
 

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <memory>
 #include <sstream>
+#include <string>
 #include <tuple>
 #include <vector>
 

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstddef>
 #include <numeric>
 #include <vector>
 

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -5,7 +5,10 @@
 #include "Core/IOS/USB/USB_HID/HIDv4.h"
 
 #include <cstring>
+#include <mutex>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "Common/Align.h"
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -5,6 +5,7 @@
 #include "Core/IOS/USB/USB_KBD.h"
 
 #include <cstring>
+#include <queue>
 
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -4,7 +4,11 @@
 
 #include "Core/IOS/USB/USB_VEN/VEN.h"
 
+#include <cstddef>
 #include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
 
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -3,11 +3,16 @@
 // Refer to the license.txt file included.
 
 #include "Core/NetPlayClient.h"
+
 #include <algorithm>
 #include <fstream>
-#include <mbedtls/md5.h>
 #include <memory>
+#include <mutex>
+#include <sstream>
 #include <thread>
+
+#include <mbedtls/md5.h>
+
 #include "Common/Common.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -3,9 +3,15 @@
 // Refer to the license.txt file included.
 
 #include "Core/NetPlayServer.h"
+
+#include <algorithm>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <unordered_set>
 #include <vector>
+
 #include "Common/Common.h"
 #include "Common/ENetUtil.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -2,7 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <assert.h>
+#include <array>
+#include <cassert>
 #include <cinttypes>
 #include <string>
 

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -4,6 +4,9 @@
 
 #include "Core/PowerPC/Jit64Common/EmuCodeBlock.h"
 
+#include <functional>
+#include <limits>
+
 #include "Common/Assert.h"
 #include "Common/CPUDetect.h"
 #include "Common/Intrinsics.h"

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -3,6 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
+
+#include <array>
+
 #include "Common/Assert.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -10,8 +10,11 @@
 // locating performance issues.
 
 #include <algorithm>
+#include <array>
 #include <cstring>
+#include <functional>
 #include <map>
+#include <set>
 #include <utility>
 
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -8,6 +8,7 @@
 #include <cinttypes>
 #include <cstdio>
 #include <string>
+#include <unordered_set>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <string>
 
 #include "Common/Atomic.h"
 #include "Common/BitSet.h"

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -3,8 +3,10 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <map>
 #include <queue>
 #include <string>
+#include <vector>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/PowerPC/SignatureDB/DSYSignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/DSYSignatureDB.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <string>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <limits>
 #include <sstream>
+#include <string>
 #include <utility>
 
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <fstream>
 #include <functional>
+#include <unordered_map>
 #include <utility>
 
 #include "Core/TitleDatabase.h"


### PR DESCRIPTION
Eliminates a swath of indirectly included standard headers