### PR TITLE
ControlReference/ExpressionParser: separate parsing from binding

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -344,7 +344,7 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
   auto set_key_expression = [this](int index, const std::string& expression) {
     m_keys[FindGroupByID(index)]
         ->controls[GetIndexForGroup(FindGroupByID(index), index)]
-        ->control_ref->expression = expression;
+        ->control_ref->SetExpression(expression);
   };
 
   // General hotkeys

--- a/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
@@ -110,7 +110,7 @@ void IOWindow::CreateMainLayout()
 
 void IOWindow::Update()
 {
-  m_expression_text->setPlainText(QString::fromStdString(m_reference->expression));
+  m_expression_text->setPlainText(QString::fromStdString(m_reference->GetExpression()));
   m_range_spinbox->setValue(m_reference->range * SLIDER_TICK_COUNT);
   m_range_slider->setValue(m_reference->range * SLIDER_TICK_COUNT);
 
@@ -164,7 +164,7 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
     return;
   }
 
-  m_reference->expression = m_expression_text->toPlainText().toStdString();
+  m_reference->SetExpression(m_expression_text->toPlainText().toStdString());
 
   if (button != m_apply_button)
     accept();

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -27,7 +27,7 @@ static QString EscapeAmpersand(QString&& string)
 }
 
 MappingButton::MappingButton(MappingWidget* widget, ControlReference* ref)
-    : ElidedButton(EscapeAmpersand(QString::fromStdString(ref->expression))), m_parent(widget),
+    : ElidedButton(EscapeAmpersand(QString::fromStdString(ref->GetExpression()))), m_parent(widget),
       m_reference(ref)
 {
   Connect();
@@ -66,7 +66,7 @@ void MappingButton::OnButtonPressed()
 
     if (!expr.isEmpty())
     {
-      m_reference->expression = expr.toStdString();
+      m_reference->SetExpression(expr.toStdString());
       Update();
     }
     else
@@ -78,13 +78,13 @@ void MappingButton::OnButtonPressed()
 
 void MappingButton::OnButtonTimeout()
 {
-  setText(EscapeAmpersand(QString::fromStdString(m_reference->expression)));
+  setText(EscapeAmpersand(QString::fromStdString(m_reference->GetExpression())));
 }
 
 void MappingButton::Clear()
 {
   m_parent->Update();
-  m_reference->expression.clear();
+  m_reference->SetExpression("");
   Update();
 }
 
@@ -92,7 +92,7 @@ void MappingButton::Update()
 {
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   m_reference->UpdateReference(g_controller_interface, m_parent->GetParent()->GetDeviceQualifier());
-  setText(EscapeAmpersand(QString::fromStdString(m_reference->expression)));
+  setText(EscapeAmpersand(QString::fromStdString(m_reference->GetExpression())));
   m_parent->SaveSettings();
 }
 

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -243,7 +243,7 @@ ControlButton::ControlButton(wxWindow* const parent, ControlReference* const _re
       m_configured_width(FromDIP(width))
 {
   if (label.empty())
-    SetLabelText(StrToWxStr(_ref->expression));
+    SetLabelText(StrToWxStr(_ref->GetExpression()));
   else
     SetLabel(StrToWxStr(label));
 }
@@ -336,7 +336,7 @@ void ControlDialog::SelectControl(const std::string& name)
 void ControlDialog::UpdateGUI()
 {
   // update textbox
-  textctrl->SetValue(StrToWxStr(control_reference->expression));
+  textctrl->SetValue(StrToWxStr(control_reference->GetExpression()));
 
   // updates the "bound controls:" label
   m_bound_label->SetLabel(
@@ -365,7 +365,7 @@ void InputConfigDialog::UpdateGUI()
   {
     for (ControlButton* button : cgBox->control_buttons)
     {
-      button->SetLabelText(StrToWxStr(button->control_reference->expression));
+      button->SetLabelText(StrToWxStr(button->control_reference->GetExpression()));
     }
 
     for (PadSetting* padSetting : cgBox->options)
@@ -400,7 +400,7 @@ void InputConfigDialog::LoadDefaults(wxCommandEvent&)
 
 bool ControlDialog::Validate()
 {
-  control_reference->expression = WxStrToStr(textctrl->GetValue());
+  control_reference->SetExpression(WxStrToStr(textctrl->GetValue()));
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
@@ -439,7 +439,7 @@ void ControlDialog::SetDevice(wxCommandEvent&)
 
 void ControlDialog::ClearControl(wxCommandEvent&)
 {
-  control_reference->expression.clear();
+  control_reference->SetExpression("");
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
@@ -498,7 +498,7 @@ void ControlDialog::SetSelectedControl(wxCommandEvent&)
     return;
 
   textctrl->WriteText(expr);
-  control_reference->expression = textctrl->GetValue();
+  control_reference->SetExpression(WxStrToStr(textctrl->GetValue()));
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
@@ -534,7 +534,7 @@ void ControlDialog::AppendControl(wxCommandEvent& event)
   }
 
   textctrl->WriteText(expr);
-  control_reference->expression = textctrl->GetValue();
+  control_reference->SetExpression(WxStrToStr(textctrl->GetValue()));
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
@@ -638,7 +638,7 @@ void InputConfigDialog::ConfigControl(wxEvent& event)
 void InputConfigDialog::ClearControl(wxEvent& event)
 {
   ControlButton* const btn = (ControlButton*)event.GetEventObject();
-  btn->control_reference->expression.clear();
+  btn->control_reference->SetExpression("");
   btn->control_reference->range = 1.0;
 
   controller->UpdateReferences(g_controller_interface);
@@ -717,7 +717,7 @@ bool InputConfigDialog::DetectButton(ControlButton* button)
       wxString control_name = ctrl->GetName();
       wxString expr;
       GetExpressionForControl(expr, control_name);
-      button->control_reference->expression = expr;
+      button->control_reference->SetExpression(WxStrToStr(expr));
       const auto lock = ControllerEmu::EmulatedController::GetStateLock();
       button->control_reference->UpdateReference(g_controller_interface,
                                                  controller->default_device);

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -70,7 +70,7 @@
 #include "InputCommon/ControllerInterface/Device.h"
 #include "InputCommon/InputConfig.h"
 
-using namespace ciface::ExpressionParser;
+using ciface::ExpressionParser::ParseStatus;
 
 void InputConfigDialog::ConfigExtension(wxCommandEvent& event)
 {

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -347,11 +347,12 @@ void ControlDialog::UpdateGUI()
   case ParseStatus::SyntaxError:
     m_error_label->SetLabel(_("Syntax error"));
     break;
-  case ParseStatus::NoDevice:
-    m_error_label->SetLabel(_("Device not found"));
+  case ParseStatus::Successful:
+    m_error_label->SetLabel(control_reference->BoundCount() > 0 ? "" : _("Device not found"));
     break;
-  default:
+  case ParseStatus::EmptyExpression:
     m_error_label->SetLabel("");
+    break;
   }
 };
 
@@ -408,7 +409,7 @@ bool ControlDialog::Validate()
   UpdateGUI();
 
   const auto parse_status = control_reference->GetParseStatus();
-  return parse_status == ParseStatus::Successful || parse_status == ParseStatus::NoDevice;
+  return parse_status == ParseStatus::Successful || parse_status == ParseStatus::EmptyExpression;
 }
 
 void InputConfigDialog::SetDevice(wxCommandEvent&)

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -37,7 +37,7 @@ void ControlReference::UpdateReference(const ciface::Core::DeviceContainer& devi
 int ControlReference::BoundCount() const
 {
   if (m_parsed_expression)
-    return m_parsed_expression->num_controls;
+    return m_parsed_expression->CountNumControls();
   else
     return 0;
 }

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -31,9 +31,7 @@ void ControlReference::UpdateReference(const ciface::Core::DeviceContainer& devi
                                        const ciface::Core::DeviceQualifier& default_device)
 {
   ControlFinder finder(devices, default_device, IsInput());
-  Expression* expr;
-  std::tie(m_parse_status, expr) = ParseExpression(expression, finder);
-  m_parsed_expression.reset(expr);
+  std::tie(m_parse_status, m_parsed_expression) = ParseExpression(expression, finder);
 }
 
 int ControlReference::BoundCount() const

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -31,7 +31,9 @@ void ControlReference::UpdateReference(const ciface::Core::DeviceContainer& devi
                                        const ciface::Core::DeviceQualifier& default_device)
 {
   ControlFinder finder(devices, default_device, IsInput());
-  std::tie(m_parse_status, m_parsed_expression) = ParseExpression(expression, finder);
+  std::tie(m_parse_status, m_parsed_expression) = ParseExpression(expression);
+  if (m_parsed_expression)
+    m_parsed_expression->UpdateReferences(finder);
 }
 
 int ControlReference::BoundCount() const

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -30,9 +30,9 @@ bool ControlReference::InputGateOn()
 void ControlReference::UpdateReference(const ciface::Core::DeviceContainer& devices,
                                        const ciface::Core::DeviceQualifier& default_device)
 {
-  Expression* expr;
   ControlFinder finder(devices, default_device, IsInput());
-  m_parse_status = ParseExpression(expression, finder, &expr);
+  Expression* expr;
+  std::tie(m_parse_status, expr) = ParseExpression(expression, finder);
   m_parsed_expression.reset(expr);
 }
 

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -25,13 +25,12 @@ bool ControlReference::InputGateOn()
 // UpdateReference
 //
 // Updates a controlreference's binded devices/controls
-// need to call this to re-parse a control reference's expression after changing it
+// need to call this to re-bind a control reference after changing its expression
 //
 void ControlReference::UpdateReference(const ciface::Core::DeviceContainer& devices,
                                        const ciface::Core::DeviceQualifier& default_device)
 {
   ControlFinder finder(devices, default_device, IsInput());
-  std::tie(m_parse_status, m_parsed_expression) = ParseExpression(expression);
   if (m_parsed_expression)
     m_parsed_expression->UpdateReferences(finder);
 }
@@ -47,6 +46,17 @@ int ControlReference::BoundCount() const
 ParseStatus ControlReference::GetParseStatus() const
 {
   return m_parse_status;
+}
+
+std::string ControlReference::GetExpression() const
+{
+  return m_expression;
+}
+
+void ControlReference::SetExpression(std::string expr)
+{
+  m_expression = std::move(expr);
+  std::tie(m_parse_status, m_parsed_expression) = ParseExpression(m_expression);
 }
 
 ControlReference::ControlReference() : range(1), m_parsed_expression(nullptr)

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -34,12 +34,14 @@ public:
   ciface::ExpressionParser::ParseStatus GetParseStatus() const;
   void UpdateReference(const ciface::Core::DeviceContainer& devices,
                        const ciface::Core::DeviceQualifier& default_device);
+  std::string GetExpression() const;
+  void SetExpression(std::string expr);
 
   ControlState range;
-  std::string expression;
 
 protected:
   ControlReference();
+  std::string m_expression;
   std::unique_ptr<ciface::ExpressionParser::Expression> m_parsed_expression;
   ciface::ExpressionParser::ParseStatus m_parse_status;
 };

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/StringUtil.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
 
 using namespace ciface::Core;
@@ -393,9 +394,6 @@ private:
     {
       std::shared_ptr<Device> device = finder.FindDevice(tok.qualifier);
       Device::Control* control = finder.FindControl(tok.qualifier);
-      if (control == nullptr)
-        return {ParseStatus::NoDevice, std::make_unique<ControlExpression>(tok.qualifier, control)};
-
       return {ParseStatus::Successful,
               std::make_unique<ControlExpression>(tok.qualifier, std::move(device), control)};
     }
@@ -510,8 +508,8 @@ Expression::~Expression()
 static std::pair<ParseStatus, std::unique_ptr<Expression>>
 ParseExpressionInner(const std::string& str, ControlFinder& finder)
 {
-  if (str == "")
-    return std::make_pair(ParseStatus::Successful, nullptr);
+  if (StripSpaces(str).empty())
+    return std::make_pair(ParseStatus::EmptyExpression, nullptr);
 
   Lexer l(str);
   std::vector<Token> tokens;

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -519,7 +519,7 @@ static ParseResult ParseComplexExpression(const std::string& str)
   if (tokenize_status != ParseStatus::Successful)
     return {tokenize_status};
 
-  return Parser(tokens).Parse();
+  return Parser(std::move(tokens)).Parse();
 }
 
 static std::unique_ptr<Expression> ParseBarewordExpression(const std::string& str)

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -216,7 +216,7 @@ public:
   // Keep a shared_ptr to the device so the control pointer doesn't become invalid
   std::shared_ptr<Device> m_device;
 
-  ControlExpression(ControlQualifier qualifier_) : qualifier(qualifier_) {}
+  explicit ControlExpression(ControlQualifier qualifier_) : qualifier(qualifier_) {}
   ControlState GetValue() const override { return control ? control->ToInput()->GetState() : 0.0; }
   void SetValue(ControlState value) override
   {

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -54,6 +54,7 @@ public:
   virtual ControlState GetValue() const = 0;
   virtual void SetValue(ControlState state) = 0;
   virtual int CountNumControls() const = 0;
+  virtual void UpdateReferences(ControlFinder& finder) = 0;
   virtual operator std::string() const = 0;
 };
 
@@ -64,7 +65,6 @@ enum class ParseStatus
   EmptyExpression,
 };
 
-std::pair<ParseStatus, std::unique_ptr<Expression>> ParseExpression(const std::string& expr,
-                                                                    ControlFinder& finder);
+std::pair<ParseStatus, std::unique_ptr<Expression>> ParseExpression(const std::string& expr);
 }
 }

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include "InputCommon/ControllerInterface/Device.h"
 
 namespace ciface
@@ -66,6 +67,6 @@ enum class ParseStatus
   NoDevice,
 };
 
-ParseStatus ParseExpression(const std::string& expr, ControlFinder& finder, Expression** expr_out);
+std::pair<ParseStatus, Expression*> ParseExpression(const std::string& expr, ControlFinder& finder);
 }
 }

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -51,13 +51,12 @@ class ExpressionNode;
 class Expression
 {
 public:
-  Expression() : node(nullptr) {}
-  Expression(ExpressionNode* node);
+  explicit Expression(std::unique_ptr<ExpressionNode>&& node = {});
   ~Expression();
   ControlState GetValue() const;
   void SetValue(ControlState state);
   int num_controls;
-  ExpressionNode* node;
+  std::unique_ptr<ExpressionNode> node;
 };
 
 enum class ParseStatus
@@ -67,6 +66,7 @@ enum class ParseStatus
   NoDevice,
 };
 
-std::pair<ParseStatus, Expression*> ParseExpression(const std::string& expr, ControlFinder& finder);
+std::pair<ParseStatus, std::unique_ptr<Expression>> ParseExpression(const std::string& expr,
+                                                                    ControlFinder& finder);
 }
 }

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -63,7 +63,7 @@ enum class ParseStatus
 {
   Successful,
   SyntaxError,
-  NoDevice,
+  EmptyExpression,
 };
 
 std::pair<ParseStatus, std::unique_ptr<Expression>> ParseExpression(const std::string& expr,

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -47,16 +47,14 @@ private:
   bool is_input;
 };
 
-class ExpressionNode;
 class Expression
 {
 public:
-  explicit Expression(std::unique_ptr<ExpressionNode>&& node = {});
-  ~Expression();
-  ControlState GetValue() const;
-  void SetValue(ControlState state);
-  int num_controls;
-  std::unique_ptr<ExpressionNode> node;
+  virtual ~Expression() = default;
+  virtual ControlState GetValue() const = 0;
+  virtual void SetValue(ControlState state) = 0;
+  virtual int CountNumControls() const = 0;
+  virtual operator std::string() const = 0;
 };
 
 enum class ParseStatus

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -54,8 +54,12 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
 
   for (auto& c : controls)
   {
-    // control expression
-    sec->Get(group + c->name, &c->control_ref->expression, "");
+    {
+      // control expression
+      std::string expression;
+      sec->Get(group + c->name, &expression, "");
+      c->control_ref->SetExpression(std::move(expression));
+    }
 
     // range
     sec->Get(group + c->name + "/Range", &c->control_ref->range, 100.0);
@@ -109,7 +113,7 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
   for (auto& c : controls)
   {
     // control expression
-    sec->Set(group + c->name, c->control_ref->expression, "");
+    sec->Set(group + c->name, c->control_ref->GetExpression(), "");
 
     // range
     sec->Set(group + c->name + "/Range", c->control_ref->range * 100.0, 100.0);
@@ -128,6 +132,6 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
 
 void ControlGroup::SetControlExpression(int index, const std::string& expression)
 {
-  controls.at(index)->control_ref->expression = expression;
+  controls.at(index)->control_ref->SetExpression(expression);
 }
 }  // namespace ControllerEmu


### PR DESCRIPTION
Depends on #5479 because I didn't want to have to rebase later.

This cleans up and makes a number of changes to `ExpressionParser`, namely:
- Merges `DummyExpression` into `ControlExpression`, so the same node can be used whether a control is found or not.
- Adds a `FallbackExpression` (naming?) that selects between a left and right expression node tree based on whether one has controls bound. This is used to combine the old-style bareword expression compatibility into the main expression tree, and remove parsing logic that's conditional on whether a control is found or not.
- Removes the `ControlFinder&` parameter of `ExpressionParser::ParseExpression`.
- Adds an `UpdateReferences(ControlFinder&)` method to all expression nodes that performs control binding.
- Makes `ControlReference::expression` a private member, and moves expression parsing out of `ControlReference::UpdateReferences` and into `ControlReference::SetExpression`.