### PR TITLE
Core: Remove unnecessary header inclusions

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -19,6 +19,8 @@
 // copy, etc
 // -------------------------------------------------------------------------------------------------------------
 
+#include "Core/ActionReplay.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cstdarg>
@@ -36,9 +38,7 @@
 #include "Common/StringUtil.h"
 
 #include "Core/ARDecrypt.h"
-#include "Core/ActionReplay.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/PowerPC/PowerPC.h"
 
 namespace ActionReplay

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -26,8 +26,6 @@
 #include "Core/Boot/DolReader.h"
 #include "Core/Boot/ElfReader.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
-#include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HW/DVD/DVDInterface.h"
@@ -40,7 +38,6 @@
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
-#include "Core/PowerPC/SignatureDB/SignatureDB.h"
 
 #include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -25,7 +25,6 @@
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/IOS.h"
-#include "Core/PatchEngine.h"
 #include "Core/PowerPC/PowerPC.h"
 
 #include "DiscIO/Enums.h"

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -20,7 +20,6 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileIO.h"
 #include "Core/IOS/IOS.h"
-#include "Core/PatchEngine.h"
 
 #include "DiscIO/NANDContentLoader.h"
 

--- a/Source/Core/Core/Config/Config.cpp
+++ b/Source/Core/Core/Config/Config.cpp
@@ -2,9 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <tuple>
-
 #include "Core/Config/Config.h"
+
+#include <tuple>
 
 namespace Config
 {

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -2,10 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/Config/GraphicsSettings.h"
+
 #include <string>
 
 #include "Core/Config/Config.h"
-#include "Core/Config/GraphicsSettings.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace Config

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -2,13 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/ConfigLoaders/BaseConfigLoader.h"
+
 #include <cstring>
 #include <list>
 #include <map>
 #include <memory>
 #include <string>
 
-#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
@@ -16,7 +17,6 @@
 #include "Common/Logging/Log.h"
 
 #include "Core/Config/Config.h"
-#include "Core/ConfigLoaders/BaseConfigLoader.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 
 namespace ConfigLoaders

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/ConfigLoaders/GameConfigLoader.h"
+
 #include <algorithm>
 #include <array>
 #include <list>
@@ -22,7 +24,6 @@
 
 #include "Core/Config/Config.h"
 #include "Core/Config/GraphicsSettings.h"
-#include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 
 namespace ConfigLoaders

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.h
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.h
@@ -6,6 +6,7 @@
 
 #include <cstring>
 #include <memory>
+#include <string>
 
 #include "Common/CommonTypes.h"
 

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -2,12 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/ConfigLoaders/IsSettingSaveable.h"
+
 #include <algorithm>
 #include <vector>
 
 #include "Core/Config/Config.h"
 #include "Core/Config/GraphicsSettings.h"
-#include "Core/ConfigLoaders/IsSettingSaveable.h"
 
 namespace ConfigLoaders
 {

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -2,18 +2,17 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/ConfigLoaders/MovieConfigLoader.h"
+
 #include <cstring>
 #include <memory>
 #include <string>
 
 #include "Common/CommonFuncs.h"
-#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
-#include "Common/IniFile.h"
 
-#include "Core/ConfigLoaders/MovieConfigLoader.h"
 #include "Core/Movie.h"
 
 namespace ConfigLoaders

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -2,15 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/ConfigLoaders/NetPlayConfigLoader.h"
+
 #include <memory>
 
-#include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
-#include "Common/FileUtil.h"
-#include "Common/IniFile.h"
-#include "Common/Logging/Log.h"
-
-#include "Core/ConfigLoaders/NetPlayConfigLoader.h"
 #include "Core/NetPlayProto.h"
 
 namespace ConfigLoaders

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/ConfigManager.h"
+
 #include <cinttypes>
 #include <climits>
 #include <memory>
@@ -24,8 +26,6 @@
 
 #include "Core/Analytics.h"
 #include "Core/Boot/Boot.h"
-#include "Core/Config/Config.h"
-#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
 #include "Core/HLE/HLE.h"

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -415,6 +415,9 @@
     <ClInclude Include="HW\SystemTimers.h" />
     <ClInclude Include="HW\VideoInterface.h" />
     <ClInclude Include="HW\Wiimote.h" />
+    <ClInclude Include="HW\WiimoteCommon\WiimoteConstants.h" />
+    <ClInclude Include="HW\WiimoteCommon\WiimoteHid.h" />
+    <ClInclude Include="HW\WiimoteCommon\WiimoteReport.h" />
     <ClInclude Include="HW\WiimoteEmu\Attachment\Attachment.h" />
     <ClInclude Include="HW\WiimoteEmu\Attachment\Classic.h" />
     <ClInclude Include="HW\WiimoteEmu\Attachment\Drums.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -160,6 +160,9 @@
     <Filter Include="PowerPC\SignatureDB">
       <UniqueIdentifier>{f0b52c84-49f4-470a-b037-edeea5634b9e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="HW %28Flipper/Hollywood%29\WiimoteCommon">
+      <UniqueIdentifier>{ee6645da-3ad9-4fe7-809f-e4646d0b0ca5}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BootManager.cpp" />
@@ -1525,6 +1528,15 @@
     </ClInclude>
     <ClInclude Include="IOS\Network\NCD\WiiNetConfig.h">
       <Filter>IOS\Network\NCD</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\WiimoteCommon\WiimoteConstants.h">
+      <Filter>HW %28Flipper/Hollywood%29\WiimoteCommon</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\WiimoteCommon\WiimoteHid.h">
+      <Filter>HW %28Flipper/Hollywood%29\WiimoteCommon</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\WiimoteCommon\WiimoteReport.h">
+      <Filter>HW %28Flipper/Hollywood%29\WiimoteCommon</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/CoreTiming.h"
+
 #include <algorithm>
 #include <cinttypes>
 #include <mutex>
@@ -18,7 +20,6 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
-#include "Core/CoreTiming.h"
 #include "Core/PowerPC/PowerPC.h"
 
 #include "VideoCommon/Fifo.h"

--- a/Source/Core/Core/DSP/DSPCaptureLogger.cpp
+++ b/Source/Core/Core/DSP/DSPCaptureLogger.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/DSP/DSPCaptureLogger.h"
+
 #include <cstring>
 #include <memory>
 #include <string>
@@ -9,8 +11,6 @@
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
 #include "Common/PcapFile.h"
-
-#include "Core/DSP/DSPCaptureLogger.h"
 
 namespace DSP
 {

--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/DSP/DSPCodeUtil.h"
+
 #include <algorithm>
 #include <iostream>
 #include <string>
@@ -14,7 +16,6 @@
 #include "Common/Swap.h"
 
 #include "Core/DSP/DSPAssembler.h"
-#include "Core/DSP/DSPCodeUtil.h"
 #include "Core/DSP/DSPDisassembler.h"
 
 namespace DSP

--- a/Source/Core/Core/DSPEmulator.cpp
+++ b/Source/Core/Core/DSPEmulator.cpp
@@ -2,11 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/DSPEmulator.h"
+
 #include <memory>
 
-#include "Core/DSPEmulator.h"
 #include "Core/HW/DSPHLE/DSPHLE.h"
-#include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/DSPLLE/DSPLLE.h"
 
 std::unique_ptr<DSPEmulator> CreateDSPEmulator(bool hle)

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/Debugger/Debugger_SymbolMap.h"
+
 #include <cstdio>
 #include <functional>
 #include <string>
@@ -10,7 +12,6 @@
 #include "Common/StringUtil.h"
 
 #include "Core/Core.h"
-#include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PPCSymbolDB.h"

--- a/Source/Core/Core/Debugger/Dump.cpp
+++ b/Source/Core/Core/Debugger/Dump.cpp
@@ -2,13 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/Debugger/Dump.h"
+
 #include <cstdio>
 #include <string>
 
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
-
-#include "Core/Debugger/Dump.h"
 
 CDump::CDump(const std::string& filename) : m_pData(nullptr)
 {

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -12,7 +12,6 @@
 
 #include "Core/Core.h"
 #include "Core/HW/DSP.h"
-#include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/FifoPlayer/FifoDataFile.h"
+
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -9,8 +11,6 @@
 #include <vector>
 
 #include "Common/File.h"
-
-#include "Core/FifoPlayer/FifoDataFile.h"
 
 enum
 {

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -2,10 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/FifoPlayer/FifoPlayer.h"
+
 #include <algorithm>
 #include <mutex>
-
-#include "Core/FifoPlayer/FifoPlayer.h"
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -2,10 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/FifoPlayer/FifoRecordAnalyzer.h"
+
 #include <algorithm>
 #include <cstring>
-
-#include "Core/FifoPlayer/FifoRecordAnalyzer.h"
 
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoRecorder.h"

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -2,11 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/FifoPlayer/FifoRecorder.h"
+
 #include <algorithm>
 #include <cstring>
 #include <mutex>
-
-#include "Core/FifoPlayer/FifoRecorder.h"
 
 #include "Common/MsgHandler.h"
 #include "Common/Thread.h"

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/GeckoCode.h"
+
 #include <algorithm>
 #include <iterator>
 #include <mutex>
@@ -13,7 +15,6 @@
 #include "Common/FileUtil.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/GeckoCode.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/PowerPC.h"
 

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -2,16 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HLE/HLE.h"
+
 #include <algorithm>
 #include <map>
 
 #include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
-#include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/GeckoCode.h"
-#include "Core/HLE/HLE.h"
 #include "Core/HLE/HLE_Misc.h"
 #include "Core/HLE/HLE_OS.h"
 #include "Core/HW/Memmap.h"

--- a/Source/Core/Core/HLE/HLE_Misc.cpp
+++ b/Source/Core/Core/HLE/HLE_Misc.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/HLE/HLE_Misc.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HLE/HLE_OS.h"
+
 #include <memory>
 #include <string>
 
@@ -9,9 +11,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
-#include "Core/HLE/HLE_OS.h"
 #include "Core/HLE/HLE_VarArgs.h"
-#include "Core/HW/Memmap.h"
 #include "Core/PowerPC/PowerPC.h"
 
 namespace HLE_OS

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -37,13 +37,14 @@ This file mainly deals with the [Drive I/F], however [AIDFR] controls
   TODO maybe the files should be merged?
 */
 
+#include "Core/HW/AudioInterface.h"
+
 #include <algorithm>
 
 #include "AudioCommon/AudioCommon.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Core/CoreTiming.h"
-#include "Core/HW/AudioInterface.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SystemTimers.h"

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -2,17 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/CPU.h"
+
 #include <condition_variable>
 #include <mutex>
 
 #include "AudioCommon/AudioCommon.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
-#include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Core/Core.h"
-#include "Core/HW/CPU.h"
-#include "Core/HW/Memmap.h"
 #include "Core/Host.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "VideoCommon/Fifo.h"

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -22,6 +22,8 @@
 // the just used buffer through the AXList (or whatever it might be called in
 // Nintendo games).
 
+#include "Core/HW/DSP.h"
+
 #include <memory>
 
 #include "AudioCommon/AudioCommon.h"
@@ -31,11 +33,10 @@
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/DSPEmulator.h"
-#include "Core/HW/DSP.h"
+
 #include "Core/HW/MMIO.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/ProcessorInterface.h"
-#include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 
 namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -2,13 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <iostream>
+#include "Core/HW/DSPHLE/DSPHLE.h"
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 #include "Core/Core.h"
-#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/SystemTimers.h"
 
@@ -16,9 +15,9 @@ namespace DSP
 {
 namespace HLE
 {
-DSPHLE::DSPHLE()
-{
-}
+DSPHLE::DSPHLE() = default;
+
+DSPHLE::~DSPHLE() = default;
 
 bool DSPHLE::Initialize(bool wii, bool dsp_thread)
 {

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -23,6 +23,7 @@ class DSPHLE : public DSPEmulator
 {
 public:
   DSPHLE();
+  ~DSPHLE();
 
   bool Initialize(bool wii, bool dsp_thread) override;
   void Shutdown() override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -12,11 +12,8 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
-#include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/Logging/Log.h"
-#include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/DSP/DSPCodeUtil.h"
 #include "Core/HW/DSPHLE/DSPHLE.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -14,11 +14,8 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
-#include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/Logging/Log.h"
-#include "Common/StringUtil.h"
 #include "Common/Swap.h"
 #include "Core/ConfigManager.h"
 #include "Core/DSP/DSPCodeUtil.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
@@ -2,13 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/DSPLLE/DSPLLEGlobals.h"
+
 #include <cinttypes>
 
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
 
 #include "Core/DSP/DSPCore.h"
-#include "Core/HW/DSPLLE/DSPLLEGlobals.h"
 
 namespace DSP
 {

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -2,10 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/DSPLLE/DSPSymbols.h"
+
 #include <cctype>
 #include <list>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
@@ -13,7 +16,6 @@
 
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPDisassembler.h"
-#include "Core/HW/DSPLLE/DSPSymbols.h"
 
 namespace DSP
 {

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/DVD/DVDInterface.h"
+
 #include <algorithm>
 #include <cinttypes>
 #include <memory>
@@ -20,7 +22,6 @@
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/AudioInterface.h"
-#include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/DVD/DVDMath.h"
 #include "Core/HW/DVD/DVDThread.h"
 #include "Core/HW/MMIO.h"

--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>

--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/DVD/DVDThread.h"
+
 #include <cinttypes>
 #include <map>
 #include <memory>
@@ -25,7 +27,6 @@
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/DVD/DVDInterface.h"
-#include "Core/HW/DVD/DVDThread.h"
 #include "Core/HW/DVD/FileMonitor.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -31,7 +31,6 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/Movie.h"
 #include "DiscIO/Enums.h"
-#include "DiscIO/NANDContentLoader.h"
 
 namespace ExpansionInterface
 {

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/EXI/EXI_DeviceMic.h"
+
 #include <algorithm>
 #include <cstring>
 #include <mutex>
@@ -12,8 +14,6 @@
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-
-#include "Core/HW/EXI/EXI_DeviceMic.h"
 
 #include "Core/CoreTiming.h"
 #include "Core/HW/EXI/EXI.h"

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <mutex>
-#include "Common/Common.h"
+
+#include "Common/CommonTypes.h"
 #include "Core/HW/EXI/EXI_Device.h"
 
 struct cubeb;

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -2,11 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/HW.h"
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/AudioInterface.h"
 #include "Core/HW/CPU.h"
@@ -14,7 +15,6 @@
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/GPFifo.h"
-#include "Core/HW/HW.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI/SI.h"
@@ -22,7 +22,6 @@
 #include "Core/HW/VideoInterface.h"
 #include "Core/HW/WII_IPC.h"
 #include "Core/IOS/IOS.h"
-#include "Core/Movie.h"
 #include "Core/State.h"
 
 namespace HW

--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -2,11 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/MMIO.h"
+
 #include <functional>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
-#include "Core/HW/MMIO.h"
 #include "Core/HW/MMIOHandlers.h"
 
 namespace MMIO

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -7,6 +7,8 @@
 // However, if a JITed instruction (for example lwz) wants to access a bad memory area that call
 // may be redirected here (for example to Read_U32()).
 
+#include "Core/HW/Memmap.h"
+
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -22,7 +24,6 @@
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/MMIO.h"
-#include "Core/HW/Memmap.h"
 #include "Core/HW/MemoryInterface.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI/SI.h"

--- a/Source/Core/Core/HW/MemoryInterface.cpp
+++ b/Source/Core/Core/HW/MemoryInterface.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/MemoryInterface.h"
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Core/HW/MMIO.h"

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/ProcessorInterface.h"
+
 #include <cstdio>
 #include <memory>
 
@@ -10,7 +12,6 @@
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/MMIO.h"
-#include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/STM/STM.h"

--- a/Source/Core/Core/HW/ProcessorInterface.h
+++ b/Source/Core/Core/HW/ProcessorInterface.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+
 class PointerWrap;
 
 namespace MMIO

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -7,8 +7,6 @@
 #include <cstring>
 
 #include "Common/CommonTypes.h"
-#include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/GCPad.h"

--- a/Source/Core/Core/HW/StreamADPCM.cpp
+++ b/Source/Core/Core/HW/StreamADPCM.cpp
@@ -5,6 +5,7 @@
 // Adapted from in_cube by hcs & destop
 
 #include "Core/HW/StreamADPCM.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -44,6 +44,7 @@ IPC_HLE_PERIOD: For the Wii Remote this is the call schedule:
 */
 
 #include "Core/HW/SystemTimers.h"
+
 #include "Common/Atomic.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/WII_IPC.h"
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
@@ -6,8 +6,8 @@
 
 #include "Common/CommonTypes.h"
 
-// what is this ?
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4200)
 #endif
 
@@ -32,3 +32,7 @@ constexpr u8 HID_PARAM_INPUT = 1;
 constexpr u8 HID_PARAM_OUTPUT = 2;
 
 #pragma pack(pop)
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
@@ -8,6 +8,11 @@
 
 #include "Common/CommonTypes.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+
 typedef std::vector<u8> Report;
 
 // Report defines
@@ -498,3 +503,7 @@ struct wm_speaker_data
 };
 static_assert(sizeof(wm_speaker_data) == 21, "Wrong size");
 #pragma pack(pop)
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
@@ -4,10 +4,11 @@
 //
 // Copyright (C) Hector Martin "marcan" (hector@marcansoft.com)
 
+#include "Core/HW/WiimoteEmu/Encryption.h"
+
 #include <cstring>
 
 #include "Common/CommonTypes.h"
-#include "Core/HW/WiimoteEmu/Encryption.h"
 
 static const u8 ans_tbl[7][6] = {
     {0xA8, 0x77, 0xA6, 0xE0, 0xF7, 0x43}, {0x5A, 0x35, 0x85, 0xE2, 0x72, 0x97},

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -16,7 +16,6 @@
 #include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
-#include "InputCommon/ControllerEmu/Setting/BooleanSetting.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCPadStatus.h"
 

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/DI/DI.h"
+
 #include <cinttypes>
 #include <memory>
 #include <vector>
@@ -14,7 +16,6 @@
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/DVD/DVDThread.h"
 #include "Core/HW/Memmap.h"
-#include "Core/IOS/DI/DI.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
 #include "DiscIO/Volume.h"

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/Device.h"
+
 #include <algorithm>
 #include <map>
 
@@ -9,7 +11,6 @@
 #include "Common/StringUtil.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
-#include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/DeviceStub.cpp
+++ b/Source/Core/Core/IOS/DeviceStub.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/IOS/DeviceStub.h"
+
 #include "Common/Logging/Log.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -7,7 +7,6 @@
 #include <cstring>
 #include <vector>
 
-#include "Common/Assert.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"

--- a/Source/Core/Core/IOS/ES/TitleInformation.cpp
+++ b/Source/Core/Core/IOS/ES/TitleInformation.cpp
@@ -9,13 +9,9 @@
 #include <string>
 #include <vector>
 
-#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
-#include "Common/NandPaths.h"
-#include "Common/StringUtil.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
-#include "DiscIO/NANDContentLoader.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/FS/FS.cpp
+++ b/Source/Core/Core/IOS/FS/FS.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/FS/FS.h"
+
 #include <algorithm>
 #include <cstring>
 #include <deque>
@@ -17,10 +19,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
-#include "Common/StringUtil.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
-#include "Core/IOS/FS/FS.h"
 #include "Core/IOS/FS/FileIO.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/FS/FileIO.h"
+
 #include <cinttypes>
 #include <cstdio>
 #include <map>
@@ -15,7 +17,6 @@
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
 #include "Core/HW/Memmap.h"
-#include "Core/IOS/FS/FileIO.h"
 #include "Core/IOS/IOS.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/IOSC.h"
+
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -21,7 +23,6 @@
 #include "Common/ScopeGuard.h"
 #include "Common/Swap.h"
 #include "Core/IOS/Device.h"
-#include "Core/IOS/IOSC.h"
 #include "Core/ec_wii.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/MIOS.h"
+
 #include <cstring>
 #include <utility>
 #include <vector>
@@ -22,11 +24,9 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/ES/Formats.h"
-#include "Core/IOS/MIOS.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "DiscIO/NANDContentLoader.h"
-#include "DiscIO/Volume.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/Network/SSL.h"
+
 #include <array>
 #include <cstring>
 #include <memory>
@@ -17,7 +19,6 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
-#include "Core/IOS/Network/SSL.h"
 #include "Core/IOS/Network/Socket.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+// No Wii socket support while using NetPlay or TAS
+#include "Core/IOS/Network/Socket.h"
+
 #include <algorithm>
 #include <mbedtls/error.h>
 #ifndef _WIN32
@@ -18,7 +21,6 @@
 #include "Core/Core.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
-#include "Core/IOS/Network/Socket.h"  // No Wii socket support while using NetPlay or TAS
 
 #ifdef _WIN32
 #define ERRORCODE(name) WSA##name

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/SDIO/SDIOSlot0.h"
+
 #include <cstdio>
 #include <cstring>
 #include <memory>
@@ -16,7 +18,6 @@
 #include "Core/ConfigManager.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/IOS.h"
-#include "Core/IOS/SDIO/SDIOSlot0.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -7,7 +7,6 @@
 #include <functional>
 #include <memory>
 
-#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/USB/Bluetooth/BTEmu.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -9,7 +11,6 @@
 #include <string>
 
 #include "Common/Assert.h"
-#include "Common/CommonPaths.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
@@ -24,7 +25,6 @@
 #include "Core/Host.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
-#include "Core/IOS/USB/Bluetooth/BTEmu.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/USB/Bluetooth/BTReal.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -16,7 +18,6 @@
 
 #include <libusb.h>
 
-#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -28,7 +29,6 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
-#include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/IOS/USB/Bluetooth/hci.h"
 #include "VideoCommon/OnScreenDisplay.h"
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
+
 #include <cstring>
 #include <memory>
 #include <utility>
@@ -17,7 +19,6 @@
 #include "Core/HW/Wiimote.h"
 #include "Core/Host.h"
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
-#include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
 #include "Core/IOS/USB/Bluetooth/WiimoteHIDAttr.h"
 #include "Core/IOS/USB/Bluetooth/l2cap.h"
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/IOS/USB/Bluetooth/WiimoteHIDAttr.h"
+
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/USB/Host.h"
+
 #include <algorithm>
 #include <memory>
 #include <mutex>
@@ -21,7 +23,6 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IOS/USB/Common.h"
-#include "Core/IOS/USB/Host.h"
 #include "Core/IOS/USB/LibusbDevice.h"
 
 namespace IOS

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/USB/LibusbDevice.h"
+
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
@@ -16,11 +18,9 @@
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
-#include "Core/CoreTiming.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
-#include "Core/IOS/USB/LibusbDevice.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/USB/OH0/OH0Device.h"
+
 #include <memory>
 #include <sstream>
 #include <string>
@@ -11,7 +13,6 @@
 #include "Common/ChunkFile.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/OH0/OH0.h"
-#include "Core/IOS/USB/OH0/OH0Device.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/IOS/USB/USBV5.h"
+
 #include <cstddef>
 #include <numeric>
 #include <vector>
@@ -9,7 +11,6 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
-#include "Core/IOS/USB/USBV5.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -39,20 +39,17 @@
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/Wiimote.h"
-#include "Core/HW/WiimoteCommon/WiimoteHid.h"
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
 #include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
 #include "Core/NetPlayProto.h"
-#include "Core/PowerPC/PowerPC.h"
 #include "Core/State.h"
 
 #include "DiscIO/Enums.h"
 
 #include "InputCommon/GCPadStatus.h"
 
-#include "VideoCommon/Fifo.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -15,12 +15,10 @@
 #include "Common/Common.h"
 #include "Common/ENetUtil.h"
 #include "Common/FileUtil.h"
-#include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
-#include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/Sram.h"
 #include "Core/NetPlayClient.h"  //for NetPlayUI
 #include "InputCommon/GCPadStatus.h"

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -6,6 +6,8 @@
 // Supports simple memory patches, and has a partial Action Replay implementation
 // in ActionReplay.cpp/h.
 
+#include "Core/PatchEngine.h"
+
 #include <algorithm>
 #include <map>
 #include <set>
@@ -20,7 +22,6 @@
 #include "Core/ConfigManager.h"
 #include "Core/GeckoCode.h"
 #include "Core/GeckoCodeConfig.h"
-#include "Core/PatchEngine.h"
 #include "Core/PowerPC/PowerPC.h"
 
 namespace PatchEngine

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/PowerPC/CachedInterpreter/CachedInterpreter.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/PowerPC/CachedInterpreter/InterpreterBlockCache.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/InterpreterBlockCache.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/PowerPC/CachedInterpreter/InterpreterBlockCache.h"
+
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
 BlockCache::BlockCache(JitBase& jit) : JitBaseBlockCache{jit}

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/Interpreter/Interpreter.h"
+
 #include <array>
 #include <cassert>
 #include <cinttypes>
@@ -18,7 +20,6 @@
 #include "Core/HLE/HLE.h"
 #include "Core/HW/CPU.h"
 #include "Core/Host.h"
-#include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/PPCTables.h"
 #include "Core/PowerPC/PowerPC.h"
 

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/PowerPC/Jit64/JitAsm.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/JitRegister.h"
 #include "Common/x64ABI.h"

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/Jit64/JitRegCache.h"
+
 #include <algorithm>
 #include <cinttypes>
 #include <cmath>
@@ -13,7 +15,6 @@
 #include "Common/MsgHandler.h"
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/Jit64/Jit.h"
-#include "Core/PowerPC/Jit64/JitRegCache.h"
 #include "Core/PowerPC/PowerPC.h"
 
 using namespace Gen;

--- a/Source/Core/Core/PowerPC/Jit64Common/ConstantPool.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/ConstantPool.cpp
@@ -2,12 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/Jit64Common/ConstantPool.h"
+
 #include <cstring>
 #include <memory>
 #include <utility>
 
 #include "Common/Assert.h"
-#include "Core/PowerPC/Jit64Common/ConstantPool.h"
 
 ConstantPool::ConstantPool() = default;
 

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -6,7 +6,6 @@
 
 #include <array>
 
-#include "Common/Assert.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/JitRegister.h"

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -14,7 +14,6 @@
 #include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 #include "Core/PowerPC/Jit64Common/TrampolineInfo.h"
-#include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PowerPC.h"
 
 #ifdef _WIN32

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -11,7 +11,6 @@
 #include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/MMIO.h"

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/PPCAnalyst.h"
+
 #include <algorithm>
 #include <map>
 #include <queue>
@@ -13,8 +15,6 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
-#include "Core/PowerPC/JitCommon/JitCache.h"
-#include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PPCTables.h"
 #include "Core/PowerPC/PowerPC.h"

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/PPCSymbolDB.h"
+
 #include <map>
 #include <string>
 #include <utility>
@@ -11,9 +13,7 @@
 #include "Common/File.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
-#include "Common/StringUtil.h"
 #include "Core/PowerPC/PPCAnalyst.h"
-#include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/SignatureDB/SignatureDB.h"
 

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -19,7 +19,6 @@
 #include "Common/StringUtil.h"
 
 #include "Core/PowerPC/Interpreter/Interpreter.h"
-#include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 
 std::array<GekkoOPInfo*, 64> m_infoTable;

--- a/Source/Core/Core/PowerPC/Profiler.cpp
+++ b/Source/Core/Core/PowerPC/Profiler.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/PowerPC/Profiler.h"
+
 #include <string>
 #include "Core/PowerPC/JitInterface.h"
 

--- a/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/SignatureDB/CSVSignatureDB.h"
+
 #include <cstdio>
 #include <fstream>
 #include <sstream>
@@ -9,8 +11,6 @@
 #include "Common/File.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
-
-#include "Core/PowerPC/SignatureDB/CSVSignatureDB.h"
 
 // CSV separated with tabs
 // Checksum | Size | Symbol | [Object Location |] Object Name

--- a/Source/Core/Core/PowerPC/SignatureDB/DSYSignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/DSYSignatureDB.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/SignatureDB/DSYSignatureDB.h"
+
 #include <cstddef>
 #include <cstring>
 #include <string>
@@ -9,8 +11,6 @@
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
 #include "Common/Logging/Log.h"
-
-#include "Core/PowerPC/SignatureDB/DSYSignatureDB.h"
 
 namespace
 {

--- a/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
@@ -2,16 +2,16 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/SignatureDB/SignatureDB.h"
+
 #include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
-#include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
-#include "Core/PowerPC/SignatureDB/SignatureDB.h"
 
 // Format Handlers
 #include "Core/PowerPC/SignatureDB/CSVSignatureDB.h"

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/State.h"
+
 #include <lzo/lzo1x.h>
 #include <map>
 #include <mutex>
@@ -31,7 +33,6 @@
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"
 #include "Core/PowerPC/PowerPC.h"
-#include "Core/State.h"
 
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/OnScreenDisplay.h"

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -2,13 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/TitleDatabase.h"
+
 #include <cstddef>
 #include <fstream>
 #include <functional>
 #include <unordered_map>
 #include <utility>
-
-#include "Core/TitleDatabase.h"
 
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"


### PR DESCRIPTION
So, this is kind of a three-fold-PR:

- WiimoteCommon headers weren't in the VS project, so shuffling the headers around caused build failures due to those headers using a non-standard extension.
- Moves a cpp file's header to the top of the inclusions if not already there (normalizing include order across Core).
- Removes unnecessary headers.


