### PR TITLE
Boot: Check TMD validity before reading from TMD

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -343,6 +343,9 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::Volume* volume)
   const DiscIO::Partition partition = volume->GetGamePartition();
   const IOS::ES::TMDReader tmd = volume->GetTMD(partition);
 
+  if (!tmd.IsValid())
+    return false;
+
   if (!SetupWiiMemory(volume, tmd.GetIOSId()))
     return false;
 


### PR DESCRIPTION
Otherwise Dolphin crashes when trying to boot a Wii game with an invalid TMD.