### PR TITLE
FilesystemPanel: Expand game partition rather than second partition

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
@@ -215,7 +215,7 @@ bool FilesystemPanel::PopulateFileSystemTree()
         m_tree_ctrl->SetItemData(partition_root, partition);
         CreateDirectoryTree(m_tree_ctrl, partition_root, partition->filesystem->GetFileList());
 
-        if (i == 1)
+        if (partitions[i] == m_opened_iso->GetGamePartition())
           m_tree_ctrl->Expand(partition_root);
       }
     }


### PR DESCRIPTION
The game partition is normally the second partition, but not if the disc has been scrubbed to only contain one partition.