### PR TITLE
Vulkan: Don't transition image layouts inside render passes

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -87,7 +87,10 @@ private:
   bool CompileShaders();
   void DestroyShaders();
 
-  void ResolveEFBForSwap(const TargetRectangle& scaled_rect);
+  // Transitions EFB/XFB buffers to SHADER_READ_ONLY, ready for presenting/dumping.
+  // If MSAA is enabled, and XFB is disabled, also resolves the EFB buffer.
+  void TransitionBuffersForSwap(const TargetRectangle& scaled_rect,
+                                const XFBSourceBase* const* xfb_sources, u32 xfb_count);
 
   // Draw either the EFB, or specified XFB sources to the currently-bound framebuffer.
   void DrawFrame(VkRenderPass render_pass, const TargetRectangle& target_rect,

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -416,7 +416,8 @@ bool TextureConverter::SupportsTextureDecoding(TextureFormat format, TlutFormat 
   return true;
 }
 
-void TextureConverter::DecodeTexture(TextureCache::TCacheEntry* entry, u32 dst_level,
+void TextureConverter::DecodeTexture(VkCommandBuffer command_buffer,
+                                     TextureCache::TCacheEntry* entry, u32 dst_level,
                                      const u8* data, size_t data_size, TextureFormat format,
                                      u32 width, u32 height, u32 aligned_width, u32 aligned_height,
                                      u32 row_stride, const u8* palette, TlutFormat palette_format)
@@ -497,11 +498,6 @@ void TextureConverter::DecodeTexture(TextureCache::TCacheEntry* entry, u32 dst_l
   default:
     break;
   }
-
-  // Place compute shader dispatches together in the init command buffer.
-  // That way we don't have to pay a penalty for switching from graphics->compute,
-  // or end/restart our render pass.
-  VkCommandBuffer command_buffer = g_command_buffer_mgr->GetCurrentInitCommandBuffer();
 
   // Dispatch compute to temporary texture.
   ComputeShaderDispatcher dispatcher(command_buffer,

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -49,10 +49,10 @@ public:
                                    u32 src_width, u32 src_stride, u32 src_height);
 
   bool SupportsTextureDecoding(TextureFormat format, TlutFormat palette_format);
-  void DecodeTexture(TextureCache::TCacheEntry* entry, u32 dst_level, const u8* data,
-                     size_t data_size, TextureFormat format, u32 width, u32 height,
-                     u32 aligned_width, u32 aligned_height, u32 row_stride, const u8* palette,
-                     TlutFormat palette_format);
+  void DecodeTexture(VkCommandBuffer command_buffer, TextureCache::TCacheEntry* entry,
+                     u32 dst_level, const u8* data, size_t data_size, TextureFormat format,
+                     u32 width, u32 height, u32 aligned_width, u32 aligned_height, u32 row_stride,
+                     const u8* palette, TlutFormat palette_format);
 
 private:
   static const u32 ENCODING_TEXTURE_WIDTH = EFB_WIDTH * 4;


### PR DESCRIPTION
This is against the spec, and detected by recent versions of the validation layers (see section 6.6 of the spec).