### PR TITLE
VideoConfigDiag: Refresh VideoConfig before opening configuration dialog

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -375,6 +375,8 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
                                                   wxGetTranslation(StrToWxStr(title)))),
       vconfig(g_Config)
 {
+  vconfig.Refresh();
+
   Bind(wxEVT_UPDATE_UI, &VideoConfigDiag::OnUpdateUI, this);
 
   wxNotebook* const notebook = new wxNotebook(this, wxID_ANY);


### PR DESCRIPTION
If the video configuration dialog is opened before a game was run, VideoConfig::Refresh was never called.

This results in:
(a) incorrect settings being shown, and
(b) the configuration change callback never being registered.

Went to check why this wasn't a problem previously, it was because I had removed [this line](https://github.com/dolphin-emu/dolphin/pull/5418/files#diff-39ba00c1eb8ac062f9ee51dad8ad9314L362) without replacing it with anything that loads the settings.