### PR TITLE
Config: Remove creation of unnecessary CommandLine layer

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -92,7 +92,6 @@ void Save()
 void Init()
 {
   // These layers contain temporary values
-  s_layers[LayerType::CommandLine] = std::make_unique<Layer>(LayerType::CommandLine);
   ClearCurrentRunLayer();
   // This layer always has to exist
   s_layers[LayerType::Meta] = std::make_unique<RecursiveLayer>();


### PR DESCRIPTION
`CommandLineConfigLayerLoader` already exists in `CommandLineParse.cpp`.

Setting video configuration options from the command line now works.

e.g.:

    ./Dolphin --config=Graphics.Settings.ShowFPS=true