### PR TITLE
Cleanup Projection Hack

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -128,8 +128,10 @@ const ConfigInfo<bool> GFX_HACK_VERTEX_ROUDING{{System::GFX, "Hacks", "VertexRou
 const ConfigInfo<int> GFX_PROJECTION_HACK{{System::GFX, "GameSpecific", "ProjectionHack"}, 0};
 const ConfigInfo<int> GFX_PROJECTION_HACK_SZNEAR{{System::GFX, "GameSpecific", "PH_SZNear"}, 0};
 const ConfigInfo<int> GFX_PROJECTION_HACK_SZFAR{{System::GFX, "GameSpecific", "PH_SZFar"}, 0};
-const ConfigInfo<int> GFX_PROJECTION_HACK_ZNEAR{{System::GFX, "GameSpecific", "PH_ZNear"}, 0};
-const ConfigInfo<int> GFX_PROJECTION_HACK_ZFAR{{System::GFX, "GameSpecific", "PH_ZFar"}, 0};
+const ConfigInfo<std::string> GFX_PROJECTION_HACK_ZNEAR{{System::GFX, "GameSpecific", "PH_ZNear"},
+                                                        ""};
+const ConfigInfo<std::string> GFX_PROJECTION_HACK_ZFAR{{System::GFX, "GameSpecific", "PH_ZFar"},
+                                                       ""};
 const ConfigInfo<bool> GFX_PERF_QUERIES_ENABLE{{System::GFX, "GameSpecific", "PerfQueriesEnable"},
                                                false};
 }  // namespace Config

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -101,8 +101,8 @@ extern const ConfigInfo<bool> GFX_HACK_VERTEX_ROUDING;
 extern const ConfigInfo<int> GFX_PROJECTION_HACK;
 extern const ConfigInfo<int> GFX_PROJECTION_HACK_SZNEAR;
 extern const ConfigInfo<int> GFX_PROJECTION_HACK_SZFAR;
-extern const ConfigInfo<int> GFX_PROJECTION_HACK_ZNEAR;
-extern const ConfigInfo<int> GFX_PROJECTION_HACK_ZFAR;
+extern const ConfigInfo<std::string> GFX_PROJECTION_HACK_ZNEAR;
+extern const ConfigInfo<std::string> GFX_PROJECTION_HACK_ZFAR;
 extern const ConfigInfo<bool> GFX_PERF_QUERIES_ENABLE;
 
 }  // namespace Config

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -50,7 +50,7 @@
 
 void VideoConfig::UpdateProjectionHack()
 {
-  ::UpdateProjectionHack(g_Config.iPhackvalue, g_Config.sPhackvalue);
+  ::UpdateProjectionHack(g_Config.phack);
 }
 
 namespace OGL

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -56,8 +56,8 @@ struct ProjectionHack
 namespace
 {
 // Control Variables
-static ProjectionHack g_ProjHack1;
-static ProjectionHack g_ProjHack2;
+static ProjectionHack g_proj_hack_near;
+static ProjectionHack g_proj_hack_far;
 }  // Namespace
 
 static float PHackValue(std::string sValue)
@@ -92,31 +92,39 @@ static float PHackValue(std::string sValue)
   return f;
 }
 
-void UpdateProjectionHack(int iPhackvalue[], std::string sPhackvalue[])
+void UpdateProjectionHack(const ProjectionHackConfig& config)
 {
-  float fhackvalue1 = 0, fhackvalue2 = 0;
-  float fhacksign1 = 1.0, fhacksign2 = 1.0;
-  const char* sTemp[2];
+  float near_value = 0, far_value = 0;
+  float near_sign = 1.0, far_sign = 1.0;
 
-  if (iPhackvalue[0] == 1)
+  if (config.m_enable)
   {
+    const char* near_sign_str = "";
+    const char* far_sign_str = "";
+
     NOTICE_LOG(VIDEO, "\t\t--- Orthographic Projection Hack ON ---");
 
-    fhacksign1 *= (iPhackvalue[1] == 1) ? -1.0f : fhacksign1;
-    sTemp[0] = (iPhackvalue[1] == 1) ? " * (-1)" : "";
-    fhacksign2 *= (iPhackvalue[2] == 1) ? -1.0f : fhacksign2;
-    sTemp[1] = (iPhackvalue[2] == 1) ? " * (-1)" : "";
+    if (config.m_sznear)
+    {
+      near_sign *= -1.0f;
+      near_sign_str = " * (-1)";
+    }
+    if (config.m_szfar)
+    {
+      far_sign *= -1.0f;
+      far_sign_str = " * (-1)";
+    }
 
-    fhackvalue1 = PHackValue(sPhackvalue[0]);
-    NOTICE_LOG(VIDEO, "- zNear Correction = (%f + zNear)%s", fhackvalue1, sTemp[0]);
+    near_value = PHackValue(config.m_znear);
+    NOTICE_LOG(VIDEO, "- zNear Correction = (%f + zNear)%s", near_value, near_sign_str);
 
-    fhackvalue2 = PHackValue(sPhackvalue[1]);
-    NOTICE_LOG(VIDEO, "- zFar Correction =  (%f + zFar)%s", fhackvalue2, sTemp[1]);
+    far_value = PHackValue(config.m_zfar);
+    NOTICE_LOG(VIDEO, "- zFar Correction =  (%f + zFar)%s", far_value, far_sign_str);
   }
 
   // Set the projections hacks
-  g_ProjHack1 = ProjectionHack(fhacksign1, fhackvalue1);
-  g_ProjHack2 = ProjectionHack(fhacksign2, fhackvalue2);
+  g_proj_hack_near = ProjectionHack(near_sign, near_value);
+  g_proj_hack_far = ProjectionHack(far_sign, far_value);
 }
 
 // Viewport correction:
@@ -485,10 +493,10 @@ void VertexShaderManager::SetConstants()
 
       g_fProjectionMatrix[8] = 0.0f;
       g_fProjectionMatrix[9] = 0.0f;
-      g_fProjectionMatrix[10] = (g_ProjHack1.value + rawProjection[4]) *
-                                ((g_ProjHack1.sign == 0) ? 1.0f : g_ProjHack1.sign);
-      g_fProjectionMatrix[11] = (g_ProjHack2.value + rawProjection[5]) *
-                                ((g_ProjHack2.sign == 0) ? 1.0f : g_ProjHack2.sign);
+      g_fProjectionMatrix[10] = (g_proj_hack_near.value + rawProjection[4]) *
+                                ((g_proj_hack_near.sign == 0) ? 1.0f : g_proj_hack_near.sign);
+      g_fProjectionMatrix[11] = (g_proj_hack_far.value + rawProjection[5]) *
+                                ((g_proj_hack_far.sign == 0) ? 1.0f : g_proj_hack_far.sign);
 
       g_fProjectionMatrix[12] = 0.0f;
       g_fProjectionMatrix[13] = 0.0f;

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -10,8 +10,9 @@
 #include "VideoCommon/ConstantManager.h"
 
 class PointerWrap;
+struct ProjectionHackConfig;
 
-void UpdateProjectionHack(int iParams[], std::string sParams[]);
+void UpdateProjectionHack(const ProjectionHackConfig& config);
 
 // The non-API dependent parts.
 class VertexShaderManager

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -124,11 +124,11 @@ void VideoConfig::Refresh()
   bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
   bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
 
-  iPhackvalue[0] = Config::Get(Config::GFX_PROJECTION_HACK);
-  iPhackvalue[1] = Config::Get(Config::GFX_PROJECTION_HACK_SZNEAR);
-  iPhackvalue[2] = Config::Get(Config::GFX_PROJECTION_HACK_SZFAR);
-  sPhackvalue[0] = Config::Get(Config::GFX_PROJECTION_HACK_ZNEAR);
-  sPhackvalue[1] = Config::Get(Config::GFX_PROJECTION_HACK_ZFAR);
+  phack.m_enable = Config::Get(Config::GFX_PROJECTION_HACK) == 1;
+  phack.m_sznear = Config::Get(Config::GFX_PROJECTION_HACK_SZNEAR) == 1;
+  phack.m_szfar = Config::Get(Config::GFX_PROJECTION_HACK_SZFAR) == 1;
+  phack.m_znear = Config::Get(Config::GFX_PROJECTION_HACK_ZNEAR);
+  phack.m_zfar = Config::Get(Config::GFX_PROJECTION_HACK_ZFAR);
   bPerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);
 
   if (iEFBScale == SCALE_FORCE_INTEGRAL)

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -50,6 +50,15 @@ enum StereoMode
   STEREO_3DVISION
 };
 
+struct ProjectionHackConfig final
+{
+  bool m_enable;
+  bool m_sznear;
+  bool m_szfar;
+  std::string m_znear;
+  std::string m_zfar;
+};
+
 // NEVER inherit from this class.
 struct VideoConfig final
 {
@@ -119,8 +128,7 @@ struct VideoConfig final
   bool bSkipEFBCopyToRam;
   bool bCopyEFBScaled;
   int iSafeTextureCache_ColorSamples;
-  int iPhackvalue[3];
-  std::string sPhackvalue[2];
+  ProjectionHackConfig phack;
   float fAspectRatioHackW, fAspectRatioHackH;
   bool bEnablePixelLighting;
   bool bFastDepthCalc;


### PR DESCRIPTION
Replace `iPhackvalue` and `sPhackvalue` in VideoConfig with more sensible names.

Rename everything else to have more sensible names while we're at it.