### PR TITLE
Skip GameCube IPL by default

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -234,7 +234,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 {
   IniFile::Section* core = ini.GetOrCreateSection("Core");
 
-  core->Set("HLE_BS2", bHLE_BS2);
+  core->Set("SkipIPL", bHLE_BS2);
   core->Set("TimingVariance", iTimingVariance);
   core->Set("CPUCore", iCPUCore);
   core->Set("Fastmem", bFastmem);
@@ -543,7 +543,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 {
   IniFile::Section* core = ini.GetOrCreateSection("Core");
 
-  core->Get("HLE_BS2", &bHLE_BS2, false);
+  core->Get("SkipIPL", &bHLE_BS2, true);
 #ifdef _M_X86
   core->Get("CPUCore", &iCPUCore, PowerPC::CORE_JIT64);
 #elif _M_ARM_64


### PR DESCRIPTION
See https://github.com/dolphin-emu/dolphin/pull/5492#issuecomment-306988942.

I'm also renaming the setting because `HLE_BS2` has already been set to False automatically in existing INIs.