### PR TITLE
Common: Add HttpRequest to simplify HTTP requests

### DIFF
--- a/Source/Core/Common/Analytics.cpp
+++ b/Source/Core/Common/Analytics.cpp
@@ -4,7 +4,6 @@
 
 #include <cmath>
 #include <cstdio>
-#include <curl/curl.h>
 #include <string>
 
 #include "Common/Analytics.h"
@@ -60,13 +59,6 @@ void AppendType(std::string* out, TypeId type)
 {
   out->push_back(static_cast<u8>(type));
 }
-
-// Dummy write function for curl.
-size_t DummyCurlWriteFunction(char* ptr, size_t size, size_t nmemb, void* userdata)
-{
-  return size * nmemb;
-}
-
 }  // namespace
 
 AnalyticsReportBuilder::AnalyticsReportBuilder()
@@ -187,44 +179,16 @@ void StdoutAnalyticsBackend::Send(std::string report)
          HexDump(reinterpret_cast<const u8*>(report.data()), report.size()).c_str());
 }
 
-HttpAnalyticsBackend::HttpAnalyticsBackend(const std::string& endpoint)
+HttpAnalyticsBackend::HttpAnalyticsBackend(const std::string& endpoint) : m_endpoint(endpoint)
 {
-  CURL* curl = curl_easy_init();
-  if (curl)
-  {
-    // libcurl may not have been built with async DNS support, so we disable
-    // signal handlers to avoid a possible and likely crash if a resolve times out.
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, true);
-    curl_easy_setopt(curl, CURLOPT_URL, endpoint.c_str());
-    curl_easy_setopt(curl, CURLOPT_POST, true);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &DummyCurlWriteFunction);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 3000);
-
-#ifdef _WIN32
-    // ALPN support is enabled by default but requires Windows >= 8.1.
-    curl_easy_setopt(curl, CURLOPT_SSL_ENABLE_ALPN, false);
-#endif
-
-    m_curl = curl;
-  }
 }
 
-HttpAnalyticsBackend::~HttpAnalyticsBackend()
-{
-  if (m_curl)
-  {
-    curl_easy_cleanup(m_curl);
-  }
-}
+HttpAnalyticsBackend::~HttpAnalyticsBackend() = default;
 
 void HttpAnalyticsBackend::Send(std::string report)
 {
-  if (!m_curl)
-    return;
-
-  curl_easy_setopt(m_curl, CURLOPT_POSTFIELDS, report.c_str());
-  curl_easy_setopt(m_curl, CURLOPT_POSTFIELDSIZE, report.size());
-  curl_easy_perform(m_curl);
+  if (m_http.IsValid())
+    m_http.Post(m_endpoint, report);
 }
 
 }  // namespace Common

--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -11,12 +11,11 @@
 #include <utility>
 #include <vector>
 
-#include <curl/curl.h>
-
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/FifoQueue.h"
 #include "Common/Flag.h"
+#include "Common/HttpRequest.h"
 
 // Utilities for analytics reporting in Dolphin. This reporting is designed to
 // provide anonymous data about how well Dolphin performs in the wild. It also
@@ -179,7 +178,8 @@ public:
   void Send(std::string report) override;
 
 protected:
-  CURL* m_curl = nullptr;
+  std::string m_endpoint;
+  HttpRequest m_http;
 };
 
 }  // namespace Common

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRCS
   FileUtil.cpp
   GekkoDisassembler.cpp
   Hash.cpp
+  HttpRequest.cpp
   IniFile.cpp
   JitRegister.cpp
   MathUtil.cpp

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -121,6 +121,7 @@
     <ClInclude Include="GL\GLInterface\WGL.h" />
     <ClInclude Include="GL\GLUtil.h" />
     <ClInclude Include="Hash.h" />
+    <ClInclude Include="HttpRequest.h" />
     <ClInclude Include="IniFile.h" />
     <ClInclude Include="JitRegister.h" />
     <ClInclude Include="LinearDiskCache.h" />
@@ -173,6 +174,7 @@
     <ClCompile Include="GL\GLInterface\WGL.cpp" />
     <ClCompile Include="GL\GLUtil.cpp" />
     <ClCompile Include="Hash.cpp" />
+    <ClCompile Include="HttpRequest.cpp" />
     <ClCompile Include="IniFile.cpp" />
     <ClCompile Include="JitRegister.cpp" />
     <ClCompile Include="Logging\ConsoleListenerWin.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -48,6 +48,7 @@
     <ClInclude Include="Flag.h" />
     <ClInclude Include="FPURoundMode.h" />
     <ClInclude Include="Hash.h" />
+    <ClInclude Include="HttpRequest.h" />
     <ClInclude Include="IniFile.h" />
     <ClInclude Include="LinearDiskCache.h" />
     <ClInclude Include="MathUtil.h" />
@@ -263,6 +264,7 @@
     <ClCompile Include="FileSearch.cpp" />
     <ClCompile Include="FileUtil.cpp" />
     <ClCompile Include="Hash.cpp" />
+    <ClCompile Include="HttpRequest.cpp" />
     <ClCompile Include="IniFile.cpp" />
     <ClCompile Include="MathUtil.cpp" />
     <ClCompile Include="MemArena.cpp" />

--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -111,7 +111,8 @@ HttpRequest::Response HttpRequest::Impl::Fetch(const std::string& url, Method me
   curl_easy_getinfo(m_curl.get(), CURLINFO_RESPONSE_CODE, &response_code);
   if (response_code != 200)
   {
-    ERROR_LOG(COMMON, "Failed to %s %s: response code was %li", type, url.c_str(), response_code);
+    ERROR_LOG(COMMON, "Failed to %s %s: server replied with code %li and body\n\x1b[0m%s", type,
+              url.c_str(), response_code, buffer.data());
     return {};
   }
 

--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -1,0 +1,120 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Common/HttpRequest.h"
+
+#include <cstddef>
+#include <curl/curl.h>
+
+#include "Common/Logging/Log.h"
+
+namespace Common
+{
+class HttpRequest::Impl final
+{
+public:
+  enum class Method
+  {
+    GET,
+    POST,
+  };
+
+  Impl();
+
+  bool IsValid() const;
+  Response Fetch(const std::string& url, Method method, const u8* payload, size_t size);
+
+private:
+  std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> m_curl{curl_easy_init(), curl_easy_cleanup};
+};
+
+HttpRequest::HttpRequest() : m_impl(std::make_unique<Impl>())
+{
+}
+
+HttpRequest::~HttpRequest() = default;
+
+bool HttpRequest::IsValid() const
+{
+  return m_impl->IsValid();
+}
+
+HttpRequest::Response HttpRequest::Get(const std::string& url)
+{
+  return m_impl->Fetch(url, Impl::Method::GET, nullptr, 0);
+}
+
+HttpRequest::Response HttpRequest::Post(const std::string& url, const std::vector<u8>& payload)
+{
+  return m_impl->Fetch(url, Impl::Method::POST, payload.data(), payload.size());
+}
+
+HttpRequest::Response HttpRequest::Post(const std::string& url, const std::string& payload)
+{
+  return m_impl->Fetch(url, Impl::Method::POST, reinterpret_cast<const u8*>(payload.data()),
+                       payload.size());
+}
+
+HttpRequest::Impl::Impl()
+{
+  if (!m_curl)
+    return;
+
+  // libcurl may not have been built with async DNS support, so we disable
+  // signal handlers to avoid a possible and likely crash if a resolve times out.
+  curl_easy_setopt(m_curl.get(), CURLOPT_NOSIGNAL, true);
+  curl_easy_setopt(m_curl.get(), CURLOPT_TIMEOUT, 3);
+#ifdef _WIN32
+  // ALPN support is enabled by default but requires Windows >= 8.1.
+  curl_easy_setopt(m_curl.get(), CURLOPT_SSL_ENABLE_ALPN, false);
+#endif
+}
+
+bool HttpRequest::Impl::IsValid() const
+{
+  return m_curl != nullptr;
+}
+
+static size_t CurlCallback(char* data, size_t size, size_t nmemb, void* userdata)
+{
+  auto* buffer = static_cast<std::vector<u8>*>(userdata);
+  const size_t actual_size = size * nmemb;
+  buffer->insert(buffer->end(), data, data + actual_size);
+  return actual_size;
+}
+
+HttpRequest::Response HttpRequest::Impl::Fetch(const std::string& url, Method method,
+                                               const u8* payload, size_t size)
+{
+  curl_easy_setopt(m_curl.get(), CURLOPT_POST, method == Method::POST);
+  curl_easy_setopt(m_curl.get(), CURLOPT_URL, url.c_str());
+  if (method == Method::POST)
+  {
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDS, payload);
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDSIZE, size);
+  }
+
+  std::vector<u8> buffer;
+  curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION, CurlCallback);
+  curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, &buffer);
+
+  const char* type = method == Method::POST ? "POST" : "GET";
+  const CURLcode res = curl_easy_perform(m_curl.get());
+  if (res != CURLE_OK)
+  {
+    ERROR_LOG(COMMON, "Failed to %s %s: %s", type, url.c_str(), curl_easy_strerror(res));
+    return {};
+  }
+
+  long response_code = 0;
+  curl_easy_getinfo(m_curl.get(), CURLINFO_RESPONSE_CODE, &response_code);
+  if (response_code != 200)
+  {
+    ERROR_LOG(COMMON, "Failed to %s %s: response code was %li", type, url.c_str(), response_code);
+    return {};
+  }
+
+  return buffer;
+}
+}  // namespace Common

--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -22,7 +22,7 @@ public:
     POST,
   };
 
-  Impl();
+  Impl(int timeout_ms);
 
   bool IsValid() const;
   Response Fetch(const std::string& url, Method method, const Headers& headers, const u8* payload,
@@ -32,7 +32,7 @@ private:
   std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> m_curl{curl_easy_init(), curl_easy_cleanup};
 };
 
-HttpRequest::HttpRequest() : m_impl(std::make_unique<Impl>())
+HttpRequest::HttpRequest(int timeout_ms) : m_impl(std::make_unique<Impl>(timeout_ms))
 {
 }
 
@@ -61,7 +61,7 @@ HttpRequest::Response HttpRequest::Post(const std::string& url, const std::strin
                        reinterpret_cast<const u8*>(payload.data()), payload.size());
 }
 
-HttpRequest::Impl::Impl()
+HttpRequest::Impl::Impl(int timeout_ms)
 {
   if (!m_curl)
     return;
@@ -69,7 +69,7 @@ HttpRequest::Impl::Impl()
   // libcurl may not have been built with async DNS support, so we disable
   // signal handlers to avoid a possible and likely crash if a resolve times out.
   curl_easy_setopt(m_curl.get(), CURLOPT_NOSIGNAL, true);
-  curl_easy_setopt(m_curl.get(), CURLOPT_TIMEOUT, 3);
+  curl_easy_setopt(m_curl.get(), CURLOPT_TIMEOUT_MS, timeout_ms);
 #ifdef _WIN32
   // ALPN support is enabled by default but requires Windows >= 8.1.
   curl_easy_setopt(m_curl.get(), CURLOPT_SSL_ENABLE_ALPN, false);

--- a/Source/Core/Common/HttpRequest.h
+++ b/Source/Core/Common/HttpRequest.h
@@ -17,7 +17,7 @@ namespace Common
 class HttpRequest final
 {
 public:
-  HttpRequest();
+  HttpRequest(int timeout_ms = 3000);
   ~HttpRequest();
   bool IsValid() const;
 

--- a/Source/Core/Common/HttpRequest.h
+++ b/Source/Core/Common/HttpRequest.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -21,9 +22,11 @@ public:
   bool IsValid() const;
 
   using Response = std::optional<std::vector<u8>>;
-  Response Get(const std::string& url);
-  Response Post(const std::string& url, const std::vector<u8>& payload);
-  Response Post(const std::string& url, const std::string& payload);
+  using Headers = std::map<std::string, std::optional<std::string>>;
+  Response Get(const std::string& url, const Headers& headers = {});
+  Response Post(const std::string& url, const std::vector<u8>& payload,
+                const Headers& headers = {});
+  Response Post(const std::string& url, const std::string& payload, const Headers& headers = {});
 
 private:
   class Impl;

--- a/Source/Core/Common/HttpRequest.h
+++ b/Source/Core/Common/HttpRequest.h
@@ -1,0 +1,32 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+namespace Common
+{
+class HttpRequest final
+{
+public:
+  HttpRequest();
+  ~HttpRequest();
+  bool IsValid() const;
+
+  using Response = std::optional<std::vector<u8>>;
+  Response Get(const std::string& url);
+  Response Post(const std::string& url, const std::vector<u8>& payload);
+  Response Post(const std::string& url, const std::string& payload);
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> m_impl;
+};
+}  // namespace Common


### PR DESCRIPTION
Too much boilerplate that is duplicated if we use curl directly. I was implementing online updates and found that having to write 40+ lines everywhere we need to GET/POST is a bit too much, especially as the setup code is all very similiar and nearly duplicated.

This PR adds a simple wrapper class that hides the implementation details and allows to make HTTP requests and get the response very simply.