### PR TITLE
PathConfigPane: Prevent an invalid index assert

### DIFF
--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -144,7 +144,14 @@ void PathConfigPane::BindEvents()
   m_wii_sdcard_filepicker->Bind(wxEVT_FILEPICKER_CHANGED, &PathConfigPane::OnSdCardPathChanged,
                                 this);
 
-  Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+  Bind(wxEVT_UPDATE_UI, &PathConfigPane::OnEnableIfCoreNotRunning, this);
+}
+
+void PathConfigPane::OnEnableIfCoreNotRunning(wxUpdateUIEvent& event)
+{
+  // Prevent the Remove button from being enabled via wxUpdateUIEvent
+  if (event.GetId() != m_remove_iso_path_button->GetId())
+    WxEventUtils::OnEnableIfCoreNotRunning(event);
 }
 
 void PathConfigPane::OnISOPathSelectionChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/PathConfigPane.h
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.h
@@ -22,6 +22,8 @@ private:
   void LoadGUIValues();
   void BindEvents();
 
+  void OnEnableIfCoreNotRunning(wxUpdateUIEvent& event);
+
   void OnISOPathSelectionChanged(wxCommandEvent&);
   void OnRecursiveISOCheckBoxChanged(wxCommandEvent&);
   void OnAddISOPath(wxCommandEvent&);


### PR DESCRIPTION
This PR prevents the following assert to be triggered:
```
---------------------------
wxWidgets Debug Alert
---------------------------
..\..\src\common\ctrlsub.cpp(111): assert ""pos < GetCount()"" failed in wxItemContainer::Delete(): invalid index
Do you want to stop the program?
You can also choose [Cancel] to suppress further warnings.
```
Ready to be reviewed & merged.