### PR TITLE
DSPCore: update free DSP ROM messages

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -88,6 +88,12 @@ static bool VerifyRoms()
     Host::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
     Host::OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.", 8000);
   }
+  else if (rom_idx == 4)
+  {
+    Host::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
+    Host::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
+    Host::OSD_AddMessage("also work fine, but the IPL and CARD UCodes will not work.", 8000);
+  }
 
   return true;
 }

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -85,14 +85,14 @@ static bool VerifyRoms()
   else if (rom_idx == 2 || rom_idx == 3)
   {
     Host::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
-    Host::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
-    Host::OSD_AddMessage("also work fine, but the GBA/CARD UCodes will not work.", 8000);
+    Host::OSD_AddMessage("All Wii games will work correctly, and most GameCube games", 8000);
+    Host::OSD_AddMessage("should also work fine, but the GBA/CARD UCodes will not work.", 8000);
   }
   else if (rom_idx == 4)
   {
     Host::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
-    Host::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
-    Host::OSD_AddMessage("also work fine, but the CARD UCode will not work.", 8000);
+    Host::OSD_AddMessage("All Wii games will work correctly, and most GameCube games", 8000);
+    Host::OSD_AddMessage("should also work fine, but the CARD UCode will not work.", 8000);
   }
 
   return true;

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -86,13 +86,13 @@ static bool VerifyRoms()
   {
     Host::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
     Host::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
-    Host::OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.", 8000);
+    Host::OSD_AddMessage("also work fine, but the GBA/CARD UCodes will not work.", 8000);
   }
   else if (rom_idx == 4)
   {
     Host::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
     Host::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
-    Host::OSD_AddMessage("also work fine, but the IPL and CARD UCodes will not work.", 8000);
+    Host::OSD_AddMessage("also work fine, but the CARD UCode will not work.", 8000);
   }
 
   return true;


### PR DESCRIPTION
The GBA ucode is supported as of #5524 / d51be94.