### PR TITLE
DolphinWX: Fix encoding errors in UpdateTitle

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -747,17 +747,17 @@ void CFrame::UninhibitScreensaver()
 #endif
 }
 
-void CFrame::UpdateTitle(const std::string& str)
+void CFrame::UpdateTitle(const wxString& str)
 {
+  const wxString revision_string = StrToWxStr(scm_rev_str);
   if (SConfig::GetInstance().bRenderToMain && SConfig::GetInstance().m_InterfaceStatusbar)
   {
     GetStatusBar()->SetStatusText(str, 0);
-    m_render_frame->SetTitle(scm_rev_str);
+    m_render_frame->SetTitle(revision_string);
   }
   else
   {
-    std::string titleStr = StringFromFormat("%s | %s", scm_rev_str.c_str(), str.c_str());
-    m_render_frame->SetTitle(titleStr);
+    m_render_frame->SetTitle(revision_string + StrToWxStr(" | ") + str);
   }
 }
 
@@ -780,7 +780,7 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
     break;
 
   case IDM_UPDATE_TITLE:
-    UpdateTitle(WxStrToStr(event.GetString()));
+    UpdateTitle(event.GetString());
     break;
 
   case IDM_WINDOW_SIZE_REQUEST:

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -14,6 +14,7 @@
 #include <wx/frame.h>
 #include <wx/image.h>
 #include <wx/panel.h>
+#include <wx/string.h>
 #include <wx/timer.h>
 
 #include "Common/CommonTypes.h"
@@ -254,7 +255,7 @@ private:
   bool TriggerSTMPowerEvent();
   void OnStopped();
   void OnRenderWindowSizeRequest(int width, int height);
-  void UpdateTitle(const std::string& str);
+  void UpdateTitle(const wxString& str);
   static void ConnectWiimote(int wm_idx, bool connect);
 
   // Event functions


### PR DESCRIPTION
An implicit conversion from std::string to wxString was to blame, as usual. Fixes [issue 10341](https://bugs.dolphin-emu.org/issues/10341).