### PR TITLE
SysConf: Don't set "config done" flags by default

### DIFF
--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -297,8 +297,8 @@ void SysConf::InsertDefaultEntries()
   AddEntry({Entry::Type::Byte, "IPL.AR", {1}});
   AddEntry({Entry::Type::Byte, "IPL.SSV", {1}});
 
-  AddEntry({Entry::Type::ByteBool, "IPL.CD", {1}});
-  AddEntry({Entry::Type::ByteBool, "IPL.CD2", {1}});
+  AddEntry({Entry::Type::ByteBool, "IPL.CD", {0}});
+  AddEntry({Entry::Type::ByteBool, "IPL.CD2", {0}});
   AddEntry({Entry::Type::ByteBool, "IPL.EULA", {1}});
   AddEntry({Entry::Type::Byte, "IPL.UPT", {2}});
   AddEntry({Entry::Type::Byte, "IPL.PGS", {0}});


### PR DESCRIPTION
This allows the user to go through the Wii Menu first boot setup screen when they launch the System Menu for the first time.

Most useful on a clean profile, after doing a full system update, to configure settings like the console country.

![1](https://i.imgur.com/QRXMf8i.png)

![2](https://i.imgur.com/pzioW34.png)