### PR TITLE
[WIP] Make g_Config read-only

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -29,6 +29,7 @@
 #include "Common/Timer.h"
 
 #include "Core/Boot/Boot.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -1486,11 +1487,14 @@ void CallWiiInputManip(u8* data, WiimoteEmu::ReportFeatures rptf, int controller
 // NOTE: GPU Thread
 void SetGraphicsConfig()
 {
-  g_Config.bEFBAccessEnable = tmpHeader.bEFBAccessEnable;
-  g_Config.bSkipEFBCopyToRam = tmpHeader.bSkipEFBCopyToRam;
-  g_Config.bEFBEmulateFormatChanges = tmpHeader.bEFBEmulateFormatChanges;
-  g_Config.bUseXFB = tmpHeader.bUseXFB;
-  g_Config.bUseRealXFB = tmpHeader.bUseRealXFB;
+  Config::Set(Config::LayerType::Movie, Config::GFX_HACK_EFB_ACCESS_ENABLE,
+              tmpHeader.bEFBAccessEnable);
+  Config::Set(Config::LayerType::Movie, Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM,
+              tmpHeader.bSkipEFBCopyToRam);
+  Config::Set(Config::LayerType::Movie, Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES,
+              tmpHeader.bEFBEmulateFormatChanges);
+  Config::Set(Config::LayerType::Movie, Config::GFX_USE_XFB, tmpHeader.bUseXFB);
+  Config::Set(Config::LayerType::Movie, Config::GFX_USE_REAL_XFB, tmpHeader.bUseRealXFB);
 }
 
 // NOTE: EmuThread / Host Thread

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -371,11 +371,12 @@ static wxArrayString GetListOfResolutions()
 #endif
 
 VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
-    : wxDialog(parent, wxID_ANY, wxString::Format(_("Dolphin %s Graphics Configuration"),
-                                                  wxGetTranslation(StrToWxStr(title)))),
+    : wxDialog(parent, wxID_ANY,
+               wxString::Format(_("Dolphin %s Graphics Configuration"),
+                                wxGetTranslation(StrToWxStr(title)))),
       vconfig(g_Config)
 {
-  vconfig.Refresh();
+  RefreshVideoConfig();
 
   Bind(wxEVT_UPDATE_UI, &VideoConfigDiag::OnUpdateUI, this);
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -174,7 +174,7 @@ protected:
                                                   // setting controls) to their description text
                                                   // objects
 
-  VideoConfig& vconfig;
+  const VideoConfig& vconfig;
 
   size_t m_msaa_modes;
 };

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -660,7 +660,7 @@ Renderer::Renderer()
     return;
   }
 
-  g_Config.VerifyValidity();
+  VerifyVideoConfigValidity();
   UpdateActiveConfig();
 
   OSD::AddMessage(StringFromFormat("Video Info: %s, %s, %s", g_ogl_config.gl_vendor,
@@ -1223,24 +1223,24 @@ void Renderer::SetBlendMode(bool forceUpdate)
       state.usedualsrc && g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
       (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) || state.dstalpha);
 
-  const GLenum src_factors[8] = {
-      GL_ZERO,
-      GL_ONE,
-      GL_DST_COLOR,
-      GL_ONE_MINUS_DST_COLOR,
-      useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
-      useDualSource ? GL_ONE_MINUS_SRC1_ALPHA : (GLenum)GL_ONE_MINUS_SRC_ALPHA,
-      GL_DST_ALPHA,
-      GL_ONE_MINUS_DST_ALPHA};
-  const GLenum dst_factors[8] = {
-      GL_ZERO,
-      GL_ONE,
-      GL_SRC_COLOR,
-      GL_ONE_MINUS_SRC_COLOR,
-      useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
-      useDualSource ? GL_ONE_MINUS_SRC1_ALPHA : (GLenum)GL_ONE_MINUS_SRC_ALPHA,
-      GL_DST_ALPHA,
-      GL_ONE_MINUS_DST_ALPHA};
+  const GLenum src_factors[8] = {GL_ZERO,
+                                 GL_ONE,
+                                 GL_DST_COLOR,
+                                 GL_ONE_MINUS_DST_COLOR,
+                                 useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
+                                 useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
+                                                 (GLenum)GL_ONE_MINUS_SRC_ALPHA,
+                                 GL_DST_ALPHA,
+                                 GL_ONE_MINUS_DST_ALPHA};
+  const GLenum dst_factors[8] = {GL_ZERO,
+                                 GL_ONE,
+                                 GL_SRC_COLOR,
+                                 GL_ONE_MINUS_SRC_COLOR,
+                                 useDualSource ? GL_SRC1_ALPHA : (GLenum)GL_SRC_ALPHA,
+                                 useDualSource ? GL_ONE_MINUS_SRC1_ALPHA :
+                                                 (GLenum)GL_ONE_MINUS_SRC_ALPHA,
+                                 GL_DST_ALPHA,
+                                 GL_ONE_MINUS_DST_ALPHA};
 
   if (state.blendenable)
   {

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -222,79 +222,82 @@ VulkanContext::GPUList VulkanContext::EnumerateGPUs(VkInstance instance)
   return gpus;
 }
 
-void VulkanContext::PopulateBackendInfo(VideoConfig* config)
+void VulkanContext::PopulateBackendInfo(VideoConfig::BackendInfo* backend_info)
 {
-  config->backend_info.api_type = APIType::Vulkan;
-  config->backend_info.bSupportsExclusiveFullscreen = false;  // Currently WSI does not allow this.
-  config->backend_info.bSupports3DVision = false;             // D3D-exclusive.
-  config->backend_info.bSupportsOversizedViewports = true;    // Assumed support.
-  config->backend_info.bSupportsEarlyZ = true;                // Assumed support.
-  config->backend_info.bSupportsPrimitiveRestart = true;      // Assumed support.
-  config->backend_info.bSupportsBindingLayout = false;        // Assumed support.
-  config->backend_info.bSupportsPaletteConversion = true;     // Assumed support.
-  config->backend_info.bSupportsClipControl = true;           // Assumed support.
-  config->backend_info.bSupportsMultithreading = true;        // Assumed support.
-  config->backend_info.bSupportsComputeShaders = true;        // Assumed support.
-  config->backend_info.bSupportsGPUTextureDecoding = true;    // Assumed support.
-  config->backend_info.bSupportsInternalResolutionFrameDumps = true;  // Assumed support.
-  config->backend_info.bSupportsPostProcessing = true;                // Assumed support.
-  config->backend_info.bSupportsDualSourceBlend = false;              // Dependent on features.
-  config->backend_info.bSupportsGeometryShaders = false;              // Dependent on features.
-  config->backend_info.bSupportsGSInstancing = false;                 // Dependent on features.
-  config->backend_info.bSupportsBBox = false;                         // Dependent on features.
-  config->backend_info.bSupportsFragmentStoresAndAtomics = false;     // Dependent on features.
-  config->backend_info.bSupportsSSAA = false;                         // Dependent on features.
-  config->backend_info.bSupportsDepthClamp = false;                   // Dependent on features.
-  config->backend_info.bSupportsST3CTextures = false;                 // Dependent on features.
-  config->backend_info.bSupportsReversedDepthRange = false;  // No support yet due to driver bugs.
+  backend_info->api_type = APIType::Vulkan;
+  backend_info->bSupportsExclusiveFullscreen = false;          // Currently WSI does not allow this.
+  backend_info->bSupports3DVision = false;                     // D3D-exclusive.
+  backend_info->bSupportsOversizedViewports = true;            // Assumed support.
+  backend_info->bSupportsEarlyZ = true;                        // Assumed support.
+  backend_info->bSupportsPrimitiveRestart = true;              // Assumed support.
+  backend_info->bSupportsBindingLayout = false;                // Assumed support.
+  backend_info->bSupportsPaletteConversion = true;             // Assumed support.
+  backend_info->bSupportsClipControl = true;                   // Assumed support.
+  backend_info->bSupportsMultithreading = true;                // Assumed support.
+  backend_info->bSupportsComputeShaders = true;                // Assumed support.
+  backend_info->bSupportsGPUTextureDecoding = true;            // Assumed support.
+  backend_info->bSupportsInternalResolutionFrameDumps = true;  // Assumed support.
+  backend_info->bSupportsPostProcessing = true;                // Assumed support.
+  backend_info->bSupportsDualSourceBlend = false;              // Dependent on features.
+  backend_info->bSupportsGeometryShaders = false;              // Dependent on features.
+  backend_info->bSupportsGSInstancing = false;                 // Dependent on features.
+  backend_info->bSupportsBBox = false;                         // Dependent on features.
+  backend_info->bSupportsFragmentStoresAndAtomics = false;     // Dependent on features.
+  backend_info->bSupportsSSAA = false;                         // Dependent on features.
+  backend_info->bSupportsDepthClamp = false;                   // Dependent on features.
+  backend_info->bSupportsST3CTextures = false;                 // Dependent on features.
+  backend_info->bSupportsReversedDepthRange = false;           // No support yet due to driver bugs.
 }
 
-void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)
+void VulkanContext::PopulateBackendInfoAdapters(VideoConfig::BackendInfo* backend_info,
+                                                const GPUList& gpu_list)
 {
-  config->backend_info.Adapters.clear();
+  backend_info->Adapters.clear();
   for (VkPhysicalDevice physical_device : gpu_list)
   {
     VkPhysicalDeviceProperties properties;
     vkGetPhysicalDeviceProperties(physical_device, &properties);
-    config->backend_info.Adapters.push_back(properties.deviceName);
+    backend_info->Adapters.push_back(properties.deviceName);
   }
 }
 
-void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalDevice gpu,
+void VulkanContext::PopulateBackendInfoFeatures(VideoConfig::BackendInfo* backend_info,
+                                                VkPhysicalDevice gpu,
                                                 const VkPhysicalDeviceProperties& properties,
                                                 const VkPhysicalDeviceFeatures& features)
 {
-  config->backend_info.MaxTextureSize = properties.limits.maxImageDimension2D;
-  config->backend_info.bSupportsDualSourceBlend = (features.dualSrcBlend == VK_TRUE);
-  config->backend_info.bSupportsGeometryShaders = (features.geometryShader == VK_TRUE);
-  config->backend_info.bSupportsGSInstancing = (features.geometryShader == VK_TRUE);
-  config->backend_info.bSupportsBBox = config->backend_info.bSupportsFragmentStoresAndAtomics =
+  backend_info->MaxTextureSize = properties.limits.maxImageDimension2D;
+  backend_info->bSupportsDualSourceBlend = (features.dualSrcBlend == VK_TRUE);
+  backend_info->bSupportsGeometryShaders = (features.geometryShader == VK_TRUE);
+  backend_info->bSupportsGSInstancing = (features.geometryShader == VK_TRUE);
+  backend_info->bSupportsBBox = backend_info->bSupportsFragmentStoresAndAtomics =
       (features.fragmentStoresAndAtomics == VK_TRUE);
-  config->backend_info.bSupportsSSAA = (features.sampleRateShading == VK_TRUE);
+  backend_info->bSupportsSSAA = (features.sampleRateShading == VK_TRUE);
 
   // Disable geometry shader when shaderTessellationAndGeometryPointSize is not supported.
   // Seems this is needed for gl_Layer.
   if (!features.shaderTessellationAndGeometryPointSize)
   {
-    config->backend_info.bSupportsGeometryShaders = VK_FALSE;
-    config->backend_info.bSupportsGSInstancing = VK_FALSE;
+    backend_info->bSupportsGeometryShaders = VK_FALSE;
+    backend_info->bSupportsGSInstancing = VK_FALSE;
   }
 
   // Depth clamping implies shaderClipDistance and depthClamp
-  config->backend_info.bSupportsDepthClamp =
+  backend_info->bSupportsDepthClamp =
       (features.depthClamp == VK_TRUE && features.shaderClipDistance == VK_TRUE);
 
   // textureCompressionBC implies BC1 through BC7, which is a superset of DXT1/3/5, which we need.
-  config->backend_info.bSupportsST3CTextures = features.textureCompressionBC == VK_TRUE;
+  backend_info->bSupportsST3CTextures = features.textureCompressionBC == VK_TRUE;
 
   // Our usage of primitive restart appears to be broken on AMD's binary drivers.
   // Seems to be fine on GCN Gen 1-2, unconfirmed on GCN Gen 3, causes driver resets on GCN Gen 4.
   if (DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART))
-    config->backend_info.bSupportsPrimitiveRestart = false;
+    backend_info->bSupportsPrimitiveRestart = false;
 }
 
 void VulkanContext::PopulateBackendInfoMultisampleModes(
-    VideoConfig* config, VkPhysicalDevice gpu, const VkPhysicalDeviceProperties& properties)
+    VideoConfig::BackendInfo* backend_info, VkPhysicalDevice gpu,
+    const VkPhysicalDeviceProperties& properties)
 {
   // Query image support for the EFB texture formats.
   VkImageFormatProperties efb_color_properties = {};
@@ -313,32 +316,32 @@ void VulkanContext::PopulateBackendInfoMultisampleModes(
                                                efb_depth_properties.sampleCounts;
 
   // No AA
-  config->backend_info.AAModes.clear();
-  config->backend_info.AAModes.emplace_back(1);
+  backend_info->AAModes.clear();
+  backend_info->AAModes.emplace_back(1);
 
   // 2xMSAA/SSAA
   if (supported_sample_counts & VK_SAMPLE_COUNT_2_BIT)
-    config->backend_info.AAModes.emplace_back(2);
+    backend_info->AAModes.emplace_back(2);
 
   // 4xMSAA/SSAA
   if (supported_sample_counts & VK_SAMPLE_COUNT_4_BIT)
-    config->backend_info.AAModes.emplace_back(4);
+    backend_info->AAModes.emplace_back(4);
 
   // 8xMSAA/SSAA
   if (supported_sample_counts & VK_SAMPLE_COUNT_8_BIT)
-    config->backend_info.AAModes.emplace_back(8);
+    backend_info->AAModes.emplace_back(8);
 
   // 16xMSAA/SSAA
   if (supported_sample_counts & VK_SAMPLE_COUNT_16_BIT)
-    config->backend_info.AAModes.emplace_back(16);
+    backend_info->AAModes.emplace_back(16);
 
   // 32xMSAA/SSAA
   if (supported_sample_counts & VK_SAMPLE_COUNT_32_BIT)
-    config->backend_info.AAModes.emplace_back(32);
+    backend_info->AAModes.emplace_back(32);
 
   // 64xMSAA/SSAA
   if (supported_sample_counts & VK_SAMPLE_COUNT_64_BIT)
-    config->backend_info.AAModes.emplace_back(64);
+    backend_info->AAModes.emplace_back(64);
 }
 
 std::unique_ptr<VulkanContext> VulkanContext::Create(VkInstance instance, VkPhysicalDevice gpu,

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.h
@@ -32,12 +32,15 @@ public:
 
   // Populates backend/video config.
   // These are public so that the backend info can be populated without creating a context.
-  static void PopulateBackendInfo(VideoConfig* config);
-  static void PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list);
-  static void PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalDevice gpu,
+  static void PopulateBackendInfo(VideoConfig::BackendInfo* backend_info);
+  static void PopulateBackendInfoAdapters(VideoConfig::BackendInfo* backend_info,
+                                          const GPUList& gpu_list);
+  static void PopulateBackendInfoFeatures(VideoConfig::BackendInfo* backend_info,
+                                          VkPhysicalDevice gpu,
                                           const VkPhysicalDeviceProperties& properties,
                                           const VkPhysicalDeviceFeatures& features);
-  static void PopulateBackendInfoMultisampleModes(VideoConfig* config, VkPhysicalDevice gpu,
+  static void PopulateBackendInfoMultisampleModes(VideoConfig::BackendInfo* backend_info,
+                                                  VkPhysicalDevice gpu,
                                                   const VkPhysicalDeviceProperties& properties);
 
   // Creates a Vulkan device context.

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -28,7 +28,7 @@ namespace Vulkan
 {
 void VideoBackend::InitBackendInfo()
 {
-  VulkanContext::PopulateBackendInfo(&g_Config);
+  VulkanContext::PopulateBackendInfo(&g_Config.backend_info);
 
   if (LoadVulkanLibrary())
   {
@@ -38,7 +38,7 @@ void VideoBackend::InitBackendInfo()
       if (LoadVulkanInstanceFunctions(temp_instance))
       {
         VulkanContext::GPUList gpu_list = VulkanContext::EnumerateGPUs(temp_instance);
-        VulkanContext::PopulateBackendInfoAdapters(&g_Config, gpu_list);
+        VulkanContext::PopulateBackendInfoAdapters(&g_Config.backend_info, gpu_list);
 
         if (!gpu_list.empty())
         {
@@ -52,8 +52,10 @@ void VideoBackend::InitBackendInfo()
           vkGetPhysicalDeviceProperties(gpu, &properties);
           VkPhysicalDeviceFeatures features;
           vkGetPhysicalDeviceFeatures(gpu, &features);
-          VulkanContext::PopulateBackendInfoFeatures(&g_Config, gpu, properties, features);
-          VulkanContext::PopulateBackendInfoMultisampleModes(&g_Config, gpu, properties);
+          VulkanContext::PopulateBackendInfoFeatures(&g_Config.backend_info, gpu, properties,
+                                                     features);
+          VulkanContext::PopulateBackendInfoMultisampleModes(&g_Config.backend_info, gpu,
+                                                             properties);
         }
       }
 
@@ -139,8 +141,8 @@ bool VideoBackend::Initialize(void* window_handle)
   }
 
   // Populate BackendInfo with as much information as we can at this point.
-  VulkanContext::PopulateBackendInfo(&g_Config);
-  VulkanContext::PopulateBackendInfoAdapters(&g_Config, gpu_list);
+  VulkanContext::PopulateBackendInfo(&g_Config.backend_info);
+  VulkanContext::PopulateBackendInfoAdapters(&g_Config.backend_info, gpu_list);
 
   // We need the surface before we can create a device, as some parameters depend on it.
   VkSurfaceKHR surface = VK_NULL_HANDLE;
@@ -177,11 +179,12 @@ bool VideoBackend::Initialize(void* window_handle)
 
   // Since VulkanContext maintains a copy of the device features and properties, we can use this
   // to initialize the backend information, so that we don't need to enumerate everything again.
-  VulkanContext::PopulateBackendInfoFeatures(&g_Config, g_vulkan_context->GetPhysicalDevice(),
-                                             g_vulkan_context->GetDeviceProperties(),
-                                             g_vulkan_context->GetDeviceFeatures());
-  VulkanContext::PopulateBackendInfoMultisampleModes(
-      &g_Config, g_vulkan_context->GetPhysicalDevice(), g_vulkan_context->GetDeviceProperties());
+  VulkanContext::PopulateBackendInfoFeatures(
+      &g_Config.backend_info, g_vulkan_context->GetPhysicalDevice(),
+      g_vulkan_context->GetDeviceProperties(), g_vulkan_context->GetDeviceFeatures());
+  VulkanContext::PopulateBackendInfoMultisampleModes(&g_Config.backend_info,
+                                                     g_vulkan_context->GetPhysicalDevice(),
+                                                     g_vulkan_context->GetDeviceProperties());
 
   // With the backend information populated, we can now initialize videocommon.
   InitializeShared();

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -190,9 +190,9 @@ void VideoBackendBase::InitializeShared()
   GeometryShaderManager::Init();
   PixelShaderManager::Init();
 
-  g_Config.Refresh();
-  g_Config.UpdateProjectionHack();
-  g_Config.VerifyValidity();
+  RefreshVideoConfig();
+  UpdateProjectionHack(g_Config.phack);
+  VerifyVideoConfigValidity();
   UpdateActiveConfig();
 
   // Notify the core that the video backend is ready

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -121,7 +121,7 @@ TextureCacheBase::~TextureCacheBase()
   temp = nullptr;
 }
 
-void TextureCacheBase::OnConfigChanged(VideoConfig& config)
+void TextureCacheBase::OnConfigChanged(const VideoConfig& config)
 {
   if (config.bHiresTextures != backup_config.hires_textures ||
       config.bCacheHiresTextures != backup_config.cache_hires_textures)

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -150,7 +150,7 @@ public:
   static bool IsCompressedHostTextureFormat(HostTextureFormat format);
   static size_t CalculateHostTextureLevelPitch(HostTextureFormat format, u32 row_length);
 
-  void OnConfigChanged(VideoConfig& config);
+  void OnConfigChanged(const VideoConfig& config);
 
   // Removes textures which aren't used for more than TEXTURE_KILL_THRESHOLD frames,
   // frameCount is the current frame number.

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -66,7 +66,7 @@ struct VideoConfig final
   void Refresh();
   void VerifyValidity();
   void UpdateProjectionHack();
-  bool IsVSync();
+  bool IsVSync() const;
 
   // General
   bool bVSync;
@@ -129,12 +129,12 @@ struct VideoConfig final
   bool bCopyEFBScaled;
   int iSafeTextureCache_ColorSamples;
   ProjectionHackConfig phack;
-  float fAspectRatioHackW, fAspectRatioHackH;
+  mutable float fAspectRatioHackW, fAspectRatioHackH;
   bool bEnablePixelLighting;
   bool bFastDepthCalc;
   bool bVertexRounding;
-  int iLog;           // CONF_ bits
-  int iSaveTargetId;  // TODO: Should be dropped
+  int iLog;                   // CONF_ bits
+  mutable int iSaveTargetId;  // TODO: Should be dropped
 
   // Stereoscopy
   int iStereoMode;
@@ -169,7 +169,7 @@ struct VideoConfig final
 
   // Static config per API
   // TODO: Move this out of VideoConfig
-  struct
+  mutable struct
   {
     APIType api_type;
 
@@ -224,8 +224,11 @@ struct VideoConfig final
   }
 };
 
-extern VideoConfig g_Config;
-extern VideoConfig g_ActiveConfig;
+extern const VideoConfig& g_Config;
+extern const VideoConfig& g_ActiveConfig;
+
+void RefreshVideoConfig();
+void VerifyVideoConfigValidity();
 
 // Called every frame.
 void UpdateActiveConfig();

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -169,7 +169,7 @@ struct VideoConfig final
 
   // Static config per API
   // TODO: Move this out of VideoConfig
-  mutable struct
+  mutable struct BackendInfo
   {
     APIType api_type;
 


### PR DESCRIPTION
This PR is here for CI to make sure I've not missed anything.

Final version would obviously not use `mutable`.

Things to do:

- [ ] Move `fAspectRatioHackW`, `fAspectRatioHackH`, `iSaveTargetId`, `backend_info` out of VideoConfig.