### PR TITLE
Fixed latency setting and cleaned-up OpenAL backend

### DIFF
--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -296,8 +296,8 @@ void OpenALStream::SoundLoop()
     // Remove the Buffer from the Queue.
     if (num_buffers_processed)
     {
-      ALuint unqueued_buffer_ids[OAL_BUFFERS];
-      palSourceUnqueueBuffers(m_source, num_buffers_processed, unqueued_buffer_ids);
+      std::array<ALuint, OAL_BUFFERS> unqueued_buffer_ids;
+      palSourceUnqueueBuffers(m_source, num_buffers_processed, unqueued_buffer_ids.data());
       err = CheckALError("unqueuing buffers");
 
       num_buffers_queued -= num_buffers_processed;
@@ -307,8 +307,8 @@ void OpenALStream::SoundLoop()
 
     if (use_surround)
     {
-      float dpl2[OAL_MAX_FRAMES * SURROUND_CHANNELS];
-      u32 rendered_frames = m_mixer->MixSurround(dpl2, min_frames);
+      std::array<float, OAL_MAX_FRAMES * SURROUND_CHANNELS> dpl2;
+      u32 rendered_frames = m_mixer->MixSurround(dpl2.data(), min_frames);
 
       if (rendered_frames < min_frames)
         continue;
@@ -324,12 +324,12 @@ void OpenALStream::SoundLoop()
 
       if (float32_capable)
       {
-        palBufferData(m_buffers[next_buffer], AL_FORMAT_51CHN32, dpl2,
+        palBufferData(m_buffers[next_buffer], AL_FORMAT_51CHN32, dpl2.data(),
                       rendered_frames * FRAME_SURROUND_FLOAT, frequency);
       }
       else if (fixed32_capable)
       {
-        int surround_int32[OAL_MAX_FRAMES * SURROUND_CHANNELS];
+        std::array<int, OAL_MAX_FRAMES * SURROUND_CHANNELS> surround_int32;
 
         for (u32 i = 0; i < rendered_frames * SURROUND_CHANNELS; ++i)
         {
@@ -342,15 +342,15 @@ void OpenALStream::SoundLoop()
           else if (dpl2[i] < INT_MIN)
             surround_int32[i] = INT_MIN;
           else
-            surround_int32[i] = (int)dpl2[i];
+            surround_int32[i] = static_cast<int>(dpl2[i]);
         }
 
-        palBufferData(m_buffers[next_buffer], AL_FORMAT_51CHN32, surround_int32,
+        palBufferData(m_buffers[next_buffer], AL_FORMAT_51CHN32, surround_int32.data(),
                       rendered_frames * FRAME_SURROUND_INT32, frequency);
       }
       else
       {
-        short surround_short[OAL_MAX_FRAMES * SURROUND_CHANNELS];
+        std::array<short, OAL_MAX_FRAMES * SURROUND_CHANNELS> surround_short;
 
         for (u32 i = 0; i < rendered_frames * SURROUND_CHANNELS; ++i)
         {
@@ -360,10 +360,10 @@ void OpenALStream::SoundLoop()
           else if (dpl2[i] < SHRT_MIN)
             surround_short[i] = SHRT_MIN;
           else
-            surround_short[i] = (int)dpl2[i];
+            surround_short[i] = static_cast<int>(dpl2[i]);
         }
 
-        palBufferData(m_buffers[next_buffer], AL_FORMAT_51CHN16, surround_short,
+        palBufferData(m_buffers[next_buffer], AL_FORMAT_51CHN16, surround_short.data(),
                       rendered_frames * FRAME_SURROUND_SHORT, frequency);
       }
 

--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -290,7 +290,7 @@ void OpenALStream::SoundLoop()
     palGetSourcei(m_source, AL_BUFFERS_PROCESSED, &num_buffers_processed);
     if (num_buffers_queued == OAL_BUFFERS && !num_buffers_processed)
     {
-      m_sound_sync_event.Wait();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
       continue;
     }
 

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -56,7 +56,7 @@ class OpenALStream final : public SoundStream
 {
 #ifdef _WIN32
 public:
-  OpenALStream() : uiSource(0) {}
+  OpenALStream() : m_source(0) {}
   bool Start() override;
   void SoundLoop() override;
   void SetVolume(int volume) override;
@@ -67,16 +67,16 @@ public:
   static bool isValid();
 
 private:
-  std::thread thread;
+  std::thread m_thread;
   Common::Flag m_run_thread;
 
-  Common::Event soundSyncEvent;
+  Common::Event m_sound_sync_event;
 
-  std::vector<short> realtimeBuffer;
-  std::vector<float> sampleBuffer;
-  std::array<ALuint, OAL_BUFFERS> uiBuffers;
-  ALuint uiSource;
-  ALfloat fVolume;
+  std::vector<short> m_realtime_buffer;
+  std::vector<float> m_sample_buffer;
+  std::array<ALuint, OAL_BUFFERS> m_buffers;
+  ALuint m_source;
+  ALfloat m_volume;
 
 #endif  // _WIN32
 };

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -26,8 +26,6 @@
 #define SIZE_INT32 4
 #define SIZE_FLOAT 4  // size of a float in bytes
 #define FRAME_STEREO_SHORT STEREO_CHANNELS* SIZE_SHORT
-#define FRAME_STEREO_FLOAT STEREO_CHANNELS* SIZE_FLOAT
-#define FRAME_STEREO_INT32 STEREO_CHANNELS* SIZE_INT32
 #define FRAME_SURROUND_FLOAT SURROUND_CHANNELS* SIZE_FLOAT
 #define FRAME_SURROUND_SHORT SURROUND_CHANNELS* SIZE_SHORT
 #define FRAME_SURROUND_INT32 SURROUND_CHANNELS* SIZE_INT32
@@ -73,7 +71,6 @@ private:
   Common::Event m_sound_sync_event;
 
   std::vector<short> m_realtime_buffer;
-  std::vector<float> m_sample_buffer;
   std::array<ALuint, OAL_BUFFERS> m_buffers;
   ALuint m_source;
   ALfloat m_volume;

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -17,9 +17,9 @@
 #include <OpenAL/include/alc.h>
 #include <OpenAL/include/alext.h>
 
-#define SFX_MAX_SOURCE 1
-#define OAL_MAX_BUFFERS 32
-#define OAL_MAX_SAMPLES 256
+// OpenAL requires a minimum of two buffers, three or more recommended
+#define OAL_BUFFERS 3
+#define OAL_MAX_FRAMES 4096
 #define STEREO_CHANNELS 2
 #define SURROUND_CHANNELS 6  // number of channels in surround mode
 #define SIZE_SHORT 2
@@ -72,12 +72,11 @@ private:
 
   Common::Event soundSyncEvent;
 
-  short realtimeBuffer[OAL_MAX_SAMPLES * STEREO_CHANNELS];
-  float sampleBuffer[OAL_MAX_SAMPLES * SURROUND_CHANNELS * OAL_MAX_BUFFERS];
-  ALuint uiBuffers[OAL_MAX_BUFFERS];
+  std::vector<short> realtimeBuffer;
+  std::vector<float> sampleBuffer;
+  std::array<ALuint, OAL_BUFFERS> uiBuffers;
   ALuint uiSource;
   ALfloat fVolume;
 
-  u8 numBuffers;
 #endif  // _WIN32
 };

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -254,7 +254,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("SelectedLanguage", SelectedLanguage);
   core->Set("OverrideGCLang", bOverrideGCLanguage);
   core->Set("DPL2Decoder", bDPL2Decoder);
-  core->Set("Latency", iLatency);
+  core->Set("AudioLatency", iLatency);
   core->Set("AudioStretch", m_audio_stretch);
   core->Set("AudioStretchMaxLatency", m_audio_stretch_max_latency);
   core->Set("MemcardAPath", m_strMemoryCardA);
@@ -568,7 +568,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("SelectedLanguage", &SelectedLanguage, 0);
   core->Get("OverrideGCLang", &bOverrideGCLanguage, false);
   core->Get("DPL2Decoder", &bDPL2Decoder, false);
-  core->Get("Latency", &iLatency, 5);
+  core->Get("AudioLatency", &iLatency, 20);
   core->Get("AudioStretch", &m_audio_stretch, false);
   core->Get("AudioStretchMaxLatency", &m_audio_stretch_max_latency, 80);
   core->Get("MemcardAPath", &m_strMemoryCardA);
@@ -831,7 +831,7 @@ void SConfig::LoadDefaults()
   bOverrideGCLanguage = false;
   bWii = false;
   bDPL2Decoder = false;
-  iLatency = 14;
+  iLatency = 20;
   m_audio_stretch = false;
   m_audio_stretch_max_latency = 80;
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -109,7 +109,7 @@ struct SConfig : NonCopyable
   bool bCopyWiiSaveNetplay = true;
 
   bool bDPL2Decoder = false;
-  int iLatency = 14;
+  int iLatency = 20;
   bool m_audio_stretch = false;
   int m_audio_stretch_max_latency = 80;
 

--- a/Source/Core/DolphinWX/Config/AudioConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AudioConfigPane.cpp
@@ -45,8 +45,8 @@ void AudioConfigPane::InitializeGUI()
   m_audio_backend_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_audio_backend_strings);
   m_audio_latency_spinctrl =
-      new wxSpinCtrl(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 30);
-  m_audio_latency_label = new wxStaticText(this, wxID_ANY, _("Latency:"));
+      new wxSpinCtrl(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 200);
+  m_audio_latency_label = new wxStaticText(this, wxID_ANY, _("Latency (ms):"));
 
   m_stretch_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Audio Stretching"));
   m_stretch_label = new wxStaticText(this, wxID_ANY, _("Buffer Size:"));


### PR DESCRIPTION
Before these changes each unit of latency was actually 5ms, with a minimum latency of ~10 ms. If it was set to 4 ms on the UI, the actual latency was 10 ms + 5 ms (for each buffer, 256 samples at 48kHz) * 4 ms = 30 ms.
Now 30 ms on the UI means 30 ms on the backend.

~~**Problem:** People that had "low" values on their latency setting may think that the latency is now higher (even though it can be lower as I also commented out a Wait() event that did more harm than good) and they will need to increase their values to 20 or 30 ms.~~
I changed the setting in the INI from "Latency" to "AudioLatency" so everyone should have a good default.
Instead of commenting out the Wait() event (which I soon discovered caused high CPU usage, duh), I swapped it out for a std::sleep_for. Works a lot better now, only causes buffer underruns when the latency is set too low.

I also renamed all variables to the current coding standard, renamed some variables to better represent what they really are, removed a redundant conversion from short to floating point when playing back stereo and swapped all C-style arrays to std::array.

This PR is partially based on PR# 5191 and PR# 5235. Some changes I believe are particularly important (such as the removal of the redundant conversion from short to float) so I want to move it from PR# 5235 which will only be merged when I manage to discover why FreeSurround causes glitches on Ubuntu 16.04.

EDIT:

Just did some experiments with this PR and OpenAL Soft. If we set the latency to 15 ms and reduce the period size in its config file to 128 we get the same audio latency as XAudio2 😊

I also investigated why commenting out the Wait() event allows lower latencies.
After we call Wait() the thread unpauses only when SoundStream.Update() is called and samples are pushed into the mixer by SendAIBuffer(), but for some reason this doesn't work very well with OpenAL and fixed sized buffers. I made some changes on another branch where OpenAL receives and buffers all available samples at once hoping to lower its latency. The latency continued the same but works really well with Wait().

Luckily as OpenAL is in sync with the mixer (as it plays samples at the same rate it receives them) changing Wait() to sleep_for brings only advantages.