### PR TITLE
JitCache: use SymbolDB names as JIT block names

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -22,6 +22,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
+#include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 
 #ifdef _WIN32
@@ -131,7 +132,12 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& block, bool block_link,
     LinkBlock(block);
   }
 
-  JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_%08x", block.physicalAddress);
+  if (Symbol* symbol = g_symbolDB.GetSymbolFromAddr(block.effectiveAddress))
+    JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_%s_%08x",
+                          symbol->function_name.c_str(), block.physicalAddress);
+  else
+    JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_%08x",
+                          block.physicalAddress);
 }
 
 JitBlock* JitBaseBlockCache::GetBlockFromStartAddress(u32 addr, u32 msr)

--- a/Tools/perf-disassemble.sh
+++ b/Tools/perf-disassemble.sh
@@ -9,8 +9,8 @@
 #   kernel.yama.ptrace_scope = 0
 #
 # Example usage:
-# $ dolphin-emu -P /tmp -b -e $game
-# $ perf top -p $(pidof dolphin-emu) --objdump ./Tools/perf-disassemble.sh
+# $ dolphin-emu -C Dolphin.Core.PerfMapDir=/tmp -b -e $game
+# $ perf top -p $(pidof dolphin-emu) --objdump ./Tools/perf-disassemble.sh -M intel
 
 flavor=att
 raw=r


### PR DESCRIPTION
Useful to profile games that have map files. See the comment in Tools/perf-disassemble.sh for how to use this.