### PR TITLE
Rewrite SysConf handling

### DIFF
--- a/Source/Core/Common/SysConf.h
+++ b/Source/Core/Common/SysConf.h
@@ -2,193 +2,92 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+// Utilities to parse and modify a Wii SYSCONF file and its sections.
+
 #pragma once
 
-#include <algorithm>
-#include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
-#include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
 
-namespace File
-{
-class IOFile;
-}
-
-// This class is meant to edit the values in a given Wii SYSCONF file
-// It currently does not add/remove/rearrange sections,
-// instead only modifies exiting sections' data
-
-#define SYSCONF_SIZE 0x4000
-
-enum SysconfType
-{
-  Type_BigArray = 1,
-  Type_SmallArray,
-  Type_Byte,
-  Type_Short,
-  Type_Long,
-  Type_LongLong,
-  Type_Bool
-};
-
-struct SSysConfHeader
-{
-  char version[4];
-  u16 numEntries;
-};
-
-struct SSysConfEntry
-{
-  u16 offset = 0;
-  SysconfType type;
-  u8 nameLength = 0;
-  char name[32] = {};
-  u16 dataLength = 0;
-  std::vector<u8> data;
-
-  template <class T>
-  T GetData() const
-  {
-    T extracted_data;
-    std::memcpy(&extracted_data, data.data(), sizeof(T));
-    return extracted_data;
-  }
-  bool GetArrayData(u8* dest, u16 destSize) const
-  {
-    if (dest && destSize >= dataLength)
-    {
-      memcpy(dest, data.data(), dataLength);
-      return true;
-    }
-    return false;
-  }
-  bool SetArrayData(const u8* buffer, u16 bufferSize)
-  {
-    if (buffer)
-    {
-      memcpy(data.data(), buffer, std::min<u16>(bufferSize, dataLength));
-      return true;
-    }
-    return false;
-  }
-};
-
-class SysConf
+class SysConf final
 {
 public:
   SysConf(Common::FromWhichRoot root_type);
   ~SysConf();
 
-  bool IsValid() const { return m_IsValid; }
-  template <class T>
-  T GetData(const char* sectionName) const
+  void Clear();
+  void Load();
+  bool Save() const;
+
+  struct Entry
   {
-    if (!m_IsValid)
+    enum Type : u8
     {
-      PanicAlertT("Trying to read from invalid SYSCONF");
-      return 0;
+      BigArray = 1,
+      SmallArray = 2,
+      Byte = 3,
+      Short = 4,
+      Long = 5,
+      LongLong = 6,
+      // Should really be named Bool, but this conflicts with some random macro. :/
+      ByteBool = 7,
+    };
+
+    Entry(Type type_, const std::string& name_);
+    Entry(Type type_, const std::string& name_, const std::vector<u8>& bytes_);
+    Entry(Type type_, const std::string& name_, std::vector<u8>&& bytes_);
+
+    // Intended for use with the non array types.
+    template <typename T>
+    T GetData(T default_value) const
+    {
+      if (bytes.size() != sizeof(T))
+        return default_value;
+      T value;
+      std::memcpy(&value, bytes.data(), bytes.size());
+      return value;
+    }
+    template <typename T>
+    void SetData(T value)
+    {
+      _assert_(sizeof(value) == bytes.size());
+      std::memcpy(bytes.data(), &value, bytes.size());
     }
 
-    auto index = m_Entries.cbegin();
-    for (; index < m_Entries.cend() - 1; ++index)
-    {
-      if (strcmp(index->name, sectionName) == 0)
-        break;
-    }
-    if (index == m_Entries.cend() - 1)
-    {
-      PanicAlertT("Section %s not found in SYSCONF", sectionName);
-      return 0;
-    }
+    Type type;
+    std::string name;
+    std::vector<u8> bytes;
+  };
 
-    return index->GetData<T>();
-  }
+  void AddEntry(Entry&& entry);
+  Entry* GetEntry(const std::string& key);
+  const Entry* GetEntry(const std::string& key) const;
+  Entry* GetOrAddEntry(const std::string& key, Entry::Type type);
+  void RemoveEntry(const std::string& key);
 
-  bool GetArrayData(const char* sectionName, u8* dest, u16 destSize) const
+  // Intended for use with the non array types.
+  template <typename T>
+  T GetData(const std::string& key, T default_value) const
   {
-    if (!m_IsValid)
-    {
-      PanicAlertT("Trying to read from invalid SYSCONF");
-      return false;
-    }
-
-    auto index = m_Entries.cbegin();
-    for (; index < m_Entries.cend() - 1; ++index)
-    {
-      if (strcmp(index->name, sectionName) == 0)
-        break;
-    }
-    if (index == m_Entries.cend() - 1)
-    {
-      PanicAlertT("Section %s not found in SYSCONF", sectionName);
-      return false;
-    }
-
-    return index->GetArrayData(dest, destSize);
+    const Entry* entry = GetEntry(key);
+    return entry ? entry->GetData(default_value) : default_value;
   }
-
-  bool SetArrayData(const char* sectionName, const u8* buffer, u16 bufferSize)
+  template <typename T>
+  void SetData(const std::string& key, Entry::Type type, T value)
   {
-    if (!m_IsValid)
-      return false;
-
-    auto index = m_Entries.begin();
-    for (; index < m_Entries.end() - 1; ++index)
-    {
-      if (strcmp(index->name, sectionName) == 0)
-        break;
-    }
-    if (index == m_Entries.end() - 1)
-    {
-      PanicAlertT("Section %s not found in SYSCONF", sectionName);
-      return false;
-    }
-
-    return index->SetArrayData(buffer, bufferSize);
+    GetOrAddEntry(key, type)->SetData(value);
   }
-
-  template <class T>
-  bool SetData(const char* sectionName, T newValue)
-  {
-    if (!m_IsValid)
-      return false;
-
-    auto index = m_Entries.begin();
-    for (; index < m_Entries.end() - 1; ++index)
-    {
-      if (strcmp(index->name, sectionName) == 0)
-        break;
-    }
-    if (index == m_Entries.end() - 1)
-    {
-      PanicAlertT("Section %s not found in SYSCONF", sectionName);
-      return false;
-    }
-
-    std::memcpy(index->data.data(), &newValue, sizeof(T));
-    return true;
-  }
-
-  bool Save();
-  bool SaveToFile(const std::string& filename);
-  bool LoadFromFile(const std::string& filename);
-  bool Reload();
-  void UpdateLocation(Common::FromWhichRoot root_type);
 
 private:
-  bool LoadFromFileInternal(File::IOFile&& file);
-  void GenerateSysConf();
-  void Clear();
   void ApplySettingsFromMovie();
+  void InsertDefaultEntries();
+  bool LoadFromFile(const std::string& file_name);
 
-  std::string m_Filename;
-  std::string m_FilenameDefault;
-  std::vector<SSysConfEntry> m_Entries;
-  bool m_IsValid = false;
+  std::string m_file_name;
+  std::vector<Entry> m_entries;
 };

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -376,21 +376,25 @@ void SConfig::SaveSettingsToSysconf()
 {
   SysConf sysconf{Common::FromWhichRoot::FROM_CONFIGURED_ROOT};
 
-  sysconf.SetData<u8>("IPL.SSV", m_wii_screensaver);
-  sysconf.SetData<u8>("IPL.LNG", m_wii_language);
+  sysconf.SetData<u8>("IPL.SSV", SysConf::Entry::Type::Byte, m_wii_screensaver);
+  sysconf.SetData<u8>("IPL.LNG", SysConf::Entry::Type::Byte, m_wii_language);
 
-  sysconf.SetData<u8>("IPL.AR", m_wii_aspect_ratio);
-  sysconf.SetData<u8>("BT.BAR", m_sensor_bar_position);
-  sysconf.SetData<u32>("BT.SENS", m_sensor_bar_sensitivity);
-  sysconf.SetData<u8>("BT.SPKV", m_speaker_volume);
-  sysconf.SetData("BT.MOT", m_wiimote_motor);
-  sysconf.SetData("IPL.PGS", bProgressive);
-  sysconf.SetData("IPL.E60", bPAL60);
+  sysconf.SetData<u8>("IPL.AR", SysConf::Entry::Type::Byte, m_wii_aspect_ratio);
+  sysconf.SetData<u8>("BT.BAR", SysConf::Entry::Type::Byte, m_sensor_bar_position);
+  sysconf.SetData<u32>("BT.SENS", SysConf::Entry::Type::Long, m_sensor_bar_sensitivity);
+  sysconf.SetData<u8>("BT.SPKV", SysConf::Entry::Type::Byte, m_speaker_volume);
+  sysconf.SetData<u8>("BT.MOT", SysConf::Entry::Type::Byte, m_wiimote_motor);
+  sysconf.SetData<u8>("IPL.PGS", SysConf::Entry::Type::Byte, bProgressive);
+  sysconf.SetData<u8>("IPL.E60", SysConf::Entry::Type::Byte, bPAL60);
 
   // Disable WiiConnect24's standby mode. If it is enabled, it prevents us from receiving
   // shutdown commands in the State Transition Manager (STM).
   // TODO: remove this if and once Dolphin supports WC24 standby mode.
-  sysconf.SetData<u8>("IPL.IDL", 0x00);
+  SysConf::Entry* idle_entry = sysconf.GetOrAddEntry("IPL.IDL", SysConf::Entry::Type::SmallArray);
+  if (idle_entry->bytes.empty())
+    idle_entry->bytes = std::vector<u8>(2);
+  else
+    idle_entry->bytes[0] = 0;
   NOTICE_LOG(COMMON, "Disabling WC24 'standby' (shutdown to idle) to avoid hanging on shutdown");
 
   IOS::HLE::RestoreBTInfoSection(&sysconf);
@@ -706,15 +710,15 @@ void SConfig::LoadSettingsFromSysconf()
 {
   SysConf sysconf{Common::FromWhichRoot::FROM_CONFIGURED_ROOT};
 
-  m_wii_screensaver = sysconf.GetData<u8>("IPL.SSV");
-  m_wii_language = sysconf.GetData<u8>("IPL.LNG");
-  m_wii_aspect_ratio = sysconf.GetData<u8>("IPL.AR");
-  m_sensor_bar_position = sysconf.GetData<u8>("BT.BAR");
-  m_sensor_bar_sensitivity = sysconf.GetData<u32>("BT.SENS");
-  m_speaker_volume = sysconf.GetData<u8>("BT.SPKV");
-  m_wiimote_motor = sysconf.GetData<u8>("BT.MOT") != 0;
-  bProgressive = sysconf.GetData<u8>("IPL.PGS") != 0;
-  bPAL60 = sysconf.GetData<u8>("IPL.E60") != 0;
+  m_wii_screensaver = sysconf.GetData<u8>("IPL.SSV", m_wii_screensaver);
+  m_wii_language = sysconf.GetData<u8>("IPL.LNG", m_wii_language);
+  m_wii_aspect_ratio = sysconf.GetData<u8>("IPL.AR", m_wii_aspect_ratio);
+  m_sensor_bar_position = sysconf.GetData<u8>("BT.BAR", m_sensor_bar_position);
+  m_sensor_bar_sensitivity = sysconf.GetData<u32>("BT.SENS", m_sensor_bar_sensitivity);
+  m_speaker_volume = sysconf.GetData<u8>("BT.SPKV", m_speaker_volume);
+  m_wiimote_motor = sysconf.GetData<u8>("BT.MOT", m_wiimote_motor) != 0;
+  bProgressive = sysconf.GetData<u8>("IPL.PGS", bProgressive) != 0;
+  bPAL60 = sysconf.GetData<u8>("IPL.E60", bPAL60) != 0;
 }
 
 void SConfig::ResetRunningGameMetadata()

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
@@ -27,12 +27,12 @@ void BackUpBTInfoSection(const SysConf* sysconf)
   if (File::Exists(filename))
     return;
   File::IOFile backup(filename, "wb");
-  std::vector<u8> section(BT_INFO_SECTION_LENGTH);
-  if (!sysconf->GetArrayData("BT.DINF", section.data(), static_cast<u16>(section.size())))
-  {
-    ERROR_LOG(IOS_WIIMOTE, "Failed to read source BT.DINF section");
+
+  const SysConf::Entry* btdinf = sysconf->GetEntry("BT.DINF");
+  if (!btdinf)
     return;
-  }
+
+  const std::vector<u8>& section = btdinf->bytes;
   if (!backup.WriteBytes(section.data(), section.size()))
     ERROR_LOG(IOS_WIIMOTE, "Failed to back up BT.DINF section");
 }
@@ -49,7 +49,8 @@ void RestoreBTInfoSection(SysConf* sysconf)
     ERROR_LOG(IOS_WIIMOTE, "Failed to read backed up BT.DINF section");
     return;
   }
-  sysconf->SetArrayData("BT.DINF", section.data(), static_cast<u16>(section.size()));
+
+  sysconf->GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes = std::move(section);
   File::Delete(filename);
 }
 }  // namespace HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -48,44 +48,41 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
     BackUpBTInfoSection(&sysconf);
 
   _conf_pads BT_DINF;
-  if (!sysconf.GetArrayData("BT.DINF", (u8*)&BT_DINF, sizeof(_conf_pads)))
+  bdaddr_t tmpBD = BDADDR_ANY;
+  u8 i = 0;
+  while (i < MAX_BBMOTES)
   {
-    PanicAlertT("Trying to read from invalid SYSCONF\nWii Remote Bluetooth IDs are not available");
+    // Previous records can be safely overwritten, since they are backed up
+    tmpBD.b[5] = BT_DINF.active[i].bdaddr[0] = BT_DINF.registered[i].bdaddr[0] = i;
+    tmpBD.b[4] = BT_DINF.active[i].bdaddr[1] = BT_DINF.registered[i].bdaddr[1] = 0;
+    tmpBD.b[3] = BT_DINF.active[i].bdaddr[2] = BT_DINF.registered[i].bdaddr[2] = 0x79;
+    tmpBD.b[2] = BT_DINF.active[i].bdaddr[3] = BT_DINF.registered[i].bdaddr[3] = 0x19;
+    tmpBD.b[1] = BT_DINF.active[i].bdaddr[4] = BT_DINF.registered[i].bdaddr[4] = 2;
+    tmpBD.b[0] = BT_DINF.active[i].bdaddr[5] = BT_DINF.registered[i].bdaddr[5] = 0x11;
+
+    const char* wmName;
+    if (i == WIIMOTE_BALANCE_BOARD)
+      wmName = "Nintendo RVL-WBC-01";
+    else
+      wmName = "Nintendo RVL-CNT-01";
+    memcpy(BT_DINF.registered[i].name, wmName, 20);
+    memcpy(BT_DINF.active[i].name, wmName, 20);
+
+    DEBUG_LOG(IOS_WIIMOTE, "Wii Remote %d BT ID %x,%x,%x,%x,%x,%x", i, tmpBD.b[0], tmpBD.b[1],
+              tmpBD.b[2], tmpBD.b[3], tmpBD.b[4], tmpBD.b[5]);
+    m_WiiMotes.emplace_back(this, i, tmpBD, g_wiimote_sources[i] != WIIMOTE_SRC_NONE);
+    i++;
   }
-  else
-  {
-    bdaddr_t tmpBD = BDADDR_ANY;
-    u8 i = 0;
-    while (i < MAX_BBMOTES)
-    {
-      // Previous records can be safely overwritten, since they are backed up
-      tmpBD.b[5] = BT_DINF.active[i].bdaddr[0] = BT_DINF.registered[i].bdaddr[0] = i;
-      tmpBD.b[4] = BT_DINF.active[i].bdaddr[1] = BT_DINF.registered[i].bdaddr[1] = 0;
-      tmpBD.b[3] = BT_DINF.active[i].bdaddr[2] = BT_DINF.registered[i].bdaddr[2] = 0x79;
-      tmpBD.b[2] = BT_DINF.active[i].bdaddr[3] = BT_DINF.registered[i].bdaddr[3] = 0x19;
-      tmpBD.b[1] = BT_DINF.active[i].bdaddr[4] = BT_DINF.registered[i].bdaddr[4] = 2;
-      tmpBD.b[0] = BT_DINF.active[i].bdaddr[5] = BT_DINF.registered[i].bdaddr[5] = 0x11;
 
-      const char* wmName;
-      if (i == WIIMOTE_BALANCE_BOARD)
-        wmName = "Nintendo RVL-WBC-01";
-      else
-        wmName = "Nintendo RVL-CNT-01";
-      memcpy(BT_DINF.registered[i].name, wmName, 20);
-      memcpy(BT_DINF.active[i].name, wmName, 20);
+  BT_DINF.num_registered = MAX_BBMOTES;
 
-      DEBUG_LOG(IOS_WIIMOTE, "Wii Remote %d BT ID %x,%x,%x,%x,%x,%x", i, tmpBD.b[0], tmpBD.b[1],
-                tmpBD.b[2], tmpBD.b[3], tmpBD.b[4], tmpBD.b[5]);
-      m_WiiMotes.emplace_back(this, i, tmpBD, g_wiimote_sources[i] != WIIMOTE_SRC_NONE);
-      i++;
-    }
-
-    BT_DINF.num_registered = MAX_BBMOTES;
-    // save now so that when games load sysconf file it includes the new Wii Remotes
-    // and the correct order for connected Wii Remotes
-    if (!sysconf.SetArrayData("BT.DINF", (u8*)&BT_DINF, sizeof(_conf_pads)) || !sysconf.Save())
-      PanicAlertT("Failed to write BT.DINF to SYSCONF");
-  }
+  // save now so that when games load sysconf file it includes the new Wii Remotes
+  // and the correct order for connected Wii Remotes
+  std::vector<u8> data(sizeof(_conf_pads));
+  std::memcpy(data.data(), &BT_DINF, data.size());
+  sysconf.GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes = std::move(data);
+  if (!sysconf.Save())
+    PanicAlertT("Failed to write BT.DINF to SYSCONF");
 
   // The BCM2045's btaddr:
   m_ControllerBD.b[0] = 0x11;


### PR DESCRIPTION
This rewrites the SysConf code for several reasons:

* Modernising the SysConf class. The naming was entirely cleaned up. constexpr for constants.

* Exposing less stuff in the header.

* Probably less efficient parsing and writing logic, but much simpler to understand and use in my opinion. No more hardcoded offsets. No more duplicated code for the initial SYSCONF generation.

* More flexibility. It is now possible to add and remove entries, since we rebuild the file. This allows us to stop spamming "section not found" panic alerts; we can now use and insert default entries.