### PR TITLE
UnitTests: Use a temporary profile directory

### DIFF
--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -6,7 +6,9 @@
 
 #include <array>
 #include <bitset>
+#include <string>
 
+#include "Common/FileUtil.h"
 #include "Core/Config/Config.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -35,10 +37,10 @@ void CallbackTemplate(u64 userdata, s64 lateness)
 class ScopeInit final
 {
 public:
-  ScopeInit()
+  ScopeInit() : m_profile_path(File::CreateTempDir())
   {
     Core::DeclareAsCPUThread();
-    UICommon::SetUserDirectory("");
+    UICommon::SetUserDirectory(m_profile_path);
     Config::Init();
     SConfig::Init();
     PowerPC::Init(PowerPC::CORE_INTERPRETER);
@@ -51,7 +53,10 @@ public:
     SConfig::Shutdown();
     Config::Shutdown();
     Core::UndeclareAsCPUThread();
+    File::DeleteDirRecursively(m_profile_path);
   }
+private:
+  std::string m_profile_path;
 };
 
 static void AdvanceAndCheck(u32 idx, int downcount, int expected_lateness = 0,

--- a/Source/UnitTests/Core/MMIOTest.cpp
+++ b/Source/UnitTests/Core/MMIOTest.cpp
@@ -3,9 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <gtest/gtest.h>
+#include <string>
 #include <unordered_set>
 
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Core/Config/Config.h"
 #include "Core/HW/MMIO.h"
 #include "UICommon/UICommon.h"
@@ -31,7 +33,8 @@ TEST(UniqueID, UniqueEnough)
 
 TEST(IsMMIOAddress, SpecialAddresses)
 {
-  UICommon::SetUserDirectory("");
+  const std::string profile_path = File::CreateTempDir();
+  UICommon::SetUserDirectory(profile_path);
   Config::Init();
   SConfig::Init();
   SConfig::GetInstance().bWii = true;
@@ -56,6 +59,7 @@ TEST(IsMMIOAddress, SpecialAddresses)
 
   SConfig::Shutdown();
   Config::Shutdown();
+  File::DeleteDirRecursively(profile_path);
 }
 
 class MappingTest : public testing::Test


### PR DESCRIPTION
This prevents Dolphin from modifying any file in the user directory.