### PR TITLE
VideoCommon: Fix VS filter for AbstractTexture.cpp

### DIFF
--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -171,8 +171,8 @@
       <Filter>Base</Filter>
     </ClCompile>
     <ClCompile Include="AbstractTexture.cpp">
-	  <Filter>Base</Filter>
-	</C1Compile>
+      <Filter>Base</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CommandProcessor.h" />


### PR DESCRIPTION
This would cause failures when building with VS.