### PR TITLE
AbstractRawTexture

### DIFF
--- a/Source/Core/VideoBackends/D3D/CMakeLists.txt
+++ b/Source/Core/VideoBackends/D3D/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SRCS
   D3DUtil.h
   DXTexture.cpp
   DXTexture.h
+  DXTextureRaw.cpp
+  DXTextureRaw.h
   FramebufferManager.cpp
   FramebufferManager.h
   GeometryShaderCache.cpp

--- a/Source/Core/VideoBackends/D3D/D3D.vcxproj
+++ b/Source/Core/VideoBackends/D3D/D3D.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="D3DTexture.cpp" />
     <ClCompile Include="D3DUtil.cpp" />
     <ClCompile Include="DXTexture.cpp" />
+    <ClCompile Include="DXTextureRaw.cpp" />
     <ClCompile Include="FramebufferManager.cpp" />
     <ClCompile Include="GeometryShaderCache.cpp" />
     <ClCompile Include="main.cpp" />
@@ -67,6 +68,7 @@
     <ClInclude Include="D3DTexture.h" />
     <ClInclude Include="D3DUtil.h" />
     <ClInclude Include="DXTexture.h" />
+    <ClInclude Include="DXTextureRaw.h" />
     <ClInclude Include="FramebufferManager.h" />
     <ClInclude Include="GeometryShaderCache.h" />
     <ClInclude Include="PerfQuery.h" />

--- a/Source/Core/VideoBackends/D3D/D3D.vcxproj.filters
+++ b/Source/Core/VideoBackends/D3D/D3D.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="DXTexture.cpp">
       <Filter>Render</Filter>
     </ClCompile>
+    <ClCompile Include="DXTextureRaw.cpp">
+      <Filter>Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="D3DBase.h">
@@ -128,6 +131,9 @@
       <Filter>Render</Filter>
     </ClInclude>
     <ClInclude Include="DXTexture.h">
+      <Filter>Render</Filter>
+    </ClInclude>
+    <ClInclude Include="DXTextureRaw.h">
       <Filter>Render</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Source/Core/VideoBackends/D3D/DXTexture.h
+++ b/Source/Core/VideoBackends/D3D/DXTexture.h
@@ -19,7 +19,7 @@ public:
   ~DXTexture();
 
   void Bind(unsigned int stage) override;
-  bool Save(const std::string& filename, unsigned int level) override;
+  std::unique_ptr<AbstractRawTexture> GetRawData(unsigned int level) override;
 
   void CopyRectangleFromTexture(const AbstractTexture* source,
                                 const MathUtil::Rectangle<int>& srcrect,

--- a/Source/Core/VideoBackends/D3D/DXTextureRaw.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTextureRaw.cpp
@@ -1,0 +1,24 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <d3d11.h>
+
+#include "VideoBackends/D3D/D3DBase.h"
+#include "VideoBackends/D3D/DXTextureRaw.h"
+
+namespace DX11
+{
+DXTextureRaw::DXTextureRaw(const u8* data, u32 stride, u32 width, u32 height,
+                           ID3D11Texture2D* texture)
+    : AbstractRawTexture(data, stride, width, height), m_stagingTexture(texture)
+{
+}
+
+DXTextureRaw::~DXTextureRaw()
+{
+  D3D::context->Unmap(m_stagingTexture, 0);
+  m_stagingTexture->Release();
+}
+
+}  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/DXTextureRaw.h
+++ b/Source/Core/VideoBackends/D3D/DXTextureRaw.h
@@ -1,0 +1,25 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "VideoCommon/AbstractRawTexture.h"
+
+struct ID3D11Texture2D;
+
+namespace DX11
+{
+class DXTextureRaw final : public AbstractRawTexture
+{
+public:
+  DXTextureRaw(const u8* data, u32 stride, u32 width, u32 height, ID3D11Texture2D* texture);
+  ~DXTextureRaw();
+
+private:
+  ID3D11Texture2D* m_stagingTexture;
+};
+
+}  // namespace DX11

--- a/Source/Core/VideoBackends/OGL/CMakeLists.txt
+++ b/Source/Core/VideoBackends/OGL/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRCS
   main.cpp
   NativeVertexFormat.cpp
   OGLTexture.cpp
+  OGLTextureRaw.cpp
   PerfQuery.cpp
   PostProcessing.cpp
   ProgramShaderCache.cpp

--- a/Source/Core/VideoBackends/OGL/OGL.vcxproj
+++ b/Source/Core/VideoBackends/OGL/OGL.vcxproj
@@ -41,6 +41,7 @@
     <ClCompile Include="FramebufferManager.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="NativeVertexFormat.cpp" />
+    <ClCompile Include="OGLTextureRaw.cpp" />
     <ClCompile Include="PerfQuery.cpp" />
     <ClCompile Include="PostProcessing.cpp" />
     <ClCompile Include="ProgramShaderCache.cpp" />
@@ -57,6 +58,7 @@
     <ClInclude Include="BoundingBox.h" />
     <ClInclude Include="FramebufferManager.h" />
     <ClInclude Include="GPUTimer.h" />
+    <ClInclude Include="OGLTextureRaw.h" />
     <ClInclude Include="PerfQuery.h" />
     <ClInclude Include="PostProcessing.h" />
     <ClInclude Include="ProgramShaderCache.h" />

--- a/Source/Core/VideoBackends/OGL/OGL.vcxproj.filters
+++ b/Source/Core/VideoBackends/OGL/OGL.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClCompile Include="OGLTexture.cpp">
       <Filter>Render</Filter>
     </ClCompile>
+    <ClCompile Include="OGLTextureRaw.cpp">
+      <Filter>Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="VertexManager.h">
@@ -97,6 +100,9 @@
       <Filter>GLUtil</Filter>
     </ClInclude>
     <ClInclude Include="OGLTexture.h">
+      <Filter>Render</Filter>
+    </ClInclude>
+    <ClInclude Include="OGLTextureRaw.h">
       <Filter>Render</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Source/Core/VideoBackends/OGL/OGLTexture.h
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.h
@@ -17,7 +17,7 @@ public:
   ~OGLTexture();
 
   void Bind(unsigned int stage) override;
-  bool Save(const std::string& filename, unsigned int level) override;
+  std::unique_ptr<AbstractRawTexture> GetRawData(unsigned int level) override;
 
   void CopyRectangleFromTexture(const AbstractTexture* source,
                                 const MathUtil::Rectangle<int>& srcrect,

--- a/Source/Core/VideoBackends/OGL/OGLTextureRaw.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTextureRaw.cpp
@@ -1,0 +1,15 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoBackends/OGL/OGLTextureRaw.h"
+
+namespace OGL
+{
+OGLTextureRaw::OGLTextureRaw(u32 stride, u32 width, u32 height, std::vector<u8>&& glData)
+    : AbstractRawTexture(nullptr, stride, width, height), m_glData(std::move(glData))
+{
+  m_data = m_glData.data();
+}
+
+}  // namespace OGL

--- a/Source/Core/VideoBackends/OGL/OGLTextureRaw.h
+++ b/Source/Core/VideoBackends/OGL/OGLTextureRaw.h
@@ -1,0 +1,25 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "VideoCommon/AbstractRawTexture.h"
+
+namespace OGL
+{
+class StagingTexture2D;
+
+class OGLTextureRaw final : public AbstractRawTexture
+{
+public:
+  OGLTextureRaw(u32 stride, u32 width, u32 height, std::vector<u8>&& glData);
+
+private:
+  std::vector<u8> m_glData;
+};
+
+}  // namespace OGL

--- a/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRCS
   VertexFormat.cpp
   VertexManager.cpp
   VKTexture.cpp
+  VKTextureRaw.cpp
   VulkanContext.cpp
   VulkanLoader.cpp
   main.cpp

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -20,7 +20,7 @@ public:
   ~VKTexture();
 
   void Bind(unsigned int stage) override;
-  bool Save(const std::string& filename, unsigned int level) override;
+  std::unique_ptr<AbstractRawTexture> GetRawData(unsigned int level) override;
 
   void CopyRectangleFromTexture(const AbstractTexture* source,
                                 const MathUtil::Rectangle<int>& srcrect,

--- a/Source/Core/VideoBackends/Vulkan/VKTextureRaw.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTextureRaw.cpp
@@ -1,0 +1,21 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoBackends/Vulkan/VKTextureRaw.h"
+#include "VideoBackends/Vulkan/StagingTexture2D.h"
+
+namespace Vulkan
+{
+VKTextureRaw::VKTextureRaw(const u8* data, u32 stride, u32 width, u32 height,
+                           std::unique_ptr<StagingTexture2D> texture)
+    : AbstractRawTexture(data, stride, width, height), m_stagingTexture(std::move(texture))
+{
+}
+
+VKTextureRaw::~VKTextureRaw()
+{
+  m_stagingTexture->Unmap();
+}
+
+}  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/VKTextureRaw.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTextureRaw.h
@@ -1,0 +1,26 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "VideoCommon/AbstractRawTexture.h"
+
+namespace Vulkan
+{
+class StagingTexture2D;
+
+class VKTextureRaw final : public AbstractRawTexture
+{
+public:
+  VKTextureRaw(const u8* data, u32 stride, u32 width, u32 height,
+               std::unique_ptr<StagingTexture2D> texture);
+  ~VKTextureRaw();
+
+private:
+  std::unique_ptr<StagingTexture2D> m_stagingTexture;
+};
+
+}  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
+++ b/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
@@ -58,6 +58,7 @@
     <ClCompile Include="TextureCache.cpp" />
     <ClCompile Include="VertexManager.cpp" />
     <ClCompile Include="VKTexture.cpp" />
+    <ClCompile Include="VKTextureRaw.cpp" />
     <ClCompile Include="VulkanContext.cpp" />
     <ClCompile Include="VulkanLoader.cpp" />
   </ItemGroup>
@@ -85,6 +86,7 @@
     <ClInclude Include="VertexManager.h" />
     <ClInclude Include="VideoBackend.h" />
     <ClInclude Include="VKTexture.h" />
+    <ClInclude Include="VKTextureRaw.h" />
     <ClInclude Include="VulkanContext.h" />
     <ClInclude Include="VulkanLoader.h" />
   </ItemGroup>

--- a/Source/Core/VideoCommon/AbstractRawTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractRawTexture.cpp
@@ -1,0 +1,38 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/AbstractRawTexture.h"
+#include "VideoCommon/ImageWrite.h"
+
+AbstractRawTexture::AbstractRawTexture(const u8* data, u32 stride, u32 width, u32 height)
+    : m_data(data), m_stride(stride), m_width(width), m_height(height)
+{
+}
+
+AbstractRawTexture::~AbstractRawTexture() = default;
+
+const u8* AbstractRawTexture::GetData() const
+{
+  return m_data;
+}
+
+u32 AbstractRawTexture::GetStride() const
+{
+  return m_stride;
+}
+
+u32 AbstractRawTexture::GetWidth() const
+{
+  return m_width;
+}
+
+u32 AbstractRawTexture::GetHeight() const
+{
+  return m_height;
+}
+
+bool AbstractRawTexture::Save(const std::string& filename)
+{
+  return TextureToPng(m_data, m_stride, filename, m_width, m_height);
+}

--- a/Source/Core/VideoCommon/AbstractRawTexture.h
+++ b/Source/Core/VideoCommon/AbstractRawTexture.h
@@ -1,0 +1,29 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "Common/CommonTypes.h"
+
+class AbstractRawTexture
+{
+public:
+  AbstractRawTexture(const u8* data, u32 stride, u32 width, u32 height);
+  virtual ~AbstractRawTexture();
+
+  const u8* GetData() const;
+  u32 GetStride() const;
+  u32 GetWidth() const;
+  u32 GetHeight() const;
+
+  bool Save(const std::string& filename);
+
+protected:
+  const u8* m_data;
+  u32 m_stride;
+  u32 m_width;
+  u32 m_height;
+};

--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "VideoCommon/AbstractRawTexture.h"
 #include "VideoCommon/AbstractTexture.h"
 
 AbstractTexture::AbstractTexture(const TextureConfig& c) : m_config(c)
@@ -14,7 +15,19 @@ AbstractTexture::~AbstractTexture() = default;
 
 bool AbstractTexture::Save(const std::string& filename, unsigned int level)
 {
-  return false;
+  auto raw_texture = GetRawData(level);
+
+  if (raw_texture == nullptr)
+  {
+    return false;
+  }
+
+  return raw_texture->Save(filename);
+}
+
+std::unique_ptr<AbstractRawTexture> AbstractTexture::GetRawData(unsigned int level)
+{
+  return nullptr;
 }
 
 bool AbstractTexture::IsCompressedHostTextureFormat(AbstractTextureFormat format)

--- a/Source/Core/VideoCommon/AbstractTexture.h
+++ b/Source/Core/VideoCommon/AbstractTexture.h
@@ -5,11 +5,14 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "VideoCommon/TextureConfig.h"
+
+class AbstractRawTexture;
 
 class AbstractTexture
 {
@@ -17,7 +20,8 @@ public:
   explicit AbstractTexture(const TextureConfig& c);
   virtual ~AbstractTexture();
   virtual void Bind(unsigned int stage) = 0;
-  virtual bool Save(const std::string& filename, unsigned int level);
+  bool Save(const std::string& filename, unsigned int level);
+  virtual std::unique_ptr<AbstractRawTexture> GetRawData(unsigned int level);
 
   virtual void CopyRectangleFromTexture(const AbstractTexture* source,
                                         const MathUtil::Rectangle<int>& srcrect,

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SRCS
+  AbstractRawTexture.cpp
   AbstractTexture.cpp
   AsyncRequests.cpp
   BoundingBox.cpp

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -36,6 +36,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClCompile Include="AbstractRawTexture.cpp" />
     <ClCompile Include="AbstractTexture.cpp" />
     <ClCompile Include="AsyncRequests.cpp" />
     <ClCompile Include="AVIDump.cpp" />
@@ -91,6 +92,7 @@
     <ClCompile Include="XFStructs.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AbstractRawTexture.h" />
     <ClInclude Include="AbstractTexture.h" />
     <ClInclude Include="AsyncRequests.h" />
     <ClInclude Include="AVIDump.h" />

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -173,6 +173,9 @@
     <ClCompile Include="AbstractTexture.cpp">
       <Filter>Base</Filter>
     </ClCompile>
+    <ClCompile Include="AbstractRawTexture.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CommandProcessor.h" />
@@ -327,6 +330,9 @@
       <Filter>Base</Filter>
     </ClInclude>
     <ClInclude Include="AbstractTexture.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractRawTexture.h">
       <Filter>Base</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Much like the AbstractTexture ( #5305 ), this allows a way to get texture data in a backend agnostic way.  This is used in Hybrid xfb ( #5498 ) to save frame and movie data directly in videocommon.

Ready to be reviewed and merged.  Tested saving textures on all backends with no issues.