### PR TITLE
Qt: Fix emulation stopped signal

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -52,6 +52,7 @@ MainWindow::MainWindow() : QMainWindow(nullptr)
   ConnectMenuBar();
 
   InitControllers();
+  InitCoreCallbacks();
 }
 
 MainWindow::~MainWindow()
@@ -86,6 +87,11 @@ void MainWindow::ShutdownControllers()
   HotkeyManagerEmu::Shutdown();
 
   m_hotkey_scheduler->deleteLater();
+}
+
+void MainWindow::InitCoreCallbacks()
+{
+  Core::SetOnStoppedCallback([this] { emit EmulationStopped(); });
 }
 
 static void InstallHotkeyFilter(QWidget* dialog)
@@ -291,7 +297,6 @@ void MainWindow::ForceStop()
 {
   BootManager::Stop();
   HideRenderWidget();
-  emit EmulationStopped();
 }
 
 void MainWindow::Reset()

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -69,6 +69,8 @@ private:
   void InitControllers();
   void ShutdownControllers();
 
+  void InitCoreCallbacks();
+
   void StartGame(const QString& path);
   void ShowRenderWidget();
   void HideRenderWidget();


### PR DESCRIPTION
Same old bug as in WX. The core is not shut down until the on stopped callback is invoked.