### PR TITLE
IOS/ES: Add some sanity checks to ImportTitleDone

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -61,6 +61,11 @@ bool Content::IsShared() const
   return (type & 0x8000) != 0;
 }
 
+bool Content::IsOptional() const
+{
+  return (type & 0x4000) != 0;
+}
+
 SignedBlobReader::SignedBlobReader(const std::vector<u8>& bytes) : m_bytes(bytes)
 {
 }

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -83,6 +83,7 @@ static_assert(sizeof(TMDHeader) == 0x1e4, "TMDHeader has the wrong size");
 struct Content
 {
   bool IsShared() const;
+  bool IsOptional() const;
   u32 id;
   u16 index;
   u16 type;

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -350,7 +350,7 @@ IPCCommandResult ES::ImportContentEnd(Context& context, const IOCtlVRequest& req
 
 ReturnCode ES::ImportTitleDone(Context& context)
 {
-  if (!context.title_import.tmd.IsValid())
+  if (!context.title_import.tmd.IsValid() || context.title_import.content_id != 0xFFFFFFFF)
     return ES_EINVAL;
 
   if (!WriteImportTMD(context.title_import.tmd))


### PR DESCRIPTION
It should not be possible to finish the title import if:
* A content import is still a progress, or;
* Some contents that are listed as required in the TMD haven't been imported at all.

This should prevent titles from getting into an inconsistent, half-installed state.