### PR TITLE
Qt: Remove the warning in the settings window

### DIFF
--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -26,7 +26,6 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   // Main Layout
   QVBoxLayout* layout = new QVBoxLayout;
   QHBoxLayout* content = new QHBoxLayout;
-  QVBoxLayout* content_inner = new QVBoxLayout;
   // Content's widgets
   {
     // Category list
@@ -36,12 +35,7 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
     // Actual Settings UI
     SetupSettingsWidget();
 
-    MakeUnfinishedWarning();
-
-    content_inner->addWidget(m_warning_group);
-    content_inner->addWidget(m_settings_outer);
-
-    content->addLayout(content_inner);
+    content->addWidget(m_settings_outer);
   }
 
   // Add content to layout before dialog buttons.
@@ -64,16 +58,6 @@ void SettingsWindow::SetupSettingsWidget()
   m_settings_outer->addWidget(new GeneralPane);
   m_settings_outer->addWidget(new InterfacePane);
   m_settings_outer->addWidget(new PathPane);
-}
-
-void SettingsWindow::MakeUnfinishedWarning()
-{
-  m_warning_group = new QGroupBox(tr("Warning"));
-  QHBoxLayout* m_warning_group_layout = new QHBoxLayout;
-  QLabel* warning_text = new QLabel(tr("Some categories and settings will not work.\n"
-                                       "This Settings Window is under active development."));
-  m_warning_group_layout->addWidget(warning_text);
-  m_warning_group->setLayout(m_warning_group_layout);
 }
 
 void SettingsWindow::AddCategoryToList(const QString& title, const std::string& icon_name)

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -24,10 +24,8 @@ public slots:
 
 private:
   void MakeCategoryList();
-  void MakeUnfinishedWarning();
   void AddCategoryToList(const QString& title, const std::string& icon_name);
   void SetupSettingsWidget();
   QStackedWidget* m_settings_outer;
   QListWidget* m_categories;
-  QGroupBox* m_warning_group;
 };


### PR DESCRIPTION
There is no need for this warning in the settings window, as we already scare users away with the big warning when you launch the program.

Before: 
![image](https://user-images.githubusercontent.com/4411333/27358096-4b28a15c-55d2-11e7-8c5b-9e9feb4a8839.png)

After:
![image](https://user-images.githubusercontent.com/4411333/27358036-fd8b49f4-55d1-11e7-9dfc-cfcc4374caff.png)
