### PR TITLE
Qt: Shrink settings window and make widgets stretch

### DIFF
--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -7,6 +7,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidget>
+#include <QScrollBar>
 #include <QStackedWidget>
 #include <QVBoxLayout>
 
@@ -24,7 +25,6 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   // Set Window Properties
   setWindowTitle(tr("Settings"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-  resize(720, 600);
 
   // Main Layout
   QVBoxLayout* layout = new QVBoxLayout;
@@ -76,7 +76,6 @@ void SettingsWindow::AddCategoryToList(const QString& title, const std::string& 
   QListWidgetItem* button = new QListWidgetItem();
   button->setText(title);
   button->setTextAlignment(Qt::AlignVCenter);
-  button->setSizeHint(QSize(28, 28));
   button->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
   auto set_icon = [=] { button->setIcon(Resources::GetScaledThemeIcon(icon_name)); };
@@ -88,7 +87,6 @@ void SettingsWindow::AddCategoryToList(const QString& title, const std::string& 
 void SettingsWindow::MakeCategoryList()
 {
   m_categories = new QListWidget;
-  m_categories->setMaximumWidth(175);
   m_categories->setIconSize(QSize(32, 32));
   m_categories->setMovement(QListView::Static);
   m_categories->setSpacing(0);
@@ -98,6 +96,10 @@ void SettingsWindow::MakeCategoryList()
   AddCategoryToList(tr("Audio"), "play");
   AddCategoryToList(tr("Paths"), "browse");
   connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);
+
+  m_categories->setFixedWidth(m_categories->sizeHintForColumn(0) +
+                              m_categories->verticalScrollBar()->sizeHint().width() +
+                              2 * m_categories->frameWidth());
 }
 
 void SettingsWindow::changePage(QListWidgetItem* current, QListWidgetItem* previous)

--- a/Source/Core/DolphinQt2/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/AudioPane.cpp
@@ -110,6 +110,7 @@ void AudioPane::CreateWidgets()
   m_main_layout->addWidget(backend_box, 1, 0, 1, -1);
   m_main_layout->addWidget(stretching_box, 2, 0, 1, -1);
 
+  m_main_layout->setContentsMargins(0, 0, 0, 0);
   setLayout(m_main_layout);
 }
 

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
@@ -38,6 +38,8 @@ void GeneralPane::CreateLayout()
   CreateAnalytics();
 #endif
   CreateAdvanced();
+
+  m_main_layout->setContentsMargins(0, 0, 0, 0);
   m_main_layout->addStretch(1);
   setLayout(m_main_layout);
 }
@@ -79,7 +81,6 @@ void GeneralPane::CreateBasic()
   basic_group_layout->addLayout(speed_limit_layout);
 
   m_combobox_speedlimit = new QComboBox();
-  m_combobox_speedlimit->setMaximumWidth(300);
 
   m_combobox_speedlimit->addItem(tr("Unlimited"));
   for (int i = 10; i <= 200; i += 10)  // from 10% to 200%
@@ -106,7 +107,6 @@ void GeneralPane::CreateAnalytics()
 
   m_checkbox_enable_analytics = new QCheckBox(tr("Enable Usage Statistics Reporting"));
   m_button_generate_new_identity = new QPushButton(tr("Generate a New Statistics Identity"));
-  m_button_generate_new_identity->setMaximumWidth(300);
   analytics_group_layout->addWidget(m_checkbox_enable_analytics);
   analytics_group_layout->addWidget(m_button_generate_new_identity);
 }

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -33,6 +33,7 @@ void InterfacePane::CreateLayout()
   CreateUI();
   CreateInGame();
 
+  m_main_layout->setContentsMargins(0, 0, 0, 0);
   m_main_layout->addStretch(1);
   setLayout(m_main_layout);
 }
@@ -48,14 +49,12 @@ void InterfacePane::CreateUI()
   groupbox_layout->addLayout(combobox_layout);
 
   m_combobox_language = new QComboBox;
-  m_combobox_language->setMaximumWidth(300);
   // TODO: Support more languages other then English
   m_combobox_language->addItem(tr("English"));
   combobox_layout->addRow(tr("&Language:"), m_combobox_language);
 
   // Theme Combobox
   m_combobox_theme = new QComboBox;
-  m_combobox_theme->setMaximumWidth(300);
   combobox_layout->addRow(tr("&Theme:"), m_combobox_theme);
 
   // List avalable themes

--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -23,6 +23,7 @@ PathPane::PathPane(QWidget* parent) : QWidget(parent)
   layout->addWidget(MakeGameFolderBox());
   layout->addLayout(MakePathsLayout());
 
+  layout->setContentsMargins(0, 0, 0, 0);
   setLayout(layout);
 }
 
@@ -82,7 +83,6 @@ void PathPane::BrowseWiiNAND()
 QGroupBox* PathPane::MakeGameFolderBox()
 {
   QGroupBox* game_box = new QGroupBox(tr("Game Folders"));
-  game_box->setMinimumSize(QSize(400, 250));
   QVBoxLayout* vlayout = new QVBoxLayout;
 
   m_path_list = new QListWidget;


### PR DESCRIPTION
Before, default size: 
![image](https://user-images.githubusercontent.com/4411333/27365115-8db013ec-55fb-11e7-8914-03b9e10e7f91.png)

Before, minimum size: 
![image](https://user-images.githubusercontent.com/4411333/27365122-95df9ba0-55fb-11e7-8a0e-53a982cbf039.png)

After: 
![image](https://user-images.githubusercontent.com/4411333/27612106-3e78eaa4-5b52-11e7-9d91-2b8afdde0d18.png)
