### PR TITLE
Invalidate less textures on efb copies, fixes bloom in Spyro: A Hero'…

### DIFF
--- a/Data/Sys/GameSettings/G5S.ini
+++ b/Data/Sys/GameSettings/G5S.ini
@@ -16,7 +16,3 @@ EmulationIssues = Needs efb to Ram for proper lighting.
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-


### PR DESCRIPTION
…s Tail

Now, when an efb copy is created, it only removes other efb copies from the
cache that are fully overwritten. Partly overwritten efb copies and textures
are kept, but marked as partly overwritten. Those efb copies are not loaded
directly anymore, but still used for partial updates. The oudated data of them
is "fixed" by applying the newer efb copy as update afterwards.

Partly overwritten normal textures are now only removed, when their hash changes.
This possibly leads to more garbage in the cache, until it is cleaned after X
frames. I'm not really sure how much of a problem that is.

I know that it would be better to fix this using some logic that marks which
parts of the efb copies are invalid. But that seems a bit complicated, since
you'd need to create (a) list(s) with the good parts and rehash the efb copies.
(at least that's the only proper solution that i see) Would this be really worth
it?

Well, i'm not sure if the results are correct. The bloom now scales with higher
IR, which i kinda expected. But it's not affected by the scaled efb setting somehow.
The light from the fairy wings that is weirdly reflected on the floor with efb2ram,
before and after the pr, is not happening anymore with efb2tex, but instead there's
more light on the walls. I don't know which one is the proper emulation.

Screenshot of the fairy's light on the ground with efb2ram(before and after the pr):
https://drive.google.com/open?id=0ByQgqzsPdirYenY4M2txUGhlNHM
and the same screen with efb2tex and this pr:
https://drive.google.com/open?id=0ByQgqzsPdirYd1RBQmZxMmExMWc