### PR TITLE
DolphinQt2: replace Settings with SConfig where possible

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -168,6 +168,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("ShowLogConfigWindow", m_InterfaceLogConfigWindow);
   interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
   interface->Set("ShowActiveTitle", m_show_active_title);
+  interface->Set("ShowDevelopmentWarning", m_show_development_warning);
   interface->Set("ThemeName", theme_name);
   interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
   interface->Set("DisableTooltips", m_DisableTooltips);
@@ -480,6 +481,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("ShowLogConfigWindow", &m_InterfaceLogConfigWindow, false);
   interface->Get("ExtendedFPSInfo", &m_InterfaceExtendedFPSInfo, false);
   interface->Get("ShowActiveTitle", &m_show_active_title, true);
+  interface->Get("ShowDevelopmentWarning", &m_show_development_warning, true);
   interface->Get("ThemeName", &theme_name, DEFAULT_THEME_DIR);
   interface->Get("PauseOnFocusLost", &m_PauseOnFocusLost, false);
   interface->Get("DisableTooltips", &m_DisableTooltips, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -257,6 +257,7 @@ struct SConfig : NonCopyable
   bool m_InterfaceLogConfigWindow;
   bool m_InterfaceExtendedFPSInfo;
   bool m_show_active_title = false;
+  bool m_show_development_warning;
 
   bool m_ListDrives;
   bool m_ListWad;

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -378,7 +378,7 @@ void ControllersWindow::OnWiimoteRefreshPressed()
 
 void ControllersWindow::OnEmulationStateChanged(bool running)
 {
-  if (!Settings::Instance().IsWiiGameRunning() || NetPlay::IsNetPlayRunning())
+  if (!SConfig::GetInstance().bWii || NetPlay::IsNetPlayRunning())
   {
     m_wiimote_sync->setEnabled(!running);
     m_wiimote_reset->setEnabled(!running);
@@ -390,7 +390,7 @@ void ControllersWindow::OnEmulationStateChanged(bool running)
   m_wiimote_emu->setEnabled(!running);
   m_wiimote_passthrough->setEnabled(!running);
 
-  if (!Settings::Instance().IsWiiGameRunning())
+  if (!SConfig::GetInstance().bWii)
   {
     m_wiimote_real_balance_board->setEnabled(!running);
     m_wiimote_continuous_scanning->setEnabled(!running);
@@ -478,35 +478,32 @@ void ControllersWindow::UnimplementedButton()
 
 void ControllersWindow::LoadSettings()
 {
-  auto& settings = Settings::Instance();
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
-    m_gc_controller_boxes[i]->setCurrentIndex(ToGCMenuIndex(settings.GetSIDevice(i)));
+    m_gc_controller_boxes[i]->setCurrentIndex(ToGCMenuIndex(SConfig::GetInstance().m_SIDevice[i]));
     m_wiimote_boxes[i]->setCurrentIndex(ToWiimoteMenuIndex(g_wiimote_sources[i]));
   }
   m_wiimote_real_balance_board->setChecked(g_wiimote_sources[WIIMOTE_BALANCE_BOARD] ==
                                            WIIMOTE_SRC_REAL);
-  m_wiimote_speaker_data->setChecked(settings.IsWiimoteSpeakerEnabled());
-  m_wiimote_continuous_scanning->setChecked(settings.IsContinuousScanningEnabled());
+  m_wiimote_speaker_data->setChecked(SConfig::GetInstance().m_WiimoteEnableSpeaker);
+  m_wiimote_continuous_scanning->setChecked(SConfig::GetInstance().m_WiimoteContinuousScanning);
 
-  m_advanced_bg_input->setChecked(settings.IsBackgroundInputEnabled());
+  m_advanced_bg_input->setChecked(SConfig::GetInstance().m_BackgroundInput);
 
-  if (settings.IsBluetoothPassthroughEnabled())
+  if (SConfig::GetInstance().m_bt_passthrough_enabled)
     m_wiimote_passthrough->setChecked(true);
   else
     m_wiimote_emu->setChecked(true);
 
-  OnWiimoteModeChanged(settings.IsBluetoothPassthroughEnabled());
+  OnWiimoteModeChanged(SConfig::GetInstance().m_bt_passthrough_enabled);
 }
 
 void ControllersWindow::SaveSettings()
 {
-  auto& settings = Settings::Instance();
-  settings.SetWiimoteSpeakerEnabled(m_wiimote_speaker_data->isChecked());
-  settings.SetContinuousScanningEnabled(m_wiimote_continuous_scanning->isChecked());
-
-  settings.SetBluetoothPassthroughEnabled(m_wiimote_passthrough->isChecked());
-  settings.SetBackgroundInputEnabled(m_advanced_bg_input->isChecked());
+  SConfig::GetInstance().m_WiimoteEnableSpeaker = m_wiimote_speaker_data->isChecked();
+  SConfig::GetInstance().m_WiimoteContinuousScanning = m_wiimote_continuous_scanning->isChecked();
+  SConfig::GetInstance().m_bt_passthrough_enabled = m_wiimote_passthrough->isChecked();
+  SConfig::GetInstance().m_BackgroundInput = m_advanced_bg_input->isChecked();
 
   WiimoteReal::ChangeWiimoteSource(WIIMOTE_BALANCE_BOARD,
                                    m_wiimote_real_balance_board->isChecked() ? WIIMOTE_SRC_REAL :
@@ -524,8 +521,8 @@ void ControllersWindow::SaveSettings()
   for (size_t i = 0; i < m_gc_groups.size(); i++)
   {
     const int index = m_gc_controller_boxes[i]->currentIndex();
-    settings.SetSIDevice(i, FromGCMenuIndex(index));
+    SConfig::GetInstance().m_SIDevice[i] = FromGCMenuIndex(index);
     m_gc_buttons[i]->setEnabled(index != 0 && index != 6);
   }
-  settings.Save();
+  SConfig::GetInstance().SaveSettings();
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.cpp
@@ -8,7 +8,7 @@
 
 #include "DolphinQt2/Config/Mapping/GCPadWiiU.h"
 
-#include "DolphinQt2/Settings.h"
+#include "Core/ConfigManager.h"
 #include "InputCommon/GCAdapter.h"
 
 GCPadWiiU::GCPadWiiU(MappingWindow* window) : MappingWidget(window)
@@ -48,14 +48,14 @@ void GCPadWiiU::ConnectWidgets()
 
 void GCPadWiiU::LoadSettings()
 {
-  m_rumble->setChecked(Settings::Instance().IsGCAdapterRumbleEnabled(GetPort()));
-  m_simulate_bongos->setChecked(Settings::Instance().IsGCAdapterSimulatingDKBongos(GetPort()));
+  m_rumble->setChecked(SConfig::GetInstance().m_AdapterRumble[GetPort()]);
+  m_simulate_bongos->setChecked(SConfig::GetInstance().m_AdapterKonga[GetPort()]);
 }
 
 void GCPadWiiU::SaveSettings()
 {
-  Settings::Instance().SetGCAdapterRumbleEnabled(GetPort(), m_rumble->isChecked());
-  Settings::Instance().SetGCAdapterSimulatingDKBongos(GetPort(), m_simulate_bongos->isChecked());
+  SConfig::GetInstance().m_AdapterRumble[GetPort()] = m_rumble->isChecked();
+  SConfig::GetInstance().m_AdapterKonga[GetPort()] = m_simulate_bongos->isChecked();
 }
 
 InputConfig* GCPadWiiU::GetConfig()

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -72,7 +72,6 @@ void SettingsWindow::SetupSettingsWidget()
 
 void SettingsWindow::AddCategoryToList(const QString& title, const std::string& icon_name)
 {
-  QString dir = Settings::Instance().GetThemeDir();
   QListWidgetItem* button = new QListWidgetItem();
   button->setText(title);
   button->setTextAlignment(Qt::AlignVCenter);

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -215,11 +215,7 @@ QString GameFile::GetBannerString(const QMap<DiscIO::Language, QString>& m) cons
     return QString();
 
   bool wii = m_platform != DiscIO::Platform::GAMECUBE_DISC;
-  DiscIO::Language current_lang;
-  if (wii)
-    current_lang = Settings::Instance().GetWiiSystemLanguage();
-  else
-    current_lang = Settings::Instance().GetGCSystemLanguage();
+  DiscIO::Language current_lang = SConfig::GetInstance().GetCurrentLanguage(wii);
 
   if (m.contains(current_lang))
     return m[current_lang];

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -16,6 +16,7 @@
 #include <QUrl>
 
 #include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/Enums.h"
 
@@ -71,16 +72,16 @@ void GameList::MakeTableView()
 
   connect(m_table, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
 
-  auto& settings = Settings::Instance();
-  m_table->setColumnHidden(GameListModel::COL_PLATFORM, !settings.PlatformVisible());
-  m_table->setColumnHidden(GameListModel::COL_ID, !settings.IDVisible());
-  m_table->setColumnHidden(GameListModel::COL_BANNER, !settings.BannerVisible());
-  m_table->setColumnHidden(GameListModel::COL_TITLE, !settings.TitleVisible());
-  m_table->setColumnHidden(GameListModel::COL_DESCRIPTION, !settings.DescriptionVisible());
-  m_table->setColumnHidden(GameListModel::COL_MAKER, !settings.MakerVisible());
-  m_table->setColumnHidden(GameListModel::COL_SIZE, !settings.SizeVisible());
-  m_table->setColumnHidden(GameListModel::COL_COUNTRY, !settings.CountryVisible());
-  m_table->setColumnHidden(GameListModel::COL_RATING, !settings.StateVisible());
+  m_table->setColumnHidden(GameListModel::COL_PLATFORM, !SConfig::GetInstance().m_showSystemColumn);
+  m_table->setColumnHidden(GameListModel::COL_ID, !SConfig::GetInstance().m_showIDColumn);
+  m_table->setColumnHidden(GameListModel::COL_BANNER, !SConfig::GetInstance().m_showBannerColumn);
+  m_table->setColumnHidden(GameListModel::COL_TITLE, !SConfig::GetInstance().m_showTitleColumn);
+  m_table->setColumnHidden(GameListModel::COL_DESCRIPTION,
+                           !SConfig::GetInstance().m_showDescriptionColumn);
+  m_table->setColumnHidden(GameListModel::COL_MAKER, !SConfig::GetInstance().m_showMakerColumn);
+  m_table->setColumnHidden(GameListModel::COL_SIZE, !SConfig::GetInstance().m_showSizeColumn);
+  m_table->setColumnHidden(GameListModel::COL_COUNTRY, !SConfig::GetInstance().m_showRegionColumn);
+  m_table->setColumnHidden(GameListModel::COL_RATING, !SConfig::GetInstance().m_showStateColumn);
 
   QHeaderView* hor_header = m_table->horizontalHeader();
   hor_header->setSectionResizeMode(GameListModel::COL_PLATFORM, QHeaderView::ResizeToContents);
@@ -295,7 +296,7 @@ void GameList::UninstallWAD()
 
 void GameList::SetDefaultISO()
 {
-  Settings::Instance().SetDefaultGame(GetSelectedGame());
+  SConfig::GetInstance().m_strDefaultISO = GetSelectedGame().toStdString();
 }
 
 void GameList::OpenContainingFolder()

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -11,6 +11,7 @@
 
 #include "AudioCommon/AudioCommon.h"
 #include "Common/Thread.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HotkeyManager.h"
 #include "Core/IOS/IOS.h"
@@ -172,7 +173,7 @@ void HotkeyScheduler::Run()
         AudioCommon::ToggleMuteVolume();
 
       // Wiimote
-      if (settings.IsBluetoothPassthroughEnabled())
+      if (SConfig::GetInstance().m_bt_passthrough_enabled)
       {
         const auto ios = IOS::HLE::GetIOS();
         auto device = ios ? ios->GetDeviceByName("/dev/usb/oh1/57e/305") : nullptr;
@@ -184,7 +185,7 @@ void HotkeyScheduler::Run()
 
       // TODO Debugging shortcuts (Separate PR)
 
-      if (settings.IsWiiGameRunning())
+      if (SConfig::GetInstance().bWii)
       {
         int wiimote_id = -1;
         if (IsHotkey(HK_WIIMOTE1_CONNECT))
@@ -224,16 +225,16 @@ void HotkeyScheduler::Run()
 
       if (IsHotkey(HK_DECREASE_EMULATION_SPEED))
       {
-        auto speed = settings.GetEmulationSpeed() - 0.1;
+        auto speed = SConfig::GetInstance().m_EmulationSpeed - 0.1;
         speed = (speed <= 0 || (speed >= 0.95 && speed <= 1.05)) ? 1.0 : speed;
-        settings.SetEmulationSpeed(speed);
+        SConfig::GetInstance().m_EmulationSpeed = speed;
       }
 
       if (IsHotkey(HK_INCREASE_EMULATION_SPEED))
       {
-        auto speed = settings.GetEmulationSpeed() + 0.1;
+        auto speed = SConfig::GetInstance().m_EmulationSpeed + 0.1;
         speed = (speed >= 0.95 && speed <= 1.05) ? 1.0 : speed;
-        settings.SetEmulationSpeed(speed);
+        SConfig::GetInstance().m_EmulationSpeed = speed;
       }
 
       // Slot Saving / Loading

--- a/Source/Core/DolphinQt2/Main.cpp
+++ b/Source/Core/DolphinQt2/Main.cpp
@@ -42,9 +42,11 @@ int main(int argc, char* argv[])
   QObject::connect(QAbstractEventDispatcher::instance(), &QAbstractEventDispatcher::aboutToBlock,
                    &app, &Core::HostDispatchJobs);
 
-  auto& settings = Settings::Instance();
   int retval = 0;
-  if (settings.IsInDevelopmentWarningEnabled())
+
+  // There's intentionally no way to set this from the UI.
+  // Add it to your INI manually instead.
+  if (SConfig::GetInstance().m_show_development_warning)
   {
     InDevelopmentWarning warning_box;
     retval = warning_box.exec() == QDialog::Rejected;
@@ -57,7 +59,7 @@ int main(int argc, char* argv[])
     win.show();
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
-    if (!settings.HasAskedForAnalyticsPermission())
+    if (!SConfig::GetInstance().m_analytics_permission_asked)
     {
       QMessageBox analytics_prompt(&win);
 
@@ -78,9 +80,8 @@ int main(int argc, char* argv[])
 
       const int answer = analytics_prompt.exec();
 
-      settings.SetAskedForAnalyticsPermission(true);
-      settings.SetAnalyticsEnabled(answer == QMessageBox::Yes);
-      settings.Save();
+      SConfig::GetInstance().m_analytics_permission_asked = true;
+      SConfig::GetInstance().m_analytics_enabled = (answer == QMessageBox::Yes);
 
       DolphinAnalytics::Instance()->ReloadConfig();
     }

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -295,7 +295,7 @@ void MainWindow::Play()
     }
     else
     {
-      QString default_path = Settings::Instance().GetDefaultGame();
+      auto default_path = QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);
       if (!default_path.isEmpty() && QFile::exists(default_path))
       {
         StartGame(default_path);
@@ -319,7 +319,7 @@ bool MainWindow::Stop()
   if (!Core::IsRunning())
     return true;
 
-  if (Settings::Instance().GetConfirmStop())
+  if (SConfig::GetInstance().bConfirmStop)
   {
     const Core::State state = Core::GetState();
     // Set to false when Netplay is running as a CPU thread
@@ -430,8 +430,7 @@ void MainWindow::StartGame(const QString& path)
 
 void MainWindow::ShowRenderWidget()
 {
-  auto& settings = Settings::Instance();
-  if (settings.GetRenderToMain())
+  if (SConfig::GetInstance().bRenderToMain)
   {
     // If we're rendering to main, add it to the stack and update our title when necessary.
     m_rendering_to_main = true;
@@ -442,13 +441,13 @@ void MainWindow::ShowRenderWidget()
   {
     // Otherwise, just show it.
     m_rendering_to_main = false;
-    if (settings.GetFullScreen())
+    if (SConfig::GetInstance().bFullscreen)
     {
       m_render_widget->showFullScreen();
     }
     else
     {
-      m_render_widget->resize(settings.GetRenderWindowSize());
+      m_render_widget->resize(640, 480);
       m_render_widget->showNormal();
     }
   }

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -10,6 +10,7 @@
 #include <QUrl>
 
 #include "Core/CommonTitles.h"
+#include "Core/ConfigManager.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/IOS.h"
 #include "Core/State.h"
@@ -235,16 +236,16 @@ void MenuBar::AddGameListTypeSection(QMenu* view_menu)
 
 void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
 {
-  auto& settings = Settings::Instance();
-  static const QMap<QString, bool*> columns{{tr("Platform"), &settings.PlatformVisible()},
-                                            {tr("ID"), &settings.IDVisible()},
-                                            {tr("Banner"), &settings.BannerVisible()},
-                                            {tr("Title"), &settings.TitleVisible()},
-                                            {tr("Description"), &settings.DescriptionVisible()},
-                                            {tr("Maker"), &settings.MakerVisible()},
-                                            {tr("Size"), &settings.SizeVisible()},
-                                            {tr("Country"), &settings.CountryVisible()},
-                                            {tr("Quality"), &settings.StateVisible()}};
+  static const QMap<QString, bool*> columns{
+      {tr("Platform"), &SConfig::GetInstance().m_showSystemColumn},
+      {tr("ID"), &SConfig::GetInstance().m_showIDColumn},
+      {tr("Banner"), &SConfig::GetInstance().m_showBannerColumn},
+      {tr("Title"), &SConfig::GetInstance().m_showTitleColumn},
+      {tr("Description"), &SConfig::GetInstance().m_showDescriptionColumn},
+      {tr("Maker"), &SConfig::GetInstance().m_showMakerColumn},
+      {tr("Size"), &SConfig::GetInstance().m_showSizeColumn},
+      {tr("Country"), &SConfig::GetInstance().m_showRegionColumn},
+      {tr("Quality"), &SConfig::GetInstance().m_showStateColumn}};
 
   QActionGroup* column_group = new QActionGroup(this);
   QMenu* cols_menu = view_menu->addMenu(tr("Table Columns"));
@@ -258,7 +259,6 @@ void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
     action->setChecked(*config);
     connect(action, &QAction::toggled, [this, config, key](bool value) {
       *config = value;
-      Settings::Instance().Save();
       emit ColumnVisibilityToggled(key, value);
     });
   }
@@ -266,7 +266,7 @@ void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
 
 void MenuBar::UpdateToolsMenu(bool emulation_started)
 {
-  const bool enable_wii_tools = !emulation_started || !Settings::Instance().IsWiiGameRunning();
+  const bool enable_wii_tools = !emulation_started || !SConfig::GetInstance().bWii;
   m_perform_online_update_menu->setEnabled(enable_wii_tools);
   if (enable_wii_tools)
   {

--- a/Source/Core/DolphinQt2/Resources.cpp
+++ b/Source/Core/DolphinQt2/Resources.cpp
@@ -10,6 +10,7 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 
@@ -20,7 +21,7 @@ QList<QPixmap> Resources::m_misc;
 
 QIcon Resources::GetIcon(const QString& name, const QString& dir)
 {
-  QString base_path = dir + name;
+  QString base_path = dir + QStringLiteral("/") + name;
 
   const auto dpr = QGuiApplication::primaryScreen()->devicePixelRatio();
 
@@ -45,24 +46,34 @@ QPixmap Resources::GetPixmap(const QString& name, const QString& dir)
   return icon.pixmap(icon.availableSizes()[0]);
 }
 
+static QString GetCurrentThemeDir()
+{
+  return QString::fromStdString(File::GetThemeDir(SConfig::GetInstance().theme_name));
+}
+
+static QString GetResourcesDir()
+{
+  return QString::fromStdString(File::GetSysDirectory() + "Resources");
+}
+
 QIcon Resources::GetScaledIcon(const std::string& name)
 {
-  return GetIcon(QString::fromStdString(name), Settings::Instance().GetResourcesDir());
+  return GetIcon(QString::fromStdString(name), GetResourcesDir());
 }
 
 QIcon Resources::GetScaledThemeIcon(const std::string& name)
 {
-  return GetIcon(QString::fromStdString(name), Settings::Instance().GetThemeDir());
+  return GetIcon(QString::fromStdString(name), GetCurrentThemeDir());
 }
 
 QPixmap Resources::GetScaledPixmap(const std::string& name)
 {
-  return GetPixmap(QString::fromStdString(name), Settings::Instance().GetResourcesDir());
+  return GetPixmap(QString::fromStdString(name), GetResourcesDir());
 }
 
 QPixmap Resources::GetScaledThemePixmap(const std::string& name)
 {
-  return GetPixmap(QString::fromStdString(name), Settings::Instance().GetThemeDir());
+  return GetPixmap(QString::fromStdString(name), GetCurrentThemeDir());
 }
 
 void Resources::Init()

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -13,12 +13,13 @@
 #include "DolphinQt2/Settings.h"
 #include "InputCommon/InputConfig.h"
 
-static QString GetSettingsPath()
-{
-  return QString::fromStdString(File::GetUserPath(D_CONFIG_IDX)) + QStringLiteral("/UI.ini");
-}
-
-Settings::Settings() : QSettings(GetSettingsPath(), QSettings::IniFormat)
+Settings::Settings()
+    :
+#ifdef Q_OS_MAC
+      m_native_settings(QStringLiteral("dolphin-emu.org"), QStringLiteral("dolphin"))
+#else
+      m_native_settings(QStringLiteral("Dolphin Emulator"), QStringLiteral("Dolphin"))
+#endif
 {
 }
 
@@ -34,17 +35,6 @@ void Settings::SetThemeName(const QString& theme_name)
   emit ThemeChanged();
 }
 
-QString Settings::GetThemeDir() const
-{
-  return QString::fromStdString(File::GetThemeDir(SConfig::GetInstance().theme_name));
-}
-
-QString Settings::GetResourcesDir() const
-{
-  return QString::fromStdString(File::GetSysDirectory().append("Resources"))
-      .append(QDir::separator());
-}
-
 QString Settings::GetProfilesDir() const
 {
   return QString::fromStdString(File::GetUserPath(D_CONFIG_IDX) + "Profiles/");
@@ -56,168 +46,57 @@ QString Settings::GetProfileINIPath(const InputConfig* config, const QString& na
          name + QStringLiteral(".ini");
 }
 
-bool Settings::IsInDevelopmentWarningEnabled() const
-{
-  // There's intentionally no way to set this from the UI.
-  // Add it to your INI manually instead.
-  return value(QStringLiteral("ShowDevelopmentWarning"), true).toBool();
-}
-
 QStringList Settings::GetPaths() const
 {
-  return value(QStringLiteral("GameList/Paths")).toStringList();
+  QStringList list;
+  for (const auto& path : SConfig::GetInstance().m_ISOFolder)
+    list << QString::fromStdString(path);
+  return list;
 }
 
-void Settings::AddPath(const QString& path)
+void Settings::AddPath(const QString& qpath)
 {
-  QStringList game_folders = Settings::Instance().GetPaths();
-  if (!game_folders.contains(path))
-  {
-    game_folders << path;
-    Settings::Instance().SetPaths(game_folders);
-    emit PathAdded(path);
-  }
-}
+  std::string path = qpath.toStdString();
 
-void Settings::SetPaths(const QStringList& paths)
-{
-  setValue(QStringLiteral("GameList/Paths"), paths);
-}
-
-void Settings::RemovePath(const QString& path)
-{
-  QStringList paths = GetPaths();
-  int i = paths.indexOf(path);
-  if (i < 0)
+  std::vector<std::string>& paths = SConfig::GetInstance().m_ISOFolder;
+  if (std::find(paths.begin(), paths.end(), path) != paths.end())
     return;
 
-  paths.removeAt(i);
-  SetPaths(paths);
-  emit PathRemoved(path);
+  paths.emplace_back(path);
+  emit PathAdded(qpath);
 }
 
-QString Settings::GetDefaultGame() const
+void Settings::RemovePath(const QString& qpath)
 {
-  return QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);
-}
+  std::string path = qpath.toStdString();
+  std::vector<std::string>& paths = SConfig::GetInstance().m_ISOFolder;
 
-void Settings::SetDefaultGame(const QString& path)
-{
-  SConfig::GetInstance().m_strDefaultISO = path.toStdString();
-  SConfig::GetInstance().SaveSettings();
-}
+  auto new_end = std::remove(paths.begin(), paths.end(), path);
+  if (new_end == paths.end())
+    return;
 
-QString Settings::GetDVDRoot() const
-{
-  return QString::fromStdString(SConfig::GetInstance().m_strDVDRoot);
-}
-
-void Settings::SetDVDRoot(const QString& path)
-{
-  SConfig::GetInstance().m_strDVDRoot = path.toStdString();
-  SConfig::GetInstance().SaveSettings();
-}
-
-QString Settings::GetApploader() const
-{
-  return QString::fromStdString(SConfig::GetInstance().m_strApploader);
-}
-
-void Settings::SetApploader(const QString& path)
-{
-  SConfig::GetInstance().m_strApploader = path.toStdString();
-  SConfig::GetInstance().SaveSettings();
-}
-
-QString Settings::GetWiiNAND() const
-{
-  return QString::fromStdString(SConfig::GetInstance().m_NANDPath);
-}
-
-void Settings::SetWiiNAND(const QString& path)
-{
-  SConfig::GetInstance().m_NANDPath = path.toStdString();
-  SConfig::GetInstance().SaveSettings();
-}
-
-float Settings::GetEmulationSpeed() const
-{
-  return SConfig::GetInstance().m_EmulationSpeed;
-}
-
-void Settings::SetEmulationSpeed(float val)
-{
-  SConfig::GetInstance().m_EmulationSpeed = val;
-}
-
-bool Settings::GetForceNTSCJ() const
-{
-  return SConfig::GetInstance().bForceNTSCJ;
-}
-
-void Settings::SetForceNTSCJ(bool val)
-{
-  SConfig::GetInstance().bForceNTSCJ = val;
-}
-
-bool Settings::GetAnalyticsEnabled() const
-{
-  return SConfig::GetInstance().m_analytics_enabled;
-}
-
-void Settings::SetAnalyticsEnabled(bool val)
-{
-  SConfig::GetInstance().m_analytics_enabled = val;
-}
-
-DiscIO::Language Settings::GetWiiSystemLanguage() const
-{
-  return SConfig::GetInstance().GetCurrentLanguage(true);
-}
-
-DiscIO::Language Settings::GetGCSystemLanguage() const
-{
-  return SConfig::GetInstance().GetCurrentLanguage(false);
+  paths.erase(new_end, paths.end());
+  emit PathRemoved(qpath);
 }
 
 bool Settings::GetPreferredView() const
 {
-  return value(QStringLiteral("PreferredView"), true).toBool();
+  return m_native_settings.value(QStringLiteral("PreferredView"), true).toBool();
 }
 
 void Settings::SetPreferredView(bool table)
 {
-  setValue(QStringLiteral("PreferredView"), table);
-}
-
-bool Settings::GetConfirmStop() const
-{
-  return value(QStringLiteral("Emulation/ConfirmStop"), true).toBool();
+  m_native_settings.setValue(QStringLiteral("PreferredView"), table);
 }
 
 int Settings::GetStateSlot() const
 {
-  return value(QStringLiteral("Emulation/StateSlot"), 1).toInt();
+  return m_native_settings.value(QStringLiteral("Emulation/StateSlot"), 1).toInt();
 }
 
 void Settings::SetStateSlot(int slot)
 {
-  setValue(QStringLiteral("Emulation/StateSlot"), slot);
-}
-
-bool Settings::GetRenderToMain() const
-{
-  return value(QStringLiteral("Graphics/RenderToMain"), false).toBool();
-}
-
-bool Settings::GetFullScreen() const
-{
-  return value(QStringLiteral("Graphics/FullScreen"), false).toBool();
-}
-
-QSize Settings::GetRenderWindowSize() const
-{
-  return value(QStringLiteral("Graphics/RenderWindowSize"), QSize(640, 480)).toSize();
+  m_native_settings.setValue(QStringLiteral("Emulation/StateSlot"), slot);
 }
 
 void Settings::SetHideCursor(bool hide_cursor)
@@ -257,136 +136,6 @@ void Settings::DecreaseVolume(int volume)
   emit VolumeChanged(GetVolume());
 }
 
-bool& Settings::BannerVisible() const
-{
-  return SConfig::GetInstance().m_showBannerColumn;
-}
-
-bool& Settings::CountryVisible() const
-{
-  return SConfig::GetInstance().m_showRegionColumn;
-}
-
-bool& Settings::DescriptionVisible() const
-{
-  return SConfig::GetInstance().m_showDescriptionColumn;
-}
-
-bool& Settings::FilenameVisible() const
-{
-  return SConfig::GetInstance().m_showFileNameColumn;
-}
-
-bool& Settings::IDVisible() const
-{
-  return SConfig::GetInstance().m_showIDColumn;
-}
-
-bool& Settings::MakerVisible() const
-{
-  return SConfig::GetInstance().m_showMakerColumn;
-}
-
-bool& Settings::PlatformVisible() const
-{
-  return SConfig::GetInstance().m_showSystemColumn;
-}
-
-bool& Settings::TitleVisible() const
-{
-  return SConfig::GetInstance().m_showTitleColumn;
-}
-
-bool& Settings::SizeVisible() const
-{
-  return SConfig::GetInstance().m_showSizeColumn;
-}
-
-bool& Settings::StateVisible() const
-{
-  return SConfig::GetInstance().m_showStateColumn;
-}
-
-bool Settings::IsBluetoothPassthroughEnabled() const
-{
-  return SConfig::GetInstance().m_bt_passthrough_enabled;
-}
-
-void Settings::SetBluetoothPassthroughEnabled(bool enabled)
-{
-  SConfig::GetInstance().m_bt_passthrough_enabled = enabled;
-}
-
-bool Settings::IsContinuousScanningEnabled() const
-{
-  return SConfig::GetInstance().m_WiimoteContinuousScanning;
-}
-
-void Settings::SetContinuousScanningEnabled(bool enabled)
-{
-  SConfig::GetInstance().m_WiimoteContinuousScanning = enabled;
-}
-
-bool Settings::IsBackgroundInputEnabled() const
-{
-  return SConfig::GetInstance().m_BackgroundInput;
-}
-
-void Settings::SetBackgroundInputEnabled(bool enabled)
-{
-  SConfig::GetInstance().m_BackgroundInput = enabled;
-}
-
-bool Settings::IsWiimoteSpeakerEnabled() const
-{
-  return SConfig::GetInstance().m_WiimoteEnableSpeaker;
-}
-
-void Settings::SetWiimoteSpeakerEnabled(bool enabled)
-{
-  SConfig::GetInstance().m_WiimoteEnableSpeaker = enabled;
-}
-
-SerialInterface::SIDevices Settings::GetSIDevice(size_t i) const
-{
-  return SConfig::GetInstance().m_SIDevice[i];
-}
-
-void Settings::SetSIDevice(size_t i, SerialInterface::SIDevices device)
-{
-  SConfig::GetInstance().m_SIDevice[i] = device;
-}
-
-bool Settings::IsWiiGameRunning() const
-{
-  return SConfig::GetInstance().bWii;
-}
-
-bool Settings::IsGCAdapterRumbleEnabled(int port) const
-{
-  return SConfig::GetInstance().m_AdapterRumble[port];
-}
-
-void Settings::SetGCAdapterRumbleEnabled(int port, bool enabled)
-{
-  SConfig::GetInstance().m_AdapterRumble[port] = enabled;
-}
-
-bool Settings::IsGCAdapterSimulatingDKBongos(int port) const
-{
-  return SConfig::GetInstance().m_AdapterKonga[port];
-}
-
-void Settings::SetGCAdapterSimulatingDKBongos(int port, bool enabled)
-{
-  SConfig::GetInstance().m_AdapterKonga[port] = enabled;
-}
-
-void Settings::Save()
-{
-  return SConfig::GetInstance().SaveSettings();
-}
-
 QVector<QString> Settings::GetProfiles(const InputConfig* config) const
 {
   const std::string path = GetProfilesDir().toStdString() + config->GetProfileName();
@@ -400,14 +149,4 @@ QVector<QString> Settings::GetProfiles(const InputConfig* config) const
   }
 
   return vec;
-}
-
-bool Settings::HasAskedForAnalyticsPermission() const
-{
-  return SConfig::GetInstance().m_analytics_permission_asked;
-}
-
-void Settings::SetAskedForAnalyticsPermission(bool value)
-{
-  SConfig::GetInstance().m_analytics_permission_asked = value;
 }

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -18,7 +18,7 @@ enum class Language;
 class InputConfig;
 
 // UI settings to be stored in the config directory.
-class Settings final : public QSettings, NonCopyable
+class Settings final : public QObject, NonCopyable
 {
   Q_OBJECT
 
@@ -27,8 +27,6 @@ public:
 
   // UI
   void SetThemeName(const QString& theme_name);
-  QString GetThemeDir() const;
-  QString GetResourcesDir() const;
   QString GetProfilesDir() const;
   QVector<QString> GetProfiles(const InputConfig* config) const;
   QString GetProfileINIPath(const InputConfig* config, const QString& name) const;
@@ -39,39 +37,14 @@ public:
   void AddPath(const QString& path);
   void SetPaths(const QStringList& paths);
   void RemovePath(const QString& path);
-  QString GetDefaultGame() const;
-  void SetDefaultGame(const QString& path);
-  QString GetDVDRoot() const;
-  void SetDVDRoot(const QString& path);
-  QString GetApploader() const;
-  void SetApploader(const QString& path);
-  QString GetWiiNAND() const;
-  void SetWiiNAND(const QString& path);
-  DiscIO::Language GetWiiSystemLanguage() const;
-  DiscIO::Language GetGCSystemLanguage() const;
   bool GetPreferredView() const;
   void SetPreferredView(bool table);
 
   // Emulation
-  bool GetConfirmStop() const;
-  bool IsWiiGameRunning() const;
   int GetStateSlot() const;
   void SetStateSlot(int);
-  float GetEmulationSpeed() const;
-  void SetEmulationSpeed(float val);
-  bool GetForceNTSCJ() const;
-  void SetForceNTSCJ(bool val);
-
-  // Analytics
-  bool HasAskedForAnalyticsPermission() const;
-  void SetAskedForAnalyticsPermission(bool value);
-  bool GetAnalyticsEnabled() const;
-  void SetAnalyticsEnabled(bool val);
 
   // Graphics
-  bool GetRenderToMain() const;
-  bool GetFullScreen() const;
-  QSize GetRenderWindowSize() const;
   void SetHideCursor(bool hide_cursor);
   bool GetHideCursor() const;
 
@@ -80,42 +53,6 @@ public:
   void SetVolume(int volume);
   void IncreaseVolume(int volume);
   void DecreaseVolume(int volume);
-
-  // Columns
-  bool& BannerVisible() const;
-  bool& CountryVisible() const;
-  bool& DescriptionVisible() const;
-  bool& FilenameVisible() const;
-  bool& IDVisible() const;
-  bool& PlatformVisible() const;
-  bool& MakerVisible() const;
-  bool& SizeVisible() const;
-  bool& StateVisible() const;
-  bool& TitleVisible() const;
-
-  // Input
-  bool IsWiimoteSpeakerEnabled() const;
-  void SetWiimoteSpeakerEnabled(bool enabled);
-
-  bool IsBackgroundInputEnabled() const;
-  void SetBackgroundInputEnabled(bool enabled);
-
-  bool IsBluetoothPassthroughEnabled() const;
-  void SetBluetoothPassthroughEnabled(bool enabled);
-
-  SerialInterface::SIDevices GetSIDevice(size_t i) const;
-  void SetSIDevice(size_t i, SerialInterface::SIDevices device);
-
-  bool IsContinuousScanningEnabled() const;
-  void SetContinuousScanningEnabled(bool enabled);
-
-  bool IsGCAdapterRumbleEnabled(int port) const;
-  void SetGCAdapterRumbleEnabled(int port, bool enabled);
-
-  bool IsGCAdapterSimulatingDKBongos(int port) const;
-  void SetGCAdapterSimulatingDKBongos(int port, bool enabled);
-
-  void Save();
 
 signals:
   void ThemeChanged();
@@ -126,4 +63,5 @@ signals:
 
 private:
   Settings();
+  QSettings m_native_settings;
 };

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
@@ -140,14 +140,13 @@ void GeneralPane::CreateAdvanced()
 
 void GeneralPane::LoadConfig()
 {
-  auto& settings = Settings::Instance();
-  m_checkbox_force_ntsc->setChecked(settings.GetForceNTSCJ());
+  m_checkbox_force_ntsc->setChecked(SConfig::GetInstance().bForceNTSCJ);
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
-  m_checkbox_enable_analytics->setChecked(settings.GetAnalyticsEnabled());
+  m_checkbox_enable_analytics->setChecked(SConfig::GetInstance().m_analytics_enabled);
 #endif
   m_checkbox_dualcore->setChecked(SConfig::GetInstance().bCPUThread);
   m_checkbox_cheats->setChecked(SConfig::GetInstance().bEnableCheats);
-  int selection = qRound(settings.GetEmulationSpeed() * 10);
+  int selection = qRound(SConfig::GetInstance().m_EmulationSpeed * 10);
   if (selection < m_combobox_speedlimit->count())
     m_combobox_speedlimit->setCurrentIndex(selection);
   m_checkbox_dualcore->setChecked(SConfig::GetInstance().bCPUThread);
@@ -173,10 +172,9 @@ void GeneralPane::LoadConfig()
 
 void GeneralPane::OnSaveConfig()
 {
-  auto& settings = Settings::Instance();
-  settings.SetForceNTSCJ(m_checkbox_force_ntsc->isChecked());
+  SConfig::GetInstance().bForceNTSCJ = m_checkbox_force_ntsc->isChecked();
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
-  settings.SetAnalyticsEnabled(m_checkbox_enable_analytics->isChecked());
+  SConfig::GetInstance().m_analytics_enabled = m_checkbox_enable_analytics->isChecked();
 #endif
   SConfig::GetInstance().bCPUThread = m_checkbox_dualcore->isChecked();
   SConfig::GetInstance().bEnableCheats = m_checkbox_cheats->isChecked();

--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -10,6 +10,8 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
+#include "Core/ConfigManager.h"
+
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/Settings/PathPane.h"
 
@@ -41,7 +43,7 @@ void PathPane::BrowseDefaultGame()
   if (!file.isEmpty())
   {
     m_game_edit->setText(file);
-    Settings::Instance().SetDefaultGame(file);
+    SConfig::GetInstance().m_strDefaultISO = file.toStdString();
   }
 }
 
@@ -51,7 +53,7 @@ void PathPane::BrowseDVDRoot()
   if (!dir.isEmpty())
   {
     m_dvd_edit->setText(dir);
-    Settings::Instance().SetDVDRoot(dir);
+    SConfig::GetInstance().m_strDVDRoot = dir.toStdString();
   }
 }
 
@@ -62,7 +64,7 @@ void PathPane::BrowseApploader()
   if (!file.isEmpty())
   {
     m_app_edit->setText(file);
-    Settings::Instance().SetApploader(file);
+    SConfig::GetInstance().m_strApploader = file.toStdString();
   }
 }
 
@@ -73,7 +75,7 @@ void PathPane::BrowseWiiNAND()
   if (!dir.isEmpty())
   {
     m_nand_edit->setText(dir);
-    Settings::Instance().SetWiiNAND(dir);
+    SConfig::GetInstance().m_NANDPath = dir.toStdString();
   }
 }
 
@@ -113,40 +115,39 @@ QGroupBox* PathPane::MakeGameFolderBox()
 
 QGridLayout* PathPane::MakePathsLayout()
 {
-  auto& settings = Settings::Instance();
   QGridLayout* layout = new QGridLayout;
   layout->setColumnStretch(1, 1);
 
-  m_game_edit = new QLineEdit(settings.GetDefaultGame());
+  m_game_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_strDefaultISO));
   connect(m_game_edit, &QLineEdit::editingFinished,
-          [=, &settings] { settings.SetDefaultGame(m_game_edit->text()); });
+          [=] { SConfig::GetInstance().m_strDefaultISO = m_game_edit->text().toStdString(); });
   QPushButton* game_open = new QPushButton;
   connect(game_open, &QPushButton::clicked, this, &PathPane::BrowseDefaultGame);
   layout->addWidget(new QLabel(tr("Default Game")), 0, 0);
   layout->addWidget(m_game_edit, 0, 1);
   layout->addWidget(game_open, 0, 2);
 
-  m_dvd_edit = new QLineEdit(settings.GetDVDRoot());
+  m_dvd_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_strDVDRoot));
   connect(m_dvd_edit, &QLineEdit::editingFinished,
-          [=, &settings] { settings.SetDVDRoot(m_dvd_edit->text()); });
+          [=] { SConfig::GetInstance().m_strDVDRoot = m_dvd_edit->text().toStdString(); });
   QPushButton* dvd_open = new QPushButton;
   connect(dvd_open, &QPushButton::clicked, this, &PathPane::BrowseDVDRoot);
   layout->addWidget(new QLabel(tr("DVD Root")), 1, 0);
   layout->addWidget(m_dvd_edit, 1, 1);
   layout->addWidget(dvd_open, 1, 2);
 
-  m_app_edit = new QLineEdit(settings.GetApploader());
+  m_app_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_strApploader));
   connect(m_app_edit, &QLineEdit::editingFinished,
-          [=, &settings] { settings.SetApploader(m_app_edit->text()); });
+          [=] { SConfig::GetInstance().m_strApploader = m_app_edit->text().toStdString(); });
   QPushButton* app_open = new QPushButton;
   connect(app_open, &QPushButton::clicked, this, &PathPane::BrowseApploader);
   layout->addWidget(new QLabel(tr("Apploader")), 2, 0);
   layout->addWidget(m_app_edit, 2, 1);
   layout->addWidget(app_open, 2, 2);
 
-  m_nand_edit = new QLineEdit(settings.GetWiiNAND());
+  m_nand_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_NANDPath));
   connect(m_nand_edit, &QLineEdit::editingFinished,
-          [=, &settings] { settings.SetWiiNAND(m_nand_edit->text()); });
+          [=] { SConfig::GetInstance().m_NANDPath = m_nand_edit->text().toStdString(); });
   QPushButton* nand_open = new QPushButton;
   connect(nand_open, &QPushButton::clicked, this, &PathPane::BrowseWiiNAND);
   layout->addWidget(new QLabel(tr("Wii NAND Root")), 3, 0);


### PR DESCRIPTION
Removes a layer of indirection from accessing Dolphin core settings, where possible. Settings which emit signals when changed and Qt-only settings remain (along with the controller profiles stuff, which is removed anyways in another of my PRs...).

Changes:
- `ShowDevelopmentWarning` is now under the '[Interface]' group in Dolphin.ini, with other interface-related settings. So, whoever uses DolphinQt will have to edit that manually again. Sorry!
- Game search paths and the last file are now shared properly with DolphinWX.
- Qt-only preferences like "Preferred View: list/table" are now stored using the platform's native settings storage, rather than in UI.ini.