### PR TITLE
Don't enable Boot to Pause by default in the debugger

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -70,7 +70,7 @@ void CCodeWindow::Load()
   IniFile::Section* general = ini.GetOrCreateSection("General");
   general->Get("DebuggerFont", &fontDesc);
   general->Get("AutomaticStart", &config_instance.bAutomaticStart, false);
-  general->Get("BootToPause", &config_instance.bBootToPause, true);
+  general->Get("BootToPause", &config_instance.bBootToPause, false);
 
   if (!fontDesc.empty())
     DebuggerFont.SetNativeFontInfoUserDesc(StrToWxStr(fontDesc));


### PR DESCRIPTION
This behavior is useful sometimes, but it's not always useful, and it can be rather confusing if you're not aware of it.

See https://bugs.dolphin-emu.org/issues/9956