### PR TITLE
Wind Waker PAL: Remove Distance Blur

### DIFF
--- a/Data/Sys/GameSettings/GZLE01.ini
+++ b/Data/Sys/GameSettings/GZLE01.ini
@@ -20,6 +20,9 @@ $Snow test room
 
 [ActionReplay]
 # Add action replay cheats here.
+$Remove Distance Blur
+04008FF0 60000000
+023FE0B6 0000FF00
 $Shadow Link
 423BCDA0 00BCFFFF
 423BCDA0 00BDFF87
@@ -112,7 +115,7 @@ $Sink or Swim A+D-pad down sink B+D-pad down swim
 0435D560 42B40000
 $Jump to a ledge at any height
 0435D734 469C4000
-$Very Fast on Ladders (May have to barly tap forward on joystick inorder to get on vein walls)
+$Very Fast on Ladders (May have to barly tap forward on joystick in order to get on vein walls)
 00000000 8435DB18
 41200000 00040002
 0435DB38 7F7FFFFF
@@ -317,25 +320,25 @@ $Test room 10 - Hold (L + R + Z)
 043C9D48 4B5F5465
 043C9D4C 73746100
 00000000 40000000
-$Test room 11 - Hold (L + R+ Y)
+$Test room 11 - Hold (L + R + Y)
 8A3ED84A 00000860
 043C9D44 000000FF
 043C9D48 4B5F5465
 043C9D4C 73746200
 00000000 40000000
-$Test room 12 - Hold (L + R+ X)
+$Test room 12 - Hold (L + R + X)
 8A3ED84A 00000460
 043C9D44 000000FF
 043C9D48 4B5F5465
 043C9D4C 73746300
 00000000 40000000
-$Test room 13 - Hold (L + R+ A)
+$Test room 13 - Hold (L + R + A)
 8A3ED84A 00000160
 043C9D44 000000FF
 043C9D48 4B5F5465
 043C9D4C 73746400
 00000000 40000000
-$Test room 14 - Hold (L + R+ B)
+$Test room 14 - Hold (L + R + B)
 8A3ED84A 00000260
 043C9D44 000000FF
 043C9D48 4B5F5465


### PR DESCRIPTION
Useful code for HD resolution. Taken from https://wiki.dolphin-emu.org/index.php?title=The_Legend_of_Zelda:_The_Wind_Waker#Removing_Distance_Blur