### PR TITLE
[RFC/POC] DolphinQt2: make connecting widgets to settings more declarative

### DIFF
--- a/Source/Core/DolphinQt2/QtUtils/Bind.h
+++ b/Source/Core/DolphinQt2/QtUtils/Bind.h
@@ -1,0 +1,109 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <type_traits>
+
+#include <QAbstractSlider>
+#include <QCheckBox>
+#include <QLabel>
+#include <QSpinBox>
+
+template <typename T>
+struct MemberFunctionArgType;
+
+template <typename R, typename C, typename A>
+struct MemberFunctionArgType<R (C::*)(A)>
+{
+  using ArgType = A;
+};
+
+template <typename R, typename C, typename A>
+struct MemberFunctionArgType<R (C::*const)(A)>
+{
+  using ArgType = A;
+};
+
+template <typename ControlClass, typename EnableIf = void>
+struct BindableControlTrait;
+
+template <>
+struct BindableControlTrait<QCheckBox>
+{
+  static constexpr auto SetFunc = &QCheckBox::setChecked;
+  static constexpr auto SignalFunc = &QCheckBox::toggled;
+};
+
+template <>
+struct BindableControlTrait<QComboBox>
+{
+  static constexpr auto SetFunc = &QComboBox::setCurrentIndex;  // TODO: handle out-of-range values
+  static constexpr auto SignalFunc = static_cast<void (QComboBox::*)(int)>(&QComboBox::activated);
+};
+
+void ButtonGroupSetChecked(QButtonGroup* button_group, int id)
+{
+  button_group->button(id)->setChecked(true);
+}
+
+template <>
+struct BindableControlTrait<QButtonGroup>
+{
+  static decltype(&ButtonGroupSetChecked) SetFunc;
+  static constexpr auto SignalFunc =
+      static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked);
+};
+// TODO: why doesn't it work with constexpr? macOS gives me an undefined symbol error
+auto BindableControlTrait<QButtonGroup>::SetFunc = &ButtonGroupSetChecked;
+
+template <typename T>
+struct BindableControlTrait<
+    T, typename std::enable_if<std::is_base_of<QAbstractSlider, T>::value>::type>
+{
+  static constexpr auto SetFunc = &QAbstractSlider::setValue;
+  static constexpr auto SignalFunc = &QAbstractSlider::valueChanged;
+};
+
+template <typename Ret, typename Base, typename T, typename... Args>
+Ret CallWithContext(Ret (Base::*member_function)(Args...), T* context, Args... args)
+{
+  return (context->*member_function)(std::forward<Args>(args)...);
+}
+
+template <typename F, typename T, typename... Args>
+auto CallWithContext(F&& functor, T* context, Args&&... args)
+{
+  return functor(context, std::forward<Args>(args)...);
+}
+
+// Set ups one-way (write-only) binding between a control and a value reference
+template <typename T, typename Control>
+static void BindControlToValue(Control* control, T& value)
+{
+  using control_trait = BindableControlTrait<Control>;
+  QObject::connect(control, control_trait::SignalFunc,
+                   [&value](T new_value) { value = new_value; });
+  CallWithContext(control_trait::SetFunc, control, value);
+}
+
+// Set ups one-way (write-only) binding between a control and a value reference, with transformers
+template <typename T, typename Control, typename Transform, typename ReverseTransform>
+static void BindControlToValue(Control* control, T& value, Transform transform,
+                               ReverseTransform reverse_transform)
+{
+  using control_trait = BindableControlTrait<Control>;
+  using control_value =
+      typename MemberFunctionArgType<decltype(control_trait::SignalFunc)>::ArgType;
+
+  CallWithContext(control_trait::SetFunc, control, transform(value));
+
+  auto* reverse_transform_function = new std::function<T(control_value)>(reverse_transform);
+  QObject::connect(control, &QObject::destroyed, [=]() { delete reverse_transform_function; });
+  QObject::connect(control, control_trait::SignalFunc,
+                   [&value, reverse_transform_function](T new_value) {
+                     value = (*reverse_transform_function)(new_value);
+                   });
+}

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.h
@@ -26,9 +26,6 @@ private:
   void CreateBasic();
   void CreateAdvanced();
 
-  void LoadConfig();
-  void OnSaveConfig();
-
   // Widgets
   QVBoxLayout* m_main_layout;
   QComboBox* m_combobox_speedlimit;


### PR DESCRIPTION
The point of this: **write less code.** That means faster development, and easier UI changes.

Here's a quick taste of the new way:

```c++
BindControlToValue(m_checkbox_cheats, SConfig::GetInstance().bEnableCheats);
BindControlToValue(m_combobox_speedlimit, SConfig::GetInstance().m_EmulationSpeed,
                   [](float speedlimit) { return static_cast<int>(std::round(speedlimit * 10)); },
                   [](int index) { return index * 0.1f; });
auto* cpu_emulator_engine = new QButtonGroup(this);
cpu_emulator_engine->addButton(m_radio_interpreter, PowerPC::CPUCore::CORE_INTERPRETER);
cpu_emulator_engine->addButton(m_radio_cached_interpreter,
                               PowerPC::CPUCore::CORE_CACHEDINTERPRETER);
cpu_emulator_engine->addButton(m_radio_jit, PowerPC::CPUCore::CORE_JIT64);
BindControlToValue(cpu_emulator_engine, SConfig::GetInstance().iCPUCore);
```

versus the current way:

```c++
connect(m_checkbox_cheats, &QCheckBox::clicked, this, &GeneralPane::OnSaveConfig);
connect(m_combobox_speedlimit,
        static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::activated),
        this, &GeneralPane::OnSaveConfig);
connect(m_radio_interpreter, &QRadioButton::clicked, this, &GeneralPane::OnSaveConfig);
connect(m_radio_cached_interpreter, &QRadioButton::clicked, this, &GeneralPane::OnSaveConfig);
connect(m_radio_jit, &QRadioButton::clicked, this, &GeneralPane::OnSaveConfig);
LoadConfig();

void GeneralPane::LoadConfig()
{
  m_checkbox_cheats->setChecked(SConfig::GetInstance().bEnableCheats);

  int selection = qRound(SConfig::GetInstance().m_EmulationSpeed * 10);
  if (selection < m_combobox_speedlimit->count())
    m_combobox_speedlimit->setCurrentIndex(selection);

  switch (SConfig::GetInstance().iCPUCore)
  {
  case PowerPC::CPUCore::CORE_INTERPRETER:
    m_radio_interpreter->setChecked(true);
    break;
  case PowerPC::CPUCore::CORE_CACHEDINTERPRETER:
    m_radio_cached_interpreter->setChecked(true);
    break;
  case PowerPC::CPUCore::CORE_JIT64:
    m_radio_jit->setChecked(true);
    break;
  default:
    break;
  }
}

void GeneralPane::OnSaveConfig()
{
  SConfig::GetInstance().bEnableCheats = m_checkbox_cheats->isChecked();
  SConfig::GetInstance().m_EmulationSpeed = m_combobox_speedlimit->currentIndex() * 0.1f;

  int engine_value = 0;
  if (m_radio_interpreter->isChecked())
    engine_value = PowerPC::CPUCore::CORE_INTERPRETER;
  else if (m_radio_cached_interpreter->isChecked())
    engine_value = PowerPC::CPUCore::CORE_CACHEDINTERPRETER;
  else
    engine_value = PowerPC::CPUCore::CORE_JIT64;
  SConfig::GetInstance().iCPUCore = engine_value;
}

```

This adds a new `QtUtils/Bind.h` header containing the `BindControlToValue` function and various machinery to make it work (there's some template magic going on, so... help pls?). Supporting for additional widgets is added by specializing a traits struct with two, simple properties: `SetFunc` and `SignalFunc`.

As an initial proof-of-concept, the General settings pane has been modified to use these new functions.

I haven't worked out how this applies to observable properties (the ones with signals in Settings.cpp) or non-SConfig properties (ControllerEmu stuff, for example) yet.