### PR TITLE
ShaderGen: Decouple host state from shader UIDs

### DIFF
--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -163,14 +163,9 @@ void GeometryShaderCache::Init()
 
 void GeometryShaderCache::LoadShaderCache()
 {
-  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
-  std::string cache_filename = StringFromFormat(
-      "%sdx11-%s-%s-gs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-      SConfig::GetInstance().GetGameID().c_str(), g_ActiveConfig.GetHostConfigFilename().c_str());
   GeometryShaderCacheInserter inserter;
-  g_gs_disk_cache.OpenAndRead(cache_filename, inserter);
+  g_gs_disk_cache.OpenAndRead(g_ActiveConfig.GetDiskCacheFileName(APIType::D3D, "GS", true, true),
+                              inserter);
 }
 
 void GeometryShaderCache::Reload()

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -158,18 +158,29 @@ void GeometryShaderCache::Init()
   Clear();
 
   if (g_ActiveConfig.bShaderCache)
-  {
-    if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-      File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+    LoadShaderCache();
+}
 
-    std::string cache_filename =
-        StringFromFormat("%sdx11-%s-gs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                         SConfig::GetInstance().GetGameID().c_str());
-    GeometryShaderCacheInserter inserter;
-    g_gs_disk_cache.OpenAndRead(cache_filename, inserter);
-  }
+void GeometryShaderCache::LoadShaderCache()
+{
+  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
+    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
 
-  last_entry = nullptr;
+  std::string cache_filename = StringFromFormat(
+      "%sdx11-%s-%s-gs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
+      SConfig::GetInstance().GetGameID().c_str(), g_ActiveConfig.GetHostConfigFilename().c_str());
+  GeometryShaderCacheInserter inserter;
+  g_gs_disk_cache.OpenAndRead(cache_filename, inserter);
+}
+
+void GeometryShaderCache::Reload()
+{
+  g_gs_disk_cache.Sync();
+  g_gs_disk_cache.Close();
+  Clear();
+
+  if (g_ActiveConfig.bShaderCache)
+    LoadShaderCache();
 }
 
 // ONLY to be used during shutdown.
@@ -180,6 +191,7 @@ void GeometryShaderCache::Clear()
   GeometryShaders.clear();
 
   last_entry = nullptr;
+  last_uid = {};
 }
 
 void GeometryShaderCache::Shutdown()

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -164,8 +164,7 @@ void GeometryShaderCache::Init()
 void GeometryShaderCache::LoadShaderCache()
 {
   GeometryShaderCacheInserter inserter;
-  g_gs_disk_cache.OpenAndRead(g_ActiveConfig.GetDiskCacheFileName(APIType::D3D, "GS", true, true),
-                              inserter);
+  g_gs_disk_cache.OpenAndRead(GetDiskShaderCacheFileName(APIType::D3D, "GS", true, true), inserter);
 }
 
 void GeometryShaderCache::Reload()
@@ -237,7 +236,8 @@ bool GeometryShaderCache::SetShader(u32 primitive_type)
   }
 
   // Need to compile a new shader
-  ShaderCode code = GenerateGeometryShaderCode(APIType::D3D, uid.GetUidData());
+  ShaderCode code =
+      GenerateGeometryShaderCode(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
 
   D3DBlob* pbytecode;
   if (!D3D::CompileGeometryShader(code.GetBuffer(), &pbytecode))

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -15,6 +15,7 @@ class GeometryShaderCache
 {
 public:
   static void Init();
+  static void Reload();
   static void Clear();
   static void Shutdown();
   static bool SetShader(u32 primitive_type);  // TODO: Should be renamed to LoadShader
@@ -37,6 +38,8 @@ private:
   };
 
   typedef std::map<GeometryShaderUid, GSCacheEntry> GSCache;
+
+  static void LoadShaderCache();
 
   static GSCache GeometryShaders;
   static const GSCacheEntry* last_entry;

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -504,8 +504,7 @@ void PixelShaderCache::Init()
 void PixelShaderCache::LoadShaderCache()
 {
   PixelShaderCacheInserter inserter;
-  g_ps_disk_cache.OpenAndRead(g_ActiveConfig.GetDiskCacheFileName(APIType::D3D, "PS", true, true),
-                              inserter);
+  g_ps_disk_cache.OpenAndRead(GetDiskShaderCacheFileName(APIType::D3D, "PS", true, true), inserter);
 }
 
 void PixelShaderCache::Reload()
@@ -590,7 +589,8 @@ bool PixelShaderCache::SetShader()
   }
 
   // Need to compile a new shader
-  ShaderCode code = GeneratePixelShaderCode(APIType::D3D, uid.GetUidData());
+  ShaderCode code =
+      GeneratePixelShaderCode(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
 
   D3DBlob* pbytecode;
   if (!D3D::CompilePixelShader(code.GetBuffer(), &pbytecode))

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -503,14 +503,9 @@ void PixelShaderCache::Init()
 
 void PixelShaderCache::LoadShaderCache()
 {
-  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
-  std::string cache_filename = StringFromFormat(
-      "%sdx11-%s-%s-ps.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-      SConfig::GetInstance().GetGameID().c_str(), g_ActiveConfig.GetHostConfigFilename().c_str());
   PixelShaderCacheInserter inserter;
-  g_ps_disk_cache.OpenAndRead(cache_filename, inserter);
+  g_ps_disk_cache.OpenAndRead(g_ActiveConfig.GetDiskCacheFileName(APIType::D3D, "PS", true, true),
+                              inserter);
 }
 
 void PixelShaderCache::Reload()

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -15,6 +15,7 @@ class PixelShaderCache
 {
 public:
   static void Init();
+  static void Reload();
   static void Clear();
   static void Shutdown();
   static bool SetShader();  // TODO: Should be renamed to LoadShader
@@ -45,6 +46,8 @@ private:
   };
 
   typedef std::map<PixelShaderUid, PSCacheEntry> PSCache;
+
+  static void LoadShaderCache();
 
   static PSCache PixelShaders;
   static const PSCacheEntry* last_entry;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -242,6 +242,7 @@ Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferH
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
   s_last_fullscreen_mode = D3D::GetFullscreenState();
+  m_last_host_config_bits = g_ActiveConfig.GetHostConfigBits();
 
   g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
   SetupDeviceObjects();
@@ -892,6 +893,16 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                                         clear_color.data());
     D3D::context->ClearDepthStencilView(FramebufferManager::GetEFBDepthTexture()->GetDSV(),
                                         D3D11_CLEAR_DEPTH, 0.f, 0);
+  }
+
+  u32 new_host_config_bits = g_ActiveConfig.GetHostConfigBits();
+  if (new_host_config_bits != m_last_host_config_bits)
+  {
+    OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
+    VertexShaderCache::Reload();
+    GeometryShaderCache::Reload();
+    PixelShaderCache::Reload();
+    m_last_host_config_bits = new_host_config_bits;
   }
 
   // begin next frame

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -242,7 +242,6 @@ Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferH
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
   s_last_fullscreen_mode = D3D::GetFullscreenState();
-  m_last_host_config_bits = g_ActiveConfig.GetHostConfigBits();
 
   g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
   SetupDeviceObjects();
@@ -895,14 +894,11 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                                         D3D11_CLEAR_DEPTH, 0.f, 0);
   }
 
-  u32 new_host_config_bits = g_ActiveConfig.GetHostConfigBits();
-  if (new_host_config_bits != m_last_host_config_bits)
+  if (CheckForHostConfigChanges())
   {
-    OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
     VertexShaderCache::Reload();
     GeometryShaderCache::Reload();
     PixelShaderCache::Reload();
-    m_last_host_config_bits = new_host_config_bits;
   }
 
   // begin next frame

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -64,7 +64,5 @@ public:
 private:
   void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
                   u32 src_width, u32 src_height, float Gamma);
-
-  u32 m_last_host_config_bits = 0;
 };
 }

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -64,5 +64,7 @@ public:
 private:
   void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
                   u32 src_width, u32 src_height, float Gamma);
+
+  u32 m_last_host_config_bits = 0;
 };
 }

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -159,18 +159,29 @@ void VertexShaderCache::Init()
   SETSTAT(stats.numVertexShadersAlive, 0);
 
   if (g_ActiveConfig.bShaderCache)
-  {
-    if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-      File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+    LoadShaderCache();
+}
 
-    std::string cache_filename =
-        StringFromFormat("%sdx11-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                         SConfig::GetInstance().GetGameID().c_str());
-    VertexShaderCacheInserter inserter;
-    g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
-  }
+void VertexShaderCache::LoadShaderCache()
+{
+  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
+    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
 
-  last_entry = nullptr;
+  std::string cache_filename = StringFromFormat(
+      "%sdx11-%s-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
+      SConfig::GetInstance().GetGameID().c_str(), g_ActiveConfig.GetHostConfigFilename().c_str());
+  VertexShaderCacheInserter inserter;
+  g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
+}
+
+void VertexShaderCache::Reload()
+{
+  g_vs_disk_cache.Sync();
+  g_vs_disk_cache.Close();
+  Clear();
+
+  if (g_ActiveConfig.bShaderCache)
+    LoadShaderCache();
 }
 
 void VertexShaderCache::Clear()
@@ -180,6 +191,7 @@ void VertexShaderCache::Clear()
   vshaders.clear();
 
   last_entry = nullptr;
+  last_uid = {};
 }
 
 void VertexShaderCache::Shutdown()

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -165,8 +165,7 @@ void VertexShaderCache::Init()
 void VertexShaderCache::LoadShaderCache()
 {
   VertexShaderCacheInserter inserter;
-  g_vs_disk_cache.OpenAndRead(g_ActiveConfig.GetDiskCacheFileName(APIType::D3D, "VS", true, true),
-                              inserter);
+  g_vs_disk_cache.OpenAndRead(GetDiskShaderCacheFileName(APIType::D3D, "VS", true, true), inserter);
 }
 
 void VertexShaderCache::Reload()
@@ -229,7 +228,8 @@ bool VertexShaderCache::SetShader()
     return (entry.shader != nullptr);
   }
 
-  ShaderCode code = GenerateVertexShaderCode(APIType::D3D, uid.GetUidData());
+  ShaderCode code =
+      GenerateVertexShaderCode(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
 
   D3DBlob* pbytecode = nullptr;
   D3D::CompileVertexShader(code.GetBuffer(), &pbytecode);

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -164,14 +164,9 @@ void VertexShaderCache::Init()
 
 void VertexShaderCache::LoadShaderCache()
 {
-  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
-  std::string cache_filename = StringFromFormat(
-      "%sdx11-%s-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-      SConfig::GetInstance().GetGameID().c_str(), g_ActiveConfig.GetHostConfigFilename().c_str());
   VertexShaderCacheInserter inserter;
-  g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
+  g_vs_disk_cache.OpenAndRead(g_ActiveConfig.GetDiskCacheFileName(APIType::D3D, "VS", true, true),
+                              inserter);
 }
 
 void VertexShaderCache::Reload()

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -17,6 +17,7 @@ class VertexShaderCache
 {
 public:
   static void Init();
+  static void Reload();
   static void Clear();
   static void Shutdown();
   static bool SetShader();  // TODO: Should be renamed to LoadShader
@@ -52,6 +53,8 @@ private:
     }
   };
   typedef std::map<VertexShaderUid, VSCacheEntry> VSCache;
+
+  static void LoadShaderCache();
 
   static VSCache vshaders;
   static const VSCacheEntry* last_entry;

--- a/Source/Core/VideoBackends/Null/ShaderCache.h
+++ b/Source/Core/VideoBackends/Null/ShaderCache.h
@@ -46,7 +46,7 @@ protected:
   }
   ShaderCode GenerateCode(APIType api_type, VertexShaderUid uid) override
   {
-    return GenerateVertexShaderCode(api_type, uid.GetUidData());
+    return GenerateVertexShaderCode(api_type, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   }
 };
 
@@ -62,7 +62,7 @@ protected:
   }
   ShaderCode GenerateCode(APIType api_type, GeometryShaderUid uid) override
   {
-    return GenerateGeometryShaderCode(api_type, uid.GetUidData());
+    return GenerateGeometryShaderCode(api_type, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   }
 };
 
@@ -78,7 +78,7 @@ protected:
   }
   ShaderCode GenerateCode(APIType api_type, PixelShaderUid uid) override
   {
-    return GeneratePixelShaderCode(api_type, uid.GetUidData());
+    return GeneratePixelShaderCode(api_type, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   }
 };
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -217,12 +217,13 @@ SHADER* ProgramShaderCache::SetShader(u32 primitive_type)
   last_entry = &newentry;
   newentry.in_cache = 0;
 
-  ShaderCode vcode = GenerateVertexShaderCode(APIType::OpenGL, uid.vuid.GetUidData());
-  ShaderCode pcode = GeneratePixelShaderCode(APIType::OpenGL, uid.puid.GetUidData());
+  ShaderHostConfig host_config = ShaderHostConfig::GetCurrent();
+  ShaderCode vcode = GenerateVertexShaderCode(APIType::OpenGL, host_config, uid.vuid.GetUidData());
+  ShaderCode pcode = GeneratePixelShaderCode(APIType::OpenGL, host_config, uid.puid.GetUidData());
   ShaderCode gcode;
   if (g_ActiveConfig.backend_info.bSupportsGeometryShaders &&
       !uid.guid.GetUidData()->IsPassthrough())
-    gcode = GenerateGeometryShaderCode(APIType::OpenGL, uid.guid.GetUidData());
+    gcode = GenerateGeometryShaderCode(APIType::OpenGL, host_config, uid.guid.GetUidData());
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   if (g_ActiveConfig.iLog & CONF_SAVESHADERS)
@@ -553,7 +554,7 @@ void ProgramShaderCache::LoadProgramBinaries()
   else
   {
     std::string cache_filename =
-        g_ActiveConfig.GetDiskCacheFileName(APIType::OpenGL, "ProgramBinaries", true, true);
+        GetDiskShaderCacheFileName(APIType::OpenGL, "ProgramBinaries", true, true);
     ProgramShaderCacheInserter inserter;
     g_program_disk_cache.OpenAndRead(cache_filename, inserter);
   }

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -552,14 +552,8 @@ void ProgramShaderCache::LoadProgramBinaries()
   }
   else
   {
-    if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-      File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
-    std::string host_part = g_ActiveConfig.GetHostConfigFilename();
     std::string cache_filename =
-        StringFromFormat("%sogl-%s-%s-shaders.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                         SConfig::GetInstance().GetGameID().c_str(), host_part.c_str());
-
+        g_ActiveConfig.GetDiskCacheFileName(APIType::OpenGL, "ProgramBinaries", true, true);
     ProgramShaderCacheInserter inserter;
     g_program_disk_cache.OpenAndRead(cache_filename, inserter);
   }

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -72,6 +72,7 @@ public:
   static void UploadConstants();
 
   static void Init();
+  static void Reload();
   static void Shutdown();
   static void CreateHeader();
 
@@ -81,6 +82,10 @@ private:
   public:
     void Read(const SHADERUID& key, const u8* value, u32 value_size) override;
   };
+
+  static void LoadProgramBinaries();
+  static void SaveProgramBinaries();
+  static void DestroyShaders();
 
   typedef std::map<SHADERUID, PCacheEntry> PCache;
   static PCache pshaders;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -688,6 +688,7 @@ Renderer::Renderer()
 
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
+  m_last_host_config_bits = g_ActiveConfig.GetHostConfigBits();
 
   // Handle VSync on/off
   s_vsync = g_ActiveConfig.IsVSync();
@@ -1468,6 +1469,15 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
   UpdateActiveConfig();
   g_texture_cache->OnConfigChanged(g_ActiveConfig);
+
+  // Invalidate shader cache when the host config changes.
+  u32 new_host_config_bits = g_ActiveConfig.GetHostConfigBits();
+  if (new_host_config_bits != m_last_host_config_bits)
+  {
+    OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
+    ProgramShaderCache::Reload();
+    m_last_host_config_bits = new_host_config_bits;
+  }
 
   // For testing zbuffer targets.
   // Renderer::SetZBufferRender();

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -148,8 +148,5 @@ private:
   std::array<int, 2> m_last_frame_height = {};
   bool m_last_frame_exported = false;
   AVIDump::Frame m_last_frame_state;
-
-  // last host config state
-  u32 m_last_host_config_bits = 0;
 };
 }

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -148,5 +148,8 @@ private:
   std::array<int, 2> m_last_frame_height = {};
   bool m_last_frame_exported = false;
   AVIDump::Frame m_last_frame_state;
+
+  // last host config state
+  u32 m_last_host_config_bits = 0;
 };
 }

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -1274,12 +1274,12 @@ bool FramebufferManager::CompilePokeShaders()
     layout(triangles) in;
     layout(triangle_strip, max_vertices = EFB_LAYERS * 3) out;
 
-    in VertexData
+    VARYING_LOCATION(0) in VertexData
     {
       vec4 col0;
     } in_data[];
 
-    out VertexData
+    VARYING_LOCATION(0) out VertexData
     {
       vec4 col0;
     } out_data;

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -49,9 +49,17 @@ bool ObjectCache::Initialize()
   if (!CreatePipelineLayouts())
     return false;
 
-  LoadShaderCaches();
-  if (!CreatePipelineCache(true))
-    return false;
+  if (g_ActiveConfig.bShaderCache)
+  {
+    LoadShaderCaches();
+    if (!LoadPipelineCache())
+      return false;
+  }
+  else
+  {
+    if (!CreatePipelineCache())
+      return false;
+  }
 
   if (!CreateUtilityShaderVertexFormat())
     return false;
@@ -465,26 +473,44 @@ public:
   void Read(const u32& key, const u8* value, u32 value_size) override {}
 };
 
-bool ObjectCache::CreatePipelineCache(bool load_from_disk)
+bool ObjectCache::CreatePipelineCache()
+{
+  m_pipeline_cache_filename = GetDiskCacheFileName("pipeline");
+
+  VkPipelineCacheCreateInfo info = {
+      VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,  // VkStructureType            sType
+      nullptr,                                       // const void*                pNext
+      0,                                             // VkPipelineCacheCreateFlags flags
+      0,                                             // size_t                     initialDataSize
+      nullptr                                        // const void*                pInitialData
+  };
+
+  VkResult res =
+      vkCreatePipelineCache(g_vulkan_context->GetDevice(), &info, nullptr, &m_pipeline_cache);
+  if (res == VK_SUCCESS)
+    return true;
+
+  LOG_VULKAN_ERROR(res, "vkCreatePipelineCache failed: ");
+  return false;
+}
+
+bool ObjectCache::LoadPipelineCache()
 {
   // We have to keep the pipeline cache file name around since when we save it
   // we delete the old one, by which time the game's unique ID is already cleared.
   m_pipeline_cache_filename = GetDiskCacheFileName("pipeline");
 
   std::vector<u8> disk_data;
-  if (load_from_disk)
-  {
-    LinearDiskCache<u32, u8> disk_cache;
-    PipelineCacheReadCallback read_callback(&disk_data);
-    if (disk_cache.OpenAndRead(m_pipeline_cache_filename, read_callback) != 1)
-      disk_data.clear();
-  }
+  LinearDiskCache<u32, u8> disk_cache;
+  PipelineCacheReadCallback read_callback(&disk_data);
+  if (disk_cache.OpenAndRead(m_pipeline_cache_filename, read_callback) != 1)
+    disk_data.clear();
 
   if (!disk_data.empty() && !ValidatePipelineCache(disk_data.data(), disk_data.size()))
   {
     // Don't use this data. In fact, we should delete it to prevent it from being used next time.
     File::Delete(m_pipeline_cache_filename);
-    disk_data.clear();
+    return CreatePipelineCache();
   }
 
   VkPipelineCacheCreateInfo info = {
@@ -492,7 +518,7 @@ bool ObjectCache::CreatePipelineCache(bool load_from_disk)
       nullptr,                                       // const void*                pNext
       0,                                             // VkPipelineCacheCreateFlags flags
       disk_data.size(),                              // size_t                     initialDataSize
-      !disk_data.empty() ? disk_data.data() : nullptr,  // const void*                pInitialData
+      disk_data.data()                               // const void*                pInitialData
   };
 
   VkResult res =
@@ -502,14 +528,7 @@ bool ObjectCache::CreatePipelineCache(bool load_from_disk)
 
   // Failed to create pipeline cache, try with it empty.
   LOG_VULKAN_ERROR(res, "vkCreatePipelineCache failed, trying empty cache: ");
-  info.initialDataSize = 0;
-  info.pInitialData = nullptr;
-  res = vkCreatePipelineCache(g_vulkan_context->GetDevice(), &info, nullptr, &m_pipeline_cache);
-  if (res == VK_SUCCESS)
-    return true;
-
-  LOG_VULKAN_ERROR(res, "vkCreatePipelineCache failed: ");
-  return false;
+  return CreatePipelineCache();
 }
 
 // Based on Vulkan 1.0 specification,
@@ -644,19 +663,16 @@ struct ShaderCacheReader : public LinearDiskCacheReader<Uid, u32>
 
 void ObjectCache::LoadShaderCaches()
 {
-  if (g_ActiveConfig.bShaderCache)
+  ShaderCacheReader<VertexShaderUid> vs_reader(m_vs_cache.shader_map);
+  m_vs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("vs"), vs_reader);
+
+  ShaderCacheReader<PixelShaderUid> ps_reader(m_ps_cache.shader_map);
+  m_ps_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("ps"), ps_reader);
+
+  if (g_vulkan_context->SupportsGeometryShaders())
   {
-    ShaderCacheReader<VertexShaderUid> vs_reader(m_vs_cache.shader_map);
-    m_vs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("vs"), vs_reader);
-
-    ShaderCacheReader<PixelShaderUid> ps_reader(m_ps_cache.shader_map);
-    m_ps_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("ps"), ps_reader);
-
-    if (g_vulkan_context->SupportsGeometryShaders())
-    {
-      ShaderCacheReader<GeometryShaderUid> gs_reader(m_gs_cache.shader_map);
-      m_gs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("gs"), gs_reader);
-    }
+    ShaderCacheReader<GeometryShaderUid> gs_reader(m_gs_cache.shader_map);
+    m_gs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("gs"), gs_reader);
   }
 
   SETSTAT(stats.numPixelShadersCreated, static_cast<int>(m_ps_cache.shader_map.size()));
@@ -684,6 +700,11 @@ void ObjectCache::DestroyShaderCaches()
 
   if (g_vulkan_context->SupportsGeometryShaders())
     DestroyShaderCache(m_gs_cache);
+
+  SETSTAT(stats.numPixelShadersCreated, 0);
+  SETSTAT(stats.numPixelShadersAlive, 0);
+  SETSTAT(stats.numVertexShadersCreated, 0);
+  SETSTAT(stats.numVertexShadersAlive, 0);
 }
 
 VkShaderModule ObjectCache::GetVertexShaderForUid(const VertexShaderUid& uid)

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -446,16 +446,6 @@ void ObjectCache::ClearPipelineCache()
   m_compute_pipeline_objects.clear();
 }
 
-std::string ObjectCache::GetDiskCacheFileName(const char* type, bool include_gameid,
-                                              bool include_host_config)
-{
-  return StringFromFormat(
-      "%svulkan-%s%s%s%s%s.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(), type,
-      include_gameid ? "-" : "", include_gameid ? SConfig::GetInstance().GetGameID().c_str() : "",
-      include_host_config ? "-" : "",
-      include_host_config ? g_ActiveConfig.GetHostConfigFilename().c_str() : "");
-}
-
 class PipelineCacheReadCallback : public LinearDiskCacheReader<u32, u8>
 {
 public:
@@ -482,7 +472,8 @@ bool ObjectCache::CreatePipelineCache()
   // Vulkan pipeline caches can be shared between games for shader compile time reduction.
   // This assumes that drivers don't create all pipelines in the cache on load time, only
   // when a lookup occurs that matches a pipeline (or pipeline data) in the cache.
-  m_pipeline_cache_filename = GetDiskCacheFileName("pipeline", false, true);
+  m_pipeline_cache_filename =
+      g_ActiveConfig.GetDiskCacheFileName(APIType::Vulkan, "Pipeline", false, true);
 
   VkPipelineCacheCreateInfo info = {
       VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,  // VkStructureType            sType
@@ -505,7 +496,8 @@ bool ObjectCache::LoadPipelineCache()
 {
   // We have to keep the pipeline cache file name around since when we save it
   // we delete the old one, by which time the game's unique ID is already cleared.
-  m_pipeline_cache_filename = GetDiskCacheFileName("pipeline", false, true);
+  m_pipeline_cache_filename =
+      g_ActiveConfig.GetDiskCacheFileName(APIType::Vulkan, "Pipeline", false, true);
 
   std::vector<u8> disk_data;
   LinearDiskCache<u32, u8> disk_cache;
@@ -671,15 +663,18 @@ struct ShaderCacheReader : public LinearDiskCacheReader<Uid, u32>
 void ObjectCache::LoadShaderCaches()
 {
   ShaderCacheReader<VertexShaderUid> vs_reader(m_vs_cache.shader_map);
-  m_vs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("vs", true, true), vs_reader);
+  m_vs_cache.disk_cache.OpenAndRead(
+      g_ActiveConfig.GetDiskCacheFileName(APIType::Vulkan, "VS", true, true), vs_reader);
 
   ShaderCacheReader<PixelShaderUid> ps_reader(m_ps_cache.shader_map);
-  m_ps_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("ps", true, true), ps_reader);
+  m_ps_cache.disk_cache.OpenAndRead(
+      g_ActiveConfig.GetDiskCacheFileName(APIType::Vulkan, "PS", true, true), ps_reader);
 
   if (g_vulkan_context->SupportsGeometryShaders())
   {
     ShaderCacheReader<GeometryShaderUid> gs_reader(m_gs_cache.shader_map);
-    m_gs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("gs", true, true), gs_reader);
+    m_gs_cache.disk_cache.OpenAndRead(
+        g_ActiveConfig.GetDiskCacheFileName(APIType::Vulkan, "GS", true, true), gs_reader);
   }
 
   SETSTAT(stats.numPixelShadersCreated, static_cast<int>(m_ps_cache.shader_map.size()));

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.h
@@ -154,13 +154,16 @@ public:
   // Recompile shared shaders, call when stereo mode changes.
   void RecompileSharedShaders();
 
+  // Reload pipeline cache. This will destroy all pipelines.
+  void ReloadShaderAndPipelineCaches();
+
   // Shared shader accessors
   VkShaderModule GetScreenQuadVertexShader() const { return m_screen_quad_vertex_shader; }
   VkShaderModule GetPassthroughVertexShader() const { return m_passthrough_vertex_shader; }
   VkShaderModule GetScreenQuadGeometryShader() const { return m_screen_quad_geometry_shader; }
   VkShaderModule GetPassthroughGeometryShader() const { return m_passthrough_geometry_shader; }
   // Gets the filename of the specified type of cache object (e.g. vertex shader, pipeline).
-  std::string GetDiskCacheFileName(const char* type);
+  std::string GetDiskCacheFileName(const char* type, bool include_gameid, bool include_host_config);
 
 private:
   bool CreatePipelineCache();

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.h
@@ -163,7 +163,8 @@ public:
   std::string GetDiskCacheFileName(const char* type);
 
 private:
-  bool CreatePipelineCache(bool load_from_disk);
+  bool CreatePipelineCache();
+  bool LoadPipelineCache();
   bool ValidatePipelineCache(const u8* data, size_t data_length);
   void DestroyPipelineCache();
   void LoadShaderCaches();

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.h
@@ -162,9 +162,6 @@ public:
   VkShaderModule GetPassthroughVertexShader() const { return m_passthrough_vertex_shader; }
   VkShaderModule GetScreenQuadGeometryShader() const { return m_screen_quad_geometry_shader; }
   VkShaderModule GetPassthroughGeometryShader() const { return m_passthrough_geometry_shader; }
-  // Gets the filename of the specified type of cache object (e.g. vertex shader, pipeline).
-  std::string GetDiskCacheFileName(const char* type, bool include_gameid, bool include_host_config);
-
 private:
   bool CreatePipelineCache();
   bool LoadPipelineCache();

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -114,7 +114,7 @@ bool Renderer::Initialize()
   }
 
   // Ensure all pipelines previously used by the game have been created.
-  StateTracker::GetInstance()->LoadPipelineUIDCache();
+  StateTracker::GetInstance()->ReloadPipelineUIDCache();
 
   // Initialize post processing.
   m_post_processor = std::make_unique<VulkanPostProcessing>();
@@ -1126,13 +1126,11 @@ void Renderer::CheckForSurfaceChange()
 void Renderer::CheckForConfigChanges()
 {
   // Save the video config so we can compare against to determine which settings have changed.
-  u32 old_multisamples = g_ActiveConfig.iMultisamples;
+  u32 old_host_bits = g_ActiveConfig.GetHostConfigBits();
   int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
-  int old_stereo_mode = g_ActiveConfig.iStereoMode;
   int old_aspect_ratio = g_ActiveConfig.iAspectRatio;
   int old_efb_scale = g_ActiveConfig.iEFBScale;
   bool old_force_filtering = g_ActiveConfig.bForceFiltering;
-  bool old_ssaa = g_ActiveConfig.bSSAA;
   bool old_use_xfb = g_ActiveConfig.bUseXFB;
   bool old_use_realxfb = g_ActiveConfig.bUseRealXFB;
 
@@ -1142,11 +1140,9 @@ void Renderer::CheckForConfigChanges()
   UpdateActiveConfig();
 
   // Determine which (if any) settings have changed.
-  bool msaa_changed = old_multisamples != g_ActiveConfig.iMultisamples;
-  bool ssaa_changed = old_ssaa != g_ActiveConfig.bSSAA;
+  bool host_bits_changed = old_host_bits != g_ActiveConfig.GetHostConfigBits();
   bool anisotropy_changed = old_anisotropy != g_ActiveConfig.iMaxAnisotropy;
   bool force_texture_filtering_changed = old_force_filtering != g_ActiveConfig.bForceFiltering;
-  bool stereo_changed = old_stereo_mode != g_ActiveConfig.iStereoMode;
   bool efb_scale_changed = old_efb_scale != g_ActiveConfig.iEFBScale;
   bool aspect_changed = old_aspect_ratio != g_ActiveConfig.iAspectRatio;
   bool use_xfb_changed = old_use_xfb != g_ActiveConfig.bUseXFB;
@@ -1164,23 +1160,21 @@ void Renderer::CheckForConfigChanges()
 
   // MSAA samples changed, we need to recreate the EFB render pass.
   // If the stereoscopy mode changed, we need to recreate the buffers as well.
-  if (msaa_changed || stereo_changed)
+  // SSAA changed on/off, we have to recompile shaders.
+  // Changing stereoscopy from off<->on also requires shaders to be recompiled.
+  if (host_bits_changed)
   {
+    OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
     g_command_buffer_mgr->WaitForGPUIdle();
     FramebufferManager::GetInstance()->RecreateRenderPass();
     FramebufferManager::GetInstance()->ResizeEFBTextures();
     BindEFBToStateTracker();
-  }
-
-  // SSAA changed on/off, we can leave the buffers/render pass, but have to recompile shaders.
-  // Changing stereoscopy from off<->on also requires shaders to be recompiled.
-  if (msaa_changed || ssaa_changed || stereo_changed)
-  {
-    g_command_buffer_mgr->WaitForGPUIdle();
     RecompileShaders();
     FramebufferManager::GetInstance()->RecompileShaders();
+    g_object_cache->ReloadShaderAndPipelineCaches();
     g_object_cache->RecompileSharedShaders();
-    StateTracker::GetInstance()->LoadPipelineUIDCache();
+    StateTracker::GetInstance()->InvalidateShaderPointers();
+    StateTracker::GetInstance()->ReloadPipelineUIDCache();
   }
 
   // For vsync, we need to change the present mode, which means recreating the swap chain.

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1126,7 +1126,6 @@ void Renderer::CheckForSurfaceChange()
 void Renderer::CheckForConfigChanges()
 {
   // Save the video config so we can compare against to determine which settings have changed.
-  u32 old_host_bits = g_ActiveConfig.GetHostConfigBits();
   int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
   int old_aspect_ratio = g_ActiveConfig.iAspectRatio;
   int old_efb_scale = g_ActiveConfig.iEFBScale;
@@ -1140,7 +1139,6 @@ void Renderer::CheckForConfigChanges()
   UpdateActiveConfig();
 
   // Determine which (if any) settings have changed.
-  bool host_bits_changed = old_host_bits != g_ActiveConfig.GetHostConfigBits();
   bool anisotropy_changed = old_anisotropy != g_ActiveConfig.iMaxAnisotropy;
   bool force_texture_filtering_changed = old_force_filtering != g_ActiveConfig.bForceFiltering;
   bool efb_scale_changed = old_efb_scale != g_ActiveConfig.iEFBScale;
@@ -1162,9 +1160,8 @@ void Renderer::CheckForConfigChanges()
   // If the stereoscopy mode changed, we need to recreate the buffers as well.
   // SSAA changed on/off, we have to recompile shaders.
   // Changing stereoscopy from off<->on also requires shaders to be recompiled.
-  if (host_bits_changed)
+  if (CheckForHostConfigChanges())
   {
-    OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
     g_command_buffer_mgr->WaitForGPUIdle();
     FramebufferManager::GetInstance()->RecreateRenderPass();
     FramebufferManager::GetInstance()->ResizeEFBTextures();

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -147,7 +147,8 @@ void StateTracker::ReloadPipelineUIDCache()
   m_uid_cache.Close();
 
   // UID caches don't contain any host state, so use a single uid cache per gameid.
-  std::string filename = g_object_cache->GetDiskCacheFileName("pipeline-uid", true, false);
+  std::string filename =
+      g_ActiveConfig.GetDiskCacheFileName(APIType::Vulkan, "PipelineUID", true, false);
   if (g_ActiveConfig.bShaderCache)
   {
     PipelineInserter inserter(this);

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -147,8 +147,7 @@ void StateTracker::ReloadPipelineUIDCache()
   m_uid_cache.Close();
 
   // UID caches don't contain any host state, so use a single uid cache per gameid.
-  std::string filename =
-      g_ActiveConfig.GetDiskCacheFileName(APIType::Vulkan, "PipelineUID", true, false);
+  std::string filename = GetDiskShaderCacheFileName(APIType::Vulkan, "PipelineUID", true, false);
   if (g_ActiveConfig.bShaderCache)
   {
     PipelineInserter inserter(this);

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -115,7 +115,20 @@ bool StateTracker::Initialize()
   return true;
 }
 
-void StateTracker::LoadPipelineUIDCache()
+void StateTracker::InvalidateShaderPointers()
+{
+  // Clear UIDs, forcing a false match next time.
+  m_vs_uid = {};
+  m_gs_uid = {};
+  m_ps_uid = {};
+
+  // Invalidate shader pointers.
+  m_pipeline_state.vs = VK_NULL_HANDLE;
+  m_pipeline_state.gs = VK_NULL_HANDLE;
+  m_pipeline_state.ps = VK_NULL_HANDLE;
+}
+
+void StateTracker::ReloadPipelineUIDCache()
 {
   class PipelineInserter final : public LinearDiskCacheReader<SerializedPipelineUID, u32>
   {
@@ -130,7 +143,8 @@ void StateTracker::LoadPipelineUIDCache()
     StateTracker* this_ptr;
   };
 
-  std::string filename = g_object_cache->GetDiskCacheFileName("pipeline-uid");
+  // UID caches don't contain any host state, so use a single uid cache per gameid.
+  std::string filename = g_object_cache->GetDiskCacheFileName("pipeline-uid", true, false);
   PipelineInserter inserter(this);
 
   // OpenAndRead calls Close() first, which will flush all data to disk when reloading.

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.h
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.h
@@ -117,7 +117,10 @@ public:
   bool IsWithinRenderArea(s32 x, s32 y, u32 width, u32 height) const;
 
   // Reloads the UID cache, ensuring all pipelines used by the game so far have been created.
-  void LoadPipelineUIDCache();
+  void ReloadPipelineUIDCache();
+
+  // Clears shader pointers, ensuring that now-deleted modules are not used.
+  void InvalidateShaderPointers();
 
 private:
   // Serialized version of PipelineInfo, used when loading/saving the pipeline UID cache.

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -290,7 +290,8 @@ void VideoBackend::Video_Cleanup()
   g_command_buffer_mgr->WaitForGPUIdle();
 
   // Save all cached pipelines out to disk for next time.
-  g_object_cache->SavePipelineCache();
+  if (g_ActiveConfig.bShaderCache)
+    g_object_cache->SavePipelineCache();
 
   g_perf_query.reset();
   g_texture_cache.reset();

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRCS
   PostProcessing.cpp
   RenderBase.cpp
   RenderState.cpp
+  ShaderGenCommon.cpp
   Statistics.cpp
   TextureCacheBase.cpp
   TextureConfig.cpp

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -15,18 +15,10 @@ enum class APIType;
 struct geometry_shader_uid_data
 {
   u32 NumValues() const { return sizeof(geometry_shader_uid_data); }
-  bool IsPassthrough() const
-  {
-    return primitive_type == PRIMITIVE_TRIANGLES && !stereo && !wireframe;
-  }
+  bool IsPassthrough() const;
 
-  u32 stereo : 1;
   u32 numTexGens : 4;
-  u32 pixel_lighting : 1;
   u32 primitive_type : 2;
-  u32 wireframe : 1;
-  u32 msaa : 1;
-  u32 ssaa : 1;
 };
 
 #pragma pack()

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -25,5 +25,6 @@ struct geometry_shader_uid_data
 
 typedef ShaderUid<geometry_shader_uid_data> GeometryShaderUid;
 
-ShaderCode GenerateGeometryShaderCode(APIType ApiType, const geometry_shader_uid_data* uid_data);
+ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& host_config,
+                                      const geometry_shader_uid_data* uid_data);
 GeometryShaderUid GetGeometryShaderUid(u32 primitive_type);

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -157,5 +157,6 @@ struct pixel_shader_uid_data
 
 typedef ShaderUid<pixel_shader_uid_data> PixelShaderUid;
 
-ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data* uid_data);
+ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host_config,
+                                   const pixel_shader_uid_data* uid_data);
 PixelShaderUid GetPixelShaderUid();

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -18,11 +18,10 @@ struct pixel_shader_uid_data
   u32 num_values;  // TODO: Shouldn't be a u32
   u32 NumValues() const { return num_values; }
   u32 components : 2;
-  u32 pad0 : 1;
+  u32 pad0 : 2;
   u32 useDstAlpha : 1;
   u32 Pretest : 2;
   u32 nIndirectStagesUsed : 4;
-  u32 stereo : 1;
   u32 genMode_numtexgens : 4;
   u32 genMode_numtevstages : 4;
   u32 genMode_numindstages : 3;
@@ -35,20 +34,16 @@ struct pixel_shader_uid_data
   u32 fog_fsel : 3;
   u32 fog_RangeBaseEnabled : 1;
   u32 ztex_op : 2;
-  u32 fast_depth_calc : 1;
   u32 per_pixel_depth : 1;
-  u32 per_pixel_lighting : 1;
   u32 forced_early_z : 1;
   u32 early_ztest : 1;
   u32 late_ztest : 1;
   u32 bounding_box : 1;
   u32 zfreeze : 1;
-  u32 msaa : 1;
-  u32 ssaa : 1;
   u32 numColorChans : 2;
   u32 rgba6_format : 1;
   u32 dither : 1;
-  u32 pad : 12;
+  u32 pad : 16;
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -52,6 +52,7 @@
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/PostProcessing.h"
+#include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureDecoder.h"
@@ -96,6 +97,8 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   {
     m_aspect_wide = SConfig::GetInstance().m_wii_aspect_ratio != 0;
   }
+
+  m_last_host_config_bits = ShaderHostConfig::GetCurrent().bits;
 }
 
 Renderer::~Renderer()
@@ -313,6 +316,17 @@ void Renderer::SaveScreenshot(const std::string& filename, bool wait_for_complet
     // This is currently only used by Android, and it was using a wait time of 2 seconds.
     m_screenshot_completed.WaitFor(std::chrono::seconds(2));
   }
+}
+
+bool Renderer::CheckForHostConfigChanges()
+{
+  ShaderHostConfig new_host_config = ShaderHostConfig::GetCurrent();
+  if (new_host_config.bits == m_last_host_config_bits)
+    return false;
+
+  OSD::AddMessage("Video config changed, reloading shaders.", OSD::Duration::NORMAL);
+  m_last_host_config_bits = new_host_config.bits;
+  return true;
 }
 
 // Create On-Screen-Messages

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -147,6 +147,8 @@ protected:
   std::tuple<int, int> CalculateTargetScale(int x, int y) const;
   bool CalculateTargetSize();
 
+  bool CheckForHostConfigChanges();
+
   void CheckFifoRecording();
   void RecordVideoMemory();
 
@@ -181,6 +183,8 @@ protected:
   Common::Flag m_surface_needs_change;
   Common::Event m_surface_changed;
   void* m_new_surface_handle = nullptr;
+
+  u32 m_last_host_config_bits = 0;
 
 private:
   void RunFrameDumps();

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -1,0 +1,75 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/ShaderGenCommon.h"
+#include "Common/CommonPaths.h"
+#include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
+
+ShaderHostConfig ShaderHostConfig::GetCurrent()
+{
+  ShaderHostConfig bits = {};
+  bits.msaa = g_ActiveConfig.iMultisamples > 1;
+  bits.ssaa = g_ActiveConfig.iMultisamples > 1 && g_ActiveConfig.bSSAA &&
+              g_ActiveConfig.backend_info.bSupportsSSAA;
+  bits.stereo = g_ActiveConfig.iStereoMode > 0;
+  bits.wireframe = g_ActiveConfig.bWireFrame;
+  bits.per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
+  bits.vertex_rounding = g_ActiveConfig.UseVertexRounding();
+  bits.fast_depth_calc = g_ActiveConfig.bFastDepthCalc;
+  bits.bounding_box = g_ActiveConfig.bBBoxEnable;
+  bits.backend_dual_source_blend = g_ActiveConfig.backend_info.bSupportsDualSourceBlend;
+  bits.backend_geometry_shaders = g_ActiveConfig.backend_info.bSupportsGeometryShaders;
+  bits.backend_early_z = g_ActiveConfig.backend_info.bSupportsEarlyZ;
+  bits.backend_bbox = g_ActiveConfig.backend_info.bSupportsBBox;
+  bits.backend_gs_instancing = g_ActiveConfig.backend_info.bSupportsGSInstancing;
+  bits.backend_clip_control = g_ActiveConfig.backend_info.bSupportsClipControl;
+  bits.backend_ssaa = g_ActiveConfig.backend_info.bSupportsSSAA;
+  bits.backend_atomics = g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics;
+  bits.backend_depth_clamp = g_ActiveConfig.backend_info.bSupportsDepthClamp;
+  bits.backend_reversed_depth_range = g_ActiveConfig.backend_info.bSupportsReversedDepthRange;
+  return bits;
+}
+
+std::string GetDiskShaderCacheFileName(APIType api_type, const char* type, bool include_gameid,
+                                       bool include_host_config)
+{
+  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
+    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+
+  std::string filename = File::GetUserPath(D_SHADERCACHE_IDX);
+  switch (api_type)
+  {
+  case APIType::D3D:
+    filename += "D3D";
+    break;
+  case APIType::OpenGL:
+    filename += "OpenGL";
+    break;
+  case APIType::Vulkan:
+    filename += "Vulkan";
+    break;
+  default:
+    break;
+  }
+
+  filename += '-';
+  filename += type;
+
+  if (include_gameid)
+  {
+    filename += '-';
+    filename += SConfig::GetInstance().GetGameID();
+  }
+
+  if (include_host_config)
+  {
+    // We're using 18 bits, so 5 hex characters.
+    ShaderHostConfig host_config = ShaderHostConfig::GetCurrent();
+    filename += StringFromFormat("-%05X", host_config.bits);
+  }
+
+  filename += ".cache";
+  return filename;
+}

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -151,6 +151,41 @@ private:
   std::vector<bool> constant_usage;  // TODO: Is vector<bool> appropriate here?
 };
 
+// Host config contains the settings which can influence generated shaders.
+union ShaderHostConfig
+{
+  u32 bits;
+
+  struct
+  {
+    u32 msaa : 1;
+    u32 ssaa : 1;
+    u32 stereo : 1;
+    u32 wireframe : 1;
+    u32 per_pixel_lighting : 1;
+    u32 vertex_rounding : 1;
+    u32 fast_depth_calc : 1;
+    u32 bounding_box : 1;
+    u32 backend_dual_source_blend : 1;
+    u32 backend_geometry_shaders : 1;
+    u32 backend_early_z : 1;
+    u32 backend_bbox : 1;
+    u32 backend_gs_instancing : 1;
+    u32 backend_clip_control : 1;
+    u32 backend_ssaa : 1;
+    u32 backend_atomics : 1;
+    u32 backend_depth_clamp : 1;
+    u32 backend_reversed_depth_range : 1;
+    u32 pad : 14;
+  };
+
+  static ShaderHostConfig GetCurrent();
+};
+
+// Gets the filename of the specified type of cache object (e.g. vertex shader, pipeline).
+std::string GetDiskShaderCacheFileName(APIType api_type, const char* type, bool include_gameid,
+                                       bool include_host_config);
+
 template <class T>
 inline void DefineOutputMember(T& object, APIType api_type, const char* qualifier, const char* type,
                                const char* name, int var_index, const char* semantic = "",

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -65,4 +65,5 @@ struct vertex_shader_uid_data
 typedef ShaderUid<vertex_shader_uid_data> VertexShaderUid;
 
 VertexShaderUid GetVertexShaderUid();
-ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_data* uid_data);
+ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& host_config,
+                                    const vertex_shader_uid_data* uid_data);

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -37,14 +37,10 @@ struct vertex_shader_uid_data
   u32 numTexGens : 4;
   u32 numColorChans : 2;
   u32 dualTexTrans_enabled : 1;
-  u32 pixel_lighting : 1;
-  u32 msaa : 1;
 
   u32 texMtxInfo_n_projection : 16;  // Stored separately to guarantee that the texMtxInfo struct is
                                      // 8 bits wide
-  u32 ssaa : 1;
-  u32 vertex_rounding : 1;
-  u32 pad : 14;
+  u32 pad : 18;
 
   struct
   {

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -65,6 +65,7 @@
     <ClCompile Include="RenderBase.cpp" />
     <ClCompile Include="RenderState.cpp" />
     <ClCompile Include="LightingShaderGen.cpp" />
+    <ClCompile Include="ShaderGenCommon.cpp" />
     <ClCompile Include="Statistics.cpp" />
     <ClCompile Include="GeometryShaderGen.cpp" />
     <ClCompile Include="GeometryShaderManager.cpp" />

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -173,6 +173,9 @@
     <ClCompile Include="AbstractTexture.cpp">
       <Filter>Base</Filter>
     </ClCompile>
+    <ClCompile Include="ShaderGenCommon.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CommandProcessor.h" />

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -187,3 +187,19 @@ bool VideoConfig::IsVSync()
 {
   return bVSync && !Core::GetIsThrottlerTempDisabled();
 }
+
+bool VideoConfig::IsStereoEnabled() const
+{
+  return iStereoMode > 0;
+}
+
+bool VideoConfig::IsMSAAEnabled() const
+{
+  return iMultisamples > 1;
+}
+
+bool VideoConfig::IsSSAAEnabled() const
+{
+  return iMultisamples > 1 && bSSAA && backend_info.bSupportsSSAA;
+}
+

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -4,12 +4,9 @@
 
 #include <algorithm>
 
-#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
-#include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 #include "Core/Config/GraphicsSettings.h"
-#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Movie.h"
 #include "VideoCommon/OnScreenDisplay.h"
@@ -190,110 +187,4 @@ void VideoConfig::VerifyValidity()
 bool VideoConfig::IsVSync()
 {
   return bVSync && !Core::GetIsThrottlerTempDisabled();
-}
-
-bool VideoConfig::IsStereoEnabled() const
-{
-  return iStereoMode > 0;
-}
-
-bool VideoConfig::IsMSAAEnabled() const
-{
-  return iMultisamples > 1;
-}
-
-bool VideoConfig::IsSSAAEnabled() const
-{
-  return iMultisamples > 1 && bSSAA && backend_info.bSupportsSSAA;
-}
-
-union HostConfigBits
-{
-  u32 bits;
-
-  struct
-  {
-    u32 msaa : 1;
-    u32 ssaa : 1;
-    u32 stereo : 1;
-    u32 wireframe : 1;
-    u32 per_pixel_lighting : 1;
-    u32 vertex_rounding : 1;
-    u32 fast_depth_calc : 1;
-    u32 bounding_box : 1;
-    u32 backend_dual_source_blend : 1;
-    u32 backend_geometry_shaders : 1;
-    u32 backend_early_z : 1;
-    u32 backend_bbox : 1;
-    u32 backend_gs_instancing : 1;
-    u32 backend_clip_control : 1;
-    u32 backend_ssaa : 1;
-    u32 backend_atomics : 1;
-    u32 backend_depth_clamp : 1;
-    u32 backend_reversed_depth_range : 1;
-    u32 pad : 14;
-  };
-};
-
-u32 VideoConfig::GetHostConfigBits() const
-{
-  HostConfigBits bits = {};
-  bits.msaa = IsMSAAEnabled();
-  bits.ssaa = IsSSAAEnabled();
-  bits.stereo = IsStereoEnabled();
-  bits.wireframe = bWireFrame;
-  bits.per_pixel_lighting = bEnablePixelLighting;
-  bits.vertex_rounding = UseVertexRounding();
-  bits.fast_depth_calc = bFastDepthCalc;
-  bits.bounding_box = bBBoxEnable;
-  bits.backend_dual_source_blend = backend_info.bSupportsDualSourceBlend;
-  bits.backend_geometry_shaders = backend_info.bSupportsGeometryShaders;
-  bits.backend_early_z = backend_info.bSupportsEarlyZ;
-  bits.backend_bbox = backend_info.bSupportsBBox;
-  bits.backend_gs_instancing = backend_info.bSupportsGSInstancing;
-  bits.backend_clip_control = backend_info.bSupportsClipControl;
-  bits.backend_ssaa = backend_info.bSupportsSSAA;
-  bits.backend_atomics = backend_info.bSupportsFragmentStoresAndAtomics;
-  bits.backend_depth_clamp = backend_info.bSupportsDepthClamp;
-  bits.backend_reversed_depth_range = backend_info.bSupportsReversedDepthRange;
-  return bits.bits;
-}
-
-std::string VideoConfig::GetDiskCacheFileName(APIType api_type, const char* type,
-                                              bool include_gameid, bool include_host_config) const
-{
-  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
-  std::string filename = File::GetUserPath(D_SHADERCACHE_IDX);
-  switch (api_type)
-  {
-  case APIType::D3D:
-    filename += "D3D";
-    break;
-  case APIType::OpenGL:
-    filename += "OpenGL";
-    break;
-  case APIType::Vulkan:
-    filename += "Vulkan";
-    break;
-  }
-
-  filename += '-';
-  filename += type;
-
-  if (include_gameid)
-  {
-    filename += '-';
-    filename += SConfig::GetInstance().GetGameID();
-  }
-
-  if (include_host_config)
-  {
-    // We're using 18 bits, so 5 hex characters.
-    filename += StringFromFormat("-%05X", GetHostConfigBits());
-  }
-
-  filename += ".cache";
-  return filename;
 }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 
 #include "Common/CommonTypes.h"
+#include "Common/StringUtil.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Core.h"
 #include "Core/Movie.h"
@@ -203,3 +204,60 @@ bool VideoConfig::IsSSAAEnabled() const
   return iMultisamples > 1 && bSSAA && backend_info.bSupportsSSAA;
 }
 
+union HostConfigBits
+{
+  u32 bits;
+
+  struct
+  {
+    u32 msaa : 1;
+    u32 ssaa : 1;
+    u32 stereo : 1;
+    u32 wireframe : 1;
+    u32 per_pixel_lighting : 1;
+    u32 vertex_rounding : 1;
+    u32 fast_depth_calc : 1;
+    u32 bounding_box : 1;
+    u32 backend_dual_source_blend : 1;
+    u32 backend_geometry_shaders : 1;
+    u32 backend_early_z : 1;
+    u32 backend_bbox : 1;
+    u32 backend_gs_instancing : 1;
+    u32 backend_clip_control : 1;
+    u32 backend_ssaa : 1;
+    u32 backend_atomics : 1;
+    u32 backend_depth_clamp : 1;
+    u32 backend_reversed_depth_range : 1;
+    u32 pad : 14;
+  };
+};
+
+u32 VideoConfig::GetHostConfigBits() const
+{
+  HostConfigBits bits = {};
+  bits.msaa = IsMSAAEnabled();
+  bits.ssaa = IsSSAAEnabled();
+  bits.stereo = IsStereoEnabled();
+  bits.wireframe = bWireFrame;
+  bits.per_pixel_lighting = bEnablePixelLighting;
+  bits.vertex_rounding = UseVertexRounding();
+  bits.fast_depth_calc = bFastDepthCalc;
+  bits.bounding_box = bBBoxEnable;
+  bits.backend_dual_source_blend = backend_info.bSupportsDualSourceBlend;
+  bits.backend_geometry_shaders = backend_info.bSupportsGeometryShaders;
+  bits.backend_early_z = backend_info.bSupportsEarlyZ;
+  bits.backend_bbox = backend_info.bSupportsBBox;
+  bits.backend_gs_instancing = backend_info.bSupportsGSInstancing;
+  bits.backend_clip_control = backend_info.bSupportsClipControl;
+  bits.backend_ssaa = backend_info.bSupportsSSAA;
+  bits.backend_atomics = backend_info.bSupportsFragmentStoresAndAtomics;
+  bits.backend_depth_clamp = backend_info.bSupportsDepthClamp;
+  bits.backend_reversed_depth_range = backend_info.bSupportsReversedDepthRange;
+  return bits.bits;
+}
+
+std::string VideoConfig::GetHostConfigFilename() const
+{
+  u32 bits = GetHostConfigBits();
+  return StringFromFormat("%08X", bits);
+}

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -229,7 +229,9 @@ struct VideoConfig final
   bool IsSSAAEnabled() const;
   // Host config contains the settings which can influence generated shaders.
   u32 GetHostConfigBits() const;
-  std::string GetHostConfigFilename() const;
+  // Gets the filename of the specified type of cache object (e.g. vertex shader, pipeline).
+  std::string GetDiskCacheFileName(APIType api_type, const char* type, bool include_gameid,
+                                   bool include_host_config) const;
 };
 
 extern VideoConfig g_Config;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -224,14 +224,6 @@ struct VideoConfig final
     return backend_info.bSupportsGPUTextureDecoding && bEnableGPUTextureDecoding;
   }
   bool UseVertexRounding() const { return bVertexRounding && iEFBScale != SCALE_1X; }
-  bool IsStereoEnabled() const;
-  bool IsMSAAEnabled() const;
-  bool IsSSAAEnabled() const;
-  // Host config contains the settings which can influence generated shaders.
-  u32 GetHostConfigBits() const;
-  // Gets the filename of the specified type of cache object (e.g. vertex shader, pipeline).
-  std::string GetDiskCacheFileName(APIType api_type, const char* type, bool include_gameid,
-                                   bool include_host_config) const;
 };
 
 extern VideoConfig g_Config;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -223,6 +223,13 @@ struct VideoConfig final
   {
     return backend_info.bSupportsGPUTextureDecoding && bEnableGPUTextureDecoding;
   }
+  bool UseVertexRounding() const { return bVertexRounding && iEFBScale != SCALE_1X; }
+  bool IsStereoEnabled() const;
+  bool IsMSAAEnabled() const;
+  bool IsSSAAEnabled() const;
+  // Host config contains the settings which can influence generated shaders.
+  u32 GetHostConfigBits() const;
+  std::string GetHostConfigFilename() const;
 };
 
 extern VideoConfig g_Config;


### PR DESCRIPTION
Currently, all shader stage uids contain host state (e.g. MSAA, stereo, per-pixel lighting). Therefore, our shader caches can contain duplicate UIDs, only differing by host state, if the user changes graphics options. This PR removes the host state from all shader UIDs.

This means that the shader caches are invalid if the host config is changed (either by the user, or via a gameini). I've worked around this by including a 32-bit integer in the filename which represents a union of the host settings which can affect shader generation. When the graphics options are changed at runtime, the shader cache is flushed and reloaded. Multiple shader caches exist for each set of graphics options, so users who change settings won't see any performance loss compared to before.

Vulkan also now uses a shared pipeline cache across all gameids, which will hopefully reduce some of the pipeline creation time.

Main motivation for this was for shared shader caches, which will be helpful for ubershaders, as these are shared between games, but they are still modified by host state.