### PR TITLE
FileSystemGCWii: Use case insensitive comparison in FindFileInfo

### DIFF
--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -285,7 +285,7 @@ std::unique_ptr<FileInfo> FileSystemGCWii::FindFileInfo(const std::string& path,
 
   for (const FileInfo& child : file_info)
   {
-    if (child.GetName() == searching_for)
+    if (!strcasecmp(child.GetName().c_str(), searching_for.c_str()))
     {
       // A match is found. The rest of the path is passed on to finish the search.
       std::unique_ptr<FileInfo> result = FindFileInfo(rest_of_path, child);

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -125,7 +125,7 @@ private:
   } m_image_indexes;
 
   // Actual backing GameListItems are maintained in a background thread and cached to file
-  static constexpr u32 CACHE_REVISION = 0;
+  static constexpr u32 CACHE_REVISION = 1;  // Last changed in PR 5680
   std::list<std::shared_ptr<GameListItem>> m_cached_files;
   std::thread m_scan_thread;
   Common::Event m_scan_trigger;


### PR DESCRIPTION
This was a regression in f49b64c. Some games seem to name the banner file OPENING.BNR instead of opening.bnr.

Should fix https://bugs.dolphin-emu.org/issues/10354