### PR TITLE
Qt: Implement gamelist drag and drop

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -18,6 +18,7 @@ class HotkeyScheduler;
 class MappingWindow;
 class SettingsWindow;
 class ControllersWindow;
+class DragEnterEvent;
 
 class MainWindow final : public QMainWindow
 {
@@ -81,6 +82,9 @@ private:
   void ShowControllersWindow();
   void ShowAboutDialog();
   void ShowHotkeyDialog();
+
+  void dragEnterEvent(QDragEnterEvent* event) override;
+  void dropEvent(QDropEvent* event) override;
 
   QStackedWidget* m_stack;
   ToolBar* m_tool_bar;


### PR DESCRIPTION
Allows users to
* Drag and drop games into the Dolphin window to boot them
* Drag and drop directories into the window to add them to the search path.