### PR TITLE
FileSearch: Let callers provide a filter predicate

### DIFF
--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -89,8 +89,8 @@ DoFileSearch(const std::vector<std::string>& directories, bool recursive,
 
 #endif
 
-std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
-                                      const std::vector<std::string>& exts, bool recursive)
+std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories, bool recursive,
+                                      const std::vector<std::string>& exts)
 {
   const bool accept_all = exts.empty();
   return DoFileSearch(directories, recursive, [&](const std::string& path, bool is_directory) {

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -21,8 +21,8 @@ namespace Common
 #ifndef HAS_STD_FILESYSTEM
 
 static std::vector<std::string>
-FileSearchWithTest(const std::vector<std::string>& directories, bool recursive,
-                   std::function<bool(const File::FSTEntry&)> callback)
+DoFileSearch(const std::vector<std::string>& directories, bool recursive,
+             std::function<bool(const std::string& path, bool is_directory)> filter)
 {
   std::vector<std::string> result;
   for (const std::string& directory : directories)
@@ -31,7 +31,7 @@ FileSearchWithTest(const std::vector<std::string>& directories, bool recursive,
 
     std::function<void(File::FSTEntry&)> DoEntry;
     DoEntry = [&](File::FSTEntry& entry) {
-      if (callback(entry))
+      if (filter(entry.physicalName, entry.isDirectory))
         result.push_back(entry.physicalName);
       for (auto& child : entry.children)
         DoEntry(child);
@@ -45,50 +45,17 @@ FileSearchWithTest(const std::vector<std::string>& directories, bool recursive,
   return result;
 }
 
-std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
-                                      const std::vector<std::string>& exts, bool recursive)
-{
-  bool accept_all = exts.empty();
-  return FileSearchWithTest(directories, recursive, [&](const File::FSTEntry& entry) {
-    if (accept_all)
-      return true;
-    std::string name = entry.virtualName;
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-    return std::any_of(exts.begin(), exts.end(), [&](const std::string& ext) {
-      return name.length() >= ext.length() &&
-             name.compare(name.length() - ext.length(), ext.length(), ext) == 0;
-    });
-  });
-}
-
 #else
 
-std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
-                                      const std::vector<std::string>& exts, bool recursive)
+static std::vector<std::string>
+DoFileSearch(const std::vector<std::string>& directories, bool recursive,
+             std::function<bool(const std::string& path, bool is_directory)> filter)
 {
-  bool accept_all = exts.empty();
-
-  std::vector<fs::path> native_exts;
-  for (const auto& ext : exts)
-    native_exts.push_back(ext);
-
-  // N.B. This avoids doing any copies
-  auto ext_matches = [&native_exts](const fs::path& path) {
-    const auto& native_path = path.native();
-    return std::any_of(native_exts.cbegin(), native_exts.cend(), [&native_path](const auto& ext) {
-      // TODO provide cross-platform compat for the comparison function, once more platforms
-      // support std::filesystem
-      return native_path.length() >= ext.native().length() &&
-             _wcsicmp(&native_path.c_str()[native_path.length() - ext.native().length()],
-                      ext.c_str()) == 0;
-    });
-  };
-
   std::vector<std::string> result;
   auto add_filtered = [&](const fs::directory_entry& entry) {
-    auto& path = entry.path();
-    if (accept_all || (ext_matches(path) && !fs::is_directory(path)))
-      result.emplace_back(path.u8string());
+    const std::string u8_path = entry.path().u8string();
+    if (filter(u8_path, fs::is_directory(entry.path())))
+      result.emplace_back(u8_path);
   };
   for (const auto& directory : directories)
   {
@@ -121,5 +88,23 @@ std::vector<std::string> DoFileSearch(const std::vector<std::string>& directorie
 }
 
 #endif
+
+std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
+                                      const std::vector<std::string>& exts, bool recursive)
+{
+  const bool accept_all = exts.empty();
+  return DoFileSearch(directories, recursive, [&](const std::string& path, bool is_directory) {
+    if (accept_all)
+      return true;
+    if (is_directory)
+      return false;
+    std::string path_copy = path;
+    std::transform(path_copy.begin(), path_copy.end(), path_copy.begin(), ::tolower);
+    return std::any_of(exts.begin(), exts.end(), [&](const std::string& ext) {
+      return path_copy.length() >= ext.length() &&
+             path_copy.compare(path_copy.length() - ext.length(), ext.length(), ext) == 0;
+    });
+  });
+}
 
 }  // namespace Common

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -45,9 +45,8 @@ FileSearchWithTest(const std::vector<std::string>& directories, bool recursive,
   return result;
 }
 
-static std::vector<std::string> DoFileSearchNoSTL(const std::vector<std::string>& directories,
-                                                  const std::vector<std::string>& exts,
-                                                  bool recursive)
+std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
+                                      const std::vector<std::string>& exts, bool recursive)
 {
   bool accept_all = exts.empty();
   return FileSearchWithTest(directories, recursive, [&](const File::FSTEntry& entry) {
@@ -60,12 +59,6 @@ static std::vector<std::string> DoFileSearchNoSTL(const std::vector<std::string>
              name.compare(name.length() - ext.length(), ext.length(), ext) == 0;
     });
   });
-}
-
-std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
-                                      const std::vector<std::string>& exts, bool recursive)
-{
-  return DoFileSearchNoSTL(directories, exts, recursive);
 }
 
 #else

--- a/Source/Core/Common/FileSearch.h
+++ b/Source/Core/Common/FileSearch.h
@@ -12,6 +12,6 @@ namespace Common
 // Callers can pass empty "exts" to indicate they want all files + directories in results
 // Otherwise, only files matching the extensions are returned
 std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
-                                      const std::vector<std::string>& exts = {},
-                                      bool recursive = false);
+                                      bool recursive = false,
+                                      const std::vector<std::string>& exts = {});
 }  // namespace Common

--- a/Source/Core/Common/FileSearch.h
+++ b/Source/Core/Common/FileSearch.h
@@ -4,14 +4,17 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 
 namespace Common
 {
-// Callers can pass empty "exts" to indicate they want all files + directories in results
-// Otherwise, only files matching the extensions are returned
-std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
-                                      bool recursive = false,
-                                      const std::vector<std::string>& exts = {});
+std::vector<std::string>
+DoFileSearch(const std::vector<std::string>& directories, bool recursive = false,
+             std::function<bool(const std::string& path, bool is_directory)> predicate = {});
+std::vector<std::string>
+DoFileSearch(const std::vector<std::string>& directories, bool recursive,
+             const std::vector<std::string>& exts,
+             std::function<bool(const std::string& path, bool is_directory)> predicate = {});
 }  // namespace Common

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -752,8 +752,9 @@ void GameListCtrl::RescanList()
   const std::vector<std::string> search_extensions = {".gcm",  ".tgc", ".iso", ".ciso", ".gcz",
                                                       ".wbfs", ".wad", ".dol", ".elf"};
   // TODO This could process paths iteratively as they are found
-  auto search_results = Common::DoFileSearch(SConfig::GetInstance().m_ISOFolder, search_extensions,
-                                             SConfig::GetInstance().m_RecursiveISOFolder);
+  const std::vector<std::string> search_results =
+      Common::DoFileSearch(SConfig::GetInstance().m_ISOFolder,
+                           SConfig::GetInstance().m_RecursiveISOFolder, search_extensions);
 
   std::vector<std::string> cached_paths;
   for (const auto& file : m_cached_files)

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -97,7 +97,7 @@ void HiresTexture::Update()
   };
 
   std::vector<std::string> filenames =
-      Common::DoFileSearch({texture_directory}, extensions, /*recursive*/ true);
+      Common::DoFileSearch({texture_directory}, /*recursive*/ true, extensions);
 
   const std::string code = game_id + "_";
 


### PR DESCRIPTION
This will let me make a part of PR #5573 simpler and faster (the `DiscIO::ShouldHideFromGameList` filtering). It also decreases the amount of platform-specific code in FileSearch.cpp.