### PR TITLE
Minor enhancement to TCacheEntry

### DIFF
--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -144,7 +144,7 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
   D3D::stateman->SetTexture(1, palette_buf_srv);
 
   // TODO: Add support for C14X2 format.  (Different multiplier, more palette entries.)
-  float params[4] = {(source->format & 0xf) == GX_TF_I4 ? 15.f : 255.f};
+  float params[4] = {source->TextureFormat() == GX_TF_I4 ? 15.f : 255.f};
   D3D::context->UpdateSubresource(palette_uniform, 0, nullptr, &params, 0, 0);
   D3D::stateman->SetPixelConstants(palette_uniform);
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -387,13 +387,15 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
   glViewport(0, 0, destination->GetWidth(), destination->GetHeight());
   s_palette_pixel_shader[format].Bind();
 
+  const u32 src_texture_format = source->TextureFormat();
+
   // C14 textures are currently unsupported
-  int size = (source->format & 0xf) == GX_TF_I4 ? 32 : 512;
+  int size = src_texture_format == GX_TF_I4 ? 32 : 512;
   auto buffer = s_palette_stream_buffer->Map(size);
   memcpy(buffer.first, palette, size);
   s_palette_stream_buffer->Unmap(size);
   glUniform1i(s_palette_buffer_offset_uniform[format], buffer.second / 2);
-  glUniform1f(s_palette_multiplier_uniform[format], (source->format & 0xf) == 0 ? 15.0f : 255.0f);
+  glUniform1f(s_palette_multiplier_uniform[format], src_texture_format == 0 ? 15.0f : 255.0f);
   glUniform4f(s_palette_copy_position_uniform[format], 0.0f, 0.0f,
               static_cast<float>(source->GetWidth()), static_cast<float>(source->GetHeight()));
 

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -181,8 +181,10 @@ void TextureConverter::ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
   _assert_(static_cast<size_t>(palette_format) < NUM_PALETTE_CONVERSION_SHADERS);
   _assert_(destination_texture->GetConfig().rendertarget);
 
+  const u32 src_texture_format = src_entry->TextureFormat();
+
   // We want to align to 2 bytes (R16) or the device's texel buffer alignment, whichever is greater.
-  size_t palette_size = (src_entry->format & 0xF) == GX_TF_I4 ? 32 : 512;
+  size_t palette_size = src_texture_format == GX_TF_I4 ? 32 : 512;
   if (!ReserveTexelBufferStorage(palette_size, sizeof(u16)))
     return;
 
@@ -207,7 +209,7 @@ void TextureConverter::ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
   draw.BeginRenderPass(destination_texture->GetFramebuffer(), region);
 
   PSUniformBlock uniforms = {};
-  uniforms.multiplier = (src_entry->format & 0xF) == GX_TF_I4 ? 15.0f : 255.0f;
+  uniforms.multiplier = src_texture_format == GX_TF_I4 ? 15.0f : 255.0f;
   uniforms.texel_buffer_offset = static_cast<int>(palette_offset / sizeof(u16));
   draw.SetPushConstants(&uniforms, sizeof(uniforms));
   draw.SetPSSampler(0, source_texture->GetRawTexIdentifier()->GetView(),

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -34,8 +34,7 @@ public:
     u32 addr;
     u32 size_in_bytes;
     u64 base_hash;
-    u64 hash;    // for paletted textures, hash = base_hash ^ palette_hash
-    u32 format;  // bits 0-3 will contain the in-memory format.
+    u64 hash;  // for paletted textures, hash = base_hash ^ palette_hash
     u32 memory_stride;
     bool is_efb_copy;
     bool is_custom_tex;
@@ -107,6 +106,10 @@ public:
     u32 GetNumLevels() const { return texture->GetConfig().levels; }
     u32 GetNumLayers() const { return texture->GetConfig().layers; }
     AbstractTextureFormat GetFormat() const { return texture->GetConfig().format; }
+    u32 TextureFormat() const { return format & 0xf; }
+    u32 FullFormat() const { return format; }
+  private:
+    u32 format;  // bits 0-3 will contain the in-memory format.
   };
 
   virtual ~TextureCacheBase();  // needs virtual for DX11 dtor


### PR DESCRIPTION
This is pulled from @phire 's original #3880 PR.

This adds two helper functions to deal with the TCacheEntry's format.  In particular, this creates a single place where we can change the bitmasking of the format to get the texture format enumeration value.  When we go to change the mask for Hybrid XFB, this will make less code modifications needed for that change.

Additionally, this will help with some errors seen in #5718 .