### PR TITLE
Refuse to launch the shop with default credentials

### DIFF
--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -10,9 +10,6 @@
 
 #include "Common/CommonTypes.h"
 
-static const u64 TITLEID_SYSMENU = 0x0000000100000002;
-static const std::string TITLEID_SYSMENU_STRING = "0000000100000002";
-
 namespace Common
 {
 enum FromWhichRoot

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -17,6 +17,7 @@
 #include "Common/SettingsHandler.h"
 
 #include "Core/Boot/Boot.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HLE/HLE.h"
@@ -230,7 +231,7 @@ bool CBoot::SetupWiiMemory(const DiscIO::Volume* volume, u64 ios_title_id)
   SettingsHandler gen;
   std::string serno;
   const std::string settings_file_path(
-      Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
+      Common::GetTitleDataPath(Titles::SYSTEM_MENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
   if (File::Exists(settings_file_path) && gen.Open(settings_file_path))
   {
     serno = gen.GetValue("SERNO");

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -16,6 +16,7 @@
 #include "Common/NandPaths.h"
 
 #include "Core/Boot/Boot.h"
+#include "Core/CommonTitles.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileIO.h"
@@ -46,8 +47,8 @@ static u32 StateChecksum(const StateFlags& flags)
 
 bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
 {
-  std::string state_filename(Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) +
-                             WII_STATE);
+  std::string state_filename(
+      Common::GetTitleDataPath(Titles::SYSTEM_MENU, Common::FROM_SESSION_ROOT) + WII_STATE);
 
   if (File::Exists(state_filename))
   {
@@ -89,7 +90,7 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   // create data directory
   File::CreateFullPath(Common::GetTitleDataPath(titleID, Common::FROM_SESSION_ROOT));
 
-  if (titleID == TITLEID_SYSMENU)
+  if (titleID == Titles::SYSTEM_MENU)
     IOS::HLE::CreateVirtualFATFilesystem();
   // setup Wii memory
 

--- a/Source/Core/Core/CommonTitles.h
+++ b/Source/Core/Core/CommonTitles.h
@@ -1,0 +1,20 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+
+namespace Titles
+{
+constexpr u64 BOOT2 = 0x0000000100000001;
+
+constexpr u64 SYSTEM_MENU = 0x0000000100000002;
+
+// IOS used by the latest System Menu (4.3). Corresponds to IOS80.
+constexpr u64 SYSTEM_MENU_IOS = 0x0000000100000050;
+
+constexpr u64 BC = 0x0000000100000100;
+constexpr u64 MIOS = 0x0000000100000101;
+}  // namespace Titles

--- a/Source/Core/Core/CommonTitles.h
+++ b/Source/Core/Core/CommonTitles.h
@@ -17,4 +17,6 @@ constexpr u64 SYSTEM_MENU_IOS = 0x0000000100000050;
 
 constexpr u64 BC = 0x0000000100000100;
 constexpr u64 MIOS = 0x0000000100000101;
+
+constexpr u64 SHOP = 0x0001000248414241;
 }  // namespace Titles

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -521,6 +521,7 @@
     <ClInclude Include="PowerPC\PPCTables.h" />
     <ClInclude Include="PowerPC\Profiler.h" />
     <ClInclude Include="State.h" />
+    <ClInclude Include="Titles.h" />
     <ClInclude Include="TitleDatabase.h" />
     <ClInclude Include="WiiRoot.h" />
   </ItemGroup>

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -895,6 +895,7 @@
     <ClInclude Include="NetPlayServer.h" />
     <ClInclude Include="PatchEngine.h" />
     <ClInclude Include="State.h" />
+    <ClInclude Include="Titles.h" />
     <ClInclude Include="TitleDatabase.h" />
     <ClInclude Include="WiiRoot.h" />
     <ClInclude Include="ActionReplay.h">

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -18,6 +18,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/EXI/EXI.h"
@@ -160,7 +161,8 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 
   const std::string& game_id = SConfig::GetInstance().GetGameID();
   u32 CurrentGameId = 0;
-  if (game_id.length() >= 4 && game_id != "00000000" && game_id != TITLEID_SYSMENU_STRING)
+  if (game_id.length() >= 4 && game_id != "00000000" &&
+      SConfig::GetInstance().GetTitleID() != Titles::SYSTEM_MENU)
     CurrentGameId = BE32((u8*)game_id.c_str());
 
   const bool shift_jis = region == DiscIO::Region::NTSC_J;

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -21,6 +21,7 @@
 #include "Common/NandPaths.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
@@ -196,7 +197,7 @@ static bool UpdateUIDAndGID(Kernel& kernel, const IOS::ES::TMDReader& tmd)
 static ReturnCode CheckIsAllowedToSetUID(const u32 caller_uid)
 {
   IOS::ES::UIDSys uid_map{Common::FromWhichRoot::FROM_SESSION_ROOT};
-  const u32 system_menu_uid = uid_map.GetOrInsertUIDForTitle(TITLEID_SYSMENU);
+  const u32 system_menu_uid = uid_map.GetOrInsertUIDForTitle(Titles::SYSTEM_MENU);
   if (!system_menu_uid)
     return ES_SHORT_READ;
   return caller_uid == system_menu_uid ? IPC_SUCCESS : ES_EINVAL;
@@ -241,7 +242,7 @@ bool ES::LaunchTitle(u64 title_id, bool skip_reload)
   // (supposedly when trying to re-open those files).
   DiscIO::NANDContentManager::Access().ClearCache();
 
-  if (IsTitleType(title_id, IOS::ES::TitleType::System) && title_id != TITLEID_SYSMENU)
+  if (IsTitleType(title_id, IOS::ES::TitleType::System) && title_id != Titles::SYSTEM_MENU)
     return LaunchIOS(title_id);
   return LaunchPPCTitle(title_id, skip_reload);
 }
@@ -256,7 +257,7 @@ bool ES::LaunchPPCTitle(u64 title_id, bool skip_reload)
   const DiscIO::NANDContentLoader& content_loader = AccessContentDevice(title_id);
   if (!content_loader.IsValid())
   {
-    if (title_id == 0x0000000100000002)
+    if (title_id == Titles::SYSTEM_MENU)
     {
       PanicAlertT("Could not launch the Wii Menu because it is missing from the NAND.\n"
                   "The emulated software will likely hang now.");

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -423,7 +423,7 @@ IPCCommandResult ES::IOCtlV(const IOCtlVRequest& request)
   case IOCTL_ES_ADDTITLECANCEL:
     return ImportTitleCancel(*context, request);
   case IOCTL_ES_GETDEVICEID:
-    return GetConsoleID(request);
+    return GetDeviceId(request);
   case IOCTL_ES_OPENTITLECONTENT:
     return OpenTitleContent(context->uid, request);
   case IOCTL_ES_OPENCONTENT:

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -132,6 +132,8 @@ public:
   ReturnCode DeleteSharedContent(const std::array<u8, 20>& sha1) const;
   ReturnCode DeleteContent(u64 title_id, u32 content_id) const;
 
+  ReturnCode GetDeviceId(u32* device_id) const;
+
   // Views
   ReturnCode GetV0TicketFromView(const u8* ticket_view, u8* ticket) const;
   ReturnCode GetTicketFromView(const u8* ticket_view, u8* ticket, u32* ticket_size) const;
@@ -237,7 +239,7 @@ private:
   IPCCommandResult DeleteContent(const IOCtlVRequest& request);
 
   // Device identity and encryption
-  IPCCommandResult GetConsoleID(const IOCtlVRequest& request);
+  IPCCommandResult GetDeviceId(const IOCtlVRequest& request);
   IPCCommandResult GetDeviceCertificate(const IOCtlVRequest& request);
   IPCCommandResult CheckKoreaRegion(const IOCtlVRequest& request);
   IPCCommandResult Sign(const IOCtlVRequest& request);

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -24,6 +24,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
+#include "Core/CommonTitles.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/IOSC.h"
@@ -47,7 +48,7 @@ bool IsDiscTitle(u64 title_id)
 
 bool IsChannel(u64 title_id)
 {
-  if (title_id == TITLEID_SYSMENU)
+  if (title_id == Titles::SYSTEM_MENU)
     return true;
 
   return IsTitleType(title_id, TitleType::Channel) ||
@@ -233,7 +234,7 @@ u64 TMDReader::GetIOSId() const
 
 DiscIO::Region TMDReader::GetRegion() const
 {
-  if (GetTitleId() == 0x0000000100000002)
+  if (GetTitleId() == Titles::SYSTEM_MENU)
     return DiscIO::GetSysMenuRegion(GetTitleVersion());
 
   return DiscIO::RegionSwitchWii(static_cast<u8>(GetTitleId() & 0xff));
@@ -577,7 +578,7 @@ UIDSys::UIDSys(Common::FromWhichRoot root)
 
   if (m_entries.empty())
   {
-    GetOrInsertUIDForTitle(TITLEID_SYSMENU);
+    GetOrInsertUIDForTitle(Titles::SYSTEM_MENU);
   }
 }
 

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -18,14 +18,24 @@ namespace HLE
 {
 namespace Device
 {
-IPCCommandResult ES::GetConsoleID(const IOCtlVRequest& request)
+ReturnCode ES::GetDeviceId(u32* device_id) const
 {
-  if (!request.HasNumberOfValidVectors(0, 1))
+  const EcWii& ec = EcWii::GetInstance();
+  *device_id = ec.GetNGID();
+  INFO_LOG(IOS_ES, "GetDeviceId: %08X", *device_id);
+  return IPC_SUCCESS;
+}
+
+IPCCommandResult ES::GetDeviceId(const IOCtlVRequest& request)
+{
+  if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
 
-  const EcWii& ec = EcWii::GetInstance();
-  INFO_LOG(IOS_ES, "IOCTL_ES_GETDEVICEID %08X", ec.GetNGID());
-  Memory::Write_U32(ec.GetNGID(), request.io_vectors[0].address);
+  u32 device_id;
+  const ReturnCode ret = GetDeviceId(&device_id);
+  if (ret != IPC_SUCCESS)
+    return GetDefaultReply(ret);
+  Memory::Write_U32(device_id, request.io_vectors[0].address);
   return GetDefaultReply(IPC_SUCCESS);
 }
 

--- a/Source/Core/Core/IOS/ES/Views.cpp
+++ b/Source/Core/Core/IOS/ES/Views.cpp
@@ -12,6 +12,7 @@
 
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
@@ -34,7 +35,8 @@ namespace Device
 //       booted from the game list, though.
 static bool ShouldReturnFakeViewsForIOSes(u64 title_id, const TitleContext& context)
 {
-  const bool ios = IsTitleType(title_id, IOS::ES::TitleType::System) && title_id != TITLEID_SYSMENU;
+  const bool ios =
+      IsTitleType(title_id, IOS::ES::TitleType::System) && title_id != Titles::SYSTEM_MENU;
   const bool disc_title = context.active && IOS::ES::IsDiscTitle(context.tmd.GetTitleId());
   return Core::WantsDeterminism() ||
          (ios && SConfig::GetInstance().m_disc_booted_from_game_list && disc_title);

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -16,6 +16,7 @@
 #include "Common/File.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
+#include "Core/CommonTitles.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/IOS.h"
 
@@ -40,7 +41,7 @@ void CreateVirtualFATFilesystem()
 {
   const int cdbSize = 0x01400000;
   const std::string cdbPath =
-      Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + "cdb.vff";
+      Common::GetTitleDataPath(Titles::SYSTEM_MENU, Common::FROM_SESSION_ROOT) + "cdb.vff";
   if ((int)File::GetSize(cdbPath) < cdbSize)
   {
     // cdb.vff is a virtual Fat filesystem created on first launch of sysmenu

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -19,6 +19,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/Boot/DolReader.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -173,11 +174,6 @@ void WriteReturnValue(s32 value, u32 address)
   Memory::Write_U32(static_cast<u32>(value), address);
 }
 
-// IOS used by the latest System Menu (4.3).
-constexpr u64 IOS80_TITLE_ID = 0x0000000100000050;
-constexpr u64 BC_TITLE_ID = 0x0000000100000100;
-constexpr u64 MIOS_TITLE_ID = 0x0000000100000101;
-
 Kernel::Kernel()
 {
   // Until the Wii root and NAND path stuff is entirely managed by IOS and made non-static,
@@ -218,7 +214,7 @@ EmulationKernel::EmulationKernel(u64 title_id) : Kernel(title_id)
 
   Core::InitializeWiiRoot(Core::WantsDeterminism());
 
-  if (title_id == MIOS_TITLE_ID)
+  if (title_id == Titles::MIOS)
   {
     MIOS::Load();
     return;
@@ -319,10 +315,10 @@ bool Kernel::BootIOS(const u64 ios_title_id)
   //
   // Because we currently don't have boot1 and boot2, and BC is only ever used to launch MIOS
   // (indirectly via boot2), we can just launch MIOS when BC is launched.
-  if (ios_title_id == BC_TITLE_ID)
+  if (ios_title_id == Titles::BC)
   {
     NOTICE_LOG(IOS, "BC: Launching MIOS...");
-    return BootIOS(MIOS_TITLE_ID);
+    return BootIOS(Titles::MIOS);
   }
 
   // Shut down the active IOS first before switching to the new one.
@@ -595,7 +591,7 @@ void Kernel::DoState(PointerWrap& p)
 
   m_iosc.DoState(p);
 
-  if (m_title_id == MIOS_TITLE_ID)
+  if (m_title_id == Titles::MIOS)
     return;
 
   // We need to make sure all file handles are closed so IOS::HLE::Device::FS::DoState can
@@ -686,13 +682,13 @@ void Init()
   });
 
   // Start with IOS80 to simulate part of the Wii boot process.
-  s_ios = std::make_unique<EmulationKernel>(IOS80_TITLE_ID);
+  s_ios = std::make_unique<EmulationKernel>(Titles::SYSTEM_MENU_IOS);
   // On a Wii, boot2 launches the system menu IOS, which then launches the system menu
   // (which bootstraps the PPC). Bootstrapping the PPC results in memory values being set up.
   // This means that the constants in the 0x3100 region are always set up by the time
   // a game is launched. This is necessary because booting games from the game list skips
   // a significant part of a Wii's boot process.
-  SetupMemory(IOS80_TITLE_ID, MemorySetupType::Full);
+  SetupMemory(Titles::SYSTEM_MENU_IOS, MemorySetupType::Full);
 }
 
 void Shutdown()

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -15,6 +15,7 @@
 #include "Common/NandPaths.h"
 #include "Common/Swap.h"
 #include "Core/Boot/ElfReader.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/DSPEmulator.h"
@@ -34,8 +35,6 @@ namespace HLE
 {
 namespace MIOS
 {
-constexpr u64 MIOS_TITLE_ID = 0x0000000100000101;
-
 // Source: https://wiibrew.org/wiki/ARM_Binaries
 struct ARMBinary final
 {
@@ -92,7 +91,7 @@ u32 ARMBinary::GetElfSize() const
 static std::vector<u8> GetMIOSBinary()
 {
   const auto& loader =
-      DiscIO::NANDContentManager::Access().GetNANDLoader(MIOS_TITLE_ID, Common::FROM_SESSION_ROOT);
+      DiscIO::NANDContentManager::Access().GetNANDLoader(Titles::MIOS, Common::FROM_SESSION_ROOT);
   if (!loader.IsValid())
     return {};
 

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -14,6 +14,7 @@
 #include "Common/NandPaths.h"
 #include "Common/SettingsHandler.h"
 
+#include "Core/CommonTitles.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/Socket.h"
 #include "Core/ec_wii.h"
@@ -83,7 +84,7 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
     if (config.CreationStage() == NWC24::NWC24Config::NWC24_IDCS_INITIAL)
     {
       const std::string settings_file_path(
-          Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
+          Common::GetTitleDataPath(Titles::SYSTEM_MENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
       SettingsHandler gen;
       std::string area, model;
       bool got_settings = false;

--- a/Source/Core/Core/ec_wii.cpp
+++ b/Source/Core/Core/ec_wii.cpp
@@ -23,7 +23,6 @@
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
 
-constexpr u32 default_NG_id = 0x0403AC68;
 constexpr u32 default_NG_key_id = 0x6AAB8C59;
 
 constexpr u8 default_NG_priv[] = {
@@ -65,7 +64,7 @@ void MakeNGCert(u8* ng_cert_out, u32 NG_id, u32 NG_key_id, const u8* NG_priv, co
   char name[64];
   if ((NG_id == 0) || (NG_key_id == 0) || (NG_priv == nullptr) || (NG_sig == nullptr))
   {
-    NG_id = default_NG_id;
+    NG_id = DEFAULT_WII_DEVICE_ID;
     NG_key_id = default_NG_key_id;
     NG_priv = default_NG_priv;
     NG_sig = default_NG_sig;
@@ -98,7 +97,7 @@ void MakeAPSigAndCert(u8* sig_out, u8* ap_cert_out, u64 title_id, u8* data, u32 
   if ((NG_id == 0) || (NG_priv == nullptr))
   {
     NG_priv = default_NG_priv;
-    NG_id = default_NG_id;
+    NG_id = DEFAULT_WII_DEVICE_ID;
   }
 
   memset(ap_priv, 0, 0x1e);
@@ -186,7 +185,7 @@ void EcWii::InitDefaults()
 {
   memset(&BootMiiKeysBin, 0, sizeof(BootMiiKeysBin));
 
-  BootMiiKeysBin.ng_id = Common::swap32(default_NG_id);
+  BootMiiKeysBin.ng_id = Common::swap32(DEFAULT_WII_DEVICE_ID);
   BootMiiKeysBin.ng_key_id = Common::swap32(default_NG_key_id);
 
   memcpy(BootMiiKeysBin.ng_priv, default_NG_priv, sizeof(BootMiiKeysBin.ng_priv));

--- a/Source/Core/Core/ec_wii.h
+++ b/Source/Core/Core/ec_wii.h
@@ -26,6 +26,8 @@
 
 #include "Common/CommonTypes.h"
 
+constexpr u32 DEFAULT_WII_DEVICE_ID = 0x0403AC68;
+
 void MakeNGCert(u8* ng_cert_out, u32 NG_id, u32 NG_key_id, const u8* NG_priv, const u8* NG_sig);
 void MakeAPSigAndCert(u8* sig_out, u8* ap_cert_out, u64 title_id, u8* data, u32 data_size,
                       const u8* NG_priv, u32 NG_id);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -32,6 +32,7 @@
 
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/CPU.h"
@@ -1214,7 +1215,7 @@ void CFrame::OnShowCheatsWindow(wxCommandEvent& WXUNUSED(event))
 
 void CFrame::OnLoadWiiMenu(wxCommandEvent& WXUNUSED(event))
 {
-  BootGame(Common::GetTitleContentPath(TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT));
+  BootGame(Common::GetTitleContentPath(Titles::SYSTEM_MENU, Common::FROM_CONFIGURED_ROOT));
 }
 
 void CFrame::OnInstallWAD(wxCommandEvent& event)
@@ -1272,7 +1273,7 @@ void CFrame::OnUninstallWAD(wxCommandEvent&)
     return;
   }
 
-  if (title_id == TITLEID_SYSMENU)
+  if (title_id == Titles::SYSTEM_MENU)
     UpdateLoadWiiMenuItem();
 }
 
@@ -1503,7 +1504,7 @@ void CFrame::UpdateGUI()
       ->FindItem(IDM_LOAD_GC_IPL_EUR)
       ->Enable(!Initialized && File::Exists(SConfig::GetInstance().GetBootROMPath(EUR_DIR)));
   if (DiscIO::NANDContentManager::Access()
-          .GetNANDLoader(TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT)
+          .GetNANDLoader(Titles::SYSTEM_MENU, Common::FROM_CONFIGURED_ROOT)
           .IsValid())
     GetMenuBar()->FindItem(IDM_LOAD_WII_MENU)->Enable(!Initialized);
 

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Common/CDUtils.h"
+#include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -582,7 +583,7 @@ void MainMenuBar::RefreshWiiSystemMenuLabel() const
   auto* const item = FindItem(IDM_LOAD_WII_MENU);
 
   const auto& sys_menu_loader = DiscIO::NANDContentManager::Access().GetNANDLoader(
-      TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT);
+      Titles::SYSTEM_MENU, Common::FROM_CONFIGURED_ROOT);
 
   if (sys_menu_loader.IsValid())
   {

--- a/Source/UnitTests/Core/IOS/ES/FormatsTest.cpp
+++ b/Source/UnitTests/Core/IOS/ES/FormatsTest.cpp
@@ -6,14 +6,14 @@
 
 #include <vector>
 
+#include "Core/CommonTitles.h"
 #include "Core/IOS/ES/Formats.h"
 #include "TestBinaryData.h"
 
 TEST(ESFormats, TitleType)
 {
-  const u64 system_menu_title_id = 0x0000000100000002;
-  EXPECT_TRUE(IOS::ES::IsTitleType(system_menu_title_id, IOS::ES::TitleType::System));
-  EXPECT_FALSE(IOS::ES::IsDiscTitle(system_menu_title_id));
+  EXPECT_TRUE(IOS::ES::IsTitleType(Titles::SYSTEM_MENU, IOS::ES::TitleType::System));
+  EXPECT_FALSE(IOS::ES::IsDiscTitle(Titles::SYSTEM_MENU));
 
   const u64 ios59_title_id = 0x000000010000003b;
   EXPECT_TRUE(IOS::ES::IsTitleType(ios59_title_id, IOS::ES::TitleType::System));


### PR DESCRIPTION
Prevents... misusing the shop.

We are not legally obliged to do this, but let's not make piracy any easier.

The two first commits are from #5610.