### PR TITLE
IOS: Drop legacy timing hack

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -475,12 +475,6 @@ void Kernel::ExecuteIPCCommand(const u32 address)
   if (!result.send_reply)
     return;
 
-  // Ensure replies happen in order
-  const s64 ticks_until_last_reply = m_last_reply_time - CoreTiming::GetTicks();
-  if (ticks_until_last_reply > 0)
-    result.reply_delay_ticks += ticks_until_last_reply;
-  m_last_reply_time = CoreTiming::GetTicks() + result.reply_delay_ticks;
-
   EnqueueIPCReply(request, result.return_value, static_cast<int>(result.reply_delay_ticks));
 }
 
@@ -584,7 +578,6 @@ void Kernel::DoState(PointerWrap& p)
 {
   p.Do(m_request_queue);
   p.Do(m_reply_queue);
-  p.Do(m_last_reply_time);
   p.Do(m_title_id);
   p.Do(m_ppc_uid);
   p.Do(m_ppc_gid);

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -147,7 +147,6 @@ protected:
   IPCMsgQueue m_request_queue;  // ppc -> arm
   IPCMsgQueue m_reply_queue;    // arm -> ppc
   IPCMsgQueue m_ack_queue;      // arm -> ppc
-  u64 m_last_reply_time = 0;
 
   IOSC m_iosc;
 };

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -73,7 +73,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 86;  // Last changed in PR 2353
+static const u32 STATE_VERSION = 87;  // Last changed in PR 5698
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
It was introduced back in 2013 in a11827cdf when DVD timing started to be worked on and DI was still buggy.

Now that timing is solely handled by DVDInterface, which guarantees that the replies won't be sent out of order, we do not need to maintain this hack in IOS. It is a hack because IOS doesn't keep something like this globally for all IPC replies.