### PR TITLE
ESFormats: Minor changes

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -80,7 +80,7 @@ public:
 
     bool valid = false;
     IOS::ES::TMDReader tmd;
-    std::vector<u8> title_key;
+    std::array<u8, 16> title_key;
     std::map<u32, ExportContent> contents;
   };
 

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -380,7 +380,7 @@ u64 TicketReader::GetTitleId() const
   return Common::swap64(m_bytes.data() + offsetof(Ticket, title_id));
 }
 
-std::array<u8, 16> TicketReader::GetTitleKey() const
+std::array<u8, 16> TicketReader::GetTitleKey(const HLE::IOSC& iosc) const
 {
   u8 iv[16] = {};
   std::copy_n(&m_bytes[offsetof(Ticket, title_id)], sizeof(Ticket::title_id), iv);
@@ -394,15 +394,18 @@ std::array<u8, 16> TicketReader::GetTitleKey() const
              GetTitleId(), index);
   }
 
-  const bool is_rvt = (GetIssuer() == "Root-CA00000002-XS00000006");
-  const HLE::IOSC::ConsoleType console_type =
-      is_rvt ? HLE::IOSC::ConsoleType::RVT : HLE::IOSC::ConsoleType::Retail;
-
   std::array<u8, 16> key;
-  HLE::IOSC iosc(console_type);
   iosc.Decrypt(common_key_handle, iv, &m_bytes[offsetof(Ticket, title_key)], 16, key.data(),
                HLE::PID_ES);
   return key;
+}
+
+std::array<u8, 16> TicketReader::GetTitleKey() const
+{
+  const bool is_rvt = (GetIssuer() == "Root-CA00000002-XS00000006");
+  const HLE::IOSC::ConsoleType console_type =
+      is_rvt ? HLE::IOSC::ConsoleType::RVT : HLE::IOSC::ConsoleType::Retail;
+  return GetTitleKey(HLE::IOSC{console_type});
 }
 
 void TicketReader::DeleteTicket(u64 ticket_id_to_delete)
@@ -420,16 +423,16 @@ void TicketReader::DeleteTicket(u64 ticket_id_to_delete)
   m_bytes = std::move(new_ticket);
 }
 
-s32 TicketReader::Unpersonalise()
+HLE::ReturnCode TicketReader::Unpersonalise(HLE::IOSC& iosc)
 {
   const auto ticket_begin = m_bytes.begin();
 
   // IOS uses IOSC to compute an AES key from the peer public key and the device's private ECC key,
   // which is used the decrypt the title key. The IV is the ticket ID (8 bytes), zero extended.
   using namespace HLE;
-  IOSC iosc;
   IOSC::Handle public_handle;
-  s32 ret = iosc.CreateObject(&public_handle, IOSC::TYPE_PUBLIC_KEY, IOSC::SUBTYPE_ECC233, PID_ES);
+  ReturnCode ret =
+      iosc.CreateObject(&public_handle, IOSC::TYPE_PUBLIC_KEY, IOSC::SUBTYPE_ECC233, PID_ES);
   if (ret != IPC_SUCCESS)
     return ret;
 

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -380,7 +380,7 @@ u64 TicketReader::GetTitleId() const
   return Common::swap64(m_bytes.data() + offsetof(Ticket, title_id));
 }
 
-std::vector<u8> TicketReader::GetTitleKey() const
+std::array<u8, 16> TicketReader::GetTitleKey() const
 {
   u8 iv[16] = {};
   std::copy_n(&m_bytes[offsetof(Ticket, title_id)], sizeof(Ticket::title_id), iv);
@@ -398,7 +398,7 @@ std::vector<u8> TicketReader::GetTitleKey() const
   const HLE::IOSC::ConsoleType console_type =
       is_rvt ? HLE::IOSC::ConsoleType::RVT : HLE::IOSC::ConsoleType::Retail;
 
-  std::vector<u8> key(16);
+  std::array<u8, 16> key;
   HLE::IOSC iosc(console_type);
   iosc.Decrypt(common_key_handle, iv, &m_bytes[offsetof(Ticket, title_key)], 16, key.data(),
                HLE::PID_ES);

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -222,6 +222,10 @@ public:
 
   u32 GetDeviceId() const;
   u64 GetTitleId() const;
+  // Get the decrypted title key.
+  std::array<u8, 16> GetTitleKey(const HLE::IOSC& iosc) const;
+  // Same as the above version, but guesses the console type depending on the issuer
+  // and constructs a temporary IOSC instance.
   std::array<u8, 16> GetTitleKey() const;
 
   // Deletes a ticket with the given ticket ID from the internal buffer.
@@ -229,7 +233,7 @@ public:
 
   // Decrypts the title key field for a "personalised" ticket -- one that is device-specific
   // and has a title key that must be decrypted first.
-  s32 Unpersonalise();
+  HLE::ReturnCode Unpersonalise(HLE::IOSC& iosc);
 };
 
 class SharedContentMap final

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -222,7 +222,7 @@ public:
 
   u32 GetDeviceId() const;
   u64 GetTitleId() const;
-  std::vector<u8> GetTitleKey() const;
+  std::array<u8, 16> GetTitleKey() const;
 
   // Deletes a ticket with the given ticket ID from the internal buffer.
   void DeleteTicket(u64 ticket_id);

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -117,7 +117,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
       break;
     }
 
-    memcpy(m_aes_key, ticket.GetTitleKey().data(), sizeof(m_aes_key));
+    memcpy(m_aes_key, ticket.GetTitleKey(m_ios.GetIOSC()).data(), sizeof(m_aes_key));
     mbedtls_aes_setkey_dec(&m_aes_ctx, m_aes_key, 128);
 
     break;

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -186,7 +186,7 @@ void NANDContentLoader::InitializeContentEntries(const std::vector<u8>& data_app
   m_Content.resize(contents.size());
 
   u32 data_app_offset = 0;
-  const std::vector<u8> title_key = m_ticket.GetTitleKey();
+  const std::array<u8, 16> title_key = m_ticket.GetTitleKey();
   IOS::ES::SharedContentMap shared_content{m_root};
 
   for (size_t i = 0; i < contents.size(); ++i)

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -5,6 +5,7 @@
 #include "DiscIO/VolumeWii.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstring>
 #include <map>
@@ -97,9 +98,7 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
       IOS::ES::TMDReader tmd{std::move(tmd_buffer)};
 
       // Get the decryption key
-      const std::vector<u8> key = ticket.GetTitleKey();
-      if (key.size() != 16)
-        continue;
+      const std::array<u8, 16> key = ticket.GetTitleKey();
       std::unique_ptr<mbedtls_aes_context> aes_context = std::make_unique<mbedtls_aes_context>();
       mbedtls_aes_setkey_dec(aes_context.get(), key.data(), 128);
 


### PR DESCRIPTION
* Change title key related functions to use a std::array instead of std::vector. The title key is always 16 bytes, so it doesn't make sense to make it a std::vector.

* Reuse the kernel IOSC instance whenever that's possible. Saves memory and there's no reason to create a temporary instance when there's already one around.