### PR TITLE
QtUtils: add BlockUserInputFilter

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SRCS
   GameList/GameTracker.cpp
   GameList/ListProxyModel.cpp
   GameList/TableProxyModel.cpp
+  QtUtils/BlockUserInputFilter.cpp
   QtUtils/DoubleClickEventFilter.cpp
   QtUtils/ElidedButton.cpp
   QtUtils/ListTabWidget.cpp

--- a/Source/Core/DolphinQt2/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/IOWindow.h
@@ -94,6 +94,5 @@ private:
   ControllerEmu::EmulatedController* m_controller;
 
   ciface::Core::DeviceQualifier m_devq;
-  Common::Flag m_block;
   Type m_type;
 };

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.h
@@ -25,7 +25,6 @@ signals:
   void AdvancedPressed();
 
 private:
-  bool event(QEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
 
   void OnButtonPressed();
@@ -34,5 +33,4 @@ private:
 
   MappingWidget* m_parent;
   ControlReference* m_reference;
-  Common::Flag m_block;
 };

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="MenuBar.cpp" />
+    <ClCompile Include="QtUtils\BlockUserInputFilter.cpp" />
     <ClCompile Include="QtUtils\DoubleClickEventFilter.cpp" />
     <ClCompile Include="QtUtils\ElidedButton.cpp" />
     <ClCompile Include="QtUtils\ListTabWidget.cpp" />
@@ -217,6 +218,7 @@
     <ClInclude Include="Config\Mapping\WiimoteEmuExtension.h" />
     <ClInclude Include="Config\Mapping\WiimoteEmuGeneral.h" />
     <ClInclude Include="Config\Mapping\WiimoteEmuMotionControl.h" />
+    <ClInclude Include="QtUtils\BlockUserInputFilter.h" />
     <ClInclude Include="QtUtils\ElidedButton.h" />
     <ClInclude Include="QtUtils\ListTabWidget.h" />
     <ClInclude Include="Resources.h" />

--- a/Source/Core/DolphinQt2/QtUtils/BlockUserInputFilter.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/BlockUserInputFilter.cpp
@@ -1,0 +1,21 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/QtUtils/BlockUserInputFilter.h"
+
+#include <QEvent>
+
+BlockUserInputFilter* BlockUserInputFilter::Instance()
+{
+  static BlockUserInputFilter s_block_user_input_filter;
+  return &s_block_user_input_filter;
+}
+
+bool BlockUserInputFilter::eventFilter(QObject* object, QEvent* event)
+{
+  const QEvent::Type event_type = event->type();
+  return event_type == QEvent::KeyPress || event_type == QEvent::KeyRelease ||
+         event_type == QEvent::MouseButtonPress || event_type == QEvent::MouseButtonRelease ||
+         event_type == QEvent::MouseButtonDblClick;
+}

--- a/Source/Core/DolphinQt2/QtUtils/BlockUserInputFilter.h
+++ b/Source/Core/DolphinQt2/QtUtils/BlockUserInputFilter.h
@@ -1,0 +1,19 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QObject>
+
+class QEvent;
+
+class BlockUserInputFilter : public QObject
+{
+public:
+  static BlockUserInputFilter* Instance();
+
+private:
+  BlockUserInputFilter() = default;
+  bool eventFilter(QObject* object, QEvent* event) override;
+};


### PR DESCRIPTION
And use it in `MappingButton` and `IOWindow`. Makes the two windows consistent in their behavior (before this, `IOWindow` wasn't blocking input), de-duplicates a little bit of code, and separates Qt magic from controller interface logic.