### PR TITLE
BlockingLoop: fix unhandled enum value warning

### DIFF
--- a/Source/Core/Common/BlockingLoop.h
+++ b/Source/Core/Common/BlockingLoop.h
@@ -211,6 +211,8 @@ public:
 
     switch (mode)
     {
+    case kNonBlock:
+      break;
     case kBlock:
       Wait();
       break;


### PR DESCRIPTION
Fixes compiler warning:

```
Source/Core/Common/BlockingLoop.h:212:13: warning: enumeration value 'kNonBlock' not handled in switch [-Wswitch]
    switch (mode)
            ^
```