### PR TITLE
IOS/ES: Fix content table handling

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -57,9 +57,11 @@ public:
 
   struct OpenedContent
   {
-    u64 m_title_id;
+    bool m_opened = false;
+    u64 m_title_id = 0;
     IOS::ES::Content m_content;
-    u32 m_position;
+    u32 m_position = 0;
+    u32 m_uid = 0;
   };
 
   struct TitleImportContext
@@ -152,7 +154,7 @@ private:
     IOCTL_ES_ADDTITLEFINISH = 0x06,
     IOCTL_ES_GETDEVICEID = 0x07,
     IOCTL_ES_LAUNCH = 0x08,
-    IOCTL_ES_OPENCONTENT = 0x09,
+    IOCTL_ES_OPEN_ACTIVE_TITLE_CONTENT = 0x09,
     IOCTL_ES_READCONTENT = 0x0A,
     IOCTL_ES_CLOSECONTENT = 0x0B,
     IOCTL_ES_GETOWNEDTITLECNT = 0x0C,
@@ -179,7 +181,7 @@ private:
     IOCTL_ES_SETUID = 0x21,
     IOCTL_ES_DELETETITLECONTENT = 0x22,
     IOCTL_ES_SEEKCONTENT = 0x23,
-    IOCTL_ES_OPENTITLECONTENT = 0x24,
+    IOCTL_ES_OPENCONTENT = 0x24,
     IOCTL_ES_LAUNCHBC = 0x25,
     IOCTL_ES_EXPORTTITLEINIT = 0x26,
     IOCTL_ES_EXPORTCONTENTBEGIN = 0x27,
@@ -258,7 +260,7 @@ private:
   IPCCommandResult DeleteStreamKey(const IOCtlVRequest& request);
 
   // Title contents
-  IPCCommandResult OpenTitleContent(u32 uid, const IOCtlVRequest& request);
+  IPCCommandResult OpenActiveTitleContent(u32 uid, const IOCtlVRequest& request);
   IPCCommandResult OpenContent(u32 uid, const IOCtlVRequest& request);
   IPCCommandResult ReadContent(u32 uid, const IOCtlVRequest& request);
   IPCCommandResult CloseContent(u32 uid, const IOCtlVRequest& request);
@@ -340,12 +342,10 @@ private:
 
   static const DiscIO::NANDContentLoader& AccessContentDevice(u64 title_id);
 
-  u32 OpenTitleContent(u32 CFD, u64 TitleID, u16 Index);
+  s32 OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid);
 
-  using ContentAccessMap = std::map<u32, OpenedContent>;
-  ContentAccessMap m_ContentAccessMap;
-
-  u32 m_AccessIdentID = 0;
+  using ContentTable = std::array<OpenedContent, 16>;
+  ContentTable m_content_table;
 
   ContextArray m_contexts;
 };

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -73,7 +73,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 86;  // Last changed in PR 2353
+static const u32 STATE_VERSION = 87;  // Last changed in PR 5707
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This is larger than I thought it would be, but unfortunately it's quite hard to split fixes like this when the handling is wrong in tons of different places.

The content table is limited in size. It can only hold 16 entries. Three consequences:

* Since the table cannot grow indefinitely, instead of using a std::map we use a std::array as we should.

* Remove a hack where the CFD was cleared back to 0 on IPC close (wtf?)

* The CFD now doesn't keep increasing to infinity. It's unknown if this would fix anything at all, but some issues in the past were caused by CFDs being excessively large.

Other minor changes:

* Simplify the save state logic.

* Keep track of the UID like ES does. Not sure how useful this is, but we can do this very easily so why not.

* Remove the guesswork and use the actual error codes.

* Add more error checking to make Dolphin less likely to crash.

Something that should be done in the future: deduplicate the filesystem logic. Something that takes one line in the actual ES code takes 10+ lines in our implementation... while duplicating the FS logic... This will likely be harder to fix though, so I'm leaving that for another time.