### PR TITLE
Initialise WiiRoot once per emulation session

### DIFF
--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/AudioInterface.h"
 #include "Core/HW/CPU.h"
@@ -23,6 +24,7 @@
 #include "Core/HW/WII_IPC.h"
 #include "Core/IOS/IOS.h"
 #include "Core/State.h"
+#include "Core/WiiRoot.h"
 
 namespace HW
 {
@@ -48,6 +50,8 @@ void Init()
 
   if (SConfig::GetInstance().bWii)
   {
+    // The NAND should only be initialised once per emulation session.
+    Core::InitializeWiiRoot(Core::WantsDeterminism());
     IOS::Init();
     IOS::HLE::Init();  // Depends on Memory
   }
@@ -58,6 +62,7 @@ void Shutdown()
   // IOS should always be shut down regardless of bWii because it can be running in GC mode (MIOS).
   IOS::HLE::Shutdown();  // Depends on Memory
   IOS::Shutdown();
+  Core::ShutdownWiiRoot();
 
   SystemTimers::Shutdown();
   CPU::Shutdown();

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -212,8 +212,6 @@ EmulationKernel::EmulationKernel(u64 title_id) : Kernel(title_id)
   if (!SetupMemory(title_id, MemorySetupType::IOSReload))
     WARN_LOG(IOS, "No information about this IOS -- cannot set up memory values");
 
-  Core::InitializeWiiRoot(Core::WantsDeterminism());
-
   if (title_id == Titles::MIOS)
   {
     MIOS::Load();


### PR DESCRIPTION
This removes unnecessary initialisations which would cause issues in determinism mode.