### PR TITLE
Remove unnecessary WiiRoot inits/shutdowns

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -180,6 +180,7 @@ Kernel::Kernel()
   // using more than one IOS instance at a time is not supported.
   _assert_(GetIOS() == nullptr);
   Core::InitializeWiiRoot(false);
+  m_is_responsible_for_nand_root = true;
   AddCoreDevices();
 }
 
@@ -198,7 +199,8 @@ Kernel::~Kernel()
     m_device_map.clear();
   }
 
-  Core::ShutdownWiiRoot();
+  if (m_is_responsible_for_nand_root)
+    Core::ShutdownWiiRoot();
 }
 
 Kernel::Kernel(u64 title_id) : m_title_id(title_id)

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -133,6 +133,7 @@ protected:
   s32 GetFreeDeviceID();
   s32 OpenDevice(OpenRequest& request);
 
+  bool m_is_responsible_for_nand_root = false;
   u64 m_title_id = 0;
   static constexpr u8 IPC_MAX_FDS = 0x18;
   std::map<std::string, std::shared_ptr<Device::Device>> m_device_map;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -625,7 +625,8 @@ bool BeginRecordingInput(int controllers)
 
   s_currentByte = s_totalBytes = 0;
 
-  Core::UpdateWantDeterminism();
+  if (Core::IsRunning())
+    Core::UpdateWantDeterminism();
 
   Core::PauseAndLock(false, was_unpaused);
 


### PR DESCRIPTION
* IOS: WiiRoot shutdown was moved to HW.

* Movie: Don't call UpdateWantDeterminism() if we're not running yet, because this will automatically be done during the boot process. Not doing this will result in two NANDs being created.