### PR TITLE
Hide audio latency setting when no backend supports it

### DIFF
--- a/Source/Core/DolphinQt2/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/AudioPane.cpp
@@ -24,6 +24,7 @@
 
 AudioPane::AudioPane()
 {
+  CheckNeedForLatencyControl();
   CreateWidgets();
   LoadSettings();
   ConnectWidgets();
@@ -69,20 +70,24 @@ void AudioPane::CreateWidgets()
   backend_box->setLayout(backend_layout);
   m_backend_label = new QLabel(tr("Audio Backend:"));
   m_backend_combo = new QComboBox();
-  m_latency_label = new QLabel(tr("Latency:"));
   m_dolby_pro_logic = new QCheckBox(tr("Dolby Pro Logic II Decoder"));
-  m_latency_spin = new QSpinBox();
 
-  m_latency_spin->setMinimum(0);
-  m_latency_spin->setMaximum(30);
-  m_latency_spin->setToolTip(tr("Sets the latency (in ms). Higher values may reduce audio "
-                                "crackling. Certain backends only."));
+  if (m_latency_control_supported)
+  {
+    m_latency_label = new QLabel(tr("Latency:"));
+    m_latency_spin = new QSpinBox();
+    m_latency_spin->setMinimum(0);
+    m_latency_spin->setMaximum(200);
+    m_latency_spin->setToolTip(tr("Sets the latency (in ms). Higher values may reduce audio "
+                                  "crackling. Certain backends only."));
+  }
 
   m_dolby_pro_logic->setToolTip(
       tr("Enables Dolby Pro Logic II emulation using 5.1 surround. Certain backends only."));
 
   backend_layout->addRow(m_backend_label, m_backend_combo);
-  backend_layout->addRow(m_latency_label, m_latency_spin);
+  if (m_latency_control_supported)
+    backend_layout->addRow(m_latency_label, m_latency_spin);
   backend_layout->addRow(m_dolby_pro_logic);
 
   auto* stretching_box = new QGroupBox(tr("Audio Stretching Settings"));
@@ -122,8 +127,11 @@ void AudioPane::ConnectWidgets()
   connect(m_backend_combo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
           this, &AudioPane::SaveSettings);
   connect(m_volume_slider, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
-  connect(m_latency_spin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-          &AudioPane::SaveSettings);
+  if (m_latency_control_supported)
+  {
+    connect(m_latency_spin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            &AudioPane::SaveSettings);
+  }
   connect(m_stretching_buffer_slider, &QSlider::valueChanged, this, &AudioPane::SaveSettings);
   connect(m_dolby_pro_logic, &QCheckBox::toggled, this, &AudioPane::SaveSettings);
   connect(m_stretching_enable, &QCheckBox::toggled, this, &AudioPane::SaveSettings);
@@ -165,7 +173,8 @@ void AudioPane::LoadSettings()
   m_dolby_pro_logic->setChecked(SConfig::GetInstance().bDPL2Decoder);
 
   // Latency
-  m_latency_spin->setValue(SConfig::GetInstance().iLatency);
+  if (m_latency_control_supported)
+    m_latency_spin->setValue(SConfig::GetInstance().iLatency);
 
   // Stretch
   m_stretching_enable->setChecked(SConfig::GetInstance().m_audio_stretch);
@@ -204,7 +213,8 @@ void AudioPane::SaveSettings()
   SConfig::GetInstance().bDPL2Decoder = m_dolby_pro_logic->isChecked();
 
   // Latency
-  SConfig::GetInstance().iLatency = m_latency_spin->value();
+  if (m_latency_control_supported)
+    SConfig::GetInstance().iLatency = m_latency_spin->value();
 
   // Stretch
   SConfig::GetInstance().m_audio_stretch = m_stretching_enable->isChecked();
@@ -223,8 +233,11 @@ void AudioPane::OnBackendChanged()
   const auto backend = SConfig::GetInstance().sBackend;
 
   m_dolby_pro_logic->setEnabled(AudioCommon::SupportsDPL2Decoder(backend));
-  m_latency_label->setEnabled(AudioCommon::SupportsLatencyControl(backend));
-  m_latency_spin->setEnabled(AudioCommon::SupportsLatencyControl(backend));
+  if (m_latency_control_supported)
+  {
+    m_latency_label->setEnabled(AudioCommon::SupportsLatencyControl(backend));
+    m_latency_spin->setEnabled(AudioCommon::SupportsLatencyControl(backend));
+  }
   m_volume_slider->setEnabled(AudioCommon::SupportsVolumeChanges(backend));
   m_volume_indicator->setEnabled(AudioCommon::SupportsVolumeChanges(backend));
 }
@@ -237,12 +250,22 @@ void AudioPane::OnEmulationStateChanged(bool running)
   m_dolby_pro_logic->setEnabled(!running);
   m_backend_label->setEnabled(!running);
   m_backend_combo->setEnabled(!running);
-  m_latency_label->setEnabled(!running);
-  m_latency_spin->setEnabled(!running);
+  if (m_latency_control_supported)
+  {
+    m_latency_label->setEnabled(!running);
+    m_latency_spin->setEnabled(!running);
+  }
 }
 
 void AudioPane::OnVolumeChanged(int volume)
 {
   m_volume_slider->setValue(volume);
   m_volume_indicator->setText(tr("%1 %").arg(volume));
+}
+
+void AudioPane::CheckNeedForLatencyControl()
+{
+  std::vector<std::string> backends = AudioCommon::GetSoundBackends();
+  m_latency_control_supported =
+      std::any_of(backends.cbegin(), backends.cend(), AudioCommon::SupportsLatencyControl);
 }

--- a/Source/Core/DolphinQt2/Settings/AudioPane.h
+++ b/Source/Core/DolphinQt2/Settings/AudioPane.h
@@ -32,6 +32,9 @@ private:
   void OnBackendChanged();
   void OnVolumeChanged(int volume);
 
+  void CheckNeedForLatencyControl();
+  bool m_latency_control_supported;
+
   QGridLayout* m_main_layout;
 
   // DSP Engine

--- a/Source/Core/DolphinWX/Config/AudioConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AudioConfigPane.cpp
@@ -24,6 +24,7 @@
 
 AudioConfigPane::AudioConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
 {
+  CheckNeedForLatencyControl();
   InitializeGUI();
   LoadGUIValues();
   BindEvents();
@@ -44,9 +45,12 @@ void AudioConfigPane::InitializeGUI()
   m_volume_text = new wxStaticText(this, wxID_ANY, "");
   m_audio_backend_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_audio_backend_strings);
-  m_audio_latency_spinctrl =
-      new wxSpinCtrl(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 200);
-  m_audio_latency_label = new wxStaticText(this, wxID_ANY, _("Latency (ms):"));
+  if (m_latency_control_supported)
+  {
+    m_audio_latency_spinctrl = new wxSpinCtrl(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
+                                              wxSP_ARROW_KEYS, 0, 200);
+    m_audio_latency_label = new wxStaticText(this, wxID_ANY, _("Latency (ms):"));
+  }
 
   m_stretch_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Audio Stretching"));
   m_stretch_label = new wxStaticText(this, wxID_ANY, _("Buffer Size:"));
@@ -54,8 +58,12 @@ void AudioConfigPane::InitializeGUI()
       new DolphinSlider(this, wxID_ANY, 80, 5, 300, wxDefaultPosition, wxDefaultSize);
   m_stretch_text = new wxStaticText(this, wxID_ANY, "");
 
-  m_audio_latency_spinctrl->SetToolTip(_("Sets the latency (in ms). Higher values may reduce audio "
-                                         "crackling. Certain backends only."));
+  if (m_latency_control_supported)
+  {
+    m_audio_latency_spinctrl->SetToolTip(
+        _("Sets the latency (in ms). Higher values may reduce audio "
+          "crackling. Certain backends only."));
+  }
   m_dpl2_decoder_checkbox->SetToolTip(
       _("Enables Dolby Pro Logic II emulation using 5.1 surround. Certain backends only."));
   m_stretch_checkbox->SetToolTip(_("Enables stretching of the audio to match emulation speed."));
@@ -76,10 +84,13 @@ void AudioConfigPane::InitializeGUI()
                           wxALIGN_CENTER_VERTICAL);
   backend_grid_sizer->Add(m_dpl2_decoder_checkbox, wxGBPosition(1, 0), wxGBSpan(1, 2),
                           wxALIGN_CENTER_VERTICAL);
-  backend_grid_sizer->Add(m_audio_latency_label, wxGBPosition(2, 0), wxDefaultSpan,
-                          wxALIGN_CENTER_VERTICAL);
-  backend_grid_sizer->Add(m_audio_latency_spinctrl, wxGBPosition(2, 1), wxDefaultSpan,
-                          wxALIGN_CENTER_VERTICAL);
+  if (m_latency_control_supported)
+  {
+    backend_grid_sizer->Add(m_audio_latency_label, wxGBPosition(2, 0), wxDefaultSpan,
+                            wxALIGN_CENTER_VERTICAL);
+    backend_grid_sizer->Add(m_audio_latency_spinctrl, wxGBPosition(2, 1), wxDefaultSpan,
+                            wxALIGN_CENTER_VERTICAL);
+  }
 
   wxStaticBoxSizer* const backend_static_box_sizer =
       new wxStaticBoxSizer(wxVERTICAL, this, _("Backend Settings"));
@@ -139,7 +150,10 @@ void AudioConfigPane::LoadGUIValues()
   m_volume_slider->SetValue(SConfig::GetInstance().m_Volume);
   m_volume_text->SetLabel(wxString::Format("%d %%", SConfig::GetInstance().m_Volume));
   m_dpl2_decoder_checkbox->SetValue(startup_params.bDPL2Decoder);
-  m_audio_latency_spinctrl->SetValue(startup_params.iLatency);
+  if (m_latency_control_supported)
+  {
+    m_audio_latency_spinctrl->SetValue(startup_params.iLatency);
+  }
   m_stretch_checkbox->SetValue(startup_params.m_audio_stretch);
   m_stretch_slider->Enable(startup_params.m_audio_stretch);
   m_stretch_slider->SetValue(startup_params.m_audio_stretch_max_latency);
@@ -152,9 +166,12 @@ void AudioConfigPane::ToggleBackendSpecificControls(const std::string& backend)
 {
   m_dpl2_decoder_checkbox->Enable(AudioCommon::SupportsDPL2Decoder(backend));
 
-  bool supports_latency_control = AudioCommon::SupportsLatencyControl(backend);
-  m_audio_latency_spinctrl->Enable(supports_latency_control);
-  m_audio_latency_label->Enable(supports_latency_control);
+  if (m_latency_control_supported)
+  {
+    bool supports_latency_control = AudioCommon::SupportsLatencyControl(backend);
+    m_audio_latency_spinctrl->Enable(supports_latency_control);
+    m_audio_latency_label->Enable(supports_latency_control);
+  }
 
   bool supports_volume_changes = AudioCommon::SupportsVolumeChanges(backend);
   m_volume_slider->Enable(supports_volume_changes);
@@ -175,8 +192,12 @@ void AudioConfigPane::BindEvents()
   m_audio_backend_choice->Bind(wxEVT_CHOICE, &AudioConfigPane::OnAudioBackendChanged, this);
   m_audio_backend_choice->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 
-  m_audio_latency_spinctrl->Bind(wxEVT_SPINCTRL, &AudioConfigPane::OnLatencySpinCtrlChanged, this);
-  m_audio_latency_spinctrl->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+  if (m_latency_control_supported)
+  {
+    m_audio_latency_spinctrl->Bind(wxEVT_SPINCTRL, &AudioConfigPane::OnLatencySpinCtrlChanged,
+                                   this);
+    m_audio_latency_spinctrl->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+  }
 
   m_stretch_checkbox->Bind(wxEVT_CHECKBOX, &AudioConfigPane::OnStretchCheckBoxChanged, this);
   m_stretch_slider->Bind(wxEVT_SLIDER, &AudioConfigPane::OnStretchSliderChanged, this);
@@ -240,4 +261,11 @@ void AudioConfigPane::PopulateBackendChoiceBox()
 
   int num = m_audio_backend_choice->FindString(StrToWxStr(SConfig::GetInstance().sBackend));
   m_audio_backend_choice->SetSelection(num);
+}
+
+void AudioConfigPane::CheckNeedForLatencyControl()
+{
+  std::vector<std::string> backends = AudioCommon::GetSoundBackends();
+  m_latency_control_supported =
+      std::any_of(backends.cbegin(), backends.cend(), AudioCommon::SupportsLatencyControl);
 }

--- a/Source/Core/DolphinWX/Config/AudioConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AudioConfigPane.h
@@ -26,6 +26,7 @@ private:
   void BindEvents();
 
   void PopulateBackendChoiceBox();
+  void CheckNeedForLatencyControl();
   void ToggleBackendSpecificControls(const std::string& backend);
 
   void OnDSPEngineRadioBoxChanged(wxCommandEvent&);
@@ -50,4 +51,6 @@ private:
   wxStaticText* m_stretch_label;
   DolphinSlider* m_stretch_slider;
   wxStaticText* m_stretch_text;
+
+  bool m_latency_control_supported;
 };


### PR DESCRIPTION
As this setting is only used by OpenAL it can be hidden when it is not available (read: anything but Windows, or when it is not installed)