### PR TITLE
FramebufferManager: Fix EFB layers being attached to the wrong FBO.

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -97,7 +97,7 @@ void FramebufferManager::BindLayeredTexture(GLuint texture, const std::vector<GL
   // Bind all the other layers as separate FBOs for blitting.
   for (unsigned int i = 1; i < m_EFBLayers; i++)
   {
-    glBindFramebuffer(GL_FRAMEBUFFER, m_resolvedFramebuffer[i]);
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffers[i]);
     glFramebufferTextureLayer(GL_FRAMEBUFFER, attachment, texture, 0, i);
   }
 }


### PR DESCRIPTION
Fixes typo in commit 56fe938366950062984e11364af5ce1ffe474f27.

This PR fixes OpenGL stereoscopy when used together with Anti-Aliasing.