### PR TITLE
GameSettings: enforce real XFB for Pool Edge

### DIFF
--- a/Data/Sys/GameSettings/GPE.ini
+++ b/Data/Sys/GameSettings/GPE.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues =
+EmulationIssues = requires real XFB to avoid flickering
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -17,3 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+UseXFB = True
+UseRealXFB = True

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -140,7 +140,7 @@ bool WiimoteLinux::ConnectInternal()
 
   // Output channel
   addr.l2_psm = htobs(WC_OUTPUT);
-  if (m_cmd_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP))
+  if ((m_cmd_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)))
   {
     int retry = 0;
     while (connect(m_cmd_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
@@ -165,7 +165,7 @@ bool WiimoteLinux::ConnectInternal()
 
   // Input channel
   addr.l2_psm = htobs(WC_INPUT);
-  if (m_int_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP))
+  if ((m_int_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)))
   {
     int retry = 0;
     while (connect(m_int_sock, (sockaddr*)&addr, sizeof(addr)) < 0)


### PR DESCRIPTION
Without this, it flickers and shows stretched screen halves.