### PR TITLE
Update Mario Party 6 INI

### DIFF
--- a/Data/Sys/GameSettings/GP6.ini
+++ b/Data/Sys/GameSettings/GP6.ini
@@ -19,4 +19,5 @@ EmulationIssues = Mini games tour bus needs emulate format changes to preview th
 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
-
+[Video_Settings]
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GP6.ini
+++ b/Data/Sys/GameSettings/GP6.ini
@@ -19,5 +19,6 @@ EmulationIssues = Mini games tour bus needs emulate format changes to preview th
 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
+
 [Video_Settings]
 SafeTextureCacheColorSamples = 512


### PR DESCRIPTION
This game requires safe or medium texture cache to be enabled to have the ground update properly in Mowtown. Fast Texture Cache makes the ground update much slower than it should.