### PR TITLE
Update to partial texture updates

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1326,6 +1326,14 @@ void TextureCacheBase::CopyRenderTargetToTexture(u32 dstAddr, EFBCopyFormat dstF
         continue;
       }
       entry->may_have_overlapping_textures = true;
+
+      // Do not load textures by hash, if they were at least partly overwritten by an efb copy.
+      // In this case, comparing the hash is not enough to check, if two textures are identical.
+      if (entry->textures_by_hash_iter != textures_by_hash.end())
+      {
+        textures_by_hash.erase(entry->textures_by_hash_iter);
+        entry->textures_by_hash_iter = textures_by_hash.end();
+      }
     }
     ++iter.first;
   }

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -823,6 +823,7 @@ TextureCacheBase::TCacheEntry* TextureCacheBase::Load(const u32 stage)
   entry->SetHashes(base_hash, full_hash);
   entry->is_efb_copy = false;
   entry->is_custom_tex = hires_tex != nullptr;
+  entry->memory_stride = entry->BytesPerRow();
 
   std::string basename = "";
   if (g_ActiveConfig.bDumpTextures && !hires_tex)


### PR DESCRIPTION
Partial updates had a bug, that updated textures could be loaded by hash, ignoring the address(textures_by_hash). This could result in unexpected results, if a game had 2 textures where the base is identical, but they are stored in different memory locations and differ because of parts that are updated via partial updates. Since efb copies always write the same dummy data, both textures would have the same hash, and Dolphin would load one of them for both textures.

This pr also changes the logic about which textures are removed from the cache when they overlap new efb copies. Dolphin now keeps all textures that are partly overwritten and have the same stride as the efb copy. This is supposed to get efb2tex to the same texture as efb2ram, by applying the related efb copies as updates after each other, in the order of their creation.

The main purpose of this pr is to improve partial updates for hybrid xfb. Other than that, it does "fix" Spyro: A Hero's Tail, so efb2tex looks the same as efb2ram now. "fix", because the amount of bloom the game uses is high and it gets increased with higher IR, resulting at 3xIR in something i'd call hyperbloom... Anyways, this pr together with https://github.com/dolphin-emu/dolphin/pull/5726 gets efb2tex to the same output as efb2ram, while it's actually correct emulation, as far as i can see.