### PR TITLE
Make "Monospaced font" in the log window actually monospaced for all platforms.

### DIFF
--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -69,7 +69,12 @@ void CLogWindow::CreateGUIControls()
   m_FontChoice->Append(_("Selected font"));
 
   DefaultFont = GetFont();
-  MonoSpaceFont.SetNativeFontInfoUserDesc("lucida console windows-1252");
+  MonoSpaceFont.SetFamily(wxFONTFAMILY_TELETYPE);
+#ifdef _WIN32
+  // Windows uses Courier New for monospace even though there are better fonts.
+  MonoSpaceFont.SetFaceName("Consolas");
+#endif
+  MonoSpaceFont.SetPointSize(DefaultFont.GetPointSize());
   LogFont.push_back(DefaultFont);
   LogFont.push_back(MonoSpaceFont);
   LogFont.push_back(DebuggerFont);


### PR DESCRIPTION
The `MonoSpaceFont` of the `LogWindow` was using a Windows native way to
specify a font name.

Now it's using `wxFONTFAMILY_TELETYPE`.

On Win32 it will additionally request the specific font name _"Consolas"_,
so it doesn't use ugly _"Courier New"_. I pilfered that specialization
from the Action Replay code editor, which uses it in 2 places:

https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/DolphinWX/Cheats/ARCodeAddEdit.cpp
https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/DolphinWX/Cheats/ActionReplayCodesPanel.cpp
