### PR TITLE
Optimize DoFileSearch on all platforms

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(common
   Crypto/ec.cpp
   Debug/MemoryPatches.cpp
   Debug/Watches.cpp
+  DirectoryIterator.cpp
   ENetUtil.cpp
   File.cpp
   FileSearch.cpp

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -63,6 +63,7 @@
     <ClInclude Include="DebugInterface.h" />
     <ClInclude Include="Debug\MemoryPatches.h" />
     <ClInclude Include="Debug\Watches.h" />
+    <ClInclude Include="DirectoryIterator.h" />
     <ClInclude Include="ENetUtil.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="File.h" />
@@ -181,6 +182,7 @@
     <ClCompile Include="Config\Layer.cpp" />
     <ClCompile Include="Debug\MemoryPatches.cpp" />
     <ClCompile Include="Debug\Watches.cpp" />
+    <ClCompile Include="DirectoryIterator.cpp" />
     <ClCompile Include="ENetUtil.cpp" />
     <ClCompile Include="File.cpp" />
     <ClCompile Include="FileSearch.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -274,6 +274,7 @@
     <ClInclude Include="Debug\MemoryPatches.h">
       <Filter>Debug</Filter>
     </ClInclude>
+    <ClInclude Include="DirectoryIterator.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDUtils.cpp" />
@@ -353,6 +354,7 @@
     <ClCompile Include="Debug\MemoryPatches.cpp">
       <Filter>Debug</Filter>
     </ClCompile>
+    <ClCompile Include="DirectoryIterator.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/Common/DirectoryIterator.cpp
+++ b/Source/Core/Common/DirectoryIterator.cpp
@@ -1,0 +1,240 @@
+// This file is under the public domain.
+
+#include "Common/DirectoryIterator.h"
+
+#include <string>
+#include <utility>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <dirent.h>
+#include "Common/FileUtil.h"
+#endif
+
+#include "Common/StringUtil.h"
+
+namespace Common
+{
+DirectoryEntry::DirectoryEntry() = default;
+
+#ifdef _WIN32
+DirectoryEntry::DirectoryEntry(const StringType& path)
+{
+  m_handle = FindFirstFile((path + L"\\*").c_str(), &m_find_data);
+  if (IsValid())
+    SkipSpecialName();
+}
+#else
+DirectoryEntry::DirectoryEntry(const StringType& path) : m_path(&path)
+{
+  m_dir = opendir(path.c_str());
+  if (m_dir)
+    Advance();
+}
+#endif
+
+DirectoryEntry::~DirectoryEntry()
+{
+  Close();
+}
+
+DirectoryEntry::DirectoryEntry(DirectoryEntry&& other)
+{
+  Move(std::move(other));
+}
+
+DirectoryEntry& DirectoryEntry::operator=(DirectoryEntry&& other)
+{
+  Close();
+  Move(std::move(other));
+  return *this;
+}
+
+void DirectoryEntry::Close()
+{
+#ifdef _WIN32
+  FindClose(m_handle);
+#else
+  if (m_dir)
+    closedir(m_dir);
+#endif
+}
+
+void DirectoryEntry::Move(DirectoryEntry&& other)
+{
+#ifdef _WIN32
+  m_handle = other.m_handle;
+  m_find_data = other.m_find_data;
+
+  other.m_handle = INVALID_HANDLE_VALUE;
+#else
+  m_path = other.m_path;
+  m_dir = other.m_dir;
+  m_dirent = other.m_dirent;
+
+  other.m_dir = nullptr;
+#endif
+}
+
+void DirectoryEntry::Advance()
+{
+#ifdef _WIN32
+  if (!FindNextFile(m_handle, &m_find_data))
+  {
+    FindClose(m_handle);
+    m_handle = INVALID_HANDLE_VALUE;
+    return;
+  }
+#else
+  m_dirent = readdir(m_dir);
+  if (!m_dirent)
+    return;
+#endif
+
+  SkipSpecialName();
+}
+
+void DirectoryEntry::SkipSpecialName()
+{
+  // Advance to the next name if the current name is . or ..
+  const CharType* const name = GetName();
+  if (name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
+    Advance();
+}
+
+bool DirectoryEntry::IsValid() const
+{
+#ifdef _WIN32
+  return m_handle != INVALID_HANDLE_VALUE;
+#else
+  return m_dirent != nullptr;
+#endif
+}
+
+#ifdef _WIN32
+const wchar_t* DirectoryEntry::GetName() const
+{
+  return m_find_data.cFileName;
+}
+#else
+const char* DirectoryEntry::GetName() const
+{
+  return m_dirent->d_name;
+}
+#endif
+
+bool DirectoryEntry::IsDirectory() const
+{
+#ifdef _WIN32
+  // Fast
+  return static_cast<bool>(m_find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+#else
+
+#ifdef _DIRENT_HAVE_D_TYPE
+  // Fast
+  if (m_dirent->d_type != DT_UNKNOWN)
+    return m_dirent->d_type == DT_DIR;
+#endif
+
+  // Not as fast
+  return File::IsDirectory(*m_path + '/' + GetName());
+#endif
+}
+
+u64 DirectoryEntry::GetSize() const
+{
+#ifdef _WIN32
+  // Fast
+  return (static_cast<u64>(m_find_data.nFileSizeHigh) << 32) | m_find_data.nFileSizeLow;
+#else
+  // Not as fast
+  return File::GetSize(*m_path + '/' + GetName());
+#endif
+}
+
+std::string ToUTF8(const std::wstring& str)
+{
+  return UTF16ToUTF8(str);
+}
+
+const std::string& ToUTF8(const std::string& str)
+{
+  return str;
+}
+
+std::string& ToUTF8(std::string& str)
+{
+  return str;
+}
+
+std::string ToUTF8(std::string&& str)
+{
+  return str;
+}
+
+#ifdef _WIN32
+std::wstring ToOSEncoding(const std::string& str)
+{
+  return UTF8ToUTF16(str);
+}
+#endif
+
+const DirectoryEntry::StringType& ToOSEncoding(const DirectoryEntry::StringType& str)
+{
+  return str;
+}
+
+DirectoryEntry::StringType& ToOSEncoding(DirectoryEntry::StringType& str)
+{
+  return str;
+}
+
+DirectoryEntry::StringType ToOSEncoding(DirectoryEntry::StringType&& str)
+{
+  return str;
+}
+
+DirectoryIterator::DirectoryIterator() : m_entry(std::make_shared<DirectoryEntry>())
+{
+}
+
+DirectoryIterator::DirectoryIterator(const DirectoryEntry::StringType& path)
+    : m_entry(std::make_shared<DirectoryEntry>(path))
+{
+}
+
+bool DirectoryIterator::operator==(const DirectoryIterator& other) const
+{
+  // This implementation is only useful for comparing with end iterators
+  return !m_entry->IsValid() && !other.m_entry->IsValid();
+}
+
+bool DirectoryIterator::operator!=(const DirectoryIterator& other) const
+{
+  return !operator==(other);
+}
+
+DirectoryIterator& DirectoryIterator::operator++()
+{
+  m_entry->Advance();
+  return *this;
+}
+
+DirectoryIterator DirectoryIterator::operator++(int)
+{
+  DirectoryIterator old = *this;
+  m_entry->Advance();
+  return old;
+}
+
+const DirectoryIterator::value_type& DirectoryIterator::operator*() const
+{
+  return *m_entry;
+}
+
+const DirectoryIterator::value_type* DirectoryIterator::operator->() const
+{
+  return m_entry.get();
+}
+};

--- a/Source/Core/Common/DirectoryIterator.h
+++ b/Source/Core/Common/DirectoryIterator.h
@@ -1,0 +1,128 @@
+// This file is under the public domain.
+
+#pragma once
+
+#include <iterator>
+#include <memory>
+#include <string>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <dirent.h>
+#endif
+
+#include "Common/CommonTypes.h"
+
+namespace Common
+{
+// This class is designed for speed over convenience.
+// You may want to consider using FileSearch.h instead.
+class DirectoryEntry final
+{
+public:
+#ifdef _WIN32
+  using CharType = wchar_t;
+  using StringType = std::wstring;
+#else
+  using CharType = char;
+  using StringType = std::string;
+#endif
+
+  DirectoryEntry();
+  explicit DirectoryEntry(const StringType& path);
+  ~DirectoryEntry();
+
+  DirectoryEntry(const DirectoryEntry& other) = delete;
+  DirectoryEntry(DirectoryEntry&& other);
+  DirectoryEntry& operator=(const DirectoryEntry& other) = delete;
+  DirectoryEntry& operator=(DirectoryEntry&& other);
+
+  void Advance();
+  bool IsValid() const;
+
+  // Returns the name, not the full path. Only call if IsValid returns true.
+  const CharType* GetName() const;
+
+  // Runs faster than File::IsDirectory on many systems. Only call if the following are true:
+  // 1. IsValid returns true, and
+  // 2. The OS is Windows or the path reference passed to the constructor is still valid
+  // (Note that ToOSEncoding passes through references untouched on non-Windows systems.)
+  bool IsDirectory() const;
+
+  // Runs faster than File::GetSize on Windows. Only call if the following are true:
+  // 1. IsValid returns true, and
+  // 2. The OS is Windows or the path reference passed to the constructor is still valid
+  // (Note that ToOSEncoding passes through references untouched on non-Windows systems.)
+  u64 GetSize() const;
+
+private:
+  void Close();
+  void Move(DirectoryEntry&& other);
+
+  void SkipSpecialName();
+
+#ifdef _WIN32
+  HANDLE m_handle = INVALID_HANDLE_VALUE;
+  WIN32_FIND_DATA m_find_data;
+#else
+  const std::string* m_path;
+  DIR* m_dir = nullptr;
+  dirent* m_dirent = nullptr;
+#endif
+};
+
+std::string ToUTF8(const std::wstring& str);
+const std::string& ToUTF8(const std::string& str);
+std::string& ToUTF8(std::string& str);
+std::string ToUTF8(std::string&& str);
+#ifdef _WIN32
+std::wstring ToOSEncoding(const std::string& str);
+#endif
+const DirectoryEntry::StringType& ToOSEncoding(const DirectoryEntry::StringType& str);
+DirectoryEntry::StringType& ToOSEncoding(DirectoryEntry::StringType& str);
+DirectoryEntry::StringType ToOSEncoding(DirectoryEntry::StringType&& str);
+
+// Iterates through the names (not paths) of a directory's files and subdirectories.
+class DirectoryIterator final
+{
+public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = DirectoryEntry;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  DirectoryIterator();
+  explicit DirectoryIterator(const DirectoryEntry::StringType& path);
+
+  bool operator==(const DirectoryIterator& other) const;
+  bool operator!=(const DirectoryIterator& other) const;
+
+  DirectoryIterator& operator++();
+  DirectoryIterator operator++(int);
+
+  const DirectoryEntry& operator*() const;
+  const DirectoryEntry* operator->() const;
+
+private:
+  std::shared_ptr<DirectoryEntry> m_entry;
+};
+
+template <typename T>
+class Directory final
+{
+public:
+  explicit Directory(const T& path) : m_path(path) {}
+  // Only call this if the path reference still is valid
+  DirectoryIterator cbegin() { return DirectoryIterator(ToOSEncoding(m_path)); }
+  DirectoryIterator cend() { return DirectoryIterator(); }
+  // Only call this if the path reference still is valid
+  DirectoryIterator begin() { return cbegin(); }
+  DirectoryIterator end() { return cend(); }
+
+private:
+  const T& m_path;
+};
+
+}  // namespace Common

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -2,131 +2,97 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/FileSearch.h"
+
 #include <algorithm>
+#include <cstring>
 #include <functional>
 
 #include "Common/CommonPaths.h"
-#include "Common/FileSearch.h"
+#include "Common/DirectoryIterator.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <Windows.h>
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#define HAS_STD_FILESYSTEM
-#else
-#include <cstring>
-#include "Common/CommonFuncs.h"
-#include "Common/FileUtil.h"
+#include "Common/StringUtil.h"
 #endif
 
 namespace Common
 {
-#ifndef HAS_STD_FILESYSTEM
-
-static std::vector<std::string>
-FileSearchWithTest(const std::vector<std::string>& directories, bool recursive,
-                   std::function<bool(const File::FSTEntry&)> callback)
-{
-  std::vector<std::string> result;
-  for (const std::string& directory : directories)
-  {
-    File::FSTEntry top = File::ScanDirectoryTree(directory, recursive);
-
-    std::function<void(File::FSTEntry&)> DoEntry;
-    DoEntry = [&](File::FSTEntry& entry) {
-      if (callback(entry))
-        result.push_back(entry.physicalName);
-      for (auto& child : entry.children)
-        DoEntry(child);
-    };
-    for (auto& child : top.children)
-      DoEntry(child);
-  }
-  // remove duplicates
-  std::sort(result.begin(), result.end());
-  result.erase(std::unique(result.begin(), result.end()), result.end());
-  return result;
-}
-
-std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
-                                      const std::vector<std::string>& exts, bool recursive)
-{
-  bool accept_all = exts.empty();
-  return FileSearchWithTest(directories, recursive, [&](const File::FSTEntry& entry) {
-    if (accept_all)
-      return true;
-    if (entry.isDirectory)
-      return false;
-    return std::any_of(exts.begin(), exts.end(), [&](const std::string& ext) {
-      const std::string& name = entry.virtualName;
-      return name.length() >= ext.length() &&
-             strcasecmp(name.c_str() + name.length() - ext.length(), ext.c_str()) == 0;
-    });
-  });
-}
-
-#else
-
 std::vector<std::string> DoFileSearch(const std::vector<std::string>& directories,
                                       const std::vector<std::string>& exts, bool recursive)
 {
   bool accept_all = exts.empty();
 
-  std::vector<fs::path> native_exts;
-  for (const auto& ext : exts)
-    native_exts.push_back(fs::u8path(ext));
+#ifdef _WIN32
+  std::vector<std::wstring> native_exts;
+  for (const std::string& ext : exts)
+    native_exts.push_back(UTF8ToTStr(ext));
 
   // N.B. This avoids doing any copies
-  auto ext_matches = [&native_exts](const fs::path& path) {
-    const auto& native_path = path.native();
-    return std::any_of(native_exts.cbegin(), native_exts.cend(), [&native_path](const auto& ext) {
-      // TODO provide cross-platform compat for the comparison function, once more platforms
-      // support std::filesystem
-      int compare_len = static_cast<int>(ext.native().length());
-      return native_path.length() >= compare_len &&
-             CompareStringOrdinal(&native_path.c_str()[native_path.length() - compare_len],
-                                  compare_len, ext.c_str(), compare_len, TRUE) == CSTR_EQUAL;
+  auto ext_matches = [&native_exts](const wchar_t* name) {
+    return std::any_of(native_exts.cbegin(), native_exts.cend(), [&name](const std::wstring& ext) {
+      const int compare_length = static_cast<int>(ext.length());
+      const size_t name_length = wcslen(name);
+      return name_length >= compare_length &&
+             CompareStringOrdinal(&name[name_length - compare_length], compare_length, ext.c_str(),
+                                  compare_length, TRUE) == CSTR_EQUAL;
     });
   };
+#else
+  // N.B. This avoids doing any copies
+  auto ext_matches = [&exts](const char* name) {
+    return std::any_of(exts.cbegin(), exts.cend(), [&name](const std::string& ext) {
+      const size_t name_length = strlen(name);
+      return name_length >= ext.length() &&
+             strcasecmp(name + name_length - ext.length(), ext.c_str()) == 0;
+    });
+  };
+#endif
 
   std::vector<std::string> result;
-  auto add_filtered = [&](const fs::directory_entry& entry) {
-    auto& path = entry.path();
-    if (accept_all || (ext_matches(path) && !fs::is_directory(path)))
-      result.emplace_back(path.u8string());
+
+#ifdef _WIN32
+  constexpr wchar_t directory_separator = L'/';
+#else
+  constexpr char directory_separator = '/';
+#endif
+
+  std::function<void(const DirectoryEntry::StringType& path)> do_directory;
+  do_directory = [&](const DirectoryEntry::StringType& path) {
+    for (const DirectoryEntry& entry : Directory<DirectoryEntry::StringType>(path))
+    {
+      // For performance, skip calling IsDirectory if we won't be using the value
+      const bool is_directory = (!accept_all || recursive) ? entry.IsDirectory() : false;
+      const DirectoryEntry::CharType* const child_name = entry.GetName();
+
+      if (accept_all || (!is_directory && ext_matches(child_name)))
+        result.emplace_back(ToUTF8(path + directory_separator + child_name));
+
+      if (recursive && is_directory)
+        do_directory(path + directory_separator + child_name);
+
+      // TODO: We could get better performance in the (currently unused?) case
+      // (accept_all && recursive) by not computing (path + directory_separator + child_name)
+      // twice. We shouldn't compute it if the result won't be used, though.
+    }
   };
+
   for (const auto& directory : directories)
-  {
-    if (recursive)
-    {
-      // TODO use fs::directory_options::follow_directory_symlink ?
-      for (auto& entry : fs::recursive_directory_iterator(fs::u8path(directory)))
-        add_filtered(entry);
-    }
-    else
-    {
-      for (auto& entry : fs::directory_iterator(fs::u8path(directory)))
-        add_filtered(entry);
-    }
-  }
+    do_directory(ToOSEncoding(directory));
 
   // Remove duplicates (occurring because caller gave e.g. duplicate or overlapping directories -
-  // not because std::filesystem returns duplicates). Also note that this pathname-based uniqueness
-  // isn't as thorough as std::filesystem::equivalent.
+  // not because the scanning code returns duplicates). Also note that this pathname-based
+  // uniqueness isn't as thorough as std::filesystem::equivalent.
   std::sort(result.begin(), result.end());
   result.erase(std::unique(result.begin(), result.end()), result.end());
 
-  // Dolphin expects to be able to use "/" (DIR_SEP) everywhere.
-  // std::filesystem uses the OS separator.
-  constexpr fs::path::value_type os_separator = fs::path::preferred_separator;
-  static_assert(os_separator == DIR_SEP_CHR || os_separator == '\\', "Unsupported path separator");
-  if (os_separator != DIR_SEP_CHR)
-    for (auto& path : result)
-      std::replace(path.begin(), path.end(), '\\', DIR_SEP_CHR);
+#ifdef _WIN32
+  // Dolphin expects to be able to use / (DIR_SEP_CHR) everywhere, but Windows uses \.
+  for (std::string& path : result)
+    std::replace(path.begin(), path.end(), '\\', DIR_SEP_CHR);
+#endif
 
   return result;
 }
-
-#endif
 
 }  // namespace Common


### PR DESCRIPTION
My main reason for doing this was to avoid the slow function File::ScanDirectoryTree which previously was used on all OSes other than Windows, but it seems like this improved the speed a bit on Windows too; the DoFileSearch call that happens when pressing the game list refresh button took about 50-80 ms before this and 25-50 ms after this. (The directories that I tested with mostly contain files with non-matching extensions.) The performance improvement on other platforms should be much larger because of how slow File::ScanDirectoryTree was.

TODO:
- [x] Debug ScanDirectoryTree (it seems to act as if the directory it tries to scan doesn't exist)
- [x] Test on operating systems other than Windows