### PR TITLE
Fix some GCC ODR warnings

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
@@ -8,12 +8,15 @@
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/PPCTables.h"
 
+namespace
+{
 struct GekkoOPTemplate
 {
   int opcode;
   Interpreter::Instruction Inst;
   GekkoOPInfo opinfo;
 };
+}
 
 // clang-format off
 static GekkoOPInfo unknownopinfo = { "unknown_instruction", OPTYPE_UNKNOWN, FL_ENDBLOCK, 0, 0, 0, 0 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -32,11 +32,14 @@ void Jit64::DynaRunTable63(UGeckoInstruction _inst)
   (this->*dynaOpTable63[_inst.SUBOP10])(_inst);
 }
 
+namespace
+{
 struct GekkoOPTemplate
 {
   int opcode;
   Jit64::Instruction Inst;
 };
+}
 
 const GekkoOPTemplate primarytable[] = {
     {4, &Jit64::DynaRunTable4},    // RunTable4

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -39,12 +39,15 @@ void JitArm64::DynaRunTable63(UGeckoInstruction inst)
   (this->*dynaOpTable63[inst.SUBOP10])(inst);
 }
 
+namespace
+{
 struct GekkoOPTemplate
 {
   int opcode;
   _Instruction Inst;
   // GekkoOPInfo opinfo; // Doesn't need opinfo, Interpreter fills it out
 };
+}
 
 constexpr GekkoOPTemplate primarytable[] = {
     {4, &JitArm64::DynaRunTable4},    // RunTable4


### PR DESCRIPTION
struct GekkoOPTemplate was implemented differently in different
compilation units, which breaks the ODR and could end up causing issues
as symbols exported from one compilation unit 'could' end up being used by
another even if they have different implementations.

This puts them in an anonymous namespace, restricting any generated
symbols to the single compilation unit.