### PR TITLE
Implement minimal emulation of TMEM caching

### DIFF
--- a/Data/Sys/GameSettings/G5S.ini
+++ b/Data/Sys/GameSettings/G5S.ini
@@ -16,7 +16,3 @@ EmulationIssues = Needs efb to Ram for proper lighting.
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -285,6 +285,8 @@ static void BPWritten(const BPCmd& bp)
     if (g_bRecordFifoData)
       FifoRecorder::GetInstance().UseMemory(addr, tlutXferCount, MemoryUpdate::TMEM);
 
+    TextureCacheBase::InvalidateAllBindPoints();
+
     return;
   }
   case BPMEM_FOGRANGE:  // Fog Settings Control
@@ -397,6 +399,7 @@ static void BPWritten(const BPCmd& bp)
     return;
   case BPMEM_TEXINVALIDATE:
     // TODO: Needs some restructuring in TextureCacheBase.
+    TextureCacheBase::InvalidateAllBindPoints();
     return;
 
   case BPMEM_ZCOMPARE:  // Set the Z-Compare and EFB pixel format
@@ -499,6 +502,8 @@ static void BPWritten(const BPCmd& bp)
 
       if (g_bRecordFifoData)
         FifoRecorder::GetInstance().UseMemory(src_addr, bytes_read, MemoryUpdate::TMEM);
+
+      TextureCacheBase::InvalidateAllBindPoints();
     }
     return;
 
@@ -582,10 +587,12 @@ static void BPWritten(const BPCmd& bp)
   // ------------------------
   case BPMEM_TX_SETMODE0:  // (0x90 for linear)
   case BPMEM_TX_SETMODE0_4:
+    TextureCacheBase::InvalidateAllBindPoints();
     return;
 
   case BPMEM_TX_SETMODE1:
   case BPMEM_TX_SETMODE1_4:
+    TextureCacheBase::InvalidateAllBindPoints();
     return;
   // --------------------------------------------
   // BPMEM_TX_SETIMAGE0 - Texture width, height, format
@@ -602,6 +609,7 @@ static void BPWritten(const BPCmd& bp)
   case BPMEM_TX_SETIMAGE2_4:
   case BPMEM_TX_SETIMAGE3:
   case BPMEM_TX_SETIMAGE3_4:
+    TextureCacheBase::InvalidateAllBindPoints();
     return;
   // -------------------------------
   // Set a TLUT
@@ -609,6 +617,7 @@ static void BPWritten(const BPCmd& bp)
   // -------------------------------
   case BPMEM_TX_SETTLUT:
   case BPMEM_TX_SETTLUT_4:
+    TextureCacheBase::InvalidateAllBindPoints();
     return;
 
   default:

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <bitset>
 #include <map>
 #include <memory>
 #include <tuple>
@@ -39,6 +40,7 @@ public:
     bool is_efb_copy;
     bool is_custom_tex;
     bool may_have_overlapping_textures = true;
+    bool tmem_only = false;  // indicates that this texture only exists in the tmem cache
 
     unsigned int native_width,
         native_height;  // Texture dimensions from the GameCube's point of view
@@ -125,8 +127,9 @@ public:
   virtual void DeleteShaders() = 0;
 
   TCacheEntry* Load(const u32 stage);
-  void UnbindTextures();
-  virtual void BindTextures();
+  static void InvalidateAllBindPoints() { valid_bind_points.reset(); }
+  static bool IsValidBindPoint(u32 i) { return valid_bind_points.test(i); }
+  void BindTextures();
   void CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFormat, u32 dstStride,
                                  bool is_depth_copy, const EFBRectangle& srcRect, bool isIntensity,
                                  bool scaleByHalf);
@@ -158,6 +161,7 @@ protected:
   size_t temp_size = 0;
 
   std::array<TCacheEntry*, 8> bound_textures{};
+  static std::bitset<8> valid_bind_points;
 
 private:
   // Minimal version of TCacheEntry just for TexPool

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -243,7 +243,6 @@ void VertexManagerBase::Flush()
         if (bpmem.tevind[i].IsActive() && bpmem.tevind[i].bt < bpmem.genMode.numindstages)
           usedtextures[bpmem.tevindref.getTexMap(bpmem.tevind[i].bt)] = true;
 
-    g_texture_cache->UnbindTextures();
     for (unsigned int i : usedtextures)
     {
       const auto* tentry = g_texture_cache->Load(i);


### PR DESCRIPTION
This is a remake of https://github.com/dolphin-emu/dolphin/pull/3749

Full credit goes to phire.

Old message:
"If none of the texture registers have changed and TMEM hasn't been invalidated or changed in other ways, we can blindly reuse the old texture cache entries without rehashing.

Not only does this fix the bloom effect in Spyro: A Hero's Tail (The game abused texture cache) but it will also provide speedups for other games which use the same texture over multiple draw calls, especially when safe texture cache is in use."

Changed the pr per phire's instructions to only return the current texture(s), if none of the texture registers were changed. If any texture register was changed, fall back to the default hashing and rebuilding textures from memory.