### PR TITLE
Qt: Don't show the Qt "What's this" button

### DIFF
--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -13,6 +13,7 @@
 AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("About Dolphin"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setAttribute(Qt::WA_DeleteOnClose);
 
   QString text = QStringLiteral("");

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -69,6 +69,7 @@ static int FromWiimoteMenuIndex(const int menudevice)
 ControllersWindow::ControllersWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Controller Settings"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateGamecubeLayout();
   CreateWiimoteLayout();

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -39,6 +39,7 @@
 MappingWindow::MappingWindow(QWidget* parent, int port_num) : QDialog(parent), m_port(port_num)
 {
   setWindowTitle(tr("Port %1").arg(port_num + 1));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateDevicesLayout();
   CreateProfilesLayout();

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -23,6 +23,7 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
 {
   // Set Window Properties
   setWindowTitle(tr("Settings"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   resize(720, 600);
 
   // Main Layout

--- a/Source/Core/DolphinQt2/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt2/WiiUpdate.cpp
@@ -43,6 +43,7 @@ void PerformOnlineUpdate(const std::string& region, QWidget* parent)
   UpdateProgressDialog dialog{parent};
   dialog.setLabelText(QObject::tr("Preparing to update...\nThis can take a while."));
   dialog.setWindowTitle(QObject::tr("Updating"));
+  dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
   // QProgressDialog doesn't set its minimum size correctly.
   dialog.setMinimumSize(360, 150);
 


### PR DESCRIPTION
It was discussed a while ago on IRC that this is just crappy design, so we weren't going to use it. However, Qt likes to enable it by default for `QDialog`s, so we need to explicitly disable it.

Before: 
![image](https://user-images.githubusercontent.com/4411333/27716629-ee9c893a-5cfc-11e7-85fd-b93a64702c09.png)

After: 
![image](https://user-images.githubusercontent.com/4411333/27716653-09210bc8-5cfd-11e7-9361-a1a7254b9c0a.png)
