### PR TITLE
DolphinQt2: update old SLOT/SIGNAL syntax

### DIFF
--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -133,7 +133,9 @@ void InfoWidget::CreateLanguageSelector()
   }
   if (m_language_selector->count() == 1)
     m_language_selector->setDisabled(true);
-  connect(m_language_selector, SIGNAL(currentIndexChanged(int)), this, SLOT(ChangeLanguage()));
+  connect(m_language_selector,
+          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &InfoWidget::ChangeLanguage);
   ChangeLanguage();
 }
 

--- a/Source/Core/DolphinQt2/Config/InfoWidget.h
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.h
@@ -19,12 +19,11 @@ class InfoWidget final : public QWidget
 public:
   explicit InfoWidget(const GameFile& game);
 
-private slots:
+private:
   void ComputeChecksum();
   void ChangeLanguage();
   void SaveBanner();
 
-private:
   QGroupBox* CreateBannerDetails();
   QGroupBox* CreateISODetails();
   QLineEdit* CreateValueDisplay() { return CreateValueDisplay(QStringLiteral("")); };

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -157,7 +157,7 @@ void GameList::ShowContextMenu(const QPoint&)
     const auto blob_type = GameFile(game).GetBlobType();
 
     if (blob_type == DiscIO::BlobType::GCZ)
-      menu->addAction(tr("Decompress ISO"), this, SLOT(DecompressISO()));
+      menu->addAction(tr("Decompress ISO"), this, SLOT(CompressISO()));
     else if (blob_type == DiscIO::BlobType::PLAIN)
       menu->addAction(tr("Compress ISO"), this, SLOT(CompressISO()));
 

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -147,19 +147,19 @@ void GameList::ShowContextMenu(const QPoint&)
 
   QMenu* menu = new QMenu(this);
   DiscIO::Platform platform = GameFile(game).GetPlatformID();
-  menu->addAction(tr("Properties"), this, SLOT(OpenProperties()));
-  menu->addAction(tr("Wiki"), this, SLOT(OpenWiki()));
+  menu->addAction(tr("Properties"), this, &GameList::OpenProperties);
+  menu->addAction(tr("Wiki"), this, &GameList::OpenWiki);
   menu->addSeparator();
 
   if (platform == DiscIO::Platform::GAMECUBE_DISC || platform == DiscIO::Platform::WII_DISC)
   {
-    menu->addAction(tr("Default ISO"), this, SLOT(SetDefaultISO()));
+    menu->addAction(tr("Default ISO"), this, &GameList::SetDefaultISO);
     const auto blob_type = GameFile(game).GetBlobType();
 
     if (blob_type == DiscIO::BlobType::GCZ)
-      menu->addAction(tr("Decompress ISO"), this, SLOT(CompressISO()));
+      menu->addAction(tr("Decompress ISO"), this, &GameList::CompressISO);
     else if (blob_type == DiscIO::BlobType::PLAIN)
-      menu->addAction(tr("Compress ISO"), this, SLOT(CompressISO()));
+      menu->addAction(tr("Compress ISO"), this, &GameList::CompressISO);
 
     menu->addSeparator();
   }
@@ -189,13 +189,13 @@ void GameList::ShowContextMenu(const QPoint&)
 
   if (platform == DiscIO::Platform::WII_WAD || platform == DiscIO::Platform::WII_DISC)
   {
-    menu->addAction(tr("Open Wii save folder"), this, SLOT(OpenSaveFolder()));
-    menu->addAction(tr("Export Wii save (Experimental)"), this, SLOT(ExportWiiSave()));
+    menu->addAction(tr("Open Wii save folder"), this, &GameList::OpenSaveFolder);
+    menu->addAction(tr("Export Wii save (Experimental)"), this, &GameList::ExportWiiSave);
     menu->addSeparator();
   }
 
-  menu->addAction(tr("Open Containing Folder"), this, SLOT(OpenContainingFolder()));
-  menu->addAction(tr("Remove File"), this, SLOT(DeleteFile()));
+  menu->addAction(tr("Open Containing Folder"), this, &GameList::OpenContainingFolder);
+  menu->addAction(tr("Remove File"), this, &GameList::DeleteFile);
   menu->exec(QCursor::pos());
 }
 

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -21,13 +21,17 @@ public:
   explicit GameList(QWidget* parent = nullptr);
   QString GetSelectedGame() const;
 
-public slots:
   void SetTableView() { SetPreferredView(true); }
   void SetListView() { SetPreferredView(false); }
   void SetViewColumn(int col, bool view) { m_table->setColumnHidden(col, !view); }
   void OnColumnVisibilityToggled(const QString& row, bool visible);
 
-private slots:
+signals:
+  void GameSelected();
+  void EmulationStarted();
+  void EmulationStopped();
+
+private:
   void ShowContextMenu(const QPoint&);
   void OpenContainingFolder();
   void OpenProperties();
@@ -41,12 +45,6 @@ private slots:
   void CompressISO();
   void OnHeaderViewChanged();
 
-signals:
-  void GameSelected();
-  void EmulationStarted();
-  void EmulationStopped();
-
-private:
   void MakeTableView();
   void MakeListView();
   void MakeEmptyView();

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -41,7 +41,6 @@ public:
     NUM_COLS
   };
 
-public slots:
   void UpdateGame(QSharedPointer<GameFile> game);
   void RemoveGame(const QString& path);
 

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -29,7 +29,6 @@ public:
   explicit GameTracker(QObject* parent = nullptr);
   ~GameTracker();
 
-public slots:
   void AddDirectory(const QString& dir);
   void RemoveDirectory(const QString& dir);
 
@@ -54,7 +53,7 @@ class GameLoader final : public QObject
 {
   Q_OBJECT
 
-public slots:
+public:
   void LoadGame(const QString& path)
   {
     GameFile* game = new GameFile(path);

--- a/Source/Core/DolphinQt2/Host.h
+++ b/Source/Core/DolphinQt2/Host.h
@@ -23,7 +23,6 @@ public:
   bool GetRenderFocus();
   bool GetRenderFullscreen();
 
-public slots:
   void SetRenderHandle(void* handle);
   void SetRenderFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -36,7 +36,7 @@ signals:
   void EmulationPaused();
   void EmulationStopped();
 
-private slots:
+private:
   void Open();
   void Play();
   void Pause();
@@ -63,7 +63,6 @@ private slots:
   void FullScreen();
   void ScreenShot();
 
-private:
   void CreateComponents();
 
   void ConnectGameList();

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -77,14 +77,14 @@ void MenuBar::EmulationStopped()
 void MenuBar::AddFileMenu()
 {
   QMenu* file_menu = addMenu(tr("File"));
-  m_open_action = file_menu->addAction(tr("Open"), this, SIGNAL(Open()));
-  m_exit_action = file_menu->addAction(tr("Exit"), this, SIGNAL(Exit()));
+  m_open_action = file_menu->addAction(tr("Open"), this, &MenuBar::Open);
+  m_exit_action = file_menu->addAction(tr("Exit"), this, &MenuBar::Exit);
 }
 
 void MenuBar::AddToolsMenu()
 {
   QMenu* tools_menu = addMenu(tr("Tools"));
-  m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, SLOT(InstallWAD()));
+  m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, &MenuBar::InstallWAD);
 
   // Label will be set by a NANDRefresh later
   m_boot_sysmenu = tools_menu->addAction(QStringLiteral(""), [this] { emit BootWiiSystemMenu(); });
@@ -107,13 +107,13 @@ void MenuBar::AddToolsMenu()
 void MenuBar::AddEmulationMenu()
 {
   QMenu* emu_menu = addMenu(tr("Emulation"));
-  m_play_action = emu_menu->addAction(tr("Play"), this, SIGNAL(Play()));
-  m_pause_action = emu_menu->addAction(tr("Pause"), this, SIGNAL(Pause()));
-  m_stop_action = emu_menu->addAction(tr("Stop"), this, SIGNAL(Stop()));
-  m_reset_action = emu_menu->addAction(tr("Reset"), this, SIGNAL(Reset()));
-  m_fullscreen_action = emu_menu->addAction(tr("Fullscreen"), this, SIGNAL(Fullscreen()));
-  m_frame_advance_action = emu_menu->addAction(tr("Frame Advance"), this, SIGNAL(FrameAdvance()));
-  m_screenshot_action = emu_menu->addAction(tr("Take Screenshot"), this, SIGNAL(Screenshot()));
+  m_play_action = emu_menu->addAction(tr("Play"), this, &MenuBar::Play);
+  m_pause_action = emu_menu->addAction(tr("Pause"), this, &MenuBar::Pause);
+  m_stop_action = emu_menu->addAction(tr("Stop"), this, &MenuBar::Stop);
+  m_reset_action = emu_menu->addAction(tr("Reset"), this, &MenuBar::Reset);
+  m_fullscreen_action = emu_menu->addAction(tr("Fullscreen"), this, &MenuBar::Fullscreen);
+  m_frame_advance_action = emu_menu->addAction(tr("Frame Advance"), this, &MenuBar::FrameAdvance);
+  m_screenshot_action = emu_menu->addAction(tr("Take Screenshot"), this, &MenuBar::Screenshot);
   AddStateLoadMenu(emu_menu);
   AddStateSaveMenu(emu_menu);
   AddStateSlotMenu(emu_menu);
@@ -123,10 +123,10 @@ void MenuBar::AddEmulationMenu()
 void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 {
   m_state_load_menu = emu_menu->addMenu(tr("Load State"));
-  m_state_load_menu->addAction(tr("Load State from File"), this, SIGNAL(StateLoad()));
-  m_state_load_menu->addAction(tr("Load State from Selected Slot"), this, SIGNAL(StateLoadSlot()));
+  m_state_load_menu->addAction(tr("Load State from File"), this, &MenuBar::StateLoad);
+  m_state_load_menu->addAction(tr("Load State from Selected Slot"), this, &MenuBar::StateLoadSlot);
   m_state_load_slots_menu = m_state_load_menu->addMenu(tr("Load State from Slot"));
-  m_state_load_menu->addAction(tr("Undo Load State"), this, SIGNAL(StateLoadUndo()));
+  m_state_load_menu->addAction(tr("Undo Load State"), this, &MenuBar::StateLoadUndo);
 
   for (int i = 1; i <= 10; i++)
   {
@@ -139,11 +139,11 @@ void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 void MenuBar::AddStateSaveMenu(QMenu* emu_menu)
 {
   m_state_save_menu = emu_menu->addMenu(tr("Save State"));
-  m_state_save_menu->addAction(tr("Save State to File"), this, SIGNAL(StateSave()));
-  m_state_save_menu->addAction(tr("Save State to Selected Slot"), this, SIGNAL(StateSaveSlot()));
-  m_state_save_menu->addAction(tr("Save State to Oldest Slot"), this, SIGNAL(StateSaveOldest()));
+  m_state_save_menu->addAction(tr("Save State to File"), this, &MenuBar::StateSave);
+  m_state_save_menu->addAction(tr("Save State to Selected Slot"), this, &MenuBar::StateSaveSlot);
+  m_state_save_menu->addAction(tr("Save State to Oldest Slot"), this, &MenuBar::StateSaveOldest);
   m_state_save_slots_menu = m_state_save_menu->addMenu(tr("Save State to Slot"));
-  m_state_save_menu->addAction(tr("Undo Save State"), this, SIGNAL(StateSaveUndo()));
+  m_state_save_menu->addAction(tr("Undo Save State"), this, &MenuBar::StateSaveUndo);
 
   for (int i = 1; i <= 10; i++)
   {
@@ -220,8 +220,7 @@ void MenuBar::AddHelpMenu()
   });
 
   help_menu->addSeparator();
-
-  help_menu->addAction(tr("About"), this, SIGNAL(ShowAboutDialog()));
+  help_menu->addAction(tr("About"), this, &MenuBar::ShowAboutDialog);
 }
 
 void MenuBar::AddGameListTypeSection(QMenu* view_menu)

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -16,6 +16,15 @@ class MenuBar final : public QMenuBar
 public:
   explicit MenuBar(QWidget* parent = nullptr);
 
+  void EmulationStarted();
+  void EmulationPaused();
+  void EmulationStopped();
+  void UpdateStateSlotMenu();
+  void UpdateToolsMenu(bool emulation_started);
+
+  // Tools
+  void InstallWAD();
+
 signals:
   // File
   void Open();
@@ -56,16 +65,6 @@ signals:
   void ColumnVisibilityToggled(const QString& row, bool visible);
 
   void ShowAboutDialog();
-
-public slots:
-  void EmulationStarted();
-  void EmulationPaused();
-  void EmulationStopped();
-  void UpdateStateSlotMenu();
-  void UpdateToolsMenu(bool emulation_started);
-
-  // Tools
-  void InstallWAD();
 
 private:
   void AddFileMenu();

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -60,33 +60,33 @@ void ToolBar::EmulationStopped()
 void ToolBar::MakeActions()
 {
   constexpr int button_width = 65;
-  m_open_action = addAction(tr("Open"), this, SIGNAL(OpenPressed()));
+  m_open_action = addAction(tr("Open"), this, &ToolBar::OpenPressed);
   widgetForAction(m_open_action)->setMinimumWidth(button_width);
 
-  m_play_action = addAction(tr("Play"), this, SIGNAL(PlayPressed()));
+  m_play_action = addAction(tr("Play"), this, &ToolBar::PlayPressed);
   widgetForAction(m_play_action)->setMinimumWidth(button_width);
 
-  m_pause_action = addAction(tr("Pause"), this, SIGNAL(PausePressed()));
+  m_pause_action = addAction(tr("Pause"), this, &ToolBar::PausePressed);
   widgetForAction(m_pause_action)->setMinimumWidth(button_width);
 
-  m_stop_action = addAction(tr("Stop"), this, SIGNAL(StopPressed()));
+  m_stop_action = addAction(tr("Stop"), this, &ToolBar::StopPressed);
   widgetForAction(m_stop_action)->setMinimumWidth(button_width);
 
-  m_fullscreen_action = addAction(tr("Full Screen"), this, SIGNAL(FullScreenPressed()));
+  m_fullscreen_action = addAction(tr("Full Screen"), this, &ToolBar::FullScreenPressed);
   widgetForAction(m_fullscreen_action)->setMinimumWidth(button_width);
 
-  m_screenshot_action = addAction(tr("Screen Shot"), this, SIGNAL(ScreenShotPressed()));
+  m_screenshot_action = addAction(tr("Screen Shot"), this, &ToolBar::ScreenShotPressed);
   widgetForAction(m_screenshot_action)->setMinimumWidth(button_width);
 
   addSeparator();
 
-  m_config_action = addAction(tr("Settings"), this, SIGNAL(SettingsPressed()));
+  m_config_action = addAction(tr("Settings"), this, &ToolBar::SettingsPressed);
   widgetForAction(m_config_action)->setMinimumWidth(button_width);
 
-  m_graphics_action = addAction(tr("Graphics"), this, SIGNAL(GraphicsPressed()));
+  m_graphics_action = addAction(tr("Graphics"), this, &ToolBar::GraphicsPressed);
   widgetForAction(m_graphics_action)->setMinimumWidth(button_width);
 
-  m_controllers_action = addAction(tr("Controllers"), this, SIGNAL(ControllersPressed()));
+  m_controllers_action = addAction(tr("Controllers"), this, &ToolBar::ControllersPressed);
   widgetForAction(m_controllers_action)->setMinimumWidth(button_width);
   m_controllers_action->setEnabled(true);
 }


### PR DESCRIPTION
This PR:
- Replaces all use of the old SLOT and SIGNAL macros with Qt5-style, compile-time-checked function pointers. More information: [Signals and Slots in Qt5](https://woboq.com/blog/new-signals-slots-syntax-in-qt5.html).
- Removes all usage of the `(public|protected|private) slots:` macro from headers, since it's pointless when using the new syntax.
- Fixes the "Decompress ISO" option in the gamelist context menu. Compile-time-checked connections to the rescue!