### PR TITLE
Disable Background Input when Background Input is disabled

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -17,7 +17,7 @@ constexpr ControlState INPUT_DETECT_THRESHOLD = 0.55;
 
 bool ControlReference::InputGateOn()
 {
-  return SConfig::GetInstance().m_BackgroundInput || Host_RendererHasFocus() || Host_UIHasFocus();
+  return SConfig::GetInstance().m_BackgroundInput || Host_RendererHasFocus();
 }
 
 //


### PR DESCRIPTION
Only remaining issue is that clicking on the titlebar of the window, to give it focus, is already interpreted as input. But clicking on the window in the task bar, or using alt tab works to get back, without causing an input event.

This is good enough for me.

Thanks @leoetlino for pointing out how to fix this really really annoying behavior!