### PR TITLE
Prevent multiple HID elements of same usage type on OSX

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <sstream>
 
 #include <Foundation/Foundation.h>
@@ -49,11 +50,26 @@ Joystick::Joystick(IOHIDDeviceRef device, std::string name)
 
   if (axes)
   {
+    std::vector<IOHIDElementRef> elems;
     for (int i = 0; i < CFArrayGetCount(axes); i++)
     {
       IOHIDElementRef e = (IOHIDElementRef)CFArrayGetValueAtIndex(axes, i);
       // DeviceElementDebugPrint(e, nullptr);
+      uint32_t usage = IOHIDElementGetUsage(e);
 
+      // Check for any existing elements with the same usage
+      auto it = std::find_if(elems.begin(), elems.end(), [usage](const auto& ref) {
+        return usage == IOHIDElementGetUsage(ref);
+      });
+
+      if (it == elems.end())
+        elems.push_back(e);
+      else
+        *it = e;
+    }
+
+    for (auto e : elems)
+    {
       if (IOHIDElementGetUsage(e) == kHIDUsage_GD_Hatswitch)
       {
         AddInput(new Hat(e, m_device, Hat::up));
@@ -67,6 +83,7 @@ Joystick::Joystick(IOHIDDeviceRef device, std::string name)
                         new Axis(e, m_device, Axis::positive));
       }
     }
+
     CFRelease(axes);
   }
 


### PR DESCRIPTION
I recently bought a Retrolink GC gamepad and the C-stick only worked in two directions. After looking around I found I was not the only one with this problem.

After some debugging I found that it was because in OSX for some reason the device's elements returned two elements with the usage type kHIDUsage_GD_Z from IOHIDDeviceCopyMatchingElements(). The fix only retains the last of the elements and there appears to be other project using the same approach to this issue, https://fossies.org/linux/vice/src/arch/gtk3/joy-osx-hid.c for instance.

Also, I apologise if the code is not idiomatic C++ but I haven't work with it for some time but you get the idea of what the code does... :)