### PR TITLE
IOS/ES: Merge the title import and export contexts

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -321,15 +321,7 @@ void ES::Context::DoState(PointerWrap& p)
 {
   p.Do(uid);
   p.Do(gid);
-
-  title_import.tmd.DoState(p);
-  p.Do(title_import.content_id);
-  p.Do(title_import.content_buffer);
-
-  p.Do(title_export.valid);
-  title_export.tmd.DoState(p);
-  p.Do(title_export.title_key);
-  p.Do(title_export.contents);
+  title_import.DoState(p);
 
   p.Do(active);
   p.Do(ipc_fd);

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -321,7 +321,7 @@ void ES::Context::DoState(PointerWrap& p)
 {
   p.Do(uid);
   p.Do(gid);
-  title_import.DoState(p);
+  title_import_export.DoState(p);
 
   p.Do(active);
   p.Do(ipc_fd);

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -55,7 +55,7 @@ public:
   ReturnCode Close(u32 fd) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
-  struct TitleImportContext
+  struct TitleImportExportContext
   {
     void DoState(PointerWrap& p);
 
@@ -78,8 +78,7 @@ public:
 
     u16 gid = 0;
     u32 uid = 0;
-    // The same context is used for both title imports and exports.
-    TitleImportContext title_import;
+    TitleImportExportContext title_import_export;
     bool active = false;
     // We use this to associate an IPC fd with an ES context.
     s32 ipc_fd = -1;

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -113,6 +113,12 @@ public:
   u32 GetSharedContentsCount() const;
   std::vector<std::array<u8, 20>> GetSharedContents() const;
 
+  // Title contents
+  s32 OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid);
+  ReturnCode CloseContent(u32 cfd, u32 uid);
+  s32 ReadContent(u32 cfd, u8* buffer, u32 size, u32 uid);
+  s32 SeekContent(u32 cfd, u32 offset, SeekMode mode, u32 uid);
+
   // Title management
   ReturnCode ImportTicket(const std::vector<u8>& ticket_bytes, const std::vector<u8>& cert_chain);
   ReturnCode ImportTmd(Context& context, const std::vector<u8>& tmd_bytes);
@@ -341,8 +347,6 @@ private:
   void FinishAllStaleImports();
 
   static const DiscIO::NANDContentLoader& AccessContentDevice(u64 title_id);
-
-  s32 OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid);
 
   using ContentTable = std::array<OpenedContent, 16>;
   ContentTable m_content_table;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -73,7 +73,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 87;  // Last changed in PR 5707
+static const u32 STATE_VERSION = 88;  // Last changed in PR 5733
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This commit merges the import and export contexts into a single context because this is what IOS does, which means we can only reproduce its behaviour correctly if we use a single context for both operations. Overall, ES HLE should behave a lot more like ES during title imports now.

The other reason is that having two separate and very similar structs for no reason is not really a good idea.

Validity checks are also more explicit now (just need to check for `context.valid` instead of relying on a detail).
 
While working on this commit, I was notified that our handling of ImportTmd/ExportTitleInit is not correct. In particular, we always use the title key for both importing and exporting, which is wrong. To make this easier to fix in a follow-up PR, the context now also has a title key field, just like ES. This also lets us avoid computing it every single time in ImportContentDone.