### PR TITLE
Split gettextize script into two

### DIFF
--- a/Languages/update-source-strings.sh
+++ b/Languages/update-source-strings.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-cd ${0/gettextize/}/..
+# This script updates the dolphin-emu.pot file to match the strings in
+# the source code.
+
+cd ${0/update-source-strings.sh/}/..
 SRCDIR=Source
 find $SRCDIR -name '*.cpp' -o -name '*.h' -o -name '*.c' | \
 	xgettext -d dolphin-emu -s --keyword=_ --keyword=wxTRANSLATE --keyword=SuccessAlertT \
@@ -11,11 +14,3 @@ find $SRCDIR -name '*.cpp' -o -name '*.h' -o -name '*.c' | \
 sed -i "s/SOME DESCRIPTIVE TITLE\./Translation of dolphin-emu.pot to LANGUAGE/" Languages/po/dolphin-emu.pot
 sed -i "s/YEAR THE PACKAGE'S COPYRIGHT HOLDER/2003-2013/" Languages/po/dolphin-emu.pot
 sed -i "s/license as the PACKAGE package/license as the dolphin-emu package/" Languages/po/dolphin-emu.pot
-
-# XXX: Disabled now that we use Transifex (the tool will handle this automatically).
-#POTFILE=./Languages/po/dolphin-emu.pot
-#PO_FILES=$(find ./Languages/po -name '*.po')
-#for PO in $PO_FILES
-#do
-#	msgmerge --quiet --update --backup=none -s $PO $POTFILE
-#done

--- a/Languages/update-translated-strings.sh
+++ b/Languages/update-translated-strings.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script goes through the translated .po files to ensure that they
+# match dolphin-emu.pot and are correctly formatted. You must run this
+# script before committing changes to the .po files, otherwise the .po
+# files might get modified the next time you try to build using cmake.
+
+POTFILE=./Languages/po/dolphin-emu.pot
+PO_FILES=$(find ./Languages/po -name '*.po')
+for PO in $PO_FILES
+do
+	msgmerge --quiet --update --backup=none -s $PO $POTFILE
+done

--- a/Languages/update-translated-strings.sh
+++ b/Languages/update-translated-strings.sh
@@ -6,8 +6,4 @@
 # files might get modified the next time you try to build using cmake.
 
 POTFILE=./Languages/po/dolphin-emu.pot
-PO_FILES=$(find ./Languages/po -name '*.po')
-for PO in $PO_FILES
-do
-	msgmerge --quiet --update --backup=none -s $PO $POTFILE
-done
+find ./Languages/po -name '*.po' -exec msgmerge --quiet --update --backup=none -s {} $POTFILE \;


### PR DESCRIPTION
When building DolphinWX using cmake, msgmerge will run on the .po files, updating the formatting of them if they aren't already in the exact format that msgmerge uses. This means that running msgmerge on all the .po files is necessary before committing any updates to the .po files, because otherwise unstaged changes are going to appear whenever anyone tries to build that commit using cmake. The translation syncing scripts that were used by delroth and Parlane did so by invoking `cmake` and then `make translations`, but that isn't a good solution for people who sync translations on Windows (i.e. me).

This commit uncomments some existing code for running msgmerge on all the .po files, and places that code in a new script. (Unlike what the comment above the code said, the Transifex tools do not take care of the problem automatically - they write .po files using slightly different formatting than msgmerge.) Now, translation syncing scripts just have to call that script before committing, instead of using msgmerge directly or using cmake.

I'm not sure why the script was called gettextize to begin with. gettextize is the name of a gettext executable that doesn't seem to be related to what our gettextize script did.