### PR TITLE
[needs 5758] Qt: replace EmulationStateChanged connections with Core callbacks

### DIFF
--- a/Source/Core/Common/Subscribable.h
+++ b/Source/Core/Common/Subscribable.h
@@ -1,0 +1,54 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+
+#include "Common/NonCopyable.h"
+
+template <typename... Args>
+class Subscribable : NonCopyable
+{
+public:
+  using SubscriptionID = uint32_t;
+
+  void Send(const Args&... args)
+  {
+    for (const auto& subscription : m_subscriptions)
+      subscription.func(args...);
+  }
+
+  SubscriptionID Subscribe(std::function<void(Args...)> func)
+  {
+    auto id = m_next_id++;
+    m_subscriptions.emplace_back(id, std::move(func));
+    return id;
+  }
+
+  void Unsubscribe(SubscriptionID id)
+  {
+    m_subscriptions.erase(
+        std::remove_if(m_subscriptions.begin(), m_subscriptions.end(),
+                       [&](const auto& subscription) { return subscription.id == id; }),
+        m_subscriptions.end());
+  }
+
+private:
+  struct Subscription
+  {
+    Subscription(SubscriptionID id_, std::function<void(Args...)> func_)
+        : id{id_}, func{std::move(func_)}
+    {
+    }
+    SubscriptionID id;
+    std::function<void(Args...)> func;
+  };
+
+  // XXX: will overflow after UINT32_MAX subscriptions
+  SubscriptionID m_next_id = 0;
+  std::vector<Subscription> m_subscriptions;
+};

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -697,6 +697,9 @@ State GetState()
     return State::Running;
   }
 
+  if (s_is_booting.IsSet())
+    return State::Starting;
+
   return State::Uninitialized;
 }
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Subscribable.h"
 
 struct BootParameters;
 
@@ -83,8 +84,7 @@ void UpdateTitle();
 bool PauseAndLock(bool doLock, bool unpauseOnUnlock = true);
 
 // for calling back into UI code without introducing a dependency on it in core
-using StoppedCallbackFunc = std::function<void()>;
-void SetOnStoppedCallback(StoppedCallbackFunc callback);
+extern Subscribable<State> g_on_state_changed;
 
 // Run on the Host thread when the factors change. [NOT THREADSAFE]
 void UpdateWantDeterminism(bool initial = false);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -31,7 +31,8 @@ enum class State
   Uninitialized,
   Paused,
   Running,
-  Stopping
+  Stopping,
+  Starting,
 };
 
 bool Init(std::unique_ptr<BootParameters> boot);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -103,4 +103,6 @@ void QueueHostJob(std::function<void()> job, bool run_during_stop = false);
 // WM_USER_JOB_DISPATCH will be sent when something is added to the queue.
 void HostDispatchJobs();
 
+void DoFrameStep();
+
 }  // namespace

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -58,7 +58,6 @@
 
 namespace Movie
 {
-static bool s_bFrameStep = false;
 static bool s_bReadOnly = true;
 static u32 s_rerecords = 0;
 static PlayMode s_playMode = MODE_NONE;
@@ -215,11 +214,6 @@ void FrameUpdate()
     s_totalFrames = s_currentFrame;
     s_totalLagCount = s_currentLagCount;
   }
-  if (s_bFrameStep)
-  {
-    s_bFrameStep = false;
-    CPU::Break();
-  }
 
   s_bPolled = false;
 }
@@ -238,7 +232,6 @@ void Init(const BootParameters& boot)
     s_current_file_name.clear();
 
   s_bPolled = false;
-  s_bFrameStep = false;
   s_bSaveConfig = false;
   s_iCPUCore = SConfig::GetInstance().iCPUCore;
   if (IsPlayingInput())
@@ -296,23 +289,6 @@ void InputUpdate()
 void SetPolledDevice()
 {
   s_bPolled = true;
-}
-
-// NOTE: Host Thread
-void DoFrameStep()
-{
-  if (Core::GetState() == Core::State::Paused)
-  {
-    // if already paused, frame advance for 1 frame
-    s_bFrameStep = true;
-    Core::RequestRefreshInfo();
-    Core::SetState(Core::State::Running);
-  }
-  else if (!s_bFrameStep)
-  {
-    // if not paused yet, pause immediately instead
-    Core::SetState(Core::State::Paused);
-  }
 }
 
 // NOTE: Host Thread

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -157,7 +157,6 @@ bool IsUsingBongo(int controller);
 void ChangePads(bool instantly = false);
 void ChangeWiiPads(bool instantly = false);
 
-void DoFrameStep();
 void SetReadOnly(bool bEnabled);
 
 bool BeginRecordingInput(int controllers);

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -411,7 +411,10 @@ int main(int argc, char* argv[])
   UICommon::SetUserDirectory(user_directory);
   UICommon::Init();
 
-  Core::SetOnStoppedCallback([]() { s_running.Clear(); });
+  Core::g_on_state_changed.Subscribe([](Core::State state) {
+    if (state == Core::State::Uninitialized)
+      s_running.Clear();
+  });
   platform->Init();
 
   // Shut down cleanly on SIGINT and SIGTERM

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
@@ -28,6 +29,7 @@
 #include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/NetPlayProto.h"
 #include "DolphinQt2/Config/Mapping/MappingWindow.h"
+#include "DolphinQt2/QtUtils/ConnectToSubscribable.h"
 #include "DolphinQt2/Settings.h"
 #include "UICommon/UICommon.h"
 
@@ -237,6 +239,10 @@ void ControllersWindow::CreateMainLayout()
 
 void ControllersWindow::ConnectWidgets()
 {
+  ConnectToSubscribable(Core::g_on_state_changed, this, [=](Core::State state) {
+    OnEmulationStateChanged(state != Core::State::Uninitialized);
+  });
+
   connect(m_wiimote_passthrough, &QRadioButton::toggled, this,
           &ControllersWindow::OnWiimoteModeChanged);
 

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.h
@@ -25,9 +25,9 @@ class ControllersWindow final : public QDialog
   Q_OBJECT
 public:
   explicit ControllersWindow(QWidget* parent);
-  void OnEmulationStateChanged(bool running);
 
 private:
+  void OnEmulationStateChanged(bool running);
   void OnWiimoteModeChanged(bool passthrough);
   void OnWiimoteTypeChanged(int state);
   void OnGCTypeChanged(int state);

--- a/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
@@ -11,9 +11,11 @@
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt2/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt2/Config/Graphics/GraphicsWindow.h"
+#include "DolphinQt2/QtUtils/ConnectToSubscribable.h"
 #include "VideoCommon/VideoConfig.h"
 
 AdvancedWidget::AdvancedWidget(GraphicsWindow* parent) : GraphicsWidget(parent)
@@ -24,8 +26,9 @@ AdvancedWidget::AdvancedWidget(GraphicsWindow* parent) : GraphicsWidget(parent)
   AddDescriptions();
 
   connect(parent, &GraphicsWindow::BackendChanged, this, &AdvancedWidget::OnBackendChanged);
-  connect(parent, &GraphicsWindow::EmulationStarted, [this] { OnEmulationStateChanged(true); });
-  connect(parent, &GraphicsWindow::EmulationStopped, [this] { OnEmulationStateChanged(false); });
+  ConnectToSubscribable(Core::g_on_state_changed, this, [=](Core::State state) {
+    OnEmulationStateChanged(state != Core::State::Uninitialized);
+  });
 
   OnBackendChanged();
 }

--- a/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.h
@@ -22,8 +22,8 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
   void AddDescriptions();
-  void OnBackendChanged();
   void OnEmulationStateChanged(bool running);
+  void OnBackendChanged();
 
   // Debugging
   QCheckBox* m_enable_wireframe;

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -15,9 +15,11 @@
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt2/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt2/Config/Graphics/GraphicsWindow.h"
+#include "DolphinQt2/QtUtils/ConnectToSubscribable.h"
 #include "UICommon/VideoUtils.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
@@ -32,8 +34,9 @@ GeneralWidget::GeneralWidget(X11Utils::XRRConfiguration* xrr_config, GraphicsWin
   emit BackendChanged(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend));
 
   connect(parent, &GraphicsWindow::BackendChanged, this, &GeneralWidget::OnBackendChanged);
-  connect(parent, &GraphicsWindow::EmulationStarted, [this] { OnEmulationStateChanged(true); });
-  connect(parent, &GraphicsWindow::EmulationStopped, [this] { OnEmulationStateChanged(false); });
+  ConnectToSubscribable(Core::g_on_state_changed, this, [=](Core::State state) {
+    OnEmulationStateChanged(state != Core::State::Uninitialized);
+  });
 }
 
 void GeneralWidget::CreateWidgets()

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -29,9 +29,6 @@ GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindo
   setWindowFlags(Qt::Window);
 
   OnBackendChanged(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend));
-
-  connect(parent, &MainWindow::EmulationStarted, this, &GraphicsWindow::EmulationStarted);
-  connect(parent, &MainWindow::EmulationStopped, this, &GraphicsWindow::EmulationStopped);
 }
 
 void GraphicsWindow::CreateMainLayout()

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
@@ -33,8 +33,6 @@ public:
   bool eventFilter(QObject* object, QEvent* event) override;
 signals:
   void BackendChanged(const QString& backend);
-  void EmulationStarted();
-  void EmulationStopped();
 
 private:
   void CreateMainLayout();

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -59,14 +59,7 @@ void SettingsWindow::SetupSettingsWidget()
   // Panes initalised here
   m_settings_outer->addWidget(new GeneralPane);
   m_settings_outer->addWidget(new InterfacePane);
-
-  auto* audio_pane = new AudioPane;
-  connect(this, &SettingsWindow::EmulationStarted,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(true); });
-  connect(this, &SettingsWindow::EmulationStopped,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(false); });
-  m_settings_outer->addWidget(audio_pane);
-
+  m_settings_outer->addWidget(new AudioPane);
   m_settings_outer->addWidget(new PathPane);
 }
 

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -19,9 +19,6 @@ class SettingsWindow final : public QDialog
   Q_OBJECT
 public:
   explicit SettingsWindow(QWidget* parent = nullptr);
-signals:
-  void EmulationStarted();
-  void EmulationStopped();
 
 public slots:
   void changePage(QListWidgetItem* current, QListWidgetItem* previous);

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -380,7 +380,7 @@ void MainWindow::Reset()
 
 void MainWindow::FrameAdvance()
 {
-  Movie::DoFrameStep();
+  Core::DoFrameStep();
   EmulationPaused();
 }
 

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -107,7 +107,10 @@ void MainWindow::ShutdownControllers()
 
 void MainWindow::InitCoreCallbacks()
 {
-  Core::SetOnStoppedCallback([this] { emit EmulationStopped(); });
+  Core::g_on_state_changed.Subscribe([=](Core::State state) {
+    if (state == Core::State::Uninitialized)
+      emit EmulationStopped();
+  });
   installEventFilter(this);
   m_render_widget->installEventFilter(this);
 }

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -31,11 +31,6 @@ public:
 
   bool eventFilter(QObject* object, QEvent* event) override;
 
-signals:
-  void EmulationStarted();
-  void EmulationPaused();
-  void EmulationStopped();
-
 private slots:
   void Open();
   void Play();

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -11,12 +11,14 @@
 
 #include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/IOS.h"
 #include "Core/State.h"
 #include "DolphinQt2/AboutDialog.h"
 #include "DolphinQt2/GameList/GameFile.h"
 #include "DolphinQt2/MenuBar.h"
+#include "DolphinQt2/QtUtils/ConnectToSubscribable.h"
 #include "DolphinQt2/Settings.h"
 
 MenuBar::MenuBar(QWidget* parent) : QMenuBar(parent)
@@ -29,49 +31,30 @@ MenuBar::MenuBar(QWidget* parent) : QMenuBar(parent)
   AddViewMenu();
   AddHelpMenu();
 
-  EmulationStopped();
+  ConnectToSubscribable(Core::g_on_state_changed, this,
+                        [=](Core::State state) { OnEmulationStateChanged(state); });
+  OnEmulationStateChanged(Core::GetState());
 }
 
-void MenuBar::EmulationStarted()
+void MenuBar::OnEmulationStateChanged(Core::State state)
 {
-  // Emulation
-  m_play_action->setEnabled(false);
-  m_play_action->setVisible(false);
-  m_pause_action->setEnabled(true);
-  m_pause_action->setVisible(true);
-  m_stop_action->setEnabled(true);
-  m_reset_action->setEnabled(true);
-  m_fullscreen_action->setEnabled(true);
-  m_frame_advance_action->setEnabled(true);
-  m_screenshot_action->setEnabled(true);
-  m_state_load_menu->setEnabled(true);
-  m_state_save_menu->setEnabled(true);
+  bool running = state != Core::State::Uninitialized;
+  m_stop_action->setEnabled(running);
+  m_stop_action->setVisible(running);
+  m_reset_action->setEnabled(running);
+  m_fullscreen_action->setEnabled(running);
+  m_frame_advance_action->setEnabled(running);
+  m_screenshot_action->setEnabled(running);
+  m_state_load_menu->setEnabled(running);
+  m_state_save_menu->setEnabled(running);
   UpdateStateSlotMenu();
-  UpdateToolsMenu(true);
-}
-void MenuBar::EmulationPaused()
-{
-  m_play_action->setEnabled(true);
-  m_play_action->setVisible(true);
-  m_pause_action->setEnabled(false);
-  m_pause_action->setVisible(false);
-}
-void MenuBar::EmulationStopped()
-{
-  // Emulation
-  m_play_action->setEnabled(true);
-  m_play_action->setVisible(true);
-  m_pause_action->setEnabled(false);
-  m_pause_action->setVisible(false);
-  m_stop_action->setEnabled(false);
-  m_reset_action->setEnabled(false);
-  m_fullscreen_action->setEnabled(false);
-  m_frame_advance_action->setEnabled(false);
-  m_screenshot_action->setEnabled(false);
-  m_state_load_menu->setEnabled(false);
-  m_state_save_menu->setEnabled(false);
-  UpdateStateSlotMenu();
-  UpdateToolsMenu(false);
+  UpdateToolsMenu(running);
+
+  bool playing = running && state != Core::State::Paused;
+  m_play_action->setEnabled(!playing);
+  m_play_action->setVisible(!playing);
+  m_pause_action->setEnabled(playing);
+  m_pause_action->setVisible(playing);
 }
 
 void MenuBar::AddFileMenu()

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -9,6 +9,11 @@
 #include <QMenu>
 #include <QMenuBar>
 
+namespace Core
+{
+enum class State;
+}
+
 class MenuBar final : public QMenuBar
 {
   Q_OBJECT
@@ -53,9 +58,6 @@ signals:
   void ShowAboutDialog();
 
 public slots:
-  void EmulationStarted();
-  void EmulationPaused();
-  void EmulationStopped();
   void UpdateStateSlotMenu();
   void UpdateToolsMenu(bool emulation_started);
 
@@ -63,6 +65,8 @@ public slots:
   void InstallWAD();
 
 private:
+  void OnEmulationStateChanged(Core::State state);
+
   void AddFileMenu();
 
   void AddEmulationMenu();

--- a/Source/Core/DolphinQt2/QtUtils/ConnectToSubscribable.h
+++ b/Source/Core/DolphinQt2/QtUtils/ConnectToSubscribable.h
@@ -1,0 +1,22 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QObject>
+#include <utility>
+
+#include "Common/Subscribable.h"
+#include "DolphinQt2/QtUtils/QueueOnObject.h"
+
+// Bridge between Subscribables and Qt objects.
+
+template <typename F, typename... Args>
+void ConnectToSubscribable(Subscribable<Args...>& subscribable, QObject* obj, F&& func)
+{
+  auto id = subscribable.Subscribe([ obj, func = std::forward<F>(func) ](Args && ... args) {
+    QueueOnObject(obj, [func, args...] { func(args...); });
+  });
+  QObject::connect(obj, &QObject::destroyed, [id, &subscribable] { subscribable.Unsubscribe(id); });
+}

--- a/Source/Core/DolphinQt2/QtUtils/QueueOnObject.h
+++ b/Source/Core/DolphinQt2/QtUtils/QueueOnObject.h
@@ -1,0 +1,20 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QObject>
+#include <utility>
+
+// QWidget and subclasses are not thread-safe! However, Qt's signal-slot connection mechanism will
+// invoke slots/functions on the correct thread for any object. We can (ab)use this to queue up
+// arbitrary code from non-GUI threads. For more information, see:
+// https://stackoverflow.com/questions/21646467/
+
+template <typename F>
+static void QueueOnObject(QObject* obj, F&& func)
+{
+  QObject src;
+  QObject::connect(&src, &QObject::destroyed, obj, std::forward<F>(func), Qt::QueuedConnection);
+}

--- a/Source/Core/DolphinQt2/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/AudioPane.cpp
@@ -18,7 +18,9 @@
 
 #include "AudioCommon/AudioCommon.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/Config/SettingsWindow.h"
+#include "DolphinQt2/QtUtils/ConnectToSubscribable.h"
 #include "DolphinQt2/Settings.h"
 
 AudioPane::AudioPane()
@@ -28,6 +30,9 @@ AudioPane::AudioPane()
   ConnectWidgets();
 
   connect(&Settings::Instance(), &Settings::VolumeChanged, this, &AudioPane::OnVolumeChanged);
+  ConnectToSubscribable(Core::g_on_state_changed, this, [=](Core::State state) {
+    OnEmulationStateChanged(state != Core::State::Uninitialized);
+  });
 }
 
 void AudioPane::CreateWidgets()

--- a/Source/Core/DolphinQt2/Settings/AudioPane.h
+++ b/Source/Core/DolphinQt2/Settings/AudioPane.h
@@ -21,8 +21,6 @@ class AudioPane final : public QWidget
 public:
   explicit AudioPane();
 
-  void OnEmulationStateChanged(bool running);
-
 private:
   void CreateWidgets();
   void ConnectWidgets();
@@ -30,6 +28,7 @@ private:
   void LoadSettings();
   void SaveSettings();
 
+  void OnEmulationStateChanged(bool running);
   void OnBackendChanged();
   void OnVolumeChanged(int volume);
 

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -4,6 +4,8 @@
 
 #include <QIcon>
 
+#include "Core/Core.h"
+#include "DolphinQt2/QtUtils/ConnectToSubscribable.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/ToolBar.h"
@@ -21,40 +23,24 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &ToolBar::UpdateIcons);
   UpdateIcons();
 
-  EmulationStopped();
+  ConnectToSubscribable(Core::g_on_state_changed, this,
+                        [this](Core::State state) { OnEmulationStateChanged(state); });
+  OnEmulationStateChanged(Core::GetState());
 }
 
-void ToolBar::EmulationStarted()
+void ToolBar::OnEmulationStateChanged(Core::State state)
 {
-  m_play_action->setEnabled(false);
-  m_play_action->setVisible(false);
-  m_pause_action->setEnabled(true);
-  m_pause_action->setVisible(true);
-  m_stop_action->setEnabled(true);
-  m_stop_action->setVisible(true);
-  m_fullscreen_action->setEnabled(true);
-  m_screenshot_action->setEnabled(true);
-}
+  bool running = state != Core::State::Uninitialized;
+  m_stop_action->setEnabled(running);
+  m_stop_action->setVisible(running);
+  m_fullscreen_action->setEnabled(running);
+  m_screenshot_action->setEnabled(running);
 
-void ToolBar::EmulationPaused()
-{
-  m_play_action->setEnabled(true);
-  m_play_action->setVisible(true);
-  m_pause_action->setEnabled(false);
-  m_pause_action->setVisible(false);
-  m_stop_action->setEnabled(true);
-  m_stop_action->setVisible(true);
-}
-
-void ToolBar::EmulationStopped()
-{
-  m_play_action->setEnabled(true);
-  m_play_action->setVisible(true);
-  m_pause_action->setEnabled(false);
-  m_pause_action->setVisible(false);
-  m_stop_action->setEnabled(false);
-  m_fullscreen_action->setEnabled(false);
-  m_screenshot_action->setEnabled(false);
+  bool playing = running && state != Core::State::Paused;
+  m_play_action->setEnabled(!playing);
+  m_play_action->setVisible(!playing);
+  m_pause_action->setEnabled(playing);
+  m_pause_action->setVisible(playing);
 }
 
 void ToolBar::MakeActions()

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -8,17 +8,17 @@
 #include <QLineEdit>
 #include <QToolBar>
 
+namespace Core
+{
+enum class State;
+}
+
 class ToolBar final : public QToolBar
 {
   Q_OBJECT
 
 public:
   explicit ToolBar(QWidget* parent = nullptr);
-
-public slots:
-  void EmulationStarted();
-  void EmulationPaused();
-  void EmulationStopped();
 
 signals:
   void OpenPressed();
@@ -33,6 +33,8 @@ signals:
   void GraphicsPressed();
 
 private:
+  void OnEmulationStateChanged(Core::State state);
+
   void MakeActions();
   void UpdateIcons();
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -523,8 +523,9 @@ void CFrame::InitializeCoreCallbacks()
   });
 
   // Warning: this gets called from the EmuThread
-  Core::SetOnStoppedCallback([this] {
-    AddPendingEvent(wxCommandEvent{wxEVT_HOST_COMMAND, IDM_STOPPED});
+  Core::g_on_state_changed.Subscribe([this](Core::State state) {
+    if (state == Core::State::Uninitialized)
+      AddPendingEvent(wxCommandEvent{wxEVT_HOST_COMMAND, IDM_STOPPED});
   });
 }
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -445,7 +445,7 @@ void CFrame::OnFrameStep(wxCommandEvent& event)
 {
   bool wasPaused = Core::GetState() == Core::State::Paused;
 
-  Movie::DoFrameStep();
+  Core::DoFrameStep();
 
   bool isPaused = Core::GetState() == Core::State::Paused;
   if (isPaused && !wasPaused)  // don't update on unpause, otherwise the status would be wrong when


### PR DESCRIPTION
Removes the soup of `connect(parent, &Parent::EmulationStarted, child, &Child::EmulationStarted)` that was needed to pass signals through multiple levels of widgets. Blegh.

Other changes:
- Adds a `QueueOnObject` function in QtUtils, to run code on the correct thread for a QWidget.
- Adds a `ConnectToSubscribable` function in QtUtils, to hook up callbacks that will be automatically unsubscribed when a widget is destroyed (turns out you can't connect to an already-destroyed widget without crashing).