### PR TITLE
IOS/ES: Use the correct import/export key (fix DLC)

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -13,6 +13,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/IOS.h"
+#include "Core/IOS/IOSC.h"
 
 class PointerWrap;
 
@@ -61,7 +62,7 @@ public:
 
     bool valid = false;
     IOS::ES::TMDReader tmd;
-    std::array<u8, 16> key{};
+    IOSC::Handle key_handle = 0;
     struct ContentContext
     {
       bool valid = false;

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -49,6 +49,8 @@ enum TitleFlags : u32
   TITLE_TYPE_0x4 = 0x4,
   // Used for DLC titles.
   TITLE_TYPE_DATA = 0x8,
+  // Unknown.
+  TITLE_TYPE_0x10 = 0x10,
   // Appears to be used for WFS titles.
   TITLE_TYPE_WFS_MAYBE = 0x20,
   // Unknown.

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -430,8 +430,9 @@ void IOSC::LoadDefaultEntries(ConsoleType console_type)
     break;
   }
 
-  // Unimplemented.
-  m_key_entries[HANDLE_PRNG_KEY] = {TYPE_SECRET_KEY, SUBTYPE_AES128, std::vector<u8>(16), 3};
+  m_key_entries[HANDLE_PRNG_KEY] = {
+      TYPE_SECRET_KEY, SUBTYPE_AES128,
+      std::vector<u8>(ec.GetBackupKey(), ec.GetBackupKey() + AES128_KEY_SIZE), 3};
 
   m_key_entries[HANDLE_SD_KEY] = {TYPE_SECRET_KEY,
                                   SUBTYPE_AES128,

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -85,11 +85,19 @@ constexpr size_t AES128_KEY_SIZE = 0x10;
 ReturnCode IOSC::ImportSecretKey(Handle dest_handle, Handle decrypt_handle, u8* iv,
                                  const u8* encrypted_key, u32 pid)
 {
-  if (!HasOwnership(dest_handle, pid) || !HasOwnership(decrypt_handle, pid) ||
-      IsDefaultHandle(dest_handle))
-  {
+  std::array<u8, AES128_KEY_SIZE> decrypted_key;
+  const ReturnCode ret =
+      Decrypt(decrypt_handle, iv, encrypted_key, AES128_KEY_SIZE, decrypted_key.data(), pid);
+  if (ret != IPC_SUCCESS)
+    return ret;
+
+  return ImportSecretKey(dest_handle, decrypted_key.data(), pid);
+}
+
+ReturnCode IOSC::ImportSecretKey(Handle dest_handle, const u8* decrypted_key, u32 pid)
+{
+  if (!HasOwnership(dest_handle, pid) || IsDefaultHandle(dest_handle))
     return IOSC_EACCES;
-  }
 
   KeyEntry* dest_entry = FindEntry(dest_handle);
   if (!dest_entry)
@@ -99,8 +107,8 @@ ReturnCode IOSC::ImportSecretKey(Handle dest_handle, Handle decrypt_handle, u8* 
   if (dest_entry->type != TYPE_SECRET_KEY || dest_entry->subtype != SUBTYPE_AES128)
     return IOSC_INVALID_OBJTYPE;
 
-  dest_entry->data.resize(AES128_KEY_SIZE);
-  return Decrypt(decrypt_handle, iv, encrypted_key, AES128_KEY_SIZE, dest_entry->data.data(), pid);
+  dest_entry->data = std::vector<u8>(decrypted_key, decrypted_key + AES128_KEY_SIZE);
+  return IPC_SUCCESS;
 }
 
 ReturnCode IOSC::ImportPublicKey(Handle dest_handle, const u8* public_key,

--- a/Source/Core/Core/IOS/IOSC.h
+++ b/Source/Core/Core/IOS/IOSC.h
@@ -172,6 +172,8 @@ public:
   // Import a secret, encrypted key into dest_handle, which will be decrypted using decrypt_handle.
   ReturnCode ImportSecretKey(Handle dest_handle, Handle decrypt_handle, u8* iv,
                              const u8* encrypted_key, u32 pid);
+  // Import a secret key that is already decrypted.
+  ReturnCode ImportSecretKey(Handle dest_handle, const u8* decrypted_key, u32 pid);
   // Import a public key. public_key_exponent must be passed for RSA keys.
   ReturnCode ImportPublicKey(Handle dest_handle, const u8* public_key,
                              const u8* public_key_exponent, u32 pid);

--- a/Source/Core/Core/ec_wii.cpp
+++ b/Source/Core/Core/ec_wii.cpp
@@ -181,6 +181,11 @@ const u8* EcWii::GetNGSig() const
   return BootMiiKeysBin.ng_sig;
 }
 
+const u8* EcWii::GetBackupKey() const
+{
+  return BootMiiKeysBin.backup_key;
+}
+
 void EcWii::InitDefaults()
 {
   memset(&BootMiiKeysBin, 0, sizeof(BootMiiKeysBin));

--- a/Source/Core/Core/ec_wii.h
+++ b/Source/Core/Core/ec_wii.h
@@ -42,6 +42,7 @@ public:
   u32 GetNGKeyID() const;
   const u8* GetNGPriv() const;
   const u8* GetNGSig() const;
+  const u8* GetBackupKey() const;
 
 private:
   void InitDefaults();
@@ -82,7 +83,7 @@ private:
       };
     };
     u8 nand_key[0x10];    // 0x158
-    u8 rng_key[0x10];     // 0x168
+    u8 backup_key[0x10];  // 0x168
     u32 unk1;             // 0x178
     u32 unk2;             // 0x17C
     u8 eeprom_pad[0x80];  // 0x180


### PR DESCRIPTION
Imports/exports don't always use the title key. Exporting a title and importing it back uses the PRNG key (aka backup key handle or key #5), not the title key (at all).

To make things even more fun, some versions of IOS have a bug that causes it to use a zeroed key instead of the PRNG key. When Nintendo decided to fix it, they added checks to keep using the zeroed key only in affected titles to avoid making existing exports useless. (Thanks to tueidj for drawing my attention to this. I missed this edge case during the initial implementation.)

This commit implements these checks so we are using the correct key in all of these cases.

We now also use IOSC for decryption/encryption since built-in key handles are used. And we now reject any invalid common key index, just like ES.
