### PR TITLE
Qt: Remove border from game list

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -7,6 +7,7 @@
 #include <QErrorMessage>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QFrame>
 #include <QHeaderView>
 #include <QKeyEvent>
 #include <QMap>
@@ -94,6 +95,7 @@ void GameList::MakeTableView()
   hor_header->setSectionResizeMode(GameListModel::COL_RATING, QHeaderView::ResizeToContents);
 
   m_table->verticalHeader()->hide();
+  m_table->setFrameStyle(QFrame::NoFrame);
 }
 
 void GameList::MakeEmptyView()
@@ -121,6 +123,7 @@ void GameList::MakeListView()
   m_list->setResizeMode(QListView::Adjust);
   m_list->setUniformItemSizes(true);
   m_list->setContextMenuPolicy(Qt::CustomContextMenu);
+  m_list->setFrameStyle(QFrame::NoFrame);
   connect(m_list, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
 }
 


### PR DESCRIPTION
The difference is very small but it is very annoying IMO

Before (look at the border between the play button and the banner header):
![image](https://user-images.githubusercontent.com/4411333/27774134-71aadb90-5f48-11e7-9b89-245725abf4e6.png)

After:
![image](https://user-images.githubusercontent.com/4411333/27774136-780a5dee-5f48-11e7-9ff6-1ddb238d9fc0.png)

@ligfx​/​@spycrab How does this look on macOS/linux?