### PR TITLE
Remove non-integer IRs

### DIFF
--- a/Data/Sys/GameSettings/DD2.ini
+++ b/Data/Sys/GameSettings/DD2.ini
@@ -18,7 +18,6 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/G8M.ini
+++ b/Data/Sys/GameSettings/G8M.ini
@@ -21,8 +21,5 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 EFBToTextureEnable = False
 BBoxEnable = True
 
-[Video_Settings]
-EFBScale = -1
-
 [Video_Stereoscopy]
 StereoConvergence = 545

--- a/Data/Sys/GameSettings/G9S.ini
+++ b/Data/Sys/GameSettings/G9S.ini
@@ -19,6 +19,6 @@ EmulationIssues = Use directx11 backend with efb scale set at 1x to deal with bl
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
-EFBScale = 2
+InternalResolution = 1
 MSAA = 0
 MaxAnisotropy = 0

--- a/Data/Sys/GameSettings/G9S.ini
+++ b/Data/Sys/GameSettings/G9S.ini
@@ -19,6 +19,6 @@ EmulationIssues = Use directx11 backend with efb scale set at 1x to deal with bl
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
-InternalResolution = 1
+EFBScale = 2
 MSAA = 0
 MaxAnisotropy = 0

--- a/Data/Sys/GameSettings/GAL.ini
+++ b/Data/Sys/GameSettings/GAL.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-EFBScale = -1
-
 [Video_Stereoscopy]
 StereoConvergence = 64

--- a/Data/Sys/GameSettings/GC6.ini
+++ b/Data/Sys/GameSettings/GC6.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = If EFB scale is not integral, serious texture glitches occur.
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,7 +18,4 @@ EmulationIssues = If EFB scale is not integral, serious texture glitches occur.
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
-
 SafeTextureCacheColorSamples = 0
-

--- a/Data/Sys/GameSettings/GEO.ini
+++ b/Data/Sys/GameSettings/GEO.ini
@@ -21,4 +21,3 @@ EmulationIssues =
 UseXFB = True
 UseRealXFB = False
 SafeTextureCacheColorSamples = 512
-EFBScale = -1

--- a/Data/Sys/GameSettings/GF7.ini
+++ b/Data/Sys/GameSettings/GF7.ini
@@ -7,7 +7,7 @@ FPRF = True
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = EFB must be an integer (integral, 1x, 2x, 3x).
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,8 +19,6 @@ EmulationIssues = EFB must be an integer (integral, 1x, 2x, 3x).
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
-
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]

--- a/Data/Sys/GameSettings/GWO.ini
+++ b/Data/Sys/GameSettings/GWO.ini
@@ -16,7 +16,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-EFBScale = -1
-

--- a/Data/Sys/GameSettings/GXX.ini
+++ b/Data/Sys/GameSettings/GXX.ini
@@ -7,7 +7,7 @@ SyncGPU = True
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = HLE music fades in and out. If EFB scale is not integral, 1x, 2x or 3x serious texture glitches occur
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,5 +19,4 @@ EmulationIssues = HLE music fades in and out. If EFB scale is not integral, 1x, 
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/GZW.ini
+++ b/Data/Sys/GameSettings/GZW.ini
@@ -19,7 +19,6 @@ EmulationIssues =
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-EFBScale = -1
 
 [Video_Enhancements]
 ForceFiltering = False

--- a/Data/Sys/GameSettings/RFF.ini
+++ b/Data/Sys/GameSettings/RFF.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs integral scaling for the black lines to disappear.
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,6 +18,4 @@ EmulationIssues = Needs integral scaling for the black lines to disappear.
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512
-

--- a/Data/Sys/GameSettings/RPO.ini
+++ b/Data/Sys/GameSettings/RPO.ini
@@ -18,5 +18,4 @@ EmulationIssues = Jerky videos need safe cache.
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RSF.ini
+++ b/Data/Sys/GameSettings/RSF.ini
@@ -16,7 +16,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-EFBScale = -1
-

--- a/Data/Sys/GameSettings/S2E.ini
+++ b/Data/Sys/GameSettings/S2E.ini
@@ -17,9 +17,6 @@ EmulationIssues = USB Microphone not emulated
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-EFBScale = -1
-
 [Video_Enhancements]
 MaxAnisotropy = 0
 ForceFiltering = False

--- a/Data/Sys/GameSettings/S72.ini
+++ b/Data/Sys/GameSettings/S72.ini
@@ -21,7 +21,6 @@ EmulationIssues =
 UseXFB = True
 UseRealXFB = False
 SafeTextureCacheColorSamples = 0
-EFBScale = -1
 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/S75.ini
+++ b/Data/Sys/GameSettings/S75.ini
@@ -5,8 +5,8 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Skip any errors at startup and use integral efb scale.
 EmulationStateId = 4
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,6 +18,4 @@ EmulationStateId = 4
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512
-

--- a/Data/Sys/GameSettings/SD2.ini
+++ b/Data/Sys/GameSettings/SD2.ini
@@ -18,7 +18,6 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/SD2J01.ini
+++ b/Data/Sys/GameSettings/SD2J01.ini
@@ -21,7 +21,6 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/SDN.ini
+++ b/Data/Sys/GameSettings/SDN.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-EFBScale = -1
-
 [Video_Enhancements]
 MaxAnisotropy = 0
 ForceFiltering = False

--- a/Data/Sys/GameSettings/SEM.ini
+++ b/Data/Sys/GameSettings/SEM.ini
@@ -18,7 +18,6 @@ EmulationIssues = Enable progressive scan if the game has boot issues.
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 0
 
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/SER.ini
+++ b/Data/Sys/GameSettings/SER.ini
@@ -18,6 +18,5 @@ EmulationIssues = Enable progressive scan if the game has boot issues.
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/SJD.ini
+++ b/Data/Sys/GameSettings/SJD.ini
@@ -18,7 +18,6 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/SJDJ01.ini
+++ b/Data/Sys/GameSettings/SJDJ01.ini
@@ -21,7 +21,6 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-EFBScale = -1
 SafeTextureCacheColorSamples = 512
 
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/SJX.ini
+++ b/Data/Sys/GameSettings/SJX.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-EFBScale = -1
-
 [Video_Enhancements]
 MaxAnisotropy = 0
 ForceFiltering = False

--- a/Data/Sys/GameSettings/SMO.ini
+++ b/Data/Sys/GameSettings/SMO.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-EFBScale = -1
-
 [Video_Enhancements]
 MaxAnisotropy = 0
 ForceFiltering = False

--- a/Data/Sys/GameSettings/SNC.ini
+++ b/Data/Sys/GameSettings/SNC.ini
@@ -17,9 +17,6 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-EFBScale = -1
-
 [Video_Hacks]
 EFBAccessEnable = False
 

--- a/Data/Sys/GameSettings/WR9.ini
+++ b/Data/Sys/GameSettings/WR9.ini
@@ -20,7 +20,5 @@ EmulationIssues =
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False
-EFBScale = -1
-
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/WRX.ini
+++ b/Data/Sys/GameSettings/WRX.ini
@@ -20,7 +20,4 @@ EmulationIssues =
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False
-
 SafeTextureCacheColorSamples = 512
-EFBScale = -1
-

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -56,7 +56,7 @@ public final class SettingsFile
 	public static final String KEY_AUDIO_STRETCH = "AudioStretch";
 
 	public static final String KEY_SHOW_FPS = "ShowFPS";
-	public static final String KEY_INTERNAL_RES = "InternalResolution";
+	public static final String KEY_INTERNAL_RES = "EFBScale";
 	public static final String KEY_FSAA = "MSAA";
 	public static final String KEY_ANISOTROPY = "MaxAnisotropy";
 	public static final String KEY_POST_SHADER = "PostProcessingShader";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -56,7 +56,7 @@ public final class SettingsFile
 	public static final String KEY_AUDIO_STRETCH = "AudioStretch";
 
 	public static final String KEY_SHOW_FPS = "ShowFPS";
-	public static final String KEY_INTERNAL_RES = "EFBScale";
+	public static final String KEY_INTERNAL_RES = "InternalResolution";
 	public static final String KEY_FSAA = "MSAA";
 	public static final String KEY_ANISOTROPY = "MaxAnisotropy";
 	public static final String KEY_POST_SHADER = "PostProcessingShader";

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -104,23 +104,19 @@
     <!-- Internal Resolution Preference -->
     <string-array name="internalResolutionEntries" translatable="false">
         <item>1x Native (640x528)</item>
-        <item>1.5x Native (960x792)</item>
         <item>2x Native (1280x1056) for 720p</item>
-        <item>2.5x Native (1600x1320)</item>
         <item>3x Native (1920x1584) for 1080p</item>
         <item>4x Native (2560x2112)</item>
         <item>5x Native (3200x2640)</item>
         <item>6x Native (3840x3168) for 4K</item>
     </string-array>
     <integer-array name="internalResolutionValues" translatable="false">
+        <item>1</item>
         <item>2</item>
         <item>3</item>
         <item>4</item>
         <item>5</item>
         <item>6</item>
-        <item>7</item>
-        <item>8</item>
-        <item>9</item>
     </integer-array>
 
     <!-- FSAA Preference -->

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -111,12 +111,12 @@
         <item>6x Native (3840x3168) for 4K</item>
     </string-array>
     <integer-array name="internalResolutionValues" translatable="false">
-        <item>1</item>
         <item>2</item>
-        <item>3</item>
         <item>4</item>
-        <item>5</item>
         <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
     </integer-array>
 
     <!-- FSAA Preference -->

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -224,10 +224,10 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-vsync", g_Config.bVSync);
   builder.AddData("cfg-gfx-aspect-ratio", g_Config.iAspectRatio);
   builder.AddData("cfg-gfx-efb-access", g_Config.bEFBAccessEnable);
+  builder.AddData("cfg-gfx-efb-scale", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-efb-copy-format-changes", g_Config.bEFBEmulateFormatChanges);
   builder.AddData("cfg-gfx-efb-copy-ram", !g_Config.bSkipEFBCopyToRam);
   builder.AddData("cfg-gfx-efb-copy-scaled", g_Config.bCopyEFBScaled);
-  builder.AddData("cfg-gfx-internal-resolution", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-tc-samples", g_Config.iSafeTextureCache_ColorSamples);
   builder.AddData("cfg-gfx-stereo-mode", g_Config.iStereoMode);
   builder.AddData("cfg-gfx-per-pixel-lighting", g_Config.bEnablePixelLighting);

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -224,10 +224,10 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-vsync", g_Config.bVSync);
   builder.AddData("cfg-gfx-aspect-ratio", g_Config.iAspectRatio);
   builder.AddData("cfg-gfx-efb-access", g_Config.bEFBAccessEnable);
-  builder.AddData("cfg-gfx-efb-scale", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-efb-copy-format-changes", g_Config.bEFBEmulateFormatChanges);
   builder.AddData("cfg-gfx-efb-copy-ram", !g_Config.bSkipEFBCopyToRam);
   builder.AddData("cfg-gfx-efb-copy-scaled", g_Config.bCopyEFBScaled);
+  builder.AddData("cfg-gfx-internal-resolution", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-tc-samples", g_Config.iSafeTextureCache_ColorSamples);
   builder.AddData("cfg-gfx-stereo-mode", g_Config.iStereoMode);
   builder.AddData("cfg-gfx-per-pixel-lighting", g_Config.bEnablePixelLighting);

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -4,13 +4,48 @@
 
 #include "Core/Config/GraphicsSettings.h"
 
+#include <optional>
 #include <string>
 
 #include "Common/Config/Config.h"
+#include "Common/StringUtil.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace Config
 {
+std::optional<int> ConvertFromLegacyEFBScale(int efb_scale)
+{
+  // In game INIs, -1 was used as a special value meaning
+  // "use the value from the base layer but round it to an integer scale".
+  // We only support integer scales nowadays, so we can simply ignore -1
+  // in game INIs in order to automatically use a previous layer's value.
+  if (efb_scale < 0)
+    return {};
+
+  return efb_scale - (efb_scale > 0) - (efb_scale > 2) - (efb_scale > 4);
+}
+
+std::optional<int> ConvertFromLegacyEFBScale(const std::string& efb_scale)
+{
+  int efb_scale_int;
+  if (!TryParse(efb_scale, &efb_scale_int))
+    return {};
+  return ConvertFromLegacyEFBScale(efb_scale_int);
+}
+
+int ConvertToLegacyEFBScale(int efb_scale)
+{
+  return efb_scale + (efb_scale >= 0) + (efb_scale > 1) + (efb_scale > 2);
+}
+
+std::optional<int> ConvertToLegacyEFBScale(const std::string& efb_scale)
+{
+  int efb_scale_int;
+  if (!TryParse(efb_scale, &efb_scale_int))
+    return {};
+  return ConvertToLegacyEFBScale(efb_scale_int);
+}
+
 // Configuration Information
 
 // Graphics.Hardware
@@ -60,7 +95,7 @@ const ConfigInfo<bool> GFX_ENABLE_PIXEL_LIGHTING{{System::GFX, "Settings", "Enab
 const ConfigInfo<bool> GFX_FAST_DEPTH_CALC{{System::GFX, "Settings", "FastDepthCalc"}, true};
 const ConfigInfo<u32> GFX_MSAA{{System::GFX, "Settings", "MSAA"}, 1};
 const ConfigInfo<bool> GFX_SSAA{{System::GFX, "Settings", "SSAA"}, false};
-const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "InternalResolution"}, 1};
+const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "EFBScale"}, 1};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_ENABLE{{System::GFX, "Settings", "TexFmtOverlayEnable"},
                                                  false};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER{{System::GFX, "Settings", "TexFmtOverlayCenter"},

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -60,8 +60,7 @@ const ConfigInfo<bool> GFX_ENABLE_PIXEL_LIGHTING{{System::GFX, "Settings", "Enab
 const ConfigInfo<bool> GFX_FAST_DEPTH_CALC{{System::GFX, "Settings", "FastDepthCalc"}, true};
 const ConfigInfo<u32> GFX_MSAA{{System::GFX, "Settings", "MSAA"}, 1};
 const ConfigInfo<bool> GFX_SSAA{{System::GFX, "Settings", "SSAA"}, false};
-const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "EFBScale"},
-                                    static_cast<int>(SCALE_1X)};
+const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "InternalResolution"}, 1};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_ENABLE{{System::GFX, "Settings", "TexFmtOverlayEnable"},
                                                  false};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER{{System::GFX, "Settings", "TexFmtOverlayCenter"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -4,12 +4,18 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "Common/Config/Config.h"
 
 namespace Config
 {
+std::optional<int> ConvertFromLegacyEFBScale(int efb_scale);
+std::optional<int> ConvertFromLegacyEFBScale(const std::string& efb_scale);
+int ConvertToLegacyEFBScale(int efb_scale);
+std::optional<int> ConvertToLegacyEFBScale(const std::string& efb_scale);
+
 // Configuration Information
 
 // Graphics.Hardware

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -84,7 +84,7 @@ static const INIToLocationMap& GetINIToLocationMap()
       {{"Video_Settings", "MSAA"}, {Config::GFX_MSAA.location}},
       {{"Video_Settings", "SSAA"}, {Config::GFX_SSAA.location}},
       {{"Video_Settings", "ForceTrueColor"}, {Config::GFX_ENHANCE_FORCE_TRUE_COLOR.location}},
-      {{"Video_Settings", "EFBScale"}, {Config::GFX_EFB_SCALE.location}},
+      {{"Video_Settings", "InternalResolution"}, {Config::GFX_EFB_SCALE.location}},
       {{"Video_Settings", "DisableFog"}, {Config::GFX_DISABLE_FOG.location}},
       {{"Video_Settings", "BackendMultithreading"}, {Config::GFX_BACKEND_MULTITHREADING.location}},
       {{"Video_Settings", "CommandBufferExecuteInterval"},

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -43,16 +43,15 @@ void EnhancementsWidget::CreateWidgets()
   auto* enhancements_layout = new QGridLayout();
   enhancements_box->setLayout(enhancements_layout);
 
-  m_ir_combo = new GraphicsChoice(
-      {tr("Auto (Window Size)"), tr("Auto (Multiple of 640x528)"), tr("Native (640x528)"),
-       tr("1.5x Native (960x792)"), tr("2x Native (1280x1056) for 720p"),
-       tr("2.5x Native (1600x1320)"), tr("3x Native (1920x1584) for 1080p"),
-       tr("4x Native (2560x2112) for 1440p"), tr("5x Native (3200x2640)"),
-       tr("6x Native (3840x3168) for 4K"), tr("7x Native (4480x3696)"),
-       tr("8x Native (5120x4224) for 5K")},
-      Config::GFX_EFB_SCALE);
+  m_ir_combo = new GraphicsChoice({tr("Auto (Multiple of 640x528)"), tr("Native (640x528)"),
+                                   tr("2x Native (1280x1056) for 720p"),
+                                   tr("3x Native (1920x1584) for 1080p"),
+                                   tr("4x Native (2560x2112) for 1440p"),
+                                   tr("5x Native (3200x2640)"), tr("6x Native (3840x3168) for 4K"),
+                                   tr("7x Native (4480x3696)"), tr("8x Native (5120x4224) for 5K")},
+                                  Config::GFX_EFB_SCALE);
 
-  if (g_Config.iEFBScale > 11)
+  if (g_Config.iEFBScale > 8)
   {
     m_ir_combo->addItem(tr("Custom"));
     m_ir_combo->setCurrentIndex(m_ir_combo->count() - 1);
@@ -221,10 +220,8 @@ void EnhancementsWidget::AddDescriptions()
   static const char* TR_INTERNAL_RESOLUTION_DESCRIPTION =
       QT_TR_NOOP("Specifies the resolution used to render at. A high resolution greatly improves "
                  "visual quality, but also greatly increases GPU load and can cause issues in "
-                 "certain games.\n\"Multiple of 640x528\" will result in a size slightly larger "
-                 "than \"Window Size\" but yield fewer issues. Generally speaking, the lower the "
-                 "internal resolution is, the better your performance will be. Auto (Window Size), "
-                 "1.5x, and 2.5x may cause issues in some games.\n\nIf unsure, select Native.");
+                 "certain games. Generally speaking, the lower the internal resolution is, the "
+                 "better your performance will be.\n\nIf unsure, select Native.");
 
   static const char* TR_ANTIALIAS_DESCRIPTION =
       QT_TR_NOOP("Reduces the amount of aliasing caused by rasterizing 3D graphics. This smooths "

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -207,7 +207,7 @@ void HotkeyScheduler::Run()
       if (IsHotkey(HK_INCREASE_IR))
         ++g_Config.iEFBScale;
       if (IsHotkey(HK_DECREASE_IR))
-        g_Config.iEFBScale = std::max(g_Config.iEFBScale - 1, static_cast<int>(SCALE_AUTO));
+        g_Config.iEFBScale = std::max(g_Config.iEFBScale - 1, EFB_SCALE_AUTO_INTEGRAL);
       if (IsHotkey(HK_TOGGLE_CROP))
         g_Config.bCrop = !g_Config.bCrop;
       if (IsHotkey(HK_TOGGLE_AR))

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1446,7 +1446,7 @@ void CFrame::ParseHotkeys()
   if (IsHotkey(HK_DECREASE_IR))
   {
     OSDChoice = 1;
-    if (Config::Get(Config::GFX_EFB_SCALE) > SCALE_AUTO)
+    if (Config::Get(Config::GFX_EFB_SCALE) > EFB_SCALE_AUTO_INTEGRAL)
       Config::SetCurrent(Config::GFX_EFB_SCALE, Config::Get(Config::GFX_EFB_SCALE) - 1);
   }
   if (IsHotkey(HK_TOGGLE_CROP))

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -186,10 +186,8 @@ static wxString borderless_fullscreen_desc = wxTRANSLATE(
 static wxString internal_res_desc =
     wxTRANSLATE("Specifies the resolution used to render at. A high resolution greatly improves "
                 "visual quality, but also greatly increases GPU load and can cause issues in "
-                "certain games.\n\"Multiple of 640x528\" will result in a size slightly larger "
-                "than \"Window Size\" but yield fewer issues. Generally speaking, the lower the "
-                "internal resolution is, the better your performance will be. Auto (Window Size), "
-                "1.5x, and 2.5x may cause issues in some games.\n\nIf unsure, select Native.");
+                "certain games. Generally speaking, the lower the internal resolution is, the "
+                "better your performance will be.\n\nIf unsure, select Native.");
 static wxString efb_access_desc =
     wxTRANSLATE("Ignore any requests from the CPU to read from or write to the EFB.\nImproves "
                 "performance in some games, but might disable some gameplay-related features or "
@@ -517,27 +515,20 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
 
     // Internal resolution
     {
-      const wxString efbscale_choices[] = {_("Auto (Window Size)"),
-                                           _("Auto (Multiple of 640x528)"),
-                                           _("Native (640x528)"),
-                                           _("1.5x Native (960x792)"),
-                                           _("2x Native (1280x1056) for 720p"),
-                                           _("2.5x Native (1600x1320)"),
-                                           _("3x Native (1920x1584) for 1080p"),
-                                           _("4x Native (2560x2112) for 1440p"),
-                                           _("5x Native (3200x2640)"),
-                                           _("6x Native (3840x3168) for 4K"),
-                                           _("7x Native (4480x3696)"),
-                                           _("8x Native (5120x4224) for 5K"),
-                                           _("Custom")};
+      const wxString efbscale_choices[] = {
+          _("Auto (Multiple of 640x528)"),      _("Native (640x528)"),
+          _("2x Native (1280x1056) for 720p"),  _("3x Native (1920x1584) for 1080p"),
+          _("4x Native (2560x2112) for 1440p"), _("5x Native (3200x2640)"),
+          _("6x Native (3840x3168) for 4K"),    _("7x Native (4480x3696)"),
+          _("8x Native (5120x4224) for 5K"),    _("Custom")};
 
       wxChoice* const choice_efbscale = CreateChoice(
           page_enh, Config::GFX_EFB_SCALE, wxGetTranslation(internal_res_desc),
-          (vconfig.iEFBScale > 11) ? ArraySize(efbscale_choices) : ArraySize(efbscale_choices) - 1,
+          (vconfig.iEFBScale > 8) ? ArraySize(efbscale_choices) : ArraySize(efbscale_choices) - 1,
           efbscale_choices);
 
-      if (vconfig.iEFBScale > 11)
-        choice_efbscale->SetSelection(12);
+      if (vconfig.iEFBScale > 8)
+        choice_efbscale->SetSelection(9);
 
       szr_enh->Add(new wxStaticText(page_enh, wxID_ANY, _("Internal Resolution:")),
                    wxGBPosition(row, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
@@ -1120,7 +1111,7 @@ void VideoConfigDiag::OnUpdateUI(wxUpdateUIEvent& ev)
   cache_hires_textures->Enable(vconfig.bHiresTextures);
 
   // Vertex rounding
-  vertex_rounding_checkbox->Enable(vconfig.iEFBScale != SCALE_1X);
+  vertex_rounding_checkbox->Enable(vconfig.iEFBScale != 1);
 
   // Repopulating the post-processing shaders can't be done from an event
   if (choice_ppshader && choice_ppshader->IsEmpty())

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -128,10 +128,10 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyParams& params, u32 native_w
     D3D::stateman->SetPixelConstants(m_encodeParams);
 
     // We also linear filtering for both box filtering and downsampling higher resolutions to 1x
-    // TODO: This only produces perfect downsampling for 1.5x and 2x IR, other resolution will
-    //       need more complex down filtering to average all pixels and produce the correct result.
+    // TODO: This only produces perfect downsampling for 2x IR, other resolutions will need more
+    //       complex down filtering to average all pixels and produce the correct result.
     // Also, box filtering won't be correct for anything other than 1x IR
-    if (scale_by_half || g_ActiveConfig.iEFBScale != SCALE_1X)
+    if (scale_by_half || g_ActiveConfig.iEFBScale != 1)
       D3D::SetLinearCopySampler();
     else
       D3D::SetPointCopySampler();

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -230,10 +230,10 @@ static void EncodeToRamUsingShader(GLuint srcTexture, u8* destAddr, u32 dst_line
   glBindTexture(GL_TEXTURE_2D_ARRAY, srcTexture);
 
   // We also linear filtering for both box filtering and downsampling higher resolutions to 1x
-  // TODO: This only produces perfect downsampling for 1.5x and 2x IR, other resolution will
-  //       need more complex down filtering to average all pixels and produce the correct result.
+  // TODO: This only produces perfect downsampling for 2x IR, other resolutions will need more
+  //       complex down filtering to average all pixels and produce the correct result.
   // Also, box filtering won't be correct for anything other than 1x IR
-  if (linearFilter || g_ActiveConfig.iEFBScale != SCALE_1X)
+  if (linearFilter || g_ActiveConfig.iEFBScale != 1)
     g_sampler_cache->BindLinearSampler(9);
   else
     g_sampler_cache->BindNearestSampler(9);

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -248,9 +248,9 @@ void TextureConverter::EncodeTextureToMemory(VkImageView src_texture, u8* dest_p
   draw.SetPushConstants(position_uniform, sizeof(position_uniform));
 
   // We also linear filtering for both box filtering and downsampling higher resolutions to 1x
-  // TODO: This only produces perfect downsampling for 1.5x and 2x IR, other resolution will
-  //       need more complex down filtering to average all pixels and produce the correct result.
-  bool linear_filter = (scale_by_half && !params.depth) || g_ActiveConfig.iEFBScale != SCALE_1X;
+  // TODO: This only produces perfect downsampling for 2x IR, other resolutions will need more
+  //       complex down filtering to average all pixels and produce the correct result.
+  bool linear_filter = (scale_by_half && !params.depth) || g_ActiveConfig.iEFBScale != 1;
   draw.SetPSSampler(0, src_texture, linear_filter ? g_object_cache->GetLinearSampler() :
                                                     g_object_cache->GetPointSampler());
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -78,8 +78,7 @@ public:
   virtual void RestoreState() {}
   virtual void ResetAPIState() {}
   virtual void RestoreAPIState() {}
-  // Ideal internal resolution - determined by display resolution (automatic scaling) and/or a
-  // multiple of the native EFB resolution
+  // Ideal internal resolution - multiple of the native EFB resolution
   int GetTargetWidth() const { return m_target_width; }
   int GetTargetHeight() const { return m_target_height; }
   // Display resolution
@@ -170,7 +169,6 @@ protected:
   // TODO: Add functionality to reinit all the render targets when the window is resized.
   int m_backbuffer_width = 0;
   int m_backbuffer_height = 0;
-  int m_last_efb_scale = 0;
   TargetRectangle m_target_rectangle = {};
   bool m_xfb_written = false;
 
@@ -191,10 +189,7 @@ private:
   void ShutdownFrameDumping();
 
   PEControl::PixelFormat m_prev_efb_format = PEControl::INVALID_FMT;
-  unsigned int m_efb_scale_numeratorX = 1;
-  unsigned int m_efb_scale_numeratorY = 1;
-  unsigned int m_efb_scale_denominatorX = 1;
-  unsigned int m_efb_scale_denominatorY = 1;
+  unsigned int m_efb_scale = 1;
 
   // These will be set on the first call to SetWindowSize.
   int m_last_window_request_width = 0;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -376,8 +376,7 @@ void VertexShaderManager::SetConstants()
     // NOTE: If we ever emulate antialiasing, the sample locations set by
     // BP registers 0x01-0x04 need to be considered here.
     const float pixel_center_correction = 7.0f / 12.0f - 0.5f;
-    const bool bUseVertexRounding =
-        g_ActiveConfig.bVertexRounding && g_ActiveConfig.iEFBScale != SCALE_1X;
+    const bool bUseVertexRounding = g_ActiveConfig.bVertexRounding && g_ActiveConfig.iEFBScale != 1;
     const float viewport_width = bUseVertexRounding ?
                                      (2.f * xfmem.viewport.wd) :
                                      g_renderer->EFBToScaledXf(2.f * xfmem.viewport.wd);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -139,26 +139,6 @@ void VideoConfig::Refresh()
   phack.m_zfar = Config::Get(Config::GFX_PROJECTION_HACK_ZFAR);
   bPerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);
 
-  if (iEFBScale == SCALE_FORCE_INTEGRAL)
-  {
-    // Round down to multiple of native IR
-    switch (Config::GetBase(Config::GFX_EFB_SCALE))
-    {
-    case SCALE_AUTO:
-      iEFBScale = SCALE_AUTO_INTEGRAL;
-      break;
-    case SCALE_1_5X:
-      iEFBScale = SCALE_1X;
-      break;
-    case SCALE_2_5X:
-      iEFBScale = SCALE_2X;
-      break;
-    default:
-      iEFBScale = Config::GetBase(Config::GFX_EFB_SCALE);
-      break;
-    }
-  }
-
   VerifyValidity();
 }
 

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -22,23 +22,14 @@
 #define CONF_SAVETARGETS 8
 #define CONF_SAVESHADERS 16
 
+constexpr int EFB_SCALE_AUTO_INTEGRAL = 0;
+
 enum AspectMode
 {
   ASPECT_AUTO = 0,
   ASPECT_ANALOG_WIDE = 1,
   ASPECT_ANALOG = 2,
   ASPECT_STRETCH = 3,
-};
-
-enum EFBScale
-{
-  SCALE_FORCE_INTEGRAL = -1,
-  SCALE_AUTO,
-  SCALE_AUTO_INTEGRAL,
-  SCALE_1X,
-  SCALE_1_5X,
-  SCALE_2X,
-  SCALE_2_5X,
 };
 
 enum StereoMode
@@ -252,7 +243,7 @@ struct VideoConfig final
   {
     return backend_info.bSupportsGPUTextureDecoding && bEnableGPUTextureDecoding;
   }
-  bool UseVertexRounding() const { return bVertexRounding && iEFBScale != SCALE_1X; }
+  bool UseVertexRounding() const { return bVertexRounding && iEFBScale != 1; }
   u32 GetShaderCompilerThreads() const;
   u32 GetShaderPrecompilerThreads() const;
   bool CanPrecompileUberShaders() const;


### PR DESCRIPTION
Non-integer internal resolutions lead to many problems that we can't do much about – mostly graphical, but in Paper Mario TTYD's case, there are problems like [crashes](https://forums.dolphin-emu.org/Thread-paper-mario-thousand-year-door-crashing--49298) and even [save corruption](https://bugs.dolphin-emu.org/issues/10171). This PR removes non-integer internal resolutions from Dolphin entirely.

One note about the implementation of this PR: I've changed how Dolphin stores the EFB scale setting in RAM because it simplifies code significantly in several places. Now 0 means auto (integral), 1 means 1x, 2 means 2x, and so on. Do we want to apply this change to the INIs as well (so that values make more sense) or keep using the old numbering system in INIs (to be backwards compatible)? For now, I've just made it use the new numbering system with a new setting name, because I wasn't sure where in the new config code I could put code for translating between the two numbering systems.