### PR TITLE
Hide mouse delay fullscreen

### DIFF
--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <QKeyEvent>
+#include <QTimer>
 
 #include "DolphinQt2/Host.h"
 #include "DolphinQt2/RenderWidget.h"
@@ -19,14 +20,26 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
   connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle);
   emit HandleChanged((void*)winId());
 
+  m_mouse_timer = new QTimer(this);
+  connect(m_mouse_timer, &QTimer::timeout, this, &RenderWidget::HandleCursorTimer);
+  m_mouse_timer->setSingleShot(true);
+  setMouseTracking(true);
+
   connect(&Settings::Instance(), &Settings::HideCursorChanged, this,
           &RenderWidget::OnHideCursorChanged);
   OnHideCursorChanged();
+  m_mouse_timer->start(MOUSE_HIDE_DELAY);
 }
 
 void RenderWidget::OnHideCursorChanged()
 {
   setCursor(Settings::Instance().GetHideCursor() ? Qt::BlankCursor : Qt::ArrowCursor);
+}
+
+void RenderWidget::HandleCursorTimer()
+{
+  if (isActiveWindow())
+    setCursor(Qt::BlankCursor);
 }
 
 bool RenderWidget::event(QEvent* event)
@@ -40,6 +53,14 @@ bool RenderWidget::event(QEvent* event)
       emit EscapePressed();
     break;
   }
+  case QEvent::MouseMove:
+  case QEvent::MouseButtonPress:
+    if (!Settings::Instance().GetHideCursor() && isActiveWindow())
+    {
+      setCursor(Qt::ArrowCursor);
+      m_mouse_timer->start(MOUSE_HIDE_DELAY);
+    }
+    break;
   case QEvent::WinIdChange:
     emit HandleChanged((void*)winId());
     break;

--- a/Source/Core/DolphinQt2/RenderWidget.h
+++ b/Source/Core/DolphinQt2/RenderWidget.h
@@ -7,6 +7,8 @@
 #include <QEvent>
 #include <QWidget>
 
+class QTimer;
+
 class RenderWidget final : public QWidget
 {
   Q_OBJECT
@@ -24,5 +26,9 @@ signals:
   void StateChanged(bool fullscreen);
 
 private:
+  void HandleCursorTimer();
   void OnHideCursorChanged();
+
+  static constexpr int MOUSE_HIDE_DELAY = 3000;
+  QTimer* m_mouse_timer;
 };

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -91,7 +91,7 @@ void InterfacePane::CreateInGame()
   m_checkbox_enable_osd = new QCheckBox(tr("Enable On Screen Messages"));
   m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
   m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
-  m_checkbox_hide_mouse = new QCheckBox(tr("Hide Mouse Cursor"));
+  m_checkbox_hide_mouse = new QCheckBox(tr("Always Hide Mouse Cursor"));
 
   groupbox_layout->addWidget(m_checkbox_confirm_on_stop);
   groupbox_layout->addWidget(m_checkbox_use_panic_handlers);

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -448,6 +448,10 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
   Bind(wxEVT_TIMER, &CFrame::PollHotkeys, this, m_poll_hotkey_timer.GetId());
   m_poll_hotkey_timer.Start(1000 / 60, wxTIMER_CONTINUOUS);
 
+  m_cursor_timer.SetOwner(this);
+  Bind(wxEVT_TIMER, &CFrame::HandleCursorTimer, this, m_cursor_timer.GetId());
+  m_cursor_timer.StartOnce(MOUSE_HIDE_DELAY);
+
   // Shut down cleanly on SIGINT, SIGTERM (Unix) and on various signals on Windows
   m_handle_signal_timer.SetOwner(this);
   Bind(wxEVT_TIMER, &CFrame::HandleSignal, this, m_handle_signal_timer.GetId());
@@ -1122,6 +1126,13 @@ void CFrame::OnKeyDown(wxKeyEvent& event)
 
 void CFrame::OnMouse(wxMouseEvent& event)
 {
+  if (!SConfig::GetInstance().bHideCursor && main_frame->RendererHasFocus() &&
+      Core::GetState() == Core::State::Running)
+  {
+    m_render_parent->SetCursor(wxNullCursor);
+    m_cursor_timer.StartOnce(MOUSE_HIDE_DELAY);
+  }
+
   // next handlers are all for FreeLook, so we don't need to check them if disabled
   if (!g_Config.bFreeLook)
   {
@@ -1697,6 +1708,13 @@ void CFrame::HandleFrameSkipHotkeys()
     holdFrameStep = false;
     holdFrameStepDelayCount = 0;
   }
+}
+
+void CFrame::HandleCursorTimer(wxTimerEvent& event)
+{
+  if (!SConfig::GetInstance().bHideCursor && main_frame->RendererHasFocus() &&
+      Core::GetState() == Core::State::Running)
+    m_render_parent->SetCursor(wxCURSOR_BLANK);
 }
 
 void CFrame::HandleSignal(wxTimerEvent& event)

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -144,6 +144,7 @@ private:
     ADD_PANE_CENTER
   };
 
+  static constexpr int MOUSE_HIDE_DELAY = 3000;
   GameListCtrl* m_game_list_ctrl = nullptr;
   CConfigMain* m_main_config_dialog = nullptr;
   wxPanel* m_panel = nullptr;
@@ -167,6 +168,7 @@ private:
   int m_save_slot = 1;
 
   wxTimer m_poll_hotkey_timer;
+  wxTimer m_cursor_timer;
   wxTimer m_handle_signal_timer;
 
   wxMenuBar* m_menubar_shadow = nullptr;
@@ -360,6 +362,7 @@ private:
 
   void PollHotkeys(wxTimerEvent&);
   void ParseHotkeys();
+  void HandleCursorTimer(wxTimerEvent&);
   void HandleSignal(wxTimerEvent&);
 
   bool InitControllers();

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -502,7 +502,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
         szr_other->Add(CreateCheckBoxRefBool(page_general, _("Keep Window on Top"),
                                              wxGetTranslation(keep_window_on_top_desc),
                                              SConfig::GetInstance().bKeepWindowOnTop));
-        szr_other->Add(CreateCheckBoxRefBool(page_general, _("Hide Mouse Cursor"),
+        szr_other->Add(CreateCheckBoxRefBool(page_general, _("Always Hide Mouse Cursor"),
                                              wxGetTranslation(hide_mouse_cursor_desc),
                                              SConfig::GetInstance().bHideCursor));
         szr_other->Add(render_to_main_checkbox =


### PR DESCRIPTION
This PR addresses issues [9715](https://bugs.dolphin-emu.org/issues/9715) and [6116](https://bugs.dolphin-emu.org/issues/6116).   

Currently, the mouse cursor is either always shown or permanently hidden.  These changes will hide the cursor after a few seconds of inactivity while in fullscreen mode.