### PR TITLE
IOS: Add IOS4v3 Constants

### DIFF
--- a/Source/Core/Core/IOS/MemoryValues.cpp
+++ b/Source/Core/Core/IOS/MemoryValues.cpp
@@ -27,8 +27,15 @@ constexpr u32 RAM_VENDOR_MIOS = 0xCAFEBABE;
 // The writes are usually contained in a single function that
 // mostly writes raw literals to the relevant locations.
 // e.g. IOS9, version 1034, content id 0x00000006, function at 0xffff6884
-constexpr std::array<MemoryValues, 40> ios_memory_values = {
+constexpr std::array<MemoryValues, 41> ios_memory_values = {
     {{
+         4,          0x40003,     0x81006,          MEM1_SIZE,
+         MEM1_SIZE,  MEM1_END,    MEM1_ARENA_BEGIN, MEM1_ARENA_END,
+         MEM2_SIZE,  MEM2_SIZE,   0x93400000,       MEM2_ARENA_BEGIN,
+         0x933E0000, 0x933E0000,  0x93400000,       HOLLYWOOD_REVISION,
+         RAM_VENDOR, PLACEHOLDER, PLACEHOLDER,      0,
+     },
+     {
          9,          0x9040a,     0x030110,         MEM1_SIZE,
          MEM1_SIZE,  MEM1_END,    MEM1_ARENA_BEGIN, MEM1_ARENA_END,
          MEM2_SIZE,  MEM2_SIZE,   0x93400000,       MEM2_ARENA_BEGIN,
@@ -324,7 +331,7 @@ constexpr std::array<MemoryValues, 40> ios_memory_values = {
          PLACEHOLDER,
      }}};
 
-const std::array<MemoryValues, 40>& GetMemoryValues()
+const std::array<MemoryValues, 41>& GetMemoryValues()
 {
   return ios_memory_values;
 }

--- a/Source/Core/Core/IOS/MemoryValues.h
+++ b/Source/Core/Core/IOS/MemoryValues.h
@@ -36,6 +36,6 @@ struct MemoryValues
   u32 sysmenu_sync;
 };
 
-const std::array<MemoryValues, 40>& GetMemoryValues();
+const std::array<MemoryValues, 41>& GetMemoryValues();
 }
 }


### PR DESCRIPTION
I have opened up IOS4v3 in a disassembler and checked each value to properly implement IOS4 in Dolphin. This allows the Startup Disc Menu to work:

![wii startup disc](https://user-images.githubusercontent.com/7153841/27850102-38734e82-6120-11e7-9b7b-e6aef8aef7cf.PNG)