### PR TITLE
Replace StringFromInt with std::to_string

### DIFF
--- a/Source/Core/Common/Config/Section.cpp
+++ b/Source/Core/Common/Config/Section.cpp
@@ -71,7 +71,7 @@ void Section::Set(const std::string& key, double newValue)
 
 void Section::Set(const std::string& key, int newValue)
 {
-  Section::Set(key, StringFromInt(newValue));
+  Section::Set(key, std::to_string(newValue));
 }
 
 void Section::Set(const std::string& key, bool newValue)

--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -93,7 +93,7 @@ void IniFile::Section::Set(const std::string& key, double newValue)
 
 void IniFile::Section::Set(const std::string& key, int newValue)
 {
-  Set(key, StringFromInt(newValue));
+  Set(key, std::to_string(newValue));
 }
 
 void IniFile::Section::Set(const std::string& key, s64 newValue)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -283,13 +283,6 @@ bool TryParse(const std::string& str, bool* const output)
   return true;
 }
 
-std::string StringFromInt(int value)
-{
-  char temp[16];
-  sprintf(temp, "%i", value);
-  return temp;
-}
-
 std::string StringFromBool(bool value)
 {
   return value ? "True" : "False";

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -56,7 +56,6 @@ std::string ThousandSeparate(I value, int spaces = 0)
   return oss.str();
 }
 
-std::string StringFromInt(int value);
 std::string StringFromBool(bool value);
 
 bool TryParse(const std::string& str, bool* output);

--- a/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
@@ -6,6 +6,7 @@
 
 #ifdef ANDROID
 #include <jni.h>
+#include <string>
 
 #include "Common/StringUtil.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
@@ -17,7 +18,7 @@ class WiimoteAndroid final : public Wiimote
 public:
   WiimoteAndroid(int index);
   ~WiimoteAndroid() override;
-  std::string GetId() const override { return "Android " + StringFromInt(m_mayflash_index); }
+  std::string GetId() const override { return "Android " + std::to_string(m_mayflash_index); }
 protected:
   bool ConnectInternal() override;
   void DisconnectInternal() override;


### PR DESCRIPTION
Updated version of #47. Android should support to_string now that we use a modern version of libc++ when building.