### PR TITLE
D3D: Make the efb2ram shader use the same read stride as OpenGL

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -151,10 +151,9 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyFormat& format, u32 native_w
     CHECK(SUCCEEDED(hr), "map staging buffer (0x%x)", hr);
 
     u8* src = (u8*)map.pData;
-    u32 readStride = std::min(bytes_per_row, map.RowPitch);
     for (unsigned int y = 0; y < num_blocks_y; ++y)
     {
-      memcpy(dst, src, readStride);
+      memcpy(dst, src, bytes_per_row);
       dst += memory_stride;
       src += map.RowPitch;
     }


### PR DESCRIPTION
This is supposed to fix Issue 9535 (https://bugs.dolphin-emu.org/issues/9535), since OpenGL works for Paper Mario: The Thousand-Year Door, while D3D does not right now.

I don't really know what i'm doing, but i assume that D3D11_MAPPED_SUBRESOURCE map might use a different alignment in memory per row as the one the gamecube/wii uses. So i left i kept "src += map.RowPitch;" but changed the memcpy to copy "bytes_per_row" bytes, as OpenGL does.

@magumagu suggested in https://github.com/dolphin-emu/dolphin/pull/4072 to use "map.RowPitch" for the memcpy instead of "bytes_per_row", so i would try this next, if changing it to "bytes_per_row" doesn't work out.