### PR TITLE
Qt: Fix "Install WAD" being enabled while emulation is running

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -42,6 +42,8 @@ private slots:
 
 signals:
   void GameSelected();
+  void EmulationStarted();
+  void EmulationStopped();
 
 private:
   void MakeTableView();

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -249,6 +249,8 @@ void MainWindow::ConnectToolBar()
 void MainWindow::ConnectGameList()
 {
   connect(m_game_list, &GameList::GameSelected, this, &MainWindow::Play);
+  connect(this, &MainWindow::EmulationStarted, m_game_list, &GameList::EmulationStarted);
+  connect(this, &MainWindow::EmulationStopped, m_game_list, &GameList::EmulationStopped);
 }
 
 void MainWindow::ConnectRenderWidget()


### PR DESCRIPTION
Previously users were able to install WAD files while the emulation was running. This (almost) always resulted in a crash. Now, it's dynamically  disabled both in the gamelist and the menubar once the emulation is started and reenabled once the emulation stops again.