### PR TITLE
GameINI: Add Wii Startup Menu

### DIFF
--- a/Data/Sys/GameSettings/0000000100000002r1.ini
+++ b/Data/Sys/GameSettings/0000000100000002r1.ini
@@ -1,0 +1,19 @@
+# 1-2 - System Menu (v1, Startup Disc Menu)
+
+[Core]
+# Values set here will override the main Dolphin settings.
+DSPHLE = False
+
+[EmuState]
+# The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId =
+EmulationIssues =
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.


### PR DESCRIPTION
This change adds a GameINI for the Wii Startup Menu (since it needs LLE audio forced in order to boot).

As a side note to this - I was looking into doing a similar thing with the GameCube IPL (since it needs XFB enabled), however since it doesn't have a title ID it seems difficult to implement. (When loading a GameCube game with XFB forced in the GameINI, I noticed that those changes are applied before the IPL starts, meaning that just like the Wii menu needing safe texture cache it would be difficult to implement since it would still be on even when booting games.)