### PR TITLE
LogManager: clean ups and encapsulate config file management

### DIFF
--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -47,24 +47,6 @@ private:
   bool m_enable;
 };
 
-class LogContainer
-{
-public:
-  LogContainer(const std::string& short_name, const std::string& full_name, bool enable = false)
-      : m_full_name(full_name), m_short_name(short_name), m_enable(enable)
-  {
-  }
-
-  std::string GetShortName() const { return m_short_name; }
-  std::string GetFullName() const { return m_full_name; }
-  bool IsEnabled() const { return m_enable; }
-  void SetEnable(bool enable) { m_enable = enable; }
-private:
-  std::string m_full_name;
-  std::string m_short_name;
-  bool m_enable;
-};
-
 void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file, int line,
                 const char* fmt, ...)
 {
@@ -87,53 +69,53 @@ static size_t DeterminePathCutOffPoint()
 LogManager::LogManager()
 {
   // create log containers
-  m_log[LogTypes::ACTIONREPLAY] = new LogContainer("ActionReplay", "ActionReplay");
-  m_log[LogTypes::AUDIO] = new LogContainer("Audio", "Audio Emulator");
-  m_log[LogTypes::AUDIO_INTERFACE] = new LogContainer("AI", "Audio Interface (AI)");
-  m_log[LogTypes::BOOT] = new LogContainer("BOOT", "Boot");
-  m_log[LogTypes::COMMANDPROCESSOR] = new LogContainer("CP", "CommandProc");
-  m_log[LogTypes::COMMON] = new LogContainer("COMMON", "Common");
-  m_log[LogTypes::CONSOLE] = new LogContainer("CONSOLE", "Dolphin Console");
-  m_log[LogTypes::CORE] = new LogContainer("CORE", "Core");
-  m_log[LogTypes::DISCIO] = new LogContainer("DIO", "Disc IO");
-  m_log[LogTypes::DSPHLE] = new LogContainer("DSPHLE", "DSP HLE");
-  m_log[LogTypes::DSPLLE] = new LogContainer("DSPLLE", "DSP LLE");
-  m_log[LogTypes::DSP_MAIL] = new LogContainer("DSPMails", "DSP Mails");
-  m_log[LogTypes::DSPINTERFACE] = new LogContainer("DSP", "DSPInterface");
-  m_log[LogTypes::DVDINTERFACE] = new LogContainer("DVD", "DVD Interface");
-  m_log[LogTypes::DYNA_REC] = new LogContainer("JIT", "Dynamic Recompiler");
-  m_log[LogTypes::EXPANSIONINTERFACE] = new LogContainer("EXI", "Expansion Interface");
-  m_log[LogTypes::FILEMON] = new LogContainer("FileMon", "File Monitor");
-  m_log[LogTypes::GDB_STUB] = new LogContainer("GDB_STUB", "GDB Stub");
-  m_log[LogTypes::GPFIFO] = new LogContainer("GP", "GPFifo");
-  m_log[LogTypes::HOST_GPU] = new LogContainer("Host GPU", "Host GPU");
-  m_log[LogTypes::IOS] = new LogContainer("IOS", "IOS");
-  m_log[LogTypes::IOS_DI] = new LogContainer("IOS_DI", "IOS - Drive Interface");
-  m_log[LogTypes::IOS_ES] = new LogContainer("IOS_ES", "IOS - ETicket Services");
-  m_log[LogTypes::IOS_FILEIO] = new LogContainer("IOS_FILEIO", "IOS - FileIO");
-  m_log[LogTypes::IOS_SD] = new LogContainer("IOS_SD", "IOS - SDIO");
-  m_log[LogTypes::IOS_SSL] = new LogContainer("IOS_SSL", "IOS - SSL");
-  m_log[LogTypes::IOS_STM] = new LogContainer("IOS_STM", "IOS - State Transition Manager");
-  m_log[LogTypes::IOS_NET] = new LogContainer("IOS_NET", "IOS - Network");
-  m_log[LogTypes::IOS_USB] = new LogContainer("IOS_USB", "IOS - USB");
-  m_log[LogTypes::IOS_WC24] = new LogContainer("IOS_WC24", "IOS - WiiConnect24");
-  m_log[LogTypes::IOS_WIIMOTE] = new LogContainer("IOS_WIIMOTE", "IOS - Wii Remote");
-  m_log[LogTypes::MASTER_LOG] = new LogContainer("*", "Master Log");
-  m_log[LogTypes::MEMCARD_MANAGER] = new LogContainer("MemCard Manager", "MemCard Manager");
-  m_log[LogTypes::MEMMAP] = new LogContainer("MI", "MI & memmap");
-  m_log[LogTypes::NETPLAY] = new LogContainer("NETPLAY", "Netplay");
-  m_log[LogTypes::OSHLE] = new LogContainer("HLE", "HLE");
-  m_log[LogTypes::OSREPORT] = new LogContainer("OSREPORT", "OSReport");
-  m_log[LogTypes::PAD] = new LogContainer("PAD", "Pad");
-  m_log[LogTypes::PIXELENGINE] = new LogContainer("PE", "PixelEngine");
-  m_log[LogTypes::PROCESSORINTERFACE] = new LogContainer("PI", "ProcessorInt");
-  m_log[LogTypes::POWERPC] = new LogContainer("PowerPC", "IBM CPU");
-  m_log[LogTypes::SERIALINTERFACE] = new LogContainer("SI", "Serial Interface (SI)");
-  m_log[LogTypes::SP1] = new LogContainer("SP1", "Serial Port 1");
-  m_log[LogTypes::VIDEO] = new LogContainer("Video", "Video Backend");
-  m_log[LogTypes::VIDEOINTERFACE] = new LogContainer("VI", "Video Interface (VI)");
-  m_log[LogTypes::WIIMOTE] = new LogContainer("Wiimote", "Wiimote");
-  m_log[LogTypes::WII_IPC] = new LogContainer("WII_IPC", "WII IPC");
+  m_log[LogTypes::ACTIONREPLAY] = {"ActionReplay", "ActionReplay"};
+  m_log[LogTypes::AUDIO] = {"Audio", "Audio Emulator"};
+  m_log[LogTypes::AUDIO_INTERFACE] = {"AI", "Audio Interface (AI)"};
+  m_log[LogTypes::BOOT] = {"BOOT", "Boot"};
+  m_log[LogTypes::COMMANDPROCESSOR] = {"CP", "CommandProc"};
+  m_log[LogTypes::COMMON] = {"COMMON", "Common"};
+  m_log[LogTypes::CONSOLE] = {"CONSOLE", "Dolphin Console"};
+  m_log[LogTypes::CORE] = {"CORE", "Core"};
+  m_log[LogTypes::DISCIO] = {"DIO", "Disc IO"};
+  m_log[LogTypes::DSPHLE] = {"DSPHLE", "DSP HLE"};
+  m_log[LogTypes::DSPLLE] = {"DSPLLE", "DSP LLE"};
+  m_log[LogTypes::DSP_MAIL] = {"DSPMails", "DSP Mails"};
+  m_log[LogTypes::DSPINTERFACE] = {"DSP", "DSPInterface"};
+  m_log[LogTypes::DVDINTERFACE] = {"DVD", "DVD Interface"};
+  m_log[LogTypes::DYNA_REC] = {"JIT", "Dynamic Recompiler"};
+  m_log[LogTypes::EXPANSIONINTERFACE] = {"EXI", "Expansion Interface"};
+  m_log[LogTypes::FILEMON] = {"FileMon", "File Monitor"};
+  m_log[LogTypes::GDB_STUB] = {"GDB_STUB", "GDB Stub"};
+  m_log[LogTypes::GPFIFO] = {"GP", "GPFifo"};
+  m_log[LogTypes::HOST_GPU] = {"Host GPU", "Host GPU"};
+  m_log[LogTypes::IOS] = {"IOS", "IOS"};
+  m_log[LogTypes::IOS_DI] = {"IOS_DI", "IOS - Drive Interface"};
+  m_log[LogTypes::IOS_ES] = {"IOS_ES", "IOS - ETicket Services"};
+  m_log[LogTypes::IOS_FILEIO] = {"IOS_FILEIO", "IOS - FileIO"};
+  m_log[LogTypes::IOS_SD] = {"IOS_SD", "IOS - SDIO"};
+  m_log[LogTypes::IOS_SSL] = {"IOS_SSL", "IOS - SSL"};
+  m_log[LogTypes::IOS_STM] = {"IOS_STM", "IOS - State Transition Manager"};
+  m_log[LogTypes::IOS_NET] = {"IOS_NET", "IOS - Network"};
+  m_log[LogTypes::IOS_USB] = {"IOS_USB", "IOS - USB"};
+  m_log[LogTypes::IOS_WC24] = {"IOS_WC24", "IOS - WiiConnect24"};
+  m_log[LogTypes::IOS_WIIMOTE] = {"IOS_WIIMOTE", "IOS - Wii Remote"};
+  m_log[LogTypes::MASTER_LOG] = {"*", "Master Log"};
+  m_log[LogTypes::MEMCARD_MANAGER] = {"MemCard Manager", "MemCard Manager"};
+  m_log[LogTypes::MEMMAP] = {"MI", "MI & memmap"};
+  m_log[LogTypes::NETPLAY] = {"NETPLAY", "Netplay"};
+  m_log[LogTypes::OSHLE] = {"HLE", "HLE"};
+  m_log[LogTypes::OSREPORT] = {"OSREPORT", "OSReport"};
+  m_log[LogTypes::PAD] = {"PAD", "Pad"};
+  m_log[LogTypes::PIXELENGINE] = {"PE", "PixelEngine"};
+  m_log[LogTypes::PROCESSORINTERFACE] = {"PI", "ProcessorInt"};
+  m_log[LogTypes::POWERPC] = {"PowerPC", "IBM CPU"};
+  m_log[LogTypes::SERIALINTERFACE] = {"SI", "Serial Interface (SI)"};
+  m_log[LogTypes::SP1] = {"SP1", "Serial Port 1"};
+  m_log[LogTypes::VIDEO] = {"Video", "Video Backend"};
+  m_log[LogTypes::VIDEOINTERFACE] = {"VI", "Video Interface (VI)"};
+  m_log[LogTypes::WIIMOTE] = {"Wiimote", "Wiimote"};
+  m_log[LogTypes::WII_IPC] = {"WII_IPC", "WII IPC"};
 
   RegisterListener(LogListener::FILE_LISTENER,
                    new FileLogListener(File::GetUserPath(F_MAINLOG_IDX)));
@@ -165,21 +147,14 @@ LogManager::LogManager()
   EnableListener(LogListener::CONSOLE_LISTENER, write_console);
   EnableListener(LogListener::LOG_WINDOW_LISTENER, write_window);
 
-  for (LogContainer* container : m_log)
-  {
-    bool enable;
-    logs->Get(container->GetShortName(), &enable, false);
-    container->SetEnable(enable);
-  }
+  for (LogContainer& container : m_log)
+    logs->Get(container.m_short_name, &container.m_enable, false);
 
   m_path_cutoff_point = DeterminePathCutOffPoint();
 }
 
 LogManager::~LogManager()
 {
-  for (LogContainer* container : m_log)
-    delete container;
-
   // The log window listener pointer is owned by the GUI code.
   delete m_listeners[LogListener::CONSOLE_LISTENER];
   delete m_listeners[LogListener::FILE_LISTENER];
@@ -194,17 +169,15 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const 
 void LogManager::LogWithFullPath(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
                                  const char* file, int line, const char* format, va_list args)
 {
-  char temp[MAX_MSGLEN];
-  LogContainer* log = m_log[type];
-
-  if (!log->IsEnabled() || level > GetLogLevel() || !static_cast<bool>(m_listener_ids))
+  if (!IsEnabled(type, level) || !static_cast<bool>(m_listener_ids))
     return;
 
+  char temp[MAX_MSGLEN];
   CharArrayFromFormatV(temp, MAX_MSGLEN, format, args);
 
-  std::string msg = StringFromFormat(
-      "%s %s:%u %c[%s]: %s\n", Common::Timer::GetTimeFormatted().c_str(), file, line,
-      LogTypes::LOG_LEVEL_TO_CHAR[(int)level], log->GetShortName().c_str(), temp);
+  std::string msg =
+      StringFromFormat("%s %s:%u %c[%s]: %s\n", Common::Timer::GetTimeFormatted().c_str(), file,
+                       line, LogTypes::LOG_LEVEL_TO_CHAR[(int)level], GetShortName(type), temp);
 
   for (auto listener_id : m_listener_ids)
     if (m_listeners[listener_id])
@@ -223,22 +196,22 @@ void LogManager::SetLogLevel(LogTypes::LOG_LEVELS level)
 
 void LogManager::SetEnable(LogTypes::LOG_TYPE type, bool enable)
 {
-  m_log[type]->SetEnable(enable);
+  m_log[type].m_enable = enable;
 }
 
 bool LogManager::IsEnabled(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level) const
 {
-  return m_log[type]->IsEnabled() && GetLogLevel() >= level;
+  return m_log[type].m_enable && GetLogLevel() >= level;
 }
 
-std::string LogManager::GetShortName(LogTypes::LOG_TYPE type) const
+const char* LogManager::GetShortName(LogTypes::LOG_TYPE type) const
 {
-  return m_log[type]->GetShortName();
+  return m_log[type].m_short_name;
 }
 
-std::string LogManager::GetFullName(LogTypes::LOG_TYPE type) const
+const char* LogManager::GetFullName(LogTypes::LOG_TYPE type) const
 {
-  return m_log[type]->GetFullName();
+  return m_log[type].m_full_name;
 }
 
 void LogManager::RegisterListener(LogListener::LISTENER id, LogListener* listener)

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -160,6 +160,24 @@ LogManager::~LogManager()
   delete m_listeners[LogListener::FILE_LISTENER];
 }
 
+void LogManager::SaveSettings()
+{
+  IniFile ini;
+  ini.Load(File::GetUserPath(F_LOGGERCONFIG_IDX));
+
+  IniFile::Section* options = ini.GetOrCreateSection("Options");
+  options->Set("Verbosity", GetLogLevel());
+  options->Set("WriteToFile", m_listener_ids[LogListener::FILE_LISTENER]);
+  options->Set("WriteToConsole", m_listener_ids[LogListener::CONSOLE_LISTENER]);
+  options->Set("WriteToWindow", m_listener_ids[LogListener::LOG_WINDOW_LISTENER]);
+
+  // Save all enabled/disabled states of the log types to the config ini.
+  for (const auto& container : m_log)
+    ini.GetOrCreateSection("Logs")->Set(container.m_short_name, container.m_enable);
+
+  ini.Save(File::GetUserPath(F_LOGGERCONFIG_IDX));
+}
+
 void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file,
                      int line, const char* format, va_list args)
 {
@@ -244,6 +262,8 @@ void LogManager::Init()
 
 void LogManager::Shutdown()
 {
+  if (s_log_manager)
+    s_log_manager->SaveSettings();
   delete s_log_manager;
   s_log_manager = nullptr;
 }

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -6,17 +6,10 @@
 
 #include <array>
 #include <cstdarg>
-#include <fstream>
-#include <mutex>
-#include <set>
 #include <string>
 
-#include "Common/BitSet.h"
-#include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/NonCopyable.h"
-
-#define MAX_MSGLEN 1024
 
 // pure virtual interface
 class LogListener
@@ -35,100 +28,36 @@ public:
   };
 };
 
-class FileLogListener : public LogListener
-{
-public:
-  FileLogListener(const std::string& filename);
-
-  void Log(LogTypes::LOG_LEVELS, const char* msg) override;
-
-  bool IsValid() const { return m_logfile.good(); }
-  bool IsEnabled() const { return m_enable; }
-  void SetEnable(bool enable) { m_enable = enable; }
-  const char* GetName() const { return "file"; }
-private:
-  std::mutex m_log_lock;
-  std::ofstream m_logfile;
-  bool m_enable;
-};
-
-class LogContainer
-{
-public:
-  LogContainer(const std::string& shortName, const std::string& fullName, bool enable = false);
-
-  std::string GetShortName() const { return m_shortName; }
-  std::string GetFullName() const { return m_fullName; }
-  void AddListener(LogListener::LISTENER id) { m_listener_ids[id] = 1; }
-  void RemoveListener(LogListener::LISTENER id) { m_listener_ids[id] = 0; }
-  void Trigger(LogTypes::LOG_LEVELS, const char* msg);
-
-  bool IsEnabled() const { return m_enable; }
-  void SetEnable(bool enable) { m_enable = enable; }
-  LogTypes::LOG_LEVELS GetLevel() const { return m_level; }
-  void SetLevel(LogTypes::LOG_LEVELS level) { m_level = level; }
-  bool HasListeners() const { return bool(m_listener_ids); }
-  typedef class BitSet32::Iterator iterator;
-  iterator begin() const { return m_listener_ids.begin(); }
-  iterator end() const { return m_listener_ids.end(); }
-private:
-  std::string m_fullName;
-  std::string m_shortName;
-  bool m_enable;
-  LogTypes::LOG_LEVELS m_level;
-  BitSet32 m_listener_ids;
-};
-
-class ConsoleListener;
+class LogContainer;
 
 class LogManager : NonCopyable
 {
-private:
-  LogContainer* m_Log[LogTypes::NUMBER_OF_LOGS];
-  static LogManager* m_logManager;  // Singleton. Ugh.
-  std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
-  size_t m_path_cutoff_point = 0;
-
-  LogManager();
-  ~LogManager();
-
 public:
-  static u32 GetMaxLevel() { return MAX_LOGLEVEL; }
+  static LogManager* GetInstance();
+  static void Init();
+  static void Shutdown();
+
   void Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file, int line,
            const char* fmt, va_list args);
   void LogWithFullPath(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file,
                        int line, const char* fmt, va_list args);
 
-  void SetLogLevel(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level)
-  {
-    m_Log[type]->SetLevel(level);
-  }
+  void SetLogLevel(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level);
 
-  void SetEnable(LogTypes::LOG_TYPE type, bool enable) { m_Log[type]->SetEnable(enable); }
-  bool IsEnabled(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level = LogTypes::LNOTICE) const
-  {
-    return m_Log[type]->IsEnabled() && m_Log[type]->GetLevel() >= level;
-  }
+  void SetEnable(LogTypes::LOG_TYPE type, bool enable);
+  bool IsEnabled(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level = LogTypes::LNOTICE) const;
 
-  std::string GetShortName(LogTypes::LOG_TYPE type) const { return m_Log[type]->GetShortName(); }
-  std::string GetFullName(LogTypes::LOG_TYPE type) const { return m_Log[type]->GetFullName(); }
-  void RegisterListener(LogListener::LISTENER id, LogListener* listener)
-  {
-    m_listeners[id] = listener;
-  }
+  std::string GetShortName(LogTypes::LOG_TYPE type) const;
+  std::string GetFullName(LogTypes::LOG_TYPE type) const;
+  void RegisterListener(LogListener::LISTENER id, LogListener* listener);
+  void AddListener(LogTypes::LOG_TYPE type, LogListener::LISTENER id);
+  void RemoveListener(LogTypes::LOG_TYPE type, LogListener::LISTENER id);
 
-  void AddListener(LogTypes::LOG_TYPE type, LogListener::LISTENER id)
-  {
-    m_Log[type]->AddListener(id);
-  }
+private:
+  LogManager();
+  ~LogManager();
 
-  void RemoveListener(LogTypes::LOG_TYPE type, LogListener::LISTENER id)
-  {
-    m_Log[type]->RemoveListener(id);
-  }
-
-  static LogManager* GetInstance() { return m_logManager; }
-  static void SetInstance(LogManager* logManager) { m_logManager = logManager; }
-  static void Init();
-  static void Shutdown();
+  LogContainer* m_log[LogTypes::NUMBER_OF_LOGS];
+  std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
+  size_t m_path_cutoff_point = 0;
 };

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <cstdarg>
-#include <string>
 
 #include "Common/BitSet.h"
 #include "Common/Logging/Log.h"
@@ -29,8 +28,6 @@ public:
   };
 };
 
-class LogContainer;
-
 class LogManager : NonCopyable
 {
 public:
@@ -49,19 +46,26 @@ public:
   void SetEnable(LogTypes::LOG_TYPE type, bool enable);
   bool IsEnabled(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level = LogTypes::LNOTICE) const;
 
-  std::string GetShortName(LogTypes::LOG_TYPE type) const;
-  std::string GetFullName(LogTypes::LOG_TYPE type) const;
+  const char* GetShortName(LogTypes::LOG_TYPE type) const;
+  const char* GetFullName(LogTypes::LOG_TYPE type) const;
 
   void RegisterListener(LogListener::LISTENER id, LogListener* listener);
   void EnableListener(LogListener::LISTENER id, bool enable);
   bool IsListenerEnabled(LogListener::LISTENER id) const;
 
 private:
+  struct LogContainer
+  {
+    const char* m_short_name;
+    const char* m_full_name;
+    bool m_enable = false;
+  };
+
   LogManager();
   ~LogManager();
 
   LogTypes::LOG_LEVELS m_level;
-  LogContainer* m_log[LogTypes::NUMBER_OF_LOGS];
+  std::array<LogContainer, LogTypes::NUMBER_OF_LOGS> m_log{};
   std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
   BitSet32 m_listener_ids;
   size_t m_path_cutoff_point = 0;

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -42,7 +42,8 @@ public:
   void LogWithFullPath(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file,
                        int line, const char* fmt, va_list args);
 
-  void SetLogLevel(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level);
+  LogTypes::LOG_LEVELS GetLogLevel() const;
+  void SetLogLevel(LogTypes::LOG_LEVELS level);
 
   void SetEnable(LogTypes::LOG_TYPE type, bool enable);
   bool IsEnabled(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level = LogTypes::LNOTICE) const;
@@ -57,6 +58,7 @@ private:
   LogManager();
   ~LogManager();
 
+  LogTypes::LOG_LEVELS m_level;
   LogContainer* m_log[LogTypes::NUMBER_OF_LOGS];
   std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
   size_t m_path_cutoff_point = 0;

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -53,6 +53,8 @@ public:
   void EnableListener(LogListener::LISTENER id, bool enable);
   bool IsListenerEnabled(LogListener::LISTENER id) const;
 
+  void SaveSettings();
+
 private:
   struct LogContainer
   {

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -8,6 +8,7 @@
 #include <cstdarg>
 #include <string>
 
+#include "Common/BitSet.h"
 #include "Common/Logging/Log.h"
 #include "Common/NonCopyable.h"
 
@@ -50,9 +51,10 @@ public:
 
   std::string GetShortName(LogTypes::LOG_TYPE type) const;
   std::string GetFullName(LogTypes::LOG_TYPE type) const;
+
   void RegisterListener(LogListener::LISTENER id, LogListener* listener);
-  void AddListener(LogTypes::LOG_TYPE type, LogListener::LISTENER id);
-  void RemoveListener(LogTypes::LOG_TYPE type, LogListener::LISTENER id);
+  void EnableListener(LogListener::LISTENER id, bool enable);
+  bool IsListenerEnabled(LogListener::LISTENER id) const;
 
 private:
   LogManager();
@@ -61,5 +63,6 @@ private:
   LogTypes::LOG_LEVELS m_level;
   LogContainer* m_log[LogTypes::NUMBER_OF_LOGS];
   std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
+  BitSet32 m_listener_ids;
   size_t m_path_cutoff_point = 0;
 };

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -33,7 +33,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
-#include "Common/Logging/LogManager.h"
+#include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
@@ -278,7 +278,7 @@ static void LogInfo(const char* format, ...)
   if (s_disable_logging)
     return;
   bool use_internal_log = s_use_internal_log.load(std::memory_order_relaxed);
-  if (LogManager::GetMaxLevel() < LogTypes::LINFO && !use_internal_log)
+  if (MAX_LOGLEVEL < LogTypes::LINFO && !use_internal_log)
     return;
 
   va_list args;

--- a/Source/Core/DolphinWX/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/LogConfigWindow.cpp
@@ -12,7 +12,6 @@
 #include <wx/validate.h>
 
 #include "Common/FileUtil.h"
-#include "Common/IniFile.h"
 #include "Common/Logging/ConsoleListener.h"
 #include "Common/Logging/Log.h"
 #include "Common/Logging/LogManager.h"
@@ -90,39 +89,18 @@ void LogConfigWindow::CreateGUIControls()
 
 void LogConfigWindow::LoadSettings()
 {
-  IniFile ini;
-  ini.Load(File::GetUserPath(F_LOGGERCONFIG_IDX));
-
-  IniFile::Section* options = ini.GetOrCreateSection("Options");
-
-  // Retrieve the verbosity value from the config ini file.
-  int verbosity;
-  options->Get("Verbosity", &verbosity, 0);
-
-  // Ensure the verbosity level is valid.
-  if (verbosity < 1)
-    verbosity = 1;
-  if (verbosity > MAX_LOGLEVEL)
-    verbosity = MAX_LOGLEVEL;
-
-  // Actually set the logging verbosity.
-  m_verbosity->SetSelection(verbosity - 1);
+  m_verbosity->SetSelection(m_LogManager->GetLogLevel());
 
   // Get the logger output settings from the config ini file.
-  options->Get("WriteToFile", &m_writeFile, false);
-  m_writeFileCB->SetValue(m_writeFile);
-  options->Get("WriteToConsole", &m_writeConsole, true);
-  m_writeConsoleCB->SetValue(m_writeConsole);
-  options->Get("WriteToWindow", &m_writeWindow, true);
-  m_writeWindowCB->SetValue(m_writeWindow);
+  m_writeFileCB->SetValue(m_LogManager->IsListenerEnabled(LogListener::FILE_LISTENER));
+  m_writeConsoleCB->SetValue(m_LogManager->IsListenerEnabled(LogListener::CONSOLE_LISTENER));
+  m_writeWindowCB->SetValue(m_LogManager->IsListenerEnabled(LogListener::LOG_WINDOW_LISTENER));
 
   // Run through all of the log types and check each checkbox for each logging type
   // depending on its set value within the config ini.
   for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
   {
-    bool log_enabled;
-    ini.GetOrCreateSection("Logs")->Get(m_LogManager->GetShortName((LogTypes::LOG_TYPE)i),
-                                        &log_enabled, false);
+    bool log_enabled = m_LogManager->IsEnabled(static_cast<LogTypes::LOG_TYPE>(i));
 
     if (log_enabled)
       enableAll = false;
@@ -147,20 +125,17 @@ void LogConfigWindow::OnVerbosityChange(wxCommandEvent& event)
 
 void LogConfigWindow::OnWriteFileChecked(wxCommandEvent& event)
 {
-  m_writeFile = event.IsChecked();
-  m_LogManager->EnableListener(LogListener::FILE_LISTENER, m_writeFile);
+  m_LogManager->EnableListener(LogListener::FILE_LISTENER, event.IsChecked());
 }
 
 void LogConfigWindow::OnWriteConsoleChecked(wxCommandEvent& event)
 {
-  m_writeConsole = event.IsChecked();
-  m_LogManager->EnableListener(LogListener::CONSOLE_LISTENER, m_writeConsole);
+  m_LogManager->EnableListener(LogListener::CONSOLE_LISTENER, event.IsChecked());
 }
 
 void LogConfigWindow::OnWriteWindowChecked(wxCommandEvent& event)
 {
-  m_writeWindow = event.IsChecked();
-  m_LogManager->EnableListener(LogListener::LOG_WINDOW_LISTENER, m_writeWindow);
+  m_LogManager->EnableListener(LogListener::LOG_WINDOW_LISTENER, event.IsChecked());
 }
 
 void LogConfigWindow::OnToggleAll(wxCommandEvent& WXUNUSED(event))

--- a/Source/Core/DolphinWX/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/LogConfigWindow.cpp
@@ -155,14 +155,8 @@ void LogConfigWindow::SaveSettings()
 // If the verbosity changes while logging
 void LogConfigWindow::OnVerbosityChange(wxCommandEvent& event)
 {
-  // Get the new verbosity
   int v = m_verbosity->GetSelection() + 1;
-
-  // Set all log types to that verbosity level
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++)
-  {
-    m_LogManager->SetLogLevel((LogTypes::LOG_TYPE)i, (LogTypes::LOG_LEVELS)v);
-  }
+  m_LogManager->SetLogLevel(static_cast<LogTypes::LOG_LEVELS>(v));
 
   event.Skip();
 }

--- a/Source/Core/DolphinWX/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/LogConfigWindow.cpp
@@ -163,47 +163,20 @@ void LogConfigWindow::OnVerbosityChange(wxCommandEvent& event)
 
 void LogConfigWindow::OnWriteFileChecked(wxCommandEvent& event)
 {
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-  {
-    m_writeFile = event.IsChecked();
-    if (m_checks->IsChecked(i))
-    {
-      if (m_writeFile)
-        m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
-      else
-        m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
-    }
-  }
+  m_writeFile = event.IsChecked();
+  m_LogManager->EnableListener(LogListener::FILE_LISTENER, m_writeFile);
 }
 
 void LogConfigWindow::OnWriteConsoleChecked(wxCommandEvent& event)
 {
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-  {
-    m_writeConsole = event.IsChecked();
-    if (m_checks->IsChecked(i))
-    {
-      if (m_writeConsole)
-        m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::CONSOLE_LISTENER);
-      else
-        m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::CONSOLE_LISTENER);
-    }
-  }
+  m_writeConsole = event.IsChecked();
+  m_LogManager->EnableListener(LogListener::CONSOLE_LISTENER, m_writeConsole);
 }
 
 void LogConfigWindow::OnWriteWindowChecked(wxCommandEvent& event)
 {
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-  {
-    m_writeWindow = event.IsChecked();
-    if (m_checks->IsChecked(i))
-    {
-      if (m_writeWindow)
-        m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
-      else
-        m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
-    }
-  }
+  m_writeWindow = event.IsChecked();
+  m_LogManager->EnableListener(LogListener::LOG_WINDOW_LISTENER, m_writeWindow);
 }
 
 void LogConfigWindow::OnToggleAll(wxCommandEvent& WXUNUSED(event))
@@ -217,26 +190,8 @@ void LogConfigWindow::OnToggleAll(wxCommandEvent& WXUNUSED(event))
 void LogConfigWindow::ToggleLog(int _logType, bool enable)
 {
   LogTypes::LOG_TYPE logType = (LogTypes::LOG_TYPE)_logType;
-
   m_checks->Check(_logType, enable);
-
   m_LogManager->SetEnable(logType, enable);
-
-  if (enable)
-  {
-    if (m_writeWindow)
-      m_LogManager->AddListener(logType, LogListener::LOG_WINDOW_LISTENER);
-    if (m_writeFile)
-      m_LogManager->AddListener(logType, LogListener::FILE_LISTENER);
-    if (m_writeConsole)
-      m_LogManager->AddListener(logType, LogListener::CONSOLE_LISTENER);
-  }
-  else
-  {
-    m_LogManager->RemoveListener(logType, LogListener::LOG_WINDOW_LISTENER);
-    m_LogManager->RemoveListener(logType, LogListener::FILE_LISTENER);
-    m_LogManager->RemoveListener(logType, LogListener::CONSOLE_LISTENER);
-  }
 }
 
 void LogConfigWindow::OnLogCheck(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/LogConfigWindow.cpp
@@ -133,23 +133,7 @@ void LogConfigWindow::LoadSettings()
 
 void LogConfigWindow::SaveSettings()
 {
-  IniFile ini;
-  ini.Load(File::GetUserPath(F_LOGGERCONFIG_IDX));
-
-  IniFile::Section* options = ini.GetOrCreateSection("Options");
-  options->Set("Verbosity", m_verbosity->GetSelection() + 1);
-  options->Set("WriteToFile", m_writeFile);
-  options->Set("WriteToConsole", m_writeConsole);
-  options->Set("WriteToWindow", m_writeWindow);
-
-  // Save all enabled/disabled states of the log types to the config ini.
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-  {
-    ini.GetOrCreateSection("Logs")->Set(m_LogManager->GetShortName((LogTypes::LOG_TYPE)i),
-                                        m_checks->IsChecked(i));
-  }
-
-  ini.Save(File::GetUserPath(F_LOGGERCONFIG_IDX));
+  m_LogManager->SaveSettings();
 }
 
 // If the verbosity changes while logging

--- a/Source/Core/DolphinWX/LogConfigWindow.h
+++ b/Source/Core/DolphinWX/LogConfigWindow.h
@@ -22,7 +22,6 @@ public:
 
 private:
   LogManager* m_LogManager;
-  bool m_writeFile, m_writeConsole, m_writeWindow;
   bool enableAll;
 
   // Controls

--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -133,11 +133,7 @@ void CLogWindow::RemoveAllListeners()
     return;
   m_has_listeners = false;
 
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-  {
-    m_LogManager->RemoveListener(static_cast<LogTypes::LOG_TYPE>(i),
-                                 LogListener::LOG_WINDOW_LISTENER);
-  }
+  m_LogManager->EnableListener(LogListener::LOG_WINDOW_LISTENER, false);
 }
 
 void CLogWindow::SaveSettings()


### PR DESCRIPTION
LogManager was exposing functionality that was 1) never used and 2) doesn't align with what's in the config files.

This PR gets rid of that functionality, aligns the public API with that needed by config files/the UI, removes manual INI loading/saving from DolphinWX, and does a few small  other cleanups.