### PR TITLE
[WIP] Custom Textures Prefetcher Overhaul Various, Per Extension Count, New Low RAM Calc

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -75,6 +75,8 @@ const ConfigInfo<bool> GFX_OVERLAY_STATS{{System::GFX, "Settings", "OverlayStats
 const ConfigInfo<bool> GFX_OVERLAY_PROJ_STATS{{System::GFX, "Settings", "OverlayProjStats"}, false};
 const ConfigInfo<bool> GFX_DUMP_TEXTURES{{System::GFX, "Settings", "DumpTextures"}, false};
 const ConfigInfo<bool> GFX_HIRES_TEXTURES{{System::GFX, "Settings", "HiresTextures"}, false};
+const ConfigInfo<double> GFX_HIRESTEX_OVERRIDE_PREFETCH_CULLED_PERCENT{
+    {System::GFX, "Settings", "HiresTexOverridePrefetchCulledPercent"}, 30.0};
 const ConfigInfo<bool> GFX_CONVERT_HIRES_TEXTURES{{System::GFX, "Settings", "ConvertHiresTextures"},
                                                   false};
 const ConfigInfo<bool> GFX_CACHE_HIRES_TEXTURES{{System::GFX, "Settings", "CacheHiresTextures"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -40,6 +40,7 @@ extern const ConfigInfo<bool> GFX_OVERLAY_STATS;
 extern const ConfigInfo<bool> GFX_OVERLAY_PROJ_STATS;
 extern const ConfigInfo<bool> GFX_DUMP_TEXTURES;
 extern const ConfigInfo<bool> GFX_HIRES_TEXTURES;
+extern const ConfigInfo<double> GFX_HIRESTEX_OVERRIDE_PREFETCH_CULLED_PERCENT;
 extern const ConfigInfo<bool> GFX_CONVERT_HIRES_TEXTURES;
 extern const ConfigInfo<bool> GFX_CACHE_HIRES_TEXTURES;
 extern const ConfigInfo<bool> GFX_DUMP_EFB_TARGET;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -34,6 +34,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::GFX_LOG_RENDER_TIME_TO_FILE.location, Config::GFX_OVERLAY_STATS.location,
       Config::GFX_OVERLAY_PROJ_STATS.location, Config::GFX_DUMP_TEXTURES.location,
       Config::GFX_HIRES_TEXTURES.location, Config::GFX_CONVERT_HIRES_TEXTURES.location,
+      Config::GFX_HIRESTEX_OVERRIDE_PREFETCH_CULLED_PERCENT.location,
       Config::GFX_CACHE_HIRES_TEXTURES.location, Config::GFX_DUMP_EFB_TARGET.location,
       Config::GFX_DUMP_FRAMES_AS_IMAGES.location, Config::GFX_FREE_LOOK.location,
       Config::GFX_USE_FFV1.location, Config::GFX_DUMP_FORMAT.location,

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -243,11 +243,13 @@ static wxString xfb_real_desc =
 static wxString dump_textures_desc =
     wxTRANSLATE("Dump decoded game textures to User/Dump/Textures/<game_id>/.\n\nIf unsure, leave "
                 "this unchecked.");
-static wxString load_hires_textures_desc = wxTRANSLATE(
-    "Load custom textures from User/Load/Textures/<game_id>/.\n\nIf unsure, leave this unchecked.");
-static wxString cache_hires_textures_desc =
-    wxTRANSLATE("Cache custom textures to system RAM on startup.\nThis can require exponentially "
-                "more RAM but fixes possible stuttering.\n\nIf unsure, leave this unchecked.");
+static wxString load_hires_textures_desc =
+    wxTRANSLATE("Load custom textures from User/Load/Textures/<game_id>/."
+                "\n\nIf unsure, leave this unchecked.");
+static wxString cache_hires_textures_desc = wxTRANSLATE(
+    "Prefetch custom textures to system RAM on startup.\nThis can require exponentially "
+    "more RAM for non-native texture formats such as PNG, but fixes possible stuttering."
+    "\n\nIf unsure, leave this unchecked.");
 static wxString dump_efb_desc = wxTRANSLATE(
     "Dump the contents of EFB copies to User/Dump/Textures/.\n\nIf unsure, leave this unchecked.");
 static wxString internal_resolution_frame_dumping_desc = wxTRANSLATE(


### PR DESCRIPTION
![gitcontrib_dolphin_customtextures_prefetcheroverhaultake1-perextcount](https://user-images.githubusercontent.com/20824154/27988924-2ce63c9e-642e-11e7-9982-e0fdf8c90c9c.png)

Initially this does not include the option that controls the prefetcher's memory limit to be user configurable in GUI. It could be better for another PR if I don't figure this out soon (1 more day and I need a break), or simply leave it to those who are more GUI experienced. 

But I have already written but not commited some of the code that's in various config files, which should probably make it possible to be at least ini configurable for now, I can update those changes in after I'm sure about which are the only parts needed to make an option ini configurable.

Reopen EDIT: Per-Extension numbers removed in OSD Message, console log only.