### PR TITLE
Make the built-in wiitdb files optional

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -168,6 +168,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("ShowLogConfigWindow", m_InterfaceLogConfigWindow);
   interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
   interface->Set("ShowActiveTitle", m_show_active_title);
+  interface->Set("UseBuiltinTitleDatabase", m_use_builtin_title_database);
   interface->Set("ShowDevelopmentWarning", m_show_development_warning);
   interface->Set("ThemeName", theme_name);
   interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
@@ -481,6 +482,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("ShowLogConfigWindow", &m_InterfaceLogConfigWindow, false);
   interface->Get("ExtendedFPSInfo", &m_InterfaceExtendedFPSInfo, false);
   interface->Get("ShowActiveTitle", &m_show_active_title, true);
+  interface->Get("UseBuiltinTitleDatabase", &m_use_builtin_title_database, true);
   interface->Get("ShowDevelopmentWarning", &m_show_development_warning, true);
   interface->Get("ThemeName", &theme_name, DEFAULT_THEME_DIR);
   interface->Get("PauseOnFocusLost", &m_PauseOnFocusLost, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -257,6 +257,7 @@ struct SConfig : NonCopyable
   bool m_InterfaceLogConfigWindow;
   bool m_InterfaceExtendedFPSInfo;
   bool m_show_active_title = false;
+  bool m_use_builtin_title_database = true;
   bool m_show_development_warning;
 
   bool m_ListDrives;

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -124,6 +124,9 @@ TitleDatabase::TitleDatabase()
   if (!LoadMap(load_directory + "wiitdb.txt", m_gc_title_map, m_wii_title_map))
     LoadMap(load_directory + "titles.txt", m_gc_title_map, m_wii_title_map);
 
+  if (!SConfig::GetInstance().m_use_builtin_title_database)
+    return;
+
   // Load the database in the console language.
   // Note: The GameCube language setting can't be set to Japanese,
   // so instead, we use Japanese names iff the games are NTSC-J.

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -90,6 +90,7 @@ void InterfacePane::CreateInGame()
   m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
   m_checkbox_enable_osd = new QCheckBox(tr("Enable On Screen Messages"));
   m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
+  m_checkbox_use_builtin_title_database = new QCheckBox(tr("Use Built-In Database of Game Names"));
   m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
   m_checkbox_hide_mouse = new QCheckBox(tr("Hide Mouse Cursor"));
 
@@ -97,6 +98,7 @@ void InterfacePane::CreateInGame()
   groupbox_layout->addWidget(m_checkbox_use_panic_handlers);
   groupbox_layout->addWidget(m_checkbox_enable_osd);
   groupbox_layout->addWidget(m_checkbox_show_active_title);
+  groupbox_layout->addWidget(m_checkbox_use_builtin_title_database);
   groupbox_layout->addWidget(m_checkbox_pause_on_focus_lost);
   groupbox_layout->addWidget(m_checkbox_hide_mouse);
 }
@@ -132,6 +134,7 @@ void InterfacePane::LoadConfig()
   m_checkbox_use_panic_handlers->setChecked(startup_params.bUsePanicHandlers);
   m_checkbox_enable_osd->setChecked(startup_params.bOnScreenDisplayMessages);
   m_checkbox_show_active_title->setChecked(startup_params.m_show_active_title);
+  m_checkbox_use_builtin_title_database->setChecked(startup_params.m_use_builtin_title_database);
   m_checkbox_pause_on_focus_lost->setChecked(startup_params.m_PauseOnFocusLost);
   m_checkbox_hide_mouse->setChecked(Settings::Instance().GetHideCursor());
 }
@@ -148,6 +151,7 @@ void InterfacePane::OnSaveConfig()
   settings.bUsePanicHandlers = m_checkbox_use_panic_handlers->isChecked();
   settings.bOnScreenDisplayMessages = m_checkbox_enable_osd->isChecked();
   settings.m_show_active_title = m_checkbox_show_active_title->isChecked();
+  settings.m_use_builtin_title_database = m_checkbox_use_builtin_title_database->isChecked();
   settings.m_PauseOnFocusLost = m_checkbox_pause_on_focus_lost->isChecked();
 
   settings.SaveSettings();

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.h
@@ -36,6 +36,7 @@ private:
   QCheckBox* m_checkbox_use_panic_handlers;
   QCheckBox* m_checkbox_enable_osd;
   QCheckBox* m_checkbox_show_active_title;
+  QCheckBox* m_checkbox_use_builtin_title_database;
   QCheckBox* m_checkbox_pause_on_focus_lost;
   QCheckBox* m_checkbox_hide_mouse;
 };

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -90,6 +90,8 @@ void InterfaceConfigPane::InitializeGUI()
   m_osd_messages_checkbox = new wxCheckBox(this, wxID_ANY, _("On-Screen Display Messages"));
   m_show_active_title_checkbox =
       new wxCheckBox(this, wxID_ANY, _("Show Active Title in Window Title"));
+  m_use_builtin_title_database_checkbox =
+      new wxCheckBox(this, wxID_ANY, _("Use Built-In Database of Game Names"));
   m_pause_focus_lost_checkbox = new wxCheckBox(this, wxID_ANY, _("Pause on Focus Lost"));
   m_interface_lang_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_interface_lang_strings);
@@ -103,6 +105,8 @@ void InterfaceConfigPane::InitializeGUI()
                                 this);
   m_show_active_title_checkbox->Bind(wxEVT_CHECKBOX,
                                      &InterfaceConfigPane::OnShowActiveTitleCheckBoxChanged, this);
+  m_use_builtin_title_database_checkbox->Bind(
+      wxEVT_CHECKBOX, &InterfaceConfigPane::OnUseBuiltinTitleDatabaseCheckBoxChanged, this);
   m_pause_focus_lost_checkbox->Bind(wxEVT_CHECKBOX,
                                     &InterfaceConfigPane::OnPauseOnFocusLostCheckBoxChanged, this);
   m_interface_lang_choice->Bind(wxEVT_CHOICE,
@@ -119,6 +123,10 @@ void InterfaceConfigPane::InitializeGUI()
         "writes, video backend and CPU information, and JIT cache clearing."));
   m_show_active_title_checkbox->SetToolTip(
       _("Show the active title name in the emulation window title."));
+  m_use_builtin_title_database_checkbox->SetToolTip(
+      _("Read game names from an internal database instead of reading names from the games "
+        "themselves, except for games that aren't in the database. The names in the database are "
+        "often more consistently formatted, especially for Wii games."));
   m_pause_focus_lost_checkbox->SetToolTip(
       _("Pauses the emulator when focus is taken away from the emulation window."));
   m_interface_lang_choice->SetToolTip(
@@ -147,6 +155,8 @@ void InterfaceConfigPane::InitializeGUI()
   main_static_box_sizer->AddSpacer(space5);
   main_static_box_sizer->Add(m_show_active_title_checkbox, 0, wxLEFT | wxRIGHT, space5);
   main_static_box_sizer->AddSpacer(space5);
+  main_static_box_sizer->Add(m_use_builtin_title_database_checkbox, 0, wxLEFT | wxRIGHT, space5);
+  main_static_box_sizer->AddSpacer(space5);
   main_static_box_sizer->Add(m_pause_focus_lost_checkbox, 0, wxLEFT | wxRIGHT, space5);
   main_static_box_sizer->AddSpacer(space5);
   main_static_box_sizer->Add(language_and_theme_grid_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
@@ -168,6 +178,7 @@ void InterfaceConfigPane::LoadGUIValues()
   m_panic_handlers_checkbox->SetValue(startup_params.bUsePanicHandlers);
   m_osd_messages_checkbox->SetValue(startup_params.bOnScreenDisplayMessages);
   m_show_active_title_checkbox->SetValue(startup_params.m_show_active_title);
+  m_use_builtin_title_database_checkbox->SetValue(startup_params.m_use_builtin_title_database);
   m_pause_focus_lost_checkbox->SetValue(SConfig::GetInstance().m_PauseOnFocusLost);
 
   const std::string exact_language = SConfig::GetInstance().m_InterfaceLanguage;
@@ -231,6 +242,12 @@ void InterfaceConfigPane::OnOSDMessagesCheckBoxChanged(wxCommandEvent& event)
 void InterfaceConfigPane::OnShowActiveTitleCheckBoxChanged(wxCommandEvent&)
 {
   SConfig::GetInstance().m_show_active_title = m_show_active_title_checkbox->IsChecked();
+}
+
+void InterfaceConfigPane::OnUseBuiltinTitleDatabaseCheckBoxChanged(wxCommandEvent&)
+{
+  SConfig::GetInstance().m_use_builtin_title_database =
+      m_use_builtin_title_database_checkbox->IsChecked();
 }
 
 void InterfaceConfigPane::OnInterfaceLanguageChoiceChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.h
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.h
@@ -25,6 +25,7 @@ private:
   void OnPanicHandlersCheckBoxChanged(wxCommandEvent&);
   void OnOSDMessagesCheckBoxChanged(wxCommandEvent&);
   void OnShowActiveTitleCheckBoxChanged(wxCommandEvent&);
+  void OnUseBuiltinTitleDatabaseCheckBoxChanged(wxCommandEvent&);
   void OnInterfaceLanguageChoiceChanged(wxCommandEvent&);
   void OnPauseOnFocusLostCheckBoxChanged(wxCommandEvent&);
   void OnThemeSelected(wxCommandEvent&);
@@ -35,6 +36,7 @@ private:
   wxCheckBox* m_panic_handlers_checkbox;
   wxCheckBox* m_osd_messages_checkbox;
   wxCheckBox* m_show_active_title_checkbox;
+  wxCheckBox* m_use_builtin_title_database_checkbox;
   wxCheckBox* m_pause_focus_lost_checkbox;
   wxChoice* m_interface_lang_choice;
   wxChoice* m_theme_choice;


### PR DESCRIPTION
There are some cases where overriding the opening.bnr names isn't desirable, such as when someone has several modded versions of a game that differ in names but not game IDs.