### PR TITLE
Unify GetGameIniFilenames

### DIFF
--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <list>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -28,12 +29,16 @@
 
 namespace ConfigLoaders
 {
-using ConfigLocation = Config::ConfigLocation;
-
 // Returns all possible filenames in ascending order of priority
-static std::vector<std::string> GetGameIniFilenames(const std::string& id, u16 revision)
+std::vector<std::string> GetGameIniFilenames(const std::string& id, std::optional<u16> revision)
 {
   std::vector<std::string> filenames;
+
+  if (id.empty())
+    return filenames;
+
+  // INIs that match the system code (unique for each Virtual Console system)
+  filenames.push_back(id.substr(0, 1) + ".ini");
 
   // INIs that match all regions
   if (id.size() >= 4)
@@ -43,11 +48,13 @@ static std::vector<std::string> GetGameIniFilenames(const std::string& id, u16 r
   filenames.push_back(id + ".ini");
 
   // INIs with specific revisions
-  filenames.push_back(id + StringFromFormat("r%d", revision) + ".ini");
+  if (revision)
+    filenames.push_back(id + StringFromFormat("r%d", *revision) + ".ini");
 
   return filenames;
 }
 
+using ConfigLocation = Config::ConfigLocation;
 using INIToLocationMap = std::map<std::pair<std::string, std::string>, ConfigLocation>;
 
 // This is a mapping from the legacy section-key pairs to ConfigLocations.

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.h
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.h
@@ -6,7 +6,9 @@
 
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 
@@ -17,6 +19,8 @@ class ConfigLayerLoader;
 
 namespace ConfigLoaders
 {
+std::vector<std::string> GetGameIniFilenames(const std::string& id, std::optional<u16> revision);
+
 std::unique_ptr<Config::ConfigLayerLoader> GenerateGlobalGameConfigLoader(const std::string& id,
                                                                           u16 revision);
 std::unique_ptr<Config::ConfigLayerLoader> GenerateLocalGameConfigLoader(const std::string& id,

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -26,6 +26,7 @@
 
 #include "Core/Analytics.h"
 #include "Core/Boot/Boot.h"
+#include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/Core.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
 #include "Core/HLE/HLE.h"
@@ -1082,7 +1083,7 @@ IniFile SConfig::LoadGameIni() const
 IniFile SConfig::LoadDefaultGameIni(const std::string& id, std::optional<u16> revision)
 {
   IniFile game_ini;
-  for (const std::string& filename : GetGameIniFilenames(id, revision))
+  for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))
     game_ini.Load(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + filename, true);
   return game_ini;
 }
@@ -1090,7 +1091,7 @@ IniFile SConfig::LoadDefaultGameIni(const std::string& id, std::optional<u16> re
 IniFile SConfig::LoadLocalGameIni(const std::string& id, std::optional<u16> revision)
 {
   IniFile game_ini;
-  for (const std::string& filename : GetGameIniFilenames(id, revision))
+  for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))
     game_ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + filename, true);
   return game_ini;
 }
@@ -1098,35 +1099,9 @@ IniFile SConfig::LoadLocalGameIni(const std::string& id, std::optional<u16> revi
 IniFile SConfig::LoadGameIni(const std::string& id, std::optional<u16> revision)
 {
   IniFile game_ini;
-  for (const std::string& filename : GetGameIniFilenames(id, revision))
+  for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))
     game_ini.Load(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + filename, true);
-  for (const std::string& filename : GetGameIniFilenames(id, revision))
+  for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))
     game_ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + filename, true);
   return game_ini;
-}
-
-// Returns all possible filenames in ascending order of priority
-std::vector<std::string> SConfig::GetGameIniFilenames(const std::string& id,
-                                                      std::optional<u16> revision)
-{
-  std::vector<std::string> filenames;
-
-  if (id.empty())
-    return filenames;
-
-  // INIs that match the system code (unique for each Virtual Console system)
-  filenames.push_back(id.substr(0, 1) + ".ini");
-
-  // INIs that match all regions
-  if (id.size() >= 4)
-    filenames.push_back(id.substr(0, 3) + ".ini");
-
-  // Regular INIs
-  filenames.push_back(id + ".ini");
-
-  // INIs with specific revisions
-  if (revision)
-    filenames.push_back(id + StringFromFormat("r%d", *revision) + ".ini");
-
-  return filenames;
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -231,9 +231,6 @@ struct SConfig : NonCopyable
   static IniFile LoadLocalGameIni(const std::string& id, std::optional<u16> revision);
   static IniFile LoadGameIni(const std::string& id, std::optional<u16> revision);
 
-  static std::vector<std::string> GetGameIniFilenames(const std::string& id,
-                                                      std::optional<u16> revision);
-
   std::string m_NANDPath;
   std::string m_DumpPath;
 

--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
@@ -40,6 +40,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
+#include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/GeckoCodeConfig.h"
@@ -444,7 +445,7 @@ void CISOProperties::CreateGUIControls()
 
   // If there is no default gameini, disable the button.
   const std::vector<std::string> ini_names =
-      SConfig::GetGameIniFilenames(game_id, m_open_iso->GetRevision());
+      ConfigLoaders::GetGameIniFilenames(game_id, m_open_iso->GetRevision());
   const bool game_ini_exists =
       std::any_of(ini_names.cbegin(), ini_names.cend(), [](const std::string& name) {
         return File::Exists(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + name);
@@ -752,7 +753,7 @@ void CISOProperties::OnChangeTitle(wxCommandEvent& event)
 void CISOProperties::OnShowDefaultConfig(wxCommandEvent& WXUNUSED(event))
 {
   for (const std::string& filename :
-       SConfig::GetGameIniFilenames(game_id, m_open_iso->GetRevision()))
+       ConfigLoaders::GetGameIniFilenames(game_id, m_open_iso->GetRevision()))
   {
     std::string path = File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + filename;
     if (File::Exists(path))


### PR DESCRIPTION
This deduplicates code and fixes the new config system's lack of 1-char game ID INI support. (See https://forums.dolphin-emu.org/Thread-vc-games-are-broken-after-dolphin-master-5-0-4171-x64)