### PR TITLE
DolphinWX: fix input bitmaps not working when background input is off

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -125,7 +125,7 @@ void Host_SetStartupDebuggingParameters()
 {
 }
 
-bool Host_UIHasFocus()
+bool Host_UINeedsControllerState()
 {
   return true;
 }

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -23,7 +23,7 @@
 // The host can be just a command line app that opens a window, or a full blown debugger
 // interface.
 
-bool Host_UIHasFocus();
+bool Host_UINeedsControllerState();
 bool Host_RendererHasFocus();
 bool Host_RendererIsFullscreen();
 void Host_ConnectWiimote(int wm_idx, bool connect);

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -116,7 +116,7 @@ void Host_RequestRenderWindowSize(int width, int height)
 {
 }
 
-bool Host_UIHasFocus()
+bool Host_UINeedsControllerState()
 {
   return false;
 }

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -103,7 +103,7 @@ void Host_UpdateMainFrame()
 void Host_RequestRenderWindowSize(int w, int h)
 {
 }
-bool Host_UIHasFocus()
+bool Host_UINeedsControllerState()
 {
   return false;
 }

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SRCS
   PostProcessingConfigDiag.cpp
   SoftwareVideoConfigDialog.cpp
   TASInputDlg.cpp
+  UINeedsControllerState.cpp
   VideoConfigDiag.cpp
   WxEventUtils.cpp
   WxUtils.cpp

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj
@@ -125,6 +125,7 @@
     <ClCompile Include="PatchAddEdit.cpp" />
     <ClCompile Include="SoftwareVideoConfigDialog.cpp" />
     <ClCompile Include="TASInputDlg.cpp" />
+    <ClCompile Include="UINeedsControllerState.cpp" />
     <ClCompile Include="VideoConfigDiag.cpp" />
     <ClCompile Include="PostProcessingConfigDiag.cpp" />
     <ClCompile Include="ControllerConfigDiag.cpp" />
@@ -203,6 +204,7 @@
     <ClInclude Include="PatchAddEdit.h" />
     <ClInclude Include="SoftwareVideoConfigDialog.h" />
     <ClInclude Include="TASInputDlg.h" />
+    <ClInclude Include="UINeedsControllerState.h" />
     <ClInclude Include="VideoConfigDiag.h" />
     <ClInclude Include="PostProcessingConfigDiag.h" />
     <ClInclude Include="ControllerConfigDiag.h" />

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
@@ -196,6 +196,9 @@
     <ClCompile Include="TASInputDlg.cpp">
       <Filter>GUI</Filter>
     </ClCompile>
+    <ClCompile Include="UINeedsControllerState.cpp">
+      <Filter>GUI</Filter>
+    </ClCompile>
     <ClCompile Include="SoftwareVideoConfigDialog.cpp">
       <Filter>GUI\Video</Filter>
     </ClCompile>
@@ -418,6 +421,9 @@
       <Filter>GUI</Filter>
     </ClInclude>
     <ClInclude Include="TASInputDlg.h">
+      <Filter>GUI</Filter>
+    </ClInclude>
+    <ClInclude Include="UINeedsControllerState.h">
       <Filter>GUI</Filter>
     </ClInclude>
     <ClInclude Include="SoftwareVideoConfigDialog.h">

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -55,6 +55,7 @@
 #include "DolphinWX/Input/GuitarInputConfigDiag.h"
 #include "DolphinWX/Input/NunchukInputConfigDiag.h"
 #include "DolphinWX/Input/TurntableInputConfigDiag.h"
+#include "DolphinWX/UINeedsControllerState.h"
 #include "DolphinWX/WxUtils.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
@@ -1259,6 +1260,7 @@ InputConfigDialog::InputConfigDialog(wxWindow* const parent, InputConfig& config
 {
   Bind(wxEVT_CLOSE_WINDOW, &InputConfigDialog::OnClose, this);
   Bind(wxEVT_BUTTON, &InputConfigDialog::OnCloseButton, this, wxID_CLOSE);
+  Bind(wxEVT_ACTIVATE, &InputConfigDialog::OnActivate, this);
 
   SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
   SetLayoutAdaptationLevel(wxDIALOG_ADAPTATION_STANDARD_SIZER);
@@ -1267,6 +1269,12 @@ InputConfigDialog::InputConfigDialog(wxWindow* const parent, InputConfig& config
   m_update_timer.SetOwner(this);
   Bind(wxEVT_TIMER, &InputConfigDialog::UpdateBitmaps, this);
   m_update_timer.Start(PREVIEW_UPDATE_TIME, wxTIMER_CONTINUOUS);
+}
+
+void InputConfigDialog::OnActivate(wxActivateEvent& event)
+{
+  // Needed for input bitmaps
+  SetUINeedsControllerState(event.GetActive());
 }
 
 InputEventFilter::InputEventFilter()

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.h
@@ -191,6 +191,7 @@ public:
                     const int port_num = 0);
   virtual ~InputConfigDialog() = default;
 
+  void OnActivate(wxActivateEvent& event);
   void OnClose(wxCloseEvent& event);
   void OnCloseButton(wxCommandEvent& event);
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -47,6 +47,7 @@
 #include "DolphinWX/Main.h"
 #include "DolphinWX/NetPlay/NetWindow.h"
 #include "DolphinWX/SoftwareVideoConfigDialog.h"
+#include "DolphinWX/UINeedsControllerState.h"
 #include "DolphinWX/VideoConfigDiag.h"
 #include "DolphinWX/WxUtils.h"
 
@@ -486,9 +487,9 @@ void Host_SetWiiMoteConnectionState(int _State)
   main_frame->GetEventHandler()->AddPendingEvent(event);
 }
 
-bool Host_UIHasFocus()
+bool Host_UINeedsControllerState()
 {
-  return wxGetApp().IsActiveThreadsafe();
+  return wxGetApp().IsActiveThreadsafe() && GetUINeedsControllerState();
 }
 
 bool Host_RendererHasFocus()

--- a/Source/Core/DolphinWX/UINeedsControllerState.cpp
+++ b/Source/Core/DolphinWX/UINeedsControllerState.cpp
@@ -1,0 +1,17 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <atomic>
+
+static std::atomic<bool> s_needs_controller_state{false};
+
+void SetUINeedsControllerState(bool needs_controller_state)
+{
+  s_needs_controller_state = needs_controller_state;
+}
+
+bool GetUINeedsControllerState()
+{
+  return s_needs_controller_state;
+}

--- a/Source/Core/DolphinWX/UINeedsControllerState.h
+++ b/Source/Core/DolphinWX/UINeedsControllerState.h
@@ -1,0 +1,8 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+void SetUINeedsControllerState(bool needs_controller_state);
+bool GetUINeedsControllerState();

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -17,7 +17,8 @@ constexpr ControlState INPUT_DETECT_THRESHOLD = 0.55;
 
 bool ControlReference::InputGateOn()
 {
-  return SConfig::GetInstance().m_BackgroundInput || Host_RendererHasFocus();
+  return SConfig::GetInstance().m_BackgroundInput || Host_RendererHasFocus() ||
+         Host_UINeedsControllerState();
 }
 
 //

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -39,7 +39,7 @@ void Host_RequestRenderWindowSize(int, int)
 void Host_SetStartupDebuggingParameters()
 {
 }
-bool Host_UIHasFocus()
+bool Host_UINeedsControllerState()
 {
   return false;
 }


### PR DESCRIPTION
Broken by #5731.

This essentially reverts that PR when any input dialogs are focused. Ideally, the UI would be able to get controller state without also enabling it for the emulation, but I didn't see an easy way to do that (`InputGateOn` is all the way down in `ControlReference`, since that's the only piece of "get/set controller state code" that every controller touches).