### PR TITLE
Qt: allow emulation input when background input is disabled

### DIFF
--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -4,55 +4,46 @@
 
 #include <QAbstractEventDispatcher>
 #include <QApplication>
-#include <QMutexLocker>
 
 #include "Common/Common.h"
 #include "Core/Host.h"
 #include "DolphinQt2/Host.h"
-#include "DolphinQt2/MainWindow.h"
 
-Host* Host::m_instance = nullptr;
+Host::Host() = default;
 
 Host* Host::GetInstance()
 {
-  if (m_instance == nullptr)
-    m_instance = new Host();
-  return m_instance;
+  static Host* s_instance = new Host();
+  return s_instance;
 }
 
 void* Host::GetRenderHandle()
 {
-  QMutexLocker locker(&m_lock);
   return m_render_handle;
 }
 
 void Host::SetRenderHandle(void* handle)
 {
-  QMutexLocker locker(&m_lock);
   m_render_handle = handle;
 }
 
 bool Host::GetRenderFocus()
 {
-  QMutexLocker locker(&m_lock);
   return m_render_focus;
 }
 
 void Host::SetRenderFocus(bool focus)
 {
-  QMutexLocker locker(&m_lock);
   m_render_focus = focus;
 }
 
 bool Host::GetRenderFullscreen()
 {
-  QMutexLocker locker(&m_lock);
   return m_render_fullscreen;
 }
 
 void Host::SetRenderFullscreen(bool fullscreen)
 {
-  QMutexLocker locker(&m_lock);
   m_render_fullscreen = fullscreen;
 }
 

--- a/Source/Core/DolphinQt2/Host.h
+++ b/Source/Core/DolphinQt2/Host.h
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <QMutex>
 #include <QObject>
-#include <QSize>
+#include <atomic>
 
 // Singleton that talks to the Core via the interface defined in Core/Host.h.
 // Because Host_* calls might come from different threads than the MainWindow,
@@ -35,11 +34,9 @@ signals:
   void RequestRenderSize(int w, int h);
 
 private:
-  Host() {}
-  static Host* m_instance;
-  QMutex m_lock;
+  Host();
 
-  void* m_render_handle;
-  bool m_render_focus;
-  bool m_render_fullscreen;
+  std::atomic<void*> m_render_handle;
+  std::atomic<bool> m_render_focus;
+  std::atomic<bool> m_render_fullscreen;
 };

--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -14,7 +14,6 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
   setAttribute(Qt::WA_NoSystemBackground, true);
 
   connect(Host::GetInstance(), &Host::RequestTitle, this, &RenderWidget::setWindowTitle);
-  connect(this, &RenderWidget::FocusChanged, Host::GetInstance(), &Host::SetRenderFocus);
   connect(this, &RenderWidget::StateChanged, Host::GetInstance(), &Host::SetRenderFullscreen);
   connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle);
   emit HandleChanged((void*)winId());
@@ -43,9 +42,11 @@ bool RenderWidget::event(QEvent* event)
   case QEvent::WinIdChange:
     emit HandleChanged((void*)winId());
     break;
-  case QEvent::FocusIn:
-  case QEvent::FocusOut:
-    emit FocusChanged(hasFocus());
+  case QEvent::WindowActivate:
+    Host::GetInstance()->SetRenderFocus(true);
+    break;
+  case QEvent::WindowDeactivate:
+    Host::GetInstance()->SetRenderFocus(false);
     break;
   case QEvent::WindowStateChange:
     emit StateChanged(isFullScreen());

--- a/Source/Core/DolphinQt2/RenderWidget.h
+++ b/Source/Core/DolphinQt2/RenderWidget.h
@@ -14,7 +14,7 @@ class RenderWidget final : public QWidget
 public:
   explicit RenderWidget(QWidget* parent = nullptr);
 
-  bool event(QEvent* event);
+  bool event(QEvent* event) override;
 
 signals:
   void EscapePressed();

--- a/Source/Core/DolphinQt2/RenderWidget.h
+++ b/Source/Core/DolphinQt2/RenderWidget.h
@@ -20,7 +20,6 @@ signals:
   void EscapePressed();
   void Closed();
   void HandleChanged(void* handle);
-  void FocusChanged(bool focus);
   void StateChanged(bool fullscreen);
 
 private:


### PR DESCRIPTION
In Qt, "window focus" is exposed through the window activation and deactivation events. The "focus" events refer mainly to keyboard focus.