### PR TITLE
D3D: Utilize ComPtr throughout D3D11 backend

### DIFF
--- a/Source/Core/VideoBackends/D3D/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.cpp
@@ -9,13 +9,13 @@
 
 namespace DX11
 {
-static ID3D11Buffer* s_bbox_buffer;
-static ID3D11Buffer* s_bbox_staging_buffer;
-static ID3D11UnorderedAccessView* s_bbox_uav;
+static ComPtr<ID3D11Buffer> s_bbox_buffer;
+static ComPtr<ID3D11Buffer> s_bbox_staging_buffer;
+static ComPtr<ID3D11UnorderedAccessView> s_bbox_uav;
 
-ID3D11UnorderedAccessView*& BBox::GetUAV()
+ID3D11UnorderedAccessView* BBox::GetUAV()
 {
-  return s_bbox_uav;
+  return s_bbox_uav.Get();
 }
 
 void BBox::Init()
@@ -34,7 +34,7 @@ void BBox::Init()
     HRESULT hr;
     hr = D3D::device->CreateBuffer(&desc, &data, &s_bbox_buffer);
     CHECK(SUCCEEDED(hr), "Create BoundingBox Buffer.");
-    D3D::SetDebugObjectName(s_bbox_buffer, "BoundingBox Buffer");
+    D3D::SetDebugObjectName(s_bbox_buffer.Get(), "BoundingBox Buffer");
 
     // Second to use as a staging buffer.
     desc.Usage = D3D11_USAGE_STAGING;
@@ -42,7 +42,7 @@ void BBox::Init()
     desc.BindFlags = 0;
     hr = D3D::device->CreateBuffer(&desc, nullptr, &s_bbox_staging_buffer);
     CHECK(SUCCEEDED(hr), "Create BoundingBox Staging Buffer.");
-    D3D::SetDebugObjectName(s_bbox_staging_buffer, "BoundingBox Staging Buffer");
+    D3D::SetDebugObjectName(s_bbox_staging_buffer.Get(), "BoundingBox Staging Buffer");
 
     // UAV is required to allow concurrent access.
     D3D11_UNORDERED_ACCESS_VIEW_DESC UAVdesc = {};
@@ -51,36 +51,36 @@ void BBox::Init()
     UAVdesc.Buffer.FirstElement = 0;
     UAVdesc.Buffer.Flags = 0;
     UAVdesc.Buffer.NumElements = 4;
-    hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer, &UAVdesc, &s_bbox_uav);
+    hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer.Get(), &UAVdesc, &s_bbox_uav);
     CHECK(SUCCEEDED(hr), "Create BoundingBox UAV.");
-    D3D::SetDebugObjectName(s_bbox_uav, "BoundingBox UAV");
+    D3D::SetDebugObjectName(s_bbox_uav.Get(), "BoundingBox UAV");
   }
 }
 
 void BBox::Shutdown()
 {
-  SAFE_RELEASE(s_bbox_buffer);
-  SAFE_RELEASE(s_bbox_staging_buffer);
-  SAFE_RELEASE(s_bbox_uav);
+  s_bbox_buffer.Reset();
+  s_bbox_staging_buffer.Reset();
+  s_bbox_uav.Reset();
 }
 
 void BBox::Set(int index, int value)
 {
   D3D11_BOX box{index * sizeof(s32), 0, 0, (index + 1) * sizeof(s32), 1, 1};
-  D3D::context->UpdateSubresource(s_bbox_buffer, 0, &box, &value, 0, 0);
+  D3D::context->UpdateSubresource(s_bbox_buffer.Get(), 0, &box, &value, 0, 0);
 }
 
 int BBox::Get(int index)
 {
   int data = 0;
-  D3D::context->CopyResource(s_bbox_staging_buffer, s_bbox_buffer);
+  D3D::context->CopyResource(s_bbox_staging_buffer.Get(), s_bbox_buffer.Get());
   D3D11_MAPPED_SUBRESOURCE map;
-  HRESULT hr = D3D::context->Map(s_bbox_staging_buffer, 0, D3D11_MAP_READ, 0, &map);
+  HRESULT hr = D3D::context->Map(s_bbox_staging_buffer.Get(), 0, D3D11_MAP_READ, 0, &map);
   if (SUCCEEDED(hr))
   {
     data = ((s32*)map.pData)[index];
   }
-  D3D::context->Unmap(s_bbox_staging_buffer, 0);
+  D3D::context->Unmap(s_bbox_staging_buffer.Get(), 0);
   return data;
 }
 };

--- a/Source/Core/VideoBackends/D3D/BoundingBox.h
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.h
@@ -10,7 +10,7 @@ namespace DX11
 class BBox
 {
 public:
-  static ID3D11UnorderedAccessView*& GetUAV();
+  static ID3D11UnorderedAccessView* GetUAV();
   static void Init();
   static void Shutdown();
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -32,12 +32,12 @@ int d3d_dll_ref = 0;
 
 namespace D3D
 {
-ID3D11Device* device = nullptr;
-ID3D11DeviceContext* context = nullptr;
-static IDXGISwapChain1* swapchain = nullptr;
-static ID3D11Debug* debug = nullptr;
+ComPtr<ID3D11Device> device;
+ComPtr<ID3D11DeviceContext> context;
+static ComPtr<IDXGISwapChain1> swapchain;
+static ComPtr<ID3D11Debug> debug;
 D3D_FEATURE_LEVEL featlevel;
-D3DTexture2D* backbuf = nullptr;
+D3DTexture2D backbuf;
 HWND hWnd;
 
 std::vector<DXGI_SAMPLE_DESC> aa_modes;  // supported AA modes of the current adapter
@@ -184,8 +184,8 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
   // NOTE: D3D 10.0 doesn't support multisampled resources which are bound as depth buffers AND
   // shader resources.
   // Thus, we can't have MSAA with 10.0 level hardware.
-  ID3D11Device* _device;
-  ID3D11DeviceContext* _context;
+  ComPtr<ID3D11Device> _device;
+  ComPtr<ID3D11DeviceContext> _context;
   D3D_FEATURE_LEVEL feat_level;
   HRESULT hr = PD3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr,
                                   D3D11_CREATE_DEVICE_SINGLETHREADED, supported_feature_levels,
@@ -197,8 +197,6 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
     desc.Count = 1;
     desc.Quality = 0;
     _aa_modes.push_back(desc);
-    SAFE_RELEASE(_context);
-    SAFE_RELEASE(_device);
   }
   else
   {
@@ -214,8 +212,6 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
       if (quality_levels > 0)
         _aa_modes.push_back(desc);
     }
-    _context->Release();
-    _device->Release();
   }
   return _aa_modes;
 }
@@ -265,13 +261,13 @@ HRESULT Create(HWND wnd)
     return hr;
   }
 
-  IDXGIFactory2* factory;
+  ComPtr<IDXGIFactory2> factory;
   hr = PCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
   if (FAILED(hr))
     MessageBox(wnd, _T("Failed to create IDXGIFactory object"), _T("Dolphin Direct3D 11 backend"),
                MB_OK | MB_ICONERROR);
 
-  IDXGIAdapter* adapter;
+  ComPtr<IDXGIAdapter> adapter;
   hr = factory->EnumAdapters(g_ActiveConfig.iAdapter, &adapter);
   if (FAILED(hr))
   {
@@ -283,7 +279,7 @@ HRESULT Create(HWND wnd)
   }
 
   // get supported AA modes
-  aa_modes = EnumAAModes(adapter);
+  aa_modes = EnumAAModes(adapter.Get());
 
   if (std::find_if(aa_modes.begin(), aa_modes.end(), [](const DXGI_SAMPLE_DESC& desc) {
         return desc.Count == g_Config.iMultisamples;
@@ -313,16 +309,16 @@ HRESULT Create(HWND wnd)
   // Creating debug devices can sometimes fail if the user doesn't have the correct
   // version of the DirectX SDK. If it does, simply fallback to a non-debug device.
   {
-    hr = PD3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr,
+    hr = PD3D11CreateDevice(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
                             D3D11_CREATE_DEVICE_SINGLETHREADED | D3D11_CREATE_DEVICE_DEBUG,
                             supported_feature_levels, NUM_SUPPORTED_FEATURE_LEVELS,
                             D3D11_SDK_VERSION, &device, &featlevel, &context);
 
     // Debugbreak on D3D error
-    if (SUCCEEDED(hr) && SUCCEEDED(device->QueryInterface(__uuidof(ID3D11Debug), (void**)&debug)))
+    if (SUCCEEDED(hr) && SUCCEEDED(device.As(&debug)))
     {
-      ID3D11InfoQueue* infoQueue = nullptr;
-      if (SUCCEEDED(debug->QueryInterface(__uuidof(ID3D11InfoQueue), (void**)&infoQueue)))
+      ComPtr<ID3D11InfoQueue> infoQueue;
+      if (SUCCEEDED(debug.As(&infoQueue)))
       {
         infoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_CORRUPTION, true);
         infoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_ERROR, true);
@@ -333,7 +329,6 @@ HRESULT Create(HWND wnd)
         filter.DenyList.NumIDs = sizeof(hide) / sizeof(D3D11_MESSAGE_ID);
         filter.DenyList.pIDList = hide;
         infoQueue->AddStorageFilterEntries(&filter);
-        infoQueue->Release();
       }
     }
   }
@@ -341,7 +336,7 @@ HRESULT Create(HWND wnd)
   if (FAILED(hr))
 #endif
   {
-    hr = PD3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr,
+    hr = PD3D11CreateDevice(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
                             D3D11_CREATE_DEVICE_SINGLETHREADED, supported_feature_levels,
                             NUM_SUPPORTED_FEATURE_LEVELS, D3D11_SDK_VERSION, &device, &featlevel,
                             &context);
@@ -349,14 +344,14 @@ HRESULT Create(HWND wnd)
 
   if (SUCCEEDED(hr))
   {
-    hr = factory->CreateSwapChainForHwnd(device, hWnd, &swap_chain_desc, nullptr, nullptr,
+    hr = factory->CreateSwapChainForHwnd(device.Get(), hWnd, &swap_chain_desc, nullptr, nullptr,
                                          &swapchain);
     if (FAILED(hr))
     {
       // Flip-model swapchains aren't supported on Windows 7, so here we fall back to a legacy
       // BitBlt-model swapchain
       swap_chain_desc.SwapEffect = DXGI_SWAP_EFFECT_SEQUENTIAL;
-      hr = factory->CreateSwapChainForHwnd(device, hWnd, &swap_chain_desc, nullptr, nullptr,
+      hr = factory->CreateSwapChainForHwnd(device.Get(), hWnd, &swap_chain_desc, nullptr, nullptr,
                                            &swapchain);
     }
   }
@@ -367,9 +362,9 @@ HRESULT Create(HWND wnd)
         wnd,
         _T("Failed to initialize Direct3D.\nMake sure your video card supports at least D3D 10.0"),
         _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
-    SAFE_RELEASE(device);
-    SAFE_RELEASE(context);
-    SAFE_RELEASE(swapchain);
+    device.Reset();
+    context.Reset();
+    swapchain.Reset();
     return E_FAIL;
   }
 
@@ -381,35 +376,35 @@ HRESULT Create(HWND wnd)
     MessageBox(wnd, _T("Failed to associate the window"), _T("Dolphin Direct3D 11 backend"),
                MB_OK | MB_ICONERROR);
 
-  SetDebugObjectName((ID3D11DeviceChild*)context, "device context");
-  SAFE_RELEASE(factory);
-  SAFE_RELEASE(adapter);
+  SetDebugObjectName(context.Get(), "device context");
+  factory.Reset();
+  adapter.Reset();
 
-  ID3D11Texture2D* buf;
-  hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, (void**)&buf);
+  ComPtr<ID3D11Texture2D> buf;
+  hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, &buf);
   if (FAILED(hr))
   {
     MessageBox(wnd, _T("Failed to get swapchain buffer"), _T("Dolphin Direct3D 11 backend"),
                MB_OK | MB_ICONERROR);
-    SAFE_RELEASE(device);
-    SAFE_RELEASE(context);
-    SAFE_RELEASE(swapchain);
+    device.Reset();
+    context.Reset();
+    swapchain.Reset();
     return E_FAIL;
   }
-  backbuf = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-  SAFE_RELEASE(buf);
-  CHECK(backbuf != nullptr, "Create back buffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
+  backbuf.InitializeFromExisting(buf.Get(), D3D11_BIND_RENDER_TARGET);
+  buf.Reset();
+  CHECK(backbuf.GetTex() != nullptr, "Create back buffer texture");
+  SetDebugObjectName(backbuf.GetTex(), "backbuffer texture");
+  SetDebugObjectName(backbuf.GetRTV(), "backbuffer render target view");
 
-  context->OMSetRenderTargets(1, &backbuf->GetRTV(), nullptr);
+  D3D::SetRenderTarget(backbuf.GetRTV(), nullptr);
 
   // BGRA textures are easier to deal with in TextureCache, but might not be supported by the
   // hardware
   UINT format_support;
   device->CheckFormatSupport(DXGI_FORMAT_B8G8R8A8_UNORM, &format_support);
   bgra_textures_supported = (format_support & D3D11_FORMAT_SUPPORT_TEXTURE2D) != 0;
-  g_Config.backend_info.bSupportsST3CTextures = SupportsS3TCTextures(device);
+  g_Config.backend_info.bSupportsST3CTextures = SupportsS3TCTextures(device.Get());
 
   stateman = new StateManager;
   return S_OK;
@@ -422,13 +417,13 @@ void Close()
 
   // release all bound resources
   context->ClearState();
-  SAFE_RELEASE(backbuf);
-  SAFE_RELEASE(swapchain);
+  backbuf.Reset();
+  swapchain.Reset();
   SAFE_DELETE(stateman);
   context->Flush();  // immediately destroy device objects
 
-  SAFE_RELEASE(context);
-  ULONG references = device->Release();
+  context.Reset();
+  ULONG references = device.Reset();
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   if (debug)
@@ -440,7 +435,7 @@ void Close()
       // note this will also print out internal live objects to the debug console
       debug->ReportLiveDeviceObjects(D3D11_RLDO_SUMMARY | D3D11_RLDO_DETAIL);
     }
-    SAFE_RELEASE(debug)
+    debug.Reset();
   }
 #endif
 
@@ -452,7 +447,7 @@ void Close()
   {
     NOTICE_LOG(VIDEO, "Successfully released all device references!");
   }
-  device = nullptr;
+  device.Reset();
 
   // unload DLLs
   UnloadD3D();
@@ -489,7 +484,7 @@ const char* PixelShaderVersionString()
     return "ps_4_0";
 }
 
-D3DTexture2D*& GetBackBuffer()
+D3DTexture2D& GetBackBuffer()
 {
   return backbuf;
 }
@@ -535,7 +530,7 @@ u32 GetMaxTextureSize(D3D_FEATURE_LEVEL feature_level)
 void Reset()
 {
   // release all back buffer references
-  SAFE_RELEASE(backbuf);
+  backbuf.Reset();
 
   // resize swapchain buffers
   RECT client;
@@ -545,22 +540,21 @@ void Reset()
   D3D::swapchain->ResizeBuffers(NUM_SWAPCHAIN_BUFFERS, xres, yres, DXGI_FORMAT_R8G8B8A8_UNORM, 0);
 
   // recreate back buffer texture
-  ID3D11Texture2D* buf;
-  HRESULT hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, (void**)&buf);
+  ComPtr<ID3D11Texture2D> buf;
+  HRESULT hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, &buf);
   if (FAILED(hr))
   {
     MessageBox(hWnd, _T("Failed to get swapchain buffer"), _T("Dolphin Direct3D 11 backend"),
                MB_OK | MB_ICONERROR);
-    SAFE_RELEASE(device);
-    SAFE_RELEASE(context);
-    SAFE_RELEASE(swapchain);
+    device.Reset();
+    context.Reset();
+    swapchain.Reset();
     return;
   }
-  backbuf = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-  SAFE_RELEASE(buf);
-  CHECK(backbuf != nullptr, "Create back buffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
+  backbuf.InitializeFromExisting(buf.Get(), D3D11_BIND_RENDER_TARGET);
+  CHECK(backbuf.GetTex() != nullptr, "Create back buffer texture");
+  SetDebugObjectName(backbuf.GetTex(), "backbuffer texture");
+  SetDebugObjectName(backbuf.GetRTV(), "backbuffer render target view");
 }
 
 bool BeginFrame()
@@ -604,6 +598,36 @@ bool GetFullscreenState()
   BOOL state = FALSE;
   swapchain->GetFullscreenState(&state, nullptr);
   return !!state;
+}
+
+void SetDebugObjectName(ID3D11DeviceChild* resource, const char* name)
+{
+#if defined(_DEBUG) || defined(DEBUGFAST)
+  if (resource)
+    resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
+#endif
+}
+
+std::string GetDebugObjectName(ID3D11DeviceChild* resource)
+{
+  std::string name;
+#if defined(_DEBUG) || defined(DEBUGFAST)
+  if (resource)
+  {
+    UINT size = 0;
+    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr);  // get required size
+    name.resize(size + 1);
+    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, &name[0]);
+    // ensure name is null-terminated
+    name[size] = '\0';
+  }
+#endif
+  return name;
+}
+
+void SetRenderTarget(ID3D11RenderTargetView* rtv, ID3D11DepthStencilView* dsv)
+{
+  D3D::context->OMSetRenderTargets(1, &rtv, dsv);
 }
 
 }  // namespace D3D

--- a/Source/Core/VideoBackends/D3D/D3DBlob.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBlob.cpp
@@ -21,13 +21,12 @@ D3DBlob::D3DBlob(ID3D10Blob* d3dblob) : ref(1)
   blob = d3dblob;
   data = (u8*)blob->GetBufferPointer();
   size = (unsigned int)blob->GetBufferSize();
-  d3dblob->AddRef();
 }
 
 D3DBlob::~D3DBlob()
 {
   if (blob)
-    blob->Release();
+    blob.Reset();
   else
     delete[] data;
 }

--- a/Source/Core/VideoBackends/D3D/D3DBlob.h
+++ b/Source/Core/VideoBackends/D3D/D3DBlob.h
@@ -5,12 +5,14 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 
 struct ID3D10Blob;
 
 namespace DX11
 {
-// use this class instead ID3D10Blob or ID3D11Blob whenever possible
+// use this class instead ID3D10Blob or ID3D11Blob whenever possible.
+// D3DBlob is not a COM object, but it is compatible with ComPtr.
 class D3DBlob
 {
 public:
@@ -33,7 +35,7 @@ private:
   unsigned int size;
 
   u8* data;
-  ID3D10Blob* blob;
+  ComPtr<ID3D10Blob> blob;
 };
 
 }  // namespace

--- a/Source/Core/VideoBackends/D3D/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DShader.cpp
@@ -18,9 +18,9 @@ namespace DX11
 namespace D3D
 {
 // bytecode->shader
-ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-  ID3D11VertexShader* v_shader;
+  ComPtr<ID3D11VertexShader> v_shader;
   HRESULT hr = D3D::device->CreateVertexShader(bytecode, len, nullptr, &v_shader);
   if (FAILED(hr))
     return nullptr;
@@ -31,8 +31,8 @@ ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigne
 // code->bytecode
 bool CompileVertexShader(const std::string& code, D3DBlob** blob)
 {
-  ID3D10Blob* shaderBuffer = nullptr;
-  ID3D10Blob* errorBuffer = nullptr;
+  ComPtr<ID3D10Blob> shaderBuffer;
+  ComPtr<ID3D10Blob> errorBuffer;
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   UINT flags = D3D10_SHADER_ENABLE_BACKWARDS_COMPATIBILITY | D3D10_SHADER_DEBUG;
@@ -62,20 +62,19 @@ bool CompileVertexShader(const std::string& code, D3DBlob** blob)
                D3D::VertexShaderVersionString(), (const char*)errorBuffer->GetBufferPointer());
 
     *blob = nullptr;
-    errorBuffer->Release();
   }
   else
   {
-    *blob = new D3DBlob(shaderBuffer);
-    shaderBuffer->Release();
+    *blob = new D3DBlob(shaderBuffer.Get());
   }
   return SUCCEEDED(hr);
 }
 
 // bytecode->shader
-ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode,
+                                                              unsigned int len)
 {
-  ID3D11GeometryShader* g_shader;
+  ComPtr<ID3D11GeometryShader> g_shader;
   HRESULT hr = D3D::device->CreateGeometryShader(bytecode, len, nullptr, &g_shader);
   if (FAILED(hr))
     return nullptr;
@@ -87,8 +86,8 @@ ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, uns
 bool CompileGeometryShader(const std::string& code, D3DBlob** blob,
                            const D3D_SHADER_MACRO* pDefines)
 {
-  ID3D10Blob* shaderBuffer = nullptr;
-  ID3D10Blob* errorBuffer = nullptr;
+  ComPtr<ID3D10Blob> shaderBuffer;
+  ComPtr<ID3D10Blob> errorBuffer;
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   UINT flags = D3D10_SHADER_ENABLE_BACKWARDS_COMPATIBILITY | D3D10_SHADER_DEBUG;
@@ -120,20 +119,18 @@ bool CompileGeometryShader(const std::string& code, D3DBlob** blob,
                D3D::GeometryShaderVersionString(), (const char*)errorBuffer->GetBufferPointer());
 
     *blob = nullptr;
-    errorBuffer->Release();
   }
   else
   {
-    *blob = new D3DBlob(shaderBuffer);
-    shaderBuffer->Release();
+    *blob = new D3DBlob(shaderBuffer.Get());
   }
   return SUCCEEDED(hr);
 }
 
 // bytecode->shader
-ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-  ID3D11PixelShader* p_shader;
+  ComPtr<ID3D11PixelShader> p_shader;
   HRESULT hr = D3D::device->CreatePixelShader(bytecode, len, nullptr, &p_shader);
   if (FAILED(hr))
   {
@@ -146,8 +143,8 @@ ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned 
 // code->bytecode
 bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines)
 {
-  ID3D10Blob* shaderBuffer = nullptr;
-  ID3D10Blob* errorBuffer = nullptr;
+  ComPtr<ID3D10Blob> shaderBuffer;
+  ComPtr<ID3D10Blob> errorBuffer;
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   UINT flags = D3D10_SHADER_DEBUG;
@@ -177,51 +174,43 @@ bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADE
                D3D::PixelShaderVersionString(), (const char*)errorBuffer->GetBufferPointer());
 
     *blob = nullptr;
-    errorBuffer->Release();
   }
   else
   {
-    *blob = new D3DBlob(shaderBuffer);
-    shaderBuffer->Release();
+    *blob = new D3DBlob(shaderBuffer.Get());
   }
 
   return SUCCEEDED(hr);
 }
 
-ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code)
+ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code)
 {
-  D3DBlob* blob = nullptr;
+  ComPtr<D3DBlob> blob;
   if (CompileVertexShader(code, &blob))
   {
-    ID3D11VertexShader* v_shader = CreateVertexShaderFromByteCode(blob);
-    blob->Release();
-    return v_shader;
+    return CreateVertexShaderFromByteCode(blob.Get());
   }
   return nullptr;
 }
 
-ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code,
-                                                     const D3D_SHADER_MACRO* pDefines)
+ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(const std::string& code,
+                                                            const D3D_SHADER_MACRO* pDefines)
 {
-  D3DBlob* blob = nullptr;
+  ComPtr<D3DBlob> blob;
   if (CompileGeometryShader(code, &blob, pDefines))
   {
-    ID3D11GeometryShader* g_shader = CreateGeometryShaderFromByteCode(blob);
-    blob->Release();
-    return g_shader;
+    return CreateGeometryShaderFromByteCode(blob.Get());
   }
   return nullptr;
 }
 
-ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code)
+ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code)
 {
-  D3DBlob* blob = nullptr;
+  ComPtr<D3DBlob> blob;
   CompilePixelShader(code, &blob);
   if (blob)
   {
-    ID3D11PixelShader* p_shader = CreatePixelShaderFromByteCode(blob);
-    blob->Release();
-    return p_shader;
+    return CreatePixelShaderFromByteCode(blob.Get());
   }
   return nullptr;
 }

--- a/Source/Core/VideoBackends/D3D/D3DShader.h
+++ b/Source/Core/VideoBackends/D3D/D3DShader.h
@@ -16,9 +16,10 @@ namespace DX11
 {
 namespace D3D
 {
-ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len);
-ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len);
-ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len);
+ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len);
+ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode,
+                                                              unsigned int len);
+ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len);
 
 // The returned bytecode buffers should be Release()d.
 bool CompileVertexShader(const std::string& code, D3DBlob** blob);
@@ -28,36 +29,36 @@ bool CompilePixelShader(const std::string& code, D3DBlob** blob,
                         const D3D_SHADER_MACRO* pDefines = nullptr);
 
 // Utility functions
-ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code);
-ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code,
-                                                     const D3D_SHADER_MACRO* pDefines = nullptr);
-ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code);
+ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code);
+ComPtr<ID3D11GeometryShader>
+CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines = nullptr);
+ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code);
 
-inline ID3D11VertexShader* CreateVertexShaderFromByteCode(D3DBlob* bytecode)
+inline ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(D3DBlob* bytecode)
 {
   return CreateVertexShaderFromByteCode(bytecode->Data(), bytecode->Size());
 }
-inline ID3D11GeometryShader* CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
+inline ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
 {
   return CreateGeometryShaderFromByteCode(bytecode->Data(), bytecode->Size());
 }
-inline ID3D11PixelShader* CreatePixelShaderFromByteCode(D3DBlob* bytecode)
+inline ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(D3DBlob* bytecode)
 {
   return CreatePixelShaderFromByteCode(bytecode->Data(), bytecode->Size());
 }
 
-inline ID3D11VertexShader* CompileAndCreateVertexShader(D3DBlob* code)
+inline ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(D3DBlob* code)
 {
   return CompileAndCreateVertexShader((const char*)code->Data());
 }
 
-inline ID3D11GeometryShader*
+inline ComPtr<ID3D11GeometryShader>
 CompileAndCreateGeometryShader(D3DBlob* code, const D3D_SHADER_MACRO* pDefines = nullptr)
 {
   return CompileAndCreateGeometryShader((const char*)code->Data(), pDefines);
 }
 
-inline ID3D11PixelShader* CompileAndCreatePixelShader(D3DBlob* code)
+inline ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(D3DBlob* code)
 {
   return CompileAndCreatePixelShader((const char*)code->Data());
 }

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -66,40 +66,23 @@ public:
   void Clear();
 
 private:
-  std::unordered_map<u32, ID3D11DepthStencilState*> m_depth;
-  std::unordered_map<u32, ID3D11RasterizerState*> m_raster;
-  std::unordered_map<u32, ID3D11BlendState*> m_blend;
-  std::unordered_map<u64, ID3D11SamplerState*> m_sampler;
+  std::unordered_map<u32, ComPtr<ID3D11DepthStencilState>> m_depth;
+  std::unordered_map<u32, ComPtr<ID3D11RasterizerState>> m_raster;
+  std::unordered_map<u32, ComPtr<ID3D11BlendState>> m_blend;
+  std::unordered_map<u64, ComPtr<ID3D11SamplerState>> m_sampler;
 };
 
 namespace D3D
 {
-template <typename T>
-class AutoState
-{
-public:
-  AutoState(const T* object);
-  AutoState(const AutoState<T>& source);
-  ~AutoState();
-
-  const inline T* GetPtr() const { return state; }
-private:
-  const T* state;
-};
-
-typedef AutoState<ID3D11BlendState> AutoBlendState;
-typedef AutoState<ID3D11DepthStencilState> AutoDepthStencilState;
-typedef AutoState<ID3D11RasterizerState> AutoRasterizerState;
-
 class StateManager
 {
 public:
   StateManager();
 
   // call any of these to change the affected states
-  void PushBlendState(const ID3D11BlendState* state);
-  void PushDepthState(const ID3D11DepthStencilState* state);
-  void PushRasterizerState(const ID3D11RasterizerState* state);
+  void PushBlendState(ID3D11BlendState* state);
+  void PushDepthState(ID3D11DepthStencilState* state);
+  void PushRasterizerState(ID3D11RasterizerState* state);
 
   // call these after drawing
   void PopBlendState();
@@ -223,9 +206,9 @@ public:
   void Apply();
 
 private:
-  std::stack<AutoBlendState> m_blendStates;
-  std::stack<AutoDepthStencilState> m_depthStates;
-  std::stack<AutoRasterizerState> m_rasterizerStates;
+  std::stack<ComPtr<ID3D11BlendState>> m_blendStates;
+  std::stack<ComPtr<ID3D11DepthStencilState>> m_depthStates;
+  std::stack<ComPtr<ID3D11RasterizerState>> m_rasterizerStates;
 
   ID3D11BlendState* m_currentBlendState;
   ID3D11DepthStencilState* m_currentDepthState;

--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -11,95 +11,97 @@
 
 namespace DX11
 {
-D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind,
-                                   D3D11_USAGE usage, DXGI_FORMAT fmt, unsigned int levels,
-                                   unsigned int slices, D3D11_SUBRESOURCE_DATA* data)
+bool D3DTexture2D::Initialize(DXGI_FORMAT format, unsigned int width, unsigned int height,
+                              D3D11_BIND_FLAG bind, D3D11_USAGE usage, unsigned int levels,
+                              unsigned int slices, const D3D11_SUBRESOURCE_DATA* data)
 {
-  ID3D11Texture2D* pTexture = nullptr;
-  HRESULT hr;
+  ComPtr<ID3D11Texture2D> pTexture;
 
   D3D11_CPU_ACCESS_FLAG cpuflags;
   if (usage == D3D11_USAGE_STAGING)
-    cpuflags = (D3D11_CPU_ACCESS_FLAG)((int)D3D11_CPU_ACCESS_WRITE | (int)D3D11_CPU_ACCESS_READ);
+    cpuflags = (D3D11_CPU_ACCESS_FLAG)(D3D11_CPU_ACCESS_WRITE | D3D11_CPU_ACCESS_READ);
   else if (usage == D3D11_USAGE_DYNAMIC)
     cpuflags = D3D11_CPU_ACCESS_WRITE;
   else
     cpuflags = (D3D11_CPU_ACCESS_FLAG)0;
   D3D11_TEXTURE2D_DESC texdesc =
-      CD3D11_TEXTURE2D_DESC(fmt, width, height, slices, levels, bind, usage, cpuflags);
-  hr = D3D::device->CreateTexture2D(&texdesc, data, &pTexture);
+      CD3D11_TEXTURE2D_DESC(format, width, height, slices, levels, bind, usage, cpuflags);
+  HRESULT hr = D3D::device->CreateTexture2D(&texdesc, data, &pTexture);
   if (FAILED(hr))
   {
     PanicAlert("Failed to create texture at %s, line %d: hr=%#x\n", __FILE__, __LINE__, hr);
-    return nullptr;
+    return false;
   }
 
-  D3DTexture2D* ret = new D3DTexture2D(pTexture, bind);
-  SAFE_RELEASE(pTexture);
-  return ret;
+  return InitializeFromExisting(pTexture.Get(), bind);
 }
 
-void D3DTexture2D::AddRef()
+bool D3DTexture2D::InitializeFromExisting(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
+                                          DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format,
+                                          DXGI_FORMAT rtv_format, bool multisampled)
 {
-  ++ref;
-}
+  Reset();
+  m_tex = tex;
+  bool ok = (m_tex != nullptr);
 
-UINT D3DTexture2D::Release()
-{
-  --ref;
-  if (ref == 0)
-  {
-    delete this;
-    return 0;
-  }
-  return ref;
-}
-
-ID3D11Texture2D*& D3DTexture2D::GetTex()
-{
-  return tex;
-}
-ID3D11ShaderResourceView*& D3DTexture2D::GetSRV()
-{
-  return srv;
-}
-ID3D11RenderTargetView*& D3DTexture2D::GetRTV()
-{
-  return rtv;
-}
-ID3D11DepthStencilView*& D3DTexture2D::GetDSV()
-{
-  return dsv;
-}
-
-D3DTexture2D::D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind, DXGI_FORMAT srv_format,
-                           DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
-    : ref(1), tex(texptr), srv(nullptr), rtv(nullptr), dsv(nullptr)
-{
-  D3D11_SRV_DIMENSION srv_dim =
-      multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-  D3D11_DSV_DIMENSION dsv_dim =
-      multisampled ? D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
-  D3D11_RTV_DIMENSION rtv_dim =
-      multisampled ? D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY : D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-  D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
-  D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
-  D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
+  HRESULT hr;
   if (bind & D3D11_BIND_SHADER_RESOURCE)
-    D3D::device->CreateShaderResourceView(tex, &srv_desc, &srv);
+  {
+    D3D11_SRV_DIMENSION srv_dim =
+        multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+    D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc =
+        CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
+    hr = D3D::device->CreateShaderResourceView(tex, &srv_desc, &m_srv);
+    ok &= SUCCEEDED(hr);
+  }
   if (bind & D3D11_BIND_RENDER_TARGET)
-    D3D::device->CreateRenderTargetView(tex, &rtv_desc, &rtv);
+  {
+    D3D11_RTV_DIMENSION rtv_dim =
+        multisampled ? D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY : D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+    D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
+    hr = D3D::device->CreateRenderTargetView(tex, &rtv_desc, &m_rtv);
+    ok &= SUCCEEDED(hr);
+  }
   if (bind & D3D11_BIND_DEPTH_STENCIL)
-    D3D::device->CreateDepthStencilView(tex, &dsv_desc, &dsv);
-  tex->AddRef();
+  {
+    D3D11_DSV_DIMENSION dsv_dim =
+        multisampled ? D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+    D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
+    hr = D3D::device->CreateDepthStencilView(tex, &dsv_desc, &m_dsv);
+    ok &= SUCCEEDED(hr);
+  }
+
+  return ok;
 }
 
-D3DTexture2D::~D3DTexture2D()
+ID3D11Texture2D* D3DTexture2D::GetTex() const
 {
-  SAFE_RELEASE(srv);
-  SAFE_RELEASE(rtv);
-  SAFE_RELEASE(dsv);
-  SAFE_RELEASE(tex);
+  return m_tex.Get();
+}
+ID3D11ShaderResourceView* D3DTexture2D::GetSRV() const
+{
+  return m_srv.Get();
+}
+ID3D11RenderTargetView* D3DTexture2D::GetRTV() const
+{
+  return m_rtv.Get();
+}
+ID3D11DepthStencilView* D3DTexture2D::GetDSV() const
+{
+  return m_dsv.Get();
+}
+
+void D3DTexture2D::Reset()
+{
+  m_dsv.Reset();
+  m_rtv.Reset();
+  m_srv.Reset();
+  m_tex.Reset();
+}
+
+bool D3DTexture2D::IsValid() const
+{
+  return m_tex != nullptr;
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -6,44 +6,42 @@
 
 #include <d3d11.h>
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 
 namespace DX11
 {
 class D3DTexture2D
 {
 public:
-  // there are two ways to create a D3DTexture2D object:
-  //     either create an ID3D11Texture2D object, pass it to the constructor and specify what views
-  //     to create
-  //     or let the texture automatically be created by D3DTexture2D::Create
+  bool Initialize(DXGI_FORMAT format, unsigned int width, unsigned int height, D3D11_BIND_FLAG bind,
+                  D3D11_USAGE usage = D3D11_USAGE_DEFAULT, unsigned int levels = 1,
+                  unsigned int slices = 1, const D3D11_SUBRESOURCE_DATA* data = nullptr);
 
-  D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind,
-               DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN,
-               DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN,
-               DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN, bool multisampled = false);
-  static D3DTexture2D* Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind,
-                              D3D11_USAGE usage, DXGI_FORMAT, unsigned int levels = 1,
-                              unsigned int slices = 1, D3D11_SUBRESOURCE_DATA* data = nullptr);
+  // Initialize from an existing ID3D11Texture2D. This function calls AddRef on
+  // the existing texture. Callers should Release their pointer.
+  bool InitializeFromExisting(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
+                              DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN,
+                              DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN,
+                              DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN,
+                              bool multisampled = false);
 
-  // reference counting, use AddRef() when creating a new reference and Release() it when you don't
-  // need it anymore
-  void AddRef();
-  UINT Release();
+  void Reset();
+  bool IsValid() const;
 
-  ID3D11Texture2D*& GetTex();
-  ID3D11ShaderResourceView*& GetSRV();
-  ID3D11RenderTargetView*& GetRTV();
-  ID3D11DepthStencilView*& GetDSV();
+  // Note that Get* functions are marked const, despite their possibly being passed to functions
+  // that modify the texture.
+  // Essentially, D3DTexture2D owns and manages the texture's pointers, not the actual contents of
+  // the texture.
+  ID3D11Texture2D* GetTex() const;
+  ID3D11ShaderResourceView* GetSRV() const;
+  ID3D11RenderTargetView* GetRTV() const;
+  ID3D11DepthStencilView* GetDSV() const;
 
 private:
-  ~D3DTexture2D();
-
-  ID3D11Texture2D* tex;
-  ID3D11ShaderResourceView* srv;
-  ID3D11RenderTargetView* rtv;
-  ID3D11DepthStencilView* dsv;
-  D3D11_BIND_FLAG bindflags;
-  UINT ref;
+  ComPtr<ID3D11Texture2D> m_tex;
+  ComPtr<ID3D11ShaderResourceView> m_srv;
+  ComPtr<ID3D11RenderTargetView> m_rtv;
+  ComPtr<ID3D11DepthStencilView> m_dsv;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DUtil.h
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/RenderBase.h"
 
 namespace DX11
@@ -23,13 +24,13 @@ namespace D3D
 
 class CD3DFont
 {
-  ID3D11ShaderResourceView* m_pTexture;
-  ID3D11Buffer* m_pVB;
-  ID3D11InputLayout* m_InputLayout;
-  ID3D11PixelShader* m_pshader;
-  ID3D11VertexShader* m_vshader;
-  ID3D11BlendState* m_blendstate;
-  ID3D11RasterizerState* m_raststate;
+  ComPtr<ID3D11ShaderResourceView> m_pTexture;
+  ComPtr<ID3D11Buffer> m_pVB;
+  ComPtr<ID3D11InputLayout> m_InputLayout;
+  ComPtr<ID3D11PixelShader> m_pshader;
+  ComPtr<ID3D11VertexShader> m_vshader;
+  ComPtr<ID3D11BlendState> m_blendstate;
+  ComPtr<ID3D11RasterizerState> m_raststate;
   const int m_dwTexWidth;
   const int m_dwTexHeight;
   unsigned int m_LineHeight;

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -49,10 +49,9 @@ DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_conf
   DXGI_FORMAT dxgi_format = GetDXGIFormatForHostFormat(m_config.format);
   if (m_config.rendertarget)
   {
-    m_texture = D3DTexture2D::Create(
-        m_config.width, m_config.height,
-        (D3D11_BIND_FLAG)((int)D3D11_BIND_RENDER_TARGET | (int)D3D11_BIND_SHADER_RESOURCE),
-        D3D11_USAGE_DEFAULT, dxgi_format, 1, m_config.layers);
+    m_texture.Initialize(dxgi_format, m_config.width, m_config.height,
+                         (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE),
+                         D3D11_USAGE_DEFAULT, 1, m_config.layers);
   }
   else
   {
@@ -60,35 +59,27 @@ DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_conf
         CD3D11_TEXTURE2D_DESC(dxgi_format, m_config.width, m_config.height, 1, m_config.levels,
                               D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0);
 
-    ID3D11Texture2D* pTexture;
+    ComPtr<ID3D11Texture2D> pTexture;
     const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);
     CHECK(SUCCEEDED(hr), "Create texture of the TextureCache");
 
-    m_texture = new D3DTexture2D(pTexture, D3D11_BIND_SHADER_RESOURCE);
+    m_texture.InitializeFromExisting(pTexture.Get(), D3D11_BIND_SHADER_RESOURCE);
 
     // TODO: better debug names
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_texture->GetTex(),
-                            "a texture of the TextureCache");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_texture->GetSRV(),
+    D3D::SetDebugObjectName(m_texture.GetTex(), "a texture of the TextureCache");
+    D3D::SetDebugObjectName(m_texture.GetSRV(),
                             "shader resource view of a texture of the TextureCache");
-
-    SAFE_RELEASE(pTexture);
   }
 }
 
-DXTexture::~DXTexture()
+const D3DTexture2D* DXTexture::GetRawTexIdentifier() const
 {
-  m_texture->Release();
-}
-
-D3DTexture2D* DXTexture::GetRawTexIdentifier() const
-{
-  return m_texture;
+  return &m_texture;
 }
 
 void DXTexture::Bind(unsigned int stage)
 {
-  D3D::stateman->SetTexture(stage, m_texture->GetSRV());
+  D3D::stateman->SetTexture(stage, m_texture.GetSRV());
 }
 
 bool DXTexture::Save(const std::string& filename, unsigned int level)
@@ -104,7 +95,7 @@ bool DXTexture::Save(const std::string& filename, unsigned int level)
   CD3D11_TEXTURE2D_DESC staging_texture_desc(DXGI_FORMAT_R8G8B8A8_UNORM, mip_width, mip_height, 1,
                                              1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
 
-  ID3D11Texture2D* staging_texture;
+  ComPtr<ID3D11Texture2D> staging_texture;
   HRESULT hr = D3D::device->CreateTexture2D(&staging_texture_desc, nullptr, &staging_texture);
   if (FAILED(hr))
   {
@@ -114,23 +105,21 @@ bool DXTexture::Save(const std::string& filename, unsigned int level)
 
   // Copy the selected mip level to the staging texture.
   CD3D11_BOX src_box(0, 0, 0, mip_width, mip_height, 1);
-  D3D::context->CopySubresourceRegion(staging_texture, 0, 0, 0, 0, m_texture->GetTex(),
+  D3D::context->CopySubresourceRegion(staging_texture.Get(), 0, 0, 0, 0, m_texture.GetTex(),
                                       D3D11CalcSubresource(level, 0, m_config.levels), &src_box);
 
   // Map the staging texture to client memory, and encode it as a .png image.
   D3D11_MAPPED_SUBRESOURCE map;
-  hr = D3D::context->Map(staging_texture, 0, D3D11_MAP_READ, 0, &map);
+  hr = D3D::context->Map(staging_texture.Get(), 0, D3D11_MAP_READ, 0, &map);
   if (FAILED(hr))
   {
     WARN_LOG(VIDEO, "Failed to map texture dumping readback texture: %X", static_cast<u32>(hr));
-    staging_texture->Release();
     return false;
   }
 
   bool encode_result =
       TextureToPng(reinterpret_cast<u8*>(map.pData), map.RowPitch, filename, mip_width, mip_height);
-  D3D::context->Unmap(staging_texture, 0);
-  staging_texture->Release();
+  D3D::context->Unmap(staging_texture.Get(), 0);
 
   return encode_result;
 }
@@ -150,8 +139,8 @@ void DXTexture::CopyRectangleFromTexture(const AbstractTexture* source,
     srcbox.front = 0;
     srcbox.back = srcentry->m_config.layers;
 
-    D3D::context->CopySubresourceRegion(m_texture->GetTex(), 0, dstrect.left, dstrect.top, 0,
-                                        srcentry->m_texture->GetTex(), 0, &srcbox);
+    D3D::context->CopySubresourceRegion(m_texture.GetTex(), 0, dstrect.left, dstrect.top, 0,
+                                        srcentry->m_texture.GetTex(), 0, &srcbox);
     return;
   }
   else if (!m_config.rendertarget)
@@ -163,10 +152,10 @@ void DXTexture::CopyRectangleFromTexture(const AbstractTexture* source,
   const D3D11_VIEWPORT vp = CD3D11_VIEWPORT(float(dstrect.left), float(dstrect.top),
                                             float(dstrect.GetWidth()), float(dstrect.GetHeight()));
 
-  D3D::stateman->UnsetTexture(m_texture->GetSRV());
+  D3D::stateman->UnsetTexture(m_texture.GetSRV());
   D3D::stateman->Apply();
 
-  D3D::context->OMSetRenderTargets(1, &m_texture->GetRTV(), nullptr);
+  D3D::SetRenderTarget(m_texture.GetRTV(), nullptr);
   D3D::context->RSSetViewports(1, &vp);
   D3D::SetLinearCopySampler();
   D3D11_RECT srcRC;
@@ -174,14 +163,14 @@ void DXTexture::CopyRectangleFromTexture(const AbstractTexture* source,
   srcRC.right = srcrect.right;
   srcRC.top = srcrect.top;
   srcRC.bottom = srcrect.bottom;
-  D3D::drawShadedTexQuad(srcentry->m_texture->GetSRV(), &srcRC, srcentry->m_config.width,
+  D3D::drawShadedTexQuad(srcentry->m_texture.GetSRV(), &srcRC, srcentry->m_config.width,
                          srcentry->m_config.height, PixelShaderCache::GetColorCopyProgram(false),
                          VertexShaderCache::GetSimpleVertexShader(),
                          VertexShaderCache::GetSimpleInputLayout(),
                          GeometryShaderCache::GetCopyGeometryShader(), 1.0, 0);
 
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 
   g_renderer->RestoreAPIState();
 }
@@ -190,7 +179,7 @@ void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
                      size_t buffer_size)
 {
   size_t src_pitch = CalculateHostTextureLevelPitch(m_config.format, row_length);
-  D3D::context->UpdateSubresource(m_texture->GetTex(), level, nullptr, buffer,
+  D3D::context->UpdateSubresource(m_texture.GetTex(), level, nullptr, buffer,
                                   static_cast<UINT>(src_pitch), 0);
 }
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/DXTexture.h
+++ b/Source/Core/VideoBackends/D3D/DXTexture.h
@@ -16,7 +16,6 @@ class DXTexture final : public AbstractTexture
 {
 public:
   explicit DXTexture(const TextureConfig& tex_config);
-  ~DXTexture();
 
   void Bind(unsigned int stage) override;
   bool Save(const std::string& filename, unsigned int level) override;
@@ -27,10 +26,10 @@ public:
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;
 
-  D3DTexture2D* GetRawTexIdentifier() const;
+  const D3DTexture2D* GetRawTexIdentifier() const;
 
 private:
-  D3DTexture2D* m_texture;
+  D3DTexture2D m_texture;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -48,12 +48,11 @@ namespace DX11
 
 struct XFBSource : public XFBSourceBase
 {
-  XFBSource(D3DTexture2D* _tex, int slices) : tex(_tex), m_slices(slices) {}
-  ~XFBSource() { tex->Release(); }
+  XFBSource(D3DTexture2D&& _tex, int slices) : tex(_tex), m_slices(slices) {}
   void DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight) override;
   void CopyEFB(float Gamma) override;
 
-  D3DTexture2D* const tex;
+  D3DTexture2D tex;
   const int m_slices;
 };
 
@@ -63,23 +62,21 @@ public:
   FramebufferManager(int target_width, int target_height);
   ~FramebufferManager();
 
-  static D3DTexture2D*& GetEFBColorTexture();
-  static D3DTexture2D*& GetEFBColorReadTexture();
-  static ID3D11Texture2D*& GetEFBColorStagingBuffer();
+  static D3DTexture2D& GetEFBColorTexture();
+  static D3DTexture2D& GetEFBColorReadTexture();
+  static ID3D11Texture2D* GetEFBColorStagingBuffer();
 
-  static D3DTexture2D*& GetEFBDepthTexture();
-  static D3DTexture2D*& GetEFBDepthReadTexture();
-  static ID3D11Texture2D*& GetEFBDepthStagingBuffer();
+  static D3DTexture2D& GetEFBDepthTexture();
+  static D3DTexture2D& GetEFBDepthReadTexture();
+  static ID3D11Texture2D* GetEFBDepthStagingBuffer();
 
-  static D3DTexture2D*& GetResolvedEFBColorTexture();
-  static D3DTexture2D*& GetResolvedEFBDepthTexture();
+  static D3DTexture2D& GetResolvedEFBColorTexture();
+  static D3DTexture2D& GetResolvedEFBDepthTexture();
 
-  static D3DTexture2D*& GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
+  static D3DTexture2D& GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
   static void SwapReinterpretTexture()
   {
-    D3DTexture2D* swaptex = GetEFBColorTempTexture();
-    m_efb.color_temp_tex = GetEFBColorTexture();
-    m_efb.color_tex = swaptex;
+    std::swap(GetEFBColorTexture(), GetEFBColorTempTexture());
   }
 
 private:
@@ -93,18 +90,18 @@ private:
 
   static struct Efb
   {
-    D3DTexture2D* color_tex;
-    ID3D11Texture2D* color_staging_buf;
-    D3DTexture2D* color_read_texture;
+    D3DTexture2D color_tex;
+    ComPtr<ID3D11Texture2D> color_staging_buf;
+    D3DTexture2D color_read_texture;
 
-    D3DTexture2D* depth_tex;
-    ID3D11Texture2D* depth_staging_buf;
-    D3DTexture2D* depth_read_texture;
+    D3DTexture2D depth_tex;
+    ComPtr<ID3D11Texture2D> depth_staging_buf;
+    D3DTexture2D depth_read_texture;
 
-    D3DTexture2D* color_temp_tex;
+    D3DTexture2D color_temp_tex;
 
-    D3DTexture2D* resolved_color_tex;
-    D3DTexture2D* resolved_depth_tex;
+    D3DTexture2D resolved_color_tex;
+    D3DTexture2D resolved_depth_tex;
 
     int slices;
   } m_efb;

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -24,16 +24,15 @@ public:
   static ID3D11GeometryShader* GetClearGeometryShader();
   static ID3D11GeometryShader* GetCopyGeometryShader();
 
-  static ID3D11GeometryShader* GetActiveShader() { return last_entry->shader; }
-  static ID3D11Buffer*& GetConstantBuffer();
+  static ID3D11GeometryShader* GetActiveShader() { return last_entry->shader.Get(); }
+  static ID3D11Buffer* GetConstantBuffer();
 
 private:
   struct GSCacheEntry
   {
-    ID3D11GeometryShader* shader;
+    ComPtr<ID3D11GeometryShader> shader;
 
-    GSCacheEntry() : shader(nullptr) {}
-    void Destroy() { SAFE_RELEASE(shader); }
+    void Destroy() { shader.Reset(); }
   };
 
   typedef std::map<GeometryShaderUid, GSCacheEntry> GSCache;

--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -17,14 +17,13 @@ class D3DVertexFormat : public NativeVertexFormat
 {
 public:
   D3DVertexFormat(const PortableVertexDeclaration& vtx_decl);
-  ~D3DVertexFormat() { SAFE_RELEASE(m_layout); }
   void SetupVertexPointers() override;
 
 private:
   std::array<D3D11_INPUT_ELEMENT_DESC, 32> m_elems{};
   UINT m_num_elems = 0;
 
-  ID3D11InputLayout* m_layout = nullptr;
+  ComPtr<ID3D11InputLayout> m_layout;
 };
 
 std::unique_ptr<NativeVertexFormat>
@@ -142,10 +141,9 @@ void D3DVertexFormat::SetupVertexPointers()
         m_elems.data(), m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), &m_layout);
     if (FAILED(hr))
       PanicAlert("Failed to create input layout, %s %d\n", __FILE__, __LINE__);
-    DX11::D3D::SetDebugObjectName((ID3D11DeviceChild*)m_layout,
-                                  "input layout used to emulate the GX pipeline");
+    DX11::D3D::SetDebugObjectName(m_layout.Get(), "input layout used to emulate the GX pipeline");
   }
-  DX11::D3D::stateman->SetInputLayout(m_layout);
+  DX11::D3D::stateman->SetInputLayout(m_layout.Get());
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -45,14 +45,14 @@ void PSTextureEncoder::Init()
                                                     EFB_HEIGHT / 4, 1, 1, D3D11_BIND_RENDER_TARGET);
   hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_out);
   CHECK(SUCCEEDED(hr), "create efb encode output texture");
-  D3D::SetDebugObjectName(m_out, "efb encoder output texture");
+  D3D::SetDebugObjectName(m_out.Get(), "efb encoder output texture");
 
   // Create output render target view
   D3D11_RENDER_TARGET_VIEW_DESC rtvd = CD3D11_RENDER_TARGET_VIEW_DESC(
-      m_out, D3D11_RTV_DIMENSION_TEXTURE2D, DXGI_FORMAT_B8G8R8A8_UNORM);
-  hr = D3D::device->CreateRenderTargetView(m_out, &rtvd, &m_outRTV);
+      m_out.Get(), D3D11_RTV_DIMENSION_TEXTURE2D, DXGI_FORMAT_B8G8R8A8_UNORM);
+  hr = D3D::device->CreateRenderTargetView(m_out.Get(), &rtvd, &m_outRTV);
   CHECK(SUCCEEDED(hr), "create efb encode output render target view");
-  D3D::SetDebugObjectName(m_outRTV, "efb encoder output rtv");
+  D3D::SetDebugObjectName(m_outRTV.Get(), "efb encoder output rtv");
 
   // Create output staging buffer
   t2dd.Usage = D3D11_USAGE_STAGING;
@@ -60,13 +60,13 @@ void PSTextureEncoder::Init()
   t2dd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
   hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_outStage);
   CHECK(SUCCEEDED(hr), "create efb encode output staging buffer");
-  D3D::SetDebugObjectName(m_outStage, "efb encoder output staging buffer");
+  D3D::SetDebugObjectName(m_outStage.Get(), "efb encoder output staging buffer");
 
   // Create constant buffer for uploading data to shaders
   D3D11_BUFFER_DESC bd = CD3D11_BUFFER_DESC(sizeof(EFBEncodeParams), D3D11_BIND_CONSTANT_BUFFER);
   hr = D3D::device->CreateBuffer(&bd, nullptr, &m_encodeParams);
   CHECK(SUCCEEDED(hr), "create efb encode params buffer");
-  D3D::SetDebugObjectName(m_encodeParams, "efb encoder params buffer");
+  D3D::SetDebugObjectName(m_encodeParams.Get(), "efb encoder params buffer");
 
   m_ready = true;
 }
@@ -75,16 +75,12 @@ void PSTextureEncoder::Shutdown()
 {
   m_ready = false;
 
-  for (auto& it : m_encoding_shaders)
-  {
-    SAFE_RELEASE(it.second);
-  }
   m_encoding_shaders.clear();
 
-  SAFE_RELEASE(m_encodeParams);
-  SAFE_RELEASE(m_outStage);
-  SAFE_RELEASE(m_outRTV);
-  SAFE_RELEASE(m_out);
+  m_encodeParams.Reset();
+  m_outStage.Reset();
+  m_outRTV.Reset();
+  m_out.Reset();
 }
 
 void PSTextureEncoder::Encode(u8* dst, const EFBCopyFormat& format, u32 native_width,
@@ -101,8 +97,8 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyFormat& format, u32 native_w
   // single sample from each pixel. The game may break if it isn't
   // expecting the blurred edges around multisampled shapes.
   ID3D11ShaderResourceView* pEFB = is_depth_copy ?
-                                       FramebufferManager::GetResolvedEFBDepthTexture()->GetSRV() :
-                                       FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
+                                       FramebufferManager::GetResolvedEFBDepthTexture().GetSRV() :
+                                       FramebufferManager::GetResolvedEFBColorTexture().GetSRV();
 
   // Reset API
   g_renderer->ResetAPIState();
@@ -124,8 +120,8 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyFormat& format, u32 native_w
     params.SrcTop = src_rect.top;
     params.DestWidth = native_width;
     params.ScaleFactor = scale_by_half ? 2 : 1;
-    D3D::context->UpdateSubresource(m_encodeParams, 0, nullptr, &params, 0, 0);
-    D3D::stateman->SetPixelConstants(m_encodeParams);
+    D3D::context->UpdateSubresource(m_encodeParams.Get(), 0, nullptr, &params, 0, 0);
+    D3D::stateman->SetPixelConstants(m_encodeParams.Get());
 
     // We also linear filtering for both box filtering and downsampling higher resolutions to 1x
     // TODO: This only produces perfect downsampling for 1.5x and 2x IR, other resolution will
@@ -143,11 +139,11 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyFormat& format, u32 native_w
 
     // Copy to staging buffer
     D3D11_BOX srcBox = CD3D11_BOX(0, 0, 0, words_per_row, num_blocks_y, 1);
-    D3D::context->CopySubresourceRegion(m_outStage, 0, 0, 0, 0, m_out, 0, &srcBox);
+    D3D::context->CopySubresourceRegion(m_outStage.Get(), 0, 0, 0, 0, m_out.Get(), 0, &srcBox);
 
     // Transfer staging buffer to GameCube/Wii RAM
     D3D11_MAPPED_SUBRESOURCE map = {0};
-    hr = D3D::context->Map(m_outStage, 0, D3D11_MAP_READ, 0, &map);
+    hr = D3D::context->Map(m_outStage.Get(), 0, D3D11_MAP_READ, 0, &map);
     CHECK(SUCCEEDED(hr), "map staging buffer (0x%x)", hr);
 
     u8* src = (u8*)map.pData;
@@ -159,36 +155,36 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyFormat& format, u32 native_w
       src += map.RowPitch;
     }
 
-    D3D::context->Unmap(m_outStage, 0);
+    D3D::context->Unmap(m_outStage.Get(), 0);
   }
 
   // Restore API
   g_renderer->RestoreAPIState();
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 }
 
 ID3D11PixelShader* PSTextureEncoder::GetEncodingPixelShader(const EFBCopyFormat& format)
 {
   auto iter = m_encoding_shaders.find(format);
   if (iter != m_encoding_shaders.end())
-    return iter->second;
+    return iter->second.Get();
 
-  D3DBlob* bytecode = nullptr;
+  ComPtr<D3DBlob> bytecode;
   const char* shader = TextureConversionShader::GenerateEncodingShader(format, APIType::D3D);
   if (!D3D::CompilePixelShader(shader, &bytecode))
   {
     PanicAlert("Failed to compile texture encoding shader.");
-    m_encoding_shaders[format] = nullptr;
+    m_encoding_shaders[format].Reset();
     return nullptr;
   }
 
-  ID3D11PixelShader* newShader;
+  ComPtr<ID3D11PixelShader> newShader;
   HRESULT hr =
       D3D::device->CreatePixelShader(bytecode->Data(), bytecode->Size(), nullptr, &newShader);
   CHECK(SUCCEEDED(hr), "create efb encoder pixel shader");
 
   m_encoding_shaders.emplace(format, newShader);
-  return newShader;
+  return newShader.Get();
 }
 }

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -41,10 +42,10 @@ private:
 
   bool m_ready;
 
-  ID3D11Texture2D* m_out;
-  ID3D11RenderTargetView* m_outRTV;
-  ID3D11Texture2D* m_outStage;
-  ID3D11Buffer* m_encodeParams;
-  std::map<EFBCopyFormat, ID3D11PixelShader*> m_encoding_shaders;
+  ComPtr<ID3D11Texture2D> m_out;
+  ComPtr<ID3D11RenderTargetView> m_outRTV;
+  ComPtr<ID3D11Texture2D> m_outStage;
+  ComPtr<ID3D11Buffer> m_encodeParams;
+  std::map<EFBCopyFormat, ComPtr<ID3D11PixelShader>> m_encoding_shaders;
 };
 }

--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -22,15 +22,6 @@ PerfQuery::PerfQuery() : m_query_read_pos()
   ResetQuery();
 }
 
-PerfQuery::~PerfQuery()
-{
-  for (ActiveQuery& entry : m_query_buffer)
-  {
-    // TODO: EndQuery?
-    entry.query->Release();
-  }
-}
-
 void PerfQuery::EnableQuery(PerfQueryGroup type)
 {
   // Is this sane?
@@ -49,7 +40,7 @@ void PerfQuery::EnableQuery(PerfQueryGroup type)
   {
     auto& entry = m_query_buffer[(m_query_read_pos + m_query_count) % m_query_buffer.size()];
 
-    D3D::context->Begin(entry.query);
+    D3D::context->Begin(entry.query.Get());
     entry.query_type = type;
 
     ++m_query_count;
@@ -63,7 +54,7 @@ void PerfQuery::DisableQuery(PerfQueryGroup type)
   {
     auto& entry = m_query_buffer[(m_query_read_pos + m_query_count + m_query_buffer.size() - 1) %
                                  m_query_buffer.size()];
-    D3D::context->End(entry.query);
+    D3D::context->End(entry.query.Get());
   }
 }
 
@@ -98,7 +89,7 @@ void PerfQuery::FlushOne()
   while (hr != S_OK)
   {
     // TODO: Might cause us to be stuck in an infinite loop!
-    hr = D3D::context->GetData(entry.query, &result, sizeof(result), 0);
+    hr = D3D::context->GetData(entry.query.Get(), &result, sizeof(result), 0);
   }
 
   // NOTE: Reported pixel metrics should be referenced to native resolution
@@ -125,8 +116,8 @@ void PerfQuery::WeakFlush()
     auto& entry = m_query_buffer[m_query_read_pos];
 
     UINT64 result = 0;
-    HRESULT hr =
-        D3D::context->GetData(entry.query, &result, sizeof(result), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+    HRESULT hr = D3D::context->GetData(entry.query.Get(), &result, sizeof(result),
+                                       D3D11_ASYNC_GETDATA_DONOTFLUSH);
 
     if (hr == S_OK)
     {

--- a/Source/Core/VideoBackends/D3D/PerfQuery.h
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <d3d11.h>
 
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/PerfQueryBase.h"
 
 namespace DX11
@@ -15,7 +16,7 @@ class PerfQuery : public PerfQueryBase
 {
 public:
   PerfQuery();
-  ~PerfQuery();
+  // TODO: Should the destructor call EndQuery on all queries?
 
   void EnableQuery(PerfQueryGroup type) override;
   void DisableQuery(PerfQueryGroup type) override;
@@ -27,7 +28,7 @@ public:
 private:
   struct ActiveQuery
   {
-    ID3D11Query* query;
+    ComPtr<ID3D11Query> query;
     PerfQueryGroup query_type;
   };
 

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -21,8 +21,8 @@ public:
   static bool InsertByteCode(const PixelShaderUid& uid, const void* bytecode,
                              unsigned int bytecodelen);
 
-  static ID3D11PixelShader* GetActiveShader() { return last_entry->shader; }
-  static ID3D11Buffer*& GetConstantBuffer();
+  static ID3D11PixelShader* GetActiveShader() { return last_entry->shader.Get(); }
+  static ID3D11Buffer* GetConstantBuffer();
 
   static ID3D11PixelShader* GetColorMatrixProgram(bool multisampled);
   static ID3D11PixelShader* GetColorCopyProgram(bool multisampled);
@@ -38,10 +38,9 @@ public:
 private:
   struct PSCacheEntry
   {
-    ID3D11PixelShader* shader;
+    ComPtr<ID3D11PixelShader> shader;
 
-    PSCacheEntry() : shader(nullptr) {}
-    void Destroy() { SAFE_RELEASE(shader); }
+    void Destroy() { shader.Reset(); }
   };
 
   typedef std::map<PixelShaderUid, PSCacheEntry> PSCache;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -69,14 +69,14 @@ static bool s_last_xfb_mode = false;
 
 static Television s_television;
 
-static std::array<ID3D11BlendState*, 4> s_clear_blend_states{};
-static std::array<ID3D11DepthStencilState*, 3> s_clear_depth_states{};
-static ID3D11BlendState* s_reset_blend_state = nullptr;
-static ID3D11DepthStencilState* s_reset_depth_state = nullptr;
-static ID3D11RasterizerState* s_reset_rast_state = nullptr;
+static std::array<ComPtr<ID3D11BlendState>, 4> s_clear_blend_states;
+static std::array<ComPtr<ID3D11DepthStencilState>, 3> s_clear_depth_states;
+static ComPtr<ID3D11BlendState> s_reset_blend_state;
+static ComPtr<ID3D11DepthStencilState> s_reset_depth_state;
+static ComPtr<ID3D11RasterizerState> s_reset_rast_state;
 
-static ID3D11Texture2D* s_screenshot_texture = nullptr;
-static D3DTexture2D* s_3d_vision_texture = nullptr;
+static ComPtr<ID3D11Texture2D> s_screenshot_texture;
+static D3DTexture2D s_3d_vision_texture;
 
 static GXPipelineState s_gx_state;
 static StateCache s_gx_state_cache;
@@ -103,13 +103,13 @@ static void SetupDeviceObjects()
   ddesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
   hr = D3D::device->CreateDepthStencilState(&ddesc, &s_clear_depth_states[2]);
   CHECK(hr == S_OK, "Create depth state for Renderer::ClearScreen");
-  D3D::SetDebugObjectName(s_clear_depth_states[0],
+  D3D::SetDebugObjectName(s_clear_depth_states[0].Get(),
                           "depth state for Renderer::ClearScreen (depth buffer disabled)");
   D3D::SetDebugObjectName(
-      s_clear_depth_states[1],
+      s_clear_depth_states[1].Get(),
       "depth state for Renderer::ClearScreen (depth buffer enabled, writing enabled)");
   D3D::SetDebugObjectName(
-      s_clear_depth_states[2],
+      s_clear_depth_states[2].Get(),
       "depth state for Renderer::ClearScreen (depth buffer enabled, writing disabled)");
 
   D3D11_BLEND_DESC blenddesc;
@@ -125,10 +125,9 @@ static void SetupDeviceObjects()
   blenddesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
   hr = D3D::device->CreateBlendState(&blenddesc, &s_reset_blend_state);
   CHECK(hr == S_OK, "Create blend state for Renderer::ResetAPIState");
-  D3D::SetDebugObjectName(s_reset_blend_state, "blend state for Renderer::ResetAPIState");
+  D3D::SetDebugObjectName(s_reset_blend_state.Get(), "blend state for Renderer::ResetAPIState");
 
   s_clear_blend_states[0] = s_reset_blend_state;
-  s_reset_blend_state->AddRef();
 
   blenddesc.RenderTarget[0].RenderTargetWriteMask =
       D3D11_COLOR_WRITE_ENABLE_RED | D3D11_COLOR_WRITE_ENABLE_GREEN | D3D11_COLOR_WRITE_ENABLE_BLUE;
@@ -151,15 +150,16 @@ static void SetupDeviceObjects()
   ddesc.StencilWriteMask = D3D11_DEFAULT_STENCIL_WRITE_MASK;
   hr = D3D::device->CreateDepthStencilState(&ddesc, &s_reset_depth_state);
   CHECK(hr == S_OK, "Create depth state for Renderer::ResetAPIState");
-  D3D::SetDebugObjectName(s_reset_depth_state, "depth stencil state for Renderer::ResetAPIState");
+  D3D::SetDebugObjectName(s_reset_depth_state.Get(),
+                          "depth stencil state for Renderer::ResetAPIState");
 
   D3D11_RASTERIZER_DESC rastdesc = CD3D11_RASTERIZER_DESC(D3D11_FILL_SOLID, D3D11_CULL_NONE, false,
                                                           0, 0.f, 0.f, false, false, false, false);
   hr = D3D::device->CreateRasterizerState(&rastdesc, &s_reset_rast_state);
   CHECK(hr == S_OK, "Create rasterizer state for Renderer::ResetAPIState");
-  D3D::SetDebugObjectName(s_reset_rast_state, "rasterizer state for Renderer::ResetAPIState");
+  D3D::SetDebugObjectName(s_reset_rast_state.Get(), "rasterizer state for Renderer::ResetAPIState");
 
-  s_screenshot_texture = nullptr;
+  s_screenshot_texture.Reset();
 }
 
 // Kill off all device objects
@@ -167,18 +167,18 @@ static void TeardownDeviceObjects()
 {
   g_framebuffer_manager.reset();
 
-  SAFE_RELEASE(s_clear_blend_states[0]);
-  SAFE_RELEASE(s_clear_blend_states[1]);
-  SAFE_RELEASE(s_clear_blend_states[2]);
-  SAFE_RELEASE(s_clear_blend_states[3]);
-  SAFE_RELEASE(s_clear_depth_states[0]);
-  SAFE_RELEASE(s_clear_depth_states[1]);
-  SAFE_RELEASE(s_clear_depth_states[2]);
-  SAFE_RELEASE(s_reset_blend_state);
-  SAFE_RELEASE(s_reset_depth_state);
-  SAFE_RELEASE(s_reset_rast_state);
-  SAFE_RELEASE(s_screenshot_texture);
-  SAFE_RELEASE(s_3d_vision_texture);
+  s_clear_blend_states[0].Reset();
+  s_clear_blend_states[1].Reset();
+  s_clear_blend_states[2].Reset();
+  s_clear_blend_states[3].Reset();
+  s_clear_depth_states[0].Reset();
+  s_clear_depth_states[1].Reset();
+  s_clear_depth_states[2].Reset();
+  s_reset_blend_state.Reset();
+  s_reset_depth_state.Reset();
+  s_reset_rast_state.Reset();
+  s_screenshot_texture.Reset();
+  s_3d_vision_texture.Reset();
 
   s_television.Shutdown();
 
@@ -195,7 +195,7 @@ static void CreateScreenshotTexture()
       D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE);
   HRESULT hr = D3D::device->CreateTexture2D(&scrtex_desc, nullptr, &s_screenshot_texture);
   CHECK(hr == S_OK, "Create screenshot staging texture");
-  D3D::SetDebugObjectName(s_screenshot_texture, "staging screenshot texture");
+  D3D::SetDebugObjectName(s_screenshot_texture.Get(), "staging screenshot texture");
 }
 
 static D3D11_BOX GetScreenshotSourceBox(const TargetRectangle& targetRc)
@@ -230,9 +230,8 @@ static void Create3DVisionTexture(int width, int height)
   sys_data.SysMemPitch = pitch;
   sys_data.pSysMem = memory.get();
 
-  s_3d_vision_texture =
-      D3DTexture2D::Create(width * 2, height + 1, D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT,
-                           DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, &sys_data);
+  s_3d_vision_texture.Initialize(DXGI_FORMAT_R8G8B8A8_UNORM, width * 2, height + 1,
+                                 D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 1, 1, &sys_data);
 }
 
 Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferHeight())
@@ -265,15 +264,15 @@ Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferH
 
   // Clear EFB textures
   constexpr std::array<float, 4> clear_color{{0.f, 0.f, 0.f, 1.f}};
-  D3D::context->ClearRenderTargetView(FramebufferManager::GetEFBColorTexture()->GetRTV(),
+  D3D::context->ClearRenderTargetView(FramebufferManager::GetEFBColorTexture().GetRTV(),
                                       clear_color.data());
-  D3D::context->ClearDepthStencilView(FramebufferManager::GetEFBDepthTexture()->GetDSV(),
+  D3D::context->ClearDepthStencilView(FramebufferManager::GetEFBDepthTexture().GetDSV(),
                                       D3D11_CLEAR_DEPTH, 0.f, 0);
 
   D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, (float)m_target_width, (float)m_target_height);
   D3D::context->RSSetViewports(1, &vp);
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
   D3D::BeginFrame();
 }
 
@@ -397,14 +396,14 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
   ID3D11Texture2D* staging_tex;
   if (type == EFBAccessType::PeekColor)
   {
-    source_tex = FramebufferManager::GetEFBColorTexture();
-    read_tex = FramebufferManager::GetEFBColorReadTexture();
+    source_tex = &FramebufferManager::GetEFBColorTexture();
+    read_tex = &FramebufferManager::GetEFBColorReadTexture();
     staging_tex = FramebufferManager::GetEFBColorStagingBuffer();
   }
   else
   {
-    source_tex = FramebufferManager::GetEFBDepthTexture();
-    read_tex = FramebufferManager::GetEFBDepthReadTexture();
+    source_tex = &FramebufferManager::GetEFBDepthTexture();
+    read_tex = &FramebufferManager::GetEFBDepthReadTexture();
     staging_tex = FramebufferManager::GetEFBDepthStagingBuffer();
   }
 
@@ -416,15 +415,15 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
     copy_pixel_shader = PixelShaderCache::GetColorCopyProgram(true);
 
   // Draw a quad to grab the texel we want to read.
-  D3D::context->OMSetRenderTargets(1, &read_tex->GetRTV(), nullptr);
+  D3D::SetRenderTarget(read_tex->GetRTV(), nullptr);
   D3D::drawShadedTexQuad(source_tex->GetSRV(), &RectToLock, Renderer::GetTargetWidth(),
                          Renderer::GetTargetHeight(), copy_pixel_shader,
                          VertexShaderCache::GetSimpleVertexShader(),
                          VertexShaderCache::GetSimpleInputLayout());
 
   // Restore expected game state.
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
   RestoreAPIState();
 
   // Copy the pixel from the renderable to cpu-readable buffer.
@@ -499,21 +498,20 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
     D3D11_VIEWPORT vp =
         CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
     D3D::context->RSSetViewports(1, &vp);
-    D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                     nullptr);
+    D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(), nullptr);
   }
   else  // if (type == EFBAccessType::PokeZ)
   {
-    D3D::stateman->PushBlendState(s_clear_blend_states[3]);
-    D3D::stateman->PushDepthState(s_clear_depth_states[1]);
+    D3D::stateman->PushBlendState(s_clear_blend_states[3].Get());
+    D3D::stateman->PushDepthState(s_clear_depth_states[1].Get());
 
     D3D11_VIEWPORT vp =
         CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
 
     D3D::context->RSSetViewports(1, &vp);
 
-    D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                     FramebufferManager::GetEFBDepthTexture()->GetDSV());
+    D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                         FramebufferManager::GetEFBDepthTexture().GetDSV());
   }
 
   D3D::DrawEFBPokeQuads(type, points, num_points);
@@ -589,21 +587,21 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
   ResetAPIState();
 
   if (colorEnable && alphaEnable)
-    D3D::stateman->PushBlendState(s_clear_blend_states[0]);
+    D3D::stateman->PushBlendState(s_clear_blend_states[0].Get());
   else if (colorEnable)
-    D3D::stateman->PushBlendState(s_clear_blend_states[1]);
+    D3D::stateman->PushBlendState(s_clear_blend_states[1].Get());
   else if (alphaEnable)
-    D3D::stateman->PushBlendState(s_clear_blend_states[2]);
+    D3D::stateman->PushBlendState(s_clear_blend_states[2].Get());
   else
-    D3D::stateman->PushBlendState(s_clear_blend_states[3]);
+    D3D::stateman->PushBlendState(s_clear_blend_states[3].Get());
 
   // TODO: Should we enable Z testing here?
-  // if (!bpmem.zmode.testenable) D3D::stateman->PushDepthState(s_clear_depth_states[0]);
+  // if (!bpmem.zmode.testenable) D3D::stateman->PushDepthState(s_clear_depth_states[0].Get());
   // else
   if (zEnable)
-    D3D::stateman->PushDepthState(s_clear_depth_states[1]);
+    D3D::stateman->PushDepthState(s_clear_depth_states[1].Get());
   else /*if (!zEnable)*/
-    D3D::stateman->PushDepthState(s_clear_depth_states[2]);
+    D3D::stateman->PushDepthState(s_clear_depth_states[2].Get());
 
   // Update the view port for clearing the picture
   TargetRectangle targetRc = Renderer::ConvertEFBRectangle(rc);
@@ -646,19 +644,18 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
                                       static_cast<float>(GetTargetHeight()));
   D3D::context->RSSetViewports(1, &vp);
 
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTempTexture()->GetRTV(),
-                                   nullptr);
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTempTexture().GetRTV(), nullptr);
   D3D::SetPointCopySampler();
   D3D::drawShadedTexQuad(
-      FramebufferManager::GetEFBColorTexture()->GetSRV(), &source, GetTargetWidth(),
+      FramebufferManager::GetEFBColorTexture().GetSRV(), &source, GetTargetWidth(),
       GetTargetHeight(), pixel_shader, VertexShaderCache::GetSimpleVertexShader(),
       VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
 
   RestoreAPIState();
 
   FramebufferManager::SwapReinterpretTexture();
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 }
 
 void Renderer::SetBlendMode(bool forceUpdate)
@@ -728,10 +725,10 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
   UpdateDrawRectangle();
   TargetRectangle targetRc = GetTargetRectangle();
 
-  D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
+  D3D::SetRenderTarget(D3D::GetBackBuffer().GetRTV(), nullptr);
 
   constexpr std::array<float, 4> clear_color{{0.f, 0.f, 0.f, 1.f}};
-  D3D::context->ClearRenderTargetView(D3D::GetBackBuffer()->GetRTV(), clear_color.data());
+  D3D::context->ClearRenderTargetView(D3D::GetBackBuffer().GetRTV(), clear_color.data());
 
   // activate linear filtering for the buffer copies
   D3D::SetLinearCopySampler();
@@ -751,7 +748,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     // draw each xfb source
     for (u32 i = 0; i < xfbCount; ++i)
     {
-      const auto* const xfbSource = static_cast<const XFBSource*>(xfbSourceList[i]);
+      const XFBSource* const xfbSource = static_cast<const XFBSource*>(xfbSourceList[i]);
 
       // use virtual xfb with offset
       int xfbHeight = xfbSource->srcHeight;
@@ -783,7 +780,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
       sourceRc.right -= Renderer::EFBToScaledX(fbStride - fbWidth);
 
-      BlitScreen(sourceRc, drawRc, xfbSource->tex, xfbSource->texWidth, xfbSource->texHeight,
+      BlitScreen(sourceRc, drawRc, &xfbSource->tex, xfbSource->texWidth, xfbSource->texHeight,
                  Gamma);
     }
   }
@@ -793,8 +790,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
     // TODO: Improve sampling algorithm for the pixel shader so that we can use the multisampled EFB
     // texture as source
-    D3DTexture2D* read_texture = FramebufferManager::GetResolvedEFBColorTexture();
-    BlitScreen(sourceRc, targetRc, read_texture, GetTargetWidth(), GetTargetHeight(), Gamma);
+    D3DTexture2D& read_texture = FramebufferManager::GetResolvedEFBColorTexture();
+    BlitScreen(sourceRc, targetRc, &read_texture, GetTargetWidth(), GetTargetHeight(), Gamma);
   }
 
   // Dump frames
@@ -806,18 +803,18 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     D3D11_BOX source_box = GetScreenshotSourceBox(targetRc);
     unsigned int source_width = source_box.right - source_box.left;
     unsigned int source_height = source_box.bottom - source_box.top;
-    D3D::context->CopySubresourceRegion(s_screenshot_texture, 0, 0, 0, 0,
-                                        D3D::GetBackBuffer()->GetTex(), 0, &source_box);
+    D3D::context->CopySubresourceRegion(s_screenshot_texture.Get(), 0, 0, 0, 0,
+                                        D3D::GetBackBuffer().GetTex(), 0, &source_box);
 
     D3D11_MAPPED_SUBRESOURCE map;
-    D3D::context->Map(s_screenshot_texture, 0, D3D11_MAP_READ, 0, &map);
+    D3D::context->Map(s_screenshot_texture.Get(), 0, D3D11_MAP_READ, 0, &map);
 
     AVIDump::Frame state = AVIDump::FetchState(ticks);
     DumpFrameData(reinterpret_cast<const u8*>(map.pData), source_width, source_height, map.RowPitch,
                   state);
     FinishFrameData();
 
-    D3D::context->Unmap(s_screenshot_texture, 0);
+    D3D::context->Unmap(s_screenshot_texture.Get(), 0);
   }
 
   // Reset viewport for drawing text
@@ -868,8 +865,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     {
       // TODO: Aren't we still holding a reference to the back buffer right now?
       D3D::Reset();
-      SAFE_RELEASE(s_screenshot_texture);
-      SAFE_RELEASE(s_3d_vision_texture);
+      s_screenshot_texture.Reset();
+      s_3d_vision_texture.Reset();
       m_backbuffer_width = D3D::GetBackBufferWidth();
       m_backbuffer_height = D3D::GetBackBufferHeight();
     }
@@ -878,31 +875,31 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
     s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
 
-    D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
+    D3D::SetRenderTarget(D3D::GetBackBuffer().GetRTV(), nullptr);
 
     g_framebuffer_manager.reset();
     g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
 
-    D3D::context->ClearRenderTargetView(FramebufferManager::GetEFBColorTexture()->GetRTV(),
+    D3D::context->ClearRenderTargetView(FramebufferManager::GetEFBColorTexture().GetRTV(),
                                         clear_color.data());
-    D3D::context->ClearDepthStencilView(FramebufferManager::GetEFBDepthTexture()->GetDSV(),
+    D3D::context->ClearDepthStencilView(FramebufferManager::GetEFBDepthTexture().GetDSV(),
                                         D3D11_CLEAR_DEPTH, 0.f, 0);
   }
 
   // begin next frame
   RestoreAPIState();
   D3D::BeginFrame();
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
   SetViewport();
 }
 
 // ALWAYS call RestoreAPIState for each ResetAPIState call you're doing
 void Renderer::ResetAPIState()
 {
-  D3D::stateman->PushBlendState(s_reset_blend_state);
-  D3D::stateman->PushDepthState(s_reset_depth_state);
-  D3D::stateman->PushRasterizerState(s_reset_rast_state);
+  D3D::stateman->PushBlendState(s_reset_blend_state.Get());
+  D3D::stateman->PushDepthState(s_reset_depth_state.Get());
+  D3D::stateman->PushRasterizerState(s_reset_rast_state.Get());
 }
 
 void Renderer::RestoreAPIState()
@@ -1156,7 +1153,7 @@ void Renderer::BBoxWrite(int index, u16 _value)
   BBox::Set(index, value);
 }
 
-void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
+void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, const D3DTexture2D* src_texture,
                           u32 src_width, u32 src_height, float Gamma)
 {
   if (g_ActiveConfig.iStereoMode == STEREO_SBS || g_ActiveConfig.iStereoMode == STEREO_TAB)
@@ -1183,7 +1180,7 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D
   }
   else if (g_ActiveConfig.iStereoMode == STEREO_3DVISION)
   {
-    if (!s_3d_vision_texture)
+    if (!s_3d_vision_texture.GetTex())
       Create3DVisionTexture(m_backbuffer_width, m_backbuffer_height);
 
     D3D11_VIEWPORT leftVp = CD3D11_VIEWPORT((float)dst.left, (float)dst.top, (float)dst.GetWidth(),
@@ -1192,7 +1189,7 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D
                                              (float)dst.GetWidth(), (float)dst.GetHeight());
 
     // Render to staging texture which is double the width of the backbuffer
-    D3D::context->OMSetRenderTargets(1, &s_3d_vision_texture->GetRTV(), nullptr);
+    D3D::SetRenderTarget(s_3d_vision_texture.GetRTV(), nullptr);
 
     D3D::context->RSSetViewports(1, &leftVp);
     D3D::drawShadedTexQuad(src_texture->GetSRV(), src.AsRECT(), src_width, src_height,
@@ -1209,11 +1206,11 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D
     // Copy the left eye to the backbuffer, if Nvidia 3D Vision is enabled it should
     // recognize the signature and automatically include the right eye frame.
     D3D11_BOX box = CD3D11_BOX(0, 0, 0, m_backbuffer_width, m_backbuffer_height, 1);
-    D3D::context->CopySubresourceRegion(D3D::GetBackBuffer()->GetTex(), 0, 0, 0, 0,
-                                        s_3d_vision_texture->GetTex(), 0, &box);
+    D3D::context->CopySubresourceRegion(D3D::GetBackBuffer().GetTex(), 0, 0, 0, 0,
+                                        s_3d_vision_texture.GetTex(), 0, &box);
 
     // Restore render target to backbuffer
-    D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
+    D3D::SetRenderTarget(D3D::GetBackBuffer().GetRTV(), nullptr);
   }
   else
   {

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -62,7 +62,7 @@ public:
   bool CheckForResize();
 
 private:
-  void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
+  void BlitScreen(TargetRectangle src, TargetRectangle dst, const D3DTexture2D* src_texture,
                   u32 src_width, u32 src_height, float Gamma);
 };
 }

--- a/Source/Core/VideoBackends/D3D/Television.h
+++ b/Source/Core/VideoBackends/D3D/Television.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 
 struct ID3D11Texture2D;
 struct ID3D11ShaderResourceView;
@@ -16,8 +17,6 @@ namespace DX11
 class Television
 {
 public:
-  Television();
-
   void Init();
   void Shutdown();
 
@@ -37,9 +36,9 @@ private:
 
   // Used for real XFB mode
 
-  ID3D11Texture2D* m_yuyvTexture;
-  ID3D11ShaderResourceView* m_yuyvTextureSRV;
-  ID3D11PixelShader* m_pShader;
-  ID3D11SamplerState* m_samplerState;
+  ComPtr<ID3D11Texture2D> m_yuyvTexture;
+  ComPtr<ID3D11ShaderResourceView> m_yuyvTextureSRV;
+  ComPtr<ID3D11PixelShader> m_pShader;
+  ComPtr<ID3D11SamplerState> m_samplerState;
 };
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -30,7 +30,7 @@
 namespace DX11
 {
 static const size_t MAX_COPY_BUFFERS = 32;
-static ID3D11Buffer* s_efbcopycbuf[MAX_COPY_BUFFERS] = {0};
+static ComPtr<ID3D11Buffer> s_efbcopycbuf[MAX_COPY_BUFFERS] = {0};
 static std::unique_ptr<PSTextureEncoder> g_encoder;
 
 std::unique_ptr<AbstractTexture> TextureCache::CreateTexture(const TextureConfig& config)
@@ -139,14 +139,14 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
   D3D::context->RSSetViewports(1, &vp);
 
   D3D11_BOX box{0, 0, 0, 512, 1, 1};
-  D3D::context->UpdateSubresource(palette_buf, 0, &box, palette, 0, 0);
+  D3D::context->UpdateSubresource(palette_buf.Get(), 0, &box, palette, 0, 0);
 
-  D3D::stateman->SetTexture(1, palette_buf_srv);
+  D3D::stateman->SetTexture(1, palette_buf_srv.Get());
 
   // TODO: Add support for C14X2 format.  (Different multiplier, more palette entries.)
   float params[4] = {(source->format & 0xf) == GX_TF_I4 ? 15.f : 255.f};
-  D3D::context->UpdateSubresource(palette_uniform, 0, nullptr, &params, 0, 0);
-  D3D::stateman->SetPixelConstants(palette_uniform);
+  D3D::context->UpdateSubresource(palette_uniform.Get(), 0, nullptr, &params, 0, 0);
+  D3D::stateman->SetPixelConstants(palette_uniform.Get());
 
   const D3D11_RECT sourcerect = CD3D11_RECT(0, 0, source->GetWidth(), source->GetHeight());
 
@@ -157,22 +157,22 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
   D3D::stateman->UnsetTexture(destination_texture->GetRawTexIdentifier()->GetSRV());
   D3D::stateman->Apply();
 
-  D3D::context->OMSetRenderTargets(1, &destination_texture->GetRawTexIdentifier()->GetRTV(),
-                                   nullptr);
+  D3D::SetRenderTarget(destination_texture->GetRawTexIdentifier()->GetRTV(), nullptr);
 
   // Create texture copy
   D3D::drawShadedTexQuad(
       source_texture->GetRawTexIdentifier()->GetSRV(), &sourcerect, source->GetWidth(),
-      source->GetHeight(), palette_pixel_shader[format], VertexShaderCache::GetSimpleVertexShader(),
-      VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
+      source->GetHeight(), palette_pixel_shader[format].Get(),
+      VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
+      GeometryShaderCache::GetCopyGeometryShader());
 
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 
   g_renderer->RestoreAPIState();
 }
 
-ID3D11PixelShader* GetConvertShader(const char* Type)
+static ComPtr<ID3D11PixelShader> GetConvertShader(const char* Type)
 {
   std::string shader = "#define DECODE DecodePixel_";
   shader.append(Type);
@@ -187,43 +187,34 @@ TextureCache::TextureCache()
   g_encoder = std::make_unique<PSTextureEncoder>();
   g_encoder->Init();
 
-  palette_buf = nullptr;
-  palette_buf_srv = nullptr;
-  palette_uniform = nullptr;
   palette_pixel_shader[GX_TL_IA8] = GetConvertShader("IA8");
   palette_pixel_shader[GX_TL_RGB565] = GetConvertShader("RGB565");
   palette_pixel_shader[GX_TL_RGB5A3] = GetConvertShader("RGB5A3");
   auto lutBd = CD3D11_BUFFER_DESC(sizeof(u16) * 256, D3D11_BIND_SHADER_RESOURCE);
   HRESULT hr = D3D::device->CreateBuffer(&lutBd, nullptr, &palette_buf);
   CHECK(SUCCEEDED(hr), "create palette decoder lut buffer");
-  D3D::SetDebugObjectName(palette_buf, "texture decoder lut buffer");
+  D3D::SetDebugObjectName(palette_buf.Get(), "texture decoder lut buffer");
   // TODO: C14X2 format.
   auto outlutUavDesc =
-      CD3D11_SHADER_RESOURCE_VIEW_DESC(palette_buf, DXGI_FORMAT_R16_UINT, 0, 256, 0);
-  hr = D3D::device->CreateShaderResourceView(palette_buf, &outlutUavDesc, &palette_buf_srv);
+      CD3D11_SHADER_RESOURCE_VIEW_DESC(palette_buf.Get(), DXGI_FORMAT_R16_UINT, 0, 256, 0);
+  hr = D3D::device->CreateShaderResourceView(palette_buf.Get(), &outlutUavDesc, &palette_buf_srv);
   CHECK(SUCCEEDED(hr), "create palette decoder lut srv");
-  D3D::SetDebugObjectName(palette_buf_srv, "texture decoder lut srv");
+  D3D::SetDebugObjectName(palette_buf_srv.Get(), "texture decoder lut srv");
   const D3D11_BUFFER_DESC cbdesc =
       CD3D11_BUFFER_DESC(16, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DEFAULT);
   hr = D3D::device->CreateBuffer(&cbdesc, nullptr, &palette_uniform);
   CHECK(SUCCEEDED(hr), "Create palette decoder constant buffer");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)palette_uniform,
+  D3D::SetDebugObjectName(palette_uniform.Get(),
                           "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
 }
 
 TextureCache::~TextureCache()
 {
   for (unsigned int k = 0; k < MAX_COPY_BUFFERS; ++k)
-    SAFE_RELEASE(s_efbcopycbuf[k]);
+    s_efbcopycbuf[k].Reset();
 
   g_encoder->Shutdown();
   g_encoder.reset();
-
-  SAFE_RELEASE(palette_buf);
-  SAFE_RELEASE(palette_buf_srv);
-  SAFE_RELEASE(palette_uniform);
-  for (ID3D11PixelShader*& shader : palette_pixel_shader)
-    SAFE_RELEASE(shader);
 }
 
 void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
@@ -237,13 +228,13 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
   // filter is ignored.
   bool multisampled = (g_ActiveConfig.iMultisamples > 1);
   ID3D11ShaderResourceView* efbTexSRV = is_depth_copy ?
-                                            FramebufferManager::GetEFBDepthTexture()->GetSRV() :
-                                            FramebufferManager::GetEFBColorTexture()->GetSRV();
+                                            FramebufferManager::GetEFBDepthTexture().GetSRV() :
+                                            FramebufferManager::GetEFBColorTexture().GetSRV();
   if (multisampled && scale_by_half)
   {
     multisampled = false;
-    efbTexSRV = is_depth_copy ? FramebufferManager::GetResolvedEFBDepthTexture()->GetSRV() :
-                                FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
+    efbTexSRV = is_depth_copy ? FramebufferManager::GetResolvedEFBDepthTexture().GetSRV() :
+                                FramebufferManager::GetResolvedEFBColorTexture().GetSRV();
   }
 
   g_renderer->ResetAPIState();
@@ -263,10 +254,10 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
     data.pSysMem = colmat;
     HRESULT hr = D3D::device->CreateBuffer(&cbdesc, &data, &s_efbcopycbuf[cbuf_id]);
     CHECK(SUCCEEDED(hr), "Create efb copy constant buffer %d", cbuf_id);
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_efbcopycbuf[cbuf_id],
+    D3D::SetDebugObjectName(s_efbcopycbuf[cbuf_id].Get(),
                             "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
   }
-  D3D::stateman->SetPixelConstants(s_efbcopycbuf[cbuf_id]);
+  D3D::stateman->SetPixelConstants(s_efbcopycbuf[cbuf_id].Get());
 
   const TargetRectangle targetSource = g_renderer->ConvertEFBRectangle(src_rect);
   // TODO: try targetSource.asRECT();
@@ -284,8 +275,7 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
   D3D::stateman->UnsetTexture(destination_texture->GetRawTexIdentifier()->GetSRV());
   D3D::stateman->Apply();
 
-  D3D::context->OMSetRenderTargets(1, &destination_texture->GetRawTexIdentifier()->GetRTV(),
-                                   nullptr);
+  D3D::SetRenderTarget(destination_texture->GetRawTexIdentifier()->GetRTV(), nullptr);
 
   // Create texture copy
   D3D::drawShadedTexQuad(
@@ -295,8 +285,8 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
       VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
       GeometryShaderCache::GetCopyGeometryShader());
 
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 
   g_renderer->RestoreAPIState();
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -40,9 +40,9 @@ private:
 
   bool CompileShaders() override { return true; }
   void DeleteShaders() override {}
-  ID3D11Buffer* palette_buf;
-  ID3D11ShaderResourceView* palette_buf_srv;
-  ID3D11Buffer* palette_uniform;
-  ID3D11PixelShader* palette_pixel_shader[3];
+  ComPtr<ID3D11Buffer> palette_buf;
+  ComPtr<ID3D11ShaderResourceView> palette_buf_srv;
+  ComPtr<ID3D11Buffer> palette_uniform;
+  ComPtr<ID3D11PixelShader> palette_pixel_shader[3];
 };
 }

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/VertexManagerBase.h"
 
 struct ID3D11Buffer;
@@ -41,7 +42,7 @@ private:
   {
     MAX_BUFFER_COUNT = 2
   };
-  ID3D11Buffer* m_buffers[MAX_BUFFER_COUNT];
+  ComPtr<ID3D11Buffer> m_buffers[MAX_BUFFER_COUNT];
 
   std::vector<u8> LocalVBuffer;
   std::vector<u16> LocalIBuffer;

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -21,9 +21,9 @@ public:
   static void Shutdown();
   static bool SetShader();  // TODO: Should be renamed to LoadShader
 
-  static ID3D11VertexShader* GetActiveShader() { return last_entry->shader; }
-  static D3DBlob* GetActiveShaderBytecode() { return last_entry->bytecode; }
-  static ID3D11Buffer*& GetConstantBuffer();
+  static ID3D11VertexShader* GetActiveShader() { return last_entry->shader.Get(); }
+  static D3DBlob* GetActiveShaderBytecode() { return last_entry->bytecode.Get(); }
+  static ID3D11Buffer* GetConstantBuffer();
 
   static ID3D11VertexShader* GetSimpleVertexShader();
   static ID3D11VertexShader* GetClearVertexShader();
@@ -35,20 +35,18 @@ public:
 private:
   struct VSCacheEntry
   {
-    ID3D11VertexShader* shader;
-    D3DBlob* bytecode;  // needed to initialize the input layout
+    ComPtr<ID3D11VertexShader> shader;
+    ComPtr<D3DBlob> bytecode;  // needed to initialize the input layout
 
-    VSCacheEntry() : shader(nullptr), bytecode(nullptr) {}
     void SetByteCode(D3DBlob* blob)
     {
-      SAFE_RELEASE(bytecode);
+      // Note that assigning to a ComPtr calls AddRef.
       bytecode = blob;
-      blob->AddRef();
     }
     void Destroy()
     {
-      SAFE_RELEASE(shader);
-      SAFE_RELEASE(bytecode);
+      shader.Reset();
+      bytecode.Reset();
     }
   };
   typedef std::map<VertexShaderUid, VSCacheEntry> VSCache;

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -152,15 +152,15 @@ void XFBEncoder::Init()
                                                     MAX_XFB_HEIGHT, 1, 1, D3D11_BIND_RENDER_TARGET);
   hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_out);
   CHECK(SUCCEEDED(hr), "create xfb encoder output texture");
-  D3D::SetDebugObjectName(m_out, "xfb encoder output texture");
+  D3D::SetDebugObjectName(m_out.Get(), "xfb encoder output texture");
 
   // Create output render target view
 
   D3D11_RENDER_TARGET_VIEW_DESC rtvd = CD3D11_RENDER_TARGET_VIEW_DESC(
-      m_out, D3D11_RTV_DIMENSION_TEXTURE2D, DXGI_FORMAT_R8G8B8A8_UNORM);
-  hr = D3D::device->CreateRenderTargetView(m_out, &rtvd, &m_outRTV);
+      m_out.Get(), D3D11_RTV_DIMENSION_TEXTURE2D, DXGI_FORMAT_R8G8B8A8_UNORM);
+  hr = D3D::device->CreateRenderTargetView(m_out.Get(), &rtvd, &m_outRTV);
   CHECK(SUCCEEDED(hr), "create xfb encoder output texture rtv");
-  D3D::SetDebugObjectName(m_outRTV, "xfb encoder output rtv");
+  D3D::SetDebugObjectName(m_outRTV.Get(), "xfb encoder output rtv");
 
   // Create output staging buffer
 
@@ -169,14 +169,14 @@ void XFBEncoder::Init()
   t2dd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
   hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_outStage);
   CHECK(SUCCEEDED(hr), "create xfb encoder output staging buffer");
-  D3D::SetDebugObjectName(m_outStage, "xfb encoder output staging buffer");
+  D3D::SetDebugObjectName(m_outStage.Get(), "xfb encoder output staging buffer");
 
   // Create constant buffer for uploading params to shaders
 
   D3D11_BUFFER_DESC bd = CD3D11_BUFFER_DESC(sizeof(XFBEncodeParams), D3D11_BIND_CONSTANT_BUFFER);
   hr = D3D::device->CreateBuffer(&bd, nullptr, &m_encodeParams);
   CHECK(SUCCEEDED(hr), "create xfb encode params buffer");
-  D3D::SetDebugObjectName(m_encodeParams, "xfb encoder params buffer");
+  D3D::SetDebugObjectName(m_encodeParams.Get(), "xfb encoder params buffer");
 
   // Create vertex quad
 
@@ -185,11 +185,11 @@ void XFBEncoder::Init()
 
   hr = D3D::device->CreateBuffer(&bd, &srd, &m_quad);
   CHECK(SUCCEEDED(hr), "create xfb encode quad vertex buffer");
-  D3D::SetDebugObjectName(m_quad, "xfb encoder quad vertex buffer");
+  D3D::SetDebugObjectName(m_quad.Get(), "xfb encoder quad vertex buffer");
 
   // Create vertex shader
 
-  D3DBlob* bytecode = nullptr;
+  ComPtr<D3DBlob> bytecode;
   if (!D3D::CompileVertexShader(XFB_ENCODE_VS, &bytecode))
   {
     ERROR_LOG(VIDEO, "XFB encode vertex shader failed to compile");
@@ -198,7 +198,7 @@ void XFBEncoder::Init()
 
   hr = D3D::device->CreateVertexShader(bytecode->Data(), bytecode->Size(), nullptr, &m_vShader);
   CHECK(SUCCEEDED(hr), "create xfb encode vertex shader");
-  D3D::SetDebugObjectName(m_vShader, "xfb encoder vertex shader");
+  D3D::SetDebugObjectName(m_vShader.Get(), "xfb encoder vertex shader");
 
   // Create input layout for vertex quad using bytecode from vertex shader
 
@@ -206,9 +206,9 @@ void XFBEncoder::Init()
                                       sizeof(QUAD_LAYOUT_DESC) / sizeof(D3D11_INPUT_ELEMENT_DESC),
                                       bytecode->Data(), bytecode->Size(), &m_quadLayout);
   CHECK(SUCCEEDED(hr), "create xfb encode quad vertex layout");
-  D3D::SetDebugObjectName(m_quadLayout, "xfb encoder quad layout");
+  D3D::SetDebugObjectName(m_quadLayout.Get(), "xfb encoder quad layout");
 
-  bytecode->Release();
+  bytecode.Reset();
 
   // Create pixel shader
 
@@ -218,14 +218,14 @@ void XFBEncoder::Init()
     ERROR_LOG(VIDEO, "XFB encode pixel shader failed to compile");
     return;
   }
-  D3D::SetDebugObjectName(m_pShader, "xfb encoder pixel shader");
+  D3D::SetDebugObjectName(m_pShader.Get(), "xfb encoder pixel shader");
 
   // Create blend state
 
   D3D11_BLEND_DESC bld = CD3D11_BLEND_DESC(CD3D11_DEFAULT());
   hr = D3D::device->CreateBlendState(&bld, &m_xfbEncodeBlendState);
   CHECK(SUCCEEDED(hr), "create xfb encode blend state");
-  D3D::SetDebugObjectName(m_xfbEncodeBlendState, "xfb encoder blend state");
+  D3D::SetDebugObjectName(m_xfbEncodeBlendState.Get(), "xfb encoder blend state");
 
   // Create depth state
 
@@ -233,7 +233,7 @@ void XFBEncoder::Init()
   dsd.DepthEnable = FALSE;
   hr = D3D::device->CreateDepthStencilState(&dsd, &m_xfbEncodeDepthState);
   CHECK(SUCCEEDED(hr), "create xfb encode depth state");
-  D3D::SetDebugObjectName(m_xfbEncodeDepthState, "xfb encoder depth state");
+  D3D::SetDebugObjectName(m_xfbEncodeDepthState.Get(), "xfb encoder depth state");
 
   // Create rasterizer state
 
@@ -242,7 +242,7 @@ void XFBEncoder::Init()
   rd.DepthClipEnable = FALSE;
   hr = D3D::device->CreateRasterizerState(&rd, &m_xfbEncodeRastState);
   CHECK(SUCCEEDED(hr), "create xfb encode rasterizer state");
-  D3D::SetDebugObjectName(m_xfbEncodeRastState, "xfb encoder rast state");
+  D3D::SetDebugObjectName(m_xfbEncodeRastState.Get(), "xfb encoder rast state");
 
   // Create EFB texture sampler
 
@@ -250,23 +250,23 @@ void XFBEncoder::Init()
   sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
   hr = D3D::device->CreateSamplerState(&sd, &m_efbSampler);
   CHECK(SUCCEEDED(hr), "create xfb encode texture sampler");
-  D3D::SetDebugObjectName(m_efbSampler, "xfb encoder texture sampler");
+  D3D::SetDebugObjectName(m_efbSampler.Get(), "xfb encoder texture sampler");
 }
 
 void XFBEncoder::Shutdown()
 {
-  SAFE_RELEASE(m_efbSampler);
-  SAFE_RELEASE(m_xfbEncodeRastState);
-  SAFE_RELEASE(m_xfbEncodeDepthState);
-  SAFE_RELEASE(m_xfbEncodeBlendState);
-  SAFE_RELEASE(m_pShader);
-  SAFE_RELEASE(m_quadLayout);
-  SAFE_RELEASE(m_vShader);
-  SAFE_RELEASE(m_quad);
-  SAFE_RELEASE(m_encodeParams);
-  SAFE_RELEASE(m_outStage);
-  SAFE_RELEASE(m_outRTV);
-  SAFE_RELEASE(m_out);
+  m_efbSampler.Reset();
+  m_xfbEncodeRastState.Reset();
+  m_xfbEncodeDepthState.Reset();
+  m_xfbEncodeBlendState.Reset();
+  m_pShader.Reset();
+  m_quadLayout.Reset();
+  m_vShader.Reset();
+  m_quad.Reset();
+  m_encodeParams.Reset();
+  m_outStage.Reset();
+  m_outRTV.Reset();
+  m_out.Reset();
 }
 
 void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcRect, float gamma)
@@ -279,22 +279,22 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 
   // Set up all the state for XFB encoding
 
-  D3D::stateman->SetPixelShader(m_pShader);
-  D3D::stateman->SetVertexShader(m_vShader);
+  D3D::stateman->SetPixelShader(m_pShader.Get());
+  D3D::stateman->SetVertexShader(m_vShader.Get());
   D3D::stateman->SetGeometryShader(nullptr);
 
-  D3D::stateman->PushBlendState(m_xfbEncodeBlendState);
-  D3D::stateman->PushDepthState(m_xfbEncodeDepthState);
-  D3D::stateman->PushRasterizerState(m_xfbEncodeRastState);
+  D3D::stateman->PushBlendState(m_xfbEncodeBlendState.Get());
+  D3D::stateman->PushDepthState(m_xfbEncodeDepthState.Get());
+  D3D::stateman->PushRasterizerState(m_xfbEncodeRastState.Get());
 
   D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, FLOAT(width / 2), FLOAT(height));
   D3D::context->RSSetViewports(1, &vp);
 
-  D3D::stateman->SetInputLayout(m_quadLayout);
+  D3D::stateman->SetInputLayout(m_quadLayout.Get());
   D3D::stateman->SetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
   UINT stride = sizeof(QuadVertex);
   UINT offset = 0;
-  D3D::stateman->SetVertexBuffer(m_quad, stride, offset);
+  D3D::stateman->SetVertexBuffer(m_quad.Get(), stride, offset);
 
   TargetRectangle targetRect = g_renderer->ConvertEFBRectangle(srcRect);
 
@@ -306,16 +306,16 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
   params.TexRight = FLOAT(targetRect.right) / g_renderer->GetTargetWidth();
   params.TexBottom = FLOAT(targetRect.bottom) / g_renderer->GetTargetHeight();
   params.Gamma = gamma;
-  D3D::context->UpdateSubresource(m_encodeParams, 0, nullptr, &params, 0, 0);
+  D3D::context->UpdateSubresource(m_encodeParams.Get(), 0, nullptr, &params, 0, 0);
 
   D3D::context->OMSetRenderTargets(1, &m_outRTV, nullptr);
 
-  ID3D11ShaderResourceView* pEFB = FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
+  ID3D11ShaderResourceView* pEFB = FramebufferManager::GetResolvedEFBColorTexture().GetSRV();
 
-  D3D::stateman->SetVertexConstants(m_encodeParams);
-  D3D::stateman->SetPixelConstants(m_encodeParams);
+  D3D::stateman->SetVertexConstants(m_encodeParams.Get());
+  D3D::stateman->SetPixelConstants(m_encodeParams.Get());
   D3D::stateman->SetTexture(0, pEFB);
-  D3D::stateman->SetSampler(0, m_efbSampler);
+  D3D::stateman->SetSampler(0, m_efbSampler.Get());
 
   // Encode!
 
@@ -325,7 +325,7 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
   // Copy to staging buffer
 
   D3D11_BOX srcBox = CD3D11_BOX(0, 0, 0, width / 2, height, 1);
-  D3D::context->CopySubresourceRegion(m_outStage, 0, 0, 0, 0, m_out, 0, &srcBox);
+  D3D::context->CopySubresourceRegion(m_outStage.Get(), 0, 0, 0, 0, m_out.Get(), 0, &srcBox);
 
   // Clean up state
 
@@ -346,7 +346,7 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
   // Transfer staging buffer to GameCube/Wii RAM
 
   D3D11_MAPPED_SUBRESOURCE map = {0};
-  hr = D3D::context->Map(m_outStage, 0, D3D11_MAP_READ, 0, &map);
+  hr = D3D::context->Map(m_outStage.Get(), 0, D3D11_MAP_READ, 0, &map);
   CHECK(SUCCEEDED(hr), "map staging buffer");
 
   u8* src = (u8*)map.pData;
@@ -357,12 +357,12 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
     src += map.RowPitch;
   }
 
-  D3D::context->Unmap(m_outStage, 0);
+  D3D::context->Unmap(m_outStage.Get(), 0);
 
   // Restore API
   g_renderer->RestoreAPIState();
   D3D::stateman->Apply();  // force unbind efb texture as shader resource
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 }
 }

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.h
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/VideoCommon.h"
 
 struct ID3D11Texture2D;
@@ -30,17 +31,17 @@ public:
   void Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcRect, float gamma);
 
 private:
-  ID3D11Texture2D* m_out;
-  ID3D11RenderTargetView* m_outRTV;
-  ID3D11Texture2D* m_outStage;
-  ID3D11Buffer* m_encodeParams;
-  ID3D11Buffer* m_quad;
-  ID3D11VertexShader* m_vShader;
-  ID3D11InputLayout* m_quadLayout;
-  ID3D11PixelShader* m_pShader;
-  ID3D11BlendState* m_xfbEncodeBlendState;
-  ID3D11DepthStencilState* m_xfbEncodeDepthState;
-  ID3D11RasterizerState* m_xfbEncodeRastState;
-  ID3D11SamplerState* m_efbSampler;
+  ComPtr<ID3D11Texture2D> m_out;
+  ComPtr<ID3D11RenderTargetView> m_outRTV;
+  ComPtr<ID3D11Texture2D> m_outStage;
+  ComPtr<ID3D11Buffer> m_encodeParams;
+  ComPtr<ID3D11Buffer> m_quad;
+  ComPtr<ID3D11VertexShader> m_vShader;
+  ComPtr<ID3D11InputLayout> m_quadLayout;
+  ComPtr<ID3D11PixelShader> m_pShader;
+  ComPtr<ID3D11BlendState> m_xfbEncodeBlendState;
+  ComPtr<ID3D11DepthStencilState> m_xfbEncodeDepthState;
+  ComPtr<ID3D11RasterizerState> m_xfbEncodeRastState;
+  ComPtr<ID3D11SamplerState> m_efbSampler;
 };
 }

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -79,9 +79,9 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsGPUTextureDecoding = false;
   g_Config.backend_info.bSupportsST3CTextures = false;
 
-  IDXGIFactory* factory;
-  IDXGIAdapter* ad;
-  hr = DX11::PCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
+  ComPtr<IDXGIFactory> factory;
+  ComPtr<IDXGIAdapter> ad;
+  hr = DX11::PCreateDXGIFactory(__uuidof(IDXGIFactory), &factory);
   if (FAILED(hr))
     PanicAlert("Failed to create IDXGIFactory object");
 
@@ -100,14 +100,14 @@ void VideoBackend::InitBackendInfo()
     if (adapter_index == g_Config.iAdapter)
     {
       std::string samples;
-      std::vector<DXGI_SAMPLE_DESC> modes = DX11::D3D::EnumAAModes(ad);
+      std::vector<DXGI_SAMPLE_DESC> modes = DX11::D3D::EnumAAModes(ad.Get());
       // First iteration will be 1. This equals no AA.
       for (unsigned int i = 0; i < modes.size(); ++i)
       {
         g_Config.backend_info.AAModes.push_back(modes[i].Count);
       }
 
-      D3D_FEATURE_LEVEL feature_level = D3D::GetFeatureLevel(ad);
+      D3D_FEATURE_LEVEL feature_level = D3D::GetFeatureLevel(ad.Get());
       bool shader_model_5_supported = feature_level >= D3D_FEATURE_LEVEL_11_0;
       g_Config.backend_info.MaxTextureSize = D3D::GetMaxTextureSize(feature_level);
 
@@ -125,9 +125,9 @@ void VideoBackend::InitBackendInfo()
       g_Config.backend_info.bSupportsSSAA = shader_model_5_supported;
     }
     g_Config.backend_info.Adapters.push_back(UTF16ToUTF8(desc.Description));
-    ad->Release();
+    ad.Reset();
   }
-  factory->Release();
+  factory.Reset();
 
   DX11::D3D::UnloadDXGI();
   DX11::D3D::UnloadD3D();


### PR DESCRIPTION
This PR removes all manual management of COM pointers (AddRef, Release, SAFE_RELEASE, etc.) from the D3D11 backend and replaces it with WRL's ComPtr class.

This makes the code cleaner, and makes resource leaks easier to avoid.