### PR TITLE
SysConf: Minor fixes

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
@@ -19,8 +19,6 @@ namespace IOS
 {
 namespace HLE
 {
-constexpr u16 BT_INFO_SECTION_LENGTH = 0x460;
-
 void BackUpBTInfoSection(const SysConf* sysconf)
 {
   const std::string filename = File::GetUserPath(D_SESSION_WIIROOT_IDX) + DIR_SEP WII_BTDINF_BACKUP;
@@ -33,7 +31,7 @@ void BackUpBTInfoSection(const SysConf* sysconf)
     return;
 
   const std::vector<u8>& section = btdinf->bytes;
-  if (!backup.WriteBytes(section.data(), section.size()))
+  if (!backup.WriteBytes(section.data(), section.size() - 1))
     ERROR_LOG(IOS_WIIMOTE, "Failed to back up BT.DINF section");
 }
 
@@ -43,14 +41,13 @@ void RestoreBTInfoSection(SysConf* sysconf)
   File::IOFile backup(filename, "rb");
   if (!backup)
     return;
-  std::vector<u8> section(BT_INFO_SECTION_LENGTH);
-  if (!backup.ReadBytes(section.data(), section.size()))
+  auto& section = sysconf->GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes;
+  if (!backup.ReadBytes(section.data(), section.size() - 1))
   {
     ERROR_LOG(IOS_WIIMOTE, "Failed to read backed up BT.DINF section");
     return;
   }
 
-  sysconf->GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes = std::move(section);
   File::Delete(filename);
 }
 }  // namespace HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
@@ -21,7 +21,7 @@ namespace HLE
 {
 void BackUpBTInfoSection(const SysConf* sysconf)
 {
-  const std::string filename = File::GetUserPath(D_SESSION_WIIROOT_IDX) + DIR_SEP WII_BTDINF_BACKUP;
+  const std::string filename = File::GetUserPath(D_CONFIG_IDX) + DIR_SEP WII_BTDINF_BACKUP;
   if (File::Exists(filename))
     return;
   File::IOFile backup(filename, "wb");
@@ -31,18 +31,18 @@ void BackUpBTInfoSection(const SysConf* sysconf)
     return;
 
   const std::vector<u8>& section = btdinf->bytes;
-  if (!backup.WriteBytes(section.data(), section.size() - 1))
+  if (!backup.WriteBytes(section.data(), section.size()))
     ERROR_LOG(IOS_WIIMOTE, "Failed to back up BT.DINF section");
 }
 
 void RestoreBTInfoSection(SysConf* sysconf)
 {
-  const std::string filename = File::GetUserPath(D_SESSION_WIIROOT_IDX) + DIR_SEP WII_BTDINF_BACKUP;
+  const std::string filename = File::GetUserPath(D_CONFIG_IDX) + DIR_SEP WII_BTDINF_BACKUP;
   File::IOFile backup(filename, "rb");
   if (!backup)
     return;
   auto& section = sysconf->GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes;
-  if (!backup.ReadBytes(section.data(), section.size() - 1))
+  if (!backup.ReadBytes(section.data(), section.size()))
   {
     ERROR_LOG(IOS_WIIMOTE, "Failed to read backed up BT.DINF section");
     return;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -47,7 +47,7 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
   if (!Core::WantsDeterminism())
     BackUpBTInfoSection(&sysconf);
 
-  _conf_pads BT_DINF;
+  _conf_pads BT_DINF{};
   bdaddr_t tmpBD;
   u8 i = 0;
   while (i < MAX_BBMOTES)
@@ -79,7 +79,7 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
   // save now so that when games load sysconf file it includes the new Wii Remotes
   // and the correct order for connected Wii Remotes
   auto& section = sysconf.GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes;
-  section.resize(sizeof(_conf_pads) + 1);
+  section.resize(sizeof(_conf_pads));
   std::memcpy(section.data(), &BT_DINF, sizeof(_conf_pads));
   if (!sysconf.Save())
     PanicAlertT("Failed to write BT.DINF to SYSCONF");

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -78,9 +78,9 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
 
   // save now so that when games load sysconf file it includes the new Wii Remotes
   // and the correct order for connected Wii Remotes
-  std::vector<u8> data(sizeof(_conf_pads));
-  std::memcpy(data.data(), &BT_DINF, data.size());
-  sysconf.GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes = std::move(data);
+  auto& section = sysconf.GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes;
+  section.resize(sizeof(_conf_pads) + 1);
+  std::memcpy(section.data(), &BT_DINF, sizeof(_conf_pads));
   if (!sysconf.Save())
     PanicAlertT("Failed to write BT.DINF to SYSCONF");
 }

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -191,7 +191,7 @@ private:
     u8 num_registered;
     _conf_pad_device registered[CONF_PAD_MAX_REGISTERED];
     _conf_pad_device active[MAX_BBMOTES];
-    u8 unknown[0x45];
+    _conf_pad_device unknown;
   };
 #pragma pack(pop)
 };


### PR DESCRIPTION
It turns out that the last byte of array entries isn't unused (as we
thought); instead, it looks like it's actually part of the main data,
and the length stored next to the name is in fact the length minus one.

Getting it wrong and always storing a null byte in there won't affect
most entries (since the last byte is zeroed most of the time), except:

- IPL.NIK: the length is stored in the last byte, and it must be kept.
- BT.DINF: u8 unknown[0x45] should be another Bluetooth device entry.
- Possibly other unknown affected entries.