### PR TITLE
Qt: Implement Show Platforms / Show Regions

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SRCS
   GameList/GameListModel.cpp
   GameList/GameTracker.cpp
   GameList/ListProxyModel.cpp
+  GameList/TableProxyModel.cpp
   QtUtils/DoubleClickEventFilter.cpp
   QtUtils/ElidedButton.cpp
   QtUtils/WindowActivationEventFilter.cpp

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -84,6 +84,7 @@
     <QtMoc Include="GameList\GameListModel.h" />
     <QtMoc Include="GameList\GameTracker.h" />
     <QtMoc Include="GameList\ListProxyModel.h" />
+    <QtMoc Include="GameList\TableProxyModel.h" />
     <QtMoc Include="Host.h" />
     <QtMoc Include="HotkeyScheduler.h" />
     <QtMoc Include="InDevelopmentWarning.h" />
@@ -125,6 +126,7 @@
     <ClCompile Include="$(QtMocOutPrefix)InterfacePane.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)IOWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ListProxyModel.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)TableProxyModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MainWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MappingButton.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MappingWidget.cpp" />
@@ -177,6 +179,7 @@
     <ClCompile Include="GameList\GameListModel.cpp" />
     <ClCompile Include="GameList\GameTracker.cpp" />
     <ClCompile Include="GameList\ListProxyModel.cpp" />
+    <ClCompile Include="GameList\TableProxyModel.cpp" />
     <ClCompile Include="HotkeyScheduler.cpp" />
     <ClCompile Include="Host.cpp" />
     <ClCompile Include="InDevelopmentWarning.cpp" />

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -26,6 +26,7 @@
 #include "DolphinQt2/Config/PropertiesDialog.h"
 #include "DolphinQt2/GameList/GameList.h"
 #include "DolphinQt2/GameList/ListProxyModel.h"
+#include "DolphinQt2/GameList/TableProxyModel.h"
 #include "DolphinQt2/QtUtils/DoubleClickEventFilter.h"
 #include "DolphinQt2/Settings.h"
 
@@ -34,7 +35,7 @@ static bool CompressCB(const std::string&, float, void*);
 GameList::GameList(QWidget* parent) : QStackedWidget(parent)
 {
   m_model = new GameListModel(this);
-  m_table_proxy = new QSortFilterProxyModel(this);
+  m_table_proxy = new TableProxyModel(this);
   m_table_proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
   m_table_proxy->setSortRole(Qt::InitialSortOrderRole);
   m_table_proxy->setSourceModel(m_model);
@@ -442,6 +443,12 @@ void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)
       {tr("Quality"), GameListModel::COL_RATING}};
 
   m_table->setColumnHidden(rowname_to_col_index[row], !visible);
+}
+
+void GameList::OnGameListVisibilityChanged()
+{
+  m_table_proxy->invalidate();
+  m_list_proxy->invalidate();
 }
 
 static bool CompressCB(const std::string& text, float percent, void* ptr)

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -26,6 +26,7 @@ public slots:
   void SetListView() { SetPreferredView(false); }
   void SetViewColumn(int col, bool view) { m_table->setColumnHidden(col, !view); }
   void OnColumnVisibilityToggled(const QString& row, bool visible);
+  void OnGameListVisibilityChanged();
 
 private slots:
   void ShowContextMenu(const QPoint&);

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "DolphinQt2/GameList/GameListModel.h"
-
+#include "Core/ConfigManager.h"
 #include "DiscIO/Enums.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
@@ -136,6 +136,63 @@ int GameListModel::rowCount(const QModelIndex& parent) const
 int GameListModel::columnCount(const QModelIndex& parent) const
 {
   return NUM_COLS;
+}
+
+bool GameListModel::ShouldDisplayGameListItem(int index) const
+{
+  QSharedPointer<GameFile> game = m_games[index];
+
+  const bool show_platform = [&game] {
+    switch (game->GetPlatformID())
+    {
+    case DiscIO::Platform::GAMECUBE_DISC:
+      return SConfig::GetInstance().m_ListGC;
+    case DiscIO::Platform::WII_DISC:
+      return SConfig::GetInstance().m_ListWii;
+    case DiscIO::Platform::WII_WAD:
+      return SConfig::GetInstance().m_ListWad;
+    case DiscIO::Platform::ELF_DOL:
+      return SConfig::GetInstance().m_ListElfDol;
+    default:
+      return false;
+    }
+  }();
+
+  if (!show_platform)
+    return false;
+
+  switch (game->GetCountryID())
+  {
+  case DiscIO::Country::COUNTRY_AUSTRALIA:
+    return SConfig::GetInstance().m_ListAustralia;
+  case DiscIO::Country::COUNTRY_EUROPE:
+    return SConfig::GetInstance().m_ListPal;
+  case DiscIO::Country::COUNTRY_FRANCE:
+    return SConfig::GetInstance().m_ListFrance;
+  case DiscIO::Country::COUNTRY_GERMANY:
+    return SConfig::GetInstance().m_ListGermany;
+  case DiscIO::Country::COUNTRY_ITALY:
+    return SConfig::GetInstance().m_ListItaly;
+  case DiscIO::Country::COUNTRY_JAPAN:
+    return SConfig::GetInstance().m_ListJap;
+  case DiscIO::Country::COUNTRY_KOREA:
+    return SConfig::GetInstance().m_ListKorea;
+  case DiscIO::Country::COUNTRY_NETHERLANDS:
+    return SConfig::GetInstance().m_ListNetherlands;
+  case DiscIO::Country::COUNTRY_RUSSIA:
+    return SConfig::GetInstance().m_ListRussia;
+  case DiscIO::Country::COUNTRY_SPAIN:
+    return SConfig::GetInstance().m_ListSpain;
+  case DiscIO::Country::COUNTRY_TAIWAN:
+    return SConfig::GetInstance().m_ListTaiwan;
+  case DiscIO::Country::COUNTRY_USA:
+    return SConfig::GetInstance().m_ListUsa;
+  case DiscIO::Country::COUNTRY_WORLD:
+    return SConfig::GetInstance().m_ListWorld;
+  case DiscIO::Country::COUNTRY_UNKNOWN:
+  default:
+    return SConfig::GetInstance().m_ListUnknown;
+  }
 }
 
 void GameListModel::UpdateGame(QSharedPointer<GameFile> game)

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -27,6 +27,7 @@ public:
 
   // Path of the Game at the specified index.
   QString GetPath(int index) const { return m_games[index]->GetFilePath(); }
+  bool ShouldDisplayGameListItem(int index) const;
   enum
   {
     COL_PLATFORM = 0,

--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
@@ -34,3 +34,9 @@ QVariant ListProxyModel::data(const QModelIndex& i, int role) const
   }
   return QVariant();
 }
+
+bool ListProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
+{
+  GameListModel* glm = qobject_cast<GameListModel*>(sourceModel());
+  return glm->ShouldDisplayGameListItem(source_row);
+}

--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.h
@@ -13,4 +13,5 @@ class ListProxyModel final : public QSortFilterProxyModel
 public:
   explicit ListProxyModel(QObject* parent = nullptr);
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+  bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
 };

--- a/Source/Core/DolphinQt2/GameList/TableProxyModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/TableProxyModel.cpp
@@ -1,0 +1,16 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/GameList/TableProxyModel.h"
+#include "DolphinQt2/GameList/GameListModel.h"
+
+TableProxyModel::TableProxyModel(QObject* parent) : QSortFilterProxyModel(parent)
+{
+}
+
+bool TableProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
+{
+  GameListModel* glm = qobject_cast<GameListModel*>(sourceModel());
+  return glm->ShouldDisplayGameListItem(source_row);
+}

--- a/Source/Core/DolphinQt2/GameList/TableProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/TableProxyModel.h
@@ -1,0 +1,15 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QSortFilterProxyModel>
+
+// This subclass of QSortFilterProxyModel allows the data to be filtered by the view.
+class TableProxyModel final : public QSortFilterProxyModel
+{
+  Q_OBJECT
+
+public:
+  explicit TableProxyModel(QObject* parent = nullptr);
+  bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+};

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -195,6 +195,10 @@ void MainWindow::ConnectMenuBar()
   connect(m_menu_bar, &MenuBar::ShowList, m_game_list, &GameList::SetListView);
   connect(m_menu_bar, &MenuBar::ColumnVisibilityToggled, m_game_list,
           &GameList::OnColumnVisibilityToggled);
+  connect(m_menu_bar, &MenuBar::GameListPlatformVisibilityToggled, m_game_list,
+          &GameList::OnGameListVisibilityChanged);
+  connect(m_menu_bar, &MenuBar::GameListRegionVisibilityToggled, m_game_list,
+          &GameList::OnGameListVisibilityChanged);
   connect(m_menu_bar, &MenuBar::ShowAboutDialog, this, &MainWindow::ShowAboutDialog);
 
   connect(this, &MainWindow::EmulationStarted, m_menu_bar, &MenuBar::EmulationStarted);

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -192,6 +192,9 @@ void MenuBar::AddViewMenu()
   AddGameListTypeSection(view_menu);
   view_menu->addSeparator();
   AddTableColumnsMenu(view_menu);
+  view_menu->addSeparator();
+  AddShowPlatformsMenu(view_menu);
+  AddShowRegionsMenu(view_menu);
 }
 
 void MenuBar::AddOptionsMenu()
@@ -266,6 +269,66 @@ void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
     connect(action, &QAction::toggled, [this, config, key](bool value) {
       *config = value;
       emit ColumnVisibilityToggled(key, value);
+    });
+  }
+}
+
+void MenuBar::AddShowPlatformsMenu(QMenu* view_menu)
+{
+  static const QMap<QString, bool*> platform_map{
+      {tr("Show Wii"), &SConfig::GetInstance().m_ListWii},
+      {tr("Show GameCube"), &SConfig::GetInstance().m_ListGC},
+      {tr("Show WAD"), &SConfig::GetInstance().m_ListWad},
+      {tr("Show ELF/DOL"), &SConfig::GetInstance().m_ListElfDol}};
+
+  QActionGroup* platform_group = new QActionGroup(this);
+  QMenu* plat_menu = view_menu->addMenu(tr("Show Platforms"));
+  platform_group->setExclusive(false);
+
+  for (const auto& key : platform_map.keys())
+  {
+    bool* config = platform_map[key];
+    QAction* action = platform_group->addAction(plat_menu->addAction(key));
+    action->setCheckable(true);
+    action->setChecked(*config);
+    connect(action, &QAction::toggled, [this, config, key](bool value) {
+      *config = value;
+      emit GameListPlatformVisibilityToggled(key, value);
+    });
+  }
+}
+
+void MenuBar::AddShowRegionsMenu(QMenu* view_menu)
+{
+  static const QMap<QString, bool*> region_map{
+      {tr("Show JAP"), &SConfig::GetInstance().m_ListJap},
+      {tr("Show PAL"), &SConfig::GetInstance().m_ListPal},
+      {tr("Show USA"), &SConfig::GetInstance().m_ListUsa},
+      {tr("Show Australia"), &SConfig::GetInstance().m_ListAustralia},
+      {tr("Show France"), &SConfig::GetInstance().m_ListFrance},
+      {tr("Show Germany"), &SConfig::GetInstance().m_ListGermany},
+      {tr("Show Italy"), &SConfig::GetInstance().m_ListItaly},
+      {tr("Show Korea"), &SConfig::GetInstance().m_ListKorea},
+      {tr("Show Netherlands"), &SConfig::GetInstance().m_ListNetherlands},
+      {tr("Show Russia"), &SConfig::GetInstance().m_ListRussia},
+      {tr("Show Spain"), &SConfig::GetInstance().m_ListSpain},
+      {tr("Show Taiwan"), &SConfig::GetInstance().m_ListTaiwan},
+      {tr("Show World"), &SConfig::GetInstance().m_ListWorld},
+      {tr("Show Unknown"), &SConfig::GetInstance().m_ListUnknown}};
+
+  QActionGroup* region_group = new QActionGroup(this);
+  QMenu* region_menu = view_menu->addMenu(tr("Show Regions"));
+  region_group->setExclusive(false);
+
+  for (const auto& key : region_map.keys())
+  {
+    bool* config = region_map[key];
+    QAction* action = region_group->addAction(region_menu->addAction(key));
+    action->setCheckable(true);
+    action->setChecked(*config);
+    connect(action, &QAction::toggled, [this, config, key](bool value) {
+      *config = value;
+      emit GameListRegionVisibilityToggled(key, value);
     });
   }
 }

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -50,6 +50,8 @@ signals:
   void ShowTable();
   void ShowList();
   void ColumnVisibilityToggled(const QString& row, bool visible);
+  void GameListPlatformVisibilityToggled(const QString& row, bool visible);
+  void GameListRegionVisibilityToggled(const QString& row, bool visible);
 
   void ShowAboutDialog();
 
@@ -74,6 +76,8 @@ private:
   void AddViewMenu();
   void AddGameListTypeSection(QMenu* view_menu);
   void AddTableColumnsMenu(QMenu* view_menu);
+  void AddShowPlatformsMenu(QMenu* view_menu);
+  void AddShowRegionsMenu(QMenu* view_menu);
 
   void AddOptionsMenu();
   void AddToolsMenu();


### PR DESCRIPTION
Porting the View config logic from WX to Qt for Show Platforms & Show Regions.
Adds to the View Menu.

![](https://puu.sh/wJiep/20eede4f67.gif)