### PR TITLE
Wx: make GameListCtrl fallback to sorting by title

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -97,49 +97,42 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 
   switch (sortData)
   {
-  case GameListCtrl::COLUMN_TITLE:
-    if (!strcasecmp(iso1->GetName().c_str(), iso2->GetName().c_str()))
-    {
-      if (iso1->GetGameID() != iso2->GetGameID())
-        return t * (iso1->GetGameID() > iso2->GetGameID() ? 1 : -1);
-      if (iso1->GetRevision() != iso2->GetRevision())
-        return t * (iso1->GetRevision() > iso2->GetRevision() ? 1 : -1);
-      if (iso1->GetDiscNumber() != iso2->GetDiscNumber())
-        return t * (iso1->GetDiscNumber() > iso2->GetDiscNumber() ? 1 : -1);
-
-      wxString iso1_filename = wxFileNameFromPath(iso1->GetFileName());
-      wxString iso2_filename = wxFileNameFromPath(iso2->GetFileName());
-
-      if (iso1_filename != iso2_filename)
-        return t * wxStricmp(iso1_filename, iso2_filename);
-    }
-    return strcasecmp(iso1->GetName().c_str(), iso2->GetName().c_str()) * t;
   case GameListCtrl::COLUMN_MAKER:
-    return strcasecmp(iso1->GetCompany().c_str(), iso2->GetCompany().c_str()) * t;
+  {
+    int maker_cmp = strcasecmp(iso1->GetCompany().c_str(), iso2->GetCompany().c_str()) * t;
+    if (maker_cmp != 0)
+      return maker_cmp;
+    break;
+  }
   case GameListCtrl::COLUMN_FILENAME:
     return wxStricmp(wxFileNameFromPath(iso1->GetFileName()),
                      wxFileNameFromPath(iso2->GetFileName())) *
            t;
   case GameListCtrl::COLUMN_ID:
-    return strcasecmp(iso1->GetGameID().c_str(), iso2->GetGameID().c_str()) * t;
+  {
+    int id_cmp = strcasecmp(iso1->GetGameID().c_str(), iso2->GetGameID().c_str()) * t;
+    if (id_cmp != 0)
+      return id_cmp;
+    break;
+  }
   case GameListCtrl::COLUMN_COUNTRY:
     if (iso1->GetCountry() > iso2->GetCountry())
       return 1 * t;
     if (iso1->GetCountry() < iso2->GetCountry())
       return -1 * t;
-    return 0;
+    break;
   case GameListCtrl::COLUMN_SIZE:
     if (iso1->GetFileSize() > iso2->GetFileSize())
       return 1 * t;
     if (iso1->GetFileSize() < iso2->GetFileSize())
       return -1 * t;
-    return 0;
+    break;
   case GameListCtrl::COLUMN_PLATFORM:
     if (iso1->GetPlatform() > iso2->GetPlatform())
       return 1 * t;
     if (iso1->GetPlatform() < iso2->GetPlatform())
       return -1 * t;
-    return 0;
+    break;
 
   case GameListCtrl::COLUMN_EMULATION_STATE:
   {
@@ -149,11 +142,29 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
       return 1 * t;
     if (nState1 < nState2)
       return -1 * t;
-    else
-      return 0;
+    break;
   }
-  break;
   }
+
+  if (sortData != GameListCtrl::COLUMN_TITLE)
+    t = 1;
+
+  int name_cmp = strcasecmp(iso1->GetName().c_str(), iso2->GetName().c_str()) * t;
+  if (name_cmp != 0)
+    return name_cmp;
+
+  if (iso1->GetGameID() != iso2->GetGameID())
+    return t * (iso1->GetGameID() > iso2->GetGameID() ? 1 : -1);
+  if (iso1->GetRevision() != iso2->GetRevision())
+    return t * (iso1->GetRevision() > iso2->GetRevision() ? 1 : -1);
+  if (iso1->GetDiscNumber() != iso2->GetDiscNumber())
+    return t * (iso1->GetDiscNumber() > iso2->GetDiscNumber() ? 1 : -1);
+
+  wxString iso1_filename = wxFileNameFromPath(iso1->GetFileName());
+  wxString iso2_filename = wxFileNameFromPath(iso2->GetFileName());
+
+  if (iso1_filename != iso2_filename)
+    return t * wxStricmp(iso1_filename, iso2_filename);
 
   return 0;
 }
@@ -886,6 +897,9 @@ static int wxCALLBACK wxListCompare(wxIntPtr item1, wxIntPtr item2, wxIntPtr sor
   // return 0 for identity
   const GameListItem* iso1 = caller->GetISO(item1);
   const GameListItem* iso2 = caller->GetISO(item2);
+
+  if (iso1 == iso2)
+    return 0;
 
   return CompareGameListItems(iso1, iso2, sortData);
 }


### PR DESCRIPTION
Fixes an issue with game items moving around randomly when resorted.

GIF of the issue (thanks to @spycrab): 
![qmltf0g](https://user-images.githubusercontent.com/594093/28232954-5e7471e4-68a8-11e7-84cc-ea1fc55f12a9.gif)

