### PR TITLE
XAudio2: Utilize ComPtr in XAudio2 driver

### DIFF
--- a/Source/Core/AudioCommon/XAudio2Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2Stream.cpp
@@ -174,14 +174,12 @@ bool XAudio2::Start()
   HRESULT hr;
 
   // callback doesn't seem to run on a specific CPU anyways
-  IXAudio2* xaudptr;
-  if (FAILED(hr = ((XAudio2Create_t)PXAudio2Create)(&xaudptr, 0, XAUDIO2_DEFAULT_PROCESSOR)))
+  if (FAILED(hr = ((XAudio2Create_t)PXAudio2Create)(&m_xaudio2, 0, XAUDIO2_DEFAULT_PROCESSOR)))
   {
     PanicAlert("XAudio2 init failed: %#X", hr);
     Stop();
     return false;
   }
-  m_xaudio2 = std::unique_ptr<IXAudio2, Releaser>(xaudptr);
 
   // XAudio2 master voice
   // XAUDIO2_DEFAULT_CHANNELS instead of 2 for expansion?
@@ -196,7 +194,7 @@ bool XAudio2::Start()
   m_mastering_voice->SetVolume(m_volume);
 
   m_voice_context = std::unique_ptr<StreamingVoiceContext>(
-      new StreamingVoiceContext(m_xaudio2.get(), m_mixer.get(), m_sound_sync_event));
+      new StreamingVoiceContext(m_xaudio2.Get(), m_mixer.get(), m_sound_sync_event));
 
   return true;
 }
@@ -235,7 +233,7 @@ void XAudio2::Stop()
     m_mastering_voice = nullptr;
   }
 
-  m_xaudio2.reset();  // release interface
+  m_xaudio2.Reset();  // release interface
 
   if (m_xaudio2_dll)
   {

--- a/Source/Core/AudioCommon/XAudio2Stream.h
+++ b/Source/Core/AudioCommon/XAudio2Stream.h
@@ -17,6 +17,16 @@
 
 #include <windows.h>
 
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions,
+//   but destructor is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
+using Microsoft::WRL::ComPtr;
+
 struct StreamingVoiceContext;
 struct IXAudio2;
 struct IXAudio2MasteringVoice;
@@ -28,18 +38,9 @@ class XAudio2 final : public SoundStream
 #ifdef _WIN32
 
 private:
-  class Releaser
-  {
-  public:
-    template <typename R>
-    void operator()(R* ptr)
-    {
-      ptr->Release();
-    }
-  };
-
-  std::unique_ptr<IXAudio2, Releaser> m_xaudio2;
+  ComPtr<IXAudio2> m_xaudio2;
   std::unique_ptr<StreamingVoiceContext> m_voice_context;
+  // all XAudio2 objects are released when m_xaudio2 is released
   IXAudio2MasteringVoice* m_mastering_voice;
 
   Common::Event m_sound_sync_event;

--- a/Source/Core/AudioCommon/XAudio2_7Stream.h
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.h
@@ -21,6 +21,16 @@
 
 #include <Windows.h>
 
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions,
+//   but destructor is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
+using Microsoft::WRL::ComPtr;
+
 struct StreamingVoiceContext2_7;
 struct IXAudio2;
 struct IXAudio2MasteringVoice;
@@ -32,20 +42,9 @@ class XAudio2_7 final : public SoundStream
 #ifdef _WIN32
 
 private:
-  static void ReleaseIXAudio2(IXAudio2* ptr);
-
-  class Releaser
-  {
-  public:
-    template <typename R>
-    void operator()(R* ptr)
-    {
-      ReleaseIXAudio2(ptr);
-    }
-  };
-
-  std::unique_ptr<IXAudio2, Releaser> m_xaudio2;
+  ComPtr<IXAudio2> m_xaudio2;
   std::unique_ptr<StreamingVoiceContext2_7> m_voice_context;
+  // all XAudio2 objects are released when m_xaudio2 is released
   IXAudio2MasteringVoice* m_mastering_voice;
 
   Common::Event m_sound_sync_event;


### PR DESCRIPTION
Similar to the PR for the D3D backend, this PR uses ComPtr in the XAudio2 backend.