### PR TITLE
DInput: Utilize ComPtr in DInput backend

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
@@ -46,17 +46,15 @@ std::string GetDeviceName(const LPDIRECTINPUTDEVICE8 device)
 
 void PopulateDevices(HWND hwnd)
 {
-  IDirectInput8* idi8;
+  ComPtr<IDirectInput8> idi8;
   if (FAILED(DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8,
-                                (LPVOID*)&idi8, nullptr)))
+                                &idi8, nullptr)))
   {
     return;
   }
 
-  InitKeyboardMouse(idi8, hwnd);
-  InitJoystick(idi8, hwnd);
-
-  idi8->Release();
+  InitKeyboardMouse(idi8.Get(), hwnd);
+  InitJoystick(idi8.Get(), hwnd);
 }
 }
 }

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
@@ -9,12 +9,22 @@
 #include <windows.h>
 #include <list>
 
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions,
+//   but destructor is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
 #include "InputCommon/ControllerInterface/DInput/DInput8.h"
 
 namespace ciface
 {
 namespace DInput
 {
+using Microsoft::WRL::ComPtr;
+
 // BOOL CALLBACK DIEnumEffectsCallback(LPCDIEFFECTINFO pdei, LPVOID pvRef);
 BOOL CALLBACK DIEnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);
 BOOL CALLBACK DIEnumDevicesCallback(LPCDIDEVICEINSTANCE lpddi, LPVOID pvRef);

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -32,7 +32,7 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
       continue;
     }
 
-    LPDIRECTINPUTDEVICE8 js_device;
+    ComPtr<IDirectInputDevice8> js_device;
     if (SUCCEEDED(idi8->CreateDevice(joystick.guidInstance, &js_device, nullptr)))
     {
       if (SUCCEEDED(js_device->SetDataFormat(&c_dfDIJoystick)))
@@ -46,12 +46,11 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
                   js_device->SetCooperativeLevel(nullptr, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE)))
           {
             // PanicAlert("SetCooperativeLevel failed!");
-            js_device->Release();
             continue;
           }
         }
 
-        auto js = std::make_shared<Joystick>(js_device);
+        auto js = std::make_shared<Joystick>(js_device.Get());
         // only add if it has some inputs/outputs
         if (js->Inputs().size() || js->Outputs().size())
           g_controller_interface.AddDevice(std::move(js));
@@ -59,7 +58,6 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
       else
       {
         // PanicAlert("SetDataFormat failed!");
-        js_device->Release();
       }
     }
   }
@@ -140,7 +138,7 @@ Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVI
   std::list<DIDEVICEOBJECTINSTANCE> objects;
   if (SUCCEEDED(m_device->EnumObjects(DIEnumDeviceObjectsCallback, (LPVOID)&objects, DIDFT_AXIS)))
   {
-    InitForceFeedback(m_device, (int)objects.size());
+    InitForceFeedback(m_device.Get(), (int)objects.size());
   }
 
   ZeroMemory(&m_state_in, sizeof(m_state_in));
@@ -151,12 +149,11 @@ Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVI
 Joystick::~Joystick()
 {
   m_device->Unacquire();
-  m_device->Release();
 }
 
 std::string Joystick::GetName() const
 {
-  return GetDeviceName(m_device);
+  return GetDeviceName(m_device.Get());
 }
 
 std::string Joystick::GetSource() const

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
@@ -69,7 +69,7 @@ public:
   std::string GetSource() const override;
 
 private:
-  const LPDIRECTINPUTDEVICE8 m_device;
+  ComPtr<IDirectInputDevice8> m_device;
 
   DIJOYSTATE m_state_in;
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -41,8 +41,8 @@ void InitKeyboardMouse(IDirectInput8* const idi8, HWND _hwnd)
   // other devices
   // so there can be a separated Keyboard and mouse, as well as combined KeyboardMouse
 
-  LPDIRECTINPUTDEVICE8 kb_device = nullptr;
-  LPDIRECTINPUTDEVICE8 mo_device = nullptr;
+  ComPtr<IDirectInputDevice8> kb_device;
+  ComPtr<IDirectInputDevice8> mo_device;
 
   if (SUCCEEDED(idi8->CreateDevice(GUID_SysKeyboard, &kb_device, nullptr)) &&
       SUCCEEDED(kb_device->SetDataFormat(&c_dfDIKeyboard)) &&
@@ -51,24 +51,18 @@ void InitKeyboardMouse(IDirectInput8* const idi8, HWND _hwnd)
       SUCCEEDED(mo_device->SetDataFormat(&c_dfDIMouse2)) &&
       SUCCEEDED(mo_device->SetCooperativeLevel(nullptr, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE)))
   {
-    g_controller_interface.AddDevice(std::make_shared<KeyboardMouse>(kb_device, mo_device));
+    g_controller_interface.AddDevice(
+        std::make_shared<KeyboardMouse>(kb_device.Get(), mo_device.Get()));
     return;
   }
-
-  if (kb_device)
-    kb_device->Release();
-  if (mo_device)
-    mo_device->Release();
 }
 
 KeyboardMouse::~KeyboardMouse()
 {
   // kb
   m_kb_device->Unacquire();
-  m_kb_device->Release();
   // mouse
   m_mo_device->Unacquire();
-  m_mo_device->Release();
 }
 
 KeyboardMouse::KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device,

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -92,8 +92,8 @@ public:
   std::string GetSource() const override;
 
 private:
-  const LPDIRECTINPUTDEVICE8 m_kb_device;
-  const LPDIRECTINPUTDEVICE8 m_mo_device;
+  ComPtr<IDirectInputDevice8> m_kb_device;
+  ComPtr<IDirectInputDevice8> m_mo_device;
 
   DWORD m_last_update;
   State m_state_in;


### PR DESCRIPTION
Remove manual COM pointer management from the DInput backend.

With this PR plus D3D and XAudio2, every COM pointer in dolphin-emu is owned by a smart-pointer class.