### PR TITLE
Remove Wii Remote connection status from status bar

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -144,10 +144,6 @@ void Host_ConnectWiimote(int wm_idx, bool connect)
 {
 }
 
-void Host_SetWiiMoteConnectionState(int _State)
-{
-}
-
 void Host_ShowVideoConfig(void*, const std::string&)
 {
 }

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -31,7 +31,6 @@ void Host_Message(int Id);
 void Host_NotifyMapLoaded();
 void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);
-void Host_SetWiiMoteConnectionState(int _State);
 void Host_UpdateDisasmDialog();
 void Host_UpdateMainFrame();
 void Host_UpdateTitle(const std::string& title);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -91,13 +91,10 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
   m_ControllerBD.b[3] = 0x79;
   m_ControllerBD.b[4] = 0x00;
   m_ControllerBD.b[5] = 0xFF;
-
-  Host_SetWiiMoteConnectionState(0);
 }
 
 BluetoothEmu::~BluetoothEmu()
 {
-  Host_SetWiiMoteConnectionState(0);
   m_WiiMotes.clear();
 }
 
@@ -355,10 +352,7 @@ void BluetoothEmu::Update()
     for (auto& wiimote : m_WiiMotes)
     {
       if (wiimote.EventPagingChanged(m_ScanEnable))
-      {
-        Host_SetWiiMoteConnectionState(1);
         SendEventRequestConnection(wiimote);
-      }
     }
   }
 
@@ -1203,7 +1197,6 @@ void BluetoothEmu::CommandDisconnect(const u8* input)
   DEBUG_LOG(IOS_WIIMOTE, "  ConnectionHandle: 0x%04x", disconnect->con_handle);
   DEBUG_LOG(IOS_WIIMOTE, "  Reason: 0x%02x", disconnect->reason);
 
-  Host_SetWiiMoteConnectionState(0);
   DisplayDisconnectMessage((disconnect->con_handle & 0xFF) + 1, disconnect->reason);
 
   SendEventCommandStatus(HCI_CMD_DISCONNECT);

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -910,9 +910,6 @@ void WiimoteDevice::ReceiveL2capData(u16 scid, const void* _pData, u32 _Size)
   // Update Offset to the final size of the report
   Offset += _Size;
 
-  // Update the status bar
-  Host_SetWiiMoteConnectionState(2);
-
   // Send the report
   m_pHost->SendACLPacket(GetConnectionHandle(), DataFrame, Offset);
 }

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -147,10 +147,6 @@ void Host_ConnectWiimote(int wm_idx, bool connect)
   });
 }
 
-void Host_SetWiiMoteConnectionState(int _State)
-{
-}
-
 void Host_ShowVideoConfig(void*, const std::string&)
 {
 }

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -104,9 +104,6 @@ void Host_NotifyMapLoaded()
 void Host_UpdateDisasmDialog()
 {
 }
-void Host_SetWiiMoteConnectionState(int state)
-{
-}
 void Host_ConnectWiimote(int wm_idx, bool connect)
 {
 }

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -458,35 +458,6 @@ void Host_RequestRenderWindowSize(int width, int height)
   main_frame->GetEventHandler()->AddPendingEvent(event);
 }
 
-void Host_SetWiiMoteConnectionState(int _State)
-{
-  static int currentState = -1;
-  if (_State == currentState)
-    return;
-  currentState = _State;
-
-  wxCommandEvent event(wxEVT_HOST_COMMAND, IDM_UPDATE_STATUS_BAR);
-
-  switch (_State)
-  {
-  case 0:
-    event.SetString(_("Not connected"));
-    break;
-  case 1:
-    event.SetString(_("Connecting..."));
-    break;
-  case 2:
-    event.SetString(_("Wii Remote Connected"));
-    break;
-  }
-  // The second field is used for auxiliary info such as this
-  event.SetInt(1);
-
-  NOTICE_LOG(WIIMOTE, "%s", static_cast<const char*>(event.GetString().c_str()));
-
-  main_frame->GetEventHandler()->AddPendingEvent(event);
-}
-
 bool Host_UINeedsControllerState()
 {
   return wxGetApp().IsActiveThreadsafe() && GetUINeedsControllerState();

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -54,9 +54,6 @@ bool Host_RendererIsFullscreen()
 void Host_ConnectWiimote(int, bool)
 {
 }
-void Host_SetWiiMoteConnectionState(int)
-{
-}
 void Host_ShowVideoConfig(void*, const std::string&)
 {
 }


### PR DESCRIPTION
Showing the Wii remote connection status leads to inconsistent UX, because we don't do anything like that for GameCube controllers or with Bluetooth passthrough.

It's also questionable how useful it is given that:

* it doesn't print the number of connected remotes, just that one remote is connected, connecting or not connected, so the only info it provides is actually wrong when using multiple remotes;

* this user-facing feature is actually broken in master and no one has complained AFAIK, which means people don't really rely on it;

* the status bar isn't visible most of the time unless the user is using render to main or deliberately keeping the main window's status bar visible by moving the render window and they're not too far away from their screen;

* emulated Wii remotes now reconnect on input, which means that there is less of a need to actually know at all times whether a remote is connected, since pressing any button will reconnect it and provide immediate, visible feedback via OSD messages and the Wii remote pointer appearing.