### PR TITLE
Utilize ComPtr in D3D, DInput and XAudio2 backends

### DIFF
--- a/Source/Core/AudioCommon/XAudio2Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2Stream.cpp
@@ -174,14 +174,12 @@ bool XAudio2::Start()
   HRESULT hr;
 
   // callback doesn't seem to run on a specific CPU anyways
-  IXAudio2* xaudptr;
-  if (FAILED(hr = ((XAudio2Create_t)PXAudio2Create)(&xaudptr, 0, XAUDIO2_DEFAULT_PROCESSOR)))
+  if (FAILED(hr = ((XAudio2Create_t)PXAudio2Create)(&m_xaudio2, 0, XAUDIO2_DEFAULT_PROCESSOR)))
   {
     PanicAlert("XAudio2 init failed: %#X", hr);
     Stop();
     return false;
   }
-  m_xaudio2 = std::unique_ptr<IXAudio2, Releaser>(xaudptr);
 
   // XAudio2 master voice
   // XAUDIO2_DEFAULT_CHANNELS instead of 2 for expansion?
@@ -196,7 +194,7 @@ bool XAudio2::Start()
   m_mastering_voice->SetVolume(m_volume);
 
   m_voice_context = std::unique_ptr<StreamingVoiceContext>(
-      new StreamingVoiceContext(m_xaudio2.get(), m_mixer.get(), m_sound_sync_event));
+      new StreamingVoiceContext(m_xaudio2.Get(), m_mixer.get(), m_sound_sync_event));
 
   return true;
 }
@@ -235,7 +233,7 @@ void XAudio2::Stop()
     m_mastering_voice = nullptr;
   }
 
-  m_xaudio2.reset();  // release interface
+  m_xaudio2.Reset();  // release interface
 
   if (m_xaudio2_dll)
   {

--- a/Source/Core/AudioCommon/XAudio2Stream.h
+++ b/Source/Core/AudioCommon/XAudio2Stream.h
@@ -17,6 +17,16 @@
 
 #include <windows.h>
 
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
+//   is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
+using Microsoft::WRL::ComPtr;
+
 struct StreamingVoiceContext;
 struct IXAudio2;
 struct IXAudio2MasteringVoice;
@@ -28,18 +38,9 @@ class XAudio2 final : public SoundStream
 #ifdef _WIN32
 
 private:
-  class Releaser
-  {
-  public:
-    template <typename R>
-    void operator()(R* ptr)
-    {
-      ptr->Release();
-    }
-  };
-
-  std::unique_ptr<IXAudio2, Releaser> m_xaudio2;
+  ComPtr<IXAudio2> m_xaudio2;
   std::unique_ptr<StreamingVoiceContext> m_voice_context;
+  // all XAudio2 objects are released when m_xaudio2 is released
   IXAudio2MasteringVoice* m_mastering_voice;
 
   Common::Event m_sound_sync_event;

--- a/Source/Core/AudioCommon/XAudio2Stream.h
+++ b/Source/Core/AudioCommon/XAudio2Stream.h
@@ -15,17 +15,10 @@
 
 #ifdef _WIN32
 
-#include <windows.h>
+#include <Windows.h>
+#include "Common/ComPtr.h"
 
-// Disable warning C4265 in wrl/client.h:
-//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
-//   is not virtual
-#pragma warning(push)
-#pragma warning(disable : 4265)
-#include <wrl/client.h>
-#pragma warning(pop)
-
-using Microsoft::WRL::ComPtr;
+using Common::ComPtr;
 
 struct StreamingVoiceContext;
 struct IXAudio2;

--- a/Source/Core/AudioCommon/XAudio2_7Stream.h
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.h
@@ -20,16 +20,9 @@
 #ifdef _WIN32
 
 #include <Windows.h>
+#include "Common/ComPtr.h"
 
-// Disable warning C4265 in wrl/client.h:
-//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
-//   is not virtual
-#pragma warning(push)
-#pragma warning(disable : 4265)
-#include <wrl/client.h>
-#pragma warning(pop)
-
-using Microsoft::WRL::ComPtr;
+using Common::ComPtr;
 
 struct StreamingVoiceContext2_7;
 struct IXAudio2;

--- a/Source/Core/AudioCommon/XAudio2_7Stream.h
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.h
@@ -21,6 +21,16 @@
 
 #include <Windows.h>
 
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
+//   is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
+using Microsoft::WRL::ComPtr;
+
 struct StreamingVoiceContext2_7;
 struct IXAudio2;
 struct IXAudio2MasteringVoice;
@@ -32,20 +42,9 @@ class XAudio2_7 final : public SoundStream
 #ifdef _WIN32
 
 private:
-  static void ReleaseIXAudio2(IXAudio2* ptr);
-
-  class Releaser
-  {
-  public:
-    template <typename R>
-    void operator()(R* ptr)
-    {
-      ReleaseIXAudio2(ptr);
-    }
-  };
-
-  std::unique_ptr<IXAudio2, Releaser> m_xaudio2;
+  ComPtr<IXAudio2> m_xaudio2;
   std::unique_ptr<StreamingVoiceContext2_7> m_voice_context;
+  // all XAudio2 objects are released when m_xaudio2 is released
   IXAudio2MasteringVoice* m_mastering_voice;
 
   Common::Event m_sound_sync_event;

--- a/Source/Core/Common/ComPtr.h
+++ b/Source/Core/Common/ComPtr.h
@@ -1,0 +1,33 @@
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#ifdef _WIN32
+
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
+//   is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
+namespace Common
+{
+// Smart pointer class for a COM object.
+//
+// BEWARE: Taking a pointer to a ComPtr, i.e. `&my_pointer`, causes the object to be released and
+//         the pointer to be set to null. This is meant for object creation functions, such as:
+//
+//           `device->CreateTexture2D(&params, &my_pointer); // <-- THIS IS OK`
+//
+//         Do NOT take a pointer to a ComPtr when passing the object as a parameter. For example:
+//
+//           `device->OMSetRenderTargets(1, &my_pointer); // <-- DON'T DO THIS`
+//
+using Microsoft::WRL::ComPtr;
+}
+
+#endif

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -54,6 +54,7 @@
     <ClInclude Include="CommonFuncs.h" />
     <ClInclude Include="CommonPaths.h" />
     <ClInclude Include="CommonTypes.h" />
+    <ClInclude Include="ComPtr.h" />
     <ClInclude Include="Config\Config.h" />
     <ClInclude Include="Config\Enums.h" />
     <ClInclude Include="Config\Layer.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -258,6 +258,7 @@
     <ClInclude Include="GL\GLExtensions\ARB_texture_compression_bptc.h">
       <Filter>GL\GLExtensions</Filter>
     </ClInclude>
+    <ClInclude Include="ComPtr.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDUtils.cpp" />

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
@@ -46,17 +46,15 @@ std::string GetDeviceName(const LPDIRECTINPUTDEVICE8 device)
 
 void PopulateDevices(HWND hwnd)
 {
-  IDirectInput8* idi8;
+  ComPtr<IDirectInput8> idi8;
   if (FAILED(DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8,
-                                (LPVOID*)&idi8, nullptr)))
+                                &idi8, nullptr)))
   {
     return;
   }
 
-  InitKeyboardMouse(idi8, hwnd);
-  InitJoystick(idi8, hwnd);
-
-  idi8->Release();
+  InitKeyboardMouse(idi8.Get(), hwnd);
+  InitJoystick(idi8.Get(), hwnd);
 }
 }
 }

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
@@ -9,13 +9,7 @@
 #include <windows.h>
 #include <list>
 
-// Disable warning C4265 in wrl/client.h:
-//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
-//   is not virtual
-#pragma warning(push)
-#pragma warning(disable : 4265)
-#include <wrl/client.h>
-#pragma warning(pop)
+#include "Common/ComPtr.h"
 
 #include "InputCommon/ControllerInterface/DInput/DInput8.h"
 
@@ -23,7 +17,7 @@ namespace ciface
 {
 namespace DInput
 {
-using Microsoft::WRL::ComPtr;
+using Common::ComPtr;
 
 // BOOL CALLBACK DIEnumEffectsCallback(LPCDIEFFECTINFO pdei, LPVOID pvRef);
 BOOL CALLBACK DIEnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
@@ -9,12 +9,22 @@
 #include <windows.h>
 #include <list>
 
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
+//   is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
 #include "InputCommon/ControllerInterface/DInput/DInput8.h"
 
 namespace ciface
 {
 namespace DInput
 {
+using Microsoft::WRL::ComPtr;
+
 // BOOL CALLBACK DIEnumEffectsCallback(LPCDIEFFECTINFO pdei, LPVOID pvRef);
 BOOL CALLBACK DIEnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);
 BOOL CALLBACK DIEnumDevicesCallback(LPCDIDEVICEINSTANCE lpddi, LPVOID pvRef);

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
@@ -62,14 +62,15 @@ private:
 public:
   void UpdateInput() override;
 
-  Joystick(const LPDIRECTINPUTDEVICE8 device);
+  // Joystick takes ownership of device
+  Joystick(ComPtr<IDirectInputDevice8>&& device);
   ~Joystick();
 
   std::string GetName() const override;
   std::string GetSource() const override;
 
 private:
-  const LPDIRECTINPUTDEVICE8 m_device;
+  ComPtr<IDirectInputDevice8> m_device;
 
   DIJOYSTATE m_state_in;
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -85,15 +85,16 @@ private:
 public:
   void UpdateInput() override;
 
-  KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device, const LPDIRECTINPUTDEVICE8 mo_device);
+  // KeyboardMouse takes ownership of kb_device and mo_device
+  KeyboardMouse(ComPtr<IDirectInputDevice8>&& kb_device, ComPtr<IDirectInputDevice8>&& mo_device);
   ~KeyboardMouse();
 
   std::string GetName() const override;
   std::string GetSource() const override;
 
 private:
-  const LPDIRECTINPUTDEVICE8 m_kb_device;
-  const LPDIRECTINPUTDEVICE8 m_mo_device;
+  ComPtr<IDirectInputDevice8> m_kb_device;
+  ComPtr<IDirectInputDevice8> m_mo_device;
 
   DWORD m_last_update;
   State m_state_in;

--- a/Source/Core/VideoBackends/D3D/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.cpp
@@ -9,13 +9,13 @@
 
 namespace DX11
 {
-static ID3D11Buffer* s_bbox_buffer;
-static ID3D11Buffer* s_bbox_staging_buffer;
-static ID3D11UnorderedAccessView* s_bbox_uav;
+static ComPtr<ID3D11Buffer> s_bbox_buffer;
+static ComPtr<ID3D11Buffer> s_bbox_staging_buffer;
+static ComPtr<ID3D11UnorderedAccessView> s_bbox_uav;
 
-ID3D11UnorderedAccessView*& BBox::GetUAV()
+ID3D11UnorderedAccessView* BBox::GetUAV()
 {
-  return s_bbox_uav;
+  return s_bbox_uav.Get();
 }
 
 void BBox::Init()
@@ -34,7 +34,7 @@ void BBox::Init()
     HRESULT hr;
     hr = D3D::device->CreateBuffer(&desc, &data, &s_bbox_buffer);
     CHECK(SUCCEEDED(hr), "Create BoundingBox Buffer.");
-    D3D::SetDebugObjectName(s_bbox_buffer, "BoundingBox Buffer");
+    D3D::SetDebugObjectName(s_bbox_buffer.Get(), "BoundingBox Buffer");
 
     // Second to use as a staging buffer.
     desc.Usage = D3D11_USAGE_STAGING;
@@ -42,7 +42,7 @@ void BBox::Init()
     desc.BindFlags = 0;
     hr = D3D::device->CreateBuffer(&desc, nullptr, &s_bbox_staging_buffer);
     CHECK(SUCCEEDED(hr), "Create BoundingBox Staging Buffer.");
-    D3D::SetDebugObjectName(s_bbox_staging_buffer, "BoundingBox Staging Buffer");
+    D3D::SetDebugObjectName(s_bbox_staging_buffer.Get(), "BoundingBox Staging Buffer");
 
     // UAV is required to allow concurrent access.
     D3D11_UNORDERED_ACCESS_VIEW_DESC UAVdesc = {};
@@ -51,36 +51,36 @@ void BBox::Init()
     UAVdesc.Buffer.FirstElement = 0;
     UAVdesc.Buffer.Flags = 0;
     UAVdesc.Buffer.NumElements = 4;
-    hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer, &UAVdesc, &s_bbox_uav);
+    hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer.Get(), &UAVdesc, &s_bbox_uav);
     CHECK(SUCCEEDED(hr), "Create BoundingBox UAV.");
-    D3D::SetDebugObjectName(s_bbox_uav, "BoundingBox UAV");
+    D3D::SetDebugObjectName(s_bbox_uav.Get(), "BoundingBox UAV");
   }
 }
 
 void BBox::Shutdown()
 {
-  SAFE_RELEASE(s_bbox_buffer);
-  SAFE_RELEASE(s_bbox_staging_buffer);
-  SAFE_RELEASE(s_bbox_uav);
+  s_bbox_buffer.Reset();
+  s_bbox_staging_buffer.Reset();
+  s_bbox_uav.Reset();
 }
 
 void BBox::Set(int index, int value)
 {
   D3D11_BOX box{index * sizeof(s32), 0, 0, (index + 1) * sizeof(s32), 1, 1};
-  D3D::context->UpdateSubresource(s_bbox_buffer, 0, &box, &value, 0, 0);
+  D3D::context->UpdateSubresource(s_bbox_buffer.Get(), 0, &box, &value, 0, 0);
 }
 
 int BBox::Get(int index)
 {
   int data = 0;
-  D3D::context->CopyResource(s_bbox_staging_buffer, s_bbox_buffer);
+  D3D::context->CopyResource(s_bbox_staging_buffer.Get(), s_bbox_buffer.Get());
   D3D11_MAPPED_SUBRESOURCE map;
-  HRESULT hr = D3D::context->Map(s_bbox_staging_buffer, 0, D3D11_MAP_READ, 0, &map);
+  HRESULT hr = D3D::context->Map(s_bbox_staging_buffer.Get(), 0, D3D11_MAP_READ, 0, &map);
   if (SUCCEEDED(hr))
   {
     data = ((s32*)map.pData)[index];
   }
-  D3D::context->Unmap(s_bbox_staging_buffer, 0);
+  D3D::context->Unmap(s_bbox_staging_buffer.Get(), 0);
   return data;
 }
 };

--- a/Source/Core/VideoBackends/D3D/BoundingBox.h
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.h
@@ -10,7 +10,7 @@ namespace DX11
 class BBox
 {
 public:
-  static ID3D11UnorderedAccessView*& GetUAV();
+  static ID3D11UnorderedAccessView* GetUAV();
   static void Init();
   static void Shutdown();
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -9,21 +9,14 @@
 #include <dxgi1_2.h>
 #include <vector>
 
-// Disable warning C4265 in wrl/client.h:
-//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
-//   is not virtual
-#pragma warning(push)
-#pragma warning(disable : 4265)
-#include <wrl/client.h>
-#pragma warning(pop)
-
+#include "Common/ComPtr.h"
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 
 namespace DX11
 {
-using Microsoft::WRL::ComPtr;
+using Common::ComPtr;
 
 #define SAFE_DELETE(x)                                                                             \
   {                                                                                                \

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -9,18 +9,22 @@
 #include <dxgi1_2.h>
 #include <vector>
 
+// Disable warning C4265 in wrl/client.h:
+//   'Microsoft::WRL::Details::RemoveIUnknownBase<T>': class has virtual functions, but destructor
+//   is not virtual
+#pragma warning(push)
+#pragma warning(disable : 4265)
+#include <wrl/client.h>
+#pragma warning(pop)
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 
 namespace DX11
 {
-#define SAFE_RELEASE(x)                                                                            \
-  {                                                                                                \
-    if (x)                                                                                         \
-      (x)->Release();                                                                              \
-    (x) = nullptr;                                                                                 \
-  }
+using Microsoft::WRL::ComPtr;
+
 #define SAFE_DELETE(x)                                                                             \
   {                                                                                                \
     delete (x);                                                                                    \
@@ -55,8 +59,8 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter);
 HRESULT Create(HWND wnd);
 void Close();
 
-extern ID3D11Device* device;
-extern ID3D11DeviceContext* context;
+extern ComPtr<ID3D11Device> device;
+extern ComPtr<ID3D11DeviceContext> context;
 extern HWND hWnd;
 extern bool bFrameInProgress;
 
@@ -67,7 +71,7 @@ void Present();
 
 unsigned int GetBackBufferWidth();
 unsigned int GetBackBufferHeight();
-D3DTexture2D*& GetBackBuffer();
+D3DTexture2D& GetBackBuffer();
 const char* PixelShaderVersionString();
 const char* GeometryShaderVersionString();
 const char* VertexShaderVersionString();
@@ -81,34 +85,11 @@ bool GetFullscreenState();
 // This function will assign a name to the given resource.
 // The DirectX debug layer will make it easier to identify resources that way,
 // e.g. when listing up all resources who have unreleased references.
-template <typename T>
-void SetDebugObjectName(T resource, const char* name)
-{
-  static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-                "resource must be convertible to ID3D11DeviceChild*");
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  if (resource)
-    resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
-#endif
-}
+void SetDebugObjectName(ID3D11DeviceChild* resource, const char* name);
+std::string GetDebugObjectName(ID3D11DeviceChild* resource);
 
-template <typename T>
-std::string GetDebugObjectName(T resource)
-{
-  static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-                "resource must be convertible to ID3D11DeviceChild*");
-  std::string name;
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  if (resource)
-  {
-    UINT size = 0;
-    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr);  // get required size
-    name.resize(size);
-    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, const_cast<char*>(name.data()));
-  }
-#endif
-  return name;
-}
+// Convenience function for calling D3D::context->OMSetRenderTargets with 1 target
+void SetRenderTarget(ID3D11RenderTargetView* rtv, ID3D11DepthStencilView* dsv = nullptr);
 
 }  // namespace D3D
 

--- a/Source/Core/VideoBackends/D3D/D3DBlob.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBlob.cpp
@@ -16,18 +16,17 @@ D3DBlob::D3DBlob(unsigned int blob_size, const u8* init_data)
     memcpy(data, init_data, size);
 }
 
-D3DBlob::D3DBlob(ID3D10Blob* d3dblob) : ref(1)
+D3DBlob::D3DBlob(ComPtr<ID3D10Blob>&& d3dblob) : ref(1)
 {
   blob = d3dblob;
   data = (u8*)blob->GetBufferPointer();
   size = (unsigned int)blob->GetBufferSize();
-  d3dblob->AddRef();
 }
 
 D3DBlob::~D3DBlob()
 {
   if (blob)
-    blob->Release();
+    blob.Reset();
   else
     delete[] data;
 }

--- a/Source/Core/VideoBackends/D3D/D3DBlob.h
+++ b/Source/Core/VideoBackends/D3D/D3DBlob.h
@@ -5,20 +5,22 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 
 struct ID3D10Blob;
 
 namespace DX11
 {
-// use this class instead ID3D10Blob or ID3D11Blob whenever possible
+// use this class instead ID3D10Blob or ID3D11Blob whenever possible.
+// D3DBlob is not a COM object, but it is compatible with ComPtr.
 class D3DBlob
 {
 public:
   // memory will be copied into an own buffer
   D3DBlob(unsigned int blob_size, const u8* init_data = nullptr);
 
-  // d3dblob will be AddRef'd
-  D3DBlob(ID3D10Blob* d3dblob);
+  // Ownership of an existing blob is taken
+  D3DBlob(ComPtr<ID3D10Blob>&& d3dblob);
 
   void AddRef();
   unsigned int Release();
@@ -33,7 +35,7 @@ private:
   unsigned int size;
 
   u8* data;
-  ID3D10Blob* blob;
+  ComPtr<ID3D10Blob> blob;
 };
 
 }  // namespace

--- a/Source/Core/VideoBackends/D3D/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DShader.cpp
@@ -18,9 +18,9 @@ namespace DX11
 namespace D3D
 {
 // bytecode->shader
-ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, size_t len)
+ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, size_t len)
 {
-  ID3D11VertexShader* v_shader;
+  ComPtr<ID3D11VertexShader> v_shader;
   HRESULT hr = D3D::device->CreateVertexShader(bytecode, len, nullptr, &v_shader);
   if (FAILED(hr))
     return nullptr;
@@ -31,8 +31,8 @@ ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, size_t 
 // code->bytecode
 bool CompileVertexShader(const std::string& code, D3DBlob** blob)
 {
-  ID3D10Blob* shaderBuffer = nullptr;
-  ID3D10Blob* errorBuffer = nullptr;
+  ComPtr<ID3D10Blob> shaderBuffer;
+  ComPtr<ID3D10Blob> errorBuffer;
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   UINT flags = D3D10_SHADER_ENABLE_BACKWARDS_COMPATIBILITY | D3D10_SHADER_DEBUG;
@@ -62,20 +62,18 @@ bool CompileVertexShader(const std::string& code, D3DBlob** blob)
                D3D::VertexShaderVersionString(), (const char*)errorBuffer->GetBufferPointer());
 
     *blob = nullptr;
-    errorBuffer->Release();
   }
   else
   {
-    *blob = new D3DBlob(shaderBuffer);
-    shaderBuffer->Release();
+    *blob = new D3DBlob(std::move(shaderBuffer));
   }
   return SUCCEEDED(hr);
 }
 
 // bytecode->shader
-ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, size_t len)
+ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode, size_t len)
 {
-  ID3D11GeometryShader* g_shader;
+  ComPtr<ID3D11GeometryShader> g_shader;
   HRESULT hr = D3D::device->CreateGeometryShader(bytecode, len, nullptr, &g_shader);
   if (FAILED(hr))
     return nullptr;
@@ -87,8 +85,8 @@ ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, siz
 bool CompileGeometryShader(const std::string& code, D3DBlob** blob,
                            const D3D_SHADER_MACRO* pDefines)
 {
-  ID3D10Blob* shaderBuffer = nullptr;
-  ID3D10Blob* errorBuffer = nullptr;
+  ComPtr<ID3D10Blob> shaderBuffer;
+  ComPtr<ID3D10Blob> errorBuffer;
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   UINT flags = D3D10_SHADER_ENABLE_BACKWARDS_COMPATIBILITY | D3D10_SHADER_DEBUG;
@@ -120,20 +118,18 @@ bool CompileGeometryShader(const std::string& code, D3DBlob** blob,
                D3D::GeometryShaderVersionString(), (const char*)errorBuffer->GetBufferPointer());
 
     *blob = nullptr;
-    errorBuffer->Release();
   }
   else
   {
-    *blob = new D3DBlob(shaderBuffer);
-    shaderBuffer->Release();
+    *blob = new D3DBlob(std::move(shaderBuffer));
   }
   return SUCCEEDED(hr);
 }
 
 // bytecode->shader
-ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, size_t len)
+ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, size_t len)
 {
-  ID3D11PixelShader* p_shader;
+  ComPtr<ID3D11PixelShader> p_shader;
   HRESULT hr = D3D::device->CreatePixelShader(bytecode, len, nullptr, &p_shader);
   if (FAILED(hr))
   {
@@ -146,8 +142,8 @@ ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, size_t le
 // code->bytecode
 bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines)
 {
-  ID3D10Blob* shaderBuffer = nullptr;
-  ID3D10Blob* errorBuffer = nullptr;
+  ComPtr<ID3D10Blob> shaderBuffer;
+  ComPtr<ID3D10Blob> errorBuffer;
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   UINT flags = D3D10_SHADER_DEBUG;
@@ -177,52 +173,41 @@ bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADE
                D3D::PixelShaderVersionString(), (const char*)errorBuffer->GetBufferPointer());
 
     *blob = nullptr;
-    errorBuffer->Release();
   }
   else
   {
-    *blob = new D3DBlob(shaderBuffer);
-    shaderBuffer->Release();
+    *blob = new D3DBlob(std::move(shaderBuffer));
   }
 
   return SUCCEEDED(hr);
 }
 
-ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code)
+ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code)
 {
-  D3DBlob* blob = nullptr;
+  ComPtr<D3DBlob> blob;
   if (CompileVertexShader(code, &blob))
-  {
-    ID3D11VertexShader* v_shader = CreateVertexShaderFromByteCode(blob);
-    blob->Release();
-    return v_shader;
-  }
+    return CreateVertexShaderFromByteCode(blob.Get());
+
   return nullptr;
 }
 
-ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code,
-                                                     const D3D_SHADER_MACRO* pDefines)
+ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(const std::string& code,
+                                                            const D3D_SHADER_MACRO* pDefines)
 {
-  D3DBlob* blob = nullptr;
+  ComPtr<D3DBlob> blob;
   if (CompileGeometryShader(code, &blob, pDefines))
-  {
-    ID3D11GeometryShader* g_shader = CreateGeometryShaderFromByteCode(blob);
-    blob->Release();
-    return g_shader;
-  }
+    return CreateGeometryShaderFromByteCode(blob.Get());
+
   return nullptr;
 }
 
-ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code)
+ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code)
 {
-  D3DBlob* blob = nullptr;
+  ComPtr<D3DBlob> blob;
   CompilePixelShader(code, &blob);
   if (blob)
-  {
-    ID3D11PixelShader* p_shader = CreatePixelShaderFromByteCode(blob);
-    blob->Release();
-    return p_shader;
-  }
+    return CreatePixelShaderFromByteCode(blob.Get());
+
   return nullptr;
 }
 

--- a/Source/Core/VideoBackends/D3D/D3DShader.h
+++ b/Source/Core/VideoBackends/D3D/D3DShader.h
@@ -16,9 +16,9 @@ namespace DX11
 {
 namespace D3D
 {
-ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, size_t len);
-ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, size_t len);
-ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, size_t len);
+ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, size_t len);
+ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode, size_t len);
+ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, size_t len);
 
 // The returned bytecode buffers should be Release()d.
 bool CompileVertexShader(const std::string& code, D3DBlob** blob);
@@ -28,36 +28,36 @@ bool CompilePixelShader(const std::string& code, D3DBlob** blob,
                         const D3D_SHADER_MACRO* pDefines = nullptr);
 
 // Utility functions
-ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code);
-ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code,
-                                                     const D3D_SHADER_MACRO* pDefines = nullptr);
-ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code);
+ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code);
+ComPtr<ID3D11GeometryShader>
+CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines = nullptr);
+ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code);
 
-inline ID3D11VertexShader* CreateVertexShaderFromByteCode(D3DBlob* bytecode)
+inline ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(D3DBlob* bytecode)
 {
   return CreateVertexShaderFromByteCode(bytecode->Data(), bytecode->Size());
 }
-inline ID3D11GeometryShader* CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
+inline ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
 {
   return CreateGeometryShaderFromByteCode(bytecode->Data(), bytecode->Size());
 }
-inline ID3D11PixelShader* CreatePixelShaderFromByteCode(D3DBlob* bytecode)
+inline ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(D3DBlob* bytecode)
 {
   return CreatePixelShaderFromByteCode(bytecode->Data(), bytecode->Size());
 }
 
-inline ID3D11VertexShader* CompileAndCreateVertexShader(D3DBlob* code)
+inline ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(D3DBlob* code)
 {
   return CompileAndCreateVertexShader((const char*)code->Data());
 }
 
-inline ID3D11GeometryShader*
+inline ComPtr<ID3D11GeometryShader>
 CompileAndCreateGeometryShader(D3DBlob* code, const D3D_SHADER_MACRO* pDefines = nullptr)
 {
   return CompileAndCreateGeometryShader((const char*)code->Data(), pDefines);
 }
 
-inline ID3D11PixelShader* CompileAndCreatePixelShader(D3DBlob* code)
+inline ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(D3DBlob* code)
 {
   return CompileAndCreatePixelShader((const char*)code->Data());
 }

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -67,40 +67,23 @@ public:
   void Clear();
 
 private:
-  std::unordered_map<u32, ID3D11DepthStencilState*> m_depth;
-  std::unordered_map<u32, ID3D11RasterizerState*> m_raster;
-  std::unordered_map<u32, ID3D11BlendState*> m_blend;
-  std::unordered_map<u64, ID3D11SamplerState*> m_sampler;
+  std::unordered_map<u32, ComPtr<ID3D11DepthStencilState>> m_depth;
+  std::unordered_map<u32, ComPtr<ID3D11RasterizerState>> m_raster;
+  std::unordered_map<u32, ComPtr<ID3D11BlendState>> m_blend;
+  std::unordered_map<u64, ComPtr<ID3D11SamplerState>> m_sampler;
 };
 
 namespace D3D
 {
-template <typename T>
-class AutoState
-{
-public:
-  AutoState(const T* object);
-  AutoState(const AutoState<T>& source);
-  ~AutoState();
-
-  const inline T* GetPtr() const { return state; }
-private:
-  const T* state;
-};
-
-typedef AutoState<ID3D11BlendState> AutoBlendState;
-typedef AutoState<ID3D11DepthStencilState> AutoDepthStencilState;
-typedef AutoState<ID3D11RasterizerState> AutoRasterizerState;
-
 class StateManager
 {
 public:
   StateManager();
 
   // call any of these to change the affected states
-  void PushBlendState(const ID3D11BlendState* state);
-  void PushDepthState(const ID3D11DepthStencilState* state);
-  void PushRasterizerState(const ID3D11RasterizerState* state);
+  void PushBlendState(ID3D11BlendState* state);
+  void PushDepthState(ID3D11DepthStencilState* state);
+  void PushRasterizerState(ID3D11RasterizerState* state);
 
   // call these after drawing
   void PopBlendState();
@@ -224,9 +207,9 @@ public:
   void Apply();
 
 private:
-  std::stack<AutoBlendState> m_blendStates;
-  std::stack<AutoDepthStencilState> m_depthStates;
-  std::stack<AutoRasterizerState> m_rasterizerStates;
+  std::stack<ComPtr<ID3D11BlendState>> m_blendStates;
+  std::stack<ComPtr<ID3D11DepthStencilState>> m_depthStates;
+  std::stack<ComPtr<ID3D11RasterizerState>> m_rasterizerStates;
 
   ID3D11BlendState* m_currentBlendState;
   ID3D11DepthStencilState* m_currentDepthState;

--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -11,95 +11,97 @@
 
 namespace DX11
 {
-D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind,
-                                   D3D11_USAGE usage, DXGI_FORMAT fmt, unsigned int levels,
-                                   unsigned int slices, D3D11_SUBRESOURCE_DATA* data)
+bool D3DTexture2D::Initialize(DXGI_FORMAT format, unsigned int width, unsigned int height,
+                              D3D11_BIND_FLAG bind, D3D11_USAGE usage, unsigned int levels,
+                              unsigned int slices, const D3D11_SUBRESOURCE_DATA* data)
 {
-  ID3D11Texture2D* pTexture = nullptr;
-  HRESULT hr;
+  ComPtr<ID3D11Texture2D> pTexture;
 
   D3D11_CPU_ACCESS_FLAG cpuflags;
   if (usage == D3D11_USAGE_STAGING)
-    cpuflags = (D3D11_CPU_ACCESS_FLAG)((int)D3D11_CPU_ACCESS_WRITE | (int)D3D11_CPU_ACCESS_READ);
+    cpuflags = (D3D11_CPU_ACCESS_FLAG)(D3D11_CPU_ACCESS_WRITE | D3D11_CPU_ACCESS_READ);
   else if (usage == D3D11_USAGE_DYNAMIC)
     cpuflags = D3D11_CPU_ACCESS_WRITE;
   else
     cpuflags = (D3D11_CPU_ACCESS_FLAG)0;
   D3D11_TEXTURE2D_DESC texdesc =
-      CD3D11_TEXTURE2D_DESC(fmt, width, height, slices, levels, bind, usage, cpuflags);
-  hr = D3D::device->CreateTexture2D(&texdesc, data, &pTexture);
+      CD3D11_TEXTURE2D_DESC(format, width, height, slices, levels, bind, usage, cpuflags);
+  HRESULT hr = D3D::device->CreateTexture2D(&texdesc, data, &pTexture);
   if (FAILED(hr))
   {
     PanicAlert("Failed to create texture at %s, line %d: hr=%#x\n", __FILE__, __LINE__, hr);
-    return nullptr;
+    return false;
   }
 
-  D3DTexture2D* ret = new D3DTexture2D(pTexture, bind);
-  SAFE_RELEASE(pTexture);
-  return ret;
+  return InitializeFromExisting(std::move(pTexture), bind);
 }
 
-void D3DTexture2D::AddRef()
+bool D3DTexture2D::InitializeFromExisting(ComPtr<ID3D11Texture2D>&& tex, D3D11_BIND_FLAG bind,
+                                          DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format,
+                                          DXGI_FORMAT rtv_format, bool multisampled)
 {
-  ++ref;
-}
+  Reset();
+  m_tex = tex;
+  bool ok = (m_tex != nullptr);
 
-UINT D3DTexture2D::Release()
-{
-  --ref;
-  if (ref == 0)
-  {
-    delete this;
-    return 0;
-  }
-  return ref;
-}
-
-ID3D11Texture2D*& D3DTexture2D::GetTex()
-{
-  return tex;
-}
-ID3D11ShaderResourceView*& D3DTexture2D::GetSRV()
-{
-  return srv;
-}
-ID3D11RenderTargetView*& D3DTexture2D::GetRTV()
-{
-  return rtv;
-}
-ID3D11DepthStencilView*& D3DTexture2D::GetDSV()
-{
-  return dsv;
-}
-
-D3DTexture2D::D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind, DXGI_FORMAT srv_format,
-                           DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
-    : ref(1), tex(texptr), srv(nullptr), rtv(nullptr), dsv(nullptr)
-{
-  D3D11_SRV_DIMENSION srv_dim =
-      multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-  D3D11_DSV_DIMENSION dsv_dim =
-      multisampled ? D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
-  D3D11_RTV_DIMENSION rtv_dim =
-      multisampled ? D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY : D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-  D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
-  D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
-  D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
+  HRESULT hr;
   if (bind & D3D11_BIND_SHADER_RESOURCE)
-    D3D::device->CreateShaderResourceView(tex, &srv_desc, &srv);
+  {
+    D3D11_SRV_DIMENSION srv_dim =
+        multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+    D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc =
+        CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
+    hr = D3D::device->CreateShaderResourceView(m_tex.Get(), &srv_desc, &m_srv);
+    ok &= SUCCEEDED(hr);
+  }
   if (bind & D3D11_BIND_RENDER_TARGET)
-    D3D::device->CreateRenderTargetView(tex, &rtv_desc, &rtv);
+  {
+    D3D11_RTV_DIMENSION rtv_dim =
+        multisampled ? D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY : D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+    D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
+    hr = D3D::device->CreateRenderTargetView(m_tex.Get(), &rtv_desc, &m_rtv);
+    ok &= SUCCEEDED(hr);
+  }
   if (bind & D3D11_BIND_DEPTH_STENCIL)
-    D3D::device->CreateDepthStencilView(tex, &dsv_desc, &dsv);
-  tex->AddRef();
+  {
+    D3D11_DSV_DIMENSION dsv_dim =
+        multisampled ? D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+    D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
+    hr = D3D::device->CreateDepthStencilView(m_tex.Get(), &dsv_desc, &m_dsv);
+    ok &= SUCCEEDED(hr);
+  }
+
+  return ok;
 }
 
-D3DTexture2D::~D3DTexture2D()
+ID3D11Texture2D* D3DTexture2D::GetTex() const
 {
-  SAFE_RELEASE(srv);
-  SAFE_RELEASE(rtv);
-  SAFE_RELEASE(dsv);
-  SAFE_RELEASE(tex);
+  return m_tex.Get();
+}
+ID3D11ShaderResourceView* D3DTexture2D::GetSRV() const
+{
+  return m_srv.Get();
+}
+ID3D11RenderTargetView* D3DTexture2D::GetRTV() const
+{
+  return m_rtv.Get();
+}
+ID3D11DepthStencilView* D3DTexture2D::GetDSV() const
+{
+  return m_dsv.Get();
+}
+
+void D3DTexture2D::Reset()
+{
+  m_dsv.Reset();
+  m_rtv.Reset();
+  m_srv.Reset();
+  m_tex.Reset();
+}
+
+bool D3DTexture2D::IsValid() const
+{
+  return m_tex != nullptr;
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -6,44 +6,41 @@
 
 #include <d3d11.h>
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 
 namespace DX11
 {
 class D3DTexture2D
 {
 public:
-  // there are two ways to create a D3DTexture2D object:
-  //     either create an ID3D11Texture2D object, pass it to the constructor and specify what views
-  //     to create
-  //     or let the texture automatically be created by D3DTexture2D::Create
+  bool Initialize(DXGI_FORMAT format, unsigned int width, unsigned int height, D3D11_BIND_FLAG bind,
+                  D3D11_USAGE usage = D3D11_USAGE_DEFAULT, unsigned int levels = 1,
+                  unsigned int slices = 1, const D3D11_SUBRESOURCE_DATA* data = nullptr);
 
-  D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind,
-               DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN,
-               DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN,
-               DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN, bool multisampled = false);
-  static D3DTexture2D* Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind,
-                              D3D11_USAGE usage, DXGI_FORMAT, unsigned int levels = 1,
-                              unsigned int slices = 1, D3D11_SUBRESOURCE_DATA* data = nullptr);
+  // Initialize from an existing ID3D11Texture2D. This takes ownership of the texture.
+  bool InitializeFromExisting(ComPtr<ID3D11Texture2D>&& tex, D3D11_BIND_FLAG bind,
+                              DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN,
+                              DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN,
+                              DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN,
+                              bool multisampled = false);
 
-  // reference counting, use AddRef() when creating a new reference and Release() it when you don't
-  // need it anymore
-  void AddRef();
-  UINT Release();
+  void Reset();
+  bool IsValid() const;
 
-  ID3D11Texture2D*& GetTex();
-  ID3D11ShaderResourceView*& GetSRV();
-  ID3D11RenderTargetView*& GetRTV();
-  ID3D11DepthStencilView*& GetDSV();
+  // Note that Get* functions are marked const, despite their possibly being passed to functions
+  // that modify the texture.
+  // Essentially, D3DTexture2D owns and manages the texture's pointers, not the actual contents of
+  // the texture.
+  ID3D11Texture2D* GetTex() const;
+  ID3D11ShaderResourceView* GetSRV() const;
+  ID3D11RenderTargetView* GetRTV() const;
+  ID3D11DepthStencilView* GetDSV() const;
 
 private:
-  ~D3DTexture2D();
-
-  ID3D11Texture2D* tex;
-  ID3D11ShaderResourceView* srv;
-  ID3D11RenderTargetView* rtv;
-  ID3D11DepthStencilView* dsv;
-  D3D11_BIND_FLAG bindflags;
-  UINT ref;
+  ComPtr<ID3D11Texture2D> m_tex;
+  ComPtr<ID3D11ShaderResourceView> m_srv;
+  ComPtr<ID3D11RenderTargetView> m_rtv;
+  ComPtr<ID3D11DepthStencilView> m_dsv;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DUtil.h
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/RenderBase.h"
 
 namespace DX11
@@ -23,13 +24,13 @@ namespace D3D
 
 class CD3DFont
 {
-  ID3D11ShaderResourceView* m_pTexture;
-  ID3D11Buffer* m_pVB;
-  ID3D11InputLayout* m_InputLayout;
-  ID3D11PixelShader* m_pshader;
-  ID3D11VertexShader* m_vshader;
-  ID3D11BlendState* m_blendstate;
-  ID3D11RasterizerState* m_raststate;
+  ComPtr<ID3D11ShaderResourceView> m_pTexture;
+  ComPtr<ID3D11Buffer> m_pVB;
+  ComPtr<ID3D11InputLayout> m_InputLayout;
+  ComPtr<ID3D11PixelShader> m_pshader;
+  ComPtr<ID3D11VertexShader> m_vshader;
+  ComPtr<ID3D11BlendState> m_blendstate;
+  ComPtr<ID3D11RasterizerState> m_raststate;
   const int m_dwTexWidth;
   const int m_dwTexHeight;
   unsigned int m_LineHeight;

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -51,10 +51,9 @@ DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_conf
   DXGI_FORMAT dxgi_format = GetDXGIFormatForHostFormat(m_config.format);
   if (m_config.rendertarget)
   {
-    m_texture = D3DTexture2D::Create(
-        m_config.width, m_config.height,
-        (D3D11_BIND_FLAG)((int)D3D11_BIND_RENDER_TARGET | (int)D3D11_BIND_SHADER_RESOURCE),
-        D3D11_USAGE_DEFAULT, dxgi_format, 1, m_config.layers);
+    m_texture.Initialize(dxgi_format, m_config.width, m_config.height,
+                         (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE),
+                         D3D11_USAGE_DEFAULT, 1, m_config.layers);
   }
   else
   {
@@ -62,35 +61,27 @@ DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_conf
         CD3D11_TEXTURE2D_DESC(dxgi_format, m_config.width, m_config.height, 1, m_config.levels,
                               D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0);
 
-    ID3D11Texture2D* pTexture;
+    ComPtr<ID3D11Texture2D> pTexture;
     const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);
     CHECK(SUCCEEDED(hr), "Create texture of the TextureCache");
 
-    m_texture = new D3DTexture2D(pTexture, D3D11_BIND_SHADER_RESOURCE);
+    m_texture.InitializeFromExisting(std::move(pTexture), D3D11_BIND_SHADER_RESOURCE);
 
     // TODO: better debug names
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_texture->GetTex(),
-                            "a texture of the TextureCache");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_texture->GetSRV(),
+    D3D::SetDebugObjectName(m_texture.GetTex(), "a texture of the TextureCache");
+    D3D::SetDebugObjectName(m_texture.GetSRV(),
                             "shader resource view of a texture of the TextureCache");
-
-    SAFE_RELEASE(pTexture);
   }
 }
 
-DXTexture::~DXTexture()
+const D3DTexture2D* DXTexture::GetRawTexIdentifier() const
 {
-  m_texture->Release();
-}
-
-D3DTexture2D* DXTexture::GetRawTexIdentifier() const
-{
-  return m_texture;
+  return &m_texture;
 }
 
 void DXTexture::Bind(unsigned int stage)
 {
-  D3D::stateman->SetTexture(stage, m_texture->GetSRV());
+  D3D::stateman->SetTexture(stage, m_texture.GetSRV());
 }
 
 bool DXTexture::Save(const std::string& filename, unsigned int level)
@@ -106,7 +97,7 @@ bool DXTexture::Save(const std::string& filename, unsigned int level)
   CD3D11_TEXTURE2D_DESC staging_texture_desc(DXGI_FORMAT_R8G8B8A8_UNORM, mip_width, mip_height, 1,
                                              1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
 
-  ID3D11Texture2D* staging_texture;
+  ComPtr<ID3D11Texture2D> staging_texture;
   HRESULT hr = D3D::device->CreateTexture2D(&staging_texture_desc, nullptr, &staging_texture);
   if (FAILED(hr))
   {
@@ -116,23 +107,21 @@ bool DXTexture::Save(const std::string& filename, unsigned int level)
 
   // Copy the selected mip level to the staging texture.
   CD3D11_BOX src_box(0, 0, 0, mip_width, mip_height, 1);
-  D3D::context->CopySubresourceRegion(staging_texture, 0, 0, 0, 0, m_texture->GetTex(),
+  D3D::context->CopySubresourceRegion(staging_texture.Get(), 0, 0, 0, 0, m_texture.GetTex(),
                                       D3D11CalcSubresource(level, 0, m_config.levels), &src_box);
 
   // Map the staging texture to client memory, and encode it as a .png image.
   D3D11_MAPPED_SUBRESOURCE map;
-  hr = D3D::context->Map(staging_texture, 0, D3D11_MAP_READ, 0, &map);
+  hr = D3D::context->Map(staging_texture.Get(), 0, D3D11_MAP_READ, 0, &map);
   if (FAILED(hr))
   {
     WARN_LOG(VIDEO, "Failed to map texture dumping readback texture: %X", static_cast<u32>(hr));
-    staging_texture->Release();
     return false;
   }
 
   bool encode_result =
       TextureToPng(reinterpret_cast<u8*>(map.pData), map.RowPitch, filename, mip_width, mip_height);
-  D3D::context->Unmap(staging_texture, 0);
-  staging_texture->Release();
+  D3D::context->Unmap(staging_texture.Get(), 0);
 
   return encode_result;
 }
@@ -152,8 +141,8 @@ void DXTexture::CopyRectangleFromTexture(const AbstractTexture* source,
     srcbox.front = 0;
     srcbox.back = srcentry->m_config.layers;
 
-    D3D::context->CopySubresourceRegion(m_texture->GetTex(), 0, dstrect.left, dstrect.top, 0,
-                                        srcentry->m_texture->GetTex(), 0, &srcbox);
+    D3D::context->CopySubresourceRegion(m_texture.GetTex(), 0, dstrect.left, dstrect.top, 0,
+                                        srcentry->m_texture.GetTex(), 0, &srcbox);
     return;
   }
   else if (!m_config.rendertarget)
@@ -165,10 +154,10 @@ void DXTexture::CopyRectangleFromTexture(const AbstractTexture* source,
   const D3D11_VIEWPORT vp = CD3D11_VIEWPORT(float(dstrect.left), float(dstrect.top),
                                             float(dstrect.GetWidth()), float(dstrect.GetHeight()));
 
-  D3D::stateman->UnsetTexture(m_texture->GetSRV());
+  D3D::stateman->UnsetTexture(m_texture.GetSRV());
   D3D::stateman->Apply();
 
-  D3D::context->OMSetRenderTargets(1, &m_texture->GetRTV(), nullptr);
+  D3D::SetRenderTarget(m_texture.GetRTV(), nullptr);
   D3D::context->RSSetViewports(1, &vp);
   D3D::SetLinearCopySampler();
   D3D11_RECT srcRC;
@@ -176,14 +165,14 @@ void DXTexture::CopyRectangleFromTexture(const AbstractTexture* source,
   srcRC.right = srcrect.right;
   srcRC.top = srcrect.top;
   srcRC.bottom = srcrect.bottom;
-  D3D::drawShadedTexQuad(srcentry->m_texture->GetSRV(), &srcRC, srcentry->m_config.width,
+  D3D::drawShadedTexQuad(srcentry->m_texture.GetSRV(), &srcRC, srcentry->m_config.width,
                          srcentry->m_config.height, PixelShaderCache::GetColorCopyProgram(false),
                          VertexShaderCache::GetSimpleVertexShader(),
                          VertexShaderCache::GetSimpleInputLayout(),
                          GeometryShaderCache::GetCopyGeometryShader(), 1.0, 0);
 
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 
   g_renderer->RestoreAPIState();
 }
@@ -192,7 +181,7 @@ void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
                      size_t buffer_size)
 {
   size_t src_pitch = CalculateHostTextureLevelPitch(m_config.format, row_length);
-  D3D::context->UpdateSubresource(m_texture->GetTex(), level, nullptr, buffer,
+  D3D::context->UpdateSubresource(m_texture.GetTex(), level, nullptr, buffer,
                                   static_cast<UINT>(src_pitch), 0);
 }
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/DXTexture.h
+++ b/Source/Core/VideoBackends/D3D/DXTexture.h
@@ -16,7 +16,6 @@ class DXTexture final : public AbstractTexture
 {
 public:
   explicit DXTexture(const TextureConfig& tex_config);
-  ~DXTexture();
 
   void Bind(unsigned int stage) override;
   bool Save(const std::string& filename, unsigned int level) override;
@@ -27,10 +26,10 @@ public:
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;
 
-  D3DTexture2D* GetRawTexIdentifier() const;
+  const D3DTexture2D* GetRawTexIdentifier() const;
 
 private:
-  D3DTexture2D* m_texture;
+  D3DTexture2D m_texture;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -26,39 +26,39 @@ FramebufferManager::Efb FramebufferManager::m_efb;
 unsigned int FramebufferManager::m_target_width;
 unsigned int FramebufferManager::m_target_height;
 
-D3DTexture2D*& FramebufferManager::GetEFBColorTexture()
+D3DTexture2D& FramebufferManager::GetEFBColorTexture()
 {
   return m_efb.color_tex;
 }
-D3DTexture2D*& FramebufferManager::GetEFBColorReadTexture()
+D3DTexture2D& FramebufferManager::GetEFBColorReadTexture()
 {
   return m_efb.color_read_texture;
 }
-ID3D11Texture2D*& FramebufferManager::GetEFBColorStagingBuffer()
+ID3D11Texture2D* FramebufferManager::GetEFBColorStagingBuffer()
 {
-  return m_efb.color_staging_buf;
+  return m_efb.color_staging_buf.Get();
 }
 
-D3DTexture2D*& FramebufferManager::GetEFBDepthTexture()
+D3DTexture2D& FramebufferManager::GetEFBDepthTexture()
 {
   return m_efb.depth_tex;
 }
-D3DTexture2D*& FramebufferManager::GetEFBDepthReadTexture()
+D3DTexture2D& FramebufferManager::GetEFBDepthReadTexture()
 {
   return m_efb.depth_read_texture;
 }
-ID3D11Texture2D*& FramebufferManager::GetEFBDepthStagingBuffer()
+ID3D11Texture2D* FramebufferManager::GetEFBDepthStagingBuffer()
 {
-  return m_efb.depth_staging_buf;
+  return m_efb.depth_staging_buf.Get();
 }
 
-D3DTexture2D*& FramebufferManager::GetResolvedEFBColorTexture()
+D3DTexture2D& FramebufferManager::GetResolvedEFBColorTexture()
 {
   if (g_ActiveConfig.iMultisamples > 1)
   {
     for (int i = 0; i < m_efb.slices; i++)
-      D3D::context->ResolveSubresource(m_efb.resolved_color_tex->GetTex(),
-                                       D3D11CalcSubresource(0, i, 1), m_efb.color_tex->GetTex(),
+      D3D::context->ResolveSubresource(m_efb.resolved_color_tex.GetTex(),
+                                       D3D11CalcSubresource(0, i, 1), m_efb.color_tex.GetTex(),
                                        D3D11CalcSubresource(0, i, 1), DXGI_FORMAT_R8G8B8A8_UNORM);
     return m_efb.resolved_color_tex;
   }
@@ -68,7 +68,7 @@ D3DTexture2D*& FramebufferManager::GetResolvedEFBColorTexture()
   }
 }
 
-D3DTexture2D*& FramebufferManager::GetResolvedEFBDepthTexture()
+D3DTexture2D& FramebufferManager::GetResolvedEFBDepthTexture()
 {
   if (g_ActiveConfig.iMultisamples > 1)
   {
@@ -78,16 +78,16 @@ D3DTexture2D*& FramebufferManager::GetResolvedEFBDepthTexture()
 
     CD3D11_VIEWPORT viewport(0.f, 0.f, (float)m_target_width, (float)m_target_height);
     D3D::context->RSSetViewports(1, &viewport);
-    D3D::context->OMSetRenderTargets(1, &m_efb.resolved_depth_tex->GetRTV(), nullptr);
+    D3D::SetRenderTarget(m_efb.resolved_depth_tex.GetRTV(), nullptr);
 
     const D3D11_RECT source_rect = CD3D11_RECT(0, 0, m_target_width, m_target_height);
     D3D::drawShadedTexQuad(
-        m_efb.depth_tex->GetSRV(), &source_rect, m_target_width, m_target_height,
+        m_efb.depth_tex.GetSRV(), &source_rect, m_target_width, m_target_height,
         PixelShaderCache::GetDepthResolveProgram(), VertexShaderCache::GetSimpleVertexShader(),
         VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
 
-    D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                     FramebufferManager::GetEFBDepthTexture()->GetDSV());
+    D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                         FramebufferManager::GetEFBDepthTexture().GetDSV());
     g_renderer->RestoreAPIState();
 
     return m_efb.resolved_depth_tex;
@@ -106,7 +106,7 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
   sample_desc.Count = g_ActiveConfig.iMultisamples;
   sample_desc.Quality = 0;
 
-  ID3D11Texture2D* buf;
+  ComPtr<ID3D11Texture2D> buf;
   D3D11_TEXTURE2D_DESC texdesc;
   HRESULT hr;
 
@@ -120,16 +120,13 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
   CHECK(hr == S_OK, "create EFB color texture (size: %dx%d; hr=%#x)", m_target_width,
         m_target_height, hr);
-  m_efb.color_tex = new D3DTexture2D(
-      buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET),
+  m_efb.color_tex.InitializeFromExisting(
+      std::move(buf), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET),
       DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM,
       (sample_desc.Count > 1));
-  SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetTex(), "EFB color texture");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetSRV(),
-                          "EFB color texture shader resource view");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetRTV(),
-                          "EFB color texture render target view");
+  D3D::SetDebugObjectName(m_efb.color_tex.GetTex(), "EFB color texture");
+  D3D::SetDebugObjectName(m_efb.color_tex.GetSRV(), "EFB color texture shader resource view");
+  D3D::SetDebugObjectName(m_efb.color_tex.GetRTV(), "EFB color texture render target view");
 
   // Temporary EFB color texture - used in ReinterpretPixelData
   texdesc =
@@ -139,28 +136,25 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
   CHECK(hr == S_OK, "create EFB color temp texture (size: %dx%d; hr=%#x)", m_target_width,
         m_target_height, hr);
-  m_efb.color_temp_tex = new D3DTexture2D(
-      buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET),
+  m_efb.color_temp_tex.InitializeFromExisting(
+      std::move(buf), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET),
       DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM,
       (sample_desc.Count > 1));
-  SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetTex(),
-                          "EFB color temp texture");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetSRV(),
+  D3D::SetDebugObjectName(m_efb.color_temp_tex.GetTex(), "EFB color temp texture");
+  D3D::SetDebugObjectName(m_efb.color_temp_tex.GetSRV(),
                           "EFB color temp texture shader resource view");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetRTV(),
+  D3D::SetDebugObjectName(m_efb.color_temp_tex.GetRTV(),
                           "EFB color temp texture render target view");
 
   // Render buffer for AccessEFB (color data)
   texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, 1, 1, D3D11_BIND_RENDER_TARGET);
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
   CHECK(hr == S_OK, "create EFB color read texture (hr=%#x)", hr);
-  m_efb.color_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-  SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_read_texture->GetTex(),
+  m_efb.color_read_texture.InitializeFromExisting(std::move(buf), D3D11_BIND_RENDER_TARGET);
+  D3D::SetDebugObjectName(m_efb.color_read_texture.GetTex(),
                           "EFB color read texture (used in Renderer::AccessEFB)");
   D3D::SetDebugObjectName(
-      (ID3D11DeviceChild*)m_efb.color_read_texture->GetRTV(),
+      m_efb.color_read_texture.GetRTV(),
       "EFB color read texture render target view (used in Renderer::AccessEFB)");
 
   // AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
@@ -168,7 +162,7 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
                                   D3D11_CPU_ACCESS_READ);
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.color_staging_buf);
   CHECK(hr == S_OK, "create EFB color staging buffer (hr=%#x)", hr);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_staging_buf,
+  D3D::SetDebugObjectName(m_efb.color_staging_buf.Get(),
                           "EFB color staging texture (used for Renderer::AccessEFB)");
 
   // EFB depth buffer - primary depth buffer
@@ -179,26 +173,22 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
   CHECK(hr == S_OK, "create EFB depth texture (size: %dx%d; hr=%#x)", m_target_width,
         m_target_height, hr);
-  m_efb.depth_tex = new D3DTexture2D(
-      buf, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE),
+  m_efb.depth_tex.InitializeFromExisting(
+      std::move(buf), (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE),
       DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
-  SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetTex(), "EFB depth texture");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetDSV(),
-                          "EFB depth texture depth stencil view");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetSRV(),
-                          "EFB depth texture shader resource view");
+  D3D::SetDebugObjectName(m_efb.depth_tex.GetTex(), "EFB depth texture");
+  D3D::SetDebugObjectName(m_efb.depth_tex.GetDSV(), "EFB depth texture depth stencil view");
+  D3D::SetDebugObjectName(m_efb.depth_tex.GetSRV(), "EFB depth texture shader resource view");
 
   // Render buffer for AccessEFB (depth data)
   texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, 1, 1, D3D11_BIND_RENDER_TARGET);
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
   CHECK(hr == S_OK, "create EFB depth read texture (hr=%#x)", hr);
-  m_efb.depth_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-  SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetTex(),
+  m_efb.depth_read_texture.InitializeFromExisting(std::move(buf), D3D11_BIND_RENDER_TARGET);
+  D3D::SetDebugObjectName(m_efb.depth_read_texture.GetTex(),
                           "EFB depth read texture (used in Renderer::AccessEFB)");
   D3D::SetDebugObjectName(
-      (ID3D11DeviceChild*)m_efb.depth_read_texture->GetRTV(),
+      m_efb.depth_read_texture.GetRTV(),
       "EFB depth read texture render target view (used in Renderer::AccessEFB)");
 
   // AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
@@ -206,7 +196,7 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
                                   D3D11_CPU_ACCESS_READ);
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.depth_staging_buf);
   CHECK(hr == S_OK, "create EFB depth staging buffer (hr=%#x)", hr);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_staging_buf,
+  D3D::SetDebugObjectName(m_efb.depth_staging_buf.Get(),
                           "EFB depth staging texture (used for Renderer::AccessEFB)");
 
   if (g_ActiveConfig.iMultisamples > 1)
@@ -218,12 +208,10 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
     hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
     CHECK(hr == S_OK, "create EFB color resolve texture (size: %dx%d; hr=%#x)", m_target_width,
           m_target_height, hr);
-    m_efb.resolved_color_tex =
-        new D3DTexture2D(buf, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
-    SAFE_RELEASE(buf);
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetTex(),
-                            "EFB color resolve texture");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetSRV(),
+    m_efb.resolved_color_tex.InitializeFromExisting(std::move(buf), D3D11_BIND_SHADER_RESOURCE,
+                                                    DXGI_FORMAT_R8G8B8A8_UNORM);
+    D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetTex(), "EFB color resolve texture");
+    D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetSRV(),
                             "EFB color resolve texture shader resource view");
 
     texdesc =
@@ -232,19 +220,17 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
     hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
     CHECK(hr == S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width,
           m_target_height, hr);
-    m_efb.resolved_depth_tex = new D3DTexture2D(
-        buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET),
+    m_efb.resolved_depth_tex.InitializeFromExisting(
+        std::move(buf), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET),
         DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R32_FLOAT);
-    SAFE_RELEASE(buf);
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetTex(),
-                            "EFB depth resolve texture");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetSRV(),
+    D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetTex(), "EFB depth resolve texture");
+    D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetSRV(),
                             "EFB depth resolve texture shader resource view");
   }
   else
   {
-    m_efb.resolved_color_tex = nullptr;
-    m_efb.resolved_depth_tex = nullptr;
+    m_efb.resolved_color_tex.Reset();
+    m_efb.resolved_depth_tex.Reset();
   }
 
   s_xfbEncoder.Init();
@@ -254,15 +240,15 @@ FramebufferManager::~FramebufferManager()
 {
   s_xfbEncoder.Shutdown();
 
-  SAFE_RELEASE(m_efb.color_tex);
-  SAFE_RELEASE(m_efb.color_temp_tex);
-  SAFE_RELEASE(m_efb.color_staging_buf);
-  SAFE_RELEASE(m_efb.color_read_texture);
-  SAFE_RELEASE(m_efb.resolved_color_tex);
-  SAFE_RELEASE(m_efb.depth_tex);
-  SAFE_RELEASE(m_efb.depth_staging_buf);
-  SAFE_RELEASE(m_efb.depth_read_texture);
-  SAFE_RELEASE(m_efb.resolved_depth_tex);
+  m_efb.color_tex.Reset();
+  m_efb.color_temp_tex.Reset();
+  m_efb.color_staging_buf.Reset();
+  m_efb.color_read_texture.Reset();
+  m_efb.resolved_color_tex.Reset();
+  m_efb.depth_tex.Reset();
+  m_efb.depth_staging_buf.Reset();
+  m_efb.depth_read_texture.Reset();
+  m_efb.resolved_depth_tex.Reset();
 }
 
 void FramebufferManager::CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight,
@@ -279,11 +265,11 @@ std::unique_ptr<XFBSourceBase> FramebufferManager::CreateXFBSource(unsigned int 
                                                                    unsigned int target_height,
                                                                    unsigned int layers)
 {
-  return std::make_unique<XFBSource>(
-      D3DTexture2D::Create(target_width, target_height,
-                           (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE),
-                           D3D11_USAGE_DEFAULT, DXGI_FORMAT_R8G8B8A8_UNORM, 1, layers),
-      layers);
+  D3DTexture2D texture;
+  texture.Initialize(DXGI_FORMAT_R8G8B8A8_UNORM, target_width, target_height,
+                     (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE),
+                     D3D11_USAGE_DEFAULT, 1, layers);
+  return std::make_unique<XFBSource>(std::move(texture), layers);
 }
 
 std::pair<u32, u32> FramebufferManager::GetTargetSize() const
@@ -306,17 +292,17 @@ void XFBSource::CopyEFB(float Gamma)
   const D3D11_RECT rect = CD3D11_RECT(0, 0, texWidth, texHeight);
 
   D3D::context->RSSetViewports(1, &vp);
-  D3D::context->OMSetRenderTargets(1, &tex->GetRTV(), nullptr);
+  D3D::SetRenderTarget(tex.GetRTV(), nullptr);
   D3D::SetPointCopySampler();
 
   D3D::drawShadedTexQuad(
-      FramebufferManager::GetEFBColorTexture()->GetSRV(), &rect, g_renderer->GetTargetWidth(),
+      FramebufferManager::GetEFBColorTexture().GetSRV(), &rect, g_renderer->GetTargetWidth(),
       g_renderer->GetTargetHeight(), PixelShaderCache::GetColorCopyProgram(true),
       VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
       GeometryShaderCache::GetCopyGeometryShader(), Gamma);
 
-  D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-                                   FramebufferManager::GetEFBDepthTexture()->GetDSV());
+  D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+                       FramebufferManager::GetEFBDepthTexture().GetDSV());
 
   g_renderer->RestoreAPIState();
 }

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -48,12 +48,11 @@ namespace DX11
 
 struct XFBSource : public XFBSourceBase
 {
-  XFBSource(D3DTexture2D* _tex, int slices) : tex(_tex), m_slices(slices) {}
-  ~XFBSource() { tex->Release(); }
+  XFBSource(D3DTexture2D&& _tex, int slices) : tex(_tex), m_slices(slices) {}
   void DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight) override;
   void CopyEFB(float Gamma) override;
 
-  D3DTexture2D* const tex;
+  D3DTexture2D tex;
   const int m_slices;
 };
 
@@ -63,23 +62,21 @@ public:
   FramebufferManager(int target_width, int target_height);
   ~FramebufferManager();
 
-  static D3DTexture2D*& GetEFBColorTexture();
-  static D3DTexture2D*& GetEFBColorReadTexture();
-  static ID3D11Texture2D*& GetEFBColorStagingBuffer();
+  static D3DTexture2D& GetEFBColorTexture();
+  static D3DTexture2D& GetEFBColorReadTexture();
+  static ID3D11Texture2D* GetEFBColorStagingBuffer();
 
-  static D3DTexture2D*& GetEFBDepthTexture();
-  static D3DTexture2D*& GetEFBDepthReadTexture();
-  static ID3D11Texture2D*& GetEFBDepthStagingBuffer();
+  static D3DTexture2D& GetEFBDepthTexture();
+  static D3DTexture2D& GetEFBDepthReadTexture();
+  static ID3D11Texture2D* GetEFBDepthStagingBuffer();
 
-  static D3DTexture2D*& GetResolvedEFBColorTexture();
-  static D3DTexture2D*& GetResolvedEFBDepthTexture();
+  static D3DTexture2D& GetResolvedEFBColorTexture();
+  static D3DTexture2D& GetResolvedEFBDepthTexture();
 
-  static D3DTexture2D*& GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
+  static D3DTexture2D& GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
   static void SwapReinterpretTexture()
   {
-    D3DTexture2D* swaptex = GetEFBColorTempTexture();
-    m_efb.color_temp_tex = GetEFBColorTexture();
-    m_efb.color_tex = swaptex;
+    std::swap(GetEFBColorTexture(), GetEFBColorTempTexture());
   }
 
 private:
@@ -93,18 +90,18 @@ private:
 
   static struct Efb
   {
-    D3DTexture2D* color_tex;
-    ID3D11Texture2D* color_staging_buf;
-    D3DTexture2D* color_read_texture;
+    D3DTexture2D color_tex;
+    ComPtr<ID3D11Texture2D> color_staging_buf;
+    D3DTexture2D color_read_texture;
 
-    D3DTexture2D* depth_tex;
-    ID3D11Texture2D* depth_staging_buf;
-    D3DTexture2D* depth_read_texture;
+    D3DTexture2D depth_tex;
+    ComPtr<ID3D11Texture2D> depth_staging_buf;
+    D3DTexture2D depth_read_texture;
 
-    D3DTexture2D* color_temp_tex;
+    D3DTexture2D color_temp_tex;
 
-    D3DTexture2D* resolved_color_tex;
-    D3DTexture2D* resolved_depth_tex;
+    D3DTexture2D resolved_color_tex;
+    D3DTexture2D resolved_depth_tex;
 
     int slices;
   } m_efb;

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -26,15 +26,14 @@ public:
   static ID3D11GeometryShader* GetClearGeometryShader();
   static ID3D11GeometryShader* GetCopyGeometryShader();
 
-  static ID3D11Buffer*& GetConstantBuffer();
+  static ID3D11Buffer* GetConstantBuffer();
 
 private:
   struct GSCacheEntry
   {
-    ID3D11GeometryShader* shader;
+    ComPtr<ID3D11GeometryShader> shader;
 
-    GSCacheEntry() : shader(nullptr) {}
-    void Destroy() { SAFE_RELEASE(shader); }
+    void Destroy() { shader.Reset(); }
   };
 
   typedef std::map<GeometryShaderUid, GSCacheEntry> GSCache;

--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -114,11 +114,6 @@ D3DVertexFormat::D3DVertexFormat(const PortableVertexDeclaration& _vtx_decl)
   }
 }
 
-D3DVertexFormat::~D3DVertexFormat()
-{
-  SAFE_RELEASE(m_layout);
-}
-
 void D3DVertexFormat::SetInputLayout(D3DBlob* vs_bytecode)
 {
   if (!m_layout)
@@ -130,10 +125,9 @@ void D3DVertexFormat::SetInputLayout(D3DBlob* vs_bytecode)
         m_elems.data(), m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), &m_layout);
     if (FAILED(hr))
       PanicAlert("Failed to create input layout, %s %d\n", __FILE__, __LINE__);
-    DX11::D3D::SetDebugObjectName((ID3D11DeviceChild*)m_layout,
-                                  "input layout used to emulate the GX pipeline");
+    DX11::D3D::SetDebugObjectName(m_layout.Get(), "input layout used to emulate the GX pipeline");
   }
-  DX11::D3D::stateman->SetInputLayout(m_layout);
+  DX11::D3D::stateman->SetInputLayout(m_layout.Get());
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -28,8 +29,6 @@ namespace DX11
 class PSTextureEncoder final
 {
 public:
-  PSTextureEncoder();
-
   void Init();
   void Shutdown();
   void Encode(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
@@ -39,12 +38,12 @@ public:
 private:
   ID3D11PixelShader* GetEncodingPixelShader(const EFBCopyParams& params);
 
-  bool m_ready;
+  bool m_ready = false;
 
-  ID3D11Texture2D* m_out;
-  ID3D11RenderTargetView* m_outRTV;
-  ID3D11Texture2D* m_outStage;
-  ID3D11Buffer* m_encodeParams;
-  std::map<EFBCopyParams, ID3D11PixelShader*> m_encoding_shaders;
+  ComPtr<ID3D11Texture2D> m_out;
+  ComPtr<ID3D11RenderTargetView> m_outRTV;
+  ComPtr<ID3D11Texture2D> m_outStage;
+  ComPtr<ID3D11Buffer> m_encodeParams;
+  std::map<EFBCopyParams, ComPtr<ID3D11PixelShader>> m_encoding_shaders;
 };
 }

--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -22,15 +22,6 @@ PerfQuery::PerfQuery() : m_query_read_pos()
   ResetQuery();
 }
 
-PerfQuery::~PerfQuery()
-{
-  for (ActiveQuery& entry : m_query_buffer)
-  {
-    // TODO: EndQuery?
-    entry.query->Release();
-  }
-}
-
 void PerfQuery::EnableQuery(PerfQueryGroup type)
 {
   // Is this sane?
@@ -49,7 +40,7 @@ void PerfQuery::EnableQuery(PerfQueryGroup type)
   {
     auto& entry = m_query_buffer[(m_query_read_pos + m_query_count) % m_query_buffer.size()];
 
-    D3D::context->Begin(entry.query);
+    D3D::context->Begin(entry.query.Get());
     entry.query_type = type;
 
     ++m_query_count;
@@ -63,7 +54,7 @@ void PerfQuery::DisableQuery(PerfQueryGroup type)
   {
     auto& entry = m_query_buffer[(m_query_read_pos + m_query_count + m_query_buffer.size() - 1) %
                                  m_query_buffer.size()];
-    D3D::context->End(entry.query);
+    D3D::context->End(entry.query.Get());
   }
 }
 
@@ -98,7 +89,7 @@ void PerfQuery::FlushOne()
   while (hr != S_OK)
   {
     // TODO: Might cause us to be stuck in an infinite loop!
-    hr = D3D::context->GetData(entry.query, &result, sizeof(result), 0);
+    hr = D3D::context->GetData(entry.query.Get(), &result, sizeof(result), 0);
   }
 
   // NOTE: Reported pixel metrics should be referenced to native resolution
@@ -125,8 +116,8 @@ void PerfQuery::WeakFlush()
     auto& entry = m_query_buffer[m_query_read_pos];
 
     UINT64 result = 0;
-    HRESULT hr =
-        D3D::context->GetData(entry.query, &result, sizeof(result), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+    HRESULT hr = D3D::context->GetData(entry.query.Get(), &result, sizeof(result),
+                                       D3D11_ASYNC_GETDATA_DONOTFLUSH);
 
     if (hr == S_OK)
     {

--- a/Source/Core/VideoBackends/D3D/PerfQuery.h
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <d3d11.h>
 
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/PerfQueryBase.h"
 
 namespace DX11
@@ -15,7 +16,7 @@ class PerfQuery : public PerfQueryBase
 {
 public:
   PerfQuery();
-  ~PerfQuery();
+  // TODO: Should the destructor call EndQuery on all queries?
 
   void EnableQuery(PerfQueryGroup type) override;
   void DisableQuery(PerfQueryGroup type) override;
@@ -27,7 +28,7 @@ public:
 private:
   struct ActiveQuery
   {
-    ID3D11Query* query;
+    ComPtr<ID3D11Query> query;
     PerfQueryGroup query_type;
   };
 

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -38,15 +38,15 @@ LinearDiskCache<PixelShaderUid, u8> g_ps_disk_cache;
 LinearDiskCache<UberShader::PixelShaderUid, u8> g_uber_ps_disk_cache;
 extern std::unique_ptr<VideoCommon::AsyncShaderCompiler> g_async_compiler;
 
-ID3D11PixelShader* s_ColorMatrixProgram[2] = {nullptr};
-ID3D11PixelShader* s_ColorCopyProgram[2] = {nullptr};
-ID3D11PixelShader* s_DepthMatrixProgram[2] = {nullptr};
-ID3D11PixelShader* s_ClearProgram = nullptr;
-ID3D11PixelShader* s_AnaglyphProgram = nullptr;
-ID3D11PixelShader* s_DepthResolveProgram = nullptr;
-ID3D11PixelShader* s_rgba6_to_rgb8[2] = {nullptr};
-ID3D11PixelShader* s_rgb8_to_rgba6[2] = {nullptr};
-ID3D11Buffer* pscbuf = nullptr;
+ComPtr<ID3D11PixelShader> s_ColorMatrixProgram[2];
+ComPtr<ID3D11PixelShader> s_ColorCopyProgram[2];
+ComPtr<ID3D11PixelShader> s_DepthMatrixProgram[2];
+ComPtr<ID3D11PixelShader> s_ClearProgram;
+ComPtr<ID3D11PixelShader> s_AnaglyphProgram;
+ComPtr<ID3D11PixelShader> s_DepthResolveProgram;
+ComPtr<ID3D11PixelShader> s_rgba6_to_rgb8[2];
+ComPtr<ID3D11PixelShader> s_rgb8_to_rgba6[2];
+ComPtr<ID3D11Buffer> pscbuf;
 
 const char clear_program_code[] = {"void main(\n"
                                    "out float4 ocol0 : SV_Target,\n"
@@ -307,9 +307,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
     {
       s_rgba6_to_rgb8[0] = D3D::CompileAndCreatePixelShader(reint_rgba6_to_rgb8);
       CHECK(s_rgba6_to_rgb8[0], "Create RGBA6 to RGB8 pixel shader");
-      D3D::SetDebugObjectName(s_rgba6_to_rgb8[0], "RGBA6 to RGB8 pixel shader");
+      D3D::SetDebugObjectName(s_rgba6_to_rgb8[0].Get(), "RGBA6 to RGB8 pixel shader");
     }
-    return s_rgba6_to_rgb8[0];
+    return s_rgba6_to_rgb8[0].Get();
   }
   else if (!s_rgba6_to_rgb8[1])
   {
@@ -318,9 +318,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
     s_rgba6_to_rgb8[1] = D3D::CompileAndCreatePixelShader(buf);
 
     CHECK(s_rgba6_to_rgb8[1], "Create RGBA6 to RGB8 MSAA pixel shader");
-    D3D::SetDebugObjectName(s_rgba6_to_rgb8[1], "RGBA6 to RGB8 MSAA pixel shader");
+    D3D::SetDebugObjectName(s_rgba6_to_rgb8[1].Get(), "RGBA6 to RGB8 MSAA pixel shader");
   }
-  return s_rgba6_to_rgb8[1];
+  return s_rgba6_to_rgb8[1].Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
@@ -331,9 +331,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
     {
       s_rgb8_to_rgba6[0] = D3D::CompileAndCreatePixelShader(reint_rgb8_to_rgba6);
       CHECK(s_rgb8_to_rgba6[0], "Create RGB8 to RGBA6 pixel shader");
-      D3D::SetDebugObjectName(s_rgb8_to_rgba6[0], "RGB8 to RGBA6 pixel shader");
+      D3D::SetDebugObjectName(s_rgb8_to_rgba6[0].Get(), "RGB8 to RGBA6 pixel shader");
     }
-    return s_rgb8_to_rgba6[0];
+    return s_rgb8_to_rgba6[0].Get();
   }
   else if (!s_rgb8_to_rgba6[1])
   {
@@ -342,20 +342,20 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
     s_rgb8_to_rgba6[1] = D3D::CompileAndCreatePixelShader(buf);
 
     CHECK(s_rgb8_to_rgba6[1], "Create RGB8 to RGBA6 MSAA pixel shader");
-    D3D::SetDebugObjectName(s_rgb8_to_rgba6[1], "RGB8 to RGBA6 MSAA pixel shader");
+    D3D::SetDebugObjectName(s_rgb8_to_rgba6[1].Get(), "RGB8 to RGBA6 MSAA pixel shader");
   }
-  return s_rgb8_to_rgba6[1];
+  return s_rgb8_to_rgba6[1].Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
 {
   if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
   {
-    return s_ColorCopyProgram[0];
+    return s_ColorCopyProgram[0].Get();
   }
   else if (s_ColorCopyProgram[1])
   {
-    return s_ColorCopyProgram[1];
+    return s_ColorCopyProgram[1].Get();
   }
   else
   {
@@ -363,9 +363,8 @@ ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
     std::string buf = StringFromFormat(color_copy_program_code_msaa, g_ActiveConfig.iMultisamples);
     s_ColorCopyProgram[1] = D3D::CompileAndCreatePixelShader(buf);
     CHECK(s_ColorCopyProgram[1] != nullptr, "Create color copy MSAA pixel shader");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[1],
-                            "color copy MSAA pixel shader");
-    return s_ColorCopyProgram[1];
+    D3D::SetDebugObjectName(s_ColorCopyProgram[1].Get(), "color copy MSAA pixel shader");
+    return s_ColorCopyProgram[1].Get();
   }
 }
 
@@ -373,11 +372,11 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
 {
   if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
   {
-    return s_ColorMatrixProgram[0];
+    return s_ColorMatrixProgram[0].Get();
   }
   else if (s_ColorMatrixProgram[1])
   {
-    return s_ColorMatrixProgram[1];
+    return s_ColorMatrixProgram[1].Get();
   }
   else
   {
@@ -386,9 +385,8 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
         StringFromFormat(color_matrix_program_code_msaa, g_ActiveConfig.iMultisamples);
     s_ColorMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
     CHECK(s_ColorMatrixProgram[1] != nullptr, "Create color matrix MSAA pixel shader");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[1],
-                            "color matrix MSAA pixel shader");
-    return s_ColorMatrixProgram[1];
+    D3D::SetDebugObjectName(s_ColorMatrixProgram[1].Get(), "color matrix MSAA pixel shader");
+    return s_ColorMatrixProgram[1].Get();
   }
 }
 
@@ -396,11 +394,11 @@ ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
 {
   if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
   {
-    return s_DepthMatrixProgram[0];
+    return s_DepthMatrixProgram[0].Get();
   }
   else if (s_DepthMatrixProgram[1])
   {
-    return s_DepthMatrixProgram[1];
+    return s_DepthMatrixProgram[1].Get();
   }
   else
   {
@@ -408,33 +406,32 @@ ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
     std::string buf = StringFromFormat(depth_matrix_program_msaa, g_ActiveConfig.iMultisamples);
     s_DepthMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
     CHECK(s_DepthMatrixProgram[1] != nullptr, "Create depth matrix MSAA pixel shader");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[1],
-                            "depth matrix MSAA pixel shader");
-    return s_DepthMatrixProgram[1];
+    D3D::SetDebugObjectName(s_DepthMatrixProgram[1].Get(), "depth matrix MSAA pixel shader");
+    return s_DepthMatrixProgram[1].Get();
   }
 }
 
 ID3D11PixelShader* PixelShaderCache::GetClearProgram()
 {
-  return s_ClearProgram;
+  return s_ClearProgram.Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetAnaglyphProgram()
 {
-  return s_AnaglyphProgram;
+  return s_AnaglyphProgram.Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetDepthResolveProgram()
 {
   if (s_DepthResolveProgram != nullptr)
-    return s_DepthResolveProgram;
+    return s_DepthResolveProgram.Get();
 
   // create MSAA shader for current AA mode
   std::string buf = StringFromFormat(depth_resolve_program, g_ActiveConfig.iMultisamples);
   s_DepthResolveProgram = D3D::CompileAndCreatePixelShader(buf);
   CHECK(s_DepthResolveProgram != nullptr, "Create depth matrix MSAA pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthResolveProgram, "depth resolve pixel shader");
-  return s_DepthResolveProgram;
+  D3D::SetDebugObjectName(s_DepthResolveProgram.Get(), "depth resolve pixel shader");
+  return s_DepthResolveProgram.Get();
 }
 
 static void UpdateConstantBuffers()
@@ -442,9 +439,9 @@ static void UpdateConstantBuffers()
   if (PixelShaderManager::dirty)
   {
     D3D11_MAPPED_SUBRESOURCE map;
-    D3D::context->Map(pscbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
+    D3D::context->Map(pscbuf.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
     memcpy(map.pData, &PixelShaderManager::constants, sizeof(PixelShaderConstants));
-    D3D::context->Unmap(pscbuf, 0);
+    D3D::context->Unmap(pscbuf.Get(), 0);
     PixelShaderManager::dirty = false;
 
     ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(PixelShaderConstants));
@@ -454,7 +451,7 @@ static void UpdateConstantBuffers()
 ID3D11Buffer* PixelShaderCache::GetConstantBuffer()
 {
   UpdateConstantBuffers();
-  return pscbuf;
+  return pscbuf.Get();
 }
 
 // this class will load the precompiled shaders into our cache
@@ -476,33 +473,33 @@ void PixelShaderCache::Init()
                                                 D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
   D3D::device->CreateBuffer(&cbdesc, nullptr, &pscbuf);
   CHECK(pscbuf != nullptr, "Create pixel shader constant buffer");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)pscbuf,
+  D3D::SetDebugObjectName(pscbuf.Get(),
                           "pixel shader constant buffer used to emulate the GX pipeline");
 
   // used when drawing clear quads
   s_ClearProgram = D3D::CompileAndCreatePixelShader(clear_program_code);
   CHECK(s_ClearProgram != nullptr, "Create clear pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ClearProgram, "clear pixel shader");
+  D3D::SetDebugObjectName(s_ClearProgram.Get(), "clear pixel shader");
 
   // used for anaglyph stereoscopy
   s_AnaglyphProgram = D3D::CompileAndCreatePixelShader(anaglyph_program_code);
   CHECK(s_AnaglyphProgram != nullptr, "Create anaglyph pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_AnaglyphProgram, "anaglyph pixel shader");
+  D3D::SetDebugObjectName(s_AnaglyphProgram.Get(), "anaglyph pixel shader");
 
   // used when copying/resolving the color buffer
   s_ColorCopyProgram[0] = D3D::CompileAndCreatePixelShader(color_copy_program_code);
   CHECK(s_ColorCopyProgram[0] != nullptr, "Create color copy pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[0], "color copy pixel shader");
+  D3D::SetDebugObjectName(s_ColorCopyProgram[0].Get(), "color copy pixel shader");
 
   // used for color conversion
   s_ColorMatrixProgram[0] = D3D::CompileAndCreatePixelShader(color_matrix_program_code);
   CHECK(s_ColorMatrixProgram[0] != nullptr, "Create color matrix pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[0], "color matrix pixel shader");
+  D3D::SetDebugObjectName(s_ColorMatrixProgram[0].Get(), "color matrix pixel shader");
 
   // used for depth copy
   s_DepthMatrixProgram[0] = D3D::CompileAndCreatePixelShader(depth_matrix_program);
   CHECK(s_DepthMatrixProgram[0] != nullptr, "Create depth matrix pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[0], "depth matrix pixel shader");
+  D3D::SetDebugObjectName(s_DepthMatrixProgram[0].Get(), "depth matrix pixel shader");
 
   Clear();
 
@@ -560,28 +557,28 @@ void PixelShaderCache::Clear()
 // Used in Swap() when AA mode has changed
 void PixelShaderCache::InvalidateMSAAShaders()
 {
-  SAFE_RELEASE(s_ColorCopyProgram[1]);
-  SAFE_RELEASE(s_ColorMatrixProgram[1]);
-  SAFE_RELEASE(s_DepthMatrixProgram[1]);
-  SAFE_RELEASE(s_rgb8_to_rgba6[1]);
-  SAFE_RELEASE(s_rgba6_to_rgb8[1]);
-  SAFE_RELEASE(s_DepthResolveProgram);
+  s_ColorCopyProgram[1].Reset();
+  s_ColorMatrixProgram[1].Reset();
+  s_DepthMatrixProgram[1].Reset();
+  s_rgb8_to_rgba6[1].Reset();
+  s_rgba6_to_rgb8[1].Reset();
+  s_DepthResolveProgram.Reset();
 }
 
 void PixelShaderCache::Shutdown()
 {
-  SAFE_RELEASE(pscbuf);
+  pscbuf.Reset();
 
-  SAFE_RELEASE(s_ClearProgram);
-  SAFE_RELEASE(s_AnaglyphProgram);
-  SAFE_RELEASE(s_DepthResolveProgram);
+  s_ClearProgram.Reset();
+  s_AnaglyphProgram.Reset();
+  s_DepthResolveProgram.Reset();
   for (int i = 0; i < 2; ++i)
   {
-    SAFE_RELEASE(s_ColorCopyProgram[i]);
-    SAFE_RELEASE(s_ColorMatrixProgram[i]);
-    SAFE_RELEASE(s_DepthMatrixProgram[i]);
-    SAFE_RELEASE(s_rgba6_to_rgb8[i]);
-    SAFE_RELEASE(s_rgb8_to_rgba6[i]);
+    s_ColorCopyProgram[i].Reset();
+    s_ColorMatrixProgram[i].Reset();
+    s_DepthMatrixProgram[i].Reset();
+    s_rgba6_to_rgb8[i].Reset();
+    s_rgb8_to_rgba6[i].Reset();
   }
 
   Clear();
@@ -605,7 +602,7 @@ bool PixelShaderCache::SetShader()
     if (!last_entry->shader)
       return false;
 
-    D3D::stateman->SetPixelShader(last_entry->shader);
+    D3D::stateman->SetPixelShader(last_entry->shader.Get());
     return true;
   }
 
@@ -624,7 +621,7 @@ bool PixelShaderCache::SetShader()
     if (!last_entry->shader)
       return false;
 
-    D3D::stateman->SetPixelShader(last_entry->shader);
+    D3D::stateman->SetPixelShader(last_entry->shader.Get());
     return true;
   }
 
@@ -643,15 +640,12 @@ bool PixelShaderCache::SetShader()
   }
 
   // Need to compile a new shader
-  D3DBlob* bytecode = nullptr;
+  ComPtr<D3DBlob> bytecode;
   ShaderCode code =
       GeneratePixelShaderCode(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   D3D::CompilePixelShader(code.GetBuffer(), &bytecode);
   if (!InsertByteCode(uid, bytecode->Data(), bytecode->Size()))
-  {
-    SAFE_RELEASE(bytecode);
     return false;
-  }
 
   g_ps_disk_cache.Append(uid, bytecode->Data(), bytecode->Size());
   return SetShader();
@@ -666,7 +660,7 @@ bool PixelShaderCache::SetUberShader()
     if (!last_uber_entry->shader)
       return false;
 
-    D3D::stateman->SetPixelShader(last_uber_entry->shader);
+    D3D::stateman->SetPixelShader(last_uber_entry->shader.Get());
     return true;
   }
 
@@ -681,34 +675,27 @@ bool PixelShaderCache::SetUberShader()
     if (!last_uber_entry->shader)
       return false;
 
-    D3D::stateman->SetPixelShader(last_uber_entry->shader);
+    D3D::stateman->SetPixelShader(last_uber_entry->shader.Get());
     return true;
   }
 
-  D3DBlob* bytecode = nullptr;
+  ComPtr<D3DBlob> bytecode;
   ShaderCode code =
       UberShader::GenPixelShader(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   D3D::CompilePixelShader(code.GetBuffer(), &bytecode);
   if (!InsertByteCode(uid, bytecode->Data(), bytecode->Size()))
-  {
-    SAFE_RELEASE(bytecode);
     return false;
-  }
 
   // Lookup map again.
   g_uber_ps_disk_cache.Append(uid, bytecode->Data(), bytecode->Size());
-  bytecode->Release();
   return SetUberShader();
 }
 
 bool PixelShaderCache::InsertByteCode(const PixelShaderUid& uid, const u8* data, size_t len)
 {
-  ID3D11PixelShader* shader = data ? D3D::CreatePixelShaderFromByteCode(data, len) : nullptr;
-  if (!InsertShader(uid, shader))
-  {
-    SAFE_RELEASE(shader);
+  ComPtr<ID3D11PixelShader> shader = data ? D3D::CreatePixelShaderFromByteCode(data, len) : nullptr;
+  if (!InsertShader(uid, shader.Get()))
     return false;
-  }
 
   return true;
 }
@@ -716,12 +703,9 @@ bool PixelShaderCache::InsertByteCode(const PixelShaderUid& uid, const u8* data,
 bool PixelShaderCache::InsertByteCode(const UberShader::PixelShaderUid& uid, const u8* data,
                                       size_t len)
 {
-  ID3D11PixelShader* shader = data ? D3D::CreatePixelShaderFromByteCode(data, len) : nullptr;
-  if (!InsertShader(uid, shader))
-  {
-    SAFE_RELEASE(shader);
+  ComPtr<ID3D11PixelShader> shader = data ? D3D::CreatePixelShaderFromByteCode(data, len) : nullptr;
+  if (!InsertShader(uid, shader.Get()))
     return false;
-  }
 
   return true;
 }
@@ -738,7 +722,7 @@ bool PixelShaderCache::InsertShader(const PixelShaderUid& uid, ID3D11PixelShader
 
   INCSTAT(stats.numPixelShadersCreated);
   SETSTAT(stats.numPixelShadersAlive, PixelShaders.size());
-  return (shader != nullptr);
+  return (newentry.shader != nullptr);
 }
 
 bool PixelShaderCache::InsertShader(const UberShader::PixelShaderUid& uid,
@@ -751,7 +735,7 @@ bool PixelShaderCache::InsertShader(const UberShader::PixelShaderUid& uid,
   PSCacheEntry& newentry = UberPixelShaders[uid];
   newentry.pending = false;
   newentry.shader = shader;
-  return (shader != nullptr);
+  return (newentry.shader != nullptr);
 }
 
 void PixelShaderCache::QueueUberShaderCompiles()
@@ -778,28 +762,23 @@ PixelShaderCache::PixelShaderCompilerWorkItem::PixelShaderCompilerWorkItem(
   std::memcpy(&m_uid, &uid, sizeof(uid));
 }
 
-PixelShaderCache::PixelShaderCompilerWorkItem::~PixelShaderCompilerWorkItem()
-{
-  SAFE_RELEASE(m_bytecode);
-}
-
 bool PixelShaderCache::PixelShaderCompilerWorkItem::Compile()
 {
   ShaderCode code =
       GeneratePixelShaderCode(APIType::D3D, ShaderHostConfig::GetCurrent(), m_uid.GetUidData());
 
   if (D3D::CompilePixelShader(code.GetBuffer(), &m_bytecode))
-    m_shader = D3D::CreatePixelShaderFromByteCode(m_bytecode);
+    m_shader = D3D::CreatePixelShaderFromByteCode(m_bytecode.Get());
 
   return true;
 }
 
 void PixelShaderCache::PixelShaderCompilerWorkItem::Retrieve()
 {
-  if (InsertShader(m_uid, m_shader))
+  if (InsertShader(m_uid, m_shader.Get()))
     g_ps_disk_cache.Append(m_uid, m_bytecode->Data(), m_bytecode->Size());
   else
-    SAFE_RELEASE(m_shader);
+    m_shader.Reset();
 }
 
 PixelShaderCache::UberPixelShaderCompilerWorkItem::UberPixelShaderCompilerWorkItem(
@@ -808,28 +787,23 @@ PixelShaderCache::UberPixelShaderCompilerWorkItem::UberPixelShaderCompilerWorkIt
   std::memcpy(&m_uid, &uid, sizeof(uid));
 }
 
-PixelShaderCache::UberPixelShaderCompilerWorkItem::~UberPixelShaderCompilerWorkItem()
-{
-  SAFE_RELEASE(m_bytecode);
-}
-
 bool PixelShaderCache::UberPixelShaderCompilerWorkItem::Compile()
 {
   ShaderCode code =
       UberShader::GenPixelShader(APIType::D3D, ShaderHostConfig::GetCurrent(), m_uid.GetUidData());
 
   if (D3D::CompilePixelShader(code.GetBuffer(), &m_bytecode))
-    m_shader = D3D::CreatePixelShaderFromByteCode(m_bytecode);
+    m_shader = D3D::CreatePixelShaderFromByteCode(m_bytecode.Get());
 
   return true;
 }
 
 void PixelShaderCache::UberPixelShaderCompilerWorkItem::Retrieve()
 {
-  if (InsertShader(m_uid, m_shader))
+  if (InsertShader(m_uid, m_shader.Get()))
     g_uber_ps_disk_cache.Append(m_uid, m_bytecode->Data(), m_bytecode->Size());
   else
-    SAFE_RELEASE(m_shader);
+    m_shader.Reset();
 }
 
 }  // DX11

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -46,41 +46,38 @@ public:
 private:
   struct PSCacheEntry
   {
-    ID3D11PixelShader* shader;
-    bool pending;
+    ComPtr<ID3D11PixelShader> shader;
+    bool pending = false;
 
-    PSCacheEntry() : shader(nullptr), pending(false) {}
-    void Destroy() { SAFE_RELEASE(shader); }
+    void Destroy() { shader.Reset(); }
   };
 
   class PixelShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
     PixelShaderCompilerWorkItem(const PixelShaderUid& uid);
-    ~PixelShaderCompilerWorkItem() override;
 
     bool Compile() override;
     void Retrieve() override;
 
   private:
     PixelShaderUid m_uid;
-    ID3D11PixelShader* m_shader = nullptr;
-    D3DBlob* m_bytecode = nullptr;
+    ComPtr<ID3D11PixelShader> m_shader;
+    ComPtr<D3DBlob> m_bytecode;
   };
 
   class UberPixelShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
     UberPixelShaderCompilerWorkItem(const UberShader::PixelShaderUid& uid);
-    ~UberPixelShaderCompilerWorkItem() override;
 
     bool Compile() override;
     void Retrieve() override;
 
   private:
     UberShader::PixelShaderUid m_uid;
-    ID3D11PixelShader* m_shader = nullptr;
-    D3DBlob* m_bytecode = nullptr;
+    ComPtr<ID3D11PixelShader> m_shader;
+    ComPtr<D3DBlob> m_bytecode;
   };
 
   typedef std::map<PixelShaderUid, PSCacheEntry> PSCache;

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -62,7 +62,7 @@ public:
   bool CheckForResize();
 
 private:
-  void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
+  void BlitScreen(TargetRectangle src, TargetRectangle dst, const D3DTexture2D* src_texture,
                   u32 src_width, u32 src_height, float Gamma);
 };
 }

--- a/Source/Core/VideoBackends/D3D/Television.h
+++ b/Source/Core/VideoBackends/D3D/Television.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/D3DBase.h"
 
 struct ID3D11Texture2D;
 struct ID3D11ShaderResourceView;
@@ -16,8 +17,6 @@ namespace DX11
 class Television
 {
 public:
-  Television();
-
   void Init();
   void Shutdown();
 
@@ -37,9 +36,9 @@ private:
 
   // Used for real XFB mode
 
-  ID3D11Texture2D* m_yuyvTexture;
-  ID3D11ShaderResourceView* m_yuyvTextureSRV;
-  ID3D11PixelShader* m_pShader;
-  ID3D11SamplerState* m_samplerState;
+  ComPtr<ID3D11Texture2D> m_yuyvTexture;
+  ComPtr<ID3D11ShaderResourceView> m_yuyvTextureSRV;
+  ComPtr<ID3D11PixelShader> m_pShader;
+  ComPtr<ID3D11SamplerState> m_samplerState;
 };
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -40,9 +40,9 @@ private:
 
   bool CompileShaders() override { return true; }
   void DeleteShaders() override {}
-  ID3D11Buffer* palette_buf;
-  ID3D11ShaderResourceView* palette_buf_srv;
-  ID3D11Buffer* palette_uniform;
-  ID3D11PixelShader* palette_pixel_shader[3];
+  ComPtr<ID3D11Buffer> palette_buf;
+  ComPtr<ID3D11ShaderResourceView> palette_buf_srv;
+  ComPtr<ID3D11Buffer> palette_uniform;
+  ComPtr<ID3D11PixelShader> palette_pixel_shader[3];
 };
 }

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -46,7 +46,7 @@ void VertexManager::CreateDeviceObjects()
     m_buffers[i] = nullptr;
     CHECK(SUCCEEDED(D3D::device->CreateBuffer(&bufdesc, nullptr, &m_buffers[i])),
           "Failed to create buffer.");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_buffers[i], "Buffer of VertexManager");
+    D3D::SetDebugObjectName(m_buffers[i].Get(), "Buffer of VertexManager");
   }
 
   m_currentBuffer = 0;
@@ -57,7 +57,7 @@ void VertexManager::DestroyDeviceObjects()
 {
   for (int i = 0; i < MAX_BUFFER_COUNT; i++)
   {
-    SAFE_RELEASE(m_buffers[i]);
+    m_buffers[i].Reset();
   }
 }
 
@@ -105,11 +105,11 @@ void VertexManager::PrepareDrawBuffers(u32 stride)
   m_vertexDrawOffset = cursor;
   m_indexDrawOffset = cursor + vertexBufferSize;
 
-  D3D::context->Map(m_buffers[m_currentBuffer], 0, MapType, 0, &map);
+  D3D::context->Map(m_buffers[m_currentBuffer].Get(), 0, MapType, 0, &map);
   u8* mappedData = reinterpret_cast<u8*>(map.pData);
   memcpy(mappedData + m_vertexDrawOffset, m_base_buffer_pointer, vertexBufferSize);
   memcpy(mappedData + m_indexDrawOffset, GetIndexBuffer(), indexBufferSize);
-  D3D::context->Unmap(m_buffers[m_currentBuffer], 0);
+  D3D::context->Unmap(m_buffers[m_currentBuffer].Get(), 0);
 
   m_bufferCursor = cursor + totalBufferSize;
 
@@ -121,8 +121,8 @@ void VertexManager::Draw(u32 stride)
 {
   u32 indices = IndexGenerator::GetIndexLen();
 
-  D3D::stateman->SetVertexBuffer(m_buffers[m_currentBuffer], stride, 0);
-  D3D::stateman->SetIndexBuffer(m_buffers[m_currentBuffer]);
+  D3D::stateman->SetVertexBuffer(m_buffers[m_currentBuffer].Get(), stride, 0);
+  D3D::stateman->SetIndexBuffer(m_buffers[m_currentBuffer].Get());
 
   u32 baseVertex = m_vertexDrawOffset / stride;
   u32 startIndex = m_indexDrawOffset / sizeof(u16);
@@ -175,9 +175,9 @@ void VertexManager::vFlush()
 
   if (g_ActiveConfig.backend_info.bSupportsBBox && BoundingBox::active)
   {
+    ID3D11UnorderedAccessView* uav = BBox::GetUAV();
     D3D::context->OMSetRenderTargetsAndUnorderedAccessViews(
-        D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL, nullptr, nullptr, 2, 1, &BBox::GetUAV(),
-        nullptr);
+        D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL, nullptr, nullptr, 2, 1, &uav, nullptr);
   }
 
   u32 stride = VertexLoaderManager::GetCurrentVertexFormat()->GetVertexStride();

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -6,6 +6,7 @@
 
 #include <d3d11.h>
 #include <memory>
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexManagerBase.h"
 
@@ -18,14 +19,13 @@ class D3DVertexFormat : public NativeVertexFormat
 {
 public:
   D3DVertexFormat(const PortableVertexDeclaration& vtx_decl);
-  ~D3DVertexFormat();
   void SetInputLayout(D3DBlob* vs_bytecode);
 
 private:
   std::array<D3D11_INPUT_ELEMENT_DESC, 32> m_elems{};
   UINT m_num_elems = 0;
 
-  ID3D11InputLayout* m_layout = nullptr;
+  ComPtr<ID3D11InputLayout> m_layout;
 };
 
 class VertexManager : public VertexManagerBase
@@ -58,7 +58,7 @@ private:
   {
     MAX_BUFFER_COUNT = 2
   };
-  ID3D11Buffer* m_buffers[MAX_BUFFER_COUNT];
+  ComPtr<ID3D11Buffer> m_buffers[MAX_BUFFER_COUNT];
 
   std::vector<u8> LocalVBuffer;
   std::vector<u16> LocalIBuffer;

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.h
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/VideoCommon.h"
 
 struct ID3D11Texture2D;
@@ -22,25 +23,23 @@ namespace DX11
 class XFBEncoder
 {
 public:
-  XFBEncoder();
-
   void Init();
   void Shutdown();
 
   void Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcRect, float gamma);
 
 private:
-  ID3D11Texture2D* m_out;
-  ID3D11RenderTargetView* m_outRTV;
-  ID3D11Texture2D* m_outStage;
-  ID3D11Buffer* m_encodeParams;
-  ID3D11Buffer* m_quad;
-  ID3D11VertexShader* m_vShader;
-  ID3D11InputLayout* m_quadLayout;
-  ID3D11PixelShader* m_pShader;
-  ID3D11BlendState* m_xfbEncodeBlendState;
-  ID3D11DepthStencilState* m_xfbEncodeDepthState;
-  ID3D11RasterizerState* m_xfbEncodeRastState;
-  ID3D11SamplerState* m_efbSampler;
+  ComPtr<ID3D11Texture2D> m_out;
+  ComPtr<ID3D11RenderTargetView> m_outRTV;
+  ComPtr<ID3D11Texture2D> m_outStage;
+  ComPtr<ID3D11Buffer> m_encodeParams;
+  ComPtr<ID3D11Buffer> m_quad;
+  ComPtr<ID3D11VertexShader> m_vShader;
+  ComPtr<ID3D11InputLayout> m_quadLayout;
+  ComPtr<ID3D11PixelShader> m_pShader;
+  ComPtr<ID3D11BlendState> m_xfbEncodeBlendState;
+  ComPtr<ID3D11DepthStencilState> m_xfbEncodeDepthState;
+  ComPtr<ID3D11RasterizerState> m_xfbEncodeRastState;
+  ComPtr<ID3D11SamplerState> m_efbSampler;
 };
 }

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -82,9 +82,9 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDynamicSamplerIndexing = false;
   g_Config.backend_info.bSupportsBPTCTextures = false;
 
-  IDXGIFactory* factory;
-  IDXGIAdapter* ad;
-  hr = DX11::PCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
+  ComPtr<IDXGIFactory> factory;
+  ComPtr<IDXGIAdapter> ad;
+  hr = DX11::PCreateDXGIFactory(__uuidof(IDXGIFactory), &factory);
   if (FAILED(hr))
     PanicAlert("Failed to create IDXGIFactory object");
 
@@ -103,14 +103,14 @@ void VideoBackend::InitBackendInfo()
     if (adapter_index == g_Config.iAdapter)
     {
       std::string samples;
-      std::vector<DXGI_SAMPLE_DESC> modes = DX11::D3D::EnumAAModes(ad);
+      std::vector<DXGI_SAMPLE_DESC> modes = DX11::D3D::EnumAAModes(ad.Get());
       // First iteration will be 1. This equals no AA.
       for (unsigned int i = 0; i < modes.size(); ++i)
       {
         g_Config.backend_info.AAModes.push_back(modes[i].Count);
       }
 
-      D3D_FEATURE_LEVEL feature_level = D3D::GetFeatureLevel(ad);
+      D3D_FEATURE_LEVEL feature_level = D3D::GetFeatureLevel(ad.Get());
       bool shader_model_5_supported = feature_level >= D3D_FEATURE_LEVEL_11_0;
       g_Config.backend_info.MaxTextureSize = D3D::GetMaxTextureSize(feature_level);
 
@@ -128,9 +128,9 @@ void VideoBackend::InitBackendInfo()
       g_Config.backend_info.bSupportsSSAA = shader_model_5_supported;
     }
     g_Config.backend_info.Adapters.push_back(UTF16ToUTF8(desc.Description));
-    ad->Release();
+    ad.Reset();
   }
-  factory->Release();
+  factory.Reset();
 
   DX11::D3D::UnloadDXGI();
   DX11::D3D::UnloadD3D();


### PR DESCRIPTION
This PR uses COM smart pointers to manage COM pointers.

This makes it easier to avoid resource leaks of COM objects.