### PR TITLE
Qt: Fix missing window border after exiting fullscreen under Windows

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -470,8 +470,8 @@ void MainWindow::ShowRenderWidget()
     }
     else
     {
-      m_render_widget->resize(640, 480);
       m_render_widget->showNormal();
+      m_render_widget->resize(640, 480);
     }
   }
 }


### PR DESCRIPTION
Changing the order in which ``resize`` and ``showNormal`` are called seems to fix the issue.