### PR TITLE
Improve GameCube region detection

### DIFF
--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -217,6 +217,9 @@ struct SConfig : NonCopyable
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd);
 
   void LoadDefaults();
+  // Replaces NTSC-K with some other region, and doesn't replace non-NTSC-K regions
+  static DiscIO::Region ToGameCubeRegion(DiscIO::Region region);
+  // The region argument must be valid for GameCube (i.e. must not be NTSC-K)
   static const char* GetDirectoryForRegion(DiscIO::Region region);
   std::string GetBootROMPath(const std::string& region_directory) const;
   bool SetPathsAndGameMetadata(const BootParameters& boot);

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -157,7 +157,7 @@ CEXIMemoryCard::CEXIMemoryCard(const int index, bool gciFolder) : card_index(ind
 
 void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 {
-  DiscIO::Region region = SConfig::GetInstance().m_region;
+  const DiscIO::Region region = SConfig::ToGameCubeRegion(SConfig::GetInstance().m_region);
 
   const std::string& game_id = SConfig::GetInstance().GetGameID();
   u32 CurrentGameId = 0;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -44,6 +44,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, DiscIO::Region car
       return NO_INDEX;
     }
 
+    // This isn't a reliable way to detect regions. TODO: Get rid of this?
     DiscIO::Region gci_region = DiscIO::RegionSwitchGC(gci.m_gci_header.Gamecode[3]);
     // Some special save files have game IDs that we parse as UNKNOWN_REGION. For instance:
     // - Datel Action Replay uses C as the fourth character. (Can be on any region's card.)

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -232,14 +232,6 @@ u64 TMDReader::GetIOSId() const
   return Common::swap64(m_bytes.data() + offsetof(TMDHeader, ios_id));
 }
 
-DiscIO::Region TMDReader::GetRegion() const
-{
-  if (GetTitleId() == Titles::SYSTEM_MENU)
-    return DiscIO::GetSysMenuRegion(GetTitleVersion());
-
-  return DiscIO::RegionSwitchWii(static_cast<u8>(GetTitleId() & 0xff));
-}
-
 u64 TMDReader::GetTitleId() const
 {
   return Common::swap64(m_bytes.data() + offsetof(TMDHeader, title_id));
@@ -258,6 +250,14 @@ u16 TMDReader::GetTitleVersion() const
 u16 TMDReader::GetGroupId() const
 {
   return Common::swap16(m_bytes.data() + offsetof(TMDHeader, group_id));
+}
+
+DiscIO::Region TMDReader::GetRegion() const
+{
+  if (GetTitleId() == Titles::SYSTEM_MENU)
+    return DiscIO::GetSysMenuRegion(GetTitleVersion());
+
+  return DiscIO::RegionSwitchWii(static_cast<u8>(GetTitleId() & 0xff));
 }
 
 std::string TMDReader::GetGameID() const

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -185,11 +185,13 @@ public:
 
   u16 GetBootIndex() const;
   u64 GetIOSId() const;
-  DiscIO::Region GetRegion() const;
   u64 GetTitleId() const;
   u32 GetTitleFlags() const;
   u16 GetTitleVersion() const;
   u16 GetGroupId() const;
+
+  // Provides a best guess for the region. Might be inaccurate or UNKNOWN_REGION.
+  DiscIO::Region GetRegion() const;
 
   // Constructs a 6-character game ID in the format typically used by Dolphin.
   // If the 6-character game ID would contain unprintable characters,

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -94,12 +94,12 @@ static bool IsWiiTitle(const std::string& game_id)
 
 static bool IsJapaneseGCTitle(const std::string& game_id)
 {
-  return IsGCTitle(game_id) && DiscIO::RegionSwitchGC(game_id[3]) == DiscIO::Region::NTSC_J;
+  return IsGCTitle(game_id) && DiscIO::CountrySwitch(game_id[3]) == DiscIO::Country::COUNTRY_JAPAN;
 }
 
 static bool IsNonJapaneseGCTitle(const std::string& game_id)
 {
-  return IsGCTitle(game_id) && DiscIO::RegionSwitchGC(game_id[3]) != DiscIO::Region::NTSC_J;
+  return IsGCTitle(game_id) && DiscIO::CountrySwitch(game_id[3]) != DiscIO::Country::COUNTRY_JAPAN;
 }
 
 // Note that this function will not overwrite entries that already are in the maps

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -48,7 +48,7 @@ Country TypicalCountryForRegion(Region region)
 Region RegionSwitchGC(u8 country_code)
 {
   Region region = RegionSwitchWii(country_code);
-  return region == Region::NTSC_K ? Region::UNKNOWN_REGION : region;
+  return region == Region::NTSC_K ? Region::NTSC_J : region;
 }
 
 Region RegionSwitchWii(u8 country_code)

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -40,10 +40,10 @@ enum class Country
   NUMBER_OF_COUNTRIES
 };
 
-// Regions 0 - 2 and 4 match Nintendo's Wii region numbering.
+// Regions 0 - 2 and 4 match Nintendo's GameCube/Wii region numbering.
 enum class Region
 {
-  NTSC_J = 0,          // Japan and Taiwan
+  NTSC_J = 0,          // Japan and Taiwan (and South Korea for GameCube only)
   NTSC_U = 1,          // Mainly North America
   PAL = 2,             // Mainly Europe and Oceania
   UNKNOWN_REGION = 3,  // 3 seems to be unused? Anyway, we need an UNKNOWN_REGION. Let's put it here

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -71,11 +71,16 @@ enum class Language
 bool IsDisc(Platform volume_type);
 bool IsWii(Platform volume_type);
 bool IsNTSC(Region region);
+
 Country TypicalCountryForRegion(Region region);
+// Avoid using this function if you can. Country codes aren't always reliable region indicators.
 Region RegionSwitchGC(u8 country_code);
+// Avoid using this function if you can. Country codes aren't always reliable region indicators.
 Region RegionSwitchWii(u8 country_code);
 Country CountrySwitch(u8 country_code);
+
 Region GetSysMenuRegion(u16 title_version);
 std::string GetSysMenuVersionString(u16 title_version);
+
 std::string GetCompanyFromID(const std::string& company_id);
 }

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -83,6 +83,7 @@ public:
   virtual Platform GetVolumeType() const = 0;
   virtual bool SupportsIntegrityCheck() const { return false; }
   virtual bool CheckIntegrity(const Partition& partition) const { return false; }
+  // May be inaccurate for WADs
   virtual Region GetRegion() const = 0;
   Country GetCountry() const { return GetCountry(GetGamePartition()); }
   virtual Country GetCountry(const Partition& partition) const = 0;

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -67,13 +67,21 @@ Region VolumeGC::GetRegion() const
 Country VolumeGC::GetCountry(const Partition& partition) const
 {
   // The 0 that we use as a default value is mapped to COUNTRY_UNKNOWN and UNKNOWN_REGION
-  const u8 country_byte = ReadSwapped<u8>(3, partition).value_or(0);
+  const u8 country = ReadSwapped<u8>(3, partition).value_or(0);
   const Region region = GetRegion();
 
-  if (RegionSwitchGC(country_byte) != region)
+  // Korean GC releases use NTSC-J.
+  // E is normally used for America, but it's also used for English-language Korean GC releases.
+  // K is used by games that are in the Korean language.
+  // W means Taiwan for Wii games, but on the GC, it's used for English-language Korean releases.
+  // (There doesn't seem to be any pattern to which of E and W is used for Korean GC releases.)
+  if (region == Region::NTSC_J && (country == 'E' || country == 'K' || country == 'W'))
+    return Country::COUNTRY_KOREA;
+
+  if (RegionSwitchGC(country) != region)
     return TypicalCountryForRegion(region);
 
-  return CountrySwitch(country_byte);
+  return CountrySwitch(country);
 }
 
 std::string VolumeGC::GetMakerID(const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -60,14 +60,20 @@ std::string VolumeGC::GetGameID(const Partition& partition) const
 
 Region VolumeGC::GetRegion() const
 {
-  const std::optional<u8> country_code = ReadSwapped<u8>(3, PARTITION_NONE);
-  return country_code ? RegionSwitchGC(*country_code) : Region::UNKNOWN_REGION;
+  const std::optional<u32> region_code = ReadSwapped<u32>(0x458, PARTITION_NONE);
+  return region_code ? static_cast<Region>(*region_code) : Region::UNKNOWN_REGION;
 }
 
 Country VolumeGC::GetCountry(const Partition& partition) const
 {
-  const std::optional<u8> country_code = ReadSwapped<u8>(3, partition);
-  return country_code ? CountrySwitch(*country_code) : Country::COUNTRY_UNKNOWN;
+  // The 0 that we use as a default value is mapped to COUNTRY_UNKNOWN and UNKNOWN_REGION
+  const u8 country_byte = ReadSwapped<u8>(3, partition).value_or(0);
+  const Region region = GetRegion();
+
+  if (RegionSwitchGC(country_byte) != region)
+    return TypicalCountryForRegion(region);
+
+  return CountrySwitch(country_byte);
 }
 
 std::string VolumeGC::GetMakerID(const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -61,7 +61,10 @@ std::string VolumeGC::GetGameID(const Partition& partition) const
 Region VolumeGC::GetRegion() const
 {
   const std::optional<u32> region_code = ReadSwapped<u32>(0x458, PARTITION_NONE);
-  return region_code ? static_cast<Region>(*region_code) : Region::UNKNOWN_REGION;
+  if (!region_code)
+    return Region::UNKNOWN_REGION;
+  const Region region = static_cast<Region>(*region_code);
+  return region <= Region::PAL ? region : Region::UNKNOWN_REGION;
 }
 
 Country VolumeGC::GetCountry(const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -50,6 +50,7 @@ public:
     return "";
   }
   Platform GetVolumeType() const override;
+  // Provides a best guess for the region. Might be inaccurate or UNKNOWN_REGION.
   Region GetRegion() const override;
   Country GetCountry(const Partition& partition = PARTITION_NONE) const override;
 

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -233,7 +233,10 @@ std::string VolumeWii::GetGameID(const Partition& partition) const
 Region VolumeWii::GetRegion() const
 {
   const std::optional<u32> region_code = m_pReader->ReadSwapped<u32>(0x4E000);
-  return region_code ? static_cast<Region>(*region_code) : Region::UNKNOWN_REGION;
+  if (!region_code)
+    return Region::UNKNOWN_REGION;
+  const Region region = static_cast<Region>(*region_code);
+  return region <= Region::NTSC_K ? region : Region::UNKNOWN_REGION;
 }
 
 Country VolumeWii::GetCountry(const Partition& partition) const


### PR DESCRIPTION
This PR does two things: It makes GameCube disc region detection use the actual region value instead of the fourth byte of the game ID (the same change was done for Wii discs in #3515), and it improves the handling of Korean games in various ways (see commit messages for details).

@JMC47 If you were having problems with Dolphin treating Datel discs as having invalid regions, could you test if this PR fixes the problems? It would also be useful if you could look through your game list to check that this PR doesn't misdetect the region of anything.