### PR TITLE
Qt: implement remainder of 'Options' menu

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SRCS
   GameList/ListProxyModel.cpp
   QtUtils/DoubleClickEventFilter.cpp
   QtUtils/ElidedButton.cpp
+  QtUtils/ListTabWidget.cpp
   QtUtils/WindowActivationEventFilter.cpp
   Settings/AudioPane.cpp
   Settings/GeneralPane.cpp

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -3,22 +3,27 @@
 // Refer to the license.txt file included.
 
 #include <QDialogButtonBox>
-#include <QGroupBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QListWidget>
-#include <QScrollBar>
-#include <QStackedWidget>
 #include <QVBoxLayout>
 
 #include "DolphinQt2/Config/SettingsWindow.h"
 #include "DolphinQt2/MainWindow.h"
+#include "DolphinQt2/QtUtils/ListTabWidget.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/Settings/AudioPane.h"
 #include "DolphinQt2/Settings/GeneralPane.h"
 #include "DolphinQt2/Settings/InterfacePane.h"
 #include "DolphinQt2/Settings/PathPane.h"
+
+static int AddTab(ListTabWidget* tab_widget, const QString& label, QWidget* widget,
+                  const char* icon_name)
+{
+  int index = tab_widget->addTab(widget, label);
+  auto set_icon = [=] { tab_widget->setTabIcon(index, Resources::GetScaledThemeIcon(icon_name)); };
+  QObject::connect(&Settings::Instance(), &Settings::ThemeChanged, set_icon);
+  set_icon();
+  return index;
+}
 
 SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
 {
@@ -28,21 +33,21 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
 
   // Main Layout
   QVBoxLayout* layout = new QVBoxLayout;
-  QHBoxLayout* content = new QHBoxLayout;
-  // Content's widgets
-  {
-    // Category list
-    MakeCategoryList();
-    content->addWidget(m_categories);
-
-    // Actual Settings UI
-    SetupSettingsWidget();
-
-    content->addWidget(m_settings_outer);
-  }
 
   // Add content to layout before dialog buttons.
-  layout->addLayout(content);
+  m_tabs = new ListTabWidget();
+  layout->addWidget(m_tabs);
+
+  AddTab(m_tabs, tr("General"), new GeneralPane(), "config");
+  AddTab(m_tabs, tr("Interface"), new InterfacePane(), "browse");
+  auto* audio_pane = new AudioPane;
+  AddTab(m_tabs, tr("Audio"), audio_pane, "play");
+  AddTab(m_tabs, tr("Paths"), new PathPane(), "browse");
+
+  connect(this, &SettingsWindow::EmulationStarted,
+          [audio_pane] { audio_pane->OnEmulationStateChanged(true); });
+  connect(this, &SettingsWindow::EmulationStopped,
+          [audio_pane] { audio_pane->OnEmulationStateChanged(false); });
 
   // Dialog box buttons
   QDialogButtonBox* ok_box = new QDialogButtonBox(QDialogButtonBox::Ok);
@@ -50,61 +55,4 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   layout->addWidget(ok_box);
 
   setLayout(layout);
-}
-
-void SettingsWindow::SetupSettingsWidget()
-{
-  m_settings_outer = new QStackedWidget;
-  m_settings_outer->setCurrentIndex(0);
-
-  // Panes initalised here
-  m_settings_outer->addWidget(new GeneralPane);
-  m_settings_outer->addWidget(new InterfacePane);
-
-  auto* audio_pane = new AudioPane;
-  connect(this, &SettingsWindow::EmulationStarted,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(true); });
-  connect(this, &SettingsWindow::EmulationStopped,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(false); });
-  m_settings_outer->addWidget(audio_pane);
-
-  m_settings_outer->addWidget(new PathPane);
-}
-
-void SettingsWindow::AddCategoryToList(const QString& title, const std::string& icon_name)
-{
-  QListWidgetItem* button = new QListWidgetItem();
-  button->setText(title);
-  button->setTextAlignment(Qt::AlignVCenter);
-  button->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-
-  auto set_icon = [=] { button->setIcon(Resources::GetScaledThemeIcon(icon_name)); };
-  QObject::connect(&Settings::Instance(), &Settings::ThemeChanged, set_icon);
-  set_icon();
-  m_categories->addItem(button);
-}
-
-void SettingsWindow::MakeCategoryList()
-{
-  m_categories = new QListWidget;
-  m_categories->setIconSize(QSize(32, 32));
-  m_categories->setMovement(QListView::Static);
-  m_categories->setSpacing(0);
-
-  AddCategoryToList(tr("General"), "config");
-  AddCategoryToList(tr("Interface"), "browse");
-  AddCategoryToList(tr("Audio"), "play");
-  AddCategoryToList(tr("Paths"), "browse");
-  connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);
-
-  m_categories->setFixedWidth(m_categories->sizeHintForColumn(0) +
-                              m_categories->verticalScrollBar()->sizeHint().width() +
-                              2 * m_categories->frameWidth());
-}
-
-void SettingsWindow::changePage(QListWidgetItem* current, QListWidgetItem* previous)
-{
-  if (!current)
-    current = previous;
-  m_settings_outer->setCurrentIndex(m_categories->row(current));
 }

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -41,7 +41,7 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   AddTab(m_tabs, tr("General"), new GeneralPane(), "config");
   AddTab(m_tabs, tr("Interface"), new InterfacePane(), "browse");
   auto* audio_pane = new AudioPane;
-  AddTab(m_tabs, tr("Audio"), audio_pane, "play");
+  m_audio_pane_index = AddTab(m_tabs, tr("Audio"), audio_pane, "play");
   AddTab(m_tabs, tr("Paths"), new PathPane(), "browse");
 
   connect(this, &SettingsWindow::EmulationStarted,
@@ -55,4 +55,9 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   layout->addWidget(ok_box);
 
   setLayout(layout);
+}
+
+void SettingsWindow::SelectAudioPane()
+{
+  m_tabs->setCurrentIndex(m_audio_pane_index);
 }

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -13,10 +13,13 @@ class SettingsWindow final : public QDialog
   Q_OBJECT
 public:
   explicit SettingsWindow(QWidget* parent = nullptr);
+  void SelectAudioPane();
+
 signals:
   void EmulationStarted();
   void EmulationStopped();
 
 private:
   ListTabWidget* m_tabs;
+  int m_audio_pane_index = -1;
 };

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -4,15 +4,9 @@
 
 #pragma once
 
-#include <string>
-
 #include <QDialog>
 
-class MainWindow;
-class QGroupBox;
-class QListWidget;
-class QListWidgetItem;
-class QStackedWidget;
+class ListTabWidget;
 
 class SettingsWindow final : public QDialog
 {
@@ -23,13 +17,6 @@ signals:
   void EmulationStarted();
   void EmulationStopped();
 
-public slots:
-  void changePage(QListWidgetItem* current, QListWidgetItem* previous);
-
 private:
-  void MakeCategoryList();
-  void AddCategoryToList(const QString& title, const std::string& icon_name);
-  void SetupSettingsWidget();
-  QStackedWidget* m_settings_outer;
-  QListWidget* m_categories;
+  ListTabWidget* m_tabs;
 };

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="MenuBar.cpp" />
     <ClCompile Include="QtUtils\DoubleClickEventFilter.cpp" />
     <ClCompile Include="QtUtils\ElidedButton.cpp" />
+    <ClCompile Include="QtUtils\ListTabWidget.cpp" />
     <ClCompile Include="QtUtils\WindowActivationEventFilter.cpp" />
     <ClCompile Include="RenderWidget.cpp" />
     <ClCompile Include="Resources.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="Config\Mapping\WiimoteEmuGeneral.h" />
     <ClInclude Include="Config\Mapping\WiimoteEmuMotionControl.h" />
     <ClInclude Include="QtUtils\ElidedButton.h" />
+    <ClInclude Include="QtUtils\ListTabWidget.h" />
     <ClInclude Include="Resources.h" />
     <ClInclude Include="Settings\PathPane.h" />
     <ClInclude Include="WiiUpdate.h" />

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -184,6 +184,10 @@ void MainWindow::ConnectMenuBar()
   connect(m_menu_bar, &MenuBar::SetStateSlot, this, &MainWindow::SetStateSlot);
 
   // Options
+  connect(m_menu_bar, &MenuBar::Configure, this, &MainWindow::ShowSettingsWindow);
+  connect(m_menu_bar, &MenuBar::ConfigureGraphics, this, &MainWindow::ShowGraphicsWindow);
+  connect(m_menu_bar, &MenuBar::ConfigureAudio, this, &MainWindow::ShowAudioWindow);
+  connect(m_menu_bar, &MenuBar::ConfigureControllers, this, &MainWindow::ShowControllersWindow);
   connect(m_menu_bar, &MenuBar::ConfigureHotkeys, this, &MainWindow::ShowHotkeyDialog);
 
   // Tools
@@ -503,6 +507,12 @@ void MainWindow::ShowSettingsWindow()
   m_settings_window->show();
   m_settings_window->raise();
   m_settings_window->activateWindow();
+}
+
+void MainWindow::ShowAudioWindow()
+{
+  m_settings_window->SelectAudioPane();
+  ShowSettingsWindow();
 }
 
 void MainWindow::ShowAboutDialog()

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -83,6 +83,7 @@ private:
   void HideRenderWidget();
 
   void ShowSettingsWindow();
+  void ShowAudioWindow();
   void ShowControllersWindow();
   void ShowGraphicsWindow();
   void ShowAboutDialog();

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -197,7 +197,12 @@ void MenuBar::AddViewMenu()
 void MenuBar::AddOptionsMenu()
 {
   QMenu* options_menu = addMenu(tr("Options"));
-  options_menu->addAction(tr("Hotkey Settings"), this, &MenuBar::ConfigureHotkeys);
+  options_menu->addAction(tr("Co&nfiguration..."), this, &MenuBar::Configure);
+  options_menu->addSeparator();
+  options_menu->addAction(tr("&Graphics Settings..."), this, &MenuBar::ConfigureGraphics);
+  options_menu->addAction(tr("&Audio Settings..."), this, &MenuBar::ConfigureAudio);
+  options_menu->addAction(tr("&Controller Settings..."), this, &MenuBar::ConfigureControllers);
+  options_menu->addAction(tr("&Hotkey Settings..."), this, &MenuBar::ConfigureHotkeys);
 }
 
 void MenuBar::AddHelpMenu()

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -44,6 +44,10 @@ signals:
   void PerformOnlineUpdate(const std::string& region);
 
   // Options
+  void Configure();
+  void ConfigureGraphics();
+  void ConfigureAudio();
+  void ConfigureControllers();
   void ConfigureHotkeys();
 
   // View

--- a/Source/Core/DolphinQt2/QtUtils/ListTabWidget.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/ListTabWidget.cpp
@@ -21,6 +21,15 @@ public:
     int height = QListWidget::sizeHint().height();
     return {width, height};
   }
+
+  // Since this is trying to emulate tabs, an item should always be selected. If the selection tries
+  // to change to empty, don't acknowledge it.
+  void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override
+  {
+    if (selected.indexes().empty())
+      return;
+    QListWidget::selectionChanged(selected, deselected);
+  }
 };
 
 ListTabWidget::ListTabWidget()
@@ -40,8 +49,6 @@ ListTabWidget::ListTabWidget()
 
   connect(m_labels, &QListWidget::currentItemChanged, this,
           [=](QListWidgetItem* current, QListWidgetItem* previous) {
-            if (!current)
-              current = previous;
             m_display->setCurrentIndex(m_labels->row(current));
           });
 }

--- a/Source/Core/DolphinQt2/QtUtils/ListTabWidget.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/ListTabWidget.cpp
@@ -1,0 +1,72 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/QtUtils/ListTabWidget.h"
+
+#include <QHBoxLayout>
+#include <QListWidget>
+#include <QScrollBar>
+#include <QStackedWidget>
+
+class OverriddenListWidget : public QListWidget
+{
+public:
+  // We want this widget to have a fixed width that fits all items, unlike a normal QListWidget
+  // which adds scrollbars and expands/contracts.
+  OverriddenListWidget() { setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred); }
+  QSize sizeHint() const override
+  {
+    int width = sizeHintForColumn(0) + verticalScrollBar()->sizeHint().width() + 2 * frameWidth();
+    int height = QListWidget::sizeHint().height();
+    return {width, height};
+  }
+};
+
+ListTabWidget::ListTabWidget()
+{
+  QHBoxLayout* layout = new QHBoxLayout();
+  layout->setContentsMargins(0, 0, 0, 0);
+  setLayout(layout);
+
+  m_labels = new OverriddenListWidget();
+  layout->addWidget(m_labels);
+  m_labels->setIconSize(QSize(32, 32));
+  m_labels->setMovement(QListView::Static);
+  m_labels->setSpacing(0);
+
+  m_display = new QStackedWidget();
+  layout->addWidget(m_display);
+
+  connect(m_labels, &QListWidget::currentItemChanged, this,
+          [=](QListWidgetItem* current, QListWidgetItem* previous) {
+            if (!current)
+              current = previous;
+            m_display->setCurrentIndex(m_labels->row(current));
+          });
+}
+
+int ListTabWidget::addTab(QWidget* page, const QString& label)
+{
+  QListWidgetItem* button = new QListWidgetItem();
+  button->setText(label);
+  button->setTextAlignment(Qt::AlignVCenter);
+  button->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+
+  m_labels->addItem(button);
+  if (!m_labels->currentItem())
+    m_labels->setCurrentItem(button);
+
+  return m_display->addWidget(page);
+}
+
+void ListTabWidget::setTabIcon(int index, const QIcon& icon)
+{
+  if (auto* label = m_labels->item(index))
+    label->setIcon(icon);
+}
+
+void ListTabWidget::setCurrentIndex(int index)
+{
+  m_labels->setCurrentRow(index);
+}

--- a/Source/Core/DolphinQt2/QtUtils/ListTabWidget.h
+++ b/Source/Core/DolphinQt2/QtUtils/ListTabWidget.h
@@ -1,0 +1,23 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QListWidget;
+class QStackedWidget;
+
+class ListTabWidget : public QWidget
+{
+public:
+  ListTabWidget();
+  int addTab(QWidget* page, const QString& label);
+  void setTabIcon(int index, const QIcon& icon);
+  void setCurrentIndex(int index);
+
+private:
+  QListWidget* m_labels;
+  QStackedWidget* m_display;
+};


### PR DESCRIPTION
Before:

<img width="420" alt="before" src="https://user-images.githubusercontent.com/594093/28251983-6dbb6206-6a3e-11e7-8901-fc0109fa6ab6.png">

After:

<img width="458" alt="after" src="https://user-images.githubusercontent.com/594093/28251982-6abfcbb4-6a3e-11e7-886b-4026ae3dd4b8.png">

Also cleans up some code in `SettingsWindow` and extracts the custom-list-widget-plus-stacked-widget-GUI stuff into a separate file (whose API mimics QTabWidget). I think this makes the "store the index of the audio pane and then open the Settings window on the audio pane" logic a lot more obvious.