### PR TITLE
USB timeout values: increase and unify to 5000ms

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
@@ -27,6 +27,11 @@ public class Java_GCAdapter {
 	static UsbEndpoint usb_in;
 	static UsbEndpoint usb_out;
 
+	// Arbitrarily chosen value that allows GC Adapter to not block if bulkTransfer requests hang.
+	// Ideally this should be equal to 0, as they shouldn't hang and we don't trigger unnecessary
+	// bulkTransfer transfers.
+	private static final int TIMEOUT = 5000;
+
 	private static void RequestPermission()
 	{
 		HashMap<String, UsbDevice> devices = manager.getDeviceList();
@@ -73,15 +78,15 @@ public class Java_GCAdapter {
 	public static void InitAdapter()
 	{
 		byte[] init = { 0x13 };
-		usb_con.bulkTransfer(usb_in, init, init.length, 0);
+		usb_con.bulkTransfer(usb_in, init, init.length, TIMEOUT);
 	}
 
 	public static int Input() {
-		return usb_con.bulkTransfer(usb_in, controller_payload, controller_payload.length, 16);
+		return usb_con.bulkTransfer(usb_in, controller_payload, controller_payload.length, TIMEOUT);
 	}
 
 	public static int Output(byte[] rumble) {
-		return usb_con.bulkTransfer(usb_out, rumble, 5, 16);
+		return usb_con.bulkTransfer(usb_out, rumble, 5, TIMEOUT);
 	}
 
 	public static boolean OpenAdapter()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
@@ -20,7 +20,8 @@ public class Java_WiimoteAdapter
 {
 	final static int MAX_PAYLOAD = 23;
 	final static int MAX_WIIMOTES = 4;
-	// Arbitrarily chosen value that allows GC Adapter to not block if bulkTransfer requests hang.
+	// Arbitrarily chosen value that allows the Wiimote adapter to not block if bulkTransfer
+	// requests hang.
 	// Ideally this should be equal to 0, as they shouldn't hang and we don't trigger unnecessary
 	// bulkTransfer transfers.
 	final static int TIMEOUT = 5000;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
@@ -20,7 +20,10 @@ public class Java_WiimoteAdapter
 {
 	final static int MAX_PAYLOAD = 23;
 	final static int MAX_WIIMOTES = 4;
-	final static int TIMEOUT = 200;
+	// Arbitrarily chosen value that allows GC Adapter to not block if bulkTransfer requests hang.
+	// Ideally this should be equal to 0, as they shouldn't hang and we don't trigger unnecessary
+	// bulkTransfer transfers.
+	final static int TIMEOUT = 5000;
 	final static short NINTENDO_VENDOR_ID = 0x057e;
 	final static short NINTENDO_WIIMOTE_PRODUCT_ID = 0x0306;
 	public static UsbManager manager;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -373,7 +373,7 @@ void BluetoothReal::WaitForHCICommandComplete(const u16 opcode)
   for (int tries = 0; tries < 100; ++tries)
   {
     if (libusb_interrupt_transfer(m_handle, HCI_EVENT, buffer.data(),
-                                  static_cast<int>(buffer.size()), &actual_length, 20) == 0 &&
+                                  static_cast<int>(buffer.size()), &actual_length, TIMEOUT) == 0 &&
         reinterpret_cast<hci_event_hdr_t*>(buffer.data())->event == HCI_EVENT_COMMAND_COMPL &&
         reinterpret_cast<SHCIEventCommand*>(buffer.data())->Opcode == opcode)
       break;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -369,8 +369,8 @@ void BluetoothReal::WaitForHCICommandComplete(const u16 opcode)
 {
   int actual_length;
   std::vector<u8> buffer(1024);
-  // Only try 100 transfers at most, to avoid being stuck in an infinite loop
-  for (int tries = 0; tries < 100; ++tries)
+  // Only try 10 transfers at most, to avoid being stuck in an infinite loop
+  for (int tries = 0; tries < 10; ++tries)
   {
     if (libusb_interrupt_transfer(m_handle, HCI_EVENT, buffer.data(),
                                   static_cast<int>(buffer.size()), &actual_length, TIMEOUT) == 0 &&

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -65,10 +65,10 @@ public:
 
 private:
   static constexpr u8 INTERFACE = 0x00;
-  // Arbitrarily chosen value that allows emulated software to not block if libusb transfers
-  // hang for some reason.
+  // Arbitrarily chosen value that allows emulated software to send commands often enough
+  // so that the sync button event is triggered at least every 200ms.
   // Ideally this should be equal to 0, so we don't trigger unnecessary libusb transfers.
-  static constexpr int TIMEOUT = 5000;
+  static constexpr int TIMEOUT = 200;
   static constexpr int SYNC_BUTTON_HOLD_MS_TO_RESET = 10000;
 
   std::atomic<SyncButtonState> m_sync_button_state{SyncButtonState::Unpressed};

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -65,10 +65,10 @@ public:
 
 private:
   static constexpr u8 INTERFACE = 0x00;
-  // Arbitrarily chosen value that allows emulated software to send commands often enough
-  // so that the sync button event is triggered at least every 200ms.
+  // Arbitrarily chosen value that allows emulated software to not block if libusb transfers
+  // hang for some reason.
   // Ideally this should be equal to 0, so we don't trigger unnecessary libusb transfers.
-  static constexpr int TIMEOUT = 200;
+  static constexpr int TIMEOUT = 5000;
   static constexpr int SYNC_BUTTON_HOLD_MS_TO_RESET = 10000;
 
   std::atomic<SyncButtonState> m_sync_button_state{SyncButtonState::Unpressed};

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -71,7 +71,7 @@ static void Read()
   while (s_adapter_thread_running.IsSet())
   {
     libusb_interrupt_transfer(s_handle, s_endpoint_in, s_controller_payload_swap,
-                              sizeof(s_controller_payload_swap), &payload_size, 16);
+                              sizeof(s_controller_payload_swap), &payload_size, TIMEOUT);
 
     {
       std::lock_guard<std::mutex> lk(s_mutex);
@@ -313,7 +313,7 @@ static void AddGCAdapter(libusb_device* device)
 
   int tmp = 0;
   unsigned char payload = 0x13;
-  libusb_interrupt_transfer(s_handle, s_endpoint_out, &payload, sizeof(payload), &tmp, 16);
+  libusb_interrupt_transfer(s_handle, s_endpoint_out, &payload, sizeof(payload), &tmp, TIMEOUT);
 
   s_adapter_thread_running.Set(true);
   s_adapter_thread = std::thread(Read);
@@ -501,7 +501,7 @@ static void ResetRumbleLockNeeded()
                              s_controller_rumble[2], s_controller_rumble[3]};
 
   int size = 0;
-  libusb_interrupt_transfer(s_handle, s_endpoint_out, rumble, sizeof(rumble), &size, 16);
+  libusb_interrupt_transfer(s_handle, s_endpoint_out, rumble, sizeof(rumble), &size, TIMEOUT);
 
   INFO_LOG(SERIALINTERFACE, "Rumble state reset");
 }
@@ -521,7 +521,7 @@ void Output(int chan, u8 rumble_command)
                                s_controller_rumble[2], s_controller_rumble[3]};
     int size = 0;
 
-    libusb_interrupt_transfer(s_handle, s_endpoint_out, rumble, sizeof(rumble), &size, 16);
+    libusb_interrupt_transfer(s_handle, s_endpoint_out, rumble, sizeof(rumble), &size, TIMEOUT);
     // Netplay sends invalid data which results in size = 0x00.  Ignore it.
     if (size != 0x05 && size != 0x00)
     {

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -12,6 +12,10 @@ struct GCPadStatus;
 
 namespace GCAdapter
 {
+// Arbitrarily chosen value that allows the GC Adapter thread to not block if usb interrupts hang.
+// Ideally this should be equal to 0, as they shouldn't hang and we don't trigger unnecessary
+// libusb transfers.
+static constexpr int TIMEOUT = 5000;
 enum ControllerTypes
 {
   CONTROLLER_NONE = 0,


### PR DESCRIPTION
This allows Dolphin to use USB devices shared over the network if the
network adds >16ms latency to USB interrupts responses.

This is needed for game adapters and Bluetooth adapters shared with
solutions like VirtualHere on the Steam Link or via usbip for example,
if the remote device is not directly connected over a good Ethernet
network.

5000ms is to absorb any network latency burst that might occur because
of WiFi/etc. while still not indefinitely making threads hang in case
USB interrupts fail for some reason.

Bug report: https://bugs.dolphin-emu.org/issues/10408