### PR TITLE
Remove region mismatch check for GCI folders

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -199,7 +199,7 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
   }
 
   memorycard = std::make_unique<GCMemcardDirectory>(strDirectoryName + DIR_SEP, card_index, sizeMb,
-                                                    shift_jis, region, CurrentGameId);
+                                                    shift_jis, CurrentGameId);
 }
 
 void CEXIMemoryCard::SetupRawMemcard(u16 sizeMb)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -21,16 +21,15 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Common/StringUtil.h"
 #include "Common/Thread.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
-#include "DiscIO/Volume.h"
 
 const int NO_INDEX = -1;
 static const char* MC_HDR = "MC_SYSTEM_AREA";
 
-int GCMemcardDirectory::LoadGCI(const std::string& file_name, DiscIO::Region card_region,
-                                bool current_game_only)
+int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_only)
 {
   File::IOFile gci_file(file_name, "rb");
   if (gci_file)
@@ -41,20 +40,6 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, DiscIO::Region car
     if (!gci_file.ReadBytes(&(gci.m_gci_header), DENTRY_SIZE))
     {
       ERROR_LOG(EXPANSIONINTERFACE, "%s failed to read header", file_name.c_str());
-      return NO_INDEX;
-    }
-
-    // This isn't a reliable way to detect regions. TODO: Get rid of this?
-    DiscIO::Region gci_region = DiscIO::RegionSwitchGC(gci.m_gci_header.Gamecode[3]);
-    // Some special save files have game IDs that we parse as UNKNOWN_REGION. For instance:
-    // - Datel Action Replay uses C as the fourth character. (Can be on any region's card.)
-    // - Homeland's network config file only uses null bytes. (Homeland is exclusive to Japan,
-    //   but maybe the network config file ID was intended to be used in other regions too.)
-    if (card_region != gci_region && gci_region != DiscIO::Region::UNKNOWN_REGION)
-    {
-      PanicAlertT(
-          "GCI save file was not loaded because it is the wrong region for this memory card:\n%s",
-          file_name.c_str());
       return NO_INDEX;
     }
 
@@ -137,7 +122,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, DiscIO::Region car
 }
 
 GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u16 size_mbits,
-                                       bool shift_jis, DiscIO::Region card_region, int game_id)
+                                       bool shift_jis, int game_id)
     : MemoryCardBase(slot, size_mbits), m_game_id(game_id), m_last_block(-1),
       m_hdr(slot, size_mbits, shift_jis), m_bat1(size_mbits), m_saves(0),
       m_save_directory(directory), m_exiting(false)
@@ -166,7 +151,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u
           m_save_directory.c_str());
       break;
     }
-    int index = LoadGCI(gci_file, card_region, m_saves.size() > 112);
+    int index = LoadGCI(gci_file, m_saves.size() > 112);
     if (index != NO_INDEX)
     {
       m_loaded_saves.push_back(m_saves.at(index).m_gci_header.GCI_FileName());

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -12,7 +12,6 @@
 #include "Common/Event.h"
 #include "Common/NonCopyable.h"
 #include "Core/HW/GCMemcard/GCMemcard.h"
-#include "DiscIO/Enums.h"
 
 // Uncomment this to write the system data of the memorycard from directory to disc
 //#define _WRITE_MC_HEADER 1
@@ -22,7 +21,7 @@ class GCMemcardDirectory : public MemoryCardBase, NonCopyable
 {
 public:
   GCMemcardDirectory(const std::string& directory, int slot, u16 size_mbits, bool shift_jis,
-                     DiscIO::Region card_region, int game_id);
+                     int game_id);
   ~GCMemcardDirectory();
   void FlushToFile();
   void FlushThread();
@@ -33,7 +32,7 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  int LoadGCI(const std::string& file_name, DiscIO::Region card_region, bool current_game_only);
+  int LoadGCI(const std::string& file_name, bool current_game_only);
   inline s32 SaveAreaRW(u32 block, bool writing = false);
   // s32 DirectoryRead(u32 offset, u32 length, u8* dest_address);
   s32 DirectoryWrite(u32 dest_address, u32 length, const u8* src_address);


### PR DESCRIPTION
The region mismatch check that we used can give false positives. Skipping the check won't lead to any harm - games will ignore save files that have a non-matching fourth game ID character.