### PR TITLE
Replace balanced Core::PauseAndLock calls with RunAsCPUThread

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -102,7 +102,6 @@ static StoppedCallbackFunc s_on_stopped_callback;
 
 static std::thread s_cpu_thread;
 static bool s_request_refresh_info = false;
-static int s_pause_and_lock_depth = 0;
 static bool s_is_throttler_temp_disabled = false;
 
 struct HostJob
@@ -763,11 +762,6 @@ static bool PauseAndLock(bool do_lock, bool unpause_on_unlock)
 {
   // WARNING: PauseAndLock is not fully threadsafe so is only valid on the Host Thread
   if (!IsRunning())
-    return true;
-
-  // let's support recursive locking to simplify things on the caller's side,
-  // and let's do it at this outer level in case the individual systems don't support it.
-  if (do_lock ? s_pause_and_lock_depth++ : --s_pause_and_lock_depth)
     return true;
 
   bool was_unpaused = true;

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -74,12 +74,14 @@ void RequestRefreshInfo();
 
 void UpdateTitle();
 
-// waits until all systems are paused and fully idle, and acquires a lock on that state.
-// or, if doLock is false, releases a lock on that state and optionally unpauses.
-// calls must be balanced (once with doLock true, then once with doLock false) but may be recursive.
-// the return value of the first call should be passed in as the second argument of the second call.
-// [NOT THREADSAFE] Host only
-bool PauseAndLock(bool doLock, bool unpauseOnUnlock = true);
+// Run a function as the CPU thread.
+//
+// If called from the Host thread, the CPU thread is paused and the current thread temporarily
+// becomes the CPU thread while running the function.
+// If called from the CPU thread, the function will be run directly.
+//
+// This should only be called from the CPU thread or the host thread.
+void RunAsCPUThread(std::function<void()> function);
 
 // for calling back into UI code without introducing a dependency on it in core
 using StoppedCallbackFunc = std::function<void()>;

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -476,12 +476,7 @@ static void InsertDiscCallback(u64 userdata, s64 cyclesLate)
 // Can only be called by the host thread
 void ChangeDiscAsHost(const std::string& new_path)
 {
-  bool was_unpaused = Core::PauseAndLock(true);
-
-  // The host thread is now temporarily the CPU thread
-  ChangeDiscAsCPU(new_path);
-
-  Core::PauseAndLock(false, was_unpaused);
+  Core::RunAsCPUThread([&] { ChangeDiscAsCPU(new_path); });
 }
 
 // Can only be called by the CPU thread

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -137,13 +137,13 @@ void Host_ConnectWiimote(int wm_idx, bool connect)
     const auto ios = IOS::HLE::GetIOS();
     if (!ios || SConfig::GetInstance().m_bt_passthrough_enabled)
       return;
-    bool was_unpaused = Core::PauseAndLock(true);
-    const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
-        ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
-    if (bt)
-      bt->AccessWiiMote(wm_idx | 0x100)->Activate(connect);
-    Host_UpdateMainFrame();
-    Core::PauseAndLock(false, was_unpaused);
+    Core::RunAsCPUThread([&] {
+      const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
+          ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
+      if (bt)
+        bt->AccessWiiMote(wm_idx | 0x100)->Activate(connect);
+      Host_UpdateMainFrame();
+    });
   });
 }
 

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -229,25 +229,23 @@ void MappingWindow::RefreshDevices()
 {
   m_devices_combo->clear();
 
-  const bool paused = Core::PauseAndLock(true);
+  Core::RunAsCPUThread([&] {
+    g_controller_interface.RefreshDevices();
+    m_controller->UpdateReferences(g_controller_interface);
+    m_controller->UpdateDefaultDevice();
 
-  g_controller_interface.RefreshDevices();
-  m_controller->UpdateReferences(g_controller_interface);
-  m_controller->UpdateDefaultDevice();
+    const auto default_device = m_controller->default_device.ToString();
 
-  const auto default_device = m_controller->default_device.ToString();
+    m_devices_combo->addItem(QString::fromStdString(default_device));
 
-  m_devices_combo->addItem(QString::fromStdString(default_device));
+    for (const auto& name : g_controller_interface.GetAllDeviceStrings())
+    {
+      if (name != default_device)
+        m_devices_combo->addItem(QString::fromStdString(name));
+    }
 
-  for (const auto& name : g_controller_interface.GetAllDeviceStrings())
-  {
-    if (name != default_device)
-      m_devices_combo->addItem(QString::fromStdString(name));
-  }
-
-  m_devices_combo->setCurrentIndex(0);
-
-  Core::PauseAndLock(false, paused);
+    m_devices_combo->setCurrentIndex(0);
+  });
 }
 
 void MappingWindow::ChangeMappingType(MappingWindow::Type type)

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
@@ -71,12 +71,12 @@ void GCAdapterConfigDiag::ScheduleAdapterUpdate()
 
 void GCAdapterConfigDiag::OnUpdateAdapter(wxCommandEvent& WXUNUSED(event))
 {
-  bool unpause = Core::PauseAndLock(true);
-  if (GCAdapter::IsDetected())
-    m_adapter_status->SetLabelText(_("Adapter Detected"));
-  else
-    m_adapter_status->SetLabelText(_("Adapter Not Detected"));
-  Core::PauseAndLock(false, unpause);
+  Core::RunAsCPUThread([this] {
+    if (GCAdapter::IsDetected())
+      m_adapter_status->SetLabelText(_("Adapter Detected"));
+    else
+      m_adapter_status->SetLabelText(_("Adapter Not Detected"));
+  });
 }
 
 void GCAdapterConfigDiag::OnAdapterRumble(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1249,9 +1249,7 @@ void CFrame::DoExclusiveFullscreen(bool enable_fullscreen)
   if (!g_renderer || g_renderer->IsFullscreen() == enable_fullscreen)
     return;
 
-  bool was_unpaused = Core::PauseAndLock(true);
-  g_renderer->SetFullscreen(enable_fullscreen);
-  Core::PauseAndLock(false, was_unpaused);
+  Core::RunAsCPUThread([enable_fullscreen] { g_renderer->SetFullscreen(enable_fullscreen); });
 }
 
 void CFrame::PollHotkeys(wxTimerEvent& event)

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -915,25 +915,23 @@ void InputConfigDialog::UpdateDeviceComboBox()
 
 void InputConfigDialog::RefreshDevices(wxCommandEvent&)
 {
-  bool was_unpaused = Core::PauseAndLock(true);
+  Core::RunAsCPUThread([&] {
+    // refresh devices
+    g_controller_interface.RefreshDevices();
 
-  // refresh devices
-  g_controller_interface.RefreshDevices();
+    // update all control references
+    UpdateControlReferences();
 
-  // update all control references
-  UpdateControlReferences();
+    // update device cbox
+    UpdateDeviceComboBox();
 
-  // update device cbox
-  UpdateDeviceComboBox();
+    Wiimote::LoadConfig();
+    Keyboard::LoadConfig();
+    Pad::LoadConfig();
+    HotkeyManagerEmu::LoadConfig();
 
-  Wiimote::LoadConfig();
-  Keyboard::LoadConfig();
-  Pad::LoadConfig();
-  HotkeyManagerEmu::LoadConfig();
-
-  UpdateGUI();
-
-  Core::PauseAndLock(false, was_unpaused);
+    UpdateGUI();
+  });
 }
 
 ControlGroupBox::~ControlGroupBox()


### PR DESCRIPTION
Core::PauseAndLock requires all calls to it to be balanced, like this:

    const bool was_unpaused = Core::PauseAndLock(true);
    // do stuff on the CPU thread
    Core::PauseAndLock(false, was_unpaused);

Aside from being a bit cumbersome, it turns out all callers really don't need to know about was_unpaused at all. They just need to do something on the CPU thread safely, including locking/unlocking.

So this commit replaces Core::PauseAndLock with a function that makes both the purpose and the scope of what is being run on the CPU thread visually clear. This makes it harder to accidentally run something on the wrong thread, or forget the second call to PauseAndLock to unpause, or forget that it needs to be passed was_unpaused at the end.

We also don't need comments to indicate code X is being run on the CPU thread anymore, as the function name makes it obvious.