### PR TITLE
Qt: Implement Wii settings pane

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -71,6 +71,8 @@ set(SRCS
   Settings/GeneralPane.cpp
   Settings/InterfacePane.cpp
   Settings/PathPane.cpp
+  Settings/WiiPane.cpp
+  Settings/USBAddToWhitelistDialog.cpp
 )
 
 list(APPEND LIBS core uicommon)

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -14,6 +14,7 @@
 #include "DolphinQt2/Settings/GeneralPane.h"
 #include "DolphinQt2/Settings/InterfacePane.h"
 #include "DolphinQt2/Settings/PathPane.h"
+#include "DolphinQt2/Settings/WiiPane.h"
 
 static int AddTab(ListTabWidget* tab_widget, const QString& label, QWidget* widget,
                   const char* icon_name)
@@ -43,11 +44,21 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   auto* audio_pane = new AudioPane;
   m_audio_pane_index = AddTab(m_tabs, tr("Audio"), audio_pane, "play");
   AddTab(m_tabs, tr("Paths"), new PathPane(), "browse");
+  auto* wii_pane = new WiiPane;
+  AddTab(m_tabs, tr("Wii"), wii_pane, "wiimote");
 
   connect(this, &SettingsWindow::EmulationStarted,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(true); });
+          [audio_pane, 
+           wii_pane] { 
+            audio_pane->OnEmulationStateChanged(true),
+            wii_pane->OnEmulationStateChanged(true);
+          });
   connect(this, &SettingsWindow::EmulationStopped,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(false); });
+          [audio_pane,
+           wii_pane] { 
+            audio_pane->OnEmulationStateChanged(false),
+            wii_pane->OnEmulationStateChanged(false);
+          });
 
   // Dialog box buttons
   QDialogButtonBox* ok_box = new QDialogButtonBox(QDialogButtonBox::Ok);

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -89,7 +89,9 @@
     <QtMoc Include="InDevelopmentWarning.h" />
     <QtMoc Include="Settings\InterfacePane.h" />
     <QtMoc Include="Settings\AudioPane.h" />
-    <QtMoc Include="MainWindow.h" />
+    <QtMoc Include="Settings\WiiPane.h" />
+    <QtMoc Include="Settings\USBDeviceAddToWhitelistDialog.h" />
+	<QtMoc Include="MainWindow.h" />
     <QtMoc Include="MenuBar.h" />
     <QtMoc Include="QtUtils\DoubleClickEventFilter.h" />
     <QtMoc Include="QtUtils\WindowActivationEventFilter.h" />
@@ -111,6 +113,7 @@
     <ClCompile Include="$(QtMocOutPrefix)GameListModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameTracker.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GeneralPane.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)WiiPane.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GeneralWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GraphicsBool.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GraphicsChoice.cpp" />
@@ -137,6 +140,7 @@
     <ClCompile Include="$(QtMocOutPrefix)SettingsWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)SoftwareRendererWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ToolBar.cpp" />
+	<ClCompile Include="$(QtMocOutPrefix)USBDeviceAddToWhitelistDialog.cpp" />
     <ClCompile Include="AboutDialog.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
     <ClCompile Include="Config\FilesystemWidget.cpp" />
@@ -194,6 +198,8 @@
     <ClCompile Include="Settings\GeneralPane.cpp" />
     <ClCompile Include="Settings\InterfacePane.cpp" />
     <ClCompile Include="Settings\PathPane.cpp" />
+    <ClCompile Include="Settings\WiiPane.cpp" />
+	<ClCompile Include="Settings\USBDeviceAddToWhitelistDialog.cpp" />
     <ClCompile Include="ToolBar.cpp" />
     <ClCompile Include="WiiUpdate.cpp" />
   </ItemGroup>

--- a/Source/Core/DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -1,0 +1,165 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QButtonGroup>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QErrorMessage>
+#include <QMessageBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QTimer>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.h"
+#include "Common/StringUtil.h"
+#include "Core/ConfigManager.h"
+#include "DolphinQt2/Settings/WiiPane.h"
+#include "UICommon/USBUtils.h"
+
+static bool IsValidUSBIDString(const std::string& string)
+{
+  if (string.empty() || string.length() > 4)
+    return false;
+  return std::all_of(string.begin(), string.end(),
+                     [](const auto character) { return std::isxdigit(character) != 0; });
+}
+
+USBDeviceAddToWhitelistDialog::USBDeviceAddToWhitelistDialog(QWidget* parent) : QDialog(parent)
+{
+  InitControls();
+  setLayout(main_layout);
+}
+
+void USBDeviceAddToWhitelistDialog::InitControls()
+{
+  setWindowTitle(tr("Add New USB Device"));
+  m_whitelist_buttonbox = new QDialogButtonBox();
+  auto* add_button = new QPushButton(tr("Add"));
+  m_whitelist_buttonbox->addButton(add_button, QDialogButtonBox::AcceptRole);
+  connect(add_button, &QPushButton::clicked, this,
+          &USBDeviceAddToWhitelistDialog::AddUSBDeviceToWhitelist);
+  add_button->setDefault(true);
+
+  main_layout = new QVBoxLayout();
+  enter_device_id_label = new QLabel(tr("Enter USB device ID"));
+  enter_device_id_label->setAlignment(Qt::AlignCenter);
+  main_layout->addWidget(enter_device_id_label);
+
+  entry_hbox_layout = new QHBoxLayout();
+  device_vid_textbox = new QLineEdit();
+  QSizePolicy sizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+  sizePolicy.setHorizontalStretch(1);
+  sizePolicy.setVerticalStretch(0);
+  sizePolicy.setHeightForWidth(device_vid_textbox->sizePolicy().hasHeightForWidth());
+  device_vid_textbox->setSizePolicy(sizePolicy);
+
+  //entry_hbox_layout->setWidget(2, QFormLayout::LabelRole, device_vid_textbox);
+  entry_hbox_layout->addWidget(device_vid_textbox);
+
+  device_pid_textbox = new QLineEdit();
+  sizePolicy.setHeightForWidth(device_pid_textbox->sizePolicy().hasHeightForWidth());
+  device_pid_textbox->setSizePolicy(sizePolicy);
+
+  entry_hbox_layout->addWidget(device_pid_textbox);
+  main_layout->addLayout(entry_hbox_layout);
+
+  select_label = new QLabel(tr("or select a device"));
+  select_label->setAlignment(Qt::AlignCenter);
+
+  main_layout->addWidget(select_label);
+
+  usb_inserted_devices_list = new QListWidget();
+  m_refresh_devices_timer = new QTimer(this);
+  connect(usb_inserted_devices_list, &QListWidget::currentItemChanged, this,
+          &USBDeviceAddToWhitelistDialog::OnDeviceSelection);
+  connect(m_refresh_devices_timer, &QTimer::timeout, this,
+          &USBDeviceAddToWhitelistDialog::RefreshDeviceList);
+  m_refresh_devices_timer->start(1000);
+
+  main_layout->addWidget(usb_inserted_devices_list);
+  main_layout->addWidget(m_whitelist_buttonbox);
+
+  // i18n: VID means Vendor ID (in the context of a USB device)
+  device_vid_textbox->setPlaceholderText(tr("Device VID (e.g., 057e)"));
+  // i18n: PID means Product ID (in the context of a USB device), not Process ID
+  device_pid_textbox->setPlaceholderText(tr("Device PID (e.g., 0305)"));
+}
+
+void USBDeviceAddToWhitelistDialog::RefreshDeviceList()
+{
+  const auto& current_devices = USBUtils::GetInsertedDevices();
+  if (current_devices == m_shown_devices)
+    return;
+  const auto selection_string = usb_inserted_devices_list->currentItem();
+  usb_inserted_devices_list->clear();
+  for (const auto& device : current_devices)
+  {
+    if (SConfig::GetInstance().IsUSBDeviceWhitelisted(device.first))
+      continue;
+    usb_inserted_devices_list->addItem(QString::fromStdString(device.second));
+  }
+
+  usb_inserted_devices_list->setCurrentItem(selection_string);
+
+  m_shown_devices = current_devices;
+}
+
+void USBDeviceAddToWhitelistDialog::AddUSBDeviceToWhitelist()
+{
+  const std::string vid_string = StripSpaces(device_vid_textbox->text().toStdString());
+  const std::string pid_string = StripSpaces(device_pid_textbox->text().toStdString());
+  if (!IsValidUSBIDString(vid_string))
+  {
+    // i18n: Here, VID means Vendor ID (for a USB device).
+    QMessageBox vid_warning_box;
+    vid_warning_box.setIcon(QMessageBox::Warning);
+    vid_warning_box.setWindowTitle(tr("USB Whitelist Error"));
+    vid_warning_box.setText(tr("The entered VID is invalid."));
+    vid_warning_box.setStandardButtons(QMessageBox::Ok);
+    vid_warning_box.exec();
+    return;
+  }
+  if (!IsValidUSBIDString(pid_string))
+  {
+    // i18n: Here, PID means Product ID (for a USB device).
+    QMessageBox pid_warning_box;
+    pid_warning_box.setIcon(QMessageBox::Warning);
+    pid_warning_box.setWindowTitle(tr("USB Whitelist Error"));
+    pid_warning_box.setText(tr("The entered PID is invalid."));
+    pid_warning_box.setStandardButtons(QMessageBox::Ok);
+    pid_warning_box.exec();
+    return;
+  }
+
+  const u16 vid = static_cast<u16>(std::stoul(vid_string, nullptr, 16));
+  const u16 pid = static_cast<u16>(std::stoul(pid_string, nullptr, 16));
+
+  if (SConfig::GetInstance().IsUSBDeviceWhitelisted({vid, pid}))
+  {
+    QErrorMessage* error = new QErrorMessage();
+    error->showMessage(tr("This USB device is already whitelisted."));
+    return;
+  }
+  SConfig::GetInstance().m_usb_passthrough_devices.emplace(vid, pid);
+  SConfig::GetInstance().SaveSettings();
+  accept();
+}
+
+void USBDeviceAddToWhitelistDialog::OnDeviceSelection()
+{
+  // Not the nicest way of doing this but...
+  QString device = usb_inserted_devices_list->currentItem()->text().left(9);
+  QString* vid = new QString(
+      device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[0]);
+  QString* pid = new QString(
+      device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[1]);
+  device_vid_textbox->setText(*vid);
+  device_pid_textbox->setText(*pid);
+}

--- a/Source/Core/DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.h
+++ b/Source/Core/DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.h
@@ -1,0 +1,51 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+
+class QTimer;
+class QDialog;
+class QButtonGroup;
+class QHeaderView;
+class QLabel;
+class QLineEdit;
+class QDialogButtonBox;
+class QVBoxLayout;
+class QHBoxLayout;
+class QListView;
+class QPushButton;
+class QListWidget;
+class QPushButton;
+class QErrorMessage;
+class QMessageBox;
+
+class USBDeviceAddToWhitelistDialog final : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit USBDeviceAddToWhitelistDialog(QWidget* parent);
+
+private:
+  static constexpr int DEVICE_REFRESH_INTERVAL_MS = 100;
+  QTimer* m_refresh_devices_timer;
+  QDialogButtonBox* m_whitelist_buttonbox;
+  QVBoxLayout* main_layout;
+  QLabel* enter_device_id_label;
+  QHBoxLayout* entry_hbox_layout;
+  QLineEdit* device_vid_textbox;
+  QLineEdit* device_pid_textbox;
+  QLabel* select_label;
+  QListWidget* usb_inserted_devices_list;
+
+  void InitControls();
+  void RefreshDeviceList();
+  void AddUSBDeviceToWhitelist();
+
+  void OnDeviceSelection();
+
+  std::map<std::pair<quint16, quint16>, std::string> m_shown_devices;
+};

--- a/Source/Core/DolphinQt2/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/WiiPane.cpp
@@ -1,0 +1,268 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Settings/WiiPane.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QSlider>
+#include <QSpacerItem>
+#include <QStringList>
+#include "Common/StringUtil.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/IOS/IOS.h"
+#include "UICommon/USBUtils.h"
+#include "DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.h"
+
+// SYSCONF uses 0 for bottom and 1 for top, but we place them in
+// the other order in the GUI so that Top will be above Bottom,
+// matching the respective physical placements of the sensor bar.
+// This also matches the layout of the settings in the Wii Menu.
+static int TranslateSensorBarPosition(int position)
+{
+  if (position == 0)
+    return 1;
+  if (position == 1)
+    return 0;
+
+  return position;
+}
+
+WiiPane::WiiPane(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+  LoadConfig();
+  ConnectLayout();
+  ValidateSelectionState();
+}
+
+void WiiPane::CreateLayout()
+{
+  m_main_layout = new QVBoxLayout;
+  CreateMisc();
+  CreateWhitelistedUSBPassthroughDevices();
+  CreateWiiRemoteSettings();
+  m_main_layout->setContentsMargins(0, 0, 0, 0);
+  m_main_layout->addStretch(1);
+  setLayout(m_main_layout);
+}
+
+void WiiPane::ConnectLayout()
+{
+  // Misc Settings
+  connect(m_aspect_ratio_choice,
+          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &WiiPane::OnSaveConfig);
+  connect(m_system_language_choice,
+          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &WiiPane::OnSaveConfig);
+  connect(m_screensaver_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
+  connect(m_pal60_mode_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
+  connect(m_sd_card_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
+  connect(m_connect_keyboard_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
+
+  // Whitelisted USB Passthrough Devices
+  connect(m_whitelist_usb_list, &QListWidget::itemClicked, this, &WiiPane::ValidateSelectionState);
+  connect(m_whitelist_usb_add_button, &QPushButton::released, this,
+          &WiiPane::OnUSBWhitelistAddButton);
+  connect(m_whitelist_usb_remove_button, &QPushButton::released, this,
+          &WiiPane::OnUSBWhitelistRemoveButton);
+
+  // Wii Remote Settings
+  connect(m_wiimote_ir_sensor_position,
+          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &WiiPane::OnSaveConfig);
+  connect(m_wiimote_ir_sensitivity, &QSlider::valueChanged, this, &WiiPane::OnSaveConfig);
+  connect(m_wiimote_speaker_volume, &QSlider::valueChanged, this, &WiiPane::OnSaveConfig);
+  connect(m_wiimote_motor, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
+}
+
+void WiiPane::CreateMisc()
+{
+  auto* misc_settings_group = new QGroupBox(tr("Misc Settings"));
+  auto* misc_settings_group_layout = new QGridLayout();
+  misc_settings_group->setLayout(misc_settings_group_layout);
+  m_main_layout->addWidget(misc_settings_group);
+  m_pal60_mode_checkbox = new QCheckBox(tr("Use PAL60 Mode (EuRGB60)"));
+  m_screensaver_checkbox = new QCheckBox(tr("Enable Screen Saver"));
+  m_sd_card_checkbox = new QCheckBox(tr("Insert SD Card"));
+  m_connect_keyboard_checkbox = new QCheckBox(tr("Connect USB Keyboard"));
+  m_aspect_ratio_choice_label = new QLabel(tr("Aspect Ratio:"));
+  m_aspect_ratio_choice = new QComboBox();
+  m_aspect_ratio_choice->addItem(tr("4:3"));
+  m_aspect_ratio_choice->addItem(tr("16:9"));
+  m_system_language_choice_label = new QLabel(tr("System Language:"));
+  m_system_language_choice = new QComboBox();
+  m_system_language_choice->addItem(tr("Japanese"));
+  m_system_language_choice->addItem(tr("English"));
+  m_system_language_choice->addItem(tr("German"));
+  m_system_language_choice->addItem(tr("French"));
+  m_system_language_choice->addItem(tr("Spanish"));
+  m_system_language_choice->addItem(tr("Italian"));
+  m_system_language_choice->addItem(tr("Dutch"));
+  m_system_language_choice->addItem(tr("Simplified Chinese"));
+  m_system_language_choice->addItem(tr("Traditional Chinese"));
+  m_system_language_choice->addItem(tr("Korean"));
+
+  m_pal60_mode_checkbox->setToolTip(tr("Sets the Wii display mode to 60Hz (480i) instead of 50Hz "
+                                       "(576i) for PAL games.\nMay not work for all games."));
+  m_screensaver_checkbox->setToolTip(tr("Dims the screen after five minutes of inactivity."));
+  m_system_language_choice->setToolTip(tr("Sets the Wii system language."));
+  m_sd_card_checkbox->setToolTip(tr("Saved to /Wii/sd.raw (default size is 128mb)"));
+  m_connect_keyboard_checkbox->setToolTip(tr("May cause slow down in Wii Menu and some games."));
+
+  misc_settings_group_layout->addWidget(m_pal60_mode_checkbox, 0, 0, 1, 1);
+  misc_settings_group_layout->addWidget(m_sd_card_checkbox, 0, 1, 1, 1);
+  misc_settings_group_layout->addWidget(m_screensaver_checkbox, 1, 0, 1, 1);
+  misc_settings_group_layout->addWidget(m_connect_keyboard_checkbox, 1, 1, 1, 1);
+  misc_settings_group_layout->addWidget(m_aspect_ratio_choice_label, 2, 0, 1, 1);
+  misc_settings_group_layout->addWidget(m_aspect_ratio_choice, 2, 1, 1, 1);
+  misc_settings_group_layout->addWidget(m_system_language_choice_label, 3, 0, 1, 1);
+  misc_settings_group_layout->addWidget(m_system_language_choice, 3, 1, 1, 1);
+}
+
+void WiiPane::CreateWhitelistedUSBPassthroughDevices()
+{
+  auto* whitelisted_usb_passthrough_devices_group =
+      new QGroupBox(tr("Whitelisted USB Passthrough Devices"));
+  auto* whitelist_layout = new QGridLayout();
+  m_whitelist_usb_list = new QListWidget();
+  whitelist_layout->addWidget(m_whitelist_usb_list, 0, 0, 1, -1);
+  whitelist_layout->setColumnStretch(0, 1);
+  m_whitelist_usb_add_button = new QPushButton(tr("Add..."));
+  m_whitelist_usb_remove_button = new QPushButton(tr("Remove"));
+  whitelist_layout->addWidget(m_whitelist_usb_add_button, 1, 1);
+  whitelist_layout->addWidget(m_whitelist_usb_remove_button, 1, 2);
+  whitelist_layout->addWidget(m_whitelist_usb_list, 0, 0);
+  whitelisted_usb_passthrough_devices_group->setLayout(whitelist_layout);
+  m_main_layout->addWidget(whitelisted_usb_passthrough_devices_group);
+}
+
+void WiiPane::CreateWiiRemoteSettings()
+{
+  auto* wii_remote_settings_group = new QGroupBox(tr("Wii Remote Settings"));
+  auto* wii_remote_settings_group_layout = new QGridLayout();
+  wii_remote_settings_group->setLayout(wii_remote_settings_group_layout);
+  m_main_layout->addWidget(wii_remote_settings_group);
+  m_wiimote_motor = new QCheckBox(tr("Wii Remote Rumble"));
+
+  m_wiimote_sensor_position_label = new QLabel(tr("Sensor Position:"));
+  m_wiimote_ir_sensor_position = new QComboBox();
+  m_wiimote_ir_sensor_position->addItem(tr("Top"));
+  m_wiimote_ir_sensor_position->addItem(tr("Bottom"));
+
+  // IR Sensitivity Slider
+  m_wiimote_ir_sensitivity_label = new QLabel(tr("IR Sensitivity:"));
+  m_wiimote_ir_sensitivity = new QSlider(Qt::Horizontal);
+  m_wiimote_ir_sensitivity->setMinimum(4);
+  m_wiimote_ir_sensitivity->setMaximum(127);
+
+  // Speaker Volume Slider
+  m_wiimote_speaker_volume_label = new QLabel(tr("Speaker Volume:"));
+  m_wiimote_speaker_volume = new QSlider(Qt::Horizontal);
+  m_wiimote_speaker_volume->setMinimum(0);
+  m_wiimote_speaker_volume->setMaximum(127);
+
+  wii_remote_settings_group_layout->addWidget(m_wiimote_sensor_position_label, 0, 0);
+  wii_remote_settings_group_layout->addWidget(m_wiimote_ir_sensor_position, 0, 1);
+  wii_remote_settings_group_layout->addWidget(m_wiimote_ir_sensitivity_label, 1, 0);
+  wii_remote_settings_group_layout->addWidget(m_wiimote_ir_sensitivity, 1, 1);
+  wii_remote_settings_group_layout->addWidget(m_wiimote_speaker_volume_label, 2, 0);
+  wii_remote_settings_group_layout->addWidget(m_wiimote_speaker_volume, 2, 1);
+  wii_remote_settings_group_layout->addWidget(m_wiimote_motor, 3, 0, 1, -1);
+}
+
+void WiiPane::OnEmulationStateChanged(bool running)
+{
+  m_screensaver_checkbox->setEnabled(!running);
+  m_pal60_mode_checkbox->setEnabled(!running);
+  m_sd_card_checkbox->setEnabled(!running);
+  m_connect_keyboard_checkbox->setEnabled(!running);
+  m_system_language_choice->setEnabled(!running);
+  m_aspect_ratio_choice->setEnabled(!running);
+  m_wiimote_motor->setEnabled(!running);
+  m_wiimote_speaker_volume->setEnabled(!running);
+  m_wiimote_ir_sensitivity->setEnabled(!running);
+  m_wiimote_ir_sensor_position->setEnabled(!running);
+}
+
+void WiiPane::LoadConfig()
+{
+  m_screensaver_checkbox->setChecked(SConfig::GetInstance().m_wii_screensaver);
+  m_pal60_mode_checkbox->setChecked(SConfig::GetInstance().bPAL60);
+  m_connect_keyboard_checkbox->setChecked(SConfig::GetInstance().m_WiiKeyboard);
+  m_sd_card_checkbox->setChecked(SConfig::GetInstance().m_WiiSDCard);
+  m_aspect_ratio_choice->setCurrentIndex(SConfig::GetInstance().m_wii_aspect_ratio);
+  m_system_language_choice->setCurrentIndex(SConfig::GetInstance().m_wii_language);
+
+  PopulateUSBPassthroughListWidget();
+
+  m_wiimote_ir_sensor_position->setCurrentIndex(
+      TranslateSensorBarPosition(SConfig::GetInstance().m_sensor_bar_position));
+  m_wiimote_ir_sensitivity->setValue(SConfig::GetInstance().m_sensor_bar_sensitivity);
+  m_wiimote_speaker_volume->setValue(SConfig::GetInstance().m_speaker_volume);
+  m_wiimote_motor->setChecked(SConfig::GetInstance().m_wiimote_motor);
+}
+
+void WiiPane::OnSaveConfig()
+{
+  SConfig::GetInstance().m_wii_screensaver = m_screensaver_checkbox->isChecked();
+  SConfig::GetInstance().bPAL60 = m_pal60_mode_checkbox->isChecked();
+  SConfig::GetInstance().m_WiiKeyboard = m_connect_keyboard_checkbox->isChecked();
+  SConfig::GetInstance().m_WiiSDCard = m_sd_card_checkbox->isChecked();
+  SConfig::GetInstance().m_sensor_bar_position =
+      TranslateSensorBarPosition(m_wiimote_ir_sensor_position->currentIndex());
+  SConfig::GetInstance().m_sensor_bar_sensitivity = m_wiimote_ir_sensitivity->value();
+  SConfig::GetInstance().m_speaker_volume = m_wiimote_speaker_volume->value();
+  SConfig::GetInstance().m_wii_language = m_system_language_choice->currentIndex();
+  SConfig::GetInstance().m_wii_aspect_ratio = m_aspect_ratio_choice->currentIndex();
+  SConfig::GetInstance().m_wiimote_motor = m_wiimote_motor->isChecked();
+}
+
+void WiiPane::ValidateSelectionState()
+{
+  m_whitelist_usb_remove_button->setEnabled(m_whitelist_usb_list->currentIndex().isValid());
+}
+
+void WiiPane::OnUSBWhitelistAddButton()
+{
+  USBDeviceAddToWhitelistDialog* usb_whitelist_dialog = new USBDeviceAddToWhitelistDialog(this);
+  connect(usb_whitelist_dialog, &USBDeviceAddToWhitelistDialog::accepted, this,
+    &WiiPane::PopulateUSBPassthroughListWidget);
+  usb_whitelist_dialog->setModal(true);
+  usb_whitelist_dialog->show();
+}
+
+void WiiPane::OnUSBWhitelistRemoveButton()
+{
+  std::set<std::pair<u16, u16>> test_set = SConfig::GetInstance().m_usb_passthrough_devices;
+  QString device = m_whitelist_usb_list->currentItem()->text().left(9);
+  QString vid =
+      QString(device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[0]);
+  QString pid =
+      QString(device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[1]);
+  const u16 vid_u16 = static_cast<u16>(std::stoul(vid.toStdString(), nullptr, 16));
+  const u16 pid_u16 = static_cast<u16>(std::stoul(pid.toStdString(), nullptr, 16));
+  SConfig::GetInstance().m_usb_passthrough_devices.erase({vid_u16, pid_u16});
+  PopulateUSBPassthroughListWidget();
+}
+
+void WiiPane::PopulateUSBPassthroughListWidget()
+{
+  m_whitelist_usb_list->clear();
+  for (const auto& device : SConfig::GetInstance().m_usb_passthrough_devices)
+  {
+    QListWidgetItem* usb_lwi =
+        new QListWidgetItem(QString::fromStdString(USBUtils::GetDeviceName(device)));
+    m_whitelist_usb_list->addItem(usb_lwi);
+  }
+  ValidateSelectionState();
+}

--- a/Source/Core/DolphinQt2/Settings/WiiPane.h
+++ b/Source/Core/DolphinQt2/Settings/WiiPane.h
@@ -1,0 +1,66 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+class QSlider;
+class QVBoxLayout;
+class QListWidget;
+class QPushButton;
+class QComboBox;
+class QCheckBox;
+
+class WiiPane final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit WiiPane(QWidget* parent = nullptr);
+  void OnEmulationStateChanged(bool running);
+
+private:
+  void PopulateUSBPassthroughListWidget();
+  void CreateLayout();
+  void ConnectLayout();
+  void CreateMisc();
+  void CreateWhitelistedUSBPassthroughDevices();
+  void CreateWiiRemoteSettings();
+
+  void LoadConfig();
+  void OnSaveConfig();
+
+  void ValidateSelectionState();
+
+  void OnUSBWhitelistAddButton();
+  void OnUSBWhitelistRemoveButton();
+
+  // Widgets
+  QVBoxLayout* m_main_layout;
+
+  // Misc Settings
+  QCheckBox* m_screensaver_checkbox;
+  QCheckBox* m_pal60_mode_checkbox;
+  QCheckBox* m_sd_card_checkbox;
+  QCheckBox* m_connect_keyboard_checkbox;
+  QComboBox* m_system_language_choice;
+  QLabel* m_system_language_choice_label;
+  QComboBox* m_aspect_ratio_choice;
+  QLabel* m_aspect_ratio_choice_label;
+
+  // Whitelisted USB Passthrough Devices
+  QListWidget* m_whitelist_usb_list;
+  QPushButton* m_whitelist_usb_add_button;
+  QPushButton* m_whitelist_usb_remove_button;
+
+  // Wii Remote Settings
+  QLabel* m_wiimote_sensor_position_label;
+  QComboBox* m_wiimote_ir_sensor_position;
+  QSlider* m_wiimote_ir_sensitivity;
+  QLabel* m_wiimote_ir_sensitivity_label;
+  QSlider* m_wiimote_speaker_volume;
+  QLabel* m_wiimote_speaker_volume_label;
+  QCheckBox* m_wiimote_motor;
+};


### PR DESCRIPTION
![](https://puu.sh/wPdwV/ca12b903a4.png)
Current settings menu is on the left, menu with my additional settings on the right.
I ported over the volume slider for the wiimote speaker and the checkbox toggle for enabling the rumble feature on wiimotes.