### PR TITLE
Set C++ locale

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -51,10 +51,6 @@ std::string ThousandSeparate(I value, int spaces = 0)
   std::ostringstream stream;
 #endif
 
-// std::locale("") seems to be broken on many platforms
-#if defined _WIN32 || (defined __linux__ && !defined __clang__)
-  stream.imbue(std::locale(""));
-#endif
   stream << std::setw(spaces) << value;
 
 #ifdef _WIN32

--- a/Source/Core/DolphinQt2/Translation.cpp
+++ b/Source/Core/DolphinQt2/Translation.cpp
@@ -18,6 +18,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
+#include "UICommon/UICommon.h"
 
 constexpr u32 MO_MAGIC_NUMBER = 0x950412de;
 
@@ -270,6 +271,10 @@ static bool TryInstallTranslator(const QString& exact_language_code)
     if (translator->load(filename))
     {
       QApplication::instance()->installTranslator(translator);
+
+      QLocale::setDefault(QLocale(exact_language_code));
+      UICommon::SetLocale(exact_language_code.toStdString());
+
       return true;
     }
     translator->deleteLater();

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -343,6 +343,9 @@ void DolphinApp::InitLanguageSupport()
         _("Error"));
     m_locale.reset(new wxLocale(wxLANGUAGE_DEFAULT));
   }
+
+  // wxWidgets sets the C locale for us, but not the C++ locale, so let's do that ourselves
+  UICommon::SetLocale(language_code);
 }
 
 void DolphinApp::OnEndSession(wxCloseEvent& event)

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -98,6 +98,14 @@ void SetLocale(std::string locale_name)
   constexpr char OTHER_SEPARATOR = '-';
 #endif
 
+  // Users who use a system language other than English are unlikely to prefer American date and
+  // time formats, so let's explicitly request "en_GB" if Dolphin's language is set to "en".
+  // (The settings window only allows setting "en", not anything like "en_US" or "en_GB".)
+  // Users who prefer the American formats are likely to have their system language set to en_US,
+  // and are thus likely to leave Dolphin's language as the default value "" (<System Language>).
+  if (locale_name == "en")
+    locale_name = "en_GB";
+
   std::replace(locale_name.begin(), locale_name.end(), OTHER_SEPARATOR, PREFERRED_SEPARATOR);
 
   // Use the specified locale if supported.

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -5,8 +5,10 @@
 #include <algorithm>
 #include <clocale>
 #include <cmath>
+#include <iomanip>
 #include <locale>
 #include <memory>
+#include <sstream>
 #ifdef _WIN32
 #include <shlobj.h>  // for SHGetFolderPath
 #endif
@@ -406,7 +408,10 @@ std::string FormatSize(u64 bytes)
 
   // Don't need exact values, only 5 most significant digits
   const double unit_size = std::pow(2, unit * 10);
-  return StringFromFormat("%.2f %s", bytes / unit_size, GetStringT(unit_symbols[unit]).c_str());
+  std::stringstream ss;
+  ss << std::fixed << std::setprecision(2);
+  ss << bytes / unit_size << ' ' << GetStringT(unit_symbols[unit]);
+  return ss.str();
 }
 
 }  // namespace UICommon

--- a/Source/Core/UICommon/UICommon.h
+++ b/Source/Core/UICommon/UICommon.h
@@ -19,6 +19,10 @@ void EnableScreenSaver(Display* display, Window win, bool enable);
 void EnableScreenSaver(bool enable);
 #endif
 
+// Calls std::locale::global, selecting a fallback locale if the
+// requested locale isn't available
+void SetLocale(std::string locale_name);
+
 void CreateDirectories();
 void SetUserDirectory(const std::string& custom_path);
 


### PR DESCRIPTION
After 3a83ebc, the Show System Clock feature started using the unfortunate combination of MM/DD/YY dates (rare outside of the US) and 24-hour time (rare in the US) regardless of the user's locale settings. This commit makes it use the configured locale again.