### PR TITLE
BT: Use a std::array for all Bluetooth addresses

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -48,17 +48,17 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
     BackUpBTInfoSection(&sysconf);
 
   _conf_pads BT_DINF;
-  bdaddr_t tmpBD = BDADDR_ANY;
+  bdaddr_t tmpBD;
   u8 i = 0;
   while (i < MAX_BBMOTES)
   {
     // Previous records can be safely overwritten, since they are backed up
-    tmpBD.b[5] = BT_DINF.active[i].bdaddr[0] = BT_DINF.registered[i].bdaddr[0] = i;
-    tmpBD.b[4] = BT_DINF.active[i].bdaddr[1] = BT_DINF.registered[i].bdaddr[1] = 0;
-    tmpBD.b[3] = BT_DINF.active[i].bdaddr[2] = BT_DINF.registered[i].bdaddr[2] = 0x79;
-    tmpBD.b[2] = BT_DINF.active[i].bdaddr[3] = BT_DINF.registered[i].bdaddr[3] = 0x19;
-    tmpBD.b[1] = BT_DINF.active[i].bdaddr[4] = BT_DINF.registered[i].bdaddr[4] = 2;
-    tmpBD.b[0] = BT_DINF.active[i].bdaddr[5] = BT_DINF.registered[i].bdaddr[5] = 0x11;
+    tmpBD[5] = BT_DINF.active[i].bdaddr[0] = BT_DINF.registered[i].bdaddr[0] = i;
+    tmpBD[4] = BT_DINF.active[i].bdaddr[1] = BT_DINF.registered[i].bdaddr[1] = 0;
+    tmpBD[3] = BT_DINF.active[i].bdaddr[2] = BT_DINF.registered[i].bdaddr[2] = 0x79;
+    tmpBD[2] = BT_DINF.active[i].bdaddr[3] = BT_DINF.registered[i].bdaddr[3] = 0x19;
+    tmpBD[1] = BT_DINF.active[i].bdaddr[4] = BT_DINF.registered[i].bdaddr[4] = 2;
+    tmpBD[0] = BT_DINF.active[i].bdaddr[5] = BT_DINF.registered[i].bdaddr[5] = 0x11;
 
     const char* wmName;
     if (i == WIIMOTE_BALANCE_BOARD)
@@ -68,8 +68,8 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
     memcpy(BT_DINF.registered[i].name, wmName, 20);
     memcpy(BT_DINF.active[i].name, wmName, 20);
 
-    DEBUG_LOG(IOS_WIIMOTE, "Wii Remote %d BT ID %x,%x,%x,%x,%x,%x", i, tmpBD.b[0], tmpBD.b[1],
-              tmpBD.b[2], tmpBD.b[3], tmpBD.b[4], tmpBD.b[5]);
+    DEBUG_LOG(IOS_WIIMOTE, "Wii Remote %d BT ID %x,%x,%x,%x,%x,%x", i, tmpBD[0], tmpBD[1], tmpBD[2],
+              tmpBD[3], tmpBD[4], tmpBD[5]);
     m_WiiMotes.emplace_back(this, i, tmpBD, g_wiimote_sources[i] != WIIMOTE_SRC_NONE);
     i++;
   }
@@ -83,14 +83,6 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
   sysconf.GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes = std::move(data);
   if (!sysconf.Save())
     PanicAlertT("Failed to write BT.DINF to SYSCONF");
-
-  // The BCM2045's btaddr:
-  m_ControllerBD.b[0] = 0x11;
-  m_ControllerBD.b[1] = 0x02;
-  m_ControllerBD.b[2] = 0x19;
-  m_ControllerBD.b[3] = 0x79;
-  m_ControllerBD.b[4] = 0x00;
-  m_ControllerBD.b[5] = 0xFF;
 }
 
 BluetoothEmu::~BluetoothEmu()
@@ -480,9 +472,9 @@ bool BluetoothEmu::SendEventInquiryResponse()
     pResponse->clock_offset = 0x3818;
 
     DEBUG_LOG(IOS_WIIMOTE, "Event: Send Fake Inquiry of one controller");
-    DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pResponse->bdaddr.b[0],
-              pResponse->bdaddr.b[1], pResponse->bdaddr.b[2], pResponse->bdaddr.b[3],
-              pResponse->bdaddr.b[4], pResponse->bdaddr.b[5]);
+    DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pResponse->bdaddr[0],
+              pResponse->bdaddr[1], pResponse->bdaddr[2], pResponse->bdaddr[3],
+              pResponse->bdaddr[4], pResponse->bdaddr[5]);
   }
 
   AddEventToQueue(Event);
@@ -522,10 +514,10 @@ bool BluetoothEmu::SendEventConnectionComplete(const bdaddr_t& _bd)
 
   DEBUG_LOG(IOS_WIIMOTE, "Event: SendEventConnectionComplete");
   DEBUG_LOG(IOS_WIIMOTE, "  Connection_Handle: 0x%04x", pConnectionComplete->Connection_Handle);
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pConnectionComplete->bdaddr.b[0],
-            pConnectionComplete->bdaddr.b[1], pConnectionComplete->bdaddr.b[2],
-            pConnectionComplete->bdaddr.b[3], pConnectionComplete->bdaddr.b[4],
-            pConnectionComplete->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pConnectionComplete->bdaddr[0],
+            pConnectionComplete->bdaddr[1], pConnectionComplete->bdaddr[2],
+            pConnectionComplete->bdaddr[3], pConnectionComplete->bdaddr[4],
+            pConnectionComplete->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  LinkType: %s", s_szLinkType[pConnectionComplete->LinkType]);
   DEBUG_LOG(IOS_WIIMOTE, "  EncryptionEnabled: %i", pConnectionComplete->EncryptionEnabled);
 
@@ -556,10 +548,10 @@ bool BluetoothEmu::SendEventRequestConnection(WiimoteDevice& _rWiiMote)
   };
 
   DEBUG_LOG(IOS_WIIMOTE, "Event: SendEventRequestConnection");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x",
-            pEventRequestConnection->bdaddr.b[0], pEventRequestConnection->bdaddr.b[1],
-            pEventRequestConnection->bdaddr.b[2], pEventRequestConnection->bdaddr.b[3],
-            pEventRequestConnection->bdaddr.b[4], pEventRequestConnection->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pEventRequestConnection->bdaddr[0],
+            pEventRequestConnection->bdaddr[1], pEventRequestConnection->bdaddr[2],
+            pEventRequestConnection->bdaddr[3], pEventRequestConnection->bdaddr[4],
+            pEventRequestConnection->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  COD[0]: 0x%02x", pEventRequestConnection->uclass[0]);
   DEBUG_LOG(IOS_WIIMOTE, "  COD[1]: 0x%02x", pEventRequestConnection->uclass[1]);
   DEBUG_LOG(IOS_WIIMOTE, "  COD[2]: 0x%02x", pEventRequestConnection->uclass[2]);
@@ -633,9 +625,9 @@ bool BluetoothEmu::SendEventRemoteNameReq(const bdaddr_t& _bd)
   strcpy((char*)pRemoteNameReq->RemoteName, pWiiMote->GetName());
 
   DEBUG_LOG(IOS_WIIMOTE, "Event: SendEventRemoteNameReq");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pRemoteNameReq->bdaddr.b[0],
-            pRemoteNameReq->bdaddr.b[1], pRemoteNameReq->bdaddr.b[2], pRemoteNameReq->bdaddr.b[3],
-            pRemoteNameReq->bdaddr.b[4], pRemoteNameReq->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pRemoteNameReq->bdaddr[0],
+            pRemoteNameReq->bdaddr[1], pRemoteNameReq->bdaddr[2], pRemoteNameReq->bdaddr[3],
+            pRemoteNameReq->bdaddr[4], pRemoteNameReq->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  RemoteName: %s", pRemoteNameReq->RemoteName);
 
   AddEventToQueue(Event);
@@ -768,9 +760,9 @@ bool BluetoothEmu::SendEventRoleChange(bdaddr_t _bd, bool _master)
   AddEventToQueue(Event);
 
   DEBUG_LOG(IOS_WIIMOTE, "Event: SendEventRoleChange");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pRoleChange->bdaddr.b[0],
-            pRoleChange->bdaddr.b[1], pRoleChange->bdaddr.b[2], pRoleChange->bdaddr.b[3],
-            pRoleChange->bdaddr.b[4], pRoleChange->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pRoleChange->bdaddr[0],
+            pRoleChange->bdaddr[1], pRoleChange->bdaddr[2], pRoleChange->bdaddr[3],
+            pRoleChange->bdaddr[4], pRoleChange->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  NewRole: %i", pRoleChange->NewRole);
 
   return true;
@@ -870,9 +862,9 @@ bool BluetoothEmu::SendEventLinkKeyNotification(const u8 num_to_send)
     link_key_info->bdaddr = m_WiiMotes[i].GetBD();
     memcpy(link_key_info->key, m_WiiMotes[i].GetLinkKey(), HCI_KEY_SIZE);
 
-    DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", link_key_info->bdaddr.b[0],
-              link_key_info->bdaddr.b[1], link_key_info->bdaddr.b[2], link_key_info->bdaddr.b[3],
-              link_key_info->bdaddr.b[4], link_key_info->bdaddr.b[5]);
+    DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", link_key_info->bdaddr[0],
+              link_key_info->bdaddr[1], link_key_info->bdaddr[2], link_key_info->bdaddr[3],
+              link_key_info->bdaddr[4], link_key_info->bdaddr[5]);
   }
 
   AddEventToQueue(Event);
@@ -891,10 +883,10 @@ bool BluetoothEmu::SendEventRequestLinkKey(const bdaddr_t& _bd)
   pEventRequestLinkKey->bdaddr = _bd;
 
   DEBUG_LOG(IOS_WIIMOTE, "Event: SendEventRequestLinkKey");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pEventRequestLinkKey->bdaddr.b[0],
-            pEventRequestLinkKey->bdaddr.b[1], pEventRequestLinkKey->bdaddr.b[2],
-            pEventRequestLinkKey->bdaddr.b[3], pEventRequestLinkKey->bdaddr.b[4],
-            pEventRequestLinkKey->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", pEventRequestLinkKey->bdaddr[0],
+            pEventRequestLinkKey->bdaddr[1], pEventRequestLinkKey->bdaddr[2],
+            pEventRequestLinkKey->bdaddr[3], pEventRequestLinkKey->bdaddr[4],
+            pEventRequestLinkKey->bdaddr[5]);
 
   AddEventToQueue(Event);
 
@@ -1174,10 +1166,10 @@ void BluetoothEmu::CommandCreateCon(const u8* input)
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_CMD_CREATE_CON");
   DEBUG_LOG(IOS_WIIMOTE, "Input:");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", create_connection->bdaddr.b[0],
-            create_connection->bdaddr.b[1], create_connection->bdaddr.b[2],
-            create_connection->bdaddr.b[3], create_connection->bdaddr.b[4],
-            create_connection->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", create_connection->bdaddr[0],
+            create_connection->bdaddr[1], create_connection->bdaddr[2],
+            create_connection->bdaddr[3], create_connection->bdaddr[4],
+            create_connection->bdaddr[5]);
 
   DEBUG_LOG(IOS_WIIMOTE, "  pkt_type: %i", create_connection->pkt_type);
   DEBUG_LOG(IOS_WIIMOTE, "  page_scan_rep_mode: %i", create_connection->page_scan_rep_mode);
@@ -1216,10 +1208,10 @@ void BluetoothEmu::CommandAcceptCon(const u8* input)
   };
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_CMD_ACCEPT_CON");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", accept_connection->bdaddr.b[0],
-            accept_connection->bdaddr.b[1], accept_connection->bdaddr.b[2],
-            accept_connection->bdaddr.b[3], accept_connection->bdaddr.b[4],
-            accept_connection->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", accept_connection->bdaddr[0],
+            accept_connection->bdaddr[1], accept_connection->bdaddr[2],
+            accept_connection->bdaddr[3], accept_connection->bdaddr[4],
+            accept_connection->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  role: %s", roles[accept_connection->role]);
 
   SendEventCommandStatus(HCI_CMD_ACCEPT_CON);
@@ -1238,9 +1230,9 @@ void BluetoothEmu::CommandLinkKeyRep(const u8* input)
   const hci_link_key_rep_cp* key_rep = reinterpret_cast<const hci_link_key_rep_cp*>(input);
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_CMD_LINK_KEY_REP");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", key_rep->bdaddr.b[0],
-            key_rep->bdaddr.b[1], key_rep->bdaddr.b[2], key_rep->bdaddr.b[3], key_rep->bdaddr.b[4],
-            key_rep->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", key_rep->bdaddr[0],
+            key_rep->bdaddr[1], key_rep->bdaddr[2], key_rep->bdaddr[3], key_rep->bdaddr[4],
+            key_rep->bdaddr[5]);
 
   hci_link_key_rep_rp reply;
   reply.status = 0x00;
@@ -1254,9 +1246,9 @@ void BluetoothEmu::CommandLinkKeyNegRep(const u8* input)
   const hci_link_key_neg_rep_cp* key_neg = reinterpret_cast<const hci_link_key_neg_rep_cp*>(input);
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_CMD_LINK_KEY_NEG_REP");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", key_neg->bdaddr.b[0],
-            key_neg->bdaddr.b[1], key_neg->bdaddr.b[2], key_neg->bdaddr.b[3], key_neg->bdaddr.b[4],
-            key_neg->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", key_neg->bdaddr[0],
+            key_neg->bdaddr[1], key_neg->bdaddr[2], key_neg->bdaddr[3], key_neg->bdaddr[4],
+            key_neg->bdaddr[5]);
 
   hci_link_key_neg_rep_rp reply;
   reply.status = 0x00;
@@ -1298,10 +1290,9 @@ void BluetoothEmu::CommandRemoteNameReq(const u8* input)
       reinterpret_cast<const hci_remote_name_req_cp*>(input);
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_CMD_REMOTE_NAME_REQ");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", remote_name_req->bdaddr.b[0],
-            remote_name_req->bdaddr.b[1], remote_name_req->bdaddr.b[2],
-            remote_name_req->bdaddr.b[3], remote_name_req->bdaddr.b[4],
-            remote_name_req->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", remote_name_req->bdaddr[0],
+            remote_name_req->bdaddr[1], remote_name_req->bdaddr[2], remote_name_req->bdaddr[3],
+            remote_name_req->bdaddr[4], remote_name_req->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  page_scan_rep_mode: %i", remote_name_req->page_scan_rep_mode);
   DEBUG_LOG(IOS_WIIMOTE, "  page_scan_mode: %i", remote_name_req->page_scan_mode);
   DEBUG_LOG(IOS_WIIMOTE, "  clock_offset: %i", remote_name_req->clock_offset);
@@ -1433,10 +1424,10 @@ void BluetoothEmu::CommandReadStoredLinkKey(const u8* input)
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_CMD_READ_STORED_LINK_KEY:");
   DEBUG_LOG(IOS_WIIMOTE, "input:");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", read_stored_link_key->bdaddr.b[0],
-            read_stored_link_key->bdaddr.b[1], read_stored_link_key->bdaddr.b[2],
-            read_stored_link_key->bdaddr.b[3], read_stored_link_key->bdaddr.b[4],
-            read_stored_link_key->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", read_stored_link_key->bdaddr[0],
+            read_stored_link_key->bdaddr[1], read_stored_link_key->bdaddr[2],
+            read_stored_link_key->bdaddr[3], read_stored_link_key->bdaddr[4],
+            read_stored_link_key->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  read_all: %i", read_stored_link_key->read_all);
   DEBUG_LOG(IOS_WIIMOTE, "return:");
   DEBUG_LOG(IOS_WIIMOTE, "  max_num_keys: %i", reply.max_num_keys);
@@ -1453,10 +1444,10 @@ void BluetoothEmu::CommandDeleteStoredLinkKey(const u8* input)
       reinterpret_cast<const hci_delete_stored_link_key_cp*>(input);
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_OCF_DELETE_STORED_LINK_KEY");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", delete_stored_link_key->bdaddr.b[0],
-            delete_stored_link_key->bdaddr.b[1], delete_stored_link_key->bdaddr.b[2],
-            delete_stored_link_key->bdaddr.b[3], delete_stored_link_key->bdaddr.b[4],
-            delete_stored_link_key->bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", delete_stored_link_key->bdaddr[0],
+            delete_stored_link_key->bdaddr[1], delete_stored_link_key->bdaddr[2],
+            delete_stored_link_key->bdaddr[3], delete_stored_link_key->bdaddr[4],
+            delete_stored_link_key->bdaddr[5]);
   DEBUG_LOG(IOS_WIIMOTE, "  delete_all: 0x%01x", delete_stored_link_key->delete_all);
 
   WiimoteDevice* wiiMote = AccessWiiMote(delete_stored_link_key->bdaddr);
@@ -1703,9 +1694,8 @@ void BluetoothEmu::CommandReadBDAdrr(const u8* input)
 
   INFO_LOG(IOS_WIIMOTE, "Command: HCI_CMD_READ_BDADDR:");
   DEBUG_LOG(IOS_WIIMOTE, "return:");
-  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", reply.bdaddr.b[0],
-            reply.bdaddr.b[1], reply.bdaddr.b[2], reply.bdaddr.b[3], reply.bdaddr.b[4],
-            reply.bdaddr.b[5]);
+  DEBUG_LOG(IOS_WIIMOTE, "  bd: %02x:%02x:%02x:%02x:%02x:%02x", reply.bdaddr[0], reply.bdaddr[1],
+            reply.bdaddr[2], reply.bdaddr[3], reply.bdaddr[4], reply.bdaddr[5]);
 
   SendEventCommandComplete(HCI_CMD_READ_BDADDR, &reply, sizeof(hci_read_bdaddr_rp));
 }
@@ -1747,19 +1737,12 @@ void BluetoothEmu::CommandVendorSpecific_FC4C(const u8* input, u32 size)
 // --- helper
 //
 //
-WiimoteDevice* BluetoothEmu::AccessWiiMote(const bdaddr_t& _rAddr)
+WiimoteDevice* BluetoothEmu::AccessWiiMote(const bdaddr_t& address)
 {
-  for (auto& wiimote : m_WiiMotes)
-  {
-    const bdaddr_t& BD = wiimote.GetBD();
-    if ((_rAddr.b[0] == BD.b[0]) && (_rAddr.b[1] == BD.b[1]) && (_rAddr.b[2] == BD.b[2]) &&
-        (_rAddr.b[3] == BD.b[3]) && (_rAddr.b[4] == BD.b[4]) && (_rAddr.b[5] == BD.b[5]))
-      return &wiimote;
-  }
-
-  ERROR_LOG(IOS_WIIMOTE, "Can't find WiiMote by bd: %02x:%02x:%02x:%02x:%02x:%02x", _rAddr.b[0],
-            _rAddr.b[1], _rAddr.b[2], _rAddr.b[3], _rAddr.b[4], _rAddr.b[5]);
-  return nullptr;
+  const auto iterator =
+      std::find_if(m_WiiMotes.begin(), m_WiiMotes.end(),
+                   [&address](const WiimoteDevice& remote) { return remote.GetBD() == address; });
+  return iterator != m_WiiMotes.cend() ? &*iterator : nullptr;
 }
 
 WiimoteDevice* BluetoothEmu::AccessWiiMote(u16 _ConnectionHandle)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -66,7 +66,7 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  bdaddr_t m_ControllerBD;
+  bdaddr_t m_ControllerBD{{0x11, 0x02, 0x19, 0x79, 0x00, 0xff}};
 
   // this is used to trigger connecting via ACL
   u8 m_ScanEnable = 0;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -18,6 +18,7 @@
 #include "Common/Timer.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
+#include "Core/IOS/USB/Bluetooth/hci.h"
 #include "Core/IOS/USB/USBV0.h"
 
 class PointerWrap;
@@ -40,7 +41,6 @@ enum class SyncButtonState
   Ignored,
 };
 
-using btaddr_t = std::array<u8, 6>;
 using linkkey_t = std::array<u8, 16>;
 
 namespace Device
@@ -101,7 +101,7 @@ private:
   // This stores the address of paired devices and associated link keys.
   // It is needed because some adapters forget all stored link keys when they are reset,
   // which breaks pairings because the Wii relies on the Bluetooth module to remember them.
-  std::map<btaddr_t, linkkey_t> m_link_keys;
+  std::map<bdaddr_t, linkkey_t> m_link_keys;
   Common::Flag m_need_reset_keys;
 
   // This flag is set when a libusb transfer failed (for reasons other than timing out)

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -37,16 +37,9 @@ WiimoteDevice::WiimoteDevice(Device::BluetoothEmu* host, int number, bdaddr_t bd
   m_ConnectionHandle = 0x100 + number;
   memset(m_LinkKey, 0xA0 + number, HCI_KEY_SIZE);
 
-  bdaddr_t _nullBD = BDADDR_ANY;
-  if (memcmp(&m_BD, &_nullBD, sizeof(bdaddr_t)) == 0)
-  {
-    m_BD.b[0] = 0x11;
-    m_BD.b[1] = 0x02;
-    m_BD.b[2] = 0x19;
-    m_BD.b[3] = 0x79;
-    m_BD.b[4] = 0x00;
-    m_BD.b[5] = number;
-  }
+  if (m_BD == BDADDR_ANY)
+    m_BD = {{0x11, 0x02, 0x19, 0x79, static_cast<u8>(number)}};
+
   uclass[0] = 0x00;
   uclass[1] = 0x04;
   uclass[2] = 0x48;

--- a/Source/Core/Core/IOS/USB/Bluetooth/hci.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/hci.h
@@ -83,7 +83,10 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <array>
+#include <cstdint>
+
+#include "Common/CommonTypes.h"
 
 // All structs in this file are packed
 #pragma pack(push, 1)
@@ -94,18 +97,8 @@
 /*
  * Bluetooth device address
  */
-#ifndef __BLUETOOTH_H
-typedef struct
-{
-  uint8_t b[BLUETOOTH_BDADDR_SIZE];
-} bdaddr_t;
-#define BDADDR_ANY                                                                                 \
-  {                                                                                                \
-    {                                                                                              \
-      0, 0, 0, 0, 0, 0                                                                             \
-    }                                                                                              \
-  }
-#endif
+using bdaddr_t = std::array<u8, BLUETOOTH_BDADDR_SIZE>;
+constexpr bdaddr_t BDADDR_ANY{};
 
 /**************************************************************************
  **************************************************************************


### PR DESCRIPTION
BluetoothEmu had its own bdaddr_t type which is a old style C struct and typedef, which makes comparisons and copies a bit ugly. On the other hand, BTReal had its own btaddr_t type using std::array.

To make things very slightly nicer, this commit changes the Bluetooth code to use a single type (std::array<u8, 6>) for all BT addresses.