### PR TITLE
TraversalClient: Fix memory leaks in ReleaseTraversalClient()

### DIFF
--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -329,6 +329,6 @@ void ReleaseTraversalClient()
   if (!g_TraversalClient)
     return;
 
-  g_TraversalClient.release();
-  g_MainNetHost.release();
+  g_TraversalClient.reset();
+  g_MainNetHost.reset();
 }


### PR DESCRIPTION
release() relinquishes ownership of a pointer, it doesn't actually free it.