### PR TITLE
Remove CFBundleLocalizations from Info.plist

### DIFF
--- a/Source/Core/DolphinQt2/Info.plist.in
+++ b/Source/Core/DolphinQt2/Info.plist.in
@@ -33,37 +33,6 @@
     <string>org.dolphin-emu.dolphin</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>English</string>
-    <key>CFBundleLocalizations</key>
-    <array>
-        <string>ar</string>
-        <string>ca</string>
-        <string>cs</string>
-        <string>da_DK</string>
-        <string>de</string>
-        <string>el</string>
-        <string>en</string>
-        <string>es</string>
-        <string>fa</string>
-        <string>fr</string>
-        <string>hr</string>
-        <string>hu</string>
-        <string>it</string>
-        <string>ja</string>
-        <string>ko</string>
-        <string>ms_MY</string>
-        <string>nb</string>
-        <string>nl</string>
-        <string>pl</string>
-        <string>pt</string>
-        <string>pt_BR</string>
-        <string>ro_RO</string>
-        <string>ru</string>
-        <string>sr</string>
-        <string>sv</string>
-        <string>tr</string>
-        <string>zh_CN</string>
-        <string>zh_TW</string>
-    </array>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/Source/Core/DolphinWX/Info.plist.in
+++ b/Source/Core/DolphinWX/Info.plist.in
@@ -33,37 +33,6 @@
 	<string>org.dolphin-emu.dolphin</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	<key>CFBundleLocalizations</key>
-	<array>
-		<string>ar</string>
-		<string>ca</string>
-		<string>cs</string>
-		<string>da_DK</string>
-		<string>de</string>
-		<string>el</string>
-		<string>en</string>
-		<string>es</string>
-		<string>fa</string>
-		<string>fr</string>
-		<string>hr</string>
-		<string>hu</string>
-		<string>it</string>
-		<string>ja</string>
-		<string>ko</string>
-		<string>ms_MY</string>
-		<string>nb</string>
-		<string>nl</string>
-		<string>pl</string>
-		<string>pt</string>
-		<string>pt_BR</string>
-		<string>ro_RO</string>
-		<string>ru</string>
-		<string>sr</string>
-		<string>sv</string>
-		<string>tr</string>
-		<string>zh_CN</string>
-		<string>zh_TW</string>
-	</array>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
It's only needed for apps that don't use .lproj folders.