### PR TITLE
gettextize: extract arguments to QT_TR_NOOP

### DIFF
--- a/Languages/gettextize
+++ b/Languages/gettextize
@@ -5,8 +5,8 @@ SRCDIR=Source
 find $SRCDIR -name '*.cpp' -o -name '*.h' -o -name '*.c' | \
 	xgettext -d dolphin-emu -s --keyword=_ --keyword=wxTRANSLATE --keyword=SuccessAlertT \
 	--keyword=PanicAlertT --keyword=PanicYesNoT --keyword=AskYesNoT --keyword=CriticalAlertT \
-	--keyword=GetStringT --keyword=_trans --keyword=tr --add-comments=i18n -p ./Languages/po \
-	-o dolphin-emu.pot -f - --package-name="Dolphin Emulator"
+	--keyword=GetStringT --keyword=_trans --keyword=tr --keyword=QT_TR_NOOP \
+	--add-comments=i18n -p ./Languages/po -o dolphin-emu.pot -f - --package-name="Dolphin Emulator"
 
 sed -i "s/SOME DESCRIPTIVE TITLE\./Translation of dolphin-emu.pot to LANGUAGE/" Languages/po/dolphin-emu.pot
 sed -i "s/YEAR THE PACKAGE'S COPYRIGHT HOLDER/2003-2013/" Languages/po/dolphin-emu.pot


### PR DESCRIPTION
Follow-up to #5812. There's another Qt function that's used to mark translatable strings.