### PR TITLE
Make DolphinQt2 strings more like DolphinWX strings

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -43,8 +43,11 @@ Turntable::Turntable(ExtensionReg& reg) : Attachment(_trans("Turntable"), reg)
     m_buttons->controls.emplace_back(new ControllerEmu::Input(turntable_button_name));
 
   // turntables
-  groups.emplace_back(m_left_table = new ControllerEmu::Slider(_trans("Table Left")));
-  groups.emplace_back(m_right_table = new ControllerEmu::Slider(_trans("Table Right")));
+  // i18n: "Table" refers to a turntable
+  groups.emplace_back(m_left_table = new ControllerEmu::Slider("Table Left", _trans("Left Table")));
+  groups.emplace_back(m_right_table =
+                          // i18n: "Table" refers to a turntable
+                      new ControllerEmu::Slider("Table Right", _trans("Right Table")));
 
   // stick
   groups.emplace_back(

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -242,23 +242,23 @@ void Shutdown()
 const std::array<HotkeyGroupInfo, NUM_HOTKEY_GROUPS> groups_info = {
     {{_trans("General"), HK_OPEN, HK_EXIT},
      {_trans("Volume"), HK_VOLUME_DOWN, HK_VOLUME_TOGGLE_MUTE},
-     {_trans("Emulation speed"), HK_DECREASE_EMULATION_SPEED, HK_TOGGLE_THROTTLE},
-     {_trans("Frame advance"), HK_FRAME_ADVANCE, HK_FRAME_ADVANCE_RESET_SPEED},
+     {_trans("Emulation Speed"), HK_DECREASE_EMULATION_SPEED, HK_TOGGLE_THROTTLE},
+     {_trans("Frame Advance"), HK_FRAME_ADVANCE, HK_FRAME_ADVANCE_RESET_SPEED},
      {_trans("Movie"), HK_START_RECORDING, HK_READ_ONLY_MODE},
      {_trans("Stepping"), HK_STEP, HK_SKIP},
      {_trans("Program Counter"), HK_SHOW_PC, HK_SET_PC},
      {_trans("Breakpoint"), HK_BP_TOGGLE, HK_MBP_ADD},
      {_trans("Wii"), HK_TRIGGER_SYNC_BUTTON, HK_BALANCEBOARD_CONNECT},
-     {_trans("Graphics toggles"), HK_TOGGLE_CROP, HK_TOGGLE_TEXTURES},
+     {_trans("Graphics Toggles"), HK_TOGGLE_CROP, HK_TOGGLE_TEXTURES},
      {_trans("Internal Resolution"), HK_INCREASE_IR, HK_DECREASE_IR},
      {_trans("Freelook"), HK_FREELOOK_DECREASE_SPEED, HK_FREELOOK_RESET},
      {_trans("3D"), HK_TOGGLE_STEREO_SBS, HK_TOGGLE_STEREO_3DVISION},
-     {_trans("3D depth"), HK_DECREASE_DEPTH, HK_INCREASE_CONVERGENCE},
-     {_trans("Load state"), HK_LOAD_STATE_SLOT_1, HK_LOAD_STATE_SLOT_SELECTED},
-     {_trans("Save state"), HK_SAVE_STATE_SLOT_1, HK_SAVE_STATE_SLOT_SELECTED},
-     {_trans("Select state"), HK_SELECT_STATE_SLOT_1, HK_SELECT_STATE_SLOT_10},
-     {_trans("Load last state"), HK_LOAD_LAST_STATE_1, HK_LOAD_LAST_STATE_10},
-     {_trans("Other state hotkeys"), HK_SAVE_FIRST_STATE, HK_LOAD_STATE_FILE}}};
+     {_trans("3D Depth"), HK_DECREASE_DEPTH, HK_INCREASE_CONVERGENCE},
+     {_trans("Load State"), HK_LOAD_STATE_SLOT_1, HK_LOAD_STATE_SLOT_SELECTED},
+     {_trans("Save State"), HK_SAVE_STATE_SLOT_1, HK_SAVE_STATE_SLOT_SELECTED},
+     {_trans("Select State"), HK_SELECT_STATE_SLOT_1, HK_SELECT_STATE_SLOT_10},
+     {_trans("Load Last State"), HK_LOAD_LAST_STATE_1, HK_LOAD_LAST_STATE_10},
+     {_trans("Other State Hotkeys"), HK_SAVE_FIRST_STATE, HK_LOAD_STATE_FILE}}};
 
 HotkeyManager::HotkeyManager()
 {

--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -34,6 +34,10 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
   text.append(medium + tr("Check for updates: ") +
               QStringLiteral(
                   "<a href='https://dolphin-emu.org/download'>dolphin-emu.org/download</a></p>"));
+  // i18n: The word "free" in the standard phrase "free and open source"
+  // is "free" as in "freedom" - it refers to certain properties of the
+  // software's license, not the software's price. (It is true that Dolphin
+  // can be downloaded at no cost, but that's not what this message says.)
   text.append(medium + tr("Dolphin is a free and open-source GameCube and Wii emulator.") +
               QStringLiteral("</p>"));
   text.append(medium +
@@ -45,7 +49,7 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
           "<a href='https://github.com/dolphin-emu/dolphin/blob/master/license.txt'>%1</a> | "
           "<a href='https://github.com/dolphin-emu/dolphin/graphs/contributors'>%2</a> | "
           "<a href='https://forums.dolphin-emu.org/'>%3</a></p>")
-          .arg(tr("Licence"))
+          .arg(tr("License"))
           .arg(tr("Authors"))
           .arg(tr("Support")));
 
@@ -54,6 +58,10 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
   text_label->setOpenExternalLinks(true);
 
   QLabel* copyright =
+      // i18n: This message uses curly quotes in English. If you want to use curly quotes
+      // in your translation, please use the type of curly quotes that's appropriate for
+      // your language. If you aren't sure which type is appropriate, see
+      // https://en.wikipedia.org/wiki/Quotation_mark#Specific_language_features
       new QLabel(tr("\u00A9 2003-%1 Dolphin Team. \u201cGameCube\u201d and \u201cWii\u201d are "
                     "trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way.")
                      .arg(QStringLiteral(__DATE__).right(4)));

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -94,7 +94,7 @@ void ControllersWindow::CreateGamecubeLayout()
 
   for (size_t i = 0; i < m_gc_groups.size(); i++)
   {
-    auto* gc_label = new QLabel(tr("Controller %1").arg(i + 1));
+    auto* gc_label = new QLabel(tr("Port %1").arg(i + 1));
     auto* gc_box = m_gc_controller_boxes[i] = new QComboBox();
     auto* gc_button = m_gc_buttons[i] = new QPushButton(tr("Configure"));
 
@@ -156,13 +156,13 @@ void ControllersWindow::CreateWiimoteLayout()
   m_wiimote_box = new QGroupBox(tr("Wii Remotes"));
   m_wiimote_box->setLayout(m_wiimote_layout);
 
-  m_wiimote_passthrough = new QRadioButton(tr("Use Bluetooth Passthrough"));
+  m_wiimote_passthrough = new QRadioButton(tr("Passthrough a Bluetooth adapter"));
   m_wiimote_sync = new QPushButton(tr("Sync"));
   m_wiimote_reset = new QPushButton(tr("Reset"));
   m_wiimote_refresh = new QPushButton(tr("Refresh"));
   m_wiimote_pt_labels[0] = new QLabel(tr("Sync real Wii Remotes and pair them"));
   m_wiimote_pt_labels[1] = new QLabel(tr("Reset all saved Wii Remote pairings"));
-  m_wiimote_emu = new QRadioButton(tr("Emulate the Wii Bluetooth Adapter"));
+  m_wiimote_emu = new QRadioButton(tr("Emulate the Wii's Bluetooth Adapter"));
   m_wiimote_continuous_scanning = new QCheckBox(tr("Continuous Scanning"));
   m_wiimote_real_balance_board = new QCheckBox(tr("Real Balance Board"));
   m_wiimote_speaker_data = new QCheckBox(tr("Enable Speaker Data"));
@@ -358,7 +358,7 @@ void ControllersWindow::OnBluetoothPassthroughSyncPressed()
   {
     QMessageBox error(this);
     error.setIcon(QMessageBox::Warning);
-    error.setText(tr("A sync can only be triggered when a Wii game is running"));
+    error.setText(tr("A sync can only be triggered when a Wii game is running."));
     error.exec();
     return;
   }

--- a/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
@@ -77,7 +77,7 @@ void AdvancedWidget::CreateWidgets()
 #endif
 
   // Misc.
-  auto* misc_box = new QGroupBox(tr("Misc."));
+  auto* misc_box = new QGroupBox(tr("Misc"));
   auto* misc_layout = new QGridLayout();
   misc_box->setLayout(misc_layout);
 

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -77,9 +77,9 @@ void EnhancementsWidget::CreateWidgets()
 
   enhancements_layout->addWidget(new QLabel(tr("Internal Resolution:")), 0, 0);
   enhancements_layout->addWidget(m_ir_combo, 0, 1, 1, -1);
-  enhancements_layout->addWidget(new QLabel(tr("Anti-Aliasing")), 1, 0);
+  enhancements_layout->addWidget(new QLabel(tr("Anti-Aliasing:")), 1, 0);
   enhancements_layout->addWidget(m_aa_combo, 1, 1, 1, -1);
-  enhancements_layout->addWidget(new QLabel(tr("Antisotrophic Filtering:")), 2, 0);
+  enhancements_layout->addWidget(new QLabel(tr("Anisotropic Filtering:")), 2, 0);
   enhancements_layout->addWidget(m_af_combo, 2, 1, 1, -1);
   enhancements_layout->addWidget(new QLabel(tr("Post-Processing Effect:")), 3, 0);
   enhancements_layout->addWidget(m_pp_effect, 3, 1);
@@ -233,7 +233,7 @@ void EnhancementsWidget::AddDescriptions()
                  "geometry anti-aliasing and also applies anti-aliasing to lighting, shader "
                  "effects, and textures.\n\nIf unsure, select None.");
 
-  static const char* TR_ANTISTROPIC_FILTERING_DESCRIPTION = QT_TR_NOOP(
+  static const char* TR_ANISOTROPIC_FILTERING_DESCRIPTION = QT_TR_NOOP(
       "Enable anisotropic filtering.\nEnhances visual quality of textures that are at oblique "
       "viewing angles.\nMight cause issues in a small number of games.\n\nIf unsure, select 1x.");
 
@@ -263,8 +263,9 @@ void EnhancementsWidget::AddDescriptions()
   static const char* TR_3D_MODE_DESCRIPTION = QT_TR_NOOP(
       "Selects the stereoscopic 3D mode. Stereoscopy allows you to get a better feeling "
       "of depth if you have the necessary hardware.\nSide-by-Side and Top-and-Bottom are "
-      "used by most 3D TVs.\nAnaglyph is used for Red-Cyan colored glasses.\nHeavily "
-      "decreases emulation speed and sometimes causes issues.\n\nIf unsure, select Off.");
+      "used by most 3D TVs.\nAnaglyph is used for Red-Cyan colored glasses.\nHDMI 3D is "
+      "used when your monitor supports 3D display resolutions.\nHeavily decreases "
+      "emulation speed and sometimes causes issues.\n\nIf unsure, select Off.");
   static const char* TR_3D_DEPTH_DESCRIPTION =
       QT_TR_NOOP("Controls the separation distance between the virtual cameras.\nA higher value "
                  "creates a stronger feeling of depth while a lower value is more comfortable.");
@@ -286,7 +287,7 @@ void EnhancementsWidget::AddDescriptions()
 
   AddDescription(m_ir_combo, TR_INTERNAL_RESOLUTION_DESCRIPTION);
   AddDescription(m_aa_combo, TR_ANTIALIAS_DESCRIPTION);
-  AddDescription(m_af_combo, TR_ANTISTROPIC_FILTERING_DESCRIPTION);
+  AddDescription(m_af_combo, TR_ANISOTROPIC_FILTERING_DESCRIPTION);
   AddDescription(m_pp_effect, TR_POSTPROCESSING_DESCRIPTION);
   AddDescription(m_scaled_efb_copy, TR_SCALED_EFB_COPY_DESCRIPTION);
   AddDescription(m_per_pixel_lighting, TR_PER_PIXEL_LIGHTING_DESCRIPTION);

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -40,8 +40,8 @@ void GeneralWidget::CreateWidgets()
 {
   auto* main_layout = new QVBoxLayout;
 
-  // Video Section
-  auto* m_video_box = new QGroupBox(tr("Video"));
+  // Basic Section
+  auto* m_video_box = new QGroupBox(tr("Basic"));
   m_video_layout = new QGridLayout();
 
   m_backend_combo = new QComboBox();
@@ -83,14 +83,15 @@ void GeneralWidget::CreateWidgets()
   m_video_layout->addWidget(m_enable_vsync, 4, 0);
   m_video_layout->addWidget(m_enable_fullscreen, 4, 1);
 
-  // Options
-  auto* m_options_box = new QGroupBox(tr("Options"));
+  // Other
+  auto* m_options_box = new QGroupBox(tr("Other"));
   auto* m_options_layout = new QGridLayout();
 
   m_show_fps = new GraphicsBool(tr("Show FPS"), Config::GFX_SHOW_FPS);
   m_show_ping = new GraphicsBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING);
-  m_log_render_time = new GraphicsBool(tr("Log Rendertime"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
-  m_autoadjust_window_size = new QCheckBox(tr("Auto-adjust Window size"));
+  m_log_render_time =
+      new GraphicsBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
+  m_autoadjust_window_size = new QCheckBox(tr("Auto-Adjust Window Size"));
   m_show_messages =
       new GraphicsBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES);
   m_keep_window_top = new QCheckBox(tr("Keep Window on Top"));

--- a/Source/Core/DolphinQt2/Config/Graphics/SoftwareRendererWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/SoftwareRendererWidget.cpp
@@ -38,12 +38,12 @@ void SoftwareRendererWidget::CreateWidgets()
   auto* rendering_box = new QGroupBox(tr("Rendering"));
   auto* rendering_layout = new QGridLayout();
   m_backend_combo = new QComboBox();
-  m_disable_xfb = new GraphicsBool(tr("Disable XFB"), Config::GFX_USE_XFB, true);
+  m_bypass_xfb = new GraphicsBool(tr("Bypass XFB"), Config::GFX_USE_XFB, true);
 
   rendering_box->setLayout(rendering_layout);
   rendering_layout->addWidget(new QLabel(tr("Backend:")), 1, 1);
   rendering_layout->addWidget(m_backend_combo, 1, 2);
-  rendering_layout->addWidget(m_disable_xfb, 2, 1);
+  rendering_layout->addWidget(m_bypass_xfb, 2, 1);
 
   for (const auto& backend : g_available_video_backends)
     m_backend_combo->addItem(tr(backend->GetDisplayName().c_str()));
@@ -66,7 +66,7 @@ void SoftwareRendererWidget::CreateWidgets()
 
   auto* debug_box = new QGroupBox(tr("Debug Only"));
   auto* debug_layout = new QGridLayout();
-  m_dump_tev_stages = new GraphicsBool(tr("Dump TEV stages"), Config::GFX_SW_DUMP_TEV_STAGES);
+  m_dump_tev_stages = new GraphicsBool(tr("Dump TEV Stages"), Config::GFX_SW_DUMP_TEV_STAGES);
   m_dump_tev_fetches =
       new GraphicsBool(tr("Dump Texture Fetches"), Config::GFX_SW_DUMP_TEV_TEX_FETCHES);
 
@@ -155,7 +155,7 @@ void SoftwareRendererWidget::AddDescriptions()
                  "backend, so for the best emulation experience it's recommended to try both and "
                  "choose the one that's less problematic.\n\nIf unsure, select OpenGL.");
 
-  static const char* TR_DISABLE_XFB_DESCRIPTION = QT_TR_NOOP(
+  static const char* TR_BYPASS_XFB_DESCRIPTION = QT_TR_NOOP(
       "Disable any XFB emulation.\nSpeeds up emulation a lot but causes heavy glitches in many "
       "games "
       "which rely on them (especially homebrew applications).\n\nIf unsure, leave this checked.");
@@ -168,7 +168,7 @@ void SoftwareRendererWidget::AddDescriptions()
                  "this unchecked.");
 
   AddDescription(m_backend_combo, TR_BACKEND_DESCRIPTION);
-  AddDescription(m_disable_xfb, TR_DISABLE_XFB_DESCRIPTION);
+  AddDescription(m_bypass_xfb, TR_BYPASS_XFB_DESCRIPTION);
   AddDescription(m_enable_statistics, TR_SHOW_STATISTICS_DESCRIPTION);
   AddDescription(m_dump_textures, TR_DUMP_TEXTURES_DESCRIPTION);
 }

--- a/Source/Core/DolphinQt2/Config/Graphics/SoftwareRendererWidget.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/SoftwareRendererWidget.h
@@ -29,7 +29,7 @@ private:
   void AddDescriptions();
 
   QComboBox* m_backend_combo;
-  QCheckBox* m_disable_xfb;
+  QCheckBox* m_bypass_xfb;
   QCheckBox* m_enable_statistics;
   QCheckBox* m_dump_textures;
   QCheckBox* m_dump_objects;

--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -60,7 +60,7 @@ QGroupBox* InfoWidget::CreateISODetails()
 
 QGroupBox* InfoWidget::CreateBannerDetails()
 {
-  QGroupBox* group = new QGroupBox(tr("%1 Banner Details").arg(m_game.GetPlatform()));
+  QGroupBox* group = new QGroupBox(tr("Banner Details"));
   QFormLayout* layout = new QFormLayout;
 
   m_long_name = CreateValueDisplay();

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
@@ -33,7 +33,7 @@ void GCPadEmu::CreateMainLayout()
   m_main_layout->addWidget(
       CreateGroupBox(tr("Control Stick"), Pad::GetGroup(GetPort(), PadGroup::MainStick)));
   m_main_layout->addWidget(
-      CreateGroupBox(tr("C-Stick"), Pad::GetGroup(GetPort(), PadGroup::CStick)));
+      CreateGroupBox(tr("C Stick"), Pad::GetGroup(GetPort(), PadGroup::CStick)));
   m_main_layout->addWidget(CreateGroupBox(tr("D-Pad"), Pad::GetGroup(GetPort(), PadGroup::DPad)));
   m_main_layout->addItem(hbox_layout);
 

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -51,7 +51,7 @@ MappingWindow::MappingWindow(QWidget* parent, int port_num) : QDialog(parent), m
 void MappingWindow::CreateDevicesLayout()
 {
   m_devices_layout = new QHBoxLayout();
-  m_devices_box = new QGroupBox(tr("Devices"));
+  m_devices_box = new QGroupBox(tr("Device"));
   m_devices_combo = new QComboBox();
   m_devices_refresh = new QPushButton(tr("Refresh"));
 
@@ -65,7 +65,7 @@ void MappingWindow::CreateDevicesLayout()
 void MappingWindow::CreateProfilesLayout()
 {
   m_profiles_layout = new QHBoxLayout();
-  m_profiles_box = new QGroupBox(tr("Profiles"));
+  m_profiles_box = new QGroupBox(tr("Profile"));
   m_profiles_combo = new QComboBox();
   m_profiles_load = new QPushButton(tr("Load"));
   m_profiles_save = new QPushButton(tr("Save"));
@@ -284,7 +284,7 @@ void MappingWindow::ChangeMappingType(MappingWindow::Type type)
   {
     auto* extension = new WiimoteEmuExtension(this);
     widget = new WiimoteEmuGeneral(this, extension);
-    setWindowTitle(tr("Wii Remote at Port %1").arg(GetPort() + 1));
+    setWindowTitle(tr("Wii Remote %1").arg(GetPort() + 1));
     AddWidget(tr("General and Options"), widget);
     AddWidget(tr("Motion Controls and IR"), new WiimoteEmuMotionControl(this));
     AddWidget(tr("Extension"), extension);
@@ -295,10 +295,10 @@ void MappingWindow::ChangeMappingType(MappingWindow::Type type)
     widget = new HotkeyGeneral(this);
     AddWidget(tr("General"), widget);
     AddWidget(tr("TAS Tools"), new HotkeyTAS(this));
-    AddWidget(tr("Wii (Remote)"), new HotkeyWii(this));
+    AddWidget(tr("Wii and Wii Remote"), new HotkeyWii(this));
     AddWidget(tr("Graphics"), new HotkeyGraphics(this));
     AddWidget(tr("3D"), new Hotkey3D(this));
-    AddWidget(tr("Save States"), new HotkeyStates(this));
+    AddWidget(tr("Save and Load State"), new HotkeyStates(this));
     setWindowTitle(tr("Hotkey Settings"));
     break;
   }

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.cpp
@@ -136,12 +136,13 @@ void WiimoteEmuExtension::CreateTurntableLayout()
 
   auto* vbox = new QVBoxLayout();
   vbox->addWidget(CreateGroupBox(
-      tr("Effect Dial"),
-      Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::EffectDial)));
+      tr("Effect"), Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::EffectDial)));
   vbox->addWidget(
+      // i18n: "Table" refers to a turntable
       CreateGroupBox(tr("Left Table"),
                      Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::LeftTable)));
   vbox->addWidget(CreateGroupBox(
+      // i18n: "Table" refers to a turntable
       tr("Right Table"),
       Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::RightTable)));
   vbox->addWidget(

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -148,19 +148,19 @@ void GameList::ShowContextMenu(const QPoint&)
 
   QMenu* menu = new QMenu(this);
   DiscIO::Platform platform = GameFile(game).GetPlatformID();
-  menu->addAction(tr("Properties"), this, &GameList::OpenProperties);
-  menu->addAction(tr("Wiki"), this, &GameList::OpenWiki);
+  menu->addAction(tr("&Properties"), this, &GameList::OpenProperties);
+  menu->addAction(tr("&Wiki"), this, &GameList::OpenWiki);
   menu->addSeparator();
 
   if (platform == DiscIO::Platform::GAMECUBE_DISC || platform == DiscIO::Platform::WII_DISC)
   {
-    menu->addAction(tr("Default ISO"), this, &GameList::SetDefaultISO);
+    menu->addAction(tr("Set as &default ISO"), this, &GameList::SetDefaultISO);
     const auto blob_type = GameFile(game).GetBlobType();
 
     if (blob_type == DiscIO::BlobType::GCZ)
-      menu->addAction(tr("Decompress ISO"), this, &GameList::CompressISO);
+      menu->addAction(tr("Decompress ISO..."), this, &GameList::CompressISO);
     else if (blob_type == DiscIO::BlobType::PLAIN)
-      menu->addAction(tr("Compress ISO"), this, &GameList::CompressISO);
+      menu->addAction(tr("Compress ISO..."), this, &GameList::CompressISO);
 
     menu->addSeparator();
   }
@@ -190,13 +190,13 @@ void GameList::ShowContextMenu(const QPoint&)
 
   if (platform == DiscIO::Platform::WII_WAD || platform == DiscIO::Platform::WII_DISC)
   {
-    menu->addAction(tr("Open Wii save folder"), this, &GameList::OpenSaveFolder);
+    menu->addAction(tr("Open Wii &save folder"), this, &GameList::OpenSaveFolder);
     menu->addAction(tr("Export Wii save (Experimental)"), this, &GameList::ExportWiiSave);
     menu->addSeparator();
   }
 
-  menu->addAction(tr("Open Containing Folder"), this, &GameList::OpenContainingFolder);
-  menu->addAction(tr("Remove File"), this, &GameList::DeleteFile);
+  menu->addAction(tr("Open &containing folder"), this, &GameList::OpenContainingFolder);
+  menu->addAction(tr("Delete File..."), this, &GameList::DeleteFile);
   menu->exec(QCursor::pos());
 }
 
@@ -239,7 +239,7 @@ void GameList::CompressISO()
     wii_warning.setText(tr("Are you sure?"));
     wii_warning.setInformativeText(
         tr("Compressing a Wii disc image will irreversibly change the compressed copy by removing "
-           "padding data. Your disc image will still work."));
+           "padding data. Your disc image will still work. Continue?"));
     wii_warning.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 
     if (wii_warning.exec() == QMessageBox::No)
@@ -253,7 +253,7 @@ void GameList::CompressISO()
           .dir()
           .absoluteFilePath(file.GetGameID())
           .append(compressed ? QStringLiteral(".gcm") : QStringLiteral(".gcz")),
-      compressed ? tr("Uncompressed GC/Wii images (*.iso *.gcm") :
+      compressed ? tr("Uncompressed GC/Wii images (*.iso *.gcm)") :
                    tr("Compressed GC/Wii images (*.gcz)"));
 
   if (dst_path.isEmpty())
@@ -296,8 +296,8 @@ void GameList::InstallWAD()
   const bool success = GameFile(GetSelectedGame()).Install();
 
   result_dialog.setIcon(success ? QMessageBox::Information : QMessageBox::Critical);
-  result_dialog.setText(success ? tr("Succesfully installed title to the NAND") :
-                                  tr("Failed to install title to the NAND"));
+  result_dialog.setText(success ? tr("Successfully installed this title to the NAND.") :
+                                  tr("Failed to install this title to the NAND."));
   result_dialog.exec();
 }
 
@@ -318,8 +318,8 @@ void GameList::UninstallWAD()
   const bool success = GameFile(GetSelectedGame()).Uninstall();
 
   result_dialog.setIcon(success ? QMessageBox::Information : QMessageBox::Critical);
-  result_dialog.setText(success ? tr("Succesfully removed title from the NAND") :
-                                  tr("Failed to remove title from the NAND"));
+  result_dialog.setText(success ? tr("Successfully removed this title from the NAND.") :
+                                  tr("Failed to remove this title from the NAND."));
   result_dialog.exec();
 }
 
@@ -347,7 +347,7 @@ void GameList::DeleteFile()
 
   confirm_dialog.setIcon(QMessageBox::Warning);
   confirm_dialog.setText(tr("Are you sure you want to delete this file?"));
-  confirm_dialog.setInformativeText(tr("You won't be able to undo this!"));
+  confirm_dialog.setInformativeText(tr("This cannot be undone!"));
   confirm_dialog.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
 
   if (confirm_dialog.exec() == QMessageBox::Yes)
@@ -442,7 +442,7 @@ void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)
       {tr("Platform"), GameListModel::COL_PLATFORM},
       {tr("Size"), GameListModel::COL_SIZE},
       {tr("Title"), GameListModel::COL_TITLE},
-      {tr("Quality"), GameListModel::COL_RATING}};
+      {tr("State"), GameListModel::COL_RATING}};
 
   m_table->setColumnHidden(rowname_to_col_index[row], !visible);
 }

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -121,7 +121,7 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
   case COL_SIZE:
     return tr("Size");
   case COL_RATING:
-    return tr("Quality");
+    return tr("State");
   }
   return QVariant();
 }

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -76,14 +76,14 @@ void MenuBar::EmulationStopped()
 
 void MenuBar::AddFileMenu()
 {
-  QMenu* file_menu = addMenu(tr("File"));
-  m_open_action = file_menu->addAction(tr("Open"), this, &MenuBar::Open);
-  m_exit_action = file_menu->addAction(tr("Exit"), this, &MenuBar::Exit);
+  QMenu* file_menu = addMenu(tr("&File"));
+  m_open_action = file_menu->addAction(tr("&Open..."), this, &MenuBar::Open);
+  m_exit_action = file_menu->addAction(tr("E&xit"), this, &MenuBar::Exit);
 }
 
 void MenuBar::AddToolsMenu()
 {
-  QMenu* tools_menu = addMenu(tr("Tools"));
+  QMenu* tools_menu = addMenu(tr("&Tools"));
   m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, &MenuBar::InstallWAD);
 
   // Label will be set by a NANDRefresh later
@@ -106,13 +106,13 @@ void MenuBar::AddToolsMenu()
 
 void MenuBar::AddEmulationMenu()
 {
-  QMenu* emu_menu = addMenu(tr("Emulation"));
-  m_play_action = emu_menu->addAction(tr("Play"), this, &MenuBar::Play);
-  m_pause_action = emu_menu->addAction(tr("Pause"), this, &MenuBar::Pause);
-  m_stop_action = emu_menu->addAction(tr("Stop"), this, &MenuBar::Stop);
-  m_reset_action = emu_menu->addAction(tr("Reset"), this, &MenuBar::Reset);
-  m_fullscreen_action = emu_menu->addAction(tr("Fullscreen"), this, &MenuBar::Fullscreen);
-  m_frame_advance_action = emu_menu->addAction(tr("Frame Advance"), this, &MenuBar::FrameAdvance);
+  QMenu* emu_menu = addMenu(tr("&Emulation"));
+  m_play_action = emu_menu->addAction(tr("&Play"), this, &MenuBar::Play);
+  m_pause_action = emu_menu->addAction(tr("&Pause"), this, &MenuBar::Pause);
+  m_stop_action = emu_menu->addAction(tr("&Stop"), this, &MenuBar::Stop);
+  m_reset_action = emu_menu->addAction(tr("&Reset"), this, &MenuBar::Reset);
+  m_fullscreen_action = emu_menu->addAction(tr("Toggle &Fullscreen"), this, &MenuBar::Fullscreen);
+  m_frame_advance_action = emu_menu->addAction(tr("&Frame Advance"), this, &MenuBar::FrameAdvance);
   m_screenshot_action = emu_menu->addAction(tr("Take Screenshot"), this, &MenuBar::Screenshot);
   AddStateLoadMenu(emu_menu);
   AddStateSaveMenu(emu_menu);
@@ -122,7 +122,7 @@ void MenuBar::AddEmulationMenu()
 
 void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 {
-  m_state_load_menu = emu_menu->addMenu(tr("Load State"));
+  m_state_load_menu = emu_menu->addMenu(tr("&Load State"));
   m_state_load_menu->addAction(tr("Load State from File"), this, &MenuBar::StateLoad);
   m_state_load_menu->addAction(tr("Load State from Selected Slot"), this, &MenuBar::StateLoadSlot);
   m_state_load_slots_menu = m_state_load_menu->addMenu(tr("Load State from Slot"));
@@ -138,7 +138,7 @@ void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 
 void MenuBar::AddStateSaveMenu(QMenu* emu_menu)
 {
-  m_state_save_menu = emu_menu->addMenu(tr("Save State"));
+  m_state_save_menu = emu_menu->addMenu(tr("Sa&ve State"));
   m_state_save_menu->addAction(tr("Save State to File"), this, &MenuBar::StateSave);
   m_state_save_menu->addAction(tr("Save State to Selected Slot"), this, &MenuBar::StateSaveSlot);
   m_state_save_menu->addAction(tr("Save State to Oldest Slot"), this, &MenuBar::StateSaveOldest);
@@ -187,7 +187,7 @@ void MenuBar::UpdateStateSlotMenu()
 
 void MenuBar::AddViewMenu()
 {
-  QMenu* view_menu = addMenu(tr("View"));
+  QMenu* view_menu = addMenu(tr("&View"));
   AddGameListTypeSection(view_menu);
   view_menu->addSeparator();
   AddTableColumnsMenu(view_menu);
@@ -198,7 +198,7 @@ void MenuBar::AddViewMenu()
 
 void MenuBar::AddOptionsMenu()
 {
-  QMenu* options_menu = addMenu(tr("Options"));
+  QMenu* options_menu = addMenu(tr("&Options"));
   options_menu->addAction(tr("Co&nfiguration"), this, &MenuBar::Configure);
   options_menu->addSeparator();
   options_menu->addAction(tr("&Graphics Settings"), this, &MenuBar::ConfigureGraphics);
@@ -209,21 +209,21 @@ void MenuBar::AddOptionsMenu()
 
 void MenuBar::AddHelpMenu()
 {
-  QMenu* help_menu = addMenu(tr("Help"));
-  QAction* website = help_menu->addAction(tr("Website"));
+  QMenu* help_menu = addMenu(tr("&Help"));
+  QAction* website = help_menu->addAction(tr("&Website"));
   connect(website, &QAction::triggered, this,
           []() { QDesktopServices::openUrl(QUrl(QStringLiteral("https://dolphin-emu.org/"))); });
-  QAction* documentation = help_menu->addAction(tr("Online Documentation"));
+  QAction* documentation = help_menu->addAction(tr("Online &Documentation"));
   connect(documentation, &QAction::triggered, this, []() {
     QDesktopServices::openUrl(QUrl(QStringLiteral("https://dolphin-emu.org/docs/guides")));
   });
-  QAction* github = help_menu->addAction(tr("GitHub Repository"));
+  QAction* github = help_menu->addAction(tr("&GitHub Repository"));
   connect(github, &QAction::triggered, this, []() {
     QDesktopServices::openUrl(QUrl(QStringLiteral("https://github.com/dolphin-emu/dolphin")));
   });
 
   help_menu->addSeparator();
-  help_menu->addAction(tr("About"), this, &MenuBar::ShowAboutDialog);
+  help_menu->addAction(tr("&About"), this, &MenuBar::ShowAboutDialog);
 }
 
 void MenuBar::AddGameListTypeSection(QMenu* view_menu)
@@ -257,7 +257,7 @@ void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
       {tr("Maker"), &SConfig::GetInstance().m_showMakerColumn},
       {tr("Size"), &SConfig::GetInstance().m_showSizeColumn},
       {tr("Country"), &SConfig::GetInstance().m_showRegionColumn},
-      {tr("Quality"), &SConfig::GetInstance().m_showStateColumn}};
+      {tr("State"), &SConfig::GetInstance().m_showStateColumn}};
 
   QActionGroup* column_group = new QActionGroup(this);
   QMenu* cols_menu = view_menu->addMenu(tr("Table Columns"));
@@ -373,12 +373,12 @@ void MenuBar::InstallWAD()
   if (GameFile(wad_file).Install())
   {
     result_dialog.setIcon(QMessageBox::Information);
-    result_dialog.setText(tr("Successfully installed title to the NAND"));
+    result_dialog.setText(tr("Successfully installed this title to the NAND."));
   }
   else
   {
     result_dialog.setIcon(QMessageBox::Critical);
-    result_dialog.setText(tr("Failed to install title to the NAND!"));
+    result_dialog.setText(tr("Failed to install this title to the NAND."));
   }
 
   result_dialog.exec();

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -199,12 +199,12 @@ void MenuBar::AddViewMenu()
 void MenuBar::AddOptionsMenu()
 {
   QMenu* options_menu = addMenu(tr("Options"));
-  options_menu->addAction(tr("Co&nfiguration..."), this, &MenuBar::Configure);
+  options_menu->addAction(tr("Co&nfiguration"), this, &MenuBar::Configure);
   options_menu->addSeparator();
-  options_menu->addAction(tr("&Graphics Settings..."), this, &MenuBar::ConfigureGraphics);
-  options_menu->addAction(tr("&Audio Settings..."), this, &MenuBar::ConfigureAudio);
-  options_menu->addAction(tr("&Controller Settings..."), this, &MenuBar::ConfigureControllers);
-  options_menu->addAction(tr("&Hotkey Settings..."), this, &MenuBar::ConfigureHotkeys);
+  options_menu->addAction(tr("&Graphics Settings"), this, &MenuBar::ConfigureGraphics);
+  options_menu->addAction(tr("&Audio Settings"), this, &MenuBar::ConfigureAudio);
+  options_menu->addAction(tr("&Controller Settings"), this, &MenuBar::ConfigureControllers);
+  options_menu->addAction(tr("&Hotkey Settings"), this, &MenuBar::ConfigureHotkeys);
 }
 
 void MenuBar::AddHelpMenu()

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -228,9 +228,11 @@ void MenuBar::AddHelpMenu()
 
 void MenuBar::AddGameListTypeSection(QMenu* view_menu)
 {
+  // i18n: When this option is enabled, the game list is displayed as a table
   QAction* table_view = view_menu->addAction(tr("Table"));
   table_view->setCheckable(true);
 
+  // i18n: When this option is enabled, the game list is displayed as a list
   QAction* list_view = view_menu->addAction(tr("List"));
   list_view->setCheckable(true);
 

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
@@ -100,7 +100,7 @@ void GeneralPane::CreateBasic()
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
 void GeneralPane::CreateAnalytics()
 {
-  auto* analytics_group = new QGroupBox(tr("Usage Statistics Reporting"));
+  auto* analytics_group = new QGroupBox(tr("Usage Statistics Reporting Settings"));
   auto* analytics_group_layout = new QVBoxLayout;
   analytics_group->setLayout(analytics_group_layout);
   m_main_layout->addWidget(analytics_group);

--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -70,8 +70,8 @@ void InterfacePane::CreateUI()
   }
 
   // Checkboxes
-  m_checkbox_auto_window = new QCheckBox(tr("Auto Adjust Window Size"));
-  m_checkbox_top_window = new QCheckBox(tr("Keep Dolphin on Top"));
+  m_checkbox_auto_window = new QCheckBox(tr("Auto-Adjust Window Size"));
+  m_checkbox_top_window = new QCheckBox(tr("Keep Window on Top"));
   m_checkbox_render_to_window = new QCheckBox(tr("Render to Main Window"));
   m_checkbox_use_builtin_title_database = new QCheckBox(tr("Use Built-In Database of Game Names"));
   groupbox_layout->addWidget(m_checkbox_auto_window);
@@ -89,7 +89,7 @@ void InterfacePane::CreateInGame()
 
   m_checkbox_confirm_on_stop = new QCheckBox(tr("Confirm on Stop"));
   m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
-  m_checkbox_enable_osd = new QCheckBox(tr("Enable On Screen Messages"));
+  m_checkbox_enable_osd = new QCheckBox(tr("Show On-Screen Messages"));
   m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
   m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
   m_checkbox_hide_mouse = new QCheckBox(tr("Hide Mouse Cursor"));

--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -123,7 +123,7 @@ QGridLayout* PathPane::MakePathsLayout()
           [=] { SConfig::GetInstance().m_strDefaultISO = m_game_edit->text().toStdString(); });
   QPushButton* game_open = new QPushButton;
   connect(game_open, &QPushButton::clicked, this, &PathPane::BrowseDefaultGame);
-  layout->addWidget(new QLabel(tr("Default Game")), 0, 0);
+  layout->addWidget(new QLabel(tr("Default ISO:")), 0, 0);
   layout->addWidget(m_game_edit, 0, 1);
   layout->addWidget(game_open, 0, 2);
 
@@ -132,7 +132,7 @@ QGridLayout* PathPane::MakePathsLayout()
           [=] { SConfig::GetInstance().m_strDVDRoot = m_dvd_edit->text().toStdString(); });
   QPushButton* dvd_open = new QPushButton;
   connect(dvd_open, &QPushButton::clicked, this, &PathPane::BrowseDVDRoot);
-  layout->addWidget(new QLabel(tr("DVD Root")), 1, 0);
+  layout->addWidget(new QLabel(tr("DVD Root:")), 1, 0);
   layout->addWidget(m_dvd_edit, 1, 1);
   layout->addWidget(dvd_open, 1, 2);
 
@@ -141,7 +141,7 @@ QGridLayout* PathPane::MakePathsLayout()
           [=] { SConfig::GetInstance().m_strApploader = m_app_edit->text().toStdString(); });
   QPushButton* app_open = new QPushButton;
   connect(app_open, &QPushButton::clicked, this, &PathPane::BrowseApploader);
-  layout->addWidget(new QLabel(tr("Apploader")), 2, 0);
+  layout->addWidget(new QLabel(tr("Apploader:")), 2, 0);
   layout->addWidget(m_app_edit, 2, 1);
   layout->addWidget(app_open, 2, 2);
 
@@ -150,7 +150,7 @@ QGridLayout* PathPane::MakePathsLayout()
           [=] { SConfig::GetInstance().m_NANDPath = m_nand_edit->text().toStdString(); });
   QPushButton* nand_open = new QPushButton;
   connect(nand_open, &QPushButton::clicked, this, &PathPane::BrowseWiiNAND);
-  layout->addWidget(new QLabel(tr("Wii NAND Root")), 3, 0);
+  layout->addWidget(new QLabel(tr("Wii NAND Root:")), 3, 0);
   layout->addWidget(m_nand_edit, 3, 1);
   layout->addWidget(nand_open, 3, 2);
 

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -72,15 +72,15 @@ void ToolBar::MakeActions()
   m_stop_action = addAction(tr("Stop"), this, &ToolBar::StopPressed);
   widgetForAction(m_stop_action)->setMinimumWidth(button_width);
 
-  m_fullscreen_action = addAction(tr("Full Screen"), this, &ToolBar::FullScreenPressed);
+  m_fullscreen_action = addAction(tr("FullScr"), this, &ToolBar::FullScreenPressed);
   widgetForAction(m_fullscreen_action)->setMinimumWidth(button_width);
 
-  m_screenshot_action = addAction(tr("Screen Shot"), this, &ToolBar::ScreenShotPressed);
+  m_screenshot_action = addAction(tr("ScrShot"), this, &ToolBar::ScreenShotPressed);
   widgetForAction(m_screenshot_action)->setMinimumWidth(button_width);
 
   addSeparator();
 
-  m_config_action = addAction(tr("Settings"), this, &ToolBar::SettingsPressed);
+  m_config_action = addAction(tr("Config"), this, &ToolBar::SettingsPressed);
   widgetForAction(m_config_action)->setMinimumWidth(button_width);
 
   m_graphics_action = addAction(tr("Graphics"), this, &ToolBar::GraphicsPressed);

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
@@ -19,7 +19,7 @@ GCAdapterConfigDiag::GCAdapterConfigDiag(wxWindow* const parent, const wxString&
                                          const int tab_num)
     : wxDialog(parent, wxID_ANY, name), m_pad_id(tab_num)
 {
-  wxCheckBox* const gamecube_rumble = new wxCheckBox(this, wxID_ANY, _("Rumble"));
+  wxCheckBox* const gamecube_rumble = new wxCheckBox(this, wxID_ANY, _("Enable Rumble"));
   gamecube_rumble->SetValue(SConfig::GetInstance().m_AdapterRumble[m_pad_id]);
   gamecube_rumble->Bind(wxEVT_CHECKBOX, &GCAdapterConfigDiag::OnAdapterRumble, this);
 
@@ -27,7 +27,7 @@ GCAdapterConfigDiag::GCAdapterConfigDiag(wxWindow* const parent, const wxString&
   gamecube_konga->SetValue(SConfig::GetInstance().m_AdapterKonga[m_pad_id]);
   gamecube_konga->Bind(wxEVT_CHECKBOX, &GCAdapterConfigDiag::OnAdapterKonga, this);
 
-  m_adapter_status = new wxStaticText(this, wxID_ANY, _("Adapter Not Detected"));
+  m_adapter_status = new wxStaticText(this, wxID_ANY, _("No Adapter Detected"));
 
   if (!GCAdapter::IsDetected())
   {
@@ -75,7 +75,7 @@ void GCAdapterConfigDiag::OnUpdateAdapter(wxCommandEvent& WXUNUSED(event))
     if (GCAdapter::IsDetected())
       m_adapter_status->SetLabelText(_("Adapter Detected"));
     else
-      m_adapter_status->SetLabelText(_("Adapter Not Detected"));
+      m_adapter_status->SetLabelText(_("No Adapter Detected"));
   });
 }
 

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -68,7 +68,7 @@ void GeneralConfigPane::InitializeGUI()
   m_throttler_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_throttler_array_string);
   m_cpu_engine_radiobox =
-      new wxRadioBox(this, wxID_ANY, _("CPU Emulator Engine"), wxDefaultPosition, wxDefaultSize,
+      new wxRadioBox(this, wxID_ANY, _("CPU Emulation Engine"), wxDefaultPosition, wxDefaultSize,
                      m_cpu_engine_array_string, 0, wxRA_SPECIFY_ROWS);
 
   m_dual_core_checkbox->SetToolTip(
@@ -230,5 +230,5 @@ void GeneralConfigPane::OnAnalyticsCheckBoxChanged(wxCommandEvent& event)
 void GeneralConfigPane::OnAnalyticsNewIdButtonClick(wxCommandEvent& event)
 {
   DolphinAnalytics::Instance()->GenerateNewIdentity();
-  wxMessageBox(_("New identity generated."), _("Identity generation"), wxICON_INFORMATION);
+  wxMessageBox(_("New identity generated."), _("Identity Generation"), wxICON_INFORMATION);
 }

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -87,12 +87,12 @@ void InterfaceConfigPane::InitializeGUI()
 
   m_confirm_stop_checkbox = new wxCheckBox(this, wxID_ANY, _("Confirm on Stop"));
   m_panic_handlers_checkbox = new wxCheckBox(this, wxID_ANY, _("Use Panic Handlers"));
-  m_osd_messages_checkbox = new wxCheckBox(this, wxID_ANY, _("On-Screen Display Messages"));
+  m_osd_messages_checkbox = new wxCheckBox(this, wxID_ANY, _("Show On-Screen Messages"));
   m_show_active_title_checkbox =
       new wxCheckBox(this, wxID_ANY, _("Show Active Title in Window Title"));
   m_use_builtin_title_database_checkbox =
       new wxCheckBox(this, wxID_ANY, _("Use Built-In Database of Game Names"));
-  m_pause_focus_lost_checkbox = new wxCheckBox(this, wxID_ANY, _("Pause on Focus Lost"));
+  m_pause_focus_lost_checkbox = new wxCheckBox(this, wxID_ANY, _("Pause on Focus Loss"));
   m_interface_lang_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_interface_lang_strings);
   m_theme_choice = new wxChoice(this, wxID_ANY);

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -442,7 +442,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
         szr_other->Add(CreateCheckBox(page_general, _("Log Render Time to File"),
                                       wxGetTranslation(log_render_time_to_file_desc),
                                       Config::GFX_LOG_RENDER_TIME_TO_FILE));
-        szr_other->Add(CreateCheckBoxRefBool(page_general, _("Auto Adjust Window Size"),
+        szr_other->Add(CreateCheckBoxRefBool(page_general, _("Auto-Adjust Window Size"),
                                              wxGetTranslation(auto_window_size_desc),
                                              SConfig::GetInstance().bRenderWindowAutoSize));
         szr_other->Add(CreateCheckBox(page_general, _("Show NetPlay Messages"),

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -552,7 +552,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
 
     // AF
     {
-      const std::array<wxString, 5> af_choices{{"1x", "2x", "4x", "8x", "16x"}};
+      const std::array<wxString, 5> af_choices{{_("1x"), _("2x"), _("4x"), _("8x"), _("16x")}};
       szr_enh->Add(new wxStaticText(page_enh, wxID_ANY, _("Anisotropic Filtering:")),
                    wxGBPosition(row, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
       szr_enh->Add(CreateChoice(page_enh, Config::GFX_ENHANCE_MAX_ANISOTROPY,

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
@@ -17,12 +17,17 @@
 
 namespace ControllerEmu
 {
-Slider::Slider(const std::string& name_) : ControlGroup(name_, GroupType::Slider)
+Slider::Slider(const std::string& name, const std::string& ui_name)
+    : ControlGroup(name, ui_name, GroupType::Slider)
 {
   controls.emplace_back(std::make_unique<Input>("Left"));
   controls.emplace_back(std::make_unique<Input>("Right"));
 
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
+}
+
+Slider::Slider(const std::string& name) : Slider(name, name)
+{
 }
 
 void Slider::GetState(ControlState* const slider)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
@@ -13,6 +13,7 @@ namespace ControllerEmu
 class Slider : public ControlGroup
 {
 public:
+  Slider(const std::string& name, const std::string& ui_name);
   explicit Slider(const std::string& name);
 
   void GetState(ControlState* slider);


### PR DESCRIPTION
Without this, we would be pushing a lot of extra strings onto translators now that PR #5812 is merged.

@MayImilae I would like your approval for the fifth commit (`Make DolphinWX strings more like DolphinQt2 strings`) in particular, since it changes some DolphinWX strings that people see often.