### PR TITLE
Add Map/Unmap to AbstractTexture

### DIFF
--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -46,7 +46,8 @@ DXGI_FORMAT GetDXGIFormatForHostFormat(AbstractTextureFormat format)
 }
 }  // Anonymous namespace
 
-DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_config)
+DXTexture::DXTexture(const TextureConfig& tex_config)
+    : AbstractTexture(tex_config), m_staging_texture(nullptr)
 {
   DXGI_FORMAT dxgi_format = GetDXGIFormatForHostFormat(m_config.format);
   if (m_config.rendertarget)
@@ -80,6 +81,7 @@ DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_conf
 DXTexture::~DXTexture()
 {
   m_texture->Release();
+  SAFE_RELEASE(m_staging_texture);
 }
 
 D3DTexture2D* DXTexture::GetRawTexIdentifier() const
@@ -92,48 +94,72 @@ void DXTexture::Bind(unsigned int stage)
   D3D::stateman->SetTexture(stage, m_texture->GetSRV());
 }
 
-bool DXTexture::Save(const std::string& filename, unsigned int level)
+std::optional<AbstractTexture::RawTextureInfo> DXTexture::MapFullImpl()
 {
-  // We can't dump compressed textures currently (it would mean drawing them to a RGBA8
-  // framebuffer, and saving that). TextureCache does not call Save for custom textures
-  // anyway, so this is fine for now.
-  _assert_(m_config.format == AbstractTextureFormat::RGBA8);
+  CD3D11_TEXTURE2D_DESC staging_texture_desc(DXGI_FORMAT_R8G8B8A8_UNORM, m_config.width,
+                                             m_config.height, 1, 1, 0, D3D11_USAGE_STAGING,
+                                             D3D11_CPU_ACCESS_READ);
 
-  // Create a staging/readback texture with the dimensions of the specified mip level.
-  u32 mip_width = std::max(m_config.width >> level, 1u);
-  u32 mip_height = std::max(m_config.height >> level, 1u);
-  CD3D11_TEXTURE2D_DESC staging_texture_desc(DXGI_FORMAT_R8G8B8A8_UNORM, mip_width, mip_height, 1,
-                                             1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-
-  ID3D11Texture2D* staging_texture;
-  HRESULT hr = D3D::device->CreateTexture2D(&staging_texture_desc, nullptr, &staging_texture);
+  HRESULT hr = D3D::device->CreateTexture2D(&staging_texture_desc, nullptr, &m_staging_texture);
   if (FAILED(hr))
   {
     WARN_LOG(VIDEO, "Failed to create texture dumping readback texture: %X", static_cast<u32>(hr));
-    return false;
+    return {};
   }
 
-  // Copy the selected mip level to the staging texture.
-  CD3D11_BOX src_box(0, 0, 0, mip_width, mip_height, 1);
-  D3D::context->CopySubresourceRegion(staging_texture, 0, 0, 0, 0, m_texture->GetTex(),
+  // Copy the selected data to the staging texture
+  D3D::context->CopyResource(m_staging_texture, m_texture->GetTex());
+
+  // Map the staging texture to client memory, and encode it as a .png image.
+  D3D11_MAPPED_SUBRESOURCE map;
+  hr = D3D::context->Map(m_staging_texture, 0, D3D11_MAP_READ, 0, &map);
+  if (FAILED(hr))
+  {
+    WARN_LOG(VIDEO, "Failed to map texture dumping readback texture: %X", static_cast<u32>(hr));
+    return {};
+  }
+
+  return AbstractTexture::RawTextureInfo{reinterpret_cast<u8*>(map.pData), map.RowPitch,
+                                         m_config.width, m_config.height};
+}
+
+std::optional<AbstractTexture::RawTextureInfo> DXTexture::MapRegionImpl(u32 level, u32 x, u32 y,
+                                                                        u32 width, u32 height)
+{
+  CD3D11_TEXTURE2D_DESC staging_texture_desc(DXGI_FORMAT_R8G8B8A8_UNORM, width, height, 1, 1, 0,
+                                             D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
+
+  HRESULT hr = D3D::device->CreateTexture2D(&staging_texture_desc, nullptr, &m_staging_texture);
+  if (FAILED(hr))
+  {
+    WARN_LOG(VIDEO, "Failed to create texture dumping readback texture: %X", static_cast<u32>(hr));
+    return {};
+  }
+
+  // Copy the selected data to the staging texture
+  CD3D11_BOX src_box(x, y, 0, width, height, 1);
+  D3D::context->CopySubresourceRegion(m_staging_texture, 0, 0, 0, 0, m_texture->GetTex(),
                                       D3D11CalcSubresource(level, 0, m_config.levels), &src_box);
 
   // Map the staging texture to client memory, and encode it as a .png image.
   D3D11_MAPPED_SUBRESOURCE map;
-  hr = D3D::context->Map(staging_texture, 0, D3D11_MAP_READ, 0, &map);
+  hr = D3D::context->Map(m_staging_texture, 0, D3D11_MAP_READ, 0, &map);
   if (FAILED(hr))
   {
     WARN_LOG(VIDEO, "Failed to map texture dumping readback texture: %X", static_cast<u32>(hr));
-    staging_texture->Release();
-    return false;
+    return {};
   }
 
-  bool encode_result =
-      TextureToPng(reinterpret_cast<u8*>(map.pData), map.RowPitch, filename, mip_width, mip_height);
-  D3D::context->Unmap(staging_texture, 0);
-  staging_texture->Release();
+  return AbstractTexture::RawTextureInfo{reinterpret_cast<u8*>(map.pData), map.RowPitch,
+                                         m_config.width, m_config.height};
+}
 
-  return encode_result;
+void DXTexture::Unmap()
+{
+  if (m_staging_texture)
+  {
+    D3D::context->Unmap(m_staging_texture, 0);
+  }
 }
 
 void DXTexture::CopyRectangleFromTexture(const AbstractTexture* source,

--- a/Source/Core/VideoBackends/D3D/DXTexture.h
+++ b/Source/Core/VideoBackends/D3D/DXTexture.h
@@ -19,7 +19,7 @@ public:
   ~DXTexture();
 
   void Bind(unsigned int stage) override;
-  bool Save(const std::string& filename, unsigned int level) override;
+  void Unmap() override;
 
   void CopyRectangleFromTexture(const AbstractTexture* source,
                                 const MathUtil::Rectangle<int>& srcrect,
@@ -30,7 +30,12 @@ public:
   D3DTexture2D* GetRawTexIdentifier() const;
 
 private:
+  std::optional<RawTextureInfo> MapFullImpl() override;
+  std::optional<RawTextureInfo> MapRegionImpl(u32 level, u32 x, u32 y, u32 width,
+                                              u32 height) override;
+
   D3DTexture2D* m_texture;
+  ID3D11Texture2D* m_staging_texture;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -4,6 +4,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/GL/GLExtensions/GLExtensions.h"
 #include "Common/GL/GLInterfaceBase.h"
 #include "Common/MsgHandler.h"
 
@@ -65,22 +66,6 @@ GLenum GetGLTypeForTextureFormat(AbstractTextureFormat format)
   }
 }
 }  // Anonymous namespace
-
-bool SaveTexture(const std::string& filename, u32 textarget, u32 tex, int virtual_width,
-                 int virtual_height, unsigned int level)
-{
-  if (GLInterface->GetMode() != GLInterfaceMode::MODE_OPENGL)
-    return false;
-  int width = std::max(virtual_width >> level, 1);
-  int height = std::max(virtual_height >> level, 1);
-  std::vector<u8> data(width * height * 4);
-  glActiveTexture(GL_TEXTURE9);
-  glBindTexture(textarget, tex);
-  glGetTexImage(textarget, level, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
-  OGLTexture::SetStage();
-
-  return TextureToPng(data.data(), width * 4, filename, width, height, true);
-}
 
 OGLTexture::OGLTexture(const TextureConfig& tex_config) : AbstractTexture(tex_config)
 {
@@ -164,15 +149,44 @@ void OGLTexture::Bind(unsigned int stage)
   }
 }
 
-bool OGLTexture::Save(const std::string& filename, unsigned int level)
+std::optional<AbstractTexture::RawTextureInfo> OGLTexture::MapFullImpl()
 {
-  // We can't dump compressed textures currently (it would mean drawing them to a RGBA8
-  // framebuffer, and saving that). TextureCache does not call Save for custom textures
-  // anyway, so this is fine for now.
-  _assert_(m_config.format == AbstractTextureFormat::RGBA8);
+  if (GLInterface->GetMode() != GLInterfaceMode::MODE_OPENGL)
+    return {};
 
-  return SaveTexture(filename, GL_TEXTURE_2D_ARRAY, m_texId, m_config.width, m_config.height,
-                     level);
+  m_staging_data.reserve(m_config.width * m_config.height * 4);
+  glActiveTexture(GL_TEXTURE9);
+
+  glBindTexture(GL_TEXTURE_2D_ARRAY, m_texId);
+  glGetTexImage(GL_TEXTURE_2D_ARRAY, 0, GL_RGBA, GL_UNSIGNED_BYTE, m_staging_data.data());
+  OGLTexture::SetStage();
+  return AbstractTexture::RawTextureInfo{reinterpret_cast<u8*>(m_staging_data.data()),
+                                         m_config.width * 4, m_config.width, m_config.height};
+}
+
+std::optional<AbstractTexture::RawTextureInfo> OGLTexture::MapRegionImpl(u32 level, u32 x, u32 y,
+                                                                         u32 width, u32 height)
+{
+  if (GLInterface->GetMode() != GLInterfaceMode::MODE_OPENGL)
+    return {};
+  m_staging_data.reserve(m_config.width * m_config.height * 4);
+  glActiveTexture(GL_TEXTURE9);
+  glBindTexture(GL_TEXTURE_2D_ARRAY, m_texId);
+  u8* data_location;
+  if (GLExtensions::Version() >= 450)
+  {
+    glGetTextureSubImage(GL_TEXTURE_2D_ARRAY, level, GLint(x), GLint(y), 0, GLsizei(width),
+                         GLsizei(height), 0, GL_RGBA, GL_UNSIGNED_BYTE, GLsizei(width * height * 4),
+                         m_staging_data.data());
+    data_location = m_staging_data.data();
+  }
+  else
+  {
+    // TODO: implement 'slow' path for users without 4.5
+    return {};
+  }
+  OGLTexture::SetStage();
+  return AbstractTexture::RawTextureInfo{data_location, width * 4, width, height};
 }
 
 void OGLTexture::CopyRectangleFromTexture(const AbstractTexture* source,

--- a/Source/Core/VideoBackends/OGL/OGLTexture.h
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.h
@@ -17,7 +17,6 @@ public:
   ~OGLTexture();
 
   void Bind(unsigned int stage) override;
-  bool Save(const std::string& filename, unsigned int level) override;
 
   void CopyRectangleFromTexture(const AbstractTexture* source,
                                 const MathUtil::Rectangle<int>& srcrect,
@@ -32,8 +31,12 @@ public:
   static void SetStage();
 
 private:
+  std::optional<RawTextureInfo> MapFullImpl() override;
+  std::optional<RawTextureInfo> MapRegionImpl(u32 level, u32 x, u32 y, u32 width,
+                                              u32 height) override;
   GLuint m_texId;
   GLuint m_framebuffer = 0;
+  std::vector<u8> m_staging_data;
 };
 
 }  // namespace OGL

--- a/Source/Core/VideoBackends/OGL/OGLTexture.h
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.h
@@ -34,6 +34,8 @@ private:
   std::optional<RawTextureInfo> MapFullImpl() override;
   std::optional<RawTextureInfo> MapRegionImpl(u32 level, u32 x, u32 y, u32 width,
                                               u32 height) override;
+  void MapRegionSlow(u32 level, u32 x, u32 y, u32 width, u32 height);
+
   GLuint m_texId;
   GLuint m_framebuffer = 0;
   std::vector<u8> m_staging_data;

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -20,7 +20,7 @@ public:
   ~VKTexture();
 
   void Bind(unsigned int stage) override;
-  bool Save(const std::string& filename, unsigned int level) override;
+  void Unmap() override;
 
   void CopyRectangleFromTexture(const AbstractTexture* source,
                                 const MathUtil::Rectangle<int>& srcrect,
@@ -47,7 +47,12 @@ private:
   void ScaleTextureRectangle(const MathUtil::Rectangle<int>& dst_rect, Texture2D* src_texture,
                              const MathUtil::Rectangle<int>& src_rect);
 
+  std::optional<RawTextureInfo> MapFullImpl() override;
+  std::optional<RawTextureInfo> MapRegionImpl(u32 level, u32 x, u32 y, u32 width,
+                                              u32 height) override;
+
   std::unique_ptr<Texture2D> m_texture;
+  std::unique_ptr<StagingTexture2D> m_stagingTexture;
   VkFramebuffer m_framebuffer;
 };
 

--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -4,9 +4,12 @@
 
 #include <algorithm>
 
-#include "VideoCommon/AbstractTexture.h"
+#include "Common/Assert.h"
 
-AbstractTexture::AbstractTexture(const TextureConfig& c) : m_config(c)
+#include "VideoCommon/AbstractTexture.h"
+#include "VideoCommon/ImageWrite.h"
+
+AbstractTexture::AbstractTexture(const TextureConfig& c) : m_config(c), m_currently_mapped(false)
 {
 }
 
@@ -14,7 +17,87 @@ AbstractTexture::~AbstractTexture() = default;
 
 bool AbstractTexture::Save(const std::string& filename, unsigned int level)
 {
-  return false;
+  // We can't dump compressed textures currently (it would mean drawing them to a RGBA8
+  // framebuffer, and saving that). TextureCache does not call Save for custom textures
+  // anyway, so this is fine for now.
+  _assert_(m_config.format == AbstractTextureFormat::RGBA8);
+
+  auto result = level == 0 ? Map() : Map(level);
+
+  if (!result.has_value())
+  {
+    return false;
+  }
+
+  auto raw_data = result.value();
+  return TextureToPng(raw_data.data, raw_data.stride, filename, raw_data.width, raw_data.height);
+}
+
+std::optional<AbstractTexture::RawTextureInfo> AbstractTexture::Map()
+{
+  if (m_currently_mapped)
+  {
+    Unmap();
+    m_currently_mapped = false;
+  }
+  auto result = MapFullImpl();
+
+  if (!result.has_value())
+  {
+    m_currently_mapped = false;
+    return {};
+  }
+
+  m_currently_mapped = true;
+  return result;
+}
+
+std::optional<AbstractTexture::RawTextureInfo> AbstractTexture::Map(u32 level, u32 x, u32 y,
+                                                                    u32 width, u32 height)
+{
+  _assert_(level < m_config.levels);
+
+  u32 max_level_width = std::max(m_config.width >> level, 1u);
+  u32 max_level_height = std::max(m_config.height >> level, 1u);
+
+  _assert_(width < max_level_width);
+  _assert_(height < max_level_height);
+
+  auto result = MapRegionImpl(level, x, y, width, height);
+
+  if (!result.has_value())
+  {
+    m_currently_mapped = false;
+    return {};
+  }
+
+  m_currently_mapped = true;
+  return result;
+}
+
+std::optional<AbstractTexture::RawTextureInfo> AbstractTexture::Map(u32 level)
+{
+  _assert_(level < m_config.levels);
+
+  u32 level_width = std::max(m_config.width >> level, 1u);
+  u32 level_height = std::max(m_config.height >> level, 1u);
+
+  return Map(level, 0, 0, level_width, level_height);
+}
+
+void AbstractTexture::Unmap()
+{
+}
+
+std::optional<AbstractTexture::RawTextureInfo> AbstractTexture::MapFullImpl()
+{
+  return {};
+}
+
+std::optional<AbstractTexture::RawTextureInfo>
+AbstractTexture::MapRegionImpl(u32 level, u32 x, u32 y, u32 width, u32 height)
+{
+  return {};
 }
 
 bool AbstractTexture::IsCompressedHostTextureFormat(AbstractTextureFormat format)

--- a/Source/Core/VideoCommon/AbstractTexture.h
+++ b/Source/Core/VideoCommon/AbstractTexture.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -17,7 +18,20 @@ public:
   explicit AbstractTexture(const TextureConfig& c);
   virtual ~AbstractTexture();
   virtual void Bind(unsigned int stage) = 0;
-  virtual bool Save(const std::string& filename, unsigned int level);
+  bool Save(const std::string& filename, unsigned int level);
+
+  struct RawTextureInfo
+  {
+    const u8* data;
+    u32 stride;
+    u32 width;
+    u32 height;
+  };
+
+  std::optional<RawTextureInfo> Map();
+  std::optional<RawTextureInfo> Map(u32 level, u32 x, u32 y, u32 width, u32 height);
+  std::optional<RawTextureInfo> Map(u32 level);
+  virtual void Unmap();
 
   virtual void CopyRectangleFromTexture(const AbstractTexture* source,
                                         const MathUtil::Rectangle<int>& srcrect,
@@ -31,5 +45,10 @@ public:
   const TextureConfig& GetConfig() const;
 
 protected:
+  virtual std::optional<RawTextureInfo> MapFullImpl();
+  virtual std::optional<RawTextureInfo> MapRegionImpl(u32 level, u32 x, u32 y, u32 width,
+                                                      u32 height);
+  bool m_currently_mapped;
+
   const TextureConfig m_config;
 };


### PR DESCRIPTION
This supersedes #5645 by providing a way to Map/Unmap texture data abstractly using AbstractTexture.

This is needed for Hybrid for moving frame dumping / screenshots to video common but will also be used in the future for unifying the backends for EFB operations.