### PR TITLE
DolphinQt: Use Qt 5's signal/slot mechanism where applicable

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -147,19 +147,19 @@ void GameList::ShowContextMenu(const QPoint&)
 
   QMenu* menu = new QMenu(this);
   DiscIO::Platform platform = GameFile(game).GetPlatformID();
-  menu->addAction(tr("Properties"), this, SLOT(OpenProperties()));
-  menu->addAction(tr("Wiki"), this, SLOT(OpenWiki()));
+  menu->addAction(tr("Properties"), this, &GameList::OpenProperties);
+  menu->addAction(tr("Wiki"), this, &GameList::OpenWiki);
   menu->addSeparator();
 
   if (platform == DiscIO::Platform::GAMECUBE_DISC || platform == DiscIO::Platform::WII_DISC)
   {
-    menu->addAction(tr("Default ISO"), this, SLOT(SetDefaultISO()));
+    menu->addAction(tr("Default ISO"), this, &GameList::SetDefaultISO);
     const auto blob_type = GameFile(game).GetBlobType();
 
     if (blob_type == DiscIO::BlobType::GCZ)
-      menu->addAction(tr("Decompress ISO"), this, SLOT(DecompressISO()));
+      menu->addAction(tr("Decompress ISO"), this, &GameList::CompressISO);
     else if (blob_type == DiscIO::BlobType::PLAIN)
-      menu->addAction(tr("Compress ISO"), this, SLOT(CompressISO()));
+      menu->addAction(tr("Compress ISO"), this, &GameList::CompressISO);
 
     menu->addSeparator();
   }
@@ -189,13 +189,13 @@ void GameList::ShowContextMenu(const QPoint&)
 
   if (platform == DiscIO::Platform::WII_WAD || platform == DiscIO::Platform::WII_DISC)
   {
-    menu->addAction(tr("Open Wii save folder"), this, SLOT(OpenSaveFolder()));
-    menu->addAction(tr("Export Wii save (Experimental)"), this, SLOT(ExportWiiSave()));
+    menu->addAction(tr("Open Wii save folder"), this, &GameList::OpenSaveFolder);
+    menu->addAction(tr("Export Wii save (Experimental)"), this, &GameList::ExportWiiSave);
     menu->addSeparator();
   }
 
-  menu->addAction(tr("Open Containing Folder"), this, SLOT(OpenContainingFolder()));
-  menu->addAction(tr("Remove File"), this, SLOT(DeleteFile()));
+  menu->addAction(tr("Open Containing Folder"), this, &GameList::OpenContainingFolder);
+  menu->addAction(tr("Remove File"), this, &GameList::DeleteFile);
   menu->exec(QCursor::pos());
 }
 

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -10,7 +10,6 @@
 #include <QStackedWidget>
 #include <QTableView>
 
-#include "DolphinQt2/GameList/GameFile.h"
 #include "DolphinQt2/GameList/GameListModel.h"
 
 class GameList final : public QStackedWidget
@@ -27,7 +26,12 @@ public slots:
   void SetViewColumn(int col, bool view) { m_table->setColumnHidden(col, !view); }
   void OnColumnVisibilityToggled(const QString& row, bool visible);
 
-private slots:
+signals:
+  void GameSelected();
+  void EmulationStarted();
+  void EmulationStopped();
+
+private:
   void ShowContextMenu(const QPoint&);
   void OpenContainingFolder();
   void OpenProperties();
@@ -41,12 +45,6 @@ private slots:
   void CompressISO();
   void OnHeaderViewChanged();
 
-signals:
-  void GameSelected();
-  void EmulationStarted();
-  void EmulationStopped();
-
-private:
   void MakeTableView();
   void MakeListView();
   void MakeEmptyView();

--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <QSortFilterProxyModel>
 
 // This subclass of QSortFilterProxyModel transforms the raw data into a

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -77,14 +77,14 @@ void MenuBar::EmulationStopped()
 void MenuBar::AddFileMenu()
 {
   QMenu* file_menu = addMenu(tr("File"));
-  m_open_action = file_menu->addAction(tr("Open"), this, SIGNAL(Open()));
-  m_exit_action = file_menu->addAction(tr("Exit"), this, SIGNAL(Exit()));
+  m_open_action = file_menu->addAction(tr("Open"), this, &MenuBar::Open);
+  m_exit_action = file_menu->addAction(tr("Exit"), this, &MenuBar::Exit);
 }
 
 void MenuBar::AddToolsMenu()
 {
   QMenu* tools_menu = addMenu(tr("Tools"));
-  m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, SLOT(InstallWAD()));
+  m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, &MenuBar::InstallWAD);
 
   // Label will be set by a NANDRefresh later
   m_boot_sysmenu = tools_menu->addAction(QStringLiteral(""), [this] { emit BootWiiSystemMenu(); });
@@ -107,13 +107,13 @@ void MenuBar::AddToolsMenu()
 void MenuBar::AddEmulationMenu()
 {
   QMenu* emu_menu = addMenu(tr("Emulation"));
-  m_play_action = emu_menu->addAction(tr("Play"), this, SIGNAL(Play()));
-  m_pause_action = emu_menu->addAction(tr("Pause"), this, SIGNAL(Pause()));
-  m_stop_action = emu_menu->addAction(tr("Stop"), this, SIGNAL(Stop()));
-  m_reset_action = emu_menu->addAction(tr("Reset"), this, SIGNAL(Reset()));
-  m_fullscreen_action = emu_menu->addAction(tr("Fullscreen"), this, SIGNAL(Fullscreen()));
-  m_frame_advance_action = emu_menu->addAction(tr("Frame Advance"), this, SIGNAL(FrameAdvance()));
-  m_screenshot_action = emu_menu->addAction(tr("Take Screenshot"), this, SIGNAL(Screenshot()));
+  m_play_action = emu_menu->addAction(tr("Play"), this, &MenuBar::Play);
+  m_pause_action = emu_menu->addAction(tr("Pause"), this, &MenuBar::Pause);
+  m_stop_action = emu_menu->addAction(tr("Stop"), this, &MenuBar::Stop);
+  m_reset_action = emu_menu->addAction(tr("Reset"), this, &MenuBar::Reset);
+  m_fullscreen_action = emu_menu->addAction(tr("Fullscreen"), this, &MenuBar::Fullscreen);
+  m_frame_advance_action = emu_menu->addAction(tr("Frame Advance"), this, &MenuBar::FrameAdvance);
+  m_screenshot_action = emu_menu->addAction(tr("Take Screenshot"), this, &MenuBar::Screenshot);
   AddStateLoadMenu(emu_menu);
   AddStateSaveMenu(emu_menu);
   AddStateSlotMenu(emu_menu);
@@ -123,10 +123,10 @@ void MenuBar::AddEmulationMenu()
 void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 {
   m_state_load_menu = emu_menu->addMenu(tr("Load State"));
-  m_state_load_menu->addAction(tr("Load State from File"), this, SIGNAL(StateLoad()));
-  m_state_load_menu->addAction(tr("Load State from Selected Slot"), this, SIGNAL(StateLoadSlot()));
+  m_state_load_menu->addAction(tr("Load State from File"), this, &MenuBar::StateLoad);
+  m_state_load_menu->addAction(tr("Load State from Selected Slot"), this, &MenuBar::StateLoadSlot);
   m_state_load_slots_menu = m_state_load_menu->addMenu(tr("Load State from Slot"));
-  m_state_load_menu->addAction(tr("Undo Load State"), this, SIGNAL(StateLoadUndo()));
+  m_state_load_menu->addAction(tr("Undo Load State"), this, &MenuBar::StateLoadUndo);
 
   for (int i = 1; i <= 10; i++)
   {
@@ -139,11 +139,11 @@ void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 void MenuBar::AddStateSaveMenu(QMenu* emu_menu)
 {
   m_state_save_menu = emu_menu->addMenu(tr("Save State"));
-  m_state_save_menu->addAction(tr("Save State to File"), this, SIGNAL(StateSave()));
-  m_state_save_menu->addAction(tr("Save State to Selected Slot"), this, SIGNAL(StateSaveSlot()));
-  m_state_save_menu->addAction(tr("Save State to Oldest Slot"), this, SIGNAL(StateSaveOldest()));
+  m_state_save_menu->addAction(tr("Save State to File"), this, &MenuBar::StateSave);
+  m_state_save_menu->addAction(tr("Save State to Selected Slot"), this, &MenuBar::StateSaveSlot);
+  m_state_save_menu->addAction(tr("Save State to Oldest Slot"), this, &MenuBar::StateSaveOldest);
   m_state_save_slots_menu = m_state_save_menu->addMenu(tr("Save State to Slot"));
-  m_state_save_menu->addAction(tr("Undo Save State"), this, SIGNAL(StateSaveUndo()));
+  m_state_save_menu->addAction(tr("Undo Save State"), this, &MenuBar::StateSaveUndo);
 
   for (int i = 1; i <= 10; i++)
   {
@@ -221,7 +221,7 @@ void MenuBar::AddHelpMenu()
 
   help_menu->addSeparator();
 
-  help_menu->addAction(tr("About"), this, SIGNAL(ShowAboutDialog()));
+  help_menu->addAction(tr("About"), this, &MenuBar::ShowAboutDialog);
 }
 
 void MenuBar::AddGameListTypeSection(QMenu* view_menu)


### PR DESCRIPTION
Allows compile-time checking to be done on supplied function types.

Also fixes an issue relating to ISO decompression which is explained more in detail within the first commit.