### PR TITLE
Add "PreferGLES" option to EGL GLInterface

### DIFF
--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/GL/GLInterface/EGL.h"
 #include "Common/Logging/Log.h"
+#include "Core/Config/GraphicsSettings.h"
 
 #ifndef EGL_KHR_create_context
 #define EGL_KHR_create_context 1
@@ -47,6 +48,7 @@ void cInterfaceEGL::DetectMode()
 {
   if (s_opengl_mode != GLInterfaceMode::MODE_DETECT)
     return;
+  bool preferGLES = Config::Get(Config::GFX_PREFER_GLES);
 
   EGLint num_configs;
   bool supportsGL = false, supportsGLES2 = false, supportsGLES3 = false;
@@ -98,15 +100,45 @@ void cInterfaceEGL::DetectMode()
     delete[] config;
   }
 
-  if (supportsGL)
-    s_opengl_mode = GLInterfaceMode::MODE_OPENGL;
-  else if (supportsGLES3)
-    s_opengl_mode = GLInterfaceMode::MODE_OPENGLES3;
-  else if (supportsGLES2)
-    s_opengl_mode = GLInterfaceMode::MODE_OPENGLES2;
+  if (preferGLES)
+  {
+    if (supportsGLES3)
+      s_opengl_mode = GLInterfaceMode::MODE_OPENGLES3;
+    else if (supportsGLES2)
+      s_opengl_mode = GLInterfaceMode::MODE_OPENGLES2;
+    else if (supportsGL)
+      s_opengl_mode = GLInterfaceMode::MODE_OPENGL;
+  }
+  else
+  {
+    if (supportsGL)
+      s_opengl_mode = GLInterfaceMode::MODE_OPENGL;
+    else if (supportsGLES3)
+      s_opengl_mode = GLInterfaceMode::MODE_OPENGLES3;
+    else if (supportsGLES2)
+      s_opengl_mode = GLInterfaceMode::MODE_OPENGLES2;
+  }
 
-  if (s_opengl_mode == GLInterfaceMode::MODE_DETECT)  // Errored before we found a mode
-    s_opengl_mode = GLInterfaceMode::MODE_OPENGL;     // Fall back to OpenGL
+  if (s_opengl_mode == GLInterfaceMode::MODE_OPENGL)
+  {
+    INFO_LOG(VIDEO, "Using OpenGL");
+  }
+  else if (s_opengl_mode == GLInterfaceMode::MODE_OPENGLES3)
+  {
+    INFO_LOG(VIDEO, "Using OpenGL|ES 3");
+  }
+  else if (s_opengl_mode == GLInterfaceMode::MODE_OPENGLES2)
+  {
+    INFO_LOG(VIDEO, "Using OpenGL|ES 2");
+  }
+  else if (s_opengl_mode == GLInterfaceMode::MODE_DETECT)
+  {
+    // Errored before we found a mode
+    ERROR_LOG(VIDEO, "Error: Failed to detect OpenGL flavour, falling back to OpenGL");
+    // This will fail to create a context, as it'll try to use the same attribs we just failed to
+    // find a matching config with
+    s_opengl_mode = GLInterfaceMode::MODE_OPENGL;
+  }
 }
 
 // Create rendering window.

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -87,6 +87,8 @@ const ConfigInfo<bool> GFX_SW_DUMP_TEV_TEX_FETCHES{{System::GFX, "Settings", "SW
 const ConfigInfo<int> GFX_SW_DRAW_START{{System::GFX, "Settings", "SWDrawStart"}, 0};
 const ConfigInfo<int> GFX_SW_DRAW_END{{System::GFX, "Settings", "SWDrawEnd"}, 100000};
 
+const ConfigInfo<bool> GFX_PREFER_GLES{{System::GFX, "Settings", "PreferGLES"}, false};
+
 // Graphics.Enhancements
 
 const ConfigInfo<bool> GFX_ENHANCE_FORCE_FILTERING{{System::GFX, "Enhancements", "ForceFiltering"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -68,6 +68,8 @@ extern const ConfigInfo<bool> GFX_SW_DUMP_TEV_TEX_FETCHES;
 extern const ConfigInfo<int> GFX_SW_DRAW_START;
 extern const ConfigInfo<int> GFX_SW_DRAW_END;
 
+extern const ConfigInfo<bool> GFX_PREFER_GLES;
+
 // Graphics.Enhancements
 
 extern const ConfigInfo<bool> GFX_ENHANCE_FORCE_FILTERING;


### PR DESCRIPTION
This makes the EGL interface select OpenGL|ES contexts over "desktop"
OpenGL ones, if the "PreferGLES" option is set to True in GFX.ini's [Settings] section.

It's been useful for me for debugging, and others may find it useful too.

