### PR TITLE
Force ticket to have a correct key index for importing

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -463,6 +463,13 @@ HLE::ReturnCode TicketReader::Unpersonalise(HLE::IOSC& iosc)
   return ret;
 }
 
+void TicketReader::FixCommonKeyIndex()
+{
+  u8& index = m_bytes[offsetof(Ticket, common_key_index)];
+  // Assume the ticket is using the normal common key if it's an invalid value.
+  index = index <= 1 ? index : 0;
+}
+
 struct SharedContentMap::Entry
 {
   // ID string

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -238,6 +238,10 @@ public:
   // Decrypts the title key field for a "personalised" ticket -- one that is device-specific
   // and has a title key that must be decrypted first.
   HLE::ReturnCode Unpersonalise(HLE::IOSC& iosc);
+
+  // Reset the common key field back to 0 if it's an incorrect value.
+  // Intended for use before importing fakesigned tickets, which tend to have a high bogus index.
+  void FixCommonKeyIndex();
 };
 
 class SharedContentMap final

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -54,7 +54,12 @@ bool InstallWAD(const std::string& wad_path)
   IOS::HLE::Device::ES::Context context;
   IOS::HLE::ReturnCode ret;
   const bool checks_enabled = SConfig::GetInstance().m_enable_signature_checks;
-  while ((ret = es->ImportTicket(wad.GetTicket().GetBytes(), wad.GetCertificateChain())) < 0 ||
+
+  IOS::ES::TicketReader ticket = wad.GetTicket();
+  // Ensure the common key index is correct, as it's checked by IOS.
+  ticket.FixCommonKeyIndex();
+
+  while ((ret = es->ImportTicket(ticket.GetBytes(), wad.GetCertificateChain())) < 0 ||
          (ret = es->ImportTitleInit(context, tmd.GetBytes(), wad.GetCertificateChain())) < 0)
   {
     if (checks_enabled && ret == IOS::HLE::IOSC_FAIL_CHECKVALUE &&


### PR DESCRIPTION
This commit changes the import code to ensure the common key index in the ticket is correct, as it's checked by IOS.