### PR TITLE
SysConf: Add explicit to single-argument constructor

### DIFF
--- a/Source/Core/Common/SysConf.h
+++ b/Source/Core/Common/SysConf.h
@@ -17,7 +17,7 @@
 class SysConf final
 {
 public:
-  SysConf(Common::FromWhichRoot root_type);
+  explicit SysConf(Common::FromWhichRoot root_type);
   ~SysConf();
 
   void Clear();


### PR DESCRIPTION
Prevents implicit construction from FromWhichRoot values.

As simple as it gets, diff-wise.