### PR TITLE
Video: Clearly separate Texture and EFB Copy formats

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -32,12 +32,12 @@ public:
 
   void Init();
   void Shutdown();
-  void Encode(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
-              u32 num_blocks_y, u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
+  void Encode(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+              u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
               bool scale_by_half);
 
 private:
-  ID3D11PixelShader* GetEncodingPixelShader(const EFBCopyFormat& format);
+  ID3D11PixelShader* GetEncodingPixelShader(const EFBCopyParams& params);
 
   bool m_ready;
 
@@ -45,6 +45,6 @@ private:
   ID3D11RenderTargetView* m_outRTV;
   ID3D11Texture2D* m_outStage;
   ID3D11Buffer* m_encodeParams;
-  std::map<EFBCopyFormat, ID3D11PixelShader*> m_encoding_shaders;
+  std::map<EFBCopyParams, ID3D11PixelShader*> m_encoding_shaders;
 };
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -38,12 +38,12 @@ std::unique_ptr<AbstractTexture> TextureCache::CreateTexture(const TextureConfig
   return std::make_unique<DXTexture>(config);
 }
 
-void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width,
+void TextureCache::CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width,
                            u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                           bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
+                           const EFBRectangle& src_rect, bool scale_by_half)
 {
-  g_encoder->Encode(dst, format, native_width, bytes_per_row, num_blocks_y, memory_stride,
-                    is_depth_copy, src_rect, scale_by_half);
+  g_encoder->Encode(dst, params, native_width, bytes_per_row, num_blocks_y, memory_stride, src_rect,
+                    scale_by_half);
 }
 
 const char palette_shader[] =
@@ -126,8 +126,8 @@ void main(
 }
 )HLSL";
 
-void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source, void* palette,
-                                  TlutFormat format)
+void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
+                                  const void* palette, TLUTFormat format)
 {
   DXTexture* source_texture = static_cast<DXTexture*>(source->texture.get());
   DXTexture* destination_texture = static_cast<DXTexture*>(destination->texture.get());
@@ -144,7 +144,7 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
   D3D::stateman->SetTexture(1, palette_buf_srv);
 
   // TODO: Add support for C14X2 format.  (Different multiplier, more palette entries.)
-  float params[4] = {(source->format & 0xf) == GX_TF_I4 ? 15.f : 255.f};
+  float params[4] = {source->format == TextureFormat::I4 ? 15.f : 255.f};
   D3D::context->UpdateSubresource(palette_uniform, 0, nullptr, &params, 0, 0);
   D3D::stateman->SetPixelConstants(palette_uniform);
 
@@ -163,8 +163,9 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
   // Create texture copy
   D3D::drawShadedTexQuad(
       source_texture->GetRawTexIdentifier()->GetSRV(), &sourcerect, source->GetWidth(),
-      source->GetHeight(), palette_pixel_shader[format], VertexShaderCache::GetSimpleVertexShader(),
-      VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
+      source->GetHeight(), palette_pixel_shader[static_cast<int>(format)],
+      VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
+      GeometryShaderCache::GetCopyGeometryShader());
 
   D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
                                    FramebufferManager::GetEFBDepthTexture()->GetDSV());
@@ -190,9 +191,9 @@ TextureCache::TextureCache()
   palette_buf = nullptr;
   palette_buf_srv = nullptr;
   palette_uniform = nullptr;
-  palette_pixel_shader[GX_TL_IA8] = GetConvertShader("IA8");
-  palette_pixel_shader[GX_TL_RGB565] = GetConvertShader("RGB565");
-  palette_pixel_shader[GX_TL_RGB5A3] = GetConvertShader("RGB5A3");
+  palette_pixel_shader[static_cast<int>(TLUTFormat::IA8)] = GetConvertShader("IA8");
+  palette_pixel_shader[static_cast<int>(TLUTFormat::RGB565)] = GetConvertShader("RGB565");
+  palette_pixel_shader[static_cast<int>(TLUTFormat::RGB5A3)] = GetConvertShader("RGB5A3");
   auto lutBd = CD3D11_BUFFER_DESC(sizeof(u16) * 256, D3D11_BIND_SHADER_RESOURCE);
   HRESULT hr = D3D::device->CreateBuffer(&lutBd, nullptr, &palette_buf);
   CHECK(SUCCEEDED(hr), "create palette decoder lut buffer");

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -28,12 +28,12 @@ private:
     return 0;
   };
 
-  void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, void* palette,
-                      TlutFormat format) override;
+  void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
+                      TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-               const EFBRectangle& src_rect, bool scale_by_half) override;
+  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+               bool scale_by_half) override;
 
   void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy, const EFBRectangle& src_rect,
                            bool scale_by_half, unsigned int cbuf_id, const float* colmat) override;

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -20,14 +20,14 @@ public:
   ~TextureCache() {}
   bool CompileShaders() override { return true; }
   void DeleteShaders() override {}
-  void ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, void* palette,
-                      TlutFormat format) override
+  void ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, const void* palette,
+                      TLUTFormat format) override
   {
   }
 
-  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-               const EFBRectangle& src_rect, bool scale_by_half) override
+  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+               bool scale_by_half) override
   {
   }
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -26,23 +26,23 @@ public:
 
   static TextureCache* GetInstance();
 
-  bool SupportsGPUTextureDecode(TextureFormat format, TlutFormat palette_format) override;
+  bool SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format) override;
   void DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, const u8* data, size_t data_size,
                           TextureFormat format, u32 width, u32 height, u32 aligned_width,
                           u32 aligned_height, u32 row_stride, const u8* palette,
-                          TlutFormat palette_format) override;
+                          TLUTFormat palette_format) override;
 
   const SHADER& GetColorCopyProgram() const;
   GLuint GetColorCopyPositionUniform() const;
 
 private:
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
-  void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, void* palette,
-                      TlutFormat format) override;
+  void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
+                      TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-               const EFBRectangle& src_rect, bool scale_by_half) override;
+  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+               bool scale_by_half) override;
 
   void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy, const EFBRectangle& src_rect,
                            bool scale_by_half, unsigned int cbuf_id, const float* colmat) override;

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -51,7 +51,7 @@ struct EncodingProgram
   SHADER program;
   GLint copy_position_uniform;
 };
-static std::map<EFBCopyFormat, EncodingProgram> s_encoding_programs;
+static std::map<EFBCopyParams, EncodingProgram> s_encoding_programs;
 
 static GLuint s_PBO = 0;  // for readback with different strides
 
@@ -136,13 +136,13 @@ static void CreatePrograms()
   ProgramShaderCache::CompileShader(s_yuyvToRgbProgram, VProgramYuyvToRgb, FProgramYuyvToRgb);
 }
 
-static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyFormat& format)
+static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyParams& params)
 {
-  auto iter = s_encoding_programs.find(format);
+  auto iter = s_encoding_programs.find(params);
   if (iter != s_encoding_programs.end())
     return iter->second;
 
-  const char* shader = TextureConversionShader::GenerateEncodingShader(format, APIType::OpenGL);
+  const char* shader = TextureConversionShader::GenerateEncodingShader(params, APIType::OpenGL);
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   if (g_ActiveConfig.iLog & CONF_SAVESHADERS && shader)
@@ -166,7 +166,7 @@ static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyFormat& format)
     PanicAlert("Failed to compile texture encoding shader.");
 
   program.copy_position_uniform = glGetUniformLocation(program.program.glprogid, "position");
-  return s_encoding_programs.emplace(format, program).first->second;
+  return s_encoding_programs.emplace(params, program).first->second;
 }
 
 void Init()
@@ -271,24 +271,24 @@ static void EncodeToRamUsingShader(GLuint srcTexture, u8* destAddr, u32 dst_line
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 }
 
-void EncodeToRamFromTexture(u8* dest_ptr, const EFBCopyFormat& format, u32 native_width,
+void EncodeToRamFromTexture(u8* dest_ptr, const EFBCopyParams& params, u32 native_width,
                             u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                            bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
+                            const EFBRectangle& src_rect, bool scale_by_half)
 {
   g_renderer->ResetAPIState();
 
-  EncodingProgram& texconv_shader = GetOrCreateEncodingShader(format);
+  EncodingProgram& texconv_shader = GetOrCreateEncodingShader(params);
 
   texconv_shader.program.Bind();
   glUniform4i(texconv_shader.copy_position_uniform, src_rect.left, src_rect.top, native_width,
               scale_by_half ? 2 : 1);
 
-  const GLuint read_texture = is_depth_copy ?
+  const GLuint read_texture = params.depth ?
                                   FramebufferManager::ResolveAndGetDepthTarget(src_rect) :
                                   FramebufferManager::ResolveAndGetRenderTarget(src_rect);
 
   EncodeToRamUsingShader(read_texture, dest_ptr, bytes_per_row, num_blocks_y, memory_stride,
-                         scale_by_half && !is_depth_copy);
+                         scale_by_half && !params.depth);
 
   FramebufferManager::SetFramebuffer(0);
   g_renderer->RestoreAPIState();

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -7,8 +7,9 @@
 #include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
 
-#include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
+
+struct EFBCopyParams;
 
 namespace OGL
 {
@@ -25,9 +26,9 @@ void EncodeToRamYUYV(GLuint srcTexture, const TargetRectangle& sourceRc, u8* des
 void DecodeToTexture(u32 xfbAddr, int srcWidth, int srcHeight, GLuint destTexture);
 
 // returns size of the encoded data (in bytes)
-void EncodeToRamFromTexture(u8* dest_ptr, const EFBCopyFormat& format, u32 native_width,
+void EncodeToRamFromTexture(u8* dest_ptr, const EFBCopyParams& params, u32 native_width,
                             u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                            bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half);
+                            const EFBRectangle& src_rect, bool scale_by_half);
 }
 
 }  // namespace OGL

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -50,13 +50,13 @@ class TextureCache : public TextureCacheBase
 public:
   bool CompileShaders() override { return true; }
   void DeleteShaders() override {}
-  void ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, void* palette,
-                      TlutFormat format) override
+  void ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, const void* palette,
+                      TLUTFormat format) override
   {
   }
-  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-               const EFBRectangle& src_rect, bool scale_by_half) override
+  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+               bool scale_by_half) override
   {
     EfbCopy::CopyEfb();
   }

--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -111,13 +111,14 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
   TexMode0& tm0 = texUnit.texMode0[subTexmap];
   TexImage0& ti0 = texUnit.texImage0[subTexmap];
   TexTLUT& texTlut = texUnit.texTlut[subTexmap];
-  TlutFormat tlutfmt = (TlutFormat)texTlut.tlut_format;
+  TextureFormat texfmt = static_cast<TextureFormat>(ti0.format);
+  TLUTFormat tlutfmt = static_cast<TLUTFormat>(texTlut.tlut_format);
 
   u8 *imageSrc, *imageSrcOdd = nullptr;
   if (texUnit.texImage1[subTexmap].image_type)
   {
     imageSrc = &texMem[texUnit.texImage1[subTexmap].tmem_even * TMEM_LINE_SIZE];
-    if (ti0.format == GX_TF_RGBA8)
+    if (texfmt == TextureFormat::RGBA8)
       imageSrcOdd = &texMem[texUnit.texImage2[subTexmap].tmem_odd * TMEM_LINE_SIZE];
   }
   else
@@ -139,9 +140,9 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
     int mipWidth = imageWidth + 1;
     int mipHeight = imageHeight + 1;
 
-    int fmtWidth = TexDecoder_GetBlockWidthInTexels(ti0.format);
-    int fmtHeight = TexDecoder_GetBlockHeightInTexels(ti0.format);
-    int fmtDepth = TexDecoder_GetTexelSizeInNibbles(ti0.format);
+    int fmtWidth = TexDecoder_GetBlockWidthInTexels(texfmt);
+    int fmtHeight = TexDecoder_GetBlockHeightInTexels(texfmt);
+    int fmtDepth = TexDecoder_GetTexelSizeInNibbles(texfmt);
 
     imageWidth >>= mip;
     imageHeight >>= mip;
@@ -186,21 +187,21 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
     WrapCoord(&imageSPlus1, tm0.wrap_s, imageWidth);
     WrapCoord(&imageTPlus1, tm0.wrap_t, imageHeight);
 
-    if (!(ti0.format == GX_TF_RGBA8 && texUnit.texImage1[subTexmap].image_type))
+    if (!(texfmt == TextureFormat::RGBA8 && texUnit.texImage1[subTexmap].image_type))
     {
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageS, imageT, imageWidth, ti0.format, tlut,
+      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageS, imageT, imageWidth, texfmt, tlut,
                              tlutfmt);
       SetTexel(sampledTex, texel, (128 - fractS) * (128 - fractT));
 
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageSPlus1, imageT, imageWidth, ti0.format,
-                             tlut, tlutfmt);
+      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageSPlus1, imageT, imageWidth, texfmt, tlut,
+                             tlutfmt);
       AddTexel(sampledTex, texel, (fractS) * (128 - fractT));
 
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageS, imageTPlus1, imageWidth, ti0.format,
-                             tlut, tlutfmt);
+      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageS, imageTPlus1, imageWidth, texfmt, tlut,
+                             tlutfmt);
       AddTexel(sampledTex, texel, (128 - fractS) * (fractT));
 
-      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageSPlus1, imageTPlus1, imageWidth, ti0.format,
+      TexDecoder_DecodeTexel(sampledTex, imageSrc, imageSPlus1, imageTPlus1, imageWidth, texfmt,
                              tlut, tlutfmt);
       AddTexel(sampledTex, texel, (fractS) * (fractT));
     }
@@ -238,9 +239,8 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
     WrapCoord(&imageS, tm0.wrap_s, imageWidth);
     WrapCoord(&imageT, tm0.wrap_t, imageHeight);
 
-    if (!(ti0.format == GX_TF_RGBA8 && texUnit.texImage1[subTexmap].image_type))
-      TexDecoder_DecodeTexel(sample, imageSrc, imageS, imageT, imageWidth, ti0.format, tlut,
-                             tlutfmt);
+    if (!(texfmt == TextureFormat::RGBA8 && texUnit.texImage1[subTexmap].image_type))
+      TexDecoder_DecodeTexel(sample, imageSrc, imageS, imageT, imageWidth, texfmt, tlut, tlutfmt);
     else
       TexDecoder_DecodeTexelRGBA8FromTmem(sample, imageSrc, imageSrcOdd, imageS, imageT,
                                           imageWidth);

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -95,8 +95,8 @@ bool TextureCache::Initialize()
   return true;
 }
 
-void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source, void* palette,
-                                  TlutFormat format)
+void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
+                                  const void* palette, TLUTFormat format)
 {
   m_texture_converter->ConvertTexture(destination, source, m_render_pass, palette, format);
 
@@ -111,9 +111,9 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 
-void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width,
+void TextureCache::CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width,
                            u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                           bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
+                           const EFBRectangle& src_rect, bool scale_by_half)
 {
   // Flush EFB pokes first, as they're expected to be included.
   FramebufferManager::GetInstance()->FlushEFBPokes();
@@ -128,7 +128,7 @@ void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_widt
   region = Util::ClampRect2D(region, FramebufferManager::GetInstance()->GetEFBWidth(),
                              FramebufferManager::GetInstance()->GetEFBHeight());
   Texture2D* src_texture;
-  if (is_depth_copy)
+  if (params.depth)
     src_texture = FramebufferManager::GetInstance()->ResolveEFBDepthTexture(region);
   else
     src_texture = FramebufferManager::GetInstance()->ResolveEFBColorTexture(region);
@@ -144,15 +144,15 @@ void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_widt
   src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-  m_texture_converter->EncodeTextureToMemory(src_texture->GetView(), dst, format, native_width,
-                                             bytes_per_row, num_blocks_y, memory_stride,
-                                             is_depth_copy, src_rect, scale_by_half);
+  m_texture_converter->EncodeTextureToMemory(src_texture->GetView(), dst, params, native_width,
+                                             bytes_per_row, num_blocks_y, memory_stride, src_rect,
+                                             scale_by_half);
 
   // Transition back to original state
   src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(), original_layout);
 }
 
-bool TextureCache::SupportsGPUTextureDecode(TextureFormat format, TlutFormat palette_format)
+bool TextureCache::SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format)
 {
   return m_texture_converter->SupportsTextureDecoding(format, palette_format);
 }
@@ -160,7 +160,7 @@ bool TextureCache::SupportsGPUTextureDecode(TextureFormat format, TlutFormat pal
 void TextureCache::DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, const u8* data,
                                       size_t data_size, TextureFormat format, u32 width, u32 height,
                                       u32 aligned_width, u32 aligned_height, u32 row_stride,
-                                      const u8* palette, TlutFormat palette_format)
+                                      const u8* palette, TLUTFormat palette_format)
 {
   // Group compute shader dispatches together in the init command buffer. That way we don't have to
   // pay a penalty for switching from graphics->compute, or end/restart our render pass.

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.h
@@ -33,19 +33,19 @@ public:
 
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
 
-  void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, void* palette,
-                      TlutFormat format) override;
+  void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
+                      TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-               const EFBRectangle& src_rect, bool scale_by_half) override;
+  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+               bool scale_by_half) override;
 
-  bool SupportsGPUTextureDecode(TextureFormat format, TlutFormat palette_format) override;
+  bool SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format) override;
 
   void DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, const u8* data, size_t data_size,
                           TextureFormat format, u32 width, u32 height, u32 aligned_width,
                           u32 aligned_height, u32 row_stride, const u8* palette,
-                          TlutFormat palette_format) override;
+                          TLUTFormat palette_format) override;
 
   VkShaderModule GetCopyShader() const;
   VkRenderPass GetTextureCopyRenderPass() const;

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -33,14 +33,13 @@ public:
   // Applies palette to dst_entry, using indices from src_entry.
   void ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
                       TextureCache::TCacheEntry* src_entry, VkRenderPass render_pass,
-                      const void* palette, TlutFormat palette_format);
+                      const void* palette, TLUTFormat palette_format);
 
   // Uses an encoding shader to copy src_texture to dest_ptr.
   // NOTE: Executes the current command buffer.
-  void EncodeTextureToMemory(VkImageView src_texture, u8* dest_ptr, const EFBCopyFormat& format,
+  void EncodeTextureToMemory(VkImageView src_texture, u8* dest_ptr, const EFBCopyParams& params,
                              u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-                             u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
-                             bool scale_by_half);
+                             u32 memory_stride, const EFBRectangle& src_rect, bool scale_by_half);
 
   // Encodes texture to guest memory in XFB (YUYV) format.
   void EncodeTextureToMemoryYUYV(void* dst_ptr, u32 dst_width, u32 dst_stride, u32 dst_height,
@@ -50,11 +49,11 @@ public:
   void DecodeYUYVTextureFromMemory(VKTexture* dst_texture, const void* src_ptr, u32 src_width,
                                    u32 src_stride, u32 src_height);
 
-  bool SupportsTextureDecoding(TextureFormat format, TlutFormat palette_format);
+  bool SupportsTextureDecoding(TextureFormat format, TLUTFormat palette_format);
   void DecodeTexture(VkCommandBuffer command_buffer, TextureCache::TCacheEntry* entry,
                      u32 dst_level, const u8* data, size_t data_size, TextureFormat format,
                      u32 width, u32 height, u32 aligned_width, u32 aligned_height, u32 row_stride,
-                     const u8* palette, TlutFormat palette_format);
+                     const u8* palette, TLUTFormat palette_format);
 
 private:
   static const u32 ENCODING_TEXTURE_WIDTH = EFB_WIDTH * 4;
@@ -71,8 +70,8 @@ private:
 
   bool CompilePaletteConversionShaders();
 
-  VkShaderModule CompileEncodingShader(const EFBCopyFormat& format);
-  VkShaderModule GetEncodingShader(const EFBCopyFormat& format);
+  VkShaderModule CompileEncodingShader(const EFBCopyParams& params);
+  VkShaderModule GetEncodingShader(const EFBCopyParams& params);
 
   bool CreateEncodingRenderPass();
   bool CreateEncodingTexture();
@@ -105,7 +104,7 @@ private:
   std::array<VkShaderModule, NUM_PALETTE_CONVERSION_SHADERS> m_palette_conversion_shaders = {};
 
   // Texture encoding - RGBA8->GX format in memory
-  std::map<EFBCopyFormat, VkShaderModule> m_encoding_shaders;
+  std::map<EFBCopyParams, VkShaderModule> m_encoding_shaders;
   VkRenderPass m_encoding_render_pass = VK_NULL_HANDLE;
   std::unique_ptr<Texture2D> m_encoding_render_texture;
   VkFramebuffer m_encoding_render_framebuffer = VK_NULL_HANDLE;
@@ -118,7 +117,7 @@ private:
     VkShaderModule compute_shader;
     bool valid;
   };
-  std::map<std::pair<TextureFormat, TlutFormat>, TextureDecodingPipeline> m_decoding_pipelines;
+  std::map<std::pair<TextureFormat, TLUTFormat>, TextureDecodingPipeline> m_decoding_pipelines;
   std::unique_ptr<Texture2D> m_decoding_texture;
 
   // XFB encoding/decoding shaders

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -9,6 +9,8 @@
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 
+enum class EFBCopyFormat;
+
 #pragma pack(4)
 
 enum
@@ -958,7 +960,10 @@ union UPE_Copy
   BitField<16, 1, u32>
       auto_conv;  // if 0 automatic color conversion by texture format and pixel type
 
-  u32 tp_realFormat() const { return target_pixel_format / 2 + (target_pixel_format & 1) * 8; }
+  EFBCopyFormat tp_realFormat() const
+  {
+    return static_cast<EFBCopyFormat>(target_pixel_format / 2 + (target_pixel_format & 1) * 8);
+  }
 };
 
 union BPU_PreloadTileInfo

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -215,7 +215,7 @@ void HiresTexture::Prefetch()
 }
 
 std::string HiresTexture::GenBaseName(const u8* texture, size_t texture_size, const u8* tlut,
-                                      size_t tlut_size, u32 width, u32 height, int format,
+                                      size_t tlut_size, u32 width, u32 height, TextureFormat format,
                                       bool has_mipmaps, bool dump)
 {
   std::string name = "";
@@ -385,7 +385,8 @@ u32 HiresTexture::CalculateMipCount(u32 width, u32 height)
 
 std::shared_ptr<HiresTexture> HiresTexture::Search(const u8* texture, size_t texture_size,
                                                    const u8* tlut, size_t tlut_size, u32 width,
-                                                   u32 height, int format, bool has_mipmaps)
+                                                   u32 height, TextureFormat format,
+                                                   bool has_mipmaps)
 {
   std::string base_filename =
       GenBaseName(texture, texture_size, tlut, tlut_size, width, height, format, has_mipmaps);

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -11,6 +11,8 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/TextureConfig.h"
 
+enum class TextureFormat;
+
 class HiresTexture
 {
 public:
@@ -22,10 +24,10 @@ public:
 
   static std::shared_ptr<HiresTexture> Search(const u8* texture, size_t texture_size,
                                               const u8* tlut, size_t tlut_size, u32 width,
-                                              u32 height, int format, bool has_mipmaps);
+                                              u32 height, TextureFormat format, bool has_mipmaps);
 
   static std::string GenBaseName(const u8* texture, size_t texture_size, const u8* tlut,
-                                 size_t tlut_size, u32 width, u32 height, int format,
+                                 size_t tlut_size, u32 width, u32 height, TextureFormat format,
                                  bool has_mipmaps, bool dump = false);
 
   static u32 CalculateMipCount(u32 width, u32 height);

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -8,15 +8,18 @@
 #include <utility>
 
 #include "Common/CommonTypes.h"
-#include "VideoCommon/TextureDecoder.h"
 
 enum class APIType;
+enum class TextureFormat;
+enum class EFBCopyFormat;
+enum class TLUTFormat;
+struct EFBCopyParams;
 
 namespace TextureConversionShader
 {
-u16 GetEncodedSampleCount(u32 format);
+u16 GetEncodedSampleCount(EFBCopyFormat format);
 
-const char* GenerateEncodingShader(const EFBCopyFormat& format, APIType ApiType);
+const char* GenerateEncodingShader(const EFBCopyParams& params, APIType ApiType);
 
 // View format of the input data to the texture decoding shader.
 enum BufferFormat
@@ -51,7 +54,7 @@ u32 GetBytesPerBufferElement(BufferFormat buffer_format);
 std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, u32 height);
 
 // Returns the GLSL string containing the texture decoding shader for the specified format.
-std::string GenerateDecodingShader(TextureFormat format, TlutFormat palette_format,
+std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format,
                                    APIType api_type);
 
 }  // namespace TextureConversionShader

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -14,94 +14,101 @@ enum
 };
 alignas(16) extern u8 texMem[TMEM_SIZE];
 
-enum TextureFormat
+enum class TextureFormat
 {
-  // These are the texture formats that can be read by the texture mapper.
-  GX_TF_I4 = 0x0,
-  GX_TF_I8 = 0x1,
-  GX_TF_IA4 = 0x2,
-  GX_TF_IA8 = 0x3,
-  GX_TF_RGB565 = 0x4,
-  GX_TF_RGB5A3 = 0x5,
-  GX_TF_RGBA8 = 0x6,
-  GX_TF_C4 = 0x8,
-  GX_TF_C8 = 0x9,
-  GX_TF_C14X2 = 0xA,
-  GX_TF_CMPR = 0xE,
-
-  _GX_TF_ZTF = 0x10,  // flag for Z texture formats (used internally by dolphin)
-
-  // Depth texture formats (which directly map to the equivalent colour format above.)
-  GX_TF_Z8 = 0x1 | _GX_TF_ZTF,
-  GX_TF_Z16 = 0x3 | _GX_TF_ZTF,
-  GX_TF_Z24X8 = 0x6 | _GX_TF_ZTF,
-
-  _GX_TF_CTF = 0x20,  // flag for copy-texture-format only (used internally by dolphin)
-
-  // These are extra formats that can be used when copying from efb,
-  // they use one of texel formats from above, but pack diffrent data into them.
-  GX_CTF_R4 = 0x0 | _GX_TF_CTF,
-  GX_CTF_RA4 = 0x2 | _GX_TF_CTF,
-  GX_CTF_RA8 = 0x3 | _GX_TF_CTF,
-  GX_CTF_YUVA8 = 0x6 | _GX_TF_CTF,  // YUV 4:4:4 - Dolphin doesn't implement this format as no
-                                    // commercial games use it
-  GX_CTF_A8 = 0x7 | _GX_TF_CTF,
-  GX_CTF_R8 = 0x8 | _GX_TF_CTF,
-  GX_CTF_G8 = 0x9 | _GX_TF_CTF,
-  GX_CTF_B8 = 0xA | _GX_TF_CTF,
-  GX_CTF_RG8 = 0xB | _GX_TF_CTF,
-  GX_CTF_GB8 = 0xC | _GX_TF_CTF,
-
-  // extra depth texture formats that can be used for efb copies.
-  GX_CTF_Z4 = 0x0 | _GX_TF_ZTF | _GX_TF_CTF,
-  GX_CTF_Z8H = 0x8 | _GX_TF_ZTF | _GX_TF_CTF,  // This produces an identical result to to GX_TF_Z8
-  GX_CTF_Z8M = 0x9 | _GX_TF_ZTF | _GX_TF_CTF,
-  GX_CTF_Z8L = 0xA | _GX_TF_ZTF | _GX_TF_CTF,
-  GX_CTF_Z16R = 0xB | _GX_TF_ZTF | _GX_TF_CTF,  // Reversed version of GX_TF_Z16
-  GX_CTF_Z16L = 0xC | _GX_TF_ZTF | _GX_TF_CTF,
+  // These values represent texture format in GX registers.
+  I4 = 0x0,
+  I8 = 0x1,
+  IA4 = 0x2,
+  IA8 = 0x3,
+  RGB565 = 0x4,
+  RGB5A3 = 0x5,
+  RGBA8 = 0x6,
+  C4 = 0x8,
+  C8 = 0x9,
+  C14X2 = 0xA,
+  CMPR = 0xE,
 };
 
-enum TlutFormat
+static inline bool IsColorIndexed(TextureFormat format)
 {
-  GX_TL_IA8 = 0x0,
-  GX_TL_RGB565 = 0x1,
-  GX_TL_RGB5A3 = 0x2,
+  return format == TextureFormat::C4 || format == TextureFormat::C8 ||
+         format == TextureFormat::C14X2;
+}
+
+// The EFB Copy pipeline looks like:
+//
+//   1. Read EFB -> 2. Select color/depth -> 3. Downscale (optional)
+//   -> 4. YUV conversion (optional) -> 5. Encode Tiles -> 6. Write RAM
+//
+// The "Encode Tiles" stage receives RGBA8 texels from previous stages and encodes them to various
+// formats. EFBCopyFormat is the tile encoder mode. Note that the tile encoder does not care about
+// color vs. depth or intensity formats - it only sees RGBA8 texels.
+enum class EFBCopyFormat
+{
+  // These values represent EFB copy format in GX registers.
+  // Most (but not all) of these values correspond to values of TextureFormat.
+  R4 = 0x0,  // R4, I4, Z4
+
+  // FIXME: Does 0x1 (Z8) have identical results to 0x8 (Z8H)?
+  //        Is either or both of 0x1 and 0x8 used in games?
+  R8_0x1 = 0x1,  // R8, I8, Z8H (?)
+
+  RA4 = 0x2,  // RA4, IA4
+
+  // FIXME: Earlier versions of this file named the value 0x3 "GX_TF_Z16", which does not reflect
+  //        the results one would expect when copying from the depth buffer with this format.
+  //        For reference: When copying from the depth buffer, R should receive the top 8 bits of
+  //                       the Z value, and A should be either 0xFF or 0 (please investigate).
+  //        Please test original hardware and make sure dolphin-emu implements this format
+  //        correctly.
+  RA8 = 0x3,  // RA8, IA8, (FIXME: Z16 too?)
+
+  RGB565 = 0x4,
+  RGB5A3 = 0x5,
+  RGBA8 = 0x6,  // RGBA8, Z24
+  A8 = 0x7,
+  R8 = 0x8,   // R8, I8, Z8H
+  G8 = 0x9,   // G8, Z8M
+  B8 = 0xA,   // B8, Z8L
+  RG8 = 0xB,  // RG8, Z16R (Note: G and R are reversed)
+  GB8 = 0xC,  // GB8, Z16L
 };
 
-struct EFBCopyFormat
+enum class TLUTFormat
 {
-  EFBCopyFormat(u32 efb_format_, TextureFormat copy_format_)
-      : efb_format(efb_format_), copy_format(copy_format_)
-  {
-  }
-
-  bool operator<(const EFBCopyFormat& rhs) const
-  {
-    return std::tie(efb_format, copy_format) < std::tie(rhs.efb_format, rhs.copy_format);
-  }
-
-  u32 efb_format;
-  TextureFormat copy_format;
+  // These values represent TLUT format in GX registers.
+  IA8 = 0x0,
+  RGB565 = 0x1,
+  RGB5A3 = 0x2,
 };
 
-int TexDecoder_GetTexelSizeInNibbles(int format);
-int TexDecoder_GetTextureSizeInBytes(int width, int height, int format);
-int TexDecoder_GetBlockWidthInTexels(u32 format);
-int TexDecoder_GetBlockHeightInTexels(u32 format);
-int TexDecoder_GetPaletteSize(int fmt);
-int TexDecoder_GetEfbCopyBaseFormat(int format);
+static inline bool IsValidTLUTFormat(TLUTFormat tlutfmt)
+{
+  return tlutfmt == TLUTFormat::IA8 || tlutfmt == TLUTFormat::RGB565 ||
+         tlutfmt == TLUTFormat::RGB5A3;
+}
 
-void TexDecoder_Decode(u8* dst, const u8* src, int width, int height, int texformat, const u8* tlut,
-                       TlutFormat tlutfmt);
+int TexDecoder_GetTexelSizeInNibbles(TextureFormat format);
+int TexDecoder_GetTextureSizeInBytes(int width, int height, TextureFormat format);
+int TexDecoder_GetBlockWidthInTexels(TextureFormat format);
+int TexDecoder_GetBlockHeightInTexels(TextureFormat format);
+int TexDecoder_GetEFBCopyBlockWidthInTexels(EFBCopyFormat format);
+int TexDecoder_GetEFBCopyBlockHeightInTexels(EFBCopyFormat format);
+int TexDecoder_GetPaletteSize(TextureFormat fmt);
+TextureFormat TexDecoder_GetEFBCopyBaseFormat(EFBCopyFormat format);
+
+void TexDecoder_Decode(u8* dst, const u8* src, int width, int height, TextureFormat texformat,
+                       const u8* tlut, TLUTFormat tlutfmt);
 void TexDecoder_DecodeRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int width,
                                     int height);
-void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth, int texformat,
-                            const u8* tlut, TlutFormat tlutfmt);
+void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth,
+                            TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt);
 void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int s, int t,
                                          int imageWidth);
 
 void TexDecoder_SetTexFmtOverlayOptions(bool enable, bool center);
 
 /* Internal method, implemented by TextureDecoder_Generic and TextureDecoder_x64. */
-void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int texformat,
-                            const u8* tlut, TlutFormat tlutfmt);
+void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, TextureFormat texformat,
+                            const u8* tlut, TLUTFormat tlutfmt);

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -21,227 +21,176 @@ static bool TexFmt_Overlay_Center = false;
 // STATE_TO_SAVE
 alignas(16) u8 texMem[TMEM_SIZE];
 
-int TexDecoder_GetTexelSizeInNibbles(int format)
+int TexDecoder_GetTexelSizeInNibbles(TextureFormat format)
 {
-  switch (format & 0x3f)
+  switch (format)
   {
-  case GX_TF_I4:
+  // 4-bit formats
+  case TextureFormat::I4:
+  case TextureFormat::C4:
     return 1;
-  case GX_TF_I8:
+  // 8-bit formats
+  case TextureFormat::I8:
+  case TextureFormat::IA4:
+  case TextureFormat::C8:
     return 2;
-  case GX_TF_IA4:
-    return 2;
-  case GX_TF_IA8:
+  // 16-bit formats
+  case TextureFormat::IA8:
+  case TextureFormat::RGB565:
+  case TextureFormat::RGB5A3:
+  case TextureFormat::C14X2:
     return 4;
-  case GX_TF_RGB565:
-    return 4;
-  case GX_TF_RGB5A3:
-    return 4;
-  case GX_TF_RGBA8:
+  // 32-bit formats
+  case TextureFormat::RGBA8:
     return 8;
-  case GX_TF_C4:
+  // Compressed format
+  case TextureFormat::CMPR:
     return 1;
-  case GX_TF_C8:
-    return 2;
-  case GX_TF_C14X2:
-    return 4;
-  case GX_TF_CMPR:
-    return 1;
-  case GX_CTF_R4:
-    return 1;
-  case GX_CTF_RA4:
-    return 2;
-  case GX_CTF_RA8:
-    return 4;
-  case GX_CTF_A8:
-    return 2;
-  case GX_CTF_R8:
-    return 2;
-  case GX_CTF_G8:
-    return 2;
-  case GX_CTF_B8:
-    return 2;
-  case GX_CTF_RG8:
-    return 4;
-  case GX_CTF_GB8:
-    return 4;
-
-  case GX_TF_Z8:
-    return 2;
-  case GX_TF_Z16:
-    return 4;
-  case GX_TF_Z24X8:
-    return 8;
-
-  case GX_CTF_Z4:
-    return 1;
-  case GX_CTF_Z8H:
-    return 2;
-  case GX_CTF_Z8M:
-    return 2;
-  case GX_CTF_Z8L:
-    return 2;
-  case GX_CTF_Z16R:
-    return 4;
-  case GX_CTF_Z16L:
-    return 4;
   default:
-    PanicAlert("Unsupported Texture Format (%08x)! (GetTexelSizeInNibbles)", format);
+    PanicAlert("Invalid Texture Format (0x%X)! (GetTexelSizeInNibbles)", static_cast<int>(format));
     return 1;
   }
 }
 
-int TexDecoder_GetTextureSizeInBytes(int width, int height, int format)
+int TexDecoder_GetTextureSizeInBytes(int width, int height, TextureFormat format)
 {
   return (width * height * TexDecoder_GetTexelSizeInNibbles(format)) / 2;
 }
 
-int TexDecoder_GetBlockWidthInTexels(u32 format)
+int TexDecoder_GetBlockWidthInTexels(TextureFormat format)
 {
   switch (format)
   {
-  case GX_TF_I4:
+  // 4-bit formats
+  case TextureFormat::I4:
+  case TextureFormat::C4:
     return 8;
-  case GX_TF_I8:
+  // 8-bit formats
+  case TextureFormat::I8:
+  case TextureFormat::IA4:
+  case TextureFormat::C8:
     return 8;
-  case GX_TF_IA4:
-    return 8;
-  case GX_TF_IA8:
+  // 16-bit formats
+  case TextureFormat::IA8:
+  case TextureFormat::RGB565:
+  case TextureFormat::RGB5A3:
+  case TextureFormat::C14X2:
     return 4;
-  case GX_TF_RGB565:
+  // 32-bit formats
+  case TextureFormat::RGBA8:
     return 4;
-  case GX_TF_RGB5A3:
-    return 4;
-  case GX_TF_RGBA8:
-    return 4;
-  case GX_TF_C4:
+  // Compressed format
+  case TextureFormat::CMPR:
     return 8;
-  case GX_TF_C8:
-    return 8;
-  case GX_TF_C14X2:
-    return 4;
-  case GX_TF_CMPR:
-    return 8;
-  case GX_CTF_R4:
-    return 8;
-  case GX_CTF_RA4:
-    return 8;
-  case GX_CTF_RA8:
-    return 4;
-  case GX_CTF_A8:
-    return 8;
-  case GX_CTF_R8:
-    return 8;
-  case GX_CTF_G8:
-    return 8;
-  case GX_CTF_B8:
-    return 8;
-  case GX_CTF_RG8:
-    return 4;
-  case GX_CTF_GB8:
-    return 4;
-  case GX_TF_Z8:
-    return 8;
-  case GX_TF_Z16:
-    return 4;
-  case GX_TF_Z24X8:
-    return 4;
-  case GX_CTF_Z4:
-    return 8;
-  case GX_CTF_Z8H:
-    return 8;
-  case GX_CTF_Z8M:
-    return 8;
-  case GX_CTF_Z8L:
-    return 8;
-  case GX_CTF_Z16R:
-    return 4;
-  case GX_CTF_Z16L:
-    return 4;
   default:
-    PanicAlert("Unsupported Texture Format (%08x)! (GetBlockWidthInTexels)", format);
+    PanicAlert("Invalid Texture Format (0x%X)! (GetBlockWidthInTexels)", static_cast<int>(format));
     return 8;
   }
 }
 
-int TexDecoder_GetBlockHeightInTexels(u32 format)
+int TexDecoder_GetBlockHeightInTexels(TextureFormat format)
 {
   switch (format)
   {
-  case GX_TF_I4:
+  // 4-bit formats
+  case TextureFormat::I4:
+  case TextureFormat::C4:
     return 8;
-  case GX_TF_I8:
+  // 8-bit formats
+  case TextureFormat::I8:
+  case TextureFormat::IA4:
+  case TextureFormat::C8:
     return 4;
-  case GX_TF_IA4:
+  // 16-bit formats
+  case TextureFormat::IA8:
+  case TextureFormat::RGB565:
+  case TextureFormat::RGB5A3:
+  case TextureFormat::C14X2:
     return 4;
-  case GX_TF_IA8:
+  // 32-bit formats
+  case TextureFormat::RGBA8:
     return 4;
-  case GX_TF_RGB565:
-    return 4;
-  case GX_TF_RGB5A3:
-    return 4;
-  case GX_TF_RGBA8:
-    return 4;
-  case GX_TF_C4:
+  // Compressed format
+  case TextureFormat::CMPR:
     return 8;
-  case GX_TF_C8:
+  default:
+    PanicAlert("Invalid Texture Format (0x%X)! (GetBlockHeightInTexels)", static_cast<int>(format));
     return 4;
-  case GX_TF_C14X2:
-    return 4;
-  case GX_TF_CMPR:
+  }
+}
+
+int TexDecoder_GetEFBCopyBlockWidthInTexels(EFBCopyFormat format)
+{
+  switch (format)
+  {
+  // 4-bit formats
+  case EFBCopyFormat::R4:
     return 8;
-  case GX_CTF_R4:
+  // 8-bit formats
+  case EFBCopyFormat::A8:
+  case EFBCopyFormat::R8_0x1:
+  case EFBCopyFormat::R8:
+  case EFBCopyFormat::G8:
+  case EFBCopyFormat::B8:
     return 8;
-  case GX_CTF_RA4:
+  // 16-bit formats
+  case EFBCopyFormat::RA8:
+  case EFBCopyFormat::RGB565:
+  case EFBCopyFormat::RGB5A3:
+  case EFBCopyFormat::RG8:
+  case EFBCopyFormat::GB8:
     return 4;
-  case GX_CTF_RA8:
-    return 4;
-  case GX_CTF_A8:
-    return 4;
-  case GX_CTF_R8:
-    return 4;
-  case GX_CTF_G8:
-    return 4;
-  case GX_CTF_B8:
-    return 4;
-  case GX_CTF_RG8:
-    return 4;
-  case GX_CTF_GB8:
-    return 4;
-  case GX_TF_Z8:
-    return 4;
-  case GX_TF_Z16:
-    return 4;
-  case GX_TF_Z24X8:
-    return 4;
-  case GX_CTF_Z4:
-    return 8;
-  case GX_CTF_Z8H:
-    return 4;
-  case GX_CTF_Z8M:
-    return 4;
-  case GX_CTF_Z8L:
-    return 4;
-  case GX_CTF_Z16R:
-    return 4;
-  case GX_CTF_Z16L:
+  // 32-bit formats
+  case EFBCopyFormat::RGBA8:
     return 4;
   default:
-    PanicAlert("Unsupported Texture Format (%08x)! (GetBlockHeightInTexels)", format);
+    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEFBCopyBlockWidthInTexels)",
+               static_cast<int>(format));
+    return 8;
+  }
+}
+
+int TexDecoder_GetEFBCopyBlockHeightInTexels(EFBCopyFormat format)
+{
+  switch (format)
+  {
+  // 4-bit formats
+  case EFBCopyFormat::R4:
+    return 8;
+  // 8-bit formats
+  case EFBCopyFormat::A8:
+  case EFBCopyFormat::R8_0x1:
+  case EFBCopyFormat::R8:
+  case EFBCopyFormat::G8:
+  case EFBCopyFormat::B8:
+    return 4;
+  // 16-bit formats
+  case EFBCopyFormat::RA8:
+  case EFBCopyFormat::RGB565:
+  case EFBCopyFormat::RGB5A3:
+  case EFBCopyFormat::RG8:
+  case EFBCopyFormat::GB8:
+    return 4;
+  // 32-bit formats
+  case EFBCopyFormat::RGBA8:
+    return 4;
+  default:
+    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEFBCopyBlockHeightInTexels)",
+               static_cast<int>(format));
     return 4;
   }
 }
 
 // returns bytes
-int TexDecoder_GetPaletteSize(int format)
+int TexDecoder_GetPaletteSize(TextureFormat format)
 {
   switch (format)
   {
-  case GX_TF_C4:
+  case TextureFormat::C4:
     return 16 * 2;
-  case GX_TF_C8:
+  case TextureFormat::C8:
     return 256 * 2;
-  case GX_TF_C14X2:
+  case TextureFormat::C14X2:
     return 16384 * 2;
   default:
     return 0;
@@ -251,51 +200,33 @@ int TexDecoder_GetPaletteSize(int format)
 // Get the "in memory" texture format of an EFB copy's format.
 // With the exception of c4/c8/c14 paletted texture formats (which are handled elsewhere)
 // this is the format the game should be using when it is drawing an EFB copy back.
-int TexDecoder_GetEfbCopyBaseFormat(int format)
+TextureFormat TexDecoder_GetEFBCopyBaseFormat(EFBCopyFormat format)
 {
   switch (format)
   {
-  case GX_TF_I4:
-  case GX_CTF_Z4:
-  case GX_CTF_R4:
-    return GX_TF_I4;
-  case GX_TF_I8:
-  case GX_CTF_A8:
-  case GX_CTF_R8:
-  case GX_CTF_G8:
-  case GX_CTF_B8:
-  case GX_TF_Z8:
-  case GX_CTF_Z8H:
-  case GX_CTF_Z8M:
-  case GX_CTF_Z8L:
-    return GX_TF_I8;
-  case GX_TF_IA4:
-  case GX_CTF_RA4:
-    return GX_TF_IA4;
-  case GX_TF_IA8:
-  case GX_TF_Z16:
-  case GX_CTF_RA8:
-  case GX_CTF_RG8:
-  case GX_CTF_GB8:
-  case GX_CTF_Z16R:
-  case GX_CTF_Z16L:
-    return GX_TF_IA8;
-  case GX_TF_RGB565:
-    return GX_TF_RGB565;
-  case GX_TF_RGB5A3:
-    return GX_TF_RGB5A3;
-  case GX_TF_RGBA8:
-  case GX_TF_Z24X8:
-  case GX_CTF_YUVA8:
-    return GX_TF_RGBA8;
-  // These formats can't be (directly) generated by EFB copies
-  case GX_TF_C4:
-  case GX_TF_C8:
-  case GX_TF_C14X2:
-  case GX_TF_CMPR:
+  case EFBCopyFormat::R4:
+    return TextureFormat::I4;
+  case EFBCopyFormat::A8:
+  case EFBCopyFormat::R8_0x1:
+  case EFBCopyFormat::R8:
+  case EFBCopyFormat::G8:
+  case EFBCopyFormat::B8:
+    return TextureFormat::I8;
+  case EFBCopyFormat::RA4:
+    return TextureFormat::IA4;
+  case EFBCopyFormat::RA8:
+  case EFBCopyFormat::RG8:
+  case EFBCopyFormat::GB8:
+    return TextureFormat::IA8;
+  case EFBCopyFormat::RGB565:
+    return TextureFormat::RGB565;
+  case EFBCopyFormat::RGB5A3:
+    return TextureFormat::RGB5A3;
+  case EFBCopyFormat::RGBA8:
+    return TextureFormat::RGBA8;
   default:
-    PanicAlert("Unsupported Texture Format (%08x)! (GetEfbCopyBaseFormat)", format);
-    return format & 0xf;
+    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEFBCopyBaseFormat)", static_cast<int>(format));
+    return static_cast<TextureFormat>(format);
   }
 }
 
@@ -320,7 +251,7 @@ static const char* texfmt[] = {
     "CZ16L", "0x3D", "0x3E", "0x3F",
 };
 
-static void TexDecoder_DrawOverlay(u8* dst, int width, int height, int texformat)
+static void TexDecoder_DrawOverlay(u8* dst, int width, int height, TextureFormat texformat)
 {
   int w = std::min(width, 40);
   int h = std::min(height, 10);
@@ -334,7 +265,7 @@ static void TexDecoder_DrawOverlay(u8* dst, int width, int height, int texformat
     yoff = 0;
   }
 
-  const char* fmt = texfmt[texformat & 15];
+  const char* fmt = texfmt[static_cast<int>(texformat) & 15];
   while (*fmt)
   {
     int xcnt = 0;
@@ -363,8 +294,8 @@ static void TexDecoder_DrawOverlay(u8* dst, int width, int height, int texformat
   }
 }
 
-void TexDecoder_Decode(u8* dst, const u8* src, int width, int height, int texformat, const u8* tlut,
-                       TlutFormat tlutfmt)
+void TexDecoder_Decode(u8* dst, const u8* src, int width, int height, TextureFormat texformat,
+                       const u8* tlut, TLUTFormat tlutfmt)
 {
   _TexDecoder_DecodeImpl((u32*)dst, src, width, height, texformat, tlut, tlutfmt);
 
@@ -409,23 +340,23 @@ static inline u32 DecodePixel_RGB5A3(u16 val)
   return r | (g << 8) | (b << 16) | (a << 24);
 }
 
-static inline u32 DecodePixel_Paletted(u16 pixel, TlutFormat tlutfmt)
+static inline u32 DecodePixel_Paletted(u16 pixel, TLUTFormat tlutfmt)
 {
   switch (tlutfmt)
   {
-  case GX_TL_IA8:
+  case TLUTFormat::IA8:
     return DecodePixel_IA8(pixel);
-  case GX_TL_RGB565:
+  case TLUTFormat::RGB565:
     return DecodePixel_RGB565(Common::swap16(pixel));
-  case GX_TL_RGB5A3:
+  case TLUTFormat::RGB5A3:
     return DecodePixel_RGB5A3(Common::swap16(pixel));
   default:
     return 0;
   }
 }
 
-void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth, int texformat,
-                            const u8* tlut_, TlutFormat tlutfmt)
+void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth,
+                            TextureFormat texformat, const u8* tlut_, TLUTFormat tlutfmt)
 {
   /* General formula for computing texture offset
   //
@@ -440,7 +371,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
 
   switch (texformat)
   {
-  case GX_TF_C4:
+  case TextureFormat::C4:
   {
     u16 sBlk = s >> 3;
     u16 tBlk = t >> 3;
@@ -459,7 +390,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     *((u32*)dst) = DecodePixel_Paletted(tlut[val], tlutfmt);
   }
   break;
-  case GX_TF_I4:
+  case TextureFormat::I4:
   {
     u16 sBlk = s >> 3;
     u16 tBlk = t >> 3;
@@ -480,7 +411,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     dst[3] = val;
   }
   break;
-  case GX_TF_I8:
+  case TextureFormat::I8:
   {
     u16 sBlk = s >> 3;
     u16 tBlk = t >> 2;
@@ -497,7 +428,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     dst[3] = val;
   }
   break;
-  case GX_TF_C8:
+  case TextureFormat::C8:
   {
     u16 sBlk = s >> 3;
     u16 tBlk = t >> 2;
@@ -513,7 +444,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     *((u32*)dst) = DecodePixel_Paletted(tlut[val], tlutfmt);
   }
   break;
-  case GX_TF_IA4:
+  case TextureFormat::IA4:
   {
     u16 sBlk = s >> 3;
     u16 tBlk = t >> 2;
@@ -532,7 +463,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     dst[3] = a;
   }
   break;
-  case GX_TF_IA8:
+  case TextureFormat::IA8:
   {
     u16 sBlk = s >> 2;
     u16 tBlk = t >> 2;
@@ -548,7 +479,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     *((u32*)dst) = DecodePixel_IA8(*valAddr);
   }
   break;
-  case GX_TF_C14X2:
+  case TextureFormat::C14X2:
   {
     u16 sBlk = s >> 2;
     u16 tBlk = t >> 2;
@@ -567,7 +498,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     *((u32*)dst) = DecodePixel_Paletted(tlut[val], tlutfmt);
   }
   break;
-  case GX_TF_RGB565:
+  case TextureFormat::RGB565:
   {
     u16 sBlk = s >> 2;
     u16 tBlk = t >> 2;
@@ -583,7 +514,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     *((u32*)dst) = DecodePixel_RGB565(Common::swap16(*valAddr));
   }
   break;
-  case GX_TF_RGB5A3:
+  case TextureFormat::RGB5A3:
   {
     u16 sBlk = s >> 2;
     u16 tBlk = t >> 2;
@@ -599,7 +530,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     *((u32*)dst) = DecodePixel_RGB5A3(Common::swap16(*valAddr));
   }
   break;
-  case GX_TF_RGBA8:
+  case TextureFormat::RGBA8:
   {
     u16 sBlk = s >> 2;
     u16 tBlk = t >> 2;
@@ -618,7 +549,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     dst[2] = valAddr[33];
   }
   break;
-  case GX_TF_CMPR:
+  case TextureFormat::CMPR:
   {
     u16 sDxt = s >> 2;
     u16 tDxt = t >> 2;

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -212,12 +212,13 @@ static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
 // free to make the assumption that addresses are multiples of 16 in the aligned case.
 // TODO: complete SSE2 optimization of less often used texture formats.
 // TODO: refactor algorithms using _mm_loadl_epi64 unaligned loads to prefer 128-bit aligned loads.
-static void TexDecoder_DecodeImpl_C4(u32* dst, const u8* src, int width, int height, int texformat,
-                                     const u8* tlut, TlutFormat tlutfmt, int Wsteps4, int Wsteps8)
+static void TexDecoder_DecodeImpl_C4(u32* dst, const u8* src, int width, int height,
+                                     TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
+                                     int Wsteps4, int Wsteps8)
 {
   switch (tlutfmt)
   {
-  case GX_TL_RGB5A3:
+  case TLUTFormat::RGB5A3:
   {
     for (int y = 0; y < height; y += 8)
       for (int x = 0, yStep = (y / 8) * Wsteps8; x < width; x += 8, yStep++)
@@ -226,7 +227,7 @@ static void TexDecoder_DecodeImpl_C4(u32* dst, const u8* src, int width, int hei
   }
   break;
 
-  case GX_TL_IA8:
+  case TLUTFormat::IA8:
   {
     for (int y = 0; y < height; y += 8)
       for (int x = 0, yStep = (y / 8) * Wsteps8; x < width; x += 8, yStep++)
@@ -235,7 +236,7 @@ static void TexDecoder_DecodeImpl_C4(u32* dst, const u8* src, int width, int hei
   }
   break;
 
-  case GX_TL_RGB565:
+  case TLUTFormat::RGB565:
   {
     for (int y = 0; y < height; y += 8)
       for (int x = 0, yStep = (y / 8) * Wsteps8; x < width; x += 8, yStep++)
@@ -251,8 +252,8 @@ static void TexDecoder_DecodeImpl_C4(u32* dst, const u8* src, int width, int hei
 
 FUNCTION_TARGET_SSSE3
 static void TexDecoder_DecodeImpl_I4_SSSE3(u32* dst, const u8* src, int width, int height,
-                                           int texformat, const u8* tlut, TlutFormat tlutfmt,
-                                           int Wsteps4, int Wsteps8)
+                                           TextureFormat texformat, const u8* tlut,
+                                           TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
 {
   const __m128i kMask_x0f = _mm_set1_epi32(0x0f0f0f0fL);
   const __m128i kMask_xf0 = _mm_set1_epi32(0xf0f0f0f0L);
@@ -298,8 +299,9 @@ static void TexDecoder_DecodeImpl_I4_SSSE3(u32* dst, const u8* src, int width, i
   }
 }
 
-static void TexDecoder_DecodeImpl_I4(u32* dst, const u8* src, int width, int height, int texformat,
-                                     const u8* tlut, TlutFormat tlutfmt, int Wsteps4, int Wsteps8)
+static void TexDecoder_DecodeImpl_I4(u32* dst, const u8* src, int width, int height,
+                                     TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
+                                     int Wsteps4, int Wsteps8)
 {
   const __m128i kMask_x0f = _mm_set1_epi32(0x0f0f0f0fL);
   const __m128i kMask_xf0 = _mm_set1_epi32(0xf0f0f0f0L);
@@ -390,8 +392,8 @@ static void TexDecoder_DecodeImpl_I4(u32* dst, const u8* src, int width, int hei
 
 FUNCTION_TARGET_SSSE3
 static void TexDecoder_DecodeImpl_I8_SSSE3(u32* dst, const u8* src, int width, int height,
-                                           int texformat, const u8* tlut, TlutFormat tlutfmt,
-                                           int Wsteps4, int Wsteps8)
+                                           TextureFormat texformat, const u8* tlut,
+                                           TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
 {
   // xsacha optimized with SSSE3 intrinsics
   // Produces a ~10% speed improvement over SSE2 implementation
@@ -419,8 +421,9 @@ static void TexDecoder_DecodeImpl_I8_SSSE3(u32* dst, const u8* src, int width, i
   }
 }
 
-static void TexDecoder_DecodeImpl_I8(u32* dst, const u8* src, int width, int height, int texformat,
-                                     const u8* tlut, TlutFormat tlutfmt, int Wsteps4, int Wsteps8)
+static void TexDecoder_DecodeImpl_I8(u32* dst, const u8* src, int width, int height,
+                                     TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
+                                     int Wsteps4, int Wsteps8)
 {
   // JSD optimized with SSE2 intrinsics.
   // Produces an ~86% speed improvement over reference C implementation.
@@ -518,12 +521,13 @@ static void TexDecoder_DecodeImpl_I8(u32* dst, const u8* src, int width, int hei
   }
 }
 
-static void TexDecoder_DecodeImpl_C8(u32* dst, const u8* src, int width, int height, int texformat,
-                                     const u8* tlut, TlutFormat tlutfmt, int Wsteps4, int Wsteps8)
+static void TexDecoder_DecodeImpl_C8(u32* dst, const u8* src, int width, int height,
+                                     TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
+                                     int Wsteps4, int Wsteps8)
 {
   switch (tlutfmt)
   {
-  case GX_TL_RGB5A3:
+  case TLUTFormat::RGB5A3:
   {
     for (int y = 0; y < height; y += 4)
       for (int x = 0, yStep = (y / 4) * Wsteps8; x < width; x += 8, yStep++)
@@ -532,7 +536,7 @@ static void TexDecoder_DecodeImpl_C8(u32* dst, const u8* src, int width, int hei
   }
   break;
 
-  case GX_TL_IA8:
+  case TLUTFormat::IA8:
   {
     for (int y = 0; y < height; y += 4)
       for (int x = 0, yStep = (y / 4) * Wsteps8; x < width; x += 8, yStep++)
@@ -541,7 +545,7 @@ static void TexDecoder_DecodeImpl_C8(u32* dst, const u8* src, int width, int hei
   }
   break;
 
-  case GX_TL_RGB565:
+  case TLUTFormat::RGB565:
   {
     for (int y = 0; y < height; y += 4)
       for (int x = 0, yStep = (y / 4) * Wsteps8; x < width; x += 8, yStep++)
@@ -555,8 +559,9 @@ static void TexDecoder_DecodeImpl_C8(u32* dst, const u8* src, int width, int hei
   }
 }
 
-static void TexDecoder_DecodeImpl_IA4(u32* dst, const u8* src, int width, int height, int texformat,
-                                      const u8* tlut, TlutFormat tlutfmt, int Wsteps4, int Wsteps8)
+static void TexDecoder_DecodeImpl_IA4(u32* dst, const u8* src, int width, int height,
+                                      TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
+                                      int Wsteps4, int Wsteps8)
 {
   for (int y = 0; y < height; y += 4)
   {
@@ -572,8 +577,8 @@ static void TexDecoder_DecodeImpl_IA4(u32* dst, const u8* src, int width, int he
 
 FUNCTION_TARGET_SSSE3
 static void TexDecoder_DecodeImpl_IA8_SSSE3(u32* dst, const u8* src, int width, int height,
-                                            int texformat, const u8* tlut, TlutFormat tlutfmt,
-                                            int Wsteps4, int Wsteps8)
+                                            TextureFormat texformat, const u8* tlut,
+                                            TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
 {
   // xsacha optimized with SSSE3 intrinsics.
   // Produces an ~50% speed improvement over SSE2 implementation.
@@ -595,8 +600,9 @@ static void TexDecoder_DecodeImpl_IA8_SSSE3(u32* dst, const u8* src, int width, 
   }
 }
 
-static void TexDecoder_DecodeImpl_IA8(u32* dst, const u8* src, int width, int height, int texformat,
-                                      const u8* tlut, TlutFormat tlutfmt, int Wsteps4, int Wsteps8)
+static void TexDecoder_DecodeImpl_IA8(u32* dst, const u8* src, int width, int height,
+                                      TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
+                                      int Wsteps4, int Wsteps8)
 {
   // JSD optimized with SSE2 intrinsics.
   // Produces an ~80% speed improvement over reference C implementation.
@@ -656,12 +662,12 @@ static void TexDecoder_DecodeImpl_IA8(u32* dst, const u8* src, int width, int he
 }
 
 static void TexDecoder_DecodeImpl_C14X2(u32* dst, const u8* src, int width, int height,
-                                        int texformat, const u8* tlut, TlutFormat tlutfmt,
+                                        TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
                                         int Wsteps4, int Wsteps8)
 {
   switch (tlutfmt)
   {
-  case GX_TL_RGB5A3:
+  case TLUTFormat::RGB5A3:
   {
     for (int y = 0; y < height; y += 4)
       for (int x = 0, yStep = (y / 4) * Wsteps4; x < width; x += 4, yStep++)
@@ -670,7 +676,7 @@ static void TexDecoder_DecodeImpl_C14X2(u32* dst, const u8* src, int width, int 
   }
   break;
 
-  case GX_TL_IA8:
+  case TLUTFormat::IA8:
   {
     for (int y = 0; y < height; y += 4)
       for (int x = 0, yStep = (y / 4) * Wsteps4; x < width; x += 4, yStep++)
@@ -679,7 +685,7 @@ static void TexDecoder_DecodeImpl_C14X2(u32* dst, const u8* src, int width, int 
   }
   break;
 
-  case GX_TL_RGB565:
+  case TLUTFormat::RGB565:
   {
     for (int y = 0; y < height; y += 4)
       for (int x = 0, yStep = (y / 4) * Wsteps4; x < width; x += 4, yStep++)
@@ -694,8 +700,8 @@ static void TexDecoder_DecodeImpl_C14X2(u32* dst, const u8* src, int width, int 
 }
 
 static void TexDecoder_DecodeImpl_RGB565(u32* dst, const u8* src, int width, int height,
-                                         int texformat, const u8* tlut, TlutFormat tlutfmt,
-                                         int Wsteps4, int Wsteps8)
+                                         TextureFormat texformat, const u8* tlut,
+                                         TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
 {
   // JSD optimized with SSE2 intrinsics.
   // Produces an ~78% speed improvement over reference C implementation.
@@ -766,8 +772,8 @@ static void TexDecoder_DecodeImpl_RGB565(u32* dst, const u8* src, int width, int
 
 FUNCTION_TARGET_SSSE3
 static void TexDecoder_DecodeImpl_RGB5A3_SSSE3(u32* dst, const u8* src, int width, int height,
-                                               int texformat, const u8* tlut, TlutFormat tlutfmt,
-                                               int Wsteps4, int Wsteps8)
+                                               TextureFormat texformat, const u8* tlut,
+                                               TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
 {
   const __m128i kMask_x1f = _mm_set1_epi32(0x0000001fL);
   const __m128i kMask_x0f = _mm_set1_epi32(0x0000000fL);
@@ -872,8 +878,8 @@ static void TexDecoder_DecodeImpl_RGB5A3_SSSE3(u32* dst, const u8* src, int widt
 }
 
 static void TexDecoder_DecodeImpl_RGB5A3(u32* dst, const u8* src, int width, int height,
-                                         int texformat, const u8* tlut, TlutFormat tlutfmt,
-                                         int Wsteps4, int Wsteps8)
+                                         TextureFormat texformat, const u8* tlut,
+                                         TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
 {
   const __m128i kMask_x1f = _mm_set1_epi32(0x0000001fL);
   const __m128i kMask_x0f = _mm_set1_epi32(0x0000000fL);
@@ -993,8 +999,8 @@ static void TexDecoder_DecodeImpl_RGB5A3(u32* dst, const u8* src, int width, int
 
 FUNCTION_TARGET_SSSE3
 static void TexDecoder_DecodeImpl_RGBA8_SSSE3(u32* dst, const u8* src, int width, int height,
-                                              int texformat, const u8* tlut, TlutFormat tlutfmt,
-                                              int Wsteps4, int Wsteps8)
+                                              TextureFormat texformat, const u8* tlut,
+                                              TLUTFormat tlutfmt, int Wsteps4, int Wsteps8)
 {
   // xsacha optimized with SSSE3 instrinsics
   // Produces a ~30% speed improvement over SSE2 implementation
@@ -1027,7 +1033,7 @@ static void TexDecoder_DecodeImpl_RGBA8_SSSE3(u32* dst, const u8* src, int width
 }
 
 static void TexDecoder_DecodeImpl_RGBA8(u32* dst, const u8* src, int width, int height,
-                                        int texformat, const u8* tlut, TlutFormat tlutfmt,
+                                        TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
                                         int Wsteps4, int Wsteps8)
 {
   // JSD optimized with SSE2 intrinsics
@@ -1148,7 +1154,7 @@ static void TexDecoder_DecodeImpl_RGBA8(u32* dst, const u8* src, int width, int 
 }
 
 static void TexDecoder_DecodeImpl_CMPR(u32* dst, const u8* src, int width, int height,
-                                       int texformat, const u8* tlut, TlutFormat tlutfmt,
+                                       TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt,
                                        int Wsteps4, int Wsteps8)
 {
   // The metroid games use this format almost exclusively.
@@ -1403,19 +1409,19 @@ static void TexDecoder_DecodeImpl_CMPR(u32* dst, const u8* src, int width, int h
   }
 }
 
-void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int texformat,
-                            const u8* tlut, TlutFormat tlutfmt)
+void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, TextureFormat texformat,
+                            const u8* tlut, TLUTFormat tlutfmt)
 {
   int Wsteps4 = (width + 3) / 4;
   int Wsteps8 = (width + 7) / 8;
 
   switch (texformat)
   {
-  case GX_TF_C4:
+  case TextureFormat::C4:
     TexDecoder_DecodeImpl_C4(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4, Wsteps8);
     break;
 
-  case GX_TF_I4:
+  case TextureFormat::I4:
     if (cpu_info.bSSSE3)
       TexDecoder_DecodeImpl_I4_SSSE3(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4,
                                      Wsteps8);
@@ -1423,7 +1429,7 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int 
       TexDecoder_DecodeImpl_I4(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4, Wsteps8);
     break;
 
-  case GX_TF_I8:
+  case TextureFormat::I8:
     if (cpu_info.bSSSE3)
       TexDecoder_DecodeImpl_I8_SSSE3(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4,
                                      Wsteps8);
@@ -1431,15 +1437,15 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int 
       TexDecoder_DecodeImpl_I8(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4, Wsteps8);
     break;
 
-  case GX_TF_C8:
+  case TextureFormat::C8:
     TexDecoder_DecodeImpl_C8(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4, Wsteps8);
     break;
 
-  case GX_TF_IA4:
+  case TextureFormat::IA4:
     TexDecoder_DecodeImpl_IA4(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4, Wsteps8);
     break;
 
-  case GX_TF_IA8:
+  case TextureFormat::IA8:
     if (cpu_info.bSSSE3)
       TexDecoder_DecodeImpl_IA8_SSSE3(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4,
                                       Wsteps8);
@@ -1448,17 +1454,17 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int 
                                 Wsteps8);
     break;
 
-  case GX_TF_C14X2:
+  case TextureFormat::C14X2:
     TexDecoder_DecodeImpl_C14X2(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4,
                                 Wsteps8);
     break;
 
-  case GX_TF_RGB565:
+  case TextureFormat::RGB565:
     TexDecoder_DecodeImpl_RGB565(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4,
                                  Wsteps8);
     break;
 
-  case GX_TF_RGB5A3:
+  case TextureFormat::RGB5A3:
     if (cpu_info.bSSSE3)
       TexDecoder_DecodeImpl_RGB5A3_SSSE3(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4,
                                          Wsteps8);
@@ -1467,7 +1473,7 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int 
                                    Wsteps8);
     break;
 
-  case GX_TF_RGBA8:
+  case TextureFormat::RGBA8:
     if (cpu_info.bSSSE3)
       TexDecoder_DecodeImpl_RGBA8_SSSE3(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4,
                                         Wsteps8);
@@ -1476,12 +1482,13 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int 
                                   Wsteps8);
     break;
 
-  case GX_TF_CMPR:
+  case TextureFormat::CMPR:
     TexDecoder_DecodeImpl_CMPR(dst, src, width, height, texformat, tlut, tlutfmt, Wsteps4, Wsteps8);
     break;
 
   default:
-    PanicAlert("Unhandled texture format %d", texformat);
+    PanicAlert("Invalid Texture Format (0x%X)! (_TexDecoder_DecodeImpl)",
+               static_cast<int>(texformat));
     break;
   }
 }


### PR DESCRIPTION
Improve bookkeeping around texture formats. This simplifies code and hopefully makes it less confusing.

This PR does several things:
- Use enum classes to prevent using a Texture format where an EFB Copy format is expected or vice-versa.
- Rename TlutFormat -> TLUTFormat to follow our conventions.
- Use common names for EFB Copy formats; they are no longer segregated by Intensity or Depth properties. Source format, destination format, depth, and yuv are now part of a new struct, EFBCopyParams.

I made every effort to avoid breaking things, but this PR needs thorough testing before it should be merged.

**Edited to add:** Please see TextureDecoder.h for comments about problems Dolphin might have re. depth formats. I did not try to fix these problems.