### PR TITLE
Detect and use system-wide pugixml if available

### DIFF
--- a/CMake/FindPugiXML.cmake
+++ b/CMake/FindPugiXML.cmake
@@ -1,0 +1,15 @@
+# - Find PugiXML library
+# Find the native PugiXML includes and library
+#
+# This module defines
+#  PugiXML_INCLUDE_DIR, where to find PugiXML.h, etc.
+#  PugiXML_LIBRARIES, libraries to link against to use PugiXML.
+#  PugiXML_FOUND, if false, do not try to use PugiXML.
+
+find_path(PugiXML_INCLUDE_DIR pugixml.hpp)
+find_library(PugiXML_LIBRARIES NAMES pugixml)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PugiXML REQUIRED_VARS PugiXML_LIBRARIES PugiXML_INCLUDE_DIR)
+
+mark_as_advanced(PugiXML_INCLUDE_DIR PugiXML_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,7 +551,15 @@ include_directories(Externals/Bochs_disasm)
 
 add_subdirectory(Externals/glslang)
 
-add_subdirectory(Externals/pugixml)
+find_package(PugiXML)
+if(PugiXML_FOUND)
+  message(STATUS "Using shared pugixml")
+  include_directories(${PugiXML_INCLUDE_DIRS})
+else()
+  message(STATUS "Shared pugixml not found, falling back to the static library")
+  add_subdirectory(Externals/pugixml)
+  include_directories(Externals/pugixml)
+endif()
 
 add_subdirectory(Externals/cpp-optparse)
 


### PR DESCRIPTION
The included `FindPugiXML.cmake` module is as basic as it can get, so will likely only suffice if PugiXML is installed in the canonical `/usr/include` and `/usr/lib` or `/usr/lib64` paths on Linux.

It works on Mageia 6 x86_64 with:
```
/usr/include/pugiconfig.hpp
/usr/include/pugixml.hpp
/usr/lib64/libpugixml.so
```
from pugixml 1.7.