### PR TITLE
SysConf: Fix writing a new SYSCONF

### DIFF
--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -197,7 +197,7 @@ bool SysConf::Save() const
   std::copy(footer.cbegin(), footer.cend(), buffer.end() - footer.size());
 
   // Write the new data.
-  const std::string temp_file = File::GetTempFilenameForAtomicWrite(m_file_name);
+  const std::string temp_file = m_file_name + ".tmp";
   File::CreateFullPath(temp_file);
   {
     File::IOFile file(temp_file, "wb");


### PR DESCRIPTION
On Windows, File::GetTempFilenameForAtomicWrite returns a path somewhere in C:\Users\XXX\AppData\Local\Temp\{UUID here}\ in which all writes just fail.

Just use the SYSCONF path + ".tmp" for the temporary file name.