### PR TITLE
Config: Fix the loader Load() being called twice

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -38,17 +38,6 @@ void AddLayer(std::unique_ptr<ConfigLayerLoader> loader)
   AddLayer(std::make_unique<Layer>(std::move(loader)));
 }
 
-void AddLoadLayer(std::unique_ptr<Layer> layer)
-{
-  layer->Load();
-  AddLayer(std::move(layer));
-}
-
-void AddLoadLayer(std::unique_ptr<ConfigLayerLoader> loader)
-{
-  AddLoadLayer(std::make_unique<Layer>(std::move(loader)));
-}
-
 Layer* GetLayer(LayerType layer)
 {
   if (!LayerExists(layer))

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -43,8 +43,6 @@ Section* GetOrCreateSection(System system, const std::string& section_name);
 Layers* GetLayers();
 void AddLayer(std::unique_ptr<Layer> layer);
 void AddLayer(std::unique_ptr<ConfigLayerLoader> loader);
-void AddLoadLayer(std::unique_ptr<Layer> layer);
-void AddLoadLayer(std::unique_ptr<ConfigLayerLoader> loader);
 Layer* GetLayer(LayerType layer);
 void RemoveLayer(LayerType layer);
 bool LayerExists(LayerType layer);

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -244,8 +244,8 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     std::string game_id = SConfig::GetInstance().GetGameID();
     u16 revision = SConfig::GetInstance().GetRevision();
 
-    Config::AddLoadLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
-    Config::AddLoadLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
+    Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
+    Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
 
     IniFile game_ini = StartUp.LoadGameIni();
 
@@ -357,7 +357,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
 
   if (NetPlay::IsNetPlayRunning())
   {
-    Config::AddLoadLayer(ConfigLoaders::GenerateNetPlayConfigLoader(g_NetPlaySettings));
+    Config::AddLayer(ConfigLoaders::GenerateNetPlayConfigLoader(g_NetPlaySettings));
     StartUp.bCPUThread = g_NetPlaySettings.m_CPUthread;
     StartUp.bEnableCheats = g_NetPlaySettings.m_EnableCheats;
     StartUp.bDSPHLE = g_NetPlaySettings.m_DSPHLE;

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -33,7 +33,7 @@ namespace UICommon
 void Init()
 {
   Config::Init();
-  Config::AddLoadLayer(ConfigLoaders::GenerateBaseConfigLoader());
+  Config::AddLayer(ConfigLoaders::GenerateBaseConfigLoader());
   SConfig::Init();
   LogManager::Init();
   VideoBackendBase::PopulateList();


### PR DESCRIPTION
The Config::AddLoadLayer functions call Load on the layer
explicitly, but Load is already called in the constructor,
so they'd cause the loader's Load function to be called twice,
which is potentially expensive considering we have to read an INI
from the host filesystem.

This commit removes the Config::AddLoadLayer functions because
they don't appear to be necessary.