### PR TITLE
Config: Reload game INI on title change

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -241,12 +241,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
   // Load game specific settings
   if (!std::holds_alternative<BootParameters::IPL>(boot->parameters))
   {
-    std::string game_id = SConfig::GetInstance().GetGameID();
-    u16 revision = SConfig::GetInstance().GetRevision();
-
-    Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
-    Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
-
     IniFile game_ini = StartUp.LoadGameIni();
 
     // General settings

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -791,6 +791,9 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, u64 title_id, u
   m_title_description = title_database.Describe(m_game_id, type);
   NOTICE_LOG(CORE, "Active title: %s", m_title_description.c_str());
 
+  Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
+  Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
+
   if (Core::IsRunning())
   {
     // TODO: have a callback mechanism for title changes?


### PR DESCRIPTION
Enables any code that uses OnionConfig to use the correct config for the current title, not just the first title that was booted.

This is especially useful for enabling/disabling accurate video settings as required.

Depends on #5853.