### PR TITLE
Fix ubershader crashes with primus/bumblebee

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -154,6 +154,9 @@ private:
   struct SharedContextData
   {
     std::unique_ptr<cInterfaceBase> context;
+    GLuint prerender_FBO;
+    GLuint prerender_FBO_tex;
+    GLuint prerender_FBO_depth;
     GLuint prerender_VBO;
     GLuint prerender_VAO;
     GLuint prerender_IBO;


### PR DESCRIPTION
Supports surfaceless contexts in GLX, since primus/bumblebee/whatever doesn't expose the pbuffer GLX client extension.

Also creates a FBO for the shared contexts to draw into. This also ensures that the shared context shares a similar setup to the main context's framebuffer, potentially reducing the number of variants a driver needs to generate.