### PR TITLE
VideoConfig: Drop force vertex/pixel ubershader settings

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -87,10 +87,6 @@ const ConfigInfo<int> GFX_SHADER_COMPILER_THREADS{
     {System::GFX, "Settings", "ShaderCompilerThreads"}, 1};
 const ConfigInfo<int> GFX_SHADER_PRECOMPILER_THREADS{
     {System::GFX, "Settings", "ShaderPrecompilerThreads"}, 1};
-const ConfigInfo<bool> GFX_FORCE_VERTEX_UBER_SHADERS{
-    {System::GFX, "Settings", "ForceVertexUberShaders"}, false};
-const ConfigInfo<bool> GFX_FORCE_PIXEL_UBER_SHADERS{
-    {System::GFX, "Settings", "ForcePixelUberShaders"}, false};
 
 const ConfigInfo<bool> GFX_SW_ZCOMPLOC{{System::GFX, "Settings", "SWZComploc"}, true};
 const ConfigInfo<bool> GFX_SW_ZFREEZE{{System::GFX, "Settings", "SWZFreeze"}, true};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -64,8 +64,6 @@ extern const ConfigInfo<bool> GFX_DISABLE_SPECIALIZED_SHADERS;
 extern const ConfigInfo<bool> GFX_PRECOMPILE_UBER_SHADERS;
 extern const ConfigInfo<int> GFX_SHADER_COMPILER_THREADS;
 extern const ConfigInfo<int> GFX_SHADER_PRECOMPILER_THREADS;
-extern const ConfigInfo<bool> GFX_FORCE_VERTEX_UBER_SHADERS;
-extern const ConfigInfo<bool> GFX_FORCE_PIXEL_UBER_SHADERS;
 
 extern const ConfigInfo<bool> GFX_SW_ZCOMPLOC;
 extern const ConfigInfo<bool> GFX_SW_ZFREEZE;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -47,7 +47,6 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::GFX_DISABLE_SPECIALIZED_SHADERS.location,
       Config::GFX_PRECOMPILE_UBER_SHADERS.location, Config::GFX_SHADER_COMPILER_THREADS.location,
       Config::GFX_SHADER_PRECOMPILER_THREADS.location,
-      Config::GFX_FORCE_VERTEX_UBER_SHADERS.location, Config::GFX_FORCE_PIXEL_UBER_SHADERS.location,
 
       Config::GFX_SW_ZCOMPLOC.location, Config::GFX_SW_ZFREEZE.location,
       Config::GFX_SW_DUMP_OBJECTS.location, Config::GFX_SW_DUMP_TEV_STAGES.location,

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -593,7 +593,7 @@ void PixelShaderCache::Shutdown()
 
 bool PixelShaderCache::SetShader()
 {
-  if (g_ActiveConfig.bDisableSpecializedShaders || g_ActiveConfig.bForcePixelUberShaders)
+  if (g_ActiveConfig.bDisableSpecializedShaders)
     return SetUberShader();
 
   PixelShaderUid uid = GetPixelShaderUid();

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -249,7 +249,7 @@ void VertexShaderCache::Shutdown()
 
 bool VertexShaderCache::SetShader(D3DVertexFormat* vertex_format)
 {
-  if (g_ActiveConfig.bDisableSpecializedShaders || g_ActiveConfig.bForceVertexUberShaders)
+  if (g_ActiveConfig.bDisableSpecializedShaders)
     return SetUberShader(vertex_format);
 
   VertexShaderUid uid = GetVertexShaderUid();

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -271,19 +271,8 @@ SHADER* ProgramShaderCache::SetShader(u32 primitive_type, const GLVertexFormat* 
 
   // Synchronous shader compiling.
   ShaderHostConfig host_config = ShaderHostConfig::GetCurrent();
-  ShaderCode vcode;
-  if (!g_ActiveConfig.bForceVertexUberShaders)
-    vcode = GenerateVertexShaderCode(APIType::OpenGL, host_config, uid.vuid.GetUidData());
-  else
-    vcode = UberShader::GenVertexShader(APIType::OpenGL, host_config,
-                                        UberShader::GetVertexShaderUid().GetUidData());
-  ShaderCode pcode;
-  if (!g_ActiveConfig.bForcePixelUberShaders)
-    pcode = GeneratePixelShaderCode(APIType::OpenGL, host_config, uid.puid.GetUidData());
-  else
-    pcode = UberShader::GenPixelShader(APIType::OpenGL, host_config,
-                                       UberShader::GetPixelShaderUid().GetUidData());
-
+  ShaderCode vcode = GenerateVertexShaderCode(APIType::OpenGL, host_config, uid.vuid.GetUidData());
+  ShaderCode pcode = GeneratePixelShaderCode(APIType::OpenGL, host_config, uid.puid.GetUidData());
   ShaderCode gcode;
   if (g_ActiveConfig.backend_info.bSupportsGeometryShaders &&
       !uid.guid.GetUidData()->IsPassthrough())

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1132,8 +1132,6 @@ void Renderer::CheckForConfigChanges()
   bool old_force_filtering = g_ActiveConfig.bForceFiltering;
   bool old_use_xfb = g_ActiveConfig.bUseXFB;
   bool old_use_realxfb = g_ActiveConfig.bUseRealXFB;
-  bool old_vertex_ubershaders = g_ActiveConfig.bForceVertexUberShaders;
-  bool old_pixel_ubershaders = g_ActiveConfig.bForcePixelUberShaders;
 
   // Copy g_Config to g_ActiveConfig.
   // NOTE: This can potentially race with the UI thread, however if it does, the changes will be
@@ -1147,8 +1145,6 @@ void Renderer::CheckForConfigChanges()
   bool aspect_changed = old_aspect_ratio != g_ActiveConfig.iAspectRatio;
   bool use_xfb_changed = old_use_xfb != g_ActiveConfig.bUseXFB;
   bool use_realxfb_changed = old_use_realxfb != g_ActiveConfig.bUseRealXFB;
-  bool ubershaders_changed = old_vertex_ubershaders != g_ActiveConfig.bForceVertexUberShaders ||
-                             old_pixel_ubershaders != g_ActiveConfig.bForcePixelUberShaders;
 
   // Update texture cache settings with any changed options.
   TextureCache::GetInstance()->OnConfigChanged(g_ActiveConfig);
@@ -1193,10 +1189,6 @@ void Renderer::CheckForConfigChanges()
   // Wipe sampler cache if force texture filtering or anisotropy changes.
   if (anisotropy_changed || force_texture_filtering_changed)
     ResetSamplerStates();
-
-  // Clear UID state if ubershaders are toggled.
-  if (ubershaders_changed)
-    StateTracker::GetInstance()->ClearShaders();
 
   // Check for a changed post-processing shader and recompile if needed.
   static_cast<VulkanPostProcessing*>(m_post_processor.get())->UpdateConfig();

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -385,20 +385,15 @@ bool StateTracker::CheckForShaderChanges(u32 gx_primitive_type)
     }
   }
 
-  // Ubershader fallback?
-  bool uber_vertex_shader = use_ubershaders || g_ActiveConfig.bForceVertexUberShaders;
-  bool uber_pixel_shader = use_ubershaders || g_ActiveConfig.bForcePixelUberShaders;
-  bool using_ubershaders = uber_vertex_shader || uber_pixel_shader;
-
   // Switching to/from ubershaders? Have to adjust the vertex format and pipeline layout.
-  if (using_ubershaders != m_using_ubershaders)
+  if (use_ubershaders != m_using_ubershaders)
   {
-    m_using_ubershaders = using_ubershaders;
+    m_using_ubershaders = use_ubershaders;
     UpdatePipelineLayout();
     UpdatePipelineVertexFormat();
   }
 
-  if (uber_vertex_shader)
+  if (use_ubershaders)
   {
     UberShader::VertexShaderUid uber_vs_uid = UberShader::GetVertexShaderUid();
     VkShaderModule vs = g_shader_cache->GetVertexUberShaderForUid(uber_vs_uid);
@@ -408,9 +403,7 @@ bool StateTracker::CheckForShaderChanges(u32 gx_primitive_type)
       m_pipeline_state.vs = vs;
       changed = true;
     }
-  }
-  if (uber_pixel_shader)
-  {
+
     UberShader::PixelShaderUid uber_ps_uid = UberShader::GetPixelShaderUid();
     VkShaderModule ps = g_shader_cache->GetPixelUberShaderForUid(uber_ps_uid);
     if (ps != m_pipeline_state.ps)

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -99,8 +99,6 @@ void VideoConfig::Refresh()
   bPrecompileUberShaders = Config::Get(Config::GFX_PRECOMPILE_UBER_SHADERS);
   iShaderCompilerThreads = Config::Get(Config::GFX_SHADER_COMPILER_THREADS);
   iShaderPrecompilerThreads = Config::Get(Config::GFX_SHADER_PRECOMPILER_THREADS);
-  bForceVertexUberShaders = Config::Get(Config::GFX_FORCE_VERTEX_UBER_SHADERS);
-  bForcePixelUberShaders = Config::Get(Config::GFX_FORCE_PIXEL_UBER_SHADERS);
 
   bZComploc = Config::Get(Config::GFX_SW_ZCOMPLOC);
   bZFreeze = Config::Get(Config::GFX_SW_ZFREEZE);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -194,10 +194,6 @@ struct VideoConfig final
   int iShaderCompilerThreads;
   int iShaderPrecompilerThreads;
 
-  // Temporary toggling of ubershaders, for debugging
-  bool bForceVertexUberShaders;
-  bool bForcePixelUberShaders;
-
   // Static config per API
   // TODO: Move this out of VideoConfig
   struct


### PR DESCRIPTION
This was mainly included for debugging, but could end up being confusing for users, as well as polluting the GL program cache with a mix of uber and specialized shaders if the option was changed.