### PR TITLE
Ubershaders: Fix 6-bit color truncation not being applied

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -134,18 +134,19 @@ static void BPWritten(const BPCmd& bp)
     GeometryShaderManager::SetLinePtWidthChanged();
     return;
   case BPMEM_ZMODE:  // Depth Control
-    PRIM_LOG("zmode: test=%d, func=%d, upd=%d", (int)bpmem.zmode.testenable, (int)bpmem.zmode.func,
-             (int)bpmem.zmode.updateenable);
+    PRIM_LOG("zmode: test=%u, func=%u, upd=%u", bpmem.zmode.testenable.Value(),
+             bpmem.zmode.func.Value(), bpmem.zmode.updateenable.Value());
     SetDepthMode();
+    PixelShaderManager::SetZModeControl();
     return;
   case BPMEM_BLENDMODE:  // Blending Control
     if (bp.changes & 0xFFFF)
     {
-      PRIM_LOG("blendmode: en=%d, open=%d, colupd=%d, alphaupd=%d, dst=%d, src=%d, sub=%d, mode=%d",
-               (int)bpmem.blendmode.blendenable, (int)bpmem.blendmode.logicopenable,
-               (int)bpmem.blendmode.colorupdate, (int)bpmem.blendmode.alphaupdate,
-               (int)bpmem.blendmode.dstfactor, (int)bpmem.blendmode.srcfactor,
-               (int)bpmem.blendmode.subtract, (int)bpmem.blendmode.logicmode);
+      PRIM_LOG("blendmode: en=%u, open=%u, colupd=%u, alphaupd=%u, dst=%u, src=%u, sub=%u, mode=%u",
+               bpmem.blendmode.blendenable.Value(), bpmem.blendmode.logicopenable.Value(),
+               bpmem.blendmode.colorupdate.Value(), bpmem.blendmode.alphaupdate.Value(),
+               bpmem.blendmode.dstfactor.Value(), bpmem.blendmode.srcfactor.Value(),
+               bpmem.blendmode.subtract.Value(), bpmem.blendmode.logicmode.Value());
 
       // Set Blending Mode
       if (bp.changes)
@@ -424,6 +425,7 @@ static void BPWritten(const BPCmd& bp)
       g_renderer->SetColorMask();  // alpha writing needs to be disabled if the new pixel format
                                    // doesn't have an alpha channel
     }
+    PixelShaderManager::SetZModeControl();
     return;
 
   case BPMEM_MIPMAP_STRIDE:  // MipMap Stride Channel

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -33,7 +33,7 @@ struct PixelShaderConstants
   u32 fogRangeBase;  // .y
   u32 dstalpha;      // .z
   u32 ztex_op;       // .w
-  u32 early_ztest;   // .x (bool)
+  u32 late_ztest;    // .x (bool)
   u32 rgba6_format;  // .y (bool)
   u32 dither;        // .z (bool)
   u32 bounding_box;  // .w (bool)

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -379,7 +379,7 @@ void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texg
             "\tuint  bpmem_fogRangeBase;\n"
             "\tuint  bpmem_dstalpha;\n"
             "\tuint  bpmem_ztex_op;\n"
-            "\tbool  bpmem_early_ztest;\n"
+            "\tbool  bpmem_late_ztest;\n"
             "\tbool  bpmem_rgba6_format;\n"
             "\tbool  bpmem_dither;\n"
             "\tbool  bpmem_bounding_box;\n"

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -447,17 +447,17 @@ void PixelShaderManager::SetGenModeChanged()
   dirty = true;
 }
 
-void PixelShaderManager::SetZControlChanged()
+void PixelShaderManager::SetZModeControl()
 {
-  u32 early_ztest = bpmem.zcontrol.early_ztest ? 1 : 0;
+  u32 late_ztest = bpmem.UseLateDepthTest();
   u32 rgba6_format =
       (bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24 && !g_ActiveConfig.bForceTrueColor) ? 1 :
                                                                                                  0;
   u32 dither = rgba6_format && bpmem.blendmode.dither;
-  if (constants.early_ztest != early_ztest || constants.rgba6_format != rgba6_format ||
+  if (constants.late_ztest != late_ztest || constants.rgba6_format != rgba6_format ||
       constants.dither != dither)
   {
-    constants.early_ztest = early_ztest;
+    constants.late_ztest = late_ztest;
     constants.rgba6_format = rgba6_format;
     constants.dither = dither;
     dirty = true;

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -45,7 +45,7 @@ public:
   static void SetFogParamChanged();
   static void SetFogRangeAdjustChanged();
   static void SetGenModeChanged();
-  static void SetZControlChanged();
+  static void SetZModeControl();
   static void SetBlendModeChanged();
   static void SetBoundingBoxActive(bool active);
 

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -894,7 +894,7 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
   {
     out.Write("  // If early depth is enabled, write to zbuffer before depth textures\n");
     out.Write("  // If early depth isn't enabled, we write to the zbuffer here\n");
-    out.Write("  int zbuffer_zCoord = bpmem_early_ztest ? early_zCoord : zCoord;\n");
+    out.Write("  int zbuffer_zCoord = bpmem_late_ztest ? zCoord : early_zCoord;\n");
     if (ApiType == APIType::D3D || ApiType == APIType::Vulkan)
       out.Write("  depth = 1.0 - float(zbuffer_zCoord) / 16777216.0;\n");
     else


### PR DESCRIPTION
Also switches the check from early z to late z, since we use that to determine when to enable per-pixel depth in the first place. Fixes the broken UI and colors in cyber sled.