### PR TITLE
Fix axis not working with Switch Pro controller on macOS

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -39,7 +39,10 @@ Joystick::Joystick(IOHIDDeviceRef device, std::string name)
   }
 
   // Axes
-  NSDictionary* axisDict = @{ @kIOHIDElementTypeKey : @(kIOHIDElementTypeInput_Misc) };
+  NSDictionary* axisDict = @{
+    @kIOHIDElementTypeKey : @(kIOHIDElementTypeInput_Misc),
+    @kIOHIDElementUsagePageKey : @(kHIDPage_GenericDesktop)
+  };
 
   CFArrayRef axes =
       IOHIDDeviceCopyMatchingElements(m_device, (CFDictionaryRef)axisDict, kIOHIDOptionsTypeNone);


### PR DESCRIPTION
Each axis would appear as multiple elements with 0 min/max.
Filter the list of elements using the correct usage page like
done for buttons.