### PR TITLE
Config: Missed a line in #5770

### DIFF
--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -95,6 +95,7 @@ void Set(LayerType layer, const ConfigInfo<T>& info, const T& value)
   GetLayer(layer)
       ->GetOrCreateSection(info.location.system, info.location.section)
       ->Set(info.location.key, value);
+  InvokeConfigChangedCallbacks();
 }
 
 template <typename T>


### PR DESCRIPTION

Due to this missed line, settings were not reloaded after being set by the frontend, causing [issue 10424](https://bugs.dolphin-emu.org/issues/10424).