### PR TITLE
GameINI: Replace Wii.Widescreen with AspectRatio

### DIFF
--- a/Data/Sys/GameSettings/C.ini
+++ b/Data/Sys/GameSettings/C.ini
@@ -11,5 +11,5 @@ EmulationIssues =
 [Video]
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/C.ini
+++ b/Data/Sys/GameSettings/C.ini
@@ -6,12 +6,10 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = 
+EmulationIssues =
 
 [Video]
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/E.ini
+++ b/Data/Sys/GameSettings/E.ini
@@ -9,5 +9,5 @@ EmulationIssues =
 EmulationStateId = 4
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/E.ini
+++ b/Data/Sys/GameSettings/E.ini
@@ -5,11 +5,9 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = 
+EmulationIssues =
 EmulationStateId = 4
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/F.ini
+++ b/Data/Sys/GameSettings/F.ini
@@ -9,6 +9,7 @@ EmulationIssues = Texture filtering will cause glitches.
 EmulationStateId = 4
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]
@@ -24,6 +25,3 @@ EFBToTextureEnable = False
 [Video_Enhancements]
 MaxAnisotropy = 0
 ForceFiltering = False
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/F.ini
+++ b/Data/Sys/GameSettings/F.ini
@@ -9,7 +9,7 @@ EmulationIssues = Texture filtering will cause glitches.
 EmulationStateId = 4
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0
 
 [Video_Hacks]

--- a/Data/Sys/GameSettings/J.ini
+++ b/Data/Sys/GameSettings/J.ini
@@ -9,5 +9,5 @@ EmulationIssues =
 EmulationStateId = 4
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/J.ini
+++ b/Data/Sys/GameSettings/J.ini
@@ -5,11 +5,9 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = 
+EmulationIssues =
 EmulationStateId = 4
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/L.ini
+++ b/Data/Sys/GameSettings/L.ini
@@ -9,7 +9,7 @@ EmulationStateId = 4
 EmulationIssues =
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/L.ini
+++ b/Data/Sys/GameSettings/L.ini
@@ -6,12 +6,10 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = 
+EmulationIssues =
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
 UseXFB = True
 UseRealXFB = True
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/M.ini
+++ b/Data/Sys/GameSettings/M.ini
@@ -9,5 +9,5 @@ EmulationIssues =
 EmulationStateId = 4
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/M.ini
+++ b/Data/Sys/GameSettings/M.ini
@@ -5,11 +5,9 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = 
+EmulationIssues =
 EmulationStateId = 4
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/N.ini
+++ b/Data/Sys/GameSettings/N.ini
@@ -1,4 +1,4 @@
 # Nxxxxx - All Nintendo 64 Virtual Console games
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/N.ini
+++ b/Data/Sys/GameSettings/N.ini
@@ -1,4 +1,4 @@
 # Nxxxxx - All Nintendo 64 Virtual Console games
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/P.ini
+++ b/Data/Sys/GameSettings/P.ini
@@ -1,4 +1,4 @@
-# Pxxxxx - All TurboGrafx 16 Virtual Console games 
+# Pxxxxx - All TurboGrafx 16 Virtual Console games
 # Note: there are a few weird GameCube games (mostly bonus disks) which also use this code.
 
 [Core]
@@ -7,12 +7,10 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = 
+EmulationIssues =
 
 [Video]
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/P.ini
+++ b/Data/Sys/GameSettings/P.ini
@@ -12,5 +12,5 @@ EmulationIssues =
 [Video]
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/Q.ini
+++ b/Data/Sys/GameSettings/Q.ini
@@ -8,5 +8,5 @@ EmulationIssues =
 [Video]
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/Q.ini
+++ b/Data/Sys/GameSettings/Q.ini
@@ -3,12 +3,10 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = 
+EmulationIssues =
 
 [Video]
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/R55.ini
+++ b/Data/Sys/GameSettings/R55.ini
@@ -18,7 +18,5 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 0
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/R55.ini
+++ b/Data/Sys/GameSettings/R55.ini
@@ -18,5 +18,5 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RBI.ini
+++ b/Data/Sys/GameSettings/RBI.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RBI.ini
+++ b/Data/Sys/GameSettings/RBI.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RBL.ini
+++ b/Data/Sys/GameSettings/RBL.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RBL.ini
+++ b/Data/Sys/GameSettings/RBL.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RBT.ini
+++ b/Data/Sys/GameSettings/RBT.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RBT.ini
+++ b/Data/Sys/GameSettings/RBT.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RCC.ini
+++ b/Data/Sys/GameSettings/RCC.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RCC.ini
+++ b/Data/Sys/GameSettings/RCC.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RCP.ini
+++ b/Data/Sys/GameSettings/RCP.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RCP.ini
+++ b/Data/Sys/GameSettings/RCP.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RDB.ini
+++ b/Data/Sys/GameSettings/RDB.ini
@@ -18,5 +18,5 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RDB.ini
+++ b/Data/Sys/GameSettings/RDB.ini
@@ -18,7 +18,5 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 512
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/RDS.ini
+++ b/Data/Sys/GameSettings/RDS.ini
@@ -18,5 +18,5 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RDS.ini
+++ b/Data/Sys/GameSettings/RDS.ini
@@ -18,7 +18,5 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 512
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/RG2.ini
+++ b/Data/Sys/GameSettings/RG2.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RG2.ini
+++ b/Data/Sys/GameSettings/RG2.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RGB.ini
+++ b/Data/Sys/GameSettings/RGB.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RGB.ini
+++ b/Data/Sys/GameSettings/RGB.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RGM.ini
+++ b/Data/Sys/GameSettings/RGM.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RGM.ini
+++ b/Data/Sys/GameSettings/RGM.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RGS.ini
+++ b/Data/Sys/GameSettings/RGS.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RGS.ini
+++ b/Data/Sys/GameSettings/RGS.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RI3.ini
+++ b/Data/Sys/GameSettings/RI3.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RI3.ini
+++ b/Data/Sys/GameSettings/RI3.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RKD.ini
+++ b/Data/Sys/GameSettings/RKD.ini
@@ -18,7 +18,5 @@ EmulationStateId = 5
 # Add action replay cheats here.
 
 [Video_Settings]
+AspectRatio = 2
 SafeTextureCacheColorSamples = 512
-
-[Wii]
-Widescreen = False

--- a/Data/Sys/GameSettings/RKD.ini
+++ b/Data/Sys/GameSettings/RKD.ini
@@ -18,5 +18,5 @@ EmulationStateId = 5
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RLT.ini
+++ b/Data/Sys/GameSettings/RLT.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RLT.ini
+++ b/Data/Sys/GameSettings/RLT.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RMP.ini
+++ b/Data/Sys/GameSettings/RMP.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RMP.ini
+++ b/Data/Sys/GameSettings/RMP.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RNX.ini
+++ b/Data/Sys/GameSettings/RNX.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RNX.ini
+++ b/Data/Sys/GameSettings/RNX.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/ROD.ini
+++ b/Data/Sys/GameSettings/ROD.ini
@@ -20,5 +20,5 @@ EmulationIssues =
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/ROD.ini
+++ b/Data/Sys/GameSettings/ROD.ini
@@ -21,4 +21,4 @@ EmulationIssues =
 EFBEmulateFormatChanges = True
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RPG.ini
+++ b/Data/Sys/GameSettings/RPG.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RPG.ini
+++ b/Data/Sys/GameSettings/RPG.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RPY.ini
+++ b/Data/Sys/GameSettings/RPY.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RPY.ini
+++ b/Data/Sys/GameSettings/RPY.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RQW.ini
+++ b/Data/Sys/GameSettings/RQW.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RQW.ini
+++ b/Data/Sys/GameSettings/RQW.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RRB.ini
+++ b/Data/Sys/GameSettings/RRB.ini
@@ -19,4 +19,4 @@ EmulationIssues = Needs Synchronise GPU thread for stability. Use direct3d11 for
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RRB.ini
+++ b/Data/Sys/GameSettings/RRB.ini
@@ -18,5 +18,5 @@ EmulationIssues = Needs Synchronise GPU thread for stability. Use direct3d11 for
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RS5.ini
+++ b/Data/Sys/GameSettings/RS5.ini
@@ -20,5 +20,5 @@ EmulationIssues =
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RS5.ini
+++ b/Data/Sys/GameSettings/RS5.ini
@@ -21,4 +21,4 @@ EmulationIssues =
 EFBEmulateFormatChanges = True
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RTR.ini
+++ b/Data/Sys/GameSettings/RTR.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Wii]
-Widescreen = False
+[Video_Settings]
+AspectRatio = 2

--- a/Data/Sys/GameSettings/RTR.ini
+++ b/Data/Sys/GameSettings/RTR.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-AspectRatio = 2
+SuggestedAspectRatio = 2

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -23,6 +23,8 @@ const ConfigInfo<int> GFX_ADAPTER{{System::GFX, "Hardware", "Adapter"}, 0};
 const ConfigInfo<bool> GFX_WIDESCREEN_HACK{{System::GFX, "Settings", "wideScreenHack"}, false};
 const ConfigInfo<int> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"},
                                        static_cast<int>(ASPECT_AUTO)};
+const ConfigInfo<int> GFX_SUGGESTED_ASPECT_RATIO{{System::GFX, "Settings", "SuggestedAspectRatio"},
+                                                 static_cast<int>(ASPECT_AUTO)};
 const ConfigInfo<bool> GFX_CROP{{System::GFX, "Settings", "Crop"}, false};
 const ConfigInfo<bool> GFX_USE_XFB{{System::GFX, "Settings", "UseXFB"}, false};
 const ConfigInfo<bool> GFX_USE_REAL_XFB{{System::GFX, "Settings", "UseRealXFB"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -21,6 +21,7 @@ extern const ConfigInfo<int> GFX_ADAPTER;
 
 extern const ConfigInfo<bool> GFX_WIDESCREEN_HACK;
 extern const ConfigInfo<int> GFX_ASPECT_RATIO;
+extern const ConfigInfo<int> GFX_SUGGESTED_ASPECT_RATIO;
 extern const ConfigInfo<bool> GFX_CROP;
 extern const ConfigInfo<bool> GFX_USE_XFB;
 extern const ConfigInfo<bool> GFX_USE_REAL_XFB;

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -71,6 +71,7 @@ static const INIToLocationMap& GetINIToLocationMap()
 
       {{"Video_Settings", "wideScreenHack"}, {Config::GFX_WIDESCREEN_HACK.location}},
       {{"Video_Settings", "AspectRatio"}, {Config::GFX_ASPECT_RATIO.location}},
+      {{"Video_Settings", "SuggestedAspectRatio"}, {Config::GFX_SUGGESTED_ASPECT_RATIO.location}},
       {{"Video_Settings", "Crop"}, {Config::GFX_CROP.location}},
       {{"Video_Settings", "UseXFB"}, {Config::GFX_USE_XFB.location}},
       {{"Video_Settings", "UseRealXFB"}, {Config::GFX_USE_REAL_XFB.location}},

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -56,7 +56,11 @@ void VideoConfig::Refresh()
   iAdapter = Config::Get(Config::GFX_ADAPTER);
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
-  iAspectRatio = Config::Get(Config::GFX_ASPECT_RATIO);
+  const int aspect_ratio = Config::Get(Config::GFX_ASPECT_RATIO);
+  if (aspect_ratio == ASPECT_AUTO)
+    iAspectRatio = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
+  else
+    iAspectRatio = aspect_ratio;
   bCrop = Config::Get(Config::GFX_CROP);
   bUseXFB = Config::Get(Config::GFX_USE_XFB);
   bUseRealXFB = Config::Get(Config::GFX_USE_REAL_XFB);


### PR DESCRIPTION
Wii.Widescreen is a setting that cannot be changed on the fly after emulation has started, so anything booted after the initial title will have an unexpected aspect ratio.

We can just set Video_Settings.AspectRatio instead, which *can* be live changed, since it doesn't involve messing with the SYSCONF at any time.

This is also much closer to the behaviour of the Wii U, which configures the DMCU to force 4:3 transparently, instead of doing it the intrusive way (touching the SYSCONF). Also more similar to how things would work on a real Wii, where the user would change the TV settings instead of SYSCONF.