### PR TITLE
D3DBase: Raise error if d3dcompiler_47.dll cannot be loaded

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -103,25 +103,16 @@ HRESULT LoadD3DCompiler()
   if (hD3DCompilerDll)
     return S_OK;
 
-  // try to load D3DCompiler first to check whether we have proper runtime support
-  // try to use the dll the backend was compiled against first - don't bother about debug runtimes
+  // The older version of the D3D compiler cannot compile our ubershaders without various
+  // graphical issues. D3DCOMPILER_DLL_A should point to d3dcompiler_47.dll, so if this fails
+  // to load, inform the user that they need to update their system.
   hD3DCompilerDll = LoadLibraryA(D3DCOMPILER_DLL_A);
   if (!hD3DCompilerDll)
   {
-    // if that fails, use the dll which should be available in every SDK which officially supports
-    // DX11.
-    hD3DCompilerDll = LoadLibraryA("D3DCompiler_42.dll");
-    if (!hD3DCompilerDll)
-    {
-      MessageBoxA(nullptr, "Failed to load D3DCompiler_42.dll, update your DX11 runtime, please",
-                  "Critical error", MB_OK | MB_ICONERROR);
-      return E_FAIL;
-    }
-    else
-    {
-      NOTICE_LOG(VIDEO, "Successfully loaded D3DCompiler_42.dll. If you're having trouble, try "
-                        "updating your DX runtime first.");
-    }
+    PanicAlertT("Failed to load %s. If you are using Windows 7, try installing the "
+                "KB4019990 update package.",
+                D3DCOMPILER_DLL_A);
+    return E_FAIL;
   }
 
   PD3DReflect = (D3DREFLECT)GetProcAddress(hD3DCompilerDll, "D3DReflect");


### PR DESCRIPTION
Previously we were falling back to an earlier version of the compiler. The older version cannot compile our ubershaders without various graphical issues.

The error message informs the user to install KB4019990 (https://support.microsoft.com/en-us/help/4019990/update-for-the-d3dcompiler-47-dll-component-on-windows) if the DLL cannot be loaded.

The other option would be to ship d3dcompiler_47.dll with Dolphin, at the cost of a larger download size. However, personally, I don't see the issue with requiring a fully up-to-date system if the user is on Windows 7.