### PR TITLE
Properly handle g_wiimotes_mutex again for real wiimotes

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -892,11 +892,13 @@ bool CheckForButtonPress(int wiimote_number)
   if (!g_wiimotes_mutex.try_lock())
     return false;
 
+  bool button_pressed = false;
+
   if (g_wiimotes[wiimote_number])
-    return g_wiimotes[wiimote_number]->CheckForButtonPress();
+    button_pressed = g_wiimotes[wiimote_number]->CheckForButtonPress();
 
   g_wiimotes_mutex.unlock();
-  return false;
+  return button_pressed;
 }
 
 bool IsValidDeviceName(const std::string& name)


### PR DESCRIPTION
for the reconnect on button press feature.

Sorry, i overlooked the mutex in PR  https://github.com/dolphin-emu/dolphin/pull/4949

This pr fixes issue 10434: https://bugs.dolphin-emu.org/issues/10434