### PR TITLE
Config: Port SYSCONF and parts of Movie to new config system

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -101,8 +101,7 @@ void ClearCurrentRunLayer()
 static const std::map<System, std::string> system_to_name = {
     {System::Main, "Dolphin"},          {System::GCPad, "GCPad"},  {System::WiiPad, "Wiimote"},
     {System::GCKeyboard, "GCKeyboard"}, {System::GFX, "Graphics"}, {System::Logger, "Logger"},
-    {System::Debugger, "Debugger"},     {System::UI, "UI"},
-};
+    {System::Debugger, "Debugger"},     {System::UI, "UI"},        {System::SYSCONF, "SYSCONF"}};
 
 const std::string& GetSystemName(System system)
 {

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -66,9 +66,7 @@ LayerType GetActiveLayerForConfig(const ConfigLocation&);
 template <typename T>
 T Get(LayerType layer, const ConfigInfo<T>& info)
 {
-  return GetLayer(layer)
-      ->GetOrCreateSection(info.location.system, info.location.section)
-      ->template Get<T>(info.location.key, info.default_value);
+  return GetLayer(layer)->Get(info);
 }
 
 template <typename T>
@@ -92,9 +90,7 @@ LayerType GetActiveLayerForConfig(const ConfigInfo<T>& info)
 template <typename T>
 void Set(LayerType layer, const ConfigInfo<T>& info, const T& value)
 {
-  GetLayer(layer)
-      ->GetOrCreateSection(info.location.system, info.location.section)
-      ->Set(info.location.key, value);
+  GetLayer(layer)->Set(info, value);
   InvokeConfigChangedCallbacks();
 }
 

--- a/Source/Core/Common/Config/Enums.h
+++ b/Source/Core/Common/Config/Enums.h
@@ -23,6 +23,7 @@ enum class LayerType
 enum class System
 {
   Main,
+  SYSCONF,
   GCPad,
   WiiPad,
   GCKeyboard,

--- a/Source/Core/Common/Config/Layer.cpp
+++ b/Source/Core/Common/Config/Layer.cpp
@@ -109,11 +109,6 @@ const LayerMap& Layer::GetLayerMap() const
   return m_sections;
 }
 
-ConfigLayerLoader* Layer::GetLoader() const
-{
-  return m_loader.get();
-}
-
 bool Layer::IsDirty() const
 {
   return std::any_of(m_sections.begin(), m_sections.end(), [](const auto& system) {

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -14,6 +14,9 @@
 
 namespace Config
 {
+template <typename T>
+struct ConfigInfo;
+
 using LayerMap = std::map<System, std::vector<std::unique_ptr<Section>>>;
 
 class ConfigLayerLoader
@@ -51,6 +54,20 @@ public:
 
   virtual Section* GetSection(System system, const std::string& section_name);
   virtual Section* GetOrCreateSection(System system, const std::string& section_name);
+
+  template <typename T>
+  T Get(const ConfigInfo<T>& config_info)
+  {
+    return GetOrCreateSection(config_info.location.system, config_info.location.section)
+        ->template Get<T>(config_info.location.key, config_info.default_value);
+  }
+
+  template <typename T>
+  void Set(const ConfigInfo<T>& config_info, const T& value)
+  {
+    GetOrCreateSection(config_info.location.system, config_info.location.section)
+        ->Set(config_info.location.key, value);
+  }
 
   // Explicit load and save of layers
   void Load();

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -75,8 +75,6 @@ public:
 
   LayerType GetLayer() const;
   const LayerMap& GetLayerMap() const;
-  // Stay away from this routine as much as possible
-  ConfigLayerLoader* GetLoader() const;
 
 protected:
   bool IsDirty() const;

--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -14,7 +14,6 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
-#include "Core/Movie.h"
 
 constexpr size_t SYSCONF_SIZE = 0x4000;
 
@@ -61,8 +60,6 @@ void SysConf::Load()
     WARN_LOG(CORE, "No valid SYSCONF detected. Creating a new one.");
     InsertDefaultEntries();
   }
-
-  ApplySettingsFromMovie();
 }
 
 bool SysConf::LoadFromFile(const std::string& file_name)
@@ -255,17 +252,6 @@ void SysConf::RemoveEntry(const std::string& key)
   m_entries.erase(std::remove_if(m_entries.begin(), m_entries.end(),
                                  [&key](const auto& entry) { return entry.name == key; }),
                   m_entries.end());
-}
-
-// Apply Wii settings from normal SYSCONF on Movie recording/playback
-void SysConf::ApplySettingsFromMovie()
-{
-  if (!Movie::IsMovieActive())
-    return;
-
-  SetData<u8>("IPL.LNG", Entry::Type::Byte, Movie::GetLanguage());
-  SetData<u8>("IPL.E60", Entry::Type::Byte, Movie::IsPAL60());
-  SetData<u8>("IPL.PGS", Entry::Type::Byte, Movie::IsProgressive());
 }
 
 void SysConf::InsertDefaultEntries()

--- a/Source/Core/Common/SysConf.h
+++ b/Source/Core/Common/SysConf.h
@@ -84,7 +84,6 @@ public:
   }
 
 private:
-  void ApplySettingsFromMovie();
   void InsertDefaultEntries();
   bool LoadFromFile(const std::string& file_name);
 

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -20,6 +20,7 @@
 #include "Common/CDUtils.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/File.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
@@ -29,6 +30,7 @@
 #include "Core/Boot/DolReader.h"
 #include "Core/Boot/ElfReader.h"
 #include "Core/CommonTitles.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/HLE/HLE.h"
@@ -289,7 +291,8 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
   g_symbolDB.Clear();
 
   // PAL Wii uses NTSC framerate and linecount in 60Hz modes
-  VideoInterface::Preset(DiscIO::IsNTSC(config.m_region) || (config.bWii && config.bPAL60));
+  VideoInterface::Preset(DiscIO::IsNTSC(config.m_region) ||
+                         (config.bWii && Config::Get(Config::SYSCONF_PAL60)));
 
   struct BootTitle
   {

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -33,7 +33,10 @@
 
 #include "Common/Config/Config.h"
 #include "Core/Boot/Boot.h"
+#include "Core/Config/SYSCONFSettings.h"
+#include "Core/ConfigLoaders/BaseConfigLoader.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
+#include "Core/ConfigLoaders/MovieConfigLoader.h"
 #include "Core/ConfigLoaders/NetPlayConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -83,12 +86,9 @@ private:
   bool bFastDiscSpeed;
   bool bDSPHLE;
   bool bHLE_BS2;
-  bool bProgressive;
-  bool bPAL60;
   int iSelectedLanguage;
   int iCPUCore;
   int Volume;
-  int m_wii_language;
   float m_EmulationSpeed;
   float m_OCFactor;
   bool m_OCEnable;
@@ -116,8 +116,6 @@ void ConfigCache::SaveConfig(const SConfig& config)
   bFastDiscSpeed = config.bFastDiscSpeed;
   bDSPHLE = config.bDSPHLE;
   bHLE_BS2 = config.bHLE_BS2;
-  bProgressive = config.bProgressive;
-  bPAL60 = config.bPAL60;
   iSelectedLanguage = config.SelectedLanguage;
   iCPUCore = config.iCPUCore;
   Volume = config.m_Volume;
@@ -125,7 +123,6 @@ void ConfigCache::SaveConfig(const SConfig& config)
   strBackend = config.m_strVideoBackend;
   sBackend = config.sBackend;
   m_strGPUDeterminismMode = config.m_strGPUDeterminismMode;
-  m_wii_language = config.m_wii_language;
   m_OCFactor = config.m_OCFactor;
   m_OCEnable = config.m_OCEnable;
 
@@ -160,8 +157,6 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bFastDiscSpeed = bFastDiscSpeed;
   config->bDSPHLE = bDSPHLE;
   config->bHLE_BS2 = bHLE_BS2;
-  config->bProgressive = bProgressive;
-  config->bPAL60 = bPAL60;
   config->SelectedLanguage = iSelectedLanguage;
   config->iCPUCore = iCPUCore;
 
@@ -180,8 +175,6 @@ void ConfigCache::RestoreConfig(SConfig* config)
         WiimoteReal::ChangeWiimoteSource(i, iWiimoteSource[i]);
       }
     }
-
-    config->m_wii_language = m_wii_language;
   }
 
   for (unsigned int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
@@ -263,8 +256,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     core_section->Get("GFXBackend", &StartUp.m_strVideoBackend, StartUp.m_strVideoBackend);
     core_section->Get("CPUCore", &StartUp.iCPUCore, StartUp.iCPUCore);
     core_section->Get("HLE_BS2", &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
-    core_section->Get("ProgressiveScan", &StartUp.bProgressive, StartUp.bProgressive);
-    core_section->Get("PAL60", &StartUp.bPAL60, StartUp.bPAL60);
     core_section->Get("GameCubeLanguage", &StartUp.SelectedLanguage, StartUp.SelectedLanguage);
     if (core_section->Get("EmulationSpeed", &StartUp.m_EmulationSpeed, StartUp.m_EmulationSpeed))
       config_cache.bSetEmulationSpeed = true;
@@ -293,10 +284,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     // Wii settings
     if (StartUp.bWii)
     {
-      IniFile::Section* wii_section = game_ini.GetOrCreateSection("Wii");
-      wii_section->Get("Widescreen", &StartUp.m_wii_aspect_ratio, !!StartUp.m_wii_aspect_ratio);
-      wii_section->Get("Language", &StartUp.m_wii_language, StartUp.m_wii_language);
-
       int source;
       for (unsigned int i = 0; i < MAX_WIIMOTES; ++i)
       {
@@ -325,11 +312,8 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
   // Movie settings
   if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
   {
-    Config::AddLayer(std::make_unique<Config::Layer>(Config::LayerType::Movie));
     StartUp.bCPUThread = Movie::IsDualCore();
     StartUp.bDSPHLE = Movie::IsDSPHLE();
-    StartUp.bProgressive = Movie::IsProgressive();
-    StartUp.bPAL60 = Movie::IsPAL60();
     StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
     StartUp.iCPUCore = Movie::GetCPUMode();
     StartUp.bSyncGPU = Movie::IsSyncGPU();
@@ -360,8 +344,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     StartUp.iCPUCore = g_NetPlaySettings.m_CPUcore;
     StartUp.SelectedLanguage = g_NetPlaySettings.m_SelectedLanguage;
     StartUp.bOverrideGCLanguage = g_NetPlaySettings.m_OverrideGCLanguage;
-    StartUp.bProgressive = g_NetPlaySettings.m_ProgressiveScan;
-    StartUp.bPAL60 = g_NetPlaySettings.m_PAL60;
     StartUp.m_DSPEnableJIT = g_NetPlaySettings.m_DSPEnableJIT;
     StartUp.m_OCEnable = g_NetPlaySettings.m_OCEnable;
     StartUp.m_OCFactor = g_NetPlaySettings.m_OCFactor;
@@ -388,12 +370,11 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
   // Some NTSC Wii games such as Doc Louis's Punch-Out!! and
   // 1942 (Virtual Console) crash if the PAL60 option is enabled
   if (StartUp.bWii && ntsc)
-  {
-    StartUp.bPAL60 = false;
-  }
+    Config::SetCurrent(Config::SYSCONF_PAL60, false);
 
+  // Ensure any new settings are written to the SYSCONF
   if (StartUp.bWii)
-    StartUp.SaveSettingsToSysconf();
+    ConfigLoaders::SaveToSYSCONF(Config::GetLayer(Config::LayerType::Meta));
 
   const bool load_ipl = !StartUp.bWii && !StartUp.bHLE_BS2 &&
                         std::holds_alternative<BootParameters::Disc>(boot->parameters);
@@ -411,14 +392,41 @@ void Stop()
   RestoreConfig();
 }
 
+// SYSCONF can be modified during emulation by the user and internally, which makes it
+// a bad idea to just always overwrite it with the settings from the base layer.
+//
+// Conversely, we also shouldn't just ignore any changes to SYSCONF, as it may cause
+// temporary settings (from Movie, Netplay, game INIs, etc.) to stick around.
+//
+// To avoid inconveniences in most cases, we always restore only the overridden settings.
+static void RestoreSYSCONF()
+{
+  // This layer contains the new SYSCONF settings (including any temporary settings).
+  auto layer = std::make_unique<Config::Layer>(ConfigLoaders::GenerateBaseConfigLoader());
+  for (const auto& setting : Config::SYSCONF_SETTINGS)
+  {
+    std::visit(
+        [&](auto& info) {
+          // If this setting was overridden, then we copy the base layer value back to the SYSCONF.
+          // Otherwise we leave the new value in the SYSCONF.
+          if (Config::GetActiveLayerForConfig(info) != Config::LayerType::Base)
+            layer->Set(info, Config::GetBase(info));
+        },
+        setting.config_info);
+  }
+  // Save the SYSCONF.
+  layer->Save();
+  Config::AddLayer(std::move(layer));
+}
+
 void RestoreConfig()
 {
+  RestoreSYSCONF();
   Config::ClearCurrentRunLayer();
   Config::RemoveLayer(Config::LayerType::Movie);
   Config::RemoveLayer(Config::LayerType::Netplay);
   Config::RemoveLayer(Config::LayerType::GlobalGame);
   Config::RemoveLayer(Config::LayerType::LocalGame);
-  SConfig::GetInstance().LoadSettingsFromSysconf();
   SConfig::GetInstance().ResetRunningGameMetadata();
   config_cache.RestoreConfig(&SConfig::GetInstance());
 }

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -33,6 +33,7 @@
 
 #include "Common/Config/Config.h"
 #include "Core/Boot/Boot.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/BaseConfigLoader.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
@@ -312,13 +313,14 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
   // Movie settings
   if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
   {
-    StartUp.bCPUThread = Movie::IsDualCore();
-    StartUp.bDSPHLE = Movie::IsDSPHLE();
-    StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
-    StartUp.iCPUCore = Movie::GetCPUMode();
-    StartUp.bSyncGPU = Movie::IsSyncGPU();
+    // TODO: remove this once ConfigManager starts using OnionConfig.
+    StartUp.bCPUThread = Config::Get(Config::MAIN_CPU_THREAD);
+    StartUp.bDSPHLE = Config::Get(Config::MAIN_DSP_HLE);
+    StartUp.bFastDiscSpeed = Config::Get(Config::MAIN_FAST_DISC_SPEED);
+    StartUp.iCPUCore = Config::Get(Config::MAIN_CPU_CORE);
+    StartUp.bSyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
     if (!StartUp.bWii)
-      StartUp.SelectedLanguage = Movie::GetLanguage();
+      StartUp.SelectedLanguage = Config::Get(Config::MAIN_GC_LANGUAGE);
     for (int i = 0; i < 2; ++i)
     {
       if (Movie::IsUsingMemcard(i) && Movie::IsStartingFromClearSave() && !StartUp.bWii)

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SRCS
   Boot/ElfReader.cpp
   Config/GraphicsSettings.cpp
   Config/NetplaySettings.cpp
+  Config/SYSCONFSettings.cpp
   ConfigLoaders/BaseConfigLoader.cpp
   ConfigLoaders/GameConfigLoader.cpp
   ConfigLoaders/IsSettingSaveable.cpp

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRCS
   Boot/DolReader.cpp
   Boot/ElfReader.cpp
   Config/GraphicsSettings.cpp
+  Config/MainSettings.cpp
   Config/NetplaySettings.cpp
   Config/SYSCONFSettings.cpp
   ConfigLoaders/BaseConfigLoader.cpp

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -1,0 +1,108 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/Config/MainSettings.h"
+
+#include "AudioCommon/AudioCommon.h"
+#include "Common/Config/Config.h"
+#include "Common/StringUtil.h"
+#include "Core/HW/EXI/EXI_Device.h"
+#include "Core/HW/SI/SI_Device.h"
+#include "Core/PowerPC/PowerPC.h"
+
+namespace Config
+{
+// Main.Core
+
+const ConfigInfo<bool> MAIN_SKIP_IPL{{System::Main, "Core", "SkipIPL"}, true};
+const ConfigInfo<int> MAIN_CPU_CORE{{System::Main, "Core", "CPUCore"}, PowerPC::DefaultCPUCore()};
+const ConfigInfo<bool> MAIN_FASTMEM{{System::Main, "Core", "Fastmem"}, true};
+const ConfigInfo<bool> MAIN_DSP_HLE{{System::Main, "Core", "DSPHLE"}, true};
+const ConfigInfo<int> MAIN_TIMING_VARIANCE{{System::Main, "Core", "TimingVariance"}, 40};
+const ConfigInfo<bool> MAIN_CPU_THREAD{{System::Main, "Core", "CPUThread"}, true};
+const ConfigInfo<bool> MAIN_SYNC_ON_SKIP_IDLE{{System::Main, "Core", "SyncOnSkipIdle"}, true};
+const ConfigInfo<std::string> MAIN_DEFAULT_ISO{{System::Main, "Core", "DefaultISO"}, ""};
+const ConfigInfo<bool> MAIN_ENABLE_CHEATS{{System::Main, "Core", "EnableCheats"}, false};
+const ConfigInfo<int> MAIN_GC_LANGUAGE{{System::Main, "Core", "SelectedLanguage"}, 0};
+const ConfigInfo<bool> MAIN_OVERRIDE_GC_LANGUAGE{{System::Main, "Core", "OverrideGCLang"}, false};
+const ConfigInfo<bool> MAIN_DPL2_DECODER{{System::Main, "Core", "DPL2Decoder"}, false};
+const ConfigInfo<int> MAIN_AUDIO_LATENCY{{System::Main, "Core", "AudioLatency"}, 20};
+const ConfigInfo<bool> MAIN_AUDIO_STRETCH{{System::Main, "Core", "AudioStretch"}, false};
+const ConfigInfo<int> MAIN_AUDIO_STRETCH_LATENCY{{System::Main, "Core", "AudioStretchMaxLatency"},
+                                                 80};
+const ConfigInfo<std::string> MAIN_MEMCARD_A_PATH{{System::Main, "Core", "MemcardAPath"}, ""};
+const ConfigInfo<std::string> MAIN_MEMCARD_B_PATH{{System::Main, "Core", "MemcardBPath"}, ""};
+const ConfigInfo<std::string> MAIN_AGP_CART_A_PATH{{System::Main, "Core", "AgpCartAPath"}, ""};
+const ConfigInfo<std::string> MAIN_AGP_CART_B_PATH{{System::Main, "Core", "AgpCartBPath"}, ""};
+const ConfigInfo<int> MAIN_SLOT_A{{System::Main, "Core", "SlotA"},
+                                  ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER};
+const ConfigInfo<int> MAIN_SLOT_B{{System::Main, "Core", "SlotB"},
+                                  ExpansionInterface::EXIDEVICE_NONE};
+const ConfigInfo<int> MAIN_SERIAL_PORT_1{{System::Main, "Core", "SerialPort1"},
+                                         ExpansionInterface::EXIDEVICE_NONE};
+const ConfigInfo<std::string> MAIN_BBA_MAC{{System::Main, "Core", "BBA_MAC"}, ""};
+
+ConfigInfo<u32> GetInfoForSIDevice(u32 channel)
+{
+  return {{System::Main, "Core", StringFromFormat("SIDevice%u", channel)},
+          static_cast<u32>(channel == 0 ? SerialInterface::SIDEVICE_GC_CONTROLLER :
+                                          SerialInterface::SIDEVICE_NONE)};
+}
+
+ConfigInfo<bool> GetInfoForAdapterRumble(u32 channel)
+{
+  return {{System::Main, "Core", StringFromFormat("AdapterRumble%u", channel)}, true};
+}
+
+ConfigInfo<bool> GetInfoForSimulateKonga(u32 channel)
+{
+  return {{System::Main, "Core", StringFromFormat("SimulateKonga%u", channel)}, false};
+}
+
+const ConfigInfo<bool> MAIN_WII_SD_CARD{{System::Main, "Core", "WiiSDCard"}, false};
+const ConfigInfo<bool> MAIN_WII_KEYBOARD{{System::Main, "Core", "WiiKeyboard"}, false};
+const ConfigInfo<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING{
+    {System::Main, "Core", "WiimoteContinuousScanning"}, false};
+const ConfigInfo<bool> MAIN_WIIMOTE_ENABLE_SPEAKER{{System::Main, "Core", "WiimoteEnableSpeaker"},
+                                                   false};
+const ConfigInfo<bool> MAIN_RUN_COMPARE_SERVER{{System::Main, "Core", "RunCompareServer"}, false};
+const ConfigInfo<bool> MAIN_RUN_COMPARE_CLIENT{{System::Main, "Core", "RunCompareClient"}, false};
+const ConfigInfo<bool> MAIN_MMU{{System::Main, "Core", "MMU"}, false};
+const ConfigInfo<int> MAIN_BB_DUMP_PORT{{System::Main, "Core", "BBDumpPort"}, -1};
+const ConfigInfo<bool> MAIN_SYNC_GPU{{System::Main, "Core", "SyncGPU"}, false};
+const ConfigInfo<int> MAIN_SYNC_GPU_MAX_DISTANCE{{System::Main, "Core", "SyncGpuMaxDistance"},
+                                                 200000};
+const ConfigInfo<int> MAIN_SYNC_GPU_MIN_DISTANCE{{System::Main, "Core", "SyncGpuMinDistance"},
+                                                 -200000};
+const ConfigInfo<float> MAIN_SYNC_GPU_OVERCLOCK{{System::Main, "Core", "SyncGpuOverclock"}, 1.0f};
+const ConfigInfo<bool> MAIN_FAST_DISC_SPEED{{System::Main, "Core", "FastDiscSpeed"}, false};
+const ConfigInfo<bool> MAIN_DCBZ{{System::Main, "Core", "DCBZ"}, false};
+const ConfigInfo<bool> MAIN_LOW_DCBZ_HACK{{System::Main, "Core", "LowDCBZHack"}, false};
+const ConfigInfo<bool> MAIN_FPRF{{System::Main, "Core", "FPRF"}, false};
+const ConfigInfo<bool> MAIN_ACCURATE_NANS{{System::Main, "Core", "AccurateNaNs"}, false};
+const ConfigInfo<float> MAIN_EMULATION_SPEED{{System::Main, "Core", "EmulationSpeed"}, 1.0f};
+const ConfigInfo<float> MAIN_OVERCLOCK{{System::Main, "Core", "Overclock"}, 1.0f};
+const ConfigInfo<bool> MAIN_OVERCLOCK_ENABLE{{System::Main, "Core", "OverclockEnable"}, false};
+const ConfigInfo<std::string> MAIN_GFX_BACKEND{{System::Main, "Core", "GFXBackend"}, ""};
+const ConfigInfo<std::string> MAIN_GPU_DETERMINISM_MODE{
+    {System::Main, "Core", "GPUDeterminismMode"}, "auto"};
+const ConfigInfo<std::string> MAIN_PERF_MAP_DIR{{System::Main, "Core", "PerfMapDir"}, ""};
+const ConfigInfo<bool> MAIN_CUSTOM_RTC_ENABLE{{System::Main, "Core", "EnableCustomRTC"}, false};
+// Default to seconds between 1.1.1970 and 1.1.2000
+const ConfigInfo<u32> MAIN_CUSTOM_RTC_VALUE{{System::Main, "Core", "CustomRTCValue"}, 946684800};
+const ConfigInfo<bool> MAIN_ENABLE_SIGNATURE_CHECKS{{System::Main, "Core", "EnableSignatureChecks"},
+                                                    true};
+
+// Main.DSP
+
+const ConfigInfo<bool> MAIN_DSP_CAPTURE_LOG{{System::Main, "DSP", "CaptureLog"}, false};
+const ConfigInfo<bool> MAIN_DSP_JIT{{System::Main, "DSP", "EnableJIT"}, true};
+const ConfigInfo<bool> MAIN_DUMP_AUDIO{{System::Main, "DSP", "DumpAudio"}, false};
+const ConfigInfo<bool> MAIN_DUMP_AUDIO_SILENT{{System::Main, "DSP", "DumpAudioSilent"}, false};
+const ConfigInfo<bool> MAIN_DUMP_UCODE{{System::Main, "DSP", "DumpUCode"}, false};
+const ConfigInfo<std::string> MAIN_AUDIO_BACKEND{{System::Main, "DSP", "Backend"},
+                                                 AudioCommon::GetDefaultSoundBackend()};
+const ConfigInfo<int> MAIN_AUDIO_VOLUME{{System::Main, "DSP", "Volume"}, 100};
+
+}  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -1,0 +1,80 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "Common/Config/Config.h"
+
+namespace Config
+{
+// Main.Core
+
+extern const ConfigInfo<bool> MAIN_SKIP_IPL;
+extern const ConfigInfo<int> MAIN_CPU_CORE;
+extern const ConfigInfo<bool> MAIN_FASTMEM;
+// Should really be in the DSP section, but we're kind of stuck with bad decisions made in the past.
+extern const ConfigInfo<bool> MAIN_DSP_HLE;
+extern const ConfigInfo<int> MAIN_TIMING_VARIANCE;
+extern const ConfigInfo<bool> MAIN_CPU_THREAD;
+extern const ConfigInfo<bool> MAIN_SYNC_ON_SKIP_IDLE;
+extern const ConfigInfo<std::string> MAIN_DEFAULT_ISO;
+extern const ConfigInfo<bool> MAIN_ENABLE_CHEATS;
+extern const ConfigInfo<int> MAIN_GC_LANGUAGE;
+extern const ConfigInfo<bool> MAIN_OVERRIDE_GC_LANGUAGE;
+extern const ConfigInfo<bool> MAIN_DPL2_DECODER;
+extern const ConfigInfo<int> MAIN_AUDIO_LATENCY;
+extern const ConfigInfo<bool> MAIN_AUDIO_STRETCH;
+extern const ConfigInfo<int> MAIN_AUDIO_STRETCH_LATENCY;
+extern const ConfigInfo<std::string> MAIN_MEMCARD_A_PATH;
+extern const ConfigInfo<std::string> MAIN_MEMCARD_B_PATH;
+extern const ConfigInfo<std::string> MAIN_AGP_CART_A_PATH;
+extern const ConfigInfo<std::string> MAIN_AGP_CART_B_PATH;
+extern const ConfigInfo<int> MAIN_SLOT_A;
+extern const ConfigInfo<int> MAIN_SLOT_B;
+extern const ConfigInfo<int> MAIN_SERIAL_PORT_1;
+extern const ConfigInfo<std::string> MAIN_BBA_MAC;
+ConfigInfo<u32> GetInfoForSIDevice(u32 channel);
+ConfigInfo<bool> GetInfoForAdapterRumble(u32 channel);
+ConfigInfo<bool> GetInfoForSimulateKonga(u32 channel);
+extern const ConfigInfo<bool> MAIN_WII_SD_CARD;
+extern const ConfigInfo<bool> MAIN_WII_KEYBOARD;
+extern const ConfigInfo<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING;
+extern const ConfigInfo<bool> MAIN_WIIMOTE_ENABLE_SPEAKER;
+extern const ConfigInfo<bool> MAIN_RUN_COMPARE_SERVER;
+extern const ConfigInfo<bool> MAIN_RUN_COMPARE_CLIENT;
+extern const ConfigInfo<bool> MAIN_MMU;
+extern const ConfigInfo<int> MAIN_BB_DUMP_PORT;
+extern const ConfigInfo<bool> MAIN_SYNC_GPU;
+extern const ConfigInfo<int> MAIN_SYNC_GPU_MAX_DISTANCE;
+extern const ConfigInfo<int> MAIN_SYNC_GPU_MIN_DISTANCE;
+extern const ConfigInfo<float> MAIN_SYNC_GPU_OVERCLOCK;
+extern const ConfigInfo<bool> MAIN_FAST_DISC_SPEED;
+extern const ConfigInfo<bool> MAIN_DCBZ;
+extern const ConfigInfo<bool> MAIN_LOW_DCBZ_HACK;
+extern const ConfigInfo<bool> MAIN_FPRF;
+extern const ConfigInfo<bool> MAIN_ACCURATE_NANS;
+extern const ConfigInfo<float> MAIN_EMULATION_SPEED;
+extern const ConfigInfo<float> MAIN_OVERCLOCK;
+extern const ConfigInfo<bool> MAIN_OVERCLOCK_ENABLE;
+// Should really be part of System::GFX, but again, we're stuck with past mistakes.
+extern const ConfigInfo<std::string> MAIN_GFX_BACKEND;
+extern const ConfigInfo<std::string> MAIN_GPU_DETERMINISM_MODE;
+extern const ConfigInfo<std::string> MAIN_PERF_MAP_DIR;
+extern const ConfigInfo<bool> MAIN_CUSTOM_RTC_ENABLE;
+extern const ConfigInfo<u32> MAIN_CUSTOM_RTC_VALUE;
+extern const ConfigInfo<bool> MAIN_ENABLE_SIGNATURE_CHECKS;
+
+// Main.DSP
+
+extern const ConfigInfo<bool> MAIN_DSP_CAPTURE_LOG;
+extern const ConfigInfo<bool> MAIN_DSP_JIT;
+extern const ConfigInfo<bool> MAIN_DUMP_AUDIO;
+extern const ConfigInfo<bool> MAIN_DUMP_AUDIO_SILENT;
+extern const ConfigInfo<bool> MAIN_DUMP_UCODE;
+extern const ConfigInfo<std::string> MAIN_AUDIO_BACKEND;
+extern const ConfigInfo<int> MAIN_AUDIO_VOLUME;
+
+}  // namespace Config

--- a/Source/Core/Core/Config/SYSCONFSettings.cpp
+++ b/Source/Core/Core/Config/SYSCONFSettings.cpp
@@ -1,0 +1,34 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/Config/SYSCONFSettings.h"
+
+namespace Config
+{
+// SYSCONF.IPL
+
+const ConfigInfo<bool> SYSCONF_SCREENSAVER{{System::SYSCONF, "IPL", "SSV"}, false};
+const ConfigInfo<u32> SYSCONF_LANGUAGE{{System::SYSCONF, "IPL", "LNG"}, 0x01};
+const ConfigInfo<bool> SYSCONF_WIDESCREEN{{System::SYSCONF, "IPL", "AR"}, true};
+const ConfigInfo<bool> SYSCONF_PROGRESSIVE_SCAN{{System::SYSCONF, "IPL", "PGS"}, true};
+const ConfigInfo<bool> SYSCONF_PAL60{{System::SYSCONF, "IPL", "E60"}, 0x01};
+
+// SYSCONF.BT
+
+const ConfigInfo<u32> SYSCONF_SENSOR_BAR_POSITION{{System::SYSCONF, "BT", "BAR"}, 0x01};
+const ConfigInfo<u32> SYSCONF_SENSOR_BAR_SENSITIVITY{{System::SYSCONF, "BT", "SENS"}, 0x03};
+const ConfigInfo<u32> SYSCONF_SPEAKER_VOLUME{{System::SYSCONF, "BT", "SPKV"}, 0x58};
+const ConfigInfo<bool> SYSCONF_WIIMOTE_MOTOR{{System::SYSCONF, "BT", "MOT"}, true};
+
+const std::array<SYSCONFSetting, 9> SYSCONF_SETTINGS{
+    {{SYSCONF_SCREENSAVER, SysConf::Entry::Type::Byte},
+     {SYSCONF_LANGUAGE, SysConf::Entry::Type::Byte},
+     {SYSCONF_WIDESCREEN, SysConf::Entry::Type::Byte},
+     {SYSCONF_PROGRESSIVE_SCAN, SysConf::Entry::Type::Byte},
+     {SYSCONF_PAL60, SysConf::Entry::Type::Byte},
+     {SYSCONF_SENSOR_BAR_POSITION, SysConf::Entry::Type::Byte},
+     {SYSCONF_SENSOR_BAR_SENSITIVITY, SysConf::Entry::Type::Long},
+     {SYSCONF_SPEAKER_VOLUME, SysConf::Entry::Type::Byte},
+     {SYSCONF_WIIMOTE_MOTOR, SysConf::Entry::Type::Byte}}};
+}  // namespace Config

--- a/Source/Core/Core/Config/SYSCONFSettings.h
+++ b/Source/Core/Core/Config/SYSCONFSettings.h
@@ -1,0 +1,40 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <variant>
+
+#include "Common/Config/Config.h"
+#include "Common/SysConf.h"
+
+namespace Config
+{
+// Note: some settings are actually u8s, but stored as u32 in the layer because of limitations.
+
+// SYSCONF.IPL
+
+extern const ConfigInfo<bool> SYSCONF_SCREENSAVER;
+extern const ConfigInfo<u32> SYSCONF_LANGUAGE;
+extern const ConfigInfo<bool> SYSCONF_WIDESCREEN;
+extern const ConfigInfo<bool> SYSCONF_PROGRESSIVE_SCAN;
+extern const ConfigInfo<bool> SYSCONF_PAL60;
+
+// SYSCONF.BT
+
+extern const ConfigInfo<u32> SYSCONF_SENSOR_BAR_POSITION;
+extern const ConfigInfo<u32> SYSCONF_SENSOR_BAR_SENSITIVITY;
+extern const ConfigInfo<u32> SYSCONF_SPEAKER_VOLUME;
+extern const ConfigInfo<bool> SYSCONF_WIIMOTE_MOTOR;
+
+struct SYSCONFSetting
+{
+  std::variant<ConfigInfo<u32>, ConfigInfo<bool>> config_info;
+  SysConf::Entry::Type type;
+};
+
+extern const std::array<SYSCONFSetting, 9> SYSCONF_SETTINGS;
+
+}  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -9,19 +9,59 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <type_traits>
+#include <variant>
 
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
+#include "Common/SysConf.h"
 
-#include "Common/Config/Config.h"
 #include "Core/Config/GraphicsSettings.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
+#include "Core/Core.h"
+#include "Core/IOS/USB/Bluetooth/BTBase.h"
 
 namespace ConfigLoaders
 {
+void SaveToSYSCONF(Config::Layer* layer)
+{
+  if (Core::IsRunning())
+    return;
+
+  SysConf sysconf{Common::FromWhichRoot::FROM_CONFIGURED_ROOT};
+
+  for (const Config::SYSCONFSetting& setting : Config::SYSCONF_SETTINGS)
+  {
+    std::visit(
+        [layer, &setting, &sysconf](auto& info) {
+          const std::string key = info.location.section + "." + info.location.key;
+
+          if (setting.type == SysConf::Entry::Type::Long)
+            sysconf.SetData<u32>(key, setting.type, layer->Get(info));
+          else if (setting.type == SysConf::Entry::Type::Byte)
+            sysconf.SetData<u8>(key, setting.type, static_cast<u8>(layer->Get(info)));
+        },
+        setting.config_info);
+  }
+
+  // Disable WiiConnect24's standby mode. If it is enabled, it prevents us from receiving
+  // shutdown commands in the State Transition Manager (STM).
+  // TODO: remove this if and once Dolphin supports WC24 standby mode.
+  SysConf::Entry* idle_entry = sysconf.GetOrAddEntry("IPL.IDL", SysConf::Entry::Type::SmallArray);
+  if (idle_entry->bytes.empty())
+    idle_entry->bytes = std::vector<u8>(2);
+  else
+    idle_entry->bytes[0] = 0;
+  NOTICE_LOG(CORE, "Disabling WC24 'standby' (shutdown to idle) to avoid hanging on shutdown");
+
+  IOS::HLE::RestoreBTInfoSection(&sysconf);
+  sysconf.Save();
+}
+
 const std::map<Config::System, int> system_to_ini = {
     {Config::System::Main, F_DOLPHINCONFIG_IDX},
     {Config::System::GCPad, F_GCPADCONFIG_IDX},
@@ -34,12 +74,13 @@ const std::map<Config::System, int> system_to_ini = {
 };
 
 // INI layer configuration loader
-class INIBaseConfigLayerLoader final : public Config::ConfigLayerLoader
+class BaseConfigLayerLoader final : public Config::ConfigLayerLoader
 {
 public:
-  INIBaseConfigLayerLoader() : ConfigLayerLoader(Config::LayerType::Base) {}
+  BaseConfigLayerLoader() : ConfigLayerLoader(Config::LayerType::Base) {}
   void Load(Config::Layer* config_layer) override
   {
+    LoadFromSYSCONF(config_layer);
     for (const auto& system : system_to_ini)
     {
       IniFile ini;
@@ -76,6 +117,12 @@ public:
     const Config::LayerMap& sections = config_layer->GetLayerMap();
     for (const auto& system : sections)
     {
+      if (system.first == Config::System::SYSCONF)
+      {
+        SaveToSYSCONF(config_layer);
+        continue;
+      }
+
       auto mapping = system_to_ini.find(system.first);
       if (mapping == system_to_ini.end())
       {
@@ -116,11 +163,35 @@ public:
       ini.Save(File::GetUserPath(mapping->second));
     }
   }
+
+private:
+  void LoadFromSYSCONF(Config::Layer* layer)
+  {
+    if (Core::IsRunning())
+      return;
+
+    SysConf sysconf{Common::FromWhichRoot::FROM_CONFIGURED_ROOT};
+    for (const Config::SYSCONFSetting& setting : Config::SYSCONF_SETTINGS)
+    {
+      std::visit(
+          [&](auto& info) {
+            const std::string key = info.location.section + "." + info.location.key;
+            auto* section =
+                layer->GetOrCreateSection(Config::System::SYSCONF, info.location.section);
+
+            if (setting.type == SysConf::Entry::Type::Long)
+              section->Set(info.location.key, sysconf.GetData<u32>(key, info.default_value));
+            else if (setting.type == SysConf::Entry::Type::Byte)
+              section->Set(info.location.key, sysconf.GetData<u8>(key, info.default_value));
+          },
+          setting.config_info);
+    }
+  }
 };
 
 // Loader generation
 std::unique_ptr<Config::ConfigLayerLoader> GenerateBaseConfigLoader()
 {
-  return std::make_unique<INIBaseConfigLayerLoader>();
+  return std::make_unique<BaseConfigLayerLoader>();
 }
 }

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.h
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.h
@@ -9,9 +9,11 @@
 namespace Config
 {
 class ConfigLayerLoader;
+class Layer;
 }
 
 namespace ConfigLoaders
 {
+void SaveToSYSCONF(Config::Layer* layer);
 std::unique_ptr<Config::ConfigLayerLoader> GenerateBaseConfigLoader();
 }

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -25,6 +25,7 @@
 
 #include "Common/Config/Config.h"
 #include "Core/Config/GraphicsSettings.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 
 namespace ConfigLoaders
@@ -118,6 +119,11 @@ static const INIToLocationMap& GetINIToLocationMap()
       {{"Video", "PH_ZNear"}, {Config::GFX_PROJECTION_HACK_ZNEAR.location}},
       {{"Video", "PH_ZFar"}, {Config::GFX_PROJECTION_HACK_ZFAR.location}},
       {{"Video", "PerfQueriesEnable"}, {Config::GFX_PERF_QUERIES_ENABLE.location}},
+
+      {{"Core", "ProgressiveScan"}, {Config::SYSCONF_PROGRESSIVE_SCAN.location}},
+      {{"Core", "PAL60"}, {Config::SYSCONF_PAL60.location}},
+      {{"Wii", "Widescreen"}, {Config::SYSCONF_WIDESCREEN.location}},
+      {{"Wii", "Language"}, {Config::SYSCONF_LANGUAGE.location}},
   };
   return ini_to_location;
 }

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -13,6 +13,7 @@
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/Movie.h"
 
 namespace ConfigLoaders
@@ -22,7 +23,6 @@ namespace ConfigLoaders
 void MovieConfigLayerLoader::Load(Config::Layer* config_layer)
 {
   Config::Section* core = config_layer->GetOrCreateSection(Config::System::Main, "Core");
-  Config::Section* display = config_layer->GetOrCreateSection(Config::System::Main, "Display");
   Config::Section* video_settings = Config::GetOrCreateSection(Config::System::GFX, "Settings");
   Config::Section* video_hacks = Config::GetOrCreateSection(Config::System::GFX, "Hacks");
 
@@ -33,8 +33,11 @@ void MovieConfigLayerLoader::Load(Config::Layer* config_layer)
   core->Set("CPUCore", m_header->CPUCore);
   core->Set("SyncGPU", m_header->bSyncGPU);
   core->Set("GFXBackend", std::string(reinterpret_cast<char*>(m_header->videoBackend)));
-  display->Set("ProgressiveScan", m_header->bProgressive);
-  display->Set("PAL60", m_header->bPAL60);
+
+  config_layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, m_header->bProgressive);
+  config_layer->Set(Config::SYSCONF_PAL60, m_header->bPAL60);
+  if (m_header->bWii)
+    config_layer->Set(Config::SYSCONF_LANGUAGE, static_cast<u32>(m_header->language));
 
   video_settings->Set("UseXFB", m_header->bUseXFB);
   video_settings->Set("UseRealXFB", m_header->bUseRealXFB);
@@ -46,7 +49,6 @@ void MovieConfigLayerLoader::Load(Config::Layer* config_layer)
 void MovieConfigLayerLoader::Save(Config::Layer* config_layer)
 {
   Config::Section* core = config_layer->GetOrCreateSection(Config::System::Main, "Core");
-  Config::Section* display = config_layer->GetOrCreateSection(Config::System::Main, "Display");
   Config::Section* video_settings = Config::GetOrCreateSection(Config::System::GFX, "Settings");
   Config::Section* video_hacks = Config::GetOrCreateSection(Config::System::GFX, "Hacks");
 
@@ -60,8 +62,10 @@ void MovieConfigLayerLoader::Save(Config::Layer* config_layer)
   core->Get("CPUCore", &cpu_core);
   core->Get("SyncGPU", &m_header->bSyncGPU);
   core->Get("GFXBackend", &video_backend);
-  display->Get("ProgressiveScan", &m_header->bProgressive);
-  display->Get("PAL60", &m_header->bPAL60);
+  m_header->bProgressive = config_layer->Get(Config::SYSCONF_PROGRESSIVE_SCAN);
+  m_header->bPAL60 = config_layer->Get(Config::SYSCONF_PAL60);
+  if (m_header->bWii)
+    m_header->language = config_layer->Get(Config::SYSCONF_LANGUAGE);
 
   video_settings->Get("UseXFB", &m_header->bUseXFB);
   video_settings->Get("UseRealXFB", &m_header->bUseRealXFB);

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -13,73 +13,79 @@
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 
+#include "Core/Config/GraphicsSettings.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
+#include "Core/ConfigManager.h"
 #include "Core/Movie.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace ConfigLoaders
 {
+static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
+{
+  config_layer->Set(Config::MAIN_CPU_THREAD, dtm->bDualCore);
+  config_layer->Set(Config::MAIN_DSP_HLE, dtm->bDSPHLE);
+  config_layer->Set(Config::MAIN_FAST_DISC_SPEED, dtm->bFastDiscSpeed);
+  config_layer->Set(Config::MAIN_CPU_CORE, static_cast<int>(dtm->CPUCore));
+  config_layer->Set(Config::MAIN_SYNC_GPU, dtm->bSyncGPU);
+  config_layer->Set(Config::MAIN_GFX_BACKEND,
+                    std::string(reinterpret_cast<char*>(dtm->videoBackend)));
+
+  config_layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, dtm->bProgressive);
+  config_layer->Set(Config::SYSCONF_PAL60, dtm->bPAL60);
+  if (dtm->bWii)
+    config_layer->Set(Config::SYSCONF_LANGUAGE, static_cast<u32>(dtm->language));
+  else
+    config_layer->Set(Config::MAIN_GC_LANGUAGE, static_cast<int>(dtm->language));
+
+  config_layer->Set(Config::GFX_USE_XFB, dtm->bUseXFB);
+  config_layer->Set(Config::GFX_USE_REAL_XFB, dtm->bUseRealXFB);
+  config_layer->Set(Config::GFX_HACK_EFB_ACCESS_ENABLE, dtm->bEFBAccessEnable);
+  config_layer->Set(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, dtm->bSkipEFBCopyToRam);
+  config_layer->Set(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES, dtm->bEFBEmulateFormatChanges);
+}
+
+void SaveToDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
+{
+  dtm->bDualCore = config_layer->Get(Config::MAIN_CPU_THREAD);
+  dtm->bDSPHLE = config_layer->Get(Config::MAIN_DSP_HLE);
+  dtm->bFastDiscSpeed = config_layer->Get(Config::MAIN_FAST_DISC_SPEED);
+  dtm->CPUCore = config_layer->Get(Config::MAIN_CPU_CORE);
+  dtm->bSyncGPU = config_layer->Get(Config::MAIN_SYNC_GPU);
+  const std::string video_backend = config_layer->Get(Config::MAIN_GFX_BACKEND);
+
+  dtm->bProgressive = config_layer->Get(Config::SYSCONF_PROGRESSIVE_SCAN);
+  dtm->bPAL60 = config_layer->Get(Config::SYSCONF_PAL60);
+  if (dtm->bWii)
+    dtm->language = config_layer->Get(Config::SYSCONF_LANGUAGE);
+  else
+    dtm->language = config_layer->Get(Config::MAIN_GC_LANGUAGE);
+
+  dtm->bUseXFB = config_layer->Get(Config::GFX_USE_XFB);
+  dtm->bUseRealXFB = config_layer->Get(Config::GFX_USE_REAL_XFB);
+  dtm->bEFBAccessEnable = config_layer->Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
+  dtm->bSkipEFBCopyToRam = config_layer->Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
+  dtm->bEFBEmulateFormatChanges = config_layer->Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
+
+  // This never used the regular config
+  dtm->bSkipIdle = true;
+  dtm->bEFBCopyEnable = true;
+  dtm->bEFBCopyCacheEnable = false;
+
+  strncpy(reinterpret_cast<char*>(dtm->videoBackend), video_backend.c_str(),
+          ArraySize(dtm->videoBackend));
+}
+
 // TODO: Future project, let this support all the configuration options.
 // This will require a large break to the DTM format
 void MovieConfigLayerLoader::Load(Config::Layer* config_layer)
 {
-  Config::Section* core = config_layer->GetOrCreateSection(Config::System::Main, "Core");
-  Config::Section* video_settings = Config::GetOrCreateSection(Config::System::GFX, "Settings");
-  Config::Section* video_hacks = Config::GetOrCreateSection(Config::System::GFX, "Hacks");
-
-  core->Set("SkipIdle", m_header->bSkipIdle);
-  core->Set("CPUThread", m_header->bDualCore);
-  core->Set("DSPHLE", m_header->bDSPHLE);
-  core->Set("FastDiscSpeed", m_header->bFastDiscSpeed);
-  core->Set("CPUCore", m_header->CPUCore);
-  core->Set("SyncGPU", m_header->bSyncGPU);
-  core->Set("GFXBackend", std::string(reinterpret_cast<char*>(m_header->videoBackend)));
-
-  config_layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, m_header->bProgressive);
-  config_layer->Set(Config::SYSCONF_PAL60, m_header->bPAL60);
-  if (m_header->bWii)
-    config_layer->Set(Config::SYSCONF_LANGUAGE, static_cast<u32>(m_header->language));
-
-  video_settings->Set("UseXFB", m_header->bUseXFB);
-  video_settings->Set("UseRealXFB", m_header->bUseRealXFB);
-  video_hacks->Set("EFBAccessEnable", m_header->bEFBAccessEnable);
-  video_hacks->Set("EFBToTextureEnable", m_header->bSkipEFBCopyToRam);
-  video_hacks->Set("EFBEmulateFormatChanges", m_header->bEFBEmulateFormatChanges);
+  LoadFromDTM(config_layer, m_header);
 }
 
 void MovieConfigLayerLoader::Save(Config::Layer* config_layer)
 {
-  Config::Section* core = config_layer->GetOrCreateSection(Config::System::Main, "Core");
-  Config::Section* video_settings = Config::GetOrCreateSection(Config::System::GFX, "Settings");
-  Config::Section* video_hacks = Config::GetOrCreateSection(Config::System::GFX, "Hacks");
-
-  std::string video_backend;
-  u32 cpu_core;
-
-  core->Get("SkipIdle", &m_header->bSkipIdle);
-  core->Get("CPUThread", &m_header->bDualCore);
-  core->Get("DSPHLE", &m_header->bDSPHLE);
-  core->Get("FastDiscSpeed", &m_header->bFastDiscSpeed);
-  core->Get("CPUCore", &cpu_core);
-  core->Get("SyncGPU", &m_header->bSyncGPU);
-  core->Get("GFXBackend", &video_backend);
-  m_header->bProgressive = config_layer->Get(Config::SYSCONF_PROGRESSIVE_SCAN);
-  m_header->bPAL60 = config_layer->Get(Config::SYSCONF_PAL60);
-  if (m_header->bWii)
-    m_header->language = config_layer->Get(Config::SYSCONF_LANGUAGE);
-
-  video_settings->Get("UseXFB", &m_header->bUseXFB);
-  video_settings->Get("UseRealXFB", &m_header->bUseRealXFB);
-  video_hacks->Get("EFBAccessEnable", &m_header->bEFBAccessEnable);
-  video_hacks->Get("EFBToTextureEnable", &m_header->bSkipEFBCopyToRam);
-  video_hacks->Get("EFBEmulateFormatChanges", &m_header->bEFBEmulateFormatChanges);
-
-  // This never used the regular config
-  m_header->bEFBCopyEnable = true;
-  m_header->bEFBCopyCacheEnable = false;
-
-  m_header->CPUCore = cpu_core;
-  strncpy(reinterpret_cast<char*>(m_header->videoBackend), video_backend.c_str(),
-          ArraySize(m_header->videoBackend));
 }
 
 // Loader generation

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.h
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.h
@@ -26,10 +26,10 @@ public:
   void Load(Config::Layer* config_layer) override;
   void Save(Config::Layer* config_layer) override;
 
-  void ChangeDTMHeader(Movie::DTMHeader* header) { m_header = header; }
 private:
   Movie::DTMHeader* m_header;
 };
 
+void SaveToDTM(Config::Layer* layer, Movie::DTMHeader* header);
 std::unique_ptr<Config::ConfigLayerLoader> GenerateMovieConfigLoader(Movie::DTMHeader* header);
 }

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "Common/Config/Config.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/NetPlayProto.h"
 
 namespace ConfigLoaders
@@ -23,7 +24,6 @@ public:
   {
     Config::Section* core = config_layer->GetOrCreateSection(Config::System::Main, "Core");
     Config::Section* dsp = config_layer->GetOrCreateSection(Config::System::Main, "DSP");
-    Config::Section* display = config_layer->GetOrCreateSection(Config::System::Main, "Display");
 
     core->Set("CPUThread", m_settings.m_CPUthread);
     core->Set("CPUCore", m_settings.m_CPUcore);
@@ -38,8 +38,8 @@ public:
 
     dsp->Set("EnableJIT", m_settings.m_DSPEnableJIT);
 
-    display->Set("ProgressiveScan", m_settings.m_ProgressiveScan);
-    display->Set("PAL60", m_settings.m_PAL60);
+    config_layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, m_settings.m_ProgressiveScan);
+    config_layer->Set(Config::SYSCONF_PAL60, m_settings.m_PAL60);
   }
 
   void Save(Config::Layer* config_layer) override

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -147,7 +147,6 @@ struct SConfig : NonCopyable
   int iRenderWindowHeight = -1;
   bool bRenderWindowAutoSize = false, bKeepWindowOnTop = false;
   bool bFullscreen = false, bRenderToMain = false;
-  bool bProgressive = false, bPAL60 = false;
   bool bDisableScreenSaver = false;
 
   int iPosX, iPosY, iWidth, iHeight;
@@ -168,15 +167,6 @@ struct SConfig : NonCopyable
   bool IsUSBDeviceWhitelisted(std::pair<u16, u16> vid_pid) const;
 
   bool m_enable_signature_checks = true;
-
-  // SYSCONF settings
-  int m_sensor_bar_position = 0x01;
-  int m_sensor_bar_sensitivity = 0x03;
-  int m_speaker_volume = 0x58;
-  bool m_wiimote_motor = true;
-  int m_wii_language = 0x01;
-  int m_wii_aspect_ratio = 0x01;
-  int m_wii_screensaver = 0x00;
 
   // Fifo Player related settings
   bool bLoopFifoReplay = true;
@@ -333,9 +323,6 @@ struct SConfig : NonCopyable
 
   // Load settings
   void LoadSettings();
-
-  void LoadSettingsFromSysconf();
-  void SaveSettingsToSysconf();
 
   // Return the permanent and somewhat globally used instance of this struct
   static SConfig& GetInstance() { return (*m_Instance); }

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -47,6 +47,7 @@
     <ClCompile Include="Boot\ElfReader.cpp" />
     <ClCompile Include="Config\GraphicsSettings.cpp" />
     <ClCompile Include="Config\NetplaySettings.cpp" />
+    <ClCompile Include="Config\SYSCONFSettings.cpp" />
     <ClCompile Include="ConfigLoaders\BaseConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\GameConfigLoader.cpp" />
     <ClCompile Include="ConfigLoaders\IsSettingSaveable.cpp" />
@@ -303,6 +304,7 @@
     <ClInclude Include="Boot\ElfTypes.h" />
     <ClInclude Include="Config\GraphicsSettings.h" />
     <ClInclude Include="Config\NetplaySettings.h" />
+    <ClInclude Include="Config\SYSCONFSettings.h" />
     <ClInclude Include="ConfigLoaders\BaseConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\GameConfigLoader.h" />
     <ClInclude Include="ConfigLoaders\IsSettingSaveable.h" />

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -46,6 +46,7 @@
     <ClCompile Include="Boot\DolReader.cpp" />
     <ClCompile Include="Boot\ElfReader.cpp" />
     <ClCompile Include="Config\GraphicsSettings.cpp" />
+    <ClCompile Include="Config\MainSettings.cpp" />
     <ClCompile Include="Config\NetplaySettings.cpp" />
     <ClCompile Include="Config\SYSCONFSettings.cpp" />
     <ClCompile Include="ConfigLoaders\BaseConfigLoader.cpp" />
@@ -303,6 +304,7 @@
     <ClInclude Include="Boot\ElfReader.h" />
     <ClInclude Include="Boot\ElfTypes.h" />
     <ClInclude Include="Config\GraphicsSettings.h" />
+    <ClInclude Include="Config\MainSettings.h" />
     <ClInclude Include="Config\NetplaySettings.h" />
     <ClInclude Include="Config\SYSCONFSettings.h" />
     <ClInclude Include="ConfigLoaders\BaseConfigLoader.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -877,6 +877,9 @@
     <ClCompile Include="Config\NetplaySettings.cpp">
       <Filter>Config</Filter>
     </ClCompile>
+    <ClCompile Include="Config\SYSCONFSettings.cpp">
+      <Filter>Config</Filter>
+    </ClCompile>
     <ClCompile Include="IOS\Network\NCD\WiiNetConfig.cpp">
       <Filter>IOS\Network\NCD</Filter>
     </ClCompile>
@@ -1527,6 +1530,9 @@
       <Filter>Config</Filter>
     </ClInclude>
     <ClInclude Include="Config\NetplaySettings.h">
+      <Filter>Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Config\SYSCONFSettings.h">
       <Filter>Config</Filter>
     </ClInclude>
     <ClInclude Include="IOS\Network\NCD\WiiNetConfig.h">

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -874,6 +874,9 @@
     <ClCompile Include="Config\GraphicsSettings.cpp">
       <Filter>Config</Filter>
     </ClCompile>
+    <ClCompile Include="Config\MainSettings.cpp">
+      <Filter>Config</Filter>
+    </ClCompile>
     <ClCompile Include="Config\NetplaySettings.cpp">
       <Filter>Config</Filter>
     </ClCompile>
@@ -1527,6 +1530,9 @@
       <Filter>ConfigLoader</Filter>
     </ClInclude>
     <ClInclude Include="Config\GraphicsSettings.h">
+      <Filter>Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Config\MainSettings.h">
       <Filter>Config</Filter>
     </ClInclude>
     <ClInclude Include="Config\NetplaySettings.h">

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -10,9 +10,11 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -179,7 +181,7 @@ void Preset(bool _bNTSC)
   m_Clock = DiscIO::IsNTSC(region);
 
   // Say component cable is plugged
-  m_DTVStatus.component_plugged = SConfig::GetInstance().bProgressive;
+  m_DTVStatus.component_plugged = Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN);
   m_DTVStatus.ntsc_j = SConfig::GetInstance().bForceNTSCJ || region == DiscIO::Region::NTSC_J;
 
   m_FBWidth.Hex = 0;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -12,9 +12,11 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/MathUtil.h"
 #include "Common/MsgHandler.h"
 
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/Wiimote.h"
@@ -328,7 +330,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index), ir_sin(0), ir_cos(1
   m_hotkeys->AddInput(_trans("Upright Hold"), false);
 
   // TODO: This value should probably be re-read if SYSCONF gets changed
-  m_sensor_bar_on_top = SConfig::GetInstance().m_sensor_bar_position != 0;
+  m_sensor_bar_on_top = Config::Get(Config::SYSCONF_SENSOR_BAR_POSITION) != 0;
 
   // --- reset eeprom/register/values to default ---
   Reset();

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -30,6 +30,7 @@
 #include "Common/Timer.h"
 
 #include "Core/Boot/Boot.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/MovieConfigLoader.h"
 #include "Core/ConfigManager.h"
@@ -77,11 +78,7 @@ static u64 s_totalLagCount = 0;                               // just stats
 static u64 s_currentInputCount = 0, s_totalInputCount = 0;    // just stats
 static u64 s_totalTickCount = 0, s_tickCountAtLastInput = 0;  // just stats
 static u64 s_recordingStartTime;  // seconds since 1970 that recording started
-static bool s_bSaveConfig = false, s_bDualCore = false;
-static bool s_bDSPHLE = false, s_bFastDiscSpeed = false;
-static bool s_bSyncGPU = false, s_bNetPlay = false;
-static std::string s_videoBackend = "unknown";
-static int s_iCPUCore = 1;
+static bool s_bSaveConfig = false, s_bNetPlay = false;
 static bool s_bClearSave = false;
 static bool s_bDiscChange = false;
 static bool s_bReset = false;
@@ -92,7 +89,6 @@ static u8 s_bongos, s_memcards;
 static u8 s_revision[20];
 static u32 s_DSPiromHash = 0;
 static u32 s_DSPcoefHash = 0;
-static u8 s_language = static_cast<u8>(DiscIO::Language::LANGUAGE_UNKNOWN);
 
 static bool s_bRecordingFromSaveState = false;
 static bool s_bPolled = false;
@@ -106,6 +102,7 @@ static WiiManipFunction s_wii_manip_func;
 
 static std::string s_current_file_name;
 
+static void GetSettings();
 static bool IsMovieHeader(u8 magic[4])
 {
   return magic[0] == 'D' && magic[1] == 'T' && magic[2] == 'M' && magic[3] == 0x1A;
@@ -219,7 +216,6 @@ void Init(const BootParameters& boot)
   s_bPolled = false;
   s_bFrameStep = false;
   s_bSaveConfig = false;
-  s_iCPUCore = SConfig::GetInstance().iCPUCore;
   if (IsPlayingInput())
   {
     ReadHeader();
@@ -420,30 +416,6 @@ bool IsConfigSaved()
 {
   return s_bSaveConfig;
 }
-bool IsDualCore()
-{
-  return s_bDualCore;
-}
-
-bool IsDSPHLE()
-{
-  return s_bDSPHLE;
-}
-
-bool IsFastDiscSpeed()
-{
-  return s_bFastDiscSpeed;
-}
-
-int GetCPUMode()
-{
-  return s_iCPUCore;
-}
-
-u8 GetLanguage()
-{
-  return s_language;
-}
 
 bool IsStartingFromClearSave()
 {
@@ -453,11 +425,6 @@ bool IsStartingFromClearSave()
 bool IsUsingMemcard(int memcard)
 {
   return (s_memcards & (1 << memcard)) != 0;
-}
-
-bool IsSyncGPU()
-{
-  return s_bSyncGPU;
 }
 
 bool IsNetPlayRecording()
@@ -893,16 +860,10 @@ void ReadHeader()
   {
     s_bSaveConfig = true;
     Config::AddLayer(ConfigLoaders::GenerateMovieConfigLoader(&tmpHeader));
-    s_bDualCore = tmpHeader.bDualCore;
-    s_bDSPHLE = tmpHeader.bDSPHLE;
-    s_bFastDiscSpeed = tmpHeader.bFastDiscSpeed;
-    s_iCPUCore = tmpHeader.CPUCore;
     s_bClearSave = tmpHeader.bClearSave;
     s_memcards = tmpHeader.memcards;
     s_bongos = tmpHeader.bongos;
-    s_bSyncGPU = tmpHeader.bSyncGPU;
     s_bNetPlay = tmpHeader.bNetPlay;
-    s_language = tmpHeader.language;
     memcpy(s_revision, tmpHeader.revision, ArraySize(s_revision));
   }
   else
@@ -910,7 +871,6 @@ void ReadHeader()
     GetSettings();
   }
 
-  s_videoBackend = (char*)tmpHeader.videoBackend;
   s_discChange = (char*)tmpHeader.discChange;
   s_author = (char*)tmpHeader.author;
   memcpy(s_MD5, tmpHeader.md5, 16);
@@ -1369,26 +1329,9 @@ void SaveRecording(const std::string& filename)
   header.recordingStartTime = s_recordingStartTime;
 
   header.bSaveConfig = true;
-  auto* movie_layer = Config::GetLayer(Config::LayerType::Movie);
-  auto* loader = static_cast<ConfigLoaders::MovieConfigLayerLoader*>(movie_layer->GetLoader());
-  loader->ChangeDTMHeader(&header);
-  movie_layer->Save();
-  header.bSkipIdle = true;
-  header.bDualCore = s_bDualCore;
-  header.bDSPHLE = s_bDSPHLE;
-  header.bFastDiscSpeed = s_bFastDiscSpeed;
-  strncpy((char*)header.videoBackend, s_videoBackend.c_str(), ArraySize(header.videoBackend));
-  header.CPUCore = s_iCPUCore;
-  header.bEFBAccessEnable = g_ActiveConfig.bEFBAccessEnable;
-  header.bEFBCopyEnable = true;
-  header.bSkipEFBCopyToRam = g_ActiveConfig.bSkipEFBCopyToRam;
-  header.bEFBCopyCacheEnable = false;
-  header.bEFBEmulateFormatChanges = g_ActiveConfig.bEFBEmulateFormatChanges;
-  header.bUseXFB = g_ActiveConfig.bUseXFB;
-  header.bUseRealXFB = g_ActiveConfig.bUseRealXFB;
+  ConfigLoaders::SaveToDTM(Config::GetLayer(Config::LayerType::Meta), &header);
   header.memcards = s_memcards;
   header.bClearSave = s_bClearSave;
-  header.bSyncGPU = s_bSyncGPU;
   header.bNetPlay = s_bNetPlay;
   strncpy((char*)header.discChange, s_discChange.c_str(), ArraySize(header.discChange));
   strncpy((char*)header.author, s_author.c_str(), ArraySize(header.author));
@@ -1398,7 +1341,6 @@ void SaveRecording(const std::string& filename)
   header.DSPiromHash = s_DSPiromHash;
   header.DSPcoefHash = s_DSPcoefHash;
   header.tickCount = s_totalTickCount;
-  header.language = s_language;
 
   // TODO
   header.uniqueID = 0;
@@ -1457,24 +1399,16 @@ void SetGraphicsConfig()
 void GetSettings()
 {
   s_bSaveConfig = true;
-  s_bDualCore = SConfig::GetInstance().bCPUThread;
-  s_bDSPHLE = SConfig::GetInstance().bDSPHLE;
-  s_bFastDiscSpeed = SConfig::GetInstance().bFastDiscSpeed;
-  s_videoBackend = g_video_backend->GetName();
-  s_bSyncGPU = SConfig::GetInstance().bSyncGPU;
-  s_iCPUCore = SConfig::GetInstance().iCPUCore;
   s_bNetPlay = NetPlay::IsNetPlayRunning();
   if (SConfig::GetInstance().bWii)
   {
     u64 title_id = SConfig::GetInstance().GetTitleID();
     s_bClearSave =
         !File::Exists(Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT) + "banner.bin");
-    s_language = Config::Get(Config::SYSCONF_LANGUAGE);
   }
   else
   {
     s_bClearSave = !File::Exists(SConfig::GetInstance().m_strMemoryCardA);
-    s_language = SConfig::GetInstance().SelectedLanguage;
   }
   s_memcards |=
       (SConfig::GetInstance().m_EXIDevice[0] == ExpansionInterface::EXIDEVICE_MEMORYCARD ||
@@ -1488,7 +1422,7 @@ void GetSettings()
   std::array<u8, 20> revision = ConvertGitRevisionToBytes(scm_rev_git_str);
   std::copy(std::begin(revision), std::end(revision), std::begin(s_revision));
 
-  if (!s_bDSPHLE)
+  if (!Config::Get(Config::MAIN_DSP_HLE))
   {
     std::string irom_file = File::GetUserPath(D_GCUSER_IDX) + DSP_IROM;
     std::string coef_file = File::GetUserPath(D_GCUSER_IDX) + DSP_COEF;

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -138,8 +138,6 @@ void SetReset(bool reset);
 
 bool IsConfigSaved();
 bool IsDualCore();
-bool IsProgressive();
-bool IsPAL60();
 bool IsDSPHLE();
 bool IsFastDiscSpeed();
 int GetCPUMode();

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -137,16 +137,9 @@ void SignalDiscChange(const std::string& new_path);
 void SetReset(bool reset);
 
 bool IsConfigSaved();
-bool IsDualCore();
-bool IsDSPHLE();
-bool IsFastDiscSpeed();
-int GetCPUMode();
-u8 GetLanguage();
 bool IsStartingFromClearSave();
 bool IsUsingMemcard(int memcard);
-bool IsSyncGPU();
 void SetGraphicsConfig();
-void GetSettings();
 bool IsNetPlayRecording();
 
 bool IsUsingPad(int controller);

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -23,7 +23,9 @@
 #include <sstream>
 
 #include "Common/CommonPaths.h"
+#include "Common/Config/Config.h"
 #include "Common/TraversalClient.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/NetPlayServer.h"
@@ -224,8 +226,8 @@ void NetPlayDialog::OnStart()
   settings.m_EnableCheats = instance.bEnableCheats;
   settings.m_SelectedLanguage = instance.SelectedLanguage;
   settings.m_OverrideGCLanguage = instance.bOverrideGCLanguage;
-  settings.m_ProgressiveScan = instance.bProgressive;
-  settings.m_PAL60 = instance.bPAL60;
+  settings.m_ProgressiveScan = Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN);
+  settings.m_PAL60 = Config::Get(Config::SYSCONF_PAL60);
   settings.m_DSPHLE = instance.bDSPHLE;
   settings.m_DSPEnableJIT = instance.m_DSPEnableJIT;
   settings.m_WriteToMemcard = m_save_sd_box->isChecked();

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -11,6 +11,8 @@
 #include <wx/slider.h>
 #include <wx/stattext.h>
 
+#include "Common/Config/Config.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IOS/IOS.h"
@@ -174,10 +176,10 @@ void WiiConfigPane::InitializeGUI()
 
 void WiiConfigPane::LoadGUIValues()
 {
-  m_screensaver_checkbox->SetValue(!!SConfig::GetInstance().m_wii_screensaver);
-  m_pal60_mode_checkbox->SetValue(SConfig::GetInstance().bPAL60);
-  m_aspect_ratio_choice->SetSelection(SConfig::GetInstance().m_wii_aspect_ratio);
-  m_system_language_choice->SetSelection(SConfig::GetInstance().m_wii_language);
+  m_screensaver_checkbox->SetValue(Config::Get(Config::SYSCONF_SCREENSAVER));
+  m_pal60_mode_checkbox->SetValue(Config::Get(Config::SYSCONF_PAL60));
+  m_aspect_ratio_choice->SetSelection(Config::Get(Config::SYSCONF_WIDESCREEN));
+  m_system_language_choice->SetSelection(Config::Get(Config::SYSCONF_LANGUAGE));
 
   m_sd_card_checkbox->SetValue(SConfig::GetInstance().m_WiiSDCard);
   m_connect_keyboard_checkbox->SetValue(SConfig::GetInstance().m_WiiKeyboard);
@@ -185,10 +187,10 @@ void WiiConfigPane::LoadGUIValues()
   PopulateUSBPassthroughListbox();
 
   m_bt_sensor_bar_pos->SetSelection(
-      TranslateSensorBarPosition(SConfig::GetInstance().m_sensor_bar_position));
-  m_bt_sensor_bar_sens->SetValue(SConfig::GetInstance().m_sensor_bar_sensitivity);
-  m_bt_speaker_volume->SetValue(SConfig::GetInstance().m_speaker_volume);
-  m_bt_wiimote_motor->SetValue(SConfig::GetInstance().m_wiimote_motor);
+      TranslateSensorBarPosition(Config::Get(Config::SYSCONF_SENSOR_BAR_POSITION)));
+  m_bt_sensor_bar_sens->SetValue(Config::Get(Config::SYSCONF_SENSOR_BAR_SENSITIVITY));
+  m_bt_speaker_volume->SetValue(Config::Get(Config::SYSCONF_SPEAKER_VOLUME));
+  m_bt_wiimote_motor->SetValue(Config::Get(Config::SYSCONF_WIIMOTE_MOTOR));
 }
 
 void WiiConfigPane::PopulateUSBPassthroughListbox()
@@ -268,12 +270,12 @@ void WiiConfigPane::OnUSBWhitelistRemoveButtonUpdate(wxUpdateUIEvent& event)
 
 void WiiConfigPane::OnScreenSaverCheckBoxChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_wii_screensaver = m_screensaver_checkbox->IsChecked();
+  Config::SetBase(Config::SYSCONF_SCREENSAVER, m_screensaver_checkbox->IsChecked());
 }
 
 void WiiConfigPane::OnPAL60CheckBoxChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().bPAL60 = m_pal60_mode_checkbox->IsChecked();
+  Config::SetBase(Config::SYSCONF_PAL60, m_pal60_mode_checkbox->IsChecked());
 }
 
 void WiiConfigPane::OnSDCardCheckBoxChanged(wxCommandEvent& event)
@@ -291,30 +293,32 @@ void WiiConfigPane::OnConnectKeyboardCheckBoxChanged(wxCommandEvent& event)
 
 void WiiConfigPane::OnSystemLanguageChoiceChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_wii_language = m_system_language_choice->GetSelection();
+  Config::SetBase(Config::SYSCONF_LANGUAGE,
+                  static_cast<u32>(m_system_language_choice->GetSelection()));
 }
 
 void WiiConfigPane::OnAspectRatioChoiceChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_wii_aspect_ratio = m_aspect_ratio_choice->GetSelection();
+  Config::SetBase(Config::SYSCONF_WIDESCREEN, m_aspect_ratio_choice->GetSelection() == 1);
 }
 
 void WiiConfigPane::OnSensorBarPosChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_sensor_bar_position = TranslateSensorBarPosition(event.GetInt());
+  Config::SetBase(Config::SYSCONF_SENSOR_BAR_POSITION,
+                  static_cast<u32>(TranslateSensorBarPosition(event.GetInt())));
 }
 
 void WiiConfigPane::OnSensorBarSensChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_sensor_bar_sensitivity = event.GetInt();
+  Config::SetBase(Config::SYSCONF_SENSOR_BAR_SENSITIVITY, static_cast<u32>(event.GetInt()));
 }
 
 void WiiConfigPane::OnSpeakerVolumeChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_speaker_volume = event.GetInt();
+  Config::SetBase(Config::SYSCONF_SPEAKER_VOLUME, static_cast<u32>(event.GetInt()));
 }
 
 void WiiConfigPane::OnWiimoteMotorChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_wiimote_motor = event.IsChecked();
+  Config::SetBase(Config::SYSCONF_WIIMOTE_MOTOR, event.IsChecked());
 }

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -42,6 +42,9 @@ WiiConfigPane::WiiConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, 
   InitializeGUI();
   LoadGUIValues();
   BindEvents();
+  // This is only safe because WiiConfigPane is owned by CConfigMain, which exists
+  // as long as the DolphinWX app exists.
+  Config::AddConfigChangedCallback([&] { Core::QueueHostJob([&] { LoadGUIValues(); }, true); });
 }
 
 void WiiConfigPane::InitializeGUI()

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -32,11 +32,13 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/FifoQueue.h"
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/NetPlayClient.h"
@@ -316,8 +318,8 @@ void NetPlayDialog::GetNetSettings(NetSettings& settings)
   settings.m_EnableCheats = instance.bEnableCheats;
   settings.m_SelectedLanguage = instance.SelectedLanguage;
   settings.m_OverrideGCLanguage = instance.bOverrideGCLanguage;
-  settings.m_ProgressiveScan = instance.bProgressive;
-  settings.m_PAL60 = instance.bPAL60;
+  settings.m_ProgressiveScan = Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN);
+  settings.m_PAL60 = Config::Get(Config::SYSCONF_PAL60);
   settings.m_DSPHLE = instance.bDSPHLE;
   settings.m_DSPEnableJIT = instance.m_DSPEnableJIT;
   settings.m_WriteToMemcard = m_memcard_write->GetValue();

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -25,6 +25,7 @@
 #include "Common/Assert.h"
 #include "Common/FileUtil.h"
 #include "Common/SysConf.h"
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DolphinWX/DolphinSlider.h"
@@ -917,7 +918,8 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
         progressive_scan_checkbox->Bind(wxEVT_CHECKBOX, &VideoConfigDiag::Event_ProgressiveScan,
                                         this);
 
-        progressive_scan_checkbox->SetValue(SConfig::GetInstance().bProgressive);
+        // TODO: split this into two different settings, one for Wii and one for GC?
+        progressive_scan_checkbox->SetValue(Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN));
         szr_misc->Add(progressive_scan_checkbox);
       }
 
@@ -1027,7 +1029,7 @@ void VideoConfigDiag::Event_DisplayResolution(wxCommandEvent& ev)
 
 void VideoConfigDiag::Event_ProgressiveScan(wxCommandEvent& ev)
 {
-  SConfig::GetInstance().bProgressive = ev.IsChecked();
+  Config::SetBase(Config::SYSCONF_PROGRESSIVE_SCAN, ev.IsChecked());
   ev.Skip();
 }
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -23,6 +23,7 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/Event.h"
 #include "Common/FileUtil.h"
 #include "Common/Flag.h"
@@ -33,6 +34,7 @@
 #include "Common/Thread.h"
 #include "Common/Timer.h"
 
+#include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -93,9 +95,7 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   OSDTime = 0;
 
   if (SConfig::GetInstance().bWii)
-  {
-    m_aspect_wide = SConfig::GetInstance().m_wii_aspect_ratio != 0;
-  }
+    m_aspect_wide = Config::Get(Config::SYSCONF_WIDESCREEN);
 
   m_last_host_config_bits = ShaderHostConfig::GetCurrent().bits;
 }


### PR DESCRIPTION
Settings that come from the SYSCONF are now included in Dolphin's config system as part of the base layer, instead of always overriding any loaded value.

This lets the SYSCONF code not have to care about whether a Movie is active or manually apply settings from Movie, and also lets the user see what settings have been changed during emulation (thanks to the new callback system).

#### Movie changes

Because the Movie config stuff is so tied to the SYSCONF settings, I decided to also port part of the Movie config to OnionConfig. The following changes were made:

* Add missing Language setting loading/saving. This was added after the original OnionConfig PR, which is why support for it was missing.
* Change MovieConfigLoader to reuse ConfigInfos. Less duplication.
* Extract MovieConfigLoader::Save into SaveToDTM. The DTM should use   the current config and not just the movie layer. This makes more   sense than just saving the movie layer, which may not always exist,   and also fixes a crash that would happen when creating a new   recording because the movie layer wouldn't exist in that case.    (Plus, having to get the loader from the layer and call ChangeDTM   on it manually is not very pretty.)

#### Overridden settings

An issue with the SYSCONF is that it can be modified during emulation by the user or by the SDK, and Dolphin has no way to tell if a setting that was changed should be kept or not. Always overwriting the base layer with the SYSCONF settings causes temporary settings (from Movie, etc.) to be kept; always overwriting the SYSCONF with the base layer settings makes it impossible to change any Wii setting during emulation.

As a middle ground, I've decided to only restore the overridden settings. This avoids temporary settings sticking around after emulation, and still lets the user change any setting they want during emulation without having Dolphin revert their changes.

#### UI change

DolphinWX now shows changes to SYSCONF settings as soon as emulation is stopped.
