### PR TITLE
Fix array out of bounds error for connected wiimotes

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -23,7 +23,7 @@
 #include "InputCommon/InputConfig.h"
 
 // Limit the amount of wiimote connect requests, when a button is pressed in disconnected state
-static std::array<u8, 4> s_last_connect_request_counter;
+static std::array<u8, MAX_BBMOTES> s_last_connect_request_counter;
 
 namespace Wiimote
 {


### PR DESCRIPTION
Fixes an array out of bounds issue introduced by #4949 where we were off by one (4 wiimotes + balance board)