### PR TITLE
DolphinWX: Prevent Dolphin to be shutdown when closing cmd.exe

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -119,6 +119,10 @@ bool DolphinApp::OnInit()
 
   ParseCommandLine();
 
+#ifdef _WIN32
+  FreeConsole();
+#endif
+
   UICommon::SetUserDirectory(m_user_path.ToStdString());
   UICommon::CreateDirectories();
   InitLanguageSupport();  // The language setting is loaded from the user directory


### PR DESCRIPTION
That behaviour was introduced while switching to optparse by attaching the console. If FreeConsole isn't called all instances of Dolphin running on that console will get lost. AFAIC, that's not the default behaviour of a cmd.exe console and is slightly annoying.

Ready to be reviewed & merged.