### PR TITLE
VideoSW: Drop log level of missing anti aliasing support.

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -82,7 +82,7 @@ static void SetPixelColorOnly(u32 offset, u8* rgb)
   break;
   case PEControl::RGB565_Z16:
   {
-    WARN_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
     u32 src = *(u32*)rgb;
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
@@ -123,7 +123,7 @@ static void SetPixelAlphaColor(u32 offset, u8* color)
   break;
   case PEControl::RGB565_Z16:
   {
-    WARN_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
     u32 src = *(u32*)color;
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
@@ -179,7 +179,7 @@ static void SetPixelDepth(u32 offset, u32 depth)
   break;
   case PEControl::RGB565_Z16:
   {
-    WARN_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
     val |= depth & 0x00ffffff;
@@ -206,7 +206,7 @@ static u32 GetPixelDepth(u32 offset)
   break;
   case PEControl::RGB565_Z16:
   {
-    WARN_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
     depth = (*(u32*)&efb[offset]) & 0x00ffffff;
   }
   break;


### PR DESCRIPTION
We don't want to emit such a high priority warning here, else fifoci will die.