### PR TITLE
Added Player ID to Controller Port Assignment dialog.

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
+++ b/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
@@ -26,7 +26,7 @@ PadMapDialog::PadMapDialog(wxWindow* parent, NetPlayServer* server, NetPlayClien
   wxArrayString player_names;
   player_names.Add(_("None"));
   for (const auto& player : m_player_list)
-    player_names.Add(StrToWxStr(player->name));
+    player_names.Add(StrToWxStr(player->name) << "[" << std::to_wstring(player->pid) << "]");
 
   auto build_choice = [&](unsigned int base_idx, unsigned int idx, const PadMappingArray& mapping,
                           const wxString& port_name) {


### PR DESCRIPTION
This change will make it easier to assign controller ports when all players just join with the default name 'Player'.

![image](https://user-images.githubusercontent.com/20975532/29005761-5a5c176e-7ab0-11e7-9d09-b06ae2454210.png)
