### PR TITLE
ElidedButton: Add missing override specifier to paintEvent()

### DIFF
--- a/Source/Core/DolphinQt2/QtUtils/ElidedButton.h
+++ b/Source/Core/DolphinQt2/QtUtils/ElidedButton.h
@@ -9,8 +9,8 @@
 class ElidedButton : public QPushButton
 {
 public:
-  ElidedButton(const QString& text = QStringLiteral(""),
-               Qt::TextElideMode elide_mode = Qt::ElideRight);
+  explicit ElidedButton(const QString& text = QStringLiteral(""),
+                        Qt::TextElideMode elide_mode = Qt::ElideRight);
   Qt::TextElideMode elideMode() const;
   void setElideMode(Qt::TextElideMode elide_mode);
 

--- a/Source/Core/DolphinQt2/QtUtils/ElidedButton.h
+++ b/Source/Core/DolphinQt2/QtUtils/ElidedButton.h
@@ -15,6 +15,6 @@ public:
   void setElideMode(Qt::TextElideMode elide_mode);
 
 private:
-  void paintEvent(QPaintEvent* event);
+  void paintEvent(QPaintEvent* event) override;
   Qt::TextElideMode m_elide_mode;
 };


### PR DESCRIPTION
Also makes the constructor explicit.