### PR TITLE
[CIONLY] force rebuild of common/file.cpp

### DIFF
--- a/Source/Core/Common/File.cpp
+++ b/Source/Core/Common/File.cpp
@@ -88,9 +88,13 @@ void IOFile::SetHandle(std::FILE* file)
 u64 IOFile::GetSize() const
 {
   if (IsOpen())
+  {
     return File::GetSize(m_file);
+  }
   else
+  {
     return 0;
+  }
 }
 
 bool IOFile::Seek(s64 off, int origin)


### PR DESCRIPTION
Try to fix all of the crazy errors:

```
Core.lib(State.obj) : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl File::IOFile::GetSize(void)const " (?GetSize@IOFile@File@@QEBA_KXZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
Core.lib(EXI_DeviceIPL.obj) : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl File::IOFile::GetSize(void)const " (?GetSize@IOFile@File@@QEBA_KXZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
Core.lib(SDIOSlot0.obj) : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl File::IOFile::GetSize(void)const " (?GetSize@IOFile@File@@QEBA_KXZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
GameListCtrl.obj : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl File::IOFile::GetSize(void)const " (?GetSize@IOFile@File@@QEBA_KXZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
DiscIO.lib(DirectoryBlob.obj) : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl File::IOFile::GetSize(void)const " (?GetSize@IOFile@File@@QEBA_KXZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
Core.lib(Boot.obj) : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl File::IOFile::GetSize(void)const " (?GetSize@IOFile@File@@QEBA_KXZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
Core.lib(Movie.obj) : error LNK2001: unresolved external symbol "public: unsigned __int64 __cdecl File::IOFile::GetSize(void)const " (?GetSize@IOFile@File@@QEBA_KXZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
Software.lib(SWmain.obj) : error LNK2019: unresolved external symbol "public: __cdecl FramebufferManagerBase::FramebufferManagerBase(void)" (??0FramebufferManagerBase@@QEAA@XZ) referenced in function "class std::unique_ptr<class SW::FramebufferManager,struct std::default_delete<class SW::FramebufferManager> > __cdecl std::make_unique<class SW::FramebufferManager>(void)" (??$make_unique@VFramebufferManager@SW@@$$V@std@@YA?AV?$unique_ptr@VFramebufferManager@SW@@U?$default_delete@VFramebufferManager@SW@@@std@@@0@XZ) [C:\buildbot\pr-win-x64\build\Source\Core\DolphinWX\DolphinWX.vcxproj]
```