### PR TITLE
Make DolphinQt2 netplay strings more like in DolphinWX

### DIFF
--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -88,7 +88,7 @@ void MenuBar::AddToolsMenu()
   QMenu* tools_menu = addMenu(tr("&Tools"));
   m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, &MenuBar::InstallWAD);
 
-  tools_menu->addAction(tr("Start NetPlay..."), this, &MenuBar::StartNetPlay);
+  tools_menu->addAction(tr("Start &NetPlay..."), this, &MenuBar::StartNetPlay);
   tools_menu->addSeparator();
 
   // Label will be set by a NANDRefresh later

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -59,7 +59,7 @@ void NetPlayDialog::CreateMainLayout()
   m_md5_box = new QComboBox;
   m_start_button = new QPushButton(tr("Start"));
   m_buffer_size_box = new QSpinBox;
-  m_save_sd_box = new QCheckBox(tr("Write save / SD-Card data"));
+  m_save_sd_box = new QCheckBox(tr("Write save/SD data"));
   m_load_wii_box = new QCheckBox(tr("Load Wii Save"));
   m_record_input_box = new QCheckBox(tr("Record inputs"));
   m_buffer_label = new QLabel(tr("Buffer:"));

--- a/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.cpp
@@ -31,7 +31,7 @@ void PadMappingDialog::CreateWidgets()
     m_wii_boxes[i] = new QComboBox;
 
     m_main_layout->addWidget(new QLabel(tr("GC Port %1").arg(i + 1)), 0, i);
-    m_main_layout->addWidget(new QLabel(tr("Wii Remote Port %1").arg(i + 1)), 0, 4 + i);
+    m_main_layout->addWidget(new QLabel(tr("Wii Remote %1").arg(i + 1)), 0, 4 + i);
     m_main_layout->addWidget(m_gc_boxes[i], 1, i);
     m_main_layout->addWidget(m_wii_boxes[i], 1, 4 + i);
   }

--- a/Source/Core/DolphinWX/NetPlay/MD5Dialog.cpp
+++ b/Source/Core/DolphinWX/NetPlay/MD5Dialog.cpp
@@ -91,7 +91,7 @@ void MD5Dialog::SetResult(int pid, const std::string& result)
 
   if (m_hashes.size() > 1)
   {
-    wxString label = AllHashesMatch() ? _("Hashes match!") : _("Hashes do not match.");
+    wxString label = AllHashesMatch() ? _("The hashes match!") : _("The hashes do not match!");
     m_final_result_label->SetLabel(label);
   }
   Layout();


### PR DESCRIPTION
As always, I'm doing this in order to avoid pushing extra strings onto translators. (Though these strings were also questionable for other reasons - Wiis don't have any physical ports for Wii Remotes, for instance.)