### PR TITLE
Qt/NetPlay: Use TraversalClient::FailureReason

### DIFF
--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -497,23 +497,23 @@ void NetPlayDialog::OnConnectionLost()
   DisplayMessage(tr("Lost connection to NetPlay server..."), "red");
 }
 
-void NetPlayDialog::OnTraversalError(int error)
+void NetPlayDialog::OnTraversalError(TraversalClient::FailureReason error)
 {
   QueueOnObject(this, [this, error] {
     switch (error)
     {
-    case TraversalClient::BadHost:
+    case TraversalClient::FailureReason::BadHost:
       QMessageBox::critical(this, tr("Traversal Error"), tr("Couldn't look up central server"));
       QDialog::reject();
       break;
-    case TraversalClient::VersionTooOld:
+    case TraversalClient::FailureReason::VersionTooOld:
       QMessageBox::critical(this, tr("Traversal Error"),
                             tr("Dolphin is too old for traversal server"));
       QDialog::reject();
       break;
-    case TraversalClient::ServerForgotAboutUs:
-    case TraversalClient::SocketSendError:
-    case TraversalClient::ResendTimeout:
+    case TraversalClient::FailureReason::ServerForgotAboutUs:
+    case TraversalClient::FailureReason::SocketSendError:
+    case TraversalClient::FailureReason::ResendTimeout:
       UpdateGUI();
       break;
     }

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
@@ -46,7 +46,7 @@ public:
   void OnPadBufferChanged(u32 buffer) override;
   void OnDesync(u32 frame, const std::string& player) override;
   void OnConnectionLost() override;
-  void OnTraversalError(int error) override;
+  void OnTraversalError(TraversalClient::FailureReason error) override;
   bool IsRecording() override;
   std::string FindGame(const std::string& game) override;
   void ShowMD5Dialog(const std::string& file_identifier) override;


### PR DESCRIPTION
Fixes not being able to compile Dolphin due to the NetPlay PR not using #5906.