### PR TITLE
BTBase: Fix a file deletion issue on Windows

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
@@ -38,14 +38,16 @@ void BackUpBTInfoSection(const SysConf* sysconf)
 void RestoreBTInfoSection(SysConf* sysconf)
 {
   const std::string filename = File::GetUserPath(D_CONFIG_IDX) + DIR_SEP WII_BTDINF_BACKUP;
-  File::IOFile backup(filename, "rb");
-  if (!backup)
-    return;
-  auto& section = sysconf->GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes;
-  if (!backup.ReadBytes(section.data(), section.size()))
   {
-    ERROR_LOG(IOS_WIIMOTE, "Failed to read backed up BT.DINF section");
-    return;
+    File::IOFile backup(filename, "rb");
+    if (!backup)
+      return;
+    auto& section = sysconf->GetOrAddEntry("BT.DINF", SysConf::Entry::Type::BigArray)->bytes;
+    if (!backup.ReadBytes(section.data(), section.size()))
+    {
+      ERROR_LOG(IOS_WIIMOTE, "Failed to read backed up BT.DINF section");
+      return;
+    }
   }
 
   File::Delete(filename);


### PR DESCRIPTION
Fixes the following error:

> The process cannot access the file because it is being used by another process.