### PR TITLE
GameList: make GetSelectedGame a pointer to GameFile

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -19,7 +19,7 @@ class GameList final : public QStackedWidget
 
 public:
   explicit GameList(QWidget* parent = nullptr);
-  QString GetSelectedGame() const;
+  QSharedPointer<GameFile> GetSelectedGame() const;
 
   void SetListView() { SetPreferredView(true); }
   void SetGridView() { SetPreferredView(false); }

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -195,6 +195,11 @@ bool GameListModel::ShouldDisplayGameListItem(int index) const
   }
 }
 
+QSharedPointer<GameFile> GameListModel::GetGameFile(int index) const
+{
+  return m_games[index];
+}
+
 void GameListModel::UpdateGame(QSharedPointer<GameFile> game)
 {
   QString path = game->GetFilePath();

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -25,6 +25,7 @@ public:
   int rowCount(const QModelIndex& parent) const override;
   int columnCount(const QModelIndex& parent) const override;
 
+  QSharedPointer<GameFile> GetGameFile(int index) const;
   // Path of the Game at the specified index.
   QString GetPath(int index) const { return m_games[index]->GetFilePath(); }
   // Unique ID of the Game at the specified index

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -310,7 +310,7 @@ void MainWindow::Play()
   }
   else
   {
-    QString selection = m_game_list->GetSelectedGame();
+    QString selection = m_game_list->GetSelectedGame()->GetFilePath();
     if (selection.length() > 0)
     {
       StartGame(selection);


### PR DESCRIPTION
Most places it's used were effectively 1) finding a GameFile, 2) getting its file path, and 3) re-creating a GameFile.

This gets rid of steps 2 and 3.