### PR TITLE
DolphinQt2: Replace "Pad size" with "Buffer size"

### DIFF
--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -484,7 +484,7 @@ void NetPlayDialog::OnMsgStopGame()
 void NetPlayDialog::OnPadBufferChanged(u32 buffer)
 {
   QueueOnObject(this, [this, buffer] { m_buffer_size_box->setValue(buffer); });
-  DisplayMessage(tr("Pad size changed to %1").arg(buffer), "gray");
+  DisplayMessage(tr("Buffer size changed to %1").arg(buffer), "gray");
 }
 
 void NetPlayDialog::OnDesync(u32 frame, const std::string& player)

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -581,7 +581,7 @@ void NetPlayDialog::OnThread(wxThreadEvent& event)
   break;
   case NP_GUI_EVT_PAD_BUFFER_CHANGE:
   {
-    std::string msg = StringFromFormat("Pad buffer: %d", m_pad_buffer);
+    std::string msg = StringFromFormat("Buffer size: %d", m_pad_buffer);
 
     if (g_ActiveConfig.bShowNetPlayMessages)
     {


### PR DESCRIPTION
"Pad size" just doesn't make much sense. Let's go with "Buffer size" instead, since the control for it is labeled "Buffer".

(Another possibility is "Pad buffer size", but I'm against that, because we've stopped referring to controllers as "pads" in almost all GUI strings.)