### PR TITLE
Interpreter: Fix cmpi.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -287,7 +287,6 @@ private:
   // flag helper
   static void Helper_UpdateCR0(u32 value);
   static void Helper_UpdateCR1();
-  static void Helper_UpdateCRx(int x, u32 value);
 
   // address helper
   static u32 Helper_Get_EA(const UGeckoInstruction inst);


### PR DESCRIPTION
cmpi shall compare two signed 32 bit values. The used difference a-b
may overflow and so the resulting 32 bit value can't represent it.
A correct way would be cr = s64(a) - s64(b) and it should be done in
this way in the JITs, but the Interpreter shall implement the most
readable way.

Also drops the now unused helper function.