### PR TITLE
JitArm64: Fix and improve the cmpXX instructions.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -229,8 +229,8 @@ private:
 
   FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set);
 
-  void ComputeRC(Arm64Gen::ARM64Reg reg, int crf = 0, bool needs_sext = true);
-  void ComputeRC(u64 imm, int crf = 0, bool needs_sext = true);
+  void ComputeRC0(Arm64Gen::ARM64Reg reg);
+  void ComputeRC0(u64 imm);
   void ComputeCarry(bool Carry);
   void ComputeCarry();
   void FlushCarry();


### PR DESCRIPTION
This PR ports a few cases for immediate propagation, but more important, it fixes the wrong cmpi instruction. This was ported from a broken interpreter instruction...