### PR TITLE
m_bt_wiimote_motor rename and tooltip addition

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -304,7 +304,7 @@ void BluetoothReal::DoState(PointerWrap& p)
   {
     // On load, discard any pending transfer to make sure the emulated software is not stuck
     // waiting for the previous request to complete. This is usually not an issue as long as
-    // the Bluetooth state is the same (same Wii remote connections).
+    // the Bluetooth state is the same (same Wii Remote connections).
     for (const auto& address_to_discard : addresses_to_discard)
       m_ios.EnqueueIPCReply(Request{address_to_discard}, 0);
 

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -82,7 +82,7 @@ void WiiConfigPane::InitializeGUI()
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_bt_sensor_bar_pos_strings);
   m_bt_sensor_bar_sens = new DolphinSlider(this, wxID_ANY, 0, 0, 4);
   m_bt_speaker_volume = new DolphinSlider(this, wxID_ANY, 0, 0, 127);
-  m_bt_wiimote_motor = new wxCheckBox(this, wxID_ANY, _("Wii Remote Rumble"));
+  m_bt_wiimote_motor_checkbox = new wxCheckBox(this, wxID_ANY, _("Wii Remote Rumble"));
 
   m_pal60_mode_checkbox->SetToolTip(_("Sets the Wii display mode to 60Hz (480i) instead of 50Hz "
                                       "(576i) for PAL games.\nMay not work for all games."));
@@ -90,6 +90,7 @@ void WiiConfigPane::InitializeGUI()
   m_system_language_choice->SetToolTip(_("Sets the Wii system language."));
   m_sd_card_checkbox->SetToolTip(_("Saved to /Wii/sd.raw (default size is 128mb)"));
   m_connect_keyboard_checkbox->SetToolTip(_("May cause slow down in Wii Menu and some games."));
+  m_bt_wiimote_motor_checkbox->SetToolTip(_("Enables Wii Remote vibration."));
 
   const int space5 = FromDIP(5);
 
@@ -141,7 +142,7 @@ void WiiConfigPane::InitializeGUI()
                               wxGBPosition(2, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
   bt_settings_grid_sizer->Add(bt_speaker_volume_sizer, wxGBPosition(2, 1), wxDefaultSpan,
                               wxALIGN_CENTER_VERTICAL);
-  bt_settings_grid_sizer->Add(m_bt_wiimote_motor, wxGBPosition(3, 0), wxGBSpan(1, 2),
+  bt_settings_grid_sizer->Add(m_bt_wiimote_motor_checkbox, wxGBPosition(3, 0), wxGBSpan(1, 2),
                               wxALIGN_CENTER_VERTICAL);
 
   wxStaticBoxSizer* const misc_settings_static_sizer =
@@ -193,7 +194,7 @@ void WiiConfigPane::LoadGUIValues()
       TranslateSensorBarPosition(Config::Get(Config::SYSCONF_SENSOR_BAR_POSITION)));
   m_bt_sensor_bar_sens->SetValue(Config::Get(Config::SYSCONF_SENSOR_BAR_SENSITIVITY));
   m_bt_speaker_volume->SetValue(Config::Get(Config::SYSCONF_SPEAKER_VOLUME));
-  m_bt_wiimote_motor->SetValue(Config::Get(Config::SYSCONF_WIIMOTE_MOTOR));
+  m_bt_wiimote_motor_checkbox->SetValue(Config::Get(Config::SYSCONF_WIIMOTE_MOTOR));
 }
 
 void WiiConfigPane::PopulateUSBPassthroughListbox()
@@ -235,8 +236,8 @@ void WiiConfigPane::BindEvents()
   m_bt_speaker_volume->Bind(wxEVT_SLIDER, &WiiConfigPane::OnSpeakerVolumeChanged, this);
   m_bt_speaker_volume->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 
-  m_bt_wiimote_motor->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnWiimoteMotorChanged, this);
-  m_bt_wiimote_motor->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+  m_bt_wiimote_motor_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnWiimoteMotorChanged, this);
+  m_bt_wiimote_motor_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 
   m_usb_passthrough_add_device_btn->Bind(wxEVT_BUTTON, &WiiConfigPane::OnUSBWhitelistAddButton,
                                          this);

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.h
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.h
@@ -60,5 +60,5 @@ private:
   wxChoice* m_bt_sensor_bar_pos;
   DolphinSlider* m_bt_sensor_bar_sens;
   DolphinSlider* m_bt_speaker_volume;
-  wxCheckBox* m_bt_wiimote_motor;
+  wxCheckBox* m_bt_wiimote_motor_checkbox;
 };


### PR DESCRIPTION
Addresses https://bugs.dolphin-emu.org/issues/10067. Some consistency fixes:

- Adds a "Enables Wii Remote vibration." tooltip for "Wii Remote Rumble"

- Renames `m_bt_wiimote_motor` to `m_bt_wiimote_motor_checkbox`

- Renames "Wii remote" to "Wii Remote"