### PR TITLE
[QSQLITE] [OBSOLETE] Qt: Implement gamelist caching

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -1,10 +1,11 @@
 find_package(Qt5Widgets REQUIRED)
 find_Package(Qt5Gui REQUIRED)
+find_package(Qt5Sql REQUIRED)
 set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
 message(STATUS "Found Qt version ${Qt5Core_VERSION}")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
+include_directories(${Qt5SQl_INCLUDE_DIRS})
 include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 
 add_definitions(-DQT_USE_QSTRINGBUILDER -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII)
@@ -59,6 +60,7 @@ set(SRCS
   Config/Mapping/WiimoteEmuMotionControl.cpp
   Config/PropertiesDialog.cpp
   Config/SettingsWindow.cpp
+  Database.cpp
   GameList/GameFile.cpp
   GameList/GameList.cpp
   GameList/GameListModel.cpp
@@ -90,7 +92,7 @@ endif()
 set(DOLPHINQT2_BINARY dolphin-emu-qt2)
 
 add_executable(${DOLPHINQT2_BINARY} ${SRCS} ${UI_HEADERS})
-target_link_libraries(${DOLPHINQT2_BINARY} ${LIBS} Qt5::Widgets)
+target_link_libraries(${DOLPHINQT2_BINARY} ${LIBS} Qt5::Widgets Qt5::Sql)
 
 if(APPLE)
   # Note: This is copied from DolphinQt, based on the DolphinWX version.

--- a/Source/Core/DolphinQt2/Database.cpp
+++ b/Source/Core/DolphinQt2/Database.cpp
@@ -1,0 +1,116 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Database.h"
+
+#include <QDebug>
+#include <QMessageBox>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QString>
+
+Database::Database(const QString& db_file)
+{
+  m_db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"));
+
+  m_db.setHostName(QStringLiteral("localhost"));
+  m_db.setDatabaseName(db_file);
+
+  if (!m_db.open())
+  {
+    qDebug() << QStringLiteral("Failed to open Database!");
+    return;
+  }
+
+  Init();
+
+  auto cache_version =
+      GetRow(QStringLiteral("SELECT value FROM db_meta WHERE key='cache_version';"));
+
+  if (cache_version.isEmpty())
+  {
+    Execute(QStringLiteral("INSERT INTO db_meta(key,value) VALUES('cache_version', %1)")
+                .arg(GAMELIST_CACHE_VERSION));
+  }
+  else
+  {
+    int db_version = cache_version.value(0).toInt();
+    if (db_version < GAMELIST_CACHE_VERSION)
+    {
+      qDebug() << QStringLiteral("This database file is outdated. Recreating the cache tables...");
+      Execute(QStringLiteral("DROP TABLE IF EXISTS gamefile_cache"));
+      Execute(QStringLiteral("DROP TABLE IF EXISTS gamefile_cache_multilang"));
+      Execute(QStringLiteral("UPDATE db_meta SET value=%1 WHERE key='cache_version'")
+                  .arg(GAMELIST_CACHE_VERSION));
+      Init();
+    }
+  }
+}
+
+void Database::Init()
+{
+  // TABLE db_meta
+  Execute(
+      QStringLiteral("CREATE TABLE IF NOT EXISTS db_meta(key TEXT PRIMARY KEY, value INTEGER)"));
+
+  // TABLE gamefile_cache
+  Execute(QStringLiteral(
+      "CREATE TABLE IF NOT EXISTS gamefile_cache(path_hash TEXT PRIMARY KEY, "
+      "game_id TEXT, title_id TEXT, maker TEXT, maker_id TEXT, name_internal TEXT, "
+      "revision INTEGER, disc_number INTEGER, platform INTEGER, region INTEGER, country INTEGER, "
+      "blob_type INTEGER, size INTEGER, apploader_data TEXT,  banner BLOB)"));
+
+  // TABLE gamefile_cache_multilang
+  Execute(
+      QStringLiteral("CREATE TABLE IF NOT EXISTS gamefile_cache_multilang(path_hash TEXT, "
+                     "language_id TEXT, description TEXT, name_short TEXT, name_long TEXT, "
+                     "maker_short TEXT, maker_long TEXT, PRIMARY KEY(path_hash, language_id))"));
+}
+
+QSqlQuery Database::Fetch(const QString& query)
+{
+  QSqlQuery sql(m_db);
+  sql.exec(query);
+  return sql;
+}
+
+bool Database::Execute(const QString& query)
+{
+  QSqlQuery sql(m_db);
+
+  bool success = sql.exec(query);
+
+  if (!success)
+  {
+    qDebug() << QStringLiteral("Failed to execute query: ") << sql.lastError();
+  }
+
+  return success;
+}
+
+bool Database::InsertValues(const QString& table, QStringList values)
+{
+  for (auto& item : values)
+  {
+    item = QStringLiteral("'%1'").arg(item.replace(QStringLiteral("'"), QStringLiteral("''")));
+  }
+  QString query =
+      QStringLiteral("INSERT INTO %1 VALUES(%2)").arg(table, values.join(QStringLiteral(", ")));
+
+  return Execute(query);
+}
+
+QSqlRecord Database::GetRow(const QString& query)
+{
+  QSqlQuery sql = Fetch(query);
+
+  sql.last();
+  bool empty = sql.at() == QSql::AfterLastRow;
+  sql.first();
+
+  if (!empty)
+    return sql.record();
+  else
+    return QSqlRecord();
+}

--- a/Source/Core/DolphinQt2/Database.h
+++ b/Source/Core/DolphinQt2/Database.h
@@ -1,0 +1,26 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QSqlDatabase>
+#include <QSqlRecord>
+
+class Database
+{
+public:
+  Database(const QString& db_file);
+
+  bool Execute(const QString& query);
+  bool InsertValues(const QString& table, QStringList values);
+  QSqlQuery Fetch(const QString& query);
+  QSqlRecord GetRow(const QString& row);
+
+  static constexpr int GAMELIST_CACHE_VERSION = 0x00;
+
+private:
+  QSqlDatabase m_db;
+
+  void Init();
+};

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -187,6 +187,7 @@
     <ClCompile Include="Config\LoggerWidget.cpp" />
     <ClCompile Include="Config\PropertiesDialog.cpp" />
     <ClCompile Include="Config\SettingsWindow.cpp" />
+    <ClCompile Include="Database.cpp" />
     <ClCompile Include="GameList\GameFile.cpp" />
     <ClCompile Include="GameList\GameList.cpp" />
     <ClCompile Include="GameList\GameListModel.cpp" />

--- a/Source/Core/DolphinQt2/GameList/GameFile.h
+++ b/Source/Core/DolphinQt2/GameList/GameFile.h
@@ -72,11 +72,12 @@ public:
   bool Install();
   bool Uninstall();
   bool ExportWiiSave();
+  void RemoveCache();
 
 private:
   QString GetBannerString(const QMap<DiscIO::Language, QString>& m) const;
 
-  QString GetCacheFileName() const;
+  QString GetHashedFileName() const;
   void ReadBanner(const DiscIO::Volume& volume);
   bool LoadFileInfo(const QString& path);
   void LoadState();
@@ -116,6 +117,7 @@ private:
   QString m_issues;
   int m_rating = 0;
   QString m_apploader_date;
+  bool m_has_banner = false;
 };
 
 QString FormatSize(qint64 size);

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -217,6 +217,7 @@ void GameListModel::RemoveGame(const QString& path)
     return;
 
   beginRemoveRows(QModelIndex(), entry, entry);
+  m_games[entry]->RemoveCache();
   m_games.removeAt(entry);
   endRemoveRows();
 }

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -15,7 +15,10 @@
 #include "DolphinQt2/Settings.h"
 #include "InputCommon/InputConfig.h"
 
-Settings::Settings() = default;
+Settings::Settings()
+    : m_database(QString::fromStdString(File::GetUserPath(D_CONFIG_IDX) + "dolphin.sqlite"))
+{
+}
 
 Settings& Settings::Instance()
 {
@@ -197,4 +200,9 @@ NetPlayServer* Settings::GetNetPlayServer()
 void Settings::ResetNetPlayServer(NetPlayServer* server)
 {
   m_server.reset(server);
+}
+
+Database& Settings::GetDatabase()
+{
+  return m_database;
 }

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -14,6 +14,8 @@
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayServer.h"
 
+#include "DolphinQt2/Database.h"
+
 namespace DiscIO
 {
 enum class Language;
@@ -72,6 +74,8 @@ public:
   // Other
   GameListModel* GetGameListModel() const;
 
+  // Database
+  Database& GetDatabase();
 signals:
   void ThemeChanged();
   void PathAdded(const QString&);
@@ -85,5 +89,7 @@ signals:
 private:
   std::unique_ptr<NetPlayClient> m_client;
   std::unique_ptr<NetPlayServer> m_server;
+  Database m_database;
+
   Settings();
 };

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -19,13 +19,14 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">QT_NO_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions>QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_SQL_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>QT_USE_QSTRINGBUILDER;QT_NO_CAST_FROM_ASCII;QT_NO_CAST_TO_ASCII;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(QtToolOutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(QtIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(QtIncludeDir)QtCore;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(QtIncludeDir)QtGui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(QtIncludeDir)QtSql;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(QtIncludeDir)QtWidgets;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!--
       Negate the previously enabled warning (set in Base.props). Not compatible with QtCore\qtmap.h
@@ -35,7 +36,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>qtmain$(QtLibSuffix).lib;Qt5Core$(QtLibSuffix).lib;Qt5Gui$(QtLibSuffix).lib;Qt5Widgets$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>qtmain$(QtLibSuffix).lib;Qt5Core$(QtLibSuffix).lib;Qt5Gui$(QtLibSuffix).lib;Qt5Sql$(QtLibSuffix).lib;Qt5Widgets$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <!--
       <AdditionalOptions>"/manifestdependency:type='Win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\" %(AdditionalOptions)</AdditionalOptions>
@@ -46,7 +47,7 @@
   <!--Compile files needed to MOC and output in the build directory-->
   <!--TODO find a way to autocreate from ClCompile settings-->
   <PropertyGroup>
-    <MocDefines>-DQT_USE_QSTRINGBUILDER -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_DLL -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB -D_SECURE_SCL=0 -D_ARCH_64=1 -D_M_X86_64=1 -D_M_X86=1 -DUSE_UPNP -D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_UNICODE -DUNICODE</MocDefines>
+    <MocDefines>-DQT_USE_QSTRINGBUILDER -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_DLL -DQT_CORE_LIB -DQT_GUI_LIB -DQT_SQL_LIB -DQT_WIDGETS_LIB -D_SECURE_SCL=0 -D_ARCH_64=1 -D_M_X86_64=1 -D_M_X86=1 -DUSE_UPNP -D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_UNICODE -DUNICODE</MocDefines>
     <MocDefines Condition="'$(Configuration)'=='Release'">-DQT_NO_DEBUG -DNDEBUG $(MocDefines)</MocDefines>
     <!-- !!!HOLY UGLY BATMAN!!!
         Be very careful here when adding include directories. Each path must have the whole arg surrounded by doublequotes - HOWEVER,
@@ -87,7 +88,7 @@
 
   <!--Copy the needed dlls-->
   <ItemGroup>
-    <QtLibNames Include="Qt5Core$(QtLibSuffix);Qt5Gui$(QtLibSuffix);Qt5Widgets$(QtLibSuffix)" />
+    <QtLibNames Include="Qt5Core$(QtLibSuffix);Qt5Gui$(QtLibSuffix);Qt5Sql$(QtLibSuffix);Qt5Widgets$(QtLibSuffix)" />
     <QtDlls Include="@(QtLibNames -> '$(QtBinDir)%(Identity).dll')" />
     <!--Filter plugins to copy based on the observation that all debug versions end in "d"-->
     <QtAllPlugins Include="$(QtPluginsDir)**\*$(QtLibSuffix).dll" />


### PR DESCRIPTION
Stores all information read from a ``GameFile`` in an SQLite database, which should greatly speed up loading the gamelist.

Features:
* Automatic housekeeping: If a file (or its parent directory) gets removed, so does its cache entry.
* Versioning: If the cache version is outdated, all cache data will be dropped and regenerated

Issues:
* Currently this PR won't build under Windows as the part of Qt that is required for interfacing SQL(ite) is not part of our minimal externals Qt (Requires [win-ext-qt PR #5](https://github.com/dolphin-emu/ext-win-qt/pull/5))

Benchmark (Not very good at the moment, as I don't have that many games):
First load: ~1,1s
Second load (Cached): 100ms max (seems instantaneous).