### PR TITLE
JitCommon: Update the block profiler

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1218,6 +1218,14 @@ void ARM64XEmitter::MRS(ARM64Reg Rt, PStateField field)
   EncodeSystemInst(o0 | 4, op1, CRn, CRm, op2, DecodeReg(Rt));
 }
 
+void ARM64XEmitter::CNTVCT(Arm64Gen::ARM64Reg Rt)
+{
+  _assert_msg_(DYNA_REC, Is64Bit(Rt), "CNTVCT: Rt must be 64-bit");
+
+  // MRS <Xt>, CNTVCT_EL0 ; Read CNTVCT_EL0 into Xt
+  EncodeSystemInst(3 | 4, 3, 0xe, 0, 2, DecodeReg(Rt));
+}
+
 void ARM64XEmitter::HINT(SystemHint op)
 {
   EncodeSystemInst(0, 3, 2, 0, op, WSP);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -603,9 +603,9 @@ public:
 
   // System
   void _MSR(PStateField field, u8 imm);
-
   void _MSR(PStateField field, ARM64Reg Rt);
   void MRS(ARM64Reg Rt, PStateField field);
+  void CNTVCT(ARM64Reg Rt);
 
   void HINT(SystemHint op);
   void CLREX();

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -200,7 +200,6 @@ void CachedInterpreter::Jit(u32 address)
 
   b->checkedEntry = GetCodePtr();
   b->normalEntry = GetCodePtr();
-  b->runCount = 0;
 
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -375,10 +375,10 @@ bool Jit64::Cleanup()
   {
     ABI_PushRegistersAndAdjustStack({}, 0);
     // get end tic
-    MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&js.curBlock->profile_data.ticStop)));
+    MOV(64, R(ABI_PARAM1), ImmPtr(&js.curBlock->profile_data.ticStop));
     ABI_CallFunction(QueryPerformanceCounter);
     // tic counter += (end tic - start tic)
-    MOV(64, R(RSCRATCH2), Imm64(reinterpret_cast<u64>(&js.curBlock->profile_data)));
+    MOV(64, R(RSCRATCH2), ImmPtr(&js.curBlock->profile_data));
     MOV(64, R(RSCRATCH), MDisp(RSCRATCH2, offsetof(JitBlock::ProfileData, ticStop)));
     SUB(64, R(RSCRATCH), MDisp(RSCRATCH2, offsetof(JitBlock::ProfileData, ticStart)));
     ADD(64, R(RSCRATCH), MDisp(RSCRATCH2, offsetof(JitBlock::ProfileData, ticCounter)));
@@ -668,7 +668,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
   if (Profiler::g_ProfileBlocks)
   {
     // get start tic
-    MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&b->profile_data.ticStart)));
+    MOV(64, R(ABI_PARAM1), ImmPtr(&b->profile_data.ticStart));
     int offset = static_cast<int>(offsetof(JitBlock::ProfileData, runCount)) -
                  static_cast<int>(offsetof(JitBlock::ProfileData, ticStart));
     ADD(64, MDisp(ABI_PARAM1, offset), Imm8(1));

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -174,9 +174,6 @@ private:
   static void InitializeInstructionTables();
   void CompileInstruction(PPCAnalyst::CodeOp& op);
 
-  void EmitResetCycleCounters();
-  void EmitGetCycles(Arm64Gen::ARM64Reg reg);
-
   // Simple functions to switch between near and far code emitting
   void SwitchToFarCode()
   {
@@ -252,9 +249,6 @@ private:
 
   Arm64Gen::ARM64CodeBlock farcode;
   u8* nearcode;  // Backed up when we switch to far code.
-
-  // Do we support cycle counter profiling?
-  bool m_supports_cycle_counter;
 
   bool m_enable_blr_optimization;
   bool m_cleanup_after_stackfault = false;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -67,8 +67,8 @@ void JitArm64::rfi(UGeckoInstruction inst)
   LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_SRR0]));
   gpr.Unlock(WB, WC);
 
-  // WA is unlocked in this function
   WriteExceptionExit(WA);
+  gpr.Unlock(WA);
 }
 
 void JitArm64::bx(UGeckoInstruction inst)
@@ -220,6 +220,8 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
   AND(WA, WA, 30, 29);  // Wipe the bottom 2 bits.
 
   WriteExit(WA, inst.LK_3, js.compilerPC + 4);
+
+  gpr.Unlock(WA);
 }
 
 void JitArm64::bclrx(UGeckoInstruction inst)
@@ -274,6 +276,8 @@ void JitArm64::bclrx(UGeckoInstruction inst)
   fpr.Flush(conditional ? FlushMode::FLUSH_MAINTAIN_STATE : FlushMode::FLUSH_ALL);
 
   WriteBLRExit(WA);
+
+  gpr.Unlock(WA);
 
   if (conditional)
     SwitchToNearCode();

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -49,7 +49,6 @@ struct JitBlock
   // The number of PPC instructions represented by this block. Mostly
   // useful for logging.
   u32 originalSize;
-  int runCount;  // for profiling.
 
   // Information about exits to a known address from this block.
   // This is used to implement block linking.
@@ -65,11 +64,15 @@ struct JitBlock
   // This set stores all physical addresses of all occupied instructions.
   std::set<u32> physical_addresses;
 
-  // we don't really need to save start and stop
-  // TODO (mb2): ticStart and ticStop -> "local var" mean "in block" ... low priority ;)
-  u64 ticStart;    // for profiling - time.
-  u64 ticStop;     // for profiling - time.
-  u64 ticCounter;  // for profiling - time.
+  // Block profiling data, structure is inlined in Jit.cpp
+  struct ProfileData
+  {
+    u64 ticCounter;
+    u64 downcountCounter;
+    u64 runCount;
+    u64 ticStart;
+    u64 ticStop;
+  } profile_data = {};
 
   // This tracks the position if this block within the fast block cache.
   // We allow each block to have only one map entry.

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -119,12 +119,12 @@ void GetProfileResults(ProfileStats* prof_stats)
 
   QueryPerformanceFrequency((LARGE_INTEGER*)&prof_stats->countsPerSec);
   g_jit->GetBlockCache()->RunOnBlocks([&prof_stats](const JitBlock& block) {
-    // Rough heuristic.  Mem instructions should cost more.
-    u64 cost = block.originalSize * (block.runCount / 4);
-    u64 timecost = block.ticCounter;
+    const auto& data = block.profile_data;
+    u64 cost = data.downcountCounter;
+    u64 timecost = data.ticCounter;
     // Todo: tweak.
-    if (block.runCount >= 1)
-      prof_stats->block_stats.emplace_back(block.effectiveAddress, cost, timecost, block.runCount,
+    if (data.runCount >= 1)
+      prof_stats->block_stats.emplace_back(block.effectiveAddress, cost, timecost, data.runCount,
                                            block.codeSize);
     prof_stats->cost_sum += cost;
     prof_stats->timecost_sum += timecost;

--- a/Source/Core/Core/PowerPC/Profiler.cpp
+++ b/Source/Core/Core/PowerPC/Profiler.cpp
@@ -10,7 +10,7 @@
 
 namespace Profiler
 {
-bool g_ProfileBlocks;
+bool g_ProfileBlocks = false;
 
 void WriteProfileResults(const std::string& filename)
 {

--- a/Source/Core/Core/PowerPC/Profiler.cpp
+++ b/Source/Core/Core/PowerPC/Profiler.cpp
@@ -5,6 +5,7 @@
 #include "Core/PowerPC/Profiler.h"
 
 #include <string>
+#include "Common/PerformanceCounter.h"
 #include "Core/PowerPC/JitInterface.h"
 
 namespace Profiler

--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -87,6 +87,7 @@ void CJitWindow::Compare(u32 em_address)
   PPCAnalyst::CodeBlock code_block;
   PPCAnalyst::PPCAnalyzer analyzer;
   analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+  analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_FOLLOW);
 
   code_block.m_stats = &st;
   code_block.m_gpa = &gpa;


### PR DESCRIPTION
The new code also captures the sum of the emulated time spend within the block.

It fixes a few Jit64 issues:
- Blocks with conditional continue weren't profiled
- x64 code as macros within the common files is now inlined in the jit64 code
- A bit faster profiler, but a `rdpmc` usage is still missing