### PR TITLE
MemoryView: ARAM crash fixed

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -53,9 +53,11 @@ std::string PPCDebugInterface::GetRawMemoryString(int memory, unsigned int addre
   {
     const bool is_aram = memory != 0;
 
-    if (is_aram || PowerPC::HostIsRAMAddress(address))
+    if ((is_aram && DSP::HostIsARAMAddress(address)) ||
+        (!is_aram && PowerPC::HostIsRAMAddress(address)))
+    {
       return StringFromFormat("%08X%s", ReadExtraMemory(memory, address), is_aram ? " (ARAM)" : "");
-
+    }
     return is_aram ? "--ARAM--" : "--------";
   }
 

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -603,6 +603,13 @@ void WriteARAM(u8 value, u32 address)
   s_ARAM.ptr[address & s_ARAM.mask] = value;
 }
 
+bool HostIsARAMAddress(u32 address)
+{
+  if (s_ARAM.wii_mode && (address & 0x10000000) == 0)
+    return (address & Memory::RAM_MASK) < Memory::REALRAM_SIZE;
+  return (address & s_ARAM.mask) < s_ARAM.size;
+}
+
 u8* GetARAMPtr()
 {
   return s_ARAM.ptr;

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -75,6 +75,7 @@ void GenerateDSPInterruptFromDSPEmu(DSPInterruptType type, int cycles_into_futur
 // Audio/DSP Helper
 u8 ReadARAM(u32 address);
 void WriteARAM(u8 value, u32 address);
+bool HostIsARAMAddress(u32 address);
 
 // Debugger Helper
 u8* GetARAMPtr();


### PR DESCRIPTION
I don't know if the ARAM memory view is broken or not but it can be valid with plethora of different address ranges. However, when the address is out-of-bound (such as 0x8000000) it dereferences a nullptr and crashes Dolphin.

I created the ```HostIsARAMAddress``` function which is checking out-of-bounds based on the ```ReadARAM``` function. Not sure if it's the best way to check that but at least that's a working alternative.

I'm open to suggestions concerning this function implementation.

Ready to be reviewed & merged.