### PR TITLE
Fix two small lint errors

### DIFF
--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -13,7 +13,7 @@
 #define _assert_msg_(_t_, _a_, _fmt_, ...)                                                         \
   if (!(_a_))                                                                                      \
   {                                                                                                \
-    if (!PanicYesNo(_fmt_ "\n\nIgnore and continue?", __VA_ARGS__))                                                           \
+    if (!PanicYesNo(_fmt_ "\n\nIgnore and continue?", __VA_ARGS__))                                \
       Crash();                                                                                     \
   }
 

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -108,11 +108,10 @@ public:
     return instance;
   }
 
-  const NANDContentLoader&
-  GetNANDLoader(const std::string& content_path,
-                Common::FromWhichRoot from = Common::FROM_CONFIGURED_ROOT);
-  const NANDContentLoader&
-  GetNANDLoader(u64 title_id, Common::FromWhichRoot from = Common::FROM_CONFIGURED_ROOT);
+  const NANDContentLoader& GetNANDLoader(const std::string& content_path,
+                                         Common::FromWhichRoot from = Common::FROM_CONFIGURED_ROOT);
+  const NANDContentLoader& GetNANDLoader(u64 title_id,
+                                         Common::FromWhichRoot from = Common::FROM_CONFIGURED_ROOT);
   void ClearCache();
 
 private:


### PR DESCRIPTION
I'm guessing they snuck in before `lint.sh` was made to actually fail on "invalid symmetric expressions" rather than printing an error message and continuing.