### PR TITLE
Fix OPROFILE linux build with -Wl,--as-needed

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -119,6 +119,10 @@ endif()
 
 add_dolphin_library(common "${SRCS}" "${LIBS}")
 
+if(OPROFILE_FOUND)
+  target_link_libraries(common PRIVATE ${OPROFILE_LIBRARIES})
+endif()
+
 if(UNIX)
   # Posix networking code needs to be fixed for Windows
   add_executable(traversal_server TraversalServer.cpp)

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -345,10 +345,6 @@ if(TARGET Hidapi::Hidapi)
   add_definitions(-DHAVE_HIDAPI=1)
 endif()
 
-if(OPROFILE_FOUND)
-  set(LIBS ${LIBS} ${OPROFILE_LIBRARIES})
-endif()
-
 if(GDBSTUB)
   set(SRCS ${SRCS} PowerPC/GDBStub.cpp)
 endif()


### PR DESCRIPTION
The opagent library was (incorrectly) marked as a dependency for "Core"
instead of "Common".

When linked with --as-needed, any symbols the linker can tell are not
used are discarded. As the link is done in command-line order, and the
Core library (and dependencies) are processed before Common, it would
link in Core, then opagent, but as at that point no opagent symbols are
used the whole opagent library would be discarded.

Moving the opagent library to be a dependency of Common fixes this, as
after the Common library is linked, there *are* opagent symbols used.