### PR TITLE
Vulkan: Drop clear render pass

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
@@ -32,8 +32,7 @@ public:
 
   bool Initialize();
 
-  VkRenderPass GetEFBLoadRenderPass() const { return m_efb_load_render_pass; }
-  VkRenderPass GetEFBClearRenderPass() const { return m_efb_clear_render_pass; }
+  VkRenderPass GetEFBRenderPass() const { return m_efb_render_pass; }
   u32 GetEFBWidth() const { return m_efb_width; }
   u32 GetEFBHeight() const { return m_efb_height; }
   u32 GetEFBLayers() const { return m_efb_layers; }
@@ -120,8 +119,7 @@ private:
   void DrawPokeVertices(const EFBPokeVertex* vertices, size_t vertex_count, bool write_color,
                         bool write_depth);
 
-  VkRenderPass m_efb_load_render_pass = VK_NULL_HANDLE;
-  VkRenderPass m_efb_clear_render_pass = VK_NULL_HANDLE;
+  VkRenderPass m_efb_render_pass = VK_NULL_HANDLE;
   VkRenderPass m_depth_resolve_render_pass = VK_NULL_HANDLE;
 
   u32 m_efb_width = 0;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -79,7 +79,6 @@ private:
   void ResetSamplerStates();
 
   void OnSwapChainResized();
-  void BindEFBToStateTracker();
   void ResizeEFBTextures();
   void ResizeSwapChain();
 

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
@@ -1197,7 +1197,7 @@ void ShaderCache::CreateDummyPipeline(const UberShader::VertexShaderUid& vuid,
                  GetGeometryShaderForUid(guid) :
                  VK_NULL_HANDLE;
   pinfo.ps = GetPixelUberShaderForUid(puid);
-  pinfo.render_pass = FramebufferManager::GetInstance()->GetEFBLoadRenderPass();
+  pinfo.render_pass = FramebufferManager::GetInstance()->GetEFBRenderPass();
   pinfo.rasterization_state.bits = Util::GetNoCullRasterizationState().bits;
   pinfo.depth_stencil_state.bits = Util::GetNoDepthTestingDepthStencilState().bits;
   pinfo.blend_state.hex = Util::GetNoBlendingBlendState().hex;


### PR DESCRIPTION
Causes the device to be lost on some NVIDIA systems, and it isn't clear if it provided a performance advantage. Related to #5478, and hopefully will fix the cases that are still occurring.

Furthermore, the clear render pass doesn't work on PowerVR (see #5649), and this optimization is mainly aimed at tilers anyway (IIRC, begin->end without any draw calls was not causing the cleared framebuffer to be written back).

Issue tracker reference: https://dolp.in/i10463/4