### PR TITLE
SymbolDB: Blank stripped symbol name fixed

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -11,6 +11,21 @@
 #include "Common/Logging/Log.h"
 #include "Common/SymbolDB.h"
 
+static std::string GetStrippedFunctionName(const std::string& symbol_name)
+{
+  std::string name = symbol_name.substr(0, symbol_name.find('('));
+  size_t position = name.find(' ');
+  if (position != std::string::npos)
+    name.erase(position);
+  return name;
+}
+
+void Symbol::Rename(const std::string& symbol_name)
+{
+  this->name = symbol_name;
+  this->function_name = GetStrippedFunctionName(symbol_name);
+}
+
 void SymbolDB::List()
 {
   for (const auto& func : functions)

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -30,6 +30,8 @@ struct Symbol
     Data,
   };
 
+  void Rename(const std::string& symbol_name);
+
   std::string name;
   std::string function_name;   // stripped function name
   std::vector<SCall> callers;  // addresses of functions that call this function

--- a/Source/Core/Core/Debugger/RSO.cpp
+++ b/Source/Core/Core/Debugger/RSO.cpp
@@ -384,7 +384,7 @@ void RSOView::Apply(PPCSymbolDB* symbol_db) const
       if (symbol)
       {
         // Function symbol
-        symbol->name = export_name;
+        symbol->Rename(export_name);
       }
       else
       {

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -149,7 +149,7 @@ bool ReadAnnotatedAssembly(const std::string& filename)
           temp[i - 5] = 0;
 
           // Mark symbol so the next hex sets the address
-          current_symbol.name = temp;
+          current_symbol.Rename(temp);
           current_symbol.address = 0xFFFF;
           current_symbol.index = symbol_count++;
           symbol_in_progress = true;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -85,8 +85,8 @@ static u32 EvaluateBranchTarget(UGeckoInstruction instr, u32 pc)
 // one blr or rfi, and keep scanning.
 bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
 {
-  if (!func.name.size())
-    func.name = StringFromFormat("zz_%07x_", startAddr & 0x0FFFFFFF);
+  if (func.name.empty())
+    func.Rename(StringFromFormat("zz_%07x_", startAddr & 0x0FFFFFFF));
   if (func.analyzed)
     return true;  // No error, just already did it.
 
@@ -341,7 +341,7 @@ static void FindFunctionsFromHandlers(PPCSymbolDB* func_db)
       Symbol* f = func_db->AddFunction(entry.first);
       if (!f)
         continue;
-      f->name = entry.second;
+      f->Rename(entry.second);
     }
   }
 }
@@ -407,9 +407,9 @@ void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db)
     if (f.name.substr(0, 3) == "zzz")
     {
       if (f.flags & FFLAG_LEAF)
-        f.name += "_leaf";
+        f.Rename(f.name + "_leaf");
       if (f.flags & FFLAG_STRAIGHT)
-        f.name += "_straight";
+        f.Rename(f.name + "_straight");
     }
     if (f.flags & FFLAG_LEAF)
     {

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -17,15 +17,6 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/SignatureDB/SignatureDB.h"
 
-static std::string GetStrippedFunctionName(const std::string& symbol_name)
-{
-  std::string name = symbol_name.substr(0, symbol_name.find('('));
-  size_t position = name.find(' ');
-  if (position != std::string::npos)
-    name.erase(position);
-  return name;
-}
-
 PPCSymbolDB g_symbolDB;
 
 PPCSymbolDB::PPCSymbolDB()
@@ -64,8 +55,7 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
   {
     // already got it, let's just update name, checksum & size to be sure.
     Symbol* tempfunc = &iter->second;
-    tempfunc->name = name;
-    tempfunc->function_name = GetStrippedFunctionName(name);
+    tempfunc->Rename(name);
     tempfunc->hash = HashSignatureDB::ComputeCodeChecksum(startAddr, startAddr + size - 4);
     tempfunc->type = type;
     tempfunc->size = size;
@@ -74,14 +64,13 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
   {
     // new symbol. run analyze.
     Symbol tf;
-    tf.name = name;
+    tf.Rename(name);
     tf.type = type;
     tf.address = startAddr;
     if (tf.type == Symbol::Type::Function)
     {
       PPCAnalyst::AnalyzeFunction(startAddr, tf, size);
       checksumToFunction[tf.hash].insert(&functions[startAddr]);
-      tf.function_name = GetStrippedFunctionName(name);
     }
     tf.size = size;
     functions[startAddr] = tf;

--- a/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
@@ -127,15 +127,14 @@ void HashSignatureDB::Apply(PPCSymbolDB* symbol_db) const
     for (const auto& function : symbol_db->GetSymbolsFromHash(entry.first))
     {
       // Found the function. Let's rename it according to the symbol file.
+      function->Rename(entry.second.name);
       if (entry.second.size == static_cast<unsigned int>(function->size))
       {
-        function->name = entry.second.name;
         INFO_LOG(OSHLE, "Found %s at %08x (size: %08x)!", entry.second.name.c_str(),
                  function->address, function->size);
       }
       else
       {
-        function->name = entry.second.name;
         ERROR_LOG(OSHLE, "Wrong size! Found %s at %08x (size: %08x instead of %08x)!",
                   entry.second.name.c_str(), function->address, function->size, entry.second.size);
       }

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -361,7 +361,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
                                      StrToWxStr(symbol->name));
       if (input_symbol.ShowModal() == wxID_OK)
       {
-        symbol->name = WxStrToStr(input_symbol.GetValue());
+        symbol->Rename(WxStrToStr(input_symbol.GetValue()));
         Refresh();  // Redraw to show the renamed symbol
       }
       Host_NotifyMapLoaded();

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -337,7 +337,7 @@ void CCodeWindow::OnSymbolsMenu(wxCommandEvent& event)
 
         Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
         if (symbol)
-          symbol->name = line.substr(12);
+          symbol->Rename(line.substr(12));
       }
 
       Host_NotifyMapLoaded();


### PR DESCRIPTION
This PR fixes a bunch of issues related to symbols not having their function_name member set.

Ready to be reviewed & merged.