### PR TITLE
GameINI: Enable fast disc speed for Dragon Quest X

### DIFF
--- a/Data/Sys/GameSettings/S4MJGD.ini
+++ b/Data/Sys/GameSettings/S4MJGD.ini
@@ -1,0 +1,5 @@
+# S4MJGD - Dragon Quest X
+
+[Core]
+# Speed up the installer.
+FastDiscSpeed = True


### PR DESCRIPTION
Speeds up the installer a lot (~20 minutes -> ~5).