### PR TITLE
Qt: Fix old usage of GetSelectedGame

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -169,7 +169,7 @@ void GameList::ShowContextMenu(const QPoint&)
   if (platform == DiscIO::Platform::WII_DISC)
   {
     menu->addAction(tr("Perform System Update"), [this] {
-      WiiUpdate::PerformDiscUpdate(GetSelectedGame().toStdString(), this);
+      WiiUpdate::PerformDiscUpdate(GetSelectedGame()->GetFilePath().toStdString(), this);
     });
     menu->setEnabled(!Core::IsRunning() || !SConfig::GetInstance().bWii);
   }


### PR DESCRIPTION
Waited too long before merging a PR, which managed to break the build
because GetSelectedGame was changed without introducing any conflict :(