### PR TITLE
Try to fix File::Copy with non-1024-byte aligned sizes

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -354,7 +354,7 @@ bool Copy(const std::string& srcFilename, const std::string& destFilename)
   while (!input.eof())
   {
     // read input
-    input.read(buffer, BSIZE);
+    auto read_size = input.readsome(buffer, BSIZE);
     if (!input)
     {
       ERROR_LOG(COMMON, "Copy: failed reading from source, %s --> %s: %s", srcFilename.c_str(),
@@ -363,7 +363,7 @@ bool Copy(const std::string& srcFilename, const std::string& destFilename)
     }
 
     // write output
-    if (!output.WriteBytes(buffer, BSIZE))
+    if (!output.WriteBytes(buffer, read_size))
     {
       ERROR_LOG(COMMON, "Copy: failed writing to output, %s --> %s: %s", srcFilename.c_str(),
                 destFilename.c_str(), GetLastErrorMsg().c_str());


### PR DESCRIPTION
ifstream::read() sets the failbit if trying to read over the end, which
means that (!input) would be hit for the 'last' block if it wasn't
exactly BSIZE (1024) bytes.