### PR TITLE
xlocale.h was removed in glibc 2.26

### DIFF
--- a/Externals/wxWidgets3/include/wx/xlocale.h
+++ b/Externals/wxWidgets3/include/wx/xlocale.h
@@ -41,7 +41,9 @@
         #define wxXLOCALE_IDENT(name) _ ## name
     #elif defined(HAVE_LOCALE_T)
         #include <locale.h>
-        #include <xlocale.h>
+        #if !(__GLIBC__ == 2 && __GLIBC_MINOR__ >= 26 || __GLIBC__ > 2)
+            #include <xlocale.h>
+        #endif
         #include <ctype.h>
         #include <stdlib.h>
 


### PR DESCRIPTION
Dolphin fails to build on current Arch Linux testing because of this.

Source: https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27