### PR TITLE
SW NativeVertexFormat: Utilize std::array where applicable

### DIFF
--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -339,7 +339,7 @@ static void CopyVertex(OutputVertexData* dst, const OutputVertexData* src, float
   dst->screenPosition.z = src->screenPosition.z;
 
   dst->normal = src->normal;
-  dst->color[0] = src->color[0];
+  dst->color = src->color;
 
   // todo - s offset
   dst->texCoords = src->texCoords;

--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -338,15 +338,11 @@ static void CopyVertex(OutputVertexData* dst, const OutputVertexData* src, float
   dst->screenPosition.y = src->screenPosition.y + dy;
   dst->screenPosition.z = src->screenPosition.z;
 
-  for (int i = 0; i < 3; ++i)
-    dst->normal[i] = src->normal[i];
-
-  for (int i = 0; i < 4; ++i)
-    dst->color[0][i] = src->color[0][i];
+  dst->normal = src->normal;
+  dst->color[0] = src->color[0];
 
   // todo - s offset
-  for (int i = 0; i < 8; ++i)
-    dst->texCoords[i] = src->texCoords[i];
+  dst->texCoords = src->texCoords;
 }
 
 void ProcessLine(OutputVertexData* lineV0, OutputVertexData* lineV1)

--- a/Source/Core/VideoBackends/Software/NativeVertexFormat.h
+++ b/Source/Core/VideoBackends/Software/NativeVertexFormat.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Software/Vec3.h"
 
@@ -18,12 +21,12 @@ struct Vec4
 struct InputVertexData
 {
   u8 posMtx;
-  u8 texMtx[8];
+  std::array<u8, 8> texMtx;
 
   Vec3 position;
-  Vec3 normal[3];
-  u8 color[2][4];
-  float texCoords[8][2];
+  std::array<Vec3, 3> normal;
+  std::array<std::array<u8, 4>, 2> color;
+  std::array<std::array<float, 2>, 8> texCoords;
 };
 
 struct OutputVertexData
@@ -40,9 +43,9 @@ struct OutputVertexData
   Vec3 mvPosition = {};
   Vec4 projectedPosition = {};
   Vec3 screenPosition = {};
-  Vec3 normal[3] = {};
-  u8 color[2][4] = {};
-  Vec3 texCoords[8] = {};
+  std::array<Vec3, 3> normal{};
+  std::array<std::array<u8, 4>, 2> color{};
+  std::array<Vec3, 8> texCoords{};
 
   void Lerp(float t, const OutputVertexData* a, const OutputVertexData* b)
   {
@@ -57,19 +60,19 @@ struct OutputVertexData
     projectedPosition.z = LINTERP(t, a->projectedPosition.z, b->projectedPosition.z);
     projectedPosition.w = LINTERP(t, a->projectedPosition.w, b->projectedPosition.w);
 
-    for (int i = 0; i < 3; ++i)
+    for (std::size_t i = 0; i < normal.size(); ++i)
     {
       normal[i] = LINTERP(t, a->normal[i], b->normal[i]);
     }
 
-    u16 t_int = (u16)(t * 256);
-    for (int i = 0; i < 4; ++i)
+    const u16 t_int = static_cast<u16>(t * 256);
+    for (std::size_t i = 0; i < color[0].size(); ++i)
     {
       color[0][i] = LINTERP_INT(t_int, a->color[0][i], b->color[0][i]);
       color[1][i] = LINTERP_INT(t_int, a->color[1][i], b->color[1][i]);
     }
 
-    for (int i = 0; i < 8; ++i)
+    for (std::size_t i = 0; i < texCoords.size(); ++i)
     {
       texCoords[i] = LINTERP(t, a->texCoords[i], b->texCoords[i]);
     }

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -4,6 +4,7 @@
 
 #include "VideoBackends/Software/SWVertexLoader.h"
 
+#include <cstddef>
 #include <limits>
 
 #include "Common/Assert.h"
@@ -97,7 +98,7 @@ void SWVertexLoader::vFlush()
     memset(&m_Vertex, 0, sizeof(m_Vertex));
 
     // Super Mario Sunshine requires those to be zero for those debug boxes.
-    memset(&m_Vertex.color, 0, sizeof(m_Vertex.color));
+    m_Vertex.color = {};
 
     // parse the videocommon format to our own struct format (m_Vertex)
     SetFormat(g_main_cp_state.last_id, primitiveType);
@@ -106,7 +107,7 @@ void SWVertexLoader::vFlush()
     // transform this vertex so that it can be used for rasterization (outVertex)
     OutputVertexData* outVertex = m_SetupUnit.GetVertex();
     TransformUnit::TransformPosition(&m_Vertex, outVertex);
-    memset(&outVertex->normal, 0, sizeof(outVertex->normal));
+    outVertex->normal = {};
     if (VertexLoaderManager::g_current_components & VB_HAS_NRM0)
     {
       TransformUnit::TransformNormal(
@@ -218,19 +219,19 @@ void SWVertexLoader::ParseVertex(const PortableVertexDeclaration& vdec, int inde
 
   ReadVertexAttribute<float>(&m_Vertex.position[0], src, vdec.position, 0, 3, false);
 
-  for (int i = 0; i < 3; i++)
+  for (std::size_t i = 0; i < m_Vertex.normal.size(); i++)
   {
     ReadVertexAttribute<float>(&m_Vertex.normal[i][0], src, vdec.normals[i], 0, 3, false);
   }
 
-  for (int i = 0; i < 2; i++)
+  for (std::size_t i = 0; i < m_Vertex.color.size(); i++)
   {
-    ReadVertexAttribute<u8>(m_Vertex.color[i], src, vdec.colors[i], 0, 4, true);
+    ReadVertexAttribute<u8>(m_Vertex.color[i].data(), src, vdec.colors[i], 0, 4, true);
   }
 
-  for (int i = 0; i < 8; i++)
+  for (std::size_t i = 0; i < m_Vertex.texCoords.size(); i++)
   {
-    ReadVertexAttribute<float>(m_Vertex.texCoords[i], src, vdec.texcoords[i], 0, 2, false);
+    ReadVertexAttribute<float>(m_Vertex.texCoords[i].data(), src, vdec.texcoords[i], 0, 2, false);
 
     // the texmtr is stored as third component of the texCoord
     if (vdec.texcoords[i].components >= 3)

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -330,7 +330,7 @@ void TransformColor(const InputVertexData* src, OutputVertexData* dst)
     // color
     const LitChannel& colorchan = xfmem.color[chan];
     if (colorchan.matsource)
-      std::memcpy(matcolor.data(), src->color[chan], sizeof(u32));  // vertex
+      matcolor = src->color[chan];  // vertex
     else
       std::memcpy(matcolor.data(), &xfmem.matColor[chan], sizeof(u32));
 
@@ -403,7 +403,7 @@ void TransformColor(const InputVertexData* src, OutputVertexData* dst)
 
     // abgr -> rgba
     const u32 rgba_color = Common::swap32(chancolor.data());
-    std::memcpy(dst->color[chan], &rgba_color, sizeof(u32));
+    std::memcpy(dst->color[chan].data(), &rgba_color, sizeof(u32));
   }
 }
 


### PR DESCRIPTION
Just clean-up. Gets rid of some hardcoded looping bounds, and also simplifies code in some places, sometimes allowing for removal of a loop altogether.

One thing I did notice that was a little unusual is that in `CopyVertex` in Clipper.cpp, only the first color array out of the two are copied over, is that intentional or an oversight? (cc @phire and @degasus in case either of you two know anything about it).