### PR TITLE
Add initial paths to GameTracker after construction

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -49,8 +49,6 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent)
 
   connect(m_list, &QTableView::doubleClicked, this, &GameList::GameSelected);
   connect(m_grid, &QListView::doubleClicked, this, &GameList::GameSelected);
-  connect(&Settings::Instance(), &Settings::PathAdded, m_model, &GameListModel::DirectoryAdded);
-  connect(&Settings::Instance(), &Settings::PathRemoved, m_model, &GameListModel::DirectoryRemoved);
   connect(m_model, &QAbstractItemModel::rowsInserted, this, &GameList::ConsiderViewChange);
   connect(m_model, &QAbstractItemModel::rowsRemoved, this, &GameList::ConsiderViewChange);
 

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -17,6 +17,9 @@ GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
   connect(this, &GameListModel::DirectoryAdded, &m_tracker, &GameTracker::AddDirectory);
   connect(this, &GameListModel::DirectoryRemoved, &m_tracker, &GameTracker::RemoveDirectory);
 
+  for (const QString& dir : Settings::Instance().GetPaths())
+    m_tracker.AddDirectory(dir);
+
   connect(&Settings::Instance(), &Settings::ThemeChanged, [this] {
     // Tell the view to repaint. The signal 'dataChanged' also seems like it would work here, but
     // unfortunately it won't cause a repaint until the view is focused.

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -14,8 +14,8 @@ GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
 {
   connect(&m_tracker, &GameTracker::GameLoaded, this, &GameListModel::UpdateGame);
   connect(&m_tracker, &GameTracker::GameRemoved, this, &GameListModel::RemoveGame);
-  connect(this, &GameListModel::DirectoryAdded, &m_tracker, &GameTracker::AddDirectory);
-  connect(this, &GameListModel::DirectoryRemoved, &m_tracker, &GameTracker::RemoveDirectory);
+  connect(&Settings::Instance(), &Settings::PathAdded, &m_tracker, &GameTracker::AddDirectory);
+  connect(&Settings::Instance(), &Settings::PathRemoved, &m_tracker, &GameTracker::RemoveDirectory);
 
   for (const QString& dir : Settings::Instance().GetPaths())
     m_tracker.AddDirectory(dir);

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -48,10 +48,6 @@ public:
   void UpdateGame(QSharedPointer<GameFile> game);
   void RemoveGame(const QString& path);
 
-signals:
-  void DirectoryAdded(const QString& dir);
-  void DirectoryRemoved(const QString& dir);
-
 private:
   // Index in m_games, or -1 if it isn't found
   int FindGame(const QString& path) const;

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -28,9 +28,6 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
   connect(m_loader, &GameLoader::GameLoaded, this, &GameTracker::GameLoaded);
 
   m_loader_thread.start();
-
-  for (QString dir : Settings::Instance().GetPaths())
-    AddDirectory(dir);
 }
 
 GameTracker::~GameTracker()


### PR DESCRIPTION
It's strange to see GameTracker add its own initial paths in construction, because you might expect a race condition where the GameLoaded signal is emitted before it gets connected to in GameListModel.

In fact, this doesn't happen, but only because of how it abuses the Qt signals mechanism to load files asynchronously: GameLoader emits a GameLoaded signal which gets forwarded to the GameTracker::GameLoaded signal _after_ control returns to the event loop, at which point GameListModel has connected.

This PR moves the logic of adding initial paths out of GameTracker to a point after the signals are connected, which is more obvious and doesn't rely on how GameTracker implements concurrency.

It also cleans up how GameListModel was getting connected to Settings::PathAdded/PathRemoved, to coalesce the references to Settings into a single layer in the GameList/GameListModel/GameTracker/etc system.