### PR TITLE
D3DBase: Only use a stereo swapchain if quad-buffering is enabled.

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -301,11 +301,7 @@ HRESULT Create(HWND wnd)
   swap_chain_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
   swap_chain_desc.Width = xres;
   swap_chain_desc.Height = yres;
-
-  // By creating a stereo swapchain early we can toggle Quad-Buffered stereoscopy
-  // while the game is running.
-  swap_chain_desc.Stereo =
-      g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER || factory->IsWindowedStereoEnabled();
+  swap_chain_desc.Stereo = g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER;
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   // Creating debug devices can sometimes fail if the user doesn't have the correct


### PR DESCRIPTION
This fixed issue [#10445](https://bugs.dolphin-emu.org/issues/10445).

Some displays incorrectly return true for [`IsWindowedStereoEnabled`](https://msdn.microsoft.com/en-us/library/windows/desktop/hh404561(v=vs.85).aspx) even though a 3D display mode is not selected. Then when we create a stereo swap chain it will change to a stereo 3D display mode, which causes issues when the display doesn't support temporary mono.