### PR TITLE
GameListModel: make UpdateGame update existing files as well

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -200,7 +200,7 @@ QSharedPointer<GameFile> GameListModel::GetGameFile(int index) const
   return m_games[index];
 }
 
-void GameListModel::UpdateGame(QSharedPointer<GameFile> game)
+void GameListModel::UpdateGame(const QSharedPointer<GameFile>& game)
 {
   QString path = game->GetFilePath();
 

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -204,15 +204,18 @@ void GameListModel::UpdateGame(QSharedPointer<GameFile> game)
 {
   QString path = game->GetFilePath();
 
-  int entry = FindGame(path);
-  if (entry < 0)
-    entry = m_games.size();
+  int index = FindGame(path);
+  if (index < 0)
+  {
+    beginInsertRows(QModelIndex(), m_games.size(), m_games.size());
+    m_games.push_back(game);
+    endInsertRows();
+  }
   else
-    return;
-
-  beginInsertRows(QModelIndex(), entry, entry);
-  m_games.insert(entry, game);
-  endInsertRows();
+  {
+    m_games[index] = game;
+    emit dataChanged(createIndex(index, 0), createIndex(index + 1, columnCount(QModelIndex())));
+  }
 }
 
 void GameListModel::RemoveGame(const QString& path)

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -45,7 +45,7 @@ public:
     NUM_COLS
   };
 
-  void UpdateGame(QSharedPointer<GameFile> game);
+  void UpdateGame(const QSharedPointer<GameFile>& game);
   void RemoveGame(const QString& path);
 
 signals:


### PR DESCRIPTION
Potentially needed if a game file is changed, or if the soon-to-exist cache doesn't match the file on disk. It's also more accurate to the name of the method.

Example of game list updating (after some local trickery to get the current state to not match what's on disk, and some code to slow down I/O to make it obvious):

![out](https://user-images.githubusercontent.com/594093/29498330-4213e336-85ae-11e7-9bf5-7795af05ece8.gif)
