### PR TITLE
GameListModel: fallback to file name if long name is empty

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -192,7 +192,6 @@ bool GameFile::TryLoadElfDol()
     return false;
 
   m_revision = 0;
-  m_long_names[DiscIO::Language::LANGUAGE_ENGLISH] = m_file_name;
   m_platform = DiscIO::Platform::ELF_DOL;
   m_region = DiscIO::Region::UNKNOWN_REGION;
   m_country = DiscIO::Country::COUNTRY_UNKNOWN;

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -73,7 +73,10 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
                                                Core::TitleDatabase::TitleType::Channel :
                                                Core::TitleDatabase::TitleType::Other));
       if (display_name.isEmpty())
-        return game->GetLongName();
+        display_name = game->GetLongName();
+
+      if (display_name.isEmpty())
+        display_name = game->GetFileName();
 
       return display_name;
     }


### PR DESCRIPTION
This stops ELF/DOL files from setting their English long name to the file name, which doesn't make much sense.