### PR TITLE
GameTracker: use new Common::WorkQueueThread instead of signals/slots

### DIFF
--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -152,6 +152,7 @@
     <ClInclude Include="TraversalClient.h" />
     <ClInclude Include="TraversalProto.h" />
     <ClInclude Include="UPnP.h" />
+    <ClInclude Include="WorkQueueThread.h" />
     <ClInclude Include="x64ABI.h" />
     <ClInclude Include="x64Emitter.h" />
     <ClInclude Include="x64Reg.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -68,6 +68,7 @@
     <ClInclude Include="SysConf.h" />
     <ClInclude Include="Thread.h" />
     <ClInclude Include="Timer.h" />
+    <ClInclude Include="WorkQueueThread.h" />
     <ClInclude Include="x64ABI.h" />
     <ClInclude Include="x64Emitter.h" />
     <ClInclude Include="x64Reg.h" />

--- a/Source/Core/Common/WorkQueueThread.h
+++ b/Source/Core/Common/WorkQueueThread.h
@@ -1,0 +1,86 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <queue>
+#include <thread>
+
+#include "Common/Event.h"
+#include "Common/Flag.h"
+
+// A thread that executes the given function for every item placed into its queue.
+
+namespace Common
+{
+template <typename T>
+class WorkQueueThread
+{
+public:
+  WorkQueueThread() = default;
+  WorkQueueThread(std::function<void(T)> function) { Reset(std::move(function)); }
+  ~WorkQueueThread() { Shutdown(); }
+  void Reset(std::function<void(T)> function)
+  {
+    Shutdown();
+    m_shutdown.Clear();
+    m_function = std::move(function);
+    m_thread = std::thread([this] { ThreadLoop(); });
+  }
+
+  template <typename... Args>
+  void EmplaceItem(Args&&... args)
+  {
+    {
+      std::unique_lock<std::mutex> lg(m_lock);
+      m_items.emplace(std::move(args)...);
+    }
+    m_wakeup.Set();
+  }
+
+private:
+  void Shutdown()
+  {
+    if (m_thread.joinable())
+    {
+      m_shutdown.Set();
+      m_wakeup.Set();
+      m_thread.join();
+    }
+  }
+
+  void ThreadLoop()
+  {
+    while (true)
+    {
+      m_wakeup.Wait();
+
+      while (true)
+      {
+        T item;
+        {
+          std::unique_lock<std::mutex> lg(m_lock);
+          if (m_items.empty())
+            break;
+          item = m_items.front();
+          m_items.pop();
+        }
+        m_function(std::move(item));
+      }
+
+      if (m_shutdown.IsSet())
+        break;
+    }
+  }
+
+  std::function<void(T)> m_function;
+  std::thread m_thread;
+  Common::Event m_wakeup;
+  Common::Flag m_shutdown;
+  std::mutex m_lock;
+  std::queue<T> m_items;
+};
+
+}  // namespace Common

--- a/Source/Core/Common/WorkQueueThread.h
+++ b/Source/Core/Common/WorkQueueThread.h
@@ -35,7 +35,7 @@ public:
   {
     {
       std::unique_lock<std::mutex> lg(m_lock);
-      m_items.emplace(std::move(args)...);
+      m_items.emplace(std::forward<Args>(args)...);
     }
     m_wakeup.Set();
   }

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -9,25 +9,19 @@
 #include <QSet>
 #include <QSharedPointer>
 #include <QString>
-#include <QStringList>
-#include <QThread>
 
+#include "Common/WorkQueueThread.h"
 #include "DolphinQt2/GameList/GameFile.h"
-
-class GameLoader;
 
 // Watches directories and loads GameFiles in a separate thread.
 // To use this, just add directories using AddDirectory, and listen for the
-// GameLoaded and GameRemoved signals. Ignore the PathChanged signal, it's
-// only there because the Qt people made fileChanged and directoryChanged
-// private.
+// GameLoaded and GameRemoved signals.
 class GameTracker final : public QFileSystemWatcher
 {
   Q_OBJECT
 
 public:
   explicit GameTracker(QObject* parent = nullptr);
-  ~GameTracker();
 
   void AddDirectory(const QString& dir);
   void RemoveDirectory(const QString& dir);
@@ -36,28 +30,15 @@ signals:
   void GameLoaded(QSharedPointer<GameFile> game);
   void GameRemoved(const QString& path);
 
-  void PathChanged(const QString& path);
-
 private:
+  void LoadGame(const QString& path);
   void UpdateDirectory(const QString& dir);
   void UpdateFile(const QString& path);
   QSet<QString> FindMissingFiles(const QString& dir);
 
   // game path -> directories that track it
   QMap<QString, QSet<QString>> m_tracked_files;
-  QThread m_loader_thread;
-  GameLoader* m_loader;
-};
-
-class GameLoader final : public QObject
-{
-  Q_OBJECT
-
-public:
-  void LoadGame(const QString& path);
-
-signals:
-  void GameLoaded(QSharedPointer<GameFile> game);
+  Common::WorkQueueThread<QString> m_load_thread;
 };
 
 Q_DECLARE_METATYPE(QSharedPointer<GameFile>)


### PR DESCRIPTION
While using a separate GameLoader class on a separate QThread and relying on Qt to pass signals safely across threads works, it's not very semantically clear and it muddies up the GameTracker code (which has to care about the threads and signals, rather than just games).

This cleans up GameTracker and implements the "spin up a separate thread to do chunks of work" logic using the STL.

Needs #5945 or something like it in order to fix the race condition between loading files and connecting to the GameLoaded signal.