### PR TITLE
CommonTypes: Qualify standard integral types in typedefs with std::

### DIFF
--- a/Source/Core/Common/CommonTypes.h
+++ b/Source/Core/Common/CommonTypes.h
@@ -18,12 +18,12 @@
 #define LONG int
 #endif
 
-typedef uint8_t u8;
-typedef uint16_t u16;
-typedef uint32_t u32;
-typedef uint64_t u64;
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
 
-typedef int8_t s8;
-typedef int16_t s16;
-typedef int32_t s32;
-typedef int64_t s64;
+using s8 = std::int8_t;
+using s16 = std::int16_t;
+using s32 = std::int32_t;
+using s64 = std::int64_t;


### PR DESCRIPTION
Given a relatively recent proposal ([P0657R0](http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2017/p0657r0.pdf)), which calls for deprecation of putting stuff into the global namespace when using C++ headers, this just futureproofs our code a little more if it's accepted.

Technically this is what we should have been doing initially anyways, since an implementation is allowed to not provide these types in the global namespace through `<cstdint>` and still be compliant.