### PR TITLE
Fixes for OSX hotkey defaults

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -325,6 +325,15 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
   const std::string ALT = "((LMENU | RMENU) & !(LSHIFT | RSHIFT) & !(LCONTROL | RCONTROL))";
   const std::string SHIFT = "(!(LMENU | RMENU) & (LSHIFT | RSHIFT) & !(LCONTROL | RCONTROL))";
   const std::string CTRL = "(!(LMENU | RMENU) & !(LSHIFT | RSHIFT) & (LCONTROL | RCONTROL))";
+#elif __APPLE__
+  const std::string NON =
+      "(!`Left Alt` & !(`Left Shift`| `Right Shift`) & !(`Left Control` | `Right Control`))";
+  const std::string ALT =
+      "(`Left Alt` & !(`Left Shift`| `Right Shift`) & !(`Left Control` | `Right Control`))";
+  const std::string SHIFT =
+      "(!`Left Alt` & (`Left Shift`| `Right Shift`) & !(`Left Control` | `Right Control`))";
+  const std::string CTRL =
+      "(!`Left Alt` & !(`Left Shift`| `Right Shift`) & (`Left Control` | `Right Control`))";
 #else
   const std::string NON = "(!`Alt_L` & !(`Shift_L` | `Shift_R`) & !(`Control_L` | `Control_R` ))";
   const std::string ALT = "(`Alt_L` & !(`Shift_L` | `Shift_R`) & !(`Control_L` | `Control_R` ))";


### PR DESCRIPTION
I've been plagued with hotkey issues for some time now on Dolphin on OSX, which I have found stem from an issue in the keyboard.mm files for both OSX and Quartz inputs, where the keys are specifically labelled in Dolphin's InputCommon. This compounded onto the hotkey manager meant that the default setting was looking for keys that it could never receive.
I'm guessing when Quartz was implemented, it just copied a lot of things from the standard OSX Keyboard implementation, which is why they both have the same issue.

I double checked this against both Ubuntu 16.04.3 LTS and Windows 10, and the defaults still behave the same.