### PR TITLE
RenderState: Fix incorrect blending factors when removing the color usage.

### DIFF
--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -94,9 +94,10 @@ void BlendingState::Generate(const BPMemory& bp)
       srcfactor = RemoveDstAlphaUsage(srcfactor);
       dstfactor = RemoveDstAlphaUsage(dstfactor);
     }
-    // replaces SRCCLR with SRCALPHA
-    srcfactoralpha = RemoveSrcColorUsage(srcfactor);
-    dstfactoralpha = RemoveDstColorUsage(dstfactor);
+    // replaces SRCCLR with SRCALPHA and DSTCLR with DSTALPHA, it is important to
+    // use the dst function for the src factor and vice versa
+    srcfactoralpha = RemoveDstColorUsage(srcfactor);
+    dstfactoralpha = RemoveSrcColorUsage(dstfactor);
 
     if (dstalpha)
     {


### PR DESCRIPTION
The src factor uses DSTCLR factors and the dst factor uses the SRCCLR factors, but the code for converting the color factors to alpha factors assumed it the other way around.