### PR TITLE
VideoCommon: Fix bug #10464 (RA4 format not handled in TextureDecoder)

### DIFF
--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -127,6 +127,7 @@ int TexDecoder_GetEFBCopyBlockWidthInTexels(EFBCopyFormat format)
   case EFBCopyFormat::R4:
     return 8;
   // 8-bit formats
+  case EFBCopyFormat::RA4:
   case EFBCopyFormat::A8:
   case EFBCopyFormat::R8_0x1:
   case EFBCopyFormat::R8:
@@ -158,6 +159,7 @@ int TexDecoder_GetEFBCopyBlockHeightInTexels(EFBCopyFormat format)
   case EFBCopyFormat::R4:
     return 8;
   // 8-bit formats
+  case EFBCopyFormat::RA4:
   case EFBCopyFormat::A8:
   case EFBCopyFormat::R8_0x1:
   case EFBCopyFormat::R8:


### PR DESCRIPTION
This PR fixes [Issue #10464](https://bugs.dolphin-emu.org/issues/10464). Due to an oversight, RA4 format was not handled in some TextureDecoder functions.