### PR TITLE
GameFile: don't store file path parts

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -83,7 +83,7 @@ QString GameFile::GetCacheFileName() const
   // files with the same names in different folders.
   QString hash =
       QString::fromUtf8(QCryptographicHash::hash(m_path.toUtf8(), QCryptographicHash::Md5).toHex());
-  return folder + m_file_name + hash;
+  return folder + GetFileName() + hash;
 }
 
 void GameFile::ReadBanner(const DiscIO::Volume& volume)
@@ -110,9 +110,6 @@ bool GameFile::LoadFileInfo(const QString& path)
   if (!info.exists() || !info.isReadable())
     return false;
 
-  m_file_name = info.fileName();
-  m_extension = info.suffix();
-  m_folder = info.dir().dirName();
   m_last_modified = info.lastModified();
   m_size = info.size();
 
@@ -130,7 +127,8 @@ void GameFile::LoadState()
 
 bool GameFile::IsElfOrDol()
 {
-  return m_extension == QStringLiteral("elf") || m_extension == QStringLiteral("dol");
+  QString extension = GetFileExtension();
+  return extension == QStringLiteral("elf") || extension == QStringLiteral("dol");
 }
 
 bool GameFile::TryLoadCache()
@@ -207,6 +205,21 @@ bool GameFile::TryLoadElfDol()
 void GameFile::SaveCache()
 {
   // TODO
+}
+
+QString GameFile::GetFileName() const
+{
+  return QFileInfo(m_path).fileName();
+}
+
+QString GameFile::GetFileExtension() const
+{
+  return QFileInfo(m_path).suffix();
+}
+
+QString GameFile::GetFileFolder() const
+{
+  return QFileInfo(m_path).dir().dirName();
 }
 
 QString GameFile::GetBannerString(const QMap<DiscIO::Language, QString>& m) const

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -5,6 +5,7 @@
 #include <QCryptographicHash>
 #include <QDataStream>
 #include <QDir>
+#include <QFileInfo>
 #include <QImage>
 #include <QSharedPointer>
 

--- a/Source/Core/DolphinQt2/GameList/GameFile.h
+++ b/Source/Core/DolphinQt2/GameList/GameFile.h
@@ -30,9 +30,9 @@ public:
   bool IsValid() const;
   // These will be properly initialized before we try to load the file.
   QString GetFilePath() const { return m_path; }
-  QString GetFileName() const { return m_file_name; }
-  QString GetFileExtension() const { return m_extension; }
-  QString GetFileFolder() const { return m_folder; }
+  QString GetFileName() const;
+  QString GetFileExtension() const;
+  QString GetFileFolder() const;
   qint64 GetFileSize() const { return m_size; }
   // The rest will not.
   QString GetGameID() const { return m_game_id; }
@@ -88,9 +88,6 @@ private:
 
   bool m_valid;
   QString m_path;
-  QString m_file_name;
-  QString m_extension;
-  QString m_folder;
   QDateTime m_last_modified;
   qint64 m_size = 0;
 


### PR DESCRIPTION
There's no need to store these, and calculating them in the same method that tests for file existence and gets size and mtime doesn't really make sense.