### PR TITLE
GameFile: handle missing banners in UI instead

### DIFF
--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -69,7 +69,6 @@ QGroupBox* InfoWidget::CreateBannerDetails()
   m_long_maker = CreateValueDisplay();
   m_description = new QTextEdit();
   m_description->setReadOnly(true);
-  QWidget* banner = CreateBannerGraphic();
   CreateLanguageSelector();
 
   layout->addRow(tr("Show Language:"), m_language_selector);
@@ -85,7 +84,11 @@ QGroupBox* InfoWidget::CreateBannerDetails()
   {
     layout->addRow(tr("Name:"), m_long_name);
   }
-  layout->addRow(tr("Banner:"), banner);
+
+  if (!m_game.GetBanner().isNull())
+  {
+    layout->addRow(tr("Banner:"), CreateBannerGraphic());
+  }
 
   group->setLayout(layout);
   return group;

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -99,8 +99,6 @@ void GameFile::ReadBanner(const DiscIO::Volume& volume)
 
   if (!banner.isNull())
     m_banner = QPixmap::fromImage(banner);
-  else
-    m_banner = Resources::GetMisc(Resources::BANNER_MISSING);
 }
 
 bool GameFile::LoadFileInfo(const QString& path)
@@ -197,7 +195,6 @@ bool GameFile::TryLoadElfDol()
   m_country = DiscIO::Country::COUNTRY_UNKNOWN;
   m_blob_type = DiscIO::BlobType::DIRECTORY;
   m_raw_size = m_size;
-  m_banner = Resources::GetMisc(Resources::BANNER_MISSING);
   m_rating = 0;
 
   return true;

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -63,6 +63,8 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
       // GameCube banners are 96x32, but Wii banners are 192x64.
       // TODO: use custom banners from rom directory like DolphinWX?
       QPixmap banner = game->GetBanner();
+      if (banner.isNull())
+        banner = Resources::GetMisc(Resources::BANNER_MISSING);
       banner.setDevicePixelRatio(std::max(banner.width() / GAMECUBE_BANNER_SIZE.width(),
                                           banner.height() / GAMECUBE_BANNER_SIZE.height()));
       return banner;


### PR DESCRIPTION
Currently, GameFile returns a generic banner if the file didn't have one available (either because the file format doesn't support it, or because it's a Wii file without an associated save).

It makes more sense to handle the lack of banner in the UI layer. The game list will use the generic missing banner explicitly (no change from before), and the game info window now omits the banner display entirely if the file didn't have one (since it's not useful to display/allow the user to save the "missing banner" banner).

Info window before:

<img width="377" alt="screen shot 2017-08-21 at 6 02 02 pm" src="https://user-images.githubusercontent.com/594093/29544131-ebe27b24-869a-11e7-801b-893eeb6d06e1.png">


Info window after:

<img width="380" alt="screen shot 2017-08-21 at 6 02 28 pm" src="https://user-images.githubusercontent.com/594093/29544133-ef788418-869a-11e7-84e0-106a08dadb49.png">
