### PR TITLE
JitArm64: Fix rlwinmx.

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -4057,7 +4057,7 @@ void ARM64XEmitter::ANDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
   else
   {
     _assert_msg_(DYNA_REC, scratch != INVALID_REG,
-                 "ANDSI2R - failed to construct logical immediate value from %08x, need scratch",
+                 "ANDI2R - failed to construct logical immediate value from %08x, need scratch",
                  (u32)imm);
     MOVI2R(scratch, imm);
     AND(Rd, Rn, scratch);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -532,7 +532,12 @@ void JitArm64::rlwinmx(UGeckoInstruction inst)
 
   gpr.BindToRegister(a, a == s);
 
-  if (!inst.SH)
+  if (!inst.SH && mask == 0xFFFFFFFF)
+  {
+    if (a != s)
+      MOV(gpr.R(a), gpr.R(s));
+  }
+  else if (!inst.SH)
   {
     // Immediate mask
     ANDI2R(gpr.R(a), gpr.R(s), mask);


### PR DESCRIPTION
Seems like I was wrong that ANDI2R doesn't require a temporary register here.
There is *one* case when the mask won't fit in the ARM AND instruction:
mask = 0xFFFFFFFF
But let's just use MOV instead of AND here for this case...