### PR TITLE
Fix DolphinWX build issue

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -203,8 +203,9 @@ void AdvancedConfigPane::UpdateCPUClock()
   int percent = static_cast<int>(std::round(SConfig::GetInstance().m_OCFactor * 100.f));
   int clock = static_cast<int>(std::round(SConfig::GetInstance().m_OCFactor * core_clock));
 
-  m_clock_override_text->SetLabel(
-      SConfig::GetInstance().m_OCEnable ? wxString::Format("%d %% (%d MHz)", percent, clock) : "");
+  m_clock_override_text->SetLabel(SConfig::GetInstance().m_OCEnable ?
+                                      wxString::Format("%d %% (%d MHz)", percent, clock) :
+                                      wxString());
 }
 
 void AdvancedConfigPane::LoadCustomRTC()


### PR DESCRIPTION
I'm not sure why this hasn't popped up as an error on the buildbots, but the build fails on my new install of VS2017. The error is `C2445: result type of conditional expression is ambiguous: types 'wxString' and 'const char [1]' can be converted to multiple common types`