### PR TITLE
Fix vulkan crash on drivers without atomic load/store support

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -1118,7 +1118,8 @@ bool StateTracker::UpdateDescriptorSet()
     m_dirty_flags |= DIRTY_FLAG_DESCRIPTOR_SET_BINDING;
   }
 
-  if ((m_dirty_flags & DIRTY_FLAG_PS_SSBO ||
+  if (IsSSBODescriptorRequired() &&
+      (m_dirty_flags & DIRTY_FLAG_PS_SSBO ||
        m_descriptor_sets[DESCRIPTOR_SET_BIND_POINT_STORAGE_OR_TEXEL_BUFFER] == VK_NULL_HANDLE))
   {
     VkDescriptorSetLayout layout =


### PR DESCRIPTION
This would not allocate a SSBO buffer, but still try to update the
descriptor said with a NULL buffer. Which naturally crashed.