### PR TITLE
Invalidate the tmem cache on BPMEM_EFB_TL

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -384,7 +384,12 @@ static void BPWritten(const BPCmd& bp)
   // ----------------
   // EFB Copy config
   // ----------------
-  case BPMEM_EFB_TL:    // EFB Source Rect. Top, Left
+  case BPMEM_EFB_TL:  // EFB Source Rect. Top, Left
+    // NHL Slapshot uses 4 efb copies with the same offset, but different top/left source positions
+    // TODO: Find out where and how the tmem cache is invalidated for the game, this solution is
+    //       possibly wrong, or it could be done more efficiently without invalidating all stages
+    TextureCacheBase::InvalidateAllBindPoints();
+    return;
   case BPMEM_EFB_BR:    // EFB Source Rect. Bottom, Right (w, h - 1)
   case BPMEM_EFB_ADDR:  // EFB Target Address
     return;


### PR DESCRIPTION
This fixes issue #10467:
https://bugs.dolphin-emu.org/issues/10467

Needs a proper review, because i got to that register by guesswork. And it's also just guesswork that the issue should be fixed by invalidating the tmem cache on a bpmem register.

The registers that are used between the problemantic efb copies, which are all at the same offset, but have a different source position:
BPMEM_TEV_KSEL
BPMEM_COPYFILTER0
BPMEM_COPYFILTER1
BPMEM_BLENDMODE
BPMEM_EFB_TL
BPMEM_TRIGGER_EFB_COPY

Since it makes sense that an efb copy from another source position can't be identical to another, i chose BPMEM_EFB_TL, which changes top/left of the efb copy source rectangle. Hopefully that's the reason why the tmem cache is invalidated on hardware also.

Well, i guess the pr could also be merged without a proper review, because now it just caches less stuff, it fixes the issue and spyro still works. The tmem caching is only important for spyro a hero's tail, the performance gains are just a bonus.