### PR TITLE
Qt/GraphicsSettings: Fix some options being  wrongly disabled

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -28,8 +28,6 @@ GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindo
   setWindowTitle(tr("Graphics"));
   setWindowFlags(Qt::Window);
 
-  OnBackendChanged(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend));
-
   connect(parent, &MainWindow::EmulationStarted, this, &GraphicsWindow::EmulationStarted);
   connect(parent, &MainWindow::EmulationStopped, this, &GraphicsWindow::EmulationStopped);
 }


### PR DESCRIPTION
Calling ``OnBackendChanged`` is not only  unnecessary, it also breaks a few options (e.g. Anti-aliasing, some 3D settings)