### PR TITLE
Remove FFMPEG check for Renderer::IsFrameDumping()

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -682,10 +682,8 @@ bool Renderer::IsFrameDumping()
   if (m_screenshot_request.IsSet())
     return true;
 
-#if defined(HAVE_FFMPEG)
   if (SConfig::GetInstance().m_DumpFrames)
     return true;
-#endif
 
   ShutdownFrameDumping();
   return false;


### PR DESCRIPTION
This check is unnecessary because it is possible to dump frames without FFmpeg.