### PR TITLE
NetworkCaptureLogger: Move SSL logging

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -406,6 +406,8 @@ add_library(core
   NetPlayClient.h
   NetPlayServer.cpp
   NetPlayServer.h
+  NetworkCaptureLogger.cpp
+  NetworkCaptureLogger.h
   PatchEngine.cpp
   PatchEngine.h
   PowerPC/BreakPoints.cpp

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -534,6 +534,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
 
     PatchEngine::Shutdown();
     HLE::Clear();
+    PowerPC::debug_interface.Clear();
   }};
 
   VideoBackendBase::PopulateBackendInfo();

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -5,11 +5,13 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <string>
 
 #include "Common/Debug/MemoryPatches.h"
 #include "Common/Debug/Watches.h"
 #include "Common/DebugInterface.h"
+#include "Core/NetworkCaptureLogger.h"
 
 class PPCPatches : public Common::Debug::MemoryPatches
 {
@@ -82,9 +84,12 @@ public:
   u32 GetColor(u32 address) const override;
   std::string GetDescription(u32 address) const override;
 
+  std::shared_ptr<Core::NetworkCaptureLogger> NetworkLogger();
+
   void Clear() override;
 
 private:
   Common::Debug::Watches m_watches;
   PPCPatches m_patches;
+  std::shared_ptr<Core::NetworkCaptureLogger> m_network_logger;
 };

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -20,10 +20,10 @@
 #include "Common/FileUtil.h"
 #include "Common/IOFile.h"
 #include "Core/Config/MainSettings.h"
-#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
+#include "Core/PowerPC/PowerPC.h"
 
 #ifdef _WIN32
 #define ERRORCODE(name) WSA##name
@@ -460,15 +460,10 @@ void WiiSocket::Update(bool read, bool write, bool except)
             int ret = mbedtls_ssl_write(&Device::NetSSL::_SSL[sslID].ctx,
                                         Memory::GetPointer(BufferOut2), BufferOutSize2);
 
-            if (Config::Get(Config::MAIN_NETWORK_SSL_DUMP_WRITE) && ret > 0)
-            {
-              std::string filename = File::GetUserPath(D_DUMPSSL_IDX) +
-                                     SConfig::GetInstance().GetGameID() + "_write.bin";
-              File::IOFile(filename, "ab").WriteBytes(Memory::GetPointer(BufferOut2), ret);
-            }
-
             if (ret >= 0)
             {
+              PowerPC::debug_interface.NetworkLogger()->LogWrite(Memory::GetPointer(BufferOut2),
+                                                                 ret);
               // Return bytes written or SSL_ERR_ZERO if none
               WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }
@@ -498,15 +493,9 @@ void WiiSocket::Update(bool read, bool write, bool except)
             int ret = mbedtls_ssl_read(&Device::NetSSL::_SSL[sslID].ctx,
                                        Memory::GetPointer(BufferIn2), BufferInSize2);
 
-            if (Config::Get(Config::MAIN_NETWORK_SSL_DUMP_READ) && ret > 0)
-            {
-              std::string filename = File::GetUserPath(D_DUMPSSL_IDX) +
-                                     SConfig::GetInstance().GetGameID() + "_read.bin";
-              File::IOFile(filename, "ab").WriteBytes(Memory::GetPointer(BufferIn2), ret);
-            }
-
             if (ret >= 0)
             {
+              PowerPC::debug_interface.NetworkLogger()->LogRead(Memory::GetPointer(BufferIn2), ret);
               // Return bytes read or SSL_ERR_ZERO if none
               WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/NetworkCaptureLogger.h"
+
+#include "Common/FileUtil.h"
+#include "Common/IOFile.h"
+#include "Core/Config/MainSettings.h"
+#include "Core/ConfigManager.h"
+
+namespace Core
+{
+NetworkCaptureLogger::NetworkCaptureLogger() = default;
+NetworkCaptureLogger::~NetworkCaptureLogger() = default;
+
+void DummyNetworkCaptureLogger::LogRead(const void* data, std::size_t length)
+{
+}
+
+void DummyNetworkCaptureLogger::LogWrite(const void* data, std::size_t length)
+{
+}
+
+NetworkCaptureType DummyNetworkCaptureLogger::GetCaptureType() const
+{
+  return NetworkCaptureType::None;
+}
+
+void BinarySSLCaptureLogger::LogRead(const void* data, std::size_t length)
+{
+  if (!Config::Get(Config::MAIN_NETWORK_SSL_DUMP_READ))
+    return;
+  const std::string filename =
+      File::GetUserPath(D_DUMPSSL_IDX) + SConfig::GetInstance().GetGameID() + "_read.bin";
+  File::IOFile(filename, "ab").WriteBytes(data, length);
+}
+
+void BinarySSLCaptureLogger::LogWrite(const void* data, std::size_t length)
+{
+  if (!Config::Get(Config::MAIN_NETWORK_SSL_DUMP_WRITE))
+    return;
+  const std::string filename =
+      File::GetUserPath(D_DUMPSSL_IDX) + SConfig::GetInstance().GetGameID() + "_write.bin";
+  File::IOFile(filename, "ab").WriteBytes(data, length);
+}
+
+NetworkCaptureType BinarySSLCaptureLogger::GetCaptureType() const
+{
+  return NetworkCaptureType::Raw;
+}
+}  // namespace Core

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -1,0 +1,48 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+
+namespace Core
+{
+enum class NetworkCaptureType
+{
+  None,
+  Raw,
+  PCAP,
+};
+
+class NetworkCaptureLogger
+{
+public:
+  NetworkCaptureLogger();
+  NetworkCaptureLogger(const NetworkCaptureLogger&) = delete;
+  NetworkCaptureLogger(NetworkCaptureLogger&&) = delete;
+  NetworkCaptureLogger& operator=(const NetworkCaptureLogger&) = delete;
+  NetworkCaptureLogger& operator=(NetworkCaptureLogger&&) = delete;
+  virtual ~NetworkCaptureLogger();
+
+  virtual void LogRead(const void* data, std::size_t length) = 0;
+  virtual void LogWrite(const void* data, std::size_t length) = 0;
+  virtual NetworkCaptureType GetCaptureType() const = 0;
+};
+
+class DummyNetworkCaptureLogger : public NetworkCaptureLogger
+{
+public:
+  void LogRead(const void* data, std::size_t length) override;
+  void LogWrite(const void* data, std::size_t length) override;
+  NetworkCaptureType GetCaptureType() const override;
+};
+
+class BinarySSLCaptureLogger final : public NetworkCaptureLogger
+{
+public:
+  void LogRead(const void* data, std::size_t length) override;
+  void LogWrite(const void* data, std::size_t length) override;
+  NetworkCaptureType GetCaptureType() const override;
+};
+}  // namespace Core

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -375,6 +375,7 @@
     <ClInclude Include="Core\NetPlayClient.h" />
     <ClInclude Include="Core\NetPlayProto.h" />
     <ClInclude Include="Core\NetPlayServer.h" />
+    <ClInclude Include="Core\NetworkCaptureLogger.h" />
     <ClInclude Include="Core\PatchEngine.h" />
     <ClInclude Include="Core\PowerPC\BreakPoints.h" />
     <ClInclude Include="Core\PowerPC\CachedInterpreter\CachedInterpreter.h" />
@@ -943,6 +944,7 @@
     <ClCompile Include="Core\Movie.cpp" />
     <ClCompile Include="Core\NetPlayClient.cpp" />
     <ClCompile Include="Core\NetPlayServer.cpp" />
+    <ClCompile Include="Core\NetworkCaptureLogger.cpp" />
     <ClCompile Include="Core\PatchEngine.cpp" />
     <ClCompile Include="Core\PowerPC\BreakPoints.cpp" />
     <ClCompile Include="Core\PowerPC\CachedInterpreter\CachedInterpreter.cpp" />

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -43,11 +43,7 @@ BreakpointWidget::BreakpointWidget(QWidget* parent) : QDockWidget(parent)
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     UpdateButtonsEnabled();
     if (state == Core::State::Uninitialized)
-    {
-      PowerPC::breakpoints.Clear();
-      PowerPC::memchecks.Clear();
       Update();
-    }
   });
 
   connect(&Settings::Instance(), &Settings::BreakpointsVisibilityChanged, this,


### PR DESCRIPTION
This PR moves the SSL logging part to its own logger class. ~~Not sure, if putting it inside SConfig is a good idea so~~ I'm open to suggestions regarding where it should belong.

Ready to be reviewed & merged.