### PR TITLE
DiscIO: Fix TMD extraction

### DIFF
--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -166,7 +166,7 @@ bool ExportTMD(const Volume& volume, const Partition& partition, const std::stri
   if (!size || !offset)
     return false;
 
-  return ExportData(volume, PARTITION_NONE, *offset, *size, export_filename);
+  return ExportData(volume, PARTITION_NONE, partition.offset + *offset, *size, export_filename);
 }
 
 bool ExportCertificateChain(const Volume& volume, const Partition& partition,


### PR DESCRIPTION
The offset that we read from the header is relative to the partition.