### PR TITLE
Fix regression in File::CopyDir

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -564,11 +564,11 @@ void CopyDir(const std::string& source_path, const std::string& dest_path, bool 
         File::CreateFullPath(dest + DIR_SEP);
       CopyDir(source, dest, destructive);
     }
-    else if (!Exists(dest) && !destructive)
+    else if (!destructive && !Exists(dest))
     {
       Copy(source, dest);
     }
-    else
+    else if (destructive)
     {
       Rename(source, dest);
     }


### PR DESCRIPTION
This apparently fixes https://bugs.dolphin-emu.org/issues/10499 somehow.

The first changed line of this commit is just for performance - the second changed line is where the difference in behavior is.