### PR TITLE
ConstantManager: Use std::array where applicable

### DIFF
--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -4,42 +4,44 @@
 
 #pragma once
 
+#include <array>
+
 #include "Common/CommonTypes.h"
 
 // all constant buffer attributes must be 16 bytes aligned, so this are the only allowed components:
-typedef float float4[4];
-typedef u32 uint4[4];
-typedef s32 int4[4];
+using float4 = std::array<float, 4>;
+using uint4 = std::array<u32, 4>;
+using int4 = std::array<s32, 4>;
 
 struct PixelShaderConstants
 {
-  int4 colors[4];
-  int4 kcolors[4];
+  std::array<int4, 4> colors;
+  std::array<int4, 4> kcolors;
   int4 alpha;
-  float4 texdims[8];
-  int4 zbias[2];
-  int4 indtexscale[2];
-  int4 indtexmtx[6];
+  std::array<float4, 8> texdims;
+  std::array<int4, 2> zbias;
+  std::array<int4, 2> indtexscale;
+  std::array<int4, 6> indtexmtx;
   int4 fogcolor;
   int4 fogi;
-  float4 fogf[2];
+  std::array<float4, 2> fogf;
   float4 zslope;
-  float efbscale[2];
+  std::array<float, 2> efbscale;
 
   // Constants from here onwards are only used in ubershaders.
-  u32 genmode;       // .z
-  u32 alphaTest;     // .w
-  u32 fogParam3;     // .x
-  u32 fogRangeBase;  // .y
-  u32 dstalpha;      // .z
-  u32 ztex_op;       // .w
-  u32 late_ztest;    // .x (bool)
-  u32 rgba6_format;  // .y (bool)
-  u32 dither;        // .z (bool)
-  u32 bounding_box;  // .w (bool)
-  uint4 pack1[16];   // .xy - combiners, .z - tevind, .w - iref
-  uint4 pack2[8];    // .x - tevorder, .y - tevksel
-  int4 konst[32];    // .rgba
+  u32 genmode;                  // .z
+  u32 alphaTest;                // .w
+  u32 fogParam3;                // .x
+  u32 fogRangeBase;             // .y
+  u32 dstalpha;                 // .z
+  u32 ztex_op;                  // .w
+  u32 late_ztest;               // .x (bool)
+  u32 rgba6_format;             // .y (bool)
+  u32 dither;                   // .z (bool)
+  u32 bounding_box;             // .w (bool)
+  std::array<uint4, 16> pack1;  // .xy - combiners, .z - tevind, .w - iref
+  std::array<uint4, 8> pack2;   // .x - tevorder, .y - tevksel
+  std::array<int4, 32> konst;   // .rgba
 };
 
 struct VertexShaderConstants
@@ -49,9 +51,9 @@ struct VertexShaderConstants
   u32 xfmem_numColorChans;  // .z
   u32 pad1;                 // .w
 
-  float4 posnormalmatrix[6];
-  float4 projection[4];
-  int4 materials[4];
+  std::array<float4, 6> posnormalmatrix;
+  std::array<float4, 4> projection;
+  std::array<int4, 4> materials;
   struct Light
   {
     int4 color;
@@ -59,16 +61,18 @@ struct VertexShaderConstants
     float4 distatt;
     float4 pos;
     float4 dir;
-  } lights[8];
-  float4 texmatrices[24];
-  float4 transformmatrices[64];
-  float4 normalmatrices[32];
-  float4 posttransformmatrices[64];
+  };
+  std::array<Light, 8> lights;
+  std::array<float4, 24> texmatrices;
+  std::array<float4, 64> transformmatrices;
+  std::array<float4, 32> normalmatrices;
+  std::array<float4, 64> posttransformmatrices;
   float4 pixelcentercorrection;
-  float viewport[2];  // .xy
-  float pad2[2];      // .zw
+  std::array<float, 2> viewport;  // .xy
+  std::array<float, 2> pad2;      // .zw
 
-  uint4 xfmem_pack1[8];  // .x - texMtxInfo, .y - postMtxInfo, [0..1].z = color, [0..1].w = alpha
+  // .x - texMtxInfo, .y - postMtxInfo, [0..1].z = color, [0..1].w = alpha
+  std::array<uint4, 8> xfmem_pack1;
 };
 
 struct GeometryShaderConstants

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -227,7 +227,7 @@ void VertexShaderManager::SetConstants()
   {
     int startn = nTransformMatricesChanged[0] / 4;
     int endn = (nTransformMatricesChanged[1] + 3) / 4;
-    memcpy(constants.transformmatrices[startn], &xfmem.posMatrices[startn * 4],
+    memcpy(constants.transformmatrices[startn].data(), &xfmem.posMatrices[startn * 4],
            (endn - startn) * sizeof(float4));
     dirty = true;
     nTransformMatricesChanged[0] = nTransformMatricesChanged[1] = -1;
@@ -239,7 +239,7 @@ void VertexShaderManager::SetConstants()
     int endn = (nNormalMatricesChanged[1] + 2) / 3;
     for (int i = startn; i < endn; i++)
     {
-      memcpy(constants.normalmatrices[i], &xfmem.normalMatrices[3 * i], 12);
+      memcpy(constants.normalmatrices[i].data(), &xfmem.normalMatrices[3 * i], 12);
     }
     dirty = true;
     nNormalMatricesChanged[0] = nNormalMatricesChanged[1] = -1;
@@ -249,7 +249,7 @@ void VertexShaderManager::SetConstants()
   {
     int startn = nPostTransformMatricesChanged[0] / 4;
     int endn = (nPostTransformMatricesChanged[1] + 3) / 4;
-    memcpy(constants.posttransformmatrices[startn], &xfmem.postMatrices[startn * 4],
+    memcpy(constants.posttransformmatrices[startn].data(), &xfmem.postMatrices[startn * 4],
            (endn - startn) * sizeof(float4));
     dirty = true;
     nPostTransformMatricesChanged[0] = nPostTransformMatricesChanged[1] = -1;
@@ -327,10 +327,10 @@ void VertexShaderManager::SetConstants()
     const float* norm =
         &xfmem.normalMatrices[3 * (g_main_cp_state.matrix_index_a.PosNormalMtxIdx & 31)];
 
-    memcpy(constants.posnormalmatrix, pos, 3 * sizeof(float4));
-    memcpy(constants.posnormalmatrix[3], norm, 3 * sizeof(float));
-    memcpy(constants.posnormalmatrix[4], norm + 3, 3 * sizeof(float));
-    memcpy(constants.posnormalmatrix[5], norm + 6, 3 * sizeof(float));
+    memcpy(constants.posnormalmatrix.data(), pos, 3 * sizeof(float4));
+    memcpy(constants.posnormalmatrix[3].data(), norm, 3 * sizeof(float));
+    memcpy(constants.posnormalmatrix[4].data(), norm + 3, 3 * sizeof(float));
+    memcpy(constants.posnormalmatrix[5].data(), norm + 6, 3 * sizeof(float));
     dirty = true;
   }
 
@@ -345,7 +345,7 @@ void VertexShaderManager::SetConstants()
 
     for (size_t i = 0; i < ArraySize(pos_matrix_ptrs); ++i)
     {
-      memcpy(constants.texmatrices[3 * i], pos_matrix_ptrs[i], 3 * sizeof(float4));
+      memcpy(constants.texmatrices[3 * i].data(), pos_matrix_ptrs[i], 3 * sizeof(float4));
     }
     dirty = true;
   }
@@ -361,7 +361,7 @@ void VertexShaderManager::SetConstants()
 
     for (size_t i = 0; i < ArraySize(pos_matrix_ptrs); ++i)
     {
-      memcpy(constants.texmatrices[3 * i + 12], pos_matrix_ptrs[i], 3 * sizeof(float4));
+      memcpy(constants.texmatrices[3 * i + 12].data(), pos_matrix_ptrs[i], 3 * sizeof(float4));
     }
     dirty = true;
   }
@@ -549,7 +549,7 @@ void VertexShaderManager::SetConstants()
       Matrix44::Set(mtxB, g_fProjectionMatrix);
       Matrix44::Multiply(mtxB, viewMtx, mtxA);               // mtxA = projection x view
       Matrix44::Multiply(s_viewportCorrection, mtxA, mtxB);  // mtxB = viewportCorrection x mtxA
-      memcpy(constants.projection, mtxB.data, 4 * sizeof(float4));
+      memcpy(constants.projection.data(), mtxB.data, 4 * sizeof(float4));
     }
     else
     {
@@ -558,7 +558,7 @@ void VertexShaderManager::SetConstants()
 
       Matrix44 correctedMtx;
       Matrix44::Multiply(s_viewportCorrection, projMtx, correctedMtx);
-      memcpy(constants.projection, correctedMtx.data, 4 * sizeof(float4));
+      memcpy(constants.projection.data(), correctedMtx.data, 4 * sizeof(float4));
     }
 
     dirty = true;


### PR DESCRIPTION
Modernizes the arrays and makes future simplifications possible (e.g. usages within the software renderer).

It also makes cases where we use array->pointer decay explicit.