### PR TITLE
BlockingLoop: cleanup Run() logic using compare_exchange_strong

### DIFF
--- a/Source/Core/Common/BlockingLoop.h
+++ b/Source/Core/Common/BlockingLoop.h
@@ -22,15 +22,15 @@ namespace Common
 class BlockingLoop
 {
 public:
-  enum StopMode
+  enum class StopMode
   {
-    kNonBlock,
-    kBlock,
-    kBlockAndGiveUp,
+    NonBlock,
+    Block,
+    BlockAndGiveUp,
   };
 
   BlockingLoop() { m_stopped.Set(); }
-  ~BlockingLoop() { Stop(kBlockAndGiveUp); }
+  ~BlockingLoop() { Stop(StopMode::BlockAndGiveUp); }
   // Triggers to rerun the payload of the Run() function at least once again.
   // This function will never block and is designed to finish as fast as possible.
   void Wakeup()
@@ -199,7 +199,7 @@ public:
   // Quits the main loop.
   // By default, it will wait until the main loop quits.
   // Be careful to not use the blocking way within the payload of the Run() method.
-  void Stop(StopMode mode = kBlock)
+  void Stop(StopMode mode = StopMode::Block)
   {
     if (m_stopped.IsSet())
       return;
@@ -211,12 +211,12 @@ public:
 
     switch (mode)
     {
-    case kNonBlock:
+    case StopMode::NonBlock:
       break;
-    case kBlock:
+    case StopMode::Block:
       Wait();
       break;
-    case kBlockAndGiveUp:
+    case StopMode::BlockAndGiveUp:
       WaitYield(std::chrono::milliseconds(100), [&] {
         // If timed out, assume no one will come along to call Run, so force a break
         m_stopped.Set();

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -144,7 +144,7 @@ void ExitGpuLoop()
 
   // Terminate GPU thread loop
   s_emu_running_state.Set();
-  s_gpu_mainloop.Stop(s_gpu_mainloop.kNonBlock);
+  s_gpu_mainloop.Stop(Common::BlockingLoop::StopMode::NonBlock);
 }
 
 void EmulatorState(bool running)


### PR DESCRIPTION
Rather than trying to manually handle state changes that might have occurred between a load and a store, use std::atomic's compare_exchange_strong. Also changes the state machine from `Need Execution -> Last Execution -> Done -> Sleeping` to `Need Execution -> Executing -> Done -> Sleeping`.

BlockingLoopTest takes the same amount of time to run before and after this change (~260ms on my computer).