### PR TITLE
DSP: Fix missing masking for accelerator registers

### DIFF
--- a/Source/Core/Core/DSP/DSPAccelerator.cpp
+++ b/Source/Core/Core/DSP/DSPAccelerator.cpp
@@ -9,6 +9,7 @@
 #include "Common/MathUtil.h"
 
 #include "Core/DSP/DSPCore.h"
+#include "Core/DSP/DSPHWInterface.h"
 #include "Core/DSP/DSPHost.h"
 
 namespace DSP
@@ -177,8 +178,8 @@ u16 dsp_read_accelerator()
     DSPCore_SetException(EXP_ACCOV);
   }
 
-  g_dsp.ifx_regs[DSP_ACCAH] = Address >> 16;
-  g_dsp.ifx_regs[DSP_ACCAL] = Address & 0xffff;
+  gdsp_ifx_write(DSP_ACCAH, Address >> 16);
+  gdsp_ifx_write(DSP_ACCAL, Address & 0xffff);
   return val;
 }
 }  // namespace DSP

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -156,6 +156,18 @@ void gdsp_ifx_write(u32 addr, u32 val)
         dsp_step_accelerator();
         break;
   */
+
+  // Masking occurs for the start and end addresses as soon as the registers are written to.
+  case DSP_ACSAH:
+  case DSP_ACEAH:
+    g_dsp.ifx_regs[addr & 0xff] = val & 0x3fff;
+    break;
+
+  // This also happens for the current address, but with a different mask.
+  case DSP_ACCAH:
+    g_dsp.ifx_regs[addr & 0xff] = val & 0xbfff;
+    break;
+
   default:
     if ((addr & 0xff) >= 0xa0)
     {

--- a/Source/DSPSpy/tests/accelerator_test.ds
+++ b/Source/DSPSpy/tests/accelerator_test.ds
@@ -1,0 +1,153 @@
+; Test for the DSP accelerator, in particular to check its masking behaviour.
+; See https://github.com/dolphin-emu/dolphin/pull/5997
+incdir  "tests"
+include "dsp_base.inc"
+jmp test_main
+
+; Writes the passed format, start and end addresses to the accelerator registers,
+; then reads them back to registers.
+; The current address is initialised to the start.
+; Parameters:
+;   AC0.H: sample format
+;   AC0.M/L: start address
+;   AC1.M/L: end address
+test_accelerator_addrs_ex:
+  ; Set the sample format
+  sr @0xffd1, $AC0.H
+
+  ; Set the accelerator start and current address.
+  srs @ACSAH, $AC0.M
+  srs @ACCAH, $AC0.M
+  srs @ACSAL, $AC0.L
+  srs @ACCAL, $AC0.L
+  ; Set the accelerator end address.
+  srs @ACEAH, $AC1.M
+  srs @ACEAL, $AC1.L
+
+  ; Move the values back to registers that can be printed by dspspy.
+  ; AC0 -> start, AC1 -> end, AX0 -> current
+  lri $AC0.H, #0
+  lrs $AC0.M, @ACSAH
+  lrs $AC0.L, @ACSAL
+  lri $AC1.H, #0
+  lrs $AC1.M, @ACEAH
+  lrs $AC1.L, @ACEAL
+  lrs $AX0.H, @ACCAH
+  lrs $AX0.L, @ACCAL
+
+  ; Make the accelerator read memory
+  lrs $AX1.H, @ARAM
+  lrs $AX1.H, @ARAM
+  ; AX1 -> new current position after read
+  lrs $AX1.H, @ACCAH
+  lrs $AX1.L, @ACCAL
+
+  call send_back
+  ret
+
+; Same as test_accelerator_addrs_ex, but with the end address set to start + 0x1000.
+test_accelerator_addrs:
+  lri $AC1.H, #0
+  lri $AC1.M, #0
+  lri $AC1.L, #0x1000
+  add $ACC1, $ACC0
+  jmp test_accelerator_addrs_ex
+
+test_main:
+  ; Test 1
+  lri $AC0.H, #0x19 ; 8-bit PCM
+  lri $AC0.M, #0x0000 ; start
+  lri $AC0.L, #0x1000 ; start
+  call test_accelerator_addrs
+
+  ; Test 2
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x0000 ; start
+  lri $AC0.L, #0x1000 ; start
+  call test_accelerator_addrs
+
+  ; Test 3
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x1000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 4
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x2000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 5
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x3000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 6
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x3fff ; start
+  lri $AC0.L, #0xffff ; start
+  call test_accelerator_addrs
+
+  ; Test 7
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x4000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 8
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x5000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 9
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x6000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 10
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x7000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 11
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x7fff ; start
+  lri $AC0.L, #0xffff ; start
+  call test_accelerator_addrs
+
+  ; Test 12
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x8000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 13
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0x9000 ; start
+  lri $AC0.L, #0x0000 ; start
+  call test_accelerator_addrs
+
+  ; Test 14
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0xc000 ; start
+  lri $AC0.L, #0x1000 ; start
+  call test_accelerator_addrs
+
+  ; Test 15
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0xd000 ; start
+  lri $AC0.L, #0x1000 ; start
+  call test_accelerator_addrs
+
+  ; Test 16
+  lri $AC0.H, #0xa ; 16-bit PCM
+  lri $AC0.M, #0xffff ; start
+  lri $AC0.L, #0xffff ; start
+  call test_accelerator_addrs
+
+  jmp end_of_test


### PR DESCRIPTION
Based on hardware tests, masking occurs for the accelerator registers.

This fixes Red Steel and Far Cry Vengeance, which rely on this behavior when reading back the current playback position from the DSP.

Special thanks to JMC47 for doing plenty of hardware tests, helping me track the issue down in Red Steel and testing this fix.

<s>Note: because writing a homebrew to test the DSP behaviour seemed
to be very difficult, the masking behaviour was tested on HW by
hijacking the AXVoice used for Red Steel's main stream (after waiting
for a call to AXSetVoiceAddr).
This shouldn't cause any difference for the purpose of the test;
if someone knows a better way to test DSP stuff, please let me know!</s>

Rewrote the fix based on hardware test results (run using dspspy).