### PR TITLE
AsyncShaderCompiler: Forward arguments to the specified type's constructor in CreateWorkItem()

### DIFF
--- a/Source/Core/VideoCommon/AsyncShaderCompiler.h
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -36,9 +37,9 @@ public:
   virtual ~AsyncShaderCompiler();
 
   template <typename T, typename... Params>
-  static WorkItemPtr CreateWorkItem(Params... params)
+  static WorkItemPtr CreateWorkItem(Params&&... params)
   {
-    return std::unique_ptr<WorkItem>(new T(params...));
+    return std::unique_ptr<WorkItem>(new T(std::forward<Params>(params)...));
   }
 
   void QueueWorkItem(WorkItemPtr item);

--- a/Source/Core/VideoCommon/AsyncShaderCompiler.h
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.h
@@ -39,7 +39,7 @@ public:
   template <typename T, typename... Params>
   static WorkItemPtr CreateWorkItem(Params&&... params)
   {
-    return std::unique_ptr<WorkItem>(new T(std::forward<Params>(params)...));
+    return std::make_unique<T>(std::forward<Params>(params)...);
   }
 
   void QueueWorkItem(WorkItemPtr item);


### PR DESCRIPTION
As this just hands off the arguments to another type's constructor, perfect forwarding should be used here to preserve any potential move semantics.