### PR TITLE
D3D: Eliminate redundant ID3D11DeviceChild* casts

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -386,7 +386,7 @@ HRESULT Create(HWND wnd)
     MessageBox(wnd, _T("Failed to associate the window"), _T("Dolphin Direct3D 11 backend"),
                MB_OK | MB_ICONERROR);
 
-  SetDebugObjectName((ID3D11DeviceChild*)context, "device context");
+  SetDebugObjectName(context, "device context");
   SAFE_RELEASE(factory);
   SAFE_RELEASE(adapter);
 
@@ -410,8 +410,8 @@ HRESULT Create(HWND wnd)
   backbuf = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
   SAFE_RELEASE(buf);
   CHECK(backbuf != nullptr, "Create back buffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
+  SetDebugObjectName(backbuf->GetTex(), "backbuffer texture");
+  SetDebugObjectName(backbuf->GetRTV(), "backbuffer render target view");
 
   context->OMSetRenderTargets(1, &backbuf->GetRTV(), nullptr);
 
@@ -571,8 +571,8 @@ void Reset()
   backbuf = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
   SAFE_RELEASE(buf);
   CHECK(backbuf != nullptr, "Create back buffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
-  SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
+  SetDebugObjectName(backbuf->GetTex(), "backbuffer texture");
+  SetDebugObjectName(backbuf->GetRTV(), "backbuffer render target view");
 }
 
 bool BeginFrame()
@@ -616,6 +616,29 @@ bool GetFullscreenState()
   BOOL state = FALSE;
   swapchain->GetFullscreenState(&state, nullptr);
   return !!state;
+}
+
+void SetDebugObjectName(ID3D11DeviceChild* resource, const char* name)
+{
+#if defined(_DEBUG) || defined(DEBUGFAST)
+  if (resource)
+    resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
+#endif
+}
+
+std::string GetDebugObjectName(ID3D11DeviceChild* resource)
+{
+  std::string name;
+#if defined(_DEBUG) || defined(DEBUGFAST)
+  if (resource)
+  {
+    UINT size = 0;
+    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr);  // get required size
+    name.resize(size);
+    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, const_cast<char*>(name.data()));
+  }
+#endif
+  return name;
 }
 
 }  // namespace D3D

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -81,34 +81,8 @@ bool GetFullscreenState();
 // This function will assign a name to the given resource.
 // The DirectX debug layer will make it easier to identify resources that way,
 // e.g. when listing up all resources who have unreleased references.
-template <typename T>
-void SetDebugObjectName(T resource, const char* name)
-{
-  static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-                "resource must be convertible to ID3D11DeviceChild*");
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  if (resource)
-    resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
-#endif
-}
-
-template <typename T>
-std::string GetDebugObjectName(T resource)
-{
-  static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-                "resource must be convertible to ID3D11DeviceChild*");
-  std::string name;
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  if (resource)
-  {
-    UINT size = 0;
-    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr);  // get required size
-    name.resize(size);
-    resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, const_cast<char*>(name.data()));
-  }
-#endif
-  return name;
-}
+void SetDebugObjectName(ID3D11DeviceChild* resource, const char* name);
+std::string GetDebugObjectName(ID3D11DeviceChild* resource);
 
 }  // namespace D3D
 

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -345,7 +345,7 @@ ID3D11SamplerState* StateCache::Get(SamplerState state)
   if (FAILED(hr))
     PanicAlert("Fail %s %d\n", __FILE__, __LINE__);
 
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)res, "sampler state used to emulate the GX pipeline");
+  D3D::SetDebugObjectName(res, "sampler state used to emulate the GX pipeline");
   m_sampler.emplace(state.packed, res);
 
   return res;
@@ -414,7 +414,7 @@ ID3D11BlendState* StateCache::Get(BlendState state)
   if (FAILED(hr))
     PanicAlert("Failed to create blend state at %s %d\n", __FILE__, __LINE__);
 
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)res, "blend state used to emulate the GX pipeline");
+  D3D::SetDebugObjectName(res, "blend state used to emulate the GX pipeline");
   m_blend.emplace(state.packed, res);
 
   return res;
@@ -436,8 +436,7 @@ ID3D11RasterizerState* StateCache::Get(RasterizerState state)
   if (FAILED(hr))
     PanicAlert("Failed to create rasterizer state at %s %d\n", __FILE__, __LINE__);
 
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)res,
-                          "rasterizer state used to emulate the GX pipeline");
+  D3D::SetDebugObjectName(res, "rasterizer state used to emulate the GX pipeline");
   m_raster.emplace(state.packed, res);
 
   return res;
@@ -482,8 +481,7 @@ ID3D11DepthStencilState* StateCache::Get(ZMode state)
 
   HRESULT hr = D3D::device->CreateDepthStencilState(&depthdc, &res);
   if (SUCCEEDED(hr))
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)res,
-                            "depth-stencil state used to emulate the GX pipeline");
+    D3D::SetDebugObjectName(res, "depth-stencil state used to emulate the GX pipeline");
   else
     PanicAlert("Failed to create depth state at %s %d\n", __FILE__, __LINE__);
 

--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -249,7 +249,7 @@ int CD3DFont::Init()
     PanicAlert("Failed to create font texture");
     return hr;
   }
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)buftex, "texture of a CD3DFont object");
+  D3D::SetDebugObjectName(buftex, "texture of a CD3DFont object");
 
   // Lock the surface and write the alpha values for the set pixels
   D3D11_MAPPED_SUBRESOURCE texmap;
@@ -284,7 +284,7 @@ int CD3DFont::Init()
   m_pshader = D3D::CompileAndCreatePixelShader(fontpixshader);
   if (m_pshader == nullptr)
     PanicAlert("Failed to create pixel shader, %s %d\n", __FILE__, __LINE__);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_pshader, "pixel shader of a CD3DFont object");
+  D3D::SetDebugObjectName(m_pshader, "pixel shader of a CD3DFont object");
 
   D3DBlob* vsbytecode;
   D3D::CompileVertexShader(fontvertshader, &vsbytecode);
@@ -293,7 +293,7 @@ int CD3DFont::Init()
   m_vshader = D3D::CreateVertexShaderFromByteCode(vsbytecode);
   if (m_vshader == nullptr)
     PanicAlert("Failed to create vertex shader, %s %d\n", __FILE__, __LINE__);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_vshader, "vertex shader of a CD3DFont object");
+  D3D::SetDebugObjectName(m_vshader, "vertex shader of a CD3DFont object");
 
   const D3D11_INPUT_ELEMENT_DESC desc[] = {
       {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
@@ -319,13 +319,13 @@ int CD3DFont::Init()
   blenddesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
   hr = D3D::device->CreateBlendState(&blenddesc, &m_blendstate);
   CHECK(hr == S_OK, "Create font blend state");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_blendstate, "blend state of a CD3DFont object");
+  D3D::SetDebugObjectName(m_blendstate, "blend state of a CD3DFont object");
 
   D3D11_RASTERIZER_DESC rastdesc = CD3D11_RASTERIZER_DESC(D3D11_FILL_SOLID, D3D11_CULL_NONE, false,
                                                           0, 0.f, 0.f, false, false, false, false);
   hr = D3D::device->CreateRasterizerState(&rastdesc, &m_raststate);
   CHECK(hr == S_OK, "Create font rasterizer state");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_raststate, "rasterizer state of a CD3DFont object");
+  D3D::SetDebugObjectName(m_raststate, "rasterizer state of a CD3DFont object");
 
   D3D11_BUFFER_DESC vbdesc =
       CD3D11_BUFFER_DESC(MAX_NUM_VERTICES * sizeof(FONT2DVERTEX), D3D11_BIND_VERTEX_BUFFER,
@@ -335,7 +335,7 @@ int CD3DFont::Init()
     PanicAlert("Failed to create font vertex buffer at %s, line %d\n", __FILE__, __LINE__);
     return hr;
   }
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_pVB, "vertex buffer of a CD3DFont object");
+  D3D::SetDebugObjectName(m_pVB, "vertex buffer of a CD3DFont object");
   return S_OK;
 }
 
@@ -521,7 +521,7 @@ void InitUtils()
   if (FAILED(hr))
     PanicAlert("Failed to create sampler state at %s %d\n", __FILE__, __LINE__);
   else
-    SetDebugObjectName((ID3D11DeviceChild*)point_copy_sampler, "point copy sampler state");
+    SetDebugObjectName(point_copy_sampler, "point copy sampler state");
 
   samDesc = CD3D11_SAMPLER_DESC(D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_TEXTURE_ADDRESS_BORDER,
                                 D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER, 0.f, 1,
@@ -530,7 +530,7 @@ void InitUtils()
   if (FAILED(hr))
     PanicAlert("Failed to create sampler state at %s %d\n", __FILE__, __LINE__);
   else
-    SetDebugObjectName((ID3D11DeviceChild*)linear_copy_sampler, "linear copy sampler state");
+    SetDebugObjectName(linear_copy_sampler, "linear copy sampler state");
 
   // cached data used to avoid unnecessarily reloading the vertex buffers
   memset(&tex_quad_data, 0, sizeof(tex_quad_data));

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -69,9 +69,8 @@ DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_conf
     m_texture = new D3DTexture2D(pTexture, D3D11_BIND_SHADER_RESOURCE);
 
     // TODO: better debug names
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_texture->GetTex(),
-                            "a texture of the TextureCache");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_texture->GetSRV(),
+    D3D::SetDebugObjectName(m_texture->GetTex(), "a texture of the TextureCache");
+    D3D::SetDebugObjectName(m_texture->GetSRV(),
                             "shader resource view of a texture of the TextureCache");
 
     SAFE_RELEASE(pTexture);

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -125,11 +125,9 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
       DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM,
       (sample_desc.Count > 1));
   SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetTex(), "EFB color texture");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetSRV(),
-                          "EFB color texture shader resource view");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetRTV(),
-                          "EFB color texture render target view");
+  D3D::SetDebugObjectName(m_efb.color_tex->GetTex(), "EFB color texture");
+  D3D::SetDebugObjectName(m_efb.color_tex->GetSRV(), "EFB color texture shader resource view");
+  D3D::SetDebugObjectName(m_efb.color_tex->GetRTV(), "EFB color texture render target view");
 
   // Temporary EFB color texture - used in ReinterpretPixelData
   texdesc =
@@ -144,11 +142,10 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
       DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM,
       (sample_desc.Count > 1));
   SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetTex(),
-                          "EFB color temp texture");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetSRV(),
+  D3D::SetDebugObjectName(m_efb.color_temp_tex->GetTex(), "EFB color temp texture");
+  D3D::SetDebugObjectName(m_efb.color_temp_tex->GetSRV(),
                           "EFB color temp texture shader resource view");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetRTV(),
+  D3D::SetDebugObjectName(m_efb.color_temp_tex->GetRTV(),
                           "EFB color temp texture render target view");
 
   // Render buffer for AccessEFB (color data)
@@ -157,10 +154,10 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
   CHECK(hr == S_OK, "create EFB color read texture (hr=%#x)", hr);
   m_efb.color_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
   SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_read_texture->GetTex(),
+  D3D::SetDebugObjectName(m_efb.color_read_texture->GetTex(),
                           "EFB color read texture (used in Renderer::AccessEFB)");
   D3D::SetDebugObjectName(
-      (ID3D11DeviceChild*)m_efb.color_read_texture->GetRTV(),
+      m_efb.color_read_texture->GetRTV(),
       "EFB color read texture render target view (used in Renderer::AccessEFB)");
 
   // AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
@@ -168,7 +165,7 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
                                   D3D11_CPU_ACCESS_READ);
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.color_staging_buf);
   CHECK(hr == S_OK, "create EFB color staging buffer (hr=%#x)", hr);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_staging_buf,
+  D3D::SetDebugObjectName(m_efb.color_staging_buf,
                           "EFB color staging texture (used for Renderer::AccessEFB)");
 
   // EFB depth buffer - primary depth buffer
@@ -183,11 +180,9 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
       buf, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE),
       DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
   SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetTex(), "EFB depth texture");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetDSV(),
-                          "EFB depth texture depth stencil view");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetSRV(),
-                          "EFB depth texture shader resource view");
+  D3D::SetDebugObjectName(m_efb.depth_tex->GetTex(), "EFB depth texture");
+  D3D::SetDebugObjectName(m_efb.depth_tex->GetDSV(), "EFB depth texture depth stencil view");
+  D3D::SetDebugObjectName(m_efb.depth_tex->GetSRV(), "EFB depth texture shader resource view");
 
   // Render buffer for AccessEFB (depth data)
   texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, 1, 1, D3D11_BIND_RENDER_TARGET);
@@ -195,10 +190,10 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
   CHECK(hr == S_OK, "create EFB depth read texture (hr=%#x)", hr);
   m_efb.depth_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
   SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetTex(),
+  D3D::SetDebugObjectName(m_efb.depth_read_texture->GetTex(),
                           "EFB depth read texture (used in Renderer::AccessEFB)");
   D3D::SetDebugObjectName(
-      (ID3D11DeviceChild*)m_efb.depth_read_texture->GetRTV(),
+      m_efb.depth_read_texture->GetRTV(),
       "EFB depth read texture render target view (used in Renderer::AccessEFB)");
 
   // AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
@@ -206,7 +201,7 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
                                   D3D11_CPU_ACCESS_READ);
   hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.depth_staging_buf);
   CHECK(hr == S_OK, "create EFB depth staging buffer (hr=%#x)", hr);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_staging_buf,
+  D3D::SetDebugObjectName(m_efb.depth_staging_buf,
                           "EFB depth staging texture (used for Renderer::AccessEFB)");
 
   if (g_ActiveConfig.iMultisamples > 1)
@@ -221,9 +216,8 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
     m_efb.resolved_color_tex =
         new D3DTexture2D(buf, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
     SAFE_RELEASE(buf);
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetTex(),
-                            "EFB color resolve texture");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetSRV(),
+    D3D::SetDebugObjectName(m_efb.resolved_color_tex->GetTex(), "EFB color resolve texture");
+    D3D::SetDebugObjectName(m_efb.resolved_color_tex->GetSRV(),
                             "EFB color resolve texture shader resource view");
 
     texdesc =
@@ -236,9 +230,8 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
         buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET),
         DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R32_FLOAT);
     SAFE_RELEASE(buf);
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetTex(),
-                            "EFB depth resolve texture");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetSRV(),
+    D3D::SetDebugObjectName(m_efb.resolved_depth_tex->GetTex(), "EFB depth resolve texture");
+    D3D::SetDebugObjectName(m_efb.resolved_depth_tex->GetSRV(),
                             "EFB depth resolve texture shader resource view");
   }
   else

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -143,18 +143,18 @@ void GeometryShaderCache::Init()
                                                 D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
   HRESULT hr = D3D::device->CreateBuffer(&gbdesc, nullptr, &gscbuf);
   CHECK(hr == S_OK, "Create geometry shader constant buffer (size=%u)", gbsize);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)gscbuf,
+  D3D::SetDebugObjectName(gscbuf,
                           "geometry shader constant buffer used to emulate the GX pipeline");
 
   // used when drawing clear quads
   ClearGeometryShader = D3D::CompileAndCreateGeometryShader(clear_shader_code);
   CHECK(ClearGeometryShader != nullptr, "Create clear geometry shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)ClearGeometryShader, "clear geometry shader");
+  D3D::SetDebugObjectName(ClearGeometryShader, "clear geometry shader");
 
   // used for buffer copy
   CopyGeometryShader = D3D::CompileAndCreateGeometryShader(copy_shader_code);
   CHECK(CopyGeometryShader != nullptr, "Create copy geometry shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)CopyGeometryShader, "copy geometry shader");
+  D3D::SetDebugObjectName(CopyGeometryShader, "copy geometry shader");
 
   Clear();
 

--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -130,8 +130,7 @@ void D3DVertexFormat::SetInputLayout(D3DBlob* vs_bytecode)
         m_elems.data(), m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), &m_layout);
     if (FAILED(hr))
       PanicAlert("Failed to create input layout, %s %d\n", __FILE__, __LINE__);
-    DX11::D3D::SetDebugObjectName((ID3D11DeviceChild*)m_layout,
-                                  "input layout used to emulate the GX pipeline");
+    DX11::D3D::SetDebugObjectName(m_layout, "input layout used to emulate the GX pipeline");
   }
   DX11::D3D::stateman->SetInputLayout(m_layout);
 }

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -363,8 +363,7 @@ ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
     std::string buf = StringFromFormat(color_copy_program_code_msaa, g_ActiveConfig.iMultisamples);
     s_ColorCopyProgram[1] = D3D::CompileAndCreatePixelShader(buf);
     CHECK(s_ColorCopyProgram[1] != nullptr, "Create color copy MSAA pixel shader");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[1],
-                            "color copy MSAA pixel shader");
+    D3D::SetDebugObjectName(s_ColorCopyProgram[1], "color copy MSAA pixel shader");
     return s_ColorCopyProgram[1];
   }
 }
@@ -386,8 +385,7 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
         StringFromFormat(color_matrix_program_code_msaa, g_ActiveConfig.iMultisamples);
     s_ColorMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
     CHECK(s_ColorMatrixProgram[1] != nullptr, "Create color matrix MSAA pixel shader");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[1],
-                            "color matrix MSAA pixel shader");
+    D3D::SetDebugObjectName(s_ColorMatrixProgram[1], "color matrix MSAA pixel shader");
     return s_ColorMatrixProgram[1];
   }
 }
@@ -408,8 +406,7 @@ ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
     std::string buf = StringFromFormat(depth_matrix_program_msaa, g_ActiveConfig.iMultisamples);
     s_DepthMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
     CHECK(s_DepthMatrixProgram[1] != nullptr, "Create depth matrix MSAA pixel shader");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[1],
-                            "depth matrix MSAA pixel shader");
+    D3D::SetDebugObjectName(s_DepthMatrixProgram[1], "depth matrix MSAA pixel shader");
     return s_DepthMatrixProgram[1];
   }
 }
@@ -433,7 +430,7 @@ ID3D11PixelShader* PixelShaderCache::GetDepthResolveProgram()
   std::string buf = StringFromFormat(depth_resolve_program, g_ActiveConfig.iMultisamples);
   s_DepthResolveProgram = D3D::CompileAndCreatePixelShader(buf);
   CHECK(s_DepthResolveProgram != nullptr, "Create depth matrix MSAA pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthResolveProgram, "depth resolve pixel shader");
+  D3D::SetDebugObjectName(s_DepthResolveProgram, "depth resolve pixel shader");
   return s_DepthResolveProgram;
 }
 
@@ -476,33 +473,32 @@ void PixelShaderCache::Init()
                                                 D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
   D3D::device->CreateBuffer(&cbdesc, nullptr, &pscbuf);
   CHECK(pscbuf != nullptr, "Create pixel shader constant buffer");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)pscbuf,
-                          "pixel shader constant buffer used to emulate the GX pipeline");
+  D3D::SetDebugObjectName(pscbuf, "pixel shader constant buffer used to emulate the GX pipeline");
 
   // used when drawing clear quads
   s_ClearProgram = D3D::CompileAndCreatePixelShader(clear_program_code);
   CHECK(s_ClearProgram != nullptr, "Create clear pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ClearProgram, "clear pixel shader");
+  D3D::SetDebugObjectName(s_ClearProgram, "clear pixel shader");
 
   // used for anaglyph stereoscopy
   s_AnaglyphProgram = D3D::CompileAndCreatePixelShader(anaglyph_program_code);
   CHECK(s_AnaglyphProgram != nullptr, "Create anaglyph pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_AnaglyphProgram, "anaglyph pixel shader");
+  D3D::SetDebugObjectName(s_AnaglyphProgram, "anaglyph pixel shader");
 
   // used when copying/resolving the color buffer
   s_ColorCopyProgram[0] = D3D::CompileAndCreatePixelShader(color_copy_program_code);
   CHECK(s_ColorCopyProgram[0] != nullptr, "Create color copy pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[0], "color copy pixel shader");
+  D3D::SetDebugObjectName(s_ColorCopyProgram[0], "color copy pixel shader");
 
   // used for color conversion
   s_ColorMatrixProgram[0] = D3D::CompileAndCreatePixelShader(color_matrix_program_code);
   CHECK(s_ColorMatrixProgram[0] != nullptr, "Create color matrix pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[0], "color matrix pixel shader");
+  D3D::SetDebugObjectName(s_ColorMatrixProgram[0], "color matrix pixel shader");
 
   // used for depth copy
   s_DepthMatrixProgram[0] = D3D::CompileAndCreatePixelShader(depth_matrix_program);
   CHECK(s_DepthMatrixProgram[0] != nullptr, "Create depth matrix pixel shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[0], "depth matrix pixel shader");
+  D3D::SetDebugObjectName(s_DepthMatrixProgram[0], "depth matrix pixel shader");
 
   Clear();
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -208,7 +208,7 @@ TextureCache::TextureCache()
       CD3D11_BUFFER_DESC(16, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DEFAULT);
   hr = D3D::device->CreateBuffer(&cbdesc, nullptr, &palette_uniform);
   CHECK(SUCCEEDED(hr), "Create palette decoder constant buffer");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)palette_uniform,
+  D3D::SetDebugObjectName(palette_uniform,
                           "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
 }
 
@@ -264,7 +264,7 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
     data.pSysMem = colmat;
     HRESULT hr = D3D::device->CreateBuffer(&cbdesc, &data, &s_efbcopycbuf[cbuf_id]);
     CHECK(SUCCEEDED(hr), "Create efb copy constant buffer %d", cbuf_id);
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)s_efbcopycbuf[cbuf_id],
+    D3D::SetDebugObjectName(s_efbcopycbuf[cbuf_id],
                             "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
   }
   D3D::stateman->SetPixelConstants(s_efbcopycbuf[cbuf_id]);

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -46,7 +46,7 @@ void VertexManager::CreateDeviceObjects()
     m_buffers[i] = nullptr;
     CHECK(SUCCEEDED(D3D::device->CreateBuffer(&bufdesc, nullptr, &m_buffers[i])),
           "Failed to create buffer.");
-    D3D::SetDebugObjectName((ID3D11DeviceChild*)m_buffers[i], "Buffer of VertexManager");
+    D3D::SetDebugObjectName(m_buffers[i], "Buffer of VertexManager");
   }
 
   m_currentBuffer = 0;

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -141,8 +141,7 @@ void VertexShaderCache::Init()
                                                 D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
   HRESULT hr = D3D::device->CreateBuffer(&cbdesc, nullptr, &vscbuf);
   CHECK(hr == S_OK, "Create vertex shader constant buffer (size=%u)", cbsize);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)vscbuf,
-                          "vertex shader constant buffer used to emulate the GX pipeline");
+  D3D::SetDebugObjectName(vscbuf, "vertex shader constant buffer used to emulate the GX pipeline");
 
   D3DBlob* blob;
   D3D::CompileVertexShader(simple_shader_code, &blob);
@@ -152,8 +151,8 @@ void VertexShaderCache::Init()
     PanicAlert("Failed to create simple vertex shader or input layout at %s %d\n", __FILE__,
                __LINE__);
   blob->Release();
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)SimpleVertexShader, "simple vertex shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)SimpleLayout, "simple input layout");
+  D3D::SetDebugObjectName(SimpleVertexShader, "simple vertex shader");
+  D3D::SetDebugObjectName(SimpleLayout, "simple input layout");
 
   D3D::CompileVertexShader(clear_shader_code, &blob);
   D3D::device->CreateInputLayout(clearelems, 2, blob->Data(), blob->Size(), &ClearLayout);
@@ -162,8 +161,8 @@ void VertexShaderCache::Init()
     PanicAlert("Failed to create clear vertex shader or input layout at %s %d\n", __FILE__,
                __LINE__);
   blob->Release();
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)ClearVertexShader, "clear vertex shader");
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)ClearLayout, "clear input layout");
+  D3D::SetDebugObjectName(ClearVertexShader, "clear vertex shader");
+  D3D::SetDebugObjectName(ClearLayout, "clear input layout");
 
   Clear();
 


### PR DESCRIPTION
Just basic cleanup.