### PR TITLE
AsyncShaderCompiler: Make WorkItem-derived class constructors explicit

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -56,7 +56,7 @@ private:
   class PixelShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    PixelShaderCompilerWorkItem(const PixelShaderUid& uid);
+    explicit PixelShaderCompilerWorkItem(const PixelShaderUid& uid);
     ~PixelShaderCompilerWorkItem() override;
 
     bool Compile() override;
@@ -71,7 +71,7 @@ private:
   class UberPixelShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    UberPixelShaderCompilerWorkItem(const UberShader::PixelShaderUid& uid);
+    explicit UberPixelShaderCompilerWorkItem(const UberShader::PixelShaderUid& uid);
     ~UberPixelShaderCompilerWorkItem() override;
 
     bool Compile() override;

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -67,7 +67,7 @@ private:
   class VertexShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    VertexShaderCompilerWorkItem(const VertexShaderUid& uid);
+    explicit VertexShaderCompilerWorkItem(const VertexShaderUid& uid);
     ~VertexShaderCompilerWorkItem() override;
 
     bool Compile() override;
@@ -82,7 +82,7 @@ private:
   class UberVertexShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    UberVertexShaderCompilerWorkItem(const UberShader::VertexShaderUid& uid);
+    explicit UberVertexShaderCompilerWorkItem(const UberShader::VertexShaderUid& uid);
     ~UberVertexShaderCompilerWorkItem() override;
 
     bool Compile() override;

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -146,9 +146,9 @@ private:
   class SharedContextAsyncShaderCompiler : public VideoCommon::AsyncShaderCompiler
   {
   protected:
-    virtual bool WorkerThreadInitMainThread(void** param) override;
-    virtual bool WorkerThreadInitWorkerThread(void* param) override;
-    virtual void WorkerThreadExit(void* param) override;
+    bool WorkerThreadInitMainThread(void** param) override;
+    bool WorkerThreadInitWorkerThread(void* param) override;
+    void WorkerThreadExit(void* param) override;
   };
 
   struct SharedContextData

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -165,7 +165,7 @@ private:
   class ShaderCompileWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    ShaderCompileWorkItem(const SHADERUID& uid);
+    explicit ShaderCompileWorkItem(const SHADERUID& uid);
 
     bool Compile() override;
     void Retrieve() override;
@@ -178,7 +178,7 @@ private:
   class UberShaderCompileWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    UberShaderCompileWorkItem(const UBERSHADERUID& uid);
+    explicit UberShaderCompileWorkItem(const UBERSHADERUID& uid);
 
     bool Compile() override;
     void Retrieve() override;

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.h
@@ -201,7 +201,7 @@ private:
   class VertexShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    VertexShaderCompilerWorkItem(const VertexShaderUid& uid) : m_uid(uid) {}
+    explicit VertexShaderCompilerWorkItem(const VertexShaderUid& uid) : m_uid(uid) {}
     bool Compile() override;
     void Retrieve() override;
 
@@ -213,7 +213,7 @@ private:
   class PixelShaderCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    PixelShaderCompilerWorkItem(const PixelShaderUid& uid) : m_uid(uid) {}
+    explicit PixelShaderCompilerWorkItem(const PixelShaderUid& uid) : m_uid(uid) {}
     bool Compile() override;
     void Retrieve() override;
 
@@ -225,7 +225,7 @@ private:
   class PipelineCompilerWorkItem : public VideoCommon::AsyncShaderCompiler::WorkItem
   {
   public:
-    PipelineCompilerWorkItem(const PipelineInfo& info) : m_info(info) {}
+    explicit PipelineCompilerWorkItem(const PipelineInfo& info) : m_info(info) {}
     bool Compile() override;
     void Retrieve() override;
 


### PR DESCRIPTION
Prevents implicit conversions