### PR TITLE
OGL/VertexManager: Make vertex and index buffer handles private

### DIFF
--- a/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
@@ -60,8 +60,8 @@ GLVertexFormat::GLVertexFormat(const PortableVertexDeclaration& _vtx_decl)
   ProgramShaderCache::BindVertexFormat(this);
 
   // the element buffer is bound directly to the vao, so we must it set for every vao
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vm->m_index_buffers);
-  glBindBuffer(GL_ARRAY_BUFFER, vm->m_vertex_buffers);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vm->GetIndexBufferHandle());
+  glBindBuffer(GL_ARRAY_BUFFER, vm->GetVertexBufferHandle());
 
   SetPointer(SHADER_POSITION_ATTRIB, vertex_stride, _vtx_decl.position);
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1796,7 +1796,7 @@ void Renderer::RestoreAPIState()
 
   ProgramShaderCache::BindLastVertexFormat();
   const VertexManager* const vm = static_cast<VertexManager*>(g_vertex_manager.get());
-  glBindBuffer(GL_ARRAY_BUFFER, vm->m_vertex_buffers);
+  glBindBuffer(GL_ARRAY_BUFFER, vm->GetVertexBufferHandle());
 
   OGLTexture::SetStage();
 }

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -61,6 +61,16 @@ void VertexManager::DestroyDeviceObjects()
   s_indexBuffer.reset();
 }
 
+GLuint VertexManager::GetVertexBufferHandle() const
+{
+  return m_vertex_buffers;
+}
+
+GLuint VertexManager::GetIndexBufferHandle() const
+{
+  return m_index_buffers;
+}
+
 void VertexManager::PrepareDrawBuffers(u32 stride)
 {
   u32 vertex_data_size = IndexGenerator::GetNumVerts() * stride;

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -37,9 +37,8 @@ public:
   void CreateDeviceObjects() override;
   void DestroyDeviceObjects() override;
 
-  // NativeVertexFormat use this
-  GLuint m_vertex_buffers;
-  GLuint m_index_buffers;
+  GLuint GetVertexBufferHandle() const;
+  GLuint GetIndexBufferHandle() const;
 
 protected:
   void ResetBuffer(u32 stride) override;
@@ -48,6 +47,9 @@ private:
   void Draw(u32 stride);
   void vFlush() override;
   void PrepareDrawBuffers(u32 stride);
+
+  GLuint m_vertex_buffers;
+  GLuint m_index_buffers;
 
   // Alternative buffers in CPU memory for primatives we are going to discard.
   std::vector<u8> m_cpu_v_buffer;


### PR DESCRIPTION
These are only ever read, but not written to outside of the VertexManager class.