### PR TITLE
D3DBase: Use the correct version of CreateDXGIFactory.

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -66,9 +66,12 @@ HRESULT LoadDXGI()
     --dxgi_dll_ref;
     return E_FAIL;
   }
-  PCreateDXGIFactory = (CREATEDXGIFACTORY)GetProcAddress(hDXGIDll, "CreateDXGIFactory");
+
+  // Even though we use IDXGIFactory2 we use CreateDXGIFactory1 to create it to maintain
+  // compatibility with Windows 7
+  PCreateDXGIFactory = (CREATEDXGIFACTORY)GetProcAddress(hDXGIDll, "CreateDXGIFactory1");
   if (PCreateDXGIFactory == nullptr)
-    MessageBoxA(nullptr, "GetProcAddress failed for CreateDXGIFactory!", "Critical error",
+    MessageBoxA(nullptr, "GetProcAddress failed for CreateDXGIFactory1!", "Critical error",
                 MB_OK | MB_ICONERROR);
 
   return S_OK;
@@ -264,7 +267,7 @@ HRESULT Create(HWND wnd)
   }
 
   IDXGIFactory2* factory;
-  hr = PCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
+  hr = PCreateDXGIFactory(__uuidof(IDXGIFactory2), (void**)&factory);
   if (FAILED(hr))
     MessageBox(wnd, _T("Failed to create IDXGIFactory object"), _T("Dolphin Direct3D 11 backend"),
                MB_OK | MB_ICONERROR);

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -82,9 +82,9 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDynamicSamplerIndexing = false;
   g_Config.backend_info.bSupportsBPTCTextures = false;
 
-  IDXGIFactory* factory;
+  IDXGIFactory2* factory;
   IDXGIAdapter* ad;
-  hr = DX11::PCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
+  hr = DX11::PCreateDXGIFactory(__uuidof(IDXGIFactory2), (void**)&factory);
   if (FAILED(hr))
     PanicAlert("Failed to create IDXGIFactory object");
 


### PR DESCRIPTION
This is a big oversight on my part, I'm not sure why it seems to work correctly. I guess even though we request the incorrect version, the underlying object still supports the newer interfaces.