### PR TITLE
D3DTexture: Remove unused class member

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -74,7 +74,7 @@ ID3D11DepthStencilView*& D3DTexture2D::GetDSV()
 
 D3DTexture2D::D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind, DXGI_FORMAT srv_format,
                            DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
-    : ref(1), tex(texptr), srv(nullptr), rtv(nullptr), dsv(nullptr)
+    : tex{texptr}
 {
   D3D11_SRV_DIMENSION srv_dim =
       multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -39,11 +39,11 @@ private:
   ~D3DTexture2D();
 
   ID3D11Texture2D* tex;
-  ID3D11ShaderResourceView* srv;
-  ID3D11RenderTargetView* rtv;
-  ID3D11DepthStencilView* dsv;
+  ID3D11ShaderResourceView* srv = nullptr;
+  ID3D11RenderTargetView* rtv = nullptr;
+  ID3D11DepthStencilView* dsv = nullptr;
   D3D11_BIND_FLAG bindflags;
-  UINT ref;
+  UINT ref = 1;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -42,7 +42,6 @@ private:
   ID3D11ShaderResourceView* srv = nullptr;
   ID3D11RenderTargetView* rtv = nullptr;
   ID3D11DepthStencilView* dsv = nullptr;
-  D3D11_BIND_FLAG bindflags;
   UINT ref = 1;
 };
 


### PR DESCRIPTION
Alternatively, if it's preferable to keep the class member, I can just assign to it in the constructor initializer list instead.