### PR TITLE
Qt: use Settings::EmulationStateChanged

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -700,6 +700,9 @@ State GetState()
     return State::Running;
   }
 
+  if (s_is_booting.IsSet())
+    return State::Starting;
+
   return State::Uninitialized;
 }
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -105,4 +105,6 @@ void QueueHostJob(std::function<void()> job, bool run_during_stop = false);
 // WM_USER_JOB_DISPATCH will be sent when something is added to the queue.
 void HostDispatchJobs();
 
+void DoFrameStep();
+
 }  // namespace

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -31,7 +31,8 @@ enum class State
   Uninitialized,
   Paused,
   Running,
-  Stopping
+  Stopping,
+  Starting,
 };
 
 bool Init(std::unique_ptr<BootParameters> boot);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -85,8 +85,8 @@ void UpdateTitle();
 void RunAsCPUThread(std::function<void()> function);
 
 // for calling back into UI code without introducing a dependency on it in core
-using StoppedCallbackFunc = std::function<void()>;
-void SetOnStoppedCallback(StoppedCallbackFunc callback);
+using StateChangedCallbackFunc = std::function<void(Core::State)>;
+void SetOnStateChangedCallback(StateChangedCallbackFunc callback);
 
 // Run on the Host thread when the factors change. [NOT THREADSAFE]
 void UpdateWantDeterminism(bool initial = false);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -63,7 +63,6 @@
 
 namespace Movie
 {
-static bool s_bFrameStep = false;
 static bool s_bReadOnly = true;
 static u32 s_rerecords = 0;
 static PlayMode s_playMode = MODE_NONE;
@@ -192,11 +191,6 @@ void FrameUpdate()
     s_totalFrames = s_currentFrame;
     s_totalLagCount = s_currentLagCount;
   }
-  if (s_bFrameStep)
-  {
-    s_bFrameStep = false;
-    CPU::Break();
-  }
 
   s_bPolled = false;
 }
@@ -215,7 +209,6 @@ void Init(const BootParameters& boot)
     s_current_file_name.clear();
 
   s_bPolled = false;
-  s_bFrameStep = false;
   s_bSaveConfig = false;
   if (IsPlayingInput())
   {
@@ -272,23 +265,6 @@ void InputUpdate()
 void SetPolledDevice()
 {
   s_bPolled = true;
-}
-
-// NOTE: Host Thread
-void DoFrameStep()
-{
-  if (Core::GetState() == Core::State::Paused)
-  {
-    // if already paused, frame advance for 1 frame
-    s_bFrameStep = true;
-    Core::RequestRefreshInfo();
-    Core::SetState(Core::State::Running);
-  }
-  else if (!s_bFrameStep)
-  {
-    // if not paused yet, pause immediately instead
-    Core::SetState(Core::State::Paused);
-  }
 }
 
 // NOTE: Host Thread

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -148,7 +148,6 @@ bool IsUsingBongo(int controller);
 void ChangePads(bool instantly = false);
 void ChangeWiiPads(bool instantly = false);
 
-void DoFrameStep();
 void SetReadOnly(bool bEnabled);
 
 bool BeginRecordingInput(int controllers);

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -392,7 +392,10 @@ int main(int argc, char* argv[])
   UICommon::SetUserDirectory(user_directory);
   UICommon::Init();
 
-  Core::SetOnStoppedCallback([]() { s_running.Clear(); });
+  Core::SetOnStateChangedCallback([](Core::State state) {
+    if (state == Core::State::Uninitialized)
+      s_running.Clear();
+  });
   platform->Init();
 
   // Shut down cleanly on SIGINT and SIGTERM

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -21,6 +21,7 @@
 #include <map>
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
@@ -238,6 +239,9 @@ void ControllersWindow::CreateMainLayout()
 
 void ControllersWindow::ConnectWidgets()
 {
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          [=](Core::State state) { OnEmulationStateChanged(state != Core::State::Uninitialized); });
+
   connect(m_wiimote_passthrough, &QRadioButton::toggled, this,
           &ControllersWindow::OnWiimoteModeChanged);
 

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.h
@@ -25,9 +25,9 @@ class ControllersWindow final : public QDialog
   Q_OBJECT
 public:
   explicit ControllersWindow(QWidget* parent);
-  void OnEmulationStateChanged(bool running);
 
 private:
+  void OnEmulationStateChanged(bool running);
   void OnWiimoteModeChanged(bool passthrough);
   void OnWiimoteTypeChanged(int state);
   void OnGCTypeChanged(int state);

--- a/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
@@ -11,9 +11,11 @@
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt2/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt2/Config/Graphics/GraphicsWindow.h"
+#include "DolphinQt2/Settings.h"
 #include "VideoCommon/VideoConfig.h"
 
 AdvancedWidget::AdvancedWidget(GraphicsWindow* parent) : GraphicsWidget(parent)
@@ -24,8 +26,8 @@ AdvancedWidget::AdvancedWidget(GraphicsWindow* parent) : GraphicsWidget(parent)
   AddDescriptions();
 
   connect(parent, &GraphicsWindow::BackendChanged, this, &AdvancedWidget::OnBackendChanged);
-  connect(parent, &GraphicsWindow::EmulationStarted, [this] { OnEmulationStateChanged(true); });
-  connect(parent, &GraphicsWindow::EmulationStopped, [this] { OnEmulationStateChanged(false); });
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          [=](Core::State state) { OnEmulationStateChanged(state != Core::State::Uninitialized); });
 
   OnBackendChanged();
 }

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -15,9 +15,11 @@
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt2/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt2/Config/Graphics/GraphicsWindow.h"
+#include "DolphinQt2/Settings.h"
 #include "UICommon/VideoUtils.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
@@ -32,8 +34,8 @@ GeneralWidget::GeneralWidget(X11Utils::XRRConfiguration* xrr_config, GraphicsWin
   emit BackendChanged(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend));
 
   connect(parent, &GraphicsWindow::BackendChanged, this, &GeneralWidget::OnBackendChanged);
-  connect(parent, &GraphicsWindow::EmulationStarted, [this] { OnEmulationStateChanged(true); });
-  connect(parent, &GraphicsWindow::EmulationStopped, [this] { OnEmulationStateChanged(false); });
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          [=](Core::State state) { OnEmulationStateChanged(state != Core::State::Uninitialized); });
 }
 
 void GeneralWidget::CreateWidgets()

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -29,9 +29,6 @@ GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindo
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   OnBackendChanged(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend));
-
-  connect(parent, &MainWindow::EmulationStarted, this, &GraphicsWindow::EmulationStarted);
-  connect(parent, &MainWindow::EmulationStopped, this, &GraphicsWindow::EmulationStopped);
 }
 
 void GraphicsWindow::CreateMainLayout()

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
@@ -33,8 +33,6 @@ public:
   bool eventFilter(QObject* object, QEvent* event) override;
 signals:
   void BackendChanged(const QString& backend);
-  void EmulationStarted();
-  void EmulationStopped();
 
 private:
   void CreateMainLayout();

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -40,14 +40,8 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
 
   AddTab(m_tabs, tr("General"), new GeneralPane(), "config");
   AddTab(m_tabs, tr("Interface"), new InterfacePane(), "browse");
-  auto* audio_pane = new AudioPane;
-  m_audio_pane_index = AddTab(m_tabs, tr("Audio"), audio_pane, "play");
+  m_audio_pane_index = AddTab(m_tabs, tr("Audio"), new AudioPane(), "play");
   AddTab(m_tabs, tr("Paths"), new PathPane(), "browse");
-
-  connect(this, &SettingsWindow::EmulationStarted,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(true); });
-  connect(this, &SettingsWindow::EmulationStopped,
-          [audio_pane] { audio_pane->OnEmulationStateChanged(false); });
 
   // Dialog box buttons
   QDialogButtonBox* ok_box = new QDialogButtonBox(QDialogButtonBox::Ok);

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -15,10 +15,6 @@ public:
   explicit SettingsWindow(QWidget* parent = nullptr);
   void SelectAudioPane();
 
-signals:
-  void EmulationStarted();
-  void EmulationStopped();
-
 private:
   ListTabWidget* m_tabs;
   int m_audio_pane_index = -1;

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -29,8 +29,6 @@ public:
 
 signals:
   void GameSelected();
-  void EmulationStarted();
-  void EmulationStopped();
   void NetPlayHost(const QString& game_id);
   void SelectionChanged(QSharedPointer<GameFile> game_file);
 

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -121,7 +121,10 @@ void MainWindow::ShutdownControllers()
 
 void MainWindow::InitCoreCallbacks()
 {
-  Core::SetOnStoppedCallback([this] { emit EmulationStopped(); });
+  Core::SetOnStateChangedCallback([=](Core::State state) {
+    if (state == Core::State::Uninitialized)
+      emit EmulationStopped();
+  });
   installEventFilter(this);
   m_render_widget->installEventFilter(this);
 }

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -450,7 +450,7 @@ void MainWindow::Reset()
 
 void MainWindow::FrameAdvance()
 {
-  Movie::DoFrameStep();
+  Core::DoFrameStep();
   EmulationPaused();
 }
 

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -40,9 +40,6 @@ public:
   bool eventFilter(QObject* object, QEvent* event) override;
 
 signals:
-  void EmulationStarted();
-  void EmulationPaused();
-  void EmulationStopped();
   void ReadOnlyModeChanged(bool read_only);
   void RecordingStatusChanged(bool recording);
 

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -9,12 +9,17 @@
 #include <QMenu>
 #include <QMenuBar>
 
+#include "DolphinQt2/GameList/GameFile.h"
+
+namespace Core
+{
+enum class State;
+}
+
 namespace DiscIO
 {
 enum class Region;
 };
-
-#include "DolphinQt2/GameList/GameFile.h"
 
 class MenuBar final : public QMenuBar
 {
@@ -23,9 +28,6 @@ class MenuBar final : public QMenuBar
 public:
   explicit MenuBar(QWidget* parent = nullptr);
 
-  void EmulationStarted();
-  void EmulationPaused();
-  void EmulationStopped();
   void UpdateStateSlotMenu();
   void UpdateToolsMenu(bool emulation_started);
 
@@ -88,6 +90,8 @@ signals:
   void ReadOnlyModeChanged(bool read_only);
 
 private:
+  void OnEmulationStateChanged(Core::State state);
+
   void AddFileMenu();
 
   void AddEmulationMenu();

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -188,8 +188,8 @@ void NetPlayDialog::ConnectWidgets()
     }
   });
 
-  connect(this, &NetPlayDialog::EmulationStopped, this, [this] {
-    if (isVisible())
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [=](Core::State state) {
+    if (state == Core::State::Uninitialized && isVisible())
       GameStatusChanged(false);
   });
 }

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
@@ -54,7 +54,6 @@ public:
   void SetMD5Result(int pid, const std::string& result) override;
   void AbortMD5() override;
 signals:
-  void EmulationStopped();
   void Boot(const QString& filename);
   void Stop();
 

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -11,11 +11,16 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/GameList/GameListModel.h"
 #include "DolphinQt2/Settings.h"
 #include "InputCommon/InputConfig.h"
 
-Settings::Settings() = default;
+Settings::Settings()
+{
+  Core::SetOnStateChangedCallback(
+      [this](Core::State new_state) { emit EmulationStateChanged(new_state); });
+}
 
 Settings& Settings::Instance()
 {

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -12,6 +12,11 @@
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayServer.h"
 
+namespace Core
+{
+enum class State;
+}
+
 namespace DiscIO
 {
 enum class Language;
@@ -76,6 +81,7 @@ public:
   GameListModel* GetGameListModel() const;
 
 signals:
+  void EmulationStateChanged(Core::State new_state);
   void ThemeChanged();
   void PathAdded(const QString&);
   void PathRemoved(const QString&);

--- a/Source/Core/DolphinQt2/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/AudioPane.cpp
@@ -18,6 +18,7 @@
 
 #include "AudioCommon/AudioCommon.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/Config/SettingsWindow.h"
 #include "DolphinQt2/Settings.h"
 
@@ -28,6 +29,8 @@ AudioPane::AudioPane()
   ConnectWidgets();
 
   connect(&Settings::Instance(), &Settings::VolumeChanged, this, &AudioPane::OnVolumeChanged);
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          [=](Core::State state) { OnEmulationStateChanged(state != Core::State::Uninitialized); });
 }
 
 void AudioPane::CreateWidgets()

--- a/Source/Core/DolphinQt2/Settings/AudioPane.h
+++ b/Source/Core/DolphinQt2/Settings/AudioPane.h
@@ -21,8 +21,6 @@ class AudioPane final : public QWidget
 public:
   explicit AudioPane();
 
-  void OnEmulationStateChanged(bool running);
-
 private:
   void CreateWidgets();
   void ConnectWidgets();
@@ -30,6 +28,7 @@ private:
   void LoadSettings();
   void SaveSettings();
 
+  void OnEmulationStateChanged(bool running);
   void OnBackendChanged();
   void OnVolumeChanged(int volume);
 

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -4,6 +4,7 @@
 
 #include <QIcon>
 
+#include "Core/Core.h"
 #include "DolphinQt2/QtUtils/ActionHelper.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
@@ -22,40 +23,24 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &ToolBar::UpdateIcons);
   UpdateIcons();
 
-  EmulationStopped();
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+          [this](Core::State state) { OnEmulationStateChanged(state); });
+  OnEmulationStateChanged(Core::GetState());
 }
 
-void ToolBar::EmulationStarted()
+void ToolBar::OnEmulationStateChanged(Core::State state)
 {
-  m_play_action->setEnabled(false);
-  m_play_action->setVisible(false);
-  m_pause_action->setEnabled(true);
-  m_pause_action->setVisible(true);
-  m_stop_action->setEnabled(true);
-  m_stop_action->setVisible(true);
-  m_fullscreen_action->setEnabled(true);
-  m_screenshot_action->setEnabled(true);
-}
+  bool running = state != Core::State::Uninitialized;
+  m_stop_action->setEnabled(running);
+  m_stop_action->setVisible(running);
+  m_fullscreen_action->setEnabled(running);
+  m_screenshot_action->setEnabled(running);
 
-void ToolBar::EmulationPaused()
-{
-  m_play_action->setEnabled(true);
-  m_play_action->setVisible(true);
-  m_pause_action->setEnabled(false);
-  m_pause_action->setVisible(false);
-  m_stop_action->setEnabled(true);
-  m_stop_action->setVisible(true);
-}
-
-void ToolBar::EmulationStopped()
-{
-  m_play_action->setEnabled(true);
-  m_play_action->setVisible(true);
-  m_pause_action->setEnabled(false);
-  m_pause_action->setVisible(false);
-  m_stop_action->setEnabled(false);
-  m_fullscreen_action->setEnabled(false);
-  m_screenshot_action->setEnabled(false);
+  bool playing = running && state != Core::State::Paused;
+  m_play_action->setEnabled(!playing);
+  m_play_action->setVisible(!playing);
+  m_pause_action->setEnabled(playing);
+  m_pause_action->setVisible(playing);
 }
 
 void ToolBar::MakeActions()

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -8,17 +8,17 @@
 #include <QLineEdit>
 #include <QToolBar>
 
+namespace Core
+{
+enum class State;
+}
+
 class ToolBar final : public QToolBar
 {
   Q_OBJECT
 
 public:
   explicit ToolBar(QWidget* parent = nullptr);
-
-public slots:
-  void EmulationStarted();
-  void EmulationPaused();
-  void EmulationStopped();
 
 signals:
   void OpenPressed();
@@ -33,6 +33,8 @@ signals:
   void GraphicsPressed();
 
 private:
+  void OnEmulationStateChanged(Core::State state);
+
   void MakeActions();
   void UpdateIcons();
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -530,8 +530,9 @@ void CFrame::InitializeCoreCallbacks()
   });
 
   // Warning: this gets called from the EmuThread
-  Core::SetOnStoppedCallback([this] {
-    AddPendingEvent(wxCommandEvent{wxEVT_HOST_COMMAND, IDM_STOPPED});
+  Core::SetOnStateChangedCallback([this](Core::State state) {
+    if (state == Core::State::Uninitialized)
+      AddPendingEvent(wxCommandEvent{wxEVT_HOST_COMMAND, IDM_STOPPED});
   });
 }
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -446,7 +446,7 @@ void CFrame::OnFrameStep(wxCommandEvent& event)
 {
   bool wasPaused = Core::GetState() == Core::State::Paused;
 
-  Movie::DoFrameStep();
+  Core::DoFrameStep();
 
   bool isPaused = Core::GetState() == Core::State::Paused;
   if (isPaused && !wasPaused)  // don't update on unpause, otherwise the status would be wrong when

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -179,7 +179,7 @@ void Init()
   if (s_handle != nullptr)
     return;
 
-  if (Core::GetState() != Core::State::Uninitialized)
+  if (Core::GetState() != Core::State::Uninitialized && Core::GetState() != Core::State::Starting)
   {
     if ((CoreTiming::GetTicks() - s_last_init) < SystemTimers::GetTicksPerSecond())
       return;

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -195,7 +195,7 @@ void Init()
   if (s_fd)
     return;
 
-  if (Core::GetState() != Core::State::Uninitialized)
+  if (Core::GetState() != Core::State::Uninitialized && Core::GetState() != Core::State::Starting)
   {
     if ((CoreTiming::GetTicks() - s_last_init) < SystemTimers::GetTicksPerSecond())
       return;


### PR DESCRIPTION
**DolphinQt2 changes:**

Removes the soup of `connect(parent, &Parent::EmulationStarted, child, &Child::EmulationStarted)` that was needed to pass signals through multiple levels of widgets. Blegh.

Now, it looks like:

```c++
connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
        [this](Core::State new_state) { ... });
```

**Core changes:**

Currently, `Core::SetOnStoppedCallback` informs the user when emulation has actually stopped (e.g. after pressing the power button). This PR replaces it with `Core::SetOnStateChangedCallback` which triggers on all state changes (whenever `Core::GetState()` would return a different value).

Also
- Moves `Movie::DoFrameStep` into Core, since it doesn't depend on anything in Movie and changes emulation state.
- Adds a new `Core::State::Starting` enum value. This seems to work fine. The only code other than GUI stuff that uses a catchall pattern like `state != Core::State::Uninitialized` is the GCAdapter code error-handling code, which I've updated to also check `state != Core::State::Starting`.