### PR TITLE
ShaderGen: Output uint when logic op is enabled for D3D ubershaders

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -593,6 +593,7 @@ bool PixelShaderCache::SetShader()
     return SetUberShader();
 
   PixelShaderUid uid = GetPixelShaderUid();
+  ClearUnusedPixelShaderUidBits(APIType::D3D, &uid);
   if (last_entry && uid == last_uid)
   {
     if (last_entry->pending)
@@ -656,6 +657,7 @@ bool PixelShaderCache::SetShader()
 bool PixelShaderCache::SetUberShader()
 {
   UberShader::PixelShaderUid uid = UberShader::GetPixelShaderUid();
+  UberShader::ClearUnusedPixelShaderUidBits(APIType::D3D, &uid);
 
   if (last_uber_entry && last_uber_uid == uid)
   {

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -231,6 +231,7 @@ SHADER* ProgramShaderCache::SetShader(u32 primitive_type, const GLVertexFormat* 
   uid.puid = GetPixelShaderUid();
   uid.vuid = GetVertexShaderUid();
   uid.guid = GetGeometryShaderUid(primitive_type);
+  ClearUnusedPixelShaderUidBits(APIType::OpenGL, &uid.puid);
 
   // Check if the shader is already set
   if (last_entry && uid == last_uid)
@@ -298,6 +299,7 @@ SHADER* ProgramShaderCache::SetUberShader(u32 primitive_type, const GLVertexForm
   uid.puid = UberShader::GetPixelShaderUid();
   uid.vuid = UberShader::GetVertexShaderUid();
   uid.guid = GetGeometryShaderUid(primitive_type);
+  UberShader::ClearUnusedPixelShaderUidBits(APIType::OpenGL, &uid.puid);
 
   // We need to use the ubershader vertex format with all attributes enabled.
   // Otherwise, the NV driver can generate variants for the vertex shaders.

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -338,8 +338,9 @@ bool StateTracker::CheckForShaderChanges(u32 gx_primitive_type)
 {
   VertexShaderUid vs_uid = GetVertexShaderUid();
   PixelShaderUid ps_uid = GetPixelShaderUid();
-  bool changed = false;
+  ClearUnusedPixelShaderUidBits(APIType::Vulkan, &ps_uid);
 
+  bool changed = false;
   bool use_ubershaders = g_ActiveConfig.bDisableSpecializedShaders;
   if (g_ActiveConfig.CanBackgroundCompileShaders() && !g_ActiveConfig.bDisableSpecializedShaders)
   {
@@ -405,6 +406,7 @@ bool StateTracker::CheckForShaderChanges(u32 gx_primitive_type)
     }
 
     UberShader::PixelShaderUid uber_ps_uid = UberShader::GetPixelShaderUid();
+    UberShader::ClearUnusedPixelShaderUidBits(APIType::Vulkan, &uber_ps_uid);
     VkShaderModule ps = g_shader_cache->GetPixelUberShaderForUid(uber_ps_uid);
     if (ps != m_pipeline_state.ps)
     {
@@ -983,6 +985,7 @@ VkPipeline StateTracker::GetPipelineAndCacheUID()
     PipelineInfo uber_info = m_pipeline_state;
     UberShader::VertexShaderUid uber_vuid = UberShader::GetVertexShaderUid();
     UberShader::PixelShaderUid uber_puid = UberShader::GetPixelShaderUid();
+    UberShader::ClearUnusedPixelShaderUidBits(APIType::Vulkan, &uber_puid);
     uber_info.vs = g_shader_cache->GetVertexUberShaderForUid(uber_vuid);
     uber_info.ps = g_shader_cache->GetPixelUberShaderForUid(uber_puid);
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -322,6 +322,16 @@ PixelShaderUid GetPixelShaderUid()
   return out;
 }
 
+void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid)
+{
+  pixel_shader_uid_data* uid_data = uid->GetUidData<pixel_shader_uid_data>();
+
+  // OpenGL and Vulkan convert implicitly normalized color outputs to their uint representation.
+  // Therefore, it is not necessary to use a uint output on these backends.
+  if (ApiType != APIType::D3D)
+    uid_data->uint_output = 0;
+}
+
 void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texgens,
                                   bool per_pixel_lighting, bool bounding_box)
 {

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -162,5 +162,5 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
                                    const pixel_shader_uid_data* uid_data);
 void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texgens,
                                   bool per_pixel_lighting, bool bounding_box);
-ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data* uid_data);
+void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid);
 PixelShaderUid GetPixelShaderUid();

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -29,6 +29,16 @@ PixelShaderUid GetPixelShaderUid()
   return out;
 }
 
+void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid)
+{
+  pixel_ubershader_uid_data* uid_data = uid->GetUidData<pixel_ubershader_uid_data>();
+
+  // OpenGL and Vulkan convert implicitly normalized color outputs to their uint representation.
+  // Therefore, it is not necessary to use a uint output on these backends.
+  if (ApiType != APIType::D3D)
+    uid_data->uint_output = 0;
+}
+
 ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
                           const pixel_ubershader_uid_data* uid_data)
 {

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -654,13 +654,19 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
     if (early_depth && host_config.backend_early_z)
       out.Write("[earlydepthstencil]\n");
 
-    out.Write("void main(\n"
-              "  out float4 ocol0 : SV_Target0,\n"
-              "  out float4 ocol1 : SV_Target1,\n"
-              "  %s\n",
-              per_pixel_depth ? "\n  out float depth : SV_Depth," : "");
+    out.Write("void main(\n");
+    if (uid_data->uint_output)
+    {
+      out.Write("  out uint4 ocol0 : SV_Target,\n");
+    }
+    else
+    {
+      out.Write("  out float4 ocol0 : SV_Target0,\n"
+                "  out float4 ocol1 : SV_Target1,\n");
+    }
+    if (per_pixel_depth)
+      out.Write("  out float depth : SV_Depth,\n");
     out.Write("  in float4 rawpos : SV_Position,\n");
-
     out.Write("  in %s float4 colors_0 : COLOR0,\n", GetInterpolationQualifier(msaa, ssaa));
     out.Write("  in %s float4 colors_1 : COLOR1", GetInterpolationQualifier(msaa, ssaa));
 
@@ -1186,14 +1192,14 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
     out.Write("  else\n"
               "    ocol0.a = float(TevResult.a >> 2) / 63.0;\n"
               "  \n");
-  }
 
-  if (use_dual_source)
-  {
-    out.Write("  // Dest alpha override (dual source blending)\n"
-              "  // Colors will be blended against the alpha from ocol1 and\n"
-              "  // the alpha from ocol0 will be written to the framebuffer.\n"
-              "  ocol1 = float4(0.0, 0.0, 0.0, float(TevResult.a) / 255.0);\n");
+    if (use_dual_source)
+    {
+      out.Write("  // Dest alpha override (dual source blending)\n"
+                "  // Colors will be blended against the alpha from ocol1 and\n"
+                "  // the alpha from ocol0 will be written to the framebuffer.\n"
+                "  ocol1 = float4(0.0, 0.0, 0.0, float(TevResult.a) / 255.0);\n");
+    }
   }
 
   if (bounding_box)

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -29,4 +29,5 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
                           const pixel_ubershader_uid_data* uid_data);
 
 void EnumeratePixelShaderUids(const std::function<void(const PixelShaderUid&)>& callback);
+void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid);
 }


### PR DESCRIPTION
Fixes broken logic op in D3D with ubershaders enabled, as this wasn't tested before #6013 was merged.

Also partially resolves my issue with host uid bits in the shader creating duplicate shaders, by clearing the uint_output bit if the backend isn't D3D.

This will likely be extended to the framebuffer fetch/blend modes in #5802. In the future, when/if we move to VideoCommon pipelines, this state will be part of the pipeline UID anyway, and we can mask it out in the backend by using a two-level map, sharing the shaders/programs.