### PR TITLE
Qt: Fix Wii Disc options being disabled while core is running

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -185,10 +185,10 @@ void GameList::ShowContextMenu(const QPoint&)
 
   if (platform == DiscIO::Platform::WII_DISC)
   {
-    AddAction(menu, tr("Perform System Update"), this, [this] {
+    auto* perform_disc_update = AddAction(menu, tr("Perform System Update"), this, [this] {
       WiiUpdate::PerformDiscUpdate(GetSelectedGame()->GetFilePath().toStdString(), this);
     });
-    menu->setEnabled(!Core::IsRunning() || !SConfig::GetInstance().bWii);
+    perform_disc_update->setEnabled(!Core::IsRunning() || !SConfig::GetInstance().bWii);
   }
 
   if (platform == DiscIO::Platform::WII_WAD)


### PR DESCRIPTION
Fixes a regression caused by #5610.