### PR TITLE
D3D: Fix shader compile error with logicop and alpha test enabled

### DIFF
--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -251,7 +251,7 @@ bool GeometryShaderCache::CompileShader(const GeometryShaderUid& uid)
   ShaderCode code =
       GenerateGeometryShaderCode(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   if (!D3D::CompileGeometryShader(code.GetBuffer(), &bytecode) ||
-      !InsertByteCode(uid, bytecode->Data(), bytecode->Size()))
+      !InsertByteCode(uid, bytecode ? bytecode->Data() : nullptr, bytecode ? bytecode->Size() : 0))
   {
     SAFE_RELEASE(bytecode);
     return false;

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -644,7 +644,7 @@ bool PixelShaderCache::SetShader()
   ShaderCode code =
       GeneratePixelShaderCode(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   D3D::CompilePixelShader(code.GetBuffer(), &bytecode);
-  if (!InsertByteCode(uid, bytecode->Data(), bytecode->Size()))
+  if (!InsertByteCode(uid, bytecode ? bytecode->Data() : nullptr, bytecode ? bytecode->Size() : 0))
   {
     SAFE_RELEASE(bytecode);
     return false;
@@ -687,7 +687,7 @@ bool PixelShaderCache::SetUberShader()
   ShaderCode code =
       UberShader::GenPixelShader(APIType::D3D, ShaderHostConfig::GetCurrent(), uid.GetUidData());
   D3D::CompilePixelShader(code.GetBuffer(), &bytecode);
-  if (!InsertByteCode(uid, bytecode->Data(), bytecode->Size()))
+  if (!InsertByteCode(uid, bytecode ? bytecode->Data() : nullptr, bytecode ? bytecode->Size() : 0))
   {
     SAFE_RELEASE(bytecode);
     return false;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1232,7 +1232,7 @@ static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_dat
     out.Write(")) {\n");
 
   out.Write("\t\tocol0 = float4(0.0, 0.0, 0.0, 0.0);\n");
-  if (use_dual_source)
+  if (use_dual_source && !(ApiType == APIType::D3D && uid_data->uint_output))
     out.Write("\t\tocol1 = float4(0.0, 0.0, 0.0, 0.0);\n");
   if (per_pixel_depth)
   {


### PR DESCRIPTION
Regression from #6013 and #6026.
Also stops Dolphin from crashing if a shader fails to compile (regression from ubershaders).