### PR TITLE
BTReal: Reattach kernel driver after device release

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -76,6 +76,7 @@ BluetoothReal::~BluetoothReal()
     SendHCIResetCommand();
     WaitForHCICommandComplete(HCI_CMD_RESET);
     libusb_release_interface(m_handle, 0);
+    libusb_attach_kernel_driver(m_handle, INTERFACE);
     // libusb_handle_events() may block the libusb thread indefinitely, so we need to
     // call libusb_close() first then immediately stop the thread in StopTransferThread.
     StopTransferThread();

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -124,6 +124,7 @@ private:
   void SaveLinkKeys();
 
   bool OpenDevice(libusb_device* device);
+  void CloseAndCleanupDevice();
   void StartTransferThread();
   void StopTransferThread();
   void TransferThread();


### PR DESCRIPTION
I forgot to re-attach the previously active kernel driver after releasing the interface. This PR fixes that.

Note that we don't use libusb's auto detachment/attachment support, because it doesn't print nice error messages if an error occurs.