### PR TITLE
JIT: Don't always look up symbols for blocks

### DIFF
--- a/Source/Core/Common/JitRegister.cpp
+++ b/Source/Core/Common/JitRegister.cpp
@@ -37,10 +37,13 @@ static File::IOFile s_perf_map_file;
 
 namespace JitRegister
 {
+static bool s_is_enabled = false;
+
 void Init(const std::string& perf_dir)
 {
 #if defined USE_OPROFILE && USE_OPROFILE
   s_agent = op_open_agent();
+  s_is_enabled = true;
 #endif
 
   if (!perf_dir.empty() || getenv("PERF_BUILDID_DIR"))
@@ -51,6 +54,7 @@ void Init(const std::string& perf_dir)
     // Disable buffering in order to avoid missing some mappings
     // if the event of a crash:
     std::setvbuf(s_perf_map_file.GetHandle(), nullptr, _IONBF, 0);
+    s_is_enabled = true;
   }
 }
 
@@ -67,6 +71,13 @@ void Shutdown()
 
   if (s_perf_map_file.IsOpen())
     s_perf_map_file.Close();
+
+  s_is_enabled = false;
+}
+
+bool IsEnabled()
+{
+  return s_is_enabled;
 }
 
 void RegisterV(const void* base_address, u32 code_size, const char* format, va_list args)

--- a/Source/Core/Common/JitRegister.h
+++ b/Source/Core/Common/JitRegister.h
@@ -12,6 +12,7 @@ namespace JitRegister
 void Init(const std::string& perf_dir);
 void Shutdown();
 void RegisterV(const void* base_address, u32 code_size, const char* format, va_list args);
+bool IsEnabled();
 
 inline void Register(const void* base_address, u32 code_size, const char* format, ...)
 {

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -132,12 +132,18 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& block, bool block_link,
     LinkBlock(block);
   }
 
-  if (Symbol* symbol = g_symbolDB.GetSymbolFromAddr(block.effectiveAddress))
+  Symbol* symbol = nullptr;
+  if (JitRegister::IsEnabled() &&
+      (symbol = g_symbolDB.GetSymbolFromAddr(block.effectiveAddress)) != nullptr)
+  {
     JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_%s_%08x",
                           symbol->function_name.c_str(), block.physicalAddress);
+  }
   else
+  {
     JitRegister::Register(block.checkedEntry, block.codeSize, "JIT_PPC_%08x",
                           block.physicalAddress);
+  }
 }
 
 JitBlock* JitBaseBlockCache::GetBlockFromStartAddress(u32 addr, u32 msr)

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -79,19 +79,20 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
 
 Symbol* PPCSymbolDB::GetSymbolFromAddr(u32 addr)
 {
-  XFuncMap::iterator it = functions.find(addr);
-  if (it != functions.end())
-  {
+  XFuncMap::iterator it = functions.lower_bound(addr);
+  if (it == functions.end())
+    return nullptr;
+
+  // If the address is exactly the start address of a symbol, we're done.
+  if (it->second.address == addr)
     return &it->second;
-  }
-  else
-  {
-    for (auto& p : functions)
-    {
-      if (addr >= p.second.address && addr < p.second.address + p.second.size)
-        return &p.second;
-    }
-  }
+
+  // Otherwise, check whether the address is within the bounds of a symbol.
+  if (it != functions.begin())
+    --it;
+  if (addr >= it->second.address && addr < it->second.address + it->second.size)
+    return &it->second;
+
   return nullptr;
 }
 


### PR DESCRIPTION
With tons of symbols, this results in really noticeable stuttering, so skip lookups if the perf dir option isn't set anyway.