### PR TITLE
Update -d argument help message

### DIFF
--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -81,7 +81,9 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
 
   if (options == ParserOptions::IncludeGUIOptions)
   {
-    parser->add_option("-d", "--debugger").action("store_true").help("Opens the debuger");
+    parser->add_option("-d", "--debugger")
+        .action("store_true")
+        .help("Show the debugger pane and additional View menu options");
     parser->add_option("-l", "--logger").action("store_true").help("Opens the logger");
     parser->add_option("-b", "--batch").action("store_true").help("Exit Dolphin with emulation");
     parser->add_option("-c", "--confirm").action("store_true").help("Set Confirm on Stop");


### PR DESCRIPTION
Pulled from #6039.

These are the View menu options that can only be seen in the View menu with `-d`:
![2017-09-09x](https://user-images.githubusercontent.com/17330088/30238805-9eae2a98-951c-11e7-9645-3de3bea624bc.png)

I'll update readme.md once the help message is reviewed.

@leoetlino 