### PR TITLE
Buildfix for X11 where HAVE_XRANDR is disabled

### DIFF
--- a/Source/Core/UICommon/X11Utils.h
+++ b/Source/Core/UICommon/X11Utils.h
@@ -10,7 +10,7 @@
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 #include <X11/extensions/Xrandr.h>
 #endif
-#include <X11/X.h>
+#include <X11/Xlib.h>
 
 // EWMH state actions, see
 // http://freedesktop.org/wiki/Specifications/wm-spec?action=show&redirect=Standards%2Fwm-spec


### PR DESCRIPTION
The "X.h" header *just* contains protocol constants, not functions or
typedefs - so stuff like "Display" and "Window" are not defined unless
you include "Xlib.h".

"Xrandr.h" happens to include "Xlib.h" itself, so enabling xrandr
effectively worked around this issue.