### PR TITLE
Common: Move version strings to their own header

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -24,6 +24,7 @@
 #include "Common/GL/GLInterfaceBase.h"
 #include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
+#include "Common/Version.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
@@ -585,7 +586,7 @@ JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetPlatform(
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersionString(JNIEnv* env,
                                                                                         jobject obj)
 {
-  return env->NewStringUTF(scm_rev_str.c_str());
+  return env->NewStringUTF(Common::scm_rev_str.c_str());
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveScreenShot(JNIEnv* env,

--- a/Source/Core/Common/BitField.h
+++ b/Source/Core/Common/BitField.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <limits>
 #include <type_traits>
 

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstring>
 #include <deque>
 #include <list>
 #include <map>

--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -4,19 +4,6 @@
 
 #pragma once
 
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <string>
-
-// Git version number
-extern const std::string scm_desc_str;
-extern const std::string scm_branch_str;
-extern const std::string scm_rev_str;
-extern const std::string scm_rev_git_str;
-extern const std::string netplay_dolphin_ver;
-extern const std::string scm_distributor_str;
-
 // Force enable logging in the right modes. For some reason, something had changed
 // so that debugfast no longer logged.
 #if defined(_DEBUG) || defined(DEBUGFAST)

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -151,6 +151,7 @@
     <ClInclude Include="TraversalClient.h" />
     <ClInclude Include="TraversalProto.h" />
     <ClInclude Include="UPnP.h" />
+    <ClInclude Include="Version.h" />
     <ClInclude Include="WorkQueueThread.h" />
     <ClInclude Include="x64ABI.h" />
     <ClInclude Include="x64Emitter.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -68,6 +68,7 @@
     <ClInclude Include="SysConf.h" />
     <ClInclude Include="Thread.h" />
     <ClInclude Include="Timer.h" />
+    <ClInclude Include="Version.h" />
     <ClInclude Include="WorkQueueThread.h" />
     <ClInclude Include="x64ABI.h" />
     <ClInclude Include="x64Emitter.h" />

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -4,14 +4,15 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <string>
 #include <type_traits>
 
-#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/Version.h"
 
 // On disk format:
 // header{
@@ -177,7 +178,8 @@ private:
     {
       // Null-terminator is intentionally not copied.
       std::memcpy(&id, "DCAC", sizeof(u32));
-      std::memcpy(ver, scm_rev_git_str.c_str(), std::min(scm_rev_git_str.size(), sizeof(ver)));
+      std::memcpy(ver, Common::scm_rev_git_str.c_str(),
+                  std::min(Common::scm_rev_git_str.size(), sizeof(ver)));
     }
 
     u32 id;

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -1,9 +1,15 @@
 // This file is public domain, in case it's useful to anyone. -comex
 
 #include "Common/TraversalClient.h"
+
+#include <cstddef>
+#include <cstring>
+#include <random>
+#include <string>
+
+#include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
-#include "Common/Timer.h"
 
 static void GetRandomishBytes(u8* buf, size_t size)
 {

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -1,12 +1,15 @@
 // This file is public domain, in case it's useful to anyone. -comex
 
 #pragma once
-#include <enet/enet.h>
-#include <functional>
+
+#include <cstddef>
 #include <list>
 #include <memory>
-#include <random>
-#include "Common/Common.h"
+#include <string>
+
+#include <enet/enet.h>
+
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "Common/TraversalProto.h"
 

--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -2,9 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/Version.h"
+
+#include <string>
+
 #include "Common/scmrev.h"
 
+namespace Common
+{
 #ifdef _DEBUG
 #define BUILD_TYPE_STR "Debug "
 #elif defined DEBUGFAST
@@ -24,16 +29,16 @@ const std::string scm_rev_str = "Dolphin "
     BUILD_TYPE_STR SCM_DESC_STR;
 #endif
 
+const std::string scm_rev_git_str = SCM_REV_STR;
+const std::string scm_desc_str = SCM_DESC_STR;
+const std::string scm_branch_str = SCM_BRANCH_STR;
+const std::string scm_distributor_str = SCM_DISTRIBUTOR_STR;
+
 #ifdef _WIN32
 const std::string netplay_dolphin_ver = SCM_DESC_STR " Win";
 #elif __APPLE__
 const std::string netplay_dolphin_ver = SCM_DESC_STR " Mac";
 #else
-    const std::string netplay_dolphin_ver = SCM_DESC_STR " Lin";
+const std::string netplay_dolphin_ver = SCM_DESC_STR " Lin";
 #endif
-
-const std::string scm_rev_git_str = SCM_REV_STR;
-
-const std::string scm_desc_str = SCM_DESC_STR;
-const std::string scm_branch_str = SCM_BRANCH_STR;
-const std::string scm_distributor_str = SCM_DISTRIBUTOR_STR;
+}  // namespace Common

--- a/Source/Core/Common/Version.h
+++ b/Source/Core/Common/Version.h
@@ -1,0 +1,18 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+namespace Common
+{
+// Git version number
+extern const std::string scm_desc_str;
+extern const std::string scm_branch_str;
+extern const std::string scm_rev_str;
+extern const std::string scm_rev_git_str;
+extern const std::string scm_distributor_str;
+extern const std::string netplay_dolphin_ver;
+}  // namespace Common

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -15,9 +15,9 @@
 
 #include "Common/Analytics.h"
 #include "Common/CPUDetect.h"
-#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
+#include "Common/Version.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCPad.h"
 #include "Core/Movie.h"
@@ -121,10 +121,10 @@ void DolphinAnalytics::MakeBaseBuilder()
   Common::AnalyticsReportBuilder builder;
 
   // Version information.
-  builder.AddData("version-desc", scm_desc_str);
-  builder.AddData("version-hash", scm_rev_git_str);
-  builder.AddData("version-branch", scm_branch_str);
-  builder.AddData("version-dist", scm_distributor_str);
+  builder.AddData("version-desc", Common::scm_desc_str);
+  builder.AddData("version-hash", Common::scm_rev_git_str);
+  builder.AddData("version-branch", Common::scm_branch_str);
+  builder.AddData("version-dist", Common::scm_distributor_str);
 
   // CPU information.
   builder.AddData("cpu-summary", cpu_info.Summarize());

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -45,6 +45,9 @@ IPC_HLE_PERIOD: For the Wii Remote this is the call schedule:
 
 #include "Core/HW/SystemTimers.h"
 
+#include <cmath>
+#include <cstdlib>
+
 #include "Common/Atomic.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -28,6 +28,7 @@
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
+#include "Common/Version.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/Config/MainSettings.h"
@@ -1419,7 +1420,7 @@ void GetSettings()
        SConfig::GetInstance().m_EXIDevice[1] == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER)
       << 1;
 
-  std::array<u8, 20> revision = ConvertGitRevisionToBytes(scm_rev_git_str);
+  std::array<u8, 20> revision = ConvertGitRevisionToBytes(Common::scm_rev_git_str);
   std::copy(std::begin(revision), std::end(revision), std::begin(s_revision));
 
   if (!Config::Get(Config::MAIN_DSP_HLE))

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -5,6 +5,8 @@
 #include "Core/NetPlayClient.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstring>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -13,7 +15,6 @@
 
 #include <mbedtls/md5.h>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/ENetUtil.h"
@@ -21,6 +22,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
+#include "Common/Version.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/SI/SI.h"
@@ -175,8 +177,8 @@ bool NetPlayClient::Connect()
 {
   // send connect message
   sf::Packet packet;
-  packet << scm_rev_git_str;
-  packet << netplay_dolphin_ver;
+  packet << Common::scm_rev_git_str;
+  packet << Common::netplay_dolphin_ver;
   packet << m_player_name;
   Send(packet);
   enet_host_flush(m_client);
@@ -225,7 +227,7 @@ bool NetPlayClient::Connect()
     Player player;
     player.name = m_player_name;
     player.pid = m_pid;
-    player.revision = netplay_dolphin_ver;
+    player.revision = Common::netplay_dolphin_ver;
 
     // add self to player list
     m_players[m_pid] = player;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -5,6 +5,8 @@
 #include "Core/NetPlayServer.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -12,13 +14,13 @@
 #include <unordered_set>
 #include <vector>
 
-#include "Common/Common.h"
 #include "Common/ENetUtil.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/UPnP.h"
+#include "Common/Version.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Sram.h"
 #include "Core/NetPlayClient.h"  //for NetPlayUI
@@ -254,7 +256,7 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
   std::string npver;
   rpac >> npver;
   // Dolphin netplay version
-  if (npver != scm_rev_git_str)
+  if (npver != Common::scm_rev_git_str)
     return CON_ERR_VERSION_MISMATCH;
 
   // game is currently running

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -22,6 +22,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
+#include "Common/Version.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -116,7 +117,7 @@ static bool DoStateVersion(PointerWrap& p, std::string* version_created_by)
     version = cookie - COOKIE_BASE;
   }
 
-  *version_created_by = scm_rev_str;
+  *version_created_by = Common::scm_rev_str;
   if (version > 42)
     p.Do(*version_created_by);
   else

--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -6,7 +6,7 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 
-#include "Common/Common.h"
+#include "Common/Version.h"
 #include "DolphinQt2/AboutDialog.h"
 #include "DolphinQt2/Resources.h"
 
@@ -23,11 +23,11 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
   text.append(QStringLiteral("<p style='font-size:50pt; font-weight:400; margin-bottom:0px;'>") +
               tr("Dolphin") + QStringLiteral("</p>"));
   text.append(QStringLiteral("<p style='font-size:18pt; margin-top:0px;'>%1</p>")
-                  .arg(QString::fromUtf8(scm_desc_str.c_str())));
+                  .arg(QString::fromUtf8(Common::scm_desc_str.c_str())));
 
-  text.append(small + tr("Branch: ") + QString::fromUtf8(scm_branch_str.c_str()) +
+  text.append(small + tr("Branch: ") + QString::fromUtf8(Common::scm_branch_str.c_str()) +
               QStringLiteral("</p>"));
-  text.append(small + tr("Revision: ") + QString::fromUtf8(scm_rev_git_str.c_str()) +
+  text.append(small + tr("Revision: ") + QString::fromUtf8(Common::scm_rev_git_str.c_str()) +
               QStringLiteral("</p>"));
   text.append(small + tr("Compiled: ") + QStringLiteral(__DATE__ " " __TIME__ "</p>"));
 

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -16,7 +16,7 @@
 
 #include <future>
 
-#include "Common/Common.h"
+#include "Common/Version.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
@@ -66,7 +66,7 @@
 
 MainWindow::MainWindow() : QMainWindow(nullptr)
 {
-  setWindowTitle(QString::fromStdString(scm_rev_str));
+  setWindowTitle(QString::fromStdString(Common::scm_rev_str));
   setWindowIcon(QIcon(Resources::GetMisc(Resources::LOGO_SMALL)));
   setUnifiedTitleAndToolBarOnMac(true);
   setAcceptDrops(true);
@@ -541,7 +541,7 @@ void MainWindow::HideRenderWidget()
     m_render_widget->setParent(nullptr);
     m_rendering_to_main = false;
     disconnect(Host::GetInstance(), &Host::RequestTitle, this, &MainWindow::setWindowTitle);
-    setWindowTitle(QString::fromStdString(scm_rev_str));
+    setWindowTitle(QString::fromStdString(Common::scm_rev_str));
   }
   m_render_widget->hide();
 }

--- a/Source/Core/DolphinWX/AboutDolphin.cpp
+++ b/Source/Core/DolphinWX/AboutDolphin.cpp
@@ -12,7 +12,7 @@
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 
-#include "Common/Common.h"
+#include "Common/Version.h"
 #include "DolphinWX/AboutDolphin.h"
 #include "DolphinWX/WxUtils.h"
 
@@ -24,12 +24,13 @@ AboutDolphin::AboutDolphin(wxWindow* parent, wxWindowID id, const wxString& titl
       this, wxID_ANY, WxUtils::LoadScaledResourceBitmap("dolphin_logo", this));
 
   const wxString DolphinText = _("Dolphin");
-  const wxString RevisionText = scm_desc_str;
+  const wxString RevisionText = Common::scm_desc_str;
   const wxString CopyrightText =
       _("(c) 2003-2015+ Dolphin Team. \"GameCube\" and \"Wii\" are trademarks of Nintendo. Dolphin "
         "is not affiliated with Nintendo in any way.");
-  const wxString BranchText = wxString::Format(_("Branch: %s"), scm_branch_str.c_str());
-  const wxString BranchRevText = wxString::Format(_("Revision: %s"), scm_rev_git_str.c_str());
+  const wxString BranchText = wxString::Format(_("Branch: %s"), Common::scm_branch_str.c_str());
+  const wxString BranchRevText =
+      wxString::Format(_("Revision: %s"), Common::scm_rev_git_str.c_str());
   const wxString CheckUpdateText = _("Check for updates: ");
   const wxString Text =
       _("\n"

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -42,6 +42,7 @@
 #include "Common/Logging/ConsoleListener.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
+#include "Common/Version.h"
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
@@ -758,7 +759,7 @@ void CFrame::UninhibitScreensaver()
 
 void CFrame::UpdateTitle(const wxString& str)
 {
-  const wxString revision_string = StrToWxStr(scm_rev_str);
+  const wxString revision_string = StrToWxStr(Common::scm_rev_str);
   if (SConfig::GetInstance().bRenderToMain && SConfig::GetInstance().m_InterfaceStatusbar)
   {
     GetStatusBar()->SetStatusText(str, 0);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -31,6 +31,7 @@
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
+#include "Common/Version.h"
 
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
@@ -916,7 +917,7 @@ void CFrame::OnStopped()
 
   UninhibitScreensaver();
 
-  m_render_frame->SetTitle(StrToWxStr(scm_rev_str));
+  m_render_frame->SetTitle(StrToWxStr(Common::scm_rev_str));
 
   // Destroy the renderer frame when not rendering to main
   m_render_parent->Unbind(wxEVT_SIZE, &CFrame::OnRenderParentResize, this);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -31,6 +31,7 @@
 #include "Common/Logging/LogManager.h"
 #include "Common/MsgHandler.h"
 #include "Common/Thread.h"
+#include "Common/Version.h"
 
 #include "Core/Analytics.h"
 #include "Core/ConfigManager.h"
@@ -151,7 +152,7 @@ bool DolphinApp::OnInit()
   // event dispatch including WM_MOVE/WM_SIZE)
   wxRect window_geometry(SConfig::GetInstance().iPosX, SConfig::GetInstance().iPosY,
                          SConfig::GetInstance().iWidth, SConfig::GetInstance().iHeight);
-  main_frame = new CFrame(nullptr, wxID_ANY, StrToWxStr(scm_rev_str), window_geometry,
+  main_frame = new CFrame(nullptr, wxID_ANY, StrToWxStr(Common::scm_rev_str), window_geometry,
                           m_use_debugger, m_batch_mode, m_use_logger);
   SetTopWindow(main_frame);
 

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -2,10 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include <fcntl.h>
 #include <libudev.h>
 #include <map>
 #include <memory>
+#include <string>
 #include <unistd.h>
 
 #include <sys/eventfd.h>

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -9,8 +9,8 @@
 
 #include <OptionParser.h>
 
-#include "Common/Common.h"
 #include "Common/Config/Config.h"
+#include "Common/Version.h"
 #include "UICommon/CommandLineParse.h"
 
 namespace CommandLineParse
@@ -64,7 +64,7 @@ private:
 std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
 {
   auto parser = std::make_unique<optparse::OptionParser>();
-  parser->usage("usage: %prog [options]... [FILE]...").version(scm_rev_str);
+  parser->usage("usage: %prog [options]... [FILE]...").version(Common::scm_rev_str);
 
   parser->add_option("-u", "--user").action("store").help("User folder path");
   parser->add_option("-m", "--movie").action("store").help("Play a movie file");

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <cstring>
 
 #include "Common/Assert.h"
 #include "Common/CommonFuncs.h"


### PR DESCRIPTION
Ideally Common.h wouldn't be a header in the Common library, and instead be renamed to something else, like PlatformCompatibility.h or something, but even then, there's still some things in the header that don't really fall under that label

This moves the version strings out to their own version header that doesn't dump a bunch of other unrelated things into scope, like what Common.h was doing.

This also places them into the Common namespace, as opposed to letting them sit in the global namespace.