### PR TITLE
Android: Extract Sys to a different folder than the User folder

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -283,6 +283,8 @@ public final class NativeLibrary
 	 */
 	public static native String GetVersionString();
 
+	public static native String GetGitRevision();
+
 	/**
 	 * Saves a screen capture of the game
 	 */

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -303,11 +303,6 @@ public final class NativeLibrary
 	public static native void LoadState(int slot);
 
 	/**
-	 * Creates the initial folder structure in /sdcard/dolphin-emu/
-	 */
-	public static native void CreateUserFolders();
-
-	/**
 	 * Sets the current working user directory
 	 * If not set, it auto-detects a location
 	 */

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/DirectoryInitializationService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/DirectoryInitializationService.java
@@ -9,6 +9,8 @@ package org.dolphinemu.dolphinemu.services;
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
@@ -74,11 +76,19 @@ public final class DirectoryInitializationService extends IntentService
     {
         File sysDirectory = new File(getFilesDir(), "Sys");
 
-        // Delete the existing extracted Sys directory in case it's from a different version of Dolphin.
-        deleteDirectoryRecursively(sysDirectory);
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+        String revision = NativeLibrary.GetGitRevision();
+        if (!preferences.getString("sysDirectoryVersion", "").equals(revision))
+        {
+            // There is no extracted Sys directory, or there is a Sys directory from another
+            // version of Dolphin that might contain outdated files. Let's (re-)extract Sys.
+            deleteDirectoryRecursively(sysDirectory);
+            copyAssetFolder("Sys", sysDirectory, true);
 
-        // Extract the Sys directory to app-local internal storage.
-        copyAssetFolder("Sys", sysDirectory, true);
+            SharedPreferences.Editor editor = preferences.edit();
+            editor.putString("sysDirectoryVersion", revision);
+            editor.apply();
+        }
 
         // Let the native code know where the Sys directory is.
         SetSysDirectory(sysDirectory.getPath());

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -13,33 +13,31 @@ public final class StartupHandler
 {
 	public static boolean HandleInit(FragmentActivity parent)
 	{
-		NativeLibrary.SetUserDirectory(""); // Auto-Detect
+		String user_dir = "";
+		String start_file = "";
 
-		if (PermissionsHandler.checkWritePermission(parent)) {
-			DirectoryInitializationService.startService(parent);
-		}
-
-		Intent intent = parent.getIntent();
-		Bundle extras = intent.getExtras();
-
+		Bundle extras = parent.getIntent().getExtras();
 		if (extras != null)
 		{
-			String user_dir = extras.getString("UserDir");
-			String start_file = extras.getString("AutoStartFile");
-
-			if (!TextUtils.isEmpty(user_dir))
-				NativeLibrary.SetUserDirectory(user_dir);
-
-			if (!TextUtils.isEmpty(start_file))
-			{
-				// Start the emulation activity, send the ISO passed in and finish the main activity
-				Intent emulation_intent = new Intent(parent, EmulationActivity.class);
-				emulation_intent.putExtra("SelectedGame", start_file);
-				parent.startActivity(emulation_intent);
-				parent.finish();
-				return false;
-			}
+			user_dir = extras.getString("UserDir");
+			start_file = extras.getString("AutoStartFile");
 		}
+
+		NativeLibrary.SetUserDirectory(user_dir);  // Uses default path if user_dir equals ""
+
+		if (PermissionsHandler.checkWritePermission(parent))
+			DirectoryInitializationService.startService(parent);
+
+		if (!TextUtils.isEmpty(start_file))
+		{
+			// Start the emulation activity, send the ISO passed in and finish the main activity
+			Intent emulation_intent = new Intent(parent, EmulationActivity.class);
+			emulation_intent.putExtra("SelectedGame", start_file);
+			parent.startActivity(emulation_intent);
+			parent.finish();
+			return false;
+		}
+
 		return false;
 	}
 }

--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -15,6 +15,8 @@ ${LIBS}
 )
 
 file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/)
-file(COPY ${CMAKE_SOURCE_DIR}/Data/Sys/GameSettings ${CMAKE_SOURCE_DIR}/Data/Sys/GC ${CMAKE_SOURCE_DIR}/Data/Sys/Wii ${CMAKE_SOURCE_DIR}/Data/Sys/Shaders DESTINATION ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/)
+file(REMOVE_RECURSE ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/Sys/)
+file(COPY ${CMAKE_SOURCE_DIR}/Data/Sys DESTINATION ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/)
+file(REMOVE_RECURSE ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/Sys/Resources/)  # not used on Android
 
 set(CPACK_PACKAGE_EXECUTABLES ${CPACK_PACKAGE_EXECUTABLES} ${SHARED_LIB})

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -432,6 +432,8 @@ JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetPlatform(
                                                                                 jstring jFilename);
 JNIEXPORT jstring JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersionString(JNIEnv* env, jobject obj);
+JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetGitRevision(JNIEnv* env,
+                                                                                      jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveScreenShot(JNIEnv* env,
                                                                                    jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_eglBindAPI(JNIEnv* env,
@@ -587,6 +589,12 @@ JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersio
                                                                                         jobject obj)
 {
   return env->NewStringUTF(Common::scm_rev_str.c_str());
+}
+
+JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetGitRevision(JNIEnv* env,
+                                                                                      jobject obj)
+{
+  return env->NewStringUTF(Common::scm_rev_git_str.c_str());
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveScreenShot(JNIEnv* env,

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -450,8 +450,9 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveState(JN
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JNIEnv* env,
                                                                               jobject obj,
                                                                               jint slot);
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_CreateUserFolders(JNIEnv* env,
-                                                                                      jobject obj);
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_services_DirectoryInitializationService_CreateUserDirectories(
+    JNIEnv* env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirectory(
     JNIEnv* env, jobject obj, jstring jDirectory);
 JNIEXPORT jstring JNICALL
@@ -649,28 +650,19 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JN
   State::Load(slot);
 }
 
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_CreateUserFolders(JNIEnv* env,
-                                                                                      jobject obj)
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_services_DirectoryInitializationService_SetSysDirectory(
+    JNIEnv* env, jobject obj, jstring jPath)
 {
-  File::CreateFullPath(File::GetUserPath(D_CONFIG_IDX));
-  File::CreateFullPath(File::GetUserPath(D_GCUSER_IDX));
-  File::CreateFullPath(File::GetUserPath(D_WIIROOT_IDX) + DIR_SEP WII_WC24CONF_DIR DIR_SEP
-                       "mbox" DIR_SEP);
-  File::CreateFullPath(File::GetUserPath(D_WIIROOT_IDX) + DIR_SEP "shared2" DIR_SEP
-                                                                  "succession" DIR_SEP);
-  File::CreateFullPath(File::GetUserPath(D_WIIROOT_IDX) + DIR_SEP "shared2" DIR_SEP "ec" DIR_SEP);
-  File::CreateFullPath(File::GetUserPath(D_WIIROOT_IDX) + DIR_SEP WII_SYSCONF_DIR DIR_SEP);
-  File::CreateFullPath(File::GetUserPath(D_CACHE_IDX));
-  File::CreateFullPath(File::GetUserPath(D_DUMPDSP_IDX));
-  File::CreateFullPath(File::GetUserPath(D_DUMPTEXTURES_IDX));
-  File::CreateFullPath(File::GetUserPath(D_HIRESTEXTURES_IDX));
-  File::CreateFullPath(File::GetUserPath(D_SCREENSHOTS_IDX));
-  File::CreateFullPath(File::GetUserPath(D_STATESAVES_IDX));
-  File::CreateFullPath(File::GetUserPath(D_MAILLOGS_IDX));
-  File::CreateFullPath(File::GetUserPath(D_SHADERS_IDX) + "Anaglyph" DIR_SEP);
-  File::CreateFullPath(File::GetUserPath(D_GCUSER_IDX) + USA_DIR DIR_SEP);
-  File::CreateFullPath(File::GetUserPath(D_GCUSER_IDX) + EUR_DIR DIR_SEP);
-  File::CreateFullPath(File::GetUserPath(D_GCUSER_IDX) + JAP_DIR DIR_SEP);
+  const std::string path = GetJString(env, jPath);
+  File::SetSysDirectory(path);
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_services_DirectoryInitializationService_CreateUserDirectories(
+    JNIEnv* env, jobject obj)
+{
+  UICommon::CreateDirectories();
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirectory(

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -27,21 +27,6 @@
 #define DOLPHIN_DATA_DIR "dolphin-emu"
 #endif
 
-// Shared data dirs (Sys and shared User for Linux)
-#if defined(_WIN32) || defined(LINUX_LOCAL_DEV)
-#define SYSDATA_DIR "Sys"
-#elif defined __APPLE__
-#define SYSDATA_DIR "Contents/Resources/Sys"
-#elif defined ANDROID
-#define SYSDATA_DIR "/sdcard/dolphin-emu"
-#else
-#ifdef DATA_DIR
-#define SYSDATA_DIR DATA_DIR "sys"
-#else
-#define SYSDATA_DIR "sys"
-#endif
-#endif
-
 // Dirs in both User and Sys
 #define EUR_DIR "EUR"
 #define USA_DIR "USA"

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -692,6 +692,20 @@ std::string GetSysDirectory()
 {
   std::string sysDir;
 
+#if defined(_WIN32) || defined(LINUX_LOCAL_DEV)
+#define SYSDATA_DIR "Sys"
+#elif defined __APPLE__
+#define SYSDATA_DIR "Contents/Resources/Sys"
+#elif defined ANDROID
+#define SYSDATA_DIR "/sdcard/dolphin-emu"
+#else
+#ifdef DATA_DIR
+#define SYSDATA_DIR DATA_DIR "sys"
+#else
+#define SYSDATA_DIR "sys"
+#endif
+#endif
+
 #if defined(__APPLE__)
   sysDir = GetBundleDirectory() + DIR_SEP + SYSDATA_DIR;
 #elif defined(_WIN32) || defined(LINUX_LOCAL_DEV)

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/Common.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonPaths.h"
@@ -52,6 +53,10 @@
 // REMEMBER: strdup considered harmful!
 namespace File
 {
+#ifdef ANDROID
+static std::string s_android_sys_directory;
+#endif
+
 #ifdef _WIN32
 FileInfo::FileInfo(const std::string& path)
 {
@@ -696,8 +701,6 @@ std::string GetSysDirectory()
 #define SYSDATA_DIR "Sys"
 #elif defined __APPLE__
 #define SYSDATA_DIR "Contents/Resources/Sys"
-#elif defined ANDROID
-#define SYSDATA_DIR "/sdcard/dolphin-emu"
 #else
 #ifdef DATA_DIR
 #define SYSDATA_DIR DATA_DIR "sys"
@@ -710,6 +713,9 @@ std::string GetSysDirectory()
   sysDir = GetBundleDirectory() + DIR_SEP + SYSDATA_DIR;
 #elif defined(_WIN32) || defined(LINUX_LOCAL_DEV)
   sysDir = GetExeDirectory() + DIR_SEP + SYSDATA_DIR;
+#elif defined ANDROID
+  sysDir = s_android_sys_directory;
+  _assert_msg_(COMMON, !sysDir.empty(), "Sys directory has not been set");
 #else
   sysDir = SYSDATA_DIR;
 #endif
@@ -718,6 +724,14 @@ std::string GetSysDirectory()
   INFO_LOG(COMMON, "GetSysDirectory: Setting to %s:", sysDir.c_str());
   return sysDir;
 }
+
+#ifdef ANDROID
+void SetSysDirectory(const std::string& path)
+{
+  INFO_LOG(COMMON, "Setting Sys directory to %s", path.c_str());
+  s_android_sys_directory = path;
+}
+#endif
 
 static std::string s_user_paths[NUM_PATH_INDICES];
 static void RebuildUserDirectories(unsigned int dir_index)

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -183,6 +183,10 @@ std::string GetThemeDir(const std::string& theme_name);
 // Returns the path to where the sys file are
 std::string GetSysDirectory();
 
+#ifdef ANDROID
+void SetSysDirectory(const std::string& path);
+#endif
+
 #ifdef __APPLE__
 std::string GetBundleDirectory();
 #endif

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -77,7 +77,9 @@ void CreateDirectories()
   File::CreateFullPath(File::GetUserPath(D_SHADERS_IDX));
   File::CreateFullPath(File::GetUserPath(D_SHADERS_IDX) + ANAGLYPH_DIR DIR_SEP);
   File::CreateFullPath(File::GetUserPath(D_STATESAVES_IDX));
+#ifndef ANDROID
   File::CreateFullPath(File::GetUserPath(D_THEMES_IDX));
+#endif
 }
 
 void SetUserDirectory(const std::string& custom_path)


### PR DESCRIPTION
The way we're handling the Sys directory right now on Android is by extracting parts of Sys to the user directory and then using the user directory as if it is the Sys directory. This has several problems: We don't have a good way of handling the Sys files in the git repo changing (because we don't know which files have been modified by the user) (see [issue 10035](https://bugs.dolphin-emu.org/issues/10035)), and we haven't wanted to include game INIs in the files to be extracted because we don't want to dump thousands of files into the user's storage.

One way to solve this would be to read the Sys files directly from the app as assets without extracting them anywhere, which I tried to do in PR #4664. It would've solved all of the problems above, but it required a lot of invasive changes in the C++ code because we would have to use platform-specific APIs for reading the Sys files, and the PR seems to have an unsolved bug related to iterating through folders.

This PR is an alternative to that. Instead of extracting the Sys directory to the user directory, we now extract it to app-local storage. Compared to PR #4664, the advantage is that the Sys files can be accessed using standard APIs, and the disadvantages are that it uses a bit more storage space (4 MiB or so) and requires extra execution time. The latter is mitigated by doing the extraction on a separate thread and by not re-extracting the Sys directory if the previously extracted Sys directory is from the same version of Dolphin, and it should be mitigated further by delroth's plans to put the game INIs in a zip file.

So now it's time to decide: Should we go with this PR, or would it be better to fix PR #4664 and get that merged?