### PR TITLE
Remove Symbol Address Mask

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -86,7 +86,7 @@ static u32 EvaluateBranchTarget(UGeckoInstruction instr, u32 pc)
 bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
 {
   if (func.name.empty())
-    func.Rename(StringFromFormat("zz_%07x_", startAddr & 0x0FFFFFFF));
+    func.Rename(StringFromFormat("zz_%08x_", startAddr));
   if (func.analyzed)
     return true;  // No error, just already did it.
 


### PR DESCRIPTION
The upper 4 bits were masked out of symbol addresses before when generating symbols.