### PR TITLE
Add Recommended RAM Check After Init (WX)

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -29,6 +29,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/LogManager.h"
+#include "Common/MemoryUtil.h"
 #include "Common/MsgHandler.h"
 #include "Common/Thread.h"
 #include "Common/Version.h"
@@ -59,6 +60,9 @@
 #if defined HAVE_X11 && HAVE_X11
 #include <X11/Xlib.h>
 #endif
+
+size_t max_sys_mem = Common::MemPhysical();  // excl. driverlocked & hw-reserved
+constexpr double DOLPHIN_REC_MEM_AMOUNT = (1024.0 * 1024.0 * 1024.0 * 4.1);
 
 // ------------
 //  Main window
@@ -233,6 +237,14 @@ void DolphinApp::AfterInit()
     DolphinAnalytics::Instance()->ReloadConfig();
   }
 #endif
+
+  if (max_sys_mem <= DOLPHIN_REC_MEM_AMOUNT)
+  {
+    wxMessageBox(_("Warning!\n\nSystem memory (RAM) is below Dolphin's "
+                   "recommendations.\n\n"
+                   "The use of custom textures may lead to system instability or failure. "),
+                 _("Low System Resources"), wxOK, main_frame);
+  }
 
   if (m_confirm_stop)
     SConfig::GetInstance().bConfirmStop = m_confirm_setting;


### PR DESCRIPTION
Proposition for a thought in  #5996

Moving the "minimum required memory" from the prefetcher to the main window and changing it to **recommended** memory warning, appropriately increasing the amount that recommended.

Reasons for the amount change:
- Because "recommended" implies it's something above "minimal requirement", so it makes logical sense.
- As mentioned in #5996, it's very unlikely anyone has below 2GB, or even 4GB
- For the inital push I picked 4 GB + 100MB* so that the warning only triggers if the computer doesn't even have the standard 1x4GB DIMM that is probably the standard for low-end OEM PC sales out there these days.

 *offset for hw-reserved & driver-locked

