### PR TITLE
Reorganise debugger execution breakpoints

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -81,23 +81,6 @@ void Run()
       s_state_cpu_thread_active = true;
       state_lock.unlock();
 
-      // Adjust PC for JIT when debugging
-      // SingleStep so that the "continue", "step over" and "step out" debugger functions
-      // work when the PC is at a breakpoint at the beginning of the block
-      // If watchpoints are enabled, any instruction could be a breakpoint.
-      if (PowerPC::GetMode() != PowerPC::CoreMode::Interpreter)
-      {
-        if (PowerPC::breakpoints.IsAddressBreakPoint(PC) || PowerPC::memchecks.HasAny())
-        {
-          s_state = State::Stepping;
-          PowerPC::CoreMode old_mode = PowerPC::GetMode();
-          PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
-          PowerPC::SingleStep();
-          PowerPC::SetMode(old_mode);
-          s_state = State::Running;
-        }
-      }
-
       // Enter a fast runloop
       PowerPC::RunLoop();
 

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -17,6 +17,9 @@ struct TBreakPoint
   u32 address = 0;
   bool is_enabled = false;
   bool is_temporary = false;
+
+  bool log_on_hit = false;
+  bool break_on_hit = true;
 };
 
 struct TMemCheck
@@ -59,6 +62,9 @@ public:
   // is address breakpoint
   bool IsAddressBreakPoint(u32 address) const;
   bool IsTempBreakPoint(u32 address) const;
+
+  // Return a pointer to a breakpoint at an address or nullptr if it doesn't exist
+  const TBreakPoint* GetBreakPointAt(u32 address) const;
 
   // Add BreakPoint
   void Add(u32 address, bool temp = false);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -199,6 +199,11 @@ int Interpreter::SingleStepInner()
 
 void Interpreter::SingleStep()
 {
+  if (PowerPC::CheckBreakPoints() != 0)
+  {
+    Host_UpdateDisasmDialog();
+    return;
+  }
   // Declare start of new slice
   CoreTiming::Advance();
 
@@ -212,6 +217,11 @@ void Interpreter::SingleStep()
   {
     PowerPC::CheckExceptions();
     PC = NPC;
+  }
+
+  if (PowerPC::CheckBreakPoints() != 0)
+  {
+    Host_UpdateDisasmDialog();
   }
 }
 
@@ -255,9 +265,7 @@ void Interpreter::Run()
           if (PCVec.size() > ShowSteps)
             PCVec.erase(PCVec.begin());
 #endif
-
-          // 2: check for breakpoint
-          if (PowerPC::breakpoints.IsAddressBreakPoint(PC))
+          if (PowerPC::CheckBreakPoints() != 0)
           {
 #ifdef SHOW_HISTORY
             NOTICE_LOG(POWERPC, "----------------------------");
@@ -278,11 +286,6 @@ void Interpreter::Run()
               NOTICE_LOG(POWERPC, "PC: 0x%08x", PCVec.at(j));
             }
 #endif
-            INFO_LOG(POWERPC, "Hit Breakpoint - %08x", PC);
-            CPU::Break();
-            if (PowerPC::breakpoints.IsTempBreakPoint(PC))
-              PowerPC::breakpoints.Remove(PC);
-
             Host_UpdateDisasmDialog();
             return;
           }

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -853,8 +853,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
         ABI_PushRegistersAndAdjustStack({}, 0);
         ABI_CallFunction(PowerPC::CheckBreakPoints);
         ABI_PopRegistersAndAdjustStack({}, 0);
-        MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
-        TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
+        TEST(32, R(ABI_RETURN), R(ABI_RETURN));
         FixupBranch noBreakpoint = J_CC(CC_Z);
 
         WriteExit(ops[i].address);

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -86,15 +86,8 @@ void Jit64AsmRoutineManager::Generate()
   if (SConfig::GetInstance().bEnableDebugging)
   {
     MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
-    TEST(32, MatR(RSCRATCH), Imm32(static_cast<u32>(CPU::State::Stepping)));
-    FixupBranch notStepping = J_CC(CC_Z);
-    ABI_PushRegistersAndAdjustStack({}, 0);
-    ABI_CallFunction(PowerPC::CheckBreakPoints);
-    ABI_PopRegistersAndAdjustStack({}, 0);
-    MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
-    TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
-    dbg_exit = J_CC(CC_NZ, true);
-    SetJumpTarget(notStepping);
+    CMP(32, MatR(RSCRATCH), Imm32(static_cast<u32>(CPU::State::Stepping)));
+    dbg_exit = J_CC(CC_Z, true);
   }
 
   SetJumpTarget(skipToRealDispatch);

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -164,7 +164,13 @@ void InjectExternalCPUCore(CPUCoreBase* core);
 void SingleStep();
 void CheckExceptions();
 void CheckExternalExceptions();
-void CheckBreakPoints();
+
+// Return zero if execution should continue, non-zero to stop
+u32 CheckBreakPoints();
+
+// Syncs current execution with current breakpoints
+void SyncBreakPoint();
+
 void RunLoop();
 
 u32 CompactCR();

--- a/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
@@ -5,6 +5,7 @@
 #include "DolphinWX/Debugger/BreakpointDlg.h"
 
 #include <string>
+#include <wx/checkbox.h>
 #include <wx/dialog.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
@@ -23,10 +24,21 @@ BreakPointDlg::BreakPointDlg(wxWindow* _Parent) : wxDialog(_Parent, wxID_ANY, _(
 
   m_pEditAddress = new wxTextCtrl(this, wxID_ANY, "80000000");
 
+  m_log_checkbox = new wxCheckBox(this, wxID_ANY, _("Log"));
+  m_log_checkbox->SetValue(true);
+  m_break_checkbox = new wxCheckBox(this, wxID_ANY, _("Break"));
+  m_break_checkbox->SetValue(true);
+
+  auto* flags_szr = new wxStaticBoxSizer(wxVERTICAL, this, _("Flags"));
+  flags_szr->Add(m_log_checkbox);
+  flags_szr->Add(m_break_checkbox);
+
   const int space5 = FromDIP(5);
   wxBoxSizer* main_szr = new wxBoxSizer(wxVERTICAL);
   main_szr->AddSpacer(space5);
   main_szr->Add(m_pEditAddress, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  main_szr->AddSpacer(space5);
+  main_szr->Add(flags_szr);
   main_szr->AddSpacer(space5);
   main_szr->Add(CreateButtonSizer(wxOK | wxCANCEL), 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   main_szr->AddSpacer(space5);
@@ -41,7 +53,8 @@ void BreakPointDlg::OnOK(wxCommandEvent& event)
   u32 Address = 0;
   if (AsciiToHex(WxStrToStr(AddressString), Address))
   {
-    PowerPC::breakpoints.Add(Address);
+    PowerPC::breakpoints.Add(TBreakPoint{Address, true, false, m_log_checkbox->GetValue(),
+                                         m_break_checkbox->GetValue()});
     EndModal(wxID_OK);
   }
   else

--- a/Source/Core/DolphinWX/Debugger/BreakpointDlg.h
+++ b/Source/Core/DolphinWX/Debugger/BreakpointDlg.h
@@ -6,6 +6,7 @@
 
 #include <wx/dialog.h>
 
+class wxCheckBox;
 class wxTextCtrl;
 
 class BreakPointDlg : public wxDialog
@@ -15,6 +16,8 @@ public:
 
 private:
   wxTextCtrl* m_pEditAddress;
+  wxCheckBox* m_log_checkbox;
+  wxCheckBox* m_break_checkbox;
 
   void OnOK(wxCommandEvent& event);
 };

--- a/Source/Core/DolphinWX/Debugger/BreakpointView.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointView.cpp
@@ -55,6 +55,13 @@ void CBreakPointView::Repopulate()
       std::string address = StringFromFormat("%08x", rBP.address);
       SetItem(item, 3, StrToWxStr(address));
 
+      std::string mode;
+      if (rBP.log_on_hit)
+        mode += 'l';
+      if (rBP.break_on_hit)
+        mode += 'b';
+      SetItem(item, 4, StrToWxStr(mode));
+
       SetItemData(item, rBP.address);
     }
   }
@@ -79,6 +86,10 @@ void CBreakPointView::Repopulate()
     SetItem(item, 3, StrToWxStr(address_range_str));
 
     std::string mode;
+    if (rMemCheck.log_on_hit)
+      mode += 'l';
+    if (rMemCheck.break_on_hit)
+      mode += 'b';
     if (rMemCheck.is_break_on_read)
       mode += 'r';
     if (rMemCheck.is_break_on_write)


### PR DESCRIPTION
Centralise the handling of execution breakpoints in Dolphin and add two
options - 'log' (when enabled, breakpoints emit an info log message in the
'IBM CPU' category) and 'break' (when disabled, the breakpoint will not
stop execution).