### PR TITLE
DSPTool: Fix build

### DIFF
--- a/Source/DSPTool/CMakeLists.txt
+++ b/Source/DSPTool/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(dsptool DSPTool.cpp)
+add_executable(dsptool DSPTool.cpp StubHost.cpp)
 target_link_libraries(dsptool core)
 if(NOT APPLE)
   install(TARGETS dsptool RUNTIME DESTINATION ${bindir})

--- a/Source/DSPTool/DSPTool.vcxproj
+++ b/Source/DSPTool/DSPTool.vcxproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DSPTool.cpp" />
+    <ClCompile Include="StubHost.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -1,0 +1,60 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+// Stub implementation of the Host_* callbacks for DSPTool. These implementations
+// do nothing except return default values when required.
+
+#include <string>
+
+#include "Core/Host.h"
+
+void Host_NotifyMapLoaded()
+{
+}
+void Host_RefreshDSPDebuggerWindow()
+{
+}
+void Host_Message(int)
+{
+}
+void* Host_GetRenderHandle()
+{
+  return nullptr;
+}
+void Host_UpdateTitle(const std::string&)
+{
+}
+void Host_UpdateDisasmDialog()
+{
+}
+void Host_UpdateMainFrame()
+{
+}
+void Host_RequestRenderWindowSize(int, int)
+{
+}
+void Host_SetStartupDebuggingParameters()
+{
+}
+bool Host_UINeedsControllerState()
+{
+  return false;
+}
+bool Host_RendererHasFocus()
+{
+  return false;
+}
+bool Host_RendererIsFullscreen()
+{
+  return false;
+}
+void Host_ShowVideoConfig(void*, const std::string&)
+{
+}
+void Host_YieldToUI()
+{
+}
+void Host_UpdateProgressDialog(const char* caption, int position, int total)
+{
+}


### PR DESCRIPTION
Stub implementations of Host functions are required, as DSPTool links
against Core (which makes use of Host).