### PR TITLE
Misc Qt fixes

### DIFF
--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -29,7 +29,6 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
               QStringLiteral("</p>"));
   text.append(small + tr("Revision: ") + QString::fromUtf8(Common::scm_rev_git_str.c_str()) +
               QStringLiteral("</p>"));
-  text.append(small + tr("Compiled: ") + QStringLiteral(__DATE__ " " __TIME__ "</p>"));
 
   text.append(medium + tr("Check for updates: ") +
               QStringLiteral(
@@ -62,9 +61,8 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
       // in your translation, please use the type of curly quotes that's appropriate for
       // your language. If you aren't sure which type is appropriate, see
       // https://en.wikipedia.org/wiki/Quotation_mark#Specific_language_features
-      new QLabel(tr("\u00A9 2003-%1 Dolphin Team. \u201cGameCube\u201d and \u201cWii\u201d are "
-                    "trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way.")
-                     .arg(QStringLiteral(__DATE__).right(4)));
+      new QLabel(tr("\u00A9 2003-2015+ Dolphin Team. \u201cGameCube\u201d and \u201cWii\u201d are "
+                    "trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way."));
 
   QLabel* logo = new QLabel();
   logo->setPixmap(Resources::GetMisc(Resources::LOGO_LARGE));

--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -16,12 +16,12 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QString text = QStringLiteral("");
-  QString small = QStringLiteral("<p style='margin-top:0px; margin-bottom:0px; font-size:9pt;'>");
-  QString medium = QStringLiteral("<p style='margin-top:15px; font-size:11pt;'>");
+  QString small = QStringLiteral("<p style='margin-top:0; margin-bottom:0; font-size:small;'>");
+  QString medium = QStringLiteral("<p style='margin-top:15px;'>");
 
-  text.append(QStringLiteral("<p style='font-size:50pt; font-weight:400; margin-bottom:0px;'>") +
+  text.append(QStringLiteral("<p style='font-size:38pt; font-weight:400; margin-bottom:0;'>") +
               tr("Dolphin") + QStringLiteral("</p>"));
-  text.append(QStringLiteral("<p style='font-size:18pt; margin-top:0px;'>%1</p>")
+  text.append(QStringLiteral("<p style='font-size:18pt; margin-top:0;'>%1</p>")
                   .arg(QString::fromUtf8(Common::scm_desc_str.c_str())));
 
   text.append(small + tr("Branch: ") + QString::fromUtf8(Common::scm_branch_str.c_str()) +

--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -60,8 +60,10 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
       // in your translation, please use the type of curly quotes that's appropriate for
       // your language. If you aren't sure which type is appropriate, see
       // https://en.wikipedia.org/wiki/Quotation_mark#Specific_language_features
-      new QLabel(tr("\u00A9 2003-2015+ Dolphin Team. \u201cGameCube\u201d and \u201cWii\u201d are "
-                    "trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way."));
+      new QLabel(small +
+                 tr("\u00A9 2003-2015+ Dolphin Team. \u201cGameCube\u201d and \u201cWii\u201d are "
+                    "trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way.") +
+                 QStringLiteral("</p>"));
 
   QLabel* logo = new QLabel();
   logo->setPixmap(Resources::GetMisc(Resources::LOGO_LARGE));

--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -14,7 +14,6 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("About Dolphin"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-  setAttribute(Qt::WA_DeleteOnClose);
 
   QString text = QStringLiteral("");
   QString small = QStringLiteral("<p style='margin-top:0px; margin-bottom:0px; font-size:9pt;'>");

--- a/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
@@ -100,6 +100,7 @@ void AdvancedWidget::CreateWidgets()
   main_layout->addWidget(debugging_box);
   main_layout->addWidget(utility_box);
   main_layout->addWidget(misc_box);
+  main_layout->addStretch();
 
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -113,6 +113,7 @@ void EnhancementsWidget::CreateWidgets()
 
   main_layout->addWidget(enhancements_box);
   main_layout->addWidget(stereoscopy_box);
+  main_layout->addStretch();
 
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -116,6 +116,7 @@ void GeneralWidget::CreateWidgets()
 
   main_layout->addWidget(m_video_box);
   main_layout->addWidget(m_options_box);
+  main_layout->addStretch();
 
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.cpp
@@ -94,6 +94,7 @@ void HacksWidget::CreateWidgets()
   main_layout->addWidget(texture_cache_box);
   main_layout->addWidget(xfb_box);
   main_layout->addWidget(other_box);
+  main_layout->addStretch();
 
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Graphics/SoftwareRendererWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/SoftwareRendererWidget.cpp
@@ -99,6 +99,7 @@ void SoftwareRendererWidget::CreateWidgets()
   main_layout->addWidget(overlay_box);
   main_layout->addWidget(utility_box);
   main_layout->addWidget(object_range_box);
+  main_layout->addStretch();
 
   setLayout(main_layout);
 }

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -74,6 +74,8 @@ void GameList::MakeListView()
   m_list->setCurrentIndex(QModelIndex());
   m_list->setContextMenuPolicy(Qt::CustomContextMenu);
   m_list->setWordWrap(false);
+  m_list->verticalHeader()->setDefaultSectionSize(m_list->verticalHeader()->defaultSectionSize() *
+                                                  1.25);
 
   connect(m_list, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
   connect(m_list->selectionModel(), &QItemSelectionModel::selectionChanged,

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -484,7 +484,8 @@ void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)
       {tr("Platform"), GameListModel::COL_PLATFORM},
       {tr("Size"), GameListModel::COL_SIZE},
       {tr("Title"), GameListModel::COL_TITLE},
-      {tr("State"), GameListModel::COL_RATING}};
+      {tr("State"), GameListModel::COL_RATING},
+      {tr("File Name"), GameListModel::COL_FILE_NAME}};
 
   m_list->setColumnHidden(rowname_to_col_index[row], !visible);
 }

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -101,6 +101,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_FILE_NAME:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
       return game->GetFileName();
+    break;
   case COL_SIZE:
     if (role == Qt::DisplayRole)
       return FormatSize(game->GetFileSize());

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -353,7 +353,7 @@ void MainWindow::Pause()
 void MainWindow::OnStopComplete()
 {
   m_stop_requested = false;
-  m_render_widget->hide();
+  HideRenderWidget();
 
   if (m_exit_requested)
     QGuiApplication::instance()->quit();
@@ -425,7 +425,6 @@ bool MainWindow::RequestStop()
 void MainWindow::ForceStop()
 {
   BootManager::Stop();
-  HideRenderWidget();
 }
 
 void MainWindow::Reset()

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -553,8 +553,8 @@ void MainWindow::ShowAudioWindow()
 
 void MainWindow::ShowAboutDialog()
 {
-  AboutDialog* about = new AboutDialog(this);
-  about->show();
+  AboutDialog about{this};
+  about.exec();
 }
 
 void MainWindow::ShowHotkeyDialog()

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -35,7 +35,6 @@ void ToolBar::OnEmulationStateChanged(Core::State state)
 {
   bool running = state != Core::State::Uninitialized;
   m_stop_action->setEnabled(running);
-  m_stop_action->setVisible(running);
   m_fullscreen_action->setEnabled(running);
   m_screenshot_action->setEnabled(running);
 
@@ -62,7 +61,7 @@ void ToolBar::MakeActions()
   m_controllers_action = AddAction(this, tr("Controllers"), this, &ToolBar::ControllersPressed);
   m_controllers_action->setEnabled(true);
 
-  // Ensure every button has the same width
+  // Ensure every button has about the same width
   std::vector<QWidget*> items;
   for (const auto& action : {m_open_action, m_play_action, m_pause_action, m_stop_action,
                              m_stop_action, m_fullscreen_action, m_screenshot_action,

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -75,7 +75,7 @@ void ToolBar::MakeActions()
   std::transform(items.begin(), items.end(), std::back_inserter(widths),
                  [](QWidget* item) { return item->sizeHint().width(); });
 
-  const int min_width = *std::max_element(widths.begin(), widths.end());
+  const int min_width = *std::max_element(widths.begin(), widths.end()) * 0.85;
   for (QWidget* widget : items)
     widget->setMinimumWidth(min_width);
 }

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <vector>
+
 #include <QIcon>
 
 #include "Core/Core.h"
@@ -45,36 +48,36 @@ void ToolBar::OnEmulationStateChanged(Core::State state)
 
 void ToolBar::MakeActions()
 {
-  constexpr int button_width = 65;
   m_open_action = AddAction(this, tr("Open"), this, &ToolBar::OpenPressed);
-  widgetForAction(m_open_action)->setMinimumWidth(button_width);
-
   m_play_action = AddAction(this, tr("Play"), this, &ToolBar::PlayPressed);
-  widgetForAction(m_play_action)->setMinimumWidth(button_width);
-
   m_pause_action = AddAction(this, tr("Pause"), this, &ToolBar::PausePressed);
-  widgetForAction(m_pause_action)->setMinimumWidth(button_width);
-
   m_stop_action = AddAction(this, tr("Stop"), this, &ToolBar::StopPressed);
-  widgetForAction(m_stop_action)->setMinimumWidth(button_width);
-
   m_fullscreen_action = AddAction(this, tr("FullScr"), this, &ToolBar::FullScreenPressed);
-  widgetForAction(m_fullscreen_action)->setMinimumWidth(button_width);
-
   m_screenshot_action = AddAction(this, tr("ScrShot"), this, &ToolBar::ScreenShotPressed);
-  widgetForAction(m_screenshot_action)->setMinimumWidth(button_width);
 
   addSeparator();
 
   m_config_action = AddAction(this, tr("Config"), this, &ToolBar::SettingsPressed);
-  widgetForAction(m_config_action)->setMinimumWidth(button_width);
-
   m_graphics_action = AddAction(this, tr("Graphics"), this, &ToolBar::GraphicsPressed);
-  widgetForAction(m_graphics_action)->setMinimumWidth(button_width);
-
   m_controllers_action = AddAction(this, tr("Controllers"), this, &ToolBar::ControllersPressed);
-  widgetForAction(m_controllers_action)->setMinimumWidth(button_width);
   m_controllers_action->setEnabled(true);
+
+  // Ensure every button has the same width
+  std::vector<QWidget*> items;
+  for (const auto& action : {m_open_action, m_play_action, m_pause_action, m_stop_action,
+                             m_stop_action, m_fullscreen_action, m_screenshot_action,
+                             m_config_action, m_graphics_action, m_controllers_action})
+  {
+    items.emplace_back(widgetForAction(action));
+  }
+
+  std::vector<int> widths;
+  std::transform(items.begin(), items.end(), std::back_inserter(widths),
+                 [](QWidget* item) { return item->sizeHint().width(); });
+
+  const int min_width = *std::max_element(widths.begin(), widths.end());
+  for (QWidget* widget : items)
+    widget->setMinimumWidth(min_width);
 }
 
 void ToolBar::UpdateIcons()


### PR DESCRIPTION
Small fixes to DolphinQt2 to improve the UI and fix some issues with the code.
 
**About dialog**

* Remove usages of `__DATE__` to make builds reproducible. See also #3259.
* Simplify AboutDialog creation.
* Fix small issues with the HTML/CSS.
* Make the dialog look more similar to WX in general.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/4209061/30445379-0ef25b4a-9986-11e7-9e74-0e741fd587a1.png) | <img src="https://user-images.githubusercontent.com/4209061/30444737-35b8df62-9984-11e7-9ad5-4a4411971d97.png" /> |

_Note_: the links having the wrong colour is because of Qt not having proper GTK theming for links.

**Configuration**

* Fix inconsistent spacing in the Graphics configuration window.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/4209061/30445419-2d80a1de-9986-11e7-9a01-c2656a8c5515.png) | ![image](https://user-images.githubusercontent.com/4209061/30445098-4da9a13c-9985-11e7-8249-317ce75181a3.png) |
| ![image](https://user-images.githubusercontent.com/4209061/30445432-37c1c880-9986-11e7-9382-d10b52da40ce.png) | ![image](https://user-images.githubusercontent.com/4209061/30445111-584cf008-9985-11e7-96ab-ce8c94202d22.png) |

The dialog can still get improved (it's way too tall in my opinion), but this fixes the most jarring issue with it.

**Game list and main window**

* Fix the File Name column being broken.
* Increase the height of game list items.  This makes the images in the game list look less weird (since they are not squashed together anymore). The list also looks more like WX now.
* Makes the toolbar look more comfortable instead of all squished together, and more similar to our current look.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/4209061/30445497-692f09c8-9986-11e7-8574-e2eab2667ab7.png) | ![image](https://user-images.githubusercontent.com/4209061/30445267-bfb1bbe8-9985-11e7-87e9-fc74eb9266ff.png) |
