### PR TITLE
FifoRecorder: remove use of volatile

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -63,6 +63,11 @@ void FifoRecorder::StopRecording()
   m_RequestedRecordingEnd = true;
 }
 
+FifoDataFile* FifoRecorder::GetRecordedFile() const
+{
+  return m_File.get();
+}
+
 void FifoRecorder::WriteGPCommand(const u8* data, u32 size)
 {
   if (!m_SkipNextData)
@@ -203,6 +208,11 @@ void FifoRecorder::SetVideoMemory(const u32* bpMem, const u32* cpMem, const u32*
   }
 
   FifoRecordAnalyzer::Initialize(cpMem);
+}
+
+bool FifoRecorder::IsRecording() const
+{
+  return m_IsRecording;
 }
 
 FifoRecorder& FifoRecorder::GetInstance()

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.h
@@ -20,7 +20,7 @@ public:
   void StartRecording(s32 numFrames, CallbackFunc finishedCb);
   void StopRecording();
 
-  FifoDataFile* GetRecordedFile() const { return m_File.get(); }
+  FifoDataFile* GetRecordedFile() const;
   // Called from video thread
 
   // Must write one full GP command at a time
@@ -41,7 +41,7 @@ public:
                       u32 xfRegsSize, const u8* texMem);
 
   // Checked once per frame prior to callng EndFrame()
-  bool IsRecording() const { return m_IsRecording; }
+  bool IsRecording() const;
   static FifoRecorder& GetInstance();
 
 private:

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+#include <mutex>
 #include <vector>
 
 #include "Core/FifoPlayer/FifoDataFile.h"
@@ -14,12 +16,11 @@ public:
   typedef void (*CallbackFunc)(void);
 
   FifoRecorder();
-  ~FifoRecorder();
 
   void StartRecording(s32 numFrames, CallbackFunc finishedCb);
   void StopRecording();
 
-  FifoDataFile* GetRecordedFile() const { return m_File; }
+  FifoDataFile* GetRecordedFile() const { return m_File.get(); }
   // Called from video thread
 
   // Must write one full GP command at a time
@@ -46,15 +47,15 @@ public:
 private:
   // Accessed from both GUI and video threads
 
+  std::recursive_mutex m_mutex;
   // True if video thread should send data
-  volatile bool m_IsRecording = false;
+  bool m_IsRecording = false;
   // True if m_IsRecording was true during last frame
-  volatile bool m_WasRecording = false;
-  volatile bool m_RequestedRecordingEnd = false;
-  volatile s32 m_RecordFramesRemaining = 0;
-  volatile CallbackFunc m_FinishedCb = nullptr;
-
-  FifoDataFile* volatile m_File = nullptr;
+  bool m_WasRecording = false;
+  bool m_RequestedRecordingEnd = false;
+  s32 m_RecordFramesRemaining = 0;
+  CallbackFunc m_FinishedCb = nullptr;
+  std::unique_ptr<FifoDataFile> m_File;
 
   // Accessed only from video thread
 


### PR DESCRIPTION
It already took a mutex lock for almost all multithreaded accesses, so this just removes `volatile` and adds a lock to the one access without it. Plus a little cleanup.