### PR TITLE
Settings: register the Core::State type with Qt

### DIFF
--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -18,6 +18,7 @@
 
 Settings::Settings()
 {
+  qRegisterMetaType<Core::State>();
   Core::SetOnStateChangedCallback(
       [this](Core::State new_state) { emit EmulationStateChanged(new_state); });
 }

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -96,3 +96,5 @@ private:
   std::unique_ptr<NetPlayServer> m_server;
   Settings();
 };
+
+Q_DECLARE_METATYPE(Core::State);


### PR DESCRIPTION
Makes the `EmulationStateChanged` signal work. Womp.