### PR TITLE
DolphinQt2: Check for file systems being nullptr

### DIFF
--- a/Source/Core/DolphinQt2/Config/FilesystemWidget.h
+++ b/Source/Core/DolphinQt2/Config/FilesystemWidget.h
@@ -30,6 +30,7 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
   void PopulateView();
+  void PopulateDirectory(int partition_id, QStandardItem* root, const DiscIO::Partition& partition);
   void PopulateDirectory(int partition_id, QStandardItem* root, const DiscIO::FileInfo& directory);
 
   void ShowContextMenu(const QPoint&);


### PR DESCRIPTION
nullptr gets returned for file systems that are deemed invalid.