### PR TITLE
VolumeGC: Add a default constructor for ConvertedGCBanner

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -277,4 +277,6 @@ VolumeGC::ConvertedGCBanner VolumeGC::ExtractBannerInformation(const GCBanner& b
   return banner;
 }
 
+VolumeGC::ConvertedGCBanner::ConvertedGCBanner() = default;
+VolumeGC::ConvertedGCBanner::~ConvertedGCBanner() = default;
 }  // namespace

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -81,6 +81,9 @@ private:
 
   struct ConvertedGCBanner
   {
+    ConvertedGCBanner();
+    ~ConvertedGCBanner();
+
     std::map<Language, std::string> short_names;
     std::map<Language, std::string> long_names;
     std::map<Language, std::string> short_makers;


### PR DESCRIPTION
Without this, it fails to build with the following error in g++ 7.2.0:

> constructor required before non-static data member has been parsed

Keeping the constructor/destructor implementation out of the header is probably a good idea anyway to avoid recompilation in case we ever need to change the constructor.