### PR TITLE
Vulkan: Fixes for window resizing

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -353,8 +353,13 @@ void CommandBufferManager::SubmitCommandBuffer(size_t index, VkSemaphore wait_se
                                      nullptr};
 
     res = vkQueuePresentKHR(g_vulkan_context->GetPresentQueue(), &present_info);
-    if (res != VK_SUCCESS && res != VK_ERROR_OUT_OF_DATE_KHR && res != VK_SUBOPTIMAL_KHR)
-      LOG_VULKAN_ERROR(res, "vkQueuePresentKHR failed: ");
+    if (res != VK_SUCCESS)
+    {
+      // VK_ERROR_OUT_OF_DATE_KHR is not fatal, just means we need to recreate our swap chain.
+      if (res != VK_ERROR_OUT_OF_DATE_KHR && res != VK_SUBOPTIMAL_KHR)
+        LOG_VULKAN_ERROR(res, "vkQueuePresentKHR failed: ");
+      m_present_failed_flag.Set();
+    }
   }
 
   // Command buffer has been queued, so permit the next one.

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "Common/BlockingLoop.h"
+#include "Common/Flag.h"
 #include "Common/Semaphore.h"
 
 #include "VideoCommon/VideoCommon.h"
@@ -78,6 +79,8 @@ public:
 
   void ExecuteCommandBuffer(bool submit_off_thread, bool wait_for_completion);
 
+  // Was the last present submitted to the queue a failure? If so, we must recreate our swapchain.
+  bool DidLastPresentFail() { return m_present_failed_flag.TestAndClear(); }
   // Schedule a vulkan resource for destruction later on. This will occur when the command buffer
   // is next re-used, and the GPU has finished working with the specified resource.
   void DeferBufferDestruction(VkBuffer object);
@@ -144,6 +147,7 @@ private:
   };
   std::deque<PendingCommandBufferSubmit> m_pending_submits;
   std::mutex m_pending_submit_lock;
+  Common::Flag m_present_failed_flag;
   bool m_use_threaded_submission = false;
 };
 

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -80,7 +80,7 @@ public:
   void ExecuteCommandBuffer(bool submit_off_thread, bool wait_for_completion);
 
   // Was the last present submitted to the queue a failure? If so, we must recreate our swapchain.
-  bool DidLastPresentFail() { return m_present_failed_flag.TestAndClear(); }
+  bool CheckLastPresentFail() { return m_present_failed_flag.TestAndClear(); }
   // Schedule a vulkan resource for destruction later on. This will occur when the command buffer
   // is next re-used, and the GPU has finished working with the specified resource.
   void DeferBufferDestruction(VkBuffer object);

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -325,10 +325,6 @@ void Renderer::BeginFrame()
   // Activate a new command list, and restore state ready for the next draw
   g_command_buffer_mgr->ActivateCommandBuffer();
 
-  // Restore the EFB color texture to color attachment ready for rendering the next frame.
-  FramebufferManager::GetInstance()->GetEFBColorTexture()->TransitionToLayout(
-      g_command_buffer_mgr->GetCurrentCommandBuffer(), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-
   // Ensure that the state tracker rebinds everything, and allocates a new set
   // of descriptors out of the next pool.
   StateTracker::GetInstance()->InvalidateDescriptorSets();
@@ -575,6 +571,10 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
   // Prep for the next frame (get command buffer ready) before doing anything else.
   BeginFrame();
 
+  // Restore the EFB color texture to color attachment ready for rendering the next frame.
+  FramebufferManager::GetInstance()->GetEFBColorTexture()->TransitionToLayout(
+      g_command_buffer_mgr->GetCurrentCommandBuffer(), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
   // Determine what (if anything) has changed in the config.
   CheckForConfigChanges();
 
@@ -730,6 +730,7 @@ void Renderer::DrawScreen(const TargetRectangle& scaled_efb_rect, u32 xfb_addr,
     // PrepareToSubmitCommandBuffer to return to the state that the caller expects.
     g_command_buffer_mgr->SubmitCommandBuffer(false);
     ResizeSwapChain();
+    BeginFrame();
     g_command_buffer_mgr->PrepareToSubmitCommandBuffer();
     res = m_swap_chain->AcquireNextImage(m_image_available_semaphore);
   }

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -718,8 +718,18 @@ void Renderer::DrawScreen(const TargetRectangle& scaled_efb_rect, u32 xfb_addr,
                           const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                           u32 fb_stride, u32 fb_height)
 {
-  // Grab the next image from the swap chain in preparation for drawing the window.
-  VkResult res = m_swap_chain->AcquireNextImage(m_image_available_semaphore);
+  VkResult res;
+  if (!g_command_buffer_mgr->DidLastPresentFail())
+  {
+    // Grab the next image from the swap chain in preparation for drawing the window.
+    res = m_swap_chain->AcquireNextImage(m_image_available_semaphore);
+  }
+  else
+  {
+    // If the last present failed, we need to recreate the swap chain.
+    res = VK_ERROR_OUT_OF_DATE_KHR;
+  }
+
   if (res == VK_SUBOPTIMAL_KHR || res == VK_ERROR_OUT_OF_DATE_KHR)
   {
     // There's an issue here. We can't resize the swap chain while the GPU is still busy with it,

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -81,7 +81,6 @@ private:
   void OnSwapChainResized();
   void BindEFBToStateTracker();
   void ResizeEFBTextures();
-  void ResizeSwapChain();
 
   void RecompileShaders();
   bool CompileShaders();

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -472,14 +472,27 @@ bool SwapChain::ResizeSwapChain()
   return true;
 }
 
+bool SwapChain::RecreateSwapChain()
+{
+  DestroySwapChainImages();
+  DestroySwapChain();
+  if (!CreateSwapChain() || !SetupSwapChainImages())
+  {
+    PanicAlert("Failed to re-configure swap chain images, this is fatal (for now)");
+    return false;
+  }
+
+  return true;
+}
+
 bool SwapChain::SetVSync(bool enabled)
 {
   if (m_vsync_enabled == enabled)
     return true;
 
-  // Resizing recreates the swap chain with the new present mode.
+  // Recreate the swap chain with the new present mode.
   m_vsync_enabled = enabled;
-  return ResizeSwapChain();
+  return RecreateSwapChain();
 }
 
 bool SwapChain::RecreateSurface(void* native_handle)

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.h
@@ -55,6 +55,7 @@ public:
 
   bool RecreateSurface(void* native_handle);
   bool ResizeSwapChain();
+  bool RecreateSwapChain();
 
   // Change vsync enabled state. This may fail as it causes a swapchain recreation.
   bool SetVSync(bool enabled);


### PR DESCRIPTION
Seems we are a little buggy on the latest NV dev driver in this regard. Few changes here that stop the window getting "stuck" and not rendering here. This included toggling vsync as well.

**Set a flag to resize the swap chain when presenting fails:** 
Drivers can return VK_ERROR_OUT_OF_DATE_KHR from vkQueuePresentKHR, and we should resize the image in this case, as well as when getting it back from vkAcquireNextImageKHR.

**Only use oldSwapchain in response to VK_ERROR_OUT_OF_DATE_KHR:**
Seems to be required on the latest NV driver, otherwise the presented images are never shown.