### PR TITLE
Vulkan: Use reversed depth range in viewport

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -186,7 +186,6 @@ bool TextureCache::CompileShaders()
   std::string source = header + COPY_SHADER_SOURCE;
 
   m_copy_shader = Util::CompileAndCreateFragmentShader(source);
-
   return m_copy_shader != VK_NULL_HANDLE;
 }
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -296,6 +296,11 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   // Seems to be fine on GCN Gen 1-2, unconfirmed on GCN Gen 3, causes driver resets on GCN Gen 4.
   if (DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART))
     config->backend_info.bSupportsPrimitiveRestart = false;
+
+  // Reversed depth range is broken on some drivers, or is broken when used in combination
+  // with depth clamping. Fall back to inverted depth range for these.
+  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_REVERSED_DEPTH_RANGE))
+    config->backend_info.bSupportsReversedDepthRange = false;
 }
 
 void VulkanContext::PopulateBackendInfoMultisampleModes(

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -233,6 +233,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsComputeShaders = true;        // Assumed support.
   config->backend_info.bSupportsGPUTextureDecoding = true;    // Assumed support.
   config->backend_info.bSupportsBitfield = true;              // Assumed support.
+  config->backend_info.bSupportsReversedDepthRange = true;    // Assumed support.
   config->backend_info.bSupportsDynamicSamplerIndexing = true;     // Assumed support.
   config->backend_info.bSupportsPostProcessing = true;             // Assumed support.
   config->backend_info.bSupportsBackgroundCompiling = true;        // Assumed support.
@@ -245,9 +246,8 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsDepthClamp = false;                // Dependent on features.
   config->backend_info.bSupportsST3CTextures = false;              // Dependent on features.
   config->backend_info.bSupportsBPTCTextures = false;              // Dependent on features.
-  config->backend_info.bSupportsReversedDepthRange = false;  // No support yet due to driver bugs.
-  config->backend_info.bSupportsLogicOp = false;             // Dependent on features.
-  config->backend_info.bSupportsCopyToVram = true;           // Assumed support.
+  config->backend_info.bSupportsLogicOp = false;                   // Dependent on features.
+  config->backend_info.bSupportsCopyToVram = true;                 // Assumed support.
   config->backend_info.bSupportsFramebufferFetch = false;
 }
 
@@ -838,4 +838,4 @@ void VulkanContext::InitDriverDetails()
                       static_cast<double>(m_device_properties.driverVersion),
                       DriverDetails::Family::UNKNOWN);
 }
-}
+}  // namespace Vulkan

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -109,6 +109,8 @@ static BugInfo m_known_bugs[] = {
     {API_VULKAN, OS_ALL, VENDOR_IMGTEC, DRIVER_IMGTEC, Family::UNKNOWN,
      BUG_BROKEN_CLEAR_LOADOP_RENDERPASS, -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN, BUG_BROKEN_D32F_CLEAR,
+     -1.0, -1.0, true},
+    {API_VULKAN, OS_ALL, VENDOR_MESA, DRIVER_I965, Family::UNKNOWN, BUG_BROKEN_REVERSED_DEPTH_RANGE,
      -1.0, -1.0, true}};
 
 static std::map<Bug, BugInfo> m_bugs;
@@ -168,4 +170,4 @@ bool HasBug(Bug bug)
     return false;
   return it->second.m_hasbug;
 }
-}
+}  // namespace DriverDetails

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -276,6 +276,11 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_D32F_CLEAR,
+
+  // BUG: Reversed viewport depth range does not work as intended on some Vulkan drivers.
+  // The Vulkan spec allows the minDepth/maxDepth fields in the viewport to be reversed,
+  // however the implementation is broken on some drivers.
+  BUG_BROKEN_REVERSED_DEPTH_RANGE,
 };
 
 // Initializes our internal vendor, device family, and driver version
@@ -284,4 +289,4 @@ void Init(API api, Vendor vendor, Driver driver, const double version, const Fam
 // Once Vendor and driver version is set, this will return if it has the applicable bug passed to
 // it.
 bool HasBug(Bug bug);
-}
+}  // namespace DriverDetails

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -792,7 +792,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
   }
   else
   {
-    if (ApiType == APIType::D3D || ApiType == APIType::Vulkan)
+    if (!host_config.backend_reversed_depth_range)
       out.Write("\tint zCoord = int((1.0 - rawpos.z) * 16777216.0);\n");
     else
       out.Write("\tint zCoord = int(rawpos.z * 16777216.0);\n");
@@ -806,7 +806,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
   // Note: z-textures are not written to depth buffer if early depth test is used
   if (uid_data->per_pixel_depth && uid_data->early_ztest)
   {
-    if (ApiType == APIType::D3D || ApiType == APIType::Vulkan)
+    if (!host_config.backend_reversed_depth_range)
       out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
     else
       out.Write("\tdepth = float(zCoord) / 16777216.0;\n");
@@ -827,7 +827,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
 
   if (uid_data->per_pixel_depth && uid_data->late_ztest)
   {
-    if (ApiType == APIType::D3D || ApiType == APIType::Vulkan)
+    if (!host_config.backend_reversed_depth_range)
       out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
     else
       out.Write("\tdepth = float(zCoord) / 16777216.0;\n");
@@ -1296,7 +1296,7 @@ static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_dat
   if (per_pixel_depth)
   {
     out.Write("\t\tdepth = %s;\n",
-              (ApiType == APIType::D3D || ApiType == APIType::Vulkan) ? "0.0" : "1.0");
+              !g_ActiveConfig.backend_info.bSupportsReversedDepthRange ? "0.0" : "1.0");
   }
 
   // ZCOMPLOC HACK:

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -16,6 +16,7 @@
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VideoConfig.h"
 
 #define WRITE p += sprintf
 
@@ -147,7 +148,7 @@ static void WriteSampleFunction(char*& p, const EFBCopyParams& params, APIType A
     else
     {
       // Handle D3D depth inversion.
-      if (ApiType == APIType::D3D || ApiType == APIType::Vulkan)
+      if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange)
         WRITE(p, "1.0 - (");
       else
         WRITE(p, "(");

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -112,7 +112,7 @@ ShaderCode GenerateShader(APIType api_type, const UidData* uid_data)
 
   if (uid_data->is_depth_copy)
   {
-    if (api_type == APIType::D3D || api_type == APIType::Vulkan)
+    if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange)
       out.Write("texcol.x = 1.0 - texcol.x;\n");
 
     out.Write("  int depth = int(texcol.x * 16777216.0);\n"

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -1046,7 +1046,7 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
 
   if (host_config.fast_depth_calc)
   {
-    if (ApiType == APIType::D3D || ApiType == APIType::Vulkan)
+    if (!host_config.backend_reversed_depth_range)
       out.Write("  int zCoord = int((1.0 - rawpos.z) * 16777216.0);\n");
     else
       out.Write("  int zCoord = int(rawpos.z * 16777216.0);\n");
@@ -1101,7 +1101,7 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
     out.Write("  // If early depth is enabled, write to zbuffer before depth textures\n");
     out.Write("  // If early depth isn't enabled, we write to the zbuffer here\n");
     out.Write("  int zbuffer_zCoord = bpmem_late_ztest ? zCoord : early_zCoord;\n");
-    if (ApiType == APIType::D3D || ApiType == APIType::Vulkan)
+    if (!host_config.backend_reversed_depth_range)
       out.Write("  depth = 1.0 - float(zbuffer_zCoord) / 16777216.0;\n");
     else
       out.Write("  depth = float(zbuffer_zCoord) / 16777216.0;\n");
@@ -1414,4 +1414,4 @@ void EnumeratePixelShaderUids(const std::function<void(const PixelShaderUid&)>& 
     }
   }
 }
-}
+}  // namespace UberShader


### PR DESCRIPTION
Matches OpenGL behavior and accuracy, fixes a few of these bugs. Still seems to be an issue rendering Gecko OS that I need to look into.

**We need to verify that this works correctly on all drivers before merging.**

I've tested the latest NV dev driver, 383.12, and it's fine here. But we should check older versions, AMD, and Intel, and add DriverDetails bugs if it does not work there.