### PR TITLE
InputConfigDiag: Fix building DolphinWX on the latest MSVC

### DIFF
--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -348,13 +348,14 @@ void ControlDialog::UpdateGUI()
     m_error_label->SetLabel(_("Syntax error"));
     break;
   case ParseStatus::Successful:
-    m_error_label->SetLabel(control_reference->BoundCount() > 0 ? "" : _("Device not found"));
+    m_error_label->SetLabel(control_reference->BoundCount() > 0 ? wxString{} :
+                                                                  _("Device not found"));
     break;
   case ParseStatus::EmptyExpression:
     m_error_label->SetLabel("");
     break;
   }
-};
+}
 
 void InputConfigDialog::UpdateGUI()
 {


### PR DESCRIPTION
`const char[1]` and `wxString` can both be converted to multiple common types, so this results in an ambiguous conditional expression compilation error (C2445).

I dunno if the buildbot is using a slightly older version of MSVC or something, but this happens for me with compiler version 19.11.25506 (in VS 2017 version 15.3.1)