### PR TITLE
Fix NetPlay settings reset issue

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -226,25 +226,27 @@ std::string StripQuotes(const std::string& s)
     return s;
 }
 
+bool TryParse(const std::string& str, u16* const output)
+{
+  u64 value;
+  if (!TryParse(str, &value))
+    return false;
+
+  if (value >= 0x10000ull && value <= 0xFFFFFFFFFFFF0000ull)
+    return false;
+
+  *output = static_cast<u16>(value);
+  return true;
+}
+
 bool TryParse(const std::string& str, u32* const output)
 {
-  char* endptr = nullptr;
-
-  // Reset errno to a value other than ERANGE
-  errno = 0;
-
-  unsigned long value = strtoul(str.c_str(), &endptr, 0);
-
-  if (!endptr || *endptr)
+  u64 value;
+  if (!TryParse(str, &value))
     return false;
 
-  if (errno == ERANGE)
-    return false;
-
-#if ULONG_MAX > UINT_MAX
   if (value >= 0x100000000ull && value <= 0xFFFFFFFF00000000ull)
     return false;
-#endif
 
   *output = static_cast<u32>(value);
   return true;

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -59,6 +59,7 @@ std::string ThousandSeparate(I value, int spaces = 0)
 std::string StringFromBool(bool value);
 
 bool TryParse(const std::string& str, bool* output);
+bool TryParse(const std::string& str, u16* output);
 bool TryParse(const std::string& str, u32* output);
 bool TryParse(const std::string& str, u64* output);
 


### PR DESCRIPTION
Since TryParse wasn't implemented for u16 values, it was falling back to the istringstream implementation which doesn't support hex. This caused readback issues since all u16 are written to config as hex (questionable choice imo...).