### PR TITLE
Qt: bold graphics settings on ConfigChanged, not EmulationStateChanged

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsBool.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsBool.cpp
@@ -16,7 +16,7 @@ GraphicsBool::GraphicsBool(const QString& label, const Config::ConfigInfo<bool>&
   connect(this, &QCheckBox::toggled, this, &GraphicsBool::Update);
   setChecked(Config::Get(m_setting) ^ reverse);
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, [this]() {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsChoice.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsChoice.cpp
@@ -15,7 +15,7 @@ GraphicsChoice::GraphicsChoice(const QStringList& options, const Config::ConfigI
           &GraphicsChoice::Update);
   setCurrentIndex(Config::Get(m_setting));
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, [this]() {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsSlider.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsSlider.cpp
@@ -19,7 +19,7 @@ GraphicsSlider::GraphicsSlider(int minimum, int maximum, const Config::ConfigInf
 
   connect(this, &GraphicsSlider::valueChanged, this, &GraphicsSlider::Update);
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, [this]() {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -7,12 +7,14 @@
 #include <QSize>
 
 #include "AudioCommon/AudioCommon.h"
+#include "Common/Config/Config.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DolphinQt2/GameList/GameListModel.h"
+#include "DolphinQt2/QtUtils/QueueOnObject.h"
 #include "DolphinQt2/Settings.h"
 #include "InputCommon/InputConfig.h"
 
@@ -21,6 +23,9 @@ Settings::Settings()
   qRegisterMetaType<Core::State>();
   Core::SetOnStateChangedCallback(
       [this](Core::State new_state) { emit EmulationStateChanged(new_state); });
+
+  Config::AddConfigChangedCallback(
+      [this] { QueueOnObject(this, [this] { emit ConfigChanged(); }); });
 }
 
 Settings& Settings::Instance()

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -81,6 +81,7 @@ public:
   GameListModel* GetGameListModel() const;
 
 signals:
+  void ConfigChanged();
   void EmulationStateChanged(Core::State new_state);
   void ThemeChanged();
   void PathAdded(const QString&);


### PR DESCRIPTION
EmulationStateChanged is functionally correct right now, but ConfigChanged expresses more semantically why the config setting gets re-read and the widgets updated.