### PR TITLE
Update Contributing.md to warn Windows users about line endings

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -28,6 +28,8 @@ This project uses clang-format (stable branch) to check for common style issues.
 
 ## <a name="intro-formatting-issues"></a>Checking and fixing formatting issues
 
+Windows users need to be careful about line endings. Windows users should configure git to checkout UNIX-style line endings to keep clang-format simple.
+
 In most cases, clang-format can and **should** be used to automatically reformat code and solve most formatting issues.
 
 - To run clang-format on all staged files:


### PR DESCRIPTION
~~lint punched me in the face twice because it had 3.8 installed and I had 5.0~~

just kidding. This is a PR to warn Windows users about line endings.