### PR TITLE
Android: Adjust position of floating action button

### DIFF
--- a/Source/Android/app/src/main/res/layout/activity_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_main.xml
@@ -38,7 +38,7 @@
         android:id="@+id/button_add_directory"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        android:layout_margin="32dp"
+        android:layout_margin="16dp"
         android:src="@drawable/ic_add"
         app:borderWidth="0dp"
         app:rippleColor="?android:colorPrimaryDark"


### PR DESCRIPTION
I cherry-picked this from PR #5281 because it was requested by https://forums.dolphin-emu.org/Thread-misplaced-floating-action-button

Before:
![screenshot_20170921-154608](https://user-images.githubusercontent.com/6716818/30699401-ec2dc950-9ee4-11e7-9ca7-b7eff7ebeb48.png)

After:
![screenshot_20170921-155027](https://user-images.githubusercontent.com/6716818/30699408-f0a3598c-9ee4-11e7-8711-89fff5f59cd3.png)