### PR TITLE
IOS: Assume ticket is unpersonalised for WAD imports

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -106,7 +106,15 @@ public:
   s32 SeekContent(u32 cfd, u32 offset, SeekMode mode, u32 uid);
 
   // Title management
-  ReturnCode ImportTicket(const std::vector<u8>& ticket_bytes, const std::vector<u8>& cert_chain);
+  enum class TicketImportType
+  {
+    // Ticket may be personalised, so use console specific data for decryption if needed.
+    PossiblyPersonalised,
+    // Ticket is unpersonalised, so ignore any console specific decryption data.
+    Unpersonalised,
+  };
+  ReturnCode ImportTicket(const std::vector<u8>& ticket_bytes, const std::vector<u8>& cert_chain,
+                          TicketImportType type = TicketImportType::PossiblyPersonalised);
   ReturnCode ImportTmd(Context& context, const std::vector<u8>& tmd_bytes);
   ReturnCode ImportTitleInit(Context& context, const std::vector<u8>& tmd_bytes,
                              const std::vector<u8>& cert_chain);

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -56,7 +56,8 @@ void ES::TitleImportExportContext::DoState(PointerWrap& p)
   p.Do(content.buffer);
 }
 
-ReturnCode ES::ImportTicket(const std::vector<u8>& ticket_bytes, const std::vector<u8>& cert_chain)
+ReturnCode ES::ImportTicket(const std::vector<u8>& ticket_bytes, const std::vector<u8>& cert_chain,
+                            TicketImportType type)
 {
   IOS::ES::TicketReader ticket{ticket_bytes};
   if (!ticket.IsValid())
@@ -64,7 +65,7 @@ ReturnCode ES::ImportTicket(const std::vector<u8>& ticket_bytes, const std::vect
 
   const u32 ticket_device_id = ticket.GetDeviceId();
   const u32 device_id = EcWii::GetInstance().GetNGID();
-  if (ticket_device_id != 0)
+  if (type == TicketImportType::PossiblyPersonalised && ticket_device_id != 0)
   {
     if (device_id != ticket_device_id)
     {

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -65,7 +65,8 @@ static bool InstallWAD(IOS::HLE::Kernel& ios, const DiscIO::WiiWAD& wad)
   // Ensure the common key index is correct, as it's checked by IOS.
   ticket.FixCommonKeyIndex();
 
-  while ((ret = es->ImportTicket(ticket.GetBytes(), wad.GetCertificateChain())) < 0 ||
+  while ((ret = es->ImportTicket(ticket.GetBytes(), wad.GetCertificateChain(),
+                                 IOS::HLE::Device::ES::TicketImportType::Unpersonalised)) < 0 ||
          (ret = es->ImportTitleInit(context, tmd.GetBytes(), wad.GetCertificateChain())) < 0)
   {
     if (checks_enabled && ret == IOS::HLE::IOSC_FAIL_CHECKVALUE &&


### PR DESCRIPTION
The newer title dumpers don't clobber tickets anymore (that's good!),
which means personalised tickets still have the console specific data
used to decrypt the title key in them. Dolphin should ignore that data
when importing WADs, because the title key has already been decrypted,
and we must not try to decrypt it *again*.