### PR TITLE
CMake: don't use -std=c++1z

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -20,12 +20,9 @@ else()
   # CMAKE_CXX_STANDARD cannot be used here because we require C++14 or newer, not any standard.
   check_and_add_flag(CXX17 -std=c++17)
   if(NOT FLAG_CXX_CXX17)
-    check_and_add_flag(CXX1Z -std=c++1z)
-    if (NOT FLAG_CXX_CXX1Z)
-      set(CMAKE_CXX_STANDARD 14)
-      set(CMAKE_CXX_STANDARD_REQUIRED ON)
-      set(CMAKE_CXX_EXTENSIONS OFF)
-    endif()
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
   endif()
 
   # These compat headers must not be in the include path when building with MSVC,


### PR DESCRIPTION
Some toolchains provide enough of C++17 to conflict with Dolphin's included backport of `std::variant` and `std::optional`. Specifically, the recently-released macOS 10.13 SDK does not provide the `<optional>` or `<variant>` headers, but does provide `in_place_t` in the `<utility>` header.