### PR TITLE
MemArena: Name shared memory handle

### DIFF
--- a/Source/Core/Common/MemArena.cpp
+++ b/Source/Core/Common/MemArena.cpp
@@ -55,8 +55,8 @@ static int AshmemCreateFileMapping(const char* name, size_t size)
 void MemArena::GrabSHMSegment(size_t size)
 {
 #ifdef _WIN32
-  hMemoryMapping =
-      CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, (DWORD)(size), nullptr);
+  hMemoryMapping = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0,
+                                     static_cast<DWORD>(size), L"Dolphin-emu");
 #elif defined(ANDROID)
   fd = AshmemCreateFileMapping("Dolphin-emu", size);
   if (fd < 0)


### PR DESCRIPTION
Assign a name to the CreateFileMapping handle on Win32 so third party applications can read from Dolphin's memory and integrate with the current emulation.

Multiple sessions are still possible without collisions. 



