### PR TITLE
VideoCommon: Fix overflow trying to access outside of EFB bounds

### DIFF
--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -67,7 +67,7 @@ void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, 
 
 u32 VideoBackendBase::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
 {
-  if (!g_ActiveConfig.bEFBAccessEnable)
+  if (!g_ActiveConfig.bEFBAccessEnable || x >= EFB_WIDTH || y >= EFB_HEIGHT)
   {
     return 0;
   }


### PR DESCRIPTION
Unsure if this is the correct fix (not tested on hardware) but attempting to peek/poke outside of the bounds of the EFB will cause invalid reads and crash in Dolphin.