### PR TITLE
WX: Reshow cursor after game termination (issue 10503)

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -711,7 +711,6 @@ void CFrame::StartGame(std::unique_ptr<BootParameters> boot)
     // To capture key events on Linux and Mac OS X the frame needs at least one child.
     m_render_parent = new wxPanel(m_render_frame, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
 #endif
-
     m_render_frame->Show();
   }
 
@@ -760,6 +759,8 @@ void CFrame::StartGame(std::unique_ptr<BootParameters> boot)
     wxTheApp->Bind(wxEVT_MIDDLE_UP, &CFrame::OnMouse, this);
     wxTheApp->Bind(wxEVT_MOTION, &CFrame::OnMouse, this);
     m_render_parent->Bind(wxEVT_SIZE, &CFrame::OnRenderParentResize, this);
+
+    m_render_parent->SetCursor(wxCURSOR_BLANK);
   }
 }
 
@@ -909,6 +910,9 @@ void CFrame::DoStop()
 
       return;
     }
+
+    // Reshow the cursor on the parent frame after successful stop.
+    m_render_parent->SetCursor(wxNullCursor);
 
     Core::Stop();
     UpdateGUI();


### PR DESCRIPTION
Solves a small annoyance with the WX GUI where exiting emulation game via keyboard would cause the cursor to remain hidden within the frame when using "Render to Main Window" persisting.

Also fixes the issue when the cursor has not been moved it would never disappear again because the timer would one shot and expire before processing events.

Reference: https://bugs.dolphin-emu.org/issues/10503