### PR TITLE
Qt: Don't crash when pressing the Return key

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -472,7 +472,7 @@ void GameList::ConsiderViewChange()
 }
 void GameList::keyReleaseEvent(QKeyEvent* event)
 {
-  if (event->key() == Qt::Key_Return)
+  if (event->key() == Qt::Key_Return && GetSelectedGame() != nullptr)
     emit GameSelected();
   else
     QStackedWidget::keyReleaseEvent(event);


### PR DESCRIPTION
Use the "activated" signal instead of manually detecting key presses.
Handles both double clicks and Return presses, and fixes a bug in the
logic which could cause GameSelected to be emitted without any game.