### PR TITLE
DebugInterface: Rename InsertBLR to Patch

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -39,7 +39,7 @@ public:
   virtual void SetPC(unsigned int /*address*/) {}
   virtual void Step() {}
   virtual void RunToBreakpoint() {}
-  virtual void InsertBLR(unsigned int /*address*/, unsigned int /*value*/) {}
+  virtual void Patch(unsigned int /*address*/, unsigned int /*value*/) {}
   virtual int GetColor(unsigned int /*address*/) { return 0xFFFFFFFF; }
   virtual std::string GetDescription(unsigned int /*address*/) = 0;
 };

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -156,7 +156,7 @@ void PPCDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool wri
   }
 }
 
-void PPCDebugInterface::InsertBLR(unsigned int address, unsigned int value)
+void PPCDebugInterface::Patch(unsigned int address, unsigned int value)
 {
   PowerPC::HostWrite_U32(value, address);
   PowerPC::ScheduleInvalidateCacheThreadSafe(address);

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -42,7 +42,7 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
-  void InsertBLR(unsigned int address, unsigned int value) override;
+  void Patch(unsigned int address, unsigned int value) override;
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
 };

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -132,9 +132,9 @@ void DSPDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool wri
   PanicAlert("MemCheck functionality not supported in DSP module.");
 }
 
-void DSPDebugInterface::InsertBLR(unsigned int address, unsigned int value)
+void DSPDebugInterface::Patch(unsigned int address, unsigned int value)
 {
-  PanicAlert("insertBLR functionality not supported in DSP module.");
+  PanicAlert("Patch functionality not supported in DSP module.");
 }
 
 // =======================================================

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -37,7 +37,7 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
-  void InsertBLR(unsigned int address, unsigned int value) override;
+  void Patch(unsigned int address, unsigned int value) override;
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
 };

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -227,9 +227,9 @@ void CCodeView::InsertBlrNop(int Blr)
     temp.oldValue = m_debugger->ReadMemory(m_selection);
     m_blrList.push_back(temp);
     if (Blr == 0)
-      m_debugger->InsertBLR(m_selection, 0x4e800020);
+      m_debugger->Patch(m_selection, 0x4e800020);
     else
-      m_debugger->InsertBLR(m_selection, 0x60000000);
+      m_debugger->Patch(m_selection, 0x60000000);
   }
   Refresh();
 }
@@ -320,7 +320,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
       unsigned long code;
       if (dialog.GetValue().ToULong(&code, 0) && code <= std::numeric_limits<u32>::max())
       {
-        m_debugger->InsertBLR(m_selection, code);
+        m_debugger->Patch(m_selection, code);
         Refresh();
       }
     }


### PR DESCRIPTION
This PR renames the ```InsertBLR``` function to ```Patch``` as it's actually patching code rather than just inserting BLR/NOP instructions.

Ready to reviewed & merged.