### PR TITLE
TextureConfig: Specialize std::hash for TextureConfig

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -212,9 +212,9 @@ private:
     int frameCount = FRAMECOUNT_INVALID;
     TexPoolEntry(std::unique_ptr<AbstractTexture> tex) : texture(std::move(tex)) {}
   };
-  typedef std::multimap<u32, TCacheEntry*> TexAddrCache;
-  typedef std::multimap<u64, TCacheEntry*> TexHashCache;
-  typedef std::unordered_multimap<TextureConfig, TexPoolEntry, TextureConfig::Hasher> TexPool;
+  using TexAddrCache = std::multimap<u32, TCacheEntry*>;
+  using TexHashCache = std::multimap<u64, TCacheEntry*>;
+  using TexPool = std::unordered_multimap<TextureConfig, TexPoolEntry>;
 
   void SetBackupConfig(const VideoConfig& config);
 

--- a/Source/Core/VideoCommon/TextureConfig.h
+++ b/Source/Core/VideoCommon/TextureConfig.h
@@ -31,14 +31,22 @@ struct TextureConfig
   u32 layers = 1;
   AbstractTextureFormat format = AbstractTextureFormat::RGBA8;
   bool rendertarget = false;
-
-  struct Hasher : std::hash<u64>
-  {
-    size_t operator()(const TextureConfig& c) const
-    {
-      u64 id = (u64)c.rendertarget << 63 | (u64)c.format << 50 | (u64)c.layers << 48 |
-               (u64)c.levels << 32 | (u64)c.height << 16 | (u64)c.width;
-      return std::hash<u64>::operator()(id);
-    }
-  };
 };
+
+namespace std
+{
+template <>
+struct hash<TextureConfig>
+{
+  using argument_type = TextureConfig;
+  using result_type = size_t;
+
+  result_type operator()(const argument_type& c) const noexcept
+  {
+    const u64 id = static_cast<u64>(c.rendertarget) << 63 | static_cast<u64>(c.format) << 50 |
+                   static_cast<u64>(c.layers) << 48 | static_cast<u64>(c.levels) << 32 |
+                   static_cast<u64>(c.height) << 16 | static_cast<u64>(c.width);
+    return std::hash<u64>{}(id);
+  }
+};
+}  // namespace std


### PR DESCRIPTION
This allows the hashing for TextureConfig instances to automatically be resolved instead of needing to directly specify it all the time.