### PR TITLE
Guest Memory Locking

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -181,4 +181,10 @@ size_t MemPhysical()
 #endif
 }
 
+size_t MemPageSize()
+{
+  // TODO: Get correct value here
+  return 4096;
+}
+
 }  // namespace Common

--- a/Source/Core/Common/MemoryUtil.h
+++ b/Source/Core/Common/MemoryUtil.h
@@ -18,5 +18,6 @@ void ReadProtectMemory(void* ptr, size_t size);
 void WriteProtectMemory(void* ptr, size_t size, bool executable = false);
 void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute = false);
 size_t MemPhysical();
+size_t MemPageSize();
 
 }  // namespace Common

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -80,6 +80,7 @@ private:
   bool bFPRF;
   bool bAccurateNaNs;
   bool bMMU;
+  bool bDCache;
   bool bDCBZOFF;
   bool bLowDCBZHack;
   bool m_EnableJIT;
@@ -111,6 +112,7 @@ void ConfigCache::SaveConfig(const SConfig& config)
   bFPRF = config.bFPRF;
   bAccurateNaNs = config.bAccurateNaNs;
   bMMU = config.bMMU;
+  bDCache = config.bDCache;
   bDCBZOFF = config.bDCBZOFF;
   m_EnableJIT = config.m_DSPEnableJIT;
   bSyncGPU = config.bSyncGPU;
@@ -151,6 +153,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bFPRF = bFPRF;
   config->bAccurateNaNs = bAccurateNaNs;
   config->bMMU = bMMU;
+  config->bDCache = bDCache;
   config->bDCBZOFF = bDCBZOFF;
   config->bLowDCBZHack = bLowDCBZHack;
   config->m_DSPEnableJIT = m_EnableJIT;
@@ -249,6 +252,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     core_section->Get("FPRF", &StartUp.bFPRF, StartUp.bFPRF);
     core_section->Get("AccurateNaNs", &StartUp.bAccurateNaNs, StartUp.bAccurateNaNs);
     core_section->Get("MMU", &StartUp.bMMU, StartUp.bMMU);
+    core_section->Get("DCache", &StartUp.bDCache, StartUp.bDCache);
     core_section->Get("DCBZ", &StartUp.bDCBZOFF, StartUp.bDCBZOFF);
     core_section->Get("LowDCBZHack", &StartUp.bLowDCBZHack, StartUp.bLowDCBZHack);
     core_section->Get("SyncGPU", &StartUp.bSyncGPU, StartUp.bSyncGPU);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -558,6 +558,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("RunCompareServer", &bRunCompareServer, false);
   core->Get("RunCompareClient", &bRunCompareClient, false);
   core->Get("MMU", &bMMU, false);
+  core->Get("DCache", &bDCache, false);
   core->Get("BBDumpPort", &iBBDumpPort, -1);
   core->Get("SyncGPU", &bSyncGPU, false);
   core->Get("SyncGpuMaxDistance", &iSyncGpuMaxDistance, 200000);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -114,6 +114,7 @@ struct SConfig
   bool bRunCompareClient = false;
 
   bool bMMU = false;
+  bool bDCache = false;
   bool bDCBZOFF = false;
   bool bLowDCBZHack = false;
   int iBBDumpPort = 0;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -70,6 +70,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCAdapter.h"
 
+#include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/RenderBase.h"
@@ -321,6 +322,7 @@ static void CPUSetInitialExecutionState()
 static void CpuThread(const std::optional<std::string>& savestate_path, bool delete_savestate)
 {
   DeclareAsCPUThread();
+  AsyncRequests::GetInstance()->UpdateVideoThreadId();
 
   const SConfig& _CoreParameter = SConfig::GetInstance();
 
@@ -387,6 +389,7 @@ static void FifoPlayerThread(const std::optional<std::string>& savestate_path,
                              bool delete_savestate)
 {
   DeclareAsCPUThread();
+  AsyncRequests::GetInstance()->UpdateVideoThreadId();
   const SConfig& _CoreParameter = SConfig::GetInstance();
 
   if (_CoreParameter.bCPUThread)

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -11,6 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Core/Core.h"
+#include "Core/HW/Memmap.h"
 #include "Core/Host.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "VideoCommon/Fifo.h"
@@ -101,6 +102,11 @@ void Run()
       // Enter a fast runloop
       PowerPC::RunLoop();
 
+      // Flush memory locks before returning.
+      // Because save states happen on the main thread..
+      // TODO: Do this better.
+      Memory::FlushAllLocks(Memory::LockAccessType::Write);
+
       state_lock.lock();
       s_state_cpu_thread_active = false;
       s_state_cpu_idle_cvar.notify_all();
@@ -124,6 +130,11 @@ void Run()
       state_lock.unlock();
 
       PowerPC::SingleStep();
+
+      // Flush memory locks before returning.
+      // Because save states happen on the main thread..
+      // TODO: Do this better.
+      Memory::FlushAllLocks(Memory::LockAccessType::Write);
 
       state_lock.lock();
       s_state_cpu_thread_active = false;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -9,6 +9,7 @@
 #include "Common/Swap.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/HW/Memmap.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/JitInterface.h"
@@ -326,6 +327,14 @@ void Interpreter::dcbf(UGeckoInstruction inst)
   // should use icbi consistently, but games aren't portable.)
   u32 address = Helper_Get_EA_X(inst);
   JitInterface::InvalidateICache(address & ~0x1f, 32, false);
+
+  // TODO: Create wrapper for this.
+  if (Memory::GetDCacheEmulationEnabled())
+  {
+    auto tr = PowerPC::JitCache_TranslateAddress(address & ~0x1f);
+    if (tr.valid)
+      Memory::FlushLocksInPhysicalRange(tr.address, 32, Memory::LockAccessType::Write);
+  }
 }
 
 void Interpreter::dcbi(UGeckoInstruction inst)
@@ -338,6 +347,14 @@ void Interpreter::dcbi(UGeckoInstruction inst)
   // should use icbi consistently, but games aren't portable.)
   u32 address = Helper_Get_EA_X(inst);
   JitInterface::InvalidateICache(address & ~0x1f, 32, false);
+
+  // TODO: Create wrapper for this.
+  if (Memory::GetDCacheEmulationEnabled())
+  {
+    auto tr = PowerPC::JitCache_TranslateAddress(address & ~0x1f);
+    if (tr.valid)
+      Memory::FlushLocksInPhysicalRange(tr.address, 32, Memory::LockAccessType::Read);
+  }
 }
 
 void Interpreter::dcbst(UGeckoInstruction inst)
@@ -350,11 +367,28 @@ void Interpreter::dcbst(UGeckoInstruction inst)
   // should use icbi consistently, but games aren't portable.)
   u32 address = Helper_Get_EA_X(inst);
   JitInterface::InvalidateICache(address & ~0x1f, 32, false);
+
+  // TODO: Create wrapper for this.
+  if (Memory::GetDCacheEmulationEnabled())
+  {
+    auto tr = PowerPC::JitCache_TranslateAddress(address & ~0x1f);
+    if (tr.valid)
+      Memory::FlushLocksInPhysicalRange(tr.address, 32, Memory::LockAccessType::Write);
+  }
 }
 
 void Interpreter::dcbt(UGeckoInstruction inst)
 {
   // TODO: Implement some sort of L2 emulation.
+  u32 address = Helper_Get_EA_X(inst);
+
+  // TODO: Create wrapper for this.
+  if (Memory::GetDCacheEmulationEnabled())
+  {
+    auto tr = PowerPC::JitCache_TranslateAddress(address & ~0x1f);
+    if (tr.valid)
+      Memory::FlushLocksInPhysicalRange(tr.address, 32, Memory::LockAccessType::Read);
+  }
 }
 
 void Interpreter::dcbtst(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -270,6 +270,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
 void Jit64::dcbx(UGeckoInstruction inst)
 {
   INSTRUCTION_START
+  FALLBACK_IF(Memory::GetDCacheEmulationEnabled());
   JITDISABLE(bJITLoadStoreOff);
 
   X64Reg addr = RSCRATCH;
@@ -309,6 +310,7 @@ void Jit64::dcbx(UGeckoInstruction inst)
 void Jit64::dcbt(UGeckoInstruction inst)
 {
   INSTRUCTION_START
+  FALLBACK_IF(Memory::GetDCacheEmulationEnabled());
   JITDISABLE(bJITLoadStoreOff);
 
   // Prefetch. Since we don't emulate the data cache, we don't need to do anything.

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -22,6 +22,7 @@
 #include "Common/MsgHandler.h"
 
 #include "Core/Core.h"
+#include "Core/HW/Memmap.h"
 #include "Core/PowerPC/CPUCoreBase.h"
 #include "Core/PowerPC/CachedInterpreter/CachedInterpreter.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
@@ -176,6 +177,9 @@ int GetHostCode(u32* address, const u8** code, u32* code_size)
 
 bool HandleFault(uintptr_t access_address, SContext* ctx)
 {
+  if (Memory::HandlePageFault(access_address))
+    return true;
+
   // Prevent nullptr dereference on a crash with no JIT present
   if (!g_jit)
   {

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -761,6 +761,9 @@ void ClearCacheLine(u32 address)
     address = translated_address.address;
   }
 
+  if (Memory::GetDCacheEmulationEnabled())
+    Memory::FlushLocksInPhysicalRange(address, 32);
+
   // TODO: This isn't precisely correct for non-RAM regions, but the difference
   // is unlikely to matter.
   for (u32 i = 0; i < 32; i += 8)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -29,6 +29,7 @@ private:
   void OnCPUEngineRadioBoxChanged(wxCommandEvent&);
   void OnAnalyticsCheckBoxChanged(wxCommandEvent&);
   void OnAnalyticsNewIdButtonClick(wxCommandEvent&);
+  void OnDCacheChoiceChanged(wxCommandEvent&);
 
   wxArrayString m_throttler_array_string;
   wxArrayString m_cpu_engine_array_string;
@@ -42,4 +43,5 @@ private:
   wxChoice* m_throttler_choice;
 
   wxRadioBox* m_cpu_engine_radiobox;
+  wxCheckBox* m_dcache_checkbox;
 };

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -66,8 +66,8 @@ void PSTextureEncoder::Shutdown()
   SAFE_RELEASE(m_encode_params);
 }
 
-void PSTextureEncoder::Encode(u8* dst, const EFBCopyParams& params, u32 native_width,
-                              u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void PSTextureEncoder::Encode(AbstractStagingTexture* dst, const EFBCopyParams& params,
+                              u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
                               const EFBRectangle& src_rect, bool scale_by_half)
 {
   // Resolve MSAA targets before copying.
@@ -121,14 +121,7 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyParams& params, u32 native_w
 
     // Copy to staging buffer
     MathUtil::Rectangle<int> copy_rect(0, 0, words_per_row, num_blocks_y);
-    m_encoding_readback_texture->CopyFromTexture(m_encoding_render_texture.get(), copy_rect, 0, 0,
-                                                 copy_rect);
-    m_encoding_readback_texture->Flush();
-    if (m_encoding_readback_texture->Map())
-    {
-      m_encoding_readback_texture->ReadTexels(copy_rect, dst, memory_stride);
-      m_encoding_readback_texture->Unmap();
-    }
+    dst->CopyFromTexture(m_encoding_render_texture.get(), copy_rect, 0, 0, copy_rect);
   }
 
   // Restore API

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -37,8 +37,8 @@ public:
 
   void Init();
   void Shutdown();
-  void Encode(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-              u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void Encode(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+              u32 bytes_per_row, u32 num_blocks_y, const EFBRectangle& src_rect,
               bool scale_by_half);
 
 private:

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -31,11 +31,11 @@ namespace DX11
 {
 static std::unique_ptr<PSTextureEncoder> g_encoder;
 
-void TextureCache::CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width,
-                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void TextureCache::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params,
+                           u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
                            const EFBRectangle& src_rect, bool scale_by_half)
 {
-  g_encoder->Encode(dst, params, native_width, bytes_per_row, num_blocks_y, memory_stride, src_rect,
+  g_encoder->Encode(dst, params, native_width, bytes_per_row, num_blocks_y, src_rect,
                     scale_by_half);
 }
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -32,8 +32,8 @@ private:
   void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
                       TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, const EFBRectangle& src_rect,
                bool scale_by_half) override;
 
   void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy, const EFBRectangle& src_rect,

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -25,8 +25,8 @@ public:
   {
   }
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, const EFBRectangle& src_rect,
                bool scale_by_half) override
   {
   }

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -66,12 +66,12 @@ constexpr const char* geometry_program = "layout(triangles) in;\n"
 
 //#define TIME_TEXTURE_DECODING 1
 
-void TextureCache::CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width,
-                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void TextureCache::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params,
+                           u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
                            const EFBRectangle& src_rect, bool scale_by_half)
 {
   TextureConverter::EncodeToRamFromTexture(dst, params, native_width, bytes_per_row, num_blocks_y,
-                                           memory_stride, src_rect, scale_by_half);
+                                           src_rect, scale_by_half);
 }
 
 TextureCache::TextureCache()

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -63,8 +63,8 @@ private:
   void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
                       TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, const EFBRectangle& src_rect,
                bool scale_by_half) override;
 
   void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy, const EFBRectangle& src_rect,

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -10,6 +10,7 @@
 #include "VideoCommon/VideoCommon.h"
 
 struct EFBCopyParams;
+class AbstractStagingTexture;
 
 namespace OGL
 {
@@ -21,8 +22,8 @@ void Init();
 void Shutdown();
 
 // returns size of the encoded data (in bytes)
-void EncodeToRamFromTexture(u8* dest_ptr, const EFBCopyParams& params, u32 native_width,
-                            u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void EncodeToRamFromTexture(AbstractStagingTexture* dest_tex, const EFBCopyParams& params,
+                            u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
                             const EFBRectangle& src_rect, bool scale_by_half);
 }
 

--- a/Source/Core/VideoBackends/Software/TextureCache.h
+++ b/Source/Core/VideoBackends/Software/TextureCache.h
@@ -16,12 +16,12 @@ public:
                       TLUTFormat format) override
   {
   }
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, const EFBRectangle& src_rect,
                bool scale_by_half) override
   {
-    TextureEncoder::Encode(dst, params, native_width, bytes_per_row, num_blocks_y, memory_stride,
-                           src_rect, scale_by_half);
+    // TextureEncoder::Encode(dst, params, native_width, bytes_per_row, num_blocks_y, memory_stride,
+    // src_rect, scale_by_half);
   }
 
 private:

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -377,9 +377,6 @@ void CommandBufferManager::OnCommandBufferExecuted(size_t index)
     backup_iter->second.second(resources.fence);
   }
 
-  for (const auto& iter : m_fence_point_callbacks)
-    iter.second.second(resources.fence);
-
   // Clean up all objects pending destruction on this command buffer
   for (auto& it : resources.cleanup_resources)
     it();

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.h
@@ -36,8 +36,8 @@ public:
   void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
                       TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, const EFBRectangle& src_rect,
                bool scale_by_half) override;
 
   bool SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format) override;

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -212,10 +212,12 @@ void TextureConverter::ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
   draw.EndRenderPass();
 }
 
-void TextureConverter::EncodeTextureToMemory(VkImageView src_texture, u8* dest_ptr,
-                                             const EFBCopyParams& params, u32 native_width,
-                                             u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                                             const EFBRectangle& src_rect, bool scale_by_half)
+void TextureConverter::EncodeTextureToStagingTexture(VkImageView src_texture,
+                                                     AbstractStagingTexture* dest_tex,
+                                                     const EFBCopyParams& params, u32 native_width,
+                                                     u32 bytes_per_row, u32 num_blocks_y,
+                                                     const EFBRectangle& src_rect,
+                                                     bool scale_by_half)
 {
   VkShaderModule shader = GetEncodingShader(params);
   if (shader == VK_NULL_HANDLE)
@@ -270,9 +272,7 @@ void TextureConverter::EncodeTextureToMemory(VkImageView src_texture, u8* dest_p
   draw.EndRenderPass();
 
   MathUtil::Rectangle<int> copy_rect(0, 0, render_width, render_height);
-  m_encoding_readback_texture->CopyFromTexture(m_encoding_render_texture.get(), copy_rect, 0, 0,
-                                               copy_rect);
-  m_encoding_readback_texture->ReadTexels(copy_rect, dest_ptr, memory_stride);
+  dest_tex->CopyFromTexture(m_encoding_render_texture.get(), copy_rect, 0, 0, copy_rect);
 }
 
 void TextureConverter::EncodeTextureToMemoryYUYV(void* dst_ptr, u32 dst_width, u32 dst_stride,

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -21,7 +21,6 @@ class AbstractStagingTexture;
 
 namespace Vulkan
 {
-class StagingTexture2D;
 class Texture2D;
 class VKTexture;
 
@@ -39,10 +38,10 @@ public:
                       TLUTFormat palette_format);
 
   // Uses an encoding shader to copy src_texture to dest_ptr.
-  // NOTE: Executes the current command buffer.
-  void EncodeTextureToMemory(VkImageView src_texture, u8* dest_ptr, const EFBCopyParams& params,
-                             u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-                             u32 memory_stride, const EFBRectangle& src_rect, bool scale_by_half);
+  void EncodeTextureToStagingTexture(VkImageView src_texture, AbstractStagingTexture* dest_tex,
+                                     const EFBCopyParams& params, u32 native_width,
+                                     u32 bytes_per_row, u32 num_blocks_y,
+                                     const EFBRectangle& src_rect, bool scale_by_half);
 
   // Encodes texture to guest memory in XFB (YUYV) format.
   void EncodeTextureToMemoryYUYV(void* dst_ptr, u32 dst_width, u32 dst_stride, u32 dst_height,

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -505,6 +505,7 @@ void VKStagingTexture::Flush()
   {
     // WaitForFence should fire the callback.
     g_command_buffer_mgr->WaitForFence(m_flush_fence);
+    m_flush_fence = VK_NULL_HANDLE;
   }
   else
   {

--- a/Source/Core/VideoCommon/AbstractStagingTexture.h
+++ b/Source/Core/VideoCommon/AbstractStagingTexture.h
@@ -45,6 +45,10 @@ public:
   // Assumes that the level of src texture and this texture have the same dimensions.
   void CopyToTexture(AbstractTexture* dst, u32 dst_layer = 0, u32 dst_level = 0);
 
+  // Transitions the texture to a state where it can be accessed. This may involve command
+  // buffer submission, or mapping the object into the process address space.
+  bool PrepareForAccess();
+
   // Maps the texture into the CPU address space, enabling it to read the contents.
   // The Map call may not perform synchronization. If the contents of the staging texture
   // has been updated by a CopyFromTexture call, you must call Flush() first.
@@ -73,8 +77,6 @@ public:
   void WriteTexel(u32 x, u32 y, const void* in_ptr);
 
 protected:
-  bool PrepareForAccess();
-
   const StagingTextureType m_type;
   const TextureConfig m_config;
   const size_t m_texel_size;

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -28,6 +28,7 @@ public:
       SWAP_EVENT,
       BBOX_READ,
       PERF_QUERY,
+      EFB_COPY,
     } type;
     u64 time;
 
@@ -64,6 +65,10 @@ public:
       struct
       {
       } perf_query;
+
+      struct
+      {
+      } efb_copy;
     };
   };
 

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -292,8 +292,7 @@ void ResetVideoBuffer()
 // Purpose: Keep the Core HW updated about the CPU-GPU distance
 void RunGpuLoop()
 {
-  AsyncRequests::GetInstance()->SetEnable(true);
-  AsyncRequests::GetInstance()->SetPassthrough(false);
+  AsyncRequests::GetInstance()->UpdateVideoThreadId();
 
   s_gpu_mainloop.Run(
       [] {
@@ -390,9 +389,6 @@ void RunGpuLoop()
         }
       },
       100);
-
-  AsyncRequests::GetInstance()->SetEnable(false);
-  AsyncRequests::GetInstance()->SetPassthrough(true);
 }
 
 void FlushGpu()

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1922,6 +1922,8 @@ void TextureCacheBase::FlushEFBCopy(TCacheEntry* entry)
   // This should be safe because we'll catch any writes before the game can modify it.
   u64 hash = entry->CalculateHash();
   entry->SetHashes(hash, hash);
+  if (USE_HASHLESS_NON_COPIES)
+    LockEntry(entry);
 }
 
 void TextureCacheBase::DiscardEFBCopy(TCacheEntry* entry)

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -219,6 +219,8 @@ public:
     u32 GetNumLevels() const { return texture->GetConfig().levels; }
     u32 GetNumLayers() const { return texture->GetConfig().layers; }
     AbstractTextureFormat GetFormat() const { return texture->GetConfig().format; }
+
+    void FlushEFBCopy();
   };
 
   virtual ~TextureCacheBase();  // needs virtual for DX11 dtor


### PR DESCRIPTION
This PR is a huge work-in-progress, implementing guest memory page locking. I've had this around for a while, but it's at the point where it's working in at least a few games, so it's worth getting comments, ideas for optimizations, etc. There's also a lot of debugging code left in which has to be removed.

There's also a few commits that aren't directly related from my other PRs to simplify the Vulkan implementation, it's likely they will be merged before this is finished.

The idea is nothing new, it's been floating around in IRC discussions for ages, but as far as I'm aware nobody has implemented it to this level yet.

**The problem:**
Currently, if "EFB Copies To Texture Only" is checked, we don't populate the guest memory where the copy is stored, instead zeroing it out. This leads to breakage in games which read this memory on the CPU, which is often used for object detection, visual effects, etc.

If this option is disabled, we perform the readback from the host's GPU to the guest RAM. This means the CPU has to wait until the GPU has finished rendering, introducing a synchronization point, stalling the CPU. This means large drops in FPS, depending on how many copies are happening in each frame. 

It's possible the guest won't touch this RAM at all, and it is just using it for the GPU! Which means we stalled for nothing.

**The solution:**
In this PR, we are essentially creating "Lazy EFB Copies". Instead of zeroing out the memory, we change the protection on the pages that back this memory to PROT_NONE. Therefore, if the guest does read the memory after the copy, we will get a page fault, and can perform the readback. If it doesn't read it, we can skip the readback. Well, we defer it until we know the GPU is finished rendering, and copy it then instead.

Unfortunately, we can only do this at a page granularity, which means potentially up to 4KB at either end of the copy bounds will also be locked. If the game touches this region, we still still fault and have to do the readback, even though the actual copy may not have been touched. This is likely where the performance won't be as good as EFB2Tex, and we can't get rid of the option entirely.

We can use this for other things, like hashless texture caching too. Instead of changing to PROT_NONE, we can change to PROT_READ, which means if the game modifies the memory backing these textures, we will fault then, and can force a re-hash/invalidate the cache entry. If we never fault, we know the texture hasn't changed, and therefore can skip hashing it entirely!

**State:**
Don't expect huge performance boosts across the board yet. Some games are faster, others not so much, and may be slower than master with EFB2RAM on, due to the extra page fault overhead. Particularly around those which place copies adjacent in memory, there is still some optimization to do.

- [x] Base page locking support in Memmap (is this the best place to put it?)
- [x] Implement support for faulting from any thread, and executing callbacks on the GPU thread (Dual Core, AsyncRequests)
- [x] Deferred EFB copies in texture cache base
- [x] Abstract texture readback on D3D
- [x] Deferring EFB copies on D3D
- [x] Abstract texture readback on D3D
- [x] Deferring EFB copies on OpenGL
- [x] Abstract texture readback on Vulkan
- [x] Deferring EFB copies on Vulkan
- [x] Hashless texture cache (currently disabled by default)
- [ ] Locking for paletted textures in texture cache
- [ ] Make things generally faster!
