### PR TITLE
NullSoundStream: don't call Mixer->Mix

### DIFF
--- a/Source/Core/AudioCommon/NullSoundStream.cpp
+++ b/Source/Core/AudioCommon/NullSoundStream.cpp
@@ -3,9 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "AudioCommon/NullSoundStream.h"
-#include "Common/CommonTypes.h"
-#include "Core/HW/AudioInterface.h"
-#include "Core/HW/SystemTimers.h"
 
 void NullSound::SoundLoop()
 {
@@ -22,17 +19,6 @@ void NullSound::SetVolume(int volume)
 
 void NullSound::Update()
 {
-  // num_samples_to_render in this update - depends on SystemTimers::AUDIO_DMA_PERIOD.
-  constexpr u32 stereo_16_bit_size = 4;
-  constexpr u32 dma_length = 32;
-  const u64 audio_dma_period =
-      SystemTimers::GetTicksPerSecond() /
-      (AudioInterface::GetAIDSampleRate() * stereo_16_bit_size / dma_length);
-  const u64 ais_samples_per_second = 48000 * stereo_16_bit_size;
-  const u64 num_samples_to_render =
-      (audio_dma_period * ais_samples_per_second) / SystemTimers::GetTicksPerSecond();
-
-  m_mixer->Mix(m_realtime_buffer.data(), (unsigned int)num_samples_to_render);
 }
 
 void NullSound::Clear(bool mute)

--- a/Source/Core/AudioCommon/NullSoundStream.h
+++ b/Source/Core/AudioCommon/NullSoundStream.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <array>
 #include "AudioCommon/SoundStream.h"
 
 class NullSound final : public SoundStream
@@ -18,9 +17,4 @@ public:
   void Update() override;
 
   static bool isValid() { return true; }
-private:
-  static constexpr size_t BUFFER_SIZE = 48000 * 4 / 32;
-
-  // Playback position
-  std::array<short, BUFFER_SIZE / sizeof(short)> m_realtime_buffer;
 };


### PR DESCRIPTION
There should be no reason to call `Mix()` and keep a buffer around. I followed the logic, and Mix() does this:
- delegates to its MixerFifo members
- which advance m_indexR
- making `PushSamples()` a quick return if the buffer overflows
- and making `AvailableSamples()` return 0
- which is only used by Mix()