### PR TITLE
Add INI file for Midnight Bowling (WiiWare)

### DIFF
--- a/Data/Sys/GameSettings/WB8.ini
+++ b/Data/Sys/GameSettings/WB8.ini
@@ -1,0 +1,22 @@
+# WB8EGL, WB8PGL - Midnight Bowling
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[EmuState]
+# The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
+EmulationIssues = Requires Virtual XFB to prevent flickering.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+UseXFB = True
+UseRealXFB = False


### PR DESCRIPTION
Without virtual xfb, the game will show distorted graphics once leaving
the title screen. This adds an INI file to make the game playable.

The wiki page for this game also notes the need for virtual xfb.