### PR TITLE
(rfc) TextureCache: alloc 32MB palette buffer even when GPU texture decoding isn't supported

### DIFF
--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -52,7 +52,7 @@ TextureCache::TextureCache()
 
   if (g_ActiveConfig.backend_info.bSupportsPaletteConversion)
   {
-    s32 buffer_size_mb = (g_ActiveConfig.backend_info.bSupportsGPUTextureDecoding ? 32 : 1);
+    s32 buffer_size_mb = 32;
     s32 buffer_size = buffer_size_mb * 1024 * 1024;
     s32 max_buffer_size = 0;
 


### PR DESCRIPTION
I don't know what this does, but it fixes https://bugs.dolphin-emu.org/issues/10599 and I'd like to get some eyes on it.