### PR TITLE
TextureCache: don't create texture decoding resources if not enabled

### DIFF
--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -69,14 +69,16 @@ TextureCache::TextureCache()
     glBindTexture(GL_TEXTURE_BUFFER, m_palette_resolv_texture);
     glTexBuffer(GL_TEXTURE_BUFFER, GL_R16UI, m_palette_stream_buffer->m_buffer);
 
-    CreateTextureDecodingResources();
+    if (g_ActiveConfig.backend_info.bSupportsGPUTextureDecoding)
+      CreateTextureDecodingResources();
   }
 }
 
 TextureCache::~TextureCache()
 {
   DeleteShaders();
-  DestroyTextureDecodingResources();
+  if (g_ActiveConfig.backend_info.bSupportsGPUTextureDecoding)
+    DestroyTextureDecodingResources();
 
   if (g_ActiveConfig.backend_info.bSupportsPaletteConversion)
   {


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10599