### PR TITLE
Added Windows support for MemoryWatcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,7 +520,6 @@ if(UNIX)
   message(STATUS "Using named pipes as controller inputs")
   add_definitions(-DUSE_PIPES=1)
   message(STATUS "Watching game memory for changes")
-  add_definitions(-DUSE_MEMORYWATCHER=1)
 endif()
 
 if(ENABLE_ANALYTICS)

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -38,9 +38,7 @@
 #include "Core/DSPEmulator.h"
 #include "Core/Host.h"
 #include "Core/MemTools.h"
-#ifdef USE_MEMORYWATCHER
 #include "Core/MemoryWatcher.h"
-#endif
 #include "Core/Boot/Boot.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/HLE/HLE.h"
@@ -289,9 +287,7 @@ void Stop()  // - Hammertime!
   GCAdapter::ResetRumble();
 #endif
 
-#ifdef USE_MEMORYWATCHER
   MemoryWatcher::Shutdown();
-#endif
 }
 
 void DeclareAsCPUThread()
@@ -383,9 +379,7 @@ static void CpuThread()
   }
 #endif
 
-#ifdef USE_MEMORYWATCHER
   MemoryWatcher::Init();
-#endif
 
   // Enter CPU run loop. When we leave it - we are done.
   CPU::Run();

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -237,6 +237,7 @@
     <ClCompile Include="IOS\USB\Bluetooth\WiimoteHIDAttr.cpp" />
     <ClCompile Include="IOS\WFS\WFSSRV.cpp" />
     <ClCompile Include="IOS\WFS\WFSI.cpp" />
+    <ClCompile Include="MemoryWatcher.cpp" />
     <ClCompile Include="MemTools.cpp" />
     <ClCompile Include="Movie.cpp" />
     <ClCompile Include="NetPlayClient.cpp" />
@@ -486,6 +487,7 @@
     <ClInclude Include="IOS\WFS\WFSSRV.h" />
     <ClInclude Include="IOS\WFS\WFSI.h" />
     <ClInclude Include="MachineContext.h" />
+    <ClInclude Include="MemoryWatcher.h" />
     <ClInclude Include="MemTools.h" />
     <ClInclude Include="Movie.h" />
     <ClInclude Include="NetPlayClient.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -889,6 +889,7 @@
     <ClCompile Include="IOS\Network\NCD\WiiNetConfig.cpp">
       <Filter>IOS\Network\NCD</Filter>
     </ClCompile>
+    <ClCompile Include="MemoryWatcher.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BootManager.h" />
@@ -1559,6 +1560,7 @@
     <ClInclude Include="HW\WiimoteCommon\WiimoteReport.h">
       <Filter>HW %28Flipper/Hollywood%29\WiimoteCommon</Filter>
     </ClInclude>
+    <ClInclude Include="MemoryWatcher.h" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -6,7 +6,12 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#ifdef _WIN32
+#include <fileapi.h>
+#include <handleapi.h>
+#else
 #include <unistd.h>
+#endif
 
 #include "Common/FileUtil.h"
 #include "Core/CoreTiming.h"
@@ -53,7 +58,11 @@ MemoryWatcher::~MemoryWatcher()
     return;
 
   m_running = false;
+#ifdef _WIN32
+  CloseHandle(m_pipe);
+#else
   close(m_fd);
+#endif
 }
 
 bool MemoryWatcher::LoadAddresses(const std::string& path)
@@ -83,12 +92,19 @@ void MemoryWatcher::ParseLine(const std::string& line)
 
 bool MemoryWatcher::OpenSocket(const std::string& path)
 {
+#ifdef _WIN32
+  m_pipe = CreateFile(L"\\\\.\\pipe\\Dolphin Emulator\\MemoryWatcher", GENERIC_READ | GENERIC_WRITE,
+                      0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+  return m_pipe != INVALID_HANDLE_VALUE;
+#else
   memset(&m_addr, 0, sizeof(m_addr));
   m_addr.sun_family = AF_UNIX;
   strncpy(m_addr.sun_path, path.c_str(), sizeof(m_addr.sun_path) - 1);
 
   m_fd = socket(AF_UNIX, SOCK_DGRAM, 0);
   return m_fd >= 0;
+#endif
 }
 
 u32 MemoryWatcher::ChasePointer(const std::string& line)
@@ -122,8 +138,16 @@ void MemoryWatcher::Step()
       // Update the value
       current_value = new_value;
       std::string message = ComposeMessage(address, new_value);
+#ifdef _WIN32
+      unsigned long written;
+      if (m_pipe != INVALID_HANDLE_VALUE)
+        WriteFile(m_pipe, message.c_str(), static_cast<DWORD>(message.size() + 1), &written,
+                  nullptr);
+#else
       sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr),
              sizeof(m_addr));
+#endif
     }
   }
 }
+

--- a/Source/Core/Core/MemoryWatcher.h
+++ b/Source/Core/Core/MemoryWatcher.h
@@ -5,9 +5,13 @@
 #pragma once
 
 #include <map>
+#ifndef _WIN32
 #include <sys/socket.h>
 #include <sys/un.h>
+#endif
 #include <vector>
+
+#include "Common/CommonTypes.h"
 
 // MemoryWatcher reads a file containing in-game memory addresses and outputs
 // changes to those memory addresses to a unix domain socket as the game runs.
@@ -37,8 +41,12 @@ private:
 
   bool m_running;
 
+#ifdef _WIN32
+  void* m_pipe;
+#else
   int m_fd;
   sockaddr_un m_addr;
+#endif
 
   // Address as stored in the file -> list of offsets to follow
   std::map<std::string, std::vector<u32>> m_addresses;


### PR DESCRIPTION
This adds Windows support for MemoryWatcher. It opens a Windows named pipe at `\\\\.\\pipe\\Dolphin Emulator\\MemoryWatcher` and sends everything there.

So far only tested against SSBM, everything looks to works OK. Compiles normally on Windows 10 and Linux (have not tested OSX).