### PR TITLE
CMake: add DOLPHIN_CXX_FLAGS option

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,3 +1,8 @@
+option(DOLPHIN_CXX_FLAGS "Flags used to compile Dolphin-only sources" "")
+if(DOLPHIN_CXX_FLAGS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DOLPHIN_CXX_FLAGS}")
+endif()
+
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   add_definitions(-DNOMINMAX)
   add_definitions(-DUNICODE)


### PR DESCRIPTION
Lets you do fun stuff like adding extra warnings + warnings as errors for Dolphin only.

Closed the original, #6137, in a momentary lapse of thinking.