### PR TITLE
Netplay: Add Quality of Service (QoS) support

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRCS
   PcapFile.cpp
   PerformanceCounter.cpp
   Profiler.cpp
+  QoSSession.cpp
   SDCardUtil.cpp
   SettingsHandler.cpp
   StringUtil.cpp

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -137,6 +137,7 @@
     <ClInclude Include="Network.h" />
     <ClInclude Include="PcapFile.h" />
     <ClInclude Include="Profiler.h" />
+    <ClInclude Include="QoSSession.h" />
     <ClInclude Include="ScopeGuard.h" />
     <ClInclude Include="SDCardUtil.h" />
     <ClInclude Include="Semaphore.h" />
@@ -196,6 +197,7 @@
     <ClCompile Include="Network.cpp" />
     <ClCompile Include="PcapFile.cpp" />
     <ClCompile Include="Profiler.cpp" />
+    <ClCompile Include="QoSSession.cpp" />
     <ClCompile Include="SDCardUtil.cpp" />
     <ClCompile Include="SettingsHandler.cpp" />
     <ClCompile Include="StringUtil.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -58,6 +58,7 @@
     <ClInclude Include="Network.h" />
     <ClInclude Include="PcapFile.h" />
     <ClInclude Include="Profiler.h" />
+    <ClInclude Include="QoSSession.h" />
     <ClInclude Include="ScopeGuard.h" />
     <ClInclude Include="SDCardUtil.h" />
     <ClInclude Include="SettingsHandler.h" />
@@ -282,6 +283,7 @@
     <ClCompile Include="Network.cpp" />
     <ClCompile Include="PcapFile.cpp" />
     <ClCompile Include="Profiler.cpp" />
+    <ClCompile Include="QoSSession.h" />
     <ClCompile Include="SDCardUtil.cpp" />
     <ClCompile Include="SettingsHandler.cpp" />
     <ClCompile Include="StringUtil.cpp" />

--- a/Source/Core/Common/QoSSession.cpp
+++ b/Source/Core/Common/QoSSession.cpp
@@ -1,0 +1,87 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Common/QoSSession.h"
+#include "Core/ConfigManager.h"
+
+#if defined(_WIN32)
+#include <Qos2.h>
+#pragma comment(lib, "qwave")
+#endif
+
+namespace Common
+{
+#if defined(_WIN32)
+QoSSession::QoSSession(ENetPeer* peer, int tos_val) : m_peer(peer)
+{
+  QOS_VERSION ver = {1, 0};
+
+  if (!QOSCreateHandle(&ver, &m_qos_handle))
+    return;
+
+  sockaddr_in sin = {};
+
+  sin.sin_family = AF_INET;
+  sin.sin_port = ENET_HOST_TO_NET_16(peer->host->address.port);
+  sin.sin_addr.s_addr = peer->host->address.host;
+
+  if (QOSAddSocketToFlow(m_qos_handle, peer->host->socket, reinterpret_cast<PSOCKADDR>(&sin),
+                         QOSTrafficTypeControl, QOS_NON_ADAPTIVE_FLOW, &m_qos_flow_id))
+  {
+    // We shift the complete ToS value by 3 to get rid of the 3 bit ECN field
+    DWORD dscp = static_cast<DWORD>(tos_val >> 3);
+
+    // Sets DSCP to the same as Linux
+    // This will fail if we're not admin, but we ignore it
+    QOSSetFlow(m_qos_handle, m_qos_flow_id, QOSSetOutgoingDSCPValue, sizeof(DWORD), &dscp, 0,
+               nullptr);
+
+    m_success = true;
+  }
+}
+
+QoSSession::~QoSSession()
+{
+  if (m_qos_handle == nullptr)
+    return;
+
+  if (m_qos_flow_id != 0)
+    QOSRemoveSocketFromFlow(m_qos_handle, m_peer->host->socket, m_qos_flow_id, 0);
+
+  QOSCloseHandle(m_qos_handle);
+}
+#else
+QoSSession::QoSSession(ENetPeer* peer, int tos_val)
+{
+#if defined(__linux__)
+  constexpr int priority = 7;
+  setsockopt(peer->host->socket, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority));
+#endif
+
+  m_success = setsockopt(peer->host->socket, IPPROTO_IP, IP_TOS, &tos_val, sizeof(tos_val)) == 0;
+}
+
+QoSSession::~QoSSession() = default;
+#endif
+
+QoSSession& QoSSession::operator=(QoSSession&& session)
+{
+  if (this != &session)
+  {
+#if defined(_WIN32)
+    m_qos_handle = session.m_qos_handle;
+    m_qos_flow_id = session.m_qos_flow_id;
+    m_peer = session.m_peer;
+
+    session.m_qos_handle = nullptr;
+    session.m_qos_flow_id = 0;
+    session.m_peer = nullptr;
+#endif
+    m_success = session.m_success;
+    session.m_success = false;
+  }
+
+  return *this;
+}
+}  // namespace Common

--- a/Source/Core/Common/QoSSession.h
+++ b/Source/Core/Common/QoSSession.h
@@ -1,0 +1,40 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <enet/enet.h>
+#include <utility>
+
+namespace Common
+{
+class QoSSession
+{
+public:
+  // 1 0 1 1 1 0 0 0
+  // DSCP      ECN
+  static constexpr int ef_tos = 0b10111000;
+
+  QoSSession() = default;
+  QoSSession(ENetPeer* peer, int tos_val = ef_tos);
+
+  ~QoSSession();
+
+  QoSSession& operator=(const QoSSession&) = delete;
+  QoSSession(const QoSSession&) = delete;
+
+  QoSSession& operator=(QoSSession&& session);
+  QoSSession(QoSSession&& session) { *this = std::move(session); }
+  bool Successful() const { return m_success; }
+private:
+#if defined(_WIN32)
+  void* m_qos_handle = nullptr;
+  unsigned long m_qos_flow_id = 0;
+
+  ENetPeer* m_peer = nullptr;
+#endif
+
+  bool m_success = false;
+};
+}  // namespace Common

--- a/Source/Core/Core/Config/NetplaySettings.cpp
+++ b/Source/Core/Core/Config/NetplaySettings.cpp
@@ -33,4 +33,6 @@ const ConfigInfo<std::string> NETPLAY_SELECTED_HOST_GAME{
     {System::Main, "NetPlay", "SelectedHostGame"}, ""};
 const ConfigInfo<bool> NETPLAY_USE_UPNP{{System::Main, "NetPlay", "UseUPNP"}, false};
 
+const ConfigInfo<bool> NETPLAY_ENABLE_QOS{{System::Main, "NetPlay", "EnableQoS"}, true};
+
 }  // namespace Config

--- a/Source/Core/Core/Config/NetplaySettings.h
+++ b/Source/Core/Core/Config/NetplaySettings.h
@@ -29,4 +29,6 @@ extern const ConfigInfo<std::string> NETPLAY_NICKNAME;
 extern const ConfigInfo<std::string> NETPLAY_SELECTED_HOST_GAME;
 extern const ConfigInfo<bool> NETPLAY_USE_UPNP;
 
+extern const ConfigInfo<bool> NETPLAY_ENABLE_QOS;
+
 }  // namespace Config

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -20,9 +20,11 @@
 #include "Common/ENetUtil.h"
 #include "Common/MD5.h"
 #include "Common/MsgHandler.h"
+#include "Common/QoSSession.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
 #include "Common/Version.h"
+#include "Core/Config/NetplaySettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/SI/SI.h"
@@ -632,6 +634,17 @@ void NetPlayClient::SendAsync(sf::Packet&& packet)
 // called from ---NETPLAY--- thread
 void NetPlayClient::ThreadFunc()
 {
+  Common::QoSSession qos_session;
+  if (Config::Get(Config::NETPLAY_ENABLE_QOS))
+  {
+    qos_session = Common::QoSSession(m_server);
+
+    if (qos_session.Successful())
+      m_dialog->AppendChat("Quality of Service (QoS) was successfully enabled.");
+    else
+      m_dialog->AppendChat("Quality of Service (QoS) couldn't be enabled.");
+  }
+
   while (m_do_loop.IsSet())
   {
     ENetEvent netEvent;

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -6,12 +6,14 @@
 
 #include <SFML/Network/Packet.hpp>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include "Common/QoSSession.h"
 #include "Common/SPSCQueue.h"
 #include "Common/Timer.h"
 #include "Common/TraversalClient.h"
@@ -70,6 +72,8 @@ private:
     ENetPeer* socket;
     u32 ping;
     u32 current_game;
+
+    Common::QoSSession qos_session;
 
     bool operator==(const Client& other) const { return this == &other; }
   };


### PR DESCRIPTION
This adds support for tagging outgoing packets with a Quality of Service bit. 
This should make Dolphin get prioritized over other network traffic in routers, which means you can download and stream while playing NetPlay without packet drops or input lag.