### PR TITLE
Socket: Move IOCTLV_SO_SEND(TO) to INFO_LOG

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -514,13 +514,13 @@ void WiiSocket::Update(bool read, bool write, bool except)
                            has_destaddr ? sizeof(sockaddr) : 0);
           ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_SENDTO", true);
 
-          DEBUG_LOG(
-              IOS_NET,
-              "%s = %d Socket: %08x, BufferIn: (%08x, %i), BufferIn2: (%08x, %i), %u.%u.%u.%u",
-              has_destaddr ? "IOCTLV_SO_SENDTO " : "IOCTLV_SO_SEND ", ReturnValue, wii_fd, BufferIn,
-              BufferInSize, BufferIn2, BufferInSize2, local_name.sin_addr.s_addr & 0xFF,
-              (local_name.sin_addr.s_addr >> 8) & 0xFF, (local_name.sin_addr.s_addr >> 16) & 0xFF,
-              (local_name.sin_addr.s_addr >> 24) & 0xFF);
+          INFO_LOG(IOS_NET,
+                   "%s = %d Socket: %08x, BufferIn: (%08x, %i), BufferIn2: (%08x, %i), %u.%u.%u.%u",
+                   has_destaddr ? "IOCTLV_SO_SENDTO " : "IOCTLV_SO_SEND ", ReturnValue, wii_fd,
+                   BufferIn, BufferInSize, BufferIn2, BufferInSize2,
+                   local_name.sin_addr.s_addr & 0xFF, (local_name.sin_addr.s_addr >> 8) & 0xFF,
+                   (local_name.sin_addr.s_addr >> 16) & 0xFF,
+                   (local_name.sin_addr.s_addr >> 24) & 0xFF);
           break;
         }
         case IOCTLV_SO_RECVFROM:


### PR DESCRIPTION
For some reason the log level of IOCTLV_SO_SEND(TO) and IOCTLV_SO_RECV(FROM) is different. I find it quite counter-intuitive to have one but not the other. I'm fine to move both to DEBUG_LOG if INFO_LOG isn't appropriate.

@aldelaro5 Any objection? According to git-blame you're the last person who changed its log level.

Ready to be reviewed & merged.