### PR TITLE
NANDImporter: Construct strings correctly

### DIFF
--- a/Source/Core/DiscIO/NANDImporter.cpp
+++ b/Source/Core/DiscIO/NANDImporter.cpp
@@ -109,10 +109,7 @@ void NANDImporter::FindSuperblock()
 
 std::string NANDImporter::GetPath(const NANDFSTEntry& entry, const std::string& parent_path)
 {
-  std::string name(reinterpret_cast<const char*>(&entry.name), sizeof(NANDFSTEntry::name));
-  // Get rid of any extra null characters
-  while (name.back() == '\0')
-    name.pop_back();
+  std::string name(entry.name, strnlen(entry.name, sizeof(NANDFSTEntry::name)));
 
   if (name.front() == '/' || parent_path.back() == '/')
     return parent_path + name;

--- a/Source/Core/DiscIO/NANDImporter.h
+++ b/Source/Core/DiscIO/NANDImporter.h
@@ -25,7 +25,7 @@ private:
 #pragma pack(push, 1)
   struct NANDFSTEntry
   {
-    u8 name[12];
+    char name[12];
     u8 mode;   // 0x0C
     u8 attr;   // 0x0D
     u16 sub;   // 0x0E


### PR DESCRIPTION
Use `std::string(cstring, strnlen(cstring, max_length))` instead of trying to remove extra null characters manually, which is a bit ugly and error prone.

And indeed, the original code contained a bug which would cause extra NULLs to not be removed at all if the string did not end with a NULL -- causing issues down the road when constructing paths for sub-entries.