### PR TITLE
wxWidgets3: Fix compilation due to change in assert macros in macOS 10.13 SDK

### DIFF
--- a/Externals/wxWidgets3/CMakeLists.txt
+++ b/Externals/wxWidgets3/CMakeLists.txt
@@ -825,7 +825,7 @@ target_compile_definitions(wx PRIVATE "WXBUILDING")
 target_compile_options(wx PRIVATE "-w")
 
 if(APPLE)
-        target_compile_definitions(wx PRIVATE "__WXOSX_COCOA__")
+        target_compile_definitions(wx PRIVATE "__WXOSX_COCOA__" "__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1")
         target_sources(wx PRIVATE 
 		${SRCS_GENERICOSX}
 		${SRCS_OSX}


### PR DESCRIPTION
Related wx ticket: https://trac.wxwidgets.org/ticket/17929#ticket

A point release of wx that includes a fix is not yet available, hence this PR, instead of updating wx as would be perferrable.