### PR TITLE
Adjust CPU Override Text

### DIFF
--- a/Source/Core/DolphinQt2/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/AdvancedPane.cpp
@@ -37,7 +37,7 @@ void AdvancedPane::CreateLayout()
   cpu_options->setLayout(cpu_options_layout);
   main_layout->addWidget(cpu_options);
 
-  m_cpu_clock_override_checkbox = new QCheckBox(tr("Enable CPU Clock Override"));
+  m_cpu_clock_override_checkbox = new QCheckBox(tr("Enable Emulated CPU Clock Override"));
   cpu_options_layout->addWidget(m_cpu_clock_override_checkbox);
 
   auto* cpu_clock_override_slider_layout = new QHBoxLayout();
@@ -52,10 +52,12 @@ void AdvancedPane::CreateLayout()
   cpu_clock_override_slider_layout->addWidget(m_cpu_clock_override_slider_label);
 
   auto* cpu_clock_override_description =
-      new QLabel(tr("Higher values can make variable-framerate games run at a higher framerate, at "
-                    "the expense of CPU. Lower values can make variable-framerate games run at a "
-                    "lower framerate, saving CPU.\n\nWARNING: Changing this from the default "
-                    "(100%) can and will break games and cause glitches. Do so at your own risk. "
+      new QLabel(tr("Adjusts the emulated CPU's clock rate.\n\n"
+                    "Higher values may make variable-framerate games run at a higher framerate, "
+                    "at the expense of performance. Lower values may activate a game's "
+                    "internal frameskip, potentially improving performance.\n\n"
+                    "WARNING: Changing this from the default (100%) can and will "
+                    "break games and cause glitches. Do so at your own risk. "
                     "Please do not report bugs that occur with a non-default clock."));
   cpu_clock_override_description->setWordWrap(true);
   cpu_options_layout->addWidget(cpu_clock_override_description);

--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -29,7 +29,8 @@ AdvancedConfigPane::AdvancedConfigPane(wxWindow* parent, wxWindowID id) : wxPane
 
 void AdvancedConfigPane::InitializeGUI()
 {
-  m_clock_override_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable CPU Clock Override"));
+  m_clock_override_checkbox =
+      new wxCheckBox(this, wxID_ANY, _("Enable Emulated CPU Clock Override"));
   m_clock_override_slider =
       new DolphinSlider(this, wxID_ANY, 100, 0, 150, wxDefaultPosition, FromDIP(wxSize(200, -1)));
   m_clock_override_text = new wxStaticText(this, wxID_ANY, "");
@@ -45,10 +46,11 @@ void AdvancedConfigPane::InitializeGUI()
   m_custom_rtc_time_picker = new wxTimePickerCtrl(this, wxID_ANY);
 
   wxStaticText* const clock_override_description =
-      new wxStaticText(this, wxID_ANY, _("Higher values can make variable-framerate games "
-                                         "run at a higher framerate, at the expense of CPU. "
-                                         "Lower values can make variable-framerate games "
-                                         "run at a lower framerate, saving CPU.\n\n"
+      new wxStaticText(this, wxID_ANY, _("Adjusts the emulated CPU's clock rate.\n\n"
+                                         "Higher values may make variable-framerate games run "
+                                         "at a higher framerate, at the expense of performance. "
+                                         "Lower values may activate a game's internal "
+                                         "frameskip, potentially improving performance.\n\n"
                                          "WARNING: Changing this from the default (100%) "
                                          "can and will break games and cause glitches. "
                                          "Do so at your own risk. Please do not report "


### PR DESCRIPTION
There has been a lot of confusion about what the CPU clock override
section does among users, and looking at it… I’m not surprised! It
doesn’t directly state which CPU clock rate is being overridden!

This small change adjusts the language to clarify that the emulated CPU
is being adjusted.

I'm not a coder so this will definitely need some review!