### PR TITLE
Enforce UTF-8 now that VS handles it sanely

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+charset = utf-8
 indent_size = 2
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
Follow up to #5541. [Fixed in 15.3](https://developercommunity.visualstudio.com/solutions/93089/view.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/6152)
<!-- Reviewable:end -->
