### PR TITLE
D3D Backend: Change encoding parameter types from DWORD

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -22,10 +22,10 @@ namespace DX11
 {
 struct EFBEncodeParams
 {
-  DWORD SrcLeft;
-  DWORD SrcTop;
-  DWORD DestWidth;
-  DWORD ScaleFactor;
+  s32 SrcLeft;
+  s32 SrcTop;
+  u32 DestWidth;
+  u32 ScaleFactor;
 };
 
 PSTextureEncoder::PSTextureEncoder()


### PR DESCRIPTION
Change our encoding parameter types from DWORD to our platform agnostic types.  This was requested by @stenzek , he noticed it when reviewing Hybrid XFB.