### PR TITLE
Don't show "N/A" as description when there is no Gecko code

### DIFF
--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
@@ -118,9 +118,6 @@ void GeckoCodeWidget::OnSelectionChanged()
 
   m_code_description->clear();
 
-  if (code.notes.empty())
-    m_code_description->append(tr("N/A"));
-
   for (const auto& line : code.notes)
     m_code_description->append(QString::fromStdString(line));
 


### PR DESCRIPTION
"N/A" can be awkward to handle in translations.

I don't think there's much point in showing "N/A" rather than leaving the description box blank, so let's just leave it blank.