### PR TITLE
When NAND is damaged, show title names from save files

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -582,6 +582,6 @@ std::string UTF16BEToUTF8(const char16_t* str, size_t max_size)
 {
   const char16_t* str_end = std::find(str, str + max_size, '\0');
   std::wstring result(static_cast<size_t>(str_end - str), '\0');
-  std::transform(str, str_end, result.begin(), static_cast<u16(&)(u16)>(Common::swap16));
+  std::transform(str, str_end, result.begin(), static_cast<u16 (&)(u16)>(Common::swap16));
   return UTF16ToUTF8(result);
 }

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -22,6 +22,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
+#include "Common/Swap.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -576,3 +577,11 @@ std::string UTF16ToUTF8(const std::wstring& input)
 }
 
 #endif
+
+std::string UTF16BEToUTF8(const char16_t* str, size_t max_size)
+{
+  const char16_t* str_end = std::find(str, str + max_size, '\0');
+  std::wstring result(static_cast<size_t>(str_end - str), '\0');
+  std::transform(str, str_end, result.begin(), static_cast<u16(&)(u16)>(Common::swap16));
+  return UTF16ToUTF8(result);
+}

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -125,6 +125,7 @@ std::string CP1252ToUTF8(const std::string& str);
 std::string SHIFTJISToUTF8(const std::string& str);
 std::string UTF8ToSHIFTJIS(const std::string& str);
 std::string UTF16ToUTF8(const std::wstring& str);
+std::string UTF16BEToUTF8(const char16_t* str, size_t max_size);  // Stops at \0
 
 #ifdef _WIN32
 

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -166,12 +166,12 @@ std::string TitleDatabase::GetTitleName(const std::string& game_id, TitleType ty
   return iterator != map.end() ? iterator->second : "";
 }
 
-std::string TitleDatabase::GetTitleName(u64 title_id) const
+std::string TitleDatabase::GetChannelName(u64 title_id) const
 {
   const std::string id{
       {static_cast<char>((title_id >> 24) & 0xff), static_cast<char>((title_id >> 16) & 0xff),
        static_cast<char>((title_id >> 8) & 0xff), static_cast<char>(title_id & 0xff)}};
-  return GetTitleName(id, IOS::ES::IsChannel(title_id) ? TitleType::Channel : TitleType::Other);
+  return GetTitleName(id, TitleType::Channel);
 }
 
 std::string TitleDatabase::Describe(const std::string& game_id, TitleType type) const

--- a/Source/Core/Core/TitleDatabase.h
+++ b/Source/Core/Core/TitleDatabase.h
@@ -27,7 +27,9 @@ public:
   // Get a user friendly title name for a game ID.
   // This falls back to returning an empty string if none could be found.
   std::string GetTitleName(const std::string& game_id, TitleType = TitleType::Other) const;
-  std::string GetTitleName(u64 title_id) const;
+
+  // Same as above, but takes a title ID instead of a game ID, and can only find names of channels.
+  std::string GetChannelName(u64 title_id) const;
 
   // Get a description for a game ID (title name if available + game ID).
   std::string Describe(const std::string& game_id, TitleType = TitleType::Other) const;

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SRCS
   VolumeGC.cpp
   VolumeWad.cpp
   VolumeWii.cpp
+  WiiSaveBanner.cpp
   WiiWad.cpp
 )
 

--- a/Source/Core/DiscIO/DiscIO.vcxproj
+++ b/Source/Core/DiscIO/DiscIO.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="VolumeWad.cpp" />
     <ClCompile Include="VolumeWii.cpp" />
     <ClCompile Include="WbfsBlob.cpp" />
+    <ClCompile Include="WiiSaveBanner.cpp" />
     <ClCompile Include="WiiWad.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -77,6 +78,7 @@
     <ClInclude Include="VolumeWad.h" />
     <ClInclude Include="VolumeWii.h" />
     <ClInclude Include="WbfsBlob.h" />
+    <ClInclude Include="WiiSaveBanner.h" />
     <ClInclude Include="WiiWad.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/DiscIO/DiscIO.vcxproj.filters
+++ b/Source/Core/DiscIO/DiscIO.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="DiscExtractor.cpp">
       <Filter>DiscExtractor</Filter>
     </ClCompile>
+    <ClCompile Include="WiiSaveBanner.cpp">
+      <Filter>NAND</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DiscScrubber.h">
@@ -142,6 +145,9 @@
     </ClInclude>
     <ClInclude Include="DiscExtractor.h">
       <Filter>DiscExtractor</Filter>
+    </ClInclude>
+    <ClInclude Include="WiiSaveBanner.h">
+      <Filter>NAND</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -26,17 +26,15 @@ namespace DiscIO
 const IOS::ES::TicketReader Volume::INVALID_TICKET{};
 const IOS::ES::TMDReader Volume::INVALID_TMD{};
 
-std::map<Language, std::string> Volume::ReadWiiNames(const std::vector<u8>& data)
+std::map<Language, std::string> Volume::ReadWiiNames(const std::vector<char16_t>& data)
 {
   std::map<Language, std::string> names;
   for (size_t i = 0; i < NUMBER_OF_LANGUAGES; ++i)
   {
-    size_t name_start = NAME_BYTES_LENGTH * i;
-    size_t name_end = name_start + NAME_BYTES_LENGTH;
-    if (data.size() >= name_end)
+    const size_t name_start = NAME_CHARS_LENGTH * i;
+    if (name_start + NAME_CHARS_LENGTH <= data.size())
     {
-      std::string name = UTF16BEToUTF8(reinterpret_cast<const char16_t*>(data.data() + name_start),
-                                       NAME_STRING_LENGTH);
+      const std::string name = UTF16BEToUTF8(data.data() + name_start, NAME_CHARS_LENGTH);
       if (!name.empty())
         names[static_cast<Language>(i)] = name;
     }

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -116,11 +116,12 @@ protected:
   }
 
   virtual u32 GetOffsetShift() const { return 0; }
-  static std::map<Language, std::string> ReadWiiNames(const std::vector<u8>& data);
+  static std::map<Language, std::string> ReadWiiNames(const std::vector<char16_t>& data);
 
   static const size_t NUMBER_OF_LANGUAGES = 10;
-  static const size_t NAME_STRING_LENGTH = 42;
-  static const size_t NAME_BYTES_LENGTH = NAME_STRING_LENGTH * sizeof(u16);
+  static const size_t NAME_CHARS_LENGTH = 42;
+  static const size_t NAME_BYTES_LENGTH = NAME_CHARS_LENGTH * sizeof(char16_t);
+  static const size_t NAMES_TOTAL_CHARS = NAME_CHARS_LENGTH * NUMBER_OF_LANGUAGES;
   static const size_t NAMES_TOTAL_BYTES = NAME_BYTES_LENGTH * NUMBER_OF_LANGUAGES;
 
   static const IOS::ES::TicketReader INVALID_TICKET;

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -102,8 +102,6 @@ public:
   // Size on disc (compressed size)
   virtual u64 GetRawSize() const = 0;
 
-  static std::vector<u32> GetWiiBanner(int* width, int* height, u64 title_id);
-
 protected:
   template <u32 N>
   std::string DecodeString(const char (&data)[N]) const

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -22,6 +22,7 @@
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeWad.h"
+#include "DiscIO/WiiSaveBanner.h"
 
 namespace DiscIO
 {
@@ -152,7 +153,7 @@ std::vector<u32> VolumeWAD::GetBanner(int* width, int* height) const
   if (!title_id)
     return std::vector<u32>();
 
-  return GetWiiBanner(width, height, *title_id);
+  return WiiSaveBanner(*title_id).GetBanner(width, height);
 }
 
 BlobType VolumeWAD::GetBlobType() const

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -138,10 +138,10 @@ std::map<Language, std::string> VolumeWAD::GetLongNames() const
   if (!m_tmd.IsValid() || !IOS::ES::IsChannel(m_tmd.GetTitleId()))
     return {};
 
-  std::vector<u8> name_data(NAMES_TOTAL_BYTES);
-  if (!Read(m_opening_bnr_offset + 0x9C, NAMES_TOTAL_BYTES, name_data.data()))
+  std::vector<char16_t> names(NAMES_TOTAL_CHARS);
+  if (!Read(m_opening_bnr_offset + 0x9C, NAMES_TOTAL_BYTES, reinterpret_cast<u8*>(names.data())))
     return std::map<Language, std::string>();
-  return ReadWiiNames(name_data);
+  return ReadWiiNames(names);
 }
 
 std::vector<u32> VolumeWAD::GetBanner(int* width, int* height) const

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -29,6 +29,7 @@
 #include "DiscIO/FileSystemGCWii.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
+#include "DiscIO/WiiSaveBanner.h"
 
 namespace DiscIO
 {
@@ -316,7 +317,7 @@ std::vector<u32> VolumeWii::GetBanner(int* width, int* height) const
   if (!title_id)
     return std::vector<u32>();
 
-  return GetWiiBanner(width, height, *title_id);
+  return WiiSaveBanner(*title_id).GetBanner(width, height);
 }
 
 std::string VolumeWii::GetApploaderDate(const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -302,10 +302,10 @@ std::string VolumeWii::GetInternalName(const Partition& partition) const
 
 std::map<Language, std::string> VolumeWii::GetLongNames() const
 {
-  std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);
-  opening_bnr.resize(ReadFile(*this, GetGamePartition(), "opening.bnr", opening_bnr.data(),
-                              opening_bnr.size(), 0x5C));
-  return ReadWiiNames(opening_bnr);
+  std::vector<char16_t> names(NAMES_TOTAL_CHARS);
+  names.resize(ReadFile(*this, GetGamePartition(), "opening.bnr",
+                        reinterpret_cast<u8*>(names.data()), NAMES_TOTAL_BYTES, 0x5C));
+  return ReadWiiNames(names);
 }
 
 std::vector<u32> VolumeWii::GetBanner(int* width, int* height) const

--- a/Source/Core/DiscIO/WiiSaveBanner.cpp
+++ b/Source/Core/DiscIO/WiiSaveBanner.cpp
@@ -1,0 +1,78 @@
+// Copyright 2009 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DiscIO/WiiSaveBanner.h"
+
+#include <string>
+#include <vector>
+
+#include "Common/ColorUtil.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
+#include "Common/File.h"
+#include "Common/NandPaths.h"
+#include "Common/StringUtil.h"
+
+namespace DiscIO
+{
+constexpr unsigned int BANNER_WIDTH = 192;
+constexpr unsigned int BANNER_HEIGHT = 64;
+constexpr unsigned int BANNER_SIZE = BANNER_WIDTH * BANNER_HEIGHT * 2;
+
+constexpr unsigned int ICON_WIDTH = 48;
+constexpr unsigned int ICON_HEIGHT = 48;
+constexpr unsigned int ICON_SIZE = ICON_WIDTH * ICON_HEIGHT * 2;
+
+WiiSaveBanner::WiiSaveBanner(u64 title_id)
+    : WiiSaveBanner(Common::GetTitleDataPath(title_id, Common::FROM_CONFIGURED_ROOT) + "banner.bin")
+{
+}
+
+WiiSaveBanner::WiiSaveBanner(const std::string& path) : m_path(path), m_valid(true)
+{
+  constexpr size_t MINIMUM_SIZE = sizeof(Header) + BANNER_SIZE + ICON_SIZE;
+  File::IOFile file(path, "rb");
+  if (!file.ReadArray(&m_header, 1))
+  {
+    m_header = {};
+    m_valid = false;
+  }
+  else if (file.GetSize() < MINIMUM_SIZE)
+  {
+    m_valid = false;
+  }
+}
+
+std::string WiiSaveBanner::GetName() const
+{
+  return UTF16BEToUTF8(m_header.name, ArraySize(m_header.name));
+}
+
+std::string WiiSaveBanner::GetDescription() const
+{
+  return UTF16BEToUTF8(m_header.description, ArraySize(m_header.description));
+}
+
+std::vector<u32> WiiSaveBanner::GetBanner(int* width, int* height) const
+{
+  *width = 0;
+  *height = 0;
+
+  File::IOFile file(m_path, "rb");
+  if (!file.Seek(sizeof(Header), SEEK_SET))
+    return std::vector<u32>();
+
+  std::vector<u16> banner_data(BANNER_WIDTH * BANNER_HEIGHT);
+  if (!file.ReadArray(banner_data.data(), banner_data.size()))
+    return std::vector<u32>();
+
+  std::vector<u32> image_buffer(BANNER_WIDTH * BANNER_HEIGHT);
+  ColorUtil::decode5A3image(image_buffer.data(), banner_data.data(), BANNER_WIDTH, BANNER_HEIGHT);
+
+  *width = BANNER_WIDTH;
+  *height = BANNER_HEIGHT;
+  return image_buffer;
+}
+
+}  // namespace DiscIO

--- a/Source/Core/DiscIO/WiiSaveBanner.h
+++ b/Source/Core/DiscIO/WiiSaveBanner.h
@@ -1,0 +1,41 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+namespace DiscIO
+{
+class WiiSaveBanner
+{
+public:
+  explicit WiiSaveBanner(u64 title_id);
+  explicit WiiSaveBanner(const std::string& path);
+
+  bool IsValid() const { return m_valid; }
+  const std::string& GetPath() const { return m_path; }
+  std::string GetName() const;
+  std::string GetDescription() const;
+
+  std::vector<u32> GetBanner(int* width, int* height) const;
+
+private:
+  struct Header
+  {
+    char magic[4];  // "WIBN"
+    u32 flags;
+    u16 animation_speed;
+    u8 unused[22];
+    char16_t name[32];
+    char16_t description[32];
+  } m_header;
+
+  bool m_valid;
+  std::string m_path;
+};
+}

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -16,6 +16,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
+
 #include "Core/CommonTitles.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -27,7 +28,10 @@
 #include "Core/State.h"
 #include "Core/TitleDatabase.h"
 #include "Core/WiiUtils.h"
+
 #include "DiscIO/NANDImporter.h"
+#include "DiscIO/WiiSaveBanner.h"
+
 #include "DolphinQt2/AboutDialog.h"
 #include "DolphinQt2/GameList/GameFile.h"
 #include "DolphinQt2/QtUtils/ActionHelper.h"
@@ -557,10 +561,25 @@ void MenuBar::CheckNAND()
     Core::TitleDatabase title_db;
     for (const u64 title_id : result.titles_to_remove)
     {
-      const std::string name = title_db.GetTitleName(title_id);
-      title_listings += !name.empty() ?
-                            StringFromFormat("%s (%016" PRIx64 ")", name.c_str(), title_id) :
-                            StringFromFormat("%016" PRIx64, title_id);
+      title_listings += StringFromFormat("%016" PRIx64, title_id);
+
+      const std::string database_name = title_db.GetChannelName(title_id);
+      if (!database_name.empty())
+      {
+        title_listings += " - " + database_name;
+      }
+      else
+      {
+        DiscIO::WiiSaveBanner banner(title_id);
+        if (banner.IsValid())
+        {
+          title_listings += " - " + banner.GetName();
+          const std::string description = banner.GetDescription();
+          if (!StripSpaces(description).empty())
+            title_listings += " - " + description;
+        }
+      }
+
       title_listings += "\n";
     }
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -57,11 +57,13 @@
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/State.h"
+#include "Core/TitleDatabase.h"
 #include "Core/WiiUtils.h"
 
 #include "DiscIO/Enums.h"
 #include "DiscIO/NANDImporter.h"
 #include "DiscIO/VolumeWad.h"
+#include "DiscIO/WiiSaveBanner.h"
 
 #include "DolphinWX/AboutDolphin.h"
 #include "DolphinWX/Cheats/CheatsWindow.h"
@@ -1331,10 +1333,25 @@ void CFrame::OnCheckNAND(wxCommandEvent&)
     Core::TitleDatabase title_db;
     for (const u64 title_id : result.titles_to_remove)
     {
-      const std::string name = title_db.GetTitleName(title_id);
-      title_listings += !name.empty() ?
-                            StringFromFormat("%s (%016" PRIx64 ")", name.c_str(), title_id) :
-                            StringFromFormat("%016" PRIx64, title_id);
+      title_listings += StringFromFormat("%016" PRIx64, title_id);
+
+      const std::string database_name = title_db.GetChannelName(title_id);
+      if (!database_name.empty())
+      {
+        title_listings += " - " + database_name;
+      }
+      else
+      {
+        DiscIO::WiiSaveBanner banner(title_id);
+        if (banner.IsValid())
+        {
+          title_listings += " - " + banner.GetName();
+          const std::string description = banner.GetDescription();
+          if (!StripSpaces(description).empty())
+            title_listings += " - " + description;
+        }
+      }
+
       title_listings += "\n";
     }
 
@@ -1344,7 +1361,7 @@ void CFrame::OnCheckNAND(wxCommandEvent&)
           "By continuing, the following title(s) will be removed:\n\n"
           "%s"
           "\nLaunching these titles may also fix the issues."),
-        title_listings.c_str());
+        StrToWxStr(title_listings));
   }
 
   if (wxMessageBox(message, _("NAND Check"), wxYES_NO) != wxYES)

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -34,6 +34,7 @@
 #include "DiscIO/Blob.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
+#include "DiscIO/WiiSaveBanner.h"
 
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
@@ -263,8 +264,9 @@ bool GameListItem::BannerChanged()
     return false;
 
   auto& banner = m_pending.volume_banner;
-  std::vector<u32> buffer = DiscIO::Volume::GetWiiBanner(&banner.width, &banner.height, m_title_id);
-  if (!buffer.size())
+  std::vector<u32> buffer =
+      DiscIO::WiiSaveBanner(m_title_id).GetBanner(&banner.width, &banner.height);
+  if (buffer.empty())
     return false;
 
   ReadVolumeBanner(&banner.buffer, buffer, banner.width, banner.height);


### PR DESCRIPTION
The earlier code always tried to use TitleDatabase for getting title names, but that didn't work for disc-based games, because there was no way to get the maker ID.