### PR TITLE
Revert "Convert to/from old EFB scale numbering"

### DIFF
--- a/Data/Sys/GameSettings/G9S.ini
+++ b/Data/Sys/GameSettings/G9S.ini
@@ -19,6 +19,6 @@ EmulationIssues = Use directx11 backend with efb scale set at 1x to deal with bl
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
-EFBScale = 2
+InternalResolution = 1
 MSAA = 0
 MaxAnisotropy = 0

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -82,7 +82,7 @@ public final class SettingsFile
 	public static final String KEY_AUDIO_STRETCH = "AudioStretch";
 
 	public static final String KEY_SHOW_FPS = "ShowFPS";
-	public static final String KEY_INTERNAL_RES = "EFBScale";
+	public static final String KEY_INTERNAL_RES = "InternalResolution";
 	public static final String KEY_FSAA = "MSAA";
 	public static final String KEY_ANISOTROPY = "MaxAnisotropy";
 	public static final String KEY_POST_SHADER = "PostProcessingShader";

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -111,12 +111,12 @@
         <item>6x Native (3840x3168) for 4K</item>
     </string-array>
     <integer-array name="internalResolutionValues" translatable="false">
+        <item>1</item>
         <item>2</item>
+        <item>3</item>
         <item>4</item>
+        <item>5</item>
         <item>6</item>
-        <item>7</item>
-        <item>8</item>
-        <item>9</item>
     </integer-array>
 
     <!-- FSAA Preference -->

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -224,10 +224,10 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-vsync", g_Config.bVSync);
   builder.AddData("cfg-gfx-aspect-ratio", g_Config.iAspectRatio);
   builder.AddData("cfg-gfx-efb-access", g_Config.bEFBAccessEnable);
-  builder.AddData("cfg-gfx-efb-scale", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-efb-copy-format-changes", g_Config.bEFBEmulateFormatChanges);
   builder.AddData("cfg-gfx-efb-copy-ram", !g_Config.bSkipEFBCopyToRam);
   builder.AddData("cfg-gfx-efb-copy-scaled", g_Config.bCopyEFBScaled);
+  builder.AddData("cfg-gfx-internal-resolution", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-tc-samples", g_Config.iSafeTextureCache_ColorSamples);
   builder.AddData("cfg-gfx-stereo-mode", g_Config.iStereoMode);
   builder.AddData("cfg-gfx-per-pixel-lighting", g_Config.bEnablePixelLighting);

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -4,48 +4,13 @@
 
 #include "Core/Config/GraphicsSettings.h"
 
-#include <optional>
 #include <string>
 
 #include "Common/Config/Config.h"
-#include "Common/StringUtil.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace Config
 {
-std::optional<int> ConvertFromLegacyEFBScale(int efb_scale)
-{
-  // In game INIs, -1 was used as a special value meaning
-  // "use the value from the base layer but round it to an integer scale".
-  // We only support integer scales nowadays, so we can simply ignore -1
-  // in game INIs in order to automatically use a previous layer's value.
-  if (efb_scale < 0)
-    return {};
-
-  return efb_scale - (efb_scale > 0) - (efb_scale > 2) - (efb_scale > 4);
-}
-
-std::optional<int> ConvertFromLegacyEFBScale(const std::string& efb_scale)
-{
-  int efb_scale_int;
-  if (!TryParse(efb_scale, &efb_scale_int))
-    return {};
-  return ConvertFromLegacyEFBScale(efb_scale_int);
-}
-
-int ConvertToLegacyEFBScale(int efb_scale)
-{
-  return efb_scale + (efb_scale >= 0) + (efb_scale > 1) + (efb_scale > 2);
-}
-
-std::optional<int> ConvertToLegacyEFBScale(const std::string& efb_scale)
-{
-  int efb_scale_int;
-  if (!TryParse(efb_scale, &efb_scale_int))
-    return {};
-  return ConvertToLegacyEFBScale(efb_scale_int);
-}
-
 // Configuration Information
 
 // Graphics.Hardware
@@ -97,7 +62,7 @@ const ConfigInfo<bool> GFX_ENABLE_PIXEL_LIGHTING{{System::GFX, "Settings", "Enab
 const ConfigInfo<bool> GFX_FAST_DEPTH_CALC{{System::GFX, "Settings", "FastDepthCalc"}, true};
 const ConfigInfo<u32> GFX_MSAA{{System::GFX, "Settings", "MSAA"}, 1};
 const ConfigInfo<bool> GFX_SSAA{{System::GFX, "Settings", "SSAA"}, false};
-const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "EFBScale"}, 1};
+const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "InternalResolution"}, 1};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_ENABLE{{System::GFX, "Settings", "TexFmtOverlayEnable"},
                                                  false};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER{{System::GFX, "Settings", "TexFmtOverlayCenter"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -4,18 +4,12 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 
 #include "Common/Config/Config.h"
 
 namespace Config
 {
-std::optional<int> ConvertFromLegacyEFBScale(int efb_scale);
-std::optional<int> ConvertFromLegacyEFBScale(const std::string& efb_scale);
-int ConvertToLegacyEFBScale(int efb_scale);
-std::optional<int> ConvertToLegacyEFBScale(const std::string& efb_scale);
-
 // Configuration Information
 
 // Graphics.Hardware

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -19,7 +19,6 @@
 #include "Common/Logging/Log.h"
 #include "Common/SysConf.h"
 
-#include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 #include "Core/Core.h"
@@ -95,19 +94,7 @@ public:
         const IniFile::Section::SectionMap& section_map = section.GetValues();
 
         for (const auto& value : section_map)
-        {
-          const Config::ConfigLocation location{system.first, section_name, value.first};
-          if (location == Config::GFX_EFB_SCALE.location)
-          {
-            std::optional<int> efb_scale = Config::ConvertFromLegacyEFBScale(value.second);
-            if (efb_scale)
-              config_section->Set(value.first, *efb_scale);
-          }
-          else
-          {
-            config_section->Set(value.first, value.second);
-          }
-        }
+          config_section->Set(value.first, value.second);
       }
     }
   }
@@ -143,20 +130,10 @@ public:
 
         for (const auto& value : section_values)
         {
-          const Config::ConfigLocation location{system.first, section->GetName(), value.first};
-          if (!IsSettingSaveable(location))
+          if (!IsSettingSaveable({system.first, section->GetName(), value.first}))
             continue;
 
-          if (location == Config::GFX_EFB_SCALE.location)
-          {
-            std::optional<int> efb_scale = Config::ConvertToLegacyEFBScale(value.second);
-            if (efb_scale)
-              ini_section->Set(value.first, *efb_scale);
-          }
-          else
-          {
-            ini_section->Set(value.first, value.second);
-          }
+          ini_section->Set(value.first, value.second);
         }
       }
 

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -86,7 +86,7 @@ static const INIToLocationMap& GetINIToLocationMap()
       {{"Video_Settings", "MSAA"}, {Config::GFX_MSAA.location}},
       {{"Video_Settings", "SSAA"}, {Config::GFX_SSAA.location}},
       {{"Video_Settings", "ForceTrueColor"}, {Config::GFX_ENHANCE_FORCE_TRUE_COLOR.location}},
-      {{"Video_Settings", "EFBScale"}, {Config::GFX_EFB_SCALE.location}},
+      {{"Video_Settings", "InternalResolution"}, {Config::GFX_EFB_SCALE.location}},
       {{"Video_Settings", "DisableFog"}, {Config::GFX_DISABLE_FOG.location}},
       {{"Video_Settings", "BackendMultithreading"}, {Config::GFX_BACKEND_MULTITHREADING.location}},
       {{"Video_Settings", "CommandBufferExecuteInterval"},
@@ -319,17 +319,7 @@ private:
 
       auto* config_section =
           config_layer->GetOrCreateSection(mapped_config.system, mapped_config.section);
-
-      if (mapped_config == Config::GFX_EFB_SCALE.location)
-      {
-        std::optional<int> efb_scale = Config::ConvertFromLegacyEFBScale(value.second);
-        if (efb_scale)
-          config_section->Set(mapped_config.key, *efb_scale);
-      }
-      else
-      {
-        config_section->Set(mapped_config.key, value.second);
-      }
+      config_section->Set(mapped_config.key, value.second);
     }
   }
 
@@ -352,25 +342,16 @@ void INIGameConfigLayerLoader::Save(Config::Layer* config_layer)
     {
       for (const auto& value : section->GetValues())
       {
-        const Config::ConfigLocation location{system.first, section->GetName(), value.first};
-        if (!IsSettingSaveable(location))
+        if (!IsSettingSaveable({system.first, section->GetName(), value.first}))
           continue;
 
-        const auto ini_location = GetINILocationFromConfig(location);
+        const auto ini_location =
+            GetINILocationFromConfig({system.first, section->GetName(), value.first});
         if (ini_location.first.empty() && ini_location.second.empty())
           continue;
 
         IniFile::Section* ini_section = ini.GetOrCreateSection(ini_location.first);
-        if (location == Config::GFX_EFB_SCALE.location)
-        {
-          std::optional<int> efb_scale = Config::ConvertToLegacyEFBScale(value.second);
-          if (efb_scale)
-            ini_section->Set(ini_location.second, *efb_scale);
-        }
-        else
-        {
-          ini_section->Set(ini_location.second, value.second);
-        }
+        ini_section->Set(ini_location.second, value.second);
       }
     }
   }


### PR DESCRIPTION
This reverts commit 1fc910b3ea9eafcc3cc5132bdfc51731ba5fa9fd, replacing the old INI setting EFBScale with a new INI setting called InternalResolution, which has a simpler mapping:

Choice            | EFBScale             | InternalResolution
----------------- | -------------------- | --------------------
Auto (fractional) | 0                    |
Auto (integral)   | 1                    | 0
1x                | 2                    | 1
1.5x              | 3                    |
2x                | 4                    | 2
2.5x              | 5                    |
3x                | 6                    | 3
4x                | 7                    | 4
5x                | 8                    | 5
6x                | 9                    | 6

All the fractional IRs were removed in PR #5744.

---------------------------------------------------------------

This change was suggested by @MayImilae. I'm not sure what the best way to go is, so I opened this PR in order to facilitate a discussion.