### PR TITLE
Fix incorrect handling of auto IR

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -131,7 +131,7 @@ void PSTextureEncoder::Encode(u8* dst, const EFBCopyParams& params, u32 native_w
     // TODO: This only produces perfect downsampling for 2x IR, other resolutions will need more
     //       complex down filtering to average all pixels and produce the correct result.
     // Also, box filtering won't be correct for anything other than 1x IR
-    if (scale_by_half || g_ActiveConfig.iEFBScale != 1)
+    if (scale_by_half || g_renderer->GetEFBScale() != 1)
       D3D::SetLinearCopySampler();
     else
       D3D::SetPointCopySampler();

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -233,7 +233,7 @@ static void EncodeToRamUsingShader(GLuint srcTexture, u8* destAddr, u32 dst_line
   // TODO: This only produces perfect downsampling for 2x IR, other resolutions will need more
   //       complex down filtering to average all pixels and produce the correct result.
   // Also, box filtering won't be correct for anything other than 1x IR
-  if (linearFilter || g_ActiveConfig.iEFBScale != 1)
+  if (linearFilter || g_renderer->GetEFBScale() != 1)
     g_sampler_cache->BindLinearSampler(9);
   else
     g_sampler_cache->BindNearestSampler(9);

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -250,7 +250,7 @@ void TextureConverter::EncodeTextureToMemory(VkImageView src_texture, u8* dest_p
   // We also linear filtering for both box filtering and downsampling higher resolutions to 1x
   // TODO: This only produces perfect downsampling for 2x IR, other resolutions will need more
   //       complex down filtering to average all pixels and produce the correct result.
-  bool linear_filter = (scale_by_half && !params.depth) || g_ActiveConfig.iEFBScale != 1;
+  bool linear_filter = (scale_by_half && !params.depth) || g_renderer->GetEFBScale() != 1;
   draw.SetPSSampler(0, src_texture, linear_filter ? g_object_cache->GetLinearSampler() :
                                                     g_object_cache->GetPointSampler());
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -131,6 +131,11 @@ void Renderer::RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbStri
   }
 }
 
+unsigned int Renderer::GetEFBScale() const
+{
+  return m_efb_scale;
+}
+
 int Renderer::EFBToScaledX(int x) const
 {
   return x * static_cast<int>(m_efb_scale);

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -101,6 +101,8 @@ public:
   std::tuple<TargetRectangle, TargetRectangle>
   ConvertStereoRectangle(const TargetRectangle& rc) const;
 
+  unsigned int GetEFBScale() const;
+
   // Use this to upscale native EFB coordinates to IDEAL internal resolution
   int EFBToScaledX(int x) const;
   int EFBToScaledY(int y) const;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -258,7 +258,7 @@ static void SetSamplerState(u32 index, bool custom_tex, bool has_arbitrary_mips)
     // that have arbitrary contents, eg. are used for fog effects where the
     // distance they kick in at is important to preserve at any resolution.
     state.lod_bias =
-        state.lod_bias + std::log2(static_cast<float>(g_ActiveConfig.iEFBScale)) * 256.f;
+        state.lod_bias + std::log2(static_cast<float>(g_renderer->GetEFBScale())) * 256.f;
 
     // Anisotropic also pushes mips farther away so it cannot be used either
     state.anisotropic_filtering = 0;


### PR DESCRIPTION
Some lines of code in Dolphin just plainly grabbed the value of `g_ActiveConfig.iEFBScale`, which resulted in Auto being treated as 0x rather than the actual automatically selected scale.

Someone who knows about the graphics backends, please review this. I'm not sure if this is a correct fix.