### PR TITLE
ControllerInterface: cleanup callbacks API and logic

### DIFF
--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -37,7 +37,7 @@ void Initialize()
       s_config.CreateController<GCKeyboard>(i);
   }
 
-  g_controller_interface.RegisterHotplugCallback(LoadConfig);
+  g_controller_interface.RegisterDevicesChangedCallback(LoadConfig);
 
   // Load the saved controller config
   s_config.LoadConfig(true);

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -34,7 +34,7 @@ void Initialize()
       s_config.CreateController<GCPad>(i);
   }
 
-  g_controller_interface.RegisterHotplugCallback(LoadConfig);
+  g_controller_interface.RegisterDevicesChangedCallback(LoadConfig);
 
   // Load the saved controller config
   s_config.LoadConfig(true);

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -80,7 +80,7 @@ void Initialize(InitializeMode init_mode)
       s_config.CreateController<WiimoteEmu::Wiimote>(i);
   }
 
-  g_controller_interface.RegisterHotplugCallback(LoadConfig);
+  g_controller_interface.RegisterDevicesChangedCallback(LoadConfig);
 
   LoadConfig();
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -213,7 +213,7 @@ void Initialize()
   if (s_config.ControllersNeedToBeCreated())
     s_config.CreateController<HotkeyManager>();
 
-  g_controller_interface.RegisterHotplugCallback(LoadConfig);
+  g_controller_interface.RegisterDevicesChangedCallback(LoadConfig);
 
   // load the saved controller config
   s_config.LoadConfig(true);

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -4,7 +4,7 @@
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-#include <mutex>
+#include <algorithm>
 
 #include "Common/Logging/Log.h"
 
@@ -232,6 +232,7 @@ void ControllerInterface::UpdateInput()
 //
 void ControllerInterface::RegisterDevicesChangedCallback(std::function<void()> callback)
 {
+  std::lock_guard<std::mutex> lk(m_callbacks_mutex);
   m_devices_changed_callbacks.emplace_back(std::move(callback));
 }
 
@@ -242,6 +243,7 @@ void ControllerInterface::RegisterDevicesChangedCallback(std::function<void()> c
 //
 void ControllerInterface::InvokeDevicesChangedCallbacks() const
 {
+  std::lock_guard<std::mutex> lk(m_callbacks_mutex);
   for (const auto& callback : m_devices_changed_callbacks)
     callback();
 }

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -188,7 +188,7 @@ void ControllerInterface::AddDevice(std::shared_ptr<ciface::Core::Device> device
     NOTICE_LOG(SERIALINTERFACE, "Added device: %s", device->GetQualifiedName().c_str());
     m_devices.emplace_back(std::move(device));
   }
-  InvokeHotplugCallbacks();
+  InvokeDevicesChangedCallbacks();
 }
 
 void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::Device*)> callback)
@@ -205,7 +205,7 @@ void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::De
     });
     m_devices.erase(it, m_devices.end());
   }
-  InvokeHotplugCallbacks();
+  InvokeDevicesChangedCallbacks();
 }
 
 //
@@ -225,23 +225,23 @@ void ControllerInterface::UpdateInput()
 }
 
 //
-// RegisterHotplugCallback
+// RegisterDevicesChangedCallback
 //
-// Register a callback to be called from the input backends' hotplug thread
-// when there is a new device
+// Register a callback to be called when a device is added or removed (as from the input backends'
+// hotplug thread), or when devices are refreshed
 //
-void ControllerInterface::RegisterHotplugCallback(std::function<void()> callback)
+void ControllerInterface::RegisterDevicesChangedCallback(std::function<void()> callback)
 {
-  m_hotplug_callbacks.emplace_back(std::move(callback));
+  m_devices_changed_callbacks.emplace_back(std::move(callback));
 }
 
 //
-// InvokeHotplugCallbacks
+// InvokeDevicesChangedCallbacks
 //
 // Invoke all callbacks that were registered
 //
-void ControllerInterface::InvokeHotplugCallbacks() const
+void ControllerInterface::InvokeDevicesChangedCallbacks() const
 {
-  for (const auto& callback : m_hotplug_callbacks)
+  for (const auto& callback : m_devices_changed_callbacks)
     callback();
 }

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -47,6 +47,7 @@ void ControllerInterface::Initialize(void* const hwnd)
     return;
 
   m_hwnd = hwnd;
+  m_is_populating_devices = true;
 
 #ifdef CIFACE_USE_DINPUT
 // nothing needed
@@ -88,6 +89,8 @@ void ControllerInterface::RefreshDevices()
     m_devices.clear();
   }
 
+  m_is_populating_devices = true;
+
 #ifdef CIFACE_USE_DINPUT
   ciface::DInput::PopulateDevices(reinterpret_cast<HWND>(m_hwnd));
 #endif
@@ -113,6 +116,9 @@ void ControllerInterface::RefreshDevices()
 #ifdef CIFACE_USE_PIPES
   ciface::Pipes::PopulateDevices();
 #endif
+
+  m_is_populating_devices = false;
+  InvokeDevicesChangedCallbacks();
 }
 
 //
@@ -188,7 +194,9 @@ void ControllerInterface::AddDevice(std::shared_ptr<ciface::Core::Device> device
     NOTICE_LOG(SERIALINTERFACE, "Added device: %s", device->GetQualifiedName().c_str());
     m_devices.emplace_back(std::move(device));
   }
-  InvokeDevicesChangedCallbacks();
+
+  if (!m_is_populating_devices)
+    InvokeDevicesChangedCallbacks();
 }
 
 void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::Device*)> callback)
@@ -205,7 +213,9 @@ void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::De
     });
     m_devices.erase(it, m_devices.end());
   }
-  InvokeDevicesChangedCallbacks();
+
+  if (!m_is_populating_devices)
+    InvokeDevicesChangedCallbacks();
 }
 
 //

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -54,9 +54,10 @@ public:
   void UpdateInput();
 
   void RegisterHotplugCallback(std::function<void(void)> callback);
-  void InvokeHotplugCallbacks() const;
 
 private:
+  void InvokeHotplugCallbacks() const;
+
   std::vector<std::function<void()>> m_hotplug_callbacks;
   bool m_is_init;
   void* m_hwnd;

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -4,14 +4,11 @@
 
 #pragma once
 
-#include <algorithm>
 #include <functional>
-#include <map>
-#include <sstream>
-#include <string>
+#include <memory>
+#include <mutex>
 #include <vector>
 
-#include "Common/CommonTypes.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 // enable disable sources
@@ -58,6 +55,7 @@ public:
 
 private:
   std::vector<std::function<void()>> m_devices_changed_callbacks;
+  mutable std::mutex m_callbacks_mutex;
   bool m_is_init;
   void* m_hwnd;
 };

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -53,12 +53,11 @@ public:
   bool IsInit() const { return m_is_init; }
   void UpdateInput();
 
-  void RegisterHotplugCallback(std::function<void(void)> callback);
+  void RegisterDevicesChangedCallback(std::function<void(void)> callback);
+  void InvokeDevicesChangedCallbacks() const;
 
 private:
-  void InvokeHotplugCallbacks() const;
-
-  std::vector<std::function<void()>> m_hotplug_callbacks;
+  std::vector<std::function<void()>> m_devices_changed_callbacks;
   bool m_is_init;
   void* m_hwnd;
 };

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -57,6 +58,7 @@ private:
   std::vector<std::function<void()>> m_devices_changed_callbacks;
   mutable std::mutex m_callbacks_mutex;
   bool m_is_init;
+  std::atomic<bool> m_is_populating_devices{false};
   void* m_hwnd;
 };
 

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "InputCommon/ControllerInterface/Device.h"
+
 #include <memory>
 #include <sstream>
 #include <string>
 #include <tuple>
 
-#include "InputCommon/ControllerInterface/Device.h"
+#include "Common/StringUtil.h"
 
 namespace ciface
 {
@@ -37,6 +39,11 @@ void Device::AddInput(Device::Input* const i)
 void Device::AddOutput(Device::Output* const o)
 {
   m_outputs.push_back(o);
+}
+
+std::string Device::GetQualifiedName() const
+{
+  return StringFromFormat("%s/%i/%s", this->GetSource().c_str(), GetId(), this->GetName().c_str());
 }
 
 Device::Input* Device::FindInput(const std::string& name) const

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -79,6 +79,7 @@ public:
   void SetId(int id) { m_id = id; }
   virtual std::string GetName() const = 0;
   virtual std::string GetSource() const = 0;
+  std::string GetQualifiedName() const;
   virtual void UpdateInput() {}
   virtual bool IsValid() const { return true; }
   const std::vector<Input*>& Inputs() const { return m_inputs; }

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
@@ -156,8 +156,6 @@ static void DeviceRemovalCallback(void* inContext, IOReturn inResult, void* inSe
 
     return false;
   });
-  g_controller_interface.InvokeHotplugCallbacks();
-  NOTICE_LOG(SERIALINTERFACE, "Removed device: %s", GetDeviceRefName(inIOHIDDeviceRef).c_str());
 }
 
 static void DeviceMatchingCallback(void* inContext, IOReturn inResult, void* inSender,
@@ -174,9 +172,6 @@ static void DeviceMatchingCallback(void* inContext, IOReturn inResult, void* inS
   {
     g_controller_interface.AddDevice(std::make_shared<Joystick>(inIOHIDDeviceRef, name));
   }
-
-  NOTICE_LOG(SERIALINTERFACE, "Added device: %s", name.c_str());
-  g_controller_interface.InvokeHotplugCallbacks();
 }
 
 void Init(void* window)

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -92,9 +92,7 @@ static void HotplugThreadFunc()
       g_controller_interface.RemoveDevice([&name](const auto& device) {
         return device->GetSource() == "evdev" && device->GetName() == name && !device->IsValid();
       });
-      NOTICE_LOG(SERIALINTERFACE, "Removed device: %s", name.c_str());
       s_devnode_name_map.erase(devnode);
-      g_controller_interface.InvokeHotplugCallbacks();
     }
     // Only react to "device added" events for evdev devices that we can access.
     else if (strcmp(action, "add") == 0 && access(devnode, W_OK) == 0)
@@ -107,8 +105,6 @@ static void HotplugThreadFunc()
       {
         g_controller_interface.AddDevice(std::move(device));
         s_devnode_name_map.insert(std::pair<std::string, std::string>(devnode, name));
-        NOTICE_LOG(SERIALINTERFACE, "Added new device: %s", name.c_str());
-        g_controller_interface.InvokeHotplugCallbacks();
       }
     }
     udev_device_unref(dev);


### PR DESCRIPTION
~~Some backends already trigger the callbacks when `RefreshDevices` is called, so make it consistent across systems. This makes the callback a bit more useful as well.~~

This PR:
- renames `Register/InvokeHotplugCallback` to `Register/InvokeDevicesChangedCallback`
- invokes callbacks on calls to `AddDevice` or `RemoveDevice`, and removes the manual callback invocations from the evdev and OSX backends
- ensures that callbacks get invoked exactly once when `RefreshDevices` is called
- adds a mutex around the callbacks vector, since callbacks may be added and invoked from different threads at different times