### PR TITLE
EmulatedController: encapsulate default device behind getters/setters

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
@@ -114,7 +114,7 @@ void IOWindow::Update()
   m_range_spinbox->setValue(m_reference->range * SLIDER_TICK_COUNT);
   m_range_slider->setValue(m_reference->range * SLIDER_TICK_COUNT);
 
-  m_devq.FromString(m_controller->default_device.ToString());
+  m_devq.FromString(m_controller->GetDefaultDevice().ToString());
 
   UpdateDeviceList();
   UpdateOptionList();
@@ -147,7 +147,7 @@ void IOWindow::AppendSelectedOption(const std::string& prefix)
   m_expression_text->insertPlainText(
       QString::fromStdString(prefix) +
       MappingCommon::GetExpressionForControl(m_option_list->currentItem()->text(), m_devq,
-                                             m_controller->default_device));
+                                             m_controller->GetDefaultDevice()));
 }
 
 void IOWindow::OnDeviceChanged(const QString& device)
@@ -237,10 +237,9 @@ void IOWindow::UpdateDeviceList()
   Core::RunAsCPUThread([&] {
     g_controller_interface.RefreshDevices();
     m_controller->UpdateReferences(g_controller_interface);
-    m_controller->UpdateDefaultDevice();
 
     // Adding default device regardless if it's currently connected or not
-    const auto default_device = m_controller->default_device.ToString();
+    const auto default_device = m_controller->GetDefaultDevice().ToString();
 
     m_devices_combo->addItem(QString::fromStdString(default_device));
 

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -56,9 +56,9 @@ void MappingButton::OnButtonPressed()
     // Avoid that the button press itself is registered as an event
     Common::SleepCurrentThread(100);
 
-    const auto expr = MappingCommon::DetectExpression(m_reference, dev.get(),
-                                                      m_parent->GetParent()->GetDeviceQualifier(),
-                                                      m_parent->GetController()->default_device);
+    const auto expr = MappingCommon::DetectExpression(
+        m_reference, dev.get(), m_parent->GetParent()->GetDeviceQualifier(),
+        m_parent->GetController()->GetDefaultDevice());
 
     releaseMouse();
     releaseKeyboard();

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -211,7 +211,7 @@ void MappingWindow::OnDeviceChanged(int index)
 {
   const auto device = m_devices_combo->currentText().toStdString();
   m_devq.FromString(device);
-  m_controller->default_device.FromString(device);
+  m_controller->SetDefaultDevice(device);
 }
 
 void MappingWindow::RefreshDevices()
@@ -221,9 +221,8 @@ void MappingWindow::RefreshDevices()
   Core::RunAsCPUThread([&] {
     g_controller_interface.RefreshDevices();
     m_controller->UpdateReferences(g_controller_interface);
-    m_controller->UpdateDefaultDevice();
 
-    const auto default_device = m_controller->default_device.ToString();
+    const auto default_device = m_controller->GetDefaultDevice().ToString();
 
     m_devices_combo->addItem(QString::fromStdString(default_device));
 

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -198,7 +198,7 @@ ControlDialog::ControlDialog(InputConfigDialog* const parent, InputConfig& confi
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       control_reference(ref), m_config(config), m_parent(parent)
 {
-  m_devq = m_parent->GetController()->default_device;
+  m_devq = m_parent->GetController()->GetDefaultDevice();
   const int space5 = FromDIP(5);
 
   // GetStrings() sounds slow :/
@@ -360,7 +360,7 @@ void ControlDialog::UpdateGUI()
 void InputConfigDialog::UpdateGUI()
 {
   if (device_cbox != nullptr)
-    device_cbox->SetValue(StrToWxStr(controller->default_device.ToString()));
+    device_cbox->SetValue(StrToWxStr(controller->GetDefaultDevice().ToString()));
 
   for (ControlGroupBox* cgBox : control_groups)
   {
@@ -405,7 +405,7 @@ bool ControlDialog::Validate()
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
-                                     m_parent->GetController()->default_device);
+                                     m_parent->GetController()->GetDefaultDevice());
 
   UpdateGUI();
 
@@ -415,13 +415,10 @@ bool ControlDialog::Validate()
 
 void InputConfigDialog::SetDevice(wxCommandEvent&)
 {
-  controller->default_device.FromString(WxStrToStr(device_cbox->GetValue()));
+  controller->SetDefaultDevice(WxStrToStr(device_cbox->GetValue()));
 
   // show user what it was validated as
-  device_cbox->SetValue(StrToWxStr(controller->default_device.ToString()));
-
-  // this will set all the controls to this default device
-  controller->UpdateDefaultDevice();
+  device_cbox->SetValue(StrToWxStr(controller->GetDefaultDevice().ToString()));
 
   // update references
   controller->UpdateReferences(g_controller_interface);
@@ -444,7 +441,7 @@ void ControlDialog::ClearControl(wxCommandEvent&)
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
-                                     m_parent->GetController()->default_device);
+                                     m_parent->GetController()->GetDefaultDevice());
 
   UpdateGUI();
 }
@@ -459,8 +456,8 @@ inline bool IsAlphabetic(wxString& str)
 }
 
 inline void GetExpressionForControl(wxString& expr, wxString& control_name,
-                                    ciface::Core::DeviceQualifier* control_device = nullptr,
-                                    ciface::Core::DeviceQualifier* default_device = nullptr)
+                                    const ciface::Core::DeviceQualifier* control_device = nullptr,
+                                    const ciface::Core::DeviceQualifier* default_device = nullptr)
 {
   expr = "";
 
@@ -486,7 +483,8 @@ bool ControlDialog::GetExpressionForSelectedControl(wxString& expr)
     return false;
 
   wxString control_name = control_lbox->GetString(num);
-  GetExpressionForControl(expr, control_name, &m_devq, &m_parent->GetController()->default_device);
+  GetExpressionForControl(expr, control_name, &m_devq,
+                          &m_parent->GetController()->GetDefaultDevice());
 
   return true;
 }
@@ -503,7 +501,7 @@ void ControlDialog::SetSelectedControl(wxCommandEvent&)
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
-                                     m_parent->GetController()->default_device);
+                                     m_parent->GetController()->GetDefaultDevice());
 
   UpdateGUI();
 }
@@ -539,7 +537,7 @@ void ControlDialog::AppendControl(wxCommandEvent& event)
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
   control_reference->UpdateReference(g_controller_interface,
-                                     m_parent->GetController()->default_device);
+                                     m_parent->GetController()->GetDefaultDevice());
 
   UpdateGUI();
 }
@@ -700,7 +698,7 @@ bool InputConfigDialog::DetectButton(ControlButton* button)
 {
   bool success = false;
   // find device :/
-  const auto dev = g_controller_interface.FindDevice(controller->default_device);
+  const auto dev = g_controller_interface.FindDevice(controller->GetDefaultDevice());
   if (dev != nullptr)
   {
     m_event_filter.BlockEvents(true);
@@ -721,7 +719,7 @@ bool InputConfigDialog::DetectButton(ControlButton* button)
       button->control_reference->SetExpression(WxStrToStr(expr));
       const auto lock = ControllerEmu::EmulatedController::GetStateLock();
       button->control_reference->UpdateReference(g_controller_interface,
-                                                 controller->default_device);
+                                                 controller->GetDefaultDevice());
       success = true;
     }
 
@@ -912,7 +910,7 @@ void InputConfigDialog::UpdateDeviceComboBox()
   for (const std::string& device_string : g_controller_interface.GetAllDeviceStrings())
     device_cbox->Append(StrToWxStr(device_string));
 
-  device_cbox->SetValue(StrToWxStr(controller->default_device.ToString()));
+  device_cbox->SetValue(StrToWxStr(controller->GetDefaultDevice().ToString()));
 }
 
 void InputConfigDialog::RefreshDevices(wxCommandEvent&)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -78,7 +78,7 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
 
     for (auto& ai : ext->attachments)
     {
-      ai->default_device.FromString(defdev);
+      ai->SetDefaultDevice(defdev);
       ai->LoadConfig(sec, base + ai->GetName() + "/");
 
       if (ai->GetName() == extname)

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -37,7 +37,7 @@ void EmulatedController::UpdateReferences(const ControllerInterface& devi)
   for (auto& ctrlGroup : groups)
   {
     for (auto& control : ctrlGroup->controls)
-      control->control_ref.get()->UpdateReference(devi, default_device);
+      control->control_ref.get()->UpdateReference(devi, GetDefaultDevice());
 
     // extension
     if (ctrlGroup->type == GroupType::Extension)
@@ -48,8 +48,22 @@ void EmulatedController::UpdateReferences(const ControllerInterface& devi)
   }
 }
 
-void EmulatedController::UpdateDefaultDevice()
+const ciface::Core::DeviceQualifier& EmulatedController::GetDefaultDevice() const
 {
+  return m_default_device;
+}
+
+void EmulatedController::SetDefaultDevice(const std::string& device)
+{
+  ciface::Core::DeviceQualifier devq;
+  devq.FromString(device);
+  SetDefaultDevice(std::move(devq));
+}
+
+void EmulatedController::SetDefaultDevice(ciface::Core::DeviceQualifier devq)
+{
+  m_default_device = std::move(devq);
+
   for (auto& ctrlGroup : groups)
   {
     // extension
@@ -57,8 +71,7 @@ void EmulatedController::UpdateDefaultDevice()
     {
       for (auto& ai : ((Extension*)ctrlGroup.get())->attachments)
       {
-        ai->default_device = default_device;
-        ai->UpdateDefaultDevice();
+        ai->SetDefaultDevice(m_default_device);
       }
     }
   }
@@ -66,11 +79,11 @@ void EmulatedController::UpdateDefaultDevice()
 
 void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& base)
 {
-  std::string defdev = default_device.ToString();
+  std::string defdev = GetDefaultDevice().ToString();
   if (base.empty())
   {
     sec->Get(base + "Device", &defdev, "");
-    default_device.FromString(defdev);
+    SetDefaultDevice(defdev);
   }
 
   for (auto& cg : groups)
@@ -79,7 +92,7 @@ void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& ba
 
 void EmulatedController::SaveConfig(IniFile::Section* sec, const std::string& base)
 {
-  const std::string defdev = default_device.ToString();
+  const std::string defdev = GetDefaultDevice().ToString();
   if (base.empty())
     sec->Set(/*std::string(" ") +*/ base + "Device", defdev, "");
 
@@ -96,8 +109,7 @@ void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
   const std::string& default_device_string = ciface.GetDefaultDeviceString();
   if (!default_device_string.empty())
   {
-    default_device.FromString(default_device_string);
-    UpdateDefaultDevice();
+    SetDefaultDevice(default_device_string);
   }
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -32,7 +32,10 @@ public:
 
   virtual void LoadConfig(IniFile::Section* sec, const std::string& base = "");
   virtual void SaveConfig(IniFile::Section* sec, const std::string& base = "");
-  void UpdateDefaultDevice();
+
+  const ciface::Core::DeviceQualifier& GetDefaultDevice() const;
+  void SetDefaultDevice(const std::string& device);
+  void SetDefaultDevice(ciface::Core::DeviceQualifier devq);
 
   void UpdateReferences(const ControllerInterface& devi);
 
@@ -44,6 +47,7 @@ public:
 
   std::vector<std::unique_ptr<ControlGroup>> groups;
 
-  ciface::Core::DeviceQualifier default_device;
+private:
+  ciface::Core::DeviceQualifier m_default_device;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -133,7 +133,7 @@ bool InputConfig::IsControllerControlledByGamepadDevice(int index) const
   if (static_cast<size_t>(index) >= m_controllers.size())
     return false;
 
-  const auto& controller = m_controllers.at(index).get()->default_device;
+  const auto& controller = m_controllers.at(index).get()->GetDefaultDevice();
 
   // Filter out anything which obviously not a gamepad
   return !((controller.source == "Quartz")      // OSX Quartz Keyboard/Mouse


### PR DESCRIPTION
And remove the requirement to call `UpdateDefaultDevice` after setting the default device. Two steps to set a variable is no fun!