### PR TITLE
Qt: make GCPadWiiU a standalone dialog

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -50,7 +50,7 @@ set(SRCS
   Config/LogWidget.cpp
   Config/Mapping/GCKeyboardEmu.cpp
   Config/Mapping/GCPadEmu.cpp
-  Config/Mapping/GCPadWiiU.cpp
+  Config/Mapping/GCPadWiiUConfigDialog.cpp
   Config/Mapping/Hotkey3D.cpp
   Config/Mapping/HotkeyGeneral.cpp
   Config/Mapping/HotkeyGraphics.cpp

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -28,7 +28,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/NetPlayProto.h"
-#include "DolphinQt2/Config/Mapping/GCPadWiiU.h"
+#include "DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.h"
 #include "DolphinQt2/Config/Mapping/MappingWindow.h"
 #include "DolphinQt2/Settings.h"
 #include "UICommon/UICommon.h"
@@ -418,7 +418,7 @@ void ControllersWindow::OnGCPadConfigure()
     type = MappingWindow::Type::MAPPING_GCPAD;
     break;
   case 2:  // GameCube Adapter for Wii U
-    GCPadWiiU(index, this).exec();
+    GCPadWiiUConfigDialog(static_cast<int>(index), this).exec();
     return;
   case 3:  // Steering Wheel
     type = MappingWindow::Type::MAPPING_GC_STEERINGWHEEL;

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -28,6 +28,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTReal.h"
 #include "Core/NetPlayProto.h"
+#include "DolphinQt2/Config/Mapping/GCPadWiiU.h"
 #include "DolphinQt2/Config/Mapping/MappingWindow.h"
 #include "DolphinQt2/Settings.h"
 #include "UICommon/UICommon.h"
@@ -417,8 +418,8 @@ void ControllersWindow::OnGCPadConfigure()
     type = MappingWindow::Type::MAPPING_GCPAD;
     break;
   case 2:  // GameCube Adapter for Wii U
-    type = MappingWindow::Type::MAPPING_GCPAD_WIIU;
-    break;
+    GCPadWiiU(index, this).exec();
+    return;
   case 3:  // Steering Wheel
     type = MappingWindow::Type::MAPPING_GC_STEERINGWHEEL;
     break;

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -78,12 +78,6 @@ ControllersWindow::ControllersWindow(QWidget* parent) : QDialog(parent)
   CreateMainLayout();
   LoadSettings();
   ConnectWidgets();
-
-  for (size_t i = 0; i < m_gc_mappings.size(); i++)
-    m_gc_mappings[i] = new MappingWindow(this, static_cast<int>(i));
-
-  for (size_t i = 0; i < m_wiimote_mappings.size(); i++)
-    m_wiimote_mappings[i] = new MappingWindow(this, static_cast<int>(i));
 }
 
 void ControllersWindow::CreateGamecubeLayout()
@@ -440,8 +434,8 @@ void ControllersWindow::OnGCPadConfigure()
   default:
     return;
   }
-  m_gc_mappings[index]->ChangeMappingType(type);
-  m_gc_mappings[index]->exec();
+
+  MappingWindow(this, type, static_cast<int>(index)).exec();
 }
 
 void ControllersWindow::OnWiimoteConfigure()
@@ -468,8 +462,8 @@ void ControllersWindow::OnWiimoteConfigure()
   default:
     return;
   }
-  m_wiimote_mappings[index]->ChangeMappingType(type);
-  m_wiimote_mappings[index]->exec();
+
+  MappingWindow(this, type, static_cast<int>(index)).exec();
 }
 
 void ControllersWindow::UnimplementedButton()

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.h
@@ -51,7 +51,6 @@ private:
   QDialogButtonBox* m_button_box;
 
   // Gamecube
-  std::array<MappingWindow*, 4> m_gc_mappings;
   QGroupBox* m_gc_box;
   QGridLayout* m_gc_layout;
   std::array<QComboBox*, 4> m_gc_controller_boxes;
@@ -59,7 +58,6 @@ private:
   std::array<QHBoxLayout*, 4> m_gc_groups;
 
   // Wii Remote
-  std::array<MappingWindow*, 4> m_wiimote_mappings;
   QGroupBox* m_wiimote_box;
   QGridLayout* m_wiimote_layout;
   std::array<QLabel*, 4> m_wiimote_labels;

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <QCheckBox>
+#include <QDialogButtonBox>
 #include <QLabel>
 #include <QVBoxLayout>
 
@@ -11,7 +12,7 @@
 #include "Core/ConfigManager.h"
 #include "InputCommon/GCAdapter.h"
 
-GCPadWiiU::GCPadWiiU(MappingWindow* window) : MappingWidget(window)
+GCPadWiiU::GCPadWiiU(int port, QWidget* parent) : QDialog(parent), m_port{port}
 {
   CreateLayout();
   ConnectWidgets();
@@ -21,15 +22,19 @@ GCPadWiiU::GCPadWiiU(MappingWindow* window) : MappingWidget(window)
 
 void GCPadWiiU::CreateLayout()
 {
+  setWindowTitle(tr("GameCube Adapter for Wii U at Port %1").arg(m_port + 1));
+
   const bool detected = GCAdapter::IsDetected();
   m_layout = new QVBoxLayout();
   m_status_label = new QLabel(detected ? tr("Adapter Detected") : tr("No Adapter Detected"));
   m_rumble = new QCheckBox(tr("Enable Rumble"));
   m_simulate_bongos = new QCheckBox(tr("Simulate DK Bongos"));
+  m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
 
   m_layout->addWidget(m_status_label);
   m_layout->addWidget(m_rumble);
   m_layout->addWidget(m_simulate_bongos);
+  m_layout->addWidget(m_button_box);
 
   if (!detected)
   {
@@ -44,21 +49,17 @@ void GCPadWiiU::ConnectWidgets()
 {
   connect(m_rumble, &QCheckBox::toggled, this, &GCPadWiiU::SaveSettings);
   connect(m_simulate_bongos, &QCheckBox::toggled, this, &GCPadWiiU::SaveSettings);
+  connect(m_button_box, &QDialogButtonBox::accepted, this, &GCPadWiiU::accept);
 }
 
 void GCPadWiiU::LoadSettings()
 {
-  m_rumble->setChecked(SConfig::GetInstance().m_AdapterRumble[GetPort()]);
-  m_simulate_bongos->setChecked(SConfig::GetInstance().m_AdapterKonga[GetPort()]);
+  m_rumble->setChecked(SConfig::GetInstance().m_AdapterRumble[m_port]);
+  m_simulate_bongos->setChecked(SConfig::GetInstance().m_AdapterKonga[m_port]);
 }
 
 void GCPadWiiU::SaveSettings()
 {
-  SConfig::GetInstance().m_AdapterRumble[GetPort()] = m_rumble->isChecked();
-  SConfig::GetInstance().m_AdapterKonga[GetPort()] = m_simulate_bongos->isChecked();
-}
-
-InputConfig* GCPadWiiU::GetConfig()
-{
-  return nullptr;
+  SConfig::GetInstance().m_AdapterRumble[m_port] = m_rumble->isChecked();
+  SConfig::GetInstance().m_AdapterKonga[m_port] = m_simulate_bongos->isChecked();
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiU.h
@@ -4,28 +4,30 @@
 
 #pragma once
 
-#include "DolphinQt2/Config/Mapping/MappingWidget.h"
+#include <QDialog>
 
 class QCheckBox;
 class QLabel;
+class QDialogButtonBox;
 class QVBoxLayout;
 
-class GCPadWiiU final : public MappingWidget
+class GCPadWiiU final : public QDialog
 {
 public:
-  explicit GCPadWiiU(MappingWindow* window);
-
-  InputConfig* GetConfig() override;
+  explicit GCPadWiiU(int port, QWidget* parent = nullptr);
 
 private:
-  void LoadSettings() override;
-  void SaveSettings() override;
+  void LoadSettings();
+  void SaveSettings();
 
   void CreateLayout();
   void ConnectWidgets();
 
+  int m_port;
+
   QVBoxLayout* m_layout;
   QLabel* m_status_label;
+  QDialogButtonBox* m_button_box;
 
   // Checkboxes
   QCheckBox* m_rumble;

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.cpp
@@ -7,12 +7,13 @@
 #include <QLabel>
 #include <QVBoxLayout>
 
-#include "DolphinQt2/Config/Mapping/GCPadWiiU.h"
+#include "DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.h"
 
 #include "Core/ConfigManager.h"
 #include "InputCommon/GCAdapter.h"
 
-GCPadWiiU::GCPadWiiU(int port, QWidget* parent) : QDialog(parent), m_port{port}
+GCPadWiiUConfigDialog::GCPadWiiUConfigDialog(int port, QWidget* parent)
+    : QDialog(parent), m_port{port}
 {
   CreateLayout();
   ConnectWidgets();
@@ -20,7 +21,7 @@ GCPadWiiU::GCPadWiiU(int port, QWidget* parent) : QDialog(parent), m_port{port}
   LoadSettings();
 }
 
-void GCPadWiiU::CreateLayout()
+void GCPadWiiUConfigDialog::CreateLayout()
 {
   setWindowTitle(tr("GameCube Adapter for Wii U at Port %1").arg(m_port + 1));
 
@@ -45,20 +46,20 @@ void GCPadWiiU::CreateLayout()
   setLayout(m_layout);
 }
 
-void GCPadWiiU::ConnectWidgets()
+void GCPadWiiUConfigDialog::ConnectWidgets()
 {
-  connect(m_rumble, &QCheckBox::toggled, this, &GCPadWiiU::SaveSettings);
-  connect(m_simulate_bongos, &QCheckBox::toggled, this, &GCPadWiiU::SaveSettings);
-  connect(m_button_box, &QDialogButtonBox::accepted, this, &GCPadWiiU::accept);
+  connect(m_rumble, &QCheckBox::toggled, this, &GCPadWiiUConfigDialog::SaveSettings);
+  connect(m_simulate_bongos, &QCheckBox::toggled, this, &GCPadWiiUConfigDialog::SaveSettings);
+  connect(m_button_box, &QDialogButtonBox::accepted, this, &GCPadWiiUConfigDialog::accept);
 }
 
-void GCPadWiiU::LoadSettings()
+void GCPadWiiUConfigDialog::LoadSettings()
 {
   m_rumble->setChecked(SConfig::GetInstance().m_AdapterRumble[m_port]);
   m_simulate_bongos->setChecked(SConfig::GetInstance().m_AdapterKonga[m_port]);
 }
 
-void GCPadWiiU::SaveSettings()
+void GCPadWiiUConfigDialog::SaveSettings()
 {
   SConfig::GetInstance().m_AdapterRumble[m_port] = m_rumble->isChecked();
   SConfig::GetInstance().m_AdapterKonga[m_port] = m_simulate_bongos->isChecked();

--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.h
@@ -11,10 +11,10 @@ class QLabel;
 class QDialogButtonBox;
 class QVBoxLayout;
 
-class GCPadWiiU final : public QDialog
+class GCPadWiiUConfigDialog final : public QDialog
 {
 public:
-  explicit GCPadWiiU(int port, QWidget* parent = nullptr);
+  explicit GCPadWiiUConfigDialog(int port, QWidget* parent = nullptr);
 
 private:
   void LoadSettings();

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -32,12 +32,12 @@
 #include "DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.h"
 #include "DolphinQt2/Settings.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/Device.h"
 #include "InputCommon/InputConfig.h"
 
-#include "InputCommon/ControllerInterface/ControllerInterface.h"
-
-MappingWindow::MappingWindow(QWidget* parent, int port_num) : QDialog(parent), m_port(port_num)
+MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
+    : QDialog(parent), m_port(port_num)
 {
   setWindowTitle(tr("Port %1").arg(port_num + 1));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -47,6 +47,7 @@ MappingWindow::MappingWindow(QWidget* parent, int port_num) : QDialog(parent), m
   CreateResetLayout();
   CreateMainLayout();
   ConnectWidgets();
+  SetMappingType(type);
 }
 
 void MappingWindow::CreateDevicesLayout()
@@ -237,13 +238,8 @@ void MappingWindow::RefreshDevices()
   });
 }
 
-void MappingWindow::ChangeMappingType(MappingWindow::Type type)
+void MappingWindow::SetMappingType(MappingWindow::Type type)
 {
-  if (m_mapping_type == type)
-    return;
-
-  ClearWidgets();
-
   m_controller = nullptr;
 
   MappingWidget* widget;
@@ -297,8 +293,6 @@ void MappingWindow::ChangeMappingType(MappingWindow::Type type)
 
   widget->LoadSettings();
 
-  m_profiles_combo->clear();
-
   m_config = widget->GetConfig();
 
   if (m_config)
@@ -320,13 +314,6 @@ void MappingWindow::ChangeMappingType(MappingWindow::Type type)
 
   if (m_controller != nullptr)
     RefreshDevices();
-
-  m_mapping_type = type;
-}
-
-void MappingWindow::ClearWidgets()
-{
-  m_tab_widget->clear();
 }
 
 void MappingWindow::AddWidget(const QString& name, QWidget* widget)

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
@@ -37,7 +37,6 @@ public:
     MAPPING_GC_DANCEMAT,
     MAPPING_GC_KEYBOARD,
     MAPPING_GCPAD,
-    MAPPING_GCPAD_WIIU,
     MAPPING_GC_STEERINGWHEEL,
     // Wii
     MAPPING_WIIMOTE_EMU,
@@ -65,7 +64,6 @@ private:
   void CreateMainLayout();
   void ConnectWidgets();
 
-  void SetLayoutComplex(bool is_complex);
   void AddWidget(const QString& name, QWidget* widget);
 
   void RefreshDevices();
@@ -107,7 +105,6 @@ private:
 
   Type m_mapping_type;
   const int m_port;
-  bool m_is_complex;
   InputConfig* m_config;
   ciface::Core::DeviceQualifier m_devq;
 };

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
@@ -46,8 +46,7 @@ public:
     MAPPING_HOTKEYS
   };
 
-  explicit MappingWindow(QWidget* parent, int port_num);
-  void ChangeMappingType(Type type);
+  explicit MappingWindow(QWidget* parent, Type type, int port_num);
 
   int GetPort() const;
   const ciface::Core::DeviceQualifier& GetDeviceQualifier() const;
@@ -59,6 +58,7 @@ signals:
   void ClearFields();
 
 private:
+  void SetMappingType(Type type);
   void CreateDevicesLayout();
   void CreateProfilesLayout();
   void CreateResetLayout();
@@ -67,7 +67,6 @@ private:
 
   void SetLayoutComplex(bool is_complex);
   void AddWidget(const QString& name, QWidget* widget);
-  void ClearWidgets();
 
   void RefreshDevices();
 

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -177,7 +177,7 @@
     <ClCompile Include="Config\InfoWidget.cpp" />
     <ClCompile Include="Config\Mapping\GCKeyboardEmu.cpp" />
     <ClCompile Include="Config\Mapping\GCPadEmu.cpp" />
-    <ClCompile Include="Config\Mapping\GCPadWiiU.cpp" />
+    <ClCompile Include="Config\Mapping\GCPadWiiUConfigDialog.cpp" />
     <ClCompile Include="Config\Mapping\Hotkey3D.cpp" />
     <ClCompile Include="Config\Mapping\HotkeyGeneral.cpp" />
     <ClCompile Include="Config\Mapping\HotkeyGraphics.cpp" />

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -73,6 +73,8 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters) : QMainW
   setUnifiedTitleAndToolBarOnMac(true);
   setAcceptDrops(true);
 
+  InitControllers();
+
   CreateComponents();
 
   ConnectGameList();
@@ -81,7 +83,6 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters) : QMainW
   ConnectStack();
   ConnectMenuBar();
 
-  InitControllers();
   InitCoreCallbacks();
 
   NetPlayInit();
@@ -154,7 +155,7 @@ void MainWindow::CreateComponents()
   m_stack = new QStackedWidget(this);
   m_controllers_window = new ControllersWindow(this);
   m_settings_window = new SettingsWindow(this);
-  m_hotkey_window = new MappingWindow(this, 0);
+  m_hotkey_window = new MappingWindow(this, MappingWindow::Type::MAPPING_HOTKEYS, 0);
   m_log_widget = new LogWidget(this);
   m_log_config_widget = new LogConfigWidget(this);
 
@@ -570,7 +571,6 @@ void MainWindow::ShowAboutDialog()
 
 void MainWindow::ShowHotkeyDialog()
 {
-  m_hotkey_window->ChangeMappingType(MappingWindow::Type::MAPPING_HOTKEYS);
   m_hotkey_window->show();
   m_hotkey_window->raise();
   m_hotkey_window->activateWindow();


### PR DESCRIPTION
This makes the definition of the `MappingWidget` interface simpler. Creating a new `MappingWindow`/`GCPadWiiUConfigDialog` in `ControllersWindow` every time one is needed seems slightly wasteful, but has zero noticeable performance impact on my computer.