### PR TITLE
Added DPL2 decoder to XAudio2 and XAudio2_7 backends.

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -129,6 +129,8 @@ bool SupportsDPL2Decoder(const std::string& backend)
     return true;
   if (backend == BACKEND_PULSEAUDIO)
     return true;
+  if (backend == BACKEND_XAUDIO2)
+    return true;
   return false;
 }
 

--- a/Source/Core/AudioCommon/XAudio2Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2Stream.cpp
@@ -2,12 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "AudioCommon/XAudio2Stream.h"
+#include <variant>
+
 #include <xaudio2.h>
 #include "AudioCommon/AudioCommon.h"
+#include "AudioCommon/XAudio2Stream.h"
 #include "Common/Event.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Core/ConfigManager.h"
 
 #ifndef XAUDIO2_DLL
 #error You are building this module against the wrong version of DirectX. You probably need to remove DXSDK_DIR from your include path.
@@ -19,9 +22,11 @@ private:
   Mixer* const m_mixer;
   Common::Event& m_sound_sync_event;
   IXAudio2SourceVoice* m_source_voice;
-  std::unique_ptr<BYTE[]> xaudio_buffer;
+  std::variant<std::unique_ptr<short[]>, std::unique_ptr<float[]>> xaudio_buffer;
 
   void SubmitBuffer(PBYTE buf_data);
+
+  bool m_use_surround = SConfig::GetInstance().bDPL2Decoder;
 
 public:
   StreamingVoiceContext(IXAudio2* pXAudio2, Mixer* pMixer, Common::Event& pSyncEvent);
@@ -41,15 +46,26 @@ public:
 
 const int NUM_BUFFERS = 3;
 const int SAMPLES_PER_BUFFER = 96;
+const int SAMPLES_PER_BUFFER_SURROUND = 256;
 
 const int NUM_CHANNELS = 2;
 const int BUFFER_SIZE = SAMPLES_PER_BUFFER * NUM_CHANNELS;
 const int BUFFER_SIZE_BYTES = BUFFER_SIZE * sizeof(s16);
 
+const int NUM_CHANNELS_SURROUND = 6;
+const int BUFFER_SIZE_SURROUND = SAMPLES_PER_BUFFER_SURROUND * NUM_CHANNELS_SURROUND;
+const int BUFFER_SIZE_BYTES_SURROUND = BUFFER_SIZE_SURROUND * sizeof(float);
 void StreamingVoiceContext::SubmitBuffer(PBYTE buf_data)
 {
   XAUDIO2_BUFFER buf = {};
-  buf.AudioBytes = BUFFER_SIZE_BYTES;
+  if (m_use_surround)
+  {
+    buf.AudioBytes = BUFFER_SIZE_BYTES_SURROUND;
+  }
+  else
+  {
+    buf.AudioBytes = BUFFER_SIZE_BYTES;
+  }
   buf.pContext = buf_data;
   buf.pAudioData = buf_data;
 
@@ -58,21 +74,40 @@ void StreamingVoiceContext::SubmitBuffer(PBYTE buf_data)
 
 StreamingVoiceContext::StreamingVoiceContext(IXAudio2* pXAudio2, Mixer* pMixer,
                                              Common::Event& pSyncEvent)
-    : m_mixer(pMixer), m_sound_sync_event(pSyncEvent),
-      xaudio_buffer(new BYTE[NUM_BUFFERS * BUFFER_SIZE_BYTES]())
+    : m_mixer(pMixer), m_sound_sync_event(pSyncEvent)
 {
   WAVEFORMATEXTENSIBLE wfx = {};
-
   wfx.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
   wfx.Format.nSamplesPerSec = m_mixer->GetSampleRate();
-  wfx.Format.nChannels = 2;
-  wfx.Format.wBitsPerSample = 16;
+
+  // More information about these values:
+  // https://msdn.microsoft.com/en-us/library/windows/desktop/dd390971(v=vs.85).aspx
+  if (m_use_surround)
+  {
+    xaudio_buffer = std::make_unique<float[]>(NUM_BUFFERS * BUFFER_SIZE_SURROUND);
+
+    wfx.Format.nChannels = 6;
+    wfx.Format.wBitsPerSample = 32;
+    wfx.Samples.wValidBitsPerSample = 32;
+    wfx.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_FRONT_CENTER |
+                        SPEAKER_LOW_FREQUENCY | SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT;
+    wfx.SubFormat = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
+    wfx.Format.cbSize = sizeof(wfx.Samples) + sizeof(wfx.dwChannelMask) + sizeof(wfx.SubFormat);
+  }
+  else
+  {
+    xaudio_buffer = std::make_unique<short[]>(NUM_BUFFERS * BUFFER_SIZE);
+
+    wfx.Format.nChannels = 2;
+    wfx.Format.wBitsPerSample = 16;
+    wfx.Samples.wValidBitsPerSample = 16;
+    wfx.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
+    wfx.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
+    wfx.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+  }
+
   wfx.Format.nBlockAlign = wfx.Format.nChannels * wfx.Format.wBitsPerSample / 8;
   wfx.Format.nAvgBytesPerSec = wfx.Format.nSamplesPerSec * wfx.Format.nBlockAlign;
-  wfx.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
-  wfx.Samples.wValidBitsPerSample = 16;
-  wfx.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
-  wfx.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
 
   // create source voice
   HRESULT hr;
@@ -86,8 +121,24 @@ StreamingVoiceContext::StreamingVoiceContext(IXAudio2* pXAudio2, Mixer* pMixer,
   m_source_voice->Start();
 
   // start buffers with silence
-  for (int i = 0; i != NUM_BUFFERS; ++i)
-    SubmitBuffer(xaudio_buffer.get() + (i * BUFFER_SIZE_BYTES));
+  if (m_use_surround)
+  {
+    for (int i = 0; i != NUM_BUFFERS; ++i)
+    {
+      SubmitBuffer(
+          reinterpret_cast<BYTE*>(std::get<std::unique_ptr<float[]>>(xaudio_buffer).get()) +
+          (i * BUFFER_SIZE_BYTES_SURROUND));
+    }
+  }
+  else
+  {
+    for (int i = 0; i != NUM_BUFFERS; ++i)
+    {
+      SubmitBuffer(
+          reinterpret_cast<BYTE*>(std::get<std::unique_ptr<short[]>>(xaudio_buffer).get()) +
+          (i * BUFFER_SIZE_BYTES));
+    }
+  }
 }
 
 StreamingVoiceContext::~StreamingVoiceContext()
@@ -121,8 +172,15 @@ void StreamingVoiceContext::OnBufferEnd(void* context)
   // m_sound_sync_event->Wait(); // sync
   // m_sound_sync_event->Spin(); // or tight sync
 
-  m_mixer->Mix(static_cast<short*>(context), SAMPLES_PER_BUFFER);
-  SubmitBuffer(static_cast<BYTE*>(context));
+  if (m_use_surround)
+  {
+    m_mixer->MixSurround(static_cast<float*>(context), SAMPLES_PER_BUFFER_SURROUND);
+  }
+  else
+  {
+    m_mixer->Mix(static_cast<short*>(context), SAMPLES_PER_BUFFER);
+  }
+  SubmitBuffer(reinterpret_cast<BYTE*>(context));
 }
 
 HMODULE XAudio2::m_xaudio2_dll = nullptr;
@@ -185,7 +243,12 @@ bool XAudio2::Init()
 
   // XAudio2 master voice
   // XAUDIO2_DEFAULT_CHANNELS instead of 2 for expansion?
-  if (FAILED(hr = m_xaudio2->CreateMasteringVoice(&m_mastering_voice, 2, m_mixer->GetSampleRate())))
+  uint channels = NUM_CHANNELS;
+  if (SConfig::GetInstance().bDPL2Decoder)
+    channels = NUM_CHANNELS_SURROUND;
+
+  if (FAILED(hr = m_xaudio2->CreateMasteringVoice(&m_mastering_voice, channels,
+                                                  m_mixer->GetSampleRate())))
   {
     PanicAlert("XAudio2 master voice creation failed: %#X", hr);
     Stop();


### PR DESCRIPTION
I cherry picked this commit from PR #5235, as suggested by @ligfx.

Tested on Windows 8.1 x64, works fine. I will test later on Windows 10 x64, but it would be great if someone could test it on Windows 7.