### PR TITLE
Remove "Force Console as NTSC-J"

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -190,7 +190,6 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
   display->Set("RenderWindowAutoSize", bRenderWindowAutoSize);
   display->Set("KeepWindowOnTop", bKeepWindowOnTop);
   display->Set("DisableScreenSaver", bDisableScreenSaver);
-  display->Set("ForceNTSCJ", bForceNTSCJ);
 }
 
 void SConfig::SaveGameListSettings(IniFile& ini)
@@ -470,7 +469,6 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
   display->Get("RenderWindowAutoSize", &bRenderWindowAutoSize, false);
   display->Get("KeepWindowOnTop", &bKeepWindowOnTop, false);
   display->Get("DisableScreenSaver", &bDisableScreenSaver, true);
-  display->Get("ForceNTSCJ", &bForceNTSCJ, false);
 }
 
 void SConfig::LoadGameListSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -100,7 +100,6 @@ struct SConfig
   bool bDSPThread = false;
   bool bDSPHLE = true;
   bool bSyncGPUOnSkipIdleHack = true;
-  bool bForceNTSCJ = false;
   bool bHLE_BS2 = true;
   bool bEnableCheats = false;
   bool bEnableMemcardSdWriting = true;

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -182,7 +182,7 @@ void Preset(bool _bNTSC)
 
   // Say component cable is plugged
   m_DTVStatus.component_plugged = Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN);
-  m_DTVStatus.ntsc_j = SConfig::GetInstance().bForceNTSCJ || region == DiscIO::Region::NTSC_J;
+  m_DTVStatus.ntsc_j = region == DiscIO::Region::NTSC_J;
 
   m_FBWidth.Hex = 0;
   m_BorderHBlank.Hex = 0;

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
@@ -49,7 +49,6 @@ void GeneralPane::ConnectLayout()
   connect(m_checkbox_dualcore, &QCheckBox::clicked, this, &GeneralPane::OnSaveConfig);
   connect(m_checkbox_cheats, &QCheckBox::clicked, this, &GeneralPane::OnSaveConfig);
   // Advanced
-  connect(m_checkbox_force_ntsc, &QCheckBox::clicked, this, &GeneralPane::OnSaveConfig);
   connect(m_combobox_speedlimit,
           static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::activated),
           [this](const QString& text) { OnSaveConfig(); });
@@ -132,15 +131,10 @@ void GeneralPane::CreateAdvanced()
   engine_group_layout->addWidget(m_radio_interpreter);
   engine_group_layout->addWidget(m_radio_cached_interpreter);
   engine_group_layout->addWidget(m_radio_jit);
-
-  // NTSC-J
-  m_checkbox_force_ntsc = new QCheckBox(tr("Force Console as NTSC-J"));
-  advanced_group_layout->addWidget(m_checkbox_force_ntsc);
 }
 
 void GeneralPane::LoadConfig()
 {
-  m_checkbox_force_ntsc->setChecked(SConfig::GetInstance().bForceNTSCJ);
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   m_checkbox_enable_analytics->setChecked(SConfig::GetInstance().m_analytics_enabled);
 #endif
@@ -172,7 +166,6 @@ void GeneralPane::LoadConfig()
 
 void GeneralPane::OnSaveConfig()
 {
-  SConfig::GetInstance().bForceNTSCJ = m_checkbox_force_ntsc->isChecked();
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   SConfig::GetInstance().m_analytics_enabled = m_checkbox_enable_analytics->isChecked();
 #endif

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.h
@@ -32,7 +32,6 @@ private:
   // Widgets
   QVBoxLayout* m_main_layout;
   QComboBox* m_combobox_speedlimit;
-  QCheckBox* m_checkbox_force_ntsc;
   QCheckBox* m_checkbox_dualcore;
   QCheckBox* m_checkbox_cheats;
   QLabel* m_label_speedlimit;

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -55,7 +55,6 @@ void GeneralConfigPane::InitializeGUI()
 
   m_dual_core_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Dual Core (speedup)"));
   m_cheats_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Cheats"));
-  m_force_ntscj_checkbox = new wxCheckBox(this, wxID_ANY, _("Force Console as NTSC-J"));
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   m_analytics_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Usage Statistics Reporting"));
 #ifdef __APPLE__
@@ -75,9 +74,6 @@ void GeneralConfigPane::InitializeGUI()
       _("Splits the CPU and GPU threads so they can be run on separate cores.\nProvides major "
         "speed improvements on most modern PCs, but can cause occasional crashes/glitches."));
   m_cheats_checkbox->SetToolTip(_("Enables the use of Action Replay and Gecko cheats."));
-  m_force_ntscj_checkbox->SetToolTip(
-      _("Forces NTSC-J mode for using the Japanese ROM font.\nIf left unchecked, Dolphin defaults "
-        "to NTSC-U and automatically enables this setting when playing Japanese games."));
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   m_analytics_checkbox->SetToolTip(
       _("Enables the collection and sharing of usage statistics data with the Dolphin development "
@@ -127,8 +123,6 @@ void GeneralConfigPane::InitializeGUI()
   advanced_settings_sizer->AddSpacer(space5);
   advanced_settings_sizer->Add(m_cpu_engine_radiobox, 0, wxLEFT | wxRIGHT, space5);
   advanced_settings_sizer->AddSpacer(space5);
-  advanced_settings_sizer->Add(m_force_ntscj_checkbox, 0, wxLEFT | wxRIGHT, space5);
-  advanced_settings_sizer->AddSpacer(space5);
 
   wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
   main_sizer->AddSpacer(space5);
@@ -150,7 +144,6 @@ void GeneralConfigPane::LoadGUIValues()
 
   m_dual_core_checkbox->SetValue(startup_params.bCPUThread);
   m_cheats_checkbox->SetValue(startup_params.bEnableCheats);
-  m_force_ntscj_checkbox->SetValue(startup_params.bForceNTSCJ);
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   m_analytics_checkbox->SetValue(startup_params.m_analytics_enabled);
@@ -176,10 +169,6 @@ void GeneralConfigPane::BindEvents()
   m_cheats_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnCheatCheckBoxChanged, this);
   m_cheats_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 
-  m_force_ntscj_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnForceNTSCJCheckBoxChanged,
-                               this);
-  m_force_ntscj_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
-
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   m_analytics_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnAnalyticsCheckBoxChanged, this);
 
@@ -203,11 +192,6 @@ void GeneralConfigPane::OnDualCoreCheckBoxChanged(wxCommandEvent& event)
 void GeneralConfigPane::OnCheatCheckBoxChanged(wxCommandEvent& event)
 {
   SConfig::GetInstance().bEnableCheats = m_cheats_checkbox->IsChecked();
-}
-
-void GeneralConfigPane::OnForceNTSCJCheckBoxChanged(wxCommandEvent& event)
-{
-  SConfig::GetInstance().bForceNTSCJ = m_force_ntscj_checkbox->IsChecked();
 }
 
 void GeneralConfigPane::OnThrottlerChoiceChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -25,7 +25,6 @@ private:
 
   void OnDualCoreCheckBoxChanged(wxCommandEvent&);
   void OnCheatCheckBoxChanged(wxCommandEvent&);
-  void OnForceNTSCJCheckBoxChanged(wxCommandEvent&);
   void OnThrottlerChoiceChanged(wxCommandEvent&);
   void OnCPUEngineRadioBoxChanged(wxCommandEvent&);
   void OnAnalyticsCheckBoxChanged(wxCommandEvent&);
@@ -36,7 +35,6 @@ private:
 
   wxCheckBox* m_dual_core_checkbox;
   wxCheckBox* m_cheats_checkbox;
-  wxCheckBox* m_force_ntscj_checkbox;
 
   wxCheckBox* m_analytics_checkbox;
   wxButton* m_analytics_new_id;


### PR DESCRIPTION
Nowadays that Dolphin detects regions of discs properly and doesn't force programs with unknown regions (such as homebrew) into running under a certain region, the "Force Console as NTSC-J" option is practically useless for making anything run correctly. Enabling it is however an easy way to totally break many non-Japanese games.