### PR TITLE
Fix DTK audio not working after loading a savestate

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 
 #include "AudioCommon/DPL2Decoder.h"
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
@@ -23,6 +24,13 @@ Mixer::Mixer(unsigned int BackendSampleRate)
 
 Mixer::~Mixer()
 {
+}
+
+void Mixer::DoState(PointerWrap& p)
+{
+  m_dma_mixer.DoState(p);
+  m_streaming_mixer.DoState(p);
+  m_wiimote_speaker_mixer.DoState(p);
 }
 
 // Executed from sound stream thread
@@ -331,6 +339,13 @@ void Mixer::StopLogDSPAudio()
   {
     WARN_LOG(AUDIO, "DSP Audio logging has already been stopped");
   }
+}
+
+void Mixer::MixerFifo::DoState(PointerWrap& p)
+{
+  p.Do(m_input_sample_rate);
+  p.Do(m_LVolume);
+  p.Do(m_RVolume);
 }
 
 void Mixer::MixerFifo::SetInputSampleRate(unsigned int rate)

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -11,11 +11,15 @@
 #include "AudioCommon/WaveFile.h"
 #include "Common/CommonTypes.h"
 
+class PointerWrap;
+
 class Mixer final
 {
 public:
   explicit Mixer(unsigned int BackendSampleRate);
   ~Mixer();
+
+  void DoState(PointerWrap& p);
 
   // Called from audio threads
   unsigned int Mix(short* samples, unsigned int numSamples);
@@ -53,6 +57,7 @@ private:
     MixerFifo(Mixer* mixer, unsigned sample_rate) : m_mixer(mixer), m_input_sample_rate(sample_rate)
     {
     }
+    void DoState(PointerWrap& p);
     void PushSamples(const short* samples, unsigned int num_samples);
     unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
     void SetInputSampleRate(unsigned int rate);

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -127,6 +127,8 @@ void DoState(PointerWrap& p)
   p.Do(g_AISSampleRate);
   p.Do(g_AIDSampleRate);
   p.Do(g_CPUCyclesPerSample);
+
+  g_sound_stream->GetMixer()->DoState(p);
 }
 
 static void GenerateAudioInterrupt();

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -285,6 +285,8 @@ void DoState(PointerWrap& p)
   p.Do(s_disc_path_to_insert);
 
   DVDThread::DoState(p);
+
+  StreamADPCM::DoState(p);
 }
 
 static size_t ProcessDTKSamples(std::vector<s16>* temp_pcm, const std::vector<u8>& audio_data)

--- a/Source/Core/Core/HW/StreamADPCM.cpp
+++ b/Source/Core/Core/HW/StreamADPCM.cpp
@@ -6,12 +6,13 @@
 
 #include "Core/HW/StreamADPCM.h"
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
 namespace StreamADPCM
 {
-// STATE_TO_SAVE (not saved yet!)
+// STATE_TO_SAVE
 static s32 histl1;
 static s32 histl2;
 static s32 histr1;
@@ -54,6 +55,14 @@ void InitFilter()
   histl2 = 0;
   histr1 = 0;
   histr2 = 0;
+}
+
+void DoState(PointerWrap& p)
+{
+  p.Do(histl1);
+  p.Do(histl2);
+  p.Do(histr1);
+  p.Do(histr2);
 }
 
 void DecodeBlock(s16* pcm, const u8* adpcm)

--- a/Source/Core/Core/HW/StreamADPCM.h
+++ b/Source/Core/Core/HW/StreamADPCM.h
@@ -8,6 +8,8 @@
 
 #include "Common/CommonTypes.h"
 
+class PointerWrap;
+
 namespace StreamADPCM
 {
 enum
@@ -17,5 +19,6 @@ enum
 };
 
 void InitFilter();
+void DoState(PointerWrap& p);
 void DecodeBlock(s16* pcm, const u8* adpcm);
 }

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 91;  // Last changed in PR 6094
+static const u32 STATE_VERSION = 92;  // Last changed in PR 6173
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
The main problem was that the volume of the mixer wasn't savestated. The volume is typically 0 at the beginning of a game, so loading a savestate at the beginning of a game would lead to silent DTK audio.

I also added savestating to StreamADPCM.cpp.