### PR TITLE
Avoid forbidden characters when extracting disc partitions

### DIFF
--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -33,7 +33,7 @@ std::string DirectoryNameForPartitionType(u32 partition_type)
                                       static_cast<char>((partition_type >> 8) & 0xFF),
                                       static_cast<char>(partition_type & 0xFF)};
     if (std::all_of(type_as_game_id.cbegin(), type_as_game_id.cend(),
-                    [](char c) { return std::isprint(c, std::locale::classic()); }))
+                    [](char c) { return std::isalnum(c, std::locale::classic()); }))
     {
       return "P-" + type_as_game_id;
     }


### PR DESCRIPTION
We shouldn't try to create folder names that contain characters such as : or / since they are forbidden or have special meanings. (No officially released disc uses such characters, though.)