### PR TITLE
Android: Handle a database downgrade.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameDatabase.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameDatabase.java
@@ -78,6 +78,7 @@ public final class GameDatabase extends SQLiteOpenHelper
 			+ KEY_DB_ID + TYPE_PRIMARY + SEPARATOR
 			+ KEY_FOLDER_PATH + TYPE_STRING + CONSTRAINT_UNIQUE + ")";
 
+	private static final String SQL_DELETE_FOLDERS = "DROP TABLE IF EXISTS " + TABLE_NAME_FOLDERS;
 	private static final String SQL_DELETE_GAMES = "DROP TABLE IF EXISTS " + TABLE_NAME_GAMES;
 
 	public GameDatabase(Context context)
@@ -91,11 +92,19 @@ public final class GameDatabase extends SQLiteOpenHelper
 	{
 		Log.debug("[GameDatabase] GameDatabase - Creating database...");
 
-		Log.verbose("[GameDatabase] Executing SQL: " + SQL_CREATE_GAMES);
-		database.execSQL(SQL_CREATE_GAMES);
+		execSqlAndLog(database, SQL_CREATE_GAMES);
+		execSqlAndLog(database, SQL_CREATE_FOLDERS);
+	}
 
-		Log.verbose("[GameDatabase] Executing SQL: " + SQL_CREATE_FOLDERS);
-		database.execSQL(SQL_CREATE_FOLDERS);
+	@Override
+	public void onDowngrade(SQLiteDatabase database, int oldVersion, int newVersion)
+	{
+		Log.verbose("[GameDatabase] Downgrades not supporting, clearing databases..");
+		execSqlAndLog(database, SQL_DELETE_FOLDERS);
+		execSqlAndLog(database, SQL_CREATE_FOLDERS);
+
+		execSqlAndLog(database, SQL_DELETE_GAMES);
+		execSqlAndLog(database, SQL_CREATE_GAMES);
 	}
 
 	@Override
@@ -103,11 +112,9 @@ public final class GameDatabase extends SQLiteOpenHelper
 	{
 		Log.info("[GameDatabase] Upgrading database from schema version " + oldVersion + " to " + newVersion);
 
-		Log.verbose("[GameDatabase] Executing SQL: " + SQL_DELETE_GAMES);
-		database.execSQL(SQL_DELETE_GAMES);
-
-		Log.verbose("[GameDatabase] Executing SQL: " + SQL_CREATE_GAMES);
-		database.execSQL(SQL_CREATE_GAMES);
+		// Delete all the games
+		execSqlAndLog(database, SQL_DELETE_GAMES);
+		execSqlAndLog(database, SQL_CREATE_GAMES);
 
 		Log.verbose("[GameDatabase] Re-scanning library with new schema.");
 		scanLibrary(database);
@@ -282,5 +289,11 @@ public final class GameDatabase extends SQLiteOpenHelper
 				subscriber.onCompleted();
 			}
 		});
+	}
+
+	private void execSqlAndLog(SQLiteDatabase database, String sql)
+	{
+		Log.verbose("[GameDatabase] Executing SQL: " + sql);
+		database.execSQL(sql);
 	}
 }


### PR DESCRIPTION
This has no effect now, as we've never bumped the database version.
Instead, it adds future proofing, and makes moving between a future
version with a bump and master clean.