### PR TITLE
[WIP] OpenSSL logger

### DIFF
--- a/Source/Core/Common/PcapFile.cpp
+++ b/Source/Core/Common/PcapFile.cpp
@@ -15,9 +15,6 @@ const u16 PCAP_VERSION_MAJOR = 2;
 const u16 PCAP_VERSION_MINOR = 4;
 const u32 PCAP_CAPTURE_LENGTH = 65535;
 
-// TODO(delroth): Make this configurable at PCAP creation time?
-const u32 PCAP_DATA_LINK_TYPE = 147;  // Reserved for internal use.
-
 // Designed to be directly written into the PCAP file. The PCAP format is
 // endian independent, so this works just fine.
 #pragma pack(push, 1)
@@ -43,10 +40,10 @@ struct PCAPRecordHeader
 
 }  // namespace
 
-void PCAP::AddHeader()
+void PCAP::AddHeader(u32 link_type)
 {
   PCAPHeader hdr = {PCAP_MAGIC, PCAP_VERSION_MAJOR,  PCAP_VERSION_MINOR, 0,
-                    0,          PCAP_CAPTURE_LENGTH, PCAP_DATA_LINK_TYPE};
+                    0,          PCAP_CAPTURE_LENGTH, link_type};
   m_fp->WriteBytes(&hdr, sizeof(hdr));
 }
 

--- a/Source/Core/Common/PcapFile.h
+++ b/Source/Core/Common/PcapFile.h
@@ -22,9 +22,18 @@
 class PCAP final
 {
 public:
+  enum class LinkType : u32
+  {
+    Ethernet = 1,  // IEEE 802.3 Ethernet
+    User = 147,    // Reserved for internal use
+  };
+
   // Takes ownership of the file object. Assumes the file object is already
   // opened in write mode.
-  explicit PCAP(File::IOFile* fp) : m_fp(fp) { AddHeader(); }
+  explicit PCAP(File::IOFile* fp, LinkType link_type = LinkType::User) : m_fp(fp)
+  {
+    AddHeader(static_cast<u32>(link_type));
+  }
   template <typename T>
   void AddPacket(const T& obj)
   {
@@ -34,7 +43,7 @@ public:
   void AddPacket(const u8* bytes, size_t size);
 
 private:
-  void AddHeader();
+  void AddHeader(u32 link_type);
 
   std::unique_ptr<File::IOFile> m_fp;
 };

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRCS
   Movie.cpp
   NetPlayClient.cpp
   NetPlayServer.cpp
+  NetworkCaptureLogger.cpp
   PatchEngine.cpp
   State.cpp
   TitleDatabase.cpp

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -337,6 +337,7 @@ void SConfig::SaveNetworkSettings(IniFile& ini)
   network->Set("SSLDumpRootCA", m_SSLDumpRootCA);
   network->Set("SSLDumpPeerCert", m_SSLDumpPeerCert);
   network->Set("NetworkDumpPCAP", m_NetworkDumpPCAP);
+  network->Set("OpenSSLDumpPCAP", m_OpenSSLDumpPCAP);
 }
 
 void SConfig::SaveAnalyticsSettings(IniFile& ini)
@@ -635,6 +636,7 @@ void SConfig::LoadNetworkSettings(IniFile& ini)
   network->Get("SSLDumpRootCA", &m_SSLDumpRootCA, false);
   network->Get("SSLDumpPeerCert", &m_SSLDumpPeerCert, false);
   network->Get("NetworkDumpPCAP", &m_NetworkDumpPCAP, false);
+  network->Get("OpenSSLDumpPCAP", &m_OpenSSLDumpPCAP, false);
 }
 
 void SConfig::LoadAnalyticsSettings(IniFile& ini)
@@ -747,6 +749,8 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, u64 title_id, u
     m_network_logger = std::make_unique<Core::BinarySSLCaptureLogger>();
   else
     m_network_logger = std::make_unique<Core::DummyNetworkCaptureLogger>();
+  if (m_OpenSSLDumpPCAP)
+    m_openssl_logger = std::make_unique<Core::PCAPOpenSSLCaptureLogger>();
 
   if (Core::IsRunning())
   {

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -336,6 +336,7 @@ void SConfig::SaveNetworkSettings(IniFile& ini)
   network->Set("SSLVerifyCertificates", m_SSLVerifyCert);
   network->Set("SSLDumpRootCA", m_SSLDumpRootCA);
   network->Set("SSLDumpPeerCert", m_SSLDumpPeerCert);
+  network->Set("NetworkDumpPCAP", m_NetworkDumpPCAP);
 }
 
 void SConfig::SaveAnalyticsSettings(IniFile& ini)
@@ -633,6 +634,7 @@ void SConfig::LoadNetworkSettings(IniFile& ini)
   network->Get("SSLVerifyCertificates", &m_SSLVerifyCert, true);
   network->Get("SSLDumpRootCA", &m_SSLDumpRootCA, false);
   network->Get("SSLDumpPeerCert", &m_SSLDumpPeerCert, false);
+  network->Get("NetworkDumpPCAP", &m_NetworkDumpPCAP, false);
 }
 
 void SConfig::LoadAnalyticsSettings(IniFile& ini)
@@ -739,7 +741,12 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, u64 title_id, u
 
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
-  m_network_logger = std::make_unique<Core::PCAPSSLCaptureLogger>();
+  if (m_NetworkDumpPCAP)
+    m_network_logger = std::make_unique<Core::PCAPSSLCaptureLogger>();
+  else if (m_SSLDumpRead || m_SSLDumpWrite)
+    m_network_logger = std::make_unique<Core::BinarySSLCaptureLogger>();
+  else
+    m_network_logger = std::make_unique<Core::DummyNetworkCaptureLogger>();
 
   if (Core::IsRunning())
   {

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -739,6 +739,7 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, u64 title_id, u
 
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
+  m_network_logger = std::make_unique<Core::BinarySSLCaptureLogger>();
 
   if (Core::IsRunning())
   {

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -739,7 +739,7 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, u64 title_id, u
 
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
-  m_network_logger = std::make_unique<Core::BinarySSLCaptureLogger>();
+  m_network_logger = std::make_unique<Core::PCAPSSLCaptureLogger>();
 
   if (Core::IsRunning())
   {

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <limits>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
@@ -14,6 +15,7 @@
 #include "Common/IniFile.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/SI/SI_Device.h"
+#include "Core/NetworkCaptureLogger.h"
 #include "Core/TitleDatabase.h"
 
 namespace DiscIO
@@ -316,6 +318,7 @@ struct SConfig
   bool m_SSLVerifyCert;
   bool m_SSLDumpRootCA;
   bool m_SSLDumpPeerCert;
+  std::unique_ptr<Core::NetworkCaptureLogger> m_network_logger;
 
   SConfig(const SConfig&) = delete;
   SConfig& operator=(const SConfig&) = delete;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -318,6 +318,7 @@ struct SConfig
   bool m_SSLVerifyCert;
   bool m_SSLDumpRootCA;
   bool m_SSLDumpPeerCert;
+  bool m_NetworkDumpPCAP;
   std::unique_ptr<Core::NetworkCaptureLogger> m_network_logger;
 
   SConfig(const SConfig&) = delete;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -319,7 +319,9 @@ struct SConfig
   bool m_SSLDumpRootCA;
   bool m_SSLDumpPeerCert;
   bool m_NetworkDumpPCAP;
+  bool m_OpenSSLDumpPCAP;
   std::unique_ptr<Core::NetworkCaptureLogger> m_network_logger;
+  std::unique_ptr<Core::NetworkCaptureLogger> m_openssl_logger;
 
   SConfig(const SConfig&) = delete;
   SConfig& operator=(const SConfig&) = delete;

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -241,6 +241,7 @@
     <ClCompile Include="Movie.cpp" />
     <ClCompile Include="NetPlayClient.cpp" />
     <ClCompile Include="NetPlayServer.cpp" />
+    <ClCompile Include="NetworkCaptureLogger.cpp" />
     <ClCompile Include="PatchEngine.cpp" />
     <ClCompile Include="PowerPC\BreakPoints.cpp" />
     <ClCompile Include="PowerPC\CachedInterpreter\CachedInterpreter.cpp" />
@@ -492,6 +493,7 @@
     <ClInclude Include="NetPlayProto.h" />
     <ClInclude Include="NetPlayServer.h" />
     <ClInclude Include="PatchEngine.h" />
+    <ClInclude Include="NetworkCaptureLogger.h" />
     <ClInclude Include="PowerPC\BreakPoints.h" />
     <ClInclude Include="PowerPC\CPUCoreBase.h" />
     <ClInclude Include="PowerPC\Gekko.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -889,6 +889,7 @@
     <ClCompile Include="IOS\Network\NCD\WiiNetConfig.cpp">
       <Filter>IOS\Network\NCD</Filter>
     </ClCompile>
+    <ClCompile Include="NetworkCaptureLogger.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BootManager.h" />
@@ -1559,6 +1560,7 @@
     <ClInclude Include="HW\WiimoteCommon\WiimoteReport.h">
       <Filter>HW %28Flipper/Hollywood%29\WiimoteCommon</Filter>
     </ClInclude>
+    <ClInclude Include="NetworkCaptureLogger.h" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -53,6 +53,10 @@ static const SPatch OSPatches[] = {
     // Debug/OS Support
     {"OSPanic",                      HLE_OS::HLE_OSPanic,                   HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
 
+    // OpenSSL
+    {"SSL_read",                     HLE_Misc::OpenSSLRead,                 HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
+    {"SSL_write",                    HLE_Misc::OpenSSLWrite,                HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
+
     // This needs to be put before vprintf (because vprintf is called indirectly by this)
     {"JUTWarningConsole_f",          HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
 

--- a/Source/Core/Core/HLE/HLE_Misc.h
+++ b/Source/Core/Core/HLE/HLE_Misc.h
@@ -11,4 +11,6 @@ void UnimplementedFunction();
 void HBReload();
 void GeckoCodeHandlerICacheFlush();
 void GeckoReturnTrampoline();
+void OpenSSLRead();
+void OpenSSLWrite();
 }

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -405,15 +405,10 @@ void WiiSocket::Update(bool read, bool write, bool except)
             int ret = mbedtls_ssl_write(&Device::NetSSL::_SSL[sslID].ctx,
                                         Memory::GetPointer(BufferOut2), BufferOutSize2);
 
-            if (SConfig::GetInstance().m_SSLDumpWrite && ret > 0)
-            {
-              std::string filename = File::GetUserPath(D_DUMPSSL_IDX) +
-                                     SConfig::GetInstance().GetGameID() + "_write.bin";
-              File::IOFile(filename, "ab").WriteBytes(Memory::GetPointer(BufferOut2), ret);
-            }
-
             if (ret >= 0)
             {
+              SConfig::GetInstance().m_network_logger->LogWrite(Memory::GetPointer(BufferOut2),
+                                                                ret);
               // Return bytes written or SSL_ERR_ZERO if none
               WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }
@@ -443,15 +438,9 @@ void WiiSocket::Update(bool read, bool write, bool except)
             int ret = mbedtls_ssl_read(&Device::NetSSL::_SSL[sslID].ctx,
                                        Memory::GetPointer(BufferIn2), BufferInSize2);
 
-            if (SConfig::GetInstance().m_SSLDumpRead && ret > 0)
-            {
-              std::string filename = File::GetUserPath(D_DUMPSSL_IDX) +
-                                     SConfig::GetInstance().GetGameID() + "_read.bin";
-              File::IOFile(filename, "ab").WriteBytes(Memory::GetPointer(BufferIn2), ret);
-            }
-
             if (ret >= 0)
             {
+              SConfig::GetInstance().m_network_logger->LogRead(Memory::GetPointer(BufferIn2), ret);
               // Return bytes read or SSL_ERR_ZERO if none
               WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -240,9 +240,10 @@ PCAPSSLCaptureLogger::IPHeader PCAPSSLCaptureLogger::GetIPHeader(bool is_sender,
   ip_header[9] = protocol;
 
   // Get socket IP address
-  struct sockaddr_in addr;
+  struct sockaddr_in addr = {};
   socklen_t addr_len = sizeof(struct sockaddr_in);
-  getpeername(socket, reinterpret_cast<struct sockaddr*>(&addr), &addr_len);
+  if (socket >= 0)
+    getpeername(socket, reinterpret_cast<struct sockaddr*>(&addr), &addr_len);
 
   if (is_sender)
   {
@@ -287,11 +288,14 @@ void PCAPSSLCaptureLogger::LogTCP(bool is_sender, const void* data, std::size_t 
   TCPHeader tcp_header = {};
 
   // Get socket port
-  struct sockaddr_in sock_addr;
-  struct sockaddr_in peer_addr;
+  struct sockaddr_in sock_addr = {};
+  struct sockaddr_in peer_addr = {};
   socklen_t addr_len = sizeof(struct sockaddr_in);
-  getsockname(socket, reinterpret_cast<struct sockaddr*>(&sock_addr), &addr_len);
-  getpeername(socket, reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
+  if (socket >= 0)
+  {
+    getsockname(socket, reinterpret_cast<struct sockaddr*>(&sock_addr), &addr_len);
+    getpeername(socket, reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
+  }
 
   // Write port
   if (is_sender)
@@ -346,11 +350,14 @@ void PCAPSSLCaptureLogger::LogUDP(bool is_sender, const void* data, std::size_t 
   UDPHeader udp_header = {};
 
   // Get socket port
-  struct sockaddr_in sock_addr;
-  struct sockaddr_in peer_addr;
+  struct sockaddr_in sock_addr = {};
+  struct sockaddr_in peer_addr = {};
   socklen_t addr_len = sizeof(struct sockaddr_in);
-  getsockname(socket, reinterpret_cast<struct sockaddr*>(&sock_addr), &addr_len);
-  getpeername(socket, reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
+  if (socket >= 0)
+  {
+    getsockname(socket, reinterpret_cast<struct sockaddr*>(&sock_addr), &addr_len);
+    getpeername(socket, reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
+  }
 
   // Write port
   if (is_sender)

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -1,0 +1,45 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/NetworkCaptureLogger.h"
+
+#include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
+
+namespace Core
+{
+NetworkCaptureLogger::~NetworkCaptureLogger() = default;
+
+void DummyNetworkCaptureLogger::LogRead(const void* data, std::size_t length)
+{
+}
+
+void DummyNetworkCaptureLogger::LogWrite(const void* data, std::size_t length)
+{
+}
+
+BinarySSLCaptureLogger::BinarySSLCaptureLogger()
+{
+  if (SConfig::GetInstance().m_SSLDumpRead)
+  {
+    m_file_read.Open(
+        File::GetUserPath(D_DUMPSSL_IDX) + SConfig::GetInstance().GetGameID() + "_read.bin", "ab");
+  }
+  if (SConfig::GetInstance().m_SSLDumpWrite)
+  {
+    m_file_write.Open(
+        File::GetUserPath(D_DUMPSSL_IDX) + SConfig::GetInstance().GetGameID() + "_write.bin", "ab");
+  }
+}
+
+void BinarySSLCaptureLogger::LogRead(const void* data, std::size_t length)
+{
+  m_file_read.WriteBytes(data, length);
+}
+
+void BinarySSLCaptureLogger::LogWrite(const void* data, std::size_t length)
+{
+  m_file_write.WriteBytes(data, length);
+}
+}  // namespace Core

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -4,18 +4,62 @@
 
 #include "Core/NetworkCaptureLogger.h"
 
+#ifdef _WIN32
+#include <WinSock2.h>
+using socklen_t = int;
+#else
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif
+
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <iomanip>
+#include <iterator>
+#include <sstream>
+
+#include "Common/File.h"
 #include "Common/FileUtil.h"
+#include "Common/Network.h"
+#include "Common/PcapFile.h"
 #include "Core/ConfigManager.h"
 
 namespace Core
 {
 NetworkCaptureLogger::~NetworkCaptureLogger() = default;
 
-void DummyNetworkCaptureLogger::LogRead(const void* data, std::size_t length)
+void DummyNetworkCaptureLogger::LogSSLRead(const void* data, std::size_t length, s32 socket)
 {
 }
 
-void DummyNetworkCaptureLogger::LogWrite(const void* data, std::size_t length)
+void DummyNetworkCaptureLogger::LogSSLWrite(const void* data, std::size_t length, s32 socket)
+{
+}
+
+void DummyNetworkCaptureLogger::LogTCPRead(const void* data, std::size_t length, s32 socket)
+{
+}
+
+void DummyNetworkCaptureLogger::LogTCPWrite(const void* data, std::size_t length, s32 socket)
+{
+}
+
+void DummyNetworkCaptureLogger::LogUDPRead(const void* data, std::size_t length, s32 socket)
+{
+}
+
+void DummyNetworkCaptureLogger::LogUDPWrite(const void* data, std::size_t length, s32 socket)
+{
+}
+
+void DummyNetworkCaptureLogger::LogRead(const void* data, std::size_t length, s32 socket)
+{
+}
+
+void DummyNetworkCaptureLogger::LogWrite(const void* data, std::size_t length, s32 socket)
 {
 }
 
@@ -33,13 +77,305 @@ BinarySSLCaptureLogger::BinarySSLCaptureLogger()
   }
 }
 
-void BinarySSLCaptureLogger::LogRead(const void* data, std::size_t length)
+void BinarySSLCaptureLogger::LogSSLRead(const void* data, std::size_t length, s32 socket)
 {
   m_file_read.WriteBytes(data, length);
 }
 
-void BinarySSLCaptureLogger::LogWrite(const void* data, std::size_t length)
+void BinarySSLCaptureLogger::LogSSLWrite(const void* data, std::size_t length, s32 socket)
 {
   m_file_write.WriteBytes(data, length);
+}
+
+PCAPSSLCaptureLogger::PCAPSSLCaptureLogger()
+{
+  std::time_t t = std::time(nullptr);
+  std::ostringstream ss;
+  ss << std::put_time(std::localtime(&t), " %Y-%m-%d %Hh%Mm%Ss.pcap");
+
+  const std::string filename =
+      File::GetUserPath(D_DUMPSSL_IDX) + SConfig::GetInstance().GetGameID() + ss.str();
+  m_file = std::make_unique<PCAP>(new File::IOFile(filename, "wb"), PCAP::LinkType::Ethernet);
+}
+
+PCAPSSLCaptureLogger::~PCAPSSLCaptureLogger() = default;
+
+PCAPSSLCaptureLogger::ErrorState PCAPSSLCaptureLogger::SaveState() const
+{
+  return {
+      errno,
+#ifdef _WIN32
+      WSAGetLastError(),
+#endif
+  };
+}
+
+void PCAPSSLCaptureLogger::RestoreState(const PCAPSSLCaptureLogger::ErrorState& state) const
+{
+  errno = state.error;
+#ifdef _WIN32
+  WSASetLastError(state.wsa_error);
+#endif
+}
+
+void PCAPSSLCaptureLogger::Log(LogType log_type, bool is_sender, const void* data,
+                               std::size_t length, s32 socket)
+{
+  const auto state = SaveState();
+  if (log_type == LogType::UDP)
+    LogUDP(is_sender, data, length, socket);
+  else
+    LogTCP(is_sender, data, length, socket);
+  RestoreState(state);
+}
+
+void PCAPSSLCaptureLogger::LogSSLRead(const void* data, std::size_t length, s32 socket)
+{
+  Log(LogType::SSL, false, data, length, socket);
+}
+
+void PCAPSSLCaptureLogger::LogSSLWrite(const void* data, std::size_t length, s32 socket)
+{
+  Log(LogType::SSL, true, data, length, socket);
+}
+
+void PCAPSSLCaptureLogger::LogTCPRead(const void* data, std::size_t length, s32 socket)
+{
+  Log(LogType::TCP, false, data, length, socket);
+}
+
+void PCAPSSLCaptureLogger::LogTCPWrite(const void* data, std::size_t length, s32 socket)
+{
+  Log(LogType::TCP, true, data, length, socket);
+}
+
+void PCAPSSLCaptureLogger::LogUDPRead(const void* data, std::size_t length, s32 socket)
+{
+  Log(LogType::UDP, false, data, length, socket);
+}
+
+void PCAPSSLCaptureLogger::LogUDPWrite(const void* data, std::size_t length, s32 socket)
+{
+  Log(LogType::UDP, true, data, length, socket);
+}
+
+void PCAPSSLCaptureLogger::LogRead(const void* data, std::size_t length, s32 socket)
+{
+  int socket_type;
+  socklen_t option_length = sizeof(int);
+
+  const auto state = SaveState();
+  if (getsockopt(socket, SOL_SOCKET, SO_TYPE, reinterpret_cast<char*>(&socket_type),
+                 &option_length) == 0)
+  {
+    if (socket_type == SOCK_STREAM)
+      LogTCPRead(data, length, socket);
+    else if (socket_type == SOCK_DGRAM)
+      LogUDPRead(data, length, socket);
+  }
+  RestoreState(state);
+}
+
+void PCAPSSLCaptureLogger::LogWrite(const void* data, std::size_t length, s32 socket)
+{
+  int socket_type;
+  socklen_t option_length = sizeof(int);
+
+  const auto state = SaveState();
+  if (getsockopt(socket, SOL_SOCKET, SO_TYPE, reinterpret_cast<char*>(&socket_type),
+                 &option_length) == 0)
+  {
+    if (socket_type == SOCK_STREAM)
+      LogTCPWrite(data, length, socket);
+    else if (socket_type == SOCK_DGRAM)
+      LogUDPWrite(data, length, socket);
+  }
+  RestoreState(state);
+}
+
+PCAPSSLCaptureLogger::EthernetHeader PCAPSSLCaptureLogger::GetEthernetHeader(bool is_sender) const
+{
+  EthernetHeader ethernet_header = {};
+  std::array<u8, Common::MAC_ADDRESS_SIZE> mac = {};
+
+  // Get Dolphin MAC address
+  const std::string mac_address = SConfig::GetInstance().m_WirelessMac;
+  if (!Common::StringToMacAddress(mac_address, mac.data()))
+    mac.fill(0);
+
+  // Write Dolphin MAC address, the other one is dummy
+  if (is_sender)
+  {
+    // Source MAC address
+    std::copy(std::begin(mac), std::end(mac), ethernet_header.begin() + 6);
+  }
+  else
+  {
+    // Destination MAC address
+    std::copy(std::begin(mac), std::end(mac), ethernet_header.begin());
+  }
+
+  // Write the proctol type (IP = 08 00)
+  ethernet_header[12] = 8;
+  return ethernet_header;
+}
+
+PCAPSSLCaptureLogger::IPHeader PCAPSSLCaptureLogger::GetIPHeader(bool is_sender,
+                                                                 std::size_t data_size, u8 protocol,
+                                                                 s32 socket) const
+{
+  IPHeader ip_header = {};
+  const std::size_t total_length = IP_HEADER_SIZE + data_size;
+
+  // Write IP version and header length
+  ip_header[0] = 0x45;
+  // Write total length
+  ip_header[2] = static_cast<u8>(total_length >> 8 & 0xFF);
+  ip_header[3] = static_cast<u8>(total_length & 0xFF);
+  // Write flags + fragment offset
+  ip_header[6] = 0x40;
+  // Write TTL
+  ip_header[8] = 0x40;
+  // Write protocol
+  ip_header[9] = protocol;
+
+  // Get socket IP address
+  struct sockaddr_in addr;
+  socklen_t addr_len = sizeof(struct sockaddr_in);
+  getpeername(socket, reinterpret_cast<struct sockaddr*>(&addr), &addr_len);
+
+  if (is_sender)
+  {
+    // Write Source IP address: 127.0.0.1
+    ip_header[12] = 0x7F;
+    ip_header[15] = 0x01;
+    // Write Destination IP address
+    std::memcpy(&ip_header[16], &addr.sin_addr, 4);
+  }
+  else
+  {
+    // Write Source IP address
+    std::memcpy(&ip_header[12], &addr.sin_addr, 4);
+    // Write Destination IP address: 127.0.0.1
+    ip_header[16] = 0x7F;
+    ip_header[19] = 0x01;
+  }
+
+  // Compute checksum
+  std::size_t index = 0;
+  u32 checksum = 0;
+  u16 word = 0;
+  for (u8 b : ip_header)
+  {
+    if (index % 2 == 0)
+      word = b;
+    else
+      checksum += (word << 8) + b;
+    index += 1;
+  }
+  checksum = (checksum + (checksum >> 16) & 0xFFFF) ^ 0xFFFF;
+
+  // Write checksum
+  ip_header[10] = static_cast<u8>(checksum >> 8 & 0xFF);
+  ip_header[11] = static_cast<u8>(checksum & 0xFF);
+
+  return ip_header;
+}
+
+void PCAPSSLCaptureLogger::LogTCP(bool is_sender, const void* data, std::size_t length, s32 socket)
+{
+  TCPHeader tcp_header = {};
+
+  // Get socket port
+  struct sockaddr_in sock_addr;
+  struct sockaddr_in peer_addr;
+  socklen_t addr_len = sizeof(struct sockaddr_in);
+  getsockname(socket, reinterpret_cast<struct sockaddr*>(&sock_addr), &addr_len);
+  getpeername(socket, reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
+
+  // Write port
+  if (is_sender)
+  {
+    std::memcpy(&tcp_header[0], &sock_addr.sin_port, 2);
+    std::memcpy(&tcp_header[2], &peer_addr.sin_port, 2);
+
+    // Write sequence number
+    tcp_header[4] = static_cast<u8>(m_write_sequence_number >> 24 & 0xFF);
+    tcp_header[5] = static_cast<u8>(m_write_sequence_number >> 16 & 0xFF);
+    tcp_header[6] = static_cast<u8>(m_write_sequence_number >> 8 & 0xFF);
+    tcp_header[7] = static_cast<u8>(m_write_sequence_number & 0xFF);
+    m_write_sequence_number += static_cast<u32>(length);
+  }
+  else
+  {
+    std::memcpy(&tcp_header[0], &peer_addr.sin_port, 2);
+    std::memcpy(&tcp_header[2], &sock_addr.sin_port, 2);
+
+    // Write sequence number
+    tcp_header[4] = static_cast<u8>(m_read_sequence_number >> 24 & 0xFF);
+    tcp_header[5] = static_cast<u8>(m_read_sequence_number >> 16 & 0xFF);
+    tcp_header[6] = static_cast<u8>(m_read_sequence_number >> 8 & 0xFF);
+    tcp_header[7] = static_cast<u8>(m_read_sequence_number & 0xFF);
+    m_read_sequence_number += static_cast<u32>(length);
+  }
+
+  // Write data offset
+  tcp_header[12] = 0x50;
+
+  // Write flags
+  // TODO
+
+  // Write window size
+  tcp_header[14] = 0xFF;
+  tcp_header[15] = 0xFF;
+
+  // Add the packet
+  const EthernetHeader ethernet_header = GetEthernetHeader(is_sender);
+  const IPHeader ip_header = GetIPHeader(is_sender, TCP_HEADER_SIZE + length, 0x06, socket);
+  std::vector<u8> packet;
+  packet.insert(packet.end(), ethernet_header.begin(), ethernet_header.end());
+  packet.insert(packet.end(), ip_header.begin(), ip_header.end());
+  packet.insert(packet.end(), tcp_header.begin(), tcp_header.end());
+  packet.insert(packet.end(), static_cast<const char*>(data),
+                static_cast<const char*>(data) + length);
+  m_file->AddPacket(packet.data(), packet.size());
+}
+
+void PCAPSSLCaptureLogger::LogUDP(bool is_sender, const void* data, std::size_t length, s32 socket)
+{
+  UDPHeader udp_header = {};
+
+  // Get socket port
+  struct sockaddr_in sock_addr;
+  struct sockaddr_in peer_addr;
+  socklen_t addr_len = sizeof(struct sockaddr_in);
+  getsockname(socket, reinterpret_cast<struct sockaddr*>(&sock_addr), &addr_len);
+  getpeername(socket, reinterpret_cast<struct sockaddr*>(&peer_addr), &addr_len);
+
+  // Write port
+  if (is_sender)
+  {
+    std::memcpy(&udp_header[0], &sock_addr.sin_port, 2);
+    std::memcpy(&udp_header[2], &peer_addr.sin_port, 2);
+  }
+  else
+  {
+    std::memcpy(&udp_header[0], &peer_addr.sin_port, 2);
+    std::memcpy(&udp_header[2], &sock_addr.sin_port, 2);
+  }
+  const u16 udp_length = static_cast<u16>(UDP_HEADER_SIZE + length);
+  udp_header[4] = static_cast<u8>(udp_length >> 8 & 0xFF);
+  udp_header[5] = static_cast<u8>(udp_length & 0xFF);
+
+  // Add the packet
+  const EthernetHeader ethernet_header = GetEthernetHeader(is_sender);
+  const IPHeader ip_header = GetIPHeader(is_sender, UDP_HEADER_SIZE + length, 0x11, socket);
+  std::vector<u8> packet;
+  packet.insert(packet.end(), ethernet_header.begin(), ethernet_header.end());
+  packet.insert(packet.end(), ip_header.begin(), ip_header.end());
+  packet.insert(packet.end(), udp_header.begin(), udp_header.end());
+  packet.insert(packet.end(), static_cast<const char*>(data),
+                static_cast<const char*>(data) + length);
+  m_file->AddPacket(packet.data(), packet.size());
 }
 }  // namespace Core

--- a/Source/Core/Core/NetworkCaptureLogger.cpp
+++ b/Source/Core/Core/NetworkCaptureLogger.cpp
@@ -385,4 +385,18 @@ void PCAPSSLCaptureLogger::LogUDP(bool is_sender, const void* data, std::size_t 
                 static_cast<const char*>(data) + length);
   m_file->AddPacket(packet.data(), packet.size());
 }
+
+PCAPOpenSSLCaptureLogger::PCAPOpenSSLCaptureLogger()
+{
+  std::time_t t = std::time(nullptr);
+  std::ostringstream ss;
+  ss << std::put_time(std::localtime(&t), " %Y-%m-%d %Hh%Mm%Ss openssl.pcap");
+
+  const std::string filename =
+      File::GetUserPath(D_DUMPSSL_IDX) + SConfig::GetInstance().GetGameID() + ss.str();
+  m_file = std::make_unique<PCAP>(new File::IOFile(filename, "wb"), PCAP::LinkType::Ethernet);
+}
+
+PCAPOpenSSLCaptureLogger::~PCAPOpenSSLCaptureLogger() = default;
+
 }  // namespace Core

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -1,0 +1,40 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Common/File.h"
+
+namespace Core
+{
+class NetworkCaptureLogger
+{
+public:
+  virtual ~NetworkCaptureLogger();
+  virtual void LogRead(const void* data, std::size_t length) = 0;
+  virtual void LogWrite(const void* data, std::size_t length) = 0;
+};
+
+class DummyNetworkCaptureLogger : public NetworkCaptureLogger
+{
+public:
+  void LogRead(const void* data, std::size_t length) override;
+  void LogWrite(const void* data, std::size_t length) override;
+};
+
+class BinarySSLCaptureLogger : public NetworkCaptureLogger
+{
+public:
+  BinarySSLCaptureLogger();
+
+  void LogRead(const void* data, std::size_t length) override;
+  void LogWrite(const void* data, std::size_t length) override;
+
+private:
+  File::IOFile m_file_read;
+  File::IOFile m_file_write;
+};
+}  // namespace Core

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -80,6 +80,9 @@ public:
   void LogRead(const void* data, std::size_t length, s32 socket) override;
   void LogWrite(const void* data, std::size_t length, s32 socket) override;
 
+protected:
+  std::unique_ptr<PCAP> m_file;
+
 private:
   enum class LogType
   {
@@ -115,8 +118,15 @@ private:
   void LogTCP(bool is_sender, const void* data, std::size_t length, s32 socket);
   void LogUDP(bool is_sender, const void* data, std::size_t length, s32 socket);
 
-  std::unique_ptr<PCAP> m_file;
   u32 m_read_sequence_number = 0;
   u32 m_write_sequence_number = 0;
 };
+
+class PCAPOpenSSLCaptureLogger : public PCAPSSLCaptureLogger
+{
+public:
+  PCAPOpenSSLCaptureLogger();
+  ~PCAPOpenSSLCaptureLogger();
+};
+
 }  // namespace Core

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -4,9 +4,14 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <memory>
 
+#include "Common/CommonTypes.h"
 #include "Common/File.h"
+
+class PCAP;
 
 namespace Core
 {
@@ -14,27 +19,104 @@ class NetworkCaptureLogger
 {
 public:
   virtual ~NetworkCaptureLogger();
-  virtual void LogRead(const void* data, std::size_t length) = 0;
-  virtual void LogWrite(const void* data, std::size_t length) = 0;
+
+  virtual void LogSSLRead(const void* data, std::size_t length, s32 socket) = 0;
+  virtual void LogSSLWrite(const void* data, std::size_t length, s32 socket) = 0;
+
+  virtual void LogTCPRead(const void* data, std::size_t length, s32 socket) = 0;
+  virtual void LogTCPWrite(const void* data, std::size_t length, s32 socket) = 0;
+
+  virtual void LogUDPRead(const void* data, std::size_t length, s32 socket) = 0;
+  virtual void LogUDPWrite(const void* data, std::size_t length, s32 socket) = 0;
+
+  virtual void LogRead(const void* data, std::size_t length, s32 socket) = 0;
+  virtual void LogWrite(const void* data, std::size_t length, s32 socket) = 0;
 };
 
 class DummyNetworkCaptureLogger : public NetworkCaptureLogger
 {
 public:
-  void LogRead(const void* data, std::size_t length) override;
-  void LogWrite(const void* data, std::size_t length) override;
+  void LogSSLRead(const void* data, std::size_t length, s32 socket) override;
+  void LogSSLWrite(const void* data, std::size_t length, s32 socket) override;
+
+  void LogTCPRead(const void* data, std::size_t length, s32 socket) override;
+  void LogTCPWrite(const void* data, std::size_t length, s32 socket) override;
+
+  void LogUDPRead(const void* data, std::size_t length, s32 socket) override;
+  void LogUDPWrite(const void* data, std::size_t length, s32 socket) override;
+
+  void LogRead(const void* data, std::size_t length, s32 socket) override;
+  void LogWrite(const void* data, std::size_t length, s32 socket) override;
 };
 
-class BinarySSLCaptureLogger : public NetworkCaptureLogger
+class BinarySSLCaptureLogger : public DummyNetworkCaptureLogger
 {
 public:
   BinarySSLCaptureLogger();
 
-  void LogRead(const void* data, std::size_t length) override;
-  void LogWrite(const void* data, std::size_t length) override;
+  void LogSSLRead(const void* data, std::size_t length, s32 socket) override;
+  void LogSSLWrite(const void* data, std::size_t length, s32 socket) override;
 
 private:
   File::IOFile m_file_read;
   File::IOFile m_file_write;
+};
+
+class PCAPSSLCaptureLogger : public NetworkCaptureLogger
+{
+public:
+  PCAPSSLCaptureLogger();
+  ~PCAPSSLCaptureLogger();
+
+  void LogSSLRead(const void* data, std::size_t length, s32 socket) override;
+  void LogSSLWrite(const void* data, std::size_t length, s32 socket) override;
+
+  void LogTCPRead(const void* data, std::size_t length, s32 socket) override;
+  void LogTCPWrite(const void* data, std::size_t length, s32 socket) override;
+
+  void LogUDPRead(const void* data, std::size_t length, s32 socket) override;
+  void LogUDPWrite(const void* data, std::size_t length, s32 socket) override;
+
+  void LogRead(const void* data, std::size_t length, s32 socket) override;
+  void LogWrite(const void* data, std::size_t length, s32 socket) override;
+
+private:
+  enum class LogType
+  {
+    TCP,
+    UDP,
+    SSL
+  };
+
+  static constexpr std::size_t ETHERNET_HEADER_SIZE = 14;
+  static constexpr std::size_t IP_HEADER_SIZE = 20;
+  static constexpr std::size_t TCP_HEADER_SIZE = 20;
+  static constexpr std::size_t UDP_HEADER_SIZE = 8;
+
+  using EthernetHeader = std::array<u8, ETHERNET_HEADER_SIZE>;
+  using IPHeader = std::array<u8, IP_HEADER_SIZE>;
+  using TCPHeader = std::array<u8, TCP_HEADER_SIZE>;
+  using UDPHeader = std::array<u8, UDP_HEADER_SIZE>;
+
+  EthernetHeader GetEthernetHeader(bool is_sender) const;
+  IPHeader GetIPHeader(bool is_sender, std::size_t data_size, u8 protocol, s32 socket) const;
+
+  struct ErrorState
+  {
+    int error;
+#ifdef _WIN32
+    int wsa_error;
+#endif
+  };
+  ErrorState SaveState() const;
+  void RestoreState(const ErrorState& state) const;
+
+  void Log(LogType log_type, bool is_sender, const void* data, std::size_t length, s32 socket);
+  void LogTCP(bool is_sender, const void* data, std::size_t length, s32 socket);
+  void LogUDP(bool is_sender, const void* data, std::size_t length, s32 socket);
+
+  std::unique_ptr<PCAP> m_file;
+  u32 m_read_sequence_number = 0;
+  u32 m_write_sequence_number = 0;
 };
 }  // namespace Core

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <cstddef>
+#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -162,6 +164,9 @@ void InjectExternalCPUCore(CPUCoreBase* core);
 // Stepping requires the CPU Execution lock (CPU::PauseAndLock or CPU Thread)
 // It's not threadsafe otherwise.
 void SingleStep();
+// Stepping until it returns if no timeout is specified
+bool StepOut(std::optional<std::chrono::seconds> timeout = std::nullopt);
+bool WillInstructionReturn(UGeckoInstruction inst);
 void CheckExceptions();
 void CheckExternalExceptions();
 void CheckBreakPoints();

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -339,62 +339,12 @@ void CCodeWindow::StepOver()
   }
 }
 
-// Returns true on a rfi, blr or on a bclr that evaluates to true.
-static bool WillInstructionReturn(UGeckoInstruction inst)
-{
-  // Is a rfi instruction
-  if (inst.hex == 0x4C000064u)
-    return true;
-  bool counter = (inst.BO_2 >> 2 & 1) != 0 || (CTR != 0) != ((inst.BO_2 >> 1 & 1) != 0);
-  bool condition = inst.BO_2 >> 4 != 0 || GetCRBit(inst.BI_2) == (inst.BO_2 >> 3 & 1);
-  bool isBclr = inst.OPCD_7 == 0b010011 && (inst.hex >> 1 & 0b10000) != 0;
-  return isBclr && counter && condition && !inst.LK_3;
-}
-
 void CCodeWindow::StepOut()
 {
   if (CPU::IsStepping())
   {
     CPU::PauseAndLock(true, false);
-    PowerPC::breakpoints.ClearAllTemporary();
-
-    // Keep stepping until the next return instruction or timeout after five seconds
-    using clock = std::chrono::steady_clock;
-    clock::time_point timeout = clock::now() + std::chrono::seconds(5);
-    PowerPC::CoreMode old_mode = PowerPC::GetMode();
-    PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
-
-    // Loop until either the current instruction is a return instruction with no Link flag
-    // or a breakpoint is detected so it can step at the breakpoint. If the PC is currently
-    // on a breakpoint, skip it.
-    UGeckoInstruction inst = PowerPC::HostRead_Instruction(PC);
-    do
-    {
-      if (WillInstructionReturn(inst))
-      {
-        PowerPC::SingleStep();
-        break;
-      }
-
-      if (inst.LK)
-      {
-        // Step over branches
-        u32 next_pc = PC + 4;
-        do
-        {
-          PowerPC::SingleStep();
-        } while (PC != next_pc && clock::now() < timeout &&
-                 !PowerPC::breakpoints.IsAddressBreakPoint(PC));
-      }
-      else
-      {
-        PowerPC::SingleStep();
-      }
-
-      inst = PowerPC::HostRead_Instruction(PC);
-    } while (clock::now() < timeout && !PowerPC::breakpoints.IsAddressBreakPoint(PC));
-
-    PowerPC::SetMode(old_mode);
+    bool step_out_success = PowerPC::StepOut(std::chrono::seconds(5));
     CPU::PauseAndLock(false, false);
 
     wxCommandEvent ev(wxEVT_HOST_COMMAND, IDM_UPDATE_DISASM_DIALOG);
@@ -402,7 +352,7 @@ void CCodeWindow::StepOut()
 
     if (PowerPC::breakpoints.IsAddressBreakPoint(PC))
       Core::DisplayMessage(_("Breakpoint encountered! Step out aborted.").ToStdString(), 2000);
-    else if (clock::now() >= timeout)
+    else if (!step_out_success)
       Core::DisplayMessage(_("Step out timed out!").ToStdString(), 2000);
     else
       Core::DisplayMessage(_("Step out successful!").ToStdString(), 2000);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -899,6 +899,7 @@ void CFrame::DoStop()
     if (Movie::IsMovieActive())
       Movie::EndPlayInput(false);
     SConfig::GetInstance().m_network_logger = std::make_unique<Core::DummyNetworkCaptureLogger>();
+    SConfig::GetInstance().m_openssl_logger = std::make_unique<Core::DummyNetworkCaptureLogger>();
 
     if (!m_tried_graceful_shutdown && UICommon::TriggerSTMPowerEvent())
     {

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -898,6 +898,7 @@ void CFrame::DoStop()
       DoRecordingSave();
     if (Movie::IsMovieActive())
       Movie::EndPlayInput(false);
+    SConfig::GetInstance().m_network_logger = std::make_unique<Core::DummyNetworkCaptureLogger>();
 
     if (!m_tried_graceful_shutdown && UICommon::TriggerSTMPowerEvent())
     {


### PR DESCRIPTION
This PR is based on:
- https://github.com/dolphin-emu/dolphin/pull/6075
- https://github.com/dolphin-emu/dolphin/pull/6176

It adds another logger that HLE hooks with OpenSSL functions to log SSL traffic. This method should work with any other functions as long as we know the parameters. It has to be enabled with the config's option "OpenSSLDumpPCAP".

I tested it with a small homebrew and still is WIP as it needs to be tested on other games. It also requires reverse engineering skills to find these functions and add them to the symbol map in order to use HLE hooks. I might provide a OpenSSL signature database file soon if it's reliable.

I still have to figure out the SSL structure used if I want to retrieve the socket fd that's used.

**DISCLAIMER:** Keep in mind that logging SSL traffic will most likely log sensitive information. That's why you should be careful if you plan to share these network dumps.

Need to be tested on:
- [ ] Amazon Instant Video
- [ ] Crunchyroll
- [ ] Hulu PLUS
- [ ] Netflix
- [ ] Youtube (?) *does it still work if we bypass the error code 20110?*
- [ ] Dragon Quest X (?) *does it use openssl.rso?*
