### PR TITLE
Add hotplug support to DInput and XInput controller backends

### DIFF
--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -34,6 +34,7 @@ if(WIN32)
     ControllerInterface/DInput/DInputJoystick.cpp
     ControllerInterface/DInput/DInputKeyboardMouse.cpp
     ControllerInterface/DInput/XInputFilter.cpp
+    ControllerInterface/Win32/Win32.cpp
     ControllerInterface/XInput/XInput.cpp
     ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
   )

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -8,11 +8,8 @@
 
 #include "Common/Logging/Log.h"
 
-#ifdef CIFACE_USE_XINPUT
-#include "InputCommon/ControllerInterface/XInput/XInput.h"
-#endif
-#ifdef CIFACE_USE_DINPUT
-#include "InputCommon/ControllerInterface/DInput/DInput.h"
+#ifdef CIFACE_USE_WIN32
+#include "InputCommon/ControllerInterface/Win32/Win32.h"
 #endif
 #ifdef CIFACE_USE_XLIB
 #include "InputCommon/ControllerInterface/Xlib/XInput2.h"
@@ -49,11 +46,8 @@ void ControllerInterface::Initialize(void* const hwnd)
   m_hwnd = hwnd;
   m_is_populating_devices = true;
 
-#ifdef CIFACE_USE_DINPUT
-// nothing needed
-#endif
-#ifdef CIFACE_USE_XINPUT
-  ciface::XInput::Init();
+#ifdef CIFACE_USE_WIN32
+  ciface::Win32::Init();
 #endif
 #ifdef CIFACE_USE_XLIB
 // nothing needed
@@ -91,11 +85,8 @@ void ControllerInterface::RefreshDevices()
 
   m_is_populating_devices = true;
 
-#ifdef CIFACE_USE_DINPUT
-  ciface::DInput::PopulateDevices(reinterpret_cast<HWND>(m_hwnd));
-#endif
-#ifdef CIFACE_USE_XINPUT
-  ciface::XInput::PopulateDevices();
+#ifdef CIFACE_USE_WIN32
+  ciface::Win32::PopulateDevices(m_hwnd);
 #endif
 #ifdef CIFACE_USE_XLIB
   ciface::XInput2::PopulateDevices(m_hwnd);
@@ -144,11 +135,8 @@ void ControllerInterface::Shutdown()
     m_devices.clear();
   }
 
-#ifdef CIFACE_USE_XINPUT
-  ciface::XInput::DeInit();
-#endif
-#ifdef CIFACE_USE_DINPUT
-// nothing needed
+#ifdef CIFACE_USE_WIN32
+  ciface::Win32::DeInit();
 #endif
 #ifdef CIFACE_USE_XLIB
 // nothing needed

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -47,7 +47,7 @@ void ControllerInterface::Initialize(void* const hwnd)
   m_is_populating_devices = true;
 
 #ifdef CIFACE_USE_WIN32
-  ciface::Win32::Init();
+  ciface::Win32::Init(hwnd);
 #endif
 #ifdef CIFACE_USE_XLIB
 // nothing needed
@@ -86,7 +86,7 @@ void ControllerInterface::RefreshDevices()
   m_is_populating_devices = true;
 
 #ifdef CIFACE_USE_WIN32
-  ciface::Win32::PopulateDevices(m_hwnd);
+  ciface::Win32::PopulateDevices();
 #endif
 #ifdef CIFACE_USE_XLIB
   ciface::XInput2::PopulateDevices(m_hwnd);

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -14,8 +14,7 @@
 
 // enable disable sources
 #ifdef _WIN32
-#define CIFACE_USE_XINPUT
-#define CIFACE_USE_DINPUT
+#define CIFACE_USE_WIN32
 #endif
 #if defined(HAVE_X11) && HAVE_X11
 #define CIFACE_USE_XLIB

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
@@ -46,6 +46,8 @@ std::string GetDeviceName(const LPDIRECTINPUTDEVICE8 device)
 
 void PopulateDevices(HWND hwnd)
 {
+  g_controller_interface.RemoveDevice([](const auto* dev) { return dev->GetSource() == "DInput"; });
+
   IDirectInput8* idi8;
   if (FAILED(DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8,
                                 (LPVOID*)&idi8, nullptr)))

--- a/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
@@ -4,23 +4,131 @@
 
 #include "InputCommon/ControllerInterface/Win32/Win32.h"
 
+#include <windows.h>
+
+#include <thread>
+
+#include "Common/Event.h"
+#include "Common/Logging/Log.h"
+#include "Common/ScopeGuard.h"
 #include "InputCommon/ControllerInterface/DInput/DInput.h"
 #include "InputCommon/ControllerInterface/XInput/XInput.h"
 
-void ciface::Win32::Init()
+constexpr UINT WM_DOLPHIN_STOP = WM_USER;
+
+static Common::Event s_done_populating;
+static HWND s_hwnd;
+static HWND s_message_window;
+static std::thread s_thread;
+
+static LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)
 {
-  // DInput::Init();
-  XInput::Init();
+  if (message == WM_INPUT_DEVICE_CHANGE)
+  {
+    ciface::DInput::PopulateDevices(s_hwnd);
+    ciface::XInput::PopulateDevices();
+    s_done_populating.Set();
+  }
+
+  return DefWindowProc(hwnd, message, wparam, lparam);
 }
 
-void ciface::Win32::PopulateDevices(void* hwnd)
+void ciface::Win32::Init(void* hwnd)
 {
-  DInput::PopulateDevices(static_cast<HWND>(hwnd));
-  XInput::PopulateDevices();
+  s_hwnd = static_cast<HWND>(hwnd);
+  XInput::Init();
+
+  s_thread = std::thread([] {
+    if (FAILED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED)))
+    {
+      ERROR_LOG(SERIALINTERFACE, "CoInitializeEx failed: %i", GetLastError());
+      return;
+    }
+    Common::ScopeGuard uninit([] { CoUninitialize(); });
+
+    WNDCLASSEX window_class_info{};
+    window_class_info.cbSize = sizeof(window_class_info);
+    window_class_info.lpfnWndProc = WindowProc;
+    window_class_info.hInstance = GetModuleHandle(nullptr);
+    window_class_info.lpszClassName = L"Message";
+
+    ATOM window_class = RegisterClassEx(&window_class_info);
+    if (!window_class)
+    {
+      NOTICE_LOG(SERIALINTERFACE, "RegisterClassEx failed: %i", GetLastError());
+      return;
+    }
+    Common::ScopeGuard unregister([&window_class] {
+      if (!UnregisterClass(MAKEINTATOM(window_class), GetModuleHandle(nullptr)))
+        ERROR_LOG(SERIALINTERFACE, "UnregisterClass failed: %i", GetLastError());
+    });
+
+    s_message_window = CreateWindowEx(0, L"Message", nullptr, 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                      nullptr, nullptr);
+    if (!s_message_window)
+    {
+      ERROR_LOG(SERIALINTERFACE, "CreateWindowEx failed: %i", GetLastError());
+      return;
+    }
+    Common::ScopeGuard destroy([] {
+      if (!DestroyWindow(s_message_window))
+        ERROR_LOG(SERIALINTERFACE, "DestroyWindow failed: %i", GetLastError());
+      s_message_window = nullptr;
+    });
+
+    std::array<RAWINPUTDEVICE, 2> devices;
+    // game pad devices
+    devices[0].usUsagePage = 0x01;
+    devices[0].usUsage = 0x05;
+    devices[0].dwFlags = RIDEV_DEVNOTIFY;
+    devices[0].hwndTarget = s_message_window;
+    // joystick devices
+    devices[1].usUsagePage = 0x01;
+    devices[1].usUsage = 0x04;
+    devices[1].dwFlags = RIDEV_DEVNOTIFY;
+    devices[1].hwndTarget = s_message_window;
+
+    if (!RegisterRawInputDevices(devices.data(), static_cast<UINT>(devices.size()),
+                                 static_cast<UINT>(sizeof(decltype(devices)::value_type))))
+    {
+      ERROR_LOG(SERIALINTERFACE, "RegisterRawInputDevices failed: %i", GetLastError());
+      return;
+    }
+
+    MSG msg;
+    while (GetMessage(&msg, nullptr, 0, 0) > 0)
+    {
+      TranslateMessage(&msg);
+      DispatchMessage(&msg);
+      if (msg.message == WM_DOLPHIN_STOP)
+        break;
+    }
+  });
+}
+
+void ciface::Win32::PopulateDevices()
+{
+  if (s_thread.joinable())
+  {
+    s_done_populating.Reset();
+    PostMessage(s_message_window, WM_INPUT_DEVICE_CHANGE, 0, 0);
+    if (!s_done_populating.WaitFor(std::chrono::seconds(10)))
+      ERROR_LOG(SERIALINTERFACE, "win32 timed out when trying to populate devices");
+  }
+  else
+  {
+    ERROR_LOG(SERIALINTERFACE, "win32 asked to populate devices, but device thread isn't running");
+  }
 }
 
 void ciface::Win32::DeInit()
 {
-  // DInput::DeInit();
+  NOTICE_LOG(SERIALINTERFACE, "win32 DeInit");
+  if (s_thread.joinable())
+  {
+    PostMessage(s_message_window, WM_DOLPHIN_STOP, 0, 0);
+    s_thread.join();
+  }
+
   XInput::DeInit();
 }

--- a/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
@@ -1,0 +1,26 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "InputCommon/ControllerInterface/Win32/Win32.h"
+
+#include "InputCommon/ControllerInterface/DInput/DInput.h"
+#include "InputCommon/ControllerInterface/XInput/XInput.h"
+
+void ciface::Win32::Init()
+{
+  // DInput::Init();
+  XInput::Init();
+}
+
+void ciface::Win32::PopulateDevices(void* hwnd)
+{
+  DInput::PopulateDevices(static_cast<HWND>(hwnd));
+  XInput::PopulateDevices();
+}
+
+void ciface::Win32::DeInit()
+{
+  // DInput::DeInit();
+  XInput::DeInit();
+}

--- a/Source/Core/InputCommon/ControllerInterface/Win32/Win32.h
+++ b/Source/Core/InputCommon/ControllerInterface/Win32/Win32.h
@@ -8,8 +8,8 @@ namespace ciface
 {
 namespace Win32
 {
-void Init();
-void PopulateDevices(void* hwnd);
+void Init(void* hwnd);
+void PopulateDevices();
 void DeInit();
 }
 }

--- a/Source/Core/InputCommon/ControllerInterface/Win32/Win32.h
+++ b/Source/Core/InputCommon/ControllerInterface/Win32/Win32.h
@@ -1,0 +1,15 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace ciface
+{
+namespace Win32
+{
+void Init();
+void PopulateDevices(void* hwnd);
+void DeInit();
+}
+}

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -92,6 +92,8 @@ void PopulateDevices()
   if (!hXInput)
     return;
 
+  g_controller_interface.RemoveDevice([](const auto* dev) { return dev->GetSource() == "XInput"; });
+
   XINPUT_CAPABILITIES caps;
   for (int i = 0; i != 4; ++i)
     if (ERROR_SUCCESS == PXInputGetCapabilities(i, 0, &caps))

--- a/Source/Core/InputCommon/InputCommon.vcxproj
+++ b/Source/Core/InputCommon/InputCommon.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="ControlReference\ControlReference.cpp" />
     <ClCompile Include="ControlReference\ExpressionParser.cpp" />
     <ClCompile Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.cpp" />
+    <ClCompile Include="ControllerInterface\Win32\Win32.cpp" />
     <ClCompile Include="ControllerInterface\XInput\XInput.cpp" />
     <ClCompile Include="GCAdapter.cpp">
       <!--
@@ -102,6 +103,7 @@
     <ClInclude Include="ControlReference\ControlReference.h" />
     <ClInclude Include="ControlReference\ExpressionParser.h" />
     <ClInclude Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.h" />
+    <ClInclude Include="ControllerInterface\Win32\Win32.h" />
     <ClInclude Include="ControllerInterface\XInput\XInput.h" />
     <ClInclude Include="GCAdapter.h" />
     <ClInclude Include="GCPadStatus.h" />

--- a/Source/Core/InputCommon/InputCommon.vcxproj.filters
+++ b/Source/Core/InputCommon/InputCommon.vcxproj.filters
@@ -4,12 +4,6 @@
     <Filter Include="ControllerInterface">
       <UniqueIdentifier>{3a755a86-0efa-4396-bf79-bb3a1910764d}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ControllerInterface\DInput">
-      <UniqueIdentifier>{0289ef91-50f5-4c16-9fa4-ff4c4d8208e7}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="ControllerInterface\XInput">
-      <UniqueIdentifier>{07bad1aa-7e03-4f5c-ade2-a44857c5cbc3}</UniqueIdentifier>
-    </Filter>
     <Filter Include="ControllerInterface\ForceFeedback">
       <UniqueIdentifier>{e10ce316-283c-4be0-848d-578dec2b6404}</UniqueIdentifier>
     </Filter>
@@ -24,6 +18,15 @@
     </Filter>
     <Filter Include="ControllerEmu\Setting">
       <UniqueIdentifier>{ce661cb4-f23f-4ab2-952d-402d381735e5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\Win32">
+      <UniqueIdentifier>{6ca06b20-d8f6-4622-97ab-eefbc66edbd5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\DInput">
+      <UniqueIdentifier>{0289ef91-50f5-4c16-9fa4-ff4c4d8208e7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\XInput">
+      <UniqueIdentifier>{07bad1aa-7e03-4f5c-ade2-a44857c5cbc3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -103,6 +106,9 @@
     </ClCompile>
     <ClCompile Include="ControllerInterface\DInput\XInputFilter.cpp">
       <Filter>ControllerInterface\DInput</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\Win32\Win32.cpp">
+      <Filter>ControllerInterface\Win32</Filter>
     </ClCompile>
     <ClCompile Include="ControlReference\ExpressionParser.cpp">
       <Filter>ControllerInterface</Filter>
@@ -196,6 +202,9 @@
     </ClInclude>
     <ClInclude Include="ControllerInterface\DInput\XInputFilter.h">
       <Filter>ControllerInterface\DInput</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\Win32\Win32.h">
+      <Filter>ControllerInterface\Win32</Filter>
     </ClInclude>
     <ClInclude Include="ControlReference\ExpressionParser.h">
       <Filter>ControllerInterface</Filter>


### PR DESCRIPTION
Creates a third backend, Win32, which encompasses the existing XInput and DInput backends, and ask them to repopulate devices when it sees a change event.

Unfortunately, there's not really a great way to map change events to XInput and DInput devices. So, when a change event happens, _all_ XInput and DInput controllers are removed and re-added. Stupid, but works. It's how SDL does it too.

(There's supposedly a way to map events to DInput devices, but the Internet claims it's sketchy. There _is_ a straightforward way to do it for RawInput, if that's ever used in the future.)