### PR TITLE
VideoConfig: Add const specifier to IsVSync() member function

### DIFF
--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -180,7 +180,7 @@ void VideoConfig::VerifyValidity()
   }
 }
 
-bool VideoConfig::IsVSync()
+bool VideoConfig::IsVSync() const
 {
   return bVSync && !Core::GetIsThrottlerTempDisabled();
 }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -58,7 +58,7 @@ struct VideoConfig final
   void Refresh();
   void VerifyValidity();
   void UpdateProjectionHack();
-  bool IsVSync();
+  bool IsVSync() const;
 
   // General
   bool bVSync;


### PR DESCRIPTION
This member function doesn't alter VideoConfig's state.

Pretty easy PR to review.