### PR TITLE
evdev: Correctly calculate axis range for min values greater than 0.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -313,7 +313,7 @@ evdevDevice::Axis::Axis(u8 index, u16 code, bool upper, libevdev* dev)
     : m_code(code), m_index(index), m_upper(upper), m_dev(dev)
 {
   m_min = libevdev_get_abs_minimum(m_dev, m_code);
-  m_range = libevdev_get_abs_maximum(m_dev, m_code) + abs(m_min);
+  m_range = libevdev_get_abs_maximum(m_dev, m_code) - m_min;
 }
 
 std::string evdevDevice::Axis::GetName() const


### PR DESCRIPTION
Axis range was previously calculated as max + abs(min), which relies on the assumption that
min will not exceed 0. For (min, max) values like (0, 255) or (-128, 127), which I assume to
be the most common cases, the range is correctly calculated as 255. However, given (20,
235), the range is erroneously calculated as 255, leading to axis values being normalized
incorrectly.

SDL already handles this case correctly. After changing the range calculation to max - min,
the axis values received from the evdev backend are practically identical to the values
received from the SDL backend.