### PR TITLE
VideoConfig: Make AspectMode and StereoMode enum classes

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -220,7 +220,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-ssaa", g_Config.bSSAA);
   builder.AddData("cfg-gfx-anisotropy", g_Config.iMaxAnisotropy);
   builder.AddData("cfg-gfx-vsync", g_Config.bVSync);
-  builder.AddData("cfg-gfx-aspect-ratio", g_Config.iAspectRatio);
+  builder.AddData("cfg-gfx-aspect-ratio", static_cast<int>(g_Config.aspect_mode));
   builder.AddData("cfg-gfx-efb-access", g_Config.bEFBAccessEnable);
   builder.AddData("cfg-gfx-efb-copy-format-changes", g_Config.bEFBEmulateFormatChanges);
   builder.AddData("cfg-gfx-efb-copy-ram", !g_Config.bSkipEFBCopyToRam);
@@ -229,7 +229,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-efb-copy-scaled", g_Config.bCopyEFBScaled);
   builder.AddData("cfg-gfx-internal-resolution", g_Config.iEFBScale);
   builder.AddData("cfg-gfx-tc-samples", g_Config.iSafeTextureCache_ColorSamples);
-  builder.AddData("cfg-gfx-stereo-mode", g_Config.iStereoMode);
+  builder.AddData("cfg-gfx-stereo-mode", static_cast<int>(g_Config.stereo_mode));
   builder.AddData("cfg-gfx-per-pixel-lighting", g_Config.bEnablePixelLighting);
   builder.AddData("cfg-gfx-ubershader-mode", GetUbershaderMode(g_Config));
   builder.AddData("cfg-gfx-fast-depth", g_Config.bFastDepthCalc);

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -22,9 +22,9 @@ const ConfigInfo<int> GFX_ADAPTER{{System::GFX, "Hardware", "Adapter"}, 0};
 
 const ConfigInfo<bool> GFX_WIDESCREEN_HACK{{System::GFX, "Settings", "wideScreenHack"}, false};
 const ConfigInfo<int> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"},
-                                       static_cast<int>(ASPECT_AUTO)};
+                                       static_cast<int>(AspectMode::Auto)};
 const ConfigInfo<int> GFX_SUGGESTED_ASPECT_RATIO{{System::GFX, "Settings", "SuggestedAspectRatio"},
-                                                 static_cast<int>(ASPECT_AUTO)};
+                                                 static_cast<int>(AspectMode::Auto)};
 const ConfigInfo<bool> GFX_CROP{{System::GFX, "Settings", "Crop"}, false};
 const ConfigInfo<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES{
     {System::GFX, "Settings", "SafeTextureCacheColorSamples"}, 128};

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -146,7 +146,7 @@ void EnhancementsWidget::LoadSettings()
 
   // Post Processing Shader
   std::vector<std::string> shaders =
-      g_Config.iStereoMode == STEREO_ANAGLYPH ?
+      g_Config.stereo_mode == StereoMode::Anaglyph ?
           PostProcessingShaderImplementation::GetAnaglyphShaderList(
               g_Config.backend_info.api_type) :
           PostProcessingShaderImplementation::GetShaderList(g_Config.backend_info.api_type);

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -264,46 +264,46 @@ void HotkeyScheduler::Run()
       // Stereoscopy
       if (IsHotkey(HK_TOGGLE_STEREO_SBS) || IsHotkey(HK_TOGGLE_STEREO_TAB))
       {
-        if (g_Config.iStereoMode != STEREO_SBS)
+        if (g_Config.stereo_mode != StereoMode::SBS)
         {
           // Disable post-processing shader, as stereoscopy itself is currently a shader
           if (g_Config.sPostProcessingShader == DUBOIS_ALGORITHM_SHADER)
             g_Config.sPostProcessingShader = "";
 
-          g_Config.iStereoMode = IsHotkey(HK_TOGGLE_STEREO_SBS) ? STEREO_SBS : STEREO_TAB;
+          g_Config.stereo_mode = IsHotkey(HK_TOGGLE_STEREO_SBS) ? StereoMode::SBS : StereoMode::TAB;
         }
         else
         {
-          g_Config.iStereoMode = STEREO_OFF;
+          g_Config.stereo_mode = StereoMode::Off;
         }
       }
 
       if (IsHotkey(HK_TOGGLE_STEREO_ANAGLYPH))
       {
-        if (g_Config.iStereoMode != STEREO_ANAGLYPH)
+        if (g_Config.stereo_mode != StereoMode::Anaglyph)
         {
-          g_Config.iStereoMode = STEREO_ANAGLYPH;
+          g_Config.stereo_mode = StereoMode::Anaglyph;
           g_Config.sPostProcessingShader = DUBOIS_ALGORITHM_SHADER;
         }
         else
         {
-          g_Config.iStereoMode = STEREO_OFF;
+          g_Config.stereo_mode = StereoMode::Off;
           g_Config.sPostProcessingShader = "";
         }
       }
 
       if (IsHotkey(HK_TOGGLE_STEREO_3DVISION))
       {
-        if (g_Config.iStereoMode != STEREO_3DVISION)
+        if (g_Config.stereo_mode != StereoMode::Nvidia3DVision)
         {
           if (g_Config.sPostProcessingShader == DUBOIS_ALGORITHM_SHADER)
             g_Config.sPostProcessingShader = "";
 
-          g_Config.iStereoMode = STEREO_3DVISION;
+          g_Config.stereo_mode = StereoMode::Nvidia3DVision;
         }
         else
         {
-          g_Config.iStereoMode = STEREO_OFF;
+          g_Config.stereo_mode = StereoMode::Off;
         }
       }
     }

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -221,7 +221,10 @@ void HotkeyScheduler::Run()
       if (IsHotkey(HK_TOGGLE_CROP))
         g_Config.bCrop = !g_Config.bCrop;
       if (IsHotkey(HK_TOGGLE_AR))
-        g_Config.iAspectRatio = (g_Config.iAspectRatio + 1) & 3;
+      {
+        g_Config.aspect_mode =
+            static_cast<AspectMode>((static_cast<int>(g_Config.aspect_mode) + 1) & 3);
+      }
       if (IsHotkey(HK_TOGGLE_EFBCOPIES))
         g_Config.bSkipEFBCopyToRam = !g_Config.bSkipEFBCopyToRam;
       if (IsHotkey(HK_TOGGLE_XFBCOPIES))

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1549,7 +1549,7 @@ void CFrame::ParseHotkeys()
 
   if (IsHotkey(HK_TOGGLE_STEREO_SBS))
   {
-    if (g_Config.iStereoMode != STEREO_SBS)
+    if (g_Config.stereo_mode != StereoMode::SBS)
     {
       // Current implementation of anaglyph stereoscopy uses a
       // post-processing shader. Thus the shader needs to be to be
@@ -1558,56 +1558,56 @@ void CFrame::ParseHotkeys()
       {
         Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
       }
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_SBS));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::SBS));
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_TAB))
   {
-    if (g_Config.iStereoMode != STEREO_TAB)
+    if (g_Config.stereo_mode != StereoMode::TAB)
     {
       if (g_Config.sPostProcessingShader == "dubois")
       {
         Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
       }
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_TAB));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::TAB));
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_ANAGLYPH))
   {
-    if (g_Config.iStereoMode != STEREO_ANAGLYPH)
+    if (g_Config.stereo_mode != StereoMode::Anaglyph)
     {
       // Setting the anaglyph mode also requires a specific
       // post-processing shader to be activated.
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_ANAGLYPH));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Anaglyph));
       Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string("dubois"));
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
       Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_3DVISION))
   {
-    if (g_Config.iStereoMode != STEREO_3DVISION)
+    if (g_Config.stereo_mode != StereoMode::Nvidia3DVision)
     {
       if (g_Config.sPostProcessingShader == "dubois")
       {
         Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
       }
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_3DVISION));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Nvidia3DVision));
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(STEREO_OFF));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
     }
   }
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -1199,7 +1199,7 @@ void VideoConfigDiag::CreateDescriptionArea(wxPanel* const page, wxBoxSizer* con
 void VideoConfigDiag::PopulatePostProcessingShaders()
 {
   std::vector<std::string> shaders =
-      vconfig.iStereoMode == STEREO_ANAGLYPH ?
+      vconfig.stereo_mode == StereoMode::Anaglyph ?
           PostProcessingShaderImplementation::GetAnaglyphShaderList(vconfig.backend_info.api_type) :
           PostProcessingShaderImplementation::GetShaderList(vconfig.backend_info.api_type);
 
@@ -1223,7 +1223,7 @@ void VideoConfigDiag::PopulatePostProcessingShaders()
     // Invalid shader, reset it to default
     choice_ppshader->Select(0);
 
-    if (vconfig.iStereoMode == STEREO_ANAGLYPH)
+    if (vconfig.stereo_mode == StereoMode::Anaglyph)
     {
       Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string("dubois"));
       choice_ppshader->SetStringSelection(StrToWxStr(vconfig.sPostProcessingShader));

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -318,7 +318,7 @@ HRESULT Create(HWND wnd)
   swap_chain_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
   swap_chain_desc.Width = xres;
   swap_chain_desc.Height = yres;
-  swap_chain_desc.Stereo = g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER;
+  swap_chain_desc.Stereo = g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer;
 
   // This flag is necessary if we want to use a flip-model swapchain without locking the framerate
   swap_chain_desc.Flags = allow_tearing_supported ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
@@ -634,7 +634,7 @@ void Present()
   if (AllowTearingSupported() && !g_ActiveConfig.IsVSync() && !GetFullscreenState())
     present_flags |= DXGI_PRESENT_ALLOW_TEARING;
 
-  if (swapchain->IsTemporaryMonoSupported() && g_ActiveConfig.iStereoMode != STEREO_QUADBUFFER)
+  if (swapchain->IsTemporaryMonoSupported() && g_ActiveConfig.stereo_mode != StereoMode::QuadBuffer)
     present_flags |= DXGI_PRESENT_STEREO_TEMPORARY_MONO;
 
   // TODO: Is 1 the correct value for vsyncing?

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -137,7 +137,7 @@ FramebufferManager::FramebufferManager(int target_width, int target_height)
   D3D11_TEXTURE2D_DESC texdesc;
   HRESULT hr;
 
-  m_EFBLayers = m_efb.slices = (g_ActiveConfig.iStereoMode > 0) ? 2 : 1;
+  m_EFBLayers = m_efb.slices = (g_ActiveConfig.stereo_mode != StereoMode::Off) ? 2 : 1;
 
   // EFB color texture - primary render target
   texdesc =

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -37,11 +37,11 @@ LinearDiskCache<GeometryShaderUid, u8> g_gs_disk_cache;
 
 ID3D11GeometryShader* GeometryShaderCache::GetClearGeometryShader()
 {
-  return (g_ActiveConfig.iStereoMode > 0) ? ClearGeometryShader : nullptr;
+  return (g_ActiveConfig.stereo_mode != StereoMode::Off) ? ClearGeometryShader : nullptr;
 }
 ID3D11GeometryShader* GeometryShaderCache::GetCopyGeometryShader()
 {
-  return (g_ActiveConfig.iStereoMode > 0) ? CopyGeometryShader : nullptr;
+  return (g_ActiveConfig.stereo_mode != StereoMode::Off) ? CopyGeometryShader : nullptr;
 }
 
 ID3D11Buffer* gscbuf = nullptr;

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -133,7 +133,7 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
 
   glActiveTexture(GL_TEXTURE9);
 
-  m_EFBLayers = (g_ActiveConfig.iStereoMode > 0) ? 2 : 1;
+  m_EFBLayers = (g_ActiveConfig.stereo_mode != StereoMode::Off) ? 2 : 1;
   m_efbFramebuffer.resize(m_EFBLayers);
   m_resolvedFramebuffer.resize(m_EFBLayers);
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -548,7 +548,7 @@ Renderer::Renderer()
       g_ogl_config.bSupports2DTextureStorageMultisample = true;
       g_Config.backend_info.bSupportsBitfield = true;
       g_Config.backend_info.bSupportsDynamicSamplerIndexing = g_ogl_config.bSupportsAEP;
-      if (g_ActiveConfig.iStereoMode > 0 && g_ActiveConfig.iMultisamples > 1 &&
+      if (g_ActiveConfig.stereo_mode != StereoMode::Off && g_ActiveConfig.iMultisamples > 1 &&
           !g_ogl_config.bSupports3DTextureStorageMultisample)
       {
         // GLES 3.1 can't support stereo rendering and MSAA
@@ -725,7 +725,7 @@ Renderer::Renderer()
   s_last_multisamples = g_ActiveConfig.iMultisamples;
   s_MSAASamples = s_last_multisamples;
 
-  s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
+  s_last_stereo_mode = g_ActiveConfig.stereo_mode != StereoMode::Off;
 
   // Handle VSync on/off
   s_vsync = g_ActiveConfig.IsVSync();
@@ -1216,12 +1216,13 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, GLuint src_t
                           int src_width, int src_height)
 {
   OpenGLPostProcessing* post_processor = static_cast<OpenGLPostProcessing*>(m_post_processor.get());
-  if (g_ActiveConfig.iStereoMode == STEREO_SBS || g_ActiveConfig.iStereoMode == STEREO_TAB)
+  if (g_ActiveConfig.stereo_mode == StereoMode::SBS ||
+      g_ActiveConfig.stereo_mode == StereoMode::TAB)
   {
     TargetRectangle leftRc, rightRc;
 
     // Top-and-Bottom mode needs to compensate for inverted vertical screen coordinates.
-    if (g_ActiveConfig.iStereoMode == STEREO_TAB)
+    if (g_ActiveConfig.stereo_mode == StereoMode::TAB)
       std::tie(rightRc, leftRc) = ConvertStereoRectangle(dst);
     else
       std::tie(leftRc, rightRc) = ConvertStereoRectangle(dst);
@@ -1229,7 +1230,7 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, GLuint src_t
     post_processor->BlitFromTexture(src, leftRc, src_texture, src_width, src_height, 0);
     post_processor->BlitFromTexture(src, rightRc, src_texture, src_width, src_height, 1);
   }
-  else if (g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER)
+  else if (g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer)
   {
     glDrawBuffer(GL_BACK_LEFT);
     post_processor->BlitFromTexture(src, dst, src_texture, src_width, src_height, 0);
@@ -1378,7 +1379,7 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   bool fb_needs_update = target_size_changed ||
                          s_last_multisamples != g_ActiveConfig.iMultisamples ||
                          stencil_buffer_enabled != BoundingBox::NeedsStencilBuffer() ||
-                         s_last_stereo_mode != (g_ActiveConfig.iStereoMode > 0);
+                         s_last_stereo_mode != (g_ActiveConfig.stereo_mode != StereoMode::Off);
 
   if (window_resized || fb_needs_update)
   {
@@ -1386,7 +1387,7 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   }
   if (fb_needs_update)
   {
-    s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
+    s_last_stereo_mode = g_ActiveConfig.stereo_mode != StereoMode::Off;
     s_last_multisamples = g_ActiveConfig.iMultisamples;
     s_MSAASamples = s_last_multisamples;
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -178,7 +178,7 @@ bool TextureCache::CompileShaders()
       "	gl_Position = vec4(rawpos*2.0-1.0, 0.0, 1.0);\n"
       "}\n";
 
-  const std::string geo_program = g_ActiveConfig.iStereoMode > 0 ?
+  const std::string geo_program = g_ActiveConfig.stereo_mode != StereoMode::Off ?
                                       "layout(triangles) in;\n"
                                       "layout(triangle_strip, max_vertices = 6) out;\n"
                                       "in vec3 v_uv0[3];\n"

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -170,7 +170,7 @@ bool VideoBackend::Initialize(void* window_handle)
 
   InitInterface();
   GLInterface->SetMode(GLInterfaceMode::MODE_DETECT);
-  if (!GLInterface->Create(window_handle, g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER))
+  if (!GLInterface->Create(window_handle, g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer))
     return false;
 
   return true;

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -253,7 +253,7 @@ bool FramebufferManager::CreateEFBFramebuffer()
 {
   u32 efb_width = static_cast<u32>(std::max(g_renderer->GetTargetWidth(), 1));
   u32 efb_height = static_cast<u32>(std::max(g_renderer->GetTargetHeight(), 1));
-  u32 efb_layers = (g_ActiveConfig.iStereoMode != STEREO_OFF) ? 2 : 1;
+  u32 efb_layers = (g_ActiveConfig.stereo_mode != StereoMode::Off) ? 2 : 1;
   VkSampleCountFlagBits efb_samples =
       static_cast<VkSampleCountFlagBits>(g_ActiveConfig.iMultisamples);
   INFO_LOG(VIDEO, "EFB size: %ux%ux%u", efb_width, efb_height, efb_layers);

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -717,10 +717,10 @@ void Renderer::CheckForSurfaceChange()
 void Renderer::CheckForConfigChanges()
 {
   // Save the video config so we can compare against to determine which settings have changed.
-  int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
-  int old_aspect_ratio = g_ActiveConfig.iAspectRatio;
-  int old_efb_scale = g_ActiveConfig.iEFBScale;
-  bool old_force_filtering = g_ActiveConfig.bForceFiltering;
+  const int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
+  const AspectMode old_aspect_mode = g_ActiveConfig.aspect_mode;
+  const int old_efb_scale = g_ActiveConfig.iEFBScale;
+  const bool old_force_filtering = g_ActiveConfig.bForceFiltering;
 
   // Copy g_Config to g_ActiveConfig.
   // NOTE: This can potentially race with the UI thread, however if it does, the changes will be
@@ -728,10 +728,11 @@ void Renderer::CheckForConfigChanges()
   UpdateActiveConfig();
 
   // Determine which (if any) settings have changed.
-  bool anisotropy_changed = old_anisotropy != g_ActiveConfig.iMaxAnisotropy;
-  bool force_texture_filtering_changed = old_force_filtering != g_ActiveConfig.bForceFiltering;
-  bool efb_scale_changed = old_efb_scale != g_ActiveConfig.iEFBScale;
-  bool aspect_changed = old_aspect_ratio != g_ActiveConfig.iAspectRatio;
+  const bool anisotropy_changed = old_anisotropy != g_ActiveConfig.iMaxAnisotropy;
+  const bool force_texture_filtering_changed =
+      old_force_filtering != g_ActiveConfig.bForceFiltering;
+  const bool efb_scale_changed = old_efb_scale != g_ActiveConfig.iEFBScale;
+  const bool aspect_changed = old_aspect_mode != g_ActiveConfig.aspect_mode;
 
   // Update texture cache settings with any changed options.
   TextureCache::GetInstance()->OnConfigChanged(g_ActiveConfig);

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -629,7 +629,8 @@ void Renderer::BlitScreen(VkRenderPass render_pass, const TargetRectangle& dst_r
                           const TargetRectangle& src_rect, const Texture2D* src_tex)
 {
   VulkanPostProcessing* post_processor = static_cast<VulkanPostProcessing*>(m_post_processor.get());
-  if (g_ActiveConfig.iStereoMode == STEREO_SBS || g_ActiveConfig.iStereoMode == STEREO_TAB)
+  if (g_ActiveConfig.stereo_mode == StereoMode::SBS ||
+      g_ActiveConfig.stereo_mode == StereoMode::TAB)
   {
     TargetRectangle left_rect;
     TargetRectangle right_rect;
@@ -638,7 +639,7 @@ void Renderer::BlitScreen(VkRenderPass render_pass, const TargetRectangle& dst_r
     post_processor->BlitFromTexture(left_rect, src_rect, src_tex, 0, render_pass);
     post_processor->BlitFromTexture(right_rect, src_rect, src_tex, 1, render_pass);
   }
-  else if (g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER)
+  else if (g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer)
   {
     post_processor->BlitFromTexture(dst_rect, src_rect, src_tex, -1, render_pass);
   }
@@ -771,7 +772,7 @@ void Renderer::CheckForConfigChanges()
 
   // For quad-buffered stereo we need to change the layer count, so recreate the swap chain.
   if (m_swap_chain &&
-      (g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER) != m_swap_chain->IsStereoEnabled())
+      (g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer) != m_swap_chain->IsStereoEnabled())
   {
     g_command_buffer_mgr->WaitForGPUIdle();
     m_swap_chain->RecreateSwapChain();

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
@@ -971,7 +971,7 @@ std::string ShaderCache::GetUtilityShaderHeader() const
       ss << "#define SSAA_ENABLED 1" << std::endl;
   }
 
-  u32 efb_layers = (g_ActiveConfig.iStereoMode != STEREO_OFF) ? 2 : 1;
+  u32 efb_layers = (g_ActiveConfig.stereo_mode != StereoMode::Off) ? 2 : 1;
   ss << "#define EFB_LAYERS " << efb_layers << std::endl;
 
   return ss.str();
@@ -1126,7 +1126,7 @@ bool ShaderCache::CompileSharedShaders()
     return false;
   }
 
-  if (g_ActiveConfig.iStereoMode != STEREO_OFF && g_vulkan_context->SupportsGeometryShaders())
+  if (g_ActiveConfig.stereo_mode != StereoMode::Off && g_vulkan_context->SupportsGeometryShaders())
   {
     m_screen_quad_geometry_shader =
         Util::CompileAndCreateGeometryShader(header + SCREEN_QUAD_GEOMETRY_SHADER_SOURCE);

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -321,7 +321,7 @@ bool SwapChain::CreateSwapChain()
   }
 
   // Select the number of image layers for Quad-Buffered stereoscopy
-  uint32_t image_layers = g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER ? 2 : 1;
+  uint32_t image_layers = g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer ? 2 : 1;
 
   // Store the old/current swap chain when recreating for resize
   VkSwapchainKHR old_swap_chain = m_swap_chain;

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -20,7 +20,7 @@ constexpr std::array<const char*, 4> primitives_d3d = {{"point", "line", "triang
 
 bool geometry_shader_uid_data::IsPassthrough() const
 {
-  const bool stereo = g_ActiveConfig.iStereoMode > 0;
+  const bool stereo = g_ActiveConfig.stereo_mode != StereoMode::Off;
   const bool wireframe = g_ActiveConfig.bWireFrame;
   return primitive_type >= static_cast<u32>(PrimitiveType::Triangles) && !stereo && !wireframe;
 }

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -41,7 +41,7 @@ void GeometryShaderManager::Dirty()
 
 void GeometryShaderManager::SetConstants()
 {
-  if (s_projection_changed && g_ActiveConfig.iStereoMode > 0)
+  if (s_projection_changed && g_ActiveConfig.stereo_mode != StereoMode::Off)
   {
     s_projection_changed = false;
 

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -70,7 +70,8 @@ std::string PostProcessingShaderConfiguration::LoadShader(std::string shader)
     shader = g_ActiveConfig.sPostProcessingShader;
   m_current_shader = shader;
 
-  const std::string sub_dir = (g_Config.iStereoMode == STEREO_ANAGLYPH) ? ANAGLYPH_DIR DIR_SEP : "";
+  const std::string sub_dir =
+      (g_Config.stereo_mode == StereoMode::Anaglyph) ? ANAGLYPH_DIR DIR_SEP : "";
 
   // loading shader code
   std::string code;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -185,7 +185,7 @@ Renderer::ConvertStereoRectangle(const TargetRectangle& rc) const
 {
   // Resize target to half its original size
   TargetRectangle draw_rc = rc;
-  if (g_ActiveConfig.iStereoMode == STEREO_TAB)
+  if (g_ActiveConfig.stereo_mode == StereoMode::TAB)
   {
     // The height may be negative due to flipped rectangles
     int height = rc.bottom - rc.top;
@@ -202,7 +202,7 @@ Renderer::ConvertStereoRectangle(const TargetRectangle& rc) const
   // Create two target rectangle offset to the sides of the backbuffer
   TargetRectangle left_rc = draw_rc;
   TargetRectangle right_rc = draw_rc;
-  if (g_ActiveConfig.iStereoMode == STEREO_TAB)
+  if (g_ActiveConfig.stereo_mode == StereoMode::TAB)
   {
     left_rc.top -= m_backbuffer_height / 4;
     left_rc.bottom -= m_backbuffer_height / 4;

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -13,7 +13,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.msaa = g_ActiveConfig.iMultisamples > 1;
   bits.ssaa = g_ActiveConfig.iMultisamples > 1 && g_ActiveConfig.bSSAA &&
               g_ActiveConfig.backend_info.bSupportsSSAA;
-  bits.stereo = g_ActiveConfig.iStereoMode > 0;
+  bits.stereo = g_ActiveConfig.stereo_mode != StereoMode::Off;
   bits.wireframe = g_ActiveConfig.bWireFrame;
   bits.per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
   bits.vertex_rounding = g_ActiveConfig.UseVertexRounding();

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -130,7 +130,7 @@ void TextureCacheBase::OnConfigChanged(VideoConfig& config)
                                        g_ActiveConfig.bTexFmtOverlayCenter);
   }
 
-  if ((config.iStereoMode > 0) != backup_config.stereo_3d ||
+  if ((config.stereo_mode != StereoMode::Off) != backup_config.stereo_3d ||
       config.bStereoEFBMonoDepth != backup_config.efb_mono_depth)
   {
     g_texture_cache->DeleteShaders();
@@ -222,7 +222,7 @@ void TextureCacheBase::SetBackupConfig(const VideoConfig& config)
   backup_config.texfmt_overlay_center = config.bTexFmtOverlayCenter;
   backup_config.hires_textures = config.bHiresTextures;
   backup_config.cache_hires_textures = config.bCacheHiresTextures;
-  backup_config.stereo_3d = config.iStereoMode > 0;
+  backup_config.stereo_3d = config.stereo_mode != StereoMode::Off;
   backup_config.efb_mono_depth = config.bStereoEFBMonoDepth;
   backup_config.gpu_texture_decoding = config.bEnableGPUTextureDecoding;
 }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -122,7 +122,7 @@ void VideoConfig::Refresh()
   sPostProcessingShader = Config::Get(Config::GFX_ENHANCE_POST_SHADER);
   bForceTrueColor = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
 
-  iStereoMode = Config::Get(Config::GFX_STEREO_MODE);
+  stereo_mode = static_cast<StereoMode>(Config::Get(Config::GFX_STEREO_MODE));
   iStereoDepth = Config::Get(Config::GFX_STEREO_DEPTH);
   iStereoConvergencePercentage = Config::Get(Config::GFX_STEREO_CONVERGENCE_PERCENTAGE);
   bStereoSwapEyes = Config::Get(Config::GFX_STEREO_SWAP_EYES);
@@ -162,14 +162,14 @@ void VideoConfig::VerifyValidity()
       backend_info.AAModes.end())
     iMultisamples = 1;
 
-  if (iStereoMode > 0)
+  if (stereo_mode != StereoMode::Off)
   {
     if (!backend_info.bSupportsGeometryShaders)
     {
       OSD::AddMessage(
           "Stereoscopic 3D isn't supported by your GPU, support for OpenGL 3.2 is required.",
           10000);
-      iStereoMode = 0;
+      stereo_mode = StereoMode::Off;
     }
   }
 }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -61,11 +61,11 @@ void VideoConfig::Refresh()
   iAdapter = Config::Get(Config::GFX_ADAPTER);
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
-  const int aspect_ratio = Config::Get(Config::GFX_ASPECT_RATIO);
-  if (aspect_ratio == ASPECT_AUTO)
-    iAspectRatio = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
+  const auto config_aspect_mode = static_cast<AspectMode>(Config::Get(Config::GFX_ASPECT_RATIO));
+  if (config_aspect_mode == AspectMode::Auto)
+    aspect_mode = static_cast<AspectMode>(Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO));
   else
-    iAspectRatio = aspect_ratio;
+    aspect_mode = config_aspect_mode;
   bCrop = Config::Get(Config::GFX_CROP);
   iSafeTextureCache_ColorSamples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
   bShowFPS = Config::Get(Config::GFX_SHOW_FPS);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -24,12 +24,12 @@
 
 constexpr int EFB_SCALE_AUTO_INTEGRAL = 0;
 
-enum AspectMode
+enum class AspectMode
 {
-  ASPECT_AUTO = 0,
-  ASPECT_ANALOG_WIDE = 1,
-  ASPECT_ANALOG = 2,
-  ASPECT_STRETCH = 3,
+  Auto,
+  AnalogWide,
+  Analog,
+  Stretch,
 };
 
 enum StereoMode
@@ -63,7 +63,7 @@ struct VideoConfig final
   // General
   bool bVSync;
   bool bWidescreenHack;
-  int iAspectRatio;
+  AspectMode aspect_mode;
   bool bCrop;  // Aspect ratio controls.
   bool bShaderCache;
 

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -32,14 +32,14 @@ enum class AspectMode
   Stretch,
 };
 
-enum StereoMode
+enum class StereoMode
 {
-  STEREO_OFF = 0,
-  STEREO_SBS,
-  STEREO_TAB,
-  STEREO_ANAGLYPH,
-  STEREO_QUADBUFFER,
-  STEREO_3DVISION
+  Off,
+  SBS,
+  TAB,
+  Anaglyph,
+  QuadBuffer,
+  Nvidia3DVision
 };
 
 struct ProjectionHackConfig final
@@ -130,7 +130,7 @@ struct VideoConfig final
   int iSaveTargetId;  // TODO: Should be dropped
 
   // Stereoscopy
-  int iStereoMode;
+  StereoMode stereo_mode;
   int iStereoDepth;
   int iStereoConvergence;
   int iStereoConvergencePercentage;


### PR DESCRIPTION
Makes things more strongly-typed (as well as avoiding polluting namespaces).

Thoughts:
`config.stereo_mode != StereoMode::Off` is quite prevalent. Would it be preferable to make an `IsSteroscopyEnabled()` member function of VideoConfig to eliminate the need to constantly type out the expression?