### PR TITLE
Add an exit key to `dolphin-emu-nogui`

### DIFF
--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -241,6 +241,10 @@ class PlatformX11 : public Platform
           key = XLookupKeysym((XKeyEvent*)&event, 0);
           if (key == XK_Escape)
           {
+            s_shutdown_requested.Set();
+          }
+          else if (key == XK_F10)
+          {
             if (Core::GetState() == Core::State::Running)
             {
               if (SConfig::GetInstance().bHideCursor)


### PR DESCRIPTION
`dolphin-emu-nogui` doesn't follow the Hotkey definitions. And, for some reason, there is no key to exit (only the <kbd>Alt+F4</kbd> combo, which is hard to use with programs like `Xpadder` or `antimicro`).

The <kbd>Esc</kbd> key is hardcoded to pause/resume emulation, but it makes more sense exit dolphin.

Fixes https://github.com/raelgc/dolphin/issues/1