### PR TITLE
D3DUtil: Make file-scope variables internally linked where applicable

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -97,13 +97,6 @@ private:
   std::list<bool*> observers;
 };
 
-// Font creation flags
-#define D3DFONT_BOLD 0x0001
-#define D3DFONT_ITALIC 0x0002
-
-// Font rendering flags
-#define D3DFONT_CENTERED 0x0001
-
 class CD3DFont
 {
 public:

--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -97,8 +97,40 @@ private:
   std::list<bool*> observers;
 };
 
-CD3DFont font;
-UtilVertexBuffer* util_vbuf = nullptr;
+// Font creation flags
+#define D3DFONT_BOLD 0x0001
+#define D3DFONT_ITALIC 0x0002
+
+// Font rendering flags
+#define D3DFONT_CENTERED 0x0001
+
+class CD3DFont
+{
+public:
+  CD3DFont();
+  // 2D text drawing function
+  // Initializing and destroying device-dependent objects
+  int Init();
+  int Shutdown();
+  int DrawTextScaled(float x, float y, float size, float spacing, u32 dwColor,
+                     const std::string& text);
+
+private:
+  ID3D11ShaderResourceView* m_pTexture;
+  ID3D11Buffer* m_pVB;
+  ID3D11InputLayout* m_InputLayout;
+  ID3D11PixelShader* m_pshader;
+  ID3D11VertexShader* m_vshader;
+  ID3D11BlendState* m_blendstate;
+  ID3D11RasterizerState* m_raststate;
+  const int m_dwTexWidth;
+  const int m_dwTexHeight;
+  unsigned int m_LineHeight;
+  float m_fTexCoords[128 - 32][4];
+};
+
+static CD3DFont font;
+static UtilVertexBuffer* util_vbuf = nullptr;
 
 #define MAX_NUM_VERTICES 50 * 6
 struct FONT2DVERTEX
@@ -458,8 +490,8 @@ int CD3DFont::DrawTextScaled(float x, float y, float size, float spacing, u32 dw
   return S_OK;
 }
 
-ID3D11SamplerState* linear_copy_sampler = nullptr;
-ID3D11SamplerState* point_copy_sampler = nullptr;
+static ID3D11SamplerState* linear_copy_sampler = nullptr;
+static ID3D11SamplerState* point_copy_sampler = nullptr;
 
 struct STQVertex
 {
@@ -480,28 +512,31 @@ struct ColVertex
   u32 col;
 };
 
-struct
+struct TexQuadData
 {
   float u1, v1, u2, v2, S, G;
-} tex_quad_data;
+};
+static TexQuadData tex_quad_data;
 
-struct
+struct DrawQuadData
 {
   float x1, y1, x2, y2, z;
   u32 col;
-} draw_quad_data;
+};
+static DrawQuadData draw_quad_data;
 
-struct
+struct ClearQuadData
 {
   u32 col;
   float z;
-} clear_quad_data;
+};
+static ClearQuadData clear_quad_data;
 
 // ring buffer offsets
-int stq_offset, cq_offset, clearq_offset;
+static int stq_offset, cq_offset, clearq_offset;
 
 // observer variables for ring buffer wraps
-bool stq_observer, cq_observer, clearq_observer;
+static bool stq_observer, cq_observer, clearq_observer;
 
 void InitUtils()
 {
@@ -764,6 +799,10 @@ void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_
   stateman->SetGeometryShader(GeometryShaderCache::GetClearGeometryShader());
 }
 
+void DrawTextScaled(float x, float y, float size, float spacing, u32 color, const std::string& text)
+{
+  font.DrawTextScaled(x, y, size, spacing, color, text);
+}
 }  // namespace D3D
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DUtil.h
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.h
@@ -14,39 +14,6 @@ namespace DX11
 {
 namespace D3D
 {
-// Font creation flags
-#define D3DFONT_BOLD 0x0001
-#define D3DFONT_ITALIC 0x0002
-
-// Font rendering flags
-#define D3DFONT_CENTERED 0x0001
-
-class CD3DFont
-{
-  ID3D11ShaderResourceView* m_pTexture;
-  ID3D11Buffer* m_pVB;
-  ID3D11InputLayout* m_InputLayout;
-  ID3D11PixelShader* m_pshader;
-  ID3D11VertexShader* m_vshader;
-  ID3D11BlendState* m_blendstate;
-  ID3D11RasterizerState* m_raststate;
-  const int m_dwTexWidth;
-  const int m_dwTexHeight;
-  unsigned int m_LineHeight;
-  float m_fTexCoords[128 - 32][4];
-
-public:
-  CD3DFont();
-  // 2D text drawing function
-  // Initializing and destroying device-dependent objects
-  int Init();
-  int Shutdown();
-  int DrawTextScaled(float x, float y, float size, float spacing, u32 dwColor,
-                     const std::string& text);
-};
-
-extern CD3DFont font;
-
 void InitUtils();
 void ShutdownUtils();
 
@@ -61,5 +28,7 @@ void drawClearQuad(u32 Color, float z);
 void drawColorQuad(u32 Color, float z, float x1, float y1, float x2, float y2);
 
 void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_points);
+void DrawTextScaled(float x, float y, float size, float spacing, u32 color,
+                    const std::string& text);
 }
 }

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -243,9 +243,9 @@ Renderer::~Renderer()
 
 void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
 {
-  D3D::font.DrawTextScaled((float)(left + 1), (float)(top + 1), 20.f, 0.0f, color & 0xFF000000,
-                           text);
-  D3D::font.DrawTextScaled((float)left, (float)top, 20.f, 0.0f, color, text);
+  D3D::DrawTextScaled(static_cast<float>(left + 1), static_cast<float>(top + 1), 20.f, 0.0f,
+                      color & 0xFF000000, text);
+  D3D::DrawTextScaled(static_cast<float>(left), static_cast<float>(top), 20.f, 0.0f, color, text);
 }
 
 TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)


### PR DESCRIPTION
All file scope variables are able to be made internally linked.

`CD3DFont` is essentially used as an extension to the utility interface, so this is able to be made internal as well, removing a global from external view.