### PR TITLE
Off-by-one in SDHC detection

### DIFF
--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -439,7 +439,7 @@ IPCCommandResult SDIOSlot0::GetStatus(const IOCtlRequest& request)
   // Since IOS does the SD initialization itself, we just say we're always initialized.
   if (m_card)
   {
-    if (m_card.GetSize() < SDHC_BYTES)
+    if (m_card.GetSize() <= SDSC_MAX_SIZE)
     {
       // No further initialization required.
       m_status |= CARD_INITIALIZED;

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -118,8 +118,9 @@ private:
     V2,
   };
 
-  // Number of bytes to trigger using SDHC instead of SDSC
-  static constexpr u32 SDHC_BYTES = 0x80000000;
+  // Maximum number of bytes in an SDSC card
+  // Used to trigger using SDHC instead of SDSC
+  static constexpr u64 SDSC_MAX_SIZE = 0x80000000;
 
   struct Event
   {


### PR DESCRIPTION
Also update name and description of SDHC constant.

This should fix [this issue](https://bugs.dolphin-emu.org/issues/10636) in which 2GiB SD cards are interpreted as SDHC.