### PR TITLE
[UI] Remove fullscreen resolution UI.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -180,7 +180,7 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 {
   IniFile::Section* display = ini.GetOrCreateSection("Display");
 
-  display->Set("FullscreenResolution", strFullscreenResolution);
+  display->Set("FullscreenDisplayRes", strFullscreenResolution);
   display->Set("Fullscreen", bFullscreen);
   display->Set("RenderToMain", bRenderToMain);
   display->Set("RenderWindowXPos", iRenderWindowXPos);
@@ -460,7 +460,7 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
   IniFile::Section* display = ini.GetOrCreateSection("Display");
 
   display->Get("Fullscreen", &bFullscreen, false);
-  display->Get("FullscreenResolution", &strFullscreenResolution, "Auto");
+  display->Get("FullscreenDisplayRes", &strFullscreenResolution, "Auto");
   display->Get("RenderToMain", &bRenderToMain, false);
   display->Get("RenderWindowXPos", &iRenderWindowXPos, -1);
   display->Get("RenderWindowYPos", &iRenderWindowYPos, -1);

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.h
@@ -38,7 +38,6 @@ private:
   // Video
   QGridLayout* m_video_layout;
   QComboBox* m_backend_combo;
-  QComboBox* m_resolution_combo;
   QComboBox* m_adapter_combo;
   QComboBox* m_aspect_combo;
   QCheckBox* m_enable_vsync;

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -382,41 +382,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
       wxFlexGridSizer* const szr_display = new wxFlexGridSizer(2, space5, space5);
 
       {
-#if !defined(__APPLE__)
-        // display resolution
-        {
-          wxArrayString res_list;
-          res_list.Add(_("Auto"));
-#if defined(HAVE_XRANDR) && HAVE_XRANDR
-          const auto resolutions = VideoUtils::GetAvailableResolutions(main_frame->m_xrr_config);
-#else
-          const auto resolutions = VideoUtils::GetAvailableResolutions(nullptr);
-#endif
-
-          for (const auto& res : resolutions)
-            res_list.Add(res);
-
-          if (res_list.empty())
-            res_list.Add(_("<No resolutions found>"));
-          label_display_resolution =
-              new wxStaticText(page_general, wxID_ANY, _("Fullscreen Resolution:"));
-          choice_display_resolution =
-              new wxChoice(page_general, wxID_ANY, wxDefaultPosition, wxDefaultSize, res_list);
-          RegisterControl(choice_display_resolution, wxGetTranslation(display_res_desc));
-          choice_display_resolution->Bind(wxEVT_CHOICE, &VideoConfigDiag::Event_DisplayResolution,
-                                          this);
-
-          choice_display_resolution->SetStringSelection(
-              StrToWxStr(SConfig::GetInstance().strFullscreenResolution));
-          // "Auto" is used as a keyword, convert to translated string
-          if (SConfig::GetInstance().strFullscreenResolution == "Auto")
-            choice_display_resolution->SetSelection(0);
-
-          szr_display->Add(label_display_resolution, 0, wxALIGN_CENTER_VERTICAL);
-          szr_display->Add(choice_display_resolution, 0, wxALIGN_CENTER_VERTICAL);
-        }
-#endif
-
         // aspect-ratio
         {
           const wxString ar_choices[] = {_("Auto"), _("Force 16:9"), _("Force 4:3"),
@@ -1010,26 +975,6 @@ void VideoConfigDiag::Event_Backend(wxCommandEvent& ev)
   ev.Skip();
 }
 
-void VideoConfigDiag::Event_DisplayResolution(wxCommandEvent& ev)
-{
-  // "Auto" has been translated, it needs to be the English string "Auto" to work
-  switch (choice_display_resolution->GetSelection())
-  {
-  case 0:
-    SConfig::GetInstance().strFullscreenResolution = "Auto";
-    break;
-  case wxNOT_FOUND:
-    break;  // Nothing is selected.
-  default:
-    SConfig::GetInstance().strFullscreenResolution =
-        WxStrToStr(choice_display_resolution->GetStringSelection());
-  }
-#if defined(HAVE_XRANDR) && HAVE_XRANDR
-  main_frame->m_xrr_config->Update();
-#endif
-  ev.Skip();
-}
-
 void VideoConfigDiag::Event_ProgressiveScan(wxCommandEvent& ev)
 {
   Config::SetBase(Config::SYSCONF_PROGRESSIVE_SCAN, ev.IsChecked());
@@ -1134,13 +1079,6 @@ void VideoConfigDiag::OnUpdateUI(wxUpdateUIEvent& ev)
       choice_adapter->Disable();
       label_adapter->Disable();
     }
-
-#ifndef __APPLE__
-    // This isn't supported on OS X.
-
-    choice_display_resolution->Disable();
-    label_display_resolution->Disable();
-#endif
 
     progressive_scan_checkbox->Disable();
     render_to_main_checkbox->Disable();

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -100,7 +100,6 @@ public:
 
 protected:
   void Event_Backend(wxCommandEvent& ev);
-  void Event_DisplayResolution(wxCommandEvent& ev);
   void Event_ProgressiveScan(wxCommandEvent& ev);
   void Event_SafeTextureCache(wxCommandEvent& ev);
 
@@ -144,7 +143,6 @@ protected:
 
   wxChoice* choice_backend;
   wxChoice* choice_adapter;
-  wxChoice* choice_display_resolution;
 
   wxStaticText* label_backend;
   wxStaticText* label_adapter;


### PR DESCRIPTION
No real reason for most users to need to mess with this. Auto works in most cases. Left it in INI for smash players with CRTs, however it's been renamed to FullscreenDisplayRes.

Some users confuse this with IR. Clears that up.

Also removed from Qt, I think. I can't seem to actually launch debug builds on Qt. But it compiles. ¯\_(ツ)_/¯