### PR TITLE
AbstractTexture: Remove a redundant constructor initializer list entry

### DIFF
--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -9,7 +9,7 @@
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/ImageWrite.h"
 
-AbstractTexture::AbstractTexture(const TextureConfig& c) : m_config(c), m_currently_mapped(false)
+AbstractTexture::AbstractTexture(const TextureConfig& c) : m_config(c)
 {
 }
 


### PR DESCRIPTION
This is already initialized in the class definition. This would previously cause a `-Wreorder` warning on macOS, as `m_config` is defined after `m_currently_mapped`.