### PR TITLE
Qt: Fix blackscreen

### DIFF
--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -15,8 +15,14 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
   setAttribute(Qt::WA_NoSystemBackground, true);
 
   connect(Host::GetInstance(), &Host::RequestTitle, this, &RenderWidget::setWindowTitle);
-  connect(this, &RenderWidget::StateChanged, Host::GetInstance(), &Host::SetRenderFullscreen);
-  connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle);
+
+  // We have to use Qt::DirectConnection here because we don't want those signals to get queued
+  // (which results in them not getting called)
+  connect(this, &RenderWidget::StateChanged, Host::GetInstance(), &Host::SetRenderFullscreen,
+          Qt::DirectConnection);
+  connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle,
+          Qt::DirectConnection);
+
   emit HandleChanged((void*)winId());
 
   m_mouse_timer = new QTimer(this);


### PR DESCRIPTION
Fixes DolphinQt2 not rendering anything.

Credit to @stenzek for figuring out that ``Host::SetRenderHandle`` wasn't getting called.