### PR TITLE
Move Immediate XFB down in DTM header

### DIFF
--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -41,9 +41,9 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
 
   config_layer->Set(Config::GFX_HACK_EFB_ACCESS_ENABLE, dtm->bEFBAccessEnable);
   config_layer->Set(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM, dtm->bSkipEFBCopyToRam);
-  config_layer->Set(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM, dtm->bSkipXFBCopyToRam);
-  config_layer->Set(Config::GFX_HACK_IMMEDIATE_XFB, dtm->bImmediateXFB);
   config_layer->Set(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES, dtm->bEFBEmulateFormatChanges);
+  config_layer->Set(Config::GFX_HACK_IMMEDIATE_XFB, dtm->bImmediateXFB);
+  config_layer->Set(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM, dtm->bSkipXFBCopyToRam);
 }
 
 void SaveToDTM(Movie::DTMHeader* dtm)
@@ -64,9 +64,9 @@ void SaveToDTM(Movie::DTMHeader* dtm)
 
   dtm->bEFBAccessEnable = Config::Get(Config::GFX_HACK_EFB_ACCESS_ENABLE);
   dtm->bSkipEFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
-  dtm->bSkipXFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
-  dtm->bImmediateXFB = Config::Get(Config::GFX_HACK_IMMEDIATE_XFB);
   dtm->bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
+  dtm->bImmediateXFB = Config::Get(Config::GFX_HACK_IMMEDIATE_XFB);
+  dtm->bSkipXFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
 
   // This never used the regular config
   dtm->bSkipIdle = true;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1373,9 +1373,9 @@ void SetGraphicsConfig()
 {
   g_Config.bEFBAccessEnable = tmpHeader.bEFBAccessEnable;
   g_Config.bSkipEFBCopyToRam = tmpHeader.bSkipEFBCopyToRam;
-  g_Config.bSkipXFBCopyToRam = tmpHeader.bSkipXFBCopyToRam;
-  g_Config.bImmediateXFB = tmpHeader.bImmediateXFB;
   g_Config.bEFBEmulateFormatChanges = tmpHeader.bEFBEmulateFormatChanges;
+  g_Config.bImmediateXFB = tmpHeader.bImmediateXFB;
+  g_Config.bSkipXFBCopyToRam = tmpHeader.bSkipXFBCopyToRam;
 }
 
 // NOTE: EmuThread / Host Thread

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -52,6 +52,8 @@ struct ControllerState
 static_assert(sizeof(ControllerState) == 8, "ControllerState should be 8 bytes");
 #pragma pack(pop)
 
+// When making changes to the DTM format, keep in mind that there are programs other
+// than Dolphin that parse DTM files. The format is expected to be relatively stable.
 #pragma pack(push, 1)
 struct DTMHeader
 {
@@ -88,10 +90,10 @@ struct DTMHeader
   bool bEFBAccessEnable;
   bool bEFBCopyEnable;
   bool bSkipEFBCopyToRam;
-  bool bSkipXFBCopyToRam;
-  bool bImmediateXFB;
   bool bEFBCopyCacheEnable;
   bool bEFBEmulateFormatChanges;
+  bool bImmediateXFB;
+  bool bSkipXFBCopyToRam;
   u8 memcards;      // Memcards inserted (from least to most significant, the bits are slot A and B)
   bool bClearSave;  // Create a new memory card when playing back a movie if true
   u8 bongos;        // Bongos plugged in (from least to most significant, the bits are ports 1-4)


### PR DESCRIPTION
7f0834c9, which added the Immediate DTM setting, also added a byte to DTM headers for Immediate DTM. There are two problems with this:

1. The byte was added in the middle of the header, throwing off the offsets of several other settings. There are programs other than Dolphin itself that parse DTM files, so this is not acceptable.

2. If I'm not mistaken, Immediate XFB doesn't affect sync. Putting it in the DTM header unnecessarily prevents people from using a different value for that setting than what the movie author used.

I would appreciate if this could get reviewed quickly so that TASers don't have time to create DTMs with broken headers.