### PR TITLE
[WIP] Re-add the monitor resolution mode setting in the Advanced tab

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -180,6 +180,7 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 {
   IniFile::Section* display = ini.GetOrCreateSection("Display");
 
+  display->Set("FullscreenModeOverride", m_fullscreen_mode_override);
   display->Set("FullscreenResolution", strFullscreenResolution);
   display->Set("Fullscreen", bFullscreen);
   display->Set("RenderToMain", bRenderToMain);
@@ -460,6 +461,7 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
   IniFile::Section* display = ini.GetOrCreateSection("Display");
 
   display->Get("Fullscreen", &bFullscreen, false);
+  display->Get("FullscreenModeOverride", &m_fullscreen_mode_override, false);
   display->Get("FullscreenResolution", &strFullscreenResolution, "Auto");
   display->Get("RenderToMain", &bRenderToMain, false);
   display->Get("RenderWindowXPos", &iRenderWindowXPos, -1);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -180,7 +180,7 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 {
   IniFile::Section* display = ini.GetOrCreateSection("Display");
 
-  display->Set("FullscreenDisplayRes", strFullscreenResolution);
+  display->Set("FullscreenResolution", strFullscreenResolution);
   display->Set("Fullscreen", bFullscreen);
   display->Set("RenderToMain", bRenderToMain);
   display->Set("RenderWindowXPos", iRenderWindowXPos);
@@ -460,7 +460,7 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
   IniFile::Section* display = ini.GetOrCreateSection("Display");
 
   display->Get("Fullscreen", &bFullscreen, false);
-  display->Get("FullscreenDisplayRes", &strFullscreenResolution, "Auto");
+  display->Get("FullscreenResolution", &strFullscreenResolution, "Auto");
   display->Get("RenderToMain", &bRenderToMain, false);
   display->Get("RenderWindowXPos", &iRenderWindowXPos, -1);
   display->Get("RenderWindowYPos", &iRenderWindowYPos, -1);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -138,6 +138,7 @@ struct SConfig
   std::string theme_name;
 
   // Display settings
+  bool m_fullscreen_mode_override;
   std::string strFullscreenResolution;
   int iRenderWindowXPos = std::numeric_limits<int>::min();
   int iRenderWindowYPos = std::numeric_limits<int>::min();

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -47,6 +47,7 @@ void GeneralWidget::CreateWidgets()
   m_video_layout = new QGridLayout();
 
   m_backend_combo = new QComboBox();
+  m_resolution_combo = new QComboBox();
   m_aspect_combo =
       new GraphicsChoice({tr("Auto"), tr("Force 16:9"), tr("Force 4:3"), tr("Stretch to Window")},
                          Config::GFX_ASPECT_RATIO);
@@ -59,12 +60,23 @@ void GeneralWidget::CreateWidgets()
   for (auto& backend : g_available_video_backends)
     m_backend_combo->addItem(tr(backend->GetDisplayName().c_str()));
 
+#ifndef __APPLE__
+  m_resolution_combo->addItem(tr("Auto"));
+
+  for (const auto& res : VideoUtils::GetAvailableResolutions(m_xrr_config))
+    m_resolution_combo->addItem(QString::fromStdString(res));
+#endif
+
   m_video_layout->addWidget(new QLabel(tr("Backend:")), 0, 0);
   m_video_layout->addWidget(m_backend_combo, 0, 1);
-
 #ifdef _WIN32
   m_video_layout->addWidget(new QLabel(tr("Adapter:")), 1, 0);
   m_video_layout->addWidget(m_adapter_combo, 1, 1);
+#endif
+
+#ifndef __APPLE__
+  m_video_layout->addWidget(new QLabel(tr("Fullscreen Resolution:")), 2, 0);
+  m_video_layout->addWidget(m_resolution_combo, 2, 1);
 #endif
 
   m_video_layout->addWidget(new QLabel(tr("Aspect Ratio:")), 3, 0);
@@ -114,6 +126,10 @@ void GeneralWidget::ConnectWidgets()
   // Video Backend
   connect(m_backend_combo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
           [this](int) { SaveSettings(); });
+  // Fullscreen Resolution
+  connect(m_resolution_combo,
+          static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [this](int) { SaveSettings(); });
   // Enable Fullscreen
   for (QCheckBox* checkbox : {m_enable_fullscreen, m_hide_cursor, m_render_main_window})
     connect(checkbox, &QCheckBox::toggled, this, &GeneralWidget::SaveSettings);
@@ -133,6 +149,10 @@ void GeneralWidget::LoadSettings()
     }
   }
 
+  // Fullscreen Resolution
+  auto resolution = SConfig::GetInstance().strFullscreenResolution;
+  m_resolution_combo->setCurrentIndex(
+      resolution == "Auto" ? 0 : m_resolution_combo->findText(QString::fromStdString(resolution)));
   // Enable Fullscreen
   m_enable_fullscreen->setChecked(SConfig::GetInstance().bFullscreen);
   // Hide Cursor
@@ -190,6 +210,10 @@ void GeneralWidget::SaveSettings()
     }
   }
 
+  // Fullscreen Resolution
+  SConfig::GetInstance().strFullscreenResolution =
+      m_resolution_combo->currentIndex() == 0 ? "Auto" :
+                                                m_resolution_combo->currentText().toStdString();
   // Enable Fullscreen
   SConfig::GetInstance().bFullscreen = m_enable_fullscreen->isChecked();
   // Hide Cursor
@@ -206,6 +230,9 @@ void GeneralWidget::OnEmulationStateChanged(bool running)
 {
   m_backend_combo->setEnabled(!running);
   m_render_main_window->setEnabled(!running);
+#ifndef __APPLE__
+  m_resolution_combo->setEnabled(!running);
+#endif
 
 #ifdef _WIN32
   m_adapter_combo->setEnabled(!running);
@@ -230,6 +257,10 @@ void GeneralWidget::AddDescriptions()
                  "slow and only useful for debugging, so unless you have a reason to use it you'll "
                  "want to select OpenGL here.\n\nIf unsure, select OpenGL.");
 #endif
+  static const char* TR_RESOLUTION_DESCRIPTION =
+      QT_TR_NOOP("Selects the display resolution used in fullscreen mode.\nThis should always be "
+                 "bigger than or equal to the internal resolution. Performance impact is "
+                 "negligible.\n\nIf unsure, select auto.");
   static const char* TR_FULLSCREEN_DESCRIPTION = QT_TR_NOOP(
       "Enable this if you want the whole screen to be used for rendering.\nIf this is disabled, a "
       "render window will be created instead.\n\nIf unsure, leave this unchecked.");
@@ -270,6 +301,7 @@ void GeneralWidget::AddDescriptions()
 #ifdef _WIN32
   AddDescription(m_adapter_combo, TR_ADAPTER_DESCRIPTION);
 #endif
+  AddDescription(m_resolution_combo, TR_RESOLUTION_DESCRIPTION);
   AddDescription(m_enable_fullscreen, TR_FULLSCREEN_DESCRIPTION);
   AddDescription(m_autoadjust_window_size, TR_AUTOSIZE_DESCRIPTION);
   AddDescription(m_hide_cursor, TR_HIDE_MOUSE_CURSOR_DESCRIPTION);

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.h
@@ -38,6 +38,7 @@ private:
   // Video
   QGridLayout* m_video_layout;
   QComboBox* m_backend_combo;
+  QComboBox* m_resolution_combo;
   QComboBox* m_adapter_combo;
   QComboBox* m_aspect_combo;
   QCheckBox* m_enable_vsync;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -622,14 +622,17 @@ void CFrame::OnRenderParentResize(wxSizeEvent& event)
 
 void CFrame::ToggleDisplayMode(bool bFullscreen)
 {
+  const SConfig& config = SConfig::GetInstance();
+  const bool change_display_mode =
+      config.m_fullscreen_mode_override && config.strFullscreenResolution != "Auto";
 #ifdef _WIN32
-  if (bFullscreen && SConfig::GetInstance().strFullscreenResolution != "Auto")
+  if (bFullscreen && change_display_mode)
   {
     DEVMODE dmScreenSettings;
     memset(&dmScreenSettings, 0, sizeof(dmScreenSettings));
     dmScreenSettings.dmSize = sizeof(dmScreenSettings);
-    sscanf(SConfig::GetInstance().strFullscreenResolution.c_str(), "%dx%d",
-           &dmScreenSettings.dmPelsWidth, &dmScreenSettings.dmPelsHeight);
+    sscanf(config.strFullscreenResolution.c_str(), "%dx%d", &dmScreenSettings.dmPelsWidth,
+           &dmScreenSettings.dmPelsHeight);
     dmScreenSettings.dmBitsPerPel = 32;
     dmScreenSettings.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
 
@@ -642,7 +645,7 @@ void CFrame::ToggleDisplayMode(bool bFullscreen)
     ChangeDisplaySettings(nullptr, CDS_FULLSCREEN);
   }
 #elif defined(HAVE_XRANDR) && HAVE_XRANDR
-  if (SConfig::GetInstance().strFullscreenResolution != "Auto")
+  if (change_display_mode)
     m_xrr_config->ToggleDisplayMode(bFullscreen);
 #endif
 }

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -100,6 +100,7 @@ public:
 
 protected:
   void Event_Backend(wxCommandEvent& ev);
+  void Event_DisplayResolution(wxCommandEvent& ev);
   void Event_ProgressiveScan(wxCommandEvent& ev);
   void Event_SafeTextureCache(wxCommandEvent& ev);
 
@@ -143,6 +144,7 @@ protected:
 
   wxChoice* choice_backend;
   wxChoice* choice_adapter;
+  wxChoice* choice_display_resolution;
 
   wxStaticText* label_backend;
   wxStaticText* label_adapter;

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -100,6 +100,7 @@ public:
 
 protected:
   void Event_Backend(wxCommandEvent& ev);
+  void Event_FullscreenModeOverride(wxCommandEvent& ev);
   void Event_DisplayResolution(wxCommandEvent& ev);
   void Event_ProgressiveScan(wxCommandEvent& ev);
   void Event_SafeTextureCache(wxCommandEvent& ev);
@@ -153,6 +154,7 @@ protected:
   wxChoice* choice_aamode;
   DolphinSlider* conv_slider;
 
+  wxCheckBox* fullscreen_mode_override;
   wxStaticText* label_display_resolution;
 
   wxButton* button_config_pp;


### PR DESCRIPTION
This reverts PR #6196.

We've been getting complaint comments on that PR unusually quickly compared to other feature removal PRs (such at fractional IR). While I don't agree with all the points they make, the one about resolutions that can't run over 30 Hz makes sense.