### PR TITLE
MappingWindow: don't store devq separately from controller default device

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
@@ -114,7 +114,7 @@ void IOWindow::Update()
   m_range_spinbox->setValue(m_reference->range * SLIDER_TICK_COUNT);
   m_range_slider->setValue(m_reference->range * SLIDER_TICK_COUNT);
 
-  m_devq.FromString(m_controller->GetDefaultDevice().ToString());
+  m_devq = m_controller->GetDefaultDevice();
 
   UpdateDeviceList();
   UpdateOptionList();
@@ -183,7 +183,7 @@ void IOWindow::OnDetectButtonPressed()
     btn->setText(QStringLiteral("..."));
 
     const auto expr = MappingCommon::DetectExpression(
-        m_reference, g_controller_interface.FindDevice(m_devq).get(), m_devq, m_devq);
+        m_reference, g_controller_interface.FindDevice(m_devq).get(), m_devq);
 
     btn->setText(old_label);
 

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -57,8 +57,7 @@ void MappingButton::OnButtonPressed()
     Common::SleepCurrentThread(100);
 
     const auto expr = MappingCommon::DetectExpression(
-        m_reference, dev.get(), m_parent->GetParent()->GetDeviceQualifier(),
-        m_parent->GetController()->GetDefaultDevice());
+        m_reference, dev.get(), m_parent->GetController()->GetDefaultDevice());
 
     releaseMouse();
     releaseKeyboard();
@@ -90,7 +89,8 @@ void MappingButton::Clear()
 void MappingButton::Update()
 {
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
-  m_reference->UpdateReference(g_controller_interface, m_parent->GetParent()->GetDeviceQualifier());
+  m_reference->UpdateReference(g_controller_interface,
+                               m_parent->GetController()->GetDefaultDevice());
   setText(EscapeAmpersand(QString::fromStdString(m_reference->GetExpression())));
 }
 

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingCommon.cpp
@@ -35,15 +35,14 @@ QString GetExpressionForControl(const QString& control_name,
 }
 
 QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
-                         const ciface::Core::DeviceQualifier& m_devq,
                          const ciface::Core::DeviceQualifier& default_device)
 {
   ciface::Core::Device::Control* const ctrl = reference->Detect(5000, device);
 
   if (ctrl)
   {
-    return MappingCommon::GetExpressionForControl(QString::fromStdString(ctrl->GetName()), m_devq,
-                                                  default_device);
+    return MappingCommon::GetExpressionForControl(QString::fromStdString(ctrl->GetName()),
+                                                  default_device, default_device);
   }
   return QStringLiteral("");
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingCommon.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingCommon.h
@@ -22,6 +22,5 @@ QString GetExpressionForControl(const QString& control_name,
                                 const ciface::Core::DeviceQualifier& control_device,
                                 const ciface::Core::DeviceQualifier& default_device);
 QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
-                         const ciface::Core::DeviceQualifier& m_devq,
                          const ciface::Core::DeviceQualifier& default_device);
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -298,8 +298,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     m_profiles_combo->addItem(QString::fromStdString(basename), QString::fromStdString(filename));
   }
 
-  if (m_controller != nullptr)
-    RefreshDevices();
+  RefreshDevices();
 }
 
 void MappingWindow::AddWidget(const QString& name, QWidget* widget)
@@ -329,9 +328,6 @@ std::shared_ptr<ciface::Core::Device> MappingWindow::GetDevice() const
 
 void MappingWindow::OnDefaultFieldsPressed()
 {
-  if (m_controller == nullptr)
-    return;
-
   m_controller->LoadDefaults(g_controller_interface);
   m_controller->UpdateReferences(g_controller_interface);
   emit Update();

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -210,7 +210,6 @@ void MappingWindow::OnSaveProfilePressed()
 void MappingWindow::OnDeviceChanged(int index)
 {
   const auto device = m_devices_combo->currentText().toStdString();
-  m_devq.FromString(device);
   m_controller->SetDefaultDevice(device);
 }
 
@@ -316,14 +315,9 @@ ControllerEmu::EmulatedController* MappingWindow::GetController() const
   return m_controller;
 }
 
-const ciface::Core::DeviceQualifier& MappingWindow::GetDeviceQualifier() const
-{
-  return m_devq;
-}
-
 std::shared_ptr<ciface::Core::Device> MappingWindow::GetDevice() const
 {
-  return g_controller_interface.FindDevice(m_devq);
+  return g_controller_interface.FindDevice(GetController()->GetDefaultDevice());
 }
 
 void MappingWindow::OnDefaultFieldsPressed()

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.h
@@ -48,7 +48,6 @@ public:
   explicit MappingWindow(QWidget* parent, Type type, int port_num);
 
   int GetPort() const;
-  const ciface::Core::DeviceQualifier& GetDeviceQualifier() const;
   std::shared_ptr<ciface::Core::Device> GetDevice() const;
 
   ControllerEmu::EmulatedController* GetController() const;
@@ -106,5 +105,4 @@ private:
   Type m_mapping_type;
   const int m_port;
   InputConfig* m_config;
-  ciface::Core::DeviceQualifier m_devq;
 };

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -87,15 +87,17 @@ std::string DeviceQualifier::ToString() const
 //
 void DeviceQualifier::FromString(const std::string& str)
 {
+  *this = {};
+
   std::istringstream ss(str);
 
-  std::getline(ss, source = "", '/');
+  std::getline(ss, source, '/');
 
   // silly
   std::getline(ss, name, '/');
-  std::istringstream(name) >> (cid = -1);
+  std::istringstream(name) >> cid;
 
-  std::getline(ss, name = "");
+  std::getline(ss, name);
 }
 
 //

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -18,9 +18,6 @@ namespace ciface
 {
 namespace Core
 {
-// Forward declarations
-class DeviceQualifier;
-
 //
 // Device
 //


### PR DESCRIPTION
Since GCPadWiiUConfigDialog was made its own class in #6168, MappingWindow always has a valid ControllerEmu object. So, we no longer need to store the default device separately from the ControllerEmu's default device.