### PR TITLE
Texture Cache Cleanup - move backend implementations to be owned by TextureCacheBase instead of derived from it

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -34,6 +34,7 @@
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/RenderState.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -24,6 +24,7 @@
 
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/RenderBase.h"
+#include "VideoCommon/TextureCacheEntry.h"
 #include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -5,14 +5,13 @@
 #pragma once
 
 #include "VideoBackends/D3D/D3DTexture.h"
-#include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheBackend.h"
 
-class AbstractTexture;
 struct TextureConfig;
 
 namespace DX11
 {
-class TextureCache : public TextureCacheBase
+class TextureCache : public TextureCacheBackend
 {
 public:
   TextureCache();

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -21,6 +21,7 @@
 #include "VideoBackends/D3D/VertexShaderCache.h"
 #include "VideoBackends/D3D/VideoBackend.h"
 
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -157,7 +158,7 @@ void VideoBackend::Video_Prepare()
 
   // internal interfaces
   g_renderer = std::make_unique<Renderer>();
-  g_texture_cache = std::make_unique<TextureCache>();
+  g_texture_cache = std::make_unique<TextureCacheBase>(std::make_unique<TextureCache>());
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
   VertexShaderCache::Init();

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -15,6 +15,7 @@
 #include "VideoBackends/Null/VideoBackend.h"
 
 #include "VideoCommon/FramebufferManagerBase.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
@@ -69,7 +70,7 @@ void VideoBackend::Video_Prepare()
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
   g_framebuffer_manager = std::make_unique<FramebufferManagerBase>();
-  g_texture_cache = std::make_unique<TextureCache>();
+  g_texture_cache = std::make_unique<TextureCacheBase>(std::make_unique<TextureCache>());
   VertexShaderCache::s_instance = std::make_unique<VertexShaderCache>();
   GeometryShaderCache::s_instance = std::make_unique<GeometryShaderCache>();
   PixelShaderCache::s_instance = std::make_unique<PixelShaderCache>();

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -8,12 +8,12 @@
 
 #include "VideoBackends/Null/NullTexture.h"
 
-#include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheBackend.h"
 #include "VideoCommon/TextureConfig.h"
 
 namespace Null
 {
-class TextureCache : public TextureCacheBase
+class TextureCache : public TextureCacheBackend
 {
 public:
   TextureCache() {}

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -42,6 +42,7 @@
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/ShaderGenCommon.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -25,6 +25,7 @@
 #include "VideoBackends/OGL/TextureConverter.h"
 
 #include "VideoCommon/ImageWrite.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoConfig.h"
@@ -88,7 +89,7 @@ TextureCache::~TextureCache()
 
 TextureCache* TextureCache::GetInstance()
 {
-  return static_cast<TextureCache*>(g_texture_cache.get());
+  return static_cast<TextureCache*>(g_texture_cache->GetBackendImpl());
 }
 
 const SHADER& TextureCache::GetColorCopyProgram() const

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -11,7 +11,7 @@
 #include "Common/GL/GLUtil.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 
-#include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheBackend.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -21,7 +21,7 @@ struct TextureConfig;
 
 namespace OGL
 {
-class TextureCache : public TextureCacheBase
+class TextureCache : public TextureCacheBackend
 {
 public:
   TextureCache();

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -53,6 +53,7 @@ Make AA apply instantly during gameplay if possible
 #include "VideoBackends/OGL/VideoBackend.h"
 
 #include "VideoCommon/OnScreenDisplay.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -193,7 +194,7 @@ void VideoBackend::Video_Prepare()
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = GetPerfQuery();
   ProgramShaderCache::Init();
-  g_texture_cache = std::make_unique<TextureCache>();
+  g_texture_cache = std::make_unique<TextureCacheBase>(std::make_unique<TextureCache>());
   g_sampler_cache = std::make_unique<SamplerCache>();
   static_cast<Renderer*>(g_renderer.get())->Init();
   TextureConverter::Init();

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -126,7 +126,7 @@ void VideoSoftware::Video_Prepare()
   g_renderer = std::make_unique<SWRenderer>();
   g_vertex_manager = std::make_unique<SWVertexLoader>();
   g_perf_query = std::make_unique<PerfQuery>();
-  g_texture_cache = std::make_unique<TextureCache>();
+  g_texture_cache = std::make_unique<TextureCacheBase>(std::make_unique<TextureCache>());
   SWRenderer::Init();
 }
 

--- a/Source/Core/VideoBackends/Software/TextureCache.h
+++ b/Source/Core/VideoBackends/Software/TextureCache.h
@@ -3,11 +3,12 @@
 #include <memory>
 #include "VideoBackends/Software/SWTexture.h"
 #include "VideoBackends/Software/TextureEncoder.h"
-#include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheBackend.h"
+#include "VideoCommon/TextureCacheEntry.h"
 
 namespace SW
 {
-class TextureCache : public TextureCacheBase
+class TextureCache : public TextureCacheBackend
 {
 public:
   bool CompileShaders() override { return true; }

--- a/Source/Core/VideoBackends/Software/TextureEncoder.cpp
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.cpp
@@ -14,7 +14,7 @@
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/LookUpTables.h"
-#include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheBackend.h"
 #include "VideoCommon/TextureDecoder.h"
 
 namespace TextureEncoder

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -542,7 +542,7 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   SetWindowSize(xfb_texture->GetConfig().width, xfb_texture->GetConfig().height);
 
   // Clean up stale textures.
-  TextureCache::GetInstance()->Cleanup(frameCount);
+  g_texture_cache->Cleanup(frameCount);
 
   // Pull in now-ready async shaders.
   g_shader_cache->RetrieveAsyncShaders();
@@ -731,7 +731,7 @@ void Renderer::CheckForConfigChanges()
   const bool aspect_changed = old_aspect_mode != g_ActiveConfig.aspect_mode;
 
   // Update texture cache settings with any changed options.
-  TextureCache::GetInstance()->OnConfigChanged(g_ActiveConfig);
+  g_texture_cache->OnConfigChanged(g_ActiveConfig);
 
   // Handle settings that can cause the target rectangle to change.
   if (efb_scale_changed || aspect_changed)

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -27,6 +27,7 @@
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
 #include "VideoCommon/ImageWrite.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureConfig.h"
 
 namespace Vulkan
@@ -59,7 +60,7 @@ StreamBuffer* TextureCache::GetTextureUploadBuffer() const
 
 TextureCache* TextureCache::GetInstance()
 {
-  return static_cast<TextureCache*>(g_texture_cache.get());
+  return static_cast<TextureCache*>(g_texture_cache->GetBackendImpl());
 }
 
 bool TextureCache::Initialize()

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.h
@@ -8,7 +8,9 @@
 
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Vulkan/StreamBuffer.h"
-#include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheBackend.h"
+
+struct TextureConfig;
 
 namespace Vulkan
 {
@@ -17,7 +19,7 @@ class StateTracker;
 class Texture2D;
 class VKTexture;
 
-class TextureCache : public TextureCacheBase
+class TextureCache : public TextureCacheBackend
 {
 public:
   TextureCache();

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -27,6 +27,7 @@
 #include "VideoBackends/Vulkan/VKTexture.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
+#include "VideoCommon/TextureCacheEntry.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoConfig.h"
@@ -155,8 +156,7 @@ bool TextureConverter::ReserveTexelBufferStorage(size_t size, size_t alignment)
   return true;
 }
 
-VkCommandBuffer
-TextureConverter::GetCommandBufferForTextureConversion(const TextureCache::TCacheEntry* src_entry)
+VkCommandBuffer TextureConverter::GetCommandBufferForTextureConversion(const TCacheEntry* src_entry)
 {
   // EFB copies can be used as paletted textures as well. For these, we can't assume them to be
   // contain the correct data before the frame begins (when the init command buffer is executed),
@@ -174,8 +174,7 @@ TextureConverter::GetCommandBufferForTextureConversion(const TextureCache::TCach
   }
 }
 
-void TextureConverter::ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
-                                      TextureCacheBase::TCacheEntry* src_entry,
+void TextureConverter::ConvertTexture(TCacheEntry* dst_entry, TCacheEntry* src_entry,
                                       VkRenderPass render_pass, const void* palette,
                                       TLUTFormat palette_format)
 {
@@ -435,11 +434,11 @@ bool TextureConverter::SupportsTextureDecoding(TextureFormat format, TLUTFormat 
   return true;
 }
 
-void TextureConverter::DecodeTexture(VkCommandBuffer command_buffer,
-                                     TextureCache::TCacheEntry* entry, u32 dst_level,
-                                     const u8* data, size_t data_size, TextureFormat format,
-                                     u32 width, u32 height, u32 aligned_width, u32 aligned_height,
-                                     u32 row_stride, const u8* palette, TLUTFormat palette_format)
+void TextureConverter::DecodeTexture(VkCommandBuffer command_buffer, TCacheEntry* entry,
+                                     u32 dst_level, const u8* data, size_t data_size,
+                                     TextureFormat format, u32 width, u32 height, u32 aligned_width,
+                                     u32 aligned_height, u32 row_stride, const u8* palette,
+                                     TLUTFormat palette_format)
 {
   VKTexture* destination_texture = static_cast<VKTexture*>(entry->texture.get());
   auto key = std::make_pair(format, palette_format);

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -31,8 +31,7 @@ public:
   bool Initialize();
 
   // Applies palette to dst_entry, using indices from src_entry.
-  void ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
-                      TextureCache::TCacheEntry* src_entry, VkRenderPass render_pass,
+  void ConvertTexture(TCacheEntry* dst_entry, TCacheEntry* src_entry, VkRenderPass render_pass,
                       const void* palette, TLUTFormat palette_format);
 
   // Uses an encoding shader to copy src_texture to dest_ptr.
@@ -50,10 +49,10 @@ public:
                                    u32 src_stride, u32 src_height);
 
   bool SupportsTextureDecoding(TextureFormat format, TLUTFormat palette_format);
-  void DecodeTexture(VkCommandBuffer command_buffer, TextureCache::TCacheEntry* entry,
-                     u32 dst_level, const u8* data, size_t data_size, TextureFormat format,
-                     u32 width, u32 height, u32 aligned_width, u32 aligned_height, u32 row_stride,
-                     const u8* palette, TLUTFormat palette_format);
+  void DecodeTexture(VkCommandBuffer command_buffer, TCacheEntry* entry, u32 dst_level,
+                     const u8* data, size_t data_size, TextureFormat format, u32 width, u32 height,
+                     u32 aligned_width, u32 aligned_height, u32 row_stride, const u8* palette,
+                     TLUTFormat palette_format);
 
 private:
   static const u32 ENCODING_TEXTURE_WIDTH = EFB_WIDTH * 4;
@@ -90,7 +89,7 @@ private:
 
   // Returns the command buffer that the texture conversion should occur in for the given texture.
   // This can be the initialization/copy command buffer, or the drawing command buffer.
-  VkCommandBuffer GetCommandBufferForTextureConversion(const TextureCache::TCacheEntry* src_entry);
+  VkCommandBuffer GetCommandBufferForTextureConversion(const TCacheEntry* src_entry);
 
   // Shared between conversion types
   std::unique_ptr<StreamBuffer> m_texel_buffer;

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -21,6 +21,7 @@
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
 #include "VideoCommon/OnScreenDisplay.h"
+#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -228,7 +229,7 @@ bool VideoBackend::Initialize(void* window_handle)
 
   // Create remaining wrapper instances.
   g_vertex_manager = std::make_unique<VertexManager>();
-  g_texture_cache = std::make_unique<TextureCache>();
+  g_texture_cache = std::make_unique<TextureCacheBase>(std::make_unique<TextureCache>());
   g_perf_query = std::make_unique<PerfQuery>();
   if (!VertexManager::GetInstance()->Initialize() || !TextureCache::GetInstance()->Initialize() ||
       !PerfQuery::GetInstance()->Initialize())

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -35,7 +35,9 @@ set(SRCS
   UberShaderCommon.cpp
   UberShaderPixel.cpp
   UberShaderVertex.cpp
+  TextureCacheBackend.cpp
   TextureCacheBase.cpp
+  TextureCacheEntry.cpp
   TextureConfig.cpp
   TextureConversionShader.cpp
   TextureDecoder_Common.cpp

--- a/Source/Core/VideoCommon/TextureCacheBackend.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBackend.cpp
@@ -1,0 +1,19 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/TextureCacheBackend.h"
+#include "VideoCommon/TextureCacheEntry.h"
+
+void TextureCacheBackend::DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, const u8* data,
+                                             size_t data_size, TextureFormat format, u32 width,
+                                             u32 height, u32 aligned_width, u32 aligned_height,
+                                             u32 row_stride, const u8* palette,
+                                             TLUTFormat palette_format)
+{
+}
+
+bool TextureCacheBackend::SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format)
+{
+  return false;
+}

--- a/Source/Core/VideoCommon/TextureCacheBackend.h
+++ b/Source/Core/VideoCommon/TextureCacheBackend.h
@@ -1,0 +1,72 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <tuple>
+
+#include "Common/CommonTypes.h"
+
+#include "VideoCommon/BPMemory.h"
+#include "VideoCommon/TextureDecoder.h"
+#include "VideoCommon/VideoCommon.h"
+
+class AbstractTexture;
+struct TCacheEntry;
+struct TextureConfig;
+
+struct EFBCopyParams
+{
+  EFBCopyParams(PEControl::PixelFormat efb_format_, EFBCopyFormat copy_format_, bool depth_,
+                bool yuv_, float y_scale_)
+      : efb_format(efb_format_), copy_format(copy_format_), depth(depth_), yuv(yuv_),
+        y_scale(y_scale_)
+  {
+  }
+
+  bool operator<(const EFBCopyParams& rhs) const
+  {
+    return std::tie(efb_format, copy_format, depth, yuv, y_scale) <
+           std::tie(rhs.efb_format, rhs.copy_format, rhs.depth, rhs.yuv, rhs.y_scale);
+  }
+
+  PEControl::PixelFormat efb_format;
+  EFBCopyFormat copy_format;
+  bool depth;
+  bool yuv;
+  float y_scale;
+};
+
+class TextureCacheBackend
+{
+public:
+  virtual ~TextureCacheBackend() = default;
+  virtual bool CompileShaders() = 0;
+  virtual void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+                       u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+                       bool scale_by_half) = 0;
+  virtual void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
+                                   const EFBRectangle& src_rect, bool scale_by_half,
+                                   unsigned int cbuf_id, const float* colmat) = 0;
+
+  virtual void ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, const void* palette,
+                              TLUTFormat format) = 0;
+  virtual std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) = 0;
+
+  // Decodes the specified data to the GPU texture specified by entry.
+  // width, height are the size of the image in pixels.
+  // aligned_width, aligned_height are the size of the image in pixels, aligned to the block size.
+  // row_stride is the number of bytes for a row of blocks, not pixels.
+  virtual void DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, const u8* data,
+                                  size_t data_size, TextureFormat format, u32 width, u32 height,
+                                  u32 aligned_width, u32 aligned_height, u32 row_stride,
+                                  const u8* palette, TLUTFormat palette_format);
+
+  virtual void DeleteShaders() = 0;
+
+  // Returns true if the texture data and palette formats are supported by the GPU decoder.
+  virtual bool SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format);
+};

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -12,59 +12,17 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/BPMemory.h"
+#include "VideoCommon/TextureCacheEntry.h"
 #include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
 
+class TextureCacheBackend;
 struct VideoConfig;
-
-struct TextureAndTLUTFormat
-{
-  TextureAndTLUTFormat(TextureFormat texfmt_ = TextureFormat::I4,
-                       TLUTFormat tlutfmt_ = TLUTFormat::IA8)
-      : texfmt(texfmt_), tlutfmt(tlutfmt_)
-  {
-  }
-
-  bool operator==(const TextureAndTLUTFormat& other) const
-  {
-    if (IsColorIndexed(texfmt))
-      return texfmt == other.texfmt && tlutfmt == other.tlutfmt;
-
-    return texfmt == other.texfmt;
-  }
-
-  bool operator!=(const TextureAndTLUTFormat& other) const { return !operator==(other); }
-  TextureFormat texfmt;
-  TLUTFormat tlutfmt;
-};
-
-struct EFBCopyParams
-{
-  EFBCopyParams(PEControl::PixelFormat efb_format_, EFBCopyFormat copy_format_, bool depth_,
-                bool yuv_, float y_scale_)
-      : efb_format(efb_format_), copy_format(copy_format_), depth(depth_), yuv(yuv_),
-        y_scale(y_scale_)
-  {
-  }
-
-  bool operator<(const EFBCopyParams& rhs) const
-  {
-    return std::tie(efb_format, copy_format, depth, yuv, y_scale) <
-           std::tie(rhs.efb_format, rhs.copy_format, rhs.depth, rhs.yuv, rhs.y_scale);
-  }
-
-  PEControl::PixelFormat efb_format;
-  EFBCopyFormat copy_format;
-  bool depth;
-  bool yuv;
-  float y_scale;
-};
 
 struct TextureLookupInformation
 {
@@ -104,107 +62,8 @@ struct TextureLookupInformation
 
 class TextureCacheBase
 {
-private:
-  static const int FRAMECOUNT_INVALID = 0;
-
 public:
-  struct TCacheEntry
-  {
-    // common members
-    std::unique_ptr<AbstractTexture> texture;
-    u32 addr;
-    u32 size_in_bytes;
-    u64 base_hash;
-    u64 hash;  // for paletted textures, hash = base_hash ^ palette_hash
-    TextureAndTLUTFormat format;
-    u32 memory_stride;
-    bool is_efb_copy;
-    bool is_custom_tex;
-    bool may_have_overlapping_textures = true;
-    bool tmem_only = false;           // indicates that this texture only exists in the tmem cache
-    bool has_arbitrary_mips = false;  // indicates that the mips in this texture are arbitrary
-                                      // content, aren't just downscaled
-    bool should_force_safe_hashing = false;  // for XFB
-    bool is_xfb_copy = false;
-    float y_scale = 1.0f;
-    float gamma = 1.0f;
-    u64 id;
-
-    bool reference_changed = false;  // used by xfb to determine when a reference xfb changed
-
-    unsigned int native_width,
-        native_height;  // Texture dimensions from the GameCube's point of view
-    unsigned int native_levels;
-
-    // used to delete textures which haven't been used for TEXTURE_KILL_THRESHOLD frames
-    int frameCount = FRAMECOUNT_INVALID;
-
-    // Keep an iterator to the entry in textures_by_hash, so it does not need to be searched when
-    // removing the cache entry
-    std::multimap<u64, TCacheEntry*>::iterator textures_by_hash_iter;
-
-    // This is used to keep track of both:
-    //   * efb copies used by this partially updated texture
-    //   * partially updated textures which refer to this efb copy
-    std::unordered_set<TCacheEntry*> references;
-
-    explicit TCacheEntry(std::unique_ptr<AbstractTexture> tex);
-
-    ~TCacheEntry();
-
-    void SetGeneralParameters(u32 _addr, u32 _size, TextureAndTLUTFormat _format,
-                              bool force_safe_hashing)
-    {
-      addr = _addr;
-      size_in_bytes = _size;
-      format = _format;
-      should_force_safe_hashing = force_safe_hashing;
-    }
-
-    void SetDimensions(unsigned int _native_width, unsigned int _native_height,
-                       unsigned int _native_levels)
-    {
-      native_width = _native_width;
-      native_height = _native_height;
-      native_levels = _native_levels;
-      memory_stride = _native_width;
-    }
-
-    void SetHashes(u64 _base_hash, u64 _hash)
-    {
-      base_hash = _base_hash;
-      hash = _hash;
-    }
-
-    // This texture entry is used by the other entry as a sub-texture
-    void CreateReference(TCacheEntry* other_entry)
-    {
-      // References are two-way, so they can easily be destroyed later
-      this->references.emplace(other_entry);
-      other_entry->references.emplace(this);
-    }
-
-    void SetXfbCopy(u32 stride);
-    void SetEfbCopy(u32 stride);
-    void SetNotCopy();
-
-    bool OverlapsMemoryRange(u32 range_address, u32 range_size) const;
-
-    bool IsEfbCopy() const { return is_efb_copy; }
-    bool IsCopy() const { return is_xfb_copy || is_efb_copy; }
-    u32 NumBlocksY() const;
-    u32 BytesPerRow() const;
-
-    u64 CalculateHash() const;
-
-    int HashSampleSize() const;
-    u32 GetWidth() const { return texture->GetConfig().width; }
-    u32 GetHeight() const { return texture->GetConfig().height; }
-    u32 GetNumLevels() const { return texture->GetConfig().levels; }
-    u32 GetNumLayers() const { return texture->GetConfig().layers; }
-    AbstractTextureFormat GetFormat() const { return texture->GetConfig().format; }
-  };
-
+  explicit TextureCacheBase(std::unique_ptr<TextureCacheBackend> implementation);
   virtual ~TextureCacheBase();  // needs virtual for DX11 dtor
 
   void OnConfigChanged(VideoConfig& config);
@@ -214,13 +73,6 @@ public:
   void Cleanup(int _frameCount);
 
   void Invalidate();
-
-  virtual void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-                       u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
-                       bool scale_by_half) = 0;
-
-  virtual bool CompileShaders() = 0;
-  virtual void DeleteShaders() = 0;
 
   TCacheEntry* Load(const u32 stage);
   static void InvalidateAllBindPoints() { valid_bind_points.reset(); }
@@ -251,33 +103,13 @@ public:
                                  bool is_depth_copy, const EFBRectangle& srcRect, bool isIntensity,
                                  bool scaleByHalf, float y_scale, float gamma);
 
-  virtual void ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, const void* palette,
-                              TLUTFormat format) = 0;
-
-  // Returns true if the texture data and palette formats are supported by the GPU decoder.
-  virtual bool SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format)
-  {
-    return false;
-  }
-
-  // Decodes the specified data to the GPU texture specified by entry.
-  // width, height are the size of the image in pixels.
-  // aligned_width, aligned_height are the size of the image in pixels, aligned to the block size.
-  // row_stride is the number of bytes for a row of blocks, not pixels.
-  virtual void DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, const u8* data,
-                                  size_t data_size, TextureFormat format, u32 width, u32 height,
-                                  u32 aligned_width, u32 aligned_height, u32 row_stride,
-                                  const u8* palette, TLUTFormat palette_format)
-  {
-  }
-
   void ScaleTextureCacheEntryTo(TCacheEntry* entry, u32 new_width, u32 new_height);
 
-  virtual std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) = 0;
+  std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config);
+
+  TextureCacheBackend* GetBackendImpl() const;
 
 protected:
-  TextureCacheBase();
-
   alignas(16) u8* temp = nullptr;
   size_t temp_size = 0;
 
@@ -289,7 +121,7 @@ private:
   struct TexPoolEntry
   {
     std::unique_ptr<AbstractTexture> texture;
-    int frameCount = FRAMECOUNT_INVALID;
+    int frameCount = TCacheEntry::FRAMECOUNT_INVALID;
     TexPoolEntry(std::unique_ptr<AbstractTexture> tex) : texture(std::move(tex)) {}
   };
   using TexAddrCache = std::multimap<u32, TCacheEntry*>;
@@ -316,10 +148,6 @@ private:
   std::pair<TexAddrCache::iterator, TexAddrCache::iterator>
   FindOverlappingTextures(u32 addr, u32 size_in_bytes);
 
-  virtual void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
-                                   const EFBRectangle& src_rect, bool scale_by_half,
-                                   unsigned int cbuf_id, const float* colmat) = 0;
-
   // Removes and unlinks texture from texture cache and returns it to the pool
   TexAddrCache::iterator InvalidateTexture(TexAddrCache::iterator t_iter);
 
@@ -344,6 +172,8 @@ private:
     bool gpu_texture_decoding;
   };
   BackupConfig backup_config = {};
+
+  std::unique_ptr<TextureCacheBackend> backend_impl;
 };
 
 extern std::unique_ptr<TextureCacheBase> g_texture_cache;

--- a/Source/Core/VideoCommon/TextureCacheEntry.cpp
+++ b/Source/Core/VideoCommon/TextureCacheEntry.cpp
@@ -1,0 +1,155 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <algorithm>
+
+#include "Common/Align.h"
+#include "Common/Assert.h"
+#include "Common/Hash.h"
+#include "Common/MemoryUtil.h"
+
+#include "Core/HW/Memmap.h"
+
+#include "VideoCommon/AbstractTexture.h"
+#include "VideoCommon/TextureCacheEntry.h"
+#include "VideoCommon/VideoConfig.h"
+
+TCacheEntry::TCacheEntry(std::unique_ptr<AbstractTexture> tex) : texture(std::move(tex))
+{
+}
+
+TCacheEntry::~TCacheEntry()
+{
+  for (auto& reference : references)
+    reference->references.erase(this);
+}
+
+bool TCacheEntry::OverlapsMemoryRange(u32 range_address, u32 range_size) const
+{
+  if (addr + size_in_bytes <= range_address)
+    return false;
+
+  if (addr >= range_address + range_size)
+    return false;
+
+  return true;
+}
+
+u32 TCacheEntry::BytesPerRow() const
+{
+  const u32 blockW = TexDecoder_GetBlockWidthInTexels(format.texfmt);
+
+  // Round up source height to multiple of block size
+  const u32 actualWidth = Common::AlignUp(native_width, blockW);
+
+  const u32 numBlocksX = actualWidth / blockW;
+
+  // RGBA takes two cache lines per block; all others take one
+  const u32 bytes_per_block = format == TextureFormat::RGBA8 ? 64 : 32;
+
+  return numBlocksX * bytes_per_block;
+}
+
+u32 TCacheEntry::NumBlocksY() const
+{
+  u32 blockH = TexDecoder_GetBlockHeightInTexels(format.texfmt);
+  // Round up source height to multiple of block size
+  u32 actualHeight = Common::AlignUp(static_cast<unsigned int>(native_height * y_scale), blockH);
+
+  return actualHeight / blockH;
+}
+
+void TCacheEntry::SetXfbCopy(u32 stride)
+{
+  is_efb_copy = false;
+  is_xfb_copy = true;
+  memory_stride = stride;
+
+  _assert_msg_(VIDEO, memory_stride >= BytesPerRow(), "Memory stride is too small");
+
+  size_in_bytes = memory_stride * NumBlocksY();
+}
+
+void TCacheEntry::SetEfbCopy(u32 stride)
+{
+  is_efb_copy = true;
+  is_xfb_copy = false;
+  memory_stride = stride;
+
+  _assert_msg_(VIDEO, memory_stride >= BytesPerRow(), "Memory stride is too small");
+
+  size_in_bytes = memory_stride * NumBlocksY();
+}
+
+void TCacheEntry::SetNotCopy()
+{
+  is_xfb_copy = false;
+  is_efb_copy = false;
+}
+
+int TCacheEntry::HashSampleSize() const
+{
+  if (should_force_safe_hashing)
+  {
+    return 0;
+  }
+
+  return g_ActiveConfig.iSafeTextureCache_ColorSamples;
+}
+
+u64 TCacheEntry::CalculateHash() const
+{
+  u8* ptr = Memory::GetPointer(addr);
+  if (memory_stride == BytesPerRow())
+  {
+    return GetHash64(ptr, size_in_bytes, HashSampleSize());
+  }
+  else
+  {
+    u32 blocks = NumBlocksY();
+    u64 temp_hash = size_in_bytes;
+
+    u32 samples_per_row = 0;
+    if (HashSampleSize() != 0)
+    {
+      // Hash at least 4 samples per row to avoid hashing in a bad pattern, like just on the left
+      // side of the efb copy
+      samples_per_row = std::max(HashSampleSize() / blocks, 4u);
+    }
+
+    for (u32 i = 0; i < blocks; i++)
+    {
+      // Multiply by a prime number to mix the hash up a bit. This prevents identical blocks from
+      // canceling each other out
+      temp_hash = (temp_hash * 397) ^ GetHash64(ptr, BytesPerRow(), samples_per_row);
+      ptr += memory_stride;
+    }
+    return temp_hash;
+  }
+}
+
+u32 TCacheEntry::GetWidth() const
+{
+  return texture->GetConfig().width;
+}
+
+u32 TCacheEntry::GetHeight() const
+{
+  return texture->GetConfig().height;
+}
+
+u32 TCacheEntry::GetNumLevels() const
+{
+  return texture->GetConfig().levels;
+}
+
+u32 TCacheEntry::GetNumLayers() const
+{
+  return texture->GetConfig().layers;
+}
+
+AbstractTextureFormat TCacheEntry::GetFormat() const
+{
+  return texture->GetConfig().format;
+}

--- a/Source/Core/VideoCommon/TextureCacheEntry.h
+++ b/Source/Core/VideoCommon/TextureCacheEntry.h
@@ -1,0 +1,135 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <unordered_set>
+
+#include "Common/CommonTypes.h"
+
+#include "VideoCommon/TextureDecoder.h"
+
+class AbstractTexture;
+enum class AbstractTextureFormat : u32;
+
+struct TextureAndTLUTFormat
+{
+  TextureAndTLUTFormat(TextureFormat texfmt_ = TextureFormat::I4,
+                       TLUTFormat tlutfmt_ = TLUTFormat::IA8)
+      : texfmt(texfmt_), tlutfmt(tlutfmt_)
+  {
+  }
+
+  bool operator==(const TextureAndTLUTFormat& other) const
+  {
+    if (IsColorIndexed(texfmt))
+      return texfmt == other.texfmt && tlutfmt == other.tlutfmt;
+
+    return texfmt == other.texfmt;
+  }
+
+  bool operator!=(const TextureAndTLUTFormat& other) const { return !operator==(other); }
+  TextureFormat texfmt;
+  TLUTFormat tlutfmt;
+};
+
+struct TCacheEntry
+{
+  static const int FRAMECOUNT_INVALID = 0;
+
+  // common members
+  std::unique_ptr<AbstractTexture> texture;
+  u32 addr;
+  u32 size_in_bytes;
+  u64 base_hash;
+  u64 hash;  // for paletted textures, hash = base_hash ^ palette_hash
+  TextureAndTLUTFormat format;
+  u32 memory_stride;
+  bool is_efb_copy;
+  bool is_custom_tex;
+  bool may_have_overlapping_textures = true;
+  bool tmem_only = false;           // indicates that this texture only exists in the tmem cache
+  bool has_arbitrary_mips = false;  // indicates that the mips in this texture are arbitrary
+                                    // content, aren't just downscaled
+  bool should_force_safe_hashing = false;  // for XFB
+  bool is_xfb_copy = false;
+  float y_scale = 1.0f;
+  float gamma = 1.0f;
+  u64 id;
+
+  bool reference_changed = false;  // used by xfb to determine when a reference xfb changed
+
+  unsigned int native_width, native_height;  // Texture dimensions from the GameCube's point of view
+  unsigned int native_levels;
+
+  // used to delete textures which haven't been used for TEXTURE_KILL_THRESHOLD frames
+  int frameCount = FRAMECOUNT_INVALID;
+
+  // Keep an iterator to the entry in textures_by_hash, so it does not need to be searched when
+  // removing the cache entry
+  std::multimap<u64, TCacheEntry*>::iterator textures_by_hash_iter;
+
+  // This is used to keep track of both:
+  //   * efb copies used by this partially updated texture
+  //   * partially updated textures which refer to this efb copy
+  std::unordered_set<TCacheEntry*> references;
+
+  explicit TCacheEntry(std::unique_ptr<AbstractTexture> tex);
+
+  ~TCacheEntry();
+
+  void SetGeneralParameters(u32 _addr, u32 _size, TextureAndTLUTFormat _format,
+                            bool force_safe_hashing)
+  {
+    addr = _addr;
+    size_in_bytes = _size;
+    format = _format;
+    should_force_safe_hashing = force_safe_hashing;
+  }
+
+  void SetDimensions(unsigned int _native_width, unsigned int _native_height,
+                     unsigned int _native_levels)
+  {
+    native_width = _native_width;
+    native_height = _native_height;
+    native_levels = _native_levels;
+    memory_stride = _native_width;
+  }
+
+  void SetHashes(u64 _base_hash, u64 _hash)
+  {
+    base_hash = _base_hash;
+    hash = _hash;
+  }
+
+  // This texture entry is used by the other entry as a sub-texture
+  void CreateReference(TCacheEntry* other_entry)
+  {
+    // References are two-way, so they can easily be destroyed later
+    this->references.emplace(other_entry);
+    other_entry->references.emplace(this);
+  }
+
+  void SetXfbCopy(u32 stride);
+  void SetEfbCopy(u32 stride);
+  void SetNotCopy();
+
+  bool OverlapsMemoryRange(u32 range_address, u32 range_size) const;
+
+  bool IsEfbCopy() const { return is_efb_copy; }
+  bool IsCopy() const { return is_xfb_copy || is_efb_copy; }
+  u32 NumBlocksY() const;
+  u32 BytesPerRow() const;
+
+  u64 CalculateHash() const;
+
+  int HashSampleSize() const;
+  u32 GetWidth() const;
+  u32 GetHeight() const;
+  u32 GetNumLevels() const;
+  u32 GetNumLayers() const;
+  AbstractTextureFormat GetFormat() const;
+};

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -13,7 +13,7 @@
 #include "Common/MathUtil.h"
 #include "Common/MsgHandler.h"
 #include "VideoCommon/RenderBase.h"
-#include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureCacheBackend.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"
 

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -67,6 +67,8 @@
     <ClCompile Include="RenderState.cpp" />
     <ClCompile Include="LightingShaderGen.cpp" />
     <ClCompile Include="ShaderGenCommon.cpp" />
+    <ClCompile Include="TextureCacheBackend.cpp" />
+    <ClCompile Include="TextureCacheEntry.cpp" />
     <ClCompile Include="UberShaderCommon.cpp" />
     <ClCompile Include="UberShaderPixel.cpp" />
     <ClCompile Include="Statistics.cpp" />
@@ -112,6 +114,8 @@
     <ClInclude Include="Fifo.h" />
     <ClInclude Include="FPSCounter.h" />
     <ClInclude Include="FramebufferManagerBase.h" />
+    <ClInclude Include="TextureCacheBackend.h" />
+    <ClInclude Include="TextureCacheEntry.h" />
     <ClInclude Include="UberShaderCommon.h" />
     <ClInclude Include="UberShaderPixel.h" />
     <ClInclude Include="HiresTextures.h" />

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -173,9 +173,6 @@
     <ClCompile Include="AbstractTexture.cpp">
       <Filter>Base</Filter>
     </ClCompile>
-    <ClCompile Include="AbstractRawTexture.cpp">
-      <Filter>Base</Filter>
-    </ClCompile>
     <ClCompile Include="ShaderGenCommon.cpp">
       <Filter>Shader Generators</Filter>
     </ClCompile>
@@ -190,6 +187,12 @@
     </ClCompile>
     <ClCompile Include="UberShaderVertex.cpp">
       <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureCacheEntry.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureCacheBackend.cpp">
+      <Filter>Base</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -347,9 +350,6 @@
     <ClInclude Include="AbstractTexture.h">
       <Filter>Base</Filter>
     </ClInclude>
-    <ClInclude Include="AbstractRawTexture.h">
-      <Filter>Base</Filter>
-    </ClInclude>
     <ClInclude Include="AsyncShaderCompiler.h">
       <Filter>Util</Filter>
     </ClInclude>
@@ -361,6 +361,12 @@
     </ClInclude>
     <ClInclude Include="UberShaderVertex.h">
       <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureCacheEntry.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureCacheBackend.h">
+      <Filter>Base</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
With Hybrid XFB done, this will be the first PR in my plans to cleanup the texture cache.

The texture cache is made up of three different areas of content:  normal textures, EFBs, and now XFBs.  There are even high res textures.  This works but would be better if they were all split out and shared common code.  The advantages of splitting them out would be:

- **Easier debugging** - looking at a cache's textures, you'd know what type they are.  This would also save some memory/perf because we wouldn't need to check the texture-type.
- **Cleaner code** - by not having all the code in the same location, the code is easier for newcomers to absorb if they're interested in a specific area.
- **Documentation** - with everything together, it's difficult to have separate documentation for each area.  By splitting it up, we can have documentation for each area.  Today, the documentation in Dolphin code is minimal.  But keeping the documentation with the code will help preserve things for future generations.

Step 1 of doing this, is to change the backends from a "is a" to a "has a" relationship with the TextureCacheBase.  This way, the texture cache can be subclassed further into the three types, with common code staying in TextureCacheBase.