### PR TITLE
Game Inis: Additional games requiring 'Immediate Mode' off

### DIFF
--- a/Data/Sys/GameSettings/GZ2.ini
+++ b/Data/Sys/GameSettings/GZ2.ini
@@ -17,3 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/RZD.ini
+++ b/Data/Sys/GameSettings/RZD.ini
@@ -19,3 +19,4 @@ EmulationIssues =
 
 [Video_Hacks]
 EFBAccessEnable = True
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/SOM.ini
+++ b/Data/Sys/GameSettings/SOM.ini
@@ -22,5 +22,6 @@ EmulationIssues =
 [Video_Settings]
 
 [Video_Hacks]
+ImmediateXFBEnable = False
 
 [Video_Enhancements]

--- a/Data/Sys/GameSettings/SX4.ini
+++ b/Data/Sys/GameSettings/SX4.ini
@@ -18,3 +18,4 @@ EmulationIssues = The game randomly freezes.
 # Add action replay cheats here.
 
 [Video_Hacks]
+ImmediateXFBEnable = False


### PR DESCRIPTION
I seem to have missed a few in my original Hybrid XFB PR.  I've added 3 more games to have Immediate Mode off:

- Xenoblade / Twilight Princess which have frame pacing issues
- Rhythm Heaven Fever which seems to have issues in some levels with it on