### PR TITLE
OGL: Fix headless frame dumping

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -54,6 +54,7 @@ GLuint FramebufferManager::CreateTexture(GLenum texture_type, GLenum internal_fo
                                          GLenum pixel_format, GLenum data_type)
 {
   GLuint texture;
+  glActiveTexture(GL_TEXTURE9);
   glGenTextures(1, &texture);
   glBindTexture(texture_type, texture);
   if (texture_type == GL_TEXTURE_2D_ARRAY)

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -12,6 +12,7 @@
 #include "Core/Config/GraphicsSettings.h"
 
 #include "VideoBackends/OGL/FramebufferManager.h"
+#include "VideoBackends/OGL/OGLTexture.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/SamplerCache.h"
 
@@ -121,6 +122,7 @@ void OpenGLPostProcessing::BlitFromTexture(TargetRectangle src, TargetRectangle 
   glBindTexture(GL_TEXTURE_2D_ARRAY, src_texture);
   g_sampler_cache->BindLinearSampler(9);
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+  OGLTexture::SetStage();
 }
 
 void OpenGLPostProcessing::ApplyShader()

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -45,9 +45,11 @@ void SWRenderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_regi
 {
   OSD::DoCallbacks(OSD::CallbackType::OnFrame);
 
-  DrawDebugText();
-
-  SWOGLWindow::s_instance->ShowImage(texture, xfb_region);
+  if (!IsHeadless())
+  {
+    DrawDebugText();
+    SWOGLWindow::s_instance->ShowImage(texture, xfb_region);
+  }
 
   UpdateActiveConfig();
 }

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -600,7 +600,6 @@ void Renderer::DrawScreen(VKTexture* xfb_texture, const EFBRectangle& xfb_region
                        VK_SUBPASS_CONTENTS_INLINE);
 
   // Draw
-  TargetRectangle source_rc = xfb_texture->GetConfig().GetRect();
   BlitScreen(m_swap_chain->GetRenderPass(), GetTargetRectangle(), xfb_region,
              xfb_texture->GetRawTexIdentifier());
 
@@ -702,6 +701,7 @@ void Renderer::CheckForSurfaceChange()
 
     // Notify calling thread.
     m_surface_needs_change.Clear();
+    m_surface_handle = m_new_surface_handle;
     m_new_surface_handle = nullptr;
     m_surface_changed.Set();
   }

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -14,7 +14,7 @@
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 #include <Windows.h>
 #elif defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR) ||                     \
-    defined(VK_USE_PLATFORM_ANDROID_KHR)
+    defined(VK_USE_PLATFORM_ANDROID_KHR) || defined(USE_HEADLESS)
 #include <dlfcn.h>
 #endif
 
@@ -98,7 +98,7 @@ void UnloadVulkanLibrary()
 }
 
 #elif defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR) ||                     \
-    defined(VK_USE_PLATFORM_ANDROID_KHR)
+    defined(VK_USE_PLATFORM_ANDROID_KHR) || defined(USE_HEADLESS)
 
 static void* vulkan_module;
 static std::atomic_int vulkan_module_ref_count = {0};

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -94,6 +94,7 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   if (SConfig::GetInstance().bWii)
     m_aspect_wide = Config::Get(Config::SYSCONF_WIDESCREEN);
 
+  m_surface_handle = Host_GetRenderHandle();
   m_last_host_config_bits = ShaderHostConfig::GetCurrent().bits;
 }
 
@@ -398,6 +399,11 @@ float Renderer::CalculateDrawAspectRatio() const
   {
     return VideoInterface::GetAspectRatio();
   }
+}
+
+bool Renderer::IsHeadless() const
+{
+  return !m_surface_handle;
 }
 
 std::tuple<float, float> Renderer::ScaleToDisplayAspectRatio(const int width,
@@ -711,7 +717,7 @@ void Renderer::DoDumpFrame()
 void Renderer::UpdateFrameDumpTexture()
 {
   int target_width, target_height;
-  if (!g_ActiveConfig.bInternalResolutionFrameDumps)
+  if (!g_ActiveConfig.bInternalResolutionFrameDumps && !IsHeadless())
   {
     auto target_rect = GetTargetRectangle();
     target_width = target_rect.GetWidth();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -94,6 +94,7 @@ public:
 
   const TargetRectangle& GetTargetRectangle() const { return m_target_rectangle; }
   float CalculateDrawAspectRatio() const;
+  bool IsHeadless() const;
 
   std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height) const;
   void UpdateDrawRectangle();
@@ -176,9 +177,10 @@ protected:
 
   static const float GX_MAX_DEPTH;
 
+  void* m_surface_handle = nullptr;
+  void* m_new_surface_handle = nullptr;
   Common::Flag m_surface_needs_change;
   Common::Event m_surface_changed;
-  void* m_new_surface_handle = nullptr;
 
   u32 m_last_host_config_bits = 0;
 


### PR DESCRIPTION
Looks like this was a regression from Hybrid XFB.

Also skips swapping the window system buffers in headless mode, as there may not be a surface which can be swapped in the first place. Instead, we call glFlush() at the end of a frame in this case.