### PR TITLE
FIFOPlayerWindow: don't reset frame/object limit every frame

### DIFF
--- a/Source/Core/DolphinQt2/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt2/FIFOPlayerWindow.cpp
@@ -39,8 +39,12 @@ FIFOPlayerWindow::FIFOPlayerWindow(QWidget* parent) : QDialog(parent)
 
   FifoPlayer::GetInstance().SetFileLoadedCallback(
       [this] { QueueOnObject(this, &FIFOPlayerWindow::OnFIFOLoaded); });
-  FifoPlayer::GetInstance().SetFrameWrittenCallback(
-      [this] { QueueOnObject(this, &FIFOPlayerWindow::OnFIFOLoaded); });
+  FifoPlayer::GetInstance().SetFrameWrittenCallback([this] {
+    QueueOnObject(this, [this] {
+      UpdateInfo();
+      UpdateControls();
+    });
+  });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     if (state == Core::State::Running)


### PR DESCRIPTION
Otherwise, the frame/object limit keeps getting set back to the total number of frames/objects in the FIFO log.