### PR TITLE
UberShaderPixel: Fix the interpolation qualifier for interface blocks.

### DIFF
--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -89,7 +89,7 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
     {
       out.Write("VARYING_LOCATION(0) in VertexData {\n");
       GenerateVSOutputMembers(out, ApiType, numTexgen, per_pixel_lighting,
-                              GetInterpolationQualifier(msaa, ssaa));
+                              GetInterpolationQualifier(msaa, ssaa, true, true));
 
       if (stereo)
         out.Write("  flat int layer;\n");


### PR DESCRIPTION
Fixes MSAA on MacOS with ubershaders enabled.

Specifically the "centroid" qualifier was being used without specifying "centroid in" even though GLSL 420 is not supported. The two added arguments specify that the qualifier being queried is for an input interface block.