### PR TITLE
PixelShaderGen: only use dual-source if bpmem requires dual-src blending

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -135,6 +135,8 @@ void SHADER::SetProgramBindings(bool is_compute)
       // So we do support extended blending
       // So we need to set a few more things here.
       // Bind our out locations
+      // Note: on macOS, this can cause graphical issues if ocol1 exists in the fragment shader but
+      // we're not actually doing dual-source blending.
       glBindFragDataLocationIndexed(glprogid, 0, 0, "ocol0");
       glBindFragDataLocationIndexed(glprogid, 0, 1, "ocol1");
     }

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -44,7 +44,9 @@ struct pixel_shader_uid_data
   u32 rgba6_format : 1;
   u32 dither : 1;
   u32 uint_output : 1;
-  u32 pad : 15;
+  u32 blendEnable : 1;
+  u32 useDualSource : 1;
+  u32 pad : 13;
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;


### PR DESCRIPTION
This fixes [Issue 9373: Depth issues on Mario Kart Double Dash](https://bugs.dolphin-emu.org/issues/9373).

There seems to be some interaction between having `ocol1` in the fragment shader and calling `glBindFragDataLocationIndexed`: removing either one fixes the issue. Adding stronger dual source requirements to the fragment shader seemed like the cleaner option.

Before:

<img width="583" alt="screen shot 2017-11-25 at 2 18 01 pm" src="https://user-images.githubusercontent.com/594093/33235343-a1827308-d1eb-11e7-8d15-5add1ee6384b.png">

After:

<img width="583" alt="screen shot 2017-11-25 at 2 17 32 pm" src="https://user-images.githubusercontent.com/594093/33235344-a51960ee-d1eb-11e7-8382-ef08f5a1396a.png">
