### PR TITLE
WX: Fix argument parsing

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -101,15 +101,14 @@ const std::string& GetSystemName(System system)
   return system_to_name.at(system);
 }
 
-System GetSystemFromName(const std::string& name)
+std::optional<System> GetSystemFromName(const std::string& name)
 {
   const auto system = std::find_if(system_to_name.begin(), system_to_name.end(),
                                    [&name](const auto& entry) { return entry.second == name; });
   if (system != system_to_name.end())
     return system->first;
 
-  _assert_msg_(COMMON, false, "Programming error! Couldn't convert '%s' to system!", name.c_str());
-  return System::Main;
+  return {};
 }
 
 const std::string& GetLayerName(LayerType layer)

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "Common/Config/ConfigInfo.h"
@@ -38,7 +39,7 @@ void Shutdown();
 void ClearCurrentRunLayer();
 
 const std::string& GetSystemName(System system);
-System GetSystemFromName(const std::string& system);
+std::optional<System> GetSystemFromName(const std::string& system);
 const std::string& GetLayerName(LayerType layer);
 LayerType GetActiveLayerForConfig(const ConfigLocation&);
 

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -157,8 +157,9 @@ static ConfigLocation MapINIToRealLocation(const std::string& section, const std
     std::getline(buffer, config_section, '.');
     fail |= buffer.fail();
 
-    if (!fail)
-      return {Config::GetSystemFromName(system_str), config_section, key};
+    const std::optional<Config::System> system = Config::GetSystemFromName(system_str);
+    if (!fail && system)
+      return {*system, config_section, key};
 
     WARN_LOG(CORE, "Unknown game INI option in section %s: %s", section.c_str(), key.c_str());
     return {Config::System::Main, "", ""};

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -165,7 +165,14 @@ bool DolphinApp::OnInit()
 void DolphinApp::ParseCommandLine()
 {
   auto parser = CommandLineParse::CreateParser(CommandLineParse::ParserOptions::IncludeGUIOptions);
-  optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
+
+  // Manually convert each argument to a UTF-8 std::string, because the implicit
+  // conversion of wxCmdLineArgsArray to char** calls ToAscii (which is undesired).
+  std::vector<std::string> utf8_argv;
+  for (int i = 1; i < argc; ++i)
+    utf8_argv.emplace_back(argv[i].utf8_str());
+  optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), utf8_argv);
+
   std::vector<std::string> args = parser->args();
 
   if (options.is_set("exec"))

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -105,17 +105,29 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
   return parser;
 }
 
-optparse::Values& ParseArguments(optparse::OptionParser* parser, int argc, char** argv)
+static void AddConfigLayer(const optparse::Values& options)
 {
-  optparse::Values& options = parser->parse_args(argc, argv);
-
   const std::list<std::string>& config_args = options.all("config");
-  if (config_args.size())
+  if (!config_args.empty())
   {
     Config::AddLayer(std::make_unique<CommandLineConfigLayerLoader>(
         config_args, static_cast<const char*>(options.get("video_backend")),
         static_cast<const char*>(options.get("audio_emulation"))));
   }
+}
+
+optparse::Values& ParseArguments(optparse::OptionParser* parser, int argc, char** argv)
+{
+  optparse::Values& options = parser->parse_args(argc, argv);
+  AddConfigLayer(options);
+  return options;
+}
+
+optparse::Values& ParseArguments(optparse::OptionParser* parser,
+                                 const std::vector<std::string>& arguments)
+{
+  optparse::Values& options = parser->parse_args(arguments);
+  AddConfigLayer(options);
   return options;
 }
 }

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <list>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -40,8 +41,12 @@ public:
       std::getline(buffer, section, '.');
       std::getline(buffer, key, '=');
       std::getline(buffer, value, '=');
-      Config::System system = Config::GetSystemFromName(system_str);
-      m_values.emplace_back(std::make_tuple(Config::ConfigLocation{system, section, key}, value));
+      const std::optional<Config::System> system = Config::GetSystemFromName(system_str);
+      if (system)
+      {
+        m_values.emplace_back(
+            std::make_tuple(Config::ConfigLocation{*system, section, key}, value));
+      }
     }
   }
 

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -107,9 +107,9 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
 
 static void AddConfigLayer(const optparse::Values& options)
 {
-  const std::list<std::string>& config_args = options.all("config");
-  if (!config_args.empty())
+  if (options.is_set_by_user("config"))
   {
+    const std::list<std::string>& config_args = options.all("config");
     Config::AddLayer(std::make_unique<CommandLineConfigLayerLoader>(
         config_args, static_cast<const char*>(options.get("video_backend")),
         static_cast<const char*>(options.get("audio_emulation"))));

--- a/Source/Core/UICommon/CommandLineParse.h
+++ b/Source/Core/UICommon/CommandLineParse.h
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace optparse
 {
@@ -20,4 +22,6 @@ enum class ParserOptions
 
 std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options);
 optparse::Values& ParseArguments(optparse::OptionParser* parser, int argc, char** argv);
+optparse::Values& ParseArguments(optparse::OptionParser* parser,
+                                 const std::vector<std::string>& arguments);
 }


### PR DESCRIPTION
Manually convert each argument to a UTF-8 std::string, because the implicit conversion for `wxCmdLineArgsArray` to `char**` calls `ToAscii` (which is obviously undesired).

Fixes [issue 10274](https://bugs.dolphin-emu.org/issues/10274)