### PR TITLE
Don't forcibly enable immediate XFB in game INIs

### DIFF
--- a/Data/Sys/GameSettings/GAL.ini
+++ b/Data/Sys/GameSettings/GAL.ini
@@ -19,6 +19,3 @@ EmulationIssues =
 
 [Video_Stereoscopy]
 StereoConvergence = 64
-
-[Video_Hacks]
-ImmediateXFBEnable = True

--- a/Data/Sys/GameSettings/GP5.ini
+++ b/Data/Sys/GameSettings/GP5.ini
@@ -19,6 +19,3 @@ EmulationIssues =
 
 [Video_Hacks]
 EFBToTextureEnable = False
-
-[Video_Hacks]
-ImmediateXFBEnable = True

--- a/Data/Sys/GameSettings/RF7.ini
+++ b/Data/Sys/GameSettings/RF7.ini
@@ -16,6 +16,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = True

--- a/Data/Sys/GameSettings/RSB.ini
+++ b/Data/Sys/GameSettings/RSB.ini
@@ -19,6 +19,3 @@ EmulationIssues = Classic mode score report needs real xfb. Nes masterpieces and
 
 [Video_Stereoscopy]
 StereoConvergence = 136
-
-[Video_Hacks]
-ImmediateXFBEnable = True

--- a/Data/Sys/GameSettings/STK.ini
+++ b/Data/Sys/GameSettings/STK.ini
@@ -16,6 +16,3 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = True


### PR DESCRIPTION
Forcing people to use hacks is a bad idea in general, and there are two practical problems with doing it for immediate XFB in particular:

1. It breaks the GC IPL, which some users run when launching games.

2. Competitive players don't necessarily want the lowest possible latency – they might want the latency that's the closest to console, so if they're playing locally with a low-latency monitor, they might not want to use immediate XFB. (This isn't a theoretical concern – I've seen Melee players want to increase their latency.)

Besides, it feels arbitrary that just these five specific games should have immediate XFB forced on.