### PR TITLE
Android: Implement user game-specific settings overrides.

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -96,7 +96,6 @@ dependencies {
 
     // Allows FRP-style asynchronous operations in Android.
     implementation 'io.reactivex:rxandroid:1.2.1'
-
     implementation 'com.nononsenseapps:filepicker:4.1.0'
 }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.content.res.AssetManager;
 import android.view.Surface;
 import android.widget.Toast;
 
@@ -230,6 +231,12 @@ public final class NativeLibrary
 	 * @param Value  The value of the axis represented by the given ID.
 	 */
 	public static native void onGamePadMoveEvent(String Device, int Axis, float Value);
+
+	public static native String GetUserSetting(String gameID, String Section, String Key);
+
+	public static native void SetUserSetting(String gameID, String Section, String Key, String Value);
+
+	public static native void InitGameIni(String gameID);
 
 	/**
 	 * Gets a value from a key in the given ini-based config file.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -1,5 +1,7 @@
 package org.dolphinemu.dolphinemu.adapters;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.database.Cursor;
 import android.database.DataSetObserver;
 import android.graphics.Rect;
@@ -8,14 +10,19 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
-import org.dolphinemu.dolphinemu.dialogs.GameDetailsDialog;
 import org.dolphinemu.dolphinemu.model.GameDatabase;
+import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
+import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.Log;
 import org.dolphinemu.dolphinemu.utils.PicassoUtils;
+import org.dolphinemu.dolphinemu.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.viewholders.GameViewHolder;
+
+import java.io.File;
 
 /**
  * This adapter gets its information from a database Cursor. This fact, paired with the usage of
@@ -222,17 +229,46 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 		GameViewHolder holder = (GameViewHolder) view.getTag();
 
 		// Get the ID of the game we want to look at.
-		// TODO This should be all we need to pass in, eventually.
-		// String gameId = (String) holder.gameId;
+		String gameId = (String) holder.gameId;
 
 		FragmentActivity activity = (FragmentActivity) view.getContext();
-		GameDetailsDialog.newInstance(holder.title,
-				holder.description,
-				holder.country,
-				holder.company,
-				holder.path,
-				holder.screenshotPath).show(activity.getSupportFragmentManager(), "game_details");
 
+
+		AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+		builder.setTitle("Game Settings")
+			.setItems(R.array.gameSettingsMenus, new DialogInterface.OnClickListener() {
+				public void onClick(DialogInterface dialog, int which) {
+					switch (which) {
+						case 0:
+							SettingsActivity.launch(activity, SettingsFile.FILE_NAME_DOLPHIN, gameId);
+							break;
+						case 1:
+							SettingsActivity.launch(activity, SettingsFile.FILE_NAME_GFX, gameId);
+							break;
+						case 2:
+							String path = DirectoryInitializationService.getUserDirectory() + "/GameSettings/" + gameId + ".ini";
+							File gameSettingsFile = new File(path);
+							if (gameSettingsFile.exists())
+							{
+								if (gameSettingsFile.delete())
+								{
+									Toast.makeText(view.getContext(), "Cleared settings for " + gameId, Toast.LENGTH_SHORT).show();
+								}
+								else
+								{
+									Toast.makeText(view.getContext(), "Unable to clear settings for " + gameId, Toast.LENGTH_SHORT).show();
+								}
+							}
+							else
+							{
+								Toast.makeText(view.getContext(), "No game settings to delete", Toast.LENGTH_SHORT).show();
+							}
+							break;
+					}
+				}
+			});
+
+		builder.show();
 		return true;
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -1,17 +1,27 @@
 package org.dolphinemu.dolphinemu.adapters;
 
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.graphics.drawable.Drawable;
 import android.support.v17.leanback.widget.ImageCardView;
 import android.support.v17.leanback.widget.Presenter;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.Game;
+import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
+import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.PicassoUtils;
+import org.dolphinemu.dolphinemu.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.viewholders.TvGameViewHolder;
+
+import java.io.File;
 
 /**
  * The Leanback library / docs call this a Presenter, but it works very
@@ -78,7 +88,53 @@ public final class GameRowPresenter extends Presenter
 		Context context = holder.cardParent.getContext();
 		Drawable background = ContextCompat.getDrawable(context, backgroundId);
 		holder.cardParent.setInfoAreaBackground(background);
+		holder.cardParent.setOnLongClickListener(new View.OnLongClickListener() {
+			@Override
+			public boolean onLongClick(View view)
+			{
+				FragmentActivity activity = (FragmentActivity) view.getContext();
+
+
+				AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+				builder.setTitle("Game Settings")
+					.setItems(R.array.gameSettingsMenus, new DialogInterface.OnClickListener() {
+						public void onClick(DialogInterface dialog, int which) {
+							switch (which) {
+								case 0:
+									SettingsActivity.launch(activity, SettingsFile.FILE_NAME_DOLPHIN, game.getGameId());
+									break;
+								case 1:
+									SettingsActivity.launch(activity, SettingsFile.FILE_NAME_GFX, game.getGameId());
+									break;
+								case 2:
+									String path = DirectoryInitializationService.getUserDirectory() + "/GameSettings/" + game.getGameId() + ".ini";
+									File gameSettingsFile = new File(path);
+									if (gameSettingsFile.exists())
+									{
+										if (gameSettingsFile.delete())
+										{
+											Toast.makeText(view.getContext(), "Cleared settings for " + game.getGameId(), Toast.LENGTH_SHORT).show();
+										}
+										else
+										{
+											Toast.makeText(view.getContext(), "Unable to clear settings for " + game.getGameId(), Toast.LENGTH_SHORT).show();
+										}
+									}
+									else
+									{
+										Toast.makeText(view.getContext(), "No game settings to delete", Toast.LENGTH_SHORT).show();
+									}
+									break;
+							}
+						}
+					});
+
+				builder.show();
+				return true;
+			}
+		});
 	}
+
 
 	@Override
 	public void onUnbindViewHolder(ViewHolder viewHolder)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -129,7 +129,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
 	@Override
 	public void launchSettingsActivity(String menuTag)
 	{
-		SettingsActivity.launch(this, menuTag);
+		SettingsActivity.launch(this, menuTag, "");
 	}
 
 	@Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -123,7 +123,7 @@ public final class TvMainActivity extends FragmentActivity implements MainView
 	@Override
 	public void launchSettingsActivity(String menuTag)
 	{
-		SettingsActivity.launch(this, menuTag);
+		SettingsActivity.launch(this, menuTag, "");
 	}
 
 	@Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
@@ -18,6 +18,7 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.settings.SettingSection;
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
+import org.dolphinemu.dolphinemu.utils.Log;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,15 +26,19 @@ import java.util.HashMap;
 public final class SettingsActivity extends AppCompatActivity implements SettingsActivityView
 {
 	private static final String ARG_FILE_NAME = "file_name";
+	private static final String ARG_GAME_ID = "game_id";
+
 	private static final String FRAGMENT_TAG = "settings";
 	private SettingsActivityPresenter mPresenter = new SettingsActivityPresenter(this);
 
 	private ProgressDialog dialog;
 
-	public static void launch(Context context, String menuTag)
+	public static void launch(Context context, String menuTag, String gameId)
 	{
 		Intent settings = new Intent(context, SettingsActivity.class);
 		settings.putExtra(ARG_FILE_NAME, menuTag);
+		settings.putExtra(ARG_GAME_ID, gameId);
+
 		context.startActivity(settings);
 	}
 
@@ -46,8 +51,9 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
 		Intent launcher = getIntent();
 		String filename = launcher.getStringExtra(ARG_FILE_NAME);
+		String gameID = launcher.getStringExtra(ARG_GAME_ID);
 
-		mPresenter.onCreate(savedInstanceState, filename);
+		mPresenter.onCreate(savedInstanceState, filename, gameID);
 	}
 
 	@Override
@@ -101,7 +107,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
 
 	@Override
-	public void showSettingsFragment(String menuTag, boolean addToStack)
+	public void showSettingsFragment(String menuTag, boolean addToStack, String gameID)
 	{
 		FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
@@ -119,7 +125,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 			transaction.addToBackStack(null);
 			mPresenter.addToStack();
 		}
-		transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag), FRAGMENT_TAG);
+		transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag, gameID), FRAGMENT_TAG);
 
 		transaction.commit();
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
@@ -19,7 +19,7 @@ public interface SettingsActivityView
 	 * @param menuTag    Identifier for the settings group that should be displayed.
 	 * @param addToStack Whether or not this fragment should replace a previous one.
 	 */
-	void showSettingsFragment(String menuTag, boolean addToStack);
+	void showSettingsFragment(String menuTag, boolean addToStack, String gameId);
 
 	/**
 	 * Called by a contained Fragment to get access to the Setting HashMap

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragment.java
@@ -24,18 +24,20 @@ import java.util.HashMap;
 public final class SettingsFragment extends Fragment implements SettingsFragmentView
 {
 	private static final String ARGUMENT_MENU_TAG = "menu_tag";
+	private static final String ARGUMENT_GAME_ID = "game_id";
 
 	private SettingsFragmentPresenter mPresenter = new SettingsFragmentPresenter(this);
 	private SettingsActivityView mActivity;
 
 	private SettingsAdapter mAdapter;
 
-	public static Fragment newInstance(String menuTag)
+	public static Fragment newInstance(String menuTag, String gameId)
 	{
 		SettingsFragment fragment = new SettingsFragment();
 
 		Bundle arguments = new Bundle();
 		arguments.putString(ARGUMENT_MENU_TAG, menuTag);
+		arguments.putString(ARGUMENT_GAME_ID, gameId);
 
 		fragment.setArguments(arguments);
 		return fragment;
@@ -71,10 +73,11 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 
 		setRetainInstance(true);
 		String menuTag = getArguments().getString(ARGUMENT_MENU_TAG);
+		String gameId = getArguments().getString(ARGUMENT_GAME_ID);
 
 		mAdapter = new SettingsAdapter(this, getActivity());
 
-		mPresenter.onCreate(menuTag);
+		mPresenter.onCreate(menuTag, gameId);
 	}
 
 	@Nullable
@@ -147,7 +150,7 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 	@Override
 	public void loadSubMenu(String menuKey)
 	{
-		mActivity.showSettingsFragment(menuKey, true);
+		mActivity.showSettingsFragment(menuKey, true, getArguments().getString(ARGUMENT_GAME_ID));
 	}
 
 	@Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -1,5 +1,7 @@
 package org.dolphinemu.dolphinemu.ui.settings;
 
+import android.text.TextUtils;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.settings.BooleanSetting;
@@ -25,6 +27,7 @@ public final class SettingsFragmentPresenter
 	private SettingsFragmentView mView;
 
 	private String mMenuTag;
+	private String mGameID;
 
 	private ArrayList<HashMap<String, SettingSection>> mSettings;
 	private ArrayList<SettingsItem> mSettingsList;
@@ -37,8 +40,10 @@ public final class SettingsFragmentPresenter
 		mView = view;
 	}
 
-	public void onCreate(String menuTag)
+	public void onCreate(String menuTag, String gameId)
 	{
+		mGameID = gameId;
+
 		if (menuTag.startsWith(SettingsFile.KEY_GCPAD_TYPE))
 		{
 			mMenuTag = SettingsFile.KEY_GCPAD_TYPE;
@@ -106,6 +111,10 @@ public final class SettingsFragmentPresenter
 
 	private void loadSettingsList()
 	{
+		if (!TextUtils.isEmpty(mGameID))
+		{
+			mView.getActivity().setTitle("Game Settings: " + mGameID);
+		}
 		ArrayList<SettingsItem> sl = new ArrayList<>();
 
 		switch (mMenuTag)
@@ -151,7 +160,7 @@ public final class SettingsFragmentPresenter
 				break;
 
 			default:
-				mView.showToastMessage("Unimplemented menu.");
+				mView.showToastMessage("Unimplemented menu");
 				return;
 		}
 

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -286,4 +286,9 @@
         <item>Right Stick</item>
     </string-array>
 
+    <string-array name="gameSettingsMenus">
+        <item>Core Settings</item>
+        <item>GFX Settings</item>
+        <item>Clear Game Settings</item>
+    </string-array>
 </resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -211,6 +211,7 @@
     <!-- Preferences Screen -->
     <string name="preferences_save_exit">Save and Exit</string>
     <string name="preferences_settings">Settings</string>
+    <string name="preferences_game_settings">Game Settings</string>
     <string name="preferences_extensions">Extension Bindings</string>
 
     <!-- Emulation Menu -->
@@ -247,9 +248,7 @@
     <string name="header_controllers">Controllers</string>
 
     <string name="write_permission_needed">You need to allow write access to external storage for the emulator to work</string>
-
     <string name="load_settings">Loading Settings...</string>
-
     <string name="emulation_change_disc">Change Disc</string>
 
     <string name="external_storage_not_mounted">The external storage needs to be available in order to use Dolphin</string>


### PR DESCRIPTION
Holding off on fully implementing cheats for now (keeping the tabbed layout so that it's easier to add later on). This enables feature parity with desktop in terms of settings things like dual-core, and in fact has more options compared to WxWidgets/Qt does, since it's using the existing settings activity.

## Screenshot
![Popup Menu](http://i.imgur.com/yr3TdsH.png)
![Screenshot](http://i.imgur.com/g545UjD.png)