### PR TITLE
D3D/VertexManager: Add missing includes

### DIFF
--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -5,7 +5,11 @@
 #pragma once
 
 #include <d3d11.h>
+
+#include <array>
 #include <memory>
+#include <vector>
+
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexManagerBase.h"
 


### PR DESCRIPTION
Prevents things spontaneously breaking in the future if indirect includes are broken