### PR TITLE
 VKTexture: Remove unimplemented ScaleRectangleFromTexture() prototype

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -30,8 +30,7 @@ public:
   void ScaleRectangleFromTexture(const AbstractTexture* source,
                                  const MathUtil::Rectangle<int>& src_rect,
                                  const MathUtil::Rectangle<int>& dst_rect);
-  void ScaleRectangleFromTexture(Texture2D* src_texture, const MathUtil::Rectangle<int>& src_rect,
-                                 const MathUtil::Rectangle<int>& dst_rect);
+
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;
 

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -29,7 +29,7 @@ public:
                                 u32 dst_layer, u32 dst_level) override;
   void ScaleRectangleFromTexture(const AbstractTexture* source,
                                  const MathUtil::Rectangle<int>& src_rect,
-                                 const MathUtil::Rectangle<int>& dst_rect);
+                                 const MathUtil::Rectangle<int>& dst_rect) override;
 
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;


### PR DESCRIPTION
Prevents a potential linker error in the future, and also enforces the virtual signature on the other overriding prototype.