### PR TITLE
Fix Wiimote support on macOS 10.13 High Sierra

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
@@ -13,10 +13,12 @@ class WiimoteScannerDarwin final : public WiimoteScannerBackend
 {
 public:
   WiimoteScannerDarwin() = default;
-  ~WiimoteScannerDarwin() override = default;
+  ~WiimoteScannerDarwin() override;
   bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}  // not needed
+private:
+  bool stopScanning = false;
 };
 }
 

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -54,7 +54,7 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
 
   do
   {
-    CFRunLoopRun();
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
   } while (!sbt->done);
 
   int found_devices = [[bti foundDevices] count];
@@ -255,7 +255,6 @@ void WiimoteDarwin::DisablePowerAssertionInternal()
                       aborted:(BOOL)aborted
 {
   done = true;
-  CFRunLoopStop(CFRunLoopGetCurrent());
 }
 
 - (void)deviceInquiryDeviceFound:(IOBluetoothDeviceInquiry*)sender device:(IOBluetoothDevice*)device

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -21,6 +21,11 @@
 
 namespace WiimoteReal
 {
+WiimoteScannerDarwin::~WiimoteScannerDarwin() 
+{
+	stopScanning = true;
+}
+	
 void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
                                         Wiimote*& found_board)
 {
@@ -55,7 +60,7 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   do
   {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
-  } while (!sbt->done);
+  } while (!sbt->done && !stopScanning);
 
   int found_devices = [[bti foundDevices] count];
 

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -21,11 +21,11 @@
 
 namespace WiimoteReal
 {
-WiimoteScannerDarwin::~WiimoteScannerDarwin() 
+WiimoteScannerDarwin::~WiimoteScannerDarwin()
 {
-	stopScanning = true;
+  stopScanning = true;
 }
-	
+
 void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
                                         Wiimote*& found_board)
 {


### PR DESCRIPTION
-[deviceInquiryComplete:error:aborted:] comes in on the main thread in macOS 10.13, so instead of using CFRunLoopRun()/CFRunLoopStop(), just let the run loop do one pass while waiting for "done" to be true. This also means -[deviceInquiryComplete:error:aborted:] should no longer call CFRunLoopStop(). Fixes connecting to Wiimotes in macOS 10.13+, and should continue to work as before in 10.12 and below.