### PR TITLE
OGL/TextureConverter: Resolve -Wmissing-variable-declaration warnings

### DIFF
--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -34,19 +34,22 @@ namespace TextureConverter
 {
 using OGL::TextureCache;
 
-std::unique_ptr<AbstractTexture> s_encoding_render_texture;
-std::unique_ptr<AbstractStagingTexture> s_encoding_readback_texture;
-
-const int renderBufferWidth = EFB_WIDTH * 4;
-const int renderBufferHeight = 1024;
-
+namespace
+{
 struct EncodingProgram
 {
   SHADER program;
   GLint copy_position_uniform;
   GLint y_scale_uniform;
 };
-static std::map<EFBCopyParams, EncodingProgram> s_encoding_programs;
+
+std::map<EFBCopyParams, EncodingProgram> s_encoding_programs;
+std::unique_ptr<AbstractTexture> s_encoding_render_texture;
+std::unique_ptr<AbstractStagingTexture> s_encoding_readback_texture;
+
+const int renderBufferWidth = EFB_WIDTH * 4;
+const int renderBufferHeight = 1024;
+}
 
 static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyParams& params)
 {

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -32,8 +32,6 @@ namespace OGL
 {
 namespace TextureConverter
 {
-using OGL::TextureCache;
-
 namespace
 {
 struct EncodingProgram


### PR DESCRIPTION
This warning was caused by `s_encoding_render_texture` and `s_encoding_readback_texture` not being within an anonymous namespace or not having a `static` specifier on them (since there's no pre-existing `extern` for them anywhere).