### PR TITLE
[Android] Add support for true analog triggers.

### DIFF
--- a/Source/Android/app/src/main/assets/GCPadNew.ini
+++ b/Source/Android/app/src/main/assets/GCPadNew.ini
@@ -22,6 +22,8 @@ C-Stick/Right = `Axis 19`
 C-Stick/Radius = 100,000000
 Triggers/L = `Axis 20`
 Triggers/R = `Axis 21`
+Triggers/L-Analog = `Axis 20`
+Triggers/R-Analog = `Axis 21`
 Triggers/Threshold = 90,000000
 [GCPad2]
 Device = Android/1/Touchscreen
@@ -47,6 +49,8 @@ C-Stick/Right = `Axis 19`
 C-Stick/Radius = 100,000000
 Triggers/L = `Axis 20`
 Triggers/R = `Axis 21`
+Triggers/L-Analog = `Axis 20`
+Triggers/R-Analog = `Axis 21`
 Triggers/Threshold = 90,000000
 [GCPad3]
 Device = Android/2/Touchscreen
@@ -72,6 +76,8 @@ C-Stick/Right = `Axis 19`
 C-Stick/Radius = 100,000000
 Triggers/L = `Axis 20`
 Triggers/R = `Axis 21`
+Triggers/L-Analog = `Axis 20`
+Triggers/R-Analog = `Axis 21`
 Triggers/Threshold = 90,000000
 [GCPad4]
 Device = Android/3/Touchscreen
@@ -97,4 +103,6 @@ C-Stick/Right = `Axis 19`
 C-Stick/Radius = 100,000000
 Triggers/L = `Axis 20`
 Triggers/R = `Axis 21`
+Triggers/L-Analog = `Axis 20`
+Triggers/R-Analog = `Axis 21`
 Triggers/Threshold = 90,000000


### PR DESCRIPTION
This only works if GCPadNew.ini and Dolphin.ini files are not already in the dolphin config folder. Any advice would be helpful. I'd really like to tackle the UI and wiring for deadzones, radius, etc.