### PR TITLE
DolphinWX: Resolve missing declaration warnings

### DIFF
--- a/Source/Core/DolphinWX/UINeedsControllerState.cpp
+++ b/Source/Core/DolphinWX/UINeedsControllerState.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/UINeedsControllerState.h"
+
 #include <atomic>
 
 static std::atomic<bool> s_needs_controller_state{false};


### PR DESCRIPTION
Without the include, the prototypes of the functions can't be found

Silences -Wmissing-declaration warnings