### PR TITLE
Vulkan: Fix MSAA regression from 5.0-5968

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -318,17 +318,15 @@ void FramebufferManager::DestroyEFBFramebuffer()
   m_efb_resolve_depth_texture.reset();
 }
 
-void FramebufferManager::ResizeEFBTextures()
+void FramebufferManager::RecreateEFBFramebuffer()
 {
   DestroyEFBFramebuffer();
-  if (!CreateEFBFramebuffer())
-    PanicAlert("Failed to create EFB textures");
-}
 
-void FramebufferManager::RecreateRenderPass()
-{
   if (!CreateEFBRenderPasses())
     PanicAlert("Failed to create EFB render pass");
+
+  if (!CreateEFBFramebuffer())
+    PanicAlert("Failed to create EFB textures");
 }
 
 void FramebufferManager::RecompileShaders()

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -164,7 +164,7 @@ bool FramebufferManager::CreateEFBFramebuffer()
   INFO_LOG(VIDEO, "EFB size: %ux%ux%u", efb_width, efb_height, efb_layers);
 
   // Update the static variable in the base class. Why does this even exist?
-  FramebufferManagerBase::m_EFBLayers = g_ActiveConfig.iMultisamples;
+  FramebufferManagerBase::m_EFBLayers = efb_layers;
 
   // Allocate EFB render targets
   m_efb_color_texture =

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -40,14 +40,12 @@ FramebufferManager::FramebufferManager()
 FramebufferManager::~FramebufferManager()
 {
   DestroyEFBFramebuffer();
-  DestroyEFBRenderPass();
 
   DestroyConversionShaders();
 
   DestroyReadbackFramebuffer();
   DestroyReadbackTextures();
   DestroyReadbackShaders();
-  DestroyReadbackRenderPasses();
 
   DestroyPokeVertexBuffer();
   DestroyPokeShaders();
@@ -88,7 +86,7 @@ MultisamplingState FramebufferManager::GetEFBMultisamplingState() const
 
 bool FramebufferManager::Initialize()
 {
-  if (!CreateEFBRenderPass())
+  if (!CreateEFBRenderPasses())
   {
     PanicAlert("Failed to create EFB render pass");
     return false;
@@ -142,108 +140,18 @@ bool FramebufferManager::Initialize()
   return true;
 }
 
-bool FramebufferManager::CreateEFBRenderPass()
+bool FramebufferManager::CreateEFBRenderPasses()
 {
-  VkSampleCountFlagBits samples = static_cast<VkSampleCountFlagBits>(g_ActiveConfig.iMultisamples);
-
-  // render pass for rendering to the efb
-  VkAttachmentDescription attachments[] = {
-      {0, EFB_COLOR_TEXTURE_FORMAT, samples, VK_ATTACHMENT_LOAD_OP_LOAD,
-       VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-       VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-       VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
-      {0, EFB_DEPTH_TEXTURE_FORMAT, samples, VK_ATTACHMENT_LOAD_OP_LOAD,
-       VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-       VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-       VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL}};
-
-  VkAttachmentReference color_attachment_references[] = {
-      {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL}};
-
-  VkAttachmentReference depth_attachment_reference = {
-      1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
-
-  VkSubpassDescription subpass_description = {
-      0,       VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, color_attachment_references,
-      nullptr, &depth_attachment_reference,     0, nullptr};
-
-  VkRenderPassCreateInfo pass_info = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
-                                      nullptr,
-                                      0,
-                                      static_cast<u32>(ArraySize(attachments)),
-                                      attachments,
-                                      1,
-                                      &subpass_description,
-                                      0,
-                                      nullptr};
-
-  VkResult res = vkCreateRenderPass(g_vulkan_context->GetDevice(), &pass_info, nullptr,
-                                    &m_efb_load_render_pass);
-  if (res != VK_SUCCESS)
-  {
-    LOG_VULKAN_ERROR(res, "vkCreateRenderPass (EFB) failed: ");
-    return false;
-  }
-
-  // render pass for clearing color/depth on load, as opposed to loading it
-  attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-  attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-  res = vkCreateRenderPass(g_vulkan_context->GetDevice(), &pass_info, nullptr,
-                           &m_efb_clear_render_pass);
-  if (res != VK_SUCCESS)
-  {
-    LOG_VULKAN_ERROR(res, "vkCreateRenderPass (EFB) failed: ");
-    return false;
-  }
-
-  // render pass for resolving depth, since we can't do it with vkCmdResolveImage
-  if (g_ActiveConfig.MultisamplingEnabled())
-  {
-    VkAttachmentDescription resolve_attachment = {0,
-                                                  EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT,
-                                                  VK_SAMPLE_COUNT_1_BIT,
-                                                  VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                                  VK_ATTACHMENT_STORE_OP_STORE,
-                                                  VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                                  VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                                                  VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-                                                  VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-
-    subpass_description.pDepthStencilAttachment = nullptr;
-    pass_info.pAttachments = &resolve_attachment;
-    pass_info.attachmentCount = 1;
-    res = vkCreateRenderPass(g_vulkan_context->GetDevice(), &pass_info, nullptr,
-                             &m_depth_resolve_render_pass);
-
-    if (res != VK_SUCCESS)
-    {
-      LOG_VULKAN_ERROR(res, "vkCreateRenderPass (EFB depth resolve) failed: ");
-      return false;
-    }
-  }
-
-  return true;
-}
-
-void FramebufferManager::DestroyEFBRenderPass()
-{
-  if (m_efb_load_render_pass != VK_NULL_HANDLE)
-  {
-    vkDestroyRenderPass(g_vulkan_context->GetDevice(), m_efb_load_render_pass, nullptr);
-    m_efb_load_render_pass = VK_NULL_HANDLE;
-  }
-
-  if (m_efb_clear_render_pass != VK_NULL_HANDLE)
-  {
-    vkDestroyRenderPass(g_vulkan_context->GetDevice(), m_efb_clear_render_pass, nullptr);
-    m_efb_clear_render_pass = VK_NULL_HANDLE;
-  }
-
-  if (m_depth_resolve_render_pass != VK_NULL_HANDLE)
-  {
-    vkDestroyRenderPass(g_vulkan_context->GetDevice(), m_depth_resolve_render_pass, nullptr);
-    m_depth_resolve_render_pass = VK_NULL_HANDLE;
-  }
+  m_efb_load_render_pass =
+      g_object_cache->GetRenderPass(EFB_COLOR_TEXTURE_FORMAT, EFB_DEPTH_TEXTURE_FORMAT,
+                                    g_ActiveConfig.iMultisamples, VK_ATTACHMENT_LOAD_OP_LOAD);
+  m_efb_clear_render_pass =
+      g_object_cache->GetRenderPass(EFB_COLOR_TEXTURE_FORMAT, EFB_DEPTH_TEXTURE_FORMAT,
+                                    g_ActiveConfig.iMultisamples, VK_ATTACHMENT_LOAD_OP_CLEAR);
+  m_depth_resolve_render_pass = g_object_cache->GetRenderPass(
+      EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT, VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
+  return m_efb_load_render_pass != VK_NULL_HANDLE && m_efb_clear_render_pass != VK_NULL_HANDLE &&
+         m_depth_resolve_render_pass != VK_NULL_HANDLE;
 }
 
 bool FramebufferManager::CreateEFBFramebuffer()
@@ -419,9 +327,7 @@ void FramebufferManager::ResizeEFBTextures()
 
 void FramebufferManager::RecreateRenderPass()
 {
-  DestroyEFBRenderPass();
-
-  if (!CreateEFBRenderPass())
+  if (!CreateEFBRenderPasses())
     PanicAlert("Failed to create EFB render pass");
 }
 
@@ -849,62 +755,12 @@ void FramebufferManager::InvalidatePeekCache()
 
 bool FramebufferManager::CreateReadbackRenderPasses()
 {
-  VkAttachmentDescription copy_attachment = {
-      0,                                         // VkAttachmentDescriptionFlags    flags
-      EFB_COLOR_TEXTURE_FORMAT,                  // VkFormat                        format
-      VK_SAMPLE_COUNT_1_BIT,                     // VkSampleCountFlagBits           samples
-      VK_ATTACHMENT_LOAD_OP_DONT_CARE,           // VkAttachmentLoadOp              loadOp
-      VK_ATTACHMENT_STORE_OP_STORE,              // VkAttachmentStoreOp             storeOp
-      VK_ATTACHMENT_LOAD_OP_DONT_CARE,           // VkAttachmentLoadOp              stencilLoadOp
-      VK_ATTACHMENT_STORE_OP_DONT_CARE,          // VkAttachmentStoreOp             stencilStoreOp
-      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,  // VkImageLayout                   initialLayout
-      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL   // VkImageLayout                   finalLayout
-  };
-  VkAttachmentReference copy_attachment_ref = {
-      0,                                        // uint32_t         attachment
-      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL  // VkImageLayout    layout
-  };
-  VkSubpassDescription copy_subpass = {
-      0,                                // VkSubpassDescriptionFlags       flags
-      VK_PIPELINE_BIND_POINT_GRAPHICS,  // VkPipelineBindPoint             pipelineBindPoint
-      0,                                // uint32_t                        inputAttachmentCount
-      nullptr,                          // const VkAttachmentReference*    pInputAttachments
-      1,                                // uint32_t                        colorAttachmentCount
-      &copy_attachment_ref,             // const VkAttachmentReference*    pColorAttachments
-      nullptr,                          // const VkAttachmentReference*    pResolveAttachments
-      nullptr,                          // const VkAttachmentReference*    pDepthStencilAttachment
-      0,                                // uint32_t                        preserveAttachmentCount
-      nullptr                           // const uint32_t*                 pPreserveAttachments
-  };
-  VkRenderPassCreateInfo copy_pass = {
-      VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,  // VkStructureType                   sType
-      nullptr,                                    // const void*                       pNext
-      0,                                          // VkRenderPassCreateFlags           flags
-      1,                 // uint32_t                          attachmentCount
-      &copy_attachment,  // const VkAttachmentDescription*    pAttachments
-      1,                 // uint32_t                          subpassCount
-      &copy_subpass,     // const VkSubpassDescription*       pSubpasses
-      0,                 // uint32_t                          dependencyCount
-      nullptr            // const VkSubpassDependency*        pDependencies
-  };
-
-  VkResult res = vkCreateRenderPass(g_vulkan_context->GetDevice(), &copy_pass, nullptr,
-                                    &m_copy_color_render_pass);
-  if (res != VK_SUCCESS)
-  {
-    LOG_VULKAN_ERROR(res, "vkCreateRenderPass failed: ");
+  m_copy_color_render_pass = g_object_cache->GetRenderPass(
+      EFB_COLOR_TEXTURE_FORMAT, VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
+  m_copy_depth_render_pass = g_object_cache->GetRenderPass(
+      EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT, VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
+  if (m_copy_color_render_pass == VK_NULL_HANDLE || m_copy_depth_render_pass == VK_NULL_HANDLE)
     return false;
-  }
-
-  // Depth is similar to copy, just a different format.
-  copy_attachment.format = EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT;
-  res = vkCreateRenderPass(g_vulkan_context->GetDevice(), &copy_pass, nullptr,
-                           &m_copy_depth_render_pass);
-  if (res != VK_SUCCESS)
-  {
-    LOG_VULKAN_ERROR(res, "vkCreateRenderPass failed: ");
-    return false;
-  }
 
   // Some devices don't support point sizes >1 (e.g. Adreno).
   // If we can't use a point size above our maximum IR, use triangles instead.
@@ -923,20 +779,6 @@ bool FramebufferManager::CreateReadbackRenderPasses()
   }
 
   return true;
-}
-
-void FramebufferManager::DestroyReadbackRenderPasses()
-{
-  if (m_copy_color_render_pass != VK_NULL_HANDLE)
-  {
-    vkDestroyRenderPass(g_vulkan_context->GetDevice(), m_copy_color_render_pass, nullptr);
-    m_copy_color_render_pass = VK_NULL_HANDLE;
-  }
-  if (m_copy_depth_render_pass != VK_NULL_HANDLE)
-  {
-    vkDestroyRenderPass(g_vulkan_context->GetDevice(), m_copy_depth_render_pass, nullptr);
-    m_copy_depth_render_pass = VK_NULL_HANDLE;
-  }
 }
 
 bool FramebufferManager::CompileReadbackShaders()

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -529,6 +529,8 @@ Texture2D* FramebufferManager::ResolveEFBDepthTexture(const VkRect2D& region)
 
   m_efb_depth_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+  m_efb_resolve_depth_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                                  VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
   // Draw using resolve shader to write the minimum depth of all samples to the resolve texture.
   UtilityShaderDraw draw(g_command_buffer_mgr->GetCurrentCommandBuffer(),
@@ -546,8 +548,6 @@ Texture2D* FramebufferManager::ResolveEFBDepthTexture(const VkRect2D& region)
   m_efb_depth_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                           VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 
-  // Render pass transitions to shader resource.
-  m_efb_resolve_depth_texture->OverrideImageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
   return m_efb_resolve_depth_texture.get();
 }
 

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -621,6 +621,9 @@ bool FramebufferManager::PopulateColorReadbackTexture()
 
   if (GetEFBWidth() != EFB_WIDTH || GetEFBHeight() != EFB_HEIGHT)
   {
+    // Transition EFB to shader read before drawing.
+    src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     m_color_copy_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
@@ -631,10 +634,6 @@ bool FramebufferManager::PopulateColorReadbackTexture()
 
     VkRect2D rect = {{0, 0}, {EFB_WIDTH, EFB_HEIGHT}};
     draw.BeginRenderPass(m_color_copy_framebuffer, rect);
-
-    // Transition EFB to shader read before drawing.
-    src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
-                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     draw.SetPSSampler(0, src_texture->GetView(), g_object_cache->GetPointSampler());
     draw.SetViewportAndScissor(0, 0, EFB_WIDTH, EFB_HEIGHT);
     draw.DrawWithoutVertexBuffer(4);
@@ -697,6 +696,9 @@ bool FramebufferManager::PopulateDepthReadbackTexture()
   }
   if (GetEFBWidth() != EFB_WIDTH || GetEFBHeight() != EFB_HEIGHT)
   {
+    // Transition EFB to shader read before drawing.
+    src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     m_depth_copy_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
@@ -707,10 +709,6 @@ bool FramebufferManager::PopulateDepthReadbackTexture()
 
     VkRect2D rect = {{0, 0}, {EFB_WIDTH, EFB_HEIGHT}};
     draw.BeginRenderPass(m_depth_copy_framebuffer, rect);
-
-    // Transition EFB to shader read before drawing.
-    src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
-                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     draw.SetPSSampler(0, src_texture->GetView(), g_object_cache->GetPointSampler());
     draw.SetViewportAndScissor(0, 0, EFB_WIDTH, EFB_HEIGHT);
     draw.DrawWithoutVertexBuffer(4);

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
@@ -82,8 +82,7 @@ private:
     u32 color;
   };
 
-  bool CreateEFBRenderPass();
-  void DestroyEFBRenderPass();
+  bool CreateEFBRenderPasses();
   bool CreateEFBFramebuffer();
   void DestroyEFBFramebuffer();
 
@@ -91,7 +90,6 @@ private:
   void DestroyConversionShaders();
 
   bool CreateReadbackRenderPasses();
-  void DestroyReadbackRenderPasses();
   bool CompileReadbackShaders();
   void DestroyReadbackShaders();
   bool CreateReadbackTextures();

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
@@ -45,10 +45,9 @@ public:
   VkSampleCountFlagBits GetEFBSamples() const;
   MultisamplingState GetEFBMultisamplingState() const;
 
-  void ResizeEFBTextures();
+  void RecreateEFBFramebuffer();
 
   // Recompile shaders, use when MSAA mode changes.
-  void RecreateRenderPass();
   void RecompileShaders();
 
   // Reinterpret pixel format of EFB color texture.

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 
 #include "Common/CommonTypes.h"
@@ -66,6 +67,10 @@ public:
   // Dummy image for samplers that are unbound
   Texture2D* GetDummyImage() const { return m_dummy_texture.get(); }
   VkImageView GetDummyImageView() const { return m_dummy_texture->GetView(); }
+  // Render pass cache.
+  VkRenderPass GetRenderPass(VkFormat color_format, VkFormat depth_format, u32 multisamples,
+                             VkAttachmentLoadOp load_op);
+
   // Perform at startup, create descriptor layouts, compiles all static shaders.
   bool Initialize();
 
@@ -81,6 +86,7 @@ private:
   bool CreateUtilityShaderVertexFormat();
   bool CreateStaticSamplers();
   void DestroySamplers();
+  void DestroyRenderPassCache();
 
   std::array<VkDescriptorSetLayout, NUM_DESCRIPTOR_SET_LAYOUTS> m_descriptor_set_layouts = {};
   std::array<VkPipelineLayout, NUM_PIPELINE_LAYOUTS> m_pipeline_layouts = {};
@@ -96,6 +102,10 @@ private:
 
   // Dummy image for samplers that are unbound
   std::unique_ptr<Texture2D> m_dummy_texture;
+
+  // Render pass cache
+  using RenderPassCacheKey = std::tuple<VkFormat, VkFormat, u32, VkAttachmentLoadOp>;
+  std::map<RenderPassCacheKey, VkRenderPass> m_render_pass_cache;
 };
 
 extern std::unique_ptr<ObjectCache> g_object_cache;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -82,7 +82,7 @@ private:
 
   void OnSwapChainResized();
   void BindEFBToStateTracker();
-  void ResizeEFBTextures();
+  void RecreateEFBFramebuffer();
 
   void RecompileShaders();
   bool CompileShaders();

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.h
@@ -68,7 +68,6 @@ private:
   void DestroySwapChain();
 
   bool CreateRenderPass();
-  void DestroyRenderPass();
 
   bool SetupSwapChainImages();
   void DestroySwapChainImages();

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.h
@@ -48,17 +48,12 @@ public:
                           TLUTFormat palette_format) override;
 
   VkShaderModule GetCopyShader() const;
-  VkRenderPass GetTextureCopyRenderPass() const;
   StreamBuffer* GetTextureUploadBuffer() const;
 
 private:
-  bool CreateRenderPasses();
-
   void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy, const EFBRectangle& src_rect,
                            bool scale_by_half, EFBCopyFormat dst_format,
                            bool is_intensity) override;
-
-  VkRenderPass m_render_pass = VK_NULL_HANDLE;
 
   std::unique_ptr<StreamBuffer> m_texture_upload_buffer;
 

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -35,8 +35,8 @@ public:
 
   // Applies palette to dst_entry, using indices from src_entry.
   void ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
-                      TextureCache::TCacheEntry* src_entry, VkRenderPass render_pass,
-                      const void* palette, TLUTFormat palette_format);
+                      TextureCache::TCacheEntry* src_entry, const void* palette,
+                      TLUTFormat palette_format);
 
   // Uses an encoding shader to copy src_texture to dest_ptr.
   // NOTE: Executes the current command buffer.
@@ -76,7 +76,6 @@ private:
   VkShaderModule CompileEncodingShader(const EFBCopyParams& params);
   VkShaderModule GetEncodingShader(const EFBCopyParams& params);
 
-  bool CreateEncodingRenderPass();
   bool CreateEncodingTexture();
   bool CreateDecodingTexture();
 
@@ -109,7 +108,6 @@ private:
   std::map<EFBCopyParams, VkShaderModule> m_encoding_shaders;
   std::unique_ptr<AbstractTexture> m_encoding_render_texture;
   std::unique_ptr<AbstractStagingTexture> m_encoding_readback_texture;
-  VkRenderPass m_encoding_render_pass = VK_NULL_HANDLE;
 
   // Texture decoding - GX format in memory->RGBA8
   struct TextureDecodingPipeline

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -56,11 +56,13 @@ std::unique_ptr<VKTexture> VKTexture::Create(const TextureConfig& tex_config)
   if (tex_config.rendertarget)
   {
     VkImageView framebuffer_attachments[] = {texture->GetView()};
+    VkRenderPass render_pass = g_object_cache->GetRenderPass(
+        texture->GetFormat(), VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
     VkFramebufferCreateInfo framebuffer_info = {
         VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
         nullptr,
         0,
-        TextureCache::GetInstance()->GetTextureCopyRenderPass(),
+        render_pass,
         static_cast<u32>(ArraySize(framebuffer_attachments)),
         framebuffer_attachments,
         texture->GetWidth(),
@@ -175,9 +177,10 @@ void VKTexture::ScaleRectangleFromTexture(const AbstractTexture* source,
   m_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
+  VkRenderPass render_pass = g_object_cache->GetRenderPass(
+      m_texture->GetFormat(), VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
   UtilityShaderDraw draw(g_command_buffer_mgr->GetCurrentCommandBuffer(),
-                         g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_STANDARD),
-                         TextureCache::GetInstance()->GetTextureCopyRenderPass(),
+                         g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_STANDARD), render_pass,
                          g_shader_cache->GetPassthroughVertexShader(),
                          g_shader_cache->GetPassthroughGeometryShader(),
                          TextureCache::GetInstance()->GetCopyShader());

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -186,6 +186,25 @@ bool VideoBackend::Initialize(void* window_handle)
   // With the backend information populated, we can now initialize videocommon.
   InitializeShared();
 
+  // Create command buffers. We do this separately because the other classes depend on it.
+  g_command_buffer_mgr = std::make_unique<CommandBufferManager>(g_Config.bBackendMultithreading);
+  if (!g_command_buffer_mgr->Initialize())
+  {
+    PanicAlert("Failed to create Vulkan command buffers");
+    Shutdown();
+    return false;
+  }
+
+  // Remaining classes are also dependent on object/shader cache.
+  g_object_cache = std::make_unique<ObjectCache>();
+  g_shader_cache = std::make_unique<ShaderCache>();
+  if (!g_object_cache->Initialize() || !g_shader_cache->Initialize())
+  {
+    PanicAlert("Failed to initialize Vulkan object cache.");
+    Shutdown();
+    return false;
+  }
+
   // Create swap chain. This has to be done early so that the target size is correct for auto-scale.
   std::unique_ptr<SwapChain> swap_chain;
   if (surface != VK_NULL_HANDLE)
@@ -199,39 +218,19 @@ bool VideoBackend::Initialize(void* window_handle)
     }
   }
 
-  // Create command buffers. We do this separately because the other classes depend on it.
-  g_command_buffer_mgr = std::make_unique<CommandBufferManager>(g_Config.bBackendMultithreading);
-  if (!g_command_buffer_mgr->Initialize())
-  {
-    PanicAlert("Failed to create Vulkan command buffers");
-    Shutdown();
-    return false;
-  }
-
   // Create main wrapper instances.
-  g_object_cache = std::make_unique<ObjectCache>();
-  g_shader_cache = std::make_unique<ShaderCache>();
   g_framebuffer_manager = std::make_unique<FramebufferManager>();
   g_renderer = std::make_unique<Renderer>(std::move(swap_chain));
+  g_vertex_manager = std::make_unique<VertexManager>();
+  g_texture_cache = std::make_unique<TextureCache>();
+  g_perf_query = std::make_unique<PerfQuery>();
 
   // Invoke init methods on main wrapper classes.
   // These have to be done before the others because the destructors
   // for the remaining classes may call methods on these.
-  if (!g_object_cache->Initialize() || !g_shader_cache->Initialize() ||
-      !StateTracker::CreateInstance() || !FramebufferManager::GetInstance()->Initialize() ||
-      !Renderer::GetInstance()->Initialize())
-  {
-    PanicAlert("Failed to initialize Vulkan classes.");
-    Shutdown();
-    return false;
-  }
-
-  // Create remaining wrapper instances.
-  g_vertex_manager = std::make_unique<VertexManager>();
-  g_texture_cache = std::make_unique<TextureCache>();
-  g_perf_query = std::make_unique<PerfQuery>();
-  if (!VertexManager::GetInstance()->Initialize() || !TextureCache::GetInstance()->Initialize() ||
-      !PerfQuery::GetInstance()->Initialize())
+  if (!StateTracker::CreateInstance() || !FramebufferManager::GetInstance()->Initialize() ||
+      !Renderer::GetInstance()->Initialize() || !VertexManager::GetInstance()->Initialize() ||
+      !TextureCache::GetInstance()->Initialize() || !PerfQuery::GetInstance()->Initialize())
   {
     PanicAlert("Failed to initialize Vulkan classes.");
     Shutdown();


### PR DESCRIPTION
Should hopefully fix MSAA being broken/causing cmdbuffer submit failure as of abstract readback textures.
Also centralizes the render pass creation code in the backend, knocking out ~200 lines or so.