### PR TITLE
Boot: Minor fixes for Wii homebrew

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -335,7 +335,6 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
 
       if (config.bWii)
       {
-        HID4.SBE = 1;
         // Because there is no TMD to get the requested system (IOS) version from,
         // we default to IOS58, which is the version used by the Homebrew Channel.
         SetupWiiMemory();

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -282,6 +282,18 @@ static void SetDefaultDisc()
     SetDisc(DiscIO::CreateVolumeFromFilename(config.m_strDefaultISO));
 }
 
+static void CopyDefaultExceptionHandlers()
+{
+  constexpr u32 EXCEPTION_HANDLER_ADDRESSES[] = {0x00000100, 0x00000200, 0x00000300, 0x00000400,
+                                                 0x00000500, 0x00000600, 0x00000700, 0x00000800,
+                                                 0x00000900, 0x00000C00, 0x00000D00, 0x00000F00,
+                                                 0x00001300, 0x00001400, 0x00001700};
+
+  constexpr u32 RFI_INSTRUCTION = 0x4C000064;
+  for (const u32 address : EXCEPTION_HANDLER_ADDRESSES)
+    Memory::Write_U32(RFI_INSTRUCTION, address);
+}
+
 // Third boot step after BootManager and Core. See Call schedule in BootManager.cpp
 bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
 {
@@ -332,6 +344,7 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
 
       SetupMSR();
       SetupBAT(config.bWii);
+      CopyDefaultExceptionHandlers();
 
       if (config.bWii)
       {

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -335,6 +335,13 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
 
       if (config.bWii)
       {
+        PowerPC::ppcState.spr[SPR_HID0] = 0x0011c464;
+        PowerPC::ppcState.spr[SPR_HID4] = 0x82000000;
+
+        // Set a value for the SP. It doesn't matter where this points to,
+        // as long as it is a valid location. This value is taken from a homebrew binary.
+        PowerPC::ppcState.gpr[1] = 0x8004d4bc;
+
         // Because there is no TMD to get the requested system (IOS) version from,
         // we default to IOS58, which is the version used by the Homebrew Channel.
         SetupWiiMemory();

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -78,6 +78,7 @@ void CBoot::SetupBAT(bool is_wii)
     PowerPC::ppcState.spr[SPR_DBAT4L] = 0x10000002;
     PowerPC::ppcState.spr[SPR_DBAT5U] = 0xd0001fff;
     PowerPC::ppcState.spr[SPR_DBAT5L] = 0x1000002a;
+    HID4.SBE = 1;
   }
   PowerPC::DBATUpdated();
   PowerPC::IBATUpdated();


### PR DESCRIPTION
* *Fix BAT setup in Wii mode*: HID4.SBE must be set before calling PowerPC::Update{D,I}BAT, otherwise extended BATs will not be enabled.

* *Change default register values*: Set HID0, HID4, GPR1 to values that are used by libogc for initialisation. This makes boots more similar to a launch from the HBC or another loader, since normally the registers have already been initialised by the loader.

  This fixes a crash in homebrew that assume GPR1 points to a correct location and attempt to use it before initialising registers.

* *Add default exception handlers*: Some homebrew expect exception handlers to be present -- which is almost always the case on console, since most of the time homebrew are launched from either a libogc or SDK title) -- and break if they are not. To fix this, we just need to include default, dummy handlers.