### PR TITLE
Remove android.useDeprecatedNdk=true

### DIFF
--- a/Source/Android/gradle.properties
+++ b/Source/Android/gradle.properties
@@ -16,4 +16,3 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useDeprecatedNdk=true


### PR DESCRIPTION
I'm not entirely sure what this line is for, but if I build Dolphin for Android without removing it, I get errors like:

cmath:313:9: error: no member named 'signbit' in the global namespace