### PR TITLE
Common: Add a Subscribable class (from #5758)

### DIFF
--- a/Source/Core/Common/NoDiscard.h
+++ b/Source/Core/Common/NoDiscard.h
@@ -1,0 +1,20 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) 0
+#endif
+
+#if __has_cpp_attribute(nodiscard)
+#define NODISCARD [[nodiscard]]
+#elif defined(__GNUC__) && (__GNUC__ >= 4)
+#define NODISCARD __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
+// Only has an effect when code analysis is turned on
+#define NODISCARD _Check_return_
+#else
+#define NODISCARD
+#endif

--- a/Source/Core/Common/Subscribable.h
+++ b/Source/Core/Common/Subscribable.h
@@ -1,0 +1,112 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+
+#include "Common/NoDiscard.h"
+
+// This provides a callback management mechanism: create a Subscribable, register callbacks with
+// Subscribe(callback) to get RAII-style subscription handles, and trigger all callbacks with
+// Send(args...).
+
+template <typename... Args>
+class Subscribable
+{
+private:
+  struct ControlBlock;
+
+public:
+  using SubscriptionID = uint32_t;
+  using CallbackType =
+      std::function<void(std::add_lvalue_reference_t<std::add_const_t<std::decay_t<Args>>>...)>;
+
+  class Subscription
+  {
+    friend class Subscribable;
+
+  public:
+    Subscription() = default;
+    ~Subscription() { Unsubscribe(); }
+    Subscription(const Subscription&) = delete;
+    Subscription& operator=(const Subscription&) = delete;
+    Subscription(Subscription&& other) { *this = std::move(other); }
+    Subscription& operator=(Subscription&& other)
+    {
+      Unsubscribe();
+      std::swap(m_id, other.m_id);
+      std::swap(m_control_block, other.m_control_block);
+      return *this;
+    }
+
+    void Unsubscribe()
+    {
+      if (m_control_block)
+      {
+        std::unique_lock<std::mutex> lg(m_control_block->lock);
+        if (m_control_block->subscribable)
+          m_control_block->subscribable->UnsubscribeUnsafe(m_id);
+      }
+
+      m_id = {};
+      m_control_block = {};
+    }
+
+  private:
+    Subscription(SubscriptionID id, std::shared_ptr<ControlBlock> control_block)
+        : m_id{std::move(id)}, m_control_block{std::move(control_block)}
+    {
+    }
+    SubscriptionID m_id{};
+    std::shared_ptr<ControlBlock> m_control_block;
+  };
+
+  Subscribable()
+  {
+    m_control_block = std::make_shared<ControlBlock>();
+    m_control_block->subscribable = this;
+  }
+  Subscribable(const Subscribable&) = delete;
+  Subscribable& operator=(const Subscribable&) = delete;
+
+  ~Subscribable()
+  {
+    std::unique_lock<std::mutex> lg(m_control_block->lock);
+    m_control_block->subscribable = nullptr;
+  }
+
+  void Send(const Args&... args)
+  {
+    std::unique_lock<std::mutex> lg(m_control_block->lock);
+    for (auto& pair : m_callbacks)
+      pair.second(args...);
+  }
+
+  NODISCARD Subscription Subscribe(CallbackType callback)
+  {
+    std::unique_lock<std::mutex> lg(m_control_block->lock);
+    auto id = m_next_id++;
+    m_callbacks.emplace(id, std::move(callback));
+    return {id, m_control_block};
+  }
+
+private:
+  struct ControlBlock
+  {
+    std::mutex lock;
+    Subscribable* subscribable = nullptr;
+  };
+
+  void UnsubscribeUnsafe(SubscriptionID id) { m_callbacks.erase(id); }
+  // XXX: this will overflow after UINT32_MAX calls to Subscribe
+  SubscriptionID m_next_id{0};
+
+  std::shared_ptr<ControlBlock> m_control_block;
+  std::map<SubscriptionID, CallbackType> m_callbacks;
+};

--- a/Source/UnitTests/Common/CMakeLists.txt
+++ b/Source/UnitTests/Common/CMakeLists.txt
@@ -11,6 +11,7 @@ add_dolphin_test(MathUtilTest MathUtilTest.cpp)
 add_dolphin_test(NandPathsTest NandPathsTest.cpp)
 add_dolphin_test(SPSCQueueTest SPSCQueueTest.cpp)
 add_dolphin_test(StringUtilTest StringUtilTest.cpp)
+add_dolphin_test(SubscribableTest SubscribableTest.cpp)
 add_dolphin_test(SwapTest SwapTest.cpp)
 
 add_dolphin_test(x64EmitterTest x64EmitterTest.cpp)

--- a/Source/UnitTests/Common/SubscribableTest.cpp
+++ b/Source/UnitTests/Common/SubscribableTest.cpp
@@ -1,0 +1,71 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <array>
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "Common/MemoryUtil.h"
+#include "Common/Subscribable.h"
+
+TEST(Subscribable, BasicUsage)
+{
+  // Create the Subscribable in a special memory page so later we can test that it doesn't get
+  // accessed.
+  size_t mem_alignment = std::alignment_of<Subscribable<int>>::value;
+  size_t mem_size = sizeof(Subscribable<int>) + mem_alignment;
+  void* memory = Common::AllocateMemoryPages(mem_size);
+  void* aligned_address = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(memory) + reinterpret_cast<uintptr_t>(memory) % mem_alignment);
+  auto* s = new (aligned_address) Subscribable<int>();
+
+  // Send to zero subscribers
+  s->Send(0);
+
+  // Send to many subscribers
+  std::array<Subscribable<int>::Subscription, 10> subscriptions;
+  std::array<int, 10> values{};
+  for (size_t i = 0; i < values.size(); ++i)
+  {
+    subscriptions[i] = s->Subscribe([i, &values](int new_value) { values[i] = new_value; });
+  }
+
+  s->Send(47);
+  for (const auto& value : values)
+    EXPECT_EQ(value, 47);
+
+  // Send again
+  s->Send(94);
+  for (const auto& value : values)
+    EXPECT_EQ(value, 94);
+
+  // Unsubscribe some
+  for (size_t i = 0; i < subscriptions.size(); ++i)
+  {
+    if (i % 2)
+      subscriptions[i].Unsubscribe();
+  }
+
+  s->Send(188);
+  for (size_t i = 0; i < values.size(); ++i)
+    EXPECT_EQ(values[i], i % 2 ? 94 : 188);
+
+  // Doesn't try to access Subscribable after destruction
+  // Destroy the Subscribable and half of the Subscriptions in concurrent threads to try to expose
+  // race conditions (especially useful when running with ThreadSanitizer).
+  std::thread destroy_subscriptions([&] {
+    for (size_t i = 0; i < subscriptions.size() / 2; ++i)
+      subscriptions[i].Unsubscribe();
+  });
+  std::thread destroy_subscribable([&] {
+    s->~Subscribable<int>();
+    Common::ReadProtectMemory(memory, mem_size);
+  });
+  destroy_subscriptions.join();
+  destroy_subscribable.join();
+
+  // Destroy the rest of the Subscriptions after we're sure the Subscribable is destroyed
+  for (auto& subscription : subscriptions)
+    subscription.Unsubscribe();
+}


### PR DESCRIPTION
From PR https://github.com/dolphin-emu/dolphin/pull/5758 (rebased on top of master)

>Adds a `Subscribable` class in Common, to encapsulate the callback management logic. Could probably be used in other places with callbacks, too. Calling `Subscribable().Subscribe` returns a move-only value that, when destructed, unsubscribes the callback if the original Subscribable still exists (thread-safe).

This is not used anywhere yet, but I plan to replace the existing callbacks with `Subscribable`s (`Core::SetOnStoppedCallback`, config change callbacks).