### PR TITLE
[Android] Fix a bug when you open the gc pad settings after fresh install

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -336,6 +336,11 @@ public final class SettingsFile
 			}
 		}
 
+		if (fileName.equals(SettingsFile.FILE_NAME_DOLPHIN))
+		{
+			addGcPadSettingsIfTheyDontExist(sections);
+		}
+
 		return sections;
 	}
 
@@ -396,6 +401,23 @@ public final class SettingsFile
 	{
 		String sectionName = line.substring(1, line.length() - 1);
 		return new SettingSection(sectionName);
+	}
+
+	private static void addGcPadSettingsIfTheyDontExist(HashMap<String, SettingSection> sections)
+	{
+		SettingSection coreSection = sections.get(SettingsFile.SECTION_CORE);
+
+		for (int i = 0; i < 4; i++)
+		{
+			String key = SettingsFile.KEY_GCPAD_TYPE + i;
+			if (coreSection.getSetting(key) == null)
+			{
+				Setting gcPadSetting = new IntSetting(key, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, 0);
+				coreSection.putSetting(gcPadSetting);
+			}
+		}
+
+		sections.put(SettingsFile.SECTION_CORE, coreSection);
 	}
 
 	/**


### PR DESCRIPTION
You will see an empty gc pad settings screen until you open any other
settings screen and change something, at that moment the Dolphin.ini will
be created and the gc pad settings will be loaded successfully the next
time you open the screen.

This fixes the bug by putting the default gc pad settings section even if
the Dolphin.ini file doesn't exist