### PR TITLE
VideoCommon: Apply the yscale as upscaling of the XFB.

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -229,9 +229,9 @@ static void BPWritten(const BPCmd& bp)
       // bpmem.zcontrol.pixel_format to PEControl::Z24 is when the game wants to copy from ZBuffer
       // (Zbuffer uses 24-bit Format)
       bool is_depth_copy = bpmem.zcontrol.pixel_format == PEControl::Z24;
-      g_texture_cache->CopyRenderTargetToTexture(destAddr, PE_copy.tp_realFormat(), destStride,
-                                                 is_depth_copy, srcRect, !!PE_copy.intensity_fmt,
-                                                 !!PE_copy.half_scale, 1.0f, 1.0f);
+      g_texture_cache->CopyRenderTargetToTexture(
+          destAddr, PE_copy.tp_realFormat(), srcRect.GetWidth(), srcRect.GetHeight(), destStride,
+          is_depth_copy, srcRect, !!PE_copy.intensity_fmt, !!PE_copy.half_scale, 1.0f, 1.0f);
     }
     else
     {
@@ -250,8 +250,6 @@ static void BPWritten(const BPCmd& bp)
 
       float num_xfb_lines = 1.0f + bpmem.copyTexSrcWH.y * yScale;
 
-      srcRect.bottom = static_cast<int>(bpmem.copyTexSrcXY.y + num_xfb_lines);
-
       u32 height = static_cast<u32>(num_xfb_lines);
 
       DEBUG_LOG(VIDEO, "RenderToXFB: destAddr: %08x | srcRect {%d %d %d %d} | fbWidth: %u | "
@@ -260,9 +258,9 @@ static void BPWritten(const BPCmd& bp)
                 bpmem.copyTexSrcWH.x + 1, destStride, height, yScale);
 
       bool is_depth_copy = bpmem.zcontrol.pixel_format == PEControl::Z24;
-      g_texture_cache->CopyRenderTargetToTexture(destAddr, EFBCopyFormat::XFB, destStride,
-                                                 is_depth_copy, srcRect, false, false, yScale,
-                                                 s_gammaLUT[PE_copy.gamma]);
+      g_texture_cache->CopyRenderTargetToTexture(destAddr, EFBCopyFormat::XFB, srcRect.GetWidth(),
+                                                 height, destStride, is_depth_copy, srcRect, false,
+                                                 false, yScale, s_gammaLUT[PE_copy.gamma]);
 
       // This stays in to signal end of a "frame"
       g_renderer->RenderToXFB(destAddr, srcRect, destStride, height, s_gammaLUT[PE_copy.gamma]);

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -246,9 +246,9 @@ public:
   void LoadTextureLevelZeroFromMemory(TCacheEntry* entry_to_update,
                                       const TextureLookupInformation& tex_info, bool decode_on_gpu);
   virtual void BindTextures();
-  void CopyRenderTargetToTexture(u32 dstAddr, EFBCopyFormat dstFormat, u32 dstStride,
-                                 bool is_depth_copy, const EFBRectangle& srcRect, bool isIntensity,
-                                 bool scaleByHalf, float y_scale, float gamma);
+  void CopyRenderTargetToTexture(u32 dstAddr, EFBCopyFormat dstFormat, u32 width, u32 height,
+                                 u32 dstStride, bool is_depth_copy, const EFBRectangle& srcRect,
+                                 bool isIntensity, bool scaleByHalf, float y_scale, float gamma);
 
   virtual void ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, const void* palette,
                               TLUTFormat format) = 0;


### PR DESCRIPTION
This moves the logic of the y-scaling to the caller in BPStructs.