### PR TITLE
[Android] Support restore emulator state

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -343,7 +343,7 @@ public final class NativeLibrary
 	/**
 	 * Begins emulation from the specified savestate.
 	 */
-	public static native void Run(String path, String savestatePath);
+	public static native void Run(String path, String savestatePath, boolean deleteSavestate);
 
 	// Surface Handling
 	public static native void SurfaceChanged(Surface surf);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -349,6 +349,9 @@ public final class NativeLibrary
 	/** Stops emulation. */
 	public static native void StopEmulation();
 
+	/** Returns true if emulation is running (or is paused). */
+	public static native boolean IsRunning();
+
 	/**
 	 * Enables or disables CPU block profiling
 	 * @param enable

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -294,15 +294,19 @@ public final class NativeLibrary
 	 * Saves a game state to the slot number.
 	 *
 	 * @param slot  The slot location to save state to.
+	 * @param wait  If false, returns as early as possible.
+	 *              If true, returns once the savestate has been written to disk.
 	 */
-	public static native void SaveState(int slot);
+	public static native void SaveState(int slot, boolean wait);
 
 	/**
 	 * Saves a game state to the specified path.
 	 *
 	 * @param path  The path to save state to.
+	 * @param wait  If false, returns as early as possible.
+	 *              If true, returns once the savestate has been written to disk.
 	 */
-	public static native void SaveStateAs(String path);
+	public static native void SaveStateAs(String path, boolean wait);
 
 	/**
 	 * Loads a game state from the slot number.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -336,6 +336,11 @@ public final class NativeLibrary
 	 */
 	public static native void Run(String path);
 
+	/**
+	 * Begins emulation from the specified savestate.
+	 */
+	public static native void Run(String path, String savestatePath);
+
 	// Surface Handling
 	public static native void SurfaceChanged(Surface surf);
 	public static native void SurfaceDestroyed();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -298,11 +298,25 @@ public final class NativeLibrary
 	public static native void SaveState(int slot);
 
 	/**
+	 * Saves a game state to the specified path.
+	 *
+	 * @param path  The path to save state to.
+	 */
+	public static native void SaveStateAs(String path);
+
+	/**
 	 * Loads a game state from the slot number.
 	 *
 	 * @param slot  The slot location to load state from.
 	 */
 	public static native void LoadState(int slot);
+
+	/**
+	 * Loads a game state from the specified path.
+	 *
+	 * @param path  The path to load state from.
+	 */
+	public static native void LoadStateAs(String path);
 
 	/**
 	 * Sets the current working user directory

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -412,7 +412,7 @@ public final class EmulationActivity extends AppCompatActivity
 
 			// Quick save / load
 			case MENU_ACTION_QUICK_SAVE:
-				NativeLibrary.SaveState(9);
+				NativeLibrary.SaveState(9, false);
 				return;
 
 			case MENU_ACTION_QUICK_LOAD:
@@ -436,27 +436,27 @@ public final class EmulationActivity extends AppCompatActivity
 
 			// Save state slots
 			case MENU_ACTION_SAVE_SLOT1:
-				NativeLibrary.SaveState(0);
+				NativeLibrary.SaveState(0, false);
 				return;
 
 			case MENU_ACTION_SAVE_SLOT2:
-				NativeLibrary.SaveState(1);
+				NativeLibrary.SaveState(1, false);
 				return;
 
 			case MENU_ACTION_SAVE_SLOT3:
-				NativeLibrary.SaveState(2);
+				NativeLibrary.SaveState(2, false);
 				return;
 
 			case MENU_ACTION_SAVE_SLOT4:
-				NativeLibrary.SaveState(3);
+				NativeLibrary.SaveState(3, false);
 				return;
 
 			case MENU_ACTION_SAVE_SLOT5:
-				NativeLibrary.SaveState(4);
+				NativeLibrary.SaveState(4, false);
 				return;
 
 			case MENU_ACTION_SAVE_SLOT6:
-				NativeLibrary.SaveState(5);
+				NativeLibrary.SaveState(5, false);
 				return;
 
 			// Load state slots

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -25,6 +25,8 @@ import org.dolphinemu.dolphinemu.services.DirectoryInitializationService.Directo
 import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
 import org.dolphinemu.dolphinemu.utils.Log;
 
+import java.io.File;
+
 import rx.functions.Action1;
 
 public final class EmulationFragment extends Fragment implements SurfaceHolder.Callback
@@ -38,6 +40,8 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 	private EmulationState mEmulationState;
 
 	private DirectoryStateReceiver directoryStateReceiver;
+
+	private EmulationActivity activity;
 
 	public static EmulationFragment newInstance(String gamePath)
 	{
@@ -57,6 +61,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 
 		if (context instanceof EmulationActivity)
 		{
+			activity = (EmulationActivity)context;
 			NativeLibrary.setEmulationActivity((EmulationActivity) context);
 		}
 		else
@@ -79,7 +84,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 		mPreferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
 		String gamePath = getArguments().getString(KEY_GAMEPATH);
-		mEmulationState = new EmulationState(gamePath);
+		mEmulationState = new EmulationState(gamePath, getTemporaryStateFilePath());
 	}
 
 	/**
@@ -120,7 +125,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 		super.onResume();
 		if (DirectoryInitializationService.areDolphinDirectoriesReady())
 		{
-			mEmulationState.run();
+			mEmulationState.run(activity.isActivityRecreated());
 		}
 		else
 		{
@@ -155,7 +160,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 		directoryStateReceiver =
 				new DirectoryStateReceiver(directoryInitializationState -> {
 					if (directoryInitializationState == DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED) {
-						mEmulationState.run();
+						mEmulationState.run(activity.isActivityRecreated());
 					} else if (directoryInitializationState == DirectoryInitializationState.EXTERNAL_STORAGE_PERMISSION_NEEDED) {
 						Toast.makeText(getContext(), R.string.write_permission_needed, Toast.LENGTH_SHORT)
 								.show();
@@ -249,10 +254,13 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 		private State state;
 		private Surface mSurface;
 		private boolean mRunWhenSurfaceIsValid;
+		private boolean loadPreviousTemporaryState;
+		private final String temporaryStatePath;
 
-		EmulationState(String gamePath)
+		EmulationState(String gamePath, String temporaryStatePath)
 		{
 			mGamePath = gamePath;
+			this.temporaryStatePath = temporaryStatePath;
 			// Starting state is stopped.
 			state = State.STOPPED;
 		}
@@ -280,6 +288,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 		{
 			if (state != State.STOPPED)
 			{
+				Log.debug("[EmulationFragment] Stopping emulation.");
 				state = State.STOPPED;
 				NativeLibrary.StopEmulation();
 			}
@@ -307,8 +316,29 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 			}
 		}
 
-		public synchronized void run()
+		public synchronized void run(boolean isActivityRecreated)
 		{
+			if (isActivityRecreated)
+			{
+				if (NativeLibrary.IsRunning())
+				{
+					loadPreviousTemporaryState = false;
+					state = State.PAUSED;
+					deleteFile(temporaryStatePath);
+				}
+				else
+				{
+					loadPreviousTemporaryState = true;
+				}
+			}
+			else
+			{
+				Log.debug("[EmulationFragment] activity resumed or fresh start");
+				loadPreviousTemporaryState = false;
+				// activity resumed without being killed or this is the first run
+				deleteFile(temporaryStatePath);
+			}
+
 			// If the surface is set, run now. Otherwise, wait for it to get set.
 			if (mSurface != null)
 			{
@@ -362,12 +392,19 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 			mRunWhenSurfaceIsValid = false;
 			if (state == State.STOPPED)
 			{
-				Log.debug("[EmulationFragment] Starting emulation thread.");
-
 				mEmulationThread = new Thread(() ->
 				{
 					NativeLibrary.SurfaceChanged(mSurface);
-					NativeLibrary.Run(mGamePath);
+					if (loadPreviousTemporaryState)
+					{
+						Log.debug("[EmulationFragment] Starting emulation thread from previous state.");
+						NativeLibrary.Run(mGamePath, temporaryStatePath, true);
+					}
+					else
+					{
+						Log.debug("[EmulationFragment] Starting emulation thread.");
+						NativeLibrary.Run(mGamePath);
+					}
 				}, "NativeEmulation");
 				mEmulationThread.start();
 
@@ -383,6 +420,29 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 				Log.debug("[EmulationFragment] Bug, run called while already running.");
 			}
 			state = State.RUNNING;
+		}
+	}
+
+	public void saveTemporaryState()
+	{
+		NativeLibrary.SaveStateAs(getTemporaryStateFilePath(), true);
+	}
+
+	private String getTemporaryStateFilePath()
+	{
+		return getContext().getFilesDir() + File.separator + "temp.sav";
+	}
+
+	private static void deleteFile(String path)
+	{
+		try
+		{
+			File file = new File(path);
+			file.delete();
+		}
+		catch (Exception ex)
+		{
+			// fail safely
 		}
 	}
 }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -449,9 +449,15 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetFilename(
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveState(JNIEnv* env,
                                                                               jobject obj,
                                                                               jint slot);
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveStateAs(JNIEnv* env,
+                                                                                jobject obj,
+                                                                                jstring path);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JNIEnv* env,
                                                                               jobject obj,
                                                                               jint slot);
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadStateAs(JNIEnv* env,
+                                                                                jobject obj,
+                                                                                jstring path);
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_services_DirectoryInitializationService_CreateUserDirectories(
     JNIEnv* env, jobject obj);
@@ -650,12 +656,28 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveState(JN
   State::Save(slot);
 }
 
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveStateAs(JNIEnv* env,
+                                                                                jobject obj,
+                                                                                jstring path)
+{
+  std::lock_guard<std::mutex> guard(s_host_identity_lock);
+  State::SaveAs(GetJString(env, path));
+}
+
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JNIEnv* env,
                                                                               jobject obj,
                                                                               jint slot)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
   State::Load(slot);
+}
+
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadStateAs(JNIEnv* env,
+                                                                                jobject obj,
+                                                                                jstring path)
+{
+  std::lock_guard<std::mutex> guard(s_host_identity_lock);
+  State::LoadAs(GetJString(env, path));
 }
 
 JNIEXPORT void JNICALL

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -451,10 +451,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetFilename(
                                                                                 jstring jFile);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveState(JNIEnv* env,
                                                                               jobject obj,
-                                                                              jint slot);
+                                                                              jint slot,
+                                                                              jboolean wait);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveStateAs(JNIEnv* env,
                                                                                 jobject obj,
-                                                                                jstring path);
+                                                                                jstring path,
+                                                                                jboolean wait);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JNIEnv* env,
                                                                               jobject obj,
                                                                               jint slot);
@@ -664,18 +666,20 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetConfig(
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveState(JNIEnv* env,
                                                                               jobject obj,
-                                                                              jint slot)
+                                                                              jint slot,
+                                                                              jboolean wait)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  State::Save(slot);
+  State::Save(slot, wait);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveStateAs(JNIEnv* env,
                                                                                 jobject obj,
-                                                                                jstring path)
+                                                                                jstring path,
+                                                                                jboolean wait)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  State::SaveAs(GetJString(env, path));
+  State::SaveAs(GetJString(env, path), wait);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JNIEnv* env,

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -404,6 +404,8 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulati
                                                                                    jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulation(JNIEnv* env,
                                                                                   jobject obj);
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunning(JNIEnv* env,
+                                                                                  jobject obj);
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(
     JNIEnv* env, jobject obj, jstring jDevice, jint Button, jint Action);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadMoveEvent(
@@ -503,11 +505,19 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulatio
   Core::Stop();
   s_update_main_frame_event.Set();  // Kick the waiting event
 }
+
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunning(JNIEnv* env,
+                                                                                  jobject obj)
+{
+  return Core::IsRunning();
+}
+
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(
     JNIEnv* env, jobject obj, jstring jDevice, jint Button, jint Action)
 {
   return ButtonManager::GamepadEvent(GetJString(env, jDevice), Button, Action);
 }
+
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadMoveEvent(
     JNIEnv* env, jobject obj, jstring jDevice, jint Axis, jfloat Value)
 {

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -76,6 +76,7 @@ struct BootParameters
 
   Parameters parameters;
   std::optional<std::string> savestate_path;
+  bool delete_savestate = false;
 };
 
 class CBoot


### PR DESCRIPTION
Support restore emulator state after emulation screen is killed

This is more tricky that what I expected and I need help from the emulator core devs. Really sorry for the huge text below, putting it here easier to go over all of these on the chat :)

**Problem I am trying to solve**
if you leave the app by opening another app or pressing the home button, the emulator screen might be killed and we need to restore the state if you come back to Dolphin again.

**The proposed solution** 
While leaving the app we are going to save the state on special slot (8) for this situation then when you come back we will decide if we need to load the temporary state we saved or not.

**Problems I need help with**
~~1. in Android there is no way to tell if the screen got killed because you switched the app~~ ~~rotation or because of memory limitation while your app in the background and this makes the situation harder because during rotation we can theoretically pause/resume the emulation but in the other case since the OS decided to kill the screen we might not have the emulation state to resume the emulation so we have to load the temporary saved sate.~~

~~But, in order to do that I have to stop the emulation during onDestroy phase because running the emulation while previous emulation was not stopped caused an error "broken pipe". Stoping the emulation caused the pause/resume ability during rotation changed to stop working and now we are loading the temp saved state even in the case of rotating change.~~

~~If the native library can inform the app that it still has the previous emulation state and can continue, the app will be able to distinguish between the two cases and use the saved state only when needed.~~

**Or** 
~~I wonder if the app rotation is important for Dolphin, can't we just look the emulation to landscape on mobile devices? I think PPSSPP is doing that.~~

~~2. Loading the state should only happen after the game start running, there is no way the app can tell if the game start running, a hack is done inside surfaceChanged() that load the state after 2 seconds of running the game.~~

~~3. Keeping those temporary states might not be a good thing to do, if we can have a way to delete states that would make it better.~~

~~In this PR we have a working solution that can restart the state during screen rotation or after screen been killed. The downside is the during the rotation now you will loose the EFP copies since we are loading the state and it will stutter because of the 2 seconds delay hack.~~

EDIT: All cases are testing and hopefully are working fine.

The final status for each case:
1. Device rotation: working as expected using pause/resume emulation.
2. Leaving the emulation screen but the screen kept a live: Working fine using pause/resume emulation.
3. Leaving the emulation screen and the screen being killed but the native code still has the emulation data and can resume emulation again: Working fine using pause/resume emulation.
4. Leaving the emulation screen and the screen being killed but the native code doesn't have the emulation data and can't resume the emulation: Working using temporary saved states to resume emulation.