### PR TITLE
Redesign the ability to load state at boot

### DIFF
--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -67,12 +67,15 @@ struct BootParameters
     std::string dff_path;
   };
 
-  static std::unique_ptr<BootParameters> GenerateFromFile(const std::string& path);
+  static std::unique_ptr<BootParameters>
+  GenerateFromFile(const std::string& boot_path,
+                   const std::optional<std::string>& savestate_path = {});
 
   using Parameters = std::variant<Disc, Executable, DiscIO::WiiWAD, NANDTitle, IPL, DFF>;
-  BootParameters(Parameters&& parameters_);
+  BootParameters(Parameters&& parameters_, const std::optional<std::string>& savestate_path_ = {});
 
   Parameters parameters;
+  std::optional<std::string> savestate_path;
 };
 
 class CBoot

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -382,8 +382,10 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
                         std::holds_alternative<BootParameters::Disc>(boot->parameters);
   if (load_ipl)
   {
-    return Core::Init(std::make_unique<BootParameters>(BootParameters::IPL{
-        StartUp.m_region, std::move(std::get<BootParameters::Disc>(boot->parameters))}));
+    return Core::Init(std::make_unique<BootParameters>(
+        BootParameters::IPL{StartUp.m_region,
+                            std::move(std::get<BootParameters::Disc>(boot->parameters))},
+        boot->savestate_path));
   }
   return Core::Init(std::move(boot));
 }

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -64,9 +64,6 @@ void Callback_WiimoteInterruptChannel(int _number, u16 _channelID, const void* _
 // This displays messages in a user-visible way.
 void DisplayMessage(const std::string& message, int time_in_ms);
 
-std::string GetStateFileName();
-void SetStateFileName(const std::string& val);
-
 void FrameUpdateOnCPUThread();
 
 bool ShouldSkipFrame(int skipped);

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -157,8 +158,8 @@ bool BeginRecordingInput(int controllers);
 void RecordInput(GCPadStatus* PadStatus, int controllerID);
 void RecordWiimote(int wiimote, u8* data, u8 size);
 
-bool PlayInput(const std::string& filename);
-void LoadInput(const std::string& filename);
+bool PlayInput(const std::string& movie_path, std::optional<std::string>* savestate_path);
+void LoadInput(const std::string& movie_path);
 void ReadHeader();
 void PlayController(GCPadStatus* PadStatus, int controllerID);
 bool PlayWiimote(int wiimote, u8* data, const struct WiimoteEmu::ReportFeatures& rptf, int ext,

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -15,6 +15,7 @@
 #include <QProgressDialog>
 
 #include <future>
+#include <optional>
 
 #include "Common/Version.h"
 
@@ -164,7 +165,7 @@ void MainWindow::CreateComponents()
   m_fifo_window = new FIFOPlayerWindow(this);
 
   connect(m_fifo_window, &FIFOPlayerWindow::LoadFIFORequested, this,
-          static_cast<void (MainWindow::*)(const QString&)>(&MainWindow::StartGame));
+          [this](const QString& path) { StartGame(path); });
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
   m_graphics_window = new GraphicsWindow(
@@ -192,7 +193,7 @@ void MainWindow::ConnectMenuBar()
 
   // Emulation
   connect(m_menu_bar, &MenuBar::Pause, this, &MainWindow::Pause);
-  connect(m_menu_bar, &MenuBar::Play, this, &MainWindow::Play);
+  connect(m_menu_bar, &MenuBar::Play, this, [this]() { Play(); });
   connect(m_menu_bar, &MenuBar::Stop, this, &MainWindow::RequestStop);
   connect(m_menu_bar, &MenuBar::Reset, this, &MainWindow::Reset);
   connect(m_menu_bar, &MenuBar::Fullscreen, this, &MainWindow::FullScreen);
@@ -278,7 +279,7 @@ void MainWindow::ConnectToolBar()
 {
   addToolBar(m_tool_bar);
   connect(m_tool_bar, &ToolBar::OpenPressed, this, &MainWindow::Open);
-  connect(m_tool_bar, &ToolBar::PlayPressed, this, &MainWindow::Play);
+  connect(m_tool_bar, &ToolBar::PlayPressed, this, [this]() { Play(); });
   connect(m_tool_bar, &ToolBar::PausePressed, this, &MainWindow::Pause);
   connect(m_tool_bar, &ToolBar::StopPressed, this, &MainWindow::RequestStop);
   connect(m_tool_bar, &ToolBar::FullScreenPressed, this, &MainWindow::FullScreen);
@@ -290,7 +291,7 @@ void MainWindow::ConnectToolBar()
 
 void MainWindow::ConnectGameList()
 {
-  connect(m_game_list, &GameList::GameSelected, this, &MainWindow::Play);
+  connect(m_game_list, &GameList::GameSelected, this, [this]() { Play(); });
   connect(m_game_list, &GameList::NetPlayHost, this, &MainWindow::NetPlayHost);
 
   connect(m_game_list, &GameList::OpenGeneralSettings, this, &MainWindow::ShowGeneralWindow);
@@ -327,7 +328,7 @@ void MainWindow::Open()
     StartGame(file);
 }
 
-void MainWindow::Play()
+void MainWindow::Play(const std::optional<std::string>& savestate_path)
 {
   // If we're in a paused game, start it up again.
   // Otherwise, play the selected game, if there is one.
@@ -343,14 +344,14 @@ void MainWindow::Play()
     QSharedPointer<GameFile> selection = m_game_list->GetSelectedGame();
     if (selection)
     {
-      StartGame(selection->GetFilePath());
+      StartGame(selection->GetFilePath(), savestate_path);
     }
     else
     {
       auto default_path = QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);
       if (!default_path.isEmpty() && QFile::exists(default_path))
       {
-        StartGame(default_path);
+        StartGame(default_path, savestate_path);
       }
       else
       {
@@ -472,9 +473,9 @@ void MainWindow::ScreenShot()
   Core::SaveScreenShot();
 }
 
-void MainWindow::StartGame(const QString& path)
+void MainWindow::StartGame(const QString& path, const std::optional<std::string>& savestate_path)
 {
-  StartGame(BootParameters::GenerateFromFile(path.toStdString()));
+  StartGame(BootParameters::GenerateFromFile(path.toStdString(), savestate_path));
 }
 
 void MainWindow::StartGame(std::unique_ptr<BootParameters>&& parameters)
@@ -680,7 +681,7 @@ void MainWindow::NetPlayInit()
   m_netplay_dialog = new NetPlayDialog(this);
 
   connect(m_netplay_dialog, &NetPlayDialog::Boot, this,
-          static_cast<void (MainWindow::*)(const QString&)>(&MainWindow::StartGame));
+          [this](const QString& path) { StartGame(path); });
   connect(m_netplay_dialog, &NetPlayDialog::Stop, this, &MainWindow::RequestStop);
   connect(m_netplay_dialog, &NetPlayDialog::rejected, this, &MainWindow::NetPlayQuit);
   connect(m_netplay_setup_dialog, &NetPlaySetupDialog::Join, this, &MainWindow::NetPlayJoin);
@@ -938,11 +939,12 @@ void MainWindow::OnPlayRecording()
     emit ReadOnlyModeChanged(true);
   }
 
-  if (Movie::PlayInput(dtm_file.toStdString()))
+  std::optional<std::string> savestate_path;
+  if (Movie::PlayInput(dtm_file.toStdString(), &savestate_path))
   {
     emit RecordingStatusChanged(true);
 
-    Play();
+    Play(savestate_path);
   }
 }
 

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -10,6 +10,7 @@
 #include <QToolBar>
 
 #include <memory>
+#include <optional>
 
 #include "DolphinQt2/GameList/GameList.h"
 #include "DolphinQt2/MenuBar.h"
@@ -47,7 +48,7 @@ signals:
 
 private:
   void Open();
-  void Play();
+  void Play(const std::optional<std::string>& savestate_path = {});
   void Pause();
 
   // May ask for confirmation. Returns whether or not it actually stopped.
@@ -86,7 +87,7 @@ private:
 
   void InitCoreCallbacks();
 
-  void StartGame(const QString& path);
+  void StartGame(const QString& path, const std::optional<std::string>& savestate_path = {});
   void StartGame(std::unique_ptr<BootParameters>&& parameters);
   void ShowRenderWidget();
   void HideRenderWidget();

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstddef>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -130,8 +131,9 @@ void CRenderFrame::OnDropFiles(wxDropFilesEvent& event)
       main_frame->GetMenuBar()->FindItem(IDM_RECORD_READ_ONLY)->Check(true);
     }
 
-    if (Movie::PlayInput(filepath))
-      main_frame->BootGame("");
+    std::optional<std::string> savestate_path;
+    if (Movie::PlayInput(filepath, &savestate_path))
+      main_frame->BootGame("", savestate_path);
   }
   else if (!Core::IsRunning())
   {

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 #include <wx/bitmap.h>
@@ -105,7 +106,7 @@ public:
   void ToggleLogConfigWindow(bool bShow);
   void StatusBarMessage(const char* format, ...);
   void ClearStatusBar();
-  void BootGame(const std::string& filename);
+  void BootGame(const std::string& filename, const std::optional<std::string>& savestate_path = {});
   void StartGame(std::unique_ptr<BootParameters> boot);
   bool RendererHasFocus();
   bool RendererIsFullscreen();

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <future>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 #include <wx/app.h>
@@ -301,7 +302,7 @@ void CFrame::OpenGeneralConfiguration(wxWindowID tab_id)
 // 1. Show the game list and boot the selected game.
 // 2. Default ISO
 // 3. Boot last selected game
-void CFrame::BootGame(const std::string& filename)
+void CFrame::BootGame(const std::string& filename, const std::optional<std::string>& savestate_path)
 {
   std::string bootfile = filename;
   SConfig& StartUp = SConfig::GetInstance();
@@ -331,7 +332,7 @@ void CFrame::BootGame(const std::string& filename)
   }
   if (!bootfile.empty())
   {
-    StartGame(BootParameters::GenerateFromFile(bootfile));
+    StartGame(BootParameters::GenerateFromFile(bootfile, savestate_path));
   }
 }
 
@@ -513,8 +514,9 @@ void CFrame::OnPlayRecording(wxCommandEvent& WXUNUSED(event))
     GetMenuBar()->FindItem(IDM_RECORD_READ_ONLY)->Check();
   }
 
-  if (Movie::PlayInput(WxStrToStr(path)))
-    BootGame("");
+  std::optional<std::string> savestate_path;
+  if (Movie::PlayInput(WxStrToStr(path), &savestate_path))
+    BootGame("", savestate_path);
 }
 
 void CFrame::OnStopRecording(wxCommandEvent& WXUNUSED(event))

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -5,6 +5,7 @@
 #include <OptionParser.h>
 #include <cstdio>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <utility>
 #include <wx/app.h>
@@ -256,12 +257,18 @@ void DolphinApp::AfterInit()
 
   if (m_play_movie && !m_movie_file.empty())
   {
-    if (Movie::PlayInput(WxStrToStr(m_movie_file)))
+    std::optional<std::string> savestate_path;
+    if (Movie::PlayInput(WxStrToStr(m_movie_file), &savestate_path))
     {
       if (m_boot)
+      {
+        m_boot->savestate_path = savestate_path;
         main_frame->StartGame(std::move(m_boot));
+      }
       else
-        main_frame->BootGame("");
+      {
+        main_frame->BootGame("", savestate_path);
+      }
     }
   }
   // First check if we have an exec command line.


### PR DESCRIPTION
BootParameters can now contain the path of a savestate to load at boot. Movie has been made to use this instead of poking at Core.cpp's state.

I made this change so that PR #6270 could use it, but I think this change is useful enough on its own, so I'm submitting it as a separate PR.