### PR TITLE
Android: Always run HandleInit logic on app start

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
@@ -3,6 +3,8 @@ package org.dolphinemu.dolphinemu;
 import android.app.Application;
 
 import org.dolphinemu.dolphinemu.model.GameDatabase;
+import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
+import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
 
 public class DolphinApplication extends Application
 {
@@ -12,6 +14,11 @@ public class DolphinApplication extends Application
 	public void onCreate()
 	{
 		super.onCreate();
+
+		NativeLibrary.SetUserDirectory("");  // Empty string means use the default path
+
+		if (PermissionsHandler.hasWriteAccess(getApplicationContext()))
+			DirectoryInitializationService.startService(getApplicationContext());
 
 		databaseHelper = new GameDatabase(this);
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -58,7 +58,6 @@ public final class MainActivity extends AppCompatActivity implements MainView
 		mPresenter.onCreate();
 
 		// Stuff in this block only happens when this activity is newly created (i.e. not a rotation)
-		// TODO Split some of this stuff into Application.onCreate()
 		if (savedInstanceState == null)
 			StartupHandler.HandleInit(this);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -5,28 +5,19 @@ import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
 
-import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
-import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 
 public final class StartupHandler
 {
 	public static boolean HandleInit(FragmentActivity parent)
 	{
-		String user_dir = "";
-		String start_file = "";
+		// Ask the user to grant write permission if it's not already granted
+		PermissionsHandler.checkWritePermission(parent);
 
+		String start_file = "";
 		Bundle extras = parent.getIntent().getExtras();
 		if (extras != null)
-		{
-			user_dir = extras.getString("UserDir");
 			start_file = extras.getString("AutoStartFile");
-		}
-
-		NativeLibrary.SetUserDirectory(user_dir);  // Uses default path if user_dir equals ""
-
-		if (PermissionsHandler.checkWritePermission(parent))
-			DirectoryInitializationService.startService(parent);
 
 		if (!TextUtils.isEmpty(start_file))
 		{

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -9,7 +9,7 @@ import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 
 public final class StartupHandler
 {
-	public static boolean HandleInit(FragmentActivity parent)
+	public static void HandleInit(FragmentActivity parent)
 	{
 		// Ask the user to grant write permission if it's not already granted
 		PermissionsHandler.checkWritePermission(parent);
@@ -26,9 +26,6 @@ public final class StartupHandler
 			emulation_intent.putExtra("SelectedGame", start_file);
 			parent.startActivity(emulation_intent);
 			parent.finish();
-			return false;
 		}
-
-		return false;
 	}
 }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -54,7 +54,6 @@ JavaVM* g_java_vm;
 namespace
 {
 ANativeWindow* s_surf;
-std::string s_set_userpath;
 
 jclass s_jni_class;
 jmethodID s_jni_method_alert;
@@ -677,9 +676,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirec
     JNIEnv* env, jobject obj, jstring jDirectory)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  std::string directory = GetJString(env, jDirectory);
-  s_set_userpath = directory;
-  UICommon::SetUserDirectory(directory);
+  UICommon::SetUserDirectory(GetJString(env, jDirectory));
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDirectory(JNIEnv* env,
@@ -778,7 +775,6 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Run(JNIEnv* 
   RegisterMsgAlertHandler(&MsgAlert);
 
   std::unique_lock<std::mutex> guard(s_host_identity_lock);
-  UICommon::SetUserDirectory(s_set_userpath);
   UICommon::Init();
 
   WiimoteReal::InitAdapterClass();


### PR DESCRIPTION
Note: By "HandleInit" in this commit message, I mean the code that is in HandleInit in master except the part that launches EmulationActivity. In other words, I mean the call to SetUserDirectory and the call to DirectoryInitializationService.startService. Couldn't think of something more accurate to call that than "HandleInit"...

In master, HandleInit only runs when the main activity is launched. This is a problem if the app ends up being launched in some other way, such as resuming EmulationActivity after the app has been killed in order to reclaim memory. It's important that we run HandleInit, because otherwise the native code won't know where the User and Sys folders are.

In order to implement this, I'm dropping the ability to set a custom User folder in an intent. I don't think anyone is using that anyway. It's not impossible to support it, but I can't see a way to support it that doesn't involve something ugly like having code for calling HandleInit in every activity (or at least MainActivity + TvMainActivity + EmulationActivity, with more activities potentially needing it in the future if we expand the usage of native code for e.g. settings). If we want to support setting a custom user directory, we should consider another way to do it, such as a setting that's stored in getFilesDir() or getExternalStorageDirectory(). Intents are intended to control the behavior of a specific activity, not the whole app.

@mahdihijazi Any opinion?