### PR TITLE
Surfaceless egl rendering.

### DIFF
--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -63,6 +63,7 @@ void cInterfaceEGL::DetectMode()
     // 8 bits per color
     int attribs[] = {EGL_RED_SIZE,  8, EGL_GREEN_SIZE,      8,
                      EGL_BLUE_SIZE, 8, EGL_RENDERABLE_TYPE, renderable_type,
+                     EGL_SURFACE_TYPE, 0,
                      EGL_NONE};
 
     // Get how many configs there are
@@ -180,6 +181,7 @@ bool cInterfaceEGL::Create(void* window_handle, bool stereo, bool core)
                    8,
                    EGL_BLUE_SIZE,
                    8,
+                   EGL_SURFACE_TYPE, 0,
                    EGL_NONE};
 
   std::vector<EGLint> ctx_attribs;

--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -61,9 +61,16 @@ void cInterfaceEGL::DetectMode()
   {
     // attributes for a visual in RGBA format with at least
     // 8 bits per color
-    int attribs[] = {EGL_RED_SIZE,  8, EGL_GREEN_SIZE,      8,
-                     EGL_BLUE_SIZE, 8, EGL_RENDERABLE_TYPE, renderable_type,
-                     EGL_SURFACE_TYPE, 0,
+    int attribs[] = {EGL_RED_SIZE,
+                     8,
+                     EGL_GREEN_SIZE,
+                     8,
+                     EGL_BLUE_SIZE,
+                     8,
+                     EGL_RENDERABLE_TYPE,
+                     renderable_type,
+                     EGL_SURFACE_TYPE,
+                     m_has_handle ? EGL_WINDOW_BIT : 0,
                      EGL_NONE};
 
     // Get how many configs there are
@@ -181,7 +188,8 @@ bool cInterfaceEGL::Create(void* window_handle, bool stereo, bool core)
                    8,
                    EGL_BLUE_SIZE,
                    8,
-                   EGL_SURFACE_TYPE, 0,
+                   EGL_SURFACE_TYPE,
+                   m_has_handle ? EGL_WINDOW_BIT : 0,
                    EGL_NONE};
 
   std::vector<EGLint> ctx_attribs;


### PR DESCRIPTION
This allows (headless) surfaceless egl rendering to work on my system, none of whose egl configurations have the default EGL_WINDOW_BIT set.