### PR TITLE
Qt/KDE: Fix icon

### DIFF
--- a/Source/Core/DolphinQt2/Main.cpp
+++ b/Source/Core/DolphinQt2/Main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
   QCoreApplication::setOrganizationName(QStringLiteral("Dolphin Emulator"));
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
-  QCoreApplication::setApplicationName(QStringLiteral("dolphin"));
+  QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));
 
   QApplication app(argc, argv);
 


### PR DESCRIPTION
Previously when using DolphinQt2 under KDE, DolphinQt2 would use the Dolphin File Manager icon.
This is fixed now.

Before: ![Before](https://i.imgur.com/KBsi9al.png)
After: ![After](https://i.imgur.com/oh4GtOS.png)