### PR TITLE
Fix launching DolphinQt2 from Visual Studio

### DIFF
--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -251,8 +251,6 @@
   </ItemGroup>
   <!--Put standard C/C++ headers here-->
   <ItemGroup>
-    <ClInclude Include="Config\CheatWarningWidget.h" />
-    <ClInclude Include="Config\GeckoCodeWidget.h" />
     <ClInclude Include="Config\Mapping\GCKeyboardEmu.h" />
     <ClInclude Include="Config\Mapping\GCPadEmu.h" />
     <ClInclude Include="Config\Mapping\GCPadWiiU.h" />


### PR DESCRIPTION
Starting with PR #5990, trying to launch DolphinQt2 from Visual Studio shows the error message "The operation could not be completed. Undefined error" instead of launching the exe file. (The exe gets created correctly, it just doesn't get launched. It's possible to work around the problem by launching the exe manually outside of Visual Studio, but then you won't have an attached debugger automatically.) This commit fixes that by removing headers from DolphinQt2.vcxproj's ClInclude list that already are in the QtMoc list. (The problem was originally about LogWidget.h and LogConfigWidget.h, but PR #5984 made the problem be about CheatWarningWidget.h and GeckoCodeWidget.h instead.)