### PR TITLE
DolphinQt2: Don't use a mutex in GameFileCache

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameFileCache.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFileCache.cpp
@@ -6,6 +6,7 @@
 
 #include <QDataStream>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 
 #include "Common/FileUtil.h"
@@ -20,24 +21,18 @@ GameFileCache::GameFileCache()
 {
 }
 
-bool GameFileCache::IsCached(const QString& path)
+bool GameFileCache::IsCached(const QString& path) const
 {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
   return m_gamefiles.contains(path);
 }
 
-GameFile GameFileCache::GetFile(const QString& path)
+GameFile GameFileCache::GetFile(const QString& path) const
 {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
   return m_gamefiles[path];
 }
 
 void GameFileCache::Load()
 {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
   QFile file(m_path);
 
   if (!file.open(QIODevice::ReadOnly))
@@ -56,10 +51,8 @@ void GameFileCache::Load()
   stream >> m_gamefiles;
 }
 
-void GameFileCache::Save()
+void GameFileCache::Save() const
 {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
   QFile file(m_path);
 
   if (!file.open(QIODevice::WriteOnly))
@@ -74,14 +67,10 @@ void GameFileCache::Save()
 
 void GameFileCache::Update(const GameFile& gamefile)
 {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
   m_gamefiles[gamefile.GetFilePath()] = gamefile;
 }
 
-QList<QString> GameFileCache::GetCached()
+QList<QString> GameFileCache::GetCached() const
 {
-  std::lock_guard<std::mutex> guard(m_mutex);
-
   return m_gamefiles.keys();
 }

--- a/Source/Core/DolphinQt2/GameList/GameFileCache.h
+++ b/Source/Core/DolphinQt2/GameList/GameFileCache.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <QFile>
-
-#include <mutex>
+#include <QList>
+#include <QMap>
+#include <QString>
 
 #include "DolphinQt2/GameList/GameFile.h"
 
@@ -16,15 +16,14 @@ public:
   explicit GameFileCache();
 
   void Update(const GameFile& gamefile);
-  void Save();
+  void Save() const;
   void Load();
-  bool IsCached(const QString& path);
-  GameFile GetFile(const QString& path);
-  QList<QString> GetCached();
+  bool IsCached(const QString& path) const;
+  GameFile GetFile(const QString& path) const;
+  QList<QString> GetCached() const;
 
 private:
   QString m_path;
 
   QMap<QString, GameFile> m_gamefiles;
-  std::mutex m_mutex;
 };


### PR DESCRIPTION
GameTracker's usage of GameFileCache is thread-safe even without using a mutex. All of its access to GameFileCache happens on the thread m_load_thread, except for the call to GameFileCache::Load, which finishes before m_load_thread starts executing.