### PR TITLE
DolphinQt2: Perform more of GameTracker's work on a separate thread

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -22,22 +22,61 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
   connect(this, &QFileSystemWatcher::directoryChanged, this, &GameTracker::UpdateDirectory);
   connect(this, &QFileSystemWatcher::fileChanged, this, &GameTracker::UpdateFile);
 
-  m_cache.Load();
+  m_load_thread.Reset([this](Command command) {
+    switch (command.type)
+    {
+    case CommandType::LoadCache:
+      m_cache.Load();
+      break;
+    case CommandType::AddDirectory:
+      AddDirectoryInternal(command.path);
+      break;
+    case CommandType::RemoveDirectory:
+      RemoveDirectoryInternal(command.path);
+      break;
+    case CommandType::UpdateDirectory:
+      UpdateDirectoryInternal(command.path);
+      break;
+    case CommandType::UpdateFile:
+      UpdateFileInternal(command.path);
+      break;
+    }
+  });
 
-  m_load_thread.Reset([this](const QString& path) { LoadGame(path); });
+  m_load_thread.EmplaceItem(Command{CommandType::LoadCache, {}});
 
   // TODO: When language changes, reload m_title_database and call m_cache.UpdateAdditionalMetadata
 }
 
 void GameTracker::AddDirectory(const QString& dir)
 {
-  if (!QFileInfo(dir).exists())
-    return;
-  addPath(dir);
-  UpdateDirectory(dir);
+  m_load_thread.EmplaceItem(Command{CommandType::AddDirectory, dir});
 }
 
 void GameTracker::RemoveDirectory(const QString& dir)
+{
+  m_load_thread.EmplaceItem(Command{CommandType::RemoveDirectory, dir});
+}
+
+void GameTracker::UpdateDirectory(const QString& dir)
+{
+  m_load_thread.EmplaceItem(Command{CommandType::UpdateDirectory, dir});
+}
+
+void GameTracker::UpdateFile(const QString& dir)
+{
+  m_load_thread.EmplaceItem(Command{CommandType::UpdateFile, dir});
+}
+
+void GameTracker::AddDirectoryInternal(const QString& dir)
+{
+  if (!QFileInfo(dir).exists())
+    return;
+  addPath(dir);
+  UpdateDirectoryInternal(dir);
+}
+
+void GameTracker::RemoveDirectoryInternal(const QString& dir)
 {
   removePath(dir);
   QDirIterator it(dir, game_filters, QDir::NoFilter, QDirIterator::Subdirectories);
@@ -57,7 +96,7 @@ void GameTracker::RemoveDirectory(const QString& dir)
   }
 }
 
-void GameTracker::UpdateDirectory(const QString& dir)
+void GameTracker::UpdateDirectoryInternal(const QString& dir)
 {
   QDirIterator it(dir, game_filters, QDir::NoFilter, QDirIterator::Subdirectories);
   while (it.hasNext())
@@ -74,7 +113,7 @@ void GameTracker::UpdateDirectory(const QString& dir)
     {
       addPath(path);
       m_tracked_files[path] = QSet<QString>{dir};
-      m_load_thread.EmplaceItem(path);
+      LoadGame(path);
     }
   }
 
@@ -88,6 +127,21 @@ void GameTracker::UpdateDirectory(const QString& dir)
       m_tracked_files.remove(missing);
       GameRemoved(missing);
     }
+  }
+}
+
+void GameTracker::UpdateFileInternal(const QString& file)
+{
+  if (QFileInfo(file).exists())
+  {
+    GameRemoved(file);
+    addPath(file);
+    LoadGame(file);
+  }
+  else if (removePath(file))
+  {
+    m_tracked_files.remove(file);
+    emit GameRemoved(file);
   }
 }
 
@@ -111,22 +165,6 @@ QSet<QString> GameTracker::FindMissingFiles(const QString& dir)
   }
 
   return missing_files;
-}
-
-void GameTracker::UpdateFile(const QString& file)
-{
-  if (QFileInfo(file).exists())
-  {
-    GameRemoved(file);
-    addPath(file);
-
-    m_load_thread.EmplaceItem(file);
-  }
-  else if (removePath(file))
-  {
-    m_tracked_files.remove(file);
-    emit GameRemoved(file);
-  }
 }
 
 void GameTracker::LoadGame(const QString& path)

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -34,14 +34,33 @@ signals:
   void GameRemoved(const QString& path);
 
 private:
-  void LoadGame(const QString& path);
   void UpdateDirectory(const QString& dir);
   void UpdateFile(const QString& path);
+  void AddDirectoryInternal(const QString& dir);
+  void RemoveDirectoryInternal(const QString& dir);
+  void UpdateDirectoryInternal(const QString& dir);
+  void UpdateFileInternal(const QString& path);
   QSet<QString> FindMissingFiles(const QString& dir);
+  void LoadGame(const QString& path);
+
+  enum class CommandType
+  {
+    LoadCache,
+    AddDirectory,
+    RemoveDirectory,
+    UpdateDirectory,
+    UpdateFile,
+  };
+
+  struct Command
+  {
+    CommandType type;
+    QString path;
+  };
 
   // game path -> directories that track it
   QMap<QString, QSet<QString>> m_tracked_files;
-  Common::WorkQueueThread<QString> m_load_thread;
+  Common::WorkQueueThread<Command> m_load_thread;
   UICommon::GameFileCache m_cache;
   Core::TitleDatabase m_title_database;
 };


### PR DESCRIPTION
This reduces the time from startup to the game list window showing up.

I made this commit because it combined with PR #6281 would let me make the cached games show up in the game list before we check which of them actually exist on the file system, like in DolphinWX, which will make the game list fully populated quicker than in master. But I figured I might as well submit it as a separate PR, since it has some benefit on its own.