### PR TITLE
Fixed SIGSEGV in PPCDebugInterface When Reading Too Early in The Boot Process

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -88,7 +88,7 @@ unsigned int PPCDebugInterface::ReadInstruction(unsigned int address)
 
 bool PPCDebugInterface::IsAlive()
 {
-  return Core::IsRunning();
+  return Core::IsRunningAndStarted();
 }
 
 bool PPCDebugInterface::IsBreakpoint(unsigned int address)


### PR DESCRIPTION
I was encountering a weird issue when starting dolphin with the debug flag. It would immediately crash when trying to open a game **UNLESS** I had dolphin's window set to fullscreen.
It turns out that I was encountering a multithreading issue where the DR bit of MSR was not yet set. This caused a segfault when it was trying to read address 0. It is trivial to confirm that this is a multithreading issue because if you add a sleep before reading the DR bit it is properly set.
In order to fix this I simply changed PPCDebugInterface's isAlive() function to use Core::IsRunningAndStarted() instead of Core::IsRunning() which it was using previously. I also want to point out that Core::IsRunning() is kind of weird. It unnecessarily checks s_hardware_initialized.
While not necessary to fix the crash I also moved the code for setting that it is finished initializing / booting to after CBoot::BootUp happens (which initializes MSR).

There are a few other solutions I tried which worked:
Delaying before reading DR: Bad
Returning false when trying to read when DR is 0: Doesn't address the root of the problem
Changing IsRunning to s_hardware_initialized && !s_is_stopping: This might not be what IsRunning is meant to do.
  

It might also be worth checking if the comment on line 20 of PPCDebugInterface is still valid with this patch (my changes don't seem to be relevant to shutting down so it probably still doesn't work).