### PR TITLE
macOS Dolphinbar fixes

### DIFF
--- a/Externals/hidapi/applied_patches/0001-macOS-Use-unique-IDs-for-HID-paths.patch
+++ b/Externals/hidapi/applied_patches/0001-macOS-Use-unique-IDs-for-HID-paths.patch
@@ -1,0 +1,62 @@
+From 8d5810a1038347b9e56d41334d3f83641c913b3d Mon Sep 17 00:00:00 2001
+From: Vincent Duvert <vincent@duvert.net>
+Date: Sun, 7 Jan 2018 11:00:01 +0100
+Subject: [PATCH 1/2] macOS: Use unique IDs for HID paths
+
+If available, use the system-generated unique ID for HID device paths instead of a transport/vid/pid/location tuple.
+The Mayflash Dolphinbar registers four HID devices (regardless of the number of connected Wiimotes) which had the same path with the previous path building method, causing a bit of confusion when detecting and connecting to Wiimotes.
+The unique IDs do not change if the computer is suspended and resumed, but do change if the HID device is unplugged/replugged.
+---
+ Externals/hidapi/mac/hid.c | 21 ++++++++++++++++-----
+ 1 file changed, 16 insertions(+), 5 deletions(-)
+
+diff --git a/Externals/hidapi/mac/hid.c b/Externals/hidapi/mac/hid.c
+index 38bb635af2..46a97886d7 100644
+--- a/Externals/hidapi/mac/hid.c
++++ b/Externals/hidapi/mac/hid.c
+@@ -217,6 +217,11 @@ static int32_t get_location_id(IOHIDDeviceRef device)
+ 	return get_int_property(device, CFSTR(kIOHIDLocationIDKey));
+ }
+ 
++static int32_t get_unique_id(IOHIDDeviceRef device)
++{
++	return get_int_property(device, CFSTR(kIOHIDUniqueIDKey));
++}
++
+ static int32_t get_max_report_length(IOHIDDeviceRef device)
+ {
+ 	return get_int_property(device, CFSTR(kIOHIDMaxInputReportSizeKey));
+@@ -337,6 +342,7 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
+ 	unsigned short vid, pid;
+ 	char transport[32];
+ 	int32_t location;
++	int32_t unique_id;
+ 
+ 	buf[0] = '\0';
+ 
+@@ -347,12 +353,17 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
+ 	if (!res)
+ 		return -1;
+ 
+-	location = get_location_id(device);
+-	vid = get_vendor_id(device);
+-	pid = get_product_id(device);
++	unique_id = get_unique_id(device);
++	if (unique_id != 0) {
++		res = snprintf(buf, len, "id_%x", unique_id);
++	} else {
++		location = get_location_id(device);
++		vid = get_vendor_id(device);
++		pid = get_product_id(device);
+ 
+-	res = snprintf(buf, len, "%s_%04hx_%04hx_%x",
+-                       transport, vid, pid, location);
++		res = snprintf(buf, len, "%s_%04hx_%04hx_%x",
++	                       transport, vid, pid, location);
++	}
+ 
+ 
+ 	buf[len-1] = '\0';
+-- 
+2.14.3 (Apple Git-98)
+

--- a/Externals/hidapi/applied_patches/0002-macOS-Add-errno-setting-in-set_report-HID.patch
+++ b/Externals/hidapi/applied_patches/0002-macOS-Add-errno-setting-in-set_report-HID.patch
@@ -1,0 +1,51 @@
+From 3abc288e02089b3143547177e027d3820e5d7e59 Mon Sep 17 00:00:00 2001
+From: Vincent Duvert <vincent@duvert.net>
+Date: Sun, 7 Jan 2018 11:14:51 +0100
+Subject: [PATCH 2/2] macOS: Add errno setting in set_report (HID)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+IsDeviceUsable in IOhidapi.cpp uses errno to detect if hid_write failed because of an unconnected Wiimote on a Dolphinbar (it expects errno == EPIPE in this case).
+macOS’s implementation of hid_write detected this specific error (IOHIDDeviceSetReport returns kUSBHostReturnPipeStalled) but didn’t set errno so the check failed.
+This add errno assignment to failure cases of macOS’s hid_write.
+---
+ Externals/hidapi/mac/hid.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/Externals/hidapi/mac/hid.c b/Externals/hidapi/mac/hid.c
+index 46a97886d7..70b615d40d 100644
+--- a/Externals/hidapi/mac/hid.c
++++ b/Externals/hidapi/mac/hid.c
+@@ -773,8 +773,10 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
+ 	IOReturn res;
+ 
+ 	/* Return if the device has been disconnected. */
+-	if (dev->disconnected)
++	if (dev->disconnected) {
++		errno = ENODEV;
+ 		return -1;
++	}
+ 
+ 	if (data[0] == 0x0) {
+ 		/* Not using numbered Reports.
+@@ -797,9 +799,14 @@ static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char
+ 
+ 		if (res == kIOReturnSuccess) {
+ 			return length;
+-		}
+-		else
++		} else if (res == (IOReturn)0xe0005000) {
++		  /* Kernel.framework's IOUSBHostFamily.h defines this error as kUSBHostReturnPipeStalled */
++			errno = EPIPE;
++			return -1;
++		} else {
++			errno = EBUSY;
+ 			return -1;
++		}
+ 	}
+ 
+ 	return -1;
+-- 
+2.14.3 (Apple Git-98)
+

--- a/Externals/hidapi/mac/hid.c
+++ b/Externals/hidapi/mac/hid.c
@@ -217,6 +217,11 @@ static int32_t get_location_id(IOHIDDeviceRef device)
 	return get_int_property(device, CFSTR(kIOHIDLocationIDKey));
 }
 
+static int32_t get_unique_id(IOHIDDeviceRef device)
+{
+	return get_int_property(device, CFSTR(kIOHIDUniqueIDKey));
+}
+
 static int32_t get_max_report_length(IOHIDDeviceRef device)
 {
 	return get_int_property(device, CFSTR(kIOHIDMaxInputReportSizeKey));
@@ -337,6 +342,7 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
 	unsigned short vid, pid;
 	char transport[32];
 	int32_t location;
+	int32_t unique_id;
 
 	buf[0] = '\0';
 
@@ -347,12 +353,17 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
 	if (!res)
 		return -1;
 
-	location = get_location_id(device);
-	vid = get_vendor_id(device);
-	pid = get_product_id(device);
+	unique_id = get_unique_id(device);
+	if (unique_id != 0) {
+		res = snprintf(buf, len, "id_%x", unique_id);
+	} else {
+		location = get_location_id(device);
+		vid = get_vendor_id(device);
+		pid = get_product_id(device);
 
-	res = snprintf(buf, len, "%s_%04hx_%04hx_%x",
-                       transport, vid, pid, location);
+		res = snprintf(buf, len, "%s_%04hx_%04hx_%x",
+	                       transport, vid, pid, location);
+	}
 
 
 	buf[len-1] = '\0';


### PR DESCRIPTION
This pull request fixes some problems I encountered while testing a Mayflash Dolphinbar under macOS Sierra/High Sierra.

The first problem was that despite the Wiimote being detected by Dolphin, the buttons/sensors wouldn’t actually work. Looking at the logs, I noticed that Dolphin was detecting four “Mayflash Dolphinbar” HID devices and connected successfully with all four of them, which was unexpected since I have only one Wiimote synced with the Dolphinbar. On a hunch, I tried to set up Dolphin to emulate four real Wiimotes, and my Wiimote started working… as Wiimote 4.

I noticed in the logs that the four detected HID devices all had the same paths. On macOS the path is generated by taking the transport, VID, PID and location of the HID device. That’s a problem because the Dolphinbar provides four HID devices (one per Wiimote that could be connected) which have the same transport/VID/PID/location.

I found out that IOKit was providing a unique ID for all HID devices, and modified the path building code to use it (the same code is used to generate the path for a device and to lookup a device using this path). I left the old code path in place in case the unique ID property is not available (it was introduced in OS X 10.11).

This change made the Wiimote correctly detected and usable (as number 1), except that the logs were reporting three “Couldn't write to Wii Remote XXX” errors at each scan. I noticed that the code in IOhidapi.cpp was expecting `hid_write` to fail with `errno` = `EPIPE` when attempting to connect to a Dolphinbar HID device without an associated controller. Under macOS, `hid_write` calls `IOHIDDeviceSetReport` which returns failure code `0xe0005000` (defined as `kUSBHostReturnPipeStalled` in Kernel.framework) in that case, but doesn’t set errno. I modified the code to set errno in the various failure cases of this function.

I tested the changes on macOS Sierra and High Sierra, with a Wiimote connected to the Dolphinbar, a Wiimote connected to Bluetooth, and a USB controller.

I hard-coded the value of `kUSBHostReturnPipeStalled` because I couldn’t figure out how to #include Kernel.framework’s IOUSBHostFamily.h. Using `#include <Kernel/IOKit/usb/IOUSBHostFamily.h>` (which is how other framework includes are done) results in an error because that file tries to include `IOKit/usb/StandardUSB.h` which is not on the include path. It could probably be fixed by adding Kernel.framework to the include paths, but that seems a bit excessive to me as it would just be used to retrieve a constant.