### PR TITLE
[Android] Fix for single char name for Wii and WAD Games

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -29,6 +29,7 @@
 constexpr u32 CODEPAGE_SHIFT_JIS = 932;
 constexpr u32 CODEPAGE_WINDOWS_1252 = 1252;
 #else
+#include <codecvt>
 #include <errno.h>
 #include <iconv.h>
 #include <locale.h>
@@ -564,7 +565,8 @@ std::string UTF8ToSHIFTJIS(const std::string& input)
 
 std::string UTF16ToUTF8(const std::wstring& input)
 {
-  return CodeToUTF8("UTF-16LE", input);
+  std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+  return converter.to_bytes(input);
 }
 
 std::string UTF16BEToUTF8(const char16_t* str, size_t max_size)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -472,6 +472,14 @@ std::string CP1252ToUTF8(const std::string& input)
   return UTF16ToUTF8(CPToUTF16(CODEPAGE_WINDOWS_1252, input));
 }
 
+std::string UTF16BEToUTF8(const char16_t* str, size_t max_size)
+{
+  const char16_t* str_end = std::find(str, str + max_size, '\0');
+  std::wstring result(static_cast<size_t>(str_end - str), '\0');
+  std::transform(str, str_end, result.begin(), static_cast<u16 (&)(u16)>(Common::swap16));
+  return UTF16ToUTF8(result);
+}
+
 #else
 
 template <typename T>
@@ -559,12 +567,12 @@ std::string UTF16ToUTF8(const std::wstring& input)
   return CodeToUTF8("UTF-16LE", input);
 }
 
-#endif
-
 std::string UTF16BEToUTF8(const char16_t* str, size_t max_size)
 {
   const char16_t* str_end = std::find(str, str + max_size, '\0');
-  std::wstring result(static_cast<size_t>(str_end - str), '\0');
+  std::u16string result(static_cast<size_t>(str_end - str), '\0');
   std::transform(str, str_end, result.begin(), static_cast<u16 (&)(u16)>(Common::swap16));
-  return UTF16ToUTF8(result);
+  return CodeToUTF8("UTF-16LE", result);
 }
+
+#endif

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -570,9 +570,7 @@ std::string UTF16ToUTF8(const std::wstring& input)
 std::string UTF16BEToUTF8(const char16_t* str, size_t max_size)
 {
   const char16_t* str_end = std::find(str, str + max_size, '\0');
-  std::u16string result(static_cast<size_t>(str_end - str), '\0');
-  std::transform(str, str_end, result.begin(), static_cast<u16 (&)(u16)>(Common::swap16));
-  return CodeToUTF8("UTF-16LE", result);
+  return CodeToUTF8("UTF-16BE", std::u16string(str, static_cast<size_t>(str_end - str)));
 }
 
 #endif


### PR DESCRIPTION
The issue seems to be when inserting the value into the GameDatabase. The value is correctly read from the file, but every character seems to be alternated with a null-terminating character, `\0`, thus when the string is returned to the Java environment via `.c_str()`, only the first character is then shown. I added a RemoveNullTermChars method to strip them out, and applied it to the GetTitle, GetDescription, and GetCompany methods.