### PR TITLE
ISOProperties: Rename "Edit Config" and "Show Defaults"

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
@@ -231,13 +231,17 @@ void CISOProperties::CreateGUIControls()
 {
   const int space5 = FromDIP(5);
 
-  wxButton* const edit_config = new wxButton(this, ID_EDITCONFIG, _("Edit Config"));
-  edit_config->SetToolTip(_("This will let you manually edit the INI config file."));
+  wxButton* const edit_config = new wxButton(this, ID_EDITCONFIG, _("Edit User Config"));
+  edit_config->SetToolTip(
+      _("Allows manual editing of the user configuration INI file for this "
+        "game. Settings in the user config INI override default config INI settings."));
 
   wxButton* const edit_default_config =
-      new wxButton(this, ID_SHOWDEFAULTCONFIG, _("Show Defaults"));
+      new wxButton(this, ID_SHOWDEFAULTCONFIG, _("View Default Config"));
   edit_default_config->SetToolTip(
-      _("Opens the default (read-only) configuration for this game in an external text editor."));
+      _("Displays the default configuration INI file(s) for this game. These defaults are "
+        "recommended settings from the developers to avoid known issues. Changes should be made to "
+        "the user config INI files only, not to default config INI files."));
 
   // Notebook
   wxNotebook* const notebook = new wxNotebook(this, ID_NOTEBOOK);


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10775

These were very confusing to me due to the reasons outlined in the link above.