### PR TITLE
Fix Auto-Adjust Window Size option making the window too large

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -622,8 +622,6 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   g_texture_cache->OnConfigChanged(g_ActiveConfig);
   VertexShaderCache::RetreiveAsyncShaders();
 
-  SetWindowSize(xfb_texture->GetConfig().width, xfb_texture->GetConfig().height);
-
   const bool window_resized = CheckForResize();
   const bool fullscreen = D3D::GetFullscreenState();
   const bool fs_changed = m_last_fullscreen_mode != fullscreen;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1430,8 +1430,6 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   }
 #endif
 
-  // Update the render window position and the backbuffer size
-  SetWindowSize(xfb_texture->GetConfig().width, xfb_texture->GetConfig().height);
   GLInterface->Update();
 
   // Was the size changed since the last frame?

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -545,10 +545,6 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   // Handle host window resizes.
   CheckForSurfaceChange();
 
-  // Update the window size based on the frame that was just rendered.
-  // Due to depending on guest state, we need to call this every frame.
-  SetWindowSize(xfb_texture->GetConfig().width, xfb_texture->GetConfig().height);
-
   // Clean up stale textures.
   TextureCache::GetInstance()->Cleanup(frameCount);
 


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10658

When using the Auto-Adjust Window Size option, SetWindowSize was applying the scale factor to the already-scaled size, causing the window to become massive for anything above 1x IR.