### PR TITLE
Android: Don't hard code the user dircetory path to /sdcard/dolphin-emu 

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
@@ -15,8 +15,6 @@ public class DolphinApplication extends Application
 	{
 		super.onCreate();
 
-		NativeLibrary.SetUserDirectory("");  // Empty string means use the default path
-
 		if (PermissionsHandler.hasWriteAccess(getApplicationContext()))
 			DirectoryInitializationService.startService(getApplicationContext());
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -158,11 +158,20 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 				DirectoryInitializationService.BROADCAST_ACTION);
 
 		directoryStateReceiver =
-				new DirectoryStateReceiver(directoryInitializationState -> {
-					if (directoryInitializationState == DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED) {
+				new DirectoryStateReceiver(directoryInitializationState ->
+				{
+					if (directoryInitializationState == DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED)
+					{
 						mEmulationState.run(activity.isActivityRecreated());
-					} else if (directoryInitializationState == DirectoryInitializationState.EXTERNAL_STORAGE_PERMISSION_NEEDED) {
+					}
+					else if (directoryInitializationState == DirectoryInitializationState.EXTERNAL_STORAGE_PERMISSION_NEEDED)
+					{
 						Toast.makeText(getContext(), R.string.write_permission_needed, Toast.LENGTH_SHORT)
+								.show();
+					}
+					else if (directoryInitializationState == DirectoryInitializationState.CANT_FIND_EXTERNAL_STORAGE)
+					{
+						Toast.makeText(getContext(), R.string.external_storage_not_mounted, Toast.LENGTH_SHORT)
 								.show();
 					}
 				});

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
@@ -162,6 +162,13 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 	}
 
 	@Override
+	public void showExternalStorageNotMountedHint()
+	{
+		Toast.makeText(this, R.string.external_storage_not_mounted, Toast.LENGTH_SHORT)
+				.show();
+	}
+
+	@Override
 	public HashMap<String, SettingSection> getSettings(int file)
 	{
 		return mPresenter.getSettings(file);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
@@ -119,6 +119,11 @@ public interface SettingsActivityView
 	void showPermissionNeededHint();
 
 	/**
+	 * Show a hint to the user that the app needs the external storage to be mounted
+	 */
+	void showExternalStorageNotMountedHint();
+
+	/**
 	 * Start the DirectoryInitializationService and listen for the result.
 	 *
 	 * @param receiver the broadcast receiver for the DirectoryInitializationService

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -1,6 +1,5 @@
 package org.dolphinemu.dolphinemu.utils;
 
-import android.os.Environment;
 import android.support.annotation.NonNull;
 
 import org.dolphinemu.dolphinemu.model.settings.BooleanSetting;
@@ -9,6 +8,7 @@ import org.dolphinemu.dolphinemu.model.settings.IntSetting;
 import org.dolphinemu.dolphinemu.model.settings.Setting;
 import org.dolphinemu.dolphinemu.model.settings.SettingSection;
 import org.dolphinemu.dolphinemu.model.settings.StringSetting;
+import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsActivityView;
 
 import java.io.BufferedReader;
@@ -393,8 +393,7 @@ public final class SettingsFile
 	@NonNull
 	private static File getSettingsFile(String fileName)
 	{
-		String storagePath = Environment.getExternalStorageDirectory().getAbsolutePath();
-		return new File(storagePath + "/dolphin-emu/Config/" + fileName + ".ini");
+		return new File(DirectoryInitializationService.getUserDirectory() + "/Config/" + fileName + ".ini");
 	}
 
 	private static SettingSection sectionFromLine(String line)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -251,4 +251,6 @@
     <string name="load_settings">Loading Settings...</string>
 
     <string name="emulation_change_disc">Change Disc</string>
+
+    <string name="external_storage_not_mounted">The external storage needs to be available in order to use Dolphin</string>
 </resources>


### PR DESCRIPTION
Android is allowed to pick any path for the external storage media and
that's why we should always use Environment.getExternalStorageDirectory()
to get the external storage path

I need to test this first, I will ask the user who posted the issue on the forums to test if that solve the problem. If others can help me test it, that would be appreciated since all my devices don't have the issue.

for more info:
https://forums.dolphin-emu.org/Thread-unable-to-create-dolphin-folder-hence-settings-won-t-save?pid=460539#pid460539