### PR TITLE
Android: Fix settings screen animation if Animator Duration Scale is Off

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AppCompatActivity;
@@ -106,11 +107,14 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
 		if (addToStack)
 		{
-			transaction.setCustomAnimations(
-					R.animator.settings_enter,
-					R.animator.settings_exit,
-					R.animator.settings_pop_enter,
-					R.animator.setttings_pop_exit);
+			if (areSystemAnimationsEnabled())
+			{
+				transaction.setCustomAnimations(
+						R.animator.settings_enter,
+						R.animator.settings_exit,
+						R.animator.settings_pop_enter,
+						R.animator.setttings_pop_exit);
+			}
 
 			transaction.addToBackStack(null);
 			mPresenter.addToStack();
@@ -118,6 +122,17 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 		transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag), FRAGMENT_TAG);
 
 		transaction.commit();
+	}
+
+	private boolean areSystemAnimationsEnabled()
+	{
+		float duration = Settings.Global.getFloat(
+				getContentResolver(),
+				Settings.Global.ANIMATOR_DURATION_SCALE, 1);
+		float transition = Settings.Global.getFloat(
+				getContentResolver(),
+				Settings.Global.TRANSITION_ANIMATION_SCALE, 1);
+		return duration != 0 && transition != 0;
 	}
 
 	@Override


### PR DESCRIPTION
If Animator Duration Scale is Off, the Enhancements/Hacks screens were
not visible unless you enable the Animator Duration Scale back. This
make sure screens will be visible regardless of your animation settings.

for more info:
https://www.reddit.com/r/DolphinEmulator/comments/7o6abu/dolphin_emulator_android_version_fix_for_when/