### PR TITLE
Have dolphin-emu-nogui conform to the _NET_WM_PID protocol

### DIFF
--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -141,9 +141,14 @@ void Host_UpdateProgressDialog(const char* caption, int position, int total)
 }
 
 #if HAVE_X11
+#include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 #include "UICommon/X11Utils.h"
+#ifndef HOST_NAME_MAX
+#include <climits>
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
 
 class PlatformX11 : public Platform
 {
@@ -172,6 +177,16 @@ class PlatformX11 : public Platform
     Atom wmProtocols[1];
     wmProtocols[0] = XInternAtom(dpy, "WM_DELETE_WINDOW", True);
     XSetWMProtocols(dpy, win, wmProtocols, 1);
+    pid_t pid = getpid();
+    XChangeProperty(dpy, win, XInternAtom(dpy, "_NET_WM_PID", False), XA_CARDINAL, 32,
+                    PropModeReplace, reinterpret_cast<unsigned char*>(&pid), 1);
+    char host_name[HOST_NAME_MAX] = "";
+    if (!gethostname(host_name, sizeof(host_name)))
+    {
+      XTextProperty wmClientMachine = {reinterpret_cast<unsigned char*>(host_name), XA_STRING, 8,
+                                       strlen(host_name)};
+      XSetWMClientMachine(dpy, win, &wmClientMachine);
+    }
     XMapRaised(dpy, win);
     XFlush(dpy);
     s_window_handle = (void*)win;


### PR DESCRIPTION
To allow our management application to map the window opened by `dolphin-emu-nogui` to the spawned child pid, we use the `_NET_WM_PID` protocol as [documented](https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html).

When running `dolphin-emu` (with GUI), all required window properties are set. `dolphin-emu-nogui` however does not even set class hints.

This patch sets the `_NET_WM_PID` property of the emulator window, as well as the `WM_CLIENT_MACHINE` property, which is required as per spec.