### PR TITLE
Qt: Fix render window resize bug

### DIFF
--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -2,12 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinQt2/Host.h"
+
 #include <QAbstractEventDispatcher>
 #include <QApplication>
 
 #include "Common/Common.h"
+#include "Core/ConfigManager.h"
 #include "Core/Host.h"
-#include "DolphinQt2/Host.h"
+#include "VideoCommon/RenderBase.h"
 
 Host::Host() = default;
 
@@ -45,6 +48,12 @@ bool Host::GetRenderFullscreen()
 void Host::SetRenderFullscreen(bool fullscreen)
 {
   m_render_fullscreen = fullscreen;
+}
+
+void Host::UpdateSurface()
+{
+  if (g_renderer)
+    g_renderer->ChangeSurface(GetRenderHandle());
 }
 
 void Host_Message(int id)

--- a/Source/Core/DolphinQt2/Host.h
+++ b/Source/Core/DolphinQt2/Host.h
@@ -26,6 +26,7 @@ public:
   void SetRenderHandle(void* handle);
   void SetRenderFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
+  void UpdateSurface();
 
 signals:
   void RequestTitle(const QString& title);

--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -22,6 +22,8 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
           Qt::DirectConnection);
   connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle,
           Qt::DirectConnection);
+  connect(this, &RenderWidget::SizeChanged, Host::GetInstance(), &Host::UpdateSurface,
+          Qt::DirectConnection);
 
   emit HandleChanged((void*)winId());
 
@@ -74,6 +76,9 @@ bool RenderWidget::event(QEvent* event)
     break;
   case QEvent::WindowDeactivate:
     Host::GetInstance()->SetRenderFocus(false);
+    break;
+  case QEvent::Resize:
+    emit SizeChanged();
     break;
   case QEvent::WindowStateChange:
     emit StateChanged(isFullScreen());

--- a/Source/Core/DolphinQt2/RenderWidget.h
+++ b/Source/Core/DolphinQt2/RenderWidget.h
@@ -23,6 +23,7 @@ signals:
   void Closed();
   void HandleChanged(void* handle);
   void StateChanged(bool fullscreen);
+  void SizeChanged();
 
 private:
   void HandleCursorTimer();


### PR DESCRIPTION
Fixes the bug that the render surface isn't getting resized when the surface is resized (Seems to only occur when using Vulkan for some reason).