### PR TITLE
MSAA support for Abstract Textures

### DIFF
--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -52,33 +52,28 @@ DXGI_FORMAT GetDXGIFormatForHostFormat(AbstractTextureFormat format)
 
 DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_config)
 {
-  DXGI_FORMAT dxgi_format = GetDXGIFormatForHostFormat(m_config.format);
-  if (m_config.rendertarget)
-  {
-    m_texture = D3DTexture2D::Create(
-        m_config.width, m_config.height,
-        (D3D11_BIND_FLAG)((int)D3D11_BIND_RENDER_TARGET | (int)D3D11_BIND_SHADER_RESOURCE),
-        D3D11_USAGE_DEFAULT, dxgi_format, 1, m_config.layers);
-  }
-  else
-  {
-    const D3D11_TEXTURE2D_DESC texdesc =
-        CD3D11_TEXTURE2D_DESC(dxgi_format, m_config.width, m_config.height, 1, m_config.levels,
-                              D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0);
+  DXGI_FORMAT tex_format = GetDXGIFormatForHostFormat(m_config.format);
+  UINT bind_flags = D3D11_BIND_SHADER_RESOURCE;
+  if (tex_config.rendertarget)
+    bind_flags |= D3D11_BIND_RENDER_TARGET;
 
-    ID3D11Texture2D* pTexture;
-    const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);
-    CHECK(SUCCEEDED(hr), "Create texture of the TextureCache");
+  CD3D11_TEXTURE2D_DESC texdesc(tex_format, tex_config.width, tex_config.height, tex_config.layers,
+                                tex_config.levels, bind_flags, D3D11_USAGE_DEFAULT, 0,
+                                tex_config.samples, 0, 0);
 
-    m_texture = new D3DTexture2D(pTexture, D3D11_BIND_SHADER_RESOURCE);
+  ID3D11Texture2D* pTexture;
+  HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);
+  CHECK(SUCCEEDED(hr), "Create backing DXTexture");
 
-    // TODO: better debug names
-    D3D::SetDebugObjectName(m_texture->GetTex(), "a texture of the TextureCache");
-    D3D::SetDebugObjectName(m_texture->GetSRV(),
-                            "shader resource view of a texture of the TextureCache");
+  m_texture = new D3DTexture2D(
+      pTexture, static_cast<D3D11_BIND_FLAG>(bind_flags), tex_format, DXGI_FORMAT_UNKNOWN,
+      tex_config.rendertarget ? tex_format : DXGI_FORMAT_UNKNOWN, tex_config.samples > 1);
 
-    SAFE_RELEASE(pTexture);
-  }
+  D3D::SetDebugObjectName(m_texture->GetTex(), "a texture of the TextureCache");
+  D3D::SetDebugObjectName(m_texture->GetSRV(),
+                          "shader resource view of a texture of the TextureCache");
+
+  SAFE_RELEASE(pTexture);
 }
 
 DXTexture::~DXTexture()
@@ -150,6 +145,22 @@ void DXTexture::ScaleRectangleFromTexture(const AbstractTexture* source,
 
   FramebufferManager::BindEFBRenderTarget();
   g_renderer->RestoreAPIState();
+}
+
+void DXTexture::ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                                   u32 layer, u32 level)
+{
+  const DXTexture* srcentry = static_cast<const DXTexture*>(src);
+  _dbg_assert_(VIDEO, m_config.samples > 1 && m_config.width == srcentry->m_config.width &&
+                          m_config.height == srcentry->m_config.height && m_config.samples == 1);
+  _dbg_assert_(VIDEO,
+               rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
+                   rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
+
+  D3D::context->ResolveSubresource(
+      m_texture->GetTex(), D3D11CalcSubresource(level, layer, m_config.levels),
+      srcentry->m_texture->GetTex(), D3D11CalcSubresource(level, layer, srcentry->m_config.levels),
+      GetDXGIFormatForHostFormat(m_config.format));
 }
 
 void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,

--- a/Source/Core/VideoBackends/D3D/DXTexture.h
+++ b/Source/Core/VideoBackends/D3D/DXTexture.h
@@ -28,6 +28,8 @@ public:
   void ScaleRectangleFromTexture(const AbstractTexture* source,
                                  const MathUtil::Rectangle<int>& srcrect,
                                  const MathUtil::Rectangle<int>& dstrect) override;
+  void ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                          u32 layer, u32 level) override;
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;
 

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -43,7 +43,7 @@ PSTextureEncoder::~PSTextureEncoder() = default;
 void PSTextureEncoder::Init()
 {
   // TODO: Move this to a constant somewhere in common.
-  TextureConfig encoding_texture_config(EFB_WIDTH * 4, 1024, 1, 1, AbstractTextureFormat::BGRA8,
+  TextureConfig encoding_texture_config(EFB_WIDTH * 4, 1024, 1, 1, 1, AbstractTextureFormat::BGRA8,
                                         true);
   m_encoding_render_texture = g_renderer->CreateTexture(encoding_texture_config);
   m_encoding_readback_texture =

--- a/Source/Core/VideoBackends/Null/NullTexture.cpp
+++ b/Source/Core/VideoBackends/Null/NullTexture.cpp
@@ -25,6 +25,10 @@ void NullTexture::ScaleRectangleFromTexture(const AbstractTexture* source,
                                             const MathUtil::Rectangle<int>& dstrect)
 {
 }
+void NullTexture::ResolveFromTexture(const AbstractTexture* src,
+                                     const MathUtil::Rectangle<int>& rect, u32 layer, u32 level)
+{
+}
 
 void NullTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
                        size_t buffer_size)

--- a/Source/Core/VideoBackends/Null/NullTexture.h
+++ b/Source/Core/VideoBackends/Null/NullTexture.h
@@ -28,6 +28,8 @@ public:
   void ScaleRectangleFromTexture(const AbstractTexture* source,
                                  const MathUtil::Rectangle<int>& srcrect,
                                  const MathUtil::Rectangle<int>& dstrect) override;
+  void ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                          u32 layer, u32 level) override;
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;
 };

--- a/Source/Core/VideoBackends/OGL/OGLTexture.h
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.h
@@ -28,6 +28,8 @@ public:
   void ScaleRectangleFromTexture(const AbstractTexture* source,
                                  const MathUtil::Rectangle<int>& srcrect,
                                  const MathUtil::Rectangle<int>& dstrect) override;
+  void ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                          u32 layer, u32 level) override;
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;
 
@@ -38,6 +40,10 @@ public:
   static void SetStage();
 
 private:
+  void BlitFramebuffer(OGLTexture* srcentry, const MathUtil::Rectangle<int>& src_rect,
+                       u32 src_layer, u32 src_level, const MathUtil::Rectangle<int>& dst_rect,
+                       u32 dst_layer, u32 dst_level);
+
   GLuint m_texId;
   GLuint m_framebuffer = 0;
 };

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -86,7 +86,7 @@ static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyParams& params)
 
 void Init()
 {
-  TextureConfig config(renderBufferWidth, renderBufferHeight, 1, 1, AbstractTextureFormat::BGRA8,
+  TextureConfig config(renderBufferWidth, renderBufferHeight, 1, 1, 1, AbstractTextureFormat::BGRA8,
                        true);
   s_encoding_render_texture = g_renderer->CreateTexture(config);
   s_encoding_readback_texture =

--- a/Source/Core/VideoBackends/Software/SWTexture.cpp
+++ b/Source/Core/VideoBackends/Software/SWTexture.cpp
@@ -90,6 +90,10 @@ void SWTexture::ScaleRectangleFromTexture(const AbstractTexture* source,
     memcpy(GetData(), destination_pixels.data(), destination_pixels.size());
   }
 }
+void SWTexture::ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                                   u32 layer, u32 level)
+{
+}
 
 void SWTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
                      size_t buffer_size)

--- a/Source/Core/VideoBackends/Software/SWTexture.h
+++ b/Source/Core/VideoBackends/Software/SWTexture.h
@@ -28,6 +28,8 @@ public:
   void ScaleRectangleFromTexture(const AbstractTexture* source,
                                  const MathUtil::Rectangle<int>& srcrect,
                                  const MathUtil::Rectangle<int>& dstrect) override;
+  void ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                          u32 layer, u32 level) override;
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;
 

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -846,8 +846,8 @@ bool FramebufferManager::CreateReadbackTextures()
     return false;
   }
 
-  TextureConfig readback_texture_config(EFB_WIDTH, EFB_HEIGHT, 1, 1, AbstractTextureFormat::RGBA8,
-                                        false);
+  TextureConfig readback_texture_config(EFB_WIDTH, EFB_HEIGHT, 1, 1, 1,
+                                        AbstractTextureFormat::RGBA8, false);
   m_color_readback_texture =
       g_renderer->CreateStagingTexture(StagingTextureType::Mutable, readback_texture_config);
   m_depth_readback_texture =

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -714,7 +714,7 @@ VkShaderModule TextureConverter::GetEncodingShader(const EFBCopyParams& params)
 
 bool TextureConverter::CreateEncodingTexture()
 {
-  TextureConfig config(ENCODING_TEXTURE_WIDTH, ENCODING_TEXTURE_HEIGHT, 1, 1,
+  TextureConfig config(ENCODING_TEXTURE_WIDTH, ENCODING_TEXTURE_HEIGHT, 1, 1, 1,
                        ENCODING_TEXTURE_FORMAT, true);
 
   m_encoding_render_texture = g_renderer->CreateTexture(config);

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -42,9 +42,10 @@ std::unique_ptr<VKTexture> VKTexture::Create(const TextureConfig& tex_config)
 
   // Allocate texture object
   VkFormat vk_format = Util::GetVkFormatForHostTextureFormat(tex_config.format);
-  auto texture = Texture2D::Create(tex_config.width, tex_config.height, tex_config.levels,
-                                   tex_config.layers, vk_format, VK_SAMPLE_COUNT_1_BIT,
-                                   VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL, usage);
+  auto texture =
+      Texture2D::Create(tex_config.width, tex_config.height, tex_config.levels, tex_config.layers,
+                        vk_format, static_cast<VkSampleCountFlagBits>(tex_config.samples),
+                        VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL, usage);
 
   if (!texture)
   {
@@ -56,8 +57,9 @@ std::unique_ptr<VKTexture> VKTexture::Create(const TextureConfig& tex_config)
   if (tex_config.rendertarget)
   {
     VkImageView framebuffer_attachments[] = {texture->GetView()};
-    VkRenderPass render_pass = g_object_cache->GetRenderPass(
-        texture->GetFormat(), VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
+    VkRenderPass render_pass =
+        g_object_cache->GetRenderPass(texture->GetFormat(), VK_FORMAT_UNDEFINED, tex_config.samples,
+                                      VK_ATTACHMENT_LOAD_OP_DONT_CARE);
     VkFramebufferCreateInfo framebuffer_info = {
         VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
         nullptr,
@@ -199,6 +201,41 @@ void VKTexture::ScaleRectangleFromTexture(const AbstractTexture* source,
   // Ensure both textures remain in the SHADER_READ_ONLY layout so they can be bound.
   src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+  m_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+}
+
+void VKTexture::ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                                   u32 layer, u32 level)
+{
+  const VKTexture* srcentry = static_cast<const VKTexture*>(src);
+  _dbg_assert_(VIDEO, m_config.samples > 1 && m_config.width == srcentry->m_config.width &&
+                          m_config.height == srcentry->m_config.height && m_config.samples == 1);
+  _dbg_assert_(VIDEO,
+               rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
+                   rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
+
+  // Resolving is considered to be a transfer operation.
+  VkImageLayout old_src_layout = srcentry->m_texture->GetLayout();
+  srcentry->m_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+  m_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+  VkImageResolve resolve = {
+      {VK_IMAGE_ASPECT_COLOR_BIT, level, layer, 1},                               // srcSubresource
+      {rect.left, rect.top, 0},                                                   // srcOffset
+      {VK_IMAGE_ASPECT_COLOR_BIT, level, layer, 1},                               // dstSubresource
+      {rect.left, rect.top, 0},                                                   // dstOffset
+      {static_cast<u32>(rect.GetWidth()), static_cast<u32>(rect.GetHeight()), 1}  // extent
+  };
+  vkCmdResolveImage(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                    srcentry->m_texture->GetImage(), srcentry->m_texture->GetLayout(),
+                    m_texture->GetImage(), m_texture->GetLayout(), 1, &resolve);
+
+  // Restore old source texture layout. Destination is assumed to be bound as a shader resource.
+  srcentry->m_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                          old_src_layout);
   m_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -30,6 +30,8 @@ public:
   void ScaleRectangleFromTexture(const AbstractTexture* source,
                                  const MathUtil::Rectangle<int>& src_rect,
                                  const MathUtil::Rectangle<int>& dst_rect) override;
+  void ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                          u32 layer, u32 level) override;
 
   void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
             size_t buffer_size) override;

--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -31,7 +31,7 @@ bool AbstractTexture::Save(const std::string& filename, unsigned int level)
 
   // Use a temporary staging texture for the download. Certainly not optimal,
   // but this is not a frequently-executed code path..
-  TextureConfig readback_texture_config(level_width, level_height, 1, 1,
+  TextureConfig readback_texture_config(level_width, level_height, 1, 1, 1,
                                         AbstractTextureFormat::RGBA8, false);
   auto readback_texture =
       g_renderer->CreateStagingTexture(StagingTextureType::Readback, readback_texture_config);

--- a/Source/Core/VideoCommon/AbstractTexture.h
+++ b/Source/Core/VideoCommon/AbstractTexture.h
@@ -26,6 +26,8 @@ public:
   virtual void ScaleRectangleFromTexture(const AbstractTexture* source,
                                          const MathUtil::Rectangle<int>& srcrect,
                                          const MathUtil::Rectangle<int>& dstrect) = 0;
+  virtual void ResolveFromTexture(const AbstractTexture* src, const MathUtil::Rectangle<int>& rect,
+                                  u32 layer, u32 level) = 0;
   virtual void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
                     size_t buffer_size) = 0;
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -719,7 +719,7 @@ void Renderer::RenderFrameDump()
       m_frame_dump_render_texture->GetConfig().height == static_cast<u32>(target_height))
   {
     // Recreate texture objects. Release before creating so we don't temporarily use twice the RAM.
-    TextureConfig config(target_width, target_height, 1, 1, AbstractTextureFormat::RGBA8, true);
+    TextureConfig config(target_width, target_height, 1, 1, 1, AbstractTextureFormat::RGBA8, true);
     m_frame_dump_render_texture.reset();
     m_frame_dump_render_texture = CreateTexture(config);
     _assert_(m_frame_dump_render_texture);

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -32,7 +32,6 @@
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/VideoCommon.h"
 
-class AbstractRawTexture;
 class AbstractTexture;
 class AbstractStagingTexture;
 class PostProcessingShaderImplementation;

--- a/Source/Core/VideoCommon/TextureConfig.cpp
+++ b/Source/Core/VideoCommon/TextureConfig.cpp
@@ -9,8 +9,8 @@
 
 bool TextureConfig::operator==(const TextureConfig& o) const
 {
-  return std::tie(width, height, levels, layers, format, rendertarget) ==
-         std::tie(o.width, o.height, o.levels, o.layers, o.format, o.rendertarget);
+  return std::tie(width, height, levels, layers, samples, format, rendertarget) ==
+         std::tie(o.width, o.height, o.levels, o.layers, o.samples, o.format, o.rendertarget);
 }
 
 bool TextureConfig::operator!=(const TextureConfig& o) const
@@ -37,4 +37,9 @@ size_t TextureConfig::GetStride() const
 size_t TextureConfig::GetMipStride(u32 level) const
 {
   return AbstractTexture::CalculateStrideForFormat(format, std::max(width >> level, 1u));
+}
+
+bool TextureConfig::IsMultisampled() const
+{
+  return samples > 1;
 }

--- a/Source/Core/VideoCommon/TextureConfig.h
+++ b/Source/Core/VideoCommon/TextureConfig.h
@@ -31,10 +31,10 @@ enum class StagingTextureType
 struct TextureConfig
 {
   constexpr TextureConfig() = default;
-  constexpr TextureConfig(u32 width_, u32 height_, u32 levels_, u32 layers_,
+  constexpr TextureConfig(u32 width_, u32 height_, u32 levels_, u32 layers_, u32 samples_,
                           AbstractTextureFormat format_, bool rendertarget_)
-      : width(width_), height(height_), levels(levels_), layers(layers_), format(format_),
-        rendertarget(rendertarget_)
+      : width(width_), height(height_), levels(levels_), layers(layers_), samples(samples_),
+        format(format_), rendertarget(rendertarget_)
   {
   }
 
@@ -44,11 +44,13 @@ struct TextureConfig
   MathUtil::Rectangle<int> GetMipRect(u32 level) const;
   size_t GetStride() const;
   size_t GetMipStride(u32 level) const;
+  bool IsMultisampled() const;
 
   u32 width = 0;
   u32 height = 0;
   u32 levels = 1;
   u32 layers = 1;
+  u32 samples = 1;
   AbstractTextureFormat format = AbstractTextureFormat::RGBA8;
   bool rendertarget = false;
 };

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -176,9 +176,6 @@
     <ClCompile Include="AbstractTexture.cpp">
       <Filter>Base</Filter>
     </ClCompile>
-    <ClCompile Include="AbstractRawTexture.cpp">
-      <Filter>Base</Filter>
-    </ClCompile>
     <ClCompile Include="ShaderGenCommon.cpp">
       <Filter>Shader Generators</Filter>
     </ClCompile>
@@ -354,9 +351,6 @@
       <Filter>Base</Filter>
     </ClInclude>
     <ClInclude Include="AbstractTexture.h">
-      <Filter>Base</Filter>
-    </ClInclude>
-    <ClInclude Include="AbstractRawTexture.h">
       <Filter>Base</Filter>
     </ClInclude>
     <ClInclude Include="AsyncShaderCompiler.h">


### PR DESCRIPTION
This is a prerequisite for moving FramebufferManager to common.

Still have to think about how to represent framebuffers and the EFB (with both color and depth attachments).