### PR TITLE
Support saving EFB and texture cache in save states

### DIFF
--- a/Data/Sys/GameSettings/NAT.ini
+++ b/Data/Sys/GameSettings/NAT.ini
@@ -1,4 +1,4 @@
-# NALE01, NALJ01, NALP01 - Super Smash Bros. (Virtual Console)
+# NATJ01, NATP01, NATE01 - Mario Tennis (Virtual Console)
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -11,9 +11,6 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Stereoscopy]
-StereoConvergence = 5000
 
 [Video_Settings]
 # This game creates a large number of EFB copies at different addresses, resulting

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -91,6 +91,8 @@ const ConfigInfo<int> GFX_SHADER_COMPILER_THREADS{
     {System::GFX, "Settings", "ShaderCompilerThreads"}, 1};
 const ConfigInfo<int> GFX_SHADER_PRECOMPILER_THREADS{
     {System::GFX, "Settings", "ShaderPrecompilerThreads"}, 1};
+const ConfigInfo<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE{
+    {System::GFX, "Settings", "SaveTextureCacheToState"}, true};
 
 const ConfigInfo<bool> GFX_SW_ZCOMPLOC{{System::GFX, "Settings", "SWZComploc"}, true};
 const ConfigInfo<bool> GFX_SW_ZFREEZE{{System::GFX, "Settings", "SWZFreeze"}, true};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -67,6 +67,7 @@ extern const ConfigInfo<bool> GFX_WAIT_FOR_SHADERS_BEFORE_STARTING;
 extern const ConfigInfo<ShaderCompilationMode> GFX_SHADER_COMPILATION_MODE;
 extern const ConfigInfo<int> GFX_SHADER_COMPILER_THREADS;
 extern const ConfigInfo<int> GFX_SHADER_PRECOMPILER_THREADS;
+extern const ConfigInfo<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE;
 
 extern const ConfigInfo<bool> GFX_SW_ZCOMPLOC;
 extern const ConfigInfo<bool> GFX_SW_ZFREEZE;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -90,6 +90,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::GFX_SHADER_COMPILATION_MODE.location,
       Config::GFX_SHADER_COMPILER_THREADS.location,
       Config::GFX_SHADER_PRECOMPILER_THREADS.location,
+      Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE.location,
 
       Config::GFX_SW_ZCOMPLOC.location,
       Config::GFX_SW_ZFREEZE.location,

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -21,6 +21,7 @@
 #include "Common/CPUDetect.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/Event.h"
 #include "Common/FileUtil.h"
 #include "Common/Flag.h"
 #include "Common/Logging/LogManager.h"
@@ -110,6 +111,7 @@ struct HostJob
 };
 static std::mutex s_host_jobs_lock;
 static std::queue<HostJob> s_host_jobs_queue;
+static Common::Event s_cpu_thread_job_finished;
 
 static thread_local bool tls_is_cpu_thread = false;
 
@@ -433,6 +435,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   Common::ScopeGuard movie_guard{Movie::Shutdown};
 
   HW::Init();
+
   Common::ScopeGuard hw_guard{[] {
     // We must set up this flag before executing HW::Shutdown()
     s_hardware_initialized = false;
@@ -769,6 +772,45 @@ void RunAsCPUThread(std::function<void()> function)
 
   if (!is_cpu_thread)
     PauseAndLock(false, was_unpaused);
+}
+
+void RunOnCPUThread(std::function<void()> function, bool wait_for_completion)
+{
+  // If the CPU thread is not running, assume there is no active CPU thread we can race against.
+  if (!IsRunning() || IsCPUThread())
+  {
+    function();
+    return;
+  }
+
+  // Pause the CPU (set it to stepping mode).
+  const bool was_running = PauseAndLock(true, true);
+
+  // Queue the job function.
+  if (wait_for_completion)
+  {
+    // Trigger the event after executing the function.
+    s_cpu_thread_job_finished.Reset();
+    CPU::AddCPUThreadJob([&function]() {
+      function();
+      s_cpu_thread_job_finished.Set();
+    });
+  }
+  else
+  {
+    CPU::AddCPUThreadJob(std::move(function));
+  }
+
+  // Release the CPU thread, and let it execute the callback.
+  PauseAndLock(false, was_running);
+
+  // If we're waiting for completion, block until the event fires.
+  if (wait_for_completion)
+  {
+    // Periodically yield to the UI thread, so we don't deadlock.
+    while (!s_cpu_thread_job_finished.WaitFor(std::chrono::milliseconds(10)))
+      Host_YieldToUI();
+  }
 }
 
 // Display FPS info

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -82,6 +82,10 @@ void UpdateTitle();
 // This should only be called from the CPU thread or the host thread.
 void RunAsCPUThread(std::function<void()> function);
 
+// Run a function on the CPU thread, asynchronously.
+// This is only valid to call from the host thread, since it uses PauseAndLock() internally.
+void RunOnCPUThread(std::function<void()> function, bool wait_for_completion);
+
 // for calling back into UI code without introducing a dependency on it in core
 using StateChangedCallbackFunc = std::function<void(Core::State)>;
 void SetOnStateChangedCallback(StateChangedCallbackFunc callback);

--- a/Source/Core/Core/HW/CPU.h
+++ b/Source/Core/Core/HW/CPU.h
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #pragma once
+#include <functional>
 
 namespace Common
 {
@@ -74,4 +75,8 @@ const State* GetStatePtr();
 // "control_adjacent" causes PauseAndLock to behave like EnableStepping by modifying the
 //   state of the Audio and FIFO subsystems as well.
 bool PauseAndLock(bool do_lock, bool unpause_on_unlock = true, bool control_adjacent = false);
+
+// Adds a job to be executed during on the CPU thread. This should be combined with PauseAndLock(),
+// as while the CPU is in the run loop, it won't execute the function.
+void AddCPUThreadJob(std::function<void()> function);
 }  // namespace CPU

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -72,7 +72,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 110;  // Last changed in PR 8036
+static const u32 STATE_VERSION = 111;  // Last changed in PR 6321
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -170,6 +170,11 @@ static void DoState(PointerWrap& p)
     return;
   }
 
+  // Movie must be done before the video backend, because the window is redrawn in the video backend
+  // state load, and the frame number must be up-to-date.
+  Movie::DoState(p);
+  p.DoMarker("Movie");
+
   // Begin with video backend, so that it gets a chance to clear its caches and writeback modified
   // things to RAM
   g_video_backend->DoState(p);
@@ -186,8 +191,6 @@ static void DoState(PointerWrap& p)
   if (SConfig::GetInstance().bWii)
     Wiimote::DoState(p);
   p.DoMarker("Wiimote");
-  Movie::DoState(p);
-  p.DoMarker("Movie");
   Gecko::DoState(p);
   p.DoMarker("Gecko");
 

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -100,10 +100,13 @@ void HacksWidget::CreateWidgets()
   m_disable_bounding_box =
       new GraphicsBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, true);
   m_vertex_rounding = new GraphicsBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUDING);
+  m_save_texture_cache_state =
+      new GraphicsBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
 
   other_layout->addWidget(m_fast_depth_calculation, 0, 0);
   other_layout->addWidget(m_disable_bounding_box, 0, 1);
   other_layout->addWidget(m_vertex_rounding, 1, 0);
+  other_layout->addWidget(m_save_texture_cache_state, 1, 1);
 
   main_layout->addWidget(efb_box);
   main_layout->addWidget(texture_cache_box);
@@ -244,6 +247,10 @@ void HacksWidget::AddDescriptions()
   static const char TR_DISABLE_BOUNDINGBOX_DESCRIPTION[] =
       QT_TR_NOOP("Disables bounding box emulation.\n\nThis may improve GPU performance "
                  "significantly, but some games will break.\n\nIf unsure, leave this checked.");
+  static const char TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION[] = QT_TR_NOOP(
+      "Includes the contents of the embedded frame buffer (EFB) and upscaled EFB copies "
+      "in save states. Fixes missing and/or non-upscaled textures/objects when loading "
+      "states at the cost of additional save/load time.\n\nIf unsure, leave this checked.");
   static const char TR_VERTEX_ROUNDING_DESCRIPTION[] =
       QT_TR_NOOP("Rounds 2D vertices to whole pixels.\n\nFixes graphical problems in some games at "
                  "higher internal resolutions. This setting has no effect when native internal "
@@ -259,6 +266,7 @@ void HacksWidget::AddDescriptions()
   AddDescription(m_gpu_texture_decoding, TR_GPU_DECODING_DESCRIPTION);
   AddDescription(m_fast_depth_calculation, TR_FAST_DEPTH_CALC_DESCRIPTION);
   AddDescription(m_disable_bounding_box, TR_DISABLE_BOUNDINGBOX_DESCRIPTION);
+  AddDescription(m_save_texture_cache_state, TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION);
   AddDescription(m_vertex_rounding, TR_VERTEX_ROUNDING_DESCRIPTION);
 }
 

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -42,6 +42,7 @@ private:
   QCheckBox* m_fast_depth_calculation;
   QCheckBox* m_disable_bounding_box;
   QCheckBox* m_vertex_rounding;
+  QCheckBox* m_save_texture_cache_state;
   QCheckBox* m_defer_efb_copies;
 
   void CreateWidgets();

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -154,6 +154,10 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
   case Event::PERF_QUERY:
     g_perf_query->FlushResults();
     break;
+
+  case Event::DO_SAVE_STATE:
+    g_video_backend->DoStateGPUThread(*e.do_save_state.p);
+    break;
   }
 }
 

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -11,6 +11,7 @@
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VideoState.h"
 
 AsyncRequests AsyncRequests::s_singleton;
 
@@ -156,7 +157,7 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
     break;
 
   case Event::DO_SAVE_STATE:
-    g_video_backend->DoStateGPUThread(*e.do_save_state.p);
+    VideoCommon_DoState(*e.do_save_state.p);
     break;
   }
 }

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -13,6 +13,7 @@
 #include "Common/Flag.h"
 
 struct EfbPokeData;
+class PointerWrap;
 
 class AsyncRequests
 {
@@ -28,6 +29,7 @@ public:
       SWAP_EVENT,
       BBOX_READ,
       PERF_QUERY,
+      DO_SAVE_STATE,
     } type;
     u64 time;
 
@@ -64,6 +66,11 @@ public:
       struct
       {
       } perf_query;
+
+      struct
+      {
+        PointerWrap* p;
+      } do_save_state;
     };
   };
 

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -68,9 +68,6 @@ static void BPWritten(const BPCmd& bp)
   ----------------------------------------------------------------------------------------------------------------
   */
 
-  // check for invalid state, else unneeded configuration are built
-  g_video_backend->CheckInvalidState();
-
   if (((s32*)&bpmem)[bp.address] == bp.newvalue)
   {
     if (!(bp.address == BPMEM_TRIGGER_EFB_COPY || bp.address == BPMEM_CLEARBBOX1 ||

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -299,14 +299,15 @@ void RunGpuLoop()
       [] {
         const SConfig& param = SConfig::GetInstance();
 
+        // Run events from the CPU thread.
+        AsyncRequests::GetInstance()->PullEvents();
+
         // Do nothing while paused
         if (!s_emu_running_state.IsSet())
           return;
 
         if (s_use_deterministic_gpu_thread)
         {
-          AsyncRequests::GetInstance()->PullEvents();
-
           // All the fifo/CP stuff is on the CPU.  We just need to run the opcode decoder.
           u8* seen_ptr = s_video_buffer_seen_ptr;
           u8* write_ptr = s_video_buffer_write_ptr;
@@ -321,9 +322,6 @@ void RunGpuLoop()
         else
         {
           CommandProcessor::SCPFifoStruct& fifo = CommandProcessor::fifo;
-
-          AsyncRequests::GetInstance()->PullEvents();
-
           CommandProcessor::SetCPStatusFromGPU();
 
           // check if we are able to run this buffer

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -7,6 +7,7 @@
 #include "VideoCommon/FramebufferShaderGen.h"
 #include "VideoCommon/VertexManagerBase.h"
 
+#include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "VideoCommon/AbstractFramebuffer.h"
@@ -464,6 +465,20 @@ bool FramebufferManager::CompileReadbackPipelines()
       return false;
   }
 
+  // EFB restore pipeline
+  auto restore_shader = g_renderer->CreateShaderFromSource(
+      ShaderStage::Pixel, FramebufferShaderGen::GenerateEFBRestorePixelShader());
+  if (!restore_shader)
+    return false;
+
+  config.framebuffer_state = GetEFBFramebufferState();
+  config.framebuffer_state.per_sample_shading = false;
+  config.vertex_shader = g_shader_cache->GetScreenQuadVertexShader();
+  config.pixel_shader = restore_shader.get();
+  m_efb_restore_pipeline = g_renderer->CreatePipeline(config);
+  if (!m_efb_restore_pipeline)
+    return false;
+
   return true;
 }
 
@@ -841,4 +856,103 @@ void FramebufferManager::DestroyPokePipelines()
   m_depth_poke_pipeline.reset();
   m_color_poke_pipeline.reset();
   m_poke_vertex_format.reset();
+}
+
+void FramebufferManager::DoState(PointerWrap& p)
+{
+  FlushEFBPokes();
+
+  if (p.GetMode() == PointerWrap::MODE_WRITE || p.GetMode() == PointerWrap::MODE_MEASURE)
+    DoSaveState(p);
+  else
+    DoLoadState(p);
+}
+
+void FramebufferManager::DoSaveState(PointerWrap& p)
+{
+  // For multisampling, we need to resolve first before we can save.
+  // This won't be bit-exact when loading, which could cause interesting rendering side-effects for
+  // a frame. But whatever, MSAA doesn't exactly behave that well anyway.
+  AbstractTexture* color_texture = ResolveEFBColorTexture(m_efb_color_texture->GetRect());
+  AbstractTexture* depth_texture = ResolveEFBDepthTexture(m_efb_depth_texture->GetRect());
+
+  // We don't want to save these as rendertarget textures, just the data itself when deserializing.
+  const TextureConfig color_texture_config(color_texture->GetWidth(), color_texture->GetHeight(),
+                                           color_texture->GetLevels(), color_texture->GetLayers(),
+                                           1, GetEFBColorFormat(), 0);
+  g_texture_cache->SerializeTexture(color_texture, color_texture_config, p);
+
+  if (GetEFBDepthFormat() == AbstractTextureFormat::D32F)
+  {
+    const TextureConfig depth_texture_config(
+        depth_texture->GetWidth(), depth_texture->GetHeight(), depth_texture->GetLevels(),
+        depth_texture->GetLayers(), 1,
+        AbstractTexture::GetColorFormatForDepthFormat(GetEFBDepthFormat()), 0);
+    g_texture_cache->SerializeTexture(depth_texture, depth_texture_config, p);
+  }
+  else
+  {
+    // If the EFB is backed by a D24S8 texture, we first have to convert it to R32F.
+    const TextureConfig temp_texture_config(depth_texture->GetWidth(), depth_texture->GetHeight(),
+                                            depth_texture->GetLevels(), depth_texture->GetLayers(),
+                                            1, AbstractTextureFormat::R32F,
+                                            AbstractTextureFlag_RenderTarget);
+    std::unique_ptr<AbstractTexture> temp_texture = g_renderer->CreateTexture(temp_texture_config);
+    std::unique_ptr<AbstractFramebuffer> temp_fb =
+        g_renderer->CreateFramebuffer(temp_texture.get(), nullptr);
+    if (temp_texture && temp_fb)
+    {
+      g_renderer->ScaleTexture(temp_fb.get(), temp_texture->GetRect(), depth_texture,
+                               depth_texture->GetRect());
+
+      const TextureConfig depth_texture_config(
+          depth_texture->GetWidth(), depth_texture->GetHeight(), depth_texture->GetLevels(),
+          depth_texture->GetLayers(), 1, temp_texture->GetFormat(), 0);
+      g_texture_cache->SerializeTexture(depth_texture, depth_texture_config, p);
+    }
+    else
+    {
+      PanicAlert("Failed to create temp texture for depth saving");
+      g_texture_cache->SerializeTexture(color_texture, color_texture_config, p);
+    }
+  }
+}
+
+void FramebufferManager::DoLoadState(PointerWrap& p)
+{
+  // Invalidate any peek cache tiles.
+  InvalidatePeekCache(true);
+
+  // Deserialize the color and depth textures. This could fail.
+  auto color_tex = g_texture_cache->DeserializeTexture(p);
+  auto depth_tex = g_texture_cache->DeserializeTexture(p);
+
+  // If the stereo mode is different in the save state, throw it away.
+  if (!color_tex || !depth_tex ||
+      color_tex->texture->GetLayers() != m_efb_color_texture->GetLayers())
+  {
+    WARN_LOG(VIDEO, "Failed to deserialize EFB contents. Clearing instead.");
+    g_renderer->SetAndClearFramebuffer(
+        m_efb_framebuffer.get(), {{0.0f, 0.0f, 0.0f, 0.0f}},
+        g_ActiveConfig.backend_info.bSupportsReversedDepthRange ? 1.0f : 0.0f);
+    return;
+  }
+
+  // Size differences are okay here, since the linear filtering will downscale/upscale it.
+  // Depth buffer is always point sampled, since we don't want to interpolate depth values.
+  const bool rescale = color_tex->texture->GetWidth() != m_efb_color_texture->GetWidth() ||
+                       color_tex->texture->GetHeight() != m_efb_color_texture->GetHeight();
+
+  // Draw the deserialized textures over the EFB.
+  g_renderer->BeginUtilityDrawing();
+  g_renderer->SetAndDiscardFramebuffer(m_efb_framebuffer.get());
+  g_renderer->SetViewportAndScissor(m_efb_framebuffer->GetRect());
+  g_renderer->SetPipeline(m_efb_restore_pipeline.get());
+  g_renderer->SetTexture(0, color_tex->texture.get());
+  g_renderer->SetTexture(1, depth_tex->texture.get());
+  g_renderer->SetSamplerState(0, rescale ? RenderState::GetLinearSamplerState() :
+                                           RenderState::GetPointSamplerState());
+  g_renderer->SetSamplerState(1, RenderState::GetPointSamplerState());
+  g_renderer->Draw(0, 3);
+  g_renderer->EndUtilityDrawing();
 }

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -10,6 +10,7 @@
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+#include "Core/Config/GraphicsSettings.h"
 #include "VideoCommon/AbstractFramebuffer.h"
 #include "VideoCommon/AbstractPipeline.h"
 #include "VideoCommon/AbstractShader.h"
@@ -861,6 +862,11 @@ void FramebufferManager::DestroyPokePipelines()
 void FramebufferManager::DoState(PointerWrap& p)
 {
   FlushEFBPokes();
+
+  bool save_efb_state = Config::Get(Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
+  p.Do(save_efb_state);
+  if (!save_efb_state)
+    return;
 
   if (p.GetMode() == PointerWrap::MODE_WRITE || p.GetMode() == PointerWrap::MODE_MEASURE)
     DoSaveState(p);

--- a/Source/Core/VideoCommon/FramebufferManager.h
+++ b/Source/Core/VideoCommon/FramebufferManager.h
@@ -17,6 +17,7 @@
 #include "VideoCommon/TextureConfig.h"
 
 class NativeVertexFormat;
+class PointerWrap;
 
 enum class EFBReinterpretType
 {
@@ -95,6 +96,9 @@ public:
   void PokeEFBDepth(u32 x, u32 y, float depth);
   void FlushEFBPokes();
 
+  // Save state load/save.
+  void DoState(PointerWrap& p);
+
 protected:
   struct EFBPokeVertex
   {
@@ -145,6 +149,9 @@ protected:
   void DrawPokeVertices(const EFBPokeVertex* vertices, u32 vertex_count,
                         const AbstractPipeline* pipeline);
 
+  void DoLoadState(PointerWrap& p);
+  void DoSaveState(PointerWrap& p);
+
   std::unique_ptr<AbstractTexture> m_efb_color_texture;
   std::unique_ptr<AbstractTexture> m_efb_convert_color_texture;
   std::unique_ptr<AbstractTexture> m_efb_depth_texture;
@@ -155,6 +162,9 @@ protected:
   std::unique_ptr<AbstractFramebuffer> m_efb_convert_framebuffer;
   std::unique_ptr<AbstractFramebuffer> m_efb_depth_resolve_framebuffer;
   std::unique_ptr<AbstractPipeline> m_efb_depth_resolve_pipeline;
+
+  // Pipeline for restoring the contents of the EFB from a save state
+  std::unique_ptr<AbstractPipeline> m_efb_restore_pipeline;
 
   // Format conversion shaders
   std::array<std::unique_ptr<AbstractPipeline>, 6> m_format_conversion_pipelines;

--- a/Source/Core/VideoCommon/FramebufferShaderGen.cpp
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.cpp
@@ -644,4 +644,24 @@ std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureF
   return ss.str();
 }
 
+std::string GenerateEFBRestorePixelShader()
+{
+  std::stringstream ss;
+  EmitSamplerDeclarations(ss, 0, 2, false);
+  EmitPixelMainDeclaration(ss, 1, 0, "float4",
+                           GetAPIType() == APIType::D3D ? "out float depth : SV_Depth, " : "");
+  ss << "{\n";
+  ss << "  float3 coords = float3(v_tex0.x, "
+     << (g_ActiveConfig.backend_info.bUsesLowerLeftOrigin ? "1.0 - " : "")
+     << "v_tex0.y, v_tex0.z);\n";
+  ss << "  ocol0 = ";
+  EmitSampleTexture(ss, 0, "coords");
+  ss << ";\n";
+  ss << "  " << (GetAPIType() == APIType::D3D ? "depth" : "gl_FragDepth") << " = ";
+  EmitSampleTexture(ss, 1, "coords");
+  ss << ".r;\n";
+  ss << "}\n";
+  return ss.str();
+}
+
 }  // namespace FramebufferShaderGen

--- a/Source/Core/VideoCommon/FramebufferShaderGen.h
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.h
@@ -30,5 +30,6 @@ std::string GenerateEFBPokeVertexShader();
 std::string GenerateColorPixelShader();
 std::string GenerateFormatConversionShader(EFBReinterpretType convtype, u32 samples);
 std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureFormat to_format);
+std::string GenerateEFBRestorePixelShader();
 
 }  // namespace FramebufferShaderGen

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -41,6 +41,7 @@ class AbstractTexture;
 class AbstractStagingTexture;
 class NativeVertexFormat;
 class NetPlayChatUI;
+class PointerWrap;
 struct TextureConfig;
 struct ComputePipelineConfig;
 struct AbstractPipelineConfig;
@@ -237,6 +238,7 @@ public:
   void ChangeSurface(void* new_surface_handle);
   void ResizeSurface();
   bool UseVertexDepthRange() const;
+  void DoState(PointerWrap& p);
 
   virtual std::unique_ptr<VideoCommon::AsyncShaderCompiler> CreateAsyncShaderCompiler();
 
@@ -356,9 +358,10 @@ private:
 
   // Tracking of XFB textures so we don't render duplicate frames.
   u64 m_last_xfb_id = std::numeric_limits<u64>::max();
-
-  // Note: Only used for auto-ir
+  u64 m_last_xfb_ticks = 0;
+  u32 m_last_xfb_addr = 0;
   u32 m_last_xfb_width = 0;
+  u32 m_last_xfb_stride = 0;
   u32 m_last_xfb_height = 0;
 
   // NOTE: The methods below are called on the framedumping thread.

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -24,6 +24,7 @@
 
 class AbstractFramebuffer;
 class AbstractStagingTexture;
+class PointerWrap;
 struct VideoConfig;
 
 struct TextureAndTLUTFormat
@@ -185,6 +186,17 @@ public:
     u32 GetNumLevels() const { return texture->GetConfig().levels; }
     u32 GetNumLayers() const { return texture->GetConfig().layers; }
     AbstractTextureFormat GetFormat() const { return texture->GetConfig().format; }
+    void DoState(PointerWrap& p);
+  };
+
+  // Minimal version of TCacheEntry just for TexPool
+  struct TexPoolEntry
+  {
+    std::unique_ptr<AbstractTexture> texture;
+    std::unique_ptr<AbstractFramebuffer> framebuffer;
+    int frameCount = FRAMECOUNT_INVALID;
+
+    TexPoolEntry(std::unique_ptr<AbstractTexture> tex, std::unique_ptr<AbstractFramebuffer> fb);
   };
 
   TextureCacheBase();
@@ -224,6 +236,13 @@ public:
   // Flushes all pending EFB copies to emulated RAM.
   void FlushEFBCopies();
 
+  // Texture Serialization
+  void SerializeTexture(AbstractTexture* tex, const TextureConfig& config, PointerWrap& p);
+  std::optional<TexPoolEntry> DeserializeTexture(PointerWrap& p);
+
+  // Save States
+  void DoState(PointerWrap& p);
+
   // Returns false if the top/bottom row coefficients are zero.
   static bool NeedsCopyFilterInShader(const EFBCopyFilterCoefficients& coefficients);
 
@@ -256,15 +275,6 @@ protected:
   static std::bitset<8> valid_bind_points;
 
 private:
-  // Minimal version of TCacheEntry just for TexPool
-  struct TexPoolEntry
-  {
-    std::unique_ptr<AbstractTexture> texture;
-    std::unique_ptr<AbstractFramebuffer> framebuffer;
-    int frameCount = FRAMECOUNT_INVALID;
-
-    TexPoolEntry(std::unique_ptr<AbstractTexture> tex, std::unique_ptr<AbstractFramebuffer> fb);
-  };
   using TexAddrCache = std::multimap<u32, TCacheEntry*>;
   using TexHashCache = std::multimap<u64, TCacheEntry*>;
   using TexPool = std::unordered_multimap<TextureConfig, TexPoolEntry>;
@@ -319,6 +329,10 @@ private:
   // Returns an EFB copy staging texture to the pool, so it can be re-used.
   void ReleaseEFBCopyStagingTexture(std::unique_ptr<AbstractStagingTexture> tex);
 
+  bool CheckReadbackTexture(u32 width, u32 height, AbstractTextureFormat format);
+  void DoSaveState(PointerWrap& p);
+  void DoLoadState(PointerWrap& p);
+
   TexAddrCache textures_by_address;
   TexHashCache textures_by_hash;
   TexPool texture_pool;
@@ -354,6 +368,11 @@ private:
   // List of pending EFB copies. It is important that the order is preserved for these,
   // so that overlapping textures are written to guest RAM in the order they are issued.
   std::vector<TCacheEntry*> m_pending_efb_copies;
+
+  // Staging texture used for readbacks.
+  // We store this in the class so that the same staging texture can be used for multiple
+  // readbacks, saving the overhead of allocating a new buffer every time.
+  std::unique_ptr<AbstractStagingTexture> m_readback_texture;
 };
 
 extern std::unique_ptr<TextureCacheBase> g_texture_cache;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -461,6 +461,16 @@ void VertexManagerBase::Flush()
 
 void VertexManagerBase::DoState(PointerWrap& p)
 {
+  if (p.GetMode() == PointerWrap::MODE_READ)
+  {
+    // Flush old vertex data before loading state.
+    Flush();
+
+    // Clear all caches that touch RAM
+    // (? these don't appear to touch any emulation state that gets saved. moved to on load only.)
+    VertexLoaderManager::MarkAllDirty();
+  }
+
   p.Do(m_zslope);
 }
 

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -338,9 +338,6 @@ void VertexManagerBase::Flush()
 
   m_is_flushed = true;
 
-  // loading a state will invalidate BP, so check for it
-  g_video_backend->CheckInvalidState();
-
 #if defined(_DEBUG) || defined(DEBUGFAST)
   PRIM_LOG("frame%d:\n texgen=%u, numchan=%u, dualtex=%u, ztex=%u, cole=%u, alpe=%u, ze=%u",
            g_ActiveConfig.iSaveTargetId, xfmem.numTexGen.numTexGens, xfmem.numChan.numColorChans,

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -241,7 +241,7 @@ void VideoBackendBase::DoState(PointerWrap& p)
 {
   if (!SConfig::GetInstance().bCPUThread)
   {
-    DoStateGPUThread(p);
+    VideoCommon_DoState(p);
     return;
   }
 
@@ -253,34 +253,6 @@ void VideoBackendBase::DoState(PointerWrap& p)
   // Let the GPU thread sleep after loading the state, so we're not spinning if paused after loading
   // a state. The next GP burst will wake it up again.
   Fifo::GpuMaySleep();
-}
-
-void VideoBackendBase::DoStateGPUThread(PointerWrap& p)
-{
-  bool software = false;
-  p.Do(software);
-
-  if (p.GetMode() == PointerWrap::MODE_READ && software == true)
-  {
-    // change mode to abort load of incompatible save state.
-    p.SetMode(PointerWrap::MODE_VERIFY);
-  }
-
-  VideoCommon_DoState(p);
-  p.DoMarker("VideoCommon");
-
-  // Refresh state.
-  if (p.GetMode() == PointerWrap::MODE_READ)
-  {
-    // Inform backend of new state from registers.
-    g_vertex_manager->Flush();
-    g_texture_cache->Invalidate();
-    BPReload();
-
-    // Clear all caches that touch RAM
-    // (? these don't appear to touch any emulation state that gets saved. moved to on load only.)
-    VertexLoaderManager::MarkAllDirty();
-  }
 }
 
 void VideoBackendBase::InitializeShared()

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -66,9 +66,6 @@ public:
   // Wrapper function which pushes the event to the GPU thread.
   void DoState(PointerWrap& p);
 
-  // Function which handles the real state load/save logic.
-  void DoStateGPUThread(PointerWrap& p);
-
 protected:
   void InitializeShared();
   void ShutdownShared();

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -63,18 +63,17 @@ public:
   // Called by the UI thread when the graphics config is opened.
   static void PopulateBackendInfo();
 
-  // the implementation needs not do synchronization logic, because calls to it are surrounded by
-  // PauseAndLock now
+  // Wrapper function which pushes the event to the GPU thread.
   void DoState(PointerWrap& p);
 
-  void CheckInvalidState();
+  // Function which handles the real state load/save logic.
+  void DoStateGPUThread(PointerWrap& p);
 
 protected:
   void InitializeShared();
   void ShutdownShared();
 
   bool m_initialized = false;
-  bool m_invalid = false;
 };
 
 extern std::vector<std::unique_ptr<VideoBackendBase>> g_available_video_backends;

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -10,6 +10,7 @@
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
+#include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/GeometryShaderManager.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -73,6 +74,9 @@ void VideoCommon_DoState(PointerWrap& p)
 
   BoundingBox::DoState(p);
   p.DoMarker("BoundingBox");
+
+  g_framebuffer_manager->DoState(p);
+  p.DoMarker("FramebufferManager");
 
   g_texture_cache->DoState(p);
   p.DoMarker("TextureCache");


### PR DESCRIPTION
This PR adds EFB copies, texture cache entries, and eventually the EFB framebuffer to save states. Including these in save states will fix missing objects/textures when EFB2RAM is not enabled, as well as preserving the upscaled versions. Loading state while paused will auto display the last displayed frame now, rather than either not updating until the next frame, or purple no-data.

Progress:
- [x] Support serialization of texture cache entries (including EFB copies)
- [x] Support serialization of EFB framebuffer
- [x] Fix dual core