### PR TITLE
Support asynchronously executing functions on the CPU thread

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -82,6 +82,10 @@ void UpdateTitle();
 // This should only be called from the CPU thread or the host thread.
 void RunAsCPUThread(std::function<void()> function);
 
+// Run a function on the CPU thread, asynchronously.
+// This is only valid to call from the host thread, since it uses PauseAndLock() internally.
+void RunOnCPUThread(std::function<void()> function, bool wait_for_completion);
+
 // for calling back into UI code without introducing a dependency on it in core
 using StateChangedCallbackFunc = std::function<void(Core::State)>;
 void SetOnStateChangedCallback(StateChangedCallbackFunc callback);

--- a/Source/Core/Core/HW/CPU.h
+++ b/Source/Core/Core/HW/CPU.h
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #pragma once
+#include <functional>
 
 namespace Common
 {
@@ -74,4 +75,8 @@ const State* GetStatePtr();
 // "control_adjacent" causes PauseAndLock to behave like EnableStepping by modifying the
 //   state of the Audio and FIFO subsystems as well.
 bool PauseAndLock(bool do_lock, bool unpause_on_unlock = true, bool control_adjacent = false);
+
+// Adds a job to be executed during on the CPU thread. This should be combined with PauseAndLock(),
+// as while the CPU is in the run loop, it won't execute the function.
+void AddCPUThreadJob(std::function<void()> function);
 }  // namespace CPU


### PR DESCRIPTION
We currently have the issue where several things in Dolphin "take over" the CPU thread, causing issues with external libraries, as thread-local state is no longer valid. An example of this is blocking #6321, as the UI thread does not have an OpenGL context.

I'm proposing another solution; add a job queue to the CPU thread which is executed asynchronously from the calling thread.  The CPU will not be paused to execute the function, instead it is executed as part of a CoreTiming event. This means it is not currently possible to change the CPU execution mode as part of the callback, however any other state is safe to manipulate.

The second commit changes save states to use this new function, which fixes the #6321 dilemma (apart from dual core, which is a separate issue). It also has the benefit of executing asynchronously, which means the UI is not blocked while the save state data is being collected. Compression is still done in the background as before.