### PR TITLE
AbstractTexture: Fix crash in Vulkan backend when freeing texture

### DIFF
--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -83,6 +83,7 @@ DXTexture::DXTexture(const TextureConfig& tex_config) : AbstractTexture(tex_conf
 
 DXTexture::~DXTexture()
 {
+  g_renderer->UnbindTexture(this);
   m_texture->Release();
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -121,6 +121,7 @@ OGLTexture::OGLTexture(const TextureConfig& tex_config) : AbstractTexture(tex_co
 
 OGLTexture::~OGLTexture()
 {
+  g_renderer->UnbindTexture(this);
   if (m_texId)
     glDeleteTextures(1, &m_texId);
 

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<VKTexture> VKTexture::Create(const TextureConfig& tex_config)
 VKTexture::~VKTexture()
 {
   // Texture is automatically cleaned up, however, we don't want to leave it bound.
-  StateTracker::GetInstance()->UnbindTexture(m_texture->GetView());
+  g_renderer->UnbindTexture(this);
   if (m_framebuffer != VK_NULL_HANDLE)
     g_command_buffer_mgr->DeferFramebufferDestruction(m_framebuffer);
 }

--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -15,11 +15,6 @@ AbstractTexture::AbstractTexture(const TextureConfig& c) : m_config(c)
 {
 }
 
-AbstractTexture::~AbstractTexture()
-{
-  g_renderer->UnbindTexture(this);
-}
-
 bool AbstractTexture::Save(const std::string& filename, unsigned int level)
 {
   // We can't dump compressed textures currently (it would mean drawing them to a RGBA8

--- a/Source/Core/VideoCommon/AbstractTexture.h
+++ b/Source/Core/VideoCommon/AbstractTexture.h
@@ -15,7 +15,7 @@ class AbstractTexture
 {
 public:
   explicit AbstractTexture(const TextureConfig& c);
-  virtual ~AbstractTexture();
+  virtual ~AbstractTexture() = default;
 
   virtual void CopyRectangleFromTexture(const AbstractTexture* src,
                                         const MathUtil::Rectangle<int>& src_rect, u32 src_layer,


### PR DESCRIPTION
Regression from #6317. Was due to the destructor for the derived class being executed first, which meant that the underlying Vulkan::Texture2D was null when the base destructor executed.