### PR TITLE
Improve handling of surface change/resize events in graphics backends

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -420,8 +420,8 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 			else if (state == State.PAUSED)
 			{
 				Log.debug("[EmulationFragment] Resuming emulation.");
-				NativeLibrary.UnPauseEmulation();
 				NativeLibrary.SurfaceChanged(mSurface);
+				NativeLibrary.UnPauseEmulation();
 			}
 			else
 			{

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -321,12 +321,8 @@ class PlatformX11 : public Platform
           {
             last_window_width = event.xconfigure.width;
             last_window_height = event.xconfigure.height;
-
-            // We call Renderer::ChangeSurface here to indicate the size has changed,
-            // but pass the same window handle. This is needed for the Vulkan backend,
-            // otherwise it cannot tell that the window has been resized on some drivers.
             if (g_renderer)
-              g_renderer->ChangeSurface(s_window_handle);
+              g_renderer->ResizeSurface(last_window_width, last_window_height);
           }
         }
         break;

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -51,10 +51,10 @@ void Host::SetRenderFullscreen(bool fullscreen)
   m_render_fullscreen = fullscreen;
 }
 
-void Host::UpdateSurface()
+void Host::ResizeSurface(int new_width, int new_height)
 {
   if (g_renderer)
-    g_renderer->ChangeSurface(GetRenderHandle());
+    g_renderer->ResizeSurface(new_width, new_height);
 }
 
 void Host_Message(int id)

--- a/Source/Core/DolphinQt2/Host.h
+++ b/Source/Core/DolphinQt2/Host.h
@@ -26,7 +26,7 @@ public:
   void SetRenderHandle(void* handle);
   void SetRenderFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
-  void UpdateSurface();
+  void ResizeSurface(int new_width, int new_height);
 
 signals:
   void RequestTitle(const QString& title);

--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -22,7 +22,7 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
           Qt::DirectConnection);
   connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle,
           Qt::DirectConnection);
-  connect(this, &RenderWidget::SizeChanged, Host::GetInstance(), &Host::UpdateSurface,
+  connect(this, &RenderWidget::SizeChanged, Host::GetInstance(), &Host::ResizeSurface,
           Qt::DirectConnection);
 
   emit HandleChanged((void*)winId());
@@ -84,8 +84,12 @@ bool RenderWidget::event(QEvent* event)
     Host::GetInstance()->SetRenderFocus(false);
     break;
   case QEvent::Resize:
-    emit SizeChanged();
+  {
+    const QResizeEvent* se = static_cast<QResizeEvent*>(event);
+    QSize new_size = se->size();
+    emit SizeChanged(new_size.width(), new_size.height());
     break;
+  }
   case QEvent::WindowStateChange:
     emit StateChanged(isFullScreen());
     break;

--- a/Source/Core/DolphinQt2/RenderWidget.h
+++ b/Source/Core/DolphinQt2/RenderWidget.h
@@ -23,7 +23,7 @@ signals:
   void Closed();
   void HandleChanged(void* handle);
   void StateChanged(bool fullscreen);
-  void SizeChanged();
+  void SizeChanged(int new_width, int new_height);
 
 private:
   void HandleCursorTimer();

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -603,21 +603,18 @@ void CFrame::OnRenderParentResize(wxSizeEvent& event)
   if (Core::GetState() != Core::State::Uninitialized)
   {
     int width, height;
+    m_render_frame->GetClientSize(&width, &height);
     if (!SConfig::GetInstance().bRenderToMain && !RendererIsFullscreen() &&
         !m_render_frame->IsMaximized() && !m_render_frame->IsIconized())
     {
-      m_render_frame->GetClientSize(&width, &height);
       SConfig::GetInstance().iRenderWindowWidth = width;
       SConfig::GetInstance().iRenderWindowHeight = height;
     }
     m_log_window->Refresh();
     m_log_window->Update();
 
-    // We call Renderer::ChangeSurface here to indicate the size has changed,
-    // but pass the same window handle. This is needed for the Vulkan backend,
-    // otherwise it cannot tell that the window has been resized on some drivers.
     if (g_renderer)
-      g_renderer->ChangeSurface(GetRenderHandle());
+      g_renderer->ResizeSurface(width, height);
   }
   event.Skip();
 }

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -59,14 +59,13 @@ void Close();
 extern ID3D11Device* device;
 extern ID3D11Device1* device1;
 extern ID3D11DeviceContext* context;
-extern HWND hWnd;
+extern IDXGISwapChain1* swapchain;
 
-void Reset();
+void Reset(HWND new_wnd);
+void ResizeSwapChain();
 void Present();
 
-unsigned int GetBackBufferWidth();
-unsigned int GetBackBufferHeight();
-D3DTexture2D*& GetBackBuffer();
+D3DTexture2D* GetBackBuffer();
 const char* PixelShaderVersionString();
 const char* GeometryShaderVersionString();
 const char* VertexShaderVersionString();

--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -387,9 +387,9 @@ int CD3DFont::DrawTextScaled(float x, float y, float size, float spacing, u32 dw
   UINT stride = sizeof(FONT2DVERTEX);
   UINT bufoffset = 0;
 
-  float scalex = 1 / (float)D3D::GetBackBufferWidth() * 2.f;
-  float scaley = 1 / (float)D3D::GetBackBufferHeight() * 2.f;
-  float sizeratio = size / (float)m_LineHeight;
+  float scalex = 1.0f / g_renderer->GetBackbufferWidth() * 2.f;
+  float scaley = 1.0f / g_renderer->GetBackbufferHeight() * 2.f;
+  float sizeratio = size / m_LineHeight;
 
   // translate starting positions
   float sx = x * scalex - 1.f;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -53,12 +53,12 @@ typedef struct _Nv_Stereo_Image_Header
 
 #define NVSTEREO_IMAGE_SIGNATURE 0x4433564e
 
-Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferHeight())
+Renderer::Renderer(int backbuffer_width, int backbuffer_height)
+    : ::Renderer(backbuffer_width, backbuffer_height)
 {
   m_last_multisamples = g_ActiveConfig.iMultisamples;
   m_last_stereo_mode = g_ActiveConfig.stereo_mode != StereoMode::Off;
-  m_last_fullscreen_mode = D3D::GetFullscreenState();
-
+  m_last_fullscreen_state = D3D::GetFullscreenState();
   g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
   SetupDeviceObjects();
 
@@ -237,25 +237,6 @@ TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)
   result.right = EFBToScaledX(rc.right);
   result.bottom = EFBToScaledY(rc.bottom);
   return result;
-}
-
-// With D3D, we have to resize the backbuffer if the window changed
-// size.
-bool Renderer::CheckForResize()
-{
-  RECT rcWindow;
-  GetClientRect(D3D::hWnd, &rcWindow);
-  int client_width = rcWindow.right - rcWindow.left;
-  int client_height = rcWindow.bottom - rcWindow.top;
-
-  // Sanity check
-  if ((client_width != GetBackbufferWidth() || client_height != GetBackbufferHeight()) &&
-      client_width >= 4 && client_height >= 4)
-  {
-    return true;
-  }
-
-  return false;
 }
 
 void Renderer::SetScissorRect(const MathUtil::Rectangle<int>& rc)
@@ -549,12 +530,13 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   ResetAPIState();
 
   // Prepare to copy the XFBs to our backbuffer
+  CheckForSurfaceChange();
+  CheckForSurfaceResize();
   UpdateDrawRectangle();
+
   TargetRectangle targetRc = GetTargetRectangle();
-
+  static constexpr std::array<float, 4> clear_color{{0.f, 0.f, 0.f, 1.f}};
   D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
-
-  constexpr std::array<float, 4> clear_color{{0.f, 0.f, 0.f, 1.f}};
   D3D::context->ClearRenderTargetView(D3D::GetBackBuffer()->GetRTV(), clear_color.data());
 
   // activate linear filtering for the buffer copies
@@ -565,8 +547,8 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
              xfb_texture->GetConfig().width, xfb_texture->GetConfig().height, Gamma);
 
   // Reset viewport for drawing text
-  D3D11_VIEWPORT vp =
-      CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetBackbufferWidth(), (float)GetBackbufferHeight());
+  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, static_cast<float>(m_backbuffer_width),
+                                      static_cast<float>(m_backbuffer_height));
   D3D::context->RSSetViewports(1, &vp);
 
   Renderer::DrawDebugText();
@@ -580,41 +562,21 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   g_texture_cache->OnConfigChanged(g_ActiveConfig);
   VertexShaderCache::RetreiveAsyncShaders();
 
-  const bool window_resized = CheckForResize();
-  const bool fullscreen = D3D::GetFullscreenState();
-  const bool fs_changed = m_last_fullscreen_mode != fullscreen;
-
   // Flip/present backbuffer to frontbuffer here
-  D3D::Present();
+  if (D3D::swapchain)
+    D3D::Present();
 
   // Resize the back buffers NOW to avoid flickering
-  if (CalculateTargetSize() || window_resized || fs_changed ||
-      m_last_multisamples != g_ActiveConfig.iMultisamples ||
+  if (CalculateTargetSize() || m_last_multisamples != g_ActiveConfig.iMultisamples ||
       m_last_stereo_mode != (g_ActiveConfig.stereo_mode != StereoMode::Off))
   {
     m_last_multisamples = g_ActiveConfig.iMultisamples;
-    m_last_fullscreen_mode = fullscreen;
-    PixelShaderCache::InvalidateMSAAShaders();
-
-    if (window_resized || fs_changed)
-    {
-      // TODO: Aren't we still holding a reference to the back buffer right now?
-      D3D::Reset();
-      SAFE_RELEASE(m_screenshot_texture);
-      SAFE_RELEASE(m_3d_vision_texture);
-      m_backbuffer_width = D3D::GetBackBufferWidth();
-      m_backbuffer_height = D3D::GetBackBufferHeight();
-    }
-
-    UpdateDrawRectangle();
-
     m_last_stereo_mode = g_ActiveConfig.stereo_mode != StereoMode::Off;
-
-    D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
+    PixelShaderCache::InvalidateMSAAShaders();
+    UpdateDrawRectangle();
 
     g_framebuffer_manager.reset();
     g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
-
     D3D::context->ClearRenderTargetView(FramebufferManager::GetEFBColorTexture()->GetRTV(),
                                         clear_color.data());
     D3D::context->ClearDepthStencilView(FramebufferManager::GetEFBDepthTexture()->GetDSV(),
@@ -631,6 +593,54 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   // begin next frame
   RestoreAPIState();
   FramebufferManager::BindEFBRenderTarget();
+}
+
+void Renderer::CheckForSurfaceChange()
+{
+  if (!m_surface_changed.TestAndClear())
+    return;
+
+  m_surface_handle = m_new_surface_handle;
+  m_new_surface_handle = nullptr;
+
+  SAFE_RELEASE(m_screenshot_texture);
+  SAFE_RELEASE(m_3d_vision_texture);
+  D3D::Reset(reinterpret_cast<HWND>(m_new_surface_handle));
+  UpdateBackbufferSize();
+}
+
+void Renderer::CheckForSurfaceResize()
+{
+  const bool fullscreen_state = D3D::GetFullscreenState();
+  const bool exclusive_fullscreen_changed = fullscreen_state != m_last_fullscreen_state;
+  if (!m_surface_resized.TestAndClear() && !exclusive_fullscreen_changed)
+    return;
+
+  m_backbuffer_width = m_new_backbuffer_width;
+  m_backbuffer_height = m_new_backbuffer_height;
+
+  SAFE_RELEASE(m_screenshot_texture);
+  SAFE_RELEASE(m_3d_vision_texture);
+  m_last_fullscreen_state = fullscreen_state;
+  if (D3D::swapchain)
+    D3D::ResizeSwapChain();
+  UpdateBackbufferSize();
+}
+
+void Renderer::UpdateBackbufferSize()
+{
+  if (D3D::swapchain)
+  {
+    DXGI_SWAP_CHAIN_DESC1 desc = {};
+    D3D::swapchain->GetDesc1(&desc);
+    m_backbuffer_width = std::max(desc.Width, 1u);
+    m_backbuffer_height = std::max(desc.Height, 1u);
+  }
+  else
+  {
+    m_backbuffer_width = 1;
+    m_backbuffer_height = 1;
+  }
 }
 
 // ALWAYS call RestoreAPIState for each ResetAPIState call you're doing

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -18,7 +18,7 @@ class D3DTexture2D;
 class Renderer : public ::Renderer
 {
 public:
-  Renderer();
+  Renderer(int backbuffer_width, int backbuffer_height);
   ~Renderer() override;
 
   StateCache& GetStateCache() { return m_state_cache; }
@@ -63,8 +63,6 @@ public:
 
   void ReinterpretPixelData(unsigned int convtype) override;
 
-  bool CheckForResize();
-
 private:
   struct GXPipelineState
   {
@@ -77,6 +75,9 @@ private:
   void SetupDeviceObjects();
   void TeardownDeviceObjects();
   void Create3DVisionTexture(int width, int height);
+  void CheckForSurfaceChange();
+  void CheckForSurfaceResize();
+  void UpdateBackbufferSize();
 
   void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
                   u32 src_width, u32 src_height, float Gamma);
@@ -95,6 +96,6 @@ private:
 
   u32 m_last_multisamples = 1;
   bool m_last_stereo_mode = false;
-  bool m_last_fullscreen_mode = false;
+  bool m_last_fullscreen_state = false;
 };
 }

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -137,7 +137,17 @@ bool VideoBackend::Initialize(void* window_handle)
     return false;
   }
 
-  g_renderer = std::make_unique<Renderer>();
+  int backbuffer_width = 1, backbuffer_height = 1;
+  if (D3D::swapchain)
+  {
+    DXGI_SWAP_CHAIN_DESC1 desc = {};
+    D3D::swapchain->GetDesc1(&desc);
+    backbuffer_width = std::max(desc.Width, 1u);
+    backbuffer_height = std::max(desc.Height, 1u);
+  }
+
+  // internal interfaces
+  g_renderer = std::make_unique<Renderer>(backbuffer_width, backbuffer_height);
   g_texture_cache = std::make_unique<TextureCache>();
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -845,12 +845,10 @@ std::unique_ptr<AbstractStagingTexture> Renderer::CreateStagingTexture(StagingTe
 
 void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
 {
-  u32 backbuffer_width = std::max(GLInterface->GetBackBufferWidth(), 1u);
-  u32 backbuffer_height = std::max(GLInterface->GetBackBufferHeight(), 1u);
-
-  s_raster_font->printMultilineText(text, left * 2.0f / static_cast<float>(backbuffer_width) - 1.0f,
-                                    1.0f - top * 2.0f / static_cast<float>(backbuffer_height), 0,
-                                    backbuffer_width, backbuffer_height, color);
+  s_raster_font->printMultilineText(text,
+                                    left * 2.0f / static_cast<float>(m_backbuffer_width) - 1.0f,
+                                    1.0f - top * 2.0f / static_cast<float>(m_backbuffer_height), 0,
+                                    m_backbuffer_width, m_backbuffer_height, color);
 }
 
 TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)
@@ -1319,14 +1317,15 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
 
   ResetAPIState();
 
-  UpdateDrawRectangle();
-  TargetRectangle flipped_trc = GetTargetRectangle();
-
-  // Flip top and bottom for some reason; TODO: Fix the code to suck less?
-  std::swap(flipped_trc.top, flipped_trc.bottom);
-
   // Do our OSD callbacks
   OSD::DoCallbacks(OSD::CallbackType::OnFrame);
+
+  // Check if we need to render to a new surface.
+  CheckForSurfaceChange();
+  CheckForSurfaceResize();
+  UpdateDrawRectangle();
+  TargetRectangle flipped_trc = GetTargetRectangle();
+  std::swap(flipped_trc.top, flipped_trc.bottom);
 
   // Skip screen rendering when running in headless mode.
   if (!IsHeadless())
@@ -1357,32 +1356,7 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
     glFlush();
   }
 
-#ifdef ANDROID
-  // Handle surface changes on Android.
-  if (m_surface_needs_change.IsSet())
-  {
-    GLInterface->UpdateHandle(m_new_surface_handle);
-    GLInterface->UpdateSurface();
-    m_surface_handle = m_new_surface_handle;
-    m_new_surface_handle = nullptr;
-    m_surface_needs_change.Clear();
-    m_surface_changed.Set();
-  }
-#endif
-
-  GLInterface->Update();
-
   // Was the size changed since the last frame?
-  bool window_resized = false;
-  int window_width = static_cast<int>(std::max(GLInterface->GetBackBufferWidth(), 1u));
-  int window_height = static_cast<int>(std::max(GLInterface->GetBackBufferHeight(), 1u));
-  if (window_width != m_backbuffer_width || window_height != m_backbuffer_height)
-  {
-    window_resized = true;
-    m_backbuffer_width = window_width;
-    m_backbuffer_height = window_height;
-  }
-
   bool target_size_changed = CalculateTargetSize();
   bool stencil_buffer_enabled =
       static_cast<FramebufferManager*>(g_framebuffer_manager.get())->HasStencilBuffer();
@@ -1392,10 +1366,6 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
                          stencil_buffer_enabled != BoundingBox::NeedsStencilBuffer() ||
                          s_last_stereo_mode != (g_ActiveConfig.stereo_mode != StereoMode::Off);
 
-  if (window_resized || fb_needs_update)
-  {
-    UpdateDrawRectangle();
-  }
   if (fb_needs_update)
   {
     s_last_stereo_mode = g_ActiveConfig.stereo_mode != StereoMode::Off;
@@ -1415,6 +1385,7 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
     g_framebuffer_manager = std::make_unique<FramebufferManager>(
         m_target_width, m_target_height, s_MSAASamples, BoundingBox::NeedsStencilBuffer());
     BoundingBox::SetTargetSizeChanged(m_target_width, m_target_height);
+    UpdateDrawRectangle();
   }
 
   if (s_vsync != g_ActiveConfig.IsVSync())
@@ -1453,6 +1424,30 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
 
   // Invalidate EFB cache
   ClearEFBCache();
+}
+
+void Renderer::CheckForSurfaceChange()
+{
+  if (!m_surface_changed.TestAndClear())
+    return;
+
+  m_surface_handle = m_new_surface_handle;
+  m_new_surface_handle = nullptr;
+  GLInterface->UpdateHandle(m_surface_handle);
+  GLInterface->UpdateSurface();
+
+  // With a surface change, the window likely has new dimensions.
+  m_backbuffer_width = GLInterface->GetBackBufferWidth();
+  m_backbuffer_height = GLInterface->GetBackBufferHeight();
+}
+
+void Renderer::CheckForSurfaceResize()
+{
+  if (!m_surface_resized.TestAndClear())
+    return;
+
+  m_backbuffer_width = m_new_backbuffer_width;
+  m_backbuffer_height = m_new_backbuffer_height;
 }
 
 void Renderer::DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc,
@@ -1571,17 +1566,5 @@ void Renderer::UnbindTexture(const AbstractTexture* texture)
 void Renderer::SetInterlacingMode()
 {
   // TODO
-}
-
-void Renderer::ChangeSurface(void* new_surface_handle)
-{
-// Win32 polls the window size when redrawing, X11 runs an event loop in another thread.
-// This is only necessary for Android at this point, although handling resizes here
-// would be more efficient than polling.
-#ifdef ANDROID
-  m_new_surface_handle = new_surface_handle;
-  m_surface_needs_change.Set();
-  m_surface_changed.Wait();
-#endif
 }
 }

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -121,8 +121,6 @@ public:
 
   void ReinterpretPixelData(unsigned int convtype) override;
 
-  void ChangeSurface(void* new_surface_handle) override;
-
 private:
   void UpdateEFBCache(EFBAccessType type, u32 cacheRectIdx, const EFBRectangle& efbPixelRc,
                       const TargetRectangle& targetPixelRc, const void* data);
@@ -132,6 +130,9 @@ private:
 
   void BlitScreen(TargetRectangle src, TargetRectangle dst, GLuint src_texture, int src_width,
                   int src_height);
+
+  void CheckForSurfaceChange();
+  void CheckForSurfaceResize();
 
   std::array<const AbstractTexture*, 8> m_bound_textures{};
 };

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -500,6 +500,10 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   StateTracker::GetInstance()->EndRenderPass();
   StateTracker::GetInstance()->OnEndFrame();
 
+  // Handle host window resizes.
+  CheckForSurfaceChange();
+  CheckForSurfaceResize();
+
   // There are a few variables which can alter the final window draw rectangle, and some of them
   // are determined by guest state. Currently, the only way to catch these is to update every frame.
   UpdateDrawRectangle();
@@ -542,9 +546,6 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
 
   // Determine what (if anything) has changed in the config.
   CheckForConfigChanges();
-
-  // Handle host window resizes.
-  CheckForSurfaceChange();
 
   // Clean up stale textures.
   TextureCache::GetInstance()->Cleanup(frameCount);
@@ -650,68 +651,80 @@ void Renderer::BlitScreen(VkRenderPass render_pass, const TargetRectangle& dst_r
 
 void Renderer::CheckForSurfaceChange()
 {
-  if (!m_surface_needs_change.IsSet())
+  if (!m_surface_changed.TestAndClear())
     return;
 
-  // Wait for the GPU to catch up since we're going to destroy the swap chain.
+  m_surface_handle = m_new_surface_handle;
+  m_new_surface_handle = nullptr;
+
+  // Submit the current draws up until rendering the XFB.
+  g_command_buffer_mgr->ExecuteCommandBuffer(false, false);
   g_command_buffer_mgr->WaitForGPUIdle();
 
   // Clear the present failed flag, since we don't want to resize after recreating.
   g_command_buffer_mgr->CheckLastPresentFail();
 
-  // Fast path, if the surface handle is the same, the window has just been resized.
-  if (m_swap_chain && m_new_surface_handle == m_swap_chain->GetNativeHandle())
+  // Did we previously have a swap chain?
+  if (m_swap_chain)
   {
-    INFO_LOG(VIDEO, "Detected window resize.");
-    m_swap_chain->RecreateSwapChain();
-
-    // Notify the main thread we are done.
-    m_surface_needs_change.Clear();
-    m_new_surface_handle = nullptr;
-    m_surface_changed.Set();
-  }
-  else
-  {
-    // Did we previously have a swap chain?
-    if (m_swap_chain)
+    if (!m_surface_handle)
     {
-      if (!m_new_surface_handle)
-      {
-        // If there is no surface now, destroy the swap chain.
-        m_swap_chain.reset();
-      }
-      else
-      {
-        // Recreate the surface. If this fails we're in trouble.
-        if (!m_swap_chain->RecreateSurface(m_new_surface_handle))
-          PanicAlert("Failed to recreate Vulkan surface. Cannot continue.");
-      }
+      // If there is no surface now, destroy the swap chain.
+      m_swap_chain.reset();
     }
     else
     {
-      // Previously had no swap chain. So create one.
-      VkSurfaceKHR surface = SwapChain::CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(),
-                                                            m_new_surface_handle);
-      if (surface != VK_NULL_HANDLE)
-      {
-        m_swap_chain = SwapChain::Create(m_new_surface_handle, surface, g_ActiveConfig.IsVSync());
-        if (!m_swap_chain)
-          PanicAlert("Failed to create swap chain.");
-      }
-      else
-      {
-        PanicAlert("Failed to create surface.");
-      }
+      // Recreate the surface. If this fails we're in trouble.
+      if (!m_swap_chain->RecreateSurface(m_surface_handle))
+        PanicAlert("Failed to recreate Vulkan surface. Cannot continue.");
     }
-
-    // Notify calling thread.
-    m_surface_needs_change.Clear();
-    m_surface_handle = m_new_surface_handle;
-    m_new_surface_handle = nullptr;
-    m_surface_changed.Set();
+  }
+  else
+  {
+    // Previously had no swap chain. So create one.
+    VkSurfaceKHR surface =
+        SwapChain::CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(), m_surface_handle);
+    if (surface != VK_NULL_HANDLE)
+    {
+      m_swap_chain = SwapChain::Create(m_surface_handle, surface, g_ActiveConfig.IsVSync());
+      if (!m_swap_chain)
+        PanicAlert("Failed to create swap chain.");
+    }
+    else
+    {
+      PanicAlert("Failed to create surface.");
+    }
   }
 
   // Handle case where the dimensions are now different.
+  OnSwapChainResized();
+}
+
+void Renderer::CheckForSurfaceResize()
+{
+  if (!m_surface_resized.TestAndClear())
+    return;
+
+  m_backbuffer_width = m_new_backbuffer_width;
+  m_backbuffer_height = m_new_backbuffer_height;
+
+  // If we don't have a surface, how can we resize the swap chain?
+  // CheckForSurfaceChange should handle this case.
+  if (!m_swap_chain)
+  {
+    WARN_LOG(VIDEO, "Surface resize event received without active surface, ignoring");
+    return;
+  }
+
+  // Wait for the GPU to catch up since we're going to destroy the swap chain.
+  g_command_buffer_mgr->ExecuteCommandBuffer(false, false);
+  g_command_buffer_mgr->WaitForGPUIdle();
+
+  // Clear the present failed flag, since we don't want to resize after recreating.
+  g_command_buffer_mgr->CheckLastPresentFail();
+
+  // Resize the swap chain.
+  m_swap_chain->RecreateSwapChain();
   OnSwapChainResized();
 }
 
@@ -782,9 +795,6 @@ void Renderer::OnSwapChainResized()
 {
   m_backbuffer_width = m_swap_chain->GetWidth();
   m_backbuffer_height = m_swap_chain->GetHeight();
-  UpdateDrawRectangle();
-  if (CalculateTargetSize())
-    RecreateEFBFramebuffer();
 }
 
 void Renderer::BindEFBToStateTracker()
@@ -912,14 +922,6 @@ void Renderer::SetViewport(float x, float y, float width, float height, float ne
   VkViewport viewport = {x,          y,        std::max(width, 1.0f), std::max(height, 1.0f),
                          near_depth, far_depth};
   StateTracker::GetInstance()->SetViewport(viewport);
-}
-
-void Renderer::ChangeSurface(void* new_surface_handle)
-{
-  // Called by the main thread when the window is resized.
-  m_new_surface_handle = new_surface_handle;
-  m_surface_needs_change.Set();
-  m_surface_changed.Set();
 }
 
 void Renderer::RecompileShaders()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -70,8 +70,6 @@ public:
   void SetViewport(float x, float y, float width, float height, float near_depth,
                    float far_depth) override;
 
-  void ChangeSurface(void* new_surface_handle) override;
-
 private:
   bool CreateSemaphores();
   void DestroySemaphores();
@@ -79,6 +77,7 @@ private:
   void BeginFrame();
 
   void CheckForSurfaceChange();
+  void CheckForSurfaceResize();
   void CheckForConfigChanges();
 
   void ResetSamplerStates();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -154,7 +154,8 @@ public:
   PostProcessingShaderImplementation* GetPostProcessor() const { return m_post_processor.get(); }
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
-  virtual void ChangeSurface(void* new_surface_handle) {}
+  void ChangeSurface(void* new_surface_handle);
+  void ResizeSurface(int new_width, int new_height);
   bool UseVertexDepthRange() const;
 
   virtual void Shutdown();
@@ -178,9 +179,11 @@ protected:
   int m_target_width = 0;
   int m_target_height = 0;
 
-  // TODO: Add functionality to reinit all the render targets when the window is resized.
+  // Backbuffer (window) size and render area
   int m_backbuffer_width = 0;
   int m_backbuffer_height = 0;
+  int m_new_backbuffer_width = 0;
+  int m_new_backbuffer_height = 0;
   TargetRectangle m_target_rectangle = {};
 
   FPSCounter m_fps_counter;
@@ -189,8 +192,9 @@ protected:
 
   void* m_surface_handle = nullptr;
   void* m_new_surface_handle = nullptr;
-  Common::Flag m_surface_needs_change;
-  Common::Event m_surface_changed;
+  Common::Flag m_surface_changed;
+  Common::Flag m_surface_resized;
+  std::mutex m_swap_mutex;
 
   u32 m_last_host_config_bits = 0;
 


### PR DESCRIPTION
Currently, our handling of surface change and resize events is kind of a mess. We have different methods depending on the selected backend, as well as platform (e.g. OpenGL on Android can handle surface changes but no other platform can). The implementation also enabled a race with the video thread, where Dolphin could render to an invalid system window surface, leading to display corruption when the surface was recreated, for example, when the phone was rotated.

The new implementation ensures all platforms behave similar in handling surface changes. Currently, the surface change is only hooked up to Qt, but on the desktop the surface will not change during runtime. However, this enables us to change the window in the future, which can enable possibilities such as toggling render-to-main-window at runtime.

Resize events have also been reworked, instead of relying on the polled backbuffer dimensions from GLInterface, we propogate resize events from the UI to the graphics backend, and respond accordingly. This can reduce overhead very slightly, as we no longer need to repeatedly call GetClientRect() on Windows. In X11, we still need the event loop as we're using a separate display. I'm planning on eliminating this in the future by passing the display from the UI instead, and using XCB instead.

Most importantly, this should fix the bug on Android where rotating the phone or pausing/resuming, when using Vulkan, would cause the app to crash.