### PR TITLE
Renderer: Fix crash on shutdown when frame dumping or taking screenshots

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -800,6 +800,9 @@ void Renderer::ShutdownFrameDumping()
   m_frame_dump_start.Set();
   if (m_frame_dump_thread.joinable())
     m_frame_dump_thread.join();
+  m_frame_dump_render_texture.reset();
+  for (auto& tex : m_frame_dump_readback_textures)
+    tex.reset();
 }
 
 void Renderer::DumpFrameData(const u8* data, int w, int h, int stride, const AVIDump::Frame& state)


### PR DESCRIPTION
Another regression from #6317. Storing objects in the class which we call to destroy them probably is not a great design decision, perhaps we should consider creating a "GPU Device" class for resource management...