### PR TITLE
Video Backend Initialization/Core Boot Improvements

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -241,7 +241,6 @@ bool Init(std::unique_ptr<BootParameters> boot)
 
   // Start the emu thread
   s_emu_thread = std::thread(EmuThread, std::move(boot));
-
   return true;
 }
 
@@ -311,9 +310,13 @@ void UndeclareAsCPUThread()
 // For the CPU Thread only.
 static void CPUSetInitialExecutionState()
 {
-  QueueHostJob([] {
+  // The CPU starts in stepping state, and will wait until a new state is set before executing.
+  // SetState must be called on the host thread, so we defer it for later.
+  QueueHostJob([]() {
     SetState(SConfig::GetInstance().bBootToPause ? State::Paused : State::Running);
+    Host_UpdateDisasmDialog();
     Host_UpdateMainFrame();
+    Host_Message(WM_USER_CREATE);
   });
 }
 
@@ -323,23 +326,27 @@ static void CpuThread(const std::optional<std::string>& savestate_path, bool del
   DeclareAsCPUThread();
 
   const SConfig& _CoreParameter = SConfig::GetInstance();
-
   if (_CoreParameter.bCPUThread)
-  {
     Common::SetCurrentThreadName("CPU thread");
-  }
   else
-  {
     Common::SetCurrentThreadName("CPU-GPU thread");
-    g_video_backend->Video_Prepare();
-    Host_Message(WM_USER_CREATE);
-  }
 
   // This needs to be delayed until after the video backend is ready.
   DolphinAnalytics::Instance()->ReportGameStart();
 
   if (_CoreParameter.bFastmem)
     EMM::InstallExceptionHandler();  // Let's run under memory watch
+
+#ifdef USE_MEMORYWATCHER
+  MemoryWatcher::Init();
+#endif
+
+  if (savestate_path)
+  {
+    ::State::LoadAs(*savestate_path);
+    if (delete_savestate)
+      File::Delete(*savestate_path);
+  }
 
   s_is_started = true;
   CPUSetInitialExecutionState();
@@ -361,24 +368,10 @@ static void CpuThread(const std::optional<std::string>& savestate_path, bool del
   }
 #endif
 
-#ifdef USE_MEMORYWATCHER
-  MemoryWatcher::Init();
-#endif
-
-  if (savestate_path)
-  {
-    ::State::LoadAs(*savestate_path);
-    if (delete_savestate)
-      File::Delete(*savestate_path);
-  }
-
   // Enter CPU run loop. When we leave it - we are done.
   CPU::Run();
 
   s_is_started = false;
-
-  if (!_CoreParameter.bCPUThread)
-    g_video_backend->Video_CleanupShared();
 
   if (_CoreParameter.bFastmem)
     EMM::UninstallExceptionHandler();
@@ -388,18 +381,12 @@ static void FifoPlayerThread(const std::optional<std::string>& savestate_path,
                              bool delete_savestate)
 {
   DeclareAsCPUThread();
-  const SConfig& _CoreParameter = SConfig::GetInstance();
 
+  const SConfig& _CoreParameter = SConfig::GetInstance();
   if (_CoreParameter.bCPUThread)
-  {
     Common::SetCurrentThreadName("FIFO player thread");
-  }
   else
-  {
-    g_video_backend->Video_Prepare();
-    Host_Message(WM_USER_CREATE);
     Common::SetCurrentThreadName("FIFO-GPU thread");
-  }
 
   // Enter CPU run loop. When we leave it - we are done.
   if (auto cpu_core = FifoPlayer::GetInstance().GetCPUCore())
@@ -412,20 +399,15 @@ static void FifoPlayerThread(const std::optional<std::string>& savestate_path,
 
     s_is_started = false;
     PowerPC::InjectExternalCPUCore(nullptr);
+    FifoPlayer::GetInstance().Close();
   }
-  FifoPlayer::GetInstance().Close();
-
-  // If we did not enter the CPU Run Loop above then run a fake one instead.
-  // We need to be IsRunningAndStarted() for DolphinWX to stop us.
-  if (CPU::GetState() != CPU::State::PowerDown)
+  else
   {
-    s_is_started = true;
-    Host_Message(WM_USER_STOP);
-    s_is_started = false;
+    // FIFO log does not contain any frames, cannot continue.
+    PanicAlert("FIFO file is invalid, cannot playback.");
+    FifoPlayer::GetInstance().Close();
+    return;
   }
-
-  if (!_CoreParameter.bCPUThread)
-    g_video_backend->Video_CleanupShared();
 }
 
 // Initialize and create emulation thread
@@ -448,9 +430,6 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
 
     INFO_LOG(CONSOLE, "Stop\t\t---- Shutdown complete ----");
   }};
-
-  // Prevent the UI from getting stuck whenever an error occurs.
-  Common::ScopeGuard stop_message_guard{[] { Host_Message(WM_USER_STOP); }};
 
   Common::SetCurrentThreadName("Emuthread - Starting");
 
@@ -485,9 +464,11 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
     PanicAlert("Failed to initialize video backend!");
     return;
   }
-  Common::ScopeGuard video_guard{[] { g_video_backend->Shutdown(); }};
-
-  OSD::AddMessage("Dolphin " + g_video_backend->GetName() + " Video Backend.", 5000);
+  g_video_backend->Video_Prepare();
+  Common::ScopeGuard video_guard{[] {
+    g_video_backend->Video_Cleanup();
+    g_video_backend->Shutdown();
+  }};
 
   if (cpu_info.HTT)
     SConfig::GetInstance().bDSPThread = cpu_info.num_cores > 4;
@@ -568,9 +549,6 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
   // This adds the SyncGPU handler to CoreTiming, so now CoreTiming::Advance might block.
   Fifo::Prepare();
 
-  // Thread is no longer acting as CPU Thread
-  UndeclareAsCPUThread();
-
   // Setup our core, but can't use dynarec if we are compare server
   if (core_parameter.iCPUCore != PowerPC::CORE_INTERPRETER &&
       (!core_parameter.bRunCompareServer || core_parameter.bRunCompareClient))
@@ -582,21 +560,15 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
     PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
   }
 
-  // Update the window again because all stuff is initialized
-  Host_UpdateDisasmDialog();
-  Host_UpdateMainFrame();
-
   // ENTER THE VIDEO THREAD LOOP
   if (core_parameter.bCPUThread)
   {
     // This thread, after creating the EmuWindow, spawns a CPU
     // thread, and then takes over and becomes the video thread
     Common::SetCurrentThreadName("Video thread");
+    UndeclareAsCPUThread();
 
-    g_video_backend->Video_Prepare();
-    Host_Message(WM_USER_CREATE);
-
-    // Spawn the CPU thread
+    // Spawn the CPU thread. The CPU thread will signal the event that boot is complete.
     s_cpu_thread = std::thread(cpuThreadFunc, savestate_path, delete_savestate);
 
     // become the GPU thread
@@ -620,12 +592,6 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
   gdb_deinit();
   INFO_LOG(CONSOLE, "%s", StopMessage(true, "GDB stopped.").c_str());
 #endif
-
-  if (core_parameter.bCPUThread)
-    g_video_backend->Video_CleanupShared();
-
-  // If we shut down normally, the stop message does not need to be triggered.
-  stop_message_guard.Dismiss();
 }
 
 // Set or get the running state

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -464,11 +464,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
     PanicAlert("Failed to initialize video backend!");
     return;
   }
-  g_video_backend->Video_Prepare();
-  Common::ScopeGuard video_guard{[] {
-    g_video_backend->Video_Cleanup();
-    g_video_backend->Shutdown();
-  }};
+  Common::ScopeGuard video_guard{[] { g_video_backend->Shutdown(); }};
 
   if (cpu_info.HTT)
     SConfig::GetInstance().bDSPThread = cpu_info.num_cores > 4;

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -83,10 +83,9 @@ static Common::Event updateMainFrameEvent;
 void Host_Message(int Id)
 {
   if (Id == WM_USER_STOP)
-  {
     s_running.Clear();
+  if (Id == WM_USER_JOB_DISPATCH || Id == WM_USER_STOP)
     updateMainFrameEvent.Set();
-  }
 }
 
 static void* s_window_handle = nullptr;

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -761,6 +761,8 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
   case WM_USER_CREATE:
     if (SConfig::GetInstance().bHideCursor)
       m_render_parent->SetCursor(wxCURSOR_BLANK);
+    if (SConfig::GetInstance().bFullscreen)
+      DoFullscreen(true);
     break;
 
   case IDM_PANIC:

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -717,6 +717,7 @@ void CFrame::StartGame(std::unique_ptr<BootParameters> boot)
     m_render_parent = new wxPanel(m_render_frame, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
 #endif
     m_render_frame->Show();
+    m_render_frame->Raise();
   }
 
 #if defined(__APPLE__)
@@ -724,15 +725,10 @@ void CFrame::StartGame(std::unique_ptr<BootParameters> boot)
 #endif
 
   wxBusyCursor hourglass;
-
-  DoFullscreen(SConfig::GetInstance().bFullscreen);
-
   SetDebuggerStartupParameters();
 
   if (!BootManager::BootCore(std::move(boot)))
   {
-    DoFullscreen(false);
-
     // Destroy the renderer frame when not rendering to main
     if (!SConfig::GetInstance().bRenderToMain)
       m_render_frame->Destroy();

--- a/Source/Core/VideoBackends/D3D/VideoBackend.h
+++ b/Source/Core/VideoBackends/D3D/VideoBackend.h
@@ -18,7 +18,5 @@ class VideoBackend : public VideoBackendBase
   std::string GetDisplayName() const override;
 
   void InitBackendInfo() override;
-
-  unsigned int PeekMessages() override;
 };
 }

--- a/Source/Core/VideoBackends/D3D/VideoBackend.h
+++ b/Source/Core/VideoBackends/D3D/VideoBackend.h
@@ -17,13 +17,8 @@ class VideoBackend : public VideoBackendBase
   std::string GetName() const override;
   std::string GetDisplayName() const override;
 
-  void Video_Prepare() override;
-  void Video_Cleanup() override;
-
   void InitBackendInfo() override;
 
   unsigned int PeekMessages() override;
-
-  void* m_window_handle;
 };
 }

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -145,32 +145,30 @@ bool VideoBackend::Initialize(void* window_handle)
   InitBackendInfo();
   InitializeShared();
 
-  m_window_handle = window_handle;
-
-  return true;
-}
-
-void VideoBackend::Video_Prepare()
-{
-  if (FAILED(D3D::Create(reinterpret_cast<HWND>(m_window_handle))))
+  if (FAILED(D3D::Create(reinterpret_cast<HWND>(window_handle))))
+  {
     PanicAlert("Failed to create D3D device.");
+    return false;
+  }
 
-  // internal interfaces
   g_renderer = std::make_unique<Renderer>();
   g_texture_cache = std::make_unique<TextureCache>();
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
+
   VertexShaderCache::Init();
   PixelShaderCache::Init();
   GeometryShaderCache::Init();
   VertexShaderCache::WaitForBackgroundCompilesToComplete();
   D3D::InitUtils();
   BBox::Init();
+  return true;
 }
 
 void VideoBackend::Shutdown()
 {
-  // TODO: should be in Video_Cleanup
+  g_renderer->Shutdown();
+
   D3D::ShutdownUtils();
   PixelShaderCache::Shutdown();
   VertexShaderCache::Shutdown();
@@ -182,13 +180,8 @@ void VideoBackend::Shutdown()
   g_texture_cache.reset();
   g_renderer.reset();
 
-  D3D::Close();
-
   ShutdownShared();
-}
 
-void VideoBackend::Video_Cleanup()
-{
-  CleanupShared();
+  D3D::Close();
 }
 }

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -26,19 +26,6 @@
 
 namespace DX11
 {
-unsigned int VideoBackend::PeekMessages()
-{
-  MSG msg;
-  while (PeekMessage(&msg, 0, 0, 0, PM_REMOVE))
-  {
-    if (msg.message == WM_QUIT)
-      return FALSE;
-    TranslateMessage(&msg);
-    DispatchMessage(&msg);
-  }
-  return TRUE;
-}
-
 std::string VideoBackend::GetName() const
 {
   return "D3D";

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -58,38 +58,32 @@ bool VideoBackend::Initialize(void* window_handle)
   InitializeShared();
   InitBackendInfo();
 
-  return true;
-}
-
-// This is called after Initialize() from the Core
-// Run from the graphics thread
-void VideoBackend::Video_Prepare()
-{
   g_renderer = std::make_unique<Renderer>();
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
   g_framebuffer_manager = std::make_unique<FramebufferManagerBase>();
   g_texture_cache = std::make_unique<TextureCache>();
+
   VertexShaderCache::s_instance = std::make_unique<VertexShaderCache>();
   GeometryShaderCache::s_instance = std::make_unique<GeometryShaderCache>();
   PixelShaderCache::s_instance = std::make_unique<PixelShaderCache>();
+  return true;
 }
 
 void VideoBackend::Shutdown()
 {
-  ShutdownShared();
-}
+  g_renderer->Shutdown();
 
-void VideoBackend::Video_Cleanup()
-{
-  CleanupShared();
   PixelShaderCache::s_instance.reset();
   VertexShaderCache::s_instance.reset();
   GeometryShaderCache::s_instance.reset();
+
   g_texture_cache.reset();
   g_perf_query.reset();
   g_vertex_manager.reset();
   g_framebuffer_manager.reset();
   g_renderer.reset();
+
+  ShutdownShared();
 }
 }

--- a/Source/Core/VideoBackends/Null/VideoBackend.h
+++ b/Source/Core/VideoBackends/Null/VideoBackend.h
@@ -15,9 +15,6 @@ class VideoBackend : public VideoBackendBase
 
   std::string GetName() const override { return "Null"; }
   std::string GetDisplayName() const override { return "Null"; }
-  void Video_Prepare() override;
-  void Video_Cleanup() override;
-
   void InitBackendInfo() override;
 
   unsigned int PeekMessages() override { return 0; }

--- a/Source/Core/VideoBackends/Null/VideoBackend.h
+++ b/Source/Core/VideoBackends/Null/VideoBackend.h
@@ -16,7 +16,5 @@ class VideoBackend : public VideoBackendBase
   std::string GetName() const override { return "Null"; }
   std::string GetDisplayName() const override { return "Null"; }
   void InitBackendInfo() override;
-
-  unsigned int PeekMessages() override { return 0; }
 };
 }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -809,6 +809,7 @@ Renderer::~Renderer() = default;
 
 void Renderer::Shutdown()
 {
+  ::Renderer::Shutdown();
   g_framebuffer_manager.reset();
 
   UpdateActiveConfig();

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -84,7 +84,7 @@ public:
   ~Renderer() override;
 
   void Init();
-  void Shutdown();
+  void Shutdown() override;
 
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
   std::unique_ptr<AbstractStagingTexture>

--- a/Source/Core/VideoBackends/OGL/VideoBackend.h
+++ b/Source/Core/VideoBackends/OGL/VideoBackend.h
@@ -19,8 +19,6 @@ class VideoBackend : public VideoBackendBase
 
   void InitBackendInfo() override;
 
-  unsigned int PeekMessages() override;
-
 private:
   bool InitializeGLExtensions();
   bool FillBackendInfo();

--- a/Source/Core/VideoBackends/OGL/VideoBackend.h
+++ b/Source/Core/VideoBackends/OGL/VideoBackend.h
@@ -17,9 +17,6 @@ class VideoBackend : public VideoBackendBase
   std::string GetName() const override;
   std::string GetDisplayName() const override;
 
-  void Video_Prepare() override;
-  void Video_Cleanup() override;
-
   void InitBackendInfo() override;
 
   unsigned int PeekMessages() override;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -58,12 +58,6 @@ Make AA apply instantly during gameplay if possible
 
 namespace OGL
 {
-// Draw messages on top of the screen
-unsigned int VideoBackend::PeekMessages()
-{
-  return GLInterface->PeekMessages();
-}
-
 std::string VideoBackend::GetName() const
 {
   return "OGL";

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -172,23 +172,11 @@ bool VideoBackend::Initialize(void* window_handle)
   if (!GLInterface->Create(window_handle, g_ActiveConfig.stereo_mode == StereoMode::QuadBuffer))
     return false;
 
-  return true;
-}
-
-// This is called after Initialize() from the Core
-// Run from the graphics thread
-void VideoBackend::Video_Prepare()
-{
   GLInterface->MakeCurrent();
   if (!InitializeGLExtensions() || !FillBackendInfo())
-  {
-    // TODO: Handle this better. We'll likely end up crashing anyway, but this method doesn't
-    // return anything, so we can't inform the caller that startup failed.
-    return;
-  }
+    return false;
 
   g_renderer = std::make_unique<Renderer>();
-
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = GetPerfQuery();
   ProgramShaderCache::Init();
@@ -197,21 +185,12 @@ void VideoBackend::Video_Prepare()
   static_cast<Renderer*>(g_renderer.get())->Init();
   TextureConverter::Init();
   BoundingBox::Init(g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
+  return true;
 }
 
 void VideoBackend::Shutdown()
 {
-  GLInterface->Shutdown();
-  GLInterface.reset();
-  ShutdownShared();
-}
-
-void VideoBackend::Video_Cleanup()
-{
-  // The following calls are NOT Thread Safe
-  // And need to be called from the video thread
-  CleanupShared();
-  static_cast<Renderer*>(g_renderer.get())->Shutdown();
+  g_renderer->Shutdown();
   BoundingBox::Shutdown();
   TextureConverter::Shutdown();
   g_sampler_cache.reset();
@@ -221,5 +200,8 @@ void VideoBackend::Video_Cleanup()
   g_vertex_manager.reset();
   g_renderer.reset();
   GLInterface->ClearCurrent();
+  GLInterface->Shutdown();
+  GLInterface.reset();
+  ShutdownShared();
 }
 }

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -26,15 +26,6 @@ SWRenderer::SWRenderer()
 {
 }
 
-void SWRenderer::Init()
-{
-}
-
-void SWRenderer::Shutdown()
-{
-  UpdateActiveConfig();
-}
-
 std::unique_ptr<AbstractTexture> SWRenderer::CreateTexture(const TextureConfig& config)
 {
   return std::make_unique<SW::SWTexture>(config);

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -13,9 +13,6 @@ class SWRenderer : public Renderer
 public:
   SWRenderer();
 
-  static void Init();
-  static void Shutdown();
-
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -114,9 +114,4 @@ void VideoSoftware::Shutdown()
   g_renderer.reset();
   ShutdownShared();
 }
-
-unsigned int VideoSoftware::PeekMessages()
-{
-  return SWOGLWindow::s_instance->PeekMessages();
-}
 }

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -88,38 +88,8 @@ bool VideoSoftware::Initialize(void* window_handle)
 
   Clipper::Init();
   Rasterizer::Init();
-  SWRenderer::Init();
   DebugUtil::Init();
 
-  return true;
-}
-
-void VideoSoftware::Shutdown()
-{
-  SWOGLWindow::Shutdown();
-
-  ShutdownShared();
-}
-
-void VideoSoftware::Video_Cleanup()
-{
-  CleanupShared();
-
-  SWRenderer::Shutdown();
-  DebugUtil::Shutdown();
-  // The following calls are NOT Thread Safe
-  // And need to be called from the video thread
-  SWRenderer::Shutdown();
-  g_framebuffer_manager.reset();
-  g_texture_cache.reset();
-  g_perf_query.reset();
-  g_vertex_manager.reset();
-  g_renderer.reset();
-}
-
-// This is called after Video_Initialize() from the Core
-void VideoSoftware::Video_Prepare()
-{
   GLInterface->MakeCurrent();
   SWOGLWindow::s_instance->Prepare();
 
@@ -127,7 +97,22 @@ void VideoSoftware::Video_Prepare()
   g_vertex_manager = std::make_unique<SWVertexLoader>();
   g_perf_query = std::make_unique<PerfQuery>();
   g_texture_cache = std::make_unique<TextureCache>();
-  SWRenderer::Init();
+  return true;
+}
+
+void VideoSoftware::Shutdown()
+{
+  if (g_renderer)
+    g_renderer->Shutdown();
+
+  DebugUtil::Shutdown();
+  SWOGLWindow::Shutdown();
+  g_framebuffer_manager.reset();
+  g_texture_cache.reset();
+  g_perf_query.reset();
+  g_vertex_manager.reset();
+  g_renderer.reset();
+  ShutdownShared();
 }
 
 unsigned int VideoSoftware::PeekMessages()

--- a/Source/Core/VideoBackends/Software/VideoBackend.h
+++ b/Source/Core/VideoBackends/Software/VideoBackend.h
@@ -18,7 +18,5 @@ class VideoSoftware : public VideoBackendBase
   std::string GetDisplayName() const override;
 
   void InitBackendInfo() override;
-
-  unsigned int PeekMessages() override;
 };
 }

--- a/Source/Core/VideoBackends/Software/VideoBackend.h
+++ b/Source/Core/VideoBackends/Software/VideoBackend.h
@@ -17,9 +17,6 @@ class VideoSoftware : public VideoBackendBase
   std::string GetName() const override;
   std::string GetDisplayName() const override;
 
-  void Video_Prepare() override;
-  void Video_Cleanup() override;
-
   void InitBackendInfo() override;
 
   unsigned int PeekMessages() override;

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
@@ -76,6 +76,9 @@ void ShaderCache::Shutdown()
     m_async_shader_compiler->StopWorkerThreads();
     m_async_shader_compiler->RetrieveWorkItems();
   }
+
+  if (g_ActiveConfig.bShaderCache && m_pipeline_cache != VK_NULL_HANDLE)
+    SavePipelineCache();
 }
 
 static bool IsStripPrimitiveTopology(VkPrimitiveTopology topology)

--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -16,9 +16,6 @@ public:
 
   std::string GetName() const override { return "Vulkan"; }
   std::string GetDisplayName() const override { return "Vulkan (experimental)"; }
-  void Video_Prepare() override;
-  void Video_Cleanup() override;
-
   void InitBackendInfo() override;
 
   unsigned int PeekMessages() override { return 0; }

--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -17,7 +17,5 @@ public:
   std::string GetName() const override { return "Vulkan"; }
   std::string GetDisplayName() const override { return "Vulkan (experimental)"; }
   void InitBackendInfo() override;
-
-  unsigned int PeekMessages() override { return 0; }
 };
 }

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -245,22 +245,16 @@ bool VideoBackend::Initialize(void* window_handle)
   if (g_ActiveConfig.CanPrecompileUberShaders())
     g_shader_cache->PrecompileUberShaders();
 
+  // Display the name so the user knows which device was actually created.
+  INFO_LOG(VIDEO, "Vulkan Device: %s", g_vulkan_context->GetDeviceProperties().deviceName);
   return true;
-}
-
-// This is called after Initialize() from the Core
-// Run from the graphics thread
-void VideoBackend::Video_Prepare()
-{
-  // Display the name so the user knows which device was actually created
-  OSD::AddMessage(StringFromFormat("Using physical adapter %s",
-                                   g_vulkan_context->GetDeviceProperties().deviceName)
-                      .c_str(),
-                  5000);
 }
 
 void VideoBackend::Shutdown()
 {
+  if (g_renderer)
+    g_renderer->Shutdown();
+
   if (g_command_buffer_mgr)
     g_command_buffer_mgr->WaitForGPUIdle();
 
@@ -278,16 +272,5 @@ void VideoBackend::Shutdown()
   g_vulkan_context.reset();
   ShutdownShared();
   UnloadVulkanLibrary();
-}
-
-void VideoBackend::Video_Cleanup()
-{
-  g_command_buffer_mgr->WaitForGPUIdle();
-
-  // Save all cached pipelines out to disk for next time.
-  if (g_ActiveConfig.bShaderCache)
-    g_shader_cache->SavePipelineCache();
-
-  CleanupShared();
 }
 }

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -299,8 +299,6 @@ void RunGpuLoop()
       [] {
         const SConfig& param = SConfig::GetInstance();
 
-        g_video_backend->PeekMessages();
-
         // Do nothing while paused
         if (!s_emu_running_state.IsSet())
           return;

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -45,15 +45,6 @@ void VideoBackendBase::Video_ExitLoop()
   s_FifoShuttingDown.Set();
 }
 
-void VideoBackendBase::Video_CleanupShared()
-{
-  // First stop any framedumping, which might need to dump the last xfb frame. This process
-  // can require additional graphics sub-systems so it needs to be done first
-  g_renderer->ShutdownFrameDumping();
-
-  Video_Cleanup();
-}
-
 // Run from the CPU thread (from VideoInterface.cpp)
 void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                                         u64 ticks)
@@ -211,12 +202,8 @@ void VideoBackendBase::ShutdownShared()
 
   m_initialized = false;
 
-  Fifo::Shutdown();
-}
-
-void VideoBackendBase::CleanupShared()
-{
   VertexLoaderManager::Clear();
+  Fifo::Shutdown();
 }
 
 // Run from the CPU thread

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -101,6 +101,13 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
 
 Renderer::~Renderer() = default;
 
+void Renderer::Shutdown()
+{
+  // First stop any framedumping, which might need to dump the last xfb frame. This process
+  // can require additional graphics sub-systems so it needs to be done first
+  ShutdownFrameDumping();
+}
+
 void Renderer::RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbStride, u32 fbHeight,
                            float Gamma)
 {

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -154,7 +154,7 @@ public:
   virtual void ChangeSurface(void* new_surface_handle) {}
   bool UseVertexDepthRange() const;
 
-  void ShutdownFrameDumping();
+  virtual void Shutdown();
 
 protected:
   std::tuple<int, int> CalculateTargetScale(int x, int y) const;
@@ -243,6 +243,7 @@ private:
   std::string GetFrameDumpNextImageFileName() const;
   bool StartFrameDumpToImage(const FrameDumpConfig& config);
   void DumpFrameToImage(const FrameDumpConfig& config);
+  void ShutdownFrameDumping();
 
   bool IsFrameDumping();
 

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -35,8 +35,6 @@ class VideoBackendBase
 {
 public:
   virtual ~VideoBackendBase() {}
-  virtual unsigned int PeekMessages() = 0;
-
   virtual bool Initialize(void* window_handle) = 0;
   virtual void Shutdown() = 0;
 

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -45,11 +45,7 @@ public:
   void ShowConfig(void*);
   virtual void InitBackendInfo() = 0;
 
-  virtual void Video_Prepare() = 0;
   void Video_ExitLoop();
-
-  void Video_CleanupShared();  // called from gl/d3d thread
-  virtual void Video_Cleanup() = 0;
 
   void Video_BeginField(u32, u32, u32, u32, u64);
 
@@ -70,7 +66,6 @@ public:
 protected:
   void InitializeShared();
   void ShutdownShared();
-  void CleanupShared();
 
   bool m_initialized = false;
   bool m_invalid = false;


### PR DESCRIPTION
This PR cleans up parts of the video backend initialization, and removes a small amount of redundant code from the main core boot function.

The changes to boot include:
 - Don't send the boot complete message until startup has finished, and the CPU is ready to start executing. This means that all potential points of failure will be covered.
 - WM_USER_STOP is no longer sent when the CPU thread exits, as far as I could tell, this is signaling the stop button, which is redundant as the core is already shutting down by this point.
 - The OSD message with the video backend name is no longer displayed on startup. I felt this was redundant as the backend name is displayed in the title bar of the window, anyway.

It also removes the need for an additional idling thread in single-core mode, which did nothing but pump a message queue which would never see any messages posted. Furthermore, the UI thread creates the window that the backend renders into, so any messages for the backend window will be received on the UI thread anyway. The PumpMessages method has also been removed. We could probably drop it from GLInterface too, but given it was common code, I left it alone for now.

The Prepare and Cleanup methods in VideoBackend have been combined with Initialize and Shutdown respectively. This arrangement never made sense to me as both are executed on the same thread, perhaps in the past this was not the case, but now it's just over-complicating the startup process. Additionally, the code called by Prepare could not return a failure status, which meant that the emulator got "stuck" in limbo if anything in prepare failed.

The last change moves the fullscreen switch to after the core has finished booting. This is so any error messages will be displayed and can be dismissed by the user, and not obscured by a fullscreen window.
