### PR TITLE
Jit64: Fix incorrect PC in PPC state during fastmem trampoline

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -923,10 +923,6 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
           fprToFlush[js.revertFprLoad] = false;
         gpr.Flush(RegCache::FlushMode::MaintainState, gprToFlush);
         fpr.Flush(RegCache::FlushMode::MaintainState, fprToFlush);
-
-        // If a memory exception occurs, the exception handler will read
-        // from PC.  Update PC with the latest value in case that happens.
-        MOV(32, PPCSTATE(pc), Imm32(ops[i].address));
         WriteExceptionExit();
         SwitchToNearCode();
       }

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -376,6 +376,10 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
       exit = J(true);
     SetJumpTarget(slow);
   }
+
+  // Helps external systems know which instruction triggered the read.
+  MOV(32, PPCSTATE(pc), Imm32(g_jit->js.compilerPC));
+
   size_t rsp_alignment = (flags & SAFE_LOADSTORE_NO_PROLOG) ? 8 : 0;
   ABI_PushRegistersAndAdjustStack(registersInUse, rsp_alignment);
   switch (accessSize)
@@ -435,6 +439,9 @@ void EmuCodeBlock::SafeLoadToRegImmediate(X64Reg reg_value, u32 address, int acc
                   signExtend);
     return;
   }
+
+  // Helps external systems know which instruction triggered the read.
+  MOV(32, PPCSTATE(pc), Imm32(g_jit->js.compilerPC));
 
   // Fall back to general-case code.
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -70,6 +70,7 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
 
   js.generatingTrampoline = true;
   js.trampolineExceptionHandler = exceptionHandler;
+  js.compilerPC = info.pc;
 
   // Generate the trampoline.
   const u8* trampoline = trampolines.GenerateTrampoline(info);

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -63,9 +63,6 @@ const u8* TrampolineCache::GenerateWriteTrampoline(const TrampolineInfo& info)
   // Don't treat FIFO writes specially for now because they require a burst
   // check anyway.
 
-  // PC is used by memory watchpoints (if enabled) or to print accurate PC locations in debug logs
-  MOV(32, PPCSTATE(pc), Imm32(info.pc));
-
   SafeWriteRegToReg(info.op_arg, info.op_reg, info.accessSize << 3, info.offset,
                     info.registersInUse, info.flags | SAFE_LOADSTORE_FORCE_SLOWMEM);
 


### PR DESCRIPTION
This PR primarily fixes the issue with memory breakpoints showing an incorrect PC address. Associated bug: https://bugs.dolphin-emu.org/issues/10834

The code emitted slowmem references g_jit->js.compilerPC, which contains the address of the instruction currently being compiled. However, when generating trampolines, it was not being updated. This resulted in the PC being flushed in the trampoline to be the end of the last compiled JIT block, rather than the faulting instruction. Set js.compilerPC from the trampoline info instead, which contains the correct address.

The mov to PC is done in the memory access anyway, so I removed the explicit mov in the trampoline generator as it was redundant.

Also flushes PC on slowmem reads as well, which matches the behavior for writes, and should fix the address displayed for read watchpoints as well.