### PR TITLE
Update Android UI Settings to have the most common used settings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -14,9 +14,9 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.model.GameFile;
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.PicassoUtils;
-import org.dolphinemu.dolphinemu.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.viewholders.GameViewHolder;
 
 import java.io.File;
@@ -156,10 +156,10 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 				public void onClick(DialogInterface dialog, int which) {
 					switch (which) {
 						case 0:
-							SettingsActivity.launch(activity, SettingsFile.FILE_NAME_DOLPHIN, gameId);
+							SettingsActivity.launch(activity, MenuTag.CONFIG, gameId);
 							break;
 						case 1:
-							SettingsActivity.launch(activity, SettingsFile.FILE_NAME_GFX, gameId);
+							SettingsActivity.launch(activity, MenuTag.GRAPHICS, gameId);
 							break;
 						case 2:
 							String path = DirectoryInitializationService.getUserDirectory() + "/GameSettings/" + gameId + ".ini";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -17,9 +17,9 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.GameFile;
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.PicassoUtils;
-import org.dolphinemu.dolphinemu.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.viewholders.TvGameViewHolder;
 
 import java.io.File;
@@ -103,10 +103,10 @@ public final class GameRowPresenter extends Presenter
 						public void onClick(DialogInterface dialog, int which) {
 							switch (which) {
 								case 0:
-									SettingsActivity.launch(activity, SettingsFile.FILE_NAME_DOLPHIN, gameId);
+									SettingsActivity.launch(activity, MenuTag.CONFIG, gameId);
 									break;
 								case 1:
-									SettingsActivity.launch(activity, SettingsFile.FILE_NAME_GFX, gameId);
+									SettingsActivity.launch(activity, MenuTag.GRAPHICS, gameId);
 									break;
 								case 2:
 									String path = DirectoryInitializationService.getUserDirectory() + "/GameSettings/" + gameId + ".ini";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/IntSetting.java
@@ -1,13 +1,23 @@
 package org.dolphinemu.dolphinemu.model.settings;
 
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
+
 public final class IntSetting extends Setting
 {
 	private int mValue;
+	private MenuTag menuTag;
 
 	public IntSetting(String key, String section, int file, int value)
 	{
 		super(key, section, file);
 		mValue = value;
+	}
+
+	public IntSetting(String key, String section, int file, int value, MenuTag menuTag)
+	{
+		super(key, section, file);
+		mValue = value;
+		this.menuTag = menuTag;
 	}
 
 	public int getValue()
@@ -25,4 +35,10 @@ public final class IntSetting extends Setting
 	{
 		return Integer.toString(mValue);
 	}
+
+	public MenuTag getMenuTag()
+	{
+		return menuTag;
+	}
+
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SettingsItem.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SettingsItem.java
@@ -17,6 +17,7 @@ public abstract class SettingsItem
 	public static final int TYPE_SLIDER = 3;
 	public static final int TYPE_SUBMENU = 4;
 	public static final int TYPE_INPUT_BINDING = 5;
+	public static final int TYPE_STRING_SINGLE_CHOICE = 6;
 
 	private String mKey;
 	private String mSection;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SingleChoiceSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SingleChoiceSetting.java
@@ -2,6 +2,7 @@ package org.dolphinemu.dolphinemu.model.settings.view;
 
 import org.dolphinemu.dolphinemu.model.settings.IntSetting;
 import org.dolphinemu.dolphinemu.model.settings.Setting;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 
 public final class SingleChoiceSetting extends SettingsItem
 {
@@ -9,13 +10,20 @@ public final class SingleChoiceSetting extends SettingsItem
 
 	private int mChoicesId;
 	private int mValuesId;
+	private MenuTag menuTag;
 
-	public SingleChoiceSetting(String key, String section, int file, int titleId, int descriptionId, int choicesId, int valuesId, int defaultValue, Setting setting)
+	public SingleChoiceSetting(String key, String section, int file, int titleId, int descriptionId, int choicesId, int valuesId, int defaultValue, Setting setting, MenuTag menuTag)
 	{
 		super(key, section, file, setting, titleId, descriptionId);
 		mValuesId = valuesId;
 		mChoicesId = choicesId;
 		mDefaultValue = defaultValue;
+		this.menuTag = menuTag;
+	}
+
+	public SingleChoiceSetting(String key, String section, int file, int titleId, int descriptionId, int choicesId, int valuesId, int defaultValue, Setting setting)
+	{
+		this(key, section, file, titleId, descriptionId, choicesId, valuesId, defaultValue, setting, null);
 	}
 
 	public int getChoicesId()
@@ -39,6 +47,11 @@ public final class SingleChoiceSetting extends SettingsItem
 		{
 			return mDefaultValue;
 		}
+	}
+
+	public MenuTag getMenuTag()
+	{
+		return menuTag;
 	}
 
 	/**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SliderSetting.java
@@ -43,7 +43,8 @@ public final class SliderSetting extends SettingsItem
 		else if (setting instanceof FloatSetting)
 		{
 			FloatSetting floatSetting = (FloatSetting) setting;
-			if (floatSetting.getKey().equals(SettingsFile.KEY_OVERCLOCK_PERCENT))
+			if (floatSetting.getKey().equals(SettingsFile.KEY_OVERCLOCK_PERCENT)
+					|| floatSetting.getKey().equals(SettingsFile.KEY_SPEED_LIMIT))
 			{
 				return Math.round(floatSetting.getValue() * 100);
 			}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/StringSingleChoiceSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/StringSingleChoiceSetting.java
@@ -1,0 +1,97 @@
+package org.dolphinemu.dolphinemu.model.settings.view;
+
+import org.dolphinemu.dolphinemu.model.settings.Setting;
+import org.dolphinemu.dolphinemu.model.settings.StringSetting;
+
+public class StringSingleChoiceSetting extends SettingsItem
+{
+    private String mDefaultValue;
+
+    private String[] mChoicesId;
+    private String[] mValuesId;
+
+    public StringSingleChoiceSetting(String key, String section, int file, int titleId, int descriptionId, String[] choicesId, String[] valuesId, String defaultValue, Setting setting)
+    {
+        super(key, section, file, setting, titleId, descriptionId);
+        mValuesId = valuesId;
+        mChoicesId = choicesId;
+        mDefaultValue = defaultValue;
+    }
+
+    public String[] getChoicesId()
+    {
+        return mChoicesId;
+    }
+
+    public String[] getValuesId()
+    {
+        return mValuesId;
+    }
+
+    public String getValueAt(int index)
+    {
+        if (mValuesId == null)
+            return null;
+
+        if (index >= 0 && index < mValuesId.length)
+        {
+            return mValuesId[index];
+        }
+
+        return "";
+    }
+
+    public String getSelectedValue()
+    {
+        if (getSetting() != null)
+        {
+            StringSetting setting = (StringSetting) getSetting();
+            return setting.getValue();
+        }
+        else
+        {
+            return mDefaultValue;
+        }
+    }
+
+    public int getSelectValueIndex() {
+        String selectedValue = getSelectedValue();
+        for(int i=0;i<mValuesId.length;i++) {
+            if(mValuesId[i].equals(selectedValue)) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+    /**
+     * Write a value to the backing int. If that int was previously null,
+     * initializes a new one and returns it, so it can be added to the Hashmap.
+     *
+     * @param selection New value of the int.
+     * @return null if overwritten successfully otherwise; a newly created IntSetting.
+     */
+    public StringSetting setSelectedValue(String selection)
+    {
+        if (getSetting() == null)
+        {
+            StringSetting setting = new StringSetting(getKey(), getSection(), getFile(), selection);
+            setSetting(setting);
+            return setting;
+        }
+        else
+        {
+            StringSetting setting = (StringSetting) getSetting();
+            setting.setValue(selection);
+            return null;
+        }
+    }
+
+    @Override
+    public int getType()
+    {
+        return TYPE_STRING_SINGLE_CHOICE;
+    }
+}
+
+

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SubmenuSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SubmenuSetting.java
@@ -1,18 +1,19 @@
 package org.dolphinemu.dolphinemu.model.settings.view;
 
 import org.dolphinemu.dolphinemu.model.settings.Setting;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 
 public final class SubmenuSetting extends SettingsItem
 {
-	private String mMenuKey;
+	private MenuTag mMenuKey;
 
-	public SubmenuSetting(String key, Setting setting, int titleId, int descriptionId, String menuKey)
+	public SubmenuSetting(String key, Setting setting, int titleId, int descriptionId, MenuTag menuKey)
 	{
 		super(key, null, 0, setting, titleId, descriptionId);
 		mMenuKey = menuKey;
 	}
 
-	public String getMenuKey()
+	public MenuTag getMenuKey()
 	{
 		return mMenuKey;
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/DirectoryInitializationService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/DirectoryInitializationService.java
@@ -37,6 +37,7 @@ public final class DirectoryInitializationService extends IntentService
     public static final String EXTRA_STATE = "directoryState";
     private static volatile DirectoryInitializationState directoryState = null;
     private static String userPath;
+    private static String internalPath;
     private static AtomicBoolean isDolphinDirectoryInitializationRunning = new AtomicBoolean(false);
 
     public enum DirectoryInitializationState
@@ -110,6 +111,7 @@ public final class DirectoryInitializationService extends IntentService
     private void initializeInternalStorage()
     {
         File sysDirectory = new File(getFilesDir(), "Sys");
+        internalPath = sysDirectory.getAbsolutePath();
 
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
         String revision = NativeLibrary.GetGitRevision();
@@ -174,6 +176,20 @@ public final class DirectoryInitializationService extends IntentService
             throw new IllegalStateException("DirectoryInitializationService has to finish running first!");
         }
         return userPath;
+
+    }
+
+    public static String getDolphinInternalDirectory()
+    {
+        if (directoryState == null)
+        {
+            throw new IllegalStateException("DirectoryInitializationService has to run at least once!");
+        }
+        else if (isDolphinDirectoryInitializationRunning.get())
+        {
+            throw new IllegalStateException("DirectoryInitializationService has to finish running first!");
+        }
+        return internalPath;
 
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -21,6 +21,7 @@ import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesView;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
@@ -129,7 +130,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
 	}
 
 	@Override
-	public void launchSettingsActivity(String menuTag)
+	public void launchSettingsActivity(MenuTag menuTag)
 	{
 		SettingsActivity.launch(this, menuTag, "");
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -10,7 +10,7 @@ import org.dolphinemu.dolphinemu.BuildConfig;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.GameFileCache;
 import org.dolphinemu.dolphinemu.services.GameFileCacheService;
-import org.dolphinemu.dolphinemu.utils.SettingsFile;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 
 public final class MainPresenter
 {
@@ -64,19 +64,19 @@ public final class MainPresenter
 		switch (itemId)
 		{
 			case R.id.menu_settings_core:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_DOLPHIN);
+				mView.launchSettingsActivity(MenuTag.CONFIG);
 				return true;
 
 			case R.id.menu_settings_video:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_GFX);
+				mView.launchSettingsActivity(MenuTag.GRAPHICS);
 				return true;
 
 			case R.id.menu_settings_gcpad:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_GCPAD);
+				mView.launchSettingsActivity(MenuTag.GCPAD_TYPE);
 				return true;
 
 			case R.id.menu_settings_wiimote:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_WIIMOTE);
+				mView.launchSettingsActivity(MenuTag.WIIMOTE);
 				return true;
 
 			case R.id.menu_refresh:

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -67,7 +67,7 @@ public final class MainPresenter
 				mView.launchSettingsActivity(MenuTag.CONFIG);
 				return true;
 
-			case R.id.menu_settings_video:
+			case R.id.menu_settings_graphics:
 				mView.launchSettingsActivity(MenuTag.GRAPHICS);
 				return true;
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
@@ -1,9 +1,6 @@
 package org.dolphinemu.dolphinemu.ui.main;
 
-import android.database.Cursor;
-
-import org.dolphinemu.dolphinemu.model.GameFile;
-import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 
 /**
  * Abstraction for the screen that shows on application launch.
@@ -29,7 +26,7 @@ public interface MainView
 	void refreshFragmentScreenshot(int fragmentPosition);
 
 
-	void launchSettingsActivity(String menuTag);
+	void launchSettingsActivity(MenuTag menuTag);
 
 	void launchFileListActivity();
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -23,6 +23,7 @@ import org.dolphinemu.dolphinemu.model.TvSettingsItem;
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
@@ -119,7 +120,7 @@ public final class TvMainActivity extends FragmentActivity implements MainView
 	}
 
 	@Override
-	public void launchSettingsActivity(String menuTag)
+	public void launchSettingsActivity(MenuTag menuTag)
 	{
 		SettingsActivity.launch(this, menuTag, "");
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -231,11 +231,11 @@ public final class TvMainActivity extends FragmentActivity implements MainView
 
 		rowItems.add(new TvSettingsItem(R.id.menu_settings_core,
 				R.drawable.ic_settings_core_tv,
-				R.string.grid_menu_core_settings));
+				R.string.grid_menu_config));
 
-		rowItems.add(new TvSettingsItem(R.id.menu_settings_video,
+		rowItems.add(new TvSettingsItem(R.id.menu_settings_graphics,
 				R.drawable.ic_settings_graphics_tv,
-				R.string.grid_menu_video_settings));
+				R.string.grid_menu_graphics_settings));
 
 		rowItems.add(new TvSettingsItem(R.id.menu_settings_gcpad,
 				R.drawable.ic_settings_gcpad,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
@@ -1,0 +1,104 @@
+package org.dolphinemu.dolphinemu.ui.settings;
+
+public enum MenuTag
+{
+    CONFIG("config"),
+    CONFIG_GENERAL("config_general"),
+    CONFIG_INTERFACE("config_interface"),
+    WIIMOTE("wiimote"),
+    WIIMOTE_EXTENSION("wiimote_extension"),
+    GCPAD_TYPE("gc_pad_type"),
+    GRAPHICS("graphics"),
+    HACKS("hacks"),
+    ENHANCEMENTS("enhancements"),
+    STEREOSCOPY("stereoscopy"),
+    GCPAD_1("gcpad", 0),
+    GCPAD_2("gcpad", 1),
+    GCPAD_3("gcpad", 2),
+    GCPAD_4("gcpad", 3),
+    WIIMOTE_1("wiimote", 1),
+    WIIMOTE_2("wiimote", 2),
+    WIIMOTE_3("wiimote", 3),
+    WIIMOTE_4("wiimote", 4),
+    WIIMOTE_EXTENSION_1("wiimote_extension", 1),
+    WIIMOTE_EXTENSION_2("wiimote_extension", 2),
+    WIIMOTE_EXTENSION_3("wiimote_extension", 3),
+    WIIMOTE_EXTENSION_4("wiimote_extension", 4);
+
+    private String tag;
+    private int subType = -1;
+
+    MenuTag(String tag)
+    {
+        this.tag = tag;
+    }
+
+    MenuTag(String tag, int subtype)
+    {
+        this.tag = tag;
+        this.subType = subtype;
+    }
+
+    @Override
+    public String toString()
+    {
+        if (subType != -1)
+        {
+            return tag + subType;
+        }
+
+        return tag;
+    }
+
+    public String getTag()
+    {
+        return tag;
+    }
+
+    public int getSubType()
+    {
+        return subType;
+    }
+
+    public boolean isGCPadMenu()
+    {
+        return this == GCPAD_1 || this == GCPAD_2 || this == GCPAD_3 || this == GCPAD_4;
+    }
+
+    public boolean isWiimoteMenu()
+    {
+        return this == WIIMOTE_1 || this == WIIMOTE_2 || this == WIIMOTE_3 || this == WIIMOTE_4;
+    }
+
+    public boolean isWiimoteExtensionMenu()
+    {
+        return this == WIIMOTE_EXTENSION_1 || this == WIIMOTE_EXTENSION_2
+                || this == WIIMOTE_EXTENSION_3 || this == WIIMOTE_EXTENSION_4;
+    }
+
+    public static MenuTag getGCPadMenuTag(int subtype)
+    {
+        return getMenuTag("gcpad", subtype);
+    }
+
+    public static MenuTag getWiimoteMenuTag(int subtype)
+    {
+        return getMenuTag("wiimote", subtype);
+    }
+
+    public static MenuTag getWiimoteExtensionMenuTag(int subtype)
+    {
+        return getMenuTag("wiimote_extension", subtype);
+    }
+
+    private static MenuTag getMenuTag(String tag, int subtype)
+    {
+        for (MenuTag menuTag : MenuTag.values())
+        {
+            if (menuTag.tag.equals(tag) && menuTag.subType == subtype) return menuTag;
+        }
+
+        throw new IllegalArgumentException("You are asking for a menu that is not available or " +
+                "passing a wrong subtype");
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
@@ -5,6 +5,8 @@ public enum MenuTag
     CONFIG("config"),
     CONFIG_GENERAL("config_general"),
     CONFIG_INTERFACE("config_interface"),
+    CONFIG_GAME_CUBE("config_gamecube"),
+    CONFIG_WII("config_wii"),
     WIIMOTE("wiimote"),
     WIIMOTE_EXTENSION("wiimote_extension"),
     GCPAD_TYPE("gc_pad_type"),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
@@ -25,20 +25,18 @@ import java.util.HashMap;
 
 public final class SettingsActivity extends AppCompatActivity implements SettingsActivityView
 {
-	private static final String ARG_FILE_NAME = "file_name";
+	private static final String ARG_MENU_TAG = "menu_tag";
 	private static final String ARG_GAME_ID = "game_id";
-
 	private static final String FRAGMENT_TAG = "settings";
 	private SettingsActivityPresenter mPresenter = new SettingsActivityPresenter(this);
 
 	private ProgressDialog dialog;
 
-	public static void launch(Context context, String menuTag, String gameId)
+	public static void launch(Context context, MenuTag menuTag, String gameId)
 	{
 		Intent settings = new Intent(context, SettingsActivity.class);
-		settings.putExtra(ARG_FILE_NAME, menuTag);
+		settings.putExtra(ARG_MENU_TAG, menuTag);
 		settings.putExtra(ARG_GAME_ID, gameId);
-
 		context.startActivity(settings);
 	}
 
@@ -50,10 +48,9 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 		setContentView(R.layout.activity_settings);
 
 		Intent launcher = getIntent();
-		String filename = launcher.getStringExtra(ARG_FILE_NAME);
 		String gameID = launcher.getStringExtra(ARG_GAME_ID);
-
-		mPresenter.onCreate(savedInstanceState, filename, gameID);
+        MenuTag menuTag = (MenuTag) launcher.getSerializableExtra(ARG_MENU_TAG);
+		mPresenter.onCreate(savedInstanceState, menuTag, gameID);
 	}
 
 	@Override
@@ -107,7 +104,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
 
 	@Override
-	public void showSettingsFragment(String menuTag, boolean addToStack, String gameID)
+	public void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack, String gameID)
 	{
 		FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
@@ -125,7 +122,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 			transaction.addToBackStack(null);
 			mPresenter.addToStack();
 		}
-		transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag, gameID), FRAGMENT_TAG);
+		transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag, gameID, extras), FRAGMENT_TAG);
 
 		transaction.commit();
 	}
@@ -242,21 +239,21 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 	}
 
 	@Override
-	public void onGcPadSettingChanged(String key, int value)
+	public void onGcPadSettingChanged(MenuTag key, int value)
 	{
 		mPresenter.onGcPadSettingChanged(key, value);
 	}
 
 	@Override
-	public void onWiimoteSettingChanged(String section, int value)
+	public void onWiimoteSettingChanged(MenuTag section, int value)
 	{
 		mPresenter.onWiimoteSettingChanged(section, value);
 	}
 
 	@Override
-	public void onExtensionSettingChanged(String key, int value)
+	public void onExtensionSettingChanged(MenuTag menuTag, int value)
 	{
-		mPresenter.onExtensionSettingChanged(key, value);
+		mPresenter.onExtensionSettingChanged(menuTag, value);
 	}
 
 	private SettingsFragment getFragment()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityPresenter.java
@@ -31,7 +31,7 @@ public final class SettingsActivityPresenter
 
 	private DirectoryStateReceiver directoryStateReceiver;
 
-	private String menuTag;
+	private MenuTag menuTag;
 	private String gameId;
 
 	public SettingsActivityPresenter(SettingsActivityView view)
@@ -39,7 +39,7 @@ public final class SettingsActivityPresenter
 		mView = view;
 	}
 
-	public void onCreate(Bundle savedInstanceState, String menuTag, String gameId)
+	public void onCreate(Bundle savedInstanceState, MenuTag menuTag, String gameId)
 	{
 		if (savedInstanceState == null)
 		{
@@ -75,7 +75,7 @@ public final class SettingsActivityPresenter
 			}
 		}
 
-		mView.showSettingsFragment(menuTag, false, gameId);
+		mView.showSettingsFragment(menuTag, null, false, gameId);
 		mView.onSettingsFileLoaded(mSettings);
 	}
 
@@ -135,11 +135,11 @@ public final class SettingsActivityPresenter
 				if (!TextUtils.isEmpty(gameId)) {
 					Log.debug("[SettingsActivity] Settings activity stopping. Saving settings to INI...");
 					// Needed workaround for now due to an odd bug in how it handles saving two different settings sections to the same file. It won't save GFX settings if it follows the normal saving pattern
-					if (menuTag.equals("Dolphin"))
+					if (menuTag.equals(MenuTag.CONFIG))
 					{
 						SettingsFile.saveFile("../GameSettings/" + gameId, mSettings.get(SettingsFile.SETTINGS_DOLPHIN), mView);
 					}
-					else if (menuTag.equals("GFX"))
+					else if (menuTag.equals(MenuTag.GRAPHICS))
 					{
 						SettingsFile.saveFile("../GameSettings/" + gameId, mSettings.get(SettingsFile.SETTINGS_GFX), mView);
 					}
@@ -194,20 +194,22 @@ public final class SettingsActivityPresenter
 		outState.putBoolean(KEY_SHOULD_SAVE, mShouldSave);
 	}
 
-	public void onGcPadSettingChanged(String key, int value)
+	public void onGcPadSettingChanged(MenuTag key, int value)
 	{
 		if (value != 0) // Not disabled
 		{
-			mView.showSettingsFragment(key + (value / 6), true, gameId);
+			Bundle bundle = new Bundle();
+			bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value/6);
+			mView.showSettingsFragment(key, bundle, true, gameId);
 		}
 	}
 
-	public void onWiimoteSettingChanged(String section, int value)
+	public void onWiimoteSettingChanged(MenuTag menuTag, int value)
 	{
 		switch (value)
 		{
 			case 1:
-				mView.showSettingsFragment(section, true, gameId);
+				mView.showSettingsFragment(menuTag, null, true, gameId);
 				break;
 
 			case 2:
@@ -216,11 +218,13 @@ public final class SettingsActivityPresenter
 		}
 	}
 
-	public void onExtensionSettingChanged(String key, int value)
+	public void onExtensionSettingChanged(MenuTag menuTag, int value)
 	{
 		if (value != 0) // None
 		{
-			mView.showSettingsFragment(key + value, true, gameId);
+			Bundle bundle = new Bundle();
+			bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
+			mView.showSettingsFragment(menuTag, bundle, true, gameId);
 		}
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
@@ -1,6 +1,7 @@
 package org.dolphinemu.dolphinemu.ui.settings;
 
 import android.content.IntentFilter;
+import android.os.Bundle;
 
 import org.dolphinemu.dolphinemu.model.settings.SettingSection;
 import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
@@ -19,7 +20,7 @@ public interface SettingsActivityView
 	 * @param menuTag    Identifier for the settings group that should be displayed.
 	 * @param addToStack Whether or not this fragment should replace a previous one.
 	 */
-	void showSettingsFragment(String menuTag, boolean addToStack, String gameId);
+	void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack, String gameId);
 
 	/**
 	 * Called by a contained Fragment to get access to the Setting HashMap
@@ -79,29 +80,28 @@ public interface SettingsActivityView
 	 * Called by a containing Fragment to tell the containing Activity that a GCPad's setting
 	 * was modified.
 	 *
-	 * @param key   Identifier for the GCPad that was modified.
+	 * @param menuTag   Identifier for the GCPad that was modified.
 	 * @param value New setting for the GCPad.
 	 */
-	void onGcPadSettingChanged(String key, int value);
+	void onGcPadSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Called by a containing Fragment to tell the containing Activity that a Wiimote's setting
 	 * was modified.
 	 *
-	 * @param section Identifier for Wiimote that was modified; Wiimotes are identified by their section,
-	 *                not their key.
+	 * @param menuTag Identifier for Wiimote that was modified.
 	 * @param value   New setting for the Wiimote.
 	 */
-	void onWiimoteSettingChanged(String section, int value);
+	void onWiimoteSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Called by a containing Fragment to tell the containing Activity that an extension setting
 	 * was modified.
 	 *
-	 * @param key   Identifier for the extension that was modified.
+	 * @param menuTag   Identifier for the extension that was modified.
 	 * @param value New setting for the extension.
 	 */
-	void onExtensionSettingChanged(String key, int value);
+	void onExtensionSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Show loading dialog while loading the settings

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
@@ -307,7 +307,8 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 			{
 				float value;
 
-				if (sliderSetting.getKey().equals(SettingsFile.KEY_OVERCLOCK_PERCENT))
+				if (sliderSetting.getKey().equals(SettingsFile.KEY_OVERCLOCK_PERCENT)
+						|| sliderSetting.getKey().equals(SettingsFile.KEY_SPEED_LIMIT))
 				{
 					value = mSeekbarProgress / 100.0f;
 				}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
@@ -186,6 +186,7 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 
 		seekbar.setMax(item.getMax());
 		seekbar.setProgress(mSeekbarProgress);
+		seekbar.setKeyProgressIncrement(5);
 
 		seekbar.setOnSeekBarChangeListener(this);
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
@@ -234,20 +234,23 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 			SingleChoiceSetting scSetting = (SingleChoiceSetting) mClickedItem;
 
 			int value = getValueForSingleChoiceSelection(scSetting, which);
-
-			if (scSetting.getKey().startsWith(SettingsFile.KEY_GCPAD_TYPE))
+			MenuTag menuTag = scSetting.getMenuTag();
+			if(menuTag != null)
 			{
-				mView.onGcPadSettingChanged(scSetting.getKey(), value);
-			}
+				if (menuTag.isGCPadMenu())
+				{
+					mView.onGcPadSettingChanged(menuTag, value);
+				}
 
-			if (scSetting.getKey().equals(SettingsFile.KEY_WIIMOTE_TYPE))
-			{
-				mView.onWiimoteSettingChanged(scSetting.getSection(), value);
-			}
+				if (menuTag.isWiimoteMenu())
+				{
+					mView.onWiimoteSettingChanged(menuTag, value);
+				}
 
-			if (scSetting.getKey().equals(SettingsFile.KEY_WIIMOTE_EXTENSION))
-			{
-				mView.onExtensionSettingChanged(scSetting.getKey() + Character.getNumericValue(scSetting.getSection().charAt(scSetting.getSection().length() - 1)), value);
+				if (menuTag.isWiimoteExtensionMenu())
+				{
+					mView.onExtensionSettingChanged(menuTag, value);
+				}
 			}
 
 			// Get the backing Setting, which may be null (if for example it was missing from the file)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
@@ -23,6 +23,7 @@ import org.dolphinemu.dolphinemu.model.settings.view.InputBindingSetting;
 import org.dolphinemu.dolphinemu.model.settings.view.SettingsItem;
 import org.dolphinemu.dolphinemu.model.settings.view.SingleChoiceSetting;
 import org.dolphinemu.dolphinemu.model.settings.view.SliderSetting;
+import org.dolphinemu.dolphinemu.model.settings.view.StringSingleChoiceSetting;
 import org.dolphinemu.dolphinemu.model.settings.view.SubmenuSetting;
 import org.dolphinemu.dolphinemu.ui.settings.viewholder.CheckBoxSettingViewHolder;
 import org.dolphinemu.dolphinemu.ui.settings.viewholder.HeaderViewHolder;
@@ -71,6 +72,7 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 				view = inflater.inflate(R.layout.list_item_setting_checkbox, parent, false);
 				return new CheckBoxSettingViewHolder(view, this);
 
+			case SettingsItem.TYPE_STRING_SINGLE_CHOICE:
 			case SettingsItem.TYPE_SINGLE_CHOICE:
 				view = inflater.inflate(R.layout.list_item_setting, parent, false);
 				return new SingleChoiceViewHolder(view, this);
@@ -157,6 +159,18 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 
 		builder.setTitle(item.getNameId());
 		builder.setSingleChoiceItems(item.getChoicesId(), value, this);
+
+		mDialog = builder.show();
+	}
+
+	public void onStringSingleChoiceClick(StringSingleChoiceSetting item)
+	{
+		mClickedItem = item;
+
+		AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity());
+
+		builder.setTitle(item.getNameId());
+		builder.setSingleChoiceItems(item.getChoicesId(), item.getSelectValueIndex(), this);
 
 		mDialog = builder.show();
 	}
@@ -270,6 +284,18 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 				{
 					putExtensionSetting(which, Character.getNumericValue(scSetting.getSection().charAt(scSetting.getSection().length() - 1)));
 				}
+			}
+
+			closeDialog();
+		}
+		else if (mClickedItem instanceof StringSingleChoiceSetting)
+		{
+			StringSingleChoiceSetting scSetting = (StringSingleChoiceSetting) mClickedItem;
+			String value = scSetting.getValueAt(which);
+			StringSetting setting = scSetting.setSelectedValue(value);
+			if (setting != null)
+			{
+				mView.putSetting(setting);
 			}
 
 			closeDialog();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragment.java
@@ -31,12 +31,17 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 
 	private SettingsAdapter mAdapter;
 
-	public static Fragment newInstance(String menuTag, String gameId)
+	public static Fragment newInstance(MenuTag menuTag, String gameId, Bundle extras)
 	{
 		SettingsFragment fragment = new SettingsFragment();
 
 		Bundle arguments = new Bundle();
-		arguments.putString(ARGUMENT_MENU_TAG, menuTag);
+		if(extras != null)
+		{
+			arguments.putAll(extras);
+		}
+
+		arguments.putSerializable(ARGUMENT_MENU_TAG, menuTag);
 		arguments.putString(ARGUMENT_GAME_ID, gameId);
 
 		fragment.setArguments(arguments);
@@ -72,12 +77,13 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 		super.onCreate(savedInstanceState);
 
 		setRetainInstance(true);
-		String menuTag = getArguments().getString(ARGUMENT_MENU_TAG);
+		Bundle args = getArguments();
+		MenuTag menuTag = (MenuTag) args.getSerializable(ARGUMENT_MENU_TAG);
 		String gameId = getArguments().getString(ARGUMENT_GAME_ID);
 
 		mAdapter = new SettingsAdapter(this, getActivity());
 
-		mPresenter.onCreate(menuTag, gameId);
+		mPresenter.onCreate(menuTag, gameId, args);
 	}
 
 	@Nullable
@@ -148,9 +154,9 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 	}
 
 	@Override
-	public void loadSubMenu(String menuKey)
+	public void loadSubMenu(MenuTag menuKey)
 	{
-		mActivity.showSettingsFragment(menuKey, true, getArguments().getString(ARGUMENT_GAME_ID));
+		mActivity.showSettingsFragment(menuKey, null, true, getArguments().getString(ARGUMENT_GAME_ID));
 	}
 
 	@Override
@@ -172,21 +178,21 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 	}
 
 	@Override
-	public void onGcPadSettingChanged(String key, int value)
+	public void onGcPadSettingChanged(MenuTag menuTag, int value)
 	{
-		mActivity.onGcPadSettingChanged(key, value);
+		mActivity.onGcPadSettingChanged(menuTag, value);
 	}
 
 	@Override
-	public void onWiimoteSettingChanged(String section, int value)
+	public void onWiimoteSettingChanged(MenuTag menuTag, int value)
 	{
-		mActivity.onWiimoteSettingChanged(section, value);
+		mActivity.onWiimoteSettingChanged(menuTag, value);
 	}
 
 	@Override
-	public void onExtensionSettingChanged(String key, int value)
+	public void onExtensionSettingChanged(MenuTag menuTag, int value)
 	{
-		mActivity.onExtensionSettingChanged(key, value);
+		mActivity.onExtensionSettingChanged(menuTag, value);
 	}
 
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -2,6 +2,8 @@ package org.dolphinemu.dolphinemu.ui.settings;
 
 import android.text.TextUtils;
 
+import android.os.Bundle;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.settings.BooleanSetting;
@@ -26,7 +28,8 @@ public final class SettingsFragmentPresenter
 {
 	private SettingsFragmentView mView;
 
-	private String mMenuTag;
+	public static final String ARG_CONTROLLER_TYPE = "controller_type";
+	private MenuTag mMenuTag;
 	private String mGameID;
 
 	private ArrayList<HashMap<String, SettingSection>> mSettings;
@@ -40,31 +43,24 @@ public final class SettingsFragmentPresenter
 		mView = view;
 	}
 
-	public void onCreate(String menuTag, String gameId)
+	public void onCreate(MenuTag menuTag, String gameId, Bundle extras)
 	{
 		mGameID = gameId;
 
-		if (menuTag.startsWith(SettingsFile.KEY_GCPAD_TYPE))
-		{
-			mMenuTag = SettingsFile.KEY_GCPAD_TYPE;
-			mControllerNumber = Character.getNumericValue(menuTag.charAt(menuTag.length() - 2));
-			mControllerType = Character.getNumericValue(menuTag.charAt(menuTag.length() - 1));
-		}
-		else if (menuTag.startsWith(SettingsFile.SECTION_WIIMOTE) && !menuTag.equals(SettingsFile.FILE_NAME_WIIMOTE))
-		{
-			mMenuTag = SettingsFile.SECTION_WIIMOTE;
-			mControllerNumber = Character.getNumericValue(menuTag.charAt(menuTag.length() - 1)) + 3;
-		}
-		else if (menuTag.startsWith(SettingsFile.KEY_WIIMOTE_EXTENSION))
-		{
-			mMenuTag = SettingsFile.KEY_WIIMOTE_EXTENSION;
-			mControllerNumber = Character.getNumericValue(menuTag.charAt(menuTag.length() - 2)) + 3;
-			mControllerType = Character.getNumericValue(menuTag.charAt(menuTag.length() - 1));
-		}
-		else
-		{
-			mMenuTag = menuTag;
-		}
+        this.mMenuTag = menuTag;
+        if (menuTag.isGCPadMenu() || menuTag.isWiimoteExtensionMenu())
+        {
+            mControllerNumber = menuTag.getSubType();
+            mControllerType = extras.getInt(ARG_CONTROLLER_TYPE);
+        }
+        else if (menuTag.isWiimoteMenu())
+        {
+            mControllerNumber = menuTag.getSubType();
+        }
+        else
+        {
+            mMenuTag = menuTag;
+        }
 	}
 
 	public void onViewCreated(ArrayList<HashMap<String, SettingSection>> settings)
@@ -119,51 +115,60 @@ public final class SettingsFragmentPresenter
 
 		switch (mMenuTag)
 		{
-			case SettingsFile.FILE_NAME_DOLPHIN:
+			case CONFIG:
 				addConfigSettings(sl);
 				break;
 
-			case SettingsFile.SECTION_CONFIG_GENERAL:
+			case CONFIG_GENERAL:
 				addGeneralSettings(sl);
 				break;
 
-			case SettingsFile.SECTION_CONFIG_INTERFACE:
+			case CONFIG_INTERFACE:
 				addInterfaceSettings(sl);
 				break;
 
-			case SettingsFile.FILE_NAME_GFX:
+			case GRAPHICS:
 				addGraphicsSettings(sl);
 				break;
 
-			case SettingsFile.FILE_NAME_GCPAD:
+			case GCPAD_TYPE:
 				addGcPadSettings(sl);
 				break;
 
-			case SettingsFile.FILE_NAME_WIIMOTE:
+			case WIIMOTE:
 				addWiimoteSettings(sl);
 				break;
 
-			case SettingsFile.SECTION_GFX_ENHANCEMENTS:
+			case ENHANCEMENTS:
 				addEnhanceSettings(sl);
 				break;
 
-			case SettingsFile.SECTION_GFX_HACKS:
+			case HACKS:
 				addHackSettings(sl);
 				break;
 
-			case SettingsFile.KEY_GCPAD_TYPE:
+			case GCPAD_1:
+			case GCPAD_2:
+			case GCPAD_3:
+			case GCPAD_4:
 				addGcPadSubSettings(sl, mControllerNumber, mControllerType);
 				break;
 
-			case SettingsFile.SECTION_WIIMOTE:
+			case WIIMOTE_1:
+			case WIIMOTE_2:
+			case WIIMOTE_3:
+			case WIIMOTE_4:
 				addWiimoteSubSettings(sl, mControllerNumber);
 				break;
 
-			case SettingsFile.KEY_WIIMOTE_EXTENSION:
+			case WIIMOTE_EXTENSION_1:
+			case WIIMOTE_EXTENSION_2:
+			case WIIMOTE_EXTENSION_3:
+			case WIIMOTE_EXTENSION_4:
 				addExtensionTypeSettings(sl, mControllerNumber, mControllerType);
 				break;
 
-			case SettingsFile.SECTION_STEREOSCOPY:
+			case STEREOSCOPY:
 				addStereoSettings(sl);
 				break;
 
@@ -178,8 +183,8 @@ public final class SettingsFragmentPresenter
 
 	private void addConfigSettings(ArrayList<SettingsItem> sl)
 	{
-		sl.add(new SubmenuSetting(null, null, R.string.general_submenu, 0, SettingsFile.SECTION_CONFIG_GENERAL));
-		sl.add(new SubmenuSetting(null, null, R.string.interface_submenu, 0, SettingsFile.SECTION_CONFIG_INTERFACE));
+		sl.add(new SubmenuSetting(null, null, R.string.general_submenu, 0, MenuTag.CONFIG_GENERAL));
+		sl.add(new SubmenuSetting(null, null, R.string.interface_submenu, 0, MenuTag.CONFIG_INTERFACE));
 	}
 
 	private void addGeneralSettings(ArrayList<SettingsItem> sl)
@@ -265,7 +270,7 @@ public final class SettingsFragmentPresenter
 			{
 				// TODO This controller_0 + i business is quite the hack. It should work, but only if the definitions are kept together and in order.
 				Setting gcPadSetting = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_GCPAD_TYPE + i);
-				sl.add(new SingleChoiceSetting(SettingsFile.KEY_GCPAD_TYPE + i, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.controller_0 + i, 0, R.array.gcpadTypeEntries, R.array.gcpadTypeValues, 0, gcPadSetting));
+				sl.add(new SingleChoiceSetting(SettingsFile.KEY_GCPAD_TYPE + i, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.controller_0 + i, 0, R.array.gcpadTypeEntries, R.array.gcpadTypeValues, 0, gcPadSetting, MenuTag.getGCPadMenuTag(i)));
 			}
 		}
 	}
@@ -278,7 +283,7 @@ public final class SettingsFragmentPresenter
 			{
 				// TODO This wiimote_0 + i business is quite the hack. It should work, but only if the definitions are kept together and in order.
 				Setting wiimoteSetting = mSettings.get(SettingsFile.SETTINGS_WIIMOTE).get(SettingsFile.SECTION_WIIMOTE + i).getSetting(SettingsFile.KEY_WIIMOTE_TYPE);
-				sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_TYPE, SettingsFile.SECTION_WIIMOTE + i, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_0 + i - 1, 0, R.array.wiimoteTypeEntries, R.array.wiimoteTypeValues, 0, wiimoteSetting));
+				sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_TYPE, SettingsFile.SECTION_WIIMOTE + i, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_0 + i - 1, 0, R.array.wiimoteTypeEntries, R.array.wiimoteTypeValues, 0, wiimoteSetting, MenuTag.getWiimoteMenuTag(i)));
 			}
 		}
 	}
@@ -310,8 +315,8 @@ public final class SettingsFragmentPresenter
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_SHOW_FPS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.show_fps, R.string.show_fps_description, false, showFps));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SHADER_COMPILATION_MODE, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.shader_compilation_mode, R.string.shader_compilation_mode_description, R.array.shaderCompilationModeEntries, R.array.shaderCompilationModeValues, 0, shaderCompilationMode));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_WAIT_FOR_SHADERS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.wait_for_shaders, 0, false, waitForShaders));
-		sl.add(new SubmenuSetting(null, null, R.string.enhancements_submenu, 0, SettingsFile.SECTION_GFX_ENHANCEMENTS));
-		sl.add(new SubmenuSetting(null, null, R.string.hacks_submenu, 0, SettingsFile.SECTION_GFX_HACKS));
+		sl.add(new SubmenuSetting(null, null, R.string.enhancements_submenu, 0, MenuTag.ENHANCEMENTS));
+		sl.add(new SubmenuSetting(null, null, R.string.hacks_submenu, 0, MenuTag.HACKS));
 	}
 
 	private void addEnhanceSettings(ArrayList<SettingsItem> sl)
@@ -349,7 +354,7 @@ public final class SettingsFragmentPresenter
 		if ((helper.supportsOpenGL() && helper.GetVersion() >= 320) ||
 				(helper.supportsGLES3() && helper.GetVersion() >= 310 && helper.SupportsExtension("GL_ANDROID_extension_pack_es31a")))
 		{
-			sl.add(new SubmenuSetting(SettingsFile.KEY_STEREO_MODE, null, R.string.stereoscopy_submenu, R.string.stereoscopy_submenu_description, SettingsFile.SECTION_STEREOSCOPY));
+			sl.add(new SubmenuSetting(SettingsFile.KEY_STEREO_MODE, null, R.string.stereoscopy_submenu, R.string.stereoscopy_submenu_description, MenuTag.STEREOSCOPY));
 		}
 	}
 
@@ -467,7 +472,7 @@ public final class SettingsFragmentPresenter
 	private void addWiimoteSubSettings(ArrayList<SettingsItem> sl, int wiimoteNumber)
 	{
 		// Bindings use controller numbers 4-7 (0-3 are GameCube), but the extension setting uses 1-4.
-		IntSetting extension = new IntSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + (wiimoteNumber - 3), SettingsFile.SETTINGS_WIIMOTE, getExtensionValue(wiimoteNumber - 3));
+		IntSetting extension = new IntSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + wiimoteNumber, SettingsFile.SETTINGS_WIIMOTE, getExtensionValue(wiimoteNumber), MenuTag.getWiimoteExtensionMenuTag(wiimoteNumber));
 		Setting bindA = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_A + wiimoteNumber);
 		Setting bindB = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_B + wiimoteNumber);
 		Setting bind1 = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_1 + wiimoteNumber);
@@ -501,7 +506,7 @@ public final class SettingsFragmentPresenter
 		Setting bindDPadLeft = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_DPAD_LEFT + wiimoteNumber);
 		Setting bindDPadRight = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_DPAD_RIGHT + wiimoteNumber);
 
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + (wiimoteNumber - 3), SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_extensions, R.string.wiimote_extensions_description, R.array.wiimoteExtensionsEntries, R.array.wiimoteExtensionsValues, 0, extension));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + (wiimoteNumber - 3), SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_extensions, R.string.wiimote_extensions_description, R.array.wiimoteExtensionsEntries, R.array.wiimoteExtensionsValues, 0, extension, MenuTag.getWiimoteExtensionMenuTag(wiimoteNumber)));
 
 		sl.add(new HeaderSetting(null, null, R.string.generic_buttons, 0));
 		sl.add(new InputBindingSetting(SettingsFile.KEY_WIIBIND_A + wiimoteNumber, SettingsFile.SECTION_BINDINGS, SettingsFile.SETTINGS_DOLPHIN, R.string.button_a, bindA));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -335,6 +335,7 @@ public final class SettingsFragmentPresenter
 		Setting forceFilter = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_ENHANCEMENTS).getSetting(SettingsFile.KEY_FORCE_FILTERING);
 		Setting disableFog = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_FOG);
 		Setting disableCopyFilter = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_COPY_FILTER);
+        Setting force24BitColor = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_FORCE_24_BIT_COLOR);
 
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_INTERNAL_RES, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.internal_resolution, R.string.internal_resolution_description, R.array.internalResolutionEntries, R.array.internalResolutionValues, 1, resolution));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_FSAA, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.FSAA, R.string.FSAA_description, R.array.FSAAEntries, R.array.FSAAValues, 0, fsaa));
@@ -347,6 +348,7 @@ public final class SettingsFragmentPresenter
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_SCALED_EFB, SettingsFile.SECTION_GFX_HACKS, SettingsFile.SETTINGS_GFX, R.string.scaled_efb_copy, R.string.scaled_efb_copy_description, true, efbScaledCopy));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_PER_PIXEL, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.per_pixel_lighting, R.string.per_pixel_lighting_description, false, perPixel));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_FORCE_FILTERING, SettingsFile.SECTION_GFX_ENHANCEMENTS, SettingsFile.SETTINGS_GFX, R.string.force_texture_filtering, R.string.force_texture_filtering_description, false, forceFilter));
+        sl.add(new CheckBoxSetting(SettingsFile.KEY_FORCE_24_BIT_COLOR, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.force_24bit_color, R.string.force_24bit_color_description, true, force24BitColor));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DISABLE_FOG, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.disable_fog, R.string.disable_fog_description, false, disableFog));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DISABLE_COPY_FILTER, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.disable_copy_filter, R.string.disable_copy_filter_description, false, disableCopyFilter));
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -197,6 +197,7 @@ public final class SettingsFragmentPresenter
 		Setting dualCore = null;
 		Setting overclockEnable = null;
 		Setting overclock = null;
+		Setting speedLimit = null;
 		Setting slotADevice = null;
 		Setting slotBDevice = null;
 		Setting continuousScan = null;
@@ -209,6 +210,7 @@ public final class SettingsFragmentPresenter
 			dualCore = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_DUAL_CORE);
 			overclockEnable = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_OVERCLOCK_ENABLE);
 			overclock = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_OVERCLOCK_PERCENT);
+            speedLimit = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SPEED_LIMIT);
 			slotADevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_A_DEVICE);
 			slotBDevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_B_DEVICE);
 			continuousScan = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_WIIMOTE_SCAN);
@@ -245,6 +247,7 @@ public final class SettingsFragmentPresenter
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DUAL_CORE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.dual_core, R.string.dual_core_description, true, dualCore));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_OVERCLOCK_ENABLE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_enable, R.string.overclock_enable_description, false, overclockEnable));
 		sl.add(new SliderSetting(SettingsFile.KEY_OVERCLOCK_PERCENT, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_title, R.string.overclock_title_description, 400, "%", 100, overclock));
+        sl.add(new SliderSetting(SettingsFile.KEY_SPEED_LIMIT, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.speed_limit, 0, 200, "%", 100, speedLimit));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_A_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_a_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 8, slotADevice));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_B_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_b_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 255, slotBDevice));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_WIIMOTE_SCAN, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.wiimote_scanning, R.string.wiimote_scanning_description, true, continuousScan));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -386,6 +386,7 @@ public final class SettingsFragmentPresenter
 		Setting forceFilter = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_ENHANCEMENTS).getSetting(SettingsFile.KEY_FORCE_FILTERING);
 		Setting disableFog = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_FOG);
 		Setting disableCopyFilter = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_COPY_FILTER);
+		Setting arbitraryMipmapDetection = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_ARBITRARY_MIPMAP_DETECTION);
 		Setting wideScreenHack = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_ENHANCEMENTS).getSetting(SettingsFile.KEY_WIDE_SCREEN_HACK);
 		Setting force24BitColor = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_FORCE_24_BIT_COLOR);
 
@@ -408,6 +409,7 @@ public final class SettingsFragmentPresenter
         sl.add(new CheckBoxSetting(SettingsFile.KEY_FORCE_24_BIT_COLOR, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.force_24bit_color, R.string.force_24bit_color_description, true, force24BitColor));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DISABLE_FOG, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.disable_fog, R.string.disable_fog_description, false, disableFog));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DISABLE_COPY_FILTER, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.disable_copy_filter, R.string.disable_copy_filter_description, false, disableCopyFilter));
+		sl.add(new CheckBoxSetting(SettingsFile.KEY_ARBITRARY_MIPMAP_DETECTION, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.arbitrary_mipmap_detection, R.string.arbitrary_mipmap_detection_description, true, arbitraryMipmapDetection));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_WIDE_SCREEN_HACK, SettingsFile.SECTION_GFX_ENHANCEMENTS, SettingsFile.SETTINGS_GFX, R.string.wide_screen_hack, R.string.wide_screen_hack_description, false, wideScreenHack));
 
 		 /*

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -115,17 +115,17 @@ public final class SettingsFragmentPresenter
 
 		switch (mMenuTag)
 		{
-			case CONFIG:
-				addConfigSettings(sl);
-				break;
+            case CONFIG:
+                addConfigSettings(sl);
+                break;
 
-			case CONFIG_GENERAL:
+            case CONFIG_GENERAL:
 				addGeneralSettings(sl);
 				break;
 
-			case CONFIG_INTERFACE:
-				addInterfaceSettings(sl);
-				break;
+            case CONFIG_INTERFACE:
+                addInterfaceSettings(sl);
+                break;
 
 			case GRAPHICS:
 				addGraphicsSettings(sl);
@@ -294,12 +294,14 @@ public final class SettingsFragmentPresenter
 		Setting showFps = null;
 		Setting shaderCompilationMode = null;
 		Setting waitForShaders = null;
+		Setting aspectRatio = null;
 
 		if (!mSettings.get(SettingsFile.SETTINGS_GFX).isEmpty())
 		{
 			showFps = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_SHOW_FPS);
 			shaderCompilationMode = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_SHADER_COMPILATION_MODE);
 			waitForShaders = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_WAIT_FOR_SHADERS);
+			aspectRatio = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_ASPECT_RATIO);
 		}
 		else
 		{
@@ -311,10 +313,14 @@ public final class SettingsFragmentPresenter
 			mView.passSettingsToActivity(mSettings);
 		}
 
+		sl.add(new HeaderSetting(null, null, R.string.graphics_general, 0));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_VIDEO_BACKEND_INDEX, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.video_backend, R.string.video_backend_description, R.array.videoBackendEntries, R.array.videoBackendValues, 0, videoBackend));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_SHOW_FPS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.show_fps, R.string.show_fps_description, false, showFps));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SHADER_COMPILATION_MODE, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.shader_compilation_mode, R.string.shader_compilation_mode_description, R.array.shaderCompilationModeEntries, R.array.shaderCompilationModeValues, 0, shaderCompilationMode));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_WAIT_FOR_SHADERS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.wait_for_shaders, 0, false, waitForShaders));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_ASPECT_RATIO, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.aspect_ratio, R.string.aspect_ratio_description, R.array.aspectRatioEntries, R.array.aspectRatioValues, 0, aspectRatio));
+
+		sl.add(new HeaderSetting(null, null, R.string.graphics_enhancements_and_hacks, 0));
 		sl.add(new SubmenuSetting(null, null, R.string.enhancements_submenu, 0, MenuTag.ENHANCEMENTS));
 		sl.add(new SubmenuSetting(null, null, R.string.hacks_submenu, 0, MenuTag.HACKS));
 	}
@@ -371,7 +377,6 @@ public final class SettingsFragmentPresenter
 		Setting xfbToTexture = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_HACKS).getSetting(SettingsFile.KEY_XFB_TEXTURE);
 		Setting immediateXfb = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_HACKS).getSetting(SettingsFile.KEY_IMMEDIATE_XFB);
 		Setting fastDepth = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_HACKS).getSetting(SettingsFile.KEY_FAST_DEPTH);
-		Setting aspectRatio = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_ASPECT_RATIO);
 
 		sl.add(new HeaderSetting(null, null, R.string.embedded_frame_buffer, 0));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_SKIP_EFB, SettingsFile.SECTION_GFX_HACKS, SettingsFile.SETTINGS_GFX, R.string.skip_efb_access, R.string.skip_efb_access_description, false, skipEFB));
@@ -388,7 +393,6 @@ public final class SettingsFragmentPresenter
 
 		sl.add(new HeaderSetting(null, null, R.string.other, 0));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_FAST_DEPTH, SettingsFile.SECTION_GFX_HACKS, SettingsFile.SETTINGS_GFX, R.string.fast_depth_calculation, R.string.fast_depth_calculation_description, true, fastDepth));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_ASPECT_RATIO, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.aspect_ratio, R.string.aspect_ratio_description, R.array.aspectRatioEntries, R.array.aspectRatioValues, 0, aspectRatio));
 	}
 
 	private void addStereoSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -343,7 +343,8 @@ public final class SettingsFragmentPresenter
 		Setting forceFilter = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_ENHANCEMENTS).getSetting(SettingsFile.KEY_FORCE_FILTERING);
 		Setting disableFog = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_FOG);
 		Setting disableCopyFilter = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_COPY_FILTER);
-        Setting force24BitColor = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_FORCE_24_BIT_COLOR);
+		Setting wideScreenHack = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_ENHANCEMENTS).getSetting(SettingsFile.KEY_WIDE_SCREEN_HACK);
+		Setting force24BitColor = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_FORCE_24_BIT_COLOR);
 
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_INTERNAL_RES, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.internal_resolution, R.string.internal_resolution_description, R.array.internalResolutionEntries, R.array.internalResolutionValues, 1, resolution));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_FSAA, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.FSAA, R.string.FSAA_description, R.array.FSAAEntries, R.array.FSAAValues, 0, fsaa));
@@ -364,6 +365,7 @@ public final class SettingsFragmentPresenter
         sl.add(new CheckBoxSetting(SettingsFile.KEY_FORCE_24_BIT_COLOR, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.force_24bit_color, R.string.force_24bit_color_description, true, force24BitColor));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DISABLE_FOG, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.disable_fog, R.string.disable_fog_description, false, disableFog));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DISABLE_COPY_FILTER, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.disable_copy_filter, R.string.disable_copy_filter_description, false, disableCopyFilter));
+		sl.add(new CheckBoxSetting(SettingsFile.KEY_WIDE_SCREEN_HACK, SettingsFile.SECTION_GFX_ENHANCEMENTS, SettingsFile.SETTINGS_GFX, R.string.wide_screen_hack, R.string.wide_screen_hack_description, false, wideScreenHack));
 
 		 /*
 		 Check if we support stereo

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -131,6 +131,14 @@ public final class SettingsFragmentPresenter
                 addInterfaceSettings(sl);
                 break;
 
+			case CONFIG_GAME_CUBE:
+				addGameCubeSettings(sl);
+				break;
+
+			case CONFIG_WII:
+				addWiiSettings(sl);
+				break;
+
 			case GRAPHICS:
 				addGraphicsSettings(sl);
 				break;
@@ -189,6 +197,9 @@ public final class SettingsFragmentPresenter
 	{
 		sl.add(new SubmenuSetting(null, null, R.string.general_submenu, 0, MenuTag.CONFIG_GENERAL));
 		sl.add(new SubmenuSetting(null, null, R.string.interface_submenu, 0, MenuTag.CONFIG_INTERFACE));
+
+		sl.add(new SubmenuSetting(null, null, R.string.gamecube_submenu, 0, MenuTag.CONFIG_GAME_CUBE));
+		sl.add(new SubmenuSetting(null, null, R.string.wii_submenu, 0, MenuTag.CONFIG_WII));
 	}
 
 	private void addGeneralSettings(ArrayList<SettingsItem> sl)
@@ -198,10 +209,6 @@ public final class SettingsFragmentPresenter
 		Setting overclockEnable = null;
 		Setting overclock = null;
 		Setting speedLimit = null;
-		Setting slotADevice = null;
-		Setting slotBDevice = null;
-		Setting continuousScan = null;
-		Setting wiimoteSpeaker = null;
 		Setting audioStretch = null;
 
 		if (!mSettings.get(SettingsFile.SETTINGS_DOLPHIN).isEmpty())
@@ -211,10 +218,6 @@ public final class SettingsFragmentPresenter
 			overclockEnable = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_OVERCLOCK_ENABLE);
 			overclock = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_OVERCLOCK_PERCENT);
             speedLimit = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SPEED_LIMIT);
-			slotADevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_A_DEVICE);
-			slotBDevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_B_DEVICE);
-			continuousScan = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_WIIMOTE_SCAN);
-			wiimoteSpeaker = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_WIIMOTE_SPEAKER);
 			audioStretch = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_AUDIO_STRETCH);
 		}
 		else
@@ -248,10 +251,6 @@ public final class SettingsFragmentPresenter
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_OVERCLOCK_ENABLE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_enable, R.string.overclock_enable_description, false, overclockEnable));
 		sl.add(new SliderSetting(SettingsFile.KEY_OVERCLOCK_PERCENT, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_title, R.string.overclock_title_description, 400, "%", 100, overclock));
         sl.add(new SliderSetting(SettingsFile.KEY_SPEED_LIMIT, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.speed_limit, 0, 200, "%", 100, speedLimit));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_A_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_a_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 8, slotADevice));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_B_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_b_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 255, slotBDevice));
-		sl.add(new CheckBoxSetting(SettingsFile.KEY_WIIMOTE_SCAN, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.wiimote_scanning, R.string.wiimote_scanning_description, true, continuousScan));
-		sl.add(new CheckBoxSetting(SettingsFile.KEY_WIIMOTE_SPEAKER, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.wiimote_speaker, R.string.wiimote_speaker_description, true, wiimoteSpeaker));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_AUDIO_STRETCH, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.audio_stretch, R.string.audio_stretch_description, false, audioStretch));
 	}
 
@@ -267,6 +266,43 @@ public final class SettingsFragmentPresenter
 		}
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_USE_PANIC_HANDLERS, SettingsFile.SECTION_INI_INTERFACE, SettingsFile.SETTINGS_DOLPHIN, R.string.panic_handlers, R.string.panic_handlers_description, true, usePanicHandlers));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_OSD_MESSAGES, SettingsFile.SECTION_INI_INTERFACE, SettingsFile.SETTINGS_DOLPHIN, R.string.osd_messages, R.string.osd_messages_description, true, onScreenDisplayMessages));
+	}
+
+	private void addGameCubeSettings(ArrayList<SettingsItem> sl)
+	{
+		Setting slotADevice = null;
+		Setting slotBDevice = null;
+		if (!mSettings.get(SettingsFile.SETTINGS_DOLPHIN).isEmpty())
+		{
+
+			slotADevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_A_DEVICE);
+			slotBDevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_B_DEVICE);
+		}
+		else
+		{
+			mView.passSettingsToActivity(mSettings);
+		}
+
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_A_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_a_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 8, slotADevice));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_B_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_b_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 255, slotBDevice));
+	}
+
+	private void addWiiSettings(ArrayList<SettingsItem> sl)
+	{
+		Setting continuousScan = null;
+		Setting wiimoteSpeaker = null;
+		if (!mSettings.get(SettingsFile.SETTINGS_DOLPHIN).isEmpty())
+		{
+			continuousScan = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_WIIMOTE_SCAN);
+			wiimoteSpeaker = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_WIIMOTE_SPEAKER);
+		}
+		else
+		{
+			mView.passSettingsToActivity(mSettings);
+		}
+
+		sl.add(new CheckBoxSetting(SettingsFile.KEY_WIIMOTE_SCAN, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.wiimote_scanning, R.string.wiimote_scanning_description, true, continuousScan));
+		sl.add(new CheckBoxSetting(SettingsFile.KEY_WIIMOTE_SPEAKER, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.wiimote_speaker, R.string.wiimote_speaker_description, true, wiimoteSpeaker));
 	}
 
 	private void addGcPadSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -270,11 +270,16 @@ public final class SettingsFragmentPresenter
 
 	private void addGameCubeSettings(ArrayList<SettingsItem> sl)
 	{
+		Setting systemLanguage = null;
+        Setting overrideGCLanguage = null;
 		Setting slotADevice = null;
 		Setting slotBDevice = null;
+
 		if (!mSettings.get(SettingsFile.SETTINGS_DOLPHIN).isEmpty())
 		{
 
+			systemLanguage = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_GAME_CUBE_LANGUAGE);
+            overrideGCLanguage = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_OVERRIDE_GAME_CUBE_LANGUAGE);
 			slotADevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_A_DEVICE);
 			slotBDevice = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_INI_CORE).getSetting(SettingsFile.KEY_SLOT_B_DEVICE);
 		}
@@ -283,6 +288,8 @@ public final class SettingsFragmentPresenter
 			mView.passSettingsToActivity(mSettings);
 		}
 
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_GAME_CUBE_LANGUAGE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.gamecube_system_language, 0, R.array.gameCubeSystemLanguageEntries, R.array.gameCubeSystemLanguageValues, 0, systemLanguage));
+        sl.add(new CheckBoxSetting(SettingsFile.KEY_OVERRIDE_GAME_CUBE_LANGUAGE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.override_gamecube_language, 0, false, overrideGCLanguage));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_A_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_a_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 8, slotADevice));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_B_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_b_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 255, slotBDevice));
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentView.java
@@ -56,7 +56,7 @@ public interface SettingsFragmentView
 	 *
 	 * @param menuKey Identifier for the settings group that should be shown.
 	 */
-	void loadSubMenu(String menuKey);
+	void loadSubMenu(MenuTag menuKey);
 
 	/**
 	 * Tell the Fragment to tell the containing activity to display a toast message.
@@ -80,25 +80,24 @@ public interface SettingsFragmentView
 	/**
 	 * Have the fragment tell the containing Activity that a GCPad's setting was modified.
 	 *
-	 * @param key   Identifier for the GCPad that was modified.
+	 * @param menuTag   Identifier for the GCPad that was modified.
 	 * @param value New setting for the GCPad.
 	 */
-	void onGcPadSettingChanged(String key, int value);
+	void onGcPadSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Have the fragment tell the containing Activity that a Wiimote's setting was modified.
 	 *
-	 * @param section Identifier for Wiimote that was modified; Wiimotes are identified by their section,
-	 *                not their key.
+	 * @param menuTag Identifier for Wiimote that was modified.
 	 * @param value   New setting for the Wiimote.
 	 */
-	void onWiimoteSettingChanged(String section, int value);
+	void onWiimoteSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Have the fragment tell the containing Activity that an extension setting was modified.
 	 *
-	 * @param key   Identifier for the extension that was modified.
+	 * @param menuTag   Identifier for the extension that was modified.
 	 * @param value New setting for the extension.
 	 */
-	void onExtensionSettingChanged(String key, int value);
+	void onExtensionSettingChanged(MenuTag menuTag, int value);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/viewholder/SingleChoiceViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/viewholder/SingleChoiceViewHolder.java
@@ -6,11 +6,12 @@ import android.widget.TextView;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.settings.view.SettingsItem;
 import org.dolphinemu.dolphinemu.model.settings.view.SingleChoiceSetting;
+import org.dolphinemu.dolphinemu.model.settings.view.StringSingleChoiceSetting;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsAdapter;
 
 public final class SingleChoiceViewHolder extends SettingViewHolder
 {
-	private SingleChoiceSetting mItem;
+	private SettingsItem mItem;
 
 	private TextView mTextSettingName;
 	private TextView mTextSettingDescription;
@@ -30,7 +31,7 @@ public final class SingleChoiceViewHolder extends SettingViewHolder
 	@Override
 	public void bind(SettingsItem item)
 	{
-		mItem = (SingleChoiceSetting) item;
+		mItem = item;
 
 		mTextSettingName.setText(item.getNameId());
 
@@ -43,6 +44,13 @@ public final class SingleChoiceViewHolder extends SettingViewHolder
 	@Override
 	public void onClick(View clicked)
 	{
-		getAdapter().onSingleChoiceClick(mItem);
+		if (mItem instanceof SingleChoiceSetting)
+		{
+			getAdapter().onSingleChoiceClick((SingleChoiceSetting) mItem);
+		}
+		else if (mItem instanceof StringSingleChoiceSetting)
+		{
+			getAdapter().onStringSingleChoiceClick((StringSingleChoiceSetting) mItem);
+		}
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -101,6 +101,7 @@ public final class SettingsFile
 	public static final String KEY_FORCE_FILTERING = "ForceFiltering";
 	public static final String KEY_DISABLE_FOG = "DisableFog";
 	public static final String KEY_DISABLE_COPY_FILTER = "DisableCopyFilter";
+	public static final String KEY_WIDE_SCREEN_HACK = "wideScreenHack";
 	public static final String KEY_FORCE_24_BIT_COLOR = "ForceTrueColor";
 
 	public static final String KEY_STEREO_MODE = "StereoMode";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -103,6 +103,7 @@ public final class SettingsFile
 	public static final String KEY_FORCE_FILTERING = "ForceFiltering";
 	public static final String KEY_DISABLE_FOG = "DisableFog";
 	public static final String KEY_DISABLE_COPY_FILTER = "DisableCopyFilter";
+	public static final String KEY_ARBITRARY_MIPMAP_DETECTION = "ArbitraryMipmapDetection";
 	public static final String KEY_WIDE_SCREEN_HACK = "wideScreenHack";
 	public static final String KEY_FORCE_24_BIT_COLOR = "ForceTrueColor";
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -100,6 +100,7 @@ public final class SettingsFile
 	public static final String KEY_FORCE_FILTERING = "ForceFiltering";
 	public static final String KEY_DISABLE_FOG = "DisableFog";
 	public static final String KEY_DISABLE_COPY_FILTER = "DisableCopyFilter";
+	public static final String KEY_FORCE_24_BIT_COLOR = "ForceTrueColor";
 
 	public static final String KEY_STEREO_MODE = "StereoMode";
 	public static final String KEY_STEREO_DEPTH = "StereoDepth";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -82,6 +82,7 @@ public final class SettingsFile
 	public static final String KEY_DUAL_CORE = "CPUThread";
 	public static final String KEY_OVERCLOCK_ENABLE = "OverclockEnable";
 	public static final String KEY_OVERCLOCK_PERCENT = "Overclock";
+	public static final String KEY_SPEED_LIMIT = "EmulationSpeed";
 	public static final String KEY_VIDEO_BACKEND = "GFXBackend";
 	public static final String KEY_AUDIO_STRETCH = "AudioStretch";
 	public static final String KEY_SLOT_A_DEVICE = "SlotA";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -85,6 +85,8 @@ public final class SettingsFile
 	public static final String KEY_SPEED_LIMIT = "EmulationSpeed";
 	public static final String KEY_VIDEO_BACKEND = "GFXBackend";
 	public static final String KEY_AUDIO_STRETCH = "AudioStretch";
+	public static final String KEY_GAME_CUBE_LANGUAGE = "SelectedLanguage";
+    public static final String KEY_OVERRIDE_GAME_CUBE_LANGUAGE = "OverrideGCLang";
 	public static final String KEY_SLOT_A_DEVICE = "SlotA";
 	public static final String KEY_SLOT_B_DEVICE = "SlotB";
 

--- a/Source/Android/app/src/main/res/layout/list_item_settings_header.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_settings_header.xml
@@ -2,6 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              xmlns:tools="http://schemas.android.com/tools"
              android:layout_width="match_parent"
+             android:focusable="true"
              android:layout_height="48dp">
 
     <TextView

--- a/Source/Android/app/src/main/res/menu/menu_game_grid.xml
+++ b/Source/Android/app/src/main/res/menu/menu_game_grid.xml
@@ -4,13 +4,13 @@
 
     <item
         android:id="@+id/menu_settings_core"
-        android:title="@string/grid_menu_core_settings"
+        android:title="@string/grid_menu_config"
         android:icon="@drawable/ic_settings_core"
         app:showAsAction="ifRoom"/>
 
     <item
-        android:id="@+id/menu_settings_video"
-        android:title="@string/grid_menu_video_settings"
+        android:id="@+id/menu_settings_graphics"
+        android:title="@string/grid_menu_graphics_settings"
         android:icon="@drawable/ic_settings_graphics"
         app:showAsAction="ifRoom"/>
 

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -33,6 +33,24 @@
         <item>5</item>
     </integer-array>
 
+    <!-- GameCube System Languages -->
+    <string-array name="gameCubeSystemLanguageEntries" translatable="false">
+        <item>English</item>
+        <item>German</item>
+        <item>French</item>
+        <item>Spanish</item>
+        <item>Italian</item>
+        <item>Dutch</item>
+    </string-array>
+    <integer-array name="gameCubeSystemLanguageValues" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </integer-array>
+
     <!-- Slot A Device Selection -->
     <string-array name="slotDeviceEntries" translatable="false">
         <item>Nothing</item>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -171,6 +171,8 @@
     <string name="disable_copy_filter_description">Disables the blending of adjacent rows when copying the EFB. This is known in some games as \"deflickering\" or \"smoothing\". Disabling the filter is usually safe, and may result in a sharper image.</string>
     <string name="stereoscopy_submenu">Stereoscopy</string>
     <string name="stereoscopy_submenu_description">Stereoscopy allows you to get a better feeling of depth if you have the necessary hardware.\nHeavily decreases emulation speed and sometimes causes issues</string>
+    <string name="wide_screen_hack">Widescreen Hack</string>
+    <string name="wide_screen_hack_description">Forces the game to output graphics for any aspect ratio. Use with \"Aspect Ratio\" set to \"Force 16:9\" to force 4:3-only games to run at 16:9. Rarely produces good results and often partially breaks graphics and game UIs.\nUnnecessary (and detrimental) if using any AR/Gecko-code widescreen patches. If unsure, leave this unchecked.</string>
     <string name="stereoscopy_mode">Stereoscopy Mode</string>
     <string name="stereoscopy_mode_description">Select the stereoscopic 3D mode.</string>
     <string name="stereoscopy_depth">Depth</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -152,6 +152,8 @@
     <string name="FSAA_description">Reduces the amount of aliasing caused by rasterizing 3D graphics. This makes the rendered picture look less blocky. Heavily decreases emulation speed and sometimes causes issues.</string>
     <string name="anisotropic_filtering">Anisotropic Filtering</string>
     <string name="anisotropic_filtering_description">Enhances visual quality of textures that are at oblique viewing angles. Might cause issues in a small number of games.</string>
+    <string name="post_processing_shader">Post-Processing Effect</string>
+    <string name="post_processing_shader_description">Apply a post-processing effect after finishing a frame</string>
     <string name="postprocessing_shader">Post Processing Shader</string>
     <string name="postprocessing_shader_description">Apply a post-processing effect after finishing a frame.</string>
     <string name="scaled_efb_copy">Scaled EFB Copy</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="overclock_enable_description">Higher values can make variable-framerate games run at a higher framerate, requiring a powerful device. Lower values make games run at a lower framerate, increasing emulation speed, but reducing the emulated console\'s performance.</string>
     <string name="overclock_title">Emulated CPU Clock Speed</string>
     <string name="overclock_title_description">Adjusts the emulated CPU\'s clock rate if \"Override Emulated CPU Clock Speed\" is enabled.</string>
+    <string name="speed_limit">Speed Limit</string>
     <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
     <string name="slot_a_device">GameCube Slot A Device</string>
     <string name="slot_b_device">GameCube Slot B Device</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -173,6 +173,8 @@
     <string name="disable_fog_description">Makes distant objects more visible by removing fog, thus increasing the overall detail. Disabling fog will break some games which rely on proper fog emulation.</string>
     <string name="disable_copy_filter">Disable Copy Filter</string>
     <string name="disable_copy_filter_description">Disables the blending of adjacent rows when copying the EFB. This is known in some games as \"deflickering\" or \"smoothing\". Disabling the filter is usually safe, and may result in a sharper image.</string>
+    <string name="arbitrary_mipmap_detection">Arbitrary Mipmap Detection</string>
+    <string name="arbitrary_mipmap_detection_description">Enables detection of arbitrary mipmaps, which some games use for special distance-based effects.\nMay have false positives that result in blurry textures at increased internal resolution, such as in games that use very low resolution mipmaps. Disabling this can also reduce stutter in games that frequently load new textures.\n\nIf unsure, leave this checked.</string>
     <string name="stereoscopy_submenu">Stereoscopy</string>
     <string name="stereoscopy_submenu_description">Stereoscopy allows you to get a better feeling of depth if you have the necessary hardware.\nHeavily decreases emulation speed and sometimes causes issues</string>
     <string name="wide_screen_hack">Widescreen Hack</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <string name="speed_limit">Speed Limit</string>
     <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
     <string name="gamecube_submenu">GameCube</string>
+    <string name="gamecube_system_language">System Language</string>
+    <string name="override_gamecube_language">Override Language on NTSC games</string>
     <string name="slot_a_device">GameCube Slot A Device</string>
     <string name="slot_b_device">GameCube Slot B Device</string>
     <string name="wii_submenu">Wii</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -120,8 +120,10 @@
     <string name="overclock_title_description">Adjusts the emulated CPU\'s clock rate if \"Override Emulated CPU Clock Speed\" is enabled.</string>
     <string name="speed_limit">Speed Limit</string>
     <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
+    <string name="gamecube_submenu">GameCube</string>
     <string name="slot_a_device">GameCube Slot A Device</string>
     <string name="slot_b_device">GameCube Slot B Device</string>
+    <string name="wii_submenu">Wii</string>
     <string name="wiimote_scanning">Wii Remote Continuous Scanning</string>
     <string name="wiimote_scanning_description">Leave this on if you are using a DolphinBar for real Wiimote support.</string>
     <string name="wiimote_speaker">Wii Remote Speaker</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -160,6 +160,8 @@
     <string name="per_pixel_lighting_description">Calculate lighting of 3D graphics per-pixel rather than per vertex. Decreases emulation speed by some percent (depending on your GPU). This usually is a safe enhancement, but might cause issues sometimes.</string>
     <string name="force_texture_filtering">Force Texture Filtering</string>
     <string name="force_texture_filtering_description">Force texture filtering even if the emulated game explicitly disabled it. Improves texture quality slightly but causes glitches in some games.</string>
+    <string name="force_24bit_color">Force 24-Bit Color</string>
+    <string name="force_24bit_color_description">Forces the game to render the RGB color channels in 24-bit, thereby increasing quality by reducing color banding.\nIt has no impact on performance and causes few graphical issues. If unsure, leave this checked.</string>
     <string name="disable_fog">Disable Fog</string>
     <string name="disable_fog_description">Makes distant objects more visible by removing fog, thus increasing the overall detail. Disabling fog will break some games which rely on proper fog emulation.</string>
     <string name="disable_copy_filter">Disable Copy Filter</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -209,8 +209,8 @@
     <string name="other">Other</string>
 
     <!-- Game Grid Screen-->
-    <string name="grid_menu_core_settings">CPU Settings</string>
-    <string name="grid_menu_video_settings">Video Settings</string>
+    <string name="grid_menu_config">Config</string>
+    <string name="grid_menu_graphics_settings">Graphics Settings</string>
     <string name="grid_menu_gcpad_settings">GameCube Input</string>
     <string name="grid_menu_wiimote_settings">Wii Input</string>
     <string name="grid_menu_refresh">Refresh Library</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -135,6 +135,10 @@
     <string name="osd_messages">Show On-Screen Display Messages</string>
     <string name="osd_messages_description">Display messages over the emulation screen area. These messages include memory card writes, video backend and CPU information, and JIT cache clearing.</string>
 
+    <!-- Graphics Settings -->
+    <string name="graphics_general">General</string>
+    <string name="graphics_enhancements_and_hacks">Enhancements &amp; Hacks</string>
+
     <!-- Video Preference Fragment -->
     <string name="video_backend">Video Backend</string>
     <string name="video_backend_description">Select the API used for graphics rendering.</string>


### PR DESCRIPTION
I will try to update the ui settings for Android to match the latest desktop version, please let me know if I missed any and you think it should be added.

- [x] Fix clock speed slider to use incremental values of 5% instead of 20%.
- [x] Move the Aspect Ration Settings from the Enhancements Section to the General section.
- [x] Add Force 24-Bit Color enhancement option.
- [x] Support Post Processing Shaders.
- [x] Dedicated GameCube Section + System Language.
- [x] Dedicated Wii Section + ~~System Language~~.
- [x] Speed Limit Setting.
- [x] WideScreen Hack.
- [x] Expose arbitrary mipmap detection toggle in UI.

Edit: Wii system language will be moved to separate PR since it require more work and I don't want to delay this PR any more.