### PR TITLE
MemoryPatches class added

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -7,6 +7,10 @@
 #include <cstddef>
 #include <cstring>
 #include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "Core/PowerPC/MemoryPatches.h"
 
 class DebugInterface
 {
@@ -39,7 +43,12 @@ public:
   virtual void SetPC(unsigned int /*address*/) {}
   virtual void Step() {}
   virtual void RunToBreakpoint() {}
-  virtual void Patch(unsigned int /*address*/, unsigned int /*value*/) {}
+  // Memory Patches
+  virtual void Patch(unsigned int address, unsigned int value) = 0;
+  virtual const std::vector<MemoryPatch>& ListPatches() const = 0;
+  virtual void DeletePatch(std::size_t index) = 0;
+  virtual void ClearPatches() = 0;
+
   virtual int GetColor(unsigned int /*address*/) { return 0xFFFFFFFF; }
   virtual std::string GetDescription(unsigned int /*address*/) = 0;
 };

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -200,6 +200,7 @@ set(SRCS
   IOS/WFS/WFSSRV.cpp
   IOS/WFS/WFSI.cpp
   PowerPC/BreakPoints.cpp
+  PowerPC/MemoryPatches.cpp
   PowerPC/MMU.cpp
   PowerPC/PowerPC.cpp
   PowerPC/PPCAnalyst.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -278,6 +278,7 @@
     <ClCompile Include="PowerPC\JitCommon\JitAsmCommon.cpp" />
     <ClCompile Include="PowerPC\JitCommon\JitBase.cpp" />
     <ClCompile Include="PowerPC\JitCommon\JitCache.cpp" />
+    <ClCompile Include="PowerPC\MemoryPatches.cpp" />
     <ClCompile Include="PowerPC\SignatureDB\CSVSignatureDB.cpp" />
     <ClCompile Include="PowerPC\SignatureDB\DSYSignatureDB.cpp" />
     <ClCompile Include="PowerPC\SignatureDB\MEGASignatureDB.cpp" />
@@ -516,6 +517,7 @@
     <ClInclude Include="PowerPC\JitCommon\JitAsmCommon.h" />
     <ClInclude Include="PowerPC\JitCommon\JitBase.h" />
     <ClInclude Include="PowerPC\JitCommon\JitCache.h" />
+    <ClInclude Include="PowerPC\MemoryPatches.h" />
     <ClInclude Include="PowerPC\SignatureDB\CSVSignatureDB.h" />
     <ClInclude Include="PowerPC\SignatureDB\DSYSignatureDB.h" />
     <ClInclude Include="PowerPC\SignatureDB\MEGASignatureDB.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -306,6 +306,9 @@
     <ClCompile Include="PowerPC\BreakPoints.cpp">
       <Filter>PowerPC</Filter>
     </ClCompile>
+    <ClCompile Include="PowerPC\MemoryPatches.cpp">
+      <Filter>PowerPC</Filter>
+    </ClCompile>
     <ClCompile Include="PowerPC\CachedInterpreter\CachedInterpreter.cpp">
       <Filter>PowerPC\Cached Interpreter</Filter>
     </ClCompile>
@@ -1294,6 +1297,9 @@
       <Filter>PowerPC</Filter>
     </ClInclude>
     <ClInclude Include="PowerPC\JitInterface.h">
+      <Filter>PowerPC</Filter>
+    </ClInclude>
+    <ClInclude Include="PowerPC\MemoryPatches.h">
       <Filter>PowerPC</Filter>
     </ClInclude>
     <ClInclude Include="PowerPC\PowerPC.h">

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -158,8 +158,22 @@ void PPCDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool wri
 
 void PPCDebugInterface::Patch(unsigned int address, unsigned int value)
 {
-  PowerPC::HostWrite_U32(value, address);
-  PowerPC::ScheduleInvalidateCacheThreadSafe(address);
+  m_patches.Add(address, value);
+}
+
+const std::vector<MemoryPatch>& PPCDebugInterface::ListPatches() const
+{
+  return m_patches.List();
+}
+
+void PPCDebugInterface::DeletePatch(std::size_t index)
+{
+  m_patches.Delete(index);
+}
+
+void PPCDebugInterface::ClearPatches()
+{
+  m_patches.Clear();
 }
 
 // =======================================================

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -42,7 +42,16 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
+
+  // Memory Patches
   void Patch(unsigned int address, unsigned int value) override;
+  const std::vector<MemoryPatch>& ListPatches() const override;
+  void DeletePatch(std::size_t index) override;
+  void ClearPatches() override;
+
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
+
+private:
+  MemoryPatches m_patches;
 };

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -137,6 +137,22 @@ void DSPDebugInterface::Patch(unsigned int address, unsigned int value)
   PanicAlert("Patch functionality not supported in DSP module.");
 }
 
+const std::vector<MemoryPatch>& DSPDebugInterface::ListPatches() const
+{
+  PanicAlert("Patch functionality not supported in DSP module.");
+  return m_patches.List();
+}
+
+void DSPDebugInterface::DeletePatch(std::size_t index)
+{
+  PanicAlert("Patch functionality not supported in DSP module.");
+}
+
+void DSPDebugInterface::ClearPatches()
+{
+  PanicAlert("Patch functionality not supported in DSP module.");
+}
+
 // =======================================================
 // Separate the blocks with colors.
 // -------------

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -37,9 +37,18 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
+
+  // Memory Patches
   void Patch(unsigned int address, unsigned int value) override;
+  const std::vector<MemoryPatch>& ListPatches() const override;
+  void DeletePatch(std::size_t index) override;
+  void ClearPatches() override;
+
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
+
+private:
+  MemoryPatches m_patches;
 };
 }  // namespace LLE
 }  // namespace DSP

--- a/Source/Core/Core/PowerPC/MemoryPatches.cpp
+++ b/Source/Core/Core/PowerPC/MemoryPatches.cpp
@@ -1,0 +1,36 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/MemoryPatches.h"
+
+#include "Core/PowerPC/PowerPC.h"
+
+void MemoryPatches::Add(u32 address, u32 value)
+{
+  const u32 old_value = PowerPC::HostRead_U32(address);
+  m_patches.emplace_back(address, old_value);
+  PowerPC::HostWrite_U32(value, address);
+  PowerPC::ScheduleInvalidateCacheThreadSafe(address);
+}
+
+const std::vector<MemoryPatch>& MemoryPatches::List() const
+{
+  return m_patches;
+}
+
+void MemoryPatches::Delete(std::size_t index)
+{
+  if (index >= m_patches.size())
+    return;
+
+  const auto& it = m_patches.begin() + index;
+  PowerPC::HostWrite_U32(it->old_value, it->address);
+  PowerPC::ScheduleInvalidateCacheThreadSafe(it->address);
+  m_patches.erase(it);
+}
+
+void MemoryPatches::Clear()
+{
+  m_patches.clear();
+}

--- a/Source/Core/Core/PowerPC/MemoryPatches.h
+++ b/Source/Core/Core/PowerPC/MemoryPatches.h
@@ -1,0 +1,30 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+struct MemoryPatch
+{
+  u32 address;
+  u32 old_value;
+
+  MemoryPatch(u32 address, u32 old_value) : address(address), old_value(old_value) {}
+};
+
+class MemoryPatches
+{
+public:
+  void Add(u32 address, u32 value);
+  const std::vector<MemoryPatch>& List() const;
+  void Delete(std::size_t index);
+  void Clear();
+
+private:
+  std::vector<MemoryPatch> m_patches;
+};

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -14,6 +14,7 @@
 #include "Core/Debugger/PPCDebugInterface.h"
 #include "Core/PowerPC/BreakPoints.h"
 #include "Core/PowerPC/Gekko.h"
+#include "Core/PowerPC/MemoryPatches.h"
 #include "Core/PowerPC/PPCCache.h"
 
 class CPUCoreBase;

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -204,28 +204,24 @@ u32 CCodeView::AddrToBranch(u32 addr)
 void CCodeView::InsertBlrNop(int Blr)
 {
   // Check if this address has been modified
+  int i = 0;
   int find = -1;
-  for (u32 i = 0; i < m_blrList.size(); i++)
+  for (const auto& patch : m_debugger->ListPatches())
   {
-    if (m_blrList.at(i).address == m_selection)
+    if (patch.address == m_selection)
     {
       find = i;
       break;
     }
+    i += 1;
   }
 
-  // Save the old value
   if (find >= 0)
   {
-    m_debugger->WriteExtraMemory(0, m_blrList.at(find).oldValue, m_selection);
-    m_blrList.erase(m_blrList.begin() + find);
+    m_debugger->DeletePatch(find);
   }
   else
   {
-    BlrStruct temp;
-    temp.address = m_selection;
-    temp.oldValue = m_debugger->ReadMemory(m_selection);
-    m_blrList.push_back(temp);
     if (Blr == 0)
       m_debugger->Patch(m_selection, 0x4e800020);
     else

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -887,6 +887,7 @@ void CFrame::DoStop()
       PowerPC::watches.Clear();
       PowerPC::breakpoints.Clear();
       PowerPC::memchecks.Clear();
+      PowerPC::debug_interface.ClearPatches();
       if (m_code_window->HasPanel<CBreakPointWindow>())
         m_code_window->GetPanel<CBreakPointWindow>()->NotifyUpdate();
       g_symbolDB.Clear();


### PR DESCRIPTION
This PR moves the ```blrList``` logic from WxWidget to the DebugInterface under the name MemoryPatches.

It also fixes a bug? where "Insert blr/nop" couldn't be reverted (not sure if it was a bug, intended or some dead code).

Ready to be reviewed and merged. 