### PR TITLE
Qt/RenderWidget: Avoid flickering

### DIFF
--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -58,6 +58,12 @@ bool RenderWidget::event(QEvent* event)
     QKeyEvent* ke = static_cast<QKeyEvent*>(event);
     if (ke->key() == Qt::Key_Escape)
       emit EscapePressed();
+
+    // The render window might flicker on some platforms because Qt tries to change focus to a new
+    // element when there is none (?) Handling this event before it reaches QWidget fixes the issue.
+    if (ke->key() == Qt::Key_Tab)
+      return true;
+
     break;
   }
   case QEvent::MouseMove:


### PR DESCRIPTION
Fixes [issue #10849](https://bugs.dolphin-emu.org/issues/10849).