### PR TITLE
Qt/Settings: Update default gamelist path textbox when changed

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -368,7 +368,7 @@ void GameList::UninstallWAD()
 
 void GameList::SetDefaultISO()
 {
-  SConfig::GetInstance().m_strDefaultISO = GetSelectedGame()->GetFilePath().toStdString();
+  Settings::Instance().SetDefaultGame(GetSelectedGame()->GetFilePath());
 }
 
 void GameList::OpenContainingFolder()

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -72,6 +72,20 @@ void Settings::RemovePath(const QString& qpath)
   emit PathRemoved(qpath);
 }
 
+QString Settings::GetDefaultGame() const
+{
+  return QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);
+}
+
+void Settings::SetDefaultGame(QString path)
+{
+  if (GetDefaultGame() != path)
+  {
+    SConfig::GetInstance().m_strDefaultISO = path.toStdString();
+    emit DefaultGameChanged(path);
+  }
+}
+
 bool Settings::GetPreferredView() const
 {
   return QSettings().value(QStringLiteral("PreferredView"), true).toBool();

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -53,6 +53,8 @@ public:
   void RemovePath(const QString& path);
   bool GetPreferredView() const;
   void SetPreferredView(bool list);
+  QString GetDefaultGame() const;
+  void SetDefaultGame(QString path);
 
   // Emulation
   int GetStateSlot() const;
@@ -96,6 +98,7 @@ signals:
   void ThemeChanged();
   void PathAdded(const QString&);
   void PathRemoved(const QString&);
+  void DefaultGameChanged(const QString&);
   void HideCursorChanged();
   void VolumeChanged(int volume);
   void NANDRefresh();

--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -97,9 +97,11 @@ QGridLayout* PathPane::MakePathsLayout()
   QGridLayout* layout = new QGridLayout;
   layout->setColumnStretch(1, 1);
 
-  m_game_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_strDefaultISO));
+  m_game_edit = new QLineEdit(Settings::Instance().GetDefaultGame());
   connect(m_game_edit, &QLineEdit::editingFinished,
-          [=] { SConfig::GetInstance().m_strDefaultISO = m_game_edit->text().toStdString(); });
+          [this] { Settings::Instance().SetDefaultGame(m_game_edit->text()); });
+  connect(&Settings::Instance(), &Settings::DefaultGameChanged,
+          [this](const QString& path) { m_game_edit->setText(path); });
   QPushButton* game_open = new QPushButton;
   connect(game_open, &QPushButton::clicked, this, &PathPane::BrowseDefaultGame);
   layout->addWidget(new QLabel(tr("Default ISO:")), 0, 0);


### PR DESCRIPTION
Fixes [issue 10854](https://bugs.dolphin-emu.org/issues/10854).