### PR TITLE
PixelShaderGen: Implement table-based fog range as in software renderer

### DIFF
--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -24,9 +24,10 @@ struct PixelShaderConstants
   std::array<int4, 6> indtexmtx;
   int4 fogcolor;
   int4 fogi;
-  std::array<float4, 2> fogf;
+  float4 fogf;
+  std::array<float4, 3> fogrange;
   float4 zslope;
-  std::array<float, 2> efbscale;
+  std::array<float, 2> efbscale;  // .xy
 
   // Constants from here onwards are only used in ubershaders.
   u32 genmode;                  // .z

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -301,6 +301,7 @@ inline const char* GetInterpolationQualifier(bool msaa, bool ssaa,
 #define I_FOGCOLOR "cfogcolor"
 #define I_FOGI "cfogi"
 #define I_FOGF "cfogf"
+#define I_FOGRANGE "cfogrange"
 #define I_ZSLOPE "czslope"
 #define I_EFBSCALE "cefbscale"
 


### PR DESCRIPTION
This change implements the table-based fog coefficients used to alter the intensity of the fog across the horizontal direction of the screen in the hardware backends. Previously, this was only implemented in the software renderer.

The behavior here is still not verified against the console, but at least our hardware backends will match the software renderer now. Also fixes the fogged-over memory block fifolog from fortune street.