### PR TITLE
Add -Wno-register to calm down clang 6.0.0 (C++17 mode)

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wregister"
 #include <X11/XKBlib.h>
+#pragma GCC diagnostic pop
 #include <cmath>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
clang 6.0.0 is the default compiler on FreeBSD 12.

The 'register' keyword is used by a header included from Xlib (X11/XKBlib.h):

```
In file included from ../Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp:5:
/usr/local/include/X11/XKBlib.h:399:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    register KeySym *           /* sym_return */,
    ^~~~~~~~~
1 error generated.
```