### PR TITLE
Do not link to libusbhid on FreeBSD/NetBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,10 +757,6 @@ if(ENABLE_WX)
   endif()
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|NetBSD")
-  set(LIBS ${LIBS} usbhid)
-endif()
-
 ########################################
 # Pre-build events: Define configuration variables and write SCM info header
 #

--- a/Source/Core/VideoBackends/OGL/CMakeLists.txt
+++ b/Source/Core/VideoBackends/OGL/CMakeLists.txt
@@ -23,8 +23,4 @@ set(LIBS ${LIBS}
   ${X11_LIBRARIES}
 )
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|NetBSD")
-  set(LIBS ${LIBS} usbhid)
-endif()
-
 add_dolphin_library(videoogl "${SRCS}" "${LIBS}")


### PR DESCRIPTION
Both `libusbhid` (system library) and `libhidapi` (3rd party library) provide a function called `hid_init`. Dolphin was being linked to both.

The `WiimoteScannerHidapi` constructor was calling `hid_init` without arguments. `libusbhid`'s `hid_init` expects one argument (a file path).

It was being called as if it was defined without arguments, which resulted in a garbage path being passed in, and because of that, the Qt GUI was failing to launch with the following error:

```
dolphin-emu-qt2: @ : No such file or directory
```

I'm not sure why this was not discovered with the Wx GUI — probably that object wasn't created until necessary in Wx, but it's always created in Qt.