### PR TITLE
Qt TAS input windows

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -109,6 +109,7 @@ set(SRCS
   TAS/WiiTASInputWindow.cpp
   TAS/Shared.cpp
   TAS/StickWidget.cpp
+  TAS/IRWidget.cpp
 )
 
 list(APPEND LIBS core uicommon)

--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SRCS
   QtUtils/ElidedButton.cpp
   QtUtils/ListTabWidget.cpp
   QtUtils/WindowActivationEventFilter.cpp
+  QtUtils/AspectRatioWidget.cpp
   Settings/AdvancedPane.cpp
   Settings/AudioPane.cpp
   Settings/GameCubePane.cpp
@@ -104,6 +105,8 @@ set(SRCS
   Settings/PathPane.cpp
   Settings/WiiPane.cpp
   Settings/USBDeviceAddToWhitelistDialog.cpp
+  TAS/GCTASInputWindow.cpp
+  TAS/StickWidget.cpp
 )
 
 list(APPEND LIBS core uicommon)

--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -106,6 +106,8 @@ set(SRCS
   Settings/WiiPane.cpp
   Settings/USBDeviceAddToWhitelistDialog.cpp
   TAS/GCTASInputWindow.cpp
+  TAS/WiiTASInputWindow.cpp
+  TAS/Shared.cpp
   TAS/StickWidget.cpp
 )
 

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -47,7 +47,7 @@
       <AdditionalDependencies>avrt.lib;iphlpapi.lib;winmm.lib;setupapi.lib;opengl32.lib;glu32.lib;rpcrt4.lib;comctl32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)VideoInterface;$(ProjectDir)GameList;$(ProjectDir)Debugger;$(ProjectDir)Settings;$(ProjectDir)Config;$(ProjectDir)Config\Mapping;$(ProjectDir)Config\Graphics;$(ProjectDir)NetPlay;$(ProjectDir)QtUtils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)VideoInterface;$(ProjectDir)GameList;$(ProjectDir)Debugger;$(ProjectDir)Settings;$(ProjectDir)Config;$(ProjectDir)Config\Mapping;$(ProjectDir)Config\Graphics;$(ProjectDir)NetPlay;$(ProjectDir)QtUtils;$(ProjectDir)TAS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Manifest>
       <AdditionalManifestFiles>DolphinQt2.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -87,6 +87,7 @@
     <QtMoc Include="Config\SettingsWindow.h" />
     <QtMoc Include="FIFOPlayerWindow.h" />
     <QtMoc Include="TAS\GCTASInputWindow.h" />
+    <QtMoc Include="TAS\WiiTASInputWindow.h" />
     <QtMoc Include="TAS\StickWidget.h" />
     <QtMoc Include="Debugger\BreakpointWidget.h" />
     <QtMoc Include="Debugger\NewBreakpointDialog.h" />
@@ -135,6 +136,7 @@
     <ClCompile Include="$(QtMocOutPrefix)EnhancementsWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FIFOPlayerWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GCTASInputWindow.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)WiiTASInputWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)StickWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FilesystemWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WindowActivationEventFilter.cpp" />
@@ -226,7 +228,9 @@
     <ClCompile Include="Config\SettingsWindow.cpp" />
     <ClCompile Include="FIFOPlayerWindow.cpp" />
     <ClCompile Include="TAS\GCTASInputWindow.cpp" />
+    <ClCompile Include="TAS\WiiTASInputWindow.cpp" />
     <ClCompile Include="TAS\StickWidget.cpp" />
+    <ClCompile Include="TAS\Shared.cpp" />
     <ClCompile Include="Debugger\BreakpointWidget.cpp" />
     <ClCompile Include="Debugger\NewBreakpointDialog.cpp" />
     <ClCompile Include="Debugger\RegisterColumn.cpp" />
@@ -283,6 +287,7 @@
     <ClInclude Include="Config\Mapping\HotkeyGraphics.h" />
     <ClInclude Include="Config\Mapping\HotkeyStates.h" />
     <ClInclude Include="Config\Mapping\HotkeyTAS.h" />
+    <ClInclude Include="TAS\Shared.h" />
     <ClInclude Include="Config\Mapping\HotkeyWii.h" />
     <ClInclude Include="Config\Mapping\MappingBool.h" />
     <ClInclude Include="Config\Mapping\MappingCommon.h" />

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -89,6 +89,7 @@
     <QtMoc Include="TAS\GCTASInputWindow.h" />
     <QtMoc Include="TAS\WiiTASInputWindow.h" />
     <QtMoc Include="TAS\StickWidget.h" />
+    <QtMoc Include="TAS\IRWidget.h" />
     <QtMoc Include="Debugger\BreakpointWidget.h" />
     <QtMoc Include="Debugger\NewBreakpointDialog.h" />
     <QtMoc Include="Debugger\RegisterWidget.h" />
@@ -138,6 +139,7 @@
     <ClCompile Include="$(QtMocOutPrefix)GCTASInputWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WiiTASInputWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)StickWidget.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)IRWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FilesystemWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WindowActivationEventFilter.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameList.cpp" />
@@ -230,6 +232,7 @@
     <ClCompile Include="TAS\GCTASInputWindow.cpp" />
     <ClCompile Include="TAS\WiiTASInputWindow.cpp" />
     <ClCompile Include="TAS\StickWidget.cpp" />
+    <ClCompile Include="TAS\IRWidget.cpp" />
     <ClCompile Include="TAS\Shared.cpp" />
     <ClCompile Include="Debugger\BreakpointWidget.cpp" />
     <ClCompile Include="Debugger\NewBreakpointDialog.cpp" />

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -86,6 +86,8 @@
     <QtMoc Include="Config\PropertiesDialog.h" />
     <QtMoc Include="Config\SettingsWindow.h" />
     <QtMoc Include="FIFOPlayerWindow.h" />
+    <QtMoc Include="TAS\GCTASInputWindow.h" />
+    <QtMoc Include="TAS\StickWidget.h" />
     <QtMoc Include="Debugger\BreakpointWidget.h" />
     <QtMoc Include="Debugger\NewBreakpointDialog.h" />
     <QtMoc Include="Debugger\RegisterWidget.h" />
@@ -112,6 +114,7 @@
     <QtMoc Include="NetPlay\PadMappingDialog.h" />
     <QtMoc Include="QtUtils\DoubleClickEventFilter.h" />
     <QtMoc Include="QtUtils\WindowActivationEventFilter.h" />
+    <QtMoc Include="QtUtils\AspectRatioWidget.h" />
     <QtMoc Include="RenderWidget.h" />
     <QtMoc Include="Settings.h" />
     <QtMoc Include="Settings\AdvancedPane.h" />
@@ -131,6 +134,8 @@
     <ClCompile Include="$(QtMocOutPrefix)ControllersWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)EnhancementsWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FIFOPlayerWindow.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)GCTASInputWindow.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)StickWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FilesystemWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WindowActivationEventFilter.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameList.cpp" />
@@ -220,6 +225,8 @@
     <ClCompile Include="Config\PropertiesDialog.cpp" />
     <ClCompile Include="Config\SettingsWindow.cpp" />
     <ClCompile Include="FIFOPlayerWindow.cpp" />
+    <ClCompile Include="TAS\GCTASInputWindow.cpp" />
+    <ClCompile Include="TAS\StickWidget.cpp" />
     <ClCompile Include="Debugger\BreakpointWidget.cpp" />
     <ClCompile Include="Debugger\NewBreakpointDialog.cpp" />
     <ClCompile Include="Debugger\RegisterColumn.cpp" />
@@ -249,6 +256,7 @@
     <ClCompile Include="QtUtils\ElidedButton.cpp" />
     <ClCompile Include="QtUtils\ListTabWidget.cpp" />
     <ClCompile Include="QtUtils\WindowActivationEventFilter.cpp" />
+    <ClCompile Include="QtUtils\AspectRatioWidget.cpp" />
     <ClCompile Include="RenderWidget.cpp" />
     <ClCompile Include="Resources.cpp" />
     <ClCompile Include="Settings.cpp" />

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -1099,7 +1099,7 @@ void MainWindow::OnExportRecording()
 
 void MainWindow::ShowTASInput()
 {
-  for (int i = 0; i < 4; i++)
+  for (int i = 0; i < num_gc_controllers; i++)
   {
     if (SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_NONE &&
         SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_GC_GBA)
@@ -1110,7 +1110,7 @@ void MainWindow::ShowTASInput()
     }
   }
 
-  for (int i = 0; i < 4; i++)
+  for (int i = 0; i < num_wii_controllers; i++)
   {
     if (g_wiimote_sources[i] == WIIMOTE_SRC_EMU &&
         (!Core::IsRunning() || SConfig::GetInstance().bWii))

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -34,6 +34,7 @@ class DragEnterEvent;
 class GraphicsWindow;
 class RegisterWidget;
 class WatchWidget;
+class GCTASInputWindow;
 
 class MainWindow final : public QMainWindow
 {
@@ -120,6 +121,7 @@ private:
   void OnStartRecording();
   void OnStopRecording();
   void OnExportRecording();
+  void ShowTASInput();
 
   void EnableScreenSaver(bool enable);
 
@@ -146,6 +148,7 @@ private:
   NetPlayDialog* m_netplay_dialog;
   NetPlaySetupDialog* m_netplay_setup_dialog;
   GraphicsWindow* m_graphics_window;
+  std::array<GCTASInputWindow*, 4> m_gc_tas_input_windows{};
 
   BreakpointWidget* m_breakpoint_widget;
   LogWidget* m_log_widget;

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -35,6 +35,7 @@ class GraphicsWindow;
 class RegisterWidget;
 class WatchWidget;
 class GCTASInputWindow;
+class WiiTASInputWindow;
 
 class MainWindow final : public QMainWindow
 {
@@ -148,7 +149,10 @@ private:
   NetPlayDialog* m_netplay_dialog;
   NetPlaySetupDialog* m_netplay_setup_dialog;
   GraphicsWindow* m_graphics_window;
-  std::array<GCTASInputWindow*, 4> m_gc_tas_input_windows{};
+  static constexpr int num_gc_controllers = 4;
+  std::array<GCTASInputWindow*, num_gc_controllers> m_gc_tas_input_windows{};
+  static constexpr int num_wii_controllers = 4;
+  std::array<WiiTASInputWindow*, num_wii_controllers> m_wii_tas_input_windows{};
 
   BreakpointWidget* m_breakpoint_widget;
   LogWidget* m_log_widget;

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -488,6 +488,8 @@ void MenuBar::AddMovieMenu()
   m_recording_read_only->setChecked(Movie::IsReadOnly());
   connect(m_recording_read_only, &QAction::toggled, [](bool value) { Movie::SetReadOnly(value); });
 
+  AddAction(movie_menu, tr("TAS Input"), this, [this] { emit ShowTASInput(); });
+
   movie_menu->addSeparator();
 
   auto* pause_at_end = movie_menu->addAction(tr("Pause at End of Movie"));

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -87,6 +87,7 @@ signals:
   void StartRecording();
   void StopRecording();
   void ExportRecording();
+  void ShowTASInput();
 
   void SelectionChanged(QSharedPointer<GameFile> game_file);
   void RecordingStatusChanged(bool recording);

--- a/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.cpp
@@ -1,0 +1,45 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+// Based on:
+// https://stackoverflow.com/questions/30005540/keeping-the-aspect-ratio-of-a-sub-classed-qwidget-during-resize
+
+#include "DolphinQt2/QtUtils/AspectRatioWidget.h"
+
+#include <QBoxLayout>
+#include <QResizeEvent>
+
+AspectRatioWidget::AspectRatioWidget(QWidget* widget, float width, float height, QWidget* parent)
+    : QWidget(parent), m_ar_width(width), m_ar_height(height)
+{
+  m_layout = new QBoxLayout(QBoxLayout::LeftToRight, this);
+
+  // add spacer, then your widget, then spacer
+  m_layout->addItem(new QSpacerItem(0, 0));
+  m_layout->addWidget(widget);
+  m_layout->addItem(new QSpacerItem(0, 0));
+}
+
+void AspectRatioWidget::resizeEvent(QResizeEvent* event)
+{
+  float this_aspect_ratio = (float)event->size().width() / event->size().height();
+  int widget_stretch, outer_stretch;
+
+  if (this_aspect_ratio > (m_ar_width / m_ar_height))  // too wide
+  {
+    m_layout->setDirection(QBoxLayout::LeftToRight);
+    widget_stretch = height() * (m_ar_width / m_ar_height);  // i.e., my width
+    outer_stretch = (width() - widget_stretch) / 2 + 0.5;
+  }
+  else  // too tall
+  {
+    m_layout->setDirection(QBoxLayout::TopToBottom);
+    widget_stretch = width() * (m_ar_height / m_ar_width);  // i.e., my height
+    outer_stretch = (height() - widget_stretch) / 2 + 0.5;
+  }
+
+  m_layout->setStretch(0, outer_stretch);
+  m_layout->setStretch(1, widget_stretch);
+  m_layout->setStretch(2, outer_stretch);
+}

--- a/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.cpp
@@ -23,10 +23,10 @@ AspectRatioWidget::AspectRatioWidget(QWidget* widget, float width, float height,
 
 void AspectRatioWidget::resizeEvent(QResizeEvent* event)
 {
-  float this_aspect_ratio = (float)event->size().width() / event->size().height();
+  float aspect_ratio = static_cast<float>(event->size().width()) / event->size().height();
   int widget_stretch, outer_stretch;
 
-  if (this_aspect_ratio > (m_ar_width / m_ar_height))  // too wide
+  if (aspect_ratio > (m_ar_width / m_ar_height))  // too wide
   {
     m_layout->setDirection(QBoxLayout::LeftToRight);
     widget_stretch = height() * (m_ar_width / m_ar_height);  // i.e., my width

--- a/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.h
+++ b/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.h
@@ -1,0 +1,21 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+class QBoxLayout;
+
+class AspectRatioWidget : public QWidget
+{
+public:
+  AspectRatioWidget(QWidget* widget, float width, float height, QWidget* parent = 0);
+  void resizeEvent(QResizeEvent* event);
+
+private:
+  QBoxLayout* m_layout;
+  float m_ar_width;
+  float m_ar_height;
+};

--- a/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.h
+++ b/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.h
@@ -11,7 +11,7 @@ class QBoxLayout;
 class AspectRatioWidget : public QWidget
 {
 public:
-  AspectRatioWidget(QWidget* widget, float width, float height, QWidget* parent = 0);
+  AspectRatioWidget(QWidget* widget, float width, float height, QWidget* parent = nullptr);
   void resizeEvent(QResizeEvent* event);
 
 private:

--- a/Source/Core/DolphinQt2/TAS/GCTASInputWindow.cpp
+++ b/Source/Core/DolphinQt2/TAS/GCTASInputWindow.cpp
@@ -10,32 +10,32 @@
 #include <QCheckBox>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QSpinBox>
 #include <QVBoxLayout>
 
-#include <algorithm>
-
-GCTASInputWindow::GCTASInputWindow(QWidget* parent) : QDialog(parent)
+GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : QDialog(parent)
 {
-  auto* main_stick_box = CreateStickInputs(this, tr("Main Stick ALT+F/G"), &m_x_main_stick_byte,
-                                           &m_y_main_stick_byte, 255, 255, Qt::Key_F, Qt::Key_G);
-  auto* c_stick_box = CreateStickInputs(this, tr("C Stick ALT+H/J"), &m_x_c_stick_byte,
-                                        &m_y_c_stick_byte, 255, 255, Qt::Key_H, Qt::Key_J);
+  setWindowTitle(tr("GameCube TAS Input %1").arg(num + 1));
+  auto* main_stick_box = CreateStickInputs(this, tr("Main Stick (ALT+F/G)"), m_x_main_stick_value,
+                                           m_y_main_stick_value, 255, 255, Qt::Key_F, Qt::Key_G);
+  auto* c_stick_box = CreateStickInputs(this, tr("C Stick (ALT+H/J)"), m_x_c_stick_value,
+                                        m_y_c_stick_value, 255, 255, Qt::Key_H, Qt::Key_J);
 
   auto* top_layout = new QHBoxLayout;
   top_layout->addWidget(main_stick_box);
   top_layout->addWidget(c_stick_box);
 
-  auto* l_trigger_layout = new QHBoxLayout;
-  m_l_trigger_byte = CreateTriggerInputs(this, l_trigger_layout, Qt::Key_N, Qt::Horizontal);
+  auto* triggers_box = new QGroupBox(tr("Triggers"));
 
-  auto* l_trigger_box = new QGroupBox(tr("Left Trigger ALT+N"));
-  l_trigger_box->setLayout(l_trigger_layout);
+  auto* l_trigger_layout = CreateSliderValuePairLayout(this, tr("Left (ALT+N)"), m_l_trigger_value,
+                                                       255, Qt::Key_N, triggers_box);
+  auto* r_trigger_layout = CreateSliderValuePairLayout(
+      this, tr("Right (ALT+M)"), m_r_trigger_value, 255, Qt::Key_M, triggers_box);
 
-  auto* r_trigger_layout = new QHBoxLayout;
-  m_r_trigger_byte = CreateTriggerInputs(this, r_trigger_layout, Qt::Key_M, Qt::Horizontal);
-
-  auto* r_trigger_box = new QGroupBox(tr("Right Trigger ALT+M"));
-  r_trigger_box->setLayout(r_trigger_layout);
+  auto* triggers_layout = new QVBoxLayout;
+  triggers_layout->addLayout(l_trigger_layout);
+  triggers_layout->addLayout(r_trigger_layout);
+  triggers_box->setLayout(triggers_layout);
 
   m_a_button = new QCheckBox(QStringLiteral("&A"));
   m_b_button = new QCheckBox(QStringLiteral("&B"));
@@ -76,11 +76,18 @@ GCTASInputWindow::GCTASInputWindow(QWidget* parent) : QDialog(parent)
 
   auto* layout = new QVBoxLayout;
   layout->addLayout(top_layout);
-  layout->addWidget(l_trigger_box);
-  layout->addWidget(r_trigger_box);
+  layout->addWidget(triggers_box);
   layout->addWidget(buttons_box);
 
   setLayout(layout);
+}
+
+static void SetButton(QCheckBox* button, GCPadStatus* pad, u16 mask)
+{
+  if (button->isChecked())
+    pad->button |= mask;
+  else
+    pad->button &= ~mask;
 }
 
 void GCTASInputWindow::GetValues(GCPadStatus* pad)
@@ -111,11 +118,11 @@ void GCTASInputWindow::GetValues(GCPadStatus* pad)
   else
     pad->analogB = 0x00;
 
-  pad->triggerLeft = m_l_trigger_byte->value();
-  pad->triggerRight = m_r_trigger_byte->value();
+  pad->triggerLeft = m_l_trigger_value->value();
+  pad->triggerRight = m_r_trigger_value->value();
 
-  pad->stickX = m_x_main_stick_byte->value();
-  pad->stickY = m_y_main_stick_byte->value();
-  pad->substickX = m_x_c_stick_byte->value();
-  pad->substickY = m_y_c_stick_byte->value();
+  pad->stickX = m_x_main_stick_value->value();
+  pad->stickY = m_y_main_stick_value->value();
+  pad->substickX = m_x_c_stick_value->value();
+  pad->substickY = m_y_c_stick_value->value();
 }

--- a/Source/Core/DolphinQt2/TAS/GCTASInputWindow.cpp
+++ b/Source/Core/DolphinQt2/TAS/GCTASInputWindow.cpp
@@ -3,15 +3,16 @@
 // Refer to the license.txt file included.
 
 #include "DolphinQt2/TAS/GCTASInputWindow.h"
-#include "Common/CommonTypes.h"
-#include "DolphinQt2/TAS/Shared.h"
-#include "InputCommon/GCPadStatus.h"
 
 #include <QCheckBox>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QSpinBox>
 #include <QVBoxLayout>
+
+#include "Common/CommonTypes.h"
+#include "DolphinQt2/TAS/Shared.h"
+#include "InputCommon/GCPadStatus.h"
 
 GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : QDialog(parent)
 {
@@ -29,8 +30,8 @@ GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : QDialog(parent)
 
   auto* l_trigger_layout = CreateSliderValuePairLayout(this, tr("Left (ALT+N)"), m_l_trigger_value,
                                                        255, Qt::Key_N, triggers_box);
-  auto* r_trigger_layout = CreateSliderValuePairLayout(
-      this, tr("Right (ALT+M)"), m_r_trigger_value, 255, Qt::Key_M, triggers_box);
+  auto* r_trigger_layout = CreateSliderValuePairLayout(this, tr("Right (ALT+M)"), m_r_trigger_value,
+                                                       255, Qt::Key_M, triggers_box);
 
   auto* triggers_layout = new QVBoxLayout;
   triggers_layout->addLayout(l_trigger_layout);

--- a/Source/Core/DolphinQt2/TAS/GCTASInputWindow.cpp
+++ b/Source/Core/DolphinQt2/TAS/GCTASInputWindow.cpp
@@ -1,0 +1,121 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/TAS/GCTASInputWindow.h"
+#include "Common/CommonTypes.h"
+#include "DolphinQt2/TAS/Shared.h"
+#include "InputCommon/GCPadStatus.h"
+
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include <algorithm>
+
+GCTASInputWindow::GCTASInputWindow(QWidget* parent) : QDialog(parent)
+{
+  auto* main_stick_box = CreateStickInputs(this, tr("Main Stick ALT+F/G"), &m_x_main_stick_byte,
+                                           &m_y_main_stick_byte, 255, 255, Qt::Key_F, Qt::Key_G);
+  auto* c_stick_box = CreateStickInputs(this, tr("C Stick ALT+H/J"), &m_x_c_stick_byte,
+                                        &m_y_c_stick_byte, 255, 255, Qt::Key_H, Qt::Key_J);
+
+  auto* top_layout = new QHBoxLayout;
+  top_layout->addWidget(main_stick_box);
+  top_layout->addWidget(c_stick_box);
+
+  auto* l_trigger_layout = new QHBoxLayout;
+  m_l_trigger_byte = CreateTriggerInputs(this, l_trigger_layout, Qt::Key_N, Qt::Horizontal);
+
+  auto* l_trigger_box = new QGroupBox(tr("Left Trigger ALT+N"));
+  l_trigger_box->setLayout(l_trigger_layout);
+
+  auto* r_trigger_layout = new QHBoxLayout;
+  m_r_trigger_byte = CreateTriggerInputs(this, r_trigger_layout, Qt::Key_M, Qt::Horizontal);
+
+  auto* r_trigger_box = new QGroupBox(tr("Right Trigger ALT+M"));
+  r_trigger_box->setLayout(r_trigger_layout);
+
+  m_a_button = new QCheckBox(QStringLiteral("&A"));
+  m_b_button = new QCheckBox(QStringLiteral("&B"));
+  m_x_button = new QCheckBox(QStringLiteral("&X"));
+  m_y_button = new QCheckBox(QStringLiteral("&Y"));
+  m_z_button = new QCheckBox(QStringLiteral("&Z"));
+  m_l_button = new QCheckBox(QStringLiteral("&L"));
+  m_r_button = new QCheckBox(QStringLiteral("&R"));
+  m_start_button = new QCheckBox(QStringLiteral("&START"));
+  m_left_button = new QCheckBox(QStringLiteral("L&eft"));
+  m_up_button = new QCheckBox(QStringLiteral("&Up"));
+  m_down_button = new QCheckBox(QStringLiteral("&Down"));
+  m_right_button = new QCheckBox(QStringLiteral("R&ight"));
+
+  auto* buttons_layout1 = new QHBoxLayout;
+  buttons_layout1->addWidget(m_a_button);
+  buttons_layout1->addWidget(m_b_button);
+  buttons_layout1->addWidget(m_x_button);
+  buttons_layout1->addWidget(m_y_button);
+  buttons_layout1->addWidget(m_z_button);
+  buttons_layout1->addWidget(m_l_button);
+  buttons_layout1->addWidget(m_r_button);
+
+  auto* buttons_layout2 = new QHBoxLayout;
+  buttons_layout2->addWidget(m_start_button);
+  buttons_layout2->addWidget(m_left_button);
+  buttons_layout2->addWidget(m_up_button);
+  buttons_layout2->addWidget(m_down_button);
+  buttons_layout2->addWidget(m_right_button);
+
+  auto* buttons_layout = new QVBoxLayout;
+  buttons_layout->setSizeConstraint(QLayout::SetFixedSize);
+  buttons_layout->addLayout(buttons_layout1);
+  buttons_layout->addLayout(buttons_layout2);
+
+  auto* buttons_box = new QGroupBox(tr("Buttons"));
+  buttons_box->setLayout(buttons_layout);
+
+  auto* layout = new QVBoxLayout;
+  layout->addLayout(top_layout);
+  layout->addWidget(l_trigger_box);
+  layout->addWidget(r_trigger_box);
+  layout->addWidget(buttons_box);
+
+  setLayout(layout);
+}
+
+void GCTASInputWindow::GetValues(GCPadStatus* pad)
+{
+  if (!isVisible())
+    return;
+
+  SetButton(m_a_button, pad, PAD_BUTTON_A);
+  SetButton(m_b_button, pad, PAD_BUTTON_B);
+  SetButton(m_x_button, pad, PAD_BUTTON_X);
+  SetButton(m_y_button, pad, PAD_BUTTON_Y);
+  SetButton(m_z_button, pad, PAD_TRIGGER_Z);
+  SetButton(m_l_button, pad, PAD_TRIGGER_L);
+  SetButton(m_r_button, pad, PAD_TRIGGER_R);
+  SetButton(m_left_button, pad, PAD_BUTTON_LEFT);
+  SetButton(m_up_button, pad, PAD_BUTTON_UP);
+  SetButton(m_down_button, pad, PAD_BUTTON_DOWN);
+  SetButton(m_right_button, pad, PAD_BUTTON_RIGHT);
+  SetButton(m_start_button, pad, PAD_BUTTON_START);
+
+  if (m_a_button->isChecked())
+    pad->analogA = 0xFF;
+  else
+    pad->analogA = 0x00;
+
+  if (m_b_button->isChecked())
+    pad->analogB = 0xFF;
+  else
+    pad->analogB = 0x00;
+
+  pad->triggerLeft = m_l_trigger_byte->value();
+  pad->triggerRight = m_r_trigger_byte->value();
+
+  pad->stickX = m_x_main_stick_byte->value();
+  pad->stickY = m_y_main_stick_byte->value();
+  pad->substickX = m_x_c_stick_byte->value();
+  pad->substickY = m_y_c_stick_byte->value();
+}

--- a/Source/Core/DolphinQt2/TAS/GCTASInputWindow.h
+++ b/Source/Core/DolphinQt2/TAS/GCTASInputWindow.h
@@ -1,0 +1,41 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include "Common/CommonTypes.h"
+
+class QCheckBox;
+class QSpinBox;
+struct GCPadStatus;
+
+class GCTASInputWindow : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit GCTASInputWindow(QWidget* parent);
+  void GetValues(GCPadStatus* pad);
+
+private:
+  QCheckBox* m_a_button;
+  QCheckBox* m_b_button;
+  QCheckBox* m_x_button;
+  QCheckBox* m_y_button;
+  QCheckBox* m_z_button;
+  QCheckBox* m_l_button;
+  QCheckBox* m_r_button;
+  QCheckBox* m_start_button;
+  QCheckBox* m_left_button;
+  QCheckBox* m_up_button;
+  QCheckBox* m_down_button;
+  QCheckBox* m_right_button;
+  QSpinBox* m_l_trigger_byte;
+  QSpinBox* m_r_trigger_byte;
+  QSpinBox* m_x_main_stick_byte;
+  QSpinBox* m_y_main_stick_byte;
+  QSpinBox* m_x_c_stick_byte;
+  QSpinBox* m_y_c_stick_byte;
+};

--- a/Source/Core/DolphinQt2/TAS/GCTASInputWindow.h
+++ b/Source/Core/DolphinQt2/TAS/GCTASInputWindow.h
@@ -16,7 +16,7 @@ class GCTASInputWindow : public QDialog
 {
   Q_OBJECT
 public:
-  explicit GCTASInputWindow(QWidget* parent);
+  explicit GCTASInputWindow(QWidget* parent, int num);
   void GetValues(GCPadStatus* pad);
 
 private:
@@ -32,10 +32,10 @@ private:
   QCheckBox* m_up_button;
   QCheckBox* m_down_button;
   QCheckBox* m_right_button;
-  QSpinBox* m_l_trigger_byte;
-  QSpinBox* m_r_trigger_byte;
-  QSpinBox* m_x_main_stick_byte;
-  QSpinBox* m_y_main_stick_byte;
-  QSpinBox* m_x_c_stick_byte;
-  QSpinBox* m_y_c_stick_byte;
+  QSpinBox* m_l_trigger_value;
+  QSpinBox* m_r_trigger_value;
+  QSpinBox* m_x_main_stick_value;
+  QSpinBox* m_y_main_stick_value;
+  QSpinBox* m_x_c_stick_value;
+  QSpinBox* m_y_c_stick_value;
 };

--- a/Source/Core/DolphinQt2/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt2/TAS/IRWidget.cpp
@@ -18,14 +18,14 @@ IRWidget::IRWidget(QWidget* parent) : QWidget(parent)
 
 void IRWidget::SetX(u16 x)
 {
-  m_x = std::min(max_x, x);
+  m_x = std::min(ir_max_x, x);
 
   update();
 }
 
 void IRWidget::SetY(u16 y)
 {
-  m_y = std::min(max_y, y);
+  m_y = std::min(ir_max_y, y);
 
   update();
 }
@@ -41,8 +41,8 @@ void IRWidget::paintEvent(QPaintEvent* event)
   painter.drawLine(width() / 2, 0, width() / 2, height());
 
   // convert from value space to widget space
-  u16 x = width() - (m_x * width()) / max_x;
-  u16 y = (m_y * height()) / max_y;
+  u16 x = width() - (m_x * width()) / ir_max_x;
+  u16 y = (m_y * height()) / ir_max_y;
 
   painter.drawLine(width() / 2, height() / 2, x, y);
 
@@ -65,11 +65,11 @@ void IRWidget::mouseMoveEvent(QMouseEvent* event)
 void IRWidget::handleMouseEvent(QMouseEvent* event)
 {
   // convert from widget space to value space
-  int new_x = max_x - (event->x() * max_x) / width();
-  int new_y = (event->y() * max_y) / height();
+  int new_x = ir_max_x - (event->x() * ir_max_x) / width();
+  int new_y = (event->y() * ir_max_y) / height();
 
-  m_x = std::max(0, std::min(static_cast<int>(max_x), new_x));
-  m_y = std::max(0, std::min(static_cast<int>(max_y), new_y));
+  m_x = std::max(0, std::min(static_cast<int>(ir_max_x), new_x));
+  m_y = std::max(0, std::min(static_cast<int>(ir_max_y), new_y));
 
   emit ChangedX(m_x);
   emit ChangedY(m_y);

--- a/Source/Core/DolphinQt2/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt2/TAS/IRWidget.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "DolphinQt2/TAS/StickWidget.h"
+#include "DolphinQt2/TAS/IRWidget.h"
 
 #include <algorithm>
 
@@ -11,39 +11,38 @@
 
 #include "Common/CommonTypes.h"
 
-StickWidget::StickWidget(QWidget* parent, u16 max_x, u16 max_y)
-    : QWidget(parent), m_max_x(max_x), m_max_y(max_y)
+IRWidget::IRWidget(QWidget* parent) : QWidget(parent)
 {
   setMouseTracking(false);
 }
 
-void StickWidget::SetX(u16 x)
+void IRWidget::SetX(u16 x)
 {
-  m_x = std::min(m_max_x, x);
+  m_x = std::min(max_x, x);
 
   update();
 }
 
-void StickWidget::SetY(u16 y)
+void IRWidget::SetY(u16 y)
 {
-  m_y = std::min(m_max_y, y);
+  m_y = std::min(max_y, y);
 
   update();
 }
 
-void StickWidget::paintEvent(QPaintEvent* event)
+void IRWidget::paintEvent(QPaintEvent* event)
 {
   QPainter painter(this);
 
   painter.setBrush(Qt::white);
-  painter.drawEllipse(0, 0, width() - 1, height() - 1);
+  painter.drawRect(0, 0, width() - 1, height() - 1);
 
   painter.drawLine(0, height() / 2, width(), height() / 2);
   painter.drawLine(width() / 2, 0, width() / 2, height());
 
   // convert from value space to widget space
-  u16 x = (m_x * width()) / m_max_x;
-  u16 y = height() - (m_y * height()) / m_max_y;
+  u16 x = width() - (m_x * width()) / max_x;
+  u16 y = (m_y * height()) / max_y;
 
   painter.drawLine(width() / 2, height() / 2, x, y);
 
@@ -53,24 +52,24 @@ void StickWidget::paintEvent(QPaintEvent* event)
   painter.drawEllipse(x - radius, y - radius, radius * 2, radius * 2);
 }
 
-void StickWidget::mousePressEvent(QMouseEvent* event)
+void IRWidget::mousePressEvent(QMouseEvent* event)
 {
   handleMouseEvent(event);
 }
 
-void StickWidget::mouseMoveEvent(QMouseEvent* event)
+void IRWidget::mouseMoveEvent(QMouseEvent* event)
 {
   handleMouseEvent(event);
 }
 
-void StickWidget::handleMouseEvent(QMouseEvent* event)
+void IRWidget::handleMouseEvent(QMouseEvent* event)
 {
   // convert from widget space to value space
-  int new_x = (event->x() * m_max_x) / width();
-  int new_y = m_max_y - (event->y() * m_max_y) / height();
+  int new_x = max_x - (event->x() * max_x) / width();
+  int new_y = (event->y() * max_y) / height();
 
-  m_x = std::max(0, std::min(static_cast<int>(m_max_x), new_x));
-  m_y = std::max(0, std::min(static_cast<int>(m_max_y), new_y));
+  m_x = std::max(0, std::min(static_cast<int>(max_x), new_x));
+  m_y = std::max(0, std::min(static_cast<int>(max_y), new_y));
 
   emit ChangedX(m_x);
   emit ChangedY(m_y);

--- a/Source/Core/DolphinQt2/TAS/IRWidget.h
+++ b/Source/Core/DolphinQt2/TAS/IRWidget.h
@@ -1,0 +1,38 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include "Common/CommonTypes.h"
+
+class IRWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit IRWidget(QWidget* parent);
+
+signals:
+  void ChangedX(u16 x);
+  void ChangedY(u16 y);
+
+public slots:
+  void SetX(u16 x);
+  void SetY(u16 y);
+
+protected:
+  void paintEvent(QPaintEvent* event) override;
+  void mousePressEvent(QMouseEvent* event) override;
+  void mouseMoveEvent(QMouseEvent* event) override;
+  void handleMouseEvent(QMouseEvent* event);
+
+public:
+  static constexpr u16 max_x = 1023;
+  static constexpr u16 max_y = 767;
+
+private:
+  u16 m_x = 0;
+  u16 m_y = 0;
+};

--- a/Source/Core/DolphinQt2/TAS/IRWidget.h
+++ b/Source/Core/DolphinQt2/TAS/IRWidget.h
@@ -28,11 +28,11 @@ protected:
   void mouseMoveEvent(QMouseEvent* event) override;
   void handleMouseEvent(QMouseEvent* event);
 
-public:
-  static constexpr u16 max_x = 1023;
-  static constexpr u16 max_y = 767;
-
 private:
   u16 m_x = 0;
   u16 m_y = 0;
 };
+
+// Should be part of class but fails to compile on mac os
+static const u16 ir_max_x = 1023;
+static const u16 ir_max_y = 767;

--- a/Source/Core/DolphinQt2/TAS/Shared.cpp
+++ b/Source/Core/DolphinQt2/TAS/Shared.cpp
@@ -3,10 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "DolphinQt2/TAS/Shared.h"
-#include "Common/CommonTypes.h"
-#include "DolphinQt2/QtUtils/AspectRatioWidget.h"
-#include "DolphinQt2/TAS/StickWidget.h"
-#include "InputCommon/GCPadStatus.h"
 
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -15,6 +11,11 @@
 #include <QSlider>
 #include <QSpinBox>
 #include <QVBoxLayout>
+
+#include "Common/CommonTypes.h"
+#include "DolphinQt2/QtUtils/AspectRatioWidget.h"
+#include "DolphinQt2/TAS/StickWidget.h"
+#include "InputCommon/GCPadStatus.h"
 
 QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox*& x_value, QSpinBox*& y_value,
                              u16 max_x, u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key)
@@ -26,7 +27,7 @@ QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox*& x_value, 
 
   auto* y_layout = new QVBoxLayout;
   y_value = CreateSliderValuePair(window, y_layout, max_y, y_shortcut_key, Qt::Vertical, box);
-  (y_value)->setMaximumWidth(60);
+  y_value->setMaximumWidth(60);
 
   auto* visual = new StickWidget(window, max_x, max_y);
   window->connect(x_value, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), visual,
@@ -36,8 +37,8 @@ QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox*& x_value, 
   window->connect(visual, &StickWidget::ChangedX, x_value, &QSpinBox::setValue);
   window->connect(visual, &StickWidget::ChangedY, y_value, &QSpinBox::setValue);
 
-  (x_value)->setValue(max_x / 2);
-  (y_value)->setValue(max_y / 2);
+  x_value->setValue(max_x / 2);
+  y_value->setValue(max_y / 2);
 
   auto* visual_ar = new AspectRatioWidget(visual, max_x, max_y);
 
@@ -52,16 +53,17 @@ QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox*& x_value, 
 
   return box;
 }
+
 QBoxLayout* CreateSliderValuePairLayout(QDialog* window, QString name, QSpinBox*& value, u16 max,
-                                        Qt::Key shortcut_key, QWidget* shortcut_widget)
+                                        Qt::Key shortcut_key, QWidget* shortcut_widget, bool invert)
 {
   auto* label = new QLabel(name);
 
   QBoxLayout* layout = new QHBoxLayout;
   layout->addWidget(label);
 
-  value =
-      CreateSliderValuePair(window, layout, max, shortcut_key, Qt::Horizontal, shortcut_widget);
+  value = CreateSliderValuePair(window, layout, max, shortcut_key, Qt::Horizontal, shortcut_widget,
+                                invert);
 
   return layout;
 }
@@ -69,7 +71,7 @@ QBoxLayout* CreateSliderValuePairLayout(QDialog* window, QString name, QSpinBox*
 // The shortcut_widget argument needs to specify the container widget that will be hidden/shown.
 // This is done to avoid ambigous shortcuts
 QSpinBox* CreateSliderValuePair(QDialog* window, QBoxLayout* layout, u16 max, Qt::Key shortcut_key,
-                                Qt::Orientation orientation, QWidget* shortcut_widget)
+                                Qt::Orientation orientation, QWidget* shortcut_widget, bool invert)
 {
   auto* value = new QSpinBox();
   value->setRange(0, 99999);
@@ -81,6 +83,7 @@ QSpinBox* CreateSliderValuePair(QDialog* window, QBoxLayout* layout, u16 max, Qt
   auto* slider = new QSlider(orientation);
   slider->setRange(0, max);
   slider->setFocusPolicy(Qt::ClickFocus);
+  slider->setInvertedAppearance(invert);
 
   window->connect(slider, &QSlider::valueChanged, value, &QSpinBox::setValue);
   window->connect(value, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), slider,

--- a/Source/Core/DolphinQt2/TAS/Shared.cpp
+++ b/Source/Core/DolphinQt2/TAS/Shared.cpp
@@ -1,0 +1,101 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/TAS/Shared.h"
+#include "Common/CommonTypes.h"
+#include "DolphinQt2/QtUtils/AspectRatioWidget.h"
+#include "DolphinQt2/TAS/StickWidget.h"
+#include "InputCommon/GCPadStatus.h"
+
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QShortcut>
+#include <QSlider>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox*& x_value, QSpinBox*& y_value,
+                             u16 max_x, u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key)
+{
+  auto* box = new QGroupBox(name);
+
+  auto* x_layout = new QHBoxLayout;
+  x_value = CreateSliderValuePair(window, x_layout, max_x, x_shortcut_key, Qt::Horizontal, box);
+
+  auto* y_layout = new QVBoxLayout;
+  y_value = CreateSliderValuePair(window, y_layout, max_y, y_shortcut_key, Qt::Vertical, box);
+  (y_value)->setMaximumWidth(60);
+
+  auto* visual = new StickWidget(window, max_x, max_y);
+  window->connect(x_value, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), visual,
+                  &StickWidget::SetX);
+  window->connect(y_value, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), visual,
+                  &StickWidget::SetY);
+  window->connect(visual, &StickWidget::ChangedX, x_value, &QSpinBox::setValue);
+  window->connect(visual, &StickWidget::ChangedY, y_value, &QSpinBox::setValue);
+
+  (x_value)->setValue(max_x / 2);
+  (y_value)->setValue(max_y / 2);
+
+  auto* visual_ar = new AspectRatioWidget(visual, max_x, max_y);
+
+  auto* visual_layout = new QHBoxLayout;
+  visual_layout->addWidget(visual_ar);
+  visual_layout->addLayout(y_layout);
+
+  auto* layout = new QVBoxLayout;
+  layout->addLayout(x_layout);
+  layout->addLayout(visual_layout);
+  box->setLayout(layout);
+
+  return box;
+}
+QBoxLayout* CreateSliderValuePairLayout(QDialog* window, QString name, QSpinBox*& value, u16 max,
+                                        Qt::Key shortcut_key, QWidget* shortcut_widget)
+{
+  auto* label = new QLabel(name);
+
+  QBoxLayout* layout = new QHBoxLayout;
+  layout->addWidget(label);
+
+  value =
+      CreateSliderValuePair(window, layout, max, shortcut_key, Qt::Horizontal, shortcut_widget);
+
+  return layout;
+}
+
+// The shortcut_widget argument needs to specify the container widget that will be hidden/shown.
+// This is done to avoid ambigous shortcuts
+QSpinBox* CreateSliderValuePair(QDialog* window, QBoxLayout* layout, u16 max, Qt::Key shortcut_key,
+                                Qt::Orientation orientation, QWidget* shortcut_widget)
+{
+  auto* value = new QSpinBox();
+  value->setRange(0, 99999);
+  window->connect(value, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+                  [value, max](int i) {
+                    if (i > max)
+                      value->setValue(max);
+                  });
+  auto* slider = new QSlider(orientation);
+  slider->setRange(0, max);
+  slider->setFocusPolicy(Qt::ClickFocus);
+
+  window->connect(slider, &QSlider::valueChanged, value, &QSpinBox::setValue);
+  window->connect(value, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), slider,
+                  &QSlider::setValue);
+
+  auto* shortcut = new QShortcut(QKeySequence(Qt::ALT + shortcut_key), shortcut_widget);
+  window->connect(shortcut, &QShortcut::activated, [value] {
+    value->setFocus();
+    value->selectAll();
+  });
+
+  layout->addWidget(slider);
+  layout->addWidget(value);
+  if (orientation == Qt::Vertical)
+    layout->setAlignment(slider, Qt::AlignRight);
+
+  return value;
+}

--- a/Source/Core/DolphinQt2/TAS/Shared.h
+++ b/Source/Core/DolphinQt2/TAS/Shared.h
@@ -1,0 +1,112 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+#include "DolphinQt2/QtUtils/AspectRatioWidget.h"
+#include "DolphinQt2/TAS/StickWidget.h"
+#include "InputCommon/GCPadStatus.h"
+
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QShortcut>
+#include <QSlider>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox** x_byte, QSpinBox** y_byte,
+                             u16 max_x, u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key);
+QSpinBox* CreateTriggerInputs(QDialog* window, QBoxLayout* layout, Qt::Key shortcut_key,
+                              Qt::Orientation orientation);
+QSpinBox* CreateByteBox(QDialog* window);
+void SetButton(QCheckBox* button, GCPadStatus* pad, u16 mask);
+
+QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox** x_byte, QSpinBox** y_byte,
+                             u16 max_x, u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key)
+{
+  auto* x_layout = new QHBoxLayout;
+  *x_byte = CreateTriggerInputs(window, x_layout, x_shortcut_key, Qt::Horizontal);
+
+  auto* y_layout = new QVBoxLayout;
+  *y_byte = CreateTriggerInputs(window, y_layout, y_shortcut_key, Qt::Vertical);
+  (*y_byte)->setMaximumWidth(60);
+
+  auto* visual = new StickWidget(window, max_x, max_y);
+  window->connect(*x_byte, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), visual,
+                  &StickWidget::SetX);
+  window->connect(*y_byte, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), visual,
+                  &StickWidget::SetY);
+  window->connect(visual, &StickWidget::ChangedX, *x_byte, &QSpinBox::setValue);
+  window->connect(visual, &StickWidget::ChangedY, *y_byte, &QSpinBox::setValue);
+
+  (*x_byte)->setValue(max_x / 2);
+  (*y_byte)->setValue(max_y / 2);
+
+  auto* visual_ar = new AspectRatioWidget(visual, max_x, max_y);
+
+  auto* visual_layout = new QHBoxLayout;
+  visual_layout->addWidget(visual_ar);
+  visual_layout->addLayout(y_layout);
+
+  auto* layout = new QVBoxLayout;
+  layout->addLayout(x_layout);
+  layout->addLayout(visual_layout);
+
+  auto* box = new QGroupBox(name);
+  box->setLayout(layout);
+
+  return box;
+}
+
+QSpinBox* CreateTriggerInputs(QDialog* window, QBoxLayout* layout, Qt::Key shortcut_key,
+                              Qt::Orientation orientation)
+{
+  auto* byte = CreateByteBox(window);
+  auto* slider = new QSlider(orientation);
+  slider->setRange(0, 255);
+  slider->setFocusPolicy(Qt::ClickFocus);
+
+  window->connect(slider, &QSlider::valueChanged, byte, &QSpinBox::setValue);
+  window->connect(byte, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), slider,
+                  &QSlider::setValue);
+
+  auto* shortcut = new QShortcut(QKeySequence(Qt::ALT + shortcut_key), window);
+  window->connect(shortcut, &QShortcut::activated, [byte] {
+    byte->setFocus();
+    byte->selectAll();
+  });
+
+  layout->addWidget(slider);
+  layout->addWidget(byte);
+  if (orientation == Qt::Vertical)
+    layout->setAlignment(slider, Qt::AlignRight);
+
+  return byte;
+}
+
+// In cases where there are multiple widgets setup to sync the same value
+// the spinbox is considered the master that other widgets should set/get from
+
+QSpinBox* CreateByteBox(QDialog* window)
+{
+  auto* byte_box = new QSpinBox();
+  byte_box->setRange(0, 9999);
+  window->connect(byte_box, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+                  [byte_box](int i) {
+                    if (i > 255)
+                      byte_box->setValue(255);
+                  });
+
+  return byte_box;
+}
+
+void SetButton(QCheckBox* button, GCPadStatus* pad, u16 mask)
+{
+  if (button->isChecked())
+    pad->button |= mask;
+  else
+    pad->button &= ~mask;
+}

--- a/Source/Core/DolphinQt2/TAS/Shared.h
+++ b/Source/Core/DolphinQt2/TAS/Shared.h
@@ -5,108 +5,20 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-#include "DolphinQt2/QtUtils/AspectRatioWidget.h"
-#include "DolphinQt2/TAS/StickWidget.h"
-#include "InputCommon/GCPadStatus.h"
 
-#include <QCheckBox>
-#include <QGroupBox>
-#include <QHBoxLayout>
-#include <QShortcut>
-#include <QSlider>
-#include <QSpinBox>
-#include <QVBoxLayout>
+#include <QWidget>
 
-QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox** x_byte, QSpinBox** y_byte,
+class QDialog;
+class QString;
+class QSpinBox;
+class QCheckBox;
+class QBoxLayout;
+class QGroupBox;
+struct GCPadStatus;
+
+QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox*& x_value, QSpinBox*& y_value,
                              u16 max_x, u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key);
-QSpinBox* CreateTriggerInputs(QDialog* window, QBoxLayout* layout, Qt::Key shortcut_key,
-                              Qt::Orientation orientation);
-QSpinBox* CreateByteBox(QDialog* window);
-void SetButton(QCheckBox* button, GCPadStatus* pad, u16 mask);
-
-QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox** x_byte, QSpinBox** y_byte,
-                             u16 max_x, u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key)
-{
-  auto* x_layout = new QHBoxLayout;
-  *x_byte = CreateTriggerInputs(window, x_layout, x_shortcut_key, Qt::Horizontal);
-
-  auto* y_layout = new QVBoxLayout;
-  *y_byte = CreateTriggerInputs(window, y_layout, y_shortcut_key, Qt::Vertical);
-  (*y_byte)->setMaximumWidth(60);
-
-  auto* visual = new StickWidget(window, max_x, max_y);
-  window->connect(*x_byte, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), visual,
-                  &StickWidget::SetX);
-  window->connect(*y_byte, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), visual,
-                  &StickWidget::SetY);
-  window->connect(visual, &StickWidget::ChangedX, *x_byte, &QSpinBox::setValue);
-  window->connect(visual, &StickWidget::ChangedY, *y_byte, &QSpinBox::setValue);
-
-  (*x_byte)->setValue(max_x / 2);
-  (*y_byte)->setValue(max_y / 2);
-
-  auto* visual_ar = new AspectRatioWidget(visual, max_x, max_y);
-
-  auto* visual_layout = new QHBoxLayout;
-  visual_layout->addWidget(visual_ar);
-  visual_layout->addLayout(y_layout);
-
-  auto* layout = new QVBoxLayout;
-  layout->addLayout(x_layout);
-  layout->addLayout(visual_layout);
-
-  auto* box = new QGroupBox(name);
-  box->setLayout(layout);
-
-  return box;
-}
-
-QSpinBox* CreateTriggerInputs(QDialog* window, QBoxLayout* layout, Qt::Key shortcut_key,
-                              Qt::Orientation orientation)
-{
-  auto* byte = CreateByteBox(window);
-  auto* slider = new QSlider(orientation);
-  slider->setRange(0, 255);
-  slider->setFocusPolicy(Qt::ClickFocus);
-
-  window->connect(slider, &QSlider::valueChanged, byte, &QSpinBox::setValue);
-  window->connect(byte, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), slider,
-                  &QSlider::setValue);
-
-  auto* shortcut = new QShortcut(QKeySequence(Qt::ALT + shortcut_key), window);
-  window->connect(shortcut, &QShortcut::activated, [byte] {
-    byte->setFocus();
-    byte->selectAll();
-  });
-
-  layout->addWidget(slider);
-  layout->addWidget(byte);
-  if (orientation == Qt::Vertical)
-    layout->setAlignment(slider, Qt::AlignRight);
-
-  return byte;
-}
-
-// In cases where there are multiple widgets setup to sync the same value
-// the spinbox is considered the master that other widgets should set/get from
-
-QSpinBox* CreateByteBox(QDialog* window)
-{
-  auto* byte_box = new QSpinBox();
-  byte_box->setRange(0, 9999);
-  window->connect(byte_box, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
-                  [byte_box](int i) {
-                    if (i > 255)
-                      byte_box->setValue(255);
-                  });
-
-  return byte_box;
-}
-
-void SetButton(QCheckBox* button, GCPadStatus* pad, u16 mask)
-{
-  if (button->isChecked())
-    pad->button |= mask;
-  else
-    pad->button &= ~mask;
-}
+QBoxLayout* CreateSliderValuePairLayout(QDialog* window, QString name, QSpinBox*& value, u16 max,
+                                        Qt::Key shortcut_key, QWidget* shortcut_widget);
+QSpinBox* CreateSliderValuePair(QDialog* window, QBoxLayout* layout, u16 max, Qt::Key shortcut_key,
+                                Qt::Orientation orientation, QWidget* shortcut_widget);

--- a/Source/Core/DolphinQt2/TAS/Shared.h
+++ b/Source/Core/DolphinQt2/TAS/Shared.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "Common/CommonTypes.h"
-
 #include <QWidget>
+
+#include "Common/CommonTypes.h"
 
 class QDialog;
 class QString;
@@ -19,6 +19,8 @@ struct GCPadStatus;
 QGroupBox* CreateStickInputs(QDialog* window, QString name, QSpinBox*& x_value, QSpinBox*& y_value,
                              u16 max_x, u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key);
 QBoxLayout* CreateSliderValuePairLayout(QDialog* window, QString name, QSpinBox*& value, u16 max,
-                                        Qt::Key shortcut_key, QWidget* shortcut_widget);
+                                        Qt::Key shortcut_key, QWidget* shortcut_widget,
+                                        bool invert = false);
 QSpinBox* CreateSliderValuePair(QDialog* window, QBoxLayout* layout, u16 max, Qt::Key shortcut_key,
-                                Qt::Orientation orientation, QWidget* shortcut_widget);
+                                Qt::Orientation orientation, QWidget* shortcut_widget,
+                                bool invert = false);

--- a/Source/Core/DolphinQt2/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt2/TAS/StickWidget.cpp
@@ -4,20 +4,14 @@
 
 #include "DolphinQt2/TAS/StickWidget.h"
 #include "Common/CommonTypes.h"
-#include "InputCommon/GCPadStatus.h"
 
 #include <QMouseEvent>
 #include <QPainter>
 
 #include <algorithm>
 
-StickWidget::StickWidget(QWidget* parent, u16 max_x, u16 max_y) : QWidget(parent)
+StickWidget::StickWidget(QWidget* parent, u16 max_x, u16 max_y) : QWidget(parent), m_max_x(max_x), m_max_y(max_y)
 {
-  m_max_x = max_x;
-  m_max_y = max_y;
-  m_x = 0;
-  m_y = 0;
-
   setMouseTracking(false);
 }
 
@@ -70,11 +64,11 @@ void StickWidget::mouseMoveEvent(QMouseEvent* event)
 void StickWidget::handleMouseEvent(QMouseEvent* event)
 {
   // convert from widget space to value space
-  int new_x = ((int)event->x() * m_max_x) / width();
-  int new_y = m_max_y - ((int)event->y() * m_max_y) / height();
+  int new_x = (event->x() * m_max_x) / width();
+  int new_y = m_max_y - (event->y() * m_max_y) / height();
 
-  m_x = std::max(0, std::min((int)m_max_x, new_x));
-  m_y = std::max(0, std::min((int)m_max_y, new_y));
+  m_x = std::max(0, std::min(static_cast<int>(m_max_x), new_x));
+  m_y = std::max(0, std::min(static_cast<int>(m_max_y), new_y));
 
   emit ChangedX(m_x);
   emit ChangedY(m_y);

--- a/Source/Core/DolphinQt2/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt2/TAS/StickWidget.cpp
@@ -1,0 +1,82 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/TAS/StickWidget.h"
+#include "Common/CommonTypes.h"
+#include "InputCommon/GCPadStatus.h"
+
+#include <QMouseEvent>
+#include <QPainter>
+
+#include <algorithm>
+
+StickWidget::StickWidget(QWidget* parent, u16 max_x, u16 max_y) : QWidget(parent)
+{
+  m_max_x = max_x;
+  m_max_y = max_y;
+  m_x = 0;
+  m_y = 0;
+
+  setMouseTracking(false);
+}
+
+void StickWidget::SetX(u16 x)
+{
+  m_x = std::min(m_max_x, x);
+
+  update();
+}
+
+void StickWidget::SetY(u16 y)
+{
+  m_y = std::min(m_max_y, y);
+
+  update();
+}
+
+void StickWidget::paintEvent(QPaintEvent* event)
+{
+  QPainter painter(this);
+
+  painter.setBrush(Qt::white);
+  painter.drawEllipse(0, 0, width() - 1, height() - 1);
+
+  painter.drawLine(0, height() / 2, width(), height() / 2);
+  painter.drawLine(width() / 2, 0, width() / 2, height());
+
+  // convert from value space to widget space
+  u16 x = (m_x * width()) / m_max_x;
+  u16 y = height() - (m_y * height()) / m_max_y;
+
+  painter.drawLine(width() / 2, height() / 2, x, y);
+
+  painter.setBrush(Qt::blue);
+  int wh_avg = (width() + height()) / 2;
+  int radius = wh_avg / 30;
+  painter.drawEllipse(x - radius, y - radius, radius * 2, radius * 2);
+}
+
+void StickWidget::mousePressEvent(QMouseEvent* event)
+{
+  handleMouseEvent(event);
+}
+
+void StickWidget::mouseMoveEvent(QMouseEvent* event)
+{
+  handleMouseEvent(event);
+}
+
+void StickWidget::handleMouseEvent(QMouseEvent* event)
+{
+  // convert from widget space to value space
+  int new_x = ((int)event->x() * m_max_x) / width();
+  int new_y = m_max_y - ((int)event->y() * m_max_y) / height();
+
+  m_x = std::max(0, std::min((int)m_max_x, new_x));
+  m_y = std::max(0, std::min((int)m_max_y, new_y));
+
+  emit ChangedX(m_x);
+  emit ChangedY(m_y);
+  update();
+}

--- a/Source/Core/DolphinQt2/TAS/StickWidget.h
+++ b/Source/Core/DolphinQt2/TAS/StickWidget.h
@@ -8,12 +8,6 @@
 
 #include "Common/CommonTypes.h"
 
-class QBoxLayout;
-class QCheckBox;
-class QGroupBox;
-class QSpinBox;
-struct GCPadStatus;
-
 class StickWidget : public QWidget
 {
   Q_OBJECT
@@ -37,6 +31,6 @@ protected:
 private:
   u16 m_max_x;
   u16 m_max_y;
-  u16 m_x;
-  u16 m_y;
+  u16 m_x = 0;
+  u16 m_y = 0;
 };

--- a/Source/Core/DolphinQt2/TAS/StickWidget.h
+++ b/Source/Core/DolphinQt2/TAS/StickWidget.h
@@ -1,0 +1,42 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include "Common/CommonTypes.h"
+
+class QBoxLayout;
+class QCheckBox;
+class QGroupBox;
+class QSpinBox;
+struct GCPadStatus;
+
+class StickWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit StickWidget(QWidget* parent, u16 width, u16 height);
+
+signals:
+  void ChangedX(u16 x);
+  void ChangedY(u16 y);
+
+public slots:
+  void SetX(u16 x);
+  void SetY(u16 y);
+
+protected:
+  void paintEvent(QPaintEvent* event) override;
+  void mousePressEvent(QMouseEvent* event) override;
+  void mouseMoveEvent(QMouseEvent* event) override;
+  void handleMouseEvent(QMouseEvent* event);
+
+private:
+  u16 m_max_x;
+  u16 m_max_y;
+  u16 m_x;
+  u16 m_y;
+};

--- a/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.cpp
@@ -1,0 +1,431 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/TAS/WiiTASInputWindow.h"
+#include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
+#include "Core/Core.h"
+#include "Core/HW/WiimoteEmu/Attachment/Classic.h"
+#include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"
+#include "Core/HW/WiimoteReal/WiimoteReal.h"
+#include "DolphinQt2/TAS/Shared.h"
+#include "InputCommon/InputConfig.h"
+
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : QDialog(parent), m_num(num)
+{
+  m_ir_box = CreateStickInputs(this, tr("IR (ALT+F/G)"), m_ir_x_value, m_ir_y_value, 1023, 767,
+                               Qt::Key_F, Qt::Key_G);
+  m_nunchuk_stick_box =
+      CreateStickInputs(this, tr("Nunchuk Stick (ALT+X/Y)"), m_nunchuk_stick_x_value,
+                        m_nunchuk_stick_y_value, 255, 255, Qt::Key_X, Qt::Key_Y);
+
+  m_classic_left_stick_box =
+      CreateStickInputs(this, tr("Left Stick (ALT+F/G)"), m_classic_left_stick_x_value,
+                        m_classic_left_stick_y_value, 63, 63, Qt::Key_F, Qt::Key_G);
+
+  m_classic_right_stick_box =
+      CreateStickInputs(this, tr("Right Stick (ALT+Q/W)"), m_classic_right_stick_x_value,
+                        m_classic_right_stick_y_value, 31, 31, Qt::Key_Q, Qt::Key_W);
+
+  // Need to enforce the same minimum width because otherwise the different lengths in the labels
+  // used on the QGroupBox will cause the StickWidgets to have different sizes.
+  m_ir_box->setMinimumWidth(20);
+  m_nunchuk_stick_box->setMinimumWidth(20);
+
+  m_remote_orientation_box = new QGroupBox(tr("Remote Orientation"));
+
+  auto* top_layout = new QHBoxLayout;
+  top_layout->addWidget(m_ir_box);
+  top_layout->addWidget(m_nunchuk_stick_box);
+  top_layout->addWidget(m_classic_left_stick_box);
+  top_layout->addWidget(m_classic_right_stick_box);
+
+  auto* remote_orientation_x_layout =
+      CreateSliderValuePairLayout(this, tr("X (ALT+Q)"), m_remote_orientation_x_value, 1023,
+                                  Qt::Key_Q, m_remote_orientation_box);
+  auto* remote_orientation_y_layout =
+      CreateSliderValuePairLayout(this, tr("Y (ALT+W)"), m_remote_orientation_y_value, 1023,
+                                  Qt::Key_W, m_remote_orientation_box);
+  auto* remote_orientation_z_layout =
+      CreateSliderValuePairLayout(this, tr("Z (ALT+E)"), m_remote_orientation_z_value, 1023,
+                                  Qt::Key_E, m_remote_orientation_box);
+
+  auto* remote_orientation_layout = new QVBoxLayout;
+  remote_orientation_layout->addLayout(remote_orientation_x_layout);
+  remote_orientation_layout->addLayout(remote_orientation_y_layout);
+  remote_orientation_layout->addLayout(remote_orientation_z_layout);
+  m_remote_orientation_box->setLayout(remote_orientation_layout);
+
+  m_nunchuk_orientation_box = new QGroupBox(tr("Nunchuk Orientation"));
+
+  auto* nunchuk_orientation_x_layout =
+      CreateSliderValuePairLayout(this, tr("X (ALT+I)"), m_nunchuk_orientation_x_value, 1023,
+                                  Qt::Key_I, m_nunchuk_orientation_box);
+  auto* nunchuk_orientation_y_layout =
+      CreateSliderValuePairLayout(this, tr("Y (ALT+O)"), m_nunchuk_orientation_y_value, 1023,
+                                  Qt::Key_O, m_nunchuk_orientation_box);
+  auto* nunchuk_orientation_z_layout =
+      CreateSliderValuePairLayout(this, tr("Z (ALT+P)"), m_nunchuk_orientation_z_value, 1023,
+                                  Qt::Key_P, m_nunchuk_orientation_box);
+
+  auto* nunchuk_orientation_layout = new QVBoxLayout;
+  nunchuk_orientation_layout->addLayout(nunchuk_orientation_x_layout);
+  nunchuk_orientation_layout->addLayout(nunchuk_orientation_y_layout);
+  nunchuk_orientation_layout->addLayout(nunchuk_orientation_z_layout);
+  m_nunchuk_orientation_box->setLayout(nunchuk_orientation_layout);
+
+  m_triggers_box = new QGroupBox(tr("Triggers"));
+  auto* l_trigger_layout = CreateSliderValuePairLayout(
+      this, tr("Left (ALT+N)"), m_left_trigger_value, 31, Qt::Key_N, m_triggers_box);
+  auto* r_trigger_layout = CreateSliderValuePairLayout(
+      this, tr("Right (ALT+M)"), m_right_trigger_value, 31, Qt::Key_M, m_triggers_box);
+
+  auto* triggers_layout = new QVBoxLayout;
+  triggers_layout->addLayout(l_trigger_layout);
+  triggers_layout->addLayout(r_trigger_layout);
+  m_triggers_box->setLayout(triggers_layout);
+
+  m_a_button = new QCheckBox(QStringLiteral("&A"));
+  m_b_button = new QCheckBox(QStringLiteral("&B"));
+  m_1_button = new QCheckBox(QStringLiteral("&1"));
+  m_2_button = new QCheckBox(QStringLiteral("&2"));
+  m_plus_button = new QCheckBox(QStringLiteral("&+"));
+  m_minus_button = new QCheckBox(QStringLiteral("&-"));
+  m_home_button = new QCheckBox(QStringLiteral("&HOME"));
+  m_left_button = new QCheckBox(QStringLiteral("&Left"));
+  m_up_button = new QCheckBox(QStringLiteral("&Up"));
+  m_down_button = new QCheckBox(QStringLiteral("&Down"));
+  m_right_button = new QCheckBox(QStringLiteral("&Right"));
+  m_c_button = new QCheckBox(QStringLiteral("&C"));
+  m_z_button = new QCheckBox(QStringLiteral("&Z"));
+
+  auto* buttons_layout1 = new QHBoxLayout;
+  buttons_layout1->addWidget(m_a_button);
+  buttons_layout1->addWidget(m_b_button);
+  buttons_layout1->addWidget(m_1_button);
+  buttons_layout1->addWidget(m_2_button);
+  buttons_layout1->addWidget(m_plus_button);
+  buttons_layout1->addWidget(m_minus_button);
+
+  auto* buttons_layout2 = new QHBoxLayout;
+  buttons_layout2->addWidget(m_home_button);
+  buttons_layout2->addWidget(m_left_button);
+  buttons_layout2->addWidget(m_up_button);
+  buttons_layout2->addWidget(m_down_button);
+  buttons_layout2->addWidget(m_right_button);
+
+  auto* remote_buttons_layout = new QVBoxLayout;
+  remote_buttons_layout->setSizeConstraint(QLayout::SetFixedSize);
+  remote_buttons_layout->addLayout(buttons_layout1);
+  remote_buttons_layout->addLayout(buttons_layout2);
+
+  m_remote_buttons_box = new QGroupBox(tr("Remote Buttons"));
+  m_remote_buttons_box->setLayout(remote_buttons_layout);
+
+  auto* nunchuk_buttons_layout = new QHBoxLayout;
+  nunchuk_buttons_layout->addWidget(m_c_button);
+  nunchuk_buttons_layout->addWidget(m_z_button);
+
+  m_nunchuk_buttons_box = new QGroupBox(tr("Nunchuk Buttons"));
+  m_nunchuk_buttons_box->setLayout(nunchuk_buttons_layout);
+
+  m_classic_a_button = new QCheckBox(QStringLiteral("&A"));
+  m_classic_b_button = new QCheckBox(QStringLiteral("&B"));
+  m_classic_x_button = new QCheckBox(QStringLiteral("&X"));
+  m_classic_y_button = new QCheckBox(QStringLiteral("&Y"));
+  m_classic_l_button = new QCheckBox(QStringLiteral("&L"));
+  m_classic_r_button = new QCheckBox(QStringLiteral("&R"));
+  m_classic_zl_button = new QCheckBox(QStringLiteral("&ZL"));
+  m_classic_zr_button = new QCheckBox(QStringLiteral("ZR"));
+  m_classic_plus_button = new QCheckBox(QStringLiteral("&+"));
+  m_classic_minus_button = new QCheckBox(QStringLiteral("&-"));
+  m_classic_home_button = new QCheckBox(QStringLiteral("&HOME"));
+  m_classic_left_button = new QCheckBox(QStringLiteral("L&eft"));
+  m_classic_up_button = new QCheckBox(QStringLiteral("&Up"));
+  m_classic_down_button = new QCheckBox(QStringLiteral("&Down"));
+  m_classic_right_button = new QCheckBox(QStringLiteral("R&ight"));
+
+  auto* classic_buttons_layout1 = new QHBoxLayout;
+  classic_buttons_layout1->addWidget(m_classic_a_button);
+  classic_buttons_layout1->addWidget(m_classic_b_button);
+  classic_buttons_layout1->addWidget(m_classic_x_button);
+  classic_buttons_layout1->addWidget(m_classic_y_button);
+  classic_buttons_layout1->addWidget(m_classic_l_button);
+  classic_buttons_layout1->addWidget(m_classic_r_button);
+  classic_buttons_layout1->addWidget(m_classic_zl_button);
+  classic_buttons_layout1->addWidget(m_classic_zr_button);
+
+  auto* classic_buttons_layout2 = new QHBoxLayout;
+  classic_buttons_layout2->addWidget(m_classic_plus_button);
+  classic_buttons_layout2->addWidget(m_classic_minus_button);
+  classic_buttons_layout2->addWidget(m_classic_home_button);
+  classic_buttons_layout2->addWidget(m_classic_left_button);
+  classic_buttons_layout2->addWidget(m_classic_up_button);
+  classic_buttons_layout2->addWidget(m_classic_down_button);
+  classic_buttons_layout2->addWidget(m_classic_right_button);
+
+  auto* classic_buttons_layout = new QVBoxLayout;
+  classic_buttons_layout->setSizeConstraint(QLayout::SetFixedSize);
+  classic_buttons_layout->addLayout(classic_buttons_layout1);
+  classic_buttons_layout->addLayout(classic_buttons_layout2);
+
+  m_classic_buttons_box = new QGroupBox(tr("Classic Buttons"));
+  m_classic_buttons_box->setLayout(classic_buttons_layout);
+
+  auto* layout = new QVBoxLayout;
+  layout->addLayout(top_layout);
+  layout->addWidget(m_remote_orientation_box);
+  layout->addWidget(m_nunchuk_orientation_box);
+  layout->addWidget(m_triggers_box);
+  layout->addWidget(m_remote_buttons_box);
+  layout->addWidget(m_nunchuk_buttons_box);
+  layout->addWidget(m_classic_buttons_box);
+  layout->setAlignment(m_nunchuk_buttons_box, Qt::AlignLeft);
+
+  setLayout(layout);
+
+  u8 ext = 0;
+  if (Core::IsRunning())
+  {
+    ext = static_cast<WiimoteEmu::Wiimote*>(Wiimote::GetConfig()->GetController(num))
+              ->CurrentExtension();
+  }
+  else
+  {
+    IniFile ini;
+    ini.Load(File::GetUserPath(D_CONFIG_IDX) + "WiimoteNew.ini");
+    std::string extension;
+    ini.GetIfExists("Wiimote" + std::to_string(num + 1), "Extension", &extension);
+
+    if (extension == "Nunchuk")
+      ext = 1;
+    if (extension == "Classic")
+      ext = 2;
+  }
+  UpdateExt(ext);
+}
+
+void WiiTASInputWindow::UpdateExt(u8 ext)
+{
+  if (ext == 1)
+  {
+    setWindowTitle(tr("Wii TAS Input %1 - Remote + Nunchuk").arg(m_num + 1));
+    m_ir_box->show();
+    m_nunchuk_stick_box->show();
+    m_classic_right_stick_box->hide();
+    m_classic_left_stick_box->hide();
+    m_remote_orientation_box->show();
+    m_nunchuk_orientation_box->show();
+    m_triggers_box->hide();
+    m_nunchuk_buttons_box->show();
+    m_remote_buttons_box->show();
+    m_classic_buttons_box->hide();
+  }
+  else if (ext == 2)
+  {
+    setWindowTitle(tr("Wii TAS Input %1 - Classic Controller").arg(m_num + 1));
+    m_ir_box->hide();
+    m_nunchuk_stick_box->hide();
+    m_classic_right_stick_box->show();
+    m_classic_left_stick_box->show();
+    m_remote_orientation_box->hide();
+    m_nunchuk_orientation_box->hide();
+    m_triggers_box->show();
+    m_remote_buttons_box->hide();
+    m_nunchuk_buttons_box->hide();
+    m_classic_buttons_box->show();
+  }
+  else
+  {
+    setWindowTitle(tr("Wii TAS Input %1 - Remote").arg(m_num + 1));
+    m_ir_box->show();
+    m_nunchuk_stick_box->hide();
+    m_classic_right_stick_box->hide();
+    m_classic_left_stick_box->hide();
+    m_remote_orientation_box->show();
+    m_nunchuk_orientation_box->hide();
+    m_triggers_box->hide();
+    m_remote_buttons_box->show();
+    m_nunchuk_buttons_box->hide();
+    m_classic_buttons_box->hide();
+  }
+}
+
+template <typename ux> static void SetButton(QCheckBox* check_box, ux* buttons, ux mask)
+{
+  if (check_box->isChecked())
+    *buttons |= mask;
+  else
+    *buttons &= ~mask;
+}
+
+void WiiTASInputWindow::GetValues(u8* report_data, WiimoteEmu::ReportFeatures rptf, int ext,
+                                  const wiimote_key key)
+{
+  if (!isVisible())
+    return;
+
+  UpdateExt(ext);
+
+  u8* const buttons_data = rptf.core ? (report_data + rptf.core) : nullptr;
+  u8* const accel_data = rptf.accel ? (report_data + rptf.accel) : nullptr;
+  u8* const ir_data = rptf.ir ? (report_data + rptf.ir) : nullptr;
+  u8* const ext_data = rptf.ext ? (report_data + rptf.ext) : nullptr;
+
+  if (m_remote_buttons_box->isVisible() && buttons_data)
+  {
+    u16* buttons = &((wm_buttons*)buttons_data)->hex;
+    SetButton<u16>(m_a_button, buttons, WiimoteEmu::Wiimote::BUTTON_A);
+    SetButton<u16>(m_b_button, buttons, WiimoteEmu::Wiimote::BUTTON_B);
+    SetButton<u16>(m_1_button, buttons, WiimoteEmu::Wiimote::BUTTON_ONE);
+    SetButton<u16>(m_2_button, buttons, WiimoteEmu::Wiimote::BUTTON_TWO);
+    SetButton<u16>(m_plus_button, buttons, WiimoteEmu::Wiimote::BUTTON_PLUS);
+    SetButton<u16>(m_minus_button, buttons, WiimoteEmu::Wiimote::BUTTON_MINUS);
+    SetButton<u16>(m_home_button, buttons, WiimoteEmu::Wiimote::BUTTON_HOME);
+    SetButton<u16>(m_left_button, buttons, WiimoteEmu::Wiimote::PAD_LEFT);
+    SetButton<u16>(m_up_button, buttons, WiimoteEmu::Wiimote::PAD_UP);
+    SetButton<u16>(m_down_button, buttons, WiimoteEmu::Wiimote::PAD_DOWN);
+    SetButton<u16>(m_right_button, buttons, WiimoteEmu::Wiimote::PAD_RIGHT);
+  }
+
+  if (m_remote_orientation_box->isVisible() && accel_data && buttons_data)
+  {
+    wm_accel& accel = *(wm_accel*)accel_data;
+    wm_buttons& buttons = *(wm_buttons*)buttons_data;
+
+    accel.x = m_remote_orientation_x_value->value() >> 2;
+    accel.y = m_remote_orientation_y_value->value() >> 2;
+    accel.z = m_remote_orientation_z_value->value() >> 2;
+
+    buttons.acc_x_lsb = m_remote_orientation_x_value->value() & 0x3;
+    buttons.acc_y_lsb = m_remote_orientation_y_value->value() >> 1 & 0x1;
+    buttons.acc_z_lsb = m_remote_orientation_z_value->value() >> 1 & 0x1;
+  }
+
+  if (m_ir_box->isVisible() && ir_data)
+  {
+    u16 y = m_ir_y_value->value();
+    std::array<u16, 4> x;
+    x[0] = m_ir_x_value->value();
+    x[1] = x[0] + 100;
+    x[2] = x[0] - 10;
+    x[3] = x[1] + 10;
+
+    u8 mode;
+    // Mode 5 not supported in core anyway.
+    if (rptf.ext)
+      mode = (rptf.ext - rptf.ir) == 10 ? 1 : 3;
+    else
+      mode = (rptf.size - rptf.ir) == 10 ? 1 : 3;
+
+    if (mode == 1)
+    {
+      memset(ir_data, 0xFF, sizeof(wm_ir_basic) * 2);
+      wm_ir_basic* const ir_basic = (wm_ir_basic*)ir_data;
+      for (int i = 0; i < 2; ++i)
+      {
+        if (x[i * 2] < 1024 && y < 768)
+        {
+          ir_basic[i].x1 = static_cast<u8>(x[i * 2]);
+          ir_basic[i].x1hi = x[i * 2] >> 8;
+
+          ir_basic[i].y1 = static_cast<u8>(y);
+          ir_basic[i].y1hi = y >> 8;
+        }
+        if (x[i * 2 + 1] < 1024 && y < 768)
+        {
+          ir_basic[i].x2 = static_cast<u8>(x[i * 2 + 1]);
+          ir_basic[i].x2hi = x[i * 2 + 1] >> 8;
+
+          ir_basic[i].y2 = static_cast<u8>(y);
+          ir_basic[i].y2hi = y >> 8;
+        }
+      }
+    }
+    else
+    {
+      // TODO: this code doesnt work, resulting in no IR TAS inputs in e.g. wii sports menu when no
+      // remote extension is used
+      memset(ir_data, 0xFF, sizeof(wm_ir_extended) * 4);
+      wm_ir_extended* const ir_extended = (wm_ir_extended*)ir_data;
+      for (size_t i = 0; i < x.size(); ++i)
+      {
+        if (x[i] < 1024 && y < 768)
+        {
+          ir_extended[i].x = static_cast<u8>(x[i]);
+          ir_extended[i].xhi = x[i] >> 8;
+
+          ir_extended[i].y = static_cast<u8>(y);
+          ir_extended[i].yhi = y >> 8;
+
+          ir_extended[i].size = 10;
+        }
+      }
+    }
+  }
+
+  if (ext_data && m_nunchuk_stick_box->isVisible())
+  {
+    wm_nc& nunchuk = *(wm_nc*)ext_data;
+    nunchuk.jx = m_nunchuk_stick_x_value->value();
+    nunchuk.jy = m_nunchuk_stick_y_value->value();
+
+    nunchuk.ax = m_nunchuk_orientation_x_value->value() >> 2;
+    nunchuk.bt.acc_x_lsb = m_nunchuk_orientation_x_value->value() & 0x3;
+    nunchuk.ay = m_nunchuk_orientation_y_value->value() >> 2;
+    nunchuk.bt.acc_y_lsb = m_nunchuk_orientation_y_value->value() & 0x3;
+    nunchuk.az = m_nunchuk_orientation_z_value->value() >> 2;
+    nunchuk.bt.acc_z_lsb = m_nunchuk_orientation_z_value->value() & 0x3;
+
+    SetButton<u8>(m_c_button, &nunchuk.bt.hex, WiimoteEmu::Nunchuk::BUTTON_C);
+    SetButton<u8>(m_z_button, &nunchuk.bt.hex, WiimoteEmu::Nunchuk::BUTTON_Z);
+    nunchuk.bt.hex ^= 0x3;
+
+    WiimoteEncrypt(&key, (u8*)&nunchuk, 0, sizeof(wm_nc));
+  }
+
+  if (m_classic_left_stick_box->isVisible())
+  {
+    wm_classic_extension& cc = *(wm_classic_extension*)ext_data;
+    WiimoteDecrypt(&key, (u8*)&cc, 0, sizeof(wm_classic_extension));
+    cc.bt.hex = 0;
+
+    SetButton<u16>(m_classic_a_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_A);
+    SetButton<u16>(m_classic_b_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_B);
+    SetButton<u16>(m_classic_x_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_X);
+    SetButton<u16>(m_classic_y_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_Y);
+    SetButton<u16>(m_classic_plus_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_PLUS);
+    SetButton<u16>(m_classic_minus_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_MINUS);
+    SetButton<u16>(m_classic_l_button, &cc.bt.hex, WiimoteEmu::Classic::TRIGGER_L);
+    SetButton<u16>(m_classic_r_button, &cc.bt.hex, WiimoteEmu::Classic::TRIGGER_R);
+    SetButton<u16>(m_classic_zl_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_ZL);
+    SetButton<u16>(m_classic_zr_button, &cc.bt.hex, WiimoteEmu::Classic::BUTTON_ZR);
+    SetButton<u16>(m_classic_left_button, &cc.bt.hex, WiimoteEmu::Classic::PAD_LEFT);
+    SetButton<u16>(m_classic_up_button, &cc.bt.hex, WiimoteEmu::Classic::PAD_UP);
+    SetButton<u16>(m_classic_down_button, &cc.bt.hex, WiimoteEmu::Classic::PAD_DOWN);
+    SetButton<u16>(m_classic_right_button, &cc.bt.hex, WiimoteEmu::Classic::PAD_RIGHT);
+    cc.bt.hex ^= 0xFFFF;
+
+    u16 rx = m_classic_right_stick_x_value->value();
+    cc.rx1 = rx & 0x1;
+    cc.rx2 = (rx >> 1) & 0x3;
+    cc.rx3 = (rx >> 3) & 0x3;
+    cc.ry = m_classic_right_stick_y_value->value();
+
+    cc.regular_data.lx = m_classic_left_stick_x_value->value();
+    cc.regular_data.ly = m_classic_left_stick_y_value->value();
+
+    cc.rt = m_right_trigger_value->value();
+    cc.lt1 = m_left_trigger_value->value() & 0x7;
+    cc.lt2 = (m_left_trigger_value->value() >> 3) & 0x3;
+
+    WiimoteEncrypt(&key, (u8*)&cc, 0, sizeof(wm_classic_extension));
+  }
+}

--- a/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.cpp
@@ -28,11 +28,11 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : QDialog(parent)
   m_ir_box = new QGroupBox(tr("IR (ALT+F/G)"));
 
   auto* x_layout = new QHBoxLayout;
-  m_ir_x_value = CreateSliderValuePair(this, x_layout, IRWidget::max_x, Qt::Key_F, Qt::Horizontal,
+  m_ir_x_value = CreateSliderValuePair(this, x_layout, ir_max_x, Qt::Key_F, Qt::Horizontal,
                                        m_ir_box, true);
 
   auto* y_layout = new QVBoxLayout;
-  m_ir_y_value = CreateSliderValuePair(this, y_layout, IRWidget::max_y, Qt::Key_G, Qt::Vertical,
+  m_ir_y_value = CreateSliderValuePair(this, y_layout, ir_max_y, Qt::Key_G, Qt::Vertical,
                                        m_ir_box, true);
   m_ir_y_value->setMaximumWidth(60);
 
@@ -44,10 +44,10 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : QDialog(parent)
   connect(visual, &IRWidget::ChangedX, m_ir_x_value, &QSpinBox::setValue);
   connect(visual, &IRWidget::ChangedY, m_ir_y_value, &QSpinBox::setValue);
 
-  m_ir_x_value->setValue(IRWidget::max_x / 2);
-  m_ir_y_value->setValue(IRWidget::max_y / 2);
+  m_ir_x_value->setValue(ir_max_x / 2);
+  m_ir_y_value->setValue(ir_max_y / 2);
 
-  auto* visual_ar = new AspectRatioWidget(visual, IRWidget::max_x, IRWidget::max_y);
+  auto* visual_ar = new AspectRatioWidget(visual, ir_max_x, ir_max_y);
 
   auto* visual_layout = new QHBoxLayout;
   visual_layout->addWidget(visual_ar);

--- a/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.h
+++ b/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.h
@@ -1,0 +1,80 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include "Common/CommonTypes.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+
+class QCheckBox;
+class QSpinBox;
+class QGroupBox;
+
+class WiiTASInputWindow : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit WiiTASInputWindow(QWidget* parent, int num);
+  void GetValues(u8* input_data, WiimoteEmu::ReportFeatures rptf, int ext, const wiimote_key key);
+
+private:
+  void UpdateExt(u8 ext);
+  int m_num;
+  QCheckBox* m_a_button;
+  QCheckBox* m_b_button;
+  QCheckBox* m_1_button;
+  QCheckBox* m_2_button;
+  QCheckBox* m_plus_button;
+  QCheckBox* m_minus_button;
+  QCheckBox* m_home_button;
+  QCheckBox* m_left_button;
+  QCheckBox* m_up_button;
+  QCheckBox* m_down_button;
+  QCheckBox* m_right_button;
+  QCheckBox* m_c_button;
+  QCheckBox* m_z_button;
+  QCheckBox* m_classic_a_button;
+  QCheckBox* m_classic_b_button;
+  QCheckBox* m_classic_x_button;
+  QCheckBox* m_classic_y_button;
+  QCheckBox* m_classic_plus_button;
+  QCheckBox* m_classic_minus_button;
+  QCheckBox* m_classic_l_button;
+  QCheckBox* m_classic_r_button;
+  QCheckBox* m_classic_zl_button;
+  QCheckBox* m_classic_zr_button;
+  QCheckBox* m_classic_home_button;
+  QCheckBox* m_classic_left_button;
+  QCheckBox* m_classic_up_button;
+  QCheckBox* m_classic_down_button;
+  QCheckBox* m_classic_right_button;
+  QSpinBox* m_remote_orientation_x_value;
+  QSpinBox* m_remote_orientation_y_value;
+  QSpinBox* m_remote_orientation_z_value;
+  QSpinBox* m_nunchuk_orientation_x_value;
+  QSpinBox* m_nunchuk_orientation_y_value;
+  QSpinBox* m_nunchuk_orientation_z_value;
+  QSpinBox* m_ir_x_value;
+  QSpinBox* m_ir_y_value;
+  QSpinBox* m_nunchuk_stick_x_value;
+  QSpinBox* m_nunchuk_stick_y_value;
+  QSpinBox* m_classic_left_stick_x_value;
+  QSpinBox* m_classic_left_stick_y_value;
+  QSpinBox* m_classic_right_stick_x_value;
+  QSpinBox* m_classic_right_stick_y_value;
+  QSpinBox* m_left_trigger_value;
+  QSpinBox* m_right_trigger_value;
+  QGroupBox* m_remote_orientation_box;
+  QGroupBox* m_nunchuk_orientation_box;
+  QGroupBox* m_ir_box;
+  QGroupBox* m_nunchuk_stick_box;
+  QGroupBox* m_classic_left_stick_box;
+  QGroupBox* m_classic_right_stick_box;
+  QGroupBox* m_remote_buttons_box;
+  QGroupBox* m_nunchuk_buttons_box;
+  QGroupBox* m_classic_buttons_box;
+  QGroupBox* m_triggers_box;
+};

--- a/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.h
+++ b/Source/Core/DolphinQt2/TAS/WiiTASInputWindow.h
@@ -7,18 +7,22 @@
 #include <QDialog>
 
 #include "Common/CommonTypes.h"
-#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
+namespace WiimoteEmu
+{
+struct ReportFeatures;
+}
 class QCheckBox;
-class QSpinBox;
 class QGroupBox;
+class QSpinBox;
+struct wiimote_key;
 
 class WiiTASInputWindow : public QDialog
 {
   Q_OBJECT
 public:
   explicit WiiTASInputWindow(QWidget* parent, int num);
-  void GetValues(u8* input_data, WiimoteEmu::ReportFeatures rptf, int ext, const wiimote_key key);
+  void GetValues(u8* input_data, WiimoteEmu::ReportFeatures rptf, int ext, wiimote_key key);
 
 private:
   void UpdateExt(u8 ext);

--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -819,7 +819,9 @@ void TASInputDlg::GetValues(u8* data, WiimoteEmu::ReportFeatures rptf, int ext,
       }
       else
       {
-        memset(data, 0xFF, sizeof(wm_ir_extended) * 4);
+        // TODO: this code doesnt work, resulting in no IR TAS inputs in e.g. wii sports menu when
+        // no remote extension is used
+        memset(irData, 0xFF, sizeof(wm_ir_extended) * 4);
         wm_ir_extended* const ir_data = (wm_ir_extended*)irData;
         for (size_t i = 0; i < x.size(); ++i)
         {


### PR DESCRIPTION
Implements TAS windows for Wii and GC.

The code for IR when a wii remote is configured to have no extension is broken in wx.
I dont know how to fully fix it but I did change it to stop clobbering the button inputs.

The (ALT+?/?) tells the user the shortcut to focus that input box.

![qt_finished](https://user-images.githubusercontent.com/5120858/35797781-ed88fa04-0ab4-11e8-9ed6-dc35f17fb807.png)
