### PR TITLE
GameINI: Safe texture cache for uDraw games

### DIFF
--- a/Data/Sys/GameSettings/SUU.ini
+++ b/Data/Sys/GameSettings/SUU.ini
@@ -1,0 +1,4 @@
+# SUUE78 - uDraw Studio - Instant Artist
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SUW.ini
+++ b/Data/Sys/GameSettings/SUW.ini
@@ -1,0 +1,4 @@
+# SUWE78 - uDraw Studio
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
When using the uDraw tablet in Dolphin, painting lags unless the safe texture cache setting is changed.

The default option (Fast) causes it to lag a lot - the middle option is better but still not as smooth as Safe, so I set it to 0.