### PR TITLE
RFC: Refactor the settings for Android to use dedicated tags

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/IntSetting.java
@@ -1,13 +1,23 @@
 package org.dolphinemu.dolphinemu.model.settings;
 
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
+
 public final class IntSetting extends Setting
 {
 	private int mValue;
+	private MenuTag menuTag;
 
 	public IntSetting(String key, String section, int file, int value)
 	{
 		super(key, section, file);
 		mValue = value;
+	}
+
+	public IntSetting(String key, String section, int file, int value, MenuTag menuTag)
+	{
+		super(key, section, file);
+		mValue = value;
+		this.menuTag = menuTag;
 	}
 
 	public int getValue()
@@ -25,4 +35,10 @@ public final class IntSetting extends Setting
 	{
 		return Integer.toString(mValue);
 	}
+
+	public MenuTag getMenuTag()
+	{
+		return menuTag;
+	}
+
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SingleChoiceSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SingleChoiceSetting.java
@@ -2,6 +2,7 @@ package org.dolphinemu.dolphinemu.model.settings.view;
 
 import org.dolphinemu.dolphinemu.model.settings.IntSetting;
 import org.dolphinemu.dolphinemu.model.settings.Setting;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 
 public final class SingleChoiceSetting extends SettingsItem
 {
@@ -9,13 +10,20 @@ public final class SingleChoiceSetting extends SettingsItem
 
 	private int mChoicesId;
 	private int mValuesId;
+	private MenuTag menuTag;
 
-	public SingleChoiceSetting(String key, String section, int file, int titleId, int descriptionId, int choicesId, int valuesId, int defaultValue, Setting setting)
+	public SingleChoiceSetting(String key, String section, int file, int titleId, int descriptionId, int choicesId, int valuesId, int defaultValue, Setting setting, MenuTag menuTag)
 	{
 		super(key, section, file, setting, titleId, descriptionId);
 		mValuesId = valuesId;
 		mChoicesId = choicesId;
 		mDefaultValue = defaultValue;
+		this.menuTag = menuTag;
+	}
+
+	public SingleChoiceSetting(String key, String section, int file, int titleId, int descriptionId, int choicesId, int valuesId, int defaultValue, Setting setting)
+	{
+		this(key, section, file, titleId, descriptionId, choicesId, valuesId, defaultValue, setting, null);
 	}
 
 	public int getChoicesId()
@@ -39,6 +47,11 @@ public final class SingleChoiceSetting extends SettingsItem
 		{
 			return mDefaultValue;
 		}
+	}
+
+	public MenuTag getMenuTag()
+	{
+		return menuTag;
 	}
 
 	/**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SubmenuSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/settings/view/SubmenuSetting.java
@@ -1,18 +1,19 @@
 package org.dolphinemu.dolphinemu.model.settings.view;
 
 import org.dolphinemu.dolphinemu.model.settings.Setting;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 
 public final class SubmenuSetting extends SettingsItem
 {
-	private String mMenuKey;
+	private MenuTag mMenuKey;
 
-	public SubmenuSetting(String key, Setting setting, int titleId, int descriptionId, String menuKey)
+	public SubmenuSetting(String key, Setting setting, int titleId, int descriptionId, MenuTag menuKey)
 	{
 		super(key, null, 0, setting, titleId, descriptionId);
 		mMenuKey = menuKey;
 	}
 
-	public String getMenuKey()
+	public MenuTag getMenuKey()
 	{
 		return mMenuKey;
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -22,6 +22,7 @@ import org.dolphinemu.dolphinemu.model.GameProvider;
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesView;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.AddDirectoryHelper;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
@@ -127,7 +128,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
 	}
 
 	@Override
-	public void launchSettingsActivity(String menuTag)
+	public void launchSettingsActivity(MenuTag menuTag)
 	{
 		SettingsActivity.launch(this, menuTag);
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -6,8 +6,8 @@ import org.dolphinemu.dolphinemu.DolphinApplication;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.GameDatabase;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 import org.dolphinemu.dolphinemu.utils.AddDirectoryHelper;
-import org.dolphinemu.dolphinemu.utils.SettingsFile;
 
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
@@ -41,19 +41,19 @@ public final class MainPresenter
 		switch (itemId)
 		{
 			case R.id.menu_settings_core:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_DOLPHIN);
+				mView.launchSettingsActivity(MenuTag.CORE);
 				return true;
 
 			case R.id.menu_settings_video:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_GFX);
+				mView.launchSettingsActivity(MenuTag.GRAPHICS);
 				return true;
 
 			case R.id.menu_settings_gcpad:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_GCPAD);
+				mView.launchSettingsActivity(MenuTag.GCPAD_TYPE);
 				return true;
 
 			case R.id.menu_settings_wiimote:
-				mView.launchSettingsActivity(SettingsFile.FILE_NAME_WIIMOTE);
+				mView.launchSettingsActivity(MenuTag.WIIMOTE);
 				return true;
 
 			case R.id.menu_refresh:

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
@@ -3,6 +3,7 @@ package org.dolphinemu.dolphinemu.ui.main;
 import android.database.Cursor;
 
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 
 /**
  * Abstraction for the screen that shows on application launch.
@@ -33,7 +34,7 @@ public interface MainView
 	void refreshFragmentScreenshot(int fragmentPosition);
 
 
-	void launchSettingsActivity(String menuTag);
+	void launchSettingsActivity(MenuTag menuTag);
 
 	void launchFileListActivity();
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -25,6 +25,7 @@ import org.dolphinemu.dolphinemu.model.Game;
 import org.dolphinemu.dolphinemu.model.TvSettingsItem;
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.ui.settings.MenuTag;
 import org.dolphinemu.dolphinemu.ui.settings.SettingsActivity;
 import org.dolphinemu.dolphinemu.utils.AddDirectoryHelper;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
@@ -121,7 +122,7 @@ public final class TvMainActivity extends FragmentActivity implements MainView
 	}
 
 	@Override
-	public void launchSettingsActivity(String menuTag)
+	public void launchSettingsActivity(MenuTag menuTag)
 	{
 		SettingsActivity.launch(this, menuTag);
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
@@ -1,0 +1,102 @@
+package org.dolphinemu.dolphinemu.ui.settings;
+
+public enum MenuTag
+{
+    CORE("core"),
+    WIIMOTE("wiimote"),
+    WIIMOTE_EXTENSION("wiimote_extension"),
+    GCPAD_TYPE("gc_pad_type"),
+    GRAPHICS("graphics"),
+    HACKS("hacks"),
+    ENHANCEMENTS("enhancements"),
+    STEREOSCOPY("stereoscopy"),
+    GCPAD_1("gcpad", 0),
+    GCPAD_2("gcpad", 1),
+    GCPAD_3("gcpad", 2),
+    GCPAD_4("gcpad", 3),
+    WIIMOTE_1("wiimote", 1),
+    WIIMOTE_2("wiimote", 2),
+    WIIMOTE_3("wiimote", 3),
+    WIIMOTE_4("wiimote", 4),
+    WIIMOTE_EXTENSION_1("wiimote_extension", 1),
+    WIIMOTE_EXTENSION_2("wiimote_extension", 2),
+    WIIMOTE_EXTENSION_3("wiimote_extension", 3),
+    WIIMOTE_EXTENSION_4("wiimote_extension", 4);
+
+    private String tag;
+    private int subType = -1;
+
+    MenuTag(String tag)
+    {
+        this.tag = tag;
+    }
+
+    MenuTag(String tag, int subtype)
+    {
+        this.tag = tag;
+        this.subType = subtype;
+    }
+
+    @Override
+    public String toString()
+    {
+        if (subType != -1)
+        {
+            return tag + subType;
+        }
+
+        return tag;
+    }
+
+    public String getTag()
+    {
+        return tag;
+    }
+
+    public int getSubType()
+    {
+        return subType;
+    }
+
+    public boolean isGCPadMenu()
+    {
+        return this == GCPAD_1 || this == GCPAD_2 || this == GCPAD_3 || this == GCPAD_4;
+    }
+
+    public boolean isWiimoteMenu()
+    {
+        return this == WIIMOTE_1 || this == WIIMOTE_2 || this == WIIMOTE_3 || this == WIIMOTE_4;
+    }
+
+    public boolean isWiimoteExtensionMenu()
+    {
+        return this == WIIMOTE_EXTENSION_1 || this == WIIMOTE_EXTENSION_2
+                || this == WIIMOTE_EXTENSION_3 || this == WIIMOTE_EXTENSION_4;
+    }
+
+    public static MenuTag getGCPadMenuTag(int subtype)
+    {
+        return getMenuTag("gcpad", subtype);
+    }
+
+    public static MenuTag getWiimoteMenuTag(int subtype)
+    {
+        return getMenuTag("wiimote", subtype);
+    }
+
+    public static MenuTag getWiimoteExtensionMenuTag(int subtype)
+    {
+        return getMenuTag("wiimote_extension", subtype);
+    }
+
+    private static MenuTag getMenuTag(String tag, int subtype)
+    {
+        for (MenuTag menuTag : MenuTag.values())
+        {
+            if (menuTag.tag.equals(tag) && menuTag.subType == subtype) return menuTag;
+        }
+
+        throw new IllegalArgumentException("You are asking for a menu that is not available or " +
+                "passing a wrong subtype");
+    }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivity.java
@@ -24,16 +24,16 @@ import java.util.HashMap;
 
 public final class SettingsActivity extends AppCompatActivity implements SettingsActivityView
 {
-	private static final String ARG_FILE_NAME = "file_name";
+	private static final String ARG_MENU_TAG = "menu_tag";
 	private static final String FRAGMENT_TAG = "settings";
 	private SettingsActivityPresenter mPresenter = new SettingsActivityPresenter(this);
 
 	private ProgressDialog dialog;
 
-	public static void launch(Context context, String menuTag)
+	public static void launch(Context context, MenuTag menuTag)
 	{
 		Intent settings = new Intent(context, SettingsActivity.class);
-		settings.putExtra(ARG_FILE_NAME, menuTag);
+		settings.putExtra(ARG_MENU_TAG, menuTag);
 		context.startActivity(settings);
 	}
 
@@ -45,9 +45,8 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 		setContentView(R.layout.activity_settings);
 
 		Intent launcher = getIntent();
-		String filename = launcher.getStringExtra(ARG_FILE_NAME);
-
-		mPresenter.onCreate(savedInstanceState, filename);
+		MenuTag menuTag = (MenuTag) launcher.getSerializableExtra(ARG_MENU_TAG);
+		mPresenter.onCreate(savedInstanceState, menuTag);
 	}
 
 	@Override
@@ -101,7 +100,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
 
 	@Override
-	public void showSettingsFragment(String menuTag, boolean addToStack)
+	public void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack)
 	{
 		FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
@@ -119,7 +118,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 			transaction.addToBackStack(null);
 			mPresenter.addToStack();
 		}
-		transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag), FRAGMENT_TAG);
+		transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag, extras), FRAGMENT_TAG);
 
 		transaction.commit();
 	}
@@ -236,21 +235,21 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 	}
 
 	@Override
-	public void onGcPadSettingChanged(String key, int value)
+	public void onGcPadSettingChanged(MenuTag key, int value)
 	{
 		mPresenter.onGcPadSettingChanged(key, value);
 	}
 
 	@Override
-	public void onWiimoteSettingChanged(String section, int value)
+	public void onWiimoteSettingChanged(MenuTag section, int value)
 	{
 		mPresenter.onWiimoteSettingChanged(section, value);
 	}
 
 	@Override
-	public void onExtensionSettingChanged(String key, int value)
+	public void onExtensionSettingChanged(MenuTag menuTag, int value)
 	{
-		mPresenter.onExtensionSettingChanged(key, value);
+		mPresenter.onExtensionSettingChanged(menuTag, value);
 	}
 
 	private SettingsFragment getFragment()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityPresenter.java
@@ -30,14 +30,14 @@ public final class SettingsActivityPresenter
 
 	private DirectoryStateReceiver directoryStateReceiver;
 
-	private String menuTag;
+	private MenuTag menuTag;
 
 	public SettingsActivityPresenter(SettingsActivityView view)
 	{
 		mView = view;
 	}
 
-	public void onCreate(Bundle savedInstanceState, String menuTag)
+	public void onCreate(Bundle savedInstanceState, MenuTag menuTag)
 	{
 		if (savedInstanceState == null)
 		{
@@ -63,7 +63,7 @@ public final class SettingsActivityPresenter
 			mSettings.add(SettingsFile.SETTINGS_WIIMOTE, SettingsFile.readFile(SettingsFile.FILE_NAME_WIIMOTE, mView));
 		}
 
-		mView.showSettingsFragment(menuTag, false);
+		mView.showSettingsFragment(menuTag, null, false);
 		mView.onSettingsFileLoaded(mSettings);
 	}
 
@@ -168,20 +168,22 @@ public final class SettingsActivityPresenter
 		outState.putBoolean(KEY_SHOULD_SAVE, mShouldSave);
 	}
 
-	public void onGcPadSettingChanged(String key, int value)
+	public void onGcPadSettingChanged(MenuTag key, int value)
 	{
 		if (value != 0) // Not disabled
 		{
-			mView.showSettingsFragment(key + (value / 6), true);
+			Bundle bundle = new Bundle();
+			bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value/6);
+			mView.showSettingsFragment(key, bundle, true);
 		}
 	}
 
-	public void onWiimoteSettingChanged(String section, int value)
+	public void onWiimoteSettingChanged(MenuTag menuTag, int value)
 	{
 		switch (value)
 		{
 			case 1:
-				mView.showSettingsFragment(section, true);
+				mView.showSettingsFragment(menuTag, null, true);
 				break;
 
 			case 2:
@@ -190,11 +192,13 @@ public final class SettingsActivityPresenter
 		}
 	}
 
-	public void onExtensionSettingChanged(String key, int value)
+	public void onExtensionSettingChanged(MenuTag menuTag, int value)
 	{
 		if (value != 0) // None
 		{
-			mView.showSettingsFragment(key + value, true);
+			Bundle bundle = new Bundle();
+			bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
+			mView.showSettingsFragment(menuTag, bundle, true);
 		}
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityView.java
@@ -1,6 +1,7 @@
 package org.dolphinemu.dolphinemu.ui.settings;
 
 import android.content.IntentFilter;
+import android.os.Bundle;
 
 import org.dolphinemu.dolphinemu.model.settings.SettingSection;
 import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
@@ -19,7 +20,7 @@ public interface SettingsActivityView
 	 * @param menuTag    Identifier for the settings group that should be displayed.
 	 * @param addToStack Whether or not this fragment should replace a previous one.
 	 */
-	void showSettingsFragment(String menuTag, boolean addToStack);
+	void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack);
 
 	/**
 	 * Called by a contained Fragment to get access to the Setting HashMap
@@ -79,29 +80,28 @@ public interface SettingsActivityView
 	 * Called by a containing Fragment to tell the containing Activity that a GCPad's setting
 	 * was modified.
 	 *
-	 * @param key   Identifier for the GCPad that was modified.
+	 * @param menuTag   Identifier for the GCPad that was modified.
 	 * @param value New setting for the GCPad.
 	 */
-	void onGcPadSettingChanged(String key, int value);
+	void onGcPadSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Called by a containing Fragment to tell the containing Activity that a Wiimote's setting
 	 * was modified.
 	 *
-	 * @param section Identifier for Wiimote that was modified; Wiimotes are identified by their section,
-	 *                not their key.
+	 * @param menuTag Identifier for Wiimote that was modified.
 	 * @param value   New setting for the Wiimote.
 	 */
-	void onWiimoteSettingChanged(String section, int value);
+	void onWiimoteSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Called by a containing Fragment to tell the containing Activity that an extension setting
 	 * was modified.
 	 *
-	 * @param key   Identifier for the extension that was modified.
+	 * @param menuTag   Identifier for the extension that was modified.
 	 * @param value New setting for the extension.
 	 */
-	void onExtensionSettingChanged(String key, int value);
+	void onExtensionSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Show loading dialog while loading the settings

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
@@ -234,20 +234,23 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 			SingleChoiceSetting scSetting = (SingleChoiceSetting) mClickedItem;
 
 			int value = getValueForSingleChoiceSelection(scSetting, which);
-
-			if (scSetting.getKey().startsWith(SettingsFile.KEY_GCPAD_TYPE))
+			MenuTag menuTag = scSetting.getMenuTag();
+			if(menuTag != null)
 			{
-				mView.onGcPadSettingChanged(scSetting.getKey(), value);
-			}
+				if (menuTag.isGCPadMenu())
+				{
+					mView.onGcPadSettingChanged(menuTag, value);
+				}
 
-			if (scSetting.getKey().equals(SettingsFile.KEY_WIIMOTE_TYPE))
-			{
-				mView.onWiimoteSettingChanged(scSetting.getSection(), value);
-			}
+				if (menuTag.isWiimoteMenu())
+				{
+					mView.onWiimoteSettingChanged(menuTag, value);
+				}
 
-			if (scSetting.getKey().equals(SettingsFile.KEY_WIIMOTE_EXTENSION))
-			{
-				mView.onExtensionSettingChanged(scSetting.getKey() + Character.getNumericValue(scSetting.getSection().charAt(scSetting.getSection().length() - 1)), value);
+				if (menuTag.isWiimoteExtensionMenu())
+				{
+					mView.onExtensionSettingChanged(menuTag, value);
+				}
 			}
 
 			// Get the backing Setting, which may be null (if for example it was missing from the file)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragment.java
@@ -24,18 +24,22 @@ import java.util.HashMap;
 public final class SettingsFragment extends Fragment implements SettingsFragmentView
 {
 	private static final String ARGUMENT_MENU_TAG = "menu_tag";
-
 	private SettingsFragmentPresenter mPresenter = new SettingsFragmentPresenter(this);
 	private SettingsActivityView mActivity;
 
 	private SettingsAdapter mAdapter;
 
-	public static Fragment newInstance(String menuTag)
+	public static Fragment newInstance(MenuTag menuTag, Bundle extras)
 	{
 		SettingsFragment fragment = new SettingsFragment();
 
 		Bundle arguments = new Bundle();
-		arguments.putString(ARGUMENT_MENU_TAG, menuTag);
+		if(extras != null)
+		{
+			arguments.putAll(extras);
+		}
+
+		arguments.putSerializable(ARGUMENT_MENU_TAG, menuTag);
 
 		fragment.setArguments(arguments);
 		return fragment;
@@ -70,11 +74,12 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 		super.onCreate(savedInstanceState);
 
 		setRetainInstance(true);
-		String menuTag = getArguments().getString(ARGUMENT_MENU_TAG);
+		Bundle args = getArguments();
+		MenuTag menuTag = (MenuTag) args.getSerializable(ARGUMENT_MENU_TAG);
 
 		mAdapter = new SettingsAdapter(this, getActivity());
 
-		mPresenter.onCreate(menuTag);
+		mPresenter.onCreate(menuTag, args);
 	}
 
 	@Nullable
@@ -145,9 +150,9 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 	}
 
 	@Override
-	public void loadSubMenu(String menuKey)
+	public void loadSubMenu(MenuTag menuKey)
 	{
-		mActivity.showSettingsFragment(menuKey, true);
+		mActivity.showSettingsFragment(menuKey, null, true);
 	}
 
 	@Override
@@ -169,21 +174,21 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 	}
 
 	@Override
-	public void onGcPadSettingChanged(String key, int value)
+	public void onGcPadSettingChanged(MenuTag menuTag, int value)
 	{
-		mActivity.onGcPadSettingChanged(key, value);
+		mActivity.onGcPadSettingChanged(menuTag, value);
 	}
 
 	@Override
-	public void onWiimoteSettingChanged(String section, int value)
+	public void onWiimoteSettingChanged(MenuTag menuTag, int value)
 	{
-		mActivity.onWiimoteSettingChanged(section, value);
+		mActivity.onWiimoteSettingChanged(menuTag, value);
 	}
 
 	@Override
-	public void onExtensionSettingChanged(String key, int value)
+	public void onExtensionSettingChanged(MenuTag menuTag, int value)
 	{
-		mActivity.onExtensionSettingChanged(key, value);
+		mActivity.onExtensionSettingChanged(menuTag, value);
 	}
 
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -1,5 +1,7 @@
 package org.dolphinemu.dolphinemu.ui.settings;
 
+import android.os.Bundle;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.settings.BooleanSetting;
@@ -24,7 +26,8 @@ public final class SettingsFragmentPresenter
 {
 	private SettingsFragmentView mView;
 
-	private String mMenuTag;
+	public static final String ARG_CONTROLLER_TYPE = "controller_type";
+	private MenuTag mMenuTag;
 
 	private ArrayList<HashMap<String, SettingSection>> mSettings;
 	private ArrayList<SettingsItem> mSettingsList;
@@ -37,24 +40,17 @@ public final class SettingsFragmentPresenter
 		mView = view;
 	}
 
-	public void onCreate(String menuTag)
+	public void onCreate(MenuTag menuTag, Bundle extras)
 	{
-		if (menuTag.startsWith(SettingsFile.KEY_GCPAD_TYPE))
+		this.mMenuTag = menuTag;
+		if (menuTag.isGCPadMenu() || menuTag.isWiimoteExtensionMenu())
 		{
-			mMenuTag = SettingsFile.KEY_GCPAD_TYPE;
-			mControllerNumber = Character.getNumericValue(menuTag.charAt(menuTag.length() - 2));
-			mControllerType = Character.getNumericValue(menuTag.charAt(menuTag.length() - 1));
+			mControllerNumber = menuTag.getSubType();
+			mControllerType = extras.getInt(ARG_CONTROLLER_TYPE);
 		}
-		else if (menuTag.startsWith(SettingsFile.SECTION_WIIMOTE) && !menuTag.equals(SettingsFile.FILE_NAME_WIIMOTE))
+		else if (menuTag.isWiimoteMenu())
 		{
-			mMenuTag = SettingsFile.SECTION_WIIMOTE;
-			mControllerNumber = Character.getNumericValue(menuTag.charAt(menuTag.length() - 1)) + 3;
-		}
-		else if (menuTag.startsWith(SettingsFile.KEY_WIIMOTE_EXTENSION))
-		{
-			mMenuTag = SettingsFile.KEY_WIIMOTE_EXTENSION;
-			mControllerNumber = Character.getNumericValue(menuTag.charAt(menuTag.length() - 2)) + 3;
-			mControllerType = Character.getNumericValue(menuTag.charAt(menuTag.length() - 1));
+			mControllerNumber = menuTag.getSubType();
 		}
 		else
 		{
@@ -110,43 +106,52 @@ public final class SettingsFragmentPresenter
 
 		switch (mMenuTag)
 		{
-			case SettingsFile.FILE_NAME_DOLPHIN:
+			case CORE:
 				addCoreSettings(sl);
 				break;
 
-			case SettingsFile.FILE_NAME_GFX:
+			case GRAPHICS:
 				addGraphicsSettings(sl);
 				break;
 
-			case SettingsFile.FILE_NAME_GCPAD:
+			case GCPAD_TYPE:
 				addGcPadSettings(sl);
 				break;
 
-			case SettingsFile.FILE_NAME_WIIMOTE:
+			case WIIMOTE:
 				addWiimoteSettings(sl);
 				break;
 
-			case SettingsFile.SECTION_GFX_ENHANCEMENTS:
+			case ENHANCEMENTS:
 				addEnhanceSettings(sl);
 				break;
 
-			case SettingsFile.SECTION_GFX_HACKS:
+			case HACKS:
 				addHackSettings(sl);
 				break;
 
-			case SettingsFile.KEY_GCPAD_TYPE:
+			case GCPAD_1:
+			case GCPAD_2:
+			case GCPAD_3:
+			case GCPAD_4:
 				addGcPadSubSettings(sl, mControllerNumber, mControllerType);
 				break;
 
-			case SettingsFile.SECTION_WIIMOTE:
+			case WIIMOTE_1:
+			case WIIMOTE_2:
+			case WIIMOTE_3:
+			case WIIMOTE_4:
 				addWiimoteSubSettings(sl, mControllerNumber);
 				break;
 
-			case SettingsFile.KEY_WIIMOTE_EXTENSION:
+			case WIIMOTE_EXTENSION_1:
+			case WIIMOTE_EXTENSION_2:
+			case WIIMOTE_EXTENSION_3:
+			case WIIMOTE_EXTENSION_4:
 				addExtensionTypeSettings(sl, mControllerNumber, mControllerType);
 				break;
 
-			case SettingsFile.SECTION_STEREOSCOPY:
+			case STEREOSCOPY:
 				addStereoSettings(sl);
 				break;
 
@@ -228,7 +233,7 @@ public final class SettingsFragmentPresenter
 			{
 				// TODO This controller_0 + i business is quite the hack. It should work, but only if the definitions are kept together and in order.
 				Setting gcPadSetting = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_CORE).getSetting(SettingsFile.KEY_GCPAD_TYPE + i);
-				sl.add(new SingleChoiceSetting(SettingsFile.KEY_GCPAD_TYPE + i, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.controller_0 + i, 0, R.array.gcpadTypeEntries, R.array.gcpadTypeValues, 0, gcPadSetting));
+				sl.add(new SingleChoiceSetting(SettingsFile.KEY_GCPAD_TYPE + i, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.controller_0 + i, 0, R.array.gcpadTypeEntries, R.array.gcpadTypeValues, 0, gcPadSetting, MenuTag.getGCPadMenuTag(i)));
 			}
 		}
 	}
@@ -241,7 +246,7 @@ public final class SettingsFragmentPresenter
 			{
 				// TODO This wiimote_0 + i business is quite the hack. It should work, but only if the definitions are kept together and in order.
 				Setting wiimoteSetting = mSettings.get(SettingsFile.SETTINGS_WIIMOTE).get(SettingsFile.SECTION_WIIMOTE + i).getSetting(SettingsFile.KEY_WIIMOTE_TYPE);
-				sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_TYPE, SettingsFile.SECTION_WIIMOTE + i, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_0 + i - 1, 0, R.array.wiimoteTypeEntries, R.array.wiimoteTypeValues, 0, wiimoteSetting));
+				sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_TYPE, SettingsFile.SECTION_WIIMOTE + i, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_0 + i - 1, 0, R.array.wiimoteTypeEntries, R.array.wiimoteTypeValues, 0, wiimoteSetting, MenuTag.getWiimoteMenuTag(i)));
 			}
 		}
 	}
@@ -268,8 +273,8 @@ public final class SettingsFragmentPresenter
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_VIDEO_BACKEND_INDEX, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.video_backend, R.string.video_backend_descrip, R.array.videoBackendEntries, R.array.videoBackendValues, 0, videoBackend));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_SHOW_FPS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.show_fps, 0, false, showFps));
 
-		sl.add(new SubmenuSetting(null, null, R.string.enhancements, 0, SettingsFile.SECTION_GFX_ENHANCEMENTS));
-		sl.add(new SubmenuSetting(null, null, R.string.hacks, 0, SettingsFile.SECTION_GFX_HACKS));
+		sl.add(new SubmenuSetting(null, null, R.string.enhancements, 0, MenuTag.ENHANCEMENTS));
+		sl.add(new SubmenuSetting(null, null, R.string.hacks, 0, MenuTag.HACKS));
 	}
 
 	private void addEnhanceSettings(ArrayList<SettingsItem> sl)
@@ -309,7 +314,7 @@ public final class SettingsFragmentPresenter
 		if ((helper.supportsOpenGL() && helper.GetVersion() >= 320) ||
 				(helper.supportsGLES3() && helper.GetVersion() >= 310 && helper.SupportsExtension("GL_ANDROID_extension_pack_es31a")))
 		{
-			sl.add(new SubmenuSetting(SettingsFile.KEY_STEREO_MODE, null, R.string.stereoscopy, R.string.stereoscopy_descrip, SettingsFile.SECTION_STEREOSCOPY));
+			sl.add(new SubmenuSetting(SettingsFile.KEY_STEREO_MODE, null, R.string.stereoscopy, R.string.stereoscopy_descrip, MenuTag.STEREOSCOPY));
 		}
 	}
 
@@ -427,7 +432,7 @@ public final class SettingsFragmentPresenter
 	private void addWiimoteSubSettings(ArrayList<SettingsItem> sl, int wiimoteNumber)
 	{
 		// Bindings use controller numbers 4-7 (0-3 are GameCube), but the extension setting uses 1-4.
-		IntSetting extension = new IntSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + (wiimoteNumber - 3), SettingsFile.SETTINGS_WIIMOTE, getExtensionValue(wiimoteNumber - 3));
+		IntSetting extension = new IntSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + wiimoteNumber, SettingsFile.SETTINGS_WIIMOTE, getExtensionValue(wiimoteNumber), MenuTag.getWiimoteExtensionMenuTag(wiimoteNumber));
 		Setting bindA = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_A + wiimoteNumber);
 		Setting bindB = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_B + wiimoteNumber);
 		Setting bind1 = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_1 + wiimoteNumber);
@@ -461,7 +466,7 @@ public final class SettingsFragmentPresenter
 		Setting bindDPadLeft = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_DPAD_LEFT + wiimoteNumber);
 		Setting bindDPadRight = mSettings.get(SettingsFile.SETTINGS_DOLPHIN).get(SettingsFile.SECTION_BINDINGS).getSetting(SettingsFile.KEY_WIIBIND_DPAD_RIGHT + wiimoteNumber);
 
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + (wiimoteNumber - 3), SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_extensions, R.string.wiimote_extensions_descrip, R.array.wiimoteExtensionsEntries, R.array.wiimoteExtensionsValues, 0, extension));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_EXTENSION, SettingsFile.SECTION_WIIMOTE + wiimoteNumber, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_extensions, R.string.wiimote_extensions_descrip, R.array.wiimoteExtensionsEntries, R.array.wiimoteExtensionsValues, 0, extension, MenuTag.getWiimoteExtensionMenuTag(wiimoteNumber)));
 
 		sl.add(new HeaderSetting(null, null, R.string.generic_buttons, 0));
 		sl.add(new InputBindingSetting(SettingsFile.KEY_WIIBIND_A + wiimoteNumber, SettingsFile.SECTION_BINDINGS, SettingsFile.SETTINGS_DOLPHIN, R.string.button_a, bindA));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentView.java
@@ -56,7 +56,7 @@ public interface SettingsFragmentView
 	 *
 	 * @param menuKey Identifier for the settings group that should be shown.
 	 */
-	void loadSubMenu(String menuKey);
+	void loadSubMenu(MenuTag menuKey);
 
 	/**
 	 * Tell the Fragment to tell the containing activity to display a toast message.
@@ -80,25 +80,24 @@ public interface SettingsFragmentView
 	/**
 	 * Have the fragment tell the containing Activity that a GCPad's setting was modified.
 	 *
-	 * @param key   Identifier for the GCPad that was modified.
+	 * @param menuTag   Identifier for the GCPad that was modified.
 	 * @param value New setting for the GCPad.
 	 */
-	void onGcPadSettingChanged(String key, int value);
+	void onGcPadSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Have the fragment tell the containing Activity that a Wiimote's setting was modified.
 	 *
-	 * @param section Identifier for Wiimote that was modified; Wiimotes are identified by their section,
-	 *                not their key.
+	 * @param menuTag Identifier for Wiimote that was modified.
 	 * @param value   New setting for the Wiimote.
 	 */
-	void onWiimoteSettingChanged(String section, int value);
+	void onWiimoteSettingChanged(MenuTag menuTag, int value);
 
 	/**
 	 * Have the fragment tell the containing Activity that an extension setting was modified.
 	 *
-	 * @param key   Identifier for the extension that was modified.
+	 * @param menuTag   Identifier for the extension that was modified.
 	 * @param value New setting for the extension.
 	 */
-	void onExtensionSettingChanged(String key, int value);
+	void onExtensionSettingChanged(MenuTag menuTag, int value);
 }


### PR DESCRIPTION
Before we used different way of identifying which settings menu to
show, sometimes we used the section name, other times we used the
settings file name. This one replaces all those different ways by just
one way based on a menu tag which is more clear and easy to follow.

This is needed for #6338 because creating dedicated sections for WII/GC settings was really hard following all those different ways of handling the settings menu. 