### PR TITLE
OGL: Don't leave staging texture buffer bound after mapping

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -511,10 +511,8 @@ bool OGLStagingTexture::Map()
     flags = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT;
   glBindBuffer(m_target, m_buffer_name);
   m_map_pointer = reinterpret_cast<char*>(glMapBufferRange(m_target, 0, m_buffer_size, flags));
-  if (!m_map_pointer)
-    return false;
-
-  return true;
+  glBindBuffer(m_target, 0);
+  return m_map_pointer != nullptr;
 }
 
 void OGLStagingTexture::Unmap()


### PR DESCRIPTION
This could cause glReadPixels() calls which assume no buffer is bound (e.g. CPU EFB access) to fail.

The problem was limited to devices which don't support persistent mapping, as the map path is not otherwise. Might fix CPU EFB access on Android for these drivers. I've tested on AMD/Mesa by forcing persistent mapping off.