### PR TITLE
Qt: Various fixes to hotkeys

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -629,7 +629,7 @@ State GetState()
 
   if (s_hardware_initialized)
   {
-    if (CPU::IsStepping())
+    if (CPU::IsStepping() || s_frame_step)
       return State::Paused;
 
     return State::Running;

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -89,14 +89,16 @@ static void HandleFrameskipHotkeys()
     if (frame_step_delay_count < frame_step_delay && frame_step_hold)
       frame_step_delay_count++;
 
-    // TODO GUI Update (Depends on an unimplemented feature)
-    // if ((frame_step_count == 0 || frame_step_count == FRAME_STEP_DELAY) && !frame_step_hold)
+    if ((frame_step_count == 0 || frame_step_count == FRAME_STEP_DELAY) && !frame_step_hold)
+    {
+      Core::DoFrameStep();
+      frame_step_hold = true;
+    }
 
     if (frame_step_count < FRAME_STEP_DELAY)
     {
-      ++frame_step_count;
-      if (frame_step_hold)
-        frame_step_hold = false;
+      frame_step_count++;
+      frame_step_hold = false;
     }
 
     if (frame_step_count == FRAME_STEP_DELAY && frame_step_hold &&
@@ -108,8 +110,7 @@ static void HandleFrameskipHotkeys()
 
     return;
   }
-
-  if (frame_step_count > 0)
+  else if (frame_step_count > 0)
   {
     // Reset frame advance
     frame_step_count = 0;
@@ -143,7 +144,7 @@ void HotkeyScheduler::Run()
 
       // Pause and Unpause
       if (IsHotkey(HK_PLAY_PAUSE))
-        emit PauseHotkey();
+        emit TogglePauseHotkey();
 
       // Stop
       if (IsHotkey(HK_STOP))

--- a/Source/Core/DolphinQt2/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.h
@@ -23,7 +23,7 @@ signals:
   void ExitHotkey();
   void FullScreenHotkey();
   void StopHotkey();
-  void PauseHotkey();
+  void TogglePauseHotkey();
   void ScreenShotHotkey();
   void SetStateSlotHotkey(int slot);
   void StateLoadSlotHotkey();

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -271,7 +271,7 @@ void MainWindow::ConnectMenuBar()
 void MainWindow::ConnectHotkeys()
 {
   connect(m_hotkey_scheduler, &HotkeyScheduler::ExitHotkey, this, &MainWindow::close);
-  connect(m_hotkey_scheduler, &HotkeyScheduler::PauseHotkey, this, &MainWindow::Pause);
+  connect(m_hotkey_scheduler, &HotkeyScheduler::TogglePauseHotkey, this, &MainWindow::TogglePause);
   connect(m_hotkey_scheduler, &HotkeyScheduler::StopHotkey, this, &MainWindow::RequestStop);
   connect(m_hotkey_scheduler, &HotkeyScheduler::ScreenShotHotkey, this, &MainWindow::ScreenShot);
   connect(m_hotkey_scheduler, &HotkeyScheduler::FullScreenHotkey, this, &MainWindow::FullScreen);
@@ -322,7 +322,6 @@ void MainWindow::ConnectRenderWidget()
 {
   m_rendering_to_main = false;
   m_render_widget->hide();
-  connect(m_render_widget, &RenderWidget::EscapePressed, this, &MainWindow::RequestStop);
   connect(m_render_widget, &RenderWidget::Closed, this, &MainWindow::ForceStop);
 }
 
@@ -395,6 +394,18 @@ void MainWindow::Pause()
 {
   Core::SetState(Core::State::Paused);
   EnableScreenSaver(true);
+}
+
+void MainWindow::TogglePause()
+{
+  if (Core::GetState() == Core::State::Paused)
+  {
+    Play();
+  }
+  else
+  {
+    Pause();
+  }
 }
 
 void MainWindow::OnStopComplete()
@@ -577,8 +588,8 @@ void MainWindow::HideRenderWidget()
   }
 
   // The following code works around a driver bug that would lead to Dolphin crashing when changing
-  // graphics backends (e.g. OpenGL to Vulkan). To avoid this the render widget is (safely) recreated
-  disconnect(m_render_widget, &RenderWidget::EscapePressed, this, &MainWindow::RequestStop);
+  // graphics backends (e.g. OpenGL to Vulkan). To avoid this the render widget is (safely)
+  // recreated
   disconnect(m_render_widget, &RenderWidget::Closed, this, &MainWindow::ForceStop);
 
   m_render_widget->hide();
@@ -588,7 +599,6 @@ void MainWindow::HideRenderWidget()
   m_render_widget = new RenderWidget;
 
   m_render_widget->installEventFilter(this);
-  connect(m_render_widget, &RenderWidget::EscapePressed, this, &MainWindow::RequestStop);
   connect(m_render_widget, &RenderWidget::Closed, this, &MainWindow::ForceStop);
 }
 

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -53,6 +53,7 @@ private:
   void Open();
   void Play(const std::optional<std::string>& savestate_path = {});
   void Pause();
+  void TogglePause();
 
   // May ask for confirmation. Returns whether or not it actually stopped.
   bool RequestStop();


### PR DESCRIPTION
# 1
Removed hardcoded esc -> stop hotkey

# 2
Make pause toggle hotkey actually toggle pause, rather then just pausing

# 3
Make frame advance actually advance the frame.

# 4
Changed GetState to return State::Paused while frame stepping.
This prevents the MenuBar from flipping between Pause and Play state constantly while frame advance hotkey is held down.
wx handles this by not calling the UpdateGUI() method in this case, but Qt doesnt have a manual UpdateGUI() so I handled the issue earlier.