### PR TITLE
ES: Make it fail on unsupported installed IOSes

### DIFF
--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -184,10 +184,10 @@ IPCCommandResult Device::Unsupported(const Request& request)
   return GetDefaultReply(IPC_EINVAL);
 }
 
-// Returns an IPCCommandResult for a reply that takes 250 us (arbitrarily chosen value)
+// Returns an IPCCommandResult for a reply that takes 25 us (based on ES::GetTicketViews)
 IPCCommandResult Device::GetDefaultReply(const s32 return_value)
 {
-  return {return_value, true, SystemTimers::GetTicksPerSecond() / 4000};
+  return {return_value, true, SystemTimers::GetTicksPerSecond() / 40000};
 }
 
 // Returns an IPCCommandResult with no reply. Useful for async commands that will generate a reply

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -26,6 +26,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/IOSC.h"
+#include "Core/IOS/VersionInfo.h"
 #include "Core/ec_wii.h"
 
 namespace IOS
@@ -585,6 +586,10 @@ IPCCommandResult ES::Launch(const IOCtlVRequest& request)
 
   INFO_LOG(IOS_ES, "IOCTL_ES_LAUNCH %016" PRIx64 " %08x %016" PRIx64 " %08x %016" PRIx64 " %04x",
            TitleID, view, ticketid, devicetype, titleid, access);
+
+  // Prevent loading installed IOSes that are not emulated.
+  if (!IOS::HLE::IsEmulated(TitleID))
+    return GetDefaultReply(FS_ENOENT);
 
   // IOS replies to the request through the mailbox on failure, and acks if the launch succeeds.
   // Note: Launch will potentially reset the whole IOS state -- including this ES instance.

--- a/Source/Core/Core/IOS/ES/Views.cpp
+++ b/Source/Core/Core/IOS/ES/Views.cpp
@@ -17,6 +17,7 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/VersionInfo.h"
 
 namespace IOS
 {
@@ -51,7 +52,12 @@ IPCCommandResult ES::GetTicketViewCount(const IOCtlVRequest& request)
   const IOS::ES::TicketReader ticket = FindSignedTicket(TitleID);
   u32 view_count = ticket.IsValid() ? static_cast<u32>(ticket.GetNumberOfTickets()) : 0;
 
-  if (ShouldReturnFakeViewsForIOSes(TitleID, m_title_context))
+  if (!IOS::HLE::IsEmulated(TitleID))
+  {
+    view_count = 0;
+    ERROR_LOG(IOS_ES, "GetViewCount: Dolphin doesn't emulate IOS title %016" PRIx64, TitleID);
+  }
+  else if (ShouldReturnFakeViewsForIOSes(TitleID, m_title_context))
   {
     view_count = 1;
     WARN_LOG(IOS_ES, "GetViewCount: Faking IOS title %016" PRIx64 " being present", TitleID);
@@ -74,7 +80,11 @@ IPCCommandResult ES::GetTicketViews(const IOCtlVRequest& request)
 
   const IOS::ES::TicketReader ticket = FindSignedTicket(TitleID);
 
-  if (ticket.IsValid())
+  if (!IOS::HLE::IsEmulated(TitleID))
+  {
+    ERROR_LOG(IOS_ES, "GetViews: Dolphin doesn't emulate IOS title %016" PRIx64, TitleID);
+  }
+  else if (ticket.IsValid())
   {
     u32 number_of_views = std::min(maxViews, static_cast<u32>(ticket.GetNumberOfTickets()));
     for (u32 view = 0; view < number_of_views; ++view)

--- a/Source/Core/Core/IOS/VersionInfo.cpp
+++ b/Source/Core/Core/IOS/VersionInfo.cpp
@@ -4,9 +4,12 @@
 
 #include "Core/IOS/VersionInfo.h"
 
+#include <algorithm>
 #include <array>
 
 #include "Common/CommonTypes.h"
+#include "Core/CommonTitles.h"
+#include "Core/IOS/ES/Formats.h"
 
 namespace IOS
 {
@@ -373,6 +376,21 @@ Feature GetFeatures(u32 version)
 bool HasFeature(u32 major_version, Feature feature)
 {
   return HasFeature(GetFeatures(major_version), feature);
+}
+
+bool IsEmulated(u32 major_version)
+{
+  return std::any_of(
+      ios_memory_values.begin(), ios_memory_values.end(),
+      [major_version](const MemoryValues& values) { return values.ios_number == major_version; });
+}
+
+bool IsEmulated(u64 title_id)
+{
+  const bool ios =
+      IsTitleType(title_id, IOS::ES::TitleType::System) && title_id != Titles::SYSTEM_MENU;
+  const u32 version = static_cast<u32>(title_id);
+  return ios && IsEmulated(version);
 }
 }
 }

--- a/Source/Core/Core/IOS/VersionInfo.h
+++ b/Source/Core/Core/IOS/VersionInfo.h
@@ -83,5 +83,7 @@ constexpr bool HasFeature(Feature features, Feature feature)
 
 bool HasFeature(u32 major_version, Feature feature);
 Feature GetFeatures(u32 major_version);
+bool IsEmulated(u32 major_version);
+bool IsEmulated(u64 title_id);
 }
 }


### PR DESCRIPTION
This PR is a response to: https://github.com/dolphin-emu/dolphin/pull/5225

Rather than handling IOSes that Dolphin doesn't emulate, let's pretend that they don't exist. Otherwise, it creates a weird behaviour where libogc believes that the context is acceptable for running functions like ```ES_GetNumTicketViews``` and ```ES_GetTicketViews```.

This PR fixes homebrew not booting while relying on IOS reloading of an (custom) IOS that isn't emulated by Dolphin but present in the NAND. These homebrew were blocked into an infinite loop during the ```IOS_ReloadIOS``` call.

I did some hardware tests too. If the app files are made empty or deleted, ditto for the TMD or the data/content is deleted, calling ```IOS_ReloadIOS``` will result in a black screen (no trace, no stack dump message or whatsoever). I assume, the console didn't like that at all. It was tested on a 3.2E Wii with a simple homebrew which calls ```IOS_ReloadIOS```.

Ready to be reviewed.