### PR TITLE
DolphinWX: Propagate IDM_UPDATE_BREAKPOINTS to CodeWindow

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -814,6 +814,10 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
     }
   }
   break;
+
+  case IDM_UPDATE_BREAKPOINTS:
+    m_code_window->GetEventHandler()->AddPendingEvent(event);
+    break;
   }
 }
 


### PR DESCRIPTION
This PR fixes MBP created from the MemoryView not appearing in the Breakpoint list.

Ready to be reviewed & merged.