### PR TITLE
Jit64: fixed some signed to unsigned integer warnings

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -493,7 +493,8 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
   UGeckoInstruction next = js.op[1].inst;
   if (analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CROR_MERGE) &&
       CanMergeNextInstructions(1) && next.OPCD == 19 && next.SUBOP10 == 449 &&
-      (next.CRBA >> 2) == crf && (next.CRBB >> 2) == crf && (next.CRBD >> 2) == crf)
+      static_cast<u32>(next.CRBA >> 2) == crf && static_cast<u32>(next.CRBB >> 2) == crf &&
+      static_cast<u32>(next.CRBD >> 2) == crf)
   {
     js.skipInstructions = 1;
     js.downcountAmount++;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -352,7 +352,7 @@ bool Jit64::CheckMergedBranch(u32 crf)
            ((next.OPCD == 19) && (next.SUBOP10 == 528) /* bcctrx */) ||
            ((next.OPCD == 19) && (next.SUBOP10 == 16) /* bclrx */)) &&
           (next.BO & BO_DONT_DECREMENT_FLAG) && !(next.BO & BO_DONT_CHECK_CONDITION) &&
-          (next.BI >> 2) == crf);
+          static_cast<u32>(next.BI >> 2) == crf);
 }
 
 void Jit64::DoMergedBranch()


### PR DESCRIPTION
Trying to clean up some compiler warnings.  Please delete old pull request, all style commits have been merged into one.