### PR TITLE
Fix emulated Wiimotes

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -205,7 +205,7 @@ void Wiimote::RequestStatus(const wm_request_status* const rs)
   HandleExtensionSwap();
 
   // update status struct
-  m_status.extension = (m_extension->active_extension || m_motion_plus_active) ? 1 : 0;
+  m_status.extension = m_extension->active_extension ? 1 : 0;
 
   // set up report
   u8 data[8];
@@ -299,17 +299,14 @@ void Wiimote::WriteData(const wm_write_data* const wd)
 
     // extension register
     case 0xa4:
-      region_ptr = m_motion_plus_active ? (void*)&m_reg_motion_plus : (void*)&m_reg_ext;
+      region_ptr = (void*)&m_reg_ext;
       region_size = WIIMOTE_REG_EXT_SIZE;
       break;
 
     // motion plus
     case 0xa6:
-      if (false == m_motion_plus_active)
-      {
-        region_ptr = &m_reg_motion_plus;
-        region_size = WIIMOTE_REG_EXT_SIZE;
-      }
+      region_ptr = &m_reg_motion_plus;
+      region_size = WIIMOTE_REG_EXT_SIZE;
       break;
 
     // ir
@@ -340,7 +337,6 @@ void Wiimote::WriteData(const wm_write_data* const wd)
       {
         // maybe hacky
         m_reg_motion_plus.activated = 0;
-        m_motion_plus_active ^= 1;
 
         RequestStatus();
       }
@@ -434,18 +430,15 @@ void Wiimote::ReadData(const wm_read_data* const rd)
 
     // extension
     case 0xa4:
-      region_ptr = m_motion_plus_active ? (void*)&m_reg_motion_plus : (void*)&m_reg_ext;
+      region_ptr = (void*)&m_reg_ext;
       region_size = WIIMOTE_REG_EXT_SIZE;
       break;
 
     // motion plus
     case 0xa6:
       // reading from 0xa6 returns error when mplus is activated
-      if (false == m_motion_plus_active)
-      {
-        region_ptr = &m_reg_motion_plus;
-        region_size = WIIMOTE_REG_EXT_SIZE;
-      }
+      region_ptr = &m_reg_motion_plus;
+      region_size = WIIMOTE_REG_EXT_SIZE;
       break;
 
     // ir
@@ -556,8 +549,6 @@ void Wiimote::DoState(PointerWrap& p)
   p.Do(ir_cos);
   p.Do(m_rumble_on);
   p.Do(m_speaker_mute);
-  p.Do(m_motion_plus_present);
-  p.Do(m_motion_plus_active);
   p.Do(m_reporting_auto);
   p.Do(m_reporting_mode);
   p.Do(m_reporting_channel);

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -207,8 +207,6 @@ void Wiimote::Reset()
 
   m_rumble_on = false;
   m_speaker_mute = false;
-  m_motion_plus_present = false;
-  m_motion_plus_active = false;
 
   // will make the first Update() call send a status request
   // the first call to RequestStatus() will then set up the status struct extension bit
@@ -395,8 +393,6 @@ ControllerEmu::ControlGroup* Wiimote::GetTurntableGroup(TurntableGroup group)
 
 bool Wiimote::Step()
 {
-  m_motion_plus_present = m_motion_plus_setting->GetValue();
-
   m_motor->control_ref->State(m_rumble_on);
 
   // when a movie is active, this button status update is disabled (moved), because movies only
@@ -660,13 +656,6 @@ void Wiimote::GetExtData(u8* const data)
   // commercial games don't do this.
   // i think it should be unencrpyted in the register, encrypted when read.
   memcpy(m_reg_ext.controller_data, data, sizeof(wm_nc));  // TODO: Should it be nc specific?
-
-  if (m_motion_plus_active)
-  {
-    reinterpret_cast<wm_motionplus_data*>(data)->is_mp_data = 0;
-    reinterpret_cast<wm_motionplus_data*>(data)->extension_connected =
-        m_extension->active_extension;
-  }
 
   if (0xAA == m_reg_ext.encryption)
     WiimoteEncrypt(&m_ext_key, data, 0x00, sizeof(wm_nc));

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -253,7 +253,6 @@ private:
   ControllerEmu::ControlGroup* m_rumble;
   ControllerEmu::Output* m_motor;
   ControllerEmu::Extension* m_extension;
-  ControllerEmu::BooleanSetting* m_motion_plus_setting;
   ControllerEmu::ControlGroup* m_options;
   ControllerEmu::BooleanSetting* m_sideways_setting;
   ControllerEmu::BooleanSetting* m_upright_setting;
@@ -270,8 +269,6 @@ private:
 
   bool m_rumble_on;
   bool m_speaker_mute;
-  bool m_motion_plus_present;
-  bool m_motion_plus_active;
 
   bool m_reporting_auto;
   u8 m_reporting_mode;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 92;  // Last changed in PR 6173
+static const u32 STATE_VERSION = 93;  // Last changed in PR 6389
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Fixes the regression introduced by #6362.

Increases the save state version, as we don't save all that motion plus garbage anymore.