### PR TITLE
Qt: Remove unnecessary <iostream> includes

### DIFF
--- a/Source/Core/DolphinQt2/Config/CheatWarningWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/CheatWarningWidget.cpp
@@ -10,8 +10,6 @@
 #include <QPushButton>
 #include <QStyle>
 
-#include <iostream>
-
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DolphinQt2/Settings.h"
@@ -23,10 +21,8 @@ CheatWarningWidget::CheatWarningWidget(const std::string& game_id) : m_game_id(g
 
   connect(&Settings::Instance(), &Settings::EnableCheatsChanged,
           [this] { Update(Core::IsRunning()); });
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, [this](Core::State state) {
-    std::cout << (state == Core::State::Running) << std::endl;
-    Update(state == Core::State::Running);
-  });
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged,
+          [this](Core::State state) { Update(state == Core::State::Running); });
 
   Update(Core::IsRunning());
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -9,8 +9,6 @@
 #include <QString>
 #include <QTimer>
 
-#include <iostream>
-
 #include "DolphinQt2/Config/Mapping/MappingButton.h"
 
 #include "Common/Thread.h"

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingIndicator.cpp
@@ -10,8 +10,6 @@
 #include <QPainter>
 #include <QTimer>
 
-#include <iostream>
-
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"


### PR DESCRIPTION
`<iostream>` injects a static constructor into the translation units that it's included into, which should be avoided.