### PR TITLE
OGL: Call GLInterface->Update() on window resize

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1446,6 +1446,7 @@ void Renderer::CheckForSurfaceResize()
   if (!m_surface_resized.TestAndClear())
     return;
 
+  GLInterface->Update();
   m_backbuffer_width = m_new_backbuffer_width;
   m_backbuffer_height = m_new_backbuffer_height;
 }


### PR DESCRIPTION
macOS in particular requires the context be updated manually when the window is resized.