### PR TITLE
CMake/OSX: Fix missing QMacStylePlugin

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -178,6 +178,10 @@ if(APPLE)
   target_sources(${DOLPHINQT2_BINARY} PRIVATE "${qtcocoa_location}")
   set_source_files_properties("${qtcocoa_location}" PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/platforms)
 
+  get_target_property(qtmacstyle_location Qt5::QMacStylePlugin LOCATION)
+  target_sources(${DOLPHINQT2_BINARY} PRIVATE "${qtmacstyle_location}")
+  set_source_files_properties("${qtmacstyle_location}" PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/styles)
+
   # Copy resources into the bundle
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/Data/Sys")
   file(GLOB_RECURSE resources RELATIVE "${CMAKE_SOURCE_DIR}/Data" "${CMAKE_SOURCE_DIR}/Data/Sys/*")


### PR DESCRIPTION
Should fix Qt not using the native OSX style.