### PR TITLE
Include <endian.h> for byte swap macros on OpenBSD

### DIFF
--- a/Source/Core/Common/Swap.h
+++ b/Source/Core/Common/Swap.h
@@ -13,6 +13,8 @@
 #include <byteswap.h>
 #elif defined(__FreeBSD__)
 #include <sys/endian.h>
+#elif defined(__OpenBSD__)
+#include <endian.h>
 #endif
 
 #include "Common/CommonTypes.h"


### PR DESCRIPTION
There is code below that assumes the presence of those macros (by #undef'ing them), but none of the included headers provided them.

This fixes a build failure on OpenBSD where the undef'd macros _do_ get picked up later on in a compilation unit (through which include, I don't know), and thus shadow the Common::swap* functions.