### PR TITLE
IOS: Fix regression affecting BC launch

### DIFF
--- a/Source/Core/Core/IOS/VersionInfo.cpp
+++ b/Source/Core/Core/IOS/VersionInfo.cpp
@@ -380,6 +380,9 @@ bool HasFeature(u32 major_version, Feature feature)
 
 bool IsEmulated(u32 major_version)
 {
+  if (major_version == static_cast<u32>(Titles::BC & 0xffffffff))
+    return true;
+
   return std::any_of(
       ios_memory_values.begin(), ios_memory_values.end(),
       [major_version](const MemoryValues& values) { return values.ios_number == major_version; });


### PR DESCRIPTION
8e06257f19 caused Dolphin not to consider BC as emulated anymore.