### PR TITLE
IOS: Minor IPC fixes

### DIFF
--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -211,6 +211,11 @@ static void UpdateInterrupts(u64 userdata, s64 cyclesLate)
                                    !!(ppc_irq_flags & ppc_irq_masks));
 }
 
+void ClearX1()
+{
+  ctrl.X1 = 0;
+}
+
 void GenerateAck(u32 _Address)
 {
   ctrl.Y2 = 1;

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -213,7 +213,9 @@ void GenerateAck(u32 _Address)
   ctrl.Y2 = 1;
   DEBUG_LOG(WII_IPC, "GenerateAck: %08x | %08x [R:%i A:%i E:%i]", ppc_msg, _Address, ctrl.Y1,
             ctrl.Y2, ctrl.X1);
-  CoreTiming::ScheduleEvent(1000, updateInterrupts, 0);
+  // Based on a hardware test, the IPC interrupt takes approximately 100 TB ticks to fire
+  // after Y2 is seen in the control register.
+  CoreTiming::ScheduleEvent(100 * SystemTimers::TIMER_RATIO, updateInterrupts);
 }
 
 void GenerateReply(u32 _Address)
@@ -222,7 +224,9 @@ void GenerateReply(u32 _Address)
   ctrl.Y1 = 1;
   DEBUG_LOG(WII_IPC, "GenerateReply: %08x | %08x [R:%i A:%i E:%i]", ppc_msg, _Address, ctrl.Y1,
             ctrl.Y2, ctrl.X1);
-  UpdateInterrupts();
+  // Based on a hardware test, the IPC interrupt takes approximately 100 TB ticks to fire
+  // after Y1 is seen in the control register.
+  CoreTiming::ScheduleEvent(100 * SystemTimers::TIMER_RATIO, updateInterrupts);
 }
 
 bool IsReady()

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -213,7 +213,6 @@ static void UpdateInterrupts(u64 userdata, s64 cyclesLate)
 
 void GenerateAck(u32 _Address)
 {
-  arm_msg = _Address;  // dunno if it's really set here, but HLE needs to stay in context
   ctrl.Y2 = 1;
   DEBUG_LOG(WII_IPC, "GenerateAck: %08x | %08x [R:%i A:%i E:%i]", ppc_msg, _Address, ctrl.Y1,
             ctrl.Y2, ctrl.X1);

--- a/Source/Core/Core/HW/WII_IPC.h
+++ b/Source/Core/Core/HW/WII_IPC.h
@@ -42,6 +42,7 @@ void DoState(PointerWrap& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
+void ClearX1();
 void GenerateAck(u32 _Address);
 void GenerateReply(u32 _Address);
 

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -184,10 +184,18 @@ IPCCommandResult Device::Unsupported(const Request& request)
   return GetDefaultReply(IPC_EINVAL);
 }
 
-// Returns an IPCCommandResult for a reply that takes 25 us (based on ES::GetTicketViews)
+// Returns an IPCCommandResult for a reply with an average reply time for devices
+// Please avoid using this function if more accurate timings are known.
 IPCCommandResult Device::GetDefaultReply(const s32 return_value)
 {
-  return {return_value, true, SystemTimers::GetTicksPerSecond() / 40000};
+  // Based on a hardware test, a device takes at least ~2700 ticks to reply to an IPC request.
+  // Depending on how much work a command performs, this can take much longer (10000+)
+  // especially if the NAND filesystem is accessed.
+  //
+  // Because we currently don't emulate timing very accurately, we should not return
+  // the minimum possible reply time (~960 ticks from the kernel or ~2700 from devices)
+  // but an average time, otherwise we are going to be much too fast in most cases.
+  return {return_value, true, 4000 * SystemTimers::TIMER_RATIO};
 }
 
 // Returns an IPCCommandResult with no reply. Useful for async commands that will generate a reply

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -475,7 +475,7 @@ IPCCommandResult Kernel::OpenDevice(OpenRequest& request)
   if (new_fd < 0 || new_fd >= IPC_MAX_FDS)
   {
     ERROR_LOG(IOS, "Couldn't get a free fd, too many open files");
-    return IPCCommandResult{FS_EFDEXHAUSTED, true, 5000 * SystemTimers::TIMER_RATIO};
+    return IPCCommandResult{IPC_EMAX, true, 5000 * SystemTimers::TIMER_RATIO};
   }
   request.fd = new_fd;
 

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -629,6 +629,7 @@ void Kernel::UpdateIPC()
 
   if (m_request_queue.size())
   {
+    ClearX1();
     GenerateAck(m_request_queue.front());
     u32 command = m_request_queue.front();
     m_request_queue.pop_front();

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -622,8 +622,6 @@ void Kernel::HandleIPCEvent(u64 userdata)
   UpdateIPC();
 }
 
-// This is called every IPC_HLE_PERIOD from SystemTimers.cpp
-// Takes care of routing ipc <-> ipc HLE
 void Kernel::UpdateIPC()
 {
   if (!IsReady())


### PR DESCRIPTION
This adjusts IOS IPC timing to be closer to actual hardware according to [hardware tests](https://github.com/leoetlino/hwtests/blob/af320e4/iostest/ipc_timing.cpp).

Dolphin, before the fixes:

<details>

```
Invalid command (1000 tests)
ack_ticks=85/1, reply_ticks=1518/1

Invalid command (with IPC interrupt) (1000 tests)
ack_ticks=187/0, reply_ticks=1436/1

Open with full FD table (1000 tests)
ack_ticks=85/0, reply_ticks=1518/0

Invalid open (1000 tests)
ack_ticks=85/0, reply_ticks=1518/0

Invalid FD (0) (1000 tests)
ack_ticks=85/0, reply_ticks=1518/1

Invalid FD (200) (1000 tests)
ack_ticks=85/0, reply_ticks=1519/1
```

</details>
<br>

Dolphin, after the fixes:

<details>

```
Invalid command (1000 tests)
ack_ticks=502/1, reply_ticks=978/1

Invalid command (with IPC interrupt) (1000 tests)
ack_ticks=620/0, reply_ticks=979/1

Open with full FD table (1000 tests)
ack_ticks=502/0, reply_ticks=5000/0

Invalid open (1000 tests)
ack_ticks=502/0, reply_ticks=3700/0

Invalid FD (0) (1000 tests)
ack_ticks=502/1, reply_ticks=549/1

Invalid FD (200) (1000 tests)
ack_ticks=502/1, reply_ticks=550/1
```

</details>
<br>

Here are the results on my console:

<details>

```
Invalid command (1000 tests)
ack_ticks=661/22, reply_ticks=963/7

Invalid command (with IPC interrupt) (1000 tests)
ack_ticks=783/23, reply_ticks=959/4

Open with full FD table (1000 tests)
ack_ticks=667/31, reply_ticks=5209/22

Invalid open (1000 tests)
ack_ticks=673/53, reply_ticks=3786/42

Invalid FD (0) (1000 tests)
ack_ticks=659/14, reply_ticks=557/5

Invalid FD (200) (1000 tests)
ack_ticks=659/14, reply_ticks=550/5
```

</details>

<br>

I picked a slightly lower number of ticks for acks because JMC's console is faster than mine (~300-400 ticks).
 
This also fixes small issues with the IPC emulation code:

* The IPC interrupt is triggered when IY1/IY2 is set and Y1/Y2 is written to even when this results in clearing the bit. In practice, this shouldn't change anything but it's a difference that Dolphin wasn't taking into account, which made me waste some time when I was trying to write a hwtest :/
* A very basic hardware test shows that the ARMMSG doesn't change until IOS replies. (People could have disassembled IOS to verify this too...)
* Hardware tests indicate that IOS clears X1 when it acknowledges an IPC request.
* Also fix the FD table full error code.

In practice, this fixes a regression introduced by a663fcb97 which caused the HBC to crash on exit.
 