### PR TITLE
IOS: Fix invalid FD being returned after an open

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -500,9 +500,12 @@ IPCCommandResult Kernel::OpenDevice(OpenRequest& request)
     return Device::Device::GetDefaultReply(IPC_ENOENT);
   }
 
-  const IPCCommandResult result = device->Open(request);
+  IPCCommandResult result = device->Open(request);
   if (result.return_value >= IPC_SUCCESS)
+  {
     m_fdmap[new_fd] = device;
+    result.return_value = new_fd;
+  }
   return result;
 }
 


### PR DESCRIPTION
Fixes a regression introduced by 80b1bf13c2.

The return value for open replies should be overwritten with the new
file descriptor.