### PR TITLE
Remove DSPLLE ReadAnnotatedAssembly error log entry

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -82,10 +82,8 @@ bool ReadAnnotatedAssembly(const std::string& filename)
 {
   File::IOFile f(filename, "r");
   if (!f)
-  {
-    ERROR_LOG(DSPLLE, "Bah! ReadAnnotatedAssembly couldn't find the file %s", filename.c_str());
     return false;
-  }
+
   char line[512];
 
   int last_addr = 0;


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10922

I tried placing the docs folder from [*REMOVED -JosJuice*] in my Dolphin Emulator folder but Dolphin still couldn't detect DSP_UC_AXWii.txt with DSPLLE. Am I placing it in the correct location?

Alternatively, if we can get DSP_UC_AXWii.txt in the proper location, I can change the `ERROR_LOG` to `INFO_LOG`