### PR TITLE
GameINI: Add a game patch to work around dcache issue (RX4E4Z)

### DIFF
--- a/Data/Sys/GameSettings/RX4E4Z.ini
+++ b/Data/Sys/GameSettings/RX4E4Z.ini
@@ -1,0 +1,26 @@
+# Casper's Scare School: Spooky Sports Day (RX4E4Z)
+
+[OnFrame]
+# Work around a dcache issue by preventing the game from doing something pointless.
+#
+# The game's DVD read function writes 0x87654321 to the entire read buffer and 0x12345678 to the
+# last 4 bytes. It then calls DVDReadAsync() and without waiting for the read to complete at all,
+# it checks if the last 4 bytes are still 0x12345678. If they are, then the game fails.
+#
+# The check always passes on console because DVDReadAsync() -> issueCommand() calls
+# DCInvalidateRange() (dcbi) on the read buffer.
+#
+# Dolphin cannot emulate this without an extremely significant performance hit.
+#
+# .text:800D2E64 lis       r7, game_dvd_read_callback@ha
+# .text:800D2E68 stw       r0, 0(r17) # write 0x12345678 to the end of the buffer
+# .text:800D2E6C mr        r5, read_length # length
+# .text:800D2E70 mr        r6, read_offset # offset
+# .text:800D2E74 addi      r3, this, file.file_info # file_info
+# .text:800D2E78 addi      r4, r4, dvd_read_buf@l # addr
+# .text:800D2E7C addi      r7, r7, game_dvd_read_callback@l # callback
+# .text:800D2E80 li        r8, 2         # unknown
+# .text:800D2E84 bl        DVDReadAsync
+#
+$Fix file reads (dcache bypass)
+0x800d2e68:dword:0x60000000


### PR DESCRIPTION
Work around a dcache issue by preventing the game from doing
something pointless.

The game's DVD read function writes 0x87654321 to the entire read
buffer and 0x12345678 to the last 4 bytes. It then calls DVDReadAsync()
and without waiting for the read to complete at all, it checks if the
last 4 bytes are still 0x12345678. If they are, then the game fails.

The check always passes on console because DVDReadAsync() calls
issueCommand(), which calls DCInvalidateRange(read_buffer) (dcbi).

Dolphin cannot emulate this without an extremely significant
performance hit (3-7x according to JMC).