### PR TITLE
Change FATAL_ERROR to STATUS message for OpenAL not found in externals

### DIFF
--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -59,13 +59,14 @@ if(WIN32)
   target_link_libraries(audiocommon PRIVATE audiocommon_xaudio27)
 
   set(ENV{OPENALDIR} ${PROJECT_SOURCE_DIR}/Externals/OpenAL)
+  # Dolphin loads openal32.dll at runtime
   find_package(OpenAL)
   if(OPENAL_FOUND)
     message(STATUS "OpenAL found, enabling OpenAL sound backend")
     target_sources(audiocommon PRIVATE OpenALStream.cpp)
     target_link_libraries(audiocommon PRIVATE OpenAL::OpenAL)
   else()
-    message(FATAL_ERROR "OpenAL NOT found in Externals")
+    message(STATUS "OpenAL NOT found in Externals")
   endif()
 endif()
 


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10924

#5691 dynamically loads openal32.dll. We don't need a `FATAL_ERROR` error message when Dolphin can't find the DLL

@LAGonauta had trouble compiling this but I had no problems on Win 10.