### PR TITLE
HLE: Improve format string detection heuristic

### DIFF
--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -47,8 +47,10 @@ void HLE_GeneralDebugPrint(ParameterType parameter_type)
 {
   std::string report_message;
 
-  // Is gpr3 pointing to a pointer rather than an ASCII string
-  if (PowerPC::HostIsRAMAddress(GPR(3)) && PowerPC::HostIsRAMAddress(PowerPC::HostRead_U32(GPR(3))))
+  // Is gpr3 pointing to a pointer (including nullptr) rather than an ASCII string
+  if (PowerPC::HostIsRAMAddress(GPR(3)) &&
+      (PowerPC::HostIsRAMAddress(PowerPC::HostRead_U32(GPR(3))) ||
+       PowerPC::HostRead_U32(GPR(3)) == 0))
   {
     if (PowerPC::HostIsRAMAddress(GPR(4)))
     {


### PR DESCRIPTION
This PR tries to improve the format string detection heuristic. I found out a function with ```___blank``` signature that passed a pointer as first parameter and the format string as second parameter. The issue was that the previous heuristic considered the first parameter as a valid empty ASCII string instead of a nullptr pointer, while the second parameter was the actual format string.

The downside of this method is that it won't work if people are displaying empty debug string (do we really care about that case?). The previous heuristic tried to distinguish the `r3` pointer between an ASCII string (`char*`) and a valid RAM pointer (`void**`), thus, excluding null pointers.

I tried it with most of my games with debug symbols and it didn't output garbage.

Ready to be reviewed.