### PR TITLE
UI: Show title ID in info panel

### DIFF
--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -32,7 +32,10 @@ QGroupBox* InfoWidget::CreateISODetails()
 
   QLineEdit* file_path = CreateValueDisplay(m_game.GetFilePath());
   QLineEdit* internal_name = CreateValueDisplay(m_game.GetInternalName());
-  QLineEdit* game_id = CreateValueDisplay(m_game.GetGameID());
+  QString game_id_string = m_game.GetGameID();
+  if (const u64 title_id = m_game.GetTitleID())
+    game_id_string += QStringLiteral(" (%1)").arg(title_id, 16, 16, QLatin1Char('0'));
+  QLineEdit* game_id = CreateValueDisplay(game_id_string);
   QLineEdit* country = CreateValueDisplay(m_game.GetCountry());
   QLineEdit* maker = CreateValueDisplay(m_game.GetMaker());
   QLineEdit* maker_id = CreateValueDisplay(QStringLiteral("0x") + m_game.GetMakerID());

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -5,6 +5,7 @@
 #include "DolphinWX/ISOProperties/InfoPanel.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <iterator>
 #include <optional>
 #include <string>
@@ -190,7 +191,11 @@ void InfoPanel::LoadISODetails()
   {
     const IOS::ES::TMDReader tmd = m_opened_iso->GetTMD(m_opened_iso->GetGamePartition());
     if (tmd.IsValid())
+    {
       m_ios_version->SetValue(StringFromFormat("IOS%u", static_cast<u32>(tmd.GetIOSId())));
+      m_game_id->SetValue(StrToWxStr(StringFromFormat(
+          "%s (%016" PRIx64 ")", m_opened_iso->GetGameID().c_str(), tmd.GetTitleId())));
+    }
   }
 }
 


### PR DESCRIPTION
Adds a way to easily get the title ID of a game. For Wii titles, it's sometimes more useful to know than the game ID.