### PR TITLE
Reimplement custom PNG banners in game list

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -193,7 +193,7 @@ static bool LoadBanner(std::string filename, u32* Banner)
 
   if (pVolume != nullptr)
   {
-    int Width, Height;
+    u32 Width, Height;
     std::vector<u32> BannerVec = pVolume->GetBanner(&Width, &Height);
     // This code (along with above inlines) is moved from
     // elsewhere.  Someone who knows anything about Android

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -83,7 +83,7 @@ public:
   virtual std::map<Language, std::string> GetShortMakers() const { return {}; }
   virtual std::map<Language, std::string> GetLongMakers() const { return {}; }
   virtual std::map<Language, std::string> GetDescriptions() const { return {}; }
-  virtual std::vector<u32> GetBanner(int* width, int* height) const = 0;
+  virtual std::vector<u32> GetBanner(u32* width, u32* height) const = 0;
   std::string GetApploaderDate() const { return GetApploaderDate(GetGamePartition()); }
   virtual std::string GetApploaderDate(const Partition& partition) const = 0;
   // 0 is the first disc, 1 is the second disc

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -150,7 +150,7 @@ std::map<Language, std::string> VolumeGC::GetDescriptions() const
   return m_converted_banner->descriptions;
 }
 
-std::vector<u32> VolumeGC::GetBanner(int* width, int* height) const
+std::vector<u32> VolumeGC::GetBanner(u32* width, u32* height) const
 {
   *width = m_converted_banner->image_width;
   *height = m_converted_banner->image_height;

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -42,7 +42,7 @@ public:
   std::map<Language, std::string> GetShortMakers() const override;
   std::map<Language, std::string> GetLongMakers() const override;
   std::map<Language, std::string> GetDescriptions() const override;
-  std::vector<u32> GetBanner(int* width, int* height) const override;
+  std::vector<u32> GetBanner(u32* width, u32* height) const override;
   std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override;
   std::optional<u8> GetDiscNumber(const Partition& partition = PARTITION_NONE) const override;
 
@@ -54,8 +54,8 @@ public:
   u64 GetRawSize() const override;
 
 private:
-  static const int GC_BANNER_WIDTH = 96;
-  static const int GC_BANNER_HEIGHT = 32;
+  static const u32 GC_BANNER_WIDTH = 96;
+  static const u32 GC_BANNER_HEIGHT = 32;
 
   struct GCBannerInformation
   {
@@ -89,8 +89,8 @@ private:
     std::map<Language, std::string> descriptions;
 
     std::vector<u32> image_buffer;
-    int image_height = 0;
-    int image_width = 0;
+    u32 image_height = 0;
+    u32 image_width = 0;
   };
 
   ConvertedGCBanner LoadBannerFile() const;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -144,7 +144,7 @@ std::map<Language, std::string> VolumeWAD::GetLongNames() const
   return ReadWiiNames(names);
 }
 
-std::vector<u32> VolumeWAD::GetBanner(int* width, int* height) const
+std::vector<u32> VolumeWAD::GetBanner(u32* width, u32* height) const
 {
   *width = 0;
   *height = 0;

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -42,7 +42,7 @@ public:
     return "";
   }
   std::map<Language, std::string> GetLongNames() const override;
-  std::vector<u32> GetBanner(int* width, int* height) const override;
+  std::vector<u32> GetBanner(u32* width, u32* height) const override;
   std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override
   {
     return "";

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -308,7 +308,7 @@ std::map<Language, std::string> VolumeWii::GetLongNames() const
   return ReadWiiNames(names);
 }
 
-std::vector<u32> VolumeWii::GetBanner(int* width, int* height) const
+std::vector<u32> VolumeWii::GetBanner(u32* width, u32* height) const
 {
   *width = 0;
   *height = 0;

--- a/Source/Core/DiscIO/VolumeWii.h
+++ b/Source/Core/DiscIO/VolumeWii.h
@@ -45,7 +45,7 @@ public:
   std::optional<u16> GetRevision(const Partition& partition) const override;
   std::string GetInternalName(const Partition& partition) const override;
   std::map<Language, std::string> GetLongNames() const override;
-  std::vector<u32> GetBanner(int* width, int* height) const override;
+  std::vector<u32> GetBanner(u32* width, u32* height) const override;
   std::string GetApploaderDate(const Partition& partition) const override;
   std::optional<u8> GetDiscNumber(const Partition& partition) const override;
 

--- a/Source/Core/DiscIO/WiiSaveBanner.cpp
+++ b/Source/Core/DiscIO/WiiSaveBanner.cpp
@@ -16,13 +16,13 @@
 
 namespace DiscIO
 {
-constexpr unsigned int BANNER_WIDTH = 192;
-constexpr unsigned int BANNER_HEIGHT = 64;
-constexpr unsigned int BANNER_SIZE = BANNER_WIDTH * BANNER_HEIGHT * 2;
+constexpr u32 BANNER_WIDTH = 192;
+constexpr u32 BANNER_HEIGHT = 64;
+constexpr u32 BANNER_SIZE = BANNER_WIDTH * BANNER_HEIGHT * 2;
 
-constexpr unsigned int ICON_WIDTH = 48;
-constexpr unsigned int ICON_HEIGHT = 48;
-constexpr unsigned int ICON_SIZE = ICON_WIDTH * ICON_HEIGHT * 2;
+constexpr u32 ICON_WIDTH = 48;
+constexpr u32 ICON_HEIGHT = 48;
+constexpr u32 ICON_SIZE = ICON_WIDTH * ICON_HEIGHT * 2;
 
 WiiSaveBanner::WiiSaveBanner(u64 title_id)
     : WiiSaveBanner(Common::GetTitleDataPath(title_id, Common::FROM_CONFIGURED_ROOT) +
@@ -55,7 +55,7 @@ std::string WiiSaveBanner::GetDescription() const
   return UTF16BEToUTF8(m_header.description, ArraySize(m_header.description));
 }
 
-std::vector<u32> WiiSaveBanner::GetBanner(int* width, int* height) const
+std::vector<u32> WiiSaveBanner::GetBanner(u32* width, u32* height) const
 {
   *width = 0;
   *height = 0;

--- a/Source/Core/DiscIO/WiiSaveBanner.h
+++ b/Source/Core/DiscIO/WiiSaveBanner.h
@@ -22,7 +22,7 @@ public:
   std::string GetName() const;
   std::string GetDescription() const;
 
-  std::vector<u32> GetBanner(int* width, int* height) const;
+  std::vector<u32> GetBanner(u32* width, u32* height) const;
 
 private:
   struct Header

--- a/Source/Core/UICommon/GameFile.h
+++ b/Source/Core/UICommon/GameFile.h
@@ -31,11 +31,14 @@ namespace UICommon
 struct GameBanner
 {
   std::vector<u32> buffer{};
-  int width{};
-  int height{};
+  u32 width{};
+  u32 height{};
   bool empty() const { return buffer.empty(); }
   void DoState(PointerWrap& p);
 };
+
+bool operator==(const GameBanner& lhs, const GameBanner& rhs);
+bool operator!=(const GameBanner& lhs, const GameBanner& rhs);
 
 // This class caches the metadata of a DiscIO::Volume (or a DOL/ELF file).
 class GameFile final
@@ -77,10 +80,12 @@ public:
   const std::string& GetApploaderDate() const { return m_apploader_date; }
   u64 GetFileSize() const { return m_file_size; }
   u64 GetVolumeSize() const { return m_volume_size; }
-  const GameBanner& GetBannerImage() const { return m_volume_banner; }
+  const GameBanner& GetBannerImage() const;
   void DoState(PointerWrap& p);
-  bool BannerChanged();
-  void BannerCommit();
+  bool WiiBannerChanged();
+  void WiiBannerCommit();
+  bool CustomBannerChanged();
+  void CustomBannerCommit();
   bool CustomNameChanged(const Core::TitleDatabase& title_database);
   void CustomNameCommit();
 
@@ -90,6 +95,7 @@ private:
   const std::string&
   LookupUsingConfigLanguage(const std::map<DiscIO::Language, std::string>& strings) const;
   bool IsElfOrDol() const;
+  bool ReadPNGBanner(const std::string& path);
 
   // IMPORTANT: Nearly all data members must be save/restored in DoState.
   // If anything is changed, make sure DoState handles it properly and
@@ -121,6 +127,7 @@ private:
   std::string m_apploader_date{};
 
   GameBanner m_volume_banner{};
+  GameBanner m_custom_banner{};
   // Overridden name from TitleDatabase
   std::string m_custom_name{};
 
@@ -129,6 +136,7 @@ private:
   struct
   {
     GameBanner volume_banner;
+    GameBanner custom_banner;
     std::string custom_name;
   } m_pending{};
 };

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -28,7 +28,7 @@
 
 namespace UICommon
 {
-static constexpr u32 CACHE_REVISION = 9;  // Last changed in PR 6569
+static constexpr u32 CACHE_REVISION = 10;  // Last changed in PR 6429
 
 std::vector<std::string> FindAllGamePaths(const std::vector<std::string>& directories_to_scan,
                                           bool recursive_scan)
@@ -138,17 +138,20 @@ bool GameFileCache::UpdateAdditionalMetadata(const Core::TitleDatabase& title_da
 bool GameFileCache::UpdateAdditionalMetadata(std::shared_ptr<GameFile>* game_file,
                                              const Core::TitleDatabase& title_database)
 {
-  const bool banner_changed = (*game_file)->BannerChanged();
+  const bool wii_banner_changed = (*game_file)->WiiBannerChanged();
+  const bool custom_banner_changed = (*game_file)->CustomBannerChanged();
   const bool custom_title_changed = (*game_file)->CustomNameChanged(title_database);
-  if (!banner_changed && !custom_title_changed)
+  if (!wii_banner_changed && !custom_banner_changed && !custom_title_changed)
     return false;
 
   // If a cached file needs an update, apply the updates to a copy and delete the original.
   // This makes the usage of cached files in other threads safe.
 
   std::shared_ptr<GameFile> copy = std::make_shared<GameFile>(**game_file);
-  if (banner_changed)
-    copy->BannerCommit();
+  if (wii_banner_changed)
+    copy->WiiBannerCommit();
+  if (custom_banner_changed)
+    copy->CustomBannerCommit();
   if (custom_title_changed)
     copy->CustomNameCommit();
   *game_file = std::move(copy);


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10938 and makes PNG banners available in DolphinQt2 for the first time.

The first commit contains code from PR #6291. Just like with that PR, the Ubuntu buildbot will need an updated version of libpng before this will build.