### PR TITLE
ShaderCache: Fix several issues in background shader compiling

### DIFF
--- a/Source/Core/VideoCommon/AsyncShaderCompiler.cpp
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.cpp
@@ -57,6 +57,12 @@ bool AsyncShaderCompiler::HasPendingWork()
   return !m_pending_work.empty() || m_busy_workers.load() != 0;
 }
 
+bool AsyncShaderCompiler::HasCompletedWork()
+{
+  std::lock_guard<std::mutex> guard(m_completed_work_lock);
+  return !m_completed_work.empty();
+}
+
 void AsyncShaderCompiler::WaitUntilCompletion()
 {
   while (HasPendingWork())

--- a/Source/Core/VideoCommon/AsyncShaderCompiler.h
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.h
@@ -45,6 +45,7 @@ public:
   void QueueWorkItem(WorkItemPtr item);
   void RetrieveWorkItems();
   bool HasPendingWork();
+  bool HasCompletedWork();
 
   // Simpler version without progress updates.
   void WaitUntilCompletion();

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -72,7 +72,7 @@ private:
   void CompileMissingPipelines();
   void InvalidateCachedPipelines();
   void ClearPipelineCaches();
-  void PrecompileUberShaders();
+  void QueueUberShaderPipelines();
 
   // GX shader compiler methods
   std::unique_ptr<AbstractShader> CompileVertexShader(const VertexShaderUid& uid) const;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -198,7 +198,7 @@ u32 VideoConfig::GetShaderCompilerThreads() const
 u32 VideoConfig::GetShaderPrecompilerThreads() const
 {
   // When using background compilation, always keep the same thread count.
-  if (bWaitForShadersBeforeStarting)
+  if (!bWaitForShadersBeforeStarting)
     return GetShaderCompilerThreads();
 
   if (!backend_info.bSupportsBackgroundCompiling)


### PR DESCRIPTION
Fixes some bugs in the videocommon shader cache which managed to sneak in. None of these are really noticeable unless you're looking at the internal state of the shader cache, but are still important nonetheless.

- In D3D, shaders could be compiled on the main thread, blocking startup.
- Reduced the latency between a pipeline being requested and used in all backends in hybrid ubershader mode, when no shader stages were present.
- Fixed a case where async compilation could cause the same UID to be appended multiple times to the UID cache.
- Fix incorrect number of threads being used when immediately compile shaders was enabled.