### PR TITLE
ShaderCache: Decouple shader UID cache from git commit

### DIFF
--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "VideoCommon/GeometryShaderGen.h"
+#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/PixelShaderGen.h"
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/UberShaderPixel.h"
@@ -15,6 +16,12 @@ class NativeVertexFormat;
 
 namespace VideoCommon
 {
+// This version number must be incremented whenever any of the shader UID structures change.
+// As pipelines encompass both shader UIDs and render states, changes to either of these should
+// also increment the pipeline UID version. Incrementing the UID version will cause all UID
+// caches to be invalidated.
+constexpr u32 GX_PIPELINE_UID_VERSION = 1;
+
 struct GXPipelineUid
 {
   const NativeVertexFormat* vertex_format;
@@ -72,4 +79,20 @@ struct GXUberPipelineUid
   }
   bool operator!=(const GXUberPipelineUid& rhs) const { return !operator==(rhs); }
 };
+
+// Disk cache of pipeline UIDs. We can't use the whole UID as a type as it contains pointers.
+// This structure is safe to save to disk, and should be compiler/platform independent.
+#pragma pack(push, 1)
+struct SerializedGXPipelineUid
+{
+  PortableVertexDeclaration vertex_decl;
+  VertexShaderUid vs_uid;
+  GeometryShaderUid gs_uid;
+  PixelShaderUid ps_uid;
+  u32 rasterization_state_bits;
+  u32 depth_state_bits;
+  u32 blending_state_bits;
+};
+#pragma pack(pop)
+
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "Common/CommonTypes.h"
+#include "Common/File.h"
 #include "Common/LinearDiskCache.h"
 
 #include "VideoCommon/AbstractPipeline.h"
@@ -22,7 +23,6 @@
 #include "VideoCommon/AsyncShaderCompiler.h"
 #include "VideoCommon/GXPipelineTypes.h"
 #include "VideoCommon/GeometryShaderGen.h"
-#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/PixelShaderGen.h"
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/UberShaderPixel.h"
@@ -68,6 +68,7 @@ private:
   void LoadShaderCaches();
   void ClearShaderCaches();
   void LoadPipelineUIDCache();
+  void ClosePipelineUIDCache();
   void CompileMissingPipelines();
   void InvalidateCachedPipelines();
   void ClearPipelineCaches();
@@ -103,6 +104,7 @@ private:
                                            std::unique_ptr<AbstractPipeline> pipeline);
   const AbstractPipeline* InsertGXUberPipeline(const GXUberPipelineUid& config,
                                                std::unique_ptr<AbstractPipeline> pipeline);
+  void AddSerializedGXPipelineUID(const SerializedGXPipelineUid& uid);
   void AppendGXPipelineUID(const GXPipelineUid& config);
 
   // ASync Compiler Methods
@@ -141,20 +143,7 @@ private:
   std::map<GXPipelineUid, std::pair<std::unique_ptr<AbstractPipeline>, bool>> m_gx_pipeline_cache;
   std::map<GXUberPipelineUid, std::pair<std::unique_ptr<AbstractPipeline>, bool>>
       m_gx_uber_pipeline_cache;
-
-  // Disk cache of pipeline UIDs
-  // We can't use the whole UID as a type
-  struct GXPipelineDiskCacheUid
-  {
-    PortableVertexDeclaration vertex_decl;
-    VertexShaderUid vs_uid;
-    GeometryShaderUid gs_uid;
-    PixelShaderUid ps_uid;
-    u32 rasterization_state_bits;
-    u32 depth_state_bits;
-    u32 blending_state_bits;
-  };
-  LinearDiskCache<GXPipelineDiskCacheUid, u8> m_gx_pipeline_uid_disk_cache;
+  File::IOFile m_gx_pipeline_uid_cache_file;
 };
 
 }  // namespace VideoCommon


### PR DESCRIPTION
This branch decouples the shader UID cache from the git hash. Instead, we use a fixed version number, defined in GXPipelineTypes.h. This enables users to share UID caches between Dolphin versions.

I've also moved the cache file location from "User/Cache/Shaders/pipeline-uid-&lt;GameID&gt;.cache" to "User/Cache/&lt;GameID&gt;.uidcache". In my opinion, this makes more sense as UIDs are not shaders, and will make it easier for users to locate these files, as there are no confusing backend-specific caches in this directory.