### PR TITLE
Qt: Improve spacing

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -102,6 +102,7 @@ set(SRCS
   QtUtils/ImageConverter.cpp
   QtUtils/ListTabWidget.cpp
   QtUtils/WindowActivationEventFilter.cpp
+  QtUtils/WrapInScrollArea.cpp
   QtUtils/AspectRatioWidget.cpp
   Settings/AdvancedPane.cpp
   Settings/AudioPane.cpp

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.cpp
@@ -30,6 +30,7 @@
 #include "Core/NetPlayProto.h"
 #include "DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.h"
 #include "DolphinQt2/Config/Mapping/MappingWindow.h"
+#include "DolphinQt2/QtUtils/WrapInScrollArea.h"
 #include "DolphinQt2/Settings.h"
 #include "UICommon/UICommon.h"
 
@@ -221,15 +222,15 @@ void ControllersWindow::CreateAdvancedLayout()
 
 void ControllersWindow::CreateMainLayout()
 {
-  m_main_layout = new QVBoxLayout();
+  auto* layout = new QVBoxLayout();
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
 
-  m_main_layout->addWidget(m_gc_box);
-  m_main_layout->addWidget(m_wiimote_box);
-  m_main_layout->addWidget(m_advanced_box);
-  m_main_layout->addWidget(m_button_box);
+  layout->addWidget(m_gc_box);
+  layout->addWidget(m_wiimote_box);
+  layout->addWidget(m_advanced_box);
+  layout->addWidget(m_button_box);
 
-  setLayout(m_main_layout);
+  WrapInScrollArea(this, layout);
 }
 
 void ControllersWindow::ConnectWidgets()

--- a/Source/Core/DolphinQt2/Config/ControllersWindow.h
+++ b/Source/Core/DolphinQt2/Config/ControllersWindow.h
@@ -47,7 +47,6 @@ private:
   void LoadSettings();
 
   // Main
-  QVBoxLayout* m_main_layout;
   QDialogButtonBox* m_button_box;
 
   // Gamecube

--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
@@ -64,7 +64,9 @@ void GeckoCodeWidget::CreateWidgets()
   m_add_code = new QPushButton(tr("&Add New Code..."));
   m_edit_code = new QPushButton(tr("&Edit Code..."));
   m_remove_code = new QPushButton(tr("&Remove Code"));
-  m_download_codes = new QPushButton(tr("Download Codes (WiiRD Database)"));
+  m_download_codes = new QPushButton(tr("Download Codes"));
+
+  m_download_codes->setToolTip(tr("Download Codes from the WiiRD Database"));
 
   m_download_codes->setEnabled(!m_game_id.empty());
   m_edit_code->setEnabled(false);

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -18,6 +18,7 @@
 #include "DolphinQt2/Config/Graphics/HacksWidget.h"
 #include "DolphinQt2/Config/Graphics/SoftwareRendererWidget.h"
 #include "DolphinQt2/MainWindow.h"
+#include "DolphinQt2/QtUtils/WrapInScrollArea.h"
 
 GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent)
     : QDialog(parent), m_xrr_config(xrr_config)
@@ -67,14 +68,14 @@ void GraphicsWindow::CreateMainLayout()
 
   if (SConfig::GetInstance().m_strVideoBackend != "Software Renderer")
   {
-    m_tab_widget->addTab(m_general_widget, tr("General"));
-    m_tab_widget->addTab(m_enhancements_widget, tr("Enhancements"));
-    m_tab_widget->addTab(m_hacks_widget, tr("Hacks"));
-    m_tab_widget->addTab(m_advanced_widget, tr("Advanced"));
+    m_tab_widget->addTab(GetWrappedWidget(m_general_widget, this, 250), tr("General"));
+    m_tab_widget->addTab(GetWrappedWidget(m_enhancements_widget, this, 250), tr("Enhancements"));
+    m_tab_widget->addTab(GetWrappedWidget(m_hacks_widget, this, 250), tr("Hacks"));
+    m_tab_widget->addTab(GetWrappedWidget(m_advanced_widget, this, 250), tr("Advanced"));
   }
   else
   {
-    m_tab_widget->addTab(m_software_renderer, tr("Software Renderer"));
+    m_tab_widget->addTab(GetWrappedWidget(m_software_renderer, this, 250), tr("Software Renderer"));
   }
 
   setLayout(main_layout);

--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -22,8 +22,10 @@
 InfoWidget::InfoWidget(const UICommon::GameFile& game) : m_game(game)
 {
   QVBoxLayout* layout = new QVBoxLayout();
+
   layout->addWidget(CreateISODetails());
   layout->addWidget(CreateBannerDetails());
+
   setLayout(layout);
 }
 
@@ -32,8 +34,15 @@ QGroupBox* InfoWidget::CreateISODetails()
   QGroupBox* group = new QGroupBox(tr("ISO Details"));
   QFormLayout* layout = new QFormLayout;
 
-  QLineEdit* file_path = CreateValueDisplay(m_game.GetFilePath());
-  QLineEdit* internal_name = CreateValueDisplay(m_game.GetInternalName());
+  QLineEdit* file_path = CreateValueDisplay(
+      QStringLiteral("%1 (%2)")
+          .arg(QString::fromStdString(m_game.GetFilePath()))
+          .arg(QString::fromStdString(UICommon::FormatSize(m_game.GetFileSize()))));
+  QLineEdit* internal_name =
+      CreateValueDisplay(tr("%1 (Disc %2, Revision %3)")
+                             .arg(QString::fromStdString(m_game.GetInternalName()))
+                             .arg(m_game.GetDiscNumber())
+                             .arg(m_game.GetRevision()));
 
   QString game_id_string = QString::fromStdString(m_game.GetGameID());
   if (const u64 title_id = m_game.GetTitleID())
@@ -41,24 +50,16 @@ QGroupBox* InfoWidget::CreateISODetails()
   QLineEdit* game_id = CreateValueDisplay(game_id_string);
 
   QLineEdit* country = CreateValueDisplay(DiscIO::GetName(m_game.GetCountry(), true));
-  QLineEdit* maker = CreateValueDisplay(m_game.GetMaker());
-  QLineEdit* maker_id = CreateValueDisplay("0x" + m_game.GetMakerID());
-  QLineEdit* disc_number = CreateValueDisplay(QString::number(m_game.GetDiscNumber()));
-  QLineEdit* revision = CreateValueDisplay(QString::number(m_game.GetRevision()));
+  QLineEdit* maker = CreateValueDisplay(m_game.GetMaker() + " (0x" + m_game.GetMakerID() + ")");
   QLineEdit* apploader_date = CreateValueDisplay(m_game.GetApploaderDate());
-  QLineEdit* iso_size = CreateValueDisplay(UICommon::FormatSize(m_game.GetFileSize()));
   QWidget* checksum = CreateChecksumComputer();
 
-  layout->addRow(tr("File Path:"), file_path);
-  layout->addRow(tr("Internal Name:"), internal_name);
+  layout->addRow(tr("Name:"), internal_name);
+  layout->addRow(tr("File:"), file_path);
   layout->addRow(tr("Game ID:"), game_id);
   layout->addRow(tr("Country:"), country);
   layout->addRow(tr("Maker:"), maker);
-  layout->addRow(tr("Maker ID:"), maker_id);
-  layout->addRow(tr("Disc Number:"), disc_number);
-  layout->addRow(tr("Revision:"), revision);
   layout->addRow(tr("Apploader Date:"), apploader_date);
-  layout->addRow(tr("ISO Size:"), iso_size);
   layout->addRow(tr("MD5 Checksum:"), checksum);
 
   group->setLayout(layout);
@@ -70,10 +71,8 @@ QGroupBox* InfoWidget::CreateBannerDetails()
   QGroupBox* group = new QGroupBox(tr("Banner Details"));
   QFormLayout* layout = new QFormLayout;
 
-  m_long_name = CreateValueDisplay();
-  m_short_name = CreateValueDisplay();
-  m_short_maker = CreateValueDisplay();
-  m_long_maker = CreateValueDisplay();
+  m_name = CreateValueDisplay();
+  m_maker = CreateValueDisplay();
   m_description = new QTextEdit();
   m_description->setReadOnly(true);
   CreateLanguageSelector();
@@ -81,15 +80,13 @@ QGroupBox* InfoWidget::CreateBannerDetails()
   layout->addRow(tr("Show Language:"), m_language_selector);
   if (m_game.GetPlatform() == DiscIO::Platform::GAMECUBE_DISC)
   {
-    layout->addRow(tr("Short Name:"), m_short_name);
-    layout->addRow(tr("Short Maker:"), m_short_maker);
-    layout->addRow(tr("Long Name:"), m_long_name);
-    layout->addRow(tr("Long Maker:"), m_long_maker);
+    layout->addRow(tr("Name:"), m_name);
+    layout->addRow(tr("Maker:"), m_maker);
     layout->addRow(tr("Description:"), m_description);
   }
   else if (DiscIO::IsWii(m_game.GetPlatform()))
   {
-    layout->addRow(tr("Name:"), m_long_name);
+    layout->addRow(tr("Name:"), m_name);
   }
 
   QPixmap banner = ToQPixmap(m_game.GetBannerImage());
@@ -156,10 +153,8 @@ void InfoWidget::ChangeLanguage()
 {
   DiscIO::Language language =
       static_cast<DiscIO::Language>(m_language_selector->currentData().toInt());
-  m_short_name->setText(QString::fromStdString(m_game.GetShortName(language)));
-  m_short_maker->setText(QString::fromStdString(m_game.GetShortMaker(language)));
-  m_long_name->setText(QString::fromStdString(m_game.GetLongName(language)));
-  m_long_maker->setText(QString::fromStdString(m_game.GetLongMaker(language)));
+  m_name->setText(QString::fromStdString(m_game.GetLongName(language)));
+  m_maker->setText(QString::fromStdString(m_game.GetLongMaker(language)));
   m_description->setText(QString::fromStdString(m_game.GetDescription(language)));
 }
 

--- a/Source/Core/DolphinQt2/Config/InfoWidget.h
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.h
@@ -38,9 +38,7 @@ private:
   UICommon::GameFile m_game;
   QLineEdit* m_checksum_result;
   QComboBox* m_language_selector;
-  QLineEdit* m_long_name;
-  QLineEdit* m_short_name;
-  QLineEdit* m_short_maker;
-  QLineEdit* m_long_maker;
+  QLineEdit* m_name;
+  QLineEdit* m_maker;
   QTextEdit* m_description;
 };

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -63,6 +63,10 @@ MappingButton::MappingButton(MappingWidget* widget, ControlReference* ref, bool 
   });
 
   m_timer->start(1000 / 30);
+
+  setMaximumHeight(24);
+  setMaximumWidth(200);
+  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 }
 
 void MappingButton::Connect()

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWidget.cpp
@@ -80,7 +80,6 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   for (auto& numeric : group->numeric_settings)
   {
     auto* spinbox = new MappingNumeric(this, numeric.get());
-    spinbox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     form_layout->addRow(QString::fromStdString(numeric->m_name), spinbox);
     m_numerics.push_back(spinbox);
   }
@@ -88,7 +87,6 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   for (auto& boolean : group->boolean_settings)
   {
     auto* checkbox = new MappingBool(this, boolean.get());
-    checkbox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     form_layout->addRow(checkbox);
     m_bools.push_back(checkbox);
   }

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -31,6 +31,7 @@
 #include "DolphinQt2/Config/Mapping/WiimoteEmuExtension.h"
 #include "DolphinQt2/Config/Mapping/WiimoteEmuGeneral.h"
 #include "DolphinQt2/Config/Mapping/WiimoteEmuMotionControl.h"
+#include "DolphinQt2/QtUtils/WrapInScrollArea.h"
 #include "DolphinQt2/Settings.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
@@ -312,7 +313,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
 
 void MappingWindow::AddWidget(const QString& name, QWidget* widget)
 {
-  m_tab_widget->addTab(widget, name);
+  m_tab_widget->addTab(GetWrappedWidget(widget, this, 150), name);
 }
 
 int MappingWindow::GetPort() const

--- a/Source/Core/DolphinQt2/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/PropertiesDialog.cpp
@@ -13,6 +13,7 @@
 #include "DolphinQt2/Config/InfoWidget.h"
 #include "DolphinQt2/Config/PatchesWidget.h"
 #include "DolphinQt2/Config/PropertiesDialog.h"
+#include "DolphinQt2/QtUtils/WrapInScrollArea.h"
 #include "UICommon/GameFile.h"
 
 PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& game)
@@ -37,11 +38,11 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
 
   connect(ar, &ARCodeWidget::OpenGeneralSettings, this, &PropertiesDialog::OpenGeneralSettings);
 
-  tab_widget->addTab(game_config, tr("Game Config"));
-  tab_widget->addTab(patches, tr("Patches"));
-  tab_widget->addTab(ar, tr("AR Codes"));
-  tab_widget->addTab(gecko, tr("Gecko Codes"));
-  tab_widget->addTab(info, tr("Info"));
+  tab_widget->addTab(GetWrappedWidget(game_config, this), tr("Game Config"));
+  tab_widget->addTab(GetWrappedWidget(patches, this), tr("Patches"));
+  tab_widget->addTab(GetWrappedWidget(ar, this), tr("AR Codes"));
+  tab_widget->addTab(GetWrappedWidget(gecko, this), tr("Gecko Codes"));
+  tab_widget->addTab(GetWrappedWidget(info, this), tr("Info"));
 
   if (DiscIO::IsDisc(game.GetPlatform()))
   {

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -120,6 +120,7 @@
     <QtMoc Include="NetPlay\PadMappingDialog.h" />
     <QtMoc Include="QtUtils\DoubleClickEventFilter.h" />
     <QtMoc Include="QtUtils\WindowActivationEventFilter.h" />
+    <QtMoc Include="QtUtils\WrapInScrollArea.h" />
     <QtMoc Include="QtUtils\AspectRatioWidget.h" />
     <QtMoc Include="RenderWidget.h" />
     <QtMoc Include="Settings.h" />
@@ -278,6 +279,7 @@
     <ClCompile Include="QtUtils\ImageConverter.cpp" />
     <ClCompile Include="QtUtils\ListTabWidget.cpp" />
     <ClCompile Include="QtUtils\WindowActivationEventFilter.cpp" />
+    <ClCompile Include="QtUtils\WrapInScrollArea.cpp" />
     <ClCompile Include="QtUtils\AspectRatioWidget.cpp" />
     <ClCompile Include="RenderWidget.cpp" />
     <ClCompile Include="Resources.cpp" />
@@ -320,6 +322,7 @@
     <ClInclude Include="QtUtils\ElidedButton.h" />
     <ClInclude Include="QtUtils\ImageConverter.h" />
     <ClInclude Include="QtUtils\ListTabWidget.h" />
+    <ClInclude Include="QtUtils\WrapInScrollArea.h" />
     <ClInclude Include="Resources.h" />
     <ClInclude Include="Settings\GameCubePane.h" />
     <ClInclude Include="Settings\PathPane.h" />

--- a/Source/Core/DolphinQt2/QtUtils/WrapInScrollArea.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/WrapInScrollArea.cpp
@@ -1,0 +1,48 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/QtUtils/WrapInScrollArea.h"
+
+#include <QFrame>
+#include <QLayout>
+#include <QScrollArea>
+#include <QVBoxLayout>
+#include <QWidget>
+
+QWidget* GetWrappedWidget(QWidget* wrapped_widget, QWidget* to_resize, int margin)
+{
+  auto* scroll = new QScrollArea;
+  scroll->setWidget(wrapped_widget);
+  scroll->setWidgetResizable(true);
+  scroll->setFrameStyle(QFrame::NoFrame);
+
+  if (to_resize != nullptr)
+  {
+    // For some reason width() is bigger than it needs to be.
+    int recommended_width = wrapped_widget->width() * 0.9;
+    int recommended_height = wrapped_widget->height() + margin;
+
+    to_resize->resize(std::max(recommended_width, to_resize->width()),
+                      std::max(recommended_height, to_resize->height()));
+  }
+
+  return scroll;
+}
+
+void WrapInScrollArea(QWidget* parent, QLayout* wrapped_layout, QWidget* to_resize)
+{
+  if (to_resize == nullptr)
+    to_resize = parent;
+
+  auto* widget = new QWidget;
+  widget->setLayout(wrapped_layout);
+
+  auto* scroll_area = GetWrappedWidget(widget, to_resize);
+
+  auto* scroll_layout = new QVBoxLayout;
+  scroll_layout->addWidget(scroll_area);
+  scroll_layout->setMargin(0);
+
+  parent->setLayout(scroll_layout);
+}

--- a/Source/Core/DolphinQt2/QtUtils/WrapInScrollArea.h
+++ b/Source/Core/DolphinQt2/QtUtils/WrapInScrollArea.h
@@ -1,0 +1,13 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+class QLayout;
+class QWidget;
+
+QWidget* GetWrappedWidget(QWidget* wrapped_widget, QWidget* to_resize = nullptr, int margin = 50);
+
+// Wrap wrapped_layout in a QScrollArea and fill the parent widget with it
+void WrapInScrollArea(QWidget* parent, QLayout* wrapped_layout, QWidget* to_resize = nullptr);


### PR DESCRIPTION
Some adjustments that should make Qt usable on smaller screens.
I've tested them with a 1280x720 resolution.

Fixes [issue #10937](https://bugs.dolphin-emu.org/issues/10937).

## Properties

*Note: Some screenshots here are outdated*

* Removed options from the Info tab and combined some others (still the same info as Wx has)
* Wrapped Info tab in scroll area (still to big for some screens)
* Turned "Download Codes (WiiRD Database)" into "Download Codes" and added a tool-tip to the button

Before:![Before](https://i.imgur.com/0blnRpu.png)
After: ![After](https://i.imgur.com/EAV0pnQ.png)

*Works fine in 720p now!*

## Controller Window

* Wrapped in scroll area, should only show up when necessary.

*Works fine in 720p now!*

## Graphics Window

* Tabs are scrollable too now.

## Controller Window

* Changed max. size of widgets

Before:![Before](https://i.imgur.com/wcTPlCh.png)
After: ![After](https://i.imgur.com/irLLsb3.png)

**Needs thorough reviewing**
