### PR TITLE
Bring the Android GUI setting for ubershaders up to date

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
@@ -262,10 +262,6 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 				{
 					putVideoBackendSetting(which);
 				}
-				else if (scSetting.getKey().equals(SettingsFile.KEY_UBERSHADER_MODE))
-				{
-					putUberShaderModeSetting(which);
-				}
 				else if (scSetting.getKey().equals(SettingsFile.KEY_WIIMOTE_EXTENSION))
 				{
 					putExtensionSetting(which, Character.getNumericValue(scSetting.getSection().charAt(scSetting.getSection().length() - 1)));
@@ -400,33 +396,6 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 		}
 
 		mView.putSetting(gfxBackend);
-	}
-
-  public void putUberShaderModeSetting(int which)
-  {
-		BooleanSetting disableSpecializedShaders = null;
-		BooleanSetting backgroundShaderCompilation = null;
-
-		switch (which)
-		{
-			case 0:
-				disableSpecializedShaders = new BooleanSetting(SettingsFile.KEY_DISABLE_SPECIALIZED_SHADERS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, false);
-				backgroundShaderCompilation = new BooleanSetting(SettingsFile.KEY_BACKGROUND_SHADER_COMPILING, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, false);
-				break;
-
-			case 1:
-				disableSpecializedShaders = new BooleanSetting(SettingsFile.KEY_DISABLE_SPECIALIZED_SHADERS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, false);
-				backgroundShaderCompilation = new BooleanSetting(SettingsFile.KEY_BACKGROUND_SHADER_COMPILING, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, true);
-				break;
-
-			case 2:
-				disableSpecializedShaders = new BooleanSetting(SettingsFile.KEY_DISABLE_SPECIALIZED_SHADERS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, true);
-				backgroundShaderCompilation = new BooleanSetting(SettingsFile.KEY_BACKGROUND_SHADER_COMPILING, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, false);
-				break;
-		}
-
-		mView.putSetting(disableSpecializedShaders);
-		mView.putSetting(backgroundShaderCompilation);
 	}
 
 	public void putExtensionSetting(int which, int wiimoteNumber)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -283,8 +283,6 @@ public final class SettingsFragmentPresenter
 
 	private void addEnhanceSettings(ArrayList<SettingsItem> sl)
 	{
-		int uberShaderModeValue = getUberShaderModeValue();
-
 		Setting resolution = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_INTERNAL_RES);
 		Setting fsaa = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_FSAA);
 		Setting anisotropic = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_ENHANCEMENTS).getSetting(SettingsFile.KEY_ANISOTROPY);
@@ -292,7 +290,7 @@ public final class SettingsFragmentPresenter
 		Setting perPixel = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_PER_PIXEL);
 		Setting forceFilter = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_ENHANCEMENTS).getSetting(SettingsFile.KEY_FORCE_FILTERING);
 		Setting disableFog = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_FOG);
-		IntSetting uberShaderMode = new IntSetting(SettingsFile.KEY_UBERSHADER_MODE, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, uberShaderModeValue);
+		Setting uberShaderMode = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_UBERSHADER_MODE);
 
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_INTERNAL_RES, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.internal_resolution, R.string.internal_resolution_descrip, R.array.internalResolutionEntries, R.array.internalResolutionValues, 0, resolution));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_FSAA, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.FSAA, R.string.FSAA_descrip, R.array.FSAAEntries, R.array.FSAAValues, 0, fsaa));
@@ -806,29 +804,6 @@ public final class SettingsFragmentPresenter
 		}
 
 		return videoBackendValue;
-	}
-
-	private int getUberShaderModeValue()
-	{
-		int uberShaderModeValue = 0;
-
-		try
-		{
-			boolean backgroundShaderCompiling = ((BooleanSetting) mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_BACKGROUND_SHADER_COMPILING)).getValue();
-			boolean disableSpecializedShaders = ((BooleanSetting) mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_GFX_SETTINGS).getSetting(SettingsFile.KEY_DISABLE_SPECIALIZED_SHADERS)).getValue();
-
-			if (disableSpecializedShaders)
-				uberShaderModeValue = 2;    // Exclusive
-			else if (backgroundShaderCompiling)
-				uberShaderModeValue = 1;    // Hybrid
-			else
-				uberShaderModeValue = 0;    // Disabled
-		}
-		catch (NullPointerException ex)
-		{
-		}
-
-		return uberShaderModeValue;
 	}
 
 	private int getExtensionValue(int wiimoteNumber)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -107,8 +107,7 @@ public final class SettingsFile
 	public static final String KEY_IMMEDIATE_XFB = "ImmediateXFBEnable";
 	public static final String KEY_FAST_DEPTH = "FastDepthCalc";
 	public static final String KEY_ASPECT_RATIO = "AspectRatio";
-	public static final String KEY_DISABLE_SPECIALIZED_SHADERS = "DisableSpecializedShaders";
-	public static final String KEY_BACKGROUND_SHADER_COMPILING = "BackgroundShaderCompiling";
+	public static final String KEY_UBERSHADER_MODE = "UberShaderMode";
 
 	public static final String KEY_GCPAD_TYPE = "SIDevice";
 
@@ -266,7 +265,6 @@ public final class SettingsFile
 
 	// Internal only, not actually found in settings file.
 	public static final String KEY_VIDEO_BACKEND_INDEX = "VideoBackendIndex";
-	public static final String KEY_UBERSHADER_MODE = "UberShaderMode";
 
 	private SettingsFile()
 	{


### PR DESCRIPTION
9fa2470 changed how the ubershader setting is stored in INIs but didn't update the Android GUI code to reflect that, so the setting in the Android GUI has been broken starting with that commit.

Fixes https://bugs.dolphin-emu.org/issues/10947