### PR TITLE
Qt/Main: Add option to launch file without -e

### DIFF
--- a/Source/Core/DolphinQt2/Main.cpp
+++ b/Source/Core/DolphinQt2/Main.cpp
@@ -104,6 +104,10 @@ int main(int argc, char* argv[])
       QMessageBox::critical(nullptr, QObject::tr("Error"), QObject::tr("Invalid title ID."));
     }
   }
+  else if (!args.empty())
+  {
+    boot = BootParameters::GenerateFromFile(args.front());
+  }
 
   int retval = 0;
 


### PR DESCRIPTION
Previously you had to use the ``-e`` flag to boot an ISO from the command line when using Qt.
In Wx the filename itself is sufficient.

Qt will behave like Wx now and assume the ``-e`` flag.