### PR TITLE
ShaderCache: Implement compile priority

### DIFF
--- a/Source/Core/VideoCommon/AsyncShaderCompiler.h
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.h
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <deque>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -42,7 +43,9 @@ public:
     return std::make_unique<T>(std::forward<Params>(params)...);
   }
 
-  void QueueWorkItem(WorkItemPtr item);
+  // Queues a new work item to the compiler threads. The lower the priority, the sooner
+  // this work item will be compiled, relative to the other work items.
+  void QueueWorkItem(WorkItemPtr item, u32 priority);
   void RetrieveWorkItems();
   bool HasPendingWork();
   bool HasCompletedWork();
@@ -74,7 +77,9 @@ private:
   std::vector<std::thread> m_worker_threads;
   std::atomic_bool m_worker_thread_start_result{false};
 
-  std::deque<WorkItemPtr> m_pending_work;
+  // A multimap is used to store the work items. We can't use a priority_queue here, because
+  // there's no way to obtain a non-const reference, which we need for the unique_ptr.
+  std::multimap<u32, WorkItemPtr> m_pending_work;
   std::mutex m_pending_work_lock;
   std::condition_variable m_worker_thread_wake;
   std::atomic_size_t m_busy_workers{0};

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -108,12 +108,23 @@ private:
   void AppendGXPipelineUID(const GXPipelineUid& config);
 
   // ASync Compiler Methods
-  void QueueVertexShaderCompile(const VertexShaderUid& uid);
-  void QueueVertexUberShaderCompile(const UberShader::VertexShaderUid& uid);
-  void QueuePixelShaderCompile(const PixelShaderUid& uid);
-  void QueuePixelUberShaderCompile(const UberShader::PixelShaderUid& uid);
-  void QueuePipelineCompile(const GXPipelineUid& uid);
-  void QueueUberPipelineCompile(const GXUberPipelineUid& uid);
+  void QueueVertexShaderCompile(const VertexShaderUid& uid, u32 priority);
+  void QueueVertexUberShaderCompile(const UberShader::VertexShaderUid& uid, u32 priority);
+  void QueuePixelShaderCompile(const PixelShaderUid& uid, u32 priority);
+  void QueuePixelUberShaderCompile(const UberShader::PixelShaderUid& uid, u32 priority);
+  void QueuePipelineCompile(const GXPipelineUid& uid, u32 priority);
+  void QueueUberPipelineCompile(const GXUberPipelineUid& uid, u32 priority);
+
+  // Priorities for compiling. The lower the value, the sooner the pipeline is compiled.
+  // The shader cache is compiled last, as it is the least likely to be required. On demand
+  // shaders are always compiled before pending ubershaders, as we want to use the ubershader
+  // for as few frames as possible, otherwise we risk framerate drops.
+  enum : u32
+  {
+    COMPILE_PRIORITY_ONDEMAND_PIPELINE = 100,
+    COMPILE_PRIORITY_UBERSHADER_PIPELINE = 200,
+    COMPILE_PRIORITY_SHADERCACHE_PIPELINE = 300
+  };
 
   // Configuration bits.
   APIType m_api_type = APIType::Nothing;


### PR DESCRIPTION
Currently, when immediately compile shaders is not enabled, the ubershaders will be placed before any specialized shaders in the compile queue in hybrid ubershaders mode. This means that Dolphin could
potentially use the ubershaders for a longer time than it would have if we blocked startup until all shaders were compiled, leading to a drop in performance.

This change sorts pending pipelines into three priorities, low, medium, and high. High is reserved for any pipelines encountered through hybrid ubershaders, as we want to use the ubershaders for as little time as possible. Medium is used for pipelines loaded from the UID caches, as we want on-demand shaders to be compiled before those which may not be needed for a while. Low is used for ubershaders only, so to not block compilation of specialized shaders at any point.

Related issue: https://bugs.dolphin-emu.org/issues/10946