### PR TITLE
Assert: Wrap assertion macro bodies in do {} while (0)

### DIFF
--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -11,41 +11,59 @@
 
 #ifdef _WIN32
 #define ASSERT_MSG(_t_, _a_, _fmt_, ...)                                                           \
-  if (!(_a_))                                                                                      \
+  do                                                                                               \
   {                                                                                                \
-    if (!PanicYesNo(_fmt_ "\n\nIgnore and continue?", __VA_ARGS__))                                \
-      Crash();                                                                                     \
-  }
+    if (!(_a_))                                                                                    \
+    {                                                                                              \
+      if (!PanicYesNo(_fmt_ "\n\nIgnore and continue?", __VA_ARGS__))                              \
+        Crash();                                                                                   \
+    }                                                                                              \
+  } while (0)
 
 #define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
-  if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG && !(_a_))                                      \
+  do                                                                                               \
   {                                                                                                \
-    ERROR_LOG(_t_, _msg_, __VA_ARGS__);                                                            \
-    if (!PanicYesNo(_msg_, __VA_ARGS__))                                                           \
-      Crash();                                                                                     \
-  }
+    if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG && !(_a_))                                    \
+    {                                                                                              \
+      ERROR_LOG(_t_, _msg_, __VA_ARGS__);                                                          \
+      if (!PanicYesNo(_msg_, __VA_ARGS__))                                                         \
+        Crash();                                                                                   \
+    }                                                                                              \
+  } while (0)
 #else
 #define ASSERT_MSG(_t_, _a_, _fmt_, ...)                                                           \
-  if (!(_a_))                                                                                      \
+  do                                                                                               \
   {                                                                                                \
-    if (!PanicYesNo(_fmt_, ##__VA_ARGS__))                                                         \
-      Crash();                                                                                     \
-  }
+    if (!(_a_))                                                                                    \
+    {                                                                                              \
+      if (!PanicYesNo(_fmt_, ##__VA_ARGS__))                                                       \
+        Crash();                                                                                   \
+    }                                                                                              \
+  } while (0)
 
 #define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
-  if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG && !(_a_))                                      \
+  do                                                                                               \
   {                                                                                                \
-    ERROR_LOG(_t_, _msg_, ##__VA_ARGS__);                                                          \
-    if (!PanicYesNo(_msg_, ##__VA_ARGS__))                                                         \
-      Crash();                                                                                     \
-  }
+    if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG && !(_a_))                                    \
+    {                                                                                              \
+      ERROR_LOG(_t_, _msg_, ##__VA_ARGS__);                                                        \
+      if (!PanicYesNo(_msg_, ##__VA_ARGS__))                                                       \
+        Crash();                                                                                   \
+    }                                                                                              \
+  } while (0)
 #endif
 
 #define ASSERT(_a_)                                                                                \
-  ASSERT_MSG(MASTER_LOG, _a_,                                                                      \
-             _trans("An error occurred.\n\n  Line: %d\n  File: %s\n\nIgnore and continue?"),       \
-             __LINE__, __FILE__)
+  do                                                                                               \
+  {                                                                                                \
+    ASSERT_MSG(MASTER_LOG, _a_,                                                                    \
+               _trans("An error occurred.\n\n  Line: %d\n  File: %s\n\nIgnore and continue?"),     \
+               __LINE__, __FILE__);                                                                \
+  } while (0)
 
 #define DEBUG_ASSERT(_t_, _a_)                                                                     \
-  if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG)                                                \
-  ASSERT(_a_)
+  do                                                                                               \
+  {                                                                                                \
+    if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG)                                              \
+      ASSERT(_a_);                                                                                 \
+  } while (0)


### PR DESCRIPTION
Enforces the termination of the macro with a semicolon. Aside from that requirement, behavior remains the same.