### PR TITLE
Assert: Remove unused parameter from DEBUG_ASSERT

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -210,8 +210,7 @@ bool IsImmLogical(uint64_t value, unsigned int width, unsigned int* n, unsigned 
   int multiplier_idx = CountLeadingZeros(d, kXRegSizeInBits) - 57;
 
   // Ensure that the index to the multipliers array is within bounds.
-  DEBUG_ASSERT(DYNA_REC,
-               (multiplier_idx >= 0) && (static_cast<size_t>(multiplier_idx) < multipliers.size()));
+  DEBUG_ASSERT((multiplier_idx >= 0) && (static_cast<size_t>(multiplier_idx) < multipliers.size()));
 
   uint64_t multiplier = multipliers[multiplier_idx];
   uint64_t candidate = (b - a) * multiplier;

--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -61,7 +61,7 @@
                __LINE__, __FILE__);                                                                \
   } while (0)
 
-#define DEBUG_ASSERT(_t_, _a_)                                                                     \
+#define DEBUG_ASSERT(_a_)                                                                          \
   do                                                                                               \
   {                                                                                                \
     if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG)                                              \

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -187,8 +187,8 @@ void OpArg::WriteREX(XEmitter* emit, int opBits, int bits, int customOp) const
   {
     emit->Write8(op);
     // Check the operation doesn't access AH, BH, CH, or DH.
-    DEBUG_ASSERT(DYNA_REC, (offsetOrBaseReg & 0x100) == 0);
-    DEBUG_ASSERT(DYNA_REC, (customOp & 0x100) == 0);
+    DEBUG_ASSERT((offsetOrBaseReg & 0x100) == 0);
+    DEBUG_ASSERT((customOp & 0x100) == 0);
   }
 }
 
@@ -553,7 +553,7 @@ void XEmitter::RET_FAST()
 // The first sign of decadence: optimized NOPs.
 void XEmitter::NOP(size_t size)
 {
-  DEBUG_ASSERT(DYNA_REC, (int)size > 0);
+  DEBUG_ASSERT((int)size > 0);
   while (true)
   {
     switch (size)
@@ -1587,7 +1587,7 @@ void XEmitter::CMP_or_TEST(int bits, const OpArg& a1, const OpArg& a2)
 void XEmitter::MOV_sum(int bits, X64Reg dest, const OpArg& a1, const OpArg& a2)
 {
   // This stomps on flags, so ensure they aren't locked
-  DEBUG_ASSERT(DYNA_REC, !flags_locked);
+  DEBUG_ASSERT(!flags_locked);
 
   // Zero shortcuts (note that this can generate no code in the case where a1 == dest && a2 == zero
   // or a2 == dest && a1 == zero)

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -156,64 +156,64 @@ struct OpArg
 
   u64 Imm64() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM64);
+    DEBUG_ASSERT(scale == SCALE_IMM64);
     return (u64)offset;
   }
   u32 Imm32() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM32);
+    DEBUG_ASSERT(scale == SCALE_IMM32);
     return (u32)offset;
   }
   u16 Imm16() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM16);
+    DEBUG_ASSERT(scale == SCALE_IMM16);
     return (u16)offset;
   }
   u8 Imm8() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM8);
+    DEBUG_ASSERT(scale == SCALE_IMM8);
     return (u8)offset;
   }
 
   s64 SImm64() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM64);
+    DEBUG_ASSERT(scale == SCALE_IMM64);
     return (s64)offset;
   }
   s32 SImm32() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM32);
+    DEBUG_ASSERT(scale == SCALE_IMM32);
     return (s32)offset;
   }
   s16 SImm16() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM16);
+    DEBUG_ASSERT(scale == SCALE_IMM16);
     return (s16)offset;
   }
   s8 SImm8() const
   {
-    DEBUG_ASSERT(DYNA_REC, scale == SCALE_IMM8);
+    DEBUG_ASSERT(scale == SCALE_IMM8);
     return (s8)offset;
   }
 
   OpArg AsImm64() const
   {
-    DEBUG_ASSERT(DYNA_REC, IsImm());
+    DEBUG_ASSERT(IsImm());
     return OpArg((u64)offset, SCALE_IMM64);
   }
   OpArg AsImm32() const
   {
-    DEBUG_ASSERT(DYNA_REC, IsImm());
+    DEBUG_ASSERT(IsImm());
     return OpArg((u32)offset, SCALE_IMM32);
   }
   OpArg AsImm16() const
   {
-    DEBUG_ASSERT(DYNA_REC, IsImm());
+    DEBUG_ASSERT(IsImm());
     return OpArg((u16)offset, SCALE_IMM16);
   }
   OpArg AsImm8() const
   {
-    DEBUG_ASSERT(DYNA_REC, IsImm());
+    DEBUG_ASSERT(IsImm());
     return OpArg((u8)offset, SCALE_IMM8);
   }
 

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -535,7 +535,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
                    if (s_DISR.BREAK)
                    {
-                     DEBUG_ASSERT(DVDINTERFACE, 0);
+                     DEBUG_ASSERT(0);
                    }
 
                    UpdateInterrupts();

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -107,7 +107,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 {
   for (int i = 0; i < MAX_EXI_CHANNELS; ++i)
   {
-    DEBUG_ASSERT(EXPANSIONINTERFACE, g_Channels[i] != nullptr);
+    DEBUG_ASSERT(g_Channels[i] != nullptr);
     // Each channel has 5 32 bit registers assigned to it. We offset the
     // base that we give to each channel for registration.
     //

--- a/Source/Core/Core/HW/EXI/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.cpp
@@ -172,7 +172,7 @@ void CEXIChannel::AddDevice(const TEXIDevices device_type, const int device_num)
 void CEXIChannel::AddDevice(std::unique_ptr<IEXIDevice> device, const int device_num,
                             bool notify_presence_changed)
 {
-  DEBUG_ASSERT(EXPANSIONINTERFACE, device_num < NUM_DEVICES);
+  DEBUG_ASSERT(device_num < NUM_DEVICES);
 
   // Replace it with the new one
   m_devices[device_num] = std::move(device);

--- a/Source/Core/Core/HW/EXI/EXI_DeviceAD16.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceAD16.cpp
@@ -39,7 +39,7 @@ void CEXIAD16::TransferByte(u8& byte)
       switch (m_position)
       {
       case 1:
-        DEBUG_ASSERT(EXPANSIONINTERFACE, byte == 0x00);
+        DEBUG_ASSERT(byte == 0x00);
         break;  // just skip
       case 2:
         byte = m_ad16_register.U8[0];

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -210,13 +210,13 @@ private:
 template <>
 inline u64 Mapping::Read<u64>(u32 addr)
 {
-  DEBUG_ASSERT(MEMMAP, 0);
+  DEBUG_ASSERT(0);
   return 0;
 }
 
 template <>
 inline void Mapping::Write(u32 addr, u64 val)
 {
-  DEBUG_ASSERT(MEMMAP, 0);
+  DEBUG_ASSERT(0);
 }
 }

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
@@ -134,7 +134,7 @@ int WiimoteHidapi::IORead(u8* buf)
 
 int WiimoteHidapi::IOWrite(const u8* buf, size_t len)
 {
-  DEBUG_ASSERT(WIIMOTE, buf[0] == (WR_SET_REPORT | BT_OUTPUT));
+  DEBUG_ASSERT(buf[0] == (WR_SET_REPORT | BT_OUTPUT));
   int result = hid_write(m_handle, buf + 1, len - 1);
   if (result == -1)
   {

--- a/Source/Core/Core/IOS/FS/FS.cpp
+++ b/Source/Core/Core/IOS/FS/FS.cpp
@@ -230,7 +230,7 @@ IPCCommandResult FS::GetStats(const IOCtlRequest& request)
 
 IPCCommandResult FS::CreateDirectory(const IOCtlRequest& request)
 {
-  DEBUG_ASSERT(IOS_FILEIO, request.buffer_out_size == 0);
+  DEBUG_ASSERT(request.buffer_out_size == 0);
   u32 Addr = request.buffer_in;
 
   u32 OwnerID = Memory::Read_U32(Addr);
@@ -377,7 +377,7 @@ IPCCommandResult FS::GetAttribute(const IOCtlRequest& request)
 
 IPCCommandResult FS::DeleteFile(const IOCtlRequest& request)
 {
-  DEBUG_ASSERT(IOS_FILEIO, request.buffer_out_size == 0);
+  DEBUG_ASSERT(request.buffer_out_size == 0);
   int Offset = 0;
 
   const std::string wii_path = Memory::GetString(request.buffer_in + Offset, 64);
@@ -407,7 +407,7 @@ IPCCommandResult FS::DeleteFile(const IOCtlRequest& request)
 
 IPCCommandResult FS::RenameFile(const IOCtlRequest& request)
 {
-  DEBUG_ASSERT(IOS_FILEIO, request.buffer_out_size == 0);
+  DEBUG_ASSERT(request.buffer_out_size == 0);
   int Offset = 0;
 
   const std::string wii_path = Memory::GetString(request.buffer_in + Offset, 64);
@@ -454,7 +454,7 @@ IPCCommandResult FS::RenameFile(const IOCtlRequest& request)
 
 IPCCommandResult FS::CreateFile(const IOCtlRequest& request)
 {
-  DEBUG_ASSERT(IOS_FILEIO, request.buffer_out_size == 0);
+  DEBUG_ASSERT(request.buffer_out_size == 0);
 
   u32 Addr = request.buffer_in;
   u32 OwnerID = Memory::Read_U32(Addr);
@@ -600,9 +600,9 @@ IPCCommandResult FS::ReadDirectory(const IOCtlVRequest& request)
 
 IPCCommandResult FS::GetUsage(const IOCtlVRequest& request)
 {
-  DEBUG_ASSERT(IOS_FILEIO, request.io_vectors.size() == 2);
-  DEBUG_ASSERT(IOS_FILEIO, request.io_vectors[0].size == 4);
-  DEBUG_ASSERT(IOS_FILEIO, request.io_vectors[1].size == 4);
+  DEBUG_ASSERT(request.io_vectors.size() == 2);
+  DEBUG_ASSERT(request.io_vectors[0].size == 4);
+  DEBUG_ASSERT(request.io_vectors[1].size == 4);
 
   // this command sucks because it asks of the number of used
   // fsBlocks and inodes

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -171,8 +171,8 @@ IPCCommandResult BluetoothEmu::IOCtlV(const IOCtlVRequest& request)
       const auto* acl_header =
           reinterpret_cast<hci_acldata_hdr_t*>(Memory::GetPointer(ctrl.data_address));
 
-      DEBUG_ASSERT(IOS_WIIMOTE, HCI_BC_FLAG(acl_header->con_handle) == HCI_POINT2POINT);
-      DEBUG_ASSERT(IOS_WIIMOTE, HCI_PB_FLAG(acl_header->con_handle) == HCI_PACKET_START);
+      DEBUG_ASSERT(HCI_BC_FLAG(acl_header->con_handle) == HCI_POINT2POINT);
+      DEBUG_ASSERT(HCI_PB_FLAG(acl_header->con_handle) == HCI_PACKET_START);
 
       SendToDevice(HCI_CON_HANDLE(acl_header->con_handle),
                    Memory::GetPointer(ctrl.data_address + sizeof(hci_acldata_hdr_t)),
@@ -437,9 +437,9 @@ bool BluetoothEmu::SendEventInquiryResponse()
   if (m_WiiMotes.empty())
     return false;
 
-  DEBUG_ASSERT(IOS_WIIMOTE, sizeof(SHCIEventInquiryResult) - 2 +
-                                    (m_WiiMotes.size() * sizeof(hci_inquiry_response)) <
-                                256);
+  DEBUG_ASSERT(sizeof(SHCIEventInquiryResult) - 2 +
+                   (m_WiiMotes.size() * sizeof(hci_inquiry_response)) <
+               256);
 
   SQueuedEvent Event(static_cast<u32>(sizeof(SHCIEventInquiryResult) +
                                       m_WiiMotes.size() * sizeof(hci_inquiry_response)),
@@ -701,7 +701,7 @@ bool BluetoothEmu::SendEventReadRemoteVerInfo(u16 _connectionHandle)
 
 void BluetoothEmu::SendEventCommandComplete(u16 opcode, const void* data, u32 data_size)
 {
-  DEBUG_ASSERT(IOS_WIIMOTE, (sizeof(SHCIEventCommand) - 2 + data_size) < 256);
+  DEBUG_ASSERT((sizeof(SHCIEventCommand) - 2 + data_size) < 256);
 
   SQueuedEvent event(sizeof(SHCIEventCommand) + data_size, 0);
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -393,7 +393,7 @@ void WiimoteDevice::ReceiveConnectionResponse(u8 _Ident, u8* _pData, u32 _Size)
 {
   l2cap_con_rsp_cp* rsp = (l2cap_con_rsp_cp*)_pData;
 
-  DEBUG_ASSERT(IOS_WIIMOTE, _Size == sizeof(l2cap_con_rsp_cp));
+  DEBUG_ASSERT(_Size == sizeof(l2cap_con_rsp_cp));
 
   DEBUG_LOG(IOS_WIIMOTE, "[L2CAP] ReceiveConnectionResponse");
   DEBUG_LOG(IOS_WIIMOTE, "    DCID: 0x%04x", rsp->dcid);
@@ -401,9 +401,9 @@ void WiimoteDevice::ReceiveConnectionResponse(u8 _Ident, u8* _pData, u32 _Size)
   DEBUG_LOG(IOS_WIIMOTE, "    Result: 0x%04x", rsp->result);
   DEBUG_LOG(IOS_WIIMOTE, "    Status: 0x%04x", rsp->status);
 
-  DEBUG_ASSERT(IOS_WIIMOTE, rsp->result == L2CAP_SUCCESS);
-  DEBUG_ASSERT(IOS_WIIMOTE, rsp->status == L2CAP_NO_INFO);
-  DEBUG_ASSERT(IOS_WIIMOTE, DoesChannelExist(rsp->scid));
+  DEBUG_ASSERT(rsp->result == L2CAP_SUCCESS);
+  DEBUG_ASSERT(rsp->status == L2CAP_NO_INFO);
+  DEBUG_ASSERT(DoesChannelExist(rsp->scid));
 
   SChannel& rChannel = m_Channel[rsp->scid];
   rChannel.DCID = rsp->dcid;
@@ -420,9 +420,9 @@ void WiimoteDevice::ReceiveConfigurationReq(u8 _Ident, u8* _pData, u32 _Size)
   u32 Offset = 0;
   l2cap_cfg_req_cp* pCommandConfigReq = (l2cap_cfg_req_cp*)_pData;
 
-  DEBUG_ASSERT(IOS_WIIMOTE, pCommandConfigReq->flags ==
-                                0x00);  // 1 means that the options are send in multi-packets
-  DEBUG_ASSERT(IOS_WIIMOTE, DoesChannelExist(pCommandConfigReq->dcid));
+  // Flags being 1 means that the options are sent in multi-packets
+  DEBUG_ASSERT(pCommandConfigReq->flags == 0x00);
+  DEBUG_ASSERT(DoesChannelExist(pCommandConfigReq->dcid));
 
   SChannel& rChannel = m_Channel[pCommandConfigReq->dcid];
 
@@ -453,7 +453,7 @@ void WiimoteDevice::ReceiveConfigurationReq(u8 _Ident, u8* _pData, u32 _Size)
     {
     case L2CAP_OPT_MTU:
     {
-      DEBUG_ASSERT(IOS_WIIMOTE, pOptions->length == L2CAP_OPT_MTU_SIZE);
+      DEBUG_ASSERT(pOptions->length == L2CAP_OPT_MTU_SIZE);
       l2cap_cfg_opt_val_t* pMTU = (l2cap_cfg_opt_val_t*)&_pData[Offset];
       rChannel.MTU = pMTU->mtu;
       DEBUG_LOG(IOS_WIIMOTE, "    MTU: 0x%04x", pMTU->mtu);
@@ -462,7 +462,7 @@ void WiimoteDevice::ReceiveConfigurationReq(u8 _Ident, u8* _pData, u32 _Size)
 
     case L2CAP_OPT_FLUSH_TIMO:
     {
-      DEBUG_ASSERT(IOS_WIIMOTE, pOptions->length == L2CAP_OPT_FLUSH_TIMO_SIZE);
+      DEBUG_ASSERT(pOptions->length == L2CAP_OPT_FLUSH_TIMO_SIZE);
       l2cap_cfg_opt_val_t* pFlushTimeOut = (l2cap_cfg_opt_val_t*)&_pData[Offset];
       rChannel.FlushTimeOut = pFlushTimeOut->flush_timo;
       DEBUG_LOG(IOS_WIIMOTE, "    FlushTimeOut: 0x%04x", pFlushTimeOut->flush_timo);
@@ -500,7 +500,7 @@ void WiimoteDevice::ReceiveConfigurationResponse(u8 _Ident, u8* _pData, u32 _Siz
   DEBUG_LOG(IOS_WIIMOTE, "    Flags: 0x%04x", rsp->flags);
   DEBUG_LOG(IOS_WIIMOTE, "    Result: 0x%04x", rsp->result);
 
-  DEBUG_ASSERT(IOS_WIIMOTE, rsp->result == L2CAP_SUCCESS);
+  DEBUG_ASSERT(rsp->result == L2CAP_SUCCESS);
 
   // update state machine
   SChannel& rChannel = m_Channel[rsp->scid];
@@ -579,7 +579,7 @@ void WiimoteDevice::SendDisconnectRequest(u16 scid)
 
 void WiimoteDevice::SendConfigurationRequest(u16 scid, u16 MTU, u16 FlushTimeOut)
 {
-  DEBUG_ASSERT(IOS_WIIMOTE, DoesChannelExist(scid));
+  DEBUG_ASSERT(DoesChannelExist(scid));
   SChannel& rChannel = m_Channel[scid];
 
   u8 Buffer[1024];
@@ -653,12 +653,12 @@ void WiimoteDevice::SDPSendServiceSearchResponse(u16 cid, u16 TransactionID,
   // verify block... we handle search pattern for HID service only
   {
     CBigEndianBuffer buffer(pServiceSearchPattern);
-    DEBUG_ASSERT(IOS_WIIMOTE, buffer.Read8(0) == SDP_SEQ8);  // data sequence
-    DEBUG_ASSERT(IOS_WIIMOTE, buffer.Read8(1) == 0x03);      // sequence size
+    DEBUG_ASSERT(buffer.Read8(0) == SDP_SEQ8);  // data sequence
+    DEBUG_ASSERT(buffer.Read8(1) == 0x03);      // sequence size
 
     // HIDClassID
-    DEBUG_ASSERT(IOS_WIIMOTE, buffer.Read8(2) == 0x19);
-    DEBUG_ASSERT(IOS_WIIMOTE, buffer.Read16(3) == 0x1124);
+    DEBUG_ASSERT(buffer.Read8(2) == 0x19);
+    DEBUG_ASSERT(buffer.Read16(3) == 0x1124);
   }
 
   u8 DataFrame[1000];
@@ -722,7 +722,7 @@ static int ParseAttribList(u8* pAttribIDList, u16& _startID, u16& _endID)
 
   if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG)
   {
-    DEBUG_ASSERT(IOS_WIIMOTE, sequence == SDP_SEQ8);
+    DEBUG_ASSERT(sequence == SDP_SEQ8);
     (void)seqSize;
   }
 
@@ -798,7 +798,7 @@ void WiimoteDevice::HandleSDP(u16 cid, u8* _pData, u32 _Size)
   {
     WARN_LOG(IOS_WIIMOTE, "!!! SDP_ServiceSearchRequest !!!");
 
-    DEBUG_ASSERT(IOS_WIIMOTE, _Size == 13);
+    DEBUG_ASSERT(_Size == 13);
 
     u16 TransactionID = buffer.Read16(1);
     u8* pServiceSearchPattern = buffer.GetPointer(5);
@@ -889,7 +889,7 @@ void WiimoteDevice::ReceiveL2capData(u16 scid, const void* _pData, u32 _Size)
   Offset += sizeof(l2cap_hdr_t);
 
   // Check if we are already reporting on this channel
-  DEBUG_ASSERT(IOS_WIIMOTE, DoesChannelExist(scid));
+  DEBUG_ASSERT(DoesChannelExist(scid));
   SChannel& rChannel = m_Channel[scid];
 
   // Add an additional 4 byte header to the Wiimote report

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.cpp
@@ -94,7 +94,7 @@ const u8* GetAttribPacket(u32 serviceHandle, u32 cont, u32& _size)
 
   if (serviceHandle == 0x10001)
   {
-    DEBUG_ASSERT(IOS_WIIMOTE, cont == 0x00);
+    DEBUG_ASSERT(cont == 0x00);
     _size = sizeof(packet4_0x10001);
     return packet4_0x10001;
   }

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -194,7 +194,7 @@ static void ApplyPatches(const std::vector<Patch>& patches)
 // We require at least 2 stack frames, if the stack is shallower than that then it won't work.
 static bool IsStackSane()
 {
-  DEBUG_ASSERT(ACTIONREPLAY, UReg_MSR(MSR).DR && UReg_MSR(MSR).IR);
+  DEBUG_ASSERT(UReg_MSR(MSR).DR && UReg_MSR(MSR).IR);
 
   // Check the stack pointer
   u32 SP = GPR(1);

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -109,7 +109,7 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
       *ptr = Common::swap64(static_cast<u64>(*ptr));
       break;
     default:
-      DEBUG_ASSERT(DYNA_REC, 0);
+      DEBUG_ASSERT(0);
       break;
     }
   }

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -741,7 +741,7 @@ void DMA_MemoryToLC(const u32 cacheAddr, const u32 memAddr, const u32 numBlocks)
 
 void ClearCacheLine(u32 address)
 {
-  DEBUG_ASSERT(POWERPC, (address & 0x1F) == 0);
+  DEBUG_ASSERT((address & 0x1F) == 0);
   if (UReg_MSR(MSR).DR)
   {
     auto translated_address = TranslateAddress<FLAG_WRITE>(address);

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -92,7 +92,7 @@ bool DiscContent::Read(u64* offset, u64* length, u8** buffer) const
   if (m_size == 0)
     return true;
 
-  DEBUG_ASSERT(DISCIO, *offset >= m_offset);
+  DEBUG_ASSERT(*offset >= m_offset);
   const u64 offset_in_content = *offset - m_offset;
 
   if (offset_in_content < m_size)
@@ -160,7 +160,7 @@ bool DiscContentContainer::Read(u64 offset, u64 length, u8* buffer) const
       return false;
 
     ++it;
-    DEBUG_ASSERT(DISCIO, it == m_contents.end() || it->GetOffset() >= offset);
+    DEBUG_ASSERT(it == m_contents.end() || it->GetOffset() >= offset);
   }
 
   // Zero fill if we went beyond the last DiscContent

--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -62,7 +62,7 @@ public:
 
   int BeginAppendData(void** write_ptr, unsigned int size, unsigned int vertex_size)
   {
-    DEBUG_ASSERT(VIDEO, size < max_size);
+    DEBUG_ASSERT(size < max_size);
 
     D3D11_MAPPED_SUBRESOURCE map;
     unsigned int aligned_offset = Common::AlignUp(offset, vertex_size);

--- a/Source/Core/VideoBackends/D3D/DXShader.cpp
+++ b/Source/Core/VideoBackends/D3D/DXShader.cpp
@@ -43,25 +43,25 @@ D3DBlob* DXShader::GetByteCode() const
 
 ID3D11VertexShader* DXShader::GetD3DVertexShader() const
 {
-  DEBUG_ASSERT(VIDEO, m_stage == ShaderStage::Vertex);
+  DEBUG_ASSERT(m_stage == ShaderStage::Vertex);
   return static_cast<ID3D11VertexShader*>(m_shader);
 }
 
 ID3D11GeometryShader* DXShader::GetD3DGeometryShader() const
 {
-  DEBUG_ASSERT(VIDEO, m_stage == ShaderStage::Geometry);
+  DEBUG_ASSERT(m_stage == ShaderStage::Geometry);
   return static_cast<ID3D11GeometryShader*>(m_shader);
 }
 
 ID3D11PixelShader* DXShader::GetD3DPixelShader() const
 {
-  DEBUG_ASSERT(VIDEO, m_stage == ShaderStage::Pixel);
+  DEBUG_ASSERT(m_stage == ShaderStage::Pixel);
   return static_cast<ID3D11PixelShader*>(m_shader);
 }
 
 ID3D11ComputeShader* DXShader::GetD3DComputeShader() const
 {
-  DEBUG_ASSERT(VIDEO, m_stage == ShaderStage::Compute);
+  DEBUG_ASSERT(m_stage == ShaderStage::Compute);
   return static_cast<ID3D11ComputeShader*>(m_shader);
 }
 

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -193,11 +193,10 @@ void DXTexture::ResolveFromTexture(const AbstractTexture* src, const MathUtil::R
                                    u32 layer, u32 level)
 {
   const DXTexture* srcentry = static_cast<const DXTexture*>(src);
-  DEBUG_ASSERT(VIDEO, m_config.samples > 1 && m_config.width == srcentry->m_config.width &&
-                          m_config.height == srcentry->m_config.height && m_config.samples == 1);
-  DEBUG_ASSERT(VIDEO,
-               rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
-                   rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
+  DEBUG_ASSERT(m_config.samples > 1 && m_config.width == srcentry->m_config.width &&
+               m_config.height == srcentry->m_config.height && m_config.samples == 1);
+  DEBUG_ASSERT(rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
+               rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
 
   D3D::context->ResolveSubresource(
       m_texture->GetTex(), D3D11CalcSubresource(level, layer, m_config.levels),

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -270,7 +270,7 @@ std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelin
 
 void Renderer::UpdateUtilityUniformBuffer(const void* uniforms, u32 uniforms_size)
 {
-  DEBUG_ASSERT(VIDEO, uniforms_size > 0 && uniforms_size < UTILITY_UBO_SIZE);
+  DEBUG_ASSERT(uniforms_size > 0 && uniforms_size < UTILITY_UBO_SIZE);
   D3D11_MAPPED_SUBRESOURCE mapped;
   HRESULT hr = D3D::context->Map(m_utility_uniform_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
   CHECK(SUCCEEDED(hr), "Map utility UBO");
@@ -323,7 +323,7 @@ void Renderer::DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, cons
     if (vertices_ptr)
     {
       vertices_this_draw = std::min(vertices_this_draw, UTILITY_VBO_SIZE / vertex_stride);
-      DEBUG_ASSERT(VIDEO, vertices_this_draw > 0);
+      DEBUG_ASSERT(vertices_this_draw > 0);
       UpdateUtilityVertexBuffer(vertices_ptr, vertex_stride, vertices_this_draw);
       D3D::stateman->SetVertexBuffer(m_utility_vertex_buffer, vertex_stride, 0);
     }

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -279,11 +279,10 @@ void OGLTexture::ResolveFromTexture(const AbstractTexture* src,
                                     const MathUtil::Rectangle<int>& rect, u32 layer, u32 level)
 {
   const OGLTexture* srcentry = static_cast<const OGLTexture*>(src);
-  DEBUG_ASSERT(VIDEO, m_config.samples > 1 && m_config.width == srcentry->m_config.width &&
-                          m_config.height == srcentry->m_config.height && m_config.samples == 1);
-  DEBUG_ASSERT(VIDEO,
-               rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
-                   rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
+  DEBUG_ASSERT(m_config.samples > 1 && m_config.width == srcentry->m_config.width &&
+               m_config.height == srcentry->m_config.height && m_config.samples == 1);
+  DEBUG_ASSERT(rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
+               rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
   BlitFramebuffer(const_cast<OGLTexture*>(srcentry), rect, layer, level, rect, layer, level);
 }
 
@@ -655,7 +654,7 @@ std::unique_ptr<OGLFramebuffer> OGLFramebuffer::Create(const OGLTexture* color_a
     }
   }
 
-  DEBUG_ASSERT(VIDEO, glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+  DEBUG_ASSERT(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
   FramebufferManager::SetFramebuffer(0);
   return std::make_unique<OGLFramebuffer>(color_format, depth_format, width, height, layers,
                                           samples, fbo);

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -507,7 +507,7 @@ void ProgramShaderCache::Shutdown()
   s_last_VAO = 0;
 
   // All pipeline programs should have been released.
-  DEBUG_ASSERT(VIDEO, s_pipeline_programs.empty());
+  DEBUG_ASSERT(s_pipeline_programs.empty());
   s_pipeline_programs.clear();
 }
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1690,7 +1690,7 @@ void Renderer::DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, cons
 
 void Renderer::UploadUtilityUniforms(const void* uniforms, u32 uniforms_size)
 {
-  DEBUG_ASSERT(VIDEO, uniforms_size > 0);
+  DEBUG_ASSERT(uniforms_size > 0);
 
   auto buf = ProgramShaderCache::GetUniformBuffer()->Map(
       uniforms_size, ProgramShaderCache::GetUniformBufferAlignment());

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1123,7 +1123,7 @@ void Renderer::SetTexture(u32 index, const AbstractTexture* texture)
   // Texture should always be in SHADER_READ_ONLY layout prior to use.
   // This is so we don't need to transition during render passes.
   auto* tex = texture ? static_cast<const VKTexture*>(texture)->GetRawTexIdentifier() : nullptr;
-  DEBUG_ASSERT(VIDEO, !tex || tex->GetLayout() == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+  DEBUG_ASSERT(!tex || tex->GetLayout() == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
   StateTracker::GetInstance()->SetTexture(index, tex ? tex->GetView() : VK_NULL_HANDLE);
 }
 

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -27,7 +27,7 @@ VKPipeline::~VKPipeline()
 
 std::unique_ptr<VKPipeline> VKPipeline::Create(const AbstractPipelineConfig& config)
 {
-  DEBUG_ASSERT(VIDEO, config.vertex_shader && config.pixel_shader);
+  DEBUG_ASSERT(config.vertex_shader && config.pixel_shader);
 
   // Get render pass for config.
   VkRenderPass render_pass = g_object_cache->GetRenderPass(

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -216,12 +216,10 @@ void VKTexture::ResolveFromTexture(const AbstractTexture* src, const MathUtil::R
                                    u32 layer, u32 level)
 {
   const VKTexture* srcentry = static_cast<const VKTexture*>(src);
-  DEBUG_ASSERT(VIDEO, m_config.samples == 1 && m_config.width == srcentry->m_config.width &&
-                          m_config.height == srcentry->m_config.height &&
-                          srcentry->m_config.samples > 1);
-  DEBUG_ASSERT(VIDEO,
-               rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
-                   rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
+  DEBUG_ASSERT(m_config.samples == 1 && m_config.width == srcentry->m_config.width &&
+               m_config.height == srcentry->m_config.height && srcentry->m_config.samples > 1);
+  DEBUG_ASSERT(rect.left + rect.GetWidth() <= static_cast<int>(srcentry->m_config.width) &&
+               rect.top + rect.GetHeight() <= static_cast<int>(srcentry->m_config.height));
 
   // Resolving is considered to be a transfer operation.
   StateTracker::GetInstance()->EndRenderPass();


### PR DESCRIPTION
This brings the macro in line with the regular ASSERT macro, which only has one macro parameter.