### PR TITLE
Use __func__ instead of __FUNCTION__ where applicable

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -481,12 +481,12 @@ void ARM64XEmitter::EncodeCompareBranchInst(u32 op, ARM64Reg Rt, const void* ptr
   s64 distance = (s64)ptr - (s64)m_code;
 
   ASSERT_MSG(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %" PRIx64,
-             __FUNCTION__, distance);
+             __func__, distance);
 
   distance >>= 2;
 
   ASSERT_MSG(DYNA_REC, distance >= -0x40000 && distance <= 0x3FFFF,
-             "%s: Received too large distance: %" PRIx64, __FUNCTION__, distance);
+             "%s: Received too large distance: %" PRIx64, __func__, distance);
 
   Rt = DecodeReg(Rt);
   Write32((b64Bit << 31) | (0x34 << 24) | (op << 24) | (((u32)distance << 5) & 0xFFFFE0) | Rt);
@@ -498,12 +498,12 @@ void ARM64XEmitter::EncodeTestBranchInst(u32 op, ARM64Reg Rt, u8 bits, const voi
   s64 distance = (s64)ptr - (s64)m_code;
 
   ASSERT_MSG(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %" PRIx64,
-             __FUNCTION__, distance);
+             __func__, distance);
 
   distance >>= 2;
 
   ASSERT_MSG(DYNA_REC, distance >= -0x3FFF && distance < 0x3FFF,
-             "%s: Received too large distance: %" PRIx64, __FUNCTION__, distance);
+             "%s: Received too large distance: %" PRIx64, __func__, distance);
 
   Rt = DecodeReg(Rt);
   Write32((b64Bit << 31) | (0x36 << 24) | (op << 24) | (bits << 19) |
@@ -515,12 +515,12 @@ void ARM64XEmitter::EncodeUnconditionalBranchInst(u32 op, const void* ptr)
   s64 distance = (s64)ptr - s64(m_code);
 
   ASSERT_MSG(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %" PRIx64,
-             __FUNCTION__, distance);
+             __func__, distance);
 
   distance >>= 2;
 
   ASSERT_MSG(DYNA_REC, distance >= -0x2000000LL && distance <= 0x1FFFFFFLL,
-             "%s: Received too large distance: %" PRIx64, __FUNCTION__, distance);
+             "%s: Received too large distance: %" PRIx64, __func__, distance);
 
   Write32((op << 31) | (0x5 << 26) | (distance & 0x3FFFFFF));
 }
@@ -534,7 +534,7 @@ void ARM64XEmitter::EncodeUnconditionalBranchInst(u32 opc, u32 op2, u32 op3, u32
 void ARM64XEmitter::EncodeExceptionInst(u32 instenc, u32 imm)
 {
   ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "%s: Exception instruction too large immediate: %d",
-             __FUNCTION__, imm);
+             __func__, imm);
 
   Write32((0xD4 << 24) | (ExcEnc[instenc][0] << 21) | (imm << 5) | (ExcEnc[instenc][1] << 2) |
           ExcEnc[instenc][2]);
@@ -573,8 +573,8 @@ void ARM64XEmitter::EncodeCondCompareImmInst(u32 op, ARM64Reg Rn, u32 imm, u32 n
 {
   bool b64Bit = Is64Bit(Rn);
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0x1F), "%s: too large immediate: %d", __FUNCTION__, imm);
-  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __FUNCTION__, nzcv);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0x1F), "%s: too large immediate: %d", __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __func__, nzcv);
 
   Rn = DecodeReg(Rn);
   Write32((b64Bit << 31) | (op << 30) | (1 << 29) | (0xD2 << 21) | (imm << 16) | (cond << 12) |
@@ -586,7 +586,7 @@ void ARM64XEmitter::EncodeCondCompareRegInst(u32 op, ARM64Reg Rn, ARM64Reg Rm, u
 {
   bool b64Bit = Is64Bit(Rm);
 
-  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __FUNCTION__, nzcv);
+  ASSERT_MSG(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __func__, nzcv);
 
   Rm = DecodeReg(Rm);
   Rn = DecodeReg(Rn);
@@ -657,7 +657,7 @@ void ARM64XEmitter::EncodeLoadRegisterInst(u32 bitop, ARM64Reg Rt, u32 imm)
   bool b64Bit = Is64Bit(Rt);
   bool bVec = IsVector(Rt);
 
-  ASSERT_MSG(DYNA_REC, !(imm & 0xFFFFF), "%s: offset too large %d", __FUNCTION__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & 0xFFFFF), "%s: offset too large %d", __func__, imm);
 
   Rt = DecodeReg(Rt);
   if (b64Bit && bitop != 0x2)  // LDRSW(0x2) uses 64bit reg, doesn't have 64bit bit set
@@ -691,7 +691,7 @@ void ARM64XEmitter::EncodeLoadStorePairedInst(u32 op, ARM64Reg Rt, ARM64Reg Rt2,
   else
     imm >>= 2;
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xF), "%s: offset too large %d", __FUNCTION__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xF), "%s: offset too large %d", __func__, imm);
 
   u32 opc = 0;
   if (b128Bit)
@@ -714,7 +714,7 @@ void ARM64XEmitter::EncodeLoadStoreIndexedInst(u32 op, u32 op2, ARM64Reg Rt, ARM
 
   u32 offset = imm & 0x1FF;
 
-  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s: offset too large %d", __FUNCTION__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s: offset too large %d", __func__, imm);
 
   Rt = DecodeReg(Rt);
   Rn = DecodeReg(Rn);
@@ -734,10 +734,8 @@ void ARM64XEmitter::EncodeLoadStoreIndexedInst(u32 op, ARM64Reg Rt, ARM64Reg Rn,
   else if (size == 16)
     imm >>= 1;
 
-  ASSERT_MSG(DYNA_REC, imm >= 0, "%s(INDEX_UNSIGNED): offset must be positive %d", __FUNCTION__,
-             imm);
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "%s(INDEX_UNSIGNED): offset too large %d", __FUNCTION__,
-             imm);
+  ASSERT_MSG(DYNA_REC, imm >= 0, "%s(INDEX_UNSIGNED): offset must be positive %d", __func__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "%s(INDEX_UNSIGNED): offset too large %d", __func__, imm);
 
   Rt = DecodeReg(Rt);
   Rn = DecodeReg(Rn);
@@ -748,7 +746,7 @@ void ARM64XEmitter::EncodeMOVWideInst(u32 op, ARM64Reg Rd, u32 imm, ShiftAmount 
 {
   bool b64Bit = Is64Bit(Rd);
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "%s: immediate out of range: %d", __FUNCTION__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "%s: immediate out of range: %d", __func__, imm);
 
   Rd = DecodeReg(Rd);
   Write32((b64Bit << 31) | (op << 29) | (0x25 << 23) | (pos << 21) | (imm << 5) | Rd);
@@ -780,7 +778,7 @@ void ARM64XEmitter::EncodeAddSubImmInst(u32 op, bool flags, u32 shift, u32 imm, 
 {
   bool b64Bit = Is64Bit(Rd);
 
-  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "%s: immediate too large: %x", __FUNCTION__, imm);
+  ASSERT_MSG(DYNA_REC, !(imm & ~0xFFF), "%s: immediate too large: %x", __func__, imm);
 
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
@@ -820,7 +818,7 @@ void ARM64XEmitter::EncodeLoadStorePair(u32 op, u32 load, IndexType type, ARM64R
     type_encode = 0b011;
     break;
   case INDEX_UNSIGNED:
-    ASSERT_MSG(DYNA_REC, false, "%s doesn't support INDEX_UNSIGNED!", __FUNCTION__);
+    ASSERT_MSG(DYNA_REC, false, "%s doesn't support INDEX_UNSIGNED!", __func__);
     break;
   }
 
@@ -850,7 +848,7 @@ void ARM64XEmitter::EncodeAddressInst(u32 op, ARM64Reg Rd, s32 imm)
 
 void ARM64XEmitter::EncodeLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __FUNCTION__,
+  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __func__,
              imm);
   Rt = DecodeReg(Rt);
   Rn = DecodeReg(Rn);
@@ -903,7 +901,7 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
   case 0:  // CBZ
   {
     ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __FUNCTION__, branch.type, distance);
+               __func__, branch.type, distance);
     bool b64Bit = Is64Bit(branch.reg);
     ARM64Reg reg = DecodeReg(branch.reg);
     inst = (b64Bit << 31) | (0x1A << 25) | (Not << 24) | (MaskImm19(distance) << 5) | reg;
@@ -911,7 +909,7 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
   break;
   case 2:  // B (conditional)
     ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __FUNCTION__, branch.type, distance);
+               __func__, branch.type, distance);
     inst = (0x2A << 25) | (MaskImm19(distance) << 5) | branch.cond;
     break;
   case 4:  // TBNZ
@@ -919,7 +917,7 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
   case 3:  // TBZ
   {
     ASSERT_MSG(DYNA_REC, IsInRangeImm14(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __FUNCTION__, branch.type, distance);
+               __func__, branch.type, distance);
     ARM64Reg reg = DecodeReg(branch.reg);
     inst = ((branch.bit & 0x20) << 26) | (0x1B << 25) | (Not << 24) | ((branch.bit & 0x1F) << 19) |
            (MaskImm14(distance) << 5) | reg;
@@ -927,12 +925,12 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
   break;
   case 5:  // B (uncoditional)
     ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __FUNCTION__, branch.type, distance);
+               __func__, branch.type, distance);
     inst = (0x5 << 26) | MaskImm26(distance);
     break;
   case 6:  // BL (unconditional)
     ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __FUNCTION__, branch.type, distance);
+               __func__, branch.type, distance);
     inst = (0x25 << 26) | MaskImm26(distance);
     break;
   }
@@ -1021,8 +1019,8 @@ void ARM64XEmitter::B(CCFlags cond, const void* ptr)
   distance >>= 2;
 
   ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance),
-             "%s: Received too large distance: %p->%p %" PRIi64 " %" PRIx64, __FUNCTION__, m_code,
-             ptr, distance, distance);
+             "%s: Received too large distance: %p->%p %" PRIi64 " %" PRIx64, __func__, m_code, ptr,
+             distance, distance);
   Write32((0x54 << 24) | (MaskImm19(distance) << 5) | cond);
 }
 
@@ -1638,7 +1636,7 @@ void ARM64XEmitter::BFI(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;
   ASSERT_MSG(DYNA_REC, (lsb + width) <= size,
-             "%s passed lsb %d and width %d which is greater than the register size!", __FUNCTION__,
+             "%s passed lsb %d and width %d which is greater than the register size!", __func__,
              lsb, width);
   EncodeBitfieldMOVInst(1, Rd, Rn, (size - lsb) % size, width - 1);
 }
@@ -1646,7 +1644,7 @@ void ARM64XEmitter::UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;
   ASSERT_MSG(DYNA_REC, (lsb + width) <= size,
-             "%s passed lsb %d and width %d which is greater than the register size!", __FUNCTION__,
+             "%s passed lsb %d and width %d which is greater than the register size!", __func__,
              lsb, width);
   EncodeBitfieldMOVInst(2, Rd, Rn, (size - lsb) % size, width - 1);
 }
@@ -1669,7 +1667,7 @@ void ARM64XEmitter::SXTH(ARM64Reg Rd, ARM64Reg Rn)
 }
 void ARM64XEmitter::SXTW(ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, Is64Bit(Rd), "%s requires 64bit register as destination", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, Is64Bit(Rd), "%s requires 64bit register as destination", __func__);
   SBFM(Rd, Rn, 0, 31);
 }
 void ARM64XEmitter::UXTB(ARM64Reg Rd, ARM64Reg Rn)
@@ -1960,7 +1958,7 @@ void ARM64XEmitter::LDUR(ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 }
 void ARM64XEmitter::LDURSW(ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-  ASSERT_MSG(DYNA_REC, !Is64Bit(Rt), "%s must have a 64bit destination register!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !Is64Bit(Rt), "%s must have a 64bit destination register!", __func__);
   EncodeLoadStoreUnscaled(2, 2, Rt, Rn, imm);
 }
 
@@ -2111,7 +2109,7 @@ void ARM64XEmitter::ABI_PushRegisters(BitSet32 registers)
   for (int i = 0; i < (num_regs - 1) / 2; i++)
     STP(INDEX_SIGNED, (ARM64Reg)(X0 + *it++), (ARM64Reg)(X0 + *it++), SP, 16 * (i + 1));
 
-  ASSERT_MSG(DYNA_REC, it == registers.end(), "%s registers don't match.", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, it == registers.end(), "%s registers don't match.", __func__);
 }
 
 void ARM64XEmitter::ABI_PopRegisters(BitSet32 registers, BitSet32 ignore_mask)
@@ -2142,7 +2140,7 @@ void ARM64XEmitter::ABI_PopRegisters(BitSet32 registers, BitSet32 ignore_mask)
   else
     LDP(INDEX_POST, first, second, SP, stack_size);
 
-  ASSERT_MSG(DYNA_REC, it == registers.end(), "%s registers don't match.", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, it == registers.end(), "%s registers don't match.", __func__);
 }
 
 // Float Emitter
@@ -2168,10 +2166,10 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
   if (type == INDEX_UNSIGNED)
   {
     ASSERT_MSG(DYNA_REC, !(imm & ((size - 1) >> 3)),
-               "%s(INDEX_UNSIGNED) immediate offset must be aligned to size! (%d) (%p)",
-               __FUNCTION__, imm, m_emit->GetCodePtr());
+               "%s(INDEX_UNSIGNED) immediate offset must be aligned to size! (%d) (%p)", __func__,
+               imm, m_emit->GetCodePtr());
     ASSERT_MSG(DYNA_REC, imm >= 0, "%s(INDEX_UNSIGNED) immediate offset must be positive!",
-               __FUNCTION__);
+               __func__);
     if (size == 16)
       imm >>= 1;
     else if (size == 32)
@@ -2185,7 +2183,7 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
   else
   {
     ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255),
-               "%s immediate offset must be within range of -256 to 256!", __FUNCTION__);
+               "%s immediate offset must be within range of -256 to 256!", __func__);
     encoded_imm = (imm & 0x1FF) << 2;
     if (type == INDEX_POST)
       encoded_imm |= 1;
@@ -2200,7 +2198,7 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
 void ARM64FloatEmitter::EmitScalar2Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd,
                                           ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s only supports double and single registers!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s only supports double and single registers!", __func__);
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
   Rm = DecodeReg(Rm);
@@ -2212,7 +2210,7 @@ void ARM64FloatEmitter::EmitScalar2Source(bool M, bool S, u32 type, u32 opcode, 
 void ARM64FloatEmitter::EmitThreeSame(bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn,
                                       ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __func__);
   bool quad = IsQuad(Rd);
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
@@ -2233,7 +2231,7 @@ void ARM64FloatEmitter::EmitCopy(bool Q, u32 op, u32 imm5, u32 imm4, ARM64Reg Rd
 
 void ARM64FloatEmitter::Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __func__);
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
 
@@ -2244,7 +2242,7 @@ void ARM64FloatEmitter::Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64
 void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size,
                                                      ARM64Reg Rt, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __func__);
   bool quad = IsQuad(Rt);
   Rt = DecodeReg(Rt);
   Rn = DecodeReg(Rn);
@@ -2256,7 +2254,7 @@ void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode,
 void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size,
                                                      ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __func__);
   bool quad = IsQuad(Rt);
   Rt = DecodeReg(Rt);
   Rn = DecodeReg(Rn);
@@ -2268,7 +2266,7 @@ void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode,
 
 void ARM64FloatEmitter::Emit1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
 
@@ -2279,7 +2277,7 @@ void ARM64FloatEmitter::Emit1Source(bool M, bool S, u32 type, u32 opcode, ARM64R
 void ARM64FloatEmitter::EmitConversion(bool sf, bool S, u32 type, u32 rmode, u32 opcode,
                                        ARM64Reg Rd, ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, Rn <= SP, "%s only supports GPR as source!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, Rn <= SP, "%s only supports GPR as source!", __func__);
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
 
@@ -2375,7 +2373,7 @@ void ARM64FloatEmitter::EmitConversion2(bool sf, bool S, bool direction, u32 typ
 
 void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rn), "%s doesn't support vector!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rn), "%s doesn't support vector!", __func__);
   bool is_double = IsDouble(Rn);
 
   Rn = DecodeReg(Rn);
@@ -2388,7 +2386,7 @@ void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Re
 void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd, ARM64Reg Rn,
                                        ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
   bool is_double = IsDouble(Rd);
 
   Rd = DecodeReg(Rd);
@@ -2401,7 +2399,7 @@ void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd
 
 void ARM64FloatEmitter::EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __func__);
 
   bool quad = IsQuad(Rd);
 
@@ -2423,7 +2421,7 @@ void ARM64FloatEmitter::EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, 
 
 void ARM64FloatEmitter::EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64Reg Rd, u32 imm8)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
 
   bool is_double = !IsSingle(Rd);
 
@@ -2436,7 +2434,7 @@ void ARM64FloatEmitter::EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64R
 void ARM64FloatEmitter::EmitShiftImm(bool Q, bool U, u32 immh, u32 immb, u32 opcode, ARM64Reg Rd,
                                      ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, immh, "%s bad encoding! Can't have zero immh", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, immh, "%s bad encoding! Can't have zero immh", __func__);
 
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
@@ -2499,7 +2497,7 @@ void ARM64FloatEmitter::EmitLoadStoreMultipleStructurePost(u32 size, bool L, u32
 void ARM64FloatEmitter::EmitScalar1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd,
                                           ARM64Reg Rn)
 {
-  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __func__);
 
   Rd = DecodeReg(Rd);
   Rn = DecodeReg(Rn);
@@ -2523,7 +2521,7 @@ void ARM64FloatEmitter::EmitVectorxElement(bool U, u32 size, bool L, u32 opcode,
 
 void ARM64FloatEmitter::EmitLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __FUNCTION__,
+  ASSERT_MSG(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __func__,
              imm);
   Rt = DecodeReg(Rt);
   Rn = DecodeReg(Rn);
@@ -2549,25 +2547,25 @@ void ARM64FloatEmitter::EncodeLoadStorePair(u32 size, bool load, IndexType type,
     type_encode = 0b011;
     break;
   case INDEX_UNSIGNED:
-    ASSERT_MSG(DYNA_REC, false, "%s doesn't support INDEX_UNSIGNED!", __FUNCTION__);
+    ASSERT_MSG(DYNA_REC, false, "%s doesn't support INDEX_UNSIGNED!", __func__);
     break;
   }
 
   if (size == 128)
   {
-    ASSERT_MSG(DYNA_REC, !(imm & 0xF), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
+    ASSERT_MSG(DYNA_REC, !(imm & 0xF), "%s received invalid offset 0x%x!", __func__, imm);
     opc = 2;
     imm >>= 4;
   }
   else if (size == 64)
   {
-    ASSERT_MSG(DYNA_REC, !(imm & 0x7), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
+    ASSERT_MSG(DYNA_REC, !(imm & 0x7), "%s received invalid offset 0x%x!", __func__, imm);
     opc = 1;
     imm >>= 3;
   }
   else if (size == 32)
   {
-    ASSERT_MSG(DYNA_REC, !(imm & 0x3), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
+    ASSERT_MSG(DYNA_REC, !(imm & 0x3), "%s received invalid offset 0x%x!", __func__, imm);
     opc = 0;
     imm >>= 2;
   }
@@ -2584,7 +2582,7 @@ void ARM64FloatEmitter::EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64
                                                       ArithOption Rm)
 {
   ASSERT_MSG(DYNA_REC, Rm.GetType() == ArithOption::TYPE_EXTENDEDREG,
-             "%s must contain an extended reg as Rm!", __FUNCTION__);
+             "%s must contain an extended reg as Rm!", __func__);
 
   u32 encoded_size = 0;
   u32 encoded_op = 0;
@@ -2946,7 +2944,7 @@ void ARM64FloatEmitter::ST1(u8 size, ARM64Reg Rt, u8 index, ARM64Reg Rn, ARM64Re
 void ARM64FloatEmitter::LD1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 {
   ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __FUNCTION__);
+             __func__);
   u32 opcode = 0;
   if (count == 1)
     opcode = 0b111;
@@ -2962,8 +2960,8 @@ void ARM64FloatEmitter::LD1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM6
                             ARM64Reg Rm)
 {
   ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __FUNCTION__);
-  ASSERT_MSG(DYNA_REC, type == INDEX_POST, "%s only supports post indexing!", __FUNCTION__);
+             __func__);
+  ASSERT_MSG(DYNA_REC, type == INDEX_POST, "%s only supports post indexing!", __func__);
 
   u32 opcode = 0;
   if (count == 1)
@@ -2979,7 +2977,7 @@ void ARM64FloatEmitter::LD1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM6
 void ARM64FloatEmitter::ST1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 {
   ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __FUNCTION__);
+             __func__);
   u32 opcode = 0;
   if (count == 1)
     opcode = 0b111;
@@ -2995,8 +2993,8 @@ void ARM64FloatEmitter::ST1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM6
                             ARM64Reg Rm)
 {
   ASSERT_MSG(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!",
-             __FUNCTION__);
-  ASSERT_MSG(DYNA_REC, type == INDEX_POST, "%s only supports post indexing!", __FUNCTION__);
+             __func__);
+  ASSERT_MSG(DYNA_REC, type == INDEX_POST, "%s only supports post indexing!", __func__);
 
   u32 opcode = 0;
   if (count == 1)
@@ -3398,9 +3396,9 @@ void ARM64FloatEmitter::INS(u8 size, ARM64Reg Rd, u8 index1, ARM64Reg Rn, u8 ind
 void ARM64FloatEmitter::UMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {
   bool b64Bit = Is64Bit(Rd);
-  ASSERT_MSG(DYNA_REC, Rd < SP, "%s destination must be a GPR!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, Rd < SP, "%s destination must be a GPR!", __func__);
   ASSERT_MSG(DYNA_REC, !(b64Bit && size != 64),
-             "%s must have a size of 64 when destination is 64bit!", __FUNCTION__);
+             "%s must have a size of 64 when destination is 64bit!", __func__);
   u32 imm5 = 0;
 
   if (size == 8)
@@ -3429,8 +3427,8 @@ void ARM64FloatEmitter::UMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 void ARM64FloatEmitter::SMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {
   bool b64Bit = Is64Bit(Rd);
-  ASSERT_MSG(DYNA_REC, Rd < SP, "%s destination must be a GPR!", __FUNCTION__);
-  ASSERT_MSG(DYNA_REC, size != 64, "%s doesn't support 64bit destination. Use UMOV!", __FUNCTION__);
+  ASSERT_MSG(DYNA_REC, Rd < SP, "%s destination must be a GPR!", __func__);
+  ASSERT_MSG(DYNA_REC, size != 64, "%s doesn't support 64bit destination. Use UMOV!", __func__);
   u32 imm5 = 0;
 
   if (size == 8)
@@ -3663,7 +3661,7 @@ void ARM64FloatEmitter::UXTL2(u8 src_size, ARM64Reg Rd, ARM64Reg Rn)
 void ARM64FloatEmitter::SSHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
   ASSERT_MSG(DYNA_REC, shift < src_size, "%s shift amount must less than the element size!",
-             __FUNCTION__);
+             __func__);
   u32 immh = 0;
   u32 immb = shift & 0xFFF;
 
@@ -3686,7 +3684,7 @@ void ARM64FloatEmitter::SSHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, 
 void ARM64FloatEmitter::USHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
   ASSERT_MSG(DYNA_REC, shift < src_size, "%s shift amount must less than the element size!",
-             __FUNCTION__);
+             __func__);
   u32 immh = 0;
   u32 immb = shift & 0xFFF;
 
@@ -3709,7 +3707,7 @@ void ARM64FloatEmitter::USHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, 
 void ARM64FloatEmitter::SHRN(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
   ASSERT_MSG(DYNA_REC, shift < dest_size, "%s shift amount must less than the element size!",
-             __FUNCTION__);
+             __func__);
   u32 immh = 0;
   u32 immb = shift & 0xFFF;
 
@@ -3743,7 +3741,7 @@ void ARM64FloatEmitter::UXTL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, bool upper)
 void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
   ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!",
-             __FUNCTION__);
+             __func__);
 
   bool L = false;
   bool H = false;
@@ -3763,7 +3761,7 @@ void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 
 void ARM64FloatEmitter::FMLA(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
   ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!",
-             __FUNCTION__);
+             __func__);
 
   bool L = false;
   bool H = false;
@@ -3789,14 +3787,14 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
   u8 abcdefgh = imm & 0xFF;
   if (size == 8)
   {
-    ASSERT_MSG(DYNA_REC, shift == 0, "%s(size8) doesn't support shift!", __FUNCTION__);
-    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size8) only supports 8bit values!", __FUNCTION__);
+    ASSERT_MSG(DYNA_REC, shift == 0, "%s(size8) doesn't support shift!", __func__);
+    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size8) only supports 8bit values!", __func__);
   }
   else if (size == 16)
   {
     ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8, "%s(size16) only supports shift of {0, 8}!",
-               __FUNCTION__);
-    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size16) only supports 8bit values!", __FUNCTION__);
+               __func__);
+    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size16) only supports 8bit values!", __func__);
 
     if (shift == 8)
       cmode |= 2;
@@ -3804,9 +3802,9 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
   else if (size == 32)
   {
     ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8 || shift == 16 || shift == 24,
-               "%s(size32) only supports shift of {0, 8, 16, 24}!", __FUNCTION__);
+               "%s(size32) only supports shift of {0, 8, 16, 24}!", __func__);
     // XXX: Implement support for MOVI - shifting ones variant
-    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size32) only supports 8bit values!", __FUNCTION__);
+    ASSERT_MSG(DYNA_REC, !(imm & ~0xFFULL), "%s(size32) only supports 8bit values!", __func__);
     switch (shift)
     {
     case 8:
@@ -3824,7 +3822,7 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
   }
   else  // 64
   {
-    ASSERT_MSG(DYNA_REC, shift == 0, "%s(size64) doesn't support shift!", __FUNCTION__);
+    ASSERT_MSG(DYNA_REC, shift == 0, "%s(size64) doesn't support shift!", __func__);
 
     op = 1;
     cmode = 0xE;
@@ -3832,7 +3830,7 @@ void ARM64FloatEmitter::MOVI(u8 size, ARM64Reg Rd, u64 imm, u8 shift)
     for (int i = 0; i < 8; ++i)
     {
       u8 tmp = (imm >> (i << 3)) & 0xFF;
-      ASSERT_MSG(DYNA_REC, tmp == 0xFF || tmp == 0, "%s(size64) Invalid immediate!", __FUNCTION__);
+      ASSERT_MSG(DYNA_REC, tmp == 0xFF || tmp == 0, "%s(size64) Invalid immediate!", __func__);
       if (tmp == 0xFF)
         abcdefgh |= (1 << i);
     }
@@ -3848,7 +3846,7 @@ void ARM64FloatEmitter::BIC(u8 size, ARM64Reg Rd, u8 imm, u8 shift)
   if (size == 16)
   {
     ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8, "%s(size16) only supports shift of {0, 8}!",
-               __FUNCTION__);
+               __func__);
 
     if (shift == 8)
       cmode |= 2;
@@ -3856,7 +3854,7 @@ void ARM64FloatEmitter::BIC(u8 size, ARM64Reg Rd, u8 imm, u8 shift)
   else if (size == 32)
   {
     ASSERT_MSG(DYNA_REC, shift == 0 || shift == 8 || shift == 16 || shift == 24,
-               "%s(size32) only supports shift of {0, 8, 16, 24}!", __FUNCTION__);
+               "%s(size32) only supports shift of {0, 8, 16, 24}!", __func__);
     // XXX: Implement support for MOVI - shifting ones variant
     switch (shift)
     {
@@ -3875,7 +3873,7 @@ void ARM64FloatEmitter::BIC(u8 size, ARM64Reg Rd, u8 imm, u8 shift)
   }
   else
   {
-    ASSERT_MSG(DYNA_REC, false, "%s only supports size of {16, 32}!", __FUNCTION__);
+    ASSERT_MSG(DYNA_REC, false, "%s only supports size of {16, 32}!", __func__);
   }
   EncodeModImm(Q, op, cmode, 0, Rd, imm);
 }

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -35,7 +35,7 @@ namespace DX11
 #define CHECK(cond, Message, ...)                                                                  \
   if (!(cond))                                                                                     \
   {                                                                                                \
-    PanicAlert(__FUNCTION__ " failed in %s at line %d: " Message, __FILE__, __LINE__,              \
+    PanicAlert("%s failed in %s at line %d: " Message, __func__, __FILE__, __LINE__,               \
                __VA_ARGS__);                                                                       \
   }
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -40,6 +40,6 @@ void UnloadVulkanLibrary();
 const char* VkResultToString(VkResult res);
 void LogVulkanResult(int level, const char* func_name, VkResult res, const char* msg, ...);
 
-#define LOG_VULKAN_ERROR(res, ...) LogVulkanResult(2, __FUNCTION__, res, __VA_ARGS__)
+#define LOG_VULKAN_ERROR(res, ...) LogVulkanResult(2, __func__, res, __VA_ARGS__)
 
 }  // namespace Vulkan


### PR DESCRIPTION
This replaces usages of the non-standard `__FUNCTION__` macro with the standard mandated `__func__` identifier.

`__FUNCTION__` is a preprocessor definition that is provided as an extension by compilers. This was the only convenient option to rely on pre-C++11. However, C++11 and greater mandate the predefined identifier `__func__`, which lets us accomplish the same thing.

The difference between the two, however, is that `__func__` isn't a preprocessor macro, it's an actual identifier that exists at function scope. The C++17 draft standard (N4659) at section [dcl.fct.def.general] paragraph 8 states:

>
> The function-local predefined variable `__func__` is defined as if a definition of the form
>
> `static const char __func__[] = "function-name ";`
>
> had been provided, where function-name is an implementation-defined string. It is unspecified whether  such a variable has an address distinct from that of any other object in the program.

Thankfully, we don't do any macro or string concatenation with `__FUNCTION__` that can't be modified to use `__func__`.