### PR TITLE
DolphinQt2: Fix project loading in VS

### DIFF
--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -305,8 +305,6 @@
     <ClInclude Include="Config\Mapping\HotkeyGraphics.h" />
     <ClInclude Include="Config\Mapping\HotkeyStates.h" />
     <ClInclude Include="Config\Mapping\HotkeyTAS.h" />
-    <ClInclude Include="Debugger\CodeViewWidget.h" />
-    <ClInclude Include="Debugger\CodeWidget.h" />
     <ClInclude Include="TAS\Shared.h" />
     <ClInclude Include="Config\Mapping\HotkeyWii.h" />
     <ClInclude Include="Config\Mapping\MappingBool.h" />


### PR DESCRIPTION
These headers are already specified in the QtMoc item section, so these are seen as a duplicate definition of the file, causing a project load error.