### PR TITLE
CPUDetect: Make the cpu_info global const

### DIFF
--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -41,7 +41,7 @@ static std::string GetCPUString()
   return cpu_string;
 }
 
-CPUInfo cpu_info;
+const CPUInfo cpu_info;
 
 CPUInfo::CPUInfo()
 {

--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -73,7 +73,7 @@ void CPUInfo::Detect()
 }
 
 // Turn the CPU info into a string we can show
-std::string CPUInfo::Summarize()
+std::string CPUInfo::Summarize() const
 {
   std::string sum;
   if (num_cores == 1)

--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -73,4 +73,4 @@ private:
   void Detect();
 };
 
-extern CPUInfo cpu_info;
+extern const CPUInfo cpu_info;

--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -66,7 +66,7 @@ struct CPUInfo
   explicit CPUInfo();
 
   // Turn the CPU info into a string we can show
-  std::string Summarize();
+  std::string Summarize() const;
 
 private:
   // Detects the various CPU features

--- a/Source/Core/Common/GenericCPUDetect.cpp
+++ b/Source/Core/Common/GenericCPUDetect.cpp
@@ -4,7 +4,7 @@
 
 #include "Common/CPUDetect.h"
 
-CPUInfo cpu_info;
+const CPUInfo cpu_info;
 
 CPUInfo::CPUInfo()
 {

--- a/Source/Core/Common/GenericCPUDetect.cpp
+++ b/Source/Core/Common/GenericCPUDetect.cpp
@@ -10,7 +10,7 @@ CPUInfo::CPUInfo()
 {
 }
 
-std::string CPUInfo::Summarize()
+std::string CPUInfo::Summarize() const
 {
   return "Generic";
 }

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -218,7 +218,7 @@ void CPUInfo::Detect()
 }
 
 // Turn the CPU info into a string we can show
-std::string CPUInfo::Summarize()
+std::string CPUInfo::Summarize() const
 {
   std::string sum(cpu_string);
   sum += " (";

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -47,7 +47,7 @@ static u64 _xgetbv(u32 index)
 
 #endif  // ifndef _WIN32
 
-CPUInfo cpu_info;
+const CPUInfo cpu_info;
 
 CPUInfo::CPUInfo()
 {


### PR DESCRIPTION
Modifying the members in this struct is almost certainly a mistake. It's only around so the members can be queried about whether or not the CPU supports a feature. Therefore, we prevent it at the type-system level.