### PR TITLE
Boot: Set TYPE_NANDBOOT when booting from NAND

### DIFF
--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -25,7 +25,7 @@
 bool CBoot::BootNANDTitle(const u64 title_id)
 {
   UpdateStateFlags([](StateFlags* state) {
-    state->type = 0x03;  // TYPE_RETURN
+    state->type = 0x04;  // TYPE_NANDBOOT
   });
 
   if (title_id == Titles::SYSTEM_MENU)


### PR DESCRIPTION
It makes more sense to set TYPE_NANDBOOT than TYPE_RETURN. The latter is normally only set when returning to the system menu from a game.