### PR TITLE
Config: Set bMMU to true by default on x64

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -557,7 +557,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("WiimoteEnableSpeaker", &m_WiimoteEnableSpeaker, false);
   core->Get("RunCompareServer", &bRunCompareServer, false);
   core->Get("RunCompareClient", &bRunCompareClient, false);
-  core->Get("MMU", &bMMU, false);
+  core->Get("MMU", &bMMU, bMMU);
   core->Get("BBDumpPort", &iBBDumpPort, -1);
   core->Get("SyncGPU", &bSyncGPU, false);
   core->Get("SyncGpuMaxDistance", &iSyncGpuMaxDistance, 200000);
@@ -772,7 +772,11 @@ void SConfig::LoadDefaults()
   bFastmem = true;
   bFPRF = false;
   bAccurateNaNs = false;
+#ifdef _M_X86_64
+  bMMU = true;
+#else
   bMMU = false;
+#endif
   bDCBZOFF = false;
   bLowDCBZHack = false;
   iBBDumpPort = -1;


### PR DESCRIPTION
This prevents Dolphin from crashing when the emulated software crashes.
AFAIK, there is absolutely no performance hit by enabling this with the x64 JIT.

Eventually, we should probably just remove bMMU (https://github.com/dolphin-emu/dolphin/pull/1831). We can't do that yet because of the ARM JIT.