### PR TITLE
OGLShader: Fix mismatched assignment in compute shader constructor

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -30,7 +30,8 @@ OGLShader::OGLShader(ShaderStage stage, GLenum gl_type, GLuint shader_id)
 }
 
 OGLShader::OGLShader(GLuint compute_program_id)
-    : AbstractShader(ShaderStage::Compute), m_type(GL_COMPUTE_SHADER), m_id(compute_program_id)
+    : AbstractShader(ShaderStage::Compute), m_type(GL_COMPUTE_SHADER),
+      m_compute_program_id(compute_program_id)
 {
 }
 

--- a/Source/Core/VideoBackends/OGL/OGLShader.h
+++ b/Source/Core/VideoBackends/OGL/OGLShader.h
@@ -31,8 +31,8 @@ public:
 
 private:
   GLenum m_type;
-  GLuint m_id;
-  GLuint m_compute_program_id;
+  GLuint m_id = 0;
+  GLuint m_compute_program_id = 0;
 };
 
 }  // namespace OGL


### PR DESCRIPTION
Stumbled on this while working on killing off the rest of the static state in FramebufferManager. Thankfully, the constructor wasn't used yet.