### PR TITLE
MainBase: Remove unused file-scope variables

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 93;  // Last changed in PR 6389
+static const u32 STATE_VERSION = 94;  // Last changed in PR 6456
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -31,14 +31,6 @@
 
 static Common::Flag s_FifoShuttingDown;
 
-static volatile struct
-{
-  u32 xfbAddr;
-  u32 fbWidth;
-  u32 fbStride;
-  u32 fbHeight;
-} s_beginFieldArgs;
-
 void VideoBackendBase::Video_ExitLoop()
 {
   Fifo::ExitGpuLoop();
@@ -175,7 +167,6 @@ void VideoBackendBase::InitializeShared()
   m_initialized = true;
 
   s_FifoShuttingDown.Clear();
-  memset((void*)&s_beginFieldArgs, 0, sizeof(s_beginFieldArgs));
   m_invalid = false;
   frameCount = 0;
 
@@ -220,9 +211,6 @@ void VideoBackendBase::DoState(PointerWrap& p)
 
   VideoCommon_DoState(p);
   p.DoMarker("VideoCommon");
-
-  p.Do(s_beginFieldArgs);
-  p.DoMarker("VideoBackendBase");
 
   // Refresh state.
   if (p.GetMode() == PointerWrap::MODE_READ)

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -7,7 +7,6 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
-#include "Common/Flag.h"
 #include "Common/Logging/Log.h"
 #include "Core/Host.h"
 #include "VideoCommon/AsyncRequests.h"
@@ -29,12 +28,9 @@
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoState.h"
 
-static Common::Flag s_FifoShuttingDown;
-
 void VideoBackendBase::Video_ExitLoop()
 {
   Fifo::ExitGpuLoop();
-  s_FifoShuttingDown.Set();
 }
 
 // Run from the CPU thread (from VideoInterface.cpp)
@@ -166,7 +162,6 @@ void VideoBackendBase::InitializeShared()
   // do not initialize again for the config window
   m_initialized = true;
 
-  s_FifoShuttingDown.Clear();
   m_invalid = false;
   frameCount = 0;
 


### PR DESCRIPTION
Removes some variables that have become unused (also yay, less `volatile` uses in the codebase).

Given this removes all file-scope variables, it's likely better to eliminate the file entirely and move the functions into VideoBackendBase.cpp where they belong, however, I'll save that for a follow-up PR.