### PR TITLE
x64Emitter: Move FloatOp and NormalOp enum definitions into the cpp file

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -76,6 +76,32 @@ enum NormalSSEOps
   sseMOVNTP = 0x2B,
 };
 
+enum NormalOp : int
+{
+  nrmADD,
+  nrmADC,
+  nrmSUB,
+  nrmSBB,
+  nrmAND,
+  nrmOR,
+  nrmXOR,
+  nrmMOV,
+  nrmTEST,
+  nrmCMP,
+  nrmXCHG,
+};
+
+enum FloatOp : int
+{
+  floatLD = 0,
+  floatST = 2,
+  floatSTP = 3,
+  floatLD80 = 5,
+  floatSTP80 = 7,
+
+  floatINVALID = -1,
+};
+
 void XEmitter::SetCodePtr(u8* ptr)
 {
   code = ptr;

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -91,8 +91,8 @@ enum SSECompare
 };
 
 class XEmitter;
-enum FloatOp : int;
-enum NormalOp : int;
+enum class FloatOp;
+enum class NormalOp;
 
 // Information about a generated MOV op
 struct MovInfo final


### PR DESCRIPTION
These are only used internally for writing ops. This also removes the amount of symbols exported in the header, which is nice, because some other source files dump the whole `Gen` namespace with `using namespace Gen;`