### PR TITLE
Remove "experimental" tag from Vulkan

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -15,7 +15,7 @@ public:
   void Shutdown() override;
 
   std::string GetName() const override { return "Vulkan"; }
-  std::string GetDisplayName() const override { return "Vulkan (experimental)"; }
+  std::string GetDisplayName() const override { return "Vulkan"; }
   void InitBackendInfo() override;
 };
 }


### PR DESCRIPTION
Drivers may be buggy but that's [the same with OpenGL](https://dolphin-emu.org/blog/2013/09/26/dolphin-emulator-and-opengl-drivers-hall-fameshame/) and that back-end isn't marked experimental either.

The "experimental" tag implies that the back-end is severely broken. It's not. It's fine. :-)