### PR TITLE
Interpreter_SystemRegisters: Handle mffs, mtfsb0, mtfsb1, mtfsf and mtfsfi with the record bit set

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -56,7 +56,7 @@ void Interpreter::mtfsb0x(UGeckoInstruction inst)
   FPSCRtoFPUSettings(FPSCR);
 
   if (inst.Rc)
-    PanicAlert("mtfsb0x: inst.Rc");
+    Helper_UpdateCR1();
 }
 
 void Interpreter::mtfsb1x(UGeckoInstruction inst)
@@ -70,7 +70,7 @@ void Interpreter::mtfsb1x(UGeckoInstruction inst)
   FPSCRtoFPUSettings(FPSCR);
 
   if (inst.Rc)
-    PanicAlert("mtfsb1x: inst.Rc");
+    Helper_UpdateCR1();
 }
 
 void Interpreter::mtfsfix(UGeckoInstruction inst)
@@ -87,7 +87,7 @@ void Interpreter::mtfsfix(UGeckoInstruction inst)
   FPSCRtoFPUSettings(FPSCR);
 
   if (inst.Rc)
-    PanicAlert("mtfsfix: inst.Rc");
+    Helper_UpdateCR1();
 }
 
 void Interpreter::mtfsfx(UGeckoInstruction inst)
@@ -108,7 +108,7 @@ void Interpreter::mtfsfx(UGeckoInstruction inst)
   FPSCRtoFPUSettings(FPSCR);
 
   if (inst.Rc)
-    PanicAlert("mtfsfx: inst.Rc");
+    Helper_UpdateCR1();
 }
 
 void Interpreter::mcrxr(UGeckoInstruction inst)
@@ -517,5 +517,5 @@ void Interpreter::mffsx(UGeckoInstruction inst)
   riPS0(inst.FD) = 0xFFF8000000000000 | FPSCR.Hex;
 
   if (inst.Rc)
-    PanicAlert("mffsx: inst_.Rc");
+    Helper_UpdateCR1();
 }


### PR DESCRIPTION
mffs with the record bit set updates condition register 1 with the contents of the FPSCR's FX, FEX, VX and OX bits.

Helper_UpdateCR1() does exactly that, so we use it here to perform this for us.