### PR TITLE
JitInterface: Remove a downcast within InitJitCore

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -46,21 +46,20 @@ void DoState(PointerWrap& p)
 }
 CPUCoreBase* InitJitCore(int core)
 {
-  CPUCoreBase* ptr = nullptr;
   switch (core)
   {
 #if _M_X86
   case PowerPC::CORE_JIT64:
-    ptr = new Jit64();
+    g_jit = new Jit64();
     break;
 #endif
 #if _M_ARM_64
   case PowerPC::CORE_JITARM64:
-    ptr = new JitArm64();
+    g_jit = new JitArm64();
     break;
 #endif
   case PowerPC::CORE_CACHEDINTERPRETER:
-    ptr = new CachedInterpreter();
+    g_jit = new CachedInterpreter();
     break;
 
   default:
@@ -68,9 +67,8 @@ CPUCoreBase* InitJitCore(int core)
     g_jit = nullptr;
     return nullptr;
   }
-  g_jit = static_cast<JitBase*>(ptr);
   g_jit->Init();
-  return ptr;
+  return g_jit;
 }
 
 CPUCoreBase* GetCore()


### PR DESCRIPTION
This cast isn't necessary as JitBase is already within the type hierarchy that CPUCoreBase is.