### PR TITLE
Core/CMakeLists: Migrate off add_dolphin_library

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -35,6 +35,7 @@ endif()
 add_definitions(-D__STDC_LIMIT_MACROS)
 add_definitions(-D__STDC_CONSTANT_MACROS)
 
+# DEPRECATED: When introducing new libraries, do it explicitly.
 macro(add_dolphin_library lib srcs libs)
   add_library(${lib} STATIC ${srcs})
   target_link_libraries(${lib} PUBLIC ${libs})

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS
+add_library(core
   ActionReplay.cpp
   Analytics.cpp
   ARDecrypt.cpp
@@ -228,7 +228,7 @@ set(SRCS
 )
 
 if(_M_X86)
-  set(SRCS ${SRCS}
+  target_sources(core PRIVATE
     PowerPC/Jit64/FPURegCache.cpp
     PowerPC/Jit64/GPRRegCache.cpp
     PowerPC/Jit64/Jit64_Tables.cpp
@@ -252,7 +252,7 @@ if(_M_X86)
     PowerPC/Jit64Common/TrampolineCache.cpp
   )
 elseif(_M_ARM_64)
-  set(SRCS ${SRCS}
+  target_sources(core PRIVATE
     PowerPC/JitArm64/Jit.cpp
     PowerPC/JitArm64/JitAsm.cpp
     PowerPC/JitArm64/JitArm64Cache.cpp
@@ -271,7 +271,8 @@ elseif(_M_ARM_64)
   )
 endif()
 
-set(LIBS
+target_link_libraries(core
+PUBLIC
   audiocommon
   bdisasm
   common
@@ -280,6 +281,7 @@ set(LIBS
   enet
   inputcommon
   ${LZO}
+  ${MBEDTLS_LIBRARIES}
   pugixml
   sfml-network
   sfml-system
@@ -291,33 +293,37 @@ set(LIBS
 
 if(LIBUSB_FOUND)
   # Using shared LibUSB
-  set(LIBS ${LIBS} ${LIBUSB_LIBRARIES})
-  set(SRCS ${SRCS}
+  target_link_libraries(core PUBLIC ${LIBUSB_LIBRARIES})
+  target_sources(core PRIVATE
     IOS/USB/LibusbDevice.cpp
     IOS/USB/Bluetooth/BTReal.cpp
   )
 endif()
 
 if(NOT APPLE)
-  set(LIBS ${LIBS} videovulkan)
+  target_link_libraries(core PUBLIC videovulkan)
 endif()
 
-set(LIBS ${LIBS} ${MBEDTLS_LIBRARIES})
-
 if(WIN32)
-  set(SRCS ${SRCS} HW/EXI/BBA-TAP/TAP_Win32.cpp HW/WiimoteReal/IOWin.cpp)
-  list(APPEND LIBS
+  target_sources(core PRIVATE
+    HW/EXI/BBA-TAP/TAP_Win32.cpp
+    HW/WiimoteReal/IOWin.cpp
+  )
+  target_link_libraries(core PUBLIC
     videod3d
     setupapi.lib
     iphlpapi.lib
   )
 elseif(APPLE)
-  set(SRCS ${SRCS} HW/EXI/BBA-TAP/TAP_Apple.cpp HW/WiimoteReal/IOdarwin.mm)
-  set(LIBS ${LIBS} ${IOB_LIBRARY})
+  target_sources(core PRIVATE
+    HW/EXI/BBA-TAP/TAP_Apple.cpp
+    HW/WiimoteReal/IOdarwin.mm
+  )
+  target_link_libraries(core PUBLIC ${IOB_LIBRARY})
 elseif(UNIX)
-  set(SRCS ${SRCS} HW/EXI/BBA-TAP/TAP_Unix.cpp)
+  target_sources(core PRIVATE HW/EXI/BBA-TAP/TAP_Unix.cpp)
   if(ANDROID)
-    set(SRCS ${SRCS} HW/WiimoteReal/IOAndroid.cpp)
+    target_sources(core PRIVATE HW/WiimoteReal/IOAndroid.cpp)
   endif()
 endif()
 
@@ -328,9 +334,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(BlueZ)
     if(BLUEZ_FOUND)
       message(STATUS "BlueZ found, enabling bluetooth support")
-      set(SRCS ${SRCS} HW/WiimoteReal/IOLinux.cpp)
-      set(LIBS ${LIBS} BlueZ::BlueZ)
-      add_definitions(-DHAVE_BLUEZ=1)
+      target_sources(core PRIVATE HW/WiimoteReal/IOLinux.cpp)
+      target_link_libraries(core PUBLIC BlueZ::BlueZ)
+      target_compile_definitions(core PRIVATE -DHAVE_BLUEZ=1)
     else()
       message(STATUS "BlueZ NOT found, disabling bluetooth support")
     endif()
@@ -340,17 +346,15 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 if(TARGET Hidapi::Hidapi)
-  set(SRCS ${SRCS} HW/WiimoteReal/IOhidapi.cpp)
-  list(APPEND LIBS Hidapi::Hidapi)
-  add_definitions(-DHAVE_HIDAPI=1)
+  target_sources(core PRIVATE HW/WiimoteReal/IOhidapi.cpp)
+  target_link_libraries(core PUBLIC Hidapi::Hidapi)
+  target_compile_definitions(core PRIVATE -DHAVE_HIDAPI=1)
 endif()
 
 if(GDBSTUB)
-  set(SRCS ${SRCS} PowerPC/GDBStub.cpp)
+  target_sources(core PRIVATE PowerPC/GDBStub.cpp)
 endif()
 
 if(UNIX)
-  set(SRCS ${SRCS} MemoryWatcher.cpp)
+  target_sources(core PRIVATE MemoryWatcher.cpp)
 endif()
-
-add_dolphin_library(core "${SRCS}" "${LIBS}")


### PR DESCRIPTION
This macro (that has unfortunately become the de-facto way of introducing targets) has a lot of disadvantages that outweigh the fact that you avoid writing two extra lines of CMake script.

- It encourages the use of variables. In a build system the last thing we want to care about is mutable state that can be avoided.
- It only handles linking in the libraries and nothing else. It's a laziness macro.
- We should be explicit about what we're doing by introducing the target first, not last.

This gets the ball rolling by migrating Core off the macro. Note that this is essentially 1-to-1 unrolling of the macro, therefore we're still linking in all libraries as public, even though that may not be necessary.

This can be revisited once everything is off the macro for a quicker transition period.