### PR TITLE
Interpreter: Handle setting the overflow flag when the OE bit is set in divw, divwu, and neg

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -580,16 +580,15 @@ void Interpreter::mullwx(UGeckoInstruction inst)
 
 void Interpreter::negx(UGeckoInstruction inst)
 {
-  rGPR[inst.RD] = (~rGPR[inst.RA]) + 1;
+  const u32 a = rGPR[inst.RA];
 
-  if (rGPR[inst.RD] == 0x80000000)
-  {
-    if (inst.OE)
-      PanicAlert("OE: negx");
-  }
+  rGPR[inst.RD] = (~a) + 1;
 
   if (inst.Rc)
     Helper_UpdateCR0(rGPR[inst.RD]);
+
+  if (inst.OE && a == 0x80000000)
+    SetXER_OV(true);
 }
 
 void Interpreter::subfx(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -499,8 +499,7 @@ void Interpreter::divwx(UGeckoInstruction inst)
   {
     if (inst.OE)
     {
-      // should set OV
-      PanicAlert("OE: divwx");
+      SetXER_OV(true);
     }
 
     if (((u32)a & 0x80000000) && b == 0)
@@ -526,8 +525,7 @@ void Interpreter::divwux(UGeckoInstruction inst)
   {
     if (inst.OE)
     {
-      // should set OV
-      PanicAlert("OE: divwux");
+      SetXER_OV(true);
     }
 
     rGPR[inst.RD] = 0;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -417,14 +417,25 @@ inline void SetXER(UReg_XER new_xer)
   PowerPC::ppcState.xer_so_ov = (new_xer.SO << 1) + new_xer.OV;
 }
 
-inline int GetXER_SO()
+inline u32 GetXER_SO()
 {
   return PowerPC::ppcState.xer_so_ov >> 1;
 }
 
-inline void SetXER_SO(int value)
+inline void SetXER_SO(bool value)
 {
-  PowerPC::ppcState.xer_so_ov |= value << 1;
+  PowerPC::ppcState.xer_so_ov |= static_cast<u32>(value) << 1;
+}
+
+inline u32 GetXER_OV()
+{
+  return PowerPC::ppcState.xer_so_ov & 1;
+}
+
+inline void SetXER_OV(bool value)
+{
+  PowerPC::ppcState.xer_so_ov |= static_cast<u32>(value);
+  SetXER_SO(value);
 }
 
 void UpdateFPRF(double dvalue);


### PR DESCRIPTION
Gets the dead simple instructions out of the way in terms of overflow flag support