### PR TITLE
JitBase: Ensure JitOptions and JitState instances are consistently initialized

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -110,8 +110,8 @@ protected:
 
 public:
   // This should probably be removed from public:
-  JitOptions jo;
-  JitState js;
+  JitOptions jo{};
+  JitState js{};
 
   JitBase();
   ~JitBase() override;


### PR DESCRIPTION
Ensures that upon construction of a JitBase instance, that all underlying members within the option and state structs are guaranteed to be initialized. This prevents potentially using a member uninitialized in some form, even after the Init() call if not all members are set.