### PR TITLE
HW: Fix infinite rumble on emulation pause

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -244,6 +244,17 @@ bool Init(std::unique_ptr<BootParameters> boot)
   return true;
 }
 
+static void ResetRumble()
+{
+#if defined(__LIBUSB__)
+  GCAdapter::ResetRumble();
+#endif
+#if defined(CIFACE_USE_XINPUT) || defined(CIFACE_USE_DINPUT)
+  for (int i = 0; i < 4; ++i)
+    Pad::ResetRumble(i);
+#endif
+}
+
 // Called from GUI thread
 void Stop()  // - Hammertime!
 {
@@ -274,9 +285,8 @@ void Stop()  // - Hammertime!
 
     g_video_backend->Video_ExitLoop();
   }
-#if defined(__LIBUSB__)
-  GCAdapter::ResetRumble();
-#endif
+
+  ResetRumble();
 
 #ifdef USE_MEMORYWATCHER
   MemoryWatcher::Shutdown();
@@ -605,9 +615,7 @@ void SetState(State state)
     //   stopped (including the CPU).
     CPU::EnableStepping(true);  // Break
     Wiimote::Pause();
-#if defined(__LIBUSB__)
-    GCAdapter::ResetRumble();
-#endif
+    ResetRumble();
     break;
   case State::Running:
     CPU::EnableStepping(false);
@@ -726,9 +734,7 @@ static bool PauseAndLock(bool do_lock, bool unpause_on_unlock)
   // (s_efbAccessRequested).
   Fifo::PauseAndLock(do_lock, false);
 
-#if defined(__LIBUSB__)
-  GCAdapter::ResetRumble();
-#endif
+  ResetRumble();
 
   // CPU is unlocked last because CPU::PauseAndLock contains the synchronization
   // mechanism that prevents CPU::Break from racing.

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -60,6 +60,11 @@ void Rumble(const int pad_num, const ControlState strength)
   static_cast<GCPad*>(s_config.GetController(pad_num))->SetOutput(strength);
 }
 
+void ResetRumble(const int pad_num)
+{
+  static_cast<GCPad*>(s_config.GetController(pad_num))->SetOutput(0.0);
+}
+
 bool GetMicButton(const int pad_num)
 {
   return static_cast<GCPad*>(s_config.GetController(pad_num))->GetMicButton();

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -27,6 +27,7 @@ InputConfig* GetConfig();
 GCPadStatus GetStatus(int pad_num);
 ControllerEmu::ControlGroup* GetGroup(int pad_num, PadGroup group);
 void Rumble(int pad_num, ControlState strength);
+void ResetRumble(int pad_num);
 
 bool GetMicButton(int pad_num);
 }


### PR DESCRIPTION
This fixes the old issue of [rumble not stopping when emulation is paused](https://bugs.dolphin-emu.org/issues/9001). It was fixed for the GameCube adapter and LibUSB controllers [here](https://dolphin-emu.org/download/dev/59b54a77d33f2a59fabfc4d5a7643538d9b81327/), but that fix did not work for XInput or DInput controllers on Windows.

A partner and I tested on two different machines in multiple games and multiple controllers. With XInput controllers, the rumble stopped on emulation pause and resumed where appropriate, and stopped properly on emulation close. Neither me nor my partner were able to test with DInput. I have a DInput controller, but my rumble motors are not recognized by Dolphin on any build that I've tested.

I believe it follows the code style guidelines, but this is the first pull request from my team so if anything is off please let us know.