### PR TITLE
Jit_Integer: Make NOP check more flexible for ori and expand NOP checking to oris, xori, and xoris

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -304,8 +304,8 @@ void Jit64::reg_imm(UGeckoInstruction inst)
   case 15:  // addis
     regimmop(d, a, false, (u32)inst.SIMM_16 << 16, Add, &XEmitter::ADD);
     break;
-  case 24:                                               // ori
-    if (a == 0 && s == 0 && inst.UIMM == 0 && !inst.Rc)  // check for nop
+  case 24:                         // ori
+    if (a == s && inst.UIMM == 0)  // check for nop
     {
       // Make the nop visible in the generated code. not much use but interesting if we see one.
       NOP();

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -326,11 +326,19 @@ void Jit64::reg_imm(UGeckoInstruction inst)
     regimmop(a, s, true, inst.UIMM << 16, And, &XEmitter::AND, true);
     break;
   case 26:  // xori
-    regimmop(a, s, true, inst.UIMM, Xor, &XEmitter::XOR, false);
-    break;
   case 27:  // xoris
-    regimmop(a, s, true, inst.UIMM << 16, Xor, &XEmitter::XOR, false);
+  {
+    if (s == a && inst.UIMM == 0)
+    {
+      // Make the nop visible in the generated code.
+      NOP();
+      return;
+    }
+
+    const u32 immediate = inst.OPCD == 26 ? inst.UIMM : inst.UIMM << 16;
+    regimmop(a, s, true, immediate, Xor, &XEmitter::XOR, false);
     break;
+  }
   case 12:  // addic
     regimmop(d, a, false, (u32)(s32)inst.SIMM_16, Add, &XEmitter::ADD, false, true);
     break;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -304,18 +304,21 @@ void Jit64::reg_imm(UGeckoInstruction inst)
   case 15:  // addis
     regimmop(d, a, false, (u32)inst.SIMM_16 << 16, Add, &XEmitter::ADD);
     break;
-  case 24:                         // ori
-    if (a == s && inst.UIMM == 0)  // check for nop
+  case 24:  // ori
+  case 25:  // oris
+  {
+    // check for nop
+    if (a == s && inst.UIMM == 0)
     {
       // Make the nop visible in the generated code. not much use but interesting if we see one.
       NOP();
       return;
     }
-    regimmop(a, s, true, inst.UIMM, Or, &XEmitter::OR);
+
+    const u32 immediate = inst.OPCD == 24 ? inst.UIMM : inst.UIMM << 16;
+    regimmop(a, s, true, immediate, Or, &XEmitter::OR);
     break;
-  case 25:  // oris
-    regimmop(a, s, true, inst.UIMM << 16, Or, &XEmitter::OR, false);
-    break;
+  }
   case 28:  // andi
     regimmop(a, s, true, inst.UIMM, And, &XEmitter::AND, true);
     break;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -121,8 +121,9 @@ void JitArm64::arith_imm(UGeckoInstruction inst)
 
   switch (inst.OPCD)
   {
-  case 24:                                               // ori
-    if (a == 0 && s == 0 && inst.UIMM == 0 && !inst.Rc)  // check for nop
+  case 24:  // ori
+    // check for nop
+    if (a == s && inst.UIMM == 0)
     {
       // NOP
       return;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -142,11 +142,18 @@ void JitArm64::arith_imm(UGeckoInstruction inst)
     reg_imm(a, s, inst.UIMM << 16, BitAND, &ARM64XEmitter::ANDI2R, true);
     break;
   case 26:  // xori
-    reg_imm(a, s, inst.UIMM, BitXOR, &ARM64XEmitter::EORI2R);
-    break;
   case 27:  // xoris
-    reg_imm(a, s, inst.UIMM << 16, BitXOR, &ARM64XEmitter::EORI2R);
+  {
+    if (a == s && inst.UIMM == 0)
+    {
+      // NOP
+      return;
+    }
+
+    const u32 immediate = inst.OPCD == 26 ? inst.UIMM : inst.UIMM << 16;
+    reg_imm(a, s, immediate, BitXOR, &ARM64XEmitter::EORI2R);
     break;
+  }
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -122,17 +122,19 @@ void JitArm64::arith_imm(UGeckoInstruction inst)
   switch (inst.OPCD)
   {
   case 24:  // ori
+  case 25:  // oris
+  {
     // check for nop
     if (a == s && inst.UIMM == 0)
     {
       // NOP
       return;
     }
-    reg_imm(a, s, inst.UIMM, BitOR, &ARM64XEmitter::ORRI2R);
+
+    const u32 immediate = inst.OPCD == 24 ? inst.UIMM : inst.UIMM << 16;
+    reg_imm(a, s, immediate, BitOR, &ARM64XEmitter::ORRI2R);
     break;
-  case 25:  // oris
-    reg_imm(a, s, inst.UIMM << 16, BitOR, &ARM64XEmitter::ORRI2R);
-    break;
+  }
   case 28:  // andi
     reg_imm(a, s, inst.UIMM, BitAND, &ARM64XEmitter::ANDI2R, true);
     break;


### PR DESCRIPTION
A NOP for ori is really whenever the destination and source registers are the same and the immediate is zero. The source and destination don't strictly have to be `r0`. Similarly this also applies to oris, xori, and xoris.

We don't really need to actually emit a NOP, but I've done so to keep it consistent with what was already in place in ori. I can remove them if that's desirable however.