### PR TITLE
Qt/CheatCodeEditor: Fix valid, encrypted AR codes not being accepted

### DIFF
--- a/Source/Core/DolphinQt2/Config/CheatCodeEditor.cpp
+++ b/Source/Core/DolphinQt2/Config/CheatCodeEditor.cpp
@@ -148,7 +148,7 @@ bool CheatCodeEditor::AcceptAR()
       QStringList blocks = line.split(QStringLiteral("-"));
 
       if (blocks.size() == 3 && blocks[0].size() == 4 && blocks[1].size() == 4 &&
-          blocks[2].size() == 4)
+          blocks[2].size() == 5)
       {
         encrypted_lines.emplace_back(blocks[0].toStdString() + blocks[1].toStdString() +
                                      blocks[2].toStdString());


### PR DESCRIPTION
The last section of encrypted AR codes is 5 characters long, not 4.