### PR TITLE
PowerPC: Namespace all header contents for PowerPC.h

### DIFF
--- a/Source/Core/Core/HLE/HLE_VarArgs.cpp
+++ b/Source/Core/Core/HLE/HLE_VarArgs.cpp
@@ -21,7 +21,7 @@ double HLE::SystemVABI::VAList::GetFPR(u32 fpr) const
 HLE::SystemVABI::VAListStruct::VAListStruct(u32 address)
     : VAList(0), m_va_list{PowerPC::HostRead_U8(address), PowerPC::HostRead_U8(address + 1),
                            PowerPC::HostRead_U32(address + 4), PowerPC::HostRead_U32(address + 8)},
-      m_address(address), m_has_fpr_area(GetCRBit(6) == 1)
+      m_address(address), m_has_fpr_area(PowerPC::GetCRBit(6) == 1)
 {
   m_stack = m_va_list.overflow_arg_area;
   m_gpr += m_va_list.gpr;

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -450,7 +450,7 @@ static void gdb_read_register()
     wbe32hex(reply, MSR);
     break;
   case 66:
-    wbe32hex(reply, GetCR());
+    wbe32hex(reply, PowerPC::GetCR());
     break;
   case 67:
     wbe32hex(reply, LR);
@@ -497,7 +497,7 @@ static void gdb_read_registers()
   bufptr += 32 * 8;
   wbe32hex(bufptr, PC);      bufptr += 4;
   wbe32hex(bufptr, MSR);     bufptr += 4;
-  wbe32hex(bufptr, GetCR()); bufptr += 4;
+  wbe32hex(bufptr, PowerPC::GetCR()); bufptr += 4;
   wbe32hex(bufptr, LR);      bufptr += 4;
 
 
@@ -553,7 +553,7 @@ static void gdb_write_register()
     MSR = re32hex(bufptr);
     break;
   case 66:
-    SetCR(re32hex(bufptr));
+    PowerPC::SetCR(re32hex(bufptr));
     break;
   case 67:
     LR = re32hex(bufptr);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -39,7 +39,7 @@ void Interpreter::bcx(UGeckoInstruction inst)
   const bool only_condition_check = ((inst.BO >> 2) & 1);
   int ctr_check = ((CTR != 0) ^ (inst.BO >> 1)) & 1;
   bool counter = only_condition_check || ctr_check;
-  bool condition = only_counter_check || (GetCRBit(inst.BI) == u32(true_false));
+  bool condition = only_counter_check || (PowerPC::GetCRBit(inst.BI) == u32(true_false));
 
   if (counter && condition)
   {
@@ -78,7 +78,7 @@ void Interpreter::bcctrx(UGeckoInstruction inst)
   DEBUG_ASSERT_MSG(POWERPC, inst.BO_2 & BO_DONT_DECREMENT_FLAG,
                    "bcctrx with decrement and test CTR option is invalid!");
 
-  int condition = ((inst.BO_2 >> 4) | (GetCRBit(inst.BI_2) == ((inst.BO_2 >> 3) & 1))) & 1;
+  int condition = ((inst.BO_2 >> 4) | (PowerPC::GetCRBit(inst.BI_2) == ((inst.BO_2 >> 3) & 1))) & 1;
 
   if (condition)
   {
@@ -96,7 +96,7 @@ void Interpreter::bclrx(UGeckoInstruction inst)
     CTR--;
 
   int counter = ((inst.BO_2 >> 2) | ((CTR != 0) ^ (inst.BO_2 >> 1))) & 1;
-  int condition = ((inst.BO_2 >> 4) | (GetCRBit(inst.BI_2) == ((inst.BO_2 >> 3) & 1))) & 1;
+  int condition = ((inst.BO_2 >> 4) | (PowerPC::GetCRBit(inst.BI_2) == ((inst.BO_2 >> 3) & 1))) & 1;
 
   if (counter & condition)
   {

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -17,7 +17,7 @@ using namespace MathUtil;
 // Star Wars : Rogue Leader spams that at some point :|
 void Interpreter::Helper_UpdateCR1()
 {
-  SetCRField(1, (FPSCR.FX << 3) | (FPSCR.FEX << 2) | (FPSCR.VX << 1) | FPSCR.OX);
+  PowerPC::SetCRField(1, (FPSCR.FX << 3) | (FPSCR.FEX << 2) | (FPSCR.VX << 1) | FPSCR.OX);
 }
 
 void Interpreter::Helper_FloatCompareOrdered(UGeckoInstruction inst, double fa, double fb)
@@ -56,7 +56,7 @@ void Interpreter::Helper_FloatCompareOrdered(UGeckoInstruction inst, double fa, 
   // Clear and set the FPCC bits accordingly.
   FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compareResult;
 
-  SetCRField(inst.CRFD, compareResult);
+  PowerPC::SetCRField(inst.CRFD, compareResult);
 }
 
 void Interpreter::Helper_FloatCompareUnordered(UGeckoInstruction inst, double fa, double fb)
@@ -88,7 +88,7 @@ void Interpreter::Helper_FloatCompareUnordered(UGeckoInstruction inst, double fa
   // Clear and set the FPCC bits accordingly.
   FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compareResult;
 
-  SetCRField(inst.CRFD, compareResult);
+  PowerPC::SetCRField(inst.CRFD, compareResult);
 }
 
 void Interpreter::fcmpo(UGeckoInstruction inst)
@@ -278,7 +278,7 @@ void Interpreter::frspx(UGeckoInstruction inst)  // round to single
   double rounded = ForceSingle(b);
   SetFI(b != rounded);
   FPSCR.FR = fabs(rounded) > fabs(b);
-  UpdateFPRF(rounded);
+  PowerPC::UpdateFPRF(rounded);
   rPS0(inst.FD) = rPS1(inst.FD) = rounded;
 
   if (inst.Rc)
@@ -290,7 +290,7 @@ void Interpreter::fmulx(UGeckoInstruction inst)
   rPS0(inst.FD) = ForceDouble(NI_mul(rPS0(inst.FA), rPS0(inst.FC)));
   FPSCR.FI = 0;  // are these flags important?
   FPSCR.FR = 0;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -303,7 +303,7 @@ void Interpreter::fmulsx(UGeckoInstruction inst)
   // FPSCR.FI = d_value != rPS0(_inst.FD);
   FPSCR.FI = 0;
   FPSCR.FR = 0;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -313,7 +313,7 @@ void Interpreter::fmaddx(UGeckoInstruction inst)
 {
   double result = ForceDouble(NI_madd(rPS0(inst.FA), rPS0(inst.FC), rPS0(inst.FB)));
   rPS0(inst.FD) = result;
-  UpdateFPRF(result);
+  PowerPC::UpdateFPRF(result);
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -326,7 +326,7 @@ void Interpreter::fmaddsx(UGeckoInstruction inst)
   rPS0(inst.FD) = rPS1(inst.FD) = ForceSingle(d_value);
   FPSCR.FI = d_value != rPS0(inst.FD);
   FPSCR.FR = 0;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -335,7 +335,7 @@ void Interpreter::fmaddsx(UGeckoInstruction inst)
 void Interpreter::faddx(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = ForceDouble(NI_add(rPS0(inst.FA), rPS0(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -343,7 +343,7 @@ void Interpreter::faddx(UGeckoInstruction inst)
 void Interpreter::faddsx(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = rPS1(inst.FD) = ForceSingle(NI_add(rPS0(inst.FA), rPS0(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -352,7 +352,7 @@ void Interpreter::faddsx(UGeckoInstruction inst)
 void Interpreter::fdivx(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = ForceDouble(NI_div(rPS0(inst.FA), rPS0(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   // FR,FI,OX,UX???
   if (inst.Rc)
@@ -361,7 +361,7 @@ void Interpreter::fdivx(UGeckoInstruction inst)
 void Interpreter::fdivsx(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = rPS1(inst.FD) = ForceSingle(NI_div(rPS0(inst.FA), rPS0(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -378,7 +378,7 @@ void Interpreter::fresx(UGeckoInstruction inst)
     SetFPException(FPSCR_ZX);
   }
 
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -398,7 +398,7 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   }
 
   rPS0(inst.FD) = ApproximateReciprocalSquareRoot(b);
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -407,7 +407,7 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
 void Interpreter::fmsubx(UGeckoInstruction _inst)
 {
   rPS0(_inst.FD) = ForceDouble(NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
-  UpdateFPRF(rPS0(_inst.FD));
+  PowerPC::UpdateFPRF(rPS0(_inst.FD));
 
   if (_inst.Rc)
     Helper_UpdateCR1();
@@ -417,7 +417,7 @@ void Interpreter::fmsubsx(UGeckoInstruction inst)
 {
   double c_value = Force25Bit(rPS0(inst.FC));
   rPS0(inst.FD) = rPS1(inst.FD) = ForceSingle(NI_msub(rPS0(inst.FA), c_value, rPS0(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -427,7 +427,7 @@ void Interpreter::fnmaddx(UGeckoInstruction inst)
 {
   double result = ForceDouble(NI_madd(rPS0(inst.FA), rPS0(inst.FC), rPS0(inst.FB)));
   rPS0(inst.FD) = std::isnan(result) ? result : -result;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -438,7 +438,7 @@ void Interpreter::fnmaddsx(UGeckoInstruction inst)
   double c_value = Force25Bit(rPS0(inst.FC));
   double result = ForceSingle(NI_madd(rPS0(inst.FA), c_value, rPS0(inst.FB)));
   rPS0(inst.FD) = rPS1(inst.FD) = std::isnan(result) ? result : -result;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -448,7 +448,7 @@ void Interpreter::fnmsubx(UGeckoInstruction inst)
 {
   double result = ForceDouble(NI_msub(rPS0(inst.FA), rPS0(inst.FC), rPS0(inst.FB)));
   rPS0(inst.FD) = std::isnan(result) ? result : -result;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -459,7 +459,7 @@ void Interpreter::fnmsubsx(UGeckoInstruction inst)
   double c_value = Force25Bit(rPS0(inst.FC));
   double result = ForceSingle(NI_msub(rPS0(inst.FA), c_value, rPS0(inst.FB)));
   rPS0(inst.FD) = rPS1(inst.FD) = std::isnan(result) ? result : -result;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -468,7 +468,7 @@ void Interpreter::fnmsubsx(UGeckoInstruction inst)
 void Interpreter::fsubx(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = ForceDouble(NI_sub(rPS0(inst.FA), rPS0(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -477,7 +477,7 @@ void Interpreter::fsubx(UGeckoInstruction inst)
 void Interpreter::fsubsx(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = rPS1(inst.FD) = ForceSingle(NI_sub(rPS0(inst.FA), rPS0(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -765,13 +765,13 @@ void Interpreter::stwcxd(UGeckoInstruction inst)
       if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
       {
         m_reserve = false;
-        SetCRField(0, 2 | GetXER_SO());
+        PowerPC::SetCRField(0, 2 | PowerPC::GetXER_SO());
         return;
       }
     }
   }
 
-  SetCRField(0, GetXER_SO());
+  PowerPC::SetCRField(0, PowerPC::GetXER_SO());
 }
 
 void Interpreter::stwux(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -108,7 +108,7 @@ void Interpreter::ps_div(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = ForceSingle(NI_div(rPS0(inst.FA), rPS0(inst.FB)));
   rPS1(inst.FD) = ForceSingle(NI_div(rPS1(inst.FA), rPS1(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -127,7 +127,7 @@ void Interpreter::ps_res(UGeckoInstruction inst)
 
   rPS0(inst.FD) = ApproximateReciprocal(a);
   rPS1(inst.FD) = ApproximateReciprocal(b);
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -148,7 +148,7 @@ void Interpreter::ps_rsqrte(UGeckoInstruction inst)
   rPS0(inst.FD) = ForceSingle(ApproximateReciprocalSquareRoot(rPS0(inst.FB)));
   rPS1(inst.FD) = ForceSingle(ApproximateReciprocalSquareRoot(rPS1(inst.FB)));
 
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -158,7 +158,7 @@ void Interpreter::ps_sub(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = ForceSingle(NI_sub(rPS0(inst.FA), rPS0(inst.FB)));
   rPS1(inst.FD) = ForceSingle(NI_sub(rPS1(inst.FA), rPS1(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -168,7 +168,7 @@ void Interpreter::ps_add(UGeckoInstruction inst)
 {
   rPS0(inst.FD) = ForceSingle(NI_add(rPS0(inst.FA), rPS0(inst.FB)));
   rPS1(inst.FD) = ForceSingle(NI_add(rPS1(inst.FA), rPS1(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -180,7 +180,7 @@ void Interpreter::ps_mul(UGeckoInstruction inst)
   double c1 = Force25Bit(rPS1(inst.FC));
   rPS0(inst.FD) = ForceSingle(NI_mul(rPS0(inst.FA), c0));
   rPS1(inst.FD) = ForceSingle(NI_mul(rPS1(inst.FA), c1));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -192,7 +192,7 @@ void Interpreter::ps_msub(UGeckoInstruction inst)
   double c1 = Force25Bit(rPS1(inst.FC));
   rPS0(inst.FD) = ForceSingle(NI_msub(rPS0(inst.FA), c0, rPS0(inst.FB)));
   rPS1(inst.FD) = ForceSingle(NI_msub(rPS1(inst.FA), c1, rPS1(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -204,7 +204,7 @@ void Interpreter::ps_madd(UGeckoInstruction inst)
   double c1 = Force25Bit(rPS1(inst.FC));
   rPS0(inst.FD) = ForceSingle(NI_madd(rPS0(inst.FA), c0, rPS0(inst.FB)));
   rPS1(inst.FD) = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)));
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -218,7 +218,7 @@ void Interpreter::ps_nmsub(UGeckoInstruction inst)
   double result1 = ForceSingle(NI_msub(rPS1(inst.FA), c1, rPS1(inst.FB)));
   rPS0(inst.FD) = std::isnan(result0) ? result0 : -result0;
   rPS1(inst.FD) = std::isnan(result1) ? result1 : -result1;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -232,7 +232,7 @@ void Interpreter::ps_nmadd(UGeckoInstruction inst)
   double result1 = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)));
   rPS0(inst.FD) = std::isnan(result0) ? result0 : -result0;
   rPS1(inst.FD) = std::isnan(result1) ? result1 : -result1;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -244,7 +244,7 @@ void Interpreter::ps_sum0(UGeckoInstruction inst)
   double p1 = ForceSingle(rPS1(inst.FC));
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -256,7 +256,7 @@ void Interpreter::ps_sum1(UGeckoInstruction inst)
   double p1 = ForceSingle(NI_add(rPS0(inst.FA), rPS1(inst.FB)));
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
-  UpdateFPRF(rPS1(inst.FD));
+  PowerPC::UpdateFPRF(rPS1(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -269,7 +269,7 @@ void Interpreter::ps_muls0(UGeckoInstruction inst)
   double p1 = ForceSingle(NI_mul(rPS1(inst.FA), c0));
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -282,7 +282,7 @@ void Interpreter::ps_muls1(UGeckoInstruction inst)
   double p1 = ForceSingle(NI_mul(rPS1(inst.FA), c1));
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -295,7 +295,7 @@ void Interpreter::ps_madds0(UGeckoInstruction inst)
   double p1 = ForceSingle(NI_madd(rPS1(inst.FA), c0, rPS1(inst.FB)));
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();
@@ -308,7 +308,7 @@ void Interpreter::ps_madds1(UGeckoInstruction inst)
   double p1 = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)));
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
-  UpdateFPRF(rPS0(inst.FD));
+  PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
     Helper_UpdateCR1();

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -113,14 +113,14 @@ void Interpreter::mtfsfx(UGeckoInstruction inst)
 
 void Interpreter::mcrxr(UGeckoInstruction inst)
 {
-  SetCRField(inst.CRFD, GetXER().Hex >> 28);
+  PowerPC::SetCRField(inst.CRFD, PowerPC::GetXER().Hex >> 28);
   PowerPC::ppcState.xer_ca = 0;
   PowerPC::ppcState.xer_so_ov = 0;
 }
 
 void Interpreter::mfcr(UGeckoInstruction inst)
 {
-  rGPR[inst.RD] = GetCR();
+  rGPR[inst.RD] = PowerPC::GetCR();
 }
 
 void Interpreter::mtcrf(UGeckoInstruction inst)
@@ -128,7 +128,7 @@ void Interpreter::mtcrf(UGeckoInstruction inst)
   u32 crm = inst.CRM;
   if (crm == 0xFF)
   {
-    SetCR(rGPR[inst.RS]);
+    PowerPC::SetCR(rGPR[inst.RS]);
   }
   else
   {
@@ -140,7 +140,7 @@ void Interpreter::mtcrf(UGeckoInstruction inst)
         mask |= 0xF << (i * 4);
     }
 
-    SetCR((GetCR() & ~mask) | (rGPR[inst.RS] & mask));
+    PowerPC::SetCR((PowerPC::GetCR() & ~mask) | (rGPR[inst.RS] & mask));
   }
 }
 
@@ -238,7 +238,7 @@ void Interpreter::mfspr(UGeckoInstruction inst)
   }
   break;
   case SPR_XER:
-    rSPR(iIndex) = GetXER().Hex;
+    rSPR(iIndex) = PowerPC::GetXER().Hex;
     break;
   }
   rGPR[inst.RD] = rSPR(iIndex);
@@ -367,7 +367,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
     break;
 
   case SPR_XER:
-    SetXER(rSPR(iIndex));
+    PowerPC::SetXER(rSPR(iIndex));
     break;
 
   case SPR_DBAT0L:
@@ -420,48 +420,48 @@ void Interpreter::mtspr(UGeckoInstruction inst)
 
 void Interpreter::crand(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, GetCRBit(inst.CRBA) & GetCRBit(inst.CRBB));
+  PowerPC::SetCRBit(inst.CRBD, PowerPC::GetCRBit(inst.CRBA) & PowerPC::GetCRBit(inst.CRBB));
 }
 
 void Interpreter::crandc(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, GetCRBit(inst.CRBA) & (1 ^ GetCRBit(inst.CRBB)));
+  PowerPC::SetCRBit(inst.CRBD, PowerPC::GetCRBit(inst.CRBA) & (1 ^ PowerPC::GetCRBit(inst.CRBB)));
 }
 
 void Interpreter::creqv(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, 1 ^ (GetCRBit(inst.CRBA) ^ GetCRBit(inst.CRBB)));
+  PowerPC::SetCRBit(inst.CRBD, 1 ^ (PowerPC::GetCRBit(inst.CRBA) ^ PowerPC::GetCRBit(inst.CRBB)));
 }
 
 void Interpreter::crnand(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, 1 ^ (GetCRBit(inst.CRBA) & GetCRBit(inst.CRBB)));
+  PowerPC::SetCRBit(inst.CRBD, 1 ^ (PowerPC::GetCRBit(inst.CRBA) & PowerPC::GetCRBit(inst.CRBB)));
 }
 
 void Interpreter::crnor(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, 1 ^ (GetCRBit(inst.CRBA) | GetCRBit(inst.CRBB)));
+  PowerPC::SetCRBit(inst.CRBD, 1 ^ (PowerPC::GetCRBit(inst.CRBA) | PowerPC::GetCRBit(inst.CRBB)));
 }
 
 void Interpreter::cror(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, (GetCRBit(inst.CRBA) | GetCRBit(inst.CRBB)));
+  PowerPC::SetCRBit(inst.CRBD, (PowerPC::GetCRBit(inst.CRBA) | PowerPC::GetCRBit(inst.CRBB)));
 }
 
 void Interpreter::crorc(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, (GetCRBit(inst.CRBA) | (1 ^ GetCRBit(inst.CRBB))));
+  PowerPC::SetCRBit(inst.CRBD, (PowerPC::GetCRBit(inst.CRBA) | (1 ^ PowerPC::GetCRBit(inst.CRBB))));
 }
 
 void Interpreter::crxor(UGeckoInstruction inst)
 {
-  SetCRBit(inst.CRBD, (GetCRBit(inst.CRBA) ^ GetCRBit(inst.CRBB)));
+  PowerPC::SetCRBit(inst.CRBD, (PowerPC::GetCRBit(inst.CRBA) ^ PowerPC::GetCRBit(inst.CRBB)));
 }
 
 void Interpreter::mcrf(UGeckoInstruction inst)
 {
-  int cr_f = GetCRField(inst.CRFS);
-  SetCRField(inst.CRFD, cr_f);
+  int cr_f = PowerPC::GetCRField(inst.CRFS);
+  PowerPC::SetCRField(inst.CRFD, cr_f);
 }
 
 void Interpreter::isync(UGeckoInstruction inst)
@@ -505,7 +505,7 @@ void Interpreter::mcrfs(UGeckoInstruction inst)
     FPSCR.VXCVI = 0;
     break;
   }
-  SetCRField(inst.CRFD, fpflags);
+  PowerPC::SetCRField(inst.CRFD, fpflags);
 }
 
 void Interpreter::mffsx(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -487,7 +487,7 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
   int a = inst.FA;
   int b = inst.FB;
   u32 crf = inst.CRFD;
-  int output[4] = {CR_SO, CR_EQ, CR_GT, CR_LT};
+  int output[4] = {PowerPC::CR_SO, PowerPC::CR_EQ, PowerPC::CR_GT, PowerPC::CR_LT};
 
   // Merge neighboring fcmp and cror (the primary use of cror).
   UGeckoInstruction next = js.op[1].inst;
@@ -541,31 +541,31 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
     pGreater = J_CC(CC_B);
   }
 
-  MOV(64, R(RSCRATCH), Imm64(PPCCRToInternal(output[CR_EQ_BIT])));
+  MOV(64, R(RSCRATCH), Imm64(PowerPC::PPCCRToInternal(output[PowerPC::CR_EQ_BIT])));
   if (fprf)
-    OR(32, PPCSTATE(fpscr), Imm32(CR_EQ << FPRF_SHIFT));
+    OR(32, PPCSTATE(fpscr), Imm32(PowerPC::CR_EQ << FPRF_SHIFT));
 
   continue1 = J();
 
   SetJumpTarget(pNaN);
-  MOV(64, R(RSCRATCH), Imm64(PPCCRToInternal(output[CR_SO_BIT])));
+  MOV(64, R(RSCRATCH), Imm64(PowerPC::PPCCRToInternal(output[PowerPC::CR_SO_BIT])));
   if (fprf)
-    OR(32, PPCSTATE(fpscr), Imm32(CR_SO << FPRF_SHIFT));
+    OR(32, PPCSTATE(fpscr), Imm32(PowerPC::CR_SO << FPRF_SHIFT));
 
   if (a != b)
   {
     continue2 = J();
 
     SetJumpTarget(pGreater);
-    MOV(64, R(RSCRATCH), Imm64(PPCCRToInternal(output[CR_GT_BIT])));
+    MOV(64, R(RSCRATCH), Imm64(PowerPC::PPCCRToInternal(output[PowerPC::CR_GT_BIT])));
     if (fprf)
-      OR(32, PPCSTATE(fpscr), Imm32(CR_GT << FPRF_SHIFT));
+      OR(32, PPCSTATE(fpscr), Imm32(PowerPC::CR_GT << FPRF_SHIFT));
     continue3 = J();
 
     SetJumpTarget(pLesser);
-    MOV(64, R(RSCRATCH), Imm64(PPCCRToInternal(output[CR_LT_BIT])));
+    MOV(64, R(RSCRATCH), Imm64(PowerPC::PPCCRToInternal(output[PowerPC::CR_LT_BIT])));
     if (fprf)
-      OR(32, PPCSTATE(fpscr), Imm32(CR_LT << FPRF_SHIFT));
+      OR(32, PPCSTATE(fpscr), Imm32(PowerPC::CR_LT << FPRF_SHIFT));
   }
 
   SetJumpTarget(continue1);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -19,22 +19,22 @@ void Jit64::GetCRFieldBit(int field, int bit, X64Reg out, bool negate)
 {
   switch (bit)
   {
-  case CR_SO_BIT:  // check bit 61 set
+  case PowerPC::CR_SO_BIT:  // check bit 61 set
     BT(64, PPCSTATE(cr_val[field]), Imm8(61));
     SETcc(negate ? CC_NC : CC_C, R(out));
     break;
 
-  case CR_EQ_BIT:  // check bits 31-0 == 0
+  case PowerPC::CR_EQ_BIT:  // check bits 31-0 == 0
     CMP(32, PPCSTATE(cr_val[field]), Imm8(0));
     SETcc(negate ? CC_NZ : CC_Z, R(out));
     break;
 
-  case CR_GT_BIT:  // check val > 0
+  case PowerPC::CR_GT_BIT:  // check val > 0
     CMP(64, PPCSTATE(cr_val[field]), Imm8(0));
     SETcc(negate ? CC_NG : CC_G, R(out));
     break;
 
-  case CR_LT_BIT:  // check bit 62 set
+  case PowerPC::CR_LT_BIT:  // check bit 62 set
     BT(64, PPCSTATE(cr_val[field]), Imm8(62));
     SETcc(negate ? CC_NC : CC_C, R(out));
     break;
@@ -52,7 +52,7 @@ void Jit64::SetCRFieldBit(int field, int bit, X64Reg in)
   // Gross but necessary; if the input is totally zero and we set SO or LT,
   // or even just add the (1<<32), GT will suddenly end up set without us
   // intending to. This can break actual games, so fix it up.
-  if (bit != CR_GT_BIT)
+  if (bit != PowerPC::CR_GT_BIT)
   {
     TEST(64, R(RSCRATCH2), R(RSCRATCH2));
     FixupBranch dont_clear_gt = J_CC(CC_NZ);
@@ -62,27 +62,27 @@ void Jit64::SetCRFieldBit(int field, int bit, X64Reg in)
 
   switch (bit)
   {
-  case CR_SO_BIT:  // set bit 61 to input
+  case PowerPC::CR_SO_BIT:  // set bit 61 to input
     BTR(64, R(RSCRATCH2), Imm8(61));
     SHL(64, R(in), Imm8(61));
     OR(64, R(RSCRATCH2), R(in));
     break;
 
-  case CR_EQ_BIT:  // clear low 32 bits, set bit 0 to !input
+  case PowerPC::CR_EQ_BIT:  // clear low 32 bits, set bit 0 to !input
     SHR(64, R(RSCRATCH2), Imm8(32));
     SHL(64, R(RSCRATCH2), Imm8(32));
     XOR(32, R(in), Imm8(1));
     OR(64, R(RSCRATCH2), R(in));
     break;
 
-  case CR_GT_BIT:  // set bit 63 to !input
+  case PowerPC::CR_GT_BIT:  // set bit 63 to !input
     BTR(64, R(RSCRATCH2), Imm8(63));
     NOT(32, R(in));
     SHL(64, R(in), Imm8(63));
     OR(64, R(RSCRATCH2), R(in));
     break;
 
-  case CR_LT_BIT:  // set bit 62 to input
+  case PowerPC::CR_LT_BIT:  // set bit 62 to input
     BTR(64, R(RSCRATCH2), Imm8(62));
     SHL(64, R(in), Imm8(62));
     OR(64, R(RSCRATCH2), R(in));
@@ -97,19 +97,19 @@ void Jit64::ClearCRFieldBit(int field, int bit)
 {
   switch (bit)
   {
-  case CR_SO_BIT:
+  case PowerPC::CR_SO_BIT:
     BTR(64, PPCSTATE(cr_val[field]), Imm8(61));
     break;
 
-  case CR_EQ_BIT:
+  case PowerPC::CR_EQ_BIT:
     OR(64, PPCSTATE(cr_val[field]), Imm8(1));
     break;
 
-  case CR_GT_BIT:
+  case PowerPC::CR_GT_BIT:
     BTS(64, PPCSTATE(cr_val[field]), Imm8(63));
     break;
 
-  case CR_LT_BIT:
+  case PowerPC::CR_LT_BIT:
     BTR(64, PPCSTATE(cr_val[field]), Imm8(62));
     break;
   }
@@ -120,7 +120,7 @@ void Jit64::ClearCRFieldBit(int field, int bit)
 void Jit64::SetCRFieldBit(int field, int bit)
 {
   MOV(64, R(RSCRATCH), PPCSTATE(cr_val[field]));
-  if (bit != CR_GT_BIT)
+  if (bit != PowerPC::CR_GT_BIT)
   {
     TEST(64, R(RSCRATCH), R(RSCRATCH));
     FixupBranch dont_clear_gt = J_CC(CC_NZ);
@@ -130,20 +130,20 @@ void Jit64::SetCRFieldBit(int field, int bit)
 
   switch (bit)
   {
-  case CR_SO_BIT:
+  case PowerPC::CR_SO_BIT:
     BTS(64, PPCSTATE(cr_val[field]), Imm8(61));
     break;
 
-  case CR_EQ_BIT:
+  case PowerPC::CR_EQ_BIT:
     SHR(64, R(RSCRATCH), Imm8(32));
     SHL(64, R(RSCRATCH), Imm8(32));
     break;
 
-  case CR_GT_BIT:
+  case PowerPC::CR_GT_BIT:
     BTR(64, PPCSTATE(cr_val[field]), Imm8(63));
     break;
 
-  case CR_LT_BIT:
+  case PowerPC::CR_LT_BIT:
     BTS(64, PPCSTATE(cr_val[field]), Imm8(62));
     break;
   }
@@ -156,19 +156,19 @@ FixupBranch Jit64::JumpIfCRFieldBit(int field, int bit, bool jump_if_set)
 {
   switch (bit)
   {
-  case CR_SO_BIT:  // check bit 61 set
+  case PowerPC::CR_SO_BIT:  // check bit 61 set
     BT(64, PPCSTATE(cr_val[field]), Imm8(61));
     return J_CC(jump_if_set ? CC_C : CC_NC, true);
 
-  case CR_EQ_BIT:  // check bits 31-0 == 0
+  case PowerPC::CR_EQ_BIT:  // check bits 31-0 == 0
     CMP(32, PPCSTATE(cr_val[field]), Imm8(0));
     return J_CC(jump_if_set ? CC_Z : CC_NZ, true);
 
-  case CR_GT_BIT:  // check val > 0
+  case PowerPC::CR_GT_BIT:  // check val > 0
     CMP(64, PPCSTATE(cr_val[field]), Imm8(0));
     return J_CC(jump_if_set ? CC_G : CC_LE, true);
 
-  case CR_LT_BIT:  // check bit 62 set
+  case PowerPC::CR_LT_BIT:  // check bit 62 set
     BT(64, PPCSTATE(cr_val[field]), Imm8(62));
     return J_CC(jump_if_set ? CC_C : CC_NC, true);
 
@@ -473,7 +473,7 @@ void Jit64::mtcrf(UGeckoInstruction inst)
         if ((crm & (0x80 >> i)) != 0)
         {
           u8 newcr = (gpr.R(inst.RS).Imm32() >> (28 - (i * 4))) & 0xF;
-          u64 newcrval = PPCCRToInternal(newcr);
+          u64 newcrval = PowerPC::PPCCRToInternal(newcr);
           if ((s64)newcrval == (s32)newcrval)
           {
             MOV(64, PPCSTATE(cr_val[i]), Imm32((s32)newcrval));
@@ -488,7 +488,7 @@ void Jit64::mtcrf(UGeckoInstruction inst)
     }
     else
     {
-      MOV(64, R(RSCRATCH2), ImmPtr(m_crTable.data()));
+      MOV(64, R(RSCRATCH2), ImmPtr(PowerPC::m_crTable.data()));
       gpr.Lock(inst.RS);
       gpr.BindToRegister(inst.RS, true, false);
       for (int i = 0; i < 8; i++)
@@ -535,7 +535,7 @@ void Jit64::mcrxr(UGeckoInstruction inst)
   // [SO OV CA 0] << 3
   SHL(32, R(RSCRATCH), Imm8(4));
 
-  MOV(64, R(RSCRATCH2), ImmPtr(m_crTable.data()));
+  MOV(64, R(RSCRATCH2), ImmPtr(PowerPC::m_crTable.data()));
   MOV(64, R(RSCRATCH), MRegSum(RSCRATCH, RSCRATCH2));
   MOV(64, PPCSTATE(cr_val[inst.CRFD]), R(RSCRATCH));
 
@@ -627,7 +627,7 @@ void Jit64::mcrfs(UGeckoInstruction inst)
   }
   AND(32, R(RSCRATCH), Imm32(mask));
   MOV(32, PPCSTATE(fpscr), R(RSCRATCH));
-  LEA(64, RSCRATCH, MConst(m_crTable));
+  LEA(64, RSCRATCH, MConst(PowerPC::m_crTable));
   MOV(64, R(RSCRATCH), MComplex(RSCRATCH, RSCRATCH2, SCALE_8, 0));
   MOV(64, PPCSTATE(cr_val[inst.CRFD]), R(RSCRATCH));
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -293,7 +293,7 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
 
   SetJumpTarget(pNaN);
 
-  MOVI2R(XA, PPCCRToInternal(CR_SO));
+  MOVI2R(XA, PowerPC::PPCCRToInternal(PowerPC::CR_SO));
 
   if (a != b)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -21,14 +21,14 @@ FixupBranch JitArm64::JumpIfCRFieldBit(int field, int bit, bool jump_if_set)
 
   switch (bit)
   {
-  case CR_SO_BIT:  // check bit 61 set
+  case PowerPC::CR_SO_BIT:  // check bit 61 set
     return jump_if_set ? TBNZ(XA, 61) : TBZ(XA, 61);
-  case CR_EQ_BIT:  // check bits 31-0 == 0
+  case PowerPC::CR_EQ_BIT:  // check bits 31-0 == 0
     return jump_if_set ? CBZ(WA) : CBNZ(WA);
-  case CR_GT_BIT:  // check val > 0
+  case PowerPC::CR_GT_BIT:  // check val > 0
     CMP(XA, SP);
     return B(jump_if_set ? CC_GT : CC_LE);
-  case CR_LT_BIT:  // check bit 62 set
+  case PowerPC::CR_LT_BIT:  // check bit 62 set
     return jump_if_set ? TBNZ(XA, 62) : TBZ(XA, 62);
   default:
     ASSERT_MSG(DYNA_REC, false, "Invalid CR bit");
@@ -94,7 +94,7 @@ void JitArm64::mcrxr(UGeckoInstruction inst)
   // [SO OV CA 0] << 3
   LSL(WA, WA, 4);
 
-  MOVP2R(XB, m_crTable.data());
+  MOVP2R(XB, PowerPC::m_crTable.data());
   LDR(XB, XB, XA);
 
   // Clear XER[0-3]
@@ -426,19 +426,19 @@ void JitArm64::crXXX(UGeckoInstruction inst)
     ARM64Reg XA = gpr.CR(field);
     switch (bit)
     {
-    case CR_SO_BIT:
+    case PowerPC::CR_SO_BIT:
       AND(XA, XA, 64 - 62, 62, true);  // XA & ~(1<<61)
       break;
 
-    case CR_EQ_BIT:
+    case PowerPC::CR_EQ_BIT:
       ORR(XA, XA, 0, 0, true);  // XA | 1<<0
       break;
 
-    case CR_GT_BIT:
+    case PowerPC::CR_GT_BIT:
       ORR(XA, XA, 64 - 63, 0, true);  // XA | 1<<63
       break;
 
-    case CR_LT_BIT:
+    case PowerPC::CR_LT_BIT:
       AND(XA, XA, 64 - 63, 62, true);  // XA & ~(1<<62)
       break;
     }
@@ -455,7 +455,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
     gpr.BindCRToRegister(field, true);
     ARM64Reg XA = gpr.CR(field);
 
-    if (bit != CR_GT_BIT)
+    if (bit != PowerPC::CR_GT_BIT)
     {
       ARM64Reg WB = gpr.GetReg();
       ARM64Reg XB = EncodeRegTo64(WB);
@@ -467,19 +467,19 @@ void JitArm64::crXXX(UGeckoInstruction inst)
 
     switch (bit)
     {
-    case CR_SO_BIT:
+    case PowerPC::CR_SO_BIT:
       ORR(XA, XA, 64 - 61, 0, true);  // XA | 1<<61
       break;
 
-    case CR_EQ_BIT:
+    case PowerPC::CR_EQ_BIT:
       AND(XA, XA, 32, 31, true);  // Clear lower 32bits
       break;
 
-    case CR_GT_BIT:
+    case PowerPC::CR_GT_BIT:
       AND(XA, XA, 0, 62, true);  // XA & ~(1<<63)
       break;
 
-    case CR_LT_BIT:
+    case PowerPC::CR_LT_BIT:
       ORR(XA, XA, 64 - 62, 0, true);  // XA | 1<<62
       break;
     }
@@ -511,23 +511,23 @@ void JitArm64::crXXX(UGeckoInstruction inst)
     ARM64Reg WC = DecodeReg(XC);
     switch (bit)
     {
-    case CR_SO_BIT:  // check bit 61 set
+    case PowerPC::CR_SO_BIT:  // check bit 61 set
       UBFX(out, XC, 61, 1);
       if (negate)
         EOR(out, out, 0, 0, true);  // XC ^ 1
       break;
 
-    case CR_EQ_BIT:  // check bits 31-0 == 0
+    case PowerPC::CR_EQ_BIT:  // check bits 31-0 == 0
       CMP(WC, WZR);
       CSET(out, negate ? CC_NEQ : CC_EQ);
       break;
 
-    case CR_GT_BIT:  // check val > 0
+    case PowerPC::CR_GT_BIT:  // check val > 0
       CMP(XC, ZR);
       CSET(out, negate ? CC_LE : CC_GT);
       break;
 
-    case CR_LT_BIT:  // check bit 62 set
+    case PowerPC::CR_LT_BIT:  // check bit 62 set
       UBFX(out, XC, 62, 1);
       if (negate)
         EOR(out, out, 0, 0, true);  // XC ^ 1
@@ -571,7 +571,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
   // Gross but necessary; if the input is totally zero and we set SO or LT,
   // or even just add the (1<<32), GT will suddenly end up set without us
   // intending to. This can break actual games, so fix it up.
-  if (bit != CR_GT_BIT)
+  if (bit != PowerPC::CR_GT_BIT)
   {
     ARM64Reg WC = gpr.GetReg();
     ARM64Reg XC = EncodeRegTo64(WC);
@@ -583,22 +583,22 @@ void JitArm64::crXXX(UGeckoInstruction inst)
 
   switch (bit)
   {
-  case CR_SO_BIT:  // set bit 61 to input
+  case PowerPC::CR_SO_BIT:  // set bit 61 to input
     BFI(XB, XA, 61, 1);
     break;
 
-  case CR_EQ_BIT:               // clear low 32 bits, set bit 0 to !input
+  case PowerPC::CR_EQ_BIT:      // clear low 32 bits, set bit 0 to !input
     AND(XB, XB, 32, 31, true);  // Clear lower 32bits
     EOR(XA, XA, 0, 0);          // XA ^ 1<<0
     ORR(XB, XB, XA);
     break;
 
-  case CR_GT_BIT:       // set bit 63 to !input
-    EOR(XA, XA, 0, 0);  // XA ^ 1<<0
+  case PowerPC::CR_GT_BIT:  // set bit 63 to !input
+    EOR(XA, XA, 0, 0);      // XA ^ 1<<0
     BFI(XB, XA, 63, 1);
     break;
 
-  case CR_LT_BIT:  // set bit 62 to input
+  case PowerPC::CR_LT_BIT:  // set bit 62 to input
     BFI(XB, XA, 62, 1);
     break;
   }
@@ -664,7 +664,7 @@ void JitArm64::mtcrf(UGeckoInstruction inst)
     ARM64Reg RS = gpr.R(inst.RS);
     ARM64Reg WB = gpr.GetReg();
     ARM64Reg XB = EncodeRegTo64(WB);
-    MOVP2R(XB, m_crTable.data());
+    MOVP2R(XB, PowerPC::m_crTable.data());
     for (int i = 0; i < 8; ++i)
     {
       if ((crm & (0x80 >> i)) != 0)

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -31,12 +31,15 @@ std::array<GekkoOPInfo*, 1024> m_infoTable63;
 std::array<GekkoOPInfo*, 512> m_allInstructions;
 size_t m_numInstructions;
 
+namespace PowerPC
+{
 const std::array<u64, 16> m_crTable = {{
     PPCCRToInternal(0x0), PPCCRToInternal(0x1), PPCCRToInternal(0x2), PPCCRToInternal(0x3),
     PPCCRToInternal(0x4), PPCCRToInternal(0x5), PPCCRToInternal(0x6), PPCCRToInternal(0x7),
     PPCCRToInternal(0x8), PPCCRToInternal(0x9), PPCCRToInternal(0xA), PPCCRToInternal(0xB),
     PPCCRToInternal(0xC), PPCCRToInternal(0xD), PPCCRToInternal(0xE), PPCCRToInternal(0xF),
 }};
+}  // namespace PowerPC
 
 GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst)
 {

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -556,8 +556,6 @@ void CheckBreakPoints()
   }
 }
 
-}  // namespace
-
 // FPSCR update functions
 
 void UpdateFPRF(double dvalue)
@@ -566,3 +564,5 @@ void UpdateFPRF(double dvalue)
   // if (FPSCR.FPRF == 0x11)
   //	PanicAlert("QNAN alert");
 }
+
+}  // namespace PowerPC

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -312,7 +312,6 @@ inline bool TranslateBatAddess(const BatTable& bat_table, u32* address)
   *address = (bat_result & BAT_RESULT_MASK) | (*address & (BAT_PAGE_SIZE - 1));
   return true;
 }
-}  // namespace
 
 enum CRBits
 {
@@ -439,3 +438,5 @@ inline void SetXER_OV(bool value)
 }
 
 void UpdateFPRF(double dvalue);
+
+}  // namespace PowerPC

--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
@@ -390,7 +390,7 @@ static bool WillInstructionReturn(UGeckoInstruction inst)
   if (inst.hex == 0x4C000064u)
     return true;
   bool counter = (inst.BO_2 >> 2 & 1) != 0 || (CTR != 0) != ((inst.BO_2 >> 1 & 1) != 0);
-  bool condition = inst.BO_2 >> 4 != 0 || GetCRBit(inst.BI_2) == (inst.BO_2 >> 3 & 1);
+  bool condition = inst.BO_2 >> 4 != 0 || PowerPC::GetCRBit(inst.BI_2) == (inst.BO_2 >> 3 & 1);
   bool isBclr = inst.OPCD_7 == 0b010011 && (inst.hex >> 1 & 0b10000) != 0;
   return isBclr && counter && condition && !inst.LK_3;
 }

--- a/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
@@ -283,12 +283,12 @@ void RegisterWidget::PopulateTable()
               [](u64 value) { PowerPC::ppcState.spr[SPR_CTR] = value; });
 
   // CR
-  AddRegister(20, 5, RegisterType::cr, "CR", [] { return GetCR(); },
-              [](u64 value) { SetCR(value); });
+  AddRegister(20, 5, RegisterType::cr, "CR", [] { return PowerPC::GetCR(); },
+              [](u64 value) { PowerPC::SetCR(value); });
 
   // XER
-  AddRegister(21, 5, RegisterType::xer, "XER", [] { return GetXER().Hex; },
-              [](u64 value) { SetXER(UReg_XER(value)); });
+  AddRegister(21, 5, RegisterType::xer, "XER", [] { return PowerPC::GetXER().Hex; },
+              [](u64 value) { PowerPC::SetXER(UReg_XER(value)); });
 
   // FPSCR
   AddRegister(22, 5, RegisterType::fpscr, "FPSCR", [] { return PowerPC::ppcState.fpscr; },

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -346,7 +346,7 @@ static bool WillInstructionReturn(UGeckoInstruction inst)
   if (inst.hex == 0x4C000064u)
     return true;
   bool counter = (inst.BO_2 >> 2 & 1) != 0 || (CTR != 0) != ((inst.BO_2 >> 1 & 1) != 0);
-  bool condition = inst.BO_2 >> 4 != 0 || GetCRBit(inst.BI_2) == (inst.BO_2 >> 3 & 1);
+  bool condition = inst.BO_2 >> 4 != 0 || PowerPC::GetCRBit(inst.BI_2) == (inst.BO_2 >> 3 & 1);
   bool isBclr = inst.OPCD_7 == 0b010011 && (inst.hex >> 1 & 0b10000) != 0;
   return isBclr && counter && condition && !inst.LK_3;
 }

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -76,9 +76,9 @@ u32 GetSpecialRegValue(int reg)
   case 2:
     return PowerPC::ppcState.spr[SPR_CTR];
   case 3:
-    return GetCR();
+    return PowerPC::GetCR();
   case 4:
-    return GetXER().Hex;
+    return PowerPC::GetXER().Hex;
   case 5:
     return PowerPC::ppcState.fpscr;
   case 6:
@@ -118,10 +118,10 @@ void SetSpecialRegValue(int reg, u32 value)
     PowerPC::ppcState.spr[SPR_CTR] = value;
     break;
   case 3:
-    SetCR(value);
+    PowerPC::SetCR(value);
     break;
   case 4:
-    SetXER(UReg_XER(value));
+    PowerPC::SetXER(UReg_XER(value));
     break;
   case 5:
     PowerPC::ppcState.fpscr = value;


### PR DESCRIPTION
Puts everything under the same namespace. Previously the header was only partially namespaced, which is inconsistent.