### PR TITLE
Qt: Implement missing "File" menu items

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -28,6 +28,7 @@
 #include "Core/Config/NetplaySettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/ProcessorInterface.h"
@@ -231,6 +232,10 @@ void MainWindow::ConnectMenuBar()
   // File
   connect(m_menu_bar, &MenuBar::Open, this, &MainWindow::Open);
   connect(m_menu_bar, &MenuBar::Exit, this, &MainWindow::close);
+  connect(m_menu_bar, &MenuBar::EjectDisc, this, &MainWindow::EjectDisc);
+  connect(m_menu_bar, &MenuBar::ChangeDisc, this, &MainWindow::ChangeDisc);
+  connect(m_menu_bar, &MenuBar::BootDVDBackup, this,
+          [this](const QString& drive) { StartGame(drive); });
 
   // Emulation
   connect(m_menu_bar, &MenuBar::Pause, this, &MainWindow::Pause);
@@ -406,12 +411,30 @@ void MainWindow::ConnectStack()
   tabifyDockWidget(m_log_widget, m_breakpoint_widget);
 }
 
-void MainWindow::Open()
+QString MainWindow::PromptFileName()
 {
-  QString file = QFileDialog::getOpenFileName(
+  return QFileDialog::getOpenFileName(
       this, tr("Select a File"), QDir::currentPath(),
       tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs *.ciso *.gcz *.wad);;"
          "All Files (*)"));
+}
+
+void MainWindow::ChangeDisc()
+{
+  QString file = PromptFileName();
+
+  if (!file.isEmpty())
+    Core::RunAsCPUThread([&file] { DVDInterface::ChangeDisc(file.toStdString()); });
+}
+
+void MainWindow::EjectDisc()
+{
+  Core::RunAsCPUThread(DVDInterface::EjectDisc);
+}
+
+void MainWindow::Open()
+{
+  QString file = PromptFileName();
   if (!file.isEmpty())
     StartGame(file);
 }

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -128,6 +128,11 @@ private:
   void OnExportRecording();
   void ShowTASInput();
 
+  void ChangeDisc();
+  void EjectDisc();
+
+  QString PromptFileName();
+
   void EnableScreenSaver(bool enable);
 
   void OnStopComplete();

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -40,6 +40,9 @@ signals:
   // File
   void Open();
   void Exit();
+  void ChangeDisc();
+  void BootDVDBackup(const QString& backup);
+  void EjectDisc();
 
   // Emulation
   void Play();
@@ -102,6 +105,7 @@ private:
   void OnEmulationStateChanged(Core::State state);
 
   void AddFileMenu();
+  void AddDVDBackupMenu(QMenu* file_menu);
 
   void AddEmulationMenu();
   void AddStateLoadMenu(QMenu* emu_menu);
@@ -148,6 +152,9 @@ private:
   // File
   QAction* m_open_action;
   QAction* m_exit_action;
+  QAction* m_change_disc;
+  QAction* m_eject_disc;
+  QMenu* m_backup_menu;
 
   // Tools
   QAction* m_wad_install_action;


### PR DESCRIPTION
Adds
* Change Disc
* Eject Disc
* Boot from DVD Backup

to the ``File`` Menu