### PR TITLE
DolphinQt2/GameCubePane: Correct duplicate condition in LoadSettings()

### DIFF
--- a/Source/Core/DolphinQt2/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GameCubePane.cpp
@@ -240,9 +240,9 @@ void GameCubePane::LoadSettings()
 
   for (const std::string& dir : {USA_DIR, JAP_DIR, EUR_DIR})
   {
-    const auto& path = DIR_SEP + dir + DIR_SEP GC_IPL;
+    const auto path = DIR_SEP + dir + DIR_SEP GC_IPL;
     if (File::Exists(File::GetUserPath(D_GCUSER_IDX) + path) ||
-        File::Exists(File::GetUserPath(D_GCUSER_IDX) + path))
+        File::Exists(File::GetSysDirectory() + GC_SYS_DIR + path))
     {
       have_menu = true;
       break;


### PR DESCRIPTION
Also turns a std::string const reference into a value instance. While this is well-defined and has the correct behavior, it does look out of place, given a new string is being created.