### PR TITLE
Rename "On-Screen Messages" to "On-Screen Display Messages"

### DIFF
--- a/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/InterfacePane.cpp
@@ -141,7 +141,7 @@ void InterfacePane::CreateInGame()
 
   m_checkbox_confirm_on_stop = new QCheckBox(tr("Confirm on Stop"));
   m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
-  m_checkbox_enable_osd = new QCheckBox(tr("Show On-Screen Messages"));
+  m_checkbox_enable_osd = new QCheckBox(tr("Show On-Screen Display Messages"));
   m_checkbox_show_active_title = new QCheckBox(tr("Show Active Title in Window Title"));
   m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Loss"));
   m_checkbox_hide_mouse = new QCheckBox(tr("Always Hide Mouse Cursor"));

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -86,7 +86,7 @@ void InterfaceConfigPane::InitializeGUI()
 
   m_confirm_stop_checkbox = new wxCheckBox(this, wxID_ANY, _("Confirm on Stop"));
   m_panic_handlers_checkbox = new wxCheckBox(this, wxID_ANY, _("Use Panic Handlers"));
-  m_osd_messages_checkbox = new wxCheckBox(this, wxID_ANY, _("Show On-Screen Messages"));
+  m_osd_messages_checkbox = new wxCheckBox(this, wxID_ANY, _("Show On-Screen Display Messages"));
   m_show_active_title_checkbox =
       new wxCheckBox(this, wxID_ANY, _("Show Active Title in Window Title"));
   m_use_builtin_title_database_checkbox =


### PR DESCRIPTION
Helps users associate "On-Screen Display Messages" with "OSD Messages"

This change has already been proposed for Android in #6499