### PR TITLE
Arm64Emitter: Minor cleanup

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -3771,8 +3771,7 @@ void ARM64FloatEmitter::UXTL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, bool upper)
 // vector x indexed element
 void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
-  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!",
-             __func__);
+  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __func__);
 
   bool L = false;
   bool H = false;
@@ -3791,8 +3790,7 @@ void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 
 
 void ARM64FloatEmitter::FMLA(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
-  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!",
-             __func__);
+  ASSERT_MSG(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __func__);
 
   bool L = false;
   bool H = false;

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -38,8 +38,6 @@ static uint64_t LargestPowerOf2Divisor(uint64_t value)
   return value & -(int64_t)value;
 }
 
-#define V8_UINT64_C(x) ((uint64_t)(x))
-
 bool IsImmArithmetic(uint64_t input, u32* val, bool* shift)
 {
   if (input < 4096)
@@ -151,7 +149,7 @@ bool IsImmLogical(uint64_t value, unsigned int width, unsigned int* n, unsigned 
     clz_a = CountLeadingZeros(a, kXRegSizeInBits);
     int clz_c = CountLeadingZeros(c, kXRegSizeInBits);
     d = clz_a - clz_c;
-    mask = ((V8_UINT64_C(1) << d) - 1);
+    mask = ((UINT64_C(1) << d) - 1);
     out_n = 0;
   }
   else
@@ -177,7 +175,7 @@ bool IsImmLogical(uint64_t value, unsigned int width, unsigned int* n, unsigned 
       // the general case above, and set the N bit in the output.
       clz_a = CountLeadingZeros(a, kXRegSizeInBits);
       d = 64;
-      mask = ~V8_UINT64_C(0);
+      mask = ~UINT64_C(0);
       out_n = 1;
     }
   }

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -12,6 +12,7 @@
 #include "Common/Arm64Emitter.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 
 namespace Arm64Gen
 {
@@ -35,11 +36,6 @@ static int CountLeadingZeros(uint64_t value, int width)
 static uint64_t LargestPowerOf2Divisor(uint64_t value)
 {
   return value & -(int64_t)value;
-}
-
-static bool IsPowerOfTwo(uint64_t x)
-{
-  return (x != 0) && ((x & (x - 1)) == 0);
 }
 
 #define V8_UINT64_C(x) ((uint64_t)(x))
@@ -187,7 +183,7 @@ bool IsImmLogical(uint64_t value, unsigned int width, unsigned int* n, unsigned 
   }
 
   // If the repeat period d is not a power of two, it can't be encoded.
-  if (!IsPowerOfTwo(d))
+  if (!MathUtil::IsPow2<u64>(d))
     return false;
 
   // If the bit stretch (b - a) does not fit within the mask derived from the

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -277,15 +277,6 @@ constexpr ARM64Reg EncodeRegToQuad(ARM64Reg reg)
   return static_cast<ARM64Reg>(reg | 0xC0);
 }
 
-// For AND/TST/ORR/EOR etc
-bool IsImmLogical(uint64_t value, unsigned int width, unsigned int* n, unsigned int* imm_s,
-                  unsigned int* imm_r);
-// For ADD/SUB
-bool IsImmArithmetic(uint64_t input, u32* val, bool* shift);
-
-float FPImm8ToFloat(uint8_t bits);
-bool FPImm8FromFloat(float value, uint8_t* immOut);
-
 enum OpType
 {
   TYPE_IMM = 0,

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -49,9 +49,10 @@ constexpr T Clamp(const T val, const T& min, const T& max)
   return std::max(min, std::min(max, val));
 }
 
-constexpr bool IsPow2(u32 imm)
+template <typename T>
+constexpr bool IsPow2(T imm)
 {
-  return (imm & (imm - 1)) == 0;
+  return imm > 0 && (imm & (imm - 1)) == 0;
 }
 
 // The most significant bit of the fraction is an is-quiet bit on all architectures we care about.


### PR DESCRIPTION
- Generifies `IsPow2` in MathUtils
- Removes `V8_UINT64_C` and replaces it with the standard `UINT64_C`
- Removes `IsPowerOfTwo` from Arm64Emitter.h and replaces it with `IsPow2` from our MathUtils header.
- Make functions that are only used in the emitter internally linked.