### PR TITLE
Qt: Minor fixes

### DIFF
--- a/Source/Core/DolphinQt2/QtUtils/WrapInScrollArea.cpp
+++ b/Source/Core/DolphinQt2/QtUtils/WrapInScrollArea.cpp
@@ -40,7 +40,7 @@ void WrapInScrollArea(QWidget* parent, QLayout* wrapped_layout, QWidget* to_resi
   auto* widget = new QWidget;
   widget->setLayout(wrapped_layout);
 
-  auto* scroll_area = GetWrappedWidget(widget, to_resize);
+  auto* scroll_area = GetWrappedWidget(widget, to_resize, 0, 0);
 
   auto* scroll_layout = new QVBoxLayout;
   scroll_layout->addWidget(scroll_area);

--- a/Source/Core/DolphinQt2/SearchBar.cpp
+++ b/Source/Core/DolphinQt2/SearchBar.cpp
@@ -30,7 +30,7 @@ void SearchBar::CreateWidgets()
 
   layout->addWidget(m_search_edit);
   layout->addWidget(m_close_button);
-  layout->setMargin(0);
+  layout->setSizeConstraint(QLayout::SetMinAndMaxSize);
 
   setLayout(layout);
 }

--- a/Source/Core/DolphinQt2/SearchBar.cpp
+++ b/Source/Core/DolphinQt2/SearchBar.cpp
@@ -24,7 +24,7 @@ void SearchBar::CreateWidgets()
   m_search_edit = new QLineEdit;
   m_close_button = new QPushButton(tr("Close"));
 
-  m_search_edit->setPlaceholderText(tr("Type your search term here"));
+  m_search_edit->setPlaceholderText(tr("Search games..."));
 
   auto* layout = new QHBoxLayout;
 

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -226,6 +226,8 @@ void Settings::SetDebugModeEnabled(bool enabled)
     SConfig::GetInstance().bEnableDebugging = enabled;
     emit DebugModeToggled(enabled);
   }
+  if (enabled)
+    SetCodeVisible(true);
 }
 
 bool Settings::IsDebugModeEnabled() const

--- a/Source/Core/DolphinQt2/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GameCubePane.cpp
@@ -116,6 +116,8 @@ void GameCubePane::CreateWidgets()
   layout->addWidget(ipl_box);
   layout->addWidget(device_box);
 
+  layout->addStretch();
+
   setLayout(layout);
 }
 


### PR DESCRIPTION
Fixes some small issues in DolphinQt2.

* Show the code pane by default when debug mode is enabled. Otherwise, it's confusing because the option appears to do nothing especially if the user is used to the DolphinWX debugger.

* Search bar: fix awkward spacing and placeholder text.

* Improve GameCube config pane spacing. The dialog is still way too tall imo, but at least this fixes a really bad spacing issue.

* Fix spacing in order to make the controller window fit on a 1366x768 screen again.