### PR TITLE
DiscIO/CMakeLists: Migrate off add_dolphin_library

### DIFF
--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS
+add_library(discio
   Blob.cpp
   CISOBlob.cpp
   WbfsBlob.cpp
@@ -21,5 +21,3 @@ set(SRCS
   WiiSaveBanner.cpp
   WiiWad.cpp
 )
-
-add_dolphin_library(discio "${SRCS}" "")


### PR DESCRIPTION
Continues the migration work started in 3a4c3bbe01e7a44ec997f4fbf0b678fba6f2d46c

This is probably the easiest one of the bunch