### PR TITLE
Interpreter: Remove dead code

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -137,18 +137,6 @@ void Interpreter::oris(UGeckoInstruction inst)
 
 void Interpreter::subfic(UGeckoInstruction inst)
 {
-  /*	u32 rra = ~rGPR[inst.RA];
-    s32 immediate = (s16)inst.SIMM_16 + 1;
-
-  //	#define CALC_XER_CA(X,Y) (((X) + (Y) < X) ? SET_XER_CA : CLEAR_XER_CA)
-    if ((rra + immediate) < rra)
-      PowerPC::SetCarry(1);
-    else
-      PowerPC::SetCarry(0);
-
-    rGPR[inst.RD] = rra - immediate;
-  */
-
   s32 immediate = inst.SIMM_16;
   rGPR[inst.RD] = immediate - (int)rGPR[inst.RA];
   PowerPC::SetCarry((rGPR[inst.RA] == 0) || (Helper_Carry(0 - rGPR[inst.RA], immediate)));

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -621,7 +621,6 @@ void Interpreter::sthx(UGeckoInstruction inst)
   PowerPC::Write_U16((u16)rGPR[inst.RS], Helper_Get_EA_X(inst));
 }
 
-// __________________________________________________________________________________________________
 // lswi - bizarro string instruction
 // FIXME: Should rollback if a DSI occurs
 void Interpreter::lswi(UGeckoInstruction inst)
@@ -667,7 +666,6 @@ void Interpreter::lswi(UGeckoInstruction inst)
 }
 
 // todo : optimize ?
-// __________________________________________________________________________________________________
 // stswi - bizarro string instruction
 // FIXME: Should rollback if a DSI occurs
 void Interpreter::stswi(UGeckoInstruction inst)
@@ -804,5 +802,5 @@ void Interpreter::tlbie(UGeckoInstruction inst)
 
 void Interpreter::tlbsync(UGeckoInstruction inst)
 {
-  // MessageBox(0,"TLBsync","TLBsyncE",0);
+  // Ignored
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -49,9 +49,6 @@ void Interpreter::mtfsb0x(UGeckoInstruction inst)
 {
   u32 b = 0x80000000 >> inst.CRBD;
 
-  /*if (b & 0x9ff80700)
-    PanicAlert("mtfsb0 clears bit %d, PC=%x", inst.CRBD, PC);*/
-
   FPSCR.Hex &= ~b;
   FPSCRtoFPUSettings(FPSCR);
 
@@ -78,10 +75,6 @@ void Interpreter::mtfsfix(UGeckoInstruction inst)
   u32 mask = (0xF0000000 >> (4 * inst.CRFD));
   u32 imm = (inst.hex << 16) & 0xF0000000;
 
-  /*u32 cleared = ~(imm >> (4 * _inst.CRFD)) & FPSCR.Hex & mask;
-  if (cleared & 0x9ff80700)
-    PanicAlert("mtfsfi clears %08x, PC=%x", cleared, PC);*/
-
   FPSCR.Hex = (FPSCR.Hex & ~mask) | (imm >> (4 * inst.CRFD));
 
   FPSCRtoFPUSettings(FPSCR);
@@ -99,10 +92,6 @@ void Interpreter::mtfsfx(UGeckoInstruction inst)
     if (fm & (1 << i))
       m |= (0xF << (i * 4));
   }
-
-  /*u32 cleared = ~((u32)(riPS0(_inst.FB))) & FPSCR.Hex & m;
-  if (cleared & 0x9ff80700)
-    PanicAlert("mtfsf clears %08x, PC=%x", cleared, PC);*/
 
   FPSCR.Hex = (FPSCR.Hex & ~m) | ((u32)(riPS0(inst.FB)) & m);
   FPSCRtoFPUSettings(FPSCR);
@@ -336,8 +325,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
       u32 dwMemAddress = DMAU.MEM_ADDR << 5;
       u32 dwCacheAddress = DMAL.LC_ADDR << 5;
       u32 iLength = ((DMAU.DMA_LEN_U << 2) | DMAL.DMA_LEN_L);
-      // INFO_LOG(POWERPC, "DMA: mem = %x, cache = %x, len = %u, LD = %d, PC=%x", dwMemAddress,
-      // dwCacheAddress, iLength, (int)DMAL.DMA_LD, PC);
+
       if (iLength == 0)
         iLength = 128;
       if (DMAL.DMA_LD)
@@ -349,7 +337,6 @@ void Interpreter::mtspr(UGeckoInstruction inst)
     break;
 
   case SPR_L2CR:
-    // PanicAlert("mtspr( L2CR )!");
     break;
 
   case SPR_DEC:
@@ -473,9 +460,6 @@ void Interpreter::isync(UGeckoInstruction inst)
 
 void Interpreter::mcrfs(UGeckoInstruction inst)
 {
-  // if (_inst.CRFS != 3 && _inst.CRFS != 4)
-  //   PanicAlert("msrfs at %x, CRFS = %d, CRFD = %d", PC, (int)_inst.CRFS, (int)_inst.CRFD);
-
   UpdateFPSCR();
   u32 fpflags = ((FPSCR.Hex >> (4 * (7 - inst.CRFS))) & 0xF);
   switch (inst.CRFS)

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -561,8 +561,6 @@ void CheckBreakPoints()
 void UpdateFPRF(double dvalue)
 {
   FPSCR.FPRF = MathUtil::ClassifyDouble(dvalue);
-  // if (FPSCR.FPRF == 0x11)
-  //	PanicAlert("QNAN alert");
 }
 
 }  // namespace PowerPC


### PR DESCRIPTION
Many of the commented out lines are for situational debugging, which we really shouldn't leave littered in the codebase. In subfic's case, it's just a commented out prior implementation