### PR TITLE
Interpreter_FPUtils: Get rid of a pointer cast

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -13,8 +13,7 @@
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/PowerPC.h"
 
-const u64 PPC_NAN_U64 = 0x7ff8000000000000ull;
-const double PPC_NAN = *(double* const) & PPC_NAN_U64;
+constexpr double PPC_NAN = std::numeric_limits<double>::quiet_NaN();
 
 // the 4 less-significand bits in FPSCR[FPRF]
 enum FPCC


### PR DESCRIPTION
This is undefined behavior according to the standard. We can just use the built in means of retrieving a quiet NaN.