### PR TITLE
CPUCoreBase: Make the GetName() member function const qualified

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -102,7 +102,7 @@ public:
     PanicAlertT("Cannot SingleStep the FIFO. Use Frame Advance instead.");
   }
 
-  const char* GetName() override { return "FifoPlayer"; }
+  const char* GetName() const override { return "FifoPlayer"; }
   void Run() override
   {
     while (CPU::GetState() == CPU::State::Running)

--- a/Source/Core/Core/PowerPC/CPUCoreBase.h
+++ b/Source/Core/Core/PowerPC/CPUCoreBase.h
@@ -13,5 +13,5 @@ public:
   virtual void ClearCache() = 0;
   virtual void Run() = 0;
   virtual void SingleStep() = 0;
-  virtual const char* GetName() = 0;
+  virtual const char* GetName() const = 0;
 };

--- a/Source/Core/Core/PowerPC/CPUCoreBase.h
+++ b/Source/Core/Core/PowerPC/CPUCoreBase.h
@@ -7,7 +7,7 @@
 class CPUCoreBase
 {
 public:
-  virtual ~CPUCoreBase() {}
+  virtual ~CPUCoreBase() = default;
   virtual void Init() = 0;
   virtual void Shutdown() = 0;
   virtual void ClearCache() = 0;

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
@@ -29,7 +29,7 @@ public:
   void Jit(u32 address) override;
 
   JitBaseBlockCache* GetBlockCache() override { return &m_block_cache; }
-  const char* GetName() override { return "Cached Interpreter"; }
+  const char* GetName() const override { return "Cached Interpreter"; }
   const CommonAsmRoutinesBase* GetAsmRoutines() override { return nullptr; }
 private:
   struct Instruction;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -330,7 +330,7 @@ void Interpreter::ClearCache()
   // Do nothing.
 }
 
-const char* Interpreter::GetName()
+const char* Interpreter::GetName() const
 {
 #ifdef _ARCH_64
   return "Interpreter64";

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -20,7 +20,7 @@ public:
 
   void Run() override;
   void ClearCache() override;
-  const char* GetName() override;
+  const char* GetName() const override;
 
   static void unknown_instruction(UGeckoInstruction inst);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -59,7 +59,7 @@ public:
   void ClearCache() override;
 
   const CommonAsmRoutines* GetAsmRoutines() override { return &asm_routines; }
-  const char* GetName() override { return "JIT64"; }
+  const char* GetName() const override { return "JIT64"; }
   // Run!
   void Run() override;
   void SingleStep() override;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -41,7 +41,7 @@ public:
 
   void Jit(u32) override;
 
-  const char* GetName() override { return "JITARM64"; }
+  const char* GetName() const override { return "JITARM64"; }
   // OPCODES
   void FallBackToInterpreter(UGeckoInstruction inst);
   void DoNothing(UGeckoInstruction inst);

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -30,7 +30,7 @@ public:
   void ClearCache() override {}
   void Run() override {}
   void SingleStep() override {}
-  const char* GetName() override { return nullptr; }
+  const char* GetName() const override { return nullptr; }
   // JitBase methods
   JitBaseBlockCache* GetBlockCache() override { return nullptr; }
   void Jit(u32 em_address) override {}


### PR DESCRIPTION
This function should have no need to modify internal class state, since it's just retrieving information.