### PR TITLE
PPCTables: Namespace all exposed functions

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -241,7 +241,7 @@ void CachedInterpreter::Jit(u32 address)
 
       if (endblock || memcheck)
         m_code.emplace_back(WritePC, ops[i].address);
-      m_code.emplace_back(GetInterpreterOp(ops[i].inst), ops[i].inst);
+      m_code.emplace_back(PPCTables::GetInterpreterOp(ops[i].inst), ops[i].inst);
       if (memcheck)
         m_code.emplace_back(CheckDSI, js.downcountAmount);
       if (endblock)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -193,7 +193,7 @@ int Interpreter::SingleStepInner()
   last_pc = PC;
   PC = NPC;
 
-  GekkoOPInfo* opinfo = GetOpInfo(instCode);
+  const GekkoOPInfo* opinfo = PPCTables::GetOpInfo(instCode);
   return opinfo->numCycles;
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -287,7 +287,7 @@ void Jit64::FallBackToInterpreter(UGeckoInstruction inst)
     MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
     MOV(32, PPCSTATE(npc), Imm32(js.compilerPC + 4));
   }
-  Interpreter::Instruction instr = GetInterpreterOp(inst);
+  Interpreter::Instruction instr = PPCTables::GetInterpreterOp(inst);
   ABI_PushRegistersAndAdjustStack({}, 0);
   ABI_CallFunctionC(instr, inst.hex);
   ABI_PopRegistersAndAdjustStack({}, 0);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -149,7 +149,7 @@ void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
     gpr.Unlock(WA);
   }
 
-  Interpreter::Instruction instr = GetInterpreterOp(inst);
+  Interpreter::Instruction instr = PPCTables::GetInterpreterOp(inst);
   MOVI2R(W0, inst.hex);
   MOVP2R(X30, instr);
   BLR(X30);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -239,8 +239,8 @@ void CompileExceptionCheck(ExceptionType type)
     if (type == ExceptionType::FIFOWrite)
     {
       // Check in case the code has been replaced since: do we need to do this?
-      const ::OpType optype = GetOpInfo(PowerPC::HostRead_U32(PC))->type;
-      if (optype != ::OpType::Store && optype != ::OpType::StoreFP && optype != ::OpType::StorePS)
+      const OpType optype = PPCTables::GetOpInfo(PowerPC::HostRead_U32(PC))->type;
+      if (optype != OpType::Store && optype != OpType::StoreFP && optype != OpType::StorePS)
         return;
     }
     exception_addresses->insert(PC);

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -726,7 +726,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, u32 
 
     num_inst++;
     memset(&code[i], 0, sizeof(CodeOp));
-    GekkoOPInfo* opinfo = GetOpInfo(inst);
+    GekkoOPInfo* opinfo = PPCTables::GetOpInfo(inst);
 
     code[i].opinfo = opinfo;
     code[i].address = address;

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -43,25 +43,25 @@ const std::array<u64, 16> m_crTable = {{
 
 namespace PPCTables
 {
-GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst)
+GekkoOPInfo* GetOpInfo(UGeckoInstruction inst)
 {
-  GekkoOPInfo* info = m_infoTable[_inst.OPCD];
+  const GekkoOPInfo* info = m_infoTable[inst.OPCD];
   if (info->type == OpType::Subtable)
   {
-    switch (_inst.OPCD)
+    switch (inst.OPCD)
     {
     case 4:
-      return m_infoTable4[_inst.SUBOP10];
+      return m_infoTable4[inst.SUBOP10];
     case 19:
-      return m_infoTable19[_inst.SUBOP10];
+      return m_infoTable19[inst.SUBOP10];
     case 31:
-      return m_infoTable31[_inst.SUBOP10];
+      return m_infoTable31[inst.SUBOP10];
     case 59:
-      return m_infoTable59[_inst.SUBOP5];
+      return m_infoTable59[inst.SUBOP5];
     case 63:
-      return m_infoTable63[_inst.SUBOP10];
+      return m_infoTable63[inst.SUBOP10];
     default:
-      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid subtable op %08x @ %08x", _inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid subtable op %08x @ %08x", inst.hex, PC);
       return nullptr;
     }
   }
@@ -69,32 +69,32 @@ GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst)
   {
     if (info->type == OpType::Invalid)
     {
-      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid op %08x @ %08x", _inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetOpInfo - invalid op %08x @ %08x", inst.hex, PC);
       return nullptr;
     }
-    return m_infoTable[_inst.OPCD];
+    return m_infoTable[inst.OPCD];
   }
 }
 
-Interpreter::Instruction GetInterpreterOp(UGeckoInstruction _inst)
+Interpreter::Instruction GetInterpreterOp(UGeckoInstruction inst)
 {
-  const GekkoOPInfo* info = m_infoTable[_inst.OPCD];
+  const GekkoOPInfo* info = m_infoTable[inst.OPCD];
   if (info->type == OpType::Subtable)
   {
-    switch (_inst.OPCD)
+    switch (inst.OPCD)
     {
     case 4:
-      return Interpreter::m_op_table4[_inst.SUBOP10];
+      return Interpreter::m_op_table4[inst.SUBOP10];
     case 19:
-      return Interpreter::m_op_table19[_inst.SUBOP10];
+      return Interpreter::m_op_table19[inst.SUBOP10];
     case 31:
-      return Interpreter::m_op_table31[_inst.SUBOP10];
+      return Interpreter::m_op_table31[inst.SUBOP10];
     case 59:
-      return Interpreter::m_op_table59[_inst.SUBOP5];
+      return Interpreter::m_op_table59[inst.SUBOP5];
     case 63:
-      return Interpreter::m_op_table63[_inst.SUBOP10];
+      return Interpreter::m_op_table63[inst.SUBOP10];
     default:
-      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid subtable op %08x @ %08x", _inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid subtable op %08x @ %08x", inst.hex, PC);
       return nullptr;
     }
   }
@@ -102,10 +102,10 @@ Interpreter::Instruction GetInterpreterOp(UGeckoInstruction _inst)
   {
     if (info->type == OpType::Invalid)
     {
-      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid op %08x @ %08x", _inst.hex, PC);
+      ASSERT_MSG(POWERPC, 0, "GetInterpreterOp - invalid op %08x @ %08x", inst.hex, PC);
       return nullptr;
     }
-    return Interpreter::m_op_table[_inst.OPCD];
+    return Interpreter::m_op_table[inst.OPCD];
   }
 }
 
@@ -126,21 +126,21 @@ std::vector<u32> rsplocations;
 }
 #endif
 
-const char* GetInstructionName(UGeckoInstruction _inst)
+const char* GetInstructionName(UGeckoInstruction inst)
 {
-  const GekkoOPInfo* info = GetOpInfo(_inst);
+  const GekkoOPInfo* info = GetOpInfo(inst);
   return info ? info->opname : nullptr;
 }
 
-bool IsValidInstruction(UGeckoInstruction _inst)
+bool IsValidInstruction(UGeckoInstruction inst)
 {
-  const GekkoOPInfo* info = GetOpInfo(_inst);
+  const GekkoOPInfo* info = GetOpInfo(inst);
   return info != nullptr && info->type != OpType::Unknown;
 }
 
-void CountInstruction(UGeckoInstruction _inst)
+void CountInstruction(UGeckoInstruction inst)
 {
-  GekkoOPInfo* info = GetOpInfo(_inst);
+  GekkoOPInfo* info = GetOpInfo(inst);
   if (info)
   {
     info->runCount++;

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -41,6 +41,8 @@ const std::array<u64, 16> m_crTable = {{
 }};
 }  // namespace PowerPC
 
+namespace PPCTables
+{
 GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst)
 {
   GekkoOPInfo* info = m_infoTable[_inst.OPCD];
@@ -106,8 +108,7 @@ Interpreter::Instruction GetInterpreterOp(UGeckoInstruction _inst)
     return Interpreter::m_op_table[_inst.OPCD];
   }
 }
-namespace PPCTables
-{
+
 bool UsesFPU(UGeckoInstruction inst)
 {
   GekkoOPInfo* const info = GetOpInfo(inst);

--- a/Source/Core/Core/PowerPC/PPCTables.h
+++ b/Source/Core/Core/PowerPC/PPCTables.h
@@ -105,11 +105,11 @@ extern std::array<GekkoOPInfo*, 1024> m_infoTable63;
 extern std::array<GekkoOPInfo*, 512> m_allInstructions;
 extern size_t m_numInstructions;
 
+namespace PPCTables
+{
 GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst);
 Interpreter::Instruction GetInterpreterOp(UGeckoInstruction _inst);
 
-namespace PPCTables
-{
 bool IsValidInstruction(UGeckoInstruction _instCode);
 bool UsesFPU(UGeckoInstruction _inst);
 

--- a/Source/Core/Core/PowerPC/PPCTables.h
+++ b/Source/Core/Core/PowerPC/PPCTables.h
@@ -107,14 +107,14 @@ extern size_t m_numInstructions;
 
 namespace PPCTables
 {
-GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst);
-Interpreter::Instruction GetInterpreterOp(UGeckoInstruction _inst);
+GekkoOPInfo* GetOpInfo(UGeckoInstruction inst);
+Interpreter::Instruction GetInterpreterOp(UGeckoInstruction inst);
 
-bool IsValidInstruction(UGeckoInstruction _instCode);
-bool UsesFPU(UGeckoInstruction _inst);
+bool IsValidInstruction(UGeckoInstruction inst);
+bool UsesFPU(UGeckoInstruction inst);
 
-void CountInstruction(UGeckoInstruction _inst);
+void CountInstruction(UGeckoInstruction inst);
 void PrintInstructionRunCounts();
 void LogCompiledInstructions();
-const char* GetInstructionName(UGeckoInstruction _inst);
+const char* GetInstructionName(UGeckoInstruction inst);
 }  // namespace PPCTables


### PR DESCRIPTION
It's a little inconsistent to have a few straggler functions outside the namespace.

Eventually the globals will be put into the namespace as well, however this requires renaming in a larger scope, so I've saved that for its own PR.