### PR TITLE
Interpreter: Don't dump the MathUtils namespace into scope in Interpreter_FloatingPoint and Interpreter_Paired

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -11,8 +11,6 @@
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/PowerPC.h"
 
-using namespace MathUtil;
-
 // Extremely rare - actually, never seen.
 // Star Wars : Rogue Leader spams that at some point :|
 void Interpreter::Helper_UpdateCR1()
@@ -27,7 +25,7 @@ void Interpreter::Helper_FloatCompareOrdered(UGeckoInstruction inst, double fa, 
   if (std::isnan(fa) || std::isnan(fb))
   {
     compareResult = FPCC::FU;
-    if (IsSNAN(fa) || IsSNAN(fb))
+    if (MathUtil::IsSNAN(fa) || MathUtil::IsSNAN(fb))
     {
       SetFPException(FPSCR_VXSNAN);
       if (FPSCR.VE == 0)
@@ -67,7 +65,7 @@ void Interpreter::Helper_FloatCompareUnordered(UGeckoInstruction inst, double fa
   {
     compareResult = FPCC::FU;
 
-    if (IsSNAN(fa) || IsSNAN(fb))
+    if (MathUtil::IsSNAN(fa) || MathUtil::IsSNAN(fb))
     {
       SetFPException(FPSCR_VXSNAN);
     }
@@ -371,7 +369,7 @@ void Interpreter::fdivsx(UGeckoInstruction inst)
 void Interpreter::fresx(UGeckoInstruction inst)
 {
   double b = rPS0(inst.FB);
-  rPS0(inst.FD) = rPS1(inst.FD) = ApproximateReciprocal(b);
+  rPS0(inst.FD) = rPS1(inst.FD) = MathUtil::ApproximateReciprocal(b);
 
   if (b == 0.0)
   {
@@ -397,7 +395,7 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
     SetFPException(FPSCR_ZX);
   }
 
-  rPS0(inst.FD) = ApproximateReciprocalSquareRoot(b);
+  rPS0(inst.FD) = MathUtil::ApproximateReciprocalSquareRoot(b);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -10,8 +10,6 @@
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/PowerPC.h"
 
-using namespace MathUtil;
-
 // These "binary instructions" do not alter FPSCR.
 void Interpreter::ps_sel(UGeckoInstruction inst)
 {
@@ -125,8 +123,8 @@ void Interpreter::ps_res(UGeckoInstruction inst)
     SetFPException(FPSCR_ZX);
   }
 
-  rPS0(inst.FD) = ApproximateReciprocal(a);
-  rPS1(inst.FD) = ApproximateReciprocal(b);
+  rPS0(inst.FD) = MathUtil::ApproximateReciprocal(a);
+  rPS1(inst.FD) = MathUtil::ApproximateReciprocal(b);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
@@ -145,8 +143,8 @@ void Interpreter::ps_rsqrte(UGeckoInstruction inst)
     SetFPException(FPSCR_VXSQRT);
   }
 
-  rPS0(inst.FD) = ForceSingle(ApproximateReciprocalSquareRoot(rPS0(inst.FB)));
-  rPS1(inst.FD) = ForceSingle(ApproximateReciprocalSquareRoot(rPS1(inst.FB)));
+  rPS0(inst.FD) = ForceSingle(MathUtil::ApproximateReciprocalSquareRoot(rPS0(inst.FB)));
+  rPS1(inst.FD) = ForceSingle(MathUtil::ApproximateReciprocalSquareRoot(rPS1(inst.FB)));
 
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 


### PR DESCRIPTION
These functions are only used a small handful amount of times in these files (six in one file, and four times in the other) that there's not really much benefit to dumping the whole namespace.