### PR TITLE
Qt/RenderWidget: Draw background on pause

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -655,6 +655,7 @@ void MainWindow::ShowRenderWidget()
     m_rendering_to_main = true;
     m_stack->setCurrentIndex(m_stack->addWidget(m_render_widget));
     connect(Host::GetInstance(), &Host::RequestTitle, this, &MainWindow::setWindowTitle);
+    m_stack->repaint();
   }
   else
   {

--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -3,17 +3,20 @@
 // Refer to the license.txt file included.
 
 #include <QKeyEvent>
+#include <QPalette>
 #include <QTimer>
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinQt2/Host.h"
 #include "DolphinQt2/RenderWidget.h"
 #include "DolphinQt2/Settings.h"
 
 RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
 {
-  setAttribute(Qt::WA_OpaquePaintEvent, true);
-  setAttribute(Qt::WA_NoSystemBackground, true);
+  QPalette p;
+  p.setColor(QPalette::Background, Qt::black);
+  setPalette(p);
 
   connect(Host::GetInstance(), &Host::RequestTitle, this, &RenderWidget::setWindowTitle);
   connect(Host::GetInstance(), &Host::RequestRenderSize, this, [this](int w, int h) {
@@ -21,6 +24,10 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
       return;
 
     resize(w, h);
+  });
+
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
+    SetFillBackground(SConfig::GetInstance().bRenderToMain && state == Core::State::Uninitialized);
   });
 
   // We have to use Qt::DirectConnection here because we don't want those signals to get queued
@@ -43,6 +50,15 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
           &RenderWidget::OnHideCursorChanged);
   OnHideCursorChanged();
   m_mouse_timer->start(MOUSE_HIDE_DELAY);
+
+  SetFillBackground(true);
+}
+
+void RenderWidget::SetFillBackground(bool fill)
+{
+  setAttribute(Qt::WA_OpaquePaintEvent, !fill);
+  setAttribute(Qt::WA_NoSystemBackground, !fill);
+  setAutoFillBackground(fill);
 }
 
 void RenderWidget::OnHideCursorChanged()

--- a/Source/Core/DolphinQt2/RenderWidget.h
+++ b/Source/Core/DolphinQt2/RenderWidget.h
@@ -29,6 +29,7 @@ signals:
 private:
   void HandleCursorTimer();
   void OnHideCursorChanged();
+  void SetFillBackground(bool fill);
 
   static constexpr int MOUSE_HIDE_DELAY = 3000;
   QTimer* m_mouse_timer;


### PR DESCRIPTION
Fixes [issue #10958](https://bugs.dolphin-emu.org/issues/10958).