### PR TITLE
Interpreter_Integer: Correct precedence of overflow check in nego

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -591,11 +591,11 @@ void Interpreter::negx(UGeckoInstruction inst)
 
   rGPR[inst.RD] = (~a) + 1;
 
-  if (inst.Rc)
-    Helper_UpdateCR0(rGPR[inst.RD]);
-
   if (inst.OE)
     PowerPC::SetXER_OV(a == 0x80000000);
+
+  if (inst.Rc)
+    Helper_UpdateCR0(rGPR[inst.RD]);
 }
 
 void Interpreter::subfx(UGeckoInstruction inst)


### PR DESCRIPTION
The overflow check needs to occur before the condition register update due to the fact that the summary overflow (SO) bit is used in the updating of the condition register. If we set any overflow bits after updating the CR, then we can potentially incorrectly report that an overflow did not happen (in the case the SO bit wasn't set previously).