### PR TITLE
GameINI: Force EFB2RAM for the Mii Channel

### DIFF
--- a/Data/Sys/GameSettings/HAC.ini
+++ b/Data/Sys/GameSettings/HAC.ini
@@ -20,3 +20,5 @@ EmulationIssues =
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
Without it, eyes don't appear until the channel app is reset.