### PR TITLE
Jit64/Jit_Integer: Remove dead code in arithXex()

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1354,8 +1354,6 @@ void Jit64::arithXex(UGeckoInstruction inst)
   {
     if (!js.carryFlagInverted)
       CMC();
-    if (d != b)
-      MOV(32, gpr.R(d), gpr.R(b));
     SBB(32, gpr.R(d), gpr.R(a));
     invertedCarry = true;
   }


### PR DESCRIPTION
The conditional this code is within already checks whether `d == b`, so this conditional will never be true.