### PR TITLE
DSPTables: Remove opc_t typedef

### DIFF
--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -429,7 +429,7 @@ u32 DSPAssembler::GetParams(char* parstr, param_t* par)
   return count;
 }
 
-const opc_t* DSPAssembler::FindOpcode(std::string name, size_t par_count, OpcodeType type)
+const DSPOPCTemplate* DSPAssembler::FindOpcode(std::string name, size_t par_count, OpcodeType type)
 {
   if (name[0] == 'C' && name[1] == 'W')
     return &cw;
@@ -466,7 +466,8 @@ static u16 get_mask_shifted_down(u16 mask)
   return mask;
 }
 
-bool DSPAssembler::VerifyParams(const opc_t* opc, param_t* par, size_t count, OpcodeType type)
+bool DSPAssembler::VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t count,
+                                OpcodeType type)
 {
   for (size_t i = 0; i < count; i++)
   {
@@ -712,7 +713,7 @@ bool DSPAssembler::VerifyParams(const opc_t* opc, param_t* par, size_t count, Op
 }
 
 // Merge opcode with params.
-void DSPAssembler::BuildCode(const opc_t* opc, param_t* par, u32 par_count, u16* outbuf)
+void DSPAssembler::BuildCode(const DSPOPCTemplate* opc, param_t* par, u32 par_count, u16* outbuf)
 {
   outbuf[m_cur_addr] |= opc->opcode;
   for (u32 i = 0; i < par_count; i++)
@@ -993,7 +994,7 @@ bool DSPAssembler::AssemblePass(const std::string& text, int pass)
       continue;
     }
 
-    const opc_t* opc = FindOpcode(opcode, params_count, OpcodeType::Primary);
+    const DSPOPCTemplate* opc = FindOpcode(opcode, params_count, OpcodeType::Primary);
     if (!opc)
       opc = &cw;
 
@@ -1001,7 +1002,7 @@ bool DSPAssembler::AssemblePass(const std::string& text, int pass)
 
     VerifyParams(opc, params, params_count, OpcodeType::Primary);
 
-    const opc_t* opc_ext = nullptr;
+    const DSPOPCTemplate* opc_ext = nullptr;
     // Check for opcode extensions.
     if (opc->extended)
     {

--- a/Source/Core/Core/DSP/DSPAssembler.h
+++ b/Source/Core/Core/DSP/DSPAssembler.h
@@ -98,9 +98,9 @@ private:
   // void ShowWarning(err_t err_code, const char *extra_info = nullptr);
 
   char* FindBrackets(char* src, char* dst);
-  const opc_t* FindOpcode(std::string name, size_t par_count, OpcodeType type);
-  bool VerifyParams(const opc_t* opc, param_t* par, size_t count, OpcodeType type);
-  void BuildCode(const opc_t* opc, param_t* par, u32 par_count, u16* outbuf);
+  const DSPOPCTemplate* FindOpcode(std::string name, size_t par_count, OpcodeType type);
+  bool VerifyParams(const DSPOPCTemplate* opc, param_t* par, size_t count, OpcodeType type);
+  void BuildCode(const DSPOPCTemplate* opc, param_t* par, u32 par_count, u16* outbuf);
 
   std::vector<u16> m_output_buffer;
 

--- a/Source/Core/Core/DSP/DSPTables.h
+++ b/Source/Core/Core/DSP/DSPTables.h
@@ -88,8 +88,6 @@ struct DSPOPCTemplate
   bool updates_sr;
 };
 
-typedef DSPOPCTemplate opc_t;
-
 // Opcodes
 extern const DSPOPCTemplate cw;
 


### PR DESCRIPTION
Starting to do a little housecleaning before I get rid of the dependency on the x64 DSP emitter in the DSP table code.

This was only ever used by the DSP assembler, and even then it was sparsely used. Get rid of it to be consistent with types in other sections of the DSP code.