### PR TITLE
DSPCodeUtil: Don't return data via an out parameter

### DIFF
--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -102,42 +102,45 @@ bool Compare(const std::vector<u16>& code1, const std::vector<u16>& code2)
   return code1.size() == code2.size() && code1.size() == count_equal;
 }
 
-void CodeToBinaryStringBE(const std::vector<u16>& code, std::string& str)
+std::string CodeToBinaryStringBE(const std::vector<u16>& code)
 {
-  str.resize(code.size() * 2);
+  std::string str(code.size() * 2, '\0');
+
   for (size_t i = 0; i < code.size(); i++)
   {
     str[i * 2 + 0] = code[i] >> 8;
     str[i * 2 + 1] = code[i] & 0xff;
   }
+
+  return str;
 }
 
-void BinaryStringBEToCode(const std::string& str, std::vector<u16>& code)
+std::vector<u16> BinaryStringBEToCode(const std::string& str)
 {
-  code.resize(str.size() / 2);
+  std::vector<u16> code(str.size() / 2);
+
   for (size_t i = 0; i < code.size(); i++)
   {
     code[i] = ((u16)(u8)str[i * 2 + 0] << 8) | ((u16)(u8)str[i * 2 + 1]);
   }
+
+  return code;
 }
 
-bool LoadBinary(const std::string& filename, std::vector<u16>& code)
+std::optional<std::vector<u16>> LoadBinary(const std::string& filename)
 {
   std::string buffer;
   if (!File::ReadFileToString(filename, buffer))
-    return false;
+    return std::nullopt;
 
-  BinaryStringBEToCode(buffer, code);
-  return true;
+  return std::make_optional(BinaryStringBEToCode(buffer));
 }
 
 bool SaveBinary(const std::vector<u16>& code, const std::string& filename)
 {
-  std::string buffer;
-  CodeToBinaryStringBE(code, buffer);
-  if (!File::WriteStringToFile(buffer, filename))
-    return false;
-  return true;
+  const std::string buffer = CodeToBinaryStringBE(code);
+
+  return File::WriteStringToFile(buffer, filename);
 }
 
 bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc)

--- a/Source/Core/Core/DSP/DSPCodeUtil.h
+++ b/Source/Core/Core/DSP/DSPCodeUtil.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -16,11 +17,11 @@ bool Disassemble(const std::vector<u16>& code, bool line_numbers, std::string& t
 bool Compare(const std::vector<u16>& code1, const std::vector<u16>& code2);
 
 // Big-endian, for writing straight to file using File::WriteStringToFile.
-void CodeToBinaryStringBE(const std::vector<u16>& code, std::string& str);
-void BinaryStringBEToCode(const std::string& str, std::vector<u16>& code);
+std::string CodeToBinaryStringBE(const std::vector<u16>& code);
+std::vector<u16> BinaryStringBEToCode(const std::string& str);
 
 // Load code (big endian binary).
-bool LoadBinary(const std::string& filename, std::vector<u16>& code);
+std::optional<std::vector<u16>> LoadBinary(const std::string& filename);
 bool SaveBinary(const std::vector<u16>& code, const std::string& filename);
 
 bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc);

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -212,24 +212,25 @@ int main(int argc, const char* argv[])
   {
     // Two binary inputs, let's diff.
     std::string binary_code;
-    std::vector<u16> code1, code2;
+
     File::ReadFileToString(input_name, binary_code);
-    DSP::BinaryStringBEToCode(binary_code, code1);
+    const std::vector<u16> code1 = DSP::BinaryStringBEToCode(binary_code);
+
     File::ReadFileToString(output_name, binary_code);
-    DSP::BinaryStringBEToCode(binary_code, code2);
+    const std::vector<u16> code2 = DSP::BinaryStringBEToCode(binary_code);
+
     DSP::Compare(code1, code2);
     return 0;
   }
 
   if (print_results)
   {
-    std::string dumpfile, results;
-    std::vector<u16> reg_vector;
+    std::string dumpfile;
 
     File::ReadFileToString(input_name, dumpfile);
-    DSP::BinaryStringBEToCode(dumpfile, reg_vector);
+    const std::vector<u16> reg_vector = DSP::BinaryStringBEToCode(dumpfile);
 
-    results.append("Start:\n");
+    std::string results("Start:\n");
     for (int initial_reg = 0; initial_reg < 32; initial_reg++)
     {
       results.append(StringFromFormat("%02x %04x ", initial_reg, reg_vector.at(initial_reg)));
@@ -314,9 +315,8 @@ int main(int argc, const char* argv[])
       return 1;
     }
     std::string binary_code;
-    std::vector<u16> code;
     File::ReadFileToString(input_name, binary_code);
-    DSP::BinaryStringBEToCode(binary_code, code);
+    const std::vector<u16> code = DSP::BinaryStringBEToCode(binary_code);
     std::string text;
     DSP::Disassemble(code, true, text);
     if (!output_name.empty())
@@ -408,8 +408,7 @@ int main(int argc, const char* argv[])
 
         if (!output_name.empty())
         {
-          std::string binary_code;
-          DSP::CodeToBinaryStringBE(code, binary_code);
+          const std::string binary_code = DSP::CodeToBinaryStringBE(code);
           File::WriteStringToFile(binary_code, output_name);
         }
         if (!output_header_name.empty())


### PR DESCRIPTION
We can just return directly in these cases.