### PR TITLE
Interpreter: Remove static state within SingleStepInner()

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -152,7 +152,7 @@ int Interpreter::SingleStepInner()
 
     if (m_prev_inst.hex != 0)
     {
-      UReg_MSR& msr = (UReg_MSR&)MSR;
+      const UReg_MSR msr{MSR};
       if (msr.FP)  // If FPU is enabled, just execute
       {
         m_op_table[m_prev_inst.OPCD](m_prev_inst);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -304,6 +304,8 @@ private:
   static void Helper_FloatCompareOrdered(UGeckoInstruction inst, double a, double b);
   static void Helper_FloatCompareUnordered(UGeckoInstruction inst, double a, double b);
 
+  UGeckoInstruction m_prev_inst{};
+
   static bool m_end_block;
 
   // TODO: These should really be in the save state, although it's unlikely to matter much.


### PR DESCRIPTION
Given how the hooking operates, we may not execute an instruction. Instead of making the state a static local to the function, just make it part of the lifecycle of the Interpreter class.