### PR TITLE
DSPEmitter: Remove uses of the DSP JIT global in CompileCurrent()

### DIFF
--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -374,9 +374,9 @@ void DSPEmitter::Compile(u16 start_addr)
   JMP(m_return_dispatcher, true);
 }
 
-static void CompileCurrent()
+static void CompileCurrent(DSPEmitter& emitter)
 {
-  g_dsp_jit->Compile(g_dsp.pc);
+  emitter.Compile(g_dsp.pc);
 
   bool retry = true;
 
@@ -385,11 +385,11 @@ static void CompileCurrent()
     retry = false;
     for (size_t i = 0; i < 0xffff; ++i)
     {
-      if (!g_dsp_jit->m_unresolved_jumps[i].empty())
+      if (!emitter.m_unresolved_jumps[i].empty())
       {
-        const u16 address_to_compile = g_dsp_jit->m_unresolved_jumps[i].front();
-        g_dsp_jit->Compile(address_to_compile);
-        if (!g_dsp_jit->m_unresolved_jumps[i].empty())
+        const u16 address_to_compile = emitter.m_unresolved_jumps[i].front();
+        emitter.Compile(address_to_compile);
+        if (!emitter.m_unresolved_jumps[i].empty())
           retry = true;
       }
     }
@@ -399,6 +399,7 @@ static void CompileCurrent()
 const u8* DSPEmitter::CompileStub()
 {
   const u8* entryPoint = AlignCode16();
+  MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(this)));
   ABI_CallFunction(CompileCurrent);
   XOR(32, R(EAX), R(EAX));  // Return 0 cycles executed
   JMP(m_return_dispatcher);


### PR DESCRIPTION
With this, the DSPEmitter itself no longer makes use of the DSP JIT global