### PR TITLE
Core: Check for initialized GCPad before resetting rumble

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -250,6 +250,8 @@ static void ResetRumble()
   GCAdapter::ResetRumble();
 #endif
 #if defined(CIFACE_USE_XINPUT) || defined(CIFACE_USE_DINPUT)
+  if (!Pad::IsInitialized())
+    return;
   for (int i = 0; i < 4; ++i)
     Pad::ResetRumble(i);
 #endif

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -45,6 +45,11 @@ void LoadConfig()
   s_config.LoadConfig(true);
 }
 
+bool IsInitialized()
+{
+  return !s_config.ControllersNeedToBeCreated();
+}
+
 GCPadStatus GetStatus(int pad_num)
 {
   return static_cast<GCPad*>(s_config.GetController(pad_num))->GetInput();

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -21,6 +21,7 @@ namespace Pad
 void Shutdown();
 void Initialize();
 void LoadConfig();
+bool IsInitialized();
 
 InputConfig* GetConfig();
 


### PR DESCRIPTION
At the moment we might be trying to reset rumble on uninitialized GCPad's which can (and leads!) to a segfault when quitting Dolphin.

Fixes [issue #10970](https://bugs.dolphin-emu.org/issues/10970).