### PR TITLE
DiscExtractor: Pass partition by reference rather than by value in ExtractDirectory()

### DIFF
--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -119,7 +119,7 @@ bool ExportFile(const Volume& volume, const Partition& partition, const std::str
   return ExportFile(volume, partition, file_system->FindFileInfo(path).get(), export_filename);
 }
 
-void ExportDirectory(const Volume& volume, const Partition partition, const FileInfo& directory,
+void ExportDirectory(const Volume& volume, const Partition& partition, const FileInfo& directory,
                      bool recursive, const std::string& filesystem_path,
                      const std::string& export_folder,
                      const std::function<bool(const std::string& path)>& update_progress)

--- a/Source/Core/DiscIO/DiscExtractor.h
+++ b/Source/Core/DiscIO/DiscExtractor.h
@@ -31,7 +31,7 @@ bool ExportFile(const Volume& volume, const Partition& partition, const std::str
 // update_progress is called once for each child (file or directory).
 // If update_progress returns true, the extraction gets cancelled.
 // filesystem_path is supposed to be the path corresponding to the directory argument.
-void ExportDirectory(const Volume& volume, const Partition partition, const FileInfo& directory,
+void ExportDirectory(const Volume& volume, const Partition& partition, const FileInfo& directory,
                      bool recursive, const std::string& filesystem_path,
                      const std::string& export_folder,
                      const std::function<bool(const std::string& path)>& update_progress);

--- a/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
@@ -238,7 +238,7 @@ void FilesystemWidget::ExtractSystemData(const DiscIO::Partition& partition, con
     QMessageBox::critical(nullptr, tr("Error"), tr("Failed to extract system data."));
 }
 
-void FilesystemWidget::ExtractDirectory(const DiscIO::Partition& partition, const QString path,
+void FilesystemWidget::ExtractDirectory(const DiscIO::Partition& partition, const QString& path,
                                         const QString& out)
 {
   const DiscIO::FileSystem* filesystem = m_volume->GetFileSystem(partition);

--- a/Source/Core/DolphinQt2/Config/FilesystemWidget.h
+++ b/Source/Core/DolphinQt2/Config/FilesystemWidget.h
@@ -36,8 +36,9 @@ private:
   void ShowContextMenu(const QPoint&);
 
   void ExtractPartition(const DiscIO::Partition& partition, const QString& out);
-  void ExtractDirectory(const DiscIO::Partition& partition, const QString path, const QString& out);
-  void ExtractFile(const DiscIO::Partition& pratition, const QString& path, const QString& out);
+  void ExtractDirectory(const DiscIO::Partition& partition, const QString& path,
+                        const QString& out);
+  void ExtractFile(const DiscIO::Partition& partition, const QString& path, const QString& out);
   void ExtractSystemData(const DiscIO::Partition& partition, const QString& out);
   void CheckIntegrity(const DiscIO::Partition& partition);
 


### PR DESCRIPTION
This has no performance impact, but it does make the API more consistent with the rest of the surrounding functions. Also corrects the relevant Qt function this is called from.