### PR TITLE
UICommon/CMakeLists: Migrate off of add_dolphin_library

### DIFF
--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS
+add_library(uicommon
   AutoUpdate.cpp
   CommandLineParse.cpp
   Disassembler.cpp
@@ -9,16 +9,18 @@ set(SRCS
   VideoUtils.cpp
 )
 
+target_link_libraries(uicommon PUBLIC
+  common
+  cpp-optparse
+)
+
 if(USE_X11)
-  set(SRCS ${SRCS} X11Utils.cpp)
+  target_sources(uicommon PRIVATE X11Utils.cpp)
 endif()
 
-set(LIBS common cpp-optparse)
 if(LIBUSB_FOUND)
-  set(LIBS ${LIBS} ${LIBUSB_LIBRARIES})
+  target_link_libraries(uicommon PRIVATE ${LIBUSB_LIBRARIES})
 endif()
-
-add_dolphin_library(uicommon "${SRCS}" "${LIBS}")
 
 if(ENABLE_LLVM)
   find_package(LLVM CONFIG QUIET)


### PR DESCRIPTION
Continues the migration work started in 3a4c3bbe01e7a44ec997f4fbf0b678fba6f2d46c