### PR TITLE
VideoCommon/Vulkan: Explicitly link in xxhash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,7 +588,6 @@ if(NOT XXHASH_FOUND)
   add_subdirectory(Externals/xxhash)
   include_directories(Externals/xxhash)
 endif()
-LIST(APPEND LIBS xxhash)
 
 find_package(ZLIB)
 if(ZLIB_FOUND)

--- a/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
@@ -41,5 +41,9 @@ include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/Externals/glslang/SPIRV)
 
 # Link against glslang, the other necessary libraries are referenced by the executable.
 add_dolphin_library(videovulkan "${SRCS}" "${LIBS}")
-target_link_libraries(videovulkan PRIVATE glslang)
+target_link_libraries(videovulkan
+PRIVATE
+  glslang
+  xxhash
+)
 

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -64,6 +64,7 @@ PUBLIC
   core
 PRIVATE
   png
+  xxhash
 )
 
 if(_M_X86)


### PR DESCRIPTION
Lessens the dependency on the LIBS variable (and also makes the required libraries explicit).