### PR TITLE
Qt/LogWidget: Add "Debugger Font" option

### DIFF
--- a/Source/Core/DolphinQt2/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/LogWidget.cpp
@@ -40,6 +40,8 @@ LogWidget::LogWidget(QWidget* parent) : QDockWidget(parent), m_timer(new QTimer(
   connect(m_timer, &QTimer::timeout, this, &LogWidget::UpdateLog);
   m_timer->start(UPDATE_LOG_DELAY);
 
+  connect(&Settings::Instance(), &Settings::DebugFontChanged, this, &LogWidget::UpdateFont);
+
   LogManager::GetInstance()->RegisterListener(LogListener::LOG_WINDOW_LISTENER, this);
 }
 
@@ -97,6 +99,9 @@ void LogWidget::UpdateFont()
     f = QFont(QStringLiteral("Monospace"));
     f.setStyleHint(QFont::TypeWriter);
     break;
+  case 2:  // Debugger font
+    f = Settings::Instance().GetDebugFont();
+    break;
   }
   m_log_text->setFont(f);
 }
@@ -110,7 +115,7 @@ void LogWidget::CreateWidgets()
   m_log_font = new QComboBox;
   m_log_clear = new QPushButton(tr("Clear"));
 
-  m_log_font->addItems({tr("Default Font"), tr("Monospaced Font")});
+  m_log_font->addItems({tr("Default Font"), tr("Monospaced Font"), tr("Selected Font")});
 
   auto* log_layout = new QGridLayout;
   m_tab_log->setLayout(log_layout);


### PR DESCRIPTION
Adds the missing ``Selected Font`` drop down option to the logging widget's font selection.