### PR TITLE
InputCommon/CMakeLists: Link in ForceFeedback library explicitly on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   find_library(FOUNDATION_LIBRARY Foundation)
   find_library(IOB_LIBRARY IOBluetooth)
   find_library(IOK_LIBRARY IOKit)
-  find_library(FORCEFEEDBACK ForceFeedback)
   find_library(OPENGL_LIBRARY OpenGL)
 
   # Link against OS X system frameworks.
@@ -302,7 +301,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     ${COREFUND_LIBRARY}
     ${CORESERV_LIBRARY}
     ${IOK_LIBRARY}
-    ${FORCEFEEDBACK}
   )
 endif()
 

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -40,6 +40,7 @@ elseif(APPLE)
   find_library(COREFOUNDATION_LIBRARY CoreFoundation)
   find_library(CARBON_LIBRARY Carbon)
   find_library(COCOA_LIBRARY Cocoa)
+  find_library(FORCEFEEDBACK_LIBRARY ForceFeedback)
   target_sources(inputcommon PRIVATE
     ControllerInterface/OSX/OSX.mm
     ControllerInterface/OSX/OSXJoystick.mm
@@ -47,10 +48,11 @@ elseif(APPLE)
     ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
     ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
   )
-  target_link_libraries(inputcommon PUBLIC
+  target_link_libraries(inputcommon PRIVATE
     ${COREFOUNDATION_LIBRARY}
     ${CARBON_LIBRARY}
     ${COCOA_LIBRARY}
+    ${FORCEFEEDBACK_LIBRARY}
   )
 elseif(X11_FOUND)
   target_sources(inputcommon PRIVATE


### PR DESCRIPTION
Makes an implicit dependency explicit. Also makes the macOS libraries link privately as they aren't used in the exposed interface.