### PR TITLE
Qt/PatchesWidget: Fix segfault

### DIFF
--- a/Source/Core/DolphinQt2/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/PatchesWidget.cpp
@@ -169,7 +169,8 @@ void PatchesWidget::Update()
 void PatchesWidget::UpdateActions()
 {
   bool selected = !m_list->selectedItems().isEmpty();
-  auto* item = m_list->selectedItems()[0];
+
+  auto* item = selected ? m_list->selectedItems()[0] : nullptr;
 
   bool user_defined = selected ? item->data(Qt::UserRole).toBool() : true;
 


### PR DESCRIPTION
* Fix a possible segfault in the patches widget (Didn't ever occur in the wild thus far)