### PR TITLE
DolphinQt2: Don't show invalid games in game list

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -173,7 +173,9 @@ void GameTracker::LoadGame(const QString& path)
   if (!DiscIO::ShouldHideFromGameList(converted_path))
   {
     bool cache_changed = false;
-    emit GameLoaded(m_cache.AddOrGet(converted_path, &cache_changed, m_title_database));
+    auto game = m_cache.AddOrGet(converted_path, &cache_changed, m_title_database);
+    if (game)
+      emit GameLoaded(std::move(game));
     if (cache_changed)
       m_cache.Save();
   }

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -28,7 +28,7 @@
 
 namespace UICommon
 {
-static constexpr u32 CACHE_REVISION = 7;  // Last changed in PR 6281
+static constexpr u32 CACHE_REVISION = 8;  // Last changed in PR 6560
 
 std::vector<std::string> FindAllGamePaths(const std::vector<std::string>& directories_to_scan,
                                           bool recursive_scan)
@@ -60,7 +60,12 @@ std::shared_ptr<const GameFile> GameFileCache::AddOrGet(const std::string& path,
       [&path](const std::shared_ptr<GameFile>& file) { return file->GetFilePath() == path; });
   const bool found = it != m_cached_files.cend();
   if (!found)
-    m_cached_files.emplace_back(std::make_shared<GameFile>(path));
+  {
+    std::shared_ptr<UICommon::GameFile> game = std::make_shared<GameFile>(path);
+    if (!game->IsValid())
+      return nullptr;
+    m_cached_files.emplace_back(std::move(game));
+  }
   std::shared_ptr<GameFile>& result = found ? *it : m_cached_files.back();
   if (UpdateAdditionalMetadata(&result, title_database) || !found)
     *cache_changed = true;

--- a/Source/Core/UICommon/GameFileCache.h
+++ b/Source/Core/UICommon/GameFileCache.h
@@ -35,6 +35,7 @@ public:
 
   void Clear();
 
+  // Returns nullptr if the file is invalid.
   std::shared_ptr<const GameFile> AddOrGet(const std::string& path, bool* cache_changed,
                                            const Core::TitleDatabase& title_database);
 


### PR DESCRIPTION
Regression from PR #6281.

This problem doesn't happen in DolphinWX as far as I know, but if you've ran into the problem in DolphinQt2, it will carry over to DolphinWX because of the shared game list cache.