### PR TITLE
Put a "last changed in PR" comment next to UID cache version

### DIFF
--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -20,7 +20,7 @@ namespace VideoCommon
 // As pipelines encompass both shader UIDs and render states, changes to either of these should
 // also increment the pipeline UID version. Incrementing the UID version will cause all UID
 // caches to be invalidated.
-constexpr u32 GX_PIPELINE_UID_VERSION = 1;
+constexpr u32 GX_PIPELINE_UID_VERSION = 1;  // Last changed in PR 6431
 
 struct GXPipelineUid
 {


### PR DESCRIPTION
This will create a merge conflict if two PRs try to increment the cache version at the same time, which makes it noticeable that the PR that gets merged last needs to increment the cache version again. We already use this for savestates and the game list cache.