### PR TITLE
Fix loading Wii banners for games that initially were cached without banners

### DIFF
--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -226,12 +226,9 @@ bool GameFile::BannerChanged()
       DiscIO::WiiSaveBanner(m_title_id)
           .GetBanner(&m_pending.volume_banner.width, &m_pending.volume_banner.height);
 
-  if (m_pending.volume_banner.buffer.empty())
-    return false;
-
-  // We only reach here if m_volume_banner was empty, so we can always return true
-  // without needing any extra check to know whether the banners are different
-  return true;
+  // We only reach here if the old banner was empty, so if the new banner isn't empty,
+  // the new banner is guaranteed to be different from the old banner
+  return !m_pending.volume_banner.buffer.empty();
 }
 
 void GameFile::BannerCommit()

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -222,9 +222,11 @@ bool GameFile::BannerChanged()
   if (!DiscIO::IsWii(m_platform))
     return false;
 
-  m_volume_banner.buffer =
-      DiscIO::WiiSaveBanner(m_title_id).GetBanner(&m_volume_banner.width, &m_volume_banner.height);
-  if (m_volume_banner.buffer.empty())
+  m_pending.volume_banner.buffer =
+      DiscIO::WiiSaveBanner(m_title_id)
+          .GetBanner(&m_pending.volume_banner.width, &m_pending.volume_banner.height);
+
+  if (m_pending.volume_banner.buffer.empty())
     return false;
 
   // We only reach here if m_volume_banner was empty, so we can always return true


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10969