### PR TITLE
IOS: Emulate filesystem timings

### DIFF
--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -29,10 +29,10 @@ static s32 ConvertResult(ResultCode code)
   return -(static_cast<s32>(code) + 100);
 }
 
-// XXX: timing is not the same for all commands and in all cases.
-static IPCCommandResult GetFSReply(s32 return_value)
+static IPCCommandResult GetFSReply(s32 return_value, u64 extra_tb_ticks = 0)
 {
-  return {return_value, true, SystemTimers::GetTicksPerSecond() / 500};
+  // According to hardware tests, FS takes at least 2700 TB ticks to reply to commands.
+  return {return_value, true, (2700 + extra_tb_ticks) * SystemTimers::TIMER_RATIO};
 }
 
 FS::FS(Kernel& ios, const std::string& device_name) : Device(ios, device_name)

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.h
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.h
@@ -46,6 +46,7 @@ private:
     IOS::HLE::FS::Fd fs_fd = INVALID_FD;
     // We use a std::array to keep this savestate friendly.
     std::array<char, 64> name{};
+    bool superblock_flush_needed = false;
   };
 
   enum
@@ -79,7 +80,15 @@ private:
   IPCCommandResult GetUsage(const Handle& handle, const IOCtlVRequest& request);
   IPCCommandResult Shutdown(const Handle& handle, const IOCtlRequest& request);
 
+  u64 EstimateTicksForReadWrite(const Handle& handle, const ReadWriteRequest& request);
+  u64 SimulatePopulateFileCache(u32 fd, u32 offset, u32 file_size);
+  u64 SimulateFlushFileCache();
+  bool HasCacheForFile(u32 fd, u32 offset) const;
+
   std::map<u32, Handle> m_fd_map;
+  u32 m_cache_fd = INVALID_FD;
+  u16 m_cache_chain_index = 0;
+  bool m_dirty_cache = false;
 };
 }  // namespace Device
 }  // namespace HLE

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 95;  // Last changed in PR 6421
+static const u32 STATE_VERSION = 96;  // Last changed in PR 6565
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Requires PR #6421.

This changes our filesystem code to emulate operation timings in a much more accurate way -- by using hardware tested numbers and running part of the original FS code logic to properly simulate how long operations take to complete.

Gets rid of the current hardcoded guesses which are so far from the actual timings that [MLB Power Pros](https://wiki.dolphin-emu.org/index.php?title=MLB_Power_Pros) will just refuse to write a banner file.

It's unclear if this fixes any other title, but making timings more correct can't hurt.

Note that for the sake of not having to handle a ridiculous amount of cases, some situations have been simplified but the timing is still very close (< 1ms difference). Also, some of the commands (such as `ReadDirectory`) haven't been tested yet so they were left untouched.

---

[Source code for the hardware tests](https://github.com/leoetlino/hwtests/blob/more-timing-tests/iostest/fs_timing.cpp) - [elf](http://f.leolam.fr/iostest_fs_timing3.elf) (takes ~30-50 seconds to run)

[Result graphs](https://docs.google.com/spreadsheets/d/e/2PACX-1vRN9K7yjd5jrs2m_pkK4pjeVN5vDe-haru2ijHZehnG7tXTsfonq16sWlK7eByGEz4MU8nhjDnm0WAC/pubhtml#) (note that the different cases are not separated so the equations are close but incorrect)

<details><summary>Console</summary><pre>Open /invalid/path/: reply_ticks=3009  (100 tests)
Open /title: reply_ticks=3475  (100 tests)
Open /title/00000001: reply_ticks=4051  (100 tests)
Open /sys/cert.sys: reply_ticks=4295  (100 tests)
Open /shared2/sys/SYSCONF: reply_ticks=4809  (100 tests)
Close (no cache flush): reply_ticks=2682  (100 tests)
Read 0 bytes (uncached): reply_ticks=2566  (100 tests)
Read 4 bytes (uncached): reply_ticks=119502  (100 tests)
Read 256 bytes (uncached): reply_ticks=119400  (100 tests)
Read 512 bytes (uncached): reply_ticks=119548  (100 tests)
Read 768 bytes (uncached): reply_ticks=119161  (100 tests)
Read 2048 bytes (uncached): reply_ticks=117767  (100 tests)
Read 4096 bytes (uncached): reply_ticks=119376  (100 tests)
Read 8192 bytes (uncached): reply_ticks=122407  (100 tests)
Read 16384 bytes (uncached): reply_ticks=116145  (100 tests)
Read 0 bytes (cached): reply_ticks=2603  (100 tests)
Read 4 bytes (cached): reply_ticks=2849  (100 tests)
Read 256 bytes (cached): reply_ticks=2997  (100 tests)
Read 512 bytes (cached): reply_ticks=3167  (100 tests)
Read 768 bytes (cached): reply_ticks=3353  (100 tests)
Read 2048 bytes (cached): reply_ticks=4157  (100 tests)
Read 4096 bytes (cached): reply_ticks=5482  (100 tests)
Read 8192 bytes (cached): reply_ticks=8089  (100 tests)
Read 16384 bytes (cached): reply_ticks=13182  (100 tests)
CreateFile: reply_ticks=3405872  (20 tests)
DeleteFileOrDirectory (file): reply_ticks=3388459  (20 tests)
GetMetadata /title: reply_ticks=4006  (100 tests)
GetMetadata /title/00000001: reply_ticks=4505  (100 tests)
GetMetadata /sys/cert.sys: error
GetMetadata /shared2/sys/SYSCONF: reply_ticks=4682  (100 tests)
Write 0 bytes (blank): reply_ticks=2839  (20 tests)
  -- Flush: reply_ticks=2894  (20 tests)
Write 4 bytes (blank): reply_ticks=3746  (20 tests)
  -- Flush: reply_ticks=3736854  (20 tests)
Write 256 bytes (blank): reply_ticks=3879  (20 tests)
  -- Flush: reply_ticks=3727929  (20 tests)
Write 4096 bytes (blank): reply_ticks=6109  (20 tests)
  -- Flush: reply_ticks=3727252  (20 tests)
Write 8192 bytes (blank): reply_ticks=8489  (20 tests)
  -- Flush: reply_ticks=3725920  (20 tests)
Write 16384 bytes (blank): reply_ticks=356485  (20 tests)
  -- Flush: reply_ticks=3378327  (20 tests)
Write 16385 bytes (blank): reply_ticks=357645  (20 tests)
  -- Flush: reply_ticks=3639941  (20 tests)
Write 32768 bytes (blank): reply_ticks=624324  (20 tests)
  -- Flush: reply_ticks=3370666  (20 tests)
Write 0 bytes (non-empty): reply_ticks=2788  (20 tests)
  -- Flush: reply_ticks=2761  (20 tests)
Write 4 bytes (non-empty): reply_ticks=117641  (20 tests)
  -- Flush: reply_ticks=3643022  (20 tests)
Write 256 bytes (non-empty): reply_ticks=118021  (20 tests)
  -- Flush: reply_ticks=3640709  (20 tests)
Write 4096 bytes (non-empty): reply_ticks=120140  (20 tests)
  -- Flush: reply_ticks=3640742  (20 tests)
Write 8192 bytes (non-empty): reply_ticks=122424  (20 tests)
  -- Flush: reply_ticks=3640550  (20 tests)
Write 16384 bytes (non-empty): reply_ticks=274630  (20 tests)
  -- Flush: reply_ticks=3369235  (20 tests)
Write 16385 bytes (non-empty): reply_ticks=388887  (20 tests)
  -- Flush: reply_ticks=3647483  (20 tests)
Write 32768 bytes (non-empty): reply_ticks=540823  (20 tests)
  -- Flush: reply_ticks=3360637  (20 tests)
</pre></details>

<details><summary>Dolphin (before these fixes)</summary><pre>Open /invalid/path/: reply_ticks=4000  (100 tests)
Open /title: reply_ticks=4000  (100 tests)
Open /title/00000001: reply_ticks=4000  (100 tests)
Open /sys/cert.sys: reply_ticks=4000  (100 tests)
Open /shared2/sys/SYSCONF: reply_ticks=4000  (100 tests)
Close (no cache flush): reply_ticks=4000  (100 tests)
Read 0 bytes (uncached): reply_ticks=4000  (100 tests)
Read 4 bytes (uncached): reply_ticks=4000  (100 tests)
Read 256 bytes (uncached): reply_ticks=4000  (100 tests)
Read 512 bytes (uncached): reply_ticks=4000  (100 tests)
Read 768 bytes (uncached): reply_ticks=4000  (100 tests)
Read 2048 bytes (uncached): reply_ticks=4000  (100 tests)
Read 4096 bytes (uncached): reply_ticks=4000  (100 tests)
Read 8192 bytes (uncached): reply_ticks=4000  (100 tests)
Read 16384 bytes (uncached): reply_ticks=4000  (100 tests)
Read 0 bytes (cached): reply_ticks=4000  (100 tests)
Read 4 bytes (cached): reply_ticks=4000  (100 tests)
Read 256 bytes (cached): reply_ticks=4000  (100 tests)
Read 512 bytes (cached): reply_ticks=4000  (100 tests)
Read 768 bytes (cached): reply_ticks=4000  (100 tests)
Read 2048 bytes (cached): reply_ticks=4000  (100 tests)
Read 4096 bytes (cached): reply_ticks=4000  (100 tests)
Read 8192 bytes (cached): reply_ticks=4000  (100 tests)
Read 16384 bytes (cached): reply_ticks=4000  (100 tests)
CreateFile: reply_ticks=121500  (20 tests)
DeleteFileOrDirectory (file): reply_ticks=121500  (20 tests)
GetMetadata /title: reply_ticks=121500  (100 tests)
GetMetadata /title/00000001: reply_ticks=121500  (100 tests)
GetMetadata /sys/cert.sys: reply_ticks=121500  (100 tests)
GetMetadata /shared2/sys/SYSCONF: reply_ticks=121500  (100 tests)
Write 0 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 4 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 256 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 4096 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 8192 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 16384 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 16385 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 32768 bytes (blank): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 0 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 4 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 256 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=3999  (20 tests)
Write 4096 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 8192 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 16384 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 16385 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
Write 32768 bytes (non-empty): reply_ticks=4000  (20 tests)
  -- Flush: reply_ticks=4000  (20 tests)
</pre></details>

<details><summary>Dolphin (after these fixes)</summary><pre>Open /invalid/path/: reply_ticks=2999  (100 tests)
Open /title: reply_ticks=3380  (100 tests)
Open /title/00000001: reply_ticks=4060  (100 tests)
Open /sys/cert.sys: reply_ticks=4060  (100 tests)
Open /shared2/sys/SYSCONF: reply_ticks=4740  (100 tests)
Close (no cache flush): reply_ticks=2700  (100 tests)
Read 0 bytes (uncached): reply_ticks=2700  (100 tests)
Read 4 bytes (uncached): reply_ticks=117702  (100 tests)
Read 256 bytes (uncached): reply_ticks=117861  (100 tests)
Read 512 bytes (uncached): reply_ticks=118022  (100 tests)
Read 768 bytes (uncached): reply_ticks=118183  (100 tests)
Read 2048 bytes (uncached): reply_ticks=118990  (100 tests)
Read 4096 bytes (uncached): reply_ticks=120280  (100 tests)
Read 8192 bytes (uncached): reply_ticks=122860  (100 tests)
Read 16384 bytes (uncached): reply_ticks=117700  (100 tests)
Read 0 bytes (cached): reply_ticks=2700  (100 tests)
Read 4 bytes (cached): reply_ticks=2702  (100 tests)
Read 256 bytes (cached): reply_ticks=2861  (100 tests)
Read 512 bytes (cached): reply_ticks=3022  (100 tests)
Read 768 bytes (cached): reply_ticks=3183  (100 tests)
Read 2048 bytes (cached): reply_ticks=3990  (100 tests)
Read 4096 bytes (cached): reply_ticks=5280  (100 tests)
Read 8192 bytes (cached): reply_ticks=7860  (100 tests)
Read 16384 bytes (cached): reply_ticks=13021  (100 tests)
CreateFile: reply_ticks=3372700  (20 tests)
DeleteFileOrDirectory (file): reply_ticks=3372700  (20 tests)
GetMetadata /title: reply_ticks=4040  (100 tests)
GetMetadata /title/00000001: reply_ticks=4380  (100 tests)
GetMetadata /sys/cert.sys: reply_ticks=4380  (100 tests)
GetMetadata /shared2/sys/SYSCONF: reply_ticks=4720  (100 tests)
Write 0 bytes (blank): reply_ticks=2700  (20 tests)
  -- Flush: reply_ticks=2700  (20 tests)
Write 4 bytes (blank): reply_ticks=3702  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 256 bytes (blank): reply_ticks=3861  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 4096 bytes (blank): reply_ticks=6280  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 8192 bytes (blank): reply_ticks=8860  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 16384 bytes (blank): reply_ticks=302700  (20 tests)
  -- Flush: reply_ticks=3372700  (20 tests)
Write 16385 bytes (blank): reply_ticks=303700  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 32768 bytes (blank): reply_ticks=602699  (20 tests)
  -- Flush: reply_ticks=3372700  (20 tests)
Write 0 bytes (non-empty): reply_ticks=2700  (20 tests)
  -- Flush: reply_ticks=2700  (20 tests)
Write 4 bytes (non-empty): reply_ticks=118702  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 256 bytes (non-empty): reply_ticks=118861  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 4096 bytes (non-empty): reply_ticks=121280  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 8192 bytes (non-empty): reply_ticks=123860  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 16384 bytes (non-empty): reply_ticks=302700  (20 tests)
  -- Flush: reply_ticks=3372700  (20 tests)
Write 16385 bytes (non-empty): reply_ticks=418700  (20 tests)
  -- Flush: reply_ticks=3672700  (20 tests)
Write 32768 bytes (non-empty): reply_ticks=602700  (20 tests)
  -- Flush: reply_ticks=3372700  (20 tests)
</pre></details>