### PR TITLE
CMakeLists: Link in system framework libraries explicitly on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,26 +282,15 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
   find_library(APPKIT_LIBRARY AppKit)
   find_library(APPSERV_LIBRARY ApplicationServices)
-  find_library(AU_LIBRARY AudioUnit)
   find_library(CARBON_LIBRARY Carbon)
   find_library(COCOA_LIBRARY Cocoa)
-  find_library(COREAUDIO_LIBRARY CoreAudio)
-  find_library(COREFUND_LIBRARY CoreFoundation)
+  find_library(COREFOUNDATION_LIBRARY CoreFoundation)
   find_library(CORESERV_LIBRARY CoreServices)
+  find_library(FORCEFEEDBACK_LIBRARY ForceFeedback)
   find_library(FOUNDATION_LIBRARY Foundation)
   find_library(IOB_LIBRARY IOBluetooth)
   find_library(IOK_LIBRARY IOKit)
   find_library(OPENGL_LIBRARY OpenGL)
-
-  # Link against OS X system frameworks.
-  list(APPEND LIBS
-    ${APPKIT_LIBRARY}
-    ${AU_LIBRARY}
-    ${COREAUDIO_LIBRARY}
-    ${COREFUND_LIBRARY}
-    ${CORESERV_LIBRARY}
-    ${IOK_LIBRARY}
-  )
 endif()
 
 if(ENABLE_LTO)

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -52,6 +52,15 @@ target_link_libraries(common PUBLIC
   ${VTUNE_LIBRARIES}
 )
 
+if (APPLE)
+  target_link_libraries(common
+  PRIVATE
+    ${APPKIT_LIBRARY}
+    ${COREFOUNDATION_LIBRARY}
+    ${IOK_LIBRARY}
+  )
+endif()
+
 if(ANDROID)
   target_sources(common PRIVATE
     Logging/ConsoleListenerDroid.cpp

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -291,6 +291,15 @@ PUBLIC
   z
 )
 
+if (APPLE)
+  target_link_libraries(core
+  PRIVATE
+    ${CORESERV_LIBRARY}
+    ${IOB_LIBRARY}
+    ${IOK_LIBRARY}
+  )
+endif()
+
 if(LIBUSB_FOUND)
   # Using shared LibUSB
   target_link_libraries(core PUBLIC ${LIBUSB_LIBRARIES})

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -37,10 +37,6 @@ if(WIN32)
     ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
   )
 elseif(APPLE)
-  find_library(COREFOUNDATION_LIBRARY CoreFoundation)
-  find_library(CARBON_LIBRARY Carbon)
-  find_library(COCOA_LIBRARY Cocoa)
-  find_library(FORCEFEEDBACK_LIBRARY ForceFeedback)
   target_sources(inputcommon PRIVATE
     ControllerInterface/OSX/OSX.mm
     ControllerInterface/OSX/OSXJoystick.mm
@@ -53,6 +49,7 @@ elseif(APPLE)
     ${CARBON_LIBRARY}
     ${COCOA_LIBRARY}
     ${FORCEFEEDBACK_LIBRARY}
+    ${IOK_LIBRARY}
   )
 elseif(X11_FOUND)
   target_sources(inputcommon PRIVATE

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -9,9 +9,13 @@ add_library(uicommon
   VideoUtils.cpp
 )
 
-target_link_libraries(uicommon PUBLIC
+target_link_libraries(uicommon
+PUBLIC
   common
   cpp-optparse
+
+PRIVATE
+  $<$<BOOL:APPLE>:${IOK_LIBRARY}>
 )
 
 if(USE_X11)


### PR DESCRIPTION
Makes our libraries explicitly link in which libraries they need. This makes our dependencies explicit and removes the reliance on the LIBS variable to contain the libraries that they need.