### PR TITLE
DiscIO: Don't use all uppercase for enum values

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -253,13 +253,13 @@ static int GetPlatform(std::string filename)
   {
     switch (pVolume->GetVolumeType())
     {
-    case DiscIO::Platform::GAMECUBE_DISC:
+    case DiscIO::Platform::GameCubeDisc:
       __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a GameCube disc.");
       return 0;
-    case DiscIO::Platform::WII_DISC:
+    case DiscIO::Platform::WiiDisc:
       __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii disc.");
       return 1;
-    case DiscIO::Platform::WII_WAD:
+    case DiscIO::Platform::WiiWAD:
       __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii WAD.");
       return 2;
     }
@@ -282,7 +282,7 @@ static std::string GetTitle(std::string filename)
       titles = pVolume->GetShortNames();
 
     /*
-    bool is_wii_title = pVolume->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
+    const bool is_wii_title = DiscIO::IsWii(pVolume->GetVolumeType());
     DiscIO::Language language = SConfig::GetInstance().GetCurrentLanguage(is_wii_title);
 
     auto it = titles.find(language);
@@ -292,8 +292,8 @@ static std::string GetTitle(std::string filename)
     auto end = titles.end();
 
     // English tends to be a good fallback when the requested language isn't available
-    // if (language != DiscIO::Language::LANGUAGE_ENGLISH) {
-    auto it = titles.find(DiscIO::Language::LANGUAGE_ENGLISH);
+    // if (language != DiscIO::Language::English) {
+    auto it = titles.find(DiscIO::Language::English);
     if (it != end)
       return it->second;
     //}
@@ -323,7 +323,7 @@ static std::string GetDescription(std::string filename)
     std::map<DiscIO::Language, std::string> descriptions = volume->GetDescriptions();
 
     /*
-    bool is_wii_title = pVolume->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
+    const bool is_wii_title = DiscIO::IsWii(pVolume->GetVolumeType());
     DiscIO::Language language = SConfig::GetInstance().GetCurrentLanguage(is_wii_title);
 
     auto it = descriptions.find(language);
@@ -333,8 +333,8 @@ static std::string GetDescription(std::string filename)
     auto end = descriptions.end();
 
     // English tends to be a good fallback when the requested language isn't available
-    // if (language != DiscIO::Language::LANGUAGE_ENGLISH) {
-    auto it = descriptions.find(DiscIO::Language::LANGUAGE_ENGLISH);
+    // if (language != DiscIO::Language::English) {
+    auto it = descriptions.find(DiscIO::Language::English);
     if (it != end)
       return it->second;
     //}

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -245,12 +245,12 @@ bool CBoot::Load_BS2(const std::string& boot_rom_filename)
     break;
   default:
     PanicAlertT("IPL with unknown hash %x", ipl_hash);
-    ipl_region = DiscIO::Region::UNKNOWN_REGION;
+    ipl_region = DiscIO::Region::Unknown;
     break;
   }
 
   const DiscIO::Region boot_region = SConfig::GetInstance().m_region;
-  if (ipl_region != DiscIO::Region::UNKNOWN_REGION && boot_region != ipl_region)
+  if (ipl_region != DiscIO::Region::Unknown && boot_region != ipl_region)
     PanicAlertT("%s IPL found in %s directory. The disc might not be recognized",
                 SConfig::GetDirectoryForRegion(ipl_region),
                 SConfig::GetDirectoryForRegion(boot_region));

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -341,7 +341,7 @@ static void WriteEmptyPlayRecord()
 bool CBoot::EmulatedBS2_Wii(const DiscIO::Volume& volume)
 {
   INFO_LOG(BOOT, "Faking Wii BS2...");
-  if (volume.GetVolumeType() != DiscIO::Platform::WII_DISC)
+  if (volume.GetVolumeType() != DiscIO::Platform::WiiDisc)
     return false;
 
   const DiscIO::Partition partition = volume.GetGamePartition();

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -888,7 +888,7 @@ struct SetGameMetadata
   bool operator()(const BootParameters::Disc& disc) const
   {
     config->SetRunningGameMetadata(*disc.volume, disc.volume->GetGamePartition());
-    config->bWii = disc.volume->GetVolumeType() == DiscIO::Platform::WII_DISC;
+    config->bWii = disc.volume->GetVolumeType() == DiscIO::Platform::WiiDisc;
     config->m_disc_booted_from_game_list = true;
     *region = disc.volume->GetRegion();
     return true;
@@ -901,7 +901,7 @@ struct SetGameMetadata
 
     config->bWii = executable.reader->IsWii();
 
-    *region = DiscIO::Region::UNKNOWN_REGION;
+    *region = DiscIO::Region::Unknown;
 
     // Strip the .elf/.dol file extension and directories before the name
     SplitPath(executable.path, nullptr, &config->m_debugger_game_id, nullptr);
@@ -974,7 +974,7 @@ bool SConfig::SetPathsAndGameMetadata(const BootParameters& boot)
     return false;
 
   // Fall back to the system menu region, if possible.
-  if (m_region == DiscIO::Region::UNKNOWN_REGION)
+  if (m_region == DiscIO::Region::Unknown)
   {
     IOS::HLE::Kernel ios;
     const IOS::ES::TMDReader system_menu_tmd = ios.GetES()->FindInstalledTMD(Titles::SYSTEM_MENU);
@@ -983,7 +983,7 @@ bool SConfig::SetPathsAndGameMetadata(const BootParameters& boot)
   }
 
   // Fall back to PAL.
-  if (m_region == DiscIO::Region::UNKNOWN_REGION)
+  if (m_region == DiscIO::Region::Unknown)
     m_region = DiscIO::Region::PAL;
 
   // Set up paths
@@ -1054,9 +1054,8 @@ DiscIO::Language SConfig::GetCurrentLanguage(bool wii) const
   DiscIO::Language language = static_cast<DiscIO::Language>(language_value);
 
   // Get rid of invalid values (probably doesn't matter, but might as well do it)
-  if (language > DiscIO::Language::LANGUAGE_UNKNOWN ||
-      language < DiscIO::Language::LANGUAGE_JAPANESE)
-    language = DiscIO::Language::LANGUAGE_UNKNOWN;
+  if (language > DiscIO::Language::Unknown || language < DiscIO::Language::Japanese)
+    language = DiscIO::Language::Unknown;
   return language;
 }
 

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -1127,7 +1127,7 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
 
   const u64 current_time = CoreTiming::GetTicks();
   const u32 ticks_per_second = SystemTimers::GetTicksPerSecond();
-  const bool wii_disc = DVDThread::GetDiscType() == DiscIO::Platform::WII_DISC;
+  const bool wii_disc = DVDThread::GetDiscType() == DiscIO::Platform::WiiDisc;
 
   // Where the DVD read head is (usually parked at the end of the buffer,
   // unless we've interrupted it mid-buffer-read).

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -194,7 +194,7 @@ public:
   u16 GetTitleVersion() const;
   u16 GetGroupId() const;
 
-  // Provides a best guess for the region. Might be inaccurate or UNKNOWN_REGION.
+  // Provides a best guess for the region. Might be inaccurate or Region::Unknown.
   DiscIO::Region GetRegion() const;
 
   // Constructs a 6-character game ID in the format typically used by Dolphin.

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -23,25 +23,25 @@ static std::string GetLanguageCode(DiscIO::Language language)
 {
   switch (language)
   {
-  case DiscIO::Language::LANGUAGE_JAPANESE:
+  case DiscIO::Language::Japanese:
     return "ja";
-  case DiscIO::Language::LANGUAGE_ENGLISH:
+  case DiscIO::Language::English:
     return "en";
-  case DiscIO::Language::LANGUAGE_GERMAN:
+  case DiscIO::Language::German:
     return "de";
-  case DiscIO::Language::LANGUAGE_FRENCH:
+  case DiscIO::Language::French:
     return "fr";
-  case DiscIO::Language::LANGUAGE_SPANISH:
+  case DiscIO::Language::Spanish:
     return "es";
-  case DiscIO::Language::LANGUAGE_ITALIAN:
+  case DiscIO::Language::Italian:
     return "it";
-  case DiscIO::Language::LANGUAGE_DUTCH:
+  case DiscIO::Language::Dutch:
     return "nl";
-  case DiscIO::Language::LANGUAGE_SIMPLIFIED_CHINESE:
+  case DiscIO::Language::SimplifiedChinese:
     return "zh_CN";
-  case DiscIO::Language::LANGUAGE_TRADITIONAL_CHINESE:
+  case DiscIO::Language::TraditionalChinese:
     return "zh_TW";
-  case DiscIO::Language::LANGUAGE_KOREAN:
+  case DiscIO::Language::Korean:
     return "ko";
   default:
     return "en";
@@ -95,12 +95,12 @@ static bool IsWiiTitle(const std::string& game_id)
 
 static bool IsJapaneseGCTitle(const std::string& game_id)
 {
-  return IsGCTitle(game_id) && DiscIO::CountrySwitch(game_id[3]) == DiscIO::Country::COUNTRY_JAPAN;
+  return IsGCTitle(game_id) && DiscIO::CountrySwitch(game_id[3]) == DiscIO::Country::Japan;
 }
 
 static bool IsNonJapaneseGCTitle(const std::string& game_id)
 {
-  return IsGCTitle(game_id) && DiscIO::CountrySwitch(game_id[3]) != DiscIO::Country::COUNTRY_JAPAN;
+  return IsGCTitle(game_id) && DiscIO::CountrySwitch(game_id[3]) != DiscIO::Country::Japan;
 }
 
 // Note that this function will not overwrite entries that already are in the maps

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -208,12 +208,11 @@ std::string SystemUpdater::GetDeviceRegion()
   if (tmd.IsValid())
   {
     const DiscIO::Region region = tmd.GetRegion();
-    static const std::map<DiscIO::Region, std::string> regions = {
-        {DiscIO::Region::NTSC_J, "JPN"},
-        {DiscIO::Region::NTSC_U, "USA"},
-        {DiscIO::Region::PAL, "EUR"},
-        {DiscIO::Region::NTSC_K, "KOR"},
-        {DiscIO::Region::UNKNOWN_REGION, "EUR"}};
+    static const std::map<DiscIO::Region, std::string> regions = {{DiscIO::Region::NTSC_J, "JPN"},
+                                                                  {DiscIO::Region::NTSC_U, "USA"},
+                                                                  {DiscIO::Region::PAL, "EUR"},
+                                                                  {DiscIO::Region::NTSC_K, "KOR"},
+                                                                  {DiscIO::Region::Unknown, "EUR"}};
     return regions.at(region);
   }
   return "";

--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -153,7 +153,7 @@ void ExportDirectory(const Volume& volume, const Partition& partition, const Fil
 
 bool ExportWiiUnencryptedHeader(const Volume& volume, const std::string& export_filename)
 {
-  if (volume.GetVolumeType() != Platform::WII_DISC)
+  if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
   return ExportData(volume, PARTITION_NONE, 0, 0x100, export_filename);
@@ -161,7 +161,7 @@ bool ExportWiiUnencryptedHeader(const Volume& volume, const std::string& export_
 
 bool ExportWiiRegionData(const Volume& volume, const std::string& export_filename)
 {
-  if (volume.GetVolumeType() != Platform::WII_DISC)
+  if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
   return ExportData(volume, PARTITION_NONE, 0x4E000, 0x20, export_filename);
@@ -170,7 +170,7 @@ bool ExportWiiRegionData(const Volume& volume, const std::string& export_filenam
 bool ExportTicket(const Volume& volume, const Partition& partition,
                   const std::string& export_filename)
 {
-  if (volume.GetVolumeType() != Platform::WII_DISC)
+  if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
   return ExportData(volume, PARTITION_NONE, partition.offset, 0x2a4, export_filename);
@@ -178,7 +178,7 @@ bool ExportTicket(const Volume& volume, const Partition& partition,
 
 bool ExportTMD(const Volume& volume, const Partition& partition, const std::string& export_filename)
 {
-  if (volume.GetVolumeType() != Platform::WII_DISC)
+  if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
   const std::optional<u32> size = volume.ReadSwapped<u32>(partition.offset + 0x2a4, PARTITION_NONE);
@@ -193,7 +193,7 @@ bool ExportTMD(const Volume& volume, const Partition& partition, const std::stri
 bool ExportCertificateChain(const Volume& volume, const Partition& partition,
                             const std::string& export_filename)
 {
-  if (volume.GetVolumeType() != Platform::WII_DISC)
+  if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
   const std::optional<u32> size = volume.ReadSwapped<u32>(partition.offset + 0x2ac, PARTITION_NONE);
@@ -208,7 +208,7 @@ bool ExportCertificateChain(const Volume& volume, const Partition& partition,
 bool ExportH3Hashes(const Volume& volume, const Partition& partition,
                     const std::string& export_filename)
 {
-  if (volume.GetVolumeType() != Platform::WII_DISC)
+  if (volume.GetVolumeType() != Platform::WiiDisc)
     return false;
 
   const std::optional<u64> offset =
@@ -351,7 +351,7 @@ bool ExportSystemData(const Volume& volume, const Partition& partition,
   success &= ExportDOL(volume, partition, export_folder + "/sys/main.dol");
   success &= ExportFST(volume, partition, export_folder + "/sys/fst.bin");
 
-  if (volume.GetVolumeType() == Platform::WII_DISC)
+  if (volume.GetVolumeType() == Platform::WiiDisc)
   {
     File::CreateFullPath(export_folder + "/disc/");
     success &= ExportWiiUnencryptedHeader(volume, export_folder + "/disc/header.bin");

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -20,43 +20,43 @@ std::string GetName(Country country, bool translate)
 
   switch (country)
   {
-  case Country::COUNTRY_EUROPE:
+  case Country::Europe:
     name = _trans("Europe");
     break;
-  case Country::COUNTRY_JAPAN:
+  case Country::Japan:
     name = _trans("Japan");
     break;
-  case Country::COUNTRY_USA:
+  case Country::USA:
     name = _trans("USA");
     break;
-  case Country::COUNTRY_AUSTRALIA:
+  case Country::Australia:
     name = _trans("Australia");
     break;
-  case Country::COUNTRY_FRANCE:
+  case Country::France:
     name = _trans("France");
     break;
-  case Country::COUNTRY_GERMANY:
+  case Country::Germany:
     name = _trans("Germany");
     break;
-  case Country::COUNTRY_ITALY:
+  case Country::Italy:
     name = _trans("Italy");
     break;
-  case Country::COUNTRY_KOREA:
+  case Country::Korea:
     name = _trans("Korea");
     break;
-  case Country::COUNTRY_NETHERLANDS:
+  case Country::Netherlands:
     name = _trans("Netherlands");
     break;
-  case Country::COUNTRY_RUSSIA:
+  case Country::Russia:
     name = _trans("Russia");
     break;
-  case Country::COUNTRY_SPAIN:
+  case Country::Spain:
     name = _trans("Spain");
     break;
-  case Country::COUNTRY_TAIWAN:
+  case Country::Taiwan:
     name = _trans("Taiwan");
     break;
-  case Country::COUNTRY_WORLD:
+  case Country::World:
     name = _trans("World");
     break;
   default:
@@ -73,34 +73,34 @@ std::string GetName(Language language, bool translate)
 
   switch (language)
   {
-  case Language::LANGUAGE_JAPANESE:
+  case Language::Japanese:
     name = _trans("Japanese");
     break;
-  case Language::LANGUAGE_ENGLISH:
+  case Language::English:
     name = _trans("English");
     break;
-  case Language::LANGUAGE_GERMAN:
+  case Language::German:
     name = _trans("German");
     break;
-  case Language::LANGUAGE_FRENCH:
+  case Language::French:
     name = _trans("French");
     break;
-  case Language::LANGUAGE_SPANISH:
+  case Language::Spanish:
     name = _trans("Spanish");
     break;
-  case Language::LANGUAGE_ITALIAN:
+  case Language::Italian:
     name = _trans("Italian");
     break;
-  case Language::LANGUAGE_DUTCH:
+  case Language::Dutch:
     name = _trans("Dutch");
     break;
-  case Language::LANGUAGE_SIMPLIFIED_CHINESE:
+  case Language::SimplifiedChinese:
     name = _trans("Simplified Chinese");
     break;
-  case Language::LANGUAGE_TRADITIONAL_CHINESE:
+  case Language::TraditionalChinese:
     name = _trans("Traditional Chinese");
     break;
-  case Language::LANGUAGE_KOREAN:
+  case Language::Korean:
     name = _trans("Korean");
     break;
   default:
@@ -113,12 +113,12 @@ std::string GetName(Language language, bool translate)
 
 bool IsDisc(Platform volume_type)
 {
-  return volume_type == Platform::GAMECUBE_DISC || volume_type == Platform::WII_DISC;
+  return volume_type == Platform::GameCubeDisc || volume_type == Platform::WiiDisc;
 }
 
 bool IsWii(Platform volume_type)
 {
-  return volume_type == Platform::WII_DISC || volume_type == Platform::WII_WAD;
+  return volume_type == Platform::WiiDisc || volume_type == Platform::WiiWAD;
 }
 
 bool IsNTSC(Region region)
@@ -133,15 +133,15 @@ Country TypicalCountryForRegion(Region region)
   switch (region)
   {
   case Region::NTSC_J:
-    return Country::COUNTRY_JAPAN;
+    return Country::Japan;
   case Region::NTSC_U:
-    return Country::COUNTRY_USA;
+    return Country::USA;
   case Region::PAL:
-    return Country::COUNTRY_EUROPE;
+    return Country::Europe;
   case Region::NTSC_K:
-    return Country::COUNTRY_KOREA;
+    return Country::Korea;
   default:
-    return Country::COUNTRY_UNKNOWN;
+    return Country::Unknown;
   }
 }
 
@@ -185,7 +185,7 @@ Region RegionSwitchWii(u8 country_code)
     return Region::NTSC_K;
 
   default:
-    return Region::UNKNOWN_REGION;
+    return Region::Unknown;
   }
 }
 
@@ -195,66 +195,66 @@ Country CountrySwitch(u8 country_code)
   {
   // Worldwide
   case 'A':
-    return Country::COUNTRY_WORLD;
+    return Country::World;
 
   // PAL
   case 'D':
-    return Country::COUNTRY_GERMANY;
+    return Country::Germany;
 
   case 'X':  // Used by a couple PAL games
   case 'Y':  // German, French
   case 'L':  // Japanese import to PAL regions
   case 'M':  // Japanese import to PAL regions
   case 'P':
-    return Country::COUNTRY_EUROPE;
+    return Country::Europe;
 
   case 'U':
-    return Country::COUNTRY_AUSTRALIA;
+    return Country::Australia;
 
   case 'F':
-    return Country::COUNTRY_FRANCE;
+    return Country::France;
 
   case 'I':
-    return Country::COUNTRY_ITALY;
+    return Country::Italy;
 
   case 'H':
-    return Country::COUNTRY_NETHERLANDS;
+    return Country::Netherlands;
 
   case 'R':
-    return Country::COUNTRY_RUSSIA;
+    return Country::Russia;
 
   case 'S':
-    return Country::COUNTRY_SPAIN;
+    return Country::Spain;
 
   // NTSC
   case 'E':
   case 'N':  // Japanese import to USA and other NTSC regions
   case 'Z':  // Prince of Persia - The Forgotten Sands (Wii)
   case 'B':  // Ufouria: The Saga (Virtual Console)
-    return Country::COUNTRY_USA;
+    return Country::USA;
 
   case 'J':
-    return Country::COUNTRY_JAPAN;
+    return Country::Japan;
 
   case 'K':
   case 'Q':  // Korea with Japanese language
   case 'T':  // Korea with English language
-    return Country::COUNTRY_KOREA;
+    return Country::Korea;
 
   case 'W':
-    return Country::COUNTRY_TAIWAN;
+    return Country::Taiwan;
 
   default:
     if (country_code > 'A')  // Silently ignore IOS wads
       WARN_LOG(DISCIO, "Unknown Country Code! %c", country_code);
-    return Country::COUNTRY_UNKNOWN;
+    return Country::Unknown;
   }
 }
 
 Region GetSysMenuRegion(u16 title_version)
 {
   if (title_version == 33)
-    return Region::UNKNOWN_REGION;  // 1.0 uses 33 as the version number in all regions
+    return Region::Unknown;  // 1.0 uses 33 as the version number in all regions
 
   switch (title_version & 0xf)
   {
@@ -267,7 +267,7 @@ Region GetSysMenuRegion(u16 title_version)
   case 6:
     return Region::NTSC_K;
   default:
-    return Region::UNKNOWN_REGION;
+    return Region::Unknown;
   }
 }
 
@@ -292,7 +292,7 @@ std::string GetSysMenuVersionString(u16 title_version)
   case Region::NTSC_K:
     region_letter = "K";
     break;
-  case Region::UNKNOWN_REGION:
+  case Region::Unknown:
     WARN_LOG(DISCIO, "Unknown region for Wii Menu version %u", title_version);
     break;
   }

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -14,40 +14,40 @@ namespace DiscIO
 
 enum class Platform
 {
-  GAMECUBE_DISC = 0,
-  WII_DISC,
-  WII_WAD,
-  ELF_DOL,
-  NUMBER_OF_PLATFORMS
+  GameCubeDisc = 0,
+  WiiDisc,
+  WiiWAD,
+  ELFOrDOL,
+  NumberOfPlatforms
 };
 
 enum class Country
 {
-  COUNTRY_EUROPE = 0,
-  COUNTRY_JAPAN,
-  COUNTRY_USA,
-  COUNTRY_AUSTRALIA,
-  COUNTRY_FRANCE,
-  COUNTRY_GERMANY,
-  COUNTRY_ITALY,
-  COUNTRY_KOREA,
-  COUNTRY_NETHERLANDS,
-  COUNTRY_RUSSIA,
-  COUNTRY_SPAIN,
-  COUNTRY_TAIWAN,
-  COUNTRY_WORLD,
-  COUNTRY_UNKNOWN,
-  NUMBER_OF_COUNTRIES
+  Europe = 0,
+  Japan,
+  USA,
+  Australia,
+  France,
+  Germany,
+  Italy,
+  Korea,
+  Netherlands,
+  Russia,
+  Spain,
+  Taiwan,
+  World,
+  Unknown,
+  NumberOfCountries
 };
 
 // Regions 0 - 2 and 4 match Nintendo's GameCube/Wii region numbering.
 enum class Region
 {
-  NTSC_J = 0,          // Japan and Taiwan (and South Korea for GameCube only)
-  NTSC_U = 1,          // Mainly North America
-  PAL = 2,             // Mainly Europe and Oceania
-  UNKNOWN_REGION = 3,  // 3 seems to be unused? Anyway, we need an UNKNOWN_REGION. Let's put it here
-  NTSC_K = 4           // South Korea (Wii only)
+  NTSC_J = 0,   // Japan and Taiwan (and South Korea for GameCube only)
+  NTSC_U = 1,   // Mainly North America
+  PAL = 2,      // Mainly Europe and Oceania
+  Unknown = 3,  // 3 seems to be unused? Anyway, we need an Unknown entry. Let's put it here
+  NTSC_K = 4    // South Korea (Wii only)
 };
 
 // Languages 0 - 9 match Nintendo's Wii language numbering.
@@ -55,17 +55,17 @@ enum class Region
 // NTSC GameCubes only support one language and thus don't number languages.
 enum class Language
 {
-  LANGUAGE_JAPANESE = 0,
-  LANGUAGE_ENGLISH = 1,
-  LANGUAGE_GERMAN = 2,
-  LANGUAGE_FRENCH = 3,
-  LANGUAGE_SPANISH = 4,
-  LANGUAGE_ITALIAN = 5,
-  LANGUAGE_DUTCH = 6,
-  LANGUAGE_SIMPLIFIED_CHINESE = 7,
-  LANGUAGE_TRADITIONAL_CHINESE = 8,
-  LANGUAGE_KOREAN = 9,
-  LANGUAGE_UNKNOWN
+  Japanese = 0,
+  English = 1,
+  German = 2,
+  French = 3,
+  Spanish = 4,
+  Italian = 5,
+  Dutch = 6,
+  SimplifiedChinese = 7,
+  TraditionalChinese = 8,
+  Korean = 9,
+  Unknown
 };
 
 std::string GetName(Country country, bool translate);

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -76,14 +76,14 @@ Region VolumeGC::GetRegion() const
 {
   const std::optional<u32> region_code = ReadSwapped<u32>(0x458, PARTITION_NONE);
   if (!region_code)
-    return Region::UNKNOWN_REGION;
+    return Region::Unknown;
   const Region region = static_cast<Region>(*region_code);
-  return region <= Region::PAL ? region : Region::UNKNOWN_REGION;
+  return region <= Region::PAL ? region : Region::Unknown;
 }
 
 Country VolumeGC::GetCountry(const Partition& partition) const
 {
-  // The 0 that we use as a default value is mapped to COUNTRY_UNKNOWN and UNKNOWN_REGION
+  // The 0 that we use as a default value is mapped to Country::Unknown and Region::Unknown
   const u8 country = ReadSwapped<u8>(3, partition).value_or(0);
   const Region region = GetRegion();
 
@@ -93,7 +93,7 @@ Country VolumeGC::GetCountry(const Partition& partition) const
   // W means Taiwan for Wii games, but on the GC, it's used for English-language Korean releases.
   // (There doesn't seem to be any pattern to which of E and W is used for Korean GC releases.)
   if (region == Region::NTSC_J && (country == 'E' || country == 'K' || country == 'W'))
-    return Country::COUNTRY_KOREA;
+    return Country::Korea;
 
   if (RegionSwitchGC(country) != region)
     return TypicalCountryForRegion(region);
@@ -188,7 +188,7 @@ std::optional<u8> VolumeGC::GetDiscNumber(const Partition& partition) const
 
 Platform VolumeGC::GetVolumeType() const
 {
-  return Platform::GAMECUBE_DISC;
+  return Platform::GameCubeDisc;
 }
 
 VolumeGC::ConvertedGCBanner VolumeGC::LoadBannerFile() const
@@ -228,18 +228,17 @@ VolumeGC::ConvertedGCBanner VolumeGC::ExtractBannerInformation(const GCBanner& b
   ConvertedGCBanner banner;
 
   u32 number_of_languages = 0;
-  Language start_language = Language::LANGUAGE_UNKNOWN;
+  Language start_language = Language::Unknown;
 
   if (is_bnr1)  // NTSC
   {
-    bool is_japanese = GetRegion() == Region::NTSC_J;
     number_of_languages = 1;
-    start_language = is_japanese ? Language::LANGUAGE_JAPANESE : Language::LANGUAGE_ENGLISH;
+    start_language = GetRegion() == Region::NTSC_J ? Language::Japanese : Language::English;
   }
   else  // PAL
   {
     number_of_languages = 6;
-    start_language = Language::LANGUAGE_ENGLISH;
+    start_language = Language::English;
   }
 
   banner.image_width = GC_BANNER_WIDTH;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -75,14 +75,14 @@ const FileSystem* VolumeWAD::GetFileSystem(const Partition& partition) const
 Region VolumeWAD::GetRegion() const
 {
   if (!m_tmd.IsValid())
-    return Region::UNKNOWN_REGION;
+    return Region::Unknown;
   return m_tmd.GetRegion();
 }
 
 Country VolumeWAD::GetCountry(const Partition& partition) const
 {
   if (!m_tmd.IsValid())
-    return Country::COUNTRY_UNKNOWN;
+    return Country::Unknown;
 
   u8 country_code = static_cast<u8>(m_tmd.GetTitleId() & 0xff);
   if (country_code == 2)  // SYSMENU
@@ -130,7 +130,7 @@ std::optional<u16> VolumeWAD::GetRevision(const Partition& partition) const
 
 Platform VolumeWAD::GetVolumeType() const
 {
-  return Platform::WII_WAD;
+  return Platform::WiiWAD;
 }
 
 std::map<Language, std::string> VolumeWAD::GetLongNames() const

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -48,7 +48,7 @@ public:
     return "";
   }
   Platform GetVolumeType() const override;
-  // Provides a best guess for the region. Might be inaccurate or UNKNOWN_REGION.
+  // Provides a best guess for the region. Might be inaccurate or Region::Unknown.
   Region GetRegion() const override;
   Country GetCountry(const Partition& partition = PARTITION_NONE) const override;
 

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -258,14 +258,14 @@ Region VolumeWii::GetRegion() const
 {
   const std::optional<u32> region_code = m_pReader->ReadSwapped<u32>(0x4E000);
   if (!region_code)
-    return Region::UNKNOWN_REGION;
+    return Region::Unknown;
   const Region region = static_cast<Region>(*region_code);
-  return region <= Region::NTSC_K ? region : Region::UNKNOWN_REGION;
+  return region <= Region::NTSC_K ? region : Region::Unknown;
 }
 
 Country VolumeWii::GetCountry(const Partition& partition) const
 {
-  // The 0 that we use as a default value is mapped to COUNTRY_UNKNOWN and UNKNOWN_REGION
+  // The 0 that we use as a default value is mapped to Country::Unknown and Region::Unknown
   u8 country_byte = ReadSwapped<u8>(3, partition).value_or(0);
   const Region region = GetRegion();
 
@@ -332,7 +332,7 @@ std::string VolumeWii::GetApploaderDate(const Partition& partition) const
 
 Platform VolumeWii::GetVolumeType() const
 {
-  return Platform::WII_DISC;
+  return Platform::WiiDisc;
 }
 
 std::optional<u8> VolumeWii::GetDiscNumber(const Partition& partition) const

--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -78,7 +78,7 @@ QGroupBox* InfoWidget::CreateBannerDetails()
   CreateLanguageSelector();
 
   layout->addRow(tr("Show Language:"), m_language_selector);
-  if (m_game.GetPlatform() == DiscIO::Platform::GAMECUBE_DISC)
+  if (m_game.GetPlatform() == DiscIO::Platform::GameCubeDisc)
   {
     layout->addRow(tr("Name:"), m_name);
     layout->addRow(tr("Maker:"), m_maker);

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -168,7 +168,7 @@ void GameList::ShowContextMenu(const QPoint&)
   AddAction(menu, tr("&Wiki"), this, &GameList::OpenWiki);
   menu->addSeparator();
 
-  if (platform == DiscIO::Platform::GAMECUBE_DISC || platform == DiscIO::Platform::WII_DISC)
+  if (platform == DiscIO::Platform::GameCubeDisc || platform == DiscIO::Platform::WiiDisc)
   {
     AddAction(menu, tr("Set as &default ISO"), this, &GameList::SetDefaultISO);
     const auto blob_type = game->GetBlobType();
@@ -187,7 +187,7 @@ void GameList::ShowContextMenu(const QPoint&)
     menu->addSeparator();
   }
 
-  if (platform == DiscIO::Platform::WII_DISC)
+  if (platform == DiscIO::Platform::WiiDisc)
   {
     auto* perform_disc_update = AddAction(menu, tr("Perform System Update"), this, [this] {
       WiiUpdate::PerformDiscUpdate(GetSelectedGame()->GetFilePath(), this);
@@ -195,7 +195,7 @@ void GameList::ShowContextMenu(const QPoint&)
     perform_disc_update->setEnabled(!Core::IsRunning() || !SConfig::GetInstance().bWii);
   }
 
-  if (platform == DiscIO::Platform::WII_WAD)
+  if (platform == DiscIO::Platform::WiiWAD)
   {
     QAction* wad_install_action = new QAction(tr("Install to the NAND"), menu);
     QAction* wad_uninstall_action = new QAction(tr("Uninstall from the NAND"), menu);
@@ -218,7 +218,7 @@ void GameList::ShowContextMenu(const QPoint&)
     menu->addSeparator();
   }
 
-  if (platform == DiscIO::Platform::WII_WAD || platform == DiscIO::Platform::WII_DISC)
+  if (platform == DiscIO::Platform::WiiWAD || platform == DiscIO::Platform::WiiDisc)
   {
     AddAction(menu, tr("Open Wii &save folder"), this, &GameList::OpenSaveFolder);
     AddAction(menu, tr("Export Wii save (Experimental)"), this, &GameList::ExportWiiSave);
@@ -278,7 +278,7 @@ void GameList::CompressISO()
 
   const bool compressed = (file->GetBlobType() == DiscIO::BlobType::GCZ);
 
-  if (!compressed && file->GetPlatform() == DiscIO::Platform::WII_DISC)
+  if (!compressed && file->GetPlatform() == DiscIO::Platform::WiiDisc)
   {
     QMessageBox wii_warning(this);
     wii_warning.setIcon(QMessageBox::Warning);
@@ -319,7 +319,7 @@ void GameList::CompressISO()
   else
   {
     good = DiscIO::CompressFileToBlob(original_path, dst_path.toStdString(),
-                                      file->GetPlatform() == DiscIO::Platform::WII_DISC ? 1 : 0,
+                                      file->GetPlatform() == DiscIO::Platform::WiiDisc ? 1 : 0,
                                       16384, &CompressCB, &progress_dialog);
   }
 

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -157,13 +157,13 @@ bool GameListModel::ShouldDisplayGameListItem(int index) const
   const bool show_platform = [&game] {
     switch (game.GetPlatform())
     {
-    case DiscIO::Platform::GAMECUBE_DISC:
+    case DiscIO::Platform::GameCubeDisc:
       return SConfig::GetInstance().m_ListGC;
-    case DiscIO::Platform::WII_DISC:
+    case DiscIO::Platform::WiiDisc:
       return SConfig::GetInstance().m_ListWii;
-    case DiscIO::Platform::WII_WAD:
+    case DiscIO::Platform::WiiWAD:
       return SConfig::GetInstance().m_ListWad;
-    case DiscIO::Platform::ELF_DOL:
+    case DiscIO::Platform::ELFOrDOL:
       return SConfig::GetInstance().m_ListElfDol;
     default:
       return false;
@@ -175,33 +175,33 @@ bool GameListModel::ShouldDisplayGameListItem(int index) const
 
   switch (game.GetCountry())
   {
-  case DiscIO::Country::COUNTRY_AUSTRALIA:
+  case DiscIO::Country::Australia:
     return SConfig::GetInstance().m_ListAustralia;
-  case DiscIO::Country::COUNTRY_EUROPE:
+  case DiscIO::Country::Europe:
     return SConfig::GetInstance().m_ListPal;
-  case DiscIO::Country::COUNTRY_FRANCE:
+  case DiscIO::Country::France:
     return SConfig::GetInstance().m_ListFrance;
-  case DiscIO::Country::COUNTRY_GERMANY:
+  case DiscIO::Country::Germany:
     return SConfig::GetInstance().m_ListGermany;
-  case DiscIO::Country::COUNTRY_ITALY:
+  case DiscIO::Country::Italy:
     return SConfig::GetInstance().m_ListItaly;
-  case DiscIO::Country::COUNTRY_JAPAN:
+  case DiscIO::Country::Japan:
     return SConfig::GetInstance().m_ListJap;
-  case DiscIO::Country::COUNTRY_KOREA:
+  case DiscIO::Country::Korea:
     return SConfig::GetInstance().m_ListKorea;
-  case DiscIO::Country::COUNTRY_NETHERLANDS:
+  case DiscIO::Country::Netherlands:
     return SConfig::GetInstance().m_ListNetherlands;
-  case DiscIO::Country::COUNTRY_RUSSIA:
+  case DiscIO::Country::Russia:
     return SConfig::GetInstance().m_ListRussia;
-  case DiscIO::Country::COUNTRY_SPAIN:
+  case DiscIO::Country::Spain:
     return SConfig::GetInstance().m_ListSpain;
-  case DiscIO::Country::COUNTRY_TAIWAN:
+  case DiscIO::Country::Taiwan:
     return SConfig::GetInstance().m_ListTaiwan;
-  case DiscIO::Country::COUNTRY_USA:
+  case DiscIO::Country::USA:
     return SConfig::GetInstance().m_ListUsa;
-  case DiscIO::Country::COUNTRY_WORLD:
+  case DiscIO::Country::World:
     return SConfig::GetInstance().m_ListWorld;
-  case DiscIO::Country::COUNTRY_UNKNOWN:
+  case DiscIO::Country::Unknown:
   default:
     return SConfig::GetInstance().m_ListUnknown;
   }

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -172,13 +172,13 @@ static bool ShouldDisplayGameListItem(const UICommon::GameFile& item)
   const bool show_platform = [&item] {
     switch (item.GetPlatform())
     {
-    case DiscIO::Platform::GAMECUBE_DISC:
+    case DiscIO::Platform::GameCubeDisc:
       return SConfig::GetInstance().m_ListGC;
-    case DiscIO::Platform::WII_DISC:
+    case DiscIO::Platform::WiiDisc:
       return SConfig::GetInstance().m_ListWii;
-    case DiscIO::Platform::WII_WAD:
+    case DiscIO::Platform::WiiWAD:
       return SConfig::GetInstance().m_ListWad;
-    case DiscIO::Platform::ELF_DOL:
+    case DiscIO::Platform::ELFOrDOL:
       return SConfig::GetInstance().m_ListElfDol;
     default:
       return false;
@@ -190,33 +190,33 @@ static bool ShouldDisplayGameListItem(const UICommon::GameFile& item)
 
   switch (item.GetCountry())
   {
-  case DiscIO::Country::COUNTRY_AUSTRALIA:
+  case DiscIO::Country::Australia:
     return SConfig::GetInstance().m_ListAustralia;
-  case DiscIO::Country::COUNTRY_EUROPE:
+  case DiscIO::Country::Europe:
     return SConfig::GetInstance().m_ListPal;
-  case DiscIO::Country::COUNTRY_FRANCE:
+  case DiscIO::Country::France:
     return SConfig::GetInstance().m_ListFrance;
-  case DiscIO::Country::COUNTRY_GERMANY:
+  case DiscIO::Country::Germany:
     return SConfig::GetInstance().m_ListGermany;
-  case DiscIO::Country::COUNTRY_ITALY:
+  case DiscIO::Country::Italy:
     return SConfig::GetInstance().m_ListItaly;
-  case DiscIO::Country::COUNTRY_JAPAN:
+  case DiscIO::Country::Japan:
     return SConfig::GetInstance().m_ListJap;
-  case DiscIO::Country::COUNTRY_KOREA:
+  case DiscIO::Country::Korea:
     return SConfig::GetInstance().m_ListKorea;
-  case DiscIO::Country::COUNTRY_NETHERLANDS:
+  case DiscIO::Country::Netherlands:
     return SConfig::GetInstance().m_ListNetherlands;
-  case DiscIO::Country::COUNTRY_RUSSIA:
+  case DiscIO::Country::Russia:
     return SConfig::GetInstance().m_ListRussia;
-  case DiscIO::Country::COUNTRY_SPAIN:
+  case DiscIO::Country::Spain:
     return SConfig::GetInstance().m_ListSpain;
-  case DiscIO::Country::COUNTRY_TAIWAN:
+  case DiscIO::Country::Taiwan:
     return SConfig::GetInstance().m_ListTaiwan;
-  case DiscIO::Country::COUNTRY_USA:
+  case DiscIO::Country::USA:
     return SConfig::GetInstance().m_ListUsa;
-  case DiscIO::Country::COUNTRY_WORLD:
+  case DiscIO::Country::World:
     return SConfig::GetInstance().m_ListWorld;
-  case DiscIO::Country::COUNTRY_UNKNOWN:
+  case DiscIO::Country::Unknown:
   default:
     return SConfig::GetInstance().m_ListUnknown;
   }
@@ -328,45 +328,36 @@ void GameListCtrl::InitBitmaps()
   AssignImageList(img_list, wxIMAGE_LIST_SMALL);
 
   auto& flag_indexes = m_image_indexes.flag;
-  flag_indexes.resize(static_cast<size_t>(DiscIO::Country::NUMBER_OF_COUNTRIES));
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_JAPAN,
-             "Flag_Japan");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_EUROPE,
-             "Flag_Europe");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_USA,
-             "Flag_USA");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_AUSTRALIA,
+  flag_indexes.resize(static_cast<size_t>(DiscIO::Country::NumberOfCountries));
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Japan, "Flag_Japan");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Europe, "Flag_Europe");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::USA, "Flag_USA");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Australia,
              "Flag_Australia");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_FRANCE,
-             "Flag_France");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_GERMANY,
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::France, "Flag_France");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Germany,
              "Flag_Germany");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_ITALY,
-             "Flag_Italy");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_KOREA,
-             "Flag_Korea");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_NETHERLANDS,
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Italy, "Flag_Italy");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Korea, "Flag_Korea");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Netherlands,
              "Flag_Netherlands");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_RUSSIA,
-             "Flag_Russia");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_SPAIN,
-             "Flag_Spain");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_TAIWAN,
-             "Flag_Taiwan");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_WORLD,
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Russia, "Flag_Russia");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Spain, "Flag_Spain");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Taiwan, "Flag_Taiwan");
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::World,
              "Flag_International");
-  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::COUNTRY_UNKNOWN,
+  InitBitmap(img_list, &flag_indexes, this, flag_bmp_size, DiscIO::Country::Unknown,
              "Flag_Unknown");
 
   auto& platform_indexes = m_image_indexes.platform;
-  platform_indexes.resize(static_cast<size_t>(DiscIO::Platform::NUMBER_OF_PLATFORMS));
-  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::GAMECUBE_DISC,
+  platform_indexes.resize(static_cast<size_t>(DiscIO::Platform::NumberOfPlatforms));
+  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::GameCubeDisc,
              "Platform_Gamecube");
-  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::WII_DISC,
+  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::WiiDisc,
              "Platform_Wii");
-  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::WII_WAD,
+  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::WiiWAD,
              "Platform_Wad");
-  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::ELF_DOL,
+  InitBitmap(img_list, &platform_indexes, this, platform_bmp_size, DiscIO::Platform::ELFOrDOL,
              "Platform_File");
 
   auto& emu_state_indexes = m_image_indexes.emu_state;
@@ -954,13 +945,13 @@ void GameListCtrl::OnRightClick(wxMouseEvent& event)
       wxMenu popupMenu;
       DiscIO::Platform platform = selected_iso->GetPlatform();
 
-      if (platform != DiscIO::Platform::ELF_DOL)
+      if (platform != DiscIO::Platform::ELFOrDOL)
       {
         popupMenu.Append(IDM_PROPERTIES, _("&Properties"));
         popupMenu.Append(IDM_GAME_WIKI, _("&Wiki"));
         popupMenu.AppendSeparator();
       }
-      if (platform == DiscIO::Platform::WII_DISC || platform == DiscIO::Platform::WII_WAD)
+      if (platform == DiscIO::Platform::WiiDisc || platform == DiscIO::Platform::WiiWAD)
       {
         auto* const open_save_folder_item =
             popupMenu.Append(IDM_OPEN_SAVE_FOLDER, _("Open Wii &save folder"));
@@ -979,7 +970,7 @@ void GameListCtrl::OnRightClick(wxMouseEvent& event)
       }
       popupMenu.Append(IDM_OPEN_CONTAINING_FOLDER, _("Open &containing folder"));
 
-      if (platform != DiscIO::Platform::ELF_DOL)
+      if (platform != DiscIO::Platform::ELFOrDOL)
         popupMenu.AppendCheckItem(IDM_SET_DEFAULT_ISO, _("Set as &default ISO"));
 
       // First we have to decide a starting value when we append it
@@ -989,7 +980,7 @@ void GameListCtrl::OnRightClick(wxMouseEvent& event)
       popupMenu.AppendSeparator();
       popupMenu.Append(IDM_DELETE_ISO, _("&Delete File..."));
 
-      if (platform == DiscIO::Platform::GAMECUBE_DISC || platform == DiscIO::Platform::WII_DISC)
+      if (platform == DiscIO::Platform::GameCubeDisc || platform == DiscIO::Platform::WiiDisc)
       {
         if (selected_iso->GetBlobType() == DiscIO::BlobType::GCZ)
           popupMenu.Append(IDM_COMPRESS_ISO, _("Decompress ISO..."));
@@ -1000,14 +991,14 @@ void GameListCtrl::OnRightClick(wxMouseEvent& event)
         changeDiscItem->Enable(Core::IsRunning());
       }
 
-      if (platform == DiscIO::Platform::WII_DISC)
+      if (platform == DiscIO::Platform::WiiDisc)
       {
         auto* const perform_update_item =
             popupMenu.Append(IDM_LIST_PERFORM_DISC_UPDATE, _("Perform System Update"));
         perform_update_item->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
       }
 
-      if (platform == DiscIO::Platform::WII_WAD)
+      if (platform == DiscIO::Platform::WiiWAD)
       {
         auto* const install_wad_item =
             popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to the NAND"));
@@ -1208,8 +1199,8 @@ void GameListCtrl::CompressSelection(bool _compress)
   for (const UICommon::GameFile* iso : GetAllSelectedISOs())
   {
     // Don't include items that we can't do anything with
-    if (iso->GetPlatform() != DiscIO::Platform::GAMECUBE_DISC &&
-        iso->GetPlatform() != DiscIO::Platform::WII_DISC)
+    if (iso->GetPlatform() != DiscIO::Platform::GameCubeDisc &&
+        iso->GetPlatform() != DiscIO::Platform::WiiDisc)
       continue;
     if (iso->GetBlobType() != DiscIO::BlobType::PLAIN &&
         iso->GetBlobType() != DiscIO::BlobType::GCZ)
@@ -1220,7 +1211,7 @@ void GameListCtrl::CompressSelection(bool _compress)
     // Show the Wii compression warning if it's relevant and it hasn't been shown already
     if (!wii_compression_warning_accepted && _compress &&
         iso->GetBlobType() != DiscIO::BlobType::GCZ &&
-        iso->GetPlatform() == DiscIO::Platform::WII_DISC)
+        iso->GetPlatform() == DiscIO::Platform::WiiDisc)
     {
       if (WiiCompressWarning())
         wii_compression_warning_accepted = true;
@@ -1269,7 +1260,7 @@ void GameListCtrl::CompressSelection(bool _compress)
 
         all_good &=
             DiscIO::CompressFileToBlob(iso->GetFilePath(), OutputFileName,
-                                       (iso->GetPlatform() == DiscIO::Platform::WII_DISC) ? 1 : 0,
+                                       (iso->GetPlatform() == DiscIO::Platform::WiiDisc) ? 1 : 0,
                                        16384, &MultiCompressCB, &progress);
       }
       else if (iso->GetBlobType() == DiscIO::BlobType::GCZ && !_compress)
@@ -1277,7 +1268,7 @@ void GameListCtrl::CompressSelection(bool _compress)
         std::string FileName;
         SplitPath(iso->GetFilePath(), nullptr, &FileName, nullptr);
         progress.current_filename = FileName;
-        if (iso->GetPlatform() == DiscIO::Platform::WII_DISC)
+        if (iso->GetPlatform() == DiscIO::Platform::WiiDisc)
           FileName.append(".iso");
         else
           FileName.append(".gcm");
@@ -1328,7 +1319,7 @@ void GameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED(event))
     if (is_compressed)
     {
       wxString FileType;
-      if (iso->GetPlatform() == DiscIO::Platform::WII_DISC)
+      if (iso->GetPlatform() == DiscIO::Platform::WiiDisc)
         FileType = _("All Wii ISO files (iso)") + "|*.iso";
       else
         FileType = _("All GameCube GCM files (gcm)") + "|*.gcm";
@@ -1339,7 +1330,7 @@ void GameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED(event))
     }
     else
     {
-      if (iso->GetPlatform() == DiscIO::Platform::WII_DISC && !WiiCompressWarning())
+      if (iso->GetPlatform() == DiscIO::Platform::WiiDisc && !WiiCompressWarning())
         return;
 
       path = wxFileSelector(_("Save compressed GCM/ISO"), StrToWxStr(FilePath),
@@ -1370,7 +1361,7 @@ void GameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED(event))
     else
       all_good = DiscIO::CompressFileToBlob(
           iso->GetFilePath(), WxStrToStr(path),
-          (iso->GetPlatform() == DiscIO::Platform::WII_DISC) ? 1 : 0, 16384, &CompressCB, &dialog);
+          (iso->GetPlatform() == DiscIO::Platform::WiiDisc) ? 1 : 0, 16384, &CompressCB, &dialog);
   }
 
   if (!all_good)

--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
@@ -364,7 +364,7 @@ void CISOProperties::CreateGUIControls()
 
   wxStaticBoxSizer* const wii_overrides_sizer =
       new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Wii Console"));
-  if (m_open_iso->GetVolumeType() == DiscIO::Platform::GAMECUBE_DISC)
+  if (m_open_iso->GetVolumeType() == DiscIO::Platform::GameCubeDisc)
   {
     wii_overrides_sizer->ShowItems(false);
     m_enable_widescreen->Hide();

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -52,37 +52,37 @@ wxArrayString GetLanguageChoiceStrings(const std::vector<DiscIO::Language>& lang
   {
     switch (language)
     {
-    case DiscIO::Language::LANGUAGE_JAPANESE:
+    case DiscIO::Language::Japanese:
       available_languages.Add(_("Japanese"));
       break;
-    case DiscIO::Language::LANGUAGE_ENGLISH:
+    case DiscIO::Language::English:
       available_languages.Add(_("English"));
       break;
-    case DiscIO::Language::LANGUAGE_GERMAN:
+    case DiscIO::Language::German:
       available_languages.Add(_("German"));
       break;
-    case DiscIO::Language::LANGUAGE_FRENCH:
+    case DiscIO::Language::French:
       available_languages.Add(_("French"));
       break;
-    case DiscIO::Language::LANGUAGE_SPANISH:
+    case DiscIO::Language::Spanish:
       available_languages.Add(_("Spanish"));
       break;
-    case DiscIO::Language::LANGUAGE_ITALIAN:
+    case DiscIO::Language::Italian:
       available_languages.Add(_("Italian"));
       break;
-    case DiscIO::Language::LANGUAGE_DUTCH:
+    case DiscIO::Language::Dutch:
       available_languages.Add(_("Dutch"));
       break;
-    case DiscIO::Language::LANGUAGE_SIMPLIFIED_CHINESE:
+    case DiscIO::Language::SimplifiedChinese:
       available_languages.Add(_("Simplified Chinese"));
       break;
-    case DiscIO::Language::LANGUAGE_TRADITIONAL_CHINESE:
+    case DiscIO::Language::TraditionalChinese:
       available_languages.Add(_("Traditional Chinese"));
       break;
-    case DiscIO::Language::LANGUAGE_KOREAN:
+    case DiscIO::Language::Korean:
       available_languages.Add(_("Korean"));
       break;
-    case DiscIO::Language::LANGUAGE_UNKNOWN:
+    case DiscIO::Language::Unknown:
     default:
       available_languages.Add(_("Unknown"));
       break;
@@ -96,33 +96,33 @@ wxString GetCountryName(DiscIO::Country country)
 {
   switch (country)
   {
-  case DiscIO::Country::COUNTRY_AUSTRALIA:
+  case DiscIO::Country::Australia:
     return _("Australia");
-  case DiscIO::Country::COUNTRY_EUROPE:
+  case DiscIO::Country::Europe:
     return _("Europe");
-  case DiscIO::Country::COUNTRY_FRANCE:
+  case DiscIO::Country::France:
     return _("France");
-  case DiscIO::Country::COUNTRY_ITALY:
+  case DiscIO::Country::Italy:
     return _("Italy");
-  case DiscIO::Country::COUNTRY_GERMANY:
+  case DiscIO::Country::Germany:
     return _("Germany");
-  case DiscIO::Country::COUNTRY_NETHERLANDS:
+  case DiscIO::Country::Netherlands:
     return _("Netherlands");
-  case DiscIO::Country::COUNTRY_RUSSIA:
+  case DiscIO::Country::Russia:
     return _("Russia");
-  case DiscIO::Country::COUNTRY_SPAIN:
+  case DiscIO::Country::Spain:
     return _("Spain");
-  case DiscIO::Country::COUNTRY_USA:
+  case DiscIO::Country::USA:
     return _("USA");
-  case DiscIO::Country::COUNTRY_JAPAN:
+  case DiscIO::Country::Japan:
     return _("Japan");
-  case DiscIO::Country::COUNTRY_KOREA:
+  case DiscIO::Country::Korea:
     return _("Korea");
-  case DiscIO::Country::COUNTRY_TAIWAN:
+  case DiscIO::Country::Taiwan:
     return _("Taiwan");
-  case DiscIO::Country::COUNTRY_WORLD:
+  case DiscIO::Country::World:
     return _("World");
-  case DiscIO::Country::COUNTRY_UNKNOWN:
+  case DiscIO::Country::Unknown:
   default:
     return _("Unknown");
   }

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -48,9 +48,9 @@ const std::string& GameFile::Lookup(DiscIO::Language language,
     return it->second;
 
   // English tends to be a good fallback when the requested language isn't available
-  if (language != DiscIO::Language::LANGUAGE_ENGLISH)
+  if (language != DiscIO::Language::English)
   {
-    it = strings.find(DiscIO::Language::LANGUAGE_ENGLISH);
+    it = strings.find(DiscIO::Language::English);
     if (it != end)
       return it->second;
   }
@@ -70,8 +70,7 @@ GameFile::LookupUsingConfigLanguage(const std::map<DiscIO::Language, std::string
 }
 
 GameFile::GameFile(const std::string& path)
-    : m_file_path(path), m_region(DiscIO::Region::UNKNOWN_REGION),
-      m_country(DiscIO::Country::COUNTRY_UNKNOWN)
+    : m_file_path(path), m_region(DiscIO::Region::Unknown), m_country(DiscIO::Country::Unknown)
 {
   {
     std::string name, extension;
@@ -113,7 +112,7 @@ GameFile::GameFile(const std::string& path)
   {
     m_valid = true;
     m_file_size = File::GetSize(m_file_path);
-    m_platform = DiscIO::Platform::ELF_DOL;
+    m_platform = DiscIO::Platform::ELFOrDOL;
     m_blob_type = DiscIO::BlobType::DIRECTORY;
   }
 }
@@ -123,7 +122,7 @@ bool GameFile::IsValid() const
   if (!m_valid)
     return false;
 
-  if (m_platform == DiscIO::Platform::WII_WAD && !IOS::ES::IsChannel(m_title_id))
+  if (m_platform == DiscIO::Platform::WiiWAD && !IOS::ES::IsChannel(m_title_id))
     return false;
 
   return true;
@@ -131,7 +130,7 @@ bool GameFile::IsValid() const
 
 bool GameFile::CustomNameChanged(const Core::TitleDatabase& title_database)
 {
-  const auto type = m_platform == DiscIO::Platform::WII_WAD ?
+  const auto type = m_platform == DiscIO::Platform::WiiWAD ?
                         Core::TitleDatabase::TitleType::Channel :
                         Core::TitleDatabase::TitleType::Other;
   m_pending.custom_name = title_database.GetTitleName(m_game_id, type);
@@ -273,7 +272,7 @@ std::vector<DiscIO::Language> GameFile::GetLanguages() const
 
 std::string GameFile::GetUniqueIdentifier() const
 {
-  const DiscIO::Language lang = DiscIO::Language::LANGUAGE_ENGLISH;
+  const DiscIO::Language lang = DiscIO::Language::English;
   std::vector<std::string> info;
   if (!GetGameID().empty())
     info.push_back(GetGameID());


### PR DESCRIPTION
Also removing some prefixes that we don't need now that we're using enum classes instead of plain enums.