### PR TITLE
CMakeLists: Remove lzo from the LIBS variable and make linkage private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,6 @@ else()
   include_directories(Externals/LZO)
   set(LZO lzo2)
 endif()
-list(APPEND LIBS ${LZO})
 
 if(NOT APPLE)
   check_lib(PNG libpng png png.h QUIET)

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -280,7 +280,6 @@ PUBLIC
   discio
   enet
   inputcommon
-  ${LZO}
   ${MBEDTLS_LIBRARIES}
   pugixml
   sfml-network
@@ -289,6 +288,9 @@ PUBLIC
   videoogl
   videosoftware
   z
+
+PRIVATE
+  ${LZO}
 )
 
 if (APPLE)


### PR DESCRIPTION
The only place this library is needed (core) is already linked in the core target. Also make the linkage private to create linkage failures if the dependency isn't explicitly linked in elsewhere where it should be.

Reduces the dependency on the LIBS variable.