### PR TITLE
Jit64: Make CheckMergedBranch() a const member function

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -87,7 +87,7 @@ public:
   // Use to extract bytes from a register using the regcache. offset is in bytes.
   Gen::OpArg ExtractFromReg(int reg, int offset);
   void AndWithMask(Gen::X64Reg reg, u32 mask);
-  bool CheckMergedBranch(u32 crf);
+  bool CheckMergedBranch(u32 crf) const;
   void DoMergedBranch();
   void DoMergedBranchCondition();
   void DoMergedBranchImmediate(s64 val);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -350,7 +350,7 @@ void Jit64::reg_imm(UGeckoInstruction inst)
   }
 }
 
-bool Jit64::CheckMergedBranch(u32 crf)
+bool Jit64::CheckMergedBranch(u32 crf) const
 {
   if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_MERGE))
     return false;


### PR DESCRIPTION
This function doesn't modify class state.