### PR TITLE
ShaderCache: Improve shader UID cache file reliability

### DIFF
--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -602,6 +602,12 @@ void ShaderCache::LoadPipelineUIDCache()
       m_gx_pipeline_uid_cache_file.WriteBytes(&CACHE_FILE_MAGIC, sizeof(GX_PIPELINE_UID_VERSION));
       m_gx_pipeline_uid_cache_file.WriteBytes(&GX_PIPELINE_UID_VERSION,
                                               sizeof(GX_PIPELINE_UID_VERSION));
+
+      // Write any current UIDs out to the file.
+      // This way, if we load a UID cache where the data was incomplete (e.g. Dolphin crashed),
+      // we don't lose the existing UIDs which were previously at the beginning.
+      for (const auto& it : m_gx_pipeline_cache)
+        AppendGXPipelineUID(it.first);
     }
   }
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -552,6 +552,7 @@ void ShaderCache::LoadPipelineUIDCache()
     // If an existing case exists, validate the version before reading entries.
     u32 existing_magic;
     u32 existing_version;
+    bool uid_file_valid = false;
     if (m_gx_pipeline_uid_cache_file.ReadBytes(&existing_magic, sizeof(existing_magic)) &&
         m_gx_pipeline_uid_cache_file.ReadBytes(&existing_version, sizeof(existing_version)) &&
         existing_magic == CACHE_FILE_MAGIC && existing_version == GX_PIPELINE_UID_VERSION)
@@ -563,7 +564,7 @@ void ShaderCache::LoadPipelineUIDCache()
       const size_t uid_count =
           static_cast<size_t>(file_size - CACHE_HEADER_SIZE) / sizeof(SerializedGXPipelineUid);
       const size_t expected_size = uid_count * sizeof(SerializedGXPipelineUid) + CACHE_HEADER_SIZE;
-      bool uid_file_valid = file_size == expected_size;
+      uid_file_valid = file_size == expected_size;
       if (uid_file_valid)
       {
         for (size_t i = 0; i < uid_count; i++)
@@ -583,12 +584,13 @@ void ShaderCache::LoadPipelineUIDCache()
       }
 
       // We open the file for reading and writing, so we must seek to the end before writing.
-      if (!uid_file_valid || !m_gx_pipeline_uid_cache_file.Seek(expected_size, SEEK_SET))
-      {
-        // Close the file. We re-open and truncate it below.
-        m_gx_pipeline_uid_cache_file.Close();
-      }
+      if (uid_file_valid)
+        uid_file_valid = m_gx_pipeline_uid_cache_file.Seek(expected_size, SEEK_SET);
     }
+
+    // If the file is invalid, close it. We re-open and truncate it below.
+    if (!uid_file_valid)
+      m_gx_pipeline_uid_cache_file.Close();
   }
 
   // If the file is not open, it means it was either corrupted or didn't exist.


### PR DESCRIPTION
The first commit addresses an issue which could cause an annoying problem - if the UID cache was present, but invalid (e.g. due to a bad header, dolphin crashing and the file not being flushed, etc), the file handle would not be closed and re-created. Instead, it was left open, and opening a file for read/write, then writing without seeking caused the write to fail, and the UID cache to be closed.

Previously, the solution was to delete the file. This change makes that automatic.

The second commit ensures that no UIDs are lost in the case of a Dolphin crash, or corrupted UID cache, by re-writing all the known UIDs out to the file when the new file is created. It won't necessarily retain all of the UIDs which were present in the corrupted file, but should maintain most of them.