### PR TITLE
Renderer: Only recreate frame dump texture if dimensions differ

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -755,7 +755,7 @@ void Renderer::RenderFrameDump()
   // Or, resize texture if it isn't large enough to accommodate the current frame.
   if (!m_frame_dump_render_texture ||
       m_frame_dump_render_texture->GetConfig().width != static_cast<u32>(target_width) ||
-      m_frame_dump_render_texture->GetConfig().height == static_cast<u32>(target_height))
+      m_frame_dump_render_texture->GetConfig().height != static_cast<u32>(target_height))
   {
     // Recreate texture objects. Release before creating so we don't temporarily use twice the RAM.
     TextureConfig config(target_width, target_height, 1, 1, 1, AbstractTextureFormat::RGBA8, true);


### PR DESCRIPTION
This was a typo, been around for a while. == should be !=. May improve frame dumping performnace slightly, but I doubt much if any.