### PR TITLE
CMakeLists: Remove enet from the LIBS variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,7 +568,6 @@ else()
   include_directories(Externals/enet/include)
   add_subdirectory(Externals/enet)
 endif()
-LIST(APPEND LIBS enet)
 
 if(NOT XXHASH_FOUND)
   message(STATUS "Using static xxhash from Externals")


### PR DESCRIPTION
All libraries that use enet already link it in explicitly. This reduces the usages of the LIBS variable. After this there's only two remaining usages of the LIBS variable where libraries are appended to it. After that it can be removed entirely.