### PR TITLE
CMakeLists: Remove iconv from the LIBS variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,7 +706,6 @@ else()
   add_subdirectory(Externals/libiconv-1.14)
   set(ICONV_LIBRARIES iconv)
 endif()
-list(APPEND LIBS ${ICONV_LIBRARIES})
 
 if(NOT ANDROID)
   find_package(HIDAPI)

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -44,12 +44,16 @@ add_library(common
   x64Emitter.cpp
 )
 
-target_link_libraries(common PUBLIC
+target_link_libraries(common
+PUBLIC
   ${CMAKE_THREAD_LIBS_INIT}
   ${CURL_LIBRARIES}
   enet
   ${MBEDTLS_LIBRARIES}
   ${VTUNE_LIBRARIES}
+
+PRIVATE
+  ${ICONV_LIBRARIES}
 )
 
 if (APPLE)
@@ -65,7 +69,6 @@ if(ANDROID)
   target_sources(common PRIVATE
     Logging/ConsoleListenerDroid.cpp
   )
-  target_link_libraries(common PRIVATE iconv)
 elseif(WIN32)
   target_sources(common PRIVATE
     Logging/ConsoleListenerWin.cpp


### PR DESCRIPTION
Adjusts Common to use the ICONV_LIBRARIES variable directly and doesn't append it to the LIBS variable.

After this, there's only one remaining usage where libraries are added to the LIBS variable, after which it can be removed once the rest of the targets are migrated off add_dolphin_library