### PR TITLE
EXI_DeviceMemoryCard: Get rid of magic number in SetCS()

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -293,7 +293,7 @@ void CEXIMemoryCard::SetCS(int cs)
       {
         int count = m_uPosition - 5;
         int i = 0;
-        status &= ~0x80;
+        status &= ~MC_STATUS_BUSY;
 
         while (count--)
         {


### PR DESCRIPTION
Keeps the code consistent with other usages of the same constant