### PR TITLE
DSPJitRegCache: Make FindFreeReg() a const member function

### DIFF
--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.cpp
@@ -923,7 +923,7 @@ void DSPJitRegCache::SpillXReg(X64Reg reg)
   }
 }
 
-X64Reg DSPJitRegCache::FindFreeXReg()
+X64Reg DSPJitRegCache::FindFreeXReg() const
 {
   for (X64Reg x : s_allocation_order)
   {

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.h
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitRegCache.h
@@ -160,7 +160,7 @@ private:
   };
 
   // Find a free host reg
-  Gen::X64Reg FindFreeXReg();
+  Gen::X64Reg FindFreeXReg() const;
   Gen::X64Reg SpillXReg();
   Gen::X64Reg FindSpillFreeXReg();
   void SpillXReg(Gen::X64Reg reg);


### PR DESCRIPTION
This member function doesn't modify class state.