### PR TITLE
Jit64/JitRegCache: Make member functions const qualified where applicable

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/FPURegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/FPURegCache.cpp
@@ -24,7 +24,7 @@ void FPURegCache::LoadRegister(size_t preg, X64Reg new_loc)
   m_emitter->MOVAPD(new_loc, m_regs[preg].location);
 }
 
-const X64Reg* FPURegCache::GetAllocationOrder(size_t* count)
+const X64Reg* FPURegCache::GetAllocationOrder(size_t* count) const
 {
   static const X64Reg allocation_order[] = {XMM6,  XMM7,  XMM8,  XMM9, XMM10, XMM11, XMM12,
                                             XMM13, XMM14, XMM15, XMM2, XMM3,  XMM4,  XMM5};
@@ -37,12 +37,12 @@ OpArg FPURegCache::GetDefaultLocation(size_t reg) const
   return PPCSTATE(ps[reg][0]);
 }
 
-BitSet32 FPURegCache::GetRegUtilization()
+BitSet32 FPURegCache::GetRegUtilization() const
 {
   return m_jit.js.op->gprInReg;
 }
 
-BitSet32 FPURegCache::CountRegsIn(size_t preg, u32 lookahead)
+BitSet32 FPURegCache::CountRegsIn(size_t preg, u32 lookahead) const
 {
   BitSet32 regs_used;
 

--- a/Source/Core/Core/PowerPC/Jit64/FPURegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/FPURegCache.h
@@ -15,8 +15,8 @@ public:
 
   void StoreRegister(size_t preg, const Gen::OpArg& newLoc) override;
   void LoadRegister(size_t preg, Gen::X64Reg newLoc) override;
-  const Gen::X64Reg* GetAllocationOrder(size_t* count) override;
+  const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
   Gen::OpArg GetDefaultLocation(size_t reg) const override;
-  BitSet32 GetRegUtilization() override;
-  BitSet32 CountRegsIn(size_t preg, u32 lookahead) override;
+  BitSet32 GetRegUtilization() const override;
+  BitSet32 CountRegsIn(size_t preg, u32 lookahead) const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/GPRRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/GPRRegCache.cpp
@@ -29,7 +29,7 @@ OpArg GPRRegCache::GetDefaultLocation(size_t reg) const
   return PPCSTATE(gpr[reg]);
 }
 
-const X64Reg* GPRRegCache::GetAllocationOrder(size_t* count)
+const X64Reg* GPRRegCache::GetAllocationOrder(size_t* count) const
 {
   static const X64Reg allocation_order[] = {
 // R12, when used as base register, for example in a LEA, can generate bad code! Need to look into
@@ -55,12 +55,12 @@ void GPRRegCache::SetImmediate32(size_t preg, u32 imm_value, bool dirty)
   m_regs[preg].location = Imm32(imm_value);
 }
 
-BitSet32 GPRRegCache::GetRegUtilization()
+BitSet32 GPRRegCache::GetRegUtilization() const
 {
   return m_jit.js.op->gprInReg;
 }
 
-BitSet32 GPRRegCache::CountRegsIn(size_t preg, u32 lookahead)
+BitSet32 GPRRegCache::CountRegsIn(size_t preg, u32 lookahead) const
 {
   BitSet32 regs_used;
 

--- a/Source/Core/Core/PowerPC/Jit64/GPRRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/GPRRegCache.h
@@ -16,8 +16,8 @@ public:
   void StoreRegister(size_t preg, const Gen::OpArg& new_loc) override;
   void LoadRegister(size_t preg, Gen::X64Reg new_loc) override;
   Gen::OpArg GetDefaultLocation(size_t reg) const override;
-  const Gen::X64Reg* GetAllocationOrder(size_t* count) override;
+  const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
   void SetImmediate32(size_t preg, u32 imm_value, bool dirty = true);
-  BitSet32 GetRegUtilization() override;
-  BitSet32 CountRegsIn(size_t preg, u32 lookahead) override;
+  BitSet32 GetRegUtilization() const override;
+  BitSet32 CountRegsIn(size_t preg, u32 lookahead) const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -317,7 +317,7 @@ X64Reg RegCache::GetFreeXReg()
   return INVALID_REG;
 }
 
-int RegCache::NumFreeRegisters()
+int RegCache::NumFreeRegisters() const
 {
   int count = 0;
   size_t aCount;
@@ -330,16 +330,16 @@ int RegCache::NumFreeRegisters()
 
 // Estimate roughly how bad it would be to de-allocate this register. Higher score
 // means more bad.
-float RegCache::ScoreRegister(X64Reg xr)
+float RegCache::ScoreRegister(X64Reg xreg) const
 {
-  size_t preg = m_xregs[xr].ppcReg;
+  size_t preg = m_xregs[xreg].ppcReg;
   float score = 0;
 
   // If it's not dirty, we don't need a store to write it back to the register file, so
   // bias a bit against dirty registers. Testing shows that a bias of 2 seems roughly
   // right: 3 causes too many extra clobbers, while 1 saves very few clobbers relative
   // to the number of extra stores it causes.
-  if (m_xregs[xr].dirty)
+  if (m_xregs[xreg].dirty)
     score += 2;
 
   // If the register isn't actually needed in a physical register for a later instruction,

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -120,15 +120,15 @@ public:
   bool IsBound(size_t preg) const;
 
   Gen::X64Reg GetFreeXReg();
-  int NumFreeRegisters();
+  int NumFreeRegisters() const;
 
 protected:
-  virtual const Gen::X64Reg* GetAllocationOrder(size_t* count) = 0;
+  virtual const Gen::X64Reg* GetAllocationOrder(size_t* count) const = 0;
 
-  virtual BitSet32 GetRegUtilization() = 0;
-  virtual BitSet32 CountRegsIn(size_t preg, u32 lookahead) = 0;
+  virtual BitSet32 GetRegUtilization() const = 0;
+  virtual BitSet32 CountRegsIn(size_t preg, u32 lookahead) const = 0;
 
-  float ScoreRegister(Gen::X64Reg xreg);
+  float ScoreRegister(Gen::X64Reg xreg) const;
 
   Jit64& m_jit;
   std::array<PPCCachedReg, 32> m_regs;


### PR DESCRIPTION
None of these member functions modify class state.

Also makes the parameter name for ScoreRegister's implementation consistent with its declaration.