### PR TITLE
CPUDetect: Make CPUVendor enum an enum class

### DIFF
--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -57,7 +57,7 @@ void CPUInfo::Detect()
   OS64bit = true;
   CPU64bit = true;
   Mode64bit = true;
-  vendor = VENDOR_ARM;
+  vendor = CPUVendor::ARM;
 
   // Get the information about the CPU
   num_cores = sysconf(_SC_NPROCESSORS_CONF);

--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -7,17 +7,17 @@
 
 #include <string>
 
-enum CPUVendor
+enum class CPUVendor
 {
-  VENDOR_INTEL = 0,
-  VENDOR_AMD = 1,
-  VENDOR_ARM = 2,
-  VENDOR_OTHER = 3,
+  Intel,
+  AMD,
+  ARM,
+  Other,
 };
 
 struct CPUInfo
 {
-  CPUVendor vendor = VENDOR_INTEL;
+  CPUVendor vendor = CPUVendor::Intel;
 
   char cpu_string[0x41] = {};
   char brand_string[0x21] = {};

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -84,11 +84,11 @@ void CPUInfo::Detect()
   __cpuid(cpu_id, 0x80000000);
   u32 max_ex_fn = cpu_id[0];
   if (!strcmp(brand_string, "GenuineIntel"))
-    vendor = VENDOR_INTEL;
+    vendor = CPUVendor::Intel;
   else if (!strcmp(brand_string, "AuthenticAMD"))
-    vendor = VENDOR_AMD;
+    vendor = CPUVendor::AMD;
   else
-    vendor = VENDOR_OTHER;
+    vendor = CPUVendor::Other;
 
   // Set reasonable default brand string even if brand string not available.
   strcpy(cpu_string, brand_string);
@@ -198,7 +198,7 @@ void CPUInfo::Detect()
       if (ht)
       {
         // New mechanism for modern Intel CPUs.
-        if (vendor == VENDOR_INTEL)
+        if (vendor == CPUVendor::Intel)
         {
           __cpuidex(cpu_id, 0x00000004, 0x00000000);
           int cores_x_package = ((cpu_id[0] >> 26) & 0x3F) + 1;


### PR DESCRIPTION
Avoids dumping the enum contents into the global namespace.