### PR TITLE
AsyncRequests: In-class initialize class members

### DIFF
--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -12,9 +12,7 @@
 
 AsyncRequests AsyncRequests::s_singleton;
 
-AsyncRequests::AsyncRequests() : m_enable(false), m_passthrough(true)
-{
-}
+AsyncRequests::AsyncRequests() = default;
 
 void AsyncRequests::PullEventsInternal()
 {

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -90,9 +90,9 @@ private:
   std::mutex m_mutex;
   std::condition_variable m_cond;
 
-  bool m_wake_me_up_again;
-  bool m_enable;
-  bool m_passthrough;
+  bool m_wake_me_up_again = false;
+  bool m_enable = false;
+  bool m_passthrough = true;
 
   std::vector<EfbPokeData> m_merged_efb_pokes;
 };


### PR DESCRIPTION
Prior to this change, it's possible for m_wake_me_up_again to be used while it's in an uninitialized state from the exposed API.

e.g.

- Using SetEnable after construction would perform an uninitialized read.
- Using PushEvent would perform an uninitialized read by way of operator |=.

internally, an uninitialized read can happen if PullEventsInternal() is executed before other functions.

Just to avoid the whole possibility of performing uninitialized reads, we just give the class member a default value of false.