### PR TITLE
Interpreter_LoadStore: Handle alignment exceptions in lmw, lwarx, stmw, and stwcx + fixes for eciwx and ecowx

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -24,6 +24,12 @@ void GenerateAlignmentException(u32 address)
   PowerPC::ppcState.Exceptions |= EXCEPTION_ALIGNMENT;
   PowerPC::ppcState.spr[SPR_DAR] = address;
 }
+
+void GenerateDSIException(u32 address)
+{
+  PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
+  PowerPC::ppcState.spr[SPR_DAR] = address;
+}
 }
 
 u32 Interpreter::Helper_Get_EA(const UGeckoInstruction inst)
@@ -431,7 +437,8 @@ void Interpreter::eciwx(UGeckoInstruction inst)
 
   if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
   {
-    PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
+    GenerateDSIException(EA);
+    return;
   }
 
   if (EA & 3)
@@ -449,7 +456,8 @@ void Interpreter::ecowx(UGeckoInstruction inst)
 
   if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
   {
-    PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
+    GenerateDSIException(EA);
+    return;
   }
 
   if (EA & 3)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -433,8 +433,12 @@ void Interpreter::eciwx(UGeckoInstruction inst)
   {
     PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
   }
+
   if (EA & 3)
-    PowerPC::ppcState.Exceptions |= EXCEPTION_ALIGNMENT;
+  {
+    GenerateAlignmentException(EA);
+    return;
+  }
 
   rGPR[inst.RD] = PowerPC::Read_U32(EA);
 }
@@ -447,8 +451,12 @@ void Interpreter::ecowx(UGeckoInstruction inst)
   {
     PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
   }
+
   if (EA & 3)
-    PowerPC::ppcState.Exceptions |= EXCEPTION_ALIGNMENT;
+  {
+    GenerateAlignmentException(EA);
+    return;
+  }
 
   PowerPC::Write_U32(rGPR[inst.RS], EA);
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -17,6 +17,15 @@
 bool Interpreter::m_reserve;
 u32 Interpreter::m_reserve_address;
 
+namespace
+{
+void GenerateAlignmentException(u32 address)
+{
+  PowerPC::ppcState.Exceptions |= EXCEPTION_ALIGNMENT;
+  PowerPC::ppcState.spr[SPR_DAR] = address;
+}
+}
+
 u32 Interpreter::Helper_Get_EA(const UGeckoInstruction inst)
 {
   return inst.RA ? (rGPR[inst.RA] + inst.SIMM_16) : (u32)inst.SIMM_16;
@@ -198,6 +207,12 @@ void Interpreter::lmw(UGeckoInstruction inst)
 {
   u32 address = Helper_Get_EA(inst);
 
+  if ((address & 0b11) != 0)
+  {
+    GenerateAlignmentException(address);
+    return;
+  }
+
   for (int i = inst.RD; i <= 31; i++, address += 4)
   {
     const u32 temp_reg = PowerPC::Read_U32(address);
@@ -219,6 +234,12 @@ void Interpreter::lmw(UGeckoInstruction inst)
 void Interpreter::stmw(UGeckoInstruction inst)
 {
   u32 address = Helper_Get_EA(inst);
+
+  if ((address & 0b11) != 0)
+  {
+    GenerateAlignmentException(address);
+    return;
+  }
 
   for (int i = inst.RS; i <= 31; i++, address += 4)
   {
@@ -780,6 +801,13 @@ void Interpreter::stwbrx(UGeckoInstruction inst)
 void Interpreter::lwarx(UGeckoInstruction inst)
 {
   const u32 address = Helper_Get_EA_X(inst);
+
+  if ((address & 0b11) != 0)
+  {
+    GenerateAlignmentException(address);
+    return;
+  }
+
   const u32 temp = PowerPC::Read_U32(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -790,13 +818,19 @@ void Interpreter::lwarx(UGeckoInstruction inst)
   }
 }
 
+// Stores Word Conditional indeXed
 void Interpreter::stwcxd(UGeckoInstruction inst)
 {
-  // Stores Word Conditional indeXed
+  const u32 address = Helper_Get_EA_X(inst);
+
+  if ((address & 0b11) != 0)
+  {
+    GenerateAlignmentException(address);
+    return;
+  }
+
   if (m_reserve)
   {
-    const u32 address = Helper_Get_EA_X(inst);
-
     if (address == m_reserve_address)
     {
       PowerPC::Write_U32(rGPR[inst.RS], address);

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -474,8 +474,6 @@ void CheckExceptions()
   }
   else if (exceptions & EXCEPTION_ALIGNMENT)
   {
-    // This never happens ATM
-    // perhaps we can get dcb* instructions to use this :p
     SRR0 = PC;
     SRR1 = MSR & 0x87C0FFFF;
     MSR |= (MSR >> 16) & 1;


### PR DESCRIPTION
lmw, lwarx, stmw, and stwcx are supposed to cause an alignment exception when the effective address isn't word-aligned. Furthermore, these exceptions are supposed to be taken immediately, the instruction doesn't finish execution.

This also corrects cases in eciwx and ecowx, which would still plow the data in the destination register or memory into oblivion, despite an exception occurring. It also amends them to properly update the DAR with the effective address as well.

e.g. we now crash properly with these instructions

![](https://user-images.githubusercontent.com/712067/38182106-0d023320-3605-11e8-917e-89dcb2d6fe2f.png)

![](https://user-images.githubusercontent.com/712067/38182114-2d089ea2-3605-11e8-9260-8378c8830ac6.png)

Currently the DSISR isn't updated with the correct values, since we never really handled alignment exceptions, however this will be amended after alignment handling is added to relevant floating-point loads/stores in a follow-up PR.