### PR TITLE
CMakeLists: Migrate video backends off the add_dolphin_library macro and remove said macro

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -35,12 +35,6 @@ endif()
 add_definitions(-D__STDC_LIMIT_MACROS)
 add_definitions(-D__STDC_CONSTANT_MACROS)
 
-# DEPRECATED: When introducing new libraries, do it explicitly.
-macro(add_dolphin_library lib srcs libs)
-  add_library(${lib} STATIC ${srcs})
-  target_link_libraries(${lib} PUBLIC ${libs})
-endmacro()
-
 add_subdirectory(Core)
 if (ANDROID)
   add_subdirectory(Android/jni)

--- a/Source/Core/VideoBackends/D3D/CMakeLists.txt
+++ b/Source/Core/VideoBackends/D3D/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS
+add_library(videod3d
   BoundingBox.cpp
   BoundingBox.h
   D3DBase.cpp
@@ -42,10 +42,11 @@ set(SRCS
   VideoBackend.h
 )
 
-set(LIBS
-  videocommon
-  SOIL
+target_link_libraries(videod3d
+PUBLIC
   common
-)
+  videocommon
 
-add_dolphin_library(videod3d "${SRCS}" "${LIBS}")
+PRIVATE
+  SOIL
+)

--- a/Source/Core/VideoBackends/Null/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Null/CMakeLists.txt
@@ -1,14 +1,12 @@
-set(SRCS
+add_library(videonull
   NullBackend.cpp
   NullTexture.cpp
   Render.cpp
   VertexManager.cpp
 )
 
-set(LIBS
-  videocommon
+target_link_libraries(videonull
+PUBLIC
   common
+  videocommon
 )
-
-add_dolphin_library(videonull "${SRCS}" "${LIBS}")
-

--- a/Source/Core/VideoBackends/OGL/CMakeLists.txt
+++ b/Source/Core/VideoBackends/OGL/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS
+add_library(videoogl
   BoundingBox.cpp
   FramebufferManager.cpp
   main.cpp
@@ -18,11 +18,12 @@ set(SRCS
   VertexManager.cpp
 )
 
-set(LIBS ${LIBS}
-  videocommon
-  SOIL
+target_link_libraries(videoogl
+PUBLIC
   common
+  videocommon
+
+PRIVATE
+  SOIL
   ${X11_LIBRARIES}
 )
-
-add_dolphin_library(videoogl "${SRCS}" "${LIBS}")

--- a/Source/Core/VideoBackends/Software/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Software/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS
+add_library(videosoftware
   Clipper.cpp
   DebugUtil.cpp
   EfbCopy.cpp
@@ -16,11 +16,12 @@ set(SRCS
   TransformUnit.cpp
 )
 
-set(LIBS
-  videocommon
-  SOIL
+target_link_libraries(videosoftware
+PUBLIC
   common
+  videocommon
+
+PRIVATE
+  SOIL
   ${X11_LIBRARIES}
 )
-
-add_dolphin_library(videosoftware "${SRCS}" "${LIBS}")

--- a/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS
+add_library(videovulkan
   BoundingBox.cpp
   CommandBufferManager.cpp
   FramebufferManager.cpp
@@ -27,23 +27,26 @@ set(SRCS
   main.cpp
 )
 
-set(LIBS
-  videocommon
-  common
-)
-
-# Only include the Vulkan headers when building the Vulkan backend
-include_directories(${CMAKE_SOURCE_DIR}/Externals/Vulkan/Include)
-
-# Silence warnings on glslang by flagging it as a system include
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/Externals/glslang/glslang/Public)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/Externals/glslang/SPIRV)
-
-# Link against glslang, the other necessary libraries are referenced by the executable.
-add_dolphin_library(videovulkan "${SRCS}" "${LIBS}")
 target_link_libraries(videovulkan
+PUBLIC
+  common
+  videocommon
+
 PRIVATE
+  # Link against glslang, the other necessary libraries are referenced by the executable.
   glslang
   xxhash
 )
 
+# Only include the Vulkan headers when building the Vulkan backend
+target_include_directories(videovulkan
+PRIVATE
+  ${CMAKE_SOURCE_DIR}/Externals/Vulkan/Include
+)
+
+# Silence warnings on glslang by flagging it as a system include
+target_include_directories(videovulkan
+SYSTEM PRIVATE
+  ${CMAKE_SOURCE_DIR}/Externals/glslang/glslang/Public
+  ${CMAKE_SOURCE_DIR}/Externals/glslang/SPIRV
+)


### PR DESCRIPTION
With this, the migration work in 3a4c3bbe01e7a44ec997f4fbf0b678fba6f2d46c is complete.