### PR TITLE
DolphinWX: Scale window geometry before passing to backend

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -614,7 +614,13 @@ void CFrame::OnRenderParentResize(wxSizeEvent& event)
     m_log_window->Update();
 
     if (g_renderer)
-      g_renderer->ResizeSurface(width, height);
+    {
+      // The window geometry is in device-independent points and may not match the content or
+      // framebuffer size in macOS. Multiply by the content scaling factor to get the real size.
+      double scaling_factor = m_render_frame->GetContentScaleFactor();
+      g_renderer->ResizeSurface(static_cast<int>(width * scaling_factor),
+                                static_cast<int>(height * scaling_factor));
+    }
   }
   event.Skip();
 }


### PR DESCRIPTION
In macOS, the window size is device-independent points, which may not match the content/backing framebuffer size. This was causing the game to render to only the bottom-left corner of the window (OpenGL uses a lower-left origin).

Untested as I am away from home and do not currently have access to a mac, but if my suspicions are correct, this should fix https://bugs.dolphin-emu.org/issues/10973