### PR TITLE
Android/CMakeLists: Remove usages of LIBS and SRCS variables

### DIFF
--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -1,17 +1,21 @@
-list(APPEND LIBS core uicommon)
+add_library(main SHARED
+  ButtonManager.cpp
+  MainAndroid.cpp
+)
 
-set(SRCS ButtonManager.cpp
-         MainAndroid.cpp)
+target_link_libraries(main
+PRIVATE
+  core
+  uicommon
+)
 
-set(SHARED_LIB main)
-add_library(${SHARED_LIB} SHARED ${SRCS})
-target_link_libraries(${SHARED_LIB}
-log
-android
-"-Wl,--no-warn-mismatch"
-"-Wl,--whole-archive"
-${LIBS}
-"-Wl,--no-whole-archive"
+target_link_libraries(main
+PRIVATE
+  android
+  log
+  "-Wl,--no-warn-mismatch"
+  "-Wl,--whole-archive"
+  "-Wl,--no-whole-archive"
 )
 
 file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/)
@@ -19,4 +23,4 @@ file(REMOVE_RECURSE ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/Sys/)
 file(COPY ${CMAKE_SOURCE_DIR}/Data/Sys DESTINATION ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/)
 file(REMOVE_RECURSE ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/Sys/Resources/)  # not used on Android
 
-set(CPACK_PACKAGE_EXECUTABLES ${CPACK_PACKAGE_EXECUTABLES} ${SHARED_LIB})
+set(CPACK_PACKAGE_EXECUTABLES ${CPACK_PACKAGE_EXECUTABLES} main)


### PR DESCRIPTION
Instead, operate on the target itself.