### PR TITLE
DolphinNoGUI/CMakeLists: Remove the use of SRCS and LIBS variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,6 @@ include(DolphinCompileDefinitions)
 # Enable folders for IDE
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-# Libraries to link
-set(LIBS)
-
 # Set up paths
 set(bindir  ${CMAKE_INSTALL_PREFIX}/bin               CACHE PATH "bindir")
 if(HAIKU)
@@ -386,8 +383,6 @@ elseif(HAIKU)
   set(USE_X11 0)
   set(USE_UPNP 0)
   set(USE_EGL 0)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  list(APPEND LIBS rt)
 endif()
 
 if(ENABLE_HEADLESS)

--- a/Source/Core/DolphinNoGUI/CMakeLists.txt
+++ b/Source/Core/DolphinNoGUI/CMakeLists.txt
@@ -2,16 +2,17 @@ if(NOT(USE_X11 OR ENABLE_HEADLESS))
   return()
 endif()
 
-set(NOGUI_SRCS MainNoGUI.cpp)
+add_executable(dolphin-nogui
+  MainNoGUI.cpp
+)
 
-add_executable(dolphin-nogui ${NOGUI_SRCS})
 set_target_properties(dolphin-nogui PROPERTIES OUTPUT_NAME dolphin-emu-nogui)
 
-target_link_libraries(dolphin-nogui PRIVATE
+target_link_libraries(dolphin-nogui
+PRIVATE
   core
   uicommon
   cpp-optparse
-  ${LIBS}
 )
 
 set(CPACK_PACKAGE_EXECUTABLES ${CPACK_PACKAGE_EXECUTABLES} dolphin-nogui)


### PR DESCRIPTION
With this, we can finally remove the top-level LIBS variable, as it's no longer used.