### PR TITLE
DolphinQt2/CMakeLists: Specify Qt libraries via COMPONENTS in the find_package call

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -1,10 +1,4 @@
-find_package(Qt5Widgets)
-find_package(Qt5Gui)
-
-if(NOT Qt5Widgets_FOUND OR NOT Qt5Gui_FOUND)
-  message(FATAL_ERROR "Could not find Qt5, which is required to build the DolphinQt2 frontend. If you don't want to build the Qt frontend, pass -DENABLE_QT2=False to
-CMake.")
-endif()
+find_package(Qt5 REQUIRED COMPONENTS Gui Widgets)
 
 set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
 message(STATUS "Found Qt version ${Qt5Core_VERSION}")


### PR DESCRIPTION
Eliminates the need to find the individual modules separately