### PR TITLE
Interpreter_LoadStore: Generate alignment exceptions if dcbz or dcbz_l are executed with the data cache disabled

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -421,12 +421,33 @@ void Interpreter::dcbz(UGeckoInstruction inst)
     return;
 
   const u32 dcbz_addr = Helper_Get_EA_X(inst);
+
+  if (!HID0.DCE)
+  {
+    GenerateAlignmentException(dcbz_addr);
+    return;
+  }
+
   // Hack to stop dcbz/dcbi over low MEM1 trashing memory.
   if (SConfig::GetInstance().bLowDCBZHack && (dcbz_addr < 0x80008000) && (dcbz_addr >= 0x80000000))
     return;
 
   // TODO: Implement some sort of L2 emulation.
   PowerPC::ClearCacheLine(dcbz_addr & (~31));
+}
+
+void Interpreter::dcbz_l(UGeckoInstruction inst)
+{
+  const u32 address = Helper_Get_EA_X(inst);
+
+  if (!HID0.DCE)
+  {
+    GenerateAlignmentException(address);
+    return;
+  }
+
+  // FAKE: clear memory instead of clearing the cache block
+  PowerPC::ClearCacheLine(address & (~31));
 }
 
 // eciwx/ecowx technically should access the specified device

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -331,12 +331,3 @@ void Interpreter::ps_cmpo1(UGeckoInstruction inst)
 {
   Helper_FloatCompareOrdered(inst, rPS1(inst.FA), rPS1(inst.FB));
 }
-
-// __________________________________________________________________________________________________
-// dcbz_l
-// TODO(ector) check docs
-void Interpreter::dcbz_l(UGeckoInstruction inst)
-{
-  // FAKE: clear memory instead of clearing the cache block
-  PowerPC::ClearCacheLine(Helper_Get_EA_X(inst) & (~31));
-}


### PR DESCRIPTION
This is an exception condition documented within section 4.5.6 in the architecture reference manual for the PPC 750CL, which also applies to the Gekko microprocessor.

Also moves dcbz_l's implementation out of Interpreter_Paired and beside dcbz where it belongs.