### PR TITLE
DolphinQt2/CMakeLists: Use the target_* equivalents of add_definitions and include_directories

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -3,11 +3,6 @@ find_package(Qt5 REQUIRED COMPONENTS Gui Widgets)
 set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
 message(STATUS "Found Qt version ${Qt5Core_VERSION}")
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
-include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
-
-add_definitions(-DQT_USE_QSTRINGBUILDER -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII)
 set(CMAKE_AUTOMOC ON)
 
 add_executable(dolphin-emu-qt2
@@ -116,6 +111,19 @@ add_executable(dolphin-emu-qt2
   TAS/StickWidget.cpp
   TAS/IRWidget.cpp
   Updater.cpp
+)
+
+target_compile_definitions(dolphin-emu-qt2
+PRIVATE
+  -DQT_USE_QSTRINGBUILDER
+  -DQT_NO_CAST_FROM_ASCII
+  -DQT_NO_CAST_TO_ASCII
+)
+
+target_include_directories(dolphin-emu-qt2
+PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
 )
 
 target_link_libraries(dolphin-emu-qt2


### PR DESCRIPTION
`add_definitions` and `include_directories` don't operate on a by-target basis, they act on a by-directory basis (i.e. if we defined two targets, A and B, in this CMakeLists file, `add_definitions` would add the definitions to the `COMPILE_DEFINITIONS` directory property which both A and B would implicitly use).

The same idea applies to `include_directories`, only it appends to the `INCLUDE_DIRECTORIES` directory property.

Instead, specify these on the target to keep scope as narrow as possible.