### PR TITLE
DolphinQt2/MainWindow: Resolve a memory leak on systems with X11

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -221,12 +221,11 @@ void MainWindow::CreateComponents()
           &MemoryWidget::Update);
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
-  m_graphics_window = new GraphicsWindow(
-      new X11Utils::XRRConfiguration(
-          static_cast<Display*>(QGuiApplication::platformNativeInterface()->nativeResourceForWindow(
-              "display", windowHandle())),
-          winId()),
-      this);
+  m_xrr_config = std::make_unique<X11Utils::XRRConfiguration>(
+      static_cast<Display*>(QGuiApplication::platformNativeInterface()->nativeResourceForWindow(
+          "display", windowHandle())),
+      winId());
+  m_graphics_window = new GraphicsWindow(m_xrr_config.get(), this);
 #else
   m_graphics_window = new GraphicsWindow(nullptr, this);
 #endif

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -43,6 +43,11 @@ class SettingsWindow;
 class WatchWidget;
 class WiiTASInputWindow;
 
+namespace X11Utils
+{
+class XRRConfiguration;
+}
+
 class MainWindow final : public QMainWindow
 {
   Q_OBJECT
@@ -145,6 +150,10 @@ private:
   void dragEnterEvent(QDragEnterEvent* event) override;
   void dropEvent(QDropEvent* event) override;
   QSize sizeHint() const override;
+
+#if defined(HAVE_XRANDR) && HAVE_XRANDR
+  std::unique_ptr<X11Utils::XRRConfiguration> m_xrr_config;
+#endif
 
   QProgressDialog* m_progress_dialog = nullptr;
   QStackedWidget* m_stack;


### PR DESCRIPTION
In the case we had X11 libs available, we'd allocate an XRRConfiguration instance and pass it to the GraphicsWindow instance, but it would never actually be freed.

Granted, this would only ever be a one-time leak, since there's only one instance of the main window live at any time, but this can make memory/leak analysis less annoying.