### PR TITLE
DolphinWX/DolphinQt2 CMakeLists: Use cmake -E instead of mkdir -p for creating language directories

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -162,7 +162,7 @@ if(GETTEXT_MSGMERGE_EXECUTABLE AND GETTEXT_MSGFMT_EXECUTABLE)
     endif()
 
     add_custom_command(OUTPUT ${mo}
-      COMMAND mkdir -p ${mo_dir}
+      COMMAND cmake -E make_directory ${mo_dir}
       COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} --quiet --update --backup=none -s ${po} ${pot_file}
       COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${mo} ${po}
       DEPENDS ${po}

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -137,7 +137,7 @@ if(GETTEXT_MSGMERGE_EXECUTABLE AND GETTEXT_MSGFMT_EXECUTABLE)
     endif()
 
     add_custom_command(OUTPUT ${mo}
-      COMMAND mkdir -p ${mo_dir}
+      COMMAND cmake -E make_directory ${mo_dir}
       COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} --quiet --update --backup=none -s ${po} ${pot_file}
       COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${mo} ${po}
       DEPENDS ${po}


### PR DESCRIPTION
CMake already has this functionality built-in. This lessens depending on the host system environment for utilities and is more cross-platform friendly (which is always nice from a build-system point of view).