### PR TITLE
CMakeLists: Don't dump xxhash's includes into top-level directory scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,7 +566,6 @@ endif()
 if(NOT XXHASH_FOUND)
   message(STATUS "Using static xxhash from Externals")
   add_subdirectory(Externals/xxhash)
-  include_directories(Externals/xxhash)
 endif()
 
 find_package(ZLIB)

--- a/Externals/xxhash/CMakeLists.txt
+++ b/Externals/xxhash/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(xxhash C)
 
-set(SRCS
-	xxhash.c
+add_library(xxhash STATIC xxhash.c)
+target_include_directories(xxhash
+PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
 )
-
-add_library(xxhash STATIC ${SRCS})


### PR DESCRIPTION
We already use a custom CMakeLists file for xxhash, so we can just make it's headers public as part of its target interface.

This way, only libraries that link in the xxhash target will see its headers, as opposed to every target under the top-level directory.