### PR TITLE
Interpreter_LoadStore: Generate a program exception if dcbz_l is executed when HID2[LCE] is zero

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -30,6 +30,11 @@ void GenerateDSIException(u32 address)
   PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
   PowerPC::ppcState.spr[SPR_DAR] = address;
 }
+
+void GenerateProgramException()
+{
+  PowerPC::ppcState.Exceptions |= EXCEPTION_PROGRAM;
+}
 }
 
 u32 Interpreter::Helper_Get_EA(const UGeckoInstruction inst)
@@ -526,6 +531,12 @@ void Interpreter::dcbz(UGeckoInstruction inst)
 
 void Interpreter::dcbz_l(UGeckoInstruction inst)
 {
+  if (!HID2.LCE)
+  {
+    GenerateProgramException();
+    return;
+  }
+
   const u32 address = Helper_Get_EA_X(inst);
 
   if (!HID0.DCE)


### PR DESCRIPTION
If the locked cache isn't enabled, dcbz_l is illegal to execute (locked cache is off, locked cache instructions don't work, makes sense)

This makes exception handling more accurate. It was previously possible to hit the DSI exception handler when HID2[LCE] is set to zero, which isn't correct.

With this change we no longer hit the DSI handler, however we still have a lingering issue elsewhere likely to do with exception precedence, we seem to hit the Floating Point exception handler instead in some cases. This isn't due to the instruction itself directly however, so this is just another bug to fix elsewhere.