### PR TITLE
CMakeLists: Link bochs in privately where applicable

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -276,7 +276,6 @@ endif()
 target_link_libraries(core
 PUBLIC
   audiocommon
-  bdisasm
   common
   cubeb
   discio
@@ -292,6 +291,7 @@ PUBLIC
   z
 
 PRIVATE
+  bdisasm
   ${LZO}
 )
 

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(dolphin-emu
 
 target_link_libraries(dolphin-emu
 PRIVATE
+  bdisasm
   core
   uicommon
   cpp-optparse

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -15,6 +15,7 @@ PUBLIC
   cpp-optparse
 
 PRIVATE
+  bdisasm
   $<$<BOOL:APPLE>:${IOK_LIBRARY}>
 )
 

--- a/Source/UnitTests/CMakeLists.txt
+++ b/Source/UnitTests/CMakeLists.txt
@@ -16,7 +16,7 @@ macro(add_dolphin_test target)
     $<TARGET_OBJECTS:unittests_stubhost>
   )
   set_target_properties(${target} PROPERTIES FOLDER Tests)
-  target_link_libraries(${target} core uicommon gtest_main)
+  target_link_libraries(${target} PRIVATE core uicommon gtest_main)
   add_dependencies(unittests ${target})
   add_test(NAME ${target} COMMAND ${target})
 endmacro()

--- a/Source/UnitTests/Common/CMakeLists.txt
+++ b/Source/UnitTests/Common/CMakeLists.txt
@@ -12,4 +12,6 @@ add_dolphin_test(NandPathsTest NandPathsTest.cpp)
 add_dolphin_test(SPSCQueueTest SPSCQueueTest.cpp)
 add_dolphin_test(StringUtilTest StringUtilTest.cpp)
 add_dolphin_test(SwapTest SwapTest.cpp)
+
 add_dolphin_test(x64EmitterTest x64EmitterTest.cpp)
+target_link_libraries(x64EmitterTest PRIVATE bdisasm)


### PR DESCRIPTION
Everything that links in core doesn't need to see anything related to bochs, because it's only used internally. Anything else that relies on bochs should be linking it in explicitly.