### PR TITLE
PPCDebugInterface: Remove redundant HostRead_U32() call in Disassemble()

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -28,11 +28,9 @@ std::string PPCDebugInterface::Disassemble(unsigned int address)
       return "(No RAM here)";
     }
 
-    u32 op = PowerPC::HostRead_Instruction(address);
+    const u32 op = PowerPC::HostRead_Instruction(address);
     std::string disasm = GekkoDisassembler::Disassemble(op, address);
-
-    UGeckoInstruction inst;
-    inst.hex = PowerPC::HostRead_U32(address);
+    const UGeckoInstruction inst{op};
 
     if (inst.OPCD == 1)
     {


### PR DESCRIPTION
We already read the necessary information with the `HostRead_Instruction()` call. Internally, it calls `HostRead_U32()` as well, so there's no difference in behavior.