### PR TITLE
Gekko: In-class initialize members where applicable

### DIFF
--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -13,10 +13,10 @@
 
 union UGeckoInstruction
 {
-  u32 hex;
+  u32 hex = 0;
 
-  UGeckoInstruction(u32 _hex) : hex(_hex) {}
-  UGeckoInstruction() : hex(0) {}
+  UGeckoInstruction() = default;
+  UGeckoInstruction(u32 hex_) : hex(hex_) {}
   struct
   {
     // Record bit
@@ -319,10 +319,10 @@ union UGQR
   BitField<16, 3, EQuantizeType> ld_type;
   BitField<24, 6, u32> ld_scale;
 
-  u32 Hex;
+  u32 Hex = 0;
 
-  UGQR(u32 _hex) { Hex = _hex; }
-  UGQR() { Hex = 0; }
+  UGQR() = default;
+  UGQR(u32 hex_) : Hex{hex_} {}
 };
 
 // FPU Register
@@ -354,10 +354,10 @@ union UReg_XER
     u32 OV : 1;
     u32 SO : 1;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_XER(u32 _hex) { Hex = _hex; }
-  UReg_XER() { Hex = 0; }
+  UReg_XER() = default;
+  UReg_XER(u32 hex_) : Hex{hex_} {}
 };
 
 // Machine State Register
@@ -386,10 +386,10 @@ union UReg_MSR
     u32 POW : 1;
     u32 res : 13;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_MSR(u32 _hex) { Hex = _hex; }
-  UReg_MSR() { Hex = 0; }
+  UReg_MSR() = default;
+  UReg_MSR(u32 hex_) : Hex{hex_} {}
 };
 
 #define FPRF_SHIFT 12
@@ -483,10 +483,10 @@ union UReg_FPSCR
     // Exception summary (sticky)
     u32 FX : 1;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_FPSCR(u32 _hex) { Hex = _hex; }
-  UReg_FPSCR() { Hex = 0; }
+  UReg_FPSCR() = default;
+  UReg_FPSCR(u32 hex_) : Hex{hex_} {}
 };
 
 // Hardware Implementation-Dependent Register 0
@@ -525,7 +525,7 @@ union UReg_HID0
     u32 DBP : 1;
     u32 EMCP : 1;
   };
-  u32 Hex;
+  u32 Hex = 0;
 };
 
 // Hardware Implementation-Dependent Register 2
@@ -548,10 +548,10 @@ union UReg_HID2
     u32 WPE : 1;
     u32 LSQE : 1;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_HID2(u32 _hex) { Hex = _hex; }
-  UReg_HID2() { Hex = 0; }
+  UReg_HID2() = default;
+  UReg_HID2(u32 hex_) : Hex{hex_} {}
 };
 
 // Hardware Implementation-Dependent Register 4
@@ -571,10 +571,10 @@ union UReg_HID4
     u32 L2FM : 2;
     u32 : 1;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_HID4(u32 _hex) { Hex = _hex; }
-  UReg_HID4() { Hex = 0; }
+  UReg_HID4() = default;
+  UReg_HID4(u32 hex_) : Hex{hex_} {}
 };
 
 // SPR1 - Page Table format
@@ -634,10 +634,10 @@ union UReg_WPAR
     u32 : 4;
     u32 GB_ADDR : 27;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_WPAR(u32 _hex) { Hex = _hex; }
-  UReg_WPAR() { Hex = 0; }
+  UReg_WPAR() = default;
+  UReg_WPAR(u32 hex_) : Hex{hex_} {}
 };
 
 // Direct Memory Access Upper register
@@ -648,10 +648,10 @@ union UReg_DMAU
     u32 DMA_LEN_U : 5;
     u32 MEM_ADDR : 27;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_DMAU(u32 _hex) { Hex = _hex; }
-  UReg_DMAU() { Hex = 0; }
+  UReg_DMAU() = default;
+  UReg_DMAU(u32 hex_) : Hex{hex_} {}
 };
 
 // Direct Memory Access Lower (DMAL) register
@@ -665,10 +665,10 @@ union UReg_DMAL
     u32 DMA_LD : 1;
     u32 LC_ADDR : 27;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_DMAL(u32 _hex) { Hex = _hex; }
-  UReg_DMAL() { Hex = 0; }
+  UReg_DMAL() = default;
+  UReg_DMAL(u32 hex_) : Hex{hex_} {}
 };
 
 union UReg_BAT_Up
@@ -681,10 +681,10 @@ union UReg_BAT_Up
     u32 : 4;
     u32 BEPI : 15;
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_BAT_Up(u32 _hex) { Hex = _hex; }
-  UReg_BAT_Up() { Hex = 0; }
+  UReg_BAT_Up() = default;
+  UReg_BAT_Up(u32 hex_) : Hex{hex_} {}
 };
 
 union UReg_BAT_Lo
@@ -697,10 +697,10 @@ union UReg_BAT_Lo
     u32 : 10;
     u32 BRPN : 15;  // Physical Block Number
   };
-  u32 Hex;
+  u32 Hex = 0;
 
-  UReg_BAT_Lo(u32 _hex) { Hex = _hex; }
-  UReg_BAT_Lo() { Hex = 0; }
+  UReg_BAT_Lo() = default;
+  UReg_BAT_Lo(u32 hex_) : Hex{hex_} {}
 };
 
 union UReg_PTE
@@ -720,7 +720,7 @@ union UReg_PTE
     u64 RPN : 20;
   };
 
-  u64 Hex;
+  u64 Hex = 0;
   u32 Hex32[2];
 };
 


### PR DESCRIPTION
Allows defaulting the default constructor. Also moves assignment to initializer lists where applicable as well.