### PR TITLE
Movie: Do not access NAND when emulation is running

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1383,9 +1383,18 @@ void GetSettings()
   s_bNetPlay = NetPlay::IsNetPlayRunning();
   if (SConfig::GetInstance().bWii)
   {
-    u64 title_id = SConfig::GetInstance().GetTitleID();
-    s_bClearSave =
-        !File::Exists(Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT) + "banner.bin");
+    if (Core::IsRunning())
+    {
+      // Accessing the NAND while emulation is running is unsafe, so avoid doing it.
+      // This is fine because s_bClearSave is only used during boot in WiiRoot.
+      s_bClearSave = false;
+    }
+    else
+    {
+      const u64 title_id = SConfig::GetInstance().GetTitleID();
+      s_bClearSave = !File::Exists(Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT) +
+                                   "banner.bin");
+    }
   }
   else
   {


### PR DESCRIPTION
Accessing the NAND while emulation is running is unsafe especially when we are not doing it on the CPU thread.