### PR TITLE
IOS: Do not manually close devices in destructor

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -188,14 +188,6 @@ Kernel::Kernel()
 
 Kernel::~Kernel()
 {
-  // Close all devices that were opened
-  for (auto& device : m_fdmap)
-  {
-    if (!device)
-      continue;
-    device->Close(0);
-  }
-
   {
     std::lock_guard<std::mutex> lock(m_device_map_mutex);
     m_device_map.clear();


### PR DESCRIPTION
This used to be necessary for properly cleaning up the FS state because
the old FS implementation used static state and only performed cleanup
in the close function, not in the destructor.

Now that the static state is gone, we do not need to close devices
manually anymore.