### PR TITLE
CMakeLists: Don't dump bochs' includes into the top-level directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,20 +521,21 @@ endif()
 # Process externals and setup their include directories
 #
 # NOTES about adding Externals:
-#   - add the include directory here
+#   - If an external provides a target, or one can be introduced with find_package, consider using it.
+#     - If a target doesn't exist, consider introducing a target for it with add_library and adding all necessary
+#       includes, definitions, etc, to that target. This way, only libraries that need those attributes simply
+#       need to link that target in, as opposed to them being provided to every library
+#       (which is the case with the directory-based include_directories, add_definitions, etc)
+#
 #   - make sure to tell cmake to link them statically or dynamically (most
 #     should be linked statically)
 #   - place the CMakeLists.txt in the first-level subdirectory, e.g.
 #     Externals/zlib/CMakeLists.txt (that is: NOT in some Src/ subdirectory)
 #
 add_subdirectory(Externals/Bochs_disasm)
-include_directories(Externals/Bochs_disasm)
-
-add_subdirectory(Externals/glslang)
-
-add_subdirectory(Externals/pugixml)
-
 add_subdirectory(Externals/cpp-optparse)
+add_subdirectory(Externals/glslang)
+add_subdirectory(Externals/pugixml)
 
 if(USE_SHARED_ENET)
   check_lib(ENET libenet enet enet/enet.h QUIET)

--- a/Externals/Bochs_disasm/CMakeLists.txt
+++ b/Externals/Bochs_disasm/CMakeLists.txt
@@ -1,10 +1,18 @@
-set(SRCS dis_decode.cc
-         dis_groups.cc
-         resolve.cc
-         syntax.cc)
+add_library(bdisasm STATIC
+  dis_decode.cc
+  dis_groups.cc
+  resolve.cc
+  syntax.cc
+)
 
-if(WIN32)
-    set(SRCS ${SRCS} stdafx.cc)
-endif(WIN32)
+if (WIN32)
+  target_sources(bdisasm
+  PRIVATE
+    stdafx.cc
+  )
+endif()
 
-add_library(bdisasm STATIC ${SRCS})
+target_include_directories(bdisasm
+PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)


### PR DESCRIPTION
Instead add it to the target interface. This way, only libraries that link in bochs will see its include directories.