### PR TITLE
Profiler: Move BlockStat and ProfileStats structures into the Profiler namespace

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -78,7 +78,7 @@ CPUCoreBase* GetCore()
 
 void WriteProfileResults(const std::string& filename)
 {
-  ProfileStats prof_stats;
+  Profiler::ProfileStats prof_stats;
   GetProfileResults(&prof_stats);
 
   File::IOFile f(filename, "w");
@@ -101,7 +101,7 @@ void WriteProfileResults(const std::string& filename)
   }
 }
 
-void GetProfileResults(ProfileStats* prof_stats)
+void GetProfileResults(Profiler::ProfileStats* prof_stats)
 {
   // Can't really do this with no g_jit core available
   if (!g_jit)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -11,7 +11,11 @@
 
 class CPUCoreBase;
 class PointerWrap;
+
+namespace Profiler
+{
 struct ProfileStats;
+}
 
 namespace JitInterface
 {
@@ -29,7 +33,7 @@ CPUCoreBase* GetCore();
 
 // Debugging
 void WriteProfileResults(const std::string& filename);
-void GetProfileResults(ProfileStats* prof_stats);
+void GetProfileResults(Profiler::ProfileStats* prof_stats);
 int GetHostCode(u32* address, const u8** code, u32* code_size);
 
 // Memory Utilities

--- a/Source/Core/Core/PowerPC/Profiler.h
+++ b/Source/Core/Core/PowerPC/Profiler.h
@@ -10,6 +10,10 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Profiler
+{
+extern bool g_ProfileBlocks;
+
 struct BlockStat
 {
   BlockStat(u32 _addr, u64 c, u64 ticks, u64 run, u32 size)
@@ -32,9 +36,5 @@ struct ProfileStats
   u64 countsPerSec;
 };
 
-namespace Profiler
-{
-extern bool g_ProfileBlocks;
-
 void WriteProfileResults(const std::string& filename);
-}
+}  // namespace Profiler


### PR DESCRIPTION
These should be part of the namespaced API and not be sitting in the global namespace.