### PR TITLE
StreamADPCM: Turn the ADPCM decoder into a class

### DIFF
--- a/Source/Core/Core/HW/StreamADPCM.cpp
+++ b/Source/Core/Core/HW/StreamADPCM.cpp
@@ -12,12 +12,6 @@
 
 namespace StreamADPCM
 {
-// STATE_TO_SAVE
-static s32 histl1;
-static s32 histl2;
-static s32 histr1;
-static s32 histr2;
-
 static s16 ADPDecodeSample(s32 bits, s32 q, s32& hist1, s32& hist2)
 {
   s32 hist = 0;
@@ -49,30 +43,30 @@ static s16 ADPDecodeSample(s32 bits, s32 q, s32& hist1, s32& hist2)
   return (s16)cur;
 }
 
-void InitFilter()
+void ADPCMDecoder::ResetFilter()
 {
-  histl1 = 0;
-  histl2 = 0;
-  histr1 = 0;
-  histr2 = 0;
+  m_histl1 = 0;
+  m_histl2 = 0;
+  m_histr1 = 0;
+  m_histr2 = 0;
 }
 
-void DoState(PointerWrap& p)
+void ADPCMDecoder::DoState(PointerWrap& p)
 {
-  p.Do(histl1);
-  p.Do(histl2);
-  p.Do(histr1);
-  p.Do(histr2);
+  p.Do(m_histl1);
+  p.Do(m_histl2);
+  p.Do(m_histr1);
+  p.Do(m_histr2);
 }
 
-void DecodeBlock(s16* pcm, const u8* adpcm)
+void ADPCMDecoder::DecodeBlock(s16* pcm, const u8* adpcm)
 {
   for (int i = 0; i < SAMPLES_PER_BLOCK; i++)
   {
     pcm[i * 2] = ADPDecodeSample(adpcm[i + (ONE_BLOCK_SIZE - SAMPLES_PER_BLOCK)] & 0xf, adpcm[0],
-                                 histl1, histl2);
+                                 m_histl1, m_histl2);
     pcm[i * 2 + 1] = ADPDecodeSample(adpcm[i + (ONE_BLOCK_SIZE - SAMPLES_PER_BLOCK)] >> 4, adpcm[1],
-                                     histr1, histr2);
+                                     m_histr1, m_histr2);
   }
 }
 }

--- a/Source/Core/Core/HW/StreamADPCM.h
+++ b/Source/Core/Core/HW/StreamADPCM.h
@@ -18,7 +18,17 @@ enum
   SAMPLES_PER_BLOCK = 28
 };
 
-void InitFilter();
-void DoState(PointerWrap& p);
-void DecodeBlock(s16* pcm, const u8* adpcm);
+class ADPCMDecoder
+{
+public:
+  void ResetFilter();
+  void DoState(PointerWrap& p);
+  void DecodeBlock(s16* pcm, const u8* adpcm);
+
+private:
+  s32 m_histl1 = 0;
+  s32 m_histl2 = 0;
+  s32 m_histr1 = 0;
+  s32 m_histr2 = 0;
+};
 }


### PR DESCRIPTION
Migrates the state to be instance-based as opposed to being a flat namespace. Effectively, it just 'trades' where the static is placed, but has the benefit of not allowing free-form use all over the codebase. 