### PR TITLE
GekkoDisassembler: Fix disassembly of dcbz_l

### DIFF
--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -1179,6 +1179,7 @@ void GekkoDisassembler::ps(u32 inst)
       ill(inst);
     else
       dab(inst, "dcbz_l", 3, 0, 0, 0, 0);
+    return;
   }
 
   //	default:


### PR DESCRIPTION
Previously this would fall through and disassemble as a generic "ps_[number]" junk instruction.