### PR TITLE
 PPCSymbolDB: Do not truncate fixed size symbols

### DIFF
--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -39,7 +39,7 @@ struct Symbol
   u32 hash = 0;                // use for HLE function finding
   u32 address = 0;
   u32 flags = 0;
-  int size = 0;
+  u32 size = 0;
   int numCalls = 0;
   Type type = Type::Function;
   int index = 0;  // only used for coloring the disasm view

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -83,7 +83,7 @@ static u32 EvaluateBranchTarget(UGeckoInstruction instr, u32 pc)
 // Also collect which internal branch goes the farthest.
 // If any one goes farther than the blr or rfi, assume that there is more than
 // one blr or rfi, and keep scanning.
-bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
+bool AnalyzeFunction(u32 startAddr, Symbol& func, u32 max_size)
 {
   if (func.name.empty())
     func.Rename(StringFromFormat("zz_%08x_", startAddr));
@@ -176,7 +176,7 @@ bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
   }
 }
 
-bool ReanalyzeFunction(u32 start_addr, Symbol& func, int max_size)
+bool ReanalyzeFunction(u32 start_addr, Symbol& func, u32 max_size)
 {
   ASSERT_MSG(SYMBOLS, func.analyzed, "The function wasn't previously analyzed!");
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -225,7 +225,7 @@ private:
 
 void LogFunctionCall(u32 addr);
 void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db);
-bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size = 0);
-bool ReanalyzeFunction(u32 start_addr, Symbol& func, int max_size = 0);
+bool AnalyzeFunction(u32 startAddr, Symbol& func, u32 max_size = 0);
+bool ReanalyzeFunction(u32 start_addr, Symbol& func, u32 max_size = 0);
 
 }  // namespace

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -68,6 +68,13 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
     if (tf.type == Symbol::Type::Function)
     {
       PPCAnalyst::AnalyzeFunction(startAddr, tf, size);
+      // Do not truncate symbol when a size is expected
+      if (size != 0 && tf.size != size)
+      {
+        WARN_LOG(SYMBOLS, "Analysed symbol (%s) size mismatch, %u expected but %u computed",
+                 name.c_str(), size, tf.size);
+        tf.size = size;
+      }
       checksumToFunction[tf.hash].insert(&functions[startAddr]);
     }
     else

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -405,8 +405,7 @@ bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
   }
 
   Index();
-  if (bad)
-    SuccessAlertT("Loaded %d good functions, ignored %d bad functions.", good_count, bad_count);
+  NOTICE_LOG(SYMBOLS, "%d symbols loaded, %d symbols ignored.", good_count, bad_count);
   return true;
 }
 


### PR DESCRIPTION
This PR fixes issues when loading a symbol map and saving it back truncates some symbols size. It often happens with relocated symbols. I also replaced an alert with a log message and rephrased it since symbols can refer to function and data.

Ready to be reviewed & merged.