### PR TITLE
CMakeLists: Don't dump libpng's includes into the top-level directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,7 +599,6 @@ if (PNG_FOUND)
 else()
   message(STATUS "Using static libpng from Externals")
   add_subdirectory(Externals/libpng)
-  include_directories(Externals/libpng)
   set(PNG png)
 endif()
 

--- a/Externals/libpng/CMakeLists.txt
+++ b/Externals/libpng/CMakeLists.txt
@@ -1,5 +1,4 @@
-# OUR SOURCES
-set(SRCS
+add_library(png STATIC
   png.h
   pngconf.h
   png.c
@@ -18,7 +17,15 @@ set(SRCS
   pngwtran.c
   pngwutil.c
 )
+
+target_include_directories(png
+PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 if(NOT MSVC)
-	add_definitions(-Wno-self-assign)
+  target_compile_options(png
+  PRIVATE
+    -Wno-self-assign
+  )
 endif()
-add_library(png STATIC ${SRCS})


### PR DESCRIPTION
Instead, add the includes to the target, which only libraries that link it in can actually see.