### PR TITLE
Interpreter: Don't use a union to type-pun between integral and FP types

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstring>
 #include <limits>
 
 #include "Common/CPUDetect.h"
@@ -71,16 +72,28 @@ inline double ForceDouble(double d)
 
 inline double Force25Bit(double d)
 {
-  MathUtil::IntDouble x(d);
-  x.i = (x.i & 0xFFFFFFFFF8000000ULL) + (x.i & 0x8000000);
-  return x.d;
+  u64 integral;
+  std::memcpy(&integral, &d, sizeof(u64));
+
+  integral = (integral & 0xFFFFFFFFF8000000ULL) + (integral & 0x8000000);
+
+  double result;
+  std::memcpy(&result, &integral, sizeof(double));
+
+  return result;
 }
 
 inline double MakeQuiet(double d)
 {
-  MathUtil::IntDouble x(d);
-  x.i |= MathUtil::DOUBLE_QBIT;
-  return x.d;
+  u64 integral;
+  std::memcpy(&integral, &d, sizeof(u64));
+
+  integral |= MathUtil::DOUBLE_QBIT;
+
+  double result;
+  std::memcpy(&result, &integral, sizeof(double));
+
+  return result;
 }
 
 // these functions allow globally modify operations behaviour


### PR DESCRIPTION
This sort of thing is undefined behavior in C++. Instead, use memcpy, which will always perform the intended behavior.

This removes all usages of IntFloat and IntDouble from Core. The only remaining usages are in Common and the unit tests. I've saved those changes for a separate PR (or two, one for common, one for unit tests and removal). This just makes sure nothing else uses it.