### PR TITLE
Interpreter_FloatingPoint: Handle SNaNs and QNaNs properly in frsp

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -275,11 +275,14 @@ void Interpreter::frspx(UGeckoInstruction inst)  // round to single
   const double b = rPS0(inst.FB);
   const double rounded = ForceSingle(b);
 
-  if (MathUtil::IsSNAN(b))
+  if (std::isnan(b))
   {
-    SetFPException(FPSCR_VXSNAN);
+    const bool is_snan = MathUtil::IsSNAN(b);
 
-    if (FPSCR.VE == 0)
+    if (is_snan)
+      SetFPException(FPSCR_VXSNAN);
+
+    if (!is_snan || FPSCR.VE == 0)
     {
       rPS0(inst.FD) = rounded;
       rPS1(inst.FD) = rounded;


### PR DESCRIPTION
If `FPSCR[VE]` is set, a result isn't supposed to be written to the destination, just the `FPSCR[VXSNAN]` bit gets set, and `FPSCR[FR]` and `FPSCR[FI]` get set to zero.

If `FPSCR[VE]` isn't set, then we do write out a result, however, the `FPSCR[FPRF]` field is updated to signify a QNaN (yes, a QNaN; the `FPRF` field doesn't have a bit configuration dedicated for IDing SNaNs and QNaNs separately).

In the QNaN case, it's the same behavior, however we just don't set the `FPSCR[VXSNAN]` bit and always store a result.

(See D.4.1 in *PowerPC Microprocessor 32-bit Family: The Programming Environments* for more info on this behavior). This was also tested on my Wii as well.