### PR TITLE
CMakeLists: Don't dump LZO's includes into the top-level directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -587,7 +587,6 @@ if(LZO_FOUND)
 else()
   message(STATUS "Using static lzo from Externals")
   add_subdirectory(Externals/LZO)
-  include_directories(Externals/LZO)
   set(LZO lzo2)
 endif()
 

--- a/Externals/LZO/CMakeLists.txt
+++ b/Externals/LZO/CMakeLists.txt
@@ -1,1 +1,8 @@
-add_library(lzo2 STATIC minilzo.c)
+add_library(lzo2 STATIC
+  minilzo.c
+)
+
+target_include_directories(lzo2
+PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)


### PR DESCRIPTION
Instead, we add the includes to the LZO target's interface. That way only libraries that link it in can see them.