### PR TITLE
IOS/STM: Reset the event hook at the correct time

### DIFF
--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -66,10 +66,9 @@ IPCCommandResult STMImmediate::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult STMEventHook::Close(u32 fd)
+STMEventHook::~STMEventHook()
 {
   s_event_hook_request.reset();
-  return Device::Close(fd);
 }
 
 IPCCommandResult STMEventHook::IOCtl(const IOCtlRequest& request)

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -55,7 +55,7 @@ class STMEventHook final : public Device
 {
 public:
   using Device::Device;
-  IPCCommandResult Close(u32 fd) override;
+  ~STMEventHook() override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void DoState(PointerWrap& p) override;
 


### PR DESCRIPTION
Just re-disassembled STM and found out I have made a mistake when
I changed STM stuff back in 2016.

I accidentally made STM reset the event hook on close when it should
have been done in the destructor (i.e. when IOS gets reset on console).

Verified in IDA that STM just `IOS_ResourceReply(request, IOS_OK)`
without ever resetting the hook.