### PR TITLE
x64Emitter: Don't assume that std::tie is constexpr

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -120,8 +120,10 @@ struct OpArg
   }
   constexpr bool operator==(const OpArg& b) const
   {
-    return std::tie(scale, offsetOrBaseReg, indexReg, offset, operandReg) ==
-           std::tie(b.scale, b.offsetOrBaseReg, b.indexReg, b.offset, b.operandReg);
+    // TODO: Use std::tie here once Dolphin requires C++17. (We can't do it immediately,
+    // (because we still support some older versions of GCC where std::tie is not constexpr.)
+    return operandReg == b.operandReg && scale == b.scale && offsetOrBaseReg == b.offsetOrBaseReg &&
+           indexReg == b.indexReg && offset == b.offset;
   }
   constexpr bool operator!=(const OpArg& b) const { return !operator==(b); }
   u64 Imm64() const


### PR DESCRIPTION
Using `constexpr` `std::tie` broke building with older GCC versions according to https://forums.dolphin-emu.org/Thread-build-error-on-linux-mint-18-3