### PR TITLE
Qt/Debugger: correctly set the MBP attributes when adding an address one

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/BreakpointWidget.cpp
@@ -274,6 +274,8 @@ void BreakpointWidget::AddAddressMBP(u32 addr, bool on_read, bool on_write, bool
   TMemCheck check;
 
   check.start_address = addr;
+  check.end_address = addr;
+  check.is_ranged = false;
   check.is_break_on_read = on_read;
   check.is_break_on_write = on_write;
   check.log_on_hit = do_log;


### PR DESCRIPTION
This fixes the address MBP not working in Qt.

The reason they were not working was because the GetMemcheck function doesn't care if it's an address or a range, it will always treat the memcheck as a range.  What is reffered as an address MBP is just one with the same start and end address.  In Qt however, when adding an address MBP, the end address was not set, it defaulted to 0 which caused GetMemcheck to never think it would match anything.

This PR sets it correctly and also set is_ranged just in case (it's better to be explicit about it).