### PR TITLE
CMake: Use system-wide pugixml if available

### DIFF
--- a/CMake/FindPugixml.cmake
+++ b/CMake/FindPugixml.cmake
@@ -1,0 +1,14 @@
+find_path(pugixml_INCLUDE_DIRS pugixml.hpp)
+find_library(pugixml_LIBRARIES NAMES pugixml)
+mark_as_advanced(pugixml_INCLUDE_DIRS pugixml_LIBRARIES)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(pugixml REQUIRED_VARS pugixml_LIBRARIES pugixml_INCLUDE_DIRS)
+
+if(Pugixml_FOUND AND NOT TARGET pugixml)
+  add_library(pugixml UNKNOWN IMPORTED)
+  set_target_properties(pugixml PROPERTIES
+    IMPORTED_LOCATION "${pugixml_LIBRARIES}"
+    INTERFACE_INCLUDE_DIRECTORIES "${pugixml_INCLUDE_DIRS}"
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,7 +533,12 @@ endif()
 add_subdirectory(Externals/Bochs_disasm)
 add_subdirectory(Externals/cpp-optparse)
 add_subdirectory(Externals/glslang)
-add_subdirectory(Externals/pugixml)
+
+find_package(Pugixml)
+if(NOT Pugixml_FOUND)
+  message(STATUS "Using static pugixml from Externals")
+  add_subdirectory(Externals/pugixml)
+endif()
 
 if(USE_SHARED_ENET)
   check_lib(ENET libenet enet enet/enet.h QUIET)


### PR DESCRIPTION
Makes it possible to use a system-wide pugixml instead of always using Externals. This is nicer for distro packagers.