### PR TITLE
Common/Config: Remove redundant declaration and unused includes

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -15,8 +15,6 @@ namespace Config
 static Layers s_layers;
 static std::list<ConfigChangedCallback> s_callbacks;
 
-void InvokeConfigChangedCallbacks();
-
 Layers* GetLayers()
 {
   return &s_layers;

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -5,9 +5,7 @@
 #include <algorithm>
 #include <list>
 #include <map>
-#include <tuple>
 
-#include "Common/Assert.h"
 #include "Common/Config/Config.h"
 
 namespace Config


### PR DESCRIPTION
Fairly self-explanatory.