### PR TITLE
Common/Logging/Log: Wrap GENERIC_LOG macro's body in do { } while (0)

### DIFF
--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -91,33 +91,34 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char*
 
 // Let the compiler optimize this out
 #define GENERIC_LOG(t, v, ...)                                                                     \
+  do                                                                                               \
   {                                                                                                \
     if (v <= MAX_LOGLEVEL)                                                                         \
       GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__);                                           \
-  }
+  } while (0)
 
 #define ERROR_LOG(t, ...)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__)                                        \
+    GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__);                                       \
   } while (0)
 #define WARN_LOG(t, ...)                                                                           \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__)                                      \
+    GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__);                                     \
   } while (0)
 #define NOTICE_LOG(t, ...)                                                                         \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__)                                       \
+    GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__);                                      \
   } while (0)
 #define INFO_LOG(t, ...)                                                                           \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__)                                         \
+    GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__);                                        \
   } while (0)
 #define DEBUG_LOG(t, ...)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__)                                        \
+    GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__);                                       \
   } while (0)

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -616,13 +616,13 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugReportCallback(VkDebugReportFlagsEXT 
   std::string log_message =
       StringFromFormat("Vulkan debug report: (%s) %s", pLayerPrefix ? pLayerPrefix : "", pMessage);
   if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LERROR, "%s", log_message.c_str())
+    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LERROR, "%s", log_message.c_str());
   else if (flags & (VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT))
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LWARNING, "%s", log_message.c_str())
+    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LWARNING, "%s", log_message.c_str());
   else if (flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LINFO, "%s", log_message.c_str())
+    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LINFO, "%s", log_message.c_str());
   else
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LDEBUG, "%s", log_message.c_str())
+    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LDEBUG, "%s", log_message.c_str());
 
   return VK_FALSE;
 }


### PR DESCRIPTION
Enforces the termination of GENERIC_LOGs with semicolons.