### PR TITLE
Common/CMakeLists: Link curl and VTune libraries in privately

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -46,13 +46,13 @@ add_library(common
 target_link_libraries(common
 PUBLIC
   ${CMAKE_THREAD_LIBS_INIT}
-  ${CURL_LIBRARIES}
   enet
   ${MBEDTLS_LIBRARIES}
-  ${VTUNE_LIBRARIES}
 
 PRIVATE
+  ${CURL_LIBRARIES}
   ${ICONV_LIBRARIES}
+  ${VTUNE_LIBRARIES}
 )
 
 if (APPLE)


### PR DESCRIPTION
These are only used internally. Unfortunately getting mbedtls there will be a little more difficult as usages are scattered around and use indirect linkage. This will be done in a follow up; may as well get the low hanging fruit out of the way first.