### PR TITLE
Minor fixes to translatable strings

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -56,8 +56,8 @@ Turntable::Turntable(ExtensionReg& reg) : Attachment(_trans("Turntable"), reg)
   m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "-"));
   m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "+"));
 
-  // i18n: This button name refers to a gameplay element in DJ Hero
   m_buttons->controls.emplace_back(
+      // i18n: This button name refers to a gameplay element in DJ Hero
       new ControllerEmu::Input(ControllerEmu::Translate, _trans("Euphoria")));
 
   // turntables

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -73,7 +73,7 @@ void EnhancementsWidget::CreateWidgets()
   m_widescreen_hack = new GraphicsBool(tr("Widescreen Hack"), Config::GFX_WIDESCREEN_HACK);
   m_disable_fog = new GraphicsBool(tr("Disable Fog"), Config::GFX_DISABLE_FOG);
   m_force_24bit_color =
-      new GraphicsBool(tr("Force 24-bit Color"), Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
+      new GraphicsBool(tr("Force 24-Bit Color"), Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
 
   enhancements_layout->addWidget(new QLabel(tr("Internal Resolution:")), 0, 0);
   enhancements_layout->addWidget(m_ir_combo, 0, 1, 1, -1);

--- a/Source/Core/DolphinQt2/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/MemoryWidget.cpp
@@ -126,8 +126,17 @@ void MemoryWidget::CreateWidgets()
   auto* bp_layout = new QVBoxLayout;
   bp_group->setLayout(bp_layout);
 
-  m_bp_read_write = new QRadioButton(tr("Read and Write"));
+  // i18n: This string is used for a radio button that represents the type of
+  // memory breakpoint that gets triggered when a read operation or write operation occurs.
+  // The string is not a command to read and write something or to allow reading and writing.
+  m_bp_read_write = new QRadioButton(tr("Read and write"));
+  // i18n: This string is used for a radio button that represents the type of
+  // memory breakpoint that gets triggered when a read operation occurs.
+  // The string does not mean "read-only" in the sense that something cannot be written to.
   m_bp_read_only = new QRadioButton(tr("Read only"));
+  // i18n: This string is used for a radio button that represents the type of
+  // memory breakpoint that gets triggered when a write operation occurs.
+  // The string does not mean "write-only" in the sense that something cannot be read from.
   m_bp_write_only = new QRadioButton(tr("Write only"));
   m_bp_log_check = new QCheckBox(tr("Log"));
 
@@ -536,7 +545,7 @@ void MemoryWidget::FindValue(bool next)
 
   if (addr >= ram_size - search_for.size())
   {
-    m_result_label->setText(tr("Address Out Of Range"));
+    m_result_label->setText(tr("Address Out of Range"));
     return;
   }
 

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -130,7 +130,7 @@ void MenuBar::OnDebugModeToggled(bool enabled)
 
 void MenuBar::AddDVDBackupMenu(QMenu* file_menu)
 {
-  m_backup_menu = file_menu->addMenu(tr("Boot from DVD Backup"));
+  m_backup_menu = file_menu->addMenu(tr("&Boot from DVD Backup"));
 
   const std::vector<std::string> drives = cdio_get_devices();
   // Windows Limitation of 24 character drives

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -295,16 +295,6 @@ static wxString gpu_texture_decoding_desc =
     wxTRANSLATE("Enables texture decoding using the GPU instead of the CPU. This may result in "
                 "performance gains in some scenarios, or on systems where the CPU is the "
                 "bottleneck.\n\nIf unsure, leave this unchecked.");
-static wxString ubershader_desc =
-    wxTRANSLATE("Disabled: Ubershaders are never used. Stuttering will occur during shader "
-                "compilation, but GPU demands are low. Recommended for low-end hardware.\n"
-                "Hybrid: Ubershaders will be used to prevent stuttering during shader "
-                "compilation, but traditional shaders will be used when they will not cause "
-                "stuttering. Balances performance and smoothness.\n"
-                "Exclusive: Ubershaders will always be used. Only recommended for high-end "
-                "systems.\n"
-                "Skip Drawing: Does not draw objects during shader compilation. Reduces "
-                "stuttering at the cost of missing objects, or broken effects.");
 static wxString shader_compile_sync_desc =
     wxTRANSLATE("Ubershaders are never used. Stuttering will occur during shader "
                 "compilation, but GPU demands are low. Recommended for low-end hardware.\n\nIf "


### PR DESCRIPTION
The usual deduplication between DolphinWX and DolphinQt2, plus the removal of a now unused ubershader string and a fix for the Euphoria i18n comment.