### PR TITLE
TraversalClient: Minor organizational changes

### DIFF
--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -22,8 +22,7 @@ static void GetRandomishBytes(u8* buf, size_t size)
 }
 
 TraversalClient::TraversalClient(ENetHost* netHost, const std::string& server, const u16 port)
-    : m_NetHost(netHost), m_Client(nullptr), m_ConnectRequestId(0), m_PendingConnect(false),
-      m_Server(server), m_port(port), m_PingTime(0)
+    : m_NetHost(netHost), m_Server(server), m_port(port)
 {
   netHost->intercept = TraversalClient::InterceptCallback;
 

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -243,7 +243,7 @@ void TraversalClient::ResendPacket(OutgoingTraversalPacketInfo* info)
 
 void TraversalClient::HandleResends()
 {
-  enet_uint32 now = enet_time_get();
+  const u32 now = enet_time_get();
   for (auto& tpi : m_OutgoingTraversalPackets)
   {
     if (now - tpi.sendTime >= (u32)(300 * tpi.tries))
@@ -265,7 +265,7 @@ void TraversalClient::HandleResends()
 
 void TraversalClient::HandlePing()
 {
-  enet_uint32 now = enet_time_get();
+  const u32 now = enet_time_get();
   if (m_State == Connected && now - m_PingTime >= 500)
   {
     TraversalPacket ping = {};

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -32,8 +32,21 @@ TraversalClient::TraversalClient(ENetHost* netHost, const std::string& server, c
   ReconnectToServer();
 }
 
-TraversalClient::~TraversalClient()
+TraversalClient::~TraversalClient() = default;
+
+TraversalHostId TraversalClient::GetHostID() const
 {
+  return m_HostId;
+}
+
+TraversalClient::State TraversalClient::GetState() const
+{
+  return m_State;
+}
+
+TraversalClient::FailureReason TraversalClient::GetFailureReason() const
+{
+  return m_FailureReason;
 }
 
 void TraversalClient::ReconnectToServer()

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -59,7 +59,7 @@ private:
   {
     TraversalPacket packet;
     int tries;
-    enet_uint32 sendTime;
+    u32 sendTime;
   };
   void HandleServerPacket(TraversalPacket* packet);
   // called from NetHost
@@ -80,7 +80,7 @@ private:
   ENetAddress m_ServerAddress{};
   std::string m_Server;
   u16 m_port;
-  enet_uint32 m_PingTime = 0;
+  u32 m_PingTime = 0;
 };
 extern std::unique_ptr<TraversalClient> g_TraversalClient;
 // the NetHost connected to the TraversalClient.

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -50,8 +50,6 @@ public:
   void ConnectToClient(const std::string& host);
   void ReconnectToServer();
   void Update();
-  // called from NetHost
-  bool TestPacket(u8* data, size_t size, ENetAddress* from);
   void HandleResends();
 
   TraversalClientClient* m_Client = nullptr;
@@ -64,6 +62,8 @@ private:
     enet_uint32 sendTime;
   };
   void HandleServerPacket(TraversalPacket* packet);
+  // called from NetHost
+  bool TestPacket(u8* data, size_t size, ENetAddress* from);
   void ResendPacket(OutgoingTraversalPacketInfo* info);
   TraversalRequestId SendTraversalPacket(const TraversalPacket& packet);
   void OnFailure(FailureReason reason);

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -41,6 +41,11 @@ public:
   };
   TraversalClient(ENetHost* netHost, const std::string& server, const u16 port);
   ~TraversalClient();
+
+  TraversalHostId GetHostID() const;
+  State GetState() const;
+  FailureReason GetFailureReason() const;
+
   void Reset();
   void ConnectToClient(const std::string& host);
   void ReconnectToServer();
@@ -49,11 +54,7 @@ public:
   bool TestPacket(u8* data, size_t size, ENetAddress* from);
   void HandleResends();
 
-  ENetHost* m_NetHost;
   TraversalClientClient* m_Client;
-  TraversalHostId m_HostId;
-  State m_State;
-  FailureReason m_FailureReason;
 
 private:
   struct OutgoingTraversalPacketInfo
@@ -68,6 +69,11 @@ private:
   void OnFailure(FailureReason reason);
   void HandlePing();
   static int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
+
+  ENetHost* m_NetHost;
+  TraversalHostId m_HostId;
+  State m_State;
+  FailureReason m_FailureReason;
   TraversalRequestId m_ConnectRequestId;
   bool m_PendingConnect;
   std::list<OutgoingTraversalPacketInfo> m_OutgoingTraversalPackets;

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -54,7 +54,7 @@ public:
   bool TestPacket(u8* data, size_t size, ENetAddress* from);
   void HandleResends();
 
-  TraversalClientClient* m_Client;
+  TraversalClientClient* m_Client = nullptr;
 
 private:
   struct OutgoingTraversalPacketInfo
@@ -71,16 +71,16 @@ private:
   static int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
 
   ENetHost* m_NetHost;
-  TraversalHostId m_HostId;
-  State m_State;
-  FailureReason m_FailureReason;
-  TraversalRequestId m_ConnectRequestId;
-  bool m_PendingConnect;
+  TraversalHostId m_HostId{};
+  State m_State{};
+  FailureReason m_FailureReason{};
+  TraversalRequestId m_ConnectRequestId = 0;
+  bool m_PendingConnect = false;
   std::list<OutgoingTraversalPacketInfo> m_OutgoingTraversalPackets;
-  ENetAddress m_ServerAddress;
+  ENetAddress m_ServerAddress{};
   std::string m_Server;
   u16 m_port;
-  enet_uint32 m_PingTime;
+  enet_uint32 m_PingTime = 0;
 };
 extern std::unique_ptr<TraversalClient> g_TraversalClient;
 // the NetHost connected to the TraversalClient.

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -134,7 +134,7 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
     m_traversal_client = g_TraversalClient.get();
 
     // If we were disconnected in the background, reconnect.
-    if (m_traversal_client->m_State == TraversalClient::Failure)
+    if (m_traversal_client->GetState() == TraversalClient::Failure)
       m_traversal_client->ReconnectToServer();
     m_traversal_client->m_Client = this;
     m_host_spec = address;
@@ -909,17 +909,18 @@ void NetPlayClient::ClearBuffers()
 // called from ---NETPLAY--- thread
 void NetPlayClient::OnTraversalStateChanged()
 {
+  const TraversalClient::State state = m_traversal_client->GetState();
+
   if (m_connection_state == ConnectionState::WaitingForTraversalClientConnection &&
-      m_traversal_client->m_State == TraversalClient::Connected)
+      state == TraversalClient::Connected)
   {
     m_connection_state = ConnectionState::WaitingForTraversalClientConnectReady;
     m_traversal_client->ConnectToClient(m_host_spec);
   }
-  else if (m_connection_state != ConnectionState::Failure &&
-           m_traversal_client->m_State == TraversalClient::Failure)
+  else if (m_connection_state != ConnectionState::Failure && state == TraversalClient::Failure)
   {
     Disconnect();
-    m_dialog->OnTraversalError(m_traversal_client->m_FailureReason);
+    m_dialog->OnTraversalError(m_traversal_client->GetFailureReason());
   }
 }
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -90,7 +90,7 @@ NetPlayServer::NetPlayServer(const u16 port, const bool forward_port,
 
     m_server = g_MainNetHost.get();
 
-    if (g_TraversalClient->m_State == TraversalClient::Failure)
+    if (g_TraversalClient->GetState() == TraversalClient::Failure)
       g_TraversalClient->ReconnectToServer();
   }
   else
@@ -736,8 +736,8 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
 void NetPlayServer::OnTraversalStateChanged()
 {
-  if (m_dialog && m_traversal_client->m_State == TraversalClient::Failure)
-    m_dialog->OnTraversalError(m_traversal_client->m_FailureReason);
+  if (m_dialog && m_traversal_client->GetState() == TraversalClient::Failure)
+    m_dialog->OnTraversalError(m_traversal_client->GetFailureReason());
 }
 
 // called from ---GUI--- thread

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -360,19 +360,22 @@ void NetPlayDialog::UpdateGUI()
   // Update Room ID / IP label
   if (m_use_traversal && m_room_box->currentIndex() == 0)
   {
-    switch (g_TraversalClient->m_State)
+    switch (g_TraversalClient->GetState())
     {
     case TraversalClient::Connecting:
       m_hostcode_label->setText(tr("..."));
       m_hostcode_action_button->setEnabled(false);
       break;
     case TraversalClient::Connected:
-      m_hostcode_label->setText(QString::fromStdString(
-          std::string(g_TraversalClient->m_HostId.data(), g_TraversalClient->m_HostId.size())));
+    {
+      const auto host_id = g_TraversalClient->GetHostID();
+      m_hostcode_label->setText(
+          QString::fromStdString(std::string(host_id.begin(), host_id.end())));
       m_hostcode_action_button->setEnabled(true);
       m_hostcode_action_button->setText(tr("Copy"));
       m_is_copy_button_retry = false;
       break;
+    }
     case TraversalClient::Failure:
       m_hostcode_label->setText(tr("Error"));
       m_hostcode_action_button->setText(tr("Retry"));

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -777,7 +777,7 @@ void NetPlayDialog::UpdateHostLabel()
   if (sel == 0)
   {
     // the traversal ID
-    switch (g_TraversalClient->m_State)
+    switch (g_TraversalClient->GetState())
     {
     case TraversalClient::Connecting:
       m_host_label->SetForegroundColour(*wxLIGHT_GREY);
@@ -786,13 +786,15 @@ void NetPlayDialog::UpdateHostLabel()
       m_host_copy_btn->Disable();
       break;
     case TraversalClient::Connected:
+    {
+      const auto host_id = g_TraversalClient->GetHostID();
       m_host_label->SetForegroundColour(*wxBLACK);
-      m_host_label->SetLabel(
-          wxString(g_TraversalClient->m_HostId.data(), g_TraversalClient->m_HostId.size()));
+      m_host_label->SetLabel(wxString(host_id.data(), host_id.size()));
       m_host_copy_btn->SetLabel(_("Copy"));
       m_host_copy_btn->Enable();
       m_host_copy_btn_is_retry = false;
       break;
+    }
     case TraversalClient::Failure:
       m_host_label->SetForegroundColour(*wxBLACK);
       m_host_label->SetLabel("...");


### PR DESCRIPTION
A few minor changes that hides exposed class state. Certainly not at the point where enet related stuff can be entirely internally encapsulated, but it makes it slightly easier to do that (the main obstacle being the silly global variables).