### PR TITLE
Qt/Debugger: Don't pause when already paused

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
@@ -98,7 +98,7 @@ void CodeViewWidget::Update()
 
   u32 pc = PowerPC::ppcState.pc;
 
-  if (PowerPC::debug_interface.IsBreakpoint(pc))
+  if (Core::GetState() != Core::State::Paused && PowerPC::debug_interface.IsBreakpoint(pc))
     Core::SetState(Core::State::Paused);
 
   for (int i = 0; i < rowCount(); i++)


### PR DESCRIPTION
Fixes a severe performance issue which would cause the UI to use tons of CPU time and fail to update when scrolling with a breakpoint on PC.