### PR TITLE
HLE_VarArgs: PowerPC::HostRead_F64 used

### DIFF
--- a/Source/Core/Core/HLE/HLE_VarArgs.cpp
+++ b/Source/Core/Core/HLE/HLE_VarArgs.cpp
@@ -51,17 +51,11 @@ u32 HLE::SystemVABI::VAListStruct::GetGPR(u32 gpr) const
 
 double HLE::SystemVABI::VAListStruct::GetFPR(u32 fpr) const
 {
-  double value = 0.0;
-
   if (!m_has_fpr_area || fpr < 1 || fpr > 8)
   {
     ERROR_LOG(OSHLE, "VAListStruct at %08x doesn't have FPR%d!", m_address, fpr);
+    return 0.0;
   }
-  else
-  {
-    const u32 fpr_address = Common::AlignUp(GetFPRArea() + 8 * (fpr - 1), 8);
-    const u64 integral = PowerPC::HostRead_U64(fpr_address);
-    std::memcpy(&value, &integral, sizeof(double));
-  }
-  return value;
+  const u32 fpr_address = Common::AlignUp(GetFPRArea() + 8 * (fpr - 1), 8);
+  return PowerPC::HostRead_F64(fpr_address);
 }

--- a/Source/Core/Core/HLE/HLE_VarArgs.h
+++ b/Source/Core/Core/HLE/HLE_VarArgs.h
@@ -115,8 +115,7 @@ public:
     else
     {
       m_stack = Common::AlignUp(m_stack, 8);
-      const u64 integral = PowerPC::HostRead_U64(m_stack);
-      std::memcpy(&value, &integral, sizeof(double));
+      value = PowerPC::HostRead_F64(m_stack);
       m_stack += 8;
     }
 


### PR DESCRIPTION
This PR replaces the use of `memcpy` with `PowerPC::HostRead_F64` instead.

Ready to be reviewed & merged.