### PR TITLE
[TEST] IOS/STM: Reset EH at initialisation time, not shutdown

### DIFF
--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -66,7 +66,7 @@ IPCCommandResult STMImmediate::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-STMEventHook::~STMEventHook()
+STMEventHook::STMEventHook(Kernel& ios, const std::string& name) : Device{ios, name}
 {
   s_event_hook_request.reset();
 }

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -54,8 +54,7 @@ public:
 class STMEventHook final : public Device
 {
 public:
-  using Device::Device;
-  ~STMEventHook() override;
+  STMEventHook(Kernel& ios, const std::string& name);
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void DoState(PointerWrap& p) override;
 


### PR DESCRIPTION
This is actually done in the initialisation code, not at shutdown.