### PR TITLE
Fix test rumble feature in controller configuration

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -105,8 +105,8 @@ ControlState InputReference::State(const ControlState ignore)
 //
 ControlState OutputReference::State(const ControlState state)
 {
-  if (m_parsed_expression && InputGateOn())
-    m_parsed_expression->SetValue(state);
+  if (m_parsed_expression)
+    m_parsed_expression->SetValue(state * range);
   return 0.0;
 }
 


### PR DESCRIPTION
This fixes the test rumble feature in controller configuration, which previously did not make the controller rumble at all. The rumble slider feature now controls the intensity of the motors, when it previously had no effect.