### PR TITLE
GameINI: Force safe texture cache for SimCity Creator

### DIFF
--- a/Data/Sys/GameSettings/R4C.ini
+++ b/Data/Sys/GameSettings/R4C.ini
@@ -1,0 +1,4 @@
+# R4CE69 - SimCity Creator
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
This fixes the highlighting on the map when making zones in SimCity Creator.

Here is the incorrect behavior with the slider set to Fast:
![r4ce69-2](https://user-images.githubusercontent.com/7153841/39079892-a3d33bd2-44f1-11e8-8411-75ab59e7aef0.png)

Here is the correct behavior with the slider set to Safe:
![r4ce69-4](https://user-images.githubusercontent.com/7153841/39079898-b4bd5770-44f1-11e8-93e8-5316aeb17fb3.png)

Although setting the slider to the middle option does make the zones show up as well, it is only some of them, so this is the reason I have it set to Safe in the INI.