### PR TITLE
Qt/log change the notice log color to lime

### DIFF
--- a/Source/Core/DolphinQt2/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/LogWidget.cpp
@@ -198,7 +198,7 @@ void LogWidget::Log(LogTypes::LOG_LEVELS level, const char* text)
     color = "yellow";
     break;
   case LogTypes::LOG_LEVELS::LNOTICE:
-    color = "green";
+    color = "lime";
     break;
   case LogTypes::LOG_LEVELS::LINFO:
     color = "cyan";


### PR DESCRIPTION
It's slightly easier to read than green.  Also, the color was changed from Wx and I am not sure why, it's nice to read on a pure black background.

Before 
![screenshot from 2018-04-21 21-35-57](https://user-images.githubusercontent.com/8932978/39090400-3a4ef58c-45ac-11e8-854d-d04f569d9fb3.png)

After
![screenshot from 2018-04-21 21-35-00](https://user-images.githubusercontent.com/8932978/39090404-41092bd6-45ac-11e8-8366-12e3920b2b49.png)


cc: @spycrab 