### PR TITLE
Qt/Settings: Emit EmulationStateChanged from the UI thread

### DIFF
--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -20,8 +20,9 @@
 Settings::Settings()
 {
   qRegisterMetaType<Core::State>();
-  Core::SetOnStateChangedCallback(
-      [this](Core::State new_state) { emit EmulationStateChanged(new_state); });
+  Core::SetOnStateChangedCallback([this](Core::State new_state) {
+    QueueOnObject(this, [this, new_state] { emit EmulationStateChanged(new_state); });
+  });
 
   Config::AddConfigChangedCallback(
       [this] { QueueOnObject(this, [this] { emit ConfigChanged(); }); });


### PR DESCRIPTION
Previously this event would be emitted from the core thread, which is a big no-no. It seems to only affect debug builds though.