### PR TITLE
Qt/RenderWidget: Fix the render widget showing up when it shouldn't

### DIFF
--- a/Source/Core/DolphinQt2/RenderWidget.cpp
+++ b/Source/Core/DolphinQt2/RenderWidget.cpp
@@ -75,10 +75,13 @@ void RenderWidget::OnHideCursorChanged()
 
 void RenderWidget::OnKeepOnTopChanged(bool top)
 {
+  const bool was_visible = isVisible();
+
   setWindowFlags(top ? windowFlags() | Qt::WindowStaysOnTopHint :
                        windowFlags() & ~Qt::WindowStaysOnTopHint);
 
-  show();
+  if (was_visible)
+    show();
 }
 
 void RenderWidget::HandleCursorTimer()


### PR DESCRIPTION
Fixes a bug caused by #6678