### PR TITLE
Qt/GraphicsWindow: Disable unsupported options

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -165,6 +165,16 @@ void EnhancementsWidget::LoadSettings()
       m_pp_effect->setCurrentIndex(m_pp_effect->count() - 1);
   }
 
+  const bool supports_postprocessing = g_Config.backend_info.bSupportsPostProcessing;
+  m_pp_effect->setEnabled(supports_postprocessing);
+
+  if (!supports_postprocessing)
+  {
+    m_pp_effect->setToolTip(
+        tr("%1 doesn't support this feature.")
+            .arg(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend)));
+  }
+
   PostProcessingShaderConfiguration pp_shader;
   if (selected_shader != "(off)")
   {

--- a/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.cpp
@@ -13,6 +13,7 @@
 #include "Core/ConfigManager.h"
 #include "DolphinQt2/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt2/Config/Graphics/GraphicsSlider.h"
+#include "DolphinQt2/Config/Graphics/GraphicsWindow.h"
 #include "VideoCommon/VideoConfig.h"
 
 HacksWidget::HacksWidget(GraphicsWindow* parent) : GraphicsWidget(parent)
@@ -21,6 +22,9 @@ HacksWidget::HacksWidget(GraphicsWindow* parent) : GraphicsWidget(parent)
   LoadSettings();
   ConnectWidgets();
   AddDescriptions();
+
+  connect(parent, &GraphicsWindow::BackendChanged, this, &HacksWidget::OnBackendChanged);
+  OnBackendChanged(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend));
 }
 
 void HacksWidget::CreateWidgets()
@@ -96,6 +100,21 @@ void HacksWidget::CreateWidgets()
   main_layout->addStretch();
 
   setLayout(main_layout);
+}
+
+void HacksWidget::OnBackendChanged(const QString& backend_name)
+{
+  const bool bbox = g_Config.backend_info.bSupportsBBox;
+  const bool gpu_texture_decoding = g_Config.backend_info.bSupportsGPUTextureDecoding;
+
+  m_gpu_texture_decoding->setEnabled(gpu_texture_decoding);
+  m_disable_bounding_box->setEnabled(bbox);
+
+  if (!gpu_texture_decoding)
+    m_gpu_texture_decoding->setToolTip(tr("%1 doesn't support this feature.").arg(backend_name));
+
+  if (!bbox)
+    m_disable_bounding_box->setToolTip(tr("%1 doesn't support this feature.").arg(backend_name));
 }
 
 void HacksWidget::ConnectWidgets()

--- a/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.h
@@ -21,6 +21,8 @@ private:
   void LoadSettings() override;
   void SaveSettings() override;
 
+  void OnBackendChanged(const QString& backend_name);
+
   // EFB
   QCheckBox* m_skip_efb_cpu;
   QCheckBox* m_ignore_format_changes;


### PR DESCRIPTION
Fixes [issue #11016](https://bugs.dolphin-emu.org/issues/11016).