### PR TITLE
Common: Move BitSet into the Common namespace

### DIFF
--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -83,8 +83,7 @@ inline int LeastSignificantSetBit(u64 val)
 }
 #endif
 
-// namespace avoids conflict with OS X Carbon; don't use BitSet<T> directly
-namespace BS
+namespace Common
 {
 // Similar to std::bitset, this is a class which encapsulates a bitset, i.e.
 // using the set bits of an integer to represent a set of integers.  Like that
@@ -207,9 +206,9 @@ public:
   constexpr Iterator end() const { return Iterator(m_val, -1); }
   IntTy m_val;
 };
-}
+}  // namespace Common
 
-typedef BS::BitSet<u8> BitSet8;
-typedef BS::BitSet<u16> BitSet16;
-typedef BS::BitSet<u32> BitSet32;
-typedef BS::BitSet<u64> BitSet64;
+using BitSet8 = Common::BitSet<u8>;
+using BitSet16 = Common::BitSet<u16>;
+using BitSet32 = Common::BitSet<u32>;
+using BitSet64 = Common::BitSet<u64>;

--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -5,7 +5,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <type_traits>
-#include "CommonTypes.h"
+#include "Common/CommonTypes.h"
 
 #ifdef _WIN32
 

--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -7,12 +7,12 @@
 #include <type_traits>
 #include "CommonTypes.h"
 
-// Helper functions:
-
 #ifdef _WIN32
 
 #include <intrin.h>
 
+namespace Common
+{
 template <typename T>
 constexpr int CountSetBits(T v)
 {
@@ -49,6 +49,8 @@ inline int LeastSignificantSetBit(u64 val)
   return (int)index;
 }
 #else
+namespace Common
+{
 constexpr int CountSetBits(u8 val)
 {
   return __builtin_popcount(val);
@@ -83,8 +85,6 @@ inline int LeastSignificantSetBit(u64 val)
 }
 #endif
 
-namespace Common
-{
 // Similar to std::bitset, this is a class which encapsulates a bitset, i.e.
 // using the set bits of an integer to represent a set of integers.  Like that
 // class, it acts like an array of bools:

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -28,8 +28,8 @@ void StateManager::Apply()
   if (!m_dirtyFlags)
     return;
 
-  int textureMaskShift = LeastSignificantSetBit((u32)DirtyFlag_Texture0);
-  int samplerMaskShift = LeastSignificantSetBit((u32)DirtyFlag_Sampler0);
+  const int textureMaskShift = Common::LeastSignificantSetBit((u32)DirtyFlag_Texture0);
+  const int samplerMaskShift = Common::LeastSignificantSetBit((u32)DirtyFlag_Sampler0);
 
   u32 dirtyTextures =
       (m_dirtyFlags &
@@ -105,7 +105,7 @@ void StateManager::Apply()
 
   while (dirtyTextures)
   {
-    int index = LeastSignificantSetBit(dirtyTextures);
+    const int index = Common::LeastSignificantSetBit(dirtyTextures);
     if (m_current.textures[index] != m_pending.textures[index])
     {
       D3D::context->PSSetShaderResources(index, 1, &m_pending.textures[index]);
@@ -117,7 +117,7 @@ void StateManager::Apply()
 
   while (dirtySamplers)
   {
-    int index = LeastSignificantSetBit(dirtySamplers);
+    const int index = Common::LeastSignificantSetBit(dirtySamplers);
     if (m_current.samplers[index] != m_pending.samplers[index])
     {
       D3D::context->PSSetSamplers(index, 1, &m_pending.samplers[index]);
@@ -187,7 +187,7 @@ void StateManager::SetTextureByMask(u32 textureSlotMask, ID3D11ShaderResourceVie
 {
   while (textureSlotMask)
   {
-    int index = LeastSignificantSetBit(textureSlotMask);
+    const int index = Common::LeastSignificantSetBit(textureSlotMask);
     SetTexture(index, srv);
     textureSlotMask &= ~(1 << index);
   }


### PR DESCRIPTION
Having it in its own BS (lol) namespace is inconsistent with the rest of Common. This'll also set the groundwork for moving the aliases that just forward BitSet into the global namespace into the Common namespace itself.