### PR TITLE
Qt/PathPane: Add missing options

### DIFF
--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -60,6 +60,30 @@ void PathPane::BrowseWiiNAND()
   }
 }
 
+void PathPane::BrowseDump()
+{
+  QString dir =
+      QFileDialog::getExistingDirectory(this, tr("Select Dump Path"), QDir::currentPath());
+  if (!dir.isEmpty())
+  {
+    m_dump_edit->setText(dir);
+    SConfig::GetInstance().m_DumpPath = dir.toStdString();
+  }
+}
+
+void PathPane::BrowseSDCard()
+{
+  QString file =
+      QFileDialog::getOpenFileName(this, tr("Select a SD Card Image"), QDir::currentPath(),
+                                   tr("SD Card Image (*.raw);;"
+                                      "All Files (*)"));
+  if (!file.isEmpty())
+  {
+    m_sdcard_edit->setText(file);
+    SConfig::GetInstance().m_strWiiSDCardPath = file.toStdString();
+  }
+}
+
 QGroupBox* PathPane::MakeGameFolderBox()
 {
   QGroupBox* game_box = new QGroupBox(tr("Game Folders"));
@@ -128,6 +152,24 @@ QGridLayout* PathPane::MakePathsLayout()
   layout->addWidget(new QLabel(tr("Wii NAND Root:")), 1, 0);
   layout->addWidget(m_nand_edit, 1, 1);
   layout->addWidget(nand_open, 1, 2);
+
+  m_dump_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_DumpPath));
+  connect(m_dump_edit, &QLineEdit::editingFinished,
+          [=] { SConfig::GetInstance().m_DumpPath = m_dump_edit->text().toStdString(); });
+  QPushButton* dump_open = new QPushButton;
+  connect(dump_open, &QPushButton::clicked, this, &PathPane::BrowseDump);
+  layout->addWidget(new QLabel(tr("Dump Path:")), 2, 0);
+  layout->addWidget(m_dump_edit, 2, 1);
+  layout->addWidget(dump_open, 2, 2);
+
+  m_sdcard_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_strWiiSDCardPath));
+  connect(m_sdcard_edit, &QLineEdit::editingFinished,
+          [=] { SConfig::GetInstance().m_strWiiSDCardPath = m_sdcard_edit->text().toStdString(); });
+  QPushButton* sdcard_open = new QPushButton;
+  connect(sdcard_open, &QPushButton::clicked, this, &PathPane::BrowseSDCard);
+  layout->addWidget(new QLabel(tr("SD Card Path:")), 3, 0);
+  layout->addWidget(m_sdcard_edit, 3, 1);
+  layout->addWidget(sdcard_open, 3, 2);
 
   return layout;
 }

--- a/Source/Core/DolphinQt2/Settings/PathPane.h
+++ b/Source/Core/DolphinQt2/Settings/PathPane.h
@@ -20,6 +20,8 @@ private:
   void Browse();
   void BrowseDefaultGame();
   void BrowseWiiNAND();
+  void BrowseDump();
+  void BrowseSDCard();
   QGroupBox* MakeGameFolderBox();
   QGridLayout* MakePathsLayout();
   void RemovePath();
@@ -27,4 +29,6 @@ private:
   QListWidget* m_path_list;
   QLineEdit* m_game_edit;
   QLineEdit* m_nand_edit;
+  QLineEdit* m_dump_edit;
+  QLineEdit* m_sdcard_edit;
 };


### PR DESCRIPTION
Fixes [issue #11020](https://bugs.dolphin-emu.org/issues/11020).