### PR TITLE
Adds a toggleable function for sorting the gecko codes alphabetically to the gecko code menu

### DIFF
--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
@@ -66,6 +66,7 @@ void GeckoCodeWidget::CreateWidgets()
   m_edit_code = new QPushButton(tr("&Edit Code..."));
   m_remove_code = new QPushButton(tr("&Remove Code"));
   m_download_codes = new QPushButton(tr("Download Codes"));
+  m_sort_codes = new QPushButton(tr("Sort Codes"));
 
   m_download_codes->setToolTip(tr("Download Codes from the WiiRD Database"));
 
@@ -102,6 +103,7 @@ void GeckoCodeWidget::CreateWidgets()
   btn_layout->addWidget(m_edit_code);
   btn_layout->addWidget(m_remove_code);
   btn_layout->addWidget(m_download_codes);
+  btn_layout->addWidget(m_sort_codes);
 
   layout->addLayout(btn_layout);
 
@@ -118,6 +120,7 @@ void GeckoCodeWidget::ConnectWidgets()
   connect(m_remove_code, &QPushButton::pressed, this, &GeckoCodeWidget::RemoveCode);
   connect(m_edit_code, &QPushButton::pressed, this, &GeckoCodeWidget::EditCode);
   connect(m_download_codes, &QPushButton::pressed, this, &GeckoCodeWidget::DownloadCodes);
+  connect(m_sort_codes, &QPushButton::pressed, this, &GeckoCodeWidget::SortCodesLexicographically);
 
   connect(m_warning, &CheatWarningWidget::OpenCheatEnableSettings, this,
           &GeckoCodeWidget::OpenGeneralSettings);
@@ -219,6 +222,12 @@ void GeckoCodeWidget::SaveCodes()
   Gecko::SaveCodes(game_ini_local, m_gecko_codes);
 
   game_ini_local.Save(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
+}
+
+void GeckoCodeWidget::SortCodesLexicographically()
+{
+  m_code_list->setSortingEnabled(!m_code_list->isSortingEnabled());
+  GeckoCodeWidget::UpdateList();
 }
 
 void GeckoCodeWidget::UpdateList()

--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.h
@@ -46,6 +46,7 @@ private:
   void RemoveCode();
   void DownloadCodes();
   void SaveCodes();
+  void SortCodesLexicographically();
 
   const UICommon::GameFile& m_game;
   std::string m_game_id;
@@ -61,6 +62,7 @@ private:
   QPushButton* m_edit_code;
   QPushButton* m_remove_code;
   QPushButton* m_download_codes;
+  QPushButton* m_sort_codes;
   std::vector<Gecko::GeckoCode> m_gecko_codes;
   bool m_restart_required;
 };


### PR DESCRIPTION

Before change:
![beforechange](https://user-images.githubusercontent.com/18172362/39330357-5c5f99da-496f-11e8-9657-950c779d33eb.PNG)

After change with new "Sort codes" button:
![sortcodesbutton](https://user-images.githubusercontent.com/18172362/39330358-5dcdaffa-496f-11e8-99aa-9415fd6a6abc.PNG)
