### PR TITLE
Jit64: warn about code cache flushing

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -584,6 +584,12 @@ void Jit64::Jit(u32 em_address)
   if (IsAlmostFull() || m_far_code.IsAlmostFull() || trampolines.IsAlmostFull() ||
       SConfig::GetInstance().bJITNoBlockCache)
   {
+    if (!SConfig::GetInstance().bJITNoBlockCache)
+    {
+      const auto reason =
+          IsAlmostFull() ? "main" : m_far_code.IsAlmostFull() ? "far" : "trampoline";
+      WARN_LOG(POWERPC, "flushing %s code cache, please report if this happens a lot", reason);
+    }
     ClearCache();
   }
 


### PR DESCRIPTION
The game Go Vacation (SGVEAF) currently stutters a lot because it keeps overflowing the far code cache and all code needs to be re-jitted. Logging this warning gives a useful hint as to what is causing the stuttering.