### PR TITLE
Qt/GameList: Ensure resort when new entries are added

### DIFF
--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
@@ -7,6 +7,7 @@
 
 ListProxyModel::ListProxyModel(QObject* parent) : QSortFilterProxyModel(parent)
 {
+  setDynamicSortFilter(true);
 }
 
 bool ListProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const


### PR DESCRIPTION
Ensures that the gamelist remains sorted even when new entries are added.