### PR TITLE
Common/MemTools: Make handler function internally linked on Windows

### DIFF
--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -28,7 +28,7 @@ namespace EMM
 {
 #ifdef _WIN32
 
-LONG NTAPI Handler(PEXCEPTION_POINTERS pPtrs)
+static LONG NTAPI Handler(PEXCEPTION_POINTERS pPtrs)
 {
   switch (pPtrs->ExceptionRecord->ExceptionCode)
   {


### PR DESCRIPTION
This doesn't need to be an externally linked function.