### PR TITLE
Jit_Integer: Make arrays const in MultiplyImmediate() and twX()

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -968,8 +968,8 @@ void Jit64::MultiplyImmediate(u32 imm, int a, int d, bool overflow)
 
     // We could handle factors of 2^N*3, 2^N*5, and 2^N*9 using lea+shl, but testing shows
     // it seems to be slower overall.
-    static u8 lea_scales[3] = {3, 5, 9};
-    for (int i = 0; i < 3; i++)
+    static constexpr std::array<u8, 3> lea_scales{{3, 5, 9}};
+    for (size_t i = 0; i < lea_scales.size(); i++)
     {
       if (imm == lea_scales[i])
       {
@@ -1899,10 +1899,10 @@ void Jit64::twX(UGeckoInstruction inst)
     CMP(32, gpr.R(a), gpr.R(inst.RB));
   }
 
+  constexpr std::array<CCFlags, 5> conditions{{CC_A, CC_B, CC_E, CC_G, CC_L}};
   std::vector<FixupBranch> fixups;
-  CCFlags conditions[] = {CC_A, CC_B, CC_E, CC_G, CC_L};
 
-  for (int i = 0; i < 5; i++)
+  for (size_t i = 0; i < conditions.size(); i++)
   {
     if (inst.TO & (1 << i))
     {


### PR DESCRIPTION
These are only ever read from, so make the data immutable to be explicit about that up front