### PR TITLE
CubebStream: Check current state before switching it

### DIFF
--- a/Source/Core/AudioCommon/CubebStream.cpp
+++ b/Source/Core/AudioCommon/CubebStream.cpp
@@ -67,10 +67,20 @@ bool CubebStream::Init()
 
 bool CubebStream::SetRunning(bool running)
 {
+  if (m_running == running)
+    return true;
+
+  bool success;
+
   if (running)
-    return cubeb_stream_start(m_stream) == CUBEB_OK;
+    success = cubeb_stream_start(m_stream) == CUBEB_OK;
   else
-    return cubeb_stream_stop(m_stream) == CUBEB_OK;
+    success = cubeb_stream_stop(m_stream) == CUBEB_OK;
+
+  if (success)
+    m_running = running;
+
+  return success;
 }
 
 CubebStream::~CubebStream()

--- a/Source/Core/AudioCommon/CubebStream.h
+++ b/Source/Core/AudioCommon/CubebStream.h
@@ -22,6 +22,7 @@ public:
 
 private:
   bool m_stereo = false;
+  bool m_running = false;
   std::shared_ptr<cubeb> m_ctx;
   cubeb_stream* m_stream = nullptr;
 


### PR DESCRIPTION
Cubeb used to crash a lot when stopping Emulation. This PR fixes that.