### PR TITLE
DolphinQt2: Correct the condition for enabling Cheat Manager

### DIFF
--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -100,7 +100,7 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   m_recording_play->setEnabled(!running);
 
   // Tools
-  m_show_cheat_manager->setEnabled(Settings::Instance().GetCheatsEnabled());
+  m_show_cheat_manager->setEnabled(Settings::Instance().GetCheatsEnabled() && running);
 
   // Symbols
   m_symbols->setEnabled(running);


### PR DESCRIPTION
Only the other condition, the one that runs when the cheat setting changes, was taking into account whether emulation was running.