### PR TITLE
Qt/GameList: Always sort games alphabetically

### DIFF
--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
@@ -15,3 +15,20 @@ bool ListProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_
   GameListModel* glm = qobject_cast<GameListModel*>(sourceModel());
   return glm->ShouldDisplayGameListItem(source_row);
 }
+
+bool ListProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
+{
+  if (left.data(Qt::InitialSortOrderRole) != right.data(Qt::InitialSortOrderRole))
+    return !QSortFilterProxyModel::lessThan(left, right);
+
+  // If two items are otherwise equal, compare them by their title
+  const auto right_title =
+      sourceModel()->index(right.row(), GameListModel::COL_TITLE).data().toString();
+  const auto left_title =
+      sourceModel()->index(left.row(), GameListModel::COL_TITLE).data().toString();
+
+  if (sortOrder() == Qt::AscendingOrder)
+    return left_title < right_title;
+
+  return right_title < left_title;
+}

--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.h
@@ -14,4 +14,7 @@ class ListProxyModel final : public QSortFilterProxyModel
 public:
   explicit ListProxyModel(QObject* parent = nullptr);
   bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+
+protected:
+  bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 };


### PR DESCRIPTION
Even when sorting by another column (e.g. Platform) an alphabetical order within that sorting must be upheld.