### PR TITLE
TextureConversionShader: Fix compile errors in OpenGL ES

### DIFF
--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -731,8 +731,8 @@ static void WriteXFBEncoder(char*& p, APIType ApiType, const EFBCopyParams& para
   WriteSampleColor(p, "rgb", "color1", 1, ApiType, params);
 
   // Gamma is only applied to XFB copies.
-  WRITE(p, "  color0 = pow(color0, gamma_rcp.xxx);\n");
-  WRITE(p, "  color1 = pow(color1, gamma_rcp.xxx);\n");
+  WRITE(p, "  color0 = pow(color0, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
+  WRITE(p, "  color1 = pow(color1, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
 
   // Convert to YUV.
   WRITE(p, "  const float3 y_const = float3(0.257, 0.504, 0.098);\n");

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -256,7 +256,8 @@ ShaderCode GenerateShader(APIType api_type, const UidData* uid_data)
       break;
 
     case EFBCopyFormat::XFB:
-      out.Write("  ocol0 = float4(pow(texcol.rgb, gamma_rcp.xxx), texcol.a);\n");
+      out.Write("  ocol0 = float4(pow(texcol.rgb, float3(gamma_rcp, gamma_rcp, gamma_rcp)), "
+                "texcol.a);\n");
       break;
 
     default:


### PR DESCRIPTION
Regression from #6369.

Could someone please confirm this fixes the compile errors on Android?