### PR TITLE
Fixed aspect ratio bigger than 16:9 on Android Devices

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:supportsRtl="true"
         android:isGame="true"
         android:banner="@drawable/banner_tv">
+        <meta-data android:name="android.max_aspect" android:value="2.1" />
 
         <activity
             android:name=".ui.main.MainActivity"


### PR DESCRIPTION
Smallish change, makes the application fullscreen on the Galaxy S8 (or any ultrawide phone)