### PR TITLE
TextureConversionShader: Don't sample from adjacent rows when not needed

### DIFF
--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -240,7 +240,8 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
   }
 
   auto uid = TextureConversionShaderGen::GetShaderUid(dst_format, is_depth_copy, is_intensity,
-                                                      scale_by_half);
+                                                      scale_by_half,
+                                                      NeedsCopyFilterInShader(filter_coefficients));
   ID3D11PixelShader* pixel_shader = GetEFBToTexPixelShader(uid);
   if (!pixel_shader)
     return;

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -515,7 +515,8 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
   glViewport(0, 0, destination_texture->GetConfig().width, destination_texture->GetConfig().height);
 
   auto uid = TextureConversionShaderGen::GetShaderUid(dst_format, is_depth_copy, is_intensity,
-                                                      scale_by_half);
+                                                      scale_by_half,
+                                                      NeedsCopyFilterInShader(filter_coefficients));
 
   auto it = m_efb_copy_programs.emplace(uid, EFBCopyShader());
   EFBCopyShader& shader = it.first->second;

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -274,7 +274,8 @@ void TextureCache::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
                                                      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
   auto uid = TextureConversionShaderGen::GetShaderUid(dst_format, is_depth_copy, is_intensity,
-                                                      scale_by_half);
+                                                      scale_by_half,
+                                                      NeedsCopyFilterInShader(filter_coefficients));
 
   auto it = m_efb_copy_to_tex_shaders.emplace(uid, VkShaderModule(VK_NULL_HANDLE));
   VkShaderModule& shader = it.first->second;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1499,8 +1499,8 @@ void TextureCacheBase::LoadTextureLevelZeroFromMemory(TCacheEntry* entry_to_upda
   }
 }
 
-TextureCacheBase::CopyFilterCoefficientArray
-TextureCacheBase::GetRAMCopyFilterCoefficients(const CopyFilterCoefficients::Values& coefficients)
+TextureCacheBase::CopyFilterCoefficientArray TextureCacheBase::GetRAMCopyFilterCoefficients(
+    const CopyFilterCoefficients::Values& coefficients) const
 {
   // To simplify the backend, we precalculate the three coefficients in common. Coefficients 0, 1
   // are for the row above, 2, 3, 4 are for the current pixel, and 5, 6 are for the row below.
@@ -1510,8 +1510,8 @@ TextureCacheBase::GetRAMCopyFilterCoefficients(const CopyFilterCoefficients::Val
           static_cast<u32>(coefficients[5]) + static_cast<u32>(coefficients[6])};
 }
 
-TextureCacheBase::CopyFilterCoefficientArray
-TextureCacheBase::GetVRAMCopyFilterCoefficients(const CopyFilterCoefficients::Values& coefficients)
+TextureCacheBase::CopyFilterCoefficientArray TextureCacheBase::GetVRAMCopyFilterCoefficients(
+    const CopyFilterCoefficients::Values& coefficients) const
 {
   // If the user disables the copy filter, only apply it to the VRAM copy.
   // This way games which are sensitive to changes to the RAM copy of the XFB will be unaffected.
@@ -1526,6 +1526,12 @@ TextureCacheBase::GetVRAMCopyFilterCoefficients(const CopyFilterCoefficients::Va
   res[0] = 0;
   res[2] = 0;
   return res;
+}
+
+bool TextureCacheBase::NeedsCopyFilterInShader(const CopyFilterCoefficientArray& coefficients) const
+{
+  // If the top/bottom coefficients are zero, no point sampling/blending from these rows.
+  return coefficients[0] != 0 || coefficients[2] != 0;
 }
 
 void TextureCacheBase::CopyRenderTargetToTexture(
@@ -1650,11 +1656,12 @@ void TextureCacheBase::CopyRenderTargetToTexture(
 
   if (copy_to_ram)
   {
+    CopyFilterCoefficientArray coefficients = GetRAMCopyFilterCoefficients(filter_coefficients);
     PEControl::PixelFormat srcFormat = bpmem.zcontrol.pixel_format;
-    EFBCopyParams format(srcFormat, dstFormat, is_depth_copy, isIntensity);
+    EFBCopyParams format(srcFormat, dstFormat, is_depth_copy, isIntensity,
+                         NeedsCopyFilterInShader(coefficients));
     CopyEFB(dst, format, tex_w, bytes_per_row, num_blocks_y, dstStride, srcRect, scaleByHalf,
-            y_scale, gamma, clamp_top, clamp_bottom,
-            GetRAMCopyFilterCoefficients(filter_coefficients));
+            y_scale, gamma, clamp_top, clamp_bottom, coefficients);
   }
   else
   {

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -180,21 +180,33 @@ static void WriteSampleFunction(char*& p, const EFBCopyParams& params, APIType A
   // The filter is only applied to the RGB channels, the alpha channel is left intact.
   WRITE(p, "float4 SampleEFB(float2 uv, float2 pixel_size, int xoffset)\n");
   WRITE(p, "{\n");
-  WRITE(p, "  float4 prev_row = ");
-  WriteSampleOp(-1);
-  WRITE(p, ";\n");
-  WRITE(p, "  float4 current_row = ");
-  WriteSampleOp(0);
-  WRITE(p, ";\n");
-  WRITE(p, "  float4 next_row = ");
-  WriteSampleOp(1);
-  WRITE(p, ";\n");
-  WRITE(p,
+  if (params.copy_filter)
+  {
+    WRITE(p, "  float4 prev_row = ");
+    WriteSampleOp(-1);
+    WRITE(p, ";\n");
+    WRITE(p, "  float4 current_row = ");
+    WriteSampleOp(0);
+    WRITE(p, ";\n");
+    WRITE(p, "  float4 next_row = ");
+    WriteSampleOp(1);
+    WRITE(p, ";\n");
+    WRITE(
+        p,
         "  float3 col = float3(clamp((int3(prev_row.rgb * 255.0) * filter_coefficients[0] +\n"
         "                             int3(current_row.rgb * 255.0) * filter_coefficients[1] +\n"
         "                             int3(next_row.rgb * 255.0) * filter_coefficients[2]) >> 6,\n"
         "                            int3(0, 0, 0), int3(255, 255, 255))) / 255.0;\n");
-  WRITE(p, "  return float4(col, current_row.a);\n");
+    WRITE(p, "  return float4(col, current_row.a);\n");
+  }
+  else
+  {
+    WRITE(p, "  float4 current_row = ");
+    WriteSampleOp(0);
+    WRITE(p, ";\n");
+    WRITE(p, "  return float4(clamp(int3(current_row.rgb * 255.0) * filter_coefficients[1], "
+             "int3(0, 0, 0), int3(255, 255, 255)), current_row.a);\n");
+  }
   WRITE(p, "}\n");
 }
 

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.h
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.h
@@ -22,6 +22,7 @@ struct UidData
   u32 is_depth_copy : 1;
   u32 is_intensity : 1;
   u32 scale_by_half : 1;
+  u32 copy_filter : 1;
 };
 #pragma pack()
 
@@ -30,6 +31,6 @@ using TCShaderUid = ShaderUid<UidData>;
 ShaderCode GenerateShader(APIType api_type, const UidData* uid_data);
 
 TCShaderUid GetShaderUid(EFBCopyFormat dst_format, bool is_depth_copy, bool is_intensity,
-                         bool scale_by_half);
+                         bool scale_by_half, bool copy_filter);
 
 }  // namespace TextureConversionShaderGen


### PR DESCRIPTION
When the copy filter was implemented in #6369, it added sampling of the adjacent (top/bottom) texels of the image for every pixel in the EFB copy. These pixels are likely already in the GPU's caches, due to tiling, but for low-spec systems and mobile devices, it may still have a performance impact.

This change skips the sampling of the top/bottom texels when the corresponding coefficients are zero, as they are having no effects on the result. Would be interesting to see if this changes performance at all on our Android builds.