### PR TITLE
INI: Create a new INI setting for toggling the debugger UI

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -175,6 +175,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("ThemeName", theme_name);
   interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
   interface->Set("DisableTooltips", m_DisableTooltips);
+  interface->Set("DebugModeEnabled", bEnableDebugging);
 }
 
 void SConfig::SaveDisplaySettings(IniFile& ini)
@@ -461,6 +462,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("ThemeName", &theme_name, DEFAULT_THEME_DIR);
   interface->Get("PauseOnFocusLost", &m_PauseOnFocusLost, false);
   interface->Get("DisableTooltips", &m_DisableTooltips, false);
+  interface->Get("DebugModeEnabled", &bEnableDebugging, false);
 }
 
 void SConfig::LoadDisplaySettings(IniFile& ini)

--- a/Source/Core/DolphinQt2/Main.cpp
+++ b/Source/Core/DolphinQt2/Main.cpp
@@ -105,7 +105,6 @@ int main(int argc, char* argv[])
   UICommon::CreateDirectories();
   UICommon::Init();
   Resources::Init();
-  Settings::Instance().SetDebugModeEnabled(options.is_set("debugger"));
   Settings::Instance().SetBatchModeEnabled(options.is_set("batch"));
 
   // Hook up alerts from core
@@ -148,6 +147,8 @@ int main(int argc, char* argv[])
     DolphinAnalytics::Instance()->ReportDolphinStart("qt");
 
     MainWindow win{std::move(boot)};
+    if (options.is_set("debugger"))
+      Settings::Instance().SetDebugModeEnabled(true);
     win.show();
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS


### PR DESCRIPTION
Qt introduced a checkbox to toggle the debugger UI, this makes it work into a setting stored in the INI, it also makes the -d argument only in effect when enabled, in such case, it will override the INI by enabling it.

As for Wx, as I override the setting if the -d argument was passed (which is the only way other than to build in debug config to enable it in that frontend), it will still work as in the now deprecated Wx frontend.

Now, I talked with @spycrab about this and they told me that when they asked on IRC beforehand to add it as a INI setting, someone told them to not do it for a particular reason that they do not remember.  However, I would like to know possible reasons to not do it because in my opinion, this would increase convenience.  

Having to pass -d is pretty annoying in my opinion to have it on launch, especially now that Qt has a setting to it, it seems kinda strange to me to have that setting only work at runtime.  Additionally, as I am someone that uses the debugger (and test it) regularly, I would like to have an easier way to have this done, same for when debugging the debugger because I have to configure the environements to pass the -d argument.

EDIT: this also fix a ptential bug where even with the argument, the widgets wouldn't show, now the argument takes effect correctly.