### PR TITLE
HttpRequest/Curl: Use a more intelligent timeout method

### DIFF
--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -108,7 +108,12 @@ HttpRequest::Impl::Impl(std::chrono::milliseconds timeout_ms, ProgressCallback c
   // libcurl may not have been built with async DNS support, so we disable
   // signal handlers to avoid a possible and likely crash if a resolve times out.
   curl_easy_setopt(m_curl.get(), CURLOPT_NOSIGNAL, true);
-  curl_easy_setopt(m_curl.get(), CURLOPT_TIMEOUT_MS, static_cast<long>(timeout_ms.count()));
+  curl_easy_setopt(m_curl.get(), CURLOPT_CONNECTTIMEOUT_MS, static_cast<long>(timeout_ms.count()));
+  // Sadly CURLOPT_LOW_SPEED_TIME doesn't have a millisecond variant so we have to use seconds
+  curl_easy_setopt(
+      m_curl.get(), CURLOPT_LOW_SPEED_TIME,
+      static_cast<long>(std::chrono::duration_cast<std::chrono::seconds>(timeout_ms).count()));
+  curl_easy_setopt(m_curl.get(), CURLOPT_LOW_SPEED_LIMIT, 1);
 #ifdef _WIN32
   // ALPN support is enabled by default but requires Windows >= 8.1.
   curl_easy_setopt(m_curl.get(), CURLOPT_SSL_ENABLE_ALPN, false);


### PR DESCRIPTION
Instead of timing out after a fixed amount of seconds, this PR will only let the connection timeout if no data is sent for a prolonged period of time or the server doesn't send a response.