### PR TITLE
IOS/NCD: Migrate to new filesystem interface

### DIFF
--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -157,6 +157,11 @@ public:
                                      FileAttribute attribute, Mode owner_mode, Mode group_mode,
                                      Mode other_mode) = 0;
 
+  /// Create any parent directories for a path with the specified metadata.
+  /// Example: "/a/b" to create directory /a; "/a/b/" to create directories /a and /a/b
+  ResultCode CreateFullPath(Uid caller_uid, Gid caller_gid, const std::string& path,
+                            FileAttribute attribute, Mode ownerm, Mode group, Mode other);
+
   /// Delete a file or directory with the specified path.
   virtual ResultCode Delete(Uid caller_uid, Gid caller_gid, const std::string& path) = 0;
   /// Rename a file or directory with the specified path.

--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -21,6 +21,7 @@ namespace Device
 {
 NetNCDManage::NetNCDManage(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
+  config.ReadConfig(ios.GetFS().get());
 }
 
 IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
@@ -51,14 +52,14 @@ IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
 
   case IOCTLV_NCD_READCONFIG:
     INFO_LOG(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_READCONFIG");
-    config.ReadConfig();
+    config.ReadConfig(m_ios.GetFS().get());
     config.WriteToMem(request.io_vectors.at(0).address);
     break;
 
   case IOCTLV_NCD_WRITECONFIG:
     INFO_LOG(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_WRITECONFIG");
     config.ReadFromMem(request.in_vectors.at(0).address);
-    config.WriteConfig();
+    config.WriteConfig(m_ios.GetFS().get());
     break;
 
   case IOCTLV_NCD_GETLINKSTATUS:

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.h
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.h
@@ -11,6 +11,11 @@ namespace IOS
 {
 namespace HLE
 {
+namespace FS
+{
+class FileSystem;
+}
+
 namespace Net
 {
 #pragma pack(push, 1)
@@ -105,9 +110,9 @@ class WiiNetConfig final
 public:
   WiiNetConfig();
 
-  void ReadConfig();
-  void WriteConfig() const;
-  void ResetConfig();
+  void ReadConfig(FS::FileSystem* fs);
+  void WriteConfig(FS::FileSystem* fs) const;
+  void ResetConfig(FS::FileSystem* fs);
 
   void WriteToMem(u32 address) const;
   void ReadFromMem(u32 address);
@@ -135,7 +140,6 @@ private:
   };
 #pragma pack(pop)
 
-  std::string m_path;
   ConfigData m_data;
 };
 }  // namespace Net


### PR DESCRIPTION
Followup for the migration work started in 8317a66

The goal is to make all accesses to the Wii filesystem go through the common interface so that we can switch to a different storage and keep track of things like metadata in the future.

Conveniently, we already have UID values for all of the IOS sysmodules so the only thing we need to do is pass them to the FS code.