### PR TITLE
Qt: Make dialogues more consistent

### DIFF
--- a/Source/Core/DolphinQt2/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/ARCodeWidget.cpp
@@ -137,7 +137,7 @@ void ARCodeWidget::OnCodeAddPressed()
   ActionReplay::ARCode ar;
   ar.active = true;
 
-  CheatCodeEditor ed;
+  CheatCodeEditor ed(this);
 
   ed.SetARCode(&ar);
 
@@ -165,7 +165,7 @@ void ARCodeWidget::OnCodeEditPressed()
 
   ActionReplay::ARCode ar = current_ar;
 
-  CheatCodeEditor ed;
+  CheatCodeEditor ed(this);
 
   ed.SetARCode(user_defined ? &current_ar : &ar);
   ed.exec();

--- a/Source/Core/DolphinQt2/Config/CheatCodeEditor.cpp
+++ b/Source/Core/DolphinQt2/Config/CheatCodeEditor.cpp
@@ -17,8 +17,11 @@
 #include "Core/ActionReplay.h"
 #include "Core/GeckoCodeConfig.h"
 
-CheatCodeEditor::CheatCodeEditor()
+CheatCodeEditor::CheatCodeEditor(QWidget* parent) : QDialog(parent)
 {
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+  setWindowTitle(tr("Cheat Code Editor"));
+
   CreateWidgets();
   ConnectWidgets();
 }

--- a/Source/Core/DolphinQt2/Config/CheatCodeEditor.h
+++ b/Source/Core/DolphinQt2/Config/CheatCodeEditor.h
@@ -22,7 +22,7 @@ class GeckoCode;
 class CheatCodeEditor : public QDialog
 {
 public:
-  explicit CheatCodeEditor();
+  explicit CheatCodeEditor(QWidget* parent);
 
   void SetARCode(ActionReplay::ARCode* code);
   void SetGeckoCode(Gecko::GeckoCode* code);

--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
@@ -168,7 +168,7 @@ void GeckoCodeWidget::AddCode()
   Gecko::GeckoCode code;
   code.enabled = true;
 
-  CheatCodeEditor ed;
+  CheatCodeEditor ed(this);
   ed.SetGeckoCode(&code);
 
   if (ed.exec())
@@ -188,7 +188,7 @@ void GeckoCodeWidget::EditCode()
 
   int row = m_code_list->row(item);
 
-  CheatCodeEditor ed;
+  CheatCodeEditor ed(this);
 
   ed.SetGeckoCode(&m_gecko_codes[row]);
 

--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -188,6 +188,7 @@ void InfoWidget::ComputeChecksum()
   QProgressDialog* progress =
       new QProgressDialog(tr("Computing MD5 Checksum"), tr("Cancel"), 0, 1000, this);
   progress->setWindowTitle(tr("Computing MD5 Checksum"));
+  progress->setWindowFlags(progress->windowFlags() & ~Qt::WindowContextHelpButtonHint);
   progress->setMinimumDuration(500);
   progress->setWindowModality(Qt::WindowModal);
   while (read_offset < game_size)

--- a/Source/Core/DolphinQt2/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/NewPatchDialog.cpp
@@ -17,7 +17,8 @@
 
 #include <iostream>
 
-NewPatchDialog::NewPatchDialog(PatchEngine::Patch& patch) : m_patch(patch)
+NewPatchDialog::NewPatchDialog(QWidget* parent, PatchEngine::Patch& patch)
+    : QDialog(parent), m_patch(patch)
 {
   setWindowTitle(tr("Patch Editor"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);

--- a/Source/Core/DolphinQt2/Config/NewPatchDialog.h
+++ b/Source/Core/DolphinQt2/Config/NewPatchDialog.h
@@ -20,7 +20,7 @@ class QPushButton;
 class NewPatchDialog : public QDialog
 {
 public:
-  explicit NewPatchDialog(PatchEngine::Patch& patch);
+  explicit NewPatchDialog(QWidget* parent, PatchEngine::Patch& patch);
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt2/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/PatchesWidget.cpp
@@ -69,7 +69,7 @@ void PatchesWidget::OnAdd()
   PatchEngine::Patch patch;
   patch.user_defined = true;
 
-  if (NewPatchDialog(patch).exec())
+  if (NewPatchDialog(this, patch).exec())
   {
     m_patches.push_back(patch);
     SavePatches();
@@ -93,7 +93,7 @@ void PatchesWidget::OnEdit()
     patch.name = tr("%1 (Copy)").arg(QString::fromStdString(patch.name)).toStdString();
   }
 
-  if (NewPatchDialog(patch).exec())
+  if (NewPatchDialog(this, patch).exec())
   {
     if (patch.user_defined)
     {

--- a/Source/Core/DolphinQt2/NetPlay/GameListDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/GameListDialog.cpp
@@ -14,6 +14,7 @@
 GameListDialog::GameListDialog(QWidget* parent) : QDialog(parent)
 {
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+  setWindowTitle(tr("Select a game"));
 
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt2/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -40,6 +40,8 @@ USBDeviceAddToWhitelistDialog::USBDeviceAddToWhitelistDialog(QWidget* parent) : 
 void USBDeviceAddToWhitelistDialog::InitControls()
 {
   setWindowTitle(tr("Add New USB Device"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
   m_whitelist_buttonbox = new QDialogButtonBox();
   auto* add_button = new QPushButton(tr("Add"));
   m_whitelist_buttonbox->addButton(add_button, QDialogButtonBox::AcceptRole);


### PR DESCRIPTION
Changes:
* Remove "What's this" button from multiple dialogues
* Add titles to multiple dialogues that were missing them
* Make sure the dialogues display the proper application icon