### PR TITLE
Qt/NetPlay: Fix crashes on start

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -921,6 +921,7 @@ bool MainWindow::NetPlayJoin()
   {
     QMessageBox::critical(nullptr, QObject::tr("Error"),
                           QObject::tr("Failed to connect to server"));
+    NetPlayQuit();
     return false;
   }
 
@@ -970,6 +971,7 @@ bool MainWindow::NetPlayHost(const QString& game_id)
         QObject::tr(
             "Failed to listen on port %1. Is another instance of the NetPlay server running?")
             .arg(host_port));
+    NetPlayQuit();
     return false;
   }
 


### PR DESCRIPTION
Fixes [issue #11054](https://bugs.dolphin-emu.org/issues/11054).