### PR TITLE
IOS/ES: Migrate to new filesystem interface

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -343,12 +343,8 @@ void ES::DoState(PointerWrap& p)
     p.Do(entry.m_opened);
     p.Do(entry.m_title_id);
     p.Do(entry.m_content);
-    p.Do(entry.m_position);
+    p.Do(entry.m_fd);
     p.Do(entry.m_uid);
-    if (entry.m_opened)
-      entry.m_opened = entry.m_file.Open(GetContentPath(entry.m_title_id, entry.m_content), "rb");
-    else
-      entry.m_file.Close();
   }
 
   m_title_context.DoState(p);

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -10,9 +10,9 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/IOSC.h"
 
@@ -339,14 +339,12 @@ private:
                              const IOS::ES::SharedContentMap& map) const;
   std::string GetContentPath(u64 title_id, const IOS::ES::Content& content) const;
 
-  // TODO: reuse the FS code.
   struct OpenedContent
   {
     bool m_opened = false;
-    File::IOFile m_file;
+    FS::Fd m_fd;
     u64 m_title_id = 0;
     IOS::ES::Content m_content;
-    u32 m_position = 0;
     u32 m_uid = 0;
   };
 

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -336,8 +336,8 @@ private:
   void FinishAllStaleImports();
 
   std::string GetContentPath(u64 title_id, const IOS::ES::Content& content,
-                             const IOS::ES::SharedContentMap& map = IOS::ES::SharedContentMap{
-                                 Common::FROM_SESSION_ROOT}) const;
+                             const IOS::ES::SharedContentMap& map) const;
+  std::string GetContentPath(u64 title_id, const IOS::ES::Content& content) const;
 
   // TODO: reuse the FS code.
   struct OpenedContent

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -326,7 +326,7 @@ private:
                              const std::vector<u8>& cert_chain, u32 iosc_handle = 0);
 
   // Start a title import.
-  bool InitImport(u64 title_id);
+  bool InitImport(const IOS::ES::TMDReader& tmd);
   // Clean up the import content directory and move it back to /title.
   bool FinishImport(const IOS::ES::TMDReader& tmd);
   // Write a TMD for a title in /import atomically.

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -19,13 +19,13 @@
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
-#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
+#include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
 #include "Core/CommonTitles.h"
 #include "Core/IOS/Device.h"
+#include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/IOSC.h"
 
@@ -489,15 +489,15 @@ struct SharedContentMap::Entry
   std::array<u8, 20> sha1;
 };
 
-SharedContentMap::SharedContentMap(Common::FromWhichRoot root) : m_root(root)
+static const std::string CONTENT_MAP_PATH = "/shared1/content.map";
+SharedContentMap::SharedContentMap(std::shared_ptr<HLE::FS::FileSystem> fs) : m_fs{fs}
 {
   static_assert(sizeof(Entry) == 28, "SharedContentMap::Entry has the wrong size");
 
-  m_file_path = Common::RootUserPath(root) + "/shared1/content.map";
-
-  File::IOFile file(m_file_path, "rb");
   Entry entry;
-  while (file.ReadArray(&entry, 1))
+  const auto file =
+      fs->OpenFile(HLE::PID_KERNEL, HLE::PID_KERNEL, CONTENT_MAP_PATH, HLE::FS::Mode::Read);
+  while (file && file->Read(&entry, 1))
   {
     m_entries.push_back(entry);
     m_last_id++;
@@ -515,7 +515,7 @@ SharedContentMap::GetFilenameFromSHA1(const std::array<u8, 20>& sha1) const
     return {};
 
   const std::string id_string(it->id.begin(), it->id.end());
-  return Common::RootUserPath(m_root) + StringFromFormat("/shared1/%s.app", id_string.c_str());
+  return StringFromFormat("/shared1/%s.app", id_string.c_str());
 }
 
 std::vector<std::array<u8, 20>> SharedContentMap::GetHashes() const
@@ -541,7 +541,7 @@ std::string SharedContentMap::AddSharedContent(const std::array<u8, 20>& sha1)
   m_entries.push_back(entry);
 
   WriteEntries();
-  filename = Common::RootUserPath(m_root) + StringFromFormat("/shared1/%s.app", id.c_str());
+  filename = StringFromFormat("/shared1/%s.app", id.c_str());
   m_last_id++;
   return *filename;
 }
@@ -556,45 +556,49 @@ bool SharedContentMap::DeleteSharedContent(const std::array<u8, 20>& sha1)
 
 bool SharedContentMap::WriteEntries() const
 {
-  // Temporary files in ES are only 12 characters long (excluding /tmp/).
-  const std::string temp_path = Common::RootUserPath(m_root) + "/tmp/shared1/cont";
-  File::CreateFullPath(temp_path);
+  // Temporary files are only 12 characters long and must match the final file name
+  const std::string temp_path = "/tmp/content.map";
+  m_fs->CreateFile(HLE::PID_KERNEL, HLE::PID_KERNEL, temp_path, 0, HLE::FS::Mode::ReadWrite,
+                   HLE::FS::Mode::ReadWrite, HLE::FS::Mode::None);
 
   // Atomically write the new content map.
   {
-    File::IOFile file(temp_path, "w+b");
-    if (!file.WriteArray(m_entries.data(), m_entries.size()))
+    const auto file =
+        m_fs->OpenFile(HLE::PID_KERNEL, HLE::PID_KERNEL, temp_path, HLE::FS::Mode::Write);
+    if (!file || !file->Write(m_entries.data(), m_entries.size()))
       return false;
-    File::CreateFullPath(m_file_path);
   }
-  return File::RenameSync(temp_path, m_file_path);
+  return m_fs->Rename(HLE::PID_KERNEL, HLE::PID_KERNEL, temp_path, CONTENT_MAP_PATH) ==
+         HLE::FS::ResultCode::Success;
 }
 
-static std::pair<u32, u64> ReadUidSysEntry(File::IOFile& file)
+static std::pair<u32, u64> ReadUidSysEntry(const HLE::FS::FileHandle& file)
 {
   u64 title_id = 0;
-  if (!file.ReadBytes(&title_id, sizeof(title_id)))
+  if (!file.Read(&title_id, 1))
     return {};
 
   u32 uid = 0;
-  if (!file.ReadBytes(&uid, sizeof(uid)))
+  if (!file.Read(&uid, 1))
     return {};
 
   return {Common::swap32(uid), Common::swap64(title_id)};
 }
 
-UIDSys::UIDSys(Common::FromWhichRoot root)
+static const std::string UID_MAP_PATH = "/sys/uid.sys";
+UIDSys::UIDSys(std::shared_ptr<HLE::FS::FileSystem> fs) : m_fs{fs}
 {
-  m_file_path = Common::RootUserPath(root) + "/sys/uid.sys";
-
-  File::IOFile file(m_file_path, "rb");
-  while (true)
+  if (const auto file =
+          fs->OpenFile(HLE::PID_KERNEL, HLE::PID_KERNEL, UID_MAP_PATH, HLE::FS::Mode::Read))
   {
-    const std::pair<u32, u64> entry = ReadUidSysEntry(file);
-    if (!entry.first && !entry.second)
-      break;
+    while (true)
+    {
+      const std::pair<u32, u64> entry = ReadUidSysEntry(*file);
+      if (!entry.first && !entry.second)
+        break;
 
-    m_entries.insert(std::move(entry));
+      m_entries.insert(std::move(entry));
+    }
   }
 
   if (m_entries.empty())
@@ -633,11 +637,10 @@ u32 UIDSys::GetOrInsertUIDForTitle(const u64 title_id)
   const u64 swapped_title_id = Common::swap64(title_id);
   const u32 swapped_uid = Common::swap32(uid);
 
-  File::CreateFullPath(m_file_path);
-  File::IOFile file(m_file_path, "ab");
-
-  if (!file.WriteBytes(&swapped_title_id, sizeof(title_id)) ||
-      !file.WriteBytes(&swapped_uid, sizeof(uid)))
+  const auto file =
+      m_fs->OpenFile(HLE::PID_KERNEL, HLE::PID_KERNEL, UID_MAP_PATH, HLE::FS::Mode::ReadWrite);
+  if (!file || !file->Seek(0, HLE::FS::SeekMode::End) || !file->Write(&swapped_title_id, 1) ||
+      !file->Write(&swapped_uid, 1))
   {
     ERROR_LOG(IOS_ES, "Failed to write to /sys/uid.sys");
     return 0;

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -617,7 +617,7 @@ u32 UIDSys::GetUIDFromTitle(u64 title_id) const
 u32 UIDSys::GetNextUID() const
 {
   if (m_entries.empty())
-    return 0x00001000;
+    return FIRST_PPC_UID;
   return m_entries.rbegin()->first + 1;
 }
 

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -10,12 +10,12 @@
 #include <array>
 #include <cstddef>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/NandPaths.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOSC.h"
 #include "DiscIO/Enums.h"
@@ -24,6 +24,11 @@ class PointerWrap;
 
 namespace IOS
 {
+namespace HLE::FS
+{
+class FileSystem;
+}
+
 namespace ES
 {
 enum class TitleType : u32
@@ -249,7 +254,7 @@ public:
 class SharedContentMap final
 {
 public:
-  explicit SharedContentMap(Common::FromWhichRoot root);
+  explicit SharedContentMap(std::shared_ptr<HLE::FS::FileSystem> fs);
   ~SharedContentMap();
 
   std::optional<std::string> GetFilenameFromSHA1(const std::array<u8, 20>& sha1) const;
@@ -261,23 +266,22 @@ private:
   bool WriteEntries() const;
 
   struct Entry;
-  Common::FromWhichRoot m_root;
   u32 m_last_id = 0;
-  std::string m_file_path;
   std::vector<Entry> m_entries;
+  std::shared_ptr<HLE::FS::FileSystem> m_fs;
 };
 
 class UIDSys final
 {
 public:
-  explicit UIDSys(Common::FromWhichRoot root);
+  explicit UIDSys(std::shared_ptr<HLE::FS::FileSystem> fs);
 
   u32 GetUIDFromTitle(u64 title_id) const;
   u32 GetOrInsertUIDForTitle(u64 title_id);
   u32 GetNextUID() const;
 
 private:
-  std::string m_file_path;
+  std::shared_ptr<HLE::FS::FileSystem> m_fs;
   std::map<u32, u64> m_entries;
 };
 

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -271,6 +271,8 @@ private:
   std::shared_ptr<HLE::FS::FileSystem> m_fs;
 };
 
+constexpr u32 FIRST_PPC_UID = 0x1000;
+
 class UIDSys final
 {
 public:

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -177,7 +177,7 @@ std::vector<IOS::ES::Content> ES::GetStoredContentsFromTMD(const IOS::ES::TMDRea
   std::copy_if(contents.begin(), contents.end(), std::back_inserter(stored_contents),
                [this, &tmd, &map](const IOS::ES::Content& content) {
                  const std::string path = GetContentPath(tmd.GetTitleId(), content, map);
-                 return !path.empty() && File::Exists(path);
+                 return !path.empty() && m_ios.GetFS()->GetMetadata(0, 0, path).Succeeded();
                });
 
   return stored_contents;
@@ -307,13 +307,8 @@ std::string ES::GetContentPath(const u64 title_id, const IOS::ES::Content& conte
                                const IOS::ES::SharedContentMap& content_map) const
 {
   if (content.IsShared())
-  {
-    const std::string path = content_map.GetFilenameFromSHA1(content.sha1).value_or("");
-    return path.empty() ? "" : Common::RootUserPath(Common::FROM_SESSION_ROOT) + path;
-  }
-
-  return Common::GetTitleContentPath(title_id, Common::FROM_SESSION_ROOT) +
-         StringFromFormat("/%08x.app", content.id);
+    return content_map.GetFilenameFromSHA1(content.sha1).value_or("");
+  return Common::GetTitleContentPath(title_id) + StringFromFormat("/%08x.app", content.id);
 }
 
 std::string ES::GetContentPath(const u64 title_id, const IOS::ES::Content& content) const

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -13,8 +13,6 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
-#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
@@ -27,14 +25,14 @@ namespace HLE
 {
 namespace Device
 {
-static IOS::ES::TMDReader FindTMD(u64 title_id, const std::string& tmd_path)
+static IOS::ES::TMDReader FindTMD(FS::FileSystem* fs, u64 title_id, const std::string& tmd_path)
 {
-  File::IOFile file(tmd_path, "rb");
+  const auto file = fs->OpenFile(PID_KERNEL, PID_KERNEL, tmd_path, FS::Mode::Read);
   if (!file)
     return {};
 
-  std::vector<u8> tmd_bytes(file.GetSize());
-  if (!file.ReadBytes(tmd_bytes.data(), tmd_bytes.size()))
+  std::vector<u8> tmd_bytes(file->GetStatus()->size);
+  if (!file->Read(tmd_bytes.data(), tmd_bytes.size()))
     return {};
 
   return IOS::ES::TMDReader{std::move(tmd_bytes)};
@@ -42,24 +40,24 @@ static IOS::ES::TMDReader FindTMD(u64 title_id, const std::string& tmd_path)
 
 IOS::ES::TMDReader ES::FindImportTMD(u64 title_id) const
 {
-  return FindTMD(title_id, Common::GetImportTitlePath(title_id, Common::FROM_SESSION_ROOT) +
-                               "/content/title.tmd");
+  return FindTMD(m_ios.GetFS().get(), title_id,
+                 Common::GetImportTitlePath(title_id) + "/content/title.tmd");
 }
 
 IOS::ES::TMDReader ES::FindInstalledTMD(u64 title_id) const
 {
-  return FindTMD(title_id, Common::GetTMDFileName(title_id, Common::FROM_SESSION_ROOT));
+  return FindTMD(m_ios.GetFS().get(), title_id, Common::GetTMDFileName(title_id));
 }
 
 IOS::ES::TicketReader ES::FindSignedTicket(u64 title_id) const
 {
-  const std::string path = Common::GetTicketFileName(title_id, Common::FROM_SESSION_ROOT);
-  File::IOFile ticket_file(path, "rb");
+  const std::string path = Common::GetTicketFileName(title_id);
+  const auto ticket_file = m_ios.GetFS()->OpenFile(PID_KERNEL, PID_KERNEL, path, FS::Mode::Read);
   if (!ticket_file)
     return {};
 
-  std::vector<u8> signed_ticket(ticket_file.GetSize());
-  if (!ticket_file.ReadBytes(signed_ticket.data(), signed_ticket.size()))
+  std::vector<u8> signed_ticket(ticket_file->GetStatus()->size);
+  if (!ticket_file->Read(signed_ticket.data(), signed_ticket.size()))
     return {};
 
   return IOS::ES::TicketReader{std::move(signed_ticket)};
@@ -73,9 +71,10 @@ static bool IsValidPartOfTitleID(const std::string& string)
                      [](const auto character) { return std::isxdigit(character) != 0; });
 }
 
-static std::vector<u64> GetTitlesInTitleOrImport(const std::string& titles_dir)
+static std::vector<u64> GetTitlesInTitleOrImport(FS::FileSystem* fs, const std::string& titles_dir)
 {
-  if (!File::IsDirectory(titles_dir))
+  const auto entries = fs->ReadDirectory(PID_KERNEL, PID_KERNEL, titles_dir);
+  if (!entries)
   {
     ERROR_LOG(IOS_ES, "%s is not a directory", titles_dir.c_str());
     return {};
@@ -85,22 +84,26 @@ static std::vector<u64> GetTitlesInTitleOrImport(const std::string& titles_dir)
 
   // The /title and /import directories contain one directory per title type, and each of them has
   // a directory per title (where the name is the low 32 bits of the title ID in %08x format).
-  const auto entries = File::ScanDirectoryTree(titles_dir, true);
-  for (const File::FSTEntry& title_type : entries.children)
+  for (const std::string& title_type : *entries)
   {
-    if (!title_type.isDirectory || !IsValidPartOfTitleID(title_type.virtualName))
+    if (!IsValidPartOfTitleID(title_type))
       continue;
 
-    if (title_type.children.empty())
+    const auto title_entries =
+        fs->ReadDirectory(PID_KERNEL, PID_KERNEL, titles_dir + '/' + title_type);
+    if (!title_entries)
       continue;
 
-    for (const File::FSTEntry& title_identifier : title_type.children)
+    for (const std::string& title_identifier : *title_entries)
     {
-      if (!title_identifier.isDirectory || !IsValidPartOfTitleID(title_identifier.virtualName))
+      if (!IsValidPartOfTitleID(title_identifier))
+        continue;
+      if (!fs->ReadDirectory(PID_KERNEL, PID_KERNEL,
+                             titles_dir + '/' + title_type + '/' + title_identifier))
         continue;
 
-      const u32 type = std::stoul(title_type.virtualName, nullptr, 16);
-      const u32 identifier = std::stoul(title_identifier.virtualName, nullptr, 16);
+      const u32 type = std::stoul(title_type, nullptr, 16);
+      const u32 identifier = std::stoul(title_identifier, nullptr, 16);
       title_ids.push_back(static_cast<u64>(type) << 32 | identifier);
     }
   }
@@ -116,18 +119,19 @@ static std::vector<u64> GetTitlesInTitleOrImport(const std::string& titles_dir)
 
 std::vector<u64> ES::GetInstalledTitles() const
 {
-  return GetTitlesInTitleOrImport(Common::RootUserPath(Common::FROM_SESSION_ROOT) + "/title");
+  return GetTitlesInTitleOrImport(m_ios.GetFS().get(), "/title");
 }
 
 std::vector<u64> ES::GetTitleImports() const
 {
-  return GetTitlesInTitleOrImport(Common::RootUserPath(Common::FROM_SESSION_ROOT) + "/import");
+  return GetTitlesInTitleOrImport(m_ios.GetFS().get(), "/import");
 }
 
 std::vector<u64> ES::GetTitlesWithTickets() const
 {
-  const std::string tickets_dir = Common::RootUserPath(Common::FROM_SESSION_ROOT) + "/ticket";
-  if (!File::IsDirectory(tickets_dir))
+  const auto fs = m_ios.GetFS();
+  const auto entries = fs->ReadDirectory(PID_KERNEL, PID_KERNEL, "/ticket");
+  if (!entries)
   {
     ERROR_LOG(IOS_ES, "/ticket is not a directory");
     return {};
@@ -137,25 +141,25 @@ std::vector<u64> ES::GetTitlesWithTickets() const
 
   // The /ticket directory contains one directory per title type, and each of them contains
   // one ticket per title (where the name is the low 32 bits of the title ID in %08x format).
-  const auto entries = File::ScanDirectoryTree(tickets_dir, true);
-  for (const File::FSTEntry& title_type : entries.children)
+  for (const std::string& title_type : *entries)
   {
-    if (!title_type.isDirectory || !IsValidPartOfTitleID(title_type.virtualName))
+    if (!IsValidPartOfTitleID(title_type))
       continue;
 
-    if (title_type.children.empty())
+    const auto sub_entries = fs->ReadDirectory(PID_KERNEL, PID_KERNEL, "/ticket/" + title_type);
+    if (!sub_entries)
       continue;
 
-    for (const File::FSTEntry& ticket : title_type.children)
+    for (const std::string& file_name : *sub_entries)
     {
-      const std::string name_without_ext = ticket.virtualName.substr(0, 8);
-      if (ticket.isDirectory || !IsValidPartOfTitleID(name_without_ext) ||
-          name_without_ext + ".tik" != ticket.virtualName)
+      const std::string name_without_ext = file_name.substr(0, 8);
+      if (fs->ReadDirectory(PID_KERNEL, PID_KERNEL, "/ticket/" + title_type + '/' + file_name) ||
+          !IsValidPartOfTitleID(name_without_ext) || name_without_ext + ".tik" != file_name)
       {
         continue;
       }
 
-      const u32 type = std::stoul(title_type.virtualName, nullptr, 16);
+      const u32 type = std::stoul(title_type, nullptr, 16);
       const u32 identifier = std::stoul(name_without_ext, nullptr, 16);
       title_ids.push_back(static_cast<u64>(type) << 32 | identifier);
     }
@@ -177,7 +181,8 @@ std::vector<IOS::ES::Content> ES::GetStoredContentsFromTMD(const IOS::ES::TMDRea
   std::copy_if(contents.begin(), contents.end(), std::back_inserter(stored_contents),
                [this, &tmd, &map](const IOS::ES::Content& content) {
                  const std::string path = GetContentPath(tmd.GetTitleId(), content, map);
-                 return !path.empty() && m_ios.GetFS()->GetMetadata(0, 0, path).Succeeded();
+                 return !path.empty() &&
+                        m_ios.GetFS()->GetMetadata(PID_KERNEL, PID_KERNEL, path).Succeeded();
                });
 
   return stored_contents;
@@ -185,12 +190,11 @@ std::vector<IOS::ES::Content> ES::GetStoredContentsFromTMD(const IOS::ES::TMDRea
 
 u32 ES::GetSharedContentsCount() const
 {
-  const std::string shared1_path = Common::RootUserPath(Common::FROM_SESSION_ROOT) + "/shared1";
-  const auto entries = File::ScanDirectoryTree(shared1_path, false);
+  const auto entries = m_ios.GetFS()->ReadDirectory(PID_KERNEL, PID_KERNEL, "/shared1");
   return static_cast<u32>(
-      std::count_if(entries.children.begin(), entries.children.end(), [](const auto& entry) {
-        return !entry.isDirectory && entry.virtualName.size() == 12 &&
-               entry.virtualName.compare(8, 4, ".app") == 0;
+      std::count_if(entries->begin(), entries->end(), [this](const std::string& entry) {
+        return !m_ios.GetFS()->ReadDirectory(PID_KERNEL, PID_KERNEL, "/shared1/" + entry) &&
+               entry.size() == 12 && entry.compare(8, 4, ".app") == 0;
       }));
 }
 
@@ -200,65 +204,102 @@ std::vector<std::array<u8, 20>> ES::GetSharedContents() const
   return map.GetHashes();
 }
 
-bool ES::InitImport(u64 title_id)
+static bool DeleteDirectoriesIfEmpty(FS::FileSystem* fs, const std::string& path)
 {
-  const std::string content_dir = Common::GetTitleContentPath(title_id, Common::FROM_SESSION_ROOT);
-  const std::string data_dir = Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT);
-  for (const auto& dir : {content_dir, data_dir})
+  std::string::size_type position = std::string::npos;
+  do
   {
-    if (!File::IsDirectory(dir) && !File::CreateFullPath(dir) && !File::CreateDir(dir))
+    const auto directory = fs->ReadDirectory(PID_KERNEL, PID_KERNEL, path.substr(0, position));
+    if ((directory && directory->empty()) ||
+        (!directory && directory.Error() != FS::ResultCode::NotFound))
     {
-      ERROR_LOG(IOS_ES, "InitImport: Failed to create title dirs for %016" PRIx64, title_id);
-      return false;
+      if (fs->Delete(PID_KERNEL, PID_KERNEL, path.substr(0, position)) != FS::ResultCode::Success)
+        return false;
     }
+    position = path.find_last_of('/', position - 1);
+  } while (position != 0);
+  return true;
+}
+
+bool ES::InitImport(const IOS::ES::TMDReader& tmd)
+{
+  const auto fs = m_ios.GetFS();
+  const std::string content_dir = Common::GetTitleContentPath(tmd.GetTitleId());
+  const std::string import_content_dir = Common::GetImportTitlePath(tmd.GetTitleId()) + "/content";
+
+  const auto result1 = fs->CreateFullPath(PID_KERNEL, PID_KERNEL, content_dir + '/', 0,
+                                          FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::Read);
+  const auto result2 = fs->SetMetadata(PID_KERNEL, content_dir, PID_KERNEL, PID_KERNEL, 0,
+                                       FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::None);
+  const auto result3 = fs->CreateFullPath(PID_KERNEL, PID_KERNEL, import_content_dir + '/', 0,
+                                          FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::None);
+  if (result1 != FS::ResultCode::Success || result2 != FS::ResultCode::Success ||
+      result3 != FS::ResultCode::Success)
+  {
+    ERROR_LOG(IOS_ES, "InitImport: Failed to create content dir for %016" PRIx64, tmd.GetTitleId());
+    return false;
   }
 
-  IOS::ES::UIDSys uid_sys{m_ios.GetFS()};
-  uid_sys.GetOrInsertUIDForTitle(title_id);
+  const std::string data_dir = Common::GetTitleDataPath(tmd.GetTitleId());
+  const auto data_dir_contents = fs->ReadDirectory(PID_KERNEL, PID_KERNEL, data_dir);
+  if (!data_dir_contents &&
+      (data_dir_contents.Error() != FS::ResultCode::NotFound ||
+       fs->CreateDirectory(PID_KERNEL, PID_KERNEL, data_dir, 0, FS::Mode::ReadWrite, FS::Mode::None,
+                           FS::Mode::None) != FS::ResultCode::Success))
+  {
+    return false;
+  }
+
+  IOS::ES::UIDSys uid_sys{fs};
+  const u32 uid = uid_sys.GetOrInsertUIDForTitle(tmd.GetTitleId());
+  if (fs->SetMetadata(0, data_dir, uid, tmd.GetGroupId(), 0, FS::Mode::ReadWrite, FS::Mode::None,
+                      FS::Mode::None) != FS::ResultCode::Success)
+  {
+    return false;
+  }
 
   // IOS moves the title content directory to /import if the TMD exists during an import.
-  if (File::Exists(Common::GetTMDFileName(title_id, Common::FROM_SESSION_ROOT)))
-  {
-    const std::string import_content_dir =
-        Common::GetImportTitlePath(title_id, Common::FROM_SESSION_ROOT) + "/content";
-    File::CreateFullPath(import_content_dir);
-    if (!File::Rename(content_dir, import_content_dir))
-    {
-      ERROR_LOG(IOS_ES, "InitImport: Failed to move content dir for %016" PRIx64, title_id);
-      return false;
-    }
-  }
+  const auto file_info =
+      fs->GetMetadata(PID_KERNEL, PID_KERNEL, Common::GetTMDFileName(tmd.GetTitleId()));
+  if (!file_info || !file_info->is_file)
+    return true;
 
+  const auto result = fs->Rename(PID_KERNEL, PID_KERNEL, content_dir, import_content_dir);
+  if (result != FS::ResultCode::Success)
+  {
+    ERROR_LOG(IOS_ES, "InitImport: Failed to move content dir for %016" PRIx64, tmd.GetTitleId());
+    return false;
+  }
+  DeleteDirectoriesIfEmpty(m_ios.GetFS().get(), import_content_dir);
   return true;
 }
 
 bool ES::FinishImport(const IOS::ES::TMDReader& tmd)
 {
+  const auto fs = m_ios.GetFS();
   const u64 title_id = tmd.GetTitleId();
-  const std::string import_content_dir =
-      Common::GetImportTitlePath(title_id, Common::FROM_SESSION_ROOT) + "/content";
+  const std::string import_content_dir = Common::GetImportTitlePath(title_id) + "/content";
 
   // Remove everything not listed in the TMD.
   std::unordered_set<std::string> expected_entries = {"title.tmd"};
   for (const auto& content_info : tmd.GetContents())
     expected_entries.insert(StringFromFormat("%08x.app", content_info.id));
-  const auto entries = File::ScanDirectoryTree(import_content_dir, false);
-  for (const File::FSTEntry& entry : entries.children)
+  const auto entries = fs->ReadDirectory(PID_KERNEL, PID_KERNEL, import_content_dir);
+  if (!entries)
+    return false;
+  for (const std::string& name : *entries)
   {
+    const std::string absolute_path = import_content_dir + '/' + name;
     // There should not be any directory in there. Remove it.
-    if (entry.isDirectory)
-      File::DeleteDirRecursively(entry.physicalName);
-    else if (expected_entries.find(entry.virtualName) == expected_entries.end())
-      File::Delete(entry.physicalName);
+    if (fs->ReadDirectory(PID_KERNEL, PID_KERNEL, absolute_path))
+      fs->Delete(PID_KERNEL, PID_KERNEL, absolute_path);
+    else if (expected_entries.find(name) == expected_entries.end())
+      fs->Delete(PID_KERNEL, PID_KERNEL, absolute_path);
   }
 
-  const std::string content_dir = Common::GetTitleContentPath(title_id, Common::FROM_SESSION_ROOT);
-  if (File::IsDirectory(content_dir))
-  {
-    WARN_LOG(IOS_ES, "FinishImport: %s already exists -- removing", content_dir.c_str());
-    File::DeleteDirRecursively(content_dir);
-  }
-  if (!File::Rename(import_content_dir, content_dir))
+  const std::string content_dir = Common::GetTitleContentPath(title_id);
+  if (fs->Rename(PID_KERNEL, PID_KERNEL, import_content_dir, content_dir) !=
+      FS::ResultCode::Success)
   {
     ERROR_LOG(IOS_ES, "FinishImport: Failed to rename import directory to %s", content_dir.c_str());
     return false;
@@ -268,28 +309,34 @@ bool ES::FinishImport(const IOS::ES::TMDReader& tmd)
 
 bool ES::WriteImportTMD(const IOS::ES::TMDReader& tmd)
 {
-  const std::string tmd_path = Common::RootUserPath(Common::FROM_SESSION_ROOT) + "/tmp/title.tmd";
-  File::CreateFullPath(tmd_path);
-
+  const auto fs = m_ios.GetFS();
+  const std::string tmd_path = "/tmp/title.tmd";
   {
-    File::IOFile file(tmd_path, "wb");
-    if (!file.WriteBytes(tmd.GetBytes().data(), tmd.GetBytes().size()))
+    fs->CreateFile(PID_KERNEL, PID_KERNEL, tmd_path, 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite,
+                   FS::Mode::None);
+    const auto file = fs->OpenFile(PID_KERNEL, PID_KERNEL, tmd_path, FS::Mode::Write);
+    if (!file || !file->Write(tmd.GetBytes().data(), tmd.GetBytes().size()))
       return false;
   }
 
-  const std::string dest = Common::GetImportTitlePath(tmd.GetTitleId(), Common::FROM_SESSION_ROOT) +
-                           "/content/title.tmd";
-  return File::Rename(tmd_path, dest);
+  const std::string dest = Common::GetImportTitlePath(tmd.GetTitleId()) + "/content/title.tmd";
+  return fs->Rename(PID_KERNEL, PID_KERNEL, tmd_path, dest) == FS::ResultCode::Success;
 }
 
 void ES::FinishStaleImport(u64 title_id)
 {
+  const auto fs = m_ios.GetFS();
   const auto import_tmd = FindImportTMD(title_id);
   if (!import_tmd.IsValid())
-    File::DeleteDirRecursively(Common::GetImportTitlePath(title_id, Common::FROM_SESSION_ROOT) +
-                               "/content");
+  {
+    fs->Delete(PID_KERNEL, PID_KERNEL, Common::GetImportTitlePath(title_id) + "/content");
+    DeleteDirectoriesIfEmpty(fs.get(), Common::GetImportTitlePath(title_id));
+    DeleteDirectoriesIfEmpty(fs.get(), Common::GetTitlePath(title_id));
+  }
   else
+  {
     FinishImport(import_tmd);
+  }
 }
 
 void ES::FinishAllStaleImports()
@@ -297,10 +344,6 @@ void ES::FinishAllStaleImports()
   const std::vector<u64> titles = GetTitleImports();
   for (const u64& title_id : titles)
     FinishStaleImport(title_id);
-
-  const std::string import_dir = Common::RootUserPath(Common::FROM_SESSION_ROOT) + "/import";
-  File::DeleteDirRecursively(import_dir);
-  File::CreateDir(import_dir);
 }
 
 std::string ES::GetContentPath(const u64 title_id, const IOS::ES::Content& content,

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -78,7 +78,7 @@ IPCCommandResult ES::OpenActiveTitleContent(u32 caller_uid, const IOCtlVRequest&
   if (!m_title_context.active)
     return GetDefaultReply(ES_EINVAL);
 
-  IOS::ES::UIDSys uid_map{Common::FROM_SESSION_ROOT};
+  IOS::ES::UIDSys uid_map{m_ios.GetFS()};
   const u32 uid = uid_map.GetOrInsertUIDForTitle(m_title_context.tmd.GetTitleId());
   if (caller_uid != 0 && caller_uid != uid)
     return GetDefaultReply(ES_EACCES);

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -156,7 +156,7 @@ ReturnCode ES::ImportTmd(Context& context, const std::vector<u8>& tmd_bytes)
   if (ret != IPC_SUCCESS)
     return ret;
 
-  if (!InitImport(context.title_import_export.tmd.GetTitleId()))
+  if (!InitImport(context.title_import_export.tmd))
     return ES_EIO;
 
   ret =
@@ -238,7 +238,7 @@ ReturnCode ES::ImportTitleInit(Context& context, const std::vector<u8>& tmd_byte
   if (ret != IPC_SUCCESS)
     return ret;
 
-  if (!InitImport(context.title_import_export.tmd.GetTitleId()))
+  if (!InitImport(context.title_import_export.tmd))
     return ES_EIO;
 
   context.title_import_export.valid = true;

--- a/Source/Core/Core/IOS/FS/FileSystem.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystem.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/Assert.h"
 #include "Common/FileUtil.h"
+#include "Core/IOS/Device.h"
 #include "Core/IOS/FS/HostBackend/FS.h"
 
 namespace IOS::HLE::FS
@@ -15,6 +16,15 @@ std::unique_ptr<FileSystem> MakeFileSystem(Location location)
   const std::string nand_root =
       File::GetUserPath(location == Location::Session ? D_SESSION_WIIROOT_IDX : D_WIIROOT_IDX);
   return std::make_unique<HostFileSystem>(nand_root);
+}
+
+IOS::HLE::ReturnCode ConvertResult(ResultCode code)
+{
+  if (code == ResultCode::Success)
+    return IPC_SUCCESS;
+  // FS error codes start at -100. Since result codes in the enum are listed in the same way
+  // as the IOS codes, we just need to return -100-code.
+  return static_cast<ReturnCode>(-(static_cast<s32>(code) + 100));
 }
 
 FileHandle::FileHandle(FileSystem* fs, Fd fd) : m_fs{fs}, m_fd{fd}

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -14,7 +14,11 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::FS
+namespace IOS::HLE
+{
+enum ReturnCode : s32;
+
+namespace FS
 {
 enum class ResultCode
 {
@@ -218,4 +222,8 @@ enum class Location
 
 std::unique_ptr<FileSystem> MakeFileSystem(Location location = Location::Session);
 
-}  // namespace IOS::HLE::FS
+/// Convert a FS result code to an IOS error code.
+IOS::HLE::ReturnCode ConvertResult(ResultCode code);
+
+}  // namespace FS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -23,13 +23,6 @@ namespace Device
 {
 using namespace IOS::HLE::FS;
 
-static s32 ConvertResult(ResultCode code)
-{
-  if (code == ResultCode::Success)
-    return IPC_SUCCESS;
-  return -(static_cast<s32>(code) + 100);
-}
-
 static IPCCommandResult GetFSReply(s32 return_value, u64 extra_tb_ticks = 0)
 {
   // According to hardware tests, FS takes at least 2700 TB ticks to reply to commands.

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -310,10 +310,11 @@ Result<Metadata> HostFileSystem::GetMetadata(Uid, Gid, const std::string& path)
 
   // Hack: if the path that is being accessed is within an installed title directory, get the
   // UID/GID from the installed title TMD.
+  Kernel* ios = GetIOS();
   u64 title_id;
-  if (IsTitlePath(file_name, Common::FROM_SESSION_ROOT, &title_id))
+  if (ios && IsTitlePath(file_name, Common::FROM_SESSION_ROOT, &title_id))
   {
-    IOS::ES::TMDReader tmd = GetIOS()->GetES()->FindInstalledTMD(title_id);
+    IOS::ES::TMDReader tmd = ios->GetES()->FindInstalledTMD(title_id);
     if (tmd.IsValid())
       metadata.gid = tmd.GetGroupId();
   }

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 96;  // Last changed in PR 6565
+static const u32 STATE_VERSION = 97;  // Last changed in PR 6772
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Followup for the migration work started in 8317a66

The goal is to make all accesses to the Wii filesystem go through the common interface so that we can switch to a different storage and keep track of things like metadata in the future.

This PR is a bit larger than past changesets because of how much ES uses the filesystem compared to other subsystems. ES is also responsible for setting permissions on most files and directories, which is something Dolphin didn't bother with before this PR (we currently have a workaround to make the DQX installer work without proper UID/GID values).

Commits are independent and can be reviewed individually.