### PR TITLE
 PowerPC: Make the PowerPCState's fpscr member variable a UReg_FPSCR instance

### DIFF
--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -475,7 +475,7 @@ union UReg_FPSCR
   u32 Hex = 0;
 
   UReg_FPSCR() = default;
-  UReg_FPSCR(u32 hex_) : Hex{hex_} {}
+  explicit UReg_FPSCR(u32 hex_) : Hex{hex_} {}
 };
 
 // Hardware Implementation-Dependent Register 0

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -95,8 +95,8 @@ static void Trace(UGeckoInstruction& inst)
   DEBUG_LOG(POWERPC,
             "INTER PC: %08x SRR0: %08x SRR1: %08x CRval: %016lx FPSCR: %08x MSR: %08x LR: "
             "%08x %s %08x %s",
-            PC, SRR0, SRR1, (unsigned long)PowerPC::ppcState.cr_val[0], PowerPC::ppcState.fpscr,
-            MSR.Hex, PowerPC::ppcState.spr[8], regs.c_str(), inst.hex, ppc_inst.c_str());
+            PC, SRR0, SRR1, (unsigned long)PowerPC::ppcState.cr_val[0], FPSCR.Hex, MSR.Hex,
+            PowerPC::ppcState.spr[8], regs.c_str(), inst.hex, ppc_inst.c_str());
 }
 
 int Interpreter::SingleStepInner()

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -565,8 +565,8 @@ void Jit64::Trace()
 #endif
 
   DEBUG_LOG(DYNA_REC, "JIT64 PC: %08x SRR0: %08x SRR1: %08x FPSCR: %08x MSR: %08x LR: %08x %s %s",
-            PC, SRR0, SRR1, PowerPC::ppcState.fpscr, MSR.Hex, PowerPC::ppcState.spr[8],
-            regs.c_str(), fregs.c_str());
+            PC, SRR0, SRR1, FPSCR.Hex, MSR.Hex, PowerPC::ppcState.spr[8], regs.c_str(),
+            fregs.c_str());
 }
 
 void Jit64::Jit(u32 em_address)

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -128,7 +128,7 @@ static void ResetRegisters()
   ppcState.spr[SPR_ECID_M] = 0x1840c00d;
   ppcState.spr[SPR_ECID_L] = 0x82bb08e8;
 
-  ppcState.fpscr = 0;
+  ppcState.fpscr.Hex = 0;
   ppcState.pc = 0;
   ppcState.npc = 0;
   ppcState.Exceptions = 0;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -75,8 +75,8 @@ struct PowerPCState
   // be manipulated bit by bit fairly easily.
   u64 cr_val[8];
 
-  UReg_MSR msr;  // machine state register
-  u32 fpscr;     // floating point flags/status bits
+  UReg_MSR msr;      // machine state register
+  UReg_FPSCR fpscr;  // floating point flags/status bits
 
   // Exception management.
   u32 Exceptions;
@@ -185,7 +185,7 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 #define MMCR1 ((UReg_MMCR1&)PowerPC::ppcState.spr[SPR_MMCR1])
 #define PC PowerPC::ppcState.pc
 #define NPC PowerPC::ppcState.npc
-#define FPSCR ((UReg_FPSCR&)PowerPC::ppcState.fpscr)
+#define FPSCR PowerPC::ppcState.fpscr
 #define MSR PowerPC::ppcState.msr
 #define GPR(n) PowerPC::ppcState.gpr[n]
 

--- a/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
@@ -292,8 +292,8 @@ void RegisterWidget::PopulateTable()
               [](u64 value) { PowerPC::SetXER(UReg_XER(value)); });
 
   // FPSCR
-  AddRegister(22, 5, RegisterType::fpscr, "FPSCR", [] { return PowerPC::ppcState.fpscr; },
-              [](u64 value) { PowerPC::ppcState.fpscr = value; });
+  AddRegister(22, 5, RegisterType::fpscr, "FPSCR", [] { return PowerPC::ppcState.fpscr.Hex; },
+              [](u64 value) { PowerPC::ppcState.fpscr.Hex = value; });
 
   // MSR
   AddRegister(23, 5, RegisterType::msr, "MSR", [] { return PowerPC::ppcState.msr.Hex; },

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -80,7 +80,7 @@ u32 GetSpecialRegValue(int reg)
   case 4:
     return PowerPC::GetXER().Hex;
   case 5:
-    return PowerPC::ppcState.fpscr;
+    return PowerPC::ppcState.fpscr.Hex;
   case 6:
     return PowerPC::ppcState.msr.Hex;
   case 7:
@@ -124,7 +124,7 @@ void SetSpecialRegValue(int reg, u32 value)
     PowerPC::SetXER(UReg_XER(value));
     break;
   case 5:
-    PowerPC::ppcState.fpscr = value;
+    PowerPC::ppcState.fpscr.Hex = value;
     break;
   case 6:
     PowerPC::ppcState.msr.Hex = value;


### PR DESCRIPTION
Gets rid of the need to cast the actual member to access information without bit shifts and masking.