### PR TITLE
Interpreter_FPUtils: Make FPCC enum an enum class

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -17,7 +17,7 @@
 constexpr double PPC_NAN = std::numeric_limits<double>::quiet_NaN();
 
 // the 4 less-significand bits in FPSCR[FPRF]
-enum FPCC
+enum class FPCC
 {
   FL = 8,  // <
   FG = 4,  // >

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -20,11 +20,11 @@ void Interpreter::Helper_UpdateCR1()
 
 void Interpreter::Helper_FloatCompareOrdered(UGeckoInstruction inst, double fa, double fb)
 {
-  int compareResult;
+  FPCC compare_result;
 
   if (std::isnan(fa) || std::isnan(fb))
   {
-    compareResult = FPCC::FU;
+    compare_result = FPCC::FU;
     if (MathUtil::IsSNAN(fa) || MathUtil::IsSNAN(fb))
     {
       SetFPException(FPSCR_VXSNAN);
@@ -40,30 +40,32 @@ void Interpreter::Helper_FloatCompareOrdered(UGeckoInstruction inst, double fa, 
   }
   else if (fa < fb)
   {
-    compareResult = FPCC::FL;
+    compare_result = FPCC::FL;
   }
   else if (fa > fb)
   {
-    compareResult = FPCC::FG;
+    compare_result = FPCC::FG;
   }
   else  // Equals
   {
-    compareResult = FPCC::FE;
+    compare_result = FPCC::FE;
   }
 
-  // Clear and set the FPCC bits accordingly.
-  FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compareResult;
+  const u32 compare_value = static_cast<u32>(compare_result);
 
-  PowerPC::SetCRField(inst.CRFD, compareResult);
+  // Clear and set the FPCC bits accordingly.
+  FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compare_value;
+
+  PowerPC::SetCRField(inst.CRFD, compare_value);
 }
 
 void Interpreter::Helper_FloatCompareUnordered(UGeckoInstruction inst, double fa, double fb)
 {
-  int compareResult;
+  FPCC compare_result;
 
   if (std::isnan(fa) || std::isnan(fb))
   {
-    compareResult = FPCC::FU;
+    compare_result = FPCC::FU;
 
     if (MathUtil::IsSNAN(fa) || MathUtil::IsSNAN(fb))
     {
@@ -72,21 +74,23 @@ void Interpreter::Helper_FloatCompareUnordered(UGeckoInstruction inst, double fa
   }
   else if (fa < fb)
   {
-    compareResult = FPCC::FL;
+    compare_result = FPCC::FL;
   }
   else if (fa > fb)
   {
-    compareResult = FPCC::FG;
+    compare_result = FPCC::FG;
   }
   else  // Equals
   {
-    compareResult = FPCC::FE;
+    compare_result = FPCC::FE;
   }
 
-  // Clear and set the FPCC bits accordingly.
-  FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compareResult;
+  const u32 compare_value = static_cast<u32>(compare_result);
 
-  PowerPC::SetCRField(inst.CRFD, compareResult);
+  // Clear and set the FPCC bits accordingly.
+  FPSCR.FPRF = (FPSCR.FPRF & ~0xF) | compare_value;
+
+  PowerPC::SetCRField(inst.CRFD, compare_value);
 }
 
 void Interpreter::fcmpo(UGeckoInstruction inst)


### PR DESCRIPTION
Avoids dumping two letter identifiers into global scope