### PR TITLE
Interpreter_FPUtils: Properly update the FPSCR's FEX bit in UpdateFPSCR()

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -46,7 +46,8 @@ inline void SetFI(int FI)
 inline void UpdateFPSCR()
 {
   FPSCR.VX = (FPSCR.Hex & FPSCR_VX_ANY) != 0;
-  FPSCR.FEX = 0;  // we assume that "?E" bits are always 0
+  FPSCR.FEX = (FPSCR.VX & FPSCR.VE) | (FPSCR.OX & FPSCR.OE) | (FPSCR.UX & FPSCR.UE) |
+              (FPSCR.ZX & FPSCR.ZE) | (FPSCR.XX & FPSCR.XE);
 }
 
 inline double ForceSingle(double value)


### PR DESCRIPTION
FPSCR.FEX is supposed to be a logical OR of all floating-point exception bits masked by their respective enable bits.

Currently `UpdateFPSCR()` isn't called by anything in the interpreter except for `mcrfs` and `mffs`, so this doesn't alter existing behavior that much. However, this will be necessary in future PRs when making the interpreter more accurate in how it sets flags (given almost all of our FP instructions in the interpreter don't set certain flags properly).