### PR TITLE
Software: Remove ancient hack designed to fix Sexy Poker

### DIFF
--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -140,11 +140,8 @@ static void InitTriangle(float X1, float Y1, s32 xi, s32 yi)
   vertex0X = xi;
   vertex0Y = yi;
 
-  // adjust a little less than 0.5
-  const float adjust = 0.495f;
-
-  vertexOffsetX = ((float)xi - X1) + adjust;
-  vertexOffsetY = ((float)yi - Y1) + adjust;
+  vertexOffsetX = (float)xi - X1;
+  vertexOffsetY = (float)yi - Y1;
 }
 
 static void InitSlope(Slope* slope, float f1, float f2, float f3, float DX31, float DX12,


### PR DESCRIPTION
[console screenshot](https://i.imgur.com/lNsQYIr.png)
[fifolog](https://drive.google.com/open?id=1-5QQz5kTY3Y_qrwqQHaml1kidwWPy2C4)
[what shouldn't be happening](https://i.imgur.com/7AVwGEi.png)

Open FIFO Player in dolphin with software renderer, adjust Object Range to 0 - 0, then adjust it to 0 - 1. Watch the areas in the screenshot, which aren't present on the console screenshot become visible.

Makes software more consistent with hardware, which is also wrong.