### PR TITLE
RenderBase: Ensure the draw size does not exceed the window size

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -539,6 +539,10 @@ void Renderer::UpdateDrawRectangle()
     crop_width = win_width;
   }
 
+  // Clamp the draw width/height to the screen size, to ensure we don't render off-screen.
+  draw_width = std::min(draw_width, win_width);
+  draw_height = std::min(draw_height, win_height);
+
   // ensure divisibility by 4 to make it compatible with all the video encoders
   draw_width = std::ceil(draw_width) - static_cast<int>(std::ceil(draw_width)) % 4;
   draw_height = std::ceil(draw_height) - static_cast<int>(std::ceil(draw_height)) % 4;


### PR DESCRIPTION
This was happening when crop was enabled, causing blank outputs for some Vulkan drivers, as the draw rectangle is used as the viewport.

Fixed blank screen with crop enabled on radv, potentially other drivers too.