### PR TITLE
Qt/GraphicsWindow: Fix multiple issues

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -201,7 +201,11 @@ void GeneralWidget::SaveSettings()
           }
         }
         SConfig::GetInstance().m_strVideoBackend = current_backend;
-        backend->InitBackendInfo();
+
+        g_Config.Refresh();
+
+        g_video_backend = backend.get();
+        g_video_backend->InitBackendInfo();
         emit BackendChanged(QString::fromStdString(current_backend));
         break;
       }

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -173,8 +173,6 @@ void GeneralWidget::SaveSettings()
       const auto current_backend = backend->GetName();
       if (SConfig::GetInstance().m_strVideoBackend != current_backend)
       {
-        SConfig::GetInstance().m_strVideoBackend = current_backend;
-
         if (backend->GetName() == "Software Renderer")
         {
           QMessageBox confirm_sw;

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -19,10 +19,13 @@
 #include "DolphinQt2/Config/Graphics/SoftwareRendererWidget.h"
 #include "DolphinQt2/MainWindow.h"
 #include "DolphinQt2/QtUtils/WrapInScrollArea.h"
+#include "VideoCommon/VideoConfig.h"
 
 GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent)
     : QDialog(parent), m_xrr_config(xrr_config)
 {
+  g_Config.Refresh();
+
   CreateMainLayout();
 
   setWindowTitle(tr("Graphics"));

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -70,18 +70,22 @@ void GraphicsWindow::CreateMainLayout()
   connect(m_software_renderer, &SoftwareRendererWidget::BackendChanged, this,
           &GraphicsWindow::OnBackendChanged);
 
+  m_wrapped_general = GetWrappedWidget(m_general_widget, this, 50, 305);
+  m_wrapped_enhancements = GetWrappedWidget(m_enhancements_widget, this, 50, 305);
+  m_wrapped_hacks = GetWrappedWidget(m_hacks_widget, this, 50, 305);
+  m_wrapped_advanced = GetWrappedWidget(m_advanced_widget, this, 50, 305);
+  m_wrapped_software = GetWrappedWidget(m_software_renderer, this, 50, 305);
+
   if (SConfig::GetInstance().m_strVideoBackend != "Software Renderer")
   {
-    m_tab_widget->addTab(GetWrappedWidget(m_general_widget, this, 50, 305), tr("General"));
-    m_tab_widget->addTab(GetWrappedWidget(m_enhancements_widget, this, 50, 305),
-                         tr("Enhancements"));
-    m_tab_widget->addTab(GetWrappedWidget(m_hacks_widget, this, 50, 305), tr("Hacks"));
-    m_tab_widget->addTab(GetWrappedWidget(m_advanced_widget, this, 50, 305), tr("Advanced"));
+    m_tab_widget->addTab(m_wrapped_general, tr("General"));
+    m_tab_widget->addTab(m_wrapped_enhancements, tr("Enhancements"));
+    m_tab_widget->addTab(m_wrapped_hacks, tr("Hacks"));
+    m_tab_widget->addTab(m_wrapped_advanced, tr("Advanced"));
   }
   else
   {
-    m_tab_widget->addTab(GetWrappedWidget(m_software_renderer, this, 50, 305),
-                         tr("Software Renderer"));
+    m_tab_widget->addTab(m_wrapped_software, tr("Software Renderer"));
   }
 
   setLayout(main_layout);
@@ -93,16 +97,16 @@ void GraphicsWindow::OnBackendChanged(const QString& backend)
   if (backend == QStringLiteral("Software Renderer") && m_tab_widget->count() > 1)
   {
     m_tab_widget->clear();
-    m_tab_widget->addTab(m_software_renderer, tr("Software Renderer"));
+    m_tab_widget->addTab(m_wrapped_software, tr("Software Renderer"));
   }
 
   if (backend != QStringLiteral("Software Renderer") && m_tab_widget->count() == 1)
   {
     m_tab_widget->clear();
-    m_tab_widget->addTab(m_general_widget, tr("General"));
-    m_tab_widget->addTab(m_enhancements_widget, tr("Enhancements"));
-    m_tab_widget->addTab(m_hacks_widget, tr("Hacks"));
-    m_tab_widget->addTab(m_advanced_widget, tr("Advanced"));
+    m_tab_widget->addTab(m_wrapped_general, tr("General"));
+    m_tab_widget->addTab(m_wrapped_enhancements, tr("Enhancements"));
+    m_tab_widget->addTab(m_wrapped_hacks, tr("Hacks"));
+    m_tab_widget->addTab(m_wrapped_advanced, tr("Advanced"));
   }
 
   emit BackendChanged(backend);

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
@@ -49,6 +49,12 @@ private:
   GeneralWidget* m_general_widget;
   SoftwareRendererWidget* m_software_renderer;
 
+  QWidget* m_wrapped_advanced;
+  QWidget* m_wrapped_enhancements;
+  QWidget* m_wrapped_hacks;
+  QWidget* m_wrapped_general;
+  QWidget* m_wrapped_software;
+
   X11Utils::XRRConfiguration* m_xrr_config;
 
   QHash<QObject*, const char*> m_widget_descriptions;


### PR DESCRIPTION
Fixes:
* MSAA being broken on switches ([issue #11091](https://bugs.dolphin-emu.org/issues/11091))
* MSAA being broken on startup
* Switching back- and forth from Software Renderer breaking the window
* A "No" response on the Software Renderer warning not resetting the backend selection
