### PR TITLE
Qt: Use `addLayout` instead of `addItem` when adding layouts

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
@@ -32,7 +32,7 @@ void GCPadEmu::CreateMainLayout()
 
   auto* hbox_layout = new QVBoxLayout();
 
-  m_main_layout->addItem(hbox_layout);
+  m_main_layout->addLayout(hbox_layout);
 
   hbox_layout->addWidget(
       CreateGroupBox(tr("Triggers"), Pad::GetGroup(GetPort(), PadGroup::Triggers)));

--- a/Source/Core/DolphinQt2/Config/Mapping/HotkeyDebugging.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/HotkeyDebugging.cpp
@@ -26,7 +26,7 @@ void HotkeyDebugging::CreateMainLayout()
   vbox->addWidget(CreateGroupBox(tr("Program Counter"), HotkeyManagerEmu::GetHotkeyGroup(HKGP_PC)));
   vbox->addWidget(
       CreateGroupBox(tr("Breakpoint"), HotkeyManagerEmu::GetHotkeyGroup(HKGP_BREAKPOINT)));
-  m_main_layout->addItem(vbox);
+  m_main_layout->addLayout(vbox);
 
   setLayout(m_main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/HotkeyGeneral.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/HotkeyGeneral.cpp
@@ -26,7 +26,7 @@ void HotkeyGeneral::CreateMainLayout()
   vbox->addWidget(CreateGroupBox(tr("Volume"), HotkeyManagerEmu::GetHotkeyGroup(HKGP_VOLUME)));
   vbox->addWidget(
       CreateGroupBox(tr("Emulation Speed"), HotkeyManagerEmu::GetHotkeyGroup(HKGP_SPEED)));
-  m_main_layout->addItem(vbox);
+  m_main_layout->addLayout(vbox);
 
   setLayout(m_main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/HotkeyGraphics.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/HotkeyGraphics.cpp
@@ -27,7 +27,7 @@ void HotkeyGraphics::CreateMainLayout()
                                  HotkeyManagerEmu::GetHotkeyGroup(HKGP_GRAPHICS_TOGGLES)));
   vbox->addWidget(
       CreateGroupBox(tr("Internal Resolution"), HotkeyManagerEmu::GetHotkeyGroup(HKGP_IR)));
-  m_main_layout->addItem(vbox);
+  m_main_layout->addLayout(vbox);
 
   setLayout(m_main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
@@ -73,7 +73,7 @@ void IOWindow::CreateMainLayout()
   m_range_slider->setMaximum(500);
   m_range_spinbox->setMinimum(-500);
   m_range_spinbox->setMaximum(500);
-  m_main_layout->addItem(range_hbox);
+  m_main_layout->addLayout(range_hbox);
 
   // Options (Buttons, Outputs) and action buttons
   for (QPushButton* button : {m_select_button, m_detect_button, m_or_button, m_and_button,

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -87,7 +87,7 @@ void MappingWindow::CreateProfilesLayout()
   button_layout->addWidget(m_profiles_load);
   button_layout->addWidget(m_profiles_save);
   button_layout->addWidget(m_profiles_delete);
-  m_profiles_layout->addItem(button_layout);
+  m_profiles_layout->addLayout(button_layout);
 
   m_profiles_box->setLayout(m_profiles_layout);
 }
@@ -122,7 +122,7 @@ void MappingWindow::CreateMainLayout()
   m_config_layout->addWidget(m_reset_box);
   m_config_layout->addWidget(m_profiles_box);
 
-  m_main_layout->addItem(m_config_layout);
+  m_main_layout->addLayout(m_config_layout);
   m_main_layout->addWidget(m_iterative_input);
   m_main_layout->addWidget(m_tab_widget);
   m_main_layout->addWidget(m_button_box);

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuExtension.cpp
@@ -43,7 +43,7 @@ void WiimoteEmuExtension::CreateClassicLayout()
       tr("D-Pad"), Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::DPad)));
   vbox->addWidget(CreateGroupBox(
       tr("Triggers"), Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Triggers)));
-  hbox->addItem(vbox);
+  hbox->addLayout(vbox);
 
   m_classic_box->setLayout(hbox);
 }
@@ -61,7 +61,7 @@ void WiimoteEmuExtension::CreateDrumsLayout()
       CreateGroupBox(tr("Pads"), Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Pads)));
   vbox->addWidget(CreateGroupBox(tr("Stick"),
                                  Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Stick)));
-  hbox->addItem(vbox);
+  hbox->addLayout(vbox);
 
   m_drums_box->setLayout(hbox);
 }
@@ -95,7 +95,7 @@ void WiimoteEmuExtension::CreateNunchukLayout()
       tr("Buttons"), Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Buttons)));
   vbox->addWidget(CreateGroupBox(
       tr("Shake"), Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Shake)));
-  hbox->addItem(vbox);
+  hbox->addLayout(vbox);
 
   m_nunchuk_box->setLayout(hbox);
 }
@@ -112,7 +112,7 @@ void WiimoteEmuExtension::CreateGuitarLayout()
       tr("Stick"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Stick)));
   vbox->addWidget(CreateGroupBox(
       tr("Slider Bar"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::SliderBar)));
-  hbox->addItem(vbox);
+  hbox->addLayout(vbox);
 
   auto* vbox2 = new QVBoxLayout();
   vbox2->addWidget(CreateGroupBox(
@@ -121,7 +121,7 @@ void WiimoteEmuExtension::CreateGuitarLayout()
       tr("Frets"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Frets)));
   vbox2->addWidget(CreateGroupBox(
       tr("Whammy"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Whammy)));
-  hbox->addItem(vbox2);
+  hbox->addLayout(vbox2);
 
   m_guitar_box->setLayout(hbox);
 }
@@ -150,7 +150,7 @@ void WiimoteEmuExtension::CreateTurntableLayout()
   vbox->addWidget(
       CreateGroupBox(tr("Crossfade"),
                      Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Crossfade)));
-  hbox->addItem(vbox);
+  hbox->addLayout(vbox);
 
   m_turntable_box->setLayout(hbox);
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -57,7 +57,7 @@ void WiimoteEmuGeneral::CreateMainLayout()
   vbox_layout->addWidget(CreateGroupBox(
       tr("Options"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Options)));
 
-  m_main_layout->addItem(vbox_layout);
+  m_main_layout->addLayout(vbox_layout);
 
   setLayout(m_main_layout);
 }


### PR DESCRIPTION
This fixes the spacing within the layout being added (and that [`addItem` usually shouldn't be used](http://doc.qt.io/qt-5/qlayout.html#addItem))