### PR TITLE
Wii: Fix the Wii epoch and make the IPL.CB 0 by default

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -237,9 +237,7 @@ void CEXIIPL::SetCS(int _iCS)
 
 void CEXIIPL::UpdateRTC()
 {
-  u32 epoch =
-      (SConfig::GetInstance().bWii || SConfig::GetInstance().m_is_mios) ? WII_EPOCH : GC_EPOCH;
-  u32 rtc = Common::swap32(GetEmulatedTime(epoch));
+  u32 rtc = Common::swap32(GetEmulatedTime(GC_EPOCH));
   std::memcpy(m_RTC, &rtc, sizeof(u32));
 }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
@@ -22,11 +22,8 @@ public:
   bool IsPresent() const override;
   void DoState(PointerWrap& p) override;
 
-  static constexpr u32 UNIX_EPOCH = 0;          // 1970-01-01 00:00:00
-  static constexpr u32 GC_EPOCH = 0x386D4380;   // 2000-01-01 00:00:00
-  static constexpr u32 WII_EPOCH = 0x477E5826;  // 2008-01-04 16:00:38
-  // The Wii epoch is suspiciously random, and the Wii was even
-  // released before it, but apparently it works anyway?
+  static constexpr u32 UNIX_EPOCH = 0;         // 1970-01-01 00:00:00
+  static constexpr u32 GC_EPOCH = 0x386D4380;  // 2000-01-01 00:00:00
 
   static u32 GetEmulatedTime(u32 epoch);
   static u64 NetPlay_GetEmulatedTime();

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -286,7 +286,7 @@ void SysConf::InsertDefaultEntries()
   ipl_pc[2] = 0x14;
   AddEntry({Entry::Type::SmallArray, "IPL.PC", std::move(ipl_pc)});
 
-  AddEntry({Entry::Type::Long, "IPL.CB", {0x0f, 0x11, 0x14, 0xa6}});
+  AddEntry({Entry::Type::Long, "IPL.CB", {0x00, 0x00, 0x00, 0x00}});
   AddEntry({Entry::Type::Byte, "IPL.AR", {1}});
   AddEntry({Entry::Type::Byte, "IPL.SSV", {1}});
 


### PR DESCRIPTION
This bug is weird, but essentially, the Wii epoch was wrong the entire time, it was actually equal to the GC epoch.  Even the comment mentioned how suspicious it was, well it was wrong.

When I was testing with custom RTC, and I put it to the GC epoch (so essentially 0), I noticed it was underflowing and tracing back, I found that the epoch value was so big that it would underflow by a lot the RTC in the GetEmulatedTime function when subtracting the epoch at the end.  After nultiple tests and exploring the code, I found out that the default IPL.CB or the RTC counter bias (a value added to the clock to get the real time, on hardware this was to adjust the difference between the TB and the RTC) was NOT 0, but a value that suspiciously turned out to be VERY close to the difference between the Wii Epoch and the GC epoch.

In fact, when I forced this value to be 0, without custom rtc, everything was off by about 8 years too early.  It should be 0 by default as dolphin will boot with the same TB and RTC (also, see #4076 which conluded it should be 0 on GC).

On this PR which makes the Wii and the GC epoch the same number as well as change the default IPL.CB to 0, the custom rtc works again.

However it shoudl be noted that under normal operation (like setting the clock in the wii menu or GC IPL), the counter bias may be negative which will still underflow a custom RTC of 0.  I plan to suggest a fix to this issue in a further PR as I am not sure if I will fix it correctly.

So yeah, that comment had good reason to think it was suspicious, but the only reason it worked this entire time was because the counter bias was cancelling the error and it seemed to have been measured precisely enough so no one would notice.  As for why this odd value got in the default, it's likely the same story as #4076 where the person that dumped their SYSCONF put that value in, but it should have been 0 in the first place.

cc: @RisingFog  and @leoetlino 