### PR TITLE
CMake: Prefer GLVND for OpenGL.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,7 @@ endif()
 include(CheckLib)
 include(CheckCXXSourceRuns)
 
+set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL)
 if (OPENGL_GL)
   include_directories(${OPENGL_INCLUDE_DIR})


### PR DESCRIPTION
We have to decide if we want to link to
libGL.so -- legacy
libOpenGL.so -- GLVND

As we use xxxGetProcAddress, we don't care about feature
levels of the linked library, so we're very fine with the
new way.