### PR TITLE
FloatUtils: Minor cleanup

### DIFF
--- a/Source/Core/Common/FloatUtils.cpp
+++ b/Source/Core/Common/FloatUtils.cpp
@@ -167,12 +167,6 @@ const std::array<BaseAndDec, 32> fres_expected = {{
 // Used by fres and ps_res.
 double ApproximateReciprocal(double val)
 {
-  // We are using namespace std scoped here because the Android NDK is complete trash as usual
-  // For 32bit targets(mips, ARMv7, x86) it doesn't provide an implementation of std::copysign
-  // but instead provides just global namespace copysign implementations.
-  // The workaround for this is to just use namespace std within this function's scope
-  // That way on real toolchains it will use the std:: variant like normal.
-  using namespace std;
   union
   {
     double valf;
@@ -186,23 +180,23 @@ double ApproximateReciprocal(double val)
 
   // Special case 0
   if (mantissa == 0 && exponent == 0)
-    return copysign(std::numeric_limits<double>::infinity(), valf);
+    return std::copysign(std::numeric_limits<double>::infinity(), valf);
 
   // Special case NaN-ish numbers
   if (exponent == (0x7FFLL << 52))
   {
     if (mantissa == 0)
-      return copysign(0.0, valf);
+      return std::copysign(0.0, valf);
     return 0.0 + valf;
   }
 
   // Special case small inputs
   if (exponent < (895LL << 52))
-    return copysign(std::numeric_limits<float>::max(), valf);
+    return std::copysign(std::numeric_limits<float>::max(), valf);
 
   // Special case large inputs
   if (exponent >= (1149LL << 52))
-    return copysign(0.0, valf);
+    return std::copysign(0.0, valf);
 
   exponent = (0x7FDLL << 52) - exponent;
 

--- a/Source/Core/Common/FloatUtils.cpp
+++ b/Source/Core/Common/FloatUtils.cpp
@@ -11,80 +11,70 @@ namespace Common
 {
 u32 ClassifyDouble(double dvalue)
 {
-  // TODO: Optimize the below to be as fast as possible.
-  IntDouble value(dvalue);
-  u64 sign = value.i & DOUBLE_SIGN;
-  u64 exp = value.i & DOUBLE_EXP;
+  u64 ivalue;
+  std::memcpy(&ivalue, &dvalue, sizeof(ivalue));
+
+  const u64 sign = ivalue & DOUBLE_SIGN;
+  const u64 exp = ivalue & DOUBLE_EXP;
+
   if (exp > DOUBLE_ZERO && exp < DOUBLE_EXP)
   {
     // Nice normalized number.
     return sign ? PPC_FPCLASS_NN : PPC_FPCLASS_PN;
   }
-  else
+
+  const u64 mantissa = ivalue & DOUBLE_FRAC;
+  if (mantissa)
   {
-    u64 mantissa = value.i & DOUBLE_FRAC;
-    if (mantissa)
-    {
-      if (exp)
-      {
-        return PPC_FPCLASS_QNAN;
-      }
-      else
-      {
-        // Denormalized number.
-        return sign ? PPC_FPCLASS_ND : PPC_FPCLASS_PD;
-      }
-    }
-    else if (exp)
-    {
-      // Infinite
-      return sign ? PPC_FPCLASS_NINF : PPC_FPCLASS_PINF;
-    }
-    else
-    {
-      // Zero
-      return sign ? PPC_FPCLASS_NZ : PPC_FPCLASS_PZ;
-    }
+    if (exp)
+      return PPC_FPCLASS_QNAN;
+
+    // Denormalized number.
+    return sign ? PPC_FPCLASS_ND : PPC_FPCLASS_PD;
   }
+
+  if (exp)
+  {
+    // Infinite
+    return sign ? PPC_FPCLASS_NINF : PPC_FPCLASS_PINF;
+  }
+
+  // Zero
+  return sign ? PPC_FPCLASS_NZ : PPC_FPCLASS_PZ;
 }
 
 u32 ClassifyFloat(float fvalue)
 {
-  // TODO: Optimize the below to be as fast as possible.
-  IntFloat value(fvalue);
-  u32 sign = value.i & FLOAT_SIGN;
-  u32 exp = value.i & FLOAT_EXP;
+  u32 ivalue;
+  std::memcpy(&ivalue, &fvalue, sizeof(ivalue));
+
+  const u32 sign = ivalue & FLOAT_SIGN;
+  const u32 exp = ivalue & FLOAT_EXP;
+
   if (exp > FLOAT_ZERO && exp < FLOAT_EXP)
   {
     // Nice normalized number.
     return sign ? PPC_FPCLASS_NN : PPC_FPCLASS_PN;
   }
-  else
+
+  const u32 mantissa = ivalue & FLOAT_FRAC;
+  if (mantissa)
   {
-    u32 mantissa = value.i & FLOAT_FRAC;
-    if (mantissa)
-    {
-      if (exp)
-      {
-        return PPC_FPCLASS_QNAN;  // Quiet NAN
-      }
-      else
-      {
-        // Denormalized number.
-        return sign ? PPC_FPCLASS_ND : PPC_FPCLASS_PD;
-      }
-    }
-    else if (exp)
-    {
-      // Infinite
-      return sign ? PPC_FPCLASS_NINF : PPC_FPCLASS_PINF;
-    }
-    else
-    {
-      // Zero
-      return sign ? PPC_FPCLASS_NZ : PPC_FPCLASS_PZ;
-    }
+    if (exp)
+      return PPC_FPCLASS_QNAN;  // Quiet NAN
+
+    // Denormalized number.
+    return sign ? PPC_FPCLASS_ND : PPC_FPCLASS_PD;
   }
+
+  if (exp)
+  {
+    // Infinite
+    return sign ? PPC_FPCLASS_NINF : PPC_FPCLASS_PINF;
+  }
+
+  // Zero
+  return sign ? PPC_FPCLASS_NZ : PPC_FPCLASS_PZ;
 }
 
 const std::array<BaseAndDec, 32> frsqrte_expected = {{


### PR DESCRIPTION
Removes union type-punning from the classify and approximation functions, as well as getting rid of a `using namespace std;`

A follow-up PR will remove `IntDouble` and `IntFloat`. This change was kept separate since it'll also touch the unit tests.