### PR TITLE
Atomic_Win32: Replace deprecated (and since been removed) barrier intrinsics

### DIFF
--- a/Source/Core/Common/Atomic_Win32.h
+++ b/Source/Core/Common/Atomic_Win32.h
@@ -8,6 +8,7 @@
 
 #include <Windows.h>
 
+#include <atomic>
 #include "Common/CommonTypes.h"
 
 // Atomic operations are performed in a single step by the CPU. It is
@@ -64,8 +65,10 @@ inline T AtomicLoad(volatile T& src)
 template <typename T>
 inline T AtomicLoadAcquire(volatile T& src)
 {
-  T result = src;  // 32-bit reads are always atomic.
-  _ReadBarrier();  // Compiler instruction only. x86 loads always have acquire semantics.
+  // 32-bit reads are always atomic.
+  T result = src;
+  // Compiler instruction only. x86 loads always have acquire semantics.
+  std::atomic_thread_fence(std::memory_order_acquire);
   return result;
 }
 
@@ -78,7 +81,8 @@ inline void AtomicStore(volatile T& dest, U value)
 template <typename T, typename U>
 inline void AtomicStoreRelease(volatile T& dest, U value)
 {
-  _WriteBarrier();  // Compiler instruction only. x86 stores always have release semantics.
+  // Compiler instruction only. x86 stores always have release semantics.
+  std::atomic_thread_fence(std::memory_order_release);
   dest = (T)value;  // 32-bit writes are always atomic.
 }
 


### PR DESCRIPTION
As of VS 15.7, these seem to have been removed. Given we shouldn't have been using these for some time, just replace them with the standard library equivalent (they are functionally equivalent) given `_Atomic_thread_fence` (which `atomic_thread_fence` forwards to) is implemented as:

```cpp
inline void _Atomic_thread_fence(memory_order _Order)
{	/* force memory visibility and inhibit compiler reordering */
#if defined(_M_ARM) || defined(_M_ARM64)
	if (_Order != memory_order_relaxed)
	{
		_Memory_barrier();
	}

#else
	_Compiler_barrier(); // <- Barrier still inserted (as expected)
	if (_Order == memory_order_seq_cst)
	{	/* force visibility */
		static _Uint4_t _Guard;
		_Atomic_exchange_4(&_Guard, 0, memory_order_seq_cst);
		_Compiler_barrier();
	}
#endif
}
```

This fixes building on Windows with VS 15.7