### PR TITLE
Move all UID constants to a single file

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -25,6 +25,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOSC.h"
+#include "Core/IOS/Uids.h"
 #include "Core/IOS/VersionInfo.h"
 
 namespace IOS
@@ -55,8 +56,8 @@ constexpr std::array<DirectoryToCreate, 9> s_directories_to_create = {{
     {"/shared2", 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite},
     {"/tmp", 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite},
     {"/import", 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::None},
-    {"/meta", 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite,
-     IOS::ES::FIRST_PPC_UID, 0x1},
+    {"/meta", 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite, SYSMENU_UID,
+     SYSMENU_GID},
     {"/wfs", 0, FS::Mode::ReadWrite, FS::Mode::None, FS::Mode::None, PID_UNKNOWN, PID_UNKNOWN},
 }};
 
@@ -683,8 +684,6 @@ s32 ES::DIVerify(const IOS::ES::TMDReader& tmd, const IOS::ES::TicketReader& tic
   return FS::ConvertResult(fs->SetMetadata(0, data_dir, m_ios.GetUidForPPC(), m_ios.GetGidForPPC(),
                                            0, FS::Mode::ReadWrite, FS::Mode::None, FS::Mode::None));
 }
-
-constexpr u32 FIRST_PPC_UID = 0x1000;
 
 ReturnCode ES::CheckStreamKeyPermissions(const u32 uid, const u8* ticket_view,
                                          const IOS::ES::TMDReader& tmd) const

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -271,8 +271,6 @@ private:
   std::shared_ptr<HLE::FS::FileSystem> m_fs;
 };
 
-constexpr u32 FIRST_PPC_UID = 0x1000;
-
 class UIDSys final
 {
 public:

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -10,6 +10,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/Uids.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -18,6 +18,7 @@
 #include "Common/StringUtil.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/Uids.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -12,6 +12,7 @@
 #include "Common/MsgHandler.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/Uids.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -20,6 +20,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileSystem.h"
+#include "Core/IOS/Uids.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -57,30 +57,6 @@ enum IPCCommandType : u32
   IPC_REPLY = 8,
 };
 
-enum ProcessId : u32
-{
-  PID_KERNEL = 0,
-  PID_ES = 1,
-  PID_FS = 2,
-  PID_DI = 3,
-  PID_OH0 = 4,
-  PID_OH1 = 5,
-  PID_EHCI = 6,
-  PID_SDI = 7,
-  PID_USBETH = 8,
-  PID_NET = 9,
-  PID_WD = 10,
-  PID_WL = 11,
-  PID_KD = 12,
-  PID_NCD = 13,
-  PID_STM = 14,
-  PID_PPCBOOT = 15,
-  PID_SSL = 16,
-  PID_USB = 17,
-  PID_P2P = 18,
-  PID_UNKNOWN = 19,
-};
-
 void WriteReturnValue(s32 value, u32 address);
 
 // HLE for the IOS kernel: IPC, device management, syscalls, and Dolphin-specific, IOS-wide calls.

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
@@ -12,6 +12,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
+#include "Core/IOS/Uids.h"
 
 namespace IOS
 {

--- a/Source/Core/Core/IOS/Uids.h
+++ b/Source/Core/Core/IOS/Uids.h
@@ -1,0 +1,41 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+
+namespace IOS
+{
+// IOS processes have their UID and GID set to their (hardcoded) PID.
+enum IOSUid : u32
+{
+  PID_KERNEL = 0,
+  PID_ES = 1,
+  PID_FS = 2,
+  PID_DI = 3,
+  PID_OH0 = 4,
+  PID_OH1 = 5,
+  PID_EHCI = 6,
+  PID_SDI = 7,
+  PID_USBETH = 8,
+  PID_NET = 9,
+  PID_WD = 10,
+  PID_WL = 11,
+  PID_KD = 12,
+  PID_NCD = 13,
+  PID_STM = 14,
+  PID_PPCBOOT = 15,
+  PID_SSL = 16,
+  PID_USB = 17,
+  PID_P2P = 18,
+  PID_UNKNOWN = 19,
+};
+
+constexpr u32 FIRST_PPC_UID = 0x1000;
+
+constexpr u32 SYSMENU_UID = FIRST_PPC_UID;
+constexpr u16 SYSMENU_GID = 1;
+
+}  // namespace IOS

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -15,6 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
 #include "Core/IOS/FS/FileSystem.h"
+#include "Core/IOS/Uids.h"
 
 constexpr size_t SYSCONF_SIZE = 0x4000;
 
@@ -196,17 +197,17 @@ bool SysConf::Save() const
 
   // Write the new data.
   const std::string temp_file = "/tmp/SYSCONF";
-  constexpr u32 SYSMENU_UID = 0x1000;
-  constexpr u16 SYSMENU_GID = 1;
   constexpr auto rw_mode = IOS::HLE::FS::Mode::ReadWrite;
   {
-    m_fs->CreateFile(SYSMENU_UID, SYSMENU_GID, temp_file, 0, rw_mode, rw_mode, rw_mode);
-    auto file = m_fs->OpenFile(SYSMENU_UID, SYSMENU_GID, temp_file, IOS::HLE::FS::Mode::Write);
+    auto file = m_fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, temp_file, rw_mode,
+                                        rw_mode, rw_mode);
     if (!file || !file->Write(buffer.data(), buffer.size()))
       return false;
   }
-  m_fs->CreateDirectory(SYSMENU_UID, SYSMENU_GID, "/shared2/sys", 0, rw_mode, rw_mode, rw_mode);
-  const auto result = m_fs->Rename(SYSMENU_UID, SYSMENU_GID, temp_file, "/shared2/sys/SYSCONF");
+  m_fs->CreateDirectory(IOS::SYSMENU_UID, IOS::SYSMENU_GID, "/shared2/sys", 0, rw_mode, rw_mode,
+                        rw_mode);
+  const auto result =
+      m_fs->Rename(IOS::SYSMENU_UID, IOS::SYSMENU_GID, temp_file, "/shared2/sys/SYSCONF");
   return result == IOS::HLE::FS::ResultCode::Success;
 }
 


### PR DESCRIPTION
Keeps them all next to each other and deduplicates a few constants,
notably the PPC UIDs. Apparently I forgot that I already added them
for ES::SetupStreamKey.