### PR TITLE
D3D/Vulkan: Fix incorrect clamp in EFB RAM copy

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -110,7 +110,7 @@ void PSTextureEncoder::Encode(
     encode_params.y_scale = y_scale;
     encode_params.gamma_rcp = 1.0f / gamma;
     encode_params.clamp_top = clamp_top ? src_rect.top / float(EFB_HEIGHT) : 0.0f;
-    encode_params.clamp_bottom = clamp_bottom ? src_rect.bottom / float(EFB_HEIGHT) : 0.0f;
+    encode_params.clamp_bottom = clamp_bottom ? src_rect.bottom / float(EFB_HEIGHT) : 1.0f;
     for (size_t i = 0; i < filter_coefficients.size(); i++)
       encode_params.filter_coefficients[i] = filter_coefficients[i];
 

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -245,7 +245,7 @@ void TextureConverter::EncodeTextureToMemory(
   encoder_params.y_scale = y_scale;
   encoder_params.gamma_rcp = 1.0f / gamma;
   encoder_params.clamp_top = clamp_top ? src_rect.top / float(EFB_HEIGHT) : 0.0f;
-  encoder_params.clamp_bottom = clamp_bottom ? src_rect.bottom / float(EFB_HEIGHT) : 0.0f;
+  encoder_params.clamp_bottom = clamp_bottom ? src_rect.bottom / float(EFB_HEIGHT) : 1.0f;
   for (size_t i = 0; i < filter_coefficients.size(); i++)
     encoder_params.filter_coefficients[i] = filter_coefficients[i];
   u8* ubo_ptr = draw.AllocatePSUniforms(sizeof(EFBEncodeParams));


### PR DESCRIPTION
This could cause darker-than-expected EFB copies if clamping was not enabled, and the user forced EFB copies to RAM only.