### PR TITLE
Qt: Save and restore main window size and position

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -113,6 +113,7 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters) : QMainW
   QSettings& settings = Settings::GetQSettings();
 
   restoreState(settings.value(QStringLiteral("mainwindow/state")).toByteArray());
+  restoreGeometry(settings.value(QStringLiteral("mainwindow/geometry")).toByteArray());
   m_render_widget_size =
       QSize(SConfig::GetInstance().iRenderWindowWidth, SConfig::GetInstance().iRenderWindowHeight);
 
@@ -128,6 +129,7 @@ MainWindow::~MainWindow()
   QSettings& settings = Settings::GetQSettings();
 
   settings.setValue(QStringLiteral("mainwindow/state"), saveState());
+  settings.setValue(QStringLiteral("mainwindow/geometry"), saveGeometry());
 
   SConfig::GetInstance().iRenderWindowWidth = m_render_widget_size.width();
   SConfig::GetInstance().iRenderWindowHeight = m_render_widget_size.height();


### PR DESCRIPTION
Just like DolphinWX. Tries to fix https://forums.dolphin-emu.org/Thread-qt-gui-doesn-t-remember-window-size-and-position

This is rather more basic than the WX version, which [uses some more complicated logic](https://github.com/dolphin-emu/dolphin/blob/fd1ea63383f7d9189a14a99948e08fddc4e4d7ee/Source/Core/DolphinWX/WxUtils.cpp#L142) to set the window size and position.