### PR TITLE
Git Ignore: Add VisualStudio .APS and .LOG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,14 @@ Source/Core/Common/scmrev.h
 # Android cmake builds to here then copies to Source/Android.
 /libs/
 # Ignore various files created by visual studio/msbuild
+*.aps
 *.ipch
 *.opensdf
 *.sdf
 *.suo
 *.vcxproj.user
 *.obj
+*.log
 *.tlog
 *.VC.opendb
 *.VC.db


### PR DESCRIPTION
Generated a DolphinQt2.aps file. It's used by VS for performance.

Update: In some circumstances, Visual Studio may create .log files in some Externals, even if there is no errors.