### PR TITLE
Qt/IOWindow: Fix crash

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/IOWindow.cpp
@@ -217,6 +217,9 @@ void IOWindow::UpdateOptionList()
 
   const auto device = g_controller_interface.FindDevice(m_devq);
 
+  if (device == nullptr)
+    return;
+
   if (m_reference->IsInput())
   {
     for (const auto* input : device->Inputs())


### PR DESCRIPTION
Fixes [issue #11084](https://bugs.dolphin-emu.org/issues/11084).