### PR TITLE
Boot: Migrate to new filesystem interface

### DIFF
--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -44,7 +44,7 @@ void SettingsHandler::SetBytes(SettingsHandler::Buffer&& buffer)
   Decrypt();
 }
 
-const std::string SettingsHandler::GetValue(const std::string& key)
+std::string SettingsHandler::GetValue(const std::string& key) const
 {
   std::string delim = std::string("\r\n");
   std::string toFind = delim + key + "=";

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -19,8 +19,6 @@
 #endif
 
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
-#include "Common/FileUtil.h"
 #include "Common/SettingsHandler.h"
 #include "Common/Timer.h"
 
@@ -29,30 +27,21 @@ SettingsHandler::SettingsHandler()
   Reset();
 }
 
-bool SettingsHandler::Open(const std::string& settings_file_path)
+SettingsHandler::SettingsHandler(Buffer&& buffer)
+{
+  SetBytes(std::move(buffer));
+}
+
+const SettingsHandler::Buffer& SettingsHandler::GetBytes() const
+{
+  return m_buffer;
+}
+
+void SettingsHandler::SetBytes(SettingsHandler::Buffer&& buffer)
 {
   Reset();
-
-  File::IOFile file{settings_file_path, "rb"};
-  if (!file.ReadBytes(m_buffer.data(), m_buffer.size()))
-    return false;
-
+  m_buffer = std::move(buffer);
   Decrypt();
-  return true;
-}
-
-bool SettingsHandler::Save(const std::string& destination_file_path) const
-{
-  if (!File::CreateFullPath(destination_file_path))
-    return false;
-
-  File::IOFile file{destination_file_path, "wb"};
-  return file.WriteBytes(m_buffer.data(), m_buffer.size());
-}
-
-const u8* SettingsHandler::GetData() const
-{
-  return m_buffer.data();
 }
 
 const std::string SettingsHandler::GetValue(const std::string& key)

--- a/Source/Core/Common/SettingsHandler.h
+++ b/Source/Core/Common/SettingsHandler.h
@@ -21,14 +21,14 @@ public:
     INITIAL_SEED = 0x73B5DBFA
   };
 
+  using Buffer = std::array<u8, SETTINGS_SIZE>;
   SettingsHandler();
-
-  bool Open(const std::string& settings_file_path);
-  bool Save(const std::string& destination_file_path) const;
+  explicit SettingsHandler(Buffer&& buffer);
 
   void AddSetting(const std::string& key, const std::string& value);
 
-  const u8* GetData() const;
+  const Buffer& GetBytes() const;
+  void SetBytes(Buffer&& buffer);
   const std::string GetValue(const std::string& key);
 
   void Decrypt();

--- a/Source/Core/Common/SettingsHandler.h
+++ b/Source/Core/Common/SettingsHandler.h
@@ -29,7 +29,7 @@ public:
 
   const Buffer& GetBytes() const;
   void SetBytes(Buffer&& buffer);
-  const std::string GetValue(const std::string& key);
+  std::string GetValue(const std::string& key) const;
 
   void Decrypt();
   void Reset();

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -151,3 +151,9 @@ struct StateFlags
 // Reads the state file from the NAND, then calls the passed update function to update the struct,
 // and finally writes the updated state file to the NAND.
 void UpdateStateFlags(std::function<void(StateFlags*)> update_function);
+
+/// Create title directories for the system menu (if needed).
+///
+/// Normally, this is automatically done by ES when the System Menu is installed,
+/// but we cannot rely on this because we don't require any system titles to be installed.
+void CreateSystemMenuTitleDirs();

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -9,8 +9,6 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
-#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
@@ -227,6 +225,7 @@ bool CBoot::SetupWiiMemory()
 
   SettingsHandler gen;
   std::string serno;
+  CreateSystemMenuTitleDirs();
   const std::string settings_file_path(Common::GetTitleDataPath(Titles::SYSTEM_MENU) +
                                        "/" WII_SETTING);
 
@@ -338,11 +337,16 @@ bool CBoot::SetupWiiMemory()
 
 static void WriteEmptyPlayRecord()
 {
-  const std::string file_path =
-      Common::GetTitleDataPath(Titles::SYSTEM_MENU, Common::FROM_SESSION_ROOT) + "/play_rec.dat";
-  File::IOFile playrec_file(file_path, "r+b");
+  CreateSystemMenuTitleDirs();
+  const std::string file_path = Common::GetTitleDataPath(Titles::SYSTEM_MENU) + "/play_rec.dat";
+  const auto fs = IOS::HLE::GetIOS()->GetFS();
+  constexpr IOS::HLE::FS::Mode rw_mode = IOS::HLE::FS::Mode::ReadWrite;
+  const auto playrec_file = fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, file_path,
+                                                  rw_mode, rw_mode, rw_mode);
+  if (!playrec_file)
+    return;
   std::vector<u8> empty_record(0x80);
-  playrec_file.WriteBytes(empty_record.data(), empty_record.size());
+  playrec_file->Write(empty_record.data(), empty_record.size());
 }
 
 // __________________________________________________________________________________________________

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -139,6 +139,8 @@ public:
   ReturnCode SetUpStreamKey(u32 uid, const u8* ticket_view, const IOS::ES::TMDReader& tmd,
                             u32* handle);
 
+  bool CreateTitleDirectories(u64 title_id, u16 group_id) const;
+
 private:
   enum
   {


### PR DESCRIPTION
Followup for the migration work started in 8317a66

The goal is to make all accesses to the Wii filesystem go through the common interface so that we can switch to a different storage and keep track of things like metadata in the future.

The first commit changes SettingsHandler to take a buffer instead of assuming that the setting file to read is always on the host filesystem for more flexibility and make it possible to use the new FS code.

The third commit moves title directory creation code into a separate function that can easily be called from the boot code. We can't assume that the System Menu title dirs exist as we don't require users to install system titles, so we need to create them in the boot code with the proper permissions ourselves.

The last commit changes the remaining parts of the boot code to use the new FS interface, creating title dirs for 1-2 if necessary.