### PR TITLE
CommonFuncs: Convert ROUND_UP_POW2 macro to a function

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -15,13 +15,6 @@ constexpr size_t ArraySize(T (&arr)[N])
   return N;
 }
 
-#define b2(x) ((x) | ((x) >> 1))
-#define b4(x) (b2(x) | (b2(x) >> 2))
-#define b8(x) (b4(x) | (b4(x) >> 4))
-#define b16(x) (b8(x) | (b8(x) >> 8))
-#define b32(x) (b16(x) | (b16(x) >> 16))
-#define ROUND_UP_POW2(x) (b32(x - 1) + 1)
-
 #ifndef _WIN32
 
 // go to debugger mode

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -29,6 +29,19 @@ constexpr bool IsPow2(T imm)
   return imm > 0 && (imm & (imm - 1)) == 0;
 }
 
+constexpr u32 NextPowerOf2(u32 value)
+{
+  --value;
+  value |= value >> 1;
+  value |= value >> 2;
+  value |= value >> 4;
+  value |= value >> 8;
+  value |= value >> 16;
+  ++value;
+
+  return value;
+}
+
 template <class T>
 struct Rectangle
 {

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -7,8 +7,8 @@
 #include <memory>
 #include <string>
 
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 #include "Common/Swap.h"
 #include "Core/PowerPC/PowerPC.h"
 
@@ -44,7 +44,7 @@ enum
   // Note: Writing to lowmem is done by IPL. If using retail IPL, it will
   // always be set to 24MB.
   REALRAM_SIZE = 0x01800000,
-  RAM_SIZE = ROUND_UP_POW2(REALRAM_SIZE),
+  RAM_SIZE = MathUtil::NextPowerOf2(REALRAM_SIZE),
   RAM_MASK = RAM_SIZE - 1,
   FAKEVMEM_SIZE = 0x02000000,
   FAKEVMEM_MASK = FAKEVMEM_SIZE - 1,

--- a/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
@@ -5,8 +5,8 @@
 #include "VideoBackends/OGL/StreamBuffer.h"
 
 #include "Common/Align.h"
-#include "Common/CommonFuncs.h"
 #include "Common/GL/GLUtil.h"
+#include "Common/MathUtil.h"
 #include "Common/MemoryUtil.h"
 
 #include "VideoBackends/OGL/Render.h"
@@ -25,8 +25,8 @@ static u32 GenBuffer()
 }
 
 StreamBuffer::StreamBuffer(u32 type, u32 size)
-    : m_buffer(GenBuffer()), m_buffertype(type), m_size(ROUND_UP_POW2(size)),
-      m_bit_per_slot(IntLog2(ROUND_UP_POW2(size) / SYNC_POINTS))
+    : m_buffer(GenBuffer()), m_buffertype(type), m_size(MathUtil::NextPowerOf2(size)),
+      m_bit_per_slot(IntLog2(MathUtil::NextPowerOf2(size) / SYNC_POINTS))
 {
   m_iterator = 0;
   m_used_iterator = 0;

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -7,8 +7,8 @@
 #include <memory>
 #include <vector>
 
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/ShaderCache.h"
 
@@ -37,10 +37,10 @@ private:
 
 public:
   static constexpr u32 MAXVBUFFERSIZE =
-      ROUND_UP_POW2(MAX_PRIMITIVES_PER_COMMAND * LARGEST_POSSIBLE_VERTEX);
+      MathUtil::NextPowerOf2(MAX_PRIMITIVES_PER_COMMAND * LARGEST_POSSIBLE_VERTEX);
 
   // We may convert triangle-fans to triangle-lists, almost 3x as many indices.
-  static constexpr u32 MAXIBUFFERSIZE = ROUND_UP_POW2(MAX_PRIMITIVES_PER_COMMAND * 3);
+  static constexpr u32 MAXIBUFFERSIZE = MathUtil::NextPowerOf2(MAX_PRIMITIVES_PER_COMMAND * 3);
 
   VertexManagerBase();
   // needs to be virtual for DX11's dtor

--- a/Source/UnitTests/Common/CommonFuncsTest.cpp
+++ b/Source/UnitTests/Common/CommonFuncsTest.cpp
@@ -18,14 +18,6 @@ TEST(CommonFuncs, ArraySizeFunction)
   (void)test2;
 }
 
-TEST(CommonFuncs, RoundUpPow2Macro)
-{
-  EXPECT_EQ(4, ROUND_UP_POW2(3));
-  EXPECT_EQ(4, ROUND_UP_POW2(4));
-  EXPECT_EQ(8, ROUND_UP_POW2(6));
-  EXPECT_EQ(0x40000000, ROUND_UP_POW2(0x23456789));
-}
-
 TEST(CommonFuncs, CrashMacro)
 {
   EXPECT_DEATH({ Crash(); }, "");

--- a/Source/UnitTests/Common/MathUtilTest.cpp
+++ b/Source/UnitTests/Common/MathUtilTest.cpp
@@ -30,3 +30,11 @@ TEST(MathUtil, IntLog2)
   EXPECT_EQ(3, IntLog2(15));
   EXPECT_EQ(63, IntLog2(0xFFFFFFFFFFFFFFFFull));
 }
+
+TEST(MathUtil, NextPowerOf2)
+{
+  EXPECT_EQ(4, MathUtil::NextPowerOf2(3));
+  EXPECT_EQ(4, MathUtil::NextPowerOf2(4));
+  EXPECT_EQ(8, MathUtil::NextPowerOf2(6));
+  EXPECT_EQ(0x40000000, MathUtil::NextPowerOf2(0x23456789));
+}


### PR DESCRIPTION
Also move it to MathUtils where it belongs with the rest of the power-of-two functions. This gets rid of pollution of the current scope of any translation unit with `b<value>` macros that aren't intended to be used directly.