### PR TITLE
DolphinQt2/MemoryWidget: Use QString's toUtf8() where applicable instead of toStdString()

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/MemoryWidget.cpp
@@ -385,9 +385,9 @@ void MemoryWidget::OnSetValue()
 
   if (m_find_ascii->isChecked())
   {
-    std::string ascii = m_data_edit->text().toStdString();
+    const QByteArray bytes = m_data_edit->text().toUtf8();
 
-    for (char c : ascii)
+    for (char c : bytes)
       PowerPC::HostWrite_U8(static_cast<u8>(c), addr++);
   }
   else
@@ -471,10 +471,8 @@ std::vector<u8> MemoryWidget::GetValueData() const
 
   if (m_find_ascii->isChecked())
   {
-    std::string s = m_data_edit->text().toStdString();
-
-    for (char c : s)
-      search_for.push_back(c);
+    const QByteArray bytes = m_data_edit->text().toUtf8();
+    search_for.assign(bytes.begin(), bytes.end());
   }
   else
   {


### PR DESCRIPTION
Avoids needing to iterate and append the characters manually in one case. This also alters the function to not need to construct a temporary std::string (QString's `toUtf8()` is sufficient, as QByteArray exposes iterators).

toStdString() is equivalent to retrieving the QString's underlying QByteArray via calling QString's `.toUtf8()` member function and then calling `.toStdString()` on the result of it (discarding the QByteArray afterwords), so this just trims off an unnecessary step in the process.

This is also somewhat more indicative of the conversions going on: toStdString() converts the underlying character sequence of a QString to UTF-8, not strict ASCII, so we're really using a superset of ASCII.