### PR TITLE
IOS/KD: Migrate to new filesystem interface

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
@@ -8,10 +8,10 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
-#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
+#include "Core/IOS/FS/FileSystem.h"
+#include "Core/IOS/Uids.h"
 
 namespace IOS
 {
@@ -19,43 +19,41 @@ namespace HLE
 {
 namespace NWC24
 {
-NWC24Config::NWC24Config()
+constexpr const char CONFIG_PATH[] = "/" WII_WC24CONF_DIR "/nwc24msg.cfg";
+
+NWC24Config::NWC24Config(std::shared_ptr<FS::FileSystem> fs) : m_fs{std::move(fs)}
 {
-  m_path = File::GetUserPath(D_SESSION_WIIROOT_IDX) + "/" WII_WC24CONF_DIR "/nwc24msg.cfg";
   ReadConfig();
 }
 
 void NWC24Config::ReadConfig()
 {
-  if (!File::IOFile(m_path, "rb").ReadBytes(&m_data, sizeof(m_data)))
+  if (const auto file = m_fs->OpenFile(PID_KD, PID_KD, CONFIG_PATH, FS::Mode::Read))
   {
-    ResetConfig();
+    if (file->Read(&m_data, 1))
+    {
+      const s32 config_error = CheckNwc24Config();
+      if (config_error)
+        ERROR_LOG(IOS_WC24, "There is an error in the config for for WC24: %d", config_error);
+
+      return;
+    }
   }
-  else
-  {
-    const s32 config_error = CheckNwc24Config();
-    if (config_error)
-      ERROR_LOG(IOS_WC24, "There is an error in the config for for WC24: %d", config_error);
-  }
+  ResetConfig();
 }
 
 void NWC24Config::WriteConfig() const
 {
-  if (!File::Exists(m_path))
-  {
-    if (!File::CreateFullPath(File::GetUserPath(D_SESSION_WIIROOT_IDX) + "/" WII_WC24CONF_DIR))
-    {
-      ERROR_LOG(IOS_WC24, "Failed to create directory for WC24");
-    }
-  }
-
-  File::IOFile(m_path, "wb").WriteBytes(&m_data, sizeof(m_data));
+  constexpr FS::Mode rw_mode = FS::Mode::ReadWrite;
+  m_fs->CreateFullPath(PID_KD, PID_KD, CONFIG_PATH, 0, rw_mode, rw_mode, rw_mode);
+  const auto file = m_fs->CreateAndOpenFile(PID_KD, PID_KD, CONFIG_PATH, rw_mode, rw_mode, rw_mode);
+  if (!file || !file->Write(&m_data, 1))
+    ERROR_LOG(IOS_WC24, "Failed to open or write WC24 config file");
 }
 
 void NWC24Config::ResetConfig()
 {
-  if (File::Exists(m_path))
-    File::Delete(m_path);
+  m_fs->Delete(PID_KD, PID_KD, CONFIG_PATH);
 
   constexpr const char* urls[5] = {
       "https://amw.wc24.wii.com/cgi-bin/account.cgi", "http://rcw.wc24.wii.com/cgi-bin/check.cgi",

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.h
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include "Common/CommonTypes.h"
 
@@ -11,6 +12,10 @@ namespace IOS
 {
 namespace HLE
 {
+namespace FS
+{
+class FileSystem;
+}
 namespace NWC24
 {
 enum ErrorCode : s32
@@ -41,7 +46,7 @@ public:
     MAX_PASSWORD_LENGTH = 0x20,
   };
 
-  NWC24Config();
+  explicit NWC24Config(std::shared_ptr<FS::FileSystem> fs);
 
   void ReadConfig();
   void WriteConfig() const;
@@ -94,7 +99,7 @@ private:
   };
 #pragma pack(pop)
 
-  std::string m_path;
+  std::shared_ptr<FS::FileSystem> m_fs;
   ConfigData m_data;
 };
 }  // namespace NWC24

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -26,7 +26,8 @@ namespace HLE
 {
 namespace Device
 {
-NetKDRequest::NetKDRequest(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+NetKDRequest::NetKDRequest(Kernel& ios, const std::string& device_name)
+    : Device(ios, device_name), config{ios.GetFS()}
 {
 }
 


### PR DESCRIPTION
Followup for the migration work started in 8317a66 and all the other [filesystem PRs](https://github.com/dolphin-emu/dolphin/pull/6807).