### PR TITLE
RTC: Write 0 to the counter bias if we are on custom RTC

### DIFF
--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -20,6 +20,7 @@
 
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
@@ -48,6 +49,9 @@ void SaveToSYSCONF(Config::LayerType layer)
         },
         setting.config_info);
   }
+
+  if (SConfig::GetInstance().bEnableCustomRTC)
+    sysconf.SetData<u32>("IPL.CB", SysConf::Entry::Type::Long, 0);
 
   // Disable WiiConnect24's standby mode. If it is enabled, it prevents us from receiving
   // shutdown commands in the State Transition Manager (STM).
@@ -177,4 +181,4 @@ std::unique_ptr<Config::ConfigLayerLoader> GenerateBaseConfigLoader()
 {
   return std::make_unique<BaseConfigLayerLoader>();
 }
-}
+}  // namespace ConfigLoaders

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -129,6 +129,8 @@ CEXIIPL::CEXIIPL() : m_uPosition(0), m_uAddress(0), m_uRWOffset(0), m_FontsLoade
   // We Overwrite language selection here since it's possible on the GC to change the language as
   // you please
   g_SRAM.lang = SConfig::GetInstance().SelectedLanguage;
+  if (SConfig::GetInstance().bEnableCustomRTC)
+    g_SRAM.counter_bias = 0;
   FixSRAMChecksums();
 
   Common::WriteProtectMemory(m_pIPL, ROM_SIZE);


### PR DESCRIPTION
This is kind of a hack, but one that might be very desirable as far as the user is concerned if they want custom RTC.

Both the GameCube and the Wii has what's called an RTC counter bias which is a value that is added on boot to the RTC value, this makes sense on hardware if you set the clock to get the correct time.

However, the custom RTC option of Dolphin allows to boot with any RTC value making this bias pretty undesirable.  If say you want the epoch on boot and the bias happened to not be 0, either it's positive and it will offset the time (so it's no longer on the epoch anymore early on boot) or it's negative and it underflows which is even less desirable.  The counter bias is mainly set by previous set of the clock in the GameCube IPL or the Wii settings in the Wii menu making the bias pretty annoying to deal with unless you manually edit the SRAM or the SYSCONF before booting which is annoying user wise.

This PR aims to put the value 0 in the bias before we boot if we use custom RTC so the emualted system will not touch the desired time.

Now frankly (and especially for the Wii part), I have no idea if the way I am doing this is the best, nor if there's a better solution because it is a hack.  Maybe @leoetlino can tell if I am doing this correctly on Wii and I do welcome alternative if any.

cc: @leoetlino and @RisingFog 