### PR TITLE
Config: Fix implicit conversions/enum config types

### DIFF
--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -70,26 +70,26 @@ LayerType GetActiveLayerForConfig(const ConfigInfo<T>& info)
 }
 
 template <typename T>
-void Set(LayerType layer, const ConfigInfo<T>& info, const T& value)
+void Set(LayerType layer, const ConfigInfo<T>& info, const std::common_type_t<T>& value)
 {
   GetLayer(layer)->Set(info, value);
   InvokeConfigChangedCallbacks();
 }
 
 template <typename T>
-void SetBase(const ConfigInfo<T>& info, const T& value)
+void SetBase(const ConfigInfo<T>& info, const std::common_type_t<T>& value)
 {
   Set<T>(LayerType::Base, info, value);
 }
 
 template <typename T>
-void SetCurrent(const ConfigInfo<T>& info, const T& value)
+void SetCurrent(const ConfigInfo<T>& info, const std::common_type_t<T>& value)
 {
   Set<T>(LayerType::CurrentRun, info, value);
 }
 
 template <typename T>
-void SetBaseOrCurrent(const ConfigInfo<T>& info, const T& value)
+void SetBaseOrCurrent(const ConfigInfo<T>& info, const std::common_type_t<T>& value)
 {
   if (GetActiveLayerForConfig(info) == LayerType::Base)
     Set<T>(LayerType::Base, info, value);

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -5,11 +5,19 @@
 #pragma once
 
 #include <string>
+#include <type_traits>
 
 #include "Common/Config/Enums.h"
 
 namespace Config
 {
+namespace detail
+{
+// std::underlying_type may only be used with enum types, so make sure T is an enum type first.
+template <typename T>
+using UnderlyingType = typename std::enable_if_t<std::is_enum<T>{}, std::underlying_type<T>>::type;
+}  // namespace detail
+
 struct ConfigLocation
 {
   System system;
@@ -24,6 +32,21 @@ struct ConfigLocation
 template <typename T>
 struct ConfigInfo
 {
+  ConfigInfo(const ConfigLocation& location_, const T& default_value_)
+      : location{location_}, default_value{default_value_}
+  {
+  }
+
+  // Make it easy to convert ConfigInfo<Enum> into ConfigInfo<UnderlyingType<Enum>>
+  // so that enum settings can still easily work with code that doesn't care about the enum values.
+  template <typename Enum,
+            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
+  ConfigInfo(const ConfigInfo<Enum>& other)
+      : location{other.location}, default_value{static_cast<detail::UnderlyingType<Enum>>(
+                                      other.default_value)}
+  {
+  }
+
   ConfigLocation location;
   T default_value;
 };

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -116,7 +116,7 @@ public:
   }
 
   template <typename T>
-  void Set(const ConfigInfo<T>& config_info, const T& value)
+  void Set(const ConfigInfo<T>& config_info, const std::common_type_t<T>& value)
   {
     Set<T>(config_info.location, value);
   }

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "Common/Config/ConfigInfo.h"
@@ -25,14 +26,28 @@ std::string ValueToString(double value);
 std::string ValueToString(int value);
 std::string ValueToString(bool value);
 std::string ValueToString(const std::string& value);
+template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+std::string ValueToString(T value)
+{
+  return ValueToString(static_cast<std::underlying_type_t<T>>(value));
+}
 
-template <typename T>
+template <typename T, std::enable_if_t<!std::is_enum<T>::value>* = nullptr>
 std::optional<T> TryParse(const std::string& str_value)
 {
   T value;
   if (!::TryParse(str_value, &value))
     return std::nullopt;
   return value;
+}
+
+template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+std::optional<T> TryParse(const std::string& str_value)
+{
+  const auto result = TryParse<std::underlying_type_t<T>>(str_value);
+  if (result)
+    return static_cast<T>(*result);
+  return {};
 }
 
 template <>

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -169,8 +169,11 @@ void LogManager::SaveSettings()
   Config::SetBaseOrCurrent(LOGGER_VERBOSITY, static_cast<int>(GetLogLevel()));
 
   for (const auto& container : m_log)
-    Config::SetBaseOrCurrent({{Config::System::Logger, "Logs", container.m_short_name}, false},
-                             container.m_enable);
+  {
+    const Config::ConfigInfo<bool> info{{Config::System::Logger, "Logs", container.m_short_name},
+                                        false};
+    Config::SetBaseOrCurrent(info, container.m_enable);
+  }
 
   Config::Save();
 }

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -21,10 +21,10 @@ const ConfigInfo<int> GFX_ADAPTER{{System::GFX, "Hardware", "Adapter"}, 0};
 // Graphics.Settings
 
 const ConfigInfo<bool> GFX_WIDESCREEN_HACK{{System::GFX, "Settings", "wideScreenHack"}, false};
-const ConfigInfo<int> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"},
-                                       static_cast<int>(AspectMode::Auto)};
-const ConfigInfo<int> GFX_SUGGESTED_ASPECT_RATIO{{System::GFX, "Settings", "SuggestedAspectRatio"},
-                                                 static_cast<int>(AspectMode::Auto)};
+const ConfigInfo<AspectMode> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"},
+                                              AspectMode::Auto};
+const ConfigInfo<AspectMode> GFX_SUGGESTED_ASPECT_RATIO{
+    {System::GFX, "Settings", "SuggestedAspectRatio"}, AspectMode::Auto};
 const ConfigInfo<bool> GFX_CROP{{System::GFX, "Settings", "Crop"}, false};
 const ConfigInfo<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES{
     {System::GFX, "Settings", "SafeTextureCacheColorSamples"}, 128};
@@ -78,9 +78,8 @@ const ConfigInfo<int> GFX_COMMAND_BUFFER_EXECUTE_INTERVAL{
 const ConfigInfo<bool> GFX_SHADER_CACHE{{System::GFX, "Settings", "ShaderCache"}, true};
 const ConfigInfo<bool> GFX_WAIT_FOR_SHADERS_BEFORE_STARTING{
     {System::GFX, "Settings", "WaitForShadersBeforeStarting"}, false};
-const ConfigInfo<int> GFX_SHADER_COMPILATION_MODE{
-    {System::GFX, "Settings", "ShaderCompilationMode"},
-    static_cast<int>(ShaderCompilationMode::Synchronous)};
+const ConfigInfo<ShaderCompilationMode> GFX_SHADER_COMPILATION_MODE{
+    {System::GFX, "Settings", "ShaderCompilationMode"}, ShaderCompilationMode::Synchronous};
 const ConfigInfo<int> GFX_SHADER_COMPILER_THREADS{
     {System::GFX, "Settings", "ShaderCompilerThreads"}, 1};
 const ConfigInfo<int> GFX_SHADER_PRECOMPILER_THREADS{
@@ -111,7 +110,8 @@ const ConfigInfo<bool> GFX_ENHANCE_DISABLE_COPY_FILTER{
 
 // Graphics.Stereoscopy
 
-const ConfigInfo<int> GFX_STEREO_MODE{{System::GFX, "Stereoscopy", "StereoMode"}, 0};
+const ConfigInfo<StereoMode> GFX_STEREO_MODE{{System::GFX, "Stereoscopy", "StereoMode"},
+                                             StereoMode::Off};
 const ConfigInfo<int> GFX_STEREO_DEPTH{{System::GFX, "Stereoscopy", "StereoDepth"}, 20};
 const ConfigInfo<int> GFX_STEREO_CONVERGENCE_PERCENTAGE{
     {System::GFX, "Stereoscopy", "StereoConvergencePercentage"}, 100};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -8,6 +8,10 @@
 
 #include "Common/Config/Config.h"
 
+enum class AspectMode : int;
+enum class ShaderCompilationMode : int;
+enum class StereoMode : int;
+
 namespace Config
 {
 // Configuration Information
@@ -20,8 +24,8 @@ extern const ConfigInfo<int> GFX_ADAPTER;
 // Graphics.Settings
 
 extern const ConfigInfo<bool> GFX_WIDESCREEN_HACK;
-extern const ConfigInfo<int> GFX_ASPECT_RATIO;
-extern const ConfigInfo<int> GFX_SUGGESTED_ASPECT_RATIO;
+extern const ConfigInfo<AspectMode> GFX_ASPECT_RATIO;
+extern const ConfigInfo<AspectMode> GFX_SUGGESTED_ASPECT_RATIO;
 extern const ConfigInfo<bool> GFX_CROP;
 extern const ConfigInfo<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES;
 extern const ConfigInfo<bool> GFX_SHOW_FPS;
@@ -60,7 +64,7 @@ extern const ConfigInfo<bool> GFX_BACKEND_MULTITHREADING;
 extern const ConfigInfo<int> GFX_COMMAND_BUFFER_EXECUTE_INTERVAL;
 extern const ConfigInfo<bool> GFX_SHADER_CACHE;
 extern const ConfigInfo<bool> GFX_WAIT_FOR_SHADERS_BEFORE_STARTING;
-extern const ConfigInfo<int> GFX_SHADER_COMPILATION_MODE;
+extern const ConfigInfo<ShaderCompilationMode> GFX_SHADER_COMPILATION_MODE;
 extern const ConfigInfo<int> GFX_SHADER_COMPILER_THREADS;
 extern const ConfigInfo<int> GFX_SHADER_PRECOMPILER_THREADS;
 
@@ -84,7 +88,7 @@ extern const ConfigInfo<bool> GFX_ENHANCE_DISABLE_COPY_FILTER;
 
 // Graphics.Stereoscopy
 
-extern const ConfigInfo<int> GFX_STEREO_MODE;
+extern const ConfigInfo<StereoMode> GFX_STEREO_MODE;
 extern const ConfigInfo<int> GFX_STEREO_DEPTH;
 extern const ConfigInfo<int> GFX_STEREO_CONVERGENCE_PERCENTAGE;
 extern const ConfigInfo<bool> GFX_STEREO_SWAP_EYES;

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -29,7 +29,7 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
   config_layer->Set(Config::MAIN_FAST_DISC_SPEED, dtm->bFastDiscSpeed);
   config_layer->Set(Config::MAIN_CPU_CORE, static_cast<int>(dtm->CPUCore));
   config_layer->Set(Config::MAIN_SYNC_GPU, dtm->bSyncGPU);
-  config_layer->Set(Config::MAIN_GFX_BACKEND, std::string(dtm->videoBackend.data()));
+  config_layer->Set(Config::MAIN_GFX_BACKEND, dtm->videoBackend.data());
 
   config_layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, dtm->bProgressive);
   config_layer->Set(Config::SYSCONF_PAL60, dtm->bPAL60);

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsChoice.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsChoice.h
@@ -6,11 +6,7 @@
 
 #include <QComboBox>
 
-namespace Config
-{
-template <typename T>
-struct ConfigInfo;
-}
+#include "Common/Config/Config.h"
 
 class GraphicsChoice : public QComboBox
 {
@@ -20,5 +16,5 @@ public:
 private:
   void Update(int choice);
 
-  const Config::ConfigInfo<int>& m_setting;
+  Config::ConfigInfo<int> m_setting;
 };

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsRadio.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsRadio.h
@@ -6,11 +6,7 @@
 
 #include <QRadioButton>
 
-namespace Config
-{
-template <typename T>
-struct ConfigInfo;
-}
+#include "Common/Config/Config.h"
 
 class GraphicsRadioInt : public QRadioButton
 {
@@ -21,6 +17,6 @@ public:
 private:
   void Update();
 
-  const Config::ConfigInfo<int>& m_setting;
+  Config::ConfigInfo<int> m_setting;
   int m_value;
 };

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -348,7 +348,7 @@ void HotkeyScheduler::Run()
         {
           // Disable post-processing shader, as stereoscopy itself is currently a shader
           if (Config::Get(Config::GFX_ENHANCE_POST_SHADER) == DUBOIS_ALGORITHM_SHADER)
-            Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+            Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
 
           Config::SetCurrent(Config::GFX_STEREO_MODE, IsHotkey(HK_TOGGLE_STEREO_SBS) ?
                                                           static_cast<int>(StereoMode::SBS) :
@@ -365,12 +365,12 @@ void HotkeyScheduler::Run()
         if (Config::Get(Config::GFX_STEREO_MODE) != static_cast<int>(StereoMode::Anaglyph))
         {
           Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Anaglyph));
-          Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(DUBOIS_ALGORITHM_SHADER));
+          Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, DUBOIS_ALGORITHM_SHADER);
         }
         else
         {
           Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
-          Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+          Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
         }
       }
 
@@ -379,7 +379,7 @@ void HotkeyScheduler::Run()
         if (Config::Get(Config::GFX_STEREO_MODE) != static_cast<int>(StereoMode::Nvidia3DVision))
         {
           if (Config::Get(Config::GFX_ENHANCE_POST_SHADER) == DUBOIS_ALGORITHM_SHADER)
-            Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+            Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
 
           Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Nvidia3DVision));
         }

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -279,8 +279,8 @@ void HotkeyScheduler::Run()
       if (IsHotkey(HK_TOGGLE_AR))
       {
         show_msg(OSDMessage::ARToggled);
-        const auto aspect_ratio = (Config::Get(Config::GFX_ASPECT_RATIO) + 1) & 3;
-        Config::SetCurrent(Config::GFX_ASPECT_RATIO, aspect_ratio);
+        const int aspect_ratio = (static_cast<int>(Config::Get(Config::GFX_ASPECT_RATIO)) + 1) & 3;
+        Config::SetCurrent(Config::GFX_ASPECT_RATIO, static_cast<AspectMode>(aspect_ratio));
       }
       if (IsHotkey(HK_TOGGLE_EFBCOPIES))
       {
@@ -344,48 +344,47 @@ void HotkeyScheduler::Run()
       // Stereoscopy
       if (IsHotkey(HK_TOGGLE_STEREO_SBS) || IsHotkey(HK_TOGGLE_STEREO_TAB))
       {
-        if (Config::Get(Config::GFX_STEREO_MODE) != static_cast<int>(StereoMode::SBS))
+        if (Config::Get(Config::GFX_STEREO_MODE) != StereoMode::SBS)
         {
           // Disable post-processing shader, as stereoscopy itself is currently a shader
           if (Config::Get(Config::GFX_ENHANCE_POST_SHADER) == DUBOIS_ALGORITHM_SHADER)
             Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
 
-          Config::SetCurrent(Config::GFX_STEREO_MODE, IsHotkey(HK_TOGGLE_STEREO_SBS) ?
-                                                          static_cast<int>(StereoMode::SBS) :
-                                                          static_cast<int>(StereoMode::TAB));
+          Config::SetCurrent(Config::GFX_STEREO_MODE,
+                             IsHotkey(HK_TOGGLE_STEREO_SBS) ? StereoMode::SBS : StereoMode::TAB);
         }
         else
         {
-          Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
+          Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Off);
         }
       }
 
       if (IsHotkey(HK_TOGGLE_STEREO_ANAGLYPH))
       {
-        if (Config::Get(Config::GFX_STEREO_MODE) != static_cast<int>(StereoMode::Anaglyph))
+        if (Config::Get(Config::GFX_STEREO_MODE) != StereoMode::Anaglyph)
         {
-          Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Anaglyph));
+          Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Anaglyph);
           Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, DUBOIS_ALGORITHM_SHADER);
         }
         else
         {
-          Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
+          Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Off);
           Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
         }
       }
 
       if (IsHotkey(HK_TOGGLE_STEREO_3DVISION))
       {
-        if (Config::Get(Config::GFX_STEREO_MODE) != static_cast<int>(StereoMode::Nvidia3DVision))
+        if (Config::Get(Config::GFX_STEREO_MODE) != StereoMode::Nvidia3DVision)
         {
           if (Config::Get(Config::GFX_ENHANCE_POST_SHADER) == DUBOIS_ALGORITHM_SHADER)
             Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
 
-          Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Nvidia3DVision));
+          Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Nvidia3DVision);
         }
         else
         {
-          Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
+          Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Off);
         }
       }
     }

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1524,7 +1524,7 @@ void CFrame::ParseHotkeys()
       // turned off when selecting other stereoscopy modes.
       if (g_Config.sPostProcessingShader == "dubois")
       {
-        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
       }
       Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::SBS));
     }
@@ -1539,7 +1539,7 @@ void CFrame::ParseHotkeys()
     {
       if (g_Config.sPostProcessingShader == "dubois")
       {
-        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
       }
       Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::TAB));
     }
@@ -1555,12 +1555,12 @@ void CFrame::ParseHotkeys()
       // Setting the anaglyph mode also requires a specific
       // post-processing shader to be activated.
       Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Anaglyph));
-      Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string("dubois"));
+      Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "dubois");
     }
     else
     {
       Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
-      Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+      Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_3DVISION))
@@ -1569,7 +1569,7 @@ void CFrame::ParseHotkeys()
     {
       if (g_Config.sPostProcessingShader == "dubois")
       {
-        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+        Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
       }
       Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Nvidia3DVision));
     }

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1441,9 +1441,9 @@ void CFrame::ParseHotkeys()
   {
     show_msg(OSDMessage::ARToggled);
     // Toggle aspect ratio
-    int aspect_ratio = Config::Get(Config::GFX_ASPECT_RATIO);
+    int aspect_ratio = static_cast<int>(Config::Get(Config::GFX_ASPECT_RATIO));
     aspect_ratio = (aspect_ratio + 1) & 3;
-    Config::SetCurrent(Config::GFX_ASPECT_RATIO, aspect_ratio);
+    Config::SetCurrent(Config::GFX_ASPECT_RATIO, static_cast<AspectMode>(aspect_ratio));
   }
   if (IsHotkey(HK_TOGGLE_EFBCOPIES))
   {
@@ -1526,11 +1526,11 @@ void CFrame::ParseHotkeys()
       {
         Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
       }
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::SBS));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::SBS);
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Off);
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_TAB))
@@ -1541,11 +1541,11 @@ void CFrame::ParseHotkeys()
       {
         Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
       }
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::TAB));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::TAB);
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Off);
     }
   }
   if (IsHotkey(HK_TOGGLE_STEREO_ANAGLYPH))
@@ -1554,12 +1554,12 @@ void CFrame::ParseHotkeys()
     {
       // Setting the anaglyph mode also requires a specific
       // post-processing shader to be activated.
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Anaglyph));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Anaglyph);
       Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "dubois");
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Off);
       Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
     }
   }
@@ -1571,11 +1571,11 @@ void CFrame::ParseHotkeys()
       {
         Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
       }
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Nvidia3DVision));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Nvidia3DVision);
     }
     else
     {
-      Config::SetCurrent(Config::GFX_STEREO_MODE, static_cast<int>(StereoMode::Off));
+      Config::SetCurrent(Config::GFX_STEREO_MODE, StereoMode::Off);
     }
   }
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -465,7 +465,8 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
         {
           szr_shader_compilation->Add(
               CreateRadioButton(page_general, modes[i].first, modes[i].second,
-                                Config::GFX_SHADER_COMPILATION_MODE, static_cast<int>(i)),
+                                Config::GFX_SHADER_COMPILATION_MODE,
+                                static_cast<ShaderCompilationMode>(i)),
               wxGBPosition(static_cast<int>(i / 2), static_cast<int>(i % 2)), wxDefaultSpan,
               wxALIGN_CENTER_VERTICAL);
         }

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -1233,11 +1233,11 @@ void VideoConfigDiag::PopulatePostProcessingShaders()
 
     if (vconfig.stereo_mode == StereoMode::Anaglyph)
     {
-      Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string("dubois"));
+      Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, "dubois");
       choice_ppshader->SetStringSelection(StrToWxStr(vconfig.sPostProcessingShader));
     }
     else
-      Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+      Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
   }
 
   // Should the configuration button be loaded by default?

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -141,7 +141,7 @@ void OpenGLPostProcessing::ApplyShader()
   if (!ProgramShaderCache::CompileShader(m_shader, s_vertex_shader, code))
   {
     ERROR_LOG(VIDEO, "Failed to compile post-processing shader %s", m_config.GetShader().c_str());
-    Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, std::string(""));
+    Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
     code = m_config.LoadShader();
     ProgramShaderCache::CompileShader(m_shader, s_vertex_shader, code);
   }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -60,9 +60,9 @@ void VideoConfig::Refresh()
   iAdapter = Config::Get(Config::GFX_ADAPTER);
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
-  const auto config_aspect_mode = static_cast<AspectMode>(Config::Get(Config::GFX_ASPECT_RATIO));
+  const AspectMode config_aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
   if (config_aspect_mode == AspectMode::Auto)
-    aspect_mode = static_cast<AspectMode>(Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO));
+    aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
   else
     aspect_mode = config_aspect_mode;
   bCrop = Config::Get(Config::GFX_CROP);
@@ -103,8 +103,7 @@ void VideoConfig::Refresh()
   iCommandBufferExecuteInterval = Config::Get(Config::GFX_COMMAND_BUFFER_EXECUTE_INTERVAL);
   bShaderCache = Config::Get(Config::GFX_SHADER_CACHE);
   bWaitForShadersBeforeStarting = Config::Get(Config::GFX_WAIT_FOR_SHADERS_BEFORE_STARTING);
-  iShaderCompilationMode =
-      static_cast<ShaderCompilationMode>(Config::Get(Config::GFX_SHADER_COMPILATION_MODE));
+  iShaderCompilationMode = Config::Get(Config::GFX_SHADER_COMPILATION_MODE);
   iShaderCompilerThreads = Config::Get(Config::GFX_SHADER_COMPILER_THREADS);
   iShaderPrecompilerThreads = Config::Get(Config::GFX_SHADER_PRECOMPILER_THREADS);
 
@@ -122,7 +121,7 @@ void VideoConfig::Refresh()
   bForceTrueColor = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
   bDisableCopyFilter = Config::Get(Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
 
-  stereo_mode = static_cast<StereoMode>(Config::Get(Config::GFX_STEREO_MODE));
+  stereo_mode = Config::Get(Config::GFX_STEREO_MODE);
   iStereoDepth = Config::Get(Config::GFX_STEREO_DEPTH);
   iStereoConvergencePercentage = Config::Get(Config::GFX_STEREO_CONVERGENCE_PERCENTAGE);
   bStereoSwapEyes = Config::Get(Config::GFX_STEREO_SWAP_EYES);


### PR DESCRIPTION
Fix the Config code to make it possible to use enums and std::strings without manual, explicit casts.

The first commit excludes the second argument from template deduction. Otherwise, it is required to manually cast the second argument to the ConfigInfo type (because implicit conversions won't work).
e.g. to set the value for a `ConfigInfo<std::string>` from a string literal, you'd need a ugly `std::string("yourstring")`.

The second commit adds support for enum types by using the underlying type when loading/saving settings.

A copy constructor is also provided for conversions from `ConfigInfo<Enum>` to `ConfigInfo<underlying_type<Enum>>` so that enum settings can still easily work with code that doesn't care about the actual enum values (like Graphics{Choice,Radio} in DolphinQt2 which only treat the setting as an integer).

With both changes, default values are now clearer and in most cases there's no need for casts when calling Config::Get/Set anymore.