### PR TITLE
Jit64: Invalidate cached constant values w/o host register on flush

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -101,6 +101,13 @@ void RegCache::Flush(FlushMode mode, BitSet32 regsToFlush)
         ASSERT_MSG(DYNA_REC, 0, "Jit64 - Flush unhandled case, reg %u PC: %08x", i, PC);
       }
     }
+    else if (m_regs[i].location.IsImm())
+    {
+      // We can have a cached value without a host register through speculative constants.
+      // It must be cleared when flushing, otherwise it may be out of sync with PPCSTATE,
+      // if PPCSTATE is modified externally (e.g. fallback to interpreter).
+      m_regs[i].location = GetDefaultLocation(i);
+    }
   }
 }
 


### PR DESCRIPTION
If we don't flush the values, they persist in the register cache, potentially resulting in the values being out of sync with PPCSTATE.

This was causing random crashes in games, mainly booting, when certain JIT instructions were disabled, or forced to fall back to interpreter.

I haven't tested with the game listed in https://bugs.dolphin-emu.org/issues/10455, but this may fix it as well, as well as who knows how many other minor cases where a fallback in the middle of a block caused breakage..