### PR TITLE
DolphinQt2/NewPatchDialog: Remove unused <iostream> include

### DIFF
--- a/Source/Core/DolphinQt2/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/NewPatchDialog.cpp
@@ -15,8 +15,6 @@
 #include <QScrollArea>
 #include <QVBoxLayout>
 
-#include <iostream>
-
 NewPatchDialog::NewPatchDialog(QWidget* parent, PatchEngine::Patch& patch)
     : QDialog(parent), m_patch(patch)
 {


### PR DESCRIPTION
Including `<iostream>` causes a static constructor to be injected into the translation unit, even if the everything from the header itself is unused.