### PR TITLE
WiiSave: Reuse IOS services where possible

### DIFF
--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -14,7 +14,6 @@
 #include <cstdio>
 #include <cstring>
 #include <mbedtls/md5.h>
-#include <mbedtls/sha1.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -28,6 +27,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
+#include "Core/CommonTitles.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
@@ -461,46 +461,6 @@ void WiiSave::do_sig()
 {
   if (!m_valid)
     return;
-  u8 sig[0x40];
-  u8 ng_cert[0x180];
-  u8 ap_cert[0x180];
-  u8 hash[0x14];
-  u8 ap_priv[30];
-  u8 ap_sig[60];
-  char signer[64];
-  char name[64];
-  u32 data_size;
-
-  const u32 ng_key_id = 0x6AAB8C59;
-
-  const u8 ng_priv[30] = {0,    0xAB, 0xEE, 0xC1, 0xDD, 0xB4, 0xA6, 0x16, 0x6B, 0x70,
-                          0xFD, 0x7E, 0x56, 0x67, 0x70, 0x57, 0x55, 0x27, 0x38, 0xA3,
-                          0x26, 0xC5, 0x46, 0x16, 0xF7, 0x62, 0xC9, 0xED, 0x73, 0xF2};
-
-  const u8 ng_sig[0x3C] = {0,    0xD8, 0x81, 0x63, 0xB2, 0x00, 0x6B, 0x0B, 0x54, 0x82, 0x88, 0x63,
-                           0x81, 0x1C, 0x00, 0x71, 0x12, 0xED, 0xB7, 0xFD, 0x21, 0xAB, 0x0E, 0x50,
-                           0x0E, 0x1F, 0xBF, 0x78, 0xAD, 0x37, 0x00, 0x71, 0x8D, 0x82, 0x41, 0xEE,
-                           0x45, 0x11, 0xC7, 0x3B, 0xAC, 0x08, 0xB6, 0x83, 0xDC, 0x05, 0xB8, 0xA8,
-                           0x90, 0x1F, 0xA8, 0x2A, 0x0E, 0x4E, 0x76, 0xEF, 0x44, 0x72, 0x99, 0xF8};
-
-  sprintf(signer, "Root-CA00000001-MS00000002");
-  sprintf(name, "NG%08x", s_ng_id);
-  make_ec_cert(ng_cert, ng_sig, signer, name, ng_priv, ng_key_id);
-
-  memset(ap_priv, 0, sizeof ap_priv);
-  ap_priv[10] = 1;
-
-  memset(ap_sig, 81, sizeof ap_sig);  // temp
-
-  sprintf(signer, "Root-CA00000001-MS00000002-NG%08x", s_ng_id);
-  sprintf(name, "AP%08x%08x", 1, 2);
-  make_ec_cert(ap_cert, ap_sig, signer, name, ap_priv, 0);
-
-  mbedtls_sha1(ap_cert + 0x80, 0x100, hash);
-  generate_ecdsa(ap_sig, ap_sig + 30, ng_priv, hash);
-  make_ec_cert(ap_cert, ap_sig, signer, name, ap_priv, 0);
-
-  data_size = m_bk_hdr.size_of_files + 0x80;
 
   File::IOFile data_file(m_encrypted_save_path, "rb");
   if (!data_file)
@@ -508,8 +468,10 @@ void WiiSave::do_sig()
     m_valid = false;
     return;
   }
-  auto data = std::make_unique<u8[]>(data_size);
 
+  // Read data to sign.
+  const u32 data_size = m_bk_hdr.size_of_files + 0x80;
+  auto data = std::make_unique<u8[]>(data_size);
   data_file.Seek(0xf0c0, SEEK_SET);
   if (!data_file.ReadBytes(data.get(), data_size))
   {
@@ -517,37 +479,27 @@ void WiiSave::do_sig()
     return;
   }
 
-  mbedtls_sha1(data.get(), data_size, hash);
-  mbedtls_sha1(hash, 20, hash);
+  // Sign the data.
+  IOS::Certificate ap_cert;
+  IOS::ECCSignature ap_sig;
+  m_ios.GetIOSC().Sign(ap_sig.data(), ap_cert.data(), Titles::SYSTEM_MENU, data.get(), data_size);
 
+  // Write signatures.
   data_file.Open(m_encrypted_save_path, "ab");
   if (!data_file)
   {
     m_valid = false;
     return;
   }
-  generate_ecdsa(sig, sig + 30, ap_priv, hash);
-  *(u32*)(sig + 60) = Common::swap32(0x2f536969);
 
-  data_file.WriteArray(sig, sizeof(sig));
-  data_file.WriteArray(ng_cert, sizeof(ng_cert));
-  data_file.WriteArray(ap_cert, sizeof(ap_cert));
+  data_file.WriteArray(ap_sig.data(), ap_sig.size());
+  const u32 SIGNATURE_END_MAGIC = Common::swap32(0x2f536969);
+  data_file.WriteArray(&SIGNATURE_END_MAGIC, sizeof(SIGNATURE_END_MAGIC));
+  const IOS::Certificate device_certificate = m_ios.GetIOSC().GetDeviceCertificate();
+  data_file.WriteArray(device_certificate.data(), device_certificate.size());
+  data_file.WriteArray(ap_cert.data(), ap_cert.size());
 
   m_valid = data_file.IsGood();
-}
-
-void WiiSave::make_ec_cert(u8* cert, const u8* sig, const char* signer, const char* name,
-                           const u8* priv, const u32 key_id)
-{
-  memset(cert, 0, 0x180);
-  *(u32*)cert = Common::swap32(0x10002);
-
-  memcpy(cert + 4, sig, 60);
-  strcpy((char*)cert + 0x80, signer);
-  *(u32*)(cert + 0xc0) = Common::swap32(2);
-  strcpy((char*)cert + 0xc4, name);
-  *(u32*)(cert + 0x104) = Common::swap32(key_id);
-  ec_priv_to_pub(priv, cert + 0x108);
 }
 
 bool WiiSave::getPaths(bool for_export)

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -28,6 +28,7 @@
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Core/CommonTitles.h"
+#include "Core/IOS/ES/ES.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
@@ -57,35 +58,8 @@ bool WiiSave::Export(u64 title_id, std::string export_path)
 size_t WiiSave::ExportAll(std::string export_path)
 {
   IOS::HLE::Kernel ios;
-
-  std::string title_folder = File::GetUserPath(D_WIIROOT_IDX) + "/title";
-  std::vector<u64> titles;
-  const u32 path_mask = 0x00010000;
-  for (int i = 0; i < 8; ++i)
-  {
-    std::string folder = StringFromFormat("%s/%08x/", title_folder.c_str(), path_mask | i);
-    File::FSTEntry fst_tmp = File::ScanDirectoryTree(folder, false);
-
-    for (const File::FSTEntry& entry : fst_tmp.children)
-    {
-      if (entry.isDirectory)
-      {
-        u32 game_id;
-        if (AsciiToHex(entry.virtualName, game_id))
-        {
-          std::string banner_path =
-              StringFromFormat("%s%08x/data/banner.bin", folder.c_str(), game_id);
-          if (File::Exists(banner_path))
-          {
-            u64 title_id = (((u64)path_mask | i) << 32) | game_id;
-            titles.push_back(title_id);
-          }
-        }
-      }
-    }
-  }
   size_t exported_save_count = 0;
-  for (const u64& title : titles)
+  for (const u64 title : ios.GetES()->GetInstalledTitles())
   {
     WiiSave export_save{ios, title, export_path};
     if (export_save.Export())

--- a/Source/Core/Core/HW/WiiSave.h
+++ b/Source/Core/Core/HW/WiiSave.h
@@ -5,13 +5,20 @@
 #pragma once
 
 #include <array>
-#include <mbedtls/aes.h>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/Swap.h"
+
+namespace IOS
+{
+namespace HLE
+{
+class Kernel;
+}
+}  // namespace IOS::HLE
 
 class WiiSave
 {
@@ -24,8 +31,8 @@ public:
   static size_t ExportAll(std::string export_path);
 
 private:
-  explicit WiiSave(std::string filename);
-  explicit WiiSave(u64 title_id, std::string export_path);
+  WiiSave(IOS::HLE::Kernel& ios, std::string filename);
+  WiiSave(IOS::HLE::Kernel& ios, u64 title_id, std::string export_path);
   ~WiiSave();
 
   bool Import();
@@ -44,7 +51,8 @@ private:
   void ScanForFiles(const std::string& save_directory, std::vector<std::string>& file_list,
                     u32* num_files, u32* size_files);
 
-  mbedtls_aes_context m_aes_ctx;
+  IOS::HLE::Kernel& m_ios;
+
   std::array<u8, 0x10> m_sd_iv;
   std::vector<std::string> m_files_list;
 

--- a/Source/Core/Core/HW/WiiSave.h
+++ b/Source/Core/Core/HW/WiiSave.h
@@ -45,8 +45,6 @@ private:
   void ImportWiiSaveFiles();
   void ExportWiiSaveFiles();
   void do_sig();
-  void make_ec_cert(u8* cert, const u8* sig, const char* signer, const char* name, const u8* priv,
-                    const u32 key_id);
   bool getPaths(bool for_export = false);
   void ScanForFiles(const std::string& save_directory, std::vector<std::string>& file_list,
                     u32* num_files, u32* size_files);


### PR DESCRIPTION
Crypto stuff and title listing functions are provided by IOS. Let's use them and deduplicate some code.

(This also makes the WiiSave class more similar to the save code in the System Menu, which also just uses ES and crypto services.)