### PR TITLE
NewPatchDialog/PatchesWidget: Use forward declarations where applicable

### DIFF
--- a/Source/Core/DolphinQt2/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/NewPatchDialog.cpp
@@ -15,6 +15,8 @@
 #include <QScrollArea>
 #include <QVBoxLayout>
 
+#include "Core/PatchEngine.h"
+
 NewPatchDialog::NewPatchDialog(QWidget* parent, PatchEngine::Patch& patch)
     : QDialog(parent), m_patch(patch)
 {

--- a/Source/Core/DolphinQt2/Config/NewPatchDialog.h
+++ b/Source/Core/DolphinQt2/Config/NewPatchDialog.h
@@ -9,7 +9,10 @@
 #include <QDialog>
 #include <QWidget>
 
-#include "Core/PatchEngine.h"
+namespace PatchEngine
+{
+struct Patch;
+}
 
 class QDialogButtonBox;
 class QGroupBox;

--- a/Source/Core/DolphinQt2/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/PatchesWidget.cpp
@@ -11,8 +11,13 @@
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
+
 #include "Core/ConfigManager.h"
+#include "Core/PatchEngine.h"
+
 #include "DolphinQt2/Config/NewPatchDialog.h"
+
+#include "UICommon/GameFile.h"
 
 PatchesWidget::PatchesWidget(const UICommon::GameFile& game)
     : m_game(game), m_game_id(game.GetGameID()), m_game_revision(game.GetRevision())

--- a/Source/Core/DolphinQt2/Config/PatchesWidget.h
+++ b/Source/Core/DolphinQt2/Config/PatchesWidget.h
@@ -9,12 +9,21 @@
 
 #include <QWidget>
 
-#include "Core/PatchEngine.h"
-#include "UICommon/GameFile.h"
+#include "Common/CommonTypes.h"
+
+namespace PatchEngine
+{
+struct Patch;
+}
 
 class QListWidget;
 class QListWidgetItem;
 class QPushButton;
+
+namespace UICommon
+{
+class GameFile;
+}
 
 class PatchesWidget : public QWidget
 {


### PR DESCRIPTION
Avoids propagation of includes through UI headers. This also corrects an indirect inclusion of `CommonTypes.h` within `PatchesWidget.h`