### PR TITLE
Qt: Use native dir separators

### DIFF
--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -4,6 +4,7 @@
 
 #include <QComboBox>
 #include <QCryptographicHash>
+#include <QDir>
 #include <QFileDialog>
 #include <QFormLayout>
 #include <QGroupBox>
@@ -36,7 +37,7 @@ QGroupBox* InfoWidget::CreateISODetails()
 
   QLineEdit* file_path = CreateValueDisplay(
       QStringLiteral("%1 (%2)")
-          .arg(QString::fromStdString(m_game.GetFilePath()))
+          .arg(QDir::toNativeSeparators(QString::fromStdString(m_game.GetFilePath())))
           .arg(QString::fromStdString(UICommon::FormatSize(m_game.GetFileSize()))));
   QLineEdit* internal_name =
       CreateValueDisplay(tr("%1 (Disc %2, Revision %3)")

--- a/Source/Core/DolphinQt2/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt2/GCMemcardManager.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 
 #include <QDialogButtonBox>
+#include <QDir>
 #include <QFileDialog>
 #include <QGridLayout>
 #include <QGroupBox>
@@ -248,11 +249,11 @@ void GCMemcardManager::SetSlotFile(int slot, QString path)
 
 void GCMemcardManager::SetSlotFileInteractive(int slot)
 {
-  QString path = QFileDialog::getOpenFileName(
+  QString path = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
       this,
       slot == 0 ? tr("Set memory card file for Slot A") : tr("Set memory card file for Slot B"),
       QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
-      tr("GameCube Memory Cards (*.raw *.gcp)"));
+      tr("GameCube Memory Cards (*.raw *.gcp)")));
   if (!path.isEmpty())
     m_slot_file_edit[slot]->setText(path);
 }

--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <QCheckBox>
+#include <QDir>
 #include <QFileDialog>
 #include <QGroupBox>
 #include <QLabel>
@@ -30,8 +31,8 @@ PathPane::PathPane(QWidget* parent) : QWidget(parent)
 
 void PathPane::Browse()
 {
-  QString dir =
-      QFileDialog::getExistingDirectory(this, tr("Select a Directory"), QDir::currentPath());
+  QString dir = QDir::toNativeSeparators(
+      QFileDialog::getExistingDirectory(this, tr("Select a Directory"), QDir::currentPath()));
   if (!dir.isEmpty())
     Settings::Instance().AddPath(dir);
 }
@@ -40,10 +41,10 @@ void PathPane::BrowseDefaultGame()
 {
   auto& default_iso = SConfig::GetInstance().m_strDefaultISO;
 
-  QString file = QFileDialog::getOpenFileName(
+  QString file = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
       this, tr("Select a Game"), QString::fromStdString(default_iso),
       tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs *.ciso *.gcz *.wad);;"
-         "All Files (*)"));
+         "All Files (*)")));
   if (!file.isEmpty())
   {
     m_game_edit->setText(file);
@@ -53,8 +54,8 @@ void PathPane::BrowseDefaultGame()
 
 void PathPane::BrowseWiiNAND()
 {
-  QString dir = QFileDialog::getExistingDirectory(
-      this, tr("Select Wii NAND Root"), QString::fromStdString(SConfig::GetInstance().m_NANDPath));
+  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+      this, tr("Select Wii NAND Root"), QString::fromStdString(SConfig::GetInstance().m_NANDPath)));
   if (!dir.isEmpty())
   {
     m_nand_edit->setText(dir);
@@ -65,8 +66,8 @@ void PathPane::BrowseWiiNAND()
 void PathPane::BrowseDump()
 {
   auto& dump_path = SConfig::GetInstance().m_DumpPath;
-  QString dir = QFileDialog::getExistingDirectory(this, tr("Select Dump Path"),
-                                                  QString::fromStdString(dump_path));
+  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+      this, tr("Select Dump Path"), QString::fromStdString(dump_path)));
   if (!dir.isEmpty())
   {
     m_dump_edit->setText(dir);
@@ -76,11 +77,11 @@ void PathPane::BrowseDump()
 
 void PathPane::BrowseSDCard()
 {
-  QString file = QFileDialog::getOpenFileName(
+  QString file = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
       this, tr("Select a SD Card Image"),
       QString::fromStdString(SConfig::GetInstance().m_strWiiSDCardPath),
       tr("SD Card Image (*.raw);;"
-         "All Files (*)"));
+         "All Files (*)")));
   if (!file.isEmpty())
   {
     m_sdcard_edit->setText(file);


### PR DESCRIPTION
Qt uses normal slashes internally which is fine except when we are displaying paths to the user.