### PR TITLE
FilesystemWidget: Replace DiscIO includes with forward declarations

### DIFF
--- a/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
@@ -19,8 +19,9 @@
 #include <future>
 
 #include "DiscIO/DiscExtractor.h"
-#include "DiscIO/Enums.h"
 #include "DiscIO/Filesystem.h"
+#include "DiscIO/Volume.h"
+
 #include "DolphinQt2/QtUtils/ActionHelper.h"
 #include "DolphinQt2/Resources.h"
 
@@ -44,6 +45,8 @@ FilesystemWidget::FilesystemWidget(const UICommon::GameFile& game)
   ConnectWidgets();
   PopulateView();
 }
+
+FilesystemWidget::~FilesystemWidget() = default;
 
 void FilesystemWidget::CreateWidgets()
 {

--- a/Source/Core/DolphinQt2/Config/FilesystemWidget.h
+++ b/Source/Core/DolphinQt2/Config/FilesystemWidget.h
@@ -7,12 +7,6 @@
 #include <QDialog>
 #include <memory>
 
-// Qt versions prior to 5.9 don't support C++17 nested namespaces in moc so we have to if-guard
-// this header
-#ifndef Q_MOC_RUN
-#include "DiscIO/Volume.h"
-#endif
-
 #include "UICommon/GameFile.h"
 
 class QStandardItem;
@@ -22,14 +16,17 @@ class QTreeView;
 namespace DiscIO
 {
 class FileInfo;
+class Volume;
+
 struct Partition;
-};  // namespace DiscIO
+}  // namespace DiscIO
 
 class FilesystemWidget final : public QWidget
 {
   Q_OBJECT
 public:
   explicit FilesystemWidget(const UICommon::GameFile& game);
+  ~FilesystemWidget() override;
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt2/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/PropertiesDialog.cpp
@@ -7,6 +7,8 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 
+#include "DiscIO/Enums.h"
+
 #include "DolphinQt2/Config/ARCodeWidget.h"
 #include "DolphinQt2/Config/FilesystemWidget.h"
 #include "DolphinQt2/Config/GameConfigWidget.h"


### PR DESCRIPTION
Avoids the need to use an ugly ifdef around a header, and also resolves an indirect inclusion in PropertiesDialog.