### PR TITLE
DolphinQt2: Add missing header guards for CheatCodeEditor and MappingIndicator

### DIFF
--- a/Source/Core/DolphinQt2/Config/CheatCodeEditor.h
+++ b/Source/Core/DolphinQt2/Config/CheatCodeEditor.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <QDialog>
 
 class QDialogButtonBox;

--- a/Source/Core/DolphinQt2/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingIndicator.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <QWidget>
 
 namespace ControllerEmu


### PR DESCRIPTION
Prevents potential double inclusion issues from ever happening.