### PR TITLE
Qt debugger hotkey fixes

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingWindow.cpp
@@ -289,7 +289,18 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     widget = new HotkeyGeneral(this);
     AddWidget(tr("General"), widget);
     AddWidget(tr("TAS Tools"), new HotkeyTAS(this));
-    AddWidget(tr("Debugging"), new HotkeyDebugging(this));
+
+    HotkeyDebugging* debugging_widget = new HotkeyDebugging(this);
+    QWidget* debugging_widget_wrapper = GetWrappedWidget(debugging_widget, this, 150, 150);
+    connect(&Settings::Instance(), &Settings::DebugModeToggled, this, [=](bool enabled) {
+      if (enabled)
+        m_tab_widget->insertTab(2, debugging_widget_wrapper, tr("Debugging"));
+      else
+        m_tab_widget->removeTab(2);
+    });
+    if (Settings::Instance().IsDebugModeEnabled())
+      AddWidget(tr("Debugging"), debugging_widget);
+
     AddWidget(tr("Wii and Wii Remote"), new HotkeyWii(this));
     AddWidget(tr("Graphics"), new HotkeyGraphics(this));
     AddWidget(tr("3D"), new Hotkey3D(this));

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -215,29 +215,7 @@ void HotkeyScheduler::Run()
 
       if (SConfig::GetInstance().bEnableDebugging)
       {
-        if (IsHotkey(HK_STEP))
-          emit Step();
-
-        if (IsHotkey(HK_STEP_OVER))
-          emit StepOver();
-
-        if (IsHotkey(HK_STEP_OUT))
-          emit StepOut();
-
-        if (IsHotkey(HK_SKIP))
-          emit Skip();
-
-        if (IsHotkey(HK_SHOW_PC))
-          emit ShowPC();
-
-        if (IsHotkey(HK_SET_PC))
-          emit Skip();
-
-        if (IsHotkey(HK_BP_TOGGLE))
-          emit ToggleBreakpoint();
-
-        if (IsHotkey(HK_BP_ADD))
-          emit AddBreakpoint();
+        CheckDebuggingHotkeys();
       }
 
       // TODO: HK_MBP_ADD
@@ -470,4 +448,31 @@ void HotkeyScheduler::Run()
     if (IsHotkey(HK_UNDO_SAVE_STATE))
       State::UndoSaveState();
   }
+}
+
+void HotkeyScheduler::CheckDebuggingHotkeys()
+{
+  if (IsHotkey(HK_STEP))
+    emit Step();
+
+  if (IsHotkey(HK_STEP_OVER))
+    emit StepOver();
+
+  if (IsHotkey(HK_STEP_OUT))
+    emit StepOut();
+
+  if (IsHotkey(HK_SKIP))
+    emit Skip();
+
+  if (IsHotkey(HK_SHOW_PC))
+    emit ShowPC();
+
+  if (IsHotkey(HK_SET_PC))
+    emit Skip();
+
+  if (IsHotkey(HK_BP_TOGGLE))
+    emit ToggleBreakpoint();
+
+  if (IsHotkey(HK_BP_ADD))
+    emit AddBreakpoint();
 }

--- a/Source/Core/DolphinQt2/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.cpp
@@ -213,29 +213,32 @@ void HotkeyScheduler::Run()
               IsHotkey(HK_TRIGGER_SYNC_BUTTON, true));
       }
 
-      if (IsHotkey(HK_STEP))
-        emit Step();
+      if (SConfig::GetInstance().bEnableDebugging)
+      {
+        if (IsHotkey(HK_STEP))
+          emit Step();
 
-      if (IsHotkey(HK_STEP_OVER))
-        emit StepOver();
+        if (IsHotkey(HK_STEP_OVER))
+          emit StepOver();
 
-      if (IsHotkey(HK_STEP_OUT))
-        emit StepOut();
+        if (IsHotkey(HK_STEP_OUT))
+          emit StepOut();
 
-      if (IsHotkey(HK_SKIP))
-        emit Skip();
+        if (IsHotkey(HK_SKIP))
+          emit Skip();
 
-      if (IsHotkey(HK_SHOW_PC))
-        emit ShowPC();
+        if (IsHotkey(HK_SHOW_PC))
+          emit ShowPC();
 
-      if (IsHotkey(HK_SET_PC))
-        emit Skip();
+        if (IsHotkey(HK_SET_PC))
+          emit Skip();
 
-      if (IsHotkey(HK_BP_TOGGLE))
-        emit ToggleBreakpoint();
+        if (IsHotkey(HK_BP_TOGGLE))
+          emit ToggleBreakpoint();
 
-      if (IsHotkey(HK_BP_ADD))
-        emit AddBreakpoint();
+        if (IsHotkey(HK_BP_ADD))
+          emit AddBreakpoint();
+      }
 
       // TODO: HK_MBP_ADD
 

--- a/Source/Core/DolphinQt2/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt2/HotkeyScheduler.h
@@ -51,6 +51,7 @@ signals:
 
 private:
   void Run();
+  void CheckDebuggingHotkeys();
 
   Common::Flag m_stop_requested;
   std::thread m_thread;


### PR DESCRIPTION
This is a set of 2 bugfixes for the debugger hotkeys:

1. Do not have the hotkeys activate when the debugger is disabled.
2. Do not show the debugging hotkey tab if the debugger is disabled.