### PR TITLE
Qt: allow to resize the render widget however wanted on render to main

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -761,6 +761,7 @@ void MainWindow::ShowRenderWidget()
 
     m_stack->setCurrentIndex(m_stack->addWidget(m_render_widget));
     connect(Host::GetInstance(), &Host::RequestTitle, this, &MainWindow::setWindowTitle);
+    m_stack->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
     m_stack->repaint();
 
     Host::GetInstance()->SetRenderFocus(isActiveWindow());
@@ -786,6 +787,7 @@ void MainWindow::HideRenderWidget(bool reinit)
     m_stack->removeWidget(m_render_widget);
     m_render_widget->setParent(nullptr);
     m_rendering_to_main = false;
+    m_stack->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     disconnect(Host::GetInstance(), &Host::RequestTitle, this, &MainWindow::setWindowTitle);
     setWindowTitle(QString::fromStdString(Common::scm_rev_str));
   }


### PR DESCRIPTION
This makes it so that if the debugger stuff is present, it's possible to resize the render widget to be however small the user wants.  On master, it gets blocked by a certain point which seems to be caused by the game list.

One note though @spycrab there's an issue in this pr where after you stop and you attempt to resize the game list panel horizontally.....it shakes for some reasons.  Maybe you are more familair with Qt sizing mechanics because they were kinda confusing to me...