### PR TITLE
PowerPC: Factor common part of function hooking code out of the interpreter and JITs

### DIFF
--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -42,4 +42,33 @@ HookType GetFunctionTypeByIndex(u32 index);
 HookFlag GetFunctionFlagsByIndex(u32 index);
 
 bool IsEnabled(HookFlag flag);
+
+// Performs the backend-independent preliminary checking before calling a
+// FunctionObject to do the actual replacing. Typically, this callback will
+// be in the backend itself, containing the backend-specific portions
+// required in replacing a function.
+//
+// fn may be any object that satisfies the FunctionObject concept in the C++
+// standard library. That is, any lambda, object with an overloaded function
+// call operator, or regular function pointer.
+//
+// fn must return a bool indicating whether or not function replacing occurred.
+// fn must also accept a parameter list of the form: fn(u32 function, HLE::HookType type).
+template <typename FunctionObject>
+bool ReplaceFunctionIfPossible(u32 address, FunctionObject fn)
+{
+  const u32 function = GetFirstFunctionIndex(address);
+  if (function == 0)
+    return false;
+
+  const HookType type = GetFunctionTypeByIndex(function);
+  if (type != HookType::Start && type != HookType::Replace)
+    return false;
+
+  const HookFlag flags = GetFunctionFlagsByIndex(function);
+  if (!IsEnabled(flags))
+    return false;
+
+  return fn(function, type);
 }
+}  // namespace HLE

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
@@ -38,6 +38,8 @@ private:
   const u8* GetCodePtr() const;
   void ExecuteOneBlock();
 
+  bool HandleFunctionHooking(u32 address);
+
   BlockCache m_block_cache{*this};
   std::vector<Instruction> m_code;
   PPCAnalyst::CodeBuffer code_buffer;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -284,6 +284,8 @@ public:
 private:
   static void InitializeInstructionTables();
 
+  static bool HandleFunctionHooking(u32 address);
+
   // flag helper
   static void Helper_UpdateCR0(u32 value);
   static void Helper_UpdateCR1();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -234,6 +234,8 @@ private:
   static void InitializeInstructionTables();
   void CompileInstruction(PPCAnalyst::CodeOp& op);
 
+  bool HandleFunctionHooking(u32 address);
+
   void AllocStack();
   void FreeStack();
 


### PR DESCRIPTION
Extracts the self-contained code into its own function to clean up the flow of Jit() a little more.