### PR TITLE
DolphinQt2: Resolve unused lambda capture warnings

### DIFF
--- a/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
@@ -189,7 +189,7 @@ void FilesystemWidget::ShowContextMenu(const QPoint&)
   switch (type)
   {
   case EntryType::Disc:
-    AddAction(menu, tr("Extract Entire Disc..."), this, [this, partition, path] {
+    AddAction(menu, tr("Extract Entire Disc..."), this, [this, path] {
       auto folder = SelectFolder();
 
       if (folder.isEmpty())

--- a/Source/Core/DolphinQt2/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/BreakpointWidget.cpp
@@ -143,7 +143,7 @@ void BreakpointWidget::Update()
   int i = 0;
   m_table->setRowCount(i);
 
-  auto create_item = [this](const QString string = QStringLiteral("")) {
+  auto create_item = [](const QString string = QStringLiteral("")) {
     QTableWidgetItem* item = new QTableWidgetItem(string);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     return item;

--- a/Source/Core/DolphinQt2/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt2/GCMemcardManager.cpp
@@ -161,7 +161,7 @@ void GCMemcardManager::UpdateSlotTable(int slot)
   auto& memcard = m_slot_memcard[slot];
   auto* table = m_slot_table[slot];
 
-  auto create_item = [this](const QString string = QStringLiteral("")) {
+  auto create_item = [](const QString string = QStringLiteral("")) {
     QTableWidgetItem* item = new QTableWidgetItem(string);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     return item;

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -478,14 +478,14 @@ void MenuBar::AddOptionsMenu()
   m_boot_to_pause->setChecked(SConfig::GetInstance().bBootToPause);
 
   connect(m_boot_to_pause, &QAction::toggled, this,
-          [this](bool enable) { SConfig::GetInstance().bBootToPause = enable; });
+          [](bool enable) { SConfig::GetInstance().bBootToPause = enable; });
 
   m_automatic_start = options_menu->addAction(tr("&Automatic Start"));
   m_automatic_start->setCheckable(true);
   m_automatic_start->setChecked(SConfig::GetInstance().bAutomaticStart);
 
   connect(m_automatic_start, &QAction::toggled, this,
-          [this](bool enable) { SConfig::GetInstance().bAutomaticStart = enable; });
+          [](bool enable) { SConfig::GetInstance().bAutomaticStart = enable; });
 
   m_change_font = AddAction(options_menu, tr("&Font..."), this, &MenuBar::ChangeDebugFont);
 }

--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -136,7 +136,7 @@ QGroupBox* PathPane::MakeGameFolderBox()
   vlayout->addLayout(hlayout);
   vlayout->addWidget(checkbox);
 
-  connect(checkbox, &QCheckBox::toggled, this, [this](bool checked) {
+  connect(checkbox, &QCheckBox::toggled, this, [](bool checked) {
     SConfig::GetInstance().m_RecursiveISOFolder = checked;
     for (const auto& path : Settings::Instance().GetPaths())
       Settings::Instance().ReloadPath(path);


### PR DESCRIPTION
Resolves `-Wunused-lambda-capture` warnings.