### PR TITLE
Qt: make the pause play button only one button

### DIFF
--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -56,10 +56,7 @@ void ToolBar::OnEmulationStateChanged(Core::State state)
   m_screenshot_action->setEnabled(running);
 
   bool playing = running && state != Core::State::Paused;
-  m_play_action->setEnabled(!playing);
-  m_play_action->setVisible(!playing);
-  m_pause_action->setEnabled(playing);
-  m_pause_action->setVisible(playing);
+  UpdatePausePlayButtonState(playing);
 
   bool paused = Core::GetState() == Core::State::Paused;
   m_step_action->setEnabled(paused);
@@ -101,8 +98,8 @@ void ToolBar::MakeActions()
   m_set_pc_action = AddAction(this, tr("Set PC"), this, &ToolBar::SetPCPressed);
 
   m_open_action = AddAction(this, tr("Open"), this, &ToolBar::OpenPressed);
-  m_play_action = AddAction(this, tr("Play"), this, &ToolBar::PlayPressed);
-  m_pause_action = AddAction(this, tr("Pause"), this, &ToolBar::PausePressed);
+  m_pause_play_action = AddAction(this, tr("Play"), this, &ToolBar::PlayPressed);
+
   m_stop_action = AddAction(this, tr("Stop"), this, &ToolBar::StopPressed);
   m_fullscreen_action = AddAction(this, tr("FullScr"), this, &ToolBar::FullScreenPressed);
   m_screenshot_action = AddAction(this, tr("ScrShot"), this, &ToolBar::ScreenShotPressed);
@@ -117,10 +114,10 @@ void ToolBar::MakeActions()
   // Ensure every button has about the same width
   std::vector<QWidget*> items;
   for (const auto& action :
-       {m_open_action, m_play_action, m_pause_action, m_stop_action, m_stop_action,
-        m_fullscreen_action, m_screenshot_action, m_config_action, m_graphics_action,
-        m_controllers_action, m_step_action, m_step_over_action, m_step_out_action, m_skip_action,
-        m_show_pc_action, m_set_pc_action})
+       {m_open_action, m_pause_play_action, m_stop_action, m_stop_action, m_fullscreen_action,
+        m_screenshot_action, m_config_action, m_graphics_action, m_controllers_action,
+        m_step_action, m_step_over_action, m_step_out_action, m_skip_action, m_show_pc_action,
+        m_set_pc_action})
   {
     items.emplace_back(widgetForAction(action));
   }
@@ -134,6 +131,24 @@ void ToolBar::MakeActions()
     widget->setMinimumWidth(min_width);
 }
 
+void ToolBar::UpdatePausePlayButtonState(const bool playing_state)
+{
+  if (playing_state)
+  {
+    disconnect(m_pause_play_action, 0, 0, 0);
+    m_pause_play_action->setText(tr("Pause"));
+    m_pause_play_action->setIcon(Resources::GetScaledThemeIcon("pause"));
+    connect(m_pause_play_action, &QAction::triggered, this, &ToolBar::PausePressed);
+  }
+  else
+  {
+    disconnect(m_pause_play_action, 0, 0, 0);
+    m_pause_play_action->setText(tr("Play"));
+    m_pause_play_action->setIcon(Resources::GetScaledThemeIcon("play"));
+    connect(m_pause_play_action, &QAction::triggered, this, &ToolBar::PlayPressed);
+  }
+}
+
 void ToolBar::UpdateIcons()
 {
   m_step_action->setIcon(Resources::GetScaledThemeIcon("debugger_step_in"));
@@ -144,8 +159,14 @@ void ToolBar::UpdateIcons()
   m_set_pc_action->setIcon(Resources::GetScaledThemeIcon("debugger_show_pc"));
 
   m_open_action->setIcon(Resources::GetScaledThemeIcon("open"));
-  m_play_action->setIcon(Resources::GetScaledThemeIcon("play"));
-  m_pause_action->setIcon(Resources::GetScaledThemeIcon("pause"));
+
+  const Core::State state = Core::GetState();
+  const bool playing = state != Core::State::Uninitialized && state != Core::State::Paused;
+  if (!playing)
+    m_pause_play_action->setIcon(Resources::GetScaledThemeIcon("play"));
+  else
+    m_pause_play_action->setIcon(Resources::GetScaledThemeIcon("pause"));
+
   m_stop_action->setIcon(Resources::GetScaledThemeIcon("stop"));
   m_fullscreen_action->setIcon(Resources::GetScaledThemeIcon("fullscreen"));
   m_screenshot_action->setIcon(Resources::GetScaledThemeIcon("screenshot"));

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -46,10 +46,10 @@ private:
 
   void MakeActions();
   void UpdateIcons();
+  void UpdatePausePlayButtonState(bool playing_state);
 
   QAction* m_open_action;
-  QAction* m_play_action;
-  QAction* m_pause_action;
+  QAction* m_pause_play_action;
   QAction* m_stop_action;
   QAction* m_fullscreen_action;
   QAction* m_screenshot_action;


### PR DESCRIPTION
This is to avoid some issue with using 2 actions and switching between them.  This commit will instead have one action get his property changed on pause and play.

I noticed it acted very odd when for example using the debugger where it kept going to disabled, maybe blink once and then switch to the other button, it's really weird, but I noticed Wx was jsut using one button and instead changed the properties of the button as the state changes.  This button should now behave like Wx and not have some awakward disabled state when pressing it which give it a snappier feel.