### PR TITLE
Qt/Host: Fix random crashes when exiting fullscreen

### DIFF
--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -46,7 +46,10 @@ void Host::SetRenderFocus(bool focus)
 {
   m_render_focus = focus;
   if (g_renderer && m_render_fullscreen && g_ActiveConfig.ExclusiveFullscreenEnabled())
-    Core::RunAsCPUThread([focus] { g_renderer->SetFullscreen(focus); });
+    Core::RunAsCPUThread([focus] {
+      if (!SConfig::GetInstance().bRenderToMain)
+        g_renderer->SetFullscreen(focus);
+    });
 }
 
 bool Host::GetRenderFullscreen()
@@ -110,10 +113,7 @@ void Host_YieldToUI()
 
 void Host_UpdateDisasmDialog()
 {
-  RunOnObject(QApplication::instance(), [&] {
-    emit Host::GetInstance()->UpdateDisasmDialog();
-    return true;
-  });
+  QueueOnObject(Host::GetInstance(), [] { emit Host::GetInstance()->UpdateDisasmDialog(); });
 }
 
 void Host_UpdateProgressDialog(const char* caption, int position, int total)


### PR DESCRIPTION
Apart from the fact that it breaks exiting fullscreen under certain conditions this call of ``RunOnObject`` has the following problems attached to it:

* It queued on ``QApplication::instance()`` instead of the actual object that should emit the signal
* ``RunOnObject`` blocks when blocking is not necessary here and blocking the Host thread for UI stuff is unacceptable
* It used a reference capture (``[&]``) when none was needed.