### PR TITLE
Qt/CodeViewWidget: Dynamic background dimming for dark themes

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
@@ -100,6 +100,8 @@ void CodeViewWidget::Update()
   if (Core::GetState() != Core::State::Paused && PowerPC::debug_interface.IsBreakpoint(pc))
     Core::SetState(Core::State::Paused);
 
+  const bool dark_theme = qApp->palette().color(QPalette::Base).valueF() < 0.5;
+
   for (int i = 0; i < rowCount(); i++)
   {
     u32 addr = m_address - ((rowCount() / 2) * 4) + i * 4;
@@ -123,15 +125,14 @@ void CodeViewWidget::Update()
       item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
       item->setData(Qt::UserRole, addr);
 
-      if (color != 0xFFFFFF)
-      {
-        item->setForeground(Qt::black);
-        item->setBackground(QColor(color));
-      }
       if (addr == pc && item != bp_item)
       {
-        item->setBackground(Qt::green);
-        item->setForeground(Qt::black);
+        item->setBackground(QColor(Qt::green));
+        item->setForeground(QColor(Qt::black));
+      }
+      else if (color != 0xFFFFFF)
+      {
+        item->setBackground(dark_theme ? QColor(color).darker(240) : QColor(color));
       }
     }
 
@@ -151,7 +152,7 @@ void CodeViewWidget::Update()
     }
 
     if (ins == "blr")
-      ins_item->setForeground(Qt::darkGreen);
+      ins_item->setForeground(dark_theme ? QColor(0xa0FFa0) : Qt::darkGreen);
 
     if (PowerPC::debug_interface.IsBreakpoint(addr))
     {


### PR DESCRIPTION
This is an alternate solution to the hardcoded code view colors added in 9a2dd47.

It will test for a dark base color based on the current system theme and darken the selected background color accordingly.

The darkening values are subjective, adjusted according to the light and dark Breeze themes on Plasma Desktop.

Breeze Light:
![screenshot_20180515_143453](https://user-images.githubusercontent.com/505536/40090977-d2f9b5cc-5850-11e8-93d0-20ef66df737f.png)

Breeze Dark:
![screenshot_20180515_143515](https://user-images.githubusercontent.com/505536/40090979-d6b6aec2-5850-11e8-9211-18ecf24a2c71.png)