### PR TITLE
Qt/Debugger: Use QApplication::instance() as the connection context in Host_UpdateDisasmDialog()

### DIFF
--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -14,7 +14,7 @@
 #include "Core/Debugger/PPCDebugInterface.h"
 #include "Core/Host.h"
 #include "Core/PowerPC/PowerPC.h"
-#include "DolphinQt2/QtUtils/RunOnObject.h"
+#include "DolphinQt2/QtUtils/QueueOnObject.h"
 #include "DolphinQt2/Settings.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoConfig.h"
@@ -113,7 +113,7 @@ void Host_YieldToUI()
 
 void Host_UpdateDisasmDialog()
 {
-  QueueOnObject(Host::GetInstance(), [] { emit Host::GetInstance()->UpdateDisasmDialog(); });
+  QueueOnObject(QApplication::instance(), [] { emit Host::GetInstance()->UpdateDisasmDialog(); });
 }
 
 void Host_UpdateProgressDialog(const char* caption, int position, int total)


### PR DESCRIPTION
@spycrab as of #6864 , this introduced a regression where no stepping commands were updating the GUI.  You cannot actually use the instance of the host to trigger the event, in fact, I remember I tried to do this and it didn't worked so this is why I ran this on the application because I still need to fire the event somewhere I can connect.  

Idk if this is a proper way to fix this, maybe you have a suggestion, but next time, just inform me when you work on this event because the debugger relies on it (since the emu thread is pausing and signaling the GUI which is the opposite of what happens usually).