### PR TITLE
Fix "Show Input Display"

### DIFF
--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -666,7 +666,7 @@ void MenuBar::AddMovieMenu()
   auto* input_display = movie_menu->addAction(tr("Show Input Display"));
   input_display->setCheckable(true);
   input_display->setChecked(SConfig::GetInstance().m_ShowInputDisplay);
-  connect(frame_counter, &QAction::toggled,
+  connect(input_display, &QAction::toggled,
           [](bool value) { SConfig::GetInstance().m_ShowInputDisplay = value; });
 
   auto* system_clock = movie_menu->addAction(tr("Show System Clock"));


### PR DESCRIPTION
Currently in Qt the Input Display is enabled/disabled with the "Show Frame Counter" Option, while the "Show Input Display" Option does nothing. This should fix this.

This is my first PR so if I'm doing anything wrong please let me know.
