### PR TITLE
DSPHLE/UCodes: Replace unnecessary virtual keywords with override

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -59,7 +59,7 @@ class AXUCode : public UCodeInterface
 {
 public:
   AXUCode(DSPHLE* dsphle, u32 crc);
-  virtual ~AXUCode();
+  ~AXUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -18,7 +18,7 @@ class AXWiiUCode : public AXUCode
 {
 public:
   AXWiiUCode(DSPHLE* dsphle, u32 crc);
-  virtual ~AXWiiUCode();
+  ~AXWiiUCode() override;
 
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
@@ -17,7 +17,7 @@ class CARDUCode : public UCodeInterface
 {
 public:
   CARDUCode(DSPHLE* dsphle, u32 crc);
-  virtual ~CARDUCode();
+  ~CARDUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
@@ -21,7 +21,7 @@ void ProcessGBACrypto(u32 address);
 struct GBAUCode : public UCodeInterface
 {
   GBAUCode(DSPHLE* dsphle, u32 crc);
-  virtual ~GBAUCode();
+  ~GBAUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
@@ -17,7 +17,7 @@ class INITUCode : public UCodeInterface
 {
 public:
   INITUCode(DSPHLE* dsphle, u32 crc);
-  virtual ~INITUCode();
+  ~INITUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -17,7 +17,7 @@ class ROMUCode : public UCodeInterface
 {
 public:
   ROMUCode(DSPHLE* dsphle, u32 crc);
-  virtual ~ROMUCode();
+  ~ROMUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -194,7 +194,7 @@ class ZeldaUCode : public UCodeInterface
 {
 public:
   ZeldaUCode(DSPHLE* dsphle, u32 crc);
-  virtual ~ZeldaUCode();
+  ~ZeldaUCode() override;
 
   void Initialize() override;
   void HandleMail(u32 mail) override;


### PR DESCRIPTION
Given these HLE classes inherit from a common base with a virtual destructor, override is more appropriate here, as virtual propagates to these destructors anyway.

This is also safer. If the base class' destructor is ever made non-virtual, then these classes will cause a compilation error if they aren't taken into account, as they'd be overriding a non-virtual function (the destructor).