### PR TITLE
EXI_DeviceEthernet: Minor cleanup

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Apple.cpp
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Apple.cpp
@@ -63,7 +63,7 @@ bool CEXIETHERNET::SendFrame(const u8* frame, u32 size)
   }
 }
 
-static void ReadThreadHandler(CEXIETHERNET* self)
+void CEXIETHERNET::ReadThreadHandler(CEXIETHERNET* self)
 {
   while (!self->readThreadShutdown.IsSet())
   {

--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Unix.cpp
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Unix.cpp
@@ -125,7 +125,7 @@ bool CEXIETHERNET::SendFrame(const u8* frame, u32 size)
 }
 
 #ifdef __linux__
-static void ReadThreadHandler(CEXIETHERNET* self)
+void CEXIETHERNET::ReadThreadHandler(CEXIETHERNET* self)
 {
   while (!self->readThreadShutdown.IsSet())
   {

--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Win32.cpp
@@ -263,7 +263,7 @@ bool CEXIETHERNET::IsActivated()
   return mHAdapter != INVALID_HANDLE_VALUE;
 }
 
-static void ReadThreadHandler(CEXIETHERNET* self)
+void CEXIETHERNET::ReadThreadHandler(CEXIETHERNET* self)
 {
   while (!self->readThreadShutdown.IsSet())
   {

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -26,9 +26,7 @@ CEXIETHERNET::CEXIETHERNET()
 {
   tx_fifo = std::make_unique<u8[]>(BBA_TXFIFO_SIZE);
   mBbaMem = std::make_unique<u8[]>(BBA_MEM_SIZE);
-
   mRecvBuffer = std::make_unique<u8[]>(BBA_RECV_SIZE);
-  mRecvBufferLength = 0;
 
   MXHardReset();
 
@@ -48,15 +46,6 @@ CEXIETHERNET::CEXIETHERNET()
 
   // HACK: .. fully established 100BASE-T link
   mBbaMem[BBA_NWAYS] = NWAYS_LS100 | NWAYS_LPNWAY | NWAYS_100TXF | NWAYS_ANCLPT;
-
-#if defined(_WIN32)
-  mHAdapter = INVALID_HANDLE_VALUE;
-  memset(&mReadOverlapped, 0, sizeof(mReadOverlapped));
-  memset(&mWriteOverlapped, 0, sizeof(mWriteOverlapped));
-  mWritePending = false;
-#elif defined(__linux__) || defined(__APPLE__)
-  fd = -1;
-#endif
 }
 
 CEXIETHERNET::~CEXIETHERNET()

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -210,7 +210,7 @@ public:
   void DMARead(u32 addr, u32 size) override;
   void DoState(PointerWrap& p) override;
 
-  // private:
+private:
   struct
   {
     enum
@@ -312,6 +312,7 @@ public:
   std::unique_ptr<u8[]> tx_fifo;
 
   // TAP interface
+  static void ReadThreadHandler(CEXIETHERNET* self);
   bool Activate();
   void Deactivate();
   bool IsActivated();

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -227,7 +227,7 @@ private:
 
     u16 address;
     bool valid;
-  } transfer;
+  } transfer = {};
 
   enum
   {
@@ -251,28 +251,14 @@ private:
       TRANSFER = 0x80
     };
 
-    u8 revision_id;
-    u8 interrupt_mask;
-    u8 interrupt;
-    u16 device_id;
-    u8 acstart;
-    u32 hash_challenge;
-    u32 hash_response;
-    u8 hash_status;
-
-    EXIStatus()
-    {
-      device_id = 0xd107;
-      revision_id = 0;  // 0xf0;
-      acstart = 0x4e;
-
-      interrupt_mask = 0;
-      interrupt = 0;
-      hash_challenge = 0;
-      hash_response = 0;
-      hash_status = 0;
-    }
-
+    u8 revision_id = 0;  // 0xf0
+    u8 interrupt_mask = 0;
+    u8 interrupt = 0;
+    u16 device_id = 0xD107;
+    u8 acstart = 0x4E;
+    u32 hash_challenge = 0;
+    u32 hash_response = 0;
+    u8 hash_status = 0;
   } exi_status;
 
   struct Descriptor
@@ -322,16 +308,16 @@ private:
   void RecvStop();
 
   std::unique_ptr<u8[]> mRecvBuffer;
-  u32 mRecvBufferLength;
+  u32 mRecvBufferLength = 0;
 
 #if defined(_WIN32)
-  HANDLE mHAdapter;
-  OVERLAPPED mReadOverlapped;
-  OVERLAPPED mWriteOverlapped;
+  HANDLE mHAdapter = INVALID_HANDLE_VALUE;
+  OVERLAPPED mReadOverlapped = {};
+  OVERLAPPED mWriteOverlapped = {};
   std::vector<u8> mWriteBuffer;
-  bool mWritePending;
+  bool mWritePending = false;
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-  int fd;
+  int fd = -1;
 #endif
 
 #if defined(WIN32) || defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) ||          \


### PR DESCRIPTION
Just minor tidying. This makes the thread handler function a static function part of CEXIETHERNET itself, which allows making all internals private once again. This also cleans up the in-class initialization which allows removing the preprocessor ifdef chain within the constructor.