### PR TITLE
Interpreter_FPUtils: Use Common::BitCast where applicable

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <cmath>
-#include <cstring>
 #include <limits>
 
+#include "Common/BitUtils.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
 #include "Common/FloatUtils.h"
@@ -73,28 +73,18 @@ inline double ForceDouble(double d)
 
 inline double Force25Bit(double d)
 {
-  u64 integral;
-  std::memcpy(&integral, &d, sizeof(u64));
+  u64 integral = Common::BitCast<u64>(d);
 
   integral = (integral & 0xFFFFFFFFF8000000ULL) + (integral & 0x8000000);
 
-  double result;
-  std::memcpy(&result, &integral, sizeof(double));
-
-  return result;
+  return Common::BitCast<double>(integral);
 }
 
 inline double MakeQuiet(double d)
 {
-  u64 integral;
-  std::memcpy(&integral, &d, sizeof(u64));
+  const u64 integral = Common::BitCast<u64>(d) | Common::DOUBLE_QBIT;
 
-  integral |= Common::DOUBLE_QBIT;
-
-  double result;
-  std::memcpy(&result, &integral, sizeof(double));
-
-  return result;
+  return Common::BitCast<double>(integral);
 }
 
 // these functions allow globally modify operations behaviour


### PR DESCRIPTION
Gets rid of now-unnecessary memcpy boilerplating for different bit representations between integral and fp types.