### PR TITLE
Qt/debugger: properly update when we load the symbols on boot

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
@@ -45,6 +45,8 @@ CodeWidget::CodeWidget(QWidget* parent) : QDockWidget(parent)
     Update();
   });
 
+  connect(Host::GetInstance(), &Host::NotifyMapLoaded, this, &CodeWidget::UpdateSymbols);
+
   connect(&Settings::Instance(), &Settings::DebugModeToggled,
           [this](bool enabled) { setHidden(!enabled || !Settings::Instance().IsCodeVisible()); });
 

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -121,6 +121,16 @@ void Host_UpdateProgressDialog(const char* caption, int position, int total)
   emit Host::GetInstance()->UpdateProgressDialog(QString::fromUtf8(caption), position, total);
 }
 
+void Host::RequestNotifyMapLoaded()
+{
+  QueueOnObject(QApplication::instance(), [this] { emit NotifyMapLoaded(); });
+}
+
+void Host_NotifyMapLoaded()
+{
+  Host::GetInstance()->RequestNotifyMapLoaded();
+}
+
 // We ignore these, and their purpose should be questioned individually.
 // In particular, RequestRenderWindowSize, RequestFullscreen, and
 // UpdateMainFrame should almost certainly be removed.
@@ -136,9 +146,6 @@ void Host_RequestRenderWindowSize(int w, int h)
 bool Host_UINeedsControllerState()
 {
   return Settings::Instance().IsControllerStateNeeded();
-}
-void Host_NotifyMapLoaded()
-{
 }
 void Host_ShowVideoConfig(void* parent, const std::string& backend_name)
 {

--- a/Source/Core/DolphinQt2/Host.h
+++ b/Source/Core/DolphinQt2/Host.h
@@ -27,6 +27,7 @@ public:
   void SetRenderFocus(bool focus);
   void SetRenderFullscreen(bool fullscreen);
   void ResizeSurface(int new_width, int new_height);
+  void RequestNotifyMapLoaded();
 
 signals:
   void RequestTitle(const QString& title);
@@ -34,6 +35,7 @@ signals:
   void RequestRenderSize(int w, int h);
   void UpdateProgressDialog(QString label, int position, int maximum);
   void UpdateDisasmDialog();
+  void NotifyMapLoaded();
 
 private:
   Host();


### PR DESCRIPTION
This host event is still useful because the emu thread will load the symbols on boot if required.  Though, this is the only useful place where it is used, the rest of the symbols update occurs manually with events when actually loading or editing symbols.

cc: @spycrab 