### PR TITLE
PowerPC: Parenthesize GQR macro argument

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -200,7 +200,7 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 #define SPRG1 PowerPC::ppcState.spr[SPR_SPRG1]
 #define SPRG2 PowerPC::ppcState.spr[SPR_SPRG2]
 #define SPRG3 PowerPC::ppcState.spr[SPR_SPRG3]
-#define GQR(x) PowerPC::ppcState.spr[SPR_GQR0 + x]
+#define GQR(x) PowerPC::ppcState.spr[SPR_GQR0 + (x)]
 #define TL PowerPC::ppcState.spr[SPR_TL]
 #define TU PowerPC::ppcState.spr[SPR_TU]
 


### PR DESCRIPTION
Ideally none of these macros would exist (long-term goal), however in the meantime at least make sure expressions always evaluate correctly (thankfully no current usages rely on this).