### PR TITLE
Interpreter_FloatingPoint: Fix build in frspx()

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -281,7 +281,7 @@ void Interpreter::frspx(UGeckoInstruction inst)  // round to single
 
   if (std::isnan(b))
   {
-    const bool is_snan = MathUtil::IsSNAN(b);
+    const bool is_snan = Common::IsSNAN(b);
 
     if (is_snan)
       SetFPException(FPSCR_VXSNAN);


### PR DESCRIPTION
Github didn't detect conflicts here, however, since the float handling functions were moved into the Common namespace, this would cause a build failure.