### PR TITLE
DolphinQt2/Settings: Remove unimplemented IsInDevelopmentWarningEnabled() prototype

### DIFF
--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -50,7 +50,6 @@ public:
   void SetUserStylesEnabled(bool enabled);
   bool AreUserStylesEnabled() const;
 
-  bool IsInDevelopmentWarningEnabled() const;
   bool IsLogVisible() const;
   void SetLogVisible(bool visible);
   bool IsLogConfigVisible() const;


### PR DESCRIPTION
The "in development" dialog was removed quite a while ago, so this is just a leftover remnant that must have been missed during said removal.