### PR TITLE
Qt/HacksWidget: Fix slider not showing overridden settings

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.h
@@ -8,6 +8,7 @@
 
 class GraphicsWindow;
 class QCheckBox;
+class QLabel;
 class QRadioButton;
 class QSlider;
 
@@ -29,6 +30,7 @@ private:
   QCheckBox* m_store_efb_copies;
 
   // Texture Cache
+  QLabel* m_accuracy_label;
   QSlider* m_accuracy;
   QCheckBox* m_gpu_texture_decoding;
 


### PR DESCRIPTION
Fixes [issue #11128](https://bugs.dolphin-emu.org/issues/11128).