### PR TITLE
DolphinQt2: Minor changes

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/NewBreakpointDialog.h
+++ b/Source/Core/DolphinQt2/Debugger/NewBreakpointDialog.h
@@ -22,7 +22,7 @@ class NewBreakpointDialog : public QDialog
 public:
   explicit NewBreakpointDialog(BreakpointWidget* parent);
 
-  void accept();
+  void accept() override;
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt2/NetPlay/GameListDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/GameListDialog.cpp
@@ -59,7 +59,7 @@ void GameListDialog::PopulateGameList()
   m_game_list->sortItems();
 }
 
-const QString& GameListDialog::GetSelectedUniqueID()
+const QString& GameListDialog::GetSelectedUniqueID() const
 {
   return m_game_id;
 }

--- a/Source/Core/DolphinQt2/NetPlay/GameListDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/GameListDialog.h
@@ -17,7 +17,7 @@ class GameListDialog : public QDialog
 public:
   explicit GameListDialog(QWidget* parent);
 
-  int exec();
+  int exec() override;
   const QString& GetSelectedUniqueID();
 
 private:

--- a/Source/Core/DolphinQt2/NetPlay/GameListDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/GameListDialog.h
@@ -18,7 +18,7 @@ public:
   explicit GameListDialog(QWidget* parent);
 
   int exec() override;
-  const QString& GetSelectedUniqueID();
+  const QString& GetSelectedUniqueID() const;
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt2/NetPlay/MD5Dialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/MD5Dialog.h
@@ -17,7 +17,7 @@ class MD5Dialog : public QDialog
 {
   Q_OBJECT
 public:
-  MD5Dialog(QWidget* parent);
+  explicit MD5Dialog(QWidget* parent);
 
   void show(const QString& title);
   void SetProgress(int pid, int progress);

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
@@ -30,7 +30,7 @@ class NetPlayDialog : public QDialog, public NetPlayUI
 {
   Q_OBJECT
 public:
-  NetPlayDialog(QWidget* parent);
+  explicit NetPlayDialog(QWidget* parent);
   ~NetPlayDialog();
 
   void show(std::string nickname, bool use_traversal);

--- a/Source/Core/DolphinQt2/NetPlay/NetPlaySetupDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlaySetupDialog.h
@@ -22,7 +22,7 @@ class NetPlaySetupDialog : public QDialog
 {
   Q_OBJECT
 public:
-  NetPlaySetupDialog(QWidget* parent);
+  explicit NetPlaySetupDialog(QWidget* parent);
 
   void accept() override;
   void show();

--- a/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.h
@@ -20,7 +20,7 @@ class PadMappingDialog : public QDialog
 public:
   explicit PadMappingDialog(QWidget* widget);
 
-  int exec();
+  int exec() override;
 
   PadMappingArray GetGCPadArray();
   PadMappingArray GetWiimoteArray();

--- a/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.h
+++ b/Source/Core/DolphinQt2/QtUtils/AspectRatioWidget.h
@@ -13,7 +13,7 @@ class AspectRatioWidget : public QWidget
   Q_OBJECT
 public:
   AspectRatioWidget(QWidget* widget, float width, float height, QWidget* parent = nullptr);
-  void resizeEvent(QResizeEvent* event);
+  void resizeEvent(QResizeEvent* event) override;
 
 private:
   QBoxLayout* m_layout;


### PR DESCRIPTION
Individual self-contained miscellaneous changes, which are just:

- Adding missing override specifiers
- Making constructors explicit
- Making a member function const-qualified