### PR TITLE
Qt/CheatWarningWidget: properly supply a parent for the widget

### DIFF
--- a/Source/Core/DolphinQt2/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/ARCodeWidget.cpp
@@ -40,7 +40,7 @@ ARCodeWidget::ARCodeWidget(const UICommon::GameFile& game, bool restart_required
 
 void ARCodeWidget::CreateWidgets()
 {
-  m_warning = new CheatWarningWidget(m_game_id, m_restart_required);
+  m_warning = new CheatWarningWidget(m_game_id, m_restart_required, this);
   m_code_list = new QListWidget;
   m_code_add = new QPushButton(tr("&Add New Code..."));
   m_code_edit = new QPushButton(tr("&Edit Code..."));

--- a/Source/Core/DolphinQt2/Config/CheatWarningWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/CheatWarningWidget.cpp
@@ -14,8 +14,9 @@
 #include "Core/Core.h"
 #include "DolphinQt2/Settings.h"
 
-CheatWarningWidget::CheatWarningWidget(const std::string& game_id, bool restart_required)
-    : m_game_id(game_id), m_restart_required(restart_required)
+CheatWarningWidget::CheatWarningWidget(const std::string& game_id, bool restart_required,
+                                       QWidget* parent)
+    : QWidget(parent), m_game_id(game_id), m_restart_required(restart_required)
 {
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt2/Config/CheatWarningWidget.h
+++ b/Source/Core/DolphinQt2/Config/CheatWarningWidget.h
@@ -15,7 +15,7 @@ class CheatWarningWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit CheatWarningWidget(const std::string& game_id, bool restart_required);
+  explicit CheatWarningWidget(const std::string& game_id, bool restart_required, QWidget* parent);
 
 signals:
   void OpenCheatEnableSettings();

--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.cpp
@@ -43,7 +43,7 @@ GeckoCodeWidget::GeckoCodeWidget(const UICommon::GameFile& game, bool restart_re
 
 void GeckoCodeWidget::CreateWidgets()
 {
-  m_warning = new CheatWarningWidget(m_game_id, m_restart_required);
+  m_warning = new CheatWarningWidget(m_game_id, m_restart_required, this);
   m_code_list = new QListWidget;
   m_name_label = new QLabel;
   m_creator_label = new QLabel;


### PR DESCRIPTION
Because it wasn't parented properly, it would show briefly the widget in its own window when creating an ARCodeWidget or a GeckoCodeWidget which would occur when accessing the game properties page or when the state changes to pause/running.

For some reaosns, this window could only be seen on Windows...

cc: @spycrab 