### PR TITLE
Interpreter_Branch: Make type of the bitmask in rfi a u32 instead of int

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Branch.cpp
@@ -121,7 +121,7 @@ void Interpreter::rfi(UGeckoInstruction inst)
 {
   // Restore saved bits from SRR1 to MSR.
   // Gecko/Broadway can save more bits than explicitly defined in ppc spec
-  const int mask = 0x87C0FFFF;
+  const u32 mask = 0x87C0FFFF;
   MSR.Hex = (MSR.Hex & ~mask) | (SRR1 & mask);
   // MSR[13] is set to 0.
   MSR.Hex &= 0xFFFBFFFF;


### PR DESCRIPTION
Given this is a bitmask, we should be using an unsigned type to store it (especially given it's outside the range an int can represent properly without being considered negative).

No behavior change is caused by this, it just silences a sign conversion warning.