### PR TITLE
PPCAnalyst: Make CodeBuffer an alias for std::vector<CodeOp>

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -194,7 +194,7 @@ void CachedInterpreter::Jit(u32 address)
     ClearCache();
   }
 
-  u32 nextPC = analyzer.Analyze(PC, &code_block, &code_buffer, code_buffer.GetSize());
+  const u32 nextPC = analyzer.Analyze(PC, &code_block, &code_buffer, code_buffer.size());
   if (code_block.m_memory_exception)
   {
     // Address of instruction could not be translated
@@ -216,10 +216,9 @@ void CachedInterpreter::Jit(u32 address)
   b->checkedEntry = GetCodePtr();
   b->normalEntry = GetCodePtr();
 
-  PPCAnalyst::CodeOp* const ops = code_buffer.codebuffer;
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
-    PPCAnalyst::CodeOp& op = ops[i];
+    PPCAnalyst::CodeOp& op = code_buffer[i];
 
     js.downcountAmount += op.opinfo->numCycles;
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -637,11 +637,11 @@ void Jit64::Jit(u32 em_address)
   }
 
   JitBlock* b = blocks.AllocateBlock(em_address);
-  DoJit(em_address, &code_buffer, b, nextPC);
+  DoJit(em_address, b, nextPC);
   blocks.FinalizeBlock(*b, jo.enableBlocklink, code_block.m_physical_addresses);
 }
 
-const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock* b, u32 nextPC)
+const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 {
   js.firstFPInstructionFound = false;
   js.isLastInstruction = false;
@@ -741,7 +741,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
   // Translate instructions
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
-    PPCAnalyst::CodeOp& op = (*code_buf)[i];
+    PPCAnalyst::CodeOp& op = code_buffer[i];
 
     js.compilerPC = op.address;
     js.op = &op;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -594,7 +594,7 @@ void Jit64::Jit(u32 em_address)
     ClearCache();
   }
 
-  int blockSize = code_buffer.GetSize();
+  std::size_t block_size = code_buffer.size();
 
   if (SConfig::GetInstance().bEnableDebugging)
   {
@@ -607,7 +607,7 @@ void Jit64::Jit(u32 em_address)
     {
       if (CPU::IsStepping())
       {
-        blockSize = 1;
+        block_size = 1;
 
         // Do not link this block to other blocks While single stepping
         jo.enableBlocklink = false;
@@ -624,7 +624,7 @@ void Jit64::Jit(u32 em_address)
   // Analyze the block, collect all instructions it is made of (including inlining,
   // if that is enabled), reorder instructions for optimal performance, and join joinable
   // instructions.
-  u32 nextPC = analyzer.Analyze(em_address, &code_block, &code_buffer, blockSize);
+  const u32 nextPC = analyzer.Analyze(em_address, &code_block, &code_buffer, block_size);
 
   if (code_block.m_memory_exception)
   {
@@ -739,10 +739,9 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
   }
 
   // Translate instructions
-  PPCAnalyst::CodeOp* const ops = code_buf->codebuffer;
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
-    PPCAnalyst::CodeOp& op = ops[i];
+    PPCAnalyst::CodeOp& op = (*code_buf)[i];
 
     js.compilerPC = op.address;
     js.op = &op;
@@ -951,7 +950,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
   b->originalSize = code_block.m_num_instructions;
 
 #ifdef JIT_LOG_X86
-  LogGeneratedX86(code_block.m_num_instructions, code_buf, start, b);
+  LogGeneratedX86(code_block.m_num_instructions, code_buffer, start, b);
 #endif
 
   return normalEntry;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -46,7 +46,7 @@ public:
   // Jit!
 
   void Jit(u32 em_address) override;
-  const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock* b, u32 nextPC);
+  const u8* DoJit(u32 em_address, JitBlock* b, u32 nextPC);
 
   BitSet32 CallerSavedRegistersInUse() const;
   BitSet8 ComputeStaticGQRs(const PPCAnalyst::CodeBlock&) const;

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -127,12 +127,12 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
   return true;
 }
 
-void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
+void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer& code_buffer, const u8* normalEntry,
                      const JitBlock* b)
 {
   for (size_t i = 0; i < size; i++)
   {
-    const PPCAnalyst::CodeOp& op = code_buffer->codebuffer[i];
+    const PPCAnalyst::CodeOp& op = code_buffer[i];
     std::string temp = StringFromFormat(
         "%08x %s", op.address, GekkoDisassembler::Disassemble(op.inst.hex, op.address).c_str());
     DEBUG_LOG(DYNA_REC, "IR_X86 PPC: %s\n", temp.c_str());

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
@@ -13,11 +13,7 @@
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
 #include "Core/PowerPC/Jit64Common/TrampolineCache.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
-
-namespace PPCAnalyst
-{
-class CodeBuffer;
-}
+#include "Core/PowerPC/PPCAnalyst.h"
 
 // RSCRATCH and RSCRATCH2 are always scratch registers and can be used without
 // limitation.
@@ -46,5 +42,5 @@ public:
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
 };
 
-void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
+void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer& code_buffer, const u8* normalEntry,
                      const JitBlock* b);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -578,11 +578,11 @@ void JitArm64::Jit(u32)
   }
 
   JitBlock* b = blocks.AllocateBlock(em_address);
-  DoJit(em_address, &code_buffer, b, nextPC);
+  DoJit(em_address, b, nextPC);
   blocks.FinalizeBlock(*b, jo.enableBlocklink, code_block.m_physical_addresses);
 }
 
-void JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock* b, u32 nextPC)
+void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 {
   if (em_address == 0)
   {
@@ -651,7 +651,7 @@ void JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock*
   // Translate instructions
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
-    PPCAnalyst::CodeOp& op = (*code_buf)[i];
+    PPCAnalyst::CodeOp& op = code_buffer[i];
 
     js.compilerPC = op.address;
     js.op = &op;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -553,19 +553,19 @@ void JitArm64::Jit(u32)
     ClearCache();
   }
 
-  int blockSize = code_buffer.GetSize();
-  u32 em_address = PowerPC::ppcState.pc;
+  std::size_t block_size = code_buffer.size();
+  const u32 em_address = PowerPC::ppcState.pc;
 
   if (SConfig::GetInstance().bEnableDebugging)
   {
     // Comment out the following to disable breakpoints (speed-up)
-    blockSize = 1;
+    block_size = 1;
   }
 
   // Analyze the block, collect all instructions it is made of (including inlining,
   // if that is enabled), reorder instructions for optimal performance, and join joinable
   // instructions.
-  u32 nextPC = analyzer.Analyze(em_address, &code_block, &code_buffer, blockSize);
+  const u32 nextPC = analyzer.Analyze(em_address, &code_block, &code_buffer, block_size);
 
   if (code_block.m_memory_exception)
   {
@@ -649,10 +649,9 @@ void JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock*
   fpr.Start(js.fpa);
 
   // Translate instructions
-  PPCAnalyst::CodeOp* const ops = code_buf->codebuffer;
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
-    PPCAnalyst::CodeOp& op = ops[i];
+    PPCAnalyst::CodeOp& op = (*code_buf)[i];
 
     js.compilerPC = op.address;
     js.op = &op;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -200,7 +200,7 @@ private:
   void SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 offset, bool update);
   void SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s32 offset);
 
-  void DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock* b, u32 nextPC);
+  void DoJit(u32 em_address, JitBlock* b, u32 nextPC);
 
   void DoDownCount();
   void Cleanup();

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include <algorithm>
+#include <cstddef>
 #include <set>
+#include <vector>
 
 #include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
@@ -113,18 +115,7 @@ struct BlockRegStats
   }
 };
 
-class CodeBuffer
-{
-public:
-  CodeBuffer(int size);
-  ~CodeBuffer();
-
-  int GetSize() const { return size_; }
-  PPCAnalyst::CodeOp* codebuffer;
-
-private:
-  int size_;
-};
+using CodeBuffer = std::vector<CodeOp>;
 
 struct CodeBlock
 {
@@ -205,7 +196,7 @@ public:
   void SetOption(AnalystOption option) { m_options |= option; }
   void ClearOption(AnalystOption option) { m_options &= ~(option); }
   bool HasOption(AnalystOption option) const { return !!(m_options & option); }
-  u32 Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, u32 blockSize);
+  u32 Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std::size_t block_size);
 
 private:
   enum class ReorderType

--- a/Source/Core/DolphinQt2/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/JITWidget.cpp
@@ -155,12 +155,12 @@ void JITWidget::Update()
   code_block.m_gpa = &gpa;
   code_block.m_fpa = &fpa;
 
-  if (analyzer.Analyze(ppc_addr, &code_block, &code_buffer, 32000) != 0xFFFFFFFF)
+  if (analyzer.Analyze(ppc_addr, &code_block, &code_buffer, code_buffer.size()) != 0xFFFFFFFF)
   {
     std::ostringstream ppc_disasm;
     for (u32 i = 0; i < code_block.m_num_instructions; i++)
     {
-      const PPCAnalyst::CodeOp& op = code_buffer.codebuffer[i];
+      const PPCAnalyst::CodeOp& op = code_buffer[i];
       std::string opcode = GekkoDisassembler::Disassemble(op.inst.hex, op.address);
       ppc_disasm << std::setfill('0') << std::setw(8) << std::hex << op.address;
       ppc_disasm << " " << opcode << std::endl;

--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -93,12 +93,12 @@ void CJitWindow::Compare(u32 em_address)
   code_block.m_gpa = &gpa;
   code_block.m_fpa = &fpa;
 
-  if (analyzer.Analyze(ppc_addr, &code_block, &code_buffer, 32000) != 0xFFFFFFFF)
+  if (analyzer.Analyze(ppc_addr, &code_block, &code_buffer, code_buffer.size()) != 0xFFFFFFFF)
   {
     std::ostringstream ppc_disasm;
     for (u32 i = 0; i < code_block.m_num_instructions; i++)
     {
-      const PPCAnalyst::CodeOp& op = code_buffer.codebuffer[i];
+      const PPCAnalyst::CodeOp& op = code_buffer[i];
       std::string opcode = GekkoDisassembler::Disassemble(op.inst.hex, op.address);
       ppc_disasm << std::setfill('0') << std::setw(8) << std::hex << op.address;
       ppc_disasm << " " << opcode << std::endl;


### PR DESCRIPTION
`CodeBuffer` was previously essentially acting as a "discount std::vector", in that it allocated a given size of memory and deallocated it when it goes out of scope. It also gave you the ability to check its size. Instead of building up a class like that, we can simply alias `std::vector<CodeOp>` to do away with the need to remember the template arguments and use it as is.

