### PR TITLE
GCMemcardDirectory: Save memory card header

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -606,12 +606,11 @@ void GCMemcardDirectory::FlushToFile()
       m_saves[i].m_save_data.clear();
     }
   }
-#if _WRITE_MC_HEADER
+
   u8 mc[BLOCK_SIZE * MC_FST_BLOCKS];
   Read(0, BLOCK_SIZE * MC_FST_BLOCKS, mc);
   File::IOFile hdrfile(m_save_directory + MC_HDR, "wb");
   hdrfile.WriteBytes(mc, BLOCK_SIZE * MC_FST_BLOCKS);
-#endif
 }
 
 void GCMemcardDirectory::DoState(PointerWrap& p)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -12,8 +12,6 @@
 #include "Common/Event.h"
 #include "Core/HW/GCMemcard/GCMemcard.h"
 
-// Uncomment this to write the system data of the memorycard from directory to disc
-//#define _WRITE_MC_HEADER 1
 void MigrateFromMemcardFile(const std::string& directory_name, int card_index);
 
 class GCMemcardDirectory : public MemoryCardBase


### PR DESCRIPTION
Should fix the issue of not being able to save GCI files after loading a save state.