### PR TITLE
CMakeLists: Remove "Enabling GUI" from the "Wx enabled" message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -700,7 +700,7 @@ if(ENABLE_WX)
   endif()
 
   if(wxWidgets_FOUND)
-    message(STATUS "wxWidgets found, enabling GUI build")
+    message(STATUS "wxWidgets found")
     if(NOT TARGET wxWidgets::wxWidgets)
       add_library(wxWidgets::wxWidgets INTERFACE IMPORTED)
       set_target_properties(wxWidgets::wxWidgets PROPERTIES


### PR DESCRIPTION
It doesn't make much sense anymore now that Qt is the main UI.