### PR TITLE
Qt/MappingIndicator: Improve render quality

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingIndicator.cpp
@@ -109,6 +109,8 @@ void MappingIndicator::DrawCursor(bool tilt)
   float centerx = width() / 2., centery = height() / 2.;
 
   QPainter p(this);
+  p.setRenderHint(QPainter::Antialiasing, true);
+  p.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
   float width = 64, height = 64;
   float deadzone = m_cursor_deadzone->GetValue() * 48;
@@ -194,6 +196,8 @@ void MappingIndicator::DrawStick()
   }};
 
   QPainter p(this);
+  p.setRenderHint(QPainter::Antialiasing, true);
+  p.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
   // Draw maximum values
   p.setBrush(Qt::white);
@@ -222,6 +226,9 @@ void MappingIndicator::DrawStick()
 void MappingIndicator::DrawMixedTriggers()
 {
   QPainter p(this);
+  p.setRenderHint(QPainter::Antialiasing, true);
+  p.setRenderHint(QPainter::TextAntialiasing, true);
+  p.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
   // Polled values
   double r_analog = PollControlState(m_mixed_triggers_r_analog);


### PR DESCRIPTION
Before:
![Before](https://i.imgur.com/zziystC.png)
After:
![After](https://i.imgur.com/d38HcaM.png)

*(You may need to zoom in to see the difference)*

Makes the indicators much more pleasant to look at!