### PR TITLE
Interpreter_LoadStore: Remove unnecessary cast in lhzx()

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -673,7 +673,7 @@ void Interpreter::lhzux(UGeckoInstruction inst)
 
 void Interpreter::lhzx(UGeckoInstruction inst)
 {
-  const u32 temp = (u32)PowerPC::Read_U16(Helper_Get_EA_X(inst));
+  const u32 temp = PowerPC::Read_U16(Helper_Get_EA_X(inst));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {


### PR DESCRIPTION
This is only moving a smaller unsigned integral type into a larger unsigned integral type, so there's no loss of information that could occur.