### PR TITLE
Interpreter_LoadStore: No-op dcbt and dcbtst if HID0.NOOPTI is set

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -499,11 +499,17 @@ void Interpreter::dcbst(UGeckoInstruction inst)
 
 void Interpreter::dcbt(UGeckoInstruction inst)
 {
+  if (HID0.NOOPTI)
+    return;
+
   // TODO: Implement some sort of L2 emulation.
 }
 
 void Interpreter::dcbtst(UGeckoInstruction inst)
 {
+  if (HID0.NOOPTI)
+    return;
+
   // TODO: Implement some sort of L2 emulation.
 }
 


### PR DESCRIPTION
If `HID0.NOOPTI` is set, then `dcbt` and `dcbtst` are no-oped globally. We currently don't perform data cache emulation, but we put this in anyway so this detail isn't forgotten about if data cache emulation is introduced at some point in the future.