### PR TITLE
MMU: Avoid sign conversions in EFB_Read and EFB_Write

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -117,8 +117,8 @@ static u32 EFB_Read(const u32 addr)
   u32 var = 0;
   // Convert address to coordinates. It's possible that this should be done
   // differently depending on color depth, especially regarding PeekColor.
-  int x = (addr & 0xfff) >> 2;
-  int y = (addr >> 12) & 0x3ff;
+  const u32 x = (addr & 0xfff) >> 2;
+  const u32 y = (addr >> 12) & 0x3ff;
 
   if (addr & 0x00800000)
   {
@@ -127,12 +127,12 @@ static u32 EFB_Read(const u32 addr)
   else if (addr & 0x00400000)
   {
     var = g_video_backend->Video_AccessEFB(EFBAccessType::PeekZ, x, y, 0);
-    DEBUG_LOG(MEMMAP, "EFB Z Read @ %i, %i\t= 0x%08x", x, y, var);
+    DEBUG_LOG(MEMMAP, "EFB Z Read @ %u, %u\t= 0x%08x", x, y, var);
   }
   else
   {
     var = g_video_backend->Video_AccessEFB(EFBAccessType::PeekColor, x, y, 0);
-    DEBUG_LOG(MEMMAP, "EFB Color Read @ %i, %i\t= 0x%08x", x, y, var);
+    DEBUG_LOG(MEMMAP, "EFB Color Read @ %u, %u\t= 0x%08x", x, y, var);
   }
 
   return var;
@@ -140,8 +140,8 @@ static u32 EFB_Read(const u32 addr)
 
 static void EFB_Write(u32 data, u32 addr)
 {
-  int x = (addr & 0xfff) >> 2;
-  int y = (addr >> 12) & 0x3ff;
+  const u32 x = (addr & 0xfff) >> 2;
+  const u32 y = (addr >> 12) & 0x3ff;
 
   if (addr & 0x00800000)
   {
@@ -152,12 +152,12 @@ static void EFB_Write(u32 data, u32 addr)
   else if (addr & 0x00400000)
   {
     g_video_backend->Video_AccessEFB(EFBAccessType::PokeZ, x, y, data);
-    DEBUG_LOG(MEMMAP, "EFB Z Write %08x @ %i, %i", data, x, y);
+    DEBUG_LOG(MEMMAP, "EFB Z Write %08x @ %u, %u", data, x, y);
   }
   else
   {
     g_video_backend->Video_AccessEFB(EFBAccessType::PokeColor, x, y, data);
-    DEBUG_LOG(MEMMAP, "EFB Color Write %08x @ %i, %i", data, x, y);
+    DEBUG_LOG(MEMMAP, "EFB Color Write %08x @ %u, %u", data, x, y);
   }
 }
 


### PR DESCRIPTION
There's no reason to use int here as opposed to an unsigned value. Video_AccessEFB() takes its arguments as u32 values, so we'd be doing sign conversions for no reason here (along with causing avoidable compiler warnings).