### PR TITLE
VideoBackendBase: Include parameter names in member function declarations

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -74,7 +74,7 @@ void VideoBackendBase::Video_ExitLoop()
 }
 
 // Run from the CPU thread (from VideoInterface.cpp)
-void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
+void VideoBackendBase::Video_BeginField(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height,
                                         u64 ticks)
 {
   if (m_initialized && g_renderer && !g_ActiveConfig.bImmediateXFB)
@@ -85,15 +85,15 @@ void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, 
     e.time = ticks;
     e.type = AsyncRequests::Event::SWAP_EVENT;
 
-    e.swap_event.xfbAddr = xfbAddr;
-    e.swap_event.fbWidth = fbWidth;
-    e.swap_event.fbStride = fbStride;
-    e.swap_event.fbHeight = fbHeight;
+    e.swap_event.xfbAddr = xfb_addr;
+    e.swap_event.fbWidth = fb_width;
+    e.swap_event.fbStride = fb_stride;
+    e.swap_event.fbHeight = fb_height;
     AsyncRequests::GetInstance()->PushEvent(e, false);
   }
 }
 
-u32 VideoBackendBase::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
+u32 VideoBackendBase::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 data)
 {
   if (!g_ActiveConfig.bEFBAccessEnable || x >= EFB_WIDTH || y >= EFB_HEIGHT)
   {
@@ -106,7 +106,7 @@ u32 VideoBackendBase::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 Inpu
     e.type = type == EFBAccessType::PokeColor ? AsyncRequests::Event::EFB_POKE_COLOR :
                                                 AsyncRequests::Event::EFB_POKE_Z;
     e.time = 0;
-    e.efb_poke.data = InputData;
+    e.efb_poke.data = data;
     e.efb_poke.x = x;
     e.efb_poke.y = y;
     AsyncRequests::GetInstance()->PushEvent(e, false);

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -40,14 +40,14 @@ public:
 
   virtual std::string GetName() const = 0;
   virtual std::string GetDisplayName() const { return GetName(); }
-  void ShowConfig(void*);
+  void ShowConfig(void* parent_handle);
   virtual void InitBackendInfo() = 0;
 
   void Video_ExitLoop();
 
-  void Video_BeginField(u32, u32, u32, u32, u64);
+  void Video_BeginField(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u64 ticks);
 
-  u32 Video_AccessEFB(EFBAccessType, u32, u32, u32);
+  u32 Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 data);
   u32 Video_GetQueryResult(PerfQueryType type);
   u16 Video_GetBoundingBox(int index);
 


### PR DESCRIPTION
Given this is a base class, we should clearly state what the parameters to the functions in its exposed interface actually mean or represent. This avoids needing to hunt for the definition of the functions in cpp files.

While we're at it, also normalize said parameter names