### PR TITLE
DolphinQt2/GeckoCodeWidget: Remove unimplemented OnDelete() prototype

### DIFF
--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.h
@@ -36,7 +36,6 @@ signals:
 private:
   void OnSelectionChanged();
   void OnItemChanged(QListWidgetItem* item);
-  void OnDelete();
 
   void CreateWidgets();
   void ConnectWidgets();


### PR DESCRIPTION
Tidies up the interface a little (and prevents a linker error from occurring in the future, should it ever have been called).