### PR TITLE
Interpreter: Move common exception functions to ExceptionUtils.h

### DIFF
--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -500,6 +500,7 @@
     <ClInclude Include="PowerPC\Gekko.h" />
     <ClInclude Include="PowerPC\CachedInterpreter\CachedInterpreter.h" />
     <ClInclude Include="PowerPC\CachedInterpreter\InterpreterBlockCache.h" />
+    <ClInclude Include="PowerPC\Interpreter\ExceptionUtils.h" />
     <ClInclude Include="PowerPC\Interpreter\Interpreter.h" />
     <ClInclude Include="PowerPC\Interpreter\Interpreter_FPUtils.h" />
     <ClInclude Include="PowerPC\Jit64Common\ConstantPool.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -1011,6 +1011,9 @@
     <ClInclude Include="PowerPC\CachedInterpreter\InterpreterBlockCache.h">
       <Filter>PowerPC\Cached Interpreter</Filter>
     </ClInclude>
+    <ClInclude Include="PowerPC\Interpreter\ExceptionUtils.h">
+      <Filter>PowerPC\Interpreter</Filter>
+    </ClInclude>
     <ClInclude Include="PowerPC\Interpreter\Interpreter.h">
       <Filter>PowerPC\Interpreter</Filter>
     </ClInclude>

--- a/Source/Core/Core/PowerPC/Interpreter/ExceptionUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/ExceptionUtils.h
@@ -1,0 +1,26 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+#include "Core/PowerPC/Gekko.h"
+#include "Core/PowerPC/PowerPC.h"
+
+inline void GenerateAlignmentException(u32 address)
+{
+  PowerPC::ppcState.Exceptions |= EXCEPTION_ALIGNMENT;
+  PowerPC::ppcState.spr[SPR_DAR] = address;
+}
+
+inline void GenerateDSIException(u32 address)
+{
+  PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
+  PowerPC::ppcState.spr[SPR_DAR] = address;
+}
+
+inline void GenerateProgramException()
+{
+  PowerPC::ppcState.Exceptions |= EXCEPTION_PROGRAM;
+}

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -9,6 +9,7 @@
 #include "Common/Swap.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/PowerPC/Interpreter/ExceptionUtils.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/JitInterface.h"
@@ -17,26 +18,6 @@
 
 bool Interpreter::m_reserve;
 u32 Interpreter::m_reserve_address;
-
-namespace
-{
-void GenerateAlignmentException(u32 address)
-{
-  PowerPC::ppcState.Exceptions |= EXCEPTION_ALIGNMENT;
-  PowerPC::ppcState.spr[SPR_DAR] = address;
-}
-
-void GenerateDSIException(u32 address)
-{
-  PowerPC::ppcState.Exceptions |= EXCEPTION_DSI;
-  PowerPC::ppcState.spr[SPR_DAR] = address;
-}
-
-void GenerateProgramException()
-{
-  PowerPC::ppcState.Exceptions |= EXCEPTION_PROGRAM;
-}
-}
 
 u32 Interpreter::Helper_Get_EA(const UGeckoInstruction inst)
 {

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -12,6 +12,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/PowerPC/Interpreter/ExceptionUtils.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -198,7 +199,7 @@ void Interpreter::mfspr(UGeckoInstruction inst)
   if (MSR.PR && index != SPR_XER && index != SPR_LR && index != SPR_CTR && index != SPR_TL &&
       index != SPR_TU)
   {
-    PowerPC::ppcState.Exceptions |= EXCEPTION_PROGRAM;
+    GenerateProgramException();
     return;
   }
 
@@ -245,7 +246,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
   // XER, LR, and CTR are the only ones available to be written to in user mode
   if (MSR.PR && index != SPR_XER && index != SPR_LR && index != SPR_CTR)
   {
-    PowerPC::ppcState.Exceptions |= EXCEPTION_PROGRAM;
+    GenerateProgramException();
     return;
   }
 


### PR DESCRIPTION
Keeps all of the interpreter-specific exception handling functions together in a reusable way across translation units, similar to FPUtils.h for reusable floating-point functions