### PR TITLE
IOSC: Remove some hardcoded offsets and magic numbers

### DIFF
--- a/Source/Core/Common/Crypto/ec.cpp
+++ b/Source/Core/Common/Crypto/ec.cpp
@@ -241,7 +241,7 @@ static void silly_random(u8* rndArea, u8 count)
   }
 }
 
-std::array<u8, 60> Sign(const u8* key, const u8* hash)
+Signature Sign(const u8* key, const u8* hash)
 {
   u8 e[30]{};
   memcpy(e + 10, hash, 20);
@@ -272,7 +272,7 @@ std::array<u8, 60> Sign(const u8* key, const u8* hash)
   bn_inv(minv, m, ec_N, sizeof(minv));
   bn_mul(s.data.data(), minv, kk, ec_N, 30);
 
-  std::array<u8, 60> signature;
+  Signature signature;
   std::copy(r.data.cbegin(), r.data.cend(), signature.begin());
   std::copy(s.data.cbegin(), s.data.cend(), signature.begin() + 30);
   return signature;
@@ -300,10 +300,10 @@ bool VerifySignature(const u8* public_key, const u8* signature, const u8* hash)
   return (bn_compare(rx.data(), R, 30) == 0);
 }
 
-std::array<u8, 60> PrivToPub(const u8* key)
+PublicKey PrivToPub(const u8* key)
 {
   const Point data = key * ec_G;
-  std::array<u8, 60> result;
+  PublicKey result;
   std::copy_n(data.Data(), result.size(), result.begin());
   return result;
 }

--- a/Source/Core/Common/Crypto/ec.h
+++ b/Source/Core/Common/Crypto/ec.h
@@ -10,8 +10,11 @@
 
 namespace Common::ec
 {
+using Signature = std::array<u8, 60>;
+using PublicKey = std::array<u8, 60>;
+
 /// Generate a signature using ECDSA.
-std::array<u8, 60> Sign(const u8* key, const u8* hash);
+Signature Sign(const u8* key, const u8* hash);
 
 /// Check a signature using ECDSA.
 ///
@@ -24,5 +27,5 @@ bool VerifySignature(const u8* public_key, const u8* signature, const u8* hash);
 std::array<u8, 60> ComputeSharedSecret(const u8* private_key, const u8* public_key);
 
 /// Convert a ECC private key (30 bytes) to a public key (60 bytes).
-std::array<u8, 60> PrivToPub(const u8* key);
+PublicKey PrivToPub(const u8* key);
 }  // namespace Common::ec

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -455,7 +455,7 @@ void WiiSave::do_sig()
 
   // Sign the data.
   IOS::CertECC ap_cert;
-  IOS::ECCSignature ap_sig;
+  Common::ec::Signature ap_sig;
   m_ios.GetIOSC().Sign(ap_sig.data(), reinterpret_cast<u8*>(&ap_cert), Titles::SYSTEM_MENU,
                        data.get(), data_size);
 

--- a/Source/Core/Core/HW/WiiSave.cpp
+++ b/Source/Core/Core/HW/WiiSave.cpp
@@ -454,9 +454,10 @@ void WiiSave::do_sig()
   }
 
   // Sign the data.
-  IOS::Certificate ap_cert;
+  IOS::CertECC ap_cert;
   IOS::ECCSignature ap_sig;
-  m_ios.GetIOSC().Sign(ap_sig.data(), ap_cert.data(), Titles::SYSTEM_MENU, data.get(), data_size);
+  m_ios.GetIOSC().Sign(ap_sig.data(), reinterpret_cast<u8*>(&ap_cert), Titles::SYSTEM_MENU,
+                       data.get(), data_size);
 
   // Write signatures.
   data_file.Open(m_encrypted_save_path, "ab");
@@ -469,9 +470,9 @@ void WiiSave::do_sig()
   data_file.WriteArray(ap_sig.data(), ap_sig.size());
   const u32 SIGNATURE_END_MAGIC = Common::swap32(0x2f536969);
   data_file.WriteArray(&SIGNATURE_END_MAGIC, 1);
-  const IOS::Certificate device_certificate = m_ios.GetIOSC().GetDeviceCertificate();
-  data_file.WriteArray(device_certificate.data(), device_certificate.size());
-  data_file.WriteArray(ap_cert.data(), ap_cert.size());
+  const IOS::CertECC device_certificate = m_ios.GetIOSC().GetDeviceCertificate();
+  data_file.WriteArray(&device_certificate, 1);
+  data_file.WriteArray(&ap_cert, 1);
 
   m_valid = data_file.IsGood();
 }

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -8,12 +8,14 @@
 
 #include <mbedtls/sha1.h>
 
+#include "Common/Crypto/ec.h"
 #include "Common/Logging/Log.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
 
 namespace IOS
@@ -197,7 +199,7 @@ IPCCommandResult ES::VerifySign(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
     return GetDefaultReply(ES_EINVAL);
-  if (request.in_vectors[1].size != sizeof(IOS::ECCSignature))
+  if (request.in_vectors[1].size != sizeof(Common::ec::Signature))
     return GetDefaultReply(ES_EINVAL);
 
   std::vector<u8> hash(request.in_vectors[0].size);

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -96,8 +96,8 @@ IPCCommandResult ES::GetDeviceCertificate(const IOCtlVRequest& request)
 
   INFO_LOG(IOS_ES, "IOCTL_ES_GETDEVICECERT");
 
-  const auto cert = m_ios.GetIOSC().GetDeviceCertificate();
-  Memory::CopyToEmu(request.io_vectors[0].address, cert.data(), cert.size());
+  const IOS::CertECC cert = m_ios.GetIOSC().GetDeviceCertificate();
+  Memory::CopyToEmu(request.io_vectors[0].address, &cert, sizeof(cert));
   return GetDefaultReply(IPC_SUCCESS);
 }
 

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -70,10 +70,10 @@ struct BootMiiKeyDump
   u32 unk2;                         // 0x17C
   std::array<u8, 0x80> eeprom_pad;  // 0x180
 
-  u32 ms_id;                 // 0x200
-  u32 ca_id;                 // 0x204
-  u32 ng_key_id;             // 0x208
-  IOS::ECCSignature ng_sig;  // 0x20c
+  u32 ms_id;                     // 0x200
+  u32 ca_id;                     // 0x204
+  u32 ng_key_id;                 // 0x208
+  Common::ec::Signature ng_sig;  // 0x20c
   struct Counter
   {
     u8 boot2version;
@@ -108,7 +108,7 @@ constexpr std::array<u8, 30> DEFAULT_PRIVATE_KEY = {{
 }};
 
 // clang-format off
-constexpr ECCSignature DEFAULT_SIGNATURE = {{
+constexpr Common::ec::Signature DEFAULT_SIGNATURE = {{
     // R
     0x00, 0xD8, 0x81, 0x63, 0xB2, 0x00, 0x6B, 0x0B, 0x54, 0x82, 0x88, 0x63, 0x81, 0x1C, 0x00, 0x71,
     0x12, 0xED, 0xB7, 0xFD, 0x21, 0xAB, 0x0E, 0x50, 0x0E, 0x1F, 0xBF, 0x78, 0xAD, 0x37,

--- a/Source/Core/Core/IOS/IOSC.h
+++ b/Source/Core/Core/IOS/IOSC.h
@@ -37,6 +37,8 @@ enum class PublicKeyType : u32
   ECC = 2,
 };
 
+using ECCSignature = std::array<u8, 60>;
+
 #pragma pack(push, 4)
 struct SignatureRSA4096
 {
@@ -59,7 +61,7 @@ static_assert(sizeof(SignatureRSA2048) == 0x180, "Wrong size for SignatureRSA204
 struct SignatureECC
 {
   SignatureType type;
-  u8 sig[0x3c];
+  ECCSignature sig;
   u8 fill[0x40];
   char issuer[0x40];
 };
@@ -116,9 +118,6 @@ struct CertECC
 };
 static_assert(sizeof(CertECC) == 0x180, "Wrong size for CertECC");
 #pragma pack(pop)
-
-using ECCSignature = std::array<u8, 60>;
-using Certificate = std::array<u8, 0x180>;
 
 namespace HLE
 {
@@ -223,7 +222,7 @@ public:
 
   bool IsUsingDefaultId() const;
   u32 GetDeviceId() const;
-  Certificate GetDeviceCertificate() const;
+  CertECC GetDeviceCertificate() const;
   void Sign(u8* sig_out, u8* ap_cert_out, u64 title_id, const u8* data, u32 data_size) const;
 
   void DoState(PointerWrap& p);

--- a/Source/Core/Core/IOS/IOSC.h
+++ b/Source/Core/Core/IOS/IOSC.h
@@ -13,6 +13,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Crypto/AES.h"
+#include "Common/Crypto/ec.h"
 
 class PointerWrap;
 
@@ -37,8 +38,6 @@ enum class PublicKeyType : u32
   ECC = 2,
 };
 
-using ECCSignature = std::array<u8, 60>;
-
 #pragma pack(push, 4)
 struct SignatureRSA4096
 {
@@ -61,7 +60,7 @@ static_assert(sizeof(SignatureRSA2048) == 0x180, "Wrong size for SignatureRSA204
 struct SignatureECC
 {
   SignatureType type;
-  ECCSignature sig;
+  Common::ec::Signature sig;
   u8 fill[0x40];
   char issuer[0x40];
 };
@@ -76,7 +75,6 @@ struct CertHeader
 };
 
 using RSA2048PublicKey = std::array<u8, 0x100>;
-using ECCPublicKey = std::array<u8, 60>;
 
 struct CertRSA4096RSA2048
 {
@@ -103,7 +101,7 @@ struct CertRSA2048ECC
 {
   SignatureRSA2048 signature;
   CertHeader header;
-  ECCPublicKey public_key;
+  Common::ec::PublicKey public_key;
   std::array<u8, 60> padding;
 };
 static_assert(sizeof(CertRSA2048ECC) == 0x240, "Wrong size for CertRSA2048ECC");
@@ -113,7 +111,7 @@ struct CertECC
 {
   SignatureECC signature;
   CertHeader header;
-  ECCPublicKey public_key;
+  Common::ec::PublicKey public_key;
   std::array<u8, 60> padding;
 };
 static_assert(sizeof(CertECC) == 0x180, "Wrong size for CertECC");
@@ -267,7 +265,7 @@ private:
 
   KeyEntries m_key_entries;
   KeyEntry m_root_key_entry;
-  ECCSignature m_console_signature{};
+  Common::ec::Signature m_console_signature{};
   // Retail keyblob are issued by CA00000001. Default to 1 even though IOSC actually defaults to 2.
   u32 m_ms_id = 2;
   u32 m_ca_id = 1;


### PR DESCRIPTION
* Get rid of magic numbers for CertECC struct member offsets. This makes it easier to tell what is being written to the struct.

* <s>Remove hardcoded MS and CA IDs (https://github.com/dolphin-emu/dolphin/pull/6895). Re-included here as it's also a change that removes hardcoded values. Also because the commit was on the same branch and removing it would cause conflicts</s>