### PR TITLE
DebugInterface: MemoryPatches methods added

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(common
   Crypto/AES.cpp
   Crypto/bn.cpp
   Crypto/ec.cpp
+  Debug/MemoryPatches.cpp
   Debug/Watches.cpp
   ENetUtil.cpp
   File.cpp

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -60,6 +60,7 @@
     <ClInclude Include="Config\Layer.h" />
     <ClInclude Include="CPUDetect.h" />
     <ClInclude Include="DebugInterface.h" />
+    <ClInclude Include="Debug\MemoryPatches.h" />
     <ClInclude Include="Debug\Watches.h" />
     <ClInclude Include="ENetUtil.h" />
     <ClInclude Include="Event.h" />
@@ -176,6 +177,7 @@
     <ClCompile Include="Config\Config.cpp" />
     <ClCompile Include="Config\ConfigInfo.cpp" />
     <ClCompile Include="Config\Layer.cpp" />
+    <ClCompile Include="Debug\MemoryPatches.cpp" />
     <ClCompile Include="Debug\Watches.cpp" />
     <ClCompile Include="ENetUtil.cpp" />
     <ClCompile Include="File.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -269,6 +269,9 @@
     <ClInclude Include="Debug\Watches.h">
       <Filter>Debug</Filter>
     </ClInclude>
+    <ClInclude Include="Debug\MemoryPatches.h">
+      <Filter>Debug</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDUtils.cpp" />
@@ -292,7 +295,6 @@
     <ClCompile Include="Network.cpp" />
     <ClCompile Include="PcapFile.cpp" />
     <ClCompile Include="Profiler.cpp" />
-    <ClCompile Include="QoSSession.h" />
     <ClCompile Include="SDCardUtil.cpp" />
     <ClCompile Include="SettingsHandler.cpp" />
     <ClCompile Include="StringUtil.cpp" />
@@ -342,6 +344,10 @@
     <ClCompile Include="CompatPatches.cpp" />
     <ClCompile Include="Config\ConfigInfo.cpp" />
     <ClCompile Include="Debug\Watches.cpp">
+      <Filter>Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="QoSSession.cpp" />
+    <ClCompile Include="Debug\MemoryPatches.cpp">
       <Filter>Debug</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Source/Core/Common/Debug/MemoryPatches.cpp
+++ b/Source/Core/Common/Debug/MemoryPatches.cpp
@@ -1,0 +1,99 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Common/Debug/MemoryPatches.h"
+
+#include <algorithm>
+#include <sstream>
+
+namespace Common::Debug
+{
+MemoryPatch::MemoryPatch(u32 address_, std::vector<u8> value_)
+    : address(address_), value(value_), is_enabled(State::Enabled)
+{
+}
+
+MemoryPatch::MemoryPatch(u32 address, u32 value)
+    : MemoryPatch(address, {static_cast<u8>(value >> 24), static_cast<u8>(value >> 16),
+                            static_cast<u8>(value >> 8), static_cast<u8>(value)})
+{
+}
+
+MemoryPatches::MemoryPatches() = default;
+MemoryPatches::~MemoryPatches() = default;
+
+void MemoryPatches::SetPatch(u32 address, u32 value)
+{
+  const std::size_t index = m_patches.size();
+  m_patches.emplace_back(address, value);
+  Patch(index);
+}
+
+void MemoryPatches::SetPatch(u32 address, std::vector<u8> value)
+{
+  const std::size_t index = m_patches.size();
+  m_patches.emplace_back(address, std::move(value));
+  Patch(index);
+}
+
+const std::vector<MemoryPatch>& MemoryPatches::GetPatches() const
+{
+  return m_patches;
+}
+
+void MemoryPatches::UnsetPatch(u32 address)
+{
+  const auto it = std::remove_if(m_patches.begin(), m_patches.end(),
+                                 [address](const auto& patch) { return patch.address == address; });
+
+  if (it == m_patches.end())
+    return;
+
+  const std::size_t size = m_patches.size();
+  std::size_t index = size - std::distance(it, m_patches.end());
+  while (index < size)
+  {
+    DisablePatch(index);
+    ++index;
+  }
+  m_patches.erase(it, m_patches.end());
+}
+
+void MemoryPatches::EnablePatch(std::size_t index)
+{
+  if (m_patches[index].is_enabled == MemoryPatch::State::Enabled)
+    return;
+  m_patches[index].is_enabled = MemoryPatch::State::Enabled;
+  Patch(index);
+}
+
+void MemoryPatches::DisablePatch(std::size_t index)
+{
+  if (m_patches[index].is_enabled == MemoryPatch::State::Disabled)
+    return;
+  m_patches[index].is_enabled = MemoryPatch::State::Disabled;
+  Patch(index);
+}
+
+bool MemoryPatches::HasEnabledPatch(u32 address) const
+{
+  return std::any_of(m_patches.begin(), m_patches.end(), [address](const MemoryPatch& patch) {
+    return patch.address == address && patch.is_enabled == MemoryPatch::State::Enabled;
+  });
+}
+
+void MemoryPatches::RemovePatch(std::size_t index)
+{
+  DisablePatch(index);
+  m_patches.erase(m_patches.begin() + index);
+}
+
+void MemoryPatches::ClearPatches()
+{
+  const std::size_t size = m_patches.size();
+  for (std::size_t index = 0; index < size; ++index)
+    DisablePatch(index);
+  m_patches.clear();
+}
+}  // namespace Common::Debug

--- a/Source/Core/Common/Debug/MemoryPatches.h
+++ b/Source/Core/Common/Debug/MemoryPatches.h
@@ -1,0 +1,52 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+namespace Common::Debug
+{
+struct MemoryPatch
+{
+  enum class State
+  {
+    Enabled,
+    Disabled
+  };
+
+  u32 address;
+  std::vector<u8> value;
+  State is_enabled;
+
+  MemoryPatch(u32 address, std::vector<u8> value);
+  MemoryPatch(u32 address, u32 value);
+};
+
+class MemoryPatches
+{
+public:
+  MemoryPatches();
+  virtual ~MemoryPatches();
+
+  void SetPatch(u32 address, u32 value);
+  void SetPatch(u32 address, std::vector<u8> value);
+  const std::vector<MemoryPatch>& GetPatches() const;
+  void UnsetPatch(u32 address);
+  void EnablePatch(std::size_t index);
+  void DisablePatch(std::size_t index);
+  bool HasEnabledPatch(u32 address) const;
+  void RemovePatch(std::size_t index);
+  void ClearPatches();
+
+protected:
+  virtual void Patch(std::size_t index) = 0;
+
+  std::vector<MemoryPatch> m_patches;
+};
+}  // namespace Common::Debug

--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Debug/MemoryPatches.h"
 #include "Common/Debug/Watches.h"
 
 class DebugInterface
@@ -33,6 +34,17 @@ public:
   virtual void LoadWatchesFromStrings(const std::vector<std::string>& watches) = 0;
   virtual std::vector<std::string> SaveWatchesToStrings() const = 0;
   virtual void ClearWatches() = 0;
+
+  // Memory Patches
+  virtual void SetPatch(u32 address, u32 value) = 0;
+  virtual void SetPatch(u32 address, std::vector<u8> value) = 0;
+  virtual const std::vector<Common::Debug::MemoryPatch>& GetPatches() const = 0;
+  virtual void UnsetPatch(u32 address) = 0;
+  virtual void EnablePatch(std::size_t index) = 0;
+  virtual void DisablePatch(std::size_t index) = 0;
+  virtual bool HasEnabledPatch(u32 address) const = 0;
+  virtual void RemovePatch(std::size_t index) = 0;
+  virtual void ClearPatches() = 0;
 
   virtual std::string Disassemble(unsigned int /*address*/) { return "NODEBUGGER"; }
   virtual std::string GetRawMemoryString(int /*memory*/, unsigned int /*address*/)
@@ -59,7 +71,6 @@ public:
   virtual void SetPC(unsigned int /*address*/) {}
   virtual void Step() {}
   virtual void RunToBreakpoint() {}
-  virtual void Patch(unsigned int /*address*/, unsigned int /*value*/) {}
   virtual int GetColor(unsigned int /*address*/) { return 0xFFFFFFFF; }
   virtual std::string GetDescription(unsigned int /*address*/) = 0;
   virtual void Clear() = 0;

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -9,6 +9,12 @@
 
 #include "Common/DebugInterface.h"
 
+class PPCPatches : public Common::Debug::MemoryPatches
+{
+private:
+  void Patch(std::size_t index) override;
+};
+
 // wrapper between disasm control and Dolphin debugger
 
 class PPCDebugInterface final : public DebugInterface
@@ -30,6 +36,17 @@ public:
   void LoadWatchesFromStrings(const std::vector<std::string>& watches) override;
   std::vector<std::string> SaveWatchesToStrings() const override;
   void ClearWatches() override;
+
+  // Memory Patches
+  void SetPatch(u32 address, u32 value);
+  void SetPatch(u32 address, std::vector<u8> value);
+  const std::vector<Common::Debug::MemoryPatch>& GetPatches() const;
+  void UnsetPatch(u32 address);
+  void EnablePatch(std::size_t index);
+  void DisablePatch(std::size_t index);
+  bool HasEnabledPatch(u32 address) const;
+  void RemovePatch(std::size_t index);
+  void ClearPatches();
 
   std::string Disassemble(unsigned int address) override;
   std::string GetRawMemoryString(int memory, unsigned int address) override;
@@ -57,7 +74,6 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
-  void Patch(unsigned int address, unsigned int value) override;
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
 
@@ -65,4 +81,5 @@ public:
 
 private:
   Common::Debug::Watches m_watches;
+  PPCPatches m_patches;
 };

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -17,6 +17,11 @@ namespace DSP
 {
 namespace LLE
 {
+void DSPPatches::Patch(std::size_t index)
+{
+  PanicAlert("Patch functionality not supported in DSP module.");
+}
+
 std::size_t DSPDebugInterface::SetWatch(u32 address, const std::string& name)
 {
   return m_watches.SetWatch(address, name);
@@ -85,6 +90,51 @@ std::vector<std::string> DSPDebugInterface::SaveWatchesToStrings() const
 void DSPDebugInterface::ClearWatches()
 {
   m_watches.Clear();
+}
+
+void DSPDebugInterface::SetPatch(u32 address, u32 value)
+{
+  m_patches.SetPatch(address, value);
+}
+
+void DSPDebugInterface::SetPatch(u32 address, std::vector<u8> value)
+{
+  m_patches.SetPatch(address, value);
+}
+
+const std::vector<Common::Debug::MemoryPatch>& DSPDebugInterface::GetPatches() const
+{
+  return m_patches.GetPatches();
+}
+
+void DSPDebugInterface::UnsetPatch(u32 address)
+{
+  m_patches.UnsetPatch(address);
+}
+
+void DSPDebugInterface::EnablePatch(std::size_t index)
+{
+  m_patches.EnablePatch(index);
+}
+
+void DSPDebugInterface::DisablePatch(std::size_t index)
+{
+  m_patches.DisablePatch(index);
+}
+
+void DSPDebugInterface::RemovePatch(std::size_t index)
+{
+  m_patches.RemovePatch(index);
+}
+
+bool DSPDebugInterface::HasEnabledPatch(u32 address) const
+{
+  return m_patches.HasEnabledPatch(address);
+}
+
+void DSPDebugInterface::ClearPatches()
+{
+  m_patches.ClearPatches();
 }
 
 std::string DSPDebugInterface::Disassemble(unsigned int address)
@@ -202,11 +252,6 @@ void DSPDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool wri
   PanicAlert("MemCheck functionality not supported in DSP module.");
 }
 
-void DSPDebugInterface::Patch(unsigned int address, unsigned int value)
-{
-  PanicAlert("Patch functionality not supported in DSP module.");
-}
-
 // =======================================================
 // Separate the blocks with colors.
 // -------------
@@ -264,6 +309,7 @@ void DSPDebugInterface::RunToBreakpoint()
 
 void DSPDebugInterface::Clear()
 {
+  ClearPatches();
   ClearWatches();
 }
 }  // namespace LLE

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -14,6 +14,12 @@ namespace DSP
 {
 namespace LLE
 {
+class DSPPatches : public Common::Debug::MemoryPatches
+{
+private:
+  void Patch(std::size_t index) override;
+};
+
 class DSPDebugInterface final : public DebugInterface
 {
 public:
@@ -34,6 +40,17 @@ public:
   std::vector<std::string> SaveWatchesToStrings() const override;
   void ClearWatches() override;
 
+  // Memory Patches
+  void SetPatch(u32 address, u32 value);
+  void SetPatch(u32 address, std::vector<u8> value);
+  const std::vector<Common::Debug::MemoryPatch>& GetPatches() const;
+  void UnsetPatch(u32 address);
+  void EnablePatch(std::size_t index);
+  void DisablePatch(std::size_t index);
+  void RemovePatch(std::size_t index);
+  bool HasEnabledPatch(u32 address) const;
+  void ClearPatches();
+
   std::string Disassemble(unsigned int address) override;
   std::string GetRawMemoryString(int memory, unsigned int address) override;
   int GetInstructionSize(int instruction) override { return 1; }
@@ -53,7 +70,6 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
-  void Patch(unsigned int address, unsigned int value) override;
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
 
@@ -61,6 +77,7 @@ public:
 
 private:
   Common::Debug::Watches m_watches;
+  DSPPatches m_patches;
 };
 }  // namespace LLE
 }  // namespace DSP

--- a/Source/Core/DolphinQt2/CheatsManager.cpp
+++ b/Source/Core/DolphinQt2/CheatsManager.cpp
@@ -549,7 +549,7 @@ void CheatsManager::Update()
       {
         if (m_watch[i].locked)
         {
-          PowerPC::debug_interface.Patch(m_watch[i].address, m_watch[i].locked_value);
+          PowerPC::debug_interface.SetPatch(m_watch[i].address, m_watch[i].locked_value);
         }
 
         switch (m_watch[i].type)

--- a/Source/Core/DolphinQt2/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt2/Debugger/CodeViewWidget.h
@@ -70,14 +70,8 @@ private:
   void OnInsertBLR();
   void OnInsertNOP();
   void OnReplaceInstruction();
+  void OnRestoreInstruction();
 
-  struct ReplStruct
-  {
-    u32 address;
-    u32 old_value;
-  };
-
-  std::vector<ReplStruct> m_repl_list;
   bool m_updating = false;
 
   u32 m_address = 0;

--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -55,13 +55,6 @@ private:
   u32 AddrToBranch(u32 addr);
   void OnResize(wxSizeEvent& event);
 
-  struct BlrStruct  // for IDM_INSERTBLR
-  {
-    u32 address;
-    u32 oldValue;
-  };
-  std::vector<BlrStruct> m_blrList;
-
   static constexpr int LEFT_COL_WIDTH = 16;
 
   DebugInterface* m_debugger;


### PR DESCRIPTION
This PR moves the `blrList` logic from the UI to the `DebugInterface` under the name `MemoryPatches`.

A "Restore instruction" menu item is added to revert "Insert BLR/NOP" and "Replace instruction" actions.

Ready to be reviewed and merged.