### PR TITLE
Qt/FIFOPlayerWindow: Properly reset ranges

### DIFF
--- a/Source/Core/DolphinQt2/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt2/FIFOPlayerWindow.cpp
@@ -215,6 +215,7 @@ void FIFOPlayerWindow::StopRecording()
 void FIFOPlayerWindow::OnEmulationStarted()
 {
   UpdateControls();
+  OnFIFOLoaded();
 }
 
 void FIFOPlayerWindow::OnEmulationStopped()


### PR DESCRIPTION
Fixes a bug where loading ranges works improperly sometimes and breaks the FIFO Player.
.