### PR TITLE
HiresTextures: Do not load compressed textures with unaligned dimensions

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -335,7 +335,7 @@ std::unique_ptr<HiresTexture> HiresTexture::Load(const std::string& base_filenam
     // Try loading DDS textures first, that way we maintain compression of DXT formats.
     // TODO: Reduce the number of open() calls here. We could use one fd.
     Level level;
-    if (!LoadDDSTexture(level, filename_iter->second.path))
+    if (!LoadDDSTexture(level, filename_iter->second.path, mip_level))
     {
       File::IOFile file;
       file.Open(filename_iter->second.path, "rb");

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -49,7 +49,7 @@ private:
   static std::unique_ptr<HiresTexture> Load(const std::string& base_filename, u32 width,
                                             u32 height);
   static bool LoadDDSTexture(HiresTexture* tex, const std::string& filename);
-  static bool LoadDDSTexture(Level& level, const std::string& filename);
+  static bool LoadDDSTexture(Level& level, const std::string& filename, u32 mip_level);
   static bool LoadTexture(Level& level, const std::vector<u8>& buffer);
   static void Prefetch();
 


### PR DESCRIPTION
D3D11 cannot handle block compressed textures where the first mip level is not a multiple of the block size. The simple fix for texture pack authors: leave these textures uncompressed. You can still use a .dds
container.