### PR TITLE
BreakPoints: Make OverlapsMemcheck() a const member function

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -210,7 +210,7 @@ TMemCheck* MemChecks::GetMemCheck(u32 address, size_t size)
   return &*iter;
 }
 
-bool MemChecks::OverlapsMemcheck(u32 address, u32 length)
+bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const
 {
   if (!HasAny())
     return false;

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -81,7 +81,7 @@ public:
 
   // memory breakpoint
   TMemCheck* GetMemCheck(u32 address, size_t size = 1);
-  bool OverlapsMemcheck(u32 address, u32 length);
+  bool OverlapsMemcheck(u32 address, u32 length) const;
   void Remove(u32 address);
 
   void Clear() { m_mem_checks.clear(); }


### PR DESCRIPTION
This doesn't modify class state, it only queries said state.