### PR TITLE
Interpreter/Jit64/JitArm64: Correct negative overflow handling for divw

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -501,18 +501,18 @@ void Interpreter::divwx(UGeckoInstruction inst)
 {
   const s32 a = rGPR[inst.RA];
   const s32 b = rGPR[inst.RB];
-  const bool overflow = b == 0 || ((u32)a == 0x80000000 && b == -1);
+  const bool overflow = b == 0 || (static_cast<u32>(a) == 0x80000000 && b == -1);
 
   if (overflow)
   {
-    if (((u32)a & 0x80000000) && b == 0)
+    if (a < 0)
       rGPR[inst.RD] = UINT32_MAX;
     else
       rGPR[inst.RD] = 0;
   }
   else
   {
-    rGPR[inst.RD] = (u32)(a / b);
+    rGPR[inst.RD] = static_cast<u32>(a / b);
   }
 
   if (inst.OE)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1164,17 +1164,17 @@ void JitArm64::divwx(UGeckoInstruction inst)
   {
     s32 imm_a = gpr.GetImm(a);
     s32 imm_b = gpr.GetImm(b);
-    s32 imm_d;
-    if (imm_b == 0 || ((u32)imm_a == 0x80000000 && imm_b == -1))
+    u32 imm_d;
+    if (imm_b == 0 || (static_cast<u32>(imm_a) == 0x80000000 && imm_b == -1))
     {
-      if (((u32)imm_a & 0x80000000) && imm_b == 0)
-        imm_d = -1;
+      if (imm_a < 0)
+        imm_d = 0xFFFFFFFF;
       else
         imm_d = 0;
     }
     else
     {
-      imm_d = (u32)(imm_a / imm_b);
+      imm_d = static_cast<u32>(imm_a / imm_b);
     }
     gpr.SetImmediate(d, imm_d);
 
@@ -1217,9 +1217,7 @@ void JitArm64::divwx(UGeckoInstruction inst)
     SetJumpTarget(slow1);
     SetJumpTarget(slow2);
 
-    CMP(RB, 0);
-    CCMP(RA, 0, 0, CC_EQ);
-    CSETM(RD, CC_LT);
+    ASR(RD, RA, 31);
 
     SetJumpTarget(done);
 


### PR DESCRIPTION
Previously, given cases such as `0x80000000 / 0xFFFFFFFF` we'd incorrectly set the destination register value to zero. If the dividend is negative, then the destination should be set to `-1` (`0xFFFFFFFF`), however if the dividend is positive, then the destination should be set to `0`.

Note that the 750CL documents state that:

> If an attempt is made to perform either of the divisions -- 0x80000000 / -1 or \<anything\> / 0, then the contents of rD are undefined, as are the contents of the LT, GT, and EQ bits of the CR0 field (if Rc = 1). In this case, if OE = 1 then OV is set.

So this is a particular behavior of the hardware itself.