### PR TITLE
Move Wii FS content init to happen after Boot

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -517,6 +517,12 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
   if (!CBoot::BootUp(std::move(boot)))
     return;
 
+  // Initialise Wii filesystem contents.
+  // This is done here after Boot and not in HW to ensure that we operate
+  // with the correct title context since save copying requires title directories to exist.
+  Common::ScopeGuard wiifs_guard{Core::CleanUpWiiFileSystemContents};
+  Core::InitializeWiiFileSystemContents();
+
   // This adds the SyncGPU handler to CoreTiming, so now CoreTiming::Advance might block.
   Fifo::Prepare();
 

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -54,13 +54,11 @@ void Init()
     Core::InitializeWiiRoot(Core::WantsDeterminism());
     IOS::Init();
     IOS::HLE::Init();  // Depends on Memory
-    Core::InitializeWiiFileSystemContents();
   }
 }
 
 void Shutdown()
 {
-  Core::CleanUpWiiFileSystemContents();
   // IOS should always be shut down regardless of bWii because it can be running in GC mode (MIOS).
   IOS::HLE::Shutdown();  // Depends on Memory
   IOS::Shutdown();


### PR DESCRIPTION
Initialising Wii filesystem contents should be done after Boot and not in HW to ensure that we operate with the correct title context and to make sure required title directories exist (so that Movie and Netplay code can copy data from and to the temporary NAND).

Fixes 'Load Wii data' option being broken in netplay.