### PR TITLE
Qt/RunOnObject: Fix no result being returned

### DIFF
--- a/Source/Core/DolphinQt2/QtUtils/RunOnObject.h
+++ b/Source/Core/DolphinQt2/QtUtils/RunOnObject.h
@@ -46,7 +46,7 @@ auto RunOnObject(QObject* object, F&& functor)
     {
       if (m_obj)
       {
-        (*m_result) = m_func();
+        m_result = m_func();
       }
       else
       {


### PR DESCRIPTION
Causes the updater to be broken and every other thing that relies on the return value of ``RunOnObject`` (Regression caused by #6934).