### PR TITLE
Make the support for unencrypted Wii disc images less broken

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -1142,7 +1142,7 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
   // The variable dvd_offset tracks the actual offset on the DVD
   // that the disc drive starts reading at, which differs in two ways:
   // It's rounded to a whole ECC block and never uses Wii partition addressing.
-  u64 dvd_offset = DiscIO::VolumeWii::PartitionOffsetToRawOffset(offset, partition);
+  u64 dvd_offset = DVDThread::PartitionOffsetToRawOffset(offset, partition);
   dvd_offset = Common::AlignDown(dvd_offset, DVD_ECC_BLOCK_SIZE);
 
   if (SConfig::GetInstance().bFastDiscSpeed)
@@ -1209,7 +1209,9 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
   u32 unbuffered_blocks = 0;
 
   const u32 bytes_per_chunk =
-      partition == DiscIO::PARTITION_NONE ? DVD_ECC_BLOCK_SIZE : DiscIO::VolumeWii::BLOCK_DATA_SIZE;
+      partition != DiscIO::PARTITION_NONE && DVDThread::IsEncryptedAndHashed() ?
+          DiscIO::VolumeWii::BLOCK_DATA_SIZE :
+          DVD_ECC_BLOCK_SIZE;
 
   do
   {

--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -186,10 +186,22 @@ bool HasDisc()
   return s_disc != nullptr;
 }
 
+bool IsEncryptedAndHashed()
+{
+  // IsEncryptedAndHashed is thread-safe, so calling WaitUntilIdle isn't necessary.
+  return s_disc->IsEncryptedAndHashed();
+}
+
 DiscIO::Platform GetDiscType()
 {
   // GetVolumeType is thread-safe, so calling WaitUntilIdle isn't necessary.
   return s_disc->GetVolumeType();
+}
+
+u64 PartitionOffsetToRawOffset(u64 offset, const DiscIO::Partition& partition)
+{
+  // PartitionOffsetToRawOffset is thread-safe, so calling WaitUntilIdle isn't necessary.
+  return s_disc->PartitionOffsetToRawOffset(offset, partition);
 }
 
 IOS::ES::TMDReader GetTMD(const DiscIO::Partition& partition)

--- a/Source/Core/Core/HW/DVD/DVDThread.h
+++ b/Source/Core/Core/HW/DVD/DVDThread.h
@@ -42,7 +42,9 @@ void DoState(PointerWrap& p);
 void SetDisc(std::unique_ptr<DiscIO::Volume> disc);
 bool HasDisc();
 
+bool IsEncryptedAndHashed();
 DiscIO::Platform GetDiscType();
+u64 PartitionOffsetToRawOffset(u64 offset, const DiscIO::Partition& partition);
 IOS::ES::TMDReader GetTMD(const DiscIO::Partition& partition);
 IOS::ES::TicketReader GetTicket(const DiscIO::Partition& partition);
 // This function returns true and calls SConfig::SetRunningGameMetadata(Volume&, Partition&)

--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -361,7 +361,8 @@ bool ExportSystemData(const Volume& volume, const Partition& partition,
     success &= ExportTicket(volume, partition, export_folder + "/ticket.bin");
     success &= ExportTMD(volume, partition, export_folder + "/tmd.bin");
     success &= ExportCertificateChain(volume, partition, export_folder + "/cert.bin");
-    success &= ExportH3Hashes(volume, partition, export_folder + "/h3.bin");
+    if (volume.IsEncryptedAndHashed())
+      success &= ExportH3Hashes(volume, partition, export_folder + "/h3.bin");
   }
 
   return success;

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -58,6 +58,7 @@ public:
     return temp ? static_cast<u64>(*temp) << GetOffsetShift() : std::optional<u64>();
   }
 
+  virtual bool IsEncryptedAndHashed() const { return false; }
   virtual std::vector<Partition> GetPartitions() const { return {}; }
   virtual Partition GetGamePartition() const { return PARTITION_NONE; }
   virtual std::optional<u32> GetPartitionType(const Partition& partition) const { return {}; }
@@ -70,6 +71,10 @@ public:
   virtual const IOS::ES::TMDReader& GetTMD(const Partition& partition) const { return INVALID_TMD; }
   // Returns a non-owning pointer. Returns nullptr if the file system couldn't be read.
   virtual const FileSystem* GetFileSystem(const Partition& partition) const = 0;
+  virtual u64 PartitionOffsetToRawOffset(u64 offset, const Partition& partition) const
+  {
+    return offset;
+  }
   std::string GetGameID() const { return GetGameID(GetGamePartition()); }
   virtual std::string GetGameID(const Partition& partition) const = 0;
   std::string GetMakerID() const { return GetMakerID(GetGamePartition()); }

--- a/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/FilesystemWidget.cpp
@@ -219,9 +219,12 @@ void FilesystemWidget::ShowContextMenu(const QPoint&)
       if (!folder.isEmpty())
         ExtractPartition(partition, folder);
     });
-    menu->addSeparator();
-    AddAction(menu, tr("Check Partition Integrity"), this,
-              [this, partition] { CheckIntegrity(partition); });
+    if (m_volume->IsEncryptedAndHashed())
+    {
+      menu->addSeparator();
+      AddAction(menu, tr("Check Partition Integrity"), this,
+                [this, partition] { CheckIntegrity(partition); });
+    }
     break;
   case EntryType::File:
     AddAction(menu, tr("Extract File..."), this, [this, partition, path] {

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
@@ -204,7 +204,7 @@ void FilesystemPanel::OnRightClickTree(wxTreeEvent& event)
     else
       menu.Append(ID_EXTRACT_ALL, _("Extract Entire Partition..."));
 
-    if (first_visible_item != selection)
+    if (first_visible_item != selection && m_opened_iso->IsEncryptedAndHashed())
     {
       menu.AppendSeparator();
       menu.Append(ID_CHECK_INTEGRITY, _("Check Partition Integrity"));


### PR DESCRIPTION
These disc images are only used on dev units and not retail units. There are two important differences compared to normal Wii disc images:

- The data starts 0x8000 bytes into each partition instead of 0x20000
- The data of a partition is stored unencrypted and contains no hashes

Our old implementation was just guesswork and doesn't work at all. According to testing by @GerbilSoft, this PR's implementation is able to read and extract files in the filesystem correctly, but the tested game still isn't able to boot. (It's thanks to their info about unencrypted disc images that I was able to make this PR.)