### PR TITLE
Remove useless BootManager::Stop

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -390,12 +390,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
   return Core::Init(std::move(boot));
 }
 
-void Stop()
-{
-  Core::Stop();
-  RestoreConfig();
-}
-
 // SYSCONF can be modified during emulation by the user and internally, which makes it
 // a bad idea to just always overwrite it with the settings from the base layer.
 //

--- a/Source/Core/Core/BootManager.h
+++ b/Source/Core/Core/BootManager.h
@@ -15,8 +15,6 @@ namespace BootManager
 {
 bool BootCore(std::unique_ptr<BootParameters> parameters);
 
-// Stop the emulation core and restore the configuration.
-void Stop();
 // Synchronise Dolphin's configuration with the SYSCONF (which may have changed during emulation),
 // and restore settings that were overriden by per-game INIs or for some other reason.
 void RestoreConfig();

--- a/Source/Core/DolphinQt2/Main.cpp
+++ b/Source/Core/DolphinQt2/Main.cpp
@@ -220,7 +220,6 @@ int main(int argc, char* argv[])
     retval = app.exec();
   }
 
-  BootManager::Stop();
   Core::Shutdown();
   UICommon::Shutdown();
   Host::GetInstance()->deleteLater();


### PR DESCRIPTION
It's not used anywhere other than in DolphinQt2, where the usage is
incorrect and stupid since we shouldn't be trying to stop the core
and 'restore config' that was changed by the core at app exit time,
but immediately when the core is being shut down.