### PR TITLE
Port FS, SD and dump path to onion config

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -62,12 +62,14 @@ void Load()
 {
   for (auto& layer : s_layers)
     layer.second->Load();
+  InvokeConfigChangedCallbacks();
 }
 
 void Save()
 {
   for (auto& layer : s_layers)
     layer.second->Save();
+  InvokeConfigChangedCallbacks();
 }
 
 void Init()

--- a/Source/Core/Common/Config/Layer.cpp
+++ b/Source/Core/Common/Config/Layer.cpp
@@ -115,7 +115,6 @@ void Layer::Load()
   if (m_loader)
     m_loader->Load(this);
   m_is_dirty = false;
-  InvokeConfigChangedCallbacks();
 }
 
 void Layer::Save()
@@ -125,7 +124,6 @@ void Layer::Save()
 
   m_loader->Save(this);
   m_is_dirty = false;
-  InvokeConfigChangedCallbacks();
 }
 
 LayerType Layer::GetLayer() const

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -106,4 +106,10 @@ const ConfigInfo<std::string> MAIN_AUDIO_BACKEND{{System::Main, "DSP", "Backend"
                                                  AudioCommon::GetDefaultSoundBackend()};
 const ConfigInfo<int> MAIN_AUDIO_VOLUME{{System::Main, "DSP", "Volume"}, 100};
 
+// Main.General
+
+const ConfigInfo<std::string> MAIN_DUMP_PATH{{System::Main, "General", "DumpPath"}, ""};
+const ConfigInfo<std::string> MAIN_FS_PATH{{System::Main, "General", "NANDRootPath"}, ""};
+const ConfigInfo<std::string> MAIN_SD_PATH{{System::Main, "General", "WiiSDCardPath"}, ""};
+
 }  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -78,4 +78,10 @@ extern const ConfigInfo<bool> MAIN_DUMP_UCODE;
 extern const ConfigInfo<std::string> MAIN_AUDIO_BACKEND;
 extern const ConfigInfo<int> MAIN_AUDIO_VOLUME;
 
+// Main.General
+
+extern const ConfigInfo<std::string> MAIN_DUMP_PATH;
+extern const ConfigInfo<std::string> MAIN_FS_PATH;
+extern const ConfigInfo<std::string> MAIN_SD_PATH;
+
 }  // namespace Config

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -98,21 +98,6 @@ void SConfig::SaveSettings()
   Config::Save();
 }
 
-namespace
-{
-void CreateDumpPath(const std::string& path)
-{
-  if (path.empty())
-    return;
-  File::SetUserPath(D_DUMP_IDX, path + '/');
-  File::CreateFullPath(File::GetUserPath(D_DUMPAUDIO_IDX));
-  File::CreateFullPath(File::GetUserPath(D_DUMPDSP_IDX));
-  File::CreateFullPath(File::GetUserPath(D_DUMPSSL_IDX));
-  File::CreateFullPath(File::GetUserPath(D_DUMPFRAMES_IDX));
-  File::CreateFullPath(File::GetUserPath(D_DUMPTEXTURES_IDX));
-}
-}  // namespace
-
 void SConfig::SaveGeneralSettings(IniFile& ini)
 {
   IniFile::Section* general = ini.GetOrCreateSection("General");
@@ -138,11 +123,7 @@ void SConfig::SaveGeneralSettings(IniFile& ini)
   }
 
   general->Set("RecursiveISOPaths", m_RecursiveISOFolder);
-  general->Set("NANDRootPath", m_NANDPath);
-  general->Set("DumpPath", m_DumpPath);
-  CreateDumpPath(m_DumpPath);
   general->Set("WirelessMac", m_WirelessMac);
-  general->Set("WiiSDCardPath", m_strWiiSDCardPath);
 
 #ifdef USE_GDBSTUB
 #ifndef _WIN32
@@ -430,13 +411,7 @@ void SConfig::LoadGeneralSettings(IniFile& ini)
   }
 
   general->Get("RecursiveISOPaths", &m_RecursiveISOFolder, false);
-  general->Get("NANDRootPath", &m_NANDPath);
-  File::SetUserPath(D_WIIROOT_IDX, m_NANDPath);
-  general->Get("DumpPath", &m_DumpPath);
-  CreateDumpPath(m_DumpPath);
   general->Get("WirelessMac", &m_WirelessMac);
-  general->Get("WiiSDCardPath", &m_strWiiSDCardPath, File::GetUserPath(F_WIISDCARD_IDX));
-  File::SetUserPath(F_WIISDCARD_IDX, m_strWiiSDCardPath);
 }
 
 void SConfig::LoadInterfaceSettings(IniFile& ini)
@@ -799,7 +774,6 @@ void SConfig::LoadDefaults()
   iBBDumpPort = -1;
   bSyncGPU = false;
   bFastDiscSpeed = false;
-  m_strWiiSDCardPath = File::GetUserPath(F_WIISDCARD_IDX);
   bEnableMemcardSdWriting = true;
   SelectedLanguage = 0;
   bOverrideGCLanguage = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -185,7 +185,6 @@ struct SConfig
   std::string m_strBootROM;
   std::string m_strSRAM;
   std::string m_strDefaultISO;
-  std::string m_strWiiSDCardPath;
 
   std::string m_perfDir;
 
@@ -218,9 +217,6 @@ struct SConfig
   static IniFile LoadDefaultGameIni(const std::string& id, std::optional<u16> revision);
   static IniFile LoadLocalGameIni(const std::string& id, std::optional<u16> revision);
   static IniFile LoadGameIni(const std::string& id, std::optional<u16> revision);
-
-  std::string m_NANDPath;
-  std::string m_DumpPath;
 
   std::string m_strMemoryCardA;
   std::string m_strMemoryCardB;

--- a/Source/Core/DolphinQt2/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/PathPane.cpp
@@ -12,7 +12,8 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-#include "Common/FileUtil.h"
+#include "Common/Config/Config.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt2/Settings.h"
@@ -55,7 +56,7 @@ void PathPane::BrowseDefaultGame()
 void PathPane::BrowseWiiNAND()
 {
   QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
-      this, tr("Select Wii NAND Root"), QString::fromStdString(SConfig::GetInstance().m_NANDPath)));
+      this, tr("Select Wii NAND Root"), QString::fromStdString(Config::Get(Config::MAIN_FS_PATH))));
   if (!dir.isEmpty())
   {
     m_nand_edit->setText(dir);
@@ -65,21 +66,19 @@ void PathPane::BrowseWiiNAND()
 
 void PathPane::BrowseDump()
 {
-  auto& dump_path = SConfig::GetInstance().m_DumpPath;
   QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
-      this, tr("Select Dump Path"), QString::fromStdString(dump_path)));
+      this, tr("Select Dump Path"), QString::fromStdString(Config::Get(Config::MAIN_DUMP_PATH))));
   if (!dir.isEmpty())
   {
     m_dump_edit->setText(dir);
-    dump_path = dir.toStdString();
+    Config::SetBase(Config::MAIN_DUMP_PATH, dir.toStdString());
   }
 }
 
 void PathPane::BrowseSDCard()
 {
   QString file = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
-      this, tr("Select a SD Card Image"),
-      QString::fromStdString(SConfig::GetInstance().m_strWiiSDCardPath),
+      this, tr("Select a SD Card Image"), QString::fromStdString(Config::Get(Config::MAIN_SD_PATH)),
       tr("SD Card Image (*.raw);;"
          "All Files (*)")));
   if (!file.isEmpty())
@@ -91,18 +90,12 @@ void PathPane::BrowseSDCard()
 
 void PathPane::OnSDCardPathChanged()
 {
-  const auto sd_card_path = m_sdcard_edit->text().toStdString();
-
-  SConfig::GetInstance().m_strWiiSDCardPath = sd_card_path;
-  File::SetUserPath(F_WIISDCARD_IDX, sd_card_path);
+  Config::SetBase(Config::MAIN_SD_PATH, m_sdcard_edit->text().toStdString());
 }
 
 void PathPane::OnNANDPathChanged()
 {
-  const auto nand_path = m_nand_edit->text().toStdString();
-
-  SConfig::GetInstance().m_NANDPath = nand_path;
-  File::SetUserPath(D_WIIROOT_IDX, nand_path);
+  Config::SetBase(Config::MAIN_FS_PATH, m_nand_edit->text().toStdString());
 }
 
 QGroupBox* PathPane::MakeGameFolderBox()
@@ -170,7 +163,7 @@ QGridLayout* PathPane::MakePathsLayout()
   layout->addWidget(m_game_edit, 0, 1);
   layout->addWidget(game_open, 0, 2);
 
-  m_nand_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_NANDPath));
+  m_nand_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_FS_PATH)));
   connect(m_nand_edit, &QLineEdit::editingFinished, this, &PathPane::OnNANDPathChanged);
   QPushButton* nand_open = new QPushButton(QStringLiteral("..."));
   connect(nand_open, &QPushButton::pressed, this, &PathPane::BrowseWiiNAND);
@@ -178,16 +171,16 @@ QGridLayout* PathPane::MakePathsLayout()
   layout->addWidget(m_nand_edit, 1, 1);
   layout->addWidget(nand_open, 1, 2);
 
-  m_dump_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_DumpPath));
+  m_dump_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_DUMP_PATH)));
   connect(m_dump_edit, &QLineEdit::editingFinished,
-          [=] { SConfig::GetInstance().m_DumpPath = m_dump_edit->text().toStdString(); });
+          [=] { Config::SetBase(Config::MAIN_DUMP_PATH, m_dump_edit->text().toStdString()); });
   QPushButton* dump_open = new QPushButton(QStringLiteral("..."));
   connect(dump_open, &QPushButton::pressed, this, &PathPane::BrowseDump);
   layout->addWidget(new QLabel(tr("Dump Path:")), 2, 0);
   layout->addWidget(m_dump_edit, 2, 1);
   layout->addWidget(dump_open, 2, 2);
 
-  m_sdcard_edit = new QLineEdit(QString::fromStdString(SConfig::GetInstance().m_strWiiSDCardPath));
+  m_sdcard_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_SD_PATH)));
   connect(m_sdcard_edit, &QLineEdit::editingFinished, this, &PathPane::OnSDCardPathChanged);
   QPushButton* sdcard_open = new QPushButton(QStringLiteral("..."));
   connect(sdcard_open, &QPushButton::pressed, this, &PathPane::BrowseSDCard);

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -15,7 +15,8 @@
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
-#include "Common/FileUtil.h"
+#include "Common/Config/Config.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DolphinWX/Config/ConfigMain.h"
@@ -101,9 +102,9 @@ void PathConfigPane::LoadGUIValues()
 
   m_recursive_iso_paths_checkbox->SetValue(SConfig::GetInstance().m_RecursiveISOFolder);
   m_default_iso_filepicker->SetPath(StrToWxStr(startup_params.m_strDefaultISO));
-  m_nand_root_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_NANDPath));
-  m_dump_path_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_DumpPath));
-  m_wii_sdcard_filepicker->SetPath(StrToWxStr(SConfig::GetInstance().m_strWiiSDCardPath));
+  m_nand_root_dirpicker->SetPath(StrToWxStr(Config::Get(Config::MAIN_FS_PATH)));
+  m_dump_path_dirpicker->SetPath(StrToWxStr(Config::Get(Config::MAIN_DUMP_PATH)));
+  m_wii_sdcard_filepicker->SetPath(StrToWxStr(Config::Get(Config::MAIN_SD_PATH)));
 
   // Update selected ISO paths
   for (const std::string& folder : SConfig::GetInstance().m_ISOFolder)
@@ -188,18 +189,12 @@ void PathConfigPane::OnDefaultISOChanged(wxCommandEvent& event)
 
 void PathConfigPane::OnSdCardPathChanged(wxCommandEvent& event)
 {
-  std::string sd_card_path = WxStrToStr(m_wii_sdcard_filepicker->GetPath());
-  SConfig::GetInstance().m_strWiiSDCardPath = sd_card_path;
-  File::SetUserPath(F_WIISDCARD_IDX, sd_card_path);
+  Config::SetBase(Config::MAIN_SD_PATH, WxStrToStr(m_wii_sdcard_filepicker->GetPath()));
 }
 
 void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)
 {
-  std::string nand_path = SConfig::GetInstance().m_NANDPath =
-      WxStrToStr(m_nand_root_dirpicker->GetPath());
-
-  File::SetUserPath(D_WIIROOT_IDX, nand_path);
-  m_nand_root_dirpicker->SetPath(StrToWxStr(nand_path));
+  Config::SetBase(Config::MAIN_FS_PATH, WxStrToStr(m_nand_root_dirpicker->GetPath()));
 
   wxCommandEvent update_event{DOLPHIN_EVT_UPDATE_LOAD_WII_MENU_ITEM, GetId()};
   update_event.SetEventObject(this);
@@ -208,10 +203,7 @@ void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)
 
 void PathConfigPane::OnDumpPathChanged(wxCommandEvent& event)
 {
-  std::string dump_path = SConfig::GetInstance().m_DumpPath =
-      WxStrToStr(m_dump_path_dirpicker->GetPath());
-
-  m_dump_path_dirpicker->SetPath(StrToWxStr(dump_path));
+  Config::SetBase(Config::MAIN_DUMP_PATH, WxStrToStr(m_dump_path_dirpicker->GetPath()));
 }
 
 void PathConfigPane::SaveISOPathChanges()

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -22,6 +22,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigLoaders/BaseConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -47,9 +48,31 @@
 
 namespace UICommon
 {
+static void CreateDumpPath(const std::string& path)
+{
+  if (path.empty())
+    return;
+  File::SetUserPath(D_DUMP_IDX, path + '/');
+  File::CreateFullPath(File::GetUserPath(D_DUMPAUDIO_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DUMPDSP_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DUMPSSL_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DUMPFRAMES_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DUMPTEXTURES_IDX));
+}
+
+static void InitCustomPaths()
+{
+  File::SetUserPath(D_WIIROOT_IDX, Config::Get(Config::MAIN_FS_PATH));
+  CreateDumpPath(Config::Get(Config::MAIN_DUMP_PATH));
+  const std::string sd_path = Config::Get(Config::MAIN_SD_PATH);
+  if (!sd_path.empty())
+    File::SetUserPath(F_WIISDCARD_IDX, sd_path);
+}
+
 void Init()
 {
   Config::Init();
+  Config::AddConfigChangedCallback(InitCustomPaths);
   Config::AddLayer(ConfigLoaders::GenerateBaseConfigLoader());
   SConfig::Init();
   LogManager::Init();


### PR DESCRIPTION
This ports the Wii filesystem root, Wii SD card path and dump path settings to the new config system (OnionConfig).

My initial plan was to wait until DolphinWX was removed before porting most of the Main (Core, DSP, General) settings to onion config, but I've decided to submit a small part of those changes to fix [issue 10566](https://bugs.dolphin-emu.org/issues/10566).

Removes the need to manually set the FileUtil path in the UI frontends and gets rid of some more members that don't really belong in SConfig.

Also fixes a bug which would cause the dump path not to get created after change.