### PR TITLE
Qt/MappingButton: Fix window becoming unresponsive after mapping

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/MappingButton.cpp
@@ -104,7 +104,6 @@ void MappingButton::Detect()
 
   installEventFilter(BlockUserInputFilter::Instance());
   grabKeyboard();
-  grabMouse();
 
   // Make sure that we don't block event handling
   std::thread thread([this] {
@@ -118,7 +117,6 @@ void MappingButton::Detect()
     const auto expr = MappingCommon::DetectExpression(
         m_reference, dev.get(), m_parent->GetController()->GetDefaultDevice());
 
-    releaseMouse();
     releaseKeyboard();
     removeEventFilter(BlockUserInputFilter::Instance());
 


### PR DESCRIPTION
Fixes issues like
* Not being able to close the window
* Not being able to move the window

Fixing this is at the cost of no longer grabbing the mouse which is a pretty small cost considering it works just fine without it and I couldn't find any issues caused by removing it.