### PR TITLE
Interpreter_FPUtils: Set the FPSCR.VX bit if any invalid operation exception bits are set

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -31,7 +31,9 @@ inline void SetFPException(u32 mask)
   {
     FPSCR.FX = 1;
   }
+
   FPSCR.Hex |= mask;
+  FPSCR.VX = (FPSCR.Hex & FPSCR_VX_ANY) != 0;
 }
 
 inline void SetFI(int FI)


### PR DESCRIPTION
The VX bit is intended to be a summary bit indicating the occurrence of any kind of invalid operation. Therefore, whenever an invalid operation exception is set, also set VX.

This corrects our CR flag setting for multiple instructions in certain scenarios. This corrects flag setting cases in fadd, fadds, fctiw, fctiwz, fdiv, frsp, frsqrte, fsub, and fsubs (and technically every floating-point instruction that we make more accurate in the future with regards to flag setting).