### PR TITLE
Interpreter_FloatingPoint: Handle SNaN flag setting in frsqrte

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -410,19 +410,29 @@ void Interpreter::fresx(UGeckoInstruction inst)
 
 void Interpreter::frsqrtex(UGeckoInstruction inst)
 {
-  double b = rPS0(inst.FB);
+  const double b = rPS0(inst.FB);
+  const double result = Common::ApproximateReciprocalSquareRoot(b);
 
   if (b < 0.0)
   {
     SetFPException(FPSCR_VXSQRT);
+
+    if (FPSCR.VE == 0)
+      PowerPC::UpdateFPRF(result);
   }
   else if (b == 0.0)
   {
     SetFPException(FPSCR_ZX);
+
+    if (FPSCR.ZE == 0)
+      PowerPC::UpdateFPRF(result);
+  }
+  else
+  {
+    PowerPC::UpdateFPRF(result);
   }
 
-  rPS0(inst.FD) = Common::ApproximateReciprocalSquareRoot(b);
-  PowerPC::UpdateFPRF(rPS0(inst.FD));
+  rPS0(inst.FD) = result;
 
   if (inst.Rc)
     Helper_UpdateCR1();

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -427,6 +427,13 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
     if (FPSCR.ZE == 0)
       PowerPC::UpdateFPRF(result);
   }
+  else if (Common::IsSNAN(b))
+  {
+    SetFPException(FPSCR_VXSNAN);
+
+    if (FPSCR.VE == 0)
+      PowerPC::UpdateFPRF(result);
+  }
   else
   {
     PowerPC::UpdateFPRF(result);


### PR DESCRIPTION
Corrects our flag handling for frsqrte, and also handles cases where we shouldn't be updating the FPRF flags. This in conjunction with #6956 corrects the flag setting across the board for frsqrte (as we'll also correctly set the FPSCR.VX bit).