### PR TITLE
D3D: Don't emit uint outputs when logic op is unsupported

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -414,7 +414,10 @@ HRESULT Create(HWND wnd)
 
   hr = device->QueryInterface<ID3D11Device1>(&device1);
   if (FAILED(hr))
+  {
     WARN_LOG(VIDEO, "Missing Direct3D 11.1 support. Logical operations will not be supported.");
+    g_Config.backend_info.bSupportsLogicOp = false;
+  }
 
   // BGRA textures are easier to deal with in TextureCache, but might not be supported
   UINT format_support;

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -62,6 +62,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsClipControl = true;
   g_Config.backend_info.bSupportsDepthClamp = true;
   g_Config.backend_info.bSupportsReversedDepthRange = false;
+  g_Config.backend_info.bSupportsLogicOp = true;
   g_Config.backend_info.bSupportsMultithreading = false;
   g_Config.backend_info.bSupportsGPUTextureDecoding = false;
   g_Config.backend_info.bSupportsST3CTextures = false;

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -47,6 +47,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsBPTCTextures = false;
   g_Config.backend_info.bSupportsFramebufferFetch = false;
   g_Config.backend_info.bSupportsBackgroundCompiling = false;
+  g_Config.backend_info.bSupportsLogicOp = false;
 
   // aamodes: We only support 1 sample, so no MSAA
   g_Config.backend_info.Adapters.clear();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -521,6 +521,9 @@ Renderer::Renderer()
     // depth clamping.
     g_Config.backend_info.bSupportsDepthClamp = false;
 
+    // GLES does not support logic op.
+    g_Config.backend_info.bSupportsLogicOp = false;
+
     if (GLExtensions::Supports("GL_EXT_shader_framebuffer_fetch"))
     {
       g_ogl_config.SupportedFramebufferFetch = EsFbFetchType::FbFetchExt;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -83,6 +83,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPostProcessing = true;
   g_Config.backend_info.bSupportsSSAA = true;
   g_Config.backend_info.bSupportsReversedDepthRange = true;
+  g_Config.backend_info.bSupportsLogicOp = true;
   g_Config.backend_info.bSupportsMultithreading = false;
   g_Config.backend_info.bSupportsCopyToVram = true;
 

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -71,6 +71,7 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsCopyToVram = false;
   g_Config.backend_info.bSupportsFramebufferFetch = false;
   g_Config.backend_info.bSupportsBackgroundCompiling = false;
+  g_Config.backend_info.bSupportsLogicOp = true;
 
   // aamodes
   g_Config.backend_info.AAModes = {1};

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -246,6 +246,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsST3CTextures = false;              // Dependent on features.
   config->backend_info.bSupportsBPTCTextures = false;              // Dependent on features.
   config->backend_info.bSupportsReversedDepthRange = false;  // No support yet due to driver bugs.
+  config->backend_info.bSupportsLogicOp = false;             // Dependent on features.
   config->backend_info.bSupportsCopyToVram = true;           // Assumed support.
   config->backend_info.bSupportsFramebufferFetch = false;
 }
@@ -272,6 +273,7 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   config->backend_info.bSupportsBBox = config->backend_info.bSupportsFragmentStoresAndAtomics =
       (features.fragmentStoresAndAtomics == VK_TRUE);
   config->backend_info.bSupportsSSAA = (features.sampleRateShading == VK_TRUE);
+  config->backend_info.bSupportsLogicOp = (features.logicOp == VK_TRUE);
 
   // Disable geometry shader when shaderTessellationAndGeometryPointSize is not supported.
   // Seems this is needed for gl_Layer.

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -344,8 +344,9 @@ void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host
   pixel_shader_uid_data* uid_data = uid->GetUidData<pixel_shader_uid_data>();
 
   // OpenGL and Vulkan convert implicitly normalized color outputs to their uint representation.
-  // Therefore, it is not necessary to use a uint output on these backends.
-  if (ApiType != APIType::D3D)
+  // Therefore, it is not necessary to use a uint output on these backends. We also disable the
+  // uint output when logic op is not supported (i.e. driver/device does not support D3D11.1).
+  if (ApiType != APIType::D3D || !host_config.backend_logic_op)
     uid_data->uint_output = 0;
 }
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -338,7 +338,8 @@ PixelShaderUid GetPixelShaderUid()
   return out;
 }
 
-void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid)
+void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host_config,
+                                   PixelShaderUid* uid)
 {
   pixel_shader_uid_data* uid_data = uid->GetUidData<pixel_shader_uid_data>();
 

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -168,5 +168,6 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
                                    const pixel_shader_uid_data* uid_data);
 void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texgens,
                                   bool per_pixel_lighting, bool bounding_box);
-void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid);
+void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host_config,
+                                   PixelShaderUid* uid);
 PixelShaderUid GetPixelShaderUid();

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -33,6 +33,7 @@ ShaderHostConfig ShaderHostConfig::GetCurrent()
   bits.backend_dynamic_sampler_indexing =
       g_ActiveConfig.backend_info.bSupportsDynamicSamplerIndexing;
   bits.backend_shader_framebuffer_fetch = g_ActiveConfig.backend_info.bSupportsFramebufferFetch;
+  bits.backend_logic_op = g_ActiveConfig.backend_info.bSupportsLogicOp;
   return bits;
 }
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -180,7 +180,8 @@ union ShaderHostConfig
     u32 backend_bitfield : 1;
     u32 backend_dynamic_sampler_indexing : 1;
     u32 backend_shader_framebuffer_fetch : 1;
-    u32 pad : 11;
+    u32 backend_logic_op : 1;
+    u32 pad : 10;
   };
 
   static ShaderHostConfig GetCurrent();

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -29,7 +29,8 @@ PixelShaderUid GetPixelShaderUid()
   return out;
 }
 
-void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid)
+void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host_config,
+                                   PixelShaderUid* uid)
 {
   pixel_ubershader_uid_data* uid_data = uid->GetUidData<pixel_ubershader_uid_data>();
 

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -35,8 +35,9 @@ void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host
   pixel_ubershader_uid_data* uid_data = uid->GetUidData<pixel_ubershader_uid_data>();
 
   // OpenGL and Vulkan convert implicitly normalized color outputs to their uint representation.
-  // Therefore, it is not necessary to use a uint output on these backends.
-  if (ApiType != APIType::D3D)
+  // Therefore, it is not necessary to use a uint output on these backends. We also disable the
+  // uint output when logic op is not supported (i.e. driver/device does not support D3D11.1).
+  if (ApiType != APIType::D3D || !host_config.backend_logic_op)
     uid_data->uint_output = 0;
 }
 

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -29,5 +29,6 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
                           const pixel_ubershader_uid_data* uid_data);
 
 void EnumeratePixelShaderUids(const std::function<void(const PixelShaderUid&)>& callback);
-void ClearUnusedPixelShaderUidBits(APIType ApiType, PixelShaderUid* uid);
+void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host_config,
+                                   PixelShaderUid* uid);
 }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -201,6 +201,7 @@ struct VideoConfig final
     bool bSupportsFragmentStoresAndAtomics;  // a.k.a. OpenGL SSBOs a.k.a. Direct3D UAVs
     bool bSupportsDepthClamp;  // Needed by VertexShaderGen, so must stay in VideoCommon
     bool bSupportsReversedDepthRange;
+    bool bSupportsLogicOp;
     bool bSupportsMultithreading;
     bool bSupportsGPUTextureDecoding;
     bool bSupportsST3CTextures;


### PR DESCRIPTION
Related to issue https://bugs.dolphin-emu.org/issues/10975

I don't have any old D3D10-level hardware handy to test, so if anyone does and has experienced the issue above, confirmation that this change fixes the issue would be appreciated.

Also adds calls to remove the unused bits from shader UIDs in the new shader cache.