### PR TITLE
Interpreter_FPUtils: Set FPSCR.VXSNAN if either operand to NI_mul() is a signaling NaN

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -94,13 +94,17 @@ inline double MakeQuiet(double d)
 
 inline double NI_mul(double a, double b)
 {
-  double t = a * b;
+  const double t = a * b;
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(a) || Common::IsSNAN(b))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(a))
       return MakeQuiet(a);
     if (std::isnan(b))
       return MakeQuiet(b);
+
     SetFPException(FPSCR_VXIMZ);
     return PPC_NAN;
   }


### PR DESCRIPTION
If either of the operands are signaling NaNs, then an invalid operation exception needs to be indicated within the FPSCR.

This corrects SNaN flag setting for `fmul`, `fmuls`, `ps_mul`, `ps_muls0`, and `ps_muls1`.