### PR TITLE
Qt/Win32: Remove font weight calculation

### DIFF
--- a/Source/Core/DolphinQt2/Main.cpp
+++ b/Source/Core/DolphinQt2/Main.cpp
@@ -111,11 +111,6 @@ int main(int argc, char* argv[])
     QFont font = QApplication::font();
     font.setFamily(QString::fromStdString(UTF16ToUTF8(logfont.lfFaceName)));
 
-    // LOGFONT uses a scale from 1 to 1000 to represent font weight while Qt uses a scale from 0
-    // to 99. LOGFONT also has a DONTCARE value which we have to ignore.
-    if (logfont.lfWeight != FW_DONTCARE)
-      font.setWeight((logfont.lfWeight / 10) - 1);
-
     font.setItalic(logfont.lfItalic);
     font.setStrikeOut(logfont.lfStrikeOut);
     font.setUnderline(logfont.lfUnderline);


### PR DESCRIPTION
Specifying the font weight turned out to be pretty useless as we rely on ``setBold`` in multiple places and ``setBold(false)`` defaults to a fixed font weight that isn't influenced by what we specify. Better go with what Qt thinks is reasonable.