### PR TITLE
When CPU core is invalid, fall back to JIT instead of interpreter

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -64,7 +64,9 @@ CPUCoreBase* InitJitCore(int core)
     break;
 
   default:
-    PanicAlert("Unrecognizable cpu_core: %d", core);
+    PanicAlertT("The selected CPU emulation core (%d) is not available. "
+                "Please select a different CPU emulation core in the settings.",
+                core);
     g_jit = nullptr;
     return nullptr;
   }

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -164,20 +164,13 @@ static void InitializeCPUCore(int cpu_core)
     s_cpu_core_base = JitInterface::InitJitCore(cpu_core);
     if (!s_cpu_core_base)  // Handle Situations where JIT core isn't available
     {
-      WARN_LOG(POWERPC, "Jit core %d not available. Defaulting to interpreter.", cpu_core);
-      s_cpu_core_base = s_interpreter;
+      WARN_LOG(POWERPC, "CPU core %d not available. Falling back to default.", cpu_core);
+      s_cpu_core_base = JitInterface::InitJitCore(DefaultCPUCore());
     }
     break;
   }
 
-  if (s_cpu_core_base != s_interpreter)
-  {
-    s_mode = CoreMode::JIT;
-  }
-  else
-  {
-    s_mode = CoreMode::Interpreter;
-  }
+  s_mode = s_cpu_core_base == s_interpreter ? CoreMode::Interpreter : CoreMode::JIT;
 }
 
 const std::vector<CPUCore>& AvailableCPUCores()


### PR DESCRIPTION
This might happen if someone moves settings between e.g. a PC and an Android device, or if someone was using JITIL and updates Dolphin.

I also made the panic alert a bit more explanatory.