### PR TITLE
DolphinQt2: Show cached games before checking whether they exist on disk

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -28,6 +28,8 @@ GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
   for (const QString& dir : Settings::Instance().GetPaths())
     m_tracker.AddDirectory(dir);
 
+  m_tracker.Start();
+
   connect(&Settings::Instance(), &Settings::ThemeChanged, [this] {
     // Tell the view to repaint. The signal 'dataChanged' also seems like it would work here, but
     // unfortunately it won't cause a repaint until the view is focused.

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -18,8 +18,7 @@ const QSize GAMECUBE_BANNER_SIZE(96, 32);
 GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
 {
   connect(&m_tracker, &GameTracker::GameLoaded, this, &GameListModel::UpdateGame);
-  connect(&m_tracker, &GameTracker::GameRemoved, this,
-          [this](const QString& path) { RemoveGame(path.toStdString()); });
+  connect(&m_tracker, &GameTracker::GameRemoved, this, &GameListModel::RemoveGame);
   connect(&Settings::Instance(), &Settings::PathAdded, &m_tracker, &GameTracker::AddDirectory);
   connect(&Settings::Instance(), &Settings::PathRemoved, &m_tracker, &GameTracker::RemoveDirectory);
   connect(&Settings::Instance(), &Settings::PathReloadRequested, &m_tracker,

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -90,9 +90,7 @@ void GameTracker::StartInternal()
   auto emit_game_loaded = [this](const std::shared_ptr<const UICommon::GameFile>& game) {
     emit GameLoaded(std::move(game));
   };
-  auto emit_game_removed = [this](const std::string& path) {
-    emit GameRemoved(QString::fromStdString(path));
-  };
+  auto emit_game_removed = [this](const std::string& path) { emit GameRemoved(path); };
 
   std::lock_guard<std::mutex> lk(m_mutex);
 
@@ -159,7 +157,7 @@ void GameTracker::RemoveDirectoryInternal(const QString& dir)
         removePath(path);
         m_tracked_files.remove(path);
         if (m_started)
-          emit GameRemoved(path);
+          emit GameRemoved(path.toStdString());
       }
     }
   }
@@ -195,7 +193,7 @@ void GameTracker::UpdateDirectoryInternal(const QString& dir)
     {
       m_tracked_files.remove(missing);
       if (m_started)
-        GameRemoved(missing);
+        GameRemoved(missing.toStdString());
     }
   }
 }
@@ -205,7 +203,7 @@ void GameTracker::UpdateFileInternal(const QString& file)
   if (QFileInfo(file).exists())
   {
     if (m_started)
-      GameRemoved(file);
+      GameRemoved(file.toStdString());
     addPath(file);
     LoadGame(file);
   }
@@ -213,7 +211,7 @@ void GameTracker::UpdateFileInternal(const QString& file)
   {
     m_tracked_files.remove(file);
     if (m_started)
-      emit GameRemoved(file);
+      emit GameRemoved(file.toStdString());
   }
 }
 

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -30,8 +30,10 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
     switch (command.type)
     {
     case CommandType::LoadCache:
-      m_cache.Load();
+      LoadCache();
       break;
+    case CommandType::Start:
+      StartInternal();
     case CommandType::AddDirectory:
       AddDirectoryInternal(command.path);
       break;
@@ -50,6 +52,54 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
   m_load_thread.EmplaceItem(Command{CommandType::LoadCache, {}});
 
   // TODO: When language changes, reload m_title_database and call m_cache.UpdateAdditionalMetadata
+}
+
+void GameTracker::LoadCache()
+{
+  std::lock_guard<std::mutex> lk(m_mutex);
+  m_cache.Load();
+}
+
+void GameTracker::Start()
+{
+  if (m_initial_games_emitted)
+    return;
+
+  m_initial_games_emitted = true;
+
+  std::lock_guard<std::mutex> lk(m_mutex);
+
+  m_load_thread.EmplaceItem(Command{CommandType::Start, {}});
+
+  m_cache.ForEach(
+      [this](const std::shared_ptr<const UICommon::GameFile>& game) { emit GameLoaded(game); });
+}
+
+void GameTracker::StartInternal()
+{
+  if (m_started)
+    return;
+
+  m_started = true;
+
+  std::vector<std::string> paths;
+  paths.reserve(m_tracked_files.size());
+  for (const QString& path : m_tracked_files.keys())
+    paths.push_back(path.toStdString());
+
+  auto emit_game_loaded = [this](const std::shared_ptr<const UICommon::GameFile>& game) {
+    emit GameLoaded(std::move(game));
+  };
+  auto emit_game_removed = [this](const std::string& path) {
+    emit GameRemoved(QString::fromStdString(path));
+  };
+
+  std::lock_guard<std::mutex> lk(m_mutex);
+
+  bool cache_updated = m_cache.Update(paths, emit_game_loaded, emit_game_removed);
+  cache_updated |= m_cache.UpdateAdditionalMetadata(m_title_database, emit_game_loaded);
+  if (cache_updated)
+    m_cache.Save();
 }
 
 void GameTracker::AddDirectory(const QString& dir)
@@ -108,7 +158,8 @@ void GameTracker::RemoveDirectoryInternal(const QString& dir)
       {
         removePath(path);
         m_tracked_files.remove(path);
-        emit GameRemoved(path);
+        if (m_started)
+          emit GameRemoved(path);
       }
     }
   }
@@ -143,7 +194,8 @@ void GameTracker::UpdateDirectoryInternal(const QString& dir)
     if (tracked_file.empty())
     {
       m_tracked_files.remove(missing);
-      GameRemoved(missing);
+      if (m_started)
+        GameRemoved(missing);
     }
   }
 }
@@ -152,14 +204,16 @@ void GameTracker::UpdateFileInternal(const QString& file)
 {
   if (QFileInfo(file).exists())
   {
-    GameRemoved(file);
+    if (m_started)
+      GameRemoved(file);
     addPath(file);
     LoadGame(file);
   }
   else if (removePath(file))
   {
     m_tracked_files.remove(file);
-    emit GameRemoved(file);
+    if (m_started)
+      emit GameRemoved(file);
   }
 }
 
@@ -187,6 +241,9 @@ QSet<QString> GameTracker::FindMissingFiles(const QString& dir)
 
 void GameTracker::LoadGame(const QString& path)
 {
+  if (!m_started)
+    return;
+
   const std::string converted_path = path.toStdString();
   if (!DiscIO::ShouldHideFromGameList(converted_path))
   {

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <mutex>
+#include <string>
 
 #include <QFileSystemWatcher>
 #include <QMap>
@@ -39,7 +40,7 @@ public:
 
 signals:
   void GameLoaded(std::shared_ptr<const UICommon::GameFile> game);
-  void GameRemoved(const QString& path);
+  void GameRemoved(const std::string& path);
 
 private:
   void LoadCache();
@@ -80,3 +81,4 @@ private:
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<const UICommon::GameFile>)
+Q_DECLARE_METATYPE(std::string)

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -92,7 +92,7 @@ bool GameFileCache::Update(
   bool cache_changed = false;
 
   // Delete paths that aren't in game_paths from m_cached_files,
-  // while simultaneously deleting paths that aren't in m_cached_files from game_paths.
+  // while simultaneously deleting paths that are in m_cached_files from game_paths.
   // For the sake of speed, we don't care about maintaining the order of m_cached_files.
   {
     auto it = m_cached_files.begin();

--- a/Source/Core/UICommon/GameFileCache.h
+++ b/Source/Core/UICommon/GameFileCache.h
@@ -40,8 +40,12 @@ public:
                                            const Core::TitleDatabase& title_database);
 
   // These functions return true if the call modified the cache.
-  bool Update(const std::vector<std::string>& all_game_paths);
-  bool UpdateAdditionalMetadata(const Core::TitleDatabase& title_database);
+  bool Update(const std::vector<std::string>& all_game_paths,
+              std::function<void(const std::shared_ptr<const GameFile>&)> game_added_to_cache = {},
+              std::function<void(const std::string&)> game_removed_from_cache = {});
+  bool UpdateAdditionalMetadata(
+      const Core::TitleDatabase& title_database,
+      std::function<void(const std::shared_ptr<const GameFile>&)> game_updated = {});
 
   bool Load();
   bool Save();


### PR DESCRIPTION
DolphinWX already has this improvement in startup time, and it matters a lot when you have a large game list.