### PR TITLE
GameListModel: Don't do a linear scan for each newly added game

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -17,7 +17,8 @@ const QSize GAMECUBE_BANNER_SIZE(96, 32);
 
 GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
 {
-  connect(&m_tracker, &GameTracker::GameLoaded, this, &GameListModel::UpdateGame);
+  connect(&m_tracker, &GameTracker::GameLoaded, this, &GameListModel::AddGame);
+  connect(&m_tracker, &GameTracker::GameUpdated, this, &GameListModel::UpdateGame);
   connect(&m_tracker, &GameTracker::GameRemoved, this, &GameListModel::RemoveGame);
   connect(&Settings::Instance(), &Settings::PathAdded, &m_tracker, &GameTracker::AddDirectory);
   connect(&Settings::Instance(), &Settings::PathRemoved, &m_tracker, &GameTracker::RemoveDirectory);
@@ -218,14 +219,19 @@ std::shared_ptr<const UICommon::GameFile> GameListModel::GetGameFile(int index) 
   return m_games[index];
 }
 
+void GameListModel::AddGame(const std::shared_ptr<const UICommon::GameFile>& game)
+{
+  beginInsertRows(QModelIndex(), m_games.size(), m_games.size());
+  m_games.push_back(game);
+  endInsertRows();
+}
+
 void GameListModel::UpdateGame(const std::shared_ptr<const UICommon::GameFile>& game)
 {
   int index = FindGame(game->GetFilePath());
   if (index < 0)
   {
-    beginInsertRows(QModelIndex(), m_games.size(), m_games.size());
-    m_games.push_back(game);
-    endInsertRows();
+    AddGame(game);
   }
   else
   {

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -52,6 +52,7 @@ public:
     NUM_COLS
   };
 
+  void AddGame(const std::shared_ptr<const UICommon::GameFile>& game);
   void UpdateGame(const std::shared_ptr<const UICommon::GameFile>& game);
   void RemoveGame(const std::string& path);
 

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -89,15 +89,18 @@ void GameTracker::StartInternal()
   for (const QString& path : m_tracked_files.keys())
     paths.push_back(path.toStdString());
 
-  auto emit_game_loaded = [this](const std::shared_ptr<const UICommon::GameFile>& game) {
-    emit GameLoaded(std::move(game));
+  const auto emit_game_loaded = [this](const std::shared_ptr<const UICommon::GameFile>& game) {
+    emit GameLoaded(game);
   };
-  auto emit_game_removed = [this](const std::string& path) { emit GameRemoved(path); };
+  const auto emit_game_updated = [this](const std::shared_ptr<const UICommon::GameFile>& game) {
+    emit GameUpdated(game);
+  };
+  const auto emit_game_removed = [this](const std::string& path) { emit GameRemoved(path); };
 
   m_initial_games_emitted_event.Wait();
 
   bool cache_updated = m_cache.Update(paths, emit_game_loaded, emit_game_removed);
-  cache_updated |= m_cache.UpdateAdditionalMetadata(m_title_database, emit_game_loaded);
+  cache_updated |= m_cache.UpdateAdditionalMetadata(m_title_database, emit_game_updated);
   if (cache_updated)
     m_cache.Save();
 }

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -39,7 +39,8 @@ public:
   void ReloadDirectory(const QString& dir);
 
 signals:
-  void GameLoaded(std::shared_ptr<const UICommon::GameFile> game);
+  void GameLoaded(const std::shared_ptr<const UICommon::GameFile>& game);
+  void GameUpdated(const std::shared_ptr<const UICommon::GameFile>& game);
   void GameRemoved(const std::string& path);
 
 private:


### PR DESCRIPTION
I can't think of any case where GameTracker would emit GameLoaded for a game that already is in the game list. Please correct me if I'm wrong.

This saves us from doing a linear scan through the game list for each game added.