### PR TITLE
Interpreter_FPUtils: Set FPSCR.VXSNAN if either operand to NI_add() is a signaling NaN

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -137,16 +137,22 @@ inline double NI_div(double a, double b)
 
 inline double NI_add(double a, double b)
 {
-  double t = a + b;
+  const double t = a + b;
+
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(a) || Common::IsSNAN(b))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(a))
       return MakeQuiet(a);
     if (std::isnan(b))
       return MakeQuiet(b);
+
     SetFPException(FPSCR_VXISI);
     return PPC_NAN;
   }
+
   return t;
 }
 


### PR DESCRIPTION
This corrects VXSNAN flag setting for `fadd`, `fadds`, `ps_add`, `ps_sum0`, and `ps_sum1`