### PR TITLE
Interpreter_FloatingPoint: Handle NaN flag setting within fctiw and fctiwz

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -288,7 +288,6 @@ private:
 
   // flag helper
   static void Helper_UpdateCR0(u32 value);
-  static void Helper_UpdateCR1();
 
   // address helper
   static u32 Helper_Get_EA(const UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -52,6 +52,11 @@ inline void UpdateFPSCR()
               (FPSCR.ZX & FPSCR.ZE) | (FPSCR.XX & FPSCR.XE);
 }
 
+inline void Helper_UpdateCR1()
+{
+  PowerPC::SetCRField(1, (FPSCR.FX << 3) | (FPSCR.FEX << 2) | (FPSCR.VX << 1) | FPSCR.OX);
+}
+
 inline double ForceSingle(double value)
 {
   // convert to float...


### PR DESCRIPTION
It's likely best to review this by viewing the second and third commit directly, as the first one cleans it up so we aren't duplicating logic between `fctiwx` and fctiwzx`. The first commit also gives rationale for the decisions made when moving stuff around.

---

Now for the explanation: If a NaN of any type is passed as the operand to either of these instructions, we shouldn't go down the regular code path, as we end up potentially setting the wrong flags. For example, we wouldn't set the FPSCR.VXCVI bit properly. We'd also set FPSCR.FI, when in actuality it should be unset.

If an SNaN is passed as an operand, we also need to set the FPSCR.VXSNAN bit as well.

The flag setting behavior for these can be found in Appendix C.4.2 in *PowerPC Microprocessor Family: The Programming Environments Manual for 32 and 64-bit Microprocessors*.

This also fixes the case where the destination register shouldn't be written to. This case would be if the FPSCR.VE bit is set (invalid operation exceptions are enabled) and an invalid operation occurs.