### PR TITLE
Qt/GameTracker: Register missing metatype

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -23,6 +23,8 @@ static const QStringList game_filters{
 GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
 {
   qRegisterMetaType<std::shared_ptr<const UICommon::GameFile>>();
+  qRegisterMetaType<std::string>();
+
   connect(this, &QFileSystemWatcher::directoryChanged, this, &GameTracker::UpdateDirectory);
   connect(this, &QFileSystemWatcher::fileChanged, this, &GameTracker::UpdateFile);
 


### PR DESCRIPTION
Should fix the regression caused by #6975.