### PR TITLE
CodeWidget/CodeViewWidget: Make symbol pointers const where applicable

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
@@ -280,17 +280,17 @@ void CodeViewWidget::OnCopyFunction()
 {
   const u32 address = GetContextAddress();
 
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
+  const Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
   if (!symbol)
     return;
 
   std::string text = symbol->name + "\r\n";
   // we got a function
-  u32 start = symbol->address;
-  u32 end = start + symbol->size;
+  const u32 start = symbol->address;
+  const u32 end = start + symbol->size;
   for (u32 addr = start; addr != end; addr += 4)
   {
-    std::string disasm = PowerPC::debug_interface.Disassemble(addr);
+    const std::string disasm = PowerPC::debug_interface.Disassemble(addr);
     text += StringFromFormat("%08x: ", addr) + disasm + "\r\n";
   }
 

--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
@@ -201,10 +201,10 @@ void CodeWidget::OnSelectSymbol()
   if (items.isEmpty())
     return;
 
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(items[0]->data(Qt::UserRole).toUInt());
+  const u32 address = items[0]->data(Qt::UserRole).toUInt();
+  const Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
 
-  m_code_view->SetAddress(items[0]->data(Qt::UserRole).toUInt(),
-                          CodeViewWidget::SetAddressUpdate::WithUpdate);
+  m_code_view->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithUpdate);
   UpdateCallstack();
   UpdateFunctionCalls(symbol);
   UpdateFunctionCallers(symbol);
@@ -252,7 +252,7 @@ void CodeWidget::SetAddress(u32 address, CodeViewWidget::SetAddressUpdate update
 
 void CodeWidget::Update()
 {
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(m_code_view->GetAddress());
+  const Symbol* symbol = g_symbolDB.GetSymbolFromAddr(m_code_view->GetAddress());
 
   UpdateCallstack();
 
@@ -321,14 +321,14 @@ void CodeWidget::UpdateSymbols()
   m_symbols_list->sortItems();
 }
 
-void CodeWidget::UpdateFunctionCalls(Symbol* symbol)
+void CodeWidget::UpdateFunctionCalls(const Symbol* symbol)
 {
   m_function_calls_list->clear();
 
   for (const auto& call : symbol->calls)
   {
-    u32 addr = call.function;
-    Symbol* call_symbol = g_symbolDB.GetSymbolFromAddr(addr);
+    const u32 addr = call.function;
+    const Symbol* call_symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
     if (call_symbol)
     {
@@ -341,14 +341,14 @@ void CodeWidget::UpdateFunctionCalls(Symbol* symbol)
   }
 }
 
-void CodeWidget::UpdateFunctionCallers(Symbol* symbol)
+void CodeWidget::UpdateFunctionCallers(const Symbol* symbol)
 {
   m_function_callers_list->clear();
 
   for (const auto& caller : symbol->callers)
   {
-    u32 addr = caller.callAddress;
-    Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(addr);
+    const u32 addr = caller.callAddress;
+    const Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
     if (caller_symbol)
     {

--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.h
@@ -45,8 +45,8 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
   void UpdateCallstack();
-  void UpdateFunctionCalls(Symbol* symbol);
-  void UpdateFunctionCallers(Symbol* symbol);
+  void UpdateFunctionCalls(const Symbol* symbol);
+  void UpdateFunctionCallers(const Symbol* symbol);
 
   void OnSearchAddress();
   void OnSearchSymbols();


### PR DESCRIPTION
These aren't used to modify the data they point to, so make that explicit. Also while we're at it, add const to any nearby variables that can be made so.