### PR TITLE
Qt/GameConfigWidget: Fix Deterministic dual core not saving if changed to "Not Set"

### DIFF
--- a/Source/Core/DolphinQt2/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/GameConfigWidget.cpp
@@ -304,6 +304,10 @@ void GameConfigWidget::SaveSettings()
       m_gameini_local.GetOrCreateSection("Core")->Set("GPUDeterminismMode", determinism_mode);
     }
   }
+  else
+  {
+    m_gameini_local.DeleteKey("Core", "GPUDeterminismMode");
+  }
 
   // Stereoscopy
   int depth_percentage = m_depth_slider->value();


### PR DESCRIPTION
It would simply revert to the previous setting, this fixes that. Tested and works as it should.