### PR TITLE
VertexLoaderArm: Fix 565 color format.

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -229,7 +229,7 @@ void VertexLoaderARM64::ReadColor(u64 attribute, int format, s32 offset)
       LDR(INDEX_UNSIGNED, scratch2_reg, src_reg, offset);
 
     if (format != FORMAT_32B_8888)
-      ORR(scratch2_reg, scratch2_reg, 8, 7);  // 0xFF000000
+      ORRI2R(scratch2_reg, scratch2_reg, 0xFF000000);
     STR(INDEX_UNSIGNED, scratch2_reg, dst_reg, m_dst_ofs);
     load_bytes = 3 + (format != FORMAT_24B_888);
     break;
@@ -264,7 +264,7 @@ void VertexLoaderARM64::ReadColor(u64 attribute, int format, s32 offset)
     ORR(scratch1_reg, scratch1_reg, scratch2_reg, ArithOption(scratch2_reg, ST_LSR, 2));
 
     // A
-    ORR(scratch2_reg, scratch2_reg, 8, 7);  // 0xFF000000
+    ORRI2R(scratch1_reg, scratch1_reg, 0xFF000000);
 
     STR(INDEX_UNSIGNED, scratch1_reg, dst_reg, m_dst_ofs);
     load_bytes = 2;


### PR DESCRIPTION
Copy & paste error for enforcing A=255.
It was copied from the 888X format, which stores the output data in another register.

A big thanks to @JMC47 for testing the issue and to break it down to a fifo log.