### PR TITLE
UICommon: fix m_cached_files pruning.

### DIFF
--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -111,9 +111,9 @@ bool GameFileCache::Update(
         cache_changed = true;
         --end;
         *it = std::move(*end);
-        m_cached_files.pop_back();
       }
     }
+    m_cached_files.erase(it, m_cached_files.end());
   }
 
   // Now that the previous loop has run, game_paths only contains paths that


### PR DESCRIPTION
`vector::pop_back` invalidates all iterators so use `remove_if` and `vector::resize` instead
VS2017 debug build caught this at runtime with a debug assertion