### PR TITLE
Interpreter_FPUtils: Set VXSNAN if any input operands are a signaling NaN in remaining NI_* functions

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -165,16 +165,22 @@ inline double NI_add(double a, double b)
 
 inline double NI_sub(double a, double b)
 {
-  double t = a - b;
+  const double t = a - b;
+
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(a) || Common::IsSNAN(b))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(a))
       return MakeQuiet(a);
     if (std::isnan(b))
       return MakeQuiet(b);
+
     SetFPException(FPSCR_VXISI);
     return PPC_NAN;
   }
+
   return t;
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -190,25 +190,37 @@ inline double NI_sub(double a, double b)
 inline double NI_madd(double a, double c, double b)
 {
   double t = a * c;
+
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(a))
       return MakeQuiet(a);
     if (std::isnan(b))
       return MakeQuiet(b);  // !
     if (std::isnan(c))
       return MakeQuiet(c);
+
     SetFPException(FPSCR_VXIMZ);
     return PPC_NAN;
   }
+
   t += b;
+
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(b))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(b))
       return MakeQuiet(b);
+
     SetFPException(FPSCR_VXISI);
     return PPC_NAN;
   }
+
   return t;
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -227,26 +227,37 @@ inline double NI_madd(double a, double c, double b)
 inline double NI_msub(double a, double c, double b)
 {
   double t = a * c;
+
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(a))
       return MakeQuiet(a);
     if (std::isnan(b))
       return MakeQuiet(b);  // !
     if (std::isnan(c))
       return MakeQuiet(c);
+
     SetFPException(FPSCR_VXIMZ);
     return PPC_NAN;
   }
 
   t -= b;
+
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(b))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(b))
       return MakeQuiet(b);
+
     SetFPException(FPSCR_VXISI);
     return PPC_NAN;
   }
+
   return t;
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -113,13 +113,18 @@ inline double NI_mul(double a, double b)
 
 inline double NI_div(double a, double b)
 {
-  double t = a / b;
+  const double t = a / b;
+
   if (std::isnan(t))
   {
+    if (Common::IsSNAN(a) || Common::IsSNAN(b))
+      SetFPException(FPSCR_VXSNAN);
+
     if (std::isnan(a))
       return MakeQuiet(a);
     if (std::isnan(b))
       return MakeQuiet(b);
+
     if (b == 0.0)
     {
       SetFPException(FPSCR_ZX);
@@ -130,8 +135,10 @@ inline double NI_div(double a, double b)
     {
       SetFPException(FPSCR_VXIDI);
     }
+
     return PPC_NAN;
   }
+
   return t;
 }
 


### PR DESCRIPTION
I've added NaN checks to some of the NI_* functions in Interpreter_FPUtils already (`NI_add` and `NI_mul`). This just adds those checks to the remaining functions that don't have them yet. This fixes quite a bit of the NaN flag inaccuracies in the arithmetic floating-point instructions.