### PR TITLE
SymbolDB: Minor changes

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -28,25 +28,25 @@ void Symbol::Rename(const std::string& symbol_name)
 
 void SymbolDB::List()
 {
-  for (const auto& func : functions)
+  for (const auto& func : m_functions)
   {
     DEBUG_LOG(OSHLE, "%s @ %08x: %i bytes (hash %08x) : %i calls", func.second.name.c_str(),
-              func.second.address, func.second.size, func.second.hash, func.second.numCalls);
+              func.second.address, func.second.size, func.second.hash, func.second.num_calls);
   }
-  INFO_LOG(OSHLE, "%zu functions known in this program above.", functions.size());
+  INFO_LOG(OSHLE, "%zu functions known in this program above.", m_functions.size());
 }
 
 void SymbolDB::Clear(const char* prefix)
 {
   // TODO: honor prefix
-  functions.clear();
-  checksumToFunction.clear();
+  m_functions.clear();
+  m_checksum_to_function.clear();
 }
 
 void SymbolDB::Index()
 {
   int i = 0;
-  for (auto& func : functions)
+  for (auto& func : m_functions)
   {
     func.second.index = i++;
   }
@@ -54,7 +54,7 @@ void SymbolDB::Index()
 
 Symbol* SymbolDB::GetSymbolFromName(const std::string& name)
 {
-  for (auto& func : functions)
+  for (auto& func : m_functions)
   {
     if (func.second.function_name == name)
       return &func.second;
@@ -67,7 +67,7 @@ std::vector<Symbol*> SymbolDB::GetSymbolsFromName(const std::string& name)
 {
   std::vector<Symbol*> symbols;
 
-  for (auto& func : functions)
+  for (auto& func : m_functions)
   {
     if (func.second.function_name == name)
       symbols.push_back(&func.second);
@@ -78,18 +78,18 @@ std::vector<Symbol*> SymbolDB::GetSymbolsFromName(const std::string& name)
 
 Symbol* SymbolDB::GetSymbolFromHash(u32 hash)
 {
-  XFuncPtrMap::iterator iter = checksumToFunction.find(hash);
-  if (iter != checksumToFunction.end())
-    return *iter->second.begin();
-  else
+  auto iter = m_checksum_to_function.find(hash);
+  if (iter == m_checksum_to_function.end())
     return nullptr;
+
+  return *iter->second.begin();
 }
 
 std::vector<Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash)
 {
-  const auto iter = checksumToFunction.find(hash);
+  const auto iter = m_checksum_to_function.find(hash);
 
-  if (iter == checksumToFunction.cend())
+  if (iter == m_checksum_to_function.cend())
     return {};
 
   return {iter->second.cbegin(), iter->second.cend()};
@@ -97,5 +97,5 @@ std::vector<Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash)
 
 void SymbolDB::AddCompleteSymbol(const Symbol& symbol)
 {
-  functions.emplace(symbol.address, symbol);
+  m_functions.emplace(symbol.address, symbol);
 }

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -20,6 +20,10 @@ static std::string GetStrippedFunctionName(const std::string& symbol_name)
   return name;
 }
 
+SymbolDB::SymbolDB() = default;
+
+SymbolDB::~SymbolDB() = default;
+
 void Symbol::Rename(const std::string& symbol_name)
 {
   this->name = symbol_name;

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -11,6 +11,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/SymbolDB.h"
 
+namespace Common
+{
 static std::string GetStrippedFunctionName(const std::string& symbol_name)
 {
   std::string name = symbol_name.substr(0, symbol_name.find('('));
@@ -103,3 +105,4 @@ void SymbolDB::AddCompleteSymbol(const Symbol& symbol)
 {
   m_functions.emplace(symbol.address, symbol);
 }
+}  // namespace Common

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -62,8 +62,9 @@ public:
   using XFuncMap = std::map<u32, Symbol>;
   using XFuncPtrMap = std::map<u32, std::set<Symbol*>>;
 
-  SymbolDB() {}
-  virtual ~SymbolDB() {}
+  SymbolDB();
+  virtual ~SymbolDB();
+
   virtual Symbol* GetSymbolFromAddr(u32 addr) { return nullptr; }
   virtual Symbol* AddFunction(u32 start_addr) { return nullptr; }
   void AddCompleteSymbol(const Symbol& symbol);

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -15,6 +15,8 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Common
+{
 struct SCall
 {
   SCall(u32 a, u32 b) : function(a), call_address(b) {}
@@ -84,3 +86,4 @@ protected:
   XFuncMap m_functions;
   XFuncPtrMap m_checksum_to_function;
 };
+}  // namespace Common

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -17,9 +17,9 @@
 
 struct SCall
 {
-  SCall(u32 a, u32 b) : function(a), callAddress(b) {}
+  SCall(u32 a, u32 b) : function(a), call_address(b) {}
   u32 function;
-  u32 callAddress;
+  u32 call_address;
 };
 
 struct Symbol
@@ -40,7 +40,7 @@ struct Symbol
   u32 address = 0;
   u32 flags = 0;
   u32 size = 0;
-  int numCalls = 0;
+  int num_calls = 0;
   Type type = Type::Function;
   int index = 0;  // only used for coloring the disasm view
   bool analyzed = false;
@@ -62,15 +62,10 @@ public:
   typedef std::map<u32, Symbol> XFuncMap;
   typedef std::map<u32, std::set<Symbol*>> XFuncPtrMap;
 
-protected:
-  XFuncMap functions;
-  XFuncPtrMap checksumToFunction;
-
-public:
   SymbolDB() {}
   virtual ~SymbolDB() {}
   virtual Symbol* GetSymbolFromAddr(u32 addr) { return nullptr; }
-  virtual Symbol* AddFunction(u32 startAddr) { return nullptr; }
+  virtual Symbol* AddFunction(u32 start_addr) { return nullptr; }
   void AddCompleteSymbol(const Symbol& symbol);
 
   Symbol* GetSymbolFromName(const std::string& name);
@@ -78,9 +73,13 @@ public:
   Symbol* GetSymbolFromHash(u32 hash);
   std::vector<Symbol*> GetSymbolsFromHash(u32 hash);
 
-  const XFuncMap& Symbols() const { return functions; }
-  XFuncMap& AccessSymbols() { return functions; }
+  const XFuncMap& Symbols() const { return m_functions; }
+  XFuncMap& AccessSymbols() { return m_functions; }
   void Clear(const char* prefix = "");
   void List();
   void Index();
+
+protected:
+  XFuncMap m_functions;
+  XFuncPtrMap m_checksum_to_function;
 };

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -59,8 +59,8 @@ enum
 class SymbolDB
 {
 public:
-  typedef std::map<u32, Symbol> XFuncMap;
-  typedef std::map<u32, std::set<Symbol*>> XFuncPtrMap;
+  using XFuncMap = std::map<u32, Symbol>;
+  using XFuncPtrMap = std::map<u32, std::set<Symbol*>>;
 
   SymbolDB() {}
   virtual ~SymbolDB() {}

--- a/Source/Core/Core/Boot/ElfReader.cpp
+++ b/Source/Core/Core/Boot/ElfReader.cpp
@@ -204,14 +204,14 @@ bool ElfReader::LoadSymbols() const
       if (bRelocate)
         value += sectionAddrs[sectionIndex];
 
-      auto symtype = Symbol::Type::Data;
+      auto symtype = Common::Symbol::Type::Data;
       switch (type)
       {
       case STT_OBJECT:
-        symtype = Symbol::Type::Data;
+        symtype = Common::Symbol::Type::Data;
         break;
       case STT_FUNC:
-        symtype = Symbol::Type::Function;
+        symtype = Common::Symbol::Type::Function;
         break;
       default:
         continue;

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -29,7 +29,7 @@ void AddAutoBreakpoints()
 
   for (const char* bp : bps)
   {
-    Symbol* symbol = g_symbolDB.GetSymbolFromName(bp);
+    Common::Symbol* symbol = g_symbolDB.GetSymbolFromName(bp);
     if (symbol)
       PowerPC::breakpoints.Add(symbol->address, false);
   }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -310,10 +310,10 @@ int PPCDebugInterface::GetColor(unsigned int address)
       0xd0FFd0,  // light green
       0xFFFFd0,  // light yellow
   };
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
+  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
   if (!symbol)
     return 0xFFFFFF;
-  if (symbol->type != Symbol::Type::Function)
+  if (symbol->type != Common::Symbol::Type::Function)
     return 0xEEEEFF;
   return colors[symbol->index % 6];
 }

--- a/Source/Core/Core/Debugger/RSO.cpp
+++ b/Source/Core/Core/Debugger/RSO.cpp
@@ -376,7 +376,7 @@ void RSOView::Apply(PPCSymbolDB* symbol_db) const
     u32 address = GetExportAddress(rso_export);
     if (address != 0)
     {
-      Symbol* symbol = symbol_db->AddFunction(address);
+      Common::Symbol* symbol = symbol_db->AddFunction(address);
       if (!symbol)
         symbol = symbol_db->GetSymbolFromAddr(address);
 
@@ -389,7 +389,7 @@ void RSOView::Apply(PPCSymbolDB* symbol_db) const
       else
       {
         // Data symbol
-        symbol_db->AddKnownSymbol(address, 0, export_name, Symbol::Type::Data);
+        symbol_db->AddKnownSymbol(address, 0, export_name, Common::Symbol::Type::Data);
       }
     }
   }

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -277,10 +277,10 @@ int DSPDebugInterface::GetColor(unsigned int address)
   if (addr == -1)
     return 0xFFFFFF;
 
-  Symbol* symbol = Symbols::g_dsp_symbol_db.GetSymbolFromAddr(addr);
+  Common::Symbol* symbol = Symbols::g_dsp_symbol_db.GetSymbolFromAddr(addr);
   if (!symbol)
     return 0xFFFFFF;
-  if (symbol->type != Symbol::Type::Function)
+  if (symbol->type != Common::Symbol::Type::Function)
     return 0xEEEEFF;
   return colors[symbol->index % 6];
 }

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -59,7 +59,7 @@ const char* GetLineText(int line)
   }
 }
 
-Symbol* DSPSymbolDB::GetSymbolFromAddr(u32 addr)
+Common::Symbol* DSPSymbolDB::GetSymbolFromAddr(u32 addr)
 {
   auto it = m_functions.find(addr);
 

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -61,20 +61,17 @@ const char* GetLineText(int line)
 
 Symbol* DSPSymbolDB::GetSymbolFromAddr(u32 addr)
 {
-  XFuncMap::iterator it = functions.find(addr);
+  auto it = m_functions.find(addr);
 
-  if (it != functions.end())
-  {
+  if (it != m_functions.end())
     return &it->second;
-  }
-  else
+
+  for (auto& func : m_functions)
   {
-    for (auto& func : functions)
-    {
-      if (addr >= func.second.address && addr < func.second.address + func.second.size)
-        return &func.second;
-    }
+    if (addr >= func.second.address && addr < func.second.address + func.second.size)
+      return &func.second;
   }
+
   return nullptr;
 }
 

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
@@ -13,12 +13,12 @@ namespace DSP
 {
 namespace Symbols
 {
-class DSPSymbolDB : public SymbolDB
+class DSPSymbolDB : public Common::SymbolDB
 {
 public:
   DSPSymbolDB() {}
   ~DSPSymbolDB() {}
-  Symbol* GetSymbolFromAddr(u32 addr) override;
+  Common::Symbol* GetSymbolFromAddr(u32 addr) override;
 };
 
 extern DSPSymbolDB g_dsp_symbol_db;

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -133,7 +133,7 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& block, bool block_link,
     LinkBlock(block);
   }
 
-  Symbol* symbol = nullptr;
+  Common::Symbol* symbol = nullptr;
   if (JitRegister::IsEnabled() &&
       (symbol = g_symbolDB.GetSymbolFromAddr(block.effectiveAddress)) != nullptr)
   {

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -14,7 +14,11 @@
 #include "Core/PowerPC/PPCTables.h"
 
 class PPCSymbolDB;
+
+namespace Common
+{
 struct Symbol;
+}
 
 namespace PPCAnalyst
 {
@@ -216,7 +220,7 @@ private:
 
 void LogFunctionCall(u32 addr);
 void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db);
-bool AnalyzeFunction(u32 startAddr, Symbol& func, u32 max_size = 0);
-bool ReanalyzeFunction(u32 start_addr, Symbol& func, u32 max_size = 0);
+bool AnalyzeFunction(u32 startAddr, Common::Symbol& func, u32 max_size = 0);
+bool ReanalyzeFunction(u32 start_addr, Common::Symbol& func, u32 max_size = 0);
 
 }  // namespace

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -14,17 +14,17 @@
 #include "Core/Debugger/PPCDebugInterface.h"
 
 // This has functionality overlapping Debugger_Symbolmap. Should merge that stuff in here later.
-class PPCSymbolDB : public SymbolDB
+class PPCSymbolDB : public Common::SymbolDB
 {
 public:
   PPCSymbolDB();
   ~PPCSymbolDB() override;
 
-  Symbol* AddFunction(u32 start_addr) override;
+  Common::Symbol* AddFunction(u32 start_addr) override;
   void AddKnownSymbol(u32 startAddr, u32 size, const std::string& name,
-                      Symbol::Type type = Symbol::Type::Function);
+                      Common::Symbol::Type type = Common::Symbol::Type::Function);
 
-  Symbol* GetSymbolFromAddr(u32 addr) override;
+  Common::Symbol* GetSymbolFromAddr(u32 addr) override;
 
   std::string GetDescription(u32 addr);
 

--- a/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeViewWidget.cpp
@@ -280,7 +280,7 @@ void CodeViewWidget::OnCopyFunction()
 {
   const u32 address = GetContextAddress();
 
-  const Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
+  const Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
   if (!symbol)
     return;
 
@@ -361,7 +361,7 @@ void CodeViewWidget::OnRenameSymbol()
 {
   const u32 addr = GetContextAddress();
 
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
+  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
   if (!symbol)
     return;
@@ -396,7 +396,7 @@ void CodeViewWidget::OnSetSymbolSize()
 {
   const u32 addr = GetContextAddress();
 
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
+  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
   if (!symbol)
     return;
@@ -419,7 +419,7 @@ void CodeViewWidget::OnSetSymbolEndAddress()
 {
   const u32 addr = GetContextAddress();
 
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
+  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
   if (!symbol)
     return;

--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
@@ -347,7 +347,7 @@ void CodeWidget::UpdateFunctionCallers(const Symbol* symbol)
 
   for (const auto& caller : symbol->callers)
   {
-    const u32 addr = caller.callAddress;
+    const u32 addr = caller.call_address;
     const Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
     if (caller_symbol)

--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
@@ -202,7 +202,7 @@ void CodeWidget::OnSelectSymbol()
     return;
 
   const u32 address = items[0]->data(Qt::UserRole).toUInt();
-  const Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
+  const Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
 
   m_code_view->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithUpdate);
   UpdateCallstack();
@@ -252,7 +252,7 @@ void CodeWidget::SetAddress(u32 address, CodeViewWidget::SetAddressUpdate update
 
 void CodeWidget::Update()
 {
-  const Symbol* symbol = g_symbolDB.GetSymbolFromAddr(m_code_view->GetAddress());
+  const Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(m_code_view->GetAddress());
 
   UpdateCallstack();
 
@@ -309,7 +309,7 @@ void CodeWidget::UpdateSymbols()
       item->setSelected(true);
 
     // Disable non-function symbols as you can't do anything with them.
-    if (symbol.second.type != Symbol::Type::Function)
+    if (symbol.second.type != Common::Symbol::Type::Function)
       item->setFlags(Qt::NoItemFlags);
 
     item->setData(Qt::UserRole, symbol.second.address);
@@ -321,14 +321,14 @@ void CodeWidget::UpdateSymbols()
   m_symbols_list->sortItems();
 }
 
-void CodeWidget::UpdateFunctionCalls(const Symbol* symbol)
+void CodeWidget::UpdateFunctionCalls(const Common::Symbol* symbol)
 {
   m_function_calls_list->clear();
 
   for (const auto& call : symbol->calls)
   {
     const u32 addr = call.function;
-    const Symbol* call_symbol = g_symbolDB.GetSymbolFromAddr(addr);
+    const Common::Symbol* call_symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
     if (call_symbol)
     {
@@ -341,14 +341,14 @@ void CodeWidget::UpdateFunctionCalls(const Symbol* symbol)
   }
 }
 
-void CodeWidget::UpdateFunctionCallers(const Symbol* symbol)
+void CodeWidget::UpdateFunctionCallers(const Common::Symbol* symbol)
 {
   m_function_callers_list->clear();
 
   for (const auto& caller : symbol->callers)
   {
     const u32 addr = caller.call_address;
-    const Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(addr);
+    const Common::Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(addr);
 
     if (caller_symbol)
     {

--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.h
@@ -15,7 +15,11 @@ class QLineEdit;
 class QSplitter;
 class QListWidget;
 class QTableWidget;
+
+namespace Common
+{
 struct Symbol;
+}
 
 class CodeWidget : public QDockWidget
 {
@@ -45,8 +49,8 @@ private:
   void CreateWidgets();
   void ConnectWidgets();
   void UpdateCallstack();
-  void UpdateFunctionCalls(const Symbol* symbol);
-  void UpdateFunctionCallers(const Symbol* symbol);
+  void UpdateFunctionCalls(const Common::Symbol* symbol);
+  void UpdateFunctionCallers(const Common::Symbol* symbol);
 
   void OnSearchAddress();
   void OnSearchSymbols();

--- a/Source/Core/DolphinWX/Debugger/BreakpointView.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointView.cpp
@@ -45,7 +45,7 @@ void CBreakPointView::Repopulate()
       int item = InsertItem(0, breakpoint_enabled_str);
       SetItem(item, 1, StrToWxStr("BP"));
 
-      Symbol* symbol = g_symbolDB.GetSymbolFromAddr(rBP.address);
+      Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(rBP.address);
       if (symbol)
       {
         wxString symbol_description = StrToWxStr(g_symbolDB.GetDescription(rBP.address));
@@ -67,7 +67,7 @@ void CBreakPointView::Repopulate()
     int item = InsertItem(0, memcheck_on_str);
     SetItem(item, 1, StrToWxStr("MBP"));
 
-    Symbol* symbol = g_symbolDB.GetSymbolFromAddr(rMemCheck.start_address);
+    Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(rMemCheck.start_address);
     if (symbol)
     {
       wxString memcheck_start_addr = StrToWxStr(g_symbolDB.GetDescription(rMemCheck.start_address));

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -57,7 +57,7 @@ enum
   IDM_ADDFUNCTION,
 };
 
-CCodeView::CCodeView(DebugInterface* debuginterface, SymbolDB* symboldb, wxWindow* parent,
+CCodeView::CCodeView(DebugInterface* debuginterface, Common::SymbolDB* symboldb, wxWindow* parent,
                      wxWindowID Id)
     : wxControl(parent, Id), m_debugger(debuginterface), m_symbol_db(symboldb), m_plain(false),
       m_curAddress(debuginterface->GetPC()), m_align(debuginterface->GetInstructionSize(0)),
@@ -243,7 +243,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 
   case IDM_COPYFUNCTION:
   {
-    Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
+    Common::Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
     if (symbol)
     {
       std::string text;
@@ -335,7 +335,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 
   case IDM_RENAMESYMBOL:
   {
-    Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
+    Common::Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
     if (symbol)
     {
       wxTextEntryDialog input_symbol(this, _("Rename symbol:"), wxGetTextFromUserPromptStr,
@@ -352,7 +352,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 
   case IDM_SETSYMBOLSIZE:
   {
-    Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
+    Common::Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
     if (!symbol)
       break;
 
@@ -375,7 +375,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 
   case IDM_SETSYMBOLEND:
   {
-    Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
+    Common::Symbol* symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
     if (!symbol)
       break;
 

--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -18,13 +18,17 @@
 wxDECLARE_EVENT(wxEVT_CODEVIEW_CHANGE, wxCommandEvent);
 
 class DebugInterface;
-class SymbolDB;
 class wxPaintDC;
+
+namespace Common
+{
+class SymbolDB;
+}
 
 class CCodeView : public wxControl
 {
 public:
-  CCodeView(DebugInterface* debuginterface, SymbolDB* symbol_db, wxWindow* parent,
+  CCodeView(DebugInterface* debuginterface, Common::SymbolDB* symbol_db, wxWindow* parent,
             wxWindowID Id = wxID_ANY);
 
   void ToggleBreakpoint(u32 address);
@@ -58,7 +62,7 @@ private:
   static constexpr int LEFT_COL_WIDTH = 16;
 
   DebugInterface* m_debugger;
-  SymbolDB* m_symbol_db;
+  Common::SymbolDB* m_symbol_db;
 
   bool m_plain;
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -440,7 +440,7 @@ void CCodeWindow::UpdateLists()
 
   for (auto& call : symbol->callers)
   {
-    u32 caller_addr = call.callAddress;
+    u32 caller_addr = call.call_address;
     Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(caller_addr);
     if (caller_symbol)
     {

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -434,14 +434,14 @@ void CCodeWindow::UpdateLists()
 {
   callers->Clear();
   u32 addr = codeview->GetSelection();
-  Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
+  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(addr);
   if (!symbol)
     return;
 
   for (auto& call : symbol->callers)
   {
     u32 caller_addr = call.call_address;
-    Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(caller_addr);
+    Common::Symbol* caller_symbol = g_symbolDB.GetSymbolFromAddr(caller_addr);
     if (caller_symbol)
     {
       int idx = callers->Append(StrToWxStr(
@@ -454,7 +454,7 @@ void CCodeWindow::UpdateLists()
   for (auto& call : symbol->calls)
   {
     u32 call_addr = call.function;
-    Symbol* call_symbol = g_symbolDB.GetSymbolFromAddr(call_addr);
+    Common::Symbol* call_symbol = g_symbolDB.GetSymbolFromAddr(call_addr);
     if (call_symbol)
     {
       int idx = calls->Append(StrToWxStr(

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -335,7 +335,7 @@ void CCodeWindow::OnSymbolsMenu(wxCommandEvent& event)
         std::istringstream ss(line);
         ss >> std::hex >> address >> std::dec >> type >> name;
 
-        Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
+        Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(address);
         if (symbol)
           symbol->Rename(line.substr(12));
       }
@@ -474,10 +474,10 @@ void CCodeWindow::OnSymbolListChange(wxCommandEvent& event)
   int index = symbols->GetSelection();
   if (index >= 0)
   {
-    Symbol* pSymbol = static_cast<Symbol*>(symbols->GetClientData(index));
+    auto* pSymbol = static_cast<Common::Symbol*>(symbols->GetClientData(index));
     if (pSymbol != nullptr)
     {
-      if (pSymbol->type == Symbol::Type::Data)
+      if (pSymbol->type == Common::Symbol::Type::Data)
       {
         CMemoryWindow* memory = GetPanel<CMemoryWindow>();
         if (memory)

--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
@@ -223,10 +223,10 @@ void DSPDebuggerLLE::OnSymbolListChange(wxCommandEvent& event)
   int index = m_SymbolList->GetSelection();
   if (index >= 0)
   {
-    Symbol* pSymbol = static_cast<Symbol*>(m_SymbolList->GetClientData(index));
+    auto* pSymbol = static_cast<Common::Symbol*>(m_SymbolList->GetClientData(index));
     if (pSymbol != nullptr)
     {
-      if (pSymbol->type == Symbol::Type::Function)
+      if (pSymbol->type == Common::Symbol::Type::Function)
       {
         JumpToAddress(pSymbol->address);
       }

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -131,7 +131,7 @@ wxString CMemoryView::ReadMemoryAsString(u32 address) const
         str += ' ';
     }
 
-    Symbol* sym = g_symbolDB.GetSymbolFromAddr(mem_data);
+    Common::Symbol* sym = g_symbolDB.GetSymbolFromAddr(mem_data);
     if (sym)
     {
       str += StringFromFormat(" # -> %s", sym->name.c_str());


### PR DESCRIPTION
Minor individual changes and cleanups. This also namespaces the code as well so we can get general names like `Symbol` out of the global namespace.