### PR TITLE
CDUtils: Namespace code under the Common namespace

### DIFF
--- a/Source/Core/Common/CDUtils.cpp
+++ b/Source/Core/Common/CDUtils.cpp
@@ -34,6 +34,8 @@
 #include <linux/cdrom.h>
 #endif
 
+namespace Common
+{
 #ifdef _WIN32
 // takes a root drive path, returns true if it is a cdrom drive
 bool is_cdrom(const TCHAR* drive)
@@ -219,3 +221,4 @@ bool cdio_is_cdrom(std::string device)
   }
   return false;
 }
+}  // namespace Common

--- a/Source/Core/Common/CDUtils.cpp
+++ b/Source/Core/Common/CDUtils.cpp
@@ -38,13 +38,13 @@ namespace Common
 {
 #ifdef _WIN32
 // takes a root drive path, returns true if it is a cdrom drive
-bool is_cdrom(const TCHAR* drive)
+static bool IsCDROM(const TCHAR* drive)
 {
   return (DRIVE_CDROM == GetDriveType(drive));
 }
 
 // Returns a vector with the device names
-std::vector<std::string> cdio_get_devices()
+std::vector<std::string> GetCDDevices()
 {
   std::vector<std::string> drives;
 
@@ -55,7 +55,7 @@ std::vector<std::string> cdio_get_devices()
     auto drive = buff.data();
     while (*drive)
     {
-      if (is_cdrom(drive))
+      if (IsCDROM(drive))
       {
         std::string str(TStrToUTF8(drive));
         str.pop_back();  // we don't want the final backslash
@@ -72,7 +72,7 @@ std::vector<std::string> cdio_get_devices()
 }
 #elif defined __APPLE__
 // Returns a pointer to an array of strings with the device names
-std::vector<std::string> cdio_get_devices()
+std::vector<std::string> GetCDDevices()
 {
   io_object_t next_media;
   mach_port_t master_port;
@@ -150,7 +150,7 @@ static struct
     {nullptr, 0, 0}};
 
 // Returns true if a device is a block or char device and not a symbolic link
-static bool is_device(const std::string& source_name)
+static bool IsDevice(const std::string& source_name)
 {
   struct stat buf;
   if (0 != lstat(source_name.c_str(), &buf))
@@ -160,10 +160,10 @@ static bool is_device(const std::string& source_name)
 }
 
 // Check a device to see if it is a DVD/CD-ROM drive
-static bool is_cdrom(const std::string& drive, char* mnttype)
+static bool IsCDROM(const std::string& drive, char* mnttype)
 {
   // Check if the device exists
-  if (!is_device(drive))
+  if (!IsDevice(drive))
     return false;
 
   bool is_cd = false;
@@ -181,7 +181,7 @@ static bool is_cdrom(const std::string& drive, char* mnttype)
 }
 
 // Returns a pointer to an array of strings with the device names
-std::vector<std::string> cdio_get_devices()
+std::vector<std::string> GetCDDevices()
 {
   std::vector<std::string> drives;
   // Scan the system for DVD/CD-ROM drives.
@@ -190,7 +190,7 @@ std::vector<std::string> cdio_get_devices()
     for (unsigned int j = checklist[i].num_min; j <= checklist[i].num_max; ++j)
     {
       std::string drive = StringFromFormat(checklist[i].format, j);
-      if (is_cdrom(drive, nullptr))
+      if (IsCDROM(drive, nullptr))
       {
         drives.push_back(std::move(drive));
       }
@@ -201,7 +201,7 @@ std::vector<std::string> cdio_get_devices()
 #endif
 
 // Returns true if device is a cdrom/dvd drive
-bool cdio_is_cdrom(std::string device)
+bool IsCDROMDevice(std::string device)
 {
 #ifndef _WIN32
   // Resolve symbolic links. This allows symbolic links to valid
@@ -213,7 +213,7 @@ bool cdio_is_cdrom(std::string device)
   device = devname;
 #endif
 
-  std::vector<std::string> devices = cdio_get_devices();
+  std::vector<std::string> devices = GetCDDevices();
   for (const std::string& d : devices)
   {
     if (d == device)

--- a/Source/Core/Common/CDUtils.cpp
+++ b/Source/Core/Common/CDUtils.cpp
@@ -160,7 +160,7 @@ static bool IsDevice(const std::string& source_name)
 }
 
 // Check a device to see if it is a DVD/CD-ROM drive
-static bool IsCDROM(const std::string& drive, char* mnttype)
+static bool IsCDROM(const std::string& drive)
 {
   // Check if the device exists
   if (!IsDevice(drive))
@@ -190,7 +190,7 @@ std::vector<std::string> GetCDDevices()
     for (unsigned int j = checklist[i].num_min; j <= checklist[i].num_max; ++j)
     {
       std::string drive = StringFromFormat(checklist[i].format, j);
-      if (IsCDROM(drive, nullptr))
+      if (IsCDROM(drive))
       {
         drives.push_back(std::move(drive));
       }

--- a/Source/Core/Common/CDUtils.h
+++ b/Source/Core/Common/CDUtils.h
@@ -7,8 +7,11 @@
 #include <string>
 #include <vector>
 
+namespace Common
+{
 // Returns a pointer to an array of strings with the device names
 std::vector<std::string> cdio_get_devices();
 
 // Returns true if device is cdrom/dvd
 bool cdio_is_cdrom(std::string device);
+}  // namespace Common

--- a/Source/Core/Common/CDUtils.h
+++ b/Source/Core/Common/CDUtils.h
@@ -10,8 +10,8 @@
 namespace Common
 {
 // Returns a pointer to an array of strings with the device names
-std::vector<std::string> cdio_get_devices();
+std::vector<std::string> GetCDDevices();
 
 // Returns true if device is cdrom/dvd
-bool cdio_is_cdrom(std::string device);
+bool IsCDROMDevice(std::string device);
 }  // namespace Common

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<BootParameters>
 BootParameters::GenerateFromFile(const std::string& path,
                                  const std::optional<std::string>& savestate_path)
 {
-  const bool is_drive = cdio_is_cdrom(path);
+  const bool is_drive = Common::cdio_is_cdrom(path);
   // Check if the file exist, we may have gotten it from a --elf command line
   // that gave an incorrect file name
   if (!is_drive && !File::Exists(path))

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<BootParameters>
 BootParameters::GenerateFromFile(const std::string& path,
                                  const std::optional<std::string>& savestate_path)
 {
-  const bool is_drive = Common::cdio_is_cdrom(path);
+  const bool is_drive = Common::IsCDROMDevice(path);
   // Check if the file exist, we may have gotten it from a --elf command line
   // that gave an incorrect file name
   if (!is_drive && !File::Exists(path))

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -176,7 +176,7 @@ u32 SectorReader::ReadChunk(u8* buffer, u64 chunk_num)
 
 std::unique_ptr<BlobReader> CreateBlobReader(const std::string& filename)
 {
-  if (Common::cdio_is_cdrom(filename))
+  if (Common::IsCDROMDevice(filename))
     return DriveReader::Create(filename);
 
   File::IOFile file(filename, "rb");

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -176,7 +176,7 @@ u32 SectorReader::ReadChunk(u8* buffer, u64 chunk_num)
 
 std::unique_ptr<BlobReader> CreateBlobReader(const std::string& filename)
 {
-  if (cdio_is_cdrom(filename))
+  if (Common::cdio_is_cdrom(filename))
     return DriveReader::Create(filename);
 
   File::IOFile file(filename, "rb");

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -166,7 +166,7 @@ void MenuBar::AddDVDBackupMenu(QMenu* file_menu)
 {
   m_backup_menu = file_menu->addMenu(tr("&Boot from DVD Backup"));
 
-  const std::vector<std::string> drives = cdio_get_devices();
+  const std::vector<std::string> drives = Common::cdio_get_devices();
   // Windows Limitation of 24 character drives
   for (size_t i = 0; i < drives.size() && i < 24; i++)
   {

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -166,7 +166,7 @@ void MenuBar::AddDVDBackupMenu(QMenu* file_menu)
 {
   m_backup_menu = file_menu->addMenu(tr("&Boot from DVD Backup"));
 
-  const std::vector<std::string> drives = Common::cdio_get_devices();
+  const std::vector<std::string> drives = Common::GetCDDevices();
   // Windows Limitation of 24 character drives
   for (size_t i = 0; i < drives.size() && i < 24; i++)
   {

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -397,7 +397,7 @@ void GameListCtrl::RefreshList()
   if (SConfig::GetInstance().m_ListDrives)
   {
     std::unique_lock<std::mutex> lk(m_title_database_mutex);
-    for (const auto& drive : cdio_get_devices())
+    for (const auto& drive : Common::cdio_get_devices())
     {
       auto file = std::make_shared<UICommon::GameFile>(drive);
       if (file->IsValid())

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -397,7 +397,7 @@ void GameListCtrl::RefreshList()
   if (SConfig::GetInstance().m_ListDrives)
   {
     std::unique_lock<std::mutex> lk(m_title_database_mutex);
-    for (const auto& drive : Common::cdio_get_devices())
+    for (const auto& drive : Common::GetCDDevices())
     {
       auto file = std::make_shared<UICommon::GameFile>(drive);
       if (file->IsValid())

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -72,7 +72,7 @@ wxMenu* MainMenuBar::CreateFileMenu() const
 {
   auto* const external_drive_menu = new wxMenu;
 
-  const std::vector<std::string> drives = cdio_get_devices();
+  const std::vector<std::string> drives = Common::cdio_get_devices();
   // Windows Limitation of 24 character drives
   for (size_t i = 0; i < drives.size() && i < 24; i++)
   {

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -72,7 +72,7 @@ wxMenu* MainMenuBar::CreateFileMenu() const
 {
   auto* const external_drive_menu = new wxMenu;
 
-  const std::vector<std::string> drives = Common::cdio_get_devices();
+  const std::vector<std::string> drives = Common::GetCDDevices();
   // Windows Limitation of 24 character drives
   for (size_t i = 0; i < drives.size() && i < 24; i++)
   {


### PR DESCRIPTION
Moves more common code into the Common namespace where it belongs. While we're in this area, also clean it up a little bit to match our coding style.