### PR TITLE
ColorUtil: Namespace code under the Common namespace

### DIFF
--- a/Source/Core/Common/ColorUtil.cpp
+++ b/Source/Core/Common/ColorUtil.cpp
@@ -40,7 +40,7 @@ static u32 Decode5A3(u16 val)
   return (a << 24) | (r << 16) | (g << 8) | b;
 }
 
-void decode5A3image(u32* dst, const u16* src, int width, int height)
+void Decode5A3Image(u32* dst, const u16* src, int width, int height)
 {
   for (int y = 0; y < height; y += 4)
   {
@@ -58,7 +58,7 @@ void decode5A3image(u32* dst, const u16* src, int width, int height)
   }
 }
 
-void decodeCI8image(u32* dst, const u8* src, const u16* pal, int width, int height)
+void DecodeCI8Image(u32* dst, const u8* src, const u16* pal, int width, int height)
 {
   for (int y = 0; y < height; y += 4)
   {

--- a/Source/Core/Common/ColorUtil.cpp
+++ b/Source/Core/Common/ColorUtil.cpp
@@ -5,7 +5,7 @@
 #include "Common/ColorUtil.h"
 #include "Common/Swap.h"
 
-namespace ColorUtil
+namespace Common
 {
 static const int s_lut5to8[] = {0x00, 0x08, 0x10, 0x18, 0x20, 0x29, 0x31, 0x39, 0x41, 0x4A, 0x52,
                                 0x5A, 0x62, 0x6A, 0x73, 0x7B, 0x83, 0x8B, 0x94, 0x9C, 0xA4, 0xAC,
@@ -70,11 +70,10 @@ void decodeCI8image(u32* dst, const u8* src, const u16* pal, int width, int heig
         for (int ix = 0; ix < 8; ix++)
         {
           // huh, this seems wrong. CI8, not 5A3, no?
-          tdst[ix] = ColorUtil::Decode5A3(Common::swap16(pal[src[ix]]));
+          tdst[ix] = Decode5A3(Common::swap16(pal[src[ix]]));
         }
       }
     }
   }
 }
-
-}  // namespace
+}  // namespace Common

--- a/Source/Core/Common/ColorUtil.h
+++ b/Source/Core/Common/ColorUtil.h
@@ -6,9 +6,8 @@
 
 #include "Common/CommonTypes.h"
 
-namespace ColorUtil
+namespace Common
 {
 void decode5A3image(u32* dst, const u16* src, int width, int height);
 void decodeCI8image(u32* dst, const u8* src, const u16* pal, int width, int height);
-
-}  // namespace
+}  // namespace Common

--- a/Source/Core/Common/ColorUtil.h
+++ b/Source/Core/Common/ColorUtil.h
@@ -8,6 +8,6 @@
 
 namespace Common
 {
-void decode5A3image(u32* dst, const u16* src, int width, int height);
-void decodeCI8image(u32* dst, const u8* src, const u16* pal, int width, int height);
+void Decode5A3Image(u32* dst, const u16* src, int width, int height);
+void DecodeCI8Image(u32* dst, const u8* src, const u16* pal, int width, int height);
 }  // namespace Common

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1082,13 +1082,13 @@ bool GCMemcard::ReadBannerRGBA8(u8 index, u32* buffer) const
     u8* pxdata = (u8*)(mc_data_blocks[DataBlock].block + DataOffset);
     u16* paldata = (u16*)(mc_data_blocks[DataBlock].block + DataOffset + pixels);
 
-    ColorUtil::decodeCI8image(buffer, pxdata, paldata, 96, 32);
+    Common::decodeCI8image(buffer, pxdata, paldata, 96, 32);
   }
   else
   {
     u16* pxdata = (u16*)(mc_data_blocks[DataBlock].block + DataOffset);
 
-    ColorUtil::decode5A3image(buffer, pxdata, 96, 32);
+    Common::decode5A3image(buffer, pxdata, 96, 32);
   }
   return true;
 }
@@ -1182,16 +1182,16 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
       switch (fmts[i])
       {
       case CI8SHARED:  // CI8 with shared palette
-        ColorUtil::decodeCI8image(buffer, data[i], sharedPal, 32, 32);
+        Common::decodeCI8image(buffer, data[i], sharedPal, 32, 32);
         buffer += 32 * 32;
         break;
       case RGB5A3:  // RGB5A3
-        ColorUtil::decode5A3image(buffer, (u16*)(data[i]), 32, 32);
+        Common::decode5A3image(buffer, (u16*)(data[i]), 32, 32);
         buffer += 32 * 32;
         break;
       case CI8:  // CI8 with own palette
         const u16* paldata = reinterpret_cast<u16*>(data[i] + 32 * 32);
-        ColorUtil::decodeCI8image(buffer, data[i], paldata, 32, 32);
+        Common::decodeCI8image(buffer, data[i], paldata, 32, 32);
         buffer += 32 * 32;
         break;
       }
@@ -1208,15 +1208,15 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
           switch (fmts[j])
           {
           case CI8SHARED:  // CI8 with shared palette
-            ColorUtil::decodeCI8image(buffer, data[j], sharedPal, 32, 32);
+            Common::decodeCI8image(buffer, data[j], sharedPal, 32, 32);
             break;
           case RGB5A3:  // RGB5A3
-            ColorUtil::decode5A3image(buffer, (u16*)(data[j]), 32, 32);
+            Common::decode5A3image(buffer, (u16*)(data[j]), 32, 32);
             buffer += 32 * 32;
             break;
           case CI8:  // CI8 with own palette
             const u16* paldata = reinterpret_cast<u16*>(data[j] + 32 * 32);
-            ColorUtil::decodeCI8image(buffer, data[j], paldata, 32, 32);
+            Common::decodeCI8image(buffer, data[j], paldata, 32, 32);
             buffer += 32 * 32;
             break;
           }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1082,13 +1082,13 @@ bool GCMemcard::ReadBannerRGBA8(u8 index, u32* buffer) const
     u8* pxdata = (u8*)(mc_data_blocks[DataBlock].block + DataOffset);
     u16* paldata = (u16*)(mc_data_blocks[DataBlock].block + DataOffset + pixels);
 
-    Common::decodeCI8image(buffer, pxdata, paldata, 96, 32);
+    Common::DecodeCI8Image(buffer, pxdata, paldata, 96, 32);
   }
   else
   {
     u16* pxdata = (u16*)(mc_data_blocks[DataBlock].block + DataOffset);
 
-    Common::decode5A3image(buffer, pxdata, 96, 32);
+    Common::Decode5A3Image(buffer, pxdata, 96, 32);
   }
   return true;
 }
@@ -1182,16 +1182,16 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
       switch (fmts[i])
       {
       case CI8SHARED:  // CI8 with shared palette
-        Common::decodeCI8image(buffer, data[i], sharedPal, 32, 32);
+        Common::DecodeCI8Image(buffer, data[i], sharedPal, 32, 32);
         buffer += 32 * 32;
         break;
       case RGB5A3:  // RGB5A3
-        Common::decode5A3image(buffer, (u16*)(data[i]), 32, 32);
+        Common::Decode5A3Image(buffer, (u16*)(data[i]), 32, 32);
         buffer += 32 * 32;
         break;
       case CI8:  // CI8 with own palette
         const u16* paldata = reinterpret_cast<u16*>(data[i] + 32 * 32);
-        Common::decodeCI8image(buffer, data[i], paldata, 32, 32);
+        Common::DecodeCI8Image(buffer, data[i], paldata, 32, 32);
         buffer += 32 * 32;
         break;
       }
@@ -1208,15 +1208,15 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
           switch (fmts[j])
           {
           case CI8SHARED:  // CI8 with shared palette
-            Common::decodeCI8image(buffer, data[j], sharedPal, 32, 32);
+            Common::DecodeCI8Image(buffer, data[j], sharedPal, 32, 32);
             break;
           case RGB5A3:  // RGB5A3
-            Common::decode5A3image(buffer, (u16*)(data[j]), 32, 32);
+            Common::Decode5A3Image(buffer, (u16*)(data[j]), 32, 32);
             buffer += 32 * 32;
             break;
           case CI8:  // CI8 with own palette
             const u16* paldata = reinterpret_cast<u16*>(data[j] + 32 * 32);
-            Common::decodeCI8image(buffer, data[j], paldata, 32, 32);
+            Common::DecodeCI8Image(buffer, data[j], paldata, 32, 32);
             buffer += 32 * 32;
             break;
           }

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -244,8 +244,8 @@ VolumeGC::ConvertedGCBanner VolumeGC::ExtractBannerInformation(const GCBanner& b
   banner.image_width = GC_BANNER_WIDTH;
   banner.image_height = GC_BANNER_HEIGHT;
   banner.image_buffer = std::vector<u32>(GC_BANNER_WIDTH * GC_BANNER_HEIGHT);
-  ColorUtil::decode5A3image(banner.image_buffer.data(), banner_file.image, GC_BANNER_WIDTH,
-                            GC_BANNER_HEIGHT);
+  Common::decode5A3image(banner.image_buffer.data(), banner_file.image, GC_BANNER_WIDTH,
+                         GC_BANNER_HEIGHT);
 
   for (u32 i = 0; i < number_of_languages; ++i)
   {

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -244,7 +244,7 @@ VolumeGC::ConvertedGCBanner VolumeGC::ExtractBannerInformation(const GCBanner& b
   banner.image_width = GC_BANNER_WIDTH;
   banner.image_height = GC_BANNER_HEIGHT;
   banner.image_buffer = std::vector<u32>(GC_BANNER_WIDTH * GC_BANNER_HEIGHT);
-  Common::decode5A3image(banner.image_buffer.data(), banner_file.image, GC_BANNER_WIDTH,
+  Common::Decode5A3Image(banner.image_buffer.data(), banner_file.image, GC_BANNER_WIDTH,
                          GC_BANNER_HEIGHT);
 
   for (u32 i = 0; i < number_of_languages; ++i)

--- a/Source/Core/DiscIO/WiiSaveBanner.cpp
+++ b/Source/Core/DiscIO/WiiSaveBanner.cpp
@@ -69,7 +69,7 @@ std::vector<u32> WiiSaveBanner::GetBanner(u32* width, u32* height) const
     return std::vector<u32>();
 
   std::vector<u32> image_buffer(BANNER_WIDTH * BANNER_HEIGHT);
-  Common::decode5A3image(image_buffer.data(), banner_data.data(), BANNER_WIDTH, BANNER_HEIGHT);
+  Common::Decode5A3Image(image_buffer.data(), banner_data.data(), BANNER_WIDTH, BANNER_HEIGHT);
 
   *width = BANNER_WIDTH;
   *height = BANNER_HEIGHT;

--- a/Source/Core/DiscIO/WiiSaveBanner.cpp
+++ b/Source/Core/DiscIO/WiiSaveBanner.cpp
@@ -69,7 +69,7 @@ std::vector<u32> WiiSaveBanner::GetBanner(u32* width, u32* height) const
     return std::vector<u32>();
 
   std::vector<u32> image_buffer(BANNER_WIDTH * BANNER_HEIGHT);
-  ColorUtil::decode5A3image(image_buffer.data(), banner_data.data(), BANNER_WIDTH, BANNER_HEIGHT);
+  Common::decode5A3image(image_buffer.data(), banner_data.data(), BANNER_WIDTH, BANNER_HEIGHT);
 
   *width = BANNER_WIDTH;
   *height = BANNER_HEIGHT;


### PR DESCRIPTION
Given this is part of Common, it should be under the Common namespace. Now that it's under the Common namespace, the ColorUtil one isn't really necessary, so we can get rid of it.