### PR TITLE
Common: Remove unnecessary ~9 year old LOGGING preprocessor define

### DIFF
--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -4,13 +4,6 @@
 
 #pragma once
 
-// Force enable logging in the right modes. For some reason, something had changed
-// so that debugfast no longer logged.
-#if defined(_DEBUG) || defined(DEBUGFAST)
-#undef LOGGING
-#define LOGGING 1
-#endif
-
 #if defined(__GNUC__) || __clang__
 // Disable "unused function" warnings for the ones manually marked as such.
 #define UNUSED __attribute__((unused))

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -81,7 +81,7 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char*
 #endif
     ;
 
-#if defined LOGGING || defined _DEBUG || defined DEBUGFAST
+#if defined(_DEBUG) || defined(DEBUGFAST)
 #define MAX_LOGLEVEL LogTypes::LOG_LEVELS::LDEBUG
 #else
 #ifndef MAX_LOGLEVEL


### PR DESCRIPTION
This was added in 4bdb4aa0d1c8520488583ba79c9f5ab6e5656eca back in 2009-02-27. The only usage spot of this macro involves the same checks that were used to define that preprocessor macro, so we can simply remove the macro