### PR TITLE
DX11 post processing

### DIFF
--- a/Data/Sys/Shaders/16bit.hlsl
+++ b/Data/Sys/Shaders/16bit.hlsl
@@ -1,0 +1,54 @@
+float4 main(float4 _ : SV_Position, float2 coord : TEXCOORD) : SV_Target
+{
+	//Change this number to increase the pixel size.
+	float pixelSize = 3.0;
+
+	float red	= 0.0;
+	float green	= 0.0;
+	float blue	= 0.0;
+
+	float2 pos = floor(coord * g_ResolutionF / pixelSize) * pixelSize * g_InvResolutionF;
+
+	float4 c0 = g_FrameBuffer.Sample(g_DefaultSampler, pos);
+
+	if (c0.r < 0.1)
+		red = 0.1;
+	else if (c0.r < 0.20)
+		red = 0.20;
+	else if (c0.r < 0.40)
+		red = 0.40;
+	else if (c0.r < 0.60)
+		red = 0.60;
+	else if (c0.r < 0.80)
+		red = 0.80;
+	else
+		red = 1.0;
+
+	if (c0.b < 0.1)
+		blue = 0.1;
+	else if (c0.b < 0.20)
+		blue = 0.20;
+	else if (c0.b < 0.40)
+		blue = 0.40;
+	else if (c0.b < 0.60)
+		blue = 0.60;
+	else if (c0.b < 0.80)
+		blue = 0.80;
+	else
+		blue = 1.0;
+
+	if (c0.g < 0.1)
+		green = 0.1;
+	else if (c0.g < 0.20)
+		green = 0.20;
+	else if (c0.g < 0.40)
+		green = 0.40;
+	else if (c0.g < 0.60)
+		green = 0.60;
+	else if (c0.g < 0.80)
+		green = 0.80;
+	else
+		green = 1.0;
+
+	return float4(red, green, blue, c0.a);
+}

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -186,7 +186,7 @@ void EnhancementsWidget::LoadPPShaders()
   PostProcessingShaderConfiguration pp_shader;
   if (selected_shader != "(off)")
   {
-    pp_shader.LoadShader(selected_shader);
+    pp_shader.LoadShader(g_Config.backend_info.api_type, selected_shader);
     m_configure_pp_effect->setEnabled(pp_shader.HasOptions());
   }
 }
@@ -258,7 +258,8 @@ void EnhancementsWidget::SaveSettings()
   PostProcessingShaderConfiguration pp_shader;
   if (Config::Get(Config::GFX_ENHANCE_POST_SHADER) != "(off)")
   {
-    pp_shader.LoadShader(Config::Get(Config::GFX_ENHANCE_POST_SHADER));
+    pp_shader.LoadShader(g_Config.backend_info.api_type,
+                         Config::Get(Config::GFX_ENHANCE_POST_SHADER));
     m_configure_pp_effect->setEnabled(pp_shader.HasOptions());
   }
   else

--- a/Source/Core/DolphinQt2/Config/Graphics/PostProcessingConfigWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/PostProcessingConfigWindow.cpp
@@ -38,7 +38,7 @@ PostProcessingConfigWindow::PostProcessingConfigWindow(EnhancementsWidget* paren
   else
   {
     m_post_processor = new PostProcessingShaderConfiguration();
-    m_post_processor->LoadShader(m_shader);
+    m_post_processor->LoadShader(g_Config.backend_info.api_type, m_shader);
   }
 
   setWindowTitle(tr("Post Processing Shader Configuration"));

--- a/Source/Core/DolphinWX/PostProcessingConfigDiag.cpp
+++ b/Source/Core/DolphinWX/PostProcessingConfigDiag.cpp
@@ -17,6 +17,7 @@
 #include "DolphinWX/PostProcessingConfigDiag.h"
 
 #include "VideoCommon/RenderBase.h"
+#include "VideoCommon/VideoConfig.h"
 
 PostProcessingConfigDiag::PostProcessingConfigDiag(wxWindow* parent, const std::string& shader)
     : wxDialog(parent, wxID_ANY, _("Post Processing Shader Configuration")), m_shader(shader)
@@ -30,7 +31,7 @@ PostProcessingConfigDiag::PostProcessingConfigDiag(wxWindow* parent, const std::
   else
   {
     m_post_processor = new PostProcessingShaderConfiguration();
-    m_post_processor->LoadShader(m_shader);
+    m_post_processor->LoadShader(g_Config.backend_info.api_type, m_shader);
   }
 
   // Create our UI classes

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -1018,7 +1018,7 @@ void VideoConfigDiag::Event_PPShader(wxCommandEvent& ev)
 
   // Should we enable the configuration button?
   PostProcessingShaderConfiguration postprocessing_shader;
-  postprocessing_shader.LoadShader(shader);
+  postprocessing_shader.LoadShader(g_Config.backend_info.api_type, shader);
   button_config_pp->Enable(postprocessing_shader.HasOptions());
 
   ev.Skip();
@@ -1243,7 +1243,7 @@ void VideoConfigDiag::PopulatePostProcessingShaders()
 
   // Should the configuration button be loaded by default?
   PostProcessingShaderConfiguration postprocessing_shader;
-  postprocessing_shader.LoadShader(vconfig.sPostProcessingShader);
+  postprocessing_shader.LoadShader(g_Config.backend_info.api_type, vconfig.sPostProcessingShader);
   button_config_pp->Enable(postprocessing_shader.HasOptions());
 }
 

--- a/Source/Core/VideoBackends/D3D/D3D.vcxproj
+++ b/Source/Core/VideoBackends/D3D/D3D.vcxproj
@@ -39,6 +39,7 @@
     <ClCompile Include="BoundingBox.cpp" />
     <ClCompile Include="D3DBase.cpp" />
     <ClCompile Include="D3DBlob.cpp" />
+    <ClCompile Include="D3DPostProcessing.cpp" />
     <ClCompile Include="D3DShader.cpp" />
     <ClCompile Include="D3DState.cpp" />
     <ClCompile Include="D3DTexture.cpp" />
@@ -62,6 +63,7 @@
     <ClInclude Include="BoundingBox.h" />
     <ClInclude Include="D3DBase.h" />
     <ClInclude Include="D3DBlob.h" />
+    <ClInclude Include="D3DPostProcessing.h" />
     <ClInclude Include="D3DShader.h" />
     <ClInclude Include="D3DState.h" />
     <ClInclude Include="D3DTexture.h" />

--- a/Source/Core/VideoBackends/D3D/D3D.vcxproj.filters
+++ b/Source/Core/VideoBackends/D3D/D3D.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="DXPipeline.cpp">
       <Filter>Render</Filter>
     </ClCompile>
+    <ClCompile Include="D3DPostProcessing.cpp">
+      <Filter>D3D</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="D3DBase.h">
@@ -129,6 +132,9 @@
     </ClInclude>
     <ClInclude Include="DXPipeline.h">
       <Filter>Render</Filter>
+    </ClInclude>
+    <ClInclude Include="D3DPostProcessing.h">
+      <Filter>D3D</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/Core/VideoBackends/D3D/D3DPostProcessing.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DPostProcessing.cpp
@@ -1,0 +1,30 @@
+// Copyright 2010 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoBackends/D3D/D3DPostProcessing.h"
+#include "VideoBackends/D3D/D3DUtil.h"
+#include "VideoBackends/D3D/PixelShaderCache.h"
+#include "VideoBackends/D3D/VertexShaderCache.h"
+
+namespace DX11
+{
+
+D3DPostProcessing::D3DPostProcessing()
+{
+}
+
+D3DPostProcessing::~D3DPostProcessing()
+{
+}
+
+void D3DPostProcessing::PostProcessTexture(ID3D11ShaderResourceView* srv, RECT* rect, u32 src_width,
+                                           u32 src_height, D3D11_VIEWPORT viewport, u32 slice)
+{
+  D3D::drawShadedTexQuad(srv, rect, src_width, src_height,
+                         PixelShaderCache::GetColorCopyProgram(false),
+                         VertexShaderCache::GetSimpleVertexShader(),
+                         VertexShaderCache::GetSimpleInputLayout(), nullptr, slice);
+}
+
+}  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DPostProcessing.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DPostProcessing.cpp
@@ -2,29 +2,113 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Align.h"
 #include "VideoBackends/D3D/D3DPostProcessing.h"
+#include "VideoBackends/D3D/D3DShader.h"
 #include "VideoBackends/D3D/D3DUtil.h"
 #include "VideoBackends/D3D/PixelShaderCache.h"
 #include "VideoBackends/D3D/VertexShaderCache.h"
 
 namespace DX11
 {
+// Dummy SV_Position variable is needed because GetSimpleVertexShader outputs TEXCOORD in v1
+static const char s_default_shader[] = R"(
+float4 main(float4 _ : SV_Position, float2 coord : TEXCOORD) : SV_Target
+{
+  return g_FrameBuffer.Sample(g_DefaultSampler, coord);
+}
+)";
+
+static const char s_hlsl_prefix[] = R"(
+Texture2D g_FrameBuffer;
+SamplerState g_DefaultSampler;
+cbuffer Globals : register(b0)
+{
+  uint2 g_Resolution;
+  float2 g_ResolutionF;
+  float2 g_InvResolutionF;
+  uint g_Time;
+}
+)";
+
+#pragma pack(push, 4)
+struct CBGlobal
+{
+  u32 resX, resY;
+  float resFX, resFY;
+  float invResX, invResY;
+  u32 time;
+};
+#pragma pack(pop)
 
 D3DPostProcessing::D3DPostProcessing()
 {
+  D3D11_BUFFER_DESC bdesc;
+  bdesc.ByteWidth = static_cast<UINT>(Common::AlignUp(sizeof(CBGlobal), 16));
+  bdesc.Usage = D3D11_USAGE_DYNAMIC;
+  bdesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+  bdesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+  bdesc.MiscFlags = 0;
+  bdesc.StructureByteStride = 0;
+  HRESULT hr;
+  hr = D3D::device->CreateBuffer(&bdesc, nullptr, &m_globals_cb);
+  CHECK(SUCCEEDED(hr), "Create D3D Post Processing CB.");
+  D3D::SetDebugObjectName(m_globals_cb, "constant buffer of D3D Post Processing");
 }
 
 D3DPostProcessing::~D3DPostProcessing()
 {
+  if (m_current_ps)
+    m_current_ps->Release();
+  m_globals_cb->Release();
 }
 
 void D3DPostProcessing::PostProcessTexture(ID3D11ShaderResourceView* srv, RECT* rect, u32 src_width,
                                            u32 src_height, D3D11_VIEWPORT viewport, u32 slice)
 {
-  D3D::drawShadedTexQuad(srv, rect, src_width, src_height,
-                         PixelShaderCache::GetColorCopyProgram(false),
+  UpdateConfig();
+
+  D3D11_MAPPED_SUBRESOURCE msr;
+  HRESULT hr;
+  hr = D3D::context->Map(m_globals_cb, 0, D3D11_MAP_WRITE_DISCARD, 0, &msr);
+  CHECK(SUCCEEDED(hr), "Map D3D Post Processing CB.");
+  CBGlobal* pCb = reinterpret_cast<CBGlobal*>(msr.pData);
+  pCb->resX = src_width;
+  pCb->resY = src_height;
+  pCb->resFX = src_width;
+  pCb->resFY = src_height;
+  pCb->invResX = 1.0f / src_width;
+  pCb->invResY = 1.0f / src_height;
+  pCb->time = static_cast<u32>(m_timer.GetTimeElapsed());
+  D3D::context->Unmap(m_globals_cb, 0);
+
+  D3D::context->PSSetConstantBuffers(0, 1, &m_globals_cb);
+
+  D3D::drawShadedTexQuad(srv, rect, src_width, src_height, m_current_ps,
                          VertexShaderCache::GetSimpleVertexShader(),
                          VertexShaderCache::GetSimpleInputLayout(), nullptr, slice);
+}
+
+ID3D11PixelShader* D3DPostProcessing::CompileShader(const std::string& source)
+{
+  return D3D::CompileAndCreatePixelShader(s_hlsl_prefix + source);
+}
+
+void D3DPostProcessing::UpdateConfig()
+{
+  if (m_config.GetShader() == g_ActiveConfig.sPostProcessingShader)
+    return;
+
+  std::string source = m_config.LoadShader(APIType::D3D);
+  if (source.empty())
+    source = s_default_shader;
+
+  if (m_current_ps)
+    m_current_ps->Release();
+
+  m_current_ps = CompileShader(source);
+  D3D::SetDebugObjectName(
+      m_current_ps, (std::string("D3D Post Processing shader: ") + m_config.GetShader()).c_str());
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DPostProcessing.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DPostProcessing.cpp
@@ -89,6 +89,12 @@ void D3DPostProcessing::PostProcessTexture(ID3D11ShaderResourceView* srv, RECT* 
                          VertexShaderCache::GetSimpleInputLayout(), nullptr, slice);
 }
 
+bool D3DPostProcessing::IsActive()
+{
+  UpdateConfig();
+  return !m_ps_is_default;
+}
+
 ID3D11PixelShader* D3DPostProcessing::CompileShader(const std::string& source)
 {
   return D3D::CompileAndCreatePixelShader(s_hlsl_prefix + source);
@@ -101,7 +107,14 @@ void D3DPostProcessing::UpdateConfig()
 
   std::string source = m_config.LoadShader(APIType::D3D);
   if (source.empty())
+  {
+    m_ps_is_default = true;
     source = s_default_shader;
+  }
+  else
+  {
+    m_ps_is_default = false;
+  }
 
   if (m_current_ps)
     m_current_ps->Release();

--- a/Source/Core/VideoBackends/D3D/D3DPostProcessing.h
+++ b/Source/Core/VideoBackends/D3D/D3DPostProcessing.h
@@ -1,0 +1,25 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <d3d11.h>
+#include "VideoCommon/PostProcessing.h"
+#include "VideoCommon/VideoCommon.h"
+
+namespace DX11
+{
+class D3DPostProcessing : public PostProcessingShaderImplementation
+{
+public:
+  D3DPostProcessing();
+  ~D3DPostProcessing();
+
+  void PostProcessTexture(ID3D11ShaderResourceView* srv, RECT* rect, u32 src_width, u32 src_height,
+                          D3D11_VIEWPORT viewport, u32 slice);
+
+private:
+};
+
+}  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DPostProcessing.h
+++ b/Source/Core/VideoBackends/D3D/D3DPostProcessing.h
@@ -18,10 +18,12 @@ public:
 
   void PostProcessTexture(ID3D11ShaderResourceView* srv, RECT* rect, u32 src_width, u32 src_height,
                           D3D11_VIEWPORT viewport, u32 slice);
+  bool IsActive();
 
 private:
   ID3D11Buffer* m_globals_cb = nullptr;
   ID3D11PixelShader* m_current_ps = nullptr;
+  bool m_ps_is_default = true;
 
   ID3D11PixelShader* CompileShader(const std::string& source);
   void UpdateConfig();

--- a/Source/Core/VideoBackends/D3D/D3DPostProcessing.h
+++ b/Source/Core/VideoBackends/D3D/D3DPostProcessing.h
@@ -20,6 +20,11 @@ public:
                           D3D11_VIEWPORT viewport, u32 slice);
 
 private:
+  ID3D11Buffer* m_globals_cb = nullptr;
+  ID3D11PixelShader* m_current_ps = nullptr;
+
+  ID3D11PixelShader* CompileShader(const std::string& source);
+  void UpdateConfig();
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -57,7 +57,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupportsComputeShaders = false;
   g_Config.backend_info.bSupports3DVision = true;
-  g_Config.backend_info.bSupportsPostProcessing = false;
+  g_Config.backend_info.bSupportsPostProcessing = true;
   g_Config.backend_info.bSupportsPaletteConversion = true;
   g_Config.backend_info.bSupportsClipControl = true;
   g_Config.backend_info.bSupportsDepthClamp = true;

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -28,6 +28,8 @@ static const char s_vertex_shader[] = "out vec2 uv0;\n"
                                       "	uv0 = vec2(mix(src_rect.xy, src_rect.zw, rawpos));\n"
                                       "}\n";
 
+static const char s_fragment_shader[] = "void main(){SetOutput(Sample());}\n";
+
 OpenGLPostProcessing::OpenGLPostProcessing() : m_initialized(false)
 {
   CreateHeader();
@@ -134,6 +136,8 @@ void OpenGLPostProcessing::ApplyShader()
 
   // load shader code
   std::string main_code = m_config.LoadShader();
+  if (main_code.empty())
+    main_code = s_fragment_shader;
   std::string options_code = LoadShaderOptions();
   std::string code = m_glsl_header + options_code + main_code;
 

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -135,7 +135,7 @@ void OpenGLPostProcessing::ApplyShader()
   m_uniform_bindings.clear();
 
   // load shader code
-  std::string main_code = m_config.LoadShader();
+  std::string main_code = m_config.LoadShader(APIType::OpenGL);
   if (main_code.empty())
     main_code = s_fragment_shader;
   std::string options_code = LoadShaderOptions();
@@ -146,7 +146,7 @@ void OpenGLPostProcessing::ApplyShader()
   {
     ERROR_LOG(VIDEO, "Failed to compile post-processing shader %s", m_config.GetShader().c_str());
     Config::SetCurrent(Config::GFX_ENHANCE_POST_SHADER, "");
-    code = m_config.LoadShader();
+    code = m_config.LoadShader(APIType::OpenGL);
     ProgramShaderCache::CompileShader(m_shader, s_vertex_shader, code);
   }
 

--- a/Source/Core/VideoBackends/Vulkan/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/Vulkan/PostProcessing.cpp
@@ -253,6 +253,8 @@ bool VulkanPostProcessing::RecompileShader()
 
   // Generate GLSL and compile the new shader.
   std::string main_code = m_config.LoadShader();
+  if (main_code.empty())
+    main_code = DEFAULT_FRAGMENT_SHADER_SOURCE;
   std::string options_code = GetGLSLUniformBlock();
   std::string code = options_code + POSTPROCESSING_SHADER_HEADER + main_code;
   m_fragment_shader = Util::CompileAndCreateFragmentShader(code);

--- a/Source/Core/VideoBackends/Vulkan/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/Vulkan/PostProcessing.cpp
@@ -252,7 +252,7 @@ bool VulkanPostProcessing::RecompileShader()
     return true;
 
   // Generate GLSL and compile the new shader.
-  std::string main_code = m_config.LoadShader();
+  std::string main_code = m_config.LoadShader(APIType::Vulkan);
   if (main_code.empty())
     main_code = DEFAULT_FRAGMENT_SHADER_SOURCE;
   std::string options_code = GetGLSLUniformBlock();

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -76,7 +76,7 @@ PostProcessingShaderConfiguration::PostProcessingShaderConfiguration() = default
 
 PostProcessingShaderConfiguration::~PostProcessingShaderConfiguration() = default;
 
-std::string PostProcessingShaderConfiguration::LoadShader(std::string shader)
+std::string PostProcessingShaderConfiguration::LoadShader(APIType api_type, std::string shader)
 {
   // Load the shader from the configuration if there isn't one sent to us.
   if (shader == "")
@@ -88,14 +88,15 @@ std::string PostProcessingShaderConfiguration::LoadShader(std::string shader)
 
   // loading shader code
   std::string code;
-  std::string path = File::GetUserPath(D_SHADERS_IDX) + sub_dir + shader + ".glsl";
+  std::string path = File::GetUserPath(D_SHADERS_IDX) + sub_dir + shader + GetShaderExtension(api_type);
 
   if (shader != "")
   {
     if (!File::Exists(path))
     {
       // Fallback to shared user dir
-      path = File::GetSysDirectory() + SHADERS_DIR DIR_SEP + sub_dir + shader + ".glsl";
+      path = File::GetSysDirectory() + SHADERS_DIR DIR_SEP + sub_dir + shader +
+             GetShaderExtension(api_type);
     }
 
     if (!File::ReadFileToString(path, code))

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -54,7 +54,7 @@ public:
   // Loads the configuration with a shader
   // If the argument is "" the class will load the shader from the g_activeConfig option.
   // Returns the loaded shader source from file
-  std::string LoadShader(std::string shader = "");
+  std::string LoadShader(APIType api_type, std::string shader = "");
   void SaveOptionsConfiguration();
   void ReloadShader();
   const std::string& GetShader() const { return m_current_shader; }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -149,7 +149,7 @@ struct VideoConfig final
   bool bDumpTevStages;
   bool bDumpTevTextureFetches;
 
-  // Enable API validation layers, currently only supported with Vulkan.
+  // Enable API validation layers, currently only supported with D3D & Vulkan.
   bool bEnableValidationLayer;
 
   // Multithreaded submission, currently only supported with Vulkan.


### PR DESCRIPTION
DX11 post processing using HLSL shaders. I don't expect this to be merged as per our conversation on IRC, but I'm leaving it here in case it's useful for someone in the future (hi @stenzek). I feel this approach is leaner than inventing a pseudo-language that's macroed from HLSL to be sort of GLSL or vice versa. Of course, this approach is not without its drawbacks either.

Some thoughts I had during development:

Anaglyph stereo is a bit hacky on the D3D side of things, because it's technically a post-processing step. If users were allowed to make "full" HLSL shaders (without the header prepended by D3DPostProcessing, having full control instead) then it could be done as a regular post-processing shader - just declare the framebuffer as a Texture2DArray instead of depending on the implicit conversion.

It would've also made my life easier if the order of position and texcoord were swapped in the basic `VertexShaderCache`/`PixelShaderCache` shaders, but I wanted to keep the scope of this branch small so I didn't touch them.