### PR TITLE
Common: Move host communication enum to Host.h

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -87,13 +87,13 @@ void Host_RefreshDSPDebuggerWindow()
 {
 }
 
-void Host_Message(int Id)
+void Host_Message(HostMessageID id)
 {
-  if (Id == WM_USER_JOB_DISPATCH)
+  if (id == HostMessageID::WMUserJobDispatch)
   {
     s_update_main_frame_event.Set();
   }
-  else if (Id == WM_USER_STOP)
+  else if (id == HostMessageID::WMUserStop)
   {
     s_have_wm_user_stop = true;
     if (Core::IsRunning())

--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -57,13 +57,3 @@ struct CrtDebugBreak
 // Dummy macro for marking translatable strings that can not be immediately translated.
 // wxWidgets does not have a true dummy macro for this.
 #define _trans(a) a
-
-// Host communication.
-enum HOST_COMM
-{
-  // Begin at 10 in case there is already messages with wParam = 0, 1, 2 and so on
-  WM_USER_STOP = 10,
-  WM_USER_CREATE,
-  WM_USER_SETCURSOR,
-  WM_USER_JOB_DISPATCH,
-};

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -291,7 +291,7 @@ static void CPUSetInitialExecutionState()
     SetState(SConfig::GetInstance().bBootToPause ? State::Paused : State::Running);
     Host_UpdateDisasmDialog();
     Host_UpdateMainFrame();
-    Host_Message(WM_USER_CREATE);
+    Host_Message(HostMessageID::WMUserCreate);
   });
 }
 
@@ -924,7 +924,7 @@ void QueueHostJob(std::function<void()> job, bool run_during_stop)
   }
   // If the the queue was empty then kick the Host to come and get this job.
   if (send_message)
-    Host_Message(WM_USER_JOB_DISPATCH);
+    Host_Message(HostMessageID::WMUserJobDispatch);
 }
 
 void HostDispatchJobs()

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -100,7 +100,7 @@ void UpdateWantDeterminism(bool initial = false);
 void QueueHostJob(std::function<void()> job, bool run_during_stop = false);
 
 // Should be called periodically by the Host to run pending jobs.
-// WM_USER_JOB_DISPATCH will be sent when something is added to the queue.
+// WMUserJobDispatch will be sent when something is added to the queue.
 void HostDispatchJobs();
 
 void DoFrameStep();

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -112,7 +112,7 @@ public:
       {
       case CPU::State::PowerDown:
         CPU::Break();
-        Host_Message(WM_USER_STOP);
+        Host_Message(HostMessageID::WMUserStop);
         break;
 
       case CPU::State::Stepping:

--- a/Source/Core/Core/HLE/HLE_Misc.cpp
+++ b/Source/Core/Core/HLE/HLE_Misc.cpp
@@ -25,7 +25,7 @@ void HBReload()
 {
   // There isn't much we can do. Just stop cleanly.
   CPU::Break();
-  Host_Message(WM_USER_STOP);
+  Host_Message(HostMessageID::WMUserStop);
 }
 
 void GeckoCodeHandlerICacheFlush()

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -8,25 +8,34 @@
 
 // Host - defines an interface for the emulator core to communicate back to the
 // OS-specific layer
-
+//
 // The emulator core is abstracted from the OS using 2 interfaces:
 // Common and Host.
-
+//
 // Common simply provides OS-neutral implementations of things like threads, mutexes,
 // INI file manipulation, memory mapping, etc.
-
+//
 // Host is an abstract interface for communicating things back to the host. The emulator
 // core is treated as a library, not as a main program, because it is far easier to
 // write GUI interfaces that control things than to squash GUI into some model that wasn't
 // designed for it.
-
+//
 // The host can be just a command line app that opens a window, or a full blown debugger
 // interface.
+
+enum class HostMessageID
+{
+  // Begin at 10 in case there is already messages with wParam = 0, 1, 2 and so on
+  WMUserStop = 10,
+  WMUserCreate,
+  WMUserSetCursor,
+  WMUserJobDispatch,
+};
 
 bool Host_UINeedsControllerState();
 bool Host_RendererHasFocus();
 bool Host_RendererIsFullscreen();
-void Host_Message(int Id);
+void Host_Message(HostMessageID id);
 void Host_NotifyMapLoaded();
 void Host_RefreshDSPDebuggerWindow();
 void Host_RequestRenderWindowSize(int width, int height);

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -80,11 +80,11 @@ void Host_RefreshDSPDebuggerWindow()
 }
 
 static Common::Event updateMainFrameEvent;
-void Host_Message(int Id)
+void Host_Message(HostMessageID id)
 {
-  if (Id == WM_USER_STOP)
+  if (id == HostMessageID::WMUserStop)
     s_running.Clear();
-  if (Id == WM_USER_JOB_DISPATCH || Id == WM_USER_STOP)
+  if (id == HostMessageID::WMUserJobDispatch || id == HostMessageID::WMUserStop)
     updateMainFrameEvent.Set();
 }
 

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -75,13 +75,13 @@ void Host::ResizeSurface(int new_width, int new_height)
     g_renderer->ResizeSurface(new_width, new_height);
 }
 
-void Host_Message(int id)
+void Host_Message(HostMessageID id)
 {
-  if (id == WM_USER_STOP)
+  if (id == HostMessageID::WMUserStop)
   {
     emit Host::GetInstance()->RequestStop();
   }
-  else if (id == WM_USER_JOB_DISPATCH)
+  else if (id == HostMessageID::WMUserJobDispatch)
   {
     // Just poke the main thread to get it to wake up, job dispatch
     // will happen automatically before it goes back to sleep again.

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -53,6 +53,7 @@
 #include "Core/HW/GCPad.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "Core/Host.h"
 #include "Core/HotkeyManager.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
@@ -186,11 +187,11 @@ WXLRESULT CRenderFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lPa
   case WM_USER:
     switch (wParam)
     {
-    case WM_USER_STOP:
+    case static_cast<int>(HostMessageID::WMUserStop):
       main_frame->DoStop();
       break;
 
-    case WM_USER_SETCURSOR:
+    case static_cast<int>(HostMessageID::WMUserSetCursor):
       if (SConfig::GetInstance().bHideCursor && main_frame->RendererHasFocus() &&
           Core::GetState() == Core::State::Running)
         SetCursor(wxCURSOR_BLANK);
@@ -758,7 +759,7 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
   }
   break;
 
-  case WM_USER_CREATE:
+  case static_cast<int>(HostMessageID::WMUserCreate):
     if (SConfig::GetInstance().bHideCursor)
       m_render_parent->SetCursor(wxCURSOR_BLANK);
     if (SConfig::GetInstance().bFullscreen)
@@ -776,7 +777,7 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
   }
   break;
 
-  case WM_USER_STOP:
+  case static_cast<int>(HostMessageID::WMUserStop):
     DoStop();
     break;
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -415,15 +415,15 @@ CFrame* DolphinApp::GetCFrame()
   return main_frame;
 }
 
-void Host_Message(int Id)
+void Host_Message(HostMessageID id)
 {
-  if (Id == WM_USER_JOB_DISPATCH)
+  if (id == HostMessageID::WMUserJobDispatch)
   {
     // Trigger a wxEVT_IDLE
     wxWakeUpIdle();
     return;
   }
-  wxCommandEvent event(wxEVT_HOST_COMMAND, Id);
+  wxCommandEvent event(wxEVT_HOST_COMMAND, static_cast<int>(id));
   main_frame->GetEventHandler()->AddPendingEvent(event);
 }
 

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -15,7 +15,7 @@ void Host_NotifyMapLoaded()
 void Host_RefreshDSPDebuggerWindow()
 {
 }
-void Host_Message(int)
+void Host_Message(HostMessageID)
 {
 }
 void* Host_GetRenderHandle()

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -17,7 +17,7 @@ void Host_NotifyMapLoaded()
 void Host_RefreshDSPDebuggerWindow()
 {
 }
-void Host_Message(int)
+void Host_Message(HostMessageID)
 {
 }
 void* Host_GetRenderHandle()


### PR DESCRIPTION
Given this is actually a part of the Host interface, this should be placed with it.

While we're at it, turn it into an enum class so that we don't dump its contained values into the surrounding scope. We can also make Host_Message take the enum type itself directly instead of taking a general int value.

After this, it'll be trivial to divide out the rest of Common.h and remove the header from the repository entirely