### PR TITLE
BPMemory: Silence a -Wmissing-braces warning

### DIFF
--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -984,10 +984,15 @@ union CopyFilterCoefficients
 
   Values GetCoefficients() const
   {
-    return {
-        static_cast<u8>(w0), static_cast<u8>(w1), static_cast<u8>(w2), static_cast<u8>(w3),
-        static_cast<u8>(w4), static_cast<u8>(w5), static_cast<u8>(w6),
-    };
+    return {{
+        static_cast<u8>(w0),
+        static_cast<u8>(w1),
+        static_cast<u8>(w2),
+        static_cast<u8>(w3),
+        static_cast<u8>(w4),
+        static_cast<u8>(w5),
+        static_cast<u8>(w6),
+    }};
   }
 };
 


### PR DESCRIPTION
Fairly trivial to resolve, we just initialize the std::array with two sets of braces (one set to create the array, the other to start and end the aggregate data that we'll end up returning). Makes clang just a tad quieter, considering BPMemory is included in several places.