### PR TITLE
Qt/GeckoCodeWidget: Autosort list and fix accessing the wrong element

### DIFF
--- a/Source/Core/DolphinQt2/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt2/Config/GeckoCodeWidget.h
@@ -45,7 +45,6 @@ private:
   void RemoveCode();
   void DownloadCodes();
   void SaveCodes();
-  void SortCodesLexicographically();
 
   const UICommon::GameFile& m_game;
   std::string m_game_id;
@@ -61,7 +60,6 @@ private:
   QPushButton* m_edit_code;
   QPushButton* m_remove_code;
   QPushButton* m_download_codes;
-  QPushButton* m_sort_codes;
   std::vector<Gecko::GeckoCode> m_gecko_codes;
   bool m_restart_required;
 };


### PR DESCRIPTION
Fixes [issue #11163](https://bugs.dolphin-emu.org/issues/11163) and [issue #11151](https://bugs.dolphin-emu.org/issues/11151).