### PR TITLE
DSPEmulator: Default destructor in the cpp file

### DIFF
--- a/Source/Core/Core/DSPEmulator.cpp
+++ b/Source/Core/Core/DSPEmulator.cpp
@@ -9,6 +9,8 @@
 #include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPLLE/DSPLLE.h"
 
+DSPEmulator::~DSPEmulator() = default;
+
 std::unique_ptr<DSPEmulator> CreateDSPEmulator(bool hle)
 {
   if (hle)

--- a/Source/Core/Core/DSPEmulator.h
+++ b/Source/Core/Core/DSPEmulator.h
@@ -12,7 +12,7 @@ class PointerWrap;
 class DSPEmulator
 {
 public:
-  virtual ~DSPEmulator() {}
+  virtual ~DSPEmulator();
   virtual bool IsLLE() = 0;
 
   virtual bool Initialize(bool wii, bool dsp_thread) = 0;


### PR DESCRIPTION
This gets rid of a -Wweak-vtables warning