### PR TITLE
Don't switch to blank NAND in the middle of emulation

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -903,10 +903,6 @@ void UpdateWantDeterminism(bool initial)
       // We need to clear the cache because some parts of the JIT depend on want_determinism,
       // e.g. use of FMA.
       JitInterface::ClearCache();
-
-      // Don't call InitializeWiiRoot during boot, because IOS already does it.
-      if (!initial)
-        Core::InitializeWiiRoot(s_wants_determinism);
     });
   }
 }


### PR DESCRIPTION
Switching to blank NAND when emulation is running is an extremely bad idea. It's akin to opening a Wii and replacing the NAND chip while you're playing a game on it.

Except we're not even replacing it with a NAND that has the same contents. The blank NAND has nothing in it except the save file for the current game, which is likely to result in the emulated software getting inconsistent results and possibly even crashing depending on how it caches title information.

An example of games that check the saves for other games is Mario Kart Wii -- it checks the filesystem for Super Mario Galaxy saves to decide whether to unlock characters. With this 'switch NAND while emulation is active' misfeature, this will likely break. And that's the main problem: it encourages sloppy emulation and no one really knows how many things it can break.

Just don't let the user do horrible things like that. If they want to use a blank NAND, they can do so by starting input recording before launching a game. It's likely they will want to do this if they plan to share their DTM anyway.