### PR TITLE
DSPEmulator: Make the IsLLE() member function const-qualified

### DIFF
--- a/Source/Core/Core/DSPEmulator.h
+++ b/Source/Core/Core/DSPEmulator.h
@@ -13,7 +13,7 @@ class DSPEmulator
 {
 public:
   virtual ~DSPEmulator();
-  virtual bool IsLLE() = 0;
+  virtual bool IsLLE() const = 0;
 
   virtual bool Initialize(bool wii, bool dsp_thread) = 0;
   virtual void Shutdown() = 0;

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -27,7 +27,7 @@ public:
 
   bool Initialize(bool wii, bool dsp_thread) override;
   void Shutdown() override;
-  bool IsLLE() override { return false; }
+  bool IsLLE() const override { return false; }
   void DoState(PointerWrap& p) override;
   void PauseAndLock(bool do_lock, bool unpause_on_unlock = true) override;
 

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.h
@@ -26,7 +26,7 @@ public:
 
   bool Initialize(bool wii, bool dsp_thread) override;
   void Shutdown() override;
-  bool IsLLE() override { return true; }
+  bool IsLLE() const override { return true; }
   void DoState(PointerWrap& p) override;
   void PauseAndLock(bool do_lock, bool unpause_on_unlock = true) override;
 


### PR DESCRIPTION
This function only queries state and doesn't modify it, so this can be made a const member function