### PR TITLE
Volume/VolumeGC/VolumeWii: Amend variable naming

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -43,7 +43,7 @@ class Volume
 public:
   Volume() {}
   virtual ~Volume() {}
-  virtual bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const = 0;
+  virtual bool Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const = 0;
   template <typename T>
   std::optional<T> ReadSwapped(u64 offset, const Partition& partition) const
   {

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -28,9 +28,9 @@
 
 namespace DiscIO
 {
-VolumeGC::VolumeGC(std::unique_ptr<BlobReader> reader) : m_pReader(std::move(reader))
+VolumeGC::VolumeGC(std::unique_ptr<BlobReader> reader) : m_reader(std::move(reader))
 {
-  ASSERT(m_pReader);
+  ASSERT(m_reader);
 
   m_file_system = [this]() -> std::unique_ptr<FileSystem> {
     auto file_system = std::make_unique<FileSystemGCWii>(this, PARTITION_NONE);
@@ -44,12 +44,12 @@ VolumeGC::~VolumeGC()
 {
 }
 
-bool VolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const
+bool VolumeGC::Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const
 {
   if (partition != PARTITION_NONE)
     return false;
 
-  return m_pReader->Read(_Offset, _Length, _pBuffer);
+  return m_reader->Read(offset, length, buffer);
 }
 
 const FileSystem* VolumeGC::GetFileSystem(const Partition& partition) const
@@ -61,15 +61,15 @@ std::string VolumeGC::GetGameID(const Partition& partition) const
 {
   static const std::string NO_UID("NO_UID");
 
-  char ID[6];
+  char id[6];
 
-  if (!Read(0, sizeof(ID), reinterpret_cast<u8*>(ID), partition))
+  if (!Read(0, sizeof(id), reinterpret_cast<u8*>(id), partition))
   {
     PanicAlertT("Failed to read unique ID from disc image");
     return NO_UID;
   }
 
-  return DecodeString(ID);
+  return DecodeString(id);
 }
 
 Region VolumeGC::GetRegion() const
@@ -103,11 +103,11 @@ Country VolumeGC::GetCountry(const Partition& partition) const
 
 std::string VolumeGC::GetMakerID(const Partition& partition) const
 {
-  char makerID[2];
-  if (!Read(0x4, 0x2, (u8*)&makerID, partition))
+  char maker_id[2];
+  if (!Read(0x4, 0x2, reinterpret_cast<u8*>(&maker_id), partition))
     return std::string();
 
-  return DecodeString(makerID);
+  return DecodeString(maker_id);
 }
 
 std::optional<u16> VolumeGC::GetRevision(const Partition& partition) const
@@ -168,17 +168,17 @@ std::string VolumeGC::GetApploaderDate(const Partition& partition) const
 
 BlobType VolumeGC::GetBlobType() const
 {
-  return m_pReader->GetBlobType();
+  return m_reader->GetBlobType();
 }
 
 u64 VolumeGC::GetSize() const
 {
-  return m_pReader->GetDataSize();
+  return m_reader->GetDataSize();
 }
 
 u64 VolumeGC::GetRawSize() const
 {
-  return m_pReader->GetRawSize();
+  return m_reader->GetRawSize();
 }
 
 std::optional<u8> VolumeGC::GetDiscNumber(const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -30,7 +30,7 @@ class VolumeGC : public Volume
 public:
   VolumeGC(std::unique_ptr<BlobReader> reader);
   ~VolumeGC();
-  bool Read(u64 _Offset, u64 _Length, u8* _pBuffer,
+  bool Read(u64 offset, u64 length, u8* buffer,
             const Partition& partition = PARTITION_NONE) const override;
   const FileSystem* GetFileSystem(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
@@ -103,7 +103,7 @@ private:
 
   Common::Lazy<std::unique_ptr<FileSystem>> m_file_system;
 
-  std::unique_ptr<BlobReader> m_pReader;
+  std::unique_ptr<BlobReader> m_reader;
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/VolumeWii.h
+++ b/Source/Core/DiscIO/VolumeWii.h
@@ -32,7 +32,7 @@ class VolumeWii : public Volume
 public:
   VolumeWii(std::unique_ptr<BlobReader> reader);
   ~VolumeWii();
-  bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const override;
+  bool Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const override;
   bool IsEncryptedAndHashed() const override;
   std::vector<Partition> GetPartitions() const override;
   Partition GetGamePartition() const override;
@@ -81,7 +81,7 @@ private:
     u32 type;
   };
 
-  std::unique_ptr<BlobReader> m_pReader;
+  std::unique_ptr<BlobReader> m_reader;
   std::map<Partition, PartitionDetails> m_partitions;
   Partition m_game_partition;
   bool m_encrypted;


### PR DESCRIPTION
Drops prefixed underscores and normalizes names to follow our coding style. This gets rid of all prefixed underscore usages on our end of things out of DiscIO