### PR TITLE
JitAsmCommon: Normalize member variable names within CommonAsmRoutinesBase

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -493,7 +493,7 @@ void Jit64::WriteBLRExit()
     MOV(32, R(RSCRATCH), PPCSTATE(pc));
   MOV(32, R(RSCRATCH2), Imm32(js.downcountAmount));
   CMP(64, R(RSCRATCH), MDisp(RSP, 8));
-  J_CC(CC_NE, asm_routines.dispatcherMispredictedBLR);
+  J_CC(CC_NE, asm_routines.dispatcher_mispredicted_blr);
   SUB(32, PPCSTATE(downcount), R(RSCRATCH2));
   RET();
 }
@@ -536,13 +536,13 @@ void Jit64::WriteExternalExceptionExit()
 
 void Jit64::Run()
 {
-  CompiledCode pExecAddr = (CompiledCode)asm_routines.enterCode;
+  CompiledCode pExecAddr = (CompiledCode)asm_routines.enter_code;
   pExecAddr();
 }
 
 void Jit64::SingleStep()
 {
-  CompiledCode pExecAddr = (CompiledCode)asm_routines.enterCode;
+  CompiledCode pExecAddr = (CompiledCode)asm_routines.enter_code;
   pExecAddr();
 }
 
@@ -660,7 +660,7 @@ const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   // available.
   FixupBranch skip = J_CC(CC_G);
   MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
-  JMP(asm_routines.doTiming, true);  // downcount hit zero - go doTiming.
+  JMP(asm_routines.do_timing, true);  // downcount hit zero - go do_timing.
   SetJumpTarget(skip);
 
   const u8* normalEntry = GetCodePtr();
@@ -717,7 +717,7 @@ const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
                         static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
       ABI_PopRegistersAndAdjustStack({}, 0);
-      JMP(asm_routines.dispatcherNoCheck, true);
+      JMP(asm_routines.dispatcher_no_check, true);
       SwitchToNearCode();
 
       // Insert a check that the GQRs are still the value we expect at

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -36,7 +36,7 @@ void Jit64AsmRoutineManager::Init(u8* stack_top)
 
 void Jit64AsmRoutineManager::Generate()
 {
-  enterCode = AlignCode16();
+  enter_code = AlignCode16();
   // We need to own the beginning of RSP, so we do an extra stack adjustment
   // for the shadow region before calls in this function.  This call will
   // waste a bit of space for a second shadow, but whatever.
@@ -66,7 +66,7 @@ void Jit64AsmRoutineManager::Generate()
   ABI_PopRegistersAndAdjustStack({}, 0);
   FixupBranch skipToRealDispatch =
       J(SConfig::GetInstance().bEnableDebugging);  // skip the sync and compare first time
-  dispatcherMispredictedBLR = GetCodePtr();
+  dispatcher_mispredicted_blr = GetCodePtr();
   AND(32, PPCSTATE(pc), Imm32(0xFFFFFFFC));
 
 #if 0  // debug mispredicts
@@ -103,7 +103,7 @@ void Jit64AsmRoutineManager::Generate()
 
   SetJumpTarget(skipToRealDispatch);
 
-  dispatcherNoCheck = GetCodePtr();
+  dispatcher_no_check = GetCodePtr();
 
   // The following is a translation of JitBaseBlockCache::Dispatch into assembly.
   const bool assembly_dispatcher = true;
@@ -187,10 +187,10 @@ void Jit64AsmRoutineManager::Generate()
   ABI_CallFunction(JitTrampoline);
   ABI_PopRegistersAndAdjustStack({}, 0);
 
-  JMP(dispatcherNoCheck, true);
+  JMP(dispatcher_no_check, true);
 
   SetJumpTarget(bail);
-  doTiming = GetCodePtr();
+  do_timing = GetCodePtr();
 
   // make sure npc contains the next pc (needed for exception checking in CoreTiming::Advance)
   MOV(32, R(RSCRATCH), PPCSTATE(pc));
@@ -215,7 +215,7 @@ void Jit64AsmRoutineManager::Generate()
   ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
   RET();
 
-  JitRegister::Register(enterCode, GetCodePtr(), "JIT_Loop");
+  JitRegister::Register(enter_code, GetCodePtr(), "JIT_Loop");
 
   GenerateCommon();
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -78,9 +78,9 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
       MOV(32, R(RSCRATCH2), Imm32(gqrValue & 0x3F00));
 
       if (w)
-        CALL(asm_routines.singleStoreQuantized[type]);
+        CALL(asm_routines.single_store_quantized[type]);
       else
-        CALL(asm_routines.pairedStoreQuantized[type]);
+        CALL(asm_routines.paired_store_quantized[type]);
     }
   }
   else
@@ -93,7 +93,8 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
     // 0b0011111100000111, or 0x3F07.
     MOV(32, R(RSCRATCH2), Imm32(0x3F07));
     AND(32, R(RSCRATCH2), PPCSTATE(spr[SPR_GQR0 + i]));
-    LEA(64, RSCRATCH, M(w ? asm_routines.singleStoreQuantized : asm_routines.pairedStoreQuantized));
+    LEA(64, RSCRATCH,
+        M(w ? asm_routines.single_store_quantized : asm_routines.paired_store_quantized));
     // 8-bit operations do not zero upper 32-bits of 64-bit registers.
     // Here we know that RSCRATCH's least significant byte is zero.
     OR(8, R(RSCRATCH), R(RSCRATCH2));
@@ -159,7 +160,8 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
     gqr.AddMemOffset(2);
     MOV(32, R(RSCRATCH2), Imm32(0x3F07));
     AND(32, R(RSCRATCH2), gqr);
-    LEA(64, RSCRATCH, M(w ? asm_routines.singleLoadQuantized : asm_routines.pairedLoadQuantized));
+    LEA(64, RSCRATCH,
+        M(w ? asm_routines.single_load_quantized : asm_routines.paired_load_quantized));
     // 8-bit operations do not zero upper 32-bits of 64-bit registers.
     // Here we know that RSCRATCH's least significant byte is zero.
     OR(8, R(RSCRATCH), R(RSCRATCH2));

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -231,22 +231,25 @@ constexpr std::array<u8, 8> sizes{{32, 0, 0, 0, 8, 16, 8, 16}};
 void CommonAsmRoutines::GenQuantizedStores()
 {
   // Aligned to 256 bytes as least significant byte needs to be zero (See: Jit64::psq_stXX).
-  pairedStoreQuantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
+  paired_store_quantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
   ReserveCodeSpace(8 * sizeof(u8*));
 
   for (int type = 0; type < 8; type++)
-    pairedStoreQuantized[type] = GenQuantizedStoreRuntime(false, static_cast<EQuantizeType>(type));
+  {
+    paired_store_quantized[type] =
+        GenQuantizedStoreRuntime(false, static_cast<EQuantizeType>(type));
+  }
 }
 
 // See comment in header for in/outs.
 void CommonAsmRoutines::GenQuantizedSingleStores()
 {
   // Aligned to 256 bytes as least significant byte needs to be zero (See: Jit64::psq_stXX).
-  singleStoreQuantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
+  single_store_quantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
   ReserveCodeSpace(8 * sizeof(u8*));
 
   for (int type = 0; type < 8; type++)
-    singleStoreQuantized[type] = GenQuantizedStoreRuntime(true, static_cast<EQuantizeType>(type));
+    single_store_quantized[type] = GenQuantizedStoreRuntime(true, static_cast<EQuantizeType>(type));
 }
 
 const u8* CommonAsmRoutines::GenQuantizedStoreRuntime(bool single, EQuantizeType type)
@@ -263,21 +266,21 @@ const u8* CommonAsmRoutines::GenQuantizedStoreRuntime(bool single, EQuantizeType
 void CommonAsmRoutines::GenQuantizedLoads()
 {
   // Aligned to 256 bytes as least significant byte needs to be zero (See: Jit64::psq_lXX).
-  pairedLoadQuantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
+  paired_load_quantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
   ReserveCodeSpace(8 * sizeof(u8*));
 
   for (int type = 0; type < 8; type++)
-    pairedLoadQuantized[type] = GenQuantizedLoadRuntime(false, static_cast<EQuantizeType>(type));
+    paired_load_quantized[type] = GenQuantizedLoadRuntime(false, static_cast<EQuantizeType>(type));
 }
 
 void CommonAsmRoutines::GenQuantizedSingleLoads()
 {
   // Aligned to 256 bytes as least significant byte needs to be zero (See: Jit64::psq_lXX).
-  singleLoadQuantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
+  single_load_quantized = reinterpret_cast<const u8**>(AlignCodeTo(256));
   ReserveCodeSpace(8 * sizeof(u8*));
 
   for (int type = 0; type < 8; type++)
-    singleLoadQuantized[type] = GenQuantizedLoadRuntime(true, static_cast<EQuantizeType>(type));
+    single_load_quantized[type] = GenQuantizedLoadRuntime(true, static_cast<EQuantizeType>(type));
 }
 
 const u8* CommonAsmRoutines::GenQuantizedLoadRuntime(bool single, EQuantizeType type)

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -526,13 +526,13 @@ void JitArm64::EndTimeProfile(JitBlock* b)
 
 void JitArm64::Run()
 {
-  CompiledCode pExecAddr = (CompiledCode)enterCode;
+  CompiledCode pExecAddr = (CompiledCode)enter_code;
   pExecAddr();
 }
 
 void JitArm64::SingleStep()
 {
-  CompiledCode pExecAddr = (CompiledCode)enterCode;
+  CompiledCode pExecAddr = (CompiledCode)enter_code;
   pExecAddr();
 }
 
@@ -608,7 +608,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   {
     FixupBranch bail = B(CC_PL);
     MOVI2R(DISPATCHER_PC, js.blockStart);
-    B(doTiming);
+    B(do_timing);
     SetJumpTarget(bail);
   }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -81,7 +81,7 @@ void JitArm64::psq_l(UGeckoInstruction inst)
     UBFM(type_reg, scale_reg, 16, 18);   // Type
     UBFM(scale_reg, scale_reg, 24, 29);  // Scale
 
-    MOVP2R(X30, inst.W ? singleLoadQuantized : pairedLoadQuantized);
+    MOVP2R(X30, inst.W ? single_load_quantized : paired_load_quantized);
     LDR(X30, X30, ArithOption(EncodeRegTo64(type_reg), true));
     BLR(X30);
 
@@ -192,7 +192,7 @@ void JitArm64::psq_st(UGeckoInstruction inst)
     SwitchToFarCode();
     SetJumpTarget(fail);
     // Slow
-    MOVP2R(X30, &pairedStoreQuantized[16 + inst.W * 8]);
+    MOVP2R(X30, &paired_store_quantized[16 + inst.W * 8]);
     LDR(EncodeRegTo64(type_reg), X30, ArithOption(EncodeRegTo64(type_reg), true));
 
     ABI_PushRegisters(gprs_in_use);
@@ -205,7 +205,7 @@ void JitArm64::psq_st(UGeckoInstruction inst)
     SetJumpTarget(pass);
 
     // Fast
-    MOVP2R(X30, &pairedStoreQuantized[inst.W * 8]);
+    MOVP2R(X30, &paired_store_quantized[inst.W * 8]);
     LDR(EncodeRegTo64(type_reg), X30, ArithOption(EncodeRegTo64(type_reg), true));
     BLR(EncodeRegTo64(type_reg));
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -25,7 +25,7 @@ void JitArm64::GenerateAsm()
   const u32 ALL_CALLEE_SAVED_FPR = 0x0000FF00;
   BitSet32 regs_to_save(ALL_CALLEE_SAVED);
   BitSet32 regs_to_save_fpr(ALL_CALLEE_SAVED_FPR);
-  enterCode = GetCodePtr();
+  enter_code = GetCodePtr();
 
   ABI_PushRegisters(regs_to_save);
   m_float_emit.ABI_PushRegisters(regs_to_save_fpr, X30);
@@ -61,11 +61,11 @@ void JitArm64::GenerateAsm()
   //   DISPATCHER_PC = PC;
   //   do
   //   {
-  // dispatcherNoCheck:
+  // dispatcher_no_check:
   //     ExecuteBlock(JitBase::Dispatch());
   // dispatcher:
   //   } while (PowerPC::ppcState.downcount > 0);
-  // doTiming:
+  // do_timing:
   //   NPC = PC = DISPATCHER_PC;
   // } while (CPU::GetState() == CPU::State::Running);
   AlignCodePage();
@@ -77,7 +77,7 @@ void JitArm64::GenerateAsm()
   // IMPORTANT - We jump on negative, not carry!!!
   FixupBranch bail = B(CC_MI);
 
-  dispatcherNoCheck = GetCodePtr();
+  dispatcher_no_check = GetCodePtr();
 
   bool assembly_dispatcher = true;
 
@@ -148,10 +148,10 @@ void JitArm64::GenerateAsm()
   MOVP2R(X30, reinterpret_cast<void*>(&JitTrampoline));
   BLR(X30);
   LDR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
-  B(dispatcherNoCheck);
+  B(dispatcher_no_check);
 
   SetJumpTarget(bail);
-  doTiming = GetCodePtr();
+  do_timing = GetCodePtr();
   // Write the current PC out to PPCSTATE
   STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
   STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(npc));
@@ -172,7 +172,7 @@ void JitArm64::GenerateAsm()
   LDR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
 
   // We can safely assume that downcount >= 1
-  B(dispatcherNoCheck);
+  B(dispatcher_no_check);
 
   SetJumpTarget(Exit);
 
@@ -185,7 +185,7 @@ void JitArm64::GenerateAsm()
   ABI_PopRegisters(regs_to_save);
   RET(X30);
 
-  JitRegister::Register(enterCode, GetCodePtr(), "JIT_Dispatcher");
+  JitRegister::Register(enter_code, GetCodePtr(), "JIT_Dispatcher");
 
   GenerateCommonAsm();
 
@@ -338,29 +338,29 @@ void JitArm64::GenerateCommonAsm()
 
   JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedLoad");
 
-  pairedLoadQuantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
+  paired_load_quantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
   ReserveCodeSpace(8 * sizeof(u8*));
 
-  pairedLoadQuantized[0] = loadPairedFloatTwo;
-  pairedLoadQuantized[1] = loadPairedIllegal;
-  pairedLoadQuantized[2] = loadPairedIllegal;
-  pairedLoadQuantized[3] = loadPairedIllegal;
-  pairedLoadQuantized[4] = loadPairedU8Two;
-  pairedLoadQuantized[5] = loadPairedU16Two;
-  pairedLoadQuantized[6] = loadPairedS8Two;
-  pairedLoadQuantized[7] = loadPairedS16Two;
+  paired_load_quantized[0] = loadPairedFloatTwo;
+  paired_load_quantized[1] = loadPairedIllegal;
+  paired_load_quantized[2] = loadPairedIllegal;
+  paired_load_quantized[3] = loadPairedIllegal;
+  paired_load_quantized[4] = loadPairedU8Two;
+  paired_load_quantized[5] = loadPairedU16Two;
+  paired_load_quantized[6] = loadPairedS8Two;
+  paired_load_quantized[7] = loadPairedS16Two;
 
-  singleLoadQuantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
+  single_load_quantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
   ReserveCodeSpace(8 * sizeof(u8*));
 
-  singleLoadQuantized[0] = loadPairedFloatOne;
-  singleLoadQuantized[1] = loadPairedIllegal;
-  singleLoadQuantized[2] = loadPairedIllegal;
-  singleLoadQuantized[3] = loadPairedIllegal;
-  singleLoadQuantized[4] = loadPairedU8One;
-  singleLoadQuantized[5] = loadPairedU16One;
-  singleLoadQuantized[6] = loadPairedS8One;
-  singleLoadQuantized[7] = loadPairedS16One;
+  single_load_quantized[0] = loadPairedFloatOne;
+  single_load_quantized[1] = loadPairedIllegal;
+  single_load_quantized[2] = loadPairedIllegal;
+  single_load_quantized[3] = loadPairedIllegal;
+  single_load_quantized[4] = loadPairedU8One;
+  single_load_quantized[5] = loadPairedU16One;
+  single_load_quantized[6] = loadPairedS8One;
+  single_load_quantized[7] = loadPairedS16One;
 
   // Stores
   start = GetCodePtr();
@@ -613,46 +613,46 @@ void JitArm64::GenerateCommonAsm()
 
   JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedStore");
 
-  pairedStoreQuantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
+  paired_store_quantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
   ReserveCodeSpace(32 * sizeof(u8*));
 
   // Fast
-  pairedStoreQuantized[0] = storePairedFloat;
-  pairedStoreQuantized[1] = storePairedIllegal;
-  pairedStoreQuantized[2] = storePairedIllegal;
-  pairedStoreQuantized[3] = storePairedIllegal;
-  pairedStoreQuantized[4] = storePairedU8;
-  pairedStoreQuantized[5] = storePairedU16;
-  pairedStoreQuantized[6] = storePairedS8;
-  pairedStoreQuantized[7] = storePairedS16;
+  paired_store_quantized[0] = storePairedFloat;
+  paired_store_quantized[1] = storePairedIllegal;
+  paired_store_quantized[2] = storePairedIllegal;
+  paired_store_quantized[3] = storePairedIllegal;
+  paired_store_quantized[4] = storePairedU8;
+  paired_store_quantized[5] = storePairedU16;
+  paired_store_quantized[6] = storePairedS8;
+  paired_store_quantized[7] = storePairedS16;
 
-  pairedStoreQuantized[8] = storeSingleFloat;
-  pairedStoreQuantized[9] = storePairedIllegal;
-  pairedStoreQuantized[10] = storePairedIllegal;
-  pairedStoreQuantized[11] = storePairedIllegal;
-  pairedStoreQuantized[12] = storeSingleU8;
-  pairedStoreQuantized[13] = storeSingleU16;
-  pairedStoreQuantized[14] = storeSingleS8;
-  pairedStoreQuantized[15] = storeSingleS16;
+  paired_store_quantized[8] = storeSingleFloat;
+  paired_store_quantized[9] = storePairedIllegal;
+  paired_store_quantized[10] = storePairedIllegal;
+  paired_store_quantized[11] = storePairedIllegal;
+  paired_store_quantized[12] = storeSingleU8;
+  paired_store_quantized[13] = storeSingleU16;
+  paired_store_quantized[14] = storeSingleS8;
+  paired_store_quantized[15] = storeSingleS16;
 
   // Slow
-  pairedStoreQuantized[16] = storePairedFloatSlow;
-  pairedStoreQuantized[17] = storePairedIllegal;
-  pairedStoreQuantized[18] = storePairedIllegal;
-  pairedStoreQuantized[19] = storePairedIllegal;
-  pairedStoreQuantized[20] = storePairedU8Slow;
-  pairedStoreQuantized[21] = storePairedU16Slow;
-  pairedStoreQuantized[22] = storePairedS8Slow;
-  pairedStoreQuantized[23] = storePairedS16Slow;
+  paired_store_quantized[16] = storePairedFloatSlow;
+  paired_store_quantized[17] = storePairedIllegal;
+  paired_store_quantized[18] = storePairedIllegal;
+  paired_store_quantized[19] = storePairedIllegal;
+  paired_store_quantized[20] = storePairedU8Slow;
+  paired_store_quantized[21] = storePairedU16Slow;
+  paired_store_quantized[22] = storePairedS8Slow;
+  paired_store_quantized[23] = storePairedS16Slow;
 
-  pairedStoreQuantized[24] = storeSingleFloatSlow;
-  pairedStoreQuantized[25] = storePairedIllegal;
-  pairedStoreQuantized[26] = storePairedIllegal;
-  pairedStoreQuantized[27] = storePairedIllegal;
-  pairedStoreQuantized[28] = storeSingleU8Slow;
-  pairedStoreQuantized[29] = storeSingleU16Slow;
-  pairedStoreQuantized[30] = storeSingleS8Slow;
-  pairedStoreQuantized[31] = storeSingleS16Slow;
+  paired_store_quantized[24] = storeSingleFloatSlow;
+  paired_store_quantized[25] = storePairedIllegal;
+  paired_store_quantized[26] = storePairedIllegal;
+  paired_store_quantized[27] = storePairedIllegal;
+  paired_store_quantized[28] = storeSingleU8Slow;
+  paired_store_quantized[29] = storeSingleU16Slow;
+  paired_store_quantized[30] = storeSingleS8Slow;
+  paired_store_quantized[31] = storeSingleS16Slow;
 
   GetAsmRoutines()->mfcr = nullptr;
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -12,9 +12,8 @@ alignas(16) extern const float m_one[4];
 alignas(16) extern const float m_quantizeTableS[128];
 alignas(16) extern const float m_dequantizeTableS[128];
 
-class CommonAsmRoutinesBase
+struct CommonAsmRoutinesBase
 {
-public:
   const u8* enter_code;
 
   const u8* dispatcher_mispredicted_blr;

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -15,13 +15,13 @@ alignas(16) extern const float m_dequantizeTableS[128];
 class CommonAsmRoutinesBase
 {
 public:
-  const u8* enterCode;
+  const u8* enter_code;
 
-  const u8* dispatcherMispredictedBLR;
+  const u8* dispatcher_mispredicted_blr;
   const u8* dispatcher;
-  const u8* dispatcherNoCheck;
+  const u8* dispatcher_no_check;
 
-  const u8* doTiming;
+  const u8* do_timing;
 
   const u8* frsqrte;
   const u8* fres;
@@ -33,14 +33,14 @@ public:
   //            converted to a pair of floats.
   // Trashes: all three RSCRATCH
   // Note: Store PC if this could cause an exception
-  const u8** pairedLoadQuantized;
+  const u8** paired_load_quantized;
 
   // In: array index: GQR to use.
   // In: ECX: Address to read from.
   // Out: XMM0: Bottom 32-bit slot holds the read value.
   // Trashes: all three RSCRATCH
   // Note: Store PC if this could cause an exception
-  const u8** singleLoadQuantized;
+  const u8** single_load_quantized;
 
   // In: array index: GQR to use.
   // In: ECX: Address to write to.
@@ -48,11 +48,11 @@ public:
   // Out: Nothing.
   // Trashes: all three RSCRATCH
   // Note: Store PC if this could cause an exception
-  const u8** pairedStoreQuantized;
+  const u8** paired_store_quantized;
 
   // In: array index: GQR to use.
   // In: ECX: Address to write to.
   // In: XMM0: Bottom 32-bit slot holds the float to be written.
   // Note: Store PC if this could cause an exception
-  const u8** singleStoreQuantized;
+  const u8** single_store_quantized;
 };


### PR DESCRIPTION
Makes the naming consistent with our coding style. Also turns CommonAsmRoutinesBase into a struct, given it's just a means for containing routine pointers and nothing more.