### PR TITLE
Use some C++17 features available since GCC 6

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -33,10 +33,10 @@
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
 
-// ewww
-
-#define IsTriviallyCopyable(T)                                                                     \
-  std::is_trivially_copyable<typename std::remove_volatile<T>::type>::value
+// XXX: Replace this with std::is_trivially_copyable<T> once we stop using volatile
+// on things that are put in savestates, as volatile types are not trivially copyable.
+template <typename T>
+constexpr bool IsTriviallyCopyable = std::is_trivially_copyable<std::remove_volatile_t<T>>::value;
 
 // Wrapper class
 class PointerWrap
@@ -155,7 +155,7 @@ public:
   template <typename T>
   void DoArray(T* x, u32 count)
   {
-    static_assert(IsTriviallyCopyable(T), "Only sane for trivially copyable types");
+    static_assert(IsTriviallyCopyable<T>, "Only sane for trivially copyable types");
     DoVoid(x, count * sizeof(T));
   }
 
@@ -185,7 +185,7 @@ public:
   template <typename T>
   void Do(T& x)
   {
-    static_assert(IsTriviallyCopyable(T), "Only sane for trivially copyable types");
+    static_assert(IsTriviallyCopyable<T>, "Only sane for trivially copyable types");
     // Note:
     // Usually we can just use x = **ptr, etc.  However, this doesn't work
     // for unions containing BitFields (long story, stupid language rules)

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -35,20 +35,8 @@
 
 // ewww
 
-#ifndef __has_feature
-#define __has_feature(x) (0)
-#endif
-
-#if (__has_feature(is_trivially_copyable) &&                                                       \
-     (defined(_LIBCPP_VERSION) || defined(__GLIBCXX__))) ||                                        \
-    (defined(__GNUC__) && __GNUC__ >= 5) || defined(_MSC_VER)
 #define IsTriviallyCopyable(T)                                                                     \
   std::is_trivially_copyable<typename std::remove_volatile<T>::type>::value
-#elif __GNUC__
-#define IsTriviallyCopyable(T) std::has_trivial_copy_constructor<T>::value
-#else
-#error No version of is_trivially_copyable
-#endif
 
 // Wrapper class
 class PointerWrap

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -56,15 +56,9 @@ public:
   {
     using std::ios_base;
 
-// Since we're reading/writing directly to the storage of K instances,
-// K must be trivially copyable. TODO: Remove #if once GCC 5.0 is a
-// minimum requirement.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
-    static_assert(std::has_trivial_copy_constructor<K>::value,
-                  "K must be a trivially copyable type");
-#else
+    // Since we're reading/writing directly to the storage of K instances,
+    // K must be trivially copyable.
     static_assert(std::is_trivially_copyable<K>::value, "K must be a trivially copyable type");
-#endif
 
     // close any currently opened file
     Close();

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -20,11 +20,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "DiscIO/Volume.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 DI::DI(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
@@ -123,6 +119,4 @@ IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
   }
   return GetDefaultReply(return_value);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -18,11 +18,7 @@ namespace DVDInterface
 enum DIInterruptType : int;
 }
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class DI : public Device
 {
@@ -41,6 +37,4 @@ private:
 
   std::deque<u32> m_commands_to_execute;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -14,9 +14,7 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 Request::Request(const u32 address_) : address(address_)
 {
@@ -205,5 +203,4 @@ IPCCommandResult Device::GetNoReply()
   return {IPC_SUCCESS, false, 0};
 }
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -13,9 +13,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 enum ReturnCode : s32
 {
@@ -213,5 +211,4 @@ private:
   IPCCommandResult Unsupported(const Request& request);
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DeviceStub.cpp
+++ b/Source/Core/Core/IOS/DeviceStub.cpp
@@ -6,11 +6,7 @@
 
 #include "Common/Logging/Log.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 IPCCommandResult Stub::Open(const OpenRequest& request)
 {
@@ -30,6 +26,4 @@ IPCCommandResult Stub::IOCtlV(const IOCtlVRequest& request)
   WARN_LOG(IOS, "%s faking IOCtlV()", m_name.c_str());
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/DeviceStub.h
+++ b/Source/Core/Core/IOS/DeviceStub.h
@@ -10,11 +10,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class Stub final : public Device
 {
@@ -25,6 +21,4 @@ public:
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -26,11 +26,7 @@
 #include "Core/IOS/Uids.h"
 #include "Core/IOS/VersionInfo.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 // Title to launch after IOS has been reset and reloaded (similar to /sys/launch.sys).
 static u64 s_title_to_launch;
@@ -992,6 +988,4 @@ ReturnCode ES::VerifyContainer(VerifyContainerType type, VerifyMode mode,
   }
   return ret;
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -18,11 +18,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 struct TitleContext
 {
@@ -365,6 +361,4 @@ private:
   ContextArray m_contexts;
   TitleContext m_title_context{};
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -32,9 +32,7 @@
 #include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace ES
+namespace IOS::ES
 {
 constexpr size_t CONTENT_VIEW_SIZE = 0x10;
 
@@ -771,5 +769,4 @@ std::map<std::string, CertReader> ParseCertChain(const std::vector<u8>& chain)
   }
   return certs;
 }
-}  // namespace ES
-}  // namespace IOS
+}  // namespace IOS::ES

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -18,11 +18,7 @@
 #include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 ReturnCode ES::GetDeviceId(u32* device_id) const
 {
@@ -213,6 +209,4 @@ IPCCommandResult ES::VerifySign(const IOCtlVRequest& request)
 
   return GetDefaultReply(VerifySign(hash, ecc_signature, certs));
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -20,11 +20,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 static IOS::ES::TMDReader FindTMD(FS::FileSystem* fs, u64 title_id, const std::string& tmd_path)
 {
@@ -376,6 +372,4 @@ std::string ES::GetContentPath(const u64 title_id, const IOS::ES::Content& conte
   IOS::ES::SharedContentMap map{m_ios.GetFS()};
   return GetContentPath(title_id, content, map);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -14,11 +14,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 s32 ES::OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid)
 {
@@ -168,6 +164,4 @@ IPCCommandResult ES::SeekContent(u32 uid, const IOCtlVRequest& request)
 
   return GetDefaultReply(SeekContent(cfd, offset, mode, uid));
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/TitleInformation.cpp
+++ b/Source/Core/Core/IOS/ES/TitleInformation.cpp
@@ -13,11 +13,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 // Used by the GetStoredContents ioctlvs. This assumes that the first output vector
 // is used for the content count (u32).
@@ -243,6 +239,4 @@ IPCCommandResult ES::GetSharedContents(const IOCtlVRequest& request) const
   INFO_LOG(IOS_ES, "GetSharedContents: %u contents (%u requested)", count, max_count);
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -22,11 +22,7 @@
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 static ReturnCode WriteTicket(FS::FileSystem* fs, const IOS::ES::TicketReader& ticket)
 {
@@ -851,6 +847,4 @@ IPCCommandResult ES::DeleteSharedContent(const IOCtlVRequest& request)
   Memory::CopyFromEmu(sha1.data(), request.in_vectors[0].address, request.in_vectors[0].size);
   return GetDefaultReply(DeleteSharedContent(sha1));
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/ES/Views.cpp
+++ b/Source/Core/Core/IOS/ES/Views.cpp
@@ -19,11 +19,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/VersionInfo.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 // HACK: Since we do not want to require users to install disc updates when launching
 //       Wii games from the game list (which is the inaccurate game boot path anyway),
@@ -412,6 +408,4 @@ IPCCommandResult ES::DIGetTMD(const IOCtlVRequest& request)
   Memory::CopyToEmu(request.io_vectors[0].address, tmd_bytes.data(), tmd_bytes.size());
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -95,9 +95,7 @@ static_assert(sizeof(BootMiiKeyDump) == 0x400, "Wrong size");
 #pragma pack(pop)
 }  // end of anonymous namespace
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 constexpr u32 DEFAULT_DEVICE_ID = 0x0403AC68;
 constexpr u32 DEFAULT_KEY_ID = 0x6AAB8C59;
@@ -655,5 +653,4 @@ void IOSC::KeyEntry::DoState(PointerWrap& p)
   p.Do(data);
   p.Do(owner_mask);
 }
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -23,11 +23,7 @@
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace MIOS
+namespace IOS::HLE::MIOS
 {
 static void ReinitHardware()
 {
@@ -81,6 +77,4 @@ bool Load()
   DVDInterface::UpdateRunningGameMetadata();
   return true;
 }
-}  // namespace MIOS
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::MIOS

--- a/Source/Core/Core/IOS/MIOS.h
+++ b/Source/Core/Core/IOS/MIOS.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-namespace IOS
-{
-namespace HLE
-{
-namespace MIOS
+namespace IOS::HLE::MIOS
 {
 bool Load();
-}  // namespace MIOS
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::MIOS

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -55,11 +55,7 @@
 #define UNSUPPORTED_WSAPOLL 0
 #endif
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 enum SOResultCode : s32
 {
@@ -1111,6 +1107,4 @@ IPCCommandResult NetIPTop::HandleICMPPingRequest(const IOCtlVRequest& request)
   // TODO proper error codes
   return GetDefaultReply(0);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/IP/Top.h
+++ b/Source/Core/Core/IOS/Network/IP/Top.h
@@ -13,9 +13,7 @@
 #include <ws2tcpip.h>
 #endif
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 enum NET_IOCTL
 {
@@ -100,5 +98,4 @@ private:
 #endif
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
@@ -13,11 +13,7 @@
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace NWC24
+namespace IOS::HLE::NWC24
 {
 constexpr const char CONFIG_PATH[] = "/" WII_WC24CONF_DIR "/nwc24msg.cfg";
 
@@ -210,6 +206,4 @@ void NWC24Config::SetEmail(const char* email)
   strncpy(m_data.email, email, MAX_EMAIL_LENGTH);
   m_data.email[MAX_EMAIL_LENGTH - 1] = '\0';
 }
-}  // namespace NWC24
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::NWC24

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.h
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.h
@@ -8,9 +8,7 @@
 #include <string>
 #include "Common/CommonTypes.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace FS
 {
@@ -103,5 +101,4 @@ private:
   ConfigData m_data;
 };
 }  // namespace NWC24
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -20,11 +20,7 @@
 #include "Core/IOS/Network/Socket.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 NetKDRequest::NetKDRequest(Kernel& ios, const std::string& device_name)
     : Device(ios, device_name), config{ios.GetFS()}
@@ -249,6 +245,4 @@ s32 NetKDRequest::NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr, u
 
   return NWC24::WC24_OK;
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -10,11 +10,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/Network/KD/NWC24Config.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 // KD is the IOS module responsible for implementing WiiConnect24 functionality.
 // It can perform HTTPS downloads, send and receive mail via SMTP, and execute a
@@ -70,6 +66,4 @@ private:
 
   NWC24::NWC24Config config;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -11,11 +11,7 @@
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/Memmap.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 NetKDTime::NetKDTime(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
@@ -91,6 +87,4 @@ void NetKDTime::SetAdjustedUTC(u64 wii_utc)
   utcdiff = ExpansionInterface::CEXIIPL::GetEmulatedTime(ExpansionInterface::CEXIIPL::UNIX_EPOCH) -
             wii_utc;
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.h
@@ -9,11 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/IOS/Device.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class NetKDTime : public Device
 {
@@ -48,6 +44,4 @@ private:
   u64 rtc = 0;
   s64 utcdiff = 0;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/MACUtils.cpp
+++ b/Source/Core/Core/IOS/Network/MACUtils.cpp
@@ -13,9 +13,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
-namespace IOS
-{
-namespace Net
+namespace IOS::Net
 {
 static void SaveMACAddress(const u8* mac)
 {
@@ -47,5 +45,4 @@ void GetMACAddress(u8* mac)
 
   INFO_LOG(IOS_NET, "Using MAC address: %s", Common::MacAddressToString(mac).c_str());
 }
-}  // namespace Net
-}  // namespace IOS
+}  // namespace IOS::Net

--- a/Source/Core/Core/IOS/Network/MACUtils.h
+++ b/Source/Core/Core/IOS/Network/MACUtils.h
@@ -6,10 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace IOS
-{
-namespace Net
+namespace IOS::Net
 {
 void GetMACAddress(u8* mac);
-}  // namespace Net
-}  // namespace IOS
+}  // namespace IOS::Net

--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -13,11 +13,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/MACUtils.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 NetNCDManage::NetNCDManage(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
@@ -88,6 +84,4 @@ IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
   }
   return GetDefaultReply(return_value);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/NCD/Manage.h
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.h
@@ -10,11 +10,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/Network/NCD/WiiNetConfig.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 // Interface for reading and changing network configuration (probably some other stuff as well)
 class NetNCDManage : public Device
@@ -39,6 +35,4 @@ private:
 
   Net::WiiNetConfig config;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
@@ -14,11 +14,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Net
+namespace IOS::HLE::Net
 {
 static const std::string CONFIG_PATH = "/shared2/sys/net/02/config.dat";
 
@@ -66,6 +62,4 @@ void WiiNetConfig::ReadFromMem(const u32 address)
 {
   Memory::CopyFromEmu(&m_data, address, sizeof(m_data));
 }
-}  // namespace Net
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Net

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.h
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.h
@@ -7,9 +7,7 @@
 #include <string>
 #include "Common/CommonTypes.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace FS
 {
@@ -143,5 +141,4 @@ private:
   ConfigData m_data;
 };
 }  // namespace Net
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -21,11 +21,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/Socket.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 WII_SSL NetSSL::_SSL[NET_SSL_MAXINSTANCES];
 
@@ -575,6 +571,4 @@ IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
   // SSL return codes are written to BufferIn
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -22,9 +22,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/Device.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 #define NET_SSL_MAXINSTANCES 4
 
@@ -106,5 +104,4 @@ private:
   bool m_cert_error_shown = false;
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -31,9 +31,7 @@
 #define closesocket close
 #endif
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 constexpr int WII_SOCKET_FD_MAX = 24;
 
@@ -757,5 +755,4 @@ void WiiSockMan::UpdateWantDeterminism(bool want)
 
 #undef ERRORCODE
 #undef EITHER
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -55,9 +55,7 @@ typedef struct pollfd pollfd_t;
 #include "Core/IOS/Network/IP/Top.h"
 #include "Core/IOS/Network/SSL.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 enum
 {
@@ -259,5 +257,4 @@ private:
   std::unordered_map<s32, WiiSocket> WiiSockets;
   s32 errno_last;
 };
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/WD/Command.cpp
+++ b/Source/Core/Core/IOS/Network/WD/Command.cpp
@@ -15,11 +15,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/MACUtils.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 NetWDCommand::NetWDCommand(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
@@ -97,6 +93,4 @@ IPCCommandResult NetWDCommand::IOCtlV(const IOCtlVRequest& request)
 
   return GetDefaultReply(return_value);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/Network/WD/Command.h
+++ b/Source/Core/Core/IOS/Network/WD/Command.h
@@ -9,11 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/IOS/Device.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class NetWDCommand : public Device
 {
@@ -103,6 +99,4 @@ private:
   };
 #pragma pack(pop)
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -20,11 +20,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/VersionInfo.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 SDIOSlot0::SDIOSlot0(Kernel& ios, const std::string& device_name)
     : Device(ios, device_name), m_sdhc_supported(HasFeature(ios.GetVersion(), Feature::SDv2))
@@ -639,6 +635,4 @@ void SDIOSlot0::InitSDHC()
   m_status |= CARD_INITIALIZED;
 }
 
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -16,11 +16,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 // The front SD slot
 class SDIOSlot0 : public Device
@@ -169,6 +165,4 @@ private:
 
   File::IOFile m_card;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -12,11 +12,7 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 static std::unique_ptr<IOCtlRequest> s_event_hook_request;
 
@@ -121,6 +117,4 @@ void STMEventHook::PowerButton() const
 {
   TriggerEvent(STM_EVENT_POWER);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -12,9 +12,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE::Device
 {
 enum
 {
@@ -40,8 +38,6 @@ enum
   STM_EVENT_POWER = 0x00000800
 };
 
-namespace Device
-{
 // The /dev/stm/immediate
 class STMImmediate final : public Device
 {
@@ -66,6 +62,4 @@ public:
 private:
   void TriggerEvent(u32 event) const;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
@@ -15,9 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/SysConf.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 void BackUpBTInfoSection(const SysConf* sysconf)
 {
@@ -52,5 +50,4 @@ void RestoreBTInfoSection(SysConf* sysconf)
 
   File::Delete(filename);
 }
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
@@ -14,9 +14,7 @@
 class PointerWrap;
 class SysConf;
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 void BackUpBTInfoSection(const SysConf* sysconf);
 void RestoreBTInfoSection(SysConf* sysconf);
@@ -46,5 +44,4 @@ protected:
   };
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -27,9 +27,7 @@
 #include "Core/SysConf.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 SQueuedEvent::SQueuedEvent(u32 size, u16 handle) : m_size(size), m_connectionHandle(handle)
 {
@@ -1769,5 +1767,4 @@ void BluetoothEmu::DisplayDisconnectMessage(const int wiimoteNumber, const int r
       StringFromFormat("Wii Remote %i disconnected by emulated software", wiimoteNumber), 3000);
 }
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -22,9 +22,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 struct SQueuedEvent
 {
@@ -197,5 +195,4 @@ private:
 #pragma pack(pop)
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -31,9 +31,7 @@
 #include "Core/IOS/Device.h"
 #include "VideoCommon/OnScreenDisplay.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE::Device
 {
 static bool IsWantedDevice(const libusb_device_descriptor& descriptor)
 {
@@ -56,8 +54,6 @@ static bool IsBluetoothDevice(const libusb_interface_descriptor& descriptor)
          descriptor.bInterfaceProtocol == PROTOCOL_BLUETOOTH;
 }
 
-namespace Device
-{
 BluetoothReal::BluetoothReal(Kernel& ios, const std::string& device_name)
     : BluetoothBase(ios, device_name)
 {
@@ -688,6 +684,4 @@ void BluetoothReal::HandleBulkOrIntrTransfer(libusb_transfer* tr)
                         CoreTiming::FromThread::NON_CPU);
   m_current_transfers.erase(tr);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -27,9 +27,7 @@ struct libusb_device;
 struct libusb_device_handle;
 struct libusb_transfer;
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 enum class SyncButtonState
 {
@@ -129,20 +127,13 @@ private:
   void TransferThread();
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE
 
 #else
 #include "Core/IOS/USB/Bluetooth/BTStub.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 using BluetoothReal = BluetoothStub;
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device
 #endif

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
@@ -8,11 +8,7 @@
 #include "Common/MsgHandler.h"
 #include "Core/Core.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 IPCCommandResult BluetoothStub::Open(const OpenRequest& request)
 {
@@ -26,6 +22,4 @@ void BluetoothStub::DoState(PointerWrap& p)
   Core::DisplayMessage("The current IPC_HLE_Device_usb is a stub. Aborting load.", 4000);
   p.SetMode(PointerWrap::MODE_VERIFY);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
@@ -12,11 +12,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class BluetoothStub final : public BluetoothBase
 {
@@ -25,6 +21,4 @@ public:
   IPCCommandResult Open(const OpenRequest& request) override;
   void DoState(PointerWrap& p) override;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -22,9 +22,7 @@
 #include "Core/IOS/USB/Bluetooth/WiimoteHIDAttr.h"
 #include "Core/IOS/USB/Bluetooth/l2cap.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 WiimoteDevice::WiimoteDevice(Device::BluetoothEmu* host, int number, bdaddr_t bd, bool ready)
     : m_BD(bd),
@@ -896,8 +894,7 @@ void WiimoteDevice::ReceiveL2capData(u16 scid, const void* _pData, u32 _Size)
   // Send the report
   m_pHost->SendACLPacket(GetConnectionHandle(), DataFrame, Offset);
 }
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE
 
 namespace Core
 {

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
@@ -14,9 +14,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace Device
 {
@@ -139,5 +137,4 @@ private:
                                        u16 _StartAttrID, u16 _EndAttrID,
                                        u16 _MaximumAttributeByteCount, u8* _pContinuationState);
 };
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.cpp
@@ -7,9 +7,7 @@
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 static u8 packet1[] = {
     0x00, 0x7b, 0x00, 0x76, 0x36, 0x01, 0xcc, 0x09, 0x00, 0x00, 0x0a, 0x00, 0x01, 0x00, 0x00, 0x09,
@@ -101,5 +99,4 @@ const u8* GetAttribPacket(u32 serviceHandle, u32 cont, u32& _size)
 
   return nullptr;
 }
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteHIDAttr.h
@@ -6,10 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 const u8* GetAttribPacket(u32 serviceHandle, u32 cont, u32& _size);
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Common.cpp
+++ b/Source/Core/Core/IOS/USB/Common.cpp
@@ -12,11 +12,7 @@
 #include "Common/Swap.h"
 #include "Core/HW/Memmap.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace USB
+namespace IOS::HLE::USB
 {
 std::unique_ptr<u8[]> TransferCommand::MakeBuffer(const size_t size) const
 {
@@ -95,6 +91,4 @@ std::string Device::GetErrorName(const int error_code) const
 {
   return StringFromFormat("unknown error %d", error_code);
 }
-}  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/Common.h
+++ b/Source/Core/Core/IOS/USB/Common.h
@@ -13,11 +13,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/IOS/Device.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace USB
+namespace IOS::HLE::USB
 {
 enum StandardDeviceRequestCodes
 {
@@ -182,6 +178,4 @@ public:
 protected:
   u64 m_id = 0xFFFFFFFFFFFFFFFF;
 };
-}  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -25,11 +25,7 @@
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/LibusbDevice.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 USBHost::USBHost(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
@@ -272,6 +268,4 @@ IPCCommandResult USBHost::HandleTransfer(std::shared_ptr<USB::Device> device, u3
             device->GetPid(), request, device->GetErrorName(ret).c_str());
   return GetDefaultReply(ret <= 0 ? ret : IPC_EINVAL);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -23,11 +23,7 @@
 class PointerWrap;
 struct libusb_context;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 // Common base class for USB host devices (such as /dev/usb/oh0 and /dev/usb/ven).
 class USBHost : public Device
@@ -81,6 +77,4 @@ private:
   Common::Flag m_scan_thread_running;
   std::thread m_scan_thread;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -22,11 +22,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace USB
+namespace IOS::HLE::USB
 {
 LibusbDevice::LibusbDevice(Kernel& ios, libusb_device* device,
                            const libusb_device_descriptor& descriptor)
@@ -436,6 +432,4 @@ LibusbConfigDescriptor::~LibusbConfigDescriptor()
   if (m_descriptor != nullptr)
     libusb_free_config_descriptor(m_descriptor);
 }
-}  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/LibusbDevice.h
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.h
@@ -22,11 +22,7 @@ struct libusb_device_descriptor;
 struct libusb_device_handle;
 struct libusb_transfer;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace USB
+namespace IOS::HLE::USB
 {
 // Simple wrapper around libusb_get_config_descriptor and libusb_free_config_descriptor.
 class LibusbConfigDescriptor final
@@ -92,7 +88,5 @@ private:
   int AttachInterface(u8 interface);
   int DetachInterface();
 };
-}  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::USB
 #endif

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -20,11 +20,7 @@
 #include "Core/IOS/USB/USBV0.h"
 #include "Core/IOS/VersionInfo.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 OH0::OH0(Kernel& ios, const std::string& device_name) : USBHost(ios, device_name)
 {
@@ -350,6 +346,4 @@ s32 OH0::SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv)
     return IPC_EINVAL;
   }
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/OH0/OH0.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.h
@@ -18,9 +18,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace USB
 {
@@ -84,5 +82,4 @@ private:
   std::mutex m_hooks_mutex;
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -14,11 +14,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/OH0/OH0.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 static void GetVidPidFromDevicePath(const std::string& device_path, u16& vid, u16& pid)
 {
@@ -82,6 +78,4 @@ IPCCommandResult OH0Device::IOCtlV(const IOCtlVRequest& request)
 {
   return m_oh0->DeviceIOCtlV(m_device_id, request);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.h
@@ -12,11 +12,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class OH0;
 class OH0Device final : public Device
@@ -36,6 +32,4 @@ private:
   u16 m_pid = 0;
   u64 m_device_id = 0;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USBV0.cpp
+++ b/Source/Core/Core/IOS/USB/USBV0.cpp
@@ -11,11 +11,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace USB
+namespace IOS::HLE::USB
 {
 V0CtrlMessage::V0CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : CtrlMessage(ios, ioctlv, ioctlv.io_vectors[0].address)
@@ -54,6 +50,4 @@ V0IsoMessage::V0IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
   for (size_t i = 0; i < num_packets; ++i)
     packet_sizes.push_back(Memory::Read_U16(static_cast<u32>(packet_sizes_addr + i * sizeof(u16))));
 }
-}  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/USBV0.h
+++ b/Source/Core/Core/IOS/USB/USBV0.h
@@ -9,9 +9,7 @@
 
 // Used by early USB interfaces, such as /dev/usb/oh0 (except in IOS57, 58, 59) and /dev/usb/oh1.
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 struct IOCtlVRequest;
 
@@ -59,5 +57,4 @@ struct V0IsoMessage final : IsoMessage
   V0IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv);
 };
 }  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBV4.cpp
+++ b/Source/Core/Core/IOS/USB/USBV4.cpp
@@ -13,11 +13,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace USB
+namespace IOS::HLE::USB
 {
 // Source: https://wiibrew.org/w/index.php?title=/dev/usb/hid&oldid=96809
 #pragma pack(push, 1)
@@ -95,6 +91,4 @@ V4IntrMessage::V4IntrMessage(Kernel& ios, const IOCtlRequest& ioctl) : IntrMessa
   endpoint = static_cast<u8>(Common::swap32(hid_request.interrupt.endpoint));
   data_address = Common::swap32(hid_request.data_addr);
 }
-}  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/USBV4.h
+++ b/Source/Core/Core/IOS/USB/USBV4.h
@@ -9,9 +9,7 @@
 
 // Used by an early version of /dev/usb/hid.
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 struct IOCtlRequest;
 
@@ -46,5 +44,4 @@ struct V4IntrMessage final : IntrMessage
   V4IntrMessage(Kernel& ios, const IOCtlRequest& ioctl);
 };
 }  // namespace USB
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -14,9 +14,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/HW/Memmap.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace USB
 {
@@ -274,5 +272,4 @@ void USBV5ResourceManager::TriggerDeviceChangeReply()
   INFO_LOG(IOS_USB, "%d USBv5 device(s), including interfaces", num_devices);
 }
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBV5.h
+++ b/Source/Core/Core/IOS/USB/USBV5.h
@@ -20,9 +20,7 @@ class PointerWrap;
 // Used by late USB interfaces for /dev/usb/ven and /dev/usb/hid (since IOS57 which
 // reorganised the USB modules in IOS).
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 struct IOCtlRequest;
 
@@ -113,5 +111,4 @@ protected:
   u16 m_current_device_number = 0x21;
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -20,11 +20,7 @@
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/USBV4.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 USB_HIDv4::USB_HIDv4(Kernel& ios, const std::string& device_name) : USBHost(ios, device_name)
 {
@@ -262,6 +258,4 @@ std::vector<u8> USB_HIDv4::GetDeviceEntry(const USB::Device& device) const
 
   return entry;
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -16,11 +16,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class USB_HIDv4 final : public USBHost
 {
@@ -57,6 +53,4 @@ private:
   std::map<s32, u64> m_ios_ids;
   std::map<u64, s32> m_device_ids;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -14,11 +14,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/USB/Common.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
@@ -194,6 +190,4 @@ bool USB_HIDv5::ShouldAddDevice(const USB::Device& device) const
   constexpr u8 HID_CLASS = 0x03;
   return device.HasClass(HID_CLASS);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
@@ -9,11 +9,7 @@
 #include "Core/IOS/USB/Host.h"
 #include "Core/IOS/USB/USBV5.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class USB_HIDv5 final : public USBV5ResourceManager
 {
@@ -38,6 +34,4 @@ private:
   };
   std::array<AdditionalDeviceData, 32> m_additional_device_data{};
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -20,11 +20,7 @@
 #include <windows.h>
 #endif
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 USB_KBD::SMessageData::SMessageData(u32 type, u8 modifiers, u8* pressed_keys)
 {
@@ -326,6 +322,4 @@ u8 USB_KBD::m_KeyCodesQWERTY[256] = {0};
 
 u8 USB_KBD::m_KeyCodesAZERTY[256] = {0};
 #endif
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USB_KBD.h
+++ b/Source/Core/Core/IOS/USB/USB_KBD.h
@@ -11,11 +11,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class USB_KBD : public Device
 {
@@ -64,6 +60,4 @@ private:
   static u8 m_KeyCodesQWERTY[256];
   static u8 m_KeyCodesAZERTY[256];
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -14,11 +14,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/USB/Common.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
@@ -155,6 +151,4 @@ IPCCommandResult USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest&
 
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
@@ -9,11 +9,7 @@
 #include "Core/IOS/USB/Host.h"
 #include "Core/IOS/USB/USBV5.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 class USB_VEN final : public USBV5ResourceManager
 {
@@ -31,6 +27,4 @@ private:
   s32 SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv);
   bool HasInterfaceNumberInIDs() const override { return false; }
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/VersionInfo.cpp
+++ b/Source/Core/Core/IOS/VersionInfo.cpp
@@ -11,9 +11,7 @@
 #include "Core/CommonTitles.h"
 #include "Core/IOS/ES/Formats.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 constexpr u32 MEM1_SIZE = 0x01800000;
 constexpr u32 MEM1_END = 0x81800000;
@@ -397,5 +395,4 @@ bool IsEmulated(u64 title_id)
   const u32 version = static_cast<u32>(title_id);
   return IsEmulated(version);
 }
-}
-}
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/VersionInfo.h
+++ b/Source/Core/Core/IOS/VersionInfo.h
@@ -8,9 +8,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 struct MemoryValues
 {
@@ -85,5 +83,4 @@ bool HasFeature(u32 major_version, Feature feature);
 Feature GetFeatures(u32 major_version);
 bool IsEmulated(u32 major_version);
 bool IsEmulated(u64 title_id);
-}
-}
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -34,9 +34,7 @@ std::string GroupIdStr(u16 gid)
 }
 }  // namespace
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 void ARCUnpacker::Reset()
 {
@@ -573,5 +571,4 @@ s32 WFSI::CancelPatchImport(bool continue_install)
   return IPC_SUCCESS;
 }
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -15,9 +15,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 class ARCUnpacker
 {
@@ -126,5 +124,4 @@ private:
   };
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -16,9 +16,7 @@
 #include "Common/NandPaths.h"
 #include "Core/HW/Memmap.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace WFS
 {
@@ -484,5 +482,4 @@ bool WFSSRV::FileDescriptor::Open()
   return file.Open(WFS::NativePath(path), mode_string);
 }
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSSRV.h
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.h
@@ -13,9 +13,7 @@
 #include "Core/IOS/IOS.h"
 #include "DiscIO/Volume.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace WFS
 {
@@ -107,5 +105,4 @@ private:
   std::vector<u32> m_hanging;
 };
 }  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
@@ -532,14 +532,8 @@ struct VK_PIPELINE_CACHE_HEADER
   u8 uuid[VK_UUID_SIZE];
 };
 #pragma pack(pop)
-// TODO: Remove the #if here when GCC 5 is a minimum build requirement.
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
-static_assert(std::has_trivial_copy_constructor<VK_PIPELINE_CACHE_HEADER>::value,
-              "VK_PIPELINE_CACHE_HEADER must be trivially copyable");
-#else
 static_assert(std::is_trivially_copyable<VK_PIPELINE_CACHE_HEADER>::value,
               "VK_PIPELINE_CACHE_HEADER must be trivially copyable");
-#endif
 
 bool ShaderCache::ValidatePipelineCache(const u8* data, size_t data_length)
 {


### PR DESCRIPTION
Now that we require GCC 6 (#7022), there are some cleanup changes that can be taken from #6273.