### PR TITLE
GeneralPane: Replace usages of obsolete QString member function sprintf

### DIFF
--- a/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
@@ -135,9 +135,9 @@ void GeneralPane::CreateBasic()
   {
     QString str;
     if (i != 100)
-      str.sprintf("%i%%", i);
+      str = QStringLiteral("%1%").arg(i);
     else
-      str.sprintf(tr("%i%% (Normal Speed)").toStdString().c_str(), i);
+      str = tr("%1% (Normal Speed)").arg(i);
 
     m_combobox_speedlimit->addItem(str);
   }


### PR DESCRIPTION
sprintf is listed as [obsolete](https://doc.qt.io/qt-5/qstring-obsolete.html) within the documentation for Qt 5. Instead, it recommends using the `asprintf` member function, `arg()`, or QTextStream`.