### PR TITLE
Qt/MemoryWidget: Fix sidebar items being stretched out

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/MemoryWidget.cpp
@@ -164,6 +164,7 @@ void MemoryWidget::CreateWidgets()
   sidebar_layout->addWidget(search_group);
   sidebar_layout->addWidget(datatype_group);
   sidebar_layout->addWidget(bp_group);
+  sidebar_layout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Expanding));
 
   // Splitter
   m_splitter = new QSplitter(Qt::Horizontal);


### PR DESCRIPTION
Fixes [issue #11179](https://bugs.dolphin-emu.org/issues/11179).