### PR TITLE
Vulkan: macOS support via MoltenVK

### DIFF
--- a/Source/Core/Common/Semaphore.h
+++ b/Source/Core/Common/Semaphore.h
@@ -30,7 +30,31 @@ private:
 };
 }  // namespace Common
 
-#else  // _WIN32
+#elif defined(__APPLE__)
+
+#include <dispatch/dispatch.h>
+
+namespace Common
+{
+class Semaphore
+{
+public:
+  Semaphore(int initial_count, int maximum_count)
+  {
+    m_handle = dispatch_semaphore_create(0);
+    for (int i = 0; i < initial_count; i++)
+      dispatch_semaphore_signal(m_handle);
+  }
+  ~Semaphore() { dispatch_release(m_handle); }
+  void Wait() { dispatch_semaphore_wait(m_handle, DISPATCH_TIME_FOREVER); }
+  void Post() { dispatch_semaphore_signal(m_handle); }
+
+private:
+  dispatch_semaphore_t m_handle;
+};
+}  // namespace Common
+
+#else
 
 #include <semaphore.h>
 

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -293,6 +293,7 @@ PUBLIC
   videonull
   videoogl
   videosoftware
+  videovulkan
 
 PRIVATE
   ${LZO}
@@ -320,10 +321,6 @@ if(LIBUSB_FOUND)
     IOS/USB/LibusbDevice.cpp
     IOS/USB/Bluetooth/BTReal.cpp
   )
-endif()
-
-if(NOT APPLE)
-  target_link_libraries(core PUBLIC videovulkan)
 endif()
 
 if(WIN32)

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -214,6 +214,9 @@ bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
 
   Host_UpdateMainFrame();  // Disable any menus or buttons at boot
 
+  // Issue any API calls which must occur on the main thread for the graphics backend.
+  g_video_backend->PrepareWindow(wsi);
+
   // Start the emu thread
   s_emu_thread = std::thread(EmuThread, std::move(boot), wsi);
   return true;

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -92,15 +92,17 @@ void AdvancedWidget::CreateWidgets()
 
   m_enable_cropping = new GraphicsBool(tr("Crop"), Config::GFX_CROP);
   m_enable_prog_scan = new QCheckBox(tr("Enable Progressive Scan"));
+  m_backend_multithreading =
+      new GraphicsBool(tr("Backend Multi-threading"), Config::GFX_BACKEND_MULTITHREADING);
 
   misc_layout->addWidget(m_enable_cropping, 0, 0);
   misc_layout->addWidget(m_enable_prog_scan, 0, 1);
-
+  misc_layout->addWidget(m_backend_multithreading, 1, 0);
 #ifdef _WIN32
   m_borderless_fullscreen =
       new GraphicsBool(tr("Borderless Fullscreen"), Config::GFX_BORDERLESS_FULLSCREEN);
 
-  misc_layout->addWidget(m_borderless_fullscreen, 1, 0);
+  misc_layout->addWidget(m_borderless_fullscreen, 1, 1);
 #endif
 
   main_layout->addWidget(debugging_box);
@@ -191,6 +193,11 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_PROGRESSIVE_SCAN_DESCRIPTION[] = QT_TR_NOOP(
       "Enables progressive scan if supported by the emulated software.\nMost games don't "
       "care about this.\n\nIf unsure, leave this unchecked.");
+  static const char TR_BACKEND_MULTITHREADING_DESCRIPTION[] =
+      QT_TR_NOOP("Enables multi-threaded command submission in backends where supported. Enabling "
+                 "this option may result in a performance improvement on systems with more than "
+                 "two CPU cores. Currently, this is limited to the Vulkan backend.\n\nIf unsure, "
+                 "leave this checked.");
 #ifdef _WIN32
   static const char TR_BORDERLESS_FULLSCREEN_DESCRIPTION[] = QT_TR_NOOP(
       "Implement fullscreen mode with a borderless window spanning the whole screen instead of "
@@ -217,6 +224,7 @@ void AdvancedWidget::AddDescriptions()
   AddDescription(m_enable_cropping, TR_CROPPING_DESCRIPTION);
   AddDescription(m_enable_prog_scan, TR_PROGRESSIVE_SCAN_DESCRIPTION);
   AddDescription(m_enable_freelook, TR_FREE_LOOK_DESCRIPTION);
+  AddDescription(m_backend_multithreading, TR_BACKEND_MULTITHREADING_DESCRIPTION);
 #ifdef _WIN32
   AddDescription(m_borderless_fullscreen, TR_BORDERLESS_FULLSCREEN_DESCRIPTION);
 #endif

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -44,5 +44,6 @@ private:
   // Misc
   QCheckBox* m_enable_cropping;
   QCheckBox* m_enable_prog_scan;
+  QCheckBox* m_backend_multithreading;
   QCheckBox* m_borderless_fullscreen;
 };

--- a/Source/Core/VideoBackends/CMakeLists.txt
+++ b/Source/Core/VideoBackends/CMakeLists.txt
@@ -1,11 +1,9 @@
 add_subdirectory(OGL)
 add_subdirectory(Null)
 add_subdirectory(Software)
+add_subdirectory(Vulkan)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_subdirectory(D3D)
 endif()
 
-if(NOT APPLE)
-  add_subdirectory(Vulkan)
-endif()

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -118,6 +118,19 @@ VkSurfaceKHR SwapChain::CreateVulkanSurface(VkInstance instance, void* display_h
 
   return surface;
 
+#elif defined(VK_USE_PLATFORM_MACOS_MVK)
+  VkMacOSSurfaceCreateInfoMVK surface_create_info = {
+      VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK, nullptr, 0, hwnd};
+
+  VkSurfaceKHR surface;
+  VkResult res = vkCreateMacOSSurfaceMVK(instance, &surface_create_info, nullptr, &surface);
+  if (res != VK_SUCCESS)
+  {
+    LOG_VULKAN_ERROR(res, "vkCreateMacOSSurfaceMVK failed: ");
+    return VK_NULL_HANDLE;
+  }
+
+  return surface;
 #else
   return VK_NULL_HANDLE;
 #endif

--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -18,5 +18,6 @@ public:
   std::string GetName() const override { return "Vulkan"; }
   std::string GetDisplayName() const override { return _trans("Vulkan"); }
   void InitBackendInfo() override;
+  void PrepareWindow(const WindowSystemInfo& wsi) override;
 };
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -186,6 +186,9 @@ bool VulkanContext::SelectInstanceExtensions(ExtensionList* extension_list, bool
 #elif defined(VK_USE_PLATFORM_ANDROID_KHR)
   if (enable_surface && !SupportsExtension(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, true))
     return false;
+#elif defined(VK_USE_PLATFORM_MACOS_MVK)
+  if (enable_surface && !SupportsExtension(VK_MVK_MACOS_SURFACE_EXTENSION_NAME, true))
+    return false;
 #endif
 
   // VK_EXT_debug_report
@@ -832,6 +835,13 @@ void VulkanContext::InitDriverDetails()
     vendor = DriverDetails::VENDOR_UNKNOWN;
     driver = DriverDetails::DRIVER_UNKNOWN;
   }
+
+#ifdef __APPLE__
+  // Vulkan on macOS goes through Metal, and is not susceptible to the same bugs
+  // as the vendor's native Vulkan drivers. We use a different driver fields to
+  // differentiate MoltenVK.
+  driver = DriverDetails::DRIVER_PORTABILITY;
+#endif
 
   DriverDetails::Init(DriverDetails::API_VULKAN, vendor, driver,
                       static_cast<double>(m_device_properties.driverVersion),

--- a/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+++ b/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
@@ -16,7 +16,7 @@ VULKAN_MODULE_ENTRY_POINT(vkGetDeviceProcAddr, true)
 VULKAN_MODULE_ENTRY_POINT(vkEnumerateInstanceExtensionProperties, true)
 VULKAN_MODULE_ENTRY_POINT(vkEnumerateInstanceLayerProperties, true)
 
-#endif		// VULKAN_MODULE_ENTRY_POINT
+#endif  // VULKAN_MODULE_ENTRY_POINT
 
 #ifdef VULKAN_INSTANCE_ENTRY_POINT
 
@@ -178,13 +178,17 @@ VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceXcbPresentationSupportKHR, false)
 
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateAndroidSurfaceKHR, false)
 
+#elif defined(VK_USE_PLATFORM_MACOS_MVK)
+
+VULKAN_INSTANCE_ENTRY_POINT(vkCreateMacOSSurfaceMVK, false)
+
 #endif
 
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateDebugReportCallbackEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkDestroyDebugReportCallbackEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkDebugReportMessageEXT, false)
 
-#endif		// VULKAN_INSTANCE_ENTRY_POINT
+#endif  // VULKAN_INSTANCE_ENTRY_POINT
 
 #ifdef VULKAN_DEVICE_ENTRY_POINT
 
@@ -194,4 +198,4 @@ VULKAN_DEVICE_ENTRY_POINT(vkGetSwapchainImagesKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkAcquireNextImageKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkQueuePresentKHR, false)
 
-#endif		// VULKAN_DEVICE_ENTRY_POINT
+#endif  // VULKAN_DEVICE_ENTRY_POINT

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -15,6 +15,8 @@
 //#define VK_USE_PLATFORM_XCB_KHR
 #elif defined(ANDROID)
 #define VK_USE_PLATFORM_ANDROID_KHR
+#elif defined(__APPLE__)
+#define VK_USE_PLATFORM_MACOS_MVK
 #else
 //#warning Unknown platform
 #endif

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -49,19 +49,20 @@ enum Vendor
 enum Driver
 {
   DRIVER_ALL = 0,
-  DRIVER_NVIDIA,     // Official Nvidia, including mobile GPU
-  DRIVER_NOUVEAU,    // OSS nouveau
-  DRIVER_ATI,        // Official ATI
-  DRIVER_R600,       // OSS Radeon
-  DRIVER_INTEL,      // Official Intel
-  DRIVER_I965,       // OSS Intel
-  DRIVER_ARM,        // Official Mali driver
-  DRIVER_LIMA,       // OSS Mali driver
-  DRIVER_QUALCOMM,   // Official Adreno driver
-  DRIVER_FREEDRENO,  // OSS Adreno driver
-  DRIVER_IMGTEC,     // Official PowerVR driver
-  DRIVER_VIVANTE,    // Official Vivante driver
-  DRIVER_UNKNOWN     // Unknown driver, default to official hardware driver
+  DRIVER_NVIDIA,       // Official Nvidia, including mobile GPU
+  DRIVER_NOUVEAU,      // OSS nouveau
+  DRIVER_ATI,          // Official ATI
+  DRIVER_R600,         // OSS Radeon
+  DRIVER_INTEL,        // Official Intel
+  DRIVER_I965,         // OSS Intel
+  DRIVER_ARM,          // Official Mali driver
+  DRIVER_LIMA,         // OSS Mali driver
+  DRIVER_QUALCOMM,     // Official Adreno driver
+  DRIVER_FREEDRENO,    // OSS Adreno driver
+  DRIVER_IMGTEC,       // Official PowerVR driver
+  DRIVER_VIVANTE,      // Official Vivante driver
+  DRIVER_PORTABILITY,  // Vulkan via Metal on macOS
+  DRIVER_UNKNOWN       // Unknown driver, default to official hardware driver
 };
 
 enum class Family
@@ -283,4 +284,4 @@ void Init(API api, Vendor vendor, Driver driver, const double version, const Fam
 // Once Vendor and driver version is set, this will return if it has the applicable bug passed to
 // it.
 bool HasBug(Bug bug);
-}
+}  // namespace DriverDetails

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -448,7 +448,7 @@ void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texg
     if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
     {
       out.Write("SSBO_BINDING(0) buffer BBox {\n"
-                "\tint4 bbox_data;\n"
+                "\tint bbox_left, bbox_right, bbox_top, bbox_bottom;\n"
                 "};\n");
     }
     else
@@ -853,13 +853,21 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
 
   if (uid_data->bounding_box)
   {
-    const char* atomic_op =
-        (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan) ? "atomic" : "Interlocked";
-    out.Write("\tif(bbox_data[0] > int(rawpos.x)) %sMin(bbox_data[0], int(rawpos.x));\n"
-              "\tif(bbox_data[1] < int(rawpos.x)) %sMax(bbox_data[1], int(rawpos.x));\n"
-              "\tif(bbox_data[2] > int(rawpos.y)) %sMin(bbox_data[2], int(rawpos.y));\n"
-              "\tif(bbox_data[3] < int(rawpos.y)) %sMax(bbox_data[3], int(rawpos.y));\n",
-              atomic_op, atomic_op, atomic_op, atomic_op);
+    if (ApiType == APIType::D3D)
+    {
+      out.Write(
+          "\tif(bbox_data[0] > int(rawpos.x)) InterlockedMin(bbox_data[0], int(rawpos.x));\n"
+          "\tif(bbox_data[1] < int(rawpos.x)) InterlockedMax(bbox_data[1], int(rawpos.x));\n"
+          "\tif(bbox_data[2] > int(rawpos.y)) InterlockedMin(bbox_data[2], int(rawpos.y));\n"
+          "\tif(bbox_data[3] < int(rawpos.y)) InterlockedMax(bbox_data[3], int(rawpos.y));\n");
+    }
+    else
+    {
+      out.Write("\tif(bbox_left > int(rawpos.x)) atomicMin(bbox_left, int(rawpos.x));\n"
+                "\tif(bbox_right < int(rawpos.x)) atomicMax(bbox_right, int(rawpos.x));\n"
+                "\tif(bbox_top > int(rawpos.y)) atomicMin(bbox_top, int(rawpos.y));\n"
+                "\tif(bbox_bottom < int(rawpos.y)) atomicMax(bbox_bottom, int(rawpos.y));\n");
+    }
   }
 
   out.Write("}\n");

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -1239,17 +1239,23 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
 
   if (bounding_box)
   {
-    const char* atomic_op =
-        (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan) ? "atomic" : "Interlocked";
     out.Write("  if (bpmem_bounding_box) {\n");
-    out.Write("    if(bbox_data[0] > int(rawpos.x)) %sMin(bbox_data[0], int(rawpos.x));\n",
-              atomic_op);
-    out.Write("    if(bbox_data[1] < int(rawpos.x)) %sMax(bbox_data[1], int(rawpos.x));\n",
-              atomic_op);
-    out.Write("    if(bbox_data[2] > int(rawpos.y)) %sMin(bbox_data[2], int(rawpos.y));\n",
-              atomic_op);
-    out.Write("    if(bbox_data[3] < int(rawpos.y)) %sMax(bbox_data[3], int(rawpos.y));\n",
-              atomic_op);
+    if (ApiType == APIType::D3D)
+    {
+      out.Write(
+          "    if(bbox_data[0] > int(rawpos.x)) InterlockedMin(bbox_data[0], int(rawpos.x));\n"
+          "    if(bbox_data[1] < int(rawpos.x)) InterlockedMax(bbox_data[1], int(rawpos.x));\n"
+          "    if(bbox_data[2] > int(rawpos.y)) InterlockedMin(bbox_data[2], int(rawpos.y));\n"
+          "    if(bbox_data[3] < int(rawpos.y)) InterlockedMax(bbox_data[3], int(rawpos.y));\n");
+    }
+    else
+    {
+      out.Write("\tif(bbox_left > int(rawpos.x)) atomicMin(bbox_left, int(rawpos.x));\n"
+                "\tif(bbox_right < int(rawpos.x)) atomicMax(bbox_right, int(rawpos.x));\n"
+                "\tif(bbox_top > int(rawpos.y)) atomicMin(bbox_top, int(rawpos.y));\n"
+                "\tif(bbox_bottom < int(rawpos.y)) atomicMax(bbox_bottom, int(rawpos.y));\n");
+    }
+
     out.Write("  }\n");
   }
 
@@ -1414,4 +1420,4 @@ void EnumeratePixelShaderUids(const std::function<void(const PixelShaderUid&)>& 
     }
   }
 }
-}
+}  // namespace UberShader

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -25,9 +25,7 @@
 #include "VideoBackends/Null/VideoBackend.h"
 #include "VideoBackends/OGL/VideoBackend.h"
 #include "VideoBackends/Software/VideoBackend.h"
-#ifndef __APPLE__
 #include "VideoBackends/Vulkan/VideoBackend.h"
-#endif
 
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/BPStructs.h"
@@ -187,9 +185,7 @@ void VideoBackendBase::PopulateList()
 #ifdef _WIN32
   g_available_video_backends.push_back(std::make_unique<DX11::VideoBackend>());
 #endif
-#ifndef __APPLE__
   g_available_video_backends.push_back(std::make_unique<Vulkan::VideoBackend>());
-#endif
   g_available_video_backends.push_back(std::make_unique<SW::VideoSoftware>());
   g_available_video_backends.push_back(std::make_unique<Null::VideoBackend>());
 

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -43,6 +43,10 @@ public:
   virtual std::string GetDisplayName() const { return GetName(); }
   virtual void InitBackendInfo() = 0;
 
+  // Prepares a native window for rendering. This is called on the main thread, or the
+  // thread which owns the window.
+  virtual void PrepareWindow(const WindowSystemInfo& wsi) {}
+
   void Video_ExitLoop();
 
   void Video_BeginField(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u64 ticks);


### PR DESCRIPTION
It seems MoltenVK is now mature enough to handle the shaders Dolphin generates without completely falling over. It will be interesting to see how it performs compared to OpenGL, but more importantly, it enables mac users to use features blocked by the GL version, e.g. bounding box.

We'll also have to decide how to distribute MoltenVK. Currently, the loader searches for an environment variable named `LIBMOLTENVK_PATH`, and if present uses that. Otherwise, it looks in the application bundle directory, under `DolphinWx.app/Contents/Frameworks/libMoltenVK.dylib`.

I'd suggest building MoltenVK externally, and copying the library in as a buildbot step. IMO, this is better than including yet another huge externals dependency, for a single platform.

**Known limitations:**

- In single core mode, enabling multithreading in graphics options can lead to lower performance. In dual core mode, it seems similar. Probably best to disable it though, due to MoltenVK doing its own threading internally.
- Ubershaders cause the shader compiler to freak out. I haven't looked into whether this is a SPIRV-Cross (via MoltenVK) issue, or we need to update our glslang.
