### PR TITLE
EXI_DeviceMic: Make data members of CEXIMic private 

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -40,14 +40,14 @@ static void state_callback(cubeb_stream* stream, void* user_data, cubeb_state st
 {
 }
 
-static long data_callback(cubeb_stream* stream, void* user_data, const void* inputbuffer,
-                          void* /*outputbuffer*/, long nframes)
+long CEXIMic::DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
+                           void* /*output_buffer*/, long nframes)
 {
   CEXIMic* mic = static_cast<CEXIMic*>(user_data);
 
   std::lock_guard<std::mutex> lk(mic->ring_lock);
 
-  const s16* buff_in = static_cast<const s16*>(inputbuffer);
+  const s16* buff_in = static_cast<const s16*>(input_buffer);
   for (long i = 0; i < nframes; i++)
   {
     mic->stream_buffer[mic->stream_wpos] = buff_in[i];
@@ -87,7 +87,7 @@ void CEXIMic::StreamStart()
 
   if (cubeb_stream_init(m_cubeb_ctx.get(), &m_cubeb_stream, "Dolphin Emulated GameCube Microphone",
                         nullptr, &params, nullptr, nullptr,
-                        std::max<u32>(buff_size_samples, minimum_latency), data_callback,
+                        std::max<u32>(buff_size_samples, minimum_latency), DataCallback,
                         state_callback, this) != CUBEB_OK)
   {
     ERROR_LOG(EXPANSIONINTERFACE, "Error initializing cubeb stream");

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -65,7 +65,6 @@ private:
 
   void TransferByte(u8& byte) override;
 
-  void StreamLog(const char* msg);
   void StreamInit();
   void StreamTerminate();
   void StreamStart();

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -60,6 +60,18 @@ private:
     };
   };
 
+  static long DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
+                           void* output_buffer, long nframes);
+
+  void TransferByte(u8& byte) override;
+
+  void StreamLog(const char* msg);
+  void StreamInit();
+  void StreamTerminate();
+  void StreamStart();
+  void StreamStop();
+  void StreamReadOne();
+
   // 64 is the max size, can be 16 or 32 as well
   int ring_pos;
   u8 ring_buffer[64 * sample_size];
@@ -73,14 +85,6 @@ private:
   std::shared_ptr<cubeb> m_cubeb_ctx = nullptr;
   cubeb_stream* m_cubeb_stream = nullptr;
 
-  void StreamLog(const char* msg);
-  void StreamInit();
-  void StreamTerminate();
-  void StreamStart();
-  void StreamStop();
-  void StreamReadOne();
-
-public:
   UStatus status;
 
   std::mutex ring_lock;
@@ -97,8 +101,5 @@ public:
   int stream_wpos;
   int stream_rpos;
   int samples_avail;
-
-protected:
-  void TransferByte(u8& byte) override;
 };
 }  // namespace ExpansionInterface


### PR DESCRIPTION
Given they were only made public so that the callback could access class state, we can simply make the callback a private static function of CEXIMic, which allows access to members from the callback function without making all of said members public.