### PR TITLE
WiimoteDevice: Get rid of pointer casting in CBigEndianBuffer

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -15,6 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Common/Swap.h"
 #include "Core/Core.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/Host.h"
@@ -26,6 +27,22 @@ namespace IOS
 {
 namespace HLE
 {
+class CBigEndianBuffer
+{
+public:
+  CBigEndianBuffer(u8* pBuffer) : m_pBuffer(pBuffer) {}
+  u8 Read8(u32 offset) const { return m_pBuffer[offset]; }
+  u16 Read16(u32 offset) const { return Common::swap16(*(u16*)&m_pBuffer[offset]); }
+  u32 Read32(u32 offset) const { return Common::swap32(*(u32*)&m_pBuffer[offset]); }
+  void Write8(u32 offset, u8 data) { m_pBuffer[offset] = data; }
+  void Write16(u32 offset, u16 data) { *(u16*)&m_pBuffer[offset] = Common::swap16(data); }
+  void Write32(u32 offset, u32 data) { *(u32*)&m_pBuffer[offset] = Common::swap32(data); }
+  u8* GetPointer(u32 offset) { return &m_pBuffer[offset]; }
+
+private:
+  u8* m_pBuffer;
+};
+
 WiimoteDevice::WiimoteDevice(Device::BluetoothEmu* host, int number, bdaddr_t bd, bool ready)
     : m_BD(bd),
       m_Name(number == WIIMOTE_BALANCE_BOARD ? "Nintendo RVL-WBC-01" : "Nintendo RVL-CNT-01"),

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -32,11 +32,19 @@ class CBigEndianBuffer
 public:
   CBigEndianBuffer(u8* pBuffer) : m_pBuffer(pBuffer) {}
   u8 Read8(u32 offset) const { return m_pBuffer[offset]; }
-  u16 Read16(u32 offset) const { return Common::swap16(*(u16*)&m_pBuffer[offset]); }
-  u32 Read32(u32 offset) const { return Common::swap32(*(u32*)&m_pBuffer[offset]); }
+  u16 Read16(u32 offset) const { return Common::swap16(&m_pBuffer[offset]); }
+  u32 Read32(u32 offset) const { return Common::swap32(&m_pBuffer[offset]); }
   void Write8(u32 offset, u8 data) { m_pBuffer[offset] = data; }
-  void Write16(u32 offset, u16 data) { *(u16*)&m_pBuffer[offset] = Common::swap16(data); }
-  void Write32(u32 offset, u32 data) { *(u32*)&m_pBuffer[offset] = Common::swap32(data); }
+  void Write16(u32 offset, u16 data)
+  {
+    const u16 swapped = Common::swap16(data);
+    std::memcpy(&m_pBuffer[offset], &swapped, sizeof(u16));
+  }
+  void Write32(u32 offset, u32 data)
+  {
+    const u32 swapped = Common::swap32(data);
+    std::memcpy(&m_pBuffer[offset], &swapped, sizeof(u32));
+  }
   u8* GetPointer(u32 offset) { return &m_pBuffer[offset]; }
 
 private:

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -30,7 +30,7 @@ namespace HLE
 class CBigEndianBuffer
 {
 public:
-  CBigEndianBuffer(u8* pBuffer) : m_pBuffer(pBuffer) {}
+  explicit CBigEndianBuffer(u8* pBuffer) : m_pBuffer(pBuffer) {}
   u8 Read8(u32 offset) const { return m_pBuffer[offset]; }
   u16 Read16(u32 offset) const { return Common::swap16(&m_pBuffer[offset]); }
   u32 Read32(u32 offset) const { return Common::swap32(&m_pBuffer[offset]); }

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
-#include "Common/Swap.h"
 #include "Core/IOS/USB/Bluetooth/hci.h"
 
 class PointerWrap;
@@ -22,22 +21,6 @@ namespace Device
 {
 class BluetoothEmu;
 }
-
-class CBigEndianBuffer
-{
-public:
-  CBigEndianBuffer(u8* pBuffer) : m_pBuffer(pBuffer) {}
-  u8 Read8(u32 offset) const { return m_pBuffer[offset]; }
-  u16 Read16(u32 offset) const { return Common::swap16(*(u16*)&m_pBuffer[offset]); }
-  u32 Read32(u32 offset) const { return Common::swap32(*(u32*)&m_pBuffer[offset]); }
-  void Write8(u32 offset, u8 data) { m_pBuffer[offset] = data; }
-  void Write16(u32 offset, u16 data) { *(u16*)&m_pBuffer[offset] = Common::swap16(data); }
-  void Write32(u32 offset, u32 data) { *(u32*)&m_pBuffer[offset] = Common::swap32(data); }
-  u8* GetPointer(u32 offset) { return &m_pBuffer[offset]; }
-
-private:
-  u8* m_pBuffer;
-};
 
 class WiimoteDevice
 {


### PR DESCRIPTION
Makes for fewer places to violate alignment requirements, and makes behavior well-defined. There's much more instances of pointer casting to clean up in this file, however this just gets the easy header-based one out of the way first, since it gets rid of an include dependency in said header.