### PR TITLE
Interpreter_FloatingPoint: Don't store to destination in frsqrte if VE or ZE is set and a relevant exception occurs

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -432,6 +432,8 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   if (b < 0.0)
   {
     SetFPException(FPSCR_VXSQRT);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
 
     if (FPSCR.VE == 0)
       compute_result(b);
@@ -446,6 +448,8 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   else if (Common::IsSNAN(b))
   {
     SetFPException(FPSCR_VXSNAN);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
 
     if (FPSCR.VE == 0)
       compute_result(b);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -422,35 +422,38 @@ void Interpreter::fresx(UGeckoInstruction inst)
 void Interpreter::frsqrtex(UGeckoInstruction inst)
 {
   const double b = rPS0(inst.FB);
-  const double result = Common::ApproximateReciprocalSquareRoot(b);
+
+  const auto compute_result = [inst](double value) {
+    const double result = Common::ApproximateReciprocalSquareRoot(value);
+    rPS0(inst.FD) = result;
+    PowerPC::UpdateFPRF(result);
+  };
 
   if (b < 0.0)
   {
     SetFPException(FPSCR_VXSQRT);
 
     if (FPSCR.VE == 0)
-      PowerPC::UpdateFPRF(result);
+      compute_result(b);
   }
   else if (b == 0.0)
   {
     SetFPException(FPSCR_ZX);
 
     if (FPSCR.ZE == 0)
-      PowerPC::UpdateFPRF(result);
+      compute_result(b);
   }
   else if (Common::IsSNAN(b))
   {
     SetFPException(FPSCR_VXSNAN);
 
     if (FPSCR.VE == 0)
-      PowerPC::UpdateFPRF(result);
+      compute_result(b);
   }
   else
   {
-    PowerPC::UpdateFPRF(result);
+    compute_result(b);
   }
-
-  rPS0(inst.FD) = result;
 
   if (inst.Rc)
     Helper_UpdateCR1();


### PR DESCRIPTION
See #7045 for an explanation with specifics (pertaining to `fres`, but also applies here as well). If the VE bit is set and an invalid operation occurs, then the destination register is supposed to remain untouched. The same applies for when ZE is set and a division by zero exception condition occurs.

On top of the invalid operation case, when an invalid operation occurs, both `FPSCR.FI` and `FPSCR.FR` should be cleared.