### PR TITLE
Update GameINI settings for the Japanese Pokémon Colosseum Bonus Discs.

### DIFF
--- a/Data/Sys/GameSettings/PCK.ini
+++ b/Data/Sys/GameSettings/PCK.ini
@@ -13,5 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-# override value that was set in P.ini back to defaults
-SafeTextureCacheColorSamples = 
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/PCS.ini
+++ b/Data/Sys/GameSettings/PCS.ini
@@ -13,5 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-# override value that was set in P.ini back to defaults
-SafeTextureCacheColorSamples = 
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
These discs use the Pokémon Colosseum engine and thus need Safe Texture Cache for scrolling text to display correctly.

As a side note, the 'PCKJ' variant includes a Pokémon Channel demo, which would mean we should also set EFB to RAM, but as far as I can tell the activity in the full game that requires this setting (the Smeargle tool) is not actually in the demo, so I didn't set it.

For reference:
http://redump.org/disc/26012/
http://redump.org/disc/45709/