### PR TITLE
Interpreter_FPUtils/FloatingPoint/Paired: Amend cases where FPSCR.FR and FPSCR.FI should be unset

### DIFF
--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -476,6 +476,12 @@ union UReg_FPSCR
 
   UReg_FPSCR() = default;
   explicit UReg_FPSCR(u32 hex_) : Hex{hex_} {}
+
+  void ClearFIFR()
+  {
+    FI = 0;
+    FR = 0;
+  }
 };
 
 // Hardware Implementation-Dependent Register 0

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -105,8 +105,7 @@ inline double NI_mul(double a, double b)
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(a))
@@ -115,8 +114,7 @@ inline double NI_mul(double a, double b)
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXIMZ);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
     return PPC_NAN;
   }
   return t;
@@ -131,8 +129,7 @@ inline double NI_div(double a, double b)
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(a))
@@ -145,21 +142,18 @@ inline double NI_div(double a, double b)
       if (a == 0.0)
       {
         SetFPException(FPSCR_VXZDZ);
-        FPSCR.FI = 0;
-        FPSCR.FR = 0;
+        FPSCR.ClearFIFR();
       }
       else
       {
         SetFPException(FPSCR_ZX);
-        FPSCR.FI = 0;
-        FPSCR.FR = 0;
+        FPSCR.ClearFIFR();
       }
     }
     else if (std::isinf(a) && std::isinf(b))
     {
       SetFPException(FPSCR_VXIDI);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     return PPC_NAN;
@@ -177,8 +171,7 @@ inline double NI_add(double a, double b)
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(a))
@@ -187,8 +180,7 @@ inline double NI_add(double a, double b)
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
     return PPC_NAN;
   }
 
@@ -204,8 +196,7 @@ inline double NI_sub(double a, double b)
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(a))
@@ -214,8 +205,7 @@ inline double NI_sub(double a, double b)
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
     return PPC_NAN;
   }
 
@@ -234,8 +224,7 @@ inline double NI_madd(double a, double c, double b)
     if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(a))
@@ -246,8 +235,7 @@ inline double NI_madd(double a, double c, double b)
       return MakeQuiet(c);
 
     SetFPException(FPSCR_VXIMZ);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
     return PPC_NAN;
   }
 
@@ -258,16 +246,14 @@ inline double NI_madd(double a, double c, double b)
     if (Common::IsSNAN(b))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(b))
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
     return PPC_NAN;
   }
 
@@ -283,8 +269,7 @@ inline double NI_msub(double a, double c, double b)
     if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(a))
@@ -295,8 +280,7 @@ inline double NI_msub(double a, double c, double b)
       return MakeQuiet(c);
 
     SetFPException(FPSCR_VXIMZ);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
     return PPC_NAN;
   }
 
@@ -307,16 +291,14 @@ inline double NI_msub(double a, double c, double b)
     if (Common::IsSNAN(b))
     {
       SetFPException(FPSCR_VXSNAN);
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
 
     if (std::isnan(b))
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
     return PPC_NAN;
   }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -103,7 +103,11 @@ inline double NI_mul(double a, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(a))
       return MakeQuiet(a);
@@ -111,6 +115,8 @@ inline double NI_mul(double a, double b)
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXIMZ);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
     return PPC_NAN;
   }
   return t;
@@ -123,7 +129,11 @@ inline double NI_div(double a, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(a))
       return MakeQuiet(a);
@@ -135,6 +145,8 @@ inline double NI_div(double a, double b)
       if (a == 0.0)
       {
         SetFPException(FPSCR_VXZDZ);
+        FPSCR.FI = 0;
+        FPSCR.FR = 0;
       }
       else
       {
@@ -146,6 +158,8 @@ inline double NI_div(double a, double b)
     else if (std::isinf(a) && std::isinf(b))
     {
       SetFPException(FPSCR_VXIDI);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
     }
 
     return PPC_NAN;
@@ -161,7 +175,11 @@ inline double NI_add(double a, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(a))
       return MakeQuiet(a);
@@ -169,6 +187,8 @@ inline double NI_add(double a, double b)
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
     return PPC_NAN;
   }
 
@@ -182,7 +202,11 @@ inline double NI_sub(double a, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(a))
       return MakeQuiet(a);
@@ -190,6 +214,8 @@ inline double NI_sub(double a, double b)
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
     return PPC_NAN;
   }
 
@@ -206,7 +232,11 @@ inline double NI_madd(double a, double c, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(a))
       return MakeQuiet(a);
@@ -216,6 +246,8 @@ inline double NI_madd(double a, double c, double b)
       return MakeQuiet(c);
 
     SetFPException(FPSCR_VXIMZ);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
     return PPC_NAN;
   }
 
@@ -224,12 +256,18 @@ inline double NI_madd(double a, double c, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(b))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(b))
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
     return PPC_NAN;
   }
 
@@ -243,7 +281,11 @@ inline double NI_msub(double a, double c, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(a) || Common::IsSNAN(b) || Common::IsSNAN(c))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(a))
       return MakeQuiet(a);
@@ -253,6 +295,8 @@ inline double NI_msub(double a, double c, double b)
       return MakeQuiet(c);
 
     SetFPException(FPSCR_VXIMZ);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
     return PPC_NAN;
   }
 
@@ -261,12 +305,18 @@ inline double NI_msub(double a, double c, double b)
   if (std::isnan(t))
   {
     if (Common::IsSNAN(b))
+    {
       SetFPException(FPSCR_VXSNAN);
+      FPSCR.FI = 0;
+      FPSCR.FR = 0;
+    }
 
     if (std::isnan(b))
       return MakeQuiet(b);
 
     SetFPException(FPSCR_VXISI);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
     return PPC_NAN;
   }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -397,6 +397,8 @@ void Interpreter::fresx(UGeckoInstruction inst)
   if (b == 0.0)
   {
     SetFPException(FPSCR_ZX);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
 
     if (FPSCR.ZE == 0)
       compute_result(b);
@@ -441,6 +443,8 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   else if (b == 0.0)
   {
     SetFPException(FPSCR_ZX);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
 
     if (FPSCR.ZE == 0)
       compute_result(b);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -92,8 +92,7 @@ void ConvertToInteger(UGeckoInstruction inst, RoundingMode rounding_mode)
     const double di = i;
     if (di == b)
     {
-      FPSCR.FI = 0;
-      FPSCR.FR = 0;
+      FPSCR.ClearFIFR();
     }
     else
     {
@@ -105,8 +104,7 @@ void ConvertToInteger(UGeckoInstruction inst, RoundingMode rounding_mode)
 
   if (exception_occurred)
   {
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
   }
 
   if (!exception_occurred || FPSCR.VE == 0)
@@ -285,8 +283,7 @@ void Interpreter::frspx(UGeckoInstruction inst)  // round to single
       PowerPC::UpdateFPRF(b);
     }
 
-    SetFI(0);
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
   }
   else
   {
@@ -397,8 +394,7 @@ void Interpreter::fresx(UGeckoInstruction inst)
   if (b == 0.0)
   {
     SetFPException(FPSCR_ZX);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
 
     if (FPSCR.ZE == 0)
       compute_result(b);
@@ -406,8 +402,7 @@ void Interpreter::fresx(UGeckoInstruction inst)
   else if (Common::IsSNAN(b))
   {
     SetFPException(FPSCR_VXSNAN);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
 
     if (FPSCR.VE == 0)
       compute_result(b);
@@ -434,8 +429,7 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   if (b < 0.0)
   {
     SetFPException(FPSCR_VXSQRT);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
 
     if (FPSCR.VE == 0)
       compute_result(b);
@@ -443,8 +437,7 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   else if (b == 0.0)
   {
     SetFPException(FPSCR_ZX);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
 
     if (FPSCR.ZE == 0)
       compute_result(b);
@@ -452,8 +445,7 @@ void Interpreter::frsqrtex(UGeckoInstruction inst)
   else if (Common::IsSNAN(b))
   {
     SetFPException(FPSCR_VXSNAN);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
 
     if (FPSCR.VE == 0)
       compute_result(b);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -115,12 +115,19 @@ void Interpreter::ps_div(UGeckoInstruction inst)
 void Interpreter::ps_res(UGeckoInstruction inst)
 {
   // this code is based on the real hardware tests
-  double a = rPS0(inst.FB);
-  double b = rPS1(inst.FB);
+  const double a = rPS0(inst.FB);
+  const double b = rPS1(inst.FB);
 
   if (a == 0.0 || b == 0.0)
   {
     SetFPException(FPSCR_ZX);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
+  }
+
+  if (Common::IsSNAN(a) || Common::IsSNAN(b))
+  {
+    SetFPException(FPSCR_VXSNAN);
     FPSCR.FI = 0;
     FPSCR.FR = 0;
   }
@@ -135,22 +142,32 @@ void Interpreter::ps_res(UGeckoInstruction inst)
 
 void Interpreter::ps_rsqrte(UGeckoInstruction inst)
 {
-  if (rPS0(inst.FB) == 0.0 || rPS1(inst.FB) == 0.0)
+  const double ps0 = rPS0(inst.FB);
+  const double ps1 = rPS1(inst.FB);
+
+  if (ps0 == 0.0 || ps1 == 0.0)
   {
     SetFPException(FPSCR_ZX);
     FPSCR.FI = 0;
     FPSCR.FR = 0;
   }
 
-  if (rPS0(inst.FB) < 0.0 || rPS1(inst.FB) < 0.0)
+  if (ps0 < 0.0 || ps1 < 0.0)
   {
     SetFPException(FPSCR_VXSQRT);
     FPSCR.FI = 0;
     FPSCR.FR = 0;
   }
 
-  rPS0(inst.FD) = ForceSingle(Common::ApproximateReciprocalSquareRoot(rPS0(inst.FB)));
-  rPS1(inst.FD) = ForceSingle(Common::ApproximateReciprocalSquareRoot(rPS1(inst.FB)));
+  if (Common::IsSNAN(ps0) || Common::IsSNAN(ps1))
+  {
+    SetFPException(FPSCR_VXSNAN);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
+  }
+
+  rPS0(inst.FD) = ForceSingle(Common::ApproximateReciprocalSquareRoot(ps0));
+  rPS1(inst.FD) = ForceSingle(Common::ApproximateReciprocalSquareRoot(ps1));
 
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -121,15 +121,13 @@ void Interpreter::ps_res(UGeckoInstruction inst)
   if (a == 0.0 || b == 0.0)
   {
     SetFPException(FPSCR_ZX);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
   }
 
   if (Common::IsSNAN(a) || Common::IsSNAN(b))
   {
     SetFPException(FPSCR_VXSNAN);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
   }
 
   rPS0(inst.FD) = Common::ApproximateReciprocal(a);
@@ -148,22 +146,19 @@ void Interpreter::ps_rsqrte(UGeckoInstruction inst)
   if (ps0 == 0.0 || ps1 == 0.0)
   {
     SetFPException(FPSCR_ZX);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
   }
 
   if (ps0 < 0.0 || ps1 < 0.0)
   {
     SetFPException(FPSCR_VXSQRT);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
   }
 
   if (Common::IsSNAN(ps0) || Common::IsSNAN(ps1))
   {
     SetFPException(FPSCR_VXSNAN);
-    FPSCR.FI = 0;
-    FPSCR.FR = 0;
+    FPSCR.ClearFIFR();
   }
 
   rPS0(inst.FD) = ForceSingle(Common::ApproximateReciprocalSquareRoot(ps0));

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -121,6 +121,8 @@ void Interpreter::ps_res(UGeckoInstruction inst)
   if (a == 0.0 || b == 0.0)
   {
     SetFPException(FPSCR_ZX);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
   }
 
   rPS0(inst.FD) = Common::ApproximateReciprocal(a);
@@ -136,11 +138,15 @@ void Interpreter::ps_rsqrte(UGeckoInstruction inst)
   if (rPS0(inst.FB) == 0.0 || rPS1(inst.FB) == 0.0)
   {
     SetFPException(FPSCR_ZX);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
   }
 
   if (rPS0(inst.FB) < 0.0 || rPS1(inst.FB) < 0.0)
   {
     SetFPException(FPSCR_VXSQRT);
+    FPSCR.FI = 0;
+    FPSCR.FR = 0;
   }
 
   rPS0(inst.FD) = ForceSingle(Common::ApproximateReciprocalSquareRoot(rPS0(inst.FB)));


### PR DESCRIPTION
When an invalid operation exception occurs and is flagged, the `FPSCR.FI` and `FPSCR.FR` bits need to be unset (except within comparisons). This also applies for zero divide exceptions as well, as defined by the *PowerPC Microprocessor Family: Programming Environments Manual for 32 and 64-bit Microprocessors*. This also matches hardware behavior as well.

This corrects discrepancies in how we were handling these bits in exceptional cases.