### PR TITLE
Don't store custom names from TitleDatabase in GameFileCache

### DIFF
--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -19,6 +19,8 @@
 
 namespace Core
 {
+static const std::string EMPTY_STRING;
+
 static std::string GetLanguageCode(DiscIO::Language language)
 {
   switch (language)
@@ -157,16 +159,16 @@ TitleDatabase::TitleDatabase()
 
 TitleDatabase::~TitleDatabase() = default;
 
-std::string TitleDatabase::GetTitleName(const std::string& game_id, TitleType type) const
+const std::string& TitleDatabase::GetTitleName(const std::string& game_id, TitleType type) const
 {
   const auto& map = IsWiiTitle(game_id) ? m_wii_title_map : m_gc_title_map;
   const std::string key =
       type == TitleType::Channel && game_id.length() == 6 ? game_id.substr(0, 4) : game_id;
   const auto iterator = map.find(key);
-  return iterator != map.end() ? iterator->second : "";
+  return iterator != map.end() ? iterator->second : EMPTY_STRING;
 }
 
-std::string TitleDatabase::GetChannelName(u64 title_id) const
+const std::string& TitleDatabase::GetChannelName(u64 title_id) const
 {
   const std::string id{
       {static_cast<char>((title_id >> 24) & 0xff), static_cast<char>((title_id >> 16) & 0xff),
@@ -176,7 +178,7 @@ std::string TitleDatabase::GetChannelName(u64 title_id) const
 
 std::string TitleDatabase::Describe(const std::string& game_id, TitleType type) const
 {
-  const std::string title_name = GetTitleName(game_id, type);
+  const std::string& title_name = GetTitleName(game_id, type);
   if (title_name.empty())
     return game_id;
   return StringFromFormat("%s (%s)", title_name.c_str(), game_id.c_str());

--- a/Source/Core/Core/TitleDatabase.h
+++ b/Source/Core/Core/TitleDatabase.h
@@ -26,10 +26,10 @@ public:
 
   // Get a user friendly title name for a game ID.
   // This falls back to returning an empty string if none could be found.
-  std::string GetTitleName(const std::string& game_id, TitleType = TitleType::Other) const;
+  const std::string& GetTitleName(const std::string& game_id, TitleType = TitleType::Other) const;
 
   // Same as above, but takes a title ID instead of a game ID, and can only find names of channels.
-  std::string GetChannelName(u64 title_id) const;
+  const std::string& GetChannelName(u64 title_id) const;
 
   // Get a description for a game ID (title name if available + game ID).
   std::string Describe(const std::string& game_id, TitleType = TitleType::Other) const;

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -80,7 +80,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_TITLE:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
-      QString name = QString::fromStdString(game.GetName());
+      QString name = QString::fromStdString(game.GetName(m_title_database));
       const int disc_nr = game.GetDiscNumber() + 1;
       if (disc_nr > 1)
       {
@@ -161,8 +161,10 @@ bool GameListModel::ShouldDisplayGameListItem(int index) const
   const UICommon::GameFile& game = *m_games[index];
 
   if (!m_term.isEmpty() &&
-      !QString::fromStdString(game.GetName()).contains(m_term, Qt::CaseInsensitive))
+      !QString::fromStdString(game.GetName(m_title_database)).contains(m_term, Qt::CaseInsensitive))
+  {
     return false;
+  }
 
   const bool show_platform = [&game] {
     switch (game.GetPlatform())

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -10,6 +10,8 @@
 #include <QAbstractTableModel>
 #include <QString>
 
+#include "Core/TitleDatabase.h"
+
 #include "DolphinQt2/GameList/GameTracker.h"
 
 #include "UICommon/GameFile.h"
@@ -63,5 +65,6 @@ private:
 
   GameTracker m_tracker;
   QList<std::shared_ptr<const UICommon::GameFile>> m_games;
+  Core::TitleDatabase m_title_database;
   QString m_term;
 };

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -105,7 +105,7 @@ void GameTracker::StartInternal()
   m_initial_games_emitted_event.Wait();
 
   bool cache_updated = m_cache.Update(paths, emit_game_loaded, emit_game_removed);
-  cache_updated |= m_cache.UpdateAdditionalMetadata(m_title_database, emit_game_updated);
+  cache_updated |= m_cache.UpdateAdditionalMetadata(emit_game_updated);
   if (cache_updated)
     m_cache.Save();
 }
@@ -256,7 +256,7 @@ void GameTracker::LoadGame(const QString& path)
   if (!DiscIO::ShouldHideFromGameList(converted_path))
   {
     bool cache_changed = false;
-    auto game = m_cache.AddOrGet(converted_path, &cache_changed, m_title_database);
+    auto game = m_cache.AddOrGet(converted_path, &cache_changed);
     if (game)
       emit GameLoaded(std::move(game));
     if (cache_changed)

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -14,7 +14,6 @@
 
 #include "Common/Event.h"
 #include "Common/WorkQueueThread.h"
-#include "Core/TitleDatabase.h"
 #include "UICommon/GameFile.h"
 #include "UICommon/GameFileCache.h"
 
@@ -75,7 +74,6 @@ private:
   QMap<QString, QSet<QString>> m_tracked_files;
   Common::WorkQueueThread<Command> m_load_thread;
   UICommon::GameFileCache m_cache;
-  Core::TitleDatabase m_title_database;
   Common::Event m_cache_loaded_event;
   Common::Event m_initial_games_emitted_event;
   bool m_initial_games_emitted = false;

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -35,6 +35,7 @@ public:
 
   void BrowseForDirectory();
   const UICommon::GameFile* GetISO(size_t index) const;
+  const std::string& GetShownName(size_t index) const;
   const UICommon::GameFile* GetSelectedISO() const;
 
   static bool IsHidingItems();
@@ -111,13 +112,12 @@ private:
   UICommon::GameFileCache m_cache;
   // Locks the cache object, not the shared_ptr<GameFile>s obtained from it
   std::mutex m_cache_mutex;
-  Core::TitleDatabase m_title_database;
-  std::mutex m_title_database_mutex;
   std::thread m_scan_thread;
   Common::Event m_scan_trigger;
   Common::Flag m_scan_exiting;
   // UI thread's view into the cache
   std::vector<std::shared_ptr<const UICommon::GameFile>> m_shown_files;
+  std::vector<std::string> m_shown_names;
 
   int m_last_column;
   int m_last_sort;

--- a/Source/Core/UICommon/GameFile.h
+++ b/Source/Core/UICommon/GameFile.h
@@ -44,6 +44,7 @@ public:
   bool IsValid() const;
   const std::string& GetFilePath() const { return m_file_path; }
   const std::string& GetFileName() const { return m_file_name; }
+  const std::string& GetName(const Core::TitleDatabase& title_database) const;
   const std::string& GetName(bool long_name = true) const;
   const std::string& GetMaker(bool long_maker = true) const;
   const std::string& GetShortName(DiscIO::Language l) const { return Lookup(l, m_short_names); }
@@ -79,8 +80,6 @@ public:
   void WiiBannerCommit();
   bool CustomBannerChanged();
   void CustomBannerCommit();
-  bool CustomNameChanged(const Core::TitleDatabase& title_database);
-  void CustomNameCommit();
 
 private:
   static const std::string& Lookup(DiscIO::Language language,
@@ -121,8 +120,6 @@ private:
 
   GameBanner m_volume_banner{};
   GameBanner m_custom_banner{};
-  // Overridden name from TitleDatabase
-  std::string m_custom_name{};
 
   // The following data members allow GameFileCache to construct updated versions
   // of GameFiles in a threadsafe way. They should not be handled in DoState.
@@ -130,7 +127,6 @@ private:
   {
     GameBanner volume_banner;
     GameBanner custom_banner;
-    std::string custom_name;
   } m_pending{};
 };
 

--- a/Source/Core/UICommon/GameFileCache.h
+++ b/Source/Core/UICommon/GameFileCache.h
@@ -16,11 +16,6 @@
 
 class PointerWrap;
 
-namespace Core
-{
-class TitleDatabase;
-}
-
 namespace UICommon
 {
 class GameFile;
@@ -36,23 +31,20 @@ public:
   void Clear();
 
   // Returns nullptr if the file is invalid.
-  std::shared_ptr<const GameFile> AddOrGet(const std::string& path, bool* cache_changed,
-                                           const Core::TitleDatabase& title_database);
+  std::shared_ptr<const GameFile> AddOrGet(const std::string& path, bool* cache_changed);
 
   // These functions return true if the call modified the cache.
   bool Update(const std::vector<std::string>& all_game_paths,
               std::function<void(const std::shared_ptr<const GameFile>&)> game_added_to_cache = {},
               std::function<void(const std::string&)> game_removed_from_cache = {});
   bool UpdateAdditionalMetadata(
-      const Core::TitleDatabase& title_database,
       std::function<void(const std::shared_ptr<const GameFile>&)> game_updated = {});
 
   bool Load();
   bool Save();
 
 private:
-  bool UpdateAdditionalMetadata(std::shared_ptr<GameFile>* game_file,
-                                const Core::TitleDatabase& title_database);
+  bool UpdateAdditionalMetadata(std::shared_ptr<GameFile>* game_file);
 
   bool SyncCacheFile(bool save);
   void DoState(PointerWrap* p, u64 size = 0);


### PR DESCRIPTION
This saves us from having to update the GameFileCache when the TitleDatabase changes (for instance when the user changes language).