### PR TITLE
WiiSave: Use new filesystem interface

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -478,8 +478,8 @@ void UpdateStateFlags(std::function<void(StateFlags*)> update_function)
   const std::string file_path = Common::GetTitleDataPath(Titles::SYSTEM_MENU) + "/" WII_STATE;
   const auto fs = IOS::HLE::GetIOS()->GetFS();
   constexpr IOS::HLE::FS::Mode rw_mode = IOS::HLE::FS::Mode::ReadWrite;
-  const auto file = fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, file_path, rw_mode,
-                                          rw_mode, rw_mode);
+  const auto file = fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, file_path,
+                                          {rw_mode, rw_mode, rw_mode});
   if (!file)
     return;
 

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -269,7 +269,7 @@ bool CBoot::SetupWiiMemory()
 
   constexpr IOS::HLE::FS::Mode rw_mode = IOS::HLE::FS::Mode::ReadWrite;
   const auto settings_file = fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID,
-                                                   settings_file_path, rw_mode, rw_mode, rw_mode);
+                                                   settings_file_path, {rw_mode, rw_mode, rw_mode});
   if (!settings_file || !settings_file->Write(gen.GetBytes().data(), gen.GetBytes().size()))
   {
     PanicAlertT("SetupWiiMemory: Can't create setting.txt file");
@@ -343,7 +343,7 @@ static void WriteEmptyPlayRecord()
   const auto fs = IOS::HLE::GetIOS()->GetFS();
   constexpr IOS::HLE::FS::Mode rw_mode = IOS::HLE::FS::Mode::ReadWrite;
   const auto playrec_file = fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, file_path,
-                                                  rw_mode, rw_mode, rw_mode);
+                                                  {rw_mode, rw_mode, rw_mode});
   if (!playrec_file)
     return;
   std::vector<u8> empty_record(0x80);

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -591,9 +591,9 @@ bool SharedContentMap::WriteEntries() const
   const std::string temp_path = "/tmp/content.map";
   // Atomically write the new content map.
   {
-    const auto file =
-        m_fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, temp_path, HLE::FS::Mode::ReadWrite,
-                                HLE::FS::Mode::ReadWrite, HLE::FS::Mode::None);
+    constexpr HLE::FS::Modes modes{HLE::FS::Mode::ReadWrite, HLE::FS::Mode::ReadWrite,
+                                   HLE::FS::Mode::None};
+    const auto file = m_fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, temp_path, modes);
     if (!file || !file->Write(m_entries.data(), m_entries.size()))
       return false;
   }
@@ -665,9 +665,9 @@ u32 UIDSys::GetOrInsertUIDForTitle(const u64 title_id)
   const u64 swapped_title_id = Common::swap64(title_id);
   const u32 swapped_uid = Common::swap32(uid);
 
-  const auto file =
-      m_fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, UID_MAP_PATH, HLE::FS::Mode::ReadWrite,
-                              HLE::FS::Mode::ReadWrite, HLE::FS::Mode::None);
+  constexpr HLE::FS::Modes modes{HLE::FS::Mode::ReadWrite, HLE::FS::Mode::ReadWrite,
+                                 HLE::FS::Mode::None};
+  const auto file = m_fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, UID_MAP_PATH, modes);
   if (!file || !file->Seek(0, HLE::FS::SeekMode::End) || !file->Write(&swapped_title_id, 1) ||
       !file->Write(&swapped_uid, 1))
   {

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -33,11 +33,9 @@ static ReturnCode WriteTicket(FS::FileSystem* fs, const IOS::ES::TicketReader& t
   const u64 title_id = ticket.GetTitleId();
 
   const std::string path = Common::GetTicketFileName(title_id);
-  fs->CreateFullPath(PID_KERNEL, PID_KERNEL, path, 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite,
-                     FS::Mode::None);
-
-  const auto file = fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, path, FS::Mode::ReadWrite,
-                                          FS::Mode::ReadWrite, FS::Mode::None);
+  constexpr FS::Modes ticket_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::None};
+  fs->CreateFullPath(PID_KERNEL, PID_KERNEL, path, 0, ticket_modes);
+  const auto file = fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, path, ticket_modes);
   if (!file)
     return FS::ConvertResult(file.Error());
 
@@ -400,8 +398,8 @@ ReturnCode ES::ImportContentEnd(Context& context, u32 content_fd)
       "/tmp/" + content_path.substr(content_path.find_last_of('/') + 1, std::string::npos);
 
   {
-    const auto file = fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, temp_path, FS::Mode::ReadWrite,
-                                            FS::Mode::ReadWrite, FS::Mode::None);
+    constexpr FS::Modes content_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::None};
+    const auto file = fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, temp_path, content_modes);
     if (!file || !file->Write(decrypted_data.data(), content_info.size))
     {
       ERROR_LOG(IOS_ES, "ImportContentEnd: Failed to write to %s", temp_path.c_str());

--- a/Source/Core/Core/IOS/FS/FileSystem.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystem.cpp
@@ -69,17 +69,17 @@ Result<FileStatus> FileHandle::GetStatus() const
 void FileSystem::Init()
 {
   if (Delete(0, 0, "/tmp") == ResultCode::Success)
-    CreateDirectory(0, 0, "/tmp", 0, Mode::ReadWrite, Mode::ReadWrite, Mode::ReadWrite);
+    CreateDirectory(0, 0, "/tmp", 0, {Mode::ReadWrite, Mode::ReadWrite, Mode::ReadWrite});
 }
 
 Result<FileHandle> FileSystem::CreateAndOpenFile(Uid uid, Gid gid, const std::string& path,
-                                                 Mode owner_mode, Mode group_mode, Mode other_mode)
+                                                 Modes modes)
 {
   Result<FileHandle> file = OpenFile(uid, gid, path, Mode::ReadWrite);
   if (file.Succeeded())
     return file;
 
-  const ResultCode result = CreateFile(uid, gid, path, 0, owner_mode, group_mode, other_mode);
+  const ResultCode result = CreateFile(uid, gid, path, 0, modes);
   if (result != ResultCode::Success)
     return result;
 
@@ -87,7 +87,7 @@ Result<FileHandle> FileSystem::CreateAndOpenFile(Uid uid, Gid gid, const std::st
 }
 
 ResultCode FileSystem::CreateFullPath(Uid uid, Gid gid, const std::string& path,
-                                      FileAttribute attribute, Mode owner, Mode group, Mode other)
+                                      FileAttribute attribute, Modes modes)
 {
   std::string::size_type position = 1;
   while (true)
@@ -103,7 +103,7 @@ ResultCode FileSystem::CreateFullPath(Uid uid, Gid gid, const std::string& path,
     if (metadata && metadata->is_file)
       return ResultCode::Invalid;
 
-    const ResultCode result = CreateDirectory(uid, gid, subpath, attribute, owner, group, other);
+    const ResultCode result = CreateDirectory(uid, gid, subpath, attribute, modes);
     if (result != ResultCode::Success && result != ResultCode::AlreadyExists)
       return result;
 

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -67,12 +67,17 @@ enum class SeekMode : u32
 
 using FileAttribute = u8;
 
+struct Modes
+{
+  Mode owner, group, other;
+};
+
 struct Metadata
 {
   Uid uid;
   Gid gid;
   FileAttribute attribute;
-  Mode owner_mode, group_mode, other_mode;
+  Modes modes;
   bool is_file;
   u32 size;
   u16 fst_index;
@@ -142,8 +147,7 @@ public:
   /// Get a file descriptor for accessing a file. The FD will be automatically closed after use.
   virtual Result<FileHandle> OpenFile(Uid uid, Gid gid, const std::string& path, Mode mode) = 0;
   /// Create a file if it doesn't exist and open it in read/write mode.
-  Result<FileHandle> CreateAndOpenFile(Uid uid, Gid gid, const std::string& path, Mode owner_mode,
-                                       Mode group_mode, Mode other_mode);
+  Result<FileHandle> CreateAndOpenFile(Uid uid, Gid gid, const std::string& path, Modes modes);
   /// Close a file descriptor.
   virtual ResultCode Close(Fd fd) = 0;
   /// Read `size` bytes from the file descriptor. Returns the number of bytes read.
@@ -157,17 +161,15 @@ public:
 
   /// Create a file with the specified path and metadata.
   virtual ResultCode CreateFile(Uid caller_uid, Gid caller_gid, const std::string& path,
-                                FileAttribute attribute, Mode owner_mode, Mode group_mode,
-                                Mode other_mode) = 0;
+                                FileAttribute attribute, Modes modes) = 0;
   /// Create a directory with the specified path and metadata.
   virtual ResultCode CreateDirectory(Uid caller_uid, Gid caller_gid, const std::string& path,
-                                     FileAttribute attribute, Mode owner_mode, Mode group_mode,
-                                     Mode other_mode) = 0;
+                                     FileAttribute attribute, Modes modes) = 0;
 
   /// Create any parent directories for a path with the specified metadata.
   /// Example: "/a/b" to create directory /a; "/a/b/" to create directories /a and /a/b
   ResultCode CreateFullPath(Uid caller_uid, Gid caller_gid, const std::string& path,
-                            FileAttribute attribute, Mode ownerm, Mode group, Mode other);
+                            FileAttribute attribute, Modes modes);
 
   /// Delete a file or directory with the specified path.
   virtual ResultCode Delete(Uid caller_uid, Gid caller_gid, const std::string& path) = 0;
@@ -183,8 +185,7 @@ public:
   virtual Result<Metadata> GetMetadata(Uid caller_uid, Gid caller_gid, const std::string& path) = 0;
   /// Set metadata for a file.
   virtual ResultCode SetMetadata(Uid caller_uid, const std::string& path, Uid uid, Gid gid,
-                                 FileAttribute attribute, Mode owner_mode, Mode group_mode,
-                                 Mode other_mode) = 0;
+                                 FileAttribute attribute, Modes modes) = 0;
 
   /// Get usage information about the NAND (block size, cluster and inode counts).
   virtual Result<NandStats> GetNandStats() = 0;

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -282,9 +282,7 @@ struct ISFSParams
   Common::BigEndianValue<Uid> uid;
   Common::BigEndianValue<Gid> gid;
   char path[64];
-  Mode owner_mode;
-  Mode group_mode;
-  Mode other_mode;
+  Modes modes;
   FileAttribute attribute;
 };
 
@@ -406,9 +404,8 @@ IPCCommandResult FS::CreateDirectory(const Handle& handle, const IOCtlRequest& r
   if (!params)
     return GetFSReply(ConvertResult(params.Error()));
 
-  const ResultCode result =
-      m_ios.GetFS()->CreateDirectory(handle.uid, handle.gid, params->path, params->attribute,
-                                     params->owner_mode, params->group_mode, params->other_mode);
+  const ResultCode result = m_ios.GetFS()->CreateDirectory(handle.uid, handle.gid, params->path,
+                                                           params->attribute, params->modes);
   LogResult(StringFromFormat("CreateDirectory(%s)", params->path), result);
   return GetReplyForSuperblockOperation(result);
 }
@@ -474,8 +471,7 @@ IPCCommandResult FS::SetAttribute(const Handle& handle, const IOCtlRequest& requ
     return GetFSReply(ConvertResult(params.Error()));
 
   const ResultCode result = m_ios.GetFS()->SetMetadata(
-      handle.uid, params->path, params->uid, params->gid, params->attribute, params->owner_mode,
-      params->group_mode, params->other_mode);
+      handle.uid, params->path, params->uid, params->gid, params->attribute, params->modes);
   LogResult(StringFromFormat("SetMetadata(%s)", params->path), result);
   return GetReplyForSuperblockOperation(result);
 }
@@ -499,9 +495,7 @@ IPCCommandResult FS::GetAttribute(const Handle& handle, const IOCtlRequest& requ
   out.uid = metadata->uid;
   out.gid = metadata->gid;
   out.attribute = metadata->attribute;
-  out.owner_mode = metadata->owner_mode;
-  out.group_mode = metadata->group_mode;
-  out.other_mode = metadata->other_mode;
+  out.modes = metadata->modes;
   Memory::CopyToEmu(request.buffer_out, &out, sizeof(out));
   return GetFSReply(IPC_SUCCESS, ticks);
 }
@@ -535,9 +529,8 @@ IPCCommandResult FS::CreateFile(const Handle& handle, const IOCtlRequest& reques
   if (!params)
     return GetFSReply(ConvertResult(params.Error()));
 
-  const ResultCode result =
-      m_ios.GetFS()->CreateFile(handle.uid, handle.gid, params->path, params->attribute,
-                                params->owner_mode, params->group_mode, params->other_mode);
+  const ResultCode result = m_ios.GetFS()->CreateFile(handle.uid, handle.gid, params->path,
+                                                      params->attribute, params->modes);
   LogResult(StringFromFormat("CreateFile(%s)", params->path), result);
   return GetReplyForSuperblockOperation(result);
 }

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -167,8 +167,7 @@ ResultCode HostFileSystem::Format(Uid uid)
   return ResultCode::Success;
 }
 
-ResultCode HostFileSystem::CreateFile(Uid, Gid, const std::string& path, FileAttribute attribute,
-                                      Mode owner_mode, Mode group_mode, Mode other_mode)
+ResultCode HostFileSystem::CreateFile(Uid, Gid, const std::string& path, FileAttribute, Modes)
 {
   std::string file_name(BuildFilename(path));
   // check if the file already exist
@@ -186,9 +185,7 @@ ResultCode HostFileSystem::CreateFile(Uid, Gid, const std::string& path, FileAtt
   return ResultCode::Success;
 }
 
-ResultCode HostFileSystem::CreateDirectory(Uid, Gid, const std::string& path,
-                                           FileAttribute attribute, Mode owner_mode,
-                                           Mode group_mode, Mode other_mode)
+ResultCode HostFileSystem::CreateDirectory(Uid, Gid, const std::string& path, FileAttribute, Modes)
 {
   if (!IsValidWiiPath(path))
     return ResultCode::Invalid;
@@ -310,9 +307,7 @@ Result<Metadata> HostFileSystem::GetMetadata(Uid, Gid, const std::string& path)
     return ResultCode::Invalid;
 
   std::string file_name = BuildFilename(path);
-  metadata.owner_mode = Mode::ReadWrite;
-  metadata.group_mode = Mode::ReadWrite;
-  metadata.other_mode = Mode::ReadWrite;
+  metadata.modes = {Mode::ReadWrite, Mode::ReadWrite, Mode::ReadWrite};
   metadata.attribute = 0x00;  // no attributes
 
   // Hack: if the path that is being accessed is within an installed title directory, get the
@@ -335,8 +330,7 @@ Result<Metadata> HostFileSystem::GetMetadata(Uid, Gid, const std::string& path)
 }
 
 ResultCode HostFileSystem::SetMetadata(Uid caller_uid, const std::string& path, Uid uid, Gid gid,
-                                       FileAttribute attribute, Mode owner_mode, Mode group_mode,
-                                       Mode other_mode)
+                                       FileAttribute, Modes)
 {
   if (!IsValidWiiPath(path))
     return ResultCode::Invalid;

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.h
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.h
@@ -38,12 +38,10 @@ public:
   Result<FileStatus> GetFileStatus(Fd fd) override;
 
   ResultCode CreateFile(Uid caller_uid, Gid caller_gid, const std::string& path,
-                        FileAttribute attribute, Mode owner_mode, Mode group_mode,
-                        Mode other_mode) override;
+                        FileAttribute attribute, Modes modes) override;
 
   ResultCode CreateDirectory(Uid caller_uid, Gid caller_gid, const std::string& path,
-                             FileAttribute attribute, Mode owner_mode, Mode group_mode,
-                             Mode other_mode) override;
+                             FileAttribute attribute, Modes modes) override;
 
   ResultCode Delete(Uid caller_uid, Gid caller_gid, const std::string& path) override;
   ResultCode Rename(Uid caller_uid, Gid caller_gid, const std::string& old_path,
@@ -54,8 +52,7 @@ public:
 
   Result<Metadata> GetMetadata(Uid caller_uid, Gid caller_gid, const std::string& path) override;
   ResultCode SetMetadata(Uid caller_uid, const std::string& path, Uid uid, Gid gid,
-                         FileAttribute attribute, Mode owner_mode, Mode group_mode,
-                         Mode other_mode) override;
+                         FileAttribute attribute, Modes modes) override;
 
   Result<NandStats> GetNandStats() override;
   Result<DirectoryStats> GetDirectoryStats(const std::string& path) override;

--- a/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NWC24Config.cpp
@@ -44,9 +44,9 @@ void NWC24Config::ReadConfig()
 
 void NWC24Config::WriteConfig() const
 {
-  constexpr FS::Mode rw_mode = FS::Mode::ReadWrite;
-  m_fs->CreateFullPath(PID_KD, PID_KD, CONFIG_PATH, 0, rw_mode, rw_mode, rw_mode);
-  const auto file = m_fs->CreateAndOpenFile(PID_KD, PID_KD, CONFIG_PATH, rw_mode, rw_mode, rw_mode);
+  constexpr FS::Modes public_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite};
+  m_fs->CreateFullPath(PID_KD, PID_KD, CONFIG_PATH, 0, public_modes);
+  const auto file = m_fs->CreateAndOpenFile(PID_KD, PID_KD, CONFIG_PATH, public_modes);
   if (!file || !file->Write(&m_data, 1))
     ERROR_LOG(IOS_WC24, "Failed to open or write WC24 config file");
 }

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
@@ -36,10 +36,9 @@ void WiiNetConfig::ReadConfig(FS::FileSystem* fs)
 
 void WiiNetConfig::WriteConfig(FS::FileSystem* fs) const
 {
-  fs->CreateFullPath(PID_NCD, PID_NCD, CONFIG_PATH, 0, FS::Mode::ReadWrite, FS::Mode::ReadWrite,
-                     FS::Mode::ReadWrite);
-  const auto file = fs->CreateAndOpenFile(PID_NCD, PID_NCD, CONFIG_PATH, FS::Mode::ReadWrite,
-                                          FS::Mode::ReadWrite, FS::Mode::ReadWrite);
+  constexpr FS::Modes public_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite};
+  fs->CreateFullPath(PID_NCD, PID_NCD, CONFIG_PATH, 0, public_modes);
+  const auto file = fs->CreateAndOpenFile(PID_NCD, PID_NCD, CONFIG_PATH, public_modes);
   if (!file || !file->Write(&m_data, 1))
     ERROR_LOG(IOS_NET, "Failed to write config");
 }

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -199,13 +199,13 @@ bool SysConf::Save() const
   const std::string temp_file = "/tmp/SYSCONF";
   constexpr auto rw_mode = IOS::HLE::FS::Mode::ReadWrite;
   {
-    auto file = m_fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, temp_file, rw_mode,
-                                        rw_mode, rw_mode);
+    auto file = m_fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, temp_file,
+                                        {rw_mode, rw_mode, rw_mode});
     if (!file || !file->Write(buffer.data(), buffer.size()))
       return false;
   }
-  m_fs->CreateDirectory(IOS::SYSMENU_UID, IOS::SYSMENU_GID, "/shared2/sys", 0, rw_mode, rw_mode,
-                        rw_mode);
+  m_fs->CreateDirectory(IOS::SYSMENU_UID, IOS::SYSMENU_GID, "/shared2/sys", 0,
+                        {rw_mode, rw_mode, rw_mode});
   const auto result =
       m_fs->Rename(IOS::SYSMENU_UID, IOS::SYSMENU_GID, temp_file, "/shared2/sys/SYSCONF");
   return result == IOS::HLE::FS::ResultCode::Success;

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -96,12 +96,11 @@ static bool CopySysmenuFilesToFS(IOS::HLE::FS::FileSystem* fs, const std::string
     const std::string host_path = host_source_path + '/' + entry.virtualName;
     const std::string nand_path = nand_target_path + '/' + entry.virtualName;
     constexpr IOS::HLE::FS::Mode rw_mode = IOS::HLE::FS::Mode::ReadWrite;
+    constexpr IOS::HLE::FS::Modes public_modes{rw_mode, rw_mode, rw_mode};
 
     if (entry.isDirectory)
     {
-      fs->CreateDirectory(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path, 0, rw_mode, rw_mode,
-                          rw_mode);
-
+      fs->CreateDirectory(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path, 0, public_modes);
       if (!CopySysmenuFilesToFS(fs, host_path, nand_path))
         return false;
     }
@@ -116,8 +115,8 @@ static bool CopySysmenuFilesToFS(IOS::HLE::FS::FileSystem* fs, const std::string
       if (!host_file.ReadBytes(file_data.data(), file_data.size()))
         return false;
 
-      const auto nand_file = fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path,
-                                                   rw_mode, rw_mode, rw_mode);
+      const auto nand_file =
+          fs->CreateAndOpenFile(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path, public_modes);
       if (!nand_file || !nand_file->Write(file_data.data(), file_data.size()))
         return false;
     }


### PR DESCRIPTION
Migrates WiiSave to the new filesystem interface.

The first commit is straightforward: it just replaces all of the FileUtil/File calls with IOS/FS in NandStorage.

The second commit makes WiiSave use the file permission information that is returned by FS or stored in the save header. Two functions, GetFsMode and GetBinMode, were added to convert the permission values between the two formats. Files will now be saved and restored with non-hardcoded, correct values.