### PR TITLE
Gekko: Make register constructors explicit where applicable

### DIFF
--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -322,7 +322,7 @@ union UGQR
   u32 Hex = 0;
 
   UGQR() = default;
-  UGQR(u32 hex_) : Hex{hex_} {}
+  explicit UGQR(u32 hex_) : Hex{hex_} {}
 };
 
 #define XER_CA_SHIFT 29
@@ -346,7 +346,7 @@ union UReg_XER
   u32 Hex = 0;
 
   UReg_XER() = default;
-  UReg_XER(u32 hex_) : Hex{hex_} {}
+  explicit UReg_XER(u32 hex_) : Hex{hex_} {}
 };
 
 // Machine State Register
@@ -546,7 +546,7 @@ union UReg_HID2
   u32 Hex = 0;
 
   UReg_HID2() = default;
-  UReg_HID2(u32 hex_) : Hex{hex_} {}
+  explicit UReg_HID2(u32 hex_) : Hex{hex_} {}
 };
 
 // Hardware Implementation-Dependent Register 4
@@ -569,7 +569,7 @@ union UReg_HID4
   u32 Hex = 0;
 
   UReg_HID4() = default;
-  UReg_HID4(u32 hex_) : Hex{hex_} {}
+  explicit UReg_HID4(u32 hex_) : Hex{hex_} {}
 };
 
 // SPR1 - Page Table format
@@ -632,7 +632,7 @@ union UReg_WPAR
   u32 Hex = 0;
 
   UReg_WPAR() = default;
-  UReg_WPAR(u32 hex_) : Hex{hex_} {}
+  explicit UReg_WPAR(u32 hex_) : Hex{hex_} {}
 };
 
 // Direct Memory Access Upper register
@@ -646,7 +646,7 @@ union UReg_DMAU
   u32 Hex = 0;
 
   UReg_DMAU() = default;
-  UReg_DMAU(u32 hex_) : Hex{hex_} {}
+  explicit UReg_DMAU(u32 hex_) : Hex{hex_} {}
 };
 
 // Direct Memory Access Lower (DMAL) register
@@ -663,7 +663,7 @@ union UReg_DMAL
   u32 Hex = 0;
 
   UReg_DMAL() = default;
-  UReg_DMAL(u32 hex_) : Hex{hex_} {}
+  explicit UReg_DMAL(u32 hex_) : Hex{hex_} {}
 };
 
 union UReg_BAT_Up
@@ -679,7 +679,7 @@ union UReg_BAT_Up
   u32 Hex = 0;
 
   UReg_BAT_Up() = default;
-  UReg_BAT_Up(u32 hex_) : Hex{hex_} {}
+  explicit UReg_BAT_Up(u32 hex_) : Hex{hex_} {}
 };
 
 union UReg_BAT_Lo
@@ -695,7 +695,7 @@ union UReg_BAT_Lo
   u32 Hex = 0;
 
   UReg_BAT_Lo() = default;
-  UReg_BAT_Lo(u32 hex_) : Hex{hex_} {}
+  explicit UReg_BAT_Lo(u32 hex_) : Hex{hex_} {}
 };
 
 union UReg_PTE

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -398,7 +398,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
     break;
 
   case SPR_XER:
-    PowerPC::SetXER(rSPR(index));
+    PowerPC::SetXER(UReg_XER{rSPR(index)});
     break;
 
   case SPR_DBAT0L:

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1170,9 +1170,9 @@ static void UpdateBATs(BatTable& bat_table, u32 base_spr)
   // TODO: Check how hardware reacts to invalid BATs (bad mask etc).
   for (int i = 0; i < 4; ++i)
   {
-    u32 spr = base_spr + i * 2;
-    UReg_BAT_Up batu = PowerPC::ppcState.spr[spr];
-    UReg_BAT_Lo batl = PowerPC::ppcState.spr[spr + 1];
+    const u32 spr = base_spr + i * 2;
+    const UReg_BAT_Up batu{ppcState.spr[spr]};
+    const UReg_BAT_Lo batl{ppcState.spr[spr + 1]};
     if (batu.VS == 0 && batu.VP == 0)
       continue;
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -303,7 +303,7 @@ inline UReg_XER GetXER()
   xer |= PowerPC::ppcState.xer_stringctrl;
   xer |= PowerPC::ppcState.xer_ca << XER_CA_SHIFT;
   xer |= PowerPC::ppcState.xer_so_ov << XER_OV_SHIFT;
-  return xer;
+  return UReg_XER{xer};
 }
 
 inline void SetXER(UReg_XER new_xer)


### PR DESCRIPTION
Prevents implicit conversions to types and requires explicitly specifying them in order to construct instances of them. Given these are used within emulation code directly, being explicit is always better than implicit. Most of our code already uses these constructs in an explicit manner to begin with, so not a lot of changes are required elsewhere in the codebase.