### PR TITLE
Add auto-hide option to Wii IR pointer

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -22,8 +22,15 @@ private:
   // to something that makes sense with the default range.
   static constexpr double SPEED_MULTIPLIER = 0.04;
 
+  // Sets the length for the auto-hide timer
+  static constexpr int TIMER_VALUE = 500;
+
   ControlState m_x = 0.0;
   ControlState m_y = 0.0;
   ControlState m_z = 0.0;
+
+  int m_autohide_timer = TIMER_VALUE;
+  ControlState m_prev_xx;
+  ControlState m_prev_yy;
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
Added an option which automatically hides the Wii IR pointer after a few seconds of inactivity. This is when you're using a joystick or similar to control the Wii's IR pointer and the game only uses the pointer for brief periods (eg. Super Mario Galaxy). The implementation probably needs work and I am quite open to feedback.