### PR TITLE
DSPAccelerator: const qualify pointer parameter for Read()

### DIFF
--- a/Source/Core/Core/DSP/DSPAccelerator.cpp
+++ b/Source/Core/Core/DSP/DSPAccelerator.cpp
@@ -58,7 +58,7 @@ void Accelerator::WriteD3(u16 value)
   }
 }
 
-u16 Accelerator::Read(s16* coefs)
+u16 Accelerator::Read(const s16* coefs)
 {
   if (m_reads_stopped)
     return 0x0000;

--- a/Source/Core/Core/DSP/DSPAccelerator.h
+++ b/Source/Core/Core/DSP/DSPAccelerator.h
@@ -15,7 +15,7 @@ class Accelerator
 public:
   virtual ~Accelerator() = default;
 
-  u16 Read(s16* coefs);
+  u16 Read(const s16* coefs);
   // Zelda ucode reads ARAM through 0xffd3.
   u16 ReadD3();
   void WriteD3(u16 value);


### PR DESCRIPTION
The data pointed to is only ever read, so make this explicit.