### PR TITLE
PadMappingDialog: Show player ID in player dropdown

### DIFF
--- a/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.cpp
@@ -56,7 +56,10 @@ int PadMappingDialog::exec()
   players.append(tr("None"));
 
   for (const auto& player : m_players)
-    players.append(QString::fromStdString(player->name));
+  {
+    players.append(
+        QStringLiteral("%1 (%2)").arg(QString::fromStdString(player->name)).arg(player->pid));
+  }
 
   for (auto& combo_group : {m_gc_boxes, m_wii_boxes})
   {


### PR DESCRIPTION
Makes it easier to differentiate players that have the same name. Replaces #5893.