### PR TITLE
Qt/PropertiesDialog: Fix tabs being cut off due to small window size

### DIFF
--- a/Source/Core/DolphinQt2/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/PropertiesDialog.cpp
@@ -44,16 +44,16 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
 
   connect(ar, &ARCodeWidget::OpenGeneralSettings, this, &PropertiesDialog::OpenGeneralSettings);
 
-  tab_widget->addTab(GetWrappedWidget(game_config, this, 50, 80), tr("Game Config"));
-  tab_widget->addTab(GetWrappedWidget(patches, this, 50, 80), tr("Patches"));
-  tab_widget->addTab(GetWrappedWidget(ar, this, 50, 80), tr("AR Codes"));
-  tab_widget->addTab(GetWrappedWidget(gecko, this, 50, 80), tr("Gecko Codes"));
-  tab_widget->addTab(GetWrappedWidget(info, this, 50, 80), tr("Info"));
+  tab_widget->addTab(GetWrappedWidget(game_config, this, 90, 80), tr("Game Config"));
+  tab_widget->addTab(GetWrappedWidget(patches, this, 90, 80), tr("Patches"));
+  tab_widget->addTab(GetWrappedWidget(ar, this, 90, 80), tr("AR Codes"));
+  tab_widget->addTab(GetWrappedWidget(gecko, this, 90, 80), tr("Gecko Codes"));
+  tab_widget->addTab(GetWrappedWidget(info, this, 90, 80), tr("Info"));
 
   if (DiscIO::IsDisc(game.GetPlatform()))
   {
     FilesystemWidget* filesystem = new FilesystemWidget(game);
-    tab_widget->addTab(GetWrappedWidget(filesystem, this, 50, 80), tr("Filesystem"));
+    tab_widget->addTab(GetWrappedWidget(filesystem, this, 90, 80), tr("Filesystem"));
   }
 
   layout->addWidget(tab_widget);


### PR DESCRIPTION
Before:
![Before](https://i.imgur.com/OU9tSY1.png)
After:
![After](https://i.imgur.com/G2KEhau.png)