### PR TITLE
Qt: Add Refresh button

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -27,6 +27,8 @@ GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
   connect(&Settings::Instance(), &Settings::PathRemoved, &m_tracker, &GameTracker::RemoveDirectory);
   connect(&Settings::Instance(), &Settings::PathReloadRequested, &m_tracker,
           &GameTracker::ReloadDirectory);
+  connect(&Settings::Instance(), &Settings::TitleDBReloadRequested, this,
+          [this] { m_title_database = Core::TitleDatabase(); });
 
   for (const QString& dir : Settings::Instance().GetPaths())
     m_tracker.AddDirectory(dir);

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -442,6 +442,7 @@ void MainWindow::ConnectToolBar()
   addToolBar(m_tool_bar);
 
   connect(m_tool_bar, &ToolBar::OpenPressed, this, &MainWindow::Open);
+  connect(m_tool_bar, &ToolBar::RefreshPressed, this, &MainWindow::RefreshGameList);
 
   connect(m_tool_bar, &ToolBar::PlayPressed, this, [this]() { Play(); });
   connect(m_tool_bar, &ToolBar::PausePressed, this, &MainWindow::Pause);
@@ -514,6 +515,14 @@ void MainWindow::ConnectStack()
   tabifyDockWidget(m_log_widget, m_breakpoint_widget);
   tabifyDockWidget(m_log_widget, m_memory_widget);
   tabifyDockWidget(m_log_widget, m_jit_widget);
+}
+
+void MainWindow::RefreshGameList()
+{
+  Settings::Instance().ReloadTitleDB();
+
+  for (const auto& path : Settings::Instance().GetPaths())
+    Settings::Instance().ReloadPath(path);
 }
 
 QString MainWindow::PromptFileName()

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -68,6 +68,7 @@ signals:
 
 private:
   void Open();
+  void RefreshGameList();
   void Play(const std::optional<std::string>& savestate_path = {});
   void Pause();
   void TogglePause();

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -128,6 +128,11 @@ void Settings::ReloadPath(const QString& qpath)
   emit PathReloadRequested(qpath);
 }
 
+void Settings::ReloadTitleDB()
+{
+  emit TitleDBReloadRequested();
+}
+
 QString Settings::GetDefaultGame() const
 {
   return QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -70,6 +70,7 @@ public:
   QString GetDefaultGame() const;
   void SetDefaultGame(QString path);
   void ReloadPath(const QString& qpath);
+  void ReloadTitleDB();
 
   // Emulation
   int GetStateSlot() const;
@@ -135,6 +136,7 @@ signals:
   void PathRemoved(const QString&);
   void DefaultGameChanged(const QString&);
   void PathReloadRequested(const QString&);
+  void TitleDBReloadRequested();
   void HideCursorChanged();
   void KeepWindowOnTopChanged(bool top);
   void VolumeChanged(int volume);

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -99,6 +99,10 @@ void ToolBar::MakeActions()
   m_set_pc_action = AddAction(this, tr("Set PC"), this, &ToolBar::SetPCPressed);
 
   m_open_action = AddAction(this, tr("Open"), this, &ToolBar::OpenPressed);
+  m_refresh_action = AddAction(this, tr("Refresh"), this, &ToolBar::RefreshPressed);
+
+  addSeparator();
+
   m_pause_play_action = AddAction(this, tr("Play"), this, &ToolBar::PlayPressed);
 
   m_stop_action = AddAction(this, tr("Stop"), this, &ToolBar::StopPressed);
@@ -160,6 +164,7 @@ void ToolBar::UpdateIcons()
   m_set_pc_action->setIcon(Resources::GetScaledThemeIcon("debugger_show_pc"));
 
   m_open_action->setIcon(Resources::GetScaledThemeIcon("open"));
+  m_refresh_action->setIcon(Resources::GetScaledThemeIcon("refresh"));
 
   const Core::State state = Core::GetState();
   const bool playing = state != Core::State::Uninitialized && state != Core::State::Paused;

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -23,6 +23,7 @@ public:
   void closeEvent(QCloseEvent*) override;
 signals:
   void OpenPressed();
+  void RefreshPressed();
   void PlayPressed();
   void PausePressed();
   void StopPressed();
@@ -49,6 +50,7 @@ private:
   void UpdatePausePlayButtonState(bool playing_state);
 
   QAction* m_open_action;
+  QAction* m_refresh_action;
   QAction* m_pause_play_action;
   QAction* m_stop_action;
   QAction* m_fullscreen_action;


### PR DESCRIPTION
While Qt usually does a good job of keeping track of changes, sometimes it won't work properly (e.g. network drives, external storage media etc). This button gives the user the option to manually kick off a complete refresh when this happens.