### PR TITLE
DSPEmitter: Make m_unresolved_jumps private

### DIFF
--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -365,7 +365,7 @@ void DSPEmitter::Compile(u16 start_addr)
   JMP(m_return_dispatcher, true);
 }
 
-static void CompileCurrent(DSPEmitter& emitter)
+void DSPEmitter::CompileCurrent(DSPEmitter& emitter)
 {
   emitter.Compile(g_dsp.pc);
 

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.h
@@ -205,9 +205,11 @@ public:
   void madd(UDSPInstruction opc);
   void msub(UDSPInstruction opc);
 
-  std::array<std::list<u16>, MAX_BLOCKS> m_unresolved_jumps;
-
 private:
+  // The emitter emits calls to this function. It's present here
+  // within the class itself to allow access to member variables.
+  static void CompileCurrent(DSPEmitter& emitter);
+
   void WriteBranchExit();
   void WriteBlockLink(u16 dest);
 
@@ -306,6 +308,8 @@ private:
   std::vector<u16> m_block_size;
   std::vector<Block> m_block_links;
   Block m_block_link_entry;
+
+  std::array<std::list<u16>, MAX_BLOCKS> m_unresolved_jumps;
 
   u16 m_cycles_left = 0;
 


### PR DESCRIPTION
By making the JITed function a private static function of DSPEmitter, we can allow access to data members within the context of the function without making them public overall. This finally makes all data members for the x64 DSP emitter private.