### PR TITLE
Qt/CheatCodeEditor: Don't accept rich text

### DIFF
--- a/Source/Core/DolphinQt2/Config/CheatCodeEditor.cpp
+++ b/Source/Core/DolphinQt2/Config/CheatCodeEditor.cpp
@@ -106,6 +106,9 @@ void CheatCodeEditor::CreateWidgets()
 
   m_code_edit->setFont(monospace);
 
+  m_code_edit->setAcceptRichText(false);
+  m_notes_edit->setAcceptRichText(false);
+
   setLayout(grid_layout);
 }
 


### PR DESCRIPTION
Fixes [issue #11204](https://bugs.dolphin-emu.org/issues/11204).