### PR TITLE
Qt/GCPadWiiUConfigDialog: Fix settings not being loaded properly

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadWiiUConfigDialog.cpp
@@ -19,9 +19,9 @@ GCPadWiiUConfigDialog::GCPadWiiUConfigDialog(int port, QWidget* parent)
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateLayout();
-  ConnectWidgets();
 
   LoadSettings();
+  ConnectWidgets();
 }
 
 void GCPadWiiUConfigDialog::CreateLayout()


### PR DESCRIPTION
Fixes [issue #11200](https://bugs.dolphin-emu.org/issues/11200)