### PR TITLE
Qt/InfoWidget: Don't prefix maker id with '0x'

### DIFF
--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -76,7 +76,7 @@ QGroupBox* InfoWidget::CreateISODetails()
   const std::string game_maker = m_game.GetMaker();
 
   QLineEdit* maker =
-      CreateValueDisplay((game_maker.empty() ? UNKNOWN_NAME.toStdString() : game_maker) + " (0x" +
+      CreateValueDisplay((game_maker.empty() ? UNKNOWN_NAME.toStdString() : game_maker) + " (" +
                          m_game.GetMakerID() + ")");
   QWidget* checksum = CreateChecksumComputer();
 


### PR DESCRIPTION
It's not actually hexadecimal.