### PR TITLE
Set 0x0000002C to NDEV 2.1 when running a debug-signed Wii disc

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -43,6 +43,7 @@
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
+#include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
 #include "Core/PatchEngine.h"
 #include "Core/PowerPC/PPCAnalyst.h"
@@ -370,7 +371,7 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
 
         // Because there is no TMD to get the requested system (IOS) version from,
         // we default to IOS58, which is the version used by the Homebrew Channel.
-        SetupWiiMemory();
+        SetupWiiMemory(IOS::HLE::IOSC::ConsoleType::Retail);
         IOS::HLE::GetIOS()->BootIOS(Titles::IOS(58));
       }
       else

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Core/IOS/IOSC.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
@@ -116,7 +117,7 @@ private:
   static bool Load_BS2(const std::string& boot_rom_filename);
 
   static void SetupGCMemory();
-  static bool SetupWiiMemory();
+  static bool SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type);
 };
 
 class BootExecutableReader

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cinttypes>
 #include <memory>
 
 #include "Common/CommonTypes.h"
@@ -12,6 +13,7 @@
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/IOS.h"
+#include "Core/IOS/IOSC.h"
 #include "Core/WiiUtils.h"
 #include "DiscIO/WiiWad.h"
 
@@ -21,9 +23,15 @@ bool CBoot::BootNANDTitle(const u64 title_id)
     state->type = 0x04;  // TYPE_NANDBOOT
   });
 
-  auto* ios = IOS::HLE::GetIOS();
-  SetupWiiMemory();
-  return ios->GetES()->LaunchTitle(title_id);
+  auto es = IOS::HLE::GetIOS()->GetES();
+  const IOS::ES::TicketReader ticket = es->FindSignedTicket(title_id);
+  auto console_type = IOS::HLE::IOSC::ConsoleType::Retail;
+  if (ticket.IsValid())
+    console_type = ticket.GetConsoleType();
+  else
+    ERROR_LOG(BOOT, "No ticket was found for %016" PRIx64, title_id);
+  SetupWiiMemory(console_type);
+  return es->LaunchTitle(title_id);
 }
 
 bool CBoot::Boot_WiiWAD(const DiscIO::WiiWAD& wad)

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -443,10 +443,13 @@ std::array<u8, 16> TicketReader::GetTitleKey(const HLE::IOSC& iosc) const
 
 std::array<u8, 16> TicketReader::GetTitleKey() const
 {
-  const bool is_rvt = (GetIssuer() == "Root-CA00000002-XS00000006");
-  const HLE::IOSC::ConsoleType console_type =
-      is_rvt ? HLE::IOSC::ConsoleType::RVT : HLE::IOSC::ConsoleType::Retail;
-  return GetTitleKey(HLE::IOSC{console_type});
+  return GetTitleKey(HLE::IOSC{GetConsoleType()});
+}
+
+HLE::IOSC::ConsoleType TicketReader::GetConsoleType() const
+{
+  const bool is_rvt = GetIssuer() == "Root-CA00000002-XS00000006";
+  return is_rvt ? HLE::IOSC::ConsoleType::RVT : HLE::IOSC::ConsoleType::Retail;
 }
 
 void TicketReader::DeleteTicket(u64 ticket_id_to_delete)

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -242,6 +242,9 @@ public:
   // and constructs a temporary IOSC instance.
   std::array<u8, 16> GetTitleKey() const;
 
+  // Infers the console type (retail or devkit) based on the certificate issuer.
+  HLE::IOSC::ConsoleType GetConsoleType() const;
+
   // Deletes a ticket with the given ticket ID from the internal buffer.
   void DeleteTicket(u64 ticket_id);
 


### PR DESCRIPTION
This fixes the The Last Story prototype that @GerbilSoft was testing, because the apploader is a bit more lenient with the max size of DOL sections when it detects that you're using a devkit console.