### PR TITLE
Interpreter_SystemRegisters: Change PanicAlert to INFO_LOG in mtspr()

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -405,7 +405,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
   case SPR_DEC:
     if (!(old_value >> 31) && (rGPR[inst.RD] >> 31))  // top bit from 0 to 1
     {
-      PanicAlert("Interesting - Software triggered Decrementer exception");
+      INFO_LOG(POWERPC, "Software triggered Decrementer exception");
       PowerPC::ppcState.Exceptions |= EXCEPTION_DECREMENTER;
     }
     SystemTimers::DecrementerSet();


### PR DESCRIPTION
As peculiar as this may be, decrementer exceptions by means of setting the decrementer's zeroth bit from 0 to 1 is valid behavior by software (and is defined in Programming Environments for 32-bit Microprocessors in section 2.3.14.1 — Decrementer operation). Given it's valid behavior, it doesn't necessarily make sense to use a panic alert and halt, as this isn't a condition where everything should be considered in a critical state.

Instead, change it to an info log, so we still make note of it, but without potentially tearing down state or halting emulation.