### PR TITLE
JitBase: Centralize location of code buffer

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -48,9 +48,7 @@ struct CachedInterpreter::Instruction
   Type type = Type::Abort;
 };
 
-CachedInterpreter::CachedInterpreter() : code_buffer(32000)
-{
-}
+CachedInterpreter::CachedInterpreter() = default;
 
 CachedInterpreter::~CachedInterpreter() = default;
 
@@ -194,7 +192,7 @@ void CachedInterpreter::Jit(u32 address)
     ClearCache();
   }
 
-  const u32 nextPC = analyzer.Analyze(PC, &code_block, &code_buffer, code_buffer.size());
+  const u32 nextPC = analyzer.Analyze(PC, &code_block, &m_code_buffer, m_code_buffer.size());
   if (code_block.m_memory_exception)
   {
     // Address of instruction could not be translated
@@ -218,7 +216,7 @@ void CachedInterpreter::Jit(u32 address)
 
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
-    PPCAnalyst::CodeOp& op = code_buffer[i];
+    PPCAnalyst::CodeOp& op = m_code_buffer[i];
 
     js.downcountAmount += op.opinfo->numCycles;
 

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
@@ -42,5 +42,4 @@ private:
 
   BlockCache m_block_cache{*this};
   std::vector<Instruction> m_code;
-  PPCAnalyst::CodeBuffer code_buffer;
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -27,13 +27,19 @@
 #include "Core/PowerPC/Jit64/JitRegCache.h"
 #include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"
-#include "Core/PowerPC/PPCAnalyst.h"
+
+namespace PPCAnalyst
+{
+struct CodeBlock;
+struct CodeOp;
+}
 
 class Jit64 : public Jitx86Base
 {
 public:
-  Jit64() : code_buffer(32000) {}
-  ~Jit64() {}
+  Jit64();
+  ~Jit64() override;
+
   void Init() override;
   void Shutdown() override;
 
@@ -242,9 +248,6 @@ private:
   GPRRegCache gpr{*this};
   FPURegCache fpr{*this};
 
-  // The default code buffer. We keep it around to not have to alloc/dealloc a
-  // large chunk of memory for each recompiled block.
-  PPCAnalyst::CodeBuffer code_buffer;
   Jit64AsmRoutineManager asm_routines{*this};
 
   bool m_enable_blr_optimization;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -36,6 +36,12 @@ constexpr size_t SAFE_STACK_SIZE = 512 * 1024;
 constexpr size_t GUARD_SIZE = 0x10000;  // two guards - bottom (permanent) and middle (see above)
 constexpr size_t GUARD_OFFSET = STACK_SIZE - SAFE_STACK_SIZE - GUARD_SIZE;
 
+JitArm64::JitArm64() : m_float_emit(this)
+{
+}
+
+JitArm64::~JitArm64() = default;
+
 void JitArm64::Init()
 {
   InitializeInstructionTables();
@@ -553,7 +559,7 @@ void JitArm64::Jit(u32)
     ClearCache();
   }
 
-  std::size_t block_size = code_buffer.size();
+  std::size_t block_size = m_code_buffer.size();
   const u32 em_address = PowerPC::ppcState.pc;
 
   if (SConfig::GetInstance().bEnableDebugging)
@@ -565,7 +571,7 @@ void JitArm64::Jit(u32)
   // Analyze the block, collect all instructions it is made of (including inlining,
   // if that is enabled), reorder instructions for optimal performance, and join joinable
   // instructions.
-  const u32 nextPC = analyzer.Analyze(em_address, &code_block, &code_buffer, block_size);
+  const u32 nextPC = analyzer.Analyze(em_address, &code_block, &m_code_buffer, block_size);
 
   if (code_block.m_memory_exception)
   {
@@ -651,7 +657,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   // Translate instructions
   for (u32 i = 0; i < code_block.m_num_instructions; i++)
   {
-    PPCAnalyst::CodeOp& op = code_buffer[i];
+    PPCAnalyst::CodeOp& op = m_code_buffer[i];
 
     js.compilerPC = op.address;
     js.op = &op;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -21,8 +21,9 @@
 class JitArm64 : public JitBase, public Arm64Gen::ARM64CodeBlock, public CommonAsmRoutinesBase
 {
 public:
-  JitArm64() : code_buffer(32000), m_float_emit(this) {}
-  ~JitArm64() {}
+  JitArm64();
+  ~JitArm64() override;
+
   void Init() override;
   void Shutdown() override;
 
@@ -244,8 +245,6 @@ private:
   Arm64FPRCache fpr;
 
   JitArm64BlockCache blocks{*this};
-
-  PPCAnalyst::CodeBuffer code_buffer;
 
   Arm64Gen::ARM64FloatEmitter m_float_emit;
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -28,7 +28,9 @@ u32 Helper_Mask(u8 mb, u8 me)
   return mb > me ? ~mask : mask;
 }
 
-JitBase::JitBase() = default;
+JitBase::JitBase() : m_code_buffer(code_buffer_size)
+{
+}
 
 JitBase::~JitBase() = default;
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -8,6 +8,7 @@
 //#define JIT_LOG_GPR     // Enables logging of the PPC general purpose regs
 //#define JIT_LOG_FPR     // Enables logging of the PPC floating point regs
 
+#include <cstddef>
 #include <map>
 #include <unordered_set>
 
@@ -102,6 +103,7 @@ protected:
   };
 
   PPCAnalyst::CodeBlock code_block;
+  PPCAnalyst::CodeBuffer m_code_buffer;
   PPCAnalyst::PPCAnalyzer analyzer;
 
   bool CanMergeNextInstructions(int count) const;
@@ -109,10 +111,6 @@ protected:
   void UpdateMemoryOptions();
 
 public:
-  // This should probably be removed from public:
-  JitOptions jo{};
-  JitState js{};
-
   JitBase();
   ~JitBase() override;
 
@@ -125,6 +123,12 @@ public:
 
   virtual bool HandleFault(uintptr_t access_address, SContext* ctx) = 0;
   virtual bool HandleStackFault() { return false; }
+
+  static constexpr std::size_t code_buffer_size = 32000;
+
+  // This should probably be removed from public:
+  JitOptions jo{};
+  JitState js{};
 };
 
 void JitTrampoline(JitBase& jit, u32 em_address);

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -15,6 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
+#include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PPCTables.h"
@@ -35,8 +36,6 @@
 
 namespace PPCAnalyst
 {
-constexpr int CODEBUFFER_SIZE = 32000;
-
 // 0 does not perform block merging
 constexpr u32 BRANCH_FOLLOWING_THRESHOLD = 2;
 
@@ -90,7 +89,7 @@ bool AnalyzeFunction(u32 startAddr, Common::Symbol& func, u32 max_size)
   for (u32 addr = startAddr; true; addr += 4)
   {
     func.size += 4;
-    if (func.size >= CODEBUFFER_SIZE * 4 || !PowerPC::HostIsInstructionRAMAddress(addr))  // weird
+    if (func.size >= JitBase::code_buffer_size * 4 || !PowerPC::HostIsInstructionRAMAddress(addr))
       return false;
 
     if (max_size && func.size > max_size)


### PR DESCRIPTION
Given the code buffer is something truly common to all JIT implementations, we can centralize it in the base class and avoid duplicating it all over the place, while still allowing for differently-sized code buffers.