### PR TITLE
Android: Add AlertDialog for files without Game IDs in Game Settings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -136,16 +136,19 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 	@Override
 	public boolean onLongClick(View view)
 	{
+		FragmentActivity activity = (FragmentActivity) view.getContext();
 		GameViewHolder holder = (GameViewHolder) view.getTag();
 		String gameId = holder.gameFile.getGameId();
 
 		if (gameId.isEmpty())
 		{
-			// We can't make a game-specific INI file if there is no game ID
+			AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+			builder.setTitle("Game Settings");
+			builder.setMessage("Files without game IDs don't support game-specific settings.");
+
+			builder.show();
 			return true;
 		}
-
-		FragmentActivity activity = (FragmentActivity) view.getContext();
 
 		AlertDialog.Builder builder = new AlertDialog.Builder(activity);
 		builder.setTitle("Game Settings")

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -89,7 +89,11 @@ public final class GameRowPresenter extends Presenter
 
 				if (gameId.isEmpty())
 				{
-					// We can't make a game-specific INI file if there is no game ID
+					AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+					builder.setTitle("Game Settings");
+					builder.setMessage("Files without game IDs don't support game-specific settings.");
+
+					builder.show();
 					return true;
 				}
 


### PR DESCRIPTION
Prevents users from long-pressing DOL or ELF and being confused when nothing happens.