### PR TITLE
Fix Renderer::DrawDebugText() interaction with Input Display

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -139,7 +139,7 @@ static std::array<u8, 20> ConvertGitRevisionToBytes(const std::string& revision)
 }
 
 // NOTE: GPU Thread
-std::string GetInputDisplay()
+InputDisplayText GetInputDisplay()
 {
   if (!IsMovieActive())
   {
@@ -153,13 +153,16 @@ std::string GetInputDisplay()
     }
   }
 
-  std::string input_display;
+  InputDisplayText input_display;
   {
     std::lock_guard<std::mutex> guard(s_input_display_lock);
     for (int i = 0; i < 8; ++i)
     {
       if ((s_controllers & (1 << i)) != 0)
-        input_display += s_InputDisplay[i] + '\n';
+      {
+        input_display.cyan += s_InputDisplay[i] + '\n';
+        input_display.yellow += '\n';
+      }
     }
   }
   return input_display;

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -175,7 +175,12 @@ void CheckPadStatus(const GCPadStatus* PadStatus, int controllerID);
 void CheckWiimoteStatus(int wiimote, const u8* data, const struct WiimoteEmu::ReportFeatures& rptf,
                         int ext, const wiimote_key key);
 
-std::string GetInputDisplay();
+struct InputDisplayText
+{
+  std::string cyan;
+  std::string yellow;
+};
+InputDisplayText GetInputDisplay();
 std::string GetRTCDisplay();
 
 // Done this way to avoid mixing of core and gui code

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -280,8 +280,8 @@ void Renderer::DrawDebugText()
 
   if (SConfig::GetInstance().m_ShowInputDisplay)
   {
-    final_cyan += Movie::GetInputDisplay();
-    final_yellow += "\n";
+    final_cyan += Movie::GetInputDisplay().cyan;
+    final_yellow += Movie::GetInputDisplay().yellow;
   }
 
   if (SConfig::GetInstance().m_ShowRTC)


### PR DESCRIPTION
Correctly adjusts the yellow line of DrawDebugText() if Input Display is enabled.