### PR TITLE
CMakeLists: Add support for ppc64le

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,10 @@ elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   add_definitions(-D_M_ARM_64=1)
   # CRC instruction set is used in the CRC32 hash function
   check_and_add_flag(HAVE_ARCH_ARMV8 -march=armv8-a+crc)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+  set(_M_GENERIC 1)
+  add_definitions(-D_M_GENERIC=1)
+  check_and_add_flag(MCMODEL -mcmodel=large)
 else()
   message(FATAL_ERROR "You're building on an unsupported platform: "
       "'${CMAKE_SYSTEM_PROCESSOR}' with ${CMAKE_SIZEOF_VOID_P}-byte pointers."


### PR DESCRIPTION
The build fails with a "relocation truncated to fit" error unless `-mcmodel=large` is added to the compiler arguments.

With this patch I can now build Dolphin on my POWER9-based system. If there's a better way to do this or if anything else needs to be changed I'm open to suggestions.