### PR TITLE
Gekko: Centralize bitmasking of the FPSCR within UReg_FPSCR

### DIFF
--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -474,8 +474,37 @@ union UReg_FPSCR
   };
   u32 Hex = 0;
 
+  // The FPSCR's 20th bit (11th from a little endian perspective)
+  // is defined as reserved and set to zero. Attempts to modify it
+  // are ignored by hardware, so we do the same.
+  static constexpr u32 mask = 0xFFFFF7FF;
+
   UReg_FPSCR() = default;
-  explicit UReg_FPSCR(u32 hex_) : Hex{hex_} {}
+  explicit UReg_FPSCR(u32 hex_) : Hex{hex_ & mask} {}
+
+  UReg_FPSCR& operator=(u32 value)
+  {
+    Hex = value & mask;
+    return *this;
+  }
+
+  UReg_FPSCR& operator|=(u32 value)
+  {
+    Hex |= value & mask;
+    return *this;
+  }
+
+  UReg_FPSCR& operator&=(u32 value)
+  {
+    Hex &= value;
+    return *this;
+  }
+
+  UReg_FPSCR& operator^=(u32 value)
+  {
+    Hex ^= value & mask;
+    return *this;
+  }
 
   void ClearFIFR()
   {

--- a/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
@@ -290,7 +290,7 @@ void RegisterWidget::PopulateTable()
 
   // FPSCR
   AddRegister(22, 5, RegisterType::fpscr, "FPSCR", [] { return PowerPC::ppcState.fpscr.Hex; },
-              [](u64 value) { PowerPC::ppcState.fpscr.Hex = value; });
+              [](u64 value) { PowerPC::ppcState.fpscr = static_cast<u32>(value); });
 
   // MSR
   AddRegister(23, 5, RegisterType::msr, "MSR", [] { return PowerPC::ppcState.msr.Hex; },

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -124,7 +124,7 @@ void SetSpecialRegValue(int reg, u32 value)
     PowerPC::SetXER(UReg_XER(value));
     break;
   case 5:
-    PowerPC::ppcState.fpscr.Hex = value;
+    PowerPC::ppcState.fpscr = value;
     break;
   case 6:
     PowerPC::ppcState.msr.Hex = value;


### PR DESCRIPTION
Rather than introduce this handling in every system instruction that modifies the FPSCR directly, we can instead just handle it within the data structure instead, which avoids duplicating mask handling across instructions.

This also allows handling proper masking from the debugger register windows themselves without duplicating masking behavior there either.

Strictly speaking, `^=` and `&=` aren't necessary with our current code, but are provided for consistency.