### PR TITLE
Jit64Common: Eliminate branch in ConvertDoubleToSingle

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -898,10 +898,9 @@ void EmuCodeBlock::ConvertDoubleToSingle(X64Reg dst, X64Reg src)
   MOVD_xmm(R(RSCRATCH), XMM1);
 
   // Check if the double is in the range of valid single subnormal
-  CMP(16, R(RSCRATCH), Imm16(896));
-  FixupBranch NoDenormalize = J_CC(CC_G);
-  CMP(16, R(RSCRATCH), Imm16(874));
-  FixupBranch NoDenormalize2 = J_CC(CC_L);
+  SUB(16, R(RSCRATCH), Imm16(874));
+  CMP(16, R(RSCRATCH), Imm16(896 - 874));
+  FixupBranch NoDenormalize = J_CC(CC_A);
 
   // Denormalise
 
@@ -927,7 +926,6 @@ void EmuCodeBlock::ConvertDoubleToSingle(X64Reg dst, X64Reg src)
   FixupBranch end = J(false);  // Goto end
 
   SetJumpTarget(NoDenormalize);
-  SetJumpTarget(NoDenormalize2);
 
   // Don't Denormalize
 


### PR DESCRIPTION
I think this is one of the optimizations @phire was suggesting in https://github.com/dolphin-emu/dolphin/pull/7040#issuecomment-394243123. I don't think we need another scratch register.

It's pretty much the same optimization I applied elsewhere a few years ago in https://github.com/dolphin-emu/dolphin/pull/2700.