### PR TITLE
JitCommon/JitBase: Rename x86-specific logging define to be platform agnostic

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -954,7 +954,7 @@ const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   b->codeSize = (u32)(GetCodePtr() - start);
   b->originalSize = code_block.m_num_instructions;
 
-#ifdef JIT_LOG_X86
+#ifdef JIT_LOG_GENERATED_CODE
   LogGeneratedX86(code_block.m_num_instructions, m_code_buffer, start, b);
 #endif
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -4,10 +4,6 @@
 
 #pragma once
 
-//#define JIT_LOG_X86     // Enables logging of the generated x86 code
-//#define JIT_LOG_GPR     // Enables logging of the PPC general purpose regs
-//#define JIT_LOG_FPR     // Enables logging of the PPC floating point regs
-
 #include <cstddef>
 #include <map>
 #include <unordered_set>
@@ -20,6 +16,10 @@
 #include "Core/PowerPC/JitCommon/JitAsmCommon.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"
 #include "Core/PowerPC/PPCAnalyst.h"
+
+//#define JIT_LOG_GENERATED_CODE  // Enables logging of generated code
+//#define JIT_LOG_GPR             // Enables logging of the PPC general purpose regs
+//#define JIT_LOG_FPR             // Enables logging of the PPC floating point regs
 
 // Use these to control the instruction selection
 // #define INSTRUCTION_START FallBackToInterpreter(inst); return;


### PR DESCRIPTION
Given JitBase shouldn't include platform specifics, we can generalize this preprocessor define and allow any JIT to use it to indicate that generated code should be logged.

While we're at it, also move these defines beneath the includes with the rest of the defines.