### PR TITLE
HotkeyManager: Minor changes

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -239,7 +239,14 @@ void Shutdown()
 }
 }
 
-const std::array<HotkeyGroupInfo, NUM_HOTKEY_GROUPS> groups_info = {
+struct HotkeyGroupInfo
+{
+  const char* name;
+  Hotkey first;
+  Hotkey last;
+};
+
+constexpr std::array<HotkeyGroupInfo, NUM_HOTKEY_GROUPS> groups_info = {
     {{_trans("General"), HK_OPEN, HK_EXIT},
      {_trans("Volume"), HK_VOLUME_DOWN, HK_VOLUME_TOGGLE_MUTE},
      {_trans("Emulation Speed"), HK_DECREASE_EMULATION_SPEED, HK_TOGGLE_THROTTLE},

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -20,7 +20,7 @@
 #include "InputCommon/GCPadStatus.h"
 
 // clang-format off
-constexpr std::array<const char*, 114> hotkey_labels{{
+constexpr std::array<const char*, 114> s_hotkey_labels{{
     _trans("Open"),
     _trans("Change Disc"),
     _trans("Eject Disc"),
@@ -156,11 +156,11 @@ constexpr std::array<const char*, 114> hotkey_labels{{
     _trans("Load State"),
 }};
 // clang-format on
-static_assert(NUM_HOTKEYS == hotkey_labels.size(), "Wrong count of hotkey_labels");
+static_assert(NUM_HOTKEYS == s_hotkey_labels.size(), "Wrong count of hotkey_labels");
 
 namespace HotkeyManagerEmu
 {
-static std::array<u32, NUM_HOTKEY_GROUPS> s_hotkeyDown;
+static std::array<u32, NUM_HOTKEY_GROUPS> s_hotkey_down;
 static HotkeyStatus s_hotkey;
 static bool s_enabled;
 
@@ -194,14 +194,14 @@ bool IsPressed(int id, bool held)
       static_cast<HotkeyManager*>(s_config.GetController(0))->GetIndexForGroup(group, id);
   if (s_hotkey.button[group] & (1 << group_key))
   {
-    bool pressed = !!(s_hotkeyDown[group] & (1 << group_key));
-    s_hotkeyDown[group] |= (1 << group_key);
+    const bool pressed = !!(s_hotkey_down[group] & (1 << group_key));
+    s_hotkey_down[group] |= (1 << group_key);
     if (!pressed || held)
       return true;
   }
   else
   {
-    s_hotkeyDown[group] &= ~(1 << group_key);
+    s_hotkey_down[group] &= ~(1 << group_key);
   }
 
   return false;
@@ -217,7 +217,7 @@ void Initialize()
   // load the saved controller config
   s_config.LoadConfig(true);
 
-  s_hotkeyDown = {};
+  s_hotkey_down = {};
 
   s_enabled = true;
 }
@@ -245,7 +245,7 @@ struct HotkeyGroupInfo
   Hotkey last;
 };
 
-constexpr std::array<HotkeyGroupInfo, NUM_HOTKEY_GROUPS> groups_info = {
+constexpr std::array<HotkeyGroupInfo, NUM_HOTKEY_GROUPS> s_groups_info = {
     {{_trans("General"), HK_OPEN, HK_EXIT},
      {_trans("Volume"), HK_VOLUME_DOWN, HK_VOLUME_TOGGLE_MUTE},
      {_trans("Emulation Speed"), HK_DECREASE_EMULATION_SPEED, HK_TOGGLE_THROTTLE},
@@ -271,12 +271,12 @@ HotkeyManager::HotkeyManager()
   for (std::size_t group = 0; group < m_hotkey_groups.size(); group++)
   {
     m_hotkey_groups[group] =
-        (m_keys[group] = new ControllerEmu::Buttons("Keys", groups_info[group].name));
+        (m_keys[group] = new ControllerEmu::Buttons("Keys", s_groups_info[group].name));
     groups.emplace_back(m_hotkey_groups[group]);
-    for (int key = groups_info[group].first; key <= groups_info[group].last; key++)
+    for (int key = s_groups_info[group].first; key <= s_groups_info[group].last; key++)
     {
       m_keys[group]->controls.emplace_back(
-          new ControllerEmu::Input(ControllerEmu::Translate, hotkey_labels[key]));
+          new ControllerEmu::Input(ControllerEmu::Translate, s_hotkey_labels[key]));
     }
   }
 }
@@ -293,9 +293,9 @@ std::string HotkeyManager::GetName() const
 void HotkeyManager::GetInput(HotkeyStatus* const kb)
 {
   const auto lock = GetStateLock();
-  for (std::size_t group = 0; group < groups_info.size(); group++)
+  for (std::size_t group = 0; group < s_groups_info.size(); group++)
   {
-    const int group_count = (groups_info[group].last - groups_info[group].first) + 1;
+    const int group_count = (s_groups_info[group].last - s_groups_info[group].first) + 1;
     std::vector<u32> bitmasks(group_count);
     for (size_t key = 0; key < bitmasks.size(); key++)
       bitmasks[key] = static_cast<u32>(1 << key);
@@ -312,15 +312,15 @@ ControllerEmu::ControlGroup* HotkeyManager::GetHotkeyGroup(HotkeyGroup group) co
 
 int HotkeyManager::FindGroupByID(int id) const
 {
-  const auto i = std::find_if(groups_info.begin(), groups_info.end(),
+  const auto i = std::find_if(s_groups_info.begin(), s_groups_info.end(),
                               [id](const auto& entry) { return entry.last >= id; });
 
-  return static_cast<int>(std::distance(groups_info.begin(), i));
+  return static_cast<int>(std::distance(s_groups_info.begin(), i));
 }
 
 int HotkeyManager::GetIndexForGroup(int group, int id) const
 {
-  return id - groups_info[group].first;
+  return id - s_groups_info[group].first;
 }
 
 void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -160,7 +160,7 @@ static_assert(NUM_HOTKEYS == hotkey_labels.size(), "Wrong count of hotkey_labels
 
 namespace HotkeyManagerEmu
 {
-static u32 s_hotkeyDown[NUM_HOTKEY_GROUPS];
+static std::array<u32, NUM_HOTKEY_GROUPS> s_hotkeyDown;
 static HotkeyStatus s_hotkey;
 static bool s_enabled;
 
@@ -217,8 +217,7 @@ void Initialize()
   // load the saved controller config
   s_config.LoadConfig(true);
 
-  for (u32& key : s_hotkeyDown)
-    key = 0;
+  s_hotkeyDown = {};
 
   s_enabled = true;
 }
@@ -269,7 +268,7 @@ constexpr std::array<HotkeyGroupInfo, NUM_HOTKEY_GROUPS> groups_info = {
 
 HotkeyManager::HotkeyManager()
 {
-  for (int group = 0; group < NUM_HOTKEY_GROUPS; group++)
+  for (std::size_t group = 0; group < m_hotkey_groups.size(); group++)
   {
     m_hotkey_groups[group] =
         (m_keys[group] = new ControllerEmu::Buttons("Keys", groups_info[group].name));
@@ -294,7 +293,7 @@ std::string HotkeyManager::GetName() const
 void HotkeyManager::GetInput(HotkeyStatus* const kb)
 {
   const auto lock = GetStateLock();
-  for (int group = 0; group < NUM_HOTKEY_GROUPS; group++)
+  for (std::size_t group = 0; group < groups_info.size(); group++)
   {
     const int group_count = (groups_info[group].last - groups_info[group].first) + 1;
     std::vector<u32> bitmasks(group_count);

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -20,7 +20,7 @@
 #include "InputCommon/GCPadStatus.h"
 
 // clang-format off
-const std::string hotkey_labels[] = {
+constexpr std::array<const char*, 114> hotkey_labels{{
     _trans("Open"),
     _trans("Change Disc"),
     _trans("Eject Disc"),
@@ -154,10 +154,9 @@ const std::string hotkey_labels[] = {
     _trans("Undo Save State"),
     _trans("Save State"),
     _trans("Load State"),
-};
+}};
 // clang-format on
-static_assert(NUM_HOTKEYS == sizeof(hotkey_labels) / sizeof(hotkey_labels[0]),
-              "Wrong count of hotkey_labels");
+static_assert(NUM_HOTKEYS == hotkey_labels.size(), "Wrong count of hotkey_labels");
 
 namespace HotkeyManagerEmu
 {

--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -182,7 +182,7 @@ enum HotkeyGroup : int
 
 struct HotkeyStatus
 {
-  u32 button[NUM_HOTKEY_GROUPS];
+  std::array<u32, NUM_HOTKEY_GROUPS> button;
   s8 err;
 };
 
@@ -200,7 +200,7 @@ public:
   void LoadDefaults(const ControllerInterface& ciface) override;
 
 private:
-  ControllerEmu::Buttons* m_keys[NUM_HOTKEY_GROUPS];
+  std::array<ControllerEmu::Buttons*, NUM_HOTKEY_GROUPS> m_keys;
   std::array<ControllerEmu::ControlGroup*, NUM_HOTKEY_GROUPS> m_hotkey_groups;
 };
 

--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -180,13 +180,6 @@ enum HotkeyGroup : int
   NUM_HOTKEY_GROUPS,
 };
 
-struct HotkeyGroupInfo
-{
-  std::string name;
-  Hotkey first;
-  Hotkey last;
-};
-
 struct HotkeyStatus
 {
   u32 button[NUM_HOTKEY_GROUPS];


### PR DESCRIPTION
The most important part of this PR makes the file-scoped arrays using `const char*` instead of `std::string`. Previously we would be constructing 114+ `std::string` instances for the entirety of program execution, which is kind of wasteful (and makes program start-up a tiny bit slower). Instead, we use const char*, which doesn't have the potential to heap allocate on us.

The rest of the changes are simply mild cleanup and consistency changes.