### PR TITLE
Common/Random: Add convenience template for simple arithmetic values

### DIFF
--- a/Source/Core/Common/Random.h
+++ b/Source/Core/Common/Random.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 #include "Common/CommonTypes.h"
 
@@ -12,4 +13,14 @@ namespace Common::Random
 {
 /// Fill `buffer` with random bytes using a cryptographically secure pseudo-random number generator.
 void Generate(void* buffer, std::size_t size);
+
+/// Generates a random value of arithmetic type `T`
+template <typename T>
+T GenerateValue()
+{
+  static_assert(std::is_arithmetic<T>(), "T must be an arithmetic type in GenerateValue.");
+  T value;
+  Generate(&value, sizeof(value));
+  return value;
+}
 }  // namespace Common::Random

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -270,7 +270,7 @@ TraversalRequestId TraversalClient::SendTraversalPacket(const TraversalPacket& p
 {
   OutgoingTraversalPacketInfo info;
   info.packet = packet;
-  Common::Random::Generate(&info.packet.requestId, sizeof(info.packet.requestId));
+  info.packet.requestId = Common::Random::GenerateValue<TraversalRequestId>();
   info.tries = 0;
   m_OutgoingTraversalPackets.push_back(info);
   ResendPacket(&m_OutgoingTraversalPackets.back());

--- a/Source/Core/Common/TraversalServer.cpp
+++ b/Source/Core/Common/TraversalServer.cpp
@@ -169,8 +169,7 @@ static sockaddr_in6 MakeSinAddr(const TraversalInetAddress& addr)
 static void GetRandomHostId(TraversalHostId* hostId)
 {
   char buf[9];
-  u32 num;
-  Common::Random::Generate(&num, sizeof(num));
+  const u32 num = Common::Random::GenerateValue<u32>();
   sprintf(buf, "%08x", num);
   memcpy(hostId->data(), buf, 8);
 }

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -73,9 +73,8 @@ void DolphinAnalytics::ReloadConfig()
 
 void DolphinAnalytics::GenerateNewIdentity()
 {
-  u64 id_high, id_low;
-  Common::Random::Generate(&id_high, sizeof(id_high));
-  Common::Random::Generate(&id_low, sizeof(id_low));
+  const u64 id_high = Common::Random::GenerateValue<u64>();
+  const u64 id_low = Common::Random::GenerateValue<u64>();
   m_unique_id = StringFromFormat("%016" PRIx64 "%016" PRIx64, id_high, id_low);
 
   // Save the new id in the configuration.


### PR DESCRIPTION
In cases where we just want a random value for a primitive arithmetic type, we can wrap this in a template to allow convenient direct assignment instead of keeping declaration and initialization separate (making it more difficult to use values uninitialized). This also allows the use of Common::Random with functions such as `std::generate`, making it more flexible in how random values can be generated.