### PR TITLE
Android: Dynamic SingleChoiceSetting descriptions

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsAdapter.java
@@ -340,6 +340,8 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 
 	public void closeDialog()
 	{
+		notifyDataSetChanged();
+
 		if (mDialog != null)
 		{
 			mDialog.dismiss();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -246,7 +246,7 @@ public final class SettingsFragmentPresenter
 			emuCoresEntries = R.array.emuCoresEntriesGeneric;
 			emuCoresValues = R.array.emuCoresValuesGeneric;
 		}
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_CPU_CORE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.cpu_core, 0, emuCoresEntries, emuCoresValues, defaultCpuCore, cpuCore));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_CPU_CORE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.cpu_core, R.string.dynamic_cpu_core, emuCoresEntries, emuCoresValues, defaultCpuCore, cpuCore));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DUAL_CORE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.dual_core, R.string.dual_core_description, true, dualCore));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_OVERCLOCK_ENABLE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_enable, R.string.overclock_enable_description, false, overclockEnable));
 		sl.add(new SliderSetting(SettingsFile.KEY_OVERCLOCK_PERCENT, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_title, R.string.overclock_title_description, 400, "%", 100, overclock));
@@ -288,10 +288,10 @@ public final class SettingsFragmentPresenter
 			mView.passSettingsToActivity(mSettings);
 		}
 
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_GAME_CUBE_LANGUAGE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.gamecube_system_language, 0, R.array.gameCubeSystemLanguageEntries, R.array.gameCubeSystemLanguageValues, 0, systemLanguage));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_GAME_CUBE_LANGUAGE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.gamecube_system_language, R.string.dynamic_system_language, R.array.gameCubeSystemLanguageEntries, R.array.gameCubeSystemLanguageValues, 0, systemLanguage));
         sl.add(new CheckBoxSetting(SettingsFile.KEY_OVERRIDE_GAME_CUBE_LANGUAGE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.override_gamecube_language, 0, false, overrideGCLanguage));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_A_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_a_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 8, slotADevice));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_B_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_b_device, 0, R.array.slotDeviceEntries, R.array.slotDeviceValues, 255, slotBDevice));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_A_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_a_device, R.string.dynamic_gamecube_slot, R.array.slotDeviceEntries, R.array.slotDeviceValues, 8, slotADevice));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SLOT_B_DEVICE, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.slot_b_device, R.string.dynamic_gamecube_slot, R.array.slotDeviceEntries, R.array.slotDeviceValues, 255, slotBDevice));
 	}
 
 	private void addWiiSettings(ArrayList<SettingsItem> sl)
@@ -364,11 +364,11 @@ public final class SettingsFragmentPresenter
 		}
 
 		sl.add(new HeaderSetting(null, null, R.string.graphics_general, 0));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_VIDEO_BACKEND_INDEX, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.video_backend, R.string.video_backend_description, R.array.videoBackendEntries, R.array.videoBackendValues, 0, videoBackend));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_VIDEO_BACKEND_INDEX, SettingsFile.SECTION_INI_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.video_backend, R.string.dynamic_video_backend, R.array.videoBackendEntries, R.array.videoBackendValues, 0, videoBackend));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_SHOW_FPS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.show_fps, R.string.show_fps_description, false, showFps));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SHADER_COMPILATION_MODE, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.shader_compilation_mode, R.string.shader_compilation_mode_description, R.array.shaderCompilationModeEntries, R.array.shaderCompilationModeValues, 0, shaderCompilationMode));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_SHADER_COMPILATION_MODE, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.shader_compilation_mode, R.string.dynamic_shader_compilation_mode, R.array.shaderCompilationModeEntries, R.array.shaderCompilationModeValues, 0, shaderCompilationMode));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_WAIT_FOR_SHADERS, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.wait_for_shaders, 0, false, waitForShaders));
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_ASPECT_RATIO, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.aspect_ratio, R.string.aspect_ratio_description, R.array.aspectRatioEntries, R.array.aspectRatioValues, 0, aspectRatio));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_ASPECT_RATIO, SettingsFile.SECTION_GFX_SETTINGS, SettingsFile.SETTINGS_GFX, R.string.aspect_ratio, R.string.dynamic_aspect_ratio, R.array.aspectRatioEntries, R.array.aspectRatioValues, 0, aspectRatio));
 
 		sl.add(new HeaderSetting(null, null, R.string.graphics_enhancements_and_hacks, 0));
 		sl.add(new SubmenuSetting(null, null, R.string.enhancements_submenu, 0, MenuTag.ENHANCEMENTS));
@@ -502,7 +502,7 @@ public final class SettingsFragmentPresenter
 		Setting convergence = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_STEREOSCOPY).getSetting(SettingsFile.KEY_STEREO_CONV);
 		Setting swapEyes = mSettings.get(SettingsFile.SETTINGS_GFX).get(SettingsFile.SECTION_STEREOSCOPY).getSetting(SettingsFile.KEY_STEREO_SWAP);
 
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_STEREO_MODE, SettingsFile.SECTION_STEREOSCOPY, SettingsFile.SETTINGS_GFX, R.string.stereoscopy_mode, R.string.stereoscopy_mode_description, R.array.stereoscopyEntries, R.array.stereoscopyValues, 0, stereoModeValue));
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_STEREO_MODE, SettingsFile.SECTION_STEREOSCOPY, SettingsFile.SETTINGS_GFX, R.string.stereoscopy_mode, R.string.dynamic_stereoscopy_mode, R.array.stereoscopyEntries, R.array.stereoscopyValues, 0, stereoModeValue));
 		sl.add(new SliderSetting(SettingsFile.KEY_STEREO_DEPTH, SettingsFile.SECTION_STEREOSCOPY, SettingsFile.SETTINGS_GFX, R.string.stereoscopy_depth, R.string.stereoscopy_depth_description, 100, "%", 20, stereoDepth));
 		sl.add(new SliderSetting(SettingsFile.KEY_STEREO_CONV, SettingsFile.SECTION_STEREOSCOPY, SettingsFile.SETTINGS_GFX, R.string.stereoscopy_convergence, R.string.stereoscopy_convergence_description, 200, "%", 0, convergence));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_STEREO_SWAP, SettingsFile.SECTION_STEREOSCOPY, SettingsFile.SETTINGS_GFX, R.string.stereoscopy_swap_eyes, R.string.stereoscopy_swap_eyes_description, false, swapEyes));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/viewholder/SingleChoiceViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/viewholder/SingleChoiceViewHolder.java
@@ -35,9 +35,169 @@ public final class SingleChoiceViewHolder extends SettingViewHolder
 
 		mTextSettingName.setText(item.getNameId());
 
-		if (item.getDescriptionId() > 0)
+		switch (item.getDescriptionId())
 		{
-			mTextSettingDescription.setText(item.getDescriptionId());
+			case R.string.dynamic_cpu_core:
+				switch (((SingleChoiceSetting) item).getSelectedValue())
+				{
+					case 0:
+						mTextSettingDescription.setText(R.string.cpu_core_interpreter);
+						break;
+
+					case 5:
+						mTextSettingDescription.setText(R.string.cpu_core_cached_interpreter);
+						break;
+
+					case 4:
+						mTextSettingDescription.setText(R.string.cpu_core_jit_arm64);
+						break;
+
+					case 1:
+						mTextSettingDescription.setText(R.string.cpu_core_jit);
+						break;
+				}
+				break;
+
+			case R.string.dynamic_system_language:
+				switch (((SingleChoiceSetting) item).getSelectedValue())
+				{
+					case 0:
+						mTextSettingDescription.setText(R.string.gamecube_system_language_english);
+						break;
+
+					case 1:
+						mTextSettingDescription.setText(R.string.gamecube_system_language_german);
+						break;
+
+					case 2:
+						mTextSettingDescription.setText(R.string.gamecube_system_language_french);
+						break;
+
+					case 3:
+						mTextSettingDescription.setText(R.string.gamecube_system_language_spanish);
+						break;
+
+					case 4:
+						mTextSettingDescription.setText(R.string.gamecube_system_language_italian);
+						break;
+
+					case 5:
+						mTextSettingDescription.setText(R.string.gamecube_system_language_dutch);
+						break;
+				}
+				break;
+
+			case R.string.dynamic_gamecube_slot:
+				switch (((SingleChoiceSetting) item).getSelectedValue())
+				{
+					case 255:
+						mTextSettingDescription.setText(R.string.slot_device_nothing);
+						break;
+
+					case 0:
+						mTextSettingDescription.setText(R.string.slot_device_dummy);
+						break;
+
+					case 1:
+						mTextSettingDescription.setText(R.string.slot_device_memory_card);
+						break;
+
+					case 8:
+						mTextSettingDescription.setText(R.string.slot_device_gci_folder);
+						break;
+				}
+				break;
+
+			case R.string.dynamic_video_backend:
+				switch (((SingleChoiceSetting) item).getSelectedValue())
+				{
+					case 0:
+						mTextSettingDescription.setText(R.string.video_backend_opengl);
+						break;
+
+					case 1:
+						mTextSettingDescription.setText(R.string.video_backend_vulkan);
+						break;
+
+					case 2:
+						mTextSettingDescription.setText(R.string.video_backend_software);
+						break;
+
+					case 3:
+						mTextSettingDescription.setText(R.string.video_backend_null);
+						break;
+				}
+				break;
+
+			case R.string.dynamic_shader_compilation_mode:
+				switch (((SingleChoiceSetting) item).getSelectedValue())
+				{
+					case 0:
+						mTextSettingDescription.setText(R.string.shader_compilation_sync_description);
+						break;
+
+					case 1:
+						mTextSettingDescription.setText(R.string.shader_compilation_sync_uber_description);
+						break;
+
+					case 2:
+						mTextSettingDescription.setText(R.string.shader_compilation_async_uber_description);
+						break;
+
+					case 3:
+						mTextSettingDescription.setText(R.string.shader_compilation_async_skip_description);
+						break;
+				}
+				break;
+
+			case R.string.dynamic_aspect_ratio:
+				switch (((SingleChoiceSetting) item).getSelectedValue())
+				{
+					case 0:
+						mTextSettingDescription.setText(R.string.aspect_ratio_auto);
+						break;
+
+					case 1:
+						mTextSettingDescription.setText(R.string.aspect_ratio_force_16_9);
+						break;
+
+					case 2:
+						mTextSettingDescription.setText(R.string.aspect_ratio_force_4_3);
+						break;
+
+					case 3:
+						mTextSettingDescription.setText(R.string.aspect_ratio_stretch);
+						break;
+				}
+				break;
+
+			case R.string.dynamic_stereoscopy_mode:
+				switch (((SingleChoiceSetting) item).getSelectedValue())
+				{
+					case 0:
+						mTextSettingDescription.setText(R.string.stereoscopy_mode_off);
+						break;
+
+					case 1:
+						mTextSettingDescription.setText(R.string.stereoscopy_mode_side_side);
+						break;
+
+					case 2:
+						mTextSettingDescription.setText(R.string.stereoscopy_mode_top_bottom);
+						break;
+
+					case 3:
+						mTextSettingDescription.setText(R.string.stereoscopy_mode_anaglyph);
+						break;
+				}
+				break;
+
+			case 0:
+				break;
+
+			default:
+				mTextSettingDescription.setText(item.getDescriptionId());
+				break;
 		}
 	}
 

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -111,7 +111,10 @@
     <!-- General Preference Fragment -->
     <string name="general_submenu">General</string>
     <string name="cpu_core">CPU Core</string>
-    <string name="cpu_core_description">%s</string>
+    <string name="cpu_core_interpreter">Interpreter</string>
+    <string name="cpu_core_cached_interpreter">Cached Interpreter</string>
+    <string name="cpu_core_jit_arm64">JIT ARM64 Recompiler</string>
+    <string name="cpu_core_jit">JIT Recompiler</string>
     <string name="dual_core">Dual Core</string>
     <string name="dual_core_description">Split workload to two CPU cores instead of one. Increases speed.</string>
     <string name="overclock_enable">Override Emulated CPU Clock Speed</string>
@@ -122,9 +125,19 @@
     <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
     <string name="gamecube_submenu">GameCube</string>
     <string name="gamecube_system_language">System Language</string>
+    <string name="gamecube_system_language_english">English</string>
+    <string name="gamecube_system_language_german">German</string>
+    <string name="gamecube_system_language_french">French</string>
+    <string name="gamecube_system_language_spanish">Spanish</string>
+    <string name="gamecube_system_language_italian">Italian</string>
+    <string name="gamecube_system_language_dutch">Dutch</string>
     <string name="override_gamecube_language">Override Language on NTSC games</string>
     <string name="slot_a_device">GameCube Slot A Device</string>
     <string name="slot_b_device">GameCube Slot B Device</string>
+    <string name="slot_device_nothing">Nothing</string>
+    <string name="slot_device_dummy">Dummy</string>
+    <string name="slot_device_memory_card">Memory Card</string>
+    <string name="slot_device_gci_folder">GCI Folder</string>
     <string name="wii_submenu">Wii</string>
     <string name="wiimote_scanning">Wii Remote Continuous Scanning</string>
     <string name="wiimote_scanning_description">Leave this on if you are using a DolphinBar for real Wiimote support.</string>
@@ -146,7 +159,10 @@
 
     <!-- Video Preference Fragment -->
     <string name="video_backend">Video Backend</string>
-    <string name="video_backend_description">Select the API used for graphics rendering.</string>
+    <string name="video_backend_opengl">OpenGL</string>
+    <string name="video_backend_vulkan">Vulkan</string>
+    <string name="video_backend_software">Software</string>
+    <string name="video_backend_null">Null</string>
     <string name="show_fps">Show FPS</string>
     <string name="show_fps_description">Show the number of frames rendered per second as a measure of emulation speed.</string>
 
@@ -174,13 +190,16 @@
     <string name="disable_copy_filter">Disable Copy Filter</string>
     <string name="disable_copy_filter_description">Disables the blending of adjacent rows when copying the EFB. This is known in some games as \"deflickering\" or \"smoothing\". Disabling the filter is usually safe, and may result in a sharper image.</string>
     <string name="arbitrary_mipmap_detection">Arbitrary Mipmap Detection</string>
-    <string name="arbitrary_mipmap_detection_description">Enables detection of arbitrary mipmaps, which some games use for special distance-based effects.\nMay have false positives that result in blurry textures at increased internal resolution, such as in games that use very low resolution mipmaps. Disabling this can also reduce stutter in games that frequently load new textures.\n\nIf unsure, leave this checked.</string>
+    <string name="arbitrary_mipmap_detection_description">Enables detection of arbitrary mipmaps, which some games use for special distance-based effects.\nMay have false positives that result in blurry textures at increased internal resolution, such as in games that use very low resolution mipmaps. Disabling this can also reduce stutter in games that frequently load new textures.\nIf unsure, leave this checked.</string>
     <string name="stereoscopy_submenu">Stereoscopy</string>
     <string name="stereoscopy_submenu_description">Stereoscopy allows you to get a better feeling of depth if you have the necessary hardware.\nHeavily decreases emulation speed and sometimes causes issues</string>
     <string name="wide_screen_hack">Widescreen Hack</string>
     <string name="wide_screen_hack_description">Forces the game to output graphics for any aspect ratio. Use with \"Aspect Ratio\" set to \"Force 16:9\" to force 4:3-only games to run at 16:9. Rarely produces good results and often partially breaks graphics and game UIs.\nUnnecessary (and detrimental) if using any AR/Gecko-code widescreen patches. If unsure, leave this unchecked.</string>
     <string name="stereoscopy_mode">Stereoscopy Mode</string>
-    <string name="stereoscopy_mode_description">Select the stereoscopic 3D mode.</string>
+    <string name="stereoscopy_mode_off">Off</string>
+    <string name="stereoscopy_mode_side_side">Side-by-Side</string>
+    <string name="stereoscopy_mode_top_bottom">Top-and-Bottom</string>
+    <string name="stereoscopy_mode_anaglyph">Anaglyph</string>
     <string name="stereoscopy_depth">Depth</string>
     <string name="stereoscopy_depth_description">Control the distance between the virtual cameras.\nA higher value creates a stronger feeling of depth while a lower value is more comfortable.</string>
     <string name="stereoscopy_convergence">Convergence</string>
@@ -211,9 +230,15 @@
     <string name="fast_depth_calculation">Fast Depth Calculation</string>
     <string name="fast_depth_calculation_description">Uses a less accurate algorithm to calculate depth values.</string>
     <string name="aspect_ratio">Aspect Ratio</string>
-    <string name="aspect_ratio_description">Select what aspect ratio to use when rendering</string>
+    <string name="aspect_ratio_auto">Auto</string>
+    <string name="aspect_ratio_force_16_9">Force 16:9</string>
+    <string name="aspect_ratio_force_4_3">Force 4:3</string>
+    <string name="aspect_ratio_stretch">Stretch to Window</string>
     <string name="shader_compilation_mode">Shader Compilation Mode</string>
-    <string name="shader_compilation_mode_description">Specifies when to use Ubershaders. Disabled - Never, Hybrid - Use ubershaders while compiling specialized shaders. Exclusive - Use only ubershaders, largest performance impact. Skip Drawing - Do not draw objects while shaders are compiling, will cause broken effects.</string>
+    <string name="shader_compilation_sync_description">Synchronous: Ubershaders are never used. Stuttering will occur during shader compilation, but GPU demands are low. Recommended for low-end hardware.\nIf unsure, select this mode.</string>
+    <string name="shader_compilation_sync_uber_description">Synchronous (Ubershaders): Ubershaders will always be used. Provides a near stutter-free experience at the cost of high GPU performance requirements. Only recommended for high-end systems.</string>
+    <string name="shader_compilation_async_uber_description">Asynchronous (Ubershaders): Ubershaders will be used to prevent stuttering during shader compilation, but specialized shaders will be used when they will not cause stuttering. In the best case it eliminates shader compilation stuttering while having minimal performance impact, but results depend on video driver behavior.</string>
+    <string name="shader_compilation_async_skip_description">Asynchronous (Skip Drawing): Prevents shader compilation stuttering by not rendering waiting objects. Can work in scenarios where Ubershaders doesn\'t, at the cost of introducing visual glitches and broken effects. Not recommended, only use if the other options give poor results on your system.</string>
     <string name="wait_for_shaders">Compile Shaders Before Starting</string>
 
     <!-- Miscellaneous -->
@@ -281,4 +306,13 @@
     <string name="emulation_change_disc">Change Disc</string>
 
     <string name="external_storage_not_mounted">The external storage needs to be available in order to use Dolphin</string>
+
+    <!-- Dynamic descriptionIds-->
+    <string name="dynamic_cpu_core">dynamic_cpu_core</string>
+    <string name="dynamic_system_language">dynamic_system_language</string>
+    <string name="dynamic_gamecube_slot">dynamic_gamecube_slot</string>
+    <string name="dynamic_video_backend">dynamic_video_backend</string>
+    <string name="dynamic_shader_compilation_mode">dynamic_shader_compilation_mode</string>
+    <string name="dynamic_aspect_ratio">dynamic_aspect_ratio</string>
+    <string name="dynamic_stereoscopy_mode">dynamic_stereoscopy_mode</string>
 </resources>


### PR DESCRIPTION
Implements https://bugs.dolphin-emu.org/issues/10699.

Currently used for:
1. CPU Core
2. System Language
3. GameCube Slot A Device
4. GameCube Slot B Device
5. Video Backend
6. Shader Compilation mode
7. Aspect Ratio
8. Stereoscopy Mode

Is this a good approach?

An example:
![screenshot_20180710-113631_dolphin emulator](https://user-images.githubusercontent.com/17330088/42521236-50963e72-8436-11e8-821e-8eec769a8466.jpg)



