### PR TITLE
 DSPCore: Convert core type enum into an enum class

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -170,7 +170,7 @@ bool DSPCore_Init(const DSPInitOptions& opts)
   Common::WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
 
   // Initialize JIT, if necessary
-  if (opts.core_type == DSPInitOptions::CORE_JIT)
+  if (opts.core_type == DSPInitOptions::CoreType::JIT)
     g_dsp_jit = std::make_unique<JIT::x64::DSPEmitter>();
 
   g_dsp_cap.reset(opts.capture_logger);

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -170,7 +170,7 @@ bool DSPCore_Init(const DSPInitOptions& opts)
   Common::WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
 
   // Initialize JIT, if necessary
-  if (opts.core_type == DSPInitOptions::CoreType::JIT)
+  if (opts.core_type == DSPInitOptions::CoreType::JIT64)
     g_dsp_jit = std::make_unique<JIT::x64::DSPEmitter>();
 
   g_dsp_cap.reset(opts.capture_logger);

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -329,13 +329,13 @@ struct DSPInitOptions
   std::array<u16, DSP_COEF_SIZE> coef_contents;
 
   // Core used to emulate the DSP.
-  // Default: JIT.
+  // Default: JIT64.
   enum class CoreType
   {
     Interpreter,
-    JIT,
+    JIT64,
   };
-  CoreType core_type = CoreType::JIT;
+  CoreType core_type = CoreType::JIT64;
 
   // Optional capture logger used to log internal DSP data transfers.
   // Default: dummy implementation, does nothing.

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -329,19 +329,19 @@ struct DSPInitOptions
   std::array<u16, DSP_COEF_SIZE> coef_contents;
 
   // Core used to emulate the DSP.
-  // Default: CORE_JIT.
-  enum CoreType
+  // Default: JIT.
+  enum class CoreType
   {
-    CORE_INTERPRETER,
-    CORE_JIT,
+    Interpreter,
+    JIT,
   };
-  CoreType core_type;
+  CoreType core_type = CoreType::JIT;
 
   // Optional capture logger used to log internal DSP data transfers.
   // Default: dummy implementation, does nothing.
   DSPCaptureLogger* capture_logger;
 
-  DSPInitOptions() : core_type(CORE_JIT), capture_logger(new DefaultDSPCaptureLogger()) {}
+  DSPInitOptions() : capture_logger(new DefaultDSPCaptureLogger()) {}
 };
 
 // Initializes the DSP emulator using the provided options. Takes ownership of

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -156,7 +156,7 @@ static bool FillDSPInitOptions(DSPInitOptions* opts)
   opts->core_type = DSPInitOptions::CoreType::Interpreter;
 #ifdef _M_X86
   if (SConfig::GetInstance().m_DSPEnableJIT)
-    opts->core_type = DSPInitOptions::CoreType::JIT;
+    opts->core_type = DSPInitOptions::CoreType::JIT64;
 #endif
 
   if (SConfig::GetInstance().m_DSPCaptureLog)

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -153,10 +153,10 @@ static bool FillDSPInitOptions(DSPInitOptions* opts)
   if (!LoadDSPRom(opts->coef_contents.data(), coef_file, DSP_COEF_BYTE_SIZE))
     return false;
 
-  opts->core_type = DSPInitOptions::CORE_INTERPRETER;
+  opts->core_type = DSPInitOptions::CoreType::Interpreter;
 #ifdef _M_X86
   if (SConfig::GetInstance().m_DSPEnableJIT)
-    opts->core_type = DSPInitOptions::CORE_JIT;
+    opts->core_type = DSPInitOptions::CoreType::JIT;
 #endif
 
   if (SConfig::GetInstance().m_DSPCaptureLog)


### PR DESCRIPTION
Converts the core type enum over so we don't pollute scope and make the values strongly-typed. This also renames the JIT core type so that it represents the x86-64 emitter, rather than a JIT in general. If another JIT is ever added in the future, they all can't use the same identifier.