### PR TITLE
PowerPC: Convert CPUCore enum into an enum class

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -445,7 +445,7 @@ JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDi
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv* env,
                                                                                    jobject obj)
 {
-  return PowerPC::DefaultCPUCore();
+  return static_cast<jint>(PowerPC::DefaultCPUCore());
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling(JNIEnv* env,

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -55,14 +55,14 @@ static bool TryParse(const std::string& str, N* const output)
   // separators
   iss.imbue(std::locale("C"));
 
-  N tmp = 0;
+  N tmp;
   if (iss >> tmp)
   {
     *output = tmp;
     return true;
   }
-  else
-    return false;
+
+  return false;
 }
 
 template <typename N>

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -28,16 +28,12 @@
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
-#include "Common/Config/Config.h"
 #include "Core/Boot/Boot.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/BaseConfigLoader.h"
-#include "Core/ConfigLoaders/GameConfigLoader.h"
-#include "Core/ConfigLoaders/MovieConfigLoader.h"
 #include "Core/ConfigLoaders/NetPlayConfigLoader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -47,6 +43,7 @@
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
+#include "Core/PowerPC/PowerPC.h"
 
 #include "DiscIO/Enums.h"
 
@@ -88,7 +85,7 @@ private:
   bool bDSPHLE;
   bool bHLE_BS2;
   int iSelectedLanguage;
-  int iCPUCore;
+  PowerPC::CPUCore cpu_core;
   int Volume;
   float m_EmulationSpeed;
   float m_OCFactor;
@@ -118,7 +115,7 @@ void ConfigCache::SaveConfig(const SConfig& config)
   bDSPHLE = config.bDSPHLE;
   bHLE_BS2 = config.bHLE_BS2;
   iSelectedLanguage = config.SelectedLanguage;
-  iCPUCore = config.iCPUCore;
+  cpu_core = config.cpu_core;
   Volume = config.m_Volume;
   m_EmulationSpeed = config.m_EmulationSpeed;
   strBackend = config.m_strVideoBackend;
@@ -159,7 +156,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bDSPHLE = bDSPHLE;
   config->bHLE_BS2 = bHLE_BS2;
   config->SelectedLanguage = iSelectedLanguage;
-  config->iCPUCore = iCPUCore;
+  config->cpu_core = cpu_core;
 
   // Only change these back if they were actually set by game ini, since they can be changed while a
   // game is running.
@@ -255,7 +252,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     core_section->Get("FastDiscSpeed", &StartUp.bFastDiscSpeed, StartUp.bFastDiscSpeed);
     core_section->Get("DSPHLE", &StartUp.bDSPHLE, StartUp.bDSPHLE);
     core_section->Get("GFXBackend", &StartUp.m_strVideoBackend, StartUp.m_strVideoBackend);
-    core_section->Get("CPUCore", &StartUp.iCPUCore, StartUp.iCPUCore);
+    core_section->Get("CPUCore", &StartUp.cpu_core, StartUp.cpu_core);
     core_section->Get("HLE_BS2", &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
     core_section->Get("GameCubeLanguage", &StartUp.SelectedLanguage, StartUp.SelectedLanguage);
     if (core_section->Get("EmulationSpeed", &StartUp.m_EmulationSpeed, StartUp.m_EmulationSpeed))
@@ -317,7 +314,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     StartUp.bCPUThread = Config::Get(Config::MAIN_CPU_THREAD);
     StartUp.bDSPHLE = Config::Get(Config::MAIN_DSP_HLE);
     StartUp.bFastDiscSpeed = Config::Get(Config::MAIN_FAST_DISC_SPEED);
-    StartUp.iCPUCore = Config::Get(Config::MAIN_CPU_CORE);
+    StartUp.cpu_core = Config::Get(Config::MAIN_CPU_CORE);
     StartUp.bSyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
     if (!StartUp.bWii)
       StartUp.SelectedLanguage = Config::Get(Config::MAIN_GC_LANGUAGE);
@@ -343,7 +340,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     StartUp.bDSPHLE = g_NetPlaySettings.m_DSPHLE;
     StartUp.bEnableMemcardSdWriting = g_NetPlaySettings.m_WriteToMemcard;
     StartUp.bCopyWiiSaveNetplay = g_NetPlaySettings.m_CopyWiiSave;
-    StartUp.iCPUCore = g_NetPlaySettings.m_CPUcore;
+    StartUp.cpu_core = g_NetPlaySettings.m_CPUcore;
     StartUp.SelectedLanguage = g_NetPlaySettings.m_SelectedLanguage;
     StartUp.bOverrideGCLanguage = g_NetPlaySettings.m_OverrideGCLanguage;
     StartUp.m_DSPEnableJIT = g_NetPlaySettings.m_DSPEnableJIT;

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -16,7 +16,8 @@ namespace Config
 // Main.Core
 
 const ConfigInfo<bool> MAIN_SKIP_IPL{{System::Main, "Core", "SkipIPL"}, true};
-const ConfigInfo<int> MAIN_CPU_CORE{{System::Main, "Core", "CPUCore"}, PowerPC::DefaultCPUCore()};
+const ConfigInfo<PowerPC::CPUCore> MAIN_CPU_CORE{{System::Main, "Core", "CPUCore"},
+                                                 PowerPC::DefaultCPUCore()};
 const ConfigInfo<bool> MAIN_FASTMEM{{System::Main, "Core", "Fastmem"}, true};
 const ConfigInfo<bool> MAIN_DSP_HLE{{System::Main, "Core", "DSPHLE"}, true};
 const ConfigInfo<int> MAIN_TIMING_VARIANCE{{System::Main, "Core", "TimingVariance"}, 40};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -8,12 +8,17 @@
 
 #include "Common/Config/Config.h"
 
+namespace PowerPC
+{
+enum class CPUCore;
+}
+
 namespace Config
 {
 // Main.Core
 
 extern const ConfigInfo<bool> MAIN_SKIP_IPL;
-extern const ConfigInfo<int> MAIN_CPU_CORE;
+extern const ConfigInfo<PowerPC::CPUCore> MAIN_CPU_CORE;
 extern const ConfigInfo<bool> MAIN_FASTMEM;
 // Should really be in the DSP section, but we're kind of stuck with bad decisions made in the past.
 extern const ConfigInfo<bool> MAIN_DSP_HLE;

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -8,10 +8,8 @@
 #include <memory>
 #include <string>
 
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"
-#include "Common/FileUtil.h"
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
@@ -20,6 +18,11 @@
 #include "Core/Movie.h"
 #include "VideoCommon/VideoConfig.h"
 
+namespace PowerPC
+{
+enum class CPUCore;
+}
+
 namespace ConfigLoaders
 {
 static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
@@ -27,7 +30,7 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
   config_layer->Set(Config::MAIN_CPU_THREAD, dtm->bDualCore);
   config_layer->Set(Config::MAIN_DSP_HLE, dtm->bDSPHLE);
   config_layer->Set(Config::MAIN_FAST_DISC_SPEED, dtm->bFastDiscSpeed);
-  config_layer->Set(Config::MAIN_CPU_CORE, static_cast<int>(dtm->CPUCore));
+  config_layer->Set(Config::MAIN_CPU_CORE, static_cast<PowerPC::CPUCore>(dtm->CPUCore));
   config_layer->Set(Config::MAIN_SYNC_GPU, dtm->bSyncGPU);
   config_layer->Set(Config::MAIN_GFX_BACKEND, dtm->videoBackend.data());
 
@@ -50,7 +53,7 @@ void SaveToDTM(Movie::DTMHeader* dtm)
   dtm->bDualCore = Config::Get(Config::MAIN_CPU_THREAD);
   dtm->bDSPHLE = Config::Get(Config::MAIN_DSP_HLE);
   dtm->bFastDiscSpeed = Config::Get(Config::MAIN_FAST_DISC_SPEED);
-  dtm->CPUCore = Config::Get(Config::MAIN_CPU_CORE);
+  dtm->CPUCore = static_cast<u8>(Config::Get(Config::MAIN_CPU_CORE));
   dtm->bSyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
   const std::string video_backend = Config::Get(Config::MAIN_GFX_BACKEND);
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -218,7 +218,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 
   core->Set("SkipIPL", bHLE_BS2);
   core->Set("TimingVariance", iTimingVariance);
-  core->Set("CPUCore", iCPUCore);
+  core->Set("CPUCore", cpu_core);
   core->Set("Fastmem", bFastmem);
   core->Set("CPUThread", bCPUThread);
   core->Set("DSPHLE", bDSPHLE);
@@ -505,11 +505,11 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 
   core->Get("SkipIPL", &bHLE_BS2, true);
 #ifdef _M_X86
-  core->Get("CPUCore", &iCPUCore, PowerPC::CORE_JIT64);
+  core->Get("CPUCore", &cpu_core, PowerPC::CPUCore::JIT64);
 #elif _M_ARM_64
-  core->Get("CPUCore", &iCPUCore, PowerPC::CORE_JITARM64);
+  core->Get("CPUCore", &cpu_core, PowerPC::CPUCore::JITARM64);
 #else
-  core->Get("CPUCore", &iCPUCore, PowerPC::CORE_INTERPRETER);
+  core->Get("CPUCore", &cpu_core, PowerPC::CPUCore::Interpreter);
 #endif
   core->Get("Fastmem", &bFastmem, true);
   core->Get("DSPHLE", &bDSPHLE, true);
@@ -763,7 +763,7 @@ void SConfig::LoadDefaults()
 #endif
 #endif
 
-  iCPUCore = PowerPC::DefaultCPUCore();
+  cpu_core = PowerPC::DefaultCPUCore();
   iTimingVariance = 40;
   bCPUThread = false;
   bSyncGPUOnSkipIdleHack = true;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -23,6 +23,7 @@ enum class Region;
 struct Partition;
 class Volume;
 }  // namespace DiscIO
+
 namespace IOS
 {
 namespace ES
@@ -30,6 +31,11 @@ namespace ES
 class TMDReader;
 }
 }  // namespace IOS
+
+namespace PowerPC
+{
+enum class CPUCore;
+}  // namespace PowerPC
 
 // DSP Backend Types
 #define BACKEND_NULLSOUND _trans("No Audio Output")
@@ -75,7 +81,7 @@ struct SConfig
   bool bAutomaticStart = false;
   bool bBootToPause = false;
 
-  int iCPUCore;  // Uses the values of PowerPC::CPUCore
+  PowerPC::CPUCore cpu_core;
 
   bool bJITNoBlockCache = false;
   bool bJITNoBlockLinking = false;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -530,7 +530,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot)
   Fifo::Prepare();
 
   // Setup our core, but can't use dynarec if we are compare server
-  if (core_parameter.iCPUCore != PowerPC::CORE_INTERPRETER &&
+  if (core_parameter.cpu_core != PowerPC::CPUCore::Interpreter &&
       (!core_parameter.bRunCompareServer || core_parameter.bRunCompareClient))
   {
     PowerPC::SetMode(PowerPC::CoreMode::JIT);

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -45,7 +45,7 @@ static bool s_state_system_request_stepping = false;
 static bool s_state_cpu_step_instruction = false;
 static Common::Event* s_state_cpu_step_instruction_sync = nullptr;
 
-void Init(int cpu_core)
+void Init(PowerPC::CPUCore cpu_core)
 {
   PowerPC::Init(cpu_core);
   s_state = State::Stepping;

--- a/Source/Core/Core/HW/CPU.h
+++ b/Source/Core/Core/HW/CPU.h
@@ -9,6 +9,11 @@ namespace Common
 class Event;
 }
 
+namespace PowerPC
+{
+enum class CPUCore;
+}
+
 namespace CPU
 {
 enum class State
@@ -19,7 +24,7 @@ enum class State
 };
 
 // Init
-void Init(int cpu_core);
+void Init(PowerPC::CPUCore cpu_core);
 
 // Shutdown
 void Shutdown();

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -45,7 +45,7 @@ void Init()
   DSP::Init(SConfig::GetInstance().bDSPHLE);
   DVDInterface::Init();
   GPFifo::Init();
-  CPU::Init(SConfig::GetInstance().iCPUCore);
+  CPU::Init(SConfig::GetInstance().cpu_core);
   SystemTimers::Init();
 
   if (SConfig::GetInstance().bWii)

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <sstream>
 #include <thread>
+#include <type_traits>
 
 #include <mbedtls/md5.h>
 
@@ -35,6 +36,7 @@
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
 #include "Core/Movie.h"
+#include "Core/PowerPC/PowerPC.h"
 #include "InputCommon/GCAdapter.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoConfig.h"
@@ -412,7 +414,15 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       std::lock_guard<std::recursive_mutex> lkg(m_crit.game);
       packet >> m_current_game;
       packet >> g_NetPlaySettings.m_CPUthread;
-      packet >> g_NetPlaySettings.m_CPUcore;
+
+      {
+        std::underlying_type_t<PowerPC::CPUCore> core;
+        if (packet >> core)
+          g_NetPlaySettings.m_CPUcore = static_cast<PowerPC::CPUCore>(core);
+        else
+          g_NetPlaySettings.m_CPUcore = PowerPC::CPUCore::CachedInterpreter;
+      }
+
       packet >> g_NetPlaySettings.m_EnableCheats;
       packet >> g_NetPlaySettings.m_SelectedLanguage;
       packet >> g_NetPlaySettings.m_OverrideGCLanguage;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -9,10 +9,15 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/EXI/EXI_Device.h"
 
+namespace PowerPC
+{
+enum class CPUCore;
+}
+
 struct NetSettings
 {
   bool m_CPUthread;
-  int m_CPUcore;
+  PowerPC::CPUCore m_CPUcore;
   bool m_EnableCheats;
   int m_SelectedLanguage;
   bool m_OverrideGCLanguage;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
 
@@ -815,10 +816,10 @@ bool NetPlayServer::StartGame()
 
   // tell clients to start game
   sf::Packet spac;
-  spac << (MessageId)NP_MSG_START_GAME;
+  spac << static_cast<MessageId>(NP_MSG_START_GAME);
   spac << m_current_game;
   spac << m_settings.m_CPUthread;
-  spac << m_settings.m_CPUcore;
+  spac << static_cast<std::underlying_type_t<PowerPC::CPUCore>>(m_settings.m_CPUcore);
   spac << m_settings.m_EnableCheats;
   spac << m_settings.m_SelectedLanguage;
   spac << m_settings.m_OverrideGCLanguage;
@@ -832,8 +833,8 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_OCFactor;
   spac << m_settings.m_EXIDevice[0];
   spac << m_settings.m_EXIDevice[1];
-  spac << (u32)g_netplay_initial_rtc;
-  spac << (u32)(g_netplay_initial_rtc >> 32);
+  spac << static_cast<u32>(g_netplay_initial_rtc);
+  spac << static_cast<u32>(g_netplay_initial_rtc >> 32);
 
   SendAsyncToClients(std::move(spac));
 

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -45,28 +45,28 @@ void DoState(PointerWrap& p)
   if (g_jit && p.GetMode() == PointerWrap::MODE_READ)
     g_jit->ClearCache();
 }
-CPUCoreBase* InitJitCore(int core)
+CPUCoreBase* InitJitCore(PowerPC::CPUCore core)
 {
   switch (core)
   {
 #if _M_X86
-  case PowerPC::CORE_JIT64:
+  case PowerPC::CPUCore::JIT64:
     g_jit = new Jit64();
     break;
 #endif
 #if _M_ARM_64
-  case PowerPC::CORE_JITARM64:
+  case PowerPC::CPUCore::JITARM64:
     g_jit = new JitArm64();
     break;
 #endif
-  case PowerPC::CORE_CACHEDINTERPRETER:
+  case PowerPC::CPUCore::CachedInterpreter:
     g_jit = new CachedInterpreter();
     break;
 
   default:
     PanicAlertT("The selected CPU emulation core (%d) is not available. "
                 "Please select a different CPU emulation core in the settings.",
-                core);
+                static_cast<int>(core));
     g_jit = nullptr;
     return nullptr;
   }

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -12,6 +12,11 @@
 class CPUCoreBase;
 class PointerWrap;
 
+namespace PowerPC
+{
+enum class CPUCore;
+}
+
 namespace Profiler
 {
 struct ProfileStats;
@@ -28,7 +33,7 @@ enum class ExceptionType
 
 void DoState(PointerWrap& p);
 
-CPUCoreBase* InitJitCore(int core);
+CPUCoreBase* InitJitCore(PowerPC::CPUCore core);
 CPUCoreBase* GetCore();
 
 // Debugging

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstddef>
+#include <iosfwd>
 #include <tuple>
 #include <vector>
 
@@ -23,13 +24,17 @@ namespace PowerPC
 {
 // The gaps in the CPUCore numbering are from cores that only existed in the past.
 // We avoid re-numbering cores so that settings will be compatible across versions.
-enum CPUCore
+enum class CPUCore
 {
-  CORE_INTERPRETER = 0,
-  CORE_JIT64 = 1,
-  CORE_JITARM64 = 4,
-  CORE_CACHEDINTERPRETER = 5,
+  Interpreter = 0,
+  JIT64 = 1,
+  JITARM64 = 4,
+  CachedInterpreter = 5,
 };
+
+// For reading from and writing to our config.
+std::istream& operator>>(std::istream& is, CPUCore& core);
+std::ostream& operator<<(std::ostream& os, CPUCore core);
 
 enum class CoreMode
 {
@@ -142,7 +147,7 @@ extern PPCDebugInterface debug_interface;
 const std::vector<CPUCore>& AvailableCPUCores();
 CPUCore DefaultCPUCore();
 
-void Init(int cpu_core);
+void Init(CPUCore cpu_core);
 void Reset();
 void Shutdown();
 void DoState(PointerWrap& p);

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -725,7 +725,8 @@ void MenuBar::AddJITMenu()
 
   m_jit_interpreter_core = m_jit->addAction(tr("Interpreter Core"));
   m_jit_interpreter_core->setCheckable(true);
-  m_jit_interpreter_core->setChecked(SConfig::GetInstance().iCPUCore == PowerPC::CORE_INTERPRETER);
+  m_jit_interpreter_core->setChecked(SConfig::GetInstance().cpu_core ==
+                                     PowerPC::CPUCore::Interpreter);
 
   connect(m_jit_interpreter_core, &QAction::toggled, [](bool enabled) {
     PowerPC::SetMode(enabled ? PowerPC::CoreMode::Interpreter : PowerPC::CoreMode::JIT);

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -278,7 +278,7 @@ void NetPlayDialog::OnStart()
   // Copy all relevant settings
   SConfig& instance = SConfig::GetInstance();
   settings.m_CPUthread = instance.bCPUThread;
-  settings.m_CPUcore = instance.iCPUCore;
+  settings.m_CPUcore = instance.cpu_core;
   settings.m_EnableCheats = instance.bEnableCheats;
   settings.m_SelectedLanguage = instance.SelectedLanguage;
   settings.m_OverrideGCLanguage = instance.bOverrideGCLanguage;

--- a/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt2/Settings/GeneralPane.cpp
@@ -38,10 +38,10 @@ constexpr const char* AUTO_UPDATE_BETA_STRING = "beta";
 constexpr const char* AUTO_UPDATE_DEV_STRING = "dev";
 
 static const std::map<PowerPC::CPUCore, const char*> CPU_CORE_NAMES = {
-    {PowerPC::CORE_INTERPRETER, QT_TR_NOOP("Interpreter (slowest)")},
-    {PowerPC::CORE_CACHEDINTERPRETER, QT_TR_NOOP("Cached Interpreter (slower)")},
-    {PowerPC::CORE_JIT64, QT_TR_NOOP("JIT Recompiler (recommended)")},
-    {PowerPC::CORE_JITARM64, QT_TR_NOOP("JIT Arm64 (experimental)")},
+    {PowerPC::CPUCore::Interpreter, QT_TR_NOOP("Interpreter (slowest)")},
+    {PowerPC::CPUCore::CachedInterpreter, QT_TR_NOOP("Cached Interpreter (slower)")},
+    {PowerPC::CPUCore::JIT64, QT_TR_NOOP("JIT Recompiler (recommended)")},
+    {PowerPC::CPUCore::JITARM64, QT_TR_NOOP("JIT Arm64 (experimental)")},
 };
 
 GeneralPane::GeneralPane(QWidget* parent) : QWidget(parent)
@@ -227,7 +227,7 @@ void GeneralPane::LoadConfig()
   const std::vector<PowerPC::CPUCore>& available_cpu_cores = PowerPC::AvailableCPUCores();
   for (size_t i = 0; i < available_cpu_cores.size(); ++i)
   {
-    if (available_cpu_cores[i] == SConfig::GetInstance().iCPUCore)
+    if (available_cpu_cores[i] == SConfig::GetInstance().cpu_core)
       m_cpu_cores[i]->setChecked(true);
   }
 }
@@ -275,7 +275,7 @@ void GeneralPane::OnSaveConfig()
   {
     if (m_cpu_cores[i]->isChecked())
     {
-      settings.iCPUCore = PowerPC::AvailableCPUCores()[i];
+      settings.cpu_core = PowerPC::AvailableCPUCores()[i];
       break;
     }
   }

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -26,10 +26,10 @@
 #include "DolphinWX/WxEventUtils.h"
 
 static const std::map<PowerPC::CPUCore, std::string> CPU_CORE_NAMES = {
-    {PowerPC::CORE_INTERPRETER, _trans("Interpreter (slowest)")},
-    {PowerPC::CORE_CACHEDINTERPRETER, _trans("Cached Interpreter (slower)")},
-    {PowerPC::CORE_JIT64, _trans("JIT Recompiler (recommended)")},
-    {PowerPC::CORE_JITARM64, _trans("JIT Arm64 (experimental)")},
+    {PowerPC::CPUCore::Interpreter, _trans("Interpreter (slowest)")},
+    {PowerPC::CPUCore::CachedInterpreter, _trans("Cached Interpreter (slower)")},
+    {PowerPC::CPUCore::JIT64, _trans("JIT Recompiler (recommended)")},
+    {PowerPC::CPUCore::JITARM64, _trans("JIT Arm64 (experimental)")},
 };
 
 GeneralConfigPane::GeneralConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
@@ -156,7 +156,7 @@ void GeneralConfigPane::LoadGUIValues()
   const std::vector<PowerPC::CPUCore>& cpu_cores = PowerPC::AvailableCPUCores();
   for (size_t i = 0; i < cpu_cores.size(); ++i)
   {
-    if (cpu_cores[i] == startup_params.iCPUCore)
+    if (cpu_cores[i] == startup_params.cpu_core)
       m_cpu_engine_radiobox->SetSelection(i);
   }
 }
@@ -202,7 +202,7 @@ void GeneralConfigPane::OnThrottlerChoiceChanged(wxCommandEvent& event)
 
 void GeneralConfigPane::OnCPUEngineRadioBoxChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().iCPUCore = PowerPC::AvailableCPUCores()[event.GetSelection()];
+  SConfig::GetInstance().cpu_core = PowerPC::AvailableCPUCores()[event.GetSelection()];
 }
 
 void GeneralConfigPane::OnAnalyticsCheckBoxChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1137,7 +1137,7 @@ void CFrame::OnUpdateInterpreterMenuItem(wxUpdateUIEvent& event)
   if (GetMenuBar()->FindItem(IDM_INTERPRETER)->IsChecked())
     return;
 
-  event.Check(SConfig::GetInstance().iCPUCore == PowerPC::CORE_INTERPRETER);
+  event.Check(SConfig::GetInstance().cpu_core == PowerPC::CPUCore::Interpreter);
 }
 
 void CFrame::ClearStatusBar()

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -371,7 +371,7 @@ wxMenu* MainMenuBar::CreateJITMenu() const
       _("This is necessary to get break points"
         " and stepping to work as explained in the Developer Documentation. But it can be very"
         " slow, perhaps slower than 1 fps."));
-  interpreter->Check(config_instance.iCPUCore == PowerPC::CORE_INTERPRETER);
+  interpreter->Check(config_instance.cpu_core == PowerPC::CPUCore::Interpreter);
 
   jit_menu->AppendSeparator();
   jit_menu->AppendCheckItem(IDM_JIT_NO_BLOCK_LINKING, _("&JIT Block Linking Off"),

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -315,7 +315,7 @@ void NetPlayDialog::GetNetSettings(NetSettings& settings)
 {
   SConfig& instance = SConfig::GetInstance();
   settings.m_CPUthread = instance.bCPUThread;
-  settings.m_CPUcore = instance.iCPUCore;
+  settings.m_CPUcore = instance.cpu_core;
   settings.m_EnableCheats = instance.bEnableCheats;
   settings.m_SelectedLanguage = instance.SelectedLanguage;
   settings.m_OverrideGCLanguage = instance.bOverrideGCLanguage;

--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -43,7 +43,7 @@ public:
     UICommon::SetUserDirectory(m_profile_path);
     Config::Init();
     SConfig::Init();
-    PowerPC::Init(PowerPC::CORE_INTERPRETER);
+    PowerPC::Init(PowerPC::CPUCore::Interpreter);
     CoreTiming::Init();
   }
   ~ScopeInit()


### PR DESCRIPTION
Makes the enum values strongly-typed and prevents the identifiers from polluting the PowerPC namespace. This also cleans up the parameters of some functions where we were accepting an ambiguous `int` type and expecting the correct values to be passed in.

Now those parameters accept a `PowerPC::CPUCore` type, making it immediately obvious which values should be passed in (if the names weren't already obvious). It also turns out we were storing these core types into other structures as plain `int`s, which have also been corrected.

As this type is used directly with the configuration code, it's a little more complicated than just modifying the existing occurrences in code to conform to new names. We need to provide our own overloaded insertion (`<<`) and extraction (`>>`) operators in order to make it compatible with it. These are fairly trivial to implement, so there's no issue here.

A minor adjustment to `TryParse()` was required, as our generic function was doing the following:

```cpp
N tmp = 0;
```

which is problematic, as custom types may not be able to have that assignment performed (e.g. strongly-typed enums), so we change this to:

```cpp
N tmp;
```

which is OK, as the value is attempted to be initialized with a value immediately under that statement anyways. I believe after this, all of the "core type"-like enums within our codebase are all converted over to strongly-typed enums.