### PR TITLE
ConfigManager: Convert GPUDeterminismMode into an enum class

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -203,14 +203,14 @@ static ConfigCache config_cache;
 static GPUDeterminismMode ParseGPUDeterminismMode(const std::string& mode)
 {
   if (mode == "auto")
-    return GPU_DETERMINISM_AUTO;
+    return GPUDeterminismMode::Auto;
   if (mode == "none")
-    return GPU_DETERMINISM_NONE;
+    return GPUDeterminismMode::Disabled;
   if (mode == "fake-completion")
-    return GPU_DETERMINISM_FAKE_COMPLETION;
+    return GPUDeterminismMode::FakeCompletion;
 
   NOTICE_LOG(BOOT, "Unknown GPU determinism mode %s", mode.c_str());
-  return GPU_DETERMINISM_AUTO;
+  return GPUDeterminismMode::Auto;
 }
 
 // Boot the ISO or file

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -37,6 +37,8 @@ namespace PowerPC
 enum class CPUCore;
 }  // namespace PowerPC
 
+struct BootParameters;
+
 // DSP Backend Types
 #define BACKEND_NULLSOUND _trans("No Audio Output")
 #define BACKEND_ALSA "ALSA"
@@ -47,16 +49,14 @@ enum class CPUCore;
 #define BACKEND_OPENSLES "OpenSLES"
 #define BACKEND_WASAPI "WASAPI (Exclusive Mode)"
 
-enum GPUDeterminismMode
+enum class GPUDeterminismMode
 {
-  GPU_DETERMINISM_AUTO,
-  GPU_DETERMINISM_NONE,
+  Auto,
+  Disabled,
   // This is currently the only mode.  There will probably be at least
   // one more at some point.
-  GPU_DETERMINISM_FAKE_COMPLETION,
+  FakeCompletion,
 };
-
-struct BootParameters;
 
 struct SConfig
 {

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -498,13 +498,13 @@ void UpdateWantDeterminism(bool want)
   bool gpu_thread = false;
   switch (param.m_GPUDeterminismMode)
   {
-  case GPU_DETERMINISM_AUTO:
+  case GPUDeterminismMode::Auto:
     gpu_thread = want;
     break;
-  case GPU_DETERMINISM_NONE:
+  case GPUDeterminismMode::Disabled:
     gpu_thread = false;
     break;
-  case GPU_DETERMINISM_FAKE_COMPLETION:
+  case GPUDeterminismMode::FakeCompletion:
     gpu_thread = true;
     break;
   }


### PR DESCRIPTION
Makes the values strongly-typed and gets more identifiers out of the global namespace.