### PR TITLE
DSPCore: Make DSPCore_SetException() take an enum type instead of a u8

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <type_traits>
 
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
@@ -118,7 +119,7 @@ class LLEAccelerator final : public Accelerator
 protected:
   u8 ReadMemory(u32 address) override { return Host::ReadHostMemory(address); }
   void WriteMemory(u32 address, u8 value) override { Host::WriteHostMemory(value, address); }
-  void OnEndException() override { DSPCore_SetException(EXP_ACCOV); }
+  void OnEndException() override { DSPCore_SetException(ExceptionType::AcceleratorOverflow); }
 };
 
 bool DSPCore_Init(const DSPInitOptions& opts)
@@ -204,7 +205,7 @@ void DSPCore_Reset()
 
 void DSPCore_SetException(ExceptionType exception)
 {
-  g_dsp.exceptions |= 1 << exception;
+  g_dsp.exceptions |= 1 << static_cast<std::underlying_type_t<ExceptionType>>(exception);
 }
 
 // Notify that an external interrupt is pending (used by thread mode)
@@ -220,7 +221,7 @@ void DSPCore_CheckExternalInterrupt()
     return;
 
   // Signal the SPU about new mail
-  DSPCore_SetException(EXP_INT);
+  DSPCore_SetException(ExceptionType::ExternalInterrupt);
 
   g_dsp.cr &= ~CR_EXTERNAL_INT;
 }
@@ -236,7 +237,8 @@ void DSPCore_CheckExceptions()
     // Seems exp int are not masked by sr_int_enable
     if (g_dsp.exceptions & (1 << i))
     {
-      if (Interpreter::dsp_SR_is_flag_set(SR_INT_ENABLE) || (i == EXP_INT))
+      if (Interpreter::dsp_SR_is_flag_set(SR_INT_ENABLE) ||
+          i == static_cast<int>(ExceptionType::ExternalInterrupt))
       {
         // store pc and sr until RTI
         dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -202,9 +202,9 @@ void DSPCore_Reset()
   Analyzer::Analyze();
 }
 
-void DSPCore_SetException(u8 level)
+void DSPCore_SetException(ExceptionType exception)
 {
-  g_dsp.exceptions |= 1 << level;
+  g_dsp.exceptions |= 1 << exception;
 }
 
 // Notify that an external interrupt is pending (used by thread mode)

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -208,7 +208,7 @@ enum : u16
 };
 
 // Exception vectors
-enum : int
+enum ExceptionType : int
 {
   EXP_STOVF = 1,  // 0x0002 stack under/over flow
   EXP_2 = 2,      // 0x0004
@@ -356,7 +356,7 @@ void DSPCore_CheckExceptions();
 void DSPCore_SetExternalInterrupt(bool val);
 
 // sets a flag in the pending exception register.
-void DSPCore_SetException(u8 level);
+void DSPCore_SetException(ExceptionType exception);
 
 enum class State
 {

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -208,15 +208,15 @@ enum : u16
 };
 
 // Exception vectors
-enum ExceptionType : int
+enum class ExceptionType
 {
-  EXP_STOVF = 1,  // 0x0002 stack under/over flow
-  EXP_2 = 2,      // 0x0004
-  EXP_3 = 3,      // 0x0006
-  EXP_4 = 4,      // 0x0008
-  EXP_ACCOV = 5,  // 0x000a accelerator address overflow
-  EXP_6 = 6,      // 0x000c
-  EXP_INT = 7     // 0x000e external int (message from CPU)
+  StackOverflow = 1,        // 0x0002 stack under/over flow
+  EXP_2 = 2,                // 0x0004
+  EXP_3 = 3,                // 0x0006
+  EXP_4 = 4,                // 0x0008
+  AcceleratorOverflow = 5,  // 0x000a accelerator address overflow
+  EXP_6 = 6,                // 0x000c
+  ExternalInterrupt = 7     // 0x000e external int (message from CPU)
 };
 
 struct DSP_Regs


### PR DESCRIPTION
Makes it more immediately indicative which values are intended to be passed to this function.