### PR TITLE
PowerPC: Add functions to read/write the full timebase value

### DIFF
--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -156,7 +156,7 @@ u32 GetFakeDecrementer()
 void TimeBaseSet()
 {
   CoreTiming::SetFakeTBStartTicks(CoreTiming::GetTicks());
-  CoreTiming::SetFakeTBStartValue(*((u64*)&TL));
+  CoreTiming::SetFakeTBStartValue(PowerPC::ReadFullTimeBaseValue());
 }
 
 u64 GetFakeTimeBase()

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -4,8 +4,6 @@
 
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 
-#include <cstring>
-
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/FPURoundMode.h"
@@ -253,12 +251,8 @@ void Interpreter::mfspr(UGeckoInstruction inst)
 
   case SPR_TL:
   case SPR_TU:
-  {
-    // works since we are little endian and TL comes first :)
-    const u64 time_base = SystemTimers::GetFakeTimeBase();
-    std::memcpy(&TL, &time_base, sizeof(u64));
-  }
-  break;
+    PowerPC::WriteFullTimeBaseValue(SystemTimers::GetFakeTimeBase());
+    break;
 
   case SPR_WPAR:
   {

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -349,6 +349,18 @@ void RunLoop()
   Host_UpdateDisasmDialog();
 }
 
+u64 ReadFullTimeBaseValue()
+{
+  u64 value;
+  std::memcpy(&value, &TL, sizeof(value));
+  return value;
+}
+
+void WriteFullTimeBaseValue(u64 value)
+{
+  std::memcpy(&TL, &value, sizeof(value));
+}
+
 void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst)
 {
   switch (MMCR0.PMC1SELECT)

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -178,6 +178,9 @@ void RunLoop();
 u32 CompactCR();
 void ExpandCR(u32 cr);
 
+u64 ReadFullTimeBaseValue();
+void WriteFullTimeBaseValue(u64 value);
+
 void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 
 // Easy register access macros.

--- a/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/RegisterWidget.cpp
@@ -261,12 +261,7 @@ void RegisterWidget::PopulateTable()
 
   // Special registers
   // TB
-  AddRegister(16, 5, RegisterType::tb, "TB",
-              [] {
-                return static_cast<u64>(PowerPC::ppcState.spr[SPR_TU]) << 32 |
-                       PowerPC::ppcState.spr[SPR_TL];
-              },
-              nullptr);
+  AddRegister(16, 5, RegisterType::tb, "TB", PowerPC::ReadFullTimeBaseValue, nullptr);
 
   // PC
   AddRegister(17, 5, RegisterType::pc, "PC", [] { return PowerPC::ppcState.pc; },

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -334,9 +334,7 @@ wxString CRegTable::GetValue(int row, int col)
                                     PowerPC::ppcState.spr[SPR_IBAT4L + (row - 16) * 2]);
 
       if (row == 16)
-        return wxString::Format("%016" PRIx64, static_cast<u64>(PowerPC::ppcState.spr[SPR_TU])
-                                                       << 32 |
-                                                   PowerPC::ppcState.spr[SPR_TL]);
+        return wxString::Format("%016" PRIx64, PowerPC::ReadFullTimeBaseValue());
 
       break;
     }


### PR DESCRIPTION
Allows us to get rid of a silly pointer cast and deduplicate some code from the front-end when it comes to reading the value.