### PR TITLE
Interpreter_FPUtils: Handle the FPSCR.ZE and FPSCR.VE flags with arithmetic instructions

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -104,8 +104,8 @@ void Interpreter::ps_merge11(UGeckoInstruction inst)
 // From here on, the real deal.
 void Interpreter::ps_div(UGeckoInstruction inst)
 {
-  rPS0(inst.FD) = ForceSingle(NI_div(rPS0(inst.FA), rPS0(inst.FB)));
-  rPS1(inst.FD) = ForceSingle(NI_div(rPS1(inst.FA), rPS1(inst.FB)));
+  rPS0(inst.FD) = ForceSingle(NI_div(rPS0(inst.FA), rPS0(inst.FB)).value);
+  rPS1(inst.FD) = ForceSingle(NI_div(rPS1(inst.FA), rPS1(inst.FB)).value);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
@@ -172,8 +172,8 @@ void Interpreter::ps_rsqrte(UGeckoInstruction inst)
 
 void Interpreter::ps_sub(UGeckoInstruction inst)
 {
-  rPS0(inst.FD) = ForceSingle(NI_sub(rPS0(inst.FA), rPS0(inst.FB)));
-  rPS1(inst.FD) = ForceSingle(NI_sub(rPS1(inst.FA), rPS1(inst.FB)));
+  rPS0(inst.FD) = ForceSingle(NI_sub(rPS0(inst.FA), rPS0(inst.FB)).value);
+  rPS1(inst.FD) = ForceSingle(NI_sub(rPS1(inst.FA), rPS1(inst.FB)).value);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
@@ -182,8 +182,8 @@ void Interpreter::ps_sub(UGeckoInstruction inst)
 
 void Interpreter::ps_add(UGeckoInstruction inst)
 {
-  rPS0(inst.FD) = ForceSingle(NI_add(rPS0(inst.FA), rPS0(inst.FB)));
-  rPS1(inst.FD) = ForceSingle(NI_add(rPS1(inst.FA), rPS1(inst.FB)));
+  rPS0(inst.FD) = ForceSingle(NI_add(rPS0(inst.FA), rPS0(inst.FB)).value);
+  rPS1(inst.FD) = ForceSingle(NI_add(rPS1(inst.FA), rPS1(inst.FB)).value);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
@@ -192,10 +192,10 @@ void Interpreter::ps_add(UGeckoInstruction inst)
 
 void Interpreter::ps_mul(UGeckoInstruction inst)
 {
-  double c0 = Force25Bit(rPS0(inst.FC));
-  double c1 = Force25Bit(rPS1(inst.FC));
-  rPS0(inst.FD) = ForceSingle(NI_mul(rPS0(inst.FA), c0));
-  rPS1(inst.FD) = ForceSingle(NI_mul(rPS1(inst.FA), c1));
+  const double c0 = Force25Bit(rPS0(inst.FC));
+  const double c1 = Force25Bit(rPS1(inst.FC));
+  rPS0(inst.FD) = ForceSingle(NI_mul(rPS0(inst.FA), c0).value);
+  rPS1(inst.FD) = ForceSingle(NI_mul(rPS1(inst.FA), c1).value);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
@@ -204,10 +204,10 @@ void Interpreter::ps_mul(UGeckoInstruction inst)
 
 void Interpreter::ps_msub(UGeckoInstruction inst)
 {
-  double c0 = Force25Bit(rPS0(inst.FC));
-  double c1 = Force25Bit(rPS1(inst.FC));
-  rPS0(inst.FD) = ForceSingle(NI_msub(rPS0(inst.FA), c0, rPS0(inst.FB)));
-  rPS1(inst.FD) = ForceSingle(NI_msub(rPS1(inst.FA), c1, rPS1(inst.FB)));
+  const double c0 = Force25Bit(rPS0(inst.FC));
+  const double c1 = Force25Bit(rPS1(inst.FC));
+  rPS0(inst.FD) = ForceSingle(NI_msub(rPS0(inst.FA), c0, rPS0(inst.FB)).value);
+  rPS1(inst.FD) = ForceSingle(NI_msub(rPS1(inst.FA), c1, rPS1(inst.FB)).value);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
@@ -216,10 +216,10 @@ void Interpreter::ps_msub(UGeckoInstruction inst)
 
 void Interpreter::ps_madd(UGeckoInstruction inst)
 {
-  double c0 = Force25Bit(rPS0(inst.FC));
-  double c1 = Force25Bit(rPS1(inst.FC));
-  rPS0(inst.FD) = ForceSingle(NI_madd(rPS0(inst.FA), c0, rPS0(inst.FB)));
-  rPS1(inst.FD) = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)));
+  const double c0 = Force25Bit(rPS0(inst.FC));
+  const double c1 = Force25Bit(rPS1(inst.FC));
+  rPS0(inst.FD) = ForceSingle(NI_madd(rPS0(inst.FA), c0, rPS0(inst.FB)).value);
+  rPS1(inst.FD) = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)).value);
   PowerPC::UpdateFPRF(rPS0(inst.FD));
 
   if (inst.Rc)
@@ -228,10 +228,10 @@ void Interpreter::ps_madd(UGeckoInstruction inst)
 
 void Interpreter::ps_nmsub(UGeckoInstruction inst)
 {
-  double c0 = Force25Bit(rPS0(inst.FC));
-  double c1 = Force25Bit(rPS1(inst.FC));
-  double result0 = ForceSingle(NI_msub(rPS0(inst.FA), c0, rPS0(inst.FB)));
-  double result1 = ForceSingle(NI_msub(rPS1(inst.FA), c1, rPS1(inst.FB)));
+  const double c0 = Force25Bit(rPS0(inst.FC));
+  const double c1 = Force25Bit(rPS1(inst.FC));
+  const double result0 = ForceSingle(NI_msub(rPS0(inst.FA), c0, rPS0(inst.FB)).value);
+  const double result1 = ForceSingle(NI_msub(rPS1(inst.FA), c1, rPS1(inst.FB)).value);
   rPS0(inst.FD) = std::isnan(result0) ? result0 : -result0;
   rPS1(inst.FD) = std::isnan(result1) ? result1 : -result1;
   PowerPC::UpdateFPRF(rPS0(inst.FD));
@@ -242,10 +242,10 @@ void Interpreter::ps_nmsub(UGeckoInstruction inst)
 
 void Interpreter::ps_nmadd(UGeckoInstruction inst)
 {
-  double c0 = Force25Bit(rPS0(inst.FC));
-  double c1 = Force25Bit(rPS1(inst.FC));
-  double result0 = ForceSingle(NI_madd(rPS0(inst.FA), c0, rPS0(inst.FB)));
-  double result1 = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)));
+  const double c0 = Force25Bit(rPS0(inst.FC));
+  const double c1 = Force25Bit(rPS1(inst.FC));
+  const double result0 = ForceSingle(NI_madd(rPS0(inst.FA), c0, rPS0(inst.FB)).value);
+  const double result1 = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)).value);
   rPS0(inst.FD) = std::isnan(result0) ? result0 : -result0;
   rPS1(inst.FD) = std::isnan(result1) ? result1 : -result1;
   PowerPC::UpdateFPRF(rPS0(inst.FD));
@@ -256,8 +256,8 @@ void Interpreter::ps_nmadd(UGeckoInstruction inst)
 
 void Interpreter::ps_sum0(UGeckoInstruction inst)
 {
-  double p0 = ForceSingle(NI_add(rPS0(inst.FA), rPS1(inst.FB)));
-  double p1 = ForceSingle(rPS1(inst.FC));
+  const double p0 = ForceSingle(NI_add(rPS0(inst.FA), rPS1(inst.FB)).value);
+  const double p1 = ForceSingle(rPS1(inst.FC));
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
   PowerPC::UpdateFPRF(rPS0(inst.FD));
@@ -268,8 +268,8 @@ void Interpreter::ps_sum0(UGeckoInstruction inst)
 
 void Interpreter::ps_sum1(UGeckoInstruction inst)
 {
-  double p0 = ForceSingle(rPS0(inst.FC));
-  double p1 = ForceSingle(NI_add(rPS0(inst.FA), rPS1(inst.FB)));
+  const double p0 = ForceSingle(rPS0(inst.FC));
+  const double p1 = ForceSingle(NI_add(rPS0(inst.FA), rPS1(inst.FB)).value);
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
   PowerPC::UpdateFPRF(rPS1(inst.FD));
@@ -280,9 +280,9 @@ void Interpreter::ps_sum1(UGeckoInstruction inst)
 
 void Interpreter::ps_muls0(UGeckoInstruction inst)
 {
-  double c0 = Force25Bit(rPS0(inst.FC));
-  double p0 = ForceSingle(NI_mul(rPS0(inst.FA), c0));
-  double p1 = ForceSingle(NI_mul(rPS1(inst.FA), c0));
+  const double c0 = Force25Bit(rPS0(inst.FC));
+  const double p0 = ForceSingle(NI_mul(rPS0(inst.FA), c0).value);
+  const double p1 = ForceSingle(NI_mul(rPS1(inst.FA), c0).value);
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
   PowerPC::UpdateFPRF(rPS0(inst.FD));
@@ -293,9 +293,9 @@ void Interpreter::ps_muls0(UGeckoInstruction inst)
 
 void Interpreter::ps_muls1(UGeckoInstruction inst)
 {
-  double c1 = Force25Bit(rPS1(inst.FC));
-  double p0 = ForceSingle(NI_mul(rPS0(inst.FA), c1));
-  double p1 = ForceSingle(NI_mul(rPS1(inst.FA), c1));
+  const double c1 = Force25Bit(rPS1(inst.FC));
+  const double p0 = ForceSingle(NI_mul(rPS0(inst.FA), c1).value);
+  const double p1 = ForceSingle(NI_mul(rPS1(inst.FA), c1).value);
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
   PowerPC::UpdateFPRF(rPS0(inst.FD));
@@ -306,9 +306,9 @@ void Interpreter::ps_muls1(UGeckoInstruction inst)
 
 void Interpreter::ps_madds0(UGeckoInstruction inst)
 {
-  double c0 = Force25Bit(rPS0(inst.FC));
-  double p0 = ForceSingle(NI_madd(rPS0(inst.FA), c0, rPS0(inst.FB)));
-  double p1 = ForceSingle(NI_madd(rPS1(inst.FA), c0, rPS1(inst.FB)));
+  const double c0 = Force25Bit(rPS0(inst.FC));
+  const double p0 = ForceSingle(NI_madd(rPS0(inst.FA), c0, rPS0(inst.FB)).value);
+  const double p1 = ForceSingle(NI_madd(rPS1(inst.FA), c0, rPS1(inst.FB)).value);
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
   PowerPC::UpdateFPRF(rPS0(inst.FD));
@@ -319,9 +319,9 @@ void Interpreter::ps_madds0(UGeckoInstruction inst)
 
 void Interpreter::ps_madds1(UGeckoInstruction inst)
 {
-  double c1 = Force25Bit(rPS1(inst.FC));
-  double p0 = ForceSingle(NI_madd(rPS0(inst.FA), c1, rPS0(inst.FB)));
-  double p1 = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)));
+  const double c1 = Force25Bit(rPS1(inst.FC));
+  const double p0 = ForceSingle(NI_madd(rPS0(inst.FA), c1, rPS0(inst.FB)).value);
+  const double p1 = ForceSingle(NI_madd(rPS1(inst.FA), c1, rPS1(inst.FB)).value);
   rPS0(inst.FD) = p0;
   rPS1(inst.FD) = p1;
   PowerPC::UpdateFPRF(rPS0(inst.FD));


### PR DESCRIPTION
According to PEM 3.3.6.1, if a division by zero occurs and FPSCR.ZE is set, then the result of the instruction operation is unchanged (see table 3-13). Similarly, if an invalid operation occurs and FPSCR.VE is set, then the destination should also remain unchanged (see table 3-12). Hardware also matches this behavior.

We were handling this for other relevant instructions, but we weren't doing so for the arithmetic instructions. This corrects that.

This also alters our NI_* functions to return an FPResult type, which allows us to see which kind of exception in particular is set in exceptional cases. This is necessary for cases like the fdiv instructions, which requires handling both ZE and VE being potentially set.