### PR TITLE
BTEmu: Make m_WiiMotes private

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -59,7 +59,7 @@ State GetState();
 void SaveScreenShot(bool wait_for_completion = false);
 void SaveScreenShot(const std::string& name, bool wait_for_completion = false);
 
-void Callback_WiimoteInterruptChannel(int _number, u16 _channelID, const void* _pData, u32 _Size);
+void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const u8* data, u32 size);
 
 // This displays messages in a user-visible way.
 void DisplayMessage(const std::string& message, int time_in_ms);

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -104,9 +104,9 @@ void Connect(unsigned int index, bool connect)
       ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
 
   if (bluetooth)
-    bluetooth->AccessWiiMote(index | 0x100)->Activate(connect);
+    bluetooth->AccessWiiMoteByIndex(index)->Activate(connect);
 
-  const char* message = connect ? "Wii Remote %i connected" : "Wii Remote %i disconnected";
+  const char* message = connect ? "Wii Remote %u connected" : "Wii Remote %u disconnected";
   Core::DisplayMessage(StringFromFormat(message, index + 1), 3000);
 }
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -1740,6 +1740,12 @@ void BluetoothEmu::CommandVendorSpecific_FC4C(const u8* input, u32 size)
 // --- helper
 //
 //
+WiimoteDevice* BluetoothEmu::AccessWiiMoteByIndex(std::size_t index)
+{
+  const u16 connection_handle = static_cast<u16>(0x100 + index);
+  return AccessWiiMote(connection_handle);
+}
+
 WiimoteDevice* BluetoothEmu::AccessWiiMote(const bdaddr_t& address)
 {
   const auto iterator =

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <algorithm>
+#include <cstddef>
 #include <deque>
 #include <memory>
-#include <queue>
 #include <string>
 #include <vector>
 
@@ -57,8 +56,7 @@ public:
 
   bool RemoteDisconnect(u16 _connectionHandle);
 
-  WiimoteDevice* AccessWiiMote(const bdaddr_t& _rAddr);
-  WiimoteDevice* AccessWiiMote(u16 _ConnectionHandle);
+  WiimoteDevice* AccessWiiMoteByIndex(std::size_t index);
 
   void DoState(PointerWrap& p) override;
 
@@ -101,6 +99,9 @@ private:
 
   u32 m_PacketCount[MAX_BBMOTES] = {};
   u64 m_last_ticks = 0;
+
+  WiimoteDevice* AccessWiiMote(const bdaddr_t& _rAddr);
+  WiimoteDevice* AccessWiiMote(u16 _ConnectionHandle);
 
   // Send ACL data to a device (wiimote)
   void IncDataPacket(u16 _ConnectionHandle);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -57,13 +57,14 @@ public:
 
   bool RemoteDisconnect(u16 _connectionHandle);
 
-  std::vector<WiimoteDevice> m_WiiMotes;
   WiimoteDevice* AccessWiiMote(const bdaddr_t& _rAddr);
   WiimoteDevice* AccessWiiMote(u16 _ConnectionHandle);
 
   void DoState(PointerWrap& p) override;
 
 private:
+  std::vector<WiimoteDevice> m_WiiMotes;
+
   bdaddr_t m_ControllerBD{{0x11, 0x02, 0x19, 0x79, 0x00, 0xff}};
 
   // this is used to trigger connecting via ACL

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -926,6 +926,6 @@ void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const u8* data
   const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
       IOS::HLE::GetIOS()->GetDeviceByName("/dev/usb/oh1/57e/305"));
   if (bt)
-    bt->AccessWiiMote(0x100 + number)->ReceiveL2capData(channel_id, data, size);
+    bt->AccessWiiMoteByIndex(number)->ReceiveL2capData(channel_id, data, size);
 }
 }

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -915,7 +915,7 @@ void WiimoteDevice::ReceiveL2capData(u16 scid, const void* data, u32 size)
 namespace Core
 {
 /* This is called continuously from the Wiimote plugin as soon as it has received
-   a reporting mode. _Size is the byte size of the report. */
+   a reporting mode. size is the byte size of the report. */
 void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const void* opaque_data, u32 size)
 {
   const u8* data = (const u8*)opaque_data;
@@ -928,6 +928,6 @@ void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const void* op
   const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
       IOS::HLE::GetIOS()->GetDeviceByName("/dev/usb/oh1/57e/305"));
   if (bt)
-    bt->m_WiiMotes[number].ReceiveL2capData(channel_id, opaque_data, size);
+    bt->AccessWiiMote(0x100 + number)->ReceiveL2capData(channel_id, opaque_data, size);
 }
 }

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -914,12 +914,10 @@ void WiimoteDevice::ReceiveL2capData(u16 scid, const void* data, u32 size)
 
 namespace Core
 {
-/* This is called continuously from the Wiimote plugin as soon as it has received
-   a reporting mode. size is the byte size of the report. */
-void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const void* opaque_data, u32 size)
+// This is called continuously from the Wiimote plugin as soon as it has received
+// a reporting mode. size is the byte size of the report.
+void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const u8* data, u32 size)
 {
-  const u8* data = (const u8*)opaque_data;
-
   DEBUG_LOG(WIIMOTE, "====================");
   DEBUG_LOG(WIIMOTE, "Callback_WiimoteInterruptChannel: (Wiimote: #%i)", number);
   DEBUG_LOG(WIIMOTE, "   Data: %s", ArrayToString(data, size, 50).c_str());
@@ -928,6 +926,6 @@ void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const void* op
   const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
       IOS::HLE::GetIOS()->GetDeviceByName("/dev/usb/oh1/57e/305"));
   if (bt)
-    bt->AccessWiiMote(0x100 + number)->ReceiveL2capData(channel_id, opaque_data, size);
+    bt->AccessWiiMote(0x100 + number)->ReceiveL2capData(channel_id, data, size);
 }
 }

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -466,9 +466,11 @@ void ChangeWiiPads(bool instantly)
                         nullptr;
   for (int i = 0; i < MAX_WIIMOTES; ++i)
   {
-    g_wiimote_sources[i] = IsUsingWiimote(i) ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE;
+    const bool is_using_wiimote = IsUsingWiimote(i);
+
+    g_wiimote_sources[i] = is_using_wiimote ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE;
     if (!SConfig::GetInstance().m_bt_passthrough_enabled && bt)
-      bt->AccessWiiMote(i | 0x100)->Activate(IsUsingWiimote(i));
+      bt->AccessWiiMoteByIndex(i)->Activate(is_using_wiimote);
   }
 }
 

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -1401,7 +1401,7 @@ void MainWindow::OnConnectWiiRemote(int id)
   Core::RunAsCPUThread([&] {
     const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
         ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
-    const bool is_connected = bt && bt->AccessWiiMote(id | 0x100)->IsConnected();
+    const bool is_connected = bt && bt->AccessWiiMoteByIndex(id)->IsConnected();
     Wiimote::Connect(id, !is_connected);
   });
 }

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -914,14 +914,16 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
   const auto bt = ios ? std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
                             ios->GetDeviceByName("/dev/usb/oh1/57e/305")) :
                         nullptr;
-  bool enable_wiimotes =
+  const bool enable_wiimotes =
       emulation_started && bt && !SConfig::GetInstance().m_bt_passthrough_enabled;
 
-  for (int i = 0; i < 5; i++)
+  for (std::size_t i = 0; i < m_wii_remotes.size(); i++)
   {
-    m_wii_remotes[i]->setEnabled(enable_wiimotes);
+    QAction* const wii_remote = m_wii_remotes[i];
+
+    wii_remote->setEnabled(enable_wiimotes);
     if (enable_wiimotes)
-      m_wii_remotes[i]->setChecked(bt->AccessWiiMote(0x0100 + i)->IsConnected());
+      wii_remote->setChecked(bt->AccessWiiMoteByIndex(i)->IsConnected());
   }
 }
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1539,7 +1539,7 @@ void CFrame::OnConnectWiimote(wxCommandEvent& event)
     const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
         ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
     const unsigned int wiimote_index = event.GetId() - IDM_CONNECT_WIIMOTE1;
-    const bool is_connected = bt && bt->AccessWiiMote(wiimote_index | 0x100)->IsConnected();
+    const bool is_connected = bt && bt->AccessWiiMoteByIndex(wiimote_index)->IsConnected();
     Wiimote::Connect(wiimote_index, !is_connected);
   });
 }
@@ -1699,22 +1699,27 @@ void CFrame::UpdateGUI()
   const auto bt = ios ? std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
                             ios->GetDeviceByName("/dev/usb/oh1/57e/305")) :
                         nullptr;
-  bool ShouldEnableWiimotes = Running && bt && !SConfig::GetInstance().m_bt_passthrough_enabled;
-  GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE1)->Enable(ShouldEnableWiimotes);
-  GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE2)->Enable(ShouldEnableWiimotes);
-  GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE3)->Enable(ShouldEnableWiimotes);
-  GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE4)->Enable(ShouldEnableWiimotes);
-  GetMenuBar()->FindItem(IDM_CONNECT_BALANCEBOARD)->Enable(ShouldEnableWiimotes);
-  if (ShouldEnableWiimotes)
+  const bool should_enable_wiimotes =
+      Running && bt && !SConfig::GetInstance().m_bt_passthrough_enabled;
+  auto* const wiimote_1 = GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE1);
+  auto* const wiimote_2 = GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE2);
+  auto* const wiimote_3 = GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE3);
+  auto* const wiimote_4 = GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE4);
+  auto* const balance_board = GetMenuBar()->FindItem(IDM_CONNECT_BALANCEBOARD);
+
+  wiimote_1->Enable(should_enable_wiimotes);
+  wiimote_2->Enable(should_enable_wiimotes);
+  wiimote_3->Enable(should_enable_wiimotes);
+  wiimote_4->Enable(should_enable_wiimotes);
+  balance_board->Enable(should_enable_wiimotes);
+  if (should_enable_wiimotes)
   {
     Core::RunAsCPUThread([&] {
-      GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE1)->Check(bt->AccessWiiMote(0x0100)->IsConnected());
-      GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE2)->Check(bt->AccessWiiMote(0x0101)->IsConnected());
-      GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE3)->Check(bt->AccessWiiMote(0x0102)->IsConnected());
-      GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE4)->Check(bt->AccessWiiMote(0x0103)->IsConnected());
-      GetMenuBar()
-          ->FindItem(IDM_CONNECT_BALANCEBOARD)
-          ->Check(bt->AccessWiiMote(0x0104)->IsConnected());
+      wiimote_1->Check(bt->AccessWiiMoteByIndex(0)->IsConnected());
+      wiimote_2->Check(bt->AccessWiiMoteByIndex(1)->IsConnected());
+      wiimote_3->Check(bt->AccessWiiMoteByIndex(2)->IsConnected());
+      wiimote_4->Check(bt->AccessWiiMoteByIndex(3)->IsConnected());
+      balance_board->Check(bt->AccessWiiMoteByIndex(4)->IsConnected());
     });
   }
 


### PR DESCRIPTION
This just makes a lingering data member private. It was only ever used directly within `Callback_WiimoteInterruptChannel()`, however, we already had public functions that would do the access for us, so we can use them instead.

This also adds `AccessWiiMoteByIndex()` to the public functions, which gets rid of the need to OR indices with `0x100` in order to create correct connection handles (which is something that should be handled by the class, not calling code, given it's an internal detail). This allows us to make a few calls within the codebase more straightforward.