### PR TITLE
ActionReplay: Use Common::BitCast instead of reinterpret_cast in Subtype_AddCode()

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -31,6 +31,7 @@
 #include <utility>
 #include <vector>
 
+#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
@@ -474,10 +475,10 @@ static bool Subtype_AddCode(const ARAddr& addr, const u32 data)
     LogInfo("--------");
 
     const u32 read = PowerPC::HostRead_U32(new_addr);
-    const float read_float = reinterpret_cast<const float&>(read);
+    const float read_float = Common::BitCast<float>(read);
     // data contains an (unsigned?) integer value
     const float fread = read_float + static_cast<float>(data);
-    const u32 newval = reinterpret_cast<const u32&>(fread);
+    const u32 newval = Common::BitCast<u32>(fread);
     PowerPC::HostWrite_U32(newval, new_addr);
     LogInfo("Old Value %08x", read);
     LogInfo("Increment %08x", data);


### PR DESCRIPTION
Using reinterpret_cast (or a C-styled equivalent) to reinterpret integers as floating-point values and vice-versa invokes undefined behavior. Instead, use BitCast, which does this in a well-defined manner.