### PR TITLE
Interpreter_SystemRegisters: Handle mtspr to HID1 and PVR properly

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -312,6 +312,11 @@ void Interpreter::mtspr(UGeckoInstruction inst)
     SystemTimers::TimeBaseSet();
     break;
 
+  case SPR_PVR:
+    // PVR is a read-only register so maintain its value.
+    rSPR(index) = old_value;
+    break;
+
   case SPR_HID0:  // HID0
   {
     UReg_HID0 old_hid0;
@@ -334,6 +339,14 @@ void Interpreter::mtspr(UGeckoInstruction inst)
     }
   }
   break;
+
+  case SPR_HID1:
+    // Despite being documented as a read-only register, it actually isn't. Bits
+    // 0-4 (27-31 from a little endian perspective) are modifiable. The rest are not
+    // affected, as those bits are reserved and ignore writes to them.
+    rSPR(index) &= 0xF8000000;
+    break;
+
   case SPR_HID2:  // HID2
     // TODO: generate illegal instruction for paired inst if PSE or LSQE
     // not set.


### PR DESCRIPTION
Despite both being documented as read-only registers, only one of them is truly read-only. An mtspr to HID1 will steamroll bits 0-4 with bits 0-4 of whatever value is currently in the source register, the rest of the bits are not modified as bits 5-31 are considered reserved, so these ignore writes to them. (e.g. see [my tweet](https://twitter.com/Lioncache/status/1009560432133263360))

PVR on the other hand, is truly a read-only register. Attempts to write to it don't modify the value within it, so we model this behavior.