### PR TITLE
Software: Don't link against X11 libraries

### DIFF
--- a/Source/Core/VideoBackends/Software/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Software/CMakeLists.txt
@@ -20,7 +20,4 @@ target_link_libraries(videosoftware
 PUBLIC
   common
   videocommon
-
-PRIVATE
-  ${X11_LIBRARIES}
 )


### PR DESCRIPTION
The software backend doesn't actually use X11 in any capacity directly.