### PR TITLE
DSPTables: Deduplicate FindByOpcode() implementations in DSP opcode tables

### DIFF
--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -511,14 +511,6 @@ std::array<const DSPOPCTemplate*, OPTABLE_SIZE> s_op_table;
 std::array<const DSPOPCTemplate*, EXT_OPTABLE_SIZE> s_ext_op_table;
 
 template <size_t N>
-auto FindByOpcode(UDSPInstruction opcode, const std::array<DSPOPCTemplate, N>& data)
-{
-  return std::find_if(data.cbegin(), data.cend(), [opcode](const auto& info) {
-    return (opcode & info.opcode_mask) == info.opcode;
-  });
-}
-
-template <size_t N>
 auto FindByName(const std::string& name, const std::array<DSPOPCTemplate, N>& data)
 {
   return std::find_if(data.cbegin(), data.cend(),

--- a/Source/Core/Core/DSP/DSPTables.h
+++ b/Source/Core/Core/DSP/DSPTables.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <string>
@@ -118,4 +119,12 @@ const DSPOPCTemplate* FindExtOpInfoByName(const std::string& name);
 // Used by the interpreter and JIT for instruction emulation
 const DSPOPCTemplate* GetOpTemplate(UDSPInstruction inst);
 const DSPOPCTemplate* GetExtOpTemplate(UDSPInstruction inst);
+
+template <typename T, size_t N>
+auto FindByOpcode(UDSPInstruction opcode, const std::array<T, N>& data)
+{
+  return std::find_if(data.cbegin(), data.cend(), [opcode](const auto& info) {
+    return (opcode & info.opcode_mask) == info.opcode;
+  });
+}
 }  // namespace DSP

--- a/Source/Core/Core/DSP/Interpreter/DSPIntTables.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntTables.cpp
@@ -4,10 +4,10 @@
 
 #include "Core/DSP/Interpreter/DSPIntTables.h"
 
-#include <algorithm>
 #include <array>
 
 #include "Common/CommonTypes.h"
+#include "Core/DSP/DSPTables.h"
 #include "Core/DSP/Interpreter/DSPIntExtOps.h"
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 
@@ -16,7 +16,7 @@ namespace DSP::Interpreter
 struct InterpreterOpInfo
 {
   u16 opcode;
-  u16 mask;
+  u16 opcode_mask;
   InterpreterFunction function;
 };
 
@@ -331,13 +331,6 @@ namespace
 std::array<InterpreterFunction, 65536> s_op_table;
 std::array<InterpreterFunction, 256> s_ext_op_table;
 bool s_tables_initialized = false;
-
-template <size_t N>
-auto FindByOpcode(UDSPInstruction opcode, const std::array<InterpreterOpInfo, N>& data)
-{
-  return std::find_if(data.cbegin(), data.cend(),
-                      [opcode](const auto& info) { return (opcode & info.mask) == info.opcode; });
-}
 }  // Anonymous namespace
 
 InterpreterFunction GetOp(UDSPInstruction inst)

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitTables.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitTables.cpp
@@ -4,10 +4,10 @@
 
 #include "Core/DSP/Jit/x64/DSPJitTables.h"
 
-#include <algorithm>
 #include <array>
 
 #include "Common/CommonTypes.h"
+#include "Core/DSP/DSPTables.h"
 #include "Core/DSP/Jit/x64/DSPEmitter.h"
 
 namespace DSP::JIT::x64
@@ -15,7 +15,7 @@ namespace DSP::JIT::x64
 struct JITOpInfo
 {
   u16 opcode;
-  u16 mask;
+  u16 opcode_mask;
   JITFunction function;
 };
 
@@ -330,13 +330,6 @@ namespace
 std::array<JITFunction, 65536> s_op_table;
 std::array<JITFunction, 256> s_ext_op_table;
 bool s_tables_initialized = false;
-
-template <size_t N>
-auto FindByOpcode(UDSPInstruction opcode, const std::array<JITOpInfo, N>& data)
-{
-  return std::find_if(data.cbegin(), data.cend(),
-                      [opcode](const auto& info) { return (opcode & info.mask) == info.opcode; });
-}
 }  // Anonymous namespace
 
 JITFunction GetOp(UDSPInstruction inst)


### PR DESCRIPTION
This function was duplicated across all the opcode tables: the main info tables, the interpreter tables, and the x86-64 JIT tables. However, we can just make the type of the `std::array` parameter a template type and get rid of this duplication.