### PR TITLE
JitArm64: Drop the plattform register.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -338,7 +338,6 @@ void Arm64GPRCache::GetAllocationOrder()
       W19,
 
       // Caller saved
-      W18,
       W17,
       W16,
       W15,


### PR DESCRIPTION
This register is defined as "optional reserved" within the aarch64 ABI.
Linux doesn't use it, but we must not modify it on ios or windows.
As we have plenty of registers on aarch64, let's just always skip this one.