### PR TITLE
Interpreter_LoadStorePaired: Generate a program exception if non-indexed paired-single load/stores are used and HID2.LSQE is not set

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -10,6 +10,7 @@
 #include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+#include "Core/PowerPC/Interpreter/ExceptionUtils.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/MMU.h"
@@ -306,12 +307,24 @@ void Interpreter::Helper_Dequantize(u32 addr, u32 instI, u32 instRD, u32 instW)
 
 void Interpreter::psq_l(UGeckoInstruction inst)
 {
+  if (HID2.LSQE == 0)
+  {
+    GenerateProgramException();
+    return;
+  }
+
   const u32 EA = inst.RA ? (rGPR[inst.RA] + inst.SIMM_12) : (u32)inst.SIMM_12;
   Helper_Dequantize(EA, inst.I, inst.RD, inst.W);
 }
 
 void Interpreter::psq_lu(UGeckoInstruction inst)
 {
+  if (HID2.LSQE == 0)
+  {
+    GenerateProgramException();
+    return;
+  }
+
   const u32 EA = rGPR[inst.RA] + inst.SIMM_12;
   Helper_Dequantize(EA, inst.I, inst.RD, inst.W);
 
@@ -324,12 +337,24 @@ void Interpreter::psq_lu(UGeckoInstruction inst)
 
 void Interpreter::psq_st(UGeckoInstruction inst)
 {
+  if (HID2.LSQE == 0)
+  {
+    GenerateProgramException();
+    return;
+  }
+
   const u32 EA = inst.RA ? (rGPR[inst.RA] + inst.SIMM_12) : (u32)inst.SIMM_12;
   Helper_Quantize(EA, inst.I, inst.RS, inst.W);
 }
 
 void Interpreter::psq_stu(UGeckoInstruction inst)
 {
+  if (HID2.LSQE == 0)
+  {
+    GenerateProgramException();
+    return;
+  }
+
   const u32 EA = rGPR[inst.RA] + inst.SIMM_12;
   Helper_Quantize(EA, inst.I, inst.RS, inst.W);
 


### PR DESCRIPTION
HID2.LSQE is the load/store quantize enable bit for non-indexed format instructions (which are psq_l, psq_lu, psq_st, and psq_stu). If this bit is not set and any of these instructions are attempted to be executed, then a program exception is supposed to occur.