### PR TITLE
Qt/Mapping: Fix "Options" entries disappearing

### DIFF
--- a/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/GCPadEmu.cpp
@@ -41,17 +41,8 @@ void GCPadEmu::CreateMainLayout()
       CreateGroupBox(tr("Triggers"), Pad::GetGroup(GetPort(), PadGroup::Triggers)));
   hbox_layout->addWidget(CreateGroupBox(tr("Rumble"), Pad::GetGroup(GetPort(), PadGroup::Rumble)));
 
-  // TODO: Get rid of this garbage once wx is removed
-  // Remove "Iterative Input"
-  auto* options_group = Pad::GetGroup(GetPort(), PadGroup::Options);
-
-  auto& bools = options_group->boolean_settings;
-
-  if (bools.size() > 1 || !options_group->numeric_settings.empty())
-  {
-    bools.pop_back();
-    hbox_layout->addWidget(CreateGroupBox(tr("Options"), options_group));
-  }
+  hbox_layout->addWidget(
+      CreateGroupBox(tr("Options"), Pad::GetGroup(GetPort(), PadGroup::Options)));
 
   setLayout(m_main_layout);
 }

--- a/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt2/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -58,12 +58,8 @@ void WiimoteEmuGeneral::CreateMainLayout()
   vbox_layout->addWidget(CreateGroupBox(
       tr("Rumble"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Rumble)));
 
-  // TODO: Get rid of this garbage once wx is removed
-  // Remove "Iterative Input"
-  auto* options_group = Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Options);
-  options_group->boolean_settings.pop_back();
-
-  vbox_layout->addWidget(CreateGroupBox(tr("Options"), options_group));
+  vbox_layout->addWidget(CreateGroupBox(
+      tr("Options"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Options)));
 
   m_main_layout->addLayout(vbox_layout);
 


### PR DESCRIPTION
Fixes [issue #11240](https://bugs.dolphin-emu.org/issues/11240).

The hack is just not worth maintaining IHMO, I'd rather do it properly once wx is gone.