### PR TITLE
CMake: Only link in Bochs on x86 platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,7 +534,9 @@ endif()
 #   - place the CMakeLists.txt in the first-level subdirectory, e.g.
 #     Externals/zlib/CMakeLists.txt (that is: NOT in some Src/ subdirectory)
 #
-add_subdirectory(Externals/Bochs_disasm)
+if (_M_X86)
+  add_subdirectory(Externals/Bochs_disasm)
+endif()
 add_subdirectory(Externals/cpp-optparse)
 add_subdirectory(Externals/glslang)
 

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -295,10 +295,14 @@ PUBLIC
   videosoftware
 
 PRIVATE
-  bdisasm
   ${LZO}
   ZLIB::ZLIB
 )
+
+if ((DEFINED CMAKE_ANDROID_ARCH_ABI AND CMAKE_ANDROID_ARCH_ABI MATCHES "x86|x86_64") OR
+    (NOT DEFINED CMAKE_ANDROID_ARCH_ABI AND _M_X86))
+  target_link_libraries(core PRIVATE bdisasm)
+endif()
 
 if (APPLE)
   target_link_libraries(core

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -16,9 +16,13 @@ PUBLIC
   cpp-optparse
 
 PRIVATE
-  bdisasm
   $<$<BOOL:APPLE>:${IOK_LIBRARY}>
 )
+
+if ((DEFINED CMAKE_ANDROID_ARCH_ABI AND CMAKE_ANDROID_ARCH_ABI MATCHES "x86|x86_64") OR
+    (NOT DEFINED CMAKE_ANDROID_ARCH_ABI AND _M_X86))
+  target_link_libraries(uicommon PRIVATE bdisasm)
+endif()
 
 if(USE_X11)
   target_sources(uicommon PRIVATE X11Utils.cpp)

--- a/Source/Core/UICommon/Disassembler.cpp
+++ b/Source/Core/UICommon/Disassembler.cpp
@@ -1,11 +1,11 @@
-#include <disasm.h>  // Bochs
-
 #if defined(HAVE_LLVM)
 // PowerPC.h defines PC.
 // This conflicts with a function that has an argument named PC
 #undef PC
 #include <llvm-c/Disassembler.h>
 #include <llvm-c/Target.h>
+#elif defined(_M_X86)
+#include <disasm.h>  // Bochs
 #endif
 
 #include "Common/StringUtil.h"
@@ -15,18 +15,6 @@
 #include "Core/PowerPC/JitInterface.h"
 
 #include "UICommon/Disassembler.h"
-
-class HostDisassemblerX86 : public HostDisassembler
-{
-public:
-  HostDisassemblerX86();
-
-private:
-  disassembler m_disasm;
-
-  std::string DisassembleHostBlock(const u8* code_start, const u32 code_size,
-                                   u32* host_instructions_count, u64 starting_pc) override;
-};
 
 #if defined(HAVE_LLVM)
 class HostDisassemblerLLVM : public HostDisassembler
@@ -126,7 +114,18 @@ std::string HostDisassemblerLLVM::DisassembleHostBlock(const u8* code_start, con
 
   return x86_disasm.str();
 }
-#endif
+#elif defined(_M_X86)
+class HostDisassemblerX86 : public HostDisassembler
+{
+public:
+  HostDisassemblerX86();
+
+private:
+  disassembler m_disasm;
+
+  std::string DisassembleHostBlock(const u8* code_start, const u32 code_size,
+                                   u32* host_instructions_count, u64 starting_pc) override;
+};
 
 HostDisassemblerX86::HostDisassemblerX86()
 {
@@ -150,6 +149,7 @@ std::string HostDisassemblerX86::DisassembleHostBlock(const u8* code_start, cons
 
   return x86_disasm.str();
 }
+#endif
 
 std::unique_ptr<HostDisassembler> GetNewDisassembler(const std::string& arch)
 {


### PR DESCRIPTION
Bochs' disassembler is only for disassembling x86 code. On non-x86 platforms it doesn't really make sense to build and link this in.