### PR TITLE
BTEmu: Make WriteToEndpoint's reference parameter const

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -390,7 +390,7 @@ void BluetoothEmu::ACLPool::Store(const u8* data, const u16 size, const u16 conn
   packet.conn_handle = conn_handle;
 }
 
-void BluetoothEmu::ACLPool::WriteToEndpoint(USB::V0BulkMessage& endpoint)
+void BluetoothEmu::ACLPool::WriteToEndpoint(const USB::V0BulkMessage& endpoint)
 {
   auto& packet = m_queue.front();
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -79,7 +79,7 @@ private:
     explicit ACLPool(Kernel& ios) : m_ios(ios), m_queue() {}
     void Store(const u8* data, const u16 size, const u16 conn_handle);
 
-    void WriteToEndpoint(USB::V0BulkMessage& endpoint);
+    void WriteToEndpoint(const USB::V0BulkMessage& endpoint);
 
     bool IsEmpty() const { return m_queue.empty(); }
     // For SaveStates


### PR DESCRIPTION
This function doesn't modify anything being referenced.