### PR TITLE
Add nag dialog to get users to explain why they still use DolphinWX

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -176,6 +176,8 @@ private:
   wxString m_aui_fullscreen_perspective;
   wxString m_aui_current_perspective;
 
+  bool m_qt_nag_shown = false;
+
 #ifdef __WXGTK__
   std::recursive_mutex m_keystate_lock;
 #endif


### PR DESCRIPTION
In DolphinWX:
Each time dolphin opens, display a feedback request dialog for 10 seconds, upon the first time emulation is started.
![capture](https://user-images.githubusercontent.com/113063/41815241-c8ed4b60-7719-11e8-874b-20cc5a8d63db.PNG)

