### PR TITLE
Qt/PadMappingDialog: Retain previous settings

### DIFF
--- a/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/PadMappingDialog.h
@@ -28,6 +28,7 @@ public:
 private:
   void CreateWidgets();
   void ConnectWidgets();
+
   void OnMappingChanged();
 
   PadMappingArray m_pad_mapping;


### PR DESCRIPTION
Previously re-configuring netplay mappings would show none of the previous assignments, that should be fixed now.