### PR TITLE
Qt/NetPlay: Make double clicking game entries confirm dialogs

### DIFF
--- a/Source/Core/DolphinQt2/NetPlay/GameListDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/GameListDialog.cpp
@@ -41,6 +41,8 @@ void GameListDialog::ConnectWidgets()
     m_button_box->setEnabled(row != -1);
     m_game_id = m_game_list->currentItem()->text();
   });
+
+  connect(m_game_list, &QListWidget::itemDoubleClicked, this, &GameListDialog::accept);
   connect(m_button_box, &QDialogButtonBox::accepted, this, &GameListDialog::accept);
 }
 

--- a/Source/Core/DolphinQt2/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlaySetupDialog.cpp
@@ -164,6 +164,9 @@ void NetPlaySetupDialog::ConnectWidgets()
           [](int index) {
             Settings::GetQSettings().setValue(QStringLiteral("netplay/hostgame"), index);
           });
+
+  connect(m_host_games, &QListWidget::itemDoubleClicked, this, &NetPlaySetupDialog::accept);
+
   connect(m_host_force_port_check, &QCheckBox::toggled,
           [this](int value) { m_host_force_port_box->setEnabled(value); });
 #ifdef USE_UPNP


### PR DESCRIPTION
So you don't have to press ``Ok`` manually afterwards.