### PR TITLE
Expose arbitrary mipmap detection toggle in UI

### DIFF
--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -21,6 +21,7 @@ EFBAccessEnable = True
 
 [Video_Enhancements]
 ForceFiltering = False
+ArbitraryMipmapDetection = True
 
 [Video_Stereoscopy]
 StereoConvergence = 732

--- a/Data/Sys/GameSettings/GZ2.ini
+++ b/Data/Sys/GameSettings/GZ2.ini
@@ -14,3 +14,6 @@
 
 [Video_Hacks]
 ImmediateXFBEnable = False
+
+[Video_Enhancements]
+ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -16,5 +16,8 @@
 EFBAccessEnable = True
 EFBToTextureEnable = False
 
+[Video_Enhancements]
+ArbitraryMipmapDetection = True
+
 [Video_Stereoscopy]
 StereoConvergence = 115

--- a/Data/Sys/GameSettings/RMG.ini
+++ b/Data/Sys/GameSettings/RMG.ini
@@ -14,3 +14,6 @@
 
 [Video_Hacks]
 EFBAccessEnable = True
+
+[Video_Enhancements]
+ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/RZD.ini
+++ b/Data/Sys/GameSettings/RZD.ini
@@ -15,3 +15,6 @@
 [Video_Hacks]
 EFBAccessEnable = True
 ImmediateXFBEnable = False
+
+[Video_Enhancements]
+ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/SB4.ini
+++ b/Data/Sys/GameSettings/SB4.ini
@@ -15,5 +15,8 @@
 [Video_Hacks]
 EFBAccessEnable = True
 
+[Video_Enhancements]
+ArbitraryMipmapDetection = True
+
 [Video_Stereoscopy]
 StereoConvergence = 929

--- a/Data/Sys/GameSettings/SOU.ini
+++ b/Data/Sys/GameSettings/SOU.ini
@@ -13,3 +13,6 @@
 [Video_Hacks]
 EFBAccessEnable = True
 EFBEmulateFormatChanges = True
+
+[Video_Enhancements]
+ArbitraryMipmapDetection = True

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -90,6 +90,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::GFX_ENHANCE_POST_SHADER.location,
       Config::GFX_ENHANCE_FORCE_TRUE_COLOR.location,
       Config::GFX_ENHANCE_DISABLE_COPY_FILTER.location,
+      Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION.location,
 
       // Graphics.Stereoscopy
 
@@ -128,4 +129,4 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
   return std::find(s_setting_saveable.begin(), s_setting_saveable.end(), config_location) !=
          s_setting_saveable.end();
 }
-}  // namespace ConfigLoader
+}  // namespace ConfigLoaders

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -81,6 +81,8 @@ void EnhancementsWidget::CreateWidgets()
       new GraphicsBool(tr("Force 24-Bit Color"), Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
   m_disable_copy_filter =
       new GraphicsBool(tr("Disable Copy Filter"), Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
+  m_arbitrary_mipmap_detection = new GraphicsBool(tr("Arbitrary Mipmap Detection"),
+                                                  Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
 
   enhancements_layout->addWidget(new QLabel(tr("Internal Resolution:")), 0, 0);
   enhancements_layout->addWidget(m_ir_combo, 0, 1, 1, -1);
@@ -100,6 +102,7 @@ void EnhancementsWidget::CreateWidgets()
   enhancements_layout->addWidget(m_disable_fog, 7, 0);
   enhancements_layout->addWidget(m_force_24bit_color, 7, 1);
   enhancements_layout->addWidget(m_disable_copy_filter, 8, 0);
+  enhancements_layout->addWidget(m_arbitrary_mipmap_detection, 8, 1);
 
   // Stereoscopy
   auto* stereoscopy_box = new QGroupBox(tr("Stereoscopy"));
@@ -336,7 +339,7 @@ void EnhancementsWidget::AddDescriptions()
   static const char TR_FORCE_24BIT_DESCRIPTION[] =
       QT_TR_NOOP("Forces the game to render the RGB color channels in 24-bit, thereby increasing "
                  "quality by reducing color banding.\nIt has no impact on performance and causes "
-                 "few graphical issues.\n\n\nIf unsure, leave this checked.");
+                 "few graphical issues.\n\nIf unsure, leave this checked.");
   static const char TR_FORCE_TEXTURE_FILTERING_DESCRIPTION[] =
       QT_TR_NOOP("Filter all textures, including any that the game explicitly set as "
                  "unfiltered.\nMay improve quality of certain textures in some games, but will "
@@ -345,7 +348,13 @@ void EnhancementsWidget::AddDescriptions()
       QT_TR_NOOP("Disables the blending of adjacent rows when copying the EFB. This is known in "
                  "some games as \"deflickering\" or \"smoothing\". Disabling the filter has no "
                  "effect on performance, but may result in a sharper image, and causes few "
-                 "graphical issues.\n\n\nIf unsure, leave this checked.");
+                 "graphical issues.\n\nIf unsure, leave this checked.");
+  static const char TR_ARBITRARY_MIPMAP_DETECTION_DESCRIPTION[] =
+      QT_TR_NOOP("Enables detection of arbitrary mipmaps, which some games use for special "
+                 "distance-based effects.\nMay have false positives that result in blurry textures "
+                 "at increased internal resolution, such as in games that use very low resolution "
+                 "mipmaps.\nDisabling this can also reduce stutter in games that "
+                 "frequently load new textures.\n\nIf unsure, leave this checked.");
 
   AddDescription(m_ir_combo, TR_INTERNAL_RESOLUTION_DESCRIPTION);
   AddDescription(m_aa_combo, TR_ANTIALIAS_DESCRIPTION);
@@ -358,6 +367,7 @@ void EnhancementsWidget::AddDescriptions()
   AddDescription(m_force_24bit_color, TR_FORCE_24BIT_DESCRIPTION);
   AddDescription(m_force_texture_filtering, TR_FORCE_TEXTURE_FILTERING_DESCRIPTION);
   AddDescription(m_disable_copy_filter, TR_DISABLE_COPY_FILTER_DESCRIPTION);
+  AddDescription(m_arbitrary_mipmap_detection, TR_ARBITRARY_MIPMAP_DETECTION_DESCRIPTION);
   AddDescription(m_3d_mode, TR_3D_MODE_DESCRIPTION);
   AddDescription(m_3d_depth, TR_3D_DEPTH_DESCRIPTION);
   AddDescription(m_3d_convergence, TR_3D_CONVERGENCE_DESCRIPTION);

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.h
@@ -41,6 +41,7 @@ private:
   QCheckBox* m_disable_fog;
   QCheckBox* m_force_24bit_color;
   QCheckBox* m_disable_copy_filter;
+  QCheckBox* m_arbitrary_mipmap_detection;
 
   // Stereoscopy
   QComboBox* m_3d_mode;


### PR DESCRIPTION
Several games have very low resolution mipmaps (such as 1x1 in Skies of Arcadia) which are triggering false positives, due to the heuristic not being particularly accurate. The result is all the textures being quite blurry at increased internal resolution.

I believe exposing this option is a good idea, as it will allow users to work around the problem correctly, rather than relying on the GPU texture decoding hack which only "fixes" the problem because it doesn't support arbitrary mipmap detection, especially since that may be changing in the near future. Disabling it also provides a nice stutter reduction in games that frequently load textures on-the-fly, though that is somewhat mitigated by #7170.

The heuristic can definitely be improved, and once it's good enough to not trigger many false positives, and performs well enough to not cause any stutter, we could consider removing this option entirely.