### PR TITLE
Qt/GameList: Explicitly set minimum section size

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -115,6 +115,9 @@ void GameList::MakeListView()
   hor_header->setSectionResizeMode(GameListModel::COL_SIZE, QHeaderView::Fixed);
   hor_header->setSectionResizeMode(GameListModel::COL_FILE_NAME, QHeaderView::Interactive);
 
+  // There's some odd platform-specific behavior with default minimum section size
+  hor_header->setMinimumSectionSize(38);
+
   // Cells have 3 pixels of padding, so the width of these needs to be image width + 6. Banners are
   // 96 pixels wide, platform and country icons are 32 pixels wide.
   m_list->setColumnWidth(GameListModel::COL_BANNER, 102);


### PR DESCRIPTION
There's some weird platform-specific behavior with the default minimum section size in Qt (read: it's too big on my Linux install, but looks fine on Windows), so I think it's best we set it ourselves to ensure things look correct.

Significance of the value `38` is in #7168, and these 2 PRs will likely conflict, requiring one of them to be rebased.