### PR TITLE
Android: Make touch joystick re-centering configurable

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -120,6 +120,7 @@ public final class EmulationActivity extends AppCompatActivity
 	public static final int MENU_ACTION_LOAD_SLOT6 = 21;
 	public static final int MENU_ACTION_EXIT = 22;
 	public static final int MENU_ACTION_CHANGE_DISC = 23;
+	public static final int MENU_ACTION_JOYSTICK_REL_CENTER = 24;
 
 
 	private static SparseIntArray buttonsActionsMap = new SparseIntArray();
@@ -147,6 +148,7 @@ public final class EmulationActivity extends AppCompatActivity
 		buttonsActionsMap.append(R.id.menu_emulation_load_5, EmulationActivity.MENU_ACTION_LOAD_SLOT5);
 		buttonsActionsMap.append(R.id.menu_change_disc, EmulationActivity.MENU_ACTION_CHANGE_DISC);
 		buttonsActionsMap.append(R.id.menu_exit, EmulationActivity.MENU_ACTION_EXIT);
+		buttonsActionsMap.append(R.id.menu_emulation_joystick_rel_center, EmulationActivity.MENU_ACTION_JOYSTICK_REL_CENTER);
 	}
 
 	public static void launch(FragmentActivity activity, GameFile gameFile, int position, View sharedView)
@@ -431,6 +433,10 @@ public final class EmulationActivity extends AppCompatActivity
 		{
 			getMenuInflater().inflate(R.menu.menu_emulation_wii, menu);
 		}
+
+		// Populate the checkbox value for joystick center on touch
+		menu.findItem(R.id.menu_emulation_joystick_rel_center).setChecked(mPreferences.getBoolean("joystickRelCenter", true));
+
 		return true;
 	}
 
@@ -441,9 +447,28 @@ public final class EmulationActivity extends AppCompatActivity
 		int action = buttonsActionsMap.get(item.getItemId(), -1);
 		if (action >= 0)
 		{
-			handleMenuAction(action);
+			if (item.isCheckable())
+			{
+				// Need to pass a reference to the item to set the checkbox state, since it is not done automatically
+				handleCheckableMenuAction(action, item);
+			}
+			else
+			{
+				handleMenuAction(action);
+			}
 		}
 		return true;
+	}
+
+	public void handleCheckableMenuAction(@MenuAction int menuAction, MenuItem item)
+	{
+		switch (menuAction)
+		{
+			case MENU_ACTION_JOYSTICK_REL_CENTER:
+				item.setChecked(!item.isChecked());
+				toggleJoystickRelCenter(item.isChecked());
+				return;
+		}
 	}
 
 	public void handleMenuAction(@MenuAction int menuAction)
@@ -563,6 +588,13 @@ public final class EmulationActivity extends AppCompatActivity
 				exitWithAnimation();
 				return;
 		}
+	}
+
+	private void toggleJoystickRelCenter(boolean state)
+	{
+		final SharedPreferences.Editor editor = mPreferences.edit();
+		editor.putBoolean("joystickRelCenter", state);
+		editor.commit();
 	}
 
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -829,7 +829,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		final InputOverlayDrawableJoystick overlayDrawable
 				= new InputOverlayDrawableJoystick(res, bitmapOuter,
 								   bitmapInnerDefault, bitmapInnerPressed,
-								   outerRect, innerRect, joystick);
+								   outerRect, innerRect, joystick, sPrefs);
 
 		// Need to set the image's position
 		overlayDrawable.setPosition(drawableX, drawableY);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
@@ -6,6 +6,8 @@
 
 package org.dolphinemu.dolphinemu.overlay;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -19,6 +21,8 @@ import android.view.MotionEvent;
  */
 public final class InputOverlayDrawableJoystick
 {
+	private SharedPreferences mPreferences;
+
 	private final int[] axisIDs = {0, 0, 0, 0};
 	private final float[] axises = {0f, 0f};
 	private int trackId = -1;
@@ -48,7 +52,7 @@ public final class InputOverlayDrawableJoystick
 	 */
 	public InputOverlayDrawableJoystick(Resources res, Bitmap bitmapOuter,
 					    Bitmap bitmapInnerDefault, Bitmap bitmapInnerPressed,
-					    Rect rectOuter, Rect rectInner, int joystick)
+					    Rect rectOuter, Rect rectInner, int joystick, SharedPreferences prefsHandle)
 	{
 		axisIDs[0] = joystick + 1;
 		axisIDs[1] = joystick + 2;
@@ -56,6 +60,7 @@ public final class InputOverlayDrawableJoystick
 		axisIDs[3] = joystick + 4;
 		mJoystickType = joystick;
 
+		mPreferences = prefsHandle;
 		mOuterBitmap = new BitmapDrawable(res, bitmapOuter);
 		mDefaultStateInnerBitmap = new BitmapDrawable(res, bitmapInnerDefault);
 		mPressedStateInnerBitmap = new BitmapDrawable(res, bitmapInnerPressed);
@@ -92,6 +97,7 @@ public final class InputOverlayDrawableJoystick
 
 	public void TrackEvent(MotionEvent event)
 	{
+		boolean reCenter = mPreferences.getBoolean("joystickRelCenter", true);
 		int pointerIndex = event.getActionIndex();
 
 		switch(event.getAction() & MotionEvent.ACTION_MASK)
@@ -103,7 +109,10 @@ public final class InputOverlayDrawableJoystick
 				mPressedState = true;
 				mOuterBitmap.setAlpha(0);
 				mBoundsBoxBitmap.setAlpha(255);
-				getVirtBounds().offset((int)event.getX(pointerIndex) - getVirtBounds().centerX(), (int)event.getY(pointerIndex) - getVirtBounds().centerY());
+				if (reCenter)
+				{
+					getVirtBounds().offset((int)event.getX(pointerIndex) - getVirtBounds().centerX(), (int)event.getY(pointerIndex) - getVirtBounds().centerY());
+				}
 				mBoundsBoxBitmap.setBounds(getVirtBounds());
 				trackId = event.getPointerId(pointerIndex);
 			}

--- a/Source/Android/app/src/main/res/menu/menu_emulation.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation.xml
@@ -93,6 +93,11 @@
             <item
                 android:id="@+id/menu_emulation_adjust_scale"
                 android:title="@string/emulation_control_scale"/>
+
+            <item
+                android:id="@+id/menu_emulation_joystick_rel_center"
+                android:checkable="true"
+                android:title="@string/emulation_control_joystick_rel_center"/>
         </menu>
     </item>
 

--- a/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
@@ -93,6 +93,13 @@
                 android:id="@+id/menu_emulation_adjust_scale"
                 android:title="@string/emulation_control_scale"/>
 
+            <group android:checkableBehavior="all">
+                <item
+                    android:id="@+id/menu_emulation_joystick_rel_center"
+                    android:checkable="true"
+                    android:title="@string/emulation_control_joystick_rel_center"/>
+            </group>
+
             <item
                 android:id="@+id/menu_emulation_choose_controller"
                 android:title="@string/emulation_choose_controller"/>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="emulation_toggle_controls">Toggle Controls</string>
     <string name="emulation_toggle_all">Toggle All</string>
     <string name="emulation_control_scale">Adjust Scale</string>
+    <string name="emulation_control_joystick_rel_center">Relative Stick Center</string>
     <string name="emulation_choose_controller">Choose Controller</string>
     <string name="emulation_controller_changed">You may have to reload the game after changing extensions.</string>
 


### PR DESCRIPTION
Adds a new menu option to the in-game controls sub-menu, to make the joystick centering on the initial touch point configurable (defaults to on, demo below is somewhat misleading).

See below:

![ezgif-2-24756eeccf](https://user-images.githubusercontent.com/1276215/42111741-78fd99d6-7bb3-11e8-84b1-32ef99ac3409.gif)
