### PR TITLE
Add "Reduce Polling Rate" option to NetPlay

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -95,6 +95,7 @@ const ConfigInfo<bool> MAIN_CUSTOM_RTC_ENABLE{{System::Main, "Core", "EnableCust
 const ConfigInfo<u32> MAIN_CUSTOM_RTC_VALUE{{System::Main, "Core", "CustomRTCValue"}, 946684800};
 const ConfigInfo<bool> MAIN_ENABLE_SIGNATURE_CHECKS{{System::Main, "Core", "EnableSignatureChecks"},
                                                     true};
+const ConfigInfo<bool> MAIN_REDUCE_POLLING_RATE{{System::Main, "Core", "ReducePollingRate"}, false};
 
 // Main.DSP
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -72,6 +72,7 @@ extern const ConfigInfo<std::string> MAIN_PERF_MAP_DIR;
 extern const ConfigInfo<bool> MAIN_CUSTOM_RTC_ENABLE;
 extern const ConfigInfo<u32> MAIN_CUSTOM_RTC_VALUE;
 extern const ConfigInfo<bool> MAIN_ENABLE_SIGNATURE_CHECKS;
+extern const ConfigInfo<bool> MAIN_REDUCE_POLLING_RATE;
 
 // Main.DSP
 

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -33,6 +33,7 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
   config_layer->Set(Config::MAIN_CPU_CORE, static_cast<PowerPC::CPUCore>(dtm->CPUCore));
   config_layer->Set(Config::MAIN_SYNC_GPU, dtm->bSyncGPU);
   config_layer->Set(Config::MAIN_GFX_BACKEND, dtm->videoBackend.data());
+  config_layer->Set(Config::MAIN_REDUCE_POLLING_RATE, dtm->bReducePollingRate);
 
   config_layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, dtm->bProgressive);
   config_layer->Set(Config::SYSCONF_PAL60, dtm->bPAL60);
@@ -56,6 +57,7 @@ void SaveToDTM(Movie::DTMHeader* dtm)
   dtm->CPUCore = static_cast<u8>(Config::Get(Config::MAIN_CPU_CORE));
   dtm->bSyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
   const std::string video_backend = Config::Get(Config::MAIN_GFX_BACKEND);
+  dtm->bReducePollingRate = Config::Get(Config::MAIN_REDUCE_POLLING_RATE);
 
   dtm->bProgressive = Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN);
   dtm->bPAL60 = Config::Get(Config::SYSCONF_PAL60);
@@ -94,4 +96,4 @@ std::unique_ptr<Config::ConfigLayerLoader> GenerateMovieConfigLoader(Movie::DTMH
 {
   return std::make_unique<MovieConfigLayerLoader>(header);
 }
-}
+}  // namespace ConfigLoaders

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -33,6 +33,7 @@ public:
     layer->Set(Config::MAIN_SLOT_A, static_cast<int>(m_settings.m_EXIDevice[0]));
     layer->Set(Config::MAIN_SLOT_B, static_cast<int>(m_settings.m_EXIDevice[1]));
     layer->Set(Config::MAIN_WII_SD_CARD_WRITABLE, m_settings.m_WriteToMemcard);
+    layer->Set(Config::MAIN_REDUCE_POLLING_RATE, m_settings.m_ReducePollingRate);
 
     layer->Set(Config::MAIN_DSP_JIT, m_settings.m_DSPEnableJIT);
 
@@ -54,4 +55,4 @@ std::unique_ptr<Config::ConfigLayerLoader> GenerateNetPlayConfigLoader(const Net
 {
   return std::make_unique<NetPlayConfigLayerLoader>(settings);
 }
-}
+}  // namespace ConfigLoaders

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -11,6 +11,8 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/MMIO.h"
@@ -622,7 +624,11 @@ SIDevices GetDeviceType(int channel)
 
 u32 GetPollXLines()
 {
-  return s_poll.X;
+  // Returning 0 here effectively makes polling happen once per frame, as this is used to increment
+  // a value in VI for when the next SI poll happens. This should normally only be set during
+  // NetPlay, as it does not matter for a non-networked session. However, it may also be set during
+  // movie playback for movies recorded during NetPlay.
+  return Config::Get(Config::MAIN_REDUCE_POLLING_RATE) ? 0 : s_poll.X;
 }
 
 }  // end of namespace SerialInterface

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -103,7 +103,8 @@ struct DTMHeader
   bool bNetPlay;
   bool bPAL60;
   u8 language;
-  std::array<u8, 11> reserved;      // Padding for any new config options
+  bool bReducePollingRate;
+  std::array<u8, 10> reserved;      // Padding for any new config options
   std::array<char, 40> discChange;  // Name of iso file to switch to, for two disc games.
   std::array<u8, 20> revision;      // Git hash
   u32 DSPiromHash;
@@ -186,4 +187,4 @@ void SetWiiInputManip(WiiManipFunction);
 void CallGCInputManip(GCPadStatus* PadStatus, int controllerID);
 void CallWiiInputManip(u8* core, WiimoteEmu::ReportFeatures rptf, int controllerID, int ext,
                        const wiimote_key key);
-}
+}  // namespace Movie

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -434,6 +434,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> g_NetPlaySettings.m_CopyWiiSave;
       packet >> g_NetPlaySettings.m_OCEnable;
       packet >> g_NetPlaySettings.m_OCFactor;
+      packet >> g_NetPlaySettings.m_ReducePollingRate;
 
       int tmp;
       packet >> tmp;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -27,6 +27,7 @@ struct NetSettings
   bool m_DSPEnableJIT;
   bool m_WriteToMemcard;
   bool m_CopyWiiSave;
+  bool m_ReducePollingRate;
   bool m_OCEnable;
   float m_OCFactor;
   ExpansionInterface::TEXIDevices m_EXIDevice[2];

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -831,6 +831,7 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_CopyWiiSave;
   spac << m_settings.m_OCEnable;
   spac << m_settings.m_OCFactor;
+  spac << m_settings.m_ReducePollingRate;
   spac << m_settings.m_EXIDevice[0];
   spac << m_settings.m_EXIDevice[1];
   spac << static_cast<u32>(g_netplay_initial_rtc);

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -85,6 +85,7 @@ void NetPlayDialog::CreateMainLayout()
   m_save_sd_box = new QCheckBox(tr("Write save/SD data"));
   m_load_wii_box = new QCheckBox(tr("Load Wii Save"));
   m_record_input_box = new QCheckBox(tr("Record inputs"));
+  m_reduce_polling_rate_box = new QCheckBox(tr("Reduce Polling Rate"));
   m_buffer_label = new QLabel(tr("Buffer:"));
   m_quit_button = new QPushButton(tr("Quit"));
   m_splitter = new QSplitter(Qt::Horizontal);
@@ -119,6 +120,10 @@ void NetPlayDialog::CreateMainLayout()
   m_md5_button->setPopupMode(QToolButton::MenuButtonPopup);
   m_md5_button->setMenu(menu);
 
+  m_reduce_polling_rate_box->setToolTip(
+      tr("This will reduce bandwidth usage, but may add up to one frame of additional latency, as "
+         "controllers will be polled only once per frame."));
+
   m_main_layout->addWidget(m_game_button, 0, 0);
   m_main_layout->addWidget(m_md5_button, 0, 1);
   m_main_layout->addWidget(m_splitter, 1, 0, 1, -1);
@@ -134,6 +139,7 @@ void NetPlayDialog::CreateMainLayout()
   options_widget->addWidget(m_save_sd_box);
   options_widget->addWidget(m_load_wii_box);
   options_widget->addWidget(m_record_input_box);
+  options_widget->addWidget(m_reduce_polling_rate_box);
   options_widget->addWidget(m_quit_button);
   m_main_layout->addLayout(options_widget, 2, 0, 1, -1, Qt::AlignRight);
 
@@ -290,6 +296,7 @@ void NetPlayDialog::OnStart()
   settings.m_CopyWiiSave = m_load_wii_box->isChecked();
   settings.m_OCEnable = instance.m_OCEnable;
   settings.m_OCFactor = instance.m_OCFactor;
+  settings.m_ReducePollingRate = m_reduce_polling_rate_box->isChecked();
   settings.m_EXIDevice[0] = instance.m_EXIDevice[0];
   settings.m_EXIDevice[1] = instance.m_EXIDevice[1];
 
@@ -333,6 +340,7 @@ void NetPlayDialog::show(std::string nickname, bool use_traversal)
   m_start_button->setHidden(!is_hosting);
   m_save_sd_box->setHidden(!is_hosting);
   m_load_wii_box->setHidden(!is_hosting);
+  m_reduce_polling_rate_box->setHidden(!is_hosting);
   m_buffer_size_box->setHidden(!is_hosting);
   m_buffer_label->setHidden(!is_hosting);
   m_kick_button->setHidden(!is_hosting);
@@ -516,6 +524,7 @@ void NetPlayDialog::GameStatusChanged(bool running)
       m_load_wii_box->setEnabled(!running);
       m_save_sd_box->setEnabled(!running);
       m_assign_ports_button->setEnabled(!running);
+      m_reduce_polling_rate_box->setEnabled(!running);
     }
 
     m_record_input_box->setEnabled(!running);

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
@@ -98,6 +98,7 @@ private:
   QCheckBox* m_save_sd_box;
   QCheckBox* m_load_wii_box;
   QCheckBox* m_record_input_box;
+  QCheckBox* m_reduce_polling_rate_box;
   QPushButton* m_quit_button;
   QSplitter* m_splitter;
 


### PR DESCRIPTION
Normally, SI is polled at a rate defined by the game, and we have to send the pad state to other clients on every poll or else we'll desync. This can result in fairly high bandwidth usage, especially with multiple controllers, mostly due to UDP overhead.

This change introduces an option to reduce the SI poll rate to once per frame, which may introduce up to one frame of additional latency, but will reduce bandwidth usage substantially, which is useful for users on very slow internet connections (hi there :).

Polling SI less frequently than the game asked for did not seem to cause any problems in my testing, so this should be perfectly safe to do.