### PR TITLE
Qt: Fix inability to select translated video backend names

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -111,8 +111,8 @@ void GraphicsWindow::OnBackendChanged(const QString& backend_name)
     }
   }
 
-  setWindowTitle(tr("%1 Graphics Configuration")
-                     .arg(QString::fromStdString(g_video_backend->GetDisplayName())));
+  setWindowTitle(
+      tr("%1 Graphics Configuration").arg(tr(g_video_backend->GetDisplayName().c_str())));
   if (backend_name == QStringLiteral("Software Renderer") && m_tab_widget->count() > 1)
   {
     m_tab_widget->clear();


### PR DESCRIPTION
Refactored to use userData functionality of QComboBox, so code is cleaner and more robust.