### PR TITLE
CMake: Use thin archives on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,15 @@ else()
 
   dolphin_compile_definitions(_DEBUG DEBUG_ONLY)
   check_and_add_flag(GGDB -ggdb DEBUG_ONLY)
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # GNU ar: Create thin archive files.
+    # Requires binutils-2.19 or later.
+    set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_APPEND   "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+  endif()
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ option(OPROFILING "Enable profiling" OFF)
 option(DSPTOOL "Build dsptool" OFF)
 
 # Enable SDL for default on operating systems that aren't OSX, Android, Linux or Windows.
-if(NOT APPLE AND NOT ANDROID AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT MSVC)
+if(NOT APPLE AND NOT ANDROID AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT MSVC)
   option(ENABLE_SDL "Enables SDL as a generic controller backend" ON)
 else()
   option(ENABLE_SDL "Enables SDL as a generic controller backend" OFF)
@@ -59,7 +59,7 @@ if(APPLE)
   option(SKIP_POSTPROCESS_BUNDLE "Skip postprocessing bundle for redistributability" OFF)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   option(ENABLE_VTUNE "Enable Intel VTune integration for JIT code." OFF)
 
   if(NOT ANDROID)

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -142,7 +142,7 @@ elseif(USE_X11)
   target_link_libraries(common PUBLIC ${XRANDR_LIBRARIES})
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(common PUBLIC dl rt)
 endif()
 


### PR DESCRIPTION
Thin archives contain pathnames pointing to the object files instead of full copies of the object files. This significantly reduces the disk usage when building Dolphin.

Size of *.a files: (gcc-8.1.0, Linux amd64)
- Before: 83,876 KB
- After:   1,876 KB
- Diff:  -82,000 KB

The resulting binaries are the same as before.

A similar change was implemented in the Linux kernel v4.8:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=a5967db9af51a84f5e181600954714a9e4c69f1f

NOTE: Thin archives were first implemented in binutils-2.19, released in October 28, 2008. I'm unsure of any easy way to check the binutils (ar) version using Dolphin's CMake infrastructure; however, since the minimum gcc version is 6.0, that should be a sufficient check, since most Linux distros don't mix new gcc with ancient binutils.