### PR TITLE
Removed iterative input from the option group. It already exists in t…

### DIFF
--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -80,8 +80,6 @@ GCKeyboard::GCKeyboard(const unsigned int index) : m_index(index)
 
   // options
   groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));
-  m_options->boolean_settings.emplace_back(std::make_unique<ControllerEmu::BooleanSetting>(
-      _trans("Iterative Input"), false, ControllerEmu::SettingType::VIRTUAL));
 }
 
 std::string GCKeyboard::GetName() const

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -98,8 +98,6 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
       // i18n: Treat a controller as always being connected regardless of what
       // devices the user actually has plugged in
       m_always_connected = new ControllerEmu::BooleanSetting(_trans("Always Connected"), false));
-  m_options->boolean_settings.emplace_back(std::make_unique<ControllerEmu::BooleanSetting>(
-      _trans("Iterative Input"), false, ControllerEmu::SettingType::VIRTUAL));
 }
 
 std::string GCPad::GetName() const

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -314,8 +314,6 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index), ir_sin(0), ir_cos(1
   m_options->boolean_settings.emplace_back(
       m_upright_setting = new ControllerEmu::BooleanSetting("Upright Wiimote",
                                                             _trans("Upright Wii Remote"), false));
-  m_options->boolean_settings.emplace_back(std::make_unique<ControllerEmu::BooleanSetting>(
-      _trans("Iterative Input"), false, ControllerEmu::SettingType::VIRTUAL));
   m_options->numeric_settings.emplace_back(
       std::make_unique<ControllerEmu::NumericSetting>(_trans("Speaker Pan"), 0, -127, 127));
   m_options->numeric_settings.emplace_back(


### PR DESCRIPTION
…he mapping window. The checkbox in the option group also did not function. Since the iterative input is not a option for the actual controllers I agree with having it in the mapping window.