### PR TITLE
Qt/CodeWidget: Fix Address Search Focus Lost

### DIFF
--- a/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt2/Debugger/CodeWidget.cpp
@@ -187,6 +187,8 @@ void CodeWidget::OnSearchAddress()
     m_code_view->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithUpdate);
 
   Update();
+
+  m_search_address->setFocus();
 }
 
 void CodeWidget::OnSearchSymbols()


### PR DESCRIPTION
When its text is changed, CodeWidget::Update is called which sets focus to the Code Window.