### PR TITLE
Qt: Update graphics config descriptions for consistency

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/AdvancedWidget.cpp
@@ -142,62 +142,60 @@ void AdvancedWidget::OnEmulationStateChanged(bool running)
 void AdvancedWidget::AddDescriptions()
 {
   static const char TR_WIREFRAME_DESCRIPTION[] =
-      QT_TR_NOOP("Render the scene as a wireframe.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Renders the scene as a wireframe.\n\nIf unsure, leave unchecked.");
   static const char TR_SHOW_STATS_DESCRIPTION[] =
-      QT_TR_NOOP("Show various rendering statistics.\n\nIf unsure, leave this unchecked.");
-  static const char TR_TEXTURE_FORMAT_DECRIPTION[] =
-      QT_TR_NOOP("Modify textures to show the format they're encoded in. Needs an emulation reset "
-                 "in most cases.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Shows various rendering statistics.\n\nIf unsure, leave unchecked.");
+  static const char TR_TEXTURE_FORMAT_DECRIPTION[] = QT_TR_NOOP(
+      "Modifies textures to show the format that they are encoded in.\n\nMay require "
+      "an emulation reset to apply in some cases.\n\nIf unsure, leave unchecked.");
   static const char TR_VALIDATION_LAYER_DESCRIPTION[] =
       QT_TR_NOOP("Enables validation of API calls made by the video backend, which may assist in "
-                 "debugging graphical issues.\n\nIf unsure, leave this unchecked.");
-  static const char TR_DUMP_TEXTURE_DESCRIPTION[] =
-      QT_TR_NOOP("Dump decoded game textures to User/Dump/Textures/<game_id>/.\n\nIf unsure, leave "
-                 "this unchecked.");
-  static const char TR_LOAD_CUSTOM_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
-      "Load custom textures from User/Load/Textures/<game_id>/.\n\nIf unsure, leave this "
+                 "debugging graphical issues.\n\nIf unsure, leave unchecked.");
+  static const char TR_DUMP_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
+      "Dumps decoded game textures to User/Dump/Textures/<game_id>/.\n\nIf unsure, leave "
       "unchecked.");
-  static const char TR_CACHE_CUSTOM_TEXTURE_DESCRIPTION[] =
-      QT_TR_NOOP("Cache custom textures to system RAM on startup.\nThis can require exponentially "
-                 "more RAM but fixes possible stuttering.\n\nIf unsure, leave this unchecked.");
-  static const char TR_DUMP_EFB_DESCRIPTION[] =
-      QT_TR_NOOP("Dump the contents of EFB copies to User/Dump/Textures/.\n\nIf unsure, leave this "
-                 "unchecked.");
-  static const char TR_DISABLE_VRAM_COPIES_DESCRIPTION[] =
-      QT_TR_NOOP("Disables the VRAM copy of the EFB, forcing a round-trip to RAM. Inhibits all "
-                 "upscaling.\n\nIf unsure, leave this unchecked.");
+  static const char TR_LOAD_CUSTOM_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
+      "Loads custom textures from User/Load/Textures/<game_id>/.\n\nIf unsure, leave "
+      "unchecked.");
+  static const char TR_CACHE_CUSTOM_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
+      "Caches custom textures to system RAM on startup.\n\nThis can require exponentially "
+      "more RAM but fixes possible stuttering.\n\nIf unsure, leave unchecked.");
+  static const char TR_DUMP_EFB_DESCRIPTION[] = QT_TR_NOOP(
+      "Dumps the contents of EFB copies to User/Dump/Textures/.\n\nIf unsure, leave "
+      "unchecked.");
+  static const char TR_DISABLE_VRAM_COPIES_DESCRIPTION[] = QT_TR_NOOP(
+      "Disables the VRAM copy of the EFB, forcing a round-trip to RAM. Inhibits all "
+      "upscaling.\n\nIf unsure, leave unchecked.");
   static const char TR_INTERNAL_RESOLUTION_FRAME_DUMPING_DESCRIPTION[] = QT_TR_NOOP(
-      "Create frame dumps and screenshots at the internal resolution of the renderer, rather than "
-      "the size of the window it is displayed within. If the aspect ratio is widescreen, the "
-      "output "
+      "Creates frame dumps and screenshots at the internal resolution of the "
+      "renderer, rather than the size of the window it is displayed within. "
+      "\n\nIf the aspect ratio is widescreen, the output "
       "image will be scaled horizontally to preserve the vertical resolution.\n\nIf unsure, leave "
-      "this unchecked.");
+      "unchecked.");
 #if defined(HAVE_FFMPEG)
   static const char TR_USE_FFV1_DESCRIPTION[] =
-      QT_TR_NOOP("Encode frame dumps using the FFV1 codec.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Encodes frame dumps using the FFV1 codec.\n\nIf unsure, leave unchecked.");
 #endif
   static const char TR_FREE_LOOK_DESCRIPTION[] = QT_TR_NOOP(
-      "This feature allows you to change the game's camera.\nMove the mouse while holding the "
-      "right "
-      "mouse button to pan and while holding the middle button to move.\nHold SHIFT and press "
-      "one of "
-      "the WASD keys to move the camera by a certain step distance (SHIFT+2 to move faster and "
-      "SHIFT+1 to move slower). Press SHIFT+R to reset the camera and SHIFT+F to reset the "
-      "speed.\n\nIf unsure, leave this unchecked.");
+      "Allows the user to manipulate the game camera.\n\nMove the mouse and hold the right "
+      "button to pan or middle button to move. Hold SHIFT and use the WASD keys to move "
+      "the camera. Press SHIFT+2 to increase speed or SHIFT+1 to decrease speed. Press SHIFT+R "
+      "to reset the camera or SHIFT+F to reset the speed. "
+      "\n\nIf unsure, leave unchecked.");
   static const char TR_CROPPING_DESCRIPTION[] =
-      QT_TR_NOOP("Crop the picture from its native aspect ratio to 4:3 or "
-                 "16:9.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Crops the picture from its native aspect ratio to 4:3 or "
+                 "16:9.\n\nIf unsure, leave unchecked.");
   static const char TR_PROGRESSIVE_SCAN_DESCRIPTION[] = QT_TR_NOOP(
-      "Enables progressive scan if supported by the emulated software.\nMost games don't "
-      "care about this.\n\nIf unsure, leave this unchecked.");
+      "Enables progressive scan if supported by the emulated software. Most "
+      "games are completely unaffected by this.\n\nIf unsure, leave unchecked.");
 #ifdef _WIN32
   static const char TR_BORDERLESS_FULLSCREEN_DESCRIPTION[] = QT_TR_NOOP(
-      "Implement fullscreen mode with a borderless window spanning the whole screen instead of "
+      "Implements fullscreen mode with a borderless window spanning the whole screen instead of "
       "using "
-      "exclusive mode.\nAllows for faster transitions between fullscreen and windowed mode, but "
+      "exclusive mode.\n\nAllows for faster transitions between fullscreen and windowed mode, but "
       "slightly increases input latency, makes movement less smooth and slightly decreases "
-      "performance.\nExclusive mode is required for Nvidia 3D Vision to work in the Direct3D "
-      "backend.\n\nIf unsure, leave this unchecked.");
+      "performance.\n\nExclusive mode is required for Nvidia 3D Vision to work in the Direct3D "
+      "backend.\n\nIf unsure, leave unchecked.");
 #endif
 
   AddDescription(m_enable_wireframe, TR_WIREFRAME_DESCRIPTION);

--- a/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/EnhancementsWidget.cpp
@@ -273,74 +273,73 @@ void EnhancementsWidget::SaveSettings()
 
 void EnhancementsWidget::AddDescriptions()
 {
-  static const char TR_INTERNAL_RESOLUTION_DESCRIPTION[] =
-      QT_TR_NOOP("Specifies the resolution used to render at. A high resolution greatly improves "
-                 "visual quality, but also greatly increases GPU load and can cause issues in "
-                 "certain games. Generally speaking, the lower the internal resolution is, the "
-                 "better your performance will be.\n\nIf unsure, select Native.");
+  static const char TR_INTERNAL_RESOLUTION_DESCRIPTION[] = QT_TR_NOOP(
+      "Specifies the resolution used to render at.\n\nA higher resolution greatly improves "
+      "visual quality, but greatly increases GPU load and can cause issues in "
+      "certain games. Generally speaking, the lower the internal resolution is, the "
+      "better your performance will be.\n\nIf unsure, select Native.");
 
-  static const char TR_ANTIALIAS_DESCRIPTION[] =
-      QT_TR_NOOP("Reduces the amount of aliasing caused by rasterizing 3D graphics. This smooths "
-                 "out jagged edges on objects.\nIncreases GPU load and sometimes causes graphical "
-                 "issues. SSAA is significantly more demanding than MSAA, but provides top quality "
-                 "geometry anti-aliasing and also applies anti-aliasing to lighting, shader "
-                 "effects, and textures.\n\nIf unsure, select None.");
+  static const char TR_ANTIALIAS_DESCRIPTION[] = QT_TR_NOOP(
+      "Reduces the amount of aliasing caused by rasterizing 3D graphics. This smooths "
+      "out jagged edges on objects.\n\nIncreases GPU load and sometimes causes graphical "
+      "issues. SSAA is significantly more demanding than MSAA, but provides top quality "
+      "geometry anti-aliasing and applies anti-aliasing to lighting, shader "
+      "effects, and textures.\n\nIf unsure, select None.");
 
   static const char TR_ANISOTROPIC_FILTERING_DESCRIPTION[] = QT_TR_NOOP(
-      "Enable anisotropic filtering.\nEnhances visual quality of textures that are at oblique "
-      "viewing angles.\nMight cause issues in a small number of games.\n\nIf unsure, select 1x.");
+      "Enables anisotropic filtering.\n\nEnhances visual quality of textures that are at oblique "
+      "viewing angles. Might cause issues in a small number of games.\n\nIf unsure, select 1x.");
 
   static const char TR_POSTPROCESSING_DESCRIPTION[] = QT_TR_NOOP(
-      "Apply a post-processing effect after finishing a frame.\n\nIf unsure, select (off).");
+      "Applies a post-processing effect after finishing a frame.\n\nIf unsure, select (off).");
 
   static const char TR_SCALED_EFB_COPY_DESCRIPTION[] = QT_TR_NOOP(
-      "Greatly increases quality of textures generated using render-to-texture "
-      "effects.\nRaising the "
-      "internal resolution will improve the effect of this setting.\nSlightly increases GPU "
-      "load and "
-      "causes relatively few graphical issues.\n\nIf unsure, leave this checked.");
+      "Greatly increases the quality of textures generated using render-to-texture "
+      "effects.\n\nSlightly increases GPU load and causes relatively few grpahical issues. "
+      "Raising the internal resolution will improve the effect of this setting. "
+      "\n\nIf unsure, leave this checked.");
   static const char TR_PER_PIXEL_LIGHTING_DESCRIPTION[] = QT_TR_NOOP(
       "Calculates lighting of 3D objects per-pixel rather than per-vertex, smoothing out the "
-      "appearance of lit polygons and making individual triangles less noticeable.\nRarely causes "
-      "slowdowns or graphical issues.\n\nIf unsure, leave this unchecked.");
+      "appearance of lit polygons and making individual triangles less noticeable.\n\nRarely "
+      "causes slowdowns or graphical issues.\n\nIf unsure, leave this unchecked.");
   static const char TR_WIDESCREEN_HACK_DESCRIPTION[] = QT_TR_NOOP(
-      "Forces the game to output graphics for any aspect ratio.\nUse with \"Aspect Ratio\" set to "
-      "\"Force 16:9\" to force 4:3-only games to run at 16:9.\nRarely produces good results and "
-      "often partially breaks graphics and game UIs.\nUnnecessary (and detrimental) if using any "
+      "Forces the game to output graphics at any given aspect ratio.\n\nUse with \"Aspect Ratio\" "
+      "set to \"Force 16:9\" to force 4:3-only games to run at 16:9. Rarely produces good results "
+      "and often partially breaks graphics and game UIs. Unnecessary (and detrimental) if using any "
       "AR/Gecko-code widescreen patches.\n\nIf unsure, leave this unchecked.");
   static const char TR_REMOVE_FOG_DESCRIPTION[] =
-      QT_TR_NOOP("Makes distant objects more visible by removing fog, thus increasing the overall "
-                 "detail.\nDisabling fog will break some games which rely on proper fog "
-                 "emulation.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Makes distant objects more visible by removing fog, thus increasing overall "
+                 "detail.\n\nDisabling fog will break some games which rely on proper fog "
+                 "emulation.\n\nIf unsure, leave unchecked.");
   static const char TR_3D_MODE_DESCRIPTION[] = QT_TR_NOOP(
-      "Selects the stereoscopic 3D mode. Stereoscopy allows you to get a better feeling "
-      "of depth if you have the necessary hardware.\nSide-by-Side and Top-and-Bottom are "
+      "Selects the stereoscopic 3D mode. Stereoscopy allows you to get a better perception "
+      "of depth if you have the necessary hardware. This option heavily decreases emulation "
+      "speed and sometimes causes issues.\n\nSide-by-Side and Top-and-Bottom are "
       "used by most 3D TVs.\nAnaglyph is used for Red-Cyan colored glasses.\nHDMI 3D is "
-      "used when your monitor supports 3D display resolutions.\nHeavily decreases "
-      "emulation speed and sometimes causes issues.\n\nIf unsure, select Off.");
+      "used when your monitor supports 3D display resolutions.\n\nIf unsure, select Off.");
   static const char TR_3D_DEPTH_DESCRIPTION[] =
-      QT_TR_NOOP("Controls the separation distance between the virtual cameras.\nA higher value "
+      QT_TR_NOOP("Controls the separation distance between the virtual cameras.\n\nA higher value "
                  "creates a stronger feeling of depth while a lower value is more comfortable.");
   static const char TR_3D_CONVERGENCE_DESCRIPTION[] = QT_TR_NOOP(
       "Controls the distance of the convergence plane. This is the distance at which "
-      "virtual objects will appear to be in front of the screen.\nA higher value creates "
+      "virtual objects will appear to be in front of the screen.\n\nA higher value creates "
       "stronger out-of-screen effects while a lower value is more comfortable.");
   static const char TR_3D_SWAP_EYES_DESCRIPTION[] =
-      QT_TR_NOOP("Swaps the left and right eye. Mostly useful if you want to view side-by-side "
-                 "cross-eyed.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Swaps the left and right eye. \n\nMostly useful if you want to view "
+                 "side-by-side cross-eyed.\n\nIf unsure, leave unchecked.");
   static const char TR_FORCE_24BIT_DESCRIPTION[] =
       QT_TR_NOOP("Forces the game to render the RGB color channels in 24-bit, thereby increasing "
-                 "quality by reducing color banding.\nIt has no impact on performance and causes "
-                 "few graphical issues.\n\n\nIf unsure, leave this checked.");
+                 "quality by reducing color banding.\n\nThis option has no impact on performance"
+                 "and causes few graphical issues.\n\nIf unsure, leave checked.");
   static const char TR_FORCE_TEXTURE_FILTERING_DESCRIPTION[] =
       QT_TR_NOOP("Filter all textures, including any that the game explicitly set as "
                  "unfiltered.\nMay improve quality of certain textures in some games, but will "
-                 "cause issues in others.\n\nIf unsure, leave this unchecked.");
-  static const char TR_DISABLE_COPY_FILTER_DESCRIPTION[] =
-      QT_TR_NOOP("Disables the blending of adjacent rows when copying the EFB. This is known in "
-                 "some games as \"deflickering\" or \"smoothing\". Disabling the filter has no "
-                 "effect on performance, but may result in a sharper image, and causes few "
-                 "graphical issues.\n\n\nIf unsure, leave this checked.");
+                 "cause issues in others.\n\nIf unsure, leave unchecked.");
+  static const char TR_DISABLE_COPY_FILTER_DESCRIPTION[] = QT_TR_NOOP(
+      "Disables the blending of adjacent rows when copying the EFB.\n\nThis is known "
+      "in some games as \"deflickering\" or \"smoothing\". Disabling the filter has no "
+      "effect on performance, but may result in a sharper image, and causes few "
+      "graphical issues.\n\nIf unsure, leave checked.");
 
   AddDescription(m_ir_combo, TR_INTERNAL_RESOLUTION_DESCRIPTION);
   AddDescription(m_aa_combo, TR_ANTIALIAS_DESCRIPTION);

--- a/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GeneralWidget.cpp
@@ -239,43 +239,43 @@ void GeneralWidget::AddDescriptions()
       "select the backend that is least problematic.\n\nIf unsure, select OpenGL.");
 #else
   static const char TR_BACKEND_DESCRIPTION[] =
-      QT_TR_NOOP("Selects what graphics API to use internally.\nThe software renderer is extremely "
-                 "slow and only useful for debugging, so unless you have a reason to use it you'll "
+      QT_TR_NOOP("Selects which graphics API to use internally.\n\nThe software renderer is extremely "
+                 "slow and only useful for debugging, so unless you have a reason to use it you will "
                  "want to select OpenGL here.\n\nIf unsure, select OpenGL.");
 #endif
   static const char TR_ADAPTER_DESCRIPTION[] =
-      QT_TR_NOOP("Selects a hardware adapter to use.\n\nIf unsure, use the first one.");
+      QT_TR_NOOP("Selects a hardware adapter to use.\n\nIf unsure, select the first option.");
   static const char TR_FULLSCREEN_DESCRIPTION[] = QT_TR_NOOP(
-      "Enable this if you want the whole screen to be used for rendering.\nIf this is disabled, a "
-      "render window will be created instead.\n\nIf unsure, leave this unchecked.");
+      "Uses the entire screen for rendering.\n\nIf disabled, a "
+      "render window will be created instead.\n\nIf unsure, leave unchecked.");
   static const char TR_AUTOSIZE_DESCRIPTION[] =
       QT_TR_NOOP("Automatically adjusts the window size to your internal resolution.\n\nIf unsure, "
-                 "leave this unchecked.");
+                 "leave unchecked.");
 
   static const char TR_RENDER_TO_MAINWINDOW_DESCRIPTION[] =
-      QT_TR_NOOP("Enable this if you want to use the main Dolphin window for rendering rather than "
-                 "a separate render window.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Uses the main Dolphin window for rendering rather than "
+                 "a separate render window.\n\nIf unsure, leave unchecked.");
   static const char TR_ASPECT_RATIO_DESCRIPTION[] = QT_TR_NOOP(
-      "Select what aspect ratio to use when rendering:\nAuto: Use the native aspect "
-      "ratio\nForce 16:9: Mimic an analog TV with a widescreen aspect ratio.\nForce 4:3: "
-      "Mimic a standard 4:3 analog TV.\nStretch to Window: Stretch the picture to the "
+      "Selects which aspect ratio to use when rendering:\nAuto: Uses the native aspect "
+      "ratio.\nForce 16:9: Mimics an analog TV with a widescreen aspect ratio.\nForce 4:3: "
+      "Mimics a standard 4:3 analog TV.\nStretch to Window: Stretches the picture to the "
       "window size.\n\nIf unsure, select Auto.");
   static const char TR_VSYNC_DESCRIPTION[] =
-      QT_TR_NOOP("Wait for vertical blanks in order to reduce tearing.\nDecreases performance if "
-                 "emulation speed is below 100%.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Waits for vertical blanks in order to reduce tearing.\n\nDecreases performance if "
+                 "emulation speed is below 100%.\n\nIf unsure, leave unchecked.");
   static const char TR_SHOW_FPS_DESCRIPTION[] =
-      QT_TR_NOOP("Show the number of frames rendered per second as a measure of "
-                 "emulation speed.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Shows the number of frames rendered per second as a measure of "
+                 "emulation speed.\n\nIf unsure, leave unchecked.");
   static const char TR_SHOW_NETPLAY_PING_DESCRIPTION[] =
-      QT_TR_NOOP("Show the players' maximum Ping while playing on "
-                 "NetPlay.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Shows players' maximum ping while playing on "
+                 "NetPlay.\n\nIf unsure, leave unchecked.");
   static const char TR_LOG_RENDERTIME_DESCRIPTION[] =
-      QT_TR_NOOP("Log the render time of every frame to User/Logs/render_time.txt. Use this "
-                 "feature when you want to measure the performance of Dolphin.\n\nIf "
-                 "unsure, leave this unchecked.");
+      QT_TR_NOOP("Logs the render time of every frame to User/Logs/render_time.txt. \n\nUse "
+                 "this feature when you want to measure the performance of Dolphin.\n\nIf "
+                 "unsure, leave unchecked.");
   static const char TR_SHOW_NETPLAY_MESSAGES_DESCRIPTION[] =
-      QT_TR_NOOP("When playing on NetPlay, show chat messages, buffer changes and "
-                 "desync alerts.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Shows chat messages, buffer changes, and desync alerts while playing "
+                 "on NetPlay.\n\nIf unsure, leave unchecked.");
   static const char TR_SHADER_COMPILE_SYNC_DESCRIPTION[] =
       QT_TR_NOOP("Ubershaders are never used. Stuttering will occur during shader "
                  "compilation, but GPU demands are low. Recommended for low-end hardware.\n\nIf "
@@ -293,11 +293,11 @@ void GeneralWidget::AddDescriptions()
       "scenarios where Ubershaders doesn't, at the cost of introducing visual glitches and broken "
       "effects. Not recommended, only use if the other options give poor results on your system.");
   static const char TR_SHADER_COMPILE_BEFORE_START_DESCRIPTION[] =
-      QT_TR_NOOP("Waits for all shaders to finish compiling before starting a game. Enabling this "
-                 "option may reduce stuttering or hitching for a short time after the game is "
+      QT_TR_NOOP("Waits for all shaders to finish compiling before starting a game.\n\nEnabling "
+                 "this option may reduce stuttering or hitching for a short time after the game is "
                  "started, at the cost of a longer delay before the game starts. For systems with "
                  "two or fewer cores, it is recommended to enable this option, as a large shader "
-                 "queue may reduce frame rates. Otherwise, if unsure, leave this unchecked.");
+                 "queue may reduce frame rates.\n\nOtherwise, if unsure, leave unchecked.");
 
   AddDescription(m_backend_combo, TR_BACKEND_DESCRIPTION);
   AddDescription(m_adapter_combo, TR_ADAPTER_DESCRIPTION);

--- a/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/HacksWidget.cpp
@@ -190,53 +190,54 @@ void HacksWidget::SaveSettings()
 
 void HacksWidget::AddDescriptions()
 {
-  static const char TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION[] =
-      QT_TR_NOOP("Ignore any requests from the CPU to read from or write to the EFB.\nImproves "
-                 "performance in some games, but might disable some gameplay-related features or "
-                 "graphical effects.\n\nIf unsure, leave this unchecked.");
+  static const char TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION[] = QT_TR_NOOP(
+      "Ignores any requests from the CPU to read from or write to the EFB.\n\n"
+      "Improves performance in some games, but might disable some gameplay-related "
+      "features or graphical effects.\n\nIf unsure, leave unchecked.");
   static const char TR_IGNORE_FORMAT_CHANGE_DESCRIPTION[] = QT_TR_NOOP(
-      "Ignore any changes to the EFB format.\nImproves performance in many games without "
-      "any negative effect. Causes graphical defects in a small number of other "
-      "games.\n\nIf unsure, leave this checked.");
+      "Ignores any changes to the EFB format.\n\nImproves performance in many games "
+      "without any negative effect. Causes graphical defects in a small "
+      "number of other games.\n\nIf unsure, leave checked.");
   static const char TR_STORE_EFB_TO_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
-      "Stores EFB Copies exclusively on the GPU, bypassing system memory. Causes graphical defects "
-      "in a small number of games.\n\nEnabled = EFB Copies to Texture\nDisabled = EFB Copies to "
-      "RAM "
-      "(and Texture)\n\nIf unsure, leave this checked.");
+      "Stores EFB Copies exclusively on the GPU, bypassing system memory.\nEnabled: EFB "
+      "Copies to Texture\nDisabled: EFB Copies to RAM (and Texture)\n\nCauses "
+      "graphical defects in a small number of games that need to readback from "
+      "memory.\n\nIf unsure, leave checked.");
   static const char TR_ACCUARCY_DESCRIPTION[] = QT_TR_NOOP(
-      "The \"Safe\" setting eliminates the likelihood of the GPU missing texture updates "
-      "from RAM.\nLower accuracies cause in-game text to appear garbled in certain "
-      "games.\n\nIf unsure, use the rightmost value.");
+      "Adjusts the accuracy at which the GPU receives texture updates from RAM. "
+      "\n\nThe \"Safe\" setting eliminates the likelihood of the GPU missing texture updates "
+      "from RAM.\n\nLower accuracies cause in-game text to appear garbled in certain "
+      "games.\n\nIf unsure, select the rightmost value.");
 
   static const char TR_STORE_XFB_TO_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
-      "Stores XFB Copies exclusively on the GPU, bypassing system memory. Causes graphical defects "
-      "in a small number of games that need to readback from memory.\n\nEnabled = XFB Copies to "
-      "Texture\nDisabled = XFB Copies to RAM "
-      "(and Texture)\n\nIf unsure, leave this checked.");
+      "Stores XFB Copies exclusively on the GPU, bypassing system memory. "
+      "\nEnabled: XFB Copies to Texture\nDisabled: XFB Copies to RAM (and Texture)\n\nCauses "
+      "graphical defects in a small number of games that need to readback from memory. "
+      "\n\nIf unsure, leave checked.");
 
   static const char TR_IMMEDIATE_XFB_DESCRIPTION[] =
       QT_TR_NOOP("Displays the XFB copies as soon as they are created, without waiting for "
-                 "scanout. Can cause graphical defects "
-                 "in some games if the game doesn't expect all XFB copies to be displayed. "
+                 "scanout.\n\nCan cause graphical defects "
+                 "in some games if the game does not expect all XFB copies to be displayed. "
                  "However, turning this setting on reduces latency."
-                 "\n\nIf unsure, leave this unchecked.");
+                 "\n\nIf unsure, leave unchecked.");
 
   static const char TR_GPU_DECODING_DESCRIPTION[] =
-      QT_TR_NOOP("Enables texture decoding using the GPU instead of the CPU. This may result in "
-                 "performance gains in some scenarios, or on systems where the CPU is the "
-                 "bottleneck.\n\nIf unsure, leave this unchecked.");
+      QT_TR_NOOP("Enables texture decoding using the GPU instead of the CPU.\n\nThis may "
+                 "result in performance gains in some scenarios, or on systems "
+                 "where the CPU is the bottleneck.\n\nIf unsure, leave unchecked.");
 
   static const char TR_FAST_DEPTH_CALC_DESCRIPTION[] = QT_TR_NOOP(
-      "Use a less accurate algorithm to calculate depth values.\nCauses issues in a few "
-      "games, but can give a decent speedup depending on the game and/or your GPU.\n\nIf "
-      "unsure, leave this checked.");
-  static const char TR_DISABLE_BOUNDINGBOX_DESCRIPTION[] =
-      QT_TR_NOOP("Disable the bounding box emulation.\nThis may improve the GPU performance a lot, "
-                 "but some games will break.\n\nIf unsure, leave this checked.");
-  static const char TR_VERTEX_ROUNDING_DESCRIPTION[] =
-      QT_TR_NOOP("Rounds 2D vertices to whole pixels. Fixes graphical problems in some games at "
-                 "higher internal resolutions. This setting has no effect when native internal "
-                 "resolution is used.\n\nIf unsure, leave this unchecked.");
+      "Uses a less accurate algorithm to calculate depth values.\n\nCauses issues in a few "
+      "games, but can give a decent speed increase depending on the game and/or your "
+      "GPU.\n\nIf unsure, leave checked.");
+  static const char TR_DISABLE_BOUNDINGBOX_DESCRIPTION[] = QT_TR_NOOP(
+      "Disables the bounding box emulation.\n\nThis may improve the GPU performance a lot, "
+      "but some games will break.\n\nIf unsure, leave checked.");
+  static const char TR_VERTEX_ROUNDING_DESCRIPTION[] = QT_TR_NOOP(
+      "Rounds 2D vertices to whole pixels.\n\nFixes graphical problems in some games at "
+      "higher internal resolutions. This setting has no effect when native internal "
+      "resolution is used.\n\nIf unsure, leave unchecked.");
 
   AddDescription(m_skip_efb_cpu, TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION);
   AddDescription(m_ignore_format_changes, TR_IGNORE_FORMAT_CHANGE_DESCRIPTION);

--- a/Source/Core/DolphinQt2/Config/Graphics/PostProcessingConfigWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/PostProcessingConfigWindow.cpp
@@ -42,7 +42,7 @@ PostProcessingConfigWindow::PostProcessingConfigWindow(EnhancementsWidget* paren
     m_post_processor->LoadShader(m_shader);
   }
 
-  setWindowTitle(tr("Post Processing Shader Configuration"));
+  setWindowTitle(tr("Post-Processing Shader Configuration"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   PopulateGroups();


### PR DESCRIPTION
I've updated the graphics config descriptions for overall consistency. They've been edited for the format:

- Brief sentence describing what the option does (with the verb in the form of what the option itself does as opposed to what the user can do with the option)
- 2 line breaks (one blank line in between)
- Further notes to user (with necessary line breaks between)
- 2 line breaks
- Brief sentence recommending the best setting

I also removed any contractions and made the descriptions more concise where I could. I didn't touch the ubershaders descriptions as IIRC there was already a lengthy discussion over the best wording for them.

Additionally on the Post-Processing config window I added a dash in the title.