### PR TITLE
Qt/MemoryViewWidget: Allow toggling view between RAM & ExRAM

### DIFF
--- a/Source/Core/Common/Swap.h
+++ b/Source/Core/Common/Swap.h
@@ -126,6 +126,32 @@ inline u64 swap64(const u8* data)
   return swap64(value);
 }
 
+// Overloaded byteswap functions.
+inline u8 bswap(u8 val)
+{
+  return val;
+}
+inline s8 bswap(s8 val)
+{
+  return val;
+}
+inline u16 bswap(u16 val)
+{
+  return Common::swap16(val);
+}
+inline s16 bswap(s16 val)
+{
+  return Common::swap16(val);
+}
+inline u32 bswap(u32 val)
+{
+  return Common::swap32(val);
+}
+inline u64 bswap(u64 val)
+{
+  return Common::swap64(val);
+}
+
 template <int count>
 void swap(u8*);
 

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -216,8 +216,7 @@ unsigned int PPCDebugInterface::ReadExtraMemory(int memory, unsigned int address
   case 0:
     return PowerPC::HostRead_U32(address);
   case 1:
-    return (DSP::ReadARAM(address) << 24) | (DSP::ReadARAM(address + 1) << 16) |
-           (DSP::ReadARAM(address + 2) << 8) | (DSP::ReadARAM(address + 3));
+    return DSP::ReadARAM_U32(address);
   default:
     return 0;
   }

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -73,8 +73,19 @@ void DoState(PointerWrap& p);
 void GenerateDSPInterruptFromDSPEmu(DSPInterruptType type, int cycles_into_future = 0);
 
 // Audio/DSP Helper
-u8 ReadARAM(u32 address);
-void WriteARAM(u8 value, u32 address);
+u8 ReadARAM_U8(u32 address);
+u16 ReadARAM_U16(u32 address);
+u32 ReadARAM_U32(u32 address);
+u64 ReadARAM_U64(u32 address);
+float ReadARAM_F32(u32 address);
+double ReadARAM_F64(u32 address);
+
+void WriteARAM_U8(u8 value, u32 address);
+void WriteARAM_U16(u16 value, u32 address);
+void WriteARAM_U32(u32 value, u32 address);
+void WriteARAM_U64(u64 value, u32 address);
+void WriteARAM_F32(float value, u32 address);
+void WriteARAM_F64(double value, u32 address);
 
 // Debugger Helper
 u8* GetARAMPtr();

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -208,8 +208,8 @@ protected:
     }
   }
 
-  u8 ReadMemory(u32 address) override { return ReadARAM(address); }
-  void WriteMemory(u32 address, u8 value) override { WriteARAM(value, address); }
+  u8 ReadMemory(u32 address) override { return ReadARAM_U8(address); }
+  void WriteMemory(u32 address, u8 value) override { WriteARAM_U8(value, address); }
 };
 
 static std::unique_ptr<Accelerator> s_accelerator = std::make_unique<HLEAccelerator>();

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -30,12 +30,12 @@ namespace Host
 {
 u8 ReadHostMemory(u32 addr)
 {
-  return DSP::ReadARAM(addr);
+  return DSP::ReadARAM_U8(addr);
 }
 
 void WriteHostMemory(u8 value, u32 addr)
 {
-  DSP::WriteARAM(value, addr);
+  DSP::WriteARAM_U8(value, addr);
 }
 
 void OSD_AddMessage(const std::string& str, u32 ms)

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -46,37 +46,6 @@ GXPeekZ
 80322e0c: blr
 */
 
-// =================================
-// From Memmap.cpp
-// ----------------
-
-// Overloaded byteswap functions, for use within the templated functions below.
-inline u8 bswap(u8 val)
-{
-  return val;
-}
-inline s8 bswap(s8 val)
-{
-  return val;
-}
-inline u16 bswap(u16 val)
-{
-  return Common::swap16(val);
-}
-inline s16 bswap(s16 val)
-{
-  return Common::swap16(val);
-}
-inline u32 bswap(u32 val)
-{
-  return Common::swap32(val);
-}
-inline u64 bswap(u64 val)
-{
-  return Common::swap64(val);
-}
-// =================
-
 enum class XCheckTLBFlag
 {
   NoException,
@@ -214,7 +183,7 @@ static T ReadFromHardware(u32 em_address)
     // TODO: Only the first REALRAM_SIZE is supposed to be backed by actual memory.
     T value;
     std::memcpy(&value, &Memory::m_pRAM[em_address & Memory::RAM_MASK], sizeof(T));
-    return bswap(value);
+    return Common::bswap(value);
   }
 
   if (Memory::m_pEXRAM && (em_address >> 28) == 0x1 &&
@@ -222,7 +191,7 @@ static T ReadFromHardware(u32 em_address)
   {
     T value;
     std::memcpy(&value, &Memory::m_pEXRAM[em_address & 0x0FFFFFFF], sizeof(T));
-    return bswap(value);
+    return Common::bswap(value);
   }
 
   // Locked L1 technically doesn't have a fixed address, but games all use 0xE0000000.
@@ -230,7 +199,7 @@ static T ReadFromHardware(u32 em_address)
   {
     T value;
     std::memcpy(&value, &Memory::m_pL1Cache[em_address & 0x0FFFFFFF], sizeof(T));
-    return bswap(value);
+    return Common::bswap(value);
   }
   // In Fake-VMEM mode, we need to map the memory somewhere into
   // physical memory for BAT translation to work; we currently use
@@ -239,7 +208,7 @@ static T ReadFromHardware(u32 em_address)
   {
     T value;
     std::memcpy(&value, &Memory::m_pFakeVMEM[em_address & Memory::RAM_MASK], sizeof(T));
-    return bswap(value);
+    return Common::bswap(value);
   }
 
   if (flag == XCheckTLBFlag::Read && (em_address & 0xF8000000) == 0x08000000)
@@ -281,7 +250,7 @@ static void WriteToHardware(u32 em_address, const T data)
           GenerateDSIException(em_address_next_page, true);
         return;
       }
-      T val = bswap(data);
+      T val = Common::bswap(data);
       u32 addr_translated = translated_addr.address;
       for (size_t i = 0; i < sizeof(T); i++, addr_translated++)
       {
@@ -301,7 +270,7 @@ static void WriteToHardware(u32 em_address, const T data)
     // Handle RAM; the masking intentionally discards bits (essentially creating
     // mirrors of memory).
     // TODO: Only the first REALRAM_SIZE is supposed to be backed by actual memory.
-    const T swapped_data = bswap(data);
+    const T swapped_data = Common::bswap(data);
     std::memcpy(&Memory::m_pRAM[em_address & Memory::RAM_MASK], &swapped_data, sizeof(T));
     return;
   }
@@ -309,7 +278,7 @@ static void WriteToHardware(u32 em_address, const T data)
   if (Memory::m_pEXRAM && (em_address >> 28) == 0x1 &&
       (em_address & 0x0FFFFFFF) < Memory::EXRAM_SIZE)
   {
-    const T swapped_data = bswap(data);
+    const T swapped_data = Common::bswap(data);
     std::memcpy(&Memory::m_pEXRAM[em_address & 0x0FFFFFFF], &swapped_data, sizeof(T));
     return;
   }
@@ -317,7 +286,7 @@ static void WriteToHardware(u32 em_address, const T data)
   // Locked L1 technically doesn't have a fixed address, but games all use 0xE0000000.
   if ((em_address >> 28 == 0xE) && (em_address < (0xE0000000 + Memory::L1_CACHE_SIZE)))
   {
-    const T swapped_data = bswap(data);
+    const T swapped_data = Common::bswap(data);
     std::memcpy(&Memory::m_pL1Cache[em_address & 0x0FFFFFFF], &swapped_data, sizeof(T));
     return;
   }
@@ -327,7 +296,7 @@ static void WriteToHardware(u32 em_address, const T data)
   // [0x7E000000, 0x80000000).
   if (Memory::m_pFakeVMEM && ((em_address & 0xFE000000) == 0x7E000000))
   {
-    const T swapped_data = bswap(data);
+    const T swapped_data = Common::bswap(data);
     std::memcpy(&Memory::m_pFakeVMEM[em_address & Memory::RAM_MASK], &swapped_data, sizeof(T));
     return;
   }

--- a/Source/Core/DolphinQt2/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt2/Debugger/MemoryViewWidget.h
@@ -12,6 +12,12 @@ class MemoryViewWidget : public QTableWidget
 {
   Q_OBJECT
 public:
+  enum class MemoryType
+  {
+    RAM,
+    ExRAM
+  };
+
   enum class Type
   {
     U8,
@@ -35,12 +41,14 @@ public:
   void ToggleRowBreakpoint(bool row);
 
   void SetType(Type type);
+  void SetMemoryType(MemoryType type);
   void SetBPType(BPType type);
   void SetAddress(u32 address);
 
   void SetBPLoggingEnabled(bool enabled);
 
   u32 GetContextAddress() const;
+  MemoryType GetMemoryType() const;
 
   void resizeEvent(QResizeEvent*) override;
   void keyPressEvent(QKeyEvent* event) override;
@@ -55,6 +63,7 @@ private:
   void OnCopyAddress();
   void OnCopyHex();
 
+  MemoryType m_mem_type = MemoryType::RAM;
   Type m_type = Type::U8;
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;

--- a/Source/Core/DolphinQt2/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt2/Debugger/MemoryWidget.h
@@ -37,6 +37,7 @@ private:
   void SaveSettings();
 
   void OnTypeChanged();
+  void OnMemoryTypeChanged();
   void OnBPLogChanged();
   void OnBPTypeChanged();
 
@@ -79,6 +80,10 @@ private:
   QRadioButton* m_type_u32;
   QRadioButton* m_type_ascii;
   QRadioButton* m_type_float;
+
+  // Memory Types
+  QRadioButton* m_mem_type_ram;
+  QRadioButton* m_mem_type_exram;
 
   // Breakpoint options
   QRadioButton* m_bp_read_write;


### PR DESCRIPTION
This feature was present in DolphinWx, but never was added to Qt. I also added additional DSP helper methods to make it more inline with the methods from MMU. ExRAM breakpoints aren't supported currently.

![image](https://user-images.githubusercontent.com/24523422/42132377-c017498e-7ce4-11e8-841f-0f18fcbdf665.png)
