### PR TITLE
Qt/GameList: Change multiselection deletion name for consistency

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -239,7 +239,7 @@ void GameList::ShowContextMenu(const QPoint&)
       menu->addSeparator();
     }
 
-    AddAction(menu, tr("Delete selected ISOs..."), this, &GameList::DeleteFile);
+    AddAction(menu, tr("Delete selected files..."), this, &GameList::DeleteFile);
   }
   else
   {


### PR DESCRIPTION
When deleting any game file individually the menu item reads "Delete File...", so for consistency it makes sense that when multiselecting game files the menu item should read "Delete selected files...".