### PR TITLE
dqt2: lazy-initialize GraphicsWindow

### DIFF
--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.cpp
@@ -27,6 +27,17 @@
 GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent)
     : QDialog(parent), m_xrr_config(xrr_config)
 {
+  // GraphicsWindow initialization is heavy due to dependencies on the graphics subsystem.
+  // To prevent blocking startup, we create the layout and children at first show time.
+}
+
+void GraphicsWindow::Initialize()
+{
+  if (m_lazy_initialized)
+    return;
+
+  m_lazy_initialized = true;
+
   g_Config.Refresh();
   g_video_backend->InitBackendInfo();
 

--- a/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
+++ b/Source/Core/DolphinQt2/Config/Graphics/GraphicsWindow.h
@@ -29,6 +29,8 @@ class GraphicsWindow final : public QDialog
 public:
   explicit GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent);
 
+  void Initialize();
+
   void RegisterWidget(GraphicsWidget* widget);
   bool eventFilter(QObject* object, QEvent* event) override;
 signals:
@@ -38,6 +40,8 @@ private:
   void CreateMainLayout();
   void OnBackendChanged(const QString& backend);
   void OnDescriptionAdded(QWidget* widget, const char* description);
+
+  bool m_lazy_initialized = false;
 
   QTabWidget* m_tab_widget;
   QLabel* m_description;

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -935,6 +935,7 @@ void MainWindow::ShowHotkeyDialog()
 
 void MainWindow::ShowGraphicsWindow()
 {
+  m_graphics_window->Initialize();
   m_graphics_window->show();
   m_graphics_window->raise();
   m_graphics_window->activateWindow();


### PR DESCRIPTION
Initializing GraphicsWindow layout & children requires cooperation from
the graphics stack: on my system, for example, it causes a Vulkan
context to get created in order to get driver info. This is a slow
operation, and right now it is taking about 60-70% of the Dolphin
startup time on my system.

Move instead to a lazy-initialization model where the constructor
does nothing, instead offloading work to a separate Initialize() method
called before the window is shown.

I would expect this should be done for other larger parts of the UI,
especially the ones where creating widgets ends up triggering large IO
subsystems (I suspect controller configuration might be doing that).

(I'm not super happy with how this is implemented, but right now it's a
one-off, and it's a major complaint users have with the new UI. I
prioritized getting something working quickly...)