### PR TITLE
Android: Upgrade targetSDK to 27 and androidSupportVersion to 7.1.1

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion '27.0.3'
 
     compileOptions {
@@ -23,7 +23,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
-        targetSdkVersion 25
+        targetSdkVersion 27
 
         versionCode(getBuildVersionCode())
 
@@ -75,7 +75,7 @@ android {
 }
 
 ext {
-    androidSupportVersion = '26.1.0'
+    androidSupportVersion = '27.1.1'
 }
 
 dependencies {


### PR DESCRIPTION
Seems that Oreo buildTools are still on Alpha version so I will just update to Android 7 for now