### PR TITLE
Qt: Unparent NetPlay dialog from main window

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -156,6 +156,7 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters) : QMainW
 MainWindow::~MainWindow()
 {
   m_render_widget->deleteLater();
+  m_netplay_dialog->deleteLater();
   ShutdownControllers();
 
   QSettings& settings = Settings::GetQSettings();
@@ -1037,7 +1038,7 @@ void MainWindow::BootWiiSystemMenu()
 void MainWindow::NetPlayInit()
 {
   m_netplay_setup_dialog = new NetPlaySetupDialog(this);
-  m_netplay_dialog = new NetPlayDialog(this);
+  m_netplay_dialog = new NetPlayDialog;
 
   connect(m_netplay_dialog, &NetPlayDialog::Boot, this,
           [this](const QString& path) { StartGame(path); });

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.cpp
@@ -42,6 +42,7 @@
 #include "DolphinQt2/NetPlay/PadMappingDialog.h"
 #include "DolphinQt2/QtUtils/QueueOnObject.h"
 #include "DolphinQt2/QtUtils/RunOnObject.h"
+#include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 
 #include "VideoCommon/VideoConfig.h"
@@ -52,6 +53,7 @@ NetPlayDialog::NetPlayDialog(QWidget* parent)
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   setWindowTitle(tr("NetPlay"));
+  setWindowIcon(Resources::GetAppIcon());
 
   m_pad_mapping = new PadMappingDialog(this);
   m_md5_dialog = new MD5Dialog(this);

--- a/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt2/NetPlay/NetPlayDialog.h
@@ -30,7 +30,7 @@ class NetPlayDialog : public QDialog, public NetPlayUI
 {
   Q_OBJECT
 public:
-  explicit NetPlayDialog(QWidget* parent);
+  explicit NetPlayDialog(QWidget* parent = nullptr);
   ~NetPlayDialog();
 
   void show(std::string nickname, bool use_traversal);


### PR DESCRIPTION
This should make the NetPlay dialog appear as a separate window in the taskbar on most systems, which makes more sense than a parented dialog as the user will leave it open for an extended period.