### PR TITLE
Fifo: Run/sync with the GPU on command processor register access

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -234,6 +234,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 
   mmio->Register(base | STATUS_REGISTER, MMIO::ComplexRead<u16>([](u32) {
+                   Fifo::SyncGPUForRegisterAccess();
                    SetCpStatusRegister();
                    return m_CPStatusReg.Hex;
                  }),
@@ -271,18 +272,21 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::DirectWrite<u16>(MMIO::Utils::LowPart(&fifo.CPReadWriteDistance),
                                         WMASK_LO_ALIGN_32BIT));
   mmio->Register(base | FIFO_RW_DISTANCE_HI,
-                 IsOnThread() ?
-                     MMIO::ComplexRead<u16>([](u32) {
-                       if (fifo.CPWritePointer >= fifo.SafeCPReadPointer)
-                         return ReadHigh(fifo.CPWritePointer - fifo.SafeCPReadPointer);
-                       else
-                         return ReadHigh(fifo.CPEnd - fifo.SafeCPReadPointer + fifo.CPWritePointer -
-                                         fifo.CPBase + 32);
-                     }) :
-                     MMIO::DirectRead<u16>(MMIO::Utils::HighPart(&fifo.CPReadWriteDistance)),
+                 IsOnThread() ? MMIO::ComplexRead<u16>([](u32) {
+                   Fifo::SyncGPUForRegisterAccess();
+                   if (fifo.CPWritePointer >= fifo.SafeCPReadPointer)
+                     return ReadHigh(fifo.CPWritePointer - fifo.SafeCPReadPointer);
+                   else
+                     return ReadHigh(fifo.CPEnd - fifo.SafeCPReadPointer + fifo.CPWritePointer -
+                                     fifo.CPBase + 32);
+                 }) :
+                                MMIO::ComplexRead<u16>([](u32) {
+                                  Fifo::SyncGPUForRegisterAccess();
+                                  return ReadHigh(fifo.CPReadWriteDistance);
+                                }),
                  MMIO::ComplexWrite<u16>([WMASK_HI_RESTRICT](u32, u16 val) {
+                   Fifo::SyncGPUForRegisterAccess();
                    WriteHigh(fifo.CPReadWriteDistance, val & WMASK_HI_RESTRICT);
-                   Fifo::SyncGPU(Fifo::SyncGPUReason::Other);
                    Fifo::RunGpu();
                  }));
   mmio->Register(
@@ -290,16 +294,24 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
       IsOnThread() ? MMIO::DirectRead<u16>(MMIO::Utils::LowPart(&fifo.SafeCPReadPointer)) :
                      MMIO::DirectRead<u16>(MMIO::Utils::LowPart(&fifo.CPReadPointer)),
       MMIO::DirectWrite<u16>(MMIO::Utils::LowPart(&fifo.CPReadPointer), WMASK_LO_ALIGN_32BIT));
-  mmio->Register(
-      base | FIFO_READ_POINTER_HI,
-      IsOnThread() ? MMIO::DirectRead<u16>(MMIO::Utils::HighPart(&fifo.SafeCPReadPointer)) :
-                     MMIO::DirectRead<u16>(MMIO::Utils::HighPart(&fifo.CPReadPointer)),
-      IsOnThread() ?
-          MMIO::ComplexWrite<u16>([WMASK_HI_RESTRICT](u32, u16 val) {
-            WriteHigh(fifo.CPReadPointer, val & WMASK_HI_RESTRICT);
-            fifo.SafeCPReadPointer = fifo.CPReadPointer;
-          }) :
-          MMIO::DirectWrite<u16>(MMIO::Utils::HighPart(&fifo.CPReadPointer), WMASK_HI_RESTRICT));
+  mmio->Register(base | FIFO_READ_POINTER_HI,
+                 IsOnThread() ? MMIO::ComplexRead<u16>([](u32) {
+                   Fifo::SyncGPUForRegisterAccess();
+                   return ReadHigh(fifo.SafeCPReadPointer);
+                 }) :
+                                MMIO::ComplexRead<u16>([](u32) {
+                                  Fifo::SyncGPUForRegisterAccess();
+                                  return ReadHigh(fifo.CPReadPointer);
+                                }),
+                 IsOnThread() ? MMIO::ComplexWrite<u16>([WMASK_HI_RESTRICT](u32, u16 val) {
+                   Fifo::SyncGPUForRegisterAccess();
+                   WriteHigh(fifo.CPReadPointer, val & WMASK_HI_RESTRICT);
+                   fifo.SafeCPReadPointer = fifo.CPReadPointer;
+                 }) :
+                                MMIO::ComplexWrite<u16>([WMASK_HI_RESTRICT](u32, u16 val) {
+                                  Fifo::SyncGPUForRegisterAccess();
+                                  WriteHigh(fifo.CPReadPointer, val & WMASK_HI_RESTRICT);
+                                }));
 }
 
 void GatherPipeBursted()

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -580,6 +580,16 @@ static void SyncGPUCallback(u64 ticks, s64 cyclesLate)
     CoreTiming::ScheduleEvent(next, s_event_sync_gpu, next);
 }
 
+void SyncGPUForRegisterAccess()
+{
+  SyncGPU(SyncGPUReason::Other);
+
+  if (!SConfig::GetInstance().bCPUThread || s_use_deterministic_gpu_thread)
+    RunGpuOnCpu(GPU_TIME_SLOT_SIZE);
+  else if (SConfig::GetInstance().bSyncGPU)
+    WaitForGpuThread(GPU_TIME_SLOT_SIZE);
+}
+
 // Initialize GPU - CPU thread syncing, this gives us a deterministic way to start the GPU thread.
 void Prepare()
 {

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -33,6 +33,10 @@ enum class SyncGPUReason
 // In deterministic GPU thread mode this waits for the GPU to be done with pending work.
 void SyncGPU(SyncGPUReason reason, bool may_move_read_ptr = true);
 
+// In single core mode, this runs the GPU for a single slice.
+// In dual core mode, this synchronizes with the GPU thread.
+void SyncGPUForRegisterAccess();
+
 void PushFifoAuxBuffer(const void* ptr, size_t size);
 void* PopFifoAuxBuffer(size_t size);
 


### PR DESCRIPTION
In Dolphin, we don't emulate the CPU and GPU in lock-step, for performance reasons. The CPU drives events, with the GPU emulation being one of these events which is fired periodically. This is the behavior in single core mode. Dual-core mode is completely non-deterministic here, and runs whenever Fifo::RunGpu() is called. Thus, I am mainly concerned about single-core mode.

Due to the GPU only being run every 1000 cycles or so, to a game, if it polled the command processor registers (for example, the read pointer, or distance), the GPU would appear to be stalled. Testing would suggest this is what causes FIFO resets/unknown opcodes in games such as F-Zero GX, and Rogue Squadron 3.

To work around this, each time these registers are accessed, we run the GPU for its time quantum. This way, to a game, the GPU is making progress (as it would on the console). While this isn't necessarily accurate to the hardware in terms of cycles executed, we don't *really* emulate GPU timings anyway, so executing a few extra GPU cycles doesn't really have any impact.

In dual core, it syncs with the GPU thread, and ensures that the GPU thread isn't too far behind. Again, this is not deterministic, but dual core isn't to begin with, and has numerous stability issues as a result.

Long-term, I'm planning on refactoring the FIFO in a way which resembles the current state of deterministic dual core - read from memory on the CPU thread, but process the commands on the GPU thread. This will lead to determinism for command processor behavior (e.g. FIFO breakpoints, hi/low watermark interrupts), except EFB copies to RAM, and BP token interrupts.

However, this is a much more significant task, with far larger chances of regressions, so I pulled this change out to fix RS3, in the meantime, at least. And perhaps new motivation to make full MMU faster ;).