### PR TITLE
VideoCommon/DolphinQt2: Resolve compiler warnings

### DIFF
--- a/Source/Core/DolphinQt/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.cpp
@@ -20,7 +20,7 @@
 #include "UICommon/GameFile.h"
 
 PatchesWidget::PatchesWidget(const UICommon::GameFile& game)
-    : m_game(game), m_game_id(game.GetGameID()), m_game_revision(game.GetRevision())
+    : m_game_id(game.GetGameID()), m_game_revision(game.GetRevision())
 {
   IniFile game_ini_local;
   game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");

--- a/Source/Core/DolphinQt/Config/PatchesWidget.h
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.h
@@ -48,7 +48,6 @@ private:
   QPushButton* m_remove_button;
 
   std::vector<PatchEngine::Patch> m_patches;
-  const UICommon::GameFile& m_game;
   std::string m_game_id;
   u16 m_game_revision;
 };

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -32,7 +32,7 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
 
   connect(this, &QFileSystemWatcher::directoryChanged, this, &GameTracker::UpdateDirectory);
   connect(this, &QFileSystemWatcher::fileChanged, this, &GameTracker::UpdateFile);
-  connect(&Settings::Instance(), &Settings::AutoRefreshToggled, this, [this] {
+  connect(&Settings::Instance(), &Settings::AutoRefreshToggled, this, [] {
     const auto paths = Settings::Instance().GetPaths();
 
     for (const auto& path : paths)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1515,14 +1515,15 @@ TextureCacheBase::CopyFilterCoefficientArray TextureCacheBase::GetRAMCopyFilterC
 {
   // To simplify the backend, we precalculate the three coefficients in common. Coefficients 0, 1
   // are for the row above, 2, 3, 4 are for the current pixel, and 5, 6 are for the row below.
-  return {
+  return {{
       static_cast<float>(static_cast<u32>(coefficients[0]) + static_cast<u32>(coefficients[1])) /
           64.0f,
       static_cast<float>(static_cast<u32>(coefficients[2]) + static_cast<u32>(coefficients[3]) +
                          static_cast<u32>(coefficients[4])) /
           64.0f,
       static_cast<float>(static_cast<u32>(coefficients[5]) + static_cast<u32>(coefficients[6])) /
-          64.0f};
+          64.0f,
+  }};
 }
 
 TextureCacheBase::CopyFilterCoefficientArray TextureCacheBase::GetVRAMCopyFilterCoefficients(


### PR DESCRIPTION
This resolves trivial `-Wmissing-braces`, `-Wunused-lambda-capture`, and `-Wunused-private-field` warnings that occur when compiling with clang.