### PR TITLE
Convert Dolphin.Core.DefaultISO to use new-style config

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -31,6 +31,7 @@
 #include "Core/Boot/DolReader.h"
 #include "Core/Boot/ElfReader.h"
 #include "Core/CommonTitles.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
@@ -291,9 +292,9 @@ bool CBoot::Load_BS2(const std::string& boot_rom_filename)
 
 static void SetDefaultDisc()
 {
-  const SConfig& config = SConfig::GetInstance();
-  if (!config.m_strDefaultISO.empty())
-    SetDisc(DiscIO::CreateVolumeFromFilename(config.m_strDefaultISO));
+  const std::string default_iso = Config::Get(Config::MAIN_DEFAULT_ISO);
+  if (!default_iso.empty())
+    SetDisc(DiscIO::CreateVolumeFromFilename(default_iso));
 }
 
 static void CopyDefaultExceptionHandlers()

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/Config/Config.h"
 #include "Core/Config/GraphicsSettings.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 
 namespace ConfigLoaders
@@ -25,6 +26,8 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
     return true;
 
   const static std::vector<Config::ConfigLocation> s_setting_saveable{
+      Config::MAIN_DEFAULT_ISO.location,
+
       // Graphics.Hardware
 
       Config::GFX_VSYNC.location,

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -229,7 +229,6 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("SyncGpuOverclock", fSyncGpuOverclock);
   core->Set("FPRF", bFPRF);
   core->Set("AccurateNaNs", bAccurateNaNs);
-  core->Set("DefaultISO", m_strDefaultISO);
   core->Set("EnableCheats", bEnableCheats);
   core->Set("SelectedLanguage", SelectedLanguage);
   core->Set("OverrideGCLang", bOverrideGCLanguage);
@@ -516,7 +515,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("TimingVariance", &iTimingVariance, 40);
   core->Get("CPUThread", &bCPUThread, true);
   core->Get("SyncOnSkipIdle", &bSyncGPUOnSkipIdleHack, true);
-  core->Get("DefaultISO", &m_strDefaultISO);
   core->Get("EnableCheats", &bEnableCheats, false);
   core->Get("SelectedLanguage", &SelectedLanguage, 0);
   core->Get("OverrideGCLang", &bOverrideGCLanguage, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -191,7 +191,6 @@ struct SConfig
   // files
   std::string m_strBootROM;
   std::string m_strSRAM;
-  std::string m_strDefaultISO;
 
   std::string m_perfDir;
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -30,6 +30,7 @@
 #include "Core/Boot/Boot.h"
 #include "Core/BootManager.h"
 #include "Core/CommonTitles.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/NetplaySettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -595,7 +596,7 @@ void MainWindow::Play(const std::optional<std::string>& savestate_path)
     }
     else
     {
-      QString default_path = QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);
+      const QString default_path = QString::fromStdString(Config::Get(Config::MAIN_DEFAULT_ISO));
       if (!default_path.isEmpty() && QFile::exists(default_path))
       {
         StartGame(default_path, savestate_path);

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -16,6 +16,7 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
@@ -150,14 +151,14 @@ void Settings::SetAutoRefreshEnabled(bool enabled)
 
 QString Settings::GetDefaultGame() const
 {
-  return QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);
+  return QString::fromStdString(Config::Get(Config::MAIN_DEFAULT_ISO));
 }
 
 void Settings::SetDefaultGame(QString path)
 {
   if (GetDefaultGame() != path)
   {
-    SConfig::GetInstance().m_strDefaultISO = path.toStdString();
+    Config::SetBase(Config::MAIN_DEFAULT_ISO, path.toStdString());
     emit DefaultGameChanged(path);
   }
 }


### PR DESCRIPTION
So that you can do things like:

```bash
dolphin-emu \
  -C Dolphin.General.WiiSDCardPath=smash-bros-legacy-xp-sd.raw \
  -C Dolphin.Core.DefaultISO=brawl.gcz \
  legacy-xp-launcher.wad
```

which is useful when you want to be able to launch different mods without reconfiguring Dolphin each time (e.g. from Steam).

Wasn't sure whether to call `SetBase` or `SetBaseCurrent`, so followed the example of `Config::MAIN_SD_PATH` which uses the former.