### PR TITLE
Interpreter: Remove an unnecessary cast in Trace()

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -94,9 +94,9 @@ static void Trace(UGeckoInstruction& inst)
 
   const std::string ppc_inst = Common::GekkoDisassembler::Disassemble(inst.hex, PC);
   DEBUG_LOG(POWERPC,
-            "INTER PC: %08x SRR0: %08x SRR1: %08x CRval: %016lx FPSCR: %08x MSR: %08x LR: "
+            "INTER PC: %08x SRR0: %08x SRR1: %08x CRval: %016" PRIx64 " FPSCR: %08x MSR: %08x LR: "
             "%08x %s %08x %s",
-            PC, SRR0, SRR1, (unsigned long)PowerPC::ppcState.cr_val[0], FPSCR.Hex, MSR.Hex,
+            PC, SRR0, SRR1, PowerPC::ppcState.cr_val[0], FPSCR.Hex, MSR.Hex,
             PowerPC::ppcState.spr[8], regs.c_str(), inst.hex, ppc_inst.c_str());
 }
 


### PR DESCRIPTION
PowerPCState's `cr_val` member is an array of `u64`s, so we can just use the correct printf macro specifier within `<cinttypes>`. This also avoids truncation on operating systems that use an LLP64 data model (like
Windows), where long is actually 32 bits in size, not 64-bit, which could result in wonky values being printed, should Trace ever be used on it.

Alternatively, if Trace() is a vestigial part of the interpreter, we can just remove it entirely.