### PR TITLE
RenderBase: don't clamp draw size to window

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -538,10 +538,6 @@ void Renderer::UpdateDrawRectangle()
     crop_width = win_width;
   }
 
-  // Clamp the draw width/height to the screen size, to ensure we don't render off-screen.
-  draw_width = std::min(draw_width, win_width);
-  draw_height = std::min(draw_height, win_height);
-
   // ensure divisibility by 4 to make it compatible with all the video encoders
   draw_width = std::ceil(draw_width) - static_cast<int>(std::ceil(draw_width)) % 4;
   draw_height = std::ceil(draw_height) - static_cast<int>(std::ceil(draw_height)) % 4;


### PR DESCRIPTION
It distorts the aspect ratio when cropping, rather than actually cropping.