### PR TITLE
NetPlay: Send timebase packet less frequently

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1236,15 +1236,20 @@ void NetPlayClient::SendTimeBase()
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 
-  u64 timebase = SystemTimers::GetFakeTimeBase();
+  if (netplay_client->m_timebase_frame % 60 == 0)
+  {
+    u64 timebase = SystemTimers::GetFakeTimeBase();
 
-  sf::Packet packet;
-  packet << static_cast<MessageId>(NP_MSG_TIMEBASE);
-  packet << static_cast<u32>(timebase);
-  packet << static_cast<u32>(timebase << 32);
-  packet << netplay_client->m_timebase_frame++;
+    sf::Packet packet;
+    packet << static_cast<MessageId>(NP_MSG_TIMEBASE);
+    packet << static_cast<u32>(timebase);
+    packet << static_cast<u32>(timebase << 32);
+    packet << netplay_client->m_timebase_frame;
 
-  netplay_client->SendAsync(std::move(packet));
+    netplay_client->SendAsync(std::move(packet));
+  }
+
+  netplay_client->m_timebase_frame++;
 }
 
 bool NetPlayClient::DoAllPlayersHaveGame()


### PR DESCRIPTION
This packet is only used by the host to detect desyncs, and we don't really *need* to know the exact frame we desynced on (unless you're debugging, but you can just recompile for that), so it's perfectly fine to just send it less often. This makes it so the timebase packet is sent only every 60 frames, rather than every frame, which further cuts back on unnecessary bandwidth consumption.