### PR TITLE
NetPlay: Change "Reduce Polling Rate" to poll twice per frame

### DIFF
--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -11,8 +11,6 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/Config/Config.h"
-#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/MMIO.h"
@@ -624,11 +622,7 @@ SIDevices GetDeviceType(int channel)
 
 u32 GetPollXLines()
 {
-  // Returning 0 here effectively makes polling happen once per frame, as this is used to increment
-  // a value in VI for when the next SI poll happens. This should normally only be set during
-  // NetPlay, as it does not matter for a non-networked session. However, it may also be set during
-  // movie playback for movies recorded during NetPlay.
-  return Config::Get(Config::MAIN_REDUCE_POLLING_RATE) ? 0 : s_poll.X;
+  return s_poll.X;
 }
 
 }  // end of namespace SerialInterface

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -14,6 +14,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -731,7 +732,13 @@ void Update(u64 ticks)
   if (s_half_line_of_next_si_poll == s_half_line_count)
   {
     SerialInterface::UpdateDevices();
-    s_half_line_of_next_si_poll += SerialInterface::GetPollXLines();
+
+    // If this setting is enabled, only poll twice per field instead of what the game wanted. It may
+    // be set during NetPlay or Movie playback.
+    if (Config::Get(Config::MAIN_REDUCE_POLLING_RATE))
+      s_half_line_of_next_si_poll += GetHalfLinesPerEvenField() / 2;
+    else
+      s_half_line_of_next_si_poll += SerialInterface::GetPollXLines();
   }
   if (s_half_line_count == s_even_field_first_hl)
   {
@@ -819,4 +826,4 @@ void FakeVIUpdate(u32 xfb_address, u32 fb_width, u32 fb_height)
   }
 }
 
-}  // namespace
+}  // namespace VideoInterface

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -123,8 +123,8 @@ void NetPlayDialog::CreateMainLayout()
   m_md5_button->setMenu(menu);
 
   m_reduce_polling_rate_box->setToolTip(
-      tr("This will reduce bandwidth usage, but may add up to one frame of additional latency, as "
-         "controllers will be polled only once per frame."));
+      tr("This will reduce bandwidth usage by polling GameCube controllers only twice per frame. "
+         "Does not affect Wii Remotes."));
 
   m_main_layout->addWidget(m_game_button, 0, 0);
   m_main_layout->addWidget(m_md5_button, 0, 1);


### PR DESCRIPTION
I discovered in testing that a few games (such as Mario Kart: Double Dash) don't play nice when we poll only once per frame, so this changes it to twice per frame. It will use a bit more bandwidth, but that should be compensated for by the savings from #7231.

As an additional note, this is actually how NetPlay polled back in 4.0, but the polling code back then also caused issues in more games even with "full speed" polling, as it wasn't timed correctly.