### PR TITLE
DolphinQt/Settings: Replace includes with forward declarations

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/MD5Dialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/MD5Dialog.cpp
@@ -13,6 +13,9 @@
 #include <QProgressBar>
 #include <QVBoxLayout>
 
+#include "Core/NetPlayClient.h"
+#include "Core/NetPlayServer.h"
+
 #include "DolphinQt/Settings.h"
 
 static QString GetPlayerNameFromPID(int pid)

--- a/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
@@ -3,14 +3,16 @@
 // Refer to the license.txt file included.
 
 #include "DolphinQt/NetPlay/PadMappingDialog.h"
-#include "DolphinQt/Settings.h"
-
-#include "Core/NetPlayClient.h"
 
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QGridLayout>
 #include <QLabel>
+
+#include "Core/NetPlayClient.h"
+#include "Core/NetPlayServer.h"
+
+#include "DolphinQt/Settings.h"
 
 PadMappingDialog::PadMappingDialog(QWidget* parent) : QDialog(parent)
 {

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -19,6 +19,8 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/NetPlayClient.h"
+#include "Core/NetPlayServer.h"
 
 #include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
@@ -37,6 +39,8 @@ Settings::Settings()
 
   SetCurrentUserStyle(GetCurrentUserStyle());
 }
+
+Settings::~Settings() = default;
 
 Settings& Settings::Instance()
 {

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -11,9 +11,6 @@
 #include <QSettings>
 #include <QVector>
 
-#include "Core/NetPlayClient.h"
-#include "Core/NetPlayServer.h"
-
 namespace Core
 {
 enum class State;
@@ -22,6 +19,12 @@ enum class State;
 namespace DiscIO
 {
 enum class Language;
+}
+
+namespace NetPlay
+{
+class NetPlayClient;
+class NetPlayServer;
 }
 
 class GameListModel;
@@ -38,6 +41,8 @@ public:
   Settings& operator=(const Settings&) = delete;
   Settings(Settings&&) = delete;
   Settings& operator=(Settings&&) = delete;
+
+  ~Settings();
 
   static Settings& Instance();
   static QSettings& GetQSettings();


### PR DESCRIPTION
Avoids dragging in netplay-related headers where they aren't explicitly necessary.