### PR TITLE
NetPlayClient: Make global NetSettings instance part of the NetPlayClient class

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -336,7 +336,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
 
   if (NetPlay::IsNetPlayRunning())
   {
-    const NetPlay::NetSettings& netplay_settings = NetPlay::g_NetPlaySettings;
+    const NetPlay::NetSettings& netplay_settings = NetPlay::GetNetSettings();
     Config::AddLayer(ConfigLoaders::GenerateNetPlayConfigLoader(netplay_settings));
     StartUp.bCPUThread = netplay_settings.m_CPUthread;
     StartUp.bEnableCheats = netplay_settings.m_EnableCheats;

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -75,6 +75,7 @@ public:
 
   void GetPlayerList(std::string& list, std::vector<int>& pid_list);
   std::vector<const Player*> GetPlayers();
+  const NetSettings& GetNetSettings() const;
 
   // Called from the GUI thread.
   bool IsConnected() const { return m_is_connected; }
@@ -173,6 +174,7 @@ private:
   ConnectionState m_connection_state = ConnectionState::Failure;
 
   PlayerId m_pid = 0;
+  NetSettings m_net_settings{};
   std::map<PlayerId, Player> m_players;
   std::string m_host_spec;
   std::string m_player_name;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -49,7 +49,6 @@ struct NetTraversalConfig
   u16 traversal_port = 0;
 };
 
-extern NetSettings g_NetPlaySettings;
 extern u64 g_netplay_initial_rtc;
 
 struct Rpt : public std::vector<u8>
@@ -112,4 +111,8 @@ using PadMapping = s8;
 using PadMappingArray = std::array<PadMapping, 4>;
 
 bool IsNetPlayRunning();
+
+// Precondition: A netplay client instance must be present. In other words,
+//               IsNetPlayRunning() must be true before calling this.
+const NetSettings& GetNetSettings();
 }  // namespace NetPlay


### PR DESCRIPTION
This is only ever read from externally, so we can expose a getter that ensures that immutability, while making the actual instance internal. Given the filling out of these settings depends on packets received by the client instance, it makes more sense to make it a part of the client itself.

This trims off one lingering global.