### PR TITLE
Updater: fix immediate manual updating

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -499,7 +499,7 @@ void MenuBar::InstallUpdateManually()
 
   track = "dev";
 
-  auto* updater = new Updater(this);
+  auto* updater = new Updater(this->parentWidget());
 
   if (!updater->CheckForUpdate())
   {


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/11270

Triggering a manual update was passing a reference to the menu bar to the updater instead of a reference to the root window.  When the updater eventually called close() on the passed reference, it was leaving the main window intact until the user manually closed it later.