### PR TITLE
Common/DebugInterface: Namespace code under the Common namespace

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -13,6 +13,8 @@
 #include "Common/Debug/MemoryPatches.h"
 #include "Common/Debug/Watches.h"
 
+namespace Common
+{
 class DebugInterface
 {
 protected:
@@ -75,3 +77,4 @@ public:
   virtual std::string GetDescription(unsigned int /*address*/) = 0;
   virtual void Clear() = 0;
 };
+}  // namespace Common

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -17,7 +17,7 @@ private:
 
 // wrapper between disasm control and Dolphin debugger
 
-class PPCDebugInterface final : public DebugInterface
+class PPCDebugInterface final : public Common::DebugInterface
 {
 public:
   PPCDebugInterface() {}

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -20,7 +20,7 @@ private:
   void Patch(std::size_t index) override;
 };
 
-class DSPDebugInterface final : public DebugInterface
+class DSPDebugInterface final : public Common::DebugInterface
 {
 public:
   DSPDebugInterface() {}

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -226,7 +226,7 @@ bool MemChecks::OverlapsMemcheck(u32 address, u32 length) const
   });
 }
 
-bool TMemCheck::Action(DebugInterface* debug_interface, u32 value, u32 addr, bool write,
+bool TMemCheck::Action(Common::DebugInterface* debug_interface, u32 value, u32 addr, bool write,
                        size_t size, u32 pc)
 {
   if ((write && is_break_on_write) || (!write && is_break_on_read))

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -10,7 +10,10 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Common
+{
 class DebugInterface;
+}
 
 struct TBreakPoint
 {
@@ -35,7 +38,8 @@ struct TMemCheck
   u32 num_hits = 0;
 
   // returns whether to break
-  bool Action(DebugInterface* dbg_interface, u32 value, u32 addr, bool write, size_t size, u32 pc);
+  bool Action(Common::DebugInterface* dbg_interface, u32 value, u32 addr, bool write, size_t size,
+              u32 pc);
 };
 
 // Code breakpoints.

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -39,7 +39,7 @@ public:
   void LogFunctionCall(u32 addr);
 
 private:
-  DebugInterface* debugger;
+  Common::DebugInterface* debugger;
 };
 
 extern PPCSymbolDB g_symbolDB;


### PR DESCRIPTION
Gets more identifiers out of the global namespace and makes it more in line with the rest of the (mostly) namespaced Common code.