### PR TITLE
NetPlay: Fix SRAM desyncing after first boot

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -145,10 +145,6 @@ CEXIIPL::~CEXIIPL()
     File::IOFile file(SConfig::GetInstance().m_strSRAM, "wb");
     file.WriteArray(&g_SRAM, 1);
   }
-  else
-  {
-    g_SRAM_netplay_initialized = false;
-  }
 }
 void CEXIIPL::DoState(PointerWrap& p)
 {


### PR DESCRIPTION
The bool preventing the local SRAM from being loaded would be cleared on core shutdown, so on subsequent boots in the same NetPlay session it would no longer use the synced one.