### PR TITLE
Qt/CheatsManager: Move concealable types into the cpp file

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -41,6 +41,35 @@ constexpr u32 MAX_RESULTS = 50;
 constexpr int INDEX_ROLE = Qt::UserRole;
 constexpr int COLUMN_ROLE = Qt::UserRole + 1;
 
+enum class CompareType : int
+{
+  Equal = 0,
+  NotEqual = 1,
+  Less = 2,
+  LessEqual = 3,
+  More = 4,
+  MoreEqual = 5
+};
+
+enum class DataType : int
+{
+  Byte = 0,
+  Short = 1,
+  Int = 2,
+  Float = 3,
+  Double = 4,
+  String = 5
+};
+
+struct Result
+{
+  u32 address;
+  DataType type;
+  QString name;
+  bool locked = false;
+  u32 locked_value;
+};
+
 CheatsManager::CheatsManager(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Cheats Manager"));
@@ -56,6 +85,8 @@ CheatsManager::CheatsManager(QWidget* parent) : QDialog(parent)
   Reset();
   Update();
 }
+
+CheatsManager::~CheatsManager() = default;
 
 void CheatsManager::OnStateChanged(Core::State state)
 {

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -15,6 +15,7 @@
 class ARCodeWidget;
 class QComboBox;
 class QDialogButtonBox;
+class QLabel;
 class QLineEdit;
 class QPushButton;
 class QRadioButton;
@@ -22,52 +23,24 @@ class QSplitter;
 class QTabWidget;
 class QTableWidget;
 class QTableWidgetItem;
-class QLabel;
-
-namespace UICommon
-{
-class GameFile;
-}
+struct Result;
 
 namespace Core
 {
 enum class State;
 }
 
-enum class CompareType : int
+namespace UICommon
 {
-  Equal = 0,
-  NotEqual = 1,
-  Less = 2,
-  LessEqual = 3,
-  More = 4,
-  MoreEqual = 5
-};
-
-enum class DataType : int
-{
-  Byte = 0,
-  Short = 1,
-  Int = 2,
-  Float = 3,
-  Double = 4,
-  String = 5
-};
-
-struct Result
-{
-  u32 address;
-  DataType type;
-  QString name;
-  bool locked = false;
-  u32 locked_value;
-};
+class GameFile;
+}
 
 class CheatsManager : public QDialog
 {
   Q_OBJECT
 public:
   explicit CheatsManager(QWidget* parent = nullptr);
+  ~CheatsManager();
 
 private:
   QWidget* CreateCheatSearch();


### PR DESCRIPTION
CompareType, DataType, and Result aren't directly used externally, so these can have their definitions moved into the cpp file.