### PR TITLE
Qt/Resources: Convert int parameters of GetCountry(), GetPlatform() and GetMisc() to enum classes

### DIFF
--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -67,7 +67,7 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
                  QStringLiteral("</p>"));
 
   QLabel* logo = new QLabel();
-  logo->setPixmap(Resources::GetMisc(Resources::LOGO_LARGE));
+  logo->setPixmap(Resources::GetMisc(Resources::MiscID::LogoLarge));
   logo->setContentsMargins(30, 0, 30, 0);
 
   QVBoxLayout* main_layout = new QVBoxLayout;

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -54,13 +54,13 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   {
   case COL_PLATFORM:
     if (role == Qt::DecorationRole)
-      return Resources::GetPlatform(static_cast<int>(game.GetPlatform()));
+      return Resources::GetPlatform(game.GetPlatform());
     if (role == Qt::InitialSortOrderRole)
       return static_cast<int>(game.GetPlatform());
     break;
   case COL_COUNTRY:
     if (role == Qt::DecorationRole)
-      return Resources::GetCountry(static_cast<int>(game.GetCountry()));
+      return Resources::GetCountry(game.GetCountry());
     if (role == Qt::InitialSortOrderRole)
       return static_cast<int>(game.GetCountry());
     break;
@@ -70,7 +70,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
       // GameCube banners are 96x32, but Wii banners are 192x64.
       QPixmap banner = ToQPixmap(game.GetBannerImage());
       if (banner.isNull())
-        banner = Resources::GetMisc(Resources::BANNER_MISSING);
+        banner = Resources::GetMisc(Resources::MiscID::BannerMissing);
 
       banner.setDevicePixelRatio(
           std::max(static_cast<qreal>(banner.width()) / GAMECUBE_BANNER_SIZE.width(),

--- a/Source/Core/DolphinQt/Resources.cpp
+++ b/Source/Core/DolphinQt/Resources.cpp
@@ -95,19 +95,19 @@ void Resources::Init()
   m_misc.append(GetScaledPixmap("Dolphin"));
 }
 
-QPixmap Resources::GetPlatform(int platform)
+QPixmap Resources::GetPlatform(DiscIO::Platform platform)
 {
-  return m_platforms[platform];
+  return m_platforms[static_cast<int>(platform)];
 }
 
-QPixmap Resources::GetCountry(int country)
+QPixmap Resources::GetCountry(DiscIO::Country country)
 {
-  return m_countries[country];
+  return m_countries[static_cast<int>(country)];
 }
 
-QPixmap Resources::GetMisc(int id)
+QPixmap Resources::GetMisc(MiscID id)
 {
-  return m_misc[id];
+  return m_misc[static_cast<int>(id)];
 }
 
 QIcon Resources::GetAppIcon()

--- a/Source/Core/DolphinQt/Resources.h
+++ b/Source/Core/DolphinQt/Resources.h
@@ -7,23 +7,29 @@
 #include <QList>
 #include <QPixmap>
 
+namespace DiscIO
+{
+enum class Country;
+enum class Platform;
+}
+
 // Store for various QPixmaps that will be used repeatedly.
 class Resources final
 {
 public:
+  enum class MiscID
+  {
+    BannerMissing,
+    LogoLarge,
+    LogoSmall
+  };
+
   static void Init();
 
-  static QPixmap GetPlatform(int platform);
-  static QPixmap GetCountry(int country);
+  static QPixmap GetPlatform(DiscIO::Platform platform);
+  static QPixmap GetCountry(DiscIO::Country country);
 
-  static QPixmap GetMisc(int id);
-
-  enum
-  {
-    BANNER_MISSING,
-    LOGO_LARGE,
-    LOGO_SMALL
-  };
+  static QPixmap GetMisc(MiscID id);
 
   static QIcon GetScaledIcon(const std::string& name);
   static QIcon GetScaledThemeIcon(const std::string& name);


### PR DESCRIPTION
Makes the parameter strongly-typed and doesn't accept arbitrary `int` values (letting the compiler catch cases of mismatching mistakes when shuffling things around). This also keeps the casting behind the interface, rather than making the callers cast.