### PR TITLE
Qt/GameList: Replace includes with forward declarations where applicable

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -15,11 +15,14 @@
 #include <QFrame>
 #include <QHeaderView>
 #include <QKeyEvent>
+#include <QLabel>
+#include <QListView>
 #include <QMap>
 #include <QMenu>
 #include <QMessageBox>
 #include <QProgressDialog>
-#include <QScrollBar>
+#include <QSortFilterProxyModel>
+#include <QTableView>
 #include <QUrl>
 
 #include "Common/FileUtil.h"
@@ -34,6 +37,7 @@
 #include "DiscIO/Enums.h"
 
 #include "DolphinQt/Config/PropertiesDialog.h"
+#include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/GameList/GridProxyModel.h"
 #include "DolphinQt/GameList/ListProxyModel.h"
 #include "DolphinQt/QtUtils/ActionHelper.h"
@@ -41,6 +45,8 @@
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/WiiUpdate.h"
+
+#include "UICommon/GameFile.h"
 
 static bool CompressCB(const std::string&, float, void*);
 
@@ -676,6 +682,11 @@ bool GameList::HasMultipleSelected() const
 {
   return currentWidget() == m_list ? m_list->selectionModel()->selectedRows().size() > 1 :
                                      m_grid->selectionModel()->selectedIndexes().size() > 1;
+}
+
+void GameList::SetViewColumn(int col, bool view)
+{
+  m_list->setColumnHidden(col, !view);
 }
 
 void GameList::SetPreferredView(bool list)

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -6,15 +6,18 @@
 
 #include <memory>
 
-#include <QLabel>
-#include <QListView>
-#include <QSortFilterProxyModel>
 #include <QStackedWidget>
-#include <QTableView>
 
-#include "DolphinQt/GameList/GameListModel.h"
+class GameListModel;
+class QLabel;
+class QListView;
+class QSortFilterProxyModel;
+class QTableView;
 
-#include "UICommon/GameFile.h"
+namespace UICommon
+{
+class GameFile;
+}
 
 class GameList final : public QStackedWidget
 {
@@ -30,7 +33,7 @@ public:
 
   void SetListView() { SetPreferredView(true); }
   void SetGridView() { SetPreferredView(false); }
-  void SetViewColumn(int col, bool view) { m_list->setColumnHidden(col, !view); }
+  void SetViewColumn(int col, bool view);
   void SetSearchTerm(const QString& term);
 
   void OnColumnVisibilityToggled(const QString& row, bool visible);

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -14,6 +14,7 @@
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
+#include "UICommon/GameFile.h"
 #include "UICommon/UICommon.h"
 
 const QSize GAMECUBE_BANNER_SIZE(96, 32);
@@ -224,6 +225,16 @@ bool GameListModel::ShouldDisplayGameListItem(int index) const
 std::shared_ptr<const UICommon::GameFile> GameListModel::GetGameFile(int index) const
 {
   return m_games[index];
+}
+
+QString GameListModel::GetPath(int index) const
+{
+  return QString::fromStdString(m_games[index]->GetFilePath());
+}
+
+QString GameListModel::GetUniqueIdentifier(int index) const
+{
+  return QString::fromStdString(m_games[index]->GetUniqueIdentifier());
 }
 
 void GameListModel::AddGame(const std::shared_ptr<const UICommon::GameFile>& game)

--- a/Source/Core/DolphinQt/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt/GameList/GameListModel.h
@@ -14,7 +14,10 @@
 
 #include "DolphinQt/GameList/GameTracker.h"
 
-#include "UICommon/GameFile.h"
+namespace UICommon
+{
+class GameFile;
+}
 
 class GameListModel final : public QAbstractTableModel
 {
@@ -32,12 +35,9 @@ public:
 
   std::shared_ptr<const UICommon::GameFile> GetGameFile(int index) const;
   // Path of the game at the specified index.
-  QString GetPath(int index) const { return QString::fromStdString(m_games[index]->GetFilePath()); }
+  QString GetPath(int index) const;
   // Unique identifier of the game at the specified index.
-  QString GetUniqueIdentifier(int index) const
-  {
-    return QString::fromStdString(m_games[index]->GetUniqueIdentifier());
-  }
+  QString GetUniqueIdentifier(int index) const;
   bool ShouldDisplayGameListItem(int index) const;
   void SetSearchTerm(const QString& term);
 

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -17,6 +17,8 @@
 
 #include "DolphinQt/Settings.h"
 
+#include "UICommon/GameFile.h"
+
 // NOTE: Qt likes to be case-sensitive here even though it shouldn't be thus this ugly regex hack
 static const QStringList game_filters{
     QStringLiteral("*.[gG][cC][mM]"), QStringLiteral("*.[iI][sS][oO]"),

--- a/Source/Core/DolphinQt/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt/GameList/GameTracker.h
@@ -15,8 +15,12 @@
 
 #include "Common/Event.h"
 #include "Common/WorkQueueThread.h"
-#include "UICommon/GameFile.h"
 #include "UICommon/GameFileCache.h"
+
+namespace UICommon
+{
+class GameFile;
+}
 
 // Watches directories and loads GameFiles in a separate thread.
 // To use this, just add directories using AddDirectory, and listen for the

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -86,6 +86,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 #include "UICommon/DiscordPresence.h"
+#include "UICommon/GameFile.h"
 #include "UICommon/UICommon.h"
 
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -36,7 +36,7 @@
 #include "Core/Core.h"
 #include "Core/NetPlayServer.h"
 
-#include "DolphinQt/GameList/GameList.h"
+#include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/NetPlay/GameListDialog.h"
 #include "DolphinQt/NetPlay/MD5Dialog.h"
 #include "DolphinQt/NetPlay/PadMappingDialog.h"


### PR DESCRIPTION
Avoids dragging in a bunch of includes from the header files, and also reduces the amount of files that need to be recompiled if one of those included headers' source content is ever changed.