### PR TITLE
NetPlay: Don't update mappings on leave if player had no mappings

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -366,7 +366,7 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
 // called from ---NETPLAY--- thread
 unsigned int NetPlayServer::OnDisconnect(const Client& player)
 {
-  PlayerId pid = player.pid;
+  const PlayerId pid = player.pid;
 
   if (m_is_running)
   {
@@ -405,18 +405,18 @@ unsigned int NetPlayServer::OnDisconnect(const Client& player)
     if (mapping == pid)
     {
       mapping = -1;
+      UpdatePadMapping();
     }
   }
-  UpdatePadMapping();
 
   for (PadMapping& mapping : m_wiimote_map)
   {
     if (mapping == pid)
     {
       mapping = -1;
+      UpdateWiimoteMapping();
     }
   }
-  UpdateWiimoteMapping();
 
   return 0;
 }


### PR DESCRIPTION
This stops clients randomly deadlocking when a spectator leaves, as the mappings construct is not thread-safe and should not be written while the game is running.