### PR TITLE
Core/ConfigManager: Don't set JITFollowBranch

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -219,7 +219,6 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("SkipIPL", bHLE_BS2);
   core->Set("TimingVariance", iTimingVariance);
   core->Set("CPUCore", cpu_core);
-  core->Set("JITFollowBranch", bJITFollowBranch);
   core->Set("Fastmem", bFastmem);
   core->Set("CPUThread", bCPUThread);
   core->Set("DSPHLE", bDSPHLE);


### PR DESCRIPTION
This setting shouldn't be written to Dolphin.ini, so we don't want to set it here. The only reason this was added to SConfig in the first place is because the config rewrite isn't ready to handle this particular setting through onion config (it caused perf issues).

We don't want to write this setting to disk, as SConfig has problems with leaking settings changed by GameINI into the base configs. The result of this is that if someone plays an N64 VC game (or other game where we disable this setting) the branch following option can get unintentionally disabled globally, which will reduce performance in many games and cause NetPlay to desync with users who still have it enabled.