### PR TITLE
[RFC] Qt/NetPlayDialog: Change own chat message color to better suit dark themes

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -271,7 +271,7 @@ void NetPlayDialog::OnChat()
 
     DisplayMessage(QStringLiteral("%1: %2").arg(QString::fromStdString(m_nickname).toHtmlEscaped(),
                                                 QString::fromStdString(msg).toHtmlEscaped()),
-                   "blue");
+                   "#1d6ed8");
   });
 }
 


### PR DESCRIPTION
Blue (#0000FF) is nearly impossible to see on dark UI themes. I just sort of eyeballed a color with a color picker tool, and I have no idea how it looks on light UI themes. Please try it and give screenshots and feedback.