### PR TITLE
Set Qt version to 5.6

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt5 5.9 REQUIRED COMPONENTS Gui Widgets)
+find_package(Qt5 5.6 REQUIRED COMPONENTS Gui Widgets)
 
 set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
 message(STATUS "Found Qt version ${Qt5Core_VERSION}")


### PR DESCRIPTION
In #7149 several changes were merged that were claimed to be only compatible with Qt 5.9. Actually it works fine with 5.6 as well.

Once features actually get introduced that require 5.9, the file can be modified again. Until then there's no harm in not artificially limiting compatibility. Qt 5.6 in supported until 2019 or so.

Qt 5.6 is compiling fine, see the openSUSE 42.3 build here: https://build.opensuse.org/package/show/home:KAMiKAZOW:Test/dolphin-emu