### PR TITLE
ControlGroup: Return state data via GetState() by value where applicable

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -137,29 +137,27 @@ void Classic::GetState(u8* const data)
 
   // left stick
   {
-    ControlState x, y;
-    m_left_stick->GetState(&x, &y);
+    const ControllerEmu::AnalogStick::StateData left_stick_state = m_left_stick->GetState();
 
-    classic_data.regular_data.lx =
-        static_cast<u8>(Classic::LEFT_STICK_CENTER_X + (x * Classic::LEFT_STICK_RADIUS));
-    classic_data.regular_data.ly =
-        static_cast<u8>(Classic::LEFT_STICK_CENTER_Y + (y * Classic::LEFT_STICK_RADIUS));
+    classic_data.regular_data.lx = static_cast<u8>(
+        Classic::LEFT_STICK_CENTER_X + (left_stick_state.x * Classic::LEFT_STICK_RADIUS));
+    classic_data.regular_data.ly = static_cast<u8>(
+        Classic::LEFT_STICK_CENTER_Y + (left_stick_state.y * Classic::LEFT_STICK_RADIUS));
   }
 
   // right stick
   {
-    ControlState x, y;
-    m_right_stick->GetState(&x, &y);
+    const ControllerEmu::AnalogStick::StateData right_stick_data = m_right_stick->GetState();
 
-    const u8 x_ =
-        static_cast<u8>(Classic::RIGHT_STICK_CENTER_X + (x * Classic::RIGHT_STICK_RADIUS));
-    const u8 y_ =
-        static_cast<u8>(Classic::RIGHT_STICK_CENTER_Y + (y * Classic::RIGHT_STICK_RADIUS));
+    const u8 x = static_cast<u8>(Classic::RIGHT_STICK_CENTER_X +
+                                 (right_stick_data.x * Classic::RIGHT_STICK_RADIUS));
+    const u8 y = static_cast<u8>(Classic::RIGHT_STICK_CENTER_Y +
+                                 (right_stick_data.y * Classic::RIGHT_STICK_RADIUS));
 
-    classic_data.rx1 = x_;
-    classic_data.rx2 = x_ >> 1;
-    classic_data.rx3 = x_ >> 3;
-    classic_data.ry = y_;
+    classic_data.rx1 = x;
+    classic_data.rx2 = x >> 1;
+    classic_data.rx3 = x >> 3;
+    classic_data.ry = y;
   }
 
   // triggers

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -74,11 +74,10 @@ void Drums::GetState(u8* const data)
 
   // stick
   {
-    ControlState x, y;
-    m_stick->GetState(&x, &y);
+    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
 
-    drum_data.sx = static_cast<u8>((x * 0x1F) + 0x20);
-    drum_data.sy = static_cast<u8>((y * 0x1F) + 0x20);
+    drum_data.sx = static_cast<u8>((stick_state.x * 0x1F) + 0x20);
+    drum_data.sy = static_cast<u8>((stick_state.y * 0x1F) + 0x20);
   }
 
   // TODO: softness maybe
@@ -87,6 +86,7 @@ void Drums::GetState(u8* const data)
 
   // buttons
   m_buttons->GetState(&drum_data.bt, drum_button_bitmasks.data());
+
   // pads
   m_pads->GetState(&drum_data.bt, drum_pad_bitmasks.data());
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -106,11 +106,10 @@ void Guitar::GetState(u8* const data)
 
   // stick
   {
-    ControlState x, y;
-    m_stick->GetState(&x, &y);
+    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
 
-    guitar_data.sx = static_cast<u8>((x * 0x1F) + 0x20);
-    guitar_data.sy = static_cast<u8>((y * 0x1F) + 0x20);
+    guitar_data.sx = static_cast<u8>((stick_state.x * 0x1F) + 0x20);
+    guitar_data.sy = static_cast<u8>((stick_state.y * 0x1F) + 0x20);
   }
 
   // slider bar
@@ -133,8 +132,10 @@ void Guitar::GetState(u8* const data)
 
   // buttons
   m_buttons->GetState(&guitar_data.bt, guitar_button_bitmasks.data());
+
   // frets
   m_frets->GetState(&guitar_data.bt, guitar_fret_bitmasks.data());
+
   // strum
   m_strum->GetState(&guitar_data.bt, guitar_strum_bitmasks.data());
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -126,9 +126,8 @@ void Guitar::GetState(u8* const data)
   }
 
   // whammy bar
-  ControlState whammy;
-  m_whammy->GetState(&whammy);
-  guitar_data.whammy = static_cast<u8>(whammy * 0x1F);
+  const ControllerEmu::Triggers::StateData whammy_state = m_whammy->GetState();
+  guitar_data.whammy = static_cast<u8>(whammy_state.data[0] * 0x1F);
 
   // buttons
   m_buttons->GetState(&guitar_data.bt, guitar_button_bitmasks.data());

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -115,9 +115,9 @@ void Guitar::GetState(u8* const data)
   // slider bar
   if (m_slider_bar->controls[0]->control_ref->BoundCount())
   {
-    ControlState slider_bar;
-    m_slider_bar->GetState(&slider_bar);
-    guitar_data.sb = s_slider_bar_control_codes.lower_bound(slider_bar)->second;
+    const ControllerEmu::Slider::StateData slider_data = m_slider_bar->GetState();
+
+    guitar_data.sb = s_slider_bar_control_codes.lower_bound(slider_data.value)->second;
   }
   else
   {

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -76,11 +76,9 @@ void Nunchuk::GetState(u8* const data)
   wm_nc nc_data = {};
 
   // stick
-  double jx, jy;
-  m_stick->GetState(&jx, &jy);
-
-  nc_data.jx = u8(STICK_CENTER + jx * STICK_RADIUS);
-  nc_data.jy = u8(STICK_CENTER + jy * STICK_RADIUS);
+  const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
+  nc_data.jx = u8(STICK_CENTER + stick_state.x * STICK_RADIUS);
+  nc_data.jy = u8(STICK_CENTER + stick_state.y * STICK_RADIUS);
 
   // Some terribly coded games check whether to move with a check like
   //

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -90,11 +90,10 @@ void Turntable::GetState(u8* const data)
 
   // stick
   {
-    ControlState x, y;
-    m_stick->GetState(&x, &y);
+    const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
 
-    tt_data.sx = static_cast<u8>((x * 0x1F) + 0x20);
-    tt_data.sy = static_cast<u8>((y * 0x1F) + 0x20);
+    tt_data.sx = static_cast<u8>((stick_state.x * 0x1F) + 0x20);
+    tt_data.sy = static_cast<u8>((stick_state.y * 0x1F) + 0x20);
   }
 
   // left table

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -118,13 +118,11 @@ void Turntable::GetState(u8* const data)
 
   // effect dial
   {
-    ControlState dial;
-    m_effect_dial->GetState(&dial);
+    const ControllerEmu::Triggers::StateData state = m_effect_dial->GetState();
+    const u8 dial = static_cast<u8>(state.data[0] * 0x0F);
 
-    const u8 dial_ = static_cast<u8>(dial * 0x0F);
-
-    tt_data.dial1 = dial_;
-    tt_data.dial2 = dial_ >> 3;
+    tt_data.dial1 = dial;
+    tt_data.dial2 = dial >> 3;
   }
 
   // crossfade slider

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -98,26 +98,22 @@ void Turntable::GetState(u8* const data)
 
   // left table
   {
-    ControlState tt;
-    m_left_table->GetState(&tt);
+    const ControllerEmu::Slider::StateData lt = m_left_table->GetState();
+    const s8 tt = static_cast<s8>(lt.value * 0x1F);
 
-    const s8 tt_ = static_cast<s8>(tt * 0x1F);
-
-    tt_data.ltable1 = tt_;
-    tt_data.ltable2 = tt_ >> 5;
+    tt_data.ltable1 = tt;
+    tt_data.ltable2 = tt >> 5;
   }
 
   // right table
   {
-    ControlState tt;
-    m_right_table->GetState(&tt);
+    const ControllerEmu::Slider::StateData rt = m_right_table->GetState();
+    const s8 tt = static_cast<s8>(rt.value * 0x1F);
 
-    const s8 tt_ = static_cast<s8>(tt * 0x1F);
-
-    tt_data.rtable1 = tt_;
-    tt_data.rtable2 = tt_ >> 1;
-    tt_data.rtable3 = tt_ >> 3;
-    tt_data.rtable4 = tt_ >> 5;
+    tt_data.rtable1 = tt;
+    tt_data.rtable2 = tt >> 1;
+    tt_data.rtable3 = tt >> 3;
+    tt_data.rtable4 = tt >> 5;
   }
 
   // effect dial
@@ -133,10 +129,9 @@ void Turntable::GetState(u8* const data)
 
   // crossfade slider
   {
-    ControlState cfs;
-    m_crossfade->GetState(&cfs);
+    const ControllerEmu::Slider::StateData cfs = m_crossfade->GetState();
 
-    tt_data.slider = static_cast<u8>((cfs * 0x07) + 0x08);
+    tt_data.slider = static_cast<u8>((cfs.value * 0x07) + 0x08);
   }
 
   // buttons

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -177,28 +177,24 @@ void EmulateDynamicShake(AccelData* const accel, DynamicData& dynamic_data,
 void EmulateTilt(AccelData* const accel, ControllerEmu::Tilt* const tilt_group, const bool sideways,
                  const bool upright)
 {
-  ControlState roll, pitch;
   // 180 degrees
-  tilt_group->GetState(&roll, &pitch);
+  const ControllerEmu::Tilt::StateData state = tilt_group->GetState();
+  const ControlState roll = state.x * PI;
+  const ControlState pitch = state.y * PI;
 
-  roll *= PI;
-  pitch *= PI;
-
-  unsigned int ud = 0, lr = 0, fb = 0;
-
-  // some notes that no one will understand but me :p
+  // Some notes that no one will understand but me :p
   // left, forward, up
   // lr/ left == negative for all orientations
   // ud/ up == negative for upright longways
   // fb/ forward == positive for (sideways flat)
 
-  // determine which axis is which direction
-  ud = upright ? (sideways ? 0 : 1) : 2;
-  lr = sideways;
-  fb = upright ? 2 : (sideways ? 0 : 1);
+  // Determine which axis is which direction
+  const u32 ud = upright ? (sideways ? 0 : 1) : 2;
+  const u32 lr = sideways;
+  const u32 fb = upright ? 2 : (sideways ? 0 : 1);
 
-  int sgn[3] = {-1, 1, 1};  // sign fix
-
+  // Sign fix
+  std::array<int, 3> sgn{{-1, 1, 1}};
   if (sideways && !upright)
     sgn[fb] *= -1;
   if (!sideways && upright)

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -428,9 +428,9 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index), ir_sin(0), ir_cos(1
 
   // options
   groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));
-  m_options->boolean_settings.emplace_back(new ControllerEmu::BooleanSetting(
-                                               "Forward Wiimote", _trans("Forward Wii Remote"),
-                                               true, ControllerEmu::SettingType::NORMAL, true));
+  m_options->boolean_settings.emplace_back(
+      new ControllerEmu::BooleanSetting("Forward Wiimote", _trans("Forward Wii Remote"), true,
+                                        ControllerEmu::SettingType::NORMAL, true));
   m_options->boolean_settings.emplace_back(m_upright_setting = new ControllerEmu::BooleanSetting(
                                                "Upright Wiimote", _trans("Upright Wii Remote"),
                                                false, ControllerEmu::SettingType::NORMAL, true));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -36,20 +36,20 @@ AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
-void AnalogStick::GetState(ControlState* const x, ControlState* const y)
+AnalogStick::StateData AnalogStick::GetState()
 {
-  ControlState yy = controls[0]->control_ref->State() - controls[1]->control_ref->State();
-  ControlState xx = controls[3]->control_ref->State() - controls[2]->control_ref->State();
+  ControlState y = controls[0]->control_ref->State() - controls[1]->control_ref->State();
+  ControlState x = controls[3]->control_ref->State() - controls[2]->control_ref->State();
 
-  ControlState radius = numeric_settings[SETTING_RADIUS]->GetValue();
-  ControlState deadzone = numeric_settings[SETTING_DEADZONE]->GetValue();
-  ControlState m = controls[4]->control_ref->State();
+  const ControlState radius = numeric_settings[SETTING_RADIUS]->GetValue();
+  const ControlState deadzone = numeric_settings[SETTING_DEADZONE]->GetValue();
+  const ControlState m = controls[4]->control_ref->State();
 
-  ControlState ang = atan2(yy, xx);
-  ControlState ang_sin = sin(ang);
-  ControlState ang_cos = cos(ang);
+  const ControlState ang = atan2(y, x);
+  const ControlState ang_sin = sin(ang);
+  const ControlState ang_cos = cos(ang);
 
-  ControlState dist = sqrt(xx * xx + yy * yy);
+  ControlState dist = sqrt(x * x + y * y);
 
   // dead zone code
   dist = std::max(0.0, dist - deadzone);
@@ -63,10 +63,9 @@ void AnalogStick::GetState(ControlState* const x, ControlState* const y)
   if (m)
     dist *= 0.5;
 
-  yy = std::max(-1.0, std::min(1.0, ang_sin * dist));
-  xx = std::max(-1.0, std::min(1.0, ang_cos * dist));
+  y = std::max(-1.0, std::min(1.0, ang_sin * dist));
+  x = std::max(-1.0, std::min(1.0, ang_cos * dist));
 
-  *y = yy;
-  *x = xx;
+  return {x, y};
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -18,10 +18,16 @@ public:
     SETTING_DEADZONE,
   };
 
+  struct StateData
+  {
+    ControlState x{};
+    ControlState y{};
+  };
+
   // The GameCube controller and Wiimote attachments have a different default radius
   AnalogStick(const char* name, ControlState default_radius);
   AnalogStick(const char* name, const char* ui_name, ControlState default_radius);
 
-  void GetState(ControlState* x, ControlState* y);
+  StateData GetState();
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -13,9 +13,16 @@ namespace ControllerEmu
 class Cursor : public ControlGroup
 {
 public:
+  struct StateData
+  {
+    ControlState x{};
+    ControlState y{};
+    ControlState z{};
+  };
+
   explicit Cursor(const std::string& name);
 
-  void GetState(ControlState* x, ControlState* y, ControlState* z, bool adjusted = false);
+  StateData GetState(bool adjusted = false);
 
 private:
   // This is used to reduce the cursor speed for relative input
@@ -25,9 +32,7 @@ private:
   // Sets the length for the auto-hide timer
   static constexpr int TIMER_VALUE = 500;
 
-  ControlState m_x = 0.0;
-  ControlState m_y = 0.0;
-  ControlState m_z = 0.0;
+  StateData m_state;
 
   int m_autohide_timer = TIMER_VALUE;
   ControlState m_prev_xx;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
@@ -29,18 +29,23 @@ Force::Force(const std::string& name_) : ControlGroup(name_, GroupType::Force)
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
-void Force::GetState(ControlState* axis)
+Force::StateData Force::GetState()
 {
+  StateData state_data;
   const ControlState deadzone = numeric_settings[0]->GetValue();
 
   for (u32 i = 0; i < 6; i += 2)
   {
-    ControlState tmpf = 0;
     const ControlState state =
         controls[i + 1]->control_ref->State() - controls[i]->control_ref->State();
+
+    ControlState tmpf = 0;
     if (fabs(state) > deadzone)
       tmpf = ((state - (deadzone * sign(state))) / (1 - deadzone));
-    *axis++ = tmpf;
+
+    state_data[i / 2] = tmpf;
   }
+
+  return state_data;
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
@@ -14,11 +14,13 @@ namespace ControllerEmu
 class Force : public ControlGroup
 {
 public:
+  using StateData = std::array<ControlState, 3>;
+
   explicit Force(const std::string& name);
 
-  void GetState(ControlState* axis);
+  StateData GetState();
 
 private:
-  std::array<ControlState, 3> m_swing{};
+  StateData m_swing{};
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
@@ -30,14 +30,14 @@ Slider::Slider(const std::string& name_) : Slider(name_, name_)
 {
 }
 
-void Slider::GetState(ControlState* const slider)
+Slider::StateData Slider::GetState()
 {
   const ControlState deadzone = numeric_settings[0]->GetValue();
   const ControlState state = controls[1]->control_ref->State() - controls[0]->control_ref->State();
 
   if (fabs(state) > deadzone)
-    *slider = (state - (deadzone * sign(state))) / (1 - deadzone);
-  else
-    *slider = 0;
+    return {(state - (deadzone * sign(state))) / (1 - deadzone)};
+
+  return {0.0};
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
@@ -13,9 +13,14 @@ namespace ControllerEmu
 class Slider : public ControlGroup
 {
 public:
+  struct StateData
+  {
+    ControlState value{};
+  };
+
   Slider(const std::string& name_, const std::string& ui_name_);
   explicit Slider(const std::string& name_);
 
-  void GetState(ControlState* slider);
+  StateData GetState();
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -31,7 +31,7 @@ Tilt::Tilt(const std::string& name_) : ControlGroup(name_, GroupType::Tilt)
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Angle"), 0.9, 0, 180));
 }
 
-void Tilt::GetState(ControlState* const x, ControlState* const y, const bool step)
+Tilt::StateData Tilt::GetState(const bool step)
 {
   // this is all a mess
 
@@ -80,18 +80,17 @@ void Tilt::GetState(ControlState* const x, ControlState* const y, const bool ste
   // silly
   if (step)
   {
-    if (xx > m_tilt[0])
-      m_tilt[0] = std::min(m_tilt[0] + 0.1, xx);
-    else if (xx < m_tilt[0])
-      m_tilt[0] = std::max(m_tilt[0] - 0.1, xx);
+    if (xx > m_tilt.x)
+      m_tilt.x = std::min(m_tilt.x + 0.1, xx);
+    else if (xx < m_tilt.x)
+      m_tilt.x = std::max(m_tilt.x - 0.1, xx);
 
-    if (yy > m_tilt[1])
-      m_tilt[1] = std::min(m_tilt[1] + 0.1, yy);
-    else if (yy < m_tilt[1])
-      m_tilt[1] = std::max(m_tilt[1] - 0.1, yy);
+    if (yy > m_tilt.y)
+      m_tilt.y = std::min(m_tilt.y + 0.1, yy);
+    else if (yy < m_tilt.y)
+      m_tilt.y = std::max(m_tilt.y - 0.1, yy);
   }
 
-  *y = m_tilt[1] * angle;
-  *x = m_tilt[0] * angle;
+  return {m_tilt.x * angle, m_tilt.y * angle};
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <array>
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerInterface/Device.h"
@@ -14,11 +13,17 @@ namespace ControllerEmu
 class Tilt : public ControlGroup
 {
 public:
+  struct StateData
+  {
+    ControlState x{};
+    ControlState y{};
+  };
+
   explicit Tilt(const std::string& name);
 
-  void GetState(ControlState* x, ControlState* y, bool step = true);
+  StateData GetState(bool step = true);
 
 private:
-  std::array<ControlState, 2> m_tilt{};
+  StateData m_tilt;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.cpp
@@ -21,12 +21,15 @@ Triggers::Triggers(const std::string& name_) : ControlGroup(name_, GroupType::Tr
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
-void Triggers::GetState(ControlState* analog)
+Triggers::StateData Triggers::GetState()
 {
   const size_t trigger_count = controls.size();
   const ControlState deadzone = numeric_settings[0]->GetValue();
 
-  for (size_t i = 0; i < trigger_count; ++i, ++analog)
-    *analog = std::max(controls[i]->control_ref->State() - deadzone, 0.0) / (1 - deadzone);
+  StateData result(trigger_count);
+  for (size_t i = 0; i < trigger_count; ++i)
+    result.data[i] = std::max(controls[i]->control_ref->State() - deadzone, 0.0) / (1 - deadzone);
+
+  return result;
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <string>
+#include <vector>
+
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
@@ -13,8 +15,16 @@ namespace ControllerEmu
 class Triggers : public ControlGroup
 {
 public:
+  struct StateData
+  {
+    StateData() = default;
+    explicit StateData(std::size_t trigger_count) : data(trigger_count) {}
+
+    std::vector<ControlState> data;
+  };
+
   explicit Triggers(const std::string& name);
 
-  void GetState(ControlState* analog);
+  StateData GetState();
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
This makes the API for a few of the control groups a little more flexible by returning by value whenever possible. This gets rid of the need to pass locals entirely in some cases, and in other cases, gets rid of the need to pass pointers to locals to certain functions, allowing the state data instances to be const from the get-go.

This also encloses the returned state in their own `StateData` instances, which makes distinct types, preventing accidental assignment to the wrong variable type at the type system level (as opposed to just returning `ControlState` from `GetState()` instances that only return one piece of data), making it a little more type-safe as well.

tl;dr: It makes the interfaces nicer to use.

