### PR TITLE
NetPlayServer: Make g_initial_netplay_rtc a member variable of NetPlayClient

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -528,7 +528,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_EnableGPUTextureDecoding;
       packet >> m_net_settings.m_StrictSettingsSync;
 
-      g_netplay_initial_rtc = Common::PacketReadU64(packet);
+      m_initial_rtc = Common::PacketReadU64(packet);
 
       packet >> m_net_settings.m_SyncSaveData;
       packet >> m_net_settings.m_SaveDataRegion;
@@ -1454,6 +1454,11 @@ bool NetPlayClient::GetNetPads(const int pad_nb, GCPadStatus* pad_status)
   return true;
 }
 
+u64 NetPlayClient::GetInitialRTCValue() const
+{
+  return m_initial_rtc;
+}
+
 // called from ---CPU--- thread
 bool NetPlayClient::WiimoteUpdate(int _number, u8* data, const u8 size, u8 reporting_mode)
 {
@@ -1811,7 +1816,7 @@ u64 ExpansionInterface::CEXIIPL::NetPlay_GetEmulatedTime()
   std::lock_guard<std::mutex> lk(NetPlay::crit_netplay_client);
 
   if (NetPlay::netplay_client)
-    return NetPlay::g_netplay_initial_rtc;
+    return NetPlay::netplay_client->GetInitialRTCValue();
 
   return 0;
 }

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -102,6 +102,8 @@ public:
   bool WiimoteUpdate(int _number, u8* data, const u8 size, u8 reporting_mode);
   bool GetNetPads(int pad_nb, GCPadStatus* pad_status);
 
+  u64 GetInitialRTCValue() const;
+
   void OnTraversalStateChanged() override;
   void OnConnectReady(ENetAddress addr) override;
   void OnConnectFailed(u8 reason) override;
@@ -203,6 +205,7 @@ private:
   u8 m_sync_save_data_count = 0;
   u8 m_sync_save_data_success_count = 0;
 
+  u64 m_initial_rtc = 0;
   u32 m_timebase_frame = 0;
 };
 

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -94,8 +94,6 @@ struct NetTraversalConfig
   u16 traversal_port = 0;
 };
 
-extern u64 g_netplay_initial_rtc;
-
 struct Rpt : public std::vector<u8>
 {
   u16 channel;

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -85,6 +85,8 @@ private:
   bool CompressFileIntoPacket(const std::string& file_path, sf::Packet& packet);
   bool CompressBufferIntoPacket(const std::vector<u8>& in_buffer, sf::Packet& packet);
 
+  u64 GetInitialNetPlayRTC() const;
+
   void SendToClients(const sf::Packet& packet, const PlayerId skip_pid = 0);
   void Send(ENetPeer* socket, const sf::Packet& packet);
   unsigned int OnConnect(ENetPeer* socket);


### PR DESCRIPTION
Behaviorally, this belongs within the netplay client. The server will always transmit a known RTC value, so it doesn't even need a global for this. Given the client receives the packet containing said RTC value, we can store it as a member variable and provide an accessor for reading that value.

This removes another global variable within the netplay code.