### PR TITLE
Core/BootManager: Remove unnecessary includes

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <array>
 #include <string>
-#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/Config/Config.h"

--- a/Source/Core/Core/BootManager.h
+++ b/Source/Core/Core/BootManager.h
@@ -5,9 +5,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
-
-#include "Core/ConfigManager.h"
 
 struct BootParameters;
 

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -20,7 +20,7 @@
 #include "Common/MsgHandler.h"
 #include "Core/Analytics.h"
 #include "Core/Boot/Boot.h"
-#include "Core/BootManager.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/MainWindow.h"


### PR DESCRIPTION
Lessens the amount of files that have to be recompiled if ConfigManager.h is modified. This also removes an indirect inclusion within DolphinQt/Main.cpp.