### PR TITLE
DolphinQt/MainWindow: Replace includes with forward declarations

### DIFF
--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -8,7 +8,6 @@
 #include <QVBoxLayout>
 
 #include "DolphinQt/Config/SettingsWindow.h"
-#include "DolphinQt/MainWindow.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -11,6 +11,7 @@
 
 #include "AudioCommon/AudioCommon.h"
 
+#include "Common/Config/Config.h"
 #include "Common/Thread.h"
 
 #include "Core/Config/GraphicsSettings.h"
@@ -21,7 +22,6 @@
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
 #include "Core/State.h"
 
-#include "DolphinQt/MainWindow.h"
 #include "DolphinQt/Settings.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -14,6 +14,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QProgressDialog>
+#include <QStackedWidget>
 #include <QVBoxLayout>
 
 #include <future>
@@ -68,19 +69,23 @@
 #include "DolphinQt/Debugger/WatchWidget.h"
 #include "DolphinQt/FIFO/FIFOPlayerWindow.h"
 #include "DolphinQt/GCMemcardManager.h"
+#include "DolphinQt/GameList/GameList.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/HotkeyScheduler.h"
 #include "DolphinQt/MainWindow.h"
+#include "DolphinQt/MenuBar.h"
 #include "DolphinQt/NetPlay/NetPlayDialog.h"
 #include "DolphinQt/NetPlay/NetPlaySetupDialog.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/QtUtils/RunOnObject.h"
 #include "DolphinQt/QtUtils/WindowActivationEventFilter.h"
+#include "DolphinQt/RenderWidget.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/SearchBar.h"
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/TAS/GCTASInputWindow.h"
 #include "DolphinQt/TAS/WiiTASInputWindow.h"
+#include "DolphinQt/ToolBar.h"
 #include "DolphinQt/WiiUpdate.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -5,20 +5,14 @@
 #pragma once
 
 #include <QMainWindow>
-#include <QStackedWidget>
-#include <QString>
-#include <QToolBar>
 
 #include <memory>
 #include <optional>
 #include <string>
 
-#include "DolphinQt/GameList/GameList.h"
-#include "DolphinQt/MenuBar.h"
-#include "DolphinQt/RenderWidget.h"
-#include "DolphinQt/ToolBar.h"
-
 class QProgressDialog;
+class QStackedWidget;
+class QString;
 
 class BreakpointWidget;
 struct BootParameters;
@@ -27,6 +21,7 @@ class CodeWidget;
 class ControllersWindow;
 class DragEnterEvent;
 class FIFOPlayerWindow;
+class GameList;
 class GCTASInputWindow;
 class GraphicsWindow;
 class HotkeyScheduler;
@@ -34,13 +29,21 @@ class JITWidget;
 class LogConfigWidget;
 class LogWidget;
 class MemoryWidget;
+class MenuBar;
 class NetPlayDialog;
 class NetPlaySetupDialog;
 class RegisterWidget;
+class RenderWidget;
 class SearchBar;
 class SettingsWindow;
+class ToolBar;
 class WatchWidget;
 class WiiTASInputWindow;
+
+namespace DiscIO
+{
+enum class Region;
+}
 
 namespace X11Utils
 {


### PR DESCRIPTION
Reduces the amount of dependencies dragged in by the main window's header. This also removes MainWindow.h includes elsewhere where they aren't necessary, reducing the amount of UI files that need to be recompiled if the main window's header changes.