### PR TITLE
Disable JITFollowBranch for Need For Speed:MW

### DIFF
--- a/Data/Sys/GameSettings/GOW.ini
+++ b/Data/Sys/GameSettings/GOW.ini
@@ -3,6 +3,7 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 MMU = 1
+JITFollowBranch = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
Need For Speed: Most Wanted crashes with JIT Follow Branch.  Originally reported by pandubz on the PCSX2 discord.  Verified by me, and they verified disabling it fixed it.

Without this patch, when entering the garage/shop/anywhere after freeroam, you will crash with an unknown instruction.  Disabling any particular instruction doesn't seem to help, as I disabled everything and it still crashed.

While there is a noticeable performance hit by disabling this, the fact the game doesn't crash is kinda nice.