### PR TITLE
InputCommon/XInput2: Increase mouse buttons to 32

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -12,13 +12,15 @@
 
 #include "InputCommon/ControllerInterface/Xlib/XInput2.h"
 
+#include "Common/StringUtil.h"
+
 // This is an input plugin using the XInput 2.0 extension to the X11 protocol,
 // loosely based on the old XLib plugin. (Has nothing to do with the XInput
 // API on Windows.)
 
 // This plugin creates one KeyboardMouse object for each master pointer/
 // keyboard pair. Each KeyboardMouse object exports four types of controls:
-// *    Mouse button controls: hardcoded at five of them, but could be made to
+// *    Mouse button controls: hardcoded at 32 of them, but could be made to
 //      support infinitely many mouse buttons in theory; XInput2 has no limit.
 // *    Mouse cursor controls: one for each cardinal direction. Calculated by
 //      comparing the absolute position of the mouse pointer on screen to the
@@ -173,7 +175,7 @@ KeyboardMouse::KeyboardMouse(Window window, int opcode, int pointer, int keyboar
   }
 
   // Mouse Buttons
-  for (int i = 0; i < 5; i++)
+  for (int i = 0; i < 32; i++)
     AddInput(new Button(i, &m_state.buttons));
 
   // Mouse Cursor, X-/+ and Y-/+
@@ -338,8 +340,7 @@ ControlState KeyboardMouse::Key::GetState() const
 KeyboardMouse::Button::Button(unsigned int index, unsigned int* buttons)
     : m_buttons(buttons), m_index(index)
 {
-  // this will be a problem if we remove the hardcoded five-button limit
-  name = std::string("Click ") + (char)('1' + m_index);
+  name = StringFromFormat("Click %d", m_index + 1);
 }
 
 ControlState KeyboardMouse::Button::GetState() const


### PR DESCRIPTION
Xlib supports many mouse buttons, though there are 9 standard buttons, and they aren't arranged like other mouse APIs. Using only 5 buttons was preventing the use of buttons besides left/right/middle click and the scroll wheel. Here's what all the standard buttons are:
1. left button
2. middle button (pressing the scroll wheel)
3. right button
4. turn scroll wheel up
5. turn scroll wheel down
6. push scroll wheel left
7. push scroll wheel right
8. 4th button (aka browser backward button)
9. 5th button (aka browser forward button) 
 
The remaining button indices are non-standard and device-specific, and technically far more than 32 are supported, but this seems like a reasonable limit to avoid cluttering the list with tons of useless mouse buttons. What mouse has more than 32 buttons anyways?