### PR TITLE
Qt/IOWindow: Fix detection of button names containing non-alphabetical characters

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -187,7 +187,8 @@ void IOWindow::OnDetectButtonPressed()
     btn->setText(QStringLiteral("..."));
 
     const auto expr = MappingCommon::DetectExpression(
-        m_reference, g_controller_interface.FindDevice(m_devq).get(), m_devq);
+        m_reference, g_controller_interface.FindDevice(m_devq).get(), m_devq,
+        MappingCommon::Quote::Off);
 
     btn->setText(old_label);
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -14,7 +14,7 @@ namespace MappingCommon
 {
 QString GetExpressionForControl(const QString& control_name,
                                 const ciface::Core::DeviceQualifier& control_device,
-                                const ciface::Core::DeviceQualifier& default_device)
+                                const ciface::Core::DeviceQualifier& default_device, Quote quote)
 {
   QString expr;
 
@@ -28,22 +28,26 @@ QString GetExpressionForControl(const QString& control_name,
   // append the control name
   expr += control_name;
 
-  QRegExp reg(QStringLiteral("[a-zA-Z]+"));
-  if (!reg.exactMatch(expr))
-    expr = QStringLiteral("`%1`").arg(expr);
+  if (quote == Quote::On)
+  {
+    QRegExp reg(QStringLiteral("[a-zA-Z]+"));
+    if (!reg.exactMatch(expr))
+      expr = QStringLiteral("`%1`").arg(expr);
+  }
+
   return expr;
 }
 
 QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
-                         const ciface::Core::DeviceQualifier& default_device)
+                         const ciface::Core::DeviceQualifier& default_device, Quote quote)
 {
   ciface::Core::Device::Control* const ctrl = reference->Detect(5000, device);
 
   if (ctrl)
   {
     return MappingCommon::GetExpressionForControl(QString::fromStdString(ctrl->GetName()),
-                                                  default_device, default_device);
+                                                  default_device, default_device, quote);
   }
   return QStringLiteral("");
 }
-}
+}  // namespace MappingCommon

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
@@ -18,9 +18,17 @@ class DeviceQualifier;
 
 namespace MappingCommon
 {
+enum class Quote
+{
+  On,
+  Off
+};
+
 QString GetExpressionForControl(const QString& control_name,
                                 const ciface::Core::DeviceQualifier& control_device,
-                                const ciface::Core::DeviceQualifier& default_device);
+                                const ciface::Core::DeviceQualifier& default_device,
+                                Quote quote = Quote::On);
 QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
-                         const ciface::Core::DeviceQualifier& default_device);
-}
+                         const ciface::Core::DeviceQualifier& default_device,
+                         Quote quote = Quote::On);
+}  // namespace MappingCommon


### PR DESCRIPTION
The button wouldn't be highlighted in the list, as it would look for something like `Click 1` instead of Click 1.