### PR TITLE
Android: Dynamic SettingsActivity Titles

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -98,7 +98,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     mPresenter.onBackPressed();
   }
 
-
   @Override
   public void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack,
           String gameID)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -17,6 +17,8 @@ import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
 import org.dolphinemu.dolphinemu.ui.DividerItemDecoration;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class SettingsFragment extends Fragment implements SettingsFragmentView
 {
@@ -27,6 +29,37 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   private SettingsActivityView mActivity;
 
   private SettingsAdapter mAdapter;
+
+  private static final Map<MenuTag, Integer> titles = new HashMap<>();
+
+  static
+  {
+    titles.put(MenuTag.CONFIG, R.string.preferences_settings);
+    titles.put(MenuTag.CONFIG_GENERAL, R.string.general_submenu);
+    titles.put(MenuTag.CONFIG_INTERFACE, R.string.interface_submenu);
+    titles.put(MenuTag.CONFIG_GAME_CUBE, R.string.gamecube_submenu);
+    titles.put(MenuTag.CONFIG_WII, R.string.wii_submenu);
+    titles.put(MenuTag.WIIMOTE, R.string.grid_menu_wiimote_settings);
+    titles.put(MenuTag.WIIMOTE_EXTENSION, R.string.wiimote_extensions);
+    titles.put(MenuTag.GCPAD_TYPE, R.string.grid_menu_gcpad_settings);
+    titles.put(MenuTag.GRAPHICS, R.string.grid_menu_graphics_settings);
+    titles.put(MenuTag.HACKS, R.string.hacks_submenu);
+    titles.put(MenuTag.DEBUG, R.string.debug_submenu);
+    titles.put(MenuTag.ENHANCEMENTS, R.string.enhancements_submenu);
+    titles.put(MenuTag.STEREOSCOPY, R.string.stereoscopy_submenu);
+    titles.put(MenuTag.GCPAD_1, R.string.controller_0);
+    titles.put(MenuTag.GCPAD_2, R.string.controller_1);
+    titles.put(MenuTag.GCPAD_3, R.string.controller_2);
+    titles.put(MenuTag.GCPAD_4, R.string.controller_3);
+    titles.put(MenuTag.WIIMOTE_1, R.string.wiimote_4);
+    titles.put(MenuTag.WIIMOTE_2, R.string.wiimote_5);
+    titles.put(MenuTag.WIIMOTE_3, R.string.wiimote_6);
+    titles.put(MenuTag.WIIMOTE_4, R.string.wiimote_7);
+    titles.put(MenuTag.WIIMOTE_EXTENSION_1, R.string.wiimote_extension_4);
+    titles.put(MenuTag.WIIMOTE_EXTENSION_2, R.string.wiimote_extension_5);
+    titles.put(MenuTag.WIIMOTE_EXTENSION_3, R.string.wiimote_extension_6);
+    titles.put(MenuTag.WIIMOTE_EXTENSION_4, R.string.wiimote_extension_7);
+  }
 
   public static Fragment newInstance(MenuTag menuTag, String gameId, Bundle extras)
   {
@@ -94,6 +127,14 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   @Override
   public void onViewCreated(View view, @Nullable Bundle savedInstanceState)
   {
+    Bundle args = getArguments();
+    MenuTag menuTag = (MenuTag) args.getSerializable(ARGUMENT_MENU_TAG);
+
+    if (titles.containsKey(menuTag))
+    {
+      getActivity().setTitle(titles.get(menuTag));
+    }
+
     LinearLayoutManager manager = new LinearLayoutManager(getActivity());
 
     RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.list_settings);
@@ -103,7 +144,7 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     recyclerView.addItemDecoration(new DividerItemDecoration(getActivity(), null));
 
     SettingsActivityView activity = (SettingsActivityView) getActivity();
-    mPresenter.onViewCreated(activity.getSettings());
+    mPresenter.onViewCreated(menuTag, activity.getSettings());
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -69,8 +69,9 @@ public final class SettingsFragmentPresenter
     }
   }
 
-  public void onViewCreated(Settings settings)
+  public void onViewCreated(MenuTag menuTag, Settings settings)
   {
+    this.mMenuTag = menuTag;
     setSettings(settings);
   }
 

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -31,6 +31,15 @@
     <string name="wiimote_7">Wii Remote 4</string>
     <!-- END WARNING -->
 
+    <!-- WARNING Do not move these controller entries AT ALL COSTS! They are indexed with ints, and an assumption
+            is made that they are placed together so that we can access them sequentially in a loop.
+            Wiimotes start at 4 since they are mapped to padID's 4-7 in the native code.-->
+    <string name="wiimote_extension_4">Wii Remote Extension 1</string>
+    <string name="wiimote_extension_5">Wii Remote Extension 2</string>
+    <string name="wiimote_extension_6">Wii Remote Extension 3</string>
+    <string name="wiimote_extension_7">Wii Remote Extension 4</string>
+    <!-- END WARNING -->
+
     <string name="wiimote_extensions">Extension</string>
     <string name="wiimote_extensions_description">Choose and bind the Wii Remote extension.</string>
     <string name="wiimote_ir">IR</string>


### PR DESCRIPTION
Implements https://bugs.dolphin-emu.org/issues/11012.

The old code always displayed "Settings". This PR allows different titles, which makes identifying the current menu easier for users. Example:

![screenshot_20180716-225508_dolphin emulator](https://user-images.githubusercontent.com/17330088/42794386-7ca5247c-894c-11e8-8e44-b4e0bb3475c7.jpg)
