### PR TITLE
FramebufferManager: Use D24S8 on Adreno when using Vulkan

### DIFF
--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -49,6 +49,8 @@ DXGI_FORMAT GetDXGIFormatForHostFormat(AbstractTextureFormat format)
     return DXGI_FORMAT_R32_FLOAT;
   case AbstractTextureFormat::D16:
     return DXGI_FORMAT_R16_TYPELESS;
+  case AbstractTextureFormat::D24_S8:
+    return DXGI_FORMAT_R24G8_TYPELESS;
   case AbstractTextureFormat::D32F:
     return DXGI_FORMAT_R32_TYPELESS;
   case AbstractTextureFormat::D32F_S8:
@@ -64,6 +66,8 @@ DXGI_FORMAT GetSRVFormatForHostFormat(AbstractTextureFormat format)
   {
   case AbstractTextureFormat::D16:
     return DXGI_FORMAT_R16_UNORM;
+  case AbstractTextureFormat::D24_S8:
+    return DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
   case AbstractTextureFormat::D32F:
     return DXGI_FORMAT_R32_FLOAT;
   case AbstractTextureFormat::D32F_S8:
@@ -78,6 +82,8 @@ DXGI_FORMAT GetDSVFormatForHostFormat(AbstractTextureFormat format)
   {
   case AbstractTextureFormat::D16:
     return DXGI_FORMAT_D16_UNORM;
+  case AbstractTextureFormat::D24_S8:
+    return DXGI_FORMAT_D24_UNORM_S8_UINT;
   case AbstractTextureFormat::D32F:
     return DXGI_FORMAT_D32_FLOAT;
   case AbstractTextureFormat::D32F_S8:

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -41,6 +41,8 @@ GLenum GetGLInternalFormatForTextureFormat(AbstractTextureFormat format, bool st
     return GL_R32F;
   case AbstractTextureFormat::D16:
     return GL_DEPTH_COMPONENT16;
+  case AbstractTextureFormat::D24_S8:
+    return GL_DEPTH24_STENCIL8;
   case AbstractTextureFormat::D32F:
     return GL_DEPTH_COMPONENT32F;
   case AbstractTextureFormat::D32F_S8:
@@ -65,6 +67,7 @@ GLenum GetGLFormatForTextureFormat(AbstractTextureFormat format)
   case AbstractTextureFormat::D16:
   case AbstractTextureFormat::D32F:
     return GL_DEPTH_COMPONENT;
+  case AbstractTextureFormat::D24_S8:
   case AbstractTextureFormat::D32F_S8:
     return GL_DEPTH_STENCIL;
   // Compressed texture formats don't use this parameter.
@@ -86,6 +89,8 @@ GLenum GetGLTypeForTextureFormat(AbstractTextureFormat format)
     return GL_FLOAT;
   case AbstractTextureFormat::D16:
     return GL_UNSIGNED_SHORT;
+  case AbstractTextureFormat::D24_S8:
+    return GL_UNSIGNED_INT_24_8;
   case AbstractTextureFormat::D32F:
     return GL_FLOAT;
   case AbstractTextureFormat::D32F_S8:

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -142,12 +142,12 @@ bool FramebufferManager::Initialize()
 
 bool FramebufferManager::CreateEFBRenderPasses()
 {
-  m_efb_load_render_pass =
-      g_object_cache->GetRenderPass(EFB_COLOR_TEXTURE_FORMAT, EFB_DEPTH_TEXTURE_FORMAT,
-                                    g_ActiveConfig.iMultisamples, VK_ATTACHMENT_LOAD_OP_LOAD);
-  m_efb_clear_render_pass =
-      g_object_cache->GetRenderPass(EFB_COLOR_TEXTURE_FORMAT, EFB_DEPTH_TEXTURE_FORMAT,
-                                    g_ActiveConfig.iMultisamples, VK_ATTACHMENT_LOAD_OP_CLEAR);
+  m_efb_load_render_pass = g_object_cache->GetRenderPass(
+      EFB_COLOR_TEXTURE_FORMAT, Util::GetVkFormatForHostTextureFormat(GetEFBDepthFormat()),
+      g_ActiveConfig.iMultisamples, VK_ATTACHMENT_LOAD_OP_LOAD);
+  m_efb_clear_render_pass = g_object_cache->GetRenderPass(
+      EFB_COLOR_TEXTURE_FORMAT, Util::GetVkFormatForHostTextureFormat(GetEFBDepthFormat()),
+      g_ActiveConfig.iMultisamples, VK_ATTACHMENT_LOAD_OP_CLEAR);
   m_depth_resolve_render_pass = g_object_cache->GetRenderPass(
       EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT, VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
   return m_efb_load_render_pass != VK_NULL_HANDLE && m_efb_clear_render_pass != VK_NULL_HANDLE &&
@@ -181,7 +181,8 @@ bool FramebufferManager::CreateEFBFramebuffer()
                             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
 
   m_efb_depth_texture = Texture2D::Create(
-      efb_width, efb_height, 1, efb_layers, EFB_DEPTH_TEXTURE_FORMAT, efb_samples,
+      efb_width, efb_height, 1, efb_layers,
+      Util::GetVkFormatForHostTextureFormat(GetEFBDepthFormat()), efb_samples,
       VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
       VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
           VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);

--- a/Source/Core/VideoBackends/Vulkan/Texture2D.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Texture2D.cpp
@@ -169,9 +169,8 @@ void Texture2D::TransitionToLayout(VkCommandBuffer command_buffer, VkImageLayout
       VK_QUEUE_FAMILY_IGNORED,                 // uint32_t                   srcQueueFamilyIndex
       VK_QUEUE_FAMILY_IGNORED,                 // uint32_t                   dstQueueFamilyIndex
       m_image,                                 // VkImage                    image
-      {static_cast<VkImageAspectFlags>(Util::IsDepthFormat(m_format) ? VK_IMAGE_ASPECT_DEPTH_BIT :
-                                                                       VK_IMAGE_ASPECT_COLOR_BIT),
-       0, m_levels, 0, m_layers}  // VkImageSubresourceRange    subresourceRange
+      {Util::GetImageAspectForFormat(m_format), 0, m_levels, 0,
+       m_layers}  // VkImageSubresourceRange    subresourceRange
   };
 
   // srcStageMask -> Stages that must complete before the barrier
@@ -316,9 +315,8 @@ void Texture2D::TransitionToLayout(VkCommandBuffer command_buffer, ComputeImageL
       VK_QUEUE_FAMILY_IGNORED,                 // uint32_t                   srcQueueFamilyIndex
       VK_QUEUE_FAMILY_IGNORED,                 // uint32_t                   dstQueueFamilyIndex
       m_image,                                 // VkImage                    image
-      {static_cast<VkImageAspectFlags>(Util::IsDepthFormat(m_format) ? VK_IMAGE_ASPECT_DEPTH_BIT :
-                                                                       VK_IMAGE_ASPECT_COLOR_BIT),
-       0, m_levels, 0, m_layers}  // VkImageSubresourceRange    subresourceRange
+      {Util::GetImageAspectForFormat(m_format), 0, m_levels, 0,
+       m_layers}  // VkImageSubresourceRange    subresourceRange
   };
 
   VkPipelineStageFlags srcStageMask, dstStageMask;

--- a/Source/Core/VideoBackends/Vulkan/Util.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Util.cpp
@@ -118,6 +118,9 @@ VkFormat GetVkFormatForHostTextureFormat(AbstractTextureFormat format)
   case AbstractTextureFormat::D16:
     return VK_FORMAT_D16_UNORM;
 
+  case AbstractTextureFormat::D24_S8:
+    return VK_FORMAT_D24_UNORM_S8_UINT;
+
   case AbstractTextureFormat::R32F:
     return VK_FORMAT_R32_SFLOAT;
 
@@ -130,6 +133,24 @@ VkFormat GetVkFormatForHostTextureFormat(AbstractTextureFormat format)
   default:
     PanicAlert("Unhandled texture format.");
     return VK_FORMAT_R8G8B8A8_UNORM;
+  }
+}
+
+VkImageAspectFlags GetImageAspectForFormat(VkFormat format)
+{
+  switch (format)
+  {
+  case VK_FORMAT_D16_UNORM_S8_UINT:
+  case VK_FORMAT_D24_UNORM_S8_UINT:
+  case VK_FORMAT_D32_SFLOAT_S8_UINT:
+    return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+
+  case VK_FORMAT_D16_UNORM:
+  case VK_FORMAT_D32_SFLOAT:
+    return VK_IMAGE_ASPECT_DEPTH_BIT;
+
+  default:
+    return VK_IMAGE_ASPECT_COLOR_BIT;
   }
 }
 

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -29,6 +29,7 @@ bool IsDepthFormat(VkFormat format);
 bool IsCompressedFormat(VkFormat format);
 VkFormat GetLinearFormat(VkFormat format);
 VkFormat GetVkFormatForHostTextureFormat(AbstractTextureFormat format);
+VkImageAspectFlags GetImageAspectForFormat(VkFormat format);
 u32 GetTexelSize(VkFormat format);
 u32 GetBlockSize(VkFormat format);
 

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -94,8 +94,8 @@ std::unique_ptr<VKTexture> VKTexture::Create(const TextureConfig& tex_config)
     {
       // Clear render targets before use to prevent reading uninitialized memory.
       VkClearDepthStencilValue clear_value = {0.0f, 0};
-      VkImageSubresourceRange clear_range = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, tex_config.levels, 0,
-                                             tex_config.layers};
+      VkImageSubresourceRange clear_range = {Util::GetImageAspectForFormat(vk_format), 0,
+                                             tex_config.levels, 0, tex_config.layers};
       texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentInitCommandBuffer(),
                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
       vkCmdClearDepthStencilImage(g_command_buffer_mgr->GetCurrentInitCommandBuffer(),

--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -69,6 +69,7 @@ bool AbstractTexture::IsDepthFormat(AbstractTextureFormat format)
   switch (format)
   {
   case AbstractTextureFormat::D16:
+  case AbstractTextureFormat::D24_S8:
   case AbstractTextureFormat::D32F:
   case AbstractTextureFormat::D32F_S8:
     return true;
@@ -80,7 +81,7 @@ bool AbstractTexture::IsDepthFormat(AbstractTextureFormat format)
 
 bool AbstractTexture::IsStencilFormat(AbstractTextureFormat format)
 {
-  return format == AbstractTextureFormat::D32F_S8;
+  return format == AbstractTextureFormat::D24_S8 || format == AbstractTextureFormat::D32F_S8;
 }
 
 size_t AbstractTexture::CalculateStrideForFormat(AbstractTextureFormat format, u32 row_length)
@@ -100,6 +101,7 @@ size_t AbstractTexture::CalculateStrideForFormat(AbstractTextureFormat format, u
   case AbstractTextureFormat::BGRA8:
   case AbstractTextureFormat::R32F:
   case AbstractTextureFormat::D32F:
+  case AbstractTextureFormat::D24_S8:
     return static_cast<size_t>(row_length) * 4;
   case AbstractTextureFormat::D32F_S8:
     return static_cast<size_t>(row_length) * 8;
@@ -124,6 +126,7 @@ size_t AbstractTexture::GetTexelSizeForFormat(AbstractTextureFormat format)
     return 2;
   case AbstractTextureFormat::RGBA8:
   case AbstractTextureFormat::BGRA8:
+  case AbstractTextureFormat::D24_S8:
   case AbstractTextureFormat::R32F:
   case AbstractTextureFormat::D32F:
     return 4;

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -108,7 +108,8 @@ static BugInfo m_known_bugs[] = {
      -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_IMGTEC, DRIVER_IMGTEC, Family::UNKNOWN,
      BUG_BROKEN_CLEAR_LOADOP_RENDERPASS, -1.0, -1.0, true},
-};
+    {API_VULKAN, OS_ALL, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN, BUG_BROKEN_D32F_CLEAR,
+     -1.0, -1.0, true}};
 
 static std::map<Bug, BugInfo> m_bugs;
 

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -269,6 +269,13 @@ enum Bug
   // Started Version: 1.7
   // Ended Version: 1.10
   BUG_BROKEN_CLEAR_LOADOP_RENDERPASS,
+
+  // BUG: 32-bit depth clears are broken in the Adreno Vulkan driver, and have no effect.
+  // To work around this, we use a D24_S8 buffer instead, which results in a loss of accuracy.
+  // We still resolve this to a R32F texture, as there is no 24-bit format.
+  // Started version: -1
+  // Ended version: -1
+  BUG_BROKEN_D32F_CLEAR,
 };
 
 // Initializes our internal vendor, device family, and driver version

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "VideoCommon/AbstractTexture.h"
+#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/RenderBase.h"
 
 std::unique_ptr<FramebufferManagerBase> g_framebuffer_manager;
@@ -17,5 +18,11 @@ FramebufferManagerBase::~FramebufferManagerBase() = default;
 
 AbstractTextureFormat FramebufferManagerBase::GetEFBDepthFormat()
 {
-  return AbstractTextureFormat::D32F;
+  // 32-bit depth clears are broken in the Adreno Vulkan driver, and have no effect.
+  // To work around this, we use a D24_S8 buffer instead, which results in a loss of accuracy.
+  // We still resolve this to a R32F texture, as there is no 24-bit format.
+  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_D32F_CLEAR))
+    return AbstractTextureFormat::D24_S8;
+  else
+    return AbstractTextureFormat::D32F;
 }

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/RenderBase.h"
 
 std::unique_ptr<FramebufferManagerBase> g_framebuffer_manager;
@@ -13,3 +14,8 @@ std::unique_ptr<FramebufferManagerBase> g_framebuffer_manager;
 unsigned int FramebufferManagerBase::m_EFBLayers = 1;
 
 FramebufferManagerBase::~FramebufferManagerBase() = default;
+
+AbstractTextureFormat FramebufferManagerBase::GetEFBDepthFormat()
+{
+  return AbstractTextureFormat::D32F;
+}

--- a/Source/Core/VideoCommon/FramebufferManagerBase.h
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.h
@@ -8,6 +8,8 @@
 
 #include "Common/CommonTypes.h"
 
+enum class AbstractTextureFormat : u32;
+
 inline bool AddressRangesOverlap(u32 aLower, u32 aUpper, u32 bLower, u32 bUpper)
 {
   return !((aLower >= bUpper) || (bLower >= aUpper));
@@ -19,6 +21,7 @@ public:
   virtual ~FramebufferManagerBase();
 
   static unsigned int GetEFBLayers() { return m_EFBLayers; }
+  static AbstractTextureFormat GetEFBDepthFormat();
 
 protected:
   static unsigned int m_EFBLayers;

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -10,6 +10,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Host.h"
 
+#include "VideoCommon/FramebufferManagerBase.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"
@@ -26,6 +27,7 @@ bool ShaderCache::Initialize()
 {
   m_api_type = g_ActiveConfig.backend_info.api_type;
   m_host_config = ShaderHostConfig::GetCurrent();
+  m_efb_depth_format = FramebufferManagerBase::GetEFBDepthFormat();
   m_efb_multisamples = g_ActiveConfig.iMultisamples;
 
   // Create the async compiler, and start the worker threads.
@@ -441,7 +443,7 @@ AbstractPipelineConfig ShaderCache::GetGXPipelineConfig(
   config.depth_state = depth_state;
   config.blending_state = blending_state;
   config.framebuffer_state.color_texture_format = AbstractTextureFormat::RGBA8;
-  config.framebuffer_state.depth_texture_format = AbstractTextureFormat::D32F;
+  config.framebuffer_state.depth_texture_format = m_efb_depth_format;
   config.framebuffer_state.per_sample_shading = m_host_config.ssaa;
   config.framebuffer_state.samples = m_efb_multisamples;
   return config;

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -30,6 +30,7 @@
 #include "VideoCommon/VertexShaderGen.h"
 
 class NativeVertexFormat;
+enum class AbstractTextureFormat : u32;
 
 namespace VideoCommon
 {
@@ -129,6 +130,7 @@ private:
   // Configuration bits.
   APIType m_api_type = APIType::Nothing;
   ShaderHostConfig m_host_config = {};
+  AbstractTextureFormat m_efb_depth_format;
   u32 m_efb_multisamples = 1;
   std::unique_ptr<AsyncShaderCompiler> m_async_shader_compiler;
 

--- a/Source/Core/VideoCommon/TextureConfig.h
+++ b/Source/Core/VideoCommon/TextureConfig.h
@@ -20,6 +20,7 @@ enum class AbstractTextureFormat : u32
   BPTC,
   R16,
   D16,
+  D24_S8,
   R32F,
   D32F,
   D32F_S8,


### PR DESCRIPTION
D32F clears are broken on Adreno, and appear to have no effect. This resulted in smeared geometry, and completely broken rendering. I'm sure there's plenty of other broken graphics, but this is a major one.

Note that using a 24-bit buffer here does result in a loss of accuracy, and may break a handful? of games. Therefore, it is restricted to Adreno/Vulkan, even if it would be faster on other platforms.