### PR TITLE
fix compilation w/o Discord Rich Presence

### DIFF
--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -83,7 +83,9 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
 
   m_checkbox_dualcore->setEnabled(!running);
   m_checkbox_cheats->setEnabled(!running);
+#ifdef USE_DISCORD_PRESENCE
   m_checkbox_discord_presence->setEnabled(!running);
+#endif
 
   for (QRadioButton* radio_button : m_cpu_cores)
     radio_button->setEnabled(!running);


### PR DESCRIPTION
After the merge of #7266 you can't build Dolphin anymore if `USE_DISCORD_PRESENCE` is not defined.