### PR TITLE
RFC: Cmake MacOS postprocess bundle build fix

### DIFF
--- a/CMake/DolphinPostprocessBundle.cmake
+++ b/CMake/DolphinPostprocessBundle.cmake
@@ -36,7 +36,7 @@ set(extra_dirs "/usr/local/lib" "/lib" "/usr/lib")
 
 # BundleUtilities is overly verbose, so disable most of its messages
 function(message)
-	if(NOT ARGV MATCHES "^STATUS;")
+	if(NOT ARGV MATCHES "^STATUS;" AND NOT ARGV MATCHES "")
 		_message(${ARGV})
 	endif()
 endfunction()


### PR DESCRIPTION
It seems on my system cmake (homebrew's version 3.11.4) fails on the bundle
postprocess step as it calls the log with no arguments, which causes it to
error and delete the partial build