### PR TITLE
Qt/IOWindow: Don't set QSizePolicy::Expanding on macOS

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -78,11 +78,14 @@ void IOWindow::CreateMainLayout()
   m_main_layout->addLayout(range_hbox);
 
   // Options (Buttons, Outputs) and action buttons
+  // macOS style doesn't support expanding buttons
+#ifndef __APPLE__
   for (QPushButton* button : {m_select_button, m_detect_button, m_or_button, m_and_button,
                               m_add_button, m_not_button, m_test_button})
   {
     button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   }
+#endif
 
   auto* hbox = new QHBoxLayout();
   auto* button_vbox = new QVBoxLayout();


### PR DESCRIPTION
This should fix one of of the two problems shown in this issue: https://bugs.dolphin-emu.org/issues/11292

This is more of a test, as I've found several other buttons using this size policy as well, so if it turns out to be a problem we might want to blanket all of them. Either that, or just ignore the issues entirely and say "Ask apple to support expanding buttons."