### PR TITLE
Update INI for Rubik's Rush

### DIFF
--- a/Data/Sys/GameSettings/WZI.ini
+++ b/Data/Sys/GameSettings/WZI.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-DCBZ = 1
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -13,3 +12,7 @@ DCBZ = 1
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+
+[Video_Hacks]
+ImmediateXFBEnable = False


### PR DESCRIPTION
Skip DCBZ was breaking a lot of 2D graphics for no reason and
Immediately Present XFB copies causes output issues.

Here's what Skip DCBZ was doing to the game for, all I can tell, no reason.  I was able to get in-game fine without it.  If there's something later on that requires this level of breakage for the game to work, someone will need to enlighten me.

SKIP DCBZ HACK ON
![wzietw-2](https://user-images.githubusercontent.com/6598209/42988717-ac811166-8bcb-11e8-8565-5e9d180ae791.png)

SKIP DCBZ HACK OFF
![wzietw-1](https://user-images.githubusercontent.com/6598209/42988741-c093335a-8bcb-11e8-9a8a-dd7ff27d3769.png)
