### PR TITLE
Config: Remove Core::DCBZ [bDCBZOFF] - obsolete

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -77,7 +77,6 @@ private:
   bool bFPRF;
   bool bAccurateNaNs;
   bool bMMU;
-  bool bDCBZOFF;
   bool bLowDCBZHack;
   bool m_EnableJIT;
   bool bSyncGPU;
@@ -108,7 +107,6 @@ void ConfigCache::SaveConfig(const SConfig& config)
   bFPRF = config.bFPRF;
   bAccurateNaNs = config.bAccurateNaNs;
   bMMU = config.bMMU;
-  bDCBZOFF = config.bDCBZOFF;
   m_EnableJIT = config.m_DSPEnableJIT;
   bSyncGPU = config.bSyncGPU;
   bFastDiscSpeed = config.bFastDiscSpeed;
@@ -148,7 +146,6 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bFPRF = bFPRF;
   config->bAccurateNaNs = bAccurateNaNs;
   config->bMMU = bMMU;
-  config->bDCBZOFF = bDCBZOFF;
   config->bLowDCBZHack = bLowDCBZHack;
   config->m_DSPEnableJIT = m_EnableJIT;
   config->bSyncGPU = bSyncGPU;
@@ -248,7 +245,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     core_section->Get("FPRF", &StartUp.bFPRF, StartUp.bFPRF);
     core_section->Get("AccurateNaNs", &StartUp.bAccurateNaNs, StartUp.bAccurateNaNs);
     core_section->Get("MMU", &StartUp.bMMU, StartUp.bMMU);
-    core_section->Get("DCBZ", &StartUp.bDCBZOFF, StartUp.bDCBZOFF);
     core_section->Get("LowDCBZHack", &StartUp.bLowDCBZHack, StartUp.bLowDCBZHack);
     core_section->Get("SyncGPU", &StartUp.bSyncGPU, StartUp.bSyncGPU);
     core_section->Get("FastDiscSpeed", &StartUp.bFastDiscSpeed, StartUp.bFastDiscSpeed);

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -79,7 +79,6 @@ const ConfigInfo<int> MAIN_SYNC_GPU_MIN_DISTANCE{{System::Main, "Core", "SyncGpu
                                                  -200000};
 const ConfigInfo<float> MAIN_SYNC_GPU_OVERCLOCK{{System::Main, "Core", "SyncGpuOverclock"}, 1.0f};
 const ConfigInfo<bool> MAIN_FAST_DISC_SPEED{{System::Main, "Core", "FastDiscSpeed"}, false};
-const ConfigInfo<bool> MAIN_DCBZ{{System::Main, "Core", "DCBZ"}, false};
 const ConfigInfo<bool> MAIN_LOW_DCBZ_HACK{{System::Main, "Core", "LowDCBZHack"}, false};
 const ConfigInfo<bool> MAIN_FPRF{{System::Main, "Core", "FPRF"}, false};
 const ConfigInfo<bool> MAIN_ACCURATE_NANS{{System::Main, "Core", "AccurateNaNs"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -58,7 +58,6 @@ extern const ConfigInfo<int> MAIN_SYNC_GPU_MAX_DISTANCE;
 extern const ConfigInfo<int> MAIN_SYNC_GPU_MIN_DISTANCE;
 extern const ConfigInfo<float> MAIN_SYNC_GPU_OVERCLOCK;
 extern const ConfigInfo<bool> MAIN_FAST_DISC_SPEED;
-extern const ConfigInfo<bool> MAIN_DCBZ;
 extern const ConfigInfo<bool> MAIN_LOW_DCBZ_HACK;
 extern const ConfigInfo<bool> MAIN_FPRF;
 extern const ConfigInfo<bool> MAIN_ACCURATE_NANS;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -533,7 +533,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("SyncGpuMinDistance", &iSyncGpuMinDistance, -200000);
   core->Get("SyncGpuOverclock", &fSyncGpuOverclock, 1.0f);
   core->Get("FastDiscSpeed", &bFastDiscSpeed, false);
-  core->Get("DCBZ", &bDCBZOFF, false);
   core->Get("LowDCBZHack", &bLowDCBZHack, false);
   core->Get("FPRF", &bFPRF, false);
   core->Get("AccurateNaNs", &bAccurateNaNs, false);
@@ -758,7 +757,6 @@ void SConfig::LoadDefaults()
 #else
   bMMU = false;
 #endif
-  bDCBZOFF = false;
   bLowDCBZHack = false;
   iBBDumpPort = -1;
   bSyncGPU = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -122,7 +122,6 @@ struct SConfig
   bool bRunCompareClient = false;
 
   bool bMMU = false;
-  bool bDCBZOFF = false;
   bool bLowDCBZHack = false;
   int iBBDumpPort = 0;
   bool bFastDiscSpeed = false;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -502,11 +502,6 @@ void Interpreter::dcbtst(UGeckoInstruction inst)
 
 void Interpreter::dcbz(UGeckoInstruction inst)
 {
-  // DCBZOFF is a hack to fix certain games which would otherwise require
-  // accurate L2 emulation.
-  if (SConfig::GetInstance().bDCBZOFF)
-    return;
-
   const u32 dcbz_addr = Helper_Get_EA_X(inst);
 
   if (!HID0.DCE)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -330,8 +330,6 @@ void Jit64::dcbz(UGeckoInstruction inst)
 {
   INSTRUCTION_START
   JITDISABLE(bJITLoadStoreOff);
-  if (SConfig::GetInstance().bDCBZOFF)
-    return;
   FALLBACK_IF(SConfig::GetInstance().bLowDCBZHack);
 
   int a = inst.RA;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -630,8 +630,6 @@ void JitArm64::dcbz(UGeckoInstruction inst)
 {
   INSTRUCTION_START
   JITDISABLE(bJITLoadStoreOff);
-  if (SConfig::GetInstance().bDCBZOFF)
-    return;
   FALLBACK_IF(jo.memcheck);
   FALLBACK_IF(SConfig::GetInstance().bLowDCBZHack);
 


### PR DESCRIPTION
This option completely disabled the DCBZ instruction. Users are toggling
this option in dolphin forks and using that same problematic config when
launching dolphin. Removing the option from dolphin will let the config be
ignored.

Since PR7281, no title ships an INI with a setting for this option.