### PR TITLE
Android: Fix emulated wiimotes via controller

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/MenuTag.java
@@ -18,14 +18,14 @@ public enum MenuTag
     GCPAD_2("gcpad", 1),
     GCPAD_3("gcpad", 2),
     GCPAD_4("gcpad", 3),
-    WIIMOTE_1("wiimote", 1),
-    WIIMOTE_2("wiimote", 2),
-    WIIMOTE_3("wiimote", 3),
-    WIIMOTE_4("wiimote", 4),
-    WIIMOTE_EXTENSION_1("wiimote_extension", 1),
-    WIIMOTE_EXTENSION_2("wiimote_extension", 2),
-    WIIMOTE_EXTENSION_3("wiimote_extension", 3),
-    WIIMOTE_EXTENSION_4("wiimote_extension", 4);
+    WIIMOTE_1("wiimote", 4),
+    WIIMOTE_2("wiimote", 5),
+    WIIMOTE_3("wiimote", 6),
+    WIIMOTE_4("wiimote", 7),
+    WIIMOTE_EXTENSION_1("wiimote_extension", 4),
+    WIIMOTE_EXTENSION_2("wiimote_extension", 5),
+    WIIMOTE_EXTENSION_3("wiimote_extension", 6),
+    WIIMOTE_EXTENSION_4("wiimote_extension", 7);
 
     private String tag;
     private int subType = -1;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -329,11 +329,11 @@ public final class SettingsFragmentPresenter
 	{
 		if (!mSettings.get(SettingsFile.SETTINGS_WIIMOTE).isEmpty())
 		{
-			for (int i = 1; i <= 4; i++)
+			for (int i = 0; i < 4; i++)
 			{
 				// TODO This wiimote_0 + i business is quite the hack. It should work, but only if the definitions are kept together and in order.
 				Setting wiimoteSetting = mSettings.get(SettingsFile.SETTINGS_WIIMOTE).get(SettingsFile.SECTION_WIIMOTE + i).getSetting(SettingsFile.KEY_WIIMOTE_TYPE);
-				sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_TYPE, SettingsFile.SECTION_WIIMOTE + i, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_0 + i - 1, 0, R.array.wiimoteTypeEntries, R.array.wiimoteTypeValues, 0, wiimoteSetting, MenuTag.getWiimoteMenuTag(i)));
+				sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_TYPE, SettingsFile.SECTION_WIIMOTE + i, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_4 + i, 0, R.array.wiimoteTypeEntries, R.array.wiimoteTypeValues, 0, wiimoteSetting, MenuTag.getWiimoteMenuTag(i+4)));
 			}
 		}
 	}

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -23,11 +23,12 @@
     <string name="analog_threshold">Analog Threshold (Low value = High sensitivity)</string>
 
     <!-- WARNING Do not move these controller entries AT ALL COSTS! They are indexed with ints, and an assumption
-            is made that they are placed together so that we can access them sequentially in a loop. -->
-    <string name="wiimote_0">Wii Remote 1</string>
-    <string name="wiimote_1">Wii Remote 2</string>
-    <string name="wiimote_2">Wii Remote 3</string>
-    <string name="wiimote_3">Wii Remote 4</string>
+            is made that they are placed together so that we can access them sequentially in a loop.
+            Wiimotes start at 4 since they are mapped to padID's 4-7 in the native code.-->
+    <string name="wiimote_4">Wii Remote 1</string>
+    <string name="wiimote_5">Wii Remote 2</string>
+    <string name="wiimote_6">Wii Remote 3</string>
+    <string name="wiimote_7">Wii Remote 4</string>
     <!-- END WARNING -->
 
     <string name="wiimote_extensions">Extension</string>


### PR DESCRIPTION
A little background: Android has 8 controller setup, 4 gamecube pads and 4 wiimote pads. When the static GCPadNew.ini and wiimotenew.ini is created, pads 0-3 are gc 1-4, and 4-7 are wii 1-4. 

Problem was the settings set wii controllers as pads 1-4, instead of 4-7. So any setting for wiimote1, was set for gc2(padID 1). Which is why the only wiimote to work was 4, since it mapped to padID 4, which is actually wiimote1.