### PR TITLE
Jit: Fix branch following.

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -714,9 +714,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
       if (inst.OPCD == 18 && block_size > 1)
       {
         // Always follow BX instructions.
-        // TODO: Loop unrolling might bloat the code size too much.
-        //       Enable it carefully.
-        follow = destination != block->m_address;
+        follow = true;
         destination = SignExt26(inst.LI << 2) + (inst.AA ? 0 : address);
         if (inst.LK)
         {


### PR DESCRIPTION
The idea of this code was to not unroll loops, but it was completely broken.
So we've unrolled all loops, but only up to the second iteration.
Honestly, a better check would test if we branch to code which is already in the compiling block. But this is out of scope for now.

We'll see if this makes it faster or slower...

But testing shows that this unrolling actually improve the performance. So instead of fixing this bug, this check can be dropped.