### PR TITLE
Android: Fix wiimote settings saving.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -332,7 +332,7 @@ public final class SettingsFragmentPresenter
 			for (int i = 0; i < 4; i++)
 			{
 				// TODO This wiimote_0 + i business is quite the hack. It should work, but only if the definitions are kept together and in order.
-				Setting wiimoteSetting = mSettings.get(SettingsFile.SETTINGS_WIIMOTE).get(SettingsFile.SECTION_WIIMOTE + i).getSetting(SettingsFile.KEY_WIIMOTE_TYPE);
+				Setting wiimoteSetting = mSettings.get(SettingsFile.SETTINGS_WIIMOTE).get(SettingsFile.SECTION_WIIMOTE + (i + 1)).getSetting(SettingsFile.KEY_WIIMOTE_TYPE);
 				sl.add(new SingleChoiceSetting(SettingsFile.KEY_WIIMOTE_TYPE, SettingsFile.SECTION_WIIMOTE + i, SettingsFile.SETTINGS_WIIMOTE, R.string.wiimote_4 + i, 0, R.array.wiimoteTypeEntries, R.array.wiimoteTypeValues, 0, wiimoteSetting, MenuTag.getWiimoteMenuTag(i+4)));
 			}
 		}


### PR DESCRIPTION
Index was off by one, so if you enabled Emulated Controller for
wiimote1, it would set the 'Source = 1' for wiimote0.