### PR TITLE
Qt/Debugger: Make spacing more compact

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -25,6 +25,7 @@ BreakpointWidget::BreakpointWidget(QWidget* parent) : QDockWidget(parent)
 {
   setWindowTitle(tr("Breakpoints"));
   setObjectName(QStringLiteral("breakpoints"));
+  setTitleBarWidget(new QWidget);
 
   setAllowedAreas(Qt::AllDockWidgetAreas);
 
@@ -78,9 +79,11 @@ BreakpointWidget::~BreakpointWidget()
 void BreakpointWidget::CreateWidgets()
 {
   m_toolbar = new QToolBar;
+  m_toolbar->setContentsMargins(0, 0, 0, 0);
   m_toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
   m_table = new QTableWidget;
+  m_table->setContentsMargins(0, 0, 0, 0);
   m_table->setColumnCount(5);
   m_table->setSelectionMode(QAbstractItemView::SingleSelection);
   m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -100,6 +103,8 @@ void BreakpointWidget::CreateWidgets()
 
   layout->addWidget(m_toolbar);
   layout->addWidget(m_table);
+  layout->setContentsMargins(2, 2, 2, 2);
+  layout->setSpacing(0);
 
   m_new = m_toolbar->addAction(tr("New"), this, &BreakpointWidget::OnNewBreakpoint);
   m_delete = m_toolbar->addAction(tr("Delete"), this, &BreakpointWidget::OnDelete);

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -38,7 +38,8 @@ CodeViewWidget::CodeViewWidget()
   setContextMenuPolicy(Qt::CustomContextMenu);
   setSelectionMode(QAbstractItemView::SingleSelection);
   setSelectionBehavior(QAbstractItemView::SelectRows);
-  verticalScrollBar()->setHidden(true);
+
+  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
   for (int i = 0; i < columnCount(); i++)
   {

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -85,6 +85,9 @@ void CodeWidget::CreateWidgets()
 {
   auto* layout = new QGridLayout;
 
+  layout->setContentsMargins(2, 2, 2, 2);
+  layout->setSpacing(0);
+
   m_search_address = new QLineEdit;
   m_search_symbols = new QLineEdit;
   m_code_view = new CodeViewWidget;

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -102,6 +102,7 @@ void JITWidget::CreateWidgets()
 
   QWidget* widget = new QWidget;
   auto* layout = new QVBoxLayout;
+  layout->setContentsMargins(2, 2, 2, 2);
   widget->setLayout(layout);
 
   layout->addWidget(m_table_splitter);

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -26,7 +26,7 @@ MemoryViewWidget::MemoryViewWidget(QWidget* parent) : QTableWidget(parent)
 {
   horizontalHeader()->hide();
   verticalHeader()->hide();
-  verticalScrollBar()->setHidden(true);
+  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setShowGrid(false);
 
   setFont(Settings::Instance().GetDebugFont());

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -76,6 +76,9 @@ void MemoryWidget::CreateWidgets()
 {
   auto* layout = new QHBoxLayout;
 
+  layout->setContentsMargins(2, 2, 2, 2);
+  layout->setSpacing(0);
+
   //// Sidebar
 
   // Search
@@ -105,6 +108,7 @@ void MemoryWidget::CreateWidgets()
   search_layout->addWidget(m_find_next);
   search_layout->addWidget(m_find_previous);
   search_layout->addWidget(m_result_label);
+  search_layout->setSpacing(1);
 
   // Data Type
   auto* datatype_group = new QGroupBox(tr("Data Type"));
@@ -122,6 +126,7 @@ void MemoryWidget::CreateWidgets()
   datatype_layout->addWidget(m_type_u32);
   datatype_layout->addWidget(m_type_ascii);
   datatype_layout->addWidget(m_type_float);
+  datatype_layout->setSpacing(1);
 
   // MBP options
   auto* bp_group = new QGroupBox(tr("Memory breakpoint options"));
@@ -146,10 +151,13 @@ void MemoryWidget::CreateWidgets()
   bp_layout->addWidget(m_bp_read_only);
   bp_layout->addWidget(m_bp_write_only);
   bp_layout->addWidget(m_bp_log_check);
+  bp_layout->setSpacing(1);
 
   // Sidebar
   auto* sidebar = new QWidget;
   auto* sidebar_layout = new QVBoxLayout;
+  sidebar_layout->setSpacing(1);
+
   sidebar->setLayout(sidebar_layout);
 
   sidebar_layout->addWidget(m_search_address);
@@ -172,7 +180,7 @@ void MemoryWidget::CreateWidgets()
   auto* sidebar_scroll = new QScrollArea;
   sidebar_scroll->setWidget(sidebar);
   sidebar_scroll->setWidgetResizable(true);
-  sidebar_scroll->setFixedWidth(250);
+  sidebar_scroll->setFixedWidth(190);
 
   m_memory_view = new MemoryViewWidget(this);
 

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -87,6 +87,7 @@ void RegisterWidget::CreateWidgets()
   QWidget* widget = new QWidget;
   auto* layout = new QVBoxLayout;
   layout->addWidget(m_table);
+  layout->setContentsMargins(2, 2, 2, 2);
   widget->setLayout(layout);
 
   setWidget(widget);

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -74,10 +74,12 @@ WatchWidget::~WatchWidget()
 void WatchWidget::CreateWidgets()
 {
   m_toolbar = new QToolBar;
+  m_toolbar->setContentsMargins(0, 0, 0, 0);
   m_toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
   m_table = new QTableWidget;
 
+  m_table->setContentsMargins(0, 0, 0, 0);
   m_table->setColumnCount(5);
   m_table->verticalHeader()->setHidden(true);
   m_table->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -90,6 +92,8 @@ void WatchWidget::CreateWidgets()
   m_save->setEnabled(false);
 
   auto* layout = new QVBoxLayout;
+  layout->setContentsMargins(2, 2, 2, 2);
+  layout->setSpacing(0);
   layout->addWidget(m_toolbar);
   layout->addWidget(m_table);
 


### PR DESCRIPTION
This should make the debugger widgets more compact overall.
![Screenshot](https://i.imgur.com/tFuFAei.png)