### PR TITLE
DolphinQt: Add .dff to open file filter

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -549,7 +549,7 @@ QString MainWindow::PromptFileName()
   QString path = QFileDialog::getOpenFileName(
       this, tr("Select a File"),
       settings.value(QStringLiteral("mainwindow/lastdir"), QStringLiteral("")).toString(),
-      tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs *.ciso *.gcz *.wad);;"
+      tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs *.ciso *.gcz *.wad *.dff);;"
          "All Files (*)"));
 
   if (!path.isEmpty())


### PR DESCRIPTION
Makes opening fifologs a little annoying currently.

Only issue I can see is that changing discs also goes through this method. But the filter already has .elf/.dol/.wad in it, so that should just fail in DVDInterface anyway. We probably should use a different filter for changing disc ;)