### PR TITLE
Android: Return 0 on fail on WiimoteReal IOWrite and update WiimoteNew defaults

### DIFF
--- a/Source/Android/app/src/main/assets/WiimoteNew.ini
+++ b/Source/Android/app/src/main/assets/WiimoteNew.ini
@@ -267,7 +267,7 @@ Turntable/Stick/Radius = 100,000000
 Turntable/Effect/Dial = `Axis 621`
 Turntable/Crossfade/Left = `Axis 623`
 Turntable/Crossfade/Right = `Axis 624`
-Source = 1
+Source = 0
 [Wiimote3]
 Device = Android/6/Touchscreen
 Buttons/A = `Button 100`
@@ -402,7 +402,7 @@ Turntable/Stick/Radius = 100,000000
 Turntable/Effect/Dial = `Axis 621`
 Turntable/Crossfade/Left = `Axis 623`
 Turntable/Crossfade/Right = `Axis 624`
-Source = 1
+Source = 0
 [Wiimote4]
 Device = Android/7/Touchscreen
 Buttons/A = `Button 100`
@@ -537,4 +537,4 @@ Turntable/Stick/Radius = 100,000000
 Turntable/Effect/Dial = `Axis 621`
 Turntable/Crossfade/Left = `Axis 623`
 Turntable/Crossfade/Right = `Axis 624`
-Source = 1
+Source = 0

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
@@ -107,7 +107,7 @@ public class Java_WiimoteAdapter
 				1000);
 
 		if (write < 0)
-			return -1;
+			return 0;
 
 		return write + 1;
 	}


### PR DESCRIPTION
Some of the write checks do an & on the result, returning 0 will allow these fails to be caught.
Updated the default WiimoteNew to set wiimotes 2-4 to be disabled on new install. No reason to have these enabled unless there is actually a 2+ players.

First change fixes a crash at emulation start where a user has two controllers set as Real Wiimotes(source=2) but they only have one Wiimote actually connected to the dolphin bar. There is still a crash if Wiimote 1 is disconnected during gameplay, but this should be less common since it would be an intentional act by the player. 
Updating the defaults just cleans some annoyances, one such is being spammed with "Controllers 2-4 Connected" when playing just touch screen.