### PR TITLE
Android:  Add exit to phone emu menu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -45,6 +45,7 @@ import org.dolphinemu.dolphinemu.utils.ControllerMappingHelper;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.Java_GCAdapter;
 import org.dolphinemu.dolphinemu.utils.Java_WiimoteAdapter;
+import org.dolphinemu.dolphinemu.utils.TvUtil;
 
 import java.lang.annotation.Retention;
 import java.util.List;
@@ -589,7 +590,9 @@ public final class EmulationActivity extends AppCompatActivity
 				return;
 
 			case MENU_ACTION_EXIT:
-				toggleMenu();  // Hide the menu (it will be showing since we just clicked it)
+				// ATV menu is built using a fragment, this will pop that fragment before emulation ends.
+				if(TvUtil.isLeanback(getApplicationContext()))
+					toggleMenu();  // Hide the menu (it will be showing since we just clicked it)
 				mEmulationFragment.stopEmulation();
 				exitWithAnimation();
 				return;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
@@ -6,6 +6,7 @@ import android.app.job.JobScheduler;
 import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -292,5 +293,9 @@ public class TvUtil
 				AppLinkHelper.buildBrowseUri(platform.getHeaderName()).toString()));
 		}
 		return subs;
+	}
+	public static Boolean isLeanback(Context context)
+	{
+		return(context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_LEANBACK));
 	}
 }

--- a/Source/Android/app/src/main/res/menu/menu_emulation.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation.xml
@@ -106,4 +106,8 @@
         app:showAsAction="never"
         android:title="@string/emulation_change_disc"/>
 
+    <item
+        android:id="@+id/menu_exit"
+        app:showAsAction="never"
+        android:title="@string/emulation_exit"/>
 </menu>


### PR DESCRIPTION
Some phones that have capacitive nav bar buttons disable those buttons while in emulation. This gives those devices a way to exit