### PR TITLE
RFC: Add a size cutoff to the arbitrary mipmap detection

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -111,6 +111,10 @@ const ConfigInfo<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetection"}, true};
 const ConfigInfo<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetectionThreshold"}, 14.0f};
+const ConfigInfo<int> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_CUTOFF_HEIGHT{
+    {System::GFX, "Enhancements", "ArbitraryMipmapDetectionCutoffHeight"}, 4};
+const ConfigInfo<int> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_CUTOFF_WIDTH{
+    {System::GFX, "Enhancements", "ArbitraryMipmapDetectionCutoffWidth"}, 4};
 
 // Graphics.Stereoscopy
 

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -87,6 +87,8 @@ extern const ConfigInfo<bool> GFX_ENHANCE_FORCE_TRUE_COLOR;
 extern const ConfigInfo<bool> GFX_ENHANCE_DISABLE_COPY_FILTER;
 extern const ConfigInfo<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION;
 extern const ConfigInfo<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD;
+extern const ConfigInfo<int> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_CUTOFF_HEIGHT;
+extern const ConfigInfo<int> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_CUTOFF_WIDTH;
 
 // Graphics.Stereoscopy
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -517,10 +517,20 @@ public:
 
     float total_diff = 0.f;
 
+    // Very small mipmaps can amplify differences due to compression formats, and some games seem to
+    // have complete junk in the smallest levels that can trigger this unexpectedly - so have a
+    // cutoff based on the side
+
+    const auto cutoff_width = g_ActiveConfig.iArbitraryMipmapDetectionCutoffWidth;
+    const auto cutoff_height = g_ActiveConfig.iArbitraryMipmapDetectionCutoffHeight;
+
     for (std::size_t i = 0; i < levels.size() - 1; ++i)
     {
       const auto& level = levels[i];
       const auto& mip = levels[i + 1];
+
+      if (level.shape.width <= cutoff_width || level.shape.height <= cutoff_width)
+        continue;
 
       u64 level_pixel_count = level.shape.width;
       level_pixel_count *= level.shape.height;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -123,6 +123,10 @@ void VideoConfig::Refresh()
   bArbitraryMipmapDetection = Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
   fArbitraryMipmapDetectionThreshold =
       Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD);
+  iArbitraryMipmapDetectionCutoffWidth =
+      Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_CUTOFF_WIDTH);
+  iArbitraryMipmapDetectionCutoffHeight =
+      Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_CUTOFF_HEIGHT);
 
   stereo_mode = Config::Get(Config::GFX_STEREO_MODE);
   iStereoDepth = Config::Get(Config::GFX_STEREO_DEPTH);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -76,6 +76,8 @@ struct VideoConfig final
   bool bDisableCopyFilter;
   bool bArbitraryMipmapDetection;
   float fArbitraryMipmapDetectionThreshold;
+  int iArbitraryMipmapDetectionCutoffHeight;
+  int iArbitraryMipmapDetectionCutoffWidth;
 
   // Information
   bool bShowFPS;


### PR DESCRIPTION
Initially a completely guessed value of 4x4 - so any mip level with a height or
width of 4 (or smaller) isn't considered in the arbitrary mipmap detection stuff

Hopefully this will avoid false positives due to small levels either containing
complete junk, or compressed formats amplifying errors as the size decreases.