### PR TITLE
GameList: QSortFilterProxyModel should provide strict weak ordering

### DIFF
--- a/Source/Core/DolphinQt/GameList/ListProxyModel.cpp
+++ b/Source/Core/DolphinQt/GameList/ListProxyModel.cpp
@@ -19,7 +19,7 @@ bool ListProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_
 bool ListProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
 {
   if (left.data(Qt::InitialSortOrderRole) != right.data(Qt::InitialSortOrderRole))
-    return !QSortFilterProxyModel::lessThan(left, right);
+    return QSortFilterProxyModel::lessThan(right, left);
 
   // If two items are otherwise equal, compare them by their title
   const auto right_title =


### PR DESCRIPTION
This triggers an assertion in the windows debug build if lessThan(a,b) && lessThan(b,a)

In Qt (QSortFilterProxyModelPrivate::sort_source_rows) the comparator is eventually used by std::stable_sort, which requires its comparison function to provide a strict weak ordering.