### PR TITLE
ConfigManager: Remove m_FrameSkip

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -246,7 +246,6 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("RunCompareServer", bRunCompareServer);
   core->Set("RunCompareClient", bRunCompareClient);
   core->Set("EmulationSpeed", m_EmulationSpeed);
-  core->Set("FrameSkip", m_FrameSkip);
   core->Set("Overclock", m_OCFactor);
   core->Set("OverclockEnable", m_OCEnable);
   core->Set("GFXBackend", m_strVideoBackend);
@@ -535,7 +534,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("EmulationSpeed", &m_EmulationSpeed, 1.0f);
   core->Get("Overclock", &m_OCFactor, 1.0f);
   core->Get("OverclockEnable", &m_OCEnable, false);
-  core->Get("FrameSkip", &m_FrameSkip, 0);
   core->Get("GFXBackend", &m_strVideoBackend, "");
   core->Get("GPUDeterminismMode", &m_strGPUDeterminismMode, "auto");
   core->Get("PerfMapDir", &m_perfDir, "");

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -277,7 +277,6 @@ struct SConfig
   bool m_ShowFrameCount;
   bool m_ShowRTC;
   std::string m_strMovieAuthor;
-  unsigned int m_FrameSkip;
   bool m_DumpFrames;
   bool m_DumpFramesSilent;
   bool m_ShowInputDisplay;

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -63,9 +63,9 @@ static bool IsHotkey(int id, bool held = false)
   return HotkeyManagerEmu::IsPressed(id, held);
 }
 
-static void HandleFrameskipHotkeys()
+static void HandleFrameStepHotkeys()
 {
-  constexpr int MAX_FRAME_SKIP_DELAY = 60;
+  constexpr int MAX_FRAME_STEP_DELAY = 60;
   constexpr int FRAME_STEP_DELAY = 30;
 
   static int frame_step_count = 0;
@@ -75,7 +75,7 @@ static void HandleFrameskipHotkeys()
 
   if (IsHotkey(HK_FRAME_ADVANCE_INCREASE_SPEED))
   {
-    frame_step_delay = std::min(frame_step_delay + 1, MAX_FRAME_SKIP_DELAY);
+    frame_step_delay = std::min(frame_step_delay + 1, MAX_FRAME_STEP_DELAY);
     return;
   }
 
@@ -181,8 +181,8 @@ void HotkeyScheduler::Run()
       if (IsHotkey(HK_RESET))
         emit ResetHotkey();
 
-      // Frameskipping
-      HandleFrameskipHotkeys();
+      // Frame advance
+      HandleFrameStepHotkeys();
 
       // Screenshot
       if (IsHotkey(HK_SCREENSHOT))


### PR DESCRIPTION
This setting was removed some time ago but was apparently still being read and written by ConfigManager.