### PR TITLE
Qt/Settings: Minor Fixes

### DIFF
--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -139,7 +139,7 @@ void AdvancedPane::Update()
   m_cpu_clock_override_slider_label->setEnabled(enable_cpu_clock_override_widgets);
 
   m_cpu_clock_override_slider->setValue(
-      static_cast<int>(std::ceil(std::log2f(SConfig::GetInstance().m_OCFactor) * 25.f + 100.f)));
+      static_cast<int>(std::round(std::log2f(SConfig::GetInstance().m_OCFactor) * 25.f + 100.f)));
 
   m_cpu_clock_override_slider_label->setText([] {
     int core_clock = SystemTimers::GetTicksPerSecond() / std::pow(10, 6);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -6,6 +6,7 @@
 
 #include <QCheckBox>
 #include <QComboBox>
+#include <QFileInfo>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>
@@ -218,11 +219,10 @@ void InterfacePane::LoadConfig()
       m_combobox_theme->findText(QString::fromStdString(SConfig::GetInstance().theme_name)));
 
   const QString userstyle = Settings::Instance().GetCurrentUserStyle();
+  const int index = m_combobox_userstyle->findText(QFileInfo(userstyle).baseName());
 
-  if (userstyle.isEmpty())
-    m_combobox_userstyle->setCurrentIndex(0);
-  else
-    m_combobox_userstyle->setCurrentText(userstyle);
+  if (index > 0)
+    m_combobox_userstyle->setCurrentIndex(index);
 
   m_checkbox_use_userstyle->setChecked(Settings::Instance().AreUserStylesEnabled());
 
@@ -247,8 +247,8 @@ void InterfacePane::OnSaveConfig()
   Settings::Instance().SetKeepWindowOnTop(m_checkbox_top_window->isChecked());
   settings.m_use_builtin_title_database = m_checkbox_use_builtin_title_database->isChecked();
   Settings::Instance().SetDebugModeEnabled(m_checkbox_show_debugging_ui->isChecked());
-  Settings::Instance().SetCurrentUserStyle(m_combobox_userstyle->currentData().toString());
   Settings::Instance().SetUserStylesEnabled(m_checkbox_use_userstyle->isChecked());
+  Settings::Instance().SetCurrentUserStyle(m_combobox_userstyle->currentData().toString());
 
   const bool visible = m_checkbox_use_userstyle->isChecked();
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -200,6 +200,7 @@ void InterfacePane::ConnectLayout()
           &InterfacePane::OnSaveConfig);
   connect(m_checkbox_confirm_on_stop, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_use_panic_handlers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_show_active_title, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_enable_osd, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_pause_on_focus_lost, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_hide_mouse, &QCheckBox::toggled, &Settings::Instance(),


### PR DESCRIPTION
Fixes:
-  the "User Style" drop down not loading the correct custom style after a restart,
-  the "Show Active title in Window Title" checkbox not saving when toggled,
-  and the CPU Clock Speed slider not being settable to specific values due to rounding errors.