### PR TITLE
Fix build breakage due to missing SIGTRAP def.

### DIFF
--- a/Source/Core/Core/PowerPC/GDBStub.h
+++ b/Source/Core/Core/PowerPC/GDBStub.h
@@ -12,6 +12,10 @@
 #define SIGTRAP 5
 #define SIGTERM 15
 #define MSG_WAITALL 8
+#elif !defined(SIGTRAP)
+// fixes missing defines on some systems
+// (let's hope the file exists)
+#include <signal.h>
 #endif
 
 typedef enum {


### PR DESCRIPTION
Not sure why this started happening on my Arch Linux system. I'd rather
include <signal.h> than define the constants as in the _WIN32 case, as
the values of the signal macros can differ across unices.