### PR TITLE
Rename SIGTRAP, SIGTERM etc. to GDB_SIGTRAP etc.

### DIFF
--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -252,7 +252,7 @@ static void gdb_read_command()
   else if (c == 0x03)
   {
     CPU::Break();
-    gdb_signal(SIGTRAP);
+    gdb_signal(GDB_SIGTRAP);
     return;
   }
   else if (c != GDB_STUB_START)

--- a/Source/Core/Core/PowerPC/GDBStub.h
+++ b/Source/Core/Core/PowerPC/GDBStub.h
@@ -8,11 +8,14 @@
 
 #include "Common/CommonTypes.h"
 
-#ifdef _WIN32
-#define SIGTRAP 5
-#define SIGTERM 15
-#define MSG_WAITALL 8
+#if defined(_WIN32) || !defined(MSG_WAITALL)
+#define MSG_WAITALL (8)
 #endif
+
+typedef enum {
+  GDB_SIGTRAP = 5,
+  GDB_SIGTERM = 15,
+} gdb_signals;
 
 typedef enum {
   GDB_BP_TYPE_NONE = 0,

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -117,7 +117,7 @@ int Interpreter::SingleStepInner()
     {
       Host_UpdateDisasmDialog();
 
-      gdb_signal(SIGTRAP);
+      gdb_signal(GDB_SIGTRAP);
       gdb_handle_exception();
     }
 #endif


### PR DESCRIPTION
These constants are GDB-specific, while the host ones might differ, or
mightn't even exist at all. This patch fixes the possible collision.

(It also fixes the build when `SIGTRAP` etc. aren't defined/included, which is the case on my machine.)