### PR TITLE
LogManager: Change Master Log short name to fix log configuration loading

### DIFF
--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -109,7 +109,7 @@ LogManager::LogManager()
   m_log[LogTypes::IOS_WC24] = {"IOS_WC24", "IOS - WiiConnect24"};
   m_log[LogTypes::IOS_WFS] = {"IOS_WFS", "IOS - WFS"};
   m_log[LogTypes::IOS_WIIMOTE] = {"IOS_WIIMOTE", "IOS - Wii Remote"};
-  m_log[LogTypes::MASTER_LOG] = {"*", "Master Log"};
+  m_log[LogTypes::MASTER_LOG] = {"MASTER", "Master Log"};
   m_log[LogTypes::MEMCARD_MANAGER] = {"MemCard Manager", "MemCard Manager"};
   m_log[LogTypes::MEMMAP] = {"MI", "MI & memmap"};
   m_log[LogTypes::NETPLAY] = {"NETPLAY", "Netplay"};


### PR DESCRIPTION
The Master Log short name is currently `*`. This name is used as a key when saving the log enable configuration to `Logger.ini`:

```
[Logs]
ActionReplay = False
[…]
* = True
```

This causes problems when the INI file is parsed back as the parser [does not interpret lines starting with `*`](https://github.com/dolphin-emu/dolphin/commit/e34d8aee1d3818e16281e990717fb82df49d447b) as they may be used as comments in Gecko codes.

This PR changes the short name from `*` to `MASTER`, allowing the configuration to be saved and loaded correctly. Note that this name is also used in the logs themselves, so they will change.