### PR TITLE
Android: require back to be pressed twice to exit on mobile

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -78,6 +78,7 @@ public final class EmulationActivity extends AppCompatActivity
 	private String mSelectedTitle;
 	private int mPlatform;
 	private String mPath;
+	private boolean backPressedOnce = false;
 
 	public static final String EXTRA_SELECTED_GAME = "SelectedGame";
 	public static final String EXTRA_SELECTED_TITLE = "SelectedTitle";
@@ -329,10 +330,18 @@ public final class EmulationActivity extends AppCompatActivity
 		}
 		else
 		{
-			mEmulationFragment.stopEmulation();
-			exitWithAnimation();
+			if (backPressedOnce)
+			{
+				mEmulationFragment.stopEmulation();
+				exitWithAnimation();
+			}
+			else
+			{
+				backPressedOnce = true;
+				Toast.makeText(this, "Press back again to exit", Toast.LENGTH_LONG).show();
+				new Handler().postDelayed(() -> backPressedOnce = false, 3000);
+			}
 		}
-
 	}
 
 	@Override


### PR DESCRIPTION
This is only needed on mobile since pressing the back button on TV just brings up the menu.
![exit](https://user-images.githubusercontent.com/427044/43997735-19b2f4be-9db2-11e8-9c39-2b45bee283cc.png)
