### PR TITLE
Android: Clear controller binding by long press on TV

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/MotionAlertDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/MotionAlertDialog.java
@@ -11,6 +11,7 @@ import android.view.MotionEvent;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InputBindingSetting;
 import org.dolphinemu.dolphinemu.utils.ControllerMappingHelper;
 import org.dolphinemu.dolphinemu.utils.Log;
+import org.dolphinemu.dolphinemu.utils.TvUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +46,7 @@ public final class MotionAlertDialog extends AlertDialog
 		Log.debug("[MotionAlertDialog] Received key event: " + event.getAction());
 		switch (event.getAction())
 		{
-			case KeyEvent.ACTION_DOWN:
+			case KeyEvent.ACTION_UP:
 				if (!ControllerMappingHelper.shouldKeyBeIgnored(event.getDevice(), keyCode))
 				{
 					saveKeyInput(event);
@@ -56,6 +57,21 @@ public final class MotionAlertDialog extends AlertDialog
 			default:
 				return false;
 		}
+	}
+
+	@Override
+	public boolean onKeyLongPress(int keyCode, KeyEvent event)
+	{
+		// Option to clear by long back is only needed on the TV interface
+		if (TvUtil.isLeanback(getContext()))
+		{
+			if (keyCode == KeyEvent.KEYCODE_BACK)
+			{
+				clearBinding();
+				return true;
+			}
+		}
+		return super.onKeyLongPress(keyCode, event);
 	}
 
 	@Override
@@ -195,6 +211,16 @@ public final class MotionAlertDialog extends AlertDialog
 		editor.putString(setting.getKey(), ui);
 		editor.apply();
 
+		dismiss();
+	}
+
+	private void clearBinding()
+	{
+		setting.setValue("");
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+		SharedPreferences.Editor editor = preferences.edit();
+		editor.remove(setting.getKey());
+		editor.apply();
 		dismiss();
 	}
 }

--- a/Source/Android/app/src/main/res/values-notouch/strings.xml
+++ b/Source/Android/app/src/main/res/values-notouch/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="clear">Hold back to clear</string>
+</resources>


### PR DESCRIPTION
The TV interface can't 'click' the clear button, this gives TV a way to clear.

Needed to change the bind catch to the up action so we could detect a press vs a long press. This does not affect button bindings as far as I have tested.

![clear](https://user-images.githubusercontent.com/427044/43997702-2438784c-9db1-11e8-9e31-be24f9ec1749.png)
