### PR TITLE
Qt/TAS: Enable antialiasing for Stick/IR widgets

### DIFF
--- a/Source/Core/DolphinQt/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/IRWidget.cpp
@@ -34,6 +34,9 @@ void IRWidget::paintEvent(QPaintEvent* event)
 {
   QPainter painter(this);
 
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+
   painter.setBrush(Qt::white);
   painter.drawRect(0, 0, width() - 1, height() - 1);
 

--- a/Source/Core/DolphinQt/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/StickWidget.cpp
@@ -35,6 +35,9 @@ void StickWidget::paintEvent(QPaintEvent* event)
 {
   QPainter painter(this);
 
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+
   painter.setBrush(Qt::white);
   painter.drawEllipse(0, 0, width() - 1, height() - 1);
 


### PR DESCRIPTION
Before:
![Screenshot](https://i.imgur.com/4Ed1C4c.png)

After:
![Screenshot](https://i.imgur.com/As0msOZ.png)