### PR TITLE
SI: Add 16bit accessors for SI IO buffer

### DIFF
--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -47,7 +47,7 @@ int ISIDevice::RunBuffer(u8* buffer, int length)
 
   while (num < length)
   {
-    temp += StringFromFormat("0x%02x ", buffer[num ^ 3]);
+    temp += StringFromFormat("0x%02x ", buffer[num]);
     num++;
 
     if ((num % 8) == 0)

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "Common/CommonTypes.h"
+#include "Common/Swap.h"
 #include "InputCommon/GCPadStatus.h"
 
 namespace SerialInterface
@@ -19,13 +20,13 @@ CSIDevice_DanceMat::CSIDevice_DanceMat(SIDevices device, int device_number)
 int CSIDevice_DanceMat::RunBuffer(u8* buffer, int length)
 {
   // Read the command
-  EBufferCommands command = static_cast<EBufferCommands>(buffer[3]);
+  EBufferCommands command = static_cast<EBufferCommands>(buffer[0]);
 
   if (command == CMD_RESET)
   {
     ISIDevice::RunBuffer(buffer, length);
 
-    constexpr u32 id = SI_DANCEMAT;
+    u32 id = Common::swap32(SI_DANCEMAT);
     std::memcpy(buffer, &id, sizeof(id));
   }
   else

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
@@ -8,6 +8,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/Swap.h"
 #include "Core/HW/GCPad.h"
 
 namespace SerialInterface
@@ -23,7 +24,7 @@ int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int length)
   ISIDevice::RunBuffer(buffer, length);
 
   // Read the command
-  EBufferCommands command = static_cast<EBufferCommands>(buffer[3]);
+  EBufferCommands command = static_cast<EBufferCommands>(buffer[0]);
 
   // Handle it
   switch (command)
@@ -31,7 +32,7 @@ int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int length)
   case CMD_RESET:
   case CMD_ID:
   {
-    constexpr u32 id = SI_GC_STEERING;
+    u32 id = Common::swap32(SI_GC_STEERING);
     std::memcpy(buffer, &id, sizeof(id));
     break;
   }

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
@@ -9,6 +9,7 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/Swap.h"
 #include "Core/HW/GCKeyboard.h"
 #include "InputCommon/KeyboardStatus.h"
 
@@ -26,7 +27,7 @@ int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
   ISIDevice::RunBuffer(buffer, length);
 
   // Read the command
-  EBufferCommands command = static_cast<EBufferCommands>(buffer[3]);
+  EBufferCommands command = static_cast<EBufferCommands>(buffer[0]);
 
   // Handle it
   switch (command)
@@ -34,7 +35,7 @@ int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
   case CMD_RESET:
   case CMD_ID:
   {
-    constexpr u32 id = SI_GC_KEYBOARD;
+    u32 id = Common::swap32(SI_GC_KEYBOARD);
     std::memcpy(buffer, &id, sizeof(id));
     break;
   }
@@ -46,8 +47,8 @@ int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
     GetData(high, low);
     for (int i = 0; i < (length - 1) / 2; i++)
     {
-      buffer[i + 0] = (high >> (i * 8)) & 0xff;
-      buffer[i + 4] = (low >> (i * 8)) & 0xff;
+      buffer[i + 0] = (high >> (24 - (i * 8))) & 0xff;
+      buffer[i + 4] = (low >> (24 - (i * 8))) & 0xff;
     }
   }
   break;

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/SI/SI_DeviceNull.h"
+#include "Common/Swap.h"
 
 #include <cstring>
 
@@ -15,7 +16,7 @@ CSIDevice_Null::CSIDevice_Null(SIDevices device, int device_number)
 
 int CSIDevice_Null::RunBuffer(u8* buffer, int length)
 {
-  constexpr u32 reply = SI_ERROR_NO_RESPONSE;
+  u32 reply = Common::swap32(SI_ERROR_NO_RESPONSE);
   std::memcpy(buffer, &reply, sizeof(reply));
   return 4;
 }


### PR DESCRIPTION
Adding some extra accessors to the SI IO buffer.

Dolphin has traditionally treated the SI IO buffer (128 bytes) as a set of
32 little endian u32s. This works out fine if you only ever read/write
using aligned 32bit accesses. Different sized accesses or misaligned reads
will mess it up. Byte swapping reads/writes will fix this up, but all the
SI devices that use the SI IO buffer need to be fixed.