### PR TITLE
Arm64Emitter: Get rid of a pointer cast within SetJumpTarget()

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -969,7 +969,8 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
     inst = (0x25 << 26) | MaskImm26(distance);
     break;
   }
-  *(u32*)branch.ptr = inst;
+
+  std::memcpy(branch.ptr, &inst, sizeof(inst));
 }
 
 FixupBranch ARM64XEmitter::CBZ(ARM64Reg Rt)


### PR DESCRIPTION
Type punning like this is undefined behavior. Instead, we use std::memcpy to copy the necessary data over, which is well defined (as it treats both the source and destination as unsigned char).