### PR TITLE
More cheat codes for Mario Golf: Toadstool Tour

### DIFF
--- a/Data/Sys/GameSettings/GFTE01.ini
+++ b/Data/Sys/GameSettings/GFTE01.ini
@@ -12,3 +12,57 @@ $Unlock All Courses
 0222A3CE 0000FFFF
 $Unlock All Players
 0222A3CC 0000FFFF
+$Always 1st Stroke: Player 1
+006CB4FC 00000001
+$Always 1st Stroke: Player 2
+006CB6C4 00000001
+$Always 1st Stroke: Player 3
+006CB88C 00000001
+$Always 1st Stroke: Player 4
+006CBA54 00000001
+$Always Give Up: Player 1
+006CB4FC 00000063
+$Always Give Up: Player 2
+006CB6C4 00000063
+$Always Give Up: Player 3
+006CB88C 00000063
+$Always Give Up: Player 4
+006CBA54 00000063
+$Infinite Power Shots: Player 1
+004F2070 00000063
+$Infinite Power Shots: Player 2
+004F7274 00000063
+$Infinite Power Shots: Player 3
+004FC478 00000063
+$Infinite Power Shots: Player 4
+0050167C 00000063
+$No Power Shots: Player 1
+004F2070 00000000
+$No Power Shots: Player 2
+004F7274 00000000
+$No Power Shots: Player 3
+004FC478 00000000
+$No Power Shots: Player 4
+0050167C 00000000
+$Infinite Mulligans: Player 1
+004F2071 00000063
+$Infinite Mulligans: Player 2
+004F7275 00000063
+$Infinite Mulligans: Player 3
+004FC479 00000063
+$Infinite Mulligans: Player 4
+0050167D 00000063
+$No Mulligans: Player 1
+004F2071 00000000
+$No Mulligans: Player 2
+004F7275 00000000
+$No Mulligans: Player 3
+004FC479 00000000
+$No Mulligans: Player 4
+0050167D 00000000
+$Easy Practice: Side Games
+02502666 0000000A
+$Super Fast Coin Add: Player 1
+006CB343 000000FF
+$999 Coins Collected: Player 1
+026CB342 000003E7


### PR DESCRIPTION
From https://www.cheathappens.com/7676-Gamecube-Mario_Golf_Toadstool_Tour_cheats