### PR TITLE
Android: cache all page, avoid image flicking when swipe from last page to first page

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -66,6 +66,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
 			PlatformPagerAdapter platformPagerAdapter = new PlatformPagerAdapter(
 					getSupportFragmentManager(), this);
 			mViewPager.setAdapter(platformPagerAdapter);
+			mViewPager.setOffscreenPageLimit(platformPagerAdapter.getCount());
 			showGames();
 			GameFileCacheService.startLoad(this);
 		}
@@ -174,6 +175,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
 					PlatformPagerAdapter platformPagerAdapter = new PlatformPagerAdapter(
 							getSupportFragmentManager(), this);
 					mViewPager.setAdapter(platformPagerAdapter);
+					mViewPager.setOffscreenPageLimit(platformPagerAdapter.getCount());
 					mTabLayout.setupWithViewPager(mViewPager);
 					mViewPager.setVisibility(View.VISIBLE);
 					GameFileCacheService.startLoad(this);


### PR DESCRIPTION
Current only has three pages, cache all.