### PR TITLE
Android: Set GC controller 1 to enabled if settings don't exist

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -481,7 +481,8 @@ public final class SettingsFile
 			String key = SettingsFile.KEY_GCPAD_TYPE + i;
 			if (coreSection.getSetting(key) == null)
 			{
-				Setting gcPadSetting = new IntSetting(key, Settings.SECTION_INI_CORE,0);
+				// Set GameCube controller 1 to enabled, all others disabled
+				Setting gcPadSetting = new IntSetting(key, Settings.SECTION_INI_CORE, i == 0 ? 6 : 0);
 				coreSection.putSetting(gcPadSetting);
 			}
 		}


### PR DESCRIPTION
If a user changes any config options before starting emulation then all SIDevices are set to 0.  A bare bones Dolphin.ini is copied to ensure touch controls will be enabled on first launch.