### PR TITLE
Qt: Fix widgets being visible when they shouldn't be

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -159,6 +159,10 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters) : QMainW
   restoreGeometry(settings.value(QStringLiteral("mainwindow/geometry")).toByteArray());
 
   m_render_widget_geometry = settings.value(QStringLiteral("renderwidget/geometry")).toByteArray();
+
+  // Restoring of window states can sometimes go wrong, resulting in widgets being visible when they
+  // shouldn't be so we have to reapply all our rules afterwards.
+  Settings::Instance().RefreshWidgetVisibility();
 }
 
 MainWindow::~MainWindow()

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -434,6 +434,13 @@ bool Settings::IsJITVisible() const
   return QSettings().value(QStringLiteral("debugger/showjit")).toBool();
 }
 
+void Settings::RefreshWidgetVisibility()
+{
+  emit DebugModeToggled(IsDebugModeEnabled());
+  emit LogVisibilityChanged(IsLogVisible());
+  emit LogConfigVisibilityChanged(IsLogConfigVisible());
+}
+
 void Settings::SetDebugFont(QFont font)
 {
   if (GetDebugFont() != font)

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -66,6 +66,8 @@ public:
   void SetWidgetsLocked(bool visible);
   bool AreWidgetsLocked() const;
 
+  void RefreshWidgetVisibility();
+
   // GameList
   QStringList GetPaths() const;
   void AddPath(const QString& path);


### PR DESCRIPTION
e.g. debugger widgets being shown when debugging mode is disabled.