### PR TITLE
VideoCommon/HiresTextures: Change wildcard to a Windows-compatible character

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -254,8 +254,8 @@ std::string HiresTexture::GenBaseName(const u8* texture, size_t texture_size, co
   std::string fullname = basename + tlutname + formatname;
 
   // try to match a wildcard template
-  if (!dump && s_textureMap.find(basename + "_*" + formatname) != s_textureMap.end())
-    return basename + "_*" + formatname;
+  if (!dump && s_textureMap.find(basename + "_$" + formatname) != s_textureMap.end())
+    return basename + "_$" + formatname;
 
   // else generate the complete texture
   if (dump || s_textureMap.find(fullname) != s_textureMap.end())


### PR DESCRIPTION
Windows is dumb and doesn't let you put special characters into file names like other operating systems do, so this feature was more or less impossible to use.