### PR TITLE
Android: Add usage statistics to android

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -88,6 +88,9 @@ dependencies {
     implementation "com.android.support:leanback-v17:$androidSupportVersion"
     implementation "com.android.support:support-tv-provider:$androidSupportVersion"
 
+    // For REST calls
+    implementation 'com.android.volley:volley:1.1.0'
+
     // For showing the banner as a circle a-la Material Design Guidelines
     implementation 'de.hdodenhof:circleimageview:2.1.0'
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
@@ -1,8 +1,6 @@
 package org.dolphinemu.dolphinemu;
 
 import android.app.Application;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
@@ -10,17 +8,10 @@ import org.dolphinemu.dolphinemu.utils.VolleyUtil;
 
 public class DolphinApplication extends Application
 {
-	public static final String FIRST_OPEN = "FIRST_OPEN";
 	@Override
 	public void onCreate()
 	{
 		super.onCreate();
-
-		// Passed at emulation start to trigger first open event.
-		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-		SharedPreferences.Editor sPrefsEditor = preferences.edit();
-		sPrefsEditor.putBoolean(FIRST_OPEN, true);
-		sPrefsEditor.apply();
 
 		VolleyUtil.init(getApplicationContext());
 		System.loadLibrary("main");

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
@@ -1,17 +1,28 @@
 package org.dolphinemu.dolphinemu;
 
 import android.app.Application;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
+import org.dolphinemu.dolphinemu.utils.VolleyUtil;
 
 public class DolphinApplication extends Application
 {
+	public static final String FIRST_OPEN = "FIRST_OPEN";
 	@Override
 	public void onCreate()
 	{
 		super.onCreate();
 
+		// Passed at emulation start to trigger first open event.
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+		SharedPreferences.Editor sPrefsEditor = preferences.edit();
+		sPrefsEditor.putBoolean(FIRST_OPEN, true);
+		sPrefsEditor.apply();
+
+		VolleyUtil.init(getApplicationContext());
 		System.loadLibrary("main");
 
 		if (PermissionsHandler.hasWriteAccess(getApplicationContext()))

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -322,7 +322,7 @@ public final class NativeLibrary
 	/**
 	 * Begins emulation.
 	 */
-	public static native void Run(String path);
+	public static native void Run(String path, boolean firstOpen);
 
 	/**
 	 * Begins emulation from the specified savestate.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -27,13 +27,15 @@ public class Settings
 
     public static final String SECTION_BINDINGS = "Android";
 
+    public static final String SECTION_ANALYTICS = "Analytics";
+
     private String gameId;
 
     private static final Map<String, List<String>> configFileSectionsMap = new HashMap<>();
 
     static
     {
-        configFileSectionsMap.put(SettingsFile.FILE_NAME_DOLPHIN, Arrays.asList(SECTION_INI_CORE, SECTION_INI_INTERFACE, SECTION_BINDINGS));
+        configFileSectionsMap.put(SettingsFile.FILE_NAME_DOLPHIN, Arrays.asList(SECTION_INI_CORE, SECTION_INI_INTERFACE, SECTION_BINDINGS, SECTION_ANALYTICS));
         configFileSectionsMap.put(SettingsFile.FILE_NAME_GFX, Arrays.asList(SECTION_GFX_SETTINGS, SECTION_GFX_ENHANCEMENTS, SECTION_GFX_HACKS, SECTION_STEREOSCOPY));
         configFileSectionsMap.put(SettingsFile.FILE_NAME_WIIMOTE, Arrays.asList(SECTION_WIIMOTE + 1, SECTION_WIIMOTE + 2, SECTION_WIIMOTE + 3, SECTION_WIIMOTE + 4));
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -210,14 +210,17 @@ public final class SettingsFragmentPresenter
 		Setting overclock = null;
 		Setting speedLimit = null;
 		Setting audioStretch = null;
+		Setting analytics = null;
 
 		SettingSection coreSection = mSettings.getSection(Settings.SECTION_INI_CORE);
+		SettingSection analyticsSection = mSettings.getSection(Settings.SECTION_ANALYTICS);
 		cpuCore = coreSection.getSetting(SettingsFile.KEY_CPU_CORE);
 		dualCore = coreSection.getSetting(SettingsFile.KEY_DUAL_CORE);
 		overclockEnable = coreSection.getSetting(SettingsFile.KEY_OVERCLOCK_ENABLE);
 		overclock = coreSection.getSetting(SettingsFile.KEY_OVERCLOCK_PERCENT);
 		speedLimit = coreSection.getSetting(SettingsFile.KEY_SPEED_LIMIT);
 		audioStretch = coreSection.getSetting(SettingsFile.KEY_AUDIO_STRETCH);
+		analytics = analyticsSection.getSetting(SettingsFile.KEY_ANALYTICS_ENABLED);
 
 		// TODO: Having different emuCoresEntries/emuCoresValues for each architecture is annoying.
 		// The proper solution would be to have one emuCoresEntries and one emuCoresValues
@@ -246,6 +249,7 @@ public final class SettingsFragmentPresenter
 		sl.add(new SliderSetting(SettingsFile.KEY_OVERCLOCK_PERCENT, Settings.SECTION_INI_CORE, R.string.overclock_title, R.string.overclock_title_description, 400, "%", 100, overclock));
         sl.add(new SliderSetting(SettingsFile.KEY_SPEED_LIMIT, Settings.SECTION_INI_CORE, R.string.speed_limit, 0, 200, "%", 100, speedLimit));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_AUDIO_STRETCH, Settings.SECTION_INI_CORE, R.string.audio_stretch, R.string.audio_stretch_description, false, audioStretch));
+		sl.add(new CheckBoxSetting(SettingsFile.KEY_ANALYTICS_ENABLED, Settings.SECTION_ANALYTICS, R.string.analytics, 0, false, analytics));
 	}
 
 	private void addInterfaceSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -50,6 +50,9 @@ public final class SettingsFile
 	public static final String KEY_SLOT_A_DEVICE = "SlotA";
 	public static final String KEY_SLOT_B_DEVICE = "SlotB";
 
+	public static final String KEY_ANALYTICS_ENABLED = "Enabled";
+	public static final String KEY_ANALYTICS_PERMISSION_ASKED = "PermissionAsked";
+
 	public static final String KEY_USE_PANIC_HANDLERS = "UsePanicHandlers";
 	public static final String KEY_OSD_MESSAGES = "OnScreenDisplayMessages";
 
@@ -294,12 +297,14 @@ public final class SettingsFile
 		catch (FileNotFoundException e)
 		{
 			Log.error("[SettingsFile] File not found: " + ini.getAbsolutePath() + e.getMessage());
-			view.onSettingsFileNotFound();
+			if (view != null)
+				view.onSettingsFileNotFound();
 		}
 		catch (IOException e)
 		{
 			Log.error("[SettingsFile] Error reading from: " + ini.getAbsolutePath()+ e.getMessage());
-			view.onSettingsFileNotFound();
+			if (view != null)
+				view.onSettingsFileNotFound();
 		}
 		finally
 		{
@@ -384,12 +389,14 @@ public final class SettingsFile
 		catch (FileNotFoundException e)
 		{
 			Log.error("[SettingsFile] File not found: " + fileName + ".ini: " + e.getMessage());
-			view.showToastMessage("Error saving " + fileName + ".ini: " + e.getMessage());
+			if (view != null)
+				view.showToastMessage("Error saving " + fileName + ".ini: " + e.getMessage());
 		}
 		catch (UnsupportedEncodingException e)
 		{
 			Log.error("[SettingsFile] Bad encoding; please file a bug report: " + fileName + ".ini: " + e.getMessage());
-			view.showToastMessage("Error saving " + fileName + ".ini: " + e.getMessage());
+			if (view != null)
+				view.showToastMessage("Error saving " + fileName + ".ini: " + e.getMessage());
 		}
 		finally
 		{
@@ -487,6 +494,23 @@ public final class SettingsFile
 		}
 
 		sections.put(Settings.SECTION_INI_CORE, coreSection);
+	}
+
+	public static void firstAnalyticsAdd(boolean enabled)
+	{
+		HashMap<String, SettingSection> dolphinSections = readFile(SettingsFile.FILE_NAME_DOLPHIN, null);
+		SettingSection analyticsSection = dolphinSections.get(Settings.SECTION_ANALYTICS);
+
+		Setting analyticsEnabled = new StringSetting(KEY_ANALYTICS_ENABLED, Settings.SECTION_ANALYTICS, enabled ? "True" : "False");
+		Setting analyticsFirstAsk = new StringSetting(KEY_ANALYTICS_PERMISSION_ASKED, Settings.SECTION_ANALYTICS, "True");
+
+		analyticsSection.putSetting(analyticsFirstAsk);
+		analyticsSection.putSetting(analyticsEnabled);
+
+		dolphinSections.put(Settings.SECTION_ANALYTICS, analyticsSection);
+
+		TreeMap<String, SettingSection> saveSection = new TreeMap<>(dolphinSections);
+		saveFile(SettingsFile.FILE_NAME_DOLPHIN, saveSection, null);
 	}
 
 	/**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -16,7 +16,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.Toast;
 
-import org.dolphinemu.dolphinemu.DolphinApplication;
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
@@ -25,10 +24,9 @@ import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService.DirectoryInitializationState;
 import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
 import org.dolphinemu.dolphinemu.utils.Log;
+import org.dolphinemu.dolphinemu.utils.StartupHandler;
 
 import java.io.File;
-
-import rx.functions.Action1;
 
 public final class EmulationFragment extends Fragment implements SurfaceHolder.Callback
 {
@@ -86,9 +84,9 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 
 		String gamePath = getArguments().getString(KEY_GAMEPATH);
 		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-		boolean firstOpen = preferences.getBoolean(DolphinApplication.FIRST_OPEN, true);
+		boolean firstOpen = preferences.getBoolean(StartupHandler.NEW_SESSION, true);
 		SharedPreferences.Editor sPrefsEditor = preferences.edit();
-		sPrefsEditor.putBoolean(DolphinApplication.FIRST_OPEN, false);
+		sPrefsEditor.putBoolean(StartupHandler.NEW_SESSION, false);
 		sPrefsEditor.apply();
 		mEmulationState = new EmulationState(gamePath, getTemporaryStateFilePath(), firstOpen);
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -89,6 +89,20 @@ public final class MainActivity extends AppCompatActivity implements MainView
 		mPresenter.onDestroy();
 	}
 
+	@Override
+	protected void onStart()
+	{
+		super.onStart();
+		StartupHandler.checkSessionReset(this);
+	}
+
+	@Override
+	protected void onStop()
+	{
+		super.onStop();
+		StartupHandler.setSessionTime(this);
+	}
+
 	// TODO: Replace with a ButterKnife injection.
 	private void findViews()
 	{

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -72,6 +72,20 @@ public final class TvMainActivity extends FragmentActivity implements MainView
 		mPresenter.onDestroy();
 	}
 
+	@Override
+	protected void onStart()
+	{
+		super.onStart();
+		StartupHandler.checkSessionReset(this);
+	}
+
+	@Override
+	protected void onStop()
+	{
+		super.onStop();
+		StartupHandler.setSessionTime(this);
+	}
+
 	void setupUI() {
 		final FragmentManager fragmentManager = getSupportFragmentManager();
 		mBrowseFragment = new BrowseSupportFragment();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -1,0 +1,125 @@
+package org.dolphinemu.dolphinemu.utils;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.support.v4.content.LocalBroadcastManager;
+
+import com.android.volley.Request;
+import com.android.volley.toolbox.StringRequest;
+
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
+import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
+import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
+
+public class Analytics
+{
+	private static DirectoryStateReceiver directoryStateReceiver;
+
+	private static final String analyticsAsked = Settings.SECTION_ANALYTICS + "_" + SettingsFile.KEY_ANALYTICS_PERMISSION_ASKED;
+	private static final String analyticsEnabled = Settings.SECTION_ANALYTICS + "_" + SettingsFile.KEY_ANALYTICS_ENABLED;
+
+	private static final String DEVICE_MANUFACTURER = "DEVICE_MANUFACTURER";
+	private static final String DEVICE_OS = "DEVICE_OS";
+	private static final String DEVICE_MODEL = "DEVICE_MODEL";
+	private static final String DEVICE_TYPE = "DEVICE_TYPE";
+
+	private static String deviceType;
+
+	public static void checkAnalyticsInit(Context context)
+	{
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+		if (!preferences.getBoolean(analyticsAsked, false))
+		{
+			if (!DirectoryInitializationService.areDolphinDirectoriesReady())
+			{
+				// Wait for directories to get initialized
+				IntentFilter statusIntentFilter = new IntentFilter(
+						DirectoryInitializationService.BROADCAST_ACTION);
+
+				directoryStateReceiver = new DirectoryStateReceiver(directoryInitializationState ->
+				{
+					if (directoryInitializationState == DirectoryInitializationService.DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED)
+					{
+						LocalBroadcastManager.getInstance(context).unregisterReceiver(directoryStateReceiver);
+						directoryStateReceiver = null;
+						showMessage(context, preferences);
+					}
+				});
+				// Registers the DirectoryStateReceiver and its intent filters
+				LocalBroadcastManager.getInstance(context).registerReceiver(
+						directoryStateReceiver,
+						statusIntentFilter);
+			}
+			else
+			{
+				showMessage(context, preferences);
+			}
+		}
+		// Get device type now since we have a context
+		deviceType = TvUtil.isLeanback(context) ? "android-tv" : "android-mobile";
+	}
+
+	private static void showMessage(Context context, SharedPreferences preferences)
+	{
+		// We asked, set to true regardless of answer
+		SharedPreferences.Editor sPrefsEditor = preferences.edit();
+		sPrefsEditor.putBoolean(analyticsAsked, true);
+		sPrefsEditor.apply();
+
+		new AlertDialog.Builder(context)
+				.setTitle(context.getString(R.string.analytics))
+				.setMessage(context.getString(R.string.analytics_desc))
+				.setPositiveButton(R.string.yes, (dialogInterface, i) ->
+				{
+					sPrefsEditor.putBoolean(analyticsEnabled, true);
+					sPrefsEditor.apply();
+					SettingsFile.firstAnalyticsAdd(true);
+				})
+				.setNegativeButton(R.string.no, (dialogInterface, i) ->
+				{
+					sPrefsEditor.putBoolean(analyticsEnabled, false);
+					sPrefsEditor.apply();
+					SettingsFile.firstAnalyticsAdd(false);
+				})
+				.create()
+				.show();
+	}
+
+	public static void sendReport(String endpoint, byte[] data)
+	{
+		StringRequest request = new StringRequest(Request.Method.POST, endpoint,
+				null, error -> Log.debug("Send Report Failure code: "
+				+ error.networkResponse.statusCode))
+		{
+			@Override
+			public byte[] getBody()
+			{
+				return data;
+			}
+		};
+
+		VolleyUtil.getQueue().add(request);
+	}
+
+	public static String getValue(String key)
+	{
+		switch (key)
+		{
+			case DEVICE_MODEL:
+				return Build.MODEL;
+			case DEVICE_MANUFACTURER:
+				return Build.MANUFACTURER;
+			case DEVICE_OS:
+				return String.valueOf(Build.VERSION.SDK_INT);
+			case DEVICE_TYPE:
+				return deviceType;
+			default:
+				return "";
+		}
+	}
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -1,14 +1,23 @@
 package org.dolphinemu.dolphinemu.utils;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
 
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 
+import java.util.Date;
+
 public final class StartupHandler
 {
+	public static final String NEW_SESSION = "NEW_SESSION";
+	public static final String LAST_CLOSED = "LAST_CLOSED";
+	public static final Long SESSION_TIMEOUT = 21600000L; // 6 hours in milliseconds
+
 	public static void HandleInit(FragmentActivity parent)
 	{
 		// Ask the user to grant write permission if it's not already granted
@@ -29,6 +38,35 @@ public final class StartupHandler
 			emulation_intent.putExtra("SelectedGame", start_file);
 			parent.startActivity(emulation_intent);
 			parent.finish();
+		}
+	}
+
+	/**
+	 * There isn't a good way to determine a new session. setSessionTime is called if the main
+	 * activity goes into the background.
+	 */
+	public static void setSessionTime(Context context)
+	{
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+		SharedPreferences.Editor sPrefsEditor = preferences.edit();
+		sPrefsEditor.putLong(LAST_CLOSED, new Date(System.currentTimeMillis()).getTime());
+		sPrefsEditor.apply();
+	}
+
+	/**
+	 * Called to determine if we treat this activity start as a new session.
+	 */
+	public static void checkSessionReset(Context context)
+	{
+		Long currentTime = new Date(System.currentTimeMillis()).getTime();
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+		Long lastOpen = preferences.getLong(LAST_CLOSED, 0);
+		if (currentTime > (lastOpen + SESSION_TIMEOUT))
+		{
+			// Passed at emulation start to trigger first open event.
+			SharedPreferences.Editor sPrefsEditor = preferences.edit();
+			sPrefsEditor.putBoolean(NEW_SESSION, true);
+			sPrefsEditor.apply();
 		}
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -14,6 +14,9 @@ public final class StartupHandler
 		// Ask the user to grant write permission if it's not already granted
 		PermissionsHandler.checkWritePermission(parent);
 
+		// Ask the user if he wants to enable analytics if we haven't yet.
+		Analytics.checkAnalyticsInit(parent);
+
 		String start_file = "";
 		Bundle extras = parent.getIntent().getExtras();
 		if (extras != null)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/VolleyUtil.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/VolleyUtil.java
@@ -1,0 +1,22 @@
+package org.dolphinemu.dolphinemu.utils;
+
+import android.content.Context;
+
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.Volley;
+
+public class VolleyUtil
+{
+	private static RequestQueue queue;
+
+	public static void init(Context context)
+	{
+		if (queue == null)
+			queue = Volley.newRequestQueue(context);
+	}
+
+	public static RequestQueue getQueue()
+	{
+		return queue;
+	}
+}

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -135,6 +135,8 @@
     <string name="wiimote_speaker_description">Enable sound output through the speaker on a real Wiimote (DolphinBar required).</string>
     <string name="audio_stretch">Audio Stretching</string>
     <string name="audio_stretch_description">Stretches audio to reduce stuttering. Increases latency.</string>
+    <string name="analytics">Enable usage statistics reporting</string>
+    <string name="analytics_desc">If authorized, Dolphin can collect data on its performance, feature usage, and configuration, as well as data on your system\'s hardware and operating system.\n\nNo private data is ever collected. This data helps us understand how people and emulated games use Dolphin and prioritize our efforts. It also helps us identify rare configurations that are causing bugs, performance and stability issues. This authorization can be revoked at any time through Dolphin\'s settings.</string>
     <string name="gametdb_thanks">Thanks to GameTDB.com for providing GameCube and Wii covers!</string>
 
     <!-- Interface Preference Fragment -->

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -20,6 +20,10 @@ static jmethodID s_game_file_constructor;
 static jclass s_game_file_cache_class;
 static jfieldID s_game_file_cache_pointer;
 
+static jclass s_analytics_class;
+static jmethodID s_send_analytics_report;
+static jmethodID s_get_analytics_value;
+
 namespace IDCache
 {
 JavaVM* GetJavaVM()
@@ -37,6 +41,20 @@ jmethodID GetDisplayAlertMsg()
   return s_display_alert_msg;
 }
 
+jclass GetAnalyticsClass()
+{
+  return s_analytics_class;
+}
+
+jmethodID GetSendAnalyticsReport()
+{
+  return s_send_analytics_report;
+}
+
+jmethodID GetAnalyticsValue()
+{
+  return s_get_analytics_value;
+}
 jclass GetGameFileClass()
 {
   return s_game_file_class;
@@ -91,6 +109,13 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
   s_game_file_cache_class = reinterpret_cast<jclass>(env->NewGlobalRef(game_file_cache_class));
   s_game_file_cache_pointer = env->GetFieldID(game_file_cache_class, "mPointer", "J");
 
+  const jclass analytics_class = env->FindClass("org/dolphinemu/dolphinemu/utils/Analytics");
+  s_analytics_class = reinterpret_cast<jclass>(env->NewGlobalRef(analytics_class));
+  s_send_analytics_report =
+      env->GetStaticMethodID(s_analytics_class, "sendReport", "(Ljava/lang/String;[B)V");
+  s_get_analytics_value = env->GetStaticMethodID(s_analytics_class, "getValue",
+                                                 "(Ljava/lang/String;)Ljava/lang/String;");
+
   return JNI_VERSION;
 }
 
@@ -103,6 +128,7 @@ void JNI_OnUnload(JavaVM* vm, void* reserved)
   env->DeleteGlobalRef(s_native_library_class);
   env->DeleteGlobalRef(s_game_file_class);
   env->DeleteGlobalRef(s_game_file_cache_class);
+  env->DeleteGlobalRef(s_analytics_class);
 }
 
 #ifdef __cplusplus

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -8,10 +8,16 @@
 
 namespace IDCache
 {
+static constexpr jint JNI_VERSION = JNI_VERSION_1_6;
+
 JavaVM* GetJavaVM();
 
 jclass GetNativeLibraryClass();
 jmethodID GetDisplayAlertMsg();
+
+jclass GetAnalyticsClass();
+jmethodID GetSendAnalyticsReport();
+jmethodID GetAnalyticsValue();
 
 jclass GetGameFileClass();
 jfieldID GetGameFilePointer();

--- a/Source/Core/Common/Analytics.cpp
+++ b/Source/Core/Common/Analytics.cpp
@@ -190,5 +190,4 @@ void HttpAnalyticsBackend::Send(std::string report)
   if (m_http.IsValid())
     m_http.Post(m_endpoint, report);
 }
-
 }  // namespace Common

--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -183,5 +183,4 @@ protected:
   std::string m_endpoint;
   HttpRequest m_http{std::chrono::seconds{5}};
 };
-
 }  // namespace Common

--- a/Source/Core/Common/AndroidAnalytics.cpp
+++ b/Source/Core/Common/AndroidAnalytics.cpp
@@ -1,0 +1,27 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <functional>
+#include <string>
+
+#include "Common/AndroidAnalytics.h"
+
+namespace Common
+{
+std::function<void(std::string, std::string)> s_android_send_report;
+void AndroidSetReportHandler(std::function<void(std::string, std::string)> func)
+{
+  s_android_send_report = std::move(func);
+}
+AndroidAnalyticsBackend::AndroidAnalyticsBackend(std::string passed_endpoint)
+    : m_endpoint{std::move(passed_endpoint)}
+{
+}
+AndroidAnalyticsBackend::~AndroidAnalyticsBackend() = default;
+
+void AndroidAnalyticsBackend::Send(std::string report)
+{
+  s_android_send_report(m_endpoint, report);
+}
+}  // namespace Common

--- a/Source/Core/Common/AndroidAnalytics.h
+++ b/Source/Core/Common/AndroidAnalytics.h
@@ -1,0 +1,26 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "Common/Analytics.h"
+
+namespace Common
+{
+void AndroidSetReportHandler(std::function<void(std::string, std::string)> function);
+
+class AndroidAnalyticsBackend : public AnalyticsReportingBackend
+{
+public:
+  explicit AndroidAnalyticsBackend(const std::string endpoint);
+
+  ~AndroidAnalyticsBackend() override;
+  void Send(std::string report) override;
+
+private:
+  std::string m_endpoint;
+};
+}  // namespace Common

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 
 if(ANDROID)
   target_sources(common PRIVATE
+    AndroidAnalytics.cpp
     Logging/ConsoleListenerDroid.cpp
   )
 elseif(WIN32)

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -10,6 +10,9 @@
 
 #include "Common/Analytics.h"
 
+#if defined(ANDROID)
+#include <functional>
+#endif
 // Non generic part of the Dolphin Analytics framework. See Common/Analytics.h
 // for the main documentation.
 
@@ -19,10 +22,13 @@ public:
   // Performs lazy-initialization of a singleton and returns the instance.
   static std::shared_ptr<DolphinAnalytics> Instance();
 
+#if defined(ANDROID)
+  // Get value from java.
+  static void AndroidSetGetValFunc(std::function<std::string(std::string)> function);
+#endif
   // Resets and recreates the analytics system in order to reload
   // configuration.
   void ReloadConfig();
-
   // Rotates the unique identifier used for this instance of Dolphin and saves
   // it into the configuration.
   void GenerateNewIdentity();


### PR DESCRIPTION
Added an option in General config to enable/disable analytics. Added a popup on first open if
the user would like to engage in reporting. Clicking cancel or out of the box opts out. Only
clicking 'Ok' will enable reporting. Also added a new android specific values to report.

So currently we can't call DolphinAnalytics::ReportDolphinStart at app start due to SConfig not getting initialized until emulation starts. May want to look at initializing UICommon at app start instead of emulation start, but I don't know if that will change things, will have to look more into what is going on down in the C code to see what needs to be done. So for now this just reports when a game starts with all the base info.

![analytics](https://user-images.githubusercontent.com/427044/44480519-62f9e800-a611-11e8-90ee-7553dd96d1f2.png)
![analytics2](https://user-images.githubusercontent.com/427044/44500205-775fd400-a655-11e8-9ab8-c6fd697717fa.png)
![analytics3](https://user-images.githubusercontent.com/427044/44500240-a24a2800-a655-11e8-8e76-e27cb4501968.png)

