### PR TITLE
Qt/AdvancedPane: Block signals during Update()

### DIFF
--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -9,6 +9,7 @@
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QSignalBlocker>
 #include <QSlider>
 #include <QVBoxLayout>
 #include <cmath>
@@ -138,8 +139,11 @@ void AdvancedPane::Update()
   m_cpu_clock_override_slider->setEnabled(enable_cpu_clock_override_widgets);
   m_cpu_clock_override_slider_label->setEnabled(enable_cpu_clock_override_widgets);
 
-  m_cpu_clock_override_slider->setValue(
-      static_cast<int>(std::round(std::log2f(SConfig::GetInstance().m_OCFactor) * 25.f + 100.f)));
+  {
+    const QSignalBlocker blocker(m_cpu_clock_override_slider);
+    m_cpu_clock_override_slider->setValue(
+        static_cast<int>(std::round(std::log2f(SConfig::GetInstance().m_OCFactor) * 25.f + 100.f)));
+  }
 
   m_cpu_clock_override_slider_label->setText([] {
     int core_clock = SystemTimers::GetTicksPerSecond() / std::pow(10, 6);


### PR DESCRIPTION
This should fix a random crash on NetPlay start caused by settings sync and inconsistent event timing due to latency. Also, this should be blocking signals anyways, as updating UI from config should not also update config from UI.