### PR TITLE
Qt: Switch to QSignalBlocker for scoped signal blocking

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -12,6 +12,7 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QRadioButton>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 
 #include "Core/Config/GraphicsSettings.h"
@@ -300,7 +301,7 @@ void GeneralWidget::OnBackendChanged(const QString& backend_name)
 {
   m_backend_combo->setCurrentIndex(m_backend_combo->findData(QVariant(backend_name)));
 
-  const bool old = m_adapter_combo->blockSignals(true);
+  const QSignalBlocker blocker(m_adapter_combo);
 
   m_adapter_combo->clear();
 
@@ -318,6 +319,4 @@ void GeneralWidget::OnBackendChanged(const QString& backend_name)
                                   QStringLiteral("") :
                                   tr("%1 doesn't support this feature.")
                                       .arg(tr(g_video_backend->GetDisplayName().c_str())));
-
-  m_adapter_combo->blockSignals(old);
 }

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
@@ -4,6 +4,8 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsBool.h"
 
+#include <QSignalBlocker>
+
 #include "Common/Config/Config.h"
 
 #include "DolphinQt/Settings.h"
@@ -22,9 +24,8 @@ GraphicsBool::GraphicsBool(const QString& label, const Config::ConfigInfo<bool>&
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);
 
-    bool old = blockSignals(true);
+    const QSignalBlocker blocker(this);
     setChecked(Config::Get(m_setting) ^ m_reverse);
-    blockSignals(old);
   });
 }
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsChoice.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsChoice.cpp
@@ -4,6 +4,8 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 
+#include <QSignalBlocker>
+
 #include "Common/Config/Config.h"
 
 #include "DolphinQt/Settings.h"
@@ -21,9 +23,8 @@ GraphicsChoice::GraphicsChoice(const QStringList& options, const Config::ConfigI
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);
 
-    bool old = blockSignals(true);
+    const QSignalBlocker blocker(this);
     setCurrentIndex(Config::Get(m_setting));
-    blockSignals(old);
   });
 }
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsRadio.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsRadio.cpp
@@ -4,6 +4,8 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsRadio.h"
 
+#include <QSignalBlocker>
+
 #include "Common/Config/Config.h"
 
 #include "DolphinQt/Settings.h"
@@ -20,9 +22,8 @@ GraphicsRadioInt::GraphicsRadioInt(const QString& label, const Config::ConfigInf
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);
 
-    bool old = blockSignals(true);
+    const QSignalBlocker blocker(this);
     setChecked(Config::Get(m_setting) == m_value);
-    blockSignals(old);
   });
 }
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.cpp
@@ -4,6 +4,8 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
 
+#include <QSignalBlocker>
+
 #include "Common/Config/Config.h"
 
 #include "DolphinQt/Settings.h"
@@ -25,9 +27,8 @@ GraphicsSlider::GraphicsSlider(int minimum, int maximum, const Config::ConfigInf
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);
 
-    bool old = blockSignals(true);
+    const QSignalBlocker blocker(this);
     setValue(Config::Get(m_setting));
-    blockSignals(old);
   });
 }
 

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -7,6 +7,7 @@
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QLabel>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 
 #include "Core/Config/GraphicsSettings.h"
@@ -132,7 +133,7 @@ void HacksWidget::ConnectWidgets()
 
 void HacksWidget::LoadSettings()
 {
-  const bool old = m_accuracy->blockSignals(true);
+  const QSignalBlocker blocker(m_accuracy);
   auto samples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
 
   int slider_pos = 0;
@@ -161,8 +162,6 @@ void HacksWidget::LoadSettings()
              Config::LayerType::Base);
 
   m_accuracy_label->setFont(bf);
-
-  m_accuracy->blockSignals(old);
 }
 
 void HacksWidget::SaveSettings()

--- a/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
@@ -8,6 +8,7 @@
 #include <QDialogButtonBox>
 #include <QGridLayout>
 #include <QLabel>
+#include <QSignalBlocker>
 
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayServer.h"
@@ -82,7 +83,7 @@ int PadMappingDialog::exec()
     for (size_t i = 0; i < combo_group.size(); i++)
     {
       auto& combo = combo_group[i];
-      const bool old = combo->blockSignals(true);
+      const QSignalBlocker blocker(combo);
 
       combo->clear();
       combo->addItems(players);
@@ -90,7 +91,6 @@ int PadMappingDialog::exec()
       const auto index = gc ? m_pad_mapping[i] : m_wii_mapping[i];
 
       combo->setCurrentIndex(index == -1 ? 0 : index);
-      combo->blockSignals(old);
     }
   }
 


### PR DESCRIPTION
Makes the code cleaner and is safe in the face of exceptions.