### PR TITLE
Qt/GCMemcardManager: Make slot and file selection more intuitive

### DIFF
--- a/Source/Core/DolphinQt/GCMemcardManager.h
+++ b/Source/Core/DolphinQt/GCMemcardManager.h
@@ -46,8 +46,8 @@ private:
   void FixChecksums();
   void DrawIcons();
 
-  QPixmap GetBannerFromSaveFile(int file_index);
-  std::vector<QPixmap> GetIconFromSaveFile(int file_index);
+  QPixmap GetBannerFromSaveFile(int file_index, int slot);
+  std::vector<QPixmap> GetIconFromSaveFile(int file_index, int slot);
 
   // Actions
   QPushButton* m_select_button;


### PR DESCRIPTION
Many users were unsure how to use slot B, as the button is poorly labeled and not being able to browse when slot B is inactive is weird. This fixes both of those issues.