### PR TITLE
PixelShaderGen: Ensure all components of ocol1 are initialized

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1406,13 +1406,13 @@ static void WriteColor(ShaderCode& out, APIType api_type, const pixel_shader_uid
 
     // Use dual-source color blending to perform dst alpha in a single pass
     if (use_dual_source)
-      out.Write("\tocol1.a = float(prev.a) / 255.0;\n");
+      out.Write("\tocol1 = float4(0.0, 0.0, 0.0, float(prev.a) / 255.0);\n");
   }
   else
   {
     out.Write("\tocol0.a = float(prev.a >> 2) / 63.0;\n");
     if (use_dual_source)
-      out.Write("\tocol1.a = float(prev.a) / 255.0;\n");
+      out.Write("\tocol1 = float4(0.0, 0.0, 0.0, float(prev.a) / 255.0);\n");
   }
 }
 


### PR DESCRIPTION
This was causing a warning in the shader compiler, as the rgb components were not initialized. Which shouldn't be an issue, as the rgb is not used in the blend equation, only the alpha. 

However, after some frustrating debugging, it seems the lack of initialization was causing a crash in the Intel D3D shader compiler. Wild guess, it's breaking in some late optimization stage. Also quite
weird that it only affects a handful of games...

So, we'll play nice and initialize all the channels.

Should fix https://bugs.dolphin-emu.org/issues/11320. I haven't tested with the listed games, but a fifolog provided by xperia64 on IRC, which previously crashed the driver on my Kaby Lake laptop, no longer crashes.