### PR TITLE
NetPlay host input authority mode

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -372,6 +372,8 @@ bool BootCore(std::unique_ptr<BootParameters> boot)
     StartUp.bMMU = netplay_settings.m_MMU;
     StartUp.bFastmem = netplay_settings.m_Fastmem;
     StartUp.bHLE_BS2 = netplay_settings.m_SkipIPL;
+    if (netplay_settings.m_HostInputAuthority && !netplay_settings.m_IsHosting)
+      config_cache.bSetEmulationSpeed = true;
   }
   else
   {

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -595,6 +595,10 @@ void ChangeDeviceDeterministic(SIDevices device, int channel)
 
 void UpdateDevices()
 {
+  // Hinting NetPlay that all controllers will be polled in
+  // succession, in order to optimize networking
+  NetPlay::SetSIPollBatching(true);
+
   // Update inputs at the rate of SI
   // Typically 120hz but is variable
   g_controller_interface.UpdateInput();
@@ -610,6 +614,9 @@ void UpdateDevices()
       !!s_channel[3].device->GetData(s_channel[3].in_hi.hex, s_channel[3].in_lo.hex);
 
   UpdateInterrupts();
+
+  // Polling finished
+  NetPlay::SetSIPollBatching(false);
 }
 
 SIDevices GetDeviceType(int channel)

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -78,6 +78,7 @@ struct NetSettings
   bool m_SyncSaveData;
   std::string m_SaveDataRegion;
   bool m_IsHosting;
+  bool m_HostInputAuthority;
 };
 
 struct NetTraversalConfig
@@ -110,6 +111,8 @@ enum
   NP_MSG_PAD_DATA = 0x60,
   NP_MSG_PAD_MAPPING = 0x61,
   NP_MSG_PAD_BUFFER = 0x62,
+  NP_MSG_PAD_HOST_POLL = 0x63,
+  NP_MSG_PAD_FIRST_RECEIVED = 0x64,
 
   NP_MSG_WIIMOTE_DATA = 0x70,
   NP_MSG_WIIMOTE_MAPPING = 0x71,
@@ -120,6 +123,7 @@ enum
   NP_MSG_DISABLE_GAME = 0xA3,
   NP_MSG_GAME_STATUS = 0xA4,
   NP_MSG_IPL_STATUS = 0xA5,
+  NP_MSG_HOST_INPUT_AUTHORITY = 0xA6,
 
   NP_MSG_TIMEBASE = 0xB0,
   NP_MSG_DESYNC_DETECTED = 0xB1,
@@ -175,4 +179,5 @@ const NetSettings& GetNetSettings();
 IOS::HLE::FS::FileSystem* GetWiiSyncFS();
 void SetWiiSyncFS(std::unique_ptr<IOS::HLE::FS::FileSystem> fs);
 void ClearWiiSyncFS();
+void SetSIPollBatching(bool state);
 }  // namespace NetPlay

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -307,13 +307,13 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
 
   // send join message to already connected clients
   sf::Packet spac;
-  spac << (MessageId)NP_MSG_PLAYER_JOIN;
+  spac << static_cast<MessageId>(NP_MSG_PLAYER_JOIN);
   spac << player.pid << player.name << player.revision;
   SendToClients(spac);
 
   // send new client success message with their id
   spac.clear();
-  spac << (MessageId)0;
+  spac << static_cast<MessageId>(0);
   spac << player.pid;
   Send(player.socket, spac);
 
@@ -321,15 +321,24 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
   if (m_selected_game != "")
   {
     spac.clear();
-    spac << (MessageId)NP_MSG_CHANGE_GAME;
+    spac << static_cast<MessageId>(NP_MSG_CHANGE_GAME);
     spac << m_selected_game;
     Send(player.socket, spac);
   }
 
-  // send the pad buffer value
+  if (!m_host_input_authority)
+  {
+    // send the pad buffer value
+    spac.clear();
+    spac << static_cast<MessageId>(NP_MSG_PAD_BUFFER);
+    spac << static_cast<u32>(m_target_buffer_size);
+    Send(player.socket, spac);
+  }
+
+  // send input authority state
   spac.clear();
-  spac << (MessageId)NP_MSG_PAD_BUFFER;
-  spac << (u32)m_target_buffer_size;
+  spac << static_cast<MessageId>(NP_MSG_HOST_INPUT_AUTHORITY);
+  spac << m_host_input_authority;
   Send(player.socket, spac);
 
   // sync GC SRAM with new client
@@ -340,7 +349,7 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
     g_SRAM_netplay_initialized = true;
   }
   spac.clear();
-  spac << (MessageId)NP_MSG_SYNC_GC_SRAM;
+  spac << static_cast<MessageId>(NP_MSG_SYNC_GC_SRAM);
   for (size_t i = 0; i < sizeof(g_SRAM.p_SRAM); ++i)
   {
     spac << g_SRAM.p_SRAM[i];
@@ -497,6 +506,24 @@ void NetPlayServer::AdjustPadBufferSize(unsigned int size)
   SendAsyncToClients(std::move(spac));
 }
 
+void NetPlayServer::SetHostInputAuthority(const bool enable)
+{
+  std::lock_guard<std::recursive_mutex> lkg(m_crit.game);
+
+  m_host_input_authority = enable;
+
+  // tell clients about the new value
+  sf::Packet spac;
+  spac << static_cast<MessageId>(NP_MSG_HOST_INPUT_AUTHORITY);
+  spac << m_host_input_authority;
+
+  SendAsyncToClients(std::move(spac));
+
+  // resend pad buffer to clients when disabled
+  if (!m_host_input_authority)
+    AdjustPadBufferSize(m_target_buffer_size);
+}
+
 void NetPlayServer::SendAsyncToClients(sf::Packet&& packet)
 {
   {
@@ -559,13 +586,59 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
       packet >> pad.button >> pad.analogA >> pad.analogB >> pad.stickX >> pad.stickY >>
           pad.substickX >> pad.substickY >> pad.triggerLeft >> pad.triggerRight >> pad.isConnected;
 
-      // Add to packet for relay to clients
-      spac << map << pad.button << pad.analogA << pad.analogB << pad.stickX << pad.stickY
+      if (m_host_input_authority)
+      {
+        m_last_pad_status[map] = pad;
+
+        if (!m_first_pad_status_received[map])
+        {
+          m_first_pad_status_received[map] = true;
+          SendFirstReceivedToHost(map, true);
+        }
+      }
+      else
+      {
+        spac << map << pad.button << pad.analogA << pad.analogB << pad.stickX << pad.stickY
+             << pad.substickX << pad.substickY << pad.triggerLeft << pad.triggerRight
+             << pad.isConnected;
+      }
+    }
+
+    if (!m_host_input_authority)
+      SendToClients(spac, player.pid);
+  }
+  break;
+
+  case NP_MSG_PAD_HOST_POLL:
+  {
+    PadMapping pad_num;
+    packet >> pad_num;
+
+    sf::Packet spac;
+    spac << static_cast<MessageId>(NP_MSG_PAD_DATA);
+
+    if (pad_num < 0)
+    {
+      for (size_t i = 0; i < m_pad_map.size(); i++)
+      {
+        if (m_pad_map[i] == -1)
+          continue;
+
+        const GCPadStatus& pad = m_last_pad_status[i];
+        spac << static_cast<PadMapping>(i) << pad.button << pad.analogA << pad.analogB << pad.stickX
+             << pad.stickY << pad.substickX << pad.substickY << pad.triggerLeft << pad.triggerRight
+             << pad.isConnected;
+      }
+    }
+    else if (m_pad_map.at(pad_num) != -1)
+    {
+      const GCPadStatus& pad = m_last_pad_status[pad_num];
+      spac << pad_num << pad.button << pad.analogA << pad.analogB << pad.stickX << pad.stickY
            << pad.substickX << pad.substickY << pad.triggerLeft << pad.triggerRight
            << pad.isConnected;
     }
 
-    SendToClients(spac, player.pid);
+    SendToClients(spac);
   }
   break;
 
@@ -911,7 +984,10 @@ bool NetPlayServer::StartGame()
   m_current_game = Common::Timer::GetTimeMs();
 
   // no change, just update with clients
-  AdjustPadBufferSize(m_target_buffer_size);
+  if (!m_host_input_authority)
+    AdjustPadBufferSize(m_target_buffer_size);
+
+  m_first_pad_status_received.fill(false);
 
   const u64 initial_rtc = GetInitialNetPlayRTC();
 
@@ -1289,6 +1365,15 @@ bool NetPlayServer::CompressBufferIntoPacket(const std::vector<u8>& in_buffer, s
   packet << static_cast<u32>(0);
 
   return true;
+}
+
+void NetPlayServer::SendFirstReceivedToHost(const PadMapping map, const bool state)
+{
+  sf::Packet pac;
+  pac << static_cast<MessageId>(NP_MSG_PAD_FIRST_RECEIVED);
+  pac << map;
+  pac << state;
+  Send(m_players.at(1).socket, pac);
 }
 
 u64 NetPlayServer::GetInitialNetPlayRTC() const

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -47,6 +47,7 @@ public:
   void OnMsgStartGame() override;
   void OnMsgStopGame() override;
   void OnPadBufferChanged(u32 buffer) override;
+  void OnHostInputAuthorityChanged(bool enabled) override;
   void OnDesync(u32 frame, const std::string& player) override;
   void OnConnectionLost() override;
   void OnConnectionError(const std::string& message) override;
@@ -108,6 +109,7 @@ private:
   QCheckBox* m_record_input_box;
   QCheckBox* m_reduce_polling_rate_box;
   QCheckBox* m_strict_settings_sync_box;
+  QCheckBox* m_host_input_authority_box;
   QPushButton* m_quit_button;
   QSplitter* m_splitter;
 
@@ -124,4 +126,5 @@ private:
   int m_buffer_size = 0;
   int m_player_count = 0;
   int m_old_player_count = 0;
+  bool m_host_input_authority = false;
 };


### PR DESCRIPTION
Currently, each player buffers their own inputs and sends them to the host. The host then relays those inputs to everyone else. Every player waits on inputs from all players to be buffered before continuing. What this means is all clients run in lockstep, and the total latency of inputs cannot be lower than the sum of the 2 highest client ping times in the game (in 3+ player sessions with people across the world, the latency can be very high).

Host input authority mode changes it so players no longer buffer their own inputs, and only send them to the host. The host stores only the most recent input received from a player. The host then sends inputs for all pads at the SI poll interval, similar to the existing code. If a player sends inputs to slowly, their last received input is simply sent again. If they send too quickly, inputs are dropped. This means that the host has full control over what inputs are actually read by the game, hence the name of the mode. Also, because the rate at which inputs are received by SI is decoupled from the rate at which players are sending inputs, clients are no longer dependent on each other. They only care what the host is doing. This means that they can set their buffer individually based on their latency to the host, rather than the highest latency between any 2 players, allowing someone with lower ping to the host to have less latency than someone else.

This is a catch to this: as a necessity of how the host's input sending works, the host has 0 latency. There isn't a good way to fix this, as input delay is now solely dependent on the real latency to the host's server. Having differing latency between players would be considered unfair for competitive play, but for casual play we don't really care. For this reason though, combined with the potential for a few inputs to be dropped on a bad connection, the old mode will remain and this new mode is entirely optional.