### PR TITLE
DiscordPresence: Add popular games to artwork list

### DIFF
--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -91,7 +91,75 @@ void HandleDiscordJoin(const char* join_secret)
 std::string ArtworkForGameId(const std::string& gameid)
 {
   static const std::set<std::string> REGISTERED_GAMES{
-      "GAL",  // Super Smash Bros. Melee
+      "GAF",  // GAFE01: Animal Crossing
+      "RUU",  // RUUE01: Animal Crossing: City Folk
+      "SF8",  // SF8E01: Donkey Kong Country Returns
+      "RDB",  // RDBE70: Dragon Ball Z: Budokai Tenkaichi 2
+      "RDS",  // RDSE70: Dragon Ball Z: Budokai Tenkaichi 3
+      "GFZ",  // GFZE01: F-Zero GX
+      "GFE",  // GFEE01: Fire Emblem: Path of Radiance
+      "RFE",  // RFEE01: Fire Emblem: Radiant Dawn
+      "S5S",  // S5SJHF: Inazuma Eleven GO: Strikers 2013
+      "GKY",  // GKYE01: Kirby Air Ride
+      "SUK",  // SUKE01: Kirby's Return to Dream Land
+      "GLM",  // GLME01: Luigi's Mansion
+      "GFT",  // GFTE01: Mario Golf: Toadstool Tour
+      "RMC",  // RMCE01: Mario Kart Wii
+      "GM4",  // GM4E01: Mario Kart: Double Dash!!
+      "GMP",  // GMPE01: Mario Party 4
+      "GP5",  // GP5E01: Mario Party 5
+      "GP6",  // GP6E01: Mario Party 6
+      "GP7",  // GP7E01: Mario Party 7
+      "RM8",  // RM8E01: Mario Party 8
+      "SSQ",  // SSQE01: Mario Party 9
+      "GOM",  // GOME01: Mario Power Tennis
+      "GYQ",  // GYQE01: Mario Superstar Baseball
+      "GGS",  // GGSE01: Metal Gear Solid: The Twin Snakes
+      "GM8",  // GM8E01: Metroid Prime
+      "G2M",  // G2ME01: Metroid Prime 2: Echoes
+      "RM3",  // RM3E01: Metroid Prime 3: Corruption
+      "R3M",  // R3ME01: Metroid Prime: Trilogy
+      "SMN",  // SMNE01: New Super Mario Bros. Wii
+      "G8M",  // G8ME01: Paper Mario: The Thousand-Year Door
+      "GPI",  // GPIE01: Pikmin (GC)
+      "R9I",  // R9IE01: Pikmin (Wii)
+      "GPV",  // GPVE01: Pikmin 2 (GC)
+      "R92",  // R92E01: Pikmin 2 (Wii)
+      "GC6",  // GC6E01: Pokemon Colosseum
+      "GXX",  // GXXE01: Pokemon XD: Gale of Darkness
+      "GBI",  // GBIE08: Resident Evil
+      "GHA",  // GHAE08: Resident Evil 2
+      "GLE",  // GLEE08: Resident Evil 3: Nemesis
+      "G4B",  // G4BE08: Resident Evil 4
+      "GSN",  // GSNE8P: Sonic Adventure 2: Battle
+      "GXS",  // GXSE8P: Sonic Adventure DX: Director's Cut
+      "SNC",  // SNCE8P: Sonic Colors
+      "G9S",  // G9SE8P: Sonic Heroes
+      "GRS",  // GRSEAF: SoulCalibur II
+      "RSL",  // RSLEAF: SoulCalibur Legends
+      "GK2",  // GK2E52: Spider-Man 2
+      "GQP",  // GQPE78: SpongeBob SquarePants: Battle for Bikini Bottom
+      "SVM",  // SVME01: Super Mario All-Stars: 25th Anniversary Edition
+      "RMG",  // RMGE01: Super Mario Galaxy
+      "SB4",  // SB4E01: Super Mario Galaxy 2
+      "G4Q",  // G4QE01: Super Mario Strikers
+      "GMS",  // GMSE01: Super Mario Sunshine
+      "GMB",  // GMBE8P: Super Monkey Ball
+      "GM2",  // GM2E8P: Super Monkey Ball 2
+      "R8P",  // R8PE01: Super Paper Mario
+      "RSB",  // RSBE01: Super Smash Bros. Brawl
+      "GAL",  // GALE01: Super Smash Bros. Melee
+      "PZL",  // PZLE01: The Legend of Zelda: Collector's Edition
+      "G4S",  // G4SE01: The Legend of Zelda: Four Swords Adventures
+      "D43",  // D43E01: The Legend of Zelda: Ocarina of Time / Master Quest
+      "SOU",  // SOUE01: The Legend of Zelda: Skyward Sword
+      "GZL",  // GZLE01: The Legend of Zelda: The Wind Waker
+      "GZ2",  // GZ2E01: The Legend of Zelda: Twilight Princess (GC)
+      "RZD",  // RZDE01: The Legend of Zelda: Twilight Princess (Wii)
+      "GHQ",  // GHQE7D: The Simpsons: Hit & Run
+      "RSP",  // RSPE01: Wii Sports
+      "RZT",  // RZTE01: Wii Sports Resort
+      "SX4",  // SX4E01: Xenoblade Chronicles
   };
 
   std::string region_neutral_gameid = gameid.substr(0, 3);


### PR DESCRIPTION
I've added a bunch of popular games based on our statistics. I included full GameIDs as it's easier for reference purposes, with differing publisher codes and whatnot. I also alphabetized them by the name cause it looks nice.

Here's the images which @delroth will need to upload to our app configuration:
https://owncloud.techjargaming.com/index.php/s/a6u1fBGJgkfutGM