### PR TITLE
Arm64Emitter: Make the Align* functions return a non-const data pointer

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -328,7 +328,7 @@ void ARM64XEmitter::ReserveCodeSpace(u32 bytes)
     BRK(0);
 }
 
-const u8* ARM64XEmitter::AlignCode16()
+u8* ARM64XEmitter::AlignCode16()
 {
   int c = int((u64)m_code & 15);
   if (c)
@@ -336,7 +336,7 @@ const u8* ARM64XEmitter::AlignCode16()
   return m_code;
 }
 
-const u8* ARM64XEmitter::AlignCodePage()
+u8* ARM64XEmitter::AlignCodePage()
 {
   int c = int((u64)m_code & 4095);
   if (c)

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -543,8 +543,8 @@ public:
   void SetCodePtr(u8* ptr);
   void SetCodePtrUnsafe(u8* ptr);
   void ReserveCodeSpace(u32 bytes);
-  const u8* AlignCode16();
-  const u8* AlignCodePage();
+  u8* AlignCode16();
+  u8* AlignCodePage();
   const u8* GetCodePtr() const;
   void FlushIcache();
   void FlushIcacheSection(u8* start, u8* end);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -338,7 +338,7 @@ void JitArm64::GenerateCommonAsm()
 
   JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedLoad");
 
-  paired_load_quantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
+  paired_load_quantized = reinterpret_cast<const u8**>(AlignCode16());
   ReserveCodeSpace(8 * sizeof(u8*));
 
   paired_load_quantized[0] = loadPairedFloatTwo;
@@ -350,7 +350,7 @@ void JitArm64::GenerateCommonAsm()
   paired_load_quantized[6] = loadPairedS8Two;
   paired_load_quantized[7] = loadPairedS16Two;
 
-  single_load_quantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
+  single_load_quantized = reinterpret_cast<const u8**>(AlignCode16());
   ReserveCodeSpace(8 * sizeof(u8*));
 
   single_load_quantized[0] = loadPairedFloatOne;
@@ -613,7 +613,7 @@ void JitArm64::GenerateCommonAsm()
 
   JitRegister::Register(start, GetCodePtr(), "JIT_QuantizedStore");
 
-  paired_store_quantized = reinterpret_cast<const u8**>(const_cast<u8*>(AlignCode16()));
+  paired_store_quantized = reinterpret_cast<const u8**>(AlignCode16());
   ReserveCodeSpace(32 * sizeof(u8*));
 
   // Fast


### PR DESCRIPTION
Similar in nature to e28d06353947f65fa8218871d5a488f583ec69ab in which this same change was applied to the x64 emitter.

There's no real requirement to make this const, and this should also be decided by the calling code, considering we had places that would simply cast away the const and carry on.