### PR TITLE
JitCommon/JitCache: Make JitBlock's checkedEntry and normalEntry members non-const pointers

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -71,9 +71,9 @@ void CachedInterpreter::Shutdown()
   m_block_cache.Shutdown();
 }
 
-const u8* CachedInterpreter::GetCodePtr() const
+u8* CachedInterpreter::GetCodePtr()
 {
-  return reinterpret_cast<const u8*>(m_code.data() + m_code.size());
+  return reinterpret_cast<u8*>(m_code.data() + m_code.size());
 }
 
 void CachedInterpreter::ExecuteOneBlock()

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
@@ -35,7 +35,7 @@ public:
 private:
   struct Instruction;
 
-  const u8* GetCodePtr() const;
+  u8* GetCodePtr();
   void ExecuteOneBlock();
 
   bool HandleFunctionHooking(u32 address);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -646,7 +646,7 @@ void Jit64::Jit(u32 em_address)
   blocks.FinalizeBlock(*b, jo.enableBlocklink, code_block.m_physical_addresses);
 }
 
-const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
+u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 {
   js.firstFPInstructionFound = false;
   js.isLastInstruction = false;
@@ -657,8 +657,8 @@ const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   js.numLoadStoreInst = 0;
   js.numFloatingPointInst = 0;
 
-  const u8* start =
-      AlignCode4();  // TODO: Test if this or AlignCode16 make a difference from GetCodePtr
+  // TODO: Test if this or AlignCode16 make a difference from GetCodePtr
+  u8* const start = AlignCode4();
   b->checkedEntry = start;
 
   // Downcount flag check. The last block decremented downcounter, and the flag should still be
@@ -668,8 +668,8 @@ const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   JMP(asm_routines.do_timing, true);  // downcount hit zero - go do_timing.
   SetJumpTarget(skip);
 
-  const u8* normalEntry = GetCodePtr();
-  b->normalEntry = normalEntry;
+  u8* const normal_entry = GetWritableCodePtr();
+  b->normalEntry = normal_entry;
 
   // Used to get a trace of the last few blocks before a crash, sometimes VERY useful
   if (ImHereDebug)
@@ -959,7 +959,7 @@ const u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   LogGeneratedX86(code_block.m_num_instructions, m_code_buffer, start, b);
 #endif
 
-  return normalEntry;
+  return normal_entry;
 }
 
 BitSet8 Jit64::ComputeStaticGQRs(const PPCAnalyst::CodeBlock& cb) const

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -52,7 +52,7 @@ public:
   // Jit!
 
   void Jit(u32 em_address) override;
-  const u8* DoJit(u32 em_address, JitBlock* b, u32 nextPC);
+  u8* DoJit(u32 em_address, JitBlock* b, u32 nextPC);
 
   BitSet32 CallerSavedRegistersInUse() const;
   BitSet8 ComputeStaticGQRs(const PPCAnalyst::CodeBlock&) const;

--- a/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
@@ -37,8 +37,8 @@ void JitBlockCache::WriteLinkBlock(const JitBlock::LinkData& source, const JitBl
 void JitBlockCache::WriteDestroyBlock(const JitBlock& block)
 {
   // Only clear the entry points as we might still be within this block.
-  Gen::XEmitter emit(const_cast<u8*>(block.checkedEntry));
+  Gen::XEmitter emit(block.checkedEntry);
   emit.INT3();
-  Gen::XEmitter emit2(const_cast<u8*>(block.normalEntry));
+  Gen::XEmitter emit2(block.normalEntry);
   emit2.INT3();
 }

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -607,7 +607,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   js.curBlock = b;
   js.carryFlagSet = false;
 
-  const u8* start = GetCodePtr();
+  u8* const start = GetWritableCodePtr();
   b->checkedEntry = start;
 
   // Downcount flag check, Only valid for linked blocks
@@ -619,7 +619,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   }
 
   // Normal entry doesn't need to check for downcount.
-  b->normalEntry = GetCodePtr();
+  b->normalEntry = GetWritableCodePtr();
 
   // Conditionally add profiling code.
   if (Profiler::g_ProfileBlocks)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
@@ -70,7 +70,7 @@ void JitArm64BlockCache::WriteLinkBlock(const JitBlock::LinkData& source, const 
 void JitArm64BlockCache::WriteDestroyBlock(const JitBlock& block)
 {
   // Only clear the entry points as we might still be within this block.
-  ARM64XEmitter emit((u8*)block.checkedEntry);
+  ARM64XEmitter emit(block.checkedEntry);
 
   while (emit.GetWritableCodePtr() <= block.normalEntry)
     emit.BRK(0x123);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -30,9 +30,9 @@ struct JitBlock
 
   // A special entry point for block linking; usually used to check the
   // downcount.
-  const u8* checkedEntry;
+  u8* checkedEntry;
   // The normal entry point for the block, returned by Dispatch().
-  const u8* normalEntry;
+  u8* normalEntry;
 
   // The effective address (PC) for the beginning of the block.
   u32 effectiveAddress;


### PR DESCRIPTION
In both cases of the x64 and AArch64 JITs, these would have const casted away from them, followed by them being placed within an emitter and having breakpoint instructions written in them.

In this case, we shouldn't be using const period if we're writing to the emitted data.