### PR TITLE
JitArm64/Jit: Don't cast away const within DumpCode()

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -489,9 +489,9 @@ void JitArm64::WriteExceptionExit(ARM64Reg dest, bool only_external)
 
 void JitArm64::DumpCode(const u8* start, const u8* end)
 {
-  std::string output = "";
-  for (u8* code = (u8*)start; code < end; code += 4)
-    output += StringFromFormat("%08x", Common::swap32(*(u32*)code));
+  std::string output;
+  for (const u8* code = start; code < end; code += sizeof(u32))
+    output += StringFromFormat("%08x", Common::swap32(code));
   WARN_LOG(DYNA_REC, "Code dump from %p to %p:\n%s", start, end, output.c_str());
 }
 


### PR DESCRIPTION
swap32() has a `const u8*` overload that swaps the data being pointed to as if it were a 32-bit word. We can just use that instead. It gets rid of undefined behavior, as we're not type punning a pointer and dereferencing it, and gets rid of the need to cast entirely.