### PR TITLE
 Profiler: Migrate global g_ProfileBlocks to JitOptions

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -498,7 +498,8 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
   Core::SetState(Core::State::Paused);
   JitInterface::ClearCache();
-  Profiler::g_ProfileBlocks = enable;
+  JitInterface::SetProfilingState(enable ? JitInterface::ProfilingState::Enabled :
+                                           JitInterface::ProfilingState::Disabled);
   Core::SetState(Core::State::Running);
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -382,7 +382,7 @@ bool Jit64::Cleanup()
     did_something = true;
   }
 
-  if (Profiler::g_ProfileBlocks)
+  if (jo.profile_blocks)
   {
     ABI_PushRegistersAndAdjustStack({}, 0);
     // get end tic
@@ -608,7 +608,7 @@ void Jit64::Jit(u32 em_address)
     EnableOptimization();
 
     // Comment out the following to disable breakpoints (speed-up)
-    if (!Profiler::g_ProfileBlocks)
+    if (!jo.profile_blocks)
     {
       if (CPU::IsStepping())
       {
@@ -680,7 +680,7 @@ u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   }
 
   // Conditionally add profiling code.
-  if (Profiler::g_ProfileBlocks)
+  if (jo.profile_blocks)
   {
     // get start tic
     MOV(64, R(ABI_PARAM1), ImmPtr(&b->profile_data.ticStart));

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -510,7 +510,7 @@ void JitArm64::BeginTimeProfile(JitBlock* b)
 
 void JitArm64::EndTimeProfile(JitBlock* b)
 {
-  if (!Profiler::g_ProfileBlocks)
+  if (!jo.profile_blocks)
     return;
 
   // Fetch the current counter register
@@ -622,7 +622,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   b->normalEntry = GetWritableCodePtr();
 
   // Conditionally add profiling code.
-  if (Profiler::g_ProfileBlocks)
+  if (jo.profile_blocks)
   {
     // get start tic
     BeginTimeProfile(b);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -53,6 +53,7 @@ protected:
     bool accurateSinglePrecision;
     bool fastmem;
     bool memcheck;
+    bool profile_blocks;
   };
   struct JitState
   {

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -79,6 +79,14 @@ CPUCoreBase* GetCore()
   return g_jit;
 }
 
+void SetProfilingState(ProfilingState state)
+{
+  if (!g_jit)
+    return;
+
+  g_jit->jo.profile_blocks = state == ProfilingState::Enabled;
+}
+
 void WriteProfileResults(const std::string& filename)
 {
   Profiler::ProfileStats prof_stats;

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -37,6 +37,13 @@ CPUCoreBase* InitJitCore(PowerPC::CPUCore core);
 CPUCoreBase* GetCore();
 
 // Debugging
+enum class ProfilingState
+{
+  Enabled,
+  Disabled
+};
+
+void SetProfilingState(ProfilingState state);
 void WriteProfileResults(const std::string& filename);
 void GetProfileResults(Profiler::ProfileStats* prof_stats);
 int GetHostCode(u32* address, const u8** code, u32* code_size);

--- a/Source/Core/Core/PowerPC/Profiler.cpp
+++ b/Source/Core/Core/PowerPC/Profiler.cpp
@@ -10,11 +10,9 @@
 
 namespace Profiler
 {
-bool g_ProfileBlocks = false;
-
 void WriteProfileResults(const std::string& filename)
 {
   JitInterface::WriteProfileResults(filename);
 }
 
-}  // namespace
+}  // namespace Profiler

--- a/Source/Core/Core/PowerPC/Profiler.h
+++ b/Source/Core/Core/PowerPC/Profiler.h
@@ -12,8 +12,6 @@
 
 namespace Profiler
 {
-extern bool g_ProfileBlocks;
-
 struct BlockStat
 {
   BlockStat(u32 _addr, u64 c, u64 ticks, u64 run, u32 size)


### PR DESCRIPTION
This global belongs in the JitOptions structure, as it's a conditional setting (A.K.A. option) that changes the behavior of what the JIT does.

Plus it keeps the scope of the variable constrained to the general area it's intended to be used and nothing further.