### PR TITLE
JitInterface: Move explanatory comment of ClearSafe() to the function's prototype

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -211,10 +211,6 @@ void ClearCache()
 }
 void ClearSafe()
 {
-  // This clear is "safe" in the sense that it's okay to run from
-  // inside a JIT'ed block: it clears the instruction cache, but not
-  // the JIT'ed code.
-  // TODO: There's probably a better way to handle this situation.
   if (g_jit)
     g_jit->GetBlockCache()->Clear();
 }

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -55,6 +55,9 @@ bool HandleStackFault();
 // Clearing CodeCache
 void ClearCache();
 
+// This clear is "safe" in the sense that it's okay to run from
+// inside a JIT'ed block: it clears the instruction cache, but not
+// the JIT'ed code.
 void ClearSafe();
 
 // If "forced" is true, a recompile is being requested on code that hasn't been modified.


### PR DESCRIPTION
Puts the comment in the header where it's more likely to be seen initially. We can also remove the TODO, given doing nothing or returning an error is what is generally done for the JIT interface if the JIT instance isn't valid.