### PR TITLE
Common/SFMLHelper: Remove unused forward declaration

### DIFF
--- a/Source/Core/Common/SFMLHelper.h
+++ b/Source/Core/Common/SFMLHelper.h
@@ -13,9 +13,6 @@ class Packet;
 
 namespace Common
 {
-template <typename value_type>
-struct BigEndianValue;
-
 u16 PacketReadU16(sf::Packet& packet);
 u32 PacketReadU32(sf::Packet& packet);
 u64 PacketReadU64(sf::Packet& packet);


### PR DESCRIPTION
BigEndianValue isn't used in either the header or SFMLHelper.cpp, so it can be removed.