### PR TITLE
Fix reducing log paths when building with MSVC

### DIFF
--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cstdarg>
 #include <cstring>
+#include <locale>
 #include <mutex>
 #include <ostream>
 #include <string>
@@ -67,8 +69,18 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char*
 
 static size_t DeterminePathCutOffPoint()
 {
-  constexpr const char* pattern = DIR_SEP "Source" DIR_SEP "Core" DIR_SEP;
-  size_t pos = std::string(__FILE__).find(pattern);
+  constexpr const char* pattern = "/source/core/";
+#ifdef _WIN32
+  constexpr const char* pattern2 = "\\source\\core\\";
+#endif
+  std::string path = __FILE__;
+  std::transform(path.begin(), path.end(), path.begin(),
+                 [](char c) { return std::tolower(c, std::locale::classic()); });
+  size_t pos = path.find(pattern);
+#ifdef _WIN32
+  if (pos == std::string::npos)
+    pos = path.find(pattern2);
+#endif
   if (pos != std::string::npos)
     return pos + strlen(pattern);
   return 0;


### PR DESCRIPTION
The LogManager code had trouble detecting the "/Source/Core/" substring for two reasons, neither of which seemed to happen a few years ago:

1. `__FILE__` is in lowercase on MSVC
2. `__FILE__` uses backslash as the directory separator on MSVC

Fixes [issue 11366](https://bugs.dolphin-emu.org/issues/11366).