### PR TITLE
Android: Analytics - get android ui type when called instead of setting it ahead of time

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
@@ -1,6 +1,7 @@
 package org.dolphinemu.dolphinemu;
 
 import android.app.Application;
+import android.content.Context;
 
 import org.dolphinemu.dolphinemu.services.DirectoryInitializationService;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
@@ -8,15 +9,22 @@ import org.dolphinemu.dolphinemu.utils.VolleyUtil;
 
 public class DolphinApplication extends Application
 {
+  private static DolphinApplication application;
+
   @Override
   public void onCreate()
   {
     super.onCreate();
-
+    application = this;
     VolleyUtil.init(getApplicationContext());
     System.loadLibrary("main");
 
     if (PermissionsHandler.hasWriteAccess(getApplicationContext()))
       DirectoryInitializationService.startService(getApplicationContext());
+  }
+
+  public static Context getAppContext()
+  {
+    return application.getApplicationContext();
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -11,6 +11,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import com.android.volley.Request;
 import com.android.volley.toolbox.StringRequest;
 
+import org.dolphinemu.dolphinemu.DolphinApplication;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
@@ -29,8 +30,6 @@ public class Analytics
   private static final String DEVICE_OS = "DEVICE_OS";
   private static final String DEVICE_MODEL = "DEVICE_MODEL";
   private static final String DEVICE_TYPE = "DEVICE_TYPE";
-
-  private static String deviceType;
 
   public static void checkAnalyticsInit(Context context)
   {
@@ -63,8 +62,6 @@ public class Analytics
         showMessage(context, preferences);
       }
     }
-    // Get device type now since we have a context
-    deviceType = TvUtil.isLeanback(context) ? "android-tv" : "android-mobile";
   }
 
   private static void showMessage(Context context, SharedPreferences preferences)
@@ -120,7 +117,8 @@ public class Analytics
       case DEVICE_OS:
         return String.valueOf(Build.VERSION.SDK_INT);
       case DEVICE_TYPE:
-        return deviceType;
+        return TvUtil.isLeanback(DolphinApplication.getAppContext()) ? "android-tv" :
+                "android-mobile";
       default:
         return "";
     }


### PR DESCRIPTION
It's possible to not have set the device type if the user launches a game without going to the main activity(like launching from the TV menu)