### PR TITLE
Vulkan: Drop usage of VK_NV_glsl extension

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -39,11 +39,6 @@ static bool CompileShaderToSPV(SPIRVCodeVector* out_code, EShLanguage stage,
                                const char* stage_filename, const char* source_code,
                                size_t source_code_length, const char* header, size_t header_length);
 
-// Copy GLSL source code to a SPIRVCodeVector, for use with VK_NV_glsl_shader.
-static void CopyGLSLToSPVVector(SPIRVCodeVector* out_code, const char* stage_filename,
-                                const char* source_code, size_t source_code_length,
-                                const char* header, size_t header_length);
-
 // Regarding the UBO bind points, we subtract one from the binding index because
 // the OpenGL backend requires UBO #0 for non-block uniforms (at least on NV).
 // This allows us to share the same shaders but use bind point #0 in the Vulkan
@@ -226,42 +221,6 @@ bool CompileShaderToSPV(SPIRVCodeVector* out_code, EShLanguage stage, const char
   return true;
 }
 
-void CopyGLSLToSPVVector(SPIRVCodeVector* out_code, const char* stage_filename,
-                         const char* source_code, size_t source_code_length, const char* header,
-                         size_t header_length)
-{
-  std::string full_source_code;
-  if (header_length > 0)
-  {
-    full_source_code.reserve(header_length + source_code_length);
-    full_source_code.append(header, header_length);
-    full_source_code.append(source_code, source_code_length);
-  }
-  else
-  {
-    full_source_code.append(source_code, source_code_length);
-  }
-
-  if (g_ActiveConfig.iLog & CONF_SAVESHADERS)
-  {
-    static int counter = 0;
-    std::string filename = StringFromFormat("%s%s_%04i.txt", File::GetUserPath(D_DUMP_IDX).c_str(),
-                                            stage_filename, counter++);
-
-    std::ofstream stream;
-    File::OpenFStream(stream, filename, std::ios_base::out);
-    if (stream.good())
-      stream << full_source_code << std::endl;
-  }
-
-  size_t padding = full_source_code.size() % 4;
-  if (padding != 0)
-    full_source_code.append(4 - padding, '\n');
-
-  out_code->resize(full_source_code.size() / 4);
-  std::memcpy(out_code->data(), full_source_code.c_str(), full_source_code.size());
-}
-
 bool InitializeGlslang()
 {
   static bool glslang_initialized = false;
@@ -384,13 +343,6 @@ const TBuiltInResource* GetCompilerResourceLimits()
 bool CompileVertexShader(SPIRVCodeVector* out_code, const char* source_code,
                          size_t source_code_length)
 {
-  if (g_vulkan_context->SupportsNVGLSLExtension())
-  {
-    CopyGLSLToSPVVector(out_code, "vs", source_code, source_code_length, SHADER_HEADER,
-                        sizeof(SHADER_HEADER) - 1);
-    return true;
-  }
-
   return CompileShaderToSPV(out_code, EShLangVertex, "vs", source_code, source_code_length,
                             SHADER_HEADER, sizeof(SHADER_HEADER) - 1);
 }
@@ -398,13 +350,6 @@ bool CompileVertexShader(SPIRVCodeVector* out_code, const char* source_code,
 bool CompileGeometryShader(SPIRVCodeVector* out_code, const char* source_code,
                            size_t source_code_length)
 {
-  if (g_vulkan_context->SupportsNVGLSLExtension())
-  {
-    CopyGLSLToSPVVector(out_code, "gs", source_code, source_code_length, SHADER_HEADER,
-                        sizeof(SHADER_HEADER) - 1);
-    return true;
-  }
-
   return CompileShaderToSPV(out_code, EShLangGeometry, "gs", source_code, source_code_length,
                             SHADER_HEADER, sizeof(SHADER_HEADER) - 1);
 }
@@ -412,13 +357,6 @@ bool CompileGeometryShader(SPIRVCodeVector* out_code, const char* source_code,
 bool CompileFragmentShader(SPIRVCodeVector* out_code, const char* source_code,
                            size_t source_code_length)
 {
-  if (g_vulkan_context->SupportsNVGLSLExtension())
-  {
-    CopyGLSLToSPVVector(out_code, "ps", source_code, source_code_length, SHADER_HEADER,
-                        sizeof(SHADER_HEADER) - 1);
-    return true;
-  }
-
   return CompileShaderToSPV(out_code, EShLangFragment, "ps", source_code, source_code_length,
                             SHADER_HEADER, sizeof(SHADER_HEADER) - 1);
 }
@@ -426,13 +364,6 @@ bool CompileFragmentShader(SPIRVCodeVector* out_code, const char* source_code,
 bool CompileComputeShader(SPIRVCodeVector* out_code, const char* source_code,
                           size_t source_code_length)
 {
-  if (g_vulkan_context->SupportsNVGLSLExtension())
-  {
-    CopyGLSLToSPVVector(out_code, "cs", source_code, source_code_length, COMPUTE_SHADER_HEADER,
-                        sizeof(COMPUTE_SHADER_HEADER) - 1);
-    return true;
-  }
-
   return CompileShaderToSPV(out_code, EShLangCompute, "cs", source_code, source_code_length,
                             COMPUTE_SHADER_HEADER, sizeof(COMPUTE_SHADER_HEADER) - 1);
 }

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -418,7 +418,6 @@ bool VulkanContext::SelectDeviceExtensions(ExtensionList* extension_list, bool e
   if (enable_surface && !SupportsExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME, true))
     return false;
 
-  m_supports_nv_glsl_extension = SupportsExtension(VK_NV_GLSL_SHADER_EXTENSION_NAME, false);
   return true;
 }
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.h
@@ -83,7 +83,7 @@ public:
   {
     return m_device_features.occlusionQueryPrecise == VK_TRUE;
   }
-  bool SupportsNVGLSLExtension() const { return m_supports_nv_glsl_extension; }
+
   // Helpers for getting constants
   VkDeviceSize GetUniformBufferAlignment() const
   {
@@ -131,8 +131,6 @@ private:
   VkPhysicalDeviceFeatures m_device_features = {};
   VkPhysicalDeviceProperties m_device_properties = {};
   VkPhysicalDeviceMemoryProperties m_device_memory_properties = {};
-
-  bool m_supports_nv_glsl_extension = false;
 };
 
 extern std::unique_ptr<VulkanContext> g_vulkan_context;


### PR DESCRIPTION
It's not providing a large performance improvement anymore, after the more recent drivers introduced a new shader compiler. And the extension has been since deprecated?