### PR TITLE
Disable signature checks by default and expose in UI

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -101,7 +101,7 @@ const ConfigInfo<bool> MAIN_CUSTOM_RTC_ENABLE{{System::Main, "Core", "EnableCust
 // Default to seconds between 1.1.1970 and 1.1.2000
 const ConfigInfo<u32> MAIN_CUSTOM_RTC_VALUE{{System::Main, "Core", "CustomRTCValue"}, 946684800};
 const ConfigInfo<bool> MAIN_ENABLE_SIGNATURE_CHECKS{{System::Main, "Core", "EnableSignatureChecks"},
-                                                    true};
+                                                    false};
 const ConfigInfo<bool> MAIN_REDUCE_POLLING_RATE{{System::Main, "Core", "ReducePollingRate"}, false};
 
 // Main.DSP

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -26,7 +26,10 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
     return true;
 
   const static std::vector<Config::ConfigLocation> s_setting_saveable{
+      // Main.Core
+
       Config::MAIN_DEFAULT_ISO.location,
+      Config::MAIN_ENABLE_SIGNATURE_CHECKS.location,
 
       // Graphics.Hardware
 

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -19,6 +19,7 @@
 #include "Common/Config/Config.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -74,6 +75,7 @@ void WiiPane::ConnectLayout()
   connect(m_pal60_mode_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
   connect(m_sd_card_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
   connect(m_connect_keyboard_checkbox, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
+  connect(m_enable_signature_checks, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
   connect(&Settings::Instance(), &Settings::USBKeyboardConnectionChanged,
           m_connect_keyboard_checkbox, &QCheckBox::setChecked);
 
@@ -103,6 +105,7 @@ void WiiPane::CreateMisc()
   m_screensaver_checkbox = new QCheckBox(tr("Enable Screen Saver"));
   m_sd_card_checkbox = new QCheckBox(tr("Insert SD Card"));
   m_connect_keyboard_checkbox = new QCheckBox(tr("Connect USB Keyboard"));
+  m_enable_signature_checks = new QCheckBox(tr("Check WAD Signatures"));
   m_aspect_ratio_choice_label = new QLabel(tr("Aspect Ratio:"));
   m_aspect_ratio_choice = new QComboBox();
   m_aspect_ratio_choice->addItem(tr("4:3"));
@@ -126,15 +129,17 @@ void WiiPane::CreateMisc()
   m_system_language_choice->setToolTip(tr("Sets the Wii system language."));
   m_sd_card_checkbox->setToolTip(tr("Saved to /Wii/sd.raw (default size is 128mb)."));
   m_connect_keyboard_checkbox->setToolTip(tr("May cause slow down in Wii Menu and some games."));
+  m_enable_signature_checks->setToolTip(tr("Checks for valid signatures in Wii WADs."));
 
   misc_settings_group_layout->addWidget(m_pal60_mode_checkbox, 0, 0, 1, 1);
   misc_settings_group_layout->addWidget(m_sd_card_checkbox, 0, 1, 1, 1);
   misc_settings_group_layout->addWidget(m_screensaver_checkbox, 1, 0, 1, 1);
   misc_settings_group_layout->addWidget(m_connect_keyboard_checkbox, 1, 1, 1, 1);
-  misc_settings_group_layout->addWidget(m_aspect_ratio_choice_label, 2, 0, 1, 1);
-  misc_settings_group_layout->addWidget(m_aspect_ratio_choice, 2, 1, 1, 1);
-  misc_settings_group_layout->addWidget(m_system_language_choice_label, 3, 0, 1, 1);
-  misc_settings_group_layout->addWidget(m_system_language_choice, 3, 1, 1, 1);
+  misc_settings_group_layout->addWidget(m_enable_signature_checks, 2, 0, 1, 1);
+  misc_settings_group_layout->addWidget(m_aspect_ratio_choice_label, 3, 0, 1, 1);
+  misc_settings_group_layout->addWidget(m_aspect_ratio_choice, 3, 1, 1, 1);
+  misc_settings_group_layout->addWidget(m_system_language_choice_label, 4, 0, 1, 1);
+  misc_settings_group_layout->addWidget(m_system_language_choice, 4, 1, 1, 1);
 }
 
 void WiiPane::CreateWhitelistedUSBPassthroughDevices()
@@ -207,6 +212,7 @@ void WiiPane::LoadConfig()
   m_pal60_mode_checkbox->setChecked(Config::Get(Config::SYSCONF_PAL60));
   m_connect_keyboard_checkbox->setChecked(Settings::Instance().IsUSBKeyboardConnected());
   m_sd_card_checkbox->setChecked(SConfig::GetInstance().m_WiiSDCard);
+  m_enable_signature_checks->setChecked(Config::Get(Config::MAIN_ENABLE_SIGNATURE_CHECKS));
   m_aspect_ratio_choice->setCurrentIndex(Config::Get(Config::SYSCONF_WIDESCREEN));
   m_system_language_choice->setCurrentIndex(Config::Get(Config::SYSCONF_LANGUAGE));
 
@@ -225,6 +231,8 @@ void WiiPane::OnSaveConfig()
   Config::SetBase(Config::SYSCONF_PAL60, m_pal60_mode_checkbox->isChecked());
   Settings::Instance().SetUSBKeyboardConnected(m_connect_keyboard_checkbox->isChecked());
   SConfig::GetInstance().m_WiiSDCard = m_sd_card_checkbox->isChecked();
+  Config::SetBase(Config::MAIN_ENABLE_SIGNATURE_CHECKS, m_enable_signature_checks->isChecked());
+  SConfig::GetInstance().m_enable_signature_checks = m_enable_signature_checks->isChecked();
   Config::SetBase<u32>(Config::SYSCONF_SENSOR_BAR_POSITION,
                        TranslateSensorBarPosition(m_wiimote_ir_sensor_position->currentIndex()));
   Config::SetBase<u32>(Config::SYSCONF_SENSOR_BAR_SENSITIVITY, m_wiimote_ir_sensitivity->value());

--- a/Source/Core/DolphinQt/Settings/WiiPane.h
+++ b/Source/Core/DolphinQt/Settings/WiiPane.h
@@ -45,6 +45,7 @@ private:
   QCheckBox* m_pal60_mode_checkbox;
   QCheckBox* m_sd_card_checkbox;
   QCheckBox* m_connect_keyboard_checkbox;
+  QCheckBox* m_enable_signature_checks;
   QComboBox* m_system_language_choice;
   QLabel* m_system_language_choice_label;
   QComboBox* m_aspect_ratio_choice;


### PR DESCRIPTION
Apparently, the majority of WAD dumps (even good ones) lack signatures, as dumpers strip them out. While the idea of signature checks is nice to find bad dumps, it just ends up being more of an annoyance due to the fact that even good dumps often lack signatures. We're also exposing it in the UI because it will have been written to many users' configs already.