### PR TITLE
Android: fix crash if user is offline

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -93,8 +93,7 @@ public class Analytics
   public static void sendReport(String endpoint, byte[] data)
   {
     StringRequest request = new StringRequest(Request.Method.POST, endpoint,
-            null, error -> Log.debug("Send Report Failure code: "
-            + error.networkResponse.statusCode))
+            null, error -> Log.debug("Failed to send report"))
     {
       @Override
       public byte[] getBody()


### PR DESCRIPTION
If the user is offline, then there won't be a network response. Just debug log that the report couldn't send and move on.