### PR TITLE
[WIP] Renderer: Get backbuffer dimensions from GLInterface on resize.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1516,8 +1516,8 @@ void Renderer::CheckForSurfaceResize()
     return;
 
   GLInterface->Update();
-  m_backbuffer_width = m_new_backbuffer_width;
-  m_backbuffer_height = m_new_backbuffer_height;
+  m_backbuffer_width = GLInterface->GetBackBufferWidth();
+  m_backbuffer_height = GLInterface->GetBackBufferHeight();
 }
 
 void Renderer::DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc,


### PR DESCRIPTION
**Problem:** Under Linux/KDE on HiDPI, when the surface is resized, the backbuffer is resized to be too small.

![image](https://user-images.githubusercontent.com/938744/44970372-3fcf1280-af06-11e8-9e70-234039907edc.png)

**Solution:** This might need a bit more testing as I've only tested it on Linux inside KDE, but it seems straightforward enough. The dimensions used for the backbuffer are retrieved from GLInterface when the Renderer is first initialized, which comes directly from the OpenGL windowing library. These dimensions seem to be more appropriate under GLX, where they are not DPI adjusted and represent the actual amount of pixels. Rather than work backwards and calculate the number of actual pixels, it seems logical to use the value we already have.

My main concerns are twofold: 1, If we're going to rely on the value from GLInterface, we should get signaled by GLInterface instead of RenderWidget. I was worried about a race with this patch here but in practice this seems to work perfectly fine at least on GLX. 2, if we are to go this route, there's other stuff that needs to be cleaned up.

I don't think this should be merged as-is, but I want to see if there are any opinions on the direction that should be gone for this.