### PR TITLE
Include SRAM in savestates

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -151,7 +151,7 @@ CEXIIPL::~CEXIIPL()
 }
 void CEXIIPL::DoState(PointerWrap& p)
 {
-  p.Do(g_SRAM.rtc);
+  p.Do(g_SRAM);
   p.Do(g_rtc_flags);
   p.Do(m_command);
   p.Do(m_command_bytes_received);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 116;  // Last changed in PR 8879
+constexpr u32 STATE_VERSION = 117;  // Last changed in PR 7396
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This fixes an issue with saving after loading a savestate in Pokemon Colosseum. Also seems like a good idea anyways, as SRAM is part of system state after all. Should we add a flag to not write the SRAM back to disk if it was loaded from a savestate?