### PR TITLE
VideoCommon: Skip vsync if configured emulation speed is not 100%

### DIFF
--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/Config/GraphicsSettings.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Movie.h"
 #include "VideoCommon/OnScreenDisplay.h"
@@ -174,7 +175,8 @@ void VideoConfig::VerifyValidity()
 
 bool VideoConfig::IsVSync() const
 {
-  return bVSync && !Core::GetIsThrottlerTempDisabled();
+  return bVSync && !Core::GetIsThrottlerTempDisabled() &&
+         SConfig::GetInstance().m_EmulationSpeed == 1.0;
 }
 
 bool VideoConfig::UsingUberShaders() const


### PR DESCRIPTION
It doesn't make much sense to try to vsync at weird framerates, and vsync actually causes the speed setting to not work as expected.

This also fixes the catch-up in NetPlay host input authority mode not working when vsync is enabled.