### PR TITLE
Android: Portrait Emulation Enhancements

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -94,7 +94,8 @@ public final class EmulationActivity extends AppCompatActivity
           MENU_ACTION_SAVE_SLOT3, MENU_ACTION_SAVE_SLOT4, MENU_ACTION_SAVE_SLOT5,
           MENU_ACTION_SAVE_SLOT6, MENU_ACTION_LOAD_SLOT1, MENU_ACTION_LOAD_SLOT2,
           MENU_ACTION_LOAD_SLOT3, MENU_ACTION_LOAD_SLOT4, MENU_ACTION_LOAD_SLOT5,
-          MENU_ACTION_LOAD_SLOT6, MENU_ACTION_EXIT, MENU_ACTION_CHANGE_DISC})
+          MENU_ACTION_LOAD_SLOT6, MENU_ACTION_EXIT, MENU_ACTION_CHANGE_DISC,
+          MENU_ACTION_RESET_OVERLAY})
   public @interface MenuAction
   {
   }
@@ -125,6 +126,7 @@ public final class EmulationActivity extends AppCompatActivity
   public static final int MENU_ACTION_CHANGE_DISC = 23;
   public static final int MENU_ACTION_JOYSTICK_REL_CENTER = 24;
   public static final int MENU_ACTION_RUMBLE = 25;
+  public static final int MENU_ACTION_RESET_OVERLAY = 26;
 
 
   private static SparseIntArray buttonsActionsMap = new SparseIntArray();
@@ -165,6 +167,8 @@ public final class EmulationActivity extends AppCompatActivity
     buttonsActionsMap.append(R.id.menu_emulation_joystick_rel_center,
             EmulationActivity.MENU_ACTION_JOYSTICK_REL_CENTER);
     buttonsActionsMap.append(R.id.menu_emulation_rumble, EmulationActivity.MENU_ACTION_RUMBLE);
+    buttonsActionsMap
+            .append(R.id.menu_emulation_reset_overlay, EmulationActivity.MENU_ACTION_RESET_OVERLAY);
   }
 
   public static void launch(FragmentActivity activity, GameFile gameFile, int position,
@@ -525,6 +529,11 @@ public final class EmulationActivity extends AppCompatActivity
         editControlsPlacement();
         break;
 
+      // Reset overlay placement
+      case MENU_ACTION_RESET_OVERLAY:
+        resetOverlay();
+        break;
+
       // Enable/Disable specific buttons or the entire input overlay.
       case MENU_ACTION_TOGGLE_CONTROLS:
         toggleControls();
@@ -831,6 +840,21 @@ public final class EmulationActivity extends AppCompatActivity
     AlertDialog alertDialog = builder.create();
     alertDialog.show();
 
+  }
+
+  private void resetOverlay()
+  {
+    new AlertDialog.Builder(this)
+            .setTitle(getString(R.string.emulation_touch_overlay_reset))
+            .setPositiveButton(R.string.yes, (dialogInterface, i) ->
+            {
+              mEmulationFragment.resetInputOverlay();
+            })
+            .setNegativeButton(R.string.cancel, (dialogInterface, i) ->
+            {
+            })
+            .create()
+            .show();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -218,6 +218,11 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
     mInputOverlay.refreshControls();
   }
 
+  public void resetInputOverlay()
+  {
+    mInputOverlay.resetButtonPlacement();
+  }
+
   @Override
   public void surfaceCreated(SurfaceHolder holder)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -83,7 +83,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     super(context, attrs);
 
     mPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
-    if (!mPreferences.getBoolean("OverlayInit", false))
+    if (!mPreferences.getBoolean("OverlayInitV2", false))
       defaultOverlay();
     // Load the controls.
     refreshControls();
@@ -925,10 +925,19 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     {
       gcDefaultOverlay();
     }
+    if (mPreferences.getFloat(ButtonType.BUTTON_A + "-Portrait" + "-X", 0f) == 0f)
+    {
+      gcPortraitDefaultOverlay();
+    }
+
     // Wii
     if (mPreferences.getFloat(ButtonType.WIIMOTE_BUTTON_A + "-X", 0f) == 0f)
     {
       wiiDefaultOverlay();
+    }
+    if (mPreferences.getFloat(ButtonType.WIIMOTE_BUTTON_A + "-Portrait" + "-X", 0f) == 0f)
+    {
+      wiiPortraitDefaultOverlay();
     }
 
     // Wii Classic
@@ -936,9 +945,13 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     {
       wiiClassicDefaultOverlay();
     }
+    if (mPreferences.getFloat(ButtonType.CLASSIC_BUTTON_A + "-Portrait" + "-X", 0f) == 0f)
+    {
+      wiiClassicPortraitDefaultOverlay();
+    }
 
     SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
-    sPrefsEditor.putBoolean("OverlayInit", true);
+    sPrefsEditor.putBoolean("OverlayInitV2", true);
     sPrefsEditor.apply();
   }
 
@@ -1007,6 +1020,78 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
             (((float) res.getInteger(R.integer.STICK_MAIN_X) / 1000) * maxX));
     sPrefsEditor.putFloat(ButtonType.STICK_MAIN + "-Y",
             (((float) res.getInteger(R.integer.STICK_MAIN_Y) / 1000) * maxY));
+
+    // We want to commit right away, otherwise the overlay could load before this is saved.
+    sPrefsEditor.commit();
+  }
+
+
+  private void gcPortraitDefaultOverlay()
+  {
+    SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
+
+    // Get screen size
+    Display display = ((Activity) getContext()).getWindowManager().getDefaultDisplay();
+    DisplayMetrics outMetrics = new DisplayMetrics();
+    display.getMetrics(outMetrics);
+    float maxX = outMetrics.heightPixels;
+    float maxY = outMetrics.widthPixels;
+    // Height and width changes depending on orientation. Use the larger value for height.
+    if (maxY < maxX)
+    {
+      float tmp = maxX;
+      maxX = maxY;
+      maxY = tmp;
+    }
+    Resources res = getResources();
+    String portrait = "-Portrait";
+
+    // Each value is a percent from max X/Y stored as an int. Have to bring that value down
+    // to a decimal before multiplying by MAX X/Y.
+    sPrefsEditor.putFloat(ButtonType.BUTTON_A + portrait + "-X",
+            (((float) res.getInteger(R.integer.BUTTON_A_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_A + portrait + "-Y",
+            (((float) res.getInteger(R.integer.BUTTON_A_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_B + portrait + "-X",
+            (((float) res.getInteger(R.integer.BUTTON_B_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_B + portrait + "-Y",
+            (((float) res.getInteger(R.integer.BUTTON_B_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_X + portrait + "-X",
+            (((float) res.getInteger(R.integer.BUTTON_X_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_X + portrait + "-Y",
+            (((float) res.getInteger(R.integer.BUTTON_X_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_Y + portrait + "-X",
+            (((float) res.getInteger(R.integer.BUTTON_Y_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_Y + portrait + "-Y",
+            (((float) res.getInteger(R.integer.BUTTON_Y_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_Z + portrait + "-X",
+            (((float) res.getInteger(R.integer.BUTTON_Z_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_Z + portrait + "-Y",
+            (((float) res.getInteger(R.integer.BUTTON_Z_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_UP + portrait + "-X",
+            (((float) res.getInteger(R.integer.BUTTON_UP_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_UP + portrait + "-Y",
+            (((float) res.getInteger(R.integer.BUTTON_UP_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.TRIGGER_L + portrait + "-X",
+            (((float) res.getInteger(R.integer.TRIGGER_L_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.TRIGGER_L + portrait + "-Y",
+            (((float) res.getInteger(R.integer.TRIGGER_L_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.TRIGGER_R + portrait + "-X",
+            (((float) res.getInteger(R.integer.TRIGGER_R_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.TRIGGER_R + portrait + "-Y",
+            (((float) res.getInteger(R.integer.TRIGGER_R_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_START + portrait + "-X",
+            (((float) res.getInteger(R.integer.BUTTON_START_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.BUTTON_START + portrait + "-Y",
+            (((float) res.getInteger(R.integer.BUTTON_START_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.STICK_C + portrait + "-X",
+            (((float) res.getInteger(R.integer.STICK_C_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.STICK_C + portrait + "-Y",
+            (((float) res.getInteger(R.integer.STICK_C_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.STICK_MAIN + portrait + "-X",
+            (((float) res.getInteger(R.integer.STICK_MAIN_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.STICK_MAIN + portrait + "-Y",
+            (((float) res.getInteger(R.integer.STICK_MAIN_PORTRAIT_Y) / 1000) * maxY));
 
     // We want to commit right away, otherwise the overlay could load before this is saved.
     sPrefsEditor.commit();
@@ -1082,6 +1167,82 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
             (((float) res.getInteger(R.integer.WIIMOTE_RIGHT_X) / 1000) * maxX));
     sPrefsEditor.putFloat(ButtonType.WIIMOTE_RIGHT + "-Y",
             (((float) res.getInteger(R.integer.WIIMOTE_RIGHT_Y) / 1000) * maxY));
+
+    // We want to commit right away, otherwise the overlay could load before this is saved.
+    sPrefsEditor.commit();
+  }
+
+  private void wiiPortraitDefaultOverlay()
+  {
+    SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
+
+    // Get screen size
+    Display display = ((Activity) getContext()).getWindowManager().getDefaultDisplay();
+    DisplayMetrics outMetrics = new DisplayMetrics();
+    display.getMetrics(outMetrics);
+    float maxX = outMetrics.heightPixels;
+    float maxY = outMetrics.widthPixels;
+    // Height and width changes depending on orientation. Use the larger value for maxX.
+    if (maxY < maxX)
+    {
+      float tmp = maxX;
+      maxX = maxY;
+      maxY = tmp;
+    }
+    Resources res = getResources();
+    String portrait = "-Portrait";
+
+    // Each value is a percent from max X/Y stored as an int. Have to bring that value down
+    // to a decimal before multiplying by MAX X/Y.
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_A + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_A_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_A + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_A_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_B + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_B_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_B + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_B_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_1 + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_1_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_1 + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_1_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_2 + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_2_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_2 + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_2_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.NUNCHUK_BUTTON_Z + portrait + "-X",
+            (((float) res.getInteger(R.integer.NUNCHUK_BUTTON_Z_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.NUNCHUK_BUTTON_Z + portrait + "-Y",
+            (((float) res.getInteger(R.integer.NUNCHUK_BUTTON_Z_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.NUNCHUK_BUTTON_C + portrait + "-X",
+            (((float) res.getInteger(R.integer.NUNCHUK_BUTTON_C_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.NUNCHUK_BUTTON_C + portrait + "-Y",
+            (((float) res.getInteger(R.integer.NUNCHUK_BUTTON_C_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_MINUS + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_MINUS_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_MINUS + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_MINUS_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_PLUS + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_PLUS_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_PLUS + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_PLUS_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_UP + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_UP_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_UP + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_UP_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_HOME + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_HOME_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_BUTTON_HOME + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_BUTTON_HOME_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.NUNCHUK_STICK + portrait + "-X",
+            (((float) res.getInteger(R.integer.NUNCHUK_STICK_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.NUNCHUK_STICK + portrait + "-Y",
+            (((float) res.getInteger(R.integer.NUNCHUK_STICK_PORTRAIT_Y) / 1000) * maxY));
+    // Horizontal dpad
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_RIGHT + portrait + "-X",
+            (((float) res.getInteger(R.integer.WIIMOTE_RIGHT_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.WIIMOTE_RIGHT + portrait + "-Y",
+            (((float) res.getInteger(R.integer.WIIMOTE_RIGHT_PORTRAIT_Y) / 1000) * maxY));
 
     // We want to commit right away, otherwise the overlay could load before this is saved.
     sPrefsEditor.commit();
@@ -1164,6 +1325,90 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
             (((float) res.getInteger(R.integer.CLASSIC_TRIGGER_R_X) / 1000) * maxX));
     sPrefsEditor.putFloat(ButtonType.CLASSIC_TRIGGER_R + "-Y",
             (((float) res.getInteger(R.integer.CLASSIC_TRIGGER_R_Y) / 1000) * maxY));
+
+    // We want to commit right away, otherwise the overlay could load before this is saved.
+    sPrefsEditor.commit();
+  }
+
+
+  private void wiiClassicPortraitDefaultOverlay()
+  {
+    SharedPreferences.Editor sPrefsEditor = mPreferences.edit();
+
+    // Get screen size
+    Display display = ((Activity) getContext()).getWindowManager().getDefaultDisplay();
+    DisplayMetrics outMetrics = new DisplayMetrics();
+    display.getMetrics(outMetrics);
+    float maxX = outMetrics.heightPixels;
+    float maxY = outMetrics.widthPixels;
+    // Height and width changes depending on orientation. Use the larger value for maxX.
+    if (maxY < maxX)
+    {
+      float tmp = maxX;
+      maxX = maxY;
+      maxY = tmp;
+    }
+    Resources res = getResources();
+    String portrait = "-Portrait";
+
+    // Each value is a percent from max X/Y stored as an int. Have to bring that value down
+    // to a decimal before multiplying by MAX X/Y.
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_A + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_A_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_A + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_A_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_B + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_B_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_B + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_B_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_X + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_X_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_X + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_X_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_Y + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_Y_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_Y + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_Y_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_MINUS + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_MINUS_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_MINUS + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_MINUS_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_PLUS + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_PLUS_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_PLUS + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_PLUS_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_HOME + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_HOME_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_HOME + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_HOME_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_ZL + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_ZL_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_ZL + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_ZL_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_ZR + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_ZR_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_BUTTON_ZR + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_BUTTON_ZR_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_DPAD_UP + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_DPAD_UP_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_DPAD_UP + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_DPAD_UP_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_STICK_LEFT + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_STICK_LEFT_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_STICK_LEFT + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_STICK_LEFT_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_STICK_RIGHT + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_STICK_RIGHT_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_STICK_RIGHT + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_STICK_RIGHT_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_TRIGGER_L + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_TRIGGER_L_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_TRIGGER_L + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_TRIGGER_L_PORTRAIT_Y) / 1000) * maxY));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_TRIGGER_R + portrait + "-X",
+            (((float) res.getInteger(R.integer.CLASSIC_TRIGGER_R_PORTRAIT_X) / 1000) * maxX));
+    sPrefsEditor.putFloat(ButtonType.CLASSIC_TRIGGER_R + portrait + "-Y",
+            (((float) res.getInteger(R.integer.CLASSIC_TRIGGER_R_PORTRAIT_Y) / 1000) * maxY));
 
     // We want to commit right away, otherwise the overlay could load before this is saved.
     sPrefsEditor.commit();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -9,6 +9,7 @@ package org.dolphinemu.dolphinemu.overlay;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -235,6 +236,10 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     int fingerPositionX = (int) event.getX(pointerIndex);
     int fingerPositionY = (int) event.getY(pointerIndex);
 
+    String orientation =
+            getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT ?
+                    "-Portrait" : "";
+
     // Maybe combine Button and Joystick as subclasses of the same parent?
     // Or maybe create an interface like IMoveableHUDControl?
 
@@ -269,7 +274,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
             // Persist button position by saving new place.
             saveControlPosition(mButtonBeingConfigured.getId(),
                     mButtonBeingConfigured.getBounds().left,
-                    mButtonBeingConfigured.getBounds().top);
+                    mButtonBeingConfigured.getBounds().top, orientation);
             mButtonBeingConfigured = null;
           }
           break;
@@ -306,7 +311,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
           {
             // Persist button position by saving new place.
             saveControlPosition(mDpadBeingConfigured.getId(0),
-                    mDpadBeingConfigured.getBounds().left, mDpadBeingConfigured.getBounds().top);
+                    mDpadBeingConfigured.getBounds().left, mDpadBeingConfigured.getBounds().top,
+                    orientation);
             mDpadBeingConfigured = null;
           }
           break;
@@ -339,7 +345,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
           {
             saveControlPosition(mJoystickBeingConfigured.getId(),
                     mJoystickBeingConfigured.getBounds().left,
-                    mJoystickBeingConfigured.getBounds().top);
+                    mJoystickBeingConfigured.getBounds().top, orientation);
             mJoystickBeingConfigured = null;
           }
           break;
@@ -380,47 +386,47 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     }
   }
 
-  private void addGameCubeOverlayControls()
+  private void addGameCubeOverlayControls(String orientation)
   {
     if (mPreferences.getBoolean("buttonToggleGc0", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_a,
-              R.drawable.gcpad_a_pressed, ButtonType.BUTTON_A));
+              R.drawable.gcpad_a_pressed, ButtonType.BUTTON_A, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc1", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_b,
-              R.drawable.gcpad_b_pressed, ButtonType.BUTTON_B));
+              R.drawable.gcpad_b_pressed, ButtonType.BUTTON_B, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc2", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_x,
-              R.drawable.gcpad_x_pressed, ButtonType.BUTTON_X));
+              R.drawable.gcpad_x_pressed, ButtonType.BUTTON_X, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc3", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_y,
-              R.drawable.gcpad_y_pressed, ButtonType.BUTTON_Y));
+              R.drawable.gcpad_y_pressed, ButtonType.BUTTON_Y, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc4", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_z,
-              R.drawable.gcpad_z_pressed, ButtonType.BUTTON_Z));
+              R.drawable.gcpad_z_pressed, ButtonType.BUTTON_Z, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc5", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_start,
-              R.drawable.gcpad_start_pressed, ButtonType.BUTTON_START));
+              R.drawable.gcpad_start_pressed, ButtonType.BUTTON_START, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc6", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_l,
-              R.drawable.gcpad_l_pressed, ButtonType.TRIGGER_L));
+              R.drawable.gcpad_l_pressed, ButtonType.TRIGGER_L, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc7", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_r,
-              R.drawable.gcpad_r_pressed, ButtonType.TRIGGER_R));
+              R.drawable.gcpad_r_pressed, ButtonType.TRIGGER_R, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc8", true))
     {
@@ -428,56 +434,57 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
               R.drawable.gcwii_dpad_pressed_one_direction,
               R.drawable.gcwii_dpad_pressed_two_directions,
               ButtonType.BUTTON_UP, ButtonType.BUTTON_DOWN,
-              ButtonType.BUTTON_LEFT, ButtonType.BUTTON_RIGHT));
+              ButtonType.BUTTON_LEFT, ButtonType.BUTTON_RIGHT, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc9", true))
     {
       overlayJoysticks.add(initializeOverlayJoystick(getContext(), R.drawable.gcwii_joystick_range,
-              R.drawable.gcwii_joystick, R.drawable.gcwii_joystick_pressed, ButtonType.STICK_MAIN));
+              R.drawable.gcwii_joystick, R.drawable.gcwii_joystick_pressed, ButtonType.STICK_MAIN,
+              orientation));
     }
     if (mPreferences.getBoolean("buttonToggleGc10", true))
     {
       overlayJoysticks.add(initializeOverlayJoystick(getContext(), R.drawable.gcwii_joystick_range,
-              R.drawable.gcpad_c, R.drawable.gcpad_c_pressed, ButtonType.STICK_C));
+              R.drawable.gcpad_c, R.drawable.gcpad_c_pressed, ButtonType.STICK_C, orientation));
     }
   }
 
-  private void addWiimoteOverlayControls()
+  private void addWiimoteOverlayControls(String orientation)
   {
     if (mPreferences.getBoolean("buttonToggleWii0", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_a,
-              R.drawable.wiimote_a_pressed, ButtonType.WIIMOTE_BUTTON_A));
+              R.drawable.wiimote_a_pressed, ButtonType.WIIMOTE_BUTTON_A, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii1", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_b,
-              R.drawable.wiimote_b_pressed, ButtonType.WIIMOTE_BUTTON_B));
+              R.drawable.wiimote_b_pressed, ButtonType.WIIMOTE_BUTTON_B, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii2", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_one,
-              R.drawable.wiimote_one_pressed, ButtonType.WIIMOTE_BUTTON_1));
+              R.drawable.wiimote_one_pressed, ButtonType.WIIMOTE_BUTTON_1, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii3", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_two,
-              R.drawable.wiimote_two_pressed, ButtonType.WIIMOTE_BUTTON_2));
+              R.drawable.wiimote_two_pressed, ButtonType.WIIMOTE_BUTTON_2, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii4", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_plus,
-              R.drawable.wiimote_plus_pressed, ButtonType.WIIMOTE_BUTTON_PLUS));
+              R.drawable.wiimote_plus_pressed, ButtonType.WIIMOTE_BUTTON_PLUS, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii5", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_minus,
-              R.drawable.wiimote_minus_pressed, ButtonType.WIIMOTE_BUTTON_MINUS));
+              R.drawable.wiimote_minus_pressed, ButtonType.WIIMOTE_BUTTON_MINUS, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii6", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_home,
-              R.drawable.wiimote_home_pressed, ButtonType.WIIMOTE_BUTTON_HOME));
+              R.drawable.wiimote_home_pressed, ButtonType.WIIMOTE_BUTTON_HOME, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii7", true))
     {
@@ -487,7 +494,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
                 R.drawable.gcwii_dpad_pressed_one_direction,
                 R.drawable.gcwii_dpad_pressed_two_directions,
                 ButtonType.WIIMOTE_RIGHT, ButtonType.WIIMOTE_LEFT,
-                ButtonType.WIIMOTE_UP, ButtonType.WIIMOTE_DOWN));
+                ButtonType.WIIMOTE_UP, ButtonType.WIIMOTE_DOWN, orientation));
       }
       else
       {
@@ -495,87 +502,87 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
                 R.drawable.gcwii_dpad_pressed_one_direction,
                 R.drawable.gcwii_dpad_pressed_two_directions,
                 ButtonType.WIIMOTE_UP, ButtonType.WIIMOTE_DOWN,
-                ButtonType.WIIMOTE_LEFT, ButtonType.WIIMOTE_RIGHT));
+                ButtonType.WIIMOTE_LEFT, ButtonType.WIIMOTE_RIGHT, orientation));
       }
     }
   }
 
-  private void addNunchukOverlayControls()
+  private void addNunchukOverlayControls(String orientation)
   {
     if (mPreferences.getBoolean("buttonToggleWii8", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.nunchuk_c,
-              R.drawable.nunchuk_c_pressed, ButtonType.NUNCHUK_BUTTON_C));
+              R.drawable.nunchuk_c_pressed, ButtonType.NUNCHUK_BUTTON_C, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii9", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.nunchuk_z,
-              R.drawable.nunchuk_z_pressed, ButtonType.NUNCHUK_BUTTON_Z));
+              R.drawable.nunchuk_z_pressed, ButtonType.NUNCHUK_BUTTON_Z, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleWii10", true))
     {
       overlayJoysticks.add(initializeOverlayJoystick(getContext(), R.drawable.gcwii_joystick_range,
               R.drawable.gcwii_joystick, R.drawable.gcwii_joystick_pressed,
-              ButtonType.NUNCHUK_STICK));
+              ButtonType.NUNCHUK_STICK, orientation));
     }
   }
 
-  private void addClassicOverlayControls()
+  private void addClassicOverlayControls(String orientation)
   {
     if (mPreferences.getBoolean("buttonToggleClassic0", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_a,
-              R.drawable.classic_a_pressed, ButtonType.CLASSIC_BUTTON_A));
+              R.drawable.classic_a_pressed, ButtonType.CLASSIC_BUTTON_A, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic1", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_b,
-              R.drawable.classic_b_pressed, ButtonType.CLASSIC_BUTTON_B));
+              R.drawable.classic_b_pressed, ButtonType.CLASSIC_BUTTON_B, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic2", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_x,
-              R.drawable.classic_x_pressed, ButtonType.CLASSIC_BUTTON_X));
+              R.drawable.classic_x_pressed, ButtonType.CLASSIC_BUTTON_X, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic3", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_y,
-              R.drawable.classic_y_pressed, ButtonType.CLASSIC_BUTTON_Y));
+              R.drawable.classic_y_pressed, ButtonType.CLASSIC_BUTTON_Y, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic4", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_plus,
-              R.drawable.wiimote_plus_pressed, ButtonType.CLASSIC_BUTTON_PLUS));
+              R.drawable.wiimote_plus_pressed, ButtonType.CLASSIC_BUTTON_PLUS, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic5", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_minus,
-              R.drawable.wiimote_minus_pressed, ButtonType.CLASSIC_BUTTON_MINUS));
+              R.drawable.wiimote_minus_pressed, ButtonType.CLASSIC_BUTTON_MINUS, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic6", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_home,
-              R.drawable.wiimote_home_pressed, ButtonType.CLASSIC_BUTTON_HOME));
+              R.drawable.wiimote_home_pressed, ButtonType.CLASSIC_BUTTON_HOME, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic7", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_l,
-              R.drawable.classic_l_pressed, ButtonType.CLASSIC_TRIGGER_L));
+              R.drawable.classic_l_pressed, ButtonType.CLASSIC_TRIGGER_L, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic8", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_r,
-              R.drawable.classic_r_pressed, ButtonType.CLASSIC_TRIGGER_R));
+              R.drawable.classic_r_pressed, ButtonType.CLASSIC_TRIGGER_R, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic9", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_zl,
-              R.drawable.classic_zl_pressed, ButtonType.CLASSIC_BUTTON_ZL));
+              R.drawable.classic_zl_pressed, ButtonType.CLASSIC_BUTTON_ZL, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic10", true))
     {
       overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_zr,
-              R.drawable.classic_zr_pressed, ButtonType.CLASSIC_BUTTON_ZR));
+              R.drawable.classic_zr_pressed, ButtonType.CLASSIC_BUTTON_ZR, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic11", true))
     {
@@ -583,19 +590,19 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
               R.drawable.gcwii_dpad_pressed_one_direction,
               R.drawable.gcwii_dpad_pressed_two_directions,
               ButtonType.CLASSIC_DPAD_UP, ButtonType.CLASSIC_DPAD_DOWN,
-              ButtonType.CLASSIC_DPAD_LEFT, ButtonType.CLASSIC_DPAD_RIGHT));
+              ButtonType.CLASSIC_DPAD_LEFT, ButtonType.CLASSIC_DPAD_RIGHT, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic12", true))
     {
       overlayJoysticks.add(initializeOverlayJoystick(getContext(), R.drawable.gcwii_joystick_range,
               R.drawable.gcwii_joystick, R.drawable.gcwii_joystick_pressed,
-              ButtonType.CLASSIC_STICK_LEFT));
+              ButtonType.CLASSIC_STICK_LEFT, orientation));
     }
     if (mPreferences.getBoolean("buttonToggleClassic13", true))
     {
       overlayJoysticks.add(initializeOverlayJoystick(getContext(), R.drawable.gcwii_joystick_range,
               R.drawable.gcwii_joystick, R.drawable.gcwii_joystick_pressed,
-              ButtonType.CLASSIC_STICK_RIGHT));
+              ButtonType.CLASSIC_STICK_RIGHT, orientation));
     }
   }
 
@@ -606,33 +613,37 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     overlayDpads.removeAll(overlayDpads);
     overlayJoysticks.removeAll(overlayJoysticks);
 
+    String orientation =
+            getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT ?
+                    "-Portrait" : "";
+
     // Add all the enabled overlay items back to the HashSet.
     if (EmulationActivity.isGameCubeGame() || mPreferences.getInt("wiiController", 3) == 0)
     {
-      addGameCubeOverlayControls();
+      addGameCubeOverlayControls(orientation);
     }
     else if (mPreferences.getInt("wiiController", 3) == 4)
     {
-      addClassicOverlayControls();
+      addClassicOverlayControls(orientation);
     }
     else
     {
-      addWiimoteOverlayControls();
+      addWiimoteOverlayControls(orientation);
       if (mPreferences.getInt("wiiController", 3) == 3)
       {
-        addNunchukOverlayControls();
+        addNunchukOverlayControls(orientation);
       }
     }
 
     invalidate();
   }
 
-  private void saveControlPosition(int sharedPrefsId, int x, int y)
+  private void saveControlPosition(int sharedPrefsId, int x, int y, String orientation)
   {
     final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(getContext());
     SharedPreferences.Editor sPrefsEditor = sPrefs.edit();
-    sPrefsEditor.putFloat(sharedPrefsId + "-X", x);
-    sPrefsEditor.putFloat(sharedPrefsId + "-Y", y);
+    sPrefsEditor.putFloat(sharedPrefsId + orientation + "-X", x);
+    sPrefsEditor.putFloat(sharedPrefsId + orientation + "-Y", y);
     sPrefsEditor.apply();
   }
 
@@ -667,7 +678,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
    * @return An {@link InputOverlayDrawableButton} with the correct drawing bounds set.
    */
   private static InputOverlayDrawableButton initializeOverlayButton(Context context,
-          int defaultResId, int pressedResId, int buttonId)
+          int defaultResId, int pressedResId, int buttonId, String orientation)
   {
     // Resources handle for fetching the initial Drawable resource.
     final Resources res = context.getResources();
@@ -733,8 +744,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     // The X and Y coordinates of the InputOverlayDrawableButton on the InputOverlay.
     // These were set in the input overlay configuration menu.
-    int drawableX = (int) sPrefs.getFloat(buttonId + "-X", 0f);
-    int drawableY = (int) sPrefs.getFloat(buttonId + "-Y", 0f);
+    int drawableX = (int) sPrefs.getFloat(buttonId + orientation + "-X", 0f);
+    int drawableY = (int) sPrefs.getFloat(buttonId + orientation + "-Y", 0f);
 
     int width = overlayDrawable.getWidth();
     int height = overlayDrawable.getHeight();
@@ -769,7 +780,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
           int buttonUp,
           int buttonDown,
           int buttonLeft,
-          int buttonRight)
+          int buttonRight,
+          String orientation)
   {
     // Resources handle for fetching the initial Drawable resource.
     final Resources res = context.getResources();
@@ -812,8 +824,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     // The X and Y coordinates of the InputOverlayDrawableDpad on the InputOverlay.
     // These were set in the input overlay configuration menu.
-    int drawableX = (int) sPrefs.getFloat(buttonUp + "-X", 0f);
-    int drawableY = (int) sPrefs.getFloat(buttonUp + "-Y", 0f);
+    int drawableX = (int) sPrefs.getFloat(buttonUp + orientation + "-X", 0f);
+    int drawableY = (int) sPrefs.getFloat(buttonUp + orientation + "-Y", 0f);
 
     int width = overlayDrawable.getWidth();
     int height = overlayDrawable.getHeight();
@@ -839,7 +851,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
    * @return the initialized {@link InputOverlayDrawableJoystick}.
    */
   private static InputOverlayDrawableJoystick initializeOverlayJoystick(Context context,
-          int resOuter, int defaultResInner, int pressedResInner, int joystick)
+          int resOuter, int defaultResInner, int pressedResInner, int joystick, String orientation)
   {
     // Resources handle for fetching the initial Drawable resource.
     final Resources res = context.getResources();
@@ -860,8 +872,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     // The X and Y coordinates of the InputOverlayDrawableButton on the InputOverlay.
     // These were set in the input overlay configuration menu.
-    int drawableX = (int) sPrefs.getFloat(joystick + "-X", 0f);
-    int drawableY = (int) sPrefs.getFloat(joystick + "-Y", 0f);
+    int drawableX = (int) sPrefs.getFloat(joystick + orientation + "-X", 0f);
+    int drawableY = (int) sPrefs.getFloat(joystick + orientation + "-Y", 0f);
 
     // Decide inner scale based on joystick ID
     float innerScale;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -638,6 +638,36 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     invalidate();
   }
 
+  public void resetButtonPlacement()
+  {
+    boolean isLandscape =
+            getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
+
+    // Values for these come from R.array.controllersEntries
+    if (EmulationActivity.isGameCubeGame() || mPreferences.getInt("wiiController", 3) == 0)
+    {
+      if (isLandscape)
+        gcDefaultOverlay();
+      else
+        gcPortraitDefaultOverlay();
+    }
+    else if (mPreferences.getInt("wiiController", 3) == 4)
+    {
+      if (isLandscape)
+        wiiClassicDefaultOverlay();
+      else
+        wiiClassicPortraitDefaultOverlay();
+    }
+    else
+    {
+      if (isLandscape)
+        wiiDefaultOverlay();
+      else
+        wiiPortraitDefaultOverlay();
+    }
+    refreshControls();
+  }
+
   private void saveControlPosition(int sharedPrefsId, int x, int y, String orientation)
   {
     final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(getContext());

--- a/Source/Android/app/src/main/res/layout-port/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-port/fragment_emulation.xml
@@ -1,0 +1,47 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             android:keepScreenOn="true"
+             tools:context="org.dolphinemu.dolphinemu.fragments.EmulationFragment">
+
+    <!-- Places the emulation surface to the top half of the screen -->
+    <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:baselineAligned="false">
+        <!-- This is what everything is rendered to during emulation -->
+        <SurfaceView
+            android:id="@+id/surface_emulation"
+            android:layout_height="0dp"
+            android:layout_width="wrap_content"
+            android:layout_weight="1"
+            android:focusable="false"
+            android:focusableInTouchMode="false"/>
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
+    </LinearLayout>
+    <!-- This is the onscreen input overlay -->
+    <org.dolphinemu.dolphinemu.overlay.InputOverlay
+        android:id="@+id/surface_input_overlay"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"/>
+
+    <Button
+        android:id="@+id/done_control_config"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="@dimen/spacing_small"
+        android:background="@color/dolphin_blue"
+        android:textColor="@color/lb_tv_white"
+        android:text="@string/emulation_done"
+        android:visibility="gone"/>
+
+</FrameLayout>

--- a/Source/Android/app/src/main/res/menu/menu_emulation.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation.xml
@@ -102,6 +102,10 @@
                 android:id="@+id/menu_emulation_rumble"
                 android:checkable="true"
                 android:title="@string/emulation_control_rumble"/>
+
+            <item
+                android:id="@+id/menu_emulation_reset_overlay"
+                android:title="@string/emulation_touch_overlay_reset"/>
         </menu>
     </item>
 

--- a/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
@@ -108,6 +108,9 @@
                 android:id="@+id/menu_emulation_choose_controller"
                 android:title="@string/emulation_choose_controller"/>
 
+            <item
+                android:id="@+id/menu_emulation_reset_overlay"
+                android:title="@string/emulation_touch_overlay_reset"/>
         </menu>
     </item>
 

--- a/Source/Android/app/src/main/res/values/integers.xml
+++ b/Source/Android/app/src/main/res/values/integers.xml
@@ -26,6 +26,30 @@
     <integer name="STICK_MAIN_X">17</integer>
     <integer name="STICK_MAIN_Y">620</integer>
 
+    <!-- Default GameCube portrait layout -->
+    <integer name="BUTTON_A_PORTRAIT_X">638</integer>
+    <integer name="BUTTON_A_PORTRAIT_Y">534</integer>
+    <integer name="BUTTON_B_PORTRAIT_X">560</integer>
+    <integer name="BUTTON_B_PORTRAIT_Y">648</integer>
+    <integer name="BUTTON_X_PORTRAIT_X">795</integer>
+    <integer name="BUTTON_X_PORTRAIT_Y">519</integer>
+    <integer name="BUTTON_Y_PORTRAIT_X">594</integer>
+    <integer name="BUTTON_Y_PORTRAIT_Y">463</integer>
+    <integer name="BUTTON_Z_PORTRAIT_X">357</integer>
+    <integer name="BUTTON_Z_PORTRAIT_Y">560</integer>
+    <integer name="BUTTON_UP_PORTRAIT_X">44</integer>
+    <integer name="BUTTON_UP_PORTRAIT_Y">448</integer>
+    <integer name="TRIGGER_L_PORTRAIT_X">76</integer>
+    <integer name="TRIGGER_L_PORTRAIT_Y">582</integer>
+    <integer name="TRIGGER_R_PORTRAIT_X">739</integer>
+    <integer name="TRIGGER_R_PORTRAIT_Y">629</integer>
+    <integer name="BUTTON_START_PORTRAIT_X">472</integer>
+    <integer name="BUTTON_START_PORTRAIT_Y">789</integer>
+    <integer name="STICK_C_PORTRAIT_X">622</integer>
+    <integer name="STICK_C_PORTRAIT_Y">715</integer>
+    <integer name="STICK_MAIN_PORTRAIT_X">134</integer>
+    <integer name="STICK_MAIN_PORTRAIT_Y">687</integer>
+
     <!-- Default Wii landscape layout -->
     <integer name="WIIMOTE_BUTTON_A_X">858</integer>
     <integer name="WIIMOTE_BUTTON_A_Y">772</integer>
@@ -53,6 +77,34 @@
     <integer name="WIIMOTE_RIGHT_X">100</integer>
     <integer name="WIIMOTE_RIGHT_Y">683</integer>
 
+    <!-- Default Wii portrait layout -->
+    <integer name="WIIMOTE_BUTTON_A_PORTRAIT_X">769</integer>
+    <integer name="WIIMOTE_BUTTON_A_PORTRAIT_Y">584</integer>
+    <integer name="WIIMOTE_BUTTON_B_PORTRAIT_X">553</integer>
+    <integer name="WIIMOTE_BUTTON_B_PORTRAIT_Y">621</integer>
+    <integer name="WIIMOTE_BUTTON_1_PORTRAIT_X">707</integer>
+    <integer name="WIIMOTE_BUTTON_1_PORTRAIT_Y">742</integer>
+    <integer name="WIIMOTE_BUTTON_2_PORTRAIT_X">846</integer>
+    <integer name="WIIMOTE_BUTTON_2_PORTRAIT_Y">692</integer>
+    <integer name="NUNCHUK_BUTTON_Z_PORTRAIT_X">526</integer>
+    <integer name="NUNCHUK_BUTTON_Z_PORTRAIT_Y">483</integer>
+    <integer name="NUNCHUK_BUTTON_C_PORTRAIT_X">786</integer>
+    <integer name="NUNCHUK_BUTTON_C_PORTRAIT_Y">455</integer>
+    <integer name="WIIMOTE_BUTTON_MINUS_PORTRAIT_X">100</integer>
+    <integer name="WIIMOTE_BUTTON_MINUS_PORTRAIT_Y">420</integer>
+    <integer name="WIIMOTE_BUTTON_PLUS_PORTRAIT_X">400</integer>
+    <integer name="WIIMOTE_BUTTON_PLUS_PORTRAIT_Y">420</integer>
+    <integer name="WIIMOTE_UP_PORTRAIT_X">260</integer>
+    <integer name="WIIMOTE_UP_PORTRAIT_Y">773</integer>
+    <integer name="WIIMOTE_BUTTON_HOME_PORTRAIT_X">250</integer>
+    <integer name="WIIMOTE_BUTTON_HOME_PORTRAIT_Y">420</integer>
+    <integer name="NUNCHUK_STICK_PORTRAIT_X">68</integer>
+    <integer name="NUNCHUK_STICK_PORTRAIT_Y">602</integer>
+
+    <integer name="WIIMOTE_RIGHT_PORTRAIT_X">68</integer>
+    <integer name="WIIMOTE_RIGHT_PORTRAIT_Y">602</integer>
+
+    <!-- Default Wii classic landscape layout -->
     <integer name="CLASSIC_BUTTON_A_X">860</integer>
     <integer name="CLASSIC_BUTTON_A_Y">688</integer>
     <integer name="CLASSIC_BUTTON_B_X">787</integer>
@@ -81,4 +133,34 @@
     <integer name="CLASSIC_TRIGGER_L_Y">429</integer>
     <integer name="CLASSIC_TRIGGER_R_X">737</integer>
     <integer name="CLASSIC_TRIGGER_R_Y">311</integer>
+
+    <!-- Default Wii classic portrait layout -->
+    <integer name="CLASSIC_BUTTON_A_PORTRAIT_X">820</integer>
+    <integer name="CLASSIC_BUTTON_A_PORTRAIT_Y">481</integer>
+    <integer name="CLASSIC_BUTTON_B_PORTRAIT_X">763</integer>
+    <integer name="CLASSIC_BUTTON_B_PORTRAIT_Y">562</integer>
+    <integer name="CLASSIC_BUTTON_X_PORTRAIT_X">665</integer>
+    <integer name="CLASSIC_BUTTON_X_PORTRAIT_Y">476</integer>
+    <integer name="CLASSIC_BUTTON_Y_PORTRAIT_X">601</integer>
+    <integer name="CLASSIC_BUTTON_Y_PORTRAIT_Y">552</integer>
+    <integer name="CLASSIC_BUTTON_MINUS_PORTRAIT_X">100</integer>
+    <integer name="CLASSIC_BUTTON_MINUS_PORTRAIT_Y">420</integer>
+    <integer name="CLASSIC_BUTTON_PLUS_PORTRAIT_X">400</integer>
+    <integer name="CLASSIC_BUTTON_PLUS_PORTRAIT_Y">420</integer>
+    <integer name="CLASSIC_BUTTON_HOME_PORTRAIT_X">250</integer>
+    <integer name="CLASSIC_BUTTON_HOME_PORTRAIT_Y">420</integer>
+    <integer name="CLASSIC_BUTTON_ZL_PORTRAIT_X">301</integer>
+    <integer name="CLASSIC_BUTTON_ZL_PORTRAIT_Y">613</integer>
+    <integer name="CLASSIC_BUTTON_ZR_PORTRAIT_X">445</integer>
+    <integer name="CLASSIC_BUTTON_ZR_PORTRAIT_Y">734</integer>
+    <integer name="CLASSIC_DPAD_UP_PORTRAIT_X">101</integer>
+    <integer name="CLASSIC_DPAD_UP_PORTRAIT_Y">752</integer>
+    <integer name="CLASSIC_STICK_LEFT_PORTRAIT_X">46</integer>
+    <integer name="CLASSIC_STICK_LEFT_PORTRAIT_Y">533</integer>
+    <integer name="CLASSIC_STICK_RIGHT_PORTRAIT_X">706</integer>
+    <integer name="CLASSIC_STICK_RIGHT_PORTRAIT_Y">671</integer>
+    <integer name="CLASSIC_TRIGGER_L_PORTRAIT_X">342</integer>
+    <integer name="CLASSIC_TRIGGER_L_PORTRAIT_Y">458</integer>
+    <integer name="CLASSIC_TRIGGER_R_PORTRAIT_X">650</integer>
+    <integer name="CLASSIC_TRIGGER_R_PORTRAIT_Y">360</integer>
 </resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@
     <string name="emulation_choose_controller">Choose Controller</string>
     <string name="emulation_controller_changed">You may have to reload the game after changing extensions.</string>
     <string name="emulation_touch_button_help">To change the button layout, open the menu -> Configure Controls -> Edit Layout</string>
+    <string name="emulation_touch_overlay_reset">Reset Overlay</string>
 
     <!-- GC Adapter Menu-->
     <string name="gc_adapter_rumble">Enable Vibration</string>


### PR DESCRIPTION
A few things added.

1.  Add a separate profile when phone is portrait.  Should stop the complaints about touch controls being offscreen.
2. Add a default overlay for portrait
3. Add a reset button. This is in case a user somehow moves a button offscreen.
4. Moves the emulation frame to the top half of the screen when orientation is portrait so that there is more room for touch controls.

Github doesn't like my gifs. Here is a video of the profiles in action.
https://imgur.com/a/vGBrsOq

![gcport](https://user-images.githubusercontent.com/427044/45266597-97e8a600-b42b-11e8-934f-6d8369695d6a.png)
![wiiclassicport](https://user-images.githubusercontent.com/427044/45266598-97e8a600-b42b-11e8-9b39-22fb99e98c08.png)
![wiiport](https://user-images.githubusercontent.com/427044/45266599-97e8a600-b42b-11e8-95de-79e8853c936b.png)
