### PR TITLE
Correctly adjust the rendered XFB region at non-native internal resolutions when XFB was loaded from console RAM.

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -676,7 +676,16 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
       m_last_xfb_ticks = ticks;
 
       auto xfb_rect = texture_config.GetRect();
-      xfb_rect.right -= EFBToScaledX(fbStride - fbWidth);
+
+      // It's possible that the returned XFB texture is native resolution
+      // even when we're rendering at higher than native resolution
+      // if the XFB was was loaded entirely from console memory.
+      // If so, adjust the rectangle by native resolution instead of scaled resolution.
+      const u32 native_stride_width_difference = fbStride - fbWidth;
+      if (texture_config.width == xfb_entry->native_width)
+        xfb_rect.right -= native_stride_width_difference;
+      else
+        xfb_rect.right -= EFBToScaledX(native_stride_width_difference);
 
       m_last_xfb_region = xfb_rect;
 


### PR DESCRIPTION
If, for whatever reason, the XFB has to be loaded from console memory, it's possible that the texture is returned at native resolution instead of EFB-scaled resolution. In this case, our `xfb_rect.right` adjustment must also happen at native resolution instead of scaled resolution.

This actually happens to work regardless in most circumstances because `fbStride` and `fbWidth` are rarely different, and thus the value of the adjustment is `0` anyway. The only way I could get it to happen is by disabling the `bForceProgressive` option and running any of the numerous games that benefit from that.

Also, I'm not sure if this is the best check for determining when this happened. Better ideas?