### PR TITLE
Fix Starfox Assault from accessing out of bounds memory.

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -393,7 +393,11 @@ u8* GetPointer(u32 address)
 {
   // TODO: Should we be masking off more bits here?  Can all devices access
   // EXRAM?
-  address &= 0x3FFFFFFF;
+  if (SConfig::GetInstance().bWii)
+    address &= 0x3FFFFFFF;
+  else
+    address &= 0x03FFFFFF;
+
   if (address < REALRAM_SIZE)
     return m_pRAM + address;
 


### PR DESCRIPTION
This limit was chosen based on the requirement for Metroid Prime 3's
GameCube Beta.  By setting it to 0x03FFFFFF (64MB) we can still use the
modification to REAL_RAM in order to make the beta work.  My previous
implementation broke the beta, but this one has a limit that makes more
sense while still fixing Star Fox Assault.

For what it's worth, the minimum the Metroid Prime 3 beta wants is 48MB.  I don't think we can mask at 0x02FFFFFFF though based on the reaction to me suggesting that on IRC>