### PR TITLE
Read Wii disc metadata from the unencrypted header

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -62,8 +62,10 @@ public:
   virtual std::vector<Partition> GetPartitions() const { return {}; }
   virtual Partition GetGamePartition() const { return PARTITION_NONE; }
   virtual std::optional<u32> GetPartitionType(const Partition& partition) const { return {}; }
-  std::optional<u64> GetTitleID() const { return GetTitleID(GetGamePartition()); }
-  virtual std::optional<u64> GetTitleID(const Partition& partition) const { return {}; }
+  virtual std::optional<u64> GetTitleID(const Partition& partition = PARTITION_NONE) const
+  {
+    return {};
+  }
   virtual const IOS::ES::TicketReader& GetTicket(const Partition& partition) const
   {
     return INVALID_TICKET;
@@ -75,14 +77,10 @@ public:
   {
     return offset;
   }
-  std::string GetGameID() const { return GetGameID(GetGamePartition()); }
-  virtual std::string GetGameID(const Partition& partition) const = 0;
-  std::string GetMakerID() const { return GetMakerID(GetGamePartition()); }
-  virtual std::string GetMakerID(const Partition& partition) const = 0;
-  std::optional<u16> GetRevision() const { return GetRevision(GetGamePartition()); }
-  virtual std::optional<u16> GetRevision(const Partition& partition) const = 0;
-  std::string GetInternalName() const { return GetInternalName(GetGamePartition()); }
-  virtual std::string GetInternalName(const Partition& partition) const = 0;
+  virtual std::string GetGameID(const Partition& partition = PARTITION_NONE) const = 0;
+  virtual std::string GetMakerID(const Partition& partition = PARTITION_NONE) const = 0;
+  virtual std::optional<u16> GetRevision(const Partition& partition = PARTITION_NONE) const = 0;
+  virtual std::string GetInternalName(const Partition& partition = PARTITION_NONE) const = 0;
   virtual std::map<Language, std::string> GetShortNames() const { return {}; }
   virtual std::map<Language, std::string> GetLongNames() const { return {}; }
   virtual std::map<Language, std::string> GetShortMakers() const { return {}; }
@@ -92,15 +90,16 @@ public:
   std::string GetApploaderDate() const { return GetApploaderDate(GetGamePartition()); }
   virtual std::string GetApploaderDate(const Partition& partition) const = 0;
   // 0 is the first disc, 1 is the second disc
-  std::optional<u8> GetDiscNumber() const { return GetDiscNumber(GetGamePartition()); }
-  virtual std::optional<u8> GetDiscNumber(const Partition& partition) const { return 0; }
+  virtual std::optional<u8> GetDiscNumber(const Partition& partition = PARTITION_NONE) const
+  {
+    return 0;
+  }
   virtual Platform GetVolumeType() const = 0;
   virtual bool SupportsIntegrityCheck() const { return false; }
   virtual bool CheckIntegrity(const Partition& partition) const { return false; }
   // May be inaccurate for WADs
   virtual Region GetRegion() const = 0;
-  Country GetCountry() const { return GetCountry(GetGamePartition()); }
-  virtual Country GetCountry(const Partition& partition) const = 0;
+  virtual Country GetCountry(const Partition& partition = PARTITION_NONE) const = 0;
   virtual BlobType GetBlobType() const = 0;
   // Size of virtual disc (may be inaccurate depending on the blob type)
   virtual u64 GetSize() const = 0;

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -27,7 +27,7 @@
 
 namespace UICommon
 {
-static constexpr u32 CACHE_REVISION = 12;  // Last changed in PR 7285
+static constexpr u32 CACHE_REVISION = 13;  // Last changed in PR 7411
 
 std::vector<std::string> FindAllGamePaths(const std::vector<std::string>& directories_to_scan,
                                           bool recursive_scan)


### PR DESCRIPTION
The header of a Wii disc can be read from two places: The unencrypted area at the beginning of the disc, or the beginning of the game partition. The two copies are usually identical (except for 0x60 and 0x61), but there are exceptions. For most of Dolphin's history, we have been reading from the header inside the game partition when getting metadata. This was however not the case starting with 4.0-4901 and ending with 5.0-3762. This PR once again makes Dolphin read metadata from the unencrypted header, because of the following reasons that I recently was informed about:

- The "pink fish" disc has the game ID 410E01 in the unencrypted header but the placeholder game ID RELSAB in the partition header.
- The revisions of some games differ between the two headers, with the unencrypted one making more sense. (See https://bugs.dolphin-emu.org/issues/11387)

For better or worse, this also means that sloppily hacked games where only the game ID in the unencrypted header has been changed now will use that modified game ID. And unlike with the partition header, there is no signing or hashing that can tell us whether the unencrypted header has been modified by someone other than Nintendo.

cc @JMC47 for testing