### PR TITLE
Stitch together overlapping XFB regions in order of XFB copy creation.

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 #if defined(_M_X86) || defined(_M_X86_64)
 #include <pmmintrin.h>
 #endif
@@ -1296,6 +1297,15 @@ bool TextureCacheBase::LoadTextureFromOverlappingTextures(TCacheEntry* entry_to_
 
   u32 numBlocksX = entry_to_update->native_width / tex_info.block_width;
 
+  // It is possible that some of the overlapping textures overlap each other.
+  // This behavior has been seen with XFB copies in Rogue Leader.
+  // To get the correct result, we apply the texture updates in the order the textures were
+  // originally loaded. This ensures that the parts of the texture that would have been overwritten
+  // in memory on real hardware get overwritten the same way here too.
+  // This should work, but it may be a better idea to keep track of partial XFB copy invalidations
+  // instead, which would reduce the amount of copying work here.
+  std::vector<TCacheEntry*> candidates;
+
   auto iter = FindOverlappingTextures(entry_to_update->addr, entry_to_update->size_in_bytes);
   while (iter.first != iter.second)
   {
@@ -1307,106 +1317,7 @@ bool TextureCacheBase::LoadTextureFromOverlappingTextures(TCacheEntry* entry_to_
     {
       if (entry->hash == entry->CalculateHash())
       {
-        if (tex_info.is_palette_texture)
-        {
-          TCacheEntry* decoded_entry =
-              ApplyPaletteToEntry(entry, nullptr, tex_info.full_format.tlutfmt);
-          if (decoded_entry)
-          {
-            // Link the efb copy with the partially updated texture, so we won't apply this partial
-            // update again
-            entry->CreateReference(entry_to_update);
-            // Mark the texture update as used, as if it was loaded directly
-            entry->frameCount = FRAMECOUNT_INVALID;
-            entry = decoded_entry;
-          }
-          else
-          {
-            ++iter.first;
-            continue;
-          }
-        }
-
-        s32 src_x, src_y, dst_x, dst_y;
-
-        // Note for understanding the math:
-        // Normal textures can't be strided, so the 2 missing cases with src_x > 0 don't exist
-        if (entry->addr >= entry_to_update->addr)
-        {
-          s32 block_offset = (entry->addr - entry_to_update->addr) / tex_info.bytes_per_block;
-          s32 block_x = block_offset % numBlocksX;
-          s32 block_y = block_offset / numBlocksX;
-          src_x = 0;
-          src_y = 0;
-          dst_x = block_x * tex_info.block_width;
-          dst_y = block_y * tex_info.block_height;
-        }
-        else
-        {
-          s32 block_offset = (entry_to_update->addr - entry->addr) / tex_info.bytes_per_block;
-          s32 block_x = block_offset % numBlocksX;
-          s32 block_y = block_offset / numBlocksX;
-          src_x = block_x * tex_info.block_width;
-          src_y = block_y * tex_info.block_height;
-          dst_x = 0;
-          dst_y = 0;
-        }
-
-        u32 copy_width =
-            std::min(entry->native_width - src_x, entry_to_update->native_width - dst_x);
-        u32 copy_height =
-            std::min(entry->native_height - src_y, entry_to_update->native_height - dst_y);
-
-        // If one of the textures is scaled, scale both with the current efb scaling factor
-        if (entry_to_update->native_width != entry_to_update->GetWidth() ||
-            entry_to_update->native_height != entry_to_update->GetHeight() ||
-            entry->native_width != entry->GetWidth() || entry->native_height != entry->GetHeight())
-        {
-          ScaleTextureCacheEntryTo(entry_to_update,
-                                   g_renderer->EFBToScaledX(entry_to_update->native_width),
-                                   g_renderer->EFBToScaledY(entry_to_update->native_height));
-          ScaleTextureCacheEntryTo(entry, g_renderer->EFBToScaledX(entry->native_width),
-                                   g_renderer->EFBToScaledY(entry->native_height));
-
-          src_x = g_renderer->EFBToScaledX(src_x);
-          src_y = g_renderer->EFBToScaledY(src_y);
-          dst_x = g_renderer->EFBToScaledX(dst_x);
-          dst_y = g_renderer->EFBToScaledY(dst_y);
-          copy_width = g_renderer->EFBToScaledX(copy_width);
-          copy_height = g_renderer->EFBToScaledY(copy_height);
-        }
-
-        MathUtil::Rectangle<int> srcrect, dstrect;
-        srcrect.left = src_x;
-        srcrect.top = src_y;
-        srcrect.right = (src_x + copy_width);
-        srcrect.bottom = (src_y + copy_height);
-
-        dstrect.left = dst_x;
-        dstrect.top = dst_y;
-        dstrect.right = (dst_x + copy_width);
-        dstrect.bottom = (dst_y + copy_height);
-
-        for (u32 layer = 0; layer < entry->texture->GetConfig().layers; layer++)
-        {
-          entry_to_update->texture->CopyRectangleFromTexture(entry->texture.get(), srcrect, layer,
-                                                             0, dstrect, layer, 0);
-        }
-        updated_entry = true;
-
-        if (tex_info.is_palette_texture)
-        {
-          // Remove the temporary converted texture, it won't be used anywhere else
-          // TODO: It would be nice to convert and copy in one step, but this code path isn't common
-          InvalidateTexture(GetTexCacheIter(entry));
-        }
-        else
-        {
-          // Link the two textures together, so we won't apply this partial update again
-          entry->CreateReference(entry_to_update);
-          // Mark the texture update as used, as if it was loaded directly
-          entry->frameCount = FRAMECOUNT_INVALID;
-        }
+        candidates.emplace_back(entry);
       }
       else
       {
@@ -1416,6 +1327,111 @@ bool TextureCacheBase::LoadTextureFromOverlappingTextures(TCacheEntry* entry_to_
       }
     }
     ++iter.first;
+  }
+
+  std::sort(candidates.begin(), candidates.end(),
+            [](const TCacheEntry* a, const TCacheEntry* b) { return a->id < b->id; });
+
+  for (TCacheEntry* entry : candidates)
+  {
+    if (tex_info.is_palette_texture)
+    {
+      TCacheEntry* decoded_entry =
+          ApplyPaletteToEntry(entry, nullptr, tex_info.full_format.tlutfmt);
+      if (decoded_entry)
+      {
+        // Link the efb copy with the partially updated texture, so we won't apply this partial
+        // update again
+        entry->CreateReference(entry_to_update);
+        // Mark the texture update as used, as if it was loaded directly
+        entry->frameCount = FRAMECOUNT_INVALID;
+        entry = decoded_entry;
+      }
+      else
+      {
+        continue;
+      }
+    }
+
+    s32 src_x, src_y, dst_x, dst_y;
+
+    // Note for understanding the math:
+    // Normal textures can't be strided, so the 2 missing cases with src_x > 0 don't exist
+    if (entry->addr >= entry_to_update->addr)
+    {
+      s32 block_offset = (entry->addr - entry_to_update->addr) / tex_info.bytes_per_block;
+      s32 block_x = block_offset % numBlocksX;
+      s32 block_y = block_offset / numBlocksX;
+      src_x = 0;
+      src_y = 0;
+      dst_x = block_x * tex_info.block_width;
+      dst_y = block_y * tex_info.block_height;
+    }
+    else
+    {
+      s32 block_offset = (entry_to_update->addr - entry->addr) / tex_info.bytes_per_block;
+      s32 block_x = block_offset % numBlocksX;
+      s32 block_y = block_offset / numBlocksX;
+      src_x = block_x * tex_info.block_width;
+      src_y = block_y * tex_info.block_height;
+      dst_x = 0;
+      dst_y = 0;
+    }
+
+    u32 copy_width = std::min(entry->native_width - src_x, entry_to_update->native_width - dst_x);
+    u32 copy_height =
+        std::min(entry->native_height - src_y, entry_to_update->native_height - dst_y);
+
+    // If one of the textures is scaled, scale both with the current efb scaling factor
+    if (entry_to_update->native_width != entry_to_update->GetWidth() ||
+        entry_to_update->native_height != entry_to_update->GetHeight() ||
+        entry->native_width != entry->GetWidth() || entry->native_height != entry->GetHeight())
+    {
+      ScaleTextureCacheEntryTo(entry_to_update,
+                               g_renderer->EFBToScaledX(entry_to_update->native_width),
+                               g_renderer->EFBToScaledY(entry_to_update->native_height));
+      ScaleTextureCacheEntryTo(entry, g_renderer->EFBToScaledX(entry->native_width),
+                               g_renderer->EFBToScaledY(entry->native_height));
+
+      src_x = g_renderer->EFBToScaledX(src_x);
+      src_y = g_renderer->EFBToScaledY(src_y);
+      dst_x = g_renderer->EFBToScaledX(dst_x);
+      dst_y = g_renderer->EFBToScaledY(dst_y);
+      copy_width = g_renderer->EFBToScaledX(copy_width);
+      copy_height = g_renderer->EFBToScaledY(copy_height);
+    }
+
+    MathUtil::Rectangle<int> srcrect, dstrect;
+    srcrect.left = src_x;
+    srcrect.top = src_y;
+    srcrect.right = (src_x + copy_width);
+    srcrect.bottom = (src_y + copy_height);
+
+    dstrect.left = dst_x;
+    dstrect.top = dst_y;
+    dstrect.right = (dst_x + copy_width);
+    dstrect.bottom = (dst_y + copy_height);
+
+    for (u32 layer = 0; layer < entry->texture->GetConfig().layers; layer++)
+    {
+      entry_to_update->texture->CopyRectangleFromTexture(entry->texture.get(), srcrect, layer, 0,
+                                                         dstrect, layer, 0);
+    }
+    updated_entry = true;
+
+    if (tex_info.is_palette_texture)
+    {
+      // Remove the temporary converted texture, it won't be used anywhere else
+      // TODO: It would be nice to convert and copy in one step, but this code path isn't common
+      InvalidateTexture(GetTexCacheIter(entry));
+    }
+    else
+    {
+      // Link the two textures together, so we won't apply this partial update again
+      entry->CreateReference(entry_to_update);
+      // Mark the texture update as used, as if it was loaded directly
+      entry->frameCount = FRAMECOUNT_INVALID;
+    }
   }
 
   return updated_entry;


### PR DESCRIPTION
This is a fun one!

So, the observable issue here is that if you try to play Rogue Leader in Dolphin and happen to pause during gameplay, the output image starts flickering between a properly rendered frame and something along the lines of this:

![_wrong_output](https://user-images.githubusercontent.com/4522237/45512053-e76a0180-b79e-11e8-9c26-7f0b0c5fb41a.png)

What you're seeing in the lower part here is a pretty old frame that played during the last widescreen cutscene. How did that end up here? We should be instead seeing this instead!

![_right_output](https://user-images.githubusercontent.com/4522237/45512059-ed5fe280-b79e-11e8-9586-99e6b8423c0e.png)

Well, I'm slightly simplfying here (all of this is double-buffered to two separate memory addresses and only one of them visibly shows the problem), but here's the basic idea.

During the cutscene, Rogue Leader makes XFB copies at 0x2bbae0. When the cutscene eventually ends (or you skip it) and the game switches to a more 4:3 output, it switches the location of its XFB copies to 0x25cae0. At this point, it only outputs a single full XFB copy per frame, so we just take it directly from the cache when outputting.

When you then pause the game during gameplay, the XFB copy method is switched again in order to do the half XFB copy stuff for antialiasing or whatever, this time to both 0x25cae0 and 0x2a2ae0. These copies have a size of 0x46a00 bytes each, which together make a full frame. That occupies a memory region from 0x25cae0 to 0x2e94e0.

Note how 0x2e94e0 is after 0x2bbae0, the old location of the cutscene XFB. When time comes to scan out the image, Dolphin attempts to stitch together all XFBs in the 0x25cae0-0x2e94e0 region, and finds this old cutscene XFB right in the middle of it. Finding nothing wrong with it, it proceeds to stitch that image into the output, and that's how we end up with the wrong image.

If this is a bit confusing, I've made a little visualization.

![_cutscene](https://user-images.githubusercontent.com/4522237/45512081-023c7600-b79f-11e8-9429-9ad3aae77dcb.png)

At some point in the past, the game made an XFB copy of a cutscene.

![_first_xfb](https://user-images.githubusercontent.com/4522237/45512085-05376680-b79f-11e8-8a36-491c09301e15.png)
![_second_xfb_correct](https://user-images.githubusercontent.com/4522237/45512097-0bc5de00-b79f-11e8-84d6-4d6fd12bfb39.png)

When the pause menu is rendered, the two XFB copies only partially overwrite the old cutscene XFB. The game expects the output to be something like this, and only scans out the newly rendered parts to screen.

![_second_xfb_wrong](https://user-images.githubusercontent.com/4522237/45512092-08caed80-b79f-11e8-8313-210e608a81e3.png)

But Dolphin both doesn't realize the cutscene copy has been partially overwritten and also fails to keep the order in mind. Instead, it stitches them together in the order they come back from the multimap iterator, which is memory address order.


So, with that info, we can see that our issue here is that we aren't invalidating partially overwritten XFB copies. No XFB copy made after the cutscene ever fully overwrites the cutscenes XFB copy at 0x2bbae0, so that doesn't kick it out of the cache, and for some reason I'm not quite sure of yet it doesn't get evicted by pure time passed either. But even without the time threshold, the XFB copy to 0x2a2ae0 with a size of 0x46a00 should at the very least invalidate the first 0x2da00 bytes of the old copy at 0x2bbae0.

This PR here works around this entire issue by applying overlapping XFB copies in the order they were made. That way, newer XFB copies overwrite older ones when the output image is stitched together, just like they would on hardware. This isn't incorrect, but it also doesn't really fix the actual issue here, just the visible result of it. If someone wants to go ahead and properly implement partial XFB invalidations, that's completely fine by me. I just figured I should post my findings somewhere and provide a decent alternate solution.