### PR TITLE
x64Emitter: emit shorter MOVs for 64-bit immediates

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -1591,6 +1591,12 @@ void XEmitter::XOR(int bits, const OpArg& a1, const OpArg& a2)
 }
 void XEmitter::MOV(int bits, const OpArg& a1, const OpArg& a2)
 {
+  if (bits == 64 && a1.IsSimpleReg() && a2.scale == SCALE_IMM64 &&
+      a2.offset == static_cast<u32>(a2.offset))
+  {
+    WriteNormalOp(32, NormalOp::MOV, a1, a2.AsImm32());
+    return;
+  }
   if (a1.IsSimpleReg() && a2.IsSimpleReg() && a1.GetSimpleReg() == a2.GetSimpleReg())
     ERROR_LOG(DYNA_REC, "Redundant MOV @ %p - bug in JIT?", code);
   WriteNormalOp(bits, NormalOp::MOV, a1, a2);

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -1469,11 +1469,21 @@ void OpArg::WriteNormalOp(XEmitter* emit, bool toRM, NormalOp op, const OpArg& o
       // mov reg64, imm64
       else if (op == NormalOp::MOV)
       {
-        emit->Write8(0xB8 + (offsetOrBaseReg & 7));
-        emit->Write64((u64)operand.offset);
-        return;
+        // movabs reg64, imm64 (10 bytes)
+        if (static_cast<s64>(operand.offset) != static_cast<s32>(operand.offset))
+        {
+          emit->Write8(0xB8 + (offsetOrBaseReg & 7));
+          emit->Write64(operand.offset);
+          return;
+        }
+        // mov reg64, simm32 (7 bytes)
+        emit->Write8(op_def.imm32);
+        immToWrite = 32;
       }
-      ASSERT_MSG(DYNA_REC, 0, "WriteNormalOp - Only MOV can take 64-bit imm");
+      else
+      {
+        ASSERT_MSG(DYNA_REC, 0, "WriteNormalOp - Only MOV can take 64-bit imm");
+      }
     }
     else
     {

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -547,6 +547,24 @@ TWO_OP_ARITH_TEST(OR)
 TWO_OP_ARITH_TEST(XOR)
 TWO_OP_ARITH_TEST(MOV)
 
+TEST_F(x64EmitterTest, MOV_Imm64)
+{
+  for (size_t i = 0; i < reg64names.size(); i++)
+  {
+    emitter->MOV(64, R(reg64names[i].reg), Imm64(0xDEADBEEFDEADBEEF));
+    EXPECT_EQ(emitter->GetCodePtr(), code_buffer + 10);
+    ExpectDisassembly("mov " + reg64names[i].name + ", 0xdeadbeefdeadbeef");
+
+    emitter->MOV(64, R(reg64names[i].reg), Imm64(0xFFFFFFFFDEADBEEF));
+    EXPECT_EQ(emitter->GetCodePtr(), code_buffer + 7);
+    ExpectDisassembly("mov " + reg64names[i].name + ", 0xffffffffdeadbeef");
+
+    emitter->MOV(64, R(reg64names[i].reg), Imm64(0xDEADBEEF));
+    EXPECT_EQ(emitter->GetCodePtr(), code_buffer + 5 + (i > 7));
+    ExpectDisassembly("mov " + reg32names[i].name + ", 0xdeadbeef");
+  }
+}
+
 // TODO: Disassembler inverts operands here.
 // TWO_OP_ARITH_TEST(XCHG)
 // TWO_OP_ARITH_TEST(TEST)

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -35,7 +35,10 @@ const std::vector<NamedReg> reg8names{
 };
 
 const std::vector<NamedReg> reg8hnames{
-    {AH, "ah"}, {BH, "bh"}, {CH, "ch"}, {DH, "dh"},
+    {AH, "ah"},
+    {BH, "bh"},
+    {CH, "ch"},
+    {DH, "dh"},
 };
 
 const std::vector<NamedReg> reg16names{
@@ -306,10 +309,12 @@ TEST_F(x64EmitterTest, CMOVcc_Register)
     emitter->CMOVcc(32, RAX, R(R12), cc.cc);
     emitter->CMOVcc(16, RAX, R(R12), cc.cc);
 
-    ExpectDisassembly("cmov" + cc.name + " rax, r12 "
-                                         "cmov" +
-                      cc.name + " eax, r12d "
-                                "cmov" +
+    ExpectDisassembly("cmov" + cc.name +
+                      " rax, r12 "
+                      "cmov" +
+                      cc.name +
+                      " eax, r12d "
+                      "cmov" +
                       cc.name + " ax, r12w");
   }
 }
@@ -379,10 +384,12 @@ TEST_F(x64EmitterTest, MOVNT_DQ_PS_PD)
     emitter->MOVNTDQ(MatR(RAX), r.reg);
     emitter->MOVNTPS(MatR(RAX), r.reg);
     emitter->MOVNTPD(MatR(RAX), r.reg);
-    ExpectDisassembly("movntdq dqword ptr ds:[rax], " + r.name + " "
-                                                                 "movntps dqword ptr ds:[rax], " +
-                      r.name + " "
-                               "movntpd dqword ptr ds:[rax], " +
+    ExpectDisassembly("movntdq dqword ptr ds:[rax], " + r.name +
+                      " "
+                      "movntps dqword ptr ds:[rax], " +
+                      r.name +
+                      " "
+                      "movntpd dqword ptr ds:[rax], " +
                       r.name);
   }
 }
@@ -576,7 +583,8 @@ TEST_F(x64EmitterTest, BSWAP)
     int bits;
     std::vector<NamedReg> regs;
   } regsets[] = {
-      {32, reg32names}, {64, reg64names},
+      {32, reg32names},
+      {64, reg64names},
   };
   for (const auto& regset : regsets)
     for (const auto& r : regset.regs)
@@ -889,7 +897,8 @@ TWO_OP_SSE_TEST(PMOVZXDQ, "qword")
       std::string out_name;                                                                        \
       std::string size;                                                                            \
     } regsets[] = {                                                                                \
-        {32, reg32names, "eax", "dword"}, {64, reg64names, "rax", "qword"},                        \
+        {32, reg32names, "eax", "dword"},                                                          \
+        {64, reg64names, "rax", "qword"},                                                          \
     };                                                                                             \
     for (const auto& regset : regsets)                                                             \
       for (const auto& r : regset.regs)                                                            \
@@ -921,7 +930,8 @@ VEX_RMR_TEST(BZHI)
       std::string out_name;                                                                        \
       std::string size;                                                                            \
     } regsets[] = {                                                                                \
-        {32, reg32names, "eax", "dword"}, {64, reg64names, "rax", "qword"},                        \
+        {32, reg32names, "eax", "dword"},                                                          \
+        {64, reg64names, "rax", "qword"},                                                          \
     };                                                                                             \
     for (const auto& regset : regsets)                                                             \
       for (const auto& r : regset.regs)                                                            \
@@ -952,7 +962,8 @@ VEX_RRM_TEST(ANDN)
       std::string out_name;                                                                        \
       std::string size;                                                                            \
     } regsets[] = {                                                                                \
-        {32, reg32names, "eax", "dword"}, {64, reg64names, "rax", "qword"},                        \
+        {32, reg32names, "eax", "dword"},                                                          \
+        {64, reg64names, "rax", "qword"},                                                          \
     };                                                                                             \
     for (const auto& regset : regsets)                                                             \
       for (const auto& r : regset.regs)                                                            \
@@ -981,7 +992,8 @@ VEX_RM_TEST(BLSI)
       std::string out_name;                                                                        \
       std::string size;                                                                            \
     } regsets[] = {                                                                                \
-        {32, reg32names, "eax", "dword"}, {64, reg64names, "rax", "qword"},                        \
+        {32, reg32names, "eax", "dword"},                                                          \
+        {64, reg64names, "rax", "qword"},                                                          \
     };                                                                                             \
     for (const auto& regset : regsets)                                                             \
       for (const auto& r : regset.regs)                                                            \


### PR DESCRIPTION
Previously, the emitter would unconditionally emit a 10-byte instruction known as MOVABS when loading a 64-bit immediate to a register.

```
0:  48 b8 ef be ad de ff    movabs rax,0xffffffffdeadbeef
7:  ff ff ff
a:  48 b8 ef be ad de 00    movabs rax,0xdeadbeef
11: 00 00 00 
```

This pull request teaches the emitter to instead use shorter instructions when there exists a 32-bit value that can either be zero extended or sign extended to the desired 64-bit immediate.

```
0:  48 c7 c0 ef be ad de    mov    rax,0xffffffffdeadbeef
7:  b8 ef be ad de          mov    eax,0xdeadbeef 
```