### PR TITLE
vulkan: fix SIGSEGV on config window opening

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -7,6 +7,8 @@
 #include "Common/Common.h"
 #include "VideoCommon/VideoBackendBase.h"
 
+#include <mutex>
+
 namespace Vulkan
 {
 class VideoBackend : public VideoBackendBase
@@ -18,5 +20,8 @@ public:
   std::string GetName() const override { return "Vulkan"; }
   std::string GetDisplayName() const override { return _trans("Vulkan"); }
   void InitBackendInfo() override;
+
+private:
+  std::mutex mtx;
 };
 }


### PR DESCRIPTION
Racy stores to vk{FunctionName} pointers makes dolphin crush on opening graphics config window during rendering. The fix -- make private copy of this pointers when necessary. 

Alternatively, we can get rid of manual dynamic linkage and leave it on ICD. It can hurt performance in some cases however.

Presumably, it will generate almost the same binary without extra overhead on hot path (e.g. extra indirection). But the patch makes the code uglier.