### PR TITLE
Externals/discord: Don't run clang-format on source files

### DIFF
--- a/Externals/discord-rpc/CMakeLists.txt
+++ b/Externals/discord-rpc/CMakeLists.txt
@@ -9,20 +9,6 @@ file(GLOB_RECURSE ALL_SOURCE_FILES
     src/*.cpp src/*.h src/*.c
 )
 
-# Set CLANG_FORMAT_SUFFIX if you are using custom clang-format, e.g. clang-format-5.0
-find_program(CLANG_FORMAT_CMD clang-format${CLANG_FORMAT_SUFFIX})
-
-if (CLANG_FORMAT_CMD)
-    add_custom_target(
-        clangformat
-        COMMAND ${CLANG_FORMAT_CMD}
-        -i -style=file -fallback-style=none
-        ${ALL_SOURCE_FILES}
-        DEPENDS
-        ${ALL_SOURCE_FILES}
-    )
-endif(CLANG_FORMAT_CMD)
-
 # add subdirs
 
 add_subdirectory(src)

--- a/Externals/discord-rpc/src/CMakeLists.txt
+++ b/Externals/discord-rpc/src/CMakeLists.txt
@@ -115,10 +115,6 @@ if (${BUILD_SHARED_LIBS})
     target_compile_definitions(discord-rpc PRIVATE -DDISCORD_BUILDING_SDK)
 endif(${BUILD_SHARED_LIBS})
 
-if (CLANG_FORMAT_CMD)
-    add_dependencies(discord-rpc clangformat)
-endif(CLANG_FORMAT_CMD)
-
 # install
 
 install(


### PR DESCRIPTION
It's annoying to have source files automatically reformatted every time
Dolphin is built because it causes git to consider the source tree to
be dirty.