### PR TITLE
Fix scrubbing unencrypted Wii disc images

### DIFF
--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -127,7 +127,10 @@ void DiscScrubber::MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size)
 // Compensate for 0x400 (SHA-1) per 0x8000 (cluster), and round to whole clusters
 u64 DiscScrubber::ToClusterOffset(u64 offset) const
 {
-  return offset / 0x7c00 * CLUSTER_SIZE;
+  if (m_disc->IsEncryptedAndHashed())
+    return offset / 0x7c00 * CLUSTER_SIZE;
+  else
+    return offset % CLUSTER_SIZE;
 }
 
 // Helper functions for reading the BE volume

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -106,10 +106,9 @@ void DiscScrubber::MarkAsUsed(u64 offset, u64 size)
   }
 }
 
-// Compensate for 0x400 (SHA-1) per 0x8000 (cluster), and round to whole clusters
 void DiscScrubber::MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size)
 {
-  u64 first_cluster_start = offset / 0x7c00 * CLUSTER_SIZE + partition_data_offset;
+  u64 first_cluster_start = ToClusterOffset(offset) + partition_data_offset;
 
   u64 last_cluster_end;
   if (size == 0)
@@ -119,10 +118,16 @@ void DiscScrubber::MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size)
   }
   else
   {
-    last_cluster_end = ((offset + size - 1) / 0x7c00 + 1) * CLUSTER_SIZE + partition_data_offset;
+    last_cluster_end = ToClusterOffset(offset + size - 1) + CLUSTER_SIZE + partition_data_offset;
   }
 
   MarkAsUsed(first_cluster_start, last_cluster_end - first_cluster_start);
+}
+
+// Compensate for 0x400 (SHA-1) per 0x8000 (cluster), and round to whole clusters
+u64 DiscScrubber::ToClusterOffset(u64 offset) const
+{
+  return offset / 0x7c00 * CLUSTER_SIZE;
 }
 
 // Helper functions for reading the BE volume

--- a/Source/Core/DiscIO/DiscScrubber.h
+++ b/Source/Core/DiscIO/DiscScrubber.h
@@ -61,6 +61,7 @@ private:
 
   void MarkAsUsed(u64 offset, u64 size);
   void MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size);
+  u64 ToClusterOffset(u64 offset) const;
   bool ReadFromVolume(u64 offset, u32& buffer, const Partition& partition);
   bool ReadFromVolume(u64 offset, u64& buffer, const Partition& partition);
   bool ParseDisc();


### PR DESCRIPTION
Untested with unencrypted Wii disc images, because I don't have any. I tested that normal Wii disc images still work, though.