### PR TITLE
Treat first and second gen Xbox One controllers as XboxOneWireless

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ControllerMappingHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ControllerMappingHelper.java
@@ -58,7 +58,9 @@ public class ControllerMappingHelper
 
   private static boolean isXboxOneWireless(InputDevice inputDevice)
   {
-    // Microsoft Xbox One controller
-    return inputDevice.getVendorId() == 0x45e && inputDevice.getProductId() == 0x2e0;
+		// TODO: get productID for Xbox One Elite Controller
+		// Microsoft Xbox One controller; each revision has a different product ID, but the same behavior with regards to the triggers.
+		// These IDs are for the first, second, and third revision of the standard controller, respectively
+		return inputDevice.getVendorId() == 0x45e && (inputDevice.getProductId() == 0x2d1 || inputDevice.getProductId() == 0x2dd || inputDevice.getProductId() == 0x2e0);
   }
 }


### PR DESCRIPTION
The analog triggers on Xbox One controllers are reported incorrectly within Android. This was partially fixed in #6156, but it only targeted the third revision of Xbox One controllers. This fixes it to work with both the first and second revision controllers.