### PR TITLE
zlib/CMakeLists: Fix check for unistd.h

### DIFF
--- a/Externals/zlib/CMakeLists.txt
+++ b/Externals/zlib/CMakeLists.txt
@@ -8,11 +8,12 @@ include(CheckCSourceCompiles)
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdint.h    HAVE_STDINT_H)
 check_include_file(stddef.h    HAVE_STDDEF_H)
-check_include_file(unistd.h Z_HAVE_UNISTD_H)
 
 # Check to see if we have large file support
 set(CMAKE_REQUIRED_DEFINITIONS -D_LARGEFILE64_SOURCE=1)
-
+# We add these other definitions here because CheckTypeSize.cmake
+# in CMake 2.4.x does not automatically do so and we want
+# compatibility with CMake 2.4.x.
 if(HAVE_SYS_TYPES_H)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -DHAVE_SYS_TYPES_H)
 endif()
@@ -32,6 +33,14 @@ set(CMAKE_REQUIRED_DEFINITIONS) # clear variable
 check_function_exists(fseeko HAVE_FSEEKO)
 if(NOT HAVE_FSEEKO)
     add_definitions(-DNO_FSEEKO)
+endif()
+
+#
+# Check for unistd.h
+#
+check_include_file(unistd.h HAVE_UNISTD_H)
+if(HAVE_UNISTD_H)
+    add_definitions(-DHAVE_UNISTD_H)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
The CMakeLists file for the static zlib checks for presence of unistd.h, but it doesn't properly define `HAVE_UNISTD_H` if it's found.

This change adds the necessary preprocessor definition if unistd.h is found.