### PR TITLE
Fix two bugs in Cheat Manager

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -397,11 +397,11 @@ static bool Compare(T mem_value, T value, CompareType op)
   case CompareType::Less:
     return mem_value < value;
   case CompareType::LessEqual:
-    return mem_value <= mem_value;
+    return mem_value <= value;
   case CompareType::More:
-    return value > mem_value;
+    return mem_value > value;
   case CompareType::MoreEqual:
-    return value >= mem_value;
+    return mem_value >= value;
   default:
     return false;
   }

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -163,7 +163,7 @@ void CheatsManager::OnWatchContextMenu()
   QMenu* menu = new QMenu(this);
 
   menu->addAction(tr("Remove from Watch"), this, [this] {
-    auto* item = m_match_table->selectedItems()[0];
+    auto* item = m_watch_table->selectedItems()[0];
 
     int index = item->data(INDEX_ROLE).toInt();
 


### PR DESCRIPTION
Bug 1: some Cheat manager comparisons were wrong. The Cheat Manager gives you the option of searching for memory values less than, greater than, equal to, etc. some given value. Some of those comparisons were mistyped.

Bug 2: typo caused "Remove from Watch" to crash Dolphin.