### PR TITLE
GameINI: Enable EFB format changes for The Garfield Show: Threat of the Space Lasagna

### DIFF
--- a/Data/Sys/GameSettings/SG7.ini
+++ b/Data/Sys/GameSettings/SG7.ini
@@ -1,0 +1,18 @@
+# SG7PVL, SG7E20 - The Garfield Show: Threat of the Space Lasagna
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+
+[Video_Hacks]
+EFBEmulateFormatChanges = True


### PR DESCRIPTION
Without format changes enabled, the game will hang after selecting a mini-game.