### PR TITLE
Fix issue where breakpoint type wasn't correct in debugger memory view.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -261,6 +261,13 @@ void MemoryWidget::LoadSettings()
   bool bp_w = settings.value(QStringLiteral("memorywidget/bpwrite"), false).toBool();
   bool bp_log = settings.value(QStringLiteral("memorywidget/bplog"), true).toBool();
 
+  if (bp_rw)
+    m_memory_view->SetBPType(MemoryViewWidget::BPType::ReadWrite);
+  else if (bp_r)
+    m_memory_view->SetBPType(MemoryViewWidget::BPType::ReadOnly);
+  else
+    m_memory_view->SetBPType(MemoryViewWidget::BPType::WriteOnly);
+
   m_bp_read_write->setChecked(bp_rw);
   m_bp_read_only->setChecked(bp_r);
   m_bp_write_only->setChecked(bp_w);


### PR DESCRIPTION
If you right click on a cell in the memory view (MemoryViewWidget) you can set a breakpoint at that cell. The type of breakpoint to be set wasn't being loaded into MemoryViewWidget from the user's settings file. It *was* being loaded into MemoryWidget, though, so to fix this I made it so when MemoryWidget loads the breakpoint settings it also sets the MemoryViewWidget's breakpoint type.