### PR TITLE
Never return Unknown from SConfig::GetFallbackRegion

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -955,7 +955,11 @@ DiscIO::Region SConfig::GetFallbackRegion()
   IOS::HLE::Kernel ios;
   const IOS::ES::TMDReader system_menu_tmd = ios.GetES()->FindInstalledTMD(Titles::SYSTEM_MENU);
   if (system_menu_tmd.IsValid())
-    return system_menu_tmd.GetRegion();
+  {
+    const DiscIO::Region region = system_menu_tmd.GetRegion();
+    if (region != DiscIO::Region::Unknown)
+      return region;
+  }
 
   // Fall back to PAL.
   return DiscIO::Region::PAL;


### PR DESCRIPTION
This happens if Wii Menu 1.0 is installed.

Reported by https://forums.dolphin-emu.org/Thread-default-case-should-not-be-reached