### PR TITLE
mx sram: fix checksum calc; use Common::BigEndianValue for rtc field.

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -291,13 +291,13 @@ void CEXIIPL::TransferByte(u8& data)
 #define DEV_ADDR(x) (address - x##_BASE)
 #define DEV_ADDR_CURSOR(x) (DEV_ADDR(x) + m_cursor++)
 
-    auto UartFifoAccess = [&](u8* data) {
+    auto UartFifoAccess = [&]() {
       if (m_command.is_write())
       {
-        if (*data != '\0')
-          m_buffer += *data;
+        if (data != '\0')
+          m_buffer += data;
 
-        if (*data == '\r')
+        if (data == '\r')
         {
           NOTICE_LOG(OSREPORT, "%s", SHIFTJISToUTF8(m_buffer).c_str());
           m_buffer.clear();
@@ -306,7 +306,7 @@ void CEXIIPL::TransferByte(u8& data)
       else
       {
         // "Queue Length"... return 0 cause we're instant
-        *data = 0;
+        data = 0;
       }
     };
 
@@ -351,7 +351,7 @@ void CEXIIPL::TransferByte(u8& data)
       {
       case 0:
         // Seems to be 16byte fifo
-        UartFifoAccess(&data);
+        UartFifoAccess();
         break;
       case 0xc:
         // Seen being written to after reading 4 bytes from barnacle
@@ -375,7 +375,7 @@ void CEXIIPL::TransferByte(u8& data)
         // so we can leave the byte untouched.
         break;
       case 4:
-        UartFifoAccess(&data);
+        UartFifoAccess();
         break;
       }
     }

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -127,7 +127,7 @@ CEXIIPL::CEXIIPL()
   }
 
   // Clear RTC
-  memset(g_SRAM.rtc, 0, sizeof(g_SRAM.rtc));
+  g_SRAM.rtc = 0;
 
   // We Overwrite language selection here since it's possible on the GC to change the language as
   // you please
@@ -250,8 +250,7 @@ void CEXIIPL::SetCS(int cs)
 
 void CEXIIPL::UpdateRTC()
 {
-  const u32 rtc = Common::swap32(GetEmulatedTime(GC_EPOCH));
-  std::memcpy(g_SRAM.rtc, &rtc, sizeof(u32));
+  g_SRAM.rtc = GetEmulatedTime(GC_EPOCH);
 }
 
 bool CEXIIPL::IsPresent() const

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -341,9 +341,9 @@ void CEXIIPL::TransferByte(u8& data)
     {
       u32 dev_addr = DEV_ADDR_CURSOR(SRAM);
       if (m_command.is_write())
-        g_SRAM.raw[dev_addr] = data;
+        g_SRAM[dev_addr] = data;
       else
-        data = g_SRAM.raw[dev_addr];
+        data = g_SRAM[dev_addr];
     }
     else if (IN_RANGE(UART))
     {

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -78,14 +78,16 @@ void SetCardFlashID(const u8* buffer, u8 card_index)
 
 void FixSRAMChecksums()
 {
+  // 16bit big-endian additive checksum
   u16 checksum = 0;
   u16 checksum_inv = 0;
   for (auto p = reinterpret_cast<u16*>(&g_SRAM.settings.rtc_bias);
        p != reinterpret_cast<u16*>(&g_SRAM.settings_ex); p++)
   {
-    checksum += *p;
-    checksum_inv += ~*p;
+    u16 value = Common::FromBigEndian(*p);
+    checksum += value;
+    checksum_inv += ~value;
   }
-  g_SRAM.settings.checksum = Common::swap16(checksum);
-  g_SRAM.settings.checksum_inv = Common::swap16(checksum_inv);
+  g_SRAM.settings.checksum = checksum;
+  g_SRAM.settings.checksum_inv = checksum_inv;
 }

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -10,13 +10,22 @@
 #include "Common/Swap.h"
 #include "Core/ConfigManager.h"
 
-// english
-const Sram sram_dump = {{0,    0,    0,    0,    0x00, 0x2C, 0xFF, 0xD0, 0x00, 0x00, 0x00, 0x00,
-                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2C,
-                         0x44, 0x4F, 0x4C, 0x50, 0x48, 0x49, 0x4E, 0x53, 0x4C, 0x4F, 0x54, 0x41,
-                         0x44, 0x4F, 0x4C, 0x50, 0x48, 0x49, 0x4E, 0x53, 0x4C, 0x4F, 0x54, 0x42,
-                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                         0x00, 0x00, 0x6E, 0x6D, 0x00, 0x00, 0x00, 0x00}};
+// English
+// This is just a template. Most/all fields are updated with sane(r) values at runtime.
+const Sram sram_dump = {Common::BigEndianValue<u32>{0},
+                        {Common::BigEndianValue<u16>{0x2c}, Common::BigEndianValue<u16>{0xffd0}, 0,
+                         0, 0, 0, 0, 0, 0x20 | SramFlags::kOobeDone | SramFlags::kStereo},
+                        {{
+                             {'D', 'O', 'L', 'P', 'H', 'I', 'N', 'S', 'L', 'O', 'T', 'A'},
+                             {'D', 'O', 'L', 'P', 'H', 'I', 'N', 'S', 'L', 'O', 'T', 'B'},
+                         },
+                         0,
+                         {},
+                         0,
+                         0,
+                         {0x6E, 0x6D},
+                         0,
+                         {}}};
 
 #if 0
 // german

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -114,17 +114,17 @@ struct SramSettingsEx
   u8 field_3e[2];
 };
 
-union Sram
+struct Sram
 {
-  // TODO determine real full sram size for gc/wii
-  u8 raw[0x44];
-  struct
-  {
-    Common::BigEndianValue<u32> rtc;
-    SramSettings settings;
-    SramSettingsEx settings_ex;
-  };
+  Common::BigEndianValue<u32> rtc;
+  SramSettings settings;
+  SramSettingsEx settings_ex;
+  // Allow access to this entire structure as a raw blob
+  // Typical union-with-byte-array method can't be used here on GCC
+  u8& operator[](size_t offset) { return reinterpret_cast<u8*>(&rtc)[offset]; }
 };
+// TODO determine real full sram size for gc/wii
+static_assert(sizeof(Sram) == 0x44);
 
 #pragma pack(pop)
 

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -36,6 +36,7 @@ distribution.
 
 #include <array>
 #include "Common/CommonTypes.h"
+#include "Common/Swap.h"
 
 using CardFlashId = std::array<u8, 12>;
 
@@ -79,8 +80,8 @@ struct SramFlags
 struct SramSettings
 {
   // checksum covers [rtc_bias, flags]
-  u16 checksum;
-  u16 checksum_inv;
+  Common::BigEndianValue<u16> checksum;
+  Common::BigEndianValue<u16> checksum_inv;
 
   // Unknown attributes
   u32 ead0;
@@ -119,7 +120,7 @@ union Sram
   u8 raw[0x44];
   struct
   {
-    u8 rtc[4];
+    Common::BigEndianValue<u32> rtc;
     SramSettings settings;
     SramSettingsEx settings_ex;
   };

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -353,7 +353,7 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
   spac << static_cast<MessageId>(NP_MSG_SYNC_GC_SRAM);
   for (size_t i = 0; i < sizeof(g_SRAM) - offsetof(Sram, settings); ++i)
   {
-    spac << g_SRAM.raw[offsetof(Sram, settings) + i];
+    spac << g_SRAM[offsetof(Sram, settings) + i];
   }
   Send(player.socket, spac);
 


### PR DESCRIPTION
fixes #11405 (regression from #6020 )