### PR TITLE
Improve SFMLHelper

### DIFF
--- a/Source/Core/Common/SFMLHelper.cpp
+++ b/Source/Core/Common/SFMLHelper.cpp
@@ -6,24 +6,34 @@
 
 #include <SFML/Network/Packet.hpp>
 
-namespace Common
-{
-// This only exists as a helper for BigEndianValue
-u16 PacketReadU16(sf::Packet& packet)
+sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u16>& data)
 {
   u16 tmp;
   packet >> tmp;
-  return tmp;
+  data = tmp;
+  return packet;
 }
 
-// This only exists as a helper for BigEndianValue
-u32 PacketReadU32(sf::Packet& packet)
+sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u32>& data)
 {
   u32 tmp;
   packet >> tmp;
-  return tmp;
+  data = tmp;
+  return packet;
 }
 
+sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u64>& data)
+{
+  sf::Uint64 tmp;
+  packet >> tmp;
+  data = tmp;
+  return packet;
+}
+
+namespace Common
+{
+// SFML's Uint64 type is different depending on platform,
+// so we have this for cleaner code.
 u64 PacketReadU64(sf::Packet& packet)
 {
   sf::Uint64 value;

--- a/Source/Core/Common/SFMLHelper.h
+++ b/Source/Core/Common/SFMLHelper.h
@@ -5,15 +5,18 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Common/Swap.h"
 
 namespace sf
 {
 class Packet;
 }
 
+sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u16>& data);
+sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u32>& data);
+sf::Packet& operator>>(sf::Packet& packet, Common::BigEndianValue<u64>& data);
+
 namespace Common
 {
-u16 PacketReadU16(sf::Packet& packet);
-u32 PacketReadU32(sf::Packet& packet);
 u64 PacketReadU64(sf::Packet& packet);
 }  // namespace Common

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -748,29 +748,29 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       {
         // Header
         WiiSave::Header header;
-        header.tid = Common::PacketReadU64(packet);
-        header.banner_size = Common::PacketReadU32(packet);
+        packet >> header.tid;
+        packet >> header.banner_size;
         packet >> header.permissions;
         packet >> header.unk1;
         for (size_t i = 0; i < header.md5.size(); i++)
           packet >> header.md5[i];
-        header.unk2 = Common::PacketReadU16(packet);
+        packet >> header.unk2;
         for (size_t i = 0; i < header.banner_size; i++)
           packet >> header.banner[i];
 
         // BkHeader
         WiiSave::BkHeader bk_header;
-        bk_header.size = Common::PacketReadU32(packet);
-        bk_header.magic = Common::PacketReadU32(packet);
-        bk_header.ngid = Common::PacketReadU32(packet);
-        bk_header.number_of_files = Common::PacketReadU32(packet);
-        bk_header.size_of_files = Common::PacketReadU32(packet);
-        bk_header.unk1 = Common::PacketReadU32(packet);
-        bk_header.unk2 = Common::PacketReadU32(packet);
-        bk_header.total_size = Common::PacketReadU32(packet);
+        packet >> bk_header.size;
+        packet >> bk_header.magic;
+        packet >> bk_header.ngid;
+        packet >> bk_header.number_of_files;
+        packet >> bk_header.size_of_files;
+        packet >> bk_header.unk1;
+        packet >> bk_header.unk2;
+        packet >> bk_header.total_size;
         for (size_t i = 0; i < bk_header.unk3.size(); i++)
           packet >> bk_header.unk3[i];
-        bk_header.tid = Common::PacketReadU64(packet);
+        packet >> bk_header.tid;
         for (size_t i = 0; i < bk_header.mac_address.size(); i++)
           packet >> bk_header.mac_address[i];
 
@@ -1196,7 +1196,6 @@ void NetPlayClient::SyncSaveDataResponse(const bool success)
 bool NetPlayClient::DecompressPacketIntoFile(sf::Packet& packet, const std::string& file_path)
 {
   u64 file_size = Common::PacketReadU64(packet);
-  ;
 
   if (file_size == 0)
     return true;
@@ -1245,7 +1244,6 @@ bool NetPlayClient::DecompressPacketIntoFile(sf::Packet& packet, const std::stri
 std::optional<std::vector<u8>> NetPlayClient::DecompressPacketIntoBuffer(sf::Packet& packet)
 {
   u64 size = Common::PacketReadU64(packet);
-  ;
 
   std::vector<u8> out_buffer(size);
 


### PR DESCRIPTION
Switch to using additional overloads of sf::Packet, so we can eliminate some of the messy code and just use the normal syntax for reading BigEndianValue.

We can't avoid helper functions with u64 due to SFML's non-standard way of defining 64-bit integer types.