### PR TITLE
Improve performance of cheat searching & add input validation

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -48,7 +49,7 @@ private:
   void OnStateChanged(Core::State state);
 
   size_t GetTypeSize() const;
-  bool MatchesSearch(u32 addr) const;
+  std::function<bool(u32)> CreateMatchFunction();
 
   void Reset();
   void NewSearch();


### PR DESCRIPTION
The previous implementation of cheat search would reconvert the input string for every single memory value. Now we do it once and construct a comparison lambda which we pass to the search code.

In addition, I also added input validation. So, for example, if you've selected Decimal input and you try to compare against "FF", it won't search and will instead let the user know they've entered an invalid value. Similar logic for if you enter "1.2" in a search for bytes. Before, it would just use 0 if it failed to convert the value.