### PR TITLE
OGL: Disable scissor test when calling glBlitFramebuffer()

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -234,6 +234,9 @@ void OGLTexture::BlitFramebuffer(OGLTexture* srcentry, const MathUtil::Rectangle
                               dst_layer);
   }
 
+  // glBlitFramebuffer is still affected by the scissor test, which is enabled by default.
+  glDisable(GL_SCISSOR_TEST);
+
   glBlitFramebuffer(src_rect.left, src_rect.top, src_rect.right, src_rect.bottom, dst_rect.left,
                     dst_rect.top, dst_rect.right, dst_rect.bottom, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
@@ -252,6 +255,9 @@ void OGLTexture::BlitFramebuffer(OGLTexture* srcentry, const MathUtil::Rectangle
         0);
   }
 
+  // The default state for the scissor test is enabled. We don't need to do a full state
+  // restore, as the framebuffer and scissor test are the only things we changed.
+  glEnable(GL_SCISSOR_TEST);
   FramebufferManager::SetFramebuffer(0);
 }
 


### PR DESCRIPTION
glBlitFramebuffer() does not bypass the scissor test, which meant that parts of texture copies (e.g. XFB) could have been clipped when running under OpenGL ES, as glCopyImageSubData() is not supported.

The other call sites for glBlitFramebuffer() are behind ResetAPIState() calls, so they are unaffected. We really need better state tracking in the GL backend.. one day..