### PR TITLE
Make the progress dialog look better (used for e.g. shader compiling)

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1473,13 +1473,14 @@ void MainWindow::OnUpdateProgressDialog(QString title, int progress, int total)
 {
   if (!m_progress_dialog)
   {
-    m_progress_dialog = new QProgressDialog(m_render_widget);
+    m_progress_dialog = new QProgressDialog(m_render_widget, Qt::WindowTitleHint);
     m_progress_dialog->show();
+    m_progress_dialog->setCancelButton(nullptr);
+    m_progress_dialog->setWindowTitle(tr("Dolphin"));
   }
 
   m_progress_dialog->setValue(progress);
   m_progress_dialog->setLabelText(title);
-  m_progress_dialog->setWindowTitle(title);
   m_progress_dialog->setMaximum(total);
 
   if (total < 0 || progress >= total)


### PR DESCRIPTION
* Removed the Cancel button since the code doesn't react to it anyway.
* Only show a window title, not the help icon (?), and disable the close button
* Set the title to "Dolphin" instead of repeating the label text