### PR TITLE
VideoCommon: remove unnecessary floor()

### DIFF
--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -780,7 +780,7 @@ void Tev::Draw()
       floatindex = MathUtil::Clamp(floatindex, 0.f, 9.f);  // TODO: This shouldn't be necessary!
 
       // Get the two closest integer indices, look up the corresponding samples
-      const int indexlower = (int)floor(floatindex);
+      const int indexlower = (int)floatindex;
       const int indexupper = indexlower + 1;
       // Look up coefficient... Seems like multiplying by 4 makes Fortune Street work properly (fog
       // is too strong without the factor)

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1354,7 +1354,7 @@ static void WriteFog(ShaderCode& out, const pixel_shader_uid_data* uid_data)
     out.SetConstantsUsed(C_FOGF, C_FOGF);
     out.Write("\tfloat offset = (2.0 * (rawpos.x / " I_FOGF ".w)) - 1.0 - " I_FOGF ".z;\n");
     out.Write("\tfloat floatindex = clamp(9.0 - abs(offset) * 9.0, 0.0, 9.0);\n");
-    out.Write("\tuint indexlower = uint(floor(floatindex));\n");
+    out.Write("\tuint indexlower = uint(floatindex);\n");
     out.Write("\tuint indexupper = indexlower + 1u;\n");
     out.Write("\tfloat klower = " I_FOGRANGE "[indexlower >> 2u][indexlower & 3u];\n");
     out.Write("\tfloat kupper = " I_FOGRANGE "[indexupper >> 2u][indexupper & 3u];\n");

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -1171,7 +1171,7 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
             "      // ze *= x_adjust\n"
             "      float offset = (2.0 * (rawpos.x / " I_FOGF ".w)) - 1.0 - " I_FOGF ".z;\n"
             "      float floatindex = clamp(9.0 - abs(offset) * 9.0, 0.0, 9.0);\n"
-            "      uint indexlower = uint(floor(floatindex));\n"
+            "      uint indexlower = uint(floatindex);\n"
             "      uint indexupper = indexlower + 1u;\n"
             "      float klower = " I_FOGRANGE "[indexlower >> 2u][indexlower & 3u];\n"
             "      float kupper = " I_FOGRANGE "[indexupper >> 2u][indexupper & 3u];\n"


### PR DESCRIPTION
floatindex is clamped to the range [0, 9]. For non-negative numbers floor() is equivalent to trunc(). Truncation happens implicitly when converting to uint, so the floor() is unnecessary.