### PR TITLE
JitRegCache: Cleanup

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/FPURegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/FPURegCache.cpp
@@ -14,12 +14,12 @@ FPURegCache::FPURegCache(Jit64& jit) : RegCache{jit}
 {
 }
 
-void FPURegCache::StoreRegister(size_t preg, const OpArg& new_loc)
+void FPURegCache::StoreRegister(preg_t preg, const OpArg& new_loc)
 {
   m_emitter->MOVAPD(new_loc, m_regs[preg].Location().GetSimpleReg());
 }
 
-void FPURegCache::LoadRegister(size_t preg, X64Reg new_loc)
+void FPURegCache::LoadRegister(preg_t preg, X64Reg new_loc)
 {
   m_emitter->MOVAPD(new_loc, m_regs[preg].Location());
 }
@@ -32,9 +32,9 @@ const X64Reg* FPURegCache::GetAllocationOrder(size_t* count) const
   return allocation_order;
 }
 
-OpArg FPURegCache::GetDefaultLocation(size_t reg) const
+OpArg FPURegCache::GetDefaultLocation(preg_t preg) const
 {
-  return PPCSTATE(ps[reg][0]);
+  return PPCSTATE(ps[preg][0]);
 }
 
 BitSet32 FPURegCache::GetRegUtilization() const
@@ -42,7 +42,7 @@ BitSet32 FPURegCache::GetRegUtilization() const
   return m_jit.js.op->gprInReg;
 }
 
-BitSet32 FPURegCache::CountRegsIn(size_t preg, u32 lookahead) const
+BitSet32 FPURegCache::CountRegsIn(preg_t preg, u32 lookahead) const
 {
   BitSet32 regs_used;
 

--- a/Source/Core/Core/PowerPC/Jit64/FPURegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/FPURegCache.cpp
@@ -16,12 +16,12 @@ FPURegCache::FPURegCache(Jit64& jit) : RegCache{jit}
 
 void FPURegCache::StoreRegister(size_t preg, const OpArg& new_loc)
 {
-  m_emitter->MOVAPD(new_loc, m_regs[preg].location.GetSimpleReg());
+  m_emitter->MOVAPD(new_loc, m_regs[preg].Location().GetSimpleReg());
 }
 
 void FPURegCache::LoadRegister(size_t preg, X64Reg new_loc)
 {
-  m_emitter->MOVAPD(new_loc, m_regs[preg].location);
+  m_emitter->MOVAPD(new_loc, m_regs[preg].Location());
 }
 
 const X64Reg* FPURegCache::GetAllocationOrder(size_t* count) const

--- a/Source/Core/Core/PowerPC/Jit64/FPURegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/FPURegCache.h
@@ -12,12 +12,12 @@ class FPURegCache final : public RegCache
 {
 public:
   explicit FPURegCache(Jit64& jit);
-  Gen::OpArg GetDefaultLocation(size_t reg) const override;
+  Gen::OpArg GetDefaultLocation(preg_t preg) const override;
 
 protected:
-  void StoreRegister(size_t preg, const Gen::OpArg& newLoc) override;
-  void LoadRegister(size_t preg, Gen::X64Reg newLoc) override;
+  void StoreRegister(preg_t preg, const Gen::OpArg& newLoc) override;
+  void LoadRegister(preg_t preg, Gen::X64Reg newLoc) override;
   const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
   BitSet32 GetRegUtilization() const override;
-  BitSet32 CountRegsIn(size_t preg, u32 lookahead) const override;
+  BitSet32 CountRegsIn(preg_t preg, u32 lookahead) const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/FPURegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/FPURegCache.h
@@ -12,11 +12,12 @@ class FPURegCache final : public RegCache
 {
 public:
   explicit FPURegCache(Jit64& jit);
+  Gen::OpArg GetDefaultLocation(size_t reg) const override;
 
+protected:
   void StoreRegister(size_t preg, const Gen::OpArg& newLoc) override;
   void LoadRegister(size_t preg, Gen::X64Reg newLoc) override;
   const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
-  Gen::OpArg GetDefaultLocation(size_t reg) const override;
   BitSet32 GetRegUtilization() const override;
   BitSet32 CountRegsIn(size_t preg, u32 lookahead) const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/GPRRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/GPRRegCache.cpp
@@ -16,12 +16,12 @@ GPRRegCache::GPRRegCache(Jit64& jit) : RegCache{jit}
 
 void GPRRegCache::StoreRegister(size_t preg, const OpArg& new_loc)
 {
-  m_emitter->MOV(32, new_loc, m_regs[preg].location);
+  m_emitter->MOV(32, new_loc, m_regs[preg].Location());
 }
 
 void GPRRegCache::LoadRegister(size_t preg, X64Reg new_loc)
 {
-  m_emitter->MOV(32, ::Gen::R(new_loc), m_regs[preg].location);
+  m_emitter->MOV(32, ::Gen::R(new_loc), m_regs[preg].Location());
 }
 
 OpArg GPRRegCache::GetDefaultLocation(size_t reg) const
@@ -51,8 +51,7 @@ void GPRRegCache::SetImmediate32(size_t preg, u32 imm_value, bool dirty)
   // "dirty" can be false to avoid redundantly flushing an immediate when
   // processing speculative constants.
   DiscardRegContentsIfCached(preg);
-  m_regs[preg].away |= dirty;
-  m_regs[preg].location = Imm32(imm_value);
+  m_regs[preg].SetToImm32(imm_value, dirty);
 }
 
 BitSet32 GPRRegCache::GetRegUtilization() const

--- a/Source/Core/Core/PowerPC/Jit64/GPRRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/GPRRegCache.cpp
@@ -14,19 +14,19 @@ GPRRegCache::GPRRegCache(Jit64& jit) : RegCache{jit}
 {
 }
 
-void GPRRegCache::StoreRegister(size_t preg, const OpArg& new_loc)
+void GPRRegCache::StoreRegister(preg_t preg, const OpArg& new_loc)
 {
   m_emitter->MOV(32, new_loc, m_regs[preg].Location());
 }
 
-void GPRRegCache::LoadRegister(size_t preg, X64Reg new_loc)
+void GPRRegCache::LoadRegister(preg_t preg, X64Reg new_loc)
 {
   m_emitter->MOV(32, ::Gen::R(new_loc), m_regs[preg].Location());
 }
 
-OpArg GPRRegCache::GetDefaultLocation(size_t reg) const
+OpArg GPRRegCache::GetDefaultLocation(preg_t preg) const
 {
-  return PPCSTATE(gpr[reg]);
+  return PPCSTATE(gpr[preg]);
 }
 
 const X64Reg* GPRRegCache::GetAllocationOrder(size_t* count) const
@@ -46,7 +46,7 @@ const X64Reg* GPRRegCache::GetAllocationOrder(size_t* count) const
   return allocation_order;
 }
 
-void GPRRegCache::SetImmediate32(size_t preg, u32 imm_value, bool dirty)
+void GPRRegCache::SetImmediate32(preg_t preg, u32 imm_value, bool dirty)
 {
   // "dirty" can be false to avoid redundantly flushing an immediate when
   // processing speculative constants.
@@ -59,7 +59,7 @@ BitSet32 GPRRegCache::GetRegUtilization() const
   return m_jit.js.op->gprInReg;
 }
 
-BitSet32 GPRRegCache::CountRegsIn(size_t preg, u32 lookahead) const
+BitSet32 GPRRegCache::CountRegsIn(preg_t preg, u32 lookahead) const
 {
   BitSet32 regs_used;
 

--- a/Source/Core/Core/PowerPC/Jit64/GPRRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/GPRRegCache.h
@@ -12,12 +12,13 @@ class GPRRegCache final : public RegCache
 {
 public:
   explicit GPRRegCache(Jit64& jit);
+  Gen::OpArg GetDefaultLocation(size_t reg) const override;
+  void SetImmediate32(size_t preg, u32 imm_value, bool dirty = true);
 
+protected:
   void StoreRegister(size_t preg, const Gen::OpArg& new_loc) override;
   void LoadRegister(size_t preg, Gen::X64Reg new_loc) override;
-  Gen::OpArg GetDefaultLocation(size_t reg) const override;
   const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
-  void SetImmediate32(size_t preg, u32 imm_value, bool dirty = true);
   BitSet32 GetRegUtilization() const override;
   BitSet32 CountRegsIn(size_t preg, u32 lookahead) const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/GPRRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/GPRRegCache.h
@@ -12,13 +12,13 @@ class GPRRegCache final : public RegCache
 {
 public:
   explicit GPRRegCache(Jit64& jit);
-  Gen::OpArg GetDefaultLocation(size_t reg) const override;
-  void SetImmediate32(size_t preg, u32 imm_value, bool dirty = true);
+  Gen::OpArg GetDefaultLocation(preg_t preg) const override;
+  void SetImmediate32(preg_t preg, u32 imm_value, bool dirty = true);
 
 protected:
-  void StoreRegister(size_t preg, const Gen::OpArg& new_loc) override;
-  void LoadRegister(size_t preg, Gen::X64Reg new_loc) override;
+  void StoreRegister(preg_t preg, const Gen::OpArg& new_loc) override;
+  void LoadRegister(preg_t preg, Gen::X64Reg new_loc) override;
   const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
   BitSet32 GetRegUtilization() const override;
-  BitSet32 CountRegsIn(size_t preg, u32 lookahead) const override;
+  BitSet32 CountRegsIn(preg_t preg, u32 lookahead) const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -935,10 +935,10 @@ u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     }
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
-    if (gpr.SanityCheck() || fpr.SanityCheck())
+    if (!gpr.SanityCheck() || !fpr.SanityCheck())
     {
       std::string ppc_inst = Common::GekkoDisassembler::Disassemble(op.inst.hex, em_address);
-      // NOTICE_LOG(DYNA_REC, "Unflushed register: %s", ppc_inst.c_str());
+      NOTICE_LOG(DYNA_REC, "Unflushed register: %s", ppc_inst.c_str());
     }
 #endif
     i += js.skipInstructions;

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -78,32 +78,16 @@ void RegCache::Flush(FlushMode mode, BitSet32 regsToFlush)
   }
 }
 
-void RegCache::FlushR(X64Reg reg)
-{
-  ASSERT_MSG(DYNA_REC, reg < m_xregs.size(), "Flushing non-existent reg %i", reg);
-  ASSERT(!m_xregs[reg].IsLocked());
-  if (!m_xregs[reg].IsFree())
-  {
-    StoreFromRegister(m_xregs[reg].Contents());
-  }
-}
-
-void RegCache::FlushR(X64Reg reg, X64Reg reg2)
-{
-  FlushR(reg);
-  FlushR(reg2);
-}
-
 void RegCache::FlushLockX(X64Reg reg)
 {
-  FlushR(reg);
+  FlushX(reg);
   LockX(reg);
 }
 
 void RegCache::FlushLockX(X64Reg reg1, X64Reg reg2)
 {
-  FlushR(reg1);
-  FlushR(reg2);
+  FlushX(reg1);
+  FlushX(reg2);
   LockX(reg1);
   LockX(reg2);
 }
@@ -291,6 +275,16 @@ int RegCache::NumFreeRegisters() const
     if (m_xregs[aOrder[i]].IsFree())
       count++;
   return count;
+}
+
+void RegCache::FlushX(X64Reg reg)
+{
+  ASSERT_MSG(DYNA_REC, reg < m_xregs.size(), "Flushing non-existent reg %i", reg);
+  ASSERT(!m_xregs[reg].IsLocked());
+  if (!m_xregs[reg].IsFree())
+  {
+    StoreFromRegister(m_xregs[reg].Contents());
+  }
 }
 
 // Estimate roughly how bad it would be to de-allocate this register. Higher score

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -33,7 +33,7 @@ void RegCache::Start()
   }
 }
 
-void RegCache::DiscardRegContentsIfCached(size_t preg)
+void RegCache::DiscardRegContentsIfCached(preg_t preg)
 {
   if (m_regs[preg].IsBound())
   {
@@ -117,7 +117,7 @@ int RegCache::SanityCheck() const
   return 0;
 }
 
-void RegCache::KillImmediate(size_t preg, bool doLoad, bool makeDirty)
+void RegCache::KillImmediate(preg_t preg, bool doLoad, bool makeDirty)
 {
   switch (m_regs[preg].GetLocationType())
   {
@@ -133,7 +133,7 @@ void RegCache::KillImmediate(size_t preg, bool doLoad, bool makeDirty)
   }
 }
 
-void RegCache::BindToRegister(size_t i, bool doLoad, bool makeDirty)
+void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
 {
   if (!m_regs[i].IsBound())
   {
@@ -166,7 +166,7 @@ void RegCache::BindToRegister(size_t i, bool doLoad, bool makeDirty)
   ASSERT_MSG(DYNA_REC, !m_xregs[RX(i)].IsLocked(), "WTF, this reg should have been flushed");
 }
 
-void RegCache::StoreFromRegister(size_t i, FlushMode mode)
+void RegCache::StoreFromRegister(preg_t i, FlushMode mode)
 {
   bool doStore = false;
 
@@ -194,12 +194,12 @@ void RegCache::StoreFromRegister(size_t i, FlushMode mode)
     m_regs[i].Flushed();
 }
 
-const OpArg& RegCache::R(size_t preg) const
+const OpArg& RegCache::R(preg_t preg) const
 {
   return m_regs[preg].Location();
 }
 
-X64Reg RegCache::RX(size_t preg) const
+X64Reg RegCache::RX(preg_t preg) const
 {
   ASSERT_MSG(DYNA_REC, m_regs[preg].IsBound(), "Unbound register - %zu", preg);
   return m_regs[preg].Location().GetSimpleReg();
@@ -243,7 +243,7 @@ X64Reg RegCache::GetFreeXReg()
   for (size_t i = 0; i < aCount; i++)
   {
     X64Reg xreg = (X64Reg)aOrder[i];
-    size_t preg = m_xregs[xreg].Contents();
+    preg_t preg = m_xregs[xreg].Contents();
     if (m_xregs[xreg].IsLocked() || m_regs[preg].IsLocked())
       continue;
     float score = ScoreRegister(xreg);
@@ -291,7 +291,7 @@ void RegCache::FlushX(X64Reg reg)
 // means more bad.
 float RegCache::ScoreRegister(X64Reg xreg) const
 {
-  size_t preg = m_xregs[xreg].Contents();
+  preg_t preg = m_xregs[xreg].Contents();
   float score = 0;
 
   // If it's not dirty, we don't need a store to write it back to the register file, so

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -92,7 +92,7 @@ void RegCache::FlushLockX(X64Reg reg1, X64Reg reg2)
   LockX(reg2);
 }
 
-int RegCache::SanityCheck() const
+bool RegCache::SanityCheck() const
 {
   for (size_t i = 0; i < m_regs.size(); i++)
   {
@@ -100,21 +100,23 @@ int RegCache::SanityCheck() const
     {
     case PPCCachedReg::LocationType::Default:
     case PPCCachedReg::LocationType::SpeculativeImmediate:
+    case PPCCachedReg::LocationType::Immediate:
       break;
     case PPCCachedReg::LocationType::Bound:
     {
-      Gen::X64Reg simple = m_regs[i].Location().GetSimpleReg();
-      if (m_xregs[simple].IsLocked())
-        return 1;
-      if (m_xregs[simple].Contents() != i)
-        return 2;
+      if (m_regs[i].IsLocked())
+        return false;
+
+      Gen::X64Reg xr = m_regs[i].Location().GetSimpleReg();
+      if (m_xregs[xr].IsLocked())
+        return false;
+      if (m_xregs[xr].Contents() != i)
+        return false;
       break;
     }
-    case PPCCachedReg::LocationType::Immediate:
-      return 3;
     }
   }
-  return 0;
+  return true;
 }
 
 void RegCache::KillImmediate(preg_t preg, bool doLoad, bool makeDirty)

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -57,13 +57,13 @@ public:
   bool IsAway() const { return away; }
   bool IsBound() const { return GetLocationType() == LocationType::Bound; }
 
-  void BoundTo(Gen::X64Reg xreg)
+  void SetBoundTo(Gen::X64Reg xreg)
   {
     away = true;
     location = Gen::R(xreg);
   }
 
-  void Flushed()
+  void SetFlushed()
   {
     away = false;
     location = default_location;
@@ -91,14 +91,14 @@ class X64CachedReg
 public:
   preg_t Contents() const { return ppcReg; }
 
-  void BoundTo(preg_t ppcReg_, bool dirty_)
+  void SetBoundTo(preg_t ppcReg_, bool dirty_)
   {
     free = false;
     ppcReg = ppcReg_;
     dirty = dirty_;
   }
 
-  void Flushed()
+  void SetFlushed()
   {
     ppcReg = static_cast<preg_t>(Gen::INVALID_REG);
     free = true;
@@ -108,7 +108,7 @@ public:
   bool IsFree() const { return free && !locked; }
 
   bool IsDirty() const { return dirty; }
-  void MakeDirty(bool makeDirty = true) { dirty |= makeDirty; }
+  void MakeDirty() { dirty = true; }
 
   bool IsLocked() const { return locked; }
   void Lock() { locked = true; }

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -133,8 +133,6 @@ public:
   explicit RegCache(Jit64& jit);
   virtual ~RegCache() = default;
 
-  virtual void StoreRegister(size_t preg, const Gen::OpArg& new_loc) = 0;
-  virtual void LoadRegister(size_t preg, Gen::X64Reg new_loc) = 0;
   virtual Gen::OpArg GetDefaultLocation(size_t reg) const = 0;
 
   void Start();
@@ -211,6 +209,9 @@ public:
   int NumFreeRegisters() const;
 
 protected:
+  virtual void StoreRegister(size_t preg, const Gen::OpArg& new_loc) = 0;
+  virtual void LoadRegister(size_t preg, Gen::X64Reg new_loc) = 0;
+
   virtual const Gen::X64Reg* GetAllocationOrder(size_t* count) const = 0;
 
   virtual BitSet32 GetRegUtilization() const = 0;

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -13,6 +13,8 @@
 
 class Jit64;
 
+using preg_t = size_t;
+
 class PPCCachedReg
 {
 public:
@@ -87,9 +89,9 @@ private:
 class X64CachedReg
 {
 public:
-  size_t Contents() const { return ppcReg; }
+  preg_t Contents() const { return ppcReg; }
 
-  void BoundTo(size_t ppcReg_, bool dirty_)
+  void BoundTo(preg_t ppcReg_, bool dirty_)
   {
     free = false;
     ppcReg = ppcReg_;
@@ -98,7 +100,7 @@ public:
 
   void Flushed()
   {
-    ppcReg = static_cast<size_t>(Gen::INVALID_REG);
+    ppcReg = static_cast<preg_t>(Gen::INVALID_REG);
     free = true;
     dirty = false;
   }
@@ -113,7 +115,7 @@ public:
   void Unlock() { locked = false; }
 
 private:
-  size_t ppcReg = static_cast<size_t>(Gen::INVALID_REG);
+  preg_t ppcReg = static_cast<preg_t>(Gen::INVALID_REG);
   bool free = true;
   bool dirty = false;
   bool locked = false;
@@ -133,11 +135,11 @@ public:
   explicit RegCache(Jit64& jit);
   virtual ~RegCache() = default;
 
-  virtual Gen::OpArg GetDefaultLocation(size_t reg) const = 0;
+  virtual Gen::OpArg GetDefaultLocation(preg_t preg) const = 0;
 
   void Start();
 
-  void DiscardRegContentsIfCached(size_t preg);
+  void DiscardRegContentsIfCached(preg_t preg);
   void SetEmitter(Gen::XEmitter* emitter);
 
   void Flush(FlushMode mode = FlushMode::All, BitSet32 regsToFlush = BitSet32::AllTrue(32));
@@ -146,15 +148,15 @@ public:
   void FlushLockX(Gen::X64Reg reg1, Gen::X64Reg reg2);
 
   int SanityCheck() const;
-  void KillImmediate(size_t preg, bool doLoad, bool makeDirty);
+  void KillImmediate(preg_t preg, bool doLoad, bool makeDirty);
 
   // TODO - instead of doload, use "read", "write"
   // read only will not set dirty flag
-  void BindToRegister(size_t preg, bool doLoad = true, bool makeDirty = true);
-  void StoreFromRegister(size_t preg, FlushMode mode = FlushMode::All);
+  void BindToRegister(preg_t preg, bool doLoad = true, bool makeDirty = true);
+  void StoreFromRegister(preg_t preg, FlushMode mode = FlushMode::All);
 
-  const Gen::OpArg& R(size_t preg) const;
-  Gen::X64Reg RX(size_t preg) const;
+  const Gen::OpArg& R(preg_t preg) const;
+  Gen::X64Reg RX(preg_t preg) const;
 
   // Register locking.
 
@@ -209,13 +211,13 @@ public:
   int NumFreeRegisters() const;
 
 protected:
-  virtual void StoreRegister(size_t preg, const Gen::OpArg& new_loc) = 0;
-  virtual void LoadRegister(size_t preg, Gen::X64Reg new_loc) = 0;
+  virtual void StoreRegister(preg_t preg, const Gen::OpArg& new_loc) = 0;
+  virtual void LoadRegister(preg_t preg, Gen::X64Reg new_loc) = 0;
 
   virtual const Gen::X64Reg* GetAllocationOrder(size_t* count) const = 0;
 
   virtual BitSet32 GetRegUtilization() const = 0;
-  virtual BitSet32 CountRegsIn(size_t preg, u32 lookahead) const = 0;
+  virtual BitSet32 CountRegsIn(preg_t preg, u32 lookahead) const = 0;
 
   void FlushX(Gen::X64Reg reg);
 

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -147,7 +147,7 @@ public:
   void FlushLockX(Gen::X64Reg reg);
   void FlushLockX(Gen::X64Reg reg1, Gen::X64Reg reg2);
 
-  int SanityCheck() const;
+  bool SanityCheck() const;
   void KillImmediate(preg_t preg, bool doLoad, bool makeDirty);
 
   // TODO - instead of doload, use "read", "write"

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -144,9 +144,6 @@ public:
 
   void Flush(FlushMode mode = FlushMode::All, BitSet32 regsToFlush = BitSet32::AllTrue(32));
 
-  void FlushR(Gen::X64Reg reg);
-  void FlushR(Gen::X64Reg reg, Gen::X64Reg reg2);
-
   void FlushLockX(Gen::X64Reg reg);
   void FlushLockX(Gen::X64Reg reg1, Gen::X64Reg reg2);
 
@@ -218,6 +215,8 @@ protected:
 
   virtual BitSet32 GetRegUtilization() const = 0;
   virtual BitSet32 CountRegsIn(size_t preg, u32 lookahead) const = 0;
+
+  void FlushX(Gen::X64Reg reg);
 
   float ScoreRegister(Gen::X64Reg xreg) const;
 

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -7,16 +7,81 @@
 #include <array>
 #include <cinttypes>
 
+#include "Common/Assert.h"
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
 class Jit64;
 
-struct PPCCachedReg
+class PPCCachedReg
 {
-  Gen::OpArg location;
-  bool away;  // value not in source register
-  bool locked;
+public:
+  enum class LocationType
+  {
+    /// Value is currently at its default location
+    Default,
+    /// Value is currently bound to a x64 register
+    Bound,
+    /// Value is known as an immediate and has not been written back to its default location
+    Immediate,
+    /// Value is known as an immediate and is already present at its default location
+    SpeculativeImmediate,
+  };
+
+  PPCCachedReg() = default;
+
+  explicit PPCCachedReg(Gen::OpArg default_location_)
+      : default_location(default_location_), location(default_location_)
+  {
+  }
+
+  const Gen::OpArg& Location() const { return location; }
+
+  LocationType GetLocationType() const
+  {
+    if (!away)
+    {
+      if (location.IsImm())
+        return LocationType::SpeculativeImmediate;
+
+      ASSERT(location == default_location);
+      return LocationType::Default;
+    }
+
+    ASSERT(location.IsImm() || location.IsSimpleReg());
+    return location.IsImm() ? LocationType::Immediate : LocationType::Bound;
+  }
+
+  bool IsAway() const { return away; }
+  bool IsBound() const { return GetLocationType() == LocationType::Bound; }
+
+  void BoundTo(Gen::X64Reg xreg)
+  {
+    away = true;
+    location = Gen::R(xreg);
+  }
+
+  void Flushed()
+  {
+    away = false;
+    location = default_location;
+  }
+
+  void SetToImm32(u32 imm32, bool dirty = true)
+  {
+    away |= dirty;
+    location = Gen::Imm32(imm32);
+  }
+
+  bool IsLocked() const { return locked; }
+  void Lock() { locked = true; }
+  void Unlock() { locked = false; }
+
+private:
+  Gen::OpArg default_location{};
+  Gen::OpArg location{};
+  bool away = false;  // value not in source register
+  bool locked = false;
 };
 
 struct X64CachedReg
@@ -75,7 +140,7 @@ public:
   template <typename T>
   void Lock(T p)
   {
-    m_regs[p].locked = true;
+    m_regs[p].Lock();
   }
   template <typename T, typename... Args>
   void Lock(T first, Args... args)
@@ -117,7 +182,6 @@ public:
   void UnlockAllX();
 
   bool IsFreeX(size_t xreg) const;
-  bool IsBound(size_t preg) const;
 
   Gen::X64Reg GetFreeXReg();
   int NumFreeRegisters() const;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -460,7 +460,7 @@ void Jit64::fmrx(UGeckoInstruction inst)
 
   fpr.Lock(b, d);
 
-  if (fpr.IsBound(d))
+  if (fpr.R(d).IsSimpleReg())
   {
     // We don't need to load d, but if it is loaded, we need to mark it as dirty.
     fpr.BindToRegister(d);


### PR DESCRIPTION
First in a series of register cache PRs.

Encapsulate behavior appropriately to allow for future rework.

This PR has no behavioural changes.