### PR TITLE
Qt/debugger: Accept empty prefix input

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1279,8 +1279,6 @@ void MenuBar::CreateSignatureFile()
 {
   const QString text = QInputDialog::getText(
       this, tr("Input"), tr("Only export symbols with prefix:\n(Blank for all symbols)"));
-  if (text.isEmpty())
-    return;
 
   const QString file = QFileDialog::getSaveFileName(this, tr("Save signature file"));
   if (file.isEmpty())


### PR DESCRIPTION
The code explains itself: it asks to leave it empty for all symbols, but refuse to do anything if it's empty...