### PR TITLE
WIP: Add instruction edit dialog with preview

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(dolphin-emu
   Debugger/BreakpointWidget.cpp
   Debugger/CodeViewWidget.cpp
   Debugger/CodeWidget.cpp
+  Debugger/InstructionDialog.cpp
   Debugger/JITWidget.cpp
   Debugger/MemoryViewWidget.cpp
   Debugger/MemoryWidget.cpp

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -26,6 +26,7 @@
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "DolphinQt/Debugger/InstructionDialog.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
@@ -455,14 +456,13 @@ void CodeViewWidget::OnReplaceInstruction()
   if (!read_result.valid)
     return;
 
-  bool good;
-  QString name = QInputDialog::getText(
-      this, tr("Change instruction"), tr("New instruction:"), QLineEdit::Normal,
-      QStringLiteral("%1").arg(read_result.hex, 8, 16, QLatin1Char('0')), &good);
+  u32 code = read_result.hex;
 
-  u32 code = name.toUInt(&good, 16);
+  // Show instruction edit dialog
+  InstructionDialog instr_dialog = InstructionDialog(this, addr, code);
+  int instr_dialog_res = instr_dialog.ShowModal(&code);
 
-  if (good)
+  if (instr_dialog_res == QDialog::Accepted)
   {
     PowerPC::debug_interface.UnsetPatch(addr);
     PowerPC::debug_interface.SetPatch(addr, code);

--- a/Source/Core/DolphinQt/Debugger/InstructionDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/InstructionDialog.cpp
@@ -1,0 +1,84 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Debugger/InstructionDialog.h"
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "Common/GekkoDisassembler.h"
+
+InstructionDialog::InstructionDialog(QWidget* parent, u32 addr, u32 instruction) : QDialog(parent)
+{
+  setWindowTitle(tr("Change instruction"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+  m_instruction_addr = addr;
+  m_new_instruction = instruction;
+
+  QString instr_text = QStringLiteral("%1").arg(instruction, 8, 16, QLatin1Char('0'));
+
+  QLabel* label = new QLabel(tr("New instruction:"));
+  QLineEdit* instruction_edit = new QLineEdit(instr_text);
+  m_instruction_desc_label = new QLabel;
+
+  m_btn_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+
+  connect(instruction_edit, &QLineEdit::textEdited, this,
+          &InstructionDialog::UpdateInstructionText);
+
+  connect(m_btn_box, &QDialogButtonBox::accepted, this, &InstructionDialog::accept);
+  connect(m_btn_box, &QDialogButtonBox::rejected, this, &InstructionDialog::reject);
+
+  QVBoxLayout* main_layout = new QVBoxLayout(this);
+
+  main_layout->addWidget(label);
+  main_layout->addWidget(instruction_edit);
+  main_layout->addWidget(m_instruction_desc_label);
+  main_layout->addWidget(m_btn_box);
+
+  setLayout(main_layout);
+  main_layout->setSizeConstraint(QLayout::SetFixedSize);
+
+  UpdateInstructionText(instr_text);
+}
+
+int InstructionDialog::ShowModal(u32* new_instruction)
+{
+  int result = QDialog::exec();
+  *new_instruction = m_new_instruction;
+  return result;
+}
+
+void InstructionDialog::UpdateInstructionText(const QString& text)
+{
+  // Hex to UInt
+  bool ok;
+  u32 new_instr_candidate = text.toUInt(&ok, 16);
+
+  if (!ok)
+  {
+    // Reset text
+    m_instruction_desc_label->setText(tr("Invalid instruction!"));
+    // Disable OK button
+    m_btn_box->button(QDialogButtonBox::Ok)->setDisabled(true);
+    return;
+  }
+
+  m_new_instruction = new_instr_candidate;
+
+  // Disassemble
+  QString instr_disasm = QString::fromStdString(Common::GekkoDisassembler::Disassemble(
+                                                    m_new_instruction, m_instruction_addr))
+                             .replace(QStringLiteral("\t"), QStringLiteral(" "));
+
+  m_instruction_desc_label->setText(tr("Preview: ") + instr_disasm);
+
+  // Enable OK button
+  m_btn_box->button(QDialogButtonBox::Ok)->setEnabled(true);
+}

--- a/Source/Core/DolphinQt/Debugger/InstructionDialog.h
+++ b/Source/Core/DolphinQt/Debugger/InstructionDialog.h
@@ -1,0 +1,27 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QLabel>
+
+#include "Common/CommonTypes.h"
+
+class InstructionDialog final : public QDialog
+{
+public:
+  InstructionDialog(QWidget* parent, u32 addr, u32 instruction);
+
+  int ShowModal(u32* new_instruction);
+
+private:
+  void UpdateInstructionText(const QString& text);
+
+  QLabel* m_instruction_desc_label = nullptr;
+  QDialogButtonBox* m_btn_box = nullptr;
+  u32 m_instruction_addr = 0;
+  u32 m_new_instruction = 0;
+};

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -328,6 +328,7 @@
     <ClCompile Include="DiscordJoinRequestDialog.cpp" />
     <ClCompile Include="FIFO\FIFOAnalyzer.cpp" />
     <ClCompile Include="FIFO\FIFOPlayerWindow.cpp" />
+    <ClCompile Include="Debugger\InstructionDialog.cpp" />
     <ClCompile Include="QtUtils\WinIconHelper.cpp" />
     <ClCompile Include="TAS\GCTASInputWindow.cpp" />
     <ClCompile Include="TAS\WiiTASInputWindow.cpp" />
@@ -385,6 +386,7 @@
     <ClInclude Include="Config\Mapping\MappingCommon.h" />
     <ClInclude Include="Config\Mapping\MappingRadio.h" />
     <ClInclude Include="Debugger\RegisterColumn.h" />
+    <ClInclude Include="Debugger\InstructionDialog.h" />
     <ClInclude Include="QtUtils\ActionHelper.h" />
     <ClInclude Include="QtUtils\ImageConverter.h" />
     <ClInclude Include="QtUtils\QueueOnObject.h" />


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10959

Currently crashing after the dialog closes due to some memory management issues (maybe?). Works when using individual QPushButtons instead of QDialogButtonBox.

Debugging help appreciated.