### PR TITLE
BPStructs: don't warn about busclock/perf regs

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -392,7 +392,7 @@ static void BPWritten(const BPCmd& bp)
   case BPMEM_PERF0_TRI:   // Perf: Triangles
   case BPMEM_PERF0_QUAD:  // Perf: Quads
   case BPMEM_PERF1:       // Perf: Some Clock, Texels, TX, TC
-    break;
+    return;
   // ----------------
   // EFB Copy config
   // ----------------


### PR DESCRIPTION
GXInit() initializes the busclock registers and some games spam the perf counters. Don't print warnings about that.