### PR TITLE
GekkoDisassembler: fix disassembly of mtfsf

### DIFF
--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -2242,8 +2242,7 @@ u32* GekkoDisassembler::DoDisassembly(bool big_endian)
         if ((in & 0x02010000) == 0)
         {
           m_opcode = StringFromFormat("mtfsf%s", rcsel[in & 1]);
-          m_operands = StringFromFormat("0x%x,%u", (unsigned int)(in >> 17) & 0x01fe,
-                                        (unsigned int)PPCGETB(in));
+          m_operands = StringFromFormat("0x%x,%u", (in >> 17) & 0xff, regnames[PPCGETB(in)]);
         }
         else
         {


### PR DESCRIPTION
This fixes https://dolp.in/i11411.

The FM field was masked incorrectly and the B field was printed as a number instead of a register.