### PR TITLE
Android: Require user to enable savestate menu options

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -33,6 +33,9 @@ import com.squareup.picasso.Picasso;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
+import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.fragments.EmulationFragment;
 import org.dolphinemu.dolphinemu.fragments.MenuFragment;
 import org.dolphinemu.dolphinemu.fragments.SaveLoadStateFragment;
@@ -64,6 +67,8 @@ public final class EmulationActivity extends AppCompatActivity
 
   private SharedPreferences mPreferences;
   private ControllerMappingHelper mControllerMappingHelper;
+
+  private Settings mSettings;
 
   // So that MainActivity knows which view to invalidate before the return animation.
   private int mPosition;
@@ -212,6 +217,8 @@ public final class EmulationActivity extends AppCompatActivity
       mPlatform = gameToEmulate.getIntExtra(EXTRA_PLATFORM, 0);
       mScreenPath = gameToEmulate.getStringExtra(EXTRA_SCREEN_PATH);
       mPosition = gameToEmulate.getIntExtra(EXTRA_GRID_POSITION, -1);
+      mSettings = new Settings();
+      mSettings.loadSettings(null);
       activityRecreated = false;
     }
     else
@@ -474,6 +481,17 @@ public final class EmulationActivity extends AppCompatActivity
     else
     {
       getMenuInflater().inflate(R.menu.menu_emulation_wii, menu);
+    }
+
+    BooleanSetting enableSaveStates =
+            (BooleanSetting) mSettings.getSection(Settings.SECTION_INI_CORE)
+                    .getSetting(SettingsFile.KEY_ENABLE_SAVE_STATES);
+    if (enableSaveStates != null && enableSaveStates.getValue())
+    {
+      menu.findItem(R.id.menu_quicksave).setVisible(true);
+      menu.findItem(R.id.menu_quickload).setVisible(true);
+      menu.findItem(R.id.menu_emulation_save_root).setVisible(true);
+      menu.findItem(R.id.menu_emulation_load_root).setVisible(true);
     }
 
     // Populate the checkbox value for joystick center on touch
@@ -928,5 +946,10 @@ public final class EmulationActivity extends AppCompatActivity
   public boolean isActivityRecreated()
   {
     return activityRecreated;
+  }
+
+  public Settings getSettings()
+  {
+    return mSettings;
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -211,6 +211,7 @@ public final class SettingsFragmentPresenter
     Setting speedLimit = null;
     Setting audioStretch = null;
     Setting analytics = null;
+    Setting enableSaveState;
 
     SettingSection coreSection = mSettings.getSection(Settings.SECTION_INI_CORE);
     SettingSection analyticsSection = mSettings.getSection(Settings.SECTION_ANALYTICS);
@@ -221,6 +222,7 @@ public final class SettingsFragmentPresenter
     speedLimit = coreSection.getSetting(SettingsFile.KEY_SPEED_LIMIT);
     audioStretch = coreSection.getSetting(SettingsFile.KEY_AUDIO_STRETCH);
     analytics = analyticsSection.getSetting(SettingsFile.KEY_ANALYTICS_ENABLED);
+    enableSaveState = coreSection.getSetting(SettingsFile.KEY_ENABLE_SAVE_STATES);
 
     // TODO: Having different emuCoresEntries/emuCoresValues for each architecture is annoying.
     // The proper solution would be to have one emuCoresEntries and one emuCoresValues
@@ -257,6 +259,9 @@ public final class SettingsFragmentPresenter
             R.string.speed_limit, 0, 200, "%", 100, speedLimit));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_AUDIO_STRETCH, Settings.SECTION_INI_CORE,
             R.string.audio_stretch, R.string.audio_stretch_description, false, audioStretch));
+    sl.add(new CheckBoxSetting(SettingsFile.KEY_ENABLE_SAVE_STATES, Settings.SECTION_INI_CORE,
+            R.string.enable_save_states, R.string.enable_save_states_description, false,
+            enableSaveState));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_ANALYTICS_ENABLED, Settings.SECTION_ANALYTICS,
             R.string.analytics, 0, false, analytics));
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -49,6 +49,7 @@ public final class SettingsFile
   public static final String KEY_OVERRIDE_GAME_CUBE_LANGUAGE = "OverrideGCLang";
   public static final String KEY_SLOT_A_DEVICE = "SlotA";
   public static final String KEY_SLOT_B_DEVICE = "SlotB";
+  public static final String KEY_ENABLE_SAVE_STATES = "EnableSaveStates";
 
   public static final String KEY_ANALYTICS_ENABLED = "Enabled";
   public static final String KEY_ANALYTICS_PERMISSION_ASKED = "PermissionAsked";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -13,6 +13,9 @@ import android.widget.TextView;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
+import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
 public final class MenuFragment extends Fragment implements View.OnClickListener
 {
@@ -53,6 +56,20 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
     View rootView = inflater.inflate(R.layout.fragment_ingame_menu, container, false);
 
     LinearLayout options = (LinearLayout) rootView.findViewById(R.id.layout_options);
+
+    BooleanSetting enableSaveStates =
+            (BooleanSetting) ((EmulationActivity) getActivity()).getSettings()
+                    .getSection(Settings.SECTION_INI_CORE)
+                    .getSetting(SettingsFile.KEY_ENABLE_SAVE_STATES);
+
+    if (enableSaveStates != null && enableSaveStates.getValue())
+    {
+      options.findViewById(R.id.menu_quicksave).setVisibility(View.VISIBLE);
+      options.findViewById(R.id.menu_quickload).setVisibility(View.VISIBLE);
+      options.findViewById(R.id.menu_emulation_save_root).setVisibility(View.VISIBLE);
+      options.findViewById(R.id.menu_emulation_load_root).setVisibility(View.VISIBLE);
+    }
+
     for (int childIndex = 0; childIndex < options.getChildCount(); childIndex++)
     {
       Button button = (Button) options.getChildAt(childIndex);

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -35,22 +35,26 @@
             <Button
                 android:id="@+id/menu_quicksave"
                 android:text="@string/emulation_quicksave"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:visibility="gone"/>
 
             <Button
                 android:id="@+id/menu_quickload"
                 android:text="@string/emulation_quickload"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:visibility="gone"/>
 
             <Button
                 android:id="@+id/menu_emulation_save_root"
                 android:text="@string/emulation_savestate"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:visibility="gone"/>
 
             <Button
                 android:id="@+id/menu_emulation_load_root"
                 android:text="@string/emulation_loadstate"
-                style="@style/InGameMenuOption"/>
+                style="@style/InGameMenuOption"
+                android:visibility="gone"/>
 
             <Button
                 android:id="@+id/menu_refresh_wiimotes"

--- a/Source/Android/app/src/main/res/menu/menu_emulation.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation.xml
@@ -13,19 +13,22 @@
         android:id="@+id/menu_quicksave"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_quicksave"
-        android:title="@string/emulation_quicksave"/>
+        android:title="@string/emulation_quicksave"
+        android:visible="false"/>
 
     <item
         android:id="@+id/menu_quickload"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_quickload"
-        android:title="@string/emulation_quickload"/>
+        android:title="@string/emulation_quickload"
+        android:visible="false"/>
 
     <!-- Save State Slots -->
     <item
         android:id="@+id/menu_emulation_save_root"
         app:showAsAction="never"
-        android:title="@string/emulation_savestate">
+        android:title="@string/emulation_savestate"
+        android:visible="false">
         <menu>
             <item
                 android:id="@+id/menu_emulation_save_1"
@@ -53,7 +56,8 @@
     <item
         android:id="@+id/menu_emulation_load_root"
         app:showAsAction="never"
-        android:title="@string/emulation_loadstate">
+        android:title="@string/emulation_loadstate"
+        android:visible="false">
         <menu>
             <item
                 android:id="@+id/menu_emulation_load_1"

--- a/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
@@ -13,19 +13,22 @@
         android:id="@+id/menu_quicksave"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_quicksave"
-        android:title="@string/emulation_quicksave"/>
+        android:title="@string/emulation_quicksave"
+        android:visible="false"/>
 
     <item
         android:id="@+id/menu_quickload"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_quickload"
-        android:title="@string/emulation_quickload"/>
+        android:title="@string/emulation_quickload"
+        android:visible="false"/>
 
     <!-- Save State Slots -->
     <item
         android:id="@+id/menu_emulation_save_root"
         app:showAsAction="never"
-        android:title="@string/emulation_savestate">
+        android:title="@string/emulation_savestate"
+        android:visible="false">
         <menu>
             <item
                 android:id="@+id/menu_emulation_save_1"
@@ -53,7 +56,8 @@
     <item
         android:id="@+id/menu_emulation_load_root"
         app:showAsAction="never"
-        android:title="@string/emulation_loadstate">
+        android:title="@string/emulation_loadstate"
+        android:visible="false">
         <menu>
             <item
                 android:id="@+id/menu_emulation_load_1"

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -135,6 +135,8 @@
     <string name="wiimote_speaker_description">Enable sound output through the speaker on a real Wiimote (DolphinBar required).</string>
     <string name="audio_stretch">Audio Stretching</string>
     <string name="audio_stretch_description">Stretches audio to reduce stuttering. Increases latency.</string>
+    <string name="enable_save_states">Enable Savestates</string>
+    <string name="enable_save_states_description">WARNING: Savestates may not be compatible with future versions of Dolphin and can make it impossible to create normal saves in some cases. Never use savestates as the only way of saving your progress.</string>
     <string name="analytics">Enable usage statistics reporting</string>
     <string name="analytics_desc">If authorized, Dolphin can collect data on its performance, feature usage, and configuration, as well as data on your system\'s hardware and operating system.\n\nNo private data is ever collected. This data helps us understand how people and emulated games use Dolphin and prioritize our efforts. It also helps us identify rare configurations that are causing bugs, performance and stability issues. This authorization can be revoked at any time through Dolphin\'s settings.</string>
     <string name="gametdb_thanks">Thanks to GameTDB.com for providing GameCube and Wii covers!</string>


### PR DESCRIPTION
With the nature of android updates invalidating save states, it's best to hide these options unless enabled by the user. The option to use savestates can now be enabled via the General settings menu.

@JMC47 @MayImilae @JosJuice Let me know if the warning can be improved. Possibly also something like "disable updating in the play store if you plan to use savestates as the primary way of saving."

![savestates](https://user-images.githubusercontent.com/427044/46584412-d07e9e00-ca30-11e8-8dfd-28ba45273934.png)