### PR TITLE
FifoPlayer: reduce XF_REGS_SIZE to what we know

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoDataFile.h
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "VideoCommon/XFMemory.h"
 
 namespace File
 {
@@ -50,9 +51,10 @@ public:
     BP_MEM_SIZE = 256,
     CP_MEM_SIZE = 256,
     XF_MEM_SIZE = 4096,
-    XF_REGS_SIZE = 96,
+    XF_REGS_SIZE = 88,
     TEX_MEM_SIZE = 1024 * 1024,
   };
+  static_assert((XF_MEM_SIZE + XF_REGS_SIZE) * sizeof(u32) == sizeof(XFMemory));
 
   FifoDataFile();
   ~FifoDataFile();

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -288,6 +288,7 @@ struct XFMemory
   u32 unk9[8];                              // 0x1048 - 0x104f
   PostMtxInfo postMtxInfo[8];               // 0x1050 - 0x1057
 };
+static_assert(sizeof(XFMemory) == sizeof(u32) * 0x1058);
 
 extern XFMemory xfmem;
 


### PR DESCRIPTION
This avoids out-of-bounds warnings when replaying FIFO captures.

The value of XF_REGS_SIZE is written into the DFF header and we only read the min of XF_REGS_SIZE and the header value, so this change is backward compatible and doesn't break forward compatibility for old Dolphin versions either.