### PR TITLE
Qt/Settings: Add Cancel button to USB passthrough device dialog

### DIFF
--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -48,9 +48,12 @@ void USBDeviceAddToWhitelistDialog::InitControls()
 
   m_whitelist_buttonbox = new QDialogButtonBox();
   auto* add_button = new QPushButton(tr("Add"));
+  auto* cancel_button = new QPushButton(tr("Cancel"));
   m_whitelist_buttonbox->addButton(add_button, QDialogButtonBox::AcceptRole);
+  m_whitelist_buttonbox->addButton(cancel_button, QDialogButtonBox::RejectRole);
   connect(add_button, &QPushButton::clicked, this,
           &USBDeviceAddToWhitelistDialog::AddUSBDeviceToWhitelist);
+  connect(cancel_button, &QPushButton::clicked, this, &USBDeviceAddToWhitelistDialog::reject);
   add_button->setDefault(true);
 
   main_layout = new QVBoxLayout();


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/11125

![Dialog with dismiss button](https://i.imgur.com/8SHb7LI.png)