### PR TITLE
Qt/debugger: restore previously lost symbols and signature features

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -876,13 +876,19 @@ void MenuBar::AddSymbolsMenu()
   m_symbols->addSeparator();
 
   m_symbols->addAction(tr("Load &Other Map File..."), this, &MenuBar::LoadOtherSymbolMap);
+  m_symbols->addAction(tr("Load &Bad Map File..."), this, &MenuBar::LoadBadSymbolMap);
   m_symbols->addAction(tr("Save Symbol Map &As..."), this, &MenuBar::SaveSymbolMapAs);
   m_symbols->addSeparator();
 
-  m_symbols->addAction(tr("Save Code"), this, &MenuBar::SaveCode);
+  m_symbols->addAction(tr("Sa&ve Code"), this, &MenuBar::SaveCode);
   m_symbols->addSeparator();
 
-  m_symbols->addAction(tr("&Create Signature File..."), this, &MenuBar::CreateSignatureFile);
+  m_symbols->addAction(tr("C&reate Signature File..."), this, &MenuBar::CreateSignatureFile);
+  m_symbols->addAction(tr("Append to &Existing Signature File..."), this,
+                       &MenuBar::AppendSignatureFile);
+  m_symbols->addAction(tr("Combine &Two Signature Files..."), this,
+                       &MenuBar::CombineSignatureFiles);
+  m_symbols->addAction(tr("Appl&y Signature File..."), this, &MenuBar::ApplySignatureFile);
   m_symbols->addSeparator();
 
   m_symbols->addAction(tr("&Patch HLE Functions"), this, &MenuBar::PatchHLEFunctions);
@@ -1226,6 +1232,22 @@ void MenuBar::LoadOtherSymbolMap()
   emit NotifySymbolsUpdated();
 }
 
+void MenuBar::LoadBadSymbolMap()
+{
+  const QString file = QFileDialog::getOpenFileName(
+      this, tr("Load map file"), QString::fromStdString(File::GetUserPath(D_MAPS_IDX)),
+      tr("Dolphin Map File (*.map)"));
+
+  if (file.isEmpty())
+    return;
+
+  if (!TryLoadMapFile(file, true))
+    return;
+
+  HLE::PatchFunctions();
+  emit NotifySymbolsUpdated();
+}
+
 void MenuBar::SaveSymbolMapAs()
 {
   const std::string& title_id_str = SConfig::GetInstance().m_debugger_game_id;
@@ -1256,9 +1278,9 @@ void MenuBar::SaveCode()
   }
 }
 
-bool MenuBar::TryLoadMapFile(const QString& path)
+bool MenuBar::TryLoadMapFile(const QString& path, const bool bad)
 {
-  if (!g_symbolDB.LoadMap(path.toStdString()))
+  if (!g_symbolDB.LoadMap(path.toStdString(), bad))
   {
     QMessageBox::warning(this, tr("Error"), tr("Failed to load map file '%1'").arg(path));
     return false;
@@ -1280,7 +1302,8 @@ void MenuBar::CreateSignatureFile()
   const QString text = QInputDialog::getText(
       this, tr("Input"), tr("Only export symbols with prefix:\n(Blank for all symbols)"));
 
-  const QString file = QFileDialog::getSaveFileName(this, tr("Save signature file"));
+  const QString file = QFileDialog::getSaveFileName(
+      this, tr("Save signature file"), QDir::homePath(), tr("Functions signature *.dsy(*.dsy)"));
   if (file.isEmpty())
     return;
 
@@ -1292,6 +1315,85 @@ void MenuBar::CreateSignatureFile()
   if (!db.Save(save_path))
   {
     QMessageBox::warning(this, tr("Error"), tr("Failed to save signature file '%1'").arg(file));
+    return;
+  }
+
+  db.List();
+}
+
+void MenuBar::AppendSignatureFile()
+{
+  const QString text = QInputDialog::getText(
+      this, tr("Input"), tr("Only append symbols with prefix:\n(Blank for all symbols)"));
+
+  const QString file = QFileDialog::getSaveFileName(
+      this, tr("Append signature to"), QDir::homePath(), tr("Functions signature *.dsy(*.dsy)"));
+  if (file.isEmpty())
+    return;
+
+  const std::string prefix = text.toStdString();
+  const std::string signature_path = file.toStdString();
+  SignatureDB db(signature_path);
+  db.Populate(&g_symbolDB, prefix);
+  db.List();
+  db.Load(signature_path);
+  if (!db.Save(signature_path))
+  {
+    QMessageBox::warning(this, tr("Error"),
+                         tr("Failed to append to signature file '%1'").arg(file));
+    return;
+  }
+
+  db.List();
+}
+
+void MenuBar::ApplySignatureFile()
+{
+  const QString file = QFileDialog::getOpenFileName(
+      this, tr("Apply signature file"), QDir::homePath(), tr("Functions signature *.dsy(*.dsy)"));
+
+  if (file.isEmpty())
+    return;
+
+  const std::string load_path = file.toStdString();
+  SignatureDB db(load_path);
+  db.Load(load_path);
+  db.Apply(&g_symbolDB);
+  db.List();
+  HLE::PatchFunctions();
+  emit NotifySymbolsUpdated();
+}
+
+void MenuBar::CombineSignatureFiles()
+{
+  const QString priorityFile =
+      QFileDialog::getOpenFileName(this, tr("Choose priority input file"), QDir::homePath(),
+                                   tr("Functions signature *.dsy(*.dsy)"));
+  if (priorityFile.isEmpty())
+    return;
+
+  const QString secondaryFile =
+      QFileDialog::getOpenFileName(this, tr("Choose secondary input file"), QDir::homePath(),
+                                   tr("Functions signature *.dsy(*.dsy)"));
+  if (secondaryFile.isEmpty())
+    return;
+
+  const QString saveFile =
+      QFileDialog::getSaveFileName(this, tr("Save combined output file as"), QDir::homePath(),
+                                   tr("Functions signature *.dsy(*.dsy)"));
+  if (saveFile.isEmpty())
+    return;
+
+  const std::string load_pathPriorityFile = priorityFile.toStdString();
+  const std::string load_pathSecondaryFile = secondaryFile.toStdString();
+  const std::string save_path = saveFile.toStdString();
+  SignatureDB db(load_pathPriorityFile);
+  db.Load(load_pathPriorityFile);
+  db.Load(load_pathSecondaryFile);
+  if (!db.Save(save_path))
+  {
+    QMessageBox::warning(this, tr("Error"),
+                         tr("Failed to save to signature file '%1'").arg(saveFile));
     return;
   }
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -147,12 +147,16 @@ private:
   void GenerateSymbolsFromRSO();
   void LoadSymbolMap();
   void LoadOtherSymbolMap();
+  void LoadBadSymbolMap();
   void SaveSymbolMap();
   void SaveSymbolMapAs();
   void SaveCode();
-  bool TryLoadMapFile(const QString& path);
+  bool TryLoadMapFile(const QString& path, const bool bad = false);
   void TrySaveSymbolMap(const QString& path);
   void CreateSignatureFile();
+  void AppendSignatureFile();
+  void ApplySignatureFile();
+  void CombineSignatureFiles();
   void PatchHLEFunctions();
   void ClearCache();
   void LogInstructions();


### PR DESCRIPTION
They were mysteriously lost after the Qt migration.

They are still useful to manage games which has similar functions combined with a full map file (for example, some symbols can be loaded into Super Paper Mario from a TTYD signature produced with the full map file).

cc: @spycrab 