### PR TITLE
Qt/debugger: reorder the PC toolbar icons to their correct buttons

### DIFF
--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -167,8 +167,8 @@ void ToolBar::UpdateIcons()
   m_step_over_action->setIcon(Resources::GetScaledThemeIcon("debugger_step_over"));
   m_step_out_action->setIcon(Resources::GetScaledThemeIcon("debugger_step_out"));
   m_skip_action->setIcon(Resources::GetScaledThemeIcon("debugger_skip"));
-  m_show_pc_action->setIcon(Resources::GetScaledThemeIcon("debugger_set_pc"));
-  m_set_pc_action->setIcon(Resources::GetScaledThemeIcon("debugger_show_pc"));
+  m_show_pc_action->setIcon(Resources::GetScaledThemeIcon("debugger_show_pc"));
+  m_set_pc_action->setIcon(Resources::GetScaledThemeIcon("debugger_set_pc"));
 
   m_open_action->setIcon(Resources::GetScaledThemeIcon("open"));
   m_refresh_action->setIcon(Resources::GetScaledThemeIcon("refresh"));


### PR DESCRIPTION
They seemed to have been swapped somehow.