### PR TITLE
Change gecko sorting back to manual

### DIFF
--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -51,8 +51,6 @@ void GeckoCodeWidget::CreateWidgets()
   m_name_label = new QLabel;
   m_creator_label = new QLabel;
 
-  m_code_list->setSortingEnabled(true);
-
   QFont monospace(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());
 
   const auto line_height = QFontMetrics(font()).lineSpacing();


### PR DESCRIPTION
Gecko codes are a core foundation of most netplay sessions and most general modding cases. It has gone so far as to now have an ini for almost every game.

After the massive UI overhaul, the gecko code sorting defaults to Alphabetical with no option to change it. This removes the possibility for netplay games to have important and necessary codes at the top for easy selecting, and removes the ability to sort massive code lists in categories.

This will also make the sorting consistent with AR codes, which are sorted manually as of the latest commit.