### PR TITLE
Fix warning and zero-initialize variables

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -191,7 +191,8 @@ static void InitializeCPUCore(CPUCore cpu_core)
     s_cpu_core_base = JitInterface::InitJitCore(cpu_core);
     if (!s_cpu_core_base)  // Handle Situations where JIT core isn't available
     {
-      WARN_LOG(POWERPC, "CPU core %d not available. Falling back to default.", cpu_core);
+      WARN_LOG(POWERPC, "CPU core %d not available. Falling back to default.",
+               static_cast<int>(cpu_core));
       s_cpu_core_base = JitInterface::InitJitCore(DefaultCPUCore());
     }
     break;

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -30,7 +30,7 @@
 namespace PowerPC
 {
 // STATE_TO_SAVE
-PowerPCState ppcState;
+PowerPCState ppcState{};
 
 static CPUCoreBase* s_cpu_core_base = nullptr;
 static bool s_cpu_core_base_is_injected = false;

--- a/Source/Core/DolphinQt/Debugger/RegisterColumn.h
+++ b/Source/Core/DolphinQt/Debugger/RegisterColumn.h
@@ -67,6 +67,6 @@ private:
   std::function<u64()> m_get_register;
   std::function<void(u64)> m_set_register;
 
-  u64 m_value;
+  u64 m_value = 0;
   RegisterDisplay m_display = RegisterDisplay::Hex;
 };


### PR DESCRIPTION
`cpu_core` is an enum class.

If the register view is active before starting a game, it will read uninitialized memory.