### PR TITLE
Quick GameINI update for Sonic Heroes

### DIFF
--- a/Data/Sys/GameSettings/G9S.ini
+++ b/Data/Sys/GameSettings/G9S.ini
@@ -12,8 +12,9 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+VertexRounding = True
+
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
-InternalResolution = 1
-MSAA = 0
 MaxAnisotropy = 0


### PR DESCRIPTION
Closes emulator issue #10186

This adds Vertex Rounding to the Sonic Heroes' GameINI (allowing you enjoy Sonic Heroes in higher resolution without problem) and then removed the forced 1x Native and Anti-Aliasing settings as they are not needed when Vertex Rounding is enabled.