### PR TITLE
Fix infinite polling for usb devices after the "add to whitelist" dia…

### DIFF
--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -249,11 +249,10 @@ void WiiPane::ValidateSelectionState()
 
 void WiiPane::OnUSBWhitelistAddButton()
 {
-  USBDeviceAddToWhitelistDialog* usb_whitelist_dialog = new USBDeviceAddToWhitelistDialog(this);
-  connect(usb_whitelist_dialog, &USBDeviceAddToWhitelistDialog::accepted, this,
+  USBDeviceAddToWhitelistDialog usb_whitelist_dialog(this);
+  connect(&usb_whitelist_dialog, &USBDeviceAddToWhitelistDialog::accepted, this,
           &WiiPane::PopulateUSBPassthroughListWidget);
-  usb_whitelist_dialog->setModal(true);
-  usb_whitelist_dialog->show();
+  usb_whitelist_dialog.exec();
 }
 
 void WiiPane::OnUSBWhitelistRemoveButton()


### PR DESCRIPTION
…log has been opened once

Problem is that USBDeviceAddToWhitelistDialog starts a timer once created to poll for devices every second. In Qt, closing a dialog doesn't delete it, so it keeps on polling. The fix is to tell QT to delete this dialog on close, so that the timer gets destroyed with it.