### PR TITLE
Treat Wii Menu 1.0 as NTSC-U

### DIFF
--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -276,9 +276,6 @@ Country CountryCodeToCountry(u8 country_code, Platform platform, Region region)
 
 Region GetSysMenuRegion(u16 title_version)
 {
-  if (title_version == 33)
-    return Region::Unknown;  // 1.0 uses 33 as the version number in all regions
-
   switch (title_version & 0xf)
   {
   case 0:


### PR DESCRIPTION
See the comments of PR #7440.