### PR TITLE
Jit_SystemRegisters: Correct behaviour for mtspr SPR_HID0

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -238,9 +238,9 @@ void Jit64::mtspr(UGeckoInstruction inst)
 
   case SPR_HID0:
   {
-    gpr.BindToRegister(d, true, false);
-    BTR(32, gpr.R(d), Imm8(31 - 20));  // ICFI
-    MOV(32, PPCSTATE(spr[iIndex]), gpr.R(d));
+    MOV(32, R(RSCRATCH), gpr.R(d));
+    BTR(32, R(RSCRATCH), Imm8(31 - 20));  // ICFI
+    MOV(32, PPCSTATE(spr[iIndex]), R(RSCRATCH));
     FixupBranch dont_reset_icache = J_CC(CC_NC);
     BitSet32 regs = CallerSavedRegistersInUse();
     ABI_PushRegistersAndAdjustStack(regs, 0);


### PR DESCRIPTION
`BTR` modifies its argument.

Changed to match [interpreter behaviour](https://github.com/dolphin-emu/dolphin/blob/1fe40c59fa7dbd5ecf2bedfdb941e72f0315a382/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp#L328).

It may be preferable to do the following instead, lmk if you want me to change it:

```cpp
  case SPR_HID0:
  {
    gpr.BindToRegister(d, true, false);
    MOV(32, R(RSCRATCH), gpr.R(d))
    BTR(32, R(RSCRATCH), Imm8(31 - 20));  // ICFI
    MOV(32, PPCSTATE(spr[iIndex]), R(RSCRATCH));
    FixupBranch dont_reset_icache = J_CC(CC_NC);
    BitSet32 regs = CallerSavedRegistersInUse();
```