### PR TITLE
ShaderCache: Don't create or load shader cache with Null backend

### DIFF
--- a/Source/Core/VideoBackends/Null/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Null/VertexManager.cpp
@@ -13,13 +13,13 @@ namespace Null
 class NullNativeVertexFormat : public NativeVertexFormat
 {
 public:
-  NullNativeVertexFormat() {}
+  NullNativeVertexFormat(const PortableVertexDeclaration& vtx_decl_) { vtx_decl = vtx_decl_; }
 };
 
 std::unique_ptr<NativeVertexFormat>
 VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-  return std::make_unique<NullNativeVertexFormat>();
+  return std::make_unique<NullNativeVertexFormat>(vtx_decl);
 }
 
 VertexManager::VertexManager() : m_local_v_buffer(MAXVBUFFERSIZE), m_local_i_buffer(MAXIBUFFERSIZE)

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -35,7 +35,7 @@ bool ShaderCache::Initialize()
   m_async_shader_compiler->ResizeWorkerThreads(g_ActiveConfig.GetShaderPrecompilerThreads());
 
   // Load shader and UID caches.
-  if (g_ActiveConfig.bShaderCache)
+  if (g_ActiveConfig.bShaderCache && m_api_type != APIType::Nothing)
   {
     LoadShaderCaches();
     LoadPipelineUIDCache();


### PR DESCRIPTION
Does what the title says. Prevents the shader cache from creating extra files which are never used.