### PR TITLE
Qt/MainWindow: Lazy initialize child windows

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
@@ -27,17 +27,6 @@
 GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent)
     : QDialog(parent), m_xrr_config(xrr_config)
 {
-  // GraphicsWindow initialization is heavy due to dependencies on the graphics subsystem.
-  // To prevent blocking startup, we create the layout and children at first show time.
-}
-
-void GraphicsWindow::Initialize()
-{
-  if (m_lazy_initialized)
-    return;
-
-  m_lazy_initialized = true;
-
   CreateMainLayout();
 
   setWindowTitle(tr("Graphics"));

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.h
@@ -29,8 +29,6 @@ class GraphicsWindow final : public QDialog
 public:
   explicit GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent);
 
-  void Initialize();
-
   void RegisterWidget(GraphicsWidget* widget);
   bool eventFilter(QObject* object, QEvent* event) override;
 signals:
@@ -40,8 +38,6 @@ private:
   void CreateMainLayout();
   void OnBackendChanged(const QString& backend);
   void OnDescriptionAdded(QWidget* widget, const char* description);
-
-  bool m_lazy_initialized = false;
 
   QTabWidget* m_tab_widget;
   QLabel* m_description;

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -937,13 +937,15 @@ void MainWindow::ShowAboutDialog()
 
 void MainWindow::ShowHotkeyDialog()
 {
-  auto* hotkey_window = new MappingWindow(this, MappingWindow::Type::MAPPING_HOTKEYS, 0);
+  if (!m_hotkey_window)
+  {
+    m_hotkey_window = new MappingWindow(this, MappingWindow::Type::MAPPING_HOTKEYS, 0);
+    InstallHotkeyFilter(m_hotkey_window);
+  }
 
-  InstallHotkeyFilter(hotkey_window);
-
-  hotkey_window->show();
-  hotkey_window->raise();
-  hotkey_window->activateWindow();
+  m_hotkey_window->show();
+  m_hotkey_window->raise();
+  m_hotkey_window->activateWindow();
 }
 
 void MainWindow::ShowGraphicsWindow()

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -180,13 +180,15 @@ private:
   int m_state_slot = 1;
   std::unique_ptr<BootParameters> m_pending_boot;
 
+  ControllersWindow* m_controllers_window = nullptr;
+  SettingsWindow* m_settings_window = nullptr;
+  GraphicsWindow* m_graphics_window = nullptr;
+  FIFOPlayerWindow* m_fifo_window = nullptr;
+
   HotkeyScheduler* m_hotkey_scheduler;
-  ControllersWindow* m_controllers_window;
-  SettingsWindow* m_settings_window;
   NetPlayDialog* m_netplay_dialog;
   DiscordHandler* m_netplay_discord;
   NetPlaySetupDialog* m_netplay_setup_dialog;
-  GraphicsWindow* m_graphics_window;
   static constexpr int num_gc_controllers = 4;
   std::array<GCTASInputWindow*, num_gc_controllers> m_gc_tas_input_windows{};
   static constexpr int num_wii_controllers = 4;
@@ -198,7 +200,6 @@ private:
   LogWidget* m_log_widget;
   LogConfigWidget* m_log_config_widget;
   MemoryWidget* m_memory_widget;
-  FIFOPlayerWindow* m_fifo_window;
   RegisterWidget* m_register_widget;
   WatchWidget* m_watch_widget;
   CheatsManager* m_cheats_manager;

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -29,6 +29,7 @@ class HotkeyScheduler;
 class JITWidget;
 class LogConfigWidget;
 class LogWidget;
+class MappingWindow;
 class MemoryWidget;
 class MenuBar;
 class NetPlayDialog;
@@ -184,6 +185,7 @@ private:
   SettingsWindow* m_settings_window = nullptr;
   GraphicsWindow* m_graphics_window = nullptr;
   FIFOPlayerWindow* m_fifo_window = nullptr;
+  MappingWindow* m_hotkey_window = nullptr;
 
   HotkeyScheduler* m_hotkey_scheduler;
   NetPlayDialog* m_netplay_dialog;


### PR DESCRIPTION
Previously, only the graphics window was lazy initialized, because it calls into the video backend. I've extended this to the other config windows, and deferred instantiating the window class itself until the dialog is shown.

Unfortunately, we can't defer controller initialization entirely, as hotkeys depend on it (and some of those hotkeys can be used before a game is started) :(

Also fixes a memory leak with the hotkey window, and prevents multiple hotkey windows from being opened.