### PR TITLE
Qt/GameList: Cancel ISO compression when the user cancels the save dialog

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -496,6 +496,9 @@ void GameList::CompressISO(bool decompress)
             .append(decompress ? QStringLiteral(".gcm") : QStringLiteral(".gcz")),
         decompress ? tr("Uncompressed GC/Wii images (*.iso *.gcm)") :
                      tr("Compressed GC/Wii images (*.gcz)"));
+
+    if (dst_path.isEmpty())
+      return;
   }
 
   for (const auto& file : files)


### PR DESCRIPTION
The save dialog gets cancelled correctly when the user has selected multiple files, but not when the user has selected only one file to compress.

Before this change the UI would show a warning because the file path was empty.