### PR TITLE
VideoCommon: Clean up class-memaccess warnings

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -90,7 +90,7 @@ void SWVertexLoader::vFlush()
   for (u32 i = 0; i < IndexGenerator::GetIndexLen(); i++)
   {
     const u16 index = m_local_index_buffer[i];
-    memset(&m_vertex, 0, sizeof(m_vertex));
+    memset(static_cast<void*>(&m_vertex), 0, sizeof(m_vertex));
 
     // Super Mario Sunshine requires those to be zero for those debug boxes.
     m_vertex.color = {};

--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -35,11 +35,14 @@ struct GXPipelineUid
   // We use memcmp() for comparing pipelines as std::tie generates a large number of instructions,
   // and this map lookup can happen every draw call. However, as using memcmp() will also compare
   // any padding bytes, we have to ensure these are zeroed out.
-  GXPipelineUid() { std::memset(this, 0, sizeof(*this)); }
-  GXPipelineUid(const GXPipelineUid& rhs) { std::memcpy(this, &rhs, sizeof(*this)); }
+  GXPipelineUid() { std::memset(static_cast<void*>(this), 0, sizeof(*this)); }
+  GXPipelineUid(const GXPipelineUid& rhs)
+  {
+    std::memcpy(static_cast<void*>(this), &rhs, sizeof(*this));
+  }
   GXPipelineUid& operator=(const GXPipelineUid& rhs)
   {
-    std::memcpy(this, &rhs, sizeof(*this));
+    std::memcpy(static_cast<void*>(this), &rhs, sizeof(*this));
     return *this;
   }
   bool operator<(const GXPipelineUid& rhs) const
@@ -62,11 +65,14 @@ struct GXUberPipelineUid
   DepthState depth_state;
   BlendingState blending_state;
 
-  GXUberPipelineUid() { std::memset(this, 0, sizeof(*this)); }
-  GXUberPipelineUid(const GXUberPipelineUid& rhs) { std::memcpy(this, &rhs, sizeof(*this)); }
+  GXUberPipelineUid() { std::memset(static_cast<void*>(this), 0, sizeof(*this)); }
+  GXUberPipelineUid(const GXUberPipelineUid& rhs)
+  {
+    std::memcpy(static_cast<void*>(this), &rhs, sizeof(*this));
+  }
   GXUberPipelineUid& operator=(const GXUberPipelineUid& rhs)
   {
-    std::memcpy(this, &rhs, sizeof(*this));
+    std::memcpy(static_cast<void*>(this), &rhs, sizeof(*this));
     return *this;
   }
   bool operator<(const GXUberPipelineUid& rhs) const

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -116,7 +116,7 @@ void VertexShaderManager::Init()
   bTexMtxInfoChanged = false;
   bLightingConfigChanged = false;
 
-  std::memset(&xfmem, 0, sizeof(xfmem));
+  std::memset(static_cast<void*>(&xfmem), 0, sizeof(xfmem));
   constants = {};
   ResetView();
 


### PR DESCRIPTION
These `memcpy` and `memset` calls are safe, and implemented this way for performance or low-level emulation reasons, so we can just use `static_cast` to suppress warnings.

Whether the usage of `memcmp` in the shader UID structs provides a practical performance improvement is a matter of debate, and requires more in-depth benchmarking, but it isn't inherently broken as-is, so I think this is fine to just eliminate the warnings.