### PR TITLE
Fix issue 11422 (inconsistent game ID for some hacked games)

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -655,9 +655,17 @@ void SConfig::ResetRunningGameMetadata()
 void SConfig::SetRunningGameMetadata(const DiscIO::Volume& volume,
                                      const DiscIO::Partition& partition)
 {
-  SetRunningGameMetadata(volume.GetGameID(partition), volume.GetTitleID(partition).value_or(0),
-                         volume.GetRevision(partition).value_or(0),
-                         Core::TitleDatabase::TitleType::Other);
+  if (partition == volume.GetGamePartition())
+  {
+    SetRunningGameMetadata(volume.GetGameID(), volume.GetTitleID().value_or(0),
+                           volume.GetRevision().value_or(0), Core::TitleDatabase::TitleType::Other);
+  }
+  else
+  {
+    SetRunningGameMetadata(volume.GetGameID(partition), volume.GetTitleID(partition).value_or(0),
+                           volume.GetRevision(partition).value_or(0),
+                           Core::TitleDatabase::TitleType::Other);
+  }
 }
 
 void SConfig::SetRunningGameMetadata(const IOS::ES::TMDReader& tmd)


### PR DESCRIPTION
Starting with PR 7411, the rest of Dolphin reads the game ID from `PARTITION_NONE`, but SetRunningGameMetadata was still reading from the game partition. https://bugs.dolphin-emu.org/issues/11422