### PR TITLE
Android: lock screen to landscape by default

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -4,6 +4,8 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
 import android.hardware.usb.UsbManager;
 import android.os.Bundle;
 import android.os.Handler;
@@ -237,6 +239,17 @@ public final class EmulationActivity extends AppCompatActivity
     int themeId;
     if (mDeviceHasTouchScreen)
     {
+      // Force landscape
+      if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT)
+      {
+        BooleanSetting lockLandscape =
+                (BooleanSetting) mSettings.getSection(Settings.SECTION_INI_CORE)
+                        .getSetting(SettingsFile.KEY_LOCK_LANDSCAPE);
+        if (lockLandscape == null || lockLandscape.getValue())
+          new Handler().postDelayed(
+                  () -> setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE),
+                  100);
+      }
       themeId = R.style.DolphinEmulationBase;
 
       // Get a handle to the Window containing the UI.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -212,6 +212,7 @@ public final class SettingsFragmentPresenter
     Setting audioStretch = null;
     Setting analytics = null;
     Setting enableSaveState;
+    Setting lockToLandscape;
 
     SettingSection coreSection = mSettings.getSection(Settings.SECTION_INI_CORE);
     SettingSection analyticsSection = mSettings.getSection(Settings.SECTION_ANALYTICS);
@@ -223,6 +224,7 @@ public final class SettingsFragmentPresenter
     audioStretch = coreSection.getSetting(SettingsFile.KEY_AUDIO_STRETCH);
     analytics = analyticsSection.getSetting(SettingsFile.KEY_ANALYTICS_ENABLED);
     enableSaveState = coreSection.getSetting(SettingsFile.KEY_ENABLE_SAVE_STATES);
+    lockToLandscape = coreSection.getSetting(SettingsFile.KEY_LOCK_LANDSCAPE);
 
     // TODO: Having different emuCoresEntries/emuCoresValues for each architecture is annoying.
     // The proper solution would be to have one emuCoresEntries and one emuCoresValues
@@ -262,6 +264,9 @@ public final class SettingsFragmentPresenter
     sl.add(new CheckBoxSetting(SettingsFile.KEY_ENABLE_SAVE_STATES, Settings.SECTION_INI_CORE,
             R.string.enable_save_states, R.string.enable_save_states_description, false,
             enableSaveState));
+    sl.add(new CheckBoxSetting(SettingsFile.KEY_LOCK_LANDSCAPE, Settings.SECTION_INI_CORE,
+            R.string.lock_emulation_landscape, R.string.lock_emulation_landscape_desc, true,
+            lockToLandscape));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_ANALYTICS_ENABLED, Settings.SECTION_ANALYTICS,
             R.string.analytics, 0, false, analytics));
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -50,6 +50,7 @@ public final class SettingsFile
   public static final String KEY_SLOT_A_DEVICE = "SlotA";
   public static final String KEY_SLOT_B_DEVICE = "SlotB";
   public static final String KEY_ENABLE_SAVE_STATES = "EnableSaveStates";
+  public static final String KEY_LOCK_LANDSCAPE = "LockLandscape";
 
   public static final String KEY_ANALYTICS_ENABLED = "Enabled";
   public static final String KEY_ANALYTICS_PERMISSION_ASKED = "PermissionAsked";

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -137,6 +137,8 @@
     <string name="audio_stretch_description">Stretches audio to reduce stuttering. Increases latency.</string>
     <string name="enable_save_states">Enable Savestates</string>
     <string name="enable_save_states_description">WARNING: Savestates may not be compatible with future versions of Dolphin and can make it impossible to create normal saves in some cases. Never use savestates as the only way of saving your progress.</string>
+    <string name="lock_emulation_landscape">Lock screen to landscape</string>
+    <string name="lock_emulation_landscape_desc">Some touch controls will require additional tweaking if played in portrait</string>
     <string name="analytics">Enable usage statistics reporting</string>
     <string name="analytics_desc">If authorized, Dolphin can collect data on its performance, feature usage, and configuration, as well as data on your system\'s hardware and operating system.\n\nNo private data is ever collected. This data helps us understand how people and emulated games use Dolphin and prioritize our efforts. It also helps us identify rare configurations that are causing bugs, performance and stability issues. This authorization can be revoked at any time through Dolphin\'s settings.</string>
     <string name="gametdb_thanks">Thanks to GameTDB.com for providing GameCube and Wii covers!</string>


### PR DESCRIPTION
A new setting has been added to the general config to allow rotation. This should
resolve a lot of crash complaints due to screen rotation.