### PR TITLE
Update ShadowTheHedgehog config - GUP.ini

### DIFF
--- a/Data/Sys/GameSettings/GUP.ini
+++ b/Data/Sys/GameSettings/GUP.ini
@@ -13,7 +13,6 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
-EFBToTextureEnable = False
 VertexRounding = True
 
 [Video_Stereoscopy]


### PR DESCRIPTION
As of 5.0-3251, only EFBToTextureEnable should be True, not False.
It used to be set to False to fix 2P splitscreen not rendering- this is not the case in 5.0-3251+
Setting to True causes large performance increase for this game.