### PR TITLE
Disable jit follow branch for some games

### DIFF
--- a/Data/Sys/GameSettings/GDQ.ini
+++ b/Data/Sys/GameSettings/GDQ.ini
@@ -5,6 +5,7 @@
 # This game does not work properly with large memorycards, use a 251 block card
 # see http://www.nintendo.com/consumer/memorycard1019.jsp
 MemoryCard251 = True
+JITFollowBranch = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GW5.ini
+++ b/Data/Sys/GameSettings/GW5.ini
@@ -1,0 +1,4 @@
+# GW5 - NFS Carbon
+
+[Core]
+JITFollowBranch = False

--- a/Data/Sys/GameSettings/RM9.ini
+++ b/Data/Sys/GameSettings/RM9.ini
@@ -1,18 +1,7 @@
 # RM9PGM, RM9EGM - Mushroom Men: The Spore Wars
 
 [Core]
-# Values set here will override the main Dolphin settings.
-
-[OnLoad]
-# Add memory patches to be loaded once on boot here.
-
-[OnFrame]
-# Add memory patches to be applied every frame here.
-
-[ActionReplay]
-# Add action replay cheats here.
-
-[Video_Settings]
+JITFollowBranch = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/S3H.ini
+++ b/Data/Sys/GameSettings/S3H.ini
@@ -1,0 +1,7 @@
+# S3HJ08 - Sengoku BASARA 3 Her
+
+[Core]
+JITFollowBranch = False
+
+[Video_Hacks]
+EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/SIA.ini
+++ b/Data/Sys/GameSettings/SIA.ini
@@ -1,0 +1,4 @@
+# SIAE52 - Ice Age Continental Drift- Artic Games
+
+[Core]
+JITFollowBranch = False


### PR DESCRIPTION
These games can't work with JITFollowBranch enabled.
Remove MMU setting for NFS Most Wanted.
Test on android device.
