### PR TITLE
Android: Don't require vibrate permission

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,9 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA"/>
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA"/>
-    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission
+        android:name="android.permission.VIBRATE"
+        android:required="false"/>
 
     <application
         android:name=".DolphinApplication"


### PR DESCRIPTION
Google Play won't distribute the app to devices that do not allow the vibrate permission if required is not false.