### PR TITLE
Android: Change the file browser dialog ok button title

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
@@ -1,8 +1,16 @@
 package org.dolphinemu.dolphinemu.fragments;
 
 import android.net.Uri;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.dolphinemu.dolphinemu.R;
 
 import com.nononsenseapps.filepicker.FilePickerFragment;
 
@@ -18,5 +26,24 @@ public class CustomFilePickerFragment extends FilePickerFragment
             .getUriForFile(getContext(),
                     getContext().getApplicationContext().getPackageName() + ".filesprovider",
                     file);
+  }
+
+  @Override
+  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+  {
+    View view = super.onCreateView(inflater, container, savedInstanceState);
+    if (view == null)
+      return null;
+
+    TextView ok = view.findViewById(R.id.nnf_button_ok);
+    TextView cancel = view.findViewById(R.id.nnf_button_cancel);
+
+    ok.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+    cancel.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+
+    ok.setAllCaps(false);
+    cancel.setAllCaps(false);
+    ok.setText(R.string.select_dir);
+    return view;
   }
 }

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -299,4 +299,6 @@
 
     <!-- Extra Leanback Homescreen Channels-->
     <string name="homescreen_favorites">Favorites</string>
+
+    <string name="select_dir">Select This Directory</string>
 </resources>


### PR DESCRIPTION
I saw a lot of posts over the internet for users wondering why the list is empty so I hope this will make it more clear to users that they are suppose to select the directory that has the games.

![device-2018-10-27-151753](https://user-images.githubusercontent.com/836892/47604772-49ed2900-d9fe-11e8-82da-ceddbade5204.png)




