### PR TITLE
Accurate region detection for NAND titles

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -295,11 +295,16 @@ u16 TMDReader::GetGroupId() const
 
 DiscIO::Region TMDReader::GetRegion() const
 {
+  if (!IsChannel(GetTitleId()))
+    return DiscIO::Region::Unknown;
+
   if (GetTitleId() == Titles::SYSTEM_MENU)
     return DiscIO::GetSysMenuRegion(GetTitleVersion());
 
-  return DiscIO::CountryCodeToRegion(static_cast<u8>(GetTitleId() & 0xff),
-                                     DiscIO::Platform::WiiWAD);
+  const DiscIO::Region region =
+      static_cast<DiscIO::Region>(Common::swap16(m_bytes.data() + offsetof(TMDHeader, region)));
+
+  return region <= DiscIO::Region::NTSC_K ? region : DiscIO::Region::Unknown;
 }
 
 std::string TMDReader::GetGameID() const

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -201,8 +201,6 @@ public:
   u32 GetTitleFlags() const;
   u16 GetTitleVersion() const;
   u16 GetGroupId() const;
-
-  // Provides a best guess for the region. Might be inaccurate or Region::Unknown.
   DiscIO::Region GetRegion() const;
 
   // Constructs a 6-character game ID in the format typically used by Dolphin.

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -40,13 +40,13 @@ enum class Country
   NumberOfCountries
 };
 
-// Regions 0 - 2 and 4 match Nintendo's GameCube/Wii region numbering.
+// This numbering matches Nintendo's GameCube/Wii region numbering.
 enum class Region
 {
   NTSC_J = 0,   // Japan and Taiwan (and South Korea for GameCube only)
   NTSC_U = 1,   // Mainly North America
   PAL = 2,      // Mainly Europe and Oceania
-  Unknown = 3,  // 3 seems to be unused? Anyway, we need an Unknown entry. Let's put it here
+  Unknown = 3,  // Nintendo uses this to mean region free, but we also use it for unknown regions
   NTSC_K = 4    // South Korea (Wii only)
 };
 
@@ -62,8 +62,8 @@ enum class Language
   Spanish = 4,
   Italian = 5,
   Dutch = 6,
-  SimplifiedChinese = 7,
-  TraditionalChinese = 8,
+  SimplifiedChinese = 7,   // Not selectable on any unmodded retail Wii
+  TraditionalChinese = 8,  // Not selectable on any unmodded retail Wii
   Korean = 9,
   Unknown
 };

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -95,7 +95,6 @@ public:
   virtual Platform GetVolumeType() const = 0;
   virtual bool SupportsIntegrityCheck() const { return false; }
   virtual bool CheckIntegrity(const Partition& partition) const { return false; }
-  // May be inaccurate for WADs
   virtual Region GetRegion() const = 0;
   virtual Country GetCountry(const Partition& partition = PARTITION_NONE) const = 0;
   virtual BlobType GetBlobType() const = 0;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -84,11 +84,15 @@ Country VolumeWAD::GetCountry(const Partition& partition) const
   if (!m_tmd.IsValid())
     return Country::Unknown;
 
-  u8 country_code = static_cast<u8>(m_tmd.GetTitleId() & 0xff);
-  if (country_code == 2)  // SYSMENU
+  const u8 country_byte = static_cast<u8>(m_tmd.GetTitleId() & 0xff);
+  if (country_byte == 2)  // SYSMENU
     return TypicalCountryForRegion(GetSysMenuRegion(m_tmd.GetTitleVersion()));
 
-  return CountryCodeToCountry(country_code, Platform::WiiWAD);
+  const Region region = GetRegion();
+  if (CountryCodeToRegion(country_byte, Platform::WiiWAD, region) != region)
+    return TypicalCountryForRegion(region);
+
+  return CountryCodeToCountry(country_byte, Platform::WiiWAD, region);
 }
 
 const IOS::ES::TMDReader& VolumeWAD::GetTMD(const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -48,7 +48,6 @@ public:
     return "";
   }
   Platform GetVolumeType() const override;
-  // Provides a best guess for the region. Might be inaccurate or Region::Unknown.
   Region GetRegion() const override;
   Country GetCountry(const Partition& partition = PARTITION_NONE) const override;
 


### PR DESCRIPTION
We already have accurate region detection for GameCube discs and Wii discs, so this PR should make us have accurate region detection for everything that can show up in the game list (except for loose DOL/ELF files, which just are treated as having no region).

@JMC47 please test.