### PR TITLE
TextureCache: Deferred/batched EFB copies

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -559,6 +559,7 @@ public final class SettingsFragmentPresenter
             new BooleanSetting(SettingsFile.KEY_IGNORE_FORMAT, Settings.SECTION_GFX_HACKS,
                     ignoreFormatValue);
     Setting efbToTexture = hacksSection.getSetting(SettingsFile.KEY_EFB_TEXTURE);
+    Setting deferEfbCopies = hacksSection.getSetting(SettingsFile.KEY_DEFER_EFB_COPIES);
     Setting texCacheAccuracy = gfxSection.getSetting(SettingsFile.KEY_TEXCACHE_ACCURACY);
     Setting gpuTextureDecoding = gfxSection.getSetting(SettingsFile.KEY_GPU_TEXTURE_DECODING);
     Setting xfbToTexture = hacksSection.getSetting(SettingsFile.KEY_XFB_TEXTURE);
@@ -573,6 +574,9 @@ public final class SettingsFragmentPresenter
             ignoreFormat));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_EFB_TEXTURE, Settings.SECTION_GFX_HACKS,
             R.string.efb_copy_method, R.string.efb_copy_method_description, true, efbToTexture));
+    sl.add(new CheckBoxSetting(SettingsFile.KEY_DEFER_EFB_COPIES, Settings.SECTION_GFX_HACKS,
+            R.string.defer_efb_copies, R.string.defer_efb_copies_description, true,
+            deferEfbCopies));
 
     sl.add(new HeaderSetting(null, null, R.string.texture_cache, 0));
     sl.add(new SingleChoiceSetting(SettingsFile.KEY_TEXCACHE_ACCURACY,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -80,6 +80,7 @@ public final class SettingsFile
   public static final String KEY_SKIP_EFB = "EFBAccessEnable";
   public static final String KEY_IGNORE_FORMAT = "EFBEmulateFormatChanges";
   public static final String KEY_EFB_TEXTURE = "EFBToTextureEnable";
+  public static final String KEY_DEFER_EFB_COPIES = "DeferEFBCopies";
   public static final String KEY_TEXCACHE_ACCURACY = "SafeTextureCacheColorSamples";
   public static final String KEY_GPU_TEXTURE_DECODING = "EnableGPUTextureDecoding";
   public static final String KEY_XFB_TEXTURE = "XFBToTextureEnable";

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -207,6 +207,8 @@
     <string name="ignore_format_changes_description">Ignore any changes to the EFB format.</string>
     <string name="efb_copy_method">Store EFB Copies to Texture Only</string>
     <string name="efb_copy_method_description">Stores EFB Copies exclusively on the GPU, bypassing system memory. Causes graphical defects in a small number of games. If unsure, leave this checked.</string>
+    <string name="defer_efb_copies">Defer EFB Copies to RAM</string>
+    <string name="defer_efb_copies_description">Waits until the game synchronizes with the emulated GPU before writing the contents of EFB copies to RAM. May result in faster performance. If unsure, leave this unchecked.</string>
     <string name="texture_cache">Texture Cache</string>
     <string name="texture_cache_accuracy">Texture Cache Accuracy</string>
     <string name="texture_cache_accuracy_description">The safer the selection, the less likely the emulator will be missing any texture updates from RAM.</string>

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -317,6 +317,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-efb-copy-format-changes", g_Config.bEFBEmulateFormatChanges);
   builder.AddData("cfg-gfx-efb-copy-ram", !g_Config.bSkipEFBCopyToRam);
   builder.AddData("cfg-gfx-xfb-copy-ram", !g_Config.bSkipXFBCopyToRam);
+  builder.AddData("cfg-gfx-defer-efb-copies", g_Config.bDeferEFBCopies);
   builder.AddData("cfg-gfx-immediate-xfb", !g_Config.bImmediateXFB);
   builder.AddData("cfg-gfx-efb-copy-scaled", g_Config.bCopyEFBScaled);
   builder.AddData("cfg-gfx-internal-resolution", g_Config.iEFBScale);

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -139,6 +139,7 @@ const ConfigInfo<bool> GFX_HACK_SKIP_XFB_COPY_TO_RAM{{System::GFX, "Hacks", "XFB
                                                      true};
 const ConfigInfo<bool> GFX_HACK_DISABLE_COPY_TO_VRAM{{System::GFX, "Hacks", "DisableCopyToVRAM"},
                                                      false};
+const ConfigInfo<bool> GFX_HACK_DEFER_EFB_COPIES{{System::GFX, "Hacks", "DeferEFBCopies"}, true};
 const ConfigInfo<bool> GFX_HACK_IMMEDIATE_XFB{{System::GFX, "Hacks", "ImmediateXFBEnable"}, false};
 const ConfigInfo<bool> GFX_HACK_COPY_EFB_SCALED{{System::GFX, "Hacks", "EFBScaledCopy"}, true};
 const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -107,6 +107,7 @@ extern const ConfigInfo<bool> GFX_HACK_FORCE_PROGRESSIVE;
 extern const ConfigInfo<bool> GFX_HACK_SKIP_EFB_COPY_TO_RAM;
 extern const ConfigInfo<bool> GFX_HACK_SKIP_XFB_COPY_TO_RAM;
 extern const ConfigInfo<bool> GFX_HACK_DISABLE_COPY_TO_VRAM;
+extern const ConfigInfo<bool> GFX_HACK_DEFER_EFB_COPIES;
 extern const ConfigInfo<bool> GFX_HACK_IMMEDIATE_XFB;
 extern const ConfigInfo<bool> GFX_HACK_COPY_EFB_SCALED;
 extern const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -114,6 +114,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM.location,
       Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM.location,
       Config::GFX_HACK_DISABLE_COPY_TO_VRAM.location,
+      Config::GFX_HACK_DEFER_EFB_COPIES.location,
       Config::GFX_HACK_IMMEDIATE_XFB.location,
       Config::GFX_HACK_COPY_EFB_SCALED.location,
       Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES.location,

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -42,8 +42,11 @@ private:
   QCheckBox* m_fast_depth_calculation;
   QCheckBox* m_disable_bounding_box;
   QCheckBox* m_vertex_rounding;
+  QCheckBox* m_defer_efb_copies;
 
   void CreateWidgets();
   void ConnectWidgets();
   void AddDescriptions();
+
+  void UpdateDeferEFBCopiesEnabled();
 };

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -38,9 +38,9 @@ public:
 
   void Init();
   void Shutdown();
-  void Encode(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-              u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect, bool scale_by_half,
-              float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
+  void Encode(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+              u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+              bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
               const TextureCacheBase::CopyFilterCoefficientArray& filter_coefficients);
 
 private:
@@ -48,7 +48,6 @@ private:
 
   ID3D11Buffer* m_encode_params = nullptr;
   std::unique_ptr<AbstractTexture> m_encoding_render_texture;
-  std::unique_ptr<AbstractStagingTexture> m_encoding_readback_texture;
   std::map<EFBCopyParams, ID3D11PixelShader*> m_encoding_shaders;
 };
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -31,8 +31,8 @@ namespace DX11
 {
 static std::unique_ptr<PSTextureEncoder> g_encoder;
 
-void TextureCache::CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width,
-                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void TextureCache::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params,
+                           u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
                            const EFBRectangle& src_rect, bool scale_by_half, float y_scale,
                            float gamma, bool clamp_top, bool clamp_bottom,
                            const CopyFilterCoefficientArray& filter_coefficients)

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -22,18 +22,11 @@ public:
   ~TextureCache();
 
 private:
-  u64 EncodeToRamFromTexture(u32 address, void* source_texture, u32 SourceW, u32 SourceH,
-                             bool bFromZBuffer, bool bIsIntensityFmt, u32 copyfmt, int bScaleByHalf,
-                             const EFBRectangle& source)
-  {
-    return 0;
-  };
-
   void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
                       TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
                bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
                const CopyFilterCoefficientArray& filter_coefficients) override;
 

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -25,8 +25,8 @@ public:
   {
   }
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
                bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
                const CopyFilterCoefficientArray& filter_coefficients) override
   {

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -159,8 +159,8 @@ void main()
 
 //#define TIME_TEXTURE_DECODING 1
 
-void TextureCache::CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width,
-                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void TextureCache::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params,
+                           u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
                            const EFBRectangle& src_rect, bool scale_by_half, float y_scale,
                            float gamma, bool clamp_top, bool clamp_bottom,
                            const CopyFilterCoefficientArray& filter_coefficients)

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -63,8 +63,8 @@ private:
   void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
                       TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
                bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
                const CopyFilterCoefficientArray& filter_coefficients) override;
 

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -10,6 +10,9 @@
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoCommon.h"
 
+struct EFBCopyParams;
+class AbstractStagingTexture;
+
 namespace OGL
 {
 // Converts textures between formats using shaders
@@ -21,7 +24,7 @@ void Shutdown();
 
 // returns size of the encoded data (in bytes)
 void EncodeToRamFromTexture(
-    u8* dest_ptr, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
+    AbstractStagingTexture* dest, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
     u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect, bool scale_by_half,
     float y_scale, float gamma, float clamp_top, float clamp_bottom,
     const TextureCacheBase::CopyFilterCoefficientArray& filter_coefficients);

--- a/Source/Core/VideoBackends/Software/SWTexture.h
+++ b/Source/Core/VideoBackends/Software/SWTexture.h
@@ -57,6 +57,8 @@ public:
   void Unmap() override;
   void Flush() override;
 
+  void SetMapStride(size_t stride) { m_map_stride = stride; }
+
 private:
   std::vector<u8> m_data;
 };

--- a/Source/Core/VideoBackends/Software/TextureCache.h
+++ b/Source/Core/VideoBackends/Software/TextureCache.h
@@ -16,8 +16,8 @@ public:
                       TLUTFormat format) override
   {
   }
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
                bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
                const CopyFilterCoefficientArray& filter_coefficients) override
   {

--- a/Source/Core/VideoBackends/Software/TextureEncoder.cpp
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.cpp
@@ -5,12 +5,14 @@
 #include "VideoBackends/Software/TextureEncoder.h"
 
 #include "Common/Align.h"
+#include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 #include "Common/Swap.h"
 
 #include "VideoBackends/Software/EfbInterface.h"
+#include "VideoBackends/Software/SWTexture.h"
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/LookUpTables.h"
@@ -1468,18 +1470,26 @@ void EncodeEfbCopy(u8* dst, const EFBCopyParams& params, u32 native_width, u32 b
 }
 }
 
-void Encode(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-            u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect, bool scale_by_half,
-            float y_scale, float gamma)
+void Encode(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+            u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+            bool scale_by_half, float y_scale, float gamma)
 {
+  // HACK: Override the memory stride for this staging texture with new copy stride.
+  // This is required because the texture encoder assumes that we're writing directly to memory,
+  // and each row is tightly packed with no padding, whereas our encoding abstract texture has
+  // a width of 2560. When we copy the texture back later on, it'll use the tightly packed stride.
+  ASSERT(memory_stride <= (dst->GetConfig().width * dst->GetTexelSize()));
+  static_cast<SW::SWStagingTexture*>(dst)->SetMapStride(memory_stride);
+
   if (params.copy_format == EFBCopyFormat::XFB)
   {
-    EfbInterface::EncodeXFB(dst, native_width, src_rect, y_scale, gamma);
+    EfbInterface::EncodeXFB(reinterpret_cast<u8*>(dst->GetMappedPointer()), native_width, src_rect,
+                            y_scale, gamma);
   }
   else
   {
-    EncodeEfbCopy(dst, params, native_width, bytes_per_row, num_blocks_y, memory_stride, src_rect,
-                  scale_by_half);
+    EncodeEfbCopy(reinterpret_cast<u8*>(dst->GetMappedPointer()), params, native_width,
+                  bytes_per_row, num_blocks_y, memory_stride, src_rect, scale_by_half);
   }
 }
 }

--- a/Source/Core/VideoBackends/Software/TextureEncoder.h
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.h
@@ -10,7 +10,7 @@
 
 namespace TextureEncoder
 {
-void Encode(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-            u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect, bool scale_by_half,
-            float y_scale, float gamma);
+void Encode(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+            u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+            bool scale_by_half, float y_scale, float gamma);
 }

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -611,7 +611,7 @@ bool FramebufferManager::PopulateColorReadbackTexture()
 {
   // Can't be in our normal render pass.
   StateTracker::GetInstance()->EndRenderPass();
-  StateTracker::GetInstance()->OnReadback();
+  StateTracker::GetInstance()->OnCPUEFBAccess();
 
   // Issue a copy from framebuffer -> copy texture if we have >1xIR or MSAA on.
   VkRect2D src_region = {{0, 0}, {GetEFBWidth(), GetEFBHeight()}};
@@ -684,7 +684,7 @@ bool FramebufferManager::PopulateDepthReadbackTexture()
 {
   // Can't be in our normal render pass.
   StateTracker::GetInstance()->EndRenderPass();
-  StateTracker::GetInstance()->OnReadback();
+  StateTracker::GetInstance()->OnCPUEFBAccess();
 
   // Issue a copy from framebuffer -> copy texture if we have >1xIR or MSAA on.
   VkRect2D src_region = {{0, 0}, {GetEFBWidth(), GetEFBHeight()}};

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.h
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.h
@@ -86,8 +86,10 @@ public:
   void OnDraw();
 
   // Call after CPU access is requested.
-  // This can be via EFBCache or EFB2RAM.
-  void OnReadback();
+  void OnCPUEFBAccess();
+
+  // Call after an EFB copy to RAM. If true, the current command buffer should be executed.
+  void OnEFBCopyToRAM();
 
   // Call at the end of a frame.
   void OnEndFrame();
@@ -182,6 +184,7 @@ private:
 
   // CPU access tracking
   u32 m_draw_counter = 0;
+  u32 m_last_efb_copy_draw_counter = 0;
   std::vector<u32> m_cpu_accesses_this_frame;
   std::vector<u32> m_scheduled_command_buffer_kicks;
   bool m_allow_background_execution = true;

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -126,7 +126,6 @@ void TextureCache::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& par
   // The barrier has to happen after the render pass, not inside it, as we are going to be
   // reading from the texture immediately afterwards.
   StateTracker::GetInstance()->EndRenderPass();
-  StateTracker::GetInstance()->OnReadback();
 
   // Transition to shader resource before reading.
   VkImageLayout original_layout = src_texture->GetLayout();
@@ -139,6 +138,8 @@ void TextureCache::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& par
 
   // Transition back to original state
   src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(), original_layout);
+
+  StateTracker::GetInstance()->OnEFBCopyToRAM();
 }
 
 bool TextureCache::SupportsGPUTextureDecode(TextureFormat format, TLUTFormat palette_format)

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -98,8 +98,8 @@ void TextureCache::ConvertTexture(TCacheEntry* destination, TCacheEntry* source,
                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 
-void TextureCache::CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width,
-                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void TextureCache::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params,
+                           u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
                            const EFBRectangle& src_rect, bool scale_by_half, float y_scale,
                            float gamma, bool clamp_top, bool clamp_bottom,
                            const CopyFilterCoefficientArray& filter_coefficients)

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.h
@@ -36,8 +36,8 @@ public:
   void ConvertTexture(TCacheEntry* destination, TCacheEntry* source, const void* palette,
                       TLUTFormat format) override;
 
-  void CopyEFB(u8* dst, const EFBCopyParams& params, u32 native_width, u32 bytes_per_row,
-               u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
+  void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
+               u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
                bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
                const CopyFilterCoefficientArray& filter_coefficients) override;
 

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -21,7 +21,6 @@ class AbstractStagingTexture;
 
 namespace Vulkan
 {
-class StagingTexture2D;
 class Texture2D;
 class VKTexture;
 
@@ -38,14 +37,12 @@ public:
                       TextureCache::TCacheEntry* src_entry, const void* palette,
                       TLUTFormat palette_format);
 
-  // Uses an encoding shader to copy src_texture to dest_ptr.
-  // NOTE: Executes the current command buffer.
-  void
-  EncodeTextureToMemory(VkImageView src_texture, u8* dest_ptr, const EFBCopyParams& params,
-                        u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                        const EFBRectangle& src_rect, bool scale_by_half, float y_scale,
-                        float gamma, bool clamp_top, bool clamp_bottom,
-                        const TextureCacheBase::CopyFilterCoefficientArray& filter_coefficients);
+  // Uses an encoding shader to copy src_texture to dest.
+  void EncodeTextureToMemory(
+      VkImageView src_texture, AbstractStagingTexture* dest, const EFBCopyParams& params,
+      u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+      const EFBRectangle& src_rect, bool scale_by_half, float y_scale, float gamma, bool clamp_top,
+      bool clamp_bottom, const TextureCacheBase::CopyFilterCoefficientArray& filter_coefficients);
 
   bool SupportsTextureDecoding(TextureFormat format, TLUTFormat palette_format);
   void DecodeTexture(VkCommandBuffer command_buffer, TextureCache::TCacheEntry* entry,
@@ -54,9 +51,6 @@ public:
                      const u8* palette, TLUTFormat palette_format);
 
 private:
-  static const u32 ENCODING_TEXTURE_WIDTH = EFB_WIDTH * 4;
-  static const u32 ENCODING_TEXTURE_HEIGHT = 1024;
-  static const AbstractTextureFormat ENCODING_TEXTURE_FORMAT = AbstractTextureFormat::BGRA8;
   static const size_t NUM_PALETTE_CONVERSION_SHADERS = 3;
 
   // Maximum size of a texture based on BP registers.
@@ -100,7 +94,6 @@ private:
   // Texture encoding - RGBA8->GX format in memory
   std::map<EFBCopyParams, VkShaderModule> m_encoding_shaders;
   std::unique_ptr<AbstractTexture> m_encoding_render_texture;
-  std::unique_ptr<AbstractStagingTexture> m_encoding_readback_texture;
 
   // Texture decoding - GX format in memory->RGBA8
   struct TextureDecodingPipeline

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -466,6 +466,7 @@ void VKStagingTexture::CopyFromTexture(Texture2D* src, const MathUtil::Rectangle
                                                 m_needs_flush = false;
                                                 g_command_buffer_mgr->RemoveFencePointCallback(
                                                     this);
+                                                m_staging_buffer->InvalidateCPUCache();
                                               });
 }
 

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -177,6 +177,7 @@ static void BPWritten(const BPCmd& bp)
     switch (bp.newvalue & 0xFF)
     {
     case 0x02:
+      g_texture_cache->FlushEFBCopies();
       if (!Fifo::UseDeterministicGPUThread())
         PixelEngine::SetFinish();  // may generate interrupt
       DEBUG_LOG(VIDEO, "GXSetDrawDone SetPEFinish (value: 0x%02X)", (bp.newvalue & 0xFFFF));
@@ -188,11 +189,13 @@ static void BPWritten(const BPCmd& bp)
     }
     return;
   case BPMEM_PE_TOKEN_ID:  // Pixel Engine Token ID
+    g_texture_cache->FlushEFBCopies();
     if (!Fifo::UseDeterministicGPUThread())
       PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), false);
     DEBUG_LOG(VIDEO, "SetPEToken 0x%04x", (bp.newvalue & 0xFFFF));
     return;
   case BPMEM_PE_TOKEN_INT_ID:  // Pixel Engine Interrupt Token ID
+    g_texture_cache->FlushEFBCopies();
     if (!Fifo::UseDeterministicGPUThread())
       PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), true);
     DEBUG_LOG(VIDEO, "SetPEToken + INT 0x%04x", (bp.newvalue & 0xFFFF));

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -724,6 +724,10 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
       // state changes the specialized shader will not take over.
       g_vertex_manager->InvalidatePipelineObject();
 
+      // Flush any outstanding EFB copies to RAM, in case the game is running at an uncapped frame
+      // rate and not waiting for vblank. Otherwise, we'd end up with a huge list of pending copies.
+      g_texture_cache->FlushEFBCopies();
+
       Core::Callback_VideoCopiedToXFB(true);
     }
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -28,6 +28,7 @@
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
 
+#include "VideoCommon/AbstractStagingTexture.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/FramebufferManagerBase.h"
@@ -89,6 +90,7 @@ TextureCacheBase::TextureCacheBase()
 
 void TextureCacheBase::Invalidate()
 {
+  FlushEFBCopies();
   InvalidateAllBindPoints();
   for (size_t i = 0; i < bound_textures.size(); ++i)
   {
@@ -1693,35 +1695,6 @@ void TextureCacheBase::CopyRenderTargetToTexture(
   const u32 bytes_per_row = num_blocks_x * bytes_per_block;
   const u32 covered_range = num_blocks_y * dstStride;
 
-  if (copy_to_ram)
-  {
-    CopyFilterCoefficientArray coefficients = GetRAMCopyFilterCoefficients(filter_coefficients);
-    PEControl::PixelFormat srcFormat = bpmem.zcontrol.pixel_format;
-    EFBCopyParams format(srcFormat, dstFormat, is_depth_copy, isIntensity,
-                         NeedsCopyFilterInShader(coefficients));
-    CopyEFB(dst, format, tex_w, bytes_per_row, num_blocks_y, dstStride, srcRect, scaleByHalf,
-            y_scale, gamma, clamp_top, clamp_bottom, coefficients);
-  }
-  else
-  {
-    if (is_xfb_copy)
-    {
-      UninitializeXFBMemory(dst, dstStride, bytes_per_row, num_blocks_y);
-    }
-    else
-    {
-      // Hack: Most games don't actually need the correct texture data in RAM
-      //       and we can just keep a copy in VRAM. We zero the memory so we
-      //       can check it hasn't changed before using our copy in VRAM.
-      u8* ptr = dst;
-      for (u32 i = 0; i < num_blocks_y; i++)
-      {
-        memset(ptr, 0, bytes_per_row);
-        ptr += dstStride;
-      }
-    }
-  }
-
   if (g_bRecordFifoData)
   {
     // Mark the memory behind this efb copy as dynamicly generated for the Fifo log
@@ -1775,7 +1748,9 @@ void TextureCacheBase::CopyRenderTargetToTexture(
           (!strided_efb_copy && entry->size_in_bytes == overlap_range) ||
           (strided_efb_copy && entry->size_in_bytes == overlap_range && entry->addr == dstAddr))
       {
-        iter.first = InvalidateTexture(iter.first);
+        // Pending EFB copies which are completely covered by this new copy can simply be tossed,
+        // instead of having to flush them later on, since this copy will write over everything.
+        iter.first = InvalidateTexture(iter.first, true);
         continue;
       }
       entry->may_have_overlapping_textures = true;
@@ -1804,6 +1779,7 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     ++iter.first;
   }
 
+  TCacheEntry* entry = nullptr;
   if (copy_to_vram)
   {
     // create the texture
@@ -1813,8 +1789,7 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     config.height = scaled_tex_h;
     config.layers = FramebufferManagerBase::GetEFBLayers();
 
-    TCacheEntry* entry = AllocateCacheEntry(config);
-
+    entry = AllocateCacheEntry(config);
     if (entry)
     {
       entry->SetGeneralParameters(dstAddr, 0, baseFormat, is_xfb_copy);
@@ -1835,9 +1810,6 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       CopyEFBToCacheEntry(entry, is_depth_copy, srcRect, scaleByHalf, dstFormat, isIntensity, gamma,
                           clamp_top, clamp_bottom,
                           GetVRAMCopyFilterCoefficients(filter_coefficients));
-
-      u64 hash = entry->CalculateHash();
-      entry->SetHashes(hash, hash);
 
       if (g_ActiveConfig.bDumpEFBTarget && !is_xfb_copy)
       {
@@ -1860,6 +1832,134 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       textures_by_address.emplace(dstAddr, entry);
     }
   }
+
+  if (copy_to_ram)
+  {
+    CopyFilterCoefficientArray coefficients = GetRAMCopyFilterCoefficients(filter_coefficients);
+    PEControl::PixelFormat srcFormat = bpmem.zcontrol.pixel_format;
+    EFBCopyParams format(srcFormat, dstFormat, is_depth_copy, isIntensity,
+                         NeedsCopyFilterInShader(coefficients));
+
+    std::unique_ptr<AbstractStagingTexture> staging_texture = GetEFBCopyStagingTexture();
+    if (staging_texture)
+    {
+      CopyEFB(staging_texture.get(), format, tex_w, bytes_per_row, num_blocks_y, dstStride, srcRect,
+              scaleByHalf, y_scale, gamma, clamp_top, clamp_bottom, coefficients);
+
+      // We can't defer if there is no VRAM copy (since we need to update the hash).
+      if (!copy_to_vram || !g_ActiveConfig.bDeferEFBCopies)
+      {
+        // Immediately flush it.
+        WriteEFBCopyToRAM(dst, bytes_per_row / sizeof(u32), num_blocks_y, dstStride,
+                          std::move(staging_texture));
+      }
+      else
+      {
+        // Defer the flush until later.
+        entry->pending_efb_copy = std::move(staging_texture);
+        entry->pending_efb_copy_width = bytes_per_row / sizeof(u32);
+        entry->pending_efb_copy_height = num_blocks_y;
+        entry->pending_efb_copy_invalidated = false;
+        m_pending_efb_copies.push_back(entry);
+      }
+    }
+  }
+  else
+  {
+    if (is_xfb_copy)
+    {
+      UninitializeXFBMemory(dst, dstStride, bytes_per_row, num_blocks_y);
+    }
+    else
+    {
+      // Hack: Most games don't actually need the correct texture data in RAM
+      //       and we can just keep a copy in VRAM. We zero the memory so we
+      //       can check it hasn't changed before using our copy in VRAM.
+      u8* ptr = dst;
+      for (u32 i = 0; i < num_blocks_y; i++)
+      {
+        std::memset(ptr, 0, bytes_per_row);
+        ptr += dstStride;
+      }
+    }
+  }
+
+  // Even if the copy is deferred, still compute the hash. This way if the copy is used as a texture
+  // in a subsequent draw before it is flushed, it will have the same hash.
+  if (entry)
+  {
+    const u64 hash = entry->CalculateHash();
+    entry->SetHashes(hash, hash);
+  }
+}
+
+void TextureCacheBase::FlushEFBCopies()
+{
+  if (m_pending_efb_copies.empty())
+    return;
+
+  for (TCacheEntry* entry : m_pending_efb_copies)
+    FlushEFBCopy(entry);
+  m_pending_efb_copies.clear();
+}
+
+TextureConfig TextureCacheBase::GetEncodingTextureConfig()
+{
+  return TextureConfig(EFB_WIDTH * 4, 1024, 1, 1, 1, AbstractTextureFormat::BGRA8, true);
+}
+
+void TextureCacheBase::WriteEFBCopyToRAM(u8* dst_ptr, u32 width, u32 height, u32 stride,
+                                         std::unique_ptr<AbstractStagingTexture> staging_texture)
+{
+  MathUtil::Rectangle<int> copy_rect(0, 0, static_cast<int>(width), static_cast<int>(height));
+  staging_texture->ReadTexels(copy_rect, dst_ptr, stride);
+  ReleaseEFBCopyStagingTexture(std::move(staging_texture));
+}
+
+void TextureCacheBase::FlushEFBCopy(TCacheEntry* entry)
+{
+  // Copy from texture -> guest memory.
+  u8* const dst = Memory::GetPointer(entry->addr);
+  WriteEFBCopyToRAM(dst, entry->pending_efb_copy_width, entry->pending_efb_copy_height,
+                    entry->memory_stride, std::move(entry->pending_efb_copy));
+
+  // If the EFB copy was invalidated (e.g. the bloom case mentioned in InvalidateTexture),
+  // now is the time to clean up the TCacheEntry. In which case, we don't need to compute
+  // the new hash of the RAM copy.
+  if (entry->pending_efb_copy_invalidated)
+  {
+    auto config = entry->texture->GetConfig();
+    texture_pool.emplace(config, TexPoolEntry(std::move(entry->texture)));
+    return;
+  }
+
+  // Re-hash the texture now that the guest memory is populated.
+  // This should be safe because we'll catch any writes before the game can modify it.
+  const u64 hash = entry->CalculateHash();
+  entry->SetHashes(hash, hash);
+}
+
+std::unique_ptr<AbstractStagingTexture> TextureCacheBase::GetEFBCopyStagingTexture()
+{
+  // Pull off the back first to re-use the most frequently used textures.
+  if (!m_efb_copy_staging_texture_pool.empty())
+  {
+    auto ptr = std::move(m_efb_copy_staging_texture_pool.back());
+    m_efb_copy_staging_texture_pool.pop_back();
+    return ptr;
+  }
+
+  std::unique_ptr<AbstractStagingTexture> tex =
+      g_renderer->CreateStagingTexture(StagingTextureType::Readback, GetEncodingTextureConfig());
+  if (!tex)
+    WARN_LOG(VIDEO, "Failed to create EFB copy staging texture");
+
+  return tex;
+}
+
+void TextureCacheBase::ReleaseEFBCopyStagingTexture(std::unique_ptr<AbstractStagingTexture> tex)
+{
+  m_efb_copy_staging_texture_pool.push_back(std::move(tex));
 }
 
 void TextureCacheBase::UninitializeXFBMemory(u8* dst, u32 stride, u32 bytes_per_row,
@@ -1989,7 +2089,7 @@ TextureCacheBase::FindOverlappingTextures(u32 addr, u32 size_in_bytes)
 }
 
 TextureCacheBase::TexAddrCache::iterator
-TextureCacheBase::InvalidateTexture(TexAddrCache::iterator iter)
+TextureCacheBase::InvalidateTexture(TexAddrCache::iterator iter, bool discard_pending_efb_copy)
 {
   if (iter == textures_by_address.end())
     return textures_by_address.end();
@@ -2011,6 +2111,33 @@ TextureCacheBase::InvalidateTexture(TexAddrCache::iterator iter)
     {
       bound_textures[i]->tmem_only = true;
       return ++iter;
+    }
+  }
+
+  // If this is a pending EFB copy, we don't want to flush it here.
+  // Why? Because let's say a game is rendering a bloom-type effect, using EFB copies to essentially
+  // downscale the framebuffer. Copy from EFB->Texture, draw texture to EFB, copy EFB->Texture,
+  // draw, repeat. The second copy will invalidate the first, forcing a flush. Which means we lose
+  // any benefit of EFB copy batching. So instead, let's just leave the EFB copy pending, but remove
+  // it from the texture cache. This way we don't use the old VRAM copy. When the EFB copies are
+  // eventually flushed, they will overwrite each other, and the end result should be the same.
+  if (entry->pending_efb_copy)
+  {
+    if (discard_pending_efb_copy)
+    {
+      // If the RAM copy is being completely overwritten by a new EFB copy, we can discard the
+      // existing pending copy, and not bother waiting for it in the future. This happens in
+      // Xenoblade's sunset scene, where 35 copies are done per frame, and 25 of them are
+      // copied to the same address, and can be skipped.
+      ReleaseEFBCopyStagingTexture(std::move(entry->pending_efb_copy));
+      auto pending_it = std::find(m_pending_efb_copies.begin(), m_pending_efb_copies.end(), entry);
+      if (pending_it != m_pending_efb_copies.end())
+        m_pending_efb_copies.erase(pending_it);
+    }
+    else
+    {
+      entry->pending_efb_copy_invalidated = true;
+      return textures_by_address.erase(iter);
     }
   }
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -141,6 +141,7 @@ void VideoConfig::Refresh()
   bSkipEFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_EFB_COPY_TO_RAM);
   bSkipXFBCopyToRam = Config::Get(Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
   bDisableCopyToVRAM = Config::Get(Config::GFX_HACK_DISABLE_COPY_TO_VRAM);
+  bDeferEFBCopies = Config::Get(Config::GFX_HACK_DEFER_EFB_COPIES);
   bImmediateXFB = Config::Get(Config::GFX_HACK_IMMEDIATE_XFB);
   bCopyEFBScaled = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -120,6 +120,7 @@ struct VideoConfig final
   bool bSkipEFBCopyToRam;
   bool bSkipXFBCopyToRam;
   bool bDisableCopyToVRAM;
+  bool bDeferEFBCopies;
   bool bImmediateXFB;
   bool bCopyEFBScaled;
   int iSafeTextureCache_ColorSamples;


### PR DESCRIPTION
This PR started as an extension of the locking concept, which doesn't perform very well at the moment due to a few reasons. For the explanation below, I am talking about a configuration where *EFB2RAM* is used, or "EFB Copies to Texture Only" is **disabled**.

There will be no changes to performance in EFBToTex mode, so please don't spam up the thread complaining about things still being slow on your three-year-old phone with EFB2RAM force disabled. Initial reports would suggest that performance is better, even on Android, with EFB Copies to Texture Only **disabled.**

Currently, when a game issues an EFB copy, we encode the EFB to a temporary texture, "idle" the GPU, copy the encoded texture data from the GPU (may be in RAM or VRAM, depending on the driver) to the emulated console's RAM, and continue on our merry way. The only problem, is the "idle" step takes ages. GPUs like being given large batches of work, and crunching through all of it without the CPU standing there, all intimidating-like, waiting for them to finish.

So, you might think hey, that isn't a big deal, there's only a couple of them every frame. Well, for one, it can cause GPUs to think they're not getting enough work, and stay at a lower clock rate/lower power state. It also all adds up. Imagine if you had to do this 20 or 30 times per frame, going back and forward with the host GPU. All that time, emulation is frozen, and can't progress. So FPS drops to the floor, and that's why we ship with _EFB Copies to Texture Only_ as the default. The console GPU has **no problem** crunching through all these copies, but it's a pretty big deal for us.

This feature abuses the fact that the CPU and GPU in the console run asynchronously of one another, and there are several well-defined methods of synchronizing the two. It's also similar to the reason that the dual core hack works so well. If the game (specifically the CPU) wants to read some of the texels in an EFB copy, it *should* wait for the GPU to finish writing to the memory where they're stored, right?

The DrawDone command stalls the CPU until the GPU executes the command, PE tokens can interrupt the CPU when these tokens are encountered by the GPU, and command processor breakpoints can be used to interrupt the CPU when the GPU begins to process a certain distance into the FIFO. Note that the GX is pipelined, and the command processor is at the beginning of the pipeline, so a breakpoint does not guarantee that the pixel engine has finished writing to memory yet, so I'd expect this form of synchronization to be used less frequently for CPU access to copies.

So, if you're following everything so far, you'd probably think "wait, why do we have to write the copies out immediately, if the game is going to tell us when it wants to read the copy anyway?". Yep, that's what we're doing here. Instead of immediately "flushing" the EFB copy to emulated RAM, we just queue them all up, just how the GPU likes it, until there's a DrawDone or token, then write them out to memory in the order they came in.

But wait, there's a catch. Overlapping EFB copies. Currently, we invalidate the first EFB copy when a second one comes in at the same address, or overlaps the first. Here's a real-world example: Xenoblade Chronicles's sunset title screen. Copy from EFB->Texture, draw texture to EFB, copy EFB->Texture, draw, repeat. The second copy will invalidate the first, forcing a flush. It does about 6 copies to the same address, so instead of batching all 35 copies for the frame together, we're flushing every copy after the first! Not good!

What can we do about this? Well, we know it's going to the same address, and we flush EFB copies to RAM in the same order they come in, so the end result in RAM will be the same. But we can't use the old copy, since it's now outdated. So instead, let's remove it from the texture cache, so the high-resolution VRAM copy isn't used, but **skip the flush.** Boom, correct rendering, and batching! The 35 copies in the frame are all batched together, and we only have to idle the GPU once. Perfect.

You might've thought of another optimization here. If these copies are going to the same address, what about if they're the same size. Copy B completely overlaps Copy A. In fact, this happens in Xenoblade. Well, why don't we just throw away Copy A entirely? Good idea. It's not needed anyway. Note that we can't **skip** the copy on the GPU, since we can't predict what the next copy is going to look like, as we're processing the command stream as it comes in. But we can skip the copy on the CPU.

This whole idea works surprisingly well for most of the games we've tried. It looks like they're not too naughty and synchronize with the GPU when they want to read EFB copies. Which makes sense, because there's so many factors involved in much time it takes the GPU to process commands, you can't really do cycle counting here.