### PR TITLE
Debug: Memory window fixes and additions

### DIFF
--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -1026,7 +1026,7 @@ void GekkoDisassembler::ps(u32 inst)
   {
   case 6:
     m_opcode = inst & 0x40 ? "psq_lux" : "psq_lx";
-    m_operands = StringFromFormat("p%u, (r%u + r%u), %d, qr%d", FD, RA, RB, WX, IX);
+    m_operands = StringFromFormat("p%u, r%u, r%u, %d, qr%d", FD, RA, RB, WX, IX);
     return;
 
   case 7:
@@ -1195,23 +1195,26 @@ void GekkoDisassembler::ps_mem(u32 inst)
   {
   case 56:
     m_opcode = "psq_l";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
 
   case 57:
     m_opcode = "psq_lu";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
-    ;
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
 
   case 60:
     m_opcode = "psq_st";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
 
   case 61:
     m_opcode = "psq_stu";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
   }
 }

--- a/Source/Core/Common/GekkoDisassembler.h
+++ b/Source/Core/Common/GekkoDisassembler.h
@@ -128,7 +128,25 @@ private:
     }
   }
 
-  static int SEX12(u32 x) { return x & 0x800 ? (x | 0xFFFFF000) : x; }
+  static std::string psq_offs(u32 val)
+  {
+    if (val == 0)
+    {
+      return "0";
+    }
+    else
+    {
+      if (val & 0x800)
+      {
+        return StringFromFormat("-0x%.4X", ((~val) & 0xfff) + 1);
+      }
+      else
+      {
+        return StringFromFormat("0x%.4X", val);
+      }
+    }
+  }
+
   enum InstructionType
   {
     PPCINSTR_OTHER = 0,   // No additional info for other instr.

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -208,6 +208,63 @@ void CodeViewWidget::ReplaceAddress(u32 address, ReplaceWith replace)
   Update();
 }
 
+void CodeViewWidget::OnMemoryViewAddress()
+{
+  // Checks if instruction starts with St, L, or psq_l/st and then calculates the save/load address
+  // and places it in memory view. Only works when the register holding the destination at the
+  // breakpoint and at the selection are the same.
+
+  std::string addr_str;
+  std::string offset_str;
+  u32 roffs = 0;
+  long offs = 0;
+  const u32 addy = GetContextAddress();
+  std::string codeline = PowerPC::debug_interface.Disassemble(addy);
+
+  if (codeline.compare(0, 2, "st") != 0 && codeline.compare(0, 1, "l") != 0 &&
+      codeline.compare(0, 5, "psq_l") != 0 && codeline.compare(0, 5, "psq_s") != 0)
+  {
+    return;
+  }
+
+  offset_str = codeline.substr(codeline.find(" ") + 1);
+  offset_str = offset_str.substr(0, offset_str.find(" "));
+
+  // If there's an X before the first space, it's an instruction like lwzx, where we need to get a
+  // second register value for the offset and format the address string differently.
+  std::string checkx = codeline.substr(0, codeline.find(" "));
+  if (checkx.find("x") != std::string::npos)
+  {
+    addr_str = codeline.substr(codeline.find("r", codeline.find(" ") + 2) + 1);
+    offset_str.erase(0, 1);
+    const int i = stoi(offset_str, nullptr, 10);
+    roffs = GPR(i);
+  }
+  else
+  {
+    if (codeline.find("(") == std::string::npos)
+      return;
+    addr_str = codeline.substr(codeline.find("(") + 2);
+    addr_str = addr_str.substr(0, addr_str.find(")"));
+    offs = std::stoi(offset_str, nullptr, 16);
+  }
+
+  // sp and rtoc need to be converted to 1 and 2. First letter is already removed.
+  if (addr_str.find("p") != std::string::npos)
+    addr_str = std::string("1");
+  if (addr_str.find("toc") != std::string::npos)
+    addr_str = std::string("2");
+
+  // stoi takes a number at the beginning of a string and stops at non-numbers without error, so we
+  // can leave a little trash at the end (psq_lx).
+  const int i = std::stoi(addr_str, nullptr, 10);
+  u32 addr = GPR(i);
+
+  addr = addr + offs + roffs;
+
+  emit(SendSearchValue(addr));
+}
+
 void CodeViewWidget::OnContextMenu()
 {
   QMenu* menu = new QMenu(this);
@@ -229,6 +286,8 @@ void CodeViewWidget::OnContextMenu()
   auto* copy_line_action =
       menu->addAction(tr("Copy code &line"), this, &CodeViewWidget::OnCopyCode);
   auto* copy_hex_action = menu->addAction(tr("Copy &hex"), this, &CodeViewWidget::OnCopyHex);
+  auto* mem_view_action = menu->addAction(tr("Set &memory view to address"), this,
+                                          &CodeViewWidget::OnMemoryViewAddress);
   menu->addSeparator();
 
   auto* symbol_rename_action =
@@ -252,8 +311,9 @@ void CodeViewWidget::OnContextMenu()
 
   follow_branch_action->setEnabled(running && GetBranchFromAddress(addr));
 
-  for (auto* action : {copy_address_action, copy_line_action, copy_hex_action, function_action,
-                       ppc_action, insert_blr_action, insert_nop_action, replace_action})
+  for (auto* action :
+       {copy_address_action, copy_line_action, copy_hex_action, mem_view_action, function_action,
+        ppc_action, insert_blr_action, insert_nop_action, replace_action})
     action->setEnabled(running);
 
   for (auto* action : {symbol_rename_action, symbol_size_action, symbol_end_action})

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -38,6 +38,7 @@ signals:
   void RequestPPCComparison(u32 addr);
   void SymbolsChanged();
   void BreakpointsChanged();
+  void SendSearchValue(u32 addr);
 
 private:
   enum class ReplaceWith
@@ -60,6 +61,7 @@ private:
   void OnCopyFunction();
   void OnCopyCode();
   void OnCopyHex();
+  void OnMemoryViewAddress();
   void OnRenameSymbol();
   void OnSelectionChanged();
   void OnSetSymbolSize();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -164,7 +164,8 @@ void CodeWidget::ConnectWidgets()
   connect(m_code_view, &CodeViewWidget::SymbolsChanged, this, &CodeWidget::UpdateSymbols);
   connect(m_code_view, &CodeViewWidget::BreakpointsChanged, this,
           [this] { emit BreakpointsChanged(); });
-
+  connect(m_code_view, &CodeViewWidget::SendSearchValue, this,
+          [this](u32 addr) { emit SendSearchValue(addr); });
   connect(m_code_view, &CodeViewWidget::RequestPPCComparison, this,
           &CodeWidget::RequestPPCComparison);
 }

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -44,6 +44,7 @@ public:
 signals:
   void BreakpointsChanged();
   void RequestPPCComparison(u32 addr);
+  void SendSearchValue(u32 addr);
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -18,7 +18,9 @@ public:
     U16,
     U32,
     ASCII,
-    Float32
+    U32xASCII,
+    Float32,
+    U32xFloat32
   };
 
   enum class BPType
@@ -49,6 +51,8 @@ public:
 
 signals:
   void BreakpointsChanged();
+  void SendSearchValue(const QString);
+  void SendDataValue(const QString);
 
 private:
   void OnContextMenu();

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -61,6 +61,7 @@ private:
   QSplitter* m_splitter;
   QLineEdit* m_search_address;
   QLineEdit* m_data_edit;
+  QLabel* m_data_preview;
   QPushButton* m_set_value;
   QPushButton* m_dump_mram;
   QPushButton* m_dump_exram;
@@ -79,7 +80,7 @@ private:
   QRadioButton* m_type_u32;
   QRadioButton* m_type_ascii;
   QRadioButton* m_type_float;
-
+  QCheckBox* m_mem_view_style;
   // Breakpoint options
   QRadioButton* m_bp_read_write;
   QRadioButton* m_bp_read_only;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -26,6 +26,7 @@ public:
   ~MemoryWidget();
 
   void Update();
+  void OnSetAddress(u32 addr);
 signals:
   void BreakpointsChanged();
 
@@ -60,6 +61,7 @@ private:
   MemoryViewWidget* m_memory_view;
   QSplitter* m_splitter;
   QLineEdit* m_search_address;
+  QLineEdit* m_search_address_offset;
   QLineEdit* m_data_edit;
   QLabel* m_data_preview;
   QPushButton* m_set_value;

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -346,6 +346,8 @@ void MainWindow::CreateComponents()
           &CodeWidget::Update);
   connect(m_breakpoint_widget, &BreakpointWidget::BreakpointsChanged, m_memory_widget,
           &MemoryWidget::Update);
+  connect(m_code_widget, &CodeWidget::SendSearchValue,
+          [this](u32 addr) { m_memory_widget->OnSetAddress(addr); });
   connect(m_breakpoint_widget, &BreakpointWidget::SelectedBreakpoint, [this](u32 address) {
     if (Core::GetState() == Core::State::Paused)
       m_code_widget->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithUpdate);


### PR DESCRIPTION
Allow for memory table updates while a game is running. (can cause panic handlers if spamming updates).
Skip memory table updates when window isn't visible.
Fix data input. Add preview.
Re-add 2-column view for hex + float/ascii.
Shift + Click to copy address into box.
Crtl + Click to copy value into box.
Smaller row height, and alternate colors for rows.
Fix "Previous" ram search.

Could possibly fix panic handlers by adding a limit to how often Update can be called. Not sure of the best way to do that.