### PR TITLE
Core/Config: Fix memcard path not being saved

### DIFF
--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -26,7 +26,11 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
     return true;
 
   const static std::vector<Config::ConfigLocation> s_setting_saveable{
+      // Main.Core
+
       Config::MAIN_DEFAULT_ISO.location,
+      Config::MAIN_MEMCARD_A_PATH.location,
+      Config::MAIN_MEMCARD_B_PATH.location,
 
       // Graphics.Hardware
 


### PR DESCRIPTION
I blame SConfig.