### PR TITLE
GameSettings: Set safe texture cache accuracy for Monster Hunter Tri (Japanese)

### DIFF
--- a/Data/Sys/GameSettings/RMHJ08.ini
+++ b/Data/Sys/GameSettings/RMHJ08.ini
@@ -12,3 +12,6 @@ $Bloom OFF
 
 [ActionReplay]
 # Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Needed for fonts to appear correctly.