### PR TITLE
OGL: Fix crash when opening graphics window on another backend

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -474,6 +474,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context)
   g_Config.backend_info.bSupportsDynamicSamplerIndexing =
       GLExtensions::Supports("GL_ARB_gpu_shader5");
 
+  g_ogl_config.bIsES = m_main_gl_context->IsGLES();
   g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
   g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");
   g_ogl_config.bSupportsGLSync = GLExtensions::Supports("GL_ARB_sync");

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -48,6 +48,7 @@ enum class EsFbFetchType
 // ogl-only config, so not in VideoConfig.h
 struct VideoConfig
 {
+  bool bIsES;
   bool bSupportsGLSLCache;
   bool bSupportsGLPinnedMemory;
   bool bSupportsGLSync;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -68,7 +68,7 @@ std::string VideoBackend::GetName() const
 
 std::string VideoBackend::GetDisplayName() const
 {
-  if (g_renderer && static_cast<Renderer*>(g_renderer.get())->IsGLES())
+  if (g_ogl_config.bIsES)
     return _trans("OpenGL ES");
   else
     return _trans("OpenGL");


### PR DESCRIPTION
Does what the title says. This crash occurs since the graphics window is lazy-initialized, and calls VideoBackend::GetDisplayName, which checks if g_renderer is created, not that it is actually OpenGL.