### PR TITLE
Fix glitched corner in Nickelodeon Unite.

### DIFF
--- a/Data/Sys/GameSettings/GNO.ini
+++ b/Data/Sys/GameSettings/GNO.ini
@@ -15,3 +15,7 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 
+[Video_Hacks]
+EFBToTextureEnable = False
+DeferEFBCopies = False
+


### PR DESCRIPTION
Nicktoon's Unite (also known as Spongebob and Friends Unite) has a black box over the upper left corner of the screen with *Store EFB Copies to Texture Only Enabled*

![gnox78-1](https://user-images.githubusercontent.com/6598209/48149822-15ddf780-e28b-11e8-9d45-3c9967f014e1.png)

The game also breaks with Defer EFB Copies, so, I've disabled both.

![defer](https://user-images.githubusercontent.com/6598209/48149858-35752000-e28b-11e8-8840-442dd2de6faa.png)
