### PR TITLE
Fix the widescreen hack for Wii games with 4:3 forced in game INI

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -85,6 +85,8 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   UpdateDrawRectangle();
   CalculateTargetSize();
 
+  m_aspect_wide = SConfig::GetInstance().bWii && Config::Get(Config::SYSCONF_WIDESCREEN);
+
   m_last_host_config_bits = ShaderHostConfig::GetCurrent().bits;
   m_last_efb_multisamples = g_ActiveConfig.iMultisamples;
 }

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -85,9 +85,6 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   UpdateDrawRectangle();
   CalculateTargetSize();
 
-  if (SConfig::GetInstance().bWii)
-    m_aspect_wide = Config::Get(Config::SYSCONF_WIDESCREEN);
-
   m_last_host_config_bits = ShaderHostConfig::GetCurrent().bits;
   m_last_efb_multisamples = g_ActiveConfig.iMultisamples;
 }
@@ -639,9 +636,19 @@ void Renderer::RecordVideoMemory()
 void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
                     u64 ticks)
 {
-  // Heuristic to detect if a GameCube game is in 16:9 anamorphic widescreen mode.
-  if (!SConfig::GetInstance().bWii)
+  const AspectMode suggested = g_ActiveConfig.suggested_aspect_mode;
+  if (suggested == AspectMode::Analog || suggested == AspectMode::AnalogWide)
   {
+    m_aspect_wide = suggested == AspectMode::AnalogWide;
+  }
+  else if (SConfig::GetInstance().bWii)
+  {
+    m_aspect_wide = Config::Get(Config::SYSCONF_WIDESCREEN);
+  }
+  else
+  {
+    // Heuristic to detect if a GameCube game is in 16:9 anamorphic widescreen mode.
+
     size_t flush_count_4_3, flush_count_anamorphic;
     std::tie(flush_count_4_3, flush_count_anamorphic) =
         g_vertex_manager->ResetFlushAspectRatioCount();

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -62,8 +62,9 @@ void VideoConfig::Refresh()
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
   const AspectMode config_aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
+  suggested_aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
   if (config_aspect_mode == AspectMode::Auto)
-    aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
+    aspect_mode = suggested_aspect_mode;
   else
     aspect_mode = config_aspect_mode;
   bCrop = Config::Get(Config::GFX_CROP);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -62,6 +62,7 @@ struct VideoConfig final
   bool bVSync;
   bool bWidescreenHack;
   AspectMode aspect_mode;
+  AspectMode suggested_aspect_mode;
   bool bCrop;  // Aspect ratio controls.
   bool bShaderCache;
 


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/11237