### PR TITLE
Fix photo taking in Sakura Wars - So Long My Love

### DIFF
--- a/Data/Sys/GameSettings/SAK.ini
+++ b/Data/Sys/GameSettings/SAK.ini
@@ -14,6 +14,7 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
+DeferEFBCopies = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512


### PR DESCRIPTION
The recent addition of deferring EFB copies broke the ingame photo
taking in this game. Instead of getting a photo of the actual frame you
pointed the camera at you get part of the camera stencil and some
glitched green graphics inside. (@stenzek)

Disabling deferred EFB copies works around that.

This is in the same vein as https://github.com/dolphin-emu/dolphin/pull/7549
In fact, the other pull request hinted me at trying to disable EFB copy deferral in the first place.