### PR TITLE
Jit_LoadStore: Ra needs to be ReadWrite when writeback is required

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -244,7 +244,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
     }
   }
 
-  RCX64Reg Ra = (update && storeAddress) ? gpr.Bind(a, RCMode::Write) : RCX64Reg{};
+  RCX64Reg Ra = (update && storeAddress) ? gpr.Bind(a, RCMode::ReadWrite) : RCX64Reg{};
   RegCache::Realize(opAddress, Ra, Rd);
 
   BitSet32 registersInUse = CallerSavedRegistersInUse();


### PR DESCRIPTION
This was an erronous change in 534db3b, `Ra` was previously loaded but was changed to not being loaded.

Why is loading necessary? Loading is necessary because when a memory exception occurs, the current register values are flushed. This occurs *before* a new value is loaded into `Ra`, so the previous value is required in `Ra`.

See also https://github.com/dolphin-emu/dolphin/pull/7492#issuecomment-437286421.