### PR TITLE
Tmem cache emulation option

### DIFF
--- a/Data/Sys/GameSettings/G5S.ini
+++ b/Data/Sys/GameSettings/G5S.ini
@@ -1,4 +1,4 @@
-# GM5E7D, GM5F7D, GM5P7D - Metal Arms: Glitch in the System
+# G5SE7D, G5SP7D - Spyro: A Hero's Tail
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,8 +12,5 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Hacks]
-TMEMCacheEmulation = False
+TMEMCacheEmulation = True

--- a/Data/Sys/GameSettings/GJU.ini
+++ b/Data/Sys/GameSettings/GJU.ini
@@ -1,0 +1,16 @@
+# GJUD78, GJUF78 - Tak and the Power of Juju
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+TMEMCacheEmulation = False

--- a/Data/Sys/GameSettings/GXE.ini
+++ b/Data/Sys/GameSettings/GXE.ini
@@ -1,0 +1,16 @@
+# GXEE8P, GXEJ8P, GXEP8P - Sonic Riders
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+TMEMCacheEmulation = False

--- a/Data/Sys/GameSettings/RS9.ini
+++ b/Data/Sys/GameSettings/RS9.ini
@@ -1,0 +1,16 @@
+# RS9E8P, RS9P8P - SONIC RIDERS ZERO GRAVITY
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+TMEMCacheEmulation = False

--- a/Data/Sys/GameSettings/SHY.ini
+++ b/Data/Sys/GameSettings/SHY.ini
@@ -1,4 +1,4 @@
-# GM5E7D, GM5F7D, GM5P7D - Metal Arms: Glitch in the System
+# SHYE69, SHYP69 - NHL Slapshot
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -11,9 +11,6 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
 TMEMCacheEmulation = False

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -328,6 +328,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-wait-for-shaders", g_Config.bWaitForShadersBeforeStarting);
   builder.AddData("cfg-gfx-fast-depth", g_Config.bFastDepthCalc);
   builder.AddData("cfg-gfx-vertex-rounding", g_Config.UseVertexRounding());
+  builder.AddData("cfg-gfx-tmem-cache-emulation", g_Config.bTMEMCacheEmulation);
 
   // GPU features.
   if (g_Config.iAdapter < static_cast<int>(g_Config.backend_info.Adapters.size()))

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -144,6 +144,8 @@ const ConfigInfo<bool> GFX_HACK_IMMEDIATE_XFB{{System::GFX, "Hacks", "ImmediateX
 const ConfigInfo<bool> GFX_HACK_COPY_EFB_SCALED{{System::GFX, "Hacks", "EFBScaledCopy"}, true};
 const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{
     {System::GFX, "Hacks", "EFBEmulateFormatChanges"}, false};
+const ConfigInfo<bool> GFX_HACK_TMEM_CACHE_EMULATION{{System::GFX, "Hacks", "TMEMCacheEmulation"},
+                                                     true};
 const ConfigInfo<bool> GFX_HACK_VERTEX_ROUDING{{System::GFX, "Hacks", "VertexRounding"}, false};
 
 // Graphics.GameSpecific

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -111,6 +111,7 @@ extern const ConfigInfo<bool> GFX_HACK_DEFER_EFB_COPIES;
 extern const ConfigInfo<bool> GFX_HACK_IMMEDIATE_XFB;
 extern const ConfigInfo<bool> GFX_HACK_COPY_EFB_SCALED;
 extern const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;
+extern const ConfigInfo<bool> GFX_HACK_TMEM_CACHE_EMULATION;
 extern const ConfigInfo<bool> GFX_HACK_VERTEX_ROUDING;
 
 // Graphics.GameSpecific

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -122,6 +122,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::GFX_HACK_IMMEDIATE_XFB.location,
       Config::GFX_HACK_COPY_EFB_SCALED.location,
       Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES.location,
+      Config::GFX_HACK_TMEM_CACHE_EMULATION.location,
       Config::GFX_HACK_VERTEX_ROUDING.location,
 
       // Graphics.GameSpecific

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -66,6 +66,8 @@ void HacksWidget::CreateWidgets()
   m_accuracy->setTickPosition(QSlider::TicksBelow);
   m_gpu_texture_decoding =
       new GraphicsBool(tr("GPU Texture Decoding"), Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
+  m_tmem_cache_emulation =
+      new GraphicsBool(tr("TMEM Cache Emulation"), Config::GFX_HACK_TMEM_CACHE_EMULATION);
 
   auto* safe_label = new QLabel(tr("Safe"));
   safe_label->setAlignment(Qt::AlignRight);
@@ -77,6 +79,7 @@ void HacksWidget::CreateWidgets()
   texture_cache_layout->addWidget(m_accuracy, 0, 2);
   texture_cache_layout->addWidget(new QLabel(tr("Fast")), 0, 3);
   texture_cache_layout->addWidget(m_gpu_texture_decoding, 1, 0);
+  texture_cache_layout->addWidget(m_tmem_cache_emulation, 2, 0);
 
   // XFB
   auto* xfb_box = new QGroupBox(tr("External Frame Buffer (XFB)"));
@@ -250,12 +253,17 @@ void HacksWidget::AddDescriptions()
       QT_TR_NOOP("Rounds 2D vertices to whole pixels. Fixes graphical problems in some games at "
                  "higher internal resolutions. This setting has no effect when native internal "
                  "resolution is used.\n\nIf unsure, leave this unchecked.");
+  static const char TR_TMEM_CACHE_EMULATION_DESCRIPTION[] = QT_TR_NOOP(
+      "Reuse textures from the cache without validation under certain conditions. Provides a "
+      "small performance boost in some games. Some graphical effects require this, but it causes "
+      "graphical defects in a number of games\n\nIf unsure, leave this checked.");
 
   AddDescription(m_skip_efb_cpu, TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION);
   AddDescription(m_ignore_format_changes, TR_IGNORE_FORMAT_CHANGE_DESCRIPTION);
   AddDescription(m_store_efb_copies, TR_STORE_EFB_TO_TEXTURE_DESCRIPTION);
   AddDescription(m_defer_efb_copies, TR_DEFER_EFB_COPIES_DESCRIPTION);
   AddDescription(m_accuracy, TR_ACCUARCY_DESCRIPTION);
+  AddDescription(m_tmem_cache_emulation, TR_TMEM_CACHE_EMULATION_DESCRIPTION);
   AddDescription(m_store_xfb_copies, TR_STORE_XFB_TO_TEXTURE_DESCRIPTION);
   AddDescription(m_immediate_xfb, TR_IMMEDIATE_XFB_DESCRIPTION);
   AddDescription(m_gpu_texture_decoding, TR_GPU_DECODING_DESCRIPTION);

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -33,6 +33,7 @@ private:
   QLabel* m_accuracy_label;
   QSlider* m_accuracy;
   QCheckBox* m_gpu_texture_decoding;
+  QCheckBox* m_tmem_cache_emulation;
 
   // External Framebuffer
   QCheckBox* m_store_xfb_copies;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -130,7 +130,8 @@ void TextureCacheBase::OnConfigChanged(VideoConfig& config)
       config.bHiresTextures != backup_config.hires_textures ||
       config.bEnableGPUTextureDecoding != backup_config.gpu_texture_decoding ||
       config.bDisableCopyToVRAM != backup_config.disable_vram_copies ||
-      config.bArbitraryMipmapDetection != backup_config.arbitrary_mipmap_detection)
+      config.bArbitraryMipmapDetection != backup_config.arbitrary_mipmap_detection ||
+      config.bTMEMCacheEmulation != backup_config.tmem_cache_emulation)
   {
     Invalidate();
 
@@ -235,6 +236,7 @@ void TextureCacheBase::SetBackupConfig(const VideoConfig& config)
   backup_config.gpu_texture_decoding = config.bEnableGPUTextureDecoding;
   backup_config.disable_vram_copies = config.bDisableCopyToVRAM;
   backup_config.arbitrary_mipmap_detection = config.bArbitraryMipmapDetection;
+  backup_config.tmem_cache_emulation = config.bTMEMCacheEmulation;
 }
 
 TextureCacheBase::TCacheEntry*
@@ -635,7 +637,7 @@ private:
 TextureCacheBase::TCacheEntry* TextureCacheBase::Load(const u32 stage)
 {
   // if this stage was not invalidated by changes to texture registers, keep the current texture
-  if (IsValidBindPoint(stage) && bound_textures[stage])
+  if (g_ActiveConfig.bTMEMCacheEmulation && IsValidBindPoint(stage) && bound_textures[stage])
   {
     return bound_textures[stage];
   }

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -384,6 +384,7 @@ private:
     bool gpu_texture_decoding;
     bool disable_vram_copies;
     bool arbitrary_mipmap_detection;
+    bool tmem_cache_emulation;
   };
   BackupConfig backup_config = {};
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -146,6 +146,7 @@ void VideoConfig::Refresh()
   bImmediateXFB = Config::Get(Config::GFX_HACK_IMMEDIATE_XFB);
   bCopyEFBScaled = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
+  bTMEMCacheEmulation = Config::Get(Config::GFX_HACK_TMEM_CACHE_EMULATION);
   bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
 
   bPerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -118,6 +118,7 @@ struct VideoConfig final
   bool bForceProgressive;
 
   bool bEFBEmulateFormatChanges;
+  bool bTMEMCacheEmulation;
   bool bSkipEFBCopyToRam;
   bool bSkipXFBCopyToRam;
   bool bDisableCopyToVRAM;


### PR DESCRIPTION
Patches issue #11164 https://bugs.dolphin-emu.org/issues/11164, which is a regression and was introduced in 5.0-4703 PR https://github.com/dolphin-emu/dolphin/pull/5726.

The pr just makes the tmem cache emulation optional and disables it for the games that are known to be broken with it. Ideally, it would be improved/repaired to work properly, but that's beyond by my skillset. An alternative would be to remove it completely, since the currently implemented tmem cache emulation is just a hack, but that would break some effects in Spyro: A Hero's Tail.

I have chosen to enable the option by default to avoid reports of reduced performance.

Also, i wanted to put the option in the GUI right under the texture cache slider, but couldn't figure out how to align it with the other 2nd column options.