### PR TITLE
[Debugger] Display memory tab contents while game is running

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -101,7 +101,8 @@ void MemoryViewWidget::Update()
     if (addr == m_address)
       addr_item->setSelected(true);
 
-    if (Core::GetState() != Core::State::Paused || !PowerPC::HostIsRAMAddress(addr))
+    if (Core::GetState() != Core::State::Paused && Core::GetState() != Core::State::Running ||
+        !PowerPC::HostIsRAMAddress(addr))
     {
       for (int c = 2; c < columnCount(); c++)
       {


### PR DESCRIPTION
Changes the condition to not display memory values when the core is !running && !paused, rather than just !paused. This caused the memory to never be updated while the game is running.