### PR TITLE
GCMemcard: Fix mixed memcard-based and bat-based indices in definition and usage of NextFreeBlock().

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -14,6 +14,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
+#include "Common/MathUtil.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
@@ -576,11 +577,14 @@ u16 BlockAlloc::GetNextBlock(u16 Block) const
   return Common::swap16(Map[Block - MC_FST_BLOCKS]);
 }
 
+// Parameters and return value are expected as memory card block index,
+// not BAT index; that is, block 5 is the first file data block.
 u16 BlockAlloc::NextFreeBlock(u16 MaxBlock, u16 StartingBlock) const
 {
   if (FreeBlocks)
   {
-    MaxBlock = std::min<u16>(MaxBlock, BAT_SIZE);
+    StartingBlock = MathUtil::Clamp<u16>(StartingBlock, MC_FST_BLOCKS, BAT_SIZE + MC_FST_BLOCKS);
+    MaxBlock = MathUtil::Clamp<u16>(MaxBlock, MC_FST_BLOCKS, BAT_SIZE + MC_FST_BLOCKS);
     for (u16 i = StartingBlock; i < MaxBlock; ++i)
       if (Map[i - MC_FST_BLOCKS] == 0)
         return i;
@@ -661,8 +665,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
   }
 
   // find first free data block
-  u16 firstBlock =
-      CurrentBat->NextFreeBlock(maxBlock - MC_FST_BLOCKS, BE16(CurrentBat->LastAllocated));
+  u16 firstBlock = CurrentBat->NextFreeBlock(maxBlock, BE16(CurrentBat->LastAllocated));
   if (firstBlock == 0xFFFF)
     return OUTOFBLOCKS;
   Directory UpdatedDir = *CurrentDir;
@@ -707,7 +710,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
     if (i == fileBlocks - 1)
       nextBlock = 0xFFFF;
     else
-      nextBlock = UpdatedBat.NextFreeBlock(maxBlock - MC_FST_BLOCKS, firstBlock + 1);
+      nextBlock = UpdatedBat.NextFreeBlock(maxBlock, firstBlock + 1);
     UpdatedBat.Map[firstBlock - MC_FST_BLOCKS] = BE16(nextBlock);
     UpdatedBat.LastAllocated = BE16(firstBlock);
     firstBlock = nextBlock;


### PR DESCRIPTION
Fixes the 'Fatal error' in the memory card manager on importing files that almost fill the entire remaining free space described here: https://forums.dolphin-emu.org/Thread-importing-gamecube-protected-save-fatal-error.

The function didn't quite agree with itself whether it wanted indices that are based on the whole memory card (where 0 is the Header block and 5 is the first file data block) or based on the BlockAlloc's Map member (where 0 would be the first data block). This should now be rectified.

As a sidenote, this code feels very old and I suspect there are other errors like these that aren't noticed during general usage. I've started a separate branch to update the code to more modern standards [over here](https://github.com/AdmiralCurtiss/dolphin/tree/memcard-cleanup), but that's still a bit work in progress.