### PR TITLE
GCMemcard: Fix incorrect directory block being accessed in RemoveFile().

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -739,8 +739,8 @@ u32 GCMemcard::RemoveFile(u8 index)  // index in the directory array
   if (index >= DIRLEN)
     return DELETE_FAIL;
 
-  u16 startingblock = BE16(dir.Dir[index].FirstBlock);
-  u16 numberofblocks = BE16(dir.Dir[index].BlockCount);
+  u16 startingblock = BE16(CurrentDir->Dir[index].FirstBlock);
+  u16 numberofblocks = BE16(CurrentDir->Dir[index].BlockCount);
 
   BlockAlloc UpdatedBat = *CurrentBat;
   if (!UpdatedBat.ClearBlocks(startingblock, numberofblocks))


### PR DESCRIPTION
When deleting files, block index data was always fetched from the first copy of the directory listing rather than the currently active one. This means that half the time deleting a file had the chance of using stale block indices.

For an example, try deleting the file from the attached memory card in current master.

[cant-delete-from.zip](https://github.com/dolphin-emu/dolphin/files/2601947/cant-delete-from.zip)