### PR TITLE
NetPlay: Sync Wiimote extension

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -498,6 +498,9 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
     {
       Wiimote::LoadConfig();
     }
+
+    if (NetPlay::IsNetPlayRunning())
+      NetPlay::SetupWiimotes();
   }
 
   Common::ScopeGuard controller_guard{[init_controllers] {

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -36,7 +36,7 @@ struct NetSettings
   bool m_ReducePollingRate;
   bool m_OCEnable;
   float m_OCFactor;
-  ExpansionInterface::TEXIDevices m_EXIDevice[2];
+  std::array<ExpansionInterface::TEXIDevices, 2> m_EXIDevice;
   bool m_EFBAccessEnable;
   bool m_BBoxEnable;
   bool m_ForceProgressive;
@@ -80,6 +80,7 @@ struct NetSettings
   bool m_SyncCodes;
   std::string m_SaveDataRegion;
   bool m_SyncAllWiiSaves;
+  std::array<int, 4> m_WiimoteExtension;
   bool m_IsHosting;
   bool m_HostInputAuthority;
 };
@@ -209,4 +210,5 @@ void ClearWiiSyncData();
 void SetSIPollBatching(bool state);
 void SendPowerButtonEvent();
 bool IsSyncingAllWiiSaves();
+void SetupWiimotes();
 }  // namespace NetPlay

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -42,12 +42,16 @@
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiiSave.h"
 #include "Core/HW/WiiSaveStructs.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
 #include "Core/NetPlayClient.h"  //for NetPlayUI
 #include "DiscIO/Enums.h"
+#include "InputCommon/ControllerEmu/ControlGroup/Extension.h"
 #include "InputCommon/GCPadStatus.h"
+#include "InputCommon/InputConfig.h"
 #include "UICommon/GameFile.h"
 
 #if !defined(_WIN32)
@@ -1159,8 +1163,10 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_OCEnable;
   spac << m_settings.m_OCFactor;
   spac << m_settings.m_ReducePollingRate;
-  spac << m_settings.m_EXIDevice[0];
-  spac << m_settings.m_EXIDevice[1];
+
+  for (auto& device : m_settings.m_EXIDevice)
+    spac << device;
+
   spac << m_settings.m_EFBAccessEnable;
   spac << m_settings.m_BBoxEnable;
   spac << m_settings.m_ForceProgressive;
@@ -1205,6 +1211,16 @@ bool NetPlayServer::StartGame()
   spac << region;
   spac << m_settings.m_SyncCodes;
   spac << m_settings.m_SyncAllWiiSaves;
+
+  for (int i = 0; i < m_settings.m_WiimoteExtension.size(); i++)
+  {
+    const int extension =
+        static_cast<ControllerEmu::Extension*>(
+            static_cast<WiimoteEmu::Wiimote*>(Wiimote::GetConfig()->GetController(i))
+                ->GetWiimoteGroup(WiimoteEmu::WiimoteGroup::Extension))
+            ->switch_extension;
+    spac << extension;
+  }
 
   SendAsyncToClients(std::move(spac));
 


### PR DESCRIPTION
Small addition of NetPlay code in Core.cpp was needed to set the extensions at the right time, as init would override them otherwise. This solution is more elegant than modifying the user's INI files on game start.