### PR TITLE
Qt/ControllersWindow: Fix incorrect enabled states of configure buttons

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -465,8 +465,12 @@ void ControllersWindow::LoadSettings()
   {
     const std::optional<int> gc_index = ToGCMenuIndex(SConfig::GetInstance().m_SIDevice[i]);
     if (gc_index)
+    {
       m_gc_controller_boxes[i]->setCurrentIndex(*gc_index);
+      m_gc_buttons[i]->setEnabled(*gc_index != 0 && *gc_index != 6);
+    }
     m_wiimote_boxes[i]->setCurrentIndex(g_wiimote_sources[i]);
+    m_wiimote_buttons[i]->setEnabled(g_wiimote_sources[i] != 0 && g_wiimote_sources[i] != 2);
   }
   m_wiimote_real_balance_board->setChecked(g_wiimote_sources[WIIMOTE_BALANCE_BOARD] ==
                                            WIIMOTE_SRC_REAL);


### PR DESCRIPTION
All configure buttons would be enabled, although no-op, upon initialization of the dialog. Changing a setting to cause a save would fix them.