### PR TITLE
Qt: Disable controller configuration while NetPlay is running

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -275,6 +275,8 @@ void MainWindow::InitCoreCallbacks()
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [=](Core::State state) {
     if (state == Core::State::Uninitialized)
       OnStopComplete();
+    if (state != Core::State::Uninitialized && NetPlay::IsNetPlayRunning() && m_controllers_window)
+      m_controllers_window->reject();
 
     if (state == Core::State::Running && m_fullscreen_requested)
     {

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -32,6 +32,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
 #include "Core/Movie.h"
+#include "Core/NetPlayProto.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PPCAnalyst.h"
@@ -105,6 +106,9 @@ void MenuBar::OnEmulationStateChanged(Core::State state)
   if (!running)
     m_recording_stop->setEnabled(false);
   m_recording_play->setEnabled(!running);
+
+  // Options
+  m_controllers_action->setEnabled(NetPlay::IsNetPlayRunning() ? !running : true);
 
   // Tools
   m_show_cheat_manager->setEnabled(Settings::Instance().GetCheatsEnabled() && running);
@@ -471,7 +475,8 @@ void MenuBar::AddOptionsMenu()
   options_menu->addSeparator();
   options_menu->addAction(tr("&Graphics Settings"), this, &MenuBar::ConfigureGraphics);
   options_menu->addAction(tr("&Audio Settings"), this, &MenuBar::ConfigureAudio);
-  options_menu->addAction(tr("&Controller Settings"), this, &MenuBar::ConfigureControllers);
+  m_controllers_action =
+      options_menu->addAction(tr("&Controller Settings"), this, &MenuBar::ConfigureControllers);
   options_menu->addAction(tr("&Hotkey Settings"), this, &MenuBar::ConfigureHotkeys);
 
   options_menu->addSeparator();

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -215,6 +215,7 @@ private:
   QAction* m_boot_to_pause;
   QAction* m_automatic_start;
   QAction* m_change_font;
+  QAction* m_controllers_action;
 
   // View
   QAction* m_show_code;

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -8,6 +8,7 @@
 #include <QIcon>
 
 #include "Core/Core.h"
+#include "Core/NetPlayProto.h"
 #include "DolphinQt/Host.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -54,6 +55,7 @@ void ToolBar::OnEmulationStateChanged(Core::State state)
   m_stop_action->setEnabled(running);
   m_fullscreen_action->setEnabled(running);
   m_screenshot_action->setEnabled(running);
+  m_controllers_action->setEnabled(NetPlay::IsNetPlayRunning() ? !running : true);
 
   bool playing = running && state != Core::State::Paused;
   UpdatePausePlayButtonState(playing);


### PR DESCRIPTION
Doing pretty much anything in the controller config breaks NetPlay (desync and/or deadlock), as saving the settings reconfigures controller interfaces, which NetPlay doesn't expect.