### PR TITLE
Qt/ControllersWindow: Fix Wiimote settings not being re-enabled after quitting NetPlay

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -373,7 +373,7 @@ void ControllersWindow::OnWiimoteRefreshPressed()
 
 void ControllersWindow::OnEmulationStateChanged(bool running)
 {
-  if (!SConfig::GetInstance().bWii || NetPlay::IsNetPlayRunning())
+  if (!SConfig::GetInstance().bWii)
   {
     m_wiimote_sync->setEnabled(!running);
     m_wiimote_reset->setEnabled(!running);


### PR DESCRIPTION
We no longer allow accessing controller config while NetPlay is running, so this check is no longer needed.