### PR TITLE
Mapping: Fix multi-device input detection

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -39,9 +39,10 @@ QString GetExpressionForControl(const QString& control_name,
 }
 
 QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
-                         const ciface::Core::DeviceQualifier& default_device, Quote quote)
+                         const ciface::Core::DeviceQualifier& default_device, Quote quote,
+                         const unsigned int timeout)
 {
-  ciface::Core::Device::Control* const ctrl = reference->Detect(5000, device);
+  ciface::Core::Device::Control* const ctrl = reference->Detect(timeout, device);
 
   if (ctrl)
   {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
@@ -30,5 +30,5 @@ QString GetExpressionForControl(const QString& control_name,
                                 Quote quote = Quote::On);
 QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
                          const ciface::Core::DeviceQualifier& default_device,
-                         Quote quote = Quote::On);
+                         Quote quote = Quote::On, const unsigned int timeout = 5000);
 }  // namespace MappingCommon

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -237,6 +237,7 @@ void MappingWindow::OnDeviceChanged(int index)
 
   const auto device = m_devices_combo->currentText().toStdString();
   m_controller->SetDefaultDevice(device);
+  m_config->SaveConfig();
 }
 
 bool MappingWindow::IsMappingAllDevices() const


### PR DESCRIPTION
While investigating issue 11463, I found some issues with the input mapping, in particular around the use of the "All Devices" option. This did not work well at all previously, either stalling for 5 seconds until it timed out (as all futures had to wait), and the code just generally seemed hackish. I've replaced it with a non-threaded method, which is still a little hacky, but frankly the more I look into the input code, the more I'm surprised it actually works..

Not sure if this fixes the issue, I can't seem to reproduce it anymore.