### PR TITLE
VideoBackends: Share GX vertex/index/uniform buffers with utility draws

### DIFF
--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -20,7 +20,8 @@ public:
   static ID3D11GeometryShader* GetClearGeometryShader();
   static ID3D11GeometryShader* GetCopyGeometryShader();
 
-  static ID3D11Buffer*& GetConstantBuffer();
+  static ID3D11Buffer* GetConstantBuffer();
+  static void UpdateConstantBuffer(const void* data, u32 data_size);
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -4,7 +4,6 @@
 
 #include <string>
 
-#include "Common/Align.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
@@ -20,8 +19,6 @@
 
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/PixelShaderGen.h"
-#include "VideoCommon/PixelShaderManager.h"
-#include "VideoCommon/Statistics.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX11
@@ -32,7 +29,6 @@ ID3D11PixelShader* s_AnaglyphProgram = nullptr;
 ID3D11PixelShader* s_DepthResolveProgram = nullptr;
 ID3D11PixelShader* s_rgba6_to_rgb8[2] = {nullptr};
 ID3D11PixelShader* s_rgb8_to_rgba6[2] = {nullptr};
-ID3D11Buffer* pscbuf = nullptr;
 
 const char clear_program_code[] = {"void main(\n"
                                    "out float4 ocol0 : SV_Target,\n"
@@ -277,36 +273,8 @@ ID3D11PixelShader* PixelShaderCache::GetDepthResolveProgram()
   return s_DepthResolveProgram;
 }
 
-static void UpdateConstantBuffers()
-{
-  if (PixelShaderManager::dirty)
-  {
-    D3D11_MAPPED_SUBRESOURCE map;
-    D3D::context->Map(pscbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
-    memcpy(map.pData, &PixelShaderManager::constants, sizeof(PixelShaderConstants));
-    D3D::context->Unmap(pscbuf, 0);
-    PixelShaderManager::dirty = false;
-
-    ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(PixelShaderConstants));
-  }
-}
-
-ID3D11Buffer* PixelShaderCache::GetConstantBuffer()
-{
-  UpdateConstantBuffers();
-  return pscbuf;
-}
-
 void PixelShaderCache::Init()
 {
-  unsigned int cbsize = Common::AlignUp(static_cast<unsigned int>(sizeof(PixelShaderConstants)),
-                                        16);  // must be a multiple of 16
-  D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(cbsize, D3D11_BIND_CONSTANT_BUFFER,
-                                                D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-  D3D::device->CreateBuffer(&cbdesc, nullptr, &pscbuf);
-  CHECK(pscbuf != nullptr, "Create pixel shader constant buffer");
-  D3D::SetDebugObjectName(pscbuf, "pixel shader constant buffer used to emulate the GX pipeline");
-
   // used when drawing clear quads
   s_ClearProgram = D3D::CompileAndCreatePixelShader(clear_program_code);
   CHECK(s_ClearProgram != nullptr, "Create clear pixel shader");
@@ -334,8 +302,6 @@ void PixelShaderCache::InvalidateMSAAShaders()
 
 void PixelShaderCache::Shutdown()
 {
-  SAFE_RELEASE(pscbuf);
-
   SAFE_RELEASE(s_ClearProgram);
   SAFE_RELEASE(s_AnaglyphProgram);
   SAFE_RELEASE(s_DepthResolveProgram);

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -21,8 +21,6 @@ public:
   static void Init();
   static void Shutdown();
 
-  static ID3D11Buffer* GetConstantBuffer();
-
   static ID3D11PixelShader* GetColorCopyProgram(bool multisampled);
   static ID3D11PixelShader* GetClearProgram();
   static ID3D11PixelShader* GetAnaglyphProgram();

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -549,10 +549,12 @@ void Renderer::SetViewport(float x, float y, float width, float height, float ne
 {
   // In D3D, the viewport rectangle must fit within the render target.
   D3D11_VIEWPORT vp;
-  vp.TopLeftX = MathUtil::Clamp(x, 0.0f, static_cast<float>(m_target_width - 1));
-  vp.TopLeftY = MathUtil::Clamp(y, 0.0f, static_cast<float>(m_target_height - 1));
-  vp.Width = MathUtil::Clamp(width, 1.0f, static_cast<float>(m_target_width) - vp.TopLeftX);
-  vp.Height = MathUtil::Clamp(height, 1.0f, static_cast<float>(m_target_height) - vp.TopLeftY);
+  vp.TopLeftX = MathUtil::Clamp(x, 0.0f, static_cast<float>(m_current_framebuffer_width - 1));
+  vp.TopLeftY = MathUtil::Clamp(y, 0.0f, static_cast<float>(m_current_framebuffer_height - 1));
+  vp.Width =
+      MathUtil::Clamp(width, 1.0f, static_cast<float>(m_current_framebuffer_width) - vp.TopLeftX);
+  vp.Height =
+      MathUtil::Clamp(height, 1.0f, static_cast<float>(m_current_framebuffer_height) - vp.TopLeftY);
   vp.MinDepth = near_depth;
   vp.MaxDepth = far_depth;
   D3D::context->RSSetViewports(1, &vp);

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -63,7 +63,7 @@ typedef struct _Nv_Stereo_Image_Header
 #define NVSTEREO_IMAGE_SIGNATURE 0x4433564e
 
 Renderer::Renderer(int backbuffer_width, int backbuffer_height)
-    : ::Renderer(backbuffer_width, backbuffer_height)
+    : ::Renderer(backbuffer_width, backbuffer_height, AbstractTextureFormat::RGBA8)
 {
   m_last_multisamples = g_ActiveConfig.iMultisamples;
   m_last_stereo_mode = g_ActiveConfig.stereo_mode != StereoMode::Off;

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -50,6 +50,8 @@ public:
   void SetInterlacingMode() override;
   void SetViewport(float x, float y, float width, float height, float near_depth,
                    float far_depth) override;
+  void Draw(u32 base_vertex, u32 num_vertices) override;
+  void DrawIndexed(u32 base_index, u32 num_indices, u32 base_vertex) override;
   void SetFullscreen(bool enable_fullscreen) override;
   bool IsFullscreen() const override;
 
@@ -73,11 +75,6 @@ public:
 
   void ReinterpretPixelData(unsigned int convtype) override;
 
-  void DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, const void* vertices,
-                           u32 vertex_stride, u32 num_vertices) override;
-  void DispatchComputeShader(const AbstractShader* shader, const void* uniforms, u32 uniforms_size,
-                             u32 groups_x, u32 groups_y, u32 groups_z) override;
-
 private:
   void SetupDeviceObjects();
   void TeardownDeviceObjects();
@@ -89,9 +86,6 @@ private:
   void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
                   u32 src_width, u32 src_height);
 
-  void UpdateUtilityUniformBuffer(const void* uniforms, u32 uniforms_size);
-  void UpdateUtilityVertexBuffer(const void* vertices, u32 vertex_stride, u32 num_vertices);
-
   StateCache m_state_cache;
 
   std::array<ID3D11BlendState*, 4> m_clear_blend_states{};
@@ -102,9 +96,6 @@ private:
 
   ID3D11Texture2D* m_screenshot_texture = nullptr;
   D3DTexture2D* m_3d_vision_texture = nullptr;
-
-  ID3D11Buffer* m_utility_vertex_buffer = nullptr;
-  ID3D11Buffer* m_utility_uniform_buffer = nullptr;
 
   u32 m_last_multisamples = 1;
   bool m_last_stereo_mode = false;

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -42,32 +42,32 @@ public:
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 
-  void CreateDeviceObjects() override;
-  void DestroyDeviceObjects() override;
+  void UploadUtilityUniforms(const void* uniforms, u32 uniforms_size) override;
 
 protected:
-  void ResetBuffer(u32 stride) override;
-  u16* GetIndexBuffer() { return &LocalIBuffer[0]; }
+  void CreateDeviceObjects() override;
+  void DestroyDeviceObjects() override;
+  void ResetBuffer(u32 vertex_stride, bool cull_all) override;
+  void CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices, u32* out_base_vertex,
+                    u32* out_base_index) override;
+  void UploadConstants() override;
+  void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
 private:
-  void PrepareDrawBuffers(u32 stride);
-  void Draw(u32 stride);
-  // temp
-  void vFlush() override;
-
-  u32 m_vertexDrawOffset;
-  u32 m_indexDrawOffset;
-  u32 m_currentBuffer;
-  u32 m_bufferCursor;
-
   enum
   {
     MAX_BUFFER_COUNT = 2
   };
-  ID3D11Buffer* m_buffers[MAX_BUFFER_COUNT];
+  ID3D11Buffer* m_buffers[MAX_BUFFER_COUNT] = {};
+  u32 m_current_buffer = 0;
+  u32 m_buffer_cursor = 0;
 
-  std::vector<u8> LocalVBuffer;
-  std::vector<u16> LocalIBuffer;
+  std::vector<u8> m_staging_vertex_buffer;
+  std::vector<u16> m_staging_index_buffer;
+
+  ID3D11Buffer* m_vertex_constant_buffer = nullptr;
+  ID3D11Buffer* m_geometry_constant_buffer = nullptr;
+  ID3D11Buffer* m_pixel_constant_buffer = nullptr;
 };
 
-}  // namespace
+}  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -23,8 +23,6 @@ public:
   static void Init();
   static void Shutdown();
 
-  static ID3D11Buffer*& GetConstantBuffer();
-
   static ID3D11VertexShader* GetSimpleVertexShader();
   static ID3D11VertexShader* GetClearVertexShader();
   static ID3D11InputLayout* GetSimpleInputLayout();

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -161,7 +161,8 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
 
   D3D::InitUtils();
   BBox::Init();
-  return true;
+
+  return g_renderer->Initialize();
 }
 
 void VideoBackend::Shutdown()

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -64,7 +64,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   g_framebuffer_manager = std::make_unique<FramebufferManagerBase>();
   g_texture_cache = std::make_unique<TextureCache>();
   g_shader_cache = std::make_unique<VideoCommon::ShaderCache>();
-  return g_shader_cache->Initialize();
+  return g_renderer->Initialize() && g_shader_cache->Initialize();
 }
 
 void VideoBackend::Shutdown()

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -14,7 +14,7 @@
 namespace Null
 {
 // Init functions
-Renderer::Renderer() : ::Renderer(1, 1)
+Renderer::Renderer() : ::Renderer(1, 1, AbstractTextureFormat::RGBA8)
 {
   UpdateActiveConfig();
 }

--- a/Source/Core/VideoBackends/Null/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Null/VertexManager.cpp
@@ -22,6 +22,10 @@ VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_dec
   return std::make_unique<NullNativeVertexFormat>(vtx_decl);
 }
 
+void VertexManager::UploadUtilityUniforms(const void* uniforms, u32 uniforms_size)
+{
+}
+
 VertexManager::VertexManager() : m_local_v_buffer(MAXVBUFFERSIZE), m_local_i_buffer(MAXIBUFFERSIZE)
 {
 }
@@ -30,15 +34,24 @@ VertexManager::~VertexManager()
 {
 }
 
-void VertexManager::ResetBuffer(u32 stride)
+void VertexManager::ResetBuffer(u32 vertex_stride, bool cull_all)
 {
   m_cur_buffer_pointer = m_base_buffer_pointer = m_local_v_buffer.data();
   m_end_buffer_pointer = m_cur_buffer_pointer + m_local_v_buffer.size();
   IndexGenerator::Start(&m_local_i_buffer[0]);
 }
 
-void VertexManager::vFlush()
+void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,
+                                 u32* out_base_vertex, u32* out_base_index)
 {
 }
 
-}  // namespace
+void VertexManager::UploadConstants()
+{
+}
+
+void VertexManager::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex)
+{
+}
+
+}  // namespace Null

--- a/Source/Core/VideoBackends/Null/VertexManager.h
+++ b/Source/Core/VideoBackends/Null/VertexManager.h
@@ -20,11 +20,16 @@ public:
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 
+  void UploadUtilityUniforms(const void* uniforms, u32 uniforms_size) override;
+
 protected:
-  void ResetBuffer(u32 stride) override;
+  void ResetBuffer(u32 vertex_stride, bool cull_all) override;
+  void CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices, u32* out_base_vertex,
+                    u32* out_base_index) override;
+  void UploadConstants() override;
+  void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
 private:
-  void vFlush() override;
   std::vector<u8> m_local_v_buffer;
   std::vector<u16> m_local_i_buffer;
 };

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -69,6 +69,7 @@ class ProgramShaderCache
 {
 public:
   static void BindVertexFormat(const GLVertexFormat* vertex_format);
+  static bool IsValidVertexFormatBound();
   static void InvalidateVertexFormat();
   static void InvalidateLastProgram();
 
@@ -83,6 +84,7 @@ public:
   static u32 GetUniformBufferAlignment();
   static void InvalidateConstants();
   static void UploadConstants();
+  static void UploadConstants(const void* data, u32 data_size);
 
   static void Init();
   static void Shutdown();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -811,6 +811,23 @@ bool Renderer::IsHeadless() const
   return m_main_gl_context->IsHeadless();
 }
 
+bool Renderer::Initialize()
+{
+  if (!::Renderer::Initialize())
+    return false;
+
+  // Initialize the FramebufferManager
+  g_framebuffer_manager = std::make_unique<FramebufferManager>(
+      m_target_width, m_target_height, s_MSAASamples, BoundingBox::NeedsStencilBuffer());
+  m_current_framebuffer_width = m_target_width;
+  m_current_framebuffer_height = m_target_height;
+
+  m_post_processor = std::make_unique<OpenGLPostProcessing>();
+  s_raster_font = std::make_unique<RasterFont>();
+
+  return true;
+}
+
 void Renderer::Shutdown()
 {
   ::Renderer::Shutdown();
@@ -820,18 +837,6 @@ void Renderer::Shutdown()
 
   s_raster_font.reset();
   m_post_processor.reset();
-}
-
-void Renderer::Init()
-{
-  // Initialize the FramebufferManager
-  g_framebuffer_manager = std::make_unique<FramebufferManager>(
-      m_target_width, m_target_height, s_MSAASamples, BoundingBox::NeedsStencilBuffer());
-  m_current_framebuffer_width = m_target_width;
-  m_current_framebuffer_height = m_target_height;
-
-  m_post_processor = std::make_unique<OpenGLPostProcessing>();
-  s_raster_font = std::make_unique<RasterFont>();
 }
 
 std::unique_ptr<AbstractTexture> Renderer::CreateTexture(const TextureConfig& config)

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -355,7 +355,8 @@ static void InitDriverInfo()
 // Init functions
 Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context)
     : ::Renderer(static_cast<int>(std::max(main_gl_context->GetBackBufferWidth(), 1u)),
-                 static_cast<int>(std::max(main_gl_context->GetBackBufferHeight(), 1u))),
+                 static_cast<int>(std::max(main_gl_context->GetBackBufferHeight(), 1u)),
+                 AbstractTextureFormat::RGBA8),
       m_main_gl_context(std::move(main_gl_context))
 {
   bool bSuccess = true;

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -116,6 +116,8 @@ public:
   void SetInterlacingMode() override;
   void SetViewport(float x, float y, float width, float height, float near_depth,
                    float far_depth) override;
+  void Draw(u32 base_vertex, u32 num_vertices) override;
+  void DrawIndexed(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
   void RenderText(const std::string& text, int left, int top, u32 color) override;
 
@@ -137,17 +139,13 @@ public:
 
   void ReinterpretPixelData(unsigned int convtype) override;
 
-  void DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, const void* vertices,
-                           u32 vertex_stride, u32 num_vertices) override;
-
-  void DispatchComputeShader(const AbstractShader* shader, const void* uniforms, u32 uniforms_size,
-                             u32 groups_x, u32 groups_y, u32 groups_z) override;
-
   std::unique_ptr<VideoCommon::AsyncShaderCompiler> CreateAsyncShaderCompiler() override;
 
   // Only call methods from this on the GPU thread.
   GLContext* GetMainGLContext() const { return m_main_gl_context.get(); }
   bool IsGLES() const { return m_main_gl_context->IsGLES(); }
+
+  const OGLPipeline* GetCurrentGraphicsPipeline() const { return m_graphics_pipeline; }
 
 private:
   void UpdateEFBCache(EFBAccessType type, u32 cacheRectIdx, const EFBRectangle& efbPixelRc,
@@ -165,7 +163,6 @@ private:
   void ApplyBlendingState(const BlendingState state, bool force = false);
   void ApplyRasterizationState(const RasterizationState state, bool force = false);
   void ApplyDepthState(const DepthState state, bool force = false);
-  void UploadUtilityUniforms(const void* uniforms, u32 uniforms_size);
 
   std::unique_ptr<GLContext> m_main_gl_context;
   std::array<const AbstractTexture*, 8> m_bound_textures{};

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -88,7 +88,7 @@ public:
 
   bool IsHeadless() const override;
 
-  void Init();
+  bool Initialize() override;
   void Shutdown() override;
 
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;

--- a/Source/Core/VideoBackends/OGL/StreamBuffer.h
+++ b/Source/Core/VideoBackends/OGL/StreamBuffer.h
@@ -19,6 +19,8 @@ public:
   static std::unique_ptr<StreamBuffer> Create(u32 type, u32 size);
   virtual ~StreamBuffer();
 
+  u32 GetCurrentOffset() const { return m_iterator; }
+
   /* This mapping function will return a pair of:
    * - the pointer to the mapped buffer
    * - the offset into the real GPU buffer (always multiple of stride)

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -35,27 +35,26 @@ public:
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 
-  void CreateDeviceObjects() override;
-  void DestroyDeviceObjects() override;
+  void UploadUtilityUniforms(const void* uniforms, u32 uniforms_size) override;
 
-  StreamBuffer* GetVertexBuffer() const;
-  StreamBuffer* GetIndexBuffer() const;
   GLuint GetVertexBufferHandle() const;
   GLuint GetIndexBufferHandle() const;
 
 protected:
-  void ResetBuffer(u32 stride) override;
+  void CreateDeviceObjects() override;
+  void DestroyDeviceObjects() override;
+  void ResetBuffer(u32 vertex_stride, bool cull_all) override;
+  void CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices, u32* out_base_vertex,
+                    u32* out_base_index) override;
+  void UploadConstants() override;
+  void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
 private:
-  void Draw(u32 stride);
-  void vFlush() override;
-  void PrepareDrawBuffers(u32 stride);
-
-  GLuint m_vertex_buffers;
-  GLuint m_index_buffers;
+  std::unique_ptr<StreamBuffer> m_vertex_buffer;
+  std::unique_ptr<StreamBuffer> m_index_buffer;
 
   // Alternative buffers in CPU memory for primatives we are going to discard.
   std::vector<u8> m_cpu_v_buffer;
   std::vector<u16> m_cpu_i_buffer;
 };
-}
+}  // namespace OGL

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -179,7 +179,8 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   g_texture_cache = std::make_unique<TextureCache>();
   g_sampler_cache = std::make_unique<SamplerCache>();
   g_shader_cache = std::make_unique<VideoCommon::ShaderCache>();
-  static_cast<Renderer*>(g_renderer.get())->Init();
+  if (!g_renderer->Initialize())
+    return false;
   TextureConverter::Init();
   BoundingBox::Init(g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
   return g_shader_cache->Initialize();

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -25,7 +25,8 @@
 #include "VideoCommon/VideoConfig.h"
 
 SWRenderer::SWRenderer(std::unique_ptr<SWOGLWindow> window)
-    : ::Renderer(static_cast<int>(MAX_XFB_WIDTH), static_cast<int>(MAX_XFB_HEIGHT)),
+    : ::Renderer(static_cast<int>(MAX_XFB_WIDTH), static_cast<int>(MAX_XFB_HEIGHT),
+                 AbstractTextureFormat::RGBA8),
       m_window(std::move(window))
 {
 }

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -48,14 +48,29 @@ SWVertexLoader::~SWVertexLoader()
 {
 }
 
-void SWVertexLoader::ResetBuffer(u32 stride)
+void SWVertexLoader::UploadUtilityUniforms(const void* uniforms, u32 uniforms_size)
+{
+}
+
+void SWVertexLoader::ResetBuffer(u32 vertex_stride, bool cull_all)
 {
   m_cur_buffer_pointer = m_base_buffer_pointer = m_local_vertex_buffer.data();
   m_end_buffer_pointer = m_cur_buffer_pointer + m_local_vertex_buffer.size();
   IndexGenerator::Start(m_local_index_buffer.data());
 }
 
-void SWVertexLoader::vFlush()
+void SWVertexLoader::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,
+                                  u32* out_base_vertex, u32* out_base_index)
+{
+  *out_base_vertex = 0;
+  *out_base_index = 0;
+}
+
+void SWVertexLoader::UploadConstants()
+{
+}
+
+void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex)
 {
   DebugUtil::OnObjectBegin();
 

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -23,9 +23,14 @@ public:
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vdec) override;
 
-private:
-  void ResetBuffer(u32 stride) override;
-  void vFlush() override;
+  void UploadUtilityUniforms(const void* uniforms, u32 uniforms_size) override;
+
+protected:
+  void ResetBuffer(u32 vertex_stride, bool cull_all) override;
+  void CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices, u32* out_base_vertex,
+                    u32* out_base_index) override;
+  void UploadConstants() override;
+  void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
   void SetFormat(u8 attributeIndex, u8 primitiveType);
   void ParseVertex(const PortableVertexDeclaration& vdec, int index);

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -95,7 +95,7 @@ bool VideoSoftware::Initialize(const WindowSystemInfo& wsi)
   g_perf_query = std::make_unique<PerfQuery>();
   g_texture_cache = std::make_unique<TextureCache>();
   g_shader_cache = std::make_unique<VideoCommon::ShaderCache>();
-  return g_shader_cache->Initialize();
+  return g_renderer->Initialize() && g_shader_cache->Initialize();
 }
 
 void VideoSoftware::Shutdown()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -857,7 +857,6 @@ void Renderer::DrawScreen(VKTexture* xfb_texture, const EFBRectangle& xfb_region
 
   // End drawing to backbuffer
   StateTracker::GetInstance()->EndRenderPass();
-  BindEFBToStateTracker();
 
   // Transition the backbuffer to PRESENT_SRC to ensure all commands drawing
   // to it have finished before present.
@@ -1047,6 +1046,8 @@ void Renderer::RestoreAPIState()
     static_cast<const VKFramebuffer*>(m_current_framebuffer)->TransitionForSample();
 
   BindEFBToStateTracker();
+  BPFunctions::SetViewport();
+  BPFunctions::SetScissor();
 
   // Instruct the state tracker to re-bind everything before the next draw
   StateTracker::GetInstance()->SetPendingRebind();

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -57,13 +57,7 @@ Renderer::Renderer(std::unique_ptr<SwapChain> swap_chain)
     m_sampler_states[i].hex = RenderState::GetPointSamplerState().hex;
 }
 
-Renderer::~Renderer()
-{
-  UpdateActiveConfig();
-
-  DestroyShaders();
-  DestroySemaphores();
-}
+Renderer::~Renderer() = default;
 
 Renderer* Renderer::GetInstance()
 {
@@ -77,6 +71,9 @@ bool Renderer::IsHeadless() const
 
 bool Renderer::Initialize()
 {
+  if (!::Renderer::Initialize())
+    return false;
+
   BindEFBToStateTracker();
 
   if (!CreateSemaphores())
@@ -129,6 +126,18 @@ bool Renderer::Initialize()
   BeginFrame();
 
   return true;
+}
+
+void Renderer::Shutdown()
+{
+  ::Renderer::Shutdown();
+
+  // Submit the current command buffer, in case there's a partial frame.
+  StateTracker::GetInstance()->EndRenderPass();
+  g_command_buffer_mgr->ExecuteCommandBuffer(false, true);
+
+  DestroyShaders();
+  DestroySemaphores();
 }
 
 bool Renderer::CreateSemaphores()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -259,158 +259,6 @@ void Renderer::SetPipeline(const AbstractPipeline* pipeline)
   StateTracker::GetInstance()->SetPipeline(static_cast<const VKPipeline*>(pipeline));
 }
 
-void Renderer::DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, const void* vertices,
-                                   u32 vertex_stride, u32 num_vertices)
-{
-  // Binding the utility pipeline layout breaks the standard layout.
-  StateTracker::GetInstance()->SetPendingRebind();
-
-  // Upload uniforms.
-  VkBuffer uniform_buffer = g_object_cache->GetUtilityShaderUniformBuffer()->GetBuffer();
-  u32 uniform_buffer_offset = 0;
-  if (uniforms_size > 0)
-    std::tie(uniform_buffer, uniform_buffer_offset) =
-        UpdateUtilityUniformBuffer(uniforms, uniforms_size);
-
-  // Upload vertices.
-  VkBuffer vertex_buffer = VK_NULL_HANDLE;
-  VkDeviceSize vertex_buffer_offset = 0;
-  if (vertices)
-  {
-    u32 vertices_size = vertex_stride * num_vertices;
-    StreamBuffer* vbo_buf = g_object_cache->GetUtilityShaderVertexBuffer();
-    if (!vbo_buf->ReserveMemory(vertices_size, vertex_stride))
-    {
-      Util::ExecuteCurrentCommandsAndRestoreState(true);
-      if (!vbo_buf->ReserveMemory(vertices_size, vertex_stride))
-      {
-        PanicAlert("Failed to reserve vertex buffer space for utility draw.");
-        return;
-      }
-    }
-
-    vertex_buffer = vbo_buf->GetBuffer();
-    vertex_buffer_offset = vbo_buf->GetCurrentOffset();
-    std::memcpy(vbo_buf->GetCurrentHostPointer(), vertices, vertices_size);
-    vbo_buf->CommitMemory(vertices_size);
-  }
-
-  // Allocate descriptor sets.
-  std::array<VkDescriptorSet, 2> dsets;
-  dsets[0] = g_command_buffer_mgr->AllocateDescriptorSet(
-      g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_SINGLE_UNIFORM_BUFFER));
-  dsets[1] = g_command_buffer_mgr->AllocateDescriptorSet(
-      g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_PIXEL_SHADER_SAMPLERS));
-
-  // Flush first if failed.
-  if (dsets[0] == VK_NULL_HANDLE || dsets[1] == VK_NULL_HANDLE)
-  {
-    Util::ExecuteCurrentCommandsAndRestoreState(true);
-    dsets[0] = g_command_buffer_mgr->AllocateDescriptorSet(
-        g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_SINGLE_UNIFORM_BUFFER));
-    dsets[1] = g_command_buffer_mgr->AllocateDescriptorSet(
-        g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_PIXEL_SHADER_SAMPLERS));
-
-    if (dsets[0] == VK_NULL_HANDLE || dsets[1] == VK_NULL_HANDLE)
-    {
-      PanicAlert("Failed to allocate descriptor sets in utility draw.");
-      return;
-    }
-  }
-
-  // Build UBO descriptor set.
-  std::array<VkWriteDescriptorSet, 2> dswrites;
-  VkDescriptorBufferInfo dsbuffer = {uniform_buffer, 0, std::max(uniforms_size, 4u)};
-  dswrites[0] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,    nullptr, dsets[0],  0,      0, 1,
-                 VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, nullptr, &dsbuffer, nullptr};
-  dswrites[1] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-                 nullptr,
-                 dsets[1],
-                 0,
-                 0,
-                 NUM_PIXEL_SHADER_SAMPLERS,
-                 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                 StateTracker::GetInstance()->GetPSSamplerBindings().data(),
-                 nullptr,
-                 nullptr};
-
-  // Build commands.
-  VkCommandBuffer command_buffer = g_command_buffer_mgr->GetCurrentCommandBuffer();
-  vkCmdBindPipeline(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                    StateTracker::GetInstance()->GetPipeline()->GetVkPipeline());
-  if (vertex_buffer != VK_NULL_HANDLE)
-    vkCmdBindVertexBuffers(command_buffer, 0, 1, &vertex_buffer, &vertex_buffer_offset);
-
-  // Update and bind descriptors.
-  VkPipelineLayout pipeline_layout = g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_UTILITY);
-  vkUpdateDescriptorSets(g_vulkan_context->GetDevice(), static_cast<u32>(dswrites.size()),
-                         dswrites.data(), 0, nullptr);
-  vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0,
-                          static_cast<u32>(dsets.size()), dsets.data(), 1, &uniform_buffer_offset);
-
-  // Ensure we're in a render pass before drawing, just in case we had to flush.
-  StateTracker::GetInstance()->BeginRenderPass();
-  vkCmdDraw(command_buffer, num_vertices, 1, 0, 0);
-}
-
-void Renderer::DispatchComputeShader(const AbstractShader* shader, const void* uniforms,
-                                     u32 uniforms_size, u32 groups_x, u32 groups_y, u32 groups_z)
-{
-  // Binding the utility pipeline layout breaks the standard layout.
-  StateTracker::GetInstance()->SetPendingRebind();
-  StateTracker::GetInstance()->EndRenderPass();
-
-  // Upload uniforms.
-  VkBuffer uniform_buffer = g_object_cache->GetUtilityShaderUniformBuffer()->GetBuffer();
-  u32 uniform_buffer_offset = 0;
-  if (uniforms_size > 0)
-    std::tie(uniform_buffer, uniform_buffer_offset) =
-        UpdateUtilityUniformBuffer(uniforms, uniforms_size);
-
-  // Flush first if failed.
-  VkDescriptorSet dset = g_command_buffer_mgr->AllocateDescriptorSet(
-      g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_COMPUTE));
-  if (dset == VK_NULL_HANDLE)
-  {
-    Util::ExecuteCurrentCommandsAndRestoreState(true);
-    dset = g_command_buffer_mgr->AllocateDescriptorSet(
-        g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_COMPUTE));
-    if (dset == VK_NULL_HANDLE)
-    {
-      PanicAlert("Failed to allocate descriptor sets in utility dispatch.");
-      return;
-    }
-  }
-
-  std::array<VkWriteDescriptorSet, 2> dswrites;
-  VkDescriptorBufferInfo dsbuffer = {uniform_buffer, 0, std::max(uniforms_size, 4u)};
-  dswrites[0] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,    nullptr, dset,      0,      0, 1,
-                 VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, nullptr, &dsbuffer, nullptr};
-  dswrites[1] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-                 nullptr,
-                 dset,
-                 1,
-                 0,
-                 NUM_PIXEL_SHADER_SAMPLERS,
-                 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                 StateTracker::GetInstance()->GetPSSamplerBindings().data(),
-                 nullptr,
-                 nullptr};
-
-  // TODO: Texel buffers, storage images.
-
-  // Build commands.
-  VkCommandBuffer command_buffer = g_command_buffer_mgr->GetCurrentCommandBuffer();
-  VkPipelineLayout pipeline_layout = g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_UTILITY);
-  vkCmdBindPipeline(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                    static_cast<const VKShader*>(shader)->GetComputePipeline());
-  vkUpdateDescriptorSets(g_vulkan_context->GetDevice(), static_cast<u32>(dswrites.size()),
-                         dswrites.data(), 0, nullptr);
-  vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
-                          &dset, 1, &uniform_buffer_offset);
-  vkCmdDispatch(command_buffer, groups_x, groups_y, groups_z);
-}
-
 void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
 {
   u32 backbuffer_width = m_swap_chain->GetWidth();
@@ -1183,6 +1031,23 @@ void Renderer::SetViewport(float x, float y, float width, float height, float ne
   VkViewport viewport = {x,          y,        std::max(width, 1.0f), std::max(height, 1.0f),
                          near_depth, far_depth};
   StateTracker::GetInstance()->SetViewport(viewport);
+}
+
+void Renderer::Draw(u32 base_vertex, u32 num_vertices)
+{
+  if (StateTracker::GetInstance()->Bind())
+    return;
+
+  vkCmdDraw(g_command_buffer_mgr->GetCurrentCommandBuffer(), num_vertices, 1, base_vertex, 0);
+}
+
+void Renderer::DrawIndexed(u32 base_index, u32 num_indices, u32 base_vertex)
+{
+  if (!StateTracker::GetInstance()->Bind())
+    return;
+
+  vkCmdDrawIndexed(g_command_buffer_mgr->GetCurrentCommandBuffer(), num_indices, 1, base_index,
+                   base_vertex, 0);
 }
 
 void Renderer::RecompileShaders()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -125,6 +125,8 @@ private:
 
   VkSemaphore m_image_available_semaphore = VK_NULL_HANDLE;
   VkSemaphore m_rendering_finished_semaphore = VK_NULL_HANDLE;
+  VkRenderPass m_swap_chain_render_pass = VK_NULL_HANDLE;
+  VkRenderPass m_swap_chain_clear_render_pass = VK_NULL_HANDLE;
 
   std::unique_ptr<SwapChain> m_swap_chain;
   std::unique_ptr<BoundingBox> m_bounding_box;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -87,11 +87,8 @@ public:
   void SetInterlacingMode() override;
   void SetViewport(float x, float y, float width, float height, float near_depth,
                    float far_depth) override;
-
-  void DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, const void* vertices,
-                           u32 vertex_stride, u32 num_vertices) override;
-  void DispatchComputeShader(const AbstractShader* shader, const void* uniforms, u32 uniforms_size,
-                             u32 groups_x, u32 groups_y, u32 groups_z) override;
+  void Draw(u32 base_vertex, u32 num_vertices) override;
+  void DrawIndexed(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
 private:
   bool CreateSemaphores();

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -37,6 +37,9 @@ public:
 
   bool IsHeadless() const override;
 
+  bool Initialize() override;
+  void Shutdown() override;
+
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
@@ -52,8 +55,6 @@ public:
 
   SwapChain* GetSwapChain() const { return m_swap_chain.get(); }
   BoundingBox* GetBoundingBox() const { return m_bounding_box.get(); }
-  bool Initialize();
-
   void RenderText(const std::string& pstr, int left, int top, u32 color) override;
   u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
   void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -218,6 +218,37 @@ void StateTracker::UpdatePixelShaderConstants()
   PixelShaderManager::dirty = false;
 }
 
+void StateTracker::UpdateConstants(const void* data, u32 data_size)
+{
+  if (!m_uniform_stream_buffer->ReserveMemory(
+          data_size, g_vulkan_context->GetUniformBufferAlignment(), true, true, false))
+  {
+    WARN_LOG(VIDEO, "Executing command buffer while waiting for ext space in uniform buffer");
+    Util::ExecuteCurrentCommandsAndRestoreState(false);
+  }
+
+  for (u32 binding = 0; binding < NUM_UBO_DESCRIPTOR_SET_BINDINGS; binding++)
+  {
+    if (m_bindings.uniform_buffer_bindings[binding].buffer != m_uniform_stream_buffer->GetBuffer())
+    {
+      m_bindings.uniform_buffer_bindings[binding].buffer = m_uniform_stream_buffer->GetBuffer();
+      m_dirty_flags |= DIRTY_FLAG_VS_UBO << binding;
+    }
+    m_bindings.uniform_buffer_offsets[binding] =
+        static_cast<uint32_t>(m_uniform_stream_buffer->GetCurrentOffset());
+  }
+  m_dirty_flags |= DIRTY_FLAG_DYNAMIC_OFFSETS;
+
+  std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), data, data_size);
+  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  m_uniform_stream_buffer->CommitMemory(data_size);
+
+  // Cached data is now out-of-sync.
+  VertexShaderManager::dirty = true;
+  GeometryShaderManager::dirty = true;
+  PixelShaderManager::dirty = true;
+}
+
 bool StateTracker::ReserveConstantStorage()
 {
   // Since we invalidate all constants on command buffer execution, it doesn't matter if this
@@ -473,16 +504,16 @@ bool StateTracker::Bind(bool rebind_all /*= false*/)
   {
     vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
                             m_pipeline->GetVkPipelineLayout(), 0, m_num_active_descriptor_sets,
-                            m_descriptor_sets.data(), NUM_UBO_DESCRIPTOR_SET_BINDINGS,
+                            m_descriptor_sets.data(), m_num_dynamic_offsets,
                             m_bindings.uniform_buffer_offsets.data());
   }
   else if (m_dirty_flags & DIRTY_FLAG_DYNAMIC_OFFSETS)
   {
-    vkCmdBindDescriptorSets(
-        command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline->GetVkPipelineLayout(),
-        DESCRIPTOR_SET_BIND_POINT_UNIFORM_BUFFERS, 1,
-        &m_descriptor_sets[DESCRIPTOR_SET_BIND_POINT_UNIFORM_BUFFERS],
-        NUM_UBO_DESCRIPTOR_SET_BINDINGS, m_bindings.uniform_buffer_offsets.data());
+    vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            m_pipeline->GetVkPipelineLayout(),
+                            DESCRIPTOR_SET_BIND_POINT_UNIFORM_BUFFERS, 1,
+                            &m_descriptor_sets[DESCRIPTOR_SET_BIND_POINT_UNIFORM_BUFFERS],
+                            m_num_dynamic_offsets, m_bindings.uniform_buffer_offsets.data());
   }
 
   if (m_dirty_flags & DIRTY_FLAG_VIEWPORT || rebind_all)
@@ -640,6 +671,14 @@ void StateTracker::EndClearRenderPass()
 
 bool StateTracker::UpdateDescriptorSet()
 {
+  if (m_pipeline->GetUsage() == AbstractPipelineUsage::GX)
+    return UpdateGXDescriptorSet();
+  else
+    return UpdateUtilityDescriptorSet();
+}
+
+bool StateTracker::UpdateGXDescriptorSet()
+{
   const size_t MAX_DESCRIPTOR_WRITES = NUM_UBO_DESCRIPTOR_SET_BINDINGS +  // UBO
                                        1 +                                // Samplers
                                        1;                                 // SSBO
@@ -729,6 +768,50 @@ bool StateTracker::UpdateDescriptorSet()
     vkUpdateDescriptorSets(g_vulkan_context->GetDevice(), num_writes, writes.data(), 0, nullptr);
 
   m_num_active_descriptor_sets = NUM_GX_DRAW_DESCRIPTOR_SETS;
+  m_num_dynamic_offsets = NUM_UBO_DESCRIPTOR_SET_BINDINGS;
+  return true;
+}
+
+bool StateTracker::UpdateUtilityDescriptorSet()
+{
+  // Allocate descriptor sets.
+  m_descriptor_sets[0] = g_command_buffer_mgr->AllocateDescriptorSet(
+      g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_SINGLE_UNIFORM_BUFFER));
+  m_descriptor_sets[1] = g_command_buffer_mgr->AllocateDescriptorSet(
+      g_object_cache->GetDescriptorSetLayout(DESCRIPTOR_SET_LAYOUT_PIXEL_SHADER_SAMPLERS));
+  if (m_descriptor_sets[0] == VK_NULL_HANDLE || m_descriptor_sets[1] == VK_NULL_HANDLE)
+  {
+    return false;
+  }
+
+  // Build UBO descriptor set.
+  std::array<VkWriteDescriptorSet, 2> dswrites;
+  dswrites[0] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                 nullptr,
+                 m_descriptor_sets[0],
+                 0,
+                 0,
+                 1,
+                 VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+                 nullptr,
+                 &m_bindings.uniform_buffer_bindings[UBO_DESCRIPTOR_SET_BINDING_VS],
+                 nullptr};
+  dswrites[1] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                 nullptr,
+                 m_descriptor_sets[1],
+                 0,
+                 0,
+                 NUM_PIXEL_SHADER_SAMPLERS,
+                 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                 m_bindings.ps_samplers.data(),
+                 nullptr,
+                 nullptr};
+
+  vkUpdateDescriptorSets(g_vulkan_context->GetDevice(), static_cast<uint32_t>(dswrites.size()),
+                         dswrites.data(), 0, nullptr);
+  m_num_active_descriptor_sets = NUM_UTILITY_DRAW_DESCRIPTOR_SETS;
+  m_num_dynamic_offsets = 1;
+  m_dirty_flags |= DIRTY_FLAG_DESCRIPTOR_SET_BINDING;
   return true;
 }
 

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.h
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.h
@@ -30,10 +30,6 @@ public:
   static bool CreateInstance();
   static void DestroyInstance();
 
-  const std::array<VkDescriptorImageInfo, NUM_PIXEL_SHADER_SAMPLERS>& GetPSSamplerBindings() const
-  {
-    return m_bindings.ps_samplers;
-  }
   VkFramebuffer GetFramebuffer() const { return m_framebuffer; }
   const VKPipeline* GetPipeline() const { return m_pipeline; }
   void SetVertexBuffer(VkBuffer buffer, VkDeviceSize offset);
@@ -46,6 +42,9 @@ public:
   void UpdateVertexShaderConstants();
   void UpdateGeometryShaderConstants();
   void UpdatePixelShaderConstants();
+
+  // Updates constants from external data, e.g. utility draws.
+  void UpdateConstants(const void* data, u32 data_size);
 
   void SetTexture(size_t index, VkImageView view);
   void SetSampler(size_t index, VkSampler sampler);
@@ -104,7 +103,8 @@ private:
   // Number of descriptor sets for game draws.
   enum
   {
-    NUM_GX_DRAW_DESCRIPTOR_SETS = DESCRIPTOR_SET_BIND_POINT_STORAGE_OR_TEXEL_BUFFER + 1
+    NUM_GX_DRAW_DESCRIPTOR_SETS = DESCRIPTOR_SET_BIND_POINT_STORAGE_OR_TEXEL_BUFFER + 1,
+    NUM_UTILITY_DRAW_DESCRIPTOR_SETS = 2
   };
 
   enum DITRY_FLAG : u32
@@ -133,6 +133,8 @@ private:
   bool IsViewportWithinRenderArea() const;
 
   bool UpdateDescriptorSet();
+  bool UpdateGXDescriptorSet();
+  bool UpdateUtilityDescriptorSet();
 
   // Allocates storage in the uniform buffer of the specified size. If this storage cannot be
   // allocated immediately, the current command buffer will be submitted and all stage's
@@ -167,6 +169,7 @@ private:
   } m_bindings;
   size_t m_uniform_buffer_reserve_size = 0;
   u32 m_num_active_descriptor_sets = 0;
+  u32 m_num_dynamic_offsets = 0;
 
   // rasterization
   VkViewport m_viewport = {0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -142,11 +142,8 @@ std::unique_ptr<SwapChain> SwapChain::Create(void* display_handle, void* native_
   std::unique_ptr<SwapChain> swap_chain =
       std::make_unique<SwapChain>(display_handle, native_handle, surface, vsync);
 
-  if (!swap_chain->CreateSwapChain() || !swap_chain->CreateRenderPass() ||
-      !swap_chain->SetupSwapChainImages())
-  {
+  if (!swap_chain->CreateSwapChain() || !swap_chain->SetupSwapChainImages())
     return nullptr;
-  }
 
   return swap_chain;
 }
@@ -175,13 +172,27 @@ bool SwapChain::SelectSurfaceFormat()
     return true;
   }
 
-  // Use the first surface format, just use what it prefers.
-  // Some drivers seem to return a SRGB format here (Intel Mesa).
-  // This results in gamma correction when presenting to the screen, which we don't want.
-  // Use a linear format instead, if this is the case.
-  m_surface_format.format = Util::GetLinearFormat(surface_formats[0].format);
-  m_surface_format.colorSpace = surface_formats[0].colorSpace;
-  return true;
+  // Try to find a suitable format.
+  for (const VkSurfaceFormatKHR& surface_format : surface_formats)
+  {
+    // Some drivers seem to return a SRGB format here (Intel Mesa).
+    // This results in gamma correction when presenting to the screen, which we don't want.
+    // Use a linear format instead, if this is the case.
+    VkFormat format = Util::GetLinearFormat(surface_format.format);
+    if (format == VK_FORMAT_R8G8B8A8_UNORM)
+      m_texture_format = AbstractTextureFormat::RGBA8;
+    else if (format == VK_FORMAT_B8G8R8A8_UNORM)
+      m_texture_format = AbstractTextureFormat::BGRA8;
+    else
+      continue;
+
+    m_surface_format.format = format;
+    m_surface_format.colorSpace = surface_format.colorSpace;
+    return true;
+  }
+
+  PanicAlert("Failed to find a suitable format for swap chain buffers.");
+  return false;
 }
 
 bool SwapChain::SelectPresentMode()
@@ -234,14 +245,6 @@ bool SwapChain::SelectPresentMode()
   // Fall back to whatever is available.
   m_present_mode = present_modes[0];
   return true;
-}
-
-bool SwapChain::CreateRenderPass()
-{
-  // render pass for rendering to the swap chain
-  m_render_pass = g_object_cache->GetRenderPass(m_surface_format.format, VK_FORMAT_UNDEFINED, 1,
-                                                VK_ATTACHMENT_LOAD_OP_CLEAR);
-  return m_render_pass != VK_NULL_HANDLE;
 }
 
 bool SwapChain::CreateSwapChain()
@@ -367,6 +370,9 @@ bool SwapChain::SetupSwapChainImages()
                                 images.data());
   ASSERT(res == VK_SUCCESS);
 
+  VkRenderPass render_pass = g_object_cache->GetRenderPass(
+      m_surface_format.format, VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_CLEAR);
+
   m_swap_chain_images.reserve(image_count);
   for (uint32_t i = 0; i < image_count; i++)
   {
@@ -382,7 +388,7 @@ bool SwapChain::SetupSwapChainImages()
     VkFramebufferCreateInfo framebuffer_info = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
                                                 nullptr,
                                                 0,
-                                                m_render_pass,
+                                                render_pass,
                                                 1,
                                                 &view,
                                                 m_width,
@@ -499,7 +505,7 @@ bool SwapChain::RecreateSurface(void* native_handle)
   }
 
   // Finally re-create the swap chain
-  if (!CreateSwapChain() || !SetupSwapChainImages() || !CreateRenderPass())
+  if (!CreateSwapChain() || !SetupSwapChainImages())
     return false;
 
   return true;

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.h
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Vulkan/Constants.h"
 #include "VideoBackends/Vulkan/Texture2D.h"
+#include "VideoCommon/TextureConfig.h"
 
 namespace Vulkan
 {
@@ -33,10 +34,10 @@ public:
   void* GetNativeHandle() const { return m_native_handle; }
   VkSurfaceKHR GetSurface() const { return m_surface; }
   VkSurfaceFormatKHR GetSurfaceFormat() const { return m_surface_format; }
+  AbstractTextureFormat GetTextureFormat() const { return m_texture_format; }
   bool IsVSyncEnabled() const { return m_vsync_enabled; }
   bool IsStereoEnabled() const { return m_layers == 2; }
   VkSwapchainKHR GetSwapChain() const { return m_swap_chain; }
-  VkRenderPass GetRenderPass() const { return m_render_pass; }
   u32 GetWidth() const { return m_width; }
   u32 GetHeight() const { return m_height; }
   u32 GetCurrentImageIndex() const { return m_current_swap_chain_image_index; }
@@ -69,8 +70,6 @@ private:
   bool CreateSwapChain();
   void DestroySwapChain();
 
-  bool CreateRenderPass();
-
   bool SetupSwapChainImages();
   void DestroySwapChainImages();
 
@@ -88,13 +87,12 @@ private:
   VkSurfaceKHR m_surface = VK_NULL_HANDLE;
   VkSurfaceFormatKHR m_surface_format = {};
   VkPresentModeKHR m_present_mode = VK_PRESENT_MODE_RANGE_SIZE_KHR;
+  AbstractTextureFormat m_texture_format = AbstractTextureFormat::Undefined;
   bool m_vsync_enabled;
 
   VkSwapchainKHR m_swap_chain = VK_NULL_HANDLE;
   std::vector<SwapChainImage> m_swap_chain_images;
   u32 m_current_swap_chain_image_index = 0;
-
-  VkRenderPass m_render_pass = VK_NULL_HANDLE;
 
   u32 m_width = 0;
   u32 m_height = 0;

--- a/Source/Core/VideoBackends/Vulkan/Util.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Util.cpp
@@ -130,6 +130,9 @@ VkFormat GetVkFormatForHostTextureFormat(AbstractTextureFormat format)
   case AbstractTextureFormat::D32F_S8:
     return VK_FORMAT_D32_SFLOAT_S8_UINT;
 
+  case AbstractTextureFormat::Undefined:
+    return VK_FORMAT_UNDEFINED;
+
   default:
     PanicAlert("Unhandled texture format.");
     return VK_FORMAT_R8G8B8A8_UNORM;

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.h
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.h
@@ -27,20 +27,19 @@ public:
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 
-protected:
-  void PrepareDrawBuffers(u32 stride);
-  void ResetBuffer(u32 stride) override;
+  void UploadUtilityUniforms(const void* uniforms, u32 uniforms_size) override;
 
-private:
-  void vFlush() override;
+protected:
+  void ResetBuffer(u32 vertex_stride, bool cull_all) override;
+  void CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices, u32* out_base_vertex,
+                    u32* out_base_index) override;
+  void UploadConstants() override;
+  void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;
 
   std::vector<u8> m_cpu_vertex_buffer;
   std::vector<u16> m_cpu_index_buffer;
 
   std::unique_ptr<StreamBuffer> m_vertex_stream_buffer;
   std::unique_ptr<StreamBuffer> m_index_stream_buffer;
-
-  u32 m_current_draw_base_vertex = 0;
-  u32 m_current_draw_base_index = 0;
 };
 }

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstddef>
+#include <cstring>
 
 #include "Common/CommonTypes.h"
 #include "Common/Compiler.h"
@@ -54,6 +55,13 @@ void IndexGenerator::AddIndices(int primitive, u32 numVerts)
 {
   index_buffer_current = primitive_table[primitive](index_buffer_current, numVerts, base_index);
   base_index += numVerts;
+}
+
+void IndexGenerator::AddExternalIndices(const u16* indices, u32 num_indices, u32 num_vertices)
+{
+  std::memcpy(index_buffer_current, indices, sizeof(u16) * num_indices);
+  index_buffer_current += num_indices;
+  base_index += num_vertices;
 }
 
 // Triangles

--- a/Source/Core/VideoCommon/IndexGenerator.h
+++ b/Source/Core/VideoCommon/IndexGenerator.h
@@ -18,6 +18,8 @@ public:
 
   static void AddIndices(int primitive, u32 numVertices);
 
+  static void AddExternalIndices(const u16* indices, u32 num_indices, u32 num_vertices);
+
   // returns numprimitives
   static u32 GetNumVerts() { return base_index; }
   static u32 GetIndexLen() { return (u32)(index_buffer_current - BASEIptr); }

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -697,6 +697,11 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
 
       m_last_xfb_region = xfb_rect;
 
+      // Since we use the common pipelines here and draw vertices if a batch is currently being
+      // built by the vertex loader, we end up trampling over its pointer, as we share the buffer
+      // with the loader, and it has not been unmapped yet. Force a pipeline flush to avoid this.
+      g_vertex_manager->Flush();
+
       // TODO: merge more generic parts into VideoCommon
       {
         std::lock_guard<std::mutex> guard(m_swap_mutex);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -78,8 +78,10 @@ static float AspectToWidescreen(float aspect)
   return aspect * ((16.0f / 9.0f) / (4.0f / 3.0f));
 }
 
-Renderer::Renderer(int backbuffer_width, int backbuffer_height)
-    : m_backbuffer_width(backbuffer_width), m_backbuffer_height(backbuffer_height)
+Renderer::Renderer(int backbuffer_width, int backbuffer_height,
+                   AbstractTextureFormat backbuffer_format)
+    : m_backbuffer_width(backbuffer_width), m_backbuffer_height(backbuffer_height),
+      m_backbuffer_format(backbuffer_format)
 {
   UpdateActiveConfig();
   UpdateDrawRectangle();

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -93,6 +93,11 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
 
 Renderer::~Renderer() = default;
 
+bool Renderer::Initialize()
+{
+  return true;
+}
+
 void Renderer::Shutdown()
 {
   // First stop any framedumping, which might need to dump the last xfb frame. This process

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -32,6 +32,7 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/FPSCounter.h"
 #include "VideoCommon/RenderState.h"
+#include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/VideoCommon.h"
 
 class AbstractFramebuffer;
@@ -72,7 +73,7 @@ enum class OSDMessage : s32
 class Renderer
 {
 public:
-  Renderer(int backbuffer_width, int backbuffer_height);
+  Renderer(int backbuffer_width, int backbuffer_height, AbstractTextureFormat backbuffer_format);
   virtual ~Renderer();
 
   using ClearColor = std::array<float, 4>;
@@ -230,6 +231,7 @@ protected:
   // Backbuffer (window) size and render area
   int m_backbuffer_width = 0;
   int m_backbuffer_height = 0;
+  AbstractTextureFormat m_backbuffer_format = AbstractTextureFormat::Undefined;
   TargetRectangle m_target_rectangle = {};
 
   FPSCounter m_fps_counter;

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -79,6 +79,9 @@ public:
 
   virtual bool IsHeadless() const = 0;
 
+  virtual bool Initialize();
+  virtual void Shutdown();
+
   virtual void SetPipeline(const AbstractPipeline* pipeline) {}
   virtual void SetScissorRect(const MathUtil::Rectangle<int>& rc) {}
   virtual void SetTexture(u32 index, const AbstractTexture* texture) {}
@@ -187,8 +190,6 @@ public:
   bool UseVertexDepthRange() const;
 
   virtual std::unique_ptr<VideoCommon::AsyncShaderCompiler> CreateAsyncShaderCompiler();
-
-  virtual void Shutdown();
 
   // Drawing utility shaders.
   virtual void DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, const void* vertices,

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -114,6 +114,10 @@ public:
   {
   }
 
+  // Drawing with currently-bound pipeline state.
+  virtual void Draw(u32 base_vertex, u32 num_vertices) {}
+  virtual void DrawIndexed(u32 base_index, u32 num_indices, u32 base_vertex) {}
+
   // Shader modules/objects.
   virtual std::unique_ptr<AbstractShader>
   CreateShaderFromSource(ShaderStage stage, const char* source, size_t length) = 0;
@@ -191,16 +195,6 @@ public:
   bool UseVertexDepthRange() const;
 
   virtual std::unique_ptr<VideoCommon::AsyncShaderCompiler> CreateAsyncShaderCompiler();
-
-  // Drawing utility shaders.
-  virtual void DrawUtilityPipeline(const void* uniforms, u32 uniforms_size, const void* vertices,
-                                   u32 vertex_stride, u32 num_vertices)
-  {
-  }
-  virtual void DispatchComputeShader(const AbstractShader* shader, const void* uniforms,
-                                     u32 uniforms_size, u32 groups_x, u32 groups_y, u32 groups_z)
-  {
-  }
 
   void ShowOSDMessage(OSDMessage message);
 

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -69,9 +69,29 @@ public:
     m_pipeline_config_changed = true;
   }
 
+  // Utility pipeline drawing (e.g. EFB copies, post-processing, UI).
+  virtual void UploadUtilityUniforms(const void* uniforms, u32 uniforms_size) = 0;
+  void UploadUtilityVertices(const void* vertices, u32 vertex_stride, u32 num_vertices,
+                             const u16* indices, u32 num_indices, u32* out_base_vertex,
+                             u32* out_base_index);
+
 protected:
-  virtual void vDoState(PointerWrap& p) {}
-  virtual void ResetBuffer(u32 stride) = 0;
+  // Vertex buffers/index buffer creation.
+  virtual void CreateDeviceObjects() {}
+  virtual void DestroyDeviceObjects() {}
+
+  // Prepares the buffer for the next batch of vertices.
+  virtual void ResetBuffer(u32 vertex_stride, bool cull_all) = 0;
+
+  // Commits/uploads the current batch of vertices.
+  virtual void CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,
+                            u32* out_base_vertex, u32* out_base_index) = 0;
+
+  // Uploads uniform buffers for GX draws.
+  virtual void UploadConstants() = 0;
+
+  // Issues the draw call for the current batch in the backend.
+  virtual void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) = 0;
 
   u8* m_cur_buffer_pointer = nullptr;
   u8* m_base_buffer_pointer = nullptr;
@@ -98,10 +118,6 @@ private:
   size_t m_flush_count_4_3 = 0;
   size_t m_flush_count_anamorphic = 0;
 
-  virtual void vFlush() = 0;
-
-  virtual void CreateDeviceObjects() {}
-  virtual void DestroyDeviceObjects() {}
   void UpdatePipelineConfig();
   void UpdatePipelineObject();
 };


### PR DESCRIPTION
This PR is a prerequisite for our imgui integration. It makes VertexManager a little more generic, moving some of the logic into common, and enabling buffer sharing with utility shader draws (used for imgui).

In the future, we can also use this for drawing EFB copies, and post-processing, rather than having all these different buffers sitting around the place (and duplicated across the backends). This is mainly the case in Vulkan, not _so_ much in the others.