### PR TITLE
VS2017: update windows 10 sdk from 10.0.15063.0 to 10.0.17134.0 (for minizip)

### DIFF
--- a/Externals/minizip/minizip.vcxproj
+++ b/Externals/minizip/minizip.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{23114507-079A-4418-9707-CFA81A03CA99}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">


### PR DESCRIPTION
Hi,
Dolphin requires Windows 10 SDK 10.0.17134.0 to be compiled but minizip was using another version,
It's fixes with this PR,
Tested with visual studio pro 2017 (15.9.2) and Windows 10 SDK, version 1803 (10.0.17134.0)
-Yohann