### PR TITLE
NetPlay: Allow force stopping

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -242,6 +242,10 @@ void Stop()  // - Hammertime!
 
   s_is_stopping = true;
 
+  // Notify state changed callback
+  if (s_on_state_changed_callback)
+    s_on_state_changed_callback(State::Stopping);
+
   // Dump left over jobs
   HostDispatchJobs();
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -338,6 +338,11 @@ void NetPlayDialog::ConnectWidgets()
     if (isVisible())
     {
       GameStatusChanged(state != Core::State::Uninitialized);
+      if ((state == Core::State::Uninitialized || state == Core::State::Stopping) &&
+          !m_got_stop_request)
+      {
+        Settings::Instance().GetNetPlayClient()->RequestStopGame();
+      }
       if (state == Core::State::Uninitialized)
         DisplayMessage(tr("Stopped game"), "red");
     }
@@ -808,9 +813,6 @@ void NetPlayDialog::OnMsgChangeGame(const std::string& title)
 
 void NetPlayDialog::GameStatusChanged(bool running)
 {
-  if (!running && !m_got_stop_request)
-    Settings::Instance().GetNetPlayClient()->RequestStopGame();
-
   QueueOnObject(this, [this, running] { SetOptionsEnabled(!running); });
 }
 


### PR DESCRIPTION
NetPlay never checks for `State::Stopping` to request game stop, and more importantly, core never notifies the state change callback when it enters the stopping state. The result is that attempting to force stop NetPlay when it is deadlocked would not work, and instead would just completely hang the UI.

This makes it possible to gracefully force stop emulation rather than having to kill Dolphin completely when NetPlay deadlocks in the input loop. Without a graceful stop, Wii saves do not get flushed to the main NAND, and are left in limbo in the temporary NAND.