### PR TITLE
Separate PPCAnalyst-dependent JitBase functionality into subclass, stop using g_jit outside JitInterface

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
@@ -11,7 +11,7 @@
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
-class CachedInterpreter : public JitBase
+class CachedInterpreter : public JitCommonBase
 {
 public:
   CachedInterpreter();

--- a/Source/Core/Core/PowerPC/CachedInterpreter/InterpreterBlockCache.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/InterpreterBlockCache.cpp
@@ -6,7 +6,7 @@
 
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
-BlockCache::BlockCache(JitBase& jit) : JitBaseBlockCache{jit}
+BlockCache::BlockCache(JitCommonBase& jit) : JitBaseBlockCache{jit}
 {
 }
 

--- a/Source/Core/Core/PowerPC/CachedInterpreter/InterpreterBlockCache.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/InterpreterBlockCache.h
@@ -6,12 +6,12 @@
 
 #include "Core/PowerPC/JitCommon/JitCache.h"
 
-class JitBase;
+class JitCommonBase;
 
 class BlockCache final : public JitBaseBlockCache
 {
 public:
-  explicit BlockCache(JitBase& jit);
+  explicit BlockCache(JitCommonBase& jit);
 
 private:
   void WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest) override;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -36,6 +36,11 @@ struct CodeOp;
 
 class Jit64 : public Jitx86Base
 {
+  // these three need access to the JitState
+  friend class FPURegCache;
+  friend class GPRRegCache;
+  friend class RegCache;
+
 public:
   Jit64();
   ~Jit64() override;

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -18,7 +18,7 @@
 
 using namespace Gen;
 
-Jit64AsmRoutineManager::Jit64AsmRoutineManager(JitBase& jit) : m_jit{jit}
+Jit64AsmRoutineManager::Jit64AsmRoutineManager(JitCommonBase& jit) : m_jit{jit}
 {
 }
 
@@ -158,7 +158,7 @@ void Jit64AsmRoutineManager::Generate()
   // Ok, no block, let's call the slow dispatcher
   ABI_PushRegistersAndAdjustStack({}, 0);
   MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&m_jit)));
-  ABI_CallFunction(JitBase::Dispatch);
+  ABI_CallFunction(JitCommonBase::Dispatch);
   ABI_PopRegistersAndAdjustStack({}, 0);
 
   TEST(64, R(ABI_RETURN), R(ABI_RETURN));

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.h
@@ -12,7 +12,7 @@ namespace Gen
 class X64CodeBlock;
 }
 
-class JitBase;
+class JitCommonBase;
 
 // In Dolphin, we don't use inline assembly. Instead, we generate all machine-near
 // code at runtime. In the case of fixed code like this, after writing it, we write
@@ -35,7 +35,7 @@ public:
   // want to ensure this number is big enough.
   static constexpr size_t CODE_SIZE = 16384;
 
-  explicit Jit64AsmRoutineManager(JitBase& jit);
+  explicit Jit64AsmRoutineManager(JitCommonBase& jit);
 
   void Init(u8* stack_top);
 
@@ -46,5 +46,5 @@ private:
   void GenerateCommon();
 
   u8* m_stack_top = nullptr;
-  JitBase& m_jit;
+  JitCommonBase& m_jit;
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
@@ -8,7 +8,7 @@
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
-JitBlockCache::JitBlockCache(JitBase& jit) : JitBaseBlockCache{jit}
+JitBlockCache::JitBlockCache(JitCommonBase& jit) : JitBaseBlockCache{jit}
 {
 }
 

--- a/Source/Core/Core/PowerPC/Jit64Common/BlockCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/BlockCache.h
@@ -6,12 +6,12 @@
 
 #include "Core/PowerPC/JitCommon/JitCache.h"
 
-class JitBase;
+class JitCommonBase;
 
 class JitBlockCache : public JitBaseBlockCache
 {
 public:
-  explicit JitBlockCache(JitBase& jit);
+  explicit JitBlockCache(JitCommonBase& jit);
 
 private:
   void WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest) override;

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -54,12 +54,12 @@ void EmuCodeBlock::MemoryExceptionCheck()
   // load/store, the trampoline generator will have stashed the exception
   // handler (that we previously generated after the fastmem instruction) in
   // trampolineExceptionHandler.
-  if (g_jit->js.generatingTrampoline)
+  if (Jitx86Base::GetState().generatingTrampoline)
   {
-    if (g_jit->js.trampolineExceptionHandler)
+    if (Jitx86Base::GetState().trampolineExceptionHandler)
     {
       TEST(32, PPCSTATE(Exceptions), Gen::Imm32(EXCEPTION_DSI));
-      J_CC(CC_NZ, g_jit->js.trampolineExceptionHandler);
+      J_CC(CC_NZ, Jitx86Base::GetState().trampolineExceptionHandler);
     }
     return;
   }
@@ -67,11 +67,12 @@ void EmuCodeBlock::MemoryExceptionCheck()
   // If memcheck (ie: MMU) mode is enabled and we haven't generated an
   // exception handler for this instruction yet, we will generate an
   // exception check.
-  if (g_jit->jo.memcheck && !g_jit->js.fastmemLoadStore && !g_jit->js.fixupExceptionHandler)
+  if (Jitx86Base::GetOptions().memcheck && !Jitx86Base::GetState().fastmemLoadStore &&
+      !Jitx86Base::GetState().fixupExceptionHandler)
   {
     TEST(32, PPCSTATE(Exceptions), Gen::Imm32(EXCEPTION_DSI));
-    g_jit->js.exceptionHandler = J_CC(Gen::CC_NZ, true);
-    g_jit->js.fixupExceptionHandler = true;
+    Jitx86Base::GetState().exceptionHandler = J_CC(Gen::CC_NZ, true);
+    Jitx86Base::GetState().fixupExceptionHandler = true;
   }
 }
 
@@ -319,15 +320,15 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
   bool slowmem = (flags & SAFE_LOADSTORE_FORCE_SLOWMEM) != 0;
 
   registersInUse[reg_value] = false;
-  if (g_jit->jo.fastmem && !(flags & (SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_UPDATE_PC)) &&
-      !slowmem)
+  if (Jitx86Base::GetOptions().fastmem &&
+      !(flags & (SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_UPDATE_PC)) && !slowmem)
   {
     u8* backpatchStart = GetWritableCodePtr();
     MovInfo mov;
     bool offsetAddedToAddress =
         UnsafeLoadToReg(reg_value, opAddress, accessSize, offset, signExtend, &mov);
     TrampolineInfo& info = m_back_patch_info[mov.address];
-    info.pc = g_jit->js.compilerPC;
+    info.pc = Jitx86Base::GetState().compilerPC;
     info.nonAtomicSwapStoreSrc = mov.nonAtomicSwapStore ? mov.nonAtomicSwapStoreSrc : INVALID_REG;
     info.start = backpatchStart;
     info.read = true;
@@ -346,7 +347,7 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
     }
     info.len = static_cast<u32>(GetCodePtr() - info.start);
 
-    g_jit->js.fastmemLoadStore = mov.address;
+    Jitx86Base::GetState().fastmemLoadStore = mov.address;
     return;
   }
 
@@ -384,7 +385,7 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
   // Invalid for calls from Jit64AsmCommon routines
   if (!(flags & SAFE_LOADSTORE_NO_UPDATE_PC))
   {
-    MOV(32, PPCSTATE(pc), Imm32(g_jit->js.compilerPC));
+    MOV(32, PPCSTATE(pc), Imm32(Jitx86Base::GetState().compilerPC));
   }
 
   size_t rsp_alignment = (flags & SAFE_LOADSTORE_NO_PROLOG) ? 8 : 0;
@@ -448,7 +449,7 @@ void EmuCodeBlock::SafeLoadToRegImmediate(X64Reg reg_value, u32 address, int acc
   }
 
   // Helps external systems know which instruction triggered the read.
-  MOV(32, PPCSTATE(pc), Imm32(g_jit->js.compilerPC));
+  MOV(32, PPCSTATE(pc), Imm32(Jitx86Base::GetState().compilerPC));
 
   // Fall back to general-case code.
   ABI_PushRegistersAndAdjustStack(registersInUse, 0);
@@ -490,14 +491,14 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
   // set the correct immediate format
   reg_value = FixImmediate(accessSize, reg_value);
 
-  if (g_jit->jo.fastmem && !(flags & (SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_UPDATE_PC)) &&
-      !slowmem)
+  if (Jitx86Base::GetOptions().fastmem &&
+      !(flags & (SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_UPDATE_PC)) && !slowmem)
   {
     u8* backpatchStart = GetWritableCodePtr();
     MovInfo mov;
     UnsafeWriteRegToReg(reg_value, reg_addr, accessSize, offset, swap, &mov);
     TrampolineInfo& info = m_back_patch_info[mov.address];
-    info.pc = g_jit->js.compilerPC;
+    info.pc = Jitx86Base::GetState().compilerPC;
     info.nonAtomicSwapStoreSrc = mov.nonAtomicSwapStore ? mov.nonAtomicSwapStoreSrc : INVALID_REG;
     info.start = backpatchStart;
     info.read = false;
@@ -515,7 +516,7 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
     }
     info.len = static_cast<u32>(GetCodePtr() - info.start);
 
-    g_jit->js.fastmemLoadStore = mov.address;
+    Jitx86Base::GetState().fastmemLoadStore = mov.address;
 
     return;
   }
@@ -551,7 +552,7 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
   // Invalid for calls from Jit64AsmCommon routines
   if (!(flags & SAFE_LOADSTORE_NO_UPDATE_PC))
   {
-    MOV(32, PPCSTATE(pc), Imm32(g_jit->js.compilerPC));
+    MOV(32, PPCSTATE(pc), Imm32(Jitx86Base::GetState().compilerPC));
   }
 
   size_t rsp_alignment = (flags & SAFE_LOADSTORE_NO_PROLOG) ? 8 : 0;
@@ -617,7 +618,7 @@ bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address,
 
   // If we already know the address through constant folding, we can do some
   // fun tricks...
-  if (g_jit->jo.optimizeGatherPipe && PowerPC::IsOptimizableGatherPipeWrite(address))
+  if (Jitx86Base::GetOptions().optimizeGatherPipe && PowerPC::IsOptimizableGatherPipeWrite(address))
   {
     X64Reg arg_reg = RSCRATCH;
 
@@ -634,7 +635,7 @@ bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address,
     ADD(64, R(RSCRATCH2), Imm8(accessSize >> 3));
     MOV(64, PPCSTATE(gather_pipe_ptr), R(RSCRATCH2));
 
-    g_jit->js.fifoBytesSinceCheck += accessSize >> 3;
+    Jitx86Base::GetState().fifoBytesSinceCheck += accessSize >> 3;
     return false;
   }
   else if (PowerPC::IsOptimizableRAMAddress(address))
@@ -645,7 +646,7 @@ bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address,
   else
   {
     // Helps external systems know which instruction triggered the write
-    MOV(32, PPCSTATE(pc), Imm32(g_jit->js.compilerPC));
+    MOV(32, PPCSTATE(pc), Imm32(Jitx86Base::GetState().compilerPC));
 
     ABI_PushRegistersAndAdjustStack(registersInUse, 0);
     switch (accessSize)
@@ -724,7 +725,7 @@ void EmuCodeBlock::ForceSinglePrecision(X64Reg output, const OpArg& input, bool 
                                         bool duplicate)
 {
   // Most games don't need these. Zelda requires it though - some platforms get stuck without them.
-  if (g_jit->jo.accurateSinglePrecision)
+  if (Jitx86Base::GetOptions().accurateSinglePrecision)
   {
     if (packed)
     {
@@ -840,7 +841,7 @@ alignas(16) static const u64 psRoundBit[2] = {0x8000000, 0x8000000};
 // It needs a temp, so let the caller pass that in.
 void EmuCodeBlock::Force25BitPrecision(X64Reg output, const OpArg& input, X64Reg tmp)
 {
-  if (g_jit->jo.accurateSinglePrecision)
+  if (Jitx86Base::GetOptions().accurateSinglePrecision)
   {
     // mantissa = (mantissa & ~0xFFFFFFF) + ((mantissa & (1ULL << 27)) << 1);
     if (input.IsSimpleReg() && cpu_info.bAVX)

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -505,7 +505,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoad(bool single, EQuantizeType type, 
 
   bool extend = single && (type == QUANTIZE_S8 || type == QUANTIZE_S16);
 
-  if (g_jit->jo.memcheck)
+  if (Jitx86Base::GetOptions().memcheck)
   {
     BitSet32 regsToSave = QUANTIZED_REGS_TO_SAVE_LOAD;
     int flags = isInline ? 0 :
@@ -632,7 +632,9 @@ void QuantizedMemoryRoutines::GenQuantizedLoadFloat(bool single, bool isInline)
   int size = single ? 32 : 64;
   bool extend = false;
 
-  if (g_jit->jo.memcheck)
+  const bool memcheck = Jitx86Base::GetOptions().memcheck;
+
+  if (memcheck)
   {
     BitSet32 regsToSave = QUANTIZED_REGS_TO_SAVE;
     int flags = isInline ? 0 :
@@ -643,7 +645,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoadFloat(bool single, bool isInline)
 
   if (single)
   {
-    if (g_jit->jo.memcheck)
+    if (memcheck)
     {
       MOVD_xmm(XMM0, R(RSCRATCH_EXTRA));
     }
@@ -668,7 +670,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoadFloat(bool single, bool isInline)
     // for a good reason, or merely because no game does this.
     // If we find something that actually does do this, maybe this should be changed. How
     // much of a performance hit would it be?
-    if (g_jit->jo.memcheck)
+    if (memcheck)
     {
       ROL(64, R(RSCRATCH_EXTRA), Imm8(32));
       MOVQ_xmm(XMM0, R(RSCRATCH_EXTRA));

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -20,6 +20,8 @@
 #include "Core/MachineContext.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
+Jitx86Base* Jitx86Base::s_instance = nullptr;
+
 // This generates some fairly heavy trampolines, but it doesn't really hurt.
 // Only instructions that access I/O will get these, and there won't be that
 // many of them in a typical program/game.

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
@@ -30,16 +30,26 @@ constexpr Gen::X64Reg RPPCSTATE = Gen::RBP;
 
 constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
 
-class Jitx86Base : public JitBase, public QuantizedMemoryRoutines
+class Jitx86Base : public JitCommonBase, public QuantizedMemoryRoutines
 {
+private:
+  static Jitx86Base* s_instance;
+
 protected:
   bool BackPatch(u32 emAddress, SContext* ctx);
   JitBlockCache blocks{*this};
   TrampolineCache trampolines;
 
 public:
+  Jitx86Base() { s_instance = this; }
+  ~Jitx86Base() { s_instance = nullptr; }
+
   JitBlockCache* GetBlockCache() override { return &blocks; }
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
+
+  // needed for some ASM routines
+  static JitCommonBase::JitState& GetState() { return s_instance->js; }
+  static JitCommonBase::JitOptions& GetOptions() { return s_instance->jo; }
 };
 
 void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer& code_buffer, const u8* normalEntry,

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -18,7 +18,7 @@
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
-class JitArm64 : public JitBase, public Arm64Gen::ARM64CodeBlock, public CommonAsmRoutinesBase
+class JitArm64 : public JitCommonBase, public Arm64Gen::ARM64CodeBlock, public CommonAsmRoutinesBase
 {
 public:
   JitArm64();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
@@ -9,7 +9,7 @@
 
 using namespace Arm64Gen;
 
-JitArm64BlockCache::JitArm64BlockCache(JitBase& jit) : JitBaseBlockCache{jit}
+JitArm64BlockCache::JitArm64BlockCache(JitCommonBase& jit) : JitBaseBlockCache{jit}
 {
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.h
@@ -7,14 +7,14 @@
 #include "Common/Arm64Emitter.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"
 
-class JitBase;
+class JitCommonBase;
 
 typedef void (*CompiledCode)();
 
 class JitArm64BlockCache : public JitBaseBlockCache
 {
 public:
-  explicit JitArm64BlockCache(JitBase& jit);
+  explicit JitArm64BlockCache(JitCommonBase& jit);
 
   void WriteLinkBlock(Arm64Gen::ARM64XEmitter& emit, const JitBlock::LinkData& source,
                       const JitBlock* dest = nullptr);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -62,7 +62,7 @@ void JitArm64::GenerateAsm()
   //   do
   //   {
   // dispatcher_no_check:
-  //     ExecuteBlock(JitBase::Dispatch());
+  //     ExecuteBlock(JitCommonBase::Dispatch);
   // dispatcher:
   //   } while (PowerPC::ppcState.downcount > 0);
   // do_timing:
@@ -126,7 +126,7 @@ void JitArm64::GenerateAsm()
   // Call C version of Dispatch().
   STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
   MOVP2R(X0, this);
-  MOVP2R(X30, reinterpret_cast<void*>(&JitBase::Dispatch));
+  MOVP2R(X30, reinterpret_cast<void*>(&JitCommonBase::Dispatch));
   BLR(X30);
 
   FixupBranch no_block_available = CBZ(X0);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -10,25 +10,23 @@
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
 
-JitBase* g_jit;
-
-const u8* JitBase::Dispatch(JitBase& jit)
+const u8* JitCommonBase::Dispatch(JitCommonBase& jit)
 {
   return jit.GetBlockCache()->Dispatch();
 }
 
-void JitTrampoline(JitBase& jit, u32 em_address)
+void JitTrampoline(JitCommonBase& jit, u32 em_address)
 {
   jit.Jit(em_address);
 }
 
-JitBase::JitBase() : m_code_buffer(code_buffer_size)
+JitCommonBase::JitCommonBase() : m_code_buffer(code_buffer_size)
 {
 }
 
-JitBase::~JitBase() = default;
+JitCommonBase::~JitCommonBase() = default;
 
-bool JitBase::CanMergeNextInstructions(int count) const
+bool JitCommonBase::CanMergeNextInstructions(int count) const
 {
   if (CPU::IsStepping() || js.instructionsLeft < count)
     return false;
@@ -44,7 +42,7 @@ bool JitBase::CanMergeNextInstructions(int count) const
   return true;
 }
 
-void JitBase::UpdateMemoryOptions()
+void JitCommonBase::UpdateMemoryOptions()
 {
   bool any_watchpoints = PowerPC::memchecks.HasAny();
   jo.fastmem = SConfig::GetInstance().bFastmem && (MSR.DR || !any_watchpoints);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -38,7 +38,7 @@ bool JitBlock::OverlapsPhysicalRange(u32 address, u32 length) const
          physical_addresses.lower_bound(address + length);
 }
 
-JitBaseBlockCache::JitBaseBlockCache(JitBase& jit) : m_jit{jit}
+JitBaseBlockCache::JitBaseBlockCache(JitCommonBase& jit) : m_jit{jit}
 {
 }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -15,7 +15,7 @@
 
 #include "Common/CommonTypes.h"
 
-class JitBase;
+class JitCommonBase;
 
 // A JitBlock is block of compiled code which corresponds to the PowerPC
 // code at a given address.
@@ -121,7 +121,7 @@ public:
   static constexpr u32 FAST_BLOCK_MAP_ELEMENTS = 0x10000;
   static constexpr u32 FAST_BLOCK_MAP_MASK = FAST_BLOCK_MAP_ELEMENTS - 1;
 
-  explicit JitBaseBlockCache(JitBase& jit);
+  explicit JitBaseBlockCache(JitCommonBase& jit);
   virtual ~JitBaseBlockCache();
 
   void Init();
@@ -153,7 +153,7 @@ public:
   u32* GetBlockBitSet() const;
 
 protected:
-  JitBase& m_jit;
+  JitCommonBase& m_jit;
 
 private:
   virtual void WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest) = 0;

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -45,7 +45,6 @@ enum class ProfilingState
 
 void SetProfilingState(ProfilingState state);
 void WriteProfileResults(const std::string& filename);
-void GetProfileResults(Profiler::ProfileStats* prof_stats);
 int GetHostCode(u32* address, const u8** code, u32* code_size);
 
 // Memory Utilities

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -90,7 +90,8 @@ bool AnalyzeFunction(u32 startAddr, Common::Symbol& func, u32 max_size)
   for (u32 addr = startAddr; true; addr += 4)
   {
     func.size += 4;
-    if (func.size >= JitBase::code_buffer_size * 4 || !PowerPC::HostIsInstructionRAMAddress(addr))
+    if (func.size >= JitCommonBase::code_buffer_size * 4 ||
+        !PowerPC::HostIsInstructionRAMAddress(addr))
       return false;
 
     if (max_size && func.size > max_size)

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -21,7 +21,7 @@ enum
 #endif
 };
 
-class PageFaultFakeJit : public JitBase
+class PageFaultFakeJit : public JitCommonBase
 {
 public:
   // CPUCoreBase methods


### PR DESCRIPTION
Preparation work for the tiered JIT framework, where compilers cannot access guest memory (and another compilation model is employed), so `PPCAnalyst` is not useful for that.
This PR turns `JitBase` into a pure interface class with no structural inheritance, allowing more flexibility in implementation. The inherited functionality is moved to a new class `JitCommonBase`.

The `g_jit` global is made private to the `JitInterface` module, with a new `g_common_jit` (also private to `JitInterface`, either the same as `g_jit` or null if `g_jit` is not a subclass of `JitCommonBase`).
The x86-64 ASM routines code accessing the main JIT class through `g_jit` has been rerouted through static members of Jitx86Base.