### PR TITLE
stop using g_jit outside of JitInterface

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -18,7 +18,7 @@
 
 using namespace Gen;
 
-Jit64AsmRoutineManager::Jit64AsmRoutineManager(JitBase& jit) : m_jit{jit}
+Jit64AsmRoutineManager::Jit64AsmRoutineManager(Jitx86Base& jit) : m_jit{jit}, CommonAsmRoutines(jit)
 {
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.h
@@ -35,7 +35,7 @@ public:
   // want to ensure this number is big enough.
   static constexpr size_t CODE_SIZE = 16384;
 
-  explicit Jit64AsmRoutineManager(JitBase& jit);
+  explicit Jit64AsmRoutineManager(Jitx86Base& jit);
 
   void Init(u8* stack_top);
 

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -19,10 +19,13 @@ namespace MMIO
 class Mapping;
 }
 
+class Jitx86Base;
+
 // Like XCodeBlock but has some utilities for memory access.
 class EmuCodeBlock : public Gen::X64CodeBlock
 {
 public:
+  explicit EmuCodeBlock(Jitx86Base& jit) : m_jit{jit} {}
   void MemoryExceptionCheck();
 
   // Simple functions to switch between near and far code emitting
@@ -125,6 +128,7 @@ public:
   void Clear();
 
 protected:
+  Jitx86Base& m_jit;
   ConstantPool m_const_pool;
   FarCodeCache m_far_code;
   u8* m_near_code;  // Backed up when we switch to far code.

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -505,7 +505,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoad(bool single, EQuantizeType type, 
 
   bool extend = single && (type == QUANTIZE_S8 || type == QUANTIZE_S16);
 
-  if (g_jit->jo.memcheck)
+  if (m_jit.jo.memcheck)
   {
     BitSet32 regsToSave = QUANTIZED_REGS_TO_SAVE_LOAD;
     int flags = isInline ? 0 :
@@ -632,7 +632,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoadFloat(bool single, bool isInline)
   int size = single ? 32 : 64;
   bool extend = false;
 
-  if (g_jit->jo.memcheck)
+  if (m_jit.jo.memcheck)
   {
     BitSet32 regsToSave = QUANTIZED_REGS_TO_SAVE;
     int flags = isInline ? 0 :
@@ -643,7 +643,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoadFloat(bool single, bool isInline)
 
   if (single)
   {
-    if (g_jit->jo.memcheck)
+    if (m_jit.jo.memcheck)
     {
       MOVD_xmm(XMM0, R(RSCRATCH_EXTRA));
     }
@@ -668,7 +668,7 @@ void QuantizedMemoryRoutines::GenQuantizedLoadFloat(bool single, bool isInline)
     // for a good reason, or merely because no game does this.
     // If we find something that actually does do this, maybe this should be changed. How
     // much of a performance hit would it be?
-    if (g_jit->jo.memcheck)
+    if (m_jit.jo.memcheck)
     {
       ROL(64, R(RSCRATCH_EXTRA), Imm8(32));
       MOVQ_xmm(XMM0, R(RSCRATCH_EXTRA));

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.h
@@ -13,6 +13,7 @@ enum EQuantizeType : u32;
 class QuantizedMemoryRoutines : public EmuCodeBlock
 {
 public:
+  explicit QuantizedMemoryRoutines(Jitx86Base& jit) : EmuCodeBlock(jit) {}
   void GenQuantizedLoad(bool single, EQuantizeType type, int quantize);
   void GenQuantizedStore(bool single, EQuantizeType type, int quantize);
 
@@ -24,6 +25,7 @@ private:
 class CommonAsmRoutines : public CommonAsmRoutinesBase, public QuantizedMemoryRoutines
 {
 public:
+  explicit CommonAsmRoutines(Jitx86Base& jit) : QuantizedMemoryRoutines(jit) {}
   void GenFrsqrte();
   void GenFres();
   void GenMfcr();

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
@@ -32,14 +32,15 @@ constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
 
 class Jitx86Base : public JitBase, public QuantizedMemoryRoutines
 {
+public:
+  Jitx86Base() : QuantizedMemoryRoutines(*this) {}
+  JitBlockCache* GetBlockCache() override { return &blocks; }
+  bool HandleFault(uintptr_t access_address, SContext* ctx) override;
+
 protected:
   bool BackPatch(u32 emAddress, SContext* ctx);
   JitBlockCache blocks{*this};
-  TrampolineCache trampolines;
-
-public:
-  JitBlockCache* GetBlockCache() override { return &blocks; }
-  bool HandleFault(uintptr_t access_address, SContext* ctx) override;
+  TrampolineCache trampolines{*this};
 };
 
 void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer& code_buffer, const u8* normalEntry,

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
@@ -24,6 +24,7 @@ class TrampolineCache : public EmuCodeBlock
   const u8* GenerateWriteTrampoline(const TrampolineInfo& info);
 
 public:
+  explicit TrampolineCache(Jitx86Base& jit) : EmuCodeBlock(jit) {}
   const u8* GenerateTrampoline(const TrampolineInfo& info);
   void ClearCodeSpace();
 };

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -10,8 +10,6 @@
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
 
-JitBase* g_jit;
-
 const u8* JitBase::Dispatch(JitBase& jit)
 {
   return jit.GetBlockCache()->Dispatch();

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -39,10 +39,6 @@
 #define JITDISABLE(setting)                                                                        \
   FALLBACK_IF(SConfig::GetInstance().bJITOff || SConfig::GetInstance().setting)
 
-class JitBase;
-
-extern JitBase* g_jit;
-
 class JitBase : public CPUCoreBase
 {
 protected:

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -40,6 +40,11 @@
 
 namespace JitInterface
 {
+static JitBase* g_jit = nullptr;
+void SetJit(JitBase* jit)
+{
+  g_jit = jit;
+}
 void DoState(PointerWrap& p)
 {
   if (g_jit && p.GetMode() == PointerWrap::MODE_READ)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -11,6 +11,7 @@
 
 class CPUCoreBase;
 class PointerWrap;
+class JitBase;
 
 namespace PowerPC
 {
@@ -64,6 +65,9 @@ void ClearSafe();
 void InvalidateICache(u32 address, u32 size, bool forced);
 
 void CompileExceptionCheck(ExceptionType type);
+
+/// used for the page fault unit test, don't use outside of tests!
+void SetJit(JitBase* jit);
 
 void Shutdown();
 }

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -8,6 +8,7 @@
 #include "Common/Timer.h"
 #include "Core/MemTools.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
+#include "Core/PowerPC/JitInterface.h"
 
 // include order is important
 #include <gtest/gtest.h>  // NOLINT
@@ -56,7 +57,7 @@ TEST(PageFault, PageFault)
   Common::WriteProtectMemory(data, PAGE_GRAN, false);
 
   PageFaultFakeJit pfjit;
-  g_jit = &pfjit;
+  JitInterface::SetJit(&pfjit);
   pfjit.m_data = data;
 
   auto start = std::chrono::high_resolution_clock::now();
@@ -67,7 +68,7 @@ TEST(PageFault, PageFault)
   ((unsigned long long)std::chrono::duration_cast<std::chrono::nanoseconds>(diff).count())
 
   EMM::UninstallExceptionHandler();
-  g_jit = nullptr;
+  JitInterface::SetJit(nullptr);
 
   printf("page fault timing:\n");
   printf("start->HandleFault     %llu ns\n", AS_NS(pfjit.m_pre_unprotect_time - start));

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
@@ -10,8 +10,8 @@
 #include "Common/FloatUtils.h"
 #include "Common/x64ABI.h"
 #include "Core/PowerPC/Gekko.h"
+#include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
-#include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 
 #include <gtest/gtest.h>
@@ -19,7 +19,7 @@
 class TestCommonAsmRoutines : public CommonAsmRoutines
 {
 public:
-  TestCommonAsmRoutines()
+  TestCommonAsmRoutines() : CommonAsmRoutines(jit)
   {
     using namespace Gen;
 
@@ -49,6 +49,7 @@ public:
   }
 
   u64 (*wrapped_frsqrte)(u64, UReg_FPSCR&);
+  Jit64 jit;
 };
 
 TEST(Jit64, Frsqrte)


### PR DESCRIPTION
Replace g_jit in x86-64 ASM routines code by m_jit member reference.
Followup on #7599.