### PR TITLE
TexDecoder_DecodeRGBA8FromTmem cleanup/ speedup

### DIFF
--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -59,6 +59,28 @@ static inline void AddTexel(const u8* inTexel, u32* outTexel, u32 fract)
   outTexel[3] += inTexel[3] * fract;
 }
 
+static void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int s, int t,
+                                         int imageWidth)
+{
+  u16 sBlk = s >> 2;
+  u16 tBlk = t >> 2;
+  u16 widthBlks =
+      (imageWidth >> 2) + 1;  // TODO: Looks wrong. Shouldn't this be ((imageWidth-1)>>2)+1 ?
+  u32 base_argb = (tBlk * widthBlks + sBlk) << 4;
+  u16 blkS = s & 3;
+  u16 blkT = t & 3;
+  u32 blk_off = (blkT << 2) + blkS;
+
+  u32 offset_argb = (base_argb + blk_off) << 1;
+  const u8* val_addr_ar = src_ar + offset_ar;
+  const u8* val_addr_gb = src_gb + offset_gb;
+
+  dst[3] = val_addr_ar[0];  // A
+  dst[0] = val_addr_ar[1];  // R
+  dst[1] = val_addr_gb[0];  // G
+  dst[2] = val_addr_gb[1];  // B
+}
+
 void Sample(s32 s, s32 t, s32 lod, bool linear, u8 texmap, u8* sample)
 {
   int baseMip = 0;

--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -72,8 +72,8 @@ static void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, const u8* src_ar, const
   u32 blk_off = (blkT << 2) + blkS;
 
   u32 offset_argb = (base_argb + blk_off) << 1;
-  const u8* val_addr_ar = src_ar + offset_ar;
-  const u8* val_addr_gb = src_gb + offset_gb;
+  const u8* val_addr_ar = src_ar + offset_argb;
+  const u8* val_addr_gb = src_gb + offset_argb;
 
   dst[3] = val_addr_ar[0];  // A
   dst[0] = val_addr_ar[1];  // R

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -114,8 +114,6 @@ void TexDecoder_DecodeRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb,
                                     int height);
 void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth,
                             TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt);
-void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int s, int t,
-                                         int imageWidth);
 
 void TexDecoder_SetTexFmtOverlayOptions(bool enable, bool center);
 

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -714,39 +714,31 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
   }
 }
 
-void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int s, int t,
-                                         int imageWidth)
-{
-  u16 sBlk = s >> 2;
-  u16 tBlk = t >> 2;
-  u16 widthBlks =
-      (imageWidth >> 2) + 1;  // TODO: Looks wrong. Shouldn't this be ((imageWidth-1)>>2)+1 ?
-  u32 base_ar = (tBlk * widthBlks + sBlk) << 4;
-  u32 base_gb = (tBlk * widthBlks + sBlk) << 4;
-  u16 blkS = s & 3;
-  u16 blkT = t & 3;
-  u32 blk_off = (blkT << 2) + blkS;
-
-  u32 offset_ar = (base_ar + blk_off) << 1;
-  u32 offset_gb = (base_gb + blk_off) << 1;
-  const u8* val_addr_ar = src_ar + offset_ar;
-  const u8* val_addr_gb = src_gb + offset_gb;
-
-  dst[3] = val_addr_ar[0];  // A
-  dst[0] = val_addr_ar[1];  // R
-  dst[1] = val_addr_gb[0];  // G
-  dst[2] = val_addr_gb[1];  // B
-}
-
 void TexDecoder_DecodeRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int width,
                                     int height)
 {
   // TODO for someone who cares: Make this less slow!
-  for (int y = 0; y < height; ++y)
+  u16 widthBlks = ((width - 1) >> 2) + 1;
+  for (int t = 0; t < height; ++t)
   {
-    for (int x = 0; x < width; ++x)
+    for (int s = 0; s < width; ++s)
     {
-      TexDecoder_DecodeTexelRGBA8FromTmem(dst, src_ar, src_gb, x, y, width - 1);
+      u16 sBlk = s >> 2;
+      u16 tBlk = t >> 2;
+
+      u32 base_argb = (tBlk * widthBlks + sBlk) << 4;
+      u16 blkS = s & 3;
+      u16 blkT = t & 3;
+      u32 blk_off = (blkT << 2) + blkS;
+
+      u32 offset_argb = (base_argb + blk_off) << 1;
+      const u8* val_addr_ar = src_ar + offset_argb;
+      const u8* val_addr_gb = src_gb + offset_argb;
+
+      dst[3] = val_addr_ar[0];  // A
+      dst[0] = val_addr_ar[1];  // R
+      dst[1] = val_addr_gb[0];  // G
+      dst[2] = val_addr_gb[1];  // B
       dst += 4;
     }
   }


### PR DESCRIPTION
Hi!

I noticed that TexDecoder_DecodeTexelRGBA8FromTmem was used in two places. The VideoBackend/Software/TextureSampler.cpp and then TexDecoder_DecodeRGBA8FromTmem function from below. There was a TODO that the TexDecoder_DecodeRGBA8FromTmem needed to be faster. Well it made two loops and the function was inside. I have idea what this function does but I think that the TextureSampler is not so important.

So I copied Texel Decode into the software and then I copied the code from Texel into the TexDecoder_DecodeRGBA8FromTmem. This way there is a lot less function calls. Also there were two multiple vars which did the same edit into two different vars so I compined them.

I tried not to break anything and running the system seems to work normal.