### PR TITLE
cmake: Conditionally build the unit tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(ENABLE_HEADLESS "Enables running Dolphin as a headless variant" OFF)
 option(ENABLE_ALSA "Enables ALSA sound backend" ON)
 option(ENABLE_PULSEAUDIO "Enables PulseAudio sound backend" ON)
 option(ENABLE_LLVM "Enables LLVM support, for disassembly" ON)
+option(ENABLE_TESTS "Enables building the unit tests" ON)
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence, show the current game on Discord" ON)
 
 # Maintainers: if you consider blanket disabling this for your users, please
@@ -720,8 +721,12 @@ include_directories("${PROJECT_BINARY_DIR}/Source/Core")
 ########################################
 # Unit testing.
 #
-message(STATUS "Using static gtest from Externals")
-add_subdirectory(Externals/gtest EXCLUDE_FROM_ALL)
+if(ENABLE_TESTS)
+  message(STATUS "Using static gtest from Externals")
+  add_subdirectory(Externals/gtest EXCLUDE_FROM_ALL)
+else()
+  message(STATUS "Unit tests are disabled")
+endif()
 
 ########################################
 # Process Dolphin source now that all setup is complete

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -39,7 +39,10 @@ add_subdirectory(Core)
 if (ANDROID)
   add_subdirectory(Android/jni)
 endif()
-add_subdirectory(UnitTests)
+
+if (ENABLE_TESTS)
+  add_subdirectory(UnitTests)
+endif()
 
 if (DSPTOOL)
   add_subdirectory(DSPTool)


### PR DESCRIPTION
This allows to skip building the unit tests and avoids the dependency on gtest when doing so.

The default is to build them to retain the current behavior.