### PR TITLE
Implement GC pedometer as input device

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 99;  // Last changed in PR 6020
+static const u32 STATE_VERSION = 111;  // Last changed in PR 7615
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,
@@ -177,10 +177,6 @@ static void DoState(PointerWrap& p)
   g_video_backend->DoState(p);
   p.DoMarker("video_backend");
 
-  if (SConfig::GetInstance().bWii)
-    Wiimote::DoState(p);
-  p.DoMarker("Wiimote");
-
   PowerPC::DoState(p);
   p.DoMarker("PowerPC");
   // CoreTiming needs to be restored before restoring Hardware because
@@ -189,6 +185,9 @@ static void DoState(PointerWrap& p)
   p.DoMarker("CoreTiming");
   HW::DoState(p);
   p.DoMarker("HW");
+  if (SConfig::GetInstance().bWii)
+    Wiimote::DoState(p);
+  p.DoMarker("Wiimote");
   Movie::DoState(p);
   p.DoMarker("Movie");
   Gecko::DoState(p);


### PR DESCRIPTION
The GameCube game Ohenro-san: Hosshin no Dojo came bundled with a pedometer that plugs into the 4th controller port. This implements the basics of the pedometer as an SI device. It's enough to get the game to register the emulated device:

**Before**
![Before](https://i.ibb.co/xmhK3MK/GODJGA-1.png)

**After**
![After](https://i.ibb.co/KVJFVDT/GODJGA-2.png)

Currently this does not let users specify data the pedometer sends (such as height, weight, number of steps, etc). I would like to break that up into other PRs down the road (to make code reviews easier), once I better figure out Dolphin's codebase.