### PR TITLE
Clean up GCMemcard a bit.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -188,7 +188,7 @@ GCMemcard::GCMemcard(const std::string& filename, bool forceCreation, bool shift
   for (u32 i = MC_FST_BLOCKS; i < m_size_blocks; ++i)
   {
     GCMBlock b;
-    if (mcdFile.ReadBytes(b.m_block, BLOCK_SIZE))
+    if (mcdFile.ReadBytes(b.m_block.data(), b.m_block.size()))
     {
       m_data_blocks.push_back(b);
     }
@@ -263,7 +263,7 @@ bool GCMemcard::Save()
   mcdFile.WriteBytes(&m_bat_blocks[1], BLOCK_SIZE);
   for (unsigned int i = 0; i < m_size_blocks - MC_FST_BLOCKS; ++i)
   {
-    mcdFile.WriteBytes(m_data_blocks[i].m_block, BLOCK_SIZE);
+    mcdFile.WriteBytes(m_data_blocks[i].m_block.data(), m_data_blocks[i].m_block.size());
   }
 
   return mcdFile.Close();
@@ -575,7 +575,8 @@ std::string GCMemcard::GetSaveComment1(u8 index) const
   {
     return "";
   }
-  return std::string((const char*)m_data_blocks[DataBlock].m_block + Comment1, DENTRY_STRLEN);
+  return std::string((const char*)m_data_blocks[DataBlock].m_block.data() + Comment1,
+                     DENTRY_STRLEN);
 }
 
 std::string GCMemcard::GetSaveComment2(u8 index) const
@@ -590,7 +591,8 @@ std::string GCMemcard::GetSaveComment2(u8 index) const
   {
     return "";
   }
-  return std::string((const char*)m_data_blocks[DataBlock].m_block + Comment2, DENTRY_STRLEN);
+  return std::string((const char*)m_data_blocks[DataBlock].m_block.data() + Comment2,
+                     DENTRY_STRLEN);
 }
 
 bool GCMemcard::GetDEntry(u8 index, DEntry& dest) const
@@ -888,7 +890,7 @@ u32 GCMemcard::ImportGciInternal(File::IOFile&& gci, const std::string& inputFil
   for (unsigned int i = 0; i < size; ++i)
   {
     GCMBlock b;
-    gci.ReadBytes(b.m_block, BLOCK_SIZE);
+    gci.ReadBytes(b.m_block.data(), b.m_block.size());
     saveData.push_back(b);
   }
   u32 ret;
@@ -909,7 +911,7 @@ u32 GCMemcard::ImportGciInternal(File::IOFile&& gci, const std::string& inputFil
 
     for (int i = 0; i < fileBlocks; ++i)
     {
-      if (!gci2.WriteBytes(saveData[i].m_block, BLOCK_SIZE))
+      if (!gci2.WriteBytes(saveData[i].m_block.data(), saveData[i].m_block.size()))
         completeWrite = false;
     }
 
@@ -1002,7 +1004,7 @@ u32 GCMemcard::ExportGci(u8 index, const std::string& fileName, const std::strin
   gci.Seek(DENTRY_SIZE + offset, SEEK_SET);
   for (unsigned int i = 0; i < size; ++i)
   {
-    gci.WriteBytes(saveData[i].m_block, BLOCK_SIZE);
+    gci.WriteBytes(saveData[i].m_block.data(), saveData[i].m_block.size());
   }
 
   if (gci.IsGood())
@@ -1097,14 +1099,14 @@ bool GCMemcard::ReadBannerRGBA8(u8 index, u32* buffer) const
 
   if (bnrFormat & 1)
   {
-    u8* pxdata = (u8*)(m_data_blocks[DataBlock].m_block + DataOffset);
-    u16* paldata = (u16*)(m_data_blocks[DataBlock].m_block + DataOffset + pixels);
+    u8* pxdata = (u8*)(m_data_blocks[DataBlock].m_block.data() + DataOffset);
+    u16* paldata = (u16*)(m_data_blocks[DataBlock].m_block.data() + DataOffset + pixels);
 
     Common::DecodeCI8Image(buffer, pxdata, paldata, 96, 32);
   }
   else
   {
-    u16* pxdata = (u16*)(m_data_blocks[DataBlock].m_block + DataOffset);
+    u16* pxdata = (u16*)(m_data_blocks[DataBlock].m_block.data() + DataOffset);
 
     Common::Decode5A3Image(buffer, pxdata, 96, 32);
   }
@@ -1140,7 +1142,7 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
     return 0;
   }
 
-  u8* animData = (u8*)(m_data_blocks[DataBlock].m_block + DataOffset);
+  u8* animData = (u8*)(m_data_blocks[DataBlock].m_block.data() + DataOffset);
 
   switch (bnrFormat)
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -533,7 +533,7 @@ u32 GCMemcard::DEntry_CommentsAddress(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFF;
 
-  return BE32(CurrentDir->m_dir_entries[index].m_comments_address);
+  return CurrentDir->m_dir_entries[index].m_comments_address;
 }
 
 std::string GCMemcard::GetSaveComment1(u8 index) const
@@ -541,7 +541,7 @@ std::string GCMemcard::GetSaveComment1(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  u32 Comment1 = BE32(CurrentDir->m_dir_entries[index].m_comments_address);
+  u32 Comment1 = CurrentDir->m_dir_entries[index].m_comments_address;
   u32 DataBlock = CurrentDir->m_dir_entries[index].m_first_block - MC_FST_BLOCKS;
   if ((DataBlock > maxBlock) || (Comment1 == 0xFFFFFFFF))
   {
@@ -555,7 +555,7 @@ std::string GCMemcard::GetSaveComment2(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  u32 Comment1 = BE32(CurrentDir->m_dir_entries[index].m_comments_address);
+  u32 Comment1 = CurrentDir->m_dir_entries[index].m_comments_address;
   u32 Comment2 = Comment1 + DENTRY_STRLEN;
   u32 DataBlock = CurrentDir->m_dir_entries[index].m_first_block - MC_FST_BLOCKS;
   if ((DataBlock > maxBlock) || (Comment1 == 0xFFFFFFFF))
@@ -1070,8 +1070,11 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     memcpy(&tempDEntry.m_block_count, tmp.data(), 2);
 
     ArrayByteSwap((tempDEntry.m_unused_2));
-    ArrayByteSwap((tempDEntry.m_comments_address));
-    ArrayByteSwap(&(tempDEntry.m_comments_address[2]));
+
+    memcpy(tmp.data(), &tempDEntry.m_comments_address, 4);
+    ByteSwap(&tmp[0], &tmp[1]);
+    ByteSwap(&tmp[2], &tmp[3]);
+    memcpy(&tempDEntry.m_comments_address, tmp.data(), 4);
     break;
   default:
     break;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -328,7 +328,7 @@ u8 GCMemcard::GetNumFiles() const
   u8 j = 0;
   for (int i = 0; i < DIRLEN; i++)
   {
-    if (BE32(CurrentDir->m_dir_entries[i].m_gamecode) != 0xFFFFFFFF)
+    if (CurrentDir->m_dir_entries[i].m_gamecode != DEntry::UNINITIALIZED_GAMECODE)
       j++;
   }
   return j;
@@ -341,7 +341,7 @@ u8 GCMemcard::GetFileIndex(u8 fileNumber) const
     u8 j = 0;
     for (u8 i = 0; i < DIRLEN; i++)
     {
-      if (BE32(CurrentDir->m_dir_entries[i].m_gamecode) != 0xFFFFFFFF)
+      if (CurrentDir->m_dir_entries[i].m_gamecode != DEntry::UNINITIALIZED_GAMECODE)
       {
         if (j == fileNumber)
         {
@@ -370,7 +370,7 @@ u8 GCMemcard::TitlePresent(const DEntry& d) const
   u8 i = 0;
   while (i < DIRLEN)
   {
-    if ((BE32(CurrentDir->m_dir_entries[i].m_gamecode) == BE32(d.m_gamecode)) &&
+    if (CurrentDir->m_dir_entries[i].m_gamecode == d.m_gamecode &&
         CurrentDir->m_dir_entries[i].m_filename == d.m_filename)
     {
       break;
@@ -382,7 +382,8 @@ u8 GCMemcard::TitlePresent(const DEntry& d) const
 
 bool GCMemcard::GCI_FileName(u8 index, std::string& filename) const
 {
-  if (!m_valid || index >= DIRLEN || (BE32(CurrentDir->m_dir_entries[index].m_gamecode) == 0xFFFFFFFF))
+  if (!m_valid || index >= DIRLEN ||
+      CurrentDir->m_dir_entries[index].m_gamecode == DEntry::UNINITIALIZED_GAMECODE)
     return false;
 
   filename = CurrentDir->m_dir_entries[index].GCI_FileName();
@@ -397,7 +398,9 @@ std::string GCMemcard::DEntry_GameCode(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  return std::string((const char*)CurrentDir->m_dir_entries[index].m_gamecode, 4);
+  return std::string(
+      reinterpret_cast<const char*>(CurrentDir->m_dir_entries[index].m_gamecode.data()),
+      CurrentDir->m_dir_entries[index].m_gamecode.size());
 }
 
 std::string GCMemcard::DEntry_Makercode(u8 index) const
@@ -681,7 +684,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
   // find first free dir entry
   for (int i = 0; i < DIRLEN; i++)
   {
-    if (BE32(UpdatedDir.m_dir_entries[i].m_gamecode) == 0xFFFFFFFF)
+    if (UpdatedDir.m_dir_entries[i].m_gamecode == DEntry::UNINITIALIZED_GAMECODE)
     {
       UpdatedDir.m_dir_entries[i] = direntry;
       UpdatedDir.m_dir_entries[i].m_first_block = firstBlock;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -359,7 +359,7 @@ u16 GCMemcard::GetFreeBlocks() const
   if (!m_valid)
     return 0;
 
-  return BE16(CurrentBat->m_free_blocks);
+  return CurrentBat->m_free_blocks;
 }
 
 u8 GCMemcard::TitlePresent(const DEntry& d) const
@@ -593,7 +593,7 @@ u16 BlockAlloc::GetNextBlock(u16 Block) const
 // not BAT index; that is, block 5 is the first file data block.
 u16 BlockAlloc::NextFreeBlock(u16 MaxBlock, u16 StartingBlock) const
 {
-  if (m_free_blocks)
+  if (m_free_blocks > 0)
   {
     StartingBlock = MathUtil::Clamp<u16>(StartingBlock, MC_FST_BLOCKS, BAT_SIZE + MC_FST_BLOCKS);
     MaxBlock = MathUtil::Clamp<u16>(MaxBlock, MC_FST_BLOCKS, BAT_SIZE + MC_FST_BLOCKS);
@@ -625,7 +625,7 @@ bool BlockAlloc::ClearBlocks(u16 FirstBlock, u16 BlockCount)
     }
     for (unsigned int i = 0; i < length; ++i)
       m_map[blocks.at(i) - MC_FST_BLOCKS] = 0;
-    m_free_blocks = BE16(BE16(m_free_blocks) + BlockCount);
+    m_free_blocks = m_free_blocks + BlockCount;
 
     return true;
   }
@@ -667,7 +667,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
   {
     return OUTOFDIRENTRIES;
   }
-  if (BE16(CurrentBat->m_free_blocks) < direntry.m_block_count)
+  if (CurrentBat->m_free_blocks < direntry.m_block_count)
   {
     return OUTOFBLOCKS;
   }
@@ -729,7 +729,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
     firstBlock = nextBlock;
   }
 
-  UpdatedBat.m_free_blocks = BE16(BE16(UpdatedBat.m_free_blocks) - fileBlocks);
+  UpdatedBat.m_free_blocks = UpdatedBat.m_free_blocks - fileBlocks;
   UpdatedBat.m_update_counter = UpdatedBat.m_update_counter + 1;
   *PreviousBat = UpdatedBat;
   if (PreviousBat == &bat)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -759,27 +759,11 @@ u32 GCMemcard::RemoveFile(u8 index)  // index in the directory array
   UpdateBat(UpdatedBat);
 
   Directory UpdatedDir = GetActiveDirectory();
-  /*
-  // TODO: determine when this is used, even on the same memory card I have seen
-  // both update to broken file, and not updated
-  *(u32*)&UpdatedDir.m_dir_entries[index].m_gamecode = 0;
-  *(u16*)&UpdatedDir.m_dir_entries[index].m_makercode = 0;
-  memset(UpdatedDir.m_dir_entries[index].m_filename, 0, 0x20);
-  strcpy((char*)UpdatedDir.m_dir_entries[index].m_filename, "Broken File000");
-  *(u16*)&UpdatedDir.m_update_counter = BE16(BE16(UpdatedDir.m_update_counter) + 1);
 
-  *PreviousDir = UpdatedDir;
-  if (PreviousDir == &dir )
-  {
-    CurrentDir = &dir;
-    PreviousDir = &dir_backup;
-  }
-  else
-  {
-    CurrentDir = &dir_backup;
-    PreviousDir = &dir;
-  }
-  */
+  // TODO: Deleting a file via the GC BIOS sometimes leaves behind an extra updated directory block
+  // here that has an empty file with the filename "Broken File000" where the actual deleted file
+  // was. Determine when exactly this happens and if this is neccessary for anything.
+
   memset(&(UpdatedDir.m_dir_entries[index]), 0xFF, DENTRY_SIZE);
   UpdatedDir.m_update_counter = UpdatedDir.m_update_counter + 1;
   UpdateDirectory(UpdatedDir);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -20,6 +20,9 @@
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
 
+// TODO: Remove when on C++17 everywhere.
+constexpr std::array<u8, 4> DEntry::UNINITIALIZED_GAMECODE;
+
 static void ByteSwap(u8* valueA, u8* valueB)
 {
   u8 tmp = *valueA;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -436,7 +436,7 @@ u32 GCMemcard::DEntry_ModTime(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFFFFFF;
 
-  return BE32(CurrentDir->m_dir_entries[index].m_modification_time);
+  return CurrentDir->m_dir_entries[index].m_modification_time;
 }
 
 u32 GCMemcard::DEntry_ImageOffset(u8 index) const

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -444,7 +444,7 @@ u32 GCMemcard::DEntry_ImageOffset(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFFFFFF;
 
-  return BE32(CurrentDir->m_dir_entries[index].m_image_offset);
+  return CurrentDir->m_dir_entries[index].m_image_offset;
 }
 
 std::string GCMemcard::DEntry_IconFmt(u8 index) const
@@ -1040,8 +1040,13 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     // 0x3C and 0x3D,0x3E and 0x3F.
     // It seems that sav files also swap the banner/icon flags...
     ByteSwap(&tempDEntry.m_unused_1, &tempDEntry.m_banner_and_icon_flags);
-    ArrayByteSwap((tempDEntry.m_image_offset));
-    ArrayByteSwap(&(tempDEntry.m_image_offset[2]));
+
+    std::array<u8, 4> tmp;
+    memcpy(tmp.data(), &tempDEntry.m_image_offset, 4);
+    ByteSwap(&tmp[0], &tmp[1]);
+    ByteSwap(&tmp[2], &tmp[3]);
+    memcpy(&tempDEntry.m_image_offset, tmp.data(), 4);
+
     ArrayByteSwap((tempDEntry.m_icon_format));
     ArrayByteSwap((tempDEntry.m_animation_speed));
     ByteSwap(&tempDEntry.m_file_permissions, &tempDEntry.m_copy_counter);
@@ -1072,7 +1077,7 @@ bool GCMemcard::ReadBannerRGBA8(u8 index, u32* buffer) const
   if (bnrFormat == 0)
     return false;
 
-  u32 DataOffset = BE32(CurrentDir->m_dir_entries[index].m_image_offset);
+  u32 DataOffset = CurrentDir->m_dir_entries[index].m_image_offset;
   u32 DataBlock = BE16(CurrentDir->m_dir_entries[index].m_first_block) - MC_FST_BLOCKS;
 
   if ((DataBlock > maxBlock) || (DataOffset == 0xFFFFFFFF))
@@ -1119,7 +1124,7 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
 
   int bnrFormat = (flags & 3);
 
-  u32 DataOffset = BE32(CurrentDir->m_dir_entries[index].m_image_offset);
+  u32 DataOffset = CurrentDir->m_dir_entries[index].m_image_offset;
   u32 DataBlock = BE16(CurrentDir->m_dir_entries[index].m_first_block) - MC_FST_BLOCKS;
 
   if ((DataBlock > maxBlock) || (DataOffset == 0xFFFFFFFF))

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -471,12 +471,14 @@ std::string GCMemcard::DEntry_AnimSpeed(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  int x = CurrentDir->m_dir_entries[index].m_animation_speed[0];
+  std::array<u8, 2> tmp;
+  memcpy(tmp.data(), &CurrentDir->m_dir_entries[index].m_animation_speed, 2);
+  int x = tmp[0];
   std::string speed;
   for (int i = 0; i < 16; i++)
   {
     if (i == 8)
-      x = CurrentDir->m_dir_entries[index].m_animation_speed[1];
+      x = tmp[1];
     speed.push_back((x & 0x80) ? '1' : '0');
     x = x << 1;
   }
@@ -1053,7 +1055,10 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     ByteSwap(&tmp[0], &tmp[1]);
     memcpy(&tempDEntry.m_icon_format, tmp.data(), 2);
 
-    ArrayByteSwap((tempDEntry.m_animation_speed));
+    memcpy(tmp.data(), &tempDEntry.m_animation_speed, 2);
+    ByteSwap(&tmp[0], &tmp[1]);
+    memcpy(&tempDEntry.m_animation_speed, tmp.data(), 2);
+
     ByteSwap(&tempDEntry.m_file_permissions, &tempDEntry.m_copy_counter);
     ArrayByteSwap((tempDEntry.m_first_block));
     ArrayByteSwap((tempDEntry.m_block_count));
@@ -1118,7 +1123,7 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
   // int fmtCheck = 0;
 
   int formats = CurrentDir->m_dir_entries[index].m_icon_format;
-  int fdelays = BE16(CurrentDir->m_dir_entries[index].m_animation_speed);
+  int fdelays = CurrentDir->m_dir_entries[index].m_animation_speed;
 
   int flags = CurrentDir->m_dir_entries[index].m_banner_and_icon_flags;
   // Timesplitters 2 and 3 is the only game that I see this in

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -173,7 +173,7 @@ GCMemcard::GCMemcard(const std::string& filename, bool forceCreation, bool shift
     // the backup should be copied?
     //	}
     //
-    //	if (BE16(dir_backup.m_update_counter) > BE16(dir.m_update_counter)) //check if the backup is newer
+    //	if (dir_backup.m_update_counter > dir.m_update_counter) //check if the backup is newer
     //	{
     //		dir = dir_backup;
     //		bat = bat_backup; // needed?
@@ -209,7 +209,7 @@ GCMemcard::GCMemcard(const std::string& filename, bool forceCreation, bool shift
 
 void GCMemcard::InitDirBatPointers()
 {
-  if (BE16(dir.m_update_counter) > (BE16(dir_backup.m_update_counter)))
+  if (dir.m_update_counter > dir_backup.m_update_counter)
   {
     CurrentDir = &dir;
     PreviousDir = &dir_backup;
@@ -694,7 +694,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
       break;
     }
   }
-  UpdatedDir.m_update_counter = BE16(BE16(UpdatedDir.m_update_counter) + 1);
+  UpdatedDir.m_update_counter = UpdatedDir.m_update_counter + 1;
   *PreviousDir = UpdatedDir;
   if (PreviousDir == &dir)
   {
@@ -797,7 +797,7 @@ u32 GCMemcard::RemoveFile(u8 index)  // index in the directory array
   }
   */
   memset(&(UpdatedDir.m_dir_entries[index]), 0xFF, DENTRY_SIZE);
-  UpdatedDir.m_update_counter = BE16(BE16(UpdatedDir.m_update_counter) + 1);
+  UpdatedDir.m_update_counter = UpdatedDir.m_update_counter + 1;
   *PreviousDir = UpdatedDir;
   if (PreviousDir == &dir)
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -511,7 +511,7 @@ u16 GCMemcard::DEntry_FirstBlock(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFF;
 
-  u16 block = BE16(CurrentDir->m_dir_entries[index].m_first_block);
+  u16 block = CurrentDir->m_dir_entries[index].m_first_block;
   if (block > (u16)maxBlock)
     return 0xFFFF;
   return block;
@@ -542,7 +542,7 @@ std::string GCMemcard::GetSaveComment1(u8 index) const
     return "";
 
   u32 Comment1 = BE32(CurrentDir->m_dir_entries[index].m_comments_address);
-  u32 DataBlock = BE16(CurrentDir->m_dir_entries[index].m_first_block) - MC_FST_BLOCKS;
+  u32 DataBlock = CurrentDir->m_dir_entries[index].m_first_block - MC_FST_BLOCKS;
   if ((DataBlock > maxBlock) || (Comment1 == 0xFFFFFFFF))
   {
     return "";
@@ -557,7 +557,7 @@ std::string GCMemcard::GetSaveComment2(u8 index) const
 
   u32 Comment1 = BE32(CurrentDir->m_dir_entries[index].m_comments_address);
   u32 Comment2 = Comment1 + DENTRY_STRLEN;
-  u32 DataBlock = BE16(CurrentDir->m_dir_entries[index].m_first_block) - MC_FST_BLOCKS;
+  u32 DataBlock = CurrentDir->m_dir_entries[index].m_first_block - MC_FST_BLOCKS;
   if ((DataBlock > maxBlock) || (Comment1 == 0xFFFFFFFF))
   {
     return "";
@@ -682,7 +682,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
     if (BE32(UpdatedDir.m_dir_entries[i].m_gamecode) == 0xFFFFFFFF)
     {
       UpdatedDir.m_dir_entries[i] = direntry;
-      *(u16*)&UpdatedDir.m_dir_entries[i].m_first_block = BE16(firstBlock);
+      UpdatedDir.m_dir_entries[i].m_first_block = firstBlock;
       UpdatedDir.m_dir_entries[i].m_copy_counter = UpdatedDir.m_dir_entries[i].m_copy_counter + 1;
       break;
     }
@@ -748,7 +748,7 @@ u32 GCMemcard::RemoveFile(u8 index)  // index in the directory array
   if (index >= DIRLEN)
     return DELETE_FAIL;
 
-  u16 startingblock = BE16(CurrentDir->m_dir_entries[index].m_first_block);
+  u16 startingblock = CurrentDir->m_dir_entries[index].m_first_block;
   u16 numberofblocks = BE16(CurrentDir->m_dir_entries[index].m_block_count);
 
   BlockAlloc UpdatedBat = *CurrentBat;
@@ -1060,7 +1060,11 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     memcpy(&tempDEntry.m_animation_speed, tmp.data(), 2);
 
     ByteSwap(&tempDEntry.m_file_permissions, &tempDEntry.m_copy_counter);
-    ArrayByteSwap((tempDEntry.m_first_block));
+
+    memcpy(tmp.data(), &tempDEntry.m_first_block, 2);
+    ByteSwap(&tmp[0], &tmp[1]);
+    memcpy(&tempDEntry.m_first_block, tmp.data(), 2);
+
     ArrayByteSwap((tempDEntry.m_block_count));
     ArrayByteSwap((tempDEntry.m_unused_2));
     ArrayByteSwap((tempDEntry.m_comments_address));
@@ -1088,7 +1092,7 @@ bool GCMemcard::ReadBannerRGBA8(u8 index, u32* buffer) const
     return false;
 
   u32 DataOffset = CurrentDir->m_dir_entries[index].m_image_offset;
-  u32 DataBlock = BE16(CurrentDir->m_dir_entries[index].m_first_block) - MC_FST_BLOCKS;
+  u32 DataBlock = CurrentDir->m_dir_entries[index].m_first_block - MC_FST_BLOCKS;
 
   if ((DataBlock > maxBlock) || (DataOffset == 0xFFFFFFFF))
   {
@@ -1135,7 +1139,7 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
   int bnrFormat = (flags & 3);
 
   u32 DataOffset = CurrentDir->m_dir_entries[index].m_image_offset;
-  u32 DataBlock = BE16(CurrentDir->m_dir_entries[index].m_first_block) - MC_FST_BLOCKS;
+  u32 DataBlock = CurrentDir->m_dir_entries[index].m_first_block - MC_FST_BLOCKS;
 
   if ((DataBlock > maxBlock) || (DataOffset == 0xFFFFFFFF))
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -327,7 +327,7 @@ u8 GCMemcard::GetNumFiles() const
   u8 j = 0;
   for (int i = 0; i < DIRLEN; i++)
   {
-    if (BE32(CurrentDir->Dir[i].Gamecode) != 0xFFFFFFFF)
+    if (BE32(CurrentDir->Dir[i].m_gamecode) != 0xFFFFFFFF)
       j++;
   }
   return j;
@@ -340,7 +340,7 @@ u8 GCMemcard::GetFileIndex(u8 fileNumber) const
     u8 j = 0;
     for (u8 i = 0; i < DIRLEN; i++)
     {
-      if (BE32(CurrentDir->Dir[i].Gamecode) != 0xFFFFFFFF)
+      if (BE32(CurrentDir->Dir[i].m_gamecode) != 0xFFFFFFFF)
       {
         if (j == fileNumber)
         {
@@ -369,8 +369,8 @@ u8 GCMemcard::TitlePresent(const DEntry& d) const
   u8 i = 0;
   while (i < DIRLEN)
   {
-    if ((BE32(CurrentDir->Dir[i].Gamecode) == BE32(d.Gamecode)) &&
-        (!memcmp(CurrentDir->Dir[i].Filename, d.Filename, 32)))
+    if ((BE32(CurrentDir->Dir[i].m_gamecode) == BE32(d.m_gamecode)) &&
+        (!memcmp(CurrentDir->Dir[i].m_filename, d.m_filename, 32)))
     {
       break;
     }
@@ -381,7 +381,7 @@ u8 GCMemcard::TitlePresent(const DEntry& d) const
 
 bool GCMemcard::GCI_FileName(u8 index, std::string& filename) const
 {
-  if (!m_valid || index >= DIRLEN || (BE32(CurrentDir->Dir[index].Gamecode) == 0xFFFFFFFF))
+  if (!m_valid || index >= DIRLEN || (BE32(CurrentDir->Dir[index].m_gamecode) == 0xFFFFFFFF))
     return false;
 
   filename = CurrentDir->Dir[index].GCI_FileName();
@@ -396,7 +396,7 @@ std::string GCMemcard::DEntry_GameCode(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  return std::string((const char*)CurrentDir->Dir[index].Gamecode, 4);
+  return std::string((const char*)CurrentDir->Dir[index].m_gamecode, 4);
 }
 
 std::string GCMemcard::DEntry_Makercode(u8 index) const
@@ -404,7 +404,7 @@ std::string GCMemcard::DEntry_Makercode(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  return std::string((const char*)CurrentDir->Dir[index].Makercode, 2);
+  return std::string((const char*)CurrentDir->Dir[index].m_makercode, 2);
 }
 
 std::string GCMemcard::DEntry_BIFlags(u8 index) const
@@ -413,7 +413,7 @@ std::string GCMemcard::DEntry_BIFlags(u8 index) const
     return "";
 
   std::string flags;
-  int x = CurrentDir->Dir[index].BIFlags;
+  int x = CurrentDir->Dir[index].m_banner_and_icon_flags;
   for (int i = 0; i < 8; i++)
   {
     flags.push_back((x & 0x80) ? '1' : '0');
@@ -427,7 +427,7 @@ std::string GCMemcard::DEntry_FileName(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  return std::string((const char*)CurrentDir->Dir[index].Filename, DENTRY_STRLEN);
+  return std::string((const char*)CurrentDir->Dir[index].m_filename, DENTRY_STRLEN);
 }
 
 u32 GCMemcard::DEntry_ModTime(u8 index) const
@@ -435,7 +435,7 @@ u32 GCMemcard::DEntry_ModTime(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFFFFFF;
 
-  return BE32(CurrentDir->Dir[index].ModTime);
+  return BE32(CurrentDir->Dir[index].m_modification_time);
 }
 
 u32 GCMemcard::DEntry_ImageOffset(u8 index) const
@@ -443,7 +443,7 @@ u32 GCMemcard::DEntry_ImageOffset(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFFFFFF;
 
-  return BE32(CurrentDir->Dir[index].ImageOffset);
+  return BE32(CurrentDir->Dir[index].m_image_offset);
 }
 
 std::string GCMemcard::DEntry_IconFmt(u8 index) const
@@ -451,12 +451,12 @@ std::string GCMemcard::DEntry_IconFmt(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  int x = CurrentDir->Dir[index].IconFmt[0];
+  int x = CurrentDir->Dir[index].m_icon_format[0];
   std::string format;
   for (int i = 0; i < 16; i++)
   {
     if (i == 8)
-      x = CurrentDir->Dir[index].IconFmt[1];
+      x = CurrentDir->Dir[index].m_icon_format[1];
     format.push_back((x & 0x80) ? '1' : '0');
     x = x << 1;
   }
@@ -468,12 +468,12 @@ std::string GCMemcard::DEntry_AnimSpeed(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  int x = CurrentDir->Dir[index].AnimSpeed[0];
+  int x = CurrentDir->Dir[index].m_animation_speed[0];
   std::string speed;
   for (int i = 0; i < 16; i++)
   {
     if (i == 8)
-      x = CurrentDir->Dir[index].AnimSpeed[1];
+      x = CurrentDir->Dir[index].m_animation_speed[1];
     speed.push_back((x & 0x80) ? '1' : '0');
     x = x << 1;
   }
@@ -485,7 +485,7 @@ std::string GCMemcard::DEntry_Permissions(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  u8 Permissions = CurrentDir->Dir[index].Permissions;
+  u8 Permissions = CurrentDir->Dir[index].m_file_permissions;
   std::string permissionsString;
   permissionsString.push_back((Permissions & 16) ? 'x' : 'M');
   permissionsString.push_back((Permissions & 8) ? 'x' : 'C');
@@ -498,7 +498,7 @@ u8 GCMemcard::DEntry_CopyCounter(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFF;
 
-  return CurrentDir->Dir[index].CopyCounter;
+  return CurrentDir->Dir[index].m_copy_counter;
 }
 
 u16 GCMemcard::DEntry_FirstBlock(u8 index) const
@@ -506,7 +506,7 @@ u16 GCMemcard::DEntry_FirstBlock(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFF;
 
-  u16 block = BE16(CurrentDir->Dir[index].FirstBlock);
+  u16 block = BE16(CurrentDir->Dir[index].m_first_block);
   if (block > (u16)maxBlock)
     return 0xFFFF;
   return block;
@@ -517,7 +517,7 @@ u16 GCMemcard::DEntry_BlockCount(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFF;
 
-  u16 blocks = BE16(CurrentDir->Dir[index].BlockCount);
+  u16 blocks = BE16(CurrentDir->Dir[index].m_block_count);
   if (blocks > (u16)maxBlock)
     return 0xFFFF;
   return blocks;
@@ -528,7 +528,7 @@ u32 GCMemcard::DEntry_CommentsAddress(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return 0xFFFF;
 
-  return BE32(CurrentDir->Dir[index].CommentsAddr);
+  return BE32(CurrentDir->Dir[index].m_comments_address);
 }
 
 std::string GCMemcard::GetSaveComment1(u8 index) const
@@ -536,8 +536,8 @@ std::string GCMemcard::GetSaveComment1(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  u32 Comment1 = BE32(CurrentDir->Dir[index].CommentsAddr);
-  u32 DataBlock = BE16(CurrentDir->Dir[index].FirstBlock) - MC_FST_BLOCKS;
+  u32 Comment1 = BE32(CurrentDir->Dir[index].m_comments_address);
+  u32 DataBlock = BE16(CurrentDir->Dir[index].m_first_block) - MC_FST_BLOCKS;
   if ((DataBlock > maxBlock) || (Comment1 == 0xFFFFFFFF))
   {
     return "";
@@ -550,9 +550,9 @@ std::string GCMemcard::GetSaveComment2(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  u32 Comment1 = BE32(CurrentDir->Dir[index].CommentsAddr);
+  u32 Comment1 = BE32(CurrentDir->Dir[index].m_comments_address);
   u32 Comment2 = Comment1 + DENTRY_STRLEN;
-  u32 DataBlock = BE16(CurrentDir->Dir[index].FirstBlock) - MC_FST_BLOCKS;
+  u32 DataBlock = BE16(CurrentDir->Dir[index].m_first_block) - MC_FST_BLOCKS;
   if ((DataBlock > maxBlock) || (Comment1 == 0xFFFFFFFF))
   {
     return "";
@@ -655,7 +655,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
   {
     return OUTOFDIRENTRIES;
   }
-  if (BE16(CurrentBat->FreeBlocks) < BE16(direntry.BlockCount))
+  if (BE16(CurrentBat->FreeBlocks) < BE16(direntry.m_block_count))
   {
     return OUTOFBLOCKS;
   }
@@ -673,11 +673,11 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
   // find first free dir entry
   for (int i = 0; i < DIRLEN; i++)
   {
-    if (BE32(UpdatedDir.Dir[i].Gamecode) == 0xFFFFFFFF)
+    if (BE32(UpdatedDir.Dir[i].m_gamecode) == 0xFFFFFFFF)
     {
       UpdatedDir.Dir[i] = direntry;
-      *(u16*)&UpdatedDir.Dir[i].FirstBlock = BE16(firstBlock);
-      UpdatedDir.Dir[i].CopyCounter = UpdatedDir.Dir[i].CopyCounter + 1;
+      *(u16*)&UpdatedDir.Dir[i].m_first_block = BE16(firstBlock);
+      UpdatedDir.Dir[i].m_copy_counter = UpdatedDir.Dir[i].m_copy_counter + 1;
       break;
     }
   }
@@ -694,7 +694,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
     PreviousDir = &dir;
   }
 
-  int fileBlocks = BE16(direntry.BlockCount);
+  int fileBlocks = BE16(direntry.m_block_count);
 
   FZEROGX_MakeSaveGameValid(hdr, direntry, saveBlocks);
   PSO_MakeSaveGameValid(hdr, direntry, saveBlocks);
@@ -742,8 +742,8 @@ u32 GCMemcard::RemoveFile(u8 index)  // index in the directory array
   if (index >= DIRLEN)
     return DELETE_FAIL;
 
-  u16 startingblock = BE16(CurrentDir->Dir[index].FirstBlock);
-  u16 numberofblocks = BE16(CurrentDir->Dir[index].BlockCount);
+  u16 startingblock = BE16(CurrentDir->Dir[index].m_first_block);
+  u16 numberofblocks = BE16(CurrentDir->Dir[index].m_block_count);
 
   BlockAlloc UpdatedBat = *CurrentBat;
   if (!UpdatedBat.ClearBlocks(startingblock, numberofblocks))
@@ -765,10 +765,10 @@ u32 GCMemcard::RemoveFile(u8 index)  // index in the directory array
   /*
   // TODO: determine when this is used, even on the same memory card I have seen
   // both update to broken file, and not updated
-  *(u32*)&UpdatedDir.Dir[index].Gamecode = 0;
-  *(u16*)&UpdatedDir.Dir[index].Makercode = 0;
-  memset(UpdatedDir.Dir[index].Filename, 0, 0x20);
-  strcpy((char*)UpdatedDir.Dir[index].Filename, "Broken File000");
+  *(u32*)&UpdatedDir.Dir[index].m_gamecode = 0;
+  *(u16*)&UpdatedDir.Dir[index].m_makercode = 0;
+  memset(UpdatedDir.Dir[index].m_filename, 0, 0x20);
+  strcpy((char*)UpdatedDir.Dir[index].m_filename, "Broken File000");
   *(u16*)&UpdatedDir.UpdateCounter = BE16(BE16(UpdatedDir.UpdateCounter) + 1);
 
   *PreviousDir = UpdatedDir;
@@ -882,12 +882,12 @@ u32 GCMemcard::ImportGciInternal(File::IOFile&& gci, const std::string& inputFil
 
   Gcs_SavConvert(tempDEntry, offset, length);
 
-  if (length != BE16(tempDEntry.BlockCount) * BLOCK_SIZE)
+  if (length != BE16(tempDEntry.m_block_count) * BLOCK_SIZE)
     return LENGTHFAIL;
   if (gci.Tell() != offset + DENTRY_SIZE)  // Verify correct file position
     return OPENFAIL;
 
-  u32 size = BE16((tempDEntry.BlockCount));
+  u32 size = BE16((tempDEntry.m_block_count));
   std::vector<GCMBlock> saveData;
   saveData.reserve(size);
 
@@ -910,7 +910,7 @@ u32 GCMemcard::ImportGciInternal(File::IOFile&& gci, const std::string& inputFil
 
     if (!gci2.WriteBytes(&tempDEntry, DENTRY_SIZE))
       completeWrite = false;
-    int fileBlocks = BE16(tempDEntry.BlockCount);
+    int fileBlocks = BE16(tempDEntry.m_block_count);
     gci2.Seek(DENTRY_SIZE, SEEK_SET);
 
     for (int i = 0; i < fileBlocks; ++i)
@@ -1028,7 +1028,7 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     // It is stored only within the corresponding GSV file.
     // If the GCS file is added without using the GameSaves software,
     // the value stored is always "1"
-    *(u16*)&tempDEntry.BlockCount = BE16(length / BLOCK_SIZE);
+    *(u16*)&tempDEntry.m_block_count = BE16(length / BLOCK_SIZE);
   }
   break;
   case SAV:
@@ -1036,18 +1036,18 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     // 0x2C and 0x2D, 0x2E and 0x2F, 0x30 and 0x31, 0x32 and 0x33,
     // 0x34 and 0x35, 0x36 and 0x37, 0x38 and 0x39, 0x3A and 0x3B,
     // 0x3C and 0x3D,0x3E and 0x3F.
-    // It seems that sav files also swap the BIFlags...
-    ByteSwap(&tempDEntry.Unused1, &tempDEntry.BIFlags);
-    ArrayByteSwap((tempDEntry.ImageOffset));
-    ArrayByteSwap(&(tempDEntry.ImageOffset[2]));
-    ArrayByteSwap((tempDEntry.IconFmt));
-    ArrayByteSwap((tempDEntry.AnimSpeed));
-    ByteSwap(&tempDEntry.Permissions, &tempDEntry.CopyCounter);
-    ArrayByteSwap((tempDEntry.FirstBlock));
-    ArrayByteSwap((tempDEntry.BlockCount));
-    ArrayByteSwap((tempDEntry.Unused2));
-    ArrayByteSwap((tempDEntry.CommentsAddr));
-    ArrayByteSwap(&(tempDEntry.CommentsAddr[2]));
+    // It seems that sav files also swap the banner/icon flags...
+    ByteSwap(&tempDEntry.m_unused_1, &tempDEntry.m_banner_and_icon_flags);
+    ArrayByteSwap((tempDEntry.m_image_offset));
+    ArrayByteSwap(&(tempDEntry.m_image_offset[2]));
+    ArrayByteSwap((tempDEntry.m_icon_format));
+    ArrayByteSwap((tempDEntry.m_animation_speed));
+    ByteSwap(&tempDEntry.m_file_permissions, &tempDEntry.m_copy_counter);
+    ArrayByteSwap((tempDEntry.m_first_block));
+    ArrayByteSwap((tempDEntry.m_block_count));
+    ArrayByteSwap((tempDEntry.m_unused_2));
+    ArrayByteSwap((tempDEntry.m_comments_address));
+    ArrayByteSwap(&(tempDEntry.m_comments_address[2]));
     break;
   default:
     break;
@@ -1059,7 +1059,7 @@ bool GCMemcard::ReadBannerRGBA8(u8 index, u32* buffer) const
   if (!m_valid || index >= DIRLEN)
     return false;
 
-  int flags = CurrentDir->Dir[index].BIFlags;
+  int flags = CurrentDir->Dir[index].m_banner_and_icon_flags;
   // Timesplitters 2 is the only game that I see this in
   // May be a hack
   if (flags == 0xFB)
@@ -1070,8 +1070,8 @@ bool GCMemcard::ReadBannerRGBA8(u8 index, u32* buffer) const
   if (bnrFormat == 0)
     return false;
 
-  u32 DataOffset = BE32(CurrentDir->Dir[index].ImageOffset);
-  u32 DataBlock = BE16(CurrentDir->Dir[index].FirstBlock) - MC_FST_BLOCKS;
+  u32 DataOffset = BE32(CurrentDir->Dir[index].m_image_offset);
+  u32 DataBlock = BE16(CurrentDir->Dir[index].m_first_block) - MC_FST_BLOCKS;
 
   if ((DataBlock > maxBlock) || (DataOffset == 0xFFFFFFFF))
   {
@@ -1105,10 +1105,10 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
   // Sonic Heroes it the only game I have seen that tries to use a CI8 and RGB5A3 icon
   // int fmtCheck = 0;
 
-  int formats = BE16(CurrentDir->Dir[index].IconFmt);
-  int fdelays = BE16(CurrentDir->Dir[index].AnimSpeed);
+  int formats = BE16(CurrentDir->Dir[index].m_icon_format);
+  int fdelays = BE16(CurrentDir->Dir[index].m_animation_speed);
 
-  int flags = CurrentDir->Dir[index].BIFlags;
+  int flags = CurrentDir->Dir[index].m_banner_and_icon_flags;
   // Timesplitters 2 and 3 is the only game that I see this in
   // May be a hack
   // if (flags == 0xFB) flags = ~flags;
@@ -1117,8 +1117,8 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
 
   int bnrFormat = (flags & 3);
 
-  u32 DataOffset = BE32(CurrentDir->Dir[index].ImageOffset);
-  u32 DataBlock = BE16(CurrentDir->Dir[index].FirstBlock) - MC_FST_BLOCKS;
+  u32 DataOffset = BE32(CurrentDir->Dir[index].m_image_offset);
+  u32 DataBlock = BE16(CurrentDir->Dir[index].m_first_block) - MC_FST_BLOCKS;
 
   if ((DataBlock > maxBlock) || (DataOffset == 0xFFFFFFFF))
   {
@@ -1290,7 +1290,7 @@ s32 GCMemcard::FZEROGX_MakeSaveGameValid(const Header& cardheader, const DEntry&
   int block = 0;
 
   // check for F-Zero GX system file
-  if (strcmp(reinterpret_cast<const char*>(direntry.Filename), "f_zero.dat") != 0)
+  if (strcmp(reinterpret_cast<const char*>(direntry.m_filename), "f_zero.dat") != 0)
     return 0;
 
   // get encrypted destination memory card serial numbers
@@ -1344,10 +1344,10 @@ s32 GCMemcard::PSO_MakeSaveGameValid(const Header& cardheader, const DEntry& dir
   u32 pso3offset = 0x00;
 
   // check for PSO1&2 system file
-  if (strcmp(reinterpret_cast<const char*>(direntry.Filename), "PSO_SYSTEM") != 0)
+  if (strcmp(reinterpret_cast<const char*>(direntry.m_filename), "PSO_SYSTEM") != 0)
   {
     // check for PSO3 system file
-    if (strcmp(reinterpret_cast<const char*>(direntry.Filename), "PSO3_SYSTEM") == 0)
+    if (strcmp(reinterpret_cast<const char*>(direntry.m_filename), "PSO3_SYSTEM") == 0)
     {
       // PSO3 data block size adjustment
       pso3offset = 0x10;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1076,7 +1076,7 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     ByteSwap(&tmp[0], &tmp[1]);
     memcpy(&tempDEntry.m_block_count, tmp.data(), 2);
 
-    ArrayByteSwap((tempDEntry.m_unused_2));
+    ByteSwap(&tempDEntry.m_unused_2[0], &tempDEntry.m_unused_2[1]);
 
     memcpy(tmp.data(), &tempDEntry.m_comments_address, 4);
     ByteSwap(&tmp[0], &tmp[1]);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -408,7 +408,9 @@ std::string GCMemcard::DEntry_Makercode(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  return std::string((const char*)CurrentDir->m_dir_entries[index].m_makercode, 2);
+  return std::string(
+      reinterpret_cast<const char*>(CurrentDir->m_dir_entries[index].m_makercode.data()),
+      CurrentDir->m_dir_entries[index].m_makercode.size());
 }
 
 std::string GCMemcard::DEntry_BIFlags(u8 index) const

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <vector>
 
+#include "Common/BitUtils.h"
 #include "Common/ColorUtil.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonPaths.h"
@@ -480,16 +481,11 @@ std::string GCMemcard::DEntry_IconFmt(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  std::array<u8, 2> tmp;
-  memcpy(tmp.data(), &GetActiveDirectory().m_dir_entries[index].m_icon_format, 2);
-  int x = tmp[0];
+  u16 x = GetActiveDirectory().m_dir_entries[index].m_icon_format;
   std::string format;
-  for (int i = 0; i < 16; i++)
+  for (size_t i = 0; i < 16; ++i)
   {
-    if (i == 8)
-      x = tmp[1];
-    format.push_back((x & 0x80) ? '1' : '0');
-    x = x << 1;
+    format.push_back(Common::ExtractBit(x, 15 - i) ? '1' : '0');
   }
   return format;
 }
@@ -499,16 +495,11 @@ std::string GCMemcard::DEntry_AnimSpeed(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  std::array<u8, 2> tmp;
-  memcpy(tmp.data(), &GetActiveDirectory().m_dir_entries[index].m_animation_speed, 2);
-  int x = tmp[0];
+  u16 x = GetActiveDirectory().m_dir_entries[index].m_animation_speed;
   std::string speed;
-  for (int i = 0; i < 16; i++)
+  for (size_t i = 0; i < 16; ++i)
   {
-    if (i == 8)
-      x = tmp[1];
-    speed.push_back((x & 0x80) ? '1' : '0');
-    x = x << 1;
+    speed.push_back(Common::ExtractBit(x, 15 - i) ? '1' : '0');
   }
   return speed;
 }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -93,7 +93,7 @@ GCMemcard::GCMemcard(const std::string& filename, bool forceCreation, bool shift
     PanicAlertT("Failed to read header correctly\n(0x0000-0x1FFF)");
     return;
   }
-  if (m_sizeMb != BE16(hdr.m_size_mb))
+  if (m_sizeMb != hdr.m_size_mb)
   {
     PanicAlertT("Memory card file size does not match the header size");
     return;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -677,8 +677,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
   }
 
   // find first free data block
-  u16 firstBlock =
-      CurrentBat->NextFreeBlock(maxBlock, BE16(CurrentBat->m_last_allocated_block));
+  u16 firstBlock = CurrentBat->NextFreeBlock(maxBlock, CurrentBat->m_last_allocated_block);
   if (firstBlock == 0xFFFF)
     return OUTOFBLOCKS;
   Directory UpdatedDir = *CurrentDir;
@@ -725,7 +724,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
     else
       nextBlock = UpdatedBat.NextFreeBlock(maxBlock, firstBlock + 1);
     UpdatedBat.m_map[firstBlock - MC_FST_BLOCKS] = BE16(nextBlock);
-    UpdatedBat.m_last_allocated_block = BE16(firstBlock);
+    UpdatedBat.m_last_allocated_block = firstBlock;
     firstBlock = nextBlock;
   }
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -179,14 +179,6 @@ GCMemcard::GCMemcard(const std::string& filename, bool forceCreation, bool shift
       // update checksums
       csums = TestChecksums();
     }
-    // It seems that the backup having a larger counter doesn't necessarily mean
-    // the backup should be copied?
-    //	}
-    //
-    //	if (dir_backup.m_update_counter > dir.m_update_counter) //check if the backup is newer
-    //	{
-    //		dir = dir_backup;
-    //		bat = bat_backup; // needed?
   }
 
   mcdFile.Seek(0xa000, SEEK_SET);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -371,7 +371,7 @@ u8 GCMemcard::TitlePresent(const DEntry& d) const
   while (i < DIRLEN)
   {
     if ((BE32(CurrentDir->m_dir_entries[i].m_gamecode) == BE32(d.m_gamecode)) &&
-        (!memcmp(CurrentDir->m_dir_entries[i].m_filename, d.m_filename, 32)))
+        CurrentDir->m_dir_entries[i].m_filename == d.m_filename)
     {
       break;
     }
@@ -428,7 +428,9 @@ std::string GCMemcard::DEntry_FileName(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  return std::string((const char*)CurrentDir->m_dir_entries[index].m_filename, DENTRY_STRLEN);
+  return std::string(
+      reinterpret_cast<const char*>(CurrentDir->m_dir_entries[index].m_filename.data()),
+      CurrentDir->m_dir_entries[index].m_filename.size());
 }
 
 u32 GCMemcard::DEntry_ModTime(u8 index) const
@@ -1317,7 +1319,7 @@ s32 GCMemcard::FZEROGX_MakeSaveGameValid(const Header& cardheader, const DEntry&
   int block = 0;
 
   // check for F-Zero GX system file
-  if (strcmp(reinterpret_cast<const char*>(direntry.m_filename), "f_zero.dat") != 0)
+  if (strcmp(reinterpret_cast<const char*>(direntry.m_filename.data()), "f_zero.dat") != 0)
     return 0;
 
   // get encrypted destination memory card serial numbers
@@ -1371,10 +1373,10 @@ s32 GCMemcard::PSO_MakeSaveGameValid(const Header& cardheader, const DEntry& dir
   u32 pso3offset = 0x00;
 
   // check for PSO1&2 system file
-  if (strcmp(reinterpret_cast<const char*>(direntry.m_filename), "PSO_SYSTEM") != 0)
+  if (strcmp(reinterpret_cast<const char*>(direntry.m_filename.data()), "PSO_SYSTEM") != 0)
   {
     // check for PSO3 system file
-    if (strcmp(reinterpret_cast<const char*>(direntry.m_filename), "PSO3_SYSTEM") == 0)
+    if (strcmp(reinterpret_cast<const char*>(direntry.m_filename.data()), "PSO3_SYSTEM") == 0)
     {
       // PSO3 data block size adjustment
       pso3offset = 0x10;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -586,7 +586,7 @@ u16 BlockAlloc::GetNextBlock(u16 Block) const
   if ((Block < MC_FST_BLOCKS) || (Block > 4091))
     return 0;
 
-  return Common::swap16(m_map[Block - MC_FST_BLOCKS]);
+  return m_map[Block - MC_FST_BLOCKS];
 }
 
 // Parameters and return value are expected as memory card block index,
@@ -723,7 +723,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
       nextBlock = 0xFFFF;
     else
       nextBlock = UpdatedBat.NextFreeBlock(maxBlock, firstBlock + 1);
-    UpdatedBat.m_map[firstBlock - MC_FST_BLOCKS] = BE16(nextBlock);
+    UpdatedBat.m_map[firstBlock - MC_FST_BLOCKS] = nextBlock;
     UpdatedBat.m_last_allocated_block = firstBlock;
     firstBlock = nextBlock;
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -93,7 +93,7 @@ GCMemcard::GCMemcard(const std::string& filename, bool forceCreation, bool shift
     PanicAlertT("Failed to read header correctly\n(0x0000-0x1FFF)");
     return;
   }
-  if (m_sizeMb != BE16(hdr.SizeMb))
+  if (m_sizeMb != BE16(hdr.m_size_mb))
   {
     PanicAlertT("Memory card file size does not match the header size");
     return;
@@ -233,7 +233,7 @@ void GCMemcard::InitDirBatPointers()
 
 bool GCMemcard::IsShiftJIS() const
 {
-  return hdr.Encoding != 0;
+  return hdr.m_encoding != 0;
 }
 
 bool GCMemcard::Save()
@@ -283,7 +283,7 @@ u32 GCMemcard::TestChecksums() const
   u32 results = 0;
 
   calc_checksumsBE((u16*)&hdr, 0xFE, &csum, &csum_inv);
-  if ((hdr.Checksum != csum) || (hdr.Checksum_Inv != csum_inv))
+  if ((hdr.m_checksum != csum) || (hdr.m_checksum_inv != csum_inv))
     results |= 1;
 
   calc_checksumsBE((u16*)&dir, 0xFFE, &csum, &csum_inv);
@@ -310,7 +310,7 @@ bool GCMemcard::FixChecksums()
   if (!m_valid)
     return false;
 
-  calc_checksumsBE((u16*)&hdr, 0xFE, &hdr.Checksum, &hdr.Checksum_Inv);
+  calc_checksumsBE((u16*)&hdr, 0xFE, &hdr.m_checksum, &hdr.m_checksum_inv);
   calc_checksumsBE((u16*)&dir, 0xFFE, &dir.Checksum, &dir.Checksum_Inv);
   calc_checksumsBE((u16*)&dir_backup, 0xFFE, &dir_backup.Checksum, &dir_backup.Checksum_Inv);
   calc_checksumsBE((u16*)&bat + 2, 0xFFE, &bat.Checksum, &bat.Checksum_Inv);
@@ -627,7 +627,7 @@ u32 GCMemcard::GetSaveData(u8 index, std::vector<GCMBlock>& Blocks) const
 
   u16 block = DEntry_FirstBlock(index);
   u16 BlockCount = DEntry_BlockCount(index);
-  // u16 memcardSize = BE16(hdr.SizeMb) * MBIT_TO_BLOCKS;
+  // u16 memcardSize = BE16(hdr.m_size_mb) * MBIT_TO_BLOCKS;
 
   if ((block == 0xFFFF) || (BlockCount == 0xFFFF))
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -452,12 +452,14 @@ std::string GCMemcard::DEntry_IconFmt(u8 index) const
   if (!m_valid || index >= DIRLEN)
     return "";
 
-  int x = CurrentDir->m_dir_entries[index].m_icon_format[0];
+  std::array<u8, 2> tmp;
+  memcpy(tmp.data(), &CurrentDir->m_dir_entries[index].m_icon_format, 2);
+  int x = tmp[0];
   std::string format;
   for (int i = 0; i < 16; i++)
   {
     if (i == 8)
-      x = CurrentDir->m_dir_entries[index].m_icon_format[1];
+      x = tmp[1];
     format.push_back((x & 0x80) ? '1' : '0');
     x = x << 1;
   }
@@ -1047,7 +1049,10 @@ void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
     ByteSwap(&tmp[2], &tmp[3]);
     memcpy(&tempDEntry.m_image_offset, tmp.data(), 4);
 
-    ArrayByteSwap((tempDEntry.m_icon_format));
+    memcpy(tmp.data(), &tempDEntry.m_icon_format, 2);
+    ByteSwap(&tmp[0], &tmp[1]);
+    memcpy(&tempDEntry.m_icon_format, tmp.data(), 2);
+
     ArrayByteSwap((tempDEntry.m_animation_speed));
     ByteSwap(&tempDEntry.m_file_permissions, &tempDEntry.m_copy_counter);
     ArrayByteSwap((tempDEntry.m_first_block));
@@ -1112,7 +1117,7 @@ u32 GCMemcard::ReadAnimRGBA8(u8 index, u32* buffer, u8* delays) const
   // Sonic Heroes it the only game I have seen that tries to use a CI8 and RGB5A3 icon
   // int fmtCheck = 0;
 
-  int formats = BE16(CurrentDir->m_dir_entries[index].m_icon_format);
+  int formats = CurrentDir->m_dir_entries[index].m_icon_format;
   int fdelays = BE16(CurrentDir->m_dir_entries[index].m_animation_speed);
 
   int flags = CurrentDir->m_dir_entries[index].m_banner_and_icon_flags;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -219,7 +219,7 @@ void GCMemcard::InitDirBatPointers()
     CurrentDir = &dir_backup;
     PreviousDir = &dir;
   }
-  if (BE16(bat.m_update_counter) > BE16(bat_backup.m_update_counter))
+  if (bat.m_update_counter > bat_backup.m_update_counter)
   {
     CurrentBat = &bat;
     PreviousBat = &bat_backup;
@@ -730,7 +730,7 @@ u32 GCMemcard::ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlo
   }
 
   UpdatedBat.m_free_blocks = BE16(BE16(UpdatedBat.m_free_blocks) - fileBlocks);
-  UpdatedBat.m_update_counter = BE16(BE16(UpdatedBat.m_update_counter) + 1);
+  UpdatedBat.m_update_counter = UpdatedBat.m_update_counter + 1;
   *PreviousBat = UpdatedBat;
   if (PreviousBat == &bat)
   {
@@ -761,7 +761,7 @@ u32 GCMemcard::RemoveFile(u8 index)  // index in the directory array
   BlockAlloc UpdatedBat = *CurrentBat;
   if (!UpdatedBat.ClearBlocks(startingblock, numberofblocks))
     return DELETE_FAIL;
-  UpdatedBat.m_update_counter = BE16(BE16(UpdatedBat.m_update_counter) + 1);
+  UpdatedBat.m_update_counter = UpdatedBat.m_update_counter + 1;
   *PreviousBat = UpdatedBat;
   if (PreviousBat == &bat)
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -164,15 +164,15 @@ struct DEntry
   DEntry() { memset(this, 0xFF, DENTRY_SIZE); }
   std::string GCI_FileName() const
   {
-    std::string filename = std::string((char*)Makercode, 2) + '-' +
-                           std::string((char*)Gamecode, 4) + '-' + (char*)Filename + ".gci";
+    std::string filename = std::string((char*)m_makercode, 2) + '-' +
+                           std::string((char*)m_gamecode, 4) + '-' + (char*)m_filename + ".gci";
     return Common::EscapeFileName(filename);
   }
 
-  u8 Gamecode[4];   // 0x00       0x04    Gamecode
-  u8 Makercode[2];  // 0x04      0x02    Makercode
-  u8 Unused1;       // 0x06      0x01    reserved/unused (always 0xff, has no effect)
-  u8 BIFlags;       // 0x07      0x01    banner gfx format and icon animation (Image Key)
+  u8 m_gamecode[4];            // 0x00      0x04    Gamecode
+  u8 m_makercode[2];           // 0x04      0x02    Makercode
+  u8 m_unused_1;               // 0x06      0x01    reserved/unused (always 0xff, has no effect)
+  u8 m_banner_and_icon_flags;  // 0x07      0x01    banner gfx format and icon animation (Image Key)
   //      Bit(s)  Description
   //      2       Icon Animation 0: forward 1: ping-pong
   //      1       [--0: No Banner 1: Banner present--] WRONG! YAGCD LIES!
@@ -183,35 +183,36 @@ struct DEntry
   //      10 RGB5A3 banner
   //      11 ? maybe ==00? Time Splitters 2 and 3 have it and don't have banner
   //
-  u8 Filename[DENTRY_STRLEN];  // 0x08      0x20     Filename
-  u8 ModTime[4];      // 0x28      0x04    Time of file's last modification in seconds since 12am,
-                      // January 1st, 2000
-  u8 ImageOffset[4];  // 0x2c      0x04    image data offset
-  u8 IconFmt[2];      // 0x30      0x02    icon gfx format (2bits per icon)
+  u8 m_filename[DENTRY_STRLEN];  // 0x08      0x20     Filename
+  u8 m_modification_time[4];  // 0x28      0x04    Time of file's last modification in seconds since
+                              // 12am, January 1st, 2000
+  u8 m_image_offset[4];       // 0x2c      0x04    image data offset
+  u8 m_icon_format[2];        // 0x30      0x02    icon gfx format (2bits per icon)
   //      Bits    Description
   //      00      No icon
   //      01      CI8 with a shared color palette after the last frame
   //      10      RGB5A3
   //      11      CI8 with a unique color palette after itself
   //
-  u8 AnimSpeed[2];  // 0x32      0x02    Animation speed (2bits per icon) (*1)
+  u8 m_animation_speed[2];  // 0x32      0x02    Animation speed (2bits per icon) (*1)
   //      Bits    Description
   //      00      No icon
   //      01      Icon lasts for 4 frames
   //      10      Icon lasts for 8 frames
   //      11      Icon lasts for 12 frames
   //
-  u8 Permissions;  // 0x34      0x01    File-permissions
+  u8 m_file_permissions;  // 0x34      0x01    File-permissions
   //      Bit Permission  Description
   //      4   no move     File cannot be moved by the IPL
   //      3   no copy     File cannot be copied by the IPL
   //      2   public      Can be read by any game
   //
-  u8 CopyCounter;      // 0x35      0x01    Copy counter (*2)
-  u8 FirstBlock[2];    // 0x36      0x02    Block no of first block of file (0 == offset 0)
-  u8 BlockCount[2];    // 0x38      0x02    File-length (number of blocks in file)
-  u8 Unused2[2];       // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
-  u8 CommentsAddr[4];  // 0x3c      0x04    Address of the two comments within the file data (*3)
+  u8 m_copy_counter;         // 0x35      0x01    Copy counter (*2)
+  u8 m_first_block[2];       // 0x36      0x02    Block no of first block of file (0 == offset 0)
+  u8 m_block_count[2];       // 0x38      0x02    File-length (number of blocks in file)
+  u8 m_unused_2[2];          // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
+  u8 m_comments_address[4];  // 0x3c      0x04    Address of the two comments within the file data
+                             // (*3)
 };
 static_assert(sizeof(DEntry) == DENTRY_SIZE);
 
@@ -285,9 +286,9 @@ public:
   bool LoadSaveBlocks();
   bool HasCopyProtection() const
   {
-    if ((strcmp((char*)m_gci_header.Filename, "PSO_SYSTEM") == 0) ||
-        (strcmp((char*)m_gci_header.Filename, "PSO3_SYSTEM") == 0) ||
-        (strcmp((char*)m_gci_header.Filename, "f_zero.dat") == 0))
+    if ((strcmp((char*)m_gci_header.m_filename, "PSO_SYSTEM") == 0) ||
+        (strcmp((char*)m_gci_header.m_filename, "PSO3_SYSTEM") == 0) ||
+        (strcmp((char*)m_gci_header.m_filename, "f_zero.dat") == 0))
       return true;
     return false;
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -100,24 +100,49 @@ struct GCMBlock
 void calc_checksumsBE(const u16* buf, u32 length, u16* csum, u16* inv_csum);
 
 #pragma pack(push, 1)
-struct Header  // Offset    Size    Description
+struct Header
 {
-  // Serial in libogc
-  std::array<u8, 12> m_serial;                  // 0x0000    12      ?
-  Common::BigEndianValue<u64> m_format_time;    // 0x000c    8       Time of format (OSTime value)
-  u32 m_sram_bias;                              // 0x0014    4       SRAM bias at time of format
-  Common::BigEndianValue<u32> m_sram_language;  // 0x0018    4       SRAM language
-  std::array<u8, 4> m_unknown_2;                // 0x001c    4       ? almost always 0
-  // end Serial in libogc
-  Common::BigEndianValue<u16>
-      m_device_id;  // 0x0020    2       0 if formated in slot A 1 if formated in slot B
-  Common::BigEndianValue<u16> m_size_mb;   // 0x0022    2       Size of memcard in Mbits
-  Common::BigEndianValue<u16> m_encoding;  // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
-  std::array<u8, 468> m_unused_1;          // 0x0026    468     Unused (0xff)
-  u16 m_update_counter;                    // 0x01fa    2       Update Counter (?, probably unused)
-  u16 m_checksum;                          // 0x01fc    2       Additive Checksum
-  u16 m_checksum_inv;                      // 0x01fe    2       Inverse Checksum
-  std::array<u8, 7680> m_unused_2;         // 0x0200    0x1e00  Unused (0xff)
+  // NOTE: libogc refers to 'Serial' as the first 0x20 bytes of the header,
+  // so the data from m_serial until m_unknown_2 (inclusive)
+
+  // 12 bytes at 0x0000
+  std::array<u8, 12> m_serial;
+
+  // 8 bytes at 0x000c: Time of format (OSTime value)
+  Common::BigEndianValue<u64> m_format_time;
+
+  // 4 bytes at 0x0014; SRAM bias at time of format
+  u32 m_sram_bias;
+
+  // 4 bytes at 0x0018: SRAM language
+  Common::BigEndianValue<u32> m_sram_language;
+
+  // 4 bytes at 0x001c: ? almost always 0
+  std::array<u8, 4> m_unknown_2;
+
+  // 2 bytes at 0x0020: 0 if formated in slot A, 1 if formated in slot B
+  Common::BigEndianValue<u16> m_device_id;
+
+  // 2 bytes at 0x0022: Size of memcard in Mbits
+  Common::BigEndianValue<u16> m_size_mb;
+
+  // 2 bytes at 0x0024: Encoding (Windows-1252 or Shift JIS)
+  Common::BigEndianValue<u16> m_encoding;
+
+  // 468 bytes at 0x0026: Unused (0xff)
+  std::array<u8, 468> m_unused_1;
+
+  // 2 bytes at 0x01fa: Update Counter (?, probably unused)
+  u16 m_update_counter;
+
+  // 2 bytes at 0x01fc: Additive Checksum
+  u16 m_checksum;
+
+  // 2 bytes at 0x01fe: Inverse Checksum
+  u16 m_checksum_inv;
+
+  // 0x1e00 bytes at 0x0200: Unused (0xff)
+  std::array<u8, 7680> m_unused_2;
 
   void CARD_GetSerialNo(u32* serial1, u32* serial2) const
   {
@@ -175,10 +200,16 @@ struct DEntry
 
   static constexpr std::array<u8, 4> UNINITIALIZED_GAMECODE{{0xFF, 0xFF, 0xFF, 0xFF}};
 
-  std::array<u8, 4> m_gamecode;   // 0x00      0x04    Gamecode
-  std::array<u8, 2> m_makercode;  // 0x04      0x02    Makercode
-  u8 m_unused_1;                  // 0x06      0x01    reserved/unused (always 0xff, has no effect)
-  u8 m_banner_and_icon_flags;  // 0x07      0x01    banner gfx format and icon animation (Image Key)
+  // 4 bytes at 0x00: Gamecode
+  std::array<u8, 4> m_gamecode;
+
+  // 2 bytes at 0x04: Makercode
+  std::array<u8, 2> m_makercode;
+
+  // 1 byte at 0x06: reserved/unused (always 0xff, has no effect)
+  u8 m_unused_1;
+
+  // 1 byte at 0x07: banner gfx format and icon animation (Image Key)
   //      Bit(s)  Description
   //      2       Icon Animation 0: forward 1: ping-pong
   //      1       [--0: No Banner 1: Banner present--] WRONG! YAGCD LIES!
@@ -188,42 +219,54 @@ struct DEntry
   //      01 CI8 banner
   //      10 RGB5A3 banner
   //      11 ? maybe ==00? Time Splitters 2 and 3 have it and don't have banner
-  //
-  std::array<u8, DENTRY_STRLEN> m_filename;  // 0x08      0x20     Filename
-  Common::BigEndianValue<u32>
-      m_modification_time;  // 0x28      0x04    Time of file's last modification in seconds since
-                            // 12am, January 1st, 2000
-  Common::BigEndianValue<u32> m_image_offset;  // 0x2c      0x04    image data offset
-  Common::BigEndianValue<u16> m_icon_format;   // 0x30      0x02    icon gfx format (2bits per icon)
+  u8 m_banner_and_icon_flags;
+
+  // 0x20 bytes at 0x08: Filename
+  std::array<u8, DENTRY_STRLEN> m_filename;
+
+  // 4 bytes at 0x28: Time of file's last modification in seconds since 12am, January 1st, 2000
+  Common::BigEndianValue<u32> m_modification_time;
+
+  // 4 bytes at 0x2c: image data offset
+  Common::BigEndianValue<u32> m_image_offset;
+
+  // 2 bytes at 0x30: icon gfx format (2bits per icon)
   //      Bits    Description
   //      00      No icon
   //      01      CI8 with a shared color palette after the last frame
   //      10      RGB5A3
   //      11      CI8 with a unique color palette after itself
-  //
-  Common::BigEndianValue<u16>
-      m_animation_speed;  // 0x32      0x02    Animation speed (2bits per icon) (*1)
+  Common::BigEndianValue<u16> m_icon_format;
+
+  // 2 bytes at 0x32: Animation speed (2bits per icon)
   //      Bits    Description
   //      00      No icon
   //      01      Icon lasts for 4 frames
   //      10      Icon lasts for 8 frames
   //      11      Icon lasts for 12 frames
-  //
-  u8 m_file_permissions;  // 0x34      0x01    File-permissions
+  Common::BigEndianValue<u16> m_animation_speed;
+
+  // 1 byte at 0x34: File-permissions
   //      Bit Permission  Description
   //      4   no move     File cannot be moved by the IPL
   //      3   no copy     File cannot be copied by the IPL
   //      2   public      Can be read by any game
-  //
-  u8 m_copy_counter;  // 0x35      0x01    Copy counter (*2)
-  Common::BigEndianValue<u16>
-      m_first_block;  // 0x36      0x02    Block no of first block of file (0 == offset 0)
-  Common::BigEndianValue<u16>
-      m_block_count;             // 0x38      0x02    File-length (number of blocks in file)
-  std::array<u8, 2> m_unused_2;  // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
-  Common::BigEndianValue<u32>
-      m_comments_address;  // 0x3c      0x04    Address of the two comments within the file data
-                           // (*3)
+  u8 m_file_permissions;
+
+  // 1 byte at 0x35: Copy counter
+  u8 m_copy_counter;
+
+  // 2 bytes at 0x36: Block number of first block of file (0 == offset 0)
+  Common::BigEndianValue<u16> m_first_block;
+
+  // 2 bytes at 0x38: File-length (number of blocks in file)
+  Common::BigEndianValue<u16> m_block_count;
+
+  // 2 bytes at 0x3a: Reserved/unused (always 0xffff, has no effect)
+  std::array<u8, 2> m_unused_2;
+
+  // 4 bytes at 0x3c: Address of the two comments within the file data
+  Common::BigEndianValue<u32> m_comments_address;
 };
 static_assert(sizeof(DEntry) == DENTRY_SIZE);
 
@@ -252,13 +295,23 @@ static_assert(sizeof(Directory) == BLOCK_SIZE);
 
 struct BlockAlloc
 {
-  u16 m_checksum;                                      // 0x0000    2       Additive Checksum
-  u16 m_checksum_inv;                                  // 0x0002    2       Inverse Checksum
-  Common::BigEndianValue<u16> m_update_counter;        // 0x0004    2       Update Counter
-  Common::BigEndianValue<u16> m_free_blocks;           // 0x0006    2       Free Blocks
-  Common::BigEndianValue<u16> m_last_allocated_block;  // 0x0008    2       Last allocated Block
-  std::array<Common::BigEndianValue<u16>, BAT_SIZE>
-      m_map;  // 0x000a    0x1ff8  Map of allocated Blocks
+  // 2 bytes at 0x0000: Additive Checksum
+  u16 m_checksum;
+
+  // 2 bytes at 0x0002: Inverse Checksum
+  u16 m_checksum_inv;
+
+  // 2 bytes at 0x0004: Update Counter
+  Common::BigEndianValue<u16> m_update_counter;
+
+  // 2 bytes at 0x0006: Free Blocks
+  Common::BigEndianValue<u16> m_free_blocks;
+
+  // 2 bytes at 0x0008: Last allocated Block
+  Common::BigEndianValue<u16> m_last_allocated_block;
+
+  // 0x1ff8 bytes at 0x000a: Map of allocated Blocks
+  std::array<Common::BigEndianValue<u16>, BAT_SIZE> m_map;
 
   u16 GetNextBlock(u16 Block) const;
   u16 NextFreeBlock(u16 MaxBlock, u16 StartingBlock = MC_FST_BLOCKS) const;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -168,7 +168,7 @@ struct DEntry
   std::string GCI_FileName() const
   {
     std::string filename =
-        std::string((char*)m_makercode, 2) + '-' +
+        std::string(reinterpret_cast<const char*>(m_makercode.data()), m_makercode.size()) + '-' +
         std::string(reinterpret_cast<const char*>(m_gamecode.data()), m_gamecode.size()) + '-' +
         reinterpret_cast<const char*>(m_filename.data()) + ".gci";
     return Common::EscapeFileName(filename);
@@ -176,9 +176,9 @@ struct DEntry
 
   static constexpr std::array<u8, 4> UNINITIALIZED_GAMECODE = {0xFF, 0xFF, 0xFF, 0xFF};
 
-  std::array<u8, 4> m_gamecode;  // 0x00      0x04    Gamecode
-  u8 m_makercode[2];             // 0x04      0x02    Makercode
-  u8 m_unused_1;                 // 0x06      0x01    reserved/unused (always 0xff, has no effect)
+  std::array<u8, 4> m_gamecode;   // 0x00      0x04    Gamecode
+  std::array<u8, 2> m_makercode;  // 0x04      0x02    Makercode
+  u8 m_unused_1;                  // 0x06      0x01    reserved/unused (always 0xff, has no effect)
   u8 m_banner_and_icon_flags;  // 0x07      0x01    banner gfx format and icon animation (Image Key)
   //      Bit(s)  Description
   //      2       Icon Animation 0: forward 1: ping-pong

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -110,13 +110,13 @@ struct Header  // Offset    Size    Description
   // end Serial in libogc
   Common::BigEndianValue<u16>
       m_device_id;  // 0x0020    2       0 if formated in slot A 1 if formated in slot B
-  Common::BigEndianValue<u16> m_size_mb;  // 0x0022    2       Size of memcard in Mbits
-  u16 m_encoding;                         // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
-  u8 m_unused_1[468];                     // 0x0026    468     Unused (0xff)
-  u16 m_update_counter;                   // 0x01fa    2       Update Counter (?, probably unused)
-  u16 m_checksum;                         // 0x01fc    2       Additive Checksum
-  u16 m_checksum_inv;                     // 0x01fe    2       Inverse Checksum
-  u8 m_unused_2[7680];                    // 0x0200    0x1e00  Unused (0xff)
+  Common::BigEndianValue<u16> m_size_mb;   // 0x0022    2       Size of memcard in Mbits
+  Common::BigEndianValue<u16> m_encoding;  // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
+  u8 m_unused_1[468];                      // 0x0026    468     Unused (0xff)
+  u16 m_update_counter;                    // 0x01fa    2       Update Counter (?, probably unused)
+  u16 m_checksum;                          // 0x01fc    2       Additive Checksum
+  u16 m_checksum_inv;                      // 0x01fe    2       Inverse Checksum
+  u8 m_unused_2[7680];                     // 0x0200    0x1e00  Unused (0xff)
 
   void CARD_GetSerialNo(u32* serial1, u32* serial2) const
   {
@@ -138,7 +138,7 @@ struct Header  // Offset    Size    Description
   {
     memset(this, 0xFF, BLOCK_SIZE);
     m_size_mb = sizeMb;
-    m_encoding = BE16(shift_jis ? 1 : 0);
+    m_encoding = shift_jis ? 1 : 0;
     u64 rand = Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
     m_format_time = rand;
     for (int i = 0; i < 12; i++)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -173,7 +173,7 @@ struct DEntry
     return Common::EscapeFileName(filename);
   }
 
-  static constexpr std::array<u8, 4> UNINITIALIZED_GAMECODE = {0xFF, 0xFF, 0xFF, 0xFF};
+  static constexpr std::array<u8, 4> UNINITIALIZED_GAMECODE{{0xFF, 0xFF, 0xFF, 0xFF}};
 
   std::array<u8, 4> m_gamecode;   // 0x00      0x04    Gamecode
   std::array<u8, 2> m_makercode;  // 0x04      0x02    Makercode

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <string>
 #include <vector>
 
@@ -102,21 +103,21 @@ void calc_checksumsBE(const u16* buf, u32 length, u16* csum, u16* inv_csum);
 struct Header  // Offset    Size    Description
 {
   // Serial in libogc
-  u8 m_serial[12];                              // 0x0000    12      ?
+  std::array<u8, 12> m_serial;                  // 0x0000    12      ?
   Common::BigEndianValue<u64> m_format_time;    // 0x000c    8       Time of format (OSTime value)
   u32 m_sram_bias;                              // 0x0014    4       SRAM bias at time of format
   Common::BigEndianValue<u32> m_sram_language;  // 0x0018    4       SRAM language
-  u8 m_unknown_2[4];                            // 0x001c    4       ? almost always 0
+  std::array<u8, 4> m_unknown_2;                // 0x001c    4       ? almost always 0
   // end Serial in libogc
   Common::BigEndianValue<u16>
       m_device_id;  // 0x0020    2       0 if formated in slot A 1 if formated in slot B
   Common::BigEndianValue<u16> m_size_mb;   // 0x0022    2       Size of memcard in Mbits
   Common::BigEndianValue<u16> m_encoding;  // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
-  u8 m_unused_1[468];                      // 0x0026    468     Unused (0xff)
+  std::array<u8, 468> m_unused_1;          // 0x0026    468     Unused (0xff)
   u16 m_update_counter;                    // 0x01fa    2       Update Counter (?, probably unused)
   u16 m_checksum;                          // 0x01fc    2       Additive Checksum
   u16 m_checksum_inv;                      // 0x01fe    2       Inverse Checksum
-  u8 m_unused_2[7680];                     // 0x0200    0x1e00  Unused (0xff)
+  std::array<u8, 7680> m_unused_2;         // 0x0200    0x1e00  Unused (0xff)
 
   void CARD_GetSerialNo(u32* serial1, u32* serial2) const
   {
@@ -152,7 +153,8 @@ struct Header  // Offset    Size    Description
     m_sram_language = static_cast<u32>(g_SRAM.settings.language);
     // TODO: determine the purpose of m_unknown_2
     // 1 works for slot A, 0 works for both slot A and slot B
-    *(u32*)&m_unknown_2 = 0;  // = _viReg[55];  static vu16* const _viReg = (u16*)0xCC002000;
+    memset(m_unknown_2.data(), 0,
+           m_unknown_2.size());  // = _viReg[55];  static vu16* const _viReg = (u16*)0xCC002000;
     m_device_id = 0;
     calc_checksumsBE((u16*)this, 0xFE, &m_checksum, &m_checksum_inv);
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -198,7 +198,8 @@ struct DEntry
   //      10      RGB5A3
   //      11      CI8 with a unique color palette after itself
   //
-  u8 m_animation_speed[2];  // 0x32      0x02    Animation speed (2bits per icon) (*1)
+  Common::BigEndianValue<u16>
+      m_animation_speed;  // 0x32      0x02    Animation speed (2bits per icon) (*1)
   //      Bits    Description
   //      00      No icon
   //      01      Icon lasts for 4 frames

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -253,12 +253,12 @@ static_assert(sizeof(Directory) == BLOCK_SIZE);
 
 struct BlockAlloc
 {
-  u16 m_checksum;                                // 0x0000    2       Additive Checksum
-  u16 m_checksum_inv;                            // 0x0002    2       Inverse Checksum
-  Common::BigEndianValue<u16> m_update_counter;  // 0x0004    2       Update Counter
-  Common::BigEndianValue<u16> m_free_blocks;     // 0x0006    2       Free Blocks
-  u16 m_last_allocated_block;                    // 0x0008    2       Last allocated Block
-  u16 m_map[BAT_SIZE];                           // 0x000a    0x1ff8  Map of allocated Blocks
+  u16 m_checksum;                                      // 0x0000    2       Additive Checksum
+  u16 m_checksum_inv;                                  // 0x0002    2       Inverse Checksum
+  Common::BigEndianValue<u16> m_update_counter;        // 0x0004    2       Update Counter
+  Common::BigEndianValue<u16> m_free_blocks;           // 0x0006    2       Free Blocks
+  Common::BigEndianValue<u16> m_last_allocated_block;  // 0x0008    2       Last allocated Block
+  u16 m_map[BAT_SIZE];                                 // 0x000a    0x1ff8  Map of allocated Blocks
   u16 GetNextBlock(u16 Block) const;
   u16 NextFreeBlock(u16 MaxBlock, u16 StartingBlock = MC_FST_BLOCKS) const;
   bool ClearBlocks(u16 StartingBlock, u16 Length);
@@ -270,12 +270,12 @@ struct BlockAlloc
   {
     memset(this, 0, BLOCK_SIZE);
     m_free_blocks = (sizeMb * MBIT_TO_BLOCKS) - MC_FST_BLOCKS;
-    m_last_allocated_block = BE16(4);
+    m_last_allocated_block = 4;
     fixChecksums();
   }
   u16 AssignBlocksContiguous(u16 length)
   {
-    u16 starting = BE16(m_last_allocated_block) + 1;
+    u16 starting = m_last_allocated_block + 1;
     if (length > m_free_blocks)
       return 0xFFFF;
     u16 current = starting;
@@ -285,7 +285,7 @@ struct BlockAlloc
       current++;
     }
     m_map[current - 5] = 0xFFFF;
-    m_last_allocated_block = BE16(current);
+    m_last_allocated_block = current;
     m_free_blocks = m_free_blocks - length;
     fixChecksums();
     return starting;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -324,16 +324,22 @@ class GCMemcard
 {
 private:
   bool m_valid;
-  std::string m_fileName;
+  std::string m_filename;
 
-  u32 maxBlock;
-  u16 m_sizeMb;
+  u32 m_size_blocks;
+  u16 m_size_mb;
 
-  Header hdr;
-  Directory dir, dir_backup, *CurrentDir, *PreviousDir;
-  BlockAlloc bat, bat_backup, *CurrentBat, *PreviousBat;
+  Header m_header_block;
+  Directory m_directory_block;
+  Directory m_directory_backup_block;
+  BlockAlloc m_bat_block;
+  BlockAlloc m_bat_backup_block;
+  std::vector<GCMBlock> m_data_blocks;
 
-  std::vector<GCMBlock> mc_data_blocks;
+  Directory* m_current_directory_block;
+  Directory* m_previous_directory_block;
+  BlockAlloc* m_current_bat_block;
+  BlockAlloc* m_previous_bat_block;
 
   u32 ImportGciInternal(File::IOFile&& gci, const std::string& inputFile,
                         const std::string& outputFile);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -108,7 +108,8 @@ struct Header  // Offset    Size    Description
   Common::BigEndianValue<u32> m_sram_language;  // 0x0018    4       SRAM language
   u8 m_unknown_2[4];                            // 0x001c    4       ? almost always 0
   // end Serial in libogc
-  u8 m_device_id[2];     // 0x0020    2       0 if formated in slot A 1 if formated in slot B
+  Common::BigEndianValue<u16>
+      m_device_id;       // 0x0020    2       0 if formated in slot A 1 if formated in slot B
   u8 m_size_mb[2];       // 0x0022    2       Size of memcard in Mbits
   u16 m_encoding;        // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
   u8 m_unused_1[468];    // 0x0026    468     Unused (0xff)
@@ -152,7 +153,7 @@ struct Header  // Offset    Size    Description
     // TODO: determine the purpose of m_unknown_2
     // 1 works for slot A, 0 works for both slot A and slot B
     *(u32*)&m_unknown_2 = 0;  // = _viReg[55];  static vu16* const _viReg = (u16*)0xCC002000;
-    *(u16*)&m_device_id = 0;
+    m_device_id = 0;
     calc_checksumsBE((u16*)this, 0xFE, &m_checksum, &m_checksum_inv);
   }
 };

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -230,8 +230,8 @@ static_assert(sizeof(DEntry) == DENTRY_SIZE);
 
 struct Directory
 {
-  DEntry m_dir_entries[DIRLEN];  // 0x0000            Directory Entries (max 127)
-  u8 m_padding[0x3a];
+  std::array<DEntry, DIRLEN> m_dir_entries;  // 0x0000            Directory Entries (max 127)
+  std::array<u8, 0x3a> m_padding;
   u16 m_update_counter;  // 0x1ffa    2       Update Counter
   u16 m_checksum;        // 0x1ffc    2       Additive Checksum
   u16 m_checksum_inv;    // 0x1ffe    2       Inverse Checksum

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -258,7 +258,9 @@ struct BlockAlloc
   Common::BigEndianValue<u16> m_update_counter;        // 0x0004    2       Update Counter
   Common::BigEndianValue<u16> m_free_blocks;           // 0x0006    2       Free Blocks
   Common::BigEndianValue<u16> m_last_allocated_block;  // 0x0008    2       Last allocated Block
-  u16 m_map[BAT_SIZE];                                 // 0x000a    0x1ff8  Map of allocated Blocks
+  std::array<Common::BigEndianValue<u16>, BAT_SIZE>
+      m_map;  // 0x000a    0x1ff8  Map of allocated Blocks
+
   u16 GetNextBlock(u16 Block) const;
   u16 NextFreeBlock(u16 MaxBlock, u16 StartingBlock = MC_FST_BLOCKS) const;
   bool ClearBlocks(u16 StartingBlock, u16 Length);
@@ -281,7 +283,7 @@ struct BlockAlloc
     u16 current = starting;
     while ((current - starting + 1) < length)
     {
-      m_map[current - 5] = BE16(current + 1);
+      m_map[current - 5] = current + 1;
       current++;
     }
     m_map[current - 5] = 0xFFFF;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -109,14 +109,14 @@ struct Header  // Offset    Size    Description
   u8 m_unknown_2[4];                            // 0x001c    4       ? almost always 0
   // end Serial in libogc
   Common::BigEndianValue<u16>
-      m_device_id;       // 0x0020    2       0 if formated in slot A 1 if formated in slot B
-  u8 m_size_mb[2];       // 0x0022    2       Size of memcard in Mbits
-  u16 m_encoding;        // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
-  u8 m_unused_1[468];    // 0x0026    468     Unused (0xff)
-  u16 m_update_counter;  // 0x01fa    2       Update Counter (?, probably unused)
-  u16 m_checksum;        // 0x01fc    2       Additive Checksum
-  u16 m_checksum_inv;    // 0x01fe    2       Inverse Checksum
-  u8 m_unused_2[7680];   // 0x0200    0x1e00  Unused (0xff)
+      m_device_id;  // 0x0020    2       0 if formated in slot A 1 if formated in slot B
+  Common::BigEndianValue<u16> m_size_mb;  // 0x0022    2       Size of memcard in Mbits
+  u16 m_encoding;                         // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
+  u8 m_unused_1[468];                     // 0x0026    468     Unused (0xff)
+  u16 m_update_counter;                   // 0x01fa    2       Update Counter (?, probably unused)
+  u16 m_checksum;                         // 0x01fc    2       Additive Checksum
+  u16 m_checksum_inv;                     // 0x01fe    2       Inverse Checksum
+  u8 m_unused_2[7680];                    // 0x0200    0x1e00  Unused (0xff)
 
   void CARD_GetSerialNo(u32* serial1, u32* serial2) const
   {
@@ -137,7 +137,7 @@ struct Header  // Offset    Size    Description
   explicit Header(int slot = 0, u16 sizeMb = MemCard2043Mb, bool shift_jis = false)
   {
     memset(this, 0xFF, BLOCK_SIZE);
-    *(u16*)m_size_mb = BE16(sizeMb);
+    m_size_mb = sizeMb;
     m_encoding = BE16(shift_jis ? 1 : 0);
     u64 rand = Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
     m_format_time = rand;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -155,6 +155,7 @@ struct Header  // Offset    Size    Description
     calc_checksumsBE((u16*)this, 0xFE, &Checksum, &Checksum_Inv);
   }
 };
+static_assert(sizeof(Header) == BLOCK_SIZE);
 
 struct DEntry
 {
@@ -211,6 +212,7 @@ struct DEntry
   u8 Unused2[2];       // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
   u8 CommentsAddr[4];  // 0x3c      0x04    Address of the two comments within the file data (*3)
 };
+static_assert(sizeof(DEntry) == DENTRY_SIZE);
 
 struct Directory
 {
@@ -233,6 +235,7 @@ struct Directory
   }
   void fixChecksums() { calc_checksumsBE((u16*)this, 0xFFE, &Checksum, &Checksum_Inv); }
 };
+static_assert(sizeof(Directory) == BLOCK_SIZE);
 
 struct BlockAlloc
 {
@@ -272,6 +275,7 @@ struct BlockAlloc
     return BE16(starting);
   }
 };
+static_assert(sizeof(BlockAlloc) == BLOCK_SIZE);
 #pragma pack(pop)
 
 class GCIFile

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -167,15 +167,18 @@ struct DEntry
   DEntry() { memset(this, 0xFF, DENTRY_SIZE); }
   std::string GCI_FileName() const
   {
-    std::string filename = std::string((char*)m_makercode, 2) + '-' +
-                           std::string((char*)m_gamecode, 4) + '-' +
-                           reinterpret_cast<const char*>(m_filename.data()) + ".gci";
+    std::string filename =
+        std::string((char*)m_makercode, 2) + '-' +
+        std::string(reinterpret_cast<const char*>(m_gamecode.data()), m_gamecode.size()) + '-' +
+        reinterpret_cast<const char*>(m_filename.data()) + ".gci";
     return Common::EscapeFileName(filename);
   }
 
-  u8 m_gamecode[4];            // 0x00      0x04    Gamecode
-  u8 m_makercode[2];           // 0x04      0x02    Makercode
-  u8 m_unused_1;               // 0x06      0x01    reserved/unused (always 0xff, has no effect)
+  static constexpr std::array<u8, 4> UNINITIALIZED_GAMECODE = {0xFF, 0xFF, 0xFF, 0xFF};
+
+  std::array<u8, 4> m_gamecode;  // 0x00      0x04    Gamecode
+  u8 m_makercode[2];             // 0x04      0x02    Makercode
+  u8 m_unused_1;                 // 0x06      0x01    reserved/unused (always 0xff, has no effect)
   u8 m_banner_and_icon_flags;  // 0x07      0x01    banner gfx format and icon animation (Image Key)
   //      Bit(s)  Description
   //      2       Icon Animation 0: forward 1: ping-pong

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -256,7 +256,7 @@ struct BlockAlloc
   u16 m_checksum;                                // 0x0000    2       Additive Checksum
   u16 m_checksum_inv;                            // 0x0002    2       Inverse Checksum
   Common::BigEndianValue<u16> m_update_counter;  // 0x0004    2       Update Counter
-  u16 m_free_blocks;                             // 0x0006    2       Free Blocks
+  Common::BigEndianValue<u16> m_free_blocks;     // 0x0006    2       Free Blocks
   u16 m_last_allocated_block;                    // 0x0008    2       Last allocated Block
   u16 m_map[BAT_SIZE];                           // 0x000a    0x1ff8  Map of allocated Blocks
   u16 GetNextBlock(u16 Block) const;
@@ -269,14 +269,14 @@ struct BlockAlloc
   explicit BlockAlloc(u16 sizeMb = MemCard2043Mb)
   {
     memset(this, 0, BLOCK_SIZE);
-    m_free_blocks = BE16((sizeMb * MBIT_TO_BLOCKS) - MC_FST_BLOCKS);
+    m_free_blocks = (sizeMb * MBIT_TO_BLOCKS) - MC_FST_BLOCKS;
     m_last_allocated_block = BE16(4);
     fixChecksums();
   }
   u16 AssignBlocksContiguous(u16 length)
   {
     u16 starting = BE16(m_last_allocated_block) + 1;
-    if (length > BE16(m_free_blocks))
+    if (length > m_free_blocks)
       return 0xFFFF;
     u16 current = starting;
     while ((current - starting + 1) < length)
@@ -286,7 +286,7 @@ struct BlockAlloc
     }
     m_map[current - 5] = 0xFFFF;
     m_last_allocated_block = BE16(current);
-    m_free_blocks = BE16(BE16(m_free_blocks) - length);
+    m_free_blocks = m_free_blocks - length;
     fixChecksums();
     return starting;
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -191,7 +191,7 @@ struct DEntry
       m_modification_time;  // 0x28      0x04    Time of file's last modification in seconds since
                             // 12am, January 1st, 2000
   Common::BigEndianValue<u32> m_image_offset;  // 0x2c      0x04    image data offset
-  u8 m_icon_format[2];                         // 0x30      0x02    icon gfx format (2bits per icon)
+  Common::BigEndianValue<u16> m_icon_format;   // 0x30      0x02    icon gfx format (2bits per icon)
   //      Bits    Description
   //      00      No icon
   //      01      CI8 with a shared color palette after the last frame

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -397,8 +397,9 @@ public:
   u32 DEntry_CommentsAddress(u8 index) const;
   std::string GetSaveComment1(u8 index) const;
   std::string GetSaveComment2(u8 index) const;
-  // Copies a DEntry from u8 index to DEntry& data
-  bool GetDEntry(u8 index, DEntry& dest) const;
+
+  // Fetches a DEntry from the given file index.
+  std::optional<DEntry> GetDEntry(u8 index) const;
 
   u32 GetSaveData(u8 index, std::vector<GCMBlock>& saveBlocks) const;
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -214,8 +214,9 @@ struct DEntry
   //
   u8 m_copy_counter;  // 0x35      0x01    Copy counter (*2)
   Common::BigEndianValue<u16>
-      m_first_block;         // 0x36      0x02    Block no of first block of file (0 == offset 0)
-  u8 m_block_count[2];       // 0x38      0x02    File-length (number of blocks in file)
+      m_first_block;  // 0x36      0x02    Block no of first block of file (0 == offset 0)
+  Common::BigEndianValue<u16>
+      m_block_count;         // 0x38      0x02    File-length (number of blocks in file)
   u8 m_unused_2[2];          // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
   u8 m_comments_address[4];  // 0x3c      0x04    Address of the two comments within the file data
                              // (*3)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -163,7 +163,6 @@ static_assert(sizeof(Header) == BLOCK_SIZE);
 
 struct DEntry
 {
-  static const u8 DENTRY_SIZE = 0x40;
   DEntry() { memset(this, 0xFF, DENTRY_SIZE); }
   std::string GCI_FileName() const
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -330,10 +330,8 @@ private:
   u16 m_size_mb;
 
   Header m_header_block;
-  Directory m_directory_block;
-  Directory m_directory_backup_block;
-  BlockAlloc m_bat_block;
-  BlockAlloc m_bat_backup_block;
+  std::array<Directory, 2> m_directory_blocks;
+  std::array<BlockAlloc, 2> m_bat_blocks;
   std::vector<GCMBlock> m_data_blocks;
 
   Directory* m_current_directory_block;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -187,10 +187,11 @@ struct DEntry
   //      11 ? maybe ==00? Time Splitters 2 and 3 have it and don't have banner
   //
   u8 m_filename[DENTRY_STRLEN];  // 0x08      0x20     Filename
-  u8 m_modification_time[4];  // 0x28      0x04    Time of file's last modification in seconds since
-                              // 12am, January 1st, 2000
-  u8 m_image_offset[4];       // 0x2c      0x04    image data offset
-  u8 m_icon_format[2];        // 0x30      0x02    icon gfx format (2bits per icon)
+  Common::BigEndianValue<u32>
+      m_modification_time;  // 0x28      0x04    Time of file's last modification in seconds since
+                            // 12am, January 1st, 2000
+  u8 m_image_offset[4];     // 0x2c      0x04    image data offset
+  u8 m_icon_format[2];      // 0x30      0x02    icon gfx format (2bits per icon)
   //      Bits    Description
   //      00      No icon
   //      01      CI8 with a shared color palette after the last frame

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -212,8 +212,9 @@ struct DEntry
   //      3   no copy     File cannot be copied by the IPL
   //      2   public      Can be read by any game
   //
-  u8 m_copy_counter;         // 0x35      0x01    Copy counter (*2)
-  u8 m_first_block[2];       // 0x36      0x02    Block no of first block of file (0 == offset 0)
+  u8 m_copy_counter;  // 0x35      0x01    Copy counter (*2)
+  Common::BigEndianValue<u16>
+      m_first_block;         // 0x36      0x02    Block no of first block of file (0 == offset 0)
   u8 m_block_count[2];       // 0x38      0x02    File-length (number of blocks in file)
   u8 m_unused_2[2];          // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
   u8 m_comments_address[4];  // 0x3c      0x04    Address of the two comments within the file data
@@ -281,7 +282,7 @@ struct BlockAlloc
     m_last_allocated_block = BE16(current);
     m_free_blocks = BE16(BE16(m_free_blocks) - length);
     fixChecksums();
-    return BE16(starting);
+    return starting;
   }
 };
 static_assert(sizeof(BlockAlloc) == BLOCK_SIZE);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -220,8 +220,8 @@ struct DEntry
   Common::BigEndianValue<u16>
       m_first_block;  // 0x36      0x02    Block no of first block of file (0 == offset 0)
   Common::BigEndianValue<u16>
-      m_block_count;  // 0x38      0x02    File-length (number of blocks in file)
-  u8 m_unused_2[2];   // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
+      m_block_count;             // 0x38      0x02    File-length (number of blocks in file)
+  std::array<u8, 2> m_unused_2;  // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
   Common::BigEndianValue<u32>
       m_comments_address;  // 0x3c      0x04    Address of the two comments within the file data
                            // (*3)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -216,10 +216,11 @@ struct DEntry
   Common::BigEndianValue<u16>
       m_first_block;  // 0x36      0x02    Block no of first block of file (0 == offset 0)
   Common::BigEndianValue<u16>
-      m_block_count;         // 0x38      0x02    File-length (number of blocks in file)
-  u8 m_unused_2[2];          // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
-  u8 m_comments_address[4];  // 0x3c      0x04    Address of the two comments within the file data
-                             // (*3)
+      m_block_count;  // 0x38      0x02    File-length (number of blocks in file)
+  u8 m_unused_2[2];   // 0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
+  Common::BigEndianValue<u32>
+      m_comments_address;  // 0x3c      0x04    Address of the two comments within the file data
+                           // (*3)
 };
 static_assert(sizeof(DEntry) == DENTRY_SIZE);
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -102,11 +102,11 @@ void calc_checksumsBE(const u16* buf, u32 length, u16* csum, u16* inv_csum);
 struct Header  // Offset    Size    Description
 {
   // Serial in libogc
-  u8 m_serial[12];                            // 0x0000    12      ?
-  Common::BigEndianValue<u64> m_format_time;  // 0x000c    8       Time of format (OSTime value)
-  u32 m_sram_bias;                            // 0x0014    4       SRAM bias at time of format
-  u32 m_sram_language;                        // 0x0018    4       SRAM language
-  u8 m_unknown_2[4];                          // 0x001c    4       ? almost always 0
+  u8 m_serial[12];                              // 0x0000    12      ?
+  Common::BigEndianValue<u64> m_format_time;    // 0x000c    8       Time of format (OSTime value)
+  u32 m_sram_bias;                              // 0x0014    4       SRAM bias at time of format
+  Common::BigEndianValue<u32> m_sram_language;  // 0x0018    4       SRAM language
+  u8 m_unknown_2[4];                            // 0x001c    4       ? almost always 0
   // end Serial in libogc
   u8 m_device_id[2];     // 0x0020    2       0 if formated in slot A 1 if formated in slot B
   u8 m_size_mb[2];       // 0x0022    2       Size of memcard in Mbits
@@ -148,7 +148,7 @@ struct Header  // Offset    Size    Description
       rand &= (u64)0x0000000000007fffULL;
     }
     m_sram_bias = g_SRAM.settings.rtc_bias;
-    m_sram_language = BE32(g_SRAM.settings.language);
+    m_sram_language = static_cast<u32>(g_SRAM.settings.language);
     // TODO: determine the purpose of m_unknown_2
     // 1 works for slot A, 0 works for both slot A and slot B
     *(u32*)&m_unknown_2 = 0;  // = _viReg[55];  static vu16* const _viReg = (u16*)0xCC002000;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -168,7 +168,8 @@ struct DEntry
   std::string GCI_FileName() const
   {
     std::string filename = std::string((char*)m_makercode, 2) + '-' +
-                           std::string((char*)m_gamecode, 4) + '-' + (char*)m_filename + ".gci";
+                           std::string((char*)m_gamecode, 4) + '-' +
+                           reinterpret_cast<const char*>(m_filename.data()) + ".gci";
     return Common::EscapeFileName(filename);
   }
 
@@ -186,7 +187,7 @@ struct DEntry
   //      10 RGB5A3 banner
   //      11 ? maybe ==00? Time Splitters 2 and 3 have it and don't have banner
   //
-  u8 m_filename[DENTRY_STRLEN];  // 0x08      0x20     Filename
+  std::array<u8, DENTRY_STRLEN> m_filename;  // 0x08      0x20     Filename
   Common::BigEndianValue<u32>
       m_modification_time;  // 0x28      0x04    Time of file's last modification in seconds since
                             // 12am, January 1st, 2000
@@ -296,9 +297,11 @@ public:
   bool LoadSaveBlocks();
   bool HasCopyProtection() const
   {
-    if ((strcmp((char*)m_gci_header.m_filename, "PSO_SYSTEM") == 0) ||
-        (strcmp((char*)m_gci_header.m_filename, "PSO3_SYSTEM") == 0) ||
-        (strcmp((char*)m_gci_header.m_filename, "f_zero.dat") == 0))
+    if ((strcmp(reinterpret_cast<const char*>(m_gci_header.m_filename.data()), "PSO_SYSTEM") ==
+         0) ||
+        (strcmp(reinterpret_cast<const char*>(m_gci_header.m_filename.data()), "PSO3_SYSTEM") ==
+         0) ||
+        (strcmp(reinterpret_cast<const char*>(m_gci_header.m_filename.data()), "f_zero.dat") == 0))
       return true;
     return false;
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -334,14 +334,18 @@ private:
   std::array<BlockAlloc, 2> m_bat_blocks;
   std::vector<GCMBlock> m_data_blocks;
 
-  Directory* m_current_directory_block;
-  Directory* m_previous_directory_block;
-  BlockAlloc* m_current_bat_block;
-  BlockAlloc* m_previous_bat_block;
+  int m_active_directory;
+  int m_active_bat;
 
   u32 ImportGciInternal(File::IOFile&& gci, const std::string& inputFile,
                         const std::string& outputFile);
-  void InitDirBatPointers();
+  void InitActiveDirBat();
+
+  const Directory& GetActiveDirectory() const;
+  const BlockAlloc& GetActiveBat() const;
+
+  void UpdateDirectory(const Directory& directory);
+  void UpdateBat(const BlockAlloc& bat);
 
 public:
   explicit GCMemcard(const std::string& fileName, bool forceCreation = false,

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -93,8 +93,8 @@ protected:
 struct GCMBlock
 {
   GCMBlock() { Erase(); }
-  void Erase() { memset(m_block, 0xFF, BLOCK_SIZE); }
-  u8 m_block[BLOCK_SIZE];
+  void Erase() { memset(m_block.data(), 0xFF, m_block.size()); }
+  std::array<u8, BLOCK_SIZE> m_block;
 };
 
 void calc_checksumsBE(const u16* buf, u32 length, u16* csum, u16* inv_csum);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -232,9 +232,9 @@ struct Directory
 {
   std::array<DEntry, DIRLEN> m_dir_entries;  // 0x0000            Directory Entries (max 127)
   std::array<u8, 0x3a> m_padding;
-  u16 m_update_counter;  // 0x1ffa    2       Update Counter
-  u16 m_checksum;        // 0x1ffc    2       Additive Checksum
-  u16 m_checksum_inv;    // 0x1ffe    2       Inverse Checksum
+  Common::BigEndianValue<u16> m_update_counter;  // 0x1ffa    2       Update Counter
+  u16 m_checksum;                                // 0x1ffc    2       Additive Checksum
+  u16 m_checksum_inv;                            // 0x1ffe    2       Inverse Checksum
   Directory()
   {
     memset(this, 0xFF, BLOCK_SIZE);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -190,8 +190,8 @@ struct DEntry
   Common::BigEndianValue<u32>
       m_modification_time;  // 0x28      0x04    Time of file's last modification in seconds since
                             // 12am, January 1st, 2000
-  u8 m_image_offset[4];     // 0x2c      0x04    image data offset
-  u8 m_icon_format[2];      // 0x30      0x02    icon gfx format (2bits per icon)
+  Common::BigEndianValue<u32> m_image_offset;  // 0x2c      0x04    image data offset
+  u8 m_icon_format[2];                         // 0x30      0x02    icon gfx format (2bits per icon)
   //      Bits    Description
   //      00      No icon
   //      01      CI8 with a shared color palette after the last frame

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -218,24 +218,24 @@ static_assert(sizeof(DEntry) == DENTRY_SIZE);
 
 struct Directory
 {
-  DEntry Dir[DIRLEN];  // 0x0000            Directory Entries (max 127)
-  u8 Padding[0x3a];
-  u16 UpdateCounter;  // 0x1ffa    2       Update Counter
-  u16 Checksum;       // 0x1ffc    2       Additive Checksum
-  u16 Checksum_Inv;   // 0x1ffe    2       Inverse Checksum
+  DEntry m_dir_entries[DIRLEN];  // 0x0000            Directory Entries (max 127)
+  u8 m_padding[0x3a];
+  u16 m_update_counter;  // 0x1ffa    2       Update Counter
+  u16 m_checksum;        // 0x1ffc    2       Additive Checksum
+  u16 m_checksum_inv;    // 0x1ffe    2       Inverse Checksum
   Directory()
   {
     memset(this, 0xFF, BLOCK_SIZE);
-    UpdateCounter = 0;
-    Checksum = BE16(0xF003);
-    Checksum_Inv = 0;
+    m_update_counter = 0;
+    m_checksum = BE16(0xF003);
+    m_checksum_inv = 0;
   }
   void Replace(DEntry d, int idx)
   {
-    Dir[idx] = d;
+    m_dir_entries[idx] = d;
     fixChecksums();
   }
-  void fixChecksums() { calc_checksumsBE((u16*)this, 0xFFE, &Checksum, &Checksum_Inv); }
+  void fixChecksums() { calc_checksumsBE((u16*)this, 0xFFE, &m_checksum, &m_checksum_inv); }
 };
 static_assert(sizeof(Directory) == BLOCK_SIZE);
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -93,8 +93,8 @@ protected:
 struct GCMBlock
 {
   GCMBlock() { Erase(); }
-  void Erase() { memset(block, 0xFF, BLOCK_SIZE); }
-  u8 block[BLOCK_SIZE];
+  void Erase() { memset(m_block, 0xFF, BLOCK_SIZE); }
+  u8 m_block[BLOCK_SIZE];
 };
 
 void calc_checksumsBE(const u16* buf, u32 length, u16* csum, u16* inv_csum);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -102,11 +102,11 @@ void calc_checksumsBE(const u16* buf, u32 length, u16* csum, u16* inv_csum);
 struct Header  // Offset    Size    Description
 {
   // Serial in libogc
-  u8 m_serial[12];      // 0x0000    12      ?
-  u64 m_format_time;    // 0x000c    8       Time of format (OSTime value)
-  u32 m_sram_bias;      // 0x0014    4       SRAM bias at time of format
-  u32 m_sram_language;  // 0x0018    4       SRAM language
-  u8 m_unknown_2[4];    // 0x001c    4       ? almost always 0
+  u8 m_serial[12];                            // 0x0000    12      ?
+  Common::BigEndianValue<u64> m_format_time;  // 0x000c    8       Time of format (OSTime value)
+  u32 m_sram_bias;                            // 0x0014    4       SRAM bias at time of format
+  u32 m_sram_language;                        // 0x0018    4       SRAM language
+  u8 m_unknown_2[4];                          // 0x001c    4       ? almost always 0
   // end Serial in libogc
   u8 m_device_id[2];     // 0x0020    2       0 if formated in slot A 1 if formated in slot B
   u8 m_size_mb[2];       // 0x0022    2       Size of memcard in Mbits
@@ -139,7 +139,7 @@ struct Header  // Offset    Size    Description
     *(u16*)m_size_mb = BE16(sizeMb);
     m_encoding = BE16(shift_jis ? 1 : 0);
     u64 rand = Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
-    m_format_time = Common::swap64(rand);
+    m_format_time = rand;
     for (int i = 0; i < 12; i++)
     {
       rand = (((rand * (u64)0x0000000041c64e6dULL) + (u64)0x0000000000003039ULL) >> 16);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -253,12 +253,12 @@ static_assert(sizeof(Directory) == BLOCK_SIZE);
 
 struct BlockAlloc
 {
-  u16 m_checksum;              // 0x0000    2       Additive Checksum
-  u16 m_checksum_inv;          // 0x0002    2       Inverse Checksum
-  u16 m_update_counter;        // 0x0004    2       Update Counter
-  u16 m_free_blocks;           // 0x0006    2       Free Blocks
-  u16 m_last_allocated_block;  // 0x0008    2       Last allocated Block
-  u16 m_map[BAT_SIZE];         // 0x000a    0x1ff8  Map of allocated Blocks
+  u16 m_checksum;                                // 0x0000    2       Additive Checksum
+  u16 m_checksum_inv;                            // 0x0002    2       Inverse Checksum
+  Common::BigEndianValue<u16> m_update_counter;  // 0x0004    2       Update Counter
+  u16 m_free_blocks;                             // 0x0006    2       Free Blocks
+  u16 m_last_allocated_block;                    // 0x0008    2       Last allocated Block
+  u16 m_map[BAT_SIZE];                           // 0x000a    0x1ff8  Map of allocated Blocks
   u16 GetNextBlock(u16 Block) const;
   u16 NextFreeBlock(u16 MaxBlock, u16 StartingBlock = MC_FST_BLOCKS) const;
   bool ClearBlocks(u16 StartingBlock, u16 Length);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -429,7 +429,7 @@ inline void GCMemcardDirectory::SyncSaves()
 {
   Directory* current = &m_dir2;
 
-  if (BE16(m_dir1.m_update_counter) > BE16(m_dir2.m_update_counter))
+  if (m_dir1.m_update_counter > m_dir2.m_update_counter)
   {
     current = &m_dir1;
   }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -90,7 +90,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
         return NO_INDEX;
       }
       int total_blocks = m_hdr.m_size_mb * MBIT_TO_BLOCKS - MC_FST_BLOCKS;
-      int free_blocks = BE16(m_bat1.m_free_blocks);
+      int free_blocks = m_bat1.m_free_blocks;
       if (total_blocks > free_blocks * 10)
       {
         PanicAlertT("%s\nwas not loaded because there is less than 10%% free blocks available on "

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -89,7 +89,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
       {
         return NO_INDEX;
       }
-      int total_blocks = BE16(m_hdr.SizeMb) * MBIT_TO_BLOCKS - MC_FST_BLOCKS;
+      int total_blocks = BE16(m_hdr.m_size_mb) * MBIT_TO_BLOCKS - MC_FST_BLOCKS;
       int free_blocks = BE16(m_bat1.FreeBlocks);
       if (total_blocks > free_blocks * 10)
       {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -108,7 +108,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
           file_name.c_str());
       return NO_INDEX;
     }
-    *(u16*)&gci.m_gci_header.m_first_block = first_block;
+    gci.m_gci_header.m_first_block = first_block;
     if (gci.HasCopyProtection() && gci.LoadSaveBlocks())
     {
       GCMemcard::PSO_MakeSaveGameValid(m_hdr, gci.m_gci_header, gci.m_save_data);
@@ -452,8 +452,8 @@ inline void GCMemcardDirectory::SyncSaves()
         m_saves[i].m_dirty = true;
         u32 gamecode = BE32(m_saves[i].m_gci_header.m_gamecode);
         u32 new_gamecode = BE32(current->m_dir_entries[i].m_gamecode);
-        u32 old_start = BE16(m_saves[i].m_gci_header.m_first_block);
-        u32 new_start = BE16(current->m_dir_entries[i].m_first_block);
+        u32 old_start = m_saves[i].m_gci_header.m_first_block;
+        u32 new_start = current->m_dir_entries[i].m_first_block;
 
         if ((gamecode != 0xFFFFFFFF) && (gamecode != new_gamecode))
         {
@@ -551,7 +551,7 @@ bool GCMemcardDirectory::SetUsedBlocks(int save_index)
   else
     current_bat = &m_bat1;
 
-  u16 block = BE16(m_saves[save_index].m_gci_header.m_first_block);
+  u16 block = m_saves[save_index].m_gci_header.m_first_block;
   while (block != 0xFFFF)
   {
     m_saves[save_index].m_used_blocks.push_back(block);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -429,16 +429,16 @@ inline void GCMemcardDirectory::SyncSaves()
 {
   Directory* current = &m_dir2;
 
-  if (BE16(m_dir1.UpdateCounter) > BE16(m_dir2.UpdateCounter))
+  if (BE16(m_dir1.m_update_counter) > BE16(m_dir2.m_update_counter))
   {
     current = &m_dir1;
   }
 
   for (u32 i = 0; i < DIRLEN; ++i)
   {
-    if (BE32(current->Dir[i].m_gamecode) != 0xFFFFFFFF)
+    if (BE32(current->m_dir_entries[i].m_gamecode) != 0xFFFFFFFF)
     {
-      INFO_LOG(EXPANSIONINTERFACE, "Syncing save 0x%x", *(u32*)&(current->Dir[i].m_gamecode));
+      INFO_LOG(EXPANSIONINTERFACE, "Syncing save 0x%x", *(u32*)&(current->m_dir_entries[i].m_gamecode));
       bool added = false;
       while (i >= m_saves.size())
       {
@@ -447,20 +447,20 @@ inline void GCMemcardDirectory::SyncSaves()
         added = true;
       }
 
-      if (added || memcmp((u8*)&(m_saves[i].m_gci_header), (u8*)&(current->Dir[i]), DENTRY_SIZE))
+      if (added || memcmp((u8*)&(m_saves[i].m_gci_header), (u8*)&(current->m_dir_entries[i]), DENTRY_SIZE))
       {
         m_saves[i].m_dirty = true;
         u32 gamecode = BE32(m_saves[i].m_gci_header.m_gamecode);
-        u32 new_gamecode = BE32(current->Dir[i].m_gamecode);
+        u32 new_gamecode = BE32(current->m_dir_entries[i].m_gamecode);
         u32 old_start = BE16(m_saves[i].m_gci_header.m_first_block);
-        u32 new_start = BE16(current->Dir[i].m_first_block);
+        u32 new_start = BE16(current->m_dir_entries[i].m_first_block);
 
         if ((gamecode != 0xFFFFFFFF) && (gamecode != new_gamecode))
         {
           PanicAlertT("Game overwrote with another games save. Data corruption ahead 0x%x, 0x%x",
-                      BE32(m_saves[i].m_gci_header.m_gamecode), BE32(current->Dir[i].m_gamecode));
+                      BE32(m_saves[i].m_gci_header.m_gamecode), BE32(current->m_dir_entries[i].m_gamecode));
         }
-        memcpy((u8*)&(m_saves[i].m_gci_header), (u8*)&(current->Dir[i]), DENTRY_SIZE);
+        memcpy((u8*)&(m_saves[i].m_gci_header), (u8*)&(current->m_dir_entries[i]), DENTRY_SIZE);
         if (old_start != new_start)
         {
           INFO_LOG(EXPANSIONINTERFACE, "Save moved from 0x%x to 0x%x", old_start, new_start);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -58,7 +58,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
       }
     }
 
-    u16 num_blocks = BE16(gci.m_gci_header.m_block_count);
+    u16 num_blocks = gci.m_gci_header.m_block_count;
     // largest number of free blocks on a memory card
     // in reality, there are not likely any valid gci files > 251 blocks
     if (num_blocks > 2043)
@@ -151,7 +151,7 @@ std::vector<std::string> GCMemcardDirectory::GetFileNamesForGameID(const std::st
     if (std::find(loaded_saves.begin(), loaded_saves.end(), gci_filename) != loaded_saves.end())
       continue;
 
-    const u16 num_blocks = BE16(gci.m_gci_header.m_block_count);
+    const u16 num_blocks = gci.m_gci_header.m_block_count;
     // largest number of free blocks on a memory card
     // in reality, there are not likely any valid gci files > 251 blocks
     if (num_blocks > 2043)
@@ -500,7 +500,7 @@ inline s32 GCMemcardDirectory::SaveAreaRW(u32 block, bool writing)
       {
         if (!m_saves[i].LoadSaveBlocks())
         {
-          int num_blocks = BE16(m_saves[i].m_gci_header.m_block_count);
+          int num_blocks = m_saves[i].m_gci_header.m_block_count;
           while (num_blocks)
           {
             m_saves[i].m_save_data.emplace_back();
@@ -563,7 +563,7 @@ bool GCMemcardDirectory::SetUsedBlocks(int save_index)
     }
   }
 
-  u16 num_blocks = BE16(m_saves[save_index].m_gci_header.m_block_count);
+  u16 num_blocks = m_saves[save_index].m_gci_header.m_block_count;
   u16 blocks_from_bat = (u16)m_saves[save_index].m_used_blocks.size();
   if (blocks_from_bat != num_blocks)
   {
@@ -703,7 +703,7 @@ bool GCIFile::LoadSaveBlocks()
 
     INFO_LOG(EXPANSIONINTERFACE, "Reading savedata from disk for %s", m_filename.c_str());
     save_file.Seek(DENTRY_SIZE, SEEK_SET);
-    u16 num_blocks = BE16(m_gci_header.m_block_count);
+    u16 num_blocks = m_gci_header.m_block_count;
     m_save_data.resize(num_blocks);
     if (!save_file.ReadBytes(m_save_data.data(), num_blocks * BLOCK_SIZE))
     {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -58,7 +58,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
       }
     }
 
-    u16 num_blocks = BE16(gci.m_gci_header.BlockCount);
+    u16 num_blocks = BE16(gci.m_gci_header.m_block_count);
     // largest number of free blocks on a memory card
     // in reality, there are not likely any valid gci files > 251 blocks
     if (num_blocks > 2043)
@@ -79,7 +79,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
       return NO_INDEX;
     }
 
-    if (m_game_id == BE32(gci.m_gci_header.Gamecode))
+    if (m_game_id == BE32(gci.m_gci_header.m_gamecode))
     {
       gci.LoadSaveBlocks();
     }
@@ -108,7 +108,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
           file_name.c_str());
       return NO_INDEX;
     }
-    *(u16*)&gci.m_gci_header.FirstBlock = first_block;
+    *(u16*)&gci.m_gci_header.m_first_block = first_block;
     if (gci.HasCopyProtection() && gci.LoadSaveBlocks())
     {
       GCMemcard::PSO_MakeSaveGameValid(m_hdr, gci.m_gci_header, gci.m_save_data);
@@ -151,7 +151,7 @@ std::vector<std::string> GCMemcardDirectory::GetFileNamesForGameID(const std::st
     if (std::find(loaded_saves.begin(), loaded_saves.end(), gci_filename) != loaded_saves.end())
       continue;
 
-    const u16 num_blocks = BE16(gci.m_gci_header.BlockCount);
+    const u16 num_blocks = BE16(gci.m_gci_header.m_block_count);
     // largest number of free blocks on a memory card
     // in reality, there are not likely any valid gci files > 251 blocks
     if (num_blocks > 2043)
@@ -166,7 +166,7 @@ std::vector<std::string> GCMemcardDirectory::GetFileNamesForGameID(const std::st
     // card (see above method), but since we're only loading the saves for one GameID here, we're
     // definitely not going to run out of space.
 
-    if (game_code == BE32(gci.m_gci_header.Gamecode))
+    if (game_code == BE32(gci.m_gci_header.m_gamecode))
     {
       loaded_saves.push_back(gci_filename);
       filenames.push_back(file_name);
@@ -436,9 +436,9 @@ inline void GCMemcardDirectory::SyncSaves()
 
   for (u32 i = 0; i < DIRLEN; ++i)
   {
-    if (BE32(current->Dir[i].Gamecode) != 0xFFFFFFFF)
+    if (BE32(current->Dir[i].m_gamecode) != 0xFFFFFFFF)
     {
-      INFO_LOG(EXPANSIONINTERFACE, "Syncing save 0x%x", *(u32*)&(current->Dir[i].Gamecode));
+      INFO_LOG(EXPANSIONINTERFACE, "Syncing save 0x%x", *(u32*)&(current->Dir[i].m_gamecode));
       bool added = false;
       while (i >= m_saves.size())
       {
@@ -450,15 +450,15 @@ inline void GCMemcardDirectory::SyncSaves()
       if (added || memcmp((u8*)&(m_saves[i].m_gci_header), (u8*)&(current->Dir[i]), DENTRY_SIZE))
       {
         m_saves[i].m_dirty = true;
-        u32 gamecode = BE32(m_saves[i].m_gci_header.Gamecode);
-        u32 new_gamecode = BE32(current->Dir[i].Gamecode);
-        u32 old_start = BE16(m_saves[i].m_gci_header.FirstBlock);
-        u32 new_start = BE16(current->Dir[i].FirstBlock);
+        u32 gamecode = BE32(m_saves[i].m_gci_header.m_gamecode);
+        u32 new_gamecode = BE32(current->Dir[i].m_gamecode);
+        u32 old_start = BE16(m_saves[i].m_gci_header.m_first_block);
+        u32 new_start = BE16(current->Dir[i].m_first_block);
 
         if ((gamecode != 0xFFFFFFFF) && (gamecode != new_gamecode))
         {
           PanicAlertT("Game overwrote with another games save. Data corruption ahead 0x%x, 0x%x",
-                      BE32(m_saves[i].m_gci_header.Gamecode), BE32(current->Dir[i].Gamecode));
+                      BE32(m_saves[i].m_gci_header.m_gamecode), BE32(current->Dir[i].m_gamecode));
         }
         memcpy((u8*)&(m_saves[i].m_gci_header), (u8*)&(current->Dir[i]), DENTRY_SIZE);
         if (old_start != new_start)
@@ -476,8 +476,8 @@ inline void GCMemcardDirectory::SyncSaves()
     else if ((i < m_saves.size()) && (*(u32*)&(m_saves[i].m_gci_header) != 0xFFFFFFFF))
     {
       INFO_LOG(EXPANSIONINTERFACE, "Clearing and/or deleting save 0x%x",
-               BE32(m_saves[i].m_gci_header.Gamecode));
-      *(u32*)&(m_saves[i].m_gci_header.Gamecode) = 0xFFFFFFFF;
+               BE32(m_saves[i].m_gci_header.m_gamecode));
+      *(u32*)&(m_saves[i].m_gci_header.m_gamecode) = 0xFFFFFFFF;
       m_saves[i].m_save_data.clear();
       m_saves[i].m_used_blocks.clear();
       m_saves[i].m_dirty = true;
@@ -488,7 +488,7 @@ inline s32 GCMemcardDirectory::SaveAreaRW(u32 block, bool writing)
 {
   for (u16 i = 0; i < m_saves.size(); ++i)
   {
-    if (BE32(m_saves[i].m_gci_header.Gamecode) != 0xFFFFFFFF)
+    if (BE32(m_saves[i].m_gci_header.m_gamecode) != 0xFFFFFFFF)
     {
       if (m_saves[i].m_used_blocks.size() == 0)
       {
@@ -500,7 +500,7 @@ inline s32 GCMemcardDirectory::SaveAreaRW(u32 block, bool writing)
       {
         if (!m_saves[i].LoadSaveBlocks())
         {
-          int num_blocks = BE16(m_saves[i].m_gci_header.BlockCount);
+          int num_blocks = BE16(m_saves[i].m_gci_header.m_block_count);
           while (num_blocks)
           {
             m_saves[i].m_save_data.emplace_back();
@@ -551,7 +551,7 @@ bool GCMemcardDirectory::SetUsedBlocks(int save_index)
   else
     current_bat = &m_bat1;
 
-  u16 block = BE16(m_saves[save_index].m_gci_header.FirstBlock);
+  u16 block = BE16(m_saves[save_index].m_gci_header.m_first_block);
   while (block != 0xFFFF)
   {
     m_saves[save_index].m_used_blocks.push_back(block);
@@ -563,7 +563,7 @@ bool GCMemcardDirectory::SetUsedBlocks(int save_index)
     }
   }
 
-  u16 num_blocks = BE16(m_saves[save_index].m_gci_header.BlockCount);
+  u16 num_blocks = BE16(m_saves[save_index].m_gci_header.m_block_count);
   u16 blocks_from_bat = (u16)m_saves[save_index].m_used_blocks.size();
   if (blocks_from_bat != num_blocks)
   {
@@ -585,7 +585,7 @@ void GCMemcardDirectory::FlushToFile()
   {
     if (m_saves[i].m_dirty)
     {
-      if (BE32(m_saves[i].m_gci_header.Gamecode) != 0xFFFFFFFF)
+      if (BE32(m_saves[i].m_gci_header.m_gamecode) != 0xFFFFFFFF)
       {
         m_saves[i].m_dirty = false;
         if (m_saves[i].m_save_data.size() == 0)
@@ -654,7 +654,7 @@ void GCMemcardDirectory::FlushToFile()
     // simultaneously
     // this ensures that the save data for all of the current games gci files are stored in the
     // savestate
-    u32 gamecode = BE32(m_saves[i].m_gci_header.Gamecode);
+    u32 gamecode = BE32(m_saves[i].m_gci_header.m_gamecode);
     if (gamecode != m_game_id && gamecode != 0xFFFFFFFF && m_saves[i].m_save_data.size())
     {
       INFO_LOG(EXPANSIONINTERFACE, "Flushing savedata to disk for %s",
@@ -703,7 +703,7 @@ bool GCIFile::LoadSaveBlocks()
 
     INFO_LOG(EXPANSIONINTERFACE, "Reading savedata from disk for %s", m_filename.c_str());
     save_file.Seek(DENTRY_SIZE, SEEK_SET);
-    u16 num_blocks = BE16(m_gci_header.BlockCount);
+    u16 num_blocks = BE16(m_gci_header.m_block_count);
     m_save_data.resize(num_blocks);
     if (!save_file.ReadBytes(m_save_data.data(), num_blocks * BLOCK_SIZE))
     {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -517,7 +517,7 @@ inline s32 GCMemcardDirectory::SaveAreaRW(u32 block, bool writing)
         }
 
         m_last_block = block;
-        m_last_block_address = m_saves[i].m_save_data[idx].m_block;
+        m_last_block_address = m_saves[i].m_save_data[idx].m_block.data();
         return m_last_block;
       }
     }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -89,7 +89,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
       {
         return NO_INDEX;
       }
-      int total_blocks = BE16(m_hdr.m_size_mb) * MBIT_TO_BLOCKS - MC_FST_BLOCKS;
+      int total_blocks = m_hdr.m_size_mb * MBIT_TO_BLOCKS - MC_FST_BLOCKS;
       int free_blocks = BE16(m_bat1.m_free_blocks);
       if (total_blocks > free_blocks * 10)
       {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -90,7 +90,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& file_name, bool current_game_
         return NO_INDEX;
       }
       int total_blocks = BE16(m_hdr.m_size_mb) * MBIT_TO_BLOCKS - MC_FST_BLOCKS;
-      int free_blocks = BE16(m_bat1.FreeBlocks);
+      int free_blocks = BE16(m_bat1.m_free_blocks);
       if (total_blocks > free_blocks * 10)
       {
         PanicAlertT("%s\nwas not loaded because there is less than 10%% free blocks available on "
@@ -546,7 +546,7 @@ s32 GCMemcardDirectory::DirectoryWrite(u32 dest_address, u32 length, const u8* s
 bool GCMemcardDirectory::SetUsedBlocks(int save_index)
 {
   BlockAlloc* current_bat;
-  if (BE16(m_bat2.UpdateCounter) > BE16(m_bat1.UpdateCounter))
+  if (BE16(m_bat2.m_update_counter) > BE16(m_bat1.m_update_counter))
     current_bat = &m_bat2;
   else
     current_bat = &m_bat1;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -517,7 +517,7 @@ inline s32 GCMemcardDirectory::SaveAreaRW(u32 block, bool writing)
         }
 
         m_last_block = block;
-        m_last_block_address = m_saves[i].m_save_data[idx].block;
+        m_last_block_address = m_saves[i].m_save_data[idx].m_block;
         return m_last_block;
       }
     }

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -549,7 +549,7 @@ s32 GCMemcardDirectory::DirectoryWrite(u32 dest_address, u32 length, const u8* s
 bool GCMemcardDirectory::SetUsedBlocks(int save_index)
 {
   BlockAlloc* current_bat;
-  if (BE16(m_bat2.m_update_counter) > BE16(m_bat1.m_update_counter))
+  if (m_bat2.m_update_counter > m_bat1.m_update_counter)
     current_bat = &m_bat2;
   else
     current_bat = &m_bat1;

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -199,12 +199,11 @@ void GCMemcardManager::UpdateSlotTable(int slot)
     auto* icon = new QTableWidgetItem;
     icon->setData(Qt::DecorationRole, frames[0]);
 
-    DEntry d;
-    memcard->GetDEntry(file_index, d);
+    std::optional<DEntry> entry = memcard->GetDEntry(file_index);
 
     // TODO: This is wrong, the animation speed is not static and is already correctly calculated in
     // GetIconFromSaveFile(), just not returned
-    const u16 animation_speed = d.m_animation_speed;
+    const u16 animation_speed = entry ? entry->m_animation_speed : 1;
     const auto speed = (((animation_speed >> 8) & 1) << 2) + (animation_speed & 1);
 
     m_slot_active_icons[slot].push_back({speed, frames});

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -202,7 +202,10 @@ void GCMemcardManager::UpdateSlotTable(int slot)
     DEntry d;
     memcard->GetDEntry(file_index, d);
 
-    const auto speed = ((d.m_animation_speed[0] & 1) << 2) + (d.m_animation_speed[1] & 1);
+    // TODO: This is wrong, the animation speed is not static and is already correctly calculated in
+    // GetIconFromSaveFile(), just not returned
+    const u16 animation_speed = d.m_animation_speed;
+    const auto speed = (((animation_speed >> 8) & 1) << 2) + (animation_speed & 1);
 
     m_slot_active_icons[slot].push_back({speed, frames});
 

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -202,7 +202,7 @@ void GCMemcardManager::UpdateSlotTable(int slot)
     DEntry d;
     memcard->GetDEntry(file_index, d);
 
-    const auto speed = ((d.AnimSpeed[0] & 1) << 2) + (d.AnimSpeed[1] & 1);
+    const auto speed = ((d.m_animation_speed[0] & 1) << 2) + (d.m_animation_speed[1] & 1);
 
     m_slot_active_icons[slot].push_back({speed, frames});
 


### PR DESCRIPTION
This isn't as in-depth as I had originally planned, but I'm not finding time right now to work on this more so here's what I have so far. There *should* be no functional changes in here.

This mainly updates the GCMemcard structs and classes to use modern Dolphin naming conventions and uses stuff like std::array instead of C arrays and Common::BigEndianValue instead of manually byteswapping values all over the place. This still isn't great overall though, lots of weird data reinterpretation and similar going on here...

All of this can be squashed together on merge in my opinion, left it separate to review though.