### PR TITLE
Common/GLContext: Make member functions const qualified where applicable

### DIFF
--- a/Source/Core/Common/GL/GLContext.h
+++ b/Source/Core/Common/GL/GLContext.h
@@ -24,11 +24,11 @@ public:
 
   virtual ~GLContext();
 
-  Mode GetMode() { return m_opengl_mode; }
+  Mode GetMode() const { return m_opengl_mode; }
   bool IsGLES() const { return m_opengl_mode == Mode::OpenGLES; }
 
-  u32 GetBackBufferWidth() { return m_backbuffer_width; }
-  u32 GetBackBufferHeight() { return m_backbuffer_height; }
+  u32 GetBackBufferWidth() const { return m_backbuffer_width; }
+  u32 GetBackBufferHeight() const { return m_backbuffer_height; }
 
   virtual bool IsHeadless() const;
 


### PR DESCRIPTION
These don't modify object state, so they can be const qualified.