### PR TITLE
Android: fix/ignore L2/R2 buttons

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ControllerMappingHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ControllerMappingHelper.java
@@ -18,8 +18,7 @@ public class ControllerMappingHelper
     {
       // The two analog triggers generate analog motion events as well as a keycode.
       // We always prefer to use the analog values, so throw away the button press
-      // Even though the triggers are L/R2, without mappings they generate L/R1 events.
-      return keyCode == KeyEvent.KEYCODE_BUTTON_L1 || keyCode == KeyEvent.KEYCODE_BUTTON_R1;
+      return keyCode == KeyEvent.KEYCODE_BUTTON_L2 || keyCode == KeyEvent.KEYCODE_BUTTON_R2;
     }
     return false;
   }


### PR DESCRIPTION
L2/R2 will trigger a key press and an axis event if the trigger is pressed fully down
Was incorrectly ignoring L1/R1 key presses