### PR TITLE
Always clean cache on render swap

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1528,6 +1528,13 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   ClearEFBCache();
 }
 
+void Renderer::Flush()
+{
+  // ensure all commands are sent to the GPU.
+  // Otherwise the driver could batch several frames togehter.
+  glFlush();
+}
+
 void Renderer::CheckForSurfaceChange()
 {
   if (!m_surface_changed.TestAndClear())

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -133,6 +133,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(AbstractTexture* texture, const EFBRectangle& rc, u64 ticks) override;
+  void Flush() override;
 
   void ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,
                    u32 color, u32 z) override;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -640,6 +640,11 @@ void Renderer::SwapImpl(AbstractTexture* texture, const EFBRectangle& xfb_region
   TextureCache::GetInstance()->Cleanup(frameCount);
 }
 
+void Renderer::Flush()
+{
+  Util::ExecuteCurrentCommandsAndRestoreState(true, false);
+}
+
 void Renderer::DrawScreen(VKTexture* xfb_texture, const EFBRectangle& xfb_region)
 {
   VkResult res;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -63,6 +63,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(AbstractTexture* texture, const EFBRectangle& rc, u64 ticks) override;
+  void Flush() override;
 
   void ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha_enable, bool z_enable,
                    u32 color, u32 z) override;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -751,10 +751,18 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
 
       Core::Callback_VideoCopiedToXFB(true);
     }
+    else
+    {
+      Flush();
+    }
 
     // Update our last xfb values
     m_last_xfb_width = (fbStride < 1 || fbStride > MAX_XFB_WIDTH) ? MAX_XFB_WIDTH : fbStride;
     m_last_xfb_height = (fbHeight < 1 || fbHeight > MAX_XFB_HEIGHT) ? MAX_XFB_HEIGHT : fbHeight;
+  }
+  else
+  {
+    Flush();
   }
 }
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -184,6 +184,7 @@ public:
   void Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
             u64 ticks);
   virtual void SwapImpl(AbstractTexture* texture, const EFBRectangle& rc, u64 ticks) = 0;
+  virtual void Flush() {}
 
   PEControl::PixelFormat GetPrevPixelFormat() const { return m_prev_efb_format; }
   void StorePixelFormat(PEControl::PixelFormat new_format) { m_prev_efb_format = new_format; }


### PR DESCRIPTION
Xenoblade will crash at launch on android when use vulkan backend because of out of memory.
`fbHeight` is 0 at launch and can't get in `SwapImpl`.