### PR TITLE
ControllerEmu: Add ability to reshape analog sticks. Make the mapping indicator pretty.

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -17,6 +17,9 @@
 
 namespace MathUtil
 {
+constexpr double TAU = 6.2831853071795865;
+constexpr double PI = TAU / 2;
+
 template <class T>
 constexpr T Clamp(const T val, const T& min, const T& max)
 {

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -63,10 +63,14 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
   }
 
   // sticks
-  groups.emplace_back(m_main_stick = new ControllerEmu::AnalogStick(
-                          "Main Stick", _trans("Control Stick"), DEFAULT_PAD_STICK_RADIUS));
-  groups.emplace_back(m_c_stick = new ControllerEmu::AnalogStick("C-Stick", _trans("C Stick"),
-                                                                 DEFAULT_PAD_STICK_RADIUS));
+  constexpr auto main_gate_radius =
+      ControlState(MAIN_STICK_GATE_RADIUS) / GCPadStatus::MAIN_STICK_RADIUS;
+  groups.emplace_back(m_main_stick = new ControllerEmu::OctagonAnalogStick(
+                          "Main Stick", _trans("Control Stick"), main_gate_radius));
+
+  constexpr auto c_gate_radius = ControlState(C_STICK_GATE_RADIUS) / GCPadStatus::MAIN_STICK_RADIUS;
+  groups.emplace_back(m_c_stick = new ControllerEmu::OctagonAnalogStick(
+                          "C-Stick", _trans("C Stick"), c_gate_radius));
 
   // triggers
   groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
@@ -226,7 +230,8 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
   m_main_stick->SetControlExpression(4, "LSHIFT");  // Modifier
 
 #elif __APPLE__
-  m_c_stick->SetControlExpression(4, "Left Control");  // Modifier
+  // Modifier
+  m_c_stick->SetControlExpression(4, "Left Control");
 
   // Control Stick
   m_main_stick->SetControlExpression(0, "Up Arrow");     // Up

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -16,7 +16,7 @@ namespace ControllerEmu
 class AnalogStick;
 class Buttons;
 class MixedTriggers;
-}
+}  // namespace ControllerEmu
 
 enum class PadGroup
 {
@@ -45,6 +45,9 @@ public:
 
   void LoadDefaults(const ControllerInterface& ciface) override;
 
+  static const u8 MAIN_STICK_GATE_RADIUS = 87;
+  static const u8 C_STICK_GATE_RADIUS = 74;
+
 private:
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::AnalogStick* m_main_stick;
@@ -57,7 +60,4 @@ private:
   ControllerEmu::BooleanSetting* m_always_connected;
 
   const unsigned int m_index;
-
-  // Default analog stick radius for GameCube controllers.
-  static constexpr ControlState DEFAULT_PAD_STICK_RADIUS = 1.0;
 };

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
@@ -25,9 +25,6 @@ public:
   std::string GetName() const override;
 
 protected:
-  // Default radius for attachment analog sticks.
-  static constexpr ControlState DEFAULT_ATTACHMENT_STICK_RADIUS = 1.0;
-
   std::array<u8, 6> m_id{};
   std::array<u8, 0x10> m_calibration{};
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -83,10 +83,11 @@ Classic::Classic(ExtensionReg& reg) : Attachment(_trans("Classic"), reg)
   }
 
   // sticks
-  groups.emplace_back(m_left_stick = new ControllerEmu::AnalogStick(
-                          _trans("Left Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
-  groups.emplace_back(m_right_stick = new ControllerEmu::AnalogStick(
-                          _trans("Right Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
+  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / LEFT_STICK_RADIUS;
+  groups.emplace_back(m_left_stick =
+                          new ControllerEmu::OctagonAnalogStick(_trans("Left Stick"), gate_radius));
+  groups.emplace_back(
+      m_right_stick = new ControllerEmu::OctagonAnalogStick(_trans("Right Stick"), gate_radius));
 
   // triggers
   groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.h
@@ -68,6 +68,8 @@ public:
     RIGHT_TRIGGER_RANGE = 0x1F,
   };
 
+  static const u8 STICK_GATE_RADIUS = 0x16;
+
 private:
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::MixedTriggers* m_triggers;

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -54,8 +54,9 @@ Drums::Drums(ExtensionReg& reg) : Attachment(_trans("Drums"), reg)
   }
 
   // stick
-  groups.emplace_back(
-      m_stick = new ControllerEmu::AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
+  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
+  groups.emplace_back(m_stick =
+                          new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
 
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
@@ -76,8 +77,8 @@ void Drums::GetState(u8* const data)
   {
     const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
 
-    drum_data.sx = static_cast<u8>((stick_state.x * 0x1F) + 0x20);
-    drum_data.sy = static_cast<u8>((stick_state.y * 0x1F) + 0x20);
+    drum_data.sx = static_cast<u8>((stick_state.x * STICK_RADIUS) + STICK_CENTER);
+    drum_data.sy = static_cast<u8>((stick_state.y * STICK_RADIUS) + STICK_CENTER);
   }
 
   // TODO: softness maybe
@@ -119,4 +120,4 @@ ControllerEmu::ControlGroup* Drums::GetGroup(DrumsGroup group)
     return nullptr;
   }
 }
-}
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.h
@@ -40,6 +40,12 @@ public:
     PAD_ORANGE = 0x8000,
   };
 
+  static const u8 STICK_CENTER = 0x20;
+  static const u8 STICK_RADIUS = 0x1f;
+
+  // TODO: Test real hardware. Is this accurate?
+  static const u8 STICK_GATE_RADIUS = 0x16;
+
 private:
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::Buttons* m_pads;

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -83,8 +83,9 @@ Guitar::Guitar(ExtensionReg& reg) : Attachment(_trans("Guitar"), reg)
   m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "+"));
 
   // stick
-  groups.emplace_back(
-      m_stick = new ControllerEmu::AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
+  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
+  groups.emplace_back(m_stick =
+                          new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
 
   // whammy
   groups.emplace_back(m_whammy = new ControllerEmu::Triggers(_trans("Whammy")));
@@ -108,8 +109,8 @@ void Guitar::GetState(u8* const data)
   {
     const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
 
-    guitar_data.sx = static_cast<u8>((stick_state.x * 0x1F) + 0x20);
-    guitar_data.sy = static_cast<u8>((stick_state.y * 0x1F) + 0x20);
+    guitar_data.sx = static_cast<u8>((stick_state.x * STICK_RADIUS) + STICK_CENTER);
+    guitar_data.sy = static_cast<u8>((stick_state.y * STICK_RADIUS) + STICK_CENTER);
   }
 
   // slider bar
@@ -174,4 +175,4 @@ ControllerEmu::ControlGroup* Guitar::GetGroup(GuitarGroup group)
     return nullptr;
   }
 }
-}
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.h
@@ -43,6 +43,12 @@ public:
     FRET_ORANGE = 0x8000,
   };
 
+  static const u8 STICK_CENTER = 0x20;
+  static const u8 STICK_RADIUS = 0x1f;
+
+  // TODO: Test real hardware. Is this accurate?
+  static const u8 STICK_GATE_RADIUS = 0x16;
+
 private:
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::Buttons* m_frets;

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -38,8 +38,9 @@ Nunchuk::Nunchuk(ExtensionReg& reg) : Attachment(_trans("Nunchuk"), reg)
   m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "Z"));
 
   // stick
-  groups.emplace_back(
-      m_stick = new ControllerEmu::AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
+  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
+  groups.emplace_back(m_stick =
+                          new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
 
   // swing
   groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.h
@@ -48,6 +48,7 @@ public:
   {
     STICK_CENTER = 0x80,
     STICK_RADIUS = 0x7F,
+    STICK_GATE_RADIUS = 0x52,
   };
 
   void LoadDefaults(const ControllerInterface& ciface) override;

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -69,8 +69,9 @@ Turntable::Turntable(ExtensionReg& reg) : Attachment(_trans("Turntable"), reg)
                       new ControllerEmu::Slider("Table Right", _trans("Right Table")));
 
   // stick
-  groups.emplace_back(
-      m_stick = new ControllerEmu::AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
+  constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
+  groups.emplace_back(m_stick =
+                          new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
 
   // effect dial
   groups.emplace_back(m_effect_dial = new ControllerEmu::Triggers(_trans("Effect")));
@@ -92,8 +93,8 @@ void Turntable::GetState(u8* const data)
   {
     const ControllerEmu::AnalogStick::StateData stick_state = m_stick->GetState();
 
-    tt_data.sx = static_cast<u8>((stick_state.x * 0x1F) + 0x20);
-    tt_data.sy = static_cast<u8>((stick_state.y * 0x1F) + 0x20);
+    tt_data.sx = static_cast<u8>((stick_state.x * STICK_RADIUS) + STICK_CENTER);
+    tt_data.sy = static_cast<u8>((stick_state.y * STICK_RADIUS) + STICK_CENTER);
   }
 
   // left table
@@ -170,4 +171,4 @@ ControllerEmu::ControlGroup* Turntable::GetGroup(TurntableGroup group)
     return nullptr;
   }
 }
-}
+}  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.h
@@ -45,6 +45,12 @@ public:
     BUTTON_PLUS = 0x04,
   };
 
+  static const u8 STICK_CENTER = 0x20;
+  static const u8 STICK_RADIUS = 0x1f;
+
+  // TODO: Test real hardware. Is this accurate?
+  static const u8 STICK_GATE_RADIUS = 0x16;
+
 private:
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::AnalogStick* m_stick;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -159,7 +159,8 @@ void MappingIndicator::DrawStick()
 {
   // Make the c-stick yellow:
   const bool is_c_stick = m_group->name == "C-Stick";
-  const QColor gate_color = is_c_stick ? Qt::yellow : Qt::lightGray;
+  const QColor gate_brush_color = is_c_stick ? Qt::yellow : Qt::lightGray;
+  const QColor gate_pen_color = gate_brush_color.darker(125);
 
   auto& stick = *static_cast<ControllerEmu::AnalogStick*>(m_group);
 
@@ -191,8 +192,8 @@ void MappingIndicator::DrawStick()
   p.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
   // Input gate. (i.e. the octagon shape)
-  p.setPen(Qt::darkGray);
-  p.setBrush(gate_color);
+  p.setPen(gate_pen_color);
+  p.setBrush(gate_brush_color);
   p.drawPolygon(GetPolygonFromRadiusGetter(
       [&stick](double ang) { return stick.GetGateRadiusAtAngle(ang); }, scale));
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -138,8 +138,8 @@ void MappingIndicator::DrawCursor(bool tilt)
 template <typename F>
 QPolygonF GetPolygonFromRadiusGetter(F&& radius_getter, double scale)
 {
-  // 24 is a multiple of 8 (octagon) and enough points to be visibly pleasing:
-  constexpr int shape_point_count = 24;
+  // A multiple of 8 (octagon) and enough points to be visibly pleasing:
+  constexpr int shape_point_count = 32;
   QPolygonF shape{shape_point_count};
 
   int p = 0;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -10,9 +10,11 @@
 #include <QPainter>
 #include <QTimer>
 
+#include "Common/MathUtil.h"
+
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
-#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
@@ -28,7 +30,7 @@ MappingIndicator::MappingIndicator(ControllerEmu::ControlGroup* group) : m_group
     BindCursorControls(false);
     break;
   case ControllerEmu::GroupType::Stick:
-    BindStickControls();
+    // Nothing needed:
     break;
   case ControllerEmu::GroupType::Tilt:
     BindCursorControls(true);
@@ -66,18 +68,6 @@ void MappingIndicator::BindCursorControls(bool tilt)
   {
     m_cursor_deadzone = m_group->numeric_settings[0].get();
   }
-}
-
-void MappingIndicator::BindStickControls()
-{
-  m_stick_up = m_group->controls[0]->control_ref.get();
-  m_stick_down = m_group->controls[1]->control_ref.get();
-  m_stick_left = m_group->controls[2]->control_ref.get();
-  m_stick_right = m_group->controls[3]->control_ref.get();
-  m_stick_modifier = m_group->controls[4]->control_ref.get();
-
-  m_stick_radius = m_group->numeric_settings[0].get();
-  m_stick_deadzone = m_group->numeric_settings[1].get();
 }
 
 void MappingIndicator::BindMixedTriggersControls()
@@ -144,83 +134,92 @@ void MappingIndicator::DrawCursor(bool tilt)
   p.fillRect(curx, cury, 8, 8, Qt::red);
 }
 
+// Constructs a polygon by querying a radius at varying angles:
+template <typename F>
+QPolygonF GetPolygonFromRadiusGetter(F&& radius_getter, double scale)
+{
+  // 24 is a multiple of 8 (octagon) and enough points to be visibly pleasing:
+  constexpr int shape_point_count = 24;
+  QPolygonF shape{shape_point_count};
+
+  int p = 0;
+  for (auto& point : shape)
+  {
+    const double angle = MathUtil::TAU * p / shape.size();
+    const double radius = radius_getter(angle) * scale;
+
+    point = {std::cos(angle) * radius, std::sin(angle) * radius};
+    ++p;
+  }
+
+  return shape;
+}
+
 void MappingIndicator::DrawStick()
 {
-  float centerx = width() / 2., centery = height() / 2.;
+  // Make the c-stick yellow:
+  const bool is_c_stick = m_group->name == "C-Stick";
+  const QColor gate_color = is_c_stick ? Qt::yellow : Qt::lightGray;
 
-  bool c_stick = m_group->name == "C-Stick";
-  bool classic_controller = m_group->name == "Left Stick" || m_group->name == "Right Stick";
+  auto& stick = *static_cast<ControllerEmu::AnalogStick*>(m_group);
 
-  float ratio = 1;
+  // TODO: This SetControllerStateNeeded interface leaks input into the game
+  // We should probably hold the mutex for UI updates.
+  Settings::Instance().SetControllerStateNeeded(true);
+  const auto raw_coord = stick.GetState(false);
+  const auto adj_coord = stick.GetState(true);
+  Settings::Instance().SetControllerStateNeeded(false);
 
-  if (c_stick)
-    ratio = 1.;
-  else if (classic_controller)
-    ratio = 0.9f;
+  // Bounding box size:
+  const double scale = height() / 2.5;
 
-  // Polled values
-  float mod = PollControlState(m_stick_modifier) ? 0.5 : 1;
-  float radius = m_stick_radius->GetValue();
-  float curx = -PollControlState(m_stick_left) + PollControlState(m_stick_right),
-        cury = -PollControlState(m_stick_up) + PollControlState(m_stick_down);
-  // The maximum deadzone value covers 50% of the stick area
-  float deadzone = m_stick_deadzone->GetValue() / 2.;
-
-  // Size parameters
-  float max_size = (height() / 2.5) / ratio;
-  float stick_size = (height() / 3.) / ratio;
-
-  // Emulated cursor position
-  float virt_curx, virt_cury;
-
-  if (std::abs(curx) < deadzone && std::abs(cury) < deadzone)
-  {
-    virt_curx = virt_cury = 0;
-  }
-  else
-  {
-    virt_curx = curx * mod;
-    virt_cury = cury * mod;
-  }
-
-  // Coordinates for an octagon
-  std::array<QPointF, 8> radius_octagon = {{
-      QPointF(centerx, centery + stick_size),                                   // Bottom
-      QPointF(centerx + stick_size / sqrt(2), centery + stick_size / sqrt(2)),  // Bottom Right
-      QPointF(centerx + stick_size, centery),                                   // Right
-      QPointF(centerx + stick_size / sqrt(2), centery - stick_size / sqrt(2)),  // Top Right
-      QPointF(centerx, centery - stick_size),                                   // Top
-      QPointF(centerx - stick_size / sqrt(2), centery - stick_size / sqrt(2)),  // Top Left
-      QPointF(centerx - stick_size, centery),                                   // Left
-      QPointF(centerx - stick_size / sqrt(2), centery + stick_size / sqrt(2))   // Bottom Left
-  }};
+  const float dot_radius = 2;
 
   QPainter p(this);
+  p.translate(width() / 2, height() / 2);
+
+  // Bounding box.
+  p.setBrush(Qt::white);
+  p.setPen(Qt::gray);
+  p.drawRect(-scale - 1, -scale - 1, scale * 2 + 1, scale * 2 + 1);
+
+  // UI y-axis is opposite that of stick.
+  p.scale(1.0, -1.0);
+
+  // Enable AA after drawing bounding box.
   p.setRenderHint(QPainter::Antialiasing, true);
   p.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
-  // Draw maximum values
-  p.setBrush(Qt::white);
-  p.setPen(Qt::black);
-  p.drawRect(centerx - max_size, centery - max_size, max_size * 2, max_size * 2);
+  // Input gate. (i.e. the octagon shape)
+  p.setPen(Qt::darkGray);
+  p.setBrush(gate_color);
+  p.drawPolygon(GetPolygonFromRadiusGetter(
+      [&stick](double ang) { return stick.GetGateRadiusAtAngle(ang); }, scale));
 
-  // Draw radius
-  p.setBrush(c_stick ? Qt::yellow : Qt::darkGray);
-  p.drawPolygon(radius_octagon.data(), static_cast<int>(radius_octagon.size()));
+  // Deadzone.
+  p.setPen(Qt::darkGray);
+  p.setBrush(QBrush(Qt::darkGray, Qt::BDiagPattern));
+  p.drawPolygon(GetPolygonFromRadiusGetter(
+      [&stick](double ang) { return stick.GetDeadzoneRadiusAtAngle(ang); }, scale));
 
-  // Draw deadzone
-  p.setBrush(c_stick ? Qt::darkYellow : Qt::lightGray);
-  p.drawEllipse(centerx - deadzone * stick_size, centery - deadzone * stick_size,
-                deadzone * stick_size * 2, deadzone * stick_size * 2);
+  // Input shape.
+  p.setPen(QPen(Qt::darkGray, 1.0, Qt::DashLine));
+  p.setBrush(Qt::NoBrush);
+  p.drawPolygon(GetPolygonFromRadiusGetter(
+      [&stick](double ang) { return stick.GetInputRadiusAtAngle(ang); }, scale));
 
-  // Draw stick
-  p.setBrush(Qt::black);
-  p.drawEllipse(centerx - 4 + curx * max_size, centery - 4 + cury * max_size, 8, 8);
+  // Raw stick position.
+  p.setPen(Qt::NoPen);
+  p.setBrush(Qt::darkGray);
+  p.drawEllipse(QPointF{raw_coord.x, raw_coord.y} * scale, dot_radius, dot_radius);
 
-  // Draw virtual stick
-  p.setBrush(Qt::red);
-  p.drawEllipse(centerx - 4 + virt_curx * max_size * radius,
-                centery - 4 + virt_cury * max_size * radius, 8, 8);
+  // Adjusted stick position.
+  if (adj_coord.x || adj_coord.y)
+  {
+    p.setPen(Qt::NoPen);
+    p.setBrush(Qt::red);
+    p.drawEllipse(QPointF{adj_coord.x, adj_coord.y} * scale, dot_radius, dot_radius);
+  }
 }
 
 void MappingIndicator::DrawMixedTriggers()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -25,7 +25,6 @@ public:
 
 private:
   void BindCursorControls(bool tilt);
-  void BindStickControls();
   void BindMixedTriggersControls();
 
   void DrawCursor(bool tilt);
@@ -34,16 +33,6 @@ private:
 
   void paintEvent(QPaintEvent*) override;
   ControllerEmu::ControlGroup* m_group;
-
-  // Stick settings
-  ControlReference* m_stick_up;
-  ControlReference* m_stick_down;
-  ControlReference* m_stick_left;
-  ControlReference* m_stick_right;
-  ControlReference* m_stick_modifier;
-
-  ControllerEmu::NumericSetting* m_stick_radius;
-  ControllerEmu::NumericSetting* m_stick_deadzone;
 
   // Cursor settings
   ControlReference* m_cursor_up;

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(inputcommon
   InputConfig.cpp
   InputProfile.cpp
   ControllerEmu/ControllerEmu.cpp
+  ControllerEmu/StickGate.cpp
   ControllerEmu/Control/Control.cpp
   ControllerEmu/Control/Input.cpp
   ControllerEmu/Control/Output.cpp

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -32,8 +32,10 @@ AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Modifier")));
 
   // Set default input radius to that of the gate radius (no resizing)
+  // Allow radius greater than 1.0 for definitions of rounded squares
+  // This is ideal for Xbox controllers (and probably others)
   numeric_settings.emplace_back(
-      std::make_unique<NumericSetting>(_trans("Input Radius"), GetGateRadiusAtAngle(0.0), 0, 100));
+      std::make_unique<NumericSetting>(_trans("Input Radius"), GetGateRadiusAtAngle(0.0), 0, 140));
   // Set default input shape to an octagon (no reshaping)
   numeric_settings.emplace_back(
       std::make_unique<NumericSetting>(_trans("Input Shape"), 0.0, 0, 50));
@@ -97,7 +99,10 @@ ControlState AnalogStick::GetDeadzoneRadiusAtAngle(double ang) const
 
 ControlState AnalogStick::GetInputRadiusAtAngle(double ang) const
 {
-  return CalculateInputShapeRadiusAtAngle(ang) * numeric_settings[SETTING_INPUT_RADIUS]->GetValue();
+  const ControlState radius =
+      CalculateInputShapeRadiusAtAngle(ang) * numeric_settings[SETTING_INPUT_RADIUS]->GetValue();
+  // Clamp within the -1 to +1 square as input radius may be greater than 1.0:
+  return std::min(radius, SquareStickGate(1).GetRadiusAtAngle(ang));
 }
 
 ControlState AnalogStick::CalculateInputShapeRadiusAtAngle(double ang) const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -9,12 +9,57 @@
 
 namespace ControllerEmu
 {
+// An abstract class representing the plastic shell that limits an analog stick's movement.
+class StickGate
+{
+public:
+  // Angle is in radians and should be non-negative
+  virtual ControlState GetRadiusAtAngle(double ang) const = 0;
+};
+
+// An octagon-shaped stick gate is found on most Nintendo GC/Wii analog sticks.
+class OctagonStickGate : public StickGate
+{
+public:
+  explicit OctagonStickGate(ControlState radius);
+  ControlState GetRadiusAtAngle(double ang) const override;
+
+  static ControlState ComputeRadiusAtAngle(double ang);
+
+  const ControlState m_radius;
+};
+
+// A round-shaped stick gate. Possibly found on 3rd-party accessories.
+class RoundStickGate : public StickGate
+{
+public:
+  explicit RoundStickGate(ControlState radius);
+  ControlState GetRadiusAtAngle(double ang) const override;
+
+private:
+  const ControlState m_radius;
+};
+
+// A square-shaped stick gate. e.g. keyboard input.
+class SquareStickGate : public StickGate
+{
+public:
+  explicit SquareStickGate(ControlState half_width);
+  ControlState GetRadiusAtAngle(double ang) const override;
+
+  static ControlState ComputeRadiusAtAngle(double ang);
+
+private:
+  const ControlState m_half_width;
+};
+
 class AnalogStick : public ControlGroup
 {
 public:
   enum
   {
-    SETTING_RADIUS,
+    SETTING_INPUT_RADIUS,
+    SETTING_INPUT_SHAPE,
     SETTING_DEADZONE,
   };
 
@@ -24,10 +69,28 @@ public:
     ControlState y{};
   };
 
-  // The GameCube controller and Wiimote attachments have a different default radius
-  AnalogStick(const char* name, ControlState default_radius);
-  AnalogStick(const char* name, const char* ui_name, ControlState default_radius);
+  AnalogStick(const char* name, std::unique_ptr<StickGate>&& stick_gate);
+  AnalogStick(const char* name, const char* ui_name, std::unique_ptr<StickGate>&& stick_gate);
 
-  StateData GetState();
+  StateData GetState(bool adjusted = true);
+
+  // Angle is in radians and should be non-negative
+  ControlState GetGateRadiusAtAngle(double ang) const;
+  ControlState GetDeadzoneRadiusAtAngle(double ang) const;
+  ControlState GetInputRadiusAtAngle(double ang) const;
+
+private:
+  ControlState CalculateInputShapeRadiusAtAngle(double ang) const;
+
+  std::unique_ptr<StickGate> m_stick_gate;
 };
+
+// An AnalogStick with an OctagonStickGate
+class OctagonAnalogStick : public AnalogStick
+{
+public:
+  OctagonAnalogStick(const char* name, ControlState gate_radius);
+  OctagonAnalogStick(const char* name, const char* ui_name, ControlState gate_radius);
+};
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -5,54 +5,11 @@
 #pragma once
 
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/StickGate.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {
-// An abstract class representing the plastic shell that limits an analog stick's movement.
-class StickGate
-{
-public:
-  // Angle is in radians and should be non-negative
-  virtual ControlState GetRadiusAtAngle(double ang) const = 0;
-};
-
-// An octagon-shaped stick gate is found on most Nintendo GC/Wii analog sticks.
-class OctagonStickGate : public StickGate
-{
-public:
-  explicit OctagonStickGate(ControlState radius);
-  ControlState GetRadiusAtAngle(double ang) const override;
-
-  static ControlState ComputeRadiusAtAngle(double ang);
-
-  const ControlState m_radius;
-};
-
-// A round-shaped stick gate. Possibly found on 3rd-party accessories.
-class RoundStickGate : public StickGate
-{
-public:
-  explicit RoundStickGate(ControlState radius);
-  ControlState GetRadiusAtAngle(double ang) const override;
-
-private:
-  const ControlState m_radius;
-};
-
-// A square-shaped stick gate. e.g. keyboard input.
-class SquareStickGate : public StickGate
-{
-public:
-  explicit SquareStickGate(ControlState half_width);
-  ControlState GetRadiusAtAngle(double ang) const override;
-
-  static ControlState ComputeRadiusAtAngle(double ang);
-
-private:
-  const ControlState m_half_width;
-};
-
 class AnalogStick : public ControlGroup
 {
 public:

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -1,0 +1,47 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "InputCommon/ControllerEmu/StickGate.h"
+
+#include <cmath>
+
+#include "Common/MathUtil.h"
+
+namespace ControllerEmu
+{
+OctagonStickGate::OctagonStickGate(ControlState radius) : m_radius(radius)
+{
+}
+
+ControlState OctagonStickGate::GetRadiusAtAngle(double ang) const
+{
+  constexpr int sides = 8;
+  constexpr double sum_int_angles = (sides - 2) * MathUtil::PI;
+  constexpr double half_int_angle = sum_int_angles / sides / 2;
+
+  ang = std::fmod(ang, MathUtil::TAU / sides);
+  // Solve ASA triangle using The Law of Sines:
+  return m_radius / std::sin(MathUtil::PI - ang - half_int_angle) * std::sin(half_int_angle);
+}
+
+RoundStickGate::RoundStickGate(ControlState radius) : m_radius(radius)
+{
+}
+
+ControlState RoundStickGate::GetRadiusAtAngle(double) const
+{
+  return m_radius;
+}
+
+SquareStickGate::SquareStickGate(ControlState half_width) : m_half_width(half_width)
+{
+}
+
+ControlState SquareStickGate::GetRadiusAtAngle(double ang) const
+{
+  constexpr double section_ang = MathUtil::TAU / 4;
+  return m_half_width / std::cos(std::fmod(ang + section_ang / 2, section_ang) - section_ang / 2);
+}
+
+}  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -1,0 +1,55 @@
+// Copyright 2018 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "InputCommon/ControlReference/ControlReference.h"
+
+namespace ControllerEmu
+{
+// An abstract class representing the plastic shell that limits an analog stick's movement.
+class StickGate
+{
+public:
+  // Angle is in radians and should be non-negative
+  virtual ControlState GetRadiusAtAngle(double ang) const = 0;
+
+  virtual ~StickGate() = default;
+};
+
+// An octagon-shaped stick gate is found on most Nintendo GC/Wii analog sticks.
+class OctagonStickGate : public StickGate
+{
+public:
+  // Radius of circumscribed circle
+  explicit OctagonStickGate(ControlState radius);
+  ControlState GetRadiusAtAngle(double ang) const override final;
+
+private:
+  const ControlState m_radius;
+};
+
+// A round-shaped stick gate. Possibly found on 3rd-party accessories.
+class RoundStickGate : public StickGate
+{
+public:
+  explicit RoundStickGate(ControlState radius);
+  ControlState GetRadiusAtAngle(double ang) const override final;
+
+private:
+  const ControlState m_radius;
+};
+
+// A square-shaped stick gate. e.g. keyboard input.
+class SquareStickGate : public StickGate
+{
+public:
+  explicit SquareStickGate(ControlState half_width);
+  ControlState GetRadiusAtAngle(double ang) const override final;
+
+private:
+  const ControlState m_half_width;
+};
+
+}  // namespace ControllerEmu

--- a/Source/Core/InputCommon/InputCommon.vcxproj
+++ b/Source/Core/InputCommon/InputCommon.vcxproj
@@ -37,6 +37,7 @@
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
     <ClCompile Include="ControllerEmu\ControllerEmu.cpp" />
+    <ClCompile Include="ControllerEmu\StickGate.cpp" />
     <ClCompile Include="ControllerEmu\Control\Control.cpp" />
     <ClCompile Include="ControllerEmu\Control\Input.cpp" />
     <ClCompile Include="ControllerEmu\Control\Output.cpp" />
@@ -75,6 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ControllerEmu\ControllerEmu.h" />
+    <ClInclude Include="ControllerEmu\StickGate.h" />
     <ClInclude Include="ControllerEmu\Control\Control.h" />
     <ClInclude Include="ControllerEmu\Control\Input.h" />
     <ClInclude Include="ControllerEmu\Control\Output.h" />

--- a/Source/Core/InputCommon/InputCommon.vcxproj.filters
+++ b/Source/Core/InputCommon/InputCommon.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClCompile Include="ControllerEmu\ControllerEmu.cpp">
       <Filter>ControllerEmu</Filter>
     </ClCompile>
+    <ClCompile Include="ControllerEmu\StickGate.cpp">
+      <Filter>ControllerEmu</Filter>
+    </ClCompile>
     <ClCompile Include="ControllerEmu\Control\Control.cpp">
       <Filter>ControllerEmu\Control</Filter>
     </ClCompile>
@@ -117,6 +120,9 @@
     <ClInclude Include="GCPadStatus.h" />
     <ClInclude Include="InputConfig.h" />
     <ClInclude Include="ControllerEmu\ControllerEmu.h">
+      <Filter>ControllerEmu</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\StickGate.h">
       <Filter>ControllerEmu</Filter>
     </ClInclude>
     <ClInclude Include="ControllerEmu\Control\Control.h">


### PR DESCRIPTION
User analog stick input shapes can now be specified and adapted into the octagonal shape and size that the GC/Wii expects.

Rather than clamping values into an octagon, sticks are smoothly adapted based on their angle and distance from neutral.

Users can simply match the dashed line in the mapping indicator to the shape/size of their inputs which are automatically compensated for.

Demonstration: https://i.imgur.com/hNaWSPp.gif

Analog sticks now have three settings:

"Input Radius" specifies the maximum distance from neutral of a controller input.

"Input Shape" specifies the shape of a controller input. (octagon, circle, square, or somewhere in-between)

- E.g. Keyboard input would be square while a typical analog stick would be round.

The "Dead Zone" has about the same behavior as before except that its shape changes with the "Input Shape" which I believe at least makes sense for square and circle inputs.

Users can still make use of their native GameCube controllers:

- Setting the shape to the default, 0, (an octagon) would disable reshaping.
- Setting the radius to 0 (or the default which varies by analog stick) disables radius rescaling (rather than trying to divide by zero).

The default settings perform no reshaping and no rescaling.

The default radius for each analog stick matches the stick's gate radius (the octagon shape). (which results in no rescaling).

- I'd like the default radius to be 100, which compensates for a stick using the full input range. This is going to be the approximate ideal setting in most situations. But I'm worried about android users not being able to reconfigure this if they are using native controllers.

The default shape is 0 (octagon) (no reshaping).

- If the default shape were a square (optimal setting for our keyboard controls) users would be confused why their round analog sticks are being over-compensated for and reduced to less than the ideal octagon. 

The default dead zone is 0.

I've eliminated the old "Radius" setting as it was poorly named and was really just a scalar.
The new settings provide a superset of functionality.

The octagon shape handling code is surprisingly simple and will be easy to extend for reshaping other inputs. (e.g. IR Cursor, Tilt)

I've also eliminated some magic numbers relating to stick ranges while I was there.

This fixes https://bugs.dolphin-emu.org/issues/9739