### PR TITLE
update windows 10 sdk from 10.0.15063.0 to 10.0.17134.0 for imgui

### DIFF
--- a/Externals/imgui/imgui.vcxproj
+++ b/Externals/imgui/imgui.vcxproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4C3B2264-EA73-4A7B-9CFE-65B0FD635EBB}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">


### PR DESCRIPTION
Hi,

Dolphin requires Windows 10 SDK 10.0.17134.0 to be compiled but imgui was using another version.
It's fixed with this PR,
Tested with visual studio pro 2017 (15.9.2) and Windows 10 SDK, version 1803 (10.0.17134.0)

Please note that I already fixed the same error with minizip one month ago (https://github.com/dolphin-emu/dolphin/pull/7595).
Readme is already up-to-date .

-Yohann