### PR TITLE
Jit64: Check downcount at block exit, not block entry

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
@@ -15,9 +15,9 @@ JitBlockCache::JitBlockCache(JitBase& jit) : JitBaseBlockCache{jit}
 void JitBlockCache::WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest)
 {
   u8* location = source.exitPtrs;
-  const u8* address = dest ? dest->checkedEntry : m_jit.GetAsmRoutines()->dispatcher;
+  const u8* address = dest ? dest->checkedEntry : m_jit.GetAsmRoutines()->dispatcher_no_check;
   Gen::XEmitter emit(location);
-  if (*location == 0xE8)
+  if (source.call)
   {
     emit.CALL(address);
   }


### PR DESCRIPTION
Moving downcount checking to occur at exit eases future optimization work.

As a side-effect this results in a 6% reduction in luabench benchmark time.

Optimization is primarily due to reduction in codesize.