### PR TITLE
JitArm64: Fix RC calculation of srawix.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -631,6 +631,9 @@ void JitArm64::srawix(UGeckoInstruction inst)
       ComputeCarry(true);
     else
       ComputeCarry(false);
+
+    if (inst.Rc)
+      ComputeRC0(gpr.GetImm(a));
   }
   else if (amount == 0)
   {
@@ -639,6 +642,9 @@ void JitArm64::srawix(UGeckoInstruction inst)
     ARM64Reg RS = gpr.R(s);
     MOV(RA, RS);
     ComputeCarry(false);
+
+    if (inst.Rc)
+      ComputeRC0(RA);
   }
   else
   {


### PR DESCRIPTION
Seems like it was missed from the early implementation.