### PR TITLE
[RFC/WIP] Register handover optimization

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -443,6 +443,7 @@ void Jit64::WriteExit(u32 destination, bool bl, u32 after)
   if (!m_enable_blr_optimization)
     bl = false;
 
+  fpr.Flush();
   Cleanup();
 
   if (bl)
@@ -983,8 +984,6 @@ u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
   if (code_block.m_broken)
   {
-    gpr.Flush();
-    fpr.Flush();
     WriteExit(nextPC);
   }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -32,7 +32,7 @@ namespace PPCAnalyst
 {
 struct CodeBlock;
 struct CodeOp;
-}
+}  // namespace PPCAnalyst
 
 class Jit64 : public Jitx86Base
 {
@@ -56,8 +56,10 @@ public:
 
   BitSet32 CallerSavedRegistersInUse() const;
   BitSet8 ComputeStaticGQRs(const PPCAnalyst::CodeBlock&) const;
+  BitSet32 ComputeSpeculativeConstants() const;
 
-  void IntializeSpeculativeConstants();
+  void EmitCheckStaticGQRs(BitSet8 static_gqrs);
+  void EmitCheckSpeculativeConstants(BitSet32 specul_gprs);
 
   JitBlockCache* GetBlockCache() override { return &blocks; }
   void Trace();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -82,7 +82,8 @@ public:
   void FakeBLCall(u32 after);
   void WriteExit(u32 destination, bool bl = false, u32 after = 0);
   void JustWriteExit(u32 destination, bool bl, u32 after, JitBlock::LinkData::Regs gpr_state);
-  void WriteFlushLinkDataRegs(Gen::XEmitter& emit, const JitBlock::LinkData::Regs& gpr);
+  void WriteFlushLinkDataReg(Gen::XEmitter& emit, size_t preg, const JitBlock::LinkData::Reg& reg);
+  void WriteFlushLinkDataRegs(Gen::XEmitter& emit, const JitBlock::LinkData::Regs& gpr_state);
   void WriteHandoverAtExit(Gen::XEmitter& emit, const JitBlock::LinkData&, const JitBlock*);
   void WriteExitDestInRSCRATCH(bool bl = false, u32 after = 0);
   void WriteBLRExit();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -81,7 +81,9 @@ public:
 
   void FakeBLCall(u32 after);
   void WriteExit(u32 destination, bool bl = false, u32 after = 0);
-  void JustWriteExit(u32 destination, bool bl, u32 after);
+  void JustWriteExit(u32 destination, bool bl, u32 after, JitBlock::LinkData::Regs gpr_state);
+  void WriteFlushLinkDataRegs(Gen::XEmitter& emit, const JitBlock::LinkData::Regs& gpr);
+  void WriteHandoverAtExit(Gen::XEmitter& emit, const JitBlock::LinkData&, const JitBlock*);
   void WriteExitDestInRSCRATCH(bool bl = false, u32 after = 0);
   void WriteBLRExit();
   void WriteExceptionExit();

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -84,9 +84,6 @@ void Jit64::bx(UGeckoInstruction inst)
     return;
   }
 
-  gpr.Flush();
-  fpr.Flush();
-
   u32 destination;
   if (inst.AA)
     destination = SignExt26(inst.LI << 2);
@@ -98,6 +95,8 @@ void Jit64::bx(UGeckoInstruction inst)
 #endif
   if (destination == js.compilerPC)
   {
+    gpr.Flush();
+    fpr.Flush();
     ABI_PushRegistersAndAdjustStack({}, 0);
     ABI_CallFunction(CoreTiming::Idle);
     ABI_PopRegistersAndAdjustStack({}, 0);
@@ -163,8 +162,6 @@ void Jit64::bcx(UGeckoInstruction inst)
   {
     RCForkGuard gpr_guard = gpr.Fork();
     RCForkGuard fpr_guard = fpr.Fork();
-    gpr.Flush();
-    fpr.Flush();
     WriteExit(destination, inst.LK, js.compilerPC + 4);
   }
 
@@ -175,8 +172,6 @@ void Jit64::bcx(UGeckoInstruction inst)
 
   if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
   {
-    gpr.Flush();
-    fpr.Flush();
     WriteExit(js.compilerPC + 4);
   }
 }
@@ -231,8 +226,6 @@ void Jit64::bcctrx(UGeckoInstruction inst)
 
     if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
     {
-      gpr.Flush();
-      fpr.Flush();
       WriteExit(js.compilerPC + 4);
     }
   }
@@ -292,8 +285,6 @@ void Jit64::bclrx(UGeckoInstruction inst)
 
   if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
   {
-    gpr.Flush();
-    fpr.Flush();
     WriteExit(js.compilerPC + 4);
   }
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -375,6 +375,8 @@ void Jit64::DoMergedBranch()
   }
   else if ((next.OPCD == 19) && (next.SUBOP10 == 528))  // bcctrx
   {
+    gpr.Flush();
+    fpr.Flush();
     if (next.LK)
       MOV(32, PPCSTATE(spr[SPR_LR]), Imm32(nextPC + 4));
     MOV(32, R(RSCRATCH), PPCSTATE(spr[SPR_CTR]));
@@ -383,6 +385,8 @@ void Jit64::DoMergedBranch()
   }
   else if ((next.OPCD == 19) && (next.SUBOP10 == 16))  // bclrx
   {
+    gpr.Flush();
+    fpr.Flush();
     MOV(32, R(RSCRATCH), PPCSTATE(spr[SPR_LR]));
     if (!m_enable_blr_optimization)
       AND(32, R(RSCRATCH), Imm32(0xFFFFFFFC));
@@ -420,10 +424,6 @@ void Jit64::DoMergedBranchCondition()
   {
     RCForkGuard gpr_guard = gpr.Fork();
     RCForkGuard fpr_guard = fpr.Fork();
-
-    gpr.Flush();
-    fpr.Flush();
-
     DoMergedBranch();
   }
 
@@ -431,8 +431,6 @@ void Jit64::DoMergedBranchCondition()
 
   if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
   {
-    gpr.Flush();
-    fpr.Flush();
     WriteExit(nextPC + 4);
   }
 }
@@ -460,14 +458,10 @@ void Jit64::DoMergedBranchImmediate(s64 val)
 
   if (branch)
   {
-    gpr.Flush();
-    fpr.Flush();
     DoMergedBranch();
   }
   else if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
   {
-    gpr.Flush();
-    fpr.Flush();
     WriteExit(nextPC + 4);
   }
 }
@@ -1991,8 +1985,6 @@ void Jit64::twX(UGeckoInstruction inst)
 
   if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
   {
-    gpr.Flush();
-    fpr.Flush();
     WriteExit(js.compilerPC + 4);
   }
 }

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
@@ -297,7 +297,7 @@ public:
   };
 
   void StartTracking() { state = State::Unknown; }
-  State GetState() { return state; }
+  State GetState() const { return state; }
 
   void DiscardRegContentsIfCached()
   {
@@ -311,7 +311,7 @@ public:
       return;
     state = State::Dirtied;
   }
-  void StoreFromRegister([[maybe_unused]] RegCache::FlushMode mode)
+  void StoreFromRegister()
   {
     if (state != State::Unknown)
       return;

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
@@ -305,7 +305,7 @@ public:
       return;
     state = State::Discarded;
   }
-  void BindToRegister([[maybe_unused]] bool doLoad, bool makeDirty)
+  void BindToFreeRegister([[maybe_unused]] bool doLoad, bool makeDirty)
   {
     if (state != State::Unknown || !makeDirty)
       return;

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/CachedReg.h
@@ -282,3 +282,48 @@ private:
   bool kill_mem = false;
   bool revertable = false;
 };
+
+class RegTracker
+{
+public:
+  enum State
+  {
+    Untracked,
+    Unknown,
+    Discarded,
+    Dirtied,
+    Stored,
+    Forked,
+  };
+
+  void StartTracking() { state = State::Unknown; }
+  State GetState() { return state; }
+
+  void DiscardRegContentsIfCached()
+  {
+    if (state != State::Unknown)
+      return;
+    state = State::Discarded;
+  }
+  void BindToRegister([[maybe_unused]] bool doLoad, bool makeDirty)
+  {
+    if (state != State::Unknown || !makeDirty)
+      return;
+    state = State::Dirtied;
+  }
+  void StoreFromRegister([[maybe_unused]] RegCache::FlushMode mode)
+  {
+    if (state != State::Unknown)
+      return;
+    state = State::Stored;
+  }
+  void Fork()
+  {
+    if (state != State::Unknown)
+      return;
+    state = State::Forked;
+  }
+
+private:
+  State state = State::Untracked;
+};

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/PowerPC/Jit64/RegCache/FPURegCache.h"
 
+#include "Common/x64ABI.h"
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
@@ -55,4 +56,9 @@ BitSet32 FPURegCache::CountRegsIn(preg_t preg, u32 lookahead) const
   }
 
   return regs_used;
+}
+
+BitSet32 FPURegCache::GetCallerSaveXRegs() const
+{
+  return (ABI_ALL_CALLER_SAVED & ABI_ALL_FPRS) >> 16;
 }

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.h
@@ -20,4 +20,5 @@ protected:
   const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
   BitSet32 GetRegUtilization() const override;
   BitSet32 CountRegsIn(preg_t preg, u32 lookahead) const override;
+  BitSet32 GetCallerSaveXRegs() const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/PowerPC/Jit64/RegCache/GPRRegCache.h"
 
+#include "Common/x64ABI.h"
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
@@ -72,4 +73,9 @@ BitSet32 GPRRegCache::CountRegsIn(preg_t preg, u32 lookahead) const
   }
 
   return regs_used;
+}
+
+BitSet32 GPRRegCache::GetCallerSaveXRegs() const
+{
+  return ABI_ALL_CALLER_SAVED & ABI_ALL_GPRS;
 }

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/GPRRegCache.h
@@ -21,4 +21,5 @@ protected:
   const Gen::X64Reg* GetAllocationOrder(size_t* count) const override;
   BitSet32 GetRegUtilization() const override;
   BitSet32 CountRegsIn(preg_t preg, u32 lookahead) const override;
+  BitSet32 GetCallerSaveXRegs() const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -464,7 +464,7 @@ void RegCache::PreloadRegisters(BitSet32 to_preload)
     if (NumFreeRegisters() < 2)
       return;
     if (!R(preg).IsImm())
-      BindToRegister(preg, true, false);
+      BindToFreeRegister(preg, true, false);
   }
 }
 
@@ -495,6 +495,19 @@ std::array<RegTracker::State, 32> RegCache::HandoverGetTrackingState() const
   return result;
 }
 
+Gen::X64Reg RegCache::HandoverGetXReg(size_t index)
+{
+  size_t count;
+  const Gen::X64Reg* order = GetAllocationOrder(&count);
+  ASSERT(index < count);
+  return order[index];
+}
+
+void RegCache::HandoverPrelude(size_t index, preg_t preg)
+{
+  BindToRegister(preg, HandoverGetXReg(index), true, false);
+}
+
 void RegCache::FlushX(X64Reg reg)
 {
   ASSERT_MSG(DYNA_REC, reg < m_xregs.size(), "Flushing non-existent reg %i", reg);
@@ -517,31 +530,14 @@ void RegCache::DiscardRegContentsIfCached(preg_t preg)
   }
 }
 
-void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
+void RegCache::BindToFreeRegister(preg_t i, bool doLoad, bool makeDirty)
 {
-  m_trackers[i].BindToRegister(doLoad, makeDirty);
+  m_trackers[i].BindToFreeRegister(doLoad, makeDirty);
 
   if (!m_regs[i].IsBound())
   {
-    X64Reg xr = GetFreeXReg();
-
-    ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsDirty(), "Xreg %i already dirty", xr);
-    ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsLocked(), "GetFreeXReg returned locked register");
-    ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Invalid transaction state");
-
-    m_xregs[xr].SetBoundTo(i, makeDirty || m_regs[i].IsAway());
-
-    if (doLoad)
-    {
-      LoadRegister(i, xr);
-    }
-
-    ASSERT_MSG(DYNA_REC,
-               std::none_of(m_regs.begin(), m_regs.end(),
-                            [xr](const auto& r) { return r.Location().IsSimpleReg(xr); }),
-               "Xreg %i already bound", xr);
-
-    m_regs[i].SetBoundTo(xr);
+    const X64Reg xr = GetFreeXReg();
+    BindToRegister(i, xr, doLoad, makeDirty);
   }
   else
   {
@@ -552,6 +548,28 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
   }
 
   ASSERT_MSG(DYNA_REC, !m_xregs[RX(i)].IsLocked(), "WTF, this reg should have been flushed");
+}
+
+void RegCache::BindToRegister(preg_t i, Gen::X64Reg xr, bool doLoad, bool makeDirty)
+{
+  ASSERT_MSG(DYNA_REC, !m_regs[i].IsBound(), "Register %zu already bound", i);
+  ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsDirty(), "Xreg %i already dirty", xr);
+  ASSERT_MSG(DYNA_REC, !m_xregs[xr].IsLocked(), "GetFreeXReg returned locked register");
+  ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Invalid transaction state");
+
+  m_xregs[xr].SetBoundTo(i, makeDirty || m_regs[i].IsAway());
+
+  if (doLoad)
+  {
+    LoadRegister(i, xr);
+  }
+
+  ASSERT_MSG(DYNA_REC,
+             std::none_of(m_regs.begin(), m_regs.end(),
+                          [xr](const auto& r) { return r.Location().IsSimpleReg(xr); }),
+             "Xreg %i already bound", xr);
+
+  m_regs[i].SetBoundTo(xr);
 }
 
 void RegCache::StoreFromRegister(preg_t i, FlushMode mode)
@@ -726,7 +744,7 @@ void RegCache::Realize(preg_t preg)
   const bool kill_mem = m_constraints[preg].ShouldKillMemory();
 
   const auto do_bind = [&] {
-    BindToRegister(preg, load, dirty);
+    BindToFreeRegister(preg, load, dirty);
     m_constraints[preg].Realized(RCConstraint::RealizedLoc::Bound);
   };
 

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -411,6 +411,19 @@ void RegCache::Flush(BitSet32 pregs)
   }
 }
 
+void RegCache::FlushCallerSave()
+{
+  ASSERT_MSG(
+      DYNA_REC,
+      std::none_of(m_xregs.begin(), m_xregs.end(), [](const auto& x) { return x.IsLocked(); }),
+      "Someone forgot to unlock a X64 reg");
+
+  for (int i : GetCallerSaveXRegs())
+  {
+    FlushX(static_cast<X64Reg>(i));
+  }
+}
+
 void RegCache::Revert()
 {
   ASSERT(IsAllUnlocked());

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -505,7 +505,7 @@ Gen::X64Reg RegCache::HandoverGetXReg(size_t index)
 
 void RegCache::HandoverPrelude(size_t index, preg_t preg)
 {
-  BindToRegister(preg, HandoverGetXReg(index), true, false);
+  BindToRegister(preg, HandoverGetXReg(index), true, true);
 }
 
 JitBlock::LinkData::Regs RegCache::HandoverExitState() const
@@ -540,6 +540,25 @@ JitBlock::LinkData::Regs RegCache::HandoverExitState() const
     }
   }
   return result;
+}
+
+void RegCache::HandoverFullyFlush()
+{
+  for (size_t i = 0; i < 32; i++)
+  {
+    switch (m_regs[i].GetLocationType())
+    {
+    case PPCCachedReg::LocationType::Default:
+    case PPCCachedReg::LocationType::SpeculativeImmediate:
+      break;
+    case PPCCachedReg::LocationType::Immediate:
+      ASSERT(!"We shouldn't have any immediates at this point");
+      break;
+    case PPCCachedReg::LocationType::Bound:
+      StoreRegister(i, GetDefaultLocation(i));
+      break;
+    }
+  }
 }
 
 void RegCache::FlushX(X64Reg reg)

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.cpp
@@ -487,7 +487,7 @@ void RegCache::HandoverStartTracking(BitSet32 pregs)
   }
 }
 
-std::array<RegTracker::State, 32> RegCache::HandoverTrackingState() const
+std::array<RegTracker::State, 32> RegCache::HandoverGetTrackingState() const
 {
   std::array<RegTracker::State, 32> result;
   std::transform(m_trackers.begin(), m_trackers.end(), result.begin(),
@@ -556,7 +556,7 @@ void RegCache::BindToRegister(preg_t i, bool doLoad, bool makeDirty)
 
 void RegCache::StoreFromRegister(preg_t i, FlushMode mode)
 {
-  m_trackers[i].StoreFromRegister(mode);
+  m_trackers[i].StoreFromRegister();
 
   // When a transaction is in progress, allowing the store would overwrite the old value.
   ASSERT_MSG(DYNA_REC, !m_regs[i].IsRevertable(), "Register transaction is in progress!");

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -179,6 +179,10 @@ public:
   void PreloadRegisters(BitSet32 pregs);
   BitSet32 RegistersInUse() const;
 
+  // Functions for register handover optimization use
+  void HandoverStartTracking(BitSet32 pregs);
+  std::array<RegTracker::State, 32> HandoverGetTrackingState() const;
+
 protected:
   friend class RCOpArg;
   friend class RCX64Reg;
@@ -220,5 +224,6 @@ protected:
   std::array<PPCCachedReg, 32> m_regs;
   std::array<X64CachedReg, NUM_XREGS> m_xregs;
   std::array<RCConstraint, 32> m_constraints;
+  std::array<RegTracker, 32> m_trackers;
   Gen::XEmitter* m_emitter = nullptr;
 };

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -170,6 +170,7 @@ public:
 
   RCForkGuard Fork();
   void Flush(BitSet32 pregs = BitSet32::AllTrue(32));
+  void FlushCallerSave();
   void Revert();
   void Commit();
 
@@ -191,6 +192,7 @@ protected:
 
   virtual BitSet32 GetRegUtilization() const = 0;
   virtual BitSet32 CountRegsIn(preg_t preg, u32 lookahead) const = 0;
+  virtual BitSet32 GetCallerSaveXRegs() const = 0;
 
   void FlushX(Gen::X64Reg reg);
   void DiscardRegContentsIfCached(preg_t preg);

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -12,6 +12,7 @@
 
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/Jit64/RegCache/CachedReg.h"
+#include "Core/PowerPC/JitCommon/JitCache.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
 class Jit64;
@@ -184,6 +185,7 @@ public:
   std::array<RegTracker::State, 32> HandoverGetTrackingState() const;
   Gen::X64Reg HandoverGetXReg(size_t index);
   void HandoverPrelude(size_t index, preg_t preg);
+  JitBlock::LinkData::Regs HandoverExitState() const;
 
 protected:
   friend class RCOpArg;

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -182,6 +182,8 @@ public:
   // Functions for register handover optimization use
   void HandoverStartTracking(BitSet32 pregs);
   std::array<RegTracker::State, 32> HandoverGetTrackingState() const;
+  Gen::X64Reg HandoverGetXReg(size_t index);
+  void HandoverPrelude(size_t index, preg_t preg);
 
 protected:
   friend class RCOpArg;
@@ -200,7 +202,8 @@ protected:
 
   void FlushX(Gen::X64Reg reg);
   void DiscardRegContentsIfCached(preg_t preg);
-  void BindToRegister(preg_t preg, bool doLoad = true, bool makeDirty = true);
+  void BindToFreeRegister(preg_t preg, bool doLoad = true, bool makeDirty = true);
+  void BindToRegister(preg_t preg, Gen::X64Reg xr, bool doLoad, bool makeDirty);
   void StoreFromRegister(preg_t preg, FlushMode mode = FlushMode::Full);
 
   Gen::X64Reg GetFreeXReg();

--- a/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/JitRegCache.h
@@ -186,6 +186,7 @@ public:
   Gen::X64Reg HandoverGetXReg(size_t index);
   void HandoverPrelude(size_t index, preg_t preg);
   JitBlock::LinkData::Regs HandoverExitState() const;
+  void HandoverFullyFlush();
 
 protected:
   friend class RCOpArg;

--- a/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/BlockCache.cpp
@@ -17,7 +17,7 @@ void JitBlockCache::WriteLinkBlock(const JitBlock::LinkData& source, const JitBl
   u8* location = source.exitPtrs;
   const u8* address = dest ? dest->checkedEntry : m_jit.GetAsmRoutines()->dispatcher;
   Gen::XEmitter emit(location);
-  if (*location == 0xE8)
+  if (source.call)
   {
     emit.CALL(address);
   }

--- a/Source/Core/Core/PowerPC/Jit64Common/BlockCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/BlockCache.h
@@ -6,14 +6,15 @@
 
 #include "Core/PowerPC/JitCommon/JitCache.h"
 
-class JitBase;
+class Jit64;
 
 class JitBlockCache : public JitBaseBlockCache
 {
 public:
-  explicit JitBlockCache(JitBase& jit);
+  explicit JitBlockCache(Jit64& jit);
 
 private:
+  Jit64& m_jit;
   void WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest) override;
   void WriteDestroyBlock(const JitBlock& block) override;
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -17,6 +17,8 @@
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
+#include "Core/PowerPC/Jit64Common/TrampolineCache.h"
+#include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
 

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -15,6 +15,7 @@
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
+#include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PowerPC.h"
 
 #define QUANTIZED_REGS_TO_SAVE                                                                     \

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -18,26 +18,10 @@
 #include "Common/x64Reg.h"
 #include "Core/HW/Memmap.h"
 #include "Core/MachineContext.h"
+#include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
-// This generates some fairly heavy trampolines, but it doesn't really hurt.
-// Only instructions that access I/O will get these, and there won't be that
-// many of them in a typical program/game.
-bool Jitx86Base::HandleFault(uintptr_t access_address, SContext* ctx)
-{
-  // TODO: do we properly handle off-the-end?
-  const auto base_ptr = reinterpret_cast<uintptr_t>(Memory::physical_base);
-  if (access_address >= base_ptr && access_address < base_ptr + 0x100010000)
-    return BackPatch(static_cast<u32>(access_address - base_ptr), ctx);
-
-  const auto logical_base_ptr = reinterpret_cast<uintptr_t>(Memory::logical_base);
-  if (access_address >= logical_base_ptr && access_address < logical_base_ptr + 0x100010000)
-    return BackPatch(static_cast<u32>(access_address - logical_base_ptr), ctx);
-
-  return false;
-}
-
-bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
+bool Jit64::BackPatch(u32 emAddress, SContext* ctx)
 {
   u8* codePtr = reinterpret_cast<u8*>(ctx->CTX_PC);
 

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
@@ -9,11 +9,9 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/x64Reg.h"
-#include "Core/PowerPC/Jit64Common/BlockCache.h"
-#include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
-#include "Core/PowerPC/Jit64Common/TrampolineCache.h"
-#include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PPCAnalyst.h"
+
+struct JitBlock;
 
 // RSCRATCH and RSCRATCH2 are always scratch registers and can be used without
 // limitation.
@@ -29,18 +27,6 @@ constexpr Gen::X64Reg RMEM = Gen::RBX;
 constexpr Gen::X64Reg RPPCSTATE = Gen::RBP;
 
 constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
-
-class Jitx86Base : public JitBase, public QuantizedMemoryRoutines
-{
-protected:
-  bool BackPatch(u32 emAddress, SContext* ctx);
-  JitBlockCache blocks{*this};
-  TrampolineCache trampolines;
-
-public:
-  JitBlockCache* GetBlockCache() override { return &blocks; }
-  bool HandleFault(uintptr_t access_address, SContext* ctx) override;
-};
 
 void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer& code_buffer, const u8* normalEntry,
                      const JitBlock* b);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -77,6 +77,15 @@ struct JitBlock
   // This tracks the position if this block within the fast block cache.
   // We allow each block to have only one map entry.
   size_t fast_block_map_index;
+
+  struct HandoverInfo
+  {
+    size_t index;
+    s8 preg;
+    bool needs_store;
+    u8* entry;
+  };
+  std::vector<HandoverInfo> handover_info;
 };
 
 typedef void (*CompiledCode)();

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -54,10 +54,28 @@ struct JitBlock
   // This is used to implement block linking.
   struct LinkData
   {
+    // Information about PPC register state for this exit.
+    // This is used to implement register handover.
+    struct Reg
+    {
+      enum class LocationType
+      {
+        PpcState,
+        CleanHostReg,
+        DirtyHostReg,
+        Immediate,
+      };
+
+      LocationType location_type = LocationType::PpcState;
+      size_t location;
+    };
+    using Regs = std::array<Reg, 32>;
+
     u8* exitPtrs;  // to be able to rewrite the exit jump
     u32 exitAddress;
     bool linkStatus;  // is it already linked?
     bool call;
+    Regs gpr_state;
   };
   std::vector<LinkData> linkData;
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -72,6 +72,7 @@ struct JitBlock
     using Regs = std::array<Reg, 32>;
 
     u8* exitPtrs;  // to be able to rewrite the exit jump
+    u8* exitEnd = nullptr;
     u32 exitAddress;
     bool linkStatus;  // is it already linked?
     bool call;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -830,7 +830,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
   // Scan for flag dependencies; assume the next block (or any branch that can leave the block)
   // wants flags, to be safe.
   bool wantsCR0 = true, wantsCR1 = true, wantsFPRF = true, wantsCA = true;
-  BitSet32 fprInUse, gprInUse, gprInReg, fprInXmm;
+  BitSet32 fprInUse, gprInUse, gprInReg, fprInXmm, fprWillBeSet, gprWillBeSet;
   for (int i = block->m_num_instructions - 1; i >= 0; i--)
   {
     CodeOp& op = code[i];
@@ -855,6 +855,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
     op.fprInUse = fprInUse;
     op.gprInReg = gprInReg;
     op.fprInXmm = fprInXmm;
+    op.gprWillBeSet = gprWillBeSet;
+    op.fprWillBeSet = fprWillBeSet;
     // TODO: if there's no possible endblocks or exceptions in between, tell the regcache
     // we can throw away a register if it's going to be overwritten later.
     gprInUse |= op.regsIn;
@@ -868,16 +870,27 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
     gprInUse |= op.regsOut;
     if (op.fregOut >= 0)
       fprInUse[op.fregOut] = true;
+    // These are output by this instruction
+    gprWillBeSet |= op.regsOut;
+    if (op.fregOut >= 0)
+      fprWillBeSet[op.fregOut] = true;
   }
 
   // Forward scan, for flags that need the other direction for calculation.
-  BitSet32 fprIsSingle, fprIsDuplicated, fprIsStoreSafe, gprDefined, gprBlockInputs;
+  BitSet32 fprIsSingle, fprIsDuplicated, fprIsStoreSafe, gprDefined;
   BitSet8 gqrUsed, gqrModified;
+  BitSet32 gprBlockInputsSet, fprBlockInputsSet;
+  std::vector<s8> blockInputs;
   for (u32 i = 0; i < block->m_num_instructions; i++)
   {
     CodeOp& op = code[i];
 
-    gprBlockInputs |= op.regsIn & ~gprDefined;
+    const BitSet32 newBlockInputs = op.regsIn & ~gprDefined;
+    for (auto input : newBlockInputs & ~gprBlockInputsSet)
+    {
+      blockInputs.push_back(static_cast<s8>(input));
+    }
+    gprBlockInputsSet |= newBlockInputs;
     gprDefined |= op.regsOut;
 
     op.fprIsSingle = fprIsSingle;
@@ -885,6 +898,12 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
     op.fprIsStoreSafe = fprIsStoreSafe;
     if (op.fregOut >= 0)
     {
+      if (!fprBlockInputsSet[op.fregOut])
+      {
+        blockInputs.push_back(32 + op.fregOut);
+        fprBlockInputsSet[op.fregOut] = true;
+      }
+
       fprIsSingle[op.fregOut] = false;
       fprIsDuplicated[op.fregOut] = false;
       fprIsStoreSafe[op.fregOut] = false;
@@ -932,8 +951,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
   }
   block->m_gqr_used = gqrUsed;
   block->m_gqr_modified = gqrModified;
-  block->m_gpr_inputs = gprBlockInputs;
+  block->m_inputs = blockInputs;
   return address;
 }
 
-}  // namespace
+}  // namespace PPCAnalyst

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -54,6 +54,10 @@ struct CodeOp  // 16B
   // we do double stores from GPRs, so we don't want to load a PowerPC floating point register into
   // an XMM only to move it again to a GPR afterwards.
   BitSet32 fprInXmm;
+  // which registers will be overwritten by future instructions in this block
+  // (assuming we do not terminate early)
+  BitSet32 fprWillBeSet;
+  BitSet32 gprWillBeSet;
   // whether an fpr is known to be an actual single-precision value at this point in the block.
   BitSet32 fprIsSingle;
   // whether an fpr is known to have identical top and bottom halves (e.g. due to a single
@@ -148,8 +152,10 @@ struct CodeBlock
   // Which GQRs this block modifies, if any.
   BitSet8 m_gqr_modified;
 
-  // Which GPRs this block reads from before defining, if any.
-  BitSet32 m_gpr_inputs;
+  // Which registers this block reads from before defining, if any, in order of them being read.
+  // 0-31: GPRs r0-r31
+  // 32-63: FPRs fp0-fp31
+  std::vector<s8> m_inputs;
 
   // Which memory locations are occupied by this block.
   std::set<u32> m_physical_addresses;
@@ -223,4 +229,4 @@ void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db);
 bool AnalyzeFunction(u32 startAddr, Common::Symbol& func, u32 max_size = 0);
 bool ReanalyzeFunction(u32 start_addr, Common::Symbol& func, u32 max_size = 0);
 
-}  // namespace
+}  // namespace PPCAnalyst


### PR DESCRIPTION
a.k.a. Poor Man's Macroblocks

The idea behind this optimization is that most of the overhead of tiny blocks is in regcache loads and stores, so why not try to eliminate these?

We do this by:

1. Finding out which registers block inputs, and loading them up at the beginning of the block (`EmitHandoverPrelude`), so that they'd be easy to skip over should want want to skip their loading. Record this information in `JitBlock::handover_info` for later use.

2. Track whether or not block inputs will be written to the regcache in this block, to determine whether or not future block linkees need to perform a store prior to linking to us (`RegTracker`).

3. Leave as many values bound to registers as possible at the end of blocks so we have lots of opportunities to apply this optimization (`gprWillBeSet`).

4. At block link time, reconcile the above information (`WriteHandoverAtExit`).

The current implementation shows the basic idea but needs cleanup.

TODO:

* [ ] Investigate why having [this line](https://github.com/dolphin-emu/dolphin/compare/master...MerryMage:experiments2#diff-d0dc671686b67698cb3a54b1d73cfd76R508) as `BindToRegister(preg, HandoverGetXReg(index), true, false);` instead breaks things.