### PR TITLE
PowerPC: Thread state through the address helpers

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -291,12 +291,6 @@ private:
   // flag helper
   static void Helper_UpdateCR0(u32 value);
 
-  // address helper
-  static u32 Helper_Get_EA(const UGeckoInstruction inst);
-  static u32 Helper_Get_EA_U(const UGeckoInstruction inst);
-  static u32 Helper_Get_EA_X(const UGeckoInstruction inst);
-  static u32 Helper_Get_EA_UX(const UGeckoInstruction inst);
-
   // paired helper
   static void Helper_Dequantize(u32 addr, u32 instI, u32 instRD, u32 instW);
   static void Helper_Quantize(u32 addr, u32 instI, u32 instRS, u32 instW);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -19,29 +19,29 @@
 bool Interpreter::m_reserve;
 u32 Interpreter::m_reserve_address;
 
-u32 Interpreter::Helper_Get_EA(const UGeckoInstruction inst)
+static u32 Helper_Get_EA(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return inst.RA ? (rGPR[inst.RA] + inst.SIMM_16) : (u32)inst.SIMM_16;
+  return inst.RA ? (ppcs.gpr[inst.RA] + inst.SIMM_16) : (u32)inst.SIMM_16;
 }
 
-u32 Interpreter::Helper_Get_EA_U(const UGeckoInstruction inst)
+static u32 Helper_Get_EA_U(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return (rGPR[inst.RA] + inst.SIMM_16);
+  return (ppcs.gpr[inst.RA] + inst.SIMM_16);
 }
 
-u32 Interpreter::Helper_Get_EA_X(const UGeckoInstruction inst)
+static u32 Helper_Get_EA_X(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return inst.RA ? (rGPR[inst.RA] + rGPR[inst.RB]) : rGPR[inst.RB];
+  return inst.RA ? (ppcs.gpr[inst.RA] + ppcs.gpr[inst.RB]) : ppcs.gpr[inst.RB];
 }
 
-u32 Interpreter::Helper_Get_EA_UX(const UGeckoInstruction inst)
+static u32 Helper_Get_EA_UX(const PowerPC::PowerPCState& ppcs, const UGeckoInstruction inst)
 {
-  return (rGPR[inst.RA] + rGPR[inst.RB]);
+  return (ppcs.gpr[inst.RA] + ppcs.gpr[inst.RB]);
 }
 
 void Interpreter::lbz(UGeckoInstruction inst)
 {
-  const u32 temp = PowerPC::Read_U8(Helper_Get_EA(inst));
+  const u32 temp = PowerPC::Read_U8(Helper_Get_EA(PowerPC::ppcState, inst));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
     rGPR[inst.RD] = temp;
@@ -49,7 +49,7 @@ void Interpreter::lbz(UGeckoInstruction inst)
 
 void Interpreter::lbzu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U8(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -61,7 +61,7 @@ void Interpreter::lbzu(UGeckoInstruction inst)
 
 void Interpreter::lfd(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA(inst);
+  const u32 address = Helper_Get_EA(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -77,7 +77,7 @@ void Interpreter::lfd(UGeckoInstruction inst)
 
 void Interpreter::lfdu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -96,7 +96,7 @@ void Interpreter::lfdu(UGeckoInstruction inst)
 
 void Interpreter::lfdux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -115,7 +115,7 @@ void Interpreter::lfdux(UGeckoInstruction inst)
 
 void Interpreter::lfdx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -131,7 +131,7 @@ void Interpreter::lfdx(UGeckoInstruction inst)
 
 void Interpreter::lfs(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA(inst);
+  const u32 address = Helper_Get_EA(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -150,7 +150,7 @@ void Interpreter::lfs(UGeckoInstruction inst)
 
 void Interpreter::lfsu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -170,7 +170,7 @@ void Interpreter::lfsu(UGeckoInstruction inst)
 
 void Interpreter::lfsux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -190,7 +190,7 @@ void Interpreter::lfsux(UGeckoInstruction inst)
 
 void Interpreter::lfsx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -209,7 +209,7 @@ void Interpreter::lfsx(UGeckoInstruction inst)
 
 void Interpreter::lha(UGeckoInstruction inst)
 {
-  const u32 temp = (u32)(s32)(s16)PowerPC::Read_U16(Helper_Get_EA(inst));
+  const u32 temp = (u32)(s32)(s16)PowerPC::Read_U16(Helper_Get_EA(PowerPC::ppcState, inst));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -219,7 +219,7 @@ void Interpreter::lha(UGeckoInstruction inst)
 
 void Interpreter::lhau(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
   const u32 temp = (u32)(s32)(s16)PowerPC::Read_U16(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -231,7 +231,7 @@ void Interpreter::lhau(UGeckoInstruction inst)
 
 void Interpreter::lhz(UGeckoInstruction inst)
 {
-  const u32 temp = PowerPC::Read_U16(Helper_Get_EA(inst));
+  const u32 temp = PowerPC::Read_U16(Helper_Get_EA(PowerPC::ppcState, inst));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -241,7 +241,7 @@ void Interpreter::lhz(UGeckoInstruction inst)
 
 void Interpreter::lhzu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U16(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -254,7 +254,7 @@ void Interpreter::lhzu(UGeckoInstruction inst)
 // FIXME: lmw should do a total rollback if a DSI occurs
 void Interpreter::lmw(UGeckoInstruction inst)
 {
-  u32 address = Helper_Get_EA(inst);
+  u32 address = Helper_Get_EA(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0 || MSR.LE)
   {
@@ -282,7 +282,7 @@ void Interpreter::lmw(UGeckoInstruction inst)
 // FIXME: stmw should do a total rollback if a DSI occurs
 void Interpreter::stmw(UGeckoInstruction inst)
 {
-  u32 address = Helper_Get_EA(inst);
+  u32 address = Helper_Get_EA(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0 || MSR.LE)
   {
@@ -304,7 +304,7 @@ void Interpreter::stmw(UGeckoInstruction inst)
 
 void Interpreter::lwz(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA(inst);
+  const u32 address = Helper_Get_EA(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U32(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -315,7 +315,7 @@ void Interpreter::lwz(UGeckoInstruction inst)
 
 void Interpreter::lwzu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U32(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -327,12 +327,12 @@ void Interpreter::lwzu(UGeckoInstruction inst)
 
 void Interpreter::stb(UGeckoInstruction inst)
 {
-  PowerPC::Write_U8((u8)rGPR[inst.RS], Helper_Get_EA(inst));
+  PowerPC::Write_U8((u8)rGPR[inst.RS], Helper_Get_EA(PowerPC::ppcState, inst));
 }
 
 void Interpreter::stbu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
   PowerPC::Write_U8((u8)rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -343,7 +343,7 @@ void Interpreter::stbu(UGeckoInstruction inst)
 
 void Interpreter::stfd(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA(inst);
+  const u32 address = Helper_Get_EA(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -356,7 +356,7 @@ void Interpreter::stfd(UGeckoInstruction inst)
 
 void Interpreter::stfdu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -373,7 +373,7 @@ void Interpreter::stfdu(UGeckoInstruction inst)
 
 void Interpreter::stfs(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA(inst);
+  const u32 address = Helper_Get_EA(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -386,7 +386,7 @@ void Interpreter::stfs(UGeckoInstruction inst)
 
 void Interpreter::stfsu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -403,12 +403,12 @@ void Interpreter::stfsu(UGeckoInstruction inst)
 
 void Interpreter::sth(UGeckoInstruction inst)
 {
-  PowerPC::Write_U16((u16)rGPR[inst.RS], Helper_Get_EA(inst));
+  PowerPC::Write_U16((u16)rGPR[inst.RS], Helper_Get_EA(PowerPC::ppcState, inst));
 }
 
 void Interpreter::sthu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
   PowerPC::Write_U16((u16)rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -419,12 +419,12 @@ void Interpreter::sthu(UGeckoInstruction inst)
 
 void Interpreter::stw(UGeckoInstruction inst)
 {
-  PowerPC::Write_U32(rGPR[inst.RS], Helper_Get_EA(inst));
+  PowerPC::Write_U32(rGPR[inst.RS], Helper_Get_EA(PowerPC::ppcState, inst));
 }
 
 void Interpreter::stwu(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_U(inst);
+  const u32 address = Helper_Get_EA_U(PowerPC::ppcState, inst);
 
   PowerPC::Write_U32(rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -446,7 +446,7 @@ void Interpreter::dcbf(UGeckoInstruction inst)
   // Invalidate the JIT cache here as a heuristic to compensate for
   // the lack of precise L1 icache emulation in the JIT. (Portable software
   // should use icbi consistently, but games aren't portable.)
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
   JitInterface::InvalidateICache(address & ~0x1f, 32, false);
 }
 
@@ -464,7 +464,7 @@ void Interpreter::dcbi(UGeckoInstruction inst)
   // Invalidate the JIT cache here as a heuristic to compensate for
   // the lack of precise L1 icache emulation in the JIT. (Portable software
   // should use icbi consistently, but games aren't portable.)
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
   JitInterface::InvalidateICache(address & ~0x1f, 32, false);
 }
 
@@ -476,7 +476,7 @@ void Interpreter::dcbst(UGeckoInstruction inst)
   // Invalidate the JIT cache here as a heuristic to compensate for
   // the lack of precise L1 icache emulation in the JIT. (Portable software
   // should use icbi consistently, but games aren't portable.)
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
   JitInterface::InvalidateICache(address & ~0x1f, 32, false);
 }
 
@@ -498,7 +498,7 @@ void Interpreter::dcbtst(UGeckoInstruction inst)
 
 void Interpreter::dcbz(UGeckoInstruction inst)
 {
-  const u32 dcbz_addr = Helper_Get_EA_X(inst);
+  const u32 dcbz_addr = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if (!HID0.DCE)
   {
@@ -522,7 +522,7 @@ void Interpreter::dcbz_l(UGeckoInstruction inst)
     return;
   }
 
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if (!HID0.DCE)
   {
@@ -538,7 +538,7 @@ void Interpreter::dcbz_l(UGeckoInstruction inst)
 // We just do it instantly from ppc...and hey, it works! :D
 void Interpreter::eciwx(UGeckoInstruction inst)
 {
-  const u32 EA = Helper_Get_EA_X(inst);
+  const u32 EA = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
   {
@@ -557,7 +557,7 @@ void Interpreter::eciwx(UGeckoInstruction inst)
 
 void Interpreter::ecowx(UGeckoInstruction inst)
 {
-  const u32 EA = Helper_Get_EA_X(inst);
+  const u32 EA = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
   {
@@ -585,13 +585,13 @@ void Interpreter::eieio(UGeckoInstruction inst)
 void Interpreter::icbi(UGeckoInstruction inst)
 {
   // TODO: Raise DSI if translation fails (except for direct-store segments).
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
   PowerPC::ppcState.iCache.Invalidate(address);
 }
 
 void Interpreter::lbzux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U8(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -603,7 +603,7 @@ void Interpreter::lbzux(UGeckoInstruction inst)
 
 void Interpreter::lbzx(UGeckoInstruction inst)
 {
-  const u32 temp = PowerPC::Read_U8(Helper_Get_EA_X(inst));
+  const u32 temp = PowerPC::Read_U8(Helper_Get_EA_X(PowerPC::ppcState, inst));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -613,7 +613,7 @@ void Interpreter::lbzx(UGeckoInstruction inst)
 
 void Interpreter::lhaux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
   const s32 temp = (s32)(s16)PowerPC::Read_U16(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -625,7 +625,7 @@ void Interpreter::lhaux(UGeckoInstruction inst)
 
 void Interpreter::lhax(UGeckoInstruction inst)
 {
-  const s32 temp = (s32)(s16)PowerPC::Read_U16(Helper_Get_EA_X(inst));
+  const s32 temp = (s32)(s16)PowerPC::Read_U16(Helper_Get_EA_X(PowerPC::ppcState, inst));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -635,7 +635,7 @@ void Interpreter::lhax(UGeckoInstruction inst)
 
 void Interpreter::lhbrx(UGeckoInstruction inst)
 {
-  const u32 temp = Common::swap16(PowerPC::Read_U16(Helper_Get_EA_X(inst)));
+  const u32 temp = Common::swap16(PowerPC::Read_U16(Helper_Get_EA_X(PowerPC::ppcState, inst)));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -645,7 +645,7 @@ void Interpreter::lhbrx(UGeckoInstruction inst)
 
 void Interpreter::lhzux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U16(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -657,7 +657,7 @@ void Interpreter::lhzux(UGeckoInstruction inst)
 
 void Interpreter::lhzx(UGeckoInstruction inst)
 {
-  const u32 temp = PowerPC::Read_U16(Helper_Get_EA_X(inst));
+  const u32 temp = PowerPC::Read_U16(Helper_Get_EA_X(PowerPC::ppcState, inst));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -668,7 +668,7 @@ void Interpreter::lhzx(UGeckoInstruction inst)
 // FIXME: Should rollback if a DSI occurs
 void Interpreter::lswx(UGeckoInstruction inst)
 {
-  u32 EA = Helper_Get_EA_X(inst);
+  u32 EA = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if (MSR.LE)
   {
@@ -700,7 +700,7 @@ void Interpreter::lswx(UGeckoInstruction inst)
 
 void Interpreter::lwbrx(UGeckoInstruction inst)
 {
-  const u32 temp = Common::swap32(PowerPC::Read_U32(Helper_Get_EA_X(inst)));
+  const u32 temp = Common::swap32(PowerPC::Read_U32(Helper_Get_EA_X(PowerPC::ppcState, inst)));
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
   {
@@ -710,7 +710,7 @@ void Interpreter::lwbrx(UGeckoInstruction inst)
 
 void Interpreter::lwzux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U32(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -722,7 +722,7 @@ void Interpreter::lwzux(UGeckoInstruction inst)
 
 void Interpreter::lwzx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
   const u32 temp = PowerPC::Read_U32(address);
 
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -733,7 +733,7 @@ void Interpreter::lwzx(UGeckoInstruction inst)
 
 void Interpreter::stbux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
   PowerPC::Write_U8((u8)rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -744,12 +744,12 @@ void Interpreter::stbux(UGeckoInstruction inst)
 
 void Interpreter::stbx(UGeckoInstruction inst)
 {
-  PowerPC::Write_U8((u8)rGPR[inst.RS], Helper_Get_EA_X(inst));
+  PowerPC::Write_U8((u8)rGPR[inst.RS], Helper_Get_EA_X(PowerPC::ppcState, inst));
 }
 
 void Interpreter::stfdux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -766,7 +766,7 @@ void Interpreter::stfdux(UGeckoInstruction inst)
 
 void Interpreter::stfdx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -780,7 +780,7 @@ void Interpreter::stfdx(UGeckoInstruction inst)
 // Stores Floating points into Integers indeXed
 void Interpreter::stfiwx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -793,7 +793,7 @@ void Interpreter::stfiwx(UGeckoInstruction inst)
 
 void Interpreter::stfsux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -810,7 +810,7 @@ void Interpreter::stfsux(UGeckoInstruction inst)
 
 void Interpreter::stfsx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -823,12 +823,12 @@ void Interpreter::stfsx(UGeckoInstruction inst)
 
 void Interpreter::sthbrx(UGeckoInstruction inst)
 {
-  PowerPC::Write_U16(Common::swap16((u16)rGPR[inst.RS]), Helper_Get_EA_X(inst));
+  PowerPC::Write_U16(Common::swap16((u16)rGPR[inst.RS]), Helper_Get_EA_X(PowerPC::ppcState, inst));
 }
 
 void Interpreter::sthux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
   PowerPC::Write_U16((u16)rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -839,7 +839,7 @@ void Interpreter::sthux(UGeckoInstruction inst)
 
 void Interpreter::sthx(UGeckoInstruction inst)
 {
-  PowerPC::Write_U16((u16)rGPR[inst.RS], Helper_Get_EA_X(inst));
+  PowerPC::Write_U16((u16)rGPR[inst.RS], Helper_Get_EA_X(PowerPC::ppcState, inst));
 }
 
 // lswi - bizarro string instruction
@@ -941,7 +941,7 @@ void Interpreter::stswi(UGeckoInstruction inst)
 // TODO: is this right? is it DSI interruptible?
 void Interpreter::stswx(UGeckoInstruction inst)
 {
-  u32 EA = Helper_Get_EA_X(inst);
+  u32 EA = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if (MSR.LE)
   {
@@ -970,7 +970,7 @@ void Interpreter::stswx(UGeckoInstruction inst)
 
 void Interpreter::stwbrx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   PowerPC::Write_U32(Common::swap32(rGPR[inst.RS]), address);
 }
@@ -980,7 +980,7 @@ void Interpreter::stwbrx(UGeckoInstruction inst)
 
 void Interpreter::lwarx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -1001,7 +1001,7 @@ void Interpreter::lwarx(UGeckoInstruction inst)
 // Stores Word Conditional indeXed
 void Interpreter::stwcxd(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   if ((address & 0b11) != 0)
   {
@@ -1028,7 +1028,7 @@ void Interpreter::stwcxd(UGeckoInstruction inst)
 
 void Interpreter::stwux(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_UX(inst);
+  const u32 address = Helper_Get_EA_UX(PowerPC::ppcState, inst);
 
   PowerPC::Write_U32(rGPR[inst.RS], address);
   if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
@@ -1039,7 +1039,7 @@ void Interpreter::stwux(UGeckoInstruction inst)
 
 void Interpreter::stwx(UGeckoInstruction inst)
 {
-  const u32 address = Helper_Get_EA_X(inst);
+  const u32 address = Helper_Get_EA_X(PowerPC::ppcState, inst);
 
   PowerPC::Write_U32(rGPR[inst.RS], address);
 }


### PR DESCRIPTION
More prep work for (eventually) eliminating the ppcState global variable.