### PR TITLE
ControllerInterface: Output/Rumble fixes

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -227,12 +227,10 @@ static void ResetRumble()
 #if defined(__LIBUSB__)
   GCAdapter::ResetRumble();
 #endif
-#if defined(CIFACE_USE_XINPUT) || defined(CIFACE_USE_DINPUT)
   if (!Pad::IsInitialized())
     return;
   for (int i = 0; i < 4; ++i)
     Pad::ResetRumble(i);
-#endif
 }
 
 // Called from GUI thread

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -12,6 +12,10 @@
 
 namespace MappingCommon
 {
+
+constexpr int INPUT_DETECT_TIME = 3000;
+constexpr int OUTPUT_DETECT_TIME = 2000;
+
 QString GetExpressionForControl(const QString& control_name,
                                 const ciface::Core::DeviceQualifier& control_device,
                                 const ciface::Core::DeviceQualifier& default_device, Quote quote)
@@ -41,7 +45,9 @@ QString GetExpressionForControl(const QString& control_name,
 QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
                          const ciface::Core::DeviceQualifier& default_device, Quote quote)
 {
-  ciface::Core::Device::Control* const ctrl = reference->Detect(5000, device);
+  const int ms = reference->IsInput() ? INPUT_DETECT_TIME : OUTPUT_DETECT_TIME;
+
+  ciface::Core::Device::Control* const ctrl = reference->Detect(ms, device);
 
   if (ctrl)
   {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -12,7 +12,6 @@
 
 namespace MappingCommon
 {
-
 constexpr int INPUT_DETECT_TIME = 3000;
 constexpr int OUTPUT_DETECT_TIME = 2000;
 

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -340,11 +340,7 @@ public:
   }
 
   ControlState GetValue() const override { return GetActiveChild()->GetValue(); }
-  void SetValue(ControlState value) override
-  {
-    m_lhs->SetValue(GetActiveChild() == m_lhs ? value : 0.0);
-    m_rhs->SetValue(GetActiveChild() == m_rhs ? value : 0.0);
-  }
+  void SetValue(ControlState value) override { GetActiveChild()->SetValue(value); }
 
   int CountNumControls() const override { return GetActiveChild()->CountNumControls(); }
   operator std::string() const override
@@ -549,5 +545,5 @@ std::pair<ParseStatus, std::unique_ptr<Expression>> ParseExpression(const std::s
                                                             std::move(complex_result.expr));
   return std::make_pair(complex_result.status, std::move(combined_expr));
 }
-}
-}
+}  // namespace ExpressionParser
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <sstream>
 
+#include "Common/Logging/Log.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/DInput/DInput.h"
 #include "InputCommon/ControllerInterface/DInput/DInputJoystick.h"
@@ -40,8 +41,10 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
         if (FAILED(js_device->SetCooperativeLevel(GetAncestor(hwnd, GA_ROOT),
                                                   DISCL_BACKGROUND | DISCL_EXCLUSIVE)))
         {
-          // PanicAlert("SetCooperativeLevel(DISCL_EXCLUSIVE) failed!");
-          // fall back to non-exclusive mode, with no rumble
+          WARN_LOG(
+              PAD,
+              "DInput: Failed to acquire device exclusively. Force feedback will be unavailable.");
+          // Fall back to non-exclusive mode, with no rumble
           if (FAILED(
                   js_device->SetCooperativeLevel(nullptr, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE)))
           {
@@ -136,16 +139,21 @@ Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVI
     }
   }
 
-  // force feedback
+  // Force feedback:
   std::list<DIDEVICEOBJECTINSTANCE> objects;
   if (SUCCEEDED(m_device->EnumObjects(DIEnumDeviceObjectsCallback, (LPVOID)&objects, DIDFT_AXIS)))
   {
-    InitForceFeedback(m_device, (int)objects.size());
+    const int num_ff_axes =
+        std::count_if(std::begin(objects), std::end(objects), [](DIDEVICEOBJECTINSTANCE& pdidoi) {
+          return pdidoi.dwFlags && DIDOI_FFACTUATOR;
+        });
+    InitForceFeedback(m_device, num_ff_axes);
   }
 
-  ZeroMemory(&m_state_in, sizeof(m_state_in));
-  // set hats to center
-  memset(m_state_in.rgdwPOV, 0xFF, sizeof(m_state_in.rgdwPOV));
+  // Zero inputs:
+  m_state_in = {};
+  // Set hats to center:
+  std::fill(std::begin(m_state_in.rgdwPOV), std::end(m_state_in.rgdwPOV), 0xFF);
 }
 
 Joystick::~Joystick()

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -150,6 +150,8 @@ Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVI
 
 Joystick::~Joystick()
 {
+  DeInitForceFeedback();
+
   m_device->Unacquire();
   m_device->Release();
 }
@@ -265,5 +267,5 @@ ControlState Joystick::Hat::GetState() const
 
   return (abs((int)(m_hat / 4500 - m_direction * 2 + 8) % 8 - 4) > 2);
 }
-}
-}
+}  // namespace DInput
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
@@ -3,23 +3,25 @@
 // Refer to the license.txt file included.
 
 #include "InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h"
+
 #include <algorithm>
 #include <string>
+
 #include "Common/Thread.h"
 
 namespace ciface
 {
 namespace ForceFeedback
 {
-// template instantiation
-template class ForceFeedbackDevice::Force<DICONSTANTFORCE>;
-template class ForceFeedbackDevice::Force<DIRAMPFORCE>;
-template class ForceFeedbackDevice::Force<DIPERIODIC>;
+// Template instantiation:
+template class ForceFeedbackDevice::TypedForce<DICONSTANTFORCE>;
+template class ForceFeedbackDevice::TypedForce<DIRAMPFORCE>;
+template class ForceFeedbackDevice::TypedForce<DIPERIODIC>;
 
 struct ForceType
 {
   GUID guid;
-  const std::string name;
+  const char* name;
 };
 
 static const ForceType force_type_names[] = {
@@ -36,6 +38,42 @@ static const ForceType force_type_names[] = {
     //{GUID_Friction, "Friction"},
 };
 
+void ForceFeedbackDevice::DeInitForceFeedback()
+{
+  if (!m_run_thread.TestAndClear())
+    return;
+
+  SignalUpdateThread();
+  m_update_thread.join();
+}
+
+void ForceFeedbackDevice::ThreadFunc()
+{
+  Common::SetCurrentThreadName("ForceFeedback update thread");
+
+  while (m_run_thread.IsSet())
+  {
+    m_update_event.Wait();
+
+    for (auto output : Outputs())
+    {
+      auto& force = *static_cast<Force*>(output);
+      force.UpdateOutput();
+    }
+  }
+
+  for (auto output : Outputs())
+  {
+    auto& force = *static_cast<Force*>(output);
+    force.Release();
+  }
+}
+
+void ForceFeedbackDevice::SignalUpdateThread()
+{
+  m_update_event.Set();
+}
+
 bool ForceFeedbackDevice::InitForceFeedback(const LPDIRECTINPUTDEVICE8 device, int cAxes)
 {
   if (cAxes == 0)
@@ -43,14 +81,14 @@ bool ForceFeedbackDevice::InitForceFeedback(const LPDIRECTINPUTDEVICE8 device, i
 
   // TODO: check for DIDC_FORCEFEEDBACK in devcaps?
 
-  // temporary
+  // Temporary for creating the effect:
   DWORD rgdwAxes[2] = {DIJOFS_X, DIJOFS_Y};
   LONG rglDirection[2] = {-200, 0};
 
-  DIEFFECT eff;
-  memset(&eff, 0, sizeof(eff));
+  DIEFFECT eff{};
   eff.dwSize = sizeof(DIEFFECT);
   eff.dwFlags = DIEFF_CARTESIAN | DIEFF_OBJECTOFFSETS;
+  // Infinite seems to work just fine:
   eff.dwDuration = INFINITE;  // (4 * DI_SECONDS)
   eff.dwSamplePeriod = 0;
   eff.dwGain = DI_FFNOMINALMAX;
@@ -60,19 +98,19 @@ bool ForceFeedbackDevice::InitForceFeedback(const LPDIRECTINPUTDEVICE8 device, i
   eff.rgdwAxes = rgdwAxes;
   eff.rglDirection = rglDirection;
 
-  // initialize parameters
-  DICONSTANTFORCE diCF = {-10000};
+  // Initialize parameters.
+  DICONSTANTFORCE diCF{};
   diCF.lMagnitude = DI_FFNOMINALMAX;
-  DIRAMPFORCE diRF = {0};
-  DIPERIODIC diPE = {0};
+  DIRAMPFORCE diRF{};
+  DIPERIODIC diPE{};
 
-  // doesn't seem needed
+  // This doesn't seem needed:
   // DIENVELOPE env;
   // eff.lpEnvelope = &env;
   // ZeroMemory(&env, sizeof(env));
   // env.dwSize = sizeof(env);
 
-  for (const ForceType& f : force_type_names)
+  for (auto& f : force_type_names)
   {
     if (f.guid == GUID_ConstantForce)
     {
@@ -86,7 +124,7 @@ bool ForceFeedbackDevice::InitForceFeedback(const LPDIRECTINPUTDEVICE8 device, i
     }
     else
     {
-      // all other forces need periodic parameters
+      // All other forces need periodic parameters:
       eff.cbTypeSpecificParams = sizeof(DIPERIODIC);
       eff.lpvTypeSpecificParams = &diPE;
     }
@@ -95,15 +133,15 @@ bool ForceFeedbackDevice::InitForceFeedback(const LPDIRECTINPUTDEVICE8 device, i
     if (SUCCEEDED(device->CreateEffect(f.guid, &eff, &pEffect, nullptr)))
     {
       if (f.guid == GUID_ConstantForce)
-        AddOutput(new ForceConstant(f.name, pEffect));
+        AddOutput(new ForceConstant(this, f.name, pEffect));
       else if (f.guid == GUID_RampForce)
-        AddOutput(new ForceRamp(f.name, pEffect));
+        AddOutput(new ForceRamp(this, f.name, pEffect));
       else
-        AddOutput(new ForcePeriodic(f.name, pEffect));
+        AddOutput(new ForcePeriodic(this, f.name, pEffect));
     }
   }
 
-  // disable autocentering
+  // Disable autocentering:
   if (Outputs().size())
   {
     DIPROPDWORD dipdw;
@@ -113,95 +151,114 @@ bool ForceFeedbackDevice::InitForceFeedback(const LPDIRECTINPUTDEVICE8 device, i
     dipdw.diph.dwHow = DIPH_DEVICE;
     dipdw.dwData = DIPROPAUTOCENTER_OFF;
     device->SetProperty(DIPROP_AUTOCENTER, &dipdw.diph);
+
+    m_run_thread.Set();
+    m_update_thread = std::thread(&ForceFeedbackDevice::ThreadFunc, this);
   }
 
   return true;
 }
 
 template <typename P>
-ForceFeedbackDevice::Force<P>::~Force()
+void ForceFeedbackDevice::TypedForce<P>::PlayEffect()
 {
-  m_iface->Stop();
-  m_iface->Unload();
-  m_iface->Release();
-}
-
-template <typename P>
-void ForceFeedbackDevice::Force<P>::Update()
-{
-  DIEFFECT eff = {};
+  DIEFFECT eff{};
   eff.dwSize = sizeof(DIEFFECT);
   eff.dwFlags = DIEFF_CARTESIAN | DIEFF_OBJECTOFFSETS;
 
-  eff.cbTypeSpecificParams = sizeof(P);
-  eff.lpvTypeSpecificParams = &params;
-
-  // set params and start effect
-  m_iface->SetParameters(&eff, DIEP_TYPESPECIFICPARAMS | DIEP_START);
+  eff.cbTypeSpecificParams = sizeof(m_params);
+  eff.lpvTypeSpecificParams = &m_params;
+  m_effect->SetParameters(&eff, DIEP_TYPESPECIFICPARAMS | DIEP_START);
 }
 
 template <typename P>
-void ForceFeedbackDevice::Force<P>::Stop()
+void ForceFeedbackDevice::TypedForce<P>::StopEffect()
 {
-  m_iface->Stop();
+  m_effect->Stop();
 }
 
 template <>
-void ForceFeedbackDevice::ForceConstant::SetState(const ControlState state)
+bool ForceFeedbackDevice::ForceConstant::UpdateParameters(int magnitude)
 {
-  const LONG new_val = LONG(10000 * state);
+  const auto old_magnitude = m_params.lMagnitude;
 
-  if (params.lMagnitude == new_val)
-    return;
+  m_params.lMagnitude = magnitude;
 
-  params.lMagnitude = new_val;
-  if (new_val)
-    Update();
-  else
-    Stop();
+  return old_magnitude != m_params.lMagnitude;
 }
 
 template <>
-void ForceFeedbackDevice::ForceRamp::SetState(const ControlState state)
+bool ForceFeedbackDevice::ForceRamp::UpdateParameters(int magnitude)
 {
-  const LONG new_val = LONG(10000 * state);
+  const auto old_magnitude = m_params.lStart;
 
-  if (params.lStart == new_val)
-    return;
+  m_params.lStart = m_params.lEnd = magnitude;
 
-  params.lStart = params.lEnd = new_val;
-  if (new_val)
-    Update();
-  else
-    Stop();
+  return old_magnitude != m_params.lStart;
 }
 
 template <>
-void ForceFeedbackDevice::ForcePeriodic::SetState(const ControlState state)
+bool ForceFeedbackDevice::ForcePeriodic::UpdateParameters(int magnitude)
 {
-  const DWORD new_val = DWORD(10000 * state);
+  const auto old_magnitude = m_params.dwMagnitude;
 
-  if (params.dwMagnitude == new_val)
-    return;
+  m_params.dwMagnitude = magnitude;
+  // Zero is working fine for me:
+  // params.dwPeriod = 0;//DWORD(0.05 * DI_SECONDS);
 
-  params.dwMagnitude = new_val;
-  if (new_val)
-    Update();
-  else
-    Stop();
+  return old_magnitude != m_params.dwMagnitude;
 }
 
 template <typename P>
-ForceFeedbackDevice::Force<P>::Force(const std::string& name, LPDIRECTINPUTEFFECT iface)
-    : m_name(name), m_iface(iface)
+ForceFeedbackDevice::TypedForce<P>::TypedForce(ForceFeedbackDevice* parent, std::string name,
+                                               LPDIRECTINPUTEFFECT effect)
+    : Force(parent, std::move(name), effect), m_params{}
 {
-  memset(&params, 0, sizeof(params));
 }
 
 template <typename P>
-std::string ForceFeedbackDevice::Force<P>::GetName() const
+void ForceFeedbackDevice::TypedForce<P>::UpdateEffect(int magnitude)
+{
+  if (UpdateParameters(magnitude))
+  {
+    if (magnitude)
+      PlayEffect();
+    else
+      StopEffect();
+  }
+}
+
+std::string ForceFeedbackDevice::Force::GetName() const
 {
   return m_name;
 }
+
+ForceFeedbackDevice::Force::Force(ForceFeedbackDevice* parent, const std::string name,
+                                  LPDIRECTINPUTEFFECT effect)
+    : m_effect(effect), m_parent(*parent), m_name(std::move(name)), m_desired_magnitude()
+{
 }
+
+void ForceFeedbackDevice::Force::SetState(ControlState state)
+{
+  const auto new_val = int(DI_FFNOMINALMAX * state);
+
+  if (m_desired_magnitude.exchange(new_val) != new_val)
+    m_parent.SignalUpdateThread();
 }
+
+void ForceFeedbackDevice::Force::UpdateOutput()
+{
+  UpdateEffect(m_desired_magnitude);
+}
+
+void ForceFeedbackDevice::Force::Release()
+{
+  // This isn't in the destructor because it should happen before the device is released.
+  m_effect->Stop();
+  m_effect->Unload();
+  m_effect->Release();
+}
+
+}  // namespace ForceFeedback
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
-#include <list>
+#include <atomic>
 #include <string>
+#include <thread>
 
+#include "Common/Event.h"
+#include "Common/Flag.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 #ifdef _WIN32
@@ -22,30 +25,63 @@ namespace ForceFeedback
 {
 class ForceFeedbackDevice : public Core::Device
 {
+public:
+  bool InitForceFeedback(const LPDIRECTINPUTDEVICE8, int cAxes);
+  void DeInitForceFeedback();
+
 private:
-  template <typename P>
+  void ThreadFunc();
+
   class Force : public Output
   {
   public:
-    Force(const std::string& name, LPDIRECTINPUTEFFECT iface);
-    ~Force();
+    Force(ForceFeedbackDevice* parent, const std::string name, LPDIRECTINPUTEFFECT effect);
 
-    std::string GetName() const override;
+    void UpdateOutput();
+    void Release();
+
     void SetState(ControlState state) override;
-    void Update();
-    void Stop();
+    std::string GetName() const override;
+
+  protected:
+    const LPDIRECTINPUTEFFECT m_effect;
 
   private:
-    const std::string m_name;
-    LPDIRECTINPUTEFFECT m_iface;
-    P params;
-  };
-  typedef Force<DICONSTANTFORCE> ForceConstant;
-  typedef Force<DIRAMPFORCE> ForceRamp;
-  typedef Force<DIPERIODIC> ForcePeriodic;
+    virtual void UpdateEffect(int magnitude) = 0;
 
-public:
-  bool InitForceFeedback(const LPDIRECTINPUTDEVICE8, int cAxes);
+    ForceFeedbackDevice& m_parent;
+    const std::string m_name;
+    std::atomic<int> m_desired_magnitude;
+  };
+
+  template <typename P>
+  class TypedForce : public Force
+  {
+  public:
+    TypedForce(ForceFeedbackDevice* parent, const std::string name, LPDIRECTINPUTEFFECT effect);
+
+  private:
+    void UpdateEffect(int magnitude) override;
+
+    // Returns true if parameters changed.
+    bool UpdateParameters(int magnitude);
+
+    void PlayEffect();
+    void StopEffect();
+
+    P m_params = {};
+  };
+
+  void SignalUpdateThread();
+
+  typedef TypedForce<DICONSTANTFORCE> ForceConstant;
+  typedef TypedForce<DIRAMPFORCE> ForceRamp;
+  typedef TypedForce<DIPERIODIC> ForcePeriodic;
+
+  std::thread m_update_thread;
+  Common::Event m_update_event;
+  Common::Flag m_run_thread;
 };
-}
-}
+
+}  // namespace ForceFeedback
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
@@ -26,7 +26,7 @@ namespace ForceFeedback
 class ForceFeedbackDevice : public Core::Device
 {
 public:
-  bool InitForceFeedback(const LPDIRECTINPUTDEVICE8, int cAxes);
+  bool InitForceFeedback(const LPDIRECTINPUTDEVICE8, int axis_count);
   void DeInitForceFeedback();
 
 private:
@@ -35,7 +35,7 @@ private:
   class Force : public Output
   {
   public:
-    Force(ForceFeedbackDevice* parent, const std::string name, LPDIRECTINPUTEFFECT effect);
+    Force(ForceFeedbackDevice* parent, const char* name, LPDIRECTINPUTEFFECT effect);
 
     void UpdateOutput();
     void Release();
@@ -50,7 +50,7 @@ private:
     virtual void UpdateEffect(int magnitude) = 0;
 
     ForceFeedbackDevice& m_parent;
-    const std::string m_name;
+    const char* const m_name;
     std::atomic<int> m_desired_magnitude;
   };
 
@@ -58,7 +58,8 @@ private:
   class TypedForce : public Force
   {
   public:
-    TypedForce(ForceFeedbackDevice* parent, const std::string name, LPDIRECTINPUTEFFECT effect);
+    TypedForce(ForceFeedbackDevice* parent, const char* name, LPDIRECTINPUTEFFECT effect,
+               const P& params);
 
   private:
     void UpdateEffect(int magnitude) override;

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -99,6 +99,8 @@ Joystick::Joystick(IOHIDDeviceRef device, std::string name)
 
 Joystick::~Joystick()
 {
+  DeInitForceFeedback();
+
   if (m_ff_device)
     m_ff_device->Release();
 }


### PR DESCRIPTION
Summary:
Remove a unnecessary ifdef preventing rumble stop on emu pause/stop on non-Windows.

Reduced the UI's rumble test to 2 seconds and input "detect" to 3 seconds. (Down from 5 seconds which was annoyingly long)

Fixed a bug in control expressions that was causing rumble to not work unless more than one output was configured.

Deferred force feedback updates to a thread to prevent slowdowns experienced by some users.

Adjusted force feedback effect parameters to sane values which eliminates crashes and infinite rumble with some devices.

This should fix issues:
https://bugs.dolphin-emu.org/issues/8465
https://bugs.dolphin-emu.org/issues/9540
https://bugs.dolphin-emu.org/issues/10954
https://bugs.dolphin-emu.org/issues/11465
https://bugs.dolphin-emu.org/issues/10736