### PR TITLE
HW: DK Bongos clap fix and cleanup

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -60,6 +60,18 @@ int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int length)
   return CSIDevice_GCController::RunBuffer(buffer, length);
 }
 
+bool CSIDevice_GCAdapter::GetData(u32& hi, u32& low)
+{
+  CSIDevice_GCController::GetData(hi, low);
+
+  if (m_simulate_konga)
+  {
+    hi &= CSIDevice_TaruKonga::BUTTON_MASK;
+  }
+
+  return true;
+}
+
 void CSIDevice_GCController::Rumble(int pad_num, ControlState strength)
 {
   SIDevices device = SConfig::GetInstance().m_SIDevice[pad_num];

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
@@ -17,5 +17,10 @@ public:
 
   GCPadStatus GetPadStatus() override;
   int RunBuffer(u8* buffer, int length) override;
+
+  bool GetData(u32& hi, u32& low) override;
+
+private:
+  bool m_simulate_konga{};
 };
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -231,12 +231,6 @@ bool CSIDevice_GCController::GetData(u32& hi, u32& low)
     low |= pad_status.substickX << 24;  // All 8 bits
   }
 
-  // Unset all bits except those that represent
-  // A, B, X, Y, Start and the error bits, as they
-  // are not used.
-  if (m_simulate_konga)
-    hi &= ~0x20FFFFFF;
-
   return true;
 }
 
@@ -349,4 +343,21 @@ void CSIDevice_GCController::DoState(PointerWrap& p)
   p.Do(m_timer_button_combo);
   p.Do(m_last_button_combo);
 }
+
+CSIDevice_TaruKonga::CSIDevice_TaruKonga(SIDevices device, int device_number)
+    : CSIDevice_GCController(device, device_number)
+{
+}
+
+bool CSIDevice_TaruKonga::GetData(u32& hi, u32& low)
+{
+  CSIDevice_GCController::GetData(hi, low);
+
+  // Unsets the first 16 bits (StickX/Y), PAD_USE_ORIGIN,
+  // and all buttons except: A, B, X, Y, Start, R
+  hi &= BUTTON_MASK;
+
+  return true;
+}
+
 }  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -83,9 +83,6 @@ protected:
   // Type of button combo from the last/current poll
   EButtonCombo m_last_button_combo = COMBO_NONE;
 
-  // Set this if we want to simulate the "TaruKonga" DK Bongo controller
-  bool m_simulate_konga = false;
-
 public:
   // Constructor
   CSIDevice_GCController(SIDevices device, int device_number);
@@ -122,10 +119,11 @@ protected:
 class CSIDevice_TaruKonga : public CSIDevice_GCController
 {
 public:
-  CSIDevice_TaruKonga(SIDevices device, int device_number)
-      : CSIDevice_GCController(device, device_number)
-  {
-    m_simulate_konga = true;
-  }
+  CSIDevice_TaruKonga(SIDevices device, int device_number);
+
+  bool GetData(u32& hi, u32& low) override;
+
+  static const u32 BUTTON_MASK = (PAD_BUTTON_A | PAD_BUTTON_B | PAD_BUTTON_X | PAD_BUTTON_Y |
+                                  PAD_BUTTON_START | PAD_TRIGGER_R);
 };
 }  // namespace SerialInterface


### PR DESCRIPTION
Moved the CSIDevice_GCAdapter "Simulate DK Bongos" setting variable (m_simulate_konga) from CSIDevice_GCController to CSIDevice_GCAdapter (where it belongs).

Included the right trigger in the Bongo button bit masking which fixes the in-game "clap" action behaving like it's on turbo-mode.

This fixes issue: https://bugs.dolphin-emu.org/issues/10643