### PR TITLE
Disable Defer EFB Copies for Rune Factory Frontier

### DIFF
--- a/Data/Sys/GameSettings/RUF.ini
+++ b/Data/Sys/GameSettings/RUF.ini
@@ -1,0 +1,15 @@
+# RUFP99, RUFJ99, RUFEMV - Rune Factory Frontier
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+
+[ActionReplay]
+
+[Video_Hacks]
+DeferEFBCopies = False
+


### PR DESCRIPTION
This feature causes crashes when reading mail and opening menus.  Though the game doesn't need Store EFB Copies to RAM, apparently some users had it enabled by default for accuracy and were now running into crashes.