### PR TITLE
Enable XFB2RAM by default for Monster Mayhem.

### DIFF
--- a/Data/Sys/GameSettings/RI7.ini
+++ b/Data/Sys/GameSettings/RI7.ini
@@ -1,0 +1,18 @@
+# RI7E4Z - Monster Mayhem: Build and Battle
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+
+[Video_Hacks]
+XFBToTextureEnable = False


### PR DESCRIPTION
Monster Portraits are a pretty big part of the game as you actually
build them.  If users really want performance, they can manually disable
it.