### PR TITLE
Enable EFB2RAM by default in Final Fantasy III

### DIFF
--- a/Data/Sys/GameSettings/JDA.ini
+++ b/Data/Sys/GameSettings/JDA.ini
@@ -1,0 +1,4 @@
+# JDAE01, JDAM01, JDAJ01 - Final Fantasy III
+
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
The game needs it to output correctly.