### PR TITLE
IniFile: Minor cleanup. Removed unused function. Improved template usage.

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -45,21 +45,16 @@ IniFile::Section::Section(std::string name_) : name{std::move(name_)}
 {
 }
 
-void IniFile::Section::Set(const std::string& key, const std::string& newValue)
+void IniFile::Section::Set(const std::string& key, std::string new_value)
 {
   auto it = values.find(key);
   if (it != values.end())
-    it->second = newValue;
+    it->second = std::move(new_value);
   else
   {
-    values[key] = newValue;
+    values[key] = std::move(new_value);
     keys_order.push_back(key);
   }
-}
-
-void IniFile::Section::Set(const std::string& key, const std::vector<std::string>& newValues)
-{
-  Set(key, JoinStrings(newValues, ","));
 }
 
 bool IniFile::Section::Get(const std::string& key, std::string* value,
@@ -80,36 +75,6 @@ bool IniFile::Section::Get(const std::string& key, std::string* value,
   return false;
 }
 
-bool IniFile::Section::Get(const std::string& key, std::vector<std::string>* out) const
-{
-  std::string temp;
-  bool retval = Get(key, &temp);
-  if (!retval || temp.empty())
-  {
-    return false;
-  }
-
-  // ignore starting comma, if any
-  size_t subStart = temp.find_first_not_of(",");
-
-  // split by comma
-  while (subStart != std::string::npos)
-  {
-    // Find next comma
-    size_t subEnd = temp.find(',', subStart);
-    if (subStart != subEnd)
-    {
-      // take from first char until next comma
-      out->push_back(StripSpaces(temp.substr(subStart, subEnd - subStart)));
-    }
-
-    // Find the next non-comma char
-    subStart = temp.find_first_not_of(",", subEnd);
-  }
-
-  return true;
-}
-
 bool IniFile::Section::Exists(const std::string& key) const
 {
   return values.find(key) != values.end();
@@ -126,12 +91,7 @@ bool IniFile::Section::Delete(const std::string& key)
   return true;
 }
 
-void IniFile::Section::SetLines(const std::vector<std::string>& lines)
-{
-  m_lines = lines;
-}
-
-void IniFile::Section::SetLines(std::vector<std::string>&& lines)
+void IniFile::Section::SetLines(std::vector<std::string> lines)
 {
   m_lines = std::move(lines);
 }

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -35,26 +35,26 @@ public:
     bool Exists(const std::string& key) const;
     bool Delete(const std::string& key);
 
-    void Set(const std::string& key, const std::string& newValue);
+    void Set(const std::string& key, std::string new_value);
+
     template <typename T>
-    void Set(const std::string& key, const T& new_value)
+    void Set(const std::string& key, T&& new_value)
     {
-      Set(key, ValueToString(new_value));
+      Set(key, ValueToString(std::forward<T>(new_value)));
     }
 
     template <typename T>
-    void Set(const std::string& key, const T& new_value, const std::common_type_t<T>& default_value)
+    void Set(const std::string& key, T&& new_value, const std::common_type_t<T>& default_value)
     {
       if (new_value != default_value)
-        Set(key, new_value);
+        Set(key, std::forward<T>(new_value));
       else
         Delete(key);
     }
 
-    void Set(const std::string& key, const std::vector<std::string>& newValues);
-
     bool Get(const std::string& key, std::string* value,
-             const std::string& defaultValue = NULL_STRING) const;
+             const std::string& default_value = NULL_STRING) const;
+
     template <typename T>
     bool Get(const std::string& key, T* value,
              const std::common_type_t<T>& default_value = {}) const
@@ -66,10 +66,8 @@ public:
       *value = default_value;
       return false;
     }
-    bool Get(const std::string& key, std::vector<std::string>* values) const;
 
-    void SetLines(const std::vector<std::string>& lines);
-    void SetLines(std::vector<std::string>&& lines);
+    void SetLines(std::vector<std::string> lines);
     bool GetLines(std::vector<std::string>* lines, const bool remove_comments = true) const;
 
     bool operator<(const Section& other) const { return name < other.name; }


### PR DESCRIPTION
No need for separate const& and && "Set" functions when we can pass-by-value and std::move.

Removed unused std::vector<std::string> Get/Set which split/joined on ",".

Used "perfect-forwarding" where appropriate.

Fixes: https://bugs.dolphin-emu.org/issues/9354