### PR TITLE
Fix Emulated Dance Mat

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -40,28 +40,28 @@ int CSIDevice_DanceMat::RunBuffer(u8* buffer, int length)
 u32 CSIDevice_DanceMat::MapPadStatus(const GCPadStatus& pad_status)
 {
   // Map the dpad to the blue arrows, the buttons to the orange arrows
-  // Z = + button, Start = - button
+  // Z = + button, Start = - button. Active Life Mats have a different layout.
   u16 map = 0;
   if (pad_status.button & PAD_BUTTON_UP)
-    map |= 0x1000;
-  if (pad_status.button & PAD_BUTTON_DOWN)
-    map |= 0x2;
-  if (pad_status.button & PAD_BUTTON_LEFT)
     map |= 0x8;
-  if (pad_status.button & PAD_BUTTON_RIGHT)
+  if (pad_status.button & PAD_BUTTON_DOWN)
     map |= 0x4;
-  if (pad_status.button & PAD_BUTTON_Y)
-    map |= 0x200;
-  if (pad_status.button & PAD_BUTTON_A)
-    map |= 0x10;
-  if (pad_status.button & PAD_BUTTON_B)
-    map |= 0x100;
-  if (pad_status.button & PAD_BUTTON_X)
-    map |= 0x800;
-  if (pad_status.button & PAD_TRIGGER_Z)
-    map |= 0x400;
-  if (pad_status.button & PAD_BUTTON_START)
+  if (pad_status.button & PAD_BUTTON_LEFT)
     map |= 0x1;
+  if (pad_status.button & PAD_BUTTON_RIGHT)
+    map |= 0x2;
+  if (pad_status.button & PAD_BUTTON_Y)
+    map |= 0x400;  // Only Active Life Mat has this button. Maps as + button.
+  if (pad_status.button & PAD_BUTTON_A)
+    map |= 0x100;
+  if (pad_status.button & PAD_BUTTON_B)
+    map |= 0x200;
+  if (pad_status.button & PAD_BUTTON_X)
+    map |= 0x800;  // Only Active Life Mat has this button. Maps as Right Foot Right.
+  if (pad_status.button & PAD_TRIGGER_Z)
+    map |= 0x10;
+  if (pad_status.button & PAD_BUTTON_START)
+    map |= 0x1000;
 
   return (u32)(map << 16) | 0x8080;
 }


### PR DESCRIPTION
I have no idea how it got so broken, but this makes it so both the
Active Life and DDR Mario/Wii games can be fully configured.

I have no idea how they got so broken but now you can actually play the games without needing Native GC Support and a Dance Mat (which doesn't work for Active Life).  I also noted that some of the buttons are only on the Active Life Mat, I have 4 official Dance Mats (DDR Hottest Party 1, DDR Hottest Party 2, DDR Mario, and Active Life Mat) and hardware tested the button values with assistance from Booto.

Note:  Someone still needs to make an "Dance Mat" option for Native GC Support for the games to actually notice you have a Dance Mat plugged in.  This is purely to fix Emulated Dance Mat support.