### PR TITLE
 Qt/Debugger: Add Show in Code / Show in Memory 

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -224,6 +224,9 @@ void CodeViewWidget::OnContextMenu()
   auto* copy_line_action =
       menu->addAction(tr("Copy code &line"), this, &CodeViewWidget::OnCopyCode);
   auto* copy_hex_action = menu->addAction(tr("Copy &hex"), this, &CodeViewWidget::OnCopyHex);
+
+  menu->addAction(tr("Show in &memory"), this, &CodeViewWidget::OnShowInMemory);
+
   menu->addSeparator();
 
   auto* symbol_rename_action =
@@ -265,6 +268,11 @@ void CodeViewWidget::OnCopyAddress()
   const u32 addr = GetContextAddress();
 
   QApplication::clipboard()->setText(QStringLiteral("%1").arg(addr, 8, 16, QLatin1Char('0')));
+}
+
+void CodeViewWidget::OnShowInMemory()
+{
+  emit ShowMemory(GetContextAddress());
 }
 
 void CodeViewWidget::OnCopyCode()

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -34,8 +34,10 @@ public:
 
   void ToggleBreakpoint();
   void AddBreakpoint();
+
 signals:
   void RequestPPCComparison(u32 addr);
+  void ShowMemory(u32 address);
   void SymbolsChanged();
   void BreakpointsChanged();
 
@@ -57,6 +59,7 @@ private:
 
   void OnFollowBranch();
   void OnCopyAddress();
+  void OnShowInMemory();
   void OnCopyFunction();
   void OnCopyCode();
   void OnCopyHex();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -164,6 +164,7 @@ void CodeWidget::ConnectWidgets()
 
   connect(m_code_view, &CodeViewWidget::RequestPPCComparison, this,
           &CodeWidget::RequestPPCComparison);
+  connect(m_code_view, &CodeViewWidget::ShowMemory, this, &CodeWidget::ShowMemory);
 }
 
 void CodeWidget::OnSearchAddress()
@@ -250,6 +251,12 @@ void CodeWidget::OnSelectFunctionCallers()
 void CodeWidget::SetAddress(u32 address, CodeViewWidget::SetAddressUpdate update)
 {
   m_code_view->SetAddress(address, update);
+
+  if (update == CodeViewWidget::SetAddressUpdate::WithUpdate)
+  {
+    raise();
+    m_code_view->setFocus();
+  }
 }
 
 void CodeWidget::Update()

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -44,6 +44,7 @@ public:
 signals:
   void BreakpointsChanged();
   void RequestPPCComparison(u32 addr);
+  void ShowMemory(u32 address);
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -359,6 +359,10 @@ void MemoryViewWidget::OnContextMenu()
 
   menu->addSeparator();
 
+  menu->addAction(tr("Show in code"), this, [this] { emit ShowCode(GetContextAddress()); });
+
+  menu->addSeparator();
+
   menu->addAction(tr("Toggle Breakpoint"), this, &MemoryViewWidget::ToggleBreakpoint);
 
   menu->exec(QCursor::pos());

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -49,6 +49,7 @@ public:
 
 signals:
   void BreakpointsChanged();
+  void ShowCode(u32 address);
 
 private:
   void OnContextMenu();

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -212,6 +212,7 @@ void MemoryWidget::ConnectWidgets()
   connect(m_bp_log_check, &QCheckBox::toggled, this, &MemoryWidget::OnBPLogChanged);
   connect(m_memory_view, &MemoryViewWidget::BreakpointsChanged, this,
           &MemoryWidget::BreakpointsChanged);
+  connect(m_memory_view, &MemoryViewWidget::ShowCode, this, &MemoryWidget::ShowCode);
 }
 
 void MemoryWidget::closeEvent(QCloseEvent*)
@@ -321,6 +322,15 @@ void MemoryWidget::OnBPTypeChanged()
   m_memory_view->SetBPType(type);
 
   SaveSettings();
+}
+
+void MemoryWidget::SetAddress(u32 address)
+{
+  m_memory_view->SetAddress(address);
+  Settings::Instance().SetMemoryVisible(true);
+  raise();
+
+  m_memory_view->setFocus();
 }
 
 void MemoryWidget::OnSearchAddress()

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -25,9 +25,11 @@ public:
   explicit MemoryWidget(QWidget* parent = nullptr);
   ~MemoryWidget();
 
+  void SetAddress(u32 address);
   void Update();
 signals:
   void BreakpointsChanged();
+  void ShowCode(u32 address);
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -288,8 +288,12 @@ void MainWindow::CreateComponents()
   connect(m_code_widget, &CodeWidget::BreakpointsChanged, m_breakpoint_widget,
           &BreakpointWidget::Update);
   connect(m_code_widget, &CodeWidget::RequestPPCComparison, m_jit_widget, &JITWidget::Compare);
+  connect(m_code_widget, &CodeWidget::ShowMemory, m_memory_widget, &MemoryWidget::SetAddress);
   connect(m_memory_widget, &MemoryWidget::BreakpointsChanged, m_breakpoint_widget,
           &BreakpointWidget::Update);
+  connect(m_memory_widget, &MemoryWidget::ShowCode, m_code_widget, [this](u32 address) {
+    m_code_widget->SetAddress(address, CodeViewWidget::SetAddressUpdate::WithUpdate);
+  });
 
   connect(m_breakpoint_widget, &BreakpointWidget::BreakpointsChanged, m_code_widget,
           &CodeWidget::Update);


### PR DESCRIPTION
Allows you to show a given hex block / instruction in the code / memory view.