### PR TITLE
Disable MMU in Metal Gear Solid: Twin Snakes and True Crime: New York City

### DIFF
--- a/Data/Sys/GameSettings/G2C.ini
+++ b/Data/Sys/GameSettings/G2C.ini
@@ -1,4 +1,4 @@
-# GGSEA4, GGSJA4, GGSPA4 - METAL GEAR SOLID THE TWIN SNAKES
+# G2CX52, G2CE52, G2CP52, G2CD52 - True Crime: New York City
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,8 +13,6 @@ MMU = 0
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Hacks]
-ImmediateXFBEnable = False
+
+[Video_Settings]


### PR DESCRIPTION
This is probably going to be a bit controversial as we're having the MMU
on for these games is more accurate.  But, I've probably been contacted
by over ten users in the past two months about these games stuttering
madly.

True Crime: New York City can clear the JIT caches 3 times a second, and
Metal Gear Solid will heavily stutter every single time an enemy sees
you.  Considering Dolphin is used in Speedruns for MGS, some users are
turning to forks simply because they have different default settings,
which I think is a bit silly.

Until we can figure out why Enable MMU is causing such violent results
in these games, I think it would be reasonable to disable MMU emulation
in them and bring their behavior to before MMU was forced on.  If others
disagree, feel free to close, I just wanted to bring this to attention.

Once the JIT issue is fixed, this could be reverted with no penalty.  There 
are likely other games with the same issue, but, these two are the ones
that I've seen being complained about the most and I have personally
tested.