### PR TITLE
Android: Edit the text that pops up on game launch

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -281,7 +281,7 @@
     <string name="emulation_control_rumble">Rumble</string>
     <string name="emulation_choose_controller">Choose Controller</string>
     <string name="emulation_controller_changed">You may have to reload the game after changing extensions.</string>
-    <string name="emulation_touch_button_help">To change the button layout, open the menu -> Configure Controls -> Edit Layout</string>
+    <string name="emulation_touch_button_help">Swipe down from the top of the screen to access the menu.</string>
     <string name="emulation_touch_overlay_reset">Reset Overlay</string>
 
     <!-- GC Adapter Menu-->


### PR DESCRIPTION
Some of the recent reviews on Google Play express trouble finding the emulation activity menu. One of them thought you were supposed to go to the settings accessible through the main activity to configure the virtual controller buttons.

This PR changes the text so that the user now explicitly is told to swipe down from the top of the screen to access the menu. In exchange, I removed the exact selections to make in the menu so that the text wouldn't get too long, but I think it shouldn't be too hard to understand once you know how to open the menu.