### PR TITLE
ControllerEmu: Make mapping indicators pretty

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -37,6 +37,11 @@ static const QColor TEXT_COLOR = Qt::darkGray;
 // Text color that is visible atop ADJ_INPUT_COLOR:
 static const QColor TEXT_ALT_COLOR = Qt::white;
 
+static const QColor STICK_GATE_COLOR = Qt::lightGray;
+static const QColor C_STICK_GATE_COLOR = Qt::yellow;
+static const QColor CURSOR_TV_COLOR = 0xaed6f1;
+static const QColor TILT_GATE_COLOR = 0xa2d9ce;
+
 constexpr int INPUT_DOT_RADIUS = 2;
 
 MappingIndicator::MappingIndicator(ControllerEmu::ControlGroup* group) : m_group(group)
@@ -71,7 +76,7 @@ QPolygonF GetPolygonFromRadiusGetter(F&& radius_getter, double scale)
 
 void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
 {
-  const QColor tv_brush_color = 0xaed6f1;
+  const QColor tv_brush_color = CURSOR_TV_COLOR;
   const QColor tv_pen_color = tv_brush_color.darker(125);
 
   // TODO: This SetControllerStateNeeded interface leaks input into the game
@@ -114,8 +119,8 @@ void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
   p.drawRect(
       QRectF(-scale, raw_coord.z * scale - INPUT_DOT_RADIUS / 2, scale * 2, INPUT_DOT_RADIUS));
 
-  // Adjusted Z:
-  if (adj_coord.z)
+  // Adjusted Z (if not hidden):
+  if (adj_coord.z && adj_coord.x < 10000)
   {
     p.setBrush(ADJ_INPUT_COLOR);
     p.drawRect(
@@ -158,7 +163,7 @@ void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
   p.setBrush(RAW_INPUT_COLOR);
   p.drawEllipse(QPointF{raw_coord.x, raw_coord.y} * scale, INPUT_DOT_RADIUS, INPUT_DOT_RADIUS);
 
-  // Adjusted cursor position if not hidden:
+  // Adjusted cursor position (if not hidden):
   if (adj_coord.x < 10000)
   {
     p.setPen(Qt::NoPen);
@@ -173,16 +178,13 @@ void MappingIndicator::DrawReshapableInput(ControllerEmu::ReshapableInput& stick
   // Some hacks for pretty colors:
   const bool is_c_stick = m_group->name == "C-Stick";
   const bool is_tilt = m_group->name == "Tilt";
-  const bool is_cursor = m_group->name == "IR";
 
-  QColor gate_brush_color = Qt::lightGray;
+  QColor gate_brush_color = STICK_GATE_COLOR;
 
   if (is_c_stick)
-    gate_brush_color = Qt::yellow;
+    gate_brush_color = C_STICK_GATE_COLOR;
   else if (is_tilt)
-    gate_brush_color = 0xa2d9ce;
-  else if (is_cursor)
-    gate_brush_color = 0xaed6f1;
+    gate_brush_color = TILT_GATE_COLOR;
 
   const QColor gate_pen_color = gate_brush_color.darker(125);
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -14,7 +14,6 @@
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
-#include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
 #include "InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/Device.h"
@@ -164,14 +163,12 @@ QPolygonF GetPolygonFromRadiusGetter(F&& radius_getter, double scale)
   return shape;
 }
 
-void MappingIndicator::DrawStick()
+void MappingIndicator::DrawReshapableInput(ControllerEmu::ReshapableInput& stick)
 {
   // Make the c-stick yellow:
   const bool is_c_stick = m_group->name == "C-Stick";
   const QColor gate_brush_color = is_c_stick ? Qt::yellow : Qt::lightGray;
   const QColor gate_pen_color = gate_brush_color.darker(125);
-
-  auto& stick = *static_cast<ControllerEmu::AnalogStick*>(m_group);
 
   // TODO: This SetControllerStateNeeded interface leaks input into the game
   // We should probably hold the mutex for UI updates.
@@ -334,11 +331,9 @@ void MappingIndicator::paintEvent(QPaintEvent*)
   case ControllerEmu::GroupType::Cursor:
     DrawCursor(false);
     break;
-  case ControllerEmu::GroupType::Tilt:
-    DrawCursor(true);
-    break;
   case ControllerEmu::GroupType::Stick:
-    DrawStick();
+  case ControllerEmu::GroupType::Tilt:
+    DrawReshapableInput(*static_cast<ControllerEmu::ReshapableInput*>(m_group));
     break;
   case ControllerEmu::GroupType::MixedTriggers:
     DrawMixedTriggers();

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -23,24 +23,24 @@
 
 // Color constants to keep things looking consistent:
 // TODO: could we maybe query theme colors from Qt for the bounding box?
-static const QColor BBOX_PEN_COLOR = Qt::darkGray;
-static const QColor BBOX_BRUSH_COLOR = Qt::white;
+const QColor BBOX_PEN_COLOR = Qt::darkGray;
+const QColor BBOX_BRUSH_COLOR = Qt::white;
 
-static const QColor RAW_INPUT_COLOR = Qt::darkGray;
-static const QColor ADJ_INPUT_COLOR = Qt::red;
-static const QPen INPUT_SHAPE_PEN(RAW_INPUT_COLOR, 1.0, Qt::DashLine);
+const QColor RAW_INPUT_COLOR = Qt::darkGray;
+const QColor ADJ_INPUT_COLOR = Qt::red;
+const QPen INPUT_SHAPE_PEN(RAW_INPUT_COLOR, 1.0, Qt::DashLine);
 
-static const QColor DEADZONE_COLOR = Qt::darkGray;
-static const QBrush DEADZONE_BRUSH(DEADZONE_COLOR, Qt::BDiagPattern);
+const QColor DEADZONE_COLOR = Qt::darkGray;
+const QBrush DEADZONE_BRUSH(DEADZONE_COLOR, Qt::BDiagPattern);
 
-static const QColor TEXT_COLOR = Qt::darkGray;
+const QColor TEXT_COLOR = Qt::darkGray;
 // Text color that is visible atop ADJ_INPUT_COLOR:
-static const QColor TEXT_ALT_COLOR = Qt::white;
+const QColor TEXT_ALT_COLOR = Qt::white;
 
-static const QColor STICK_GATE_COLOR = Qt::lightGray;
-static const QColor C_STICK_GATE_COLOR = Qt::yellow;
-static const QColor CURSOR_TV_COLOR = 0xaed6f1;
-static const QColor TILT_GATE_COLOR = 0xa2d9ce;
+const QColor STICK_GATE_COLOR = Qt::lightGray;
+const QColor C_STICK_GATE_COLOR = Qt::yellow;
+const QColor CURSOR_TV_COLOR = 0xaed6f1;
+const QColor TILT_GATE_COLOR = 0xa2d9ce;
 
 constexpr int INPUT_DOT_RADIUS = 2;
 
@@ -53,6 +53,8 @@ MappingIndicator::MappingIndicator(ControllerEmu::ControlGroup* group) : m_group
   m_timer->start(1000 / 30);
 }
 
+namespace
+{
 // Constructs a polygon by querying a radius at varying angles:
 template <typename F>
 QPolygonF GetPolygonFromRadiusGetter(F&& radius_getter, double scale)
@@ -73,6 +75,7 @@ QPolygonF GetPolygonFromRadiusGetter(F&& radius_getter, double scale)
 
   return shape;
 }
+}  // namespace
 
 void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
 {
@@ -250,7 +253,7 @@ void MappingIndicator::DrawMixedTriggers()
   QPainter p(this);
   p.setRenderHint(QPainter::TextAntialiasing, true);
 
-  auto& triggers = *static_cast<ControllerEmu::MixedTriggers*>(m_group);
+  const auto& triggers = *static_cast<ControllerEmu::MixedTriggers*>(m_group);
   const ControlState threshold = triggers.GetThreshold();
   const ControlState deadzone = triggers.GetDeadzone();
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -6,19 +6,17 @@
 
 #include <QWidget>
 
-#include "InputCommon/ControllerEmu/StickGate.h"
-
 namespace ControllerEmu
 {
 class Control;
 class ControlGroup;
+class Cursor;
 class NumericSetting;
+class ReshapableInput;
 }  // namespace ControllerEmu
 
 class QPaintEvent;
 class QTimer;
-
-class ControlReference;
 
 class MappingIndicator : public QWidget
 {
@@ -26,27 +24,13 @@ public:
   explicit MappingIndicator(ControllerEmu::ControlGroup* group);
 
 private:
-  void BindCursorControls(bool tilt);
-
-  void DrawCursor(bool tilt);
+  void DrawCursor(ControllerEmu::Cursor& cursor);
   void DrawReshapableInput(ControllerEmu::ReshapableInput& stick);
   void DrawMixedTriggers();
 
   void paintEvent(QPaintEvent*) override;
+
   ControllerEmu::ControlGroup* m_group;
-
-  // Cursor settings
-  ControlReference* m_cursor_up;
-  ControlReference* m_cursor_down;
-  ControlReference* m_cursor_left;
-  ControlReference* m_cursor_right;
-  ControlReference* m_cursor_forward;
-  ControlReference* m_cursor_backward;
-
-  ControllerEmu::NumericSetting* m_cursor_center;
-  ControllerEmu::NumericSetting* m_cursor_width;
-  ControllerEmu::NumericSetting* m_cursor_height;
-  ControllerEmu::NumericSetting* m_cursor_deadzone;
 
   QTimer* m_timer;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -11,7 +11,7 @@ namespace ControllerEmu
 class Control;
 class ControlGroup;
 class NumericSetting;
-}
+}  // namespace ControllerEmu
 
 class QPaintEvent;
 class QTimer;
@@ -25,7 +25,6 @@ public:
 
 private:
   void BindCursorControls(bool tilt);
-  void BindMixedTriggersControls();
 
   void DrawCursor(bool tilt);
   void DrawStick();
@@ -46,14 +45,6 @@ private:
   ControllerEmu::NumericSetting* m_cursor_width;
   ControllerEmu::NumericSetting* m_cursor_height;
   ControllerEmu::NumericSetting* m_cursor_deadzone;
-
-  // Triggers settings
-  ControlReference* m_mixed_triggers_r_analog;
-  ControlReference* m_mixed_triggers_r_button;
-  ControlReference* m_mixed_triggers_l_analog;
-  ControlReference* m_mixed_triggers_l_button;
-
-  ControllerEmu::NumericSetting* m_mixed_triggers_threshold;
 
   QTimer* m_timer;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -6,6 +6,8 @@
 
 #include <QWidget>
 
+#include "InputCommon/ControllerEmu/StickGate.h"
+
 namespace ControllerEmu
 {
 class Control;
@@ -27,7 +29,7 @@ private:
   void BindCursorControls(bool tilt);
 
   void DrawCursor(bool tilt);
-  void DrawStick();
+  void DrawReshapableInput(ControllerEmu::ReshapableInput& stick);
   void DrawMixedTriggers();
 
   void paintEvent(QPaintEvent*) override;

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -54,14 +54,14 @@ void WiimoteEmuExtension::CreateDrumsLayout()
   auto* hbox = new QHBoxLayout();
   m_drums_box = new QGroupBox(tr("Drums"), this);
 
-  hbox->addWidget(CreateGroupBox(
-      tr("Buttons"), Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Buttons)));
+  hbox->addWidget(CreateGroupBox(tr("Stick"),
+                                 Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Stick)));
 
   auto* vbox = new QVBoxLayout();
   vbox->addWidget(
       CreateGroupBox(tr("Pads"), Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Pads)));
-  vbox->addWidget(CreateGroupBox(tr("Stick"),
-                                 Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Stick)));
+  vbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Buttons)));
   hbox->addLayout(vbox);
 
   m_drums_box->setLayout(hbox);
@@ -108,11 +108,7 @@ void WiimoteEmuExtension::CreateGuitarLayout()
 
   auto* vbox = new QVBoxLayout();
   vbox->addWidget(CreateGroupBox(
-      tr("Buttons"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Buttons)));
-  vbox->addWidget(CreateGroupBox(
       tr("Stick"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Stick)));
-  vbox->addWidget(CreateGroupBox(
-      tr("Slider Bar"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::SliderBar)));
   hbox->addLayout(vbox);
 
   auto* vbox2 = new QVBoxLayout();
@@ -120,9 +116,16 @@ void WiimoteEmuExtension::CreateGuitarLayout()
       tr("Strum"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Strum)));
   vbox2->addWidget(CreateGroupBox(
       tr("Frets"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Frets)));
-  vbox2->addWidget(CreateGroupBox(
-      tr("Whammy"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Whammy)));
   hbox->addLayout(vbox2);
+
+  auto* vbox3 = new QVBoxLayout();
+  vbox3->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Buttons)));
+  vbox3->addWidget(CreateGroupBox(
+      tr("Whammy"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::Whammy)));
+  vbox3->addWidget(CreateGroupBox(
+      tr("Slider Bar"), Wiimote::GetGuitarGroup(GetPort(), WiimoteEmu::GuitarGroup::SliderBar)));
+  hbox->addLayout(vbox3);
 
   m_guitar_box->setLayout(hbox);
 }
@@ -134,24 +137,27 @@ void WiimoteEmuExtension::CreateTurntableLayout()
 
   hbox->addWidget(CreateGroupBox(
       tr("Stick"), Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Stick)));
-  hbox->addWidget(CreateGroupBox(
-      tr("Buttons"), Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Buttons)));
 
   auto* vbox = new QVBoxLayout();
   vbox->addWidget(CreateGroupBox(
+      tr("Buttons"), Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Buttons)));
+  vbox->addWidget(CreateGroupBox(
       tr("Effect"), Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::EffectDial)));
-  vbox->addWidget(
+  hbox->addLayout(vbox);
+
+  auto* vbox2 = new QVBoxLayout();
+  vbox2->addWidget(
       // i18n: "Table" refers to a turntable
       CreateGroupBox(tr("Left Table"),
                      Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::LeftTable)));
-  vbox->addWidget(CreateGroupBox(
+  vbox2->addWidget(CreateGroupBox(
       // i18n: "Table" refers to a turntable
       tr("Right Table"),
       Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::RightTable)));
-  vbox->addWidget(
+  vbox2->addWidget(
       CreateGroupBox(tr("Crossfade"),
                      Wiimote::GetTurntableGroup(GetPort(), WiimoteEmu::TurntableGroup::Crossfade)));
-  hbox->addLayout(vbox);
+  hbox->addLayout(vbox2);
 
   m_turntable_box->setLayout(hbox);
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -24,22 +24,17 @@ AnalogStick::AnalogStick(const char* const name_, std::unique_ptr<StickGate>&& s
 
 AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
                          std::unique_ptr<StickGate>&& stick_gate)
-    : ControlGroup(name_, ui_name_, GroupType::Stick), m_stick_gate(std::move(stick_gate))
+    : ReshapableInput(name_, ui_name_, GroupType::Stick), m_stick_gate(std::move(stick_gate))
 {
   for (auto& named_direction : named_directions)
     controls.emplace_back(std::make_unique<Input>(Translate, named_direction));
 
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Modifier")));
 
-  // Set default input radius to that of the gate radius (no resizing)
-  // Allow radius greater than 1.0 for definitions of rounded squares
-  // This is ideal for Xbox controllers (and probably others)
-  numeric_settings.emplace_back(
-      std::make_unique<NumericSetting>(_trans("Input Radius"), GetGateRadiusAtAngle(0.0), 0, 140));
-  // Set default input shape to an octagon (no reshaping)
-  numeric_settings.emplace_back(
-      std::make_unique<NumericSetting>(_trans("Input Shape"), 0.0, 0, 50));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
+  // Default input radius to that of the gate radius (no resizing)
+  // Default input shape to an octagon (no reshaping)
+  // Max deadzone to 50%
+  AddReshapingSettings(GetGateRadiusAtAngle(0.0), 0.0, 50);
 }
 
 AnalogStick::StateData AnalogStick::GetState(bool adjusted)
@@ -51,76 +46,14 @@ AnalogStick::StateData AnalogStick::GetState(bool adjusted)
   if (!adjusted)
     return {x, y};
 
-  // TODO: make the AtAngle functions work with negative angles:
-  const ControlState ang = std::atan2(y, x) + MathUtil::TAU;
-
-  const ControlState gate_max_dist = GetGateRadiusAtAngle(ang);
-  const ControlState input_max_dist = GetInputRadiusAtAngle(ang);
-
-  // If input radius is zero we apply no scaling.
-  // This is useful when mapping native controllers without knowing intimate radius details.
-  const ControlState max_dist = input_max_dist ? input_max_dist : gate_max_dist;
-
-  ControlState dist = std::sqrt(x * x + y * y) / max_dist;
-
-  // If the modifier is pressed, scale the distance by the modifier's value.
-  // This is affected by the modifier's "range" setting which defaults to 50%.
   const ControlState modifier = controls[4]->control_ref->State();
-  if (modifier)
-  {
-    // TODO: Modifier's range setting gets reset to 100% when the clear button is clicked.
-    // This causes the modifier to not behave how a user might suspect.
-    // Retaining the old scale-by-50% behavior until range is fixed to clear to 50%.
-    dist *= 0.5;
-    // dist *= modifier;
-  }
 
-  // Apply deadzone as a percentage of the user-defined radius/shape:
-  const ControlState deadzone = GetDeadzoneRadiusAtAngle(ang);
-  dist = std::max(0.0, dist - deadzone) / (1.0 - deadzone);
-
-  // Scale to the gate shape/radius:
-  dist = dist *= gate_max_dist;
-
-  x = MathUtil::Clamp(std::cos(ang) * dist, -1.0, 1.0);
-  y = MathUtil::Clamp(std::sin(ang) * dist, -1.0, 1.0);
-  return {x, y};
+  return Reshape(x, y, modifier);
 }
 
 ControlState AnalogStick::GetGateRadiusAtAngle(double ang) const
 {
   return m_stick_gate->GetRadiusAtAngle(ang);
-}
-
-ControlState AnalogStick::GetDeadzoneRadiusAtAngle(double ang) const
-{
-  return CalculateInputShapeRadiusAtAngle(ang) * numeric_settings[SETTING_DEADZONE]->GetValue();
-}
-
-ControlState AnalogStick::GetInputRadiusAtAngle(double ang) const
-{
-  const ControlState radius =
-      CalculateInputShapeRadiusAtAngle(ang) * numeric_settings[SETTING_INPUT_RADIUS]->GetValue();
-  // Clamp within the -1 to +1 square as input radius may be greater than 1.0:
-  return std::min(radius, SquareStickGate(1).GetRadiusAtAngle(ang));
-}
-
-ControlState AnalogStick::CalculateInputShapeRadiusAtAngle(double ang) const
-{
-  const auto shape = numeric_settings[SETTING_INPUT_SHAPE]->GetValue() * 4.0;
-
-  if (shape < 1.0)
-  {
-    // Between 0 and 25 return a shape between octagon and circle
-    const auto amt = shape;
-    return OctagonStickGate(1).GetRadiusAtAngle(ang) * (1 - amt) + amt;
-  }
-  else
-  {
-    // Between 25 and 50 return a shape between circle and square
-    const auto amt = shape - 1.0;
-    return (1 - amt) + SquareStickGate(1).GetRadiusAtAngle(ang) * amt;
-  }
 }
 
 OctagonAnalogStick::OctagonAnalogStick(const char* name, ControlState gate_radius)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -37,7 +37,7 @@ AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
   AddReshapingSettings(GetGateRadiusAtAngle(0.0), 0.0, 50);
 }
 
-AnalogStick::StateData AnalogStick::GetReshapableState(bool adjusted)
+AnalogStick::ReshapeData AnalogStick::GetReshapableState(bool adjusted)
 {
   const ControlState y = controls[0]->control_ref->State() - controls[1]->control_ref->State();
   const ControlState x = controls[3]->control_ref->State() - controls[2]->control_ref->State();

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -37,10 +37,10 @@ AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
   AddReshapingSettings(GetGateRadiusAtAngle(0.0), 0.0, 50);
 }
 
-AnalogStick::StateData AnalogStick::GetState(bool adjusted)
+AnalogStick::StateData AnalogStick::GetReshapableState(bool adjusted)
 {
-  ControlState y = controls[0]->control_ref->State() - controls[1]->control_ref->State();
-  ControlState x = controls[3]->control_ref->State() - controls[2]->control_ref->State();
+  const ControlState y = controls[0]->control_ref->State() - controls[1]->control_ref->State();
+  const ControlState x = controls[3]->control_ref->State() - controls[2]->control_ref->State();
 
   // Return raw values. (used in UI)
   if (!adjusted)
@@ -49,6 +49,11 @@ AnalogStick::StateData AnalogStick::GetState(bool adjusted)
   const ControlState modifier = controls[4]->control_ref->State();
 
   return Reshape(x, y, modifier);
+}
+
+AnalogStick::StateData AnalogStick::GetState()
+{
+  return GetReshapableState(true);
 }
 
 ControlState AnalogStick::GetGateRadiusAtAngle(double ang) const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -13,12 +13,12 @@ namespace ControllerEmu
 class AnalogStick : public ReshapableInput
 {
 public:
-  typedef ReshapeData StateData;
+  using StateData = ReshapeData;
 
   AnalogStick(const char* name, std::unique_ptr<StickGate>&& stick_gate);
   AnalogStick(const char* name, const char* ui_name, std::unique_ptr<StickGate>&& stick_gate);
 
-  StateData GetReshapableState(bool adjusted) final override;
+  ReshapeData GetReshapableState(bool adjusted) final override;
   ControlState GetGateRadiusAtAngle(double ang) const override;
 
   StateData GetState();

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -10,35 +10,17 @@
 
 namespace ControllerEmu
 {
-class AnalogStick : public ControlGroup
+class AnalogStick : public ReshapableInput
 {
 public:
-  enum
-  {
-    SETTING_INPUT_RADIUS,
-    SETTING_INPUT_SHAPE,
-    SETTING_DEADZONE,
-  };
-
-  struct StateData
-  {
-    ControlState x{};
-    ControlState y{};
-  };
-
   AnalogStick(const char* name, std::unique_ptr<StickGate>&& stick_gate);
   AnalogStick(const char* name, const char* ui_name, std::unique_ptr<StickGate>&& stick_gate);
 
-  StateData GetState(bool adjusted = true);
+  StateData GetState(bool adjusted = true) override;
 
-  // Angle is in radians and should be non-negative
-  ControlState GetGateRadiusAtAngle(double ang) const;
-  ControlState GetDeadzoneRadiusAtAngle(double ang) const;
-  ControlState GetInputRadiusAtAngle(double ang) const;
+  ControlState GetGateRadiusAtAngle(double ang) const override;
 
 private:
-  ControlState CalculateInputShapeRadiusAtAngle(double ang) const;
-
   std::unique_ptr<StickGate> m_stick_gate;
 };
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -13,12 +13,15 @@ namespace ControllerEmu
 class AnalogStick : public ReshapableInput
 {
 public:
+  typedef ReshapeData StateData;
+
   AnalogStick(const char* name, std::unique_ptr<StickGate>&& stick_gate);
   AnalogStick(const char* name, const char* ui_name, std::unique_ptr<StickGate>&& stick_gate);
 
-  StateData GetState(bool adjusted = true) override;
-
+  StateData GetReshapableState(bool adjusted) final override;
   ControlState GetGateRadiusAtAngle(double ang) const override;
+
+  StateData GetState();
 
 private:
   std::unique_ptr<StickGate> m_stick_gate;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -43,7 +43,7 @@ Cursor::Cursor(const std::string& name_)
   boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), false));
 }
 
-ReshapableInput::ReshapeData Cursor::GetReshapableState(bool adjusted)
+Cursor::ReshapeData Cursor::GetReshapableState(bool adjusted)
 {
   const ControlState y = controls[0]->control_ref->State() - controls[1]->control_ref->State();
   const ControlState x = controls[3]->control_ref->State() - controls[2]->control_ref->State();

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -21,7 +21,8 @@
 
 namespace ControllerEmu
 {
-Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor)
+Cursor::Cursor(const std::string& name_)
+    : ReshapableInput(name_, name_, GroupType::Cursor), m_last_update(Clock::now())
 {
   for (auto& named_direction : named_directions)
     controls.emplace_back(std::make_unique<Input>(Translate, named_direction));
@@ -31,89 +32,121 @@ Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Hide")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
 
+  // Default shape is a 1.0 square (no resizing/reshaping):
+  AddReshapingSettings(1.0, 0.5, 50);
+
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 20));
+
   boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), false));
   boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Auto-Hide"), false));
 }
 
+ReshapableInput::ReshapeData Cursor::GetReshapableState(bool adjusted)
+{
+  const ControlState y = controls[0]->control_ref->State() - controls[1]->control_ref->State();
+  const ControlState x = controls[3]->control_ref->State() - controls[2]->control_ref->State();
+
+  // Return raw values. (used in UI)
+  if (!adjusted)
+    return {x, y};
+
+  return Reshape(x, y, 0.0);
+}
+
+ControlState Cursor::GetGateRadiusAtAngle(double ang) const
+{
+  // TODO: Change this to 0.5 and adjust the math,
+  // so pointer doesn't have to be clamped to the configured width/height?
+  return SquareStickGate(1.0).GetRadiusAtAngle(ang);
+}
+
 Cursor::StateData Cursor::GetState(const bool adjusted)
 {
-  const ControlState zz = controls[4]->control_ref->State() - controls[5]->control_ref->State();
+  ControlState z = controls[4]->control_ref->State() - controls[5]->control_ref->State();
 
-  // silly being here
-  if (zz > m_state.z)
-    m_state.z = std::min(m_state.z + 0.1, zz);
-  else if (zz < m_state.z)
-    m_state.z = std::max(m_state.z - 0.1, zz);
-
-  StateData result;
-  result.z = m_state.z;
-
-  if (m_autohide_timer > -1)
+  if (!adjusted)
   {
-    --m_autohide_timer;
+    const auto raw_input = GetReshapableState(false);
+
+    return {raw_input.x, raw_input.y, z};
   }
 
-  ControlState yy = controls[0]->control_ref->State() - controls[1]->control_ref->State();
-  ControlState xx = controls[3]->control_ref->State() - controls[2]->control_ref->State();
+  const auto input = GetReshapableState(true);
 
-  const ControlState deadzone = numeric_settings[3]->GetValue();
+  // TODO: Using system time is ugly.
+  // Kill this after state is moved into wiimote rather than this class.
+  const auto now = Clock::now();
+  const auto ms_since_update =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_update).count();
+  m_last_update = now;
 
-  // reset auto-hide timer
-  if (std::abs(m_prev_xx - xx) > deadzone || std::abs(m_prev_yy - yy) > deadzone)
-  {
-    m_autohide_timer = TIMER_VALUE;
-  }
+  const double max_step = STEP_PER_SEC / 1000.0 * ms_since_update;
+  const double max_z_step = STEP_Z_PER_SEC / 1000.0 * ms_since_update;
 
-  // hide
-  const bool autohide = boolean_settings[1]->GetValue() && m_autohide_timer < 0;
-  if (controls[6]->control_ref->State() > 0.5 || autohide)
+  // Apply deadzone to z:
+  const ControlState deadzone = numeric_settings[SETTING_DEADZONE]->GetValue();
+  z = std::copysign(std::max(0.0, std::abs(z) - deadzone) / (1.0 - deadzone), z);
+
+  // Smooth out z movement:
+  // FYI: Not using relative input for Z.
+  m_state.z += MathUtil::Clamp(z - m_state.z, -max_z_step, max_z_step);
+
+  // Relative input:
+  if (boolean_settings[0]->GetValue())
   {
-    result.x = 10000;
-    result.y = 0;
-  }
-  else
-  {
-    // adjust cursor according to settings
-    if (adjusted)
+    // Recenter:
+    if (controls[7]->control_ref->State() > BUTTON_THRESHOLD)
     {
-      xx *= (numeric_settings[1]->GetValue() * 2);
-      yy *= (numeric_settings[2]->GetValue() * 2);
-      yy += (numeric_settings[0]->GetValue() - 0.5);
-    }
-
-    // relative input
-    if (boolean_settings[0]->GetValue())
-    {
-      // deadzone to avoid the cursor slowly drifting
-      if (std::abs(xx) > deadzone)
-        m_state.x = MathUtil::Clamp(m_state.x + xx * SPEED_MULTIPLIER, -1.0, 1.0);
-      if (std::abs(yy) > deadzone)
-        m_state.y = MathUtil::Clamp(m_state.y + yy * SPEED_MULTIPLIER, -1.0, 1.0);
-
-      // recenter
-      if (controls[7]->control_ref->State() > 0.5)
-      {
-        m_state.x = 0.0;
-        m_state.y = 0.0;
-      }
+      m_state.x = 0.0;
+      m_state.y = 0.0;
     }
     else
     {
-      m_state.x = xx;
-      m_state.y = yy;
+      m_state.x = MathUtil::Clamp(m_state.x + input.x * max_step, -1.0, 1.0);
+      m_state.y = MathUtil::Clamp(m_state.y + input.y * max_step, -1.0, 1.0);
     }
-
-    result.x = m_state.x;
-    result.y = m_state.y;
+  }
+  // Absolute input:
+  else
+  {
+    m_state.x = input.x;
+    m_state.y = input.y;
   }
 
-  m_prev_xx = xx;
-  m_prev_yy = yy;
+  StateData result = m_state;
+
+  // Adjust cursor according to settings:
+  result.x *= (numeric_settings[SETTING_WIDTH]->GetValue() * 2);
+  result.y *= (numeric_settings[SETTING_HEIGHT]->GetValue() * 2);
+  result.y += (numeric_settings[SETTING_CENTER]->GetValue() - 0.5);
+
+  const bool autohide = boolean_settings[1]->GetValue();
+
+  // Auto-hide timer:
+  // TODO: should Z movement reset this?
+  if (!autohide || std::abs(m_prev_result.x - result.x) > AUTO_HIDE_DEADZONE ||
+      std::abs(m_prev_result.y - result.y) > AUTO_HIDE_DEADZONE)
+  {
+    m_auto_hide_timer = AUTO_HIDE_MS;
+  }
+  else if (m_auto_hide_timer)
+  {
+    m_auto_hide_timer -= std::min<int>(ms_since_update, m_auto_hide_timer);
+  }
+
+  m_prev_result = result;
+
+  // If auto-hide time is up or hide button is held:
+  if (!m_auto_hide_timer || controls[6]->control_ref->State() > BUTTON_THRESHOLD)
+  {
+    // TODO: Use NaN or something:
+    result.x = 10000;
+    result.y = 0;
+  }
 
   return result;
 }
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -57,7 +57,7 @@ private:
 
   int m_auto_hide_timer = AUTO_HIDE_MS;
 
-  typedef std::chrono::steady_clock Clock;
+  using Clock = std::chrono::steady_clock;
   Clock::time_point m_last_update;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -4,13 +4,15 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
-#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+
+#include "InputCommon/ControllerEmu/StickGate.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {
-class Cursor : public ControlGroup
+class Cursor : public ReshapableInput
 {
 public:
   struct StateData
@@ -20,22 +22,42 @@ public:
     ControlState z{};
   };
 
+  enum
+  {
+    SETTING_CENTER = ReshapableInput::SETTING_COUNT,
+    SETTING_WIDTH,
+    SETTING_HEIGHT,
+  };
+
   explicit Cursor(const std::string& name);
 
-  StateData GetState(bool adjusted = false);
+  ReshapeData GetReshapableState(bool adjusted) final override;
+  ControlState GetGateRadiusAtAngle(double ang) const override;
+
+  StateData GetState(bool adjusted);
 
 private:
   // This is used to reduce the cursor speed for relative input
   // to something that makes sense with the default range.
-  static constexpr double SPEED_MULTIPLIER = 0.04;
+  static constexpr double STEP_PER_SEC = 0.04 * 200;
 
-  // Sets the length for the auto-hide timer
-  static constexpr int TIMER_VALUE = 500;
+  // Smooth out forward/backward movements:
+  static constexpr double STEP_Z_PER_SEC = 0.05 * 200;
 
+  static constexpr int AUTO_HIDE_MS = 2500;
+  static constexpr double AUTO_HIDE_DEADZONE = 0.001;
+
+  static constexpr double BUTTON_THRESHOLD = 0.5;
+
+  // Not adjusted by width/height/center:
   StateData m_state;
 
-  int m_autohide_timer = TIMER_VALUE;
-  ControlState m_prev_xx;
-  ControlState m_prev_yy;
+  // Adjusted:
+  StateData m_prev_result;
+
+  int m_auto_hide_timer = AUTO_HIDE_MS;
+
+  typedef std::chrono::steady_clock Clock;
+  Clock::time_point m_last_update;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -26,7 +26,7 @@ MixedTriggers::MixedTriggers(const std::string& name_)
 }
 
 void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlState* analog,
-                             bool adjusted)
+                             bool adjusted) const
 {
   const ControlState threshold = numeric_settings[SETTING_THRESHOLD]->GetValue();
   ControlState deadzone = numeric_settings[SETTING_DEADZONE]->GetValue();

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -4,6 +4,7 @@
 
 #include "InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -21,23 +22,53 @@ MixedTriggers::MixedTriggers(const std::string& name_)
     : ControlGroup(name_, GroupType::MixedTriggers)
 {
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Threshold"), 0.9));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0.0, 0, 25));
 }
 
-void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlState* analog)
+void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlState* analog,
+                             bool adjusted)
 {
-  const size_t trigger_count = controls.size() / 2;
+  const ControlState threshold = numeric_settings[SETTING_THRESHOLD]->GetValue();
+  ControlState deadzone = numeric_settings[SETTING_DEADZONE]->GetValue();
 
-  for (size_t i = 0; i < trigger_count; ++i, ++bitmasks, ++analog)
+  // Return raw values. (used in UI)
+  if (!adjusted)
   {
-    if (controls[i]->control_ref->State() > numeric_settings[0]->GetValue())  // threshold
+    deadzone = 0.0;
+  }
+
+  const int trigger_count = int(controls.size() / 2);
+  for (int i = 0; i != trigger_count; ++i)
+  {
+    ControlState button_value = controls[i]->control_ref->State();
+    ControlState analog_value = controls[trigger_count + i]->control_ref->State();
+
+    // Apply deadzone:
+    analog_value = std::max(0.0, analog_value - deadzone) / (1.0 - deadzone);
+    button_value = std::max(0.0, button_value - deadzone) / (1.0 - deadzone);
+
+    // Apply threshold:
+    if (button_value > threshold)
     {
-      *analog = 1.0;
-      *digital |= *bitmasks;
+      // Fully activate analog:
+      analog_value = 1.0;
+
+      // Activate button:
+      *digital |= bitmasks[i];
     }
-    else
-    {
-      *analog = controls[i + trigger_count]->control_ref->State();
-    }
+
+    analog[i] = analog_value;
   }
 }
+
+ControlState MixedTriggers::GetDeadzone() const
+{
+  return numeric_settings[SETTING_DEADZONE]->GetValue();
+}
+
+ControlState MixedTriggers::GetThreshold() const
+{
+  return numeric_settings[SETTING_THRESHOLD]->GetValue();
+}
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
@@ -13,8 +13,17 @@ namespace ControllerEmu
 class MixedTriggers : public ControlGroup
 {
 public:
+  enum
+  {
+    SETTING_THRESHOLD,
+    SETTING_DEADZONE,
+  };
+
   explicit MixedTriggers(const std::string& name);
 
-  void GetState(u16* digital, const u16* bitmasks, ControlState* analog);
+  void GetState(u16* digital, const u16* bitmasks, ControlState* analog, bool adjusted = true);
+
+  ControlState GetDeadzone() const;
+  ControlState GetThreshold() const;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
@@ -13,17 +13,19 @@ namespace ControllerEmu
 class MixedTriggers : public ControlGroup
 {
 public:
+  explicit MixedTriggers(const std::string& name);
+
+  void GetState(u16* digital, const u16* bitmasks, ControlState* analog,
+                bool adjusted = true) const;
+
+  ControlState GetDeadzone() const;
+  ControlState GetThreshold() const;
+
+private:
   enum
   {
     SETTING_THRESHOLD,
     SETTING_DEADZONE,
   };
-
-  explicit MixedTriggers(const std::string& name);
-
-  void GetState(u16* digital, const u16* bitmasks, ControlState* analog, bool adjusted = true);
-
-  ControlState GetDeadzone() const;
-  ControlState GetThreshold() const;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
@@ -22,7 +22,6 @@ namespace ControllerEmu
 ModifySettingsButton::ModifySettingsButton(std::string button_name)
     : Buttons(std::move(button_name))
 {
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Threshold"), 0.5));
 }
 
 void ModifySettingsButton::AddInput(std::string button_name, bool toggle)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -37,7 +37,7 @@ Tilt::Tilt(const std::string& name_)
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Angle"), 0.9, 0, 180));
 }
 
-Tilt::StateData Tilt::GetReshapableState(bool adjusted)
+Tilt::ReshapeData Tilt::GetReshapableState(bool adjusted)
 {
   const ControlState y = controls[0]->control_ref->State() - controls[1]->control_ref->State();
   const ControlState x = controls[3]->control_ref->State() - controls[2]->control_ref->State();

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -15,26 +15,26 @@ namespace ControllerEmu
 class Tilt : public ReshapableInput
 {
 public:
-  typedef ReshapeData StateData;
-
-  enum
-  {
-    SETTING_MAX_ANGLE = ReshapableInput::SETTING_COUNT,
-  };
+  using StateData = ReshapeData;
 
   explicit Tilt(const std::string& name);
 
-  StateData GetReshapableState(bool adjusted) final override;
+  ReshapeData GetReshapableState(bool adjusted) final override;
   ControlState GetGateRadiusAtAngle(double ang) const override;
 
   StateData GetState();
 
 private:
+  enum
+  {
+    SETTING_MAX_ANGLE = ReshapableInput::SETTING_COUNT,
+  };
+
   static constexpr int MAX_DEG_PER_SEC = 360 * 6;
 
   StateData m_tilt;
 
-  typedef std::chrono::steady_clock Clock;
+  using Clock = std::chrono::steady_clock;
   Clock::time_point m_last_update;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -4,26 +4,32 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
-#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+
+#include "InputCommon/ControllerEmu/StickGate.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {
-class Tilt : public ControlGroup
+class Tilt : public ReshapableInput
 {
 public:
-  struct StateData
+  enum
   {
-    ControlState x{};
-    ControlState y{};
+    SETTING_MAX_ANGLE = ReshapableInput::SETTING_COUNT,
   };
 
   explicit Tilt(const std::string& name);
 
-  StateData GetState(bool step = true);
+  StateData GetState(bool adjusted = true);
+
+  ControlState GetGateRadiusAtAngle(double ang) const override;
 
 private:
+  typedef std::chrono::steady_clock Clock;
+
   StateData m_tilt;
+  Clock::time_point m_last_update;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -15,6 +15,8 @@ namespace ControllerEmu
 class Tilt : public ReshapableInput
 {
 public:
+  typedef ReshapeData StateData;
+
   enum
   {
     SETTING_MAX_ANGLE = ReshapableInput::SETTING_COUNT,
@@ -22,14 +24,17 @@ public:
 
   explicit Tilt(const std::string& name);
 
-  StateData GetState(bool adjusted = true);
-
+  StateData GetReshapableState(bool adjusted) final override;
   ControlState GetGateRadiusAtAngle(double ang) const override;
 
+  StateData GetState();
+
 private:
-  typedef std::chrono::steady_clock Clock;
+  static constexpr int MAX_DEG_PER_SEC = 360 * 6;
 
   StateData m_tilt;
+
+  typedef std::chrono::steady_clock Clock;
   Clock::time_point m_last_update;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -6,7 +6,9 @@
 
 #include <cmath>
 
+#include "Common/Common.h"
 #include "Common/MathUtil.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {
@@ -42,6 +44,92 @@ ControlState SquareStickGate::GetRadiusAtAngle(double ang) const
 {
   constexpr double section_ang = MathUtil::TAU / 4;
   return m_half_width / std::cos(std::fmod(ang + section_ang / 2, section_ang) - section_ang / 2);
+}
+
+ReshapableInput::ReshapableInput(std::string name, std::string ui_name, GroupType type)
+    : ControlGroup(std::move(name), std::move(ui_name), type)
+{
+}
+
+ControlState ReshapableInput::GetDeadzoneRadiusAtAngle(double ang) const
+{
+  return CalculateInputShapeRadiusAtAngle(ang) * numeric_settings[SETTING_DEADZONE]->GetValue();
+}
+
+ControlState ReshapableInput::GetInputRadiusAtAngle(double ang) const
+{
+  const ControlState radius =
+      CalculateInputShapeRadiusAtAngle(ang) * numeric_settings[SETTING_INPUT_RADIUS]->GetValue();
+  // Clamp within the -1 to +1 square as input radius may be greater than 1.0:
+  return std::min(radius, SquareStickGate(1).GetRadiusAtAngle(ang));
+}
+
+void ReshapableInput::AddReshapingSettings(ControlState default_radius, ControlState default_shape,
+                                           int max_deadzone)
+{
+  // Allow radius greater than 1.0 for definitions of rounded squares
+  // This is ideal for Xbox controllers (and probably others)
+  numeric_settings.emplace_back(
+      std::make_unique<NumericSetting>(_trans("Input Radius"), default_radius, 0, 140));
+  numeric_settings.emplace_back(
+      std::make_unique<NumericSetting>(_trans("Input Shape"), default_shape, 0, 50));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
+}
+
+ReshapableInput::StateData ReshapableInput::Reshape(ControlState x, ControlState y,
+                                                    ControlState modifier)
+{
+  // TODO: make the AtAngle functions work with negative angles:
+  const ControlState ang = std::atan2(y, x) + MathUtil::TAU;
+
+  const ControlState gate_max_dist = GetGateRadiusAtAngle(ang);
+  const ControlState input_max_dist = GetInputRadiusAtAngle(ang);
+
+  // If input radius is zero we apply no scaling.
+  // This is useful when mapping native controllers without knowing intimate radius details.
+  const ControlState max_dist = input_max_dist ? input_max_dist : gate_max_dist;
+
+  ControlState dist = std::sqrt(x * x + y * y) / max_dist;
+
+  // If the modifier is pressed, scale the distance by the modifier's value.
+  // This is affected by the modifier's "range" setting which defaults to 50%.
+  if (modifier)
+  {
+    // TODO: Modifier's range setting gets reset to 100% when the clear button is clicked.
+    // This causes the modifier to not behave how a user might suspect.
+    // Retaining the old scale-by-50% behavior until range is fixed to clear to 50%.
+    dist *= 0.5;
+    // dist *= modifier;
+  }
+
+  // Apply deadzone as a percentage of the user-defined radius/shape:
+  const ControlState deadzone = GetDeadzoneRadiusAtAngle(ang);
+  dist = std::max(0.0, dist - deadzone) / (1.0 - deadzone);
+
+  // Scale to the gate shape/radius:
+  dist = dist *= gate_max_dist;
+
+  x = MathUtil::Clamp(std::cos(ang) * dist, -1.0, 1.0);
+  y = MathUtil::Clamp(std::sin(ang) * dist, -1.0, 1.0);
+  return {x, y};
+}
+
+ControlState ReshapableInput::CalculateInputShapeRadiusAtAngle(double ang) const
+{
+  const auto shape = numeric_settings[SETTING_INPUT_SHAPE]->GetValue() * 4.0;
+
+  if (shape < 1.0)
+  {
+    // Between 0 and 25 return a shape between octagon and circle
+    const auto amt = shape;
+    return OctagonStickGate(1).GetRadiusAtAngle(ang) * (1 - amt) + amt;
+  }
+  else
+  {
+    // Between 25 and 50 return a shape between circle and square
+    const auto amt = shape - 1.0;
+    return (1 - amt) + SquareStickGate(1).GetRadiusAtAngle(ang) * amt;
+  }
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -76,8 +76,8 @@ void ReshapableInput::AddReshapingSettings(ControlState default_radius, ControlS
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
-ReshapableInput::StateData ReshapableInput::Reshape(ControlState x, ControlState y,
-                                                    ControlState modifier)
+ReshapableInput::ReshapeData ReshapableInput::Reshape(ControlState x, ControlState y,
+                                                      ControlState modifier)
 {
   // TODO: make the AtAngle functions work with negative angles:
   const ControlState ang = std::atan2(y, x) + MathUtil::TAU;

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 
 namespace ControllerEmu
 {
@@ -50,6 +51,42 @@ public:
 
 private:
   const ControlState m_half_width;
+};
+
+class ReshapableInput : public ControlGroup
+{
+public:
+  ReshapableInput(std::string name, std::string ui_name, GroupType type);
+
+  struct StateData
+  {
+    ControlState x{};
+    ControlState y{};
+  };
+
+  enum
+  {
+    SETTING_INPUT_RADIUS,
+    SETTING_INPUT_SHAPE,
+    SETTING_DEADZONE,
+    SETTING_COUNT,
+  };
+
+  // Angle is in radians and should be non-negative
+  ControlState GetDeadzoneRadiusAtAngle(double ang) const;
+  ControlState GetInputRadiusAtAngle(double ang) const;
+
+  virtual ControlState GetGateRadiusAtAngle(double ang) const = 0;
+  virtual StateData GetState(bool adjusted = true) = 0;
+
+protected:
+  void AddReshapingSettings(ControlState default_radius, ControlState default_shape,
+                            int max_deadzone);
+
+  StateData Reshape(ControlState x, ControlState y, ControlState modifier = 0.0);
+
+private:
+  ControlState CalculateInputShapeRadiusAtAngle(double ang) const;
 };
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -58,7 +58,7 @@ class ReshapableInput : public ControlGroup
 public:
   ReshapableInput(std::string name, std::string ui_name, GroupType type);
 
-  struct StateData
+  struct ReshapeData
   {
     ControlState x{};
     ControlState y{};
@@ -77,13 +77,13 @@ public:
   ControlState GetInputRadiusAtAngle(double ang) const;
 
   virtual ControlState GetGateRadiusAtAngle(double ang) const = 0;
-  virtual StateData GetState(bool adjusted = true) = 0;
+  virtual ReshapeData GetReshapableState(bool adjusted) = 0;
 
 protected:
   void AddReshapingSettings(ControlState default_radius, ControlState default_shape,
                             int max_deadzone);
 
-  StateData Reshape(ControlState x, ControlState y, ControlState modifier = 0.0);
+  ReshapeData Reshape(ControlState x, ControlState y, ControlState modifier = 0.0);
 
 private:
   ControlState CalculateInputShapeRadiusAtAngle(double ang) const;


### PR DESCRIPTION
Demonstrations:
Cursor: https://i.imgur.com/JVnSP5m.gif
MixedTriggers: https://i.imgur.com/0I2FcZr.gif
Tilt: https://i.imgur.com/sRkIoJB.gif

Made the "MixedTriggers" mapping indicator styling match that of the analog sticks.
Reordered groups in wiimote extension mapping dialogs for better fits.
Added "Dead Zone" setting to "MixedTriggers".
Made "Tilt" mappings use the new stick reshaping code and eliminated the old mysterious "circle stick" option.
Removed an extra "Threshold" setting from the wiimote hotkeys button group.
Made wiimote "Cursor" mappings use stick reshaping and made the indicator super pretty.
Circular cursor inputs in absolute mode are now usable.
I also made relative cursor mode obey the center/width/height settings.

This fixes issues:
https://bugs.dolphin-emu.org/issues/3937
https://bugs.dolphin-emu.org/issues/7730
https://bugs.dolphin-emu.org/issues/9908
https://bugs.dolphin-emu.org/issues/11019 (partially)