### PR TITLE
ControllerEmu: Killed the button group threshold setting.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -26,6 +26,7 @@
 #include "DolphinQt/Settings.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/Device.h"
@@ -81,7 +82,7 @@ MappingButton::MappingButton(MappingWidget* widget, ControlReference* ref, bool 
     QFont f = m_parent->font();
     QPalette p = m_parent->palette();
 
-    if (state != 0)
+    if (state > ControllerEmu::Buttons::ACTIVATION_THRESHOLD)
     {
       f.setBold(true);
       p.setColor(QPalette::ButtonText, Qt::red);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.cpp
@@ -19,6 +19,6 @@ Buttons::Buttons(const std::string& name_) : Buttons(name_, name_)
 Buttons::Buttons(const std::string& ini_name, const std::string& group_name)
     : ControlGroup(ini_name, group_name, GroupType::Buttons)
 {
-  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Threshold"), 0.5));
 }
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
@@ -24,11 +24,13 @@ public:
   {
     for (auto& control : controls)
     {
-      if (control->control_ref->State() > numeric_settings[0]->GetValue())  // threshold
+      if (control->control_ref->State() > ACTIVATION_THRESHOLD)
         *buttons |= *bitmasks;
 
       bitmasks++;
     }
   }
+
+  static constexpr ControlState ACTIVATION_THRESHOLD = 0.5;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
@@ -42,14 +42,14 @@ void ModifySettingsButton::GetState()
     if (!associated_settings_toggle[i])
     {
       // not toggled
-      associated_settings[i] = state > numeric_settings[0]->GetValue();
+      associated_settings[i] = state > ACTIVATION_THRESHOLD;
     }
     else
     {
       // toggle (loading savestates does not en-/disable toggle)
       // after we passed the threshold, we en-/disable. but after that, we don't change it
       // anymore
-      if (!threshold_exceeded[i] && state > numeric_settings[0]->GetValue())
+      if (!threshold_exceeded[i] && state > ACTIVATION_THRESHOLD)
       {
         associated_settings[i] = !associated_settings[i];
 
@@ -61,7 +61,7 @@ void ModifySettingsButton::GetState()
         threshold_exceeded[i] = true;
       }
 
-      if (state < numeric_settings[0]->GetValue())
+      if (state < ACTIVATION_THRESHOLD)
         threshold_exceeded[i] = false;
     }
   }


### PR DESCRIPTION
I've removed the "Threshold" setting from button groups and hard-coded it to 50%.
Why?

- It clutters up the mapping dialogs a lot, especially the hotkeys dialog.
- Isn't this nicer? https://i.imgur.com/G5qupLf.png
- It does absolutely nothing when mapping a digital button which is the case 99% of the time.
- People probably don't even know what it does (the Qt mapping indicator wasn't even using it).
- The only time it was useful was mapping analog sticks to directional buttons and desiring to tweak the amount of analog movement required.
- You can still accomplish the same thing by adjusting the "Range" sliders in the right-click menu.
- Or in my expression-parser-improve PR you can use the greater-than sign: `` `Button`>'0.4' ``

I've also made the red button indicators use the threshold to accurately show activation.