### PR TITLE
ControllerInterface: Shutdown order and race condition fix.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -56,7 +56,7 @@ public:
 private:
   std::vector<std::function<void()>> m_devices_changed_callbacks;
   mutable std::mutex m_callbacks_mutex;
-  bool m_is_init;
+  std::atomic<bool> m_is_init;
   std::atomic<bool> m_is_populating_devices{false};
   WindowSystemInfo m_wsi;
 };


### PR DESCRIPTION
Invoke the "devices changed callbacks" after emptying the Device list and before shutting down the input backends to prevent `shared_ptr<Device>`s from living beyond backend shutdown.
- This fixes a crash on shutdown when using SDL and I'm surprised the other backends put up with this.

Prevent hotplug threads from adding devices during shutdown after clearing the list. Unlikely but possible.

This fixes issue: https://bugs.dolphin-emu.org/issues/11399