### PR TITLE
UICommon/ResourcePack: Fix packs without manifests crashing Dolphin

### DIFF
--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -54,7 +54,11 @@ bool Init()
   {
     const auto& path = pack_list[i];
 
-    error |= !Add(path);
+    if (!Add(path))
+    {
+      error = true;
+      continue;
+    }
 
     order->Set(packs[i].GetManifest()->GetID(), static_cast<u64>(i));
   }
@@ -106,6 +110,9 @@ bool Add(const std::string& path, int offset)
     offset = static_cast<int>(packs.size());
 
   ResourcePack pack(path);
+
+  if (!pack.IsValid())
+    return false;
 
   IniFile file = GetPackConfig();
 


### PR DESCRIPTION
Fix resource packs without manifests being able to crash dolphin