### PR TITLE
Qt/Debugger: Code and Memory widget new features / fixes

### DIFF
--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -390,11 +390,11 @@ std::string GekkoDisassembler::fd_ra_rb(u32 in, int mask)
   if (mask)
   {
     if (mask & 4)
-      result += StringFromFormat("f%d,", (int)PPCGETD(in));
+      result += StringFromFormat("f%d, ", (int)PPCGETD(in));
     if (mask & 2)
-      result += StringFromFormat("%s,", regnames[(int)PPCGETA(in)]);
+      result += StringFromFormat("%s, ", regnames[(int)PPCGETA(in)]);
     if (mask & 1)
-      result += StringFromFormat("%s,", regnames[(int)PPCGETB(in)]);
+      result += StringFromFormat("%s, ", regnames[(int)PPCGETB(in)]);
 
     // Drop the trailing comma
     result.pop_back();
@@ -905,25 +905,22 @@ void GekkoDisassembler::fdabc(u32 in, const char* name, int mask, unsigned char 
 
   m_flags |= dmode;
   m_opcode = StringFromFormat("f%s%s", name, rcsel[in & 1]);
-  m_operands += StringFromFormat("f%d,", (int)PPCGETD(in));
+  m_operands += StringFromFormat("f%d", (int)PPCGETD(in));
 
   if (mask & 4)
-    m_operands += StringFromFormat("f%d,", (int)PPCGETA(in));
+    m_operands += StringFromFormat(", f%d", (int)PPCGETA(in));
   else if ((mask & 8) == 0)
     err |= (int)PPCGETA(in);
 
   if (mask & 2)
-    m_operands += StringFromFormat("f%d,", (int)PPCGETC(in));
+    m_operands += StringFromFormat(", f%d", (int)PPCGETC(in));
   else if (PPCGETC(in) && (mask & 8) == 0)
     err |= (int)PPCGETC(in);
 
   if (mask & 1)
-    m_operands += StringFromFormat("f%d,", (int)PPCGETB(in));
+    m_operands += StringFromFormat(", f%d", (int)PPCGETB(in));
   else if (!(mask & 8))
     err |= (int)PPCGETB(in);
-
-  // Drop the trailing comma
-  m_operands.pop_back();
 
   if (err)
     ill(in);
@@ -952,7 +949,7 @@ void GekkoDisassembler::fcmp(u32 in, char c)
   {
     m_opcode = StringFromFormat("fcmp%c", c);
     m_operands =
-        StringFromFormat("cr%d,f%d,f%d", (int)PPCGETCRD(in), (int)PPCGETA(in), (int)PPCGETB(in));
+        StringFromFormat("cr%d, f%d, f%d", (int)PPCGETCRD(in), (int)PPCGETA(in), (int)PPCGETB(in));
   }
 }
 
@@ -1026,7 +1023,7 @@ void GekkoDisassembler::ps(u32 inst)
   {
   case 6:
     m_opcode = inst & 0x40 ? "psq_lux" : "psq_lx";
-    m_operands = StringFromFormat("p%u, (r%u + r%u), %d, qr%d", FD, RA, RB, WX, IX);
+    m_operands = StringFromFormat("p%u, r%u, r%u, %d, qr%d", FD, RA, RB, WX, IX);
     return;
 
   case 7:
@@ -1158,22 +1155,22 @@ void GekkoDisassembler::ps(u32 inst)
   }
   case 528:
     m_opcode = "ps_merge00";
-    m_operands = StringFromFormat("p%u, p%u[0],p%u[0]", FD, FA, FB);
+    m_operands = StringFromFormat("p%u, p%u[0], p%u[0]", FD, FA, FB);
     return;
 
   case 560:
     m_opcode = "ps_merge01";
-    m_operands = StringFromFormat("p%u, p%u[0],p%u[1]", FD, FA, FB);
+    m_operands = StringFromFormat("p%u, p%u[0], p%u[1]", FD, FA, FB);
     return;
 
   case 592:
     m_opcode = "ps_merge10";
-    m_operands = StringFromFormat("p%u, p%u[1],p%u[0]", FD, FA, FB);
+    m_operands = StringFromFormat("p%u, p%u[1], p%u[0]", FD, FA, FB);
     return;
 
   case 624:
     m_opcode = "ps_merge11";
-    m_operands = StringFromFormat("p%u, p%u[1],p%u[1]", FD, FA, FB);
+    m_operands = StringFromFormat("p%u, p%u[1], p%u[1]", FD, FA, FB);
     return;
 
   case 1014:
@@ -1195,23 +1192,26 @@ void GekkoDisassembler::ps_mem(u32 inst)
   {
   case 56:
     m_opcode = "psq_l";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
 
   case 57:
     m_opcode = "psq_lu";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
-    ;
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
 
   case 60:
     m_opcode = "psq_st";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
 
   case 61:
     m_opcode = "psq_stu";
-    m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
+    m_operands =
+        StringFromFormat("p%u, %s (r%u), %d, qr%d", RS, psq_offs(inst & 0xfff).c_str(), RA, W, I);
     break;
   }
 }

--- a/Source/Core/Common/GekkoDisassembler.h
+++ b/Source/Core/Common/GekkoDisassembler.h
@@ -128,7 +128,25 @@ private:
     }
   }
 
-  static int SEX12(u32 x) { return x & 0x800 ? (x | 0xFFFFF000) : x; }
+  static std::string psq_offs(u32 val)
+  {
+    if (val == 0)
+    {
+      return "0";
+    }
+    else
+    {
+      if (val & 0x800)
+      {
+        return StringFromFormat("-0x%.4X", ((~val) & 0xfff) + 1);
+      }
+      else
+      {
+        return StringFromFormat("0x%.4X", val);
+      }
+    }
+  }
+
   enum InstructionType
   {
     PPCINSTR_OTHER = 0,   // No additional info for other instr.

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -81,6 +81,11 @@ bool GetCallstack(std::vector<CallstackEntry>& output)
   }
 
   CallstackEntry entry;
+
+  entry.Name = StringFromFormat(" * %s [ PC = %08x ]\n", g_symbolDB.GetDescription(PC).c_str(), PC);
+  entry.vAddress = PC;
+  output.push_back(entry);
+
   entry.Name =
       StringFromFormat(" * %s [ LR = %08x ]\n", g_symbolDB.GetDescription(LR).c_str(), LR - 4);
   entry.vAddress = LR - 4;

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -76,6 +76,7 @@ public:
   void RunToBreakpoint() override;
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
+  u32 GetMemoryAddressFromInstruction(std::string instruction);
 
   void Clear() override;
 

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -77,6 +77,8 @@ add_executable(dolphin-emu
   Config/PropertiesDialog.cpp
   Config/SettingsWindow.cpp
   Debugger/BreakpointWidget.cpp
+	Debugger/CodeTraceDialog.cpp
+	Debugger/CodeDiffDialog.cpp
   Debugger/CodeViewWidget.cpp
   Debugger/CodeWidget.cpp
   Debugger/JITWidget.cpp

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.cpp
@@ -1,0 +1,363 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Debugger/CodeDiffDialog.h"
+
+#include <chrono>
+#include <regex>
+#include <vector>
+
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMenu>
+#include <QVBoxLayout>
+#include <QtWidgets/QListWidget>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QSpacerItem>
+
+#include "Common/StringUtil.h"
+#include "Core/Core.h"
+#include "Core/Debugger/PPCDebugInterface.h"
+#include "Core/HW/CPU.h"
+#include "Core/PowerPC/JitInterface.h"
+#include "Core/PowerPC/MMU.h"
+#include "Core/PowerPC/PPCSymbolDB.h"
+#include "Core/PowerPC/PowerPC.h"
+#include "Core/PowerPC/Profiler.h"
+#include "DolphinQt/Host.h"
+#include "DolphinQt/Settings.h"
+
+#include "DolphinQt/Debugger/CodeWidget.h"
+
+CodeDiffDialog::CodeDiffDialog(CodeWidget* parent) : QDialog(parent), m_code_widget(parent)
+{
+  setWindowTitle(tr("Diff"));
+  CreateWidgets();
+  ConnectWidgets();
+  InfoDisp();
+}
+
+void CodeDiffDialog::reject()
+{
+  // Triggered on window close. Make sure to free memory and reset info message.
+  ClearData();
+  InfoDisp(); 
+  auto& settings = Settings::GetQSettings();
+  settings.setValue(QStringLiteral("diffdialog/geometry"), saveGeometry());
+  QDialog::reject();
+}
+
+void CodeDiffDialog::CreateWidgets()
+{
+  auto& settings = Settings::GetQSettings();
+  restoreGeometry(settings.value(QStringLiteral("diffdialog/geometry")).toByteArray());
+  auto* btns_layout = new QGridLayout;
+  m_exclude_btn = new QPushButton(tr("Code did not get executed"));
+  m_include_btn = new QPushButton(tr("Code has been executed"));
+  m_record_btn = new QPushButton(tr("Record functions"));
+  m_record_btn->setCheckable(true);
+  m_record_btn->setStyleSheet(
+      QStringLiteral("QPushButton:checked { background-color: rgb(150, 0, 0); border-style: solid; "
+                     "border-width: 3px; border-color: rgb(150,0,0); color: rgb(255, 255, 255);}"));
+
+  btns_layout->addWidget(m_exclude_btn, 0, 0);
+  btns_layout->addWidget(m_include_btn, 0, 1);
+  btns_layout->addWidget(m_record_btn, 0, 2);
+
+  auto* labels_layout = new QHBoxLayout;
+  m_exclude_size_label = new QLabel(tr("Excluded"));
+  m_include_size_label = new QLabel(tr("Included"));
+
+  btns_layout->addWidget(m_exclude_size_label, 1, 0);
+  btns_layout->addWidget(m_include_size_label, 1, 1);
+
+  m_output_list = new QListWidget();
+  m_output_list->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  m_output_list->setContextMenuPolicy(Qt::CustomContextMenu);
+  m_reset_btn = new QPushButton(tr("Reset All"));
+  m_reset_btn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+  auto* layout = new QVBoxLayout();
+  layout->addLayout(btns_layout);
+  layout->addLayout(labels_layout);
+  layout->addWidget(m_output_list);
+  layout->addWidget(m_reset_btn);
+
+  setLayout(layout);
+}
+
+void CodeDiffDialog::ConnectWidgets()
+{
+  connect(m_record_btn, &QPushButton::toggled, this, &CodeDiffDialog::OnRecord);
+  connect(m_include_btn, &QPushButton::pressed, [this]() { Update(true); });
+  connect(m_exclude_btn, &QPushButton::pressed, [this]() { Update(false); });
+  connect(m_output_list, &QListWidget::itemClicked, [this](QListWidgetItem* item) {
+    m_code_widget->SetAddress(item->data(Qt::UserRole).toUInt(),
+                              CodeViewWidget::SetAddressUpdate::WithUpdate);
+  });
+  connect(m_reset_btn, &QPushButton::pressed, this, &CodeDiffDialog::ClearData);
+  connect(m_output_list, &CodeDiffDialog::customContextMenuRequested, this,
+          &CodeDiffDialog::OnContextMenu);
+}
+
+void CodeDiffDialog::ClearData()
+{
+  if (m_record_btn->isChecked())
+    m_record_btn->toggle();
+  ClearBlockCache();
+  m_output_list->clear();
+  std::vector<Diff>().swap(m_include);
+  std::vector<Diff>().swap(m_exclude);
+  JitInterface::SetProfilingState(JitInterface::ProfilingState::Disabled);
+}
+
+void CodeDiffDialog::ClearBlockCache()
+{
+  Core::State old_state = Core::GetState();
+
+  if (old_state == Core::State::Running)
+    Core::SetState(Core::State::Paused);
+
+  JitInterface::ClearCache();
+
+  if (old_state == Core::State::Running)
+    Core::SetState(Core::State::Running);
+}
+
+void CodeDiffDialog::OnRecord(bool enabled)
+{
+  JitInterface::ProfilingState state;
+
+  if (enabled)
+  {
+    ClearBlockCache();
+    m_record_btn->setText(tr("Recording..."));
+    state = JitInterface::ProfilingState::Enabled;
+  }
+  else
+  {
+    ClearBlockCache();
+    m_record_btn->setText(tr("Start Recording"));
+    state = JitInterface::ProfilingState::Disabled;
+  }
+
+  m_record_btn->update();
+  JitInterface::SetProfilingState(state);
+}
+
+void CodeDiffDialog::OnIncludeExclude(bool include)
+{
+  bool isize = m_include.size() != 0;
+  bool xsize = m_exclude.size() != 0;
+  std::vector<Diff> current_diff;
+  Profiler::ProfileStats prof_stats;
+  auto& blockstats = prof_stats.block_stats;
+  JitInterface::GetProfileResults(&prof_stats);
+  std::vector<Diff> current;
+  current.reserve(20000);
+
+  // Convert blockstats to smaller struct Diff. Exclude repeat functions via symbols.
+  for (auto& iter : blockstats)
+  {
+    Diff tmp_diff;
+    std::string symbol = g_symbolDB.GetDescription(iter.addr);
+    if (!std::any_of(current.begin(), current.end(),
+                     [&symbol](Diff& v) { return v.symbol == symbol; }))
+    {
+      tmp_diff.symbol = symbol;
+      tmp_diff.addr = iter.addr;
+      tmp_diff.hits = iter.run_count;
+      current.push_back(tmp_diff);
+    }
+  }
+
+  // Could add address based difference instead of symbols. Probably need second function.
+  // Sort for lower_bound.
+  sort(current.begin(), current.end(),
+       [](const Diff& v1, const Diff& v2) { return (v1.symbol < v2.symbol); });
+
+  // If both lists are empty, write and skip.
+  if (!isize && !xsize)
+  {
+    if (include)
+      m_include = current;
+    else
+      m_exclude = current;
+    return;
+  }
+
+  // Update exclude list. Compare to exclude list if it exists and make current_diff to check
+  // against include.
+  if (!xsize && !include)
+  {
+    m_exclude = current;
+  }
+  else if (xsize)
+  {
+    for (auto& iter : current)
+    {
+      auto pos = lower_bound(m_exclude.begin(), m_exclude.end(), iter.symbol, AddrOP);
+
+      if (pos->symbol != iter.symbol)
+      {
+        current_diff.push_back(iter);
+
+        if (!include)
+          m_exclude.insert(pos, iter);
+      }
+    }
+    // If there is no include list, we're done.
+    if (!include && !isize)
+      return;
+  }
+  else
+  {
+    current_diff = current;
+  }
+
+  // Update include list.
+  if (include && isize)
+  {
+    // Compare include with current and remove items that aren't in both.
+    std::vector<Diff> tmp_swap;
+    for (auto& iter : m_include)
+    {
+      if (std::any_of(current_diff.begin(), current_diff.end(),
+                      [&](Diff& v) { return v.symbol == iter.symbol; }))
+        tmp_swap.push_back(iter);
+    }
+    m_include.swap(tmp_swap);
+  }
+  else if ((!isize && include) || (!xsize && !include))
+  {
+    // If both lists are about to be filled for the first time, compare full lists and remove from
+    // include list.
+    if (include)
+      m_include = current;
+
+    for (auto& list : m_exclude)
+    {
+      m_include.erase(std::remove_if(m_include.begin(), m_include.end(),
+                                     [&](Diff const& v) { return v.symbol == list.symbol; }),
+                      m_include.end());
+    }
+  }
+  else
+  {
+    // If exclude pressed, remove new exclude items from include list that match.
+    for (auto& list : current_diff)
+    {
+      m_include.erase(std::remove_if(m_include.begin(), m_include.end(),
+                                     [&](Diff& v) { return v.symbol == list.symbol; }),
+                      m_include.end());
+    }
+  }
+}
+
+void CodeDiffDialog::Update(bool include)
+{
+  // Wrap everything in a pause
+  Core::State old_state = Core::GetState();
+  if (old_state == Core::State::Running)
+    Core::SetState(Core::State::Paused);
+
+  // Main process
+  OnIncludeExclude(include);
+
+  m_output_list->clear();
+
+  new QListWidgetItem(tr("Address\tHits\tSymbol"), m_output_list);
+
+  for (auto& iter : m_include)
+  {
+    QString fix_sym = QString::fromStdString(iter.symbol);
+    fix_sym.replace(QStringLiteral("\t"), QStringLiteral("  "));
+
+    QString tmp_out =
+        QString::fromStdString(StringFromFormat("%08x\t%i\t", iter.addr, iter.hits)) + fix_sym;
+
+    auto* item = new QListWidgetItem(tmp_out, m_output_list);
+    item->setData(Qt::UserRole, iter.addr);
+
+    m_output_list->addItem(item);
+  }
+  m_exclude_size_label->setText(QString::number(m_exclude.size()));
+  m_include_size_label->setText(QString::number(m_include.size()));
+
+  JitInterface::ClearCache();
+  if (old_state == Core::State::Running)
+    Core::SetState(Core::State::Running);
+}
+
+void CodeDiffDialog::InfoDisp()
+{
+  new QListWidgetItem(
+      QStringLiteral(
+          "Used to find functions based on when they should be running.\n\nRecord Functions: will "
+          "keep track of what functions run. Stop and restart to reset current "
+          "recording.\nExclude: will add recorded functions to an excluded "
+          "list, then reset the recording list.\nInclude: will add"
+          "recorded function to an include list, then reset the recording list.\nAfter you use "
+          "both "
+          "exclude and include once, the "
+          "exclude list will be subtracted\n   from the include list and any includes left over "
+          "will "
+          "be displayed.\nYou can continue to use include/exclude to narrow down the "
+          "results.\n\nExample: "
+          "You want to find a function that runs when HP is modified.\n1.  Start recording and "
+          "play "
+          "the game without letting HP be modified, then press exclude.\n2.  Immediately "
+          "gain/lose HP and hit include.\n3.  Repeat 1 or 2 to narrow down the results.\nIncludes "
+          "should "
+          "have short recordings focusing on what you want.\nAlso note, pressing include multiple "
+          "times will never increase the include list's size.\n   Pressing include twice will only "
+          "keep functions that ran for both recordings.\n\nRight click -> blr will attempt to skip "
+          "the function by placing a blr at the top of the symbol."),
+      m_output_list);
+}
+
+void CodeDiffDialog::OnContextMenu()
+{
+  QMenu* menu = new QMenu(this);
+  menu->addAction(tr("&Go to start of function"), this, &CodeDiffDialog::OnGoTop);
+  menu->addAction(tr("Toggle &blr"), this, &CodeDiffDialog::OnToggleBLR);
+  menu->addAction(tr("&Delete"), this, &CodeDiffDialog::OnDelete);
+  menu->exec(QCursor::pos());
+}
+
+void CodeDiffDialog::OnGoTop()
+{
+  auto item = m_output_list->currentItem();
+  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(item->data(Qt::UserRole).toUInt());
+  m_code_widget->SetAddress(symbol->address, CodeViewWidget::SetAddressUpdate::WithUpdate);
+}
+
+void CodeDiffDialog::OnDelete()
+{
+  // Delete from include and listwidget.
+  int remove_item = m_output_list->row(m_output_list->currentItem());
+  m_include.erase(m_include.begin() + remove_item - 1);
+  m_output_list->takeItem(remove_item);
+}
+
+void CodeDiffDialog::OnToggleBLR()
+{
+  // Get address at top of function (hopefully) and blr it.
+  auto item = m_output_list->currentItem();
+  Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(item->data(Qt::UserRole).toUInt());
+
+  PowerPC::debug_interface.UnsetPatch(symbol->address);
+
+  if (PowerPC::HostRead_U32(symbol->address) != 0x4e800020)
+  {
+    PowerPC::debug_interface.SetPatch(symbol->address, 0x4e800020);
+    item->setForeground(QBrush(Qt::red));
+    m_code_widget->Update();
+  }
+  else
+  {
+    item->setForeground(QBrush(Qt::black));
+  }
+}

--- a/Source/Core/DolphinQt/Debugger/CodeDiffDialog.h
+++ b/Source/Core/DolphinQt/Debugger/CodeDiffDialog.h
@@ -1,0 +1,65 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include "Common/CommonTypes.h"
+#include "Core/PowerPC/Profiler.h"
+
+class CodeWidget;
+class QCheckBox;
+class QLabel;
+class QListWidget;
+
+struct Diff
+{
+  u32 addr;
+  std::string symbol;
+  u32 hits;
+};
+
+class CodeDiffDialog : public QDialog
+{
+  Q_OBJECT
+
+  struct _AddrOp
+  {
+    bool operator()(const Diff& iter, const std::string& val) const { return iter.symbol < val; }
+  } AddrOP;
+
+public:
+  explicit CodeDiffDialog(CodeWidget* parent);
+  void reject() override;
+
+private:
+  void CreateWidgets();
+  void ConnectWidgets();
+  void ClearData();
+  void ClearBlockCache();
+  void OnRecord(bool enabled);
+  void OnIncludeExclude(bool include);
+  void Update(bool include);
+  void InfoDisp();
+
+  void OnContextMenu();
+
+  void OnGoTop();
+  void OnDelete();
+  void OnToggleBLR();
+
+  QListWidget* m_output_list;
+  QLabel* m_exclude_size_label;
+  QLabel* m_current_size_label;
+  QLabel* m_include_size_label;
+  QPushButton* m_exclude_btn;
+  QPushButton* m_include_btn;
+  QPushButton* m_record_btn;
+  QPushButton* m_reset_btn;
+  CodeWidget* m_code_widget;
+
+  std::vector<Diff> m_exclude;
+  std::vector<Diff> m_include;
+};

--- a/Source/Core/DolphinQt/Debugger/CodeTraceDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeTraceDialog.cpp
@@ -1,0 +1,682 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Debugger/CodeTraceDialog.h"
+
+#include <chrono>
+#include <regex>
+#include <vector>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QClipboard>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMenu>
+#include <QVBoxLayout>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QListWidget>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QSpacerItem>
+
+#include "Common/StringUtil.h"
+#include "Core/Debugger/PPCDebugInterface.h"
+#include "Core/HW/CPU.h"
+#include "Core/PowerPC/MMU.h"
+#include "Core/PowerPC/PPCSymbolDB.h"
+#include "Core/PowerPC/PowerPC.h"
+#include "DolphinQt/Host.h"
+#include "DolphinQt/Settings.h"
+
+#include "DolphinQt/Debugger/CodeWidget.h"
+
+constexpr int ADDRESS_ROLE = Qt::UserRole;
+constexpr int MEM_ADDRESS_ROLE = Qt::UserRole + 1;
+
+CodeTraceDialog::CodeTraceDialog(CodeWidget* parent) : QDialog(parent), m_parent(parent)
+{
+  setWindowTitle(tr("Trace"));
+  CreateWidgets();
+  ConnectWidgets();
+  UpdateBreakpoints();
+}
+
+void CodeTraceDialog::reject()
+{
+  // Make sure to free memory and reset info message.
+  ClearAll();
+  auto& settings = Settings::GetQSettings();
+  settings.setValue(QStringLiteral("tracedialog/geometry"), saveGeometry());
+  QDialog::reject();
+}
+
+void CodeTraceDialog::CreateWidgets()
+{  
+  auto& settings = Settings::GetQSettings();
+  restoreGeometry(settings.value(QStringLiteral("tracedialog/geometry")).toByteArray());
+  auto* input_layout = new QHBoxLayout;
+  m_trace_target = new QLineEdit();
+  m_trace_target->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+  m_trace_target->setPlaceholderText(tr("Register or Mem Address"));
+  m_bp1 = new QComboBox();
+  m_bp1->setEditable(true);
+  m_bp1->setCurrentText(tr("Uses PC as trace starting point."));
+  m_bp1->setDisabled(true);
+  m_bp2 = new QComboBox();
+  m_bp2->setEditable(true);
+  m_bp2->setCurrentText(tr("Stop BP or address"));
+
+  input_layout->addWidget(m_trace_target);
+  input_layout->addWidget(m_bp1);
+  input_layout->addWidget(m_bp2);
+
+  auto* boxes_layout = new QHBoxLayout;
+  m_backtrace = new QCheckBox(tr("BackTrace"));
+  m_verbose = new QCheckBox(tr("Verbose"));
+  m_clear_on_loop = new QCheckBox(tr("Reset on loopback"));
+  m_change_range = new QCheckBox(tr("Change Range"));
+  m_sizes = new QLabel();
+
+  m_reprocess = new QPushButton(tr("Reprocess"));
+  m_run_trace = new QPushButton(tr("Run Trace"));
+  m_run_trace->setCheckable(true);
+
+  boxes_layout->addWidget(m_backtrace);
+  boxes_layout->addWidget(m_verbose);
+  boxes_layout->addWidget(m_clear_on_loop);
+  boxes_layout->addWidget(m_change_range);
+  boxes_layout->addWidget(m_reprocess);
+
+  boxes_layout->addWidget(m_sizes);
+
+  boxes_layout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Maximum));
+  boxes_layout->addWidget(m_run_trace);
+
+  m_output_list = new QListWidget();
+  m_output_list->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+  QFont font(QStringLiteral("Monospace"));
+  font.setStyleHint(QFont::TypeWriter);
+  m_output_list->setFont(font);
+  m_output_list->setContextMenuPolicy(Qt::CustomContextMenu);
+
+  auto* layout = new QVBoxLayout();
+  layout->addLayout(input_layout);
+  layout->addLayout(boxes_layout);
+  layout->addWidget(m_output_list);
+
+  InfoDisp();
+
+  setLayout(layout);
+}
+
+void CodeTraceDialog::ConnectWidgets()
+{
+  connect(m_parent, &CodeWidget::BreakpointsChanged, this, &CodeTraceDialog::UpdateBreakpoints);
+  connect(m_run_trace, &QPushButton::toggled, this, &CodeTraceDialog::OnRunTrace);
+  connect(m_reprocess, &QPushButton::pressed, this, &CodeTraceDialog::DisplayTrace);
+  connect(m_output_list, &QListWidget::itemClicked, m_parent, [this](QListWidgetItem* item) {
+    m_parent->SetAddress(item->data(ADDRESS_ROLE).toUInt(),
+                         CodeViewWidget::SetAddressUpdate::WithUpdate);
+  });
+  connect(m_output_list, &CodeTraceDialog::customContextMenuRequested, this,
+          &CodeTraceDialog::OnContextMenu);
+}
+
+void CodeTraceDialog::ClearAll()
+{
+  std::vector<CodeTrace>().swap(m_code_trace);
+  std::vector<TraceOutput>().swap(m_trace_out);
+  m_reg.clear();
+  m_mem.clear();
+  m_output_list->clear();
+  m_bp1->setDisabled(true);
+  m_bp1->setCurrentText(tr("Uses PC as trace starting point."));
+  UpdateBreakpoints();
+  InfoDisp();
+}
+
+void CodeTraceDialog::OnRunTrace(bool checked)
+{
+  if (!checked)
+  {
+    m_run_trace->setText(tr("Run Trace"));
+    ClearAll();
+    return;
+  }
+
+  m_run_trace->setText(tr("Reset All"));
+  m_code_trace.clear();
+  m_code_trace.reserve(m_max_code_trace);
+
+  if (!CPU::IsStepping())
+    return;
+
+  CPU::PauseAndLock(true, false);
+  PowerPC::breakpoints.ClearAllTemporary();
+
+  // Keep stepping until the end_bp or timeout after five seconds
+  using clock = std::chrono::steady_clock;
+  clock::time_point timeout = clock::now() + std::chrono::seconds(10);
+  PowerPC::CoreMode old_mode = PowerPC::GetMode();
+  PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
+
+  // Try to get end_bp based on editable input text, then on combo box selection.
+  bool good;
+  u32 end_bp = m_bp2->currentText().toUInt(&good, 16);
+  if (!good)
+    end_bp = m_bp2->currentData().toUInt(&good);
+  if (!good)
+    return;
+
+  u32 start_bp = PC;
+
+  UGeckoInstruction inst = PowerPC::HostRead_Instruction(PC);
+  SaveInstruction();
+  do
+  {
+    PowerPC::SingleStep();
+    SaveInstruction();
+
+    if (PC == start_bp && m_clear_on_loop->isChecked())
+      m_code_trace.clear();
+
+  } while (clock::now() < timeout && PC != end_bp && m_code_trace.size() < m_max_code_trace);
+
+  if (clock::now() >= timeout)
+    m_error_msg = tr("Trace timed out. Backtrace won't be correct.");
+
+  PowerPC::SetMode(old_mode);
+  CPU::PauseAndLock(false, false);
+
+  // Is this needed?
+  emit Host::GetInstance()->UpdateDisasmDialog();
+
+  // Record actual start and end into combo boxes.
+  m_bp1->setDisabled(false);
+  m_bp1->clear();
+  QString instr = QString::fromStdString(PowerPC::debug_interface.Disassemble(start_bp));
+  instr.replace(QStringLiteral("\t"), QStringLiteral(" "));
+  m_bp1->addItem(
+      QStringLiteral("Trace Begin   %1 : %2").arg(start_bp, 8, 16, QLatin1Char('0')).arg(instr),
+      start_bp);
+
+  instr = QString::fromStdString(PowerPC::debug_interface.Disassemble(PC));
+  instr.replace(QStringLiteral("\t"), QStringLiteral(" "));
+  m_bp2->insertItem(
+      0, QStringLiteral("Trace End   %1 : %2").arg(PC, 8, 16, QLatin1Char('0')).arg(instr), PC);
+  m_bp2->setCurrentIndex(0);
+
+  CodeTraceDialog::DisplayTrace();
+}
+
+void CodeTraceDialog::SaveInstruction()
+{
+  if (m_code_trace.size() >= m_max_code_trace)
+    return;
+
+  CodeTrace tmp_trace;
+  std::string tmp = PowerPC::debug_interface.Disassemble(PC);
+  tmp_trace.instruction = tmp;
+  std::regex replace_sp("(\\W)sp");
+  std::regex replace_rtoc("rtoc");
+  std::regex replace_ps("(\\W)p(\\d+)");
+  tmp = std::regex_replace(tmp, replace_sp, "$1r1");
+  tmp = std::regex_replace(tmp, replace_rtoc, "r2");
+  tmp = std::regex_replace(tmp, replace_ps, "$1f$2");
+  tmp_trace.address = PC;
+
+  // Pull all register numbers out and store them. Limited to Reg0 if ps operation, as ps get
+  // too complicated to track easily.
+  std::regex regis("\\W([rfp]\\d+)[^r^f]*(?:([rf]\\d+))?[^r^f\\d]*(?:([rf]\\d+))?");
+  std::smatch match;
+
+  // ex: add r4, r5, r6 -> Reg0, Reg1, Reg2. Reg0 is always the target register.
+  if (std::regex_search(tmp, match, regis))
+  {
+    tmp_trace.reg0 = match.str(1);
+    if (match[2].matched)
+      tmp_trace.reg1 = match.str(2);
+    if (match[3].matched)
+      tmp_trace.reg2 = match.str(3);
+
+    // Get Memory Destination if load/store. The only instructions that start with L are load and
+    // load immediate li/lis (excluded).
+    if (tmp.compare(0, 2, "st") == 0 || tmp.compare(0, 5, "psq_s") == 0)
+    {
+      tmp_trace.memory_dest = PowerPC::debug_interface.GetMemoryAddressFromInstruction(tmp);
+      tmp_trace.is_store = true;
+    }
+    else if ((tmp.compare(0, 1, "l") == 0 && tmp.compare(1, 1, "i") != 0) ||
+             tmp.compare(0, 5, "psq_l") == 0)
+    {
+      tmp_trace.memory_dest = PowerPC::debug_interface.GetMemoryAddressFromInstruction(tmp);
+      tmp_trace.is_load = true;
+    }
+  }
+
+  m_code_trace.push_back(tmp_trace);
+}
+
+void CodeTraceDialog::ForwardTrace()
+{
+  std::vector<std::string> exclude{"dc", "ic", "mt", "c", "fc"};
+  TraceOutput tmp_out;
+  bool first_hit = true;
+
+  trace_itr_pair p = UpdateIterator();
+  auto begin_itr = p.first;
+  auto end_itr = p.second;
+
+  for (auto instr = begin_itr; instr != end_itr; instr++)
+  {
+    // Not an instruction we care about (branches).
+    if (instr->reg0.empty())
+      continue;
+
+    auto itR = std::find(m_reg.begin(), m_reg.end(), instr->reg0);
+    auto itM = std::find(m_mem.begin(), m_mem.end(), instr->memory_dest);
+    const bool match_reg12 =
+        (std::find(m_reg.begin(), m_reg.end(), instr->reg1) != m_reg.end() &&
+         !instr->reg1.empty()) ||
+        (std::find(m_reg.begin(), m_reg.end(), instr->reg2) != m_reg.end() && !instr->reg2.empty());
+    const bool match_reg0 = (itR != m_reg.end());
+
+    // Exclude a few instruction types, such as compares
+    bool hold_continue = false;
+    for (auto& s : exclude)
+    {
+      if (instr->instruction.compare(0, s.length(), s) == 0)
+        hold_continue = true;
+    }
+
+    if (!m_verbose->isChecked())
+    {
+      if (hold_continue)
+        continue;
+
+      // Output only where tracked items move to.
+      if ((match_reg0 && instr->is_store) || (itM != m_mem.end() && instr->is_load) || match_reg12)
+      {
+        tmp_out.instruction = instr->instruction;
+        tmp_out.mem_addr = instr->memory_dest;
+        tmp_out.address = instr->address;
+        m_trace_out.push_back(tmp_out);
+      }
+    }
+    else if (match_reg12 || match_reg0 || itM != m_mem.end())
+    {
+      // Output all uses of tracked item.
+      tmp_out.instruction = instr->instruction;
+      tmp_out.mem_addr = instr->memory_dest;
+      tmp_out.address = instr->address;
+      m_trace_out.push_back(tmp_out);
+
+      if (hold_continue)
+        continue;
+    }
+
+    // Update tracking logic.
+    // Save/Load
+    if (instr->memory_dest)
+    {
+      // If using tracked memory. Add register to tracked if Load. Remove tracked memory if
+      // overwritten with a store.
+      if (itM != m_mem.end())
+      {
+        if (instr->is_load && !match_reg0)
+          m_reg.push_back(instr->reg0);
+        else if (instr->is_store && !match_reg0)
+          m_mem.erase(itM);
+      }
+      else if (instr->is_store && match_reg0)
+      {
+        // If store but not using tracked memory & if storing tracked register, track memory
+        // location too.
+        m_mem.push_back(instr->memory_dest);
+      }
+      else if (instr->is_load && match_reg0 && !first_hit)
+      {
+        m_reg.erase(itR);
+      }
+    }
+    else
+    {
+      // Other instructions
+      // Skip if no matches. Happens most often.
+      if (!match_reg0 && !match_reg12)
+        continue;
+      // If tracked register data is being stored in a new register, save new register.
+      else if (match_reg12 && !match_reg0)
+        m_reg.push_back(instr->reg0);
+      // If tracked register is overwritten, stop tracking.
+      else if (match_reg0 && !match_reg12 && !first_hit)
+        m_reg.erase(itR);
+    }
+
+    // First hit will likely be start of value we want to track - not the end. So don't remove itR.
+    if (match_reg0 || (match_reg12 && !match_reg0))
+      first_hit = false;
+
+    if ((m_reg.empty() && m_mem.empty()) || m_trace_out.size() >= m_max_trace)
+      break;
+  }
+}
+
+void CodeTraceDialog::Backtrace()
+{
+  std::vector<std::string> exclude{"dc", "ic", "mt", "c", "fc"};
+  TraceOutput tmp_out;
+
+  trace_itr_pair p = UpdateIterator();
+  auto begin_itr = p.first;
+  auto end_itr = p.second;
+
+  for (auto instr = end_itr; instr != begin_itr; instr--)
+  {
+    // Not an instruction we care about
+    if (instr->reg0.empty())
+      continue;
+
+    auto itR = std::find(m_reg.begin(), m_reg.end(), instr->reg0);
+    auto itM = std::find(m_mem.begin(), m_mem.end(), instr->memory_dest);
+    const bool match_reg1 =
+        (std::find(m_reg.begin(), m_reg.end(), instr->reg1) != m_reg.end() && !instr->reg1.empty());
+    const bool match_reg2 =
+        (std::find(m_reg.begin(), m_reg.end(), instr->reg2) != m_reg.end() && !instr->reg2.empty());
+    const bool match_reg0 = (itR != m_reg.end());
+
+    // Exclude a few instruction types, such as compares
+    bool hold_continue = false;
+    for (auto& s : exclude)
+    {
+      if (instr->instruction.compare(0, s.length(), s) == 0)
+        hold_continue = true;
+    }
+
+    // Write instructions to output.
+    if (!m_verbose->isChecked())
+    {
+      if (hold_continue)
+        continue;
+
+      // Output only where tracked items came from.
+      if ((match_reg0 && !instr->is_store) || (itM != m_mem.end() && instr->is_store))
+      {
+        tmp_out.instruction = instr->instruction;
+        tmp_out.mem_addr = instr->memory_dest;
+        tmp_out.address = instr->address;
+        m_trace_out.push_back(tmp_out);
+      }
+    }
+    else if ((match_reg1 || match_reg2 || match_reg0 || itM != m_mem.end()))
+    {
+      // Output stuff like compares if they contain a tracked register
+      tmp_out.instruction = instr->instruction;
+      tmp_out.mem_addr = instr->memory_dest;
+      tmp_out.address = instr->address;
+      m_trace_out.push_back(tmp_out);
+
+      if (hold_continue)
+        continue;
+    }
+
+    // Update Trace Logic.
+    // Store/Load
+    if (instr->memory_dest)
+    {
+      // Backtrace: what wrote to tracked memory & remove memory track. Else if: what loaded to
+      // tracked register & remove register from track.
+      if (itM != m_mem.end())
+      {
+        if (instr->is_store && !match_reg0)
+        {
+          m_reg.push_back(instr->reg0);
+          m_mem.erase(itM);
+        }
+      }
+      else if (instr->is_load && match_reg0)
+      {
+        m_mem.push_back(instr->memory_dest);
+        m_reg.erase(itR);
+      }
+    }
+    else
+    {
+      // Other instructions
+      // Skip if we aren't watching output register. Happens most often.
+      // Else: Erase tracked register and save what wrote to it.
+      if (!match_reg0)
+        continue;
+      else if (!match_reg1 && !match_reg2)
+        m_reg.erase(itR);
+
+      // If tracked register is written, track r1 / r2.
+      if (!match_reg1 && !instr->reg1.empty())
+        m_reg.push_back(instr->reg1);
+      if (!match_reg2 && !instr->reg2.empty())
+        m_reg.push_back(instr->reg2);
+    }
+
+    // Stop if we run out of things to track
+    if ((m_reg.empty() && m_mem.empty()) || m_trace_out.size() >= m_max_trace)
+      break;
+  }
+}
+
+void CodeTraceDialog::CodePath()
+{
+  // Shows entire trace without filtering if target input is blank.
+  trace_itr_pair p = UpdateIterator();
+  auto begin_itr = p.first;
+  auto end_itr = p.second;
+
+  TraceOutput tmp_out;
+  if (m_backtrace->isChecked())
+  {
+    for (auto instr = end_itr - 1; instr != begin_itr && m_trace_out.size() < m_max_trace; instr--)
+    {
+      tmp_out.instruction = instr->instruction;
+      tmp_out.mem_addr = instr->memory_dest;
+      tmp_out.address = instr->address;
+      m_trace_out.push_back(tmp_out);
+    }
+  }
+  else
+  {
+    for (auto instr = begin_itr; instr != end_itr && m_trace_out.size() < m_max_trace; instr++)
+    {
+      tmp_out.instruction = instr->instruction;
+      tmp_out.mem_addr = instr->memory_dest;
+      tmp_out.address = instr->address;
+      m_trace_out.push_back(tmp_out);
+    }
+  }
+}
+
+void CodeTraceDialog::DisplayTrace()
+{
+  m_trace_out.clear();
+  m_reg.clear();
+  m_mem.clear();
+  m_output_list->clear();
+  m_trace_out.reserve(m_max_trace);
+
+  // Errors
+  if (!m_error_msg.isEmpty())
+  {
+    new QListWidgetItem(m_error_msg, m_output_list);
+    m_error_msg.clear();
+  }
+  if (m_code_trace.size() >= m_max_code_trace)
+    new QListWidgetItem(tr("Trace max limit reached, backtrace won't work."), m_output_list);
+
+  // Setup register to track.
+  if (!m_trace_target->text().isEmpty())
+  {
+    QString reg_tmp = m_trace_target->text();
+    reg_tmp.replace(QStringLiteral("sp"), QStringLiteral("r1"), Qt::CaseInsensitive);
+    reg_tmp.replace(QStringLiteral("rtoc"), QStringLiteral("r2"), Qt::CaseInsensitive);
+    m_reg.push_back(reg_tmp.toStdString());
+  }
+
+  if (m_trace_target->text().isEmpty())
+    CodePath();
+  else if (m_backtrace->isChecked())
+    Backtrace();
+  else
+    ForwardTrace();
+
+  if (m_trace_out.size() >= m_max_trace)
+    new QListWidgetItem(tr("Max output size reached, stopped early"), m_output_list);
+
+  m_sizes->setText(QStringLiteral("Trace: %1, List: %2")
+                       .arg(QString::number(m_code_trace.size()))
+                       .arg(QString::number(m_trace_out.size())));
+
+  // Cleanup and prepare output, then send to Qlistwidget.
+  std::regex reg("(\\S*)\\s+(?:(\\S{0,6})\\s*)?(?:(\\S{0,8})\\s*)?(?:(\\S{0,8})\\s*)?(.*)");
+  std::smatch match;
+  std::string is_mem;
+
+  for (auto out : m_trace_out)
+  {
+    QString fix_sym = QString::fromStdString(g_symbolDB.GetDescription(out.address));
+    fix_sym.replace(QStringLiteral("\t"), QStringLiteral("  "));
+
+    std::regex_search(out.instruction, match, reg);
+
+    if (out.mem_addr)
+      is_mem = StringFromFormat("%x", out.mem_addr);
+    else
+      is_mem = match.str(5);
+
+    auto* item = new QListWidgetItem(
+        QString::fromStdString(StringFromFormat(
+            "%08x : %-11s%-6s%-8s%-8s%-18s", out.address, match.str(1).c_str(),
+            match.str(2).c_str(), match.str(3).c_str(), match.str(4).c_str(), is_mem.c_str())) +
+        fix_sym);
+
+    item->setData(ADDRESS_ROLE, out.address);
+    if (out.mem_addr)
+      item->setData(MEM_ADDRESS_ROLE, out.mem_addr);
+    m_output_list->addItem(item);
+  }
+}
+
+trace_itr_pair CodeTraceDialog::UpdateIterator()
+{
+  // If the range is changed for reprocessing, this will change the iterator accordingly.
+  auto begin_itr = m_code_trace.begin();
+  auto end_itr = m_code_trace.end();
+
+  if (m_change_range->isChecked())
+  {
+    bool good;
+    u32 start = m_bp1->currentText().toUInt(&good, 16);
+    if (!good)
+      start = m_bp1->currentData().toUInt(&good);
+    if (!good)
+      return std::make_pair(begin_itr, end_itr);
+
+    u32 end = m_bp2->currentText().toUInt(&good, 16);
+    if (!good)
+      end = m_bp2->currentData().toUInt(&good);
+    if (!good)
+      return std::make_pair(begin_itr, end_itr);
+
+    begin_itr = find_if(m_code_trace.begin(), m_code_trace.end(),
+                        [start](const CodeTrace& t) { return t.address == start; });
+    end_itr = find_if(m_code_trace.rbegin(), m_code_trace.rend(),
+                      [end](const CodeTrace& t) { return t.address == end; })
+                  .base();
+  }
+  return std::make_pair(begin_itr, end_itr);
+}
+
+void CodeTraceDialog::UpdateBreakpoints()
+{
+  if (m_run_trace->isChecked())
+  {
+    for (int i = m_bp2->count(); i > 1; i--)
+      m_bp2->removeItem(1);
+    for (int i = m_bp1->count(); i > 1; i--)
+      m_bp1->removeItem(1);
+  }
+  else
+  {
+    m_bp2->clear();
+  }
+
+  auto bp_vec = PowerPC::breakpoints.GetBreakPoints();
+
+  for (auto& i : bp_vec)
+  {
+    QString instr = QString::fromStdString(PowerPC::debug_interface.Disassemble(i.address));
+    instr.replace(QStringLiteral("\t"), QStringLiteral(" "));
+    if (m_run_trace->isChecked())
+    {
+      m_bp1->addItem(QStringLiteral("%1 : %2").arg(i.address, 8, 16, QLatin1Char('0')).arg(instr),
+                     i.address);
+    }
+    m_bp2->addItem(QStringLiteral("%1 : %2").arg(i.address, 8, 16, QLatin1Char('0')).arg(instr),
+                   i.address);
+  }
+}
+
+void CodeTraceDialog::InfoDisp()
+{
+  new QListWidgetItem(
+      QStringLiteral(
+          "Used to track a register or memory address and its uses.\nInputs:\nRegister: Input "
+          "example "
+          "r5, f31, use f for ps regusters..\n    Only takes one value at a time. Leave Blank "
+          "to "
+          "view complete "
+          "code path. \n\nStarting Address: "
+          "Used to change range for reprocessing. Run Trace's starting address is always the PC\n "
+          "   (the current instruction while paused)."
+          "Can change when reprocessing.\n\nEnding breakpoint: "
+          "Where "
+          "the trace will stop. If backtracing, should be the line you want to backtrace "
+          "from.\n\nBacktrace: A reverse trace that shows where a value came from, the first "
+          "output "
+          "line "
+          "is the most recent executed.\n    Backtracing = off will show where a "
+          "tracked "
+          "item "
+          "is going "
+          "after the starting point.\n\nVerbose: Will record all references to what is being "
+          "tracked, rather than just where it is moving to/from.\n\nReset on loopback: Will clear "
+          "the "
+          "trace "
+          "if starting address is looped through.\n    Insuring only the final loop to the end "
+          "breakpoint is recorded.\n\nChange Range: Change the start and end points of the trace "
+          "during reprocessing. Loops may make certain points buggy\n\nReprocess: You don't have "
+          "to "
+          "run a trace multiple times if "
+          "the "
+          "first trace covered the area of code you need.\nYou can change any value or option "
+          "and "
+          "do a "
+          "retrace. Changing the second "
+          "breakpoint\n   "
+          "will let you backtrace from a new location."),
+      m_output_list);
+}
+
+void CodeTraceDialog::OnContextMenu()
+{
+  QMenu* menu = new QMenu(this);
+  menu->addAction(tr("Copy &address"), this, [this]() {
+    const u32 addr = m_output_list->currentItem()->data(ADDRESS_ROLE).toUInt();
+    QApplication::clipboard()->setText(QStringLiteral("%1").arg(addr, 8, 16, QLatin1Char('0')));
+  });
+  menu->addAction(tr("Copy &memory address"), this, [this]() {
+    const u32 addr = m_output_list->currentItem()->data(MEM_ADDRESS_ROLE).toUInt();
+    QApplication::clipboard()->setText(QStringLiteral("%1").arg(addr, 8, 16, QLatin1Char('0')));
+  });
+  menu->exec(QCursor::pos());
+}

--- a/Source/Core/DolphinQt/Debugger/CodeTraceDialog.h
+++ b/Source/Core/DolphinQt/Debugger/CodeTraceDialog.h
@@ -1,0 +1,86 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include "Common/CommonTypes.h"
+
+class CodeWidget;
+class QCheckBox;
+class QLineEdit;
+class QLabel;
+class QComboBox;
+class QListWidget;
+class QListWidgetItem;
+
+struct CodeTrace
+{
+  u32 address = 0;
+  std::string instruction = "";
+  std::string reg0 = "";
+  std::string reg1 = "";
+  std::string reg2 = "";
+  u32 memory_dest = 0;
+  bool is_store = false;
+  bool is_load = false;
+};
+
+struct TraceOutput
+{
+  u32 address;
+  u32 mem_addr = 0;
+  std::string instruction;
+};
+
+typedef std::pair<std::vector<CodeTrace>::iterator, std::vector<CodeTrace>::iterator>
+    trace_itr_pair;
+
+class CodeTraceDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit CodeTraceDialog(CodeWidget* parent);
+
+  void reject() override;
+
+private:
+  void CreateWidgets();
+  void ConnectWidgets();
+  void ClearAll();
+  void OnRunTrace(bool checked);
+  void SaveInstruction();
+  void ForwardTrace();
+  void Backtrace();
+  void CodePath();
+  void DisplayTrace();
+  trace_itr_pair UpdateIterator();
+  void UpdateBreakpoints();
+  void InfoDisp();
+
+  void OnContextMenu();
+
+  QListWidget* m_output_list;
+  QLineEdit* m_trace_target;
+  QComboBox* m_bp1;
+  QComboBox* m_bp2;
+  QCheckBox* m_backtrace;
+  QCheckBox* m_verbose;
+  QCheckBox* m_clear_on_loop;
+  QCheckBox* m_change_range;
+  QLabel* m_sizes;
+  QPushButton* m_reprocess;
+  QPushButton* m_run_trace;
+  CodeWidget* m_parent;
+
+  std::vector<CodeTrace> m_code_trace;
+  std::vector<TraceOutput> m_trace_out;
+  std::vector<std::string> m_reg;
+  std::vector<u32> m_mem;
+  // Make modifiable?
+  const size_t m_max_code_trace = 150000;
+  const size_t m_max_trace = 2000;
+  QString m_error_msg;
+};

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -30,6 +30,7 @@ public:
   u32 GetContextAddress() const;
   void SetAddress(u32 address, SetAddressUpdate update);
 
+  void FontBasedSizing();
   void Update();
 
   void ToggleBreakpoint();

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -48,6 +48,8 @@ private:
     NOP
   };
 
+  bool IsInstructionLoadStore(std::string instruction);
+
   void ReplaceAddress(u32 address, ReplaceWith replace);
 
   void resizeEvent(QResizeEvent*) override;
@@ -63,6 +65,8 @@ private:
   void OnCopyFunction();
   void OnCopyCode();
   void OnCopyHex();
+  void OnCopyTargetAddress();
+  void OnBreakpointTargetAddress();
   void OnRenameSymbol();
   void OnSelectionChanged();
   void OnSetSymbolSize();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -10,6 +10,7 @@
 #include <QGroupBox>
 #include <QLineEdit>
 #include <QListWidget>
+#include <QPushButton>
 #include <QSplitter>
 #include <QTableWidget>
 #include <QWidget>
@@ -90,6 +91,8 @@ void CodeWidget::CreateWidgets()
 
   m_search_address = new QLineEdit;
   m_search_symbols = new QLineEdit;
+  m_code_trace = new QPushButton(tr("Trace"));
+  m_code_diff = new QPushButton(tr("Diff"));
   m_code_view = new CodeViewWidget;
 
   m_search_address->setPlaceholderText(tr("Search Address"));
@@ -141,6 +144,8 @@ void CodeWidget::CreateWidgets()
 
   layout->addWidget(m_search_address, 0, 0);
   layout->addWidget(m_search_symbols, 0, 1);
+  layout->addWidget(m_code_trace, 0, 2);
+  layout->addWidget(m_code_diff, 0, 3);
   layout->addWidget(m_code_splitter, 1, 0, -1, -1);
 
   QWidget* widget = new QWidget(this);
@@ -152,7 +157,8 @@ void CodeWidget::ConnectWidgets()
 {
   connect(m_search_address, &QLineEdit::textChanged, this, &CodeWidget::OnSearchAddress);
   connect(m_search_symbols, &QLineEdit::textChanged, this, &CodeWidget::OnSearchSymbols);
-
+  connect(m_code_trace, &QPushButton::pressed, this, &CodeWidget::OnTrace);
+  connect(m_code_diff, &QPushButton::pressed, this, &CodeWidget::OnDiff);
   connect(m_symbols_list, &QListWidget::itemClicked, this, &CodeWidget::OnSelectSymbol);
   connect(m_callstack_list, &QListWidget::itemSelectionChanged, this,
           &CodeWidget::OnSelectCallstack);
@@ -168,6 +174,26 @@ void CodeWidget::ConnectWidgets()
   connect(m_code_view, &CodeViewWidget::RequestPPCComparison, this,
           &CodeWidget::RequestPPCComparison);
   connect(m_code_view, &CodeViewWidget::ShowMemory, this, &CodeWidget::ShowMemory);
+}
+
+void CodeWidget::OnTrace()
+{
+  if (!trace_dialog)
+    trace_dialog = new CodeTraceDialog(this);
+  trace_dialog->setWindowFlag(Qt::WindowMinimizeButtonHint);
+  trace_dialog->show();
+  trace_dialog->raise();
+  trace_dialog->activateWindow();
+}
+
+void CodeWidget::OnDiff()
+{
+  if (!diff_dialog)
+    diff_dialog = new CodeDiffDialog(this);
+  diff_dialog->setWindowFlag(Qt::WindowMinimizeButtonHint);
+  diff_dialog->show();
+  diff_dialog->raise();
+  diff_dialog->activateWindow();
 }
 
 void CodeWidget::OnSearchAddress()

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -66,6 +66,7 @@ private:
   void OnSelectFunctionCalls();
 
   void closeEvent(QCloseEvent*) override;
+  bool eventFilter(QObject* obj, QEvent* event);
 
   CodeTraceDialog* trace_dialog = nullptr;
   CodeDiffDialog* diff_dialog = nullptr;

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -8,6 +8,8 @@
 #include <QString>
 
 #include "Common/CommonTypes.h"
+#include "DolphinQt/Debugger/CodeDiffDialog.h"
+#include "DolphinQt/Debugger/CodeTraceDialog.h"
 #include "DolphinQt/Debugger/CodeViewWidget.h"
 
 class QCloseEvent;
@@ -15,6 +17,7 @@ class QLineEdit;
 class QSplitter;
 class QListWidget;
 class QTableWidget;
+class QPushButton;
 
 namespace Common
 {
@@ -35,6 +38,8 @@ public:
   void ShowPC();
   void SetPC();
 
+  void OnTrace();
+  void OnDiff();
   void ToggleBreakpoint();
   void AddBreakpoint();
   void SetAddress(u32 address, CodeViewWidget::SetAddressUpdate update);
@@ -62,9 +67,12 @@ private:
 
   void closeEvent(QCloseEvent*) override;
 
+  CodeTraceDialog* trace_dialog = nullptr;
+  CodeDiffDialog* diff_dialog = nullptr;
   QLineEdit* m_search_address;
   QLineEdit* m_search_symbols;
-
+  QPushButton* m_code_trace;
+  QPushButton* m_code_diff;
   QListWidget* m_callstack_list;
   QListWidget* m_symbols_list;
   QListWidget* m_function_calls_list;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -61,12 +61,15 @@ static int GetColumnCount(MemoryViewWidget::Type type)
 {
   switch (type)
   {
-  case MemoryViewWidget::Type::ASCII:
+  case MemoryViewWidget::Type::U32xASCII:
+  case MemoryViewWidget::Type::U32xFloat32:
+    return 2;
   case MemoryViewWidget::Type::U8:
     return 16;
   case MemoryViewWidget::Type::U16:
     return 8;
   case MemoryViewWidget::Type::U32:
+  case MemoryViewWidget::Type::ASCII:
   case MemoryViewWidget::Type::Float32:
     return 4;
   default:
@@ -94,7 +97,9 @@ void MemoryViewWidget::Update()
   {
     setRowHeight(i, 24);
 
-    u32 addr = m_address - ((rowCount() / 2) * 16) + i * 16;
+    // Two column mode has rows increment by 0x4 instead of 0x10
+    u32 rowmod = ((GetColumnCount(m_type) == 2) ? 4 : 16);
+    u32 addr = m_address - (rowCount() / 2) * rowmod + i * rowmod;
 
     auto* bp_item = new QTableWidgetItem;
     bp_item->setFlags(Qt::ItemIsEnabled);
@@ -128,13 +133,17 @@ void MemoryViewWidget::Update()
     bool row_breakpoint = true;
 
     auto update_values = [&](auto value_to_string) {
-      for (int c = 0; c < GetColumnCount(m_type); c++)
+      const int columns = GetColumnCount(m_type);
+      for (int c = 0; c < columns; c++)
       {
         auto* hex_item = new QTableWidgetItem;
         hex_item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-        const u32 address = addr + c * (16 / GetColumnCount(m_type));
+        u32 address = addr + c * (16 / columns);
 
-        if (PowerPC::memchecks.OverlapsMemcheck(address, 16 / GetColumnCount(m_type)))
+        // Alternate view requires two columns with the same address
+        if (columns == 2)
+          address = addr;
+        if (PowerPC::memchecks.OverlapsMemcheck(address, 16 / ((columns == 2) ? 4 : columns)))
           hex_item->setBackground(Qt::red);
         else
           row_breakpoint = false;
@@ -143,7 +152,17 @@ void MemoryViewWidget::Update()
 
         if (PowerPC::HostIsRAMAddress(address))
         {
-          hex_item->setText(value_to_string(address));
+          // 2 Column mode: Report hex value in first column.
+          if (columns == 2 && c == 0)
+          {
+            hex_item->setText(
+                QStringLiteral("%1").arg(PowerPC::HostRead_U32(address), 8, 16, QLatin1Char('0')));
+          }
+          else
+          {
+            hex_item->setText(value_to_string(address));
+          }
+
           hex_item->setData(Qt::UserRole, address);
         }
         else
@@ -163,9 +182,16 @@ void MemoryViewWidget::Update()
       });
       break;
     case Type::ASCII:
+    case Type::U32xASCII:
       update_values([](u32 address) {
-        const char value = PowerPC::HostRead_U8(address);
-        return std::isprint(value) ? QString{QChar::fromLatin1(value)} : QStringLiteral(".");
+        QString asciistring = QStringLiteral("");
+        // Group ASCII in sets of four.
+        for (u32 i = 0; i < 4; i++)
+        {
+          char value = PowerPC::HostRead_U8(address + i);
+          asciistring.append(std::isprint(value) ? QChar::fromLatin1(value) : QStringLiteral("."));
+        }
+        return asciistring;
       });
       break;
     case Type::U16:
@@ -181,6 +207,7 @@ void MemoryViewWidget::Update()
       });
       break;
     case Type::Float32:
+    case Type::U32xFloat32:
       update_values([](u32 address) { return QString::number(PowerPC::HostRead_F32(address)); });
       break;
     }
@@ -275,8 +302,9 @@ void MemoryViewWidget::ToggleRowBreakpoint(bool row)
 {
   TMemCheck check;
 
-  const u32 addr = row ? GetContextAddress() & 0xFFFFFFF0 : GetContextAddress();
-  const auto length = row ? 16 : (16 / GetColumnCount(m_type));
+  const u32 addr = row ? GetContextAddress() & 0xFFFFFFFC : GetContextAddress();
+  const auto length =
+      (GetColumnCount(m_type) == 2) ? 4 : (row ? 16 : (16 / GetColumnCount(m_type)));
 
   if (!PowerPC::memchecks.OverlapsMemcheck(addr, length))
   {
@@ -329,12 +357,30 @@ void MemoryViewWidget::mousePressEvent(QMouseEvent* event)
   switch (event->button())
   {
   case Qt::LeftButton:
-    if (column(item) == 0)
+
+    if (event->modifiers() & Qt::ShiftModifier)
+    {
+      QString setaddr = QStringLiteral("%1").arg(addr, 8, 16, QLatin1Char('0'));
+      emit SendSearchValue(setaddr);
+    }
+    else if (event->modifiers() & Qt::ControlModifier)
+    {
+      const auto length = 32 / ((GetColumnCount(m_type) == 2) ? 4 : GetColumnCount(m_type));
+      u64 value = PowerPC::HostRead_U64(addr);
+      QString setvalue = QStringLiteral("%1").arg(value, 16, 16, QLatin1Char('0')).left(length);
+      emit SendDataValue(setvalue);
+    }
+    else if (column(item) == 0)
+    {
       ToggleRowBreakpoint(true);
+    }
     else
     {
       // Scroll with LClick
-      SetAddress(addr & 0xFFFFFFF0);
+      if (GetColumnCount(m_type) == 2)
+        SetAddress(addr & 0xFFFFFFFC);
+      else
+        SetAddress(addr & 0xFFFFFFF0);
     }
     Update();
     break;
@@ -353,7 +399,7 @@ void MemoryViewWidget::OnCopyHex()
 {
   u32 addr = GetContextAddress();
 
-  const auto length = 16 / GetColumnCount(m_type);
+  const auto length = 16 / ((GetColumnCount(m_type) == 2) ? 4 : GetColumnCount(m_type));
 
   u64 value = PowerPC::HostRead_U64(addr);
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -18,7 +18,9 @@ public:
     U16,
     U32,
     ASCII,
-    Float32
+    U32xASCII,
+    Float32,
+    U32xFloat32
   };
 
   enum class BPType
@@ -49,6 +51,8 @@ public:
 
 signals:
   void BreakpointsChanged();
+  void SendSearchValue(const QString);
+  void SendDataValue(const QString);
   void ShowCode(u32 address);
 
 private:

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -62,7 +62,9 @@ private:
   MemoryViewWidget* m_memory_view;
   QSplitter* m_splitter;
   QLineEdit* m_search_address;
+  QLineEdit* m_search_address_offset;
   QLineEdit* m_data_edit;
+  QLabel* m_data_preview;
   QPushButton* m_set_value;
   QPushButton* m_dump_mram;
   QPushButton* m_dump_exram;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -53,6 +53,8 @@ private:
   void OnDumpExRAM();
   void OnDumpFakeVMEM();
 
+  void OnFloatToHex(bool float_in);
+
   std::vector<u8> GetValueData() const;
 
   void FindValue(bool next);
@@ -83,10 +85,13 @@ private:
   QRadioButton* m_type_u32;
   QRadioButton* m_type_ascii;
   QRadioButton* m_type_float;
-
+  QCheckBox* m_mem_view_style;
   // Breakpoint options
   QRadioButton* m_bp_read_write;
   QRadioButton* m_bp_read_only;
   QRadioButton* m_bp_write_only;
   QCheckBox* m_bp_log_check;
+  // Float to Hex conversion
+  QLineEdit* m_float_convert;
+  QLineEdit* m_hex_convert;
 };

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -123,6 +123,8 @@
     <QtMoc Include="Debugger\MemoryWidget.h" />
     <QtMoc Include="Debugger\MemoryViewWidget.h" />
     <QtMoc Include="Debugger\NewBreakpointDialog.h" />
+    <QtMoc Include="Debugger\CodeDiffDialog.h" />
+    <QtMoc Include="Debugger\CodeTraceDialog.h" />
     <QtMoc Include="Debugger\RegisterWidget.h" />
     <QtMoc Include="Debugger\WatchWidget.h" />
     <QtMoc Include="GCMemcardManager.h" />
@@ -176,6 +178,8 @@
     <ClCompile Include="$(QtMocOutPrefix)CheatWarningWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)CheatsManager.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ChunkedProgressDialog.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)CodeDiffDialog.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)CodeTraceDialog.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)CodeViewWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)CodeWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ControllersWindow.cpp" />
@@ -321,6 +325,8 @@
     <ClCompile Include="Config\PatchesWidget.cpp" />
     <ClCompile Include="Config\PropertiesDialog.cpp" />
     <ClCompile Include="Config\SettingsWindow.cpp" />
+    <ClCompile Include="Debugger\CodeDiffDialog.cpp" />
+    <ClCompile Include="Debugger\CodeTraceDialog.cpp" />
     <ClCompile Include="Debugger\CodeViewWidget.cpp" />
     <ClCompile Include="Debugger\CodeWidget.cpp" />
     <ClCompile Include="Debugger\JITWidget.cpp" />

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -584,7 +584,7 @@ void MainWindow::ConnectStack()
 
   setCentralWidget(m_stack);
 
-  setDockOptions(DockOption::AllowNestedDocks);
+  setDockOptions(DockOption::AllowNestedDocks | DockOption::AllowTabbedDocks);
   setTabPosition(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea, QTabWidget::North);
   addDockWidget(Qt::LeftDockWidgetArea, m_log_widget);
   addDockWidget(Qt::LeftDockWidgetArea, m_log_config_widget);


### PR DESCRIPTION
Backend:
(Feature request:) Adds PC to top of callstack function. If there are possible conflicts, I could just add it to the UI only.
Updates disassembler instructions. Mostly spaces and commas. PS load/store uses 0x notation. Required for new features.
Adds function to PPCDebugInterface to calculate target memory address for load/store instructions.

Code widget new features:
-Tracing instructions step-by-step between two points. Follow specific registers/values through the trace or backtrace.
-Function recording then differencing to find specific functions based on when they run.
-Context menu for copying or breakpointing the memory target in load/store instructions. Only works if the PC is near the instruction (register consistency).

Memory widget new features:
-Float <-> Hex converter. We had the space and it's quite useful.
-Shift click to send memory address to address box.
-Crtl click to send data to data box.
-2 column style view (same as Wx builds).

UI fixes / updates:
Re-add tabbing to debugger widgets. Accidentally removed with nested docking.

Memory Widget:
-Memory View font based sizing and color. More rows.
-Tweaks to when Memory View updates. Can update while a game is running. Updates on steps.
-Add offset box next to address box.
-Improve Data input box. Add preview box for clarity.
-Fix Find Value feature. Allow input to be any length.

Code Widget:
-Tweaks to when Code View updates.  Doesn't clear when you hit play.
-Code View font based sizing and column size. More rows, reduced resizing while scrolling.
-Code View will focus address when address box is clicked, instead of having to re-edit.

I can break up the commits more or the PR if needed.