### PR TITLE
Qt/Utils: Bind screen saver inhibition to QObject lifetime

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt5 5.9 REQUIRED COMPONENTS Gui Widgets)
+find_package(Qt5 5.9 REQUIRED COMPONENTS DBus Gui Widgets)
 
 set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
 message(STATUS "Found Qt version ${Qt5Core_VERSION}")
@@ -103,6 +103,7 @@ add_executable(dolphin-emu
   QtUtils/ElidedButton.cpp
   QtUtils/FlowLayout.cpp
   QtUtils/ImageConverter.cpp
+  QtUtils/ScreenSaverInhibitor.cpp
   QtUtils/SignalDaemon.cpp
   QtUtils/WindowActivationEventFilter.cpp
   QtUtils/WinIconHelper.cpp
@@ -141,6 +142,7 @@ PRIVATE
 target_link_libraries(dolphin-emu
 PRIVATE
   core
+  Qt5::DBus
   Qt5::Widgets
   uicommon
 )

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -152,6 +152,7 @@
     <QtMoc Include="QtUtils\DoubleClickEventFilter.h" />
     <QtMoc Include="QtUtils\ElidedButton.h" />
     <QtMoc Include="QtUtils\FlowLayout.h" />
+    <QtMoc Include="QtUtils\ScreenSaverInhibitor.h" />
     <QtMoc Include="QtUtils\WindowActivationEventFilter.h" />
     <QtMoc Include="QtUtils\WrapInScrollArea.h" />
     <QtMoc Include="RenderWidget.h" />
@@ -252,6 +253,7 @@
     <ClCompile Include="$(QtMocOutPrefix)PropertiesDialog.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)RegisterWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)RenderWidget.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)ScreenSaverInhibitor.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)SearchBar.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)Settings.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)SettingsWindow.cpp" />
@@ -365,6 +367,7 @@
     <ClCompile Include="QtUtils\ElidedButton.cpp" />
     <ClCompile Include="QtUtils\FlowLayout.cpp" />
     <ClCompile Include="QtUtils\ImageConverter.cpp" />
+    <ClCompile Include="QtUtils\ScreenSaverInhibitor.cpp" />
     <ClCompile Include="QtUtils\WindowActivationEventFilter.cpp" />
     <ClCompile Include="QtUtils\WrapInScrollArea.cpp" />
     <ClCompile Include="RenderWidget.cpp" />

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -36,6 +36,7 @@ class NetPlayDialog;
 class NetPlaySetupDialog;
 class RegisterWidget;
 class RenderWidget;
+class ScreenSaverInhibitor;
 class SearchBar;
 class SettingsWindow;
 class ToolBar;
@@ -196,6 +197,8 @@ private:
   std::array<GCTASInputWindow*, num_gc_controllers> m_gc_tas_input_windows{};
   static constexpr int num_wii_controllers = 4;
   std::array<WiiTASInputWindow*, num_wii_controllers> m_wii_tas_input_windows{};
+
+  ScreenSaverInhibitor* m_screen_saver_inhibitor = nullptr;
 
   BreakpointWidget* m_breakpoint_widget;
   CodeWidget* m_code_widget;

--- a/Source/Core/DolphinQt/QtUtils/ScreenSaverInhibitor.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ScreenSaverInhibitor.cpp
@@ -1,0 +1,130 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/QtUtils/ScreenSaverInhibitor.h"
+#include "Common/Logging/Log.h"
+#include "Core/ConfigManager.h"
+
+#if defined(_WIN32)
+#include <Windows.h>
+#elif !defined(__APPLE__)
+#include <QtDBus/QtDBus>
+static constexpr char s_screen_saver_path[] = "/org/freedesktop/ScreenSaver";
+static constexpr char s_screen_saver_interface[] = "org.freedesktop.ScreenSaver";
+#endif
+
+ScreenSaverInhibitor::ScreenSaverInhibitor(QObject* parent) : QObject(parent)
+{
+#if defined(_WIN32)
+  EXECUTION_STATE es_flags;
+  if (SConfig::GetInstance().bDisableScreenSaver)
+  {
+    NOTICE_LOG(VIDEO, "Inhibiting screen saver.");
+    es_flags = ES_DISPLAY_REQUIRED;
+  }
+  else
+  {
+    NOTICE_LOG(VIDEO, "Inhibiting system sleep.");
+    es_flags = 0;
+  }
+  SetThreadExecutionState(ES_CONTINUOUS | es_flags | ES_SYSTEM_REQUIRED);
+
+#elif defined(__APPLE__)
+  CFStringRef assertion_type;
+  if (SConfig::GetInstance().bDisableScreenSaver)
+  {
+    NOTICE_LOG(VIDEO, "Inhibiting screen saver.");
+    assertion_type = kIOPMAssertionTypePreventUserIdleDisplaySleep;
+  }
+  else
+  {
+    NOTICE_LOG(VIDEO, "Inhibiting system sleep.");
+    assertion_type = kIOPMAssertionTypePreventUserIdleSystemSleep;
+  }
+  const CFStringRef reason_for_activity = CFSTR("Emulation Running");
+  if (IOPMAssertionCreateWithName(assertion_type, kIOPMAssertionLevelOn, reason_for_activity,
+                                  &m_power_assertion) != kIOReturnSuccess)
+  {
+    m_power_assertion = kIOPMNullAssertionID;
+  }
+
+#else
+  if (SConfig::GetInstance().bDisableScreenSaver)
+  {
+    NOTICE_LOG(VIDEO, "Inhibiting screen saver.");
+
+    // First attempt using DBus interface for inhibiting screensaver.
+    // In situations where the user hasn't installed a screensaver daemon on
+    // newer desktop environments (e.g. Arch users on Plasma 5 or GNOME 3),
+    // the traditional xdg-screensaver suspend will *not* work. This is
+    // theoretically compatible with non-X11 display servers as well.
+    auto msg = QDBusMessage::createMethodCall(QLatin1String(s_screen_saver_interface),
+                                              QLatin1String(s_screen_saver_path),
+                                              QLatin1String(s_screen_saver_interface),
+                                              QStringLiteral("Inhibit"));
+    msg << QStringLiteral("dolphin-emu") << QStringLiteral("Emulation Running");
+    const auto pending_reply = QDBusConnection::sessionBus().asyncCall(msg);
+    const auto* call_watcher = new QDBusPendingCallWatcher(pending_reply, this);
+    connect(call_watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, parent](QDBusPendingCallWatcher* finished_watcher) {
+              QDBusPendingReply<uint> reply = *finished_watcher;
+              finished_watcher->deleteLater();
+              if (!reply.isValid())
+              {
+                // Fall back to xdg-screensaver.
+                // This will likely occur when the DBus interface is not implemented by
+                // the user's desktop environment (e.g. MATE and Xfce).
+                NOTICE_LOG(VIDEO, "Falling back to xdg-screensaver suspend.");
+                if (auto* main_window = qobject_cast<QMainWindow*>(parent))
+                {
+                  const WId window_id = main_window->winId();
+                  if (QProcess::execute(QStringLiteral("xdg-screensaver"),
+                                        {QStringLiteral("suspend"),
+                                         QStringLiteral("0x%1").arg(window_id, 0, 16)}) < 0)
+                    return;
+                  m_window_id = window_id;
+                }
+                return;
+              }
+              m_cookie = reply.value();
+            });
+  }
+
+#endif
+}
+
+ScreenSaverInhibitor::~ScreenSaverInhibitor()
+{
+#if defined(_WIN32)
+  NOTICE_LOG(VIDEO, "Uninhibiting screen saver.");
+  SetThreadExecutionState(ES_CONTINUOUS);
+
+#elif defined(__APPLE__)
+  if (m_power_assertion != kIOPMNullAssertionID)
+  {
+    NOTICE_LOG(VIDEO, "Uninhibiting screen saver.");
+    IOPMAssertionRelease(m_power_assertion);
+  }
+
+#else
+  if (m_cookie != UINT_MAX)
+  {
+    NOTICE_LOG(VIDEO, "Uninhibiting screen saver.");
+    auto msg =
+        QDBusMessage::createMethodCall(QLatin1String(s_screen_saver_interface),
+                                       QLatin1String(s_screen_saver_path),
+                                       QLatin1String(s_screen_saver_interface),
+                                       QStringLiteral("UnInhibit"));
+    msg << m_cookie;
+    QDBusConnection::sessionBus().call(msg, QDBus::NoBlock);
+  }
+  else if (m_window_id != 0)
+  {
+    NOTICE_LOG(VIDEO, "Uninhibiting screen saver.");
+    QProcess::execute(QStringLiteral("xdg-screensaver"),
+                      {QStringLiteral("resume"), QStringLiteral("0x%1").arg(m_window_id, 0, 16)});
+  }
+
+#endif
+}

--- a/Source/Core/DolphinQt/QtUtils/ScreenSaverInhibitor.h
+++ b/Source/Core/DolphinQt/QtUtils/ScreenSaverInhibitor.h
@@ -1,0 +1,30 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QObject>
+
+#if defined(__APPLE__)
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#elif !defined(_WIN32)
+#include <QMainWindow>
+#endif
+
+class ScreenSaverInhibitor : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit ScreenSaverInhibitor(QObject* parent);
+  ~ScreenSaverInhibitor() override;
+
+private:
+#if defined(__APPLE__)
+  IOPMAssertionID m_power_assertion = kIOPMNullAssertionID;
+#elif !defined(_WIN32)
+  uint m_cookie = UINT_MAX;  // For DBus inhibit
+  WId m_window_id = 0;       // For xdg-screensaver fallback inhibit
+#endif
+};

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -366,63 +366,6 @@ bool TriggerSTMPowerEvent()
   return true;
 }
 
-#if defined(HAVE_XRANDR) && HAVE_X11
-void EnableScreenSaver(Window win, bool enable)
-#else
-void EnableScreenSaver(bool enable)
-#endif
-{
-// Inhibit the screensaver. Depending on the operating system this may also
-// disable low-power states and/or screen dimming.
-
-#if defined(HAVE_X11) && HAVE_X11
-  if (SConfig::GetInstance().bDisableScreenSaver)
-  {
-    X11Utils::InhibitScreensaver(win, !enable);
-  }
-#endif
-
-#ifdef _WIN32
-  // Prevents Windows from sleeping, turning off the display, or idling
-  if (enable)
-  {
-    SetThreadExecutionState(ES_CONTINUOUS);
-  }
-  else
-  {
-    EXECUTION_STATE should_screen_save =
-        SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
-    SetThreadExecutionState(ES_CONTINUOUS | should_screen_save | ES_SYSTEM_REQUIRED);
-  }
-#endif
-
-#ifdef __APPLE__
-  static IOPMAssertionID s_power_assertion = kIOPMNullAssertionID;
-
-  if (SConfig::GetInstance().bDisableScreenSaver)
-  {
-    if (enable)
-    {
-      if (s_power_assertion != kIOPMNullAssertionID)
-      {
-        IOPMAssertionRelease(s_power_assertion);
-        s_power_assertion = kIOPMNullAssertionID;
-      }
-    }
-    else
-    {
-      CFStringRef reason_for_activity = CFSTR("Emulation Running");
-      if (IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleDisplaySleep,
-                                      kIOPMAssertionLevelOn, reason_for_activity,
-                                      &s_power_assertion) != kIOReturnSuccess)
-      {
-        s_power_assertion = kIOPMNullAssertionID;
-      }
-    }
-  }
-#endif
-}
-
 std::string FormatSize(u64 bytes)
 {
   // i18n: The symbol for the unit "bytes"

--- a/Source/Core/UICommon/UICommon.h
+++ b/Source/Core/UICommon/UICommon.h
@@ -13,12 +13,6 @@ namespace UICommon
 void Init();
 void Shutdown();
 
-#if defined(HAVE_XRANDR) && HAVE_XRANDR
-void EnableScreenSaver(unsigned long win, bool enable);
-#else
-void EnableScreenSaver(bool enable);
-#endif
-
 // Calls std::locale::global, selecting a fallback locale if the
 // requested locale isn't available
 void SetLocale(std::string locale_name);


### PR DESCRIPTION
The purpose of this PR is threefold:

1. To embrace a Qt-centric way of inhibiting the screensaver while emulating. Rather than toggling the screensaver state and (in the case of macOS) using static-global variables to track inhibition handles, a QObject subclass stores this information and treats the inhibition as a resource bound to its lifetime. This has the added benefit of being able to participate in a QObject hierarchy. If MainWindow were to somehow be destroyed without stopping the emulator, the inhibition object is guaranteed to be destroyed as a child of MainWindow.

2. [For linux] To adopt a [more direct and standardized method](https://specifications.freedesktop.org/idle-inhibit-spec/latest/index.html) of inhibiting the screensaver. The real motivation behind this PR is I'm an Arch user running KDE Plasma 5 *without* any sort of screensaver daemon (why would I want to install one when the DE is perfectly capable of power management on its own?). Without a screensaver daemon, there is nothing to centrally track X Window lifetimes. Instead, the Idle-Inhibition DBus interface provides the same functionality bound to a DBus connection. Since Qt has a built-in DBus connection already, we can cut out the `xdg-screensaver suspend` middleman and manage the inhibition directly. Additionally, `xdg-screensaver` depends on X11 Window IDs whereas the DBus interface would be compatible with non-X11 display servers.

3. To remove redundant calls to the Win32 SetThreadExecutionState function found in `RequestStop` and `StartGame`. This is better handled in a platform-agnostic manner benefiting all platforms. 