### PR TITLE
Debugger: Get target memory in load/store instructions

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -72,6 +72,11 @@ public:
   virtual void WriteExtraMemory(int /*memory*/, u32 /*value*/, u32 /*address*/) {}
   virtual u32 ReadExtraMemory(int /*memory*/, u32 /*address*/) const { return 0; }
   virtual u32 ReadInstruction(u32 /*address*/) const { return 0; }
+  virtual std::optional<u32>
+  GetMemoryAddressFromInstruction(const std::string& /*instruction*/) const
+  {
+    return std::nullopt;
+  }
   virtual u32 GetPC() const { return 0; }
   virtual void SetPC(u32 /*address*/) {}
   virtual void Step() {}

--- a/Source/Core/Common/GekkoDisassembler.h
+++ b/Source/Core/Common/GekkoDisassembler.h
@@ -56,7 +56,7 @@ private:
 
   static std::string ra_rb(u32 in);
   static std::string rd_ra_rb(u32 in, int mask);
-  static std::string fd_ra_rb(u32 in, int mask);
+  static std::string fd_ra_rb(u32 in);
 
   static void trapi(u32 in, unsigned char dmode);
   static void cmpi(u32 in, int uimm);
@@ -84,7 +84,7 @@ private:
   static void ldst(u32 in, std::string_view name, char reg, unsigned char dmode);
   static void fdabc(u32 in, std::string_view name, int mask, unsigned char dmode);
   static void fmr(u32 in);
-  static void fdab(u32 in, std::string_view name, int mask);
+  static void fdab(u32 in, std::string_view name);
   static void fcmp(u32 in, char c);
   static void mtfsb(u32 in, int n);
   static void ps(u32 inst);

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -373,6 +374,55 @@ u32 PPCDebugInterface::GetColor(u32 address) const
 std::string PPCDebugInterface::GetDescription(u32 address) const
 {
   return g_symbolDB.GetDescription(address);
+}
+
+std::optional<u32>
+PPCDebugInterface::GetMemoryAddressFromInstruction(const std::string& instruction) const
+{
+  std::regex re(",[^r0-]*(-?)(0[xX]?[0-9a-fA-F]*|r\\d+)[^r^s]*.(p|toc|\\d+)");
+  std::smatch match;
+
+  // Instructions should be identified as a load or store before using this function. This error
+  // check should never trigger.
+  if (!std::regex_search(instruction, match, re))
+    return std::nullopt;
+
+  // Output: match.str(1): negative sign for offset or no match. match.str(2): 0xNNNN, 0, or
+  // rNN. Check next for 'r' to see if a gpr needs to be loaded. match.str(3): will either be p,
+  // toc, or NN. Always a gpr.
+  const std::string offset_match = match.str(2);
+  const std::string register_match = match.str(3);
+  constexpr char is_reg = 'r';
+  u32 offset = 0;
+
+  if (is_reg == offset_match[0])
+  {
+    const int register_index = std::stoi(offset_match.substr(1), nullptr, 10);
+    offset = (register_index == 0 ? 0 : GPR(register_index));
+  }
+  else
+  {
+    offset = static_cast<u32>(std::stoi(offset_match, nullptr, 16));
+  }
+
+  // sp and rtoc need to be converted to 1 and 2.
+  constexpr char is_sp = 'p';
+  constexpr char is_rtoc = 't';
+  u32 i = 0;
+
+  if (is_sp == register_match[0])
+    i = 1;
+  else if (is_rtoc == register_match[0])
+    i = 2;
+  else
+    i = std::stoi(register_match, nullptr, 10);
+
+  const u32 base_address = GPR(i);
+
+  if (!match.str(1).empty())
+    return base_address - offset;
+
+  return base_address + offset;
 }
 
 u32 PPCDebugInterface::GetPC() const

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -76,6 +76,7 @@ public:
 
   u32 ReadExtraMemory(int memory, u32 address) const override;
   u32 ReadInstruction(u32 address) const override;
+  std::optional<u32> GetMemoryAddressFromInstruction(const std::string& instruction) const override;
   u32 GetPC() const override;
   void SetPC(u32 address) override;
   void Step() override {}

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -70,7 +70,9 @@ private:
 
   void OnFollowBranch();
   void OnCopyAddress();
+  void OnCopyTargetAddress();
   void OnShowInMemory();
+  void OnShowTargetInMemory();
   void OnCopyFunction();
   void OnCopyCode();
   void OnCopyHex();


### PR DESCRIPTION
Backend:
Updates disassembler instructions. Mostly spaces and commas. PS load/store uses 0x notation. Required for new features.
Adds function to PPCDebugInterface to calculate target memory address for load/store instructions.

Code widget new feature:
-Context menu for copying or showing memory target in load/store instructions. Only works if the PC is near the instruction (register consistency).

/edit removed trace and diff for their own PRs
/edit2 changed breakpoint memory to 'show in memory'.