### PR TITLE
GetSysDirectory() always ends with a /

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -45,7 +45,7 @@ void AXUCode::LoadResamplingCoefficients()
   m_coeffs_available = false;
 
   std::string filenames[] = {File::GetUserPath(D_GCUSER_IDX) + "dsp_coef.bin",
-                             File::GetSysDirectory() + "/GC/dsp_coef.bin"};
+                             File::GetSysDirectory() + "GC/dsp_coef.bin"};
 
   size_t fidx;
   std::string filename;


### PR DESCRIPTION
Noticed a additional / in the message 

`[libretro INFO] 02:59:530 Core/HW/DSPHLE/UCodes/AX.cpp:64 I[DSPHLE]: Loading polyphase resampling coeffs from /home/i30817/.config/retroarch/bios/dolphin-emu/Sys//GC/dsp_coef.bin`

When i was trying to debug a different bug on eternal darkness.

The dir separator is added here:
https://github.com/dolphin-emu/dolphin/blob/fc998093cce1e2876e776bdede807887cb979a17/Source/Core/Common/FileUtil.cpp#L736

So this one is extra. Probably. Maybe i'm being dumb though, so review this one character change.