### PR TITLE
Qt/Debugger Memory widget features

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -50,12 +50,15 @@ static int GetColumnCount(MemoryViewWidget::Type type)
 {
   switch (type)
   {
-  case MemoryViewWidget::Type::ASCII:
+  case MemoryViewWidget::Type::U32xASCII:
+  case MemoryViewWidget::Type::U32xFloat32:
+    return 2;
   case MemoryViewWidget::Type::U8:
     return 16;
   case MemoryViewWidget::Type::U16:
     return 8;
   case MemoryViewWidget::Type::U32:
+  case MemoryViewWidget::Type::ASCII:
   case MemoryViewWidget::Type::Float32:
     return 4;
   default:
@@ -83,7 +86,9 @@ void MemoryViewWidget::Update()
   {
     setRowHeight(i, 24);
 
-    u32 addr = m_address - ((rowCount() / 2) * 16) + i * 16;
+    // Two column mode has rows increment by 0x4 instead of 0x10
+    u32 rowmod = ((GetColumnCount(m_type) == 2) ? 4 : 16);
+    u32 addr = m_address - (rowCount() / 2) * rowmod + i * rowmod;
 
     auto* bp_item = new QTableWidgetItem;
     bp_item->setFlags(Qt::ItemIsEnabled);
@@ -126,13 +131,17 @@ void MemoryViewWidget::Update()
     bool row_breakpoint = true;
 
     auto update_values = [&](auto value_to_string) {
-      for (int c = 0; c < GetColumnCount(m_type); c++)
+      const int columns = GetColumnCount(m_type);
+      for (int c = 0; c < columns; c++)
       {
         auto* hex_item = new QTableWidgetItem;
         hex_item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-        const u32 address = addr + c * (16 / GetColumnCount(m_type));
+        u32 address = addr + c * (16 / columns);
 
-        if (PowerPC::memchecks.OverlapsMemcheck(address, 16 / GetColumnCount(m_type)))
+        // Alternate view requires two columns with the same address
+        if (columns == 2)
+          address = addr;
+        if (PowerPC::memchecks.OverlapsMemcheck(address, 16 / ((columns == 2) ? 4 : columns)))
           hex_item->setBackground(Qt::red);
         else
           row_breakpoint = false;
@@ -141,7 +150,17 @@ void MemoryViewWidget::Update()
 
         if (PowerPC::HostIsRAMAddress(address))
         {
-          hex_item->setText(value_to_string(address));
+          // 2 Column mode: Report hex value in first column.
+          if (columns == 2 && c == 0)
+          {
+            hex_item->setText(
+                QStringLiteral("%1").arg(PowerPC::HostRead_U32(address), 8, 16, QLatin1Char('0')));
+          }
+          else
+          {
+            hex_item->setText(value_to_string(address));
+          }
+
           hex_item->setData(Qt::UserRole, address);
         }
         else
@@ -161,9 +180,16 @@ void MemoryViewWidget::Update()
       });
       break;
     case Type::ASCII:
+    case Type::U32xASCII:
       update_values([](u32 address) {
-        const char value = PowerPC::HostRead_U8(address);
-        return std::isprint(value) ? QString{QChar::fromLatin1(value)} : QStringLiteral(".");
+        QString asciistring = QStringLiteral("");
+        // Group ASCII in sets of four.
+        for (u32 i = 0; i < 4; i++)
+        {
+          char value = PowerPC::HostRead_U8(address + i);
+          asciistring.append(std::isprint(value) ? QChar::fromLatin1(value) : QStringLiteral("."));
+        }
+        return asciistring;
       });
       break;
     case Type::U16:
@@ -179,6 +205,7 @@ void MemoryViewWidget::Update()
       });
       break;
     case Type::Float32:
+    case Type::U32xFloat32:
       update_values([](u32 address) { return QString::number(PowerPC::HostRead_F32(address)); });
       break;
     }
@@ -270,8 +297,9 @@ void MemoryViewWidget::ToggleRowBreakpoint(bool row)
 {
   TMemCheck check;
 
-  const u32 addr = row ? GetContextAddress() & 0xFFFFFFF0 : GetContextAddress();
-  const auto length = row ? 16 : (16 / GetColumnCount(m_type));
+  const u32 addr = row ? GetContextAddress() & 0xFFFFFFFC : GetContextAddress();
+  const auto length =
+      (GetColumnCount(m_type) == 2) ? 4 : (row ? 16 : (16 / GetColumnCount(m_type)));
 
   if (!PowerPC::memchecks.OverlapsMemcheck(addr, length))
   {
@@ -342,8 +370,13 @@ void MemoryViewWidget::mousePressEvent(QMouseEvent* event)
       ToggleRowBreakpoint(true);
     }
     else
-      SetAddress(addr & 0xFFFFFFF0);
-
+    {
+      // Scroll with LClick
+      if (GetColumnCount(m_type) == 2)
+        SetAddress(addr & 0xFFFFFFFC);
+      else
+        SetAddress(addr & 0xFFFFFFF0);
+    }
     Update();
     break;
   default:
@@ -361,7 +394,7 @@ void MemoryViewWidget::OnCopyHex()
 {
   u32 addr = GetContextAddress();
 
-  const auto length = 16 / GetColumnCount(m_type);
+  const auto length = 16 / ((GetColumnCount(m_type) == 2) ? 4 : GetColumnCount(m_type));
 
   u64 value = PowerPC::HostRead_U64(addr);
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -324,8 +324,23 @@ void MemoryViewWidget::mousePressEvent(QMouseEvent* event)
   switch (event->button())
   {
   case Qt::LeftButton:
-    if (column(item) == 0)
+
+    if (event->modifiers() & Qt::ShiftModifier)
+    {
+      QString setaddr = QStringLiteral("%1").arg(addr, 8, 16, QLatin1Char('0'));
+      emit SendSearchValue(setaddr);
+    }
+    else if (event->modifiers() & Qt::ControlModifier)
+    {
+      const auto length = 32 / ((GetColumnCount(m_type) == 2) ? 4 : GetColumnCount(m_type));
+      u64 value = PowerPC::HostRead_U64(addr);
+      QString setvalue = QStringLiteral("%1").arg(value, 16, 16, QLatin1Char('0')).left(length);
+      emit SendDataValue(setvalue);
+    }
+    else if (column(item) == 0)
+    {
       ToggleRowBreakpoint(true);
+    }
     else
       SetAddress(addr & 0xFFFFFFF0);
 

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -18,7 +18,9 @@ public:
     U16,
     U32,
     ASCII,
-    Float32
+    U32xASCII,
+    Float32,
+    U32xFloat32
   };
 
   enum class BPType

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -49,6 +49,8 @@ public:
 
 signals:
   void BreakpointsChanged();
+  void SendSearchValue(const QString);
+  void SendDataValue(const QString);
   void ShowCode(u32 address);
 
 private:

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -120,12 +120,14 @@ void MemoryWidget::CreateWidgets()
   m_type_u32 = new QRadioButton(tr("U&32"));
   m_type_ascii = new QRadioButton(tr("ASCII"));
   m_type_float = new QRadioButton(tr("Float"));
+  m_mem_view_style = new QCheckBox(tr("Alternate View"));
 
   datatype_layout->addWidget(m_type_u8);
   datatype_layout->addWidget(m_type_u16);
   datatype_layout->addWidget(m_type_u32);
   datatype_layout->addWidget(m_type_ascii);
   datatype_layout->addWidget(m_type_float);
+  datatype_layout->addWidget(m_mem_view_style);
   datatype_layout->setSpacing(1);
 
   // MBP options
@@ -214,6 +216,8 @@ void MemoryWidget::ConnectWidgets()
   for (auto* radio : {m_type_u8, m_type_u16, m_type_u32, m_type_ascii, m_type_float})
     connect(radio, &QRadioButton::toggled, this, &MemoryWidget::OnTypeChanged);
 
+  connect(m_mem_view_style, &QCheckBox::toggled, this, &MemoryWidget::OnTypeChanged);
+
   for (auto* radio : {m_bp_read_write, m_bp_read_only, m_bp_write_only})
     connect(radio, &QRadioButton::toggled, this, &MemoryWidget::OnBPTypeChanged);
 
@@ -252,12 +256,15 @@ void MemoryWidget::LoadSettings()
   const bool type_u32 = settings.value(QStringLiteral("memorywidget/typeu32"), false).toBool();
   const bool type_float = settings.value(QStringLiteral("memorywidget/typefloat"), false).toBool();
   const bool type_ascii = settings.value(QStringLiteral("memorywidget/typeascii"), false).toBool();
+  const bool mem_view_style =
+      settings.value(QStringLiteral("memorywidget/memviewstyle"), false).toBool();
 
   m_type_u8->setChecked(type_u8);
   m_type_u16->setChecked(type_u16);
   m_type_u32->setChecked(type_u32);
   m_type_float->setChecked(type_float);
   m_type_ascii->setChecked(type_ascii);
+  m_mem_view_style->setChecked(mem_view_style);
 
   bool bp_rw = settings.value(QStringLiteral("memorywidget/bpreadwrite"), true).toBool();
   bool bp_r = settings.value(QStringLiteral("memorywidget/bpread"), false).toBool();
@@ -289,6 +296,7 @@ void MemoryWidget::SaveSettings()
   settings.setValue(QStringLiteral("memorywidget/typeu32"), m_type_u32->isChecked());
   settings.setValue(QStringLiteral("memorywidget/typeascii"), m_type_ascii->isChecked());
   settings.setValue(QStringLiteral("memorywidget/typefloat"), m_type_float->isChecked());
+  settings.setValue(QStringLiteral("memorywidget/memviewstyle"), m_mem_view_style->isChecked());
 
   settings.setValue(QStringLiteral("memorywidget/bpreadwrite"), m_bp_read_write->isChecked());
   settings.setValue(QStringLiteral("memorywidget/bpread"), m_bp_read_only->isChecked());
@@ -299,8 +307,11 @@ void MemoryWidget::SaveSettings()
 void MemoryWidget::OnTypeChanged()
 {
   MemoryViewWidget::Type type;
-
-  if (m_type_u8->isChecked())
+  if (m_mem_view_style->isChecked() && m_type_ascii->isChecked())
+    type = MemoryViewWidget::Type::U32xASCII;
+  else if (m_mem_view_style->isChecked() && m_type_float->isChecked())
+    type = MemoryViewWidget::Type::U32xFloat32;
+  else if (m_type_u8->isChecked())
     type = MemoryViewWidget::Type::U8;
   else if (m_type_u16->isChecked())
     type = MemoryViewWidget::Type::U16;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -220,6 +220,8 @@ void MemoryWidget::ConnectWidgets()
   connect(m_bp_log_check, &QCheckBox::toggled, this, &MemoryWidget::OnBPLogChanged);
   connect(m_memory_view, &MemoryViewWidget::BreakpointsChanged, this,
           &MemoryWidget::BreakpointsChanged);
+  connect(m_memory_view, &MemoryViewWidget::SendSearchValue, m_search_address, &QLineEdit::setText);
+  connect(m_memory_view, &MemoryViewWidget::SendDataValue, m_data_edit, &QLineEdit::setText);
   connect(m_memory_view, &MemoryViewWidget::ShowCode, this, &MemoryWidget::ShowCode);
 }
 

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -81,7 +81,7 @@ private:
   QRadioButton* m_type_u32;
   QRadioButton* m_type_ascii;
   QRadioButton* m_type_float;
-
+  QCheckBox* m_mem_view_style;
   // Breakpoint options
   QRadioButton* m_bp_read_write;
   QRadioButton* m_bp_read_only;


### PR DESCRIPTION
Memory widget new features:
2 column style view (same as Wx builds).
Shift click to send memory address to address box.
Crtl click to send data to data box.

Restoring the 2-column view from Wx has been request by a few people and is quite useful. Dealing with both styles in the code looks a little sloppy though, if anyone has suggestions on clearing that up. Maybe just using more if statements?

/edit Removed:
Float <-> Hex converter. We had the space and it's quite useful.
Offset box next to address box.