### PR TITLE
DirectInput: Use more than 8 bits of precision on axis inputs.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <sstream>
 
@@ -121,13 +122,13 @@ Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVI
   for (unsigned int offset = 0; offset < DIJOFS_BUTTON(0) / sizeof(LONG); ++offset)
   {
     range.diph.dwObj = offset * sizeof(LONG);
-    // try to set some nice power of 2 values (128) to match the GameCube controls
-    range.lMin = -(1 << 7);
-    range.lMax = (1 << 7);
+    // Try to set a range with 16 bits of precision:
+    range.lMin = std::numeric_limits<s16>::min();
+    range.lMax = std::numeric_limits<s16>::max();
     m_device->SetProperty(DIPROP_RANGE, &range.diph);
-    // but I guess not all devices support setting range
-    // so I getproperty right afterward incase it didn't set.
-    // This also checks that the axis is present
+    // Not all devices support setting DIPROP_RANGE so we must GetProperty right back.
+    // This also checks that the axis is present.
+    // Note: Even though not all devices support setting DIPROP_RANGE, some require it.
     if (SUCCEEDED(m_device->GetProperty(DIPROP_RANGE, &range.diph)))
     {
       const LONG base = (range.lMin + range.lMax) / 2;


### PR DESCRIPTION
DirectInput will now try to use 16 bit precision on axis inputs.
While the gamecube controller sticks we emulate are only 8 bit, things like Wiimote tilt and IR cursor inputs have more precision.
Plus we are applying dead zones and all sorts of math before chopping it down to 8 bits so we might as well grab more if it's available.