### PR TITLE
Disable Deferred EFB Copies in Sonic Adventure 2

### DIFF
--- a/Data/Sys/GameSettings/GSN.ini
+++ b/Data/Sys/GameSettings/GSN.ini
@@ -15,3 +15,6 @@ CPUThread = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+DeferEFBCopies = False


### PR DESCRIPTION
Deferred EFB Copies are causing a crash during the final boss.  This game is timing sensitive in general though, so I wouldn't be surprised if certain other stages also had crashing issues.