### PR TITLE
Android: Change all AnalogInputs to just inputs

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -42,18 +42,16 @@ Touchscreen::Touchscreen(int padID) : _padID(padID)
   AddInput(new Button(_padID, ButtonManager::BUTTON_DOWN));
   AddInput(new Button(_padID, ButtonManager::BUTTON_LEFT));
   AddInput(new Button(_padID, ButtonManager::BUTTON_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::STICK_MAIN_LEFT),
-                  new Axis(_padID, ButtonManager::STICK_MAIN_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::STICK_MAIN_UP),
-                  new Axis(_padID, ButtonManager::STICK_MAIN_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::STICK_C_LEFT),
-                  new Axis(_padID, ButtonManager::STICK_C_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::STICK_C_UP),
-                  new Axis(_padID, ButtonManager::STICK_C_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TRIGGER_L),
-                  new Axis(_padID, ButtonManager::TRIGGER_L));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TRIGGER_R),
-                  new Axis(_padID, ButtonManager::TRIGGER_R));
+  AddInput(new Axis(_padID, ButtonManager::STICK_MAIN_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::STICK_MAIN_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::STICK_MAIN_UP));
+  AddInput(new Axis(_padID, ButtonManager::STICK_MAIN_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::STICK_C_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::STICK_C_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::STICK_C_UP));
+  AddInput(new Axis(_padID, ButtonManager::STICK_C_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::TRIGGER_L));
+  AddInput(new Axis(_padID, ButtonManager::TRIGGER_R));
 
   // Wiimote
   AddInput(new Button(_padID, ButtonManager::WIIMOTE_BUTTON_A));
@@ -72,22 +70,22 @@ Touchscreen::Touchscreen(int padID) : _padID(padID)
   AddInput(new Button(_padID, ButtonManager::WIIMOTE_SHAKE_X));
   AddInput(new Button(_padID, ButtonManager::WIIMOTE_SHAKE_Y));
   AddInput(new Button(_padID, ButtonManager::WIIMOTE_SHAKE_Z));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_IR_UP),
-                  new Axis(_padID, ButtonManager::WIIMOTE_IR_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_IR_LEFT),
-                  new Axis(_padID, ButtonManager::WIIMOTE_IR_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_IR_FORWARD),
-                  new Axis(_padID, ButtonManager::WIIMOTE_IR_BACKWARD));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_SWING_UP),
-                  new Axis(_padID, ButtonManager::WIIMOTE_SWING_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_SWING_LEFT),
-                  new Axis(_padID, ButtonManager::WIIMOTE_SWING_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_SWING_FORWARD),
-                  new Axis(_padID, ButtonManager::WIIMOTE_SWING_BACKWARD));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_TILT_LEFT),
-                  new Axis(_padID, ButtonManager::WIIMOTE_TILT_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::WIIMOTE_TILT_FORWARD),
-                  new Axis(_padID, ButtonManager::WIIMOTE_TILT_BACKWARD));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_IR_UP));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_IR_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_IR_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_IR_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_IR_FORWARD));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_IR_BACKWARD));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_SWING_UP));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_SWING_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_SWING_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_SWING_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_SWING_FORWARD));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_SWING_BACKWARD));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_TILT_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_TILT_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_TILT_FORWARD));
+  AddInput(new Axis(_padID, ButtonManager::WIIMOTE_TILT_BACKWARD));
 
   // Wii ext: Nunchuk
   AddInput(new Button(_padID, ButtonManager::NUNCHUK_BUTTON_C));
@@ -96,20 +94,20 @@ Touchscreen::Touchscreen(int padID) : _padID(padID)
   AddInput(new Button(_padID, ButtonManager::NUNCHUK_SHAKE_X));
   AddInput(new Button(_padID, ButtonManager::NUNCHUK_SHAKE_Y));
   AddInput(new Button(_padID, ButtonManager::NUNCHUK_SHAKE_Z));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::NUNCHUK_STICK_LEFT),
-                  new Axis(_padID, ButtonManager::NUNCHUK_STICK_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::NUNCHUK_STICK_UP),
-                  new Axis(_padID, ButtonManager::NUNCHUK_STICK_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::NUNCHUK_SWING_LEFT),
-                  new Axis(_padID, ButtonManager::NUNCHUK_SWING_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::NUNCHUK_SWING_UP),
-                  new Axis(_padID, ButtonManager::NUNCHUK_SWING_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::NUNCHUK_SWING_FORWARD),
-                  new Axis(_padID, ButtonManager::NUNCHUK_SWING_BACKWARD));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::NUNCHUK_TILT_LEFT),
-                  new Axis(_padID, ButtonManager::NUNCHUK_TILT_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::NUNCHUK_TILT_FORWARD),
-                  new Axis(_padID, ButtonManager::NUNCHUK_TILT_BACKWARD));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_STICK_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_STICK_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_STICK_UP));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_STICK_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_SWING_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_SWING_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_SWING_UP));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_SWING_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_SWING_FORWARD));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_SWING_BACKWARD));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_TILT_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_TILT_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_TILT_FORWARD));
+  AddInput(new Axis(_padID, ButtonManager::NUNCHUK_TILT_BACKWARD));
 
   // Wii ext: Classic
   AddInput(new Button(_padID, ButtonManager::CLASSIC_BUTTON_A));
@@ -125,18 +123,16 @@ Touchscreen::Touchscreen(int padID) : _padID(padID)
   AddInput(new Button(_padID, ButtonManager::CLASSIC_DPAD_DOWN));
   AddInput(new Button(_padID, ButtonManager::CLASSIC_DPAD_LEFT));
   AddInput(new Button(_padID, ButtonManager::CLASSIC_DPAD_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_LEFT),
-                  new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_UP),
-                  new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_LEFT),
-                  new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_UP),
-                  new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::CLASSIC_TRIGGER_L),
-                  new Axis(_padID, ButtonManager::CLASSIC_TRIGGER_L));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::CLASSIC_TRIGGER_R),
-                  new Axis(_padID, ButtonManager::CLASSIC_TRIGGER_R));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_UP));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_LEFT_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_UP));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_STICK_RIGHT_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_TRIGGER_L));
+  AddInput(new Axis(_padID, ButtonManager::CLASSIC_TRIGGER_R));
 
   // Wii-ext: Guitar
   AddInput(new Button(_padID, ButtonManager::GUITAR_BUTTON_MINUS));
@@ -148,12 +144,11 @@ Touchscreen::Touchscreen(int padID) : _padID(padID)
   AddInput(new Button(_padID, ButtonManager::GUITAR_FRET_ORANGE));
   AddInput(new Button(_padID, ButtonManager::GUITAR_STRUM_UP));
   AddInput(new Button(_padID, ButtonManager::GUITAR_STRUM_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::GUITAR_STICK_LEFT),
-                  new Axis(_padID, ButtonManager::GUITAR_STICK_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::GUITAR_STICK_UP),
-                  new Axis(_padID, ButtonManager::GUITAR_STICK_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::GUITAR_WHAMMY_BAR),
-                  new Axis(_padID, ButtonManager::GUITAR_WHAMMY_BAR));
+  AddInput(new Axis(_padID, ButtonManager::GUITAR_STICK_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::GUITAR_STICK_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::GUITAR_STICK_UP));
+  AddInput(new Axis(_padID, ButtonManager::GUITAR_STICK_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::GUITAR_WHAMMY_BAR));
 
   // Wii-ext: Drums
   AddInput(new Button(_padID, ButtonManager::DRUMS_BUTTON_MINUS));
@@ -164,10 +159,10 @@ Touchscreen::Touchscreen(int padID) : _padID(padID)
   AddInput(new Button(_padID, ButtonManager::DRUMS_PAD_GREEN));
   AddInput(new Button(_padID, ButtonManager::DRUMS_PAD_ORANGE));
   AddInput(new Button(_padID, ButtonManager::DRUMS_PAD_BASS));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::DRUMS_STICK_LEFT),
-                  new Axis(_padID, ButtonManager::DRUMS_STICK_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::DRUMS_STICK_UP),
-                  new Axis(_padID, ButtonManager::DRUMS_STICK_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::DRUMS_STICK_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::DRUMS_STICK_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::DRUMS_STICK_UP));
+  AddInput(new Axis(_padID, ButtonManager::DRUMS_STICK_DOWN));
 
   // Wii-ext: Turntable
   AddInput(new Button(_padID, ButtonManager::TURNTABLE_BUTTON_GREEN_LEFT));
@@ -180,18 +175,18 @@ Touchscreen::Touchscreen(int padID) : _padID(padID)
   AddInput(new Button(_padID, ButtonManager::TURNTABLE_BUTTON_PLUS));
   AddInput(new Button(_padID, ButtonManager::TURNTABLE_BUTTON_HOME));
   AddInput(new Button(_padID, ButtonManager::TURNTABLE_BUTTON_EUPHORIA));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TURNTABLE_TABLE_LEFT_LEFT),
-                  new Axis(_padID, ButtonManager::TURNTABLE_TABLE_LEFT_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TURNTABLE_TABLE_RIGHT_LEFT),
-                  new Axis(_padID, ButtonManager::TURNTABLE_TABLE_RIGHT_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TURNTABLE_STICK_LEFT),
-                  new Axis(_padID, ButtonManager::TURNTABLE_STICK_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TURNTABLE_STICK_UP),
-                  new Axis(_padID, ButtonManager::TURNTABLE_STICK_DOWN));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TURNTABLE_CROSSFADE_LEFT),
-                  new Axis(_padID, ButtonManager::TURNTABLE_CROSSFADE_RIGHT));
-  AddAnalogInputs(new Axis(_padID, ButtonManager::TURNTABLE_EFFECT_DIAL),
-                  new Axis(_padID, ButtonManager::TURNTABLE_EFFECT_DIAL));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_TABLE_LEFT_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_TABLE_LEFT_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_TABLE_RIGHT_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_TABLE_RIGHT_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_STICK_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_STICK_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_STICK_UP));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_STICK_DOWN));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_CROSSFADE_LEFT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_CROSSFADE_RIGHT));
+  AddInput(new Axis(_padID, ButtonManager::TURNTABLE_EFFECT_DIAL));
+
   // Rumble
   AddOutput(new Motor(_padID, ButtonManager::RUMBLE));
 }
@@ -208,6 +203,7 @@ ControlState Touchscreen::Button::GetState() const
 {
   return ButtonManager::GetButtonPressed(_padID, _index);
 }
+
 std::string Touchscreen::Axis::GetName() const
 {
   std::ostringstream ss;


### PR DESCRIPTION
Android doesn't report values for the inputs generated by FullAnalogInput so
there isn't a reason to add them as such. This also avoids a bug(for android)
where if there are three inputs(say 12, 11, and 121), and you generate a FullAnalogInput
with 12/11 then it will create another input with the name 121 which can cause conficts
with the real 121 input. This is probably not an issue on PC since most Axis inputs
are named and not numbered.

I should also mention this fixes the accelerometer issues(Swing/Down) that android has had for the past few months.