### PR TITLE
Ability to select visibility of game list columns by right clicking game list header

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -51,6 +51,7 @@ signals:
 
 private:
   void ShowContextMenu(const QPoint&);
+  void ShowHeaderContextMenu(const QPoint&);
   void OpenContainingFolder();
   void OpenProperties();
   void OpenSaveFolder();

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -587,6 +587,14 @@ void MenuBar::AddListColumnsMenu(QMenu* view_menu)
   QMenu* cols_menu = view_menu->addMenu(tr("List Columns"));
   column_group->setExclusive(false);
 
+  connect(cols_menu, &QMenu::aboutToShow, column_group, [this, column_group]() {
+    for (auto& action : column_group->actions())
+    {
+      bool* config = columns[action->text()];
+      action->setChecked(*config);
+    }
+   });
+
   for (const auto& key : columns.keys())
   {
     bool* config = columns[key];

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -593,7 +593,7 @@ void MenuBar::AddListColumnsMenu(QMenu* view_menu)
       bool* config = columns[action->text()];
       action->setChecked(*config);
     }
-   });
+  });
 
   for (const auto& key : columns.keys())
   {


### PR DESCRIPTION
Ability to select visibility of game list columns by right clicking the game list header

Fixes issue: https://bugs.dolphin-emu.org/issues/11429