### PR TITLE
Fix "Vitual Console" Typo in M.ini

### DIFF
--- a/Data/Sys/GameSettings/M.ini
+++ b/Data/Sys/GameSettings/M.ini
@@ -1,4 +1,4 @@
-# Mxxxxx - All Sega Mega Drive (Genesis) Vitual Console games
+# Mxxxxx - All Sega Mega Drive (Genesis) Virtual Console games
 
 [Core]
 # Values set here will override the main Dolphin settings.


### PR DESCRIPTION
Should be Virtual Console I think.  Maybe.