### PR TITLE
Reimplement savestate loading via drag and drop (resubmission of #7425)

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -4,9 +4,14 @@
 
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QFileInfo>
 #include <QGuiApplication>
 #include <QIcon>
 #include <QKeyEvent>
+#include <QMessageBox>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QPalette>
 #include <QScreen>
@@ -14,6 +19,7 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/State.h"
 
 #include "DolphinQt/Host.h"
 #include "DolphinQt/RenderWidget.h"
@@ -27,6 +33,7 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
 {
   setWindowTitle(QStringLiteral("Dolphin"));
   setWindowIcon(Resources::GetAppIcon());
+  setAcceptDrops(true);
 
   QPalette p;
   p.setColor(QPalette::Background, Qt::black);
@@ -79,6 +86,37 @@ void RenderWidget::SetFillBackground(bool fill)
   setAttribute(Qt::WA_OpaquePaintEvent, !fill);
   setAttribute(Qt::WA_NoSystemBackground, !fill);
   setAutoFillBackground(fill);
+}
+
+void RenderWidget::dragEnterEvent(QDragEnterEvent* event)
+{
+  if (event->mimeData()->hasUrls() && event->mimeData()->urls().size() == 1)
+    event->acceptProposedAction();
+}
+
+void RenderWidget::dropEvent(QDropEvent* event)
+{
+  const auto& urls = event->mimeData()->urls();
+  if (urls.empty())
+    return;
+
+  const auto& url = urls[0];
+  QFileInfo file_info(url.toLocalFile());
+
+  auto path = file_info.filePath();
+
+  if (!file_info.exists() || !file_info.isReadable())
+  {
+    QMessageBox::critical(this, tr("Error"), tr("Failed to open '%1'").arg(path));
+    return;
+  }
+
+  if (!file_info.isFile())
+  {
+    return;
+  }
+
+  State::LoadAs(path.toStdString());
 }
 
 void RenderWidget::OnHideCursorChanged()

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -36,6 +36,8 @@ private:
   void OnKeepOnTopChanged(bool top);
   void SetFillBackground(bool fill);
   void OnFreeLookMouseMove(QMouseEvent* event);
+  void dragEnterEvent(QDragEnterEvent* event) override;
+  void dropEvent(QDropEvent* event) override;
 
   static constexpr int MOUSE_HIDE_DELAY = 3000;
   QTimer* m_mouse_timer;


### PR DESCRIPTION
Resubmission of #7425 as I forgot that I had made it from master, went to sync my fork, and destroyed the branch. Properly submitted from its own branch this time. Apologies!  

---------
Original description:

This PR re-implements the missing DolphinWX functionality where you could drag and drop a savestate onto the render window and it'd load it for you.

All savestate validation is already performed within State::LoadAs so I just lifted the drag and drop code from MainWindow and implemented it into RenderWidget.