### PR TITLE
Disable Deferred EFB Copies on Mario kart Wii

### DIFF
--- a/Data/Sys/GameSettings/RMC.ini
+++ b/Data/Sys/GameSettings/RMC.ini
@@ -14,6 +14,7 @@
 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
+DeferEFBCopies = False
 
 [Video_Stereoscopy]
 StereoConvergence = 613


### PR DESCRIPTION
Can cause random hangs on track load.