### PR TITLE
Qt/Debugger Code View: Uses font based sizing and whitespace

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -30,6 +30,8 @@ public:
   u32 GetContextAddress() const;
   void SetAddress(u32 address, SetAddressUpdate update);
 
+  // Set tighter row height. Set BP column sizing. This needs to run when font type changes.
+  void FontBasedSizing();
   void Update();
 
   void ToggleBreakpoint();


### PR DESCRIPTION
Row height is now based on font size, allows more rows to fit on screen.
Added whitespace for padding. Also sets a minimum size for columns to reduce frequent resizing while scrolling. Some resizing still allowed.
Fixed the scrollbar to always work, allowing you to read the symbol text to the end.