### PR TITLE
Qt/Debugger Memory Widget: Data input box updates

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -72,8 +72,9 @@ private:
   // Search
   QPushButton* m_find_next;
   QPushButton* m_find_previous;
-  QRadioButton* m_find_ascii;
-  QRadioButton* m_find_hex;
+  QRadioButton* m_input_ascii;
+  QRadioButton* m_input_float;
+  QRadioButton* m_input_hex;
   QLabel* m_result_label;
 
   // Datatypes

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -63,6 +63,7 @@ private:
   QSplitter* m_splitter;
   QLineEdit* m_search_address;
   QLineEdit* m_data_edit;
+  QLabel* m_data_preview;
   QPushButton* m_set_value;
   QPushButton* m_dump_mram;
   QPushButton* m_dump_exram;


### PR DESCRIPTION
-Groups input type radio buttons, so one is always selected.
-Fixes being unable to enter leading zeroes.
-Changes the logic so u32 selected and '1' entered -> 00000001.  Selecting u16 would give 0001. This is similar to how Wx worked and is easy to follow.
-Adds a preview box to make it clear what will get entered. It doesn't have borders like the input boxes, not sure if it makes it look weird. I just don't want it to be confused for an input box.
-Adds float input option for data box.