### PR TITLE
Qt/Debugger CodeView: Update frequency

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -156,20 +156,12 @@ CodeViewWidget::CodeViewWidget()
 
   FontBasedSizing();
 
+  // State-change updates are called from CodeWidget.
   connect(this, &CodeViewWidget::customContextMenuRequested, this, &CodeViewWidget::OnContextMenu);
   connect(this, &CodeViewWidget::itemSelectionChanged, this, &CodeViewWidget::OnSelectionChanged);
   connect(&Settings::Instance(), &Settings::DebugFontChanged, this, &QWidget::setFont);
   connect(&Settings::Instance(), &Settings::DebugFontChanged, this,
           &CodeViewWidget::FontBasedSizing);
-
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this] {
-    m_address = PC;
-    Update();
-  });
-  connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, [this] {
-    m_address = PC;
-    Update();
-  });
 
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &CodeViewWidget::Update);
 }


### PR DESCRIPTION
Removes a redundant update trigger.
Doesn't clear the screen when you hit play. It'll still clear when you try to scroll. Useful 

/edit &Settings::EmulationStateChanged also triggers from operations linked to RunAsCPUThread (not just on pause/play), so limiting the updates to when paused seems healthy. iirc panic handlers were being thrown due to it triggering when the game was running.