### PR TITLE
Qt\Settings-WiiPane: Clear up PAL60 option label and description

### DIFF
--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -99,7 +99,7 @@ void WiiPane::CreateMisc()
   auto* misc_settings_group_layout = new QGridLayout();
   misc_settings_group->setLayout(misc_settings_group_layout);
   m_main_layout->addWidget(misc_settings_group);
-  m_pal60_mode_checkbox = new QCheckBox(tr("Use PAL60 Mode (EuRGB60)"));
+  m_pal60_mode_checkbox = new QCheckBox(tr("Use PAL60/EuRGB60 Mode (PAL Only)"));
   m_screensaver_checkbox = new QCheckBox(tr("Enable Screen Saver"));
   m_sd_card_checkbox = new QCheckBox(tr("Insert SD Card"));
   m_connect_keyboard_checkbox = new QCheckBox(tr("Connect USB Keyboard"));
@@ -121,7 +121,7 @@ void WiiPane::CreateMisc()
   m_system_language_choice->addItem(tr("Korean"));
 
   m_pal60_mode_checkbox->setToolTip(tr("Sets the Wii display mode to 60Hz (480i) instead of 50Hz "
-                                       "(576i) for PAL games.\nMay not work for all games."));
+                                       "(576i) \nexhanging some visual fidelity for higher frame rate.\nMay not work for all PAL games."));
   m_screensaver_checkbox->setToolTip(tr("Dims the screen after five minutes of inactivity."));
   m_system_language_choice->setToolTip(tr("Sets the Wii system language."));
   m_sd_card_checkbox->setToolTip(tr("Saved to /Wii/sd.raw (default size is 128mb)."));


### PR DESCRIPTION
This setting seemed to and keept causing a pause/dilema whenever I thought of the consequences, as if something was missing. Turns out there is something more to it, it is infact PAL-only as I was wondering, it is forcefully disabled if it detects NTSC in the BootManager.cpp.  It's something that simply can't be immediately obvious to non-PAL users who never heard of this mode from the original console.

I went through several versions and it wasn't that easy because I wanted to avoid using PAL twice in the same sentence while keeping it as short as possible (otherwise it modifies the dialog box dimensions) I ended up with double PAL mention, but separated in a way that is read-out differently and sounds/feels good enough IMO.

Some of the iterations minus many their variants were:

- Use 60Hz mode for PAL games (EuRGB60)
- Use PAL60 mode for PAL games (EuRGB60)
- Attempt using 60Hz Mode for PAL games
- Try using PAL60 Mode for PAL games by default
- PAL Only: Use 60Hz Mode (EuRGB60)
