### PR TITLE
Added checks to avoid dereferencing null pointers returned by Config::GetLayer(), which typically result into crashes.

### DIFF
--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -44,17 +44,26 @@ const std::string& GetLayerName(LayerType layer);
 LayerType GetActiveLayerForConfig(const ConfigLocation&);
 
 template <typename T>
-T Get(LayerType layer, const ConfigInfo<T>& info)
+T Get(LayerType layer_type, const ConfigInfo<T>& info)
 {
-  if (layer == LayerType::Meta)
+  if (layer_type == LayerType::Meta)
     return Get(info);
-  return GetLayer(layer)->Get(info);
+
+  Layer* const layer = GetLayer(layer_type);
+  if (!layer)
+    return {};
+
+  return layer->Get(info);
 }
 
 template <typename T>
 T Get(const ConfigInfo<T>& info)
 {
-  return GetLayer(GetActiveLayerForConfig(info.location))->Get(info);
+  Layer* const layer = GetLayer(GetActiveLayerForConfig(info.location));
+  if (!layer)
+    return {};
+
+  return layer->Get(info);
 }
 
 template <typename T>
@@ -70,9 +79,13 @@ LayerType GetActiveLayerForConfig(const ConfigInfo<T>& info)
 }
 
 template <typename T>
-void Set(LayerType layer, const ConfigInfo<T>& info, const std::common_type_t<T>& value)
+void Set(LayerType layer_type, const ConfigInfo<T>& info, const std::common_type_t<T>& value)
 {
-  GetLayer(layer)->Set(info, value);
+  Layer* const layer = GetLayer(layer_type);
+  if (!layer)
+    return;
+
+  layer->Set(info, value);
   InvokeConfigChangedCallbacks();
 }
 


### PR DESCRIPTION
Because the pointer returned by `GetLayer()` was being dereferenced without checking against null, **Dolphin** would crash on shutdown if the layer had already been removed.

**Reproduction steps:**
- Open **Dolphin**.
- Start copying (or downloading) a game into any of the directories monitored by **Dolphin**. This will make the game list to be refreshed every now and then, until the game is fully copied (or downloaded).
- Exit **Dolphin** by clicking on the close button, or selecting `File > Exit` in the top bar menu.
- The application will potentially crash on shutdown:

```
Thread 10 "dolphin-emu" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffc59f6700 (LWP 6006)]
0x000055555566b41b in bool Config::Get<bool>(Config::ConfigInfo<bool> const&) ()
(gdb) bt
#0  0x000055555566b41b in bool Config::Get<bool>(Config::ConfigInfo<bool> const&) ()
#1  0x00005555559a1c3f in UICommon::GameFile::CustomCoverChanged() ()
#2  0x00005555559a8442 in UICommon::GameFileCache::UpdateAdditionalMetadata(std::shared_ptr<UICommon::GameFile>*) [clone .constprop.227] ()
#3  0x00005555559a9363 in UICommon::GameFileCache::AddOrGet(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool*) ()
#4  0x000055555571bd1b in GameTracker::LoadGame(QString const&) [clone .part.191] ()
#5  0x000055555571e08b in GameTracker::UpdateFileInternal(QString const&) ()
#6  0x000055555571fb8d in std::_Function_handler<void (GameTracker::Command), GameTracker::Command(QObject*)::{lambda(GameTracker::Command)#3}>::_M_invoke(std::_Any_data const&, GameTracker::Command&&) ()
#7  0x00005555557200a8 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<Common::WorkQueueThread<GameTracker::Command>::Reset(std::function<void (GameTracker::Command)>)::{lambda()#1}> > >::_M_run() ()
#8  0x00007ffff09eb57f in  () at /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007ffff0cbe6db in start_thread (arg=0x7fffc59f6700) at pthread_create.c:463
#10 0x00007ffff02c088f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```