### PR TITLE
Disable some Video settings for 1080° Snowboarding

### DIFF
--- a/Data/Sys/GameSettings/NAO.ini
+++ b/Data/Sys/GameSettings/NAO.ini
@@ -1,0 +1,19 @@
+# NAOJ01, NAOE01, NAOP01, NAOK01 - 1080° Snowboarding 
+
+[Core] 
+# Values set here will override the main Dolphin settings. 
+
+[OnLoad] 
+# Add memory patches to be loaded once on boot here. 
+
+[OnFrame] 
+# Add memory patches to be applied every frame here. 
+
+[ActionReplay] 
+# Add action replay cheats here. 
+
+[Video_Settings] 
+
+[Video_Hacks] 
+DeferEFBCopies = False 
+EFBToTextureEnable = False


### PR DESCRIPTION
If enabled, in game virtual screens don’t works and camera might go below ground.
Also fix some graphical effects in menus.

Screenshots can be provided if needed.
All videos backends are affected if those settings are enabled.