### PR TITLE
Qt/Debugger Code Widget: Click address box to go to address.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -61,6 +61,7 @@ private:
   void OnSelectFunctionCalls();
 
   void closeEvent(QCloseEvent*) override;
+  bool eventFilter(QObject* obj, QEvent* event) override;
 
   QLineEdit* m_search_address;
   QLineEdit* m_search_symbols;


### PR DESCRIPTION
Previously had to change the value in the address box to go to address again.

Surprisingly delicate issue. Can easily break highlighting the address when trying to enable a click signal.  Looks like this method works great though. Not sure if there's another preferred method though.

Also, made it so the address size must be 8 for the code view to navigate to it.