### PR TITLE
DolphinQt: Avoid leaking the GameListModel instance to gracefully shutdown the GameTracker and prevent a crash on exit

### DIFF
--- a/Source/Core/Common/WorkQueueThread.h
+++ b/Source/Core/Common/WorkQueueThread.h
@@ -27,6 +27,7 @@ public:
   {
     Shutdown();
     m_shutdown.Clear();
+    m_cancelled.Clear();
     m_function = std::move(function);
     m_thread = std::thread(&WorkQueueThread::ThreadLoop, this);
   }
@@ -34,12 +35,31 @@ public:
   template <typename... Args>
   void EmplaceItem(Args&&... args)
   {
+    if (!m_cancelled.IsSet())
     {
       std::lock_guard lg(m_lock);
       m_items.emplace(std::forward<Args>(args)...);
     }
     m_wakeup.Set();
   }
+
+  void Clear()
+  {
+    {
+      std::lock_guard lg(m_lock);
+      m_items = std::queue<T>();
+    }
+    m_wakeup.Set();
+  }
+
+  void Cancel()
+  {
+    m_cancelled.Set();
+    Clear();
+    Shutdown();
+  }
+
+  bool IsCancelled() const { return m_cancelled.IsSet(); }
 
 private:
   void Shutdown()
@@ -81,6 +101,7 @@ private:
   std::thread m_thread;
   Common::Event m_wakeup;
   Common::Flag m_shutdown;
+  Common::Flag m_cancelled;
   std::mutex m_lock;
   std::queue<T> m_items;
 };

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -33,7 +33,6 @@
 
 #include "DolphinQt/Config/ARCodeWidget.h"
 #include "DolphinQt/Config/GeckoCodeWidget.h"
-#include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/Settings.h"
 
 constexpr u32 MAX_RESULTS = 50;
@@ -152,7 +151,8 @@ static bool Compare(T mem_value, T value, CompareType op)
   }
 }
 
-CheatsManager::CheatsManager(QWidget* parent) : QDialog(parent)
+CheatsManager::CheatsManager(const GameListModel& game_list_model, QWidget* parent)
+    : QDialog(parent), m_game_list_model(game_list_model)
 {
   setWindowTitle(tr("Cheats Manager"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -175,11 +175,9 @@ void CheatsManager::OnStateChanged(Core::State state)
   if (state != Core::State::Running && state != Core::State::Paused)
     return;
 
-  auto* model = Settings::Instance().GetGameListModel();
-
-  for (int i = 0; i < model->rowCount(QModelIndex()); i++)
+  for (int i = 0; i < m_game_list_model.rowCount(QModelIndex()); i++)
   {
-    auto file = model->GetGameFile(i);
+    auto file = m_game_list_model.GetGameFile(i);
 
     if (file->GetGameID() == SConfig::GetInstance().GetGameID())
     {

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -11,6 +11,7 @@
 #include <QDialog>
 
 #include "Common/CommonTypes.h"
+#include "DolphinQt/GameList/GameListModel.h"
 
 class ARCodeWidget;
 class QComboBox;
@@ -39,7 +40,7 @@ class CheatsManager : public QDialog
 {
   Q_OBJECT
 public:
-  explicit CheatsManager(QWidget* parent = nullptr);
+  explicit CheatsManager(const GameListModel& game_list_model, QWidget* parent = nullptr);
   ~CheatsManager();
 
 private:
@@ -61,6 +62,7 @@ private:
   void OnMatchContextMenu();
   void OnWatchItemChanged(QTableWidgetItem* item);
 
+  const GameListModel& m_game_list_model;
   std::vector<Result> m_results;
   std::vector<Result> m_watch;
   std::shared_ptr<const UICommon::GameFile> m_game_file;

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -203,9 +203,13 @@ void GameList::UpdateColumnVisibility()
 
 void GameList::MakeEmptyView()
 {
+  const QString refreshing_msg = tr("Refreshing...");
+  const QString empty_msg = tr("Dolphin could not find any GameCube/Wii ISOs or WADs.\n"
+                               "Double-click here to set a games directory...");
+
   m_empty = new QLabel(this);
-  m_empty->setText(tr("Dolphin could not find any GameCube/Wii ISOs or WADs.\n"
-                      "Double-click here to set a games directory..."));
+  m_empty->setText(refreshing_msg);
+  m_empty->setEnabled(false);
   m_empty->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
   auto event_filter = new DoubleClickEventFilter{m_empty};
@@ -216,6 +220,21 @@ void GameList::MakeEmptyView()
     if (!dir.isEmpty())
       Settings::Instance().AddPath(dir);
   });
+
+  QSizePolicy size_policy{m_empty->sizePolicy()};
+  size_policy.setRetainSizeWhenHidden(true);
+  m_empty->setSizePolicy(size_policy);
+
+  connect(&Settings::Instance(), &Settings::GameListRefreshRequested, this,
+          [this, refreshing_msg = refreshing_msg] {
+            m_empty->setText(refreshing_msg);
+            m_empty->setEnabled(false);
+          });
+  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, this,
+          [this, empty_msg = empty_msg] {
+            m_empty->setText(empty_msg);
+            m_empty->setEnabled(true);
+          });
 }
 
 void GameList::resizeEvent(QResizeEvent* event)

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -8,7 +8,8 @@
 
 #include <QStackedWidget>
 
-class GameListModel;
+#include "DolphinQt/GameList/GameListModel.h"
+
 class QLabel;
 class QListView;
 class QSortFilterProxyModel;
@@ -45,6 +46,8 @@ public:
   void resizeEvent(QResizeEvent* event) override;
 
   void PurgeCache();
+
+  const GameListModel& GetGameListModel() const { return m_model; }
 
 signals:
   void GameSelected();
@@ -85,7 +88,7 @@ private:
   void ConsiderViewChange();
   void UpdateFont();
 
-  GameListModel* m_model;
+  GameListModel m_model;
   QSortFilterProxyModel* m_list_proxy;
   QSortFilterProxyModel* m_grid_proxy;
 

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -16,7 +16,6 @@
 #include "DiscIO/DirectoryBlob.h"
 
 #include "DolphinQt/QtUtils/QueueOnObject.h"
-#include "DolphinQt/QtUtils/RunOnObject.h"
 
 #include "DolphinQt/Settings.h"
 
@@ -162,7 +161,7 @@ void GameTracker::StartInternal()
 bool GameTracker::AddPath(const QString& dir)
 {
   if (Settings::Instance().IsAutoRefreshEnabled())
-    RunOnObject(this, [this, dir] { return addPath(dir); });
+    QueueOnObject(this, [this, dir] { return addPath(dir); });
 
   m_tracked_paths.push_back(dir);
 
@@ -172,7 +171,7 @@ bool GameTracker::AddPath(const QString& dir)
 bool GameTracker::RemovePath(const QString& dir)
 {
   if (Settings::Instance().IsAutoRefreshEnabled())
-    RunOnObject(this, [this, dir] { return removePath(dir); });
+    QueueOnObject(this, [this, dir] { return removePath(dir); });
 
   const auto index = m_tracked_paths.indexOf(dir);
 

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -156,6 +156,7 @@ void GameTracker::StartInternal()
     m_cache.Save();
 
   QueueOnObject(this, [] { Settings::Instance().NotifyMetadataRefreshComplete(); });
+  QueueOnObject(this, [] { Settings::Instance().NotifyRefreshGameListComplete(); });
 }
 
 bool GameTracker::AddPath(const QString& dir)
@@ -347,5 +348,5 @@ void GameTracker::LoadGame(const QString& path)
 void GameTracker::PurgeCache()
 {
   m_load_thread.EmplaceItem(Command{CommandType::PurgeCache, {}});
-  RefreshAll();
+  Settings::Instance().RefreshGameList();
 }

--- a/Source/Core/DolphinQt/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt/GameList/GameTracker.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -72,6 +73,7 @@ private:
     UpdateDirectory,
     UpdateFile,
     UpdateMetadata,
+    ResumeProcessing,
     PurgeCache,
     BeginRefresh,
     EndRefresh,
@@ -92,8 +94,8 @@ private:
   Common::Event m_initial_games_emitted_event;
   bool m_initial_games_emitted = false;
   bool m_started = false;
-  // Count of currently running refresh jobs
-  u32 m_busy_count = 0;
+  bool m_needs_purge = false;
+  std::atomic_bool m_processing_halted = false;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<const UICommon::GameFile>)

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -399,7 +399,7 @@ void MainWindow::CreateComponents()
   m_watch_widget = new WatchWidget(this);
   m_breakpoint_widget = new BreakpointWidget(this);
   m_code_widget = new CodeWidget(this);
-  m_cheats_manager = new CheatsManager(this);
+  m_cheats_manager = new CheatsManager(m_game_list->GetGameListModel(), this);
 
   const auto request_watch = [this](QString name, u32 addr) {
     m_watch_widget->AddWatch(name, addr);
@@ -1286,8 +1286,9 @@ void MainWindow::BootWiiSystemMenu()
 
 void MainWindow::NetPlayInit()
 {
-  m_netplay_setup_dialog = new NetPlaySetupDialog(this);
-  m_netplay_dialog = new NetPlayDialog;
+  const auto& game_list_model = m_game_list->GetGameListModel();
+  m_netplay_setup_dialog = new NetPlaySetupDialog(game_list_model, this);
+  m_netplay_dialog = new NetPlayDialog(game_list_model);
 #ifdef USE_DISCORD_PRESENCE
   m_netplay_discord = new DiscordHandler(this);
 #endif

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -506,7 +506,13 @@ void MenuBar::AddViewMenu()
   AddShowRegionsMenu(view_menu);
 
   view_menu->addSeparator();
-  view_menu->addAction(tr("Purge Game List Cache"), this, &MenuBar::PurgeGameListCache);
+  QAction* const purge_action =
+      view_menu->addAction(tr("Purge Game List Cache"), this, &MenuBar::PurgeGameListCache);
+  purge_action->setEnabled(false);
+  connect(&Settings::Instance(), &Settings::GameListRefreshRequested, purge_action,
+          [purge_action] { purge_action->setEnabled(false); });
+  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, purge_action,
+          [purge_action] { purge_action->setEnabled(true); });
   view_menu->addSeparator();
   view_menu->addAction(tr("Search"), this, &MenuBar::ShowSearch, QKeySequence::Find);
 }

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -511,7 +511,7 @@ void MenuBar::AddViewMenu()
   purge_action->setEnabled(false);
   connect(&Settings::Instance(), &Settings::GameListRefreshRequested, purge_action,
           [purge_action] { purge_action->setEnabled(false); });
-  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, purge_action,
+  connect(&Settings::Instance(), &Settings::GameListRefreshStarted, purge_action,
           [purge_action] { purge_action->setEnabled(true); });
   view_menu->addSeparator();
   view_menu->addAction(tr("Search"), this, &MenuBar::ShowSearch, QKeySequence::Find);

--- a/Source/Core/DolphinQt/NetPlay/GameListDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/GameListDialog.cpp
@@ -10,11 +10,10 @@
 #include <QListWidget>
 #include <QVBoxLayout>
 
-#include "DolphinQt/GameList/GameListModel.h"
-#include "DolphinQt/Settings.h"
 #include "UICommon/GameFile.h"
 
-GameListDialog::GameListDialog(QWidget* parent) : QDialog(parent)
+GameListDialog::GameListDialog(const GameListModel& game_list_model, QWidget* parent)
+    : QDialog(parent), m_game_list_model(game_list_model)
 {
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Select a game"));
@@ -47,16 +46,14 @@ void GameListDialog::ConnectWidgets()
 
 void GameListDialog::PopulateGameList()
 {
-  auto* game_list_model = Settings::Instance().GetGameListModel();
-
   m_game_list->clear();
 
-  for (int i = 0; i < game_list_model->rowCount(QModelIndex()); i++)
+  for (int i = 0; i < m_game_list_model.rowCount(QModelIndex()); i++)
   {
-    std::shared_ptr<const UICommon::GameFile> game = game_list_model->GetGameFile(i);
+    std::shared_ptr<const UICommon::GameFile> game = m_game_list_model.GetGameFile(i);
 
     auto* item =
-        new QListWidgetItem(QString::fromStdString(game_list_model->GetNetPlayName(*game)));
+        new QListWidgetItem(QString::fromStdString(m_game_list_model.GetNetPlayName(*game)));
     item->setData(Qt::UserRole, QVariant::fromValue(std::move(game)));
     m_game_list->addItem(item);
   }

--- a/Source/Core/DolphinQt/NetPlay/GameListDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/GameListDialog.h
@@ -6,7 +6,8 @@
 
 #include <QDialog>
 
-class GameListModel;
+#include "DolphinQt/GameList/GameListModel.h"
+
 class QVBoxLayout;
 class QListWidget;
 class QDialogButtonBox;
@@ -20,7 +21,7 @@ class GameListDialog : public QDialog
 {
   Q_OBJECT
 public:
-  explicit GameListDialog(QWidget* parent);
+  explicit GameListDialog(const GameListModel& game_list_model, QWidget* parent);
 
   int exec() override;
   const UICommon::GameFile& GetSelectedGame() const;
@@ -30,6 +31,7 @@ private:
   void ConnectWidgets();
   void PopulateGameList();
 
+  const GameListModel& m_game_list_model;
   QVBoxLayout* m_main_layout;
   QListWidget* m_game_list;
   QDialogButtonBox* m_button_box;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -9,11 +9,11 @@
 
 #include "Common/Lazy.h"
 #include "Core/NetPlayClient.h"
+#include "DolphinQt/GameList/GameListModel.h"
 #include "VideoCommon/OnScreenDisplay.h"
 
 class ChunkedProgressDialog;
 class MD5Dialog;
-class GameListModel;
 class PadMappingDialog;
 class QCheckBox;
 class QComboBox;
@@ -31,7 +31,7 @@ class NetPlayDialog : public QDialog, public NetPlay::NetPlayUI
 {
   Q_OBJECT
 public:
-  explicit NetPlayDialog(QWidget* parent = nullptr);
+  explicit NetPlayDialog(const GameListModel& game_list_model, QWidget* parent = nullptr);
   ~NetPlayDialog();
 
   void show(std::string nickname, bool use_traversal);
@@ -151,7 +151,7 @@ private:
   std::string m_current_game_name;
   Common::Lazy<std::string> m_external_ip_address;
   std::string m_nickname;
-  GameListModel* m_game_list_model = nullptr;
+  const GameListModel& m_game_list_model;
   bool m_use_traversal = false;
   bool m_is_copy_button_retry = false;
   bool m_got_stop_request = true;

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -21,7 +21,6 @@
 #include "Core/Config/NetplaySettings.h"
 #include "Core/NetPlayProto.h"
 
-#include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/UTF8CodePointCountValidator.h"
 #include "DolphinQt/Settings.h"
@@ -29,8 +28,8 @@
 #include "UICommon/GameFile.h"
 #include "UICommon/NetPlayIndex.h"
 
-NetPlaySetupDialog::NetPlaySetupDialog(QWidget* parent)
-    : QDialog(parent), m_game_list_model(Settings::Instance().GetGameListModel())
+NetPlaySetupDialog::NetPlaySetupDialog(const GameListModel& game_list_model, QWidget* parent)
+    : QDialog(parent), m_game_list_model(game_list_model)
 {
   setWindowTitle(tr("NetPlay Setup"));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -359,12 +358,12 @@ void NetPlaySetupDialog::PopulateGameList()
   QSignalBlocker blocker(m_host_games);
 
   m_host_games->clear();
-  for (int i = 0; i < m_game_list_model->rowCount(QModelIndex()); i++)
+  for (int i = 0; i < m_game_list_model.rowCount(QModelIndex()); i++)
   {
-    std::shared_ptr<const UICommon::GameFile> game = m_game_list_model->GetGameFile(i);
+    std::shared_ptr<const UICommon::GameFile> game = m_game_list_model.GetGameFile(i);
 
     auto* item =
-        new QListWidgetItem(QString::fromStdString(m_game_list_model->GetNetPlayName(*game)));
+        new QListWidgetItem(QString::fromStdString(m_game_list_model.GetNetPlayName(*game)));
     item->setData(Qt::UserRole, QVariant::fromValue(std::move(game)));
     m_host_games->addItem(item);
   }

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.h
@@ -6,7 +6,8 @@
 
 #include <QDialog>
 
-class GameListModel;
+#include "DolphinQt/GameList/GameListModel.h"
+
 class QCheckBox;
 class QComboBox;
 class QDialogButtonBox;
@@ -27,7 +28,7 @@ class NetPlaySetupDialog : public QDialog
 {
   Q_OBJECT
 public:
-  explicit NetPlaySetupDialog(QWidget* parent);
+  explicit NetPlaySetupDialog(const GameListModel& game_list_model, QWidget* parent);
 
   void accept() override;
   void show();
@@ -79,5 +80,5 @@ private:
   QCheckBox* m_host_upnp;
 #endif
 
-  GameListModel* m_game_list_model;
+  const GameListModel& m_game_list_model;
 };

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -24,7 +24,6 @@
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayServer.h"
 
-#include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
@@ -294,12 +293,6 @@ void Settings::SetLogConfigVisible(bool visible)
     GetQSettings().setValue(QStringLiteral("logging/logconfigvisible"), visible);
     emit LogConfigVisibilityChanged(visible);
   }
-}
-
-GameListModel* Settings::GetGameListModel() const
-{
-  static GameListModel* model = new GameListModel;
-  return model;
 }
 
 std::shared_ptr<NetPlay::NetPlayClient> Settings::GetNetPlayClient()

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -147,6 +147,11 @@ void Settings::RefreshGameList()
   emit GameListRefreshRequested();
 }
 
+void Settings::NotifyRefreshGameListStarted()
+{
+  emit GameListRefreshStarted();
+}
+
 void Settings::NotifyRefreshGameListComplete()
 {
   emit GameListRefreshCompleted();

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -72,6 +72,7 @@ public:
   QString GetDefaultGame() const;
   void SetDefaultGame(QString path);
   void RefreshGameList();
+  void NotifyRefreshGameListStarted();
   void NotifyRefreshGameListComplete();
   void RefreshMetadata();
   void NotifyMetadataRefreshComplete();
@@ -150,6 +151,7 @@ signals:
   void PathRemoved(const QString&);
   void DefaultGameChanged(const QString&);
   void GameListRefreshRequested();
+  void GameListRefreshStarted();
   void GameListRefreshCompleted();
   void TitleDBReloadRequested();
   void MetadataRefreshRequested();

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -26,7 +26,6 @@ class NetPlayClient;
 class NetPlayServer;
 }  // namespace NetPlay
 
-class GameListModel;
 class InputConfig;
 
 // UI settings to be stored in the config directory.
@@ -143,8 +142,6 @@ public:
   bool IsAnalyticsEnabled() const;
   void SetAnalyticsEnabled(bool enabled);
 
-  // Other
-  GameListModel* GetGameListModel() const;
 signals:
   void ConfigChanged();
   void EmulationStateChanged(Core::State new_state);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -23,7 +23,6 @@
 #include "Core/Config/UISettings.h"
 #include "Core/ConfigManager.h"
 
-#include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Settings.h"
 

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -46,6 +46,8 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::WidgetLockChanged, this,
           [this](bool locked) { setMovable(!locked); });
 
+  connect(&Settings::Instance(), &Settings::GameListRefreshRequested, this,
+          [this] { m_refresh_action->setEnabled(false); });
   connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, this,
           [this] { m_refresh_action->setEnabled(true); });
 
@@ -112,10 +114,8 @@ void ToolBar::MakeActions()
   m_set_pc_action = addAction(tr("Set PC"), this, &ToolBar::SetPCPressed);
 
   m_open_action = addAction(tr("Open"), this, &ToolBar::OpenPressed);
-  m_refresh_action = addAction(tr("Refresh"), [this] {
-    m_refresh_action->setEnabled(false);
-    emit RefreshPressed();
-  });
+  m_refresh_action = addAction(tr("Refresh"), [this] { emit RefreshPressed(); });
+  m_refresh_action->setEnabled(false);
 
   addSeparator();
 

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -48,7 +48,7 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
 
   connect(&Settings::Instance(), &Settings::GameListRefreshRequested, this,
           [this] { m_refresh_action->setEnabled(false); });
-  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, this,
+  connect(&Settings::Instance(), &Settings::GameListRefreshStarted, this,
           [this] { m_refresh_action->setEnabled(true); });
 
   OnEmulationStateChanged(Core::GetState());

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -90,7 +90,8 @@ std::shared_ptr<const GameFile> GameFileCache::AddOrGet(const std::string& path,
 bool GameFileCache::Update(
     const std::vector<std::string>& all_game_paths,
     std::function<void(const std::shared_ptr<const GameFile>&)> game_added_to_cache,
-    std::function<void(const std::string&)> game_removed_from_cache)
+    std::function<void(const std::string&)> game_removed_from_cache,
+    const std::atomic_bool& processing_halted)
 {
   // Copy game paths into a set, except ones that match DiscIO::ShouldHideFromGameList.
   // TODO: Prevent DoFileSearch from looking inside /files/ directories of DirectoryBlobs at all?
@@ -113,6 +114,9 @@ bool GameFileCache::Update(
     auto end = m_cached_files.end();
     while (it != end)
     {
+      if (processing_halted)
+        break;
+
       if (game_paths.erase((*it)->GetFilePath()))
       {
         ++it;
@@ -134,6 +138,9 @@ bool GameFileCache::Update(
   // aren't in m_cached_files, so we simply add all of them to m_cached_files.
   for (const std::string& path : game_paths)
   {
+    if (processing_halted)
+      break;
+
     auto file = std::make_shared<GameFile>(path);
     if (file->IsValid())
     {
@@ -149,12 +156,16 @@ bool GameFileCache::Update(
 }
 
 bool GameFileCache::UpdateAdditionalMetadata(
-    std::function<void(const std::shared_ptr<const GameFile>&)> game_updated)
+    std::function<void(const std::shared_ptr<const GameFile>&)> game_updated,
+    const std::atomic_bool& processing_halted)
 {
   bool cache_changed = false;
 
   for (std::shared_ptr<GameFile>& file : m_cached_files)
   {
+    if (processing_halted)
+      break;
+
     const bool updated = UpdateAdditionalMetadata(&file);
     cache_changed |= updated;
     if (game_updated && updated)

--- a/Source/Core/UICommon/GameFileCache.h
+++ b/Source/Core/UICommon/GameFileCache.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -44,9 +45,11 @@ public:
   // These functions return true if the call modified the cache.
   bool Update(const std::vector<std::string>& all_game_paths,
               std::function<void(const std::shared_ptr<const GameFile>&)> game_added_to_cache = {},
-              std::function<void(const std::string&)> game_removed_from_cache = {});
+              std::function<void(const std::string&)> game_removed_from_cache = {},
+              const std::atomic_bool& processing_halted = false);
   bool UpdateAdditionalMetadata(
-      std::function<void(const std::shared_ptr<const GameFile>&)> game_updated = {});
+      std::function<void(const std::shared_ptr<const GameFile>&)> game_updated = {},
+      const std::atomic_bool& processing_halted = false);
 
   bool Load();
   bool Save();


### PR DESCRIPTION
Because the **GameListModel** was never destroyed, its **GameTracker** instance outlived the **Config** module, which led to some crashes on shutdown.

The fix consists of binding the lifespan of **GameListModel** to the **GameList** instance, ensuring that the **GameTracker** is indeed destructed.

In order to be able to destroy the **GameTracker** instance, some _race conditions_, _deadlocks_ and _other crashes_ had to be addressed. These issues were all caused by a bad combination of the **GameTracker**'s worker thread and the `RunOnObject()` function.

To summarize the list of changes:
- All references to the **GameListModel** have been removed from **Settings**.
- The **GameListModel** instance is now owned by the **GameList** instance.
- Components that need to access the **GameListModel** instance are provided with a const reference in their constructors.
- The **GameTracker**'s internal worker thread is now flushed on shutdown, to avoid it accessing stale data, and to favor responsiveness.
- `RunOnObject()` has been replaced with `QueueOnObject()` in **GameTracker**, to prevent a deadlock on shutdown.
- (Extra) **Refresh** button and **Purge Game List Cache** menu entry have now their enabled state synced correctly, and they are not much more responsive.

---

The crash could be reproduced with the following steps:
- Open **Dolphin**.
- Start copying (or downloading) a game into any of the directories monitored by **Dolphin**. This will make the game list to be refreshed every now and then, until the game is fully copied (or downloaded).
- Exit **Dolphin** by clicking on the close button, or selecting **File > Exit** in the top bar menu.
- The application will potentially crash on shutdown:

```
Thread 10 "dolphin-emu" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffc59f6700 (LWP 6006)]
0x000055555566b41b in bool Config::Get<bool>(Config::ConfigInfo<bool> const&) ()
(gdb) bt
#0  0x000055555566b41b in bool Config::Get<bool>(Config::ConfigInfo<bool> const&) ()
#1  0x00005555559a1c3f in UICommon::GameFile::CustomCoverChanged() ()
#2  0x00005555559a8442 in UICommon::GameFileCache::UpdateAdditionalMetadata(std::shared_ptr<UICommon::GameFile>*) [clone .constprop.227] ()
#3  0x00005555559a9363 in UICommon::GameFileCache::AddOrGet(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool*) ()
#4  0x000055555571bd1b in GameTracker::LoadGame(QString const&) [clone .part.191] ()
#5  0x000055555571e08b in GameTracker::UpdateFileInternal(QString const&) ()
#6  0x000055555571fb8d in std::_Function_handler<void (GameTracker::Command), GameTracker::Command(QObject*)::{lambda(GameTracker::Command)#3}>::_M_invoke(std::_Any_data const&, GameTracker::Command&&) ()
#7  0x00005555557200a8 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<Common::WorkQueueThread<GameTracker::Command>::Reset(std::function<void (GameTracker::Command)>)::{lambda()#1}> > >::_M_run() ()
#8  0x00007ffff09eb57f in  () at /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007ffff0cbe6db in start_thread (arg=0x7fffc59f6700) at pthread_create.c:463
#10 0x00007ffff02c088f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```