### PR TITLE
Qt/MainWindow: Directly delete unparented dialogs

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -243,13 +243,13 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters) : QMainW
 
 MainWindow::~MainWindow()
 {
-  m_render_widget->deleteLater();
-  m_netplay_dialog->deleteLater();
+  delete m_render_widget;
+  delete m_netplay_dialog;
 
   for (int i = 0; i < 4; i++)
   {
-    m_gc_tas_input_windows[i]->deleteLater();
-    m_wii_tas_input_windows[i]->deleteLater();
+    delete m_gc_tas_input_windows[i];
+    delete m_wii_tas_input_windows[i];
   }
 
   ShutdownControllers();


### PR DESCRIPTION
Calling `deleteLater` in **MainWindow**'s destructor doesn't work, as the event loop will stop before it gets around to deleting these dialogs. The result is that shutdown procedures of these dialogs' aren't run (such as saving geometry).

Seeing as this is a **QObject** destructor, we should already be on the event loop anyways, so simply using `delete` should be safe.