### PR TITLE
Qt/MainWindow: Also display "List Columns" menu via right-click on table's header.

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -42,6 +42,7 @@
 #include "DolphinQt/GameList/GameListModel.h"
 #include "DolphinQt/GameList/GridProxyModel.h"
 #include "DolphinQt/GameList/ListProxyModel.h"
+#include "DolphinQt/MenuBar.h"
 #include "DolphinQt/QtUtils/DoubleClickEventFilter.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
@@ -120,6 +121,9 @@ void GameList::MakeListView()
 
   hor_header->restoreState(
       Settings::GetQSettings().value(QStringLiteral("tableheader/state")).toByteArray());
+
+  hor_header->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(hor_header, &QWidget::customContextMenuRequested, this, &GameList::ShowHeaderContextMenu);
 
   connect(hor_header, &QHeaderView::sortIndicatorChanged, this, &GameList::OnHeaderViewChanged);
   connect(hor_header, &QHeaderView::sectionCountChanged, this, &GameList::OnHeaderViewChanged);
@@ -221,6 +225,20 @@ void GameList::MakeGridView()
           [this](const QItemSelection&, const QItemSelection&) {
             emit SelectionChanged(GetSelectedGame());
           });
+}
+
+void GameList::ShowHeaderContextMenu(const QPoint& pos)
+{
+  const MenuBar* const menu_bar = MenuBar::GetMenuBar();
+  if (!menu_bar)
+    return;
+
+  QMenu* const list_columns_menu = menu_bar->GetListColumnsMenu();
+  if (!list_columns_menu)
+    return;
+
+  const QWidget* const widget = qobject_cast<QWidget*>(sender());
+  list_columns_menu->exec(widget ? widget->mapToGlobal(pos) : pos);
 }
 
 void GameList::ShowContextMenu(const QPoint&)

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -52,6 +52,7 @@ signals:
   void OpenGeneralSettings();
 
 private:
+  void ShowHeaderContextMenu(const QPoint& pos);
   void ShowContextMenu(const QPoint&);
   void OpenContainingFolder();
   void OpenProperties();

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -53,8 +53,12 @@
 
 #include "UICommon/GameFile.h"
 
+QPointer<MenuBar> MenuBar::s_menu_bar;
+
 MenuBar::MenuBar(QWidget* parent) : QMenuBar(parent)
 {
+  s_menu_bar = this;
+
   AddFileMenu();
   AddEmulationMenu();
   AddMovieMenu();
@@ -584,13 +588,13 @@ void MenuBar::AddListColumnsMenu(QMenu* view_menu)
       {tr("Tags"), &SConfig::GetInstance().m_showTagsColumn}};
 
   QActionGroup* column_group = new QActionGroup(this);
-  QMenu* cols_menu = view_menu->addMenu(tr("List Columns"));
+  m_cols_menu = view_menu->addMenu(tr("List Columns"));
   column_group->setExclusive(false);
 
   for (const auto& key : columns.keys())
   {
     bool* config = columns[key];
-    QAction* action = column_group->addAction(cols_menu->addAction(key));
+    QAction* action = column_group->addAction(m_cols_menu->addAction(key));
     action->setCheckable(true);
     action->setChecked(*config);
     connect(action, &QAction::toggled, [this, config, key](bool value) {

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -10,6 +10,7 @@
 
 #include <QMenu>
 #include <QMenuBar>
+#include <QPointer>
 
 namespace Core
 {
@@ -31,10 +32,14 @@ class MenuBar final : public QMenuBar
   Q_OBJECT
 
 public:
+  static MenuBar* GetMenuBar() { return s_menu_bar; }
+
   explicit MenuBar(QWidget* parent = nullptr);
 
   void UpdateStateSlotMenu();
   void UpdateToolsMenu(bool emulation_started);
+
+  QMenu* GetListColumnsMenu() const { return m_cols_menu; }
 
 #ifdef _WIN32
   void InstallUpdateManually();
@@ -169,6 +174,8 @@ private:
   void OnReadOnlyModeChanged(bool read_only);
   void OnDebugModeToggled(bool enabled);
 
+  static QPointer<MenuBar> s_menu_bar;
+
   // File
   QAction* m_open_action;
   QAction* m_exit_action;
@@ -225,6 +232,7 @@ private:
   QAction* m_show_breakpoints;
   QAction* m_show_memory;
   QAction* m_show_jit;
+  QMenu* m_cols_menu;
 
   // JIT
   QMenu* m_jit;


### PR DESCRIPTION
Probably right-clicking on the header is the first action that users attempt to take to hide/show columns.