### PR TITLE
Added sizecheck to avoid crash when no icon could be loaded

### DIFF
--- a/Source/Core/DolphinQt/Resources.cpp
+++ b/Source/Core/DolphinQt/Resources.cpp
@@ -46,6 +46,8 @@ QIcon Resources::GetIcon(const QString& name, const QString& dir)
 QPixmap Resources::GetPixmap(const QString& name, const QString& dir)
 {
   const auto icon = GetIcon(name, dir);
+  if (icon.availableSizes().length() == 0)
+    return {};
   return icon.pixmap(icon.availableSizes()[0]);
 }
 


### PR DESCRIPTION
I am able to reproduce the crash on Arch linux, debug build with gdb attached on startup (Loading the platform icons)