### PR TITLE
Qt/MainWindow: Add "Compact View" option that minimizes tool bar size and game list's default row height.

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -111,6 +111,7 @@ void GameList::MakeListView()
   m_list->setCurrentIndex(QModelIndex());
   m_list->setContextMenuPolicy(Qt::CustomContextMenu);
   m_list->setWordWrap(false);
+
   // Have 1 pixel of padding above and below the 32 pixel banners.
   m_list->verticalHeader()->setDefaultSectionSize(32 + 2);
 
@@ -1063,6 +1064,11 @@ void GameList::SetSearchTerm(const QString& term)
   m_grid_proxy->invalidate();
 
   UpdateColumnVisibility();
+}
+
+void GameList::SetRowHeight(const int height)
+{
+  m_list->verticalHeader()->setDefaultSectionSize(height);
 }
 
 void GameList::ZoomIn()

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -37,6 +37,7 @@ public:
   void SetGridView() { SetPreferredView(false); }
   void SetViewColumn(int col, bool view);
   void SetSearchTerm(const QString& term);
+  void SetRowHeight(int height);
 
   void OnColumnVisibilityToggled(const QString& row, bool visible);
   void OnGameListVisibilityChanged();

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -19,8 +19,6 @@
 #include "UICommon/GameFile.h"
 #include "UICommon/UICommon.h"
 
-const QSize GAMECUBE_BANNER_SIZE(96, 32);
-
 GameListModel::GameListModel(QObject* parent) : QAbstractTableModel(parent)
 {
   connect(&m_tracker, &GameTracker::GameLoaded, this, &GameListModel::AddGame);

--- a/Source/Core/DolphinQt/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt/GameList/GameListModel.h
@@ -9,6 +9,7 @@
 
 #include <QAbstractTableModel>
 #include <QMap>
+#include <QSize>
 #include <QString>
 #include <QStringList>
 #include <QVariant>
@@ -27,6 +28,8 @@ class GameListModel final : public QAbstractTableModel
   Q_OBJECT
 
 public:
+  static constexpr QSize GAMECUBE_BANNER_SIZE{96, 32};
+
   explicit GameListModel(QObject* parent = nullptr);
 
   // Qt's Model/View stuff uses these overrides.

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -423,6 +423,13 @@ void MenuBar::AddViewMenu()
 
   connect(lock_widgets, &QAction::toggled, &Settings::Instance(), &Settings::SetWidgetsLocked);
 
+  QAction* compact_view = view_menu->addAction(tr("Compact View"));
+  compact_view->setCheckable(true);
+  compact_view->setChecked(Settings::Instance().IsCompactViewEnabled());
+
+  connect(compact_view, &QAction::toggled, &Settings::Instance(), &Settings::SetCompactViewEnabled);
+  connect(&Settings::Instance(), &Settings::CompactViewChanged, compact_view, &QAction::setChecked);
+
   view_menu->addSeparator();
 
   m_show_code = view_menu->addAction(tr("&Code"));

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -176,6 +176,21 @@ void Settings::SetAutoRefreshEnabled(bool enabled)
   emit AutoRefreshToggled(enabled);
 }
 
+bool Settings::IsCompactViewEnabled() const
+{
+  return GetQSettings().value(QStringLiteral("CompactView"), false).toBool();
+}
+
+void Settings::SetCompactViewEnabled(bool enabled)
+{
+  if (IsCompactViewEnabled() == enabled)
+    return;
+
+  GetQSettings().setValue(QStringLiteral("CompactView"), enabled);
+
+  emit CompactViewChanged(enabled);
+}
+
 QString Settings::GetDefaultGame() const
 {
   return QString::fromStdString(Config::Get(Config::MAIN_DEFAULT_ISO));

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -79,6 +79,8 @@ public:
   void ReloadTitleDB();
   bool IsAutoRefreshEnabled() const;
   void SetAutoRefreshEnabled(bool enabled);
+  bool IsCompactViewEnabled() const;
+  void SetCompactViewEnabled(bool enabled);
 
   // Emulation
   int GetStateSlot() const;
@@ -154,6 +156,7 @@ signals:
   void MetadataRefreshRequested();
   void MetadataRefreshCompleted();
   void AutoRefreshToggled(bool enabled);
+  void CompactViewChanged(bool enabled);
   void HideCursorChanged();
   void KeepWindowOnTopChanged(bool top);
   void VolumeChanged(int volume);

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -145,6 +145,7 @@ void InterfacePane::CreateUI()
   // Checkboxes
   m_checkbox_use_builtin_title_database = new QCheckBox(tr("Use Built-In Database of Game Names"));
   m_checkbox_use_userstyle = new QCheckBox(tr("Use Custom User Style"));
+  m_checkbox_compact_view = new QCheckBox(tr("Compact View"));
   m_checkbox_use_covers =
       new QCheckBox(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"));
   m_checkbox_show_debugging_ui = new QCheckBox(tr("Show Debugging UI"));
@@ -152,6 +153,7 @@ void InterfacePane::CreateUI()
 
   groupbox_layout->addWidget(m_checkbox_use_builtin_title_database);
   groupbox_layout->addWidget(m_checkbox_use_userstyle);
+  groupbox_layout->addWidget(m_checkbox_compact_view);
   groupbox_layout->addWidget(m_checkbox_use_covers);
   groupbox_layout->addWidget(m_checkbox_show_debugging_ui);
   groupbox_layout->addWidget(m_checkbox_focused_hotkeys);
@@ -206,6 +208,9 @@ void InterfacePane::ConnectLayout()
   connect(m_checkbox_hide_mouse, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::SetHideCursor);
   connect(m_checkbox_use_userstyle, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_compact_view, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
+  connect(&Settings::Instance(), &Settings::CompactViewChanged, m_checkbox_compact_view,
+          &QCheckBox::setChecked);
 }
 
 void InterfacePane::LoadConfig()
@@ -225,6 +230,7 @@ void InterfacePane::LoadConfig()
     m_combobox_userstyle->setCurrentIndex(index);
 
   m_checkbox_use_userstyle->setChecked(Settings::Instance().AreUserStylesEnabled());
+  m_checkbox_compact_view->setChecked(Settings::Instance().IsCompactViewEnabled());
 
   const bool visible = m_checkbox_use_userstyle->isChecked();
 
@@ -249,6 +255,7 @@ void InterfacePane::OnSaveConfig()
   settings.m_use_builtin_title_database = m_checkbox_use_builtin_title_database->isChecked();
   Settings::Instance().SetDebugModeEnabled(m_checkbox_show_debugging_ui->isChecked());
   Settings::Instance().SetUserStylesEnabled(m_checkbox_use_userstyle->isChecked());
+  Settings::Instance().SetCompactViewEnabled(m_checkbox_compact_view->isChecked());
   Settings::Instance().SetCurrentUserStyle(m_combobox_userstyle->currentData().toString());
 
   const bool visible = m_checkbox_use_userstyle->isChecked();

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -34,6 +34,7 @@ private:
   QCheckBox* m_checkbox_top_window;
   QCheckBox* m_checkbox_use_builtin_title_database;
   QCheckBox* m_checkbox_use_userstyle;
+  QCheckBox* m_checkbox_compact_view;
   QCheckBox* m_checkbox_show_debugging_ui;
   QCheckBox* m_checkbox_focused_hotkeys;
   QCheckBox* m_checkbox_use_covers;

--- a/Source/Core/DolphinQt/ToolBar.h
+++ b/Source/Core/DolphinQt/ToolBar.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <QToolBar>
 
 class QAction;
@@ -44,6 +46,7 @@ signals:
 private:
   void OnEmulationStateChanged(Core::State state);
   void OnDebugModeToggled(bool enabled);
+  void OnCompactViewChanged(bool enabled);
 
   void MakeActions();
   void UpdateIcons();
@@ -65,4 +68,7 @@ private:
   QAction* m_skip_action;
   QAction* m_show_pc_action;
   QAction* m_set_pc_action;
+
+  std::vector<QWidget*> m_actions_widgets;
+  std::vector<QAction*> m_separators;
 };


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/11305. Also, it minimizes the tool bar size when in Compact View.

![compact view](https://user-images.githubusercontent.com/1853278/51441812-89f63c00-1ccd-11e9-9bc7-49bada99bf72.gif)
