### PR TITLE
Update GeckoCodes code download to use https

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -30,7 +30,7 @@ std::vector<GeckoCode> DownloadCodes(std::string gameid, bool* succeeded)
     break;
   }
 
-  std::string endpoint{"http://geckocodes.org/txt.php?txt=" + gameid};
+  std::string endpoint{"https://geckocodes.org/txt.php?txt=" + gameid};
   Common::HttpRequest http;
 
   // Circumvent high-tech DDOS protection


### PR DESCRIPTION
The WiiRD codes respository at https://geckocodes.org has started using HTTPS, and 301 Redirecting traffic from HTTP to HTTPS.  The HTTP client does not appear to be able to handle a 301 Redirect and instead fails when attempting to download codes. This pull request is purely a string replacement to set the URL as HTTPS.