### PR TITLE
General GameCubePane improvements

### DIFF
--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -10,10 +10,13 @@
 #include <QFileInfo>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QInputDialog>
 #include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QVBoxLayout>
+
+#include <utility>
 
 #include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
@@ -27,21 +30,12 @@
 
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 
-constexpr int SLOT_A_INDEX = 0;
-constexpr int SLOT_B_INDEX = 1;
-constexpr int SLOT_SP1_INDEX = 2;
-constexpr int SLOT_COUNT = 3;
-
-enum ExpansionSelection
+enum
 {
-  EXP_NOTHING = 0,
-  EXP_DUMMY = 1,
-  EXP_MEMORYCARD = 2,
-  EXP_BROADBAND = 2,
-  EXP_GCI_FOLDER = 3,
-  EXP_GECKO = 4,
-  EXP_AGP = 5,
-  EXP_MICROPHONE = 6
+  SLOT_A_INDEX,
+  SLOT_B_INDEX,
+  SLOT_SP1_INDEX,
+  SLOT_COUNT
 };
 
 GameCubePane::GameCubePane()
@@ -53,21 +47,25 @@ GameCubePane::GameCubePane()
 
 void GameCubePane::CreateWidgets()
 {
-  QVBoxLayout* layout = new QVBoxLayout;
+  QVBoxLayout* layout = new QVBoxLayout(this);
 
   // IPL Settings
-  QGroupBox* ipl_box = new QGroupBox(tr("IPL Settings"));
-  QGridLayout* ipl_layout = new QGridLayout;
+  QGroupBox* ipl_box = new QGroupBox(tr("IPL Settings"), this);
+  QGridLayout* ipl_layout = new QGridLayout(ipl_box);
   ipl_box->setLayout(ipl_layout);
 
-  m_skip_main_menu = new QCheckBox(tr("Skip Main Menu"));
-  m_override_language_ntsc = new QCheckBox(tr("Override Language on NTSC Games"));
-  m_language_combo = new QComboBox;
+  m_skip_main_menu = new QCheckBox(tr("Skip Main Menu"), ipl_box);
+  m_override_language_ntsc = new QCheckBox(tr("Override Language on NTSC Games"), ipl_box);
+  m_language_combo = new QComboBox(ipl_box);
+  m_language_combo->setCurrentIndex(-1);
 
   // Add languages
-  for (const auto& language :
-       {tr("English"), tr("German"), tr("French"), tr("Spanish"), tr("Italian"), tr("Dutch")})
-    m_language_combo->addItem(language);
+  for (const auto& entry : {std::make_pair(tr("English"), 0), std::make_pair(tr("German"), 1),
+                            std::make_pair(tr("French"), 2), std::make_pair(tr("Spanish"), 3),
+                            std::make_pair(tr("Italian"), 4), std::make_pair(tr("Dutch"), 5)})
+  {
+    m_language_combo->addItem(entry.first, entry.second);
+  }
 
   ipl_layout->addWidget(m_skip_main_menu, 0, 0);
   ipl_layout->addWidget(new QLabel(tr("System Language:")), 1, 0);
@@ -75,37 +73,40 @@ void GameCubePane::CreateWidgets()
   ipl_layout->addWidget(m_override_language_ntsc, 2, 0);
 
   // Device Settings
-  QGroupBox* device_box = new QGroupBox(tr("Device Settings"));
-  QGridLayout* device_layout = new QGridLayout;
+  QGroupBox* device_box = new QGroupBox(tr("Device Settings"), this);
+  QGridLayout* device_layout = new QGridLayout(device_box);
   device_box->setLayout(device_layout);
 
-  m_slot_combos[0] = new QComboBox;
-  m_slot_combos[1] = new QComboBox;
-  m_slot_combos[2] = new QComboBox;
-
-  m_slot_buttons[0] = new QPushButton(tr("..."));
-  m_slot_buttons[1] = new QPushButton(tr("..."));
-
-  m_slot_buttons[0]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-  m_slot_buttons[1]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-
-  const QString i10n_nothing = tr("<Nothing>");
-  const QString i10n_dummy = tr("Dummy");
+  for (int i = 0; i < SLOT_COUNT; i++)
+  {
+    m_slot_combos[i] = new QComboBox(device_box);
+    m_slot_buttons[i] = new QPushButton(tr("..."), device_box);
+    m_slot_buttons[i]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  }
 
   // Add slot devices
 
-  for (const auto& device : {i10n_nothing, i10n_dummy, tr("Memory Card"), tr("GCI Folder"),
-                             tr("USB Gecko"), tr("Advance Game Port"), tr("Microphone")})
+  for (const auto& entry :
+       {std::make_pair(tr("<Nothing>"), ExpansionInterface::EXIDEVICE_NONE),
+        std::make_pair(tr("Dummy"), ExpansionInterface::EXIDEVICE_DUMMY),
+        std::make_pair(tr("Memory Card"), ExpansionInterface::EXIDEVICE_MEMORYCARD),
+        std::make_pair(tr("GCI Folder"), ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER),
+        std::make_pair(tr("USB Gecko"), ExpansionInterface::EXIDEVICE_GECKO),
+        std::make_pair(tr("Advance Game Port"), ExpansionInterface::EXIDEVICE_AGP),
+        std::make_pair(tr("Microphone"), ExpansionInterface::EXIDEVICE_MIC)})
   {
-    m_slot_combos[0]->addItem(device);
-    m_slot_combos[1]->addItem(device);
+    m_slot_combos[0]->addItem(entry.first, entry.second);
+    m_slot_combos[1]->addItem(entry.first, entry.second);
   }
 
   // Add SP1 devices
 
-  for (const auto& device : {i10n_nothing, i10n_dummy, tr("Broadband Adapter")})
+  for (const auto& entry :
+       {std::make_pair(tr("<Nothing>"), ExpansionInterface::EXIDEVICE_NONE),
+        std::make_pair(tr("Dummy"), ExpansionInterface::EXIDEVICE_DUMMY),
+        std::make_pair(tr("Broadband Adapter"), ExpansionInterface::EXIDEVICE_ETH)})
   {
-    m_slot_combos[2]->addItem(device);
+    m_slot_combos[2]->addItem(entry.first, entry.second);
   }
 
   device_layout->addWidget(new QLabel(tr("Slot A:")), 0, 0);
@@ -116,6 +117,7 @@ void GameCubePane::CreateWidgets()
   device_layout->addWidget(m_slot_buttons[1], 1, 2);
   device_layout->addWidget(new QLabel(tr("SP1:")), 2, 0);
   device_layout->addWidget(m_slot_combos[2], 2, 1);
+  device_layout->addWidget(m_slot_buttons[2], 2, 2);
 
   layout->addWidget(ipl_box);
   layout->addWidget(device_box);
@@ -129,21 +131,40 @@ void GameCubePane::ConnectWidgets()
 {
   // IPL Settings
   connect(m_skip_main_menu, &QCheckBox::stateChanged, this, &GameCubePane::SaveSettings);
-  connect(m_language_combo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-          this, &GameCubePane::SaveSettings);
+  connect(m_language_combo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          &GameCubePane::SaveSettings);
   connect(m_override_language_ntsc, &QCheckBox::stateChanged, this, &GameCubePane::SaveSettings);
 
   // Device Settings
   for (int i = 0; i < SLOT_COUNT; i++)
   {
-    connect(m_slot_combos[i],
-            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+    connect(m_slot_combos[i], QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            [this, i] { UpdateButton(i); });
+    connect(m_slot_combos[i], QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &GameCubePane::SaveSettings);
-    if (i <= SLOT_B_INDEX)
-    {
-      connect(m_slot_buttons[i], &QPushButton::pressed, this, [this, i] { OnConfigPressed(i); });
-    }
+    connect(m_slot_buttons[i], &QPushButton::pressed, this, [this, i] { OnConfigPressed(i); });
   }
+}
+
+void GameCubePane::UpdateButton(int slot)
+{
+  const auto value = m_slot_combos[slot]->currentData().toInt();
+  bool has_config = false;
+
+  switch (slot)
+  {
+  case SLOT_A_INDEX:
+  case SLOT_B_INDEX:
+    has_config =
+        (value == ExpansionInterface::EXIDEVICE_MEMORYCARD ||
+         value == ExpansionInterface::EXIDEVICE_AGP || value == ExpansionInterface::EXIDEVICE_MIC);
+    break;
+  case SLOT_SP1_INDEX:
+    has_config = (value == ExpansionInterface::EXIDEVICE_ETH);
+    break;
+  }
+
+  m_slot_buttons[slot]->setEnabled(has_config);
 }
 
 void GameCubePane::OnConfigPressed(int slot)
@@ -151,22 +172,30 @@ void GameCubePane::OnConfigPressed(int slot)
   QString filter;
   bool memcard = false;
 
-  switch (m_slot_combos[slot]->currentIndex())
+  switch (m_slot_combos[slot]->currentData().toInt())
   {
-  // Memory card
-  case 2:
+  case ExpansionInterface::EXIDEVICE_MEMORYCARD:
     filter = tr("GameCube Memory Cards (*.raw *.gcp)");
     memcard = true;
     break;
-  // Advance Game Port
-  case 5:
+  case ExpansionInterface::EXIDEVICE_AGP:
     filter = tr("Game Boy Advance Carts (*.gba)");
-    memcard = false;
     break;
-  // Microphone
-  case 6:
+  case ExpansionInterface::EXIDEVICE_MIC:
     MappingWindow(this, MappingWindow::Type::MAPPING_GC_MICROPHONE, slot).exec();
     return;
+  case ExpansionInterface::EXIDEVICE_ETH:
+  {
+    bool ok;
+    const auto new_mac = QInputDialog::getText(
+        this, tr("Broadband adapter MAC address"), tr("Enter new broadband adapter MAC address:"),
+        QLineEdit::Normal, QString::fromStdString(SConfig::GetInstance().m_bba_mac), &ok);
+    if (ok)
+      SConfig::GetInstance().m_bba_mac = new_mac.toStdString();
+    return;
+  }
+  default:
+    qFatal("unknown settings pressed");
   }
 
   QString filename = QFileDialog::getSaveFileName(
@@ -197,8 +226,8 @@ void GameCubePane::OnConfigPressed(int slot)
     }
 
     bool other_slot_memcard =
-        m_slot_combos[slot == 0 ? SLOT_B_INDEX : SLOT_A_INDEX]->currentIndex() == EXP_MEMORYCARD;
-
+        m_slot_combos[slot == SLOT_A_INDEX ? SLOT_B_INDEX : SLOT_A_INDEX]->currentData().toInt() ==
+        ExpansionInterface::EXIDEVICE_MEMORYCARD;
     if (other_slot_memcard)
     {
       QString path_b =
@@ -270,7 +299,7 @@ void GameCubePane::LoadSettings()
 
   // IPL Settings
   m_skip_main_menu->setChecked(params.bHLE_BS2);
-  m_language_combo->setCurrentIndex(params.SelectedLanguage);
+  m_language_combo->setCurrentIndex(m_language_combo->findData(params.SelectedLanguage));
   m_override_language_ntsc->setChecked(params.bOverrideGCLanguage);
 
   bool have_menu = false;
@@ -294,44 +323,10 @@ void GameCubePane::LoadSettings()
 
   for (int i = 0; i < SLOT_COUNT; i++)
   {
-    int index = EXP_NOTHING;
-    switch (SConfig::GetInstance().m_EXIDevice[i])
-    {
-    case ExpansionInterface::EXIDEVICE_NONE:
-      index = EXP_NOTHING;
-      break;
-    case ExpansionInterface::EXIDEVICE_DUMMY:
-      index = EXP_DUMMY;
-      break;
-    case ExpansionInterface::EXIDEVICE_MEMORYCARD:
-      index = EXP_MEMORYCARD;
-      break;
-    case ExpansionInterface::EXIDEVICE_ETH:
-      index = EXP_BROADBAND;
-      break;
-    case ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER:
-      index = EXP_GCI_FOLDER;
-      break;
-    case ExpansionInterface::EXIDEVICE_GECKO:
-      index = EXP_GECKO;
-      break;
-    case ExpansionInterface::EXIDEVICE_AGP:
-      index = EXP_AGP;
-      break;
-    case ExpansionInterface::EXIDEVICE_MIC:
-      index = EXP_MICROPHONE;
-      break;
-    default:
-      break;
-    }
-
-    if (i <= SLOT_B_INDEX)
-    {
-      bool has_config = (index == EXP_MEMORYCARD || index > EXP_GECKO);
-      m_slot_buttons[i]->setEnabled(has_config);
-    }
-
-    m_slot_combos[i]->setCurrentIndex(index);
+    QSignalBlocker blocker(m_slot_combos[i]);
+    m_slot_combos[i]->setCurrentIndex(
+        m_slot_combos[i]->findData(SConfig::GetInstance().m_EXIDevice[i]));
+    UpdateButton(i);
   }
 }
 
@@ -342,45 +337,15 @@ void GameCubePane::SaveSettings()
   // IPL Settings
   params.bHLE_BS2 = m_skip_main_menu->isChecked();
   Config::SetBaseOrCurrent(Config::MAIN_SKIP_IPL, m_skip_main_menu->isChecked());
-  params.SelectedLanguage = m_language_combo->currentIndex();
-  Config::SetBaseOrCurrent(Config::MAIN_GC_LANGUAGE, m_language_combo->currentIndex());
+  params.SelectedLanguage = m_language_combo->currentData().toInt();
+  Config::SetBaseOrCurrent(Config::MAIN_GC_LANGUAGE, m_language_combo->currentData().toInt());
   params.bOverrideGCLanguage = m_override_language_ntsc->isChecked();
   Config::SetBaseOrCurrent(Config::MAIN_OVERRIDE_GC_LANGUAGE,
                            m_override_language_ntsc->isChecked());
 
   for (int i = 0; i < SLOT_COUNT; i++)
   {
-    auto dev = SConfig::GetInstance().m_EXIDevice[i];
-
-    int index = m_slot_combos[i]->currentIndex();
-
-    switch (index)
-    {
-    case EXP_NOTHING:
-      dev = ExpansionInterface::EXIDEVICE_NONE;
-      break;
-    case EXP_DUMMY:
-      dev = ExpansionInterface::EXIDEVICE_DUMMY;
-      break;
-    case EXP_MEMORYCARD:
-      if (i == SLOT_SP1_INDEX)
-        dev = ExpansionInterface::EXIDEVICE_ETH;
-      else
-        dev = ExpansionInterface::EXIDEVICE_MEMORYCARD;
-      break;
-    case EXP_GCI_FOLDER:
-      dev = ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER;
-      break;
-    case EXP_GECKO:
-      dev = ExpansionInterface::EXIDEVICE_GECKO;
-      break;
-    case EXP_AGP:
-      dev = ExpansionInterface::EXIDEVICE_AGP;
-      break;
-    case EXP_MICROPHONE:
-      dev = ExpansionInterface::EXIDEVICE_MIC;
-      break;
-    }
+    const auto dev = ExpansionInterface::TEXIDevices(m_slot_combos[i]->currentData().toInt());
 
     if (Core::IsRunning() && SConfig::GetInstance().m_EXIDevice[i] != dev)
     {

--- a/Source/Core/DolphinQt/Settings/GameCubePane.h
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.h
@@ -23,12 +23,13 @@ private:
   void LoadSettings();
   void SaveSettings();
 
+  void UpdateButton(int slot);
   void OnConfigPressed(int slot);
 
   QCheckBox* m_skip_main_menu;
   QCheckBox* m_override_language_ntsc;
   QComboBox* m_language_combo;
 
-  QPushButton* m_slot_buttons[2];
+  QPushButton* m_slot_buttons[3];
   QComboBox* m_slot_combos[3];
 };


### PR DESCRIPTION
I tried to simplify the combo box menu entry translations (by removing the big enum at the beginning).
This change also fixes parent memory management of widgets, update loops and adds an options button for SP1 devices (Broadband adapter now allows change of MAC address).

![image](https://user-images.githubusercontent.com/10342708/51444935-d7d76800-1cfe-11e9-93fa-cf3c45002603.png)