### PR TITLE
Android: Don't clear vibrators in onStop

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -309,7 +309,6 @@ public final class EmulationActivity extends AppCompatActivity
   protected void onStop()
   {
     super.onStop();
-    Rumble.clear();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
@@ -18,10 +18,12 @@ import java.util.HashMap;
 public class Rumble
 {
   private static Vibrator phoneVibrator;
-  private static SparseArray<Vibrator> emuVibrators;
+  private static final SparseArray<Vibrator> emuVibrators = new SparseArray<>();
 
   public static void initRumble(EmulationActivity activity)
   {
+    clear();
+
     if (activity.deviceHasTouchScreen() &&
             PreferenceManager.getDefaultSharedPreferences(activity)
                     .getBoolean("phoneRumble", true))
@@ -29,7 +31,6 @@ public class Rumble
       setPhoneVibrator(true, activity);
     }
 
-    emuVibrators = new SparseArray<>();
     for (int i = 0; i < 8; i++)
     {
       StringSetting deviceName =
@@ -65,7 +66,7 @@ public class Rumble
     }
   }
 
-  public static void clear()
+  private static void clear()
   {
     phoneVibrator = null;
     emuVibrators.clear();


### PR DESCRIPTION
Fixes issue where vibration would stop if you swapped between apps mid emulation.