### PR TITLE
Android: Optimize rumble call

### DIFF
--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -25,6 +25,8 @@ static jclass s_analytics_class;
 static jmethodID s_send_analytics_report;
 static jmethodID s_get_analytics_value;
 
+static jmethodID s_do_rumble;
+
 namespace IDCache
 {
 JavaVM* GetJavaVM()
@@ -86,6 +88,11 @@ jfieldID GetGameFileCachePointer()
   return s_game_file_cache_pointer;
 }
 
+jmethodID GetDoRumble()
+{
+  return s_do_rumble;
+}
+
 }  // namespace IDCache
 
 #ifdef __cplusplus
@@ -104,8 +111,9 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
   s_native_library_class = reinterpret_cast<jclass>(env->NewGlobalRef(native_library_class));
   s_display_alert_msg = env->GetStaticMethodID(s_native_library_class, "displayAlertMsg",
                                                "(Ljava/lang/String;Ljava/lang/String;Z)Z");
+  s_do_rumble = env->GetStaticMethodID(s_native_library_class, "rumble", "(ID)V");
   s_get_update_touch_pointer =
-      env->GetStaticMethodID(IDCache::GetNativeLibraryClass(), "updateTouchPointer", "()V");
+      env->GetStaticMethodID(s_native_library_class, "updateTouchPointer", "()V");
 
   const jclass game_file_class = env->FindClass("org/dolphinemu/dolphinemu/model/GameFile");
   s_game_file_class = reinterpret_cast<jclass>(env->NewGlobalRef(game_file_class));

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -14,6 +14,7 @@ JavaVM* GetJavaVM();
 
 jclass GetNativeLibraryClass();
 jmethodID GetDisplayAlertMsg();
+jmethodID GetDoRumble();
 jmethodID GetUpdateTouchPointer();
 
 jclass GetAnalyticsClass();

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -239,9 +239,7 @@ void Touchscreen::Motor::Rumble(int padID, double state)
 {
   JNIEnv* env;
   IDCache::GetJavaVM()->AttachCurrentThread(&env, nullptr);
-  jmethodID rumbleMethod =
-      env->GetStaticMethodID(IDCache::GetNativeLibraryClass(), "rumble", "(ID)V");
-  env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(), rumbleMethod, padID, state);
+  env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(), IDCache::GetDoRumble(), padID, state);
   IDCache::GetJavaVM()->DetachCurrentThread();
 }
 }


### PR DESCRIPTION
Moved rumble call to IDCache since GetMethodID is expensive