### PR TITLE
SI_DeviceGCController: Calibrate to perfect neutral instead of initial input state.

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -65,10 +65,9 @@ protected:
   };
 
   // struct to compare input against
-  // Set on connection and (standard pad only) on button combo
-  SOrigin m_origin;
-
-  bool m_calibrated = false;
+  // Set on connection to perfect neutral values
+  // (standard pad only) Set on button combo to current input state
+  SOrigin m_origin = {};
 
   // PADAnalogMode
   // Dunno if we need to do this, game/lib should set it?
@@ -111,7 +110,6 @@ public:
   static void Rumble(int pad_num, ControlState strength);
 
 protected:
-  void Calibrate();
   void HandleMoviePadStatus(GCPadStatus* pad_status);
 };
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 99;  // Last changed in PR 6020
+static const u32 STATE_VERSION = 100;  // Last changed in PR 7728
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This changes the GCController class to set the pad origin on boot to perfect neutral values rather than that of the initial input state.

Even though initial input state calibration emulates real controller behavior I believe this is undesirable for us.

If a user inadvertently moves their sticks/triggers too soon their controller becomes mis-calibrated. (see issue 10765)

There is at least one faulty input driver that initially returns garbage values which causes mis-calibration. (see issue 9051)

Using a sensible dead-zone setting makes initial value calibration essentially do nothing anyways.

Users can still use the X+Y+Start button combo to re-calibrate to the current input state if they desire.

This changes the save state version because the m_calibrated state has been eliminated.
(it could have been eliminated from the save-states regardless of this change)

This will fix these issues:
https://bugs.dolphin-emu.org/issues/9051
https://bugs.dolphin-emu.org/issues/10765