### PR TITLE
[RFC] fx fctiwzx in ARM64 JIT

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -339,8 +339,7 @@ void JitArm64::fctiwzx(UGeckoInstruction inst)
   }
   else
   {
-    m_float_emit.FCVT(32, 64, EncodeRegToDouble(VD), EncodeRegToDouble(VB));
-    m_float_emit.FCVTS(EncodeRegToSingle(VD), EncodeRegToSingle(VD), ROUND_Z);
+    m_float_emit.FCVTS(EncodeRegToDouble(VD), EncodeRegToDouble(VD), ROUND_Z);
   }
   m_float_emit.ORR(EncodeRegToDouble(VD), EncodeRegToDouble(VD), EncodeRegToDouble(V0));
   fpr.Unlock(V0);


### PR DESCRIPTION
fx [Darkness black screen on launch with JIT arm64 recompiler](https://bugs.dolphin-emu.org/issues/11390) 
I don't know why, but it works.