### PR TITLE
Qt/MainWindow: Don't unpause after confirming shutdown

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -766,11 +766,13 @@ bool MainWindow::RequestStop()
                                            "before it completes. Force stop?") :
                                         tr("Do you want to stop the current emulation?"));
 
-    if (pause)
-      Core::SetState(state);
-
     if (confirm != QMessageBox::Yes)
+    {
+      if (pause)
+        Core::SetState(state);
+
       return false;
+    }
   }
 
   // TODO: Add Movie shutdown


### PR DESCRIPTION
There's no good reason to do this, as it just causes running signals to be sent as the core is shutting down.