### PR TITLE
Renderer: Fix throttle-disable (TAB) hotkey when vsync is enabled

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -601,7 +601,7 @@ void Present()
   // flag when it is supported, even when presenting in windowed mode.
   // However, this flag cannot be used if the app is in fullscreen mode as a
   // result of calling SetFullscreenState.
-  if (AllowTearingSupported() && !g_ActiveConfig.IsVSync() && !GetFullscreenState())
+  if (AllowTearingSupported() && !g_ActiveConfig.bVSyncActive && !GetFullscreenState())
     present_flags |= DXGI_PRESENT_ALLOW_TEARING;
 
   if (swapchain->IsTemporaryMonoSupported() && g_ActiveConfig.stereo_mode != StereoMode::QuadBuffer)
@@ -610,7 +610,7 @@ void Present()
   }
 
   // TODO: Is 1 the correct value for vsyncing?
-  swapchain->Present(static_cast<UINT>(g_ActiveConfig.IsVSync()), present_flags);
+  swapchain->Present(static_cast<UINT>(g_ActiveConfig.bVSyncActive), present_flags);
 }
 
 HRESULT SetFullscreenState(bool enable_fullscreen)

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -751,7 +751,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
 
   // Handle VSync on/off
   if (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VSYNC))
-    m_main_gl_context->SwapInterval(g_ActiveConfig.IsVSync());
+    m_main_gl_context->SwapInterval(g_ActiveConfig.bVSyncActive);
 
   // Because of the fixed framebuffer size we need to disable the resolution
   // options while running
@@ -1439,7 +1439,7 @@ void Renderer::OnConfigChanged(u32 bits)
   }
 
   if (bits & CONFIG_CHANGE_BIT_VSYNC && !DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VSYNC))
-    m_main_gl_context->SwapInterval(g_ActiveConfig.IsVSync());
+    m_main_gl_context->SwapInterval(g_ActiveConfig.bVSyncActive);
 
   if (bits & CONFIG_CHANGE_BIT_ANISOTROPY)
     g_sampler_cache->Clear();

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -735,7 +735,7 @@ void Renderer::OnConfigChanged(u32 bits)
   if (m_swap_chain && bits & CONFIG_CHANGE_BIT_VSYNC)
   {
     g_command_buffer_mgr->WaitForGPUIdle();
-    m_swap_chain->SetVSync(g_ActiveConfig.IsVSync());
+    m_swap_chain->SetVSync(g_ActiveConfig.bVSyncActive);
   }
 
   // For quad-buffered stereo we need to change the layer count, so recreate the swap chain.

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -213,8 +213,8 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   std::unique_ptr<SwapChain> swap_chain;
   if (surface != VK_NULL_HANDLE)
   {
-    swap_chain =
-        SwapChain::Create(wsi.display_connection, wsi.render_surface, surface, g_Config.IsVSync());
+    swap_chain = SwapChain::Create(wsi.display_connection, wsi.render_surface, surface,
+                                   g_ActiveConfig.bVSyncActive);
     if (!swap_chain)
     {
       PanicAlert("Failed to create Vulkan swap chain.");

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -243,7 +243,7 @@ void Renderer::CheckForConfigChanges()
   const u32 old_multisamples = g_ActiveConfig.iMultisamples;
   const int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
   const bool old_force_filtering = g_ActiveConfig.bForceFiltering;
-  const bool old_vsync = g_ActiveConfig.IsVSync();
+  const bool old_vsync = g_ActiveConfig.bVSyncActive;
   const bool old_bbox = g_ActiveConfig.bBBoxEnable;
 
   UpdateActiveConfig();
@@ -264,7 +264,7 @@ void Renderer::CheckForConfigChanges()
     changed_bits |= CONFIG_CHANGE_BIT_ANISOTROPY;
   if (old_force_filtering != g_ActiveConfig.bForceFiltering)
     changed_bits |= CONFIG_CHANGE_BIT_FORCE_TEXTURE_FILTERING;
-  if (old_vsync != g_ActiveConfig.IsVSync())
+  if (old_vsync != g_ActiveConfig.bVSyncActive)
     changed_bits |= CONFIG_CHANGE_BIT_VSYNC;
   if (old_bbox != g_ActiveConfig.bBBoxEnable)
     changed_bits |= CONFIG_CHANGE_BIT_BBOX;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -19,11 +19,19 @@ VideoConfig g_Config;
 VideoConfig g_ActiveConfig;
 static bool s_has_registered_callback = false;
 
+static bool IsVSyncActive(bool enabled)
+{
+  // Vsync is disabled when the throttler is disabled by the tab key.
+  return enabled && !Core::GetIsThrottlerTempDisabled() &&
+         SConfig::GetInstance().m_EmulationSpeed == 1.0;
+}
+
 void UpdateActiveConfig()
 {
   if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
     Movie::SetGraphicsConfig();
   g_ActiveConfig = g_Config;
+  g_ActiveConfig.bVSyncActive = IsVSyncActive(g_ActiveConfig.bVSync);
 }
 
 VideoConfig::VideoConfig()
@@ -173,12 +181,6 @@ void VideoConfig::VerifyValidity()
       stereo_mode = StereoMode::Off;
     }
   }
-}
-
-bool VideoConfig::IsVSync() const
-{
-  return bVSync && !Core::GetIsThrottlerTempDisabled() &&
-         SConfig::GetInstance().m_EmulationSpeed == 1.0;
 }
 
 bool VideoConfig::UsingUberShaders() const

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -56,10 +56,10 @@ struct VideoConfig final
   VideoConfig();
   void Refresh();
   void VerifyValidity();
-  bool IsVSync() const;
 
   // General
   bool bVSync;
+  bool bVSyncActive;
   bool bWidescreenHack;
   AspectMode aspect_mode;
   AspectMode suggested_aspect_mode;


### PR DESCRIPTION
What the title says. Regression was introduced with imgui refactoring.