### PR TITLE
DolphinQt: Fix selection of PP shader when using anaglyph 3D.

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -153,10 +153,9 @@ void EnhancementsWidget::LoadPPShaders()
 {
   const bool anaglyph = g_Config.stereo_mode == StereoMode::Anaglyph;
   std::vector<std::string> shaders =
-      g_Config.stereo_mode == StereoMode::Anaglyph ?
-          PostProcessingShaderImplementation::GetAnaglyphShaderList(
-              g_Config.backend_info.api_type) :
-          PostProcessingShaderImplementation::GetShaderList(g_Config.backend_info.api_type);
+      anaglyph ? PostProcessingShaderImplementation::GetAnaglyphShaderList(
+                     g_Config.backend_info.api_type) :
+                 PostProcessingShaderImplementation::GetShaderList(g_Config.backend_info.api_type);
 
   m_pp_effect->clear();
 
@@ -261,9 +260,11 @@ void EnhancementsWidget::SaveSettings()
 
   Config::SetBaseOrCurrent(Config::GFX_SSAA, is_ssaa);
 
-  Config::SetBaseOrCurrent(
-      Config::GFX_ENHANCE_POST_SHADER,
-      m_pp_effect->currentIndex() == 0 ? "(off)" : m_pp_effect->currentText().toStdString());
+  const bool anaglyph = g_Config.stereo_mode == StereoMode::Anaglyph;
+  Config::SetBaseOrCurrent(Config::GFX_ENHANCE_POST_SHADER,
+                           (!anaglyph && m_pp_effect->currentIndex() == 0) ?
+                               "(off)" :
+                               m_pp_effect->currentText().toStdString());
 
   PostProcessingShaderConfiguration pp_shader;
   if (Config::Get(Config::GFX_ENHANCE_POST_SHADER) != "(off)")


### PR DESCRIPTION
Logic incorrectly assumed the first item in the QComboBox was always an "off" setting.

Fixes issue: https://bugs.dolphin-emu.org/issues/11344