### PR TITLE
DolphinQt: Reduce the padding between gamelist items.

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -107,8 +107,8 @@ void GameList::MakeListView()
   m_list->setCurrentIndex(QModelIndex());
   m_list->setContextMenuPolicy(Qt::CustomContextMenu);
   m_list->setWordWrap(false);
-  m_list->verticalHeader()->setDefaultSectionSize(m_list->verticalHeader()->defaultSectionSize() *
-                                                  1.25);
+  // Have 1 pixel of padding above and below the 32 pixel banners.
+  m_list->verticalHeader()->setDefaultSectionSize(32 + 2);
 
   connect(m_list, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
   connect(m_list->selectionModel(), &QItemSelectionModel::selectionChanged,


### PR DESCRIPTION
This reduces the padding between game list rows.
The old row height seemed to be arbitrary at default * 1.25.

before: https://i.imgur.com/cWuNVtz.png
after: https://i.imgur.com/lPXF1L1.png

Eliminates issue: https://bugs.dolphin-emu.org/issues/11305