### PR TITLE
Android: Use SelectedGames instead of SelectedGame in StartupHandler 

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -26,18 +26,26 @@ public final class StartupHandler
     // Ask the user if he wants to enable analytics if we haven't yet.
     Analytics.checkAnalyticsInit(parent);
 
-    String start_file = "";
+    String[] start_files = null;
     Bundle extras = parent.getIntent().getExtras();
     if (extras != null)
     {
-      start_file = extras.getString("AutoStartFile");
+      start_files = extras.getStringArray("AutoStartFiles");
+      if (start_files == null)
+      {
+        String start_file = extras.getString("AutoStartFile");
+        if (!TextUtils.isEmpty(start_file))
+        {
+          start_files = new String[]{start_file};
+        }
+      }
     }
 
-    if (!TextUtils.isEmpty(start_file))
+    if (start_files != null && start_files.length > 0)
     {
       // Start the emulation activity, send the ISO passed in and finish the main activity
       Intent emulation_intent = new Intent(parent, EmulationActivity.class);
-      emulation_intent.putExtra(EmulationActivity.EXTRA_SELECTED_GAMES, new String[]{start_file});
+      emulation_intent.putExtra(EmulationActivity.EXTRA_SELECTED_GAMES, start_files);
       parent.startActivity(emulation_intent);
       parent.finish();
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -37,7 +37,7 @@ public final class StartupHandler
     {
       // Start the emulation activity, send the ISO passed in and finish the main activity
       Intent emulation_intent = new Intent(parent, EmulationActivity.class);
-      emulation_intent.putExtra("SelectedGame", start_file);
+      emulation_intent.putExtra(EmulationActivity.EXTRA_SELECTED_GAMES, new String[]{start_file});
       parent.startActivity(emulation_intent);
       parent.finish();
     }


### PR DESCRIPTION
Regression from the automatic disc change PR. See https://forums.dolphin-emu.org/Thread-commit-63c9831-broke-game-autostarting-on-android