### PR TITLE
WiimoteDevice: Update UI when wiimote connection status changes.

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -180,6 +180,9 @@ bool WiimoteDevice::LinkChannel()
   DEBUG_LOG(IOS_WIIMOTE, "ConnectionState CONN_LINKING -> CONN_COMPLETE");
   m_connection_state = ConnectionState::Complete;
 
+  // Update wiimote connection status in the UI
+  Host_UpdateDisasmDialog();
+
   return false;
 }
 
@@ -218,8 +221,12 @@ void WiimoteDevice::EventDisconnect()
   Wiimote::ControlChannel(m_connection_handle & 0xFF, 99, nullptr, 0);
 
   m_connection_state = ConnectionState::Inactive;
+
   // Clear channel flags
   ResetChannels();
+
+  // Update wiimote connection status in the UI
+  Host_UpdateDisasmDialog();
 }
 
 bool WiimoteDevice::EventPagingChanged(u8 page_mode) const


### PR DESCRIPTION
The check marks in the menu bar are now accurate.

Fixes issue: https://bugs.dolphin-emu.org/issues/6240