### PR TITLE
HW/Wiimote: Wiimote source change reconnection fix

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -768,6 +768,13 @@ void Pause()
 void ChangeWiimoteSource(unsigned int index, int source)
 {
   const int previous_source = g_wiimote_sources[index];
+
+  if (previous_source == source)
+  {
+    // No change. Do nothing.
+    return;
+  }
+
   g_wiimote_sources[index] = source;
   {
     // kill real connection (or swap to different slot)
@@ -919,4 +926,4 @@ bool IsNewWiimote(const std::string& identifier)
   return s_known_ids.count(identifier) == 0;
 }
 
-};  // end of namespace
+};  // namespace WiimoteReal


### PR DESCRIPTION
Don't reconnect wiimotes on ChangeWiimoteSource when the source hasn't actually changed.

This fixes the issue where all wiimotes are temporarily disconnected when opening the "Controllers" window for the first time.

It also fixes the issue where all wiimote are temporarily disconnected when changing any controller settings.