### PR TITLE
WIP - ControllerInterface: Some attempts at making macOS joystick input more reliable.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.h
@@ -19,25 +19,29 @@ private:
   class Button : public Input
   {
   public:
-    Button(IOHIDElementRef element, IOHIDDeviceRef device) : m_element(element), m_device(device) {}
+    Button(IOHIDElementRef element, IOHIDDeviceRef device, unsigned int index)
+        : m_element(element), m_device(device), m_index(index)
+    {
+    }
     std::string GetName() const override;
     ControlState GetState() const override;
 
   private:
     const IOHIDElementRef m_element;
     const IOHIDDeviceRef m_device;
+    const unsigned int m_index;
   };
 
   class Axis : public Input
   {
   public:
-    enum direction
+    enum class Direction
     {
-      positive = 0,
-      negative
+      Positive = 0,
+      Negative,
     };
 
-    Axis(IOHIDElementRef element, IOHIDDeviceRef device, direction dir);
+    Axis(IOHIDElementRef element, IOHIDDeviceRef device, Direction dir, bool force_cookie_name);
     std::string GetName() const override;
     ControlState GetState() const override;
 
@@ -45,31 +49,32 @@ private:
     const IOHIDElementRef m_element;
     const IOHIDDeviceRef m_device;
     std::string m_name;
-    const direction m_direction;
-    float m_neutral;
-    float m_scale;
+    ControlState m_neutral;
+    ControlState m_range;
   };
 
   class Hat : public Input
   {
   public:
-    enum direction
+    enum class Direction : u8
     {
-      up = 0,
-      right,
-      down,
-      left
+      Up = 0,
+      Right = 1,
+      Down = 2,
+      Left = 3,
     };
 
-    Hat(IOHIDElementRef element, IOHIDDeviceRef device, direction dir);
+    Hat(IOHIDElementRef element, IOHIDDeviceRef device, Direction dir, unsigned int index);
     std::string GetName() const override;
     ControlState GetState() const override;
 
   private:
     const IOHIDElementRef m_element;
     const IOHIDDeviceRef m_device;
-    const char* m_name;
-    const direction m_direction;
+    const Direction m_direction;
+    const unsigned int m_index;
+    const CFIndex m_min;
+    const CFIndex m_max;
   };
 
 public:
@@ -86,5 +91,5 @@ private:
 
   ForceFeedback::FFDeviceAdapterReference m_ff_device;
 };
-}
-}
+}  // namespace OSX
+}  // namespace ciface


### PR DESCRIPTION
Apparently some devices like to return elements with duplicate usages. This has caused axes to malfunction in the past and was fixed by ignoring all except the last element for each usage.
That has seemed to cause some users to have have missing axes.

I've hopefully found a middle ground where duplicate axes are used but named differently.

There are reports of missing buttons.

The button enumeration code is pretty straightforward so I can only assume that they are being named inappropriately.
I've now named buttons according to their enumeration order rather than their usage.
This matches the behavior of most of our other input backends.

Only one "hatswitch" was supported.
Now any number of enumerated hats should function.

GetState calls no longer invoke IOHIDElementGetLogicalMin/Max.
Hopefully this reduces input related slowdowns experienced by some users.

I've renamed "Input" to "IOKit".

Code is untested as I lack macOS.

Relevant issues:
https://bugs.dolphin-emu.org/issues/9801
https://bugs.dolphin-emu.org/issues/10568
https://bugs.dolphin-emu.org/issues/10647
https://bugs.dolphin-emu.org/issues/11239
https://bugs.dolphin-emu.org/issues/11289