### PR TITLE
HW: SI_Device_GCAdapter: Restore calibration behavior for real gamecube controllers.

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -37,6 +37,11 @@ GCPadStatus CSIDevice_GCAdapter::GetPadStatus()
 
   HandleMoviePadStatus(&pad_status);
 
+  // Our GCAdapter code sets PAD_GET_ORIGIN when a new device has been connected.
+  // Watch for this to calibrate real controllers on connection.
+  if (pad_status.button & PAD_GET_ORIGIN)
+    SetOrigin(pad_status);
+
   return pad_status;
 }
 

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -149,6 +149,12 @@ GCPadStatus CSIDevice_GCController::GetPadStatus()
   }
 
   HandleMoviePadStatus(&pad_status);
+
+  // Our GCAdapter code sets PAD_GET_ORIGIN when a new device has been connected.
+  // Watch for this to calibrate real controllers on connection.
+  if (pad_status.button & PAD_GET_ORIGIN)
+    SetOrigin(pad_status);
+
   return pad_status;
 }
 
@@ -257,16 +263,13 @@ CSIDevice_GCController::HandleButtonCombos(const GCPadStatus& pad_status)
     {
       if (m_last_button_combo == COMBO_RESET)
       {
+        INFO_LOG(SERIALINTERFACE, "PAD - COMBO_RESET");
         ProcessorInterface::ResetButton_Tap();
       }
       else if (m_last_button_combo == COMBO_ORIGIN)
       {
-        m_origin.origin_stick_x = pad_status.stickX;
-        m_origin.origin_stick_y = pad_status.stickY;
-        m_origin.substick_x = pad_status.substickX;
-        m_origin.substick_y = pad_status.substickY;
-        m_origin.trigger_left = pad_status.triggerLeft;
-        m_origin.trigger_right = pad_status.triggerRight;
+        INFO_LOG(SERIALINTERFACE, "PAD - COMBO_ORIGIN");
+        SetOrigin(pad_status);
       }
 
       m_last_button_combo = COMBO_NONE;
@@ -275,6 +278,16 @@ CSIDevice_GCController::HandleButtonCombos(const GCPadStatus& pad_status)
   }
 
   return COMBO_NONE;
+}
+
+void CSIDevice_GCController::SetOrigin(const GCPadStatus& pad_status)
+{
+  m_origin.origin_stick_x = pad_status.stickX;
+  m_origin.origin_stick_y = pad_status.stickY;
+  m_origin.substick_x = pad_status.substickX;
+  m_origin.substick_y = pad_status.substickY;
+  m_origin.trigger_left = pad_status.triggerLeft;
+  m_origin.trigger_right = pad_status.triggerRight;
 }
 
 // SendCommand

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -111,6 +111,7 @@ public:
 
 protected:
   void HandleMoviePadStatus(GCPadStatus* pad_status);
+  void SetOrigin(const GCPadStatus& pad_status);
 };
 
 // "TaruKonga", the DK Bongo controller


### PR DESCRIPTION
Calibrating to perfect neutral (PR #7728) is causing issues with real gamecube controllers.

Restore the old calibration behavior for GCAdapter and calibrate to perfect neutral only for fully emulated controllers.

I've unfortunately had to put some duplicate logic in GCController and GCAdapter because of how unorganized our netplay code is.