### PR TITLE
DolphinQt: cache filesystem icons for speed

### DIFF
--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -86,6 +86,10 @@ void FilesystemWidget::ConnectWidgets()
 
 void FilesystemWidget::PopulateView()
 {
+  // Cache these two icons, the tree will use them a lot.
+  m_folder_icon = Resources::GetScaledIcon("isoproperties_folder");
+  m_file_icon = Resources::GetScaledIcon("isoproperties_file");
+
   auto* disc = new QStandardItem(tr("Disc"));
   disc->setEditable(false);
   disc->setIcon(Resources::GetScaledIcon("isoproperties_disc"));
@@ -131,8 +135,7 @@ void FilesystemWidget::PopulateDirectory(int partition_id, QStandardItem* root,
   {
     auto* item = new QStandardItem(QString::fromStdString(info.GetName()));
     item->setEditable(false);
-    item->setIcon(Resources::GetScaledIcon(info.IsDirectory() ? "isoproperties_folder" :
-                                                                "isoproperties_file"));
+    item->setIcon(info.IsDirectory() ? m_folder_icon : m_file_icon);
 
     if (info.IsDirectory())
       PopulateDirectory(partition_id, item, info);

--- a/Source/Core/DolphinQt/Config/FilesystemWidget.h
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QIcon>
 #include <memory>
 
 #include "UICommon/GameFile.h"
@@ -53,4 +54,7 @@ private:
 
   UICommon::GameFile m_game;
   std::unique_ptr<DiscIO::Volume> m_volume;
+
+  QIcon m_folder_icon;
+  QIcon m_file_icon;
 };


### PR DESCRIPTION
Opening the game properties dialog can take multiple seconds for games with many files. Caching the icons of the items in the filesystem treeview reduces this time dramatically. The game Cars (GKJE78) for example has over 24000 file system entries. On my laptop it currently takes 12 seconds to load the properties dialog, with this change it takes 250 ms.