### PR TITLE
DolphinQt: Connect Host::RequestStop() to MainWindow::RequestStop()

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -578,6 +578,7 @@ void MainWindow::ConnectHost()
 {
   connect(Host::GetInstance(), &Host::UpdateProgressDialog, this,
           &MainWindow::OnUpdateProgressDialog);
+  connect(Host::GetInstance(), &Host::RequestStop, this, &MainWindow::RequestStop);
 }
 
 void MainWindow::ConnectStack()


### PR DESCRIPTION
The fact that this wasn't connected was causing fifoplayer to hang if looping was disabled.