### PR TITLE
ResourcePacks: Support compression

### DIFF
--- a/Source/Core/UICommon/ResourcePack/Manifest.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manifest.cpp
@@ -29,6 +29,7 @@ Manifest::Manifest(const std::string& json)
   picojson::value& authors = out.get("authors");
   picojson::value& description = out.get("description");
   picojson::value& website = out.get("website");
+  picojson::value& compressed = out.get("compressed");
 
   if (!name.is<std::string>() || !id.is<std::string>() || !version.is<std::string>())
   {
@@ -58,6 +59,9 @@ Manifest::Manifest(const std::string& json)
 
   if (website.is<std::string>())
     m_website = website.to_str();
+
+  if (compressed.is<bool>())
+    m_compressed = compressed.get<bool>();
 }
 
 bool Manifest::IsValid() const
@@ -99,4 +103,10 @@ const std::optional<std::string>& Manifest::GetWebsite() const
 {
   return m_website;
 }
+
+bool Manifest::IsCompressed() const
+{
+  return m_compressed;
+}
+
 }  // namespace ResourcePack

--- a/Source/Core/UICommon/ResourcePack/Manifest.h
+++ b/Source/Core/UICommon/ResourcePack/Manifest.h
@@ -15,6 +15,7 @@ public:
   explicit Manifest(const std::string& text);
 
   bool IsValid() const;
+  bool IsCompressed() const;
 
   const std::string& GetName() const;
   const std::string& GetVersion() const;
@@ -27,6 +28,7 @@ public:
 
 private:
   bool m_valid = true;
+  bool m_compressed = false;
 
   std::string m_name;
   std::string m_version;

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -126,8 +126,8 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
     if (filename.compare(0, 9, "textures/") != 0 || texture_info.uncompressed_size == 0)
       continue;
 
-    // If a texture is compressed, abort.
-    if (texture_info.compression_method != 0)
+    // If a texture is compressed and the manifest doesn't state that, abort.
+    if (!m_manifest->IsCompressed() && texture_info.compression_method != 0)
     {
       m_valid = false;
       m_error = "Texture " + filename + " is compressed!";


### PR DESCRIPTION
Adds compression support to resource packs via the ``compressed`` field in manifests.