### PR TITLE
Fix QComboBox background and transparency workaround on macOS

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/WrapInScrollArea.cpp
+++ b/Source/Core/DolphinQt/QtUtils/WrapInScrollArea.cpp
@@ -30,17 +30,8 @@ QWidget* GetWrappedWidget(QWidget* wrapped_widget, QWidget* to_resize, int margi
                       std::max(recommended_height, to_resize->height()));
   }
 
-#if defined(_WIN32) || defined(__APPLE__)
-  // Transparency can cause unwanted side-effects on OSes other than Windows / macOS
-
-  // Make sure the background color stays consistent with the parent widget
-  QPalette p = wrapped_widget->palette();
-
-  p.setColor(QPalette::Window, QColor(0, 0, 0, 0));
-
-  wrapped_widget->setPalette(p);
-  scroll->setPalette(p);
-#endif
+  scroll->viewport()->setAutoFillBackground(false);
+  wrapped_widget->setAutoFillBackground(false);
 
   return scroll;
 }


### PR DESCRIPTION
This is an attempted fix for https://bugs.dolphin-emu.org/issues/11256. The commit that seem to have caused the issue is https://github.com/dolphin-emu/dolphin/commit/4bf276e912d3fa172b18a83e1d832b5a463fb8b5.

To better understand why `4bf276e` causes the issue, I changed Line 39 in the below file to `p.setColor(QPalette::Window, Qt::black);`, and this is the result,
![solution](https://user-images.githubusercontent.com/20979457/52159846-dbaca800-2677-11e9-880c-fab1f0ac8112.png)

As you can see, Line 39, `p.setColor(QPalette::Window, QColor(0, 0, 0, 0));` changes the background color of QComboBox at the top and bottom to be transparent and gives the impression that the rounded corners are gone, which is what the issue on the issue tracker is referring to. This PR restores the default palette of all QComboBoxes in the QWidget that `GetWrappedWidget()` is called for and restores the rounded corners to ensure proper UI on macOS for Qt apps. AFAIK, this applies to Settings, Graphics and the Properties Dialog. 

This is a fix on macOS but I don't know how it will impact Windows for those QComboBoxes. I can take a look at it later if needed.