### PR TITLE
WiimoteEmu: Make IR cursor Y position tilt the wiimote slightly.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
@@ -51,7 +51,7 @@ void EmulateDynamicShake(NormalizedAccelData* accel, DynamicData& dynamic_data,
                          u8* shake_step);
 
 void EmulateTilt(NormalizedAccelData* accel, ControllerEmu::Tilt* tilt_group, bool sideways = false,
-                 bool upright = false);
+                 bool upright = false, double cursor_tilt = 0.0);
 
 void EmulateSwing(NormalizedAccelData* accel, ControllerEmu::Force* swing_group, double intensity,
                   bool sideways = false, bool upright = false);


### PR DESCRIPTION
Pointing the the wiimote to control the cursor should affect motion data as it would on physical hardware.

This PR applies some tilt to the wiimote when moving the cursor up and down.

Skyward Sword will require this for menu navigation.

This is a temporary/semi-hacky solution until I rework emulated wiimote movement, which I plan to do after emulated M+ is merged with just basic movement support at first.