### PR TITLE
DolphinQt: show game descriptions in one line

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -123,7 +123,10 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     break;
   case COL_DESCRIPTION:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
-      return QString::fromStdString(game.GetDescription());
+    {
+      return QString::fromStdString(game.GetDescription())
+          .replace(QLatin1Char('\n'), QLatin1Char(' '));
+    }
     break;
   case COL_MAKER:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)


### PR DESCRIPTION
The GameCube disc menu has two lines of text available for the description. In Dolphin's game list we want everything on a single line, so replace newlines with spaces.