### PR TITLE
WiimoteEmu: Change speaker pan to use "constant power pan law".

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -391,8 +391,7 @@ void Wiimote::HandleSpeakerData(const WiimoteCommon::OutputReportSpeakerData& rp
     else
     {
       // Speaker Pan
-      // GUI clamps pan setting from -127 to 127. Why?
-      const auto pan = int(m_options->numeric_settings[0]->GetValue() * 100);
+      const auto pan = m_options->numeric_settings[0]->GetValue();
 
       m_speaker_logic.SpeakerData(rpt.data, rpt.length, pan);
     }

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.h
@@ -23,7 +23,8 @@ public:
   void Reset();
   void DoState(PointerWrap& p);
 
-  void SpeakerData(const u8* data, int length, int speaker_pan);
+  // Pan is -1.0 to +1.0
+  void SpeakerData(const u8* data, int length, float speaker_pan);
 
 private:
   // TODO: enum class

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -233,7 +233,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
                                                false, ControllerEmu::SettingType::NORMAL, true));
 
   m_options->numeric_settings.emplace_back(
-      std::make_unique<ControllerEmu::NumericSetting>(_trans("Speaker Pan"), 0, -127, 127));
+      std::make_unique<ControllerEmu::NumericSetting>(_trans("Speaker Pan"), 0, -100, 100));
   m_options->numeric_settings.emplace_back(
       m_battery_setting = new ControllerEmu::NumericSetting(_trans("Battery"), 95.0 / 100, 0, 100));
 


### PR DESCRIPTION
This is a re-implementation of @kamiyo's PR #3474.
> A constant power pan law is audibly more pleasing than linear, since linear makes signals panned to the center seem softer than those panned either all the way to the left or all the way to the right. See: http://www.rs-met.com/documents/tutorials/PanRules.pdf

-kamiyo

I've also changed the UI pan setting from a -127..127 range to -100..100.
There's no need to expose the internals of our mixer.