### PR TITLE
Change QDialog Close button from RejectRole to AcceptRole

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -112,6 +112,8 @@ add_executable(dolphin-emu
   QtUtils/WinIconHelper.cpp
   QtUtils/WrapInScrollArea.cpp
   QtUtils/AspectRatioWidget.cpp
+  QtUtils/CustomDialog.h
+  QtUtils/CustomDialog.cpp
   ResourcePackManager.cpp
   Settings/AdvancedPane.cpp
   Settings/AudioPane.cpp

--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -21,7 +21,7 @@
 
 #include "Core/Core.h"
 
-SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
+SettingsWindow::SettingsWindow(QWidget* parent) : CustomDialog(parent)
 {
   // Set Window Properties
   setWindowTitle(tr("Settings"));

--- a/Source/Core/DolphinQt/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <QDialog>
+#include "DolphinQt/QtUtils/CustomDialog.h"
 
 class QTabWidget;
 
@@ -14,7 +14,7 @@ enum class TabIndex
   Audio = 2
 };
 
-class SettingsWindow final : public QDialog
+class SettingsWindow final : public CustomDialog
 {
   Q_OBJECT
 public:

--- a/Source/Core/DolphinQt/QtUtils/CustomDialog.cpp
+++ b/Source/Core/DolphinQt/QtUtils/CustomDialog.cpp
@@ -1,0 +1,22 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/QtUtils/CustomDialog.h"
+
+#include <QPushButton>
+
+CustomDialog::CustomDialog(QWidget *parent)
+    : QDialog(parent)
+{
+}
+
+void CustomDialog::setLayout(QLayout *layout)
+{
+    QPushButton* fake_button = new QPushButton(QStringLiteral(""));
+    fake_button->setDefault(true);
+
+    layout->addWidget(fake_button);
+    QDialog::setLayout(layout);
+    fake_button->close();
+}

--- a/Source/Core/DolphinQt/QtUtils/CustomDialog.h
+++ b/Source/Core/DolphinQt/QtUtils/CustomDialog.h
@@ -1,0 +1,17 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QLayout>
+
+// A custom QDialog that injects a fake default button when setting an input QLayout
+class CustomDialog : public QDialog
+{
+public:
+    explicit CustomDialog(QWidget *parent = 0);
+
+    void setLayout(QLayout *layout);
+};


### PR DESCRIPTION
This PR fixes https://bugs.dolphin-emu.org/issues/11184. While it says it affects macOS, Windows is also affected.

Because the Settings , Controllers and Mapping windows are QDialog classes, the first QPushButton added seems to be automatically designated as "default." This behavior is unique to QDialog classes. A "default" QPushButton means if the user press enter, it will automatically activate. This akin to a "Open File" Dialog and pressing enter to "press" the blue OK button. 

This issue can be seen for example, in the first tab, General, when opening Config window where the "Generate a New Statistics Identity" button appears as blue and will activate if the user press enter. Or the first Configure Button when opening the Controllers window as described in the above issue at the issue tracker. 

This PR changes the "Close" button (contained in QDialogButtonBox) for each of the QDialog windows to having the AcceptRole instead of the RejectRole. This prioritizes the "Close" Button as the default button and will activate if the user uses "Enter" as per the [documentation](http://doc.qt.io/qt-5/qdialogbuttonbox.html):

>However, if there is no default button set and to preserve which button is the default button across platforms when using the QPushButton::autoDefault property, the first push button with the accept role is made the default button when the QDialogButtonBox is shown.

This will prevent all QPushButtons in a dialog window from being "default" and from activating upon the user pressing Enter; instead the "Close" button will activate. Any QPushButton that wants to be "default" instead of the "Close" button will simply need to be set as default after their creation: `setDefault(true)`.

This PR so far only fixes the Config, Controller and Mapping windows. Likely any QDialog window that has a "Close" Button should be changed to having an AcceptRole so that the QPushButtons in those windows or future QPushButtons aren't considered "default" just because they come before the Close Button. I can add a second commit to cover those cases (or amend and force-push).