### PR TITLE
DolphinQt: Make the mapping window clear button use ControllerEmu's clear functionality.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingBool.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingBool.cpp
@@ -26,13 +26,6 @@ void MappingBool::Connect()
   });
 }
 
-void MappingBool::Clear()
-{
-  m_setting->SetValue(false);
-  m_parent->SaveSettings();
-  Update();
-}
-
 void MappingBool::Update()
 {
   setChecked(m_setting->GetValue());

--- a/Source/Core/DolphinQt/Config/Mapping/MappingBool.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingBool.h
@@ -18,7 +18,6 @@ class MappingBool : public QCheckBox
 public:
   MappingBool(MappingWidget* widget, ControllerEmu::BooleanSetting* setting);
 
-  void Clear();
   void Update();
 
 private:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -28,13 +28,6 @@ void MappingNumeric::Connect()
           });
 }
 
-void MappingNumeric::Clear()
-{
-  m_setting->SetValue(m_setting->m_default_value);
-  m_parent->SaveSettings();
-  Update();
-}
-
 void MappingNumeric::Update()
 {
   setValue(m_setting->GetValue() * 100);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.h
@@ -19,7 +19,6 @@ class MappingNumeric : public QSpinBox
 public:
   MappingNumeric(MappingWidget* widget, ControllerEmu::NumericSetting* ref);
 
-  void Clear();
   void Update();
 
 private:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingRadio.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingRadio.cpp
@@ -26,13 +26,6 @@ void MappingRadio::Connect()
   });
 }
 
-void MappingRadio::Clear()
-{
-  m_setting->SetValue(false);
-  m_parent->SaveSettings();
-  Update();
-}
-
 void MappingRadio::Update()
 {
   setChecked(m_setting->GetValue());

--- a/Source/Core/DolphinQt/Config/Mapping/MappingRadio.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingRadio.h
@@ -18,7 +18,6 @@ class MappingRadio : public QRadioButton
 public:
   MappingRadio(MappingWidget* widget, ControllerEmu::BooleanSetting* setting);
 
-  void Clear();
   void Update();
 
 private:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -24,7 +24,6 @@
 
 MappingWidget::MappingWidget(MappingWindow* window) : m_parent(window)
 {
-  connect(window, &MappingWindow::ClearFields, this, &MappingWidget::OnClearFields);
   connect(window, &MappingWindow::Update, this, &MappingWidget::Update);
   connect(window, &MappingWindow::Save, this, &MappingWidget::SaveSettings);
 }
@@ -139,21 +138,6 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     form_layout->addRow(new MappingIndicator(group));
 
   return group_box;
-}
-
-void MappingWidget::OnClearFields()
-{
-  for (auto* button : m_buttons)
-    button->Clear();
-
-  for (auto* spinbox : m_numerics)
-    spinbox->Clear();
-
-  for (auto* checkbox : m_bools)
-    checkbox->Clear();
-
-  for (auto* radio : m_radio)
-    radio->Clear();
 }
 
 void MappingWidget::Update()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -60,8 +60,6 @@ protected:
   QGroupBox* CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group);
 
 private:
-  void OnClearFields();
-
   MappingWindow* m_parent;
   bool m_first = true;
   std::vector<MappingBool*> m_bools;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -143,7 +143,7 @@ void MappingWindow::ConnectWidgets()
   connect(m_devices_refresh, &QPushButton::clicked, this, &MappingWindow::RefreshDevices);
   connect(m_devices_combo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
           this, &MappingWindow::OnDeviceChanged);
-  connect(m_reset_clear, &QPushButton::clicked, this, [this] { emit ClearFields(); });
+  connect(m_reset_clear, &QPushButton::clicked, this, &MappingWindow::OnClearFieldsPressed);
   connect(m_reset_default, &QPushButton::clicked, this, &MappingWindow::OnDefaultFieldsPressed);
   connect(m_profiles_save, &QPushButton::clicked, this, &MappingWindow::OnSaveProfilePressed);
   connect(m_profiles_load, &QPushButton::clicked, this, &MappingWindow::OnLoadProfilePressed);
@@ -375,6 +375,16 @@ std::shared_ptr<ciface::Core::Device> MappingWindow::GetDevice() const
 void MappingWindow::OnDefaultFieldsPressed()
 {
   m_controller->LoadDefaults(g_controller_interface);
+  m_controller->UpdateReferences(g_controller_interface);
+  emit Update();
+  emit Save();
+}
+
+void MappingWindow::OnClearFieldsPressed()
+{
+  // Loading an empty inifile section clears everything.
+  IniFile::Section sec;
+  m_controller->LoadConfig(&sec);
   m_controller->UpdateReferences(g_controller_interface);
   emit Update();
   emit Save();

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -56,7 +56,6 @@ public:
 
 signals:
   void Update();
-  void ClearFields();
   void Save();
 
 private:
@@ -75,6 +74,7 @@ private:
   void OnLoadProfilePressed();
   void OnSaveProfilePressed();
   void OnDefaultFieldsPressed();
+  void OnClearFieldsPressed();
   void OnDeviceChanged(int index);
   void OnGlobalDevicesChanged();
 


### PR DESCRIPTION
Rather than sending a clear signal to all the widgets we can directly clear the controller and just update the UI. (This is what the WxWidgets dialog did and is what the "Default" button basically does)

This makes the "Clear" button complete instantly instead of taking seconds while every single widget calls SaveSettings().

It also no longer forces newly added widget types to implement their own clear functionality. (which is what I ran into causing me to become irate)