### PR TITLE
Qt: Set MappingIndicator background to transparent

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -24,7 +24,7 @@
 // Color constants to keep things looking consistent:
 // TODO: could we maybe query theme colors from Qt for the bounding box?
 const QColor BBOX_PEN_COLOR = Qt::darkGray;
-const QColor BBOX_BRUSH_COLOR = Qt::white;
+const QColor BBOX_BRUSH_COLOR = Qt::transparent;
 
 const QColor RAW_INPUT_COLOR = Qt::darkGray;
 const QColor ADJ_INPUT_COLOR = Qt::red;


### PR DESCRIPTION
Makes MappingIndicators look much better with custom styles or macOS dark mode.

**Before:**
![before](https://user-images.githubusercontent.com/35514663/52437048-7a536180-2adb-11e9-8bc5-4a56c053a3e0.png)

**After:**
![after](https://user-images.githubusercontent.com/35514663/52437056-83443300-2adb-11e9-8148-8fbbec380f06.png)
