### PR TITLE
Android: Allowing changing disc while emulating Wii

### DIFF
--- a/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
@@ -133,4 +133,9 @@
         </menu>
     </item>
 
+    <item
+        android:id="@+id/menu_change_disc"
+        app:showAsAction="never"
+        android:title="@string/emulation_change_disc"/>
+
 </menu>


### PR DESCRIPTION
There's no good reason this should be locked to GameCube. Think of all the Dragon Quest X fans :(