### PR TITLE
ChunkFile: Don't access element zero of empty container

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -262,7 +262,8 @@ private:
     Do(size);
     container.resize(size);
 
-    DoArray(&container[0], size);
+    if (size > 0)
+      DoArray(&container[0], size);
   }
 
   template <typename T>


### PR DESCRIPTION
This was causing assertion failures in debug MSVC builds.