### PR TITLE
DolphinQt/Mapping: red = error, don't flash

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -125,16 +125,11 @@ void MappingButton::UpdateIndicator()
   const auto state = m_reference->State();
 
   QFont f = m_parent->font();
-  QPalette p = m_parent->palette();
 
   if (state > ControllerEmu::Buttons::ACTIVATION_THRESHOLD)
-  {
     f.setBold(true);
-    p.setColor(QPalette::ButtonText, Qt::red);
-  }
 
   setFont(f);
-  setPalette(p);
 }
 
 void MappingButton::ConfigChanged()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -832,12 +832,9 @@ void CalibrationWidget::Update(Common::DVec2 point)
   }
   else if (IsPointOutsideCalibration(point, m_input))
   {
-    // Flashing bold and red on miscalibration.
-    if (QDateTime::currentDateTime().toMSecsSinceEpoch() % 500 < 350)
-    {
-      f.setBold(true);
-      p.setColor(QPalette::ButtonText, Qt::red);
-    }
+    // Bold and red on miscalibration.
+    f.setBold(true);
+    p.setColor(QPalette::ButtonText, Qt::red);
   }
 
   setFont(f);


### PR DESCRIPTION
My UI proposal for your nitpicking pleasure.

This changes the calibration button to not flash and also makes it the only red thing in the dialog. All the other buttons turn bold but not red when they are triggered.