### PR TITLE
Update Discord rich presence when the PPC title changes.

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -155,6 +155,10 @@ void Host_UpdateProgressDialog(const char* caption, int position, int total)
 {
 }
 
+void Host_TitleChanged()
+{
+}
+
 static bool MsgAlert(const char* caption, const char* text, bool yes_no, MsgType /*style*/)
 {
   __android_log_print(ANDROID_LOG_ERROR, DOLPHIN_TAG, "%s:%s", caption, text);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -725,6 +725,7 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
                                         GetCurrentLanguage(bWii);
   m_title_description = title_database.Describe(m_gametdb_id, language);
   NOTICE_LOG(CORE, "Active title: %s", m_title_description.c_str());
+  Host_TitleChanged();
 
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -45,3 +45,4 @@ void Host_UpdateMainFrame();
 void Host_UpdateTitle(const std::string& title);
 void Host_YieldToUI();
 void Host_UpdateProgressDialog(const char* caption, int position, int total);
+void Host_TitleChanged();

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -105,6 +105,13 @@ void Host_UpdateProgressDialog(const char* caption, int position, int total)
 {
 }
 
+void Host_TitleChanged()
+{
+#ifdef USE_DISCORD_PRESENCE
+  Discord::UpdateDiscordPresence();
+#endif
+}
+
 static std::unique_ptr<Platform> GetPlatform(const optparse::Values& options)
 {
   std::string platform_name = static_cast<const char*>(options.get("platform"));

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -17,12 +17,15 @@
 #include "Core/Core.h"
 #include "Core/Debugger/PPCDebugInterface.h"
 #include "Core/Host.h"
+#include "Core/NetPlayProto.h"
 #include "Core/PowerPC/PowerPC.h"
 
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/Settings.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
+
+#include "UICommon/DiscordPresence.h"
 
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoConfig.h"
@@ -163,4 +166,13 @@ bool Host_UIBlocksControllerState()
 
 void Host_RefreshDSPDebuggerWindow()
 {
+}
+
+void Host_TitleChanged()
+{
+#ifdef USE_DISCORD_PRESENCE
+  // TODO: Not sure if the NetPlay check is needed.
+  if (!NetPlay::IsNetPlayRunning())
+    Discord::UpdateDiscordPresence();
+#endif
 }

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -52,3 +52,6 @@ void Host_YieldToUI()
 void Host_UpdateProgressDialog(const char* caption, int position, int total)
 {
 }
+void Host_TitleChanged()
+{
+}

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -53,3 +53,6 @@ void Host_YieldToUI()
 void Host_UpdateProgressDialog(const char* caption, int position, int total)
 {
 }
+void Host_TitleChanged()
+{
+}


### PR DESCRIPTION
This allows us to update the rich presence description if a channel is launched from the Wii Menu. It also handles other PPC title launches, e.g. Smash Bros. Masterpieces.

Relevant issue tracker link: https://bugs.dolphin-emu.org/issues/11385
Discord Rich Presence doesn't update on title switch

EDIT: For DolphinQt/Host.cpp, I'm not sure if the NetPlay check is needed.