### PR TITLE
Support synchronizing host with console refresh rate

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -585,6 +585,7 @@ public final class SettingsFragmentPresenter
     Setting gpuTextureDecoding = gfxSection.getSetting(SettingsFile.KEY_GPU_TEXTURE_DECODING);
     Setting xfbToTexture = hacksSection.getSetting(SettingsFile.KEY_XFB_TEXTURE);
     Setting immediateXfb = hacksSection.getSetting(SettingsFile.KEY_IMMEDIATE_XFB);
+    Setting skipDuplicateXfbs = hacksSection.getSetting(SettingsFile.KEY_SKIP_DUPLICATE_XFBS);
     Setting fastDepth = gfxSection.getSetting(SettingsFile.KEY_FAST_DEPTH);
 
     sl.add(new HeaderSetting(null, null, R.string.embedded_frame_buffer, 0));
@@ -613,6 +614,9 @@ public final class SettingsFragmentPresenter
             R.string.xfb_copy_method, R.string.xfb_copy_method_description, true, xfbToTexture));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_IMMEDIATE_XFB, Settings.SECTION_GFX_HACKS,
             R.string.immediate_xfb, R.string.immediate_xfb_description, false, immediateXfb));
+    sl.add(new CheckBoxSetting(SettingsFile.KEY_SKIP_DUPLICATE_XFBS, Settings.SECTION_GFX_HACKS,
+            R.string.skip_duplicate_xfbs, R.string.skip_duplicate_xfbs_description, true,
+            skipDuplicateXfbs));
 
     sl.add(new HeaderSetting(null, null, R.string.other, 0));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_FAST_DEPTH, Settings.SECTION_GFX_SETTINGS,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -89,6 +89,7 @@ public final class SettingsFile
   public static final String KEY_GPU_TEXTURE_DECODING = "EnableGPUTextureDecoding";
   public static final String KEY_XFB_TEXTURE = "XFBToTextureEnable";
   public static final String KEY_IMMEDIATE_XFB = "ImmediateXFBEnable";
+  public static final String KEY_SKIP_DUPLICATE_XFBS = "SkipDuplicateXFBs";
   public static final String KEY_FAST_DEPTH = "FastDepthCalc";
   public static final String KEY_ASPECT_RATIO = "AspectRatio";
   public static final String KEY_SHADER_COMPILATION_MODE = "ShaderCompilationMode";

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -232,6 +232,8 @@
     <string name="xfb_copy_method_description">Stores XFB Copies exclusively on the GPU, bypassing system memory. Causes graphical defects in a small number of games that need to readback from memory. If unsure, leave this checked.</string>
     <string name="immediate_xfb">Immediately Present XFB</string>
     <string name="immediate_xfb_description">Displays the XFB copies as soon as they are created, without waiting for scanout. Causes graphical defects in some games but reduces latency. If unsure, leave this unchecked.</string>
+    <string name="skip_duplicate_xfbs">Immediately Present XFB</string>
+    <string name="skip_duplicate_xfbs_description">Skips presentation of duplicate frames. This may improve performance on low-end devices, while making frame pacing less consistent. If unsure, leave this checked.</string>
     <string name="disable_destination_alpha">Disable Destination Alpha</string>
     <string name="disable_destination_alpha_description">Disables emulation of a hardware feature called destination alpha, which is used in many games for various effects.</string>
     <string name="fast_depth_calculation">Fast Depth Calculation</string>

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -120,6 +120,10 @@ void Host_UpdateMainFrame()
 {
 }
 
+void Host_RequestFullscreen(bool active, float refresh_rate)
+{
+}
+
 void Host_RequestRenderWindowSize(int width, int height)
 {
   std::thread jnicall(UpdatePointer);
@@ -129,11 +133,6 @@ void Host_RequestRenderWindowSize(int width, int height)
 bool Host_RendererHasFocus()
 {
   return true;
-}
-
-bool Host_RendererIsFullscreen()
-{
-  return false;
 }
 
 void Host_YieldToUI()

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -332,6 +332,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-gfx-ssaa", g_Config.bSSAA);
   builder.AddData("cfg-gfx-anisotropy", g_Config.iMaxAnisotropy);
   builder.AddData("cfg-gfx-vsync", g_Config.bVSync);
+  builder.AddData("cfg-gfx-sync-refresh-rate", g_Config.bSyncRefreshRate);
   builder.AddData("cfg-gfx-aspect-ratio", static_cast<int>(g_Config.aspect_mode));
   builder.AddData("cfg-gfx-efb-access", g_Config.bEFBAccessEnable);
   builder.AddData("cfg-gfx-efb-copy-format-changes", g_Config.bEFBEmulateFormatChanges);
@@ -358,8 +359,6 @@ void DolphinAnalytics::MakePerGameBuilder()
   {
     builder.AddData("gpu-adapter", g_Config.backend_info.AdapterName);
   }
-  builder.AddData("gpu-has-exclusive-fullscreen",
-                  g_Config.backend_info.bSupportsExclusiveFullscreen);
   builder.AddData("gpu-has-dual-source-blend", g_Config.backend_info.bSupportsDualSourceBlend);
   builder.AddData("gpu-has-primitive-restart", g_Config.backend_info.bSupportsPrimitiveRestart);
   builder.AddData("gpu-has-oversized-viewports", g_Config.backend_info.bSupportsOversizedViewports);

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -69,6 +69,7 @@ const ConfigInfo<bool> GFX_ENABLE_WIREFRAME{{System::GFX, "Settings", "WireFrame
 const ConfigInfo<bool> GFX_DISABLE_FOG{{System::GFX, "Settings", "DisableFog"}, false};
 const ConfigInfo<bool> GFX_BORDERLESS_FULLSCREEN{{System::GFX, "Settings", "BorderlessFullscreen"},
                                                  false};
+const ConfigInfo<bool> GFX_SYNC_REFRESH_RATE{{System::GFX, "Settings", "SyncRefreshRate"}, false};
 const ConfigInfo<bool> GFX_ENABLE_VALIDATION_LAYER{
     {System::GFX, "Settings", "EnableValidationLayer"}, false};
 

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -154,6 +154,8 @@ const ConfigInfo<bool> GFX_HACK_DISABLE_COPY_TO_VRAM{{System::GFX, "Hacks", "Dis
                                                      false};
 const ConfigInfo<bool> GFX_HACK_DEFER_EFB_COPIES{{System::GFX, "Hacks", "DeferEFBCopies"}, true};
 const ConfigInfo<bool> GFX_HACK_IMMEDIATE_XFB{{System::GFX, "Hacks", "ImmediateXFBEnable"}, false};
+const ConfigInfo<bool> GFX_HACK_SKIP_DUPLICATE_XFBS{{System::GFX, "Hacks", "SkipDuplicateXFBs"},
+                                                    true};
 const ConfigInfo<bool> GFX_HACK_COPY_EFB_SCALED{{System::GFX, "Hacks", "EFBScaledCopy"}, true};
 const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{
     {System::GFX, "Hacks", "EFBEmulateFormatChanges"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -111,6 +111,7 @@ extern const ConfigInfo<bool> GFX_HACK_SKIP_XFB_COPY_TO_RAM;
 extern const ConfigInfo<bool> GFX_HACK_DISABLE_COPY_TO_VRAM;
 extern const ConfigInfo<bool> GFX_HACK_DEFER_EFB_COPIES;
 extern const ConfigInfo<bool> GFX_HACK_IMMEDIATE_XFB;
+extern const ConfigInfo<bool> GFX_HACK_SKIP_DUPLICATE_XFBS;
 extern const ConfigInfo<bool> GFX_HACK_COPY_EFB_SCALED;
 extern const ConfigInfo<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;
 extern const ConfigInfo<bool> GFX_HACK_VERTEX_ROUDING;

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -59,6 +59,7 @@ extern const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER;
 extern const ConfigInfo<bool> GFX_ENABLE_WIREFRAME;
 extern const ConfigInfo<bool> GFX_DISABLE_FOG;
 extern const ConfigInfo<bool> GFX_BORDERLESS_FULLSCREEN;
+extern const ConfigInfo<bool> GFX_SYNC_REFRESH_RATE;
 extern const ConfigInfo<bool> GFX_ENABLE_VALIDATION_LAYER;
 extern const ConfigInfo<bool> GFX_BACKEND_MULTITHREADING;
 extern const ConfigInfo<int> GFX_COMMAND_BUFFER_EXECUTE_INTERVAL;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -28,7 +28,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       return true;
   }
 
-  static constexpr std::array<const Config::ConfigLocation*, 92> s_setting_saveable = {
+  static constexpr std::array<const Config::ConfigLocation*, 93> s_setting_saveable = {
       // Main.Core
 
       &Config::MAIN_DEFAULT_ISO.location,
@@ -136,6 +136,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       &Config::GFX_HACK_DISABLE_COPY_TO_VRAM.location,
       &Config::GFX_HACK_DEFER_EFB_COPIES.location,
       &Config::GFX_HACK_IMMEDIATE_XFB.location,
+      &Config::GFX_HACK_SKIP_DUPLICATE_XFBS.location,
       &Config::GFX_HACK_COPY_EFB_SCALED.location,
       &Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES.location,
       &Config::GFX_HACK_VERTEX_ROUDING.location,

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -28,7 +28,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       return true;
   }
 
-  static constexpr std::array<const Config::ConfigLocation*, 93> s_setting_saveable = {
+  static constexpr std::array<const Config::ConfigLocation*, 94> s_setting_saveable = {
       // Main.Core
 
       &Config::MAIN_DEFAULT_ISO.location,
@@ -87,6 +87,7 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       &Config::GFX_ENABLE_WIREFRAME.location,
       &Config::GFX_DISABLE_FOG.location,
       &Config::GFX_BORDERLESS_FULLSCREEN.location,
+      &Config::GFX_SYNC_REFRESH_RATE.location,
       &Config::GFX_ENABLE_VALIDATION_LAYER.location,
       &Config::GFX_BACKEND_MULTITHREADING.location,
       &Config::GFX_COMMAND_BUFFER_EXECUTE_INTERVAL.location,

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -706,6 +706,12 @@ u32 GetTargetRefreshRate()
   return s_target_refresh_rate;
 }
 
+float GetTargetFractionalRefreshRate()
+{
+  return static_cast<float>(2.0 * SystemTimers::GetTicksPerSecond() /
+                            (GetTicksPerEvenField() + GetTicksPerOddField()));
+}
+
 u32 GetTicksPerSample()
 {
   return 2 * SystemTimers::GetTicksPerSecond() / s_clock_freqs[m_Clock];

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -364,6 +364,7 @@ void UpdateInterrupts();
 void UpdateParameters();
 
 u32 GetTargetRefreshRate();
+float GetTargetFractionalRefreshRate();
 u32 GetTicksPerSample();
 u32 GetTicksPerHalfLine();
 u32 GetTicksPerField();

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -34,10 +34,10 @@ enum class HostMessageID
 
 bool Host_UIBlocksControllerState();
 bool Host_RendererHasFocus();
-bool Host_RendererIsFullscreen();
 void Host_Message(HostMessageID id);
 void Host_NotifyMapLoaded();
 void Host_RefreshDSPDebuggerWindow();
+void Host_RequestFullscreen(bool active, float refresh_rate);
 void Host_RequestRenderWindowSize(int width, int height);
 void Host_UpdateDisasmDialog();
 void Host_UpdateMainFrame();

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -81,6 +81,10 @@ void Host_UpdateMainFrame()
   s_update_main_frame_event.Set();
 }
 
+void Host_RequestFullscreen(bool active, float refresh_rate)
+{
+}
+
 void Host_RequestRenderWindowSize(int width, int height)
 {
 }
@@ -88,11 +92,6 @@ void Host_RequestRenderWindowSize(int width, int height)
 bool Host_RendererHasFocus()
 {
   return s_platform->IsWindowFocused();
-}
-
-bool Host_RendererIsFullscreen()
-{
-  return s_platform->IsWindowFullscreen();
 }
 
 void Host_YieldToUI()

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -109,15 +109,17 @@ void AdvancedWidget::CreateWidgets()
   m_enable_prog_scan = new QCheckBox(tr("Enable Progressive Scan"));
   m_backend_multithreading =
       new GraphicsBool(tr("Backend Multithreading"), Config::GFX_BACKEND_MULTITHREADING);
+  m_sync_refresh_rate = new GraphicsBool(tr("Sync Refresh Rate"), Config::GFX_SYNC_REFRESH_RATE);
 
   misc_layout->addWidget(m_enable_cropping, 0, 0);
   misc_layout->addWidget(m_enable_prog_scan, 0, 1);
   misc_layout->addWidget(m_backend_multithreading, 1, 0);
+  misc_layout->addWidget(m_sync_refresh_rate, 1, 1);
 #ifdef _WIN32
   m_borderless_fullscreen =
       new GraphicsBool(tr("Borderless Fullscreen"), Config::GFX_BORDERLESS_FULLSCREEN);
 
-  misc_layout->addWidget(m_borderless_fullscreen, 1, 1);
+  misc_layout->addWidget(m_borderless_fullscreen, 2, 0);
 #endif
 
   // Experimental.
@@ -229,6 +231,9 @@ void AdvancedWidget::AddDescriptions()
       "is executed. If disabled, the cache will be invalidated with every draw call. "
       "\n\nMay improve performance in some games which rely on CPU EFB Access at the cost "
       "of stability.\n\nIf unsure, leave this unchecked.");
+  static const char TR_SYNC_REFRESH_RATE_DESCRIPTION[] = QT_TR_NOOP(
+      "Synchronizes the host refresh rate with the console refresh rate where possible. This may "
+      "reduce repeated frames for 50hz games.\n\nIf unsure, leave this unchecked.");
 
 #ifdef _WIN32
   static const char TR_BORDERLESS_FULLSCREEN_DESCRIPTION[] = QT_TR_NOOP(
@@ -255,6 +260,7 @@ void AdvancedWidget::AddDescriptions()
   AddDescription(m_enable_prog_scan, TR_PROGRESSIVE_SCAN_DESCRIPTION);
   AddDescription(m_enable_freelook, TR_FREE_LOOK_DESCRIPTION);
   AddDescription(m_backend_multithreading, TR_BACKEND_MULTITHREADING_DESCRIPTION);
+  AddDescription(m_sync_refresh_rate, TR_SYNC_REFRESH_RATE_DESCRIPTION);
 #ifdef _WIN32
   AddDescription(m_borderless_fullscreen, TR_BORDERLESS_FULLSCREEN_DESCRIPTION);
 #endif

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -49,6 +49,7 @@ private:
   QCheckBox* m_enable_cropping;
   QCheckBox* m_enable_prog_scan;
   QCheckBox* m_backend_multithreading;
+  QCheckBox* m_sync_refresh_rate;
   QCheckBox* m_borderless_fullscreen;
 
   // Experimental

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -86,9 +86,12 @@ void HacksWidget::CreateWidgets()
   m_store_xfb_copies = new GraphicsBool(tr("Store XFB Copies to Texture Only"),
                                         Config::GFX_HACK_SKIP_XFB_COPY_TO_RAM);
   m_immediate_xfb = new GraphicsBool(tr("Immediately Present XFB"), Config::GFX_HACK_IMMEDIATE_XFB);
+  m_skip_duplicate_xfbs = new GraphicsBool(tr("Skip Presenting Duplicate Frames"),
+                                           Config::GFX_HACK_SKIP_DUPLICATE_XFBS);
 
   xfb_layout->addWidget(m_store_xfb_copies);
   xfb_layout->addWidget(m_immediate_xfb);
+  xfb_layout->addWidget(m_skip_duplicate_xfbs);
 
   // Other
   auto* other_box = new QGroupBox(tr("Other"));
@@ -235,6 +238,12 @@ void HacksWidget::AddDescriptions()
                  "expect all XFB copies to be displayed. However, turning this setting on reduces "
                  "latency.\n\nIf unsure, leave this unchecked.");
 
+  static const char TR_SKIP_DUPLICATE_XFBS_DESCRIPTION[] = QT_TR_NOOP(
+      "Skips presentation of duplicate frames (XFB copies) in 25fps/30fps games. This may improve "
+      "performance on low-end devices, while making frame pacing less consistent.\n\nDisable this "
+      "option as well as enabling V-Sync for optimal frame pacing.\n\nIf unsure, leave this "
+      "checked.");
+
   static const char TR_GPU_DECODING_DESCRIPTION[] =
       QT_TR_NOOP("Enables texture decoding using the GPU instead of the CPU.\n\nThis may result in "
                  "performance gains in some scenarios, or on systems where the CPU is the "
@@ -263,6 +272,7 @@ void HacksWidget::AddDescriptions()
   AddDescription(m_accuracy, TR_ACCUARCY_DESCRIPTION);
   AddDescription(m_store_xfb_copies, TR_STORE_XFB_TO_TEXTURE_DESCRIPTION);
   AddDescription(m_immediate_xfb, TR_IMMEDIATE_XFB_DESCRIPTION);
+  AddDescription(m_skip_duplicate_xfbs, TR_SKIP_DUPLICATE_XFBS_DESCRIPTION);
   AddDescription(m_gpu_texture_decoding, TR_GPU_DECODING_DESCRIPTION);
   AddDescription(m_fast_depth_calculation, TR_FAST_DEPTH_CALC_DESCRIPTION);
   AddDescription(m_disable_bounding_box, TR_DISABLE_BOUNDINGBOX_DESCRIPTION);

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -37,6 +37,7 @@ private:
   // External Framebuffer
   QCheckBox* m_store_xfb_copies;
   QCheckBox* m_immediate_xfb;
+  QCheckBox* m_skip_duplicate_xfbs;
 
   // Other
   QCheckBox* m_fast_depth_calculation;

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -20,12 +20,19 @@ class Host final : public QObject
 public:
   static Host* GetInstance();
 
-  bool GetRenderFocus();
-  bool GetRenderFullscreen();
+  bool GetRenderFocus() const;
+  bool IsFullscreenEnabled() const;
+  bool IsFullscreenActive() const;
 
   void SetRenderHandle(void* handle);
   void SetRenderFocus(bool focus);
-  void SetRenderFullscreen(bool fullscreen);
+
+  // changes the enabled state
+  void SetFullscreenEnabled(bool enabled);
+
+  // synchronizes the enabled state with the real state
+  void UpdateFullscreen(bool disable_temporarily = false);
+
   void ResizeSurface(int new_width, int new_height);
   void RequestNotifyMapLoaded();
 
@@ -33,6 +40,7 @@ signals:
   void RequestTitle(const QString& title);
   void RequestStop();
   void RequestRenderSize(int w, int h);
+  void RequestFullscreen(bool enabled, float target_refresh_rate);
   void UpdateProgressDialog(QString label, int position, int maximum);
   void UpdateDisasmDialog();
   void NotifyMapLoaded();
@@ -41,6 +49,8 @@ private:
   Host();
 
   std::atomic<void*> m_render_handle{nullptr};
-  std::atomic<bool> m_render_focus{false};
-  std::atomic<bool> m_render_fullscreen{false};
+  std::atomic_bool m_render_focus{false};
+
+  // Remains true if fullscreen is enabled, but focus is lost.
+  std::atomic_bool m_fullscreen_enabled{false};
 };

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -102,9 +102,9 @@ private:
 
   void PerformOnlineUpdate(const std::string& region);
 
-  void SetFullScreenResolution(bool fullscreen);
+  void RequestFullscreen(bool fullscreen, float refresh_rate);
 
-  void FullScreen();
+  void ToggleFullscreen();
   void ScreenShot();
 
   void CreateComponents();
@@ -197,11 +197,11 @@ private:
   SearchBar* m_search_bar;
   GameList* m_game_list;
   RenderWidget* m_render_widget = nullptr;
-  bool m_rendering_to_main;
+  bool m_rendering_to_main = false;
   bool m_stop_confirm_showing = false;
   bool m_stop_requested = false;
   bool m_exit_requested = false;
-  bool m_fullscreen_requested = false;
+  bool m_display_settings_changed = false;
   int m_state_slot = 1;
   std::unique_ptr<BootParameters> m_pending_boot;
 

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -65,8 +65,6 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
 
   // We have to use Qt::DirectConnection here because we don't want those signals to get queued
   // (which results in them not getting called)
-  connect(this, &RenderWidget::StateChanged, Host::GetInstance(), &Host::SetRenderFullscreen,
-          Qt::DirectConnection);
   connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle,
           Qt::DirectConnection);
   connect(this, &RenderWidget::SizeChanged, Host::GetInstance(), &Host::ResizeSurface,
@@ -230,9 +228,6 @@ bool RenderWidget::event(QEvent* event)
     emit SizeChanged(new_size.width() * dpr, new_size.height() * dpr);
     break;
   }
-  case QEvent::WindowStateChange:
-    emit StateChanged(isFullScreen());
-    break;
   case QEvent::Close:
     emit Closed();
     break;

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -25,7 +25,6 @@ signals:
   void EscapePressed();
   void Closed();
   void HandleChanged(void* handle);
-  void StateChanged(bool fullscreen);
   void SizeChanged(int new_width, int new_height);
   void FocusChanged(bool focus);
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -285,15 +285,16 @@ void Renderer::WaitForGPUIdle()
   D3D::context->Flush();
 }
 
-void Renderer::SetFullscreen(bool enable_fullscreen)
+bool Renderer::ChangeFullscreenState(bool enabled, float refresh_rate)
 {
-  if (m_swap_chain)
-    m_swap_chain->SetFullscreen(enable_fullscreen);
-}
+  if (g_ActiveConfig.bBorderlessFullscreen)
+    return ::Renderer::ChangeFullscreenState(enabled, refresh_rate);
 
-bool Renderer::IsFullscreen() const
-{
-  return m_swap_chain && m_swap_chain->GetFullscreen();
+  if (!m_swap_chain->SetFullscreen(enabled, refresh_rate))
+    return false;
+
+  m_fullscreen_state = enabled;
+  return true;
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -58,8 +58,6 @@ public:
                              u32 groups_z) override;
   void BindBackbuffer(const ClearColor& clear_color = {}) override;
   void PresentBackbuffer() override;
-  void SetFullscreen(bool enable_fullscreen) override;
-  bool IsFullscreen() const override;
 
   u16 BBoxRead(int index) override;
   void BBoxWrite(int index, u16 value) override;
@@ -67,7 +65,9 @@ public:
   void Flush() override;
   void WaitForGPUIdle() override;
 
+protected:
   void OnConfigChanged(u32 bits) override;
+  bool ChangeFullscreenState(bool enabled, float refresh_rate) override;
 
 private:
   void CheckForSwapChainChanges();

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -76,7 +76,6 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.api_type = APIType::D3D;
   g_Config.backend_info.MaxTextureSize = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
   g_Config.backend_info.bUsesLowerLeftOrigin = false;
-  g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = false;

--- a/Source/Core/VideoBackends/D3D12/Renderer.cpp
+++ b/Source/Core/VideoBackends/D3D12/Renderer.cpp
@@ -472,6 +472,18 @@ void Renderer::OnConfigChanged(u32 bits)
     g_dx_context->RecreateGXRootSignature();
 }
 
+bool Renderer::ChangeFullscreenState(bool enabled, float refresh_rate)
+{
+  if (g_ActiveConfig.bBorderlessFullscreen)
+    return ::Renderer::ChangeFullscreenState(enabled, refresh_rate);
+
+  if (!m_swap_chain->SetFullscreen(enabled, refresh_rate))
+    return false;
+
+  m_fullscreen_state = enabled;
+  return true;
+}
+
 void Renderer::ExecuteCommandList(bool wait_for_completion)
 {
   PerfQuery::GetInstance()->ResolveQueries();

--- a/Source/Core/VideoBackends/D3D12/Renderer.h
+++ b/Source/Core/VideoBackends/D3D12/Renderer.h
@@ -97,6 +97,7 @@ public:
 
 protected:
   void OnConfigChanged(u32 bits) override;
+  bool ChangeFullscreenState(bool enabled, float refresh_rate) override;
 
 private:
   static const u32 MAX_TEXTURES = 8;

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -48,7 +48,6 @@ void VideoBackend::FillBackendInfo()
 {
   g_Config.backend_info.api_type = APIType::D3D;
   g_Config.backend_info.bUsesLowerLeftOrigin = false;
-  g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = false;

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.h
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.h
@@ -36,7 +36,7 @@ public:
 
   // Mode switches.
   bool GetFullscreen() const;
-  void SetFullscreen(bool request);
+  bool SetFullscreen(bool request, float refresh_rate);
 
   // Checks for loss of exclusive fullscreen.
   bool CheckForFullscreenChange();

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -27,7 +27,6 @@ void VideoBackend::InitBackendInfo()
 {
   g_Config.backend_info.api_type = APIType::Nothing;
   g_Config.backend_info.MaxTextureSize = 16384;
-  g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = true;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -77,7 +77,6 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.api_type = APIType::OpenGL;
   g_Config.backend_info.MaxTextureSize = 16384;
   g_Config.backend_info.bUsesLowerLeftOrigin = true;
-  g_Config.backend_info.bSupportsExclusiveFullscreen = false;
   g_Config.backend_info.bSupportsOversizedViewports = true;
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupportsComputeShaders = false;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -286,6 +286,7 @@ void Renderer::BindBackbuffer(const ClearColor& clear_color)
   {
     // if it fails, don't keep trying
     m_swap_chain->SetNextFullscreenState(m_swap_chain->GetCurrentFullscreenState());
+    m_fullscreen_state = m_swap_chain->GetCurrentFullscreenState();
   }
 
   VkResult res = g_command_buffer_mgr->CheckLastPresentFail() ?
@@ -349,17 +350,16 @@ void Renderer::PresentBackbuffer()
   StateTracker::GetInstance()->InvalidateCachedState();
 }
 
-void Renderer::SetFullscreen(bool enable_fullscreen)
+bool Renderer::ChangeFullscreenState(bool enabled, float refresh_rate)
 {
-  if (!m_swap_chain->IsFullscreenSupported())
-    return;
+  // exclusive fullscreen only works if we're already fullscreen?
+  if (!::Renderer::ChangeFullscreenState(enabled, refresh_rate))
+    return false;
 
-  m_swap_chain->SetNextFullscreenState(enable_fullscreen);
-}
+  if (!g_ActiveConfig.bBorderlessFullscreen && m_swap_chain->IsFullscreenSupported())
+    m_swap_chain->SetNextFullscreenState(enabled);
 
-bool Renderer::IsFullscreen() const
-{
-  return m_swap_chain && m_swap_chain->GetCurrentFullscreenState();
+  return true;
 }
 
 void Renderer::ExecuteCommandBuffer(bool submit_off_thread, bool wait_for_completion)

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -60,7 +60,6 @@ public:
 
   void Flush() override;
   void WaitForGPUIdle() override;
-  void OnConfigChanged(u32 bits) override;
 
   void ClearScreen(const MathUtil::Rectangle<int>& rc, bool color_enable, bool alpha_enable,
                    bool z_enable, u32 color, u32 z) override;
@@ -83,12 +82,14 @@ public:
                              u32 groups_z) override;
   void BindBackbuffer(const ClearColor& clear_color = {}) override;
   void PresentBackbuffer() override;
-  void SetFullscreen(bool enable_fullscreen) override;
-  bool IsFullscreen() const override;
 
   // Completes the current render pass, executes the command buffer, and restores state ready for
   // next render. Use when you want to kick the current buffer to make room for new data.
   void ExecuteCommandBuffer(bool execute_off_thread, bool wait_for_completion = false);
+
+protected:
+  bool ChangeFullscreenState(bool enabled, float refresh_rate) override;
+  void OnConfigChanged(u32 bits) override;
 
 private:
   void CheckForSurfaceChange();

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -342,8 +342,6 @@ bool SwapChain::CreateSwapChain()
       // Try without exclusive fullscreen.
       WARN_LOG(VIDEO, "Failed to create exclusive fullscreen swapchain, trying without.");
       swap_chain_info.pNext = nullptr;
-      g_Config.backend_info.bSupportsExclusiveFullscreen = false;
-      g_ActiveConfig.backend_info.bSupportsExclusiveFullscreen = false;
       m_fullscreen_supported = false;
     }
   }
@@ -562,8 +560,6 @@ bool SwapChain::RecreateSurface(void* native_handle)
 
   // Update exclusive fullscreen support (unlikely to change).
   m_fullscreen_supported = g_vulkan_context->SupportsExclusiveFullscreen(m_wsi, m_surface);
-  g_Config.backend_info.bSupportsExclusiveFullscreen = m_fullscreen_supported;
-  g_ActiveConfig.backend_info.bSupportsExclusiveFullscreen = m_fullscreen_supported;
   m_current_fullscreen_state = false;
   m_next_fullscreen_state = false;
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -273,7 +273,6 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsBackgroundCompiling = true;        // Assumed support.
   config->backend_info.bSupportsCopyToVram = true;                 // Assumed support.
   config->backend_info.bSupportsReversedDepthRange = true;         // Assumed support.
-  config->backend_info.bSupportsExclusiveFullscreen = false;       // Dependent on OS and features.
   config->backend_info.bSupportsDualSourceBlend = false;           // Dependent on features.
   config->backend_info.bSupportsGeometryShaders = false;           // Dependent on features.
   config->backend_info.bSupportsGSInstancing = false;              // Dependent on features.

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -187,8 +187,6 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
                                              g_vulkan_context->GetDeviceFeatures());
   VulkanContext::PopulateBackendInfoMultisampleModes(
       &g_Config, g_vulkan_context->GetPhysicalDevice(), g_vulkan_context->GetDeviceProperties());
-  g_Config.backend_info.bSupportsExclusiveFullscreen =
-      enable_surface && g_vulkan_context->SupportsExclusiveFullscreen(wsi, surface);
 
   // With the backend information populated, we can now initialize videocommon.
   InitializeShared();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -89,8 +89,6 @@ public:
                            float far_depth)
   {
   }
-  virtual void SetFullscreen(bool enable_fullscreen) {}
-  virtual bool IsFullscreen() const { return false; }
   virtual void BeginUtilityDrawing();
   virtual void EndUtilityDrawing();
   virtual std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) = 0;
@@ -201,6 +199,11 @@ public:
 
   virtual void ClearScreen(const MathUtil::Rectangle<int>& rc, bool colorEnable, bool alphaEnable,
                            bool zEnable, u32 color, u32 z);
+
+  // Fullscreen manipulation. Called from the UI thread.
+  void SetFullscreen(bool enable_fullscreen);
+  bool IsFullscreen() const { return m_fullscreen_state; }
+
   virtual void ReinterpretPixelData(EFBReinterpretType convtype);
   void RenderToXFB(u32 xfbAddr, const MathUtil::Rectangle<int>& sourceRc, u32 fbStride,
                    u32 fbHeight, float Gamma = 1.0f);
@@ -233,6 +236,7 @@ public:
   VideoCommon::PostProcessing* GetPostProcessor() const { return m_post_processor.get(); }
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
+  float GetLastRefreshRate() const { return m_last_refresh_rate; }
   void ChangeSurface(void* new_surface_handle);
   void ResizeSurface();
   bool UseVertexDepthRange() const;
@@ -293,6 +297,9 @@ protected:
   // Should be called with the ImGui lock held.
   void DrawImGui();
 
+  // Changes fullscreen state for the backend. This is only overridden in D3D.
+  virtual bool ChangeFullscreenState(bool enable, float target_refresh_rate);
+
   AbstractFramebuffer* m_current_framebuffer = nullptr;
   const AbstractPipeline* m_current_pipeline = nullptr;
 
@@ -313,6 +320,8 @@ protected:
   AbstractTextureFormat m_backbuffer_format = AbstractTextureFormat::Undefined;
   MathUtil::Rectangle<int> m_target_rectangle = {};
   int m_frame_count = 0;
+  float m_last_refresh_rate = 0.0f;
+  bool m_fullscreen_state = false;
 
   FPSCounter m_fps_counter;
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -152,6 +152,7 @@ void VideoConfig::Refresh()
   bDisableCopyToVRAM = Config::Get(Config::GFX_HACK_DISABLE_COPY_TO_VRAM);
   bDeferEFBCopies = Config::Get(Config::GFX_HACK_DEFER_EFB_COPIES);
   bImmediateXFB = Config::Get(Config::GFX_HACK_IMMEDIATE_XFB);
+  bSkipPresentingDuplicateXFBs = Config::Get(Config::GFX_HACK_SKIP_DUPLICATE_XFBS);
   bCopyEFBScaled = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
   bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -43,7 +43,6 @@ VideoConfig::VideoConfig()
   // disable all features by default
   backend_info.api_type = APIType::Nothing;
   backend_info.MaxTextureSize = 16384;
-  backend_info.bSupportsExclusiveFullscreen = false;
   backend_info.bSupportsMultithreading = false;
   backend_info.bSupportsST3CTextures = false;
   backend_info.bSupportsBPTCTextures = false;
@@ -109,6 +108,7 @@ void VideoConfig::Refresh()
   bWireFrame = Config::Get(Config::GFX_ENABLE_WIREFRAME);
   bDisableFog = Config::Get(Config::GFX_DISABLE_FOG);
   bBorderlessFullscreen = Config::Get(Config::GFX_BORDERLESS_FULLSCREEN);
+  bSyncRefreshRate = Config::Get(Config::GFX_SYNC_REFRESH_RATE);
   bEnableValidationLayer = Config::Get(Config::GFX_ENABLE_VALIDATION_LAYER);
   bBackendMultithreading = Config::Get(Config::GFX_BACKEND_MULTITHREADING);
   iCommandBufferExecuteInterval = Config::Get(Config::GFX_COMMAND_BUFFER_EXECUTE_INTERVAL);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -124,6 +124,7 @@ struct VideoConfig final
   bool bDisableCopyToVRAM;
   bool bDeferEFBCopies;
   bool bImmediateXFB;
+  bool bSkipPresentingDuplicateXFBs;
   bool bCopyEFBScaled;
   int iSafeTextureCache_ColorSamples;
   float fAspectRatioHackW, fAspectRatioHackH;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -108,6 +108,7 @@ struct VideoConfig final
   bool bInternalResolutionFrameDumps;
   bool bFreeLook;
   bool bBorderlessFullscreen;
+  bool bSyncRefreshRate;
   bool bEnableGPUTextureDecoding;
   int iBitrateKbps;
 
@@ -191,7 +192,6 @@ struct VideoConfig final
     u32 MaxTextureSize;
     bool bUsesLowerLeftOrigin;
 
-    bool bSupportsExclusiveFullscreen;
     bool bSupportsDualSourceBlend;
     bool bSupportsPrimitiveRestart;
     bool bSupportsOversizedViewports;
@@ -227,10 +227,6 @@ struct VideoConfig final
 
   // Utility
   bool MultisamplingEnabled() const { return iMultisamples > 1; }
-  bool ExclusiveFullscreenEnabled() const
-  {
-    return backend_info.bSupportsExclusiveFullscreen && !bBorderlessFullscreen;
-  }
   bool UseGPUTextureDecoding() const
   {
     return backend_info.bSupportsGPUTextureDecoding && bEnableGPUTextureDecoding;

--- a/Source/DSPTool/StubHost.cpp
+++ b/Source/DSPTool/StubHost.cpp
@@ -31,14 +31,13 @@ void Host_UpdateDisasmDialog()
 void Host_UpdateMainFrame()
 {
 }
+void Host_RequestFullscreen(bool, float)
+{
+}
 void Host_RequestRenderWindowSize(int, int)
 {
 }
 bool Host_RendererHasFocus()
-{
-  return false;
-}
-bool Host_RendererIsFullscreen()
 {
   return false;
 }

--- a/Source/UnitTests/StubHost.cpp
+++ b/Source/UnitTests/StubHost.cpp
@@ -28,6 +28,9 @@ void Host_UpdateDisasmDialog()
 void Host_UpdateMainFrame()
 {
 }
+void Host_RequestFullscreen(bool, float)
+{
+}
 void Host_RequestRenderWindowSize(int, int)
 {
 }
@@ -36,10 +39,6 @@ bool Host_UIBlocksControllerState()
   return false;
 }
 bool Host_RendererHasFocus()
-{
-  return false;
-}
-bool Host_RendererIsFullscreen()
 {
   return false;
 }


### PR DESCRIPTION
This PR adds an option to change the host refresh rate in fullscreen mode whenever the console refresh rate changes. This is especially useful for PAL/50hz games where you'll see repeated frames or tearing as the vertical sync intervals do not line up. It may make a tiny difference with NTSC games, as there is a subtle difference between 59.94hz and 60hz. For best results, ensure vsync is on.

It also cleans up fullscreen handling in Qt, which was a little messy before.

Currently it's only implemented on Windows. Results may differ depending on what your monitor capabilities are. FWIW, I can use 50, 59.94 and 60hz on my monitors and TV over HDMI.

Only the last commit is relevant, I built it on top of my videocommon work. It's not completely dependent on it, but avoids future merge conflicts.

Note: Going forward, formally supporting G-Sync/FreeSync would probably be a good idea too (especially for those displays which can't support the other refresh rates). But I don't have one of these displays yet :)

- [x] Basic implementation
- [ ] Implement on Linux
- [ ] Re-implement fullscreen resolutions
