### PR TITLE
Qt: Disable help button globally

### DIFF
--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -14,7 +14,6 @@
 AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("About Dolphin"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QString text = QStringLiteral("");
   QString small = QStringLiteral("<p style='margin-top:0; margin-bottom:0; font-size:small;'>");

--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -72,7 +72,6 @@ struct Result
 CheatsManager::CheatsManager(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Cheats Manager"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &CheatsManager::OnStateChanged);

--- a/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
+++ b/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
@@ -19,7 +19,6 @@
 
 CheatCodeEditor::CheatCodeEditor(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Cheat Code Editor"));
 
   CreateWidgets();

--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -63,7 +63,6 @@ static std::optional<SerialInterface::SIDevices> FromGCMenuIndex(const int menud
 ControllersWindow::ControllersWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("Controller Settings"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateGamecubeLayout();
   CreateWiimoteLayout();

--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -289,7 +289,6 @@ void FilesystemWidget::ExtractDirectory(const DiscIO::Partition& partition, cons
   u32 size = info->GetTotalChildren();
 
   QProgressDialog* dialog = new QProgressDialog(this);
-  dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
   dialog->setMinimum(0);
   dialog->setMaximum(size);
   dialog->show();
@@ -335,7 +334,6 @@ void FilesystemWidget::CheckIntegrity(const DiscIO::Partition& partition)
       std::launch::async, [this, partition] { return m_volume->CheckIntegrity(partition); });
 
   dialog->setLabelText(tr("Verifying integrity of partition..."));
-  dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
   dialog->setWindowTitle(tr("Verifying partition"));
 
   dialog->setMinimum(0);

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
@@ -30,7 +30,6 @@ GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindo
   CreateMainLayout();
 
   setWindowTitle(tr("Graphics"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   OnBackendChanged(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend));
 }

--- a/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/PostProcessingConfigWindow.cpp
@@ -43,7 +43,6 @@ PostProcessingConfigWindow::PostProcessingConfigWindow(EnhancementsWidget* paren
   }
 
   setWindowTitle(tr("Post-Processing Shader Configuration"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   PopulateGroups();
   Create();

--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -225,7 +225,6 @@ void InfoWidget::ComputeChecksum()
   QProgressDialog* progress =
       new QProgressDialog(tr("Computing MD5 Checksum"), tr("Cancel"), 0, 1000, this);
   progress->setWindowTitle(tr("Computing MD5 Checksum"));
-  progress->setWindowFlags(progress->windowFlags() & ~Qt::WindowContextHelpButtonHint);
   progress->setMinimumDuration(500);
   progress->setWindowModality(Qt::WindowModal);
   while (read_offset < game_size)

--- a/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadWiiUConfigDialog.cpp
@@ -16,8 +16,6 @@
 GCPadWiiUConfigDialog::GCPadWiiUConfigDialog(int port, QWidget* parent)
     : QDialog(parent), m_port{port}
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
   CreateLayout();
 
   LoadSettings();

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -38,7 +38,6 @@ IOWindow::IOWindow(QWidget* parent, ControllerEmu::EmulatedController* controlle
   ConnectWidgets();
 
   setWindowTitle(type == IOWindow::Type::Input ? tr("Configure Input") : tr("Configure Output"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   Update();
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -50,7 +50,6 @@ MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
     : QDialog(parent), m_port(port_num)
 {
   setWindowTitle(tr("Port %1").arg(port_num + 1));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateDevicesLayout();
   CreateProfilesLayout();

--- a/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
@@ -21,7 +21,6 @@ NewPatchDialog::NewPatchDialog(QWidget* parent, PatchEngine::Patch& patch)
     : QDialog(parent), m_patch(patch)
 {
   setWindowTitle(tr("Patch Editor"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
@@ -27,7 +27,6 @@ PropertiesDialog::PropertiesDialog(QWidget* parent, const UICommon::GameFile& ga
                      .arg(QString::fromStdString(game.GetFileName()),
                           QString::fromStdString(game.GetGameID()),
                           QString::fromStdString(game.GetLongName())));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QVBoxLayout* layout = new QVBoxLayout();
 

--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -25,7 +25,6 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
 {
   // Set Window Properties
   setWindowTitle(tr("Settings"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   // Main Layout
   QVBoxLayout* layout = new QVBoxLayout;

--- a/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
+++ b/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
@@ -22,7 +22,6 @@ DiscordJoinRequestDialog::DiscordJoinRequestDialog(QWidget* parent, const std::s
     : QDialog(parent), m_user_id(id), m_close_timestamp(std::time(nullptr) + s_max_lifetime_seconds)
 {
   setWindowTitle(tr("Request to Join Your Party"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QPixmap avatar_pixmap;
 

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -31,7 +31,6 @@
 FIFOPlayerWindow::FIFOPlayerWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowTitle(tr("FIFO Player"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateWidgets();
   ConnectWidgets();

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -50,7 +50,6 @@ GCMemcardManager::GCMemcardManager(QWidget* parent) : QDialog(parent)
   resize(650, 500);
 
   setWindowTitle(tr("GameCube Memory Card Manager"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 GCMemcardManager::~GCMemcardManager() = default;

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -571,8 +571,6 @@ void GameList::CompressISO(bool decompress)
     QProgressDialog progress_dialog(decompress ? tr("Decompressing...") : tr("Compressing..."),
                                     tr("Abort"), 0, 100, this);
     progress_dialog.setWindowModality(Qt::WindowModal);
-    progress_dialog.setWindowFlags(progress_dialog.windowFlags() &
-                                   ~Qt::WindowContextHelpButtonHint);
     progress_dialog.setWindowTitle(tr("Progress"));
 
     bool good;

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -92,6 +92,7 @@ int main(int argc, char* argv[])
   QCoreApplication::setOrganizationName(QStringLiteral("Dolphin Emulator"));
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
   QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));
+  QCoreApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton);
 
   QApplication app(argc, argv);
 

--- a/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/ChunkedProgressDialog.cpp
@@ -45,7 +45,6 @@ ChunkedProgressDialog::ChunkedProgressDialog(QWidget* parent) : QDialog(parent)
   CreateWidgets();
   ConnectWidgets();
   setWindowTitle(tr("Data Transfer"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 void ChunkedProgressDialog::CreateWidgets()

--- a/Source/Core/DolphinQt/NetPlay/GameListDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/GameListDialog.cpp
@@ -13,7 +13,6 @@
 
 GameListDialog::GameListDialog(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Select a game"));
 
   CreateWidgets();

--- a/Source/Core/DolphinQt/NetPlay/MD5Dialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/MD5Dialog.cpp
@@ -42,7 +42,6 @@ MD5Dialog::MD5Dialog(QWidget* parent) : QDialog(parent)
   CreateWidgets();
   ConnectWidgets();
   setWindowTitle(tr("MD5 Checksum"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 void MD5Dialog::CreateWidgets()

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -62,8 +62,6 @@
 NetPlayDialog::NetPlayDialog(QWidget* parent)
     : QDialog(parent), m_game_list_model(Settings::Instance().GetGameListModel())
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
   setWindowTitle(tr("NetPlay"));
   setWindowIcon(Resources::GetAppIcon());
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -26,7 +26,6 @@ NetPlaySetupDialog::NetPlaySetupDialog(QWidget* parent)
     : QDialog(parent), m_game_list_model(Settings::Instance().GetGameListModel())
 {
   setWindowTitle(tr("NetPlay Setup"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateMainLayout();
 

--- a/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
@@ -17,7 +17,6 @@
 
 PadMappingDialog::PadMappingDialog(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   setWindowTitle(tr("Assign Controllers"));
 
   CreateWidgets();

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -23,7 +23,6 @@ ResourcePackManager::ResourcePackManager(QWidget* widget) : QDialog(widget)
   RepopulateTable();
 
   setWindowTitle(tr("Resource Pack Manager"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   resize(QSize(900, 600));
 }

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -44,7 +44,6 @@ USBDeviceAddToWhitelistDialog::USBDeviceAddToWhitelistDialog(QWidget* parent) : 
 void USBDeviceAddToWhitelistDialog::InitControls()
 {
   setWindowTitle(tr("Add New USB Device"));
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   m_whitelist_buttonbox = new QDialogButtonBox();
   auto* add_button = new QPushButton(tr("Add"));

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -24,7 +24,6 @@
 
 TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 {
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
   m_use_controller = new QCheckBox(QStringLiteral("Enable Controller Inpu&t"));
   m_use_controller->setToolTip(tr("Warning: Analog inputs may reset to controller values at "
                                   "random. In some cases this can be fixed by adding a deadzone."));

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -44,7 +44,6 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info)
   std::optional<int> choice = RunOnObject(m_parent, [&] {
     QDialog* dialog = new QDialog(m_parent);
     dialog->setWindowTitle(tr("Update available"));
-    dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
     auto* label = new QLabel(
         tr("<h2>A new version of Dolphin is available!</h2>Dolphin %1 is available for "

--- a/Source/Core/DolphinQt/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt/WiiUpdate.cpp
@@ -92,7 +92,6 @@ static WiiUtils::UpdateResult ShowProgress(QWidget* parent, Callable function, A
   UpdateProgressDialog dialog{parent};
   dialog.setLabelText(QObject::tr("Preparing to update...\nThis can take a while."));
   dialog.setWindowTitle(QObject::tr("Updating"));
-  dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
   // QProgressDialog doesn't set its minimum size correctly.
   dialog.setMinimumSize(360, 150);
 


### PR DESCRIPTION
So we won't have to manually disable it every time a new window is added

Tested on Windows