### PR TITLE
DolphinQt: Query mapping indicator colors using QPalette for better behavior with alternative themes.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -36,6 +36,18 @@ public:
 protected:
   WiimoteEmu::MotionState m_motion_state{};
 
+  QPen GetBBoxPen() const;
+  QBrush GetBBoxBrush() const;
+  QColor GetRawInputColor() const;
+  QPen GetInputShapePen() const;
+  QColor GetAdjustedInputColor() const;
+  QColor GetDeadZoneColor() const;
+  QPen GetDeadZonePen() const;
+  QBrush GetDeadZoneBrush() const;
+  QColor GetTextColor() const;
+  QColor GetAltTextColor() const;
+  QColor GetGateColor() const;
+
 private:
   void DrawCursor(ControllerEmu::Cursor& cursor);
   void DrawReshapableInput(ControllerEmu::ReshapableInput& stick);


### PR DESCRIPTION
Inspired by @8times9's PR #7789.

Look is mostly unchanged on my typical "light" theme.

Users of "dark" themes should please test.