### PR TITLE
Qt/LogWidget: Don't show duplicate entries

### DIFF
--- a/Source/Core/DolphinQt/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogWidget.cpp
@@ -195,6 +195,11 @@ void LogWidget::Log(LogTypes::LOG_LEVELS level, const char* text)
   QueueOnObject(this, [this, level, str]() mutable {
     std::lock_guard<std::mutex> lock(m_log_mutex);
 
+    static std::string last = "";
+
+    if (last == str)
+      return;
+
     const char* color = "white";
 
     switch (level)
@@ -222,6 +227,8 @@ void LogWidget::Log(LogTypes::LOG_LEVELS level, const char* text)
             .arg(QString::fromStdString(str.substr(0, TIMESTAMP_LENGTH)),
                  QString::fromStdString(color),
                  QString::fromStdString(str.substr(TIMESTAMP_LENGTH)).toHtmlEscaped()));
+
+    last = str;
   });
 }
 


### PR DESCRIPTION
Do not show duplicate log entries.

This takes the fully formatted strings into account.

So for a string to be considered a duplicate it has got to have the same timestamp.

Tries to somewhat fix an issue related to Melee OSReports showing up twice.