### PR TITLE
Set CFBundleName on macOS

### DIFF
--- a/Source/Core/DolphinQt/Info.plist.in
+++ b/Source/Core/DolphinQt/Info.plist.in
@@ -30,6 +30,8 @@
     <string>Dolphin</string>
     <key>CFBundleIconFile</key>
     <string>Dolphin.icns</string>
+    <key>CFBundleName</key>
+    <string>Dolphin</string>
     <key>CFBundleIdentifier</key>
     <string>org.dolphin-emu.dolphin</string>
     <key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Since CFBundleName is not set macOS uses the file name as
the name of the application in the dock. Our macOS builds
are distributed as lower case 'dolphin.' This doesn't fit in
well because on macOS the style is for every application name
to be capitalized. This commit sets CFBundleName to 'Dolphin'
so that it will display the same regardless of file name.