### PR TITLE
WiimoteEmu: Minor accuracy fixes.

### DIFF
--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
@@ -84,8 +84,9 @@ static_assert(sizeof(OutputReportRequestStatus) == 1, "Wrong size");
 struct OutputReportWriteData
 {
   u8 rumble : 1;
+  u8 : 1;
   u8 space : 2;
-  u8 : 5;
+  u8 : 4;
   // A real wiimote ignores the i2c read/write bit.
   u8 i2c_rw_ignored : 1;
   // Used only for register space (i2c bus) (7-bits):
@@ -100,8 +101,9 @@ static_assert(sizeof(OutputReportWriteData) == 21, "Wrong size");
 struct OutputReportReadData
 {
   u8 rumble : 1;
+  u8 : 1;
   u8 space : 2;
-  u8 : 5;
+  u8 : 4;
   // A real wiimote ignores the i2c read/write bit.
   u8 i2c_rw_ignored : 1;
   // Used only for register space (i2c bus) (7-bits):
@@ -114,7 +116,8 @@ static_assert(sizeof(OutputReportReadData) == 6, "Wrong size");
 
 struct OutputReportSpeakerData
 {
-  u8 unknown : 3;
+  u8 rumble : 1;
+  u8 : 2;
   u8 length : 5;
   u8 data[20];
 };

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -45,7 +45,8 @@ void Wiimote::HandleReportMode(const OutputReportMode& dr)
   m_reporting_continuous = dr.continuous;
   m_reporting_mode = dr.mode;
 
-  SendAck(OutputReportID::ReportMode, ErrorCode::Success);
+  if (dr.ack)
+    SendAck(OutputReportID::ReportMode, ErrorCode::Success);
 }
 
 // Tests that we have enough bytes for the report before we run the handler.
@@ -322,6 +323,7 @@ void Wiimote::HandleWriteData(const OutputReportWriteData& wd)
     break;
   }
 
+  // Real wiimotes seem to always ACK data writes.
   SendAck(OutputReportID::WriteData, error_code);
 }
 
@@ -426,6 +428,8 @@ void Wiimote::HandleReadData(const OutputReportReadData& rd)
   // If more data needs to be sent it will happen on the next "Update()"
   // TODO: should this be removed and let Update() take care of it?
   ProcessReadDataRequest();
+
+  // FYI: No "ACK" is sent.
 }
 
 bool Wiimote::ProcessReadDataRequest()


### PR DESCRIPTION
All verified on real hardware.

Report mode changes only "ack" when the relevant bit is set.

Read/Write "address space" is controlled by bits 0x4 and 0x8 (not 0x2 and 0x4).
This matches wiibrew documentation.
There must have been a bitfield oops at some point but it was silently working because games only ever set bit 0x4.