### PR TITLE
WiimoteEmu: Minor IR Camera behavior fix.

### DIFF
--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteConstants.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteConstants.h
@@ -38,14 +38,14 @@ enum class OutputReportID : u8
   Rumble = 0x10,
   LED = 0x11,
   ReportMode = 0x12,
-  IRPixelClock = 0x13,
+  IRLogicEnable = 0x13,
   SpeakerEnable = 0x14,
   RequestStatus = 0x15,
   WriteData = 0x16,
   ReadData = 0x17,
   SpeakerData = 0x18,
   SpeakerMute = 0x19,
-  IRLogic = 0x1a,
+  IRLogicEnable2 = 0x1a,
 };
 
 enum class LED : u8

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
@@ -16,16 +16,23 @@ namespace WiimoteEmu
 void CameraLogic::Reset()
 {
   reg_data = {};
+
+  m_is_enabled = false;
 }
 
 void CameraLogic::DoState(PointerWrap& p)
 {
   p.Do(reg_data);
+
+  // FYI: m_is_enabled is handled elsewhere.
 }
 
 int CameraLogic::BusRead(u8 slave_addr, u8 addr, int count, u8* data_out)
 {
   if (I2C_ADDR != slave_addr)
+    return 0;
+
+  if (!m_is_enabled)
     return 0;
 
   return RawRead(&reg_data, addr, count, data_out);
@@ -34,6 +41,9 @@ int CameraLogic::BusRead(u8 slave_addr, u8 addr, int count, u8* data_out)
 int CameraLogic::BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in)
 {
   if (I2C_ADDR != slave_addr)
+    return 0;
+
+  if (!m_is_enabled)
     return 0;
 
   return RawWrite(&reg_data, addr, count, data_in);
@@ -199,6 +209,11 @@ void CameraLogic::Update(const ControllerEmu::Cursor::StateData& cursor,
       break;
     }
   }
+}
+
+void CameraLogic::SetEnabled(bool is_enabled)
+{
+  m_is_enabled = is_enabled;
 }
 
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.h
@@ -68,6 +68,7 @@ public:
   void DoState(PointerWrap& p);
   void Update(const ControllerEmu::Cursor::StateData& cursor, const NormalizedAccelData& accel,
               bool sensor_bar_on_top);
+  void SetEnabled(bool is_enabled);
 
   static constexpr u8 I2C_ADDR = 0x58;
 
@@ -100,5 +101,9 @@ private:
   int BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in) override;
 
   Register reg_data;
+
+  // When disabled the camera does not respond on the bus.
+  // Change is triggered by wiimote report 0x13.
+  bool m_is_enabled;
 };
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -445,13 +445,6 @@ void Wiimote::SendDataReport()
       const auto cursor = m_ir->GetState(true);
       m_camera_logic.Update(cursor, norm_accel, m_sensor_bar_on_top);
 
-      if (!m_status.ir)
-      {
-        // TODO: What does a real wiimote send in this case? 0xFFs ?
-        // I'm assuming it still reads from the bus?
-        DEBUG_LOG(WIIMOTE, "Game is reading IR data without enabling IR logic first.");
-      }
-
       // The real wiimote reads camera data from the i2c bus starting at offset 0x37:
       const u8 camera_data_offset =
           CameraLogic::REPORT_DATA_OFFSET + rpt_builder.GetIRDataFormatOffset();

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -156,8 +156,8 @@ private:
   void HandleRequestStatus(const WiimoteCommon::OutputReportRequestStatus&);
   void HandleReadData(const WiimoteCommon::OutputReportReadData&);
   void HandleWriteData(const WiimoteCommon::OutputReportWriteData&);
-  void HandleIRPixelClock(const WiimoteCommon::OutputReportEnableFeature&);
-  void HandleIRLogic(const WiimoteCommon::OutputReportEnableFeature&);
+  void HandleIRLogicEnable(const WiimoteCommon::OutputReportEnableFeature&);
+  void HandleIRLogicEnable2(const WiimoteCommon::OutputReportEnableFeature&);
   void HandleSpeakerMute(const WiimoteCommon::OutputReportEnableFeature&);
   void HandleSpeakerEnable(const WiimoteCommon::OutputReportEnableFeature&);
   void HandleSpeakerData(const WiimoteCommon::OutputReportSpeakerData&);


### PR DESCRIPTION
Tested on physical hardware.

The camera device does not respond on the I2C bus until it is enabled by report 0x13.
Report 0x13 is also what affects the relevant status report bit.
This contradicts what Wiibrew.org implies by naming this report (0x13) "IR Pixel Clock" and the other related report (0x1a) "IR Logic".

The swap has gone unnoticed because games always enable both at the same time.