### PR TITLE
VideoConfig: Don't overwrite aspect_mode with suggested_aspect_mode

### DIFF
--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -74,12 +74,8 @@ void VideoConfig::Refresh()
   iAdapter = Config::Get(Config::GFX_ADAPTER);
 
   bWidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
-  const AspectMode config_aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
+  aspect_mode = Config::Get(Config::GFX_ASPECT_RATIO);
   suggested_aspect_mode = Config::Get(Config::GFX_SUGGESTED_ASPECT_RATIO);
-  if (config_aspect_mode == AspectMode::Auto)
-    aspect_mode = suggested_aspect_mode;
-  else
-    aspect_mode = config_aspect_mode;
   bCrop = Config::Get(Config::GFX_CROP);
   iSafeTextureCache_ColorSamples = Config::Get(Config::GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES);
   bShowFPS = Config::Get(Config::GFX_SHOW_FPS);


### PR DESCRIPTION
Unnecessary since b93b7ec. It was needed before that commit becase RenderBase.cpp only was checking the value of `aspect_mode`, not `suggested_aspect_mode`.