### PR TITLE
WIP - WiimoteEmu: Fix drum pads not working in Guitar Hero 5.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -96,6 +96,8 @@ protected:
 
   static_assert(0x100 == sizeof(Register));
 
+  void DoState(PointerWrap& p) override;
+
   Register m_reg = {};
 
 private:
@@ -105,8 +107,6 @@ private:
 
   int BusRead(u8 slave_addr, u8 addr, int count, u8* data_out) override;
   int BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in) override;
-
-  void DoState(PointerWrap& p) override;
 };
 
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 103;  // Last changed in PR 7674
+static const u32 STATE_VERSION = 104;  // Last changed in PR 7820
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Fixes issue: https://bugs.dolphin-emu.org/issues/10810

Caused by "velocity data" not ever being sent.

Implemented entirely from Wiibrew documentation because I lack the hardware.

Tested and working, though.

I also re-ordered the pads so the UI order matches the physical layout.