### PR TITLE
ControllerInterface/DolphinQt: Improve input detection.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -136,8 +136,8 @@ void IOWindow::ConnectWidgets()
   connect(m_or_button, &QPushButton::clicked, [this] { AppendSelectedOption(" | "); });
   connect(m_not_button, &QPushButton::clicked, [this] { AppendSelectedOption("!"); });
 
-  connect(m_type == IOWindow::Type::Input ? m_detect_button : m_test_button, &QPushButton::clicked,
-          this, &IOWindow::OnDetectButtonPressed);
+  connect(m_detect_button, &QPushButton::clicked, this, &IOWindow::OnDetectButtonPressed);
+  connect(m_test_button, &QPushButton::clicked, this, &IOWindow::OnTestButtonPressed);
 
   connect(m_button_box, &QDialogButtonBox::clicked, this, &IOWindow::OnDialogButtonPressed);
   connect(m_devices_combo, &QComboBox::currentTextChanged, this, &IOWindow::OnDeviceChanged);
@@ -180,35 +180,22 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
 
 void IOWindow::OnDetectButtonPressed()
 {
-  installEventFilter(BlockUserInputFilter::Instance());
-  grabKeyboard();
-  grabMouse();
+  const auto expression =
+      MappingCommon::DetectExpression(m_detect_button, g_controller_interface, {m_devq.ToString()},
+                                      m_devq, MappingCommon::Quote::Off);
 
-  std::thread([this] {
-    auto* btn = m_type == IOWindow::Type::Input ? m_detect_button : m_test_button;
-    const auto old_label = btn->text();
+  if (expression.isEmpty())
+    return;
 
-    btn->setText(QStringLiteral("..."));
+  const auto list = m_option_list->findItems(expression, Qt::MatchFixedString);
 
-    const auto expr = MappingCommon::DetectExpression(
-        m_reference, g_controller_interface.FindDevice(m_devq).get(), m_devq,
-        MappingCommon::Quote::Off);
+  if (!list.empty())
+    m_option_list->setCurrentItem(list[0]);
+}
 
-    btn->setText(old_label);
-
-    if (!expr.isEmpty())
-    {
-      const auto list = m_option_list->findItems(expr, Qt::MatchFixedString);
-
-      if (!list.empty())
-        m_option_list->setCurrentItem(list[0]);
-    }
-
-    releaseMouse();
-    releaseKeyboard();
-    removeEventFilter(BlockUserInputFilter::Instance());
-  })
-      .detach();
+void IOWindow::OnTestButtonPressed()
+{
+  MappingCommon::TestOutput(m_test_button, static_cast<OutputReference*>(m_reference));
 }
 
 void IOWindow::OnRangeChanged(int value)

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -48,6 +48,7 @@ private:
   void OnDialogButtonPressed(QAbstractButton* button);
   void OnDeviceChanged(const QString& device);
   void OnDetectButtonPressed();
+  void OnTestButtonPressed();
   void OnRangeChanged(int range);
 
   void AppendSelectedOption(const std::string& prefix);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
@@ -30,7 +30,6 @@ signals:
 private:
   void mouseReleaseEvent(QMouseEvent* event) override;
 
-  void OnButtonTimeout();
   void Connect();
 
   MappingWidget* m_parent;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
@@ -4,17 +4,21 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 class QString;
-class ControlReference;
+class OutputReference;
+class QPushButton;
 
 namespace ciface
 {
 namespace Core
 {
-class Device;
+class DeviceContainer;
 class DeviceQualifier;
-}
-}
+}  // namespace Core
+}  // namespace ciface
 
 namespace MappingCommon
 {
@@ -28,7 +32,12 @@ QString GetExpressionForControl(const QString& control_name,
                                 const ciface::Core::DeviceQualifier& control_device,
                                 const ciface::Core::DeviceQualifier& default_device,
                                 Quote quote = Quote::On);
-QString DetectExpression(ControlReference* reference, ciface::Core::Device* device,
+
+QString DetectExpression(QPushButton* button, ciface::Core::DeviceContainer& device_container,
+                         const std::vector<std::string>& device_strings,
                          const ciface::Core::DeviceQualifier& default_device,
                          Quote quote = Quote::On);
+
+void TestOutput(QPushButton* button, OutputReference* reference);
+
 }  // namespace MappingCommon

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -4,9 +4,6 @@
 
 #include "InputCommon/ControlReference/ControlReference.h"
 
-#include <vector>
-
-#include "Common/Thread.h"
 // For InputGateOn()
 // This is a bad layering violation, but it's the cleanest
 // place I could find to put it.
@@ -14,12 +11,6 @@
 #include "Core/Host.h"
 
 using namespace ciface::ExpressionParser;
-
-namespace
-{
-// Compared to an input's current state (ideally 1.0) minus abs(initial_state) (ideally 0.0).
-constexpr ControlState INPUT_DETECT_THRESHOLD = 0.55;
-}  // namespace
 
 bool ControlReference::InputGateOn()
 {
@@ -114,84 +105,4 @@ ControlState OutputReference::State(const ControlState state)
   if (m_parsed_expression)
     m_parsed_expression->SetValue(state * range);
   return 0.0;
-}
-
-// Wait for input on a particular device.
-// Inputs are considered if they are first seen in a neutral state.
-// This is useful for crazy flightsticks that have certain buttons that are always held down
-// and also properly handles detection when using "FullAnalogSurface" inputs.
-// Upon input, return a pointer to the detected Control, else return nullptr.
-ciface::Core::Device::Control* InputReference::Detect(const unsigned int ms,
-                                                      ciface::Core::Device* const device)
-{
-  struct InputState
-  {
-    ciface::Core::Device::Input& input;
-    ControlState initial_state;
-  };
-
-  std::vector<InputState> input_states;
-  for (auto* input : device->Inputs())
-  {
-    // Don't detect things like absolute cursor position.
-    if (!input->IsDetectable())
-      continue;
-
-    // Undesirable axes will have negative values here when trying to map a "FullAnalogSurface".
-    input_states.push_back({*input, input->GetState()});
-  }
-
-  if (input_states.empty())
-    return nullptr;
-
-  unsigned int time = 0;
-  while (time < ms)
-  {
-    Common::SleepCurrentThread(10);
-    time += 10;
-
-    device->UpdateInput();
-    for (auto& input_state : input_states)
-    {
-      // We want an input that was initially 0.0 and currently 1.0.
-      const auto detection_score =
-          (input_state.input.GetState() - std::abs(input_state.initial_state));
-
-      if (detection_score > INPUT_DETECT_THRESHOLD)
-        return &input_state.input;
-    }
-  }
-
-  // No input was detected. :'(
-  return nullptr;
-}
-
-//
-// OutputReference :: Detect
-//
-// Totally different from the inputReference detect / I have them combined so it was simpler to make
-// the GUI.
-// The GUI doesn't know the difference between an input and an output / it's odd but I was lazy and
-// it was easy
-//
-// set all binded outputs to <range> power for x milliseconds return false
-//
-ciface::Core::Device::Control* OutputReference::Detect(const unsigned int ms,
-                                                       ciface::Core::Device* const device)
-{
-  // ignore device
-
-  // don't hang if we don't even have any controls mapped
-  if (BoundCount() > 0)
-  {
-    State(1);
-    unsigned int slept = 0;
-
-    // this loop is to make stuff like flashing keyboard LEDs work
-    while (ms > (slept += 10))
-      Common::SleepCurrentThread(10);
-
-    State(0);
-  }
-  return nullptr;
 }

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -26,8 +26,6 @@ public:
 
   virtual ~ControlReference();
   virtual ControlState State(const ControlState state = 0) = 0;
-  virtual ciface::Core::Device::Control* Detect(const unsigned int ms,
-                                                ciface::Core::Device* const device) = 0;
   virtual bool IsInput() const = 0;
 
   int BoundCount() const;
@@ -57,8 +55,6 @@ public:
   InputReference();
   bool IsInput() const override;
   ControlState State(const ControlState state) override;
-  ciface::Core::Device::Control* Detect(const unsigned int ms,
-                                        ciface::Core::Device* const device) override;
 };
 
 //
@@ -72,6 +68,4 @@ public:
   OutputReference();
   bool IsInput() const override;
   ControlState State(const ControlState state) override;
-  ciface::Core::Device::Control* Detect(const unsigned int ms,
-                                        ciface::Core::Device* const device) override;
 };

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -217,7 +217,19 @@ public:
   std::shared_ptr<Device> m_device;
 
   explicit ControlExpression(ControlQualifier qualifier_) : qualifier(qualifier_) {}
-  ControlState GetValue() const override { return control ? control->ToInput()->GetState() : 0.0; }
+  ControlState GetValue() const override
+  {
+    if (!control)
+      return 0.0;
+
+    // Note: Inputs may return negative values in situations where opposing directions are
+    // activated. We clamp off the negative values here.
+
+    // FYI: Clamping values greater than 1.0 is purposely not done to support unbounded values in
+    // the future. (e.g. raw accelerometer/gyro data)
+
+    return std::max(0.0, control->ToInput()->GetState());
+  }
   void SetValue(ControlState value) override
   {
     if (control)

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -259,7 +259,7 @@ std::string Joystick::Hat::GetName() const
 
 ControlState Joystick::Axis::GetState() const
 {
-  return std::max(0.0, ControlState(m_axis - m_base) / m_range);
+  return ControlState(m_axis - m_base) / m_range;
 }
 
 ControlState Joystick::Button::GetState() const

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -4,6 +4,7 @@
 
 #include "InputCommon/ControllerInterface/Device.h"
 
+#include <cmath>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -66,6 +67,11 @@ Device::Output* Device::FindOutput(const std::string& name) const
   }
 
   return nullptr;
+}
+
+ControlState Device::FullAnalogSurface::GetState() const
+{
+  return (1 + std::max(0.0, m_high.GetState()) - std::max(0.0, m_low.GetState())) / 2;
 }
 
 //
@@ -214,5 +220,5 @@ bool DeviceContainer::HasConnectedDevice(const DeviceQualifier& qualifier) const
   const auto device = FindDevice(qualifier);
   return device != nullptr && device->IsValid();
 }
-}
-}
+}  // namespace Core
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -11,16 +11,15 @@
 #include <tuple>
 
 #include "Common/StringUtil.h"
+#include "Common/Thread.h"
 
 namespace ciface
 {
 namespace Core
 {
-//
-// Device :: ~Device
-//
-// Destructor, delete all inputs/outputs on device destruction
-//
+// Compared to an input's current state (ideally 1.0) minus abs(initial_state) (ideally 0.0).
+constexpr ControlState INPUT_DETECT_THRESHOLD = 0.55;
+
 Device::~Device()
 {
   // delete inputs
@@ -220,5 +219,83 @@ bool DeviceContainer::HasConnectedDevice(const DeviceQualifier& qualifier) const
   const auto device = FindDevice(qualifier);
   return device != nullptr && device->IsValid();
 }
+
+// Wait for input on a particular device.
+// Inputs are considered if they are first seen in a neutral state.
+// This is useful for crazy flightsticks that have certain buttons that are always held down
+// and also properly handles detection when using "FullAnalogSurface" inputs.
+// Upon input, return the detected Device and Input, else return nullptrs
+std::pair<std::shared_ptr<Device>, Device::Input*>
+DeviceContainer::DetectInput(u32 wait_ms, std::vector<std::string> device_strings)
+{
+  struct InputState
+  {
+    ciface::Core::Device::Input& input;
+    ControlState initial_state;
+  };
+
+  struct DeviceState
+  {
+    std::shared_ptr<Device> device;
+
+    std::vector<InputState> input_states;
+  };
+
+  // Acquire devices and initial input states.
+  std::vector<DeviceState> device_states;
+  for (auto& device_string : device_strings)
+  {
+    DeviceQualifier dq;
+    dq.FromString(device_string);
+    auto device = FindDevice(dq);
+
+    if (!device)
+      continue;
+
+    std::vector<InputState> input_states;
+
+    for (auto* input : device->Inputs())
+    {
+      // Don't detect things like absolute cursor position.
+      if (!input->IsDetectable())
+        continue;
+
+      // Undesirable axes will have negative values here when trying to map a
+      // "FullAnalogSurface".
+      input_states.push_back({*input, input->GetState()});
+    }
+
+    if (!input_states.empty())
+      device_states.emplace_back(DeviceState{std::move(device), std::move(input_states)});
+  }
+
+  if (device_states.empty())
+    return {};
+
+  u32 time = 0;
+  while (time < wait_ms)
+  {
+    Common::SleepCurrentThread(10);
+    time += 10;
+
+    for (auto& device_state : device_states)
+    {
+      device_state.device->UpdateInput();
+      for (auto& input_state : device_state.input_states)
+      {
+        // We want an input that was initially 0.0 and currently 1.0.
+        const auto detection_score =
+            (input_state.input.GetState() - std::abs(input_state.initial_state));
+
+        if (detection_score > INPUT_DETECT_THRESHOLD)
+          return {device_state.device, &input_state.input};
+      }
+    }
+  }
+
+  // No input was detected. :'(
+  return {};
+}
+
 }  // namespace Core
 }  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -172,6 +172,9 @@ public:
 
   bool HasConnectedDevice(const DeviceQualifier& qualifier) const;
 
+  std::pair<std::shared_ptr<Device>, Device::Input*>
+  DetectInput(u32 wait_ms, std::vector<std::string> device_strings);
+
 protected:
   mutable std::mutex m_devices_mutex;
   std::vector<std::shared_ptr<Device>> m_devices;

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -228,7 +228,7 @@ ControlState Device::Trigger::GetState() const
 
 ControlState Device::Axis::GetState() const
 {
-  return std::max(0.0, ControlState(m_axis) / m_range);
+  return ControlState(m_axis) / m_range;
 }
 
 void Device::Motor::SetState(ControlState state)
@@ -236,5 +236,5 @@ void Device::Motor::SetState(ControlState state)
   m_motor = (WORD)(state * m_range);
   m_parent->UpdateMotors();
 }
-}
-}
+}  // namespace XInput
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -343,7 +343,7 @@ ControlState evdevDevice::Axis::GetState() const
   int value = 0;
   libevdev_fetch_event_value(m_dev, EV_ABS, m_code, &value);
 
-  return std::max(0.0, ControlState(value - m_base) / m_range);
+  return ControlState(value - m_base) / m_range;
 }
 
 evdevDevice::Effect::Effect(int fd) : m_fd(fd)


### PR DESCRIPTION
As you may know, all `Input` states in ControllerInterface are represented by a floating point value from 0.0 to 1.0.

Axes receive two inputs (one for each direction) (e.g. X- and X+). Input backends were expected to make each return a value from 0.0 to 1.0 by clamping off negative values (so a negative X does not affect the X+ Input).

Unfortunately some silly devices like to represent inputs (usually triggers) across an entire axis so a neutral state is seen as a fully activated X- or X+.

FullAnalogSurface was introduced to solve this which maps the complete range of an axis from 0.0 to 1.0.

These workaround "full surface" inputs are added in addition to the regular ones because we have no way of knowing which representation is sensible until the user tries to use them.

Input detection logic unfortunately did poorly at determining which virtual input is desired because when a user physically moves an axis both the regular "X+" and "full surface" "X-+" are seen moving from 0.0 to 1.0 (just at slightly different rates).

What this change does is allow input backends to return negative values when opposing inputs are activated (negatives are clamped later).

Mapping logic can observe these negatives to properly detect the difference between a user moving an axis from neutral vs. a move from full negative to full positive.

The negatives are still clamped off before they reach expression parser (everything should remain the same other than mapping detection logic).

It appears by an oversight of what was expected, Android never clamped negative values. I suspect this change will fix all axes on Android from being overly sensitive because of bad math.

Note: I have purposely not "unclamped" Axis::GetState in a few backends because of some other pending cleanups.

I should mention providing the unclamped value is not required. It just allows mapping logic to detect false positives.

I hope that all makes sense. ;P

I also removed the std::async hackery in DolphinQt when mapping "All Devices".
This will make PR #7590 obsolete.