### PR TITLE
DolphinQt: Disable keyboard navigation in tab widget on MappingWindow

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -107,7 +107,7 @@ void MappingButton::Detect()
   if (m_parent->GetDevice() == nullptr || !m_reference->IsInput())
     return;
 
-  installEventFilter(BlockUserInputFilter::Instance());
+  installEventFilter(this);
   grabKeyboard();
 
   // Make sure that we don't block event handling
@@ -234,4 +234,10 @@ void MappingButton::mouseReleaseEvent(QMouseEvent* event)
   default:
     return;
   }
+}
+
+bool MappingButton::eventFilter(QObject* object, QEvent* event)
+{
+  const QEvent::Type event_type = event->type();
+  return event_type == QEvent::KeyPress || event_type == QEvent::KeyRelease;
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
@@ -36,6 +36,5 @@ private:
   MappingWidget* m_parent;
   ControlReference* m_reference;
   QTimer* m_timer;
-
-  bool eventFilter(QObject* object, QEvent* event) override;
+  QTimer* m_blockTimer;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
@@ -36,4 +36,6 @@ private:
   MappingWidget* m_parent;
   ControlReference* m_reference;
   QTimer* m_timer;
+
+  bool eventFilter(QObject* object, QEvent* event) override;
 };


### PR DESCRIPTION
Fixes issue https://bugs.dolphin-emu.org/issues/11563

Completely disables use of keys whilst the tab widget (where keys are rebound) on the Mapping Window is selected.

This allows spacebar to be bound without going through the more options menu.
It also means the arrow keys and tab cannot be used to navigate through the buttons.