### PR TITLE
TextureCache: Fix GPU decoding of XFB copies

### DIFF
--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -108,7 +108,7 @@ bool VertexManager::Initialize()
       format_mapping = {{
           {TEXEL_BUFFER_FORMAT_R8_UINT, DXGI_FORMAT_R8_UINT},
           {TEXEL_BUFFER_FORMAT_R16_UINT, DXGI_FORMAT_R16_UINT},
-          {TEXEL_BUFFER_FORMAT_RGBA8_UINT, DXGI_FORMAT_R8G8B8A8_UNORM},
+          {TEXEL_BUFFER_FORMAT_RGBA8_UINT, DXGI_FORMAT_R8G8B8A8_UINT},
           {TEXEL_BUFFER_FORMAT_R32G32_UINT, DXGI_FORMAT_R32G32_UINT},
       }};
   for (const auto& it : format_mapping)

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -75,7 +75,7 @@ bool VertexManager::Initialize()
         format_mapping = {{
             {TEXEL_BUFFER_FORMAT_R8_UINT, GL_R8UI},
             {TEXEL_BUFFER_FORMAT_R16_UINT, GL_R16UI},
-            {TEXEL_BUFFER_FORMAT_RGBA8_UINT, GL_RGBA8},
+            {TEXEL_BUFFER_FORMAT_RGBA8_UINT, GL_RGBA8UI},
             {TEXEL_BUFFER_FORMAT_R32G32_UINT, GL_RG32UI},
         }};
     glGenTextures(static_cast<GLsizei>(m_texel_buffer_views.size()), m_texel_buffer_views.data());

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -101,7 +101,7 @@ bool VertexManager::Initialize()
       format_mapping = {{
           {TEXEL_BUFFER_FORMAT_R8_UINT, VK_FORMAT_R8_UINT},
           {TEXEL_BUFFER_FORMAT_R16_UINT, VK_FORMAT_R16_UINT},
-          {TEXEL_BUFFER_FORMAT_RGBA8_UINT, VK_FORMAT_R8G8B8A8_UNORM},
+          {TEXEL_BUFFER_FORMAT_RGBA8_UINT, VK_FORMAT_R8G8B8A8_UINT},
           {TEXEL_BUFFER_FORMAT_R32G32_UINT, VK_FORMAT_R32G32_UINT},
       }};
   for (const auto& it : format_mapping)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1593,12 +1593,12 @@ void TextureCacheBase::LoadTextureLevelZeroFromMemory(TCacheEntry* entry_to_upda
   const u8* tlut = &texMem[tex_info.tlut_address];
 
   if (!decode_on_gpu ||
-      DecodeTextureOnGPU(entry_to_update, 0, tex_info.src_data, tex_info.total_bytes,
-                         tex_info.full_format.texfmt, tex_info.native_width, tex_info.native_height,
-                         tex_info.expanded_width, tex_info.expanded_height,
-                         tex_info.bytes_per_block *
-                             (tex_info.expanded_width / tex_info.block_width),
-                         tlut, tex_info.full_format.tlutfmt))
+      !DecodeTextureOnGPU(entry_to_update, 0, tex_info.src_data, tex_info.total_bytes,
+                          tex_info.full_format.texfmt, tex_info.native_width,
+                          tex_info.native_height, tex_info.expanded_width, tex_info.expanded_height,
+                          tex_info.bytes_per_block *
+                              (tex_info.expanded_width / tex_info.block_width),
+                          tlut, tex_info.full_format.tlutfmt))
   {
     size_t decoded_texture_size = tex_info.expanded_width * sizeof(u32) * tex_info.expanded_height;
     CheckTempSize(decoded_texture_size);

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -1345,7 +1345,7 @@ static const std::map<TextureFormat, DecodingShaderInfo> s_decoding_shader_info{
         int buffer_pos = int(u_src_offset + (uv.y * u_src_row_stride) + (uv.x / 2u));
         float4 yuyv = float4(texelFetch(s_input_buffer, buffer_pos));
 
-        float y = mix(yuyv.r, yuyv.b, (uv.x & 1u) == 1u);
+        float y = (uv.x & 1u) != 0u ? yuyv.r : yuyv.g;
 
         float yComp = 1.164 * (y - 16.0);
         float uComp = yuyv.g - 128.0;


### PR DESCRIPTION
Another regression from #7753. The conditional was inverted, resulting in CPU decoding being skipped when GPU decoding failed, which could lead to black screens on devices where GPU decoding isn't supported.

Also fixes the compute shader so it compiles under HLSL/D3D.