### PR TITLE
Add some gamesettings

### DIFF
--- a/Data/Sys/GameSettings/R5F.ini
+++ b/Data/Sys/GameSettings/R5F.ini
@@ -1,0 +1,7 @@
+# R5FP41, R5FE41 - Academy of Champions - Soccer
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/R8X.ini
+++ b/Data/Sys/GameSettings/R8X.ini
@@ -1,0 +1,4 @@
+# R8XE52 - Jurassic: The Hunted
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RB7.ini
+++ b/Data/Sys/GameSettings/RB7.ini
@@ -3,6 +3,7 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 FastDiscSpeed = True
+SyncOnSkipIdle = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RRY.ini
+++ b/Data/Sys/GameSettings/RRY.ini
@@ -1,0 +1,4 @@
+# RRYEHG, RRYPHY - Rogue Trooper: Quartz Zone Massacre
+
+[Core]
+CPUThread = False


### PR DESCRIPTION
- SSX on Tour: crash in game with `JITFollowBranch` enabled
- Academy of Champions - Soccer: fx text display and don't use `ImmediateXFBEnable` or screen flicking
- Jurassic The Hunted: fx text display
- Rogue Trooper Quartz Zone Massacre: stuck in game with `CPUThread` enabled