### PR TITLE
TextureConversionShader: fix XFB decoding shader

### DIFF
--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -1345,7 +1345,7 @@ static const std::map<TextureFormat, DecodingShaderInfo> s_decoding_shader_info{
         int buffer_pos = int(u_src_offset + (uv.y * u_src_row_stride) + (uv.x / 2u));
         float4 yuyv = float4(texelFetch(s_input_buffer, buffer_pos));
 
-        float y = (uv.x & 1u) != 0u ? yuyv.r : yuyv.g;
+        float y = (uv.x & 1u) != 0u ? yuyv.b : yuyv.r;
 
         float yComp = 1.164 * (y - 16.0);
         float uComp = yuyv.g - 128.0;


### PR DESCRIPTION
This fixes the issue reported by @nbohr1more in #7753 (the bug was only introduced in #7832 though):
> FMV in iNinja is a rather strange looking...