### PR TITLE
DolphinQt: Fix invalid error message when trying to save a zero-sized game config.

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -121,11 +121,14 @@ void GameConfigEdit::SaveFile()
   QFile file(m_path);
 
   if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
+  {
+    QMessageBox::warning(this, tr("Warning"), tr("Failed to open config file!"));
     return;
+  }
 
   const QByteArray contents = m_edit->toPlainText().toUtf8();
 
-  if (!file.write(contents))
+  if (file.write(contents) == -1)
     QMessageBox::warning(this, tr("Warning"), tr("Failed to write config file!"));
 }
 


### PR DESCRIPTION
QFile::write returns the number of bytes written or -1 on error.

Erasing all of the contents of the game config in the editor was producing a false error message.