### PR TITLE
Config: Move the 'Display' settings from ConfigManager to the layered config system

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -23,6 +23,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
 #include "Common/Version.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCPad.h"
 #include "Core/Movie.h"
@@ -326,7 +327,7 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("cfg-audio-backend", SConfig::GetInstance().sBackend);
   builder.AddData("cfg-oc-enable", SConfig::GetInstance().m_OCEnable);
   builder.AddData("cfg-oc-factor", SConfig::GetInstance().m_OCFactor);
-  builder.AddData("cfg-render-to-main", SConfig::GetInstance().bRenderToMain);
+  builder.AddData("cfg-render-to-main", Config::Get(Config::MAIN_RENDER_TO_MAIN));
   if (g_video_backend)
   {
     builder.AddData("cfg-video-backend", g_video_backend->GetName());

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -106,6 +106,23 @@ const ConfigInfo<bool> MAIN_ENABLE_SIGNATURE_CHECKS{{System::Main, "Core", "Enab
 const ConfigInfo<bool> MAIN_REDUCE_POLLING_RATE{{System::Main, "Core", "ReducePollingRate"}, false};
 const ConfigInfo<bool> MAIN_AUTO_DISC_CHANGE{{System::Main, "Core", "AutoDiscChange"}, false};
 
+// Main.Display
+
+const ConfigInfo<std::string> MAIN_FULLSCREEN_DISPLAY_RES{
+    {System::Main, "Display", "FullscreenDisplayRes"}, "Auto"};
+const ConfigInfo<bool> MAIN_FULLSCREEN{{System::Main, "Display", "Fullscreen"}, false};
+const ConfigInfo<bool> MAIN_RENDER_TO_MAIN{{System::Main, "Display", "RenderToMain"}, false};
+const ConfigInfo<int> MAIN_RENDER_WINDOW_XPOS{{System::Main, "Display", "RenderWindowXPos"}, -1};
+const ConfigInfo<int> MAIN_RENDER_WINDOW_YPOS{{System::Main, "Display", "RenderWindowYPos"}, -1};
+const ConfigInfo<int> MAIN_RENDER_WINDOW_WIDTH{{System::Main, "Display", "RenderWindowWidth"}, 640};
+const ConfigInfo<int> MAIN_RENDER_WINDOW_HEIGHT{{System::Main, "Display", "RenderWindowHeight"},
+                                                480};
+const ConfigInfo<bool> MAIN_RENDER_WINDOW_AUTOSIZE{
+    {System::Main, "Display", "RenderWindowAutoSize"}, false};
+const ConfigInfo<bool> MAIN_KEEP_WINDOW_ON_TOP{{System::Main, "Display", "KeepWindowOnTop"}, false};
+const ConfigInfo<bool> MAIN_DISABLE_SCREENSAVER{{System::Main, "Display", "DisableScreenSaver"},
+                                                false};
+
 // Main.DSP
 
 const ConfigInfo<bool> MAIN_DSP_CAPTURE_LOG{{System::Main, "DSP", "CaptureLog"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -90,6 +90,19 @@ extern const ConfigInfo<bool> MAIN_DUMP_UCODE;
 extern const ConfigInfo<std::string> MAIN_AUDIO_BACKEND;
 extern const ConfigInfo<int> MAIN_AUDIO_VOLUME;
 
+// Main.Display
+
+extern const ConfigInfo<std::string> MAIN_FULLSCREEN_DISPLAY_RES;
+extern const ConfigInfo<bool> MAIN_FULLSCREEN;
+extern const ConfigInfo<bool> MAIN_RENDER_TO_MAIN;
+extern const ConfigInfo<int> MAIN_RENDER_WINDOW_XPOS;
+extern const ConfigInfo<int> MAIN_RENDER_WINDOW_YPOS;
+extern const ConfigInfo<int> MAIN_RENDER_WINDOW_WIDTH;
+extern const ConfigInfo<int> MAIN_RENDER_WINDOW_HEIGHT;
+extern const ConfigInfo<bool> MAIN_RENDER_WINDOW_AUTOSIZE;
+extern const ConfigInfo<bool> MAIN_KEEP_WINDOW_ON_TOP;
+extern const ConfigInfo<bool> MAIN_DISABLE_SCREENSAVER;
+
 // Main.General
 
 extern const ConfigInfo<std::string> MAIN_DUMP_PATH;

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -84,6 +84,7 @@ static const INIToSectionMap& GetINIToSectionMap()
 {
   static const INIToSectionMap ini_to_section = {
       {"Core", {Config::System::Main, "Core"}},
+      {"Display", {Config::System::Main, "Display"}},
       {"Video_Hardware", {Config::System::GFX, "Hardware"}},
       {"Video_Settings", {Config::System::GFX, "Settings"}},
       {"Video_Enhancements", {Config::System::GFX, "Enhancements"}},

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -33,6 +33,14 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::MAIN_MEMCARD_B_PATH.location,
       Config::MAIN_AUTO_DISC_CHANGE.location,
 
+      // Main.Display
+      Config::MAIN_FULLSCREEN_DISPLAY_RES.location,
+      Config::MAIN_FULLSCREEN.location,
+      Config::MAIN_RENDER_TO_MAIN.location,
+      Config::MAIN_RENDER_WINDOW_AUTOSIZE.location,
+      Config::MAIN_KEEP_WINDOW_ON_TOP.location,
+      Config::MAIN_DISABLE_SCREENSAVER.location,
+
       // Graphics.Hardware
 
       Config::GFX_VSYNC.location,

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -80,7 +80,6 @@ void SConfig::SaveSettings()
 
   SaveGeneralSettings(ini);
   SaveInterfaceSettings(ini);
-  SaveDisplaySettings(ini);
   SaveGameListSettings(ini);
   SaveCoreSettings(ini);
   SaveMovieSettings(ini);
@@ -149,22 +148,6 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("ThemeName", theme_name);
   interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
   interface->Set("DebugModeEnabled", bEnableDebugging);
-}
-
-void SConfig::SaveDisplaySettings(IniFile& ini)
-{
-  IniFile::Section* display = ini.GetOrCreateSection("Display");
-
-  display->Set("FullscreenDisplayRes", strFullscreenResolution);
-  display->Set("Fullscreen", bFullscreen);
-  display->Set("RenderToMain", bRenderToMain);
-  display->Set("RenderWindowXPos", iRenderWindowXPos);
-  display->Set("RenderWindowYPos", iRenderWindowYPos);
-  display->Set("RenderWindowWidth", iRenderWindowWidth);
-  display->Set("RenderWindowHeight", iRenderWindowHeight);
-  display->Set("RenderWindowAutoSize", bRenderWindowAutoSize);
-  display->Set("KeepWindowOnTop", bKeepWindowOnTop);
-  display->Set("DisableScreenSaver", bDisableScreenSaver);
 }
 
 void SConfig::SaveGameListSettings(IniFile& ini)
@@ -378,7 +361,6 @@ void SConfig::LoadSettings()
 
   LoadGeneralSettings(ini);
   LoadInterfaceSettings(ini);
-  LoadDisplaySettings(ini);
   LoadGameListSettings(ini);
   LoadCoreSettings(ini);
   LoadMovieSettings(ini);
@@ -438,22 +420,6 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("ThemeName", &theme_name, DEFAULT_THEME_DIR);
   interface->Get("PauseOnFocusLost", &m_PauseOnFocusLost, false);
   interface->Get("DebugModeEnabled", &bEnableDebugging, false);
-}
-
-void SConfig::LoadDisplaySettings(IniFile& ini)
-{
-  IniFile::Section* display = ini.GetOrCreateSection("Display");
-
-  display->Get("Fullscreen", &bFullscreen, false);
-  display->Get("FullscreenDisplayRes", &strFullscreenResolution, "Auto");
-  display->Get("RenderToMain", &bRenderToMain, false);
-  display->Get("RenderWindowXPos", &iRenderWindowXPos, -1);
-  display->Get("RenderWindowYPos", &iRenderWindowYPos, -1);
-  display->Get("RenderWindowWidth", &iRenderWindowWidth, 640);
-  display->Get("RenderWindowHeight", &iRenderWindowHeight, 480);
-  display->Get("RenderWindowAutoSize", &bRenderWindowAutoSize, false);
-  display->Get("KeepWindowOnTop", &bKeepWindowOnTop, false);
-  display->Get("DisableScreenSaver", &bDisableScreenSaver, true);
 }
 
 void SConfig::LoadGameListSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -144,16 +144,6 @@ struct SConfig
   bool bOnScreenDisplayMessages = true;
   std::string theme_name;
 
-  // Display settings
-  std::string strFullscreenResolution;
-  int iRenderWindowXPos = std::numeric_limits<int>::min();
-  int iRenderWindowYPos = std::numeric_limits<int>::min();
-  int iRenderWindowWidth = -1;
-  int iRenderWindowHeight = -1;
-  bool bRenderWindowAutoSize = false, bKeepWindowOnTop = false;
-  bool bFullscreen = false, bRenderToMain = false;
-  bool bDisableScreenSaver = false;
-
   // Analytics settings.
   std::string m_analytics_id;
   bool m_analytics_enabled = false;
@@ -337,7 +327,6 @@ private:
 
   void SaveGeneralSettings(IniFile& ini);
   void SaveInterfaceSettings(IniFile& ini);
-  void SaveDisplaySettings(IniFile& ini);
   void SaveGameListSettings(IniFile& ini);
   void SaveCoreSettings(IniFile& ini);
   void SaveDSPSettings(IniFile& ini);
@@ -353,7 +342,6 @@ private:
 
   void LoadGeneralSettings(IniFile& ini);
   void LoadInterfaceSettings(IniFile& ini);
-  void LoadDisplaySettings(IniFile& ini);
   void LoadGameListSettings(IniFile& ini);
   void LoadCoreSettings(IniFile& ini);
   void LoadDSPSettings(IniFile& ini);

--- a/Source/Core/DolphinNoGUI/PlatformX11.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformX11.cpp
@@ -7,6 +7,7 @@
 #include "DolphinNoGUI/Platform.h"
 
 #include "Common/MsgHandler.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/State.h"
@@ -48,6 +49,10 @@ private:
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
   X11Utils::XRRConfiguration* m_xrr_config = nullptr;
 #endif
+  int m_window_x = Config::Get(Config::MAIN_RENDER_WINDOW_XPOS);
+  int m_window_y = Config::Get(Config::MAIN_RENDER_WINDOW_YPOS);
+  unsigned int m_window_width = Config::Get(Config::MAIN_RENDER_WINDOW_WIDTH);
+  unsigned int m_window_height = Config::Get(Config::MAIN_RENDER_WINDOW_HEIGHT);
 };
 
 PlatformX11::~PlatformX11()
@@ -75,10 +80,8 @@ bool PlatformX11::Init()
     return false;
   }
 
-  m_window = XCreateSimpleWindow(
-      m_display, DefaultRootWindow(m_display), SConfig::GetInstance().iRenderWindowXPos,
-      SConfig::GetInstance().iRenderWindowYPos, SConfig::GetInstance().iRenderWindowWidth,
-      SConfig::GetInstance().iRenderWindowHeight, 0, 0, BlackPixel(m_display, 0));
+  m_window = XCreateSimpleWindow(m_display, DefaultRootWindow(m_display), m_window_x, m_window_y,
+                                 m_window_width, m_window_height, 0, 0, BlackPixel(m_display, 0));
   XSelectInput(m_display, m_window, StructureNotifyMask | KeyPressMask | FocusChangeMask);
   Atom wmProtocols[1];
   wmProtocols[0] = XInternAtom(m_display, "WM_DELETE_WINDOW", True);
@@ -98,7 +101,7 @@ bool PlatformX11::Init()
   XSync(m_display, True);
   ProcessEvents();
 
-  if (SConfig::GetInstance().bDisableScreenSaver)
+  if (Config::Get(Config::MAIN_DISABLE_SCREENSAVER))
     X11Utils::InhibitScreensaver(m_window, true);
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
@@ -118,7 +121,7 @@ bool PlatformX11::Init()
   }
 
   // Enter fullscreen if enabled.
-  if (SConfig::GetInstance().bFullscreen)
+  if (Config::Get(Config::MAIN_FULLSCREEN))
   {
     m_window_fullscreen = X11Utils::ToggleFullscreen(m_display, m_window);
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
@@ -166,11 +169,8 @@ void PlatformX11::UpdateWindowPosition()
 
   Window winDummy;
   unsigned int borderDummy, depthDummy;
-  XGetGeometry(m_display, m_window, &winDummy, &SConfig::GetInstance().iRenderWindowXPos,
-               &SConfig::GetInstance().iRenderWindowYPos,
-               reinterpret_cast<unsigned int*>(&SConfig::GetInstance().iRenderWindowWidth),
-               reinterpret_cast<unsigned int*>(&SConfig::GetInstance().iRenderWindowHeight),
-               &borderDummy, &depthDummy);
+  XGetGeometry(m_display, m_window, &winDummy, &m_window_x, &m_window_y, &m_window_width,
+               &m_window_height, &borderDummy, &depthDummy);
 }
 
 void PlatformX11::ProcessEvents()

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -15,6 +15,7 @@
 #include <QVBoxLayout>
 
 #include "Core/Config/GraphicsSettings.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
@@ -59,7 +60,7 @@ void GeneralWidget::CreateWidgets()
                          Config::GFX_ASPECT_RATIO);
   m_adapter_combo = new QComboBox;
   m_enable_vsync = new GraphicsBool(tr("V-Sync"), Config::GFX_VSYNC);
-  m_enable_fullscreen = new QCheckBox(tr("Use Fullscreen"));
+  m_enable_fullscreen = new GraphicsBool(tr("Use Fullscreen"), Config::MAIN_FULLSCREEN);
 
   m_video_box->setLayout(m_video_layout);
 
@@ -87,10 +88,11 @@ void GeneralWidget::CreateWidgets()
   m_show_ping = new GraphicsBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING);
   m_log_render_time =
       new GraphicsBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
-  m_autoadjust_window_size = new QCheckBox(tr("Auto-Adjust Window Size"));
+  m_autoadjust_window_size =
+      new GraphicsBool(tr("Auto-Adjust Window Size"), Config::MAIN_RENDER_WINDOW_AUTOSIZE);
   m_show_messages =
       new GraphicsBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES);
-  m_render_main_window = new QCheckBox(tr("Render to Main Window"));
+  m_render_main_window = new GraphicsBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN);
 
   m_options_box->setLayout(m_options_layout);
 
@@ -143,9 +145,6 @@ void GeneralWidget::ConnectWidgets()
             g_Config.iAdapter = index;
             Config::SetBaseOrCurrent(Config::GFX_ADAPTER, index);
           });
-
-  for (QCheckBox* checkbox : {m_enable_fullscreen, m_render_main_window, m_autoadjust_window_size})
-    connect(checkbox, &QCheckBox::toggled, this, &GeneralWidget::SaveSettings);
 }
 
 void GeneralWidget::LoadSettings()
@@ -153,15 +152,6 @@ void GeneralWidget::LoadSettings()
   // Video Backend
   m_backend_combo->setCurrentIndex(m_backend_combo->findData(
       QVariant(QString::fromStdString(SConfig::GetInstance().m_strVideoBackend))));
-
-  // Enable Fullscreen
-  m_enable_fullscreen->setChecked(SConfig::GetInstance().bFullscreen);
-
-  // Render to Main Window
-  m_render_main_window->setChecked(SConfig::GetInstance().bRenderToMain);
-
-  // Autoadjust window size
-  m_autoadjust_window_size->setChecked(SConfig::GetInstance().bRenderWindowAutoSize);
 }
 
 void GeneralWidget::SaveSettings()
@@ -190,13 +180,6 @@ void GeneralWidget::SaveSettings()
     }
     emit BackendChanged(QString::fromStdString(current_backend));
   }
-
-  // Enable Fullscreen
-  SConfig::GetInstance().bFullscreen = m_enable_fullscreen->isChecked();
-  // Autoadjust window size
-  SConfig::GetInstance().bRenderWindowAutoSize = m_autoadjust_window_size->isChecked();
-  // Render To Main
-  SConfig::GetInstance().bRenderToMain = m_render_main_window->isChecked();
 }
 
 void GeneralWidget::OnEmulationStateChanged(bool running)

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -12,6 +12,7 @@
 
 #include "Common/Common.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Debugger/PPCDebugInterface.h"
@@ -58,7 +59,7 @@ void Host::SetRenderFocus(bool focus)
   m_render_focus = focus;
   if (g_renderer && m_render_fullscreen && g_ActiveConfig.ExclusiveFullscreenEnabled())
     Core::RunAsCPUThread([focus] {
-      if (!SConfig::GetInstance().bRenderToMain)
+      if (!Config::Get(Config::MAIN_RENDER_TO_MAIN))
         g_renderer->SetFullscreen(focus);
     });
 }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -930,20 +930,20 @@ void MainWindow::StartGame(std::unique_ptr<BootParameters>&& parameters)
     Discord::UpdateDiscordPresence();
 #endif
 
-  if (SConfig::GetInstance().bFullscreen)
+  if (Config::Get(Config::MAIN_FULLSCREEN))
     m_fullscreen_requested = true;
 
 #ifdef Q_OS_WIN
   // Prevents Windows from sleeping, turning off the display, or idling
   EXECUTION_STATE shouldScreenSave =
-      SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
+      Config::Get(Config::MAIN_DISABLE_SCREENSAVER) ? ES_DISPLAY_REQUIRED : 0;
   SetThreadExecutionState(ES_CONTINUOUS | shouldScreenSave | ES_SYSTEM_REQUIRED);
 #endif
 }
 
 void MainWindow::SetFullScreenResolution(bool fullscreen)
 {
-  if (SConfig::GetInstance().strFullscreenResolution == "Auto")
+  if (Config::Get(Config::MAIN_FULLSCREEN_DISPLAY_RES) == "Auto")
     return;
 #ifdef _WIN32
 
@@ -956,7 +956,7 @@ void MainWindow::SetFullScreenResolution(bool fullscreen)
   DEVMODE screen_settings;
   memset(&screen_settings, 0, sizeof(screen_settings));
   screen_settings.dmSize = sizeof(screen_settings);
-  sscanf(SConfig::GetInstance().strFullscreenResolution.c_str(), "%dx%d",
+  sscanf(Config::Get(Config::MAIN_FULLSCREEN_DISPLAY_RES).c_str(), "%dx%d",
          &screen_settings.dmPelsWidth, &screen_settings.dmPelsHeight);
   screen_settings.dmBitsPerPel = 32;
   screen_settings.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
@@ -974,7 +974,7 @@ void MainWindow::ShowRenderWidget()
   SetFullScreenResolution(false);
   Host::GetInstance()->SetRenderFullscreen(false);
 
-  if (SConfig::GetInstance().bRenderToMain)
+  if (Config::Get(Config::MAIN_RENDER_TO_MAIN))
   {
     // If we're rendering to main, add it to the stack and update our title when necessary.
     m_rendering_to_main = true;

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -18,6 +18,7 @@
 
 #include "imgui.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/State.h"
@@ -44,14 +45,15 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
 
   connect(Host::GetInstance(), &Host::RequestTitle, this, &RenderWidget::setWindowTitle);
   connect(Host::GetInstance(), &Host::RequestRenderSize, this, [this](int w, int h) {
-    if (!SConfig::GetInstance().bRenderWindowAutoSize || isFullScreen() || isMaximized())
+    if (!Config::Get(Config::MAIN_RENDER_WINDOW_AUTOSIZE) || isFullScreen() || isMaximized())
       return;
 
     resize(w, h);
   });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
-    SetFillBackground(SConfig::GetInstance().bRenderToMain && state == Core::State::Uninitialized);
+    SetFillBackground(Config::Get(Config::MAIN_RENDER_TO_MAIN) &&
+                      state == Core::State::Uninitialized);
     if (state == Core::State::Running)
       SetImGuiKeyMap();
   });

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -219,13 +219,13 @@ void Settings::SetKeepWindowOnTop(bool top)
   if (IsKeepWindowOnTopEnabled() == top)
     return;
 
-  SConfig::GetInstance().bKeepWindowOnTop = top;
+  Config::SetBaseOrCurrent(Config::MAIN_KEEP_WINDOW_ON_TOP, top);
   emit KeepWindowOnTopChanged(top);
 }
 
 bool Settings::IsKeepWindowOnTopEnabled() const
 {
-  return SConfig::GetInstance().bKeepWindowOnTop;
+  return Config::Get(Config::MAIN_KEEP_WINDOW_ON_TOP);
 }
 
 int Settings::GetVolume() const

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -376,7 +376,7 @@ void EnableScreenSaver(bool enable)
 // disable low-power states and/or screen dimming.
 
 #if defined(HAVE_X11) && HAVE_X11
-  if (SConfig::GetInstance().bDisableScreenSaver)
+  if (Config::Get(Config::MAIN_DISABLE_SCREENSAVER))
   {
     X11Utils::InhibitScreensaver(win, !enable);
   }
@@ -391,7 +391,7 @@ void EnableScreenSaver(bool enable)
   else
   {
     EXECUTION_STATE should_screen_save =
-        SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
+        Config::Get(Config::MAIN_DISABLE_SCREENSAVER) ? ES_DISPLAY_REQUIRED : 0;
     SetThreadExecutionState(ES_CONTINUOUS | should_screen_save | ES_SYSTEM_REQUIRED);
   }
 #endif
@@ -399,7 +399,7 @@ void EnableScreenSaver(bool enable)
 #ifdef __APPLE__
   static IOPMAssertionID s_power_assertion = kIOPMNullAssertionID;
 
-  if (SConfig::GetInstance().bDisableScreenSaver)
+  if (Config::Get(Config::MAIN_DISABLE_SCREENSAVER))
   {
     if (enable)
     {

--- a/Source/Core/UICommon/X11Utils.cpp
+++ b/Source/Core/UICommon/X11Utils.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <spawn.h>
 #include <string>
 #include <sys/wait.h>
@@ -14,7 +15,7 @@
 
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
-#include "Core/ConfigManager.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 
 extern char** environ;
@@ -103,7 +104,8 @@ XRRConfiguration::~XRRConfiguration()
 
 void XRRConfiguration::Update()
 {
-  if (SConfig::GetInstance().strFullscreenResolution == "Auto")
+  const std::string fullscreen_display_res = Config::Get(Config::MAIN_FULLSCREEN_DISPLAY_RES);
+  if (fullscreen_display_res == "Auto")
     return;
 
   if (!bValid)
@@ -125,15 +127,15 @@ void XRRConfiguration::Update()
   unsigned int fullWidth, fullHeight;
   char* output_name = nullptr;
   char auxFlag = '\0';
-  if (SConfig::GetInstance().strFullscreenResolution.find(':') == std::string::npos)
+  if (fullscreen_display_res.find(':') == std::string::npos)
   {
     fullWidth = fb_width;
     fullHeight = fb_height;
   }
   else
   {
-    sscanf(SConfig::GetInstance().strFullscreenResolution.c_str(), "%m[^:]: %ux%u%c", &output_name,
-           &fullWidth, &fullHeight, &auxFlag);
+    sscanf(fullscreen_display_res.c_str(), "%m[^:]: %ux%u%c", &output_name, &fullWidth, &fullHeight,
+           &auxFlag);
   }
   bool want_interlaced = ('i' == auxFlag);
 
@@ -152,8 +154,9 @@ void XRRConfiguration::Update()
           if (!output_name)
           {
             output_name = strdup(output_info->name);
-            SConfig::GetInstance().strFullscreenResolution =
-                StringFromFormat("%s: %ux%u", output_info->name, fullWidth, fullHeight);
+            Config::SetBaseOrCurrent(
+                Config::MAIN_FULLSCREEN_DISPLAY_RES,
+                StringFromFormat("%s: %ux%u", output_info->name, fullWidth, fullHeight));
           }
           outputInfo = output_info;
           crtcInfo = crtc_info;


### PR DESCRIPTION
I've been looking into emulator front-ends lately and wanted to put games into fullscreen when playing a game with Dolphin.  Unfortunately, the fullscreen option was using the old config system while the command-line support for arbitrary configuration settings was using the new system.  The fix was to move all the Display settings over to the new system.

Should fix:

[Issue 9091](https://bugs.dolphin-emu.org/issues/9091)
[Issue 10735](https://bugs.dolphin-emu.org/issues/10735)