### PR TITLE
UpdaterCommon: Move most of the programs here

### DIFF
--- a/Source/Core/MacUpdater/AppDelegate.mm
+++ b/Source/Core/MacUpdater/AppDelegate.mm
@@ -4,99 +4,11 @@
 
 #import "AppDelegate.h"
 
-#include "Common/FileUtil.h"
-
-#include "UpdaterCommon/UI.h"
 #include "UpdaterCommon/UpdaterCommon.h"
 
 #include <Cocoa/Cocoa.h>
-#include <OptionParser.h>
-#include <optional>
-#include <unistd.h>
+#include <string>
 #include <vector>
-
-namespace
-{
-struct Options
-{
-  std::string this_manifest_url;
-  std::string next_manifest_url;
-  std::string content_store_url;
-  std::string install_base_path;
-  std::optional<std::string> binary_to_restart;
-  std::optional<pid_t> parent_pid;
-  std::optional<std::string> log_file;
-};
-
-std::optional<Options> ParseCommandLine(std::vector<std::string>& args)
-{
-  using optparse::OptionParser;
-
-  OptionParser parser =
-      OptionParser().prog("Dolphin Updater").description("Dolphin Updater binary");
-
-  parser.add_option("--this-manifest-url")
-      .dest("this-manifest-url")
-      .help("URL to the update manifest for the currently installed version.")
-      .metavar("URL");
-  parser.add_option("--next-manifest-url")
-      .dest("next-manifest-url")
-      .help("URL to the update manifest for the to-be-installed version.")
-      .metavar("URL");
-  parser.add_option("--content-store-url")
-      .dest("content-store-url")
-      .help("Base URL of the content store where files to download are stored.")
-      .metavar("URL");
-  parser.add_option("--install-base-path")
-      .dest("install-base-path")
-      .help("Base path of the Dolphin install to be updated.")
-      .metavar("PATH");
-  parser.add_option("--binary-to-restart")
-      .dest("binary-to-restart")
-      .help("Binary to restart after the update is over.")
-      .metavar("PATH");
-  parser.add_option("--log-file")
-      .dest("log-file")
-      .help("File where to log updater debug output.")
-      .metavar("PATH");
-  parser.add_option("--parent-pid")
-      .dest("parent-pid")
-      .type("int")
-      .help("(optional) PID of the parent process. The updater will wait for this process to "
-            "complete before proceeding.")
-      .metavar("PID");
-
-  optparse::Values options = parser.parse_args(args);
-
-  Options opts;
-
-  // Required arguments.
-  std::vector<std::string> required{"this-manifest-url", "next-manifest-url", "content-store-url",
-                                    "install-base-path"};
-  for (const auto& req : required)
-  {
-    if (!options.is_set(req))
-    {
-      parser.print_help();
-      return {};
-    }
-  }
-  opts.this_manifest_url = options["this-manifest-url"];
-  opts.next_manifest_url = options["next-manifest-url"];
-  opts.content_store_url = options["content-store-url"];
-  opts.install_base_path = options["install-base-path"];
-
-  // Optional arguments.
-  if (options.is_set("binary-to-restart"))
-    opts.binary_to_restart = options["binary-to-restart"];
-  if (options.is_set("parent-pid"))
-    opts.parent_pid = (pid_t)options.get("parent-pid");
-  if (options.is_set("log-file"))
-    opts.log_file = options["log-file"];
-
-  return opts;
-}
-}  // namespace
 
 @interface AppDelegate ()
 
@@ -106,8 +18,6 @@ std::optional<Options> ParseCommandLine(std::vector<std::string>& args)
 
 - (void)applicationDidFinishLaunching:(NSNotification*)aNotification
 {
-  UI::SetVisible(false);
-
   NSArray* arguments = [[NSProcessInfo processInfo] arguments];
 
   __block std::vector<std::string> args;
@@ -116,118 +26,10 @@ std::optional<Options> ParseCommandLine(std::vector<std::string>& args)
         args.push_back(std::string([obj UTF8String]));
       }];
 
-  std::optional<Options> maybe_opts = ParseCommandLine(args);
-
-  if (!maybe_opts)
-  {
-    [NSApp terminate:nil];
-    return;
-  }
-
-  Options opts = std::move(*maybe_opts);
-
   dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
   dispatch_async(queue, ^{
-    if (opts.log_file)
-    {
-      log_fp = fopen(opts.log_file.value().c_str(), "w");
-      if (!log_fp)
-        log_fp = stderr;
-      else
-        atexit(FlushLog);
-    }
-
-    fprintf(log_fp, "Updating from: %s\n", opts.this_manifest_url.c_str());
-    fprintf(log_fp, "Updating to:   %s\n", opts.next_manifest_url.c_str());
-    fprintf(log_fp, "Install path:  %s\n", opts.install_base_path.c_str());
-
-    if (!File::IsDirectory(opts.install_base_path))
-    {
-      FatalError("Cannot find install base path, or not a directory.");
-
-      [NSApp performSelector:@selector(terminate:) withObject:nil afterDelay:0.0];
-      return;
-    }
-
-    if (opts.parent_pid)
-    {
-      UI::SetDescription("Waiting for Dolphin to quit...");
-
-      fprintf(log_fp, "Waiting for parent PID %d to complete...\n", *opts.parent_pid);
-
-      auto pid = opts.parent_pid.value();
-
-      for (int res = kill(pid, 0); res == 0 || (res < 0 && errno == EPERM); res = kill(pid, 0))
-      {
-        sleep(1);
-      }
-
-      fprintf(log_fp, "Completed! Proceeding with update.\n");
-    }
-
-    UI::SetVisible(true);
-
-    UI::SetDescription("Fetching and parsing manifests...");
-
-    Manifest this_manifest, next_manifest;
-    {
-      std::optional<Manifest> maybe_manifest = FetchAndParseManifest(opts.this_manifest_url);
-      if (!maybe_manifest)
-      {
-        FatalError("Could not fetch current manifest. Aborting.");
-        return;
-      }
-      this_manifest = std::move(*maybe_manifest);
-
-      maybe_manifest = FetchAndParseManifest(opts.next_manifest_url);
-      if (!maybe_manifest)
-      {
-        FatalError("Could not fetch next manifest. Aborting.");
-        [NSApp performSelector:@selector(terminate:) withObject:nil afterDelay:0.0];
-        return;
-      }
-      next_manifest = std::move(*maybe_manifest);
-    }
-
-    UI::SetDescription("Computing what to do...");
-
-    TodoList todo = ComputeActionsToDo(this_manifest, next_manifest);
-    todo.Log();
-
-    std::optional<std::string> maybe_temp_dir = FindOrCreateTempDir(opts.install_base_path);
-    if (!maybe_temp_dir)
-      return;
-    std::string temp_dir = std::move(*maybe_temp_dir);
-
-    UI::SetDescription("Performing Update...");
-
-    bool ok = PerformUpdate(todo, opts.install_base_path, opts.content_store_url, temp_dir);
-    if (!ok)
-      FatalError("Failed to apply the update.");
-
-    CleanUpTempDir(temp_dir, todo);
-
-    UI::ResetCurrentProgress();
-    UI::ResetTotalProgress();
-    UI::SetCurrentMarquee(false);
-    UI::SetTotalMarquee(false);
-    UI::SetCurrentProgress(1, 1);
-    UI::SetTotalProgress(1, 1);
-    UI::SetDescription("Done!");
-
-    // Let the user process that we are done.
-    [NSThread sleepForTimeInterval:1.0f];
-
-    if (opts.binary_to_restart)
-    {
-      [[NSWorkspace sharedWorkspace]
-          launchApplication:[NSString stringWithCString:opts.binary_to_restart.value().c_str()
-                                               encoding:[NSString defaultCStringEncoding]]];
-    }
-
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      [NSApp terminate:nil];
-    });
+    RunUpdater(args);
+    [NSApp performSelector:@selector(terminate:) withObject:nil afterDelay:0.0];
   });
 }
 

--- a/Source/Core/MacUpdater/MacUI.mm
+++ b/Source/Core/MacUpdater/MacUI.mm
@@ -7,6 +7,7 @@
 #include "UpdaterCommon/UI.h"
 
 #include <Cocoa/Cocoa.h>
+#include <unistd.h>
 
 #include <functional>
 
@@ -105,6 +106,32 @@ void UI::SetCurrentProgress(int current, int total)
 void UI::SetTotalProgress(int current, int total)
 {
   run_on_main([&] { [GetView() SetTotalProgress:(double)current total:(double)total]; });
+}
+
+void UI::Sleep(int seconds)
+{
+  [NSThread sleepForTimeInterval:static_cast<float>(seconds)];
+}
+
+void UI::WaitForPID(u32 pid)
+{
+  for (int res = kill(pid, 0); res == 0 || (res < 0 && errno == EPERM); res = kill(pid, 0))
+  {
+    UI::Sleep(1);
+  }
+}
+
+void UI::LaunchApplication(std::string path)
+{
+  [[NSWorkspace sharedWorkspace]
+      launchApplication:[NSString stringWithCString:path.c_str()
+                                           encoding:[NSString defaultCStringEncoding]]];
+}
+
+// Stubs. These are only needed on Windows
+
+void UI::Init()
+{
 }
 
 void UI::Stop()

--- a/Source/Core/Updater/Main.cpp
+++ b/Source/Core/Updater/Main.cpp
@@ -4,36 +4,18 @@
 
 #include <windows.h>
 #include <ShlObj.h>
-
-#include <OptionParser.h>
-#include <array>
-#include <optional>
 #include <shellapi.h>
+
 #include <string>
-#include <thread>
 #include <vector>
 
-#include "Common/CommonPaths.h"
-#include "Common/CommonTypes.h"
-#include "Common/FileUtil.h"
+#include "Common/StringUtil.h"
 
 #include "UpdaterCommon/UI.h"
 #include "UpdaterCommon/UpdaterCommon.h"
 
 namespace
 {
-// Internal representation of options passed on the command-line.
-struct Options
-{
-  std::string this_manifest_url;
-  std::string next_manifest_url;
-  std::string content_store_url;
-  std::string install_base_path;
-  std::optional<std::string> binary_to_restart;
-  std::optional<DWORD> parent_pid;
-  std::optional<std::string> log_file;
-};
-
 std::vector<std::string> CommandLineToUtf8Argv(PCWSTR command_line)
 {
   int nargs;
@@ -50,75 +32,6 @@ std::vector<std::string> CommandLineToUtf8Argv(PCWSTR command_line)
   LocalFree(tokenized);
   return argv;
 }
-
-std::optional<Options> ParseCommandLine(PCWSTR command_line)
-{
-  using optparse::OptionParser;
-
-  OptionParser parser = OptionParser().prog("updater.exe").description("Dolphin Updater binary");
-
-  parser.add_option("--this-manifest-url")
-      .dest("this-manifest-url")
-      .help("URL to the update manifest for the currently installed version.")
-      .metavar("URL");
-  parser.add_option("--next-manifest-url")
-      .dest("next-manifest-url")
-      .help("URL to the update manifest for the to-be-installed version.")
-      .metavar("URL");
-  parser.add_option("--content-store-url")
-      .dest("content-store-url")
-      .help("Base URL of the content store where files to download are stored.")
-      .metavar("URL");
-  parser.add_option("--install-base-path")
-      .dest("install-base-path")
-      .help("Base path of the Dolphin install to be updated.")
-      .metavar("PATH");
-  parser.add_option("--binary-to-restart")
-      .dest("binary-to-restart")
-      .help("Binary to restart after the update is over.")
-      .metavar("PATH");
-  parser.add_option("--log-file")
-      .dest("log-file")
-      .help("File where to log updater debug output.")
-      .metavar("PATH");
-  parser.add_option("--parent-pid")
-      .dest("parent-pid")
-      .type("int")
-      .help("(optional) PID of the parent process. The updater will wait for this process to "
-            "complete before proceeding.")
-      .metavar("PID");
-
-  std::vector<std::string> argv = CommandLineToUtf8Argv(command_line);
-  optparse::Values options = parser.parse_args(argv);
-
-  Options opts;
-
-  // Required arguments.
-  std::vector<std::string> required{"this-manifest-url", "next-manifest-url", "content-store-url",
-                                    "install-base-path"};
-  for (const auto& req : required)
-  {
-    if (!options.is_set(req))
-    {
-      parser.print_help();
-      return {};
-    }
-  }
-  opts.this_manifest_url = options["this-manifest-url"];
-  opts.next_manifest_url = options["next-manifest-url"];
-  opts.content_store_url = options["content-store-url"];
-  opts.install_base_path = options["install-base-path"];
-
-  // Optional arguments.
-  if (options.is_set("binary-to-restart"))
-    opts.binary_to_restart = options["binary-to-restart"];
-  if (options.is_set("parent-pid"))
-    opts.parent_pid = (DWORD)options.get("parent-pid");
-  if (options.is_set("log-file"))
-    opts.log_file = options["log-file"];
-
-  return opts;
-}
 };  // namespace
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
@@ -132,58 +45,29 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     return 1;
   }
 
-  std::optional<Options> maybe_opts = ParseCommandLine(pCmdLine);
-  if (!maybe_opts)
-    return 1;
-  Options opts = std::move(*maybe_opts);
-
+  // Test for write permissions
   bool need_admin = false;
 
-  if (opts.log_file)
-  {
-    log_fp = _wfopen(UTF8ToUTF16(*opts.log_file).c_str(), L"w");
-    if (!log_fp)
-    {
-      log_fp = stderr;
-      // Failing to create the logfile for writing is a good indicator that we need administrator
-      // priviliges
-      need_admin = true;
-    }
-    else
-      atexit(FlushLog);
-  }
+  FILE* test_fh = fopen("Updater.log", "w");
 
-  fprintf(log_fp, "Updating from: %s\n", opts.this_manifest_url.c_str());
-  fprintf(log_fp, "Updating to:   %s\n", opts.next_manifest_url.c_str());
-  fprintf(log_fp, "Install path:  %s\n", opts.install_base_path.c_str());
-
-  if (!File::IsDirectory(opts.install_base_path))
-  {
-    FatalError("Cannot find install base path, or not a directory.");
-    return 1;
-  }
-
-  if (opts.parent_pid)
-  {
-    fprintf(log_fp, "Waiting for parent PID %d to complete...\n", *opts.parent_pid);
-    HANDLE parent_handle = OpenProcess(SYNCHRONIZE, FALSE, *opts.parent_pid);
-    WaitForSingleObject(parent_handle, INFINITE);
-    CloseHandle(parent_handle);
-    fprintf(log_fp, "Completed! Proceeding with update.\n");
-  }
+  if (test_fh == nullptr)
+    need_admin = true;
+  else
+    fclose(test_fh);
 
   if (need_admin)
   {
     if (IsUserAnAdmin())
     {
-      FatalError("Failed to write to directory despite administrator priviliges.");
+      MessageBox(nullptr, L"Failed to write to directory despite administrator priviliges.",
+                 L"Error", MB_ICONERROR);
       return 1;
     }
 
     wchar_t path[MAX_PATH];
     if (GetModuleFileName(hInstance, path, sizeof(path)) == 0)
     {
-      FatalError("Failed to get updater filename.");
+      MessageBox(nullptr, L"Failed to get updater filename.", L"Error", MB_ICONERROR);
       return 1;
     }
 
@@ -192,68 +76,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     return 0;
   }
 
-  std::thread thread(UI::MessageLoop);
-  thread.detach();
+  std::vector<std::string> args = CommandLineToUtf8Argv(pCmdLine);
 
-  UI::SetDescription("Fetching and parsing manifests...");
-
-  Manifest this_manifest, next_manifest;
-  {
-    std::optional<Manifest> maybe_manifest = FetchAndParseManifest(opts.this_manifest_url);
-    if (!maybe_manifest)
-    {
-      FatalError("Could not fetch current manifest. Aborting.");
-      return 1;
-    }
-    this_manifest = std::move(*maybe_manifest);
-
-    maybe_manifest = FetchAndParseManifest(opts.next_manifest_url);
-    if (!maybe_manifest)
-    {
-      FatalError("Could not fetch next manifest. Aborting.");
-      return 1;
-    }
-    next_manifest = std::move(*maybe_manifest);
-  }
-
-  UI::SetDescription("Computing what to do...");
-
-  TodoList todo = ComputeActionsToDo(this_manifest, next_manifest);
-  todo.Log();
-
-  std::optional<std::string> maybe_temp_dir = FindOrCreateTempDir(opts.install_base_path);
-  if (!maybe_temp_dir)
-    return 1;
-  std::string temp_dir = std::move(*maybe_temp_dir);
-
-  UI::SetDescription("Performing Update...");
-
-  bool ok = PerformUpdate(todo, opts.install_base_path, opts.content_store_url, temp_dir);
-  if (!ok)
-    FatalError("Failed to apply the update.");
-
-  CleanUpTempDir(temp_dir, todo);
-
-  UI::ResetCurrentProgress();
-  UI::ResetTotalProgress();
-  UI::SetCurrentMarquee(false);
-  UI::SetTotalMarquee(false);
-  UI::SetCurrentProgress(0, 1);
-  UI::SetTotalProgress(1, 1);
-  UI::SetDescription("Done!");
-
-  // Let the user process that we are done.
-  Sleep(1000);
-
-  if (opts.binary_to_restart)
-  {
-    // Hack: Launching the updater over the explorer ensures that admin priviliges are dropped. Why?
-    // Ask Microsoft.
-    ShellExecuteW(nullptr, nullptr, L"explorer.exe", UTF8ToUTF16(*opts.binary_to_restart).c_str(),
-                  nullptr, SW_SHOW);
-  }
-
-  UI::Stop();
-
-  return !ok;
+  return RunUpdater(args) ? 0 : 1;
 }

--- a/Source/Core/Updater/Updater.vcxproj
+++ b/Source/Core/Updater/Updater.vcxproj
@@ -42,9 +42,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Externals\cpp-optparse\cpp-optparse.vcxproj">
-      <Project>{c636d9d1-82fe-42b5-9987-63b7d4836341}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\Common\Common.vcxproj">
       <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
     </ProjectReference>

--- a/Source/Core/Updater/WinUI.cpp
+++ b/Source/Core/Updater/WinUI.cpp
@@ -5,10 +5,12 @@
 #include "UpdaterCommon/UI.h"
 
 #include <string>
+#include <thread>
 
 #include <Windows.h>
 #include <CommCtrl.h>
 #include <ShObjIdl.h>
+#include <shellapi.h>
 
 #include "Common/Flag.h"
 #include "Common/StringUtil.h"
@@ -29,7 +31,7 @@ constexpr int PROGRESSBAR_FLAGS = WS_VISIBLE | WS_CHILD | PBS_SMOOTH | PBS_SMOOT
 
 namespace UI
 {
-bool Init()
+bool InitWindow()
 {
   InitCommonControls();
 
@@ -168,7 +170,7 @@ void MessageLoop()
   request_stop.Clear();
   running.Set();
 
-  if (!Init())
+  if (!InitWindow())
   {
     running.Clear();
     MessageBox(nullptr, L"Window init failed!", L"", MB_ICONERROR);
@@ -192,6 +194,12 @@ void MessageLoop()
   Destroy();
 }
 
+void Init()
+{
+  std::thread thread(MessageLoop);
+  thread.detach();
+}
+
 void Stop()
 {
   if (!running.IsSet())
@@ -203,4 +211,29 @@ void Stop()
   {
   }
 }
+
+void LaunchApplication(std::string path)
+{
+  // Hack: Launching the updater over the explorer ensures that admin priviliges are dropped. Why?
+  // Ask Microsoft.
+  ShellExecuteW(nullptr, nullptr, L"explorer.exe", UTF8ToUTF16(path).c_str(), nullptr, SW_SHOW);
+}
+
+void Sleep(int sleep)
+{
+  ::Sleep(sleep * 1000);
+}
+
+void WaitForPID(u32 pid)
+{
+  HANDLE parent_handle = OpenProcess(SYNCHRONIZE, FALSE, static_cast<DWORD>(pid));
+  WaitForSingleObject(parent_handle, INFINITE);
+  CloseHandle(parent_handle);
+}
+
+void SetVisible(bool visible)
+{
+  ShowWindow(window_handle, visible ? SW_SHOW : SW_HIDE);
+}
+
 };  // namespace UI

--- a/Source/Core/UpdaterCommon/CMakeLists.txt
+++ b/Source/Core/UpdaterCommon/CMakeLists.txt
@@ -5,4 +5,5 @@ target_link_libraries(updatercommon PRIVATE
   uicommon
   mbedtls
   z
-  ed25519)
+  ed25519
+  cpp-optparse)

--- a/Source/Core/UpdaterCommon/UI.h
+++ b/Source/Core/UpdaterCommon/UI.h
@@ -6,11 +6,11 @@
 
 #include <string>
 
+#include "Common/CommonTypes.h"
+
 namespace UI
 {
-void MessageLoop();
 void Error(const std::string& text);
-void Stop();
 
 void SetDescription(const std::string& text);
 
@@ -23,4 +23,11 @@ void ResetCurrentProgress();
 void SetCurrentProgress(int current, int total);
 
 void SetVisible(bool visible);
+
+void Stop();
+
+void Init();
+void Sleep(int seconds);
+void WaitForPID(u32 pid);
+void LaunchApplication(std::string path);
 }  // namespace UI

--- a/Source/Core/UpdaterCommon/UpdaterCommon.h
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.h
@@ -13,48 +13,4 @@
 
 #include "Common/CommonTypes.h"
 
-extern FILE* log_fp;
-
-struct Manifest
-{
-  using Filename = std::string;
-  using Hash = std::array<u8, 16>;
-  std::map<Filename, Hash> entries;
-};
-
-// Represent the operations to be performed by the updater.
-struct TodoList
-{
-  struct DownloadOp
-  {
-    Manifest::Filename filename;
-    Manifest::Hash hash;
-  };
-  std::vector<DownloadOp> to_download;
-
-  struct UpdateOp
-  {
-    Manifest::Filename filename;
-    std::optional<Manifest::Hash> old_hash;
-    Manifest::Hash new_hash;
-  };
-  std::vector<UpdateOp> to_update;
-
-  struct DeleteOp
-  {
-    Manifest::Filename filename;
-    Manifest::Hash old_hash;
-  };
-  std::vector<DeleteOp> to_delete;
-
-  void Log() const;
-};
-
-void FatalError(const std::string& message);
-std::optional<Manifest> FetchAndParseManifest(const std::string& url);
-TodoList ComputeActionsToDo(Manifest this_manifest, Manifest next_manifest);
-std::optional<std::string> FindOrCreateTempDir(const std::string& base_path);
-void CleanUpTempDir(const std::string& temp_dir, const TodoList& todo);
-bool PerformUpdate(const TodoList& todo, const std::string& install_base_path,
-                   const std::string& content_base_url, const std::string& temp_path);
-void FlushLog();
+bool RunUpdater(std::vector<std::string> args);

--- a/Source/Core/UpdaterCommon/UpdaterCommon.vcxproj
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.vcxproj
@@ -55,6 +55,9 @@
     <ProjectReference Include="..\..\..\Externals\zlib\zlib.vcxproj">
       <Project>{ff213b23-2c26-4214-9f88-85271e557e87}</Project>
     </ProjectReference>
+	<ProjectReference Include="..\..\..\Externals\cpp-optparse\cpp-optparse.vcxproj">
+      <Project>{c636d9d1-82fe-42b5-9987-63b7d4836341}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
 	<ClCompile Include="UpdaterCommon.cpp" />


### PR DESCRIPTION
Moves a great chunk of the Updater logic into UpdaterCommon. 
The macOS and Windows Updaters are mere wrappers around UpdaterCommon now and have very little unique code (apart from the UI).

Verified to be working both on macOS and Windows.