### PR TITLE
DolphinQt: Fix ElidedButton (MappingButton) from growing with long text.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -32,7 +32,6 @@
 #include "InputCommon/ControllerInterface/Device.h"
 
 constexpr int SLIDER_TICK_COUNT = 100;
-constexpr int VERTICAL_PADDING = 2;
 
 static QString EscapeAmpersand(QString&& string)
 {
@@ -48,18 +47,13 @@ MappingButton::MappingButton(MappingWidget* widget, ControlReference* ref, bool 
     : ElidedButton(EscapeAmpersand(QString::fromStdString(ref->GetExpression()))), m_parent(widget),
       m_reference(ref)
 {
-  // Force all mapping buttons to use stay at a minimal height
-  int height = QFontMetrics(qApp->font()).height() + 2 * VERTICAL_PADDING;
+  // Force all mapping buttons to stay at a minimal height.
+  setFixedHeight(minimumSizeHint().height());
 
-  setMinimumHeight(height);
+  // Make sure that long entries don't throw our layout out of whack.
+  setFixedWidth(112);
 
-  // macOS needs some wiggle room to always get round buttons
-  setMaximumHeight(height + 8);
-
-  // Make sure that long entries don't throw our layout out of whack
-  setMaximumWidth(115);
-
-  setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
 
   Connect();
   setToolTip(

--- a/Source/Core/DolphinQt/QtUtils/ElidedButton.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ElidedButton.cpp
@@ -27,6 +27,14 @@ void ElidedButton::setElideMode(Qt::TextElideMode elide_mode)
   repaint();
 }
 
+QSize ElidedButton::sizeHint() const
+{
+  // Long text produces big sizeHints which is throwing layouts off
+  // even when setting fixed sizes. This seems like a Qt layout bug.
+  // Let's always return the sizeHint of an empty button to work around this.
+  return QPushButton(parentWidget()).sizeHint();
+}
+
 void ElidedButton::paintEvent(QPaintEvent* event)
 {
   QStyleOptionButton option;

--- a/Source/Core/DolphinQt/QtUtils/ElidedButton.h
+++ b/Source/Core/DolphinQt/QtUtils/ElidedButton.h
@@ -12,10 +12,13 @@ class ElidedButton : public QPushButton
 public:
   explicit ElidedButton(const QString& text = QStringLiteral(""),
                         Qt::TextElideMode elide_mode = Qt::ElideRight);
+
   Qt::TextElideMode elideMode() const;
   void setElideMode(Qt::TextElideMode elide_mode);
 
+  QSize sizeHint() const final override;
+
 private:
-  void paintEvent(QPaintEvent* event) override;
+  void paintEvent(QPaintEvent* event) final override;
   Qt::TextElideMode m_elide_mode;
 };


### PR DESCRIPTION
Long control expressions were causing the mapping buttons to grow by a few pixels.

It seems Qt is ignoring fixed sizes no matter what we do and trying really hard to use the `sizeHint`.

I've overrided `ElidedButton`'s sizeHint to return the "hint" of an empty button.

This should fix issue: https://bugs.dolphin-emu.org/issues/11558

Please test macOS.