### PR TITLE
Common/Config: Add a utility class to defer config change callbacks.

### DIFF
--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -96,4 +96,15 @@ void SetBaseOrCurrent(const ConfigInfo<T>& info, const std::common_type_t<T>& va
   else
     Set<T>(LayerType::CurrentRun, info, value);
 }
-}
+
+// Used to defer InvokeConfigChangedCallbacks until after the completion of many config changes.
+class ConfigChangeCallbackGuard
+{
+public:
+  ConfigChangeCallbackGuard();
+  ~ConfigChangeCallbackGuard();
+
+  ConfigChangeCallbackGuard(const ConfigChangeCallbackGuard&) = delete;
+  ConfigChangeCallbackGuard& operator=(const ConfigChangeCallbackGuard&) = delete;
+};
+}  // namespace Config

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -173,6 +173,8 @@ LogManager::~LogManager()
 
 void LogManager::SaveSettings()
 {
+  Config::ConfigChangeCallbackGuard config_guard;
+
   Config::SetBaseOrCurrent(LOGGER_WRITE_TO_FILE, IsListenerEnabled(LogListener::FILE_LISTENER));
   Config::SetBaseOrCurrent(LOGGER_WRITE_TO_CONSOLE,
                            IsListenerEnabled(LogListener::CONSOLE_LISTENER));

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -1008,6 +1008,8 @@ std::shared_ptr<const UICommon::GameFile> NetPlayDialog::FindGameFile(const std:
 
 void NetPlayDialog::SaveSettings()
 {
+  Config::ConfigChangeCallbackGuard config_guard;
+
   if (m_host_input_authority)
   {
     if (!IsHosting())

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -203,6 +203,8 @@ void NetPlaySetupDialog::ConnectWidgets()
 
 void NetPlaySetupDialog::SaveSettings()
 {
+  Config::ConfigChangeCallbackGuard config_guard;
+
   Config::SetBaseOrCurrent(Config::NETPLAY_NICKNAME, m_nickname_edit->text().toStdString());
   Config::SetBaseOrCurrent(m_connection_type->currentIndex() == 0 ? Config::NETPLAY_ADDRESS :
                                                                     Config::NETPLAY_HOST_CODE,

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -332,6 +332,8 @@ void GameCubePane::LoadSettings()
 
 void GameCubePane::SaveSettings()
 {
+  Config::ConfigChangeCallbackGuard config_guard;
+
   SConfig& params = SConfig::GetInstance();
 
   // IPL Settings

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -282,6 +282,8 @@ static QString UpdateTrackFromIndex(int index)
 
 void GeneralPane::OnSaveConfig()
 {
+  Config::ConfigChangeCallbackGuard config_guard;
+
   auto& settings = SConfig::GetInstance();
   if (AutoUpdateChecker::SystemSupportsAutoUpdates())
   {

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -221,6 +221,8 @@ void WiiPane::LoadConfig()
 
 void WiiPane::OnSaveConfig()
 {
+  Config::ConfigChangeCallbackGuard config_guard;
+
   Config::SetBase(Config::SYSCONF_SCREENSAVER, m_screensaver_checkbox->isChecked());
   Config::SetBase(Config::SYSCONF_PAL60, m_pal60_mode_checkbox->isChecked());
   Settings::Instance().SetUSBKeyboardConnected(m_connect_keyboard_checkbox->isChecked());


### PR DESCRIPTION
`Config::Set` currently triggers a bunch of directory creations.

Touching one widget in our settings dialog can perform a lot of `Config::Set`s.

This of course triggers a bunch of directory creations.. a lot of times..

The "IR Sensitivity" slider, among other things, are laggy as a result on some systems.

I've introduced a class that defers callbacks until the end of its life.

This should fix: https://bugs.dolphin-emu.org/issues/11076

I'm open to suggestions on better naming.