### PR TITLE
[RFC] Pixel shader minor changes

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -421,7 +421,7 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
   if (state.alphaupdate)
     tdesc.RenderTargetWriteMask |= D3D11_COLOR_WRITE_ENABLE_ALPHA;
 
-  const bool use_dual_source = state.usedualsrc;
+  const bool use_dual_source = state.IsDualSourceBlend();
   const std::array<D3D11_BLEND, 8> src_factors = {
       {D3D11_BLEND_ZERO, D3D11_BLEND_ONE, D3D11_BLEND_DEST_COLOR, D3D11_BLEND_INV_DEST_COLOR,
        use_dual_source ? D3D11_BLEND_SRC1_ALPHA : D3D11_BLEND_SRC_ALPHA,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1183,12 +1183,21 @@ void Renderer::ApplyBlendingState(const BlendingState state)
   if (m_current_blend_state == state)
     return;
 
-  bool useDualSource =
-      state.usedualsrc && g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
-      (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) || state.dstalpha);
+  bool useDualSource = false;
   // Only use shader blend if we need to and we don't support dual-source blending directly
-  bool useShaderBlend = !useDualSource && state.usedualsrc && state.dstalpha &&
-                        g_ActiveConfig.backend_info.bSupportsFramebufferFetch;
+  bool useShaderBlend = false;
+  if (state.IsDualSourceBlend())
+  {
+    if (g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
+        !DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING))
+    {
+      useDualSource = true;
+    }
+    else if (g_ActiveConfig.backend_info.bSupportsFramebufferFetch)
+    {
+      useShaderBlend = true;
+    }
+  }
 
   if (useShaderBlend)
   {

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -134,7 +134,7 @@ static VkPipelineColorBlendAttachmentState GetVulkanAttachmentBlendState(const B
   vk_state.colorBlendOp = state.subtract ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
   vk_state.alphaBlendOp = state.subtractAlpha ? VK_BLEND_OP_REVERSE_SUBTRACT : VK_BLEND_OP_ADD;
 
-  if (state.usedualsrc && g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
+  if (state.IsDualSourceBlend() && g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
   {
     static constexpr std::array<VkBlendFactor, 8> src_factors = {
         {VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_DST_COLOR,

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -18,7 +18,8 @@ struct pixel_shader_uid_data
   u32 num_values;  // TODO: Shouldn't be a u32
   u32 NumValues() const { return num_values; }
   u32 components : 2;
-  u32 pad0 : 2;
+  u32 pad0 : 1;
+  u32 dualSrcBlend : 1;
   u32 useDstAlpha : 1;
   u32 Pretest : 2;
   u32 nIndirectStagesUsed : 4;

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -103,7 +103,6 @@ void BlendingState::Generate(const BPMemory& bp)
   colorupdate = bp.blendmode.colorupdate && alpha_test_may_success;
   alphaupdate = bp.blendmode.alphaupdate && target_has_alpha && alpha_test_may_success;
   dstalpha = bp.dstalpha.enable && alphaupdate;
-  usedualsrc = true;
 
   // The subtract bit has the highest priority
   if (bp.blendmode.subtract)
@@ -264,7 +263,6 @@ BlendingState GetInvalidBlendingState()
 BlendingState GetNoBlendingBlendState()
 {
   BlendingState state = {};
-  state.usedualsrc = false;
   state.blendenable = false;
   state.srcfactor = BlendMode::ONE;
   state.srcfactoralpha = BlendMode::ONE;
@@ -279,7 +277,6 @@ BlendingState GetNoBlendingBlendState()
 BlendingState GetNoColorWriteBlendState()
 {
   BlendingState state = {};
-  state.usedualsrc = false;
   state.blendenable = false;
   state.srcfactor = BlendMode::ONE;
   state.srcfactoralpha = BlendMode::ONE;

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -68,6 +68,10 @@ union BlendingState
 {
   void Generate(const BPMemory& bp);
 
+  bool IsDualSourceBlend() const {
+    return dstalpha && (srcfactor == BlendMode::SRCALPHA || srcfactor == BlendMode::INVSRCALPHA);
+  }
+
   BlendingState& operator=(const BlendingState& rhs);
 
   bool operator==(const BlendingState& rhs) const { return hex == rhs.hex; }


### PR DESCRIPTION
add function `bool IsDualSourceBlend() const` to decide whether using dual source blend.
disable use dst alpha if backend doesn't support dual source blend.
clear unused shader uid bits.