### PR TITLE
OGL: Fix stereoscopy

### DIFF
--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -72,7 +72,16 @@ static void WriteHeader(char*& p, APIType ApiType)
     WRITE(p, "  float2 clamp_tb;\n");
     WRITE(p, "  float3 filter_coefficients;\n");
     WRITE(p, "};\n");
-    WRITE(p, "VARYING_LOCATION(0) in float3 v_tex0;\n");
+    if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+    {
+      WRITE(p, "VARYING_LOCATION(0) in VertexData {\n");
+      WRITE(p, "  float3 v_tex0;\n");
+      WRITE(p, "};\n");
+    }
+    else
+    {
+      WRITE(p, "VARYING_LOCATION(0) in float3 v_tex0;\n");
+    }
     WRITE(p, "SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n");
     WRITE(p, "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n");
   }
@@ -1510,7 +1519,16 @@ float4 DecodePixel(int val)
   }
   else
   {
-    ss << "VARYING_LOCATION(0) in float3 v_tex0;\n";
+    if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+    {
+      ss << "VARYING_LOCATION(0) in VertexData {\n";
+      ss << "  float3 v_tex0;\n";
+      ss << "};\n";
+    }
+    else
+    {
+      ss << "VARYING_LOCATION(0) in float3 v_tex0;\n";
+    }
     ss << "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n";
     ss << "void main() {\n";
     ss << "  float3 coords = v_tex0;\n";

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -67,8 +67,17 @@ ShaderCode GenerateVertexShader(APIType api_type)
   }
   else if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
-    out.Write("VARYING_LOCATION(0) out float3 v_tex0;\n"
-              "#define id gl_VertexID\n"
+    if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+    {
+      out.Write("VARYING_LOCATION(0) out VertexData {\n");
+      out.Write("  float3 v_tex0;\n");
+      out.Write("};\n");
+    }
+    else
+    {
+      out.Write("VARYING_LOCATION(0) out float3 v_tex0;\n");
+    }
+    out.Write("#define id gl_VertexID\n"
               "#define opos gl_Position\n"
               "void main() {\n");
   }
@@ -112,8 +121,17 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
               "clamp_tb.x, clamp_tb.y), %s));\n"
               "}\n",
               mono_depth ? "0.0" : "uv.z");
-    out.Write("VARYING_LOCATION(0) in vec3 v_tex0;\n"
-              "FRAGMENT_OUTPUT_LOCATION(0) out vec4 ocol0;"
+    if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+    {
+      out.Write("VARYING_LOCATION(0) in VertexData {\n");
+      out.Write("  float3 v_tex0;\n");
+      out.Write("};\n");
+    }
+    else
+    {
+      out.Write("VARYING_LOCATION(0) in vec3 v_tex0;\n");
+    }
+    out.Write("FRAGMENT_OUTPUT_LOCATION(0) out vec4 ocol0;"
               "void main()\n{\n");
   }
 


### PR DESCRIPTION
Does what the title says. We need to use interface names for glsl because we don't use explicit locations. Needs testing to ensure it doesn't break in Vulkan.

Also fixes a random error on shutdown which was seen occasionally (if the last thing drawn was imgui).