### PR TITLE
Qt/ModalMessageBox: Use Warning instead of Critical icon for questions

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
@@ -45,7 +45,7 @@ int ModalMessageBox::information(QWidget* parent, const QString& title, const QS
 int ModalMessageBox::question(QWidget* parent, const QString& title, const QString& text,
                               StandardButtons buttons, StandardButton default_button)
 {
-  return ExecMessageBox(QMessageBox::Critical, parent, title, text, buttons, default_button);
+  return ExecMessageBox(QMessageBox::Warning, parent, title, text, buttons, default_button);
 }
 
 int ModalMessageBox::warning(QWidget* parent, const QString& title, const QString& text,


### PR DESCRIPTION
Rationale for this change:
* The critical icon (a white X in a red circle on most platforms) makes users think a critical error has occured which is inaccurate
* The warning icon is more appropriate as we make clear that the action of the user will have an important (and maybe undesired) effect while the question icon is entirely neutral.
