### PR TITLE
Vulkan: Show backend as Vulkan (MoltenVK) on macOS

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -16,7 +16,14 @@ public:
   void Shutdown() override;
 
   std::string GetName() const override { return "Vulkan"; }
-  std::string GetDisplayName() const override { return _trans("Vulkan"); }
+  std::string GetDisplayName() const override
+  {
+#ifdef __APPLE__
+    return _trans("Vulkan (MoltenVK)");
+#else
+    return _trans("Vulkan");
+#endif
+  }
   void InitBackendInfo() override;
   void PrepareWindow(const WindowSystemInfo& wsi) override;
 };


### PR DESCRIPTION
<img width="650" alt="screen shot 2019-03-06 at 15 25 13" src="https://user-images.githubusercontent.com/1440715/53888209-2ed19c00-4024-11e9-9c71-a6f610919609.png">
