### PR TITLE
Revert "Vulkan: Show backend as Vulkan (MoltenVK) on macOS"

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -16,14 +16,7 @@ public:
   void Shutdown() override;
 
   std::string GetName() const override { return "Vulkan"; }
-  std::string GetDisplayName() const override
-  {
-#ifdef __APPLE__
-    return _trans("Vulkan (MoltenVK)");
-#else
-    return _trans("Vulkan");
-#endif
-  }
+  std::string GetDisplayName() const override { return _trans("Vulkan"); }
   void InitBackendInfo() override;
   void PrepareWindow(const WindowSystemInfo& wsi) override;
 };


### PR DESCRIPTION
Reverts dolphin-emu/dolphin#7860. 

There was still discussion going on IRC regarding this suffix not being optimal as there are other Vulkan implementations for macOS.