### PR TITLE
Bumps compile API to 29 (Q) and removes deprecated calls and unnecessary casts

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -75,15 +75,11 @@ android {
     }
 }
 
-ext {
-    androidSupportVersion = '28.0.0'
-}
-
 dependencies {
-    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
 
     // Android TV UI libraries.
@@ -91,12 +87,12 @@ dependencies {
     implementation 'androidx.tvprovider:tvprovider:1.0.0'
 
     // For REST calls
-    implementation 'com.android.volley:volley:1.1.0'
+    implementation 'com.android.volley:volley:1.1.1'
 
     // For loading huge screenshots from the disk.
     implementation 'com.squareup.picasso:picasso:2.71828'
 
-    implementation 'com.nononsenseapps:filepicker:4.1.0'
+    implementation 'com.nononsenseapps:filepicker:4.2.1'
 }
 
 def getVersion() {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -3,6 +3,7 @@ package org.dolphinemu.dolphinemu.adapters;
 import android.app.AlertDialog;
 import android.graphics.Rect;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -161,8 +162,9 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
     }
 
     @Override
-    public void getItemOffsets(Rect outRect, View view, RecyclerView parent,
-            RecyclerView.State state)
+    public void getItemOffsets(@NonNull Rect outRect, @NonNull View view,
+            @NonNull RecyclerView parent,
+            @NonNull RecyclerView.State state)
     {
       outRect.left = space;
       outRect.right = space;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/MotionAlertDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/MotionAlertDialog.java
@@ -2,19 +2,13 @@ package org.dolphinemu.dolphinemu.dialogs;
 
 import android.app.AlertDialog;
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.os.Vibrator;
-import android.preference.PreferenceManager;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
-import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.features.settings.model.view.InputBindingSetting;
-import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.utils.ControllerMappingHelper;
 import org.dolphinemu.dolphinemu.utils.Log;
-import org.dolphinemu.dolphinemu.utils.Rumble;
 import org.dolphinemu.dolphinemu.utils.TvUtil;
 
 import java.util.ArrayList;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/RumbleBindingSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/RumbleBindingSetting.java
@@ -1,7 +1,5 @@
 package org.dolphinemu.dolphinemu.features.settings.model.view;
 
-import android.content.SharedPreferences;
-import android.content.res.Resources;
 import android.os.Vibrator;
 import android.view.InputDevice;
 import android.view.KeyEvent;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -89,20 +89,6 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     mPresenter.onAttach();
   }
 
-  /**
-   * This version of onAttach is needed for versions below Marshmallow.
-   *
-   * @param activity
-   */
-  @Override
-  public void onAttach(Activity activity)
-  {
-    super.onAttach(activity);
-
-    mActivity = (SettingsActivityView) activity;
-    mPresenter.onAttach();
-  }
-
   @Override
   public void onCreate(Bundle savedInstanceState)
   {
@@ -139,11 +125,11 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
 
     LinearLayoutManager manager = new LinearLayoutManager(getActivity());
 
-    RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.list_settings);
+    RecyclerView recyclerView = view.findViewById(R.id.list_settings);
 
     recyclerView.setAdapter(mAdapter);
     recyclerView.setLayoutManager(manager);
-    recyclerView.addItemDecoration(new DividerItemDecoration(getActivity(), null));
+    recyclerView.addItemDecoration(new DividerItemDecoration(requireActivity(), null));
 
     SettingsActivityView activity = (SettingsActivityView) getActivity();
     mPresenter.onViewCreated(menuTag, activity.getSettings());

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/InputBindingSettingViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/InputBindingSettingViewHolder.java
@@ -30,8 +30,8 @@ public final class InputBindingSettingViewHolder extends SettingViewHolder
   @Override
   protected void findViews(View root)
   {
-    mTextSettingName = (TextView) root.findViewById(R.id.text_setting_name);
-    mTextSettingDescription = (TextView) root.findViewById(R.id.text_setting_description);
+    mTextSettingName = root.findViewById(R.id.text_setting_name);
+    mTextSettingDescription = root.findViewById(R.id.text_setting_description);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/DividerItemDecoration.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/DividerItemDecoration.java
@@ -6,6 +6,7 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -22,7 +23,6 @@ public final class DividerItemDecoration extends RecyclerView.ItemDecoration
   private Drawable mDivider;
   private boolean mShowFirstDivider = false;
   private boolean mShowLastDivider = false;
-
 
   public DividerItemDecoration(Context context, AttributeSet attrs)
   {
@@ -54,15 +54,16 @@ public final class DividerItemDecoration extends RecyclerView.ItemDecoration
   }
 
   @Override
-  public void getItemOffsets(Rect outRect, View view, RecyclerView parent,
-          RecyclerView.State state)
+  public void getItemOffsets(@NonNull Rect outRect, @NonNull View view,
+          @NonNull RecyclerView parent,
+          @NonNull RecyclerView.State state)
   {
     super.getItemOffsets(outRect, view, parent, state);
     if (mDivider == null)
     {
       return;
     }
-    if (parent.getChildPosition(view) < 1)
+    if (parent.getChildAdapterPosition(view) < 1)
     {
       return;
     }
@@ -78,7 +79,8 @@ public final class DividerItemDecoration extends RecyclerView.ItemDecoration
   }
 
   @Override
-  public void onDrawOver(Canvas c, RecyclerView parent, RecyclerView.State state)
+  public void onDrawOver(@NonNull Canvas c, @NonNull RecyclerView parent,
+          @NonNull RecyclerView.State state)
   {
     if (mDivider == null)
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -112,10 +112,10 @@ public final class MainActivity extends AppCompatActivity implements MainView
   // TODO: Replace with a ButterKnife injection.
   private void findViews()
   {
-    mToolbar = (Toolbar) findViewById(R.id.toolbar_main);
-    mViewPager = (ViewPager) findViewById(R.id.pager_platforms);
-    mTabLayout = (TabLayout) findViewById(R.id.tabs_platforms);
-    mFab = (FloatingActionButton) findViewById(R.id.button_add_directory);
+    mToolbar = findViewById(R.id.toolbar_main);
+    mViewPager = findViewById(R.id.pager_platforms);
+    mTabLayout = findViewById(R.id.tabs_platforms);
+    mFab = findViewById(R.id.button_add_directory);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.leanback.app.BrowseFragment;
 import androidx.leanback.app.BrowseSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
@@ -100,7 +101,7 @@ public final class TvMainActivity extends FragmentActivity implements MainView
             .commit();
 
     // Set display parameters for the BrowseFragment
-    mBrowseFragment.setHeadersState(BrowseFragment.HEADERS_ENABLED);
+    mBrowseFragment.setHeadersState(BrowseSupportFragment.HEADERS_ENABLED);
     mBrowseFragment.setBrandColor(ContextCompat.getColor(this, R.color.dolphin_blue_dark));
     buildRowsAdapter();
 
@@ -191,7 +192,8 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   }
 
   @Override
-  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults)
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+          @NonNull int[] grantResults)
   {
     switch (requestCode)
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
@@ -39,7 +39,6 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
     super.onCreate(savedInstanceState);
   }
 
-  @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -14,6 +14,8 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 public class Analytics
 {
   private static final String analyticsAsked =

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-
 /**
  * A service that spawns its own thread in order to copy several binary and shader files
  * from the Dolphin APK to the external file system.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
@@ -13,8 +13,6 @@ import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.model.StringSetting;
 import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
-import java.util.HashMap;
-
 public class Rumble
 {
   private static Vibrator phoneVibrator;

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <!-- Inherit from the material theme -->
-    <style name="DolphinBase" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="DolphinBase" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Main theme colors -->
         <!-- Branding color for the app bar -->
         <item name="colorPrimary">@color/dolphin_blue</item>
@@ -19,7 +19,7 @@
     </style>
 
     <!-- Same as above, but use default action bar, and mandate margins. -->
-    <style name="DolphinSettingsBase" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="DolphinSettingsBase" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_purple</item>
@@ -29,7 +29,7 @@
 
     <!-- Inherit from the Base Dolphin Dialog Theme -->
 
-    <style name="DolphinEmulationBase" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="DolphinEmulationBase" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_purple</item>
@@ -43,7 +43,7 @@
         <item name="android:windowAllowReturnTransitionOverlap">true</item>
     </style>
 
-    <style name="DolphinEmulationTvBase" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="DolphinEmulationTvBase" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_purple</item>
@@ -111,7 +111,7 @@
         <item name="nnf_toolbarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
     </style>
 
-    <style name="FilePickerAlertDialogTheme" parent="Theme.AppCompat.Dialog.Alert">
+    <style name="FilePickerAlertDialogTheme" parent="Theme.MaterialComponents.Dialog.Alert">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_accent_gamecube</item>

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }

--- a/Source/Android/gradle.properties
+++ b/Source/Android/gradle.properties
@@ -14,3 +14,5 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
This will help the Android client to evolve with the latest libraries (as the legacy support libs will not be shipped anymore with the com.android.support package).

This PR also makes the app compliant with the new API requirements to start later this year:
https://android-developers.googleblog.com/2019/02/expanding-target-api-level-requirements.html