### PR TITLE
Work around GCC 8.2 ICE

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
@@ -104,7 +104,7 @@ void CameraLogic::Update(const Common::Matrix44& transform, bool sensor_bar_on_t
 
   std::array<CameraPoint, leds.size()> camera_points;
 
-  std::transform(leds.begin(), leds.end(), camera_points.begin(), [&](auto& v) {
+  std::transform(leds.begin(), leds.end(), camera_points.begin(), [&](const Vec3& v) {
     const auto point = camera_view * Vec4(v, 1.0);
 
     if (point.z > 0)


### PR DESCRIPTION
The ICE is supposedly fixed in GCC 8.3. This workaround fixes https://dolp.in/i11603.