### PR TITLE
VideoCommon: Change free-look's middle-mouse action to roll the camera.

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 107;  // Last changed in PR 7952
+static const u32 STATE_VERSION = 108;  // Last changed in PR 7870
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -191,7 +191,7 @@ void AdvancedWidget::AddDescriptions()
 #endif
   static const char TR_FREE_LOOK_DESCRIPTION[] = QT_TR_NOOP(
       "Allows manipulation of the in-game camera. Move the mouse while holding the right button "
-      "to pan or middle button to move.\n\nUse the WASD keys while holding SHIFT to move the "
+      "to pan or middle button to roll.\n\nUse the WASD keys while holding SHIFT to move the "
       "camera. Press SHIFT+2 to increase speed or SHIFT+1 to decrease speed. Press SHIFT+R "
       "to reset the camera or SHIFT+F to reset the speed.\n\nIf unsure, leave this unchecked. ");
   static const char TR_CROPPING_DESCRIPTION[] =

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -235,21 +235,19 @@ bool RenderWidget::event(QEvent* event)
 
 void RenderWidget::OnFreeLookMouseMove(QMouseEvent* event)
 {
-  if (event->buttons() & Qt::MidButton)
-  {
-    // Mouse Move
-    VertexShaderManager::TranslateView((event->x() - m_last_mouse[0]) / 50.0f,
-                                       (event->y() - m_last_mouse[1]) / 50.0f);
-  }
-  else if (event->buttons() & Qt::RightButton)
-  {
-    // Mouse Look
-    VertexShaderManager::RotateView((event->x() - m_last_mouse[0]) / 200.0f,
-                                    (event->y() - m_last_mouse[1]) / 200.0f);
-  }
+  const auto mouse_move = event->pos() - m_last_mouse;
+  m_last_mouse = event->pos();
 
-  m_last_mouse[0] = event->x();
-  m_last_mouse[1] = event->y();
+  if (event->buttons() & Qt::RightButton)
+  {
+    // Camera Pitch and Yaw:
+    VertexShaderManager::RotateView(mouse_move.y() / 200.f, mouse_move.x() / 200.f, 0.f);
+  }
+  else if (event->buttons() & Qt::MidButton)
+  {
+    // Camera Roll:
+    VertexShaderManager::RotateView(0.f, 0.f, mouse_move.x() / 200.f);
+  }
 }
 
 void RenderWidget::PassEventToImGui(const QEvent* event)

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <array>
-
 #include <QEvent>
 #include <QWidget>
 
@@ -43,5 +41,5 @@ private:
 
   static constexpr int MOUSE_HIDE_DELAY = 3000;
   QTimer* m_mouse_timer;
-  std::array<float, 2> m_last_mouse{};
+  QPoint m_last_mouse{};
 };

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -30,7 +30,7 @@ public:
   static void SetMaterialColorChanged(int index);
 
   static void TranslateView(float x, float y, float z = 0.0f);
-  static void RotateView(float x, float y);
+  static void RotateView(float x, float y, float z);
   static void ResetView();
 
   static void SetVertexFormat(u32 components);


### PR DESCRIPTION
PR requested by @MayImilae.

I had to add an additional rotation float so I removed some unnecessary free-look matrix state while I was there.