### PR TITLE
WiimoteReal: Improve state changes and code cleanups.

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"
@@ -137,20 +138,28 @@ void Pause()
 // An L2CAP packet is passed from the Core to the Wiimote on the HID CONTROL channel.
 void ControlChannel(int number, u16 channel_id, const void* data, u32 size)
 {
-  if (g_wiimote_sources[number])
+  if (WIIMOTE_SRC_EMU == g_wiimote_sources[number])
   {
     static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
         ->ControlChannel(channel_id, data, size);
+  }
+  else
+  {
+    WiimoteReal::ControlChannel(number, channel_id, data, size);
   }
 }
 
 // An L2CAP packet is passed from the Core to the Wiimote on the HID INTERRUPT channel.
 void InterruptChannel(int number, u16 channel_id, const void* data, u32 size)
 {
-  if (g_wiimote_sources[number])
+  if (WIIMOTE_SRC_EMU == g_wiimote_sources[number])
   {
     static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
         ->InterruptChannel(channel_id, data, size);
+  }
+  else
+  {
+    WiimoteReal::InterruptChannel(number, channel_id, data, size);
   }
 }
 
@@ -215,6 +224,26 @@ unsigned int GetAttached()
 void DoState(PointerWrap& p)
 {
   for (int i = 0; i < MAX_BBMOTES; ++i)
-    static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);
+  {
+    auto state_wiimote_source = u8(g_wiimote_sources[i]);
+    p.Do(state_wiimote_source);
+
+    if (WIIMOTE_SRC_EMU == state_wiimote_source)
+    {
+      // Sync complete state of emulated wiimotes.
+      static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);
+    }
+
+    if (p.GetMode() == PointerWrap::MODE_READ)
+    {
+      // If using a real wiimote or the save-state source does not match the current source,
+      // then force a reconnection on load.
+      if (WIIMOTE_SRC_REAL == g_wiimote_sources[i] || state_wiimote_source != g_wiimote_sources[i])
+      {
+        Connect(i, false);
+        Connect(i, true);
+      }
+    }
+  }
 }
 }  // namespace Wiimote

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <array>
+#include <atomic>
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
@@ -45,7 +48,7 @@ enum
   WIIMOTE_SRC_REAL = 2,
 };
 
-extern unsigned int g_wiimote_sources[MAX_BBMOTES];
+extern std::array<std::atomic<u32>, MAX_BBMOTES> g_wiimote_sources;
 
 namespace Wiimote
 {

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -590,24 +590,11 @@ void Wiimote::DoState(PointerWrap& p)
   p.Do(m_shake_step);
 
   p.DoMarker("Wiimote");
-
-  if (p.GetMode() == PointerWrap::MODE_READ)
-    RealState();
 }
 
 ExtensionNumber Wiimote::GetActiveExtensionNumber() const
 {
   return m_active_extension;
-}
-
-void Wiimote::RealState()
-{
-  using namespace WiimoteReal;
-
-  if (g_wiimotes[m_index])
-  {
-    g_wiimotes[m_index]->SetChannel(m_reporting_channel);
-  }
 }
 
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -20,6 +20,7 @@
 #include "Core/Config/WiimoteInputSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/HW/Wiimote.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"
 
@@ -30,7 +31,6 @@
 #include "Core/HW/WiimoteEmu/Extension/Guitar.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 #include "Core/HW/WiimoteEmu/Extension/Turntable.h"
-#include "Core/HW/WiimoteReal/WiimoteReal.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/Control/Output.h"
@@ -503,14 +503,6 @@ void Wiimote::ControlChannel(const u16 channel_id, const void* data, u32 size)
 
   m_reporting_channel = channel_id;
 
-  // FYI: ControlChannel is piped through WiimoteEmu before WiimoteReal just so we can sync the
-  // channel on state load. This is ugly.
-  if (WIIMOTE_SRC_REAL == g_wiimote_sources[m_index])
-  {
-    WiimoteReal::ControlChannel(m_index, channel_id, data, size);
-    return;
-  }
-
   const auto& hidp = *reinterpret_cast<const HIDPacket*>(data);
 
   DEBUG_LOG(WIIMOTE, "Emu ControlChannel (page: %i, type: 0x%02x, param: 0x%02x)", m_index,
@@ -558,14 +550,6 @@ void Wiimote::InterruptChannel(const u16 channel_id, const void* data, u32 size)
   }
 
   m_reporting_channel = channel_id;
-
-  // FYI: InterruptChannel is piped through WiimoteEmu before WiimoteReal just so we can sync the
-  // channel on state load. This is ugly.
-  if (WIIMOTE_SRC_REAL == g_wiimote_sources[m_index])
-  {
-    WiimoteReal::InterruptChannel(m_index, channel_id, data, size);
-    return;
-  }
 
   const auto& hidp = *reinterpret_cast<const HIDPacket*>(data);
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -35,12 +35,6 @@ class Output;
 class Tilt;
 }  // namespace ControllerEmu
 
-// Needed for friendship:
-namespace WiimoteReal
-{
-class Wiimote;
-}  // namespace WiimoteReal
-
 namespace WiimoteEmu
 {
 enum class WiimoteGroup
@@ -87,8 +81,6 @@ void UpdateCalibrationDataChecksum(T& data, int cksum_bytes)
 
 class Wiimote : public ControllerEmu::EmulatedController
 {
-  friend class WiimoteReal::Wiimote;
-
 public:
   enum : u8
   {
@@ -172,8 +164,6 @@ private:
   bool ProcessExtensionPortEvent();
   void SendDataReport();
   bool ProcessReadDataRequest();
-
-  void RealState();
 
   void SetRumble(bool on);
 

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -284,7 +284,7 @@ void WiimoteDarwin::DisablePowerAssertionInternal()
 
   for (int i = 0; i < MAX_WIIMOTES; i++)
   {
-    wm = static_cast<WiimoteReal::WiimoteDarwin*>(WiimoteReal::g_wiimotes[i]);
+    wm = static_cast<WiimoteReal::WiimoteDarwin*>(WiimoteReal::g_wiimotes[i].get());
     if (!wm)
       continue;
     if ([device isEqual:wm->m_btd])
@@ -325,7 +325,7 @@ void WiimoteDarwin::DisablePowerAssertionInternal()
 
   for (int i = 0; i < MAX_WIIMOTES; i++)
   {
-    wm = static_cast<WiimoteReal::WiimoteDarwin*>(WiimoteReal::g_wiimotes[i]);
+    wm = static_cast<WiimoteReal::WiimoteDarwin*>(WiimoteReal::g_wiimotes[i].get());
     if (!wm)
       continue;
     if ([device isEqual:wm->m_btd])

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 104;  // Last changed in PR 7806
+static const u32 STATE_VERSION = 105;  // Last changed in PR 7871
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,
@@ -177,10 +177,6 @@ static void DoState(PointerWrap& p)
   g_video_backend->DoState(p);
   p.DoMarker("video_backend");
 
-  if (SConfig::GetInstance().bWii)
-    Wiimote::DoState(p);
-  p.DoMarker("Wiimote");
-
   PowerPC::DoState(p);
   p.DoMarker("PowerPC");
   // CoreTiming needs to be restored before restoring Hardware because
@@ -189,6 +185,9 @@ static void DoState(PointerWrap& p)
   p.DoMarker("CoreTiming");
   HW::DoState(p);
   p.DoMarker("HW");
+  if (SConfig::GetInstance().bWii)
+    Wiimote::DoState(p);
+  p.DoMarker("Wiimote");
   Movie::DoState(p);
   p.DoMarker("Movie");
   Gecko::DoState(p);

--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -496,11 +496,8 @@ void ControllersWindow::SaveSettings()
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
     const int index = m_wiimote_boxes[i]->currentIndex();
-    g_wiimote_sources[i] = index;
     m_wiimote_buttons[i]->setEnabled(index != 0 && index != 2);
-
-    if (Core::IsRunning())
-      WiimoteReal::ChangeWiimoteSource(static_cast<u32>(i), index);
+    WiimoteReal::ChangeWiimoteSource(static_cast<u32>(i), index);
   }
 
   UICommon::SaveWiimoteSources();


### PR DESCRIPTION
Real wiimote code no longer relies on emulated wiimote state to function. (real wiimote packets no longer pass through the emulated wiimote class)

Unbreak sound with real wiimotes and emulated Bluetooth.

Force non-continuous reporting to potentially reduce Bluetooth traffic just a tad.
We duplicate packets to maintain 200hz input so this should have no functional effect.

Loading a save-state now forces a emulated reconnection when using real wiimotes or a source different from that in the savestate.
This is the only foolproof way to make real wiimotes work properly with savestates as we simply do not have enough control over real wiimotes to synchronize their state completely.
(I had to make Wiimote::DoState happen after HW::DoState)

Added `unique_ptr`s and other minor cleanups.

Fixes issues:
https://bugs.dolphin-emu.org/issues/8440
https://bugs.dolphin-emu.org/issues/10912
https://bugs.dolphin-emu.org/issues/11571