### PR TITLE
FFV1 fix

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -190,7 +190,7 @@ bool AVIDump::CreateVideoFile()
   s_codec_context->height = s_height;
   s_codec_context->time_base.num = 1;
   s_codec_context->time_base.den = VideoInterface::GetTargetRefreshRate();
-  s_codec_context->gop_size = 12;
+  s_codec_context->gop_size = 1;
   s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGR0 : AV_PIX_FMT_YUV420P;
 
   if (output_format->flags & AVFMT_GLOBALHEADER)

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -191,7 +191,7 @@ bool AVIDump::CreateVideoFile()
   s_codec_context->time_base.num = 1;
   s_codec_context->time_base.den = VideoInterface::GetTargetRefreshRate();
   s_codec_context->gop_size = 12;
-  s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGRA : AV_PIX_FMT_YUV420P;
+  s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGR0 : AV_PIX_FMT_YUV420P;
 
   if (output_format->flags & AVFMT_GLOBALHEADER)
     s_codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;


### PR DESCRIPTION
### Change pixel format from BGRA to BGR0

For this kind of footage carrying alpha information makes no sense, and it additionally complicates things by hugely damaging compatibility of the resulting video. After this change alone the video becomes compatible with VfW/WinAPI and tools that rely on it (avisynth, virtualdub).

Fixes https://bugs.dolphin-emu.org/issues/11141 and https://bugs.dolphin-emu.org/issues/10193

Note that internally pixel format seems to be RGBA or BGR24, but then it's converted to whatever is set for ffmpeg, and I'm only changing the latter.

### Decrease gop size (keyint)

This makes seeking a lot smoother (especially at high resolutions), while only adding less than 1% of filesize overhead with this codec.