### PR TITLE
ModalMessageBox: Remove superfluous buttons and ensure correct parent

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
@@ -6,13 +6,14 @@
 
 #include <QApplication>
 
-ModalMessageBox::ModalMessageBox(QWidget* parent) : QMessageBox(parent)
+ModalMessageBox::ModalMessageBox(QWidget* parent)
+    : QMessageBox(parent != nullptr ? parent->window() : nullptr)
 {
   setWindowModality(Qt::WindowModal);
-  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+  setWindowFlags(Qt::Sheet | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
 
   // No parent is still preferable to showing a hidden parent here.
-  if (parent != nullptr && !parent->isVisible())
+  if (parent != nullptr && !parent->window()->isVisible())
     setParent(nullptr);
 }
 


### PR DESCRIPTION
* Fixes some message boxes not showing as sheets dispite having the ability to be shown as such
* Remove window title buttons that are not supposed to be present in message boxes