### PR TITLE
Qt/GameList: Implement 'Open gamecube save folder'

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -56,7 +56,8 @@ private:
   void ShowContextMenu(const QPoint&);
   void OpenContainingFolder();
   void OpenProperties();
-  void OpenSaveFolder();
+  void OpenWiiSaveFolder();
+  void OpenGCSaveFolder();
   void OpenWiki();
   void SetDefaultISO();
   void DeleteFile();


### PR DESCRIPTION
Adds a context-menu option to open the gamecube save folder of a given game.