### PR TITLE
Enable Defer EFB Cache Invalidation for SMG1 and 2

### DIFF
--- a/Data/Sys/GameSettings/RMG.ini
+++ b/Data/Sys/GameSettings/RMG.ini
@@ -19,6 +19,7 @@ IRCenter = 50
 
 [Video_Hacks]
 EFBAccessEnable = True
+EFBAccessDeferInvalidation = True
 
 [Video_Enhancements]
 ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/SB4.ini
+++ b/Data/Sys/GameSettings/SB4.ini
@@ -18,6 +18,7 @@ IRCenter = 50
 
 [Video_Hacks]
 EFBAccessEnable = True
+EFBAccessDeferInvalidation = True
 
 [Video_Enhancements]
 ArbitraryMipmapDetection = True


### PR DESCRIPTION
These games see ~50% to 120% performance increase in parts of the game
bottlenecked by EFB peeks, such as the lenses flare effects.