### PR TITLE
Qt: Don't use 'Dark Mode'

### DIFF
--- a/Source/Core/DolphinQt/Info.plist.in
+++ b/Source/Core/DolphinQt/Info.plist.in
@@ -50,5 +50,7 @@
     <true/>
     <key>CSResourcesFileMapped</key>
     <true/>
+    <key>NSRequiresAquaSystemAppearance</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Dark Mode is currently all kinds of broken in Qt.
Support will be reinstated once those issues are fixed.