### PR TITLE
PowerPC: Turn Helper_Carry into static function

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -279,8 +279,6 @@ public:
   static void RunTable59(UGeckoInstruction inst);
   static void RunTable63(UGeckoInstruction inst);
 
-  static u32 Helper_Carry(u32 value1, u32 value2);
-
 private:
   void CheckExceptions();
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -18,7 +18,7 @@ void Interpreter::Helper_UpdateCR0(u32 value)
   PowerPC::ppcState.cr.fields[0] = cr_val;
 }
 
-u32 Interpreter::Helper_Carry(u32 value1, u32 value2)
+static u32 Helper_Carry(u32 value1, u32 value2)
 {
   return value2 > (~value1);
 }


### PR DESCRIPTION
It's only used in Interpreter_Integer.cpp and is not useful for JIT backends, so no need to expose it in the header.