### PR TITLE
DolphinQt/Debugger/RegisterColumn: Add HID registers to the register pane

### DIFF
--- a/Source/Core/DolphinQt/Debugger/RegisterColumn.h
+++ b/Source/Core/DolphinQt/Debugger/RegisterColumn.h
@@ -27,6 +27,7 @@ enum class RegisterType
   srr,         // Machine status save/restore register (SRR0 - SRR1)
   sr,          // Segment register (SR0 - SR15)
   gqr,         // Graphics quantization registers (GQR0 - GQR7)
+  hid,         // Hardware Implementation-Dependent registers (HID0-2, HID4)
   exceptions,  // Keeps track of currently triggered exceptions
   int_mask,    // ???
   int_cause,   // ???

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -255,6 +255,16 @@ void RegisterWidget::PopulateTable()
                 [i] { return PowerPC::ppcState.spr[SPR_GQR0 + i]; }, nullptr);
   }
 
+  // HID registers
+  AddRegister(24, 7, RegisterType::hid, "HID0", [] { return PowerPC::ppcState.spr[SPR_HID0]; },
+              [](u64 value) { PowerPC::ppcState.spr[SPR_HID0] = static_cast<u32>(value); });
+  AddRegister(25, 7, RegisterType::hid, "HID1", [] { return PowerPC::ppcState.spr[SPR_HID1]; },
+              [](u64 value) { PowerPC::ppcState.spr[SPR_HID1] = static_cast<u32>(value); });
+  AddRegister(26, 7, RegisterType::hid, "HID2", [] { return PowerPC::ppcState.spr[SPR_HID2]; },
+              [](u64 value) { PowerPC::ppcState.spr[SPR_HID2] = static_cast<u32>(value); });
+  AddRegister(27, 7, RegisterType::hid, "HID4", [] { return PowerPC::ppcState.spr[SPR_HID4]; },
+              [](u64 value) { PowerPC::ppcState.spr[SPR_HID4] = static_cast<u32>(value); });
+
   for (int i = 0; i < 16; i++)
   {
     // SR registers


### PR DESCRIPTION
Adds the Hardware Implementation-Dependent registers to the register pane, which makes it much nicer to see which hardware-specific features are enabled or disabled.

![Preview](https://user-images.githubusercontent.com/712067/54309569-cc8a1580-45a6-11e9-8204-252f9c4c2683.png)