### PR TITLE
 UICommon/ResourcePack: Mark ResourcePack's operator== as const 

### DIFF
--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -325,4 +325,9 @@ bool ResourcePack::operator==(const ResourcePack& pack) const
   return pack.GetPath() == m_path;
 }
 
+bool ResourcePack::operator!=(const ResourcePack& pack) const
+{
+  return !operator==(pack);
+}
+
 }  // namespace ResourcePack

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -320,7 +320,7 @@ bool ResourcePack::Uninstall(const std::string& path)
   return true;
 }
 
-bool ResourcePack::operator==(const ResourcePack& pack)
+bool ResourcePack::operator==(const ResourcePack& pack) const
 {
   return pack.GetPath() == m_path;
 }

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.h
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.h
@@ -31,6 +31,7 @@ public:
   bool Uninstall(const std::string& path);
 
   bool operator==(const ResourcePack& pack) const;
+  bool operator!=(const ResourcePack& pack) const;
 
 private:
   bool m_valid = true;

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.h
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.h
@@ -30,7 +30,7 @@ public:
   bool Install(const std::string& path);
   bool Uninstall(const std::string& path);
 
-  bool operator==(const ResourcePack& pack);
+  bool operator==(const ResourcePack& pack) const;
 
 private:
   bool m_valid = true;


### PR DESCRIPTION
This doesn't modify instance state, so it can be marked as a const member function. While we're at it, also provide the inequality operator for logical symmetry.