### PR TITLE
[vk] Remove debug assert on a fence for staging flush

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -873,7 +873,7 @@ void VKStagingTexture::Flush()
     g_command_buffer_mgr->WaitForFence(m_flush_fence);
   }
 
-  DEBUG_ASSERT(m_flush_fence == VK_NULL_HANDLE);
+  m_flush_fence = VK_NULL_HANDLE;
   m_needs_flush = false;
 
   // For readback textures, invalidate the CPU cache as there is new data there.


### PR DESCRIPTION
This assertion is fired (after the Mario Sunshine intro), and clearly the code right above it doesn't imply that the fence would be NULL. Either the assert needs to be removed, or some logic pieces are missing to make it correct.