### PR TITLE
FramebufferManager: Don't discard in ReinterpretPixelData

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -277,9 +277,12 @@ bool FramebufferManager::ReinterpretPixelData(EFBReinterpretType convtype)
     return false;
 
   // Draw to the secondary framebuffer.
+  // We don't discard here because discarding the framebuffer also throws away the depth
+  // buffer, which we want to preserve. If we find this to be hindering performance in the
+  // future (e.g. on mobile/tilers), it may be worth discarding only the color buffer.
   m_efb_color_texture->FinishedRendering();
   g_renderer->BeginUtilityDrawing();
-  g_renderer->SetAndDiscardFramebuffer(m_efb_convert_framebuffer.get());
+  g_renderer->SetFramebuffer(m_efb_convert_framebuffer.get());
   g_renderer->SetViewportAndScissor(m_efb_framebuffer->GetRect());
   g_renderer->SetPipeline(m_format_conversion_pipelines[static_cast<u32>(convtype)].get());
   g_renderer->SetTexture(0, m_efb_color_texture.get());


### PR DESCRIPTION
This was causing the depth buffer to be discarded as well, which has an effect on mobiles (doesn't get loaded into tile memory).

If we find this is hindering performance (remember, the EFB is only a 640x528 texture), it may be worth changing the interface to support discarding only the colour buffer.

Should fix the corruption in Mario Kart Wii on Adreno and possibly others.