### PR TITLE
Qt/PadMappingDialog: Improve layout

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/PadMappingDialog.cpp
@@ -35,12 +35,12 @@ void PadMappingDialog::CreateWidgets()
     m_wii_boxes[i] = new QComboBox;
 
     m_main_layout->addWidget(new QLabel(tr("GC Port %1").arg(i + 1)), 0, i);
-    m_main_layout->addWidget(new QLabel(tr("Wii Remote %1").arg(i + 1)), 0, 4 + i);
     m_main_layout->addWidget(m_gc_boxes[i], 1, i);
-    m_main_layout->addWidget(m_wii_boxes[i], 1, 4 + i);
+    m_main_layout->addWidget(new QLabel(tr("Wii Remote %1").arg(i + 1)), 2, i);
+    m_main_layout->addWidget(m_wii_boxes[i], 3, i);
   }
 
-  m_main_layout->addWidget(m_button_box, 2, 0, 1, -1);
+  m_main_layout->addWidget(m_button_box, 4, 0, 1, -1);
 
   setLayout(m_main_layout);
 }


### PR DESCRIPTION
Instead of cramming both GCPads and Wii Remotes into one row, they are in seperate ones now:

![Screenshot](https://i.imgur.com/djHqK5C.png).
