### PR TITLE
Qt/NetPlayDialog: Don't bold the player table headers

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -238,6 +238,7 @@ void NetPlayDialog::CreatePlayersLayout()
   m_players_list->verticalHeader()->hide();
   m_players_list->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_players_list->horizontalHeader()->setStretchLastSection(true);
+  m_players_list->horizontalHeader()->setHighlightSections(false);
 
   for (int i = 0; i < 4; i++)
     m_players_list->horizontalHeader()->setSectionResizeMode(i, QHeaderView::ResizeToContents);


### PR DESCRIPTION
Fixes the header of the player listing getting bold when selecting an item.