### PR TITLE
Vulkan: Simplify command buffer fence tracking

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/Vulkan/BoundingBox.cpp
@@ -99,7 +99,7 @@ void BoundingBox::Flush()
     StagingBuffer::BufferMemoryBarrier(
         g_command_buffer_mgr->GetCurrentCommandBuffer(), m_gpu_buffer, VK_ACCESS_TRANSFER_WRITE_BIT,
         VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT, 0, BUFFER_SIZE,
-        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
   }
 
   // We're now up-to-date.
@@ -223,7 +223,7 @@ void BoundingBox::Readback()
   StagingBuffer::BufferMemoryBarrier(
       g_command_buffer_mgr->GetCurrentCommandBuffer(), m_gpu_buffer,
       VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT, 0,
-      BUFFER_SIZE, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+      BUFFER_SIZE, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
   m_readback_buffer->PrepareForGPUWrite(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                         VK_ACCESS_TRANSFER_WRITE_BIT,
                                         VK_PIPELINE_STAGE_TRANSFER_BIT);
@@ -237,7 +237,7 @@ void BoundingBox::Readback()
   StagingBuffer::BufferMemoryBarrier(
       g_command_buffer_mgr->GetCurrentCommandBuffer(), m_gpu_buffer, VK_ACCESS_TRANSFER_READ_BIT,
       VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT, 0, BUFFER_SIZE,
-      VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+      VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
   m_readback_buffer->FlushGPUCache(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                    VK_ACCESS_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
 

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -51,9 +51,15 @@ public:
   // Allocates a descriptors set from the pool reserved for the current frame.
   VkDescriptorSet AllocateDescriptorSet(VkDescriptorSetLayout set_layout);
 
+  // Fence "counters" are used to track which commands have been completed by the GPU.
+  // If the last completed fence counter is greater or equal to N, it means that the work
+  // associated counter N has been completed by the GPU. The value of N to associate with
+  // commands can be retreived by calling GetCurrentFenceCounter().
+  u64 GetCompletedFenceCounter() const { return m_completed_fence_counter; }
+
   // Gets the fence that will be signaled when the currently executing command buffer is
   // queued and executed. Do not wait for this fence before the buffer is executed.
-  VkFence GetCurrentCommandBufferFence() const { return m_frame_resources[m_current_frame].fence; }
+  u64 GetCurrentFenceCounter() const { return m_frame_resources[m_current_frame].fence_counter; }
 
   // Returns the semaphore for the current command buffer, which can be used to ensure the
   // swap chain image is ready before the command buffer executes.
@@ -66,15 +72,11 @@ public:
   // Ensure that the worker thread has submitted any previous command buffers and is idle.
   void WaitForWorkerThreadIdle();
 
-  // Ensure that the worker thread has both submitted all commands, and the GPU has caught up.
-  // Use with caution, huge performance penalty.
-  void WaitForGPUIdle();
-
   // Wait for a fence to be completed.
   // Also invokes callbacks for completion.
-  void WaitForFence(VkFence fence);
+  void WaitForFenceCounter(u64 fence_counter);
 
-  void SubmitCommandBuffer(bool submit_on_worker_thread,
+  void SubmitCommandBuffer(bool submit_on_worker_thread, bool wait_for_completion,
                            VkSwapchainKHR present_swap_chain = VK_NULL_HANDLE,
                            uint32_t present_image_index = 0xFFFFFFFF);
 
@@ -90,24 +92,16 @@ public:
   void DeferImageDestruction(VkImage object);
   void DeferImageViewDestruction(VkImageView object);
 
-  // Instruct the manager to fire the specified callback when a fence is flagged to be signaled.
-  // This happens when command buffers are executed, and can be tested if signaled, which means
-  // that all commands up to the point when the callback was fired have completed.
-  using FenceSignaledCallback = std::function<void(VkFence)>;
-  void AddFenceSignaledCallback(const void* key, FenceSignaledCallback callback);
-  void RemoveFenceSignaledCallback(const void* key);
-
 private:
   bool CreateCommandBuffers();
   void DestroyCommandBuffers();
 
   bool CreateSubmitThread();
 
+  void WaitForCommandBufferCompletion(u32 command_buffer_index);
   void SubmitCommandBuffer(u32 command_buffer_index, VkSwapchainKHR present_swap_chain,
                            u32 present_image_index);
   void BeginCommandBuffer();
-
-  void OnCommandBufferExecuted(u32 index);
 
   struct FrameResources
   {
@@ -117,18 +111,18 @@ private:
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
     VkFence fence = VK_NULL_HANDLE;
     VkSemaphore semaphore = VK_NULL_HANDLE;
+    u64 fence_counter = 0;
     bool init_command_buffer_used = false;
     bool semaphore_used = false;
-    bool needs_fence_wait = false;
 
     std::vector<std::function<void()>> cleanup_resources;
   };
 
+  u64 m_next_fence_counter = 1;
+  u64 m_completed_fence_counter = 0;
+
   std::array<FrameResources, NUM_COMMAND_BUFFERS> m_frame_resources;
   u32 m_current_frame;
-
-  // callbacks when a fence point is set
-  std::map<const void*, FenceSignaledCallback> m_fence_callbacks;
 
   // Threaded command buffer execution
   // Semaphore determines when a command buffer can be queued

--- a/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
@@ -14,7 +14,6 @@
 
 #include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/Renderer.h"
-#include "VideoBackends/Vulkan/StagingBuffer.h"
 #include "VideoBackends/Vulkan/StateTracker.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
@@ -28,11 +27,6 @@ PerfQuery::~PerfQuery()
     vkDestroyQueryPool(g_vulkan_context->GetDevice(), m_query_pool, nullptr);
 }
 
-Vulkan::PerfQuery* PerfQuery::GetInstance()
-{
-  return static_cast<PerfQuery*>(g_perf_query.get());
-}
-
 bool PerfQuery::Initialize()
 {
   if (!CreateQueryPool())
@@ -41,47 +35,30 @@ bool PerfQuery::Initialize()
     return false;
   }
 
-  if (!CreateReadbackBuffer())
-  {
-    PanicAlert("Failed to create readback buffer");
-    return false;
-  }
-
   return true;
 }
 
 void PerfQuery::EnableQuery(PerfQueryGroup type)
 {
-  // Have we used half of the query buffer already?
-  if (m_query_count > m_query_buffer.size() / 2)
-    NonBlockingPartialFlush();
-
   // Block if there are no free slots.
-  if (m_query_count == PERF_QUERY_BUFFER_SIZE)
-  {
-    // ERROR_LOG(VIDEO, "Flushed query buffer early!");
-    BlockingPartialFlush();
-  }
+  // Otherwise, try to keep half of them available.
+  if (m_query_count > m_query_buffer.size() / 2)
+    PartialFlush(m_query_count == PERF_QUERY_BUFFER_SIZE);
 
   if (type == PQG_ZCOMP_ZCOMPLOC || type == PQG_ZCOMP)
   {
-    u32 index = (m_query_read_pos + m_query_count) % PERF_QUERY_BUFFER_SIZE;
-    ActiveQuery& entry = m_query_buffer[index];
-    ASSERT(!entry.active && !entry.available);
-    entry.active = true;
-    m_query_count++;
-
-    DEBUG_LOG(VIDEO, "start query %u", index);
+    ActiveQuery& entry = m_query_buffer[m_query_next_pos];
+    DEBUG_ASSERT(!entry.has_value);
+    entry.has_value = true;
 
     // Use precise queries if supported, otherwise boolean (which will be incorrect).
-    VkQueryControlFlags flags = 0;
-    if (g_vulkan_context->SupportsPreciseOcclusionQueries())
-      flags = VK_QUERY_CONTROL_PRECISE_BIT;
+    VkQueryControlFlags flags =
+        g_vulkan_context->SupportsPreciseOcclusionQueries() ? VK_QUERY_CONTROL_PRECISE_BIT : 0;
 
     // Ensure the query starts within a render pass.
-    // TODO: Is this needed?
     StateTracker::GetInstance()->BeginRenderPass();
-    vkCmdBeginQuery(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_query_pool, index, flags);
+    vkCmdBeginQuery(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_query_pool, m_query_next_pos,
+                    flags);
   }
 }
 
@@ -89,16 +66,17 @@ void PerfQuery::DisableQuery(PerfQueryGroup type)
 {
   if (type == PQG_ZCOMP_ZCOMPLOC || type == PQG_ZCOMP)
   {
-    // DisableQuery should be called for each EnableQuery, so subtract one to get the previous one.
-    u32 index = (m_query_read_pos + m_query_count - 1) % PERF_QUERY_BUFFER_SIZE;
-    vkCmdEndQuery(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_query_pool, index);
+    vkCmdEndQuery(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_query_pool, m_query_next_pos);
+    m_query_next_pos = (m_query_next_pos + 1) % PERF_QUERY_BUFFER_SIZE;
+    m_query_count++;
   }
 }
 
 void PerfQuery::ResetQuery()
 {
   m_query_count = 0;
-  m_query_read_pos = 0;
+  m_query_readback_pos = 0;
+  m_query_next_pos = 0;
   std::fill_n(m_results, ArraySize(m_results), 0);
 
   // Reset entire query pool, ensuring all queries are ready to write to.
@@ -106,34 +84,20 @@ void PerfQuery::ResetQuery()
   vkCmdResetQueryPool(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_query_pool, 0,
                       PERF_QUERY_BUFFER_SIZE);
 
-  for (auto& entry : m_query_buffer)
-  {
-    entry.fence_counter = 0;
-    entry.available = false;
-    entry.active = false;
-  }
+  std::memset(m_query_buffer.data(), 0, sizeof(ActiveQuery) * m_query_buffer.size());
 }
 
 u32 PerfQuery::GetQueryResult(PerfQueryType type)
 {
   u32 result = 0;
-
   if (type == PQ_ZCOMP_INPUT_ZCOMPLOC || type == PQ_ZCOMP_OUTPUT_ZCOMPLOC)
-  {
     result = m_results[PQG_ZCOMP_ZCOMPLOC];
-  }
   else if (type == PQ_ZCOMP_INPUT || type == PQ_ZCOMP_OUTPUT)
-  {
     result = m_results[PQG_ZCOMP];
-  }
   else if (type == PQ_BLEND_INPUT)
-  {
     result = m_results[PQG_ZCOMP] + m_results[PQG_ZCOMP_ZCOMPLOC];
-  }
   else if (type == PQ_EFB_COPY_CLOCKS)
-  {
     result = m_results[PQG_EFB_COPY_CLOCKS];
-  }
 
   return result / 4;
 }
@@ -141,7 +105,7 @@ u32 PerfQuery::GetQueryResult(PerfQueryType type)
 void PerfQuery::FlushResults()
 {
   while (!IsFlushed())
-    BlockingPartialFlush();
+    PartialFlush(true);
 }
 
 bool PerfQuery::IsFlushed() const
@@ -170,190 +134,79 @@ bool PerfQuery::CreateQueryPool()
   return true;
 }
 
-bool PerfQuery::CreateReadbackBuffer()
+void PerfQuery::ReadbackQueries()
 {
-  m_readback_buffer = StagingBuffer::Create(STAGING_BUFFER_TYPE_READBACK,
-                                            PERF_QUERY_BUFFER_SIZE * sizeof(PerfQueryDataType),
-                                            VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-
-  // Leave the buffer persistently mapped, we invalidate it when we need to read.
-  if (!m_readback_buffer || !m_readback_buffer->Map())
-    return false;
-
-  return true;
-}
-
-void PerfQuery::QueueCopyQueryResults(u32 start_index, u32 query_count)
-{
-  DEBUG_LOG(VIDEO, "queue copy of queries %u-%u", start_index, start_index + query_count - 1);
-
-  // Transition buffer for GPU write
-  // TODO: Is this needed?
-  m_readback_buffer->PrepareForGPUWrite(g_command_buffer_mgr->GetCurrentCommandBuffer(),
-                                        VK_ACCESS_TRANSFER_WRITE_BIT,
-                                        VK_PIPELINE_STAGE_TRANSFER_BIT);
-
-  // Copy from queries -> buffer
-  vkCmdCopyQueryPoolResults(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_query_pool,
-                            start_index, query_count, m_readback_buffer->GetBuffer(),
-                            start_index * sizeof(PerfQueryDataType), sizeof(PerfQueryDataType),
-                            VK_QUERY_RESULT_WAIT_BIT);
-
-  // Prepare for host readback
-  m_readback_buffer->FlushGPUCache(g_command_buffer_mgr->GetCurrentCommandBuffer(),
-                                   VK_ACCESS_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
-
-  // Reset queries so they're ready to use again
-  vkCmdResetQueryPool(g_command_buffer_mgr->GetCurrentCommandBuffer(), m_query_pool, start_index,
-                      query_count);
-
-  // Flag all queries as available, but with a fence that has to be completed first
-  for (u32 i = 0; i < query_count; i++)
-  {
-    u32 index = start_index + i;
-    ActiveQuery& entry = m_query_buffer[index];
-    entry.fence_counter = g_command_buffer_mgr->GetCurrentFenceCounter();
-    entry.available = true;
-    entry.active = false;
-  }
-}
-
-void PerfQuery::FlushQueries()
-{
-  // Flag all pending queries that aren't available as available after execution.
-  u32 copy_start_index = 0;
-  u32 copy_count = 0;
-  for (u32 i = 0; i < m_query_count; i++)
-  {
-    u32 index = (m_query_read_pos + i) % PERF_QUERY_BUFFER_SIZE;
-    ActiveQuery& entry = m_query_buffer[index];
-
-    // Skip already-copied queries (will happen if a flush hasn't occurred and
-    // a command buffer hasn't finished executing).
-    if (entry.available)
-    {
-      // These should be grouped together, and at the start.
-      ASSERT(copy_count == 0);
-      continue;
-    }
-
-    // If this wrapped around, we need to flush the entries before the end of the buffer.
-    ASSERT(entry.active);
-    if (index < copy_start_index)
-    {
-      QueueCopyQueryResults(copy_start_index, copy_count);
-      copy_start_index = index;
-      copy_count = 0;
-    }
-    else if (copy_count == 0)
-    {
-      copy_start_index = index;
-    }
-    copy_count++;
-  }
-
-  if (copy_count > 0)
-    QueueCopyQueryResults(copy_start_index, copy_count);
-}
-
-void PerfQuery::ProcessPendingResults()
-{
-  const u64 completed_fence_counter = g_command_buffer_mgr->GetCurrentFenceCounter();
+  const u64 completed_fence_counter = g_command_buffer_mgr->GetCompletedFenceCounter();
 
   // Need to save these since ProcessResults will modify them.
-  u32 query_read_pos = m_query_read_pos;
-  u32 query_count = m_query_count;
-
-  // Flush as many queries as are bound to this fence.
-  u32 flush_start_index = 0;
-  u32 flush_count = 0;
-  for (u32 i = 0; i < query_count; i++)
+  const u32 outstanding_queries = m_query_count;
+  u32 readback_count = 0;
+  for (u32 i = 0; i < outstanding_queries; i++)
   {
-    u32 index = (query_read_pos + i) % PERF_QUERY_BUFFER_SIZE;
-    if (m_query_buffer[index].fence_counter > completed_fence_counter)
-    {
-      // These should be grouped together, at the end.
+    u32 index = (m_query_readback_pos + readback_count) % PERF_QUERY_BUFFER_SIZE;
+    const ActiveQuery& entry = m_query_buffer[index];
+    if (entry.fence_counter > completed_fence_counter)
       break;
-    }
 
     // If this wrapped around, we need to flush the entries before the end of the buffer.
-    if (index < flush_start_index)
+    if (index < m_query_readback_pos)
     {
-      ProcessResults(flush_start_index, flush_count);
-      flush_start_index = index;
-      flush_count = 0;
+      ReadbackQueries(readback_count);
+      DEBUG_ASSERT(m_query_readback_pos == 0);
+      readback_count = 0;
     }
-    else if (flush_count == 0)
-    {
-      flush_start_index = index;
-    }
-    flush_count++;
+
+    readback_count++;
   }
 
-  if (flush_count > 0)
-    ProcessResults(flush_start_index, flush_count);
+  if (readback_count > 0)
+    ReadbackQueries(readback_count);
 }
 
-void PerfQuery::ProcessResults(u32 start_index, u32 query_count)
+void PerfQuery::ReadbackQueries(u32 query_count)
 {
-  // Invalidate CPU caches before reading back.
-  m_readback_buffer->InvalidateCPUCache(start_index * sizeof(PerfQueryDataType),
-                                        query_count * sizeof(PerfQueryDataType));
-
   // Should be at maximum query_count queries pending.
-  ASSERT(query_count <= m_query_count);
-  DEBUG_LOG(VIDEO, "process queries %u-%u", start_index, start_index + query_count - 1);
+  ASSERT(query_count <= m_query_count &&
+         (m_query_readback_pos + query_count) <= PERF_QUERY_BUFFER_SIZE);
+
+  // Read back from the GPU.
+  VkResult res =
+      vkGetQueryPoolResults(g_vulkan_context->GetDevice(), m_query_pool, m_query_readback_pos,
+                            query_count, query_count * sizeof(PerfQueryDataType),
+                            m_query_result_buffer.data(), sizeof(PerfQueryDataType), 0);
+  if (res != VK_SUCCESS)
+    LOG_VULKAN_ERROR(res, "vkGetQueryPoolResults failed: ");
 
   // Remove pending queries.
   for (u32 i = 0; i < query_count; i++)
   {
-    u32 index = (m_query_read_pos + i) % PERF_QUERY_BUFFER_SIZE;
+    u32 index = (m_query_readback_pos + i) % PERF_QUERY_BUFFER_SIZE;
     ActiveQuery& entry = m_query_buffer[index];
 
     // Should have a fence associated with it (waiting for a result).
-    ASSERT(entry.fence_counter != 0);
+    DEBUG_ASSERT(entry.fence_counter != 0);
     entry.fence_counter = 0;
-    entry.available = false;
-    entry.active = false;
-
-    // Grab result from readback buffer, it will already have been invalidated.
-    u32 result;
-    m_readback_buffer->Read(index * sizeof(PerfQueryDataType), &result, sizeof(result), false);
-    DEBUG_LOG(VIDEO, "  query result %u", result);
+    entry.has_value = false;
 
     // NOTE: Reported pixel metrics should be referenced to native resolution
     m_results[entry.query_type] +=
-        static_cast<u32>(static_cast<u64>(result) * EFB_WIDTH / g_renderer->GetTargetWidth() *
-                         EFB_HEIGHT / g_renderer->GetTargetHeight());
+        static_cast<u32>(static_cast<u64>(m_query_result_buffer[i]) * EFB_WIDTH /
+                         g_renderer->GetTargetWidth() * EFB_HEIGHT / g_renderer->GetTargetHeight());
   }
 
-  m_query_read_pos = (m_query_read_pos + query_count) % PERF_QUERY_BUFFER_SIZE;
+  m_query_readback_pos = (m_query_readback_pos + query_count) % PERF_QUERY_BUFFER_SIZE;
   m_query_count -= query_count;
 }
 
-void PerfQuery::NonBlockingPartialFlush()
+void PerfQuery::PartialFlush(bool blocking)
 {
-  if (IsFlushed())
-    return;
-
   // Submit a command buffer in the background if the front query is not bound to one.
-  ActiveQuery& entry = m_query_buffer[m_query_read_pos];
-  if (entry.fence_counter == g_command_buffer_mgr->GetCurrentFenceCounter())
-    Renderer::GetInstance()->ExecuteCommandBuffer(true, false);
+  if (blocking || m_query_buffer[m_query_readback_pos].fence_counter ==
+                      g_command_buffer_mgr->GetCurrentFenceCounter())
+  {
+    Renderer::GetInstance()->ExecuteCommandBuffer(true, blocking);
+  }
 
-  ProcessPendingResults();
-}
-
-void PerfQuery::BlockingPartialFlush()
-{
-  if (IsFlushed())
-    return;
-
-  // If the first pending query is needing command buffer execution, do that.
-  ActiveQuery& entry = m_query_buffer[m_query_read_pos];
-  if (entry.fence_counter == g_command_buffer_mgr->GetCurrentFenceCounter())
-    Renderer::GetInstance()->ExecuteCommandBuffer(false, true);
-
-  ProcessPendingResults();
+  ReadbackQueries();
 }
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/PerfQuery.h
+++ b/Source/Core/VideoBackends/Vulkan/PerfQuery.h
@@ -36,8 +36,8 @@ public:
 private:
   struct ActiveQuery
   {
+    u64 fence_counter;
     PerfQueryType query_type;
-    VkFence pending_fence;
     bool available;
     bool active;
   };
@@ -45,10 +45,8 @@ private:
   bool CreateQueryPool();
   bool CreateReadbackBuffer();
   void QueueCopyQueryResults(u32 start_index, u32 query_count);
+  void ProcessPendingResults();
   void ProcessResults(u32 start_index, u32 query_count);
-
-  void OnCommandBufferQueued(VkCommandBuffer command_buffer, VkFence fence);
-  void OnFenceSignaled(VkFence fence);
 
   void NonBlockingPartialFlush();
   void BlockingPartialFlush();

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -304,7 +304,6 @@ void Renderer::PresentBackbuffer()
 {
   // End drawing to backbuffer
   StateTracker::GetInstance()->EndRenderPass();
-  PerfQuery::GetInstance()->FlushQueries();
 
   // Transition the backbuffer to PRESENT_SRC to ensure all commands drawing
   // to it have finished before present.
@@ -325,7 +324,6 @@ void Renderer::PresentBackbuffer()
 void Renderer::ExecuteCommandBuffer(bool submit_off_thread, bool wait_for_completion)
 {
   StateTracker::GetInstance()->EndRenderPass();
-  PerfQuery::GetInstance()->FlushQueries();
 
   g_command_buffer_mgr->SubmitCommandBuffer(submit_off_thread, wait_for_completion);
 

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -62,11 +62,13 @@ bool StateTracker::Initialize()
       VKTexture::Create(TextureConfig(1, 1, 1, 1, 1, AbstractTextureFormat::RGBA8, 0));
   if (!m_dummy_texture)
     return false;
+  m_dummy_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentInitCommandBuffer(),
+                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
   // Initialize all samplers to point by default
   for (size_t i = 0; i < NUM_PIXEL_SHADER_SAMPLERS; i++)
   {
-    m_bindings.samplers[i].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    m_bindings.samplers[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     m_bindings.samplers[i].imageView = m_dummy_texture->GetView();
     m_bindings.samplers[i].sampler = g_object_cache->GetPointSampler();
   }
@@ -223,14 +225,14 @@ void StateTracker::UnbindTexture(VkImageView view)
     if (it.imageView == view)
     {
       it.imageView = m_dummy_texture->GetView();
-      it.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      it.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }
   }
 
   if (m_bindings.image_texture.imageView == view)
   {
     m_bindings.image_texture.imageView = m_dummy_texture->GetView();
-    m_bindings.image_texture.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    m_bindings.image_texture.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
   }
 }
 

--- a/Source/Core/VideoBackends/Vulkan/StreamBuffer.h
+++ b/Source/Core/VideoBackends/Vulkan/StreamBuffer.h
@@ -34,7 +34,7 @@ public:
 private:
   bool AllocateBuffer();
   void UpdateCurrentFencePosition();
-  void OnFenceSignaled(VkFence fence);
+  void UpdateGPUPosition();
 
   // Waits for as many fences as needed to allocate num_bytes bytes from the buffer.
   bool WaitForClearSpace(u32 num_bytes);
@@ -50,7 +50,7 @@ private:
   u8* m_host_pointer = nullptr;
 
   // List of fences and the corresponding positions in the buffer
-  std::deque<std::pair<VkFence, u32>> m_tracked_fences;
+  std::deque<std::pair<u64, u32>> m_tracked_fences;
 
   bool m_coherent_mapping = false;
 };

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -104,7 +104,7 @@ private:
                    std::unique_ptr<StagingBuffer> buffer);
 
   std::unique_ptr<StagingBuffer> m_staging_buffer;
-  VkFence m_flush_fence = VK_NULL_HANDLE;
+  u64 m_flush_fence_counter = 0;
 };
 
 class VKFramebuffer final : public AbstractFramebuffer

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -60,11 +60,11 @@ VertexManager::~VertexManager()
 bool VertexManager::Initialize()
 {
   m_vertex_stream_buffer =
-      StreamBuffer::Create(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VERTEX_STREAM_BUFFER_SIZE * 4);
+      StreamBuffer::Create(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VERTEX_STREAM_BUFFER_SIZE);
   m_index_stream_buffer =
-      StreamBuffer::Create(VK_BUFFER_USAGE_INDEX_BUFFER_BIT, INDEX_STREAM_BUFFER_SIZE * 4);
+      StreamBuffer::Create(VK_BUFFER_USAGE_INDEX_BUFFER_BIT, INDEX_STREAM_BUFFER_SIZE);
   m_uniform_stream_buffer =
-      StreamBuffer::Create(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, UNIFORM_STREAM_BUFFER_SIZE * 4);
+      StreamBuffer::Create(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, UNIFORM_STREAM_BUFFER_SIZE);
   if (!m_vertex_stream_buffer || !m_index_stream_buffer || !m_uniform_stream_buffer)
   {
     PanicAlert("Failed to allocate streaming buffers");

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -251,8 +251,8 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
 
 void VideoBackend::Shutdown()
 {
-  if (g_command_buffer_mgr)
-    g_command_buffer_mgr->WaitForGPUIdle();
+  if (g_vulkan_context)
+    vkDeviceWaitIdle(g_vulkan_context->GetDevice());
 
   if (g_shader_cache)
     g_shader_cache->Shutdown();

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -96,6 +96,9 @@ TextureCacheBase::TextureCacheBase()
 
 TextureCacheBase::~TextureCacheBase()
 {
+  // Clear pending EFB copies first, so we don't try to flush them.
+  m_pending_efb_copies.clear();
+
   HiresTexture::Shutdown();
   Invalidate();
   Common::FreeAlignedMemory(temp);


### PR DESCRIPTION
Uses counter-based fences instead of fence objects to track GPU progress. Now that this is simpler, it may even be worth using a larger number of command buffers (could be faster with EFB2RAM off).

Also fixes a couple of validation layer errors which were popping up.