### PR TITLE
DolphinQt/InputCommon: Fix a few memory leaks.

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -63,7 +63,7 @@ GameConfigEdit::GameConfigEdit(QWidget* parent, const QString& path, bool read_o
 
   m_completer = new QCompleter(m_edit);
 
-  auto* completion_model = new QStringListModel;
+  auto* completion_model = new QStringListModel(m_completer);
   completion_model->setStringList(m_completions);
 
   m_completer->setModel(completion_model);
@@ -77,8 +77,6 @@ GameConfigEdit::GameConfigEdit(QWidget* parent, const QString& path, bool read_o
 
 void GameConfigEdit::CreateWidgets()
 {
-  m_menu = new QMenu;
-
   m_edit = new QTextEdit;
   m_edit->setReadOnly(m_read_only);
   m_edit->setAcceptRichText(false);
@@ -89,6 +87,8 @@ void GameConfigEdit::CreateWidgets()
 
   menu_button->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
   menu_button->setText(tr("Presets"));
+
+  m_menu = new QMenu(menu_button);
   menu_button->setMenu(m_menu);
 
   layout->addWidget(menu_button);

--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -104,7 +104,7 @@ QGroupBox* InfoWidget::CreateBannerDetails()
 
   m_name = CreateValueDisplay();
   m_maker = CreateValueDisplay();
-  m_description = new QTextEdit();
+  m_description = new QTextEdit(group);
   m_description->setReadOnly(true);
   CreateLanguageSelector();
 
@@ -153,7 +153,7 @@ void InfoWidget::SaveBanner()
 
 QLineEdit* InfoWidget::CreateValueDisplay(const QString& value)
 {
-  QLineEdit* value_display = new QLineEdit(value);
+  QLineEdit* value_display = new QLineEdit(value, this);
   value_display->setReadOnly(true);
   value_display->setCursorPosition(0);
   return value_display;

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -196,7 +196,7 @@ void GameList::MakeEmptyView()
                       "Double-click here to set a games directory..."));
   m_empty->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
-  auto event_filter = new DoubleClickEventFilter{};
+  auto event_filter = new DoubleClickEventFilter{m_empty};
   m_empty->installEventFilter(event_filter);
   connect(event_filter, &DoubleClickEventFilter::doubleClicked, [this] {
     auto current_dir = QDir::currentPath();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -323,7 +323,7 @@ void MainWindow::InitCoreCallbacks()
 
 static void InstallHotkeyFilter(QWidget* dialog)
 {
-  auto* filter = new WindowActivationEventFilter();
+  auto* filter = new WindowActivationEventFilter(dialog);
   dialog->installEventFilter(filter);
 
   filter->connect(filter, &WindowActivationEventFilter::windowDeactivated,

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -271,7 +271,7 @@ void MenuBar::AddToolsMenu()
   m_perform_online_update_menu->addAction(tr("United States"), this,
                                           [this] { emit PerformOnlineUpdate("USA"); });
 
-  QMenu* menu = new QMenu(tr("Connect Wii Remotes"));
+  QMenu* menu = new QMenu(tr("Connect Wii Remotes"), tools_menu);
 
   tools_menu->addSeparator();
   tools_menu->addMenu(menu);

--- a/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.cpp
+++ b/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.cpp
@@ -6,6 +6,10 @@
 
 #include "DolphinQt/QtUtils/DoubleClickEventFilter.h"
 
+DoubleClickEventFilter::DoubleClickEventFilter(QObject* parent) : QObject(parent)
+{
+}
+
 bool DoubleClickEventFilter::eventFilter(QObject* object, QEvent* event)
 {
   if (event->type() == QEvent::MouseButtonDblClick)

--- a/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.h
+++ b/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.h
@@ -9,6 +9,9 @@
 class DoubleClickEventFilter : public QObject
 {
   Q_OBJECT
+public:
+  explicit DoubleClickEventFilter(QObject* parent);
+
 signals:
   void doubleClicked();
 

--- a/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.cpp
+++ b/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.cpp
@@ -7,6 +7,10 @@
 
 #include "DolphinQt/QtUtils/WindowActivationEventFilter.h"
 
+WindowActivationEventFilter::WindowActivationEventFilter(QObject* parent) : QObject(parent)
+{
+}
+
 bool WindowActivationEventFilter::eventFilter(QObject* object, QEvent* event)
 {
   if (event->type() == QEvent::WindowDeactivate)

--- a/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.h
+++ b/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.h
@@ -9,6 +9,9 @@
 class WindowActivationEventFilter : public QObject
 {
   Q_OBJECT
+public:
+  explicit WindowActivationEventFilter(QObject* parent);
+
 signals:
   void windowActivated();
   void windowDeactivated();


### PR DESCRIPTION
Qt's `setModel`, `setMenu`, and `installEventFilter` do not take ownership of the passed `QObject` so the parents must be set manually.

Manually added parents to some widgets that were created but conditionally added to the layout.

And InputCommon's evdev code was leaking some udev handles.