### PR TITLE
DolphinQt: Make Ctrl+F show the game list search and escape close it.

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -452,7 +452,7 @@ void MainWindow::ConnectMenuBar()
   connect(m_menu_bar, &MenuBar::ShowList, m_game_list, &GameList::SetListView);
   connect(m_menu_bar, &MenuBar::ShowGrid, m_game_list, &GameList::SetGridView);
   connect(m_menu_bar, &MenuBar::PurgeGameListCache, m_game_list, &GameList::PurgeCache);
-  connect(m_menu_bar, &MenuBar::ToggleSearch, m_search_bar, &SearchBar::Toggle);
+  connect(m_menu_bar, &MenuBar::ShowSearch, m_search_bar, &SearchBar::Show);
 
   connect(m_menu_bar, &MenuBar::ColumnVisibilityToggled, m_game_list,
           &GameList::OnColumnVisibilityToggled);

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -473,7 +473,7 @@ void MenuBar::AddViewMenu()
   view_menu->addSeparator();
   view_menu->addAction(tr("Purge Game List Cache"), this, &MenuBar::PurgeGameListCache);
   view_menu->addSeparator();
-  view_menu->addAction(tr("Search"), this, &MenuBar::ToggleSearch,
+  view_menu->addAction(tr("Search"), this, &MenuBar::ShowSearch,
                        QKeySequence(QStringLiteral("Ctrl+F")));
 }
 

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -96,7 +96,7 @@ signals:
   void ShowList();
   void ShowGrid();
   void PurgeGameListCache();
-  void ToggleSearch();
+  void ShowSearch();
   void ColumnVisibilityToggled(const QString& row, bool visible);
   void GameListPlatformVisibilityToggled(const QString& row, bool visible);
   void GameListRegionVisibilityToggled(const QString& row, bool visible);

--- a/Source/Core/DolphinQt/SearchBar.cpp
+++ b/Source/Core/DolphinQt/SearchBar.cpp
@@ -4,7 +4,9 @@
 
 #include "DolphinQt/SearchBar.h"
 
+#include <QEvent>
 #include <QHBoxLayout>
+#include <QKeyEvent>
 #include <QLineEdit>
 #include <QPushButton>
 
@@ -16,6 +18,8 @@ SearchBar::SearchBar(QWidget* parent) : QWidget(parent)
   setFixedHeight(32);
 
   setHidden(true);
+
+  installEventFilter(this);
 }
 
 void SearchBar::CreateWidgets()
@@ -34,20 +38,40 @@ void SearchBar::CreateWidgets()
   setLayout(layout);
 }
 
-void SearchBar::Toggle()
+void SearchBar::Show()
 {
-  m_search_edit->clear();
+  m_search_edit->setFocus();
+  m_search_edit->selectAll();
 
-  setHidden(isVisible());
+  // Re-apply the filter string.
+  emit Search(m_search_edit->text());
 
-  if (isVisible())
-    m_search_edit->setFocus();
-  else
-    m_search_edit->clearFocus();
+  show();
+}
+
+void SearchBar::Hide()
+{
+  // Clear the filter string.
+  emit Search(QString());
+
+  m_search_edit->clearFocus();
+
+  hide();
 }
 
 void SearchBar::ConnectWidgets()
 {
   connect(m_search_edit, &QLineEdit::textChanged, this, &SearchBar::Search);
-  connect(m_close_button, &QPushButton::pressed, this, &SearchBar::Toggle);
+  connect(m_close_button, &QPushButton::pressed, this, &SearchBar::Hide);
+}
+
+bool SearchBar::eventFilter(QObject* object, QEvent* event)
+{
+  if (event->type() == QEvent::KeyPress)
+  {
+    if (static_cast<QKeyEvent*>(event)->key() == Qt::Key_Escape)
+      Hide();
+  }
+
+  return false;
 }

--- a/Source/Core/DolphinQt/SearchBar.h
+++ b/Source/Core/DolphinQt/SearchBar.h
@@ -15,13 +15,17 @@ class SearchBar : public QWidget
 public:
   explicit SearchBar(QWidget* parent = nullptr);
 
-  void Toggle();
+  void Show();
+  void Hide();
+
 signals:
   void Search(const QString& serach);
 
 private:
   void CreateWidgets();
   void ConnectWidgets();
+
+  bool eventFilter(QObject* object, QEvent* event) final override;
 
   QLineEdit* m_search_edit;
   QPushButton* m_close_button;


### PR DESCRIPTION
Make Ctrl+F show the game list search and select the search text if already open.
The escape key (or the close button) closes it.

This is similar to the behavior of Firefox's Ctrl+F action.

Fixes:
https://bugs.dolphin-emu.org/issues/11549