### PR TITLE
Android: add button to reload wiimote config

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -825,19 +825,20 @@ public final class EmulationActivity extends AppCompatActivity
               NativeLibrary.SetConfig("WiimoteNew.ini", "Wiimote1", "Extension",
                       getResources().getStringArray(R.array.controllersValues)[indexSelected]);
             });
+    builder.setNeutralButton(getString(R.string.emulation_reload_wiimote_config),
+      (dialogInterface, i) -> {
+        editor.apply();
+        mEmulationFragment.refreshInputOverlay();
+        NativeLibrary.ReloadWiimoteConfig();
+    });
     builder.setPositiveButton(getString(R.string.ok), (dialogInterface, i) ->
     {
       editor.apply();
-
       mEmulationFragment.refreshInputOverlay();
-
-      Toast.makeText(getApplication(), R.string.emulation_controller_changed, Toast.LENGTH_SHORT)
-              .show();
     });
 
     AlertDialog alertDialog = builder.create();
     alertDialog.show();
-
   }
 
   private void setIRSensitivity()

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -298,7 +298,7 @@
     <string name="emulation_control_joystick_rel_center">Relative Stick Center</string>
     <string name="emulation_control_rumble">Rumble</string>
     <string name="emulation_choose_controller">Choose Controller</string>
-    <string name="emulation_controller_changed">You may have to reload the game after changing extensions.</string>
+    <string name="emulation_reload_wiimote_config">Reload Config</string>
     <string name="emulation_touch_button_help">Swipe down from the top of the screen to access the menu.</string>
     <string name="emulation_touch_overlay_reset">Reset Overlay</string>
     <string name="emulation_ir_group">Touch IR Pointer</string>


### PR DESCRIPTION
change wiimote extension without restart game.