### PR TITLE
Disable Defer EFB Copies to RAM for Majora's Mask (VC)

### DIFF
--- a/Data/Sys/GameSettings/NAR.ini
+++ b/Data/Sys/GameSettings/NAR.ini
@@ -15,3 +15,5 @@
 [Video_Hacks]
 # Fixes Link preview not appearing in Equipment Menu screen
 EFBToTextureEnable = False 
+# Fixes the screen shrinking effect not working properly.
+DeferEFBCopies = False


### PR DESCRIPTION
Defer EFB Copies to RAM being enabled causes graphical issues during Majora's Mask's screen shrinking effect.

Here's a video with it working properly with it disabled and not working properly with it enabled:
https://gfycat.com/anxiousconfusedjumpingbean