### PR TITLE
Android: Add Paths to UI

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/CustomFilePickerActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/CustomFilePickerActivity.java
@@ -1,5 +1,7 @@
 package org.dolphinemu.dolphinemu.activities;
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.os.Environment;
 
 import androidx.annotation.Nullable;
@@ -10,21 +12,38 @@ import com.nononsenseapps.filepicker.FilePickerActivity;
 import org.dolphinemu.dolphinemu.fragments.CustomFilePickerFragment;
 
 import java.io.File;
+import java.util.HashSet;
 
 public class CustomFilePickerActivity extends FilePickerActivity
-
 {
+  public static final String EXTRA_EXTENSIONS = "dolphinemu.org.filepicker.extensions";
+
+  private HashSet<String> mExtensions;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState)
+  {
+    super.onCreate(savedInstanceState);
+
+    Intent intent = getIntent();
+    if (intent != null)
+    {
+      mExtensions = (HashSet<String>) intent.getSerializableExtra(EXTRA_EXTENSIONS);
+    }
+  }
+
   @Override
   protected AbstractFilePickerFragment<File> getFragment(
           @Nullable final String startPath, final int mode, final boolean allowMultiple,
           final boolean allowCreateDir, final boolean allowExistingFile,
           final boolean singleClick)
   {
-    AbstractFilePickerFragment<File> fragment = new CustomFilePickerFragment();
+    CustomFilePickerFragment fragment = new CustomFilePickerFragment();
     // startPath is allowed to be null. In that case, default folder should be SD-card and not "/"
     fragment.setArgs(
             startPath != null ? startPath : Environment.getExternalStorageDirectory().getPath(),
             mode, allowMultiple, allowCreateDir, allowExistingFile, singleClick);
+    fragment.setExtensions(mExtensions);
     return fragment;
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -633,7 +633,8 @@ public final class EmulationActivity extends AppCompatActivity
         return;
 
       case MENU_ACTION_CHANGE_DISC:
-        FileBrowserHelper.openFilePicker(this, REQUEST_CHANGE_DISC, false);
+        FileBrowserHelper.openFilePicker(this, REQUEST_CHANGE_DISC, false,
+                FileBrowserHelper.GAME_EXTENSIONS);
         return;
 
       case MENU_SET_IR_SENSITIVITY:

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -24,7 +24,6 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
-import android.view.Surface;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
@@ -402,7 +401,7 @@ public final class EmulationActivity extends AppCompatActivity
         // If the user picked a file, as opposed to just backing out.
         if (resultCode == MainActivity.RESULT_OK)
         {
-          String newDiscPath = FileBrowserHelper.getSelectedDirectory(result);
+          String newDiscPath = FileBrowserHelper.getSelectedPath(result);
           if (!TextUtils.isEmpty(newDiscPath))
           {
             NativeLibrary.ChangeDisc(newDiscPath);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
@@ -10,9 +10,12 @@ import androidx.fragment.app.FragmentActivity;
 
 import android.widget.Toast;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivity;
+import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 
@@ -61,22 +64,28 @@ public class GamePropertiesDialog extends DialogFragment
                           .getSupportFragmentManager(), "game_details");
                   break;
                 case 1:
-                  SettingsActivity.launch(getContext(), MenuTag.CONFIG, gameId);
+                  NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini",
+                          Settings.SECTION_INI_CORE, SettingsFile.KEY_DEFAULT_ISO, path);
+                  NativeLibrary.ReloadConfig();
+                  Toast.makeText(getContext(), "Default ISO set", Toast.LENGTH_SHORT).show();
                   break;
                 case 2:
-                  SettingsActivity.launch(getContext(), MenuTag.GRAPHICS, gameId);
+                  SettingsActivity.launch(getContext(), MenuTag.CONFIG, gameId);
                   break;
                 case 3:
-                  SettingsActivity.launch(getContext(), MenuTag.GCPAD_TYPE, gameId);
+                  SettingsActivity.launch(getContext(), MenuTag.GRAPHICS, gameId);
                   break;
                 case 4:
+                  SettingsActivity.launch(getContext(), MenuTag.GCPAD_TYPE, gameId);
+                  break;
+                case 5:
                   // Clear option for GC, Wii controls for else
                   if (platform == Platform.GAMECUBE.toInt())
                     clearGameSettings(gameId);
                   else
                     SettingsActivity.launch(getActivity(), MenuTag.WIIMOTE, gameId);
                   break;
-                case 5:
+                case 6:
                   clearGameSettings(gameId);
                   break;
               }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -8,13 +8,13 @@ import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
 public class Settings
 {
+  public static final String SECTION_INI_GENERAL = "General";
   public static final String SECTION_INI_CORE = "Core";
   public static final String SECTION_INI_INTERFACE = "Interface";
   public static final String SECTION_INI_DSP = "DSP";
@@ -42,7 +42,8 @@ public class Settings
   static
   {
     configFileSectionsMap.put(SettingsFile.FILE_NAME_DOLPHIN,
-            Arrays.asList(SECTION_INI_CORE, SECTION_INI_INTERFACE, SECTION_INI_DSP,
+            Arrays.asList(SECTION_INI_GENERAL, SECTION_INI_CORE, SECTION_INI_INTERFACE,
+                    SECTION_INI_DSP,
                     SECTION_BINDINGS, SECTION_ANALYTICS, SECTION_DEBUG));
     configFileSectionsMap.put(SettingsFile.FILE_NAME_GFX,
             Arrays.asList(SECTION_GFX_SETTINGS, SECTION_GFX_ENHANCEMENTS, SECTION_GFX_HACKS,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/ConfirmRunnable.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/ConfirmRunnable.java
@@ -1,0 +1,38 @@
+package org.dolphinemu.dolphinemu.features.settings.model.view;
+
+public final class ConfirmRunnable extends SettingsItem
+{
+  private int mAlertText;
+  private int mConfirmationText;
+  private Runnable mRunnable;
+
+  public ConfirmRunnable(int titleId, int descriptionId, int alertText, int confirmationText,
+          Runnable runnable)
+  {
+    super(null, null, null, titleId, descriptionId);
+    mAlertText = alertText;
+    mConfirmationText = confirmationText;
+    mRunnable = runnable;
+  }
+
+  public int getAlertText()
+  {
+    return mAlertText;
+  }
+
+  public int getConfirmationText()
+  {
+    return mConfirmationText;
+  }
+
+  public Runnable getRunnable()
+  {
+    return mRunnable;
+  }
+
+  @Override
+  public int getType()
+  {
+    return TYPE_CONFIRM_RUNNABLE;
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FilePicker.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FilePicker.java
@@ -1,0 +1,50 @@
+package org.dolphinemu.dolphinemu.features.settings.model.view;
+
+import org.dolphinemu.dolphinemu.features.settings.model.Setting;
+import org.dolphinemu.dolphinemu.features.settings.model.StringSetting;
+
+public final class FilePicker extends SettingsItem
+{
+  private String mFile;
+  private String mDefaultValue;
+  private int mRequestType;
+
+  public FilePicker(String file, String key, String section, int titleId, int descriptionId,
+          String defaultVault, int requestType, Setting setting)
+  {
+    super(key, section, setting, titleId, descriptionId);
+    mFile = file;
+    mDefaultValue = defaultVault;
+    mRequestType = requestType;
+  }
+
+  public String getFile()
+  {
+    return mFile + ".ini";
+  }
+
+  public String getSelectedValue()
+  {
+    StringSetting setting = (StringSetting) getSetting();
+
+    if (setting == null)
+    {
+      return mDefaultValue;
+    }
+    else
+    {
+      return setting.getValue();
+    }
+  }
+
+  public int getRequestType()
+  {
+    return mRequestType;
+  }
+
+  @Override
+  public int getType()
+  {
+    return TYPE_FILE_PICKER;
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
@@ -21,6 +21,8 @@ public abstract class SettingsItem
   public static final int TYPE_STRING_SINGLE_CHOICE = 6;
   public static final int TYPE_RUMBLE_BINDING = 7;
   public static final int TYPE_SINGLE_CHOICE_DYNAMIC_DESCRIPTIONS = 8;
+  public static final int TYPE_FILE_PICKER = 9;
+  public static final int TYPE_CONFIRM_RUNNABLE = 10;
 
   private String mKey;
   private String mSection;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
@@ -5,6 +5,7 @@ public enum MenuTag
   CONFIG("config"),
   CONFIG_GENERAL("config_general"),
   CONFIG_INTERFACE("config_interface"),
+  CONFIG_PATHS("config_paths"),
   CONFIG_GAME_CUBE("config_gamecube"),
   CONFIG_WII("config_wii"),
   WIIMOTE("wiimote"),
@@ -26,7 +27,8 @@ public enum MenuTag
   WIIMOTE_EXTENSION_1("wiimote_extension", 4),
   WIIMOTE_EXTENSION_2("wiimote_extension", 5),
   WIIMOTE_EXTENSION_3("wiimote_extension", 6),
-  WIIMOTE_EXTENSION_4("wiimote_extension", 7);
+  WIIMOTE_EXTENSION_4("wiimote_extension", 7),
+  BLANK("Blank");
 
   private String tag;
   private int subType = -1;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
@@ -27,8 +27,7 @@ public enum MenuTag
   WIIMOTE_EXTENSION_1("wiimote_extension", 4),
   WIIMOTE_EXTENSION_2("wiimote_extension", 5),
   WIIMOTE_EXTENSION_3("wiimote_extension", 6),
-  WIIMOTE_EXTENSION_4("wiimote_extension", 7),
-  BLANK("Blank");
+  WIIMOTE_EXTENSION_4("wiimote_extension", 7);
 
   private String tag;
   private int subType = -1;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -176,9 +176,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
         Toast.makeText(this, "Saved settings to INI files", Toast.LENGTH_SHORT).show();
       }
     }
-    // Clear static variables for File Picker activities that don't set extensions.
-    SettingsAdapter.sFilePicker = null;
-    SettingsAdapter.sItem = null;
 
     // TODO: After result of FilePicker, duplicate SettingsActivity appears.
     //  Finish to avoid this. Is there a better method?

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -105,13 +105,13 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
   @Override
   public void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack,
-          boolean customAnimations, String gameID)
+          String gameID)
   {
     FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
     if (addToStack)
     {
-      if (areSystemAnimationsEnabled() && customAnimations)
+      if (areSystemAnimationsEnabled())
       {
         transaction.setCustomAnimations(
                 R.animator.settings_enter,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -19,8 +19,10 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.ui.main.MainActivity;
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
+import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 
 public final class SettingsActivity extends AppCompatActivity implements SettingsActivityView
 {
@@ -103,13 +105,13 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
   @Override
   public void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack,
-          String gameID)
+          boolean customAnimations, String gameID)
   {
     FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
     if (addToStack)
     {
-      if (areSystemAnimationsEnabled())
+      if (areSystemAnimationsEnabled() && customAnimations)
       {
         transaction.setCustomAnimations(
                 R.animator.settings_enter,
@@ -152,6 +154,35 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   public void stopListeningToDirectoryInitializationService(DirectoryStateReceiver receiver)
   {
     LocalBroadcastManager.getInstance(this).unregisterReceiver(receiver);
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent result)
+  {
+    super.onActivityResult(requestCode, resultCode, result);
+
+    // Save modified non-FilePicker settings beforehand since finish() won't save them.
+    // onStop() must come before handling the resultCode to properly save FilePicker selection.
+    mPresenter.onStop(true);
+
+    // If the user picked a file, as opposed to just backing out.
+    if (resultCode == MainActivity.RESULT_OK)
+    {
+      mPresenter.onFileConfirmed(FileBrowserHelper.getSelectedPath(result));
+
+      // Prevent duplicate Toasts.
+      if (!mPresenter.shouldSave())
+      {
+        Toast.makeText(this, "Saved settings to INI files", Toast.LENGTH_SHORT).show();
+      }
+    }
+    // Clear static variables for File Picker activities that don't set extensions.
+    SettingsAdapter.sFilePicker = null;
+    SettingsAdapter.sItem = null;
+
+    // TODO: After result of FilePicker, duplicate SettingsActivity appears.
+    //  Finish to avoid this. Is there a better method?
+    finish();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -70,7 +70,7 @@ public final class SettingsActivityPresenter
       }
     }
 
-    mView.showSettingsFragment(menuTag, null, false, gameId);
+    mView.showSettingsFragment(menuTag, null, false, true, gameId);
     mView.onSettingsFileLoaded(mSettings);
   }
 
@@ -184,13 +184,18 @@ public final class SettingsActivityPresenter
     outState.putBoolean(KEY_SHOULD_SAVE, mShouldSave);
   }
 
+  public boolean shouldSave()
+  {
+    return mShouldSave;
+  }
+
   public void onGcPadSettingChanged(MenuTag key, int value)
   {
     if (value != 0) // Not disabled
     {
       Bundle bundle = new Bundle();
       bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value / 6);
-      mView.showSettingsFragment(key, bundle, true, gameId);
+      mView.showSettingsFragment(key, bundle, true, true, gameId);
     }
   }
 
@@ -199,7 +204,7 @@ public final class SettingsActivityPresenter
     switch (value)
     {
       case 1:
-        mView.showSettingsFragment(menuTag, null, true, gameId);
+        mView.showSettingsFragment(menuTag, null, true, true, gameId);
         break;
 
       case 2:
@@ -214,7 +219,12 @@ public final class SettingsActivityPresenter
     {
       Bundle bundle = new Bundle();
       bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
-      mView.showSettingsFragment(menuTag, bundle, true, gameId);
+      mView.showSettingsFragment(menuTag, bundle, true, true, gameId);
     }
+  }
+
+  public void onFileConfirmed(String file)
+  {
+    SettingsAdapter.onFilePickerConfirmation(file);
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -70,7 +70,7 @@ public final class SettingsActivityPresenter
       }
     }
 
-    mView.showSettingsFragment(menuTag, null, false, true, gameId);
+    mView.showSettingsFragment(menuTag, null, false, gameId);
     mView.onSettingsFileLoaded(mSettings);
   }
 
@@ -195,7 +195,7 @@ public final class SettingsActivityPresenter
     {
       Bundle bundle = new Bundle();
       bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value / 6);
-      mView.showSettingsFragment(key, bundle, true, true, gameId);
+      mView.showSettingsFragment(key, bundle, true, gameId);
     }
   }
 
@@ -204,7 +204,7 @@ public final class SettingsActivityPresenter
     switch (value)
     {
       case 1:
-        mView.showSettingsFragment(menuTag, null, true, true, gameId);
+        mView.showSettingsFragment(menuTag, null, true, gameId);
         break;
 
       case 2:
@@ -219,7 +219,7 @@ public final class SettingsActivityPresenter
     {
       Bundle bundle = new Bundle();
       bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
-      mView.showSettingsFragment(menuTag, bundle, true, true, gameId);
+      mView.showSettingsFragment(menuTag, bundle, true, gameId);
     }
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -14,12 +14,10 @@ public interface SettingsActivityView
   /**
    * Show a new SettingsFragment.
    *
-   * @param menuTag          Identifier for the settings group that should be displayed.
-   * @param addToStack       Whether or not this fragment should replace a previous one.
-   * @param customAnimations Custom animations are used if true while system animations are enabled.
+   * @param menuTag    Identifier for the settings group that should be displayed.
+   * @param addToStack Whether or not this fragment should replace a previous one.
    */
-  void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack,
-          boolean customAnimations, String gameId);
+  void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack, String gameId);
 
   /**
    * Called by a contained Fragment to get access to the Setting HashMap

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -14,10 +14,12 @@ public interface SettingsActivityView
   /**
    * Show a new SettingsFragment.
    *
-   * @param menuTag    Identifier for the settings group that should be displayed.
-   * @param addToStack Whether or not this fragment should replace a previous one.
+   * @param menuTag          Identifier for the settings group that should be displayed.
+   * @param addToStack       Whether or not this fragment should replace a previous one.
+   * @param customAnimations Custom animations are used if true while system animations are enabled.
    */
-  void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack, String gameId);
+  void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack,
+          boolean customAnimations, String gameId);
 
   /**
    * Called by a contained Fragment to get access to the Setting HashMap

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -55,6 +55,7 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
         implements DialogInterface.OnClickListener, SeekBar.OnSeekBarChangeListener
 {
   private SettingsFragmentView mView;
+  private static SettingsFragmentView sView;
   private Context mContext;
   private ArrayList<SettingsItem> mSettings;
 
@@ -72,6 +73,7 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
   public SettingsAdapter(SettingsFragmentView view, Context context)
   {
     mView = view;
+    sView = view;
     mContext = context;
     mClickedPosition = -1;
   }
@@ -332,20 +334,32 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 
   public static void resetPaths()
   {
-    NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_CORE,
-            SettingsFile.KEY_DEFAULT_ISO, "");
-    NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_GENERAL,
-            SettingsFile.KEY_NAND_ROOT_PATH, SettingsFragmentPresenter.getDefaultNANDRootPath());
-    NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_GENERAL,
-            SettingsFile.KEY_DUMP_PATH, SettingsFragmentPresenter.getDefaultDumpPath());
-    NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_GENERAL,
-            SettingsFile.KEY_LOAD_PATH, SettingsFragmentPresenter.getDefaultLoadPath());
-    NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_GENERAL,
-            SettingsFile.KEY_RESOURCE_PACK_PATH,
-            SettingsFragmentPresenter.getDefaultResourcePackPath());
-    NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_GENERAL,
-            SettingsFile.KEY_WII_SD_CARD_PATH, SettingsFragmentPresenter.getDefaultSDPath());
-    NativeLibrary.ReloadConfig();
+    StringSetting defaultISO =
+            new StringSetting(SettingsFile.KEY_DEFAULT_ISO, Settings.SECTION_INI_CORE, "");
+    StringSetting NANDRootPath =
+            new StringSetting(SettingsFile.KEY_NAND_ROOT_PATH, Settings.SECTION_INI_GENERAL,
+                    SettingsFragmentPresenter.getDefaultNANDRootPath());
+    StringSetting dumpPath =
+            new StringSetting(SettingsFile.KEY_DUMP_PATH, Settings.SECTION_INI_GENERAL,
+                    SettingsFragmentPresenter.getDefaultDumpPath());
+    StringSetting loadPath =
+            new StringSetting(SettingsFile.KEY_LOAD_PATH, Settings.SECTION_INI_GENERAL,
+                    SettingsFragmentPresenter.getDefaultLoadPath());
+    StringSetting resourcePackPath =
+            new StringSetting(SettingsFile.KEY_RESOURCE_PACK_PATH, Settings.SECTION_INI_GENERAL,
+                    SettingsFragmentPresenter.getDefaultResourcePackPath());
+    StringSetting sdPath =
+            new StringSetting(SettingsFile.KEY_WII_SD_CARD_PATH, Settings.SECTION_INI_GENERAL,
+                    SettingsFragmentPresenter.getDefaultSDPath());
+
+    sView.putSetting(defaultISO);
+    sView.putSetting(NANDRootPath);
+    sView.putSetting(dumpPath);
+    sView.putSetting(loadPath);
+    sView.putSetting(resourcePackPath);
+    sView.putSetting(sdPath);
+
+    sView.onSettingChanged();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -20,7 +20,6 @@ import org.dolphinemu.dolphinemu.ui.DividerItemDecoration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 public final class SettingsFragment extends Fragment implements SettingsFragmentView
 {
@@ -180,18 +179,7 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   @Override
   public void loadSubMenu(MenuTag menuKey)
   {
-    mActivity
-            .showSettingsFragment(menuKey, null, true, true,
-                    getArguments().getString(ARGUMENT_GAME_ID));
-  }
-
-  @Override
-  public void reloadSubMenu()
-  {
-    mActivity
-            .showSettingsFragment(MenuTag.BLANK, null, true, false,
-                    getArguments().getString(ARGUMENT_GAME_ID));
-    Objects.requireNonNull(getActivity()).onBackPressed();
+    mActivity.showSettingsFragment(menuKey, null, true, getArguments().getString(ARGUMENT_GAME_ID));
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -1,6 +1,5 @@
 package org.dolphinemu.dolphinemu.features.settings.ui;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 
@@ -21,6 +20,7 @@ import org.dolphinemu.dolphinemu.ui.DividerItemDecoration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public final class SettingsFragment extends Fragment implements SettingsFragmentView
 {
@@ -39,6 +39,7 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     titles.put(MenuTag.CONFIG, R.string.preferences_settings);
     titles.put(MenuTag.CONFIG_GENERAL, R.string.general_submenu);
     titles.put(MenuTag.CONFIG_INTERFACE, R.string.interface_submenu);
+    titles.put(MenuTag.CONFIG_PATHS, R.string.paths_submenu);
     titles.put(MenuTag.CONFIG_GAME_CUBE, R.string.gamecube_submenu);
     titles.put(MenuTag.CONFIG_WII, R.string.wii_submenu);
     titles.put(MenuTag.WIIMOTE, R.string.grid_menu_wiimote_settings);
@@ -179,7 +180,18 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   @Override
   public void loadSubMenu(MenuTag menuKey)
   {
-    mActivity.showSettingsFragment(menuKey, null, true, getArguments().getString(ARGUMENT_GAME_ID));
+    mActivity
+            .showSettingsFragment(menuKey, null, true, true,
+                    getArguments().getString(ARGUMENT_GAME_ID));
+  }
+
+  @Override
+  public void reloadSubMenu()
+  {
+    mActivity
+            .showSettingsFragment(MenuTag.BLANK, null, true, false,
+                    getArguments().getString(ARGUMENT_GAME_ID));
+    Objects.requireNonNull(getActivity()).onBackPressed();
   }
 
   @Override
@@ -217,5 +229,4 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   {
     mActivity.onExtensionSettingChanged(menuTag, value);
   }
-
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -197,9 +197,6 @@ public final class SettingsFragmentPresenter
         addStereoSettings(sl);
         break;
 
-      case BLANK:
-        break;
-
       default:
         mView.showToastMessage("Unimplemented menu");
         return;
@@ -353,8 +350,8 @@ public final class SettingsFragmentPresenter
     sl.add(new FilePicker(SettingsFile.FILE_NAME_DOLPHIN, SettingsFile.KEY_WII_SD_CARD_PATH,
             Settings.SECTION_INI_GENERAL, R.string.SD_card_path, 0, getDefaultSDPath(),
             MainPresenter.REQUEST_SD_FILE, wiiSDCardPath));
-    sl.add(new ConfirmRunnable(R.string.reset_paths, 0, R.string.reset_paths_confirmation,
-            R.string.reset_paths_complete, () -> SettingsAdapter.resetPaths()));
+    sl.add(new ConfirmRunnable(R.string.reset_paths, 0, R.string.reset_paths_confirmation, 0,
+            SettingsAdapter::resetPaths));
   }
 
   private void addGameCubeSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -58,12 +58,6 @@ public interface SettingsFragmentView
   void loadSubMenu(MenuTag menuKey);
 
   /**
-   * Show a new blank submenu and then immediately back out of it.
-   * Useful for updating dynamic setting descriptions.
-   */
-  void reloadSubMenu();
-
-  /**
    * Tell the Fragment to tell the containing activity to display a toast message.
    *
    * @param message Text to be shown in the Toast

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -58,6 +58,12 @@ public interface SettingsFragmentView
   void loadSubMenu(MenuTag menuKey);
 
   /**
+   * Show a new blank submenu and then immediately back out of it.
+   * Useful for updating dynamic setting descriptions.
+   */
+  void reloadSubMenu();
+
+  /**
    * Tell the Fragment to tell the containing activity to display a toast message.
    *
    * @param message Text to be shown in the Toast

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
@@ -1,0 +1,85 @@
+package org.dolphinemu.dolphinemu.features.settings.ui.viewholder;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.view.ConfirmRunnable;
+import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
+import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
+import org.dolphinemu.dolphinemu.features.settings.ui.SettingsFragmentView;
+
+import androidx.appcompat.app.AlertDialog;
+
+public final class ConfirmRunnableViewHolder extends SettingViewHolder
+{
+  private ConfirmRunnable mItem;
+  private SettingsFragmentView mView;
+
+  private Context mContext;
+
+  private TextView mTextSettingName;
+  private TextView mTextSettingDescription;
+
+  public ConfirmRunnableViewHolder(View itemView, SettingsAdapter adapter, Context context,
+          SettingsFragmentView view)
+  {
+    super(itemView, adapter);
+
+    mContext = context;
+    mView = view;
+  }
+
+  @Override
+  protected void findViews(View root)
+  {
+    mTextSettingName = (TextView) root.findViewById(R.id.text_setting_name);
+    mTextSettingDescription = (TextView) root.findViewById(R.id.text_setting_description);
+  }
+
+  @Override
+  public void bind(SettingsItem item)
+  {
+    mItem = (ConfirmRunnable) item;
+
+    mTextSettingName.setText(item.getNameId());
+
+    if (item.getDescriptionId() > 0)
+    {
+      mTextSettingDescription.setText(item.getDescriptionId());
+    }
+  }
+
+  @Override
+  public void onClick(View clicked)
+  {
+    String alertTitle = mContext.getString(mItem.getNameId());
+    String alertText = mContext.getString(mItem.getAlertText());
+    String confirmationText = mContext.getString(mItem.getConfirmationText());
+
+    AlertDialog.Builder builder = new AlertDialog.Builder(mContext)
+            .setTitle(alertTitle)
+            .setMessage(alertText);
+
+    builder
+            .setPositiveButton("Yes", (dialog, whichButton) ->
+            {
+              mItem.getRunnable().run();
+
+              if (mItem.getConfirmationText() > 0)
+              {
+                Toast.makeText(mContext, confirmationText, Toast.LENGTH_SHORT).show();
+              }
+              dialog.dismiss();
+              mView.reloadSubMenu();
+            })
+            .setNegativeButton("No", (dialog, whichButton) ->
+            {
+              dialog.dismiss();
+            });
+
+    builder.show();
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
@@ -57,7 +57,6 @@ public final class ConfirmRunnableViewHolder extends SettingViewHolder
   {
     String alertTitle = mContext.getString(mItem.getNameId());
     String alertText = mContext.getString(mItem.getAlertText());
-    String confirmationText = mContext.getString(mItem.getConfirmationText());
 
     AlertDialog.Builder builder = new AlertDialog.Builder(mContext)
             .setTitle(alertTitle)
@@ -70,10 +69,13 @@ public final class ConfirmRunnableViewHolder extends SettingViewHolder
 
               if (mItem.getConfirmationText() > 0)
               {
+                String confirmationText = mContext.getString(mItem.getConfirmationText());
                 Toast.makeText(mContext, confirmationText, Toast.LENGTH_SHORT).show();
               }
               dialog.dismiss();
-              mView.reloadSubMenu();
+
+              // TODO: Remove finish and properly update dynamic settings descriptions.
+              mView.getActivity().finish();
             })
             .setNegativeButton("No", (dialog, whichButton) ->
             {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/FilePickerViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/FilePickerViewHolder.java
@@ -1,0 +1,66 @@
+package org.dolphinemu.dolphinemu.features.settings.ui.viewholder;
+
+import android.view.View;
+import android.widget.TextView;
+
+import org.dolphinemu.dolphinemu.NativeLibrary;
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.view.FilePicker;
+import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
+import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
+import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
+import org.dolphinemu.dolphinemu.ui.main.MainPresenter;
+
+public final class FilePickerViewHolder extends SettingViewHolder
+{
+  private FilePicker mFilePicker;
+  private SettingsItem mItem;
+
+  private TextView mTextSettingName;
+  private TextView mTextSettingDescription;
+
+  public FilePickerViewHolder(View itemView, SettingsAdapter adapter)
+  {
+    super(itemView, adapter);
+  }
+
+  @Override
+  protected void findViews(View root)
+  {
+    mTextSettingName = (TextView) root.findViewById(R.id.text_setting_name);
+    mTextSettingDescription = (TextView) root.findViewById(R.id.text_setting_description);
+  }
+
+  @Override
+  public void bind(SettingsItem item)
+  {
+    mFilePicker = (FilePicker) item;
+    mItem = item;
+
+    mTextSettingName.setText(item.getNameId());
+
+    if (item.getDescriptionId() > 0)
+    {
+      mTextSettingDescription.setText(item.getDescriptionId());
+    }
+    else
+    {
+      mTextSettingDescription.setText(NativeLibrary
+              .GetConfig(mFilePicker.getFile(), item.getSection(), item.getKey(),
+                      mFilePicker.getSelectedValue()));
+    }
+  }
+
+  @Override
+  public void onClick(View clicked)
+  {
+    if (mFilePicker.getRequestType() == MainPresenter.REQUEST_DIRECTORY)
+    {
+      getAdapter().onFilePickerDirectoryClick(mItem);
+    }
+    else
+    {
+      getAdapter().onFilePickerFileClick(mItem);
+    }
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -54,6 +54,7 @@ public final class SettingsFile
   public static final String KEY_SLOT_A_DEVICE = "SlotA";
   public static final String KEY_SLOT_B_DEVICE = "SlotB";
   public static final String KEY_ENABLE_SAVE_STATES = "EnableSaveStates";
+  public static final String KEY_DEFAULT_ISO = "DefaultISO";
 
   public static final String KEY_ANALYTICS_ENABLED = "Enabled";
   public static final String KEY_ANALYTICS_PERMISSION_ASKED = "PermissionAsked";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -55,6 +55,11 @@ public final class SettingsFile
   public static final String KEY_SLOT_B_DEVICE = "SlotB";
   public static final String KEY_ENABLE_SAVE_STATES = "EnableSaveStates";
   public static final String KEY_DEFAULT_ISO = "DefaultISO";
+  public static final String KEY_NAND_ROOT_PATH = "NANDRootPath";
+  public static final String KEY_DUMP_PATH = "DumpPath";
+  public static final String KEY_LOAD_PATH = "LoadPath";
+  public static final String KEY_RESOURCE_PACK_PATH = "ResourcePackPath";
+  public static final String KEY_WII_SD_CARD_PATH = "WiiSDCardPath";
 
   public static final String KEY_ANALYTICS_ENABLED = "Enabled";
   public static final String KEY_ANALYTICS_PERMISSION_ASKED = "PermissionAsked";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
@@ -10,19 +10,14 @@ import android.view.View;
 import android.widget.TextView;
 
 import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
 
 import com.nononsenseapps.filepicker.FilePickerFragment;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 public class CustomFilePickerFragment extends FilePickerFragment
 {
-  private static final Set<String> extensions = new HashSet<>(Arrays.asList(
-          "gcm", "tgc", "iso", "ciso", "gcz", "wbfs", "wad", "dol", "elf", "dff"));
-
   @NonNull
   @Override
   public Uri toUri(@NonNull final File file)
@@ -56,7 +51,8 @@ public class CustomFilePickerFragment extends FilePickerFragment
 
     return (showHiddenItems || !file.isHidden()) &&
             (file.isDirectory() ||
-                    extensions.contains(fileExtension(file.getName()).toLowerCase()));
+                    SettingsAdapter.getExtensions()
+                            .contains(fileExtension(file.getName()).toLowerCase()));
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
@@ -10,14 +10,28 @@ import android.view.View;
 import android.widget.TextView;
 
 import org.dolphinemu.dolphinemu.R;
-import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
 
 import com.nononsenseapps.filepicker.FilePickerFragment;
 
 import java.io.File;
+import java.util.HashSet;
 
 public class CustomFilePickerFragment extends FilePickerFragment
 {
+  public static final String KEY_EXTENSIONS = "KEY_EXTENSIONS";
+
+  private HashSet<String> mExtensions;
+
+  public void setExtensions(HashSet<String> extensions)
+  {
+    Bundle b = getArguments();
+    if (b == null)
+      b = new Bundle();
+
+    b.putSerializable(KEY_EXTENSIONS, extensions);
+    setArguments(b);
+  }
+
   @NonNull
   @Override
   public Uri toUri(@NonNull final File file)
@@ -31,6 +45,8 @@ public class CustomFilePickerFragment extends FilePickerFragment
   @Override public void onActivityCreated(Bundle savedInstanceState)
   {
     super.onActivityCreated(savedInstanceState);
+
+    mExtensions = (HashSet<String>) getArguments().getSerializable(KEY_EXTENSIONS);
 
     if (mode == MODE_DIR)
     {
@@ -51,8 +67,7 @@ public class CustomFilePickerFragment extends FilePickerFragment
 
     return (showHiddenItems || !file.isHidden()) &&
             (file.isDirectory() ||
-                    SettingsAdapter.getExtensions()
-                            .contains(fileExtension(file.getName()).toLowerCase()));
+                    mExtensions.contains(fileExtension(file.getName()).toLowerCase()));
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -145,13 +145,14 @@ public final class MainActivity extends AppCompatActivity implements MainView
   @Override
   public void launchFileListActivity()
   {
-    FileBrowserHelper.openDirectoryPicker(this);
+    FileBrowserHelper.openDirectoryPicker(this, FileBrowserHelper.GAME_EXTENSIONS);
   }
 
   @Override
   public void launchOpenFileActivity()
   {
-    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_GAME_FILE, false);
+    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_GAME_FILE, false,
+            FileBrowserHelper.GAME_EXTENSIONS);
   }
 
   /**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -151,7 +151,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
   @Override
   public void launchOpenFileActivity()
   {
-    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_OPEN_FILE, true);
+    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_GAME_FILE, false);
   }
 
   /**
@@ -162,17 +162,18 @@ public final class MainActivity extends AppCompatActivity implements MainView
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent result)
   {
+    super.onActivityResult(requestCode, resultCode, result);
     switch (requestCode)
     {
-      case MainPresenter.REQUEST_ADD_DIRECTORY:
+      case MainPresenter.REQUEST_DIRECTORY:
         // If the user picked a file, as opposed to just backing out.
         if (resultCode == MainActivity.RESULT_OK)
         {
-          mPresenter.onDirectorySelected(FileBrowserHelper.getSelectedDirectory(result));
+          mPresenter.onDirectorySelected(FileBrowserHelper.getSelectedPath(result));
         }
         break;
 
-      case MainPresenter.REQUEST_OPEN_FILE:
+      case MainPresenter.REQUEST_GAME_FILE:
         // If the user picked a file, as opposed to just backing out.
         if (resultCode == MainActivity.RESULT_OK)
         {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -15,8 +15,9 @@ import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 
 public final class MainPresenter
 {
-  public static final int REQUEST_ADD_DIRECTORY = 1;
-  public static final int REQUEST_OPEN_FILE = 2;
+  public static final int REQUEST_DIRECTORY = 1;
+  public static final int REQUEST_GAME_FILE = 2;
+  public static final int REQUEST_SD_FILE = 3;
 
   private final MainView mView;
   private final Context mContext;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -142,13 +142,14 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   @Override
   public void launchFileListActivity()
   {
-    FileBrowserHelper.openDirectoryPicker(this);
+    FileBrowserHelper.openDirectoryPicker(this, FileBrowserHelper.GAME_EXTENSIONS);
   }
 
   @Override
   public void launchOpenFileActivity()
   {
-    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_GAME_FILE, false);
+    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_GAME_FILE, false,
+            FileBrowserHelper.GAME_EXTENSIONS);
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -5,7 +5,6 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
-import androidx.leanback.app.BrowseFragment;
 import androidx.leanback.app.BrowseSupportFragment;
 import androidx.leanback.widget.ArrayObjectAdapter;
 import androidx.leanback.widget.HeaderItem;
@@ -149,7 +148,7 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   @Override
   public void launchOpenFileActivity()
   {
-    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_OPEN_FILE, true);
+    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_GAME_FILE, false);
   }
 
   @Override
@@ -171,17 +170,18 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent result)
   {
+    super.onActivityResult(requestCode, resultCode, result);
     switch (requestCode)
     {
-      case MainPresenter.REQUEST_ADD_DIRECTORY:
+      case MainPresenter.REQUEST_DIRECTORY:
         // If the user picked a file, as opposed to just backing out.
         if (resultCode == MainActivity.RESULT_OK)
         {
-          mPresenter.onDirectorySelected(FileBrowserHelper.getSelectedDirectory(result));
+          mPresenter.onDirectorySelected(FileBrowserHelper.getSelectedPath(result));
         }
         break;
 
-      case MainPresenter.REQUEST_OPEN_FILE:
+      case MainPresenter.REQUEST_GAME_FILE:
         // If the user picked a file, as opposed to just backing out.
         if (resultCode == MainActivity.RESULT_OK)
         {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
@@ -28,7 +28,7 @@ public final class FileBrowserHelper
     i.putExtra(FilePickerActivity.EXTRA_START_PATH,
             Environment.getExternalStorageDirectory().getPath());
 
-    activity.startActivityForResult(i, MainPresenter.REQUEST_ADD_DIRECTORY);
+    activity.startActivityForResult(i, MainPresenter.REQUEST_DIRECTORY);
   }
 
   public static void openFilePicker(FragmentActivity activity, int requestCode, boolean allowMulti)
@@ -45,7 +45,7 @@ public final class FileBrowserHelper
   }
 
   @Nullable
-  public static String getSelectedDirectory(Intent result)
+  public static String getSelectedPath(Intent result)
   {
     // Use the provided utility method to parse the result
     List<Uri> files = Utils.getSelectedFilesFromResult(result);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
@@ -14,11 +14,20 @@ import org.dolphinemu.dolphinemu.activities.CustomFilePickerActivity;
 import org.dolphinemu.dolphinemu.ui.main.MainPresenter;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 public final class FileBrowserHelper
 {
-  public static void openDirectoryPicker(FragmentActivity activity)
+  public static final HashSet<String> GAME_EXTENSIONS = new HashSet<>(Arrays.asList(
+          "gcm", "tgc", "iso", "ciso", "gcz", "wbfs", "wad", "dol", "elf", "dff"));
+
+  public static final HashSet<String> RAW_EXTENSION = new HashSet<>(Collections.singletonList(
+          "raw"));
+
+  public static void openDirectoryPicker(FragmentActivity activity, HashSet<String> extensions)
   {
     Intent i = new Intent(activity, CustomFilePickerActivity.class);
 
@@ -27,11 +36,13 @@ public final class FileBrowserHelper
     i.putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_DIR);
     i.putExtra(FilePickerActivity.EXTRA_START_PATH,
             Environment.getExternalStorageDirectory().getPath());
+    i.putExtra(CustomFilePickerActivity.EXTRA_EXTENSIONS, extensions);
 
     activity.startActivityForResult(i, MainPresenter.REQUEST_DIRECTORY);
   }
 
-  public static void openFilePicker(FragmentActivity activity, int requestCode, boolean allowMulti)
+  public static void openFilePicker(FragmentActivity activity, int requestCode, boolean allowMulti,
+          HashSet<String> extensions)
   {
     Intent i = new Intent(activity, CustomFilePickerActivity.class);
 
@@ -40,6 +51,7 @@ public final class FileBrowserHelper
     i.putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_FILE);
     i.putExtra(FilePickerActivity.EXTRA_START_PATH,
             Environment.getExternalStorageDirectory().getPath());
+    i.putExtra(CustomFilePickerActivity.EXTRA_EXTENSIONS, extensions);
 
     activity.startActivityForResult(i, requestCode);
   }

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -337,6 +337,7 @@
 
     <string-array name="gameSettingsMenusGC">
         <item>Details</item>
+        <item>Set as Default ISO</item>
         <item>Core Settings</item>
         <item>GFX Settings</item>
         <item>GameCube Controller Settings</item>
@@ -344,6 +345,7 @@
     </string-array>
     <string-array name="gameSettingsMenusWii">
         <item>Details</item>
+        <item>Set as Default ISO</item>
         <item>Core Settings</item>
         <item>GFX Settings</item>
         <item>GameCube Controller Settings</item>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -162,6 +162,18 @@
     <string name="osd_messages">Show On-Screen Display Messages</string>
     <string name="osd_messages_description">Display messages over the emulation screen area. These messages include memory card writes, video backend and CPU information, and JIT cache clearing.</string>
 
+    <!-- Path Settings -->
+    <string name="paths_submenu">Paths</string>
+    <string name="default_ISO">Default ISO</string>
+    <string name="wii_NAND_root">Wii NAND Root</string>
+    <string name="dump_path">Dump Path</string>
+    <string name="load_path">Load Path</string>
+    <string name="resource_pack_path">Resource Pack Path</string>
+    <string name="SD_card_path">SD Card Path</string>
+    <string name="reset_paths">Reset Paths to Default Settings</string>
+    <string name="reset_paths_confirmation">Are you sure you want to reset Paths to default settings?</string>
+    <string name="reset_paths_complete">Paths reset</string>
+
     <!-- Graphics Settings -->
     <string name="graphics_general">General</string>
     <string name="graphics_enhancements_and_hacks">Enhancements &amp; Hacks</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -172,7 +172,6 @@
     <string name="SD_card_path">SD Card Path</string>
     <string name="reset_paths">Reset Paths to Default Settings</string>
     <string name="reset_paths_confirmation">Are you sure you want to reset Paths to default settings?</string>
-    <string name="reset_paths_complete">Paths reset</string>
 
     <!-- Graphics Settings -->
     <string name="graphics_general">General</string>


### PR DESCRIPTION
Implements https://bugs.dolphin-emu.org/issues/10781
- Android: Add Set as Default ISO to UI
- Android: Add Paths to UI
- Very useful for loading game mods
- Removed some unnecessary import statements
- Renamed some things now that `FilePicker` is more versatile
- Added `ConfirmRunnable` to confirm running arbitrary runnables (so they're not accidentally clicked). It will also be useful for future PRs, especially when modifying multiple settings (i.e. toggling all log types).
- Fixed a bug where `launchOpenFileActivity()` could select multiple files. We don't want to be able to load multiple games at once!

- [X] Review requested: See the TODO added to `SettingsActivity`. Comment out the `finish()` to see the weirdness. My workaround works but it probably isn't the prettiest!

![Screenshot_20200105-170115_Dolphin Emulator](https://user-images.githubusercontent.com/17330088/71786806-04eb5c00-2fde-11ea-851e-61f0a2253d87.jpg)

![Screenshot_20200322-054716_Dolphin Emulator](https://user-images.githubusercontent.com/17330088/77246958-b6c01f00-6c02-11ea-9a79-fe215ac37161.jpg)