### PR TITLE
ControllerInterface: Rename full surface analog inputs.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -55,7 +55,7 @@ Device::Input* Device::FindInput(const std::string& name) const
 {
   for (Input* input : m_inputs)
   {
-    if (input->GetName() == name)
+    if (input->IsMatchingName(name))
       return input;
   }
 
@@ -66,16 +66,40 @@ Device::Output* Device::FindOutput(const std::string& name) const
 {
   for (Output* output : m_outputs)
   {
-    if (output->GetName() == name)
+    if (output->IsMatchingName(name))
       return output;
   }
 
   return nullptr;
 }
 
+bool Device::Control::IsMatchingName(const std::string& name) const
+{
+  return GetName() == name;
+}
+
 ControlState Device::FullAnalogSurface::GetState() const
 {
   return (1 + std::max(0.0, m_high.GetState()) - std::max(0.0, m_low.GetState())) / 2;
+}
+
+std::string Device::FullAnalogSurface::GetName() const
+{
+  // E.g. "Full Axis X+"
+  return "Full " + m_high.GetName();
+}
+
+bool Device::FullAnalogSurface::IsMatchingName(const std::string& name) const
+{
+  if (Control::IsMatchingName(name))
+    return true;
+
+  // Old naming scheme was "Axis X-+" which is too visually similar to "Axis X+".
+  // This has caused countless problems for users with mysterious misconfigurations.
+  // We match this old name to support old configurations.
+  const auto old_name = m_low.GetName() + *m_high.GetName().rbegin();
+
+  return old_name == name;
 }
 
 //

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -46,6 +46,10 @@ public:
     virtual ~Control() {}
     virtual Input* ToInput() { return nullptr; }
     virtual Output* ToOutput() { return nullptr; }
+
+    // May be overridden to allow multiple valid names.
+    // Useful for backwards-compatible configurations when names change.
+    virtual bool IsMatchingName(const std::string& name) const;
   };
 
   //
@@ -114,12 +118,13 @@ protected:
   void AddInput(Input* const i);
   void AddOutput(Output* const o);
 
-  class FullAnalogSurface : public Input
+  class FullAnalogSurface final : public Input
   {
   public:
     FullAnalogSurface(Input* low, Input* high) : m_low(*low), m_high(*high) {}
     ControlState GetState() const override;
-    std::string GetName() const override { return m_low.GetName() + *m_high.GetName().rbegin(); }
+    std::string GetName() const override;
+    bool IsMatchingName(const std::string& name) const override;
 
   private:
     Input& m_low;


### PR DESCRIPTION
Here's a collection of screenshots from users that couldn't figure out why their sticks were "misaligned".

https://i.imgur.com/TzBTbsf.png
https://i.redd.it/josaz8x7ipk21.jpg
https://pbs.twimg.com/media/D1ZJeaxU0AA1t9B.jpg
https://forums.dolphin-emu.org/attachment.php?aid=17746
https://pbs.twimg.com/media/D3qPb9MXkAUoWrL.png

They've all accidentally mapped a direction of their stick to the "full surface" mapping which is sometimes needed for analog triggers. This is caused by not having the stick centered when clicking the mapping button. 

The mistake is too hard to see. "+" vs. "-+" or "-" vs. "+-".

I've renamed full surface analog inputs to be more visually dissimilar from their underlying inputs.
The old naming was of the form, "Axis X-+". The new naming is "Full Axis X+".

I've added the ability for the old names to still function but new mappings will take on the new names.

This should hopefully make future wrong mappings easier to detect by users.