### PR TITLE
DolphinQt: Fix unused widgets in InfoWidget from being visible.

### DIFF
--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -102,23 +102,22 @@ QGroupBox* InfoWidget::CreateBannerDetails()
 
   layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 
-  m_name = CreateValueDisplay();
-  m_maker = CreateValueDisplay();
-  m_description = new QTextEdit(group);
-  m_description->setReadOnly(true);
   CreateLanguageSelector();
-
   layout->addRow(tr("Show Language:"), m_language_selector);
+
   if (m_game.GetPlatform() == DiscIO::Platform::GameCubeDisc)
   {
-    layout->addRow(tr("Name:"), m_name);
-    layout->addRow(tr("Maker:"), m_maker);
-    layout->addRow(tr("Description:"), m_description);
+    layout->addRow(tr("Name:"), m_name = CreateValueDisplay());
+    layout->addRow(tr("Maker:"), m_maker = CreateValueDisplay());
+    layout->addRow(tr("Description:"), m_description = new QTextEdit());
+    m_description->setReadOnly(true);
   }
   else if (DiscIO::IsWii(m_game.GetPlatform()))
   {
-    layout->addRow(tr("Name:"), m_name);
+    layout->addRow(tr("Name:"), m_name = CreateValueDisplay());
   }
+
+  ChangeLanguage();
 
   QPixmap banner = ToQPixmap(m_game.GetBannerImage());
   if (!banner.isNull())
@@ -183,16 +182,21 @@ void InfoWidget::CreateLanguageSelector()
   connect(m_language_selector,
           static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
           &InfoWidget::ChangeLanguage);
-  ChangeLanguage();
 }
 
 void InfoWidget::ChangeLanguage()
 {
   DiscIO::Language language =
       static_cast<DiscIO::Language>(m_language_selector->currentData().toInt());
-  m_name->setText(QString::fromStdString(m_game.GetLongName(language)));
-  m_maker->setText(QString::fromStdString(m_game.GetLongMaker(language)));
-  m_description->setText(QString::fromStdString(m_game.GetDescription(language)));
+
+  if (m_name)
+    m_name->setText(QString::fromStdString(m_game.GetLongName(language)));
+
+  if (m_maker)
+    m_maker->setText(QString::fromStdString(m_game.GetLongMaker(language)));
+
+  if (m_description)
+    m_description->setText(QString::fromStdString(m_game.GetDescription(language)));
 }
 
 QWidget* InfoWidget::CreateChecksumComputer()

--- a/Source/Core/DolphinQt/Config/InfoWidget.h
+++ b/Source/Core/DolphinQt/Config/InfoWidget.h
@@ -38,7 +38,7 @@ private:
   UICommon::GameFile m_game;
   QLineEdit* m_checksum_result;
   QComboBox* m_language_selector;
-  QLineEdit* m_name;
-  QLineEdit* m_maker;
-  QTextEdit* m_description;
+  QLineEdit* m_name = {};
+  QLineEdit* m_maker = {};
+  QTextEdit* m_description = {};
 };

--- a/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.cpp
+++ b/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.cpp
@@ -6,10 +6,6 @@
 
 #include "DolphinQt/QtUtils/DoubleClickEventFilter.h"
 
-DoubleClickEventFilter::DoubleClickEventFilter(QObject* parent) : QObject(parent)
-{
-}
-
 bool DoubleClickEventFilter::eventFilter(QObject* object, QEvent* event)
 {
   if (event->type() == QEvent::MouseButtonDblClick)

--- a/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.h
+++ b/Source/Core/DolphinQt/QtUtils/DoubleClickEventFilter.h
@@ -10,7 +10,7 @@ class DoubleClickEventFilter : public QObject
 {
   Q_OBJECT
 public:
-  explicit DoubleClickEventFilter(QObject* parent);
+  using QObject::QObject;
 
 signals:
   void doubleClicked();

--- a/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.cpp
+++ b/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.cpp
@@ -7,10 +7,6 @@
 
 #include "DolphinQt/QtUtils/WindowActivationEventFilter.h"
 
-WindowActivationEventFilter::WindowActivationEventFilter(QObject* parent) : QObject(parent)
-{
-}
-
 bool WindowActivationEventFilter::eventFilter(QObject* object, QEvent* event)
 {
   if (event->type() == QEvent::WindowDeactivate)

--- a/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.h
+++ b/Source/Core/DolphinQt/QtUtils/WindowActivationEventFilter.h
@@ -10,7 +10,7 @@ class WindowActivationEventFilter : public QObject
 {
   Q_OBJECT
 public:
-  explicit WindowActivationEventFilter(QObject* parent);
+  using QObject::QObject;
 
 signals:
   void windowActivated();


### PR DESCRIPTION
Fixes issue introduced by PR #7906.

https://bugs.dolphin-emu.org/issues/11633

Other minor cleanups.