### PR TITLE
TextureCache: Simplify XFB reconstruction

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -686,6 +686,9 @@ static void BeginField(FieldType field, u64 ticks)
     xfbAddr = GetXFBAddressTop();
   }
 
+  // Multiply the stride by 2 to get the byte offset for each subsequent line.
+  fbStride *= 2;
+
   if (potentially_interlaced_xfb && interlaced_video_mode && g_ActiveConfig.bForceProgressive)
   {
     // Strictly speaking, in interlaced mode, we're only supposed to read
@@ -704,10 +707,10 @@ static void BeginField(FieldType field, u64 ticks)
     // offset the xfb by (-stride_of_one_line) to get the start
     // address of the full xfb.
     if (field == FieldType::Odd && m_VBlankTimingOdd.PRB == m_VBlankTimingEven.PRB + 1 && xfbAddr)
-      xfbAddr -= fbStride * 2;
+      xfbAddr -= fbStride;
 
     if (field == FieldType::Even && m_VBlankTimingOdd.PRB == m_VBlankTimingEven.PRB - 1 && xfbAddr)
-      xfbAddr -= fbStride * 2;
+      xfbAddr -= fbStride;
   }
 
   LogField(field, xfbAddr);
@@ -787,10 +790,8 @@ void Update(u64 ticks)
 }
 
 // Create a fake VI mode for a fifolog
-void FakeVIUpdate(u32 xfb_address, u32 fb_width, u32 fb_height)
+void FakeVIUpdate(u32 xfb_address, u32 fb_width, u32 fb_stride, u32 fb_height)
 {
-  u32 fb_stride = fb_width;
-
   bool interlaced = fb_height > 480 / 2;
   if (interlaced)
   {
@@ -807,7 +808,7 @@ void FakeVIUpdate(u32 xfb_address, u32 fb_width, u32 fb_height)
   m_VBlankTimingEven.PRB = 503 - fb_height * 2;
   m_VBlankTimingEven.PSB = 4;
   m_PictureConfiguration.WPL = fb_width / 16;
-  m_PictureConfiguration.STD = fb_stride / 16;
+  m_PictureConfiguration.STD = (fb_stride / 2) / 16;
 
   UpdateParameters();
 

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -374,6 +374,6 @@ u32 GetTicksPerField();
 float GetAspectRatio();
 
 // Create a fake VI mode for a fifolog
-void FakeVIUpdate(u32 xfb_address, u32 fb_width, u32 fb_height);
+void FakeVIUpdate(u32 xfb_address, u32 fb_width, u32 fb_stride, u32 fb_height);
 
 }  // namespace VideoInterface

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -22,14 +22,14 @@ public:
 protected:
   void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
                u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
-               bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
-               const EFBCopyFilterCoefficients& filter_coefficients) override
+               bool scale_by_half, bool linear_filter, float y_scale, float gamma, bool clamp_top,
+               bool clamp_bottom, const EFBCopyFilterCoefficients& filter_coefficients) override
   {
   }
 
   void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy, const EFBRectangle& src_rect,
-                           bool scale_by_half, EFBCopyFormat dst_format, bool is_intensity,
-                           float gamma, bool clamp_top, bool clamp_bottom,
+                           bool scale_by_half, bool linear_filter, EFBCopyFormat dst_format,
+                           bool is_intensity, float gamma, bool clamp_top, bool clamp_bottom,
                            const EFBCopyFilterCoefficients& filter_coefficients) override
   {
   }

--- a/Source/Core/VideoBackends/Software/TextureCache.h
+++ b/Source/Core/VideoBackends/Software/TextureCache.h
@@ -12,15 +12,15 @@ class TextureCache : public TextureCacheBase
 protected:
   void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
                u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride, const EFBRectangle& src_rect,
-               bool scale_by_half, float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
-               const EFBCopyFilterCoefficients& filter_coefficients) override
+               bool scale_by_half, bool linear_filter, float y_scale, float gamma, bool clamp_top,
+               bool clamp_bottom, const EFBCopyFilterCoefficients& filter_coefficients) override
   {
     TextureEncoder::Encode(dst, params, native_width, bytes_per_row, num_blocks_y, memory_stride,
                            src_rect, scale_by_half, y_scale, gamma);
   }
   void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy, const EFBRectangle& src_rect,
-                           bool scale_by_half, EFBCopyFormat dst_format, bool is_intensity,
-                           float gamma, bool clamp_top, bool clamp_bottom,
+                           bool scale_by_half, bool linear_filter, EFBCopyFormat dst_format,
+                           bool is_intensity, float gamma, bool clamp_top, bool clamp_bottom,
                            const EFBCopyFilterCoefficients& filter_coefficients) override
   {
     // TODO: If we ever want to "fake" vram textures, we would need to implement this

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -113,7 +113,6 @@ void AsyncRequests::SetEnable(bool enable)
 
 void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 {
-  EFBRectangle rc;
   switch (e.type)
   {
   case Event::EFB_POKE_COLOR:
@@ -145,7 +144,7 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 
   case Event::SWAP_EVENT:
     g_renderer->Swap(e.swap_event.xfbAddr, e.swap_event.fbWidth, e.swap_event.fbStride,
-                     e.swap_event.fbHeight, rc, e.time);
+                     e.swap_event.fbHeight, e.time);
     break;
 
   case Event::BBOX_READ:

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -312,14 +312,13 @@ static void BPWritten(const BPCmd& bp)
       if (g_ActiveConfig.bImmediateXFB)
       {
         // below div two to convert from bytes to pixels - it expects width, not stride
-        g_renderer->Swap(destAddr, destStride / 2, destStride / 2, height, srcRect,
-                         CoreTiming::GetTicks());
+        g_renderer->Swap(destAddr, destStride / 2, destStride, height, CoreTiming::GetTicks());
       }
       else
       {
         if (FifoPlayer::GetInstance().IsRunningWithFakeVideoInterfaceUpdates())
         {
-          VideoInterface::FakeVIUpdate(destAddr, srcRect.GetWidth(), height);
+          VideoInterface::FakeVIUpdate(destAddr, srcRect.GetWidth(), destStride, height);
         }
       }
     }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -213,8 +213,7 @@ public:
   virtual void WaitForGPUIdle() {}
 
   // Finish up the current frame, print some stats
-  void Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
-            u64 ticks);
+  void Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u64 ticks);
 
   // Draws the specified XFB buffer to the screen, performing any post-processing.
   // Assumes that the backbuffer has already been bound and cleared.
@@ -350,10 +349,7 @@ private:
   bool m_last_frame_exported = false;
 
   // Tracking of XFB textures so we don't render duplicate frames.
-  AbstractTexture* m_last_xfb_texture = nullptr;
   u64 m_last_xfb_id = std::numeric_limits<u64>::max();
-  u64 m_last_xfb_ticks = 0;
-  EFBRectangle m_last_xfb_region;
 
   // Note: Only used for auto-ir
   u32 m_last_xfb_width = MAX_XFB_WIDTH;
@@ -377,7 +373,8 @@ private:
   bool CheckFrameDumpReadbackTexture(u32 target_width, u32 target_height);
 
   // Fills the frame dump staging texture with the current XFB texture.
-  void DumpCurrentFrame();
+  void DumpCurrentFrame(const AbstractTexture* src_texture,
+                        const MathUtil::Rectangle<int>& src_rect, u64 ticks);
 
   // Asynchronously encodes the specified pointer of frame data to the frame dump.
   void DumpFrameData(const u8* data, int w, int h, int stride, const AVIDump::Frame& state);

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -393,18 +393,6 @@ TextureCacheBase::DoPartialTextureUpdates(TCacheEntry* entry_to_update, u8* pale
           dst_y = 0;
         }
 
-        // If the source rectangle is outside of what we actually have in VRAM, skip the copy.
-        // The backend doesn't do any clamping, so if we don't, we'd pass out-of-range coordinates
-        // to the graphics driver, which can cause GPU resets.
-        if (static_cast<u32>(src_x) >= entry->native_width ||
-            static_cast<u32>(src_y) >= entry->native_height ||
-            static_cast<u32>(dst_x) >= entry_to_update->native_width ||
-            static_cast<u32>(dst_y) >= entry_to_update->native_height)
-        {
-          ++iter.first;
-          continue;
-        }
-
         u32 copy_width =
             std::min(entry->native_width - src_x, entry_to_update->native_width - dst_x);
         u32 copy_height =
@@ -427,6 +415,18 @@ TextureCacheBase::DoPartialTextureUpdates(TCacheEntry* entry_to_update, u8* pale
           dst_y = g_renderer->EFBToScaledY(dst_y);
           copy_width = g_renderer->EFBToScaledX(copy_width);
           copy_height = g_renderer->EFBToScaledY(copy_height);
+        }
+
+        // If the source rectangle is outside of what we actually have in VRAM, skip the copy.
+        // The backend doesn't do any clamping, so if we don't, we'd pass out-of-range coordinates
+        // to the graphics driver, which can cause GPU resets.
+        if (static_cast<u32>(src_x + copy_width) > entry->GetWidth() ||
+            static_cast<u32>(src_y + copy_height) > entry->GetHeight() ||
+            static_cast<u32>(dst_x + copy_width) > entry_to_update->GetWidth() ||
+            static_cast<u32>(dst_y + copy_height) > entry_to_update->GetHeight())
+        {
+          ++iter.first;
+          continue;
         }
 
         MathUtil::Rectangle<int> srcrect, dstrect;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -77,42 +77,6 @@ struct EFBCopyFilterCoefficients
   float lower;
 };
 
-struct TextureLookupInformation
-{
-  u32 address;
-
-  u32 block_width;
-  u32 block_height;
-  u32 bytes_per_block;
-
-  u32 expanded_width;
-  u32 expanded_height;
-  u32 native_width;
-  u32 native_height;
-  u32 total_bytes;
-  u32 native_levels = 1;
-  u32 computed_levels;
-
-  u64 base_hash;
-  u64 full_hash;
-
-  TextureAndTLUTFormat full_format;
-  u32 tlut_address = 0;
-
-  bool is_palette_texture = false;
-  u32 palette_size = 0;
-
-  bool use_mipmaps = false;
-
-  bool from_tmem = false;
-  u32 tmem_address_even = 0;
-  u32 tmem_address_odd = 0;
-
-  int texture_cache_safety_color_sample_size = 0;  // Default to safe hashing
-
-  u8* src_data;
-};
-
 class TextureCacheBase
 {
 private:
@@ -138,6 +102,7 @@ public:
                                       // content, aren't just downscaled
     bool should_force_safe_hashing = false;  // for XFB
     bool is_xfb_copy = false;
+    bool is_xfb_container = false;
     u64 id;
 
     bool reference_changed = false;  // used by xfb to determine when a reference xfb changed
@@ -243,20 +208,9 @@ public:
                           TLUTFormat tlutfmt = TLUTFormat::IA8, bool use_mipmaps = false,
                           u32 tex_levels = 1, bool from_tmem = false, u32 tmem_address_even = 0,
                           u32 tmem_address_odd = 0);
+  TCacheEntry* GetXFBTexture(u32 address, u32 width, u32 height, u32 stride,
+                             MathUtil::Rectangle<int>* display_rect);
 
-  TCacheEntry* GetXFBTexture(u32 address, u32 width, u32 height, TextureFormat texformat,
-                             int textureCacheSafetyColorSampleSize);
-  std::optional<TextureLookupInformation>
-  ComputeTextureInformation(u32 address, u32 width, u32 height, TextureFormat texformat,
-                            int textureCacheSafetyColorSampleSize, bool from_tmem,
-                            u32 tmem_address_even, u32 tmem_address_odd, u32 tlutaddr,
-                            TLUTFormat tlutfmt, u32 levels);
-  TCacheEntry* GetXFBFromCache(const TextureLookupInformation& tex_info);
-  TCacheEntry* GetTextureFromOverlappingTextures(const TextureLookupInformation& tex_info);
-  TCacheEntry* GetTextureFromMemory(const TextureLookupInformation& tex_info);
-  TCacheEntry* CreateNormalTexture(const TextureLookupInformation& tex_info, u32 layers);
-  void LoadTextureLevelZeroFromMemory(TCacheEntry* entry_to_update,
-                                      const TextureLookupInformation& tex_info, bool decode_on_gpu);
   virtual void BindTextures();
   void CopyRenderTargetToTexture(u32 dstAddr, EFBCopyFormat dstFormat, u32 width, u32 height,
                                  u32 dstStride, bool is_depth_copy, const EFBRectangle& srcRect,
@@ -322,10 +276,13 @@ private:
 
   void SetBackupConfig(const VideoConfig& config);
 
+  TCacheEntry* GetXFBFromCache(u32 address, u32 width, u32 height, u32 stride, u64 hash);
+
   TCacheEntry* ApplyPaletteToEntry(TCacheEntry* entry, u8* palette, TLUTFormat tlutfmt);
 
   TCacheEntry* DoPartialTextureUpdates(TCacheEntry* entry_to_update, u8* palette,
                                        TLUTFormat tlutfmt);
+  void StitchXFBCopy(TCacheEntry* entry_to_update);
 
   void DumpTexture(TCacheEntry* entry, std::string basename, unsigned int level, bool is_arbitrary);
   void CheckTempSize(size_t required_size);

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -243,13 +243,13 @@ protected:
 
   virtual void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
                        u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                       const EFBRectangle& src_rect, bool scale_by_half, float y_scale, float gamma,
-                       bool clamp_top, bool clamp_bottom,
+                       const EFBRectangle& src_rect, bool scale_by_half, bool linear_filter,
+                       float y_scale, float gamma, bool clamp_top, bool clamp_bottom,
                        const EFBCopyFilterCoefficients& filter_coefficients);
   virtual void CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_copy,
                                    const EFBRectangle& src_rect, bool scale_by_half,
-                                   EFBCopyFormat dst_format, bool is_intensity, float gamma,
-                                   bool clamp_top, bool clamp_bottom,
+                                   bool linear_filter, EFBCopyFormat dst_format, bool is_intensity,
+                                   float gamma, bool clamp_top, bool clamp_bottom,
                                    const EFBCopyFilterCoefficients& filter_coefficients);
 
   alignas(16) u8* temp = nullptr;

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -116,6 +116,7 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
                             TextureFormat texformat, const u8* tlut, TLUTFormat tlutfmt);
 void TexDecoder_DecodeTexelRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb, int s, int t,
                                          int imageWidth);
+void TexDecoder_DecodeXFB(u8* dst, const u8* src, u32 width, u32 height, u32 stride);
 
 void TexDecoder_SetTexFmtOverlayOptions(bool enable, bool center);
 

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -751,3 +751,41 @@ void TexDecoder_DecodeRGBA8FromTmem(u8* dst, const u8* src_ar, const u8* src_gb,
     }
   }
 }
+
+void TexDecoder_DecodeXFB(u8* dst, const u8* src, u32 width, u32 height, u32 stride)
+{
+  const u8* src_ptr = src;
+  u8* dst_ptr = dst;
+
+  for (u32 y = 0; y < height; y++)
+  {
+    const u8* row_ptr = src_ptr;
+    for (u32 x = 0; x < width; x += 2)
+    {
+      // We do this one color sample (aka 2 RGB pixels) at a time
+      int Y1 = int(*(row_ptr++)) - 16;
+      int U = int(*(row_ptr++)) - 128;
+      int Y2 = int(*(row_ptr++)) - 16;
+      int V = int(*(row_ptr++)) - 128;
+
+      // We do the inverse BT.601 conversion for YCbCr to RGB
+      // http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
+      u8 R1 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y1 + 1.596f * V), 0, 255));
+      u8 G1 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y1 - 0.392f * U - 0.813f * V), 0, 255));
+      u8 B1 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y1 + 2.017f * U), 0, 255));
+
+      u8 R2 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y2 + 1.596f * V), 0, 255));
+      u8 G2 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y2 - 0.392f * U - 0.813f * V), 0, 255));
+      u8 B2 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y2 + 2.017f * U), 0, 255));
+
+      u32 rgba = 0xff000000 | B1 << 16 | G1 << 8 | R1;
+      std::memcpy(dst_ptr, &rgba, sizeof(rgba));
+      dst_ptr += sizeof(rgba);
+      rgba = 0xff000000 | B2 << 16 | G2 << 8 | R2;
+      std::memcpy(dst_ptr, &rgba, sizeof(rgba));
+      dst_ptr += sizeof(rgba);
+    }
+
+    src_ptr += stride;
+  }
+}

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -346,5 +346,8 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, Text
       }
       break;
     }
+  case TextureFormat::XFB:
+    TexDecoder_DecodeXFB(reinterpret_cast<u8*>(dst), src, width, height, width * 2);
+    break;
   }
 }

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -1488,37 +1488,8 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, Text
     break;
 
   case TextureFormat::XFB:
-  {
-    for (int y = 0; y < height; y += 1)
-    {
-      for (int x = 0; x < width; x += 2)
-      {
-        size_t offset = static_cast<size_t>((y * width + x) * 2);
-
-        // We do this one color sample (aka 2 RGB pixles) at a time
-        int Y1 = int(src[offset]) - 16;
-        int U = int(src[offset + 1]) - 128;
-        int Y2 = int(src[offset + 2]) - 16;
-        int V = int(src[offset + 3]) - 128;
-
-        // We do the inverse BT.601 conversion for YCbCr to RGB
-        // http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
-        u8 R1 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y1 + 1.596f * V), 0, 255));
-        u8 G1 =
-            static_cast<u8>(MathUtil::Clamp(int(1.164f * Y1 - 0.392f * U - 0.813f * V), 0, 255));
-        u8 B1 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y1 + 2.017f * U), 0, 255));
-
-        u8 R2 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y2 + 1.596f * V), 0, 255));
-        u8 G2 =
-            static_cast<u8>(MathUtil::Clamp(int(1.164f * Y2 - 0.392f * U - 0.813f * V), 0, 255));
-        u8 B2 = static_cast<u8>(MathUtil::Clamp(int(1.164f * Y2 + 2.017f * U), 0, 255));
-
-        dst[y * width + x] = 0xff000000 | B1 << 16 | G1 << 8 | R1;
-        dst[y * width + x + 1] = 0xff000000 | B2 << 16 | G2 << 8 | R2;
-      }
-    }
-  }
-  break;
+    TexDecoder_DecodeXFB(reinterpret_cast<u8*>(dst), src, width, height, width * 2);
+    break;
 
   default:
     PanicAlert("Invalid Texture Format (0x%X)! (_TexDecoder_DecodeImpl)",


### PR DESCRIPTION
Currently, we don't consider the stride from the video interface when loading the XFB texture from memory. This results in textures which are twice the width being created, with both fields side-by-side. The data is then ignored as only the first half of the texture is actually displayed, but it's still incorrect. 

This PR changes things to create two cache entries, one for each field, and display them as the real hardware would.

ARM also had no CPU XFB decoding function, and with the GPUs not supporting texel buffers large enough, GPU decoding wasn't possible. So on Android, you likely just saw black screens for in-memory XFBs.

Lastly, we're still reliant on the force progressive hack, unless XFB2RAM is enabled. If XFB2RAM is disabled, you'll just get a purple screen, as for interlaced scanout, the stride won't match (copy stride will be half the scanout stride, as it's only displaying every second line). Otherwise, you can disable the hack, and see the half-vertical-resolution interlaced video in all its glory. See the comment in TextureCacheBase.cpp in StitchXFBCopy() for more info.