### PR TITLE
FramebufferManager: Only clear tile array when valid

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -407,15 +407,19 @@ void FramebufferManager::InvalidatePeekCache(bool forced)
 {
   if (forced || m_efb_color_cache.out_of_date)
   {
+    if (m_efb_color_cache.valid)
+      std::fill(m_efb_color_cache.tiles.begin(), m_efb_color_cache.tiles.end(), false);
+
     m_efb_color_cache.valid = false;
     m_efb_color_cache.out_of_date = false;
-    std::fill(m_efb_color_cache.tiles.begin(), m_efb_color_cache.tiles.end(), false);
   }
   if (forced || m_efb_depth_cache.out_of_date)
   {
+    if (m_efb_depth_cache.valid)
+      std::fill(m_efb_depth_cache.tiles.begin(), m_efb_depth_cache.tiles.end(), false);
+
     m_efb_depth_cache.valid = false;
     m_efb_depth_cache.out_of_date = false;
-    std::fill(m_efb_depth_cache.tiles.begin(), m_efb_depth_cache.tiles.end(), false);
   }
 }
 


### PR DESCRIPTION
When looking into the Faron Woods fifolog, I noticed this code was quite high in the profile (~10%). Clearing 4096 entries from the vector isn't needed every draw, we only need to do this when the cache was actually valid in the first place.

Should provide a slight general performance boost.