### PR TITLE
WIP: Implement in-game pause screen

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -167,6 +167,11 @@ void MappingWindow::UpdateProfileIndex()
 
   if (text_index == -1)
     m_profiles_combo->setCurrentText(current_text);
+  else
+  {
+    g_profile_manager.GetWiiDeviceProfileManager(GetPort())->SetProfile(
+        m_profiles_combo->currentIndex());
+  }
 }
 
 void MappingWindow::OnDeleteProfilePressed()
@@ -224,8 +229,6 @@ void MappingWindow::OnLoadProfilePressed()
     error.exec();
     return;
   }
-
-  g_profile_manager.GetWiiDeviceProfileManager(GetPort())->SetProfile(m_profiles_combo->currentIndex() - 1);
 
   emit ConfigChanged();
 }

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -256,44 +256,44 @@ void HotkeyScheduler::Run()
       }
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_1))
-        m_profile_cycler.PreviousWiimoteProfile(0);
+        g_profile_manager.GetWiiDeviceProfileManager(0)->PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_1))
-        m_profile_cycler.NextWiimoteProfile(0);
+        g_profile_manager.GetWiiDeviceProfileManager(0)->NextProfile();
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_2))
-        m_profile_cycler.PreviousWiimoteProfile(1);
+        g_profile_manager.GetWiiDeviceProfileManager(1)->PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_2))
-        m_profile_cycler.NextWiimoteProfile(1);
+        g_profile_manager.GetWiiDeviceProfileManager(1)->NextProfile();
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_3))
-        m_profile_cycler.PreviousWiimoteProfile(2);
+        g_profile_manager.GetWiiDeviceProfileManager(2)->PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_3))
-        m_profile_cycler.NextWiimoteProfile(2);
+        g_profile_manager.GetWiiDeviceProfileManager(2)->NextProfile();
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_4))
-        m_profile_cycler.PreviousWiimoteProfile(3);
+        g_profile_manager.GetWiiDeviceProfileManager(3)->PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_4))
-        m_profile_cycler.NextWiimoteProfile(3);
+        g_profile_manager.GetWiiDeviceProfileManager(3)->NextProfile();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_1))
-        m_profile_cycler.PreviousWiimoteProfileForGame(0);
+        g_profile_manager.GetWiiDeviceProfileManager(0)->PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_1))
-        m_profile_cycler.NextWiimoteProfileForGame(0);
+        g_profile_manager.GetWiiDeviceProfileManager(0)->NextProfileForGame();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_2))
-        m_profile_cycler.PreviousWiimoteProfileForGame(1);
+        g_profile_manager.GetWiiDeviceProfileManager(1)->PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_2))
-        m_profile_cycler.NextWiimoteProfileForGame(1);
+        g_profile_manager.GetWiiDeviceProfileManager(1)->NextProfileForGame();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_3))
-        m_profile_cycler.PreviousWiimoteProfileForGame(2);
+        g_profile_manager.GetWiiDeviceProfileManager(2)->PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_3))
-        m_profile_cycler.NextWiimoteProfileForGame(2);
+        g_profile_manager.GetWiiDeviceProfileManager(2)->NextProfileForGame();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_4))
-        m_profile_cycler.PreviousWiimoteProfileForGame(3);
+        g_profile_manager.GetWiiDeviceProfileManager(3)->PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_4))
-        m_profile_cycler.NextWiimoteProfileForGame(3);
+        g_profile_manager.GetWiiDeviceProfileManager(3)->NextProfileForGame();
 
       auto ShowVolume = []() {
         OSD::AddMessage(std::string("Volume: ") +

--- a/Source/Core/DolphinQt/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt/HotkeyScheduler.h
@@ -67,6 +67,4 @@ private:
 
   Common::Flag m_stop_requested;
   std::thread m_thread;
-
-  InputProfile::ProfileCycler m_profile_cycler;
 };

--- a/Source/Core/InputCommon/InputProfile.h
+++ b/Source/Core/InputCommon/InputProfile.h
@@ -11,6 +11,7 @@ namespace ControllerEmu
 class EmulatedController;
 }
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -19,35 +20,57 @@ namespace InputProfile
 std::vector<std::string> GetProfilesFromSetting(const std::string& setting,
                                                 const std::string& root);
 
-enum class CycleDirection : int
-{
-  Forward = 1,
-  Backward = -1
-};
-
-class ProfileCycler
+class DeviceProfileManager
 {
 public:
-  void NextWiimoteProfile(int controller_index);
-  void PreviousWiimoteProfile(int controller_index);
-  void NextWiimoteProfileForGame(int controller_index);
-  void PreviousWiimoteProfileForGame(int controller_index);
+  DeviceProfileManager(InputConfig* device_configuration, int controller_index,
+                       std::string setting_name);
+
+  static std::vector<std::string> GetProfilesForDevice(InputConfig* device_configuration);
+
+  void NextProfile();
+  void PreviousProfile();
+  void NextProfileForGame();
+  void PreviousProfileForGame();
+
+  bool SetProfile(int profile_index);
+  bool SetGameProfile(int profile_index);
+
+  void SetDefault();
+  void SetModified();
+
+  std::string GetProfileName() const;
 
 private:
-  void CycleProfile(CycleDirection cycle_direction, InputConfig* device_configuration,
-                    int& profile_index, int controller_index);
-  void CycleProfileForGame(CycleDirection cycle_direction, InputConfig* device_configuration,
-                           int& profile_index, const std::string& setting, int controller_index);
-  std::vector<std::string> GetProfilesForDevice(InputConfig* device_configuration);
-  std::string GetProfile(CycleDirection cycle_direction, int& profile_index,
-                         const std::vector<std::string>& profiles);
+  bool UpdateProfile(int index);
+  bool UpdateProfileForGame(int index, const std::string& setting);
+  std::string GetProfile(int index, const std::vector<std::string>& profiles);
   std::vector<std::string> GetMatchingProfilesFromSetting(const std::string& setting,
-                                                          const std::vector<std::string>& profiles,
-                                                          InputConfig* device_configuration);
+                                                          const std::vector<std::string>& profiles);
   void UpdateToProfile(const std::string& profile_filename,
                        ControllerEmu::EmulatedController* controller);
-  std::string GetWiimoteInputProfilesForGame(int controller_index);
+  std::string GetInputProfilesForGame();
 
-  int m_wiimote_profile_index = 0;
+  bool m_modified = false;
+  bool m_default = true;
+  int m_profile_index = 0;
+  int m_controller_index = 0;
+  std::string m_profile_path;
+  std::string m_controller_setting_name;
+  InputConfig* m_device_configuration;
+};
+
+class ProfileManager
+{
+public:
+  ProfileManager();
+  DeviceProfileManager* GetGCDeviceProfileManager(int controller_index);
+  DeviceProfileManager* GetWiiDeviceProfileManager(int controller_index);
+
+private:
+  std::array<DeviceProfileManager, 4> m_wii_devices;
+  std::array<DeviceProfileManager, 4> m_gc_devices;
 };
 }  // namespace InputProfile
+
+extern InputProfile::ProfileManager g_profile_manager;

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(videocommon
   NetPlayGolfUI.cpp
   OnScreenDisplay.cpp
   OpcodeDecoding.cpp
+  PauseScreen.cpp
   PerfQueryBase.cpp
   PixelEngine.cpp
   PixelShaderGen.cpp

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -296,24 +296,21 @@ void RunGpuLoop()
   AsyncRequests::GetInstance()->SetEnable(true);
   AsyncRequests::GetInstance()->SetPassthrough(false);
 
+  PauseScreen pause_screen;
+
   s_gpu_mainloop.Run(
-      [] {
-        static std::unique_ptr<PauseScreen> pause_screen;
+      [&pause_screen] {
         const SConfig& param = SConfig::GetInstance();
 
         // Display pause screen while paused
         if (!s_emu_running_state.IsSet())
         {
-          if (!pause_screen)
-          {
-            pause_screen = std::make_unique<PauseScreen>();
-          }
-          pause_screen->Display();
+          pause_screen.Display();
           return;
         }
-        else if (pause_screen)
+        else if (pause_screen.IsVisible())
         {
-          pause_screen.reset();
+          pause_screen.Hide();
         }
 
         if (s_use_deterministic_gpu_thread)

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -25,6 +25,7 @@
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/DataReader.h"
+#include "VideoCommon/PauseScreen.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
@@ -297,11 +298,23 @@ void RunGpuLoop()
 
   s_gpu_mainloop.Run(
       [] {
+        static std::unique_ptr<PauseScreen> pause_screen;
         const SConfig& param = SConfig::GetInstance();
 
-        // Do nothing while paused
+        // Display pause screen while paused
         if (!s_emu_running_state.IsSet())
+        {
+          if (!pause_screen)
+          {
+            pause_screen = std::make_unique<PauseScreen>();
+          }
+          pause_screen->Display();
           return;
+        }
+        else if (pause_screen)
+        {
+          pause_screen.reset();
+        }
 
         if (s_use_deterministic_gpu_thread)
         {

--- a/Source/Core/VideoCommon/PauseScreen.cpp
+++ b/Source/Core/VideoCommon/PauseScreen.cpp
@@ -38,7 +38,6 @@ PauseScreen::~PauseScreen()
 void PauseScreen::Hide()
 {
   ImGuiIO& io = ImGui::GetIO();
-  // io.WantCaptureKeyboard = false;
   io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;
   io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableKeyboard;
   io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
@@ -86,7 +85,6 @@ void PauseScreen::Display()
 
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
     io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
-    // io.WantCaptureKeyboard = true;
     g_controller_interface.UpdateInput();
     UpdateControls(io);
     g_renderer->EndUIFrame();

--- a/Source/Core/VideoCommon/PauseScreen.cpp
+++ b/Source/Core/VideoCommon/PauseScreen.cpp
@@ -1,7 +1,9 @@
 #include "PauseScreen.h"
 
+#include "Common/Config/Config.h"
 #include "Common/MsgHandler.h"
 
+#include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/GCPad.h"
@@ -184,7 +186,60 @@ void PauseScreen::DisplayOptions()
 
 void PauseScreen::DisplayGraphics()
 {
-  // TODO:
+  // IR selection
+  auto ir = Config::Get(Config::GFX_EFB_SCALE);
+  static const std::array<const char*, 9> ir_choices{
+      "Auto (Multiple of 640x528)",      "Native (640x528)",
+      "2x Native (1280x1056) for 720p",  "3x Native (1920x1584) for 1080p",
+      "4x Native (2560x2112) for 1440p", "5x Native (3200x2640)",
+      "6x Native (3840x3168) for 4K",    "7x Native (4480x3696)",
+      "8x Native (5120x4224) for 5K"};
+  ImGui::Text("Internal Resolution:");
+  ImGui::SameLine(0);
+  if (ImGui::ArrowButton("##l-ir", ImGuiDir_Left))
+  {
+    ir--;
+    if (ir < 0)
+    {
+      ir = 0;
+    }
+  }
+  ImGui::SameLine(0);
+  if (ir > ir_choices.size())
+  {
+    ImGui::Text("Custom");
+  }
+  else
+  {
+    ImGui::Text(ir_choices[ir]);
+  }
+  ImGui::SameLine(0);
+  if (ImGui::ArrowButton("##r-ir", ImGuiDir_Right))
+  {
+    ir++;
+  }
+  Config::SetBaseOrCurrent(Config::GFX_EFB_SCALE, ir);
+
+  // Anisotropy
+  auto anisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
+  static const std::array<const char*, 9> anisotropy_choices{"1x", "2x", "4x", "8x", "16x"};
+  ImGui::Text("Anisotropy:");
+  ImGui::SameLine(0);
+  if (ImGui::ArrowButton("##l-ani", ImGuiDir_Left))
+  {
+    anisotropy--;
+    anisotropy = std::clamp(anisotropy, 0, static_cast<int>(anisotropy_choices.size()));
+  }
+  ImGui::SameLine(0);
+  ImGui::Text(anisotropy_choices[anisotropy]);
+  ImGui::SameLine(0);
+  if (ImGui::ArrowButton("##r-ani", ImGuiDir_Right))
+  {
+    anisotropy++;
+    anisotropy = std::clamp(anisotropy, 0, static_cast<int>(anisotropy_choices.size()));
+  }
+  ImGui::SameLine(0);
+  Config::SetBaseOrCurrent(Config::GFX_ENHANCE_MAX_ANISOTROPY, anisotropy);
 }
 
 void PauseScreen::DisplayControls()
@@ -283,4 +338,3 @@ void PauseScreen::DisplayWiiControls()
     }
   }
 }
-

--- a/Source/Core/VideoCommon/PauseScreen.cpp
+++ b/Source/Core/VideoCommon/PauseScreen.cpp
@@ -1,12 +1,34 @@
 #include "PauseScreen.h"
 
 #include "Core/Core.h"
+#include "Core/HW/GCPad.h"
+#include "Core/HW/GCPadEmu.h"
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "Common/MsgHandler.h"
+#include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/Setting/BooleanSetting.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
+#include "InputCommon/ControllerEmu/StickGate.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "VideoCommon/RenderBase.h"
 
 #include "imgui.h"
+
+namespace
+{
+static const u16 wiimote_dpad_bitmasks[] = {WiimoteEmu::Wiimote::PAD_UP, WiimoteEmu::Wiimote::PAD_DOWN,
+                                    WiimoteEmu::Wiimote::PAD_LEFT, WiimoteEmu::Wiimote::PAD_RIGHT};
+
+static const u16 wiimote_button_bitmasks[] = {
+    WiimoteEmu::Wiimote::BUTTON_A,     WiimoteEmu::Wiimote::BUTTON_B,
+    WiimoteEmu::Wiimote::BUTTON_ONE,   WiimoteEmu::Wiimote::BUTTON_TWO,
+    WiimoteEmu::Wiimote::BUTTON_MINUS, WiimoteEmu::Wiimote::BUTTON_PLUS,
+    WiimoteEmu::Wiimote::BUTTON_HOME};
+}  // namespace
 
 PauseScreen::~PauseScreen()
 {
@@ -16,9 +38,12 @@ PauseScreen::~PauseScreen()
 void PauseScreen::Hide()
 {
   ImGuiIO& io = ImGui::GetIO();
+  // io.WantCaptureKeyboard = false;
+  io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;
   io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableKeyboard;
   io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
   g_renderer->BeginUIFrame();
+  g_renderer->RenderUIFrame();
   g_renderer->EndUIFrame();
   m_visible = false;
 }
@@ -31,9 +56,6 @@ void PauseScreen::Display()
     m_visible = true;
   }
   ImGuiIO& io = ImGui::GetIO();
-  io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavEnableGamepad;
-  g_controller_interface.UpdateInput();
-  // io.NavInputs[ImGuiNavInput_DpadDown] = 1.0f;
 
   g_renderer->BeginUIFrame();
 
@@ -60,7 +82,46 @@ void PauseScreen::Display()
 
     ImGui::End();
     g_renderer->DrawLastXFBFrame();
+    g_renderer->RenderUIFrame();
+
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+    io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
+    // io.WantCaptureKeyboard = true;
+    g_controller_interface.UpdateInput();
+    UpdateControls(io);
     g_renderer->EndUIFrame();
+  }
+}
+
+void PauseScreen::UpdateControls(ImGuiIO& io)
+{
+  memset(io.NavInputs, 0, sizeof(io.NavInputs));
+
+  auto* wiimote_dpad_group = static_cast<ControllerEmu::Buttons*>(
+      Wiimote::GetWiimoteGroup(0, WiimoteEmu::WiimoteGroup::DPad));
+
+  u16 wiimote_dpad_buttons = 0;
+  wiimote_dpad_group->GetState(&wiimote_dpad_buttons, wiimote_dpad_bitmasks);
+
+  if ((wiimote_dpad_buttons & WiimoteEmu::Wiimote::PAD_DOWN) != 0)
+  {
+    io.NavInputs[ImGuiNavInput_DpadDown] = 1.0f;
+  }
+
+  if ((wiimote_dpad_buttons & WiimoteEmu::Wiimote::PAD_UP) != 0)
+  {
+    io.NavInputs[ImGuiNavInput_DpadUp] = 1.0f;
+  }
+
+  auto* wiimote_buttons_group = static_cast<ControllerEmu::Buttons*>(
+      Wiimote::GetWiimoteGroup(0, WiimoteEmu::WiimoteGroup::Buttons));
+
+  u16 wiimote_buttons = 0;
+  wiimote_buttons_group->GetState(&wiimote_buttons, wiimote_button_bitmasks);
+
+  if ((wiimote_buttons & WiimoteEmu::Wiimote::BUTTON_A) != 0)
+  {
+    io.NavInputs[ImGuiNavInput_Activate] = 1.0f;
   }
 }
 

--- a/Source/Core/VideoCommon/PauseScreen.cpp
+++ b/Source/Core/VideoCommon/PauseScreen.cpp
@@ -259,7 +259,8 @@ void PauseScreen::DisplayWiiControls()
       }
       else
       {
-        ImGui::Text("PROFILE NAME");
+        const auto name = g_profile_manager.GetWiiDeviceProfileManager(i)->GetProfileName();
+        ImGui::Text(name.c_str());
       }
       ImGui::NextColumn();
       if (i == WIIMOTE_BALANCE_BOARD)
@@ -270,12 +271,12 @@ void PauseScreen::DisplayWiiControls()
       {
         if (ImGui::Button("Prev"))
         {
-          m_profile_cycler.PreviousWiimoteProfile(i);
+          g_profile_manager.GetWiiDeviceProfileManager(i)->PreviousProfile();
         }
         ImGui::SameLine();
         if (ImGui::Button("Next"))
         {
-          m_profile_cycler.NextWiimoteProfile(i);
+          g_profile_manager.GetWiiDeviceProfileManager(i)->NextProfile();
         }
       }
       ImGui::NextColumn();

--- a/Source/Core/VideoCommon/PauseScreen.cpp
+++ b/Source/Core/VideoCommon/PauseScreen.cpp
@@ -8,26 +8,32 @@
 
 #include "imgui.h"
 
-PauseScreen::PauseScreen()
+PauseScreen::~PauseScreen()
 {
-  m_state_stack.push(ScreenState::Main);
+  Hide();
 }
 
-PauseScreen::~PauseScreen()
+void PauseScreen::Hide()
 {
   ImGuiIO& io = ImGui::GetIO();
   io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableKeyboard;
   io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
   g_renderer->BeginUIFrame();
   g_renderer->EndUIFrame();
+  m_visible = false;
 }
 
 void PauseScreen::Display()
 {
+  if (!m_visible)
+  {
+    m_state_stack.push(ScreenState::Main);
+    m_visible = true;
+  }
   ImGuiIO& io = ImGui::GetIO();
   io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavEnableGamepad;
   g_controller_interface.UpdateInput();
-  //io.NavInputs[ImGuiNavInput_DpadDown] = 1.0f;
+  // io.NavInputs[ImGuiNavInput_DpadDown] = 1.0f;
 
   g_renderer->BeginUIFrame();
 

--- a/Source/Core/VideoCommon/PauseScreen.cpp
+++ b/Source/Core/VideoCommon/PauseScreen.cpp
@@ -1,0 +1,106 @@
+#include "PauseScreen.h"
+
+#include "Core/Core.h"
+
+#include "Common/MsgHandler.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "VideoCommon/RenderBase.h"
+
+#include "imgui.h"
+
+PauseScreen::PauseScreen()
+{
+  m_state_stack.push(ScreenState::Main);
+}
+
+PauseScreen::~PauseScreen()
+{
+  ImGuiIO& io = ImGui::GetIO();
+  io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableKeyboard;
+  io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
+  g_renderer->BeginUIFrame();
+  g_renderer->EndUIFrame();
+}
+
+void PauseScreen::Display()
+{
+  ImGuiIO& io = ImGui::GetIO();
+  io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavEnableGamepad;
+  g_controller_interface.UpdateInput();
+  //io.NavInputs[ImGuiNavInput_DpadDown] = 1.0f;
+
+  g_renderer->BeginUIFrame();
+
+  const float scale = io.DisplayFramebufferScale.x;
+  ImGui::SetNextWindowSize(ImVec2(400.0f * scale, 100.0f * scale), ImGuiCond_Always);
+  ImGui::SetNextWindowPosCenter(ImGuiCond_Always);
+  if (ImGui::Begin(GetStringT("Pause Screen").c_str(), nullptr,
+                   ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove |
+                       ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar |
+                       ImGuiWindowFlags_AlwaysAutoResize))
+  {
+    switch (m_state_stack.top())
+    {
+    case ScreenState::Main:
+      DisplayMain();
+      break;
+    case ScreenState::Options:
+      DisplayOptions();
+      break;
+    case ScreenState::Profiles:
+      DisplayProfiles();
+      break;
+    }
+
+    ImGui::End();
+    g_renderer->DrawLastXFBFrame();
+    g_renderer->EndUIFrame();
+  }
+}
+
+void PauseScreen::DisplayMain()
+{
+  if (ImGui::Button("Resume Emulation"))
+  {
+    Core::SetState(Core::State::Running);
+  }
+  else if (ImGui::Button("Options"))
+  {
+    m_state_stack.push(ScreenState::Options);
+  }
+  else if (ImGui::Button("Quit Dolphin"))
+  {
+    PanicAlert("Exit called...");
+  }
+}
+
+void PauseScreen::DisplayOptions()
+{
+  if (ImGui::Button("Wii Controller Profiles"))
+  {
+    m_state_stack.push(ScreenState::Profiles);
+  }
+  else if (ImGui::Button("Back..."))
+  {
+    m_state_stack.pop();
+  }
+}
+
+void PauseScreen::DisplayProfiles()
+{
+  // TODO: Get current profile name...
+  // TODO: Handle multiple controllers...
+
+  if (ImGui::Button("Previous Wiimote (1) Profile"))
+  {
+    m_profile_cycler.PreviousWiimoteProfile(0);
+  }
+  else if (ImGui::Button("Next Wiimote (1) Profile"))
+  {
+    m_profile_cycler.NextWiimoteProfile(0);
+  }
+  else if (ImGui::Button("Back..."))
+  {
+    m_state_stack.pop();
+  }
+}

--- a/Source/Core/VideoCommon/PauseScreen.h
+++ b/Source/Core/VideoCommon/PauseScreen.h
@@ -32,8 +32,5 @@ private:
 
   std::stack<ScreenState> m_state_stack;
 
-  // TODO: sync this with the cycler in HotkeyScheduler...
-  InputProfile::ProfileCycler m_profile_cycler;
-
   bool m_visible = false;
 };

--- a/Source/Core/VideoCommon/PauseScreen.h
+++ b/Source/Core/VideoCommon/PauseScreen.h
@@ -4,6 +4,8 @@
 
 #include <stack>
 
+struct ImGuiIO;
+
 class PauseScreen
 {
 public:
@@ -13,6 +15,7 @@ public:
   bool IsVisible() const { return m_visible; }
 
 private:
+  void UpdateControls(ImGuiIO&);
   void DisplayMain();
   void DisplayOptions();
   void DisplayProfiles();

--- a/Source/Core/VideoCommon/PauseScreen.h
+++ b/Source/Core/VideoCommon/PauseScreen.h
@@ -18,13 +18,16 @@ private:
   void UpdateControls(ImGuiIO&);
   void DisplayMain();
   void DisplayOptions();
-  void DisplayProfiles();
+  void DisplayGraphics();
+  void DisplayControls();
+  void DisplayWiiControls();
 
   enum class ScreenState
   {
     Main,
     Options,
-    Profiles
+    Graphics,
+    Controls
   };
 
   std::stack<ScreenState> m_state_stack;

--- a/Source/Core/VideoCommon/PauseScreen.h
+++ b/Source/Core/VideoCommon/PauseScreen.h
@@ -15,7 +15,18 @@ public:
   bool IsVisible() const { return m_visible; }
 
 private:
-  void UpdateControls(ImGuiIO&);
+  void UpdateControls(ImGuiIO& io);
+
+  // Wiimote controls
+  void UpdateWiimoteDpad(ImGuiIO& io);
+  void UpdateWiimoteButtons(ImGuiIO& io, bool& back_pressed);
+
+  // Wiimote accessory controls
+  void UpdateWiimoteNunchukStick(ImGuiIO& io);
+  void UpdateClassicControllerStick(ImGuiIO& io);
+  void UpdateClassicControllerDPad(ImGuiIO& io);
+  void UpdateClassicControllerButtons(ImGuiIO& io, bool& back_pressed);
+
   void DisplayMain();
   void DisplayOptions();
   void DisplayGraphics();

--- a/Source/Core/VideoCommon/PauseScreen.h
+++ b/Source/Core/VideoCommon/PauseScreen.h
@@ -6,6 +6,9 @@
 
 struct ImGuiIO;
 
+void InitPauseScreenThread();
+void ShutdownPauseScreenThread();
+
 class PauseScreen
 {
 public:
@@ -19,13 +22,13 @@ private:
 
   // Wiimote controls
   void UpdateWiimoteDpad(ImGuiIO& io);
-  void UpdateWiimoteButtons(ImGuiIO& io, bool& back_pressed);
+  void UpdateWiimoteButtons(ImGuiIO& io, bool& back_pressed, bool &accept_pressed);
 
   // Wiimote accessory controls
   void UpdateWiimoteNunchukStick(ImGuiIO& io);
   void UpdateClassicControllerStick(ImGuiIO& io);
   void UpdateClassicControllerDPad(ImGuiIO& io);
-  void UpdateClassicControllerButtons(ImGuiIO& io, bool& back_pressed);
+  void UpdateClassicControllerButtons(ImGuiIO& io, bool& back_pressed, bool& accept_pressed);
 
   void DisplayMain();
   void DisplayOptions();
@@ -44,4 +47,6 @@ private:
   std::stack<ScreenState> m_state_stack;
 
   bool m_visible = false;
+  bool m_back_held = false;
+  bool m_accept_held = false;
 };

--- a/Source/Core/VideoCommon/PauseScreen.h
+++ b/Source/Core/VideoCommon/PauseScreen.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "InputCommon/InputProfile.h"
+
+#include <stack>
+
+class PauseScreen
+{
+public:
+  PauseScreen();
+  ~PauseScreen();
+  void Display();
+
+private:
+  void DisplayMain();
+  void DisplayOptions();
+  void DisplayProfiles();
+
+  enum class ScreenState
+  {
+    Main,
+    Options,
+    Profiles
+  };
+
+  std::stack<ScreenState> m_state_stack;
+
+  // TODO: sync this with the cycler in HotkeyScheduler...
+  InputProfile::ProfileCycler m_profile_cycler;
+};

--- a/Source/Core/VideoCommon/PauseScreen.h
+++ b/Source/Core/VideoCommon/PauseScreen.h
@@ -7,9 +7,10 @@
 class PauseScreen
 {
 public:
-  PauseScreen();
   ~PauseScreen();
   void Display();
+  void Hide();
+  bool IsVisible() const { return m_visible; }
 
 private:
   void DisplayMain();
@@ -27,4 +28,6 @@ private:
 
   // TODO: sync this with the cycler in HotkeyScheduler...
   InputProfile::ProfileCycler m_profile_cycler;
+
+  bool m_visible = false;
 };

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1198,6 +1198,7 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
     if (xfb_entry && xfb_entry->id != m_last_xfb_id)
     {
       m_last_xfb_id = xfb_entry->id;
+      m_last_xfb_texture = xfb_entry->texture.get();
 
       // Since we use the common pipelines here and draw vertices if a batch is currently being
       // built by the vertex loader, we end up trampling over its pointer, as we share the buffer

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1304,6 +1304,14 @@ void Renderer::RenderXFBToScreen(const AbstractTexture* texture, const MathUtil:
   }
 }
 
+void Renderer::DrawLastXFBFrame()
+{
+  if (m_last_xfb_texture)
+  {
+    RenderXFBToScreen(m_last_xfb_texture, m_last_xfb_region);
+  }
+}
+
 bool Renderer::IsFrameDumping()
 {
   if (m_screenshot_request.IsSet())

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1142,7 +1142,7 @@ void Renderer::RenderUIFrame()
   ImGui::Render();
 }
 
-void Renderer::EndUIFrame()
+void Renderer::EndUIFrame(bool start_another)
 {
   if (!IsHeadless())
   {
@@ -1153,7 +1153,10 @@ void Renderer::EndUIFrame()
     EndUtilityDrawing();
   }
 
-  BeginImGuiFrame();
+  if (start_another)
+  {
+    BeginImGuiFrame();
+  }
 }
 
 void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u64 ticks)
@@ -1198,6 +1201,7 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
     if (xfb_entry && xfb_entry->id != m_last_xfb_id)
     {
       m_last_xfb_id = xfb_entry->id;
+      m_last_xfb_region = xfb_rect;
       m_last_xfb_texture = xfb_entry->texture.get();
 
       // Since we use the common pipelines here and draw vertices if a batch is currently being

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1136,13 +1136,14 @@ void Renderer::BeginUIFrame()
   BindBackbuffer({0.0f, 0.0f, 0.0f, 1.0f});
 }
 
+void Renderer::RenderUIFrame()
+{
+  auto lock = GetImGuiLock();
+  ImGui::Render();
+}
+
 void Renderer::EndUIFrame()
 {
-  {
-    auto lock = GetImGuiLock();
-    ImGui::Render();
-  }
-
   if (!IsHeadless())
   {
     DrawImGui();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -242,6 +242,7 @@ public:
   // Begins/presents a "UI frame". UI frames do not draw any of the console XFB, but this could
   // change in the future.
   void BeginUIFrame();
+  void RenderUIFrame();
   void EndUIFrame();
 
   // Draw the last console XFB frame

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -244,6 +244,9 @@ public:
   void BeginUIFrame();
   void EndUIFrame();
 
+  // Draw the last console XFB frame
+  void DrawLastXFBFrame();
+
 protected:
   // Bitmask containing information about which configuration has changed for the backend.
   enum ConfigChangeBits : u32

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -243,7 +243,7 @@ public:
   // change in the future.
   void BeginUIFrame();
   void RenderUIFrame();
-  void EndUIFrame();
+  void EndUIFrame(bool start_another = true);
 
   // Draw the last console XFB frame
   void DrawLastXFBFrame();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -390,6 +390,10 @@ private:
   void FinishFrameData();
 
   std::unique_ptr<NetPlayChatUI> m_netplay_chat_ui;
+
+  // Needed for re-rendering a XFB screen
+  AbstractTexture* m_last_xfb_texture = nullptr;
+  MathUtil::Rectangle<int> m_last_xfb_region;
 };
 
 extern std::unique_ptr<Renderer> g_renderer;

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -169,7 +169,7 @@ void ShaderCache::WaitForAsyncCompiler()
                            ImVec2(-1.0f, 0.0f), "");
       }
       ImGui::End();
-
+      g_renderer->RenderUIFrame();
       g_renderer->EndUIFrame();
     });
     m_async_shader_compiler->RetrieveWorkItems();

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -37,6 +37,7 @@
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/OpcodeDecoding.h"
+#include "VideoCommon/PauseScreen.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/RenderBase.h"
@@ -296,6 +297,12 @@ void VideoBackendBase::InitializeShared()
   GeometryShaderManager::Init();
   PixelShaderManager::Init();
 
+  // Only spawn a pause-screen thread if we're in single-core
+  if (!SConfig::GetInstance().bCPUThread)
+  {
+    InitPauseScreenThread();
+  }
+
   g_Config.VerifyValidity();
   UpdateActiveConfig();
 }
@@ -306,4 +313,8 @@ void VideoBackendBase::ShutdownShared()
 
   VertexLoaderManager::Clear();
   Fifo::Shutdown();
+  if (!SConfig::GetInstance().bCPUThread)
+  {
+    ShutdownPauseScreenThread();
+  }
 }

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="NetPlayGolfUI.cpp" />
     <ClCompile Include="OnScreenDisplay.cpp" />
     <ClCompile Include="OpcodeDecoding.cpp" />
+    <ClCompile Include="PauseScreen.cpp" />
     <ClCompile Include="PerfQueryBase.cpp" />
     <ClCompile Include="PixelEngine.cpp" />
     <ClCompile Include="PixelShaderGen.cpp" />
@@ -135,6 +136,7 @@
     <ClInclude Include="NativeVertexFormat.h" />
     <ClInclude Include="OnScreenDisplay.h" />
     <ClInclude Include="OpcodeDecoding.h" />
+    <ClInclude Include="PauseScreen.h" />
     <ClInclude Include="PerfQueryBase.h" />
     <ClInclude Include="PixelEngine.h" />
     <ClInclude Include="PixelShaderGen.h" />


### PR DESCRIPTION
I've been looking for more ways to improve my experience of streaming games from my computer to TV and one way is to not take the user out of the game experience by having to go to the UI.  While hotkeys are provided, remembering all the key combinations can be frustrating.

Here's a very rough attempt at a "pause screen" when the user pauses the emulation.  It's currently using IMGUI so expect the visuals to be rather bland but it should serve as a starting point if we think it's a worthwhile idea.

TODO:

- [x] Emulated wiimote controls menu
- [ ] Account for upright/sideways wiimote
- [x] Emulated nunchuk controls menu
- [x] Emulated classic controller controls menu
- [ ] Real wiimote controls menu
- [ ] Emulated gamecube controller controls menu
- [x] Don't allow 'hold' button presses for confirm/back buttons
- [x] Display Wii controller profile chosen in profiles sub-menu
- [x] Implement graphics menu options
- [ ] Decide how to exit cleanly when the exit logic is chosen
- [x] Remove dual core requirement
- [ ] Fix occasional IMGUI panic
- [x] Finish profile changes and port to a separate PR (see #8305 )
- [ ] Cleanup and get approval for UI
