### PR TITLE
FFV1: Set coder and level to 1

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -190,6 +190,8 @@ bool AVIDump::CreateVideoFile()
   s_codec_context->height = s_height;
   s_codec_context->time_base.num = 1;
   s_codec_context->time_base.den = VideoInterface::GetTargetRefreshRate();
+  s_stream->codec->level = 1;
+  s_stream->codec->coder_type = 1;
   s_codec_context->gop_size = 1;
   s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGR0 : AV_PIX_FMT_YUV420P;
 


### PR DESCRIPTION
This boosts compatibility with legacy decoders as well.
https://bugs.dolphin-emu.org/issues/11141#note-5

Explanation of those arguments:
https://trac.ffmpeg.org/wiki/Encode/FFV1