### PR TITLE
FramebufferManager: Fix EFB peek cache stretching last tile

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -569,8 +569,12 @@ void FramebufferManager::PopulateEFBCache(bool depth, u32 tile_index)
         {native_rect.left * rcp_src_width, native_rect.top * rcp_src_height,
          native_rect.GetWidth() * rcp_src_width, native_rect.GetHeight() * rcp_src_height}};
     g_vertex_manager->UploadUtilityUniforms(&uniforms, sizeof(uniforms));
+
+    // Viewport will not be TILE_SIZExTILE_SIZE for the last row of tiles, assuming a tile size of
+    // 64, because 528 is not evenly divisible by 64.
     g_renderer->SetAndDiscardFramebuffer(data.framebuffer.get());
-    g_renderer->SetViewportAndScissor(data.framebuffer->GetRect());
+    g_renderer->SetViewportAndScissor(
+        MathUtil::Rectangle<int>(0, 0, rect.GetWidth(), rect.GetHeight()));
     g_renderer->SetPipeline(data.copy_pipeline.get());
     g_renderer->SetTexture(0, src_texture);
     g_renderer->SetSamplerState(0, depth ? RenderState::GetPointSamplerState() :

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -743,7 +743,7 @@ void FramebufferManager::CreatePokeVertices(std::vector<EFBPokeVertex>* destinat
   const float x1 = static_cast<float>(x) * cs_pixel_width - 1.0f;
   const float y1 = 1.0f - static_cast<float>(y) * cs_pixel_height;
   const float x2 = x1 + cs_pixel_width;
-  const float y2 = y1 + cs_pixel_height;
+  const float y2 = y1 - cs_pixel_height;
   destination_list->push_back({{x1, y1, z, 1.0f}, color});
   destination_list->push_back({{x2, y1, z, 1.0f}, color});
   destination_list->push_back({{x1, y2, z, 1.0f}, color});


### PR DESCRIPTION
This was mainly visible in OpenGL, because of the lower-left origin, peeks for the top of the screen were incorrect. In the other backends, it's only really noticeable if a game uses the very bottom 16 pixels of the EFB.