### PR TITLE
NetPlay: Synchronize EFB access cache options

### DIFF
--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -65,6 +65,8 @@ public:
     layer->Set(Config::MAIN_SKIP_IPL, m_settings.m_SkipIPL);
     layer->Set(Config::MAIN_LOAD_IPL_DUMP, m_settings.m_LoadIPLDump);
     layer->Set(Config::GFX_HACK_DEFER_EFB_COPIES, m_settings.m_DeferEFBCopies);
+    layer->Set(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE, m_settings.m_EFBAccessTileSize);
+    layer->Set(Config::GFX_HACK_EFB_DEFER_INVALIDATION, m_settings.m_EFBAccessDeferInvalidation);
 
     if (m_settings.m_StrictSettingsSync)
     {

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -608,6 +608,8 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_ArbitraryMipmapDetectionThreshold;
       packet >> m_net_settings.m_EnableGPUTextureDecoding;
       packet >> m_net_settings.m_DeferEFBCopies;
+      packet >> m_net_settings.m_EFBAccessTileSize;
+      packet >> m_net_settings.m_EFBAccessDeferInvalidation;
       packet >> m_net_settings.m_StrictSettingsSync;
 
       m_initial_rtc = Common::PacketReadU64(packet);

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -75,6 +75,8 @@ struct NetSettings
   float m_ArbitraryMipmapDetectionThreshold;
   bool m_EnableGPUTextureDecoding;
   bool m_DeferEFBCopies;
+  bool m_EFBAccessTileSize;
+  bool m_EFBAccessDeferInvalidation;
   bool m_StrictSettingsSync;
   bool m_SyncSaveData;
   bool m_SyncCodes;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1208,6 +1208,8 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_ArbitraryMipmapDetectionThreshold;
   spac << m_settings.m_EnableGPUTextureDecoding;
   spac << m_settings.m_DeferEFBCopies;
+  spac << m_settings.m_EFBAccessTileSize;
+  spac << m_settings.m_EFBAccessDeferInvalidation;
   spac << m_settings.m_StrictSettingsSync;
   spac << initial_rtc;
   spac << m_settings.m_SyncSaveData;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -475,6 +475,8 @@ void NetPlayDialog::OnStart()
       Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD);
   settings.m_EnableGPUTextureDecoding = Config::Get(Config::GFX_ENABLE_GPU_TEXTURE_DECODING);
   settings.m_DeferEFBCopies = Config::Get(Config::GFX_HACK_DEFER_EFB_COPIES);
+  settings.m_EFBAccessTileSize = Config::Get(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE);
+  settings.m_EFBAccessDeferInvalidation = Config::Get(Config::GFX_HACK_EFB_DEFER_INVALIDATION);
   settings.m_StrictSettingsSync = m_strict_settings_sync_action->isChecked();
   settings.m_SyncSaveData = m_sync_save_data_action->isChecked();
   settings.m_SyncCodes = m_sync_codes_action->isChecked();


### PR DESCRIPTION
Defer EFB Cache Invalidation probably affects determinism in some cases, just like Defer EFB Copies, so it should be synchronized. EFB tile cache size is included only because it also probably affects determinism when defer invalidation is enabled.