### PR TITLE
Qt/HacksWidget: Fix backend feature support checks

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -124,11 +124,10 @@ void HacksWidget::OnBackendChanged(const QString& backend_name)
   m_gpu_texture_decoding->setEnabled(gpu_texture_decoding);
   m_disable_bounding_box->setEnabled(bbox);
 
-  if (!gpu_texture_decoding)
-    m_gpu_texture_decoding->setToolTip(tr("%1 doesn't support this feature.").arg(backend_name));
+  const QString tooltip = tr("%1 doesn't support this feature on your system.").arg(backend_name);
 
-  if (!bbox)
-    m_disable_bounding_box->setToolTip(tr("%1 doesn't support this feature.").arg(backend_name));
+  m_gpu_texture_decoding->setToolTip(!gpu_texture_decoding ? tooltip : QStringLiteral(""));
+  m_disable_bounding_box->setToolTip(!bbox ? tooltip : QStringLiteral(""));
 }
 
 void HacksWidget::ConnectWidgets()

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -91,10 +91,11 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsLargePoints = true;
   g_Config.backend_info.bSupportsPartialDepthCopies = true;
 
-  // TODO: There is a bug here, if texel buffers are not supported the graphics options
-  // will show the option when it is not supported. The only way around this would be
+  // TODO: There is a bug here, if texel buffers or SSBOs/atomics are not supported the graphics
+  // options will show the option when it is not supported. The only way around this would be
   // creating a context when calling this function to determine what is available.
   g_Config.backend_info.bSupportsGPUTextureDecoding = true;
+  g_Config.backend_info.bSupportsBBox = true;
 
   // Overwritten in Render.cpp later
   g_Config.backend_info.bSupportsDualSourceBlend = true;


### PR DESCRIPTION
The tooltip was not removed when the feature is detected as supported. OpenGL also claims to not support Bounding Box emulation, until a context is created to properly initialize the values. We'll just set the value to `true` by default like GPU Texture Decoding until this can be properly fixed.