### PR TITLE
Qt/GameList: Set consistent capitalization for context menu

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -273,19 +273,19 @@ void GameList::ShowContextMenu(const QPoint&)
     }
 
     if (compress)
-      menu->addAction(tr("Compress selected ISOs..."), this, [this] { CompressISO(false); });
+      menu->addAction(tr("Compress Selected ISOs..."), this, [this] { CompressISO(false); });
     if (decompress)
-      menu->addAction(tr("Decompress selected ISOs..."), this, [this] { CompressISO(true); });
+      menu->addAction(tr("Decompress Selected ISOs..."), this, [this] { CompressISO(true); });
     if (compress || decompress)
       menu->addSeparator();
 
     if (wii_saves)
     {
-      menu->addAction(tr("Export Wii saves (Experimental)"), this, &GameList::ExportWiiSave);
+      menu->addAction(tr("Export Wii Saves (Experimental)"), this, &GameList::ExportWiiSave);
       menu->addSeparator();
     }
 
-    menu->addAction(tr("Delete selected files..."), this, &GameList::DeleteFile);
+    menu->addAction(tr("Delete Selected Files..."), this, &GameList::DeleteFile);
   }
   else
   {
@@ -302,7 +302,7 @@ void GameList::ShowContextMenu(const QPoint&)
 
     if (platform == DiscIO::Platform::GameCubeDisc || platform == DiscIO::Platform::WiiDisc)
     {
-      menu->addAction(tr("Set as &default ISO"), this, &GameList::SetDefaultISO);
+      menu->addAction(tr("Set as &Default ISO"), this, &GameList::SetDefaultISO);
       const auto blob_type = game->GetBlobType();
 
       if (blob_type == DiscIO::BlobType::GCZ)
@@ -356,18 +356,18 @@ void GameList::ShowContextMenu(const QPoint&)
 
     if (platform == DiscIO::Platform::WiiWAD || platform == DiscIO::Platform::WiiDisc)
     {
-      menu->addAction(tr("Open Wii &save folder"), this, &GameList::OpenWiiSaveFolder);
-      menu->addAction(tr("Export Wii save (Experimental)"), this, &GameList::ExportWiiSave);
+      menu->addAction(tr("Open Wii &Save Folder"), this, &GameList::OpenWiiSaveFolder);
+      menu->addAction(tr("Export Wii Save (Experimental)"), this, &GameList::ExportWiiSave);
       menu->addSeparator();
     }
 
     if (platform == DiscIO::Platform::GameCubeDisc)
     {
-      menu->addAction(tr("Open GameCube &save folder"), this, &GameList::OpenGCSaveFolder);
+      menu->addAction(tr("Open GameCube &Save Folder"), this, &GameList::OpenGCSaveFolder);
       menu->addSeparator();
     }
 
-    menu->addAction(tr("Open &containing folder"), this, &GameList::OpenContainingFolder);
+    menu->addAction(tr("Open &Containing Folder"), this, &GameList::OpenContainingFolder);
     menu->addAction(tr("Delete File..."), this, &GameList::DeleteFile);
 
     menu->addSeparator();


### PR DESCRIPTION
Capitalizes mostly every word to be consistent with how the options in the menu bar are capitalized.