### PR TITLE
HW/SI: GCAdapter calibration fix.

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -18,6 +18,9 @@ namespace SerialInterface
 CSIDevice_GCAdapter::CSIDevice_GCAdapter(SIDevices device, int device_number)
     : CSIDevice_GCController(device, device_number)
 {
+  // Make sure PAD_GET_ORIGIN gets set due to a newly connected device.
+  GCAdapter::ResetDeviceType(m_device_number);
+
   // get the correct pad number that should rumble locally when using netplay
   const int pad_num = NetPlay_InGamePadToLocalPad(m_device_number);
   if (pad_num < 4)

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -485,6 +485,11 @@ bool DeviceConnected(int chan)
   return s_controller_type[chan] != ControllerTypes::CONTROLLER_NONE;
 }
 
+void ResetDeviceType(int chan)
+{
+  s_controller_type[chan] = ControllerTypes::CONTROLLER_NONE;
+}
+
 bool UseAdapter()
 {
   const auto& si_devices = SConfig::GetInstance().m_SIDevice;

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -29,6 +29,7 @@ void Output(int chan, u8 rumble_command);
 bool IsDetected();
 bool IsDriverDetected();
 bool DeviceConnected(int chan);
+void ResetDeviceType(int chan);
 bool UseAdapter();
 
 }  // end of namespace GCAdapter

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -382,6 +382,11 @@ bool DeviceConnected(int chan)
   return s_controller_type[chan] != ControllerTypes::CONTROLLER_NONE;
 }
 
+void ResetDeviceType(int chan)
+{
+  s_controller_type[chan] = ControllerTypes::CONTROLLER_NONE;
+}
+
 bool UseAdapter()
 {
   const auto& si_devices = SConfig::GetInstance().m_SIDevice;


### PR DESCRIPTION
GCAdapter's "controller type" is now reset on connection of the SI device which causes the PAD_GET_ORIGIN bit to be set like it is for newly attached physical controllers which triggers SetOrigin (calibration).

Native GC controllers now calibrate properly on 2nd run.

Fixes issue https://bugs.dolphin-emu.org/issues/11608