### PR TITLE
Qt/GameConfigEdit: Show warning if opening in an external editor fails

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -260,7 +260,12 @@ void GameConfigEdit::OpenExternalEditor()
     file.close();
   }
 
-  QDesktopServices::openUrl(QUrl::fromLocalFile(m_path));
+  if (!QDesktopServices::openUrl(QUrl::fromLocalFile(m_path)))
+  {
+    ModalMessageBox::warning(this, tr("Error"),
+                             tr("Failed to open file in external editor.\nMake sure there's an "
+                                "application assigned to open INI files."));
+  }
 }
 
 void GameConfigEdit::keyPressEvent(QKeyEvent* e)


### PR DESCRIPTION
Fixes [issue 11627](https://bugs.dolphin-emu.org/issues/11627).