### PR TITLE
Qt/MainWindow: Fix segfault on exit while NetPlay is open

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -256,6 +256,10 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
 
 MainWindow::~MainWindow()
 {
+  // Shut down NetPlay first to avoid race condition segfault
+  Settings::Instance().ResetNetPlayClient();
+  Settings::Instance().ResetNetPlayServer();
+
   delete m_render_widget;
   delete m_netplay_dialog;
 


### PR DESCRIPTION
We ensure the NetPlay client and server have been deleted (which shuts down their threads) before exiting, otherwise the NetPlay thread segfaults upon trying to access `m_dialog`.