### PR TITLE
UICommon/NetPlayIndex: Fix random segfaults after quitting NetPlay

### DIFF
--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -4,6 +4,7 @@
 
 #include "UICommon/NetPlayIndex.h"
 
+#include <chrono>
 #include <numeric>
 #include <string>
 
@@ -121,7 +122,7 @@ NetPlayIndex::List(const std::map<std::string, std::string>& filters)
 
 void NetPlayIndex::NotificationLoop()
 {
-  while (m_running.IsSet())
+  while (!m_session_thread_exit_event.WaitFor(std::chrono::seconds(5)))
   {
     Common::HttpRequest request;
     auto response = request.Get(
@@ -138,7 +139,6 @@ void NetPlayIndex::NotificationLoop()
     if (!json)
     {
       m_last_error = "BAD_JSON";
-      m_running.Set(false);
       return;
     }
 
@@ -147,18 +147,13 @@ void NetPlayIndex::NotificationLoop()
     if (status != "OK")
     {
       m_last_error = std::move(status);
-      m_running.Set(false);
       return;
     }
-
-    Common::SleepCurrentThread(1000 * 5);
   }
 }
 
 bool NetPlayIndex::Add(NetPlaySession session)
 {
-  m_running.Set(true);
-
   Common::HttpRequest request;
   auto response = request.Get(Config::Get(Config::NETPLAY_INDEX_URL) +
                                   "/v0/session/add?name=" + request.EscapeComponent(session.name) +
@@ -201,8 +196,6 @@ bool NetPlayIndex::Add(NetPlaySession session)
 
   m_session_thread = std::thread([this] { NotificationLoop(); });
 
-  m_session_thread.detach();
-
   return true;
 }
 
@@ -226,7 +219,7 @@ void NetPlayIndex::Remove()
   if (m_secret.empty())
     return;
 
-  m_running.Set(false);
+  m_session_thread_exit_event.Set();
 
   if (m_session_thread.joinable())
     m_session_thread.join();

--- a/Source/Core/UICommon/NetPlayIndex.h
+++ b/Source/Core/UICommon/NetPlayIndex.h
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include "Common/Flag.h"
+#include "Common/Event.h"
 
 struct NetPlaySession
 {
@@ -54,8 +54,6 @@ public:
 private:
   void NotificationLoop();
 
-  Common::Flag m_running;
-
   std::string m_secret;
   std::string m_game;
   int m_player_count = 0;
@@ -63,4 +61,6 @@ private:
 
   std::string m_last_error;
   std::thread m_session_thread;
+
+  Common::Event m_session_thread_exit_event;
 };


### PR DESCRIPTION
We can't join a detached thread, so NetPlayIndex gets deleted before the notification thread exits, creating a race condition. We switch to using Common::Event because just sleeping leaves the UI hung on the thread join for a few seconds.