### PR TITLE
Minor changes to usages of std::condition_variable.

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -19,6 +19,9 @@ AlsaSound::~AlsaSound()
 {
   m_thread_status.store(ALSAThreadStatus::STOPPING);
 
+  // Immediately lock and unlock mutex to prevent cv race.
+  std::unique_lock<std::mutex>{cv_m};
+
   // Give the opportunity to the audio thread
   // to realize we are stopping the emulation
   cv.notify_one();
@@ -81,7 +84,12 @@ void AlsaSound::SoundLoop()
 bool AlsaSound::SetRunning(bool running)
 {
   m_thread_status.store(running ? ALSAThreadStatus::RUNNING : ALSAThreadStatus::PAUSED);
-  cv.notify_one();  // Notify thread that status has changed
+
+  // Immediately lock and unlock mutex to prevent cv race.
+  std::unique_lock<std::mutex>{cv_m};
+
+  // Notify thread that status has changed
+  cv.notify_one();
   return true;
 }
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <array>
-#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>


### PR DESCRIPTION
AlsaSoundStream's condition variable usage did not hold the relevant mutex when notifying the worker thread. This had the unlikely potential to deadlock.

Immediately lock and unlock the mutex in `Event` to prevent the signaled thread from waiting on the mutex to be released. Unmeasurable performance increase, maybe?

RenderBase.h included <condition_variable> for no reason.