### PR TITLE
Set Cubeb as default on Windows

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -89,10 +89,8 @@ std::string GetDefaultSoundBackend()
 #elif defined __linux__
   if (AlsaSound::isValid())
     backend = BACKEND_ALSA;
-#elif defined __APPLE__
+#elif defined(__APPLE__) || defined(_WIN32)
   backend = BACKEND_CUBEB;
-#elif defined _WIN32
-  backend = BACKEND_XAUDIO2;
 #endif
   return backend;
 }


### PR DESCRIPTION
Cubeb and Xaudio2 are identical in features while Cubeb has lower latency and is actively being worked on.
I personally think Xaudio2 can be removed from the project but this change at least makes sure that new users use the better audio backend by default. 