### PR TITLE
WIP - WiimoteEmu: Improve emulated swing.

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -25,6 +25,18 @@ constexpr T Clamp(const T val, const T& min, const T& max)
 }
 
 template <typename T>
+constexpr auto Sign(const T& val) -> decltype((T{} < val) - (val < T{}))
+{
+  return (T{} < val) - (val < T{});
+}
+
+template <typename T, typename F>
+constexpr auto Lerp(const T& x, const T& y, const F& a) -> decltype(x + (y - x) * a)
+{
+  return x + (y - x) * a;
+}
+
+template <typename T>
 constexpr bool IsPow2(T imm)
 {
   return imm > 0 && (imm & (imm - 1)) == 0;

--- a/Source/Core/Common/Matrix.h
+++ b/Source/Core/Common/Matrix.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cmath>
+#include <functional>
 #include <type_traits>
 
 // Tiny matrix/vector library.
@@ -58,6 +59,24 @@ union TVec3
 
   TVec3 operator-() const { return {-x, -y, -z}; }
 
+  template <typename F>
+  auto Map(F&& f) const -> TVec3<decltype(f(T{}))>
+  {
+    return {f(x), f(y), f(z)};
+  }
+
+  template <typename F, typename T2>
+  auto Map(F&& f, const TVec3<T2>& t) const -> TVec3<decltype(f(T{}, t.x))>
+  {
+    return {f(x, t.x), f(y, t.y), f(z, t.z)};
+  }
+
+  template <typename F, typename T2>
+  auto Map(F&& f, T2 scalar) const -> TVec3<decltype(f(T{}, scalar))>
+  {
+    return {f(x, scalar), f(y, scalar), f(z, scalar)};
+  }
+
   std::array<T, 3> data = {};
 
   struct
@@ -69,39 +88,45 @@ union TVec3
 };
 
 template <typename T>
-TVec3<T> operator+(TVec3<T> lhs, const TVec3<T>& rhs)
+TVec3<bool> operator<(const TVec3<T>& lhs, const TVec3<T>& rhs)
 {
-  return lhs += rhs;
+  return lhs.Map(std::less{}, rhs);
 }
 
 template <typename T>
-TVec3<T> operator-(TVec3<T> lhs, const TVec3<T>& rhs)
+auto operator+(const TVec3<T>& lhs, const TVec3<T>& rhs) -> TVec3<decltype(lhs.x + rhs.x)>
 {
-  return lhs -= rhs;
+  return lhs.Map(std::plus{}, rhs);
 }
 
 template <typename T>
-TVec3<T> operator*(TVec3<T> lhs, const TVec3<T>& rhs)
+auto operator-(const TVec3<T>& lhs, const TVec3<T>& rhs) -> TVec3<decltype(lhs.x - rhs.x)>
 {
-  return lhs *= rhs;
+  return lhs.Map(std::minus{}, rhs);
+}
+
+template <typename T1, typename T2>
+auto operator*(const TVec3<T1>& lhs, const TVec3<T2>& rhs) -> TVec3<decltype(lhs.x * rhs.x)>
+{
+  return lhs.Map(std::multiplies{}, rhs);
 }
 
 template <typename T>
-inline TVec3<T> operator/(TVec3<T> lhs, const TVec3<T>& rhs)
+auto operator/(const TVec3<T>& lhs, const TVec3<T>& rhs) -> TVec3<decltype(lhs.x / rhs.x)>
 {
-  return lhs /= rhs;
+  return lhs.Map(std::divides{}, rhs);
 }
 
-template <typename T>
-TVec3<T> operator*(TVec3<T> lhs, std::common_type_t<T> scalar)
+template <typename T1, typename T2>
+auto operator*(const TVec3<T1>& lhs, T2 scalar) -> TVec3<decltype(lhs.x * scalar)>
 {
-  return lhs *= TVec3<T>{scalar, scalar, scalar};
+  return lhs.Map(std::multiplies{}, scalar);
 }
 
-template <typename T>
-TVec3<T> operator/(TVec3<T> lhs, std::common_type_t<T> scalar)
+template <typename T1, typename T2>
+auto operator/(const TVec3<T1>& lhs, T2 scalar) -> TVec3<decltype(lhs.x / scalar)>
 {
-  return lhs /= TVec3<T>{scalar, scalar, scalar};
+  return lhs.Map(std::divides{}, scalar);
 }
 
 using Vec3 = TVec3<float>;

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
@@ -47,8 +47,8 @@ struct MotionState : PositionalState, RotationalState
 // Build a rotational matrix from euler angles.
 Common::Matrix33 GetRotationalMatrix(const Common::Vec3& angle);
 
-void ApproachPositionWithJerk(PositionalState* state, const Common::Vec3& target, float max_jerk,
-                              float time_elapsed);
+void ApproachPositionWithJerk(PositionalState* state, const Common::Vec3& target,
+                              const Common::Vec3& max_jerk, float time_elapsed);
 
 void ApproachAngleWithAccel(RotationalState* state, const Common::Vec3& target, float max_accel,
                             float time_elapsed);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -448,11 +448,19 @@ void MappingIndicator::DrawForce(ControllerEmu::Force& force)
       QRectF(-scale, raw_coord.z * scale - INPUT_DOT_RADIUS / 2, scale * 2, INPUT_DOT_RADIUS));
 
   // Adjusted Z:
-  if (adj_coord.y)
+  const auto curve_point =
+      std::max(std::abs(m_motion_state.angle.x), std::abs(m_motion_state.angle.z)) / MathUtil::TAU;
+  if (adj_coord.y || curve_point)
   {
-    p.setBrush(ADJ_INPUT_COLOR);
-    p.drawRect(
-        QRectF(-scale, adj_coord.y * -scale - INPUT_DOT_RADIUS / 2, scale * 2, INPUT_DOT_RADIUS));
+    // Show off the angle somewhat with a curved line.
+    QPainterPath path;
+    path.moveTo(-scale, (adj_coord.y + curve_point) * -scale);
+    path.quadTo({0, (adj_coord.y - curve_point) * -scale},
+                {scale, (adj_coord.y + curve_point) * -scale});
+
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(ADJ_INPUT_COLOR, INPUT_DOT_RADIUS));
+    p.drawPath(path);
   }
 
   // Draw "gate" shape.

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
@@ -26,8 +26,9 @@ public:
 
   StateData GetState(bool adjusted = true);
 
-  // Return jerk in m/s^3.
-  ControlState GetMaxJerk() const;
+  // Velocities returned in m/s.
+  ControlState GetSpeed() const;
+  ControlState GetReturnSpeed() const;
 
   // Return twist angle in radians.
   ControlState GetTwistAngle() const;
@@ -37,7 +38,8 @@ public:
 
 private:
   SettingValue<double> m_distance_setting;
-  SettingValue<double> m_jerk_setting;
+  SettingValue<double> m_speed_setting;
+  SettingValue<double> m_return_speed_setting;
   SettingValue<double> m_angle_setting;
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
I've replaced the hard to comprehend "Jerk" setting with a "Speed", measured in m/s.
Default: 8 m/s (Range is 1 - 40)

The jerk required to reach this velocity when traveling 1 meter is used to "move" the emulated wiimote.
This results in an exponentially increasing jerk with a linear increase in the "Speed" setting which is a more friendly interface.

I've added a "Return Speed" setting which is used to move the emulated wiimote back to its neutral position after a swing.
This stops the release of swing buttons from triggering actions in games.
Default: 2 m/s

The emulated wiimote is now moved backwards and with a twist in the direction of the swing to simulate the motions one would make with their arm.
The mapping indicator shows this with some curved lines.

The swing emulation code is getting a little more ugly than I'd like but short of pulling in a physics library I don't think it can be much cleaner while maintaining this functionality.

**No More Heroes 1 and 2**
"Fatalities" are now detected with a single swing "press" on either keyboard or analog stick.
The rotational actions also work with analog sticks or circular key mashing.

**TODO**
More testing with more games.
Are "Speed" and "Return Speed" the best names for these settings?