### PR TITLE
Don't enforce that a memory card has to have a .raw or .gcp file extension.

### DIFF
--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -268,7 +268,7 @@ void GCMemcardManager::SetSlotFileInteractive(int slot)
       this,
       slot == 0 ? tr("Set memory card file for Slot A") : tr("Set memory card file for Slot B"),
       QString::fromStdString(File::GetUserPath(D_GCUSER_IDX)),
-      tr("GameCube Memory Cards (*.raw *.gcp)")));
+      tr("GameCube Memory Cards (*.raw *.gcp)") + QStringLiteral(";;") + tr("All Files (*)")));
   if (!path.isEmpty())
     m_slot_file_edit[slot]->setText(path);
 }


### PR DESCRIPTION
Sorta implements this feature request: https://forums.dolphin-emu.org/Thread-support-bin-extension-for-gc-memory-card-manager

I've not actually added `*.bin` as a suggested filetype as that's very generic, but if someone wants to open a bin as a Memory Card, why not let them?