### PR TITLE
WiimoteEmu: Fix Data Report 0x32.

### DIFF
--- a/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
+++ b/Source/Core/Core/HW/WiimoteCommon/DataReport.cpp
@@ -163,7 +163,7 @@ struct ReportCoreAccel : IncludeCore, IncludeAccel, NoIR, NoExt
   u32 GetDataSize() const override { return 5; }
 };
 
-struct ReportCoreExt8 : IncludeCore, NoAccel, NoIR, IncludeExt<5, 8>
+struct ReportCoreExt8 : IncludeCore, NoAccel, NoIR, IncludeExt<2, 8>
 {
 };
 


### PR DESCRIPTION
This fixes the offset of extension data in data report type 0x32 (core buttons with 8 extension bytes).
This report type is hardly used but Black Ops uses it on boot which caused miscalibration.
For future reference: 2 + 0 + 0 = 2.