### PR TITLE
UICommon/NetPlayIndex: Fix possible crash when Add is called again

### DIFF
--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -197,6 +197,11 @@ bool NetPlayIndex::Add(NetPlaySession session)
   m_player_count = session.player_count;
   m_game = session.game_id;
 
+  m_session_thread_exit_event.Set();
+  if (m_session_thread.joinable())
+    m_session_thread.join();
+  m_session_thread_exit_event.Reset();
+
   m_session_thread = std::thread([this] { NotificationLoop(); });
 
   return true;


### PR DESCRIPTION
Assigning to a running thread (specifically one that is `joinable`) will call `std::terminate`, so make sure any existing thread is stopped before making a new one.