### PR TITLE
IOS/FS: Don't savestate m_root_path

### DIFF
--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -53,8 +53,6 @@ HostFileSystem::~HostFileSystem() = default;
 
 void HostFileSystem::DoState(PointerWrap& p)
 {
-  p.Do(m_root_path);
-
   // Temporarily close the file, to prevent any issues with the savestating of /tmp
   for (Handle& handle : m_handles)
     handle.host_file.reset();

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 105;  // Last changed in PR 7871
+static const u32 STATE_VERSION = 106;  // Last changed in PR 7984
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
The NAND root path can be different on different systems, so we must not savestate it.