### PR TITLE
EmuCodeBlock: Correct zero handling in SetFPRF for SSE4.1

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -986,7 +986,6 @@ void EmuCodeBlock::ConvertSingleToDouble(X64Reg dst, X64Reg src, bool src_is_gpr
 alignas(16) static const u64 psDoubleExp[2] = {0x7FF0000000000000ULL, 0};
 alignas(16) static const u64 psDoubleFrac[2] = {0x000FFFFFFFFFFFFFULL, 0};
 alignas(16) static const u64 psDoubleNoSign[2] = {0x7FFFFFFFFFFFFFFFULL, 0};
-alignas(16) static const u64 psWhole[2] = {0xFFFFFFFFFFFFFFFFULL, 0};
 
 // TODO: it might be faster to handle FPRF in the same way as CR is currently handled for integer,
 // storing
@@ -1032,7 +1031,7 @@ void EmuCodeBlock::SetFPRF(Gen::X64Reg xmm)
     continue3 = J();
 
     SetJumpTarget(zeroExponent);
-    PTEST(xmm, MConst(psWhole));
+    PTEST(xmm, MConst(psDoubleNoSign));
     FixupBranch zero = J_CC(CC_Z);
 
     // No exponent + mantissa: sign ? PPC_FPCLASS_ND : PPC_FPCLASS_PD;


### PR DESCRIPTION
`PPC_FPCLASS_ND` was being emitted for negative zero instead of `PPC_FPCLASS_NZ`.

Why does this differ from the non-SSE4.1 version? That's because the non-SSE4.1 codepath [masks the sign bit away](https://github.com/dolphin-emu/dolphin/blob/e4d83a56a50482713200f96ac17d4359fd649ab6/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp#L1052), which the SSE4.1 codepath doesn't do such a thing.