### PR TITLE
ControllerEmu: Add support for setting the center of a ReshapableInput

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -777,7 +777,10 @@ void CalibrationWidget::SetupActions()
   const auto center_action = new QAction(tr("Center and Calibrate"), this);
   const auto reset_action = new QAction(tr("Reset"), this);
 
-  connect(calibrate_action, &QAction::triggered, [this]() { StartCalibration(); });
+  connect(calibrate_action, &QAction::triggered, [this]() {
+      StartCalibration();
+      m_input.SetCenter({0, 0});
+  });
   connect(center_action, &QAction::triggered, [this]() {
     StartCalibration();
     m_is_centering = true;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -29,7 +29,6 @@
 
 namespace
 {
-const QColor CENTER_COLOR = Qt::blue;
 const QColor C_STICK_GATE_COLOR = Qt::yellow;
 const QColor CURSOR_TV_COLOR = 0xaed6f1;
 const QColor TILT_GATE_COLOR = 0xa2d9ce;
@@ -63,6 +62,11 @@ QColor MappingIndicator::GetAdjustedInputColor() const
   // Using highlight color works (typically blue) but the contrast is pretty low.
   // return palette().highlight().color();
   return Qt::red;
+}
+
+QColor MappingIndicator::GetCenterColor() const
+{
+  return Qt::blue;
 }
 
 QColor MappingIndicator::GetDeadZoneColor() const
@@ -265,7 +269,7 @@ void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
   if (center.x || center.y)
   {
     p.setPen(Qt::NoPen);
-    p.setBrush(CENTER_COLOR);
+    p.setBrush(GetCenterColor());
     p.drawEllipse(QPointF{center.x, center.y} * scale, INPUT_DOT_RADIUS, INPUT_DOT_RADIUS);
   }
 
@@ -363,7 +367,7 @@ void MappingIndicator::DrawReshapableInput(ControllerEmu::ReshapableInput& stick
   if (center.x || center.y)
   {
     p.setPen(Qt::NoPen);
-    p.setBrush(CENTER_COLOR);
+    p.setBrush(GetCenterColor());
     p.drawEllipse(QPointF{center.x, center.y} * scale, INPUT_DOT_RADIUS, INPUT_DOT_RADIUS);
   }
 
@@ -566,7 +570,7 @@ void MappingIndicator::DrawForce(ControllerEmu::Force& force)
   if (center.x || center.y)
   {
     p.setPen(Qt::NoPen);
-    p.setBrush(CENTER_COLOR);
+    p.setBrush(GetCenterColor());
     p.drawEllipse(QPointF{center.x, center.y} * scale, INPUT_DOT_RADIUS, INPUT_DOT_RADIUS);
   }
 
@@ -710,6 +714,14 @@ void MappingIndicator::DrawCalibration(QPainter& p, Common::DVec2 point, Common:
   p.drawPolygon(GetPolygonFromRadiusGetter(
       [this](double angle) { return m_calibration_widget->GetCalibrationRadiusAtAngle(angle); },
       scale, center));
+
+  // Center.
+  if (center.x || center.y)
+  {
+    p.setPen(Qt::NoPen);
+    p.setBrush(GetCenterColor());
+    p.drawEllipse(QPointF{center.x, center.y} * scale, INPUT_DOT_RADIUS, INPUT_DOT_RADIUS);
+  }
 
   // Stick position.
   p.setPen(Qt::NoPen);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -40,6 +40,7 @@ protected:
   QBrush GetBBoxBrush() const;
   QColor GetRawInputColor() const;
   QPen GetInputShapePen() const;
+  QColor GetCenterColor() const;
   QColor GetAdjustedInputColor() const;
   QColor GetDeadZoneColor() const;
   QPen GetDeadZonePen() const;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -55,7 +55,7 @@ private:
   void DrawReshapableInput(ControllerEmu::ReshapableInput& stick);
   void DrawMixedTriggers();
   void DrawForce(ControllerEmu::Force&);
-  void DrawCalibration(QPainter& p, Common::DVec2 point);
+  void DrawCalibration(QPainter& p, Common::DVec2 point, Common::DVec2 center = {0, 0});
 
   void paintEvent(QPaintEvent*) override;
 
@@ -101,4 +101,7 @@ private:
   QAction* m_completion_action;
   ControllerEmu::ReshapableInput::CalibrationData m_calibration_data;
   QTimer* m_informative_timer;
+
+  bool m_is_centering = false;
+  ControllerEmu::ReshapableInput::ReshapeData m_old_center;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -56,7 +56,7 @@ private:
   void DrawReshapableInput(ControllerEmu::ReshapableInput& stick);
   void DrawMixedTriggers();
   void DrawForce(ControllerEmu::Force&);
-  void DrawCalibration(QPainter& p, Common::DVec2 point, Common::DVec2 center = {0, 0});
+  void DrawCalibration(QPainter& p, Common::DVec2 point);
 
   void paintEvent(QPaintEvent*) override;
 
@@ -91,6 +91,8 @@ public:
 
   double GetCalibrationRadiusAtAngle(double angle) const;
 
+  Common::DVec2 GetCenter() const;
+
   bool IsCalibrating() const;
 
 private:
@@ -104,5 +106,5 @@ private:
   QTimer* m_informative_timer;
 
   bool m_is_centering = false;
-  ControllerEmu::ReshapableInput::ReshapeData m_old_center;
+  Common::DVec2 m_new_center;
 };

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -20,6 +20,9 @@ constexpr auto CALIBRATION_CONFIG_NAME = "Calibration";
 constexpr auto CALIBRATION_DEFAULT_VALUE = 1.0;
 constexpr auto CALIBRATION_CONFIG_SCALE = 100;
 
+constexpr auto CENTER_CONFIG_NAME = "Center";
+constexpr auto CENTER_CONFIG_SCALE = 100;
+
 // Calculate distance to intersection of a ray with a line defined by two points.
 double GetRayLineIntersection(Common::DVec2 ray, Common::DVec2 point1, Common::DVec2 point2)
 {
@@ -214,6 +217,16 @@ void ReshapableInput::SetCalibrationData(CalibrationData data)
   m_calibration = std::move(data);
 }
 
+const ReshapableInput::ReshapeData& ReshapableInput::GetCenter() const
+{
+  return m_center;
+}
+
+void ReshapableInput::SetCenter(ReshapableInput::ReshapeData center)
+{
+  m_center = center;
+}
+
 void ReshapableInput::LoadConfig(IniFile::Section* section, const std::string& default_device,
                                  const std::string& base_name)
 {
@@ -232,6 +245,20 @@ void ReshapableInput::LoadConfig(IniFile::Section* section, const std::string& d
     if (TryParse(*(it++), &sample))
       sample /= CALIBRATION_CONFIG_SCALE;
   }
+
+  section->Get(group + CENTER_CONFIG_NAME, &load_str, "");
+  const auto center_data = SplitString(load_str, ' ');
+
+  m_center = Common::DVec2();
+
+  if (center_data.size() == 2)
+  {
+    if (TryParse(center_data[0], &m_center.x))
+      m_center.x /= CENTER_CONFIG_SCALE;
+
+    if (TryParse(center_data[1], &m_center.y))
+      m_center.y /= CENTER_CONFIG_SCALE;
+  }
 }
 
 void ReshapableInput::SaveConfig(IniFile::Section* section, const std::string& default_device,
@@ -245,11 +272,19 @@ void ReshapableInput::SaveConfig(IniFile::Section* section, const std::string& d
       m_calibration.begin(), m_calibration.end(), save_data.begin(),
       [](ControlState val) { return StringFromFormat("%.2f", val * CALIBRATION_CONFIG_SCALE); });
   section->Set(group + CALIBRATION_CONFIG_NAME, JoinStrings(save_data, " "), "");
+
+  const auto center_data = StringFromFormat("%.2f %.2f", m_center.x * CENTER_CONFIG_SCALE,
+                                            m_center.y * CENTER_CONFIG_SCALE);
+
+  section->Set(group + CENTER_CONFIG_NAME, center_data, "");
 }
 
 ReshapableInput::ReshapeData ReshapableInput::Reshape(ControlState x, ControlState y,
                                                       ControlState modifier)
 {
+  x -= m_center.x;
+  y -= m_center.y;
+
   // TODO: make the AtAngle functions work with negative angles:
   const ControlState angle = std::atan2(y, x) + MathUtil::TAU;
 

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -97,6 +97,9 @@ public:
   const CalibrationData& GetCalibrationData() const;
   void SetCalibrationData(CalibrationData data);
 
+  const ReshapeData& GetCenter() const;
+  void SetCenter(ReshapeData center);
+
 protected:
   ReshapeData Reshape(ControlState x, ControlState y, ControlState modifier = 0.0);
 
@@ -106,6 +109,7 @@ private:
 
   CalibrationData m_calibration;
   SettingValue<double> m_deadzone_setting;
+  ReshapeData m_center;
 };
 
 }  // namespace ControllerEmu


### PR DESCRIPTION
This is useful in far out-of-calibration controllers, such as the
Switch Pro controller. This also adds support for configuring the center
in the Mapping widget.