### PR TITLE
Core/NetPlayClient: Reset GCAdapter device type in UpdateDevices

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1650,6 +1650,11 @@ void NetPlayClient::UpdateDevices()
       if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[local_pad]))
       {
         SerialInterface::ChangeDevice(SConfig::GetInstance().m_SIDevice[local_pad], pad);
+
+        if (SConfig::GetInstance().m_SIDevice[local_pad] == SerialInterface::SIDEVICE_WIIU_ADAPTER)
+        {
+          GCAdapter::ResetDeviceType(local_pad);
+        }
       }
       else
       {


### PR DESCRIPTION
This will ensure an origin reset is triggered on next boot.

Fixes the calibration issue when your in-game pad isn't the same index as your local pad.