### PR TITLE
Added debug log option in GUI for debug builds

### DIFF
--- a/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
@@ -137,12 +137,12 @@ void LogConfigWidget::LoadSettings()
   setFloating(settings.value(QStringLiteral("logconfigwidget/floating")).toBool());
 
   // Config - Verbosity
-  int verbosity = logmanager->GetLogLevel();
-  m_verbosity_notice->setChecked(verbosity == 1);
-  m_verbosity_error->setChecked(verbosity == 2);
-  m_verbosity_warning->setChecked(verbosity == 3);
-  m_verbosity_info->setChecked(verbosity == 4);
-  m_verbosity_debug->setChecked(verbosity == 5);
+  const LogTypes::LOG_LEVELS verbosity = logmanager->GetLogLevel();
+  m_verbosity_notice->setChecked(verbosity == LogTypes::LOG_LEVELS::LNOTICE);
+  m_verbosity_error->setChecked(verbosity == LogTypes::LOG_LEVELS::LERROR);
+  m_verbosity_warning->setChecked(verbosity == LogTypes::LOG_LEVELS::LWARNING);
+  m_verbosity_info->setChecked(verbosity == LogTypes::LOG_LEVELS::LINFO);
+  m_verbosity_debug->setChecked(verbosity == LogTypes::LOG_LEVELS::LDEBUG);
 
   // Config - Outputs
   m_out_file->setChecked(logmanager->IsListenerEnabled(LogListener::FILE_LISTENER));
@@ -172,25 +172,25 @@ void LogConfigWidget::SaveSettings()
   settings.setValue(QStringLiteral("logconfigwidget/floating"), isFloating());
 
   // Config - Verbosity
-  int verbosity = 1;
+  LogTypes::LOG_LEVELS verbosity = LogTypes::LOG_LEVELS::LNOTICE;
 
   if (m_verbosity_notice->isChecked())
-    verbosity = 1;
+    verbosity = LogTypes::LOG_LEVELS::LNOTICE;
 
   if (m_verbosity_error->isChecked())
-    verbosity = 2;
+    verbosity = LogTypes::LOG_LEVELS::LERROR;
 
   if (m_verbosity_warning->isChecked())
-    verbosity = 3;
+    verbosity = LogTypes::LOG_LEVELS::LWARNING;
 
   if (m_verbosity_info->isChecked())
-    verbosity = 4;
+    verbosity = LogTypes::LOG_LEVELS::LINFO;
 
   if (m_verbosity_debug->isChecked())
-    verbosity = 5;
+    verbosity = LogTypes::LOG_LEVELS::LDEBUG;
 
   // Config - Verbosity
-  LogManager::GetInstance()->SetLogLevel(static_cast<LogTypes::LOG_LEVELS>(verbosity));
+  LogManager::GetInstance()->SetLogLevel(verbosity);
 
   // Config - Outputs
   LogManager::GetInstance()->EnableListener(LogListener::FILE_LISTENER, m_out_file->isChecked());

--- a/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
@@ -47,6 +47,7 @@ void LogConfigWidget::CreateWidgets()
   m_verbosity_error = new QRadioButton(tr("Error"));
   m_verbosity_warning = new QRadioButton(tr("Warning"));
   m_verbosity_info = new QRadioButton(tr("Info"));
+  m_verbosity_debug = new QRadioButton(tr("Debug"));
 
   auto* outputs = new QGroupBox(tr("Logger Outputs"));
   auto* outputs_layout = new QVBoxLayout;
@@ -74,6 +75,10 @@ void LogConfigWidget::CreateWidgets()
   verbosity_layout->addWidget(m_verbosity_error);
   verbosity_layout->addWidget(m_verbosity_warning);
   verbosity_layout->addWidget(m_verbosity_info);
+  if (MAX_LOGLEVEL == LogTypes::LOG_LEVELS::LDEBUG)
+  {
+    verbosity_layout->addWidget(m_verbosity_debug);
+  }
 
   layout->addWidget(outputs);
   outputs_layout->addWidget(m_out_file);
@@ -97,6 +102,7 @@ void LogConfigWidget::ConnectWidgets()
   connect(m_verbosity_error, &QRadioButton::toggled, this, &LogConfigWidget::SaveSettings);
   connect(m_verbosity_warning, &QRadioButton::toggled, this, &LogConfigWidget::SaveSettings);
   connect(m_verbosity_info, &QRadioButton::toggled, this, &LogConfigWidget::SaveSettings);
+  connect(m_verbosity_debug, &QRadioButton::toggled, this, &LogConfigWidget::SaveSettings);
 
   connect(m_out_file, &QCheckBox::toggled, this, &LogConfigWidget::SaveSettings);
   connect(m_out_console, &QCheckBox::toggled, this, &LogConfigWidget::SaveSettings);
@@ -136,6 +142,7 @@ void LogConfigWidget::LoadSettings()
   m_verbosity_error->setChecked(verbosity == 2);
   m_verbosity_warning->setChecked(verbosity == 3);
   m_verbosity_info->setChecked(verbosity == 4);
+  m_verbosity_debug->setChecked(verbosity == 5);
 
   // Config - Outputs
   m_out_file->setChecked(logmanager->IsListenerEnabled(LogListener::FILE_LISTENER));
@@ -178,6 +185,9 @@ void LogConfigWidget::SaveSettings()
 
   if (m_verbosity_info->isChecked())
     verbosity = 4;
+
+  if (m_verbosity_debug->isChecked())
+    verbosity = 5;
 
   // Config - Verbosity
   LogManager::GetInstance()->SetLogLevel(static_cast<LogTypes::LOG_LEVELS>(verbosity));

--- a/Source/Core/DolphinQt/Config/LogConfigWidget.h
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.h
@@ -33,6 +33,8 @@ private:
   QRadioButton* m_verbosity_error;
   QRadioButton* m_verbosity_warning;
   QRadioButton* m_verbosity_info;
+  QRadioButton* m_verbosity_debug;
+
   QCheckBox* m_out_file;
   QCheckBox* m_out_console;
   QCheckBox* m_out_window;


### PR DESCRIPTION
I didn't see an option in the debugger UI to keep debug logs on. This adds it, and marks 'Debug' as disabled if the DEBUG level log isn't compiled in (like in release builds).