### PR TITLE
update-source-strings.sh: Specify encoding

### DIFF
--- a/Languages/update-source-strings.sh
+++ b/Languages/update-source-strings.sh
@@ -9,7 +9,8 @@ find $SRCDIR -name '*.cpp' -o -name '*.h' -o -name '*.c' | \
 	xgettext -d dolphin-emu -s --keyword=_ --keyword=wxTRANSLATE --keyword=SuccessAlertT \
 	--keyword=PanicAlertT --keyword=PanicYesNoT --keyword=AskYesNoT --keyword=CriticalAlertT \
 	--keyword=GetStringT --keyword=_trans --keyword=tr --keyword=QT_TR_NOOP \
-	--add-comments=i18n -p ./Languages/po -o dolphin-emu.pot -f - --package-name="Dolphin Emulator"
+	--add-comments=i18n -p ./Languages/po -o dolphin-emu.pot -f - --package-name="Dolphin Emulator" \
+	--from-code=utf-8
 
 sed -i "s/SOME DESCRIPTIVE TITLE\./Translation of dolphin-emu.pot to LANGUAGE/" Languages/po/dolphin-emu.pot
 sed -i "s/YEAR THE PACKAGE'S COPYRIGHT HOLDER/2003-2013/" Languages/po/dolphin-emu.pot


### PR DESCRIPTION
This is needed because 84cbd51 and 5efb717 added non-ASCII characters.