### PR TITLE
update-translated-strings.sh: Disable fuzzy matching

### DIFF
--- a/Languages/update-translated-strings.sh
+++ b/Languages/update-translated-strings.sh
@@ -7,4 +7,4 @@
 
 cd "$(dirname "$0")/.."
 POTFILE=./Languages/po/dolphin-emu.pot
-find ./Languages/po -name '*.po' -exec msgmerge --quiet --update --backup=none -s {} $POTFILE \;
+find ./Languages/po -name '*.po' -exec msgmerge --quiet --update -N --backup=none -s {} $POTFILE \;


### PR DESCRIPTION
This doesn't really matter in practice, because I always sync with Transifex before running updated-translated-strings.sh, and then there can't be any fuzzy matches. But we might as well disable fuzzy matching explicitly, becase the results can be quite odd. This should make the script a bit faster too.