### PR TITLE
Implement pipeline data cache for OpenGL and D3D12

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -127,7 +127,9 @@ std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage sta
   return DXShader::CreateFromBytecode(stage, DXShader::CreateByteCode(data, length));
 }
 
-std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config)
+std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config,
+                                                           const void* cache_data,
+                                                           size_t cache_data_length)
 {
   return DXPipeline::Create(config);
 }

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -34,7 +34,9 @@ public:
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
-  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config) override;
+  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
+                                                   const void* cache_data = nullptr,
+                                                   size_t cache_data_length = 0) override;
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -82,6 +82,8 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
   g_Config.backend_info.bSupportsGSInstancing = true;
   g_Config.backend_info.bSupportsSSAA = true;
+  g_Config.backend_info.bSupportsShaderBinaries = true;
+  g_Config.backend_info.bSupportsPipelineCacheData = false;
 
   g_Config.backend_info.Adapters = D3DCommon::GetAdapterNames();
   g_Config.backend_info.AAModes = D3D::GetAAModes(g_Config.iAdapter);

--- a/Source/Core/VideoBackends/D3D12/DXPipeline.h
+++ b/Source/Core/VideoBackends/D3D12/DXPipeline.h
@@ -19,13 +19,16 @@ public:
              bool use_integer_rtv);
   ~DXPipeline() override;
 
-  static std::unique_ptr<DXPipeline> Create(const AbstractPipelineConfig& config);
+  static std::unique_ptr<DXPipeline> Create(const AbstractPipelineConfig& config,
+                                            const void* cache_data, size_t cache_data_size);
 
   ID3D12PipelineState* GetPipeline() const { return m_pipeline; }
   ID3D12RootSignature* GetRootSignature() const { return m_root_signature; }
   AbstractPipelineUsage GetUsage() const { return m_usage; }
   D3D12_PRIMITIVE_TOPOLOGY GetPrimitiveTopology() const { return m_primitive_topology; }
   bool UseIntegerRTV() const { return m_use_integer_rtv; }
+
+  CacheData GetCacheData() const override;
 
 private:
   ID3D12PipelineState* m_pipeline;

--- a/Source/Core/VideoBackends/D3D12/Renderer.cpp
+++ b/Source/Core/VideoBackends/D3D12/Renderer.cpp
@@ -99,7 +99,9 @@ Renderer::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
   return std::make_unique<DXVertexFormat>(vtx_decl);
 }
 
-std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config)
+std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config,
+                                                           const void* cache_data,
+                                                           size_t cache_data_length)
 {
   return DXPipeline::Create(config);
 }

--- a/Source/Core/VideoBackends/D3D12/Renderer.cpp
+++ b/Source/Core/VideoBackends/D3D12/Renderer.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelin
                                                            const void* cache_data,
                                                            size_t cache_data_length)
 {
-  return DXPipeline::Create(config);
+  return DXPipeline::Create(config, cache_data, cache_data_length);
 }
 
 u16 Renderer::BBoxRead(int index)

--- a/Source/Core/VideoBackends/D3D12/Renderer.h
+++ b/Source/Core/VideoBackends/D3D12/Renderer.h
@@ -41,7 +41,9 @@ public:
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
-  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config) override;
+  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
+                                                   const void* cache_data = nullptr,
+                                                   size_t cache_data_length = 0) override;
 
   u16 BBoxRead(int index) override;
   void BBoxWrite(int index, u16 value) override;

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -80,6 +80,8 @@ void VideoBackend::FillBackendInfo()
   g_Config.backend_info.bSupportsPartialDepthCopies = false;
   g_Config.backend_info.Adapters = D3DCommon::GetAdapterNames();
   g_Config.backend_info.AAModes = DXContext::GetAAModes(g_Config.iAdapter);
+  g_Config.backend_info.bSupportsShaderBinaries = true;
+  g_Config.backend_info.bSupportsPipelineCacheData = true;
 
   // We can only check texture support once we have a device.
   if (g_dx_context)

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -23,11 +23,6 @@ Shader::Shader(ShaderStage stage, BinaryData bytecode)
 
 Shader::~Shader() = default;
 
-bool Shader::HasBinary() const
-{
-  return true;
-}
-
 AbstractShader::BinaryData Shader::GetBinary() const
 {
   return m_bytecode;

--- a/Source/Core/VideoBackends/D3DCommon/Shader.h
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.h
@@ -16,7 +16,6 @@ public:
 
   const BinaryData& GetByteCode() const { return m_bytecode; }
 
-  bool HasBinary() const override;
   BinaryData GetBinary() const override;
 
   static bool CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_bytecode,

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -52,6 +52,8 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsLogicOp = false;
   g_Config.backend_info.bSupportsLargePoints = false;
   g_Config.backend_info.bSupportsPartialDepthCopies = false;
+  g_Config.backend_info.bSupportsShaderBinaries = false;
+  g_Config.backend_info.bSupportsPipelineCacheData = false;
 
   // aamodes: We only support 1 sample, so no MSAA
   g_Config.backend_info.Adapters.clear();

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -46,9 +46,6 @@ class NullShader final : public AbstractShader
 public:
   explicit NullShader(ShaderStage stage) : AbstractShader(stage) {}
   ~NullShader() = default;
-
-  bool HasBinary() const override { return false; }
-  BinaryData GetBinary() const override { return {}; }
 };
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
@@ -70,7 +67,9 @@ public:
   ~NullPipeline() override = default;
 };
 
-std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config)
+std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config,
+                                                           const void* cache_data,
+                                                           size_t cache_data_length)
 {
   return std::make_unique<NullPipeline>();
 }

--- a/Source/Core/VideoBackends/Null/Render.h
+++ b/Source/Core/VideoBackends/Null/Render.h
@@ -28,7 +28,9 @@ public:
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
-  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config) override;
+  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
+                                                   const void* cache_data = nullptr,
+                                                   size_t cache_data_length = 0) override;
 
   u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override { return 0; }
   void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override {}

--- a/Source/Core/VideoBackends/OGL/OGLPipeline.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLPipeline.cpp
@@ -9,6 +9,7 @@
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/Render.h"
 #include "VideoBackends/OGL/VertexManager.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace OGL
 {
@@ -31,7 +32,7 @@ static GLenum MapToGLPrimitive(PrimitiveType primitive_type)
 OGLPipeline::OGLPipeline(const GLVertexFormat* vertex_format,
                          const RasterizationState& rasterization_state,
                          const DepthState& depth_state, const BlendingState& blending_state,
-                         const PipelineProgram* program, GLuint gl_primitive)
+                         PipelineProgram* program, GLuint gl_primitive)
     : m_vertex_format(vertex_format), m_rasterization_state(rasterization_state),
       m_depth_state(depth_state), m_blending_state(blending_state), m_program(program),
       m_gl_primitive(gl_primitive)
@@ -44,13 +45,47 @@ OGLPipeline::~OGLPipeline()
   ProgramShaderCache::ReleasePipelineProgram(m_program);
 }
 
-std::unique_ptr<OGLPipeline> OGLPipeline::Create(const AbstractPipelineConfig& config)
+AbstractPipeline::CacheData OGLPipeline::GetCacheData() const
 {
-  const PipelineProgram* program = ProgramShaderCache::GetPipelineProgram(
+  // More than one pipeline can share the same shaders. To avoid bloating the cache with multiple
+  // copies of the same program combination, we set a flag on the program object so that it can't
+  // be retrieved again. When booting, the pipeline cache is loaded in-order, so the additional
+  // pipelines which use the program combination will re-use the already-created object.
+  if (!g_ActiveConfig.backend_info.bSupportsPipelineCacheData || m_program->binary_retrieved)
+    return {};
+
+  GLint program_size = 0;
+  glGetProgramiv(m_program->shader.glprogid, GL_PROGRAM_BINARY_LENGTH, &program_size);
+  if (program_size == 0)
+    return {};
+
+  // Clear any existing error.
+  glGetError();
+
+  // We pack the format at the start of the buffer.
+  CacheData data(program_size + sizeof(u32));
+  GLsizei data_size = 0;
+  GLenum program_format = 0;
+  glGetProgramBinary(m_program->shader.glprogid, program_size, &data_size, &program_format,
+                     &data[sizeof(u32)]);
+  if (glGetError() != GL_NO_ERROR || data_size == 0)
+    return {};
+
+  u32 program_format_u32 = static_cast<u32>(program_format);
+  std::memcpy(&data[0], &program_format_u32, sizeof(u32));
+  data.resize(data_size + sizeof(u32));
+  m_program->binary_retrieved = true;
+  return data;
+}
+
+std::unique_ptr<OGLPipeline> OGLPipeline::Create(const AbstractPipelineConfig& config,
+                                                 const void* cache_data, size_t cache_data_size)
+{
+  PipelineProgram* program = ProgramShaderCache::GetPipelineProgram(
       static_cast<const GLVertexFormat*>(config.vertex_format),
       static_cast<const OGLShader*>(config.vertex_shader),
       static_cast<const OGLShader*>(config.geometry_shader),
-      static_cast<const OGLShader*>(config.pixel_shader));
+      static_cast<const OGLShader*>(config.pixel_shader), cache_data, cache_data_size);
   if (!program)
     return nullptr;
 

--- a/Source/Core/VideoBackends/OGL/OGLPipeline.h
+++ b/Source/Core/VideoBackends/OGL/OGLPipeline.h
@@ -18,7 +18,7 @@ class OGLPipeline final : public AbstractPipeline
 public:
   explicit OGLPipeline(const GLVertexFormat* vertex_format,
                        const RasterizationState& rasterization_state, const DepthState& depth_state,
-                       const BlendingState& blending_state, const PipelineProgram* program,
+                       const BlendingState& blending_state, PipelineProgram* program,
                        GLenum gl_primitive);
   ~OGLPipeline() override;
 
@@ -29,14 +29,16 @@ public:
   const PipelineProgram* GetProgram() const { return m_program; }
   bool HasVertexInput() const { return m_vertex_format != nullptr; }
   GLenum GetGLPrimitive() const { return m_gl_primitive; }
-  static std::unique_ptr<OGLPipeline> Create(const AbstractPipelineConfig& config);
+  CacheData GetCacheData() const override;
+  static std::unique_ptr<OGLPipeline> Create(const AbstractPipelineConfig& config,
+                                             const void* cache_data, size_t cache_data_size);
 
 private:
   const GLVertexFormat* m_vertex_format;
   RasterizationState m_rasterization_state;
   DepthState m_depth_state;
   BlendingState m_blending_state;
-  const PipelineProgram* m_program;
+  PipelineProgram* m_program;
   GLenum m_gl_primitive;
 };
 

--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -44,17 +44,6 @@ OGLShader::~OGLShader()
     glDeleteProgram(m_gl_compute_program_id);
 }
 
-bool OGLShader::HasBinary() const
-{
-  // NOTE: GL shaders do not have binaries, programs do.
-  return false;
-}
-
-AbstractShader::BinaryData OGLShader::GetBinary() const
-{
-  return {};
-}
-
 std::unique_ptr<OGLShader> OGLShader::CreateFromSource(ShaderStage stage, const char* source,
                                                        size_t length)
 {

--- a/Source/Core/VideoBackends/OGL/OGLShader.h
+++ b/Source/Core/VideoBackends/OGL/OGLShader.h
@@ -24,8 +24,6 @@ public:
   GLenum GetGLShaderType() const { return m_type; }
   GLuint GetGLShaderID() const { return m_gl_id; }
   GLuint GetGLComputeProgramID() const { return m_gl_compute_program_id; }
-  bool HasBinary() const override;
-  BinaryData GetBinary() const override;
 
   static std::unique_ptr<OGLShader> CreateFromSource(ShaderStage stage, const char* source,
                                                      size_t length);

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -63,6 +63,7 @@ struct PipelineProgram
   PipelineProgramKey key;
   SHADER shader;
   std::atomic_size_t reference_count{1};
+  bool binary_retrieved = false;
 };
 
 class ProgramShaderCache
@@ -97,11 +98,12 @@ public:
   // pipeline do not match the pipeline configuration.
   static u64 GenerateShaderID();
 
-  static const PipelineProgram* GetPipelineProgram(const GLVertexFormat* vertex_format,
-                                                   const OGLShader* vertex_shader,
-                                                   const OGLShader* geometry_shader,
-                                                   const OGLShader* pixel_shader);
-  static void ReleasePipelineProgram(const PipelineProgram* prog);
+  static PipelineProgram* GetPipelineProgram(const GLVertexFormat* vertex_format,
+                                             const OGLShader* vertex_shader,
+                                             const OGLShader* geometry_shader,
+                                             const OGLShader* pixel_shader, const void* cache_data,
+                                             size_t cache_data_size);
+  static void ReleasePipelineProgram(PipelineProgram* prog);
 
 private:
   typedef std::unordered_map<PipelineProgramKey, std::unique_ptr<PipelineProgram>,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -350,6 +350,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
   }
 
   bool bSuccess = true;
+  bool supports_glsl_cache = false;
 
   g_ogl_config.gl_vendor = (const char*)glGetString(GL_VENDOR);
   g_ogl_config.gl_renderer = (const char*)glGetString(GL_RENDERER);
@@ -466,7 +467,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
       GLExtensions::Supports("GL_ARB_gpu_shader5");
 
   g_ogl_config.bIsES = m_main_gl_context->IsGLES();
-  g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
+  supports_glsl_cache = GLExtensions::Supports("GL_ARB_get_program_binary");
   g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");
   g_ogl_config.bSupportsGLSync = GLExtensions::Supports("GL_ARB_sync");
   g_ogl_config.bSupportsGLBaseVertex = GLExtensions::Supports("GL_ARB_draw_elements_base_vertex") ||
@@ -507,7 +508,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
                                                 EsTexbufType::TexbufExt :
                                                 EsTexbufType::TexbufNone;
 
-    g_ogl_config.bSupportsGLSLCache = true;
+    supports_glsl_cache = true;
     g_ogl_config.bSupportsGLSync = true;
 
     // TODO: Implement support for GL_EXT_clip_cull_distance when there is an extension for
@@ -675,6 +676,16 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
   g_Config.backend_info.bSupportsBackgroundCompiling =
       !DriverDetails::HasBug(DriverDetails::BUG_SHARED_CONTEXT_SHADER_COMPILATION);
 
+  // Program binaries are supported on GL4.1+, ARB_get_program_binary, or ES3.
+  if (supports_glsl_cache)
+  {
+    // We need to check the number of formats supported. If zero, don't bother getting the binaries.
+    GLint num_formats = 0;
+    glGetIntegerv(GL_NUM_PROGRAM_BINARY_FORMATS, &num_formats);
+    supports_glsl_cache = num_formats > 0;
+  }
+  g_Config.backend_info.bSupportsPipelineCacheData = supports_glsl_cache;
+
   if (g_ogl_config.bSupportsDebug)
   {
     if (GLExtensions::Supports("GL_KHR_debug"))
@@ -739,7 +750,7 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
            g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? "" : "PrimitiveRestart ",
            g_ActiveConfig.backend_info.bSupportsEarlyZ ? "" : "EarlyZ ",
            g_ogl_config.bSupportsGLPinnedMemory ? "" : "PinnedMemory ",
-           g_ogl_config.bSupportsGLSLCache ? "" : "ShaderCache ",
+           supports_glsl_cache ? "" : "ShaderCache ",
            g_ogl_config.bSupportsGLBaseVertex ? "" : "BaseVertex ",
            g_ogl_config.bSupportsGLBufferStorage ? "" : "BufferStorage ",
            g_ogl_config.bSupportsGLSync ? "" : "Sync ", g_ogl_config.bSupportsMSAA ? "" : "MSAA ",
@@ -832,7 +843,7 @@ std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelin
                                                            const void* cache_data,
                                                            size_t cache_data_length)
 {
-  return OGLPipeline::Create(config);
+  return OGLPipeline::Create(config, cache_data, cache_data_length);
 }
 
 void Renderer::SetScissorRect(const MathUtil::Rectangle<int>& rc)

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -828,7 +828,9 @@ std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage sta
   return nullptr;
 }
 
-std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config)
+std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config,
+                                                           const void* cache_data,
+                                                           size_t cache_data_length)
 {
   return OGLPipeline::Create(config);
 }

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -102,7 +102,9 @@ public:
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
-  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config) override;
+  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
+                                                   const void* cache_data = nullptr,
+                                                   size_t cache_data_length = 0) override;
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -48,7 +48,6 @@ enum class EsFbFetchType
 struct VideoConfig
 {
   bool bIsES;
-  bool bSupportsGLSLCache;
   bool bSupportsGLPinnedMemory;
   bool bSupportsGLSync;
   bool bSupportsGLBaseVertex;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -90,6 +90,8 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsCopyToVram = true;
   g_Config.backend_info.bSupportsLargePoints = true;
   g_Config.backend_info.bSupportsPartialDepthCopies = true;
+  g_Config.backend_info.bSupportsShaderBinaries = false;
+  g_Config.backend_info.bSupportsPipelineCacheData = false;
 
   // TODO: There is a bug here, if texel buffers or SSBOs/atomics are not supported the graphics
   // options will show the option when it is not supported. The only way around this would be

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -64,7 +64,6 @@ public:
   explicit SWShader(ShaderStage stage) : AbstractShader(stage) {}
   ~SWShader() = default;
 
-  bool HasBinary() const override { return false; }
   BinaryData GetBinary() const override { return {}; }
 };
 
@@ -87,7 +86,9 @@ public:
   ~SWPipeline() override = default;
 };
 
-std::unique_ptr<AbstractPipeline> SWRenderer::CreatePipeline(const AbstractPipelineConfig& config)
+std::unique_ptr<AbstractPipeline> SWRenderer::CreatePipeline(const AbstractPipelineConfig& config,
+                                                             const void* cache_data,
+                                                             size_t cache_data_length)
 {
   return std::make_unique<SWPipeline>();
 }

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -33,7 +33,9 @@ public:
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
-  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config) override;
+  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
+                                                   const void* cache_data = nullptr,
+                                                   size_t cache_data_length = 0) override;
 
   u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
   void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override {}

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -74,6 +74,8 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsFramebufferFetch = false;
   g_Config.backend_info.bSupportsBackgroundCompiling = false;
   g_Config.backend_info.bSupportsLogicOp = true;
+  g_Config.backend_info.bSupportsShaderBinaries = false;
+  g_Config.backend_info.bSupportsPipelineCacheData = false;
 
   // aamodes
   g_Config.backend_info.AAModes = {1};

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -112,7 +112,9 @@ Renderer::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
   return std::make_unique<VertexFormat>(vtx_decl);
 }
 
-std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config)
+std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config,
+                                                           const void* cache_data,
+                                                           size_t cache_data_length)
 {
   return VKPipeline::Create(config);
 }

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -48,7 +48,9 @@ public:
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
-  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config) override;
+  std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
+                                                   const void* cache_data = nullptr,
+                                                   size_t cache_data_length = 0) override;
 
   SwapChain* GetSwapChain() const { return m_swap_chain.get(); }
   BoundingBox* GetBoundingBox() const { return m_bounding_box.get(); }

--- a/Source/Core/VideoBackends/Vulkan/VKShader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.cpp
@@ -32,12 +32,6 @@ VKShader::~VKShader()
     vkDestroyPipeline(g_vulkan_context->GetDevice(), m_compute_pipeline, nullptr);
 }
 
-bool VKShader::HasBinary() const
-{
-  ASSERT(!m_spv.empty());
-  return true;
-}
-
 AbstractShader::BinaryData VKShader::GetBinary() const
 {
   BinaryData ret(sizeof(u32) * m_spv.size());

--- a/Source/Core/VideoBackends/Vulkan/VKShader.h
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.h
@@ -23,7 +23,6 @@ public:
 
   VkShaderModule GetShaderModule() const { return m_module; }
   VkPipeline GetComputePipeline() const { return m_compute_pipeline; }
-  bool HasBinary() const override;
   BinaryData GetBinary() const override;
 
   static std::unique_ptr<VKShader> CreateFromSource(ShaderStage stage, const char* source,

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -266,6 +266,8 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsGPUTextureDecoding = true;    // Assumed support.
   config->backend_info.bSupportsBitfield = true;              // Assumed support.
   config->backend_info.bSupportsPartialDepthCopies = true;    // Assumed support.
+  config->backend_info.bSupportsShaderBinaries = true;        // Assumed support.
+  config->backend_info.bSupportsPipelineCacheData = false;    // Handled via pipeline caches.
   config->backend_info.bSupportsDynamicSamplerIndexing = true;     // Assumed support.
   config->backend_info.bSupportsPostProcessing = true;             // Assumed support.
   config->backend_info.bSupportsBackgroundCompiling = true;        // Assumed support.

--- a/Source/Core/VideoCommon/AbstractPipeline.h
+++ b/Source/Core/VideoCommon/AbstractPipeline.h
@@ -75,4 +75,10 @@ class AbstractPipeline
 public:
   AbstractPipeline() = default;
   virtual ~AbstractPipeline() = default;
+
+  // "Cache data" can be used to assist a driver with creating pipelines by using previously
+  // compiled shader ISA. The abstract shaders and creation struct are still required to create
+  // pipeline objects, the cache is optionally used by the driver to speed up compilation.
+  using CacheData = std::vector<u8>;
+  virtual CacheData GetCacheData() const { return {}; }
 };

--- a/Source/Core/VideoCommon/AbstractShader.h
+++ b/Source/Core/VideoCommon/AbstractShader.h
@@ -25,9 +25,11 @@ public:
   virtual ~AbstractShader() = default;
 
   ShaderStage GetStage() const { return m_stage; }
+
+  // Shader binaries represent the input source code in a lower-level form. e.g. SPIR-V or DXBC.
+  // The shader source code is not required to create a shader object from the binary.
   using BinaryData = std::vector<u8>;
-  virtual bool HasBinary() const = 0;
-  virtual BinaryData GetBinary() const = 0;
+  virtual BinaryData GetBinary() const { return {}; }
 
 protected:
   ShaderStage m_stage;

--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -99,6 +99,16 @@ struct SerializedGXPipelineUid
   u32 depth_state_bits;
   u32 blending_state_bits;
 };
+struct SerializedGXUberPipelineUid
+{
+  PortableVertexDeclaration vertex_decl;
+  UberShader::VertexShaderUid vs_uid;
+  GeometryShaderUid gs_uid;
+  UberShader::PixelShaderUid ps_uid;
+  u32 rasterization_state_bits;
+  u32 depth_state_bits;
+  u32 blending_state_bits;
+};
 #pragma pack(pop)
 
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -130,8 +130,9 @@ public:
   CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length) = 0;
   virtual std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) = 0;
-  virtual std::unique_ptr<AbstractPipeline>
-  CreatePipeline(const AbstractPipelineConfig& config) = 0;
+  virtual std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
+                                                           const void* cache_data = nullptr,
+                                                           size_t cache_data_length = 0) = 0;
   std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
                                                          const std::string& source);
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -334,7 +334,7 @@ const AbstractShader* ShaderCache::InsertVertexShader(const VertexShaderUid& uid
 
   if (shader && !entry.shader)
   {
-    if (g_ActiveConfig.bShaderCache && shader->HasBinary())
+    if (g_ActiveConfig.bShaderCache && g_ActiveConfig.backend_info.bSupportsShaderBinaries)
     {
       auto binary = shader->GetBinary();
       if (!binary.empty())
@@ -356,7 +356,7 @@ const AbstractShader* ShaderCache::InsertVertexUberShader(const UberShader::Vert
 
   if (shader && !entry.shader)
   {
-    if (g_ActiveConfig.bShaderCache && shader->HasBinary())
+    if (g_ActiveConfig.bShaderCache && g_ActiveConfig.backend_info.bSupportsShaderBinaries)
     {
       auto binary = shader->GetBinary();
       if (!binary.empty())
@@ -378,7 +378,7 @@ const AbstractShader* ShaderCache::InsertPixelShader(const PixelShaderUid& uid,
 
   if (shader && !entry.shader)
   {
-    if (g_ActiveConfig.bShaderCache && shader->HasBinary())
+    if (g_ActiveConfig.bShaderCache && g_ActiveConfig.backend_info.bSupportsShaderBinaries)
     {
       auto binary = shader->GetBinary();
       if (!binary.empty())
@@ -400,7 +400,7 @@ const AbstractShader* ShaderCache::InsertPixelUberShader(const UberShader::Pixel
 
   if (shader && !entry.shader)
   {
-    if (g_ActiveConfig.bShaderCache && shader->HasBinary())
+    if (g_ActiveConfig.bShaderCache && g_ActiveConfig.backend_info.bSupportsShaderBinaries)
     {
       auto binary = shader->GetBinary();
       if (!binary.empty())
@@ -425,7 +425,7 @@ const AbstractShader* ShaderCache::CreateGeometryShader(const GeometryShaderUid&
 
   if (shader && !entry.shader)
   {
-    if (g_ActiveConfig.bShaderCache && shader->HasBinary())
+    if (g_ActiveConfig.bShaderCache && g_ActiveConfig.backend_info.bSupportsShaderBinaries)
     {
       auto binary = shader->GetBinary();
       if (!binary.empty())

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -25,8 +25,7 @@ namespace VideoCommon
 ShaderCache::ShaderCache() = default;
 ShaderCache::~ShaderCache()
 {
-  ClearShaderCaches();
-  ClearPipelineCaches();
+  ClearCaches();
 }
 
 bool ShaderCache::Initialize()
@@ -48,7 +47,7 @@ void ShaderCache::InitializeShaderCache()
   // Load shader and UID caches.
   if (g_ActiveConfig.bShaderCache && m_api_type != APIType::Nothing)
   {
-    LoadShaderCaches();
+    LoadCaches();
     LoadPipelineUIDCache();
   }
 
@@ -69,11 +68,10 @@ void ShaderCache::Reload()
 {
   WaitForAsyncCompiler();
   ClosePipelineUIDCache();
-  InvalidateCachedPipelines();
-  ClearShaderCaches();
+  ClearCaches();
 
   if (g_ActiveConfig.bShaderCache)
-    LoadShaderCaches();
+    LoadCaches();
 
   // Switch to the precompiling shader configuration while we rebuild.
   m_async_shader_compiler->ResizeWorkerThreads(g_ActiveConfig.GetShaderPrecompilerThreads());
@@ -140,7 +138,7 @@ const AbstractPipeline* ShaderCache::GetUberPipelineForUid(const GXUberPipelineU
     return it->second.first.get();
 
   std::unique_ptr<AbstractPipeline> pipeline;
-  std::optional<AbstractPipelineConfig> pipeline_config = GetGXUberPipelineConfig(uid);
+  std::optional<AbstractPipelineConfig> pipeline_config = GetGXPipelineConfig(uid);
   if (pipeline_config)
     pipeline = g_renderer->CreatePipeline(*pipeline_config);
   return InsertGXUberPipeline(uid, std::move(pipeline));
@@ -176,8 +174,34 @@ void ShaderCache::WaitForAsyncCompiler()
   }
 }
 
+template <typename SerializedUidType, typename UidType>
+static void SerializePipelineUid(const UidType& uid, SerializedUidType& serialized_uid)
+{
+  // Convert to disk format. Ensure all padding bytes are zero.
+  std::memset(&serialized_uid, 0, sizeof(serialized_uid));
+  serialized_uid.vertex_decl = uid.vertex_format->GetVertexDeclaration();
+  serialized_uid.vs_uid = uid.vs_uid;
+  serialized_uid.gs_uid = uid.gs_uid;
+  serialized_uid.ps_uid = uid.ps_uid;
+  serialized_uid.rasterization_state_bits = uid.rasterization_state.hex;
+  serialized_uid.depth_state_bits = uid.depth_state.hex;
+  serialized_uid.blending_state_bits = uid.blending_state.hex;
+}
+
+template <typename UidType, typename SerializedUidType>
+static void UnserializePipelineUid(const SerializedUidType& uid, UidType& real_uid)
+{
+  real_uid.vertex_format = VertexLoaderManager::GetOrCreateMatchingFormat(uid.vertex_decl);
+  real_uid.vs_uid = uid.vs_uid;
+  real_uid.gs_uid = uid.gs_uid;
+  real_uid.ps_uid = uid.ps_uid;
+  real_uid.rasterization_state.hex = uid.rasterization_state_bits;
+  real_uid.depth_state.hex = uid.depth_state_bits;
+  real_uid.blending_state.hex = uid.blending_state_bits;
+}
+
 template <ShaderStage stage, typename K, typename T>
-static void LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid)
+void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, bool include_gameid)
 {
   class CacheReader : public LinearDiskCacheReader<K, u8>
   {
@@ -219,38 +243,127 @@ static void LoadShaderCache(T& cache, APIType api_type, const char* type, bool i
 }
 
 template <typename T>
-static void ClearShaderCache(T& cache)
+void ShaderCache::ClearShaderCache(T& cache)
 {
   cache.disk_cache.Sync();
   cache.disk_cache.Close();
   cache.shader_map.clear();
 }
 
-void ShaderCache::LoadShaderCaches()
+template <typename KeyType, typename DiskKeyType, typename T>
+void ShaderCache::LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& disk_cache,
+                                    APIType api_type, const char* type, bool include_gameid)
 {
-  // Ubershader caches, if present.
-  LoadShaderCache<ShaderStage::Vertex, UberShader::VertexShaderUid>(m_uber_vs_cache, m_api_type,
-                                                                    "uber-vs", false);
-  LoadShaderCache<ShaderStage::Pixel, UberShader::PixelShaderUid>(m_uber_ps_cache, m_api_type,
-                                                                  "uber-ps", false);
+  class CacheReader : public LinearDiskCacheReader<DiskKeyType, u8>
+  {
+  public:
+    CacheReader(ShaderCache* this_ptr_, T& cache_) : this_ptr(this_ptr_), cache(cache_) {}
+    bool AnyFailed() const { return failed; }
+    void Read(const DiskKeyType& key, const u8* value, u32 value_size)
+    {
+      KeyType real_uid;
+      UnserializePipelineUid(key, real_uid);
 
-  // We also share geometry shaders, as there aren't many variants.
-  if (m_host_config.backend_geometry_shaders)
-    LoadShaderCache<ShaderStage::Geometry, GeometryShaderUid>(m_gs_cache, m_api_type, "gs", false);
+      // Skip those which are already compiled.
+      if (failed || cache.find(real_uid) != cache.end())
+        return;
 
-  // Specialized shaders, gameid-specific.
-  LoadShaderCache<ShaderStage::Vertex, VertexShaderUid>(m_vs_cache, m_api_type, "specialized-vs",
-                                                        true);
-  LoadShaderCache<ShaderStage::Pixel, PixelShaderUid>(m_ps_cache, m_api_type, "specialized-ps",
-                                                      true);
+      auto config = this_ptr->GetGXPipelineConfig(real_uid);
+      if (!config)
+        return;
+
+      auto pipeline = g_renderer->CreatePipeline(*config, value, value_size);
+      if (!pipeline)
+      {
+        // If any of the pipelines fail to create, consider the cache stale.
+        failed = true;
+        return;
+      }
+
+      auto& entry = cache[real_uid];
+      entry.first = std::move(pipeline);
+      entry.second = false;
+    }
+
+  private:
+    ShaderCache* this_ptr;
+    T& cache;
+    bool failed = false;
+  };
+
+  std::string filename = GetDiskShaderCacheFileName(api_type, type, include_gameid, true);
+  CacheReader reader(this, cache);
+  u32 count = disk_cache.OpenAndRead(filename, reader);
+  INFO_LOG(VIDEO, "Loaded %u cached pipelines from %s", count, filename.c_str());
+
+  // If any of the pipelines in the cache failed to create, it's likely because of a change of
+  // driver version, or system configuration. In this case, when the UID cache picks up the pipeline
+  // later on, we'll write a duplicate entry to the pipeline cache. There's also no point in keeping
+  // the old cache data around, so discard and recreate the disk cache.
+  if (reader.AnyFailed())
+  {
+    WARN_LOG(VIDEO, "Failed to load one or more pipelines from cache '%s'. Discarding.",
+             filename.c_str());
+    disk_cache.Close();
+    File::Delete(filename);
+    disk_cache.OpenAndRead(filename, reader);
+  }
 }
 
-void ShaderCache::ClearShaderCaches()
+template <typename T, typename Y>
+void ShaderCache::ClearPipelineCache(T& cache, Y& disk_cache)
 {
+  disk_cache.Sync();
+  disk_cache.Close();
+
+  // Set the pending flag to false, and destroy the pipeline.
+  for (auto& it : cache)
+  {
+    it.second.first.reset();
+    it.second.second = false;
+  }
+}
+
+void ShaderCache::LoadCaches()
+{
+  // Ubershader caches, if present.
+  if (g_ActiveConfig.backend_info.bSupportsShaderBinaries)
+  {
+    LoadShaderCache<ShaderStage::Vertex, UberShader::VertexShaderUid>(m_uber_vs_cache, m_api_type,
+                                                                      "uber-vs", false);
+    LoadShaderCache<ShaderStage::Pixel, UberShader::PixelShaderUid>(m_uber_ps_cache, m_api_type,
+                                                                    "uber-ps", false);
+
+    // We also share geometry shaders, as there aren't many variants.
+    if (m_host_config.backend_geometry_shaders)
+      LoadShaderCache<ShaderStage::Geometry, GeometryShaderUid>(m_gs_cache, m_api_type, "gs",
+                                                                false);
+
+    // Specialized shaders, gameid-specific.
+    LoadShaderCache<ShaderStage::Vertex, VertexShaderUid>(m_vs_cache, m_api_type, "specialized-vs",
+                                                          true);
+    LoadShaderCache<ShaderStage::Pixel, PixelShaderUid>(m_ps_cache, m_api_type, "specialized-ps",
+                                                        true);
+  }
+
+  if (g_ActiveConfig.backend_info.bSupportsPipelineCacheData)
+  {
+    LoadPipelineCache<GXPipelineUid, SerializedGXPipelineUid>(
+        m_gx_pipeline_cache, m_gx_pipeline_disk_cache, m_api_type, "specialized-pipeline", true);
+    LoadPipelineCache<GXUberPipelineUid, SerializedGXUberPipelineUid>(
+        m_gx_uber_pipeline_cache, m_gx_uber_pipeline_disk_cache, m_api_type, "uber-pipeline",
+        false);
+  }
+}
+
+void ShaderCache::ClearCaches()
+{
+  ClearPipelineCache(m_gx_pipeline_cache, m_gx_pipeline_disk_cache);
   ClearShaderCache(m_vs_cache);
   ClearShaderCache(m_gs_cache);
   ClearShaderCache(m_ps_cache);
 
+  ClearPipelineCache(m_gx_uber_pipeline_cache, m_gx_uber_pipeline_disk_cache);
   ClearShaderCache(m_uber_vs_cache);
   ClearShaderCache(m_uber_ps_cache);
 
@@ -265,35 +378,14 @@ void ShaderCache::CompileMissingPipelines()
   // Queue all uids with a null pipeline for compilation.
   for (auto& it : m_gx_pipeline_cache)
   {
-    if (!it.second.second)
+    if (!it.second.first)
       QueuePipelineCompile(it.first, COMPILE_PRIORITY_SHADERCACHE_PIPELINE);
   }
   for (auto& it : m_gx_uber_pipeline_cache)
   {
-    if (!it.second.second)
+    if (!it.second.first)
       QueueUberPipelineCompile(it.first, COMPILE_PRIORITY_UBERSHADER_PIPELINE);
   }
-}
-
-void ShaderCache::InvalidateCachedPipelines()
-{
-  // Set the pending flag to false, and destroy the pipeline.
-  for (auto& it : m_gx_pipeline_cache)
-  {
-    it.second.first.reset();
-    it.second.second = false;
-  }
-  for (auto& it : m_gx_uber_pipeline_cache)
-  {
-    it.second.first.reset();
-    it.second.second = false;
-  }
-}
-
-void ShaderCache::ClearPipelineCaches()
-{
-  m_gx_pipeline_cache.clear();
-  m_gx_uber_pipeline_cache.clear();
 }
 
 std::unique_ptr<AbstractShader> ShaderCache::CompileVertexShader(const VertexShaderUid& uid) const
@@ -505,7 +597,7 @@ std::optional<AbstractPipelineConfig> ShaderCache::GetGXPipelineConfig(const GXP
 }
 
 std::optional<AbstractPipelineConfig>
-ShaderCache::GetGXUberPipelineConfig(const GXUberPipelineUid& config)
+ShaderCache::GetGXPipelineConfig(const GXUberPipelineUid& config)
 {
   const AbstractShader* vs;
   auto vs_iter = m_uber_vs_cache.shader_map.find(config.vs_uid);
@@ -551,6 +643,18 @@ const AbstractPipeline* ShaderCache::InsertGXPipeline(const GXPipelineUid& confi
   if (!entry.first && pipeline)
     entry.first = std::move(pipeline);
 
+  if (g_ActiveConfig.bShaderCache)
+  {
+    auto cache_data = entry.first->GetCacheData();
+    if (!cache_data.empty())
+    {
+      SerializedGXPipelineUid disk_uid;
+      SerializePipelineUid(config, disk_uid);
+      m_gx_pipeline_disk_cache.Append(disk_uid, cache_data.data(),
+                                      static_cast<u32>(cache_data.size()));
+    }
+  }
+
   return entry.first.get();
 }
 
@@ -562,6 +666,18 @@ ShaderCache::InsertGXUberPipeline(const GXUberPipelineUid& config,
   entry.second = false;
   if (!entry.first && pipeline)
     entry.first = std::move(pipeline);
+
+  if (g_ActiveConfig.bShaderCache)
+  {
+    auto cache_data = entry.first->GetCacheData();
+    if (!cache_data.empty())
+    {
+      SerializedGXUberPipelineUid disk_uid;
+      SerializePipelineUid(config, disk_uid);
+      m_gx_uber_pipeline_disk_cache.Append(disk_uid, cache_data.data(),
+                                           static_cast<u32>(cache_data.size()));
+    }
+  }
 
   return entry.first.get();
 }
@@ -648,14 +764,8 @@ void ShaderCache::ClosePipelineUIDCache()
 
 void ShaderCache::AddSerializedGXPipelineUID(const SerializedGXPipelineUid& uid)
 {
-  GXPipelineUid real_uid = {};
-  real_uid.vertex_format = VertexLoaderManager::GetOrCreateMatchingFormat(uid.vertex_decl);
-  real_uid.vs_uid = uid.vs_uid;
-  real_uid.gs_uid = uid.gs_uid;
-  real_uid.ps_uid = uid.ps_uid;
-  real_uid.rasterization_state.hex = uid.rasterization_state_bits;
-  real_uid.depth_state.hex = uid.depth_state_bits;
-  real_uid.blending_state.hex = uid.blending_state_bits;
+  GXPipelineUid real_uid;
+  UnserializePipelineUid(uid, real_uid);
 
   auto iter = m_gx_pipeline_cache.find(real_uid);
   if (iter != m_gx_pipeline_cache.end())
@@ -671,16 +781,8 @@ void ShaderCache::AppendGXPipelineUID(const GXPipelineUid& config)
   if (!m_gx_pipeline_uid_cache_file.IsOpen())
     return;
 
-  // Convert to disk format. Ensure all padding bytes are zero.
   SerializedGXPipelineUid disk_uid;
-  std::memset(&disk_uid, 0, sizeof(disk_uid));
-  disk_uid.vertex_decl = config.vertex_format->GetVertexDeclaration();
-  disk_uid.vs_uid = config.vs_uid;
-  disk_uid.gs_uid = config.gs_uid;
-  disk_uid.ps_uid = config.ps_uid;
-  disk_uid.rasterization_state_bits = config.rasterization_state.hex;
-  disk_uid.depth_state_bits = config.depth_state.hex;
-  disk_uid.blending_state_bits = config.blending_state.hex;
+  SerializePipelineUid(config, disk_uid);
   if (!m_gx_pipeline_uid_cache_file.WriteBytes(&disk_uid, sizeof(disk_uid)))
   {
     WARN_LOG(VIDEO, "Writing pipeline UID to cache failed, closing file.");
@@ -885,7 +987,7 @@ void ShaderCache::QueueUberPipelineCompile(const GXUberPipelineUid& uid, u32 pri
       // Check if all the stages required for this UberPipeline have been compiled.
       // If not, this work item becomes a no-op, and re-queues the UberPipeline for the next frame.
       if (SetStagesReady())
-        config = shader_cache->GetGXUberPipelineConfig(uid);
+        config = shader_cache->GetGXPipelineConfig(uid);
     }
 
     bool SetStagesReady()

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -219,6 +219,8 @@ struct VideoConfig final
     bool bSupportsBackgroundCompiling;
     bool bSupportsLargePoints;
     bool bSupportsPartialDepthCopies;
+    bool bSupportsShaderBinaries;
+    bool bSupportsPipelineCacheData;
   } backend_info;
 
   // Utility


### PR DESCRIPTION
Based on bug reports, it seems that some drivers (Intel and AMD) may not have their own disk cache for D3D12 pipelines. This was resulting in shader compilation occurring every time the emulator was booted.

This PR implements a pipeline data cache. "Cache data" can be used to assist a driver with creating pipelines by using previously-compiled shader ISA. Note that the pipeline data cache does not replace the UID cache, there is no guarantee that the cache data will be accepted by the driver.

I also extended this to OpenGL, using program binaries as the payload. This means for Android devices which don't have a disk cache, it will speed up game booting. Synchronous ubershader stuttering in D3D12 could also be improved, as the ubershader variants will be cached.

If any pipelines fail to create from the cache data, the entire cache is thrown out, and rebuilt from the UID cache. This means that driver updates won't cause duplicate entries in the cache :)