### PR TITLE
Slow down relative input cursor

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -39,7 +39,7 @@ public:
 private:
   // This is used to reduce the cursor speed for relative input
   // to something that makes sense with the default range.
-  static constexpr double STEP_PER_SEC = 0.04 * 200;
+  static constexpr double STEP_PER_SEC = 0.01 * 200;
 
   // Smooth out forward/backward movements:
   static constexpr double STEP_Z_PER_SEC = 0.05 * 200;


### PR DESCRIPTION
This makes it about 1/4th the speed which may be a bit slow, but should work for most controllers.