### PR TITLE
fix and reorder lwz Jit idle skip

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -119,41 +119,6 @@ void Jit64::lXXx(UGeckoInstruction inst)
     signExtend = true;
   }
 
-  if (!CPU::IsStepping() && inst.OPCD == 32 && CanMergeNextInstructions(2) &&
-      (inst.hex & 0xFFFF0000) == 0x800D0000 &&
-      (js.op[1].inst.hex == 0x28000000 ||
-       (SConfig::GetInstance().bWii && js.op[1].inst.hex == 0x2C000000)) &&
-      js.op[2].inst.hex == 0x4182fff8)
-  {
-    s32 offset = (s32)(s16)inst.SIMM_16;
-    RCX64Reg Ra = gpr.Bind(a, RCMode::Read);
-    RCX64Reg Rd = gpr.Bind(d, RCMode::Write);
-    RegCache::Realize(Ra, Rd);
-
-    SafeLoadToReg(Rd, Ra, accessSize, offset, CallerSavedRegistersInUse(), signExtend);
-
-    // if it's still 0, we can wait until the next event
-    TEST(32, Rd, Rd);
-    FixupBranch noIdle = J_CC(CC_NZ);
-
-    BitSet32 registersInUse = CallerSavedRegistersInUse();
-    ABI_PushRegistersAndAdjustStack(registersInUse, 0);
-
-    ABI_CallFunction(CoreTiming::Idle);
-
-    ABI_PopRegistersAndAdjustStack(registersInUse, 0);
-
-    // ! we must continue executing of the loop after exception handling, maybe there is still 0 in
-    // r0
-    // MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
-    WriteExceptionExit();
-
-    SetJumpTarget(noIdle);
-
-    // js.compilerPC += 8;
-    return;
-  }
-
   // Determine whether this instruction updates inst.RA
   bool update;
   if (inst.OPCD == 31)
@@ -260,6 +225,34 @@ void Jit64::lXXx(UGeckoInstruction inst)
   // TODO: support no-swap in SafeLoadToReg instead
   if (byte_reversed)
     BSWAP(accessSize, Rd);
+
+  // LWZ idle skipping
+  if (!CPU::IsStepping() && inst.OPCD == 32 && CanMergeNextInstructions(2) &&
+      (inst.hex & 0xFFFF0000) == 0x800D0000 &&  // lwz r0, XXXX(r13)
+      (js.op[1].inst.hex == 0x28000000 ||
+       (SConfig::GetInstance().bWii && js.op[1].inst.hex == 0x2C000000)) &&  // cmpXwi r0,0
+      js.op[2].inst.hex == 0x4182fff8)                                       // beq -8
+  {
+    // if it's still 0, we can wait until the next event
+    TEST(32, Rd, Rd);
+    FixupBranch noIdle = J_CC(CC_NZ);
+
+    BitSet32 registersInUse = CallerSavedRegistersInUse();
+    ABI_PushRegistersAndAdjustStack(registersInUse, 0);
+
+    ABI_CallFunction(CoreTiming::Idle);
+
+    ABI_PopRegistersAndAdjustStack(registersInUse, 0);
+
+    // ! we must continue executing of the loop after exception handling, maybe there is still 0 in
+    // r0
+    // MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
+    // WriteExceptionExit();
+    // this call breaks RE0 at the manhole opener on the train
+    // more specifically on the instruction 800d9c20
+
+    SetJumpTarget(noIdle);
+  }
 }
 
 void Jit64::dcbx(UGeckoInstruction inst)


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/10129
Probably conflicts with https://github.com/dolphin-emu/dolphin/pull/7287 by @degasus 

This fixes the manhole opener for the back of the train in RE0 (Resident Evil 0)
I'm not familiar enough with the code to say why, my only guess is that the call to WriteExceptionExit() clobbers a register somewhere.

This DOES NOT however fix games like Need For Speed: Hot Pursuit 2. The OPCD == 32 (LWZ) causes the game to perform very poorly. Commenting it out (like in degasus' PR) fixes this problem and seems to have no effect on any of the games I have tested (see bug link).

Don't recommend to merge this, just bring attention.