### PR TITLE
VideoCommon: Move imgui-related functions/data to ImGuiManager class

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -28,7 +28,7 @@
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
-#include "VideoCommon/RenderBase.h"
+#include "VideoCommon/ImGuiManager.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -269,7 +269,7 @@ void RenderWidget::PassEventToImGui(const QEvent* event)
     const QKeyEvent* key_event = static_cast<const QKeyEvent*>(event);
     const bool is_down = event->type() == QEvent::KeyPress;
     const u32 key = static_cast<u32>(key_event->key() & 0x1FF);
-    auto lock = g_renderer->GetImGuiLock();
+    auto lock = g_imgui_manager->GetStateLock();
     if (key < ArraySize(ImGui::GetIO().KeysDown))
       ImGui::GetIO().KeysDown[key] = is_down;
 
@@ -283,7 +283,7 @@ void RenderWidget::PassEventToImGui(const QEvent* event)
 
   case QEvent::MouseMove:
   {
-    auto lock = g_renderer->GetImGuiLock();
+    auto lock = g_imgui_manager->GetStateLock();
 
     // Qt multiplies all coordinates by the scaling factor in highdpi mode, giving us "scaled" mouse
     // coordinates (as if the screen was standard dpi). We need to update the mouse position in
@@ -297,7 +297,7 @@ void RenderWidget::PassEventToImGui(const QEvent* event)
   case QEvent::MouseButtonPress:
   case QEvent::MouseButtonRelease:
   {
-    auto lock = g_renderer->GetImGuiLock();
+    auto lock = g_imgui_manager->GetStateLock();
     const u32 button_mask = static_cast<u32>(static_cast<const QMouseEvent*>(event)->buttons());
     for (size_t i = 0; i < ArraySize(ImGui::GetIO().MouseDown); i++)
       ImGui::GetIO().MouseDown[i] = (button_mask & (1u << i)) != 0;
@@ -332,7 +332,7 @@ void RenderWidget::SetImGuiKeyMap()
                                    {ImGuiKey_X, Qt::Key_X},
                                    {ImGuiKey_Y, Qt::Key_Y},
                                    {ImGuiKey_Z, Qt::Key_Z}};
-  auto lock = g_renderer->GetImGuiLock();
+  auto lock = g_imgui_manager->GetStateLock();
   for (size_t i = 0; i < ArraySize(key_map); i++)
     ImGui::GetIO().KeyMap[key_map[i][0]] = (key_map[i][1] & 0x1FF);
 }

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(videocommon
   HiresTextures.cpp
   HiresTextures_DDSLoader.cpp
   ImageWrite.cpp
+  ImGuiManager.cpp
   IndexGenerator.cpp
   LightingShaderGen.cpp
   NetPlayChatUI.cpp

--- a/Source/Core/VideoCommon/ImGuiManager.cpp
+++ b/Source/Core/VideoCommon/ImGuiManager.cpp
@@ -1,0 +1,380 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <cinttypes>
+#include <sstream>
+
+#include "Common/MsgHandler.h"
+#include "Common/Timer.h"
+#include "Core/Config/NetplaySettings.h"
+#include "Core/ConfigManager.h"
+#include "Core/Movie.h"
+#include "VideoCommon/AbstractPipeline.h"
+#include "VideoCommon/AbstractShader.h"
+#include "VideoCommon/AbstractTexture.h"
+#include "VideoCommon/FPSCounter.h"
+#include "VideoCommon/ImGuiManager.h"
+#include "VideoCommon/NetPlayChatUI.h"
+#include "VideoCommon/NetPlayGolfUI.h"
+#include "VideoCommon/OnScreenDisplay.h"
+#include "VideoCommon/RenderBase.h"
+#include "VideoCommon/Statistics.h"
+#include "VideoCommon/VertexManagerBase.h"
+#include "VideoCommon/VertexShaderGen.h"
+
+#include "imgui.h"
+
+std::unique_ptr<VideoCommon::ImGuiManager> g_imgui_manager;
+
+namespace VideoCommon
+{
+ImGuiManager::ImGuiManager(AbstractTextureFormat backbuffer_format, float backbuffer_scale)
+    : m_backbuffer_format(backbuffer_format), m_backbuffer_scale(backbuffer_scale)
+{
+}
+
+ImGuiManager::~ImGuiManager() = default;
+
+static std::string GenerateImGuiVertexShader()
+{
+  const APIType api_type = g_ActiveConfig.backend_info.api_type;
+  std::stringstream ss;
+
+  // Uniform buffer contains the viewport size, and we transform in the vertex shader.
+  if (api_type == APIType::D3D)
+    ss << "cbuffer PSBlock : register(b0) {\n";
+  else if (api_type == APIType::OpenGL)
+    ss << "UBO_BINDING(std140, 1) uniform PSBlock {\n";
+  else if (api_type == APIType::Vulkan)
+    ss << "UBO_BINDING(std140, 1) uniform PSBlock {\n";
+  ss << "float2 u_rcp_viewport_size_mul2;\n";
+  ss << "};\n";
+
+  if (api_type == APIType::D3D)
+  {
+    ss << "void main(in float2 rawpos : POSITION,\n"
+       << "          in float2 rawtex0 : TEXCOORD,\n"
+       << "          in float4 rawcolor0 : COLOR,\n"
+       << "          out float2 frag_uv : TEXCOORD,\n"
+       << "          out float4 frag_color : COLOR,\n"
+       << "          out float4 out_pos : SV_Position)\n";
+  }
+  else
+  {
+    ss << "ATTRIBUTE_LOCATION(" << SHADER_POSITION_ATTRIB << ") in float2 rawpos;\n"
+       << "ATTRIBUTE_LOCATION(" << SHADER_TEXTURE0_ATTRIB << ") in float2 rawtex0;\n"
+       << "ATTRIBUTE_LOCATION(" << SHADER_COLOR0_ATTRIB << ") in float4 rawcolor0;\n"
+       << "VARYING_LOCATION(0) out float2 frag_uv;\n"
+       << "VARYING_LOCATION(1) out float4 frag_color;\n"
+       << "void main()\n";
+  }
+
+  ss << "{\n"
+     << "  frag_uv = rawtex0;\n"
+     << "  frag_color = rawcolor0;\n";
+
+  ss << "  " << (api_type == APIType::D3D ? "out_pos" : "gl_Position")
+     << "= float4(rawpos.x * u_rcp_viewport_size_mul2.x - 1.0, 1.0 - rawpos.y * "
+        "u_rcp_viewport_size_mul2.y, 0.0, 1.0);\n";
+
+  // Clip-space is flipped in Vulkan
+  if (api_type == APIType::Vulkan)
+    ss << "  gl_Position.y = -gl_Position.y;\n";
+
+  ss << "}\n";
+  return ss.str();
+}
+
+static std::string GenerateImGuiPixelShader()
+{
+  const APIType api_type = g_ActiveConfig.backend_info.api_type;
+
+  std::stringstream ss;
+  if (api_type == APIType::D3D)
+  {
+    ss << "Texture2DArray tex0 : register(t0);\n"
+       << "SamplerState samp0 : register(s0);\n"
+       << "void main(in float2 frag_uv : TEXCOORD,\n"
+       << "          in float4 frag_color : COLOR,\n"
+       << "          out float4 ocol0 : SV_Target)\n";
+  }
+  else
+  {
+    ss << "SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n"
+       << "VARYING_LOCATION(0) in float2 frag_uv; \n"
+       << "VARYING_LOCATION(1) in float4 frag_color;\n"
+       << "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n"
+       << "void main()\n";
+  }
+
+  ss << "{\n";
+
+  if (api_type == APIType::D3D)
+    ss << "  ocol0 = tex0.Sample(samp0, float3(frag_uv, 0.0)) * frag_color;\n";
+  else
+    ss << "  ocol0 = texture(samp0, float3(frag_uv, 0.0)) * frag_color;\n";
+
+  ss << "}\n";
+
+  return ss.str();
+}
+
+bool ImGuiManager::Initialize()
+{
+  if (!ImGui::CreateContext())
+  {
+    PanicAlert("Creating ImGui context failed");
+    return false;
+  }
+
+  // Don't create an ini file. TODO: Do we want this in the future?
+  ImGuiIO& io = ImGui::GetIO();
+  io.IniFilename = nullptr;
+  io.DisplaySize.x = static_cast<float>(g_renderer->GetBackbufferWidth());
+  io.DisplaySize.y = static_cast<float>(g_renderer->GetBackbufferHeight());
+  io.DisplayFramebufferScale.x = m_backbuffer_scale;
+  io.DisplayFramebufferScale.y = m_backbuffer_scale;
+  io.FontGlobalScale = m_backbuffer_scale;
+  ImGui::GetStyle().ScaleAllSizes(m_backbuffer_scale);
+
+  PortableVertexDeclaration vdecl = {};
+  vdecl.position = {VAR_FLOAT, 2, offsetof(ImDrawVert, pos), true, false};
+  vdecl.texcoords[0] = {VAR_FLOAT, 2, offsetof(ImDrawVert, uv), true, false};
+  vdecl.colors[0] = {VAR_UNSIGNED_BYTE, 4, offsetof(ImDrawVert, col), true, false};
+  vdecl.stride = sizeof(ImDrawVert);
+  m_imgui_vertex_format = g_renderer->CreateNativeVertexFormat(vdecl);
+  if (!m_imgui_vertex_format)
+  {
+    PanicAlert("Failed to create imgui vertex format");
+    return false;
+  }
+
+  const std::string vertex_shader_source = GenerateImGuiVertexShader();
+  const std::string pixel_shader_source = GenerateImGuiPixelShader();
+  std::unique_ptr<AbstractShader> vertex_shader = g_renderer->CreateShaderFromSource(
+      ShaderStage::Vertex, vertex_shader_source.c_str(), vertex_shader_source.size());
+  std::unique_ptr<AbstractShader> pixel_shader = g_renderer->CreateShaderFromSource(
+      ShaderStage::Pixel, pixel_shader_source.c_str(), pixel_shader_source.size());
+  if (!vertex_shader || !pixel_shader)
+  {
+    PanicAlert("Failed to compile imgui shaders");
+    return false;
+  }
+
+  AbstractPipelineConfig pconfig = {};
+  pconfig.vertex_format = m_imgui_vertex_format.get();
+  pconfig.vertex_shader = vertex_shader.get();
+  pconfig.pixel_shader = pixel_shader.get();
+  pconfig.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
+  pconfig.depth_state = RenderState::GetNoDepthTestingDepthState();
+  pconfig.blending_state = RenderState::GetNoBlendingBlendState();
+  pconfig.blending_state.blendenable = true;
+  pconfig.blending_state.srcfactor = BlendMode::SRCALPHA;
+  pconfig.blending_state.dstfactor = BlendMode::INVSRCALPHA;
+  pconfig.blending_state.srcfactoralpha = BlendMode::ZERO;
+  pconfig.blending_state.dstfactoralpha = BlendMode::ONE;
+  pconfig.framebuffer_state.color_texture_format = m_backbuffer_format;
+  pconfig.framebuffer_state.depth_texture_format = AbstractTextureFormat::Undefined;
+  pconfig.framebuffer_state.samples = 1;
+  pconfig.framebuffer_state.per_sample_shading = false;
+  pconfig.usage = AbstractPipelineUsage::Utility;
+  m_imgui_pipeline = g_renderer->CreatePipeline(pconfig);
+  if (!m_imgui_pipeline)
+  {
+    PanicAlert("Failed to create imgui pipeline");
+    return false;
+  }
+
+  // Font texture(s).
+  {
+    u8* font_tex_pixels;
+    int font_tex_width, font_tex_height;
+    io.Fonts->GetTexDataAsRGBA32(&font_tex_pixels, &font_tex_width, &font_tex_height);
+
+    TextureConfig font_tex_config(font_tex_width, font_tex_height, 1, 1, 1,
+                                  AbstractTextureFormat::RGBA8, 0);
+    std::unique_ptr<AbstractTexture> font_tex = g_renderer->CreateTexture(font_tex_config);
+    if (!font_tex)
+    {
+      PanicAlert("Failed to create imgui texture");
+      return false;
+    }
+    font_tex->Load(0, font_tex_width, font_tex_height, font_tex_width, font_tex_pixels,
+                   sizeof(u32) * font_tex_width * font_tex_height);
+
+    io.Fonts->TexID = font_tex.get();
+
+    m_imgui_textures.push_back(std::move(font_tex));
+  }
+
+  m_last_frame_time = Common::Timer::GetTimeUs();
+  ImGui::NewFrame();
+  return true;
+}
+
+void ImGuiManager::Shutdown()
+{
+  ImGui::EndFrame();
+  ImGui::DestroyContext();
+  m_imgui_pipeline.reset();
+  m_imgui_vertex_format.reset();
+  m_imgui_textures.clear();
+}
+
+void ImGuiManager::Render()
+{
+  ImGui::Render();
+
+  ImDrawData* draw_data = ImGui::GetDrawData();
+  if (!draw_data || g_renderer->IsHeadless())
+    return;
+
+  ImGuiIO& io = ImGui::GetIO();
+  g_renderer->SetViewport(0.0f, 0.0f, io.DisplaySize.x, io.DisplaySize.y, 0.0f, 1.0f);
+
+  // Uniform buffer for draws.
+  struct ImGuiUbo
+  {
+    float u_rcp_viewport_size_mul2[2];
+    float padding[2];
+  };
+  ImGuiUbo ubo = {{1.0f / io.DisplaySize.x * 2.0f, 1.0f / io.DisplaySize.y * 2.0f}};
+
+  // Set up common state for drawing.
+  g_renderer->SetPipeline(m_imgui_pipeline.get());
+  g_renderer->SetSamplerState(0, RenderState::GetPointSamplerState());
+  g_vertex_manager->UploadUtilityUniforms(&ubo, sizeof(ubo));
+
+  for (int i = 0; i < draw_data->CmdListsCount; i++)
+  {
+    const ImDrawList* cmdlist = draw_data->CmdLists[i];
+    if (cmdlist->VtxBuffer.empty() || cmdlist->IdxBuffer.empty())
+      return;
+
+    u32 base_vertex, base_index;
+    g_vertex_manager->UploadUtilityVertices(cmdlist->VtxBuffer.Data, sizeof(ImDrawVert),
+                                            cmdlist->VtxBuffer.Size, cmdlist->IdxBuffer.Data,
+                                            cmdlist->IdxBuffer.Size, &base_vertex, &base_index);
+
+    for (const ImDrawCmd& cmd : cmdlist->CmdBuffer)
+    {
+      if (cmd.UserCallback)
+      {
+        cmd.UserCallback(cmdlist, &cmd);
+        continue;
+      }
+
+      g_renderer->SetScissorRect(g_renderer->ConvertFramebufferRectangle(
+          MathUtil::Rectangle<int>(
+              static_cast<int>(cmd.ClipRect.x), static_cast<int>(cmd.ClipRect.y),
+              static_cast<int>(cmd.ClipRect.z), static_cast<int>(cmd.ClipRect.w)),
+          g_renderer->GetCurrentFramebuffer()));
+      g_renderer->SetTexture(0, reinterpret_cast<const AbstractTexture*>(cmd.TextureId));
+      g_renderer->DrawIndexed(base_index, cmd.ElemCount, base_vertex);
+      base_index += cmd.ElemCount;
+    }
+  }
+}
+
+std::unique_lock<std::mutex> ImGuiManager::GetStateLock()
+{
+  return std::unique_lock<std::mutex>(m_state_mutex);
+}
+
+void ImGuiManager::EndFrame()
+{
+  std::unique_lock<std::mutex> imgui_lock(m_state_mutex);
+
+  const u64 current_time_us = Common::Timer::GetTimeUs();
+  const u64 time_diff_us = current_time_us - m_last_frame_time;
+  const float time_diff_secs = static_cast<float>(time_diff_us / 1000000.0);
+  m_last_frame_time = current_time_us;
+  ImGui::NewFrame();
+
+  // Update I/O with window dimensions.
+  ImGuiIO& io = ImGui::GetIO();
+  io.DisplaySize.x = static_cast<float>(g_renderer->GetBackbufferWidth());
+  io.DisplaySize.y = static_cast<float>(g_renderer->GetBackbufferHeight());
+  io.DeltaTime = time_diff_secs;
+}
+
+void ImGuiManager::Draw()
+{
+  DrawFPSWindow();
+  DrawMovieWindow();
+
+  if (g_ActiveConfig.bOverlayStats)
+    Statistics::Display();
+
+  if (g_ActiveConfig.bShowNetPlayMessages && g_netplay_chat_ui)
+    g_netplay_chat_ui->Display();
+
+  if (Config::Get(Config::NETPLAY_GOLF_MODE_OVERLAY) && g_netplay_golf_ui)
+    g_netplay_golf_ui->Display();
+
+  if (g_ActiveConfig.bOverlayProjStats)
+    Statistics::DisplayProj();
+
+  OSD::DrawMessages();
+}
+
+void ImGuiManager::DrawFPSWindow()
+{
+  if (!g_ActiveConfig.bShowFPS)
+    return;
+
+  // Position in the top-right corner of the screen.
+  ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - (10.0f * m_backbuffer_scale),
+                                 10.0f * m_backbuffer_scale),
+                          ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+  ImGui::SetNextWindowSize(ImVec2(100.0f * m_backbuffer_scale, 30.0f * m_backbuffer_scale));
+
+  if (ImGui::Begin("FPS", nullptr,
+                   ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
+                       ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
+                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
+                       ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
+  {
+    ImGui::TextColored(ImVec4(0.0f, 1.0f, 1.0f, 1.0f), "FPS: %.2f",
+                       g_renderer->GetFPSCounter()->GetFPS());
+  }
+  ImGui::End();
+}
+
+void ImGuiManager::DrawMovieWindow()
+{
+  const auto& config = SConfig::GetInstance();
+  const bool show_movie_window =
+      config.m_ShowFrameCount | config.m_ShowLag | config.m_ShowInputDisplay | config.m_ShowRTC;
+  if (!show_movie_window)
+    return;
+
+  // Position under the FPS display.
+  ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - (10.0f * m_backbuffer_scale),
+                                 50.0f * m_backbuffer_scale),
+                          ImGuiCond_FirstUseEver, ImVec2(1.0f, 0.0f));
+  ImGui::SetNextWindowSizeConstraints(
+      ImVec2(150.0f * m_backbuffer_scale, 20.0f * m_backbuffer_scale), ImGui::GetIO().DisplaySize);
+  if (ImGui::Begin("Movie", nullptr, ImGuiWindowFlags_NoFocusOnAppearing))
+  {
+    if (config.m_ShowFrameCount)
+    {
+      ImGui::Text("Frame: %" PRIu64, Movie::GetCurrentFrame());
+    }
+    if (Movie::IsPlayingInput())
+    {
+      ImGui::Text("Input: %" PRIu64 " / %" PRIu64, Movie::GetCurrentInputCount(),
+                  Movie::GetTotalInputCount());
+    }
+    if (config.m_ShowLag)
+      ImGui::Text("Lag: %" PRIu64 "\n", Movie::GetCurrentLagCount());
+    if (config.m_ShowInputDisplay)
+      ImGui::TextUnformatted(Movie::GetInputDisplay().c_str());
+    if (config.m_ShowRTC)
+      ImGui::TextUnformatted(Movie::GetRTCDisplay().c_str());
+  }
+  ImGui::End();
+}
+
+}  // namespace VideoCommon

--- a/Source/Core/VideoCommon/ImGuiManager.h
+++ b/Source/Core/VideoCommon/ImGuiManager.h
@@ -1,0 +1,62 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <memory>
+#include <mutex>
+
+#include "VideoCommon/NativeVertexFormat.h"
+
+enum class AbstractTextureFormat : u32;
+class AbstractTexture;
+class AbstractPipeline;
+
+namespace VideoCommon
+{
+class ImGuiManager
+{
+public:
+  ImGuiManager(AbstractTextureFormat backbuffer_format, float backbuffer_scale);
+  ~ImGuiManager();
+
+  // ImGui initialization depends on being able to create textures and pipelines, so do it last.
+  bool Initialize();
+
+  // Cleans up all resources.
+  void Shutdown();
+
+  // Draws all global imgui windows.
+  // Should be called with the ImGui lock held.
+  void Draw();
+
+  // Renders ImGui windows to the currently-bound framebuffer.
+  // No need to lock, as the draw data should be finalized by Draw().
+  void Render();
+
+  // Sets up ImGui state for the next frame. Call after presenting.
+  // This function itself acquires the ImGui lock, so it should not be held.
+  void EndFrame();
+
+  // Returns a lock for the ImGui mutex, enabling data structures to be modified from outside.
+  // Use with care, only non-drawing functions should be called from outside the video thread,
+  // as the drawing is tied to a "frame".
+  std::unique_lock<std::mutex> GetStateLock();
+
+private:
+  // Various window drawing functions.
+  void DrawFPSWindow();
+  void DrawMovieWindow();
+
+  std::unique_ptr<NativeVertexFormat> m_imgui_vertex_format;
+  std::vector<std::unique_ptr<AbstractTexture>> m_imgui_textures;
+  std::unique_ptr<AbstractPipeline> m_imgui_pipeline;
+  AbstractTextureFormat m_backbuffer_format;
+  float m_backbuffer_scale;
+
+  // Mutex protecting global imgui state, use when injecting input events.
+  std::mutex m_state_mutex;
+  u64 m_last_frame_time;
+};
+}  // namespace VideoCommon
+
+extern std::unique_ptr<VideoCommon::ImGuiManager> g_imgui_manager;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -14,14 +14,11 @@
 
 #include "VideoCommon/RenderBase.h"
 
-#include <cinttypes>
 #include <cmath>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <tuple>
-
-#include "imgui.h"
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
@@ -57,9 +54,8 @@
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/FPSCounter.h"
 #include "VideoCommon/FramebufferManager.h"
+#include "VideoCommon/ImGuiManager.h"
 #include "VideoCommon/ImageWrite.h"
-#include "VideoCommon/NetPlayChatUI.h"
-#include "VideoCommon/NetPlayGolfUI.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -99,7 +95,9 @@ Renderer::~Renderer() = default;
 
 bool Renderer::Initialize()
 {
-  if (!InitializeImGui())
+  g_imgui_manager =
+      std::make_unique<VideoCommon::ImGuiManager>(m_backbuffer_format, m_backbuffer_scale);
+  if (!g_imgui_manager->Initialize())
     return false;
 
   m_post_processor = std::make_unique<VideoCommon::PostProcessing>();
@@ -114,8 +112,9 @@ void Renderer::Shutdown()
   // First stop any framedumping, which might need to dump the last xfb frame. This process
   // can require additional graphics sub-systems so it needs to be done first
   ShutdownFrameDumping();
-  ShutdownImGui();
   m_post_processor.reset();
+  g_imgui_manager->Shutdown();
+  g_imgui_manager.reset();
 }
 
 void Renderer::BeginUtilityDrawing()
@@ -472,75 +471,6 @@ void Renderer::CheckForConfigChanges()
   }
 }
 
-// Create On-Screen-Messages
-void Renderer::DrawDebugText()
-{
-  const auto& config = SConfig::GetInstance();
-
-  if (g_ActiveConfig.bShowFPS)
-  {
-    // Position in the top-right corner of the screen.
-    ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - (10.0f * m_backbuffer_scale),
-                                   10.0f * m_backbuffer_scale),
-                            ImGuiCond_Always, ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSize(ImVec2(100.0f * m_backbuffer_scale, 30.0f * m_backbuffer_scale));
-
-    if (ImGui::Begin("FPS", nullptr,
-                     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
-                         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
-                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
-                         ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
-    {
-      ImGui::TextColored(ImVec4(0.0f, 1.0f, 1.0f, 1.0f), "FPS: %.2f", m_fps_counter.GetFPS());
-    }
-    ImGui::End();
-  }
-
-  const bool show_movie_window =
-      config.m_ShowFrameCount | config.m_ShowLag | config.m_ShowInputDisplay | config.m_ShowRTC;
-  if (show_movie_window)
-  {
-    // Position under the FPS display.
-    ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - (10.0f * m_backbuffer_scale),
-                                   50.0f * m_backbuffer_scale),
-                            ImGuiCond_FirstUseEver, ImVec2(1.0f, 0.0f));
-    ImGui::SetNextWindowSizeConstraints(
-        ImVec2(150.0f * m_backbuffer_scale, 20.0f * m_backbuffer_scale),
-        ImGui::GetIO().DisplaySize);
-    if (ImGui::Begin("Movie", nullptr, ImGuiWindowFlags_NoFocusOnAppearing))
-    {
-      if (config.m_ShowFrameCount)
-      {
-        ImGui::Text("Frame: %" PRIu64, Movie::GetCurrentFrame());
-      }
-      if (Movie::IsPlayingInput())
-      {
-        ImGui::Text("Input: %" PRIu64 " / %" PRIu64, Movie::GetCurrentInputCount(),
-                    Movie::GetTotalInputCount());
-      }
-      if (SConfig::GetInstance().m_ShowLag)
-        ImGui::Text("Lag: %" PRIu64 "\n", Movie::GetCurrentLagCount());
-      if (SConfig::GetInstance().m_ShowInputDisplay)
-        ImGui::TextUnformatted(Movie::GetInputDisplay().c_str());
-      if (SConfig::GetInstance().m_ShowRTC)
-        ImGui::TextUnformatted(Movie::GetRTCDisplay().c_str());
-    }
-    ImGui::End();
-  }
-
-  if (g_ActiveConfig.bOverlayStats)
-    Statistics::Display();
-
-  if (g_ActiveConfig.bShowNetPlayMessages && g_netplay_chat_ui)
-    g_netplay_chat_ui->Display();
-
-  if (Config::Get(Config::NETPLAY_GOLF_MODE_OVERLAY) && g_netplay_golf_ui)
-    g_netplay_golf_ui->Display();
-
-  if (g_ActiveConfig.bOverlayProjStats)
-    Statistics::DisplayProj();
-}
-
 float Renderer::CalculateDrawAspectRatio() const
 {
   if (g_ActiveConfig.aspect_mode == AspectMode::Stretch)
@@ -866,266 +796,6 @@ void Renderer::RecordVideoMemory()
                                              texMem);
 }
 
-static std::string GenerateImGuiVertexShader()
-{
-  const APIType api_type = g_ActiveConfig.backend_info.api_type;
-  std::stringstream ss;
-
-  // Uniform buffer contains the viewport size, and we transform in the vertex shader.
-  if (api_type == APIType::D3D)
-    ss << "cbuffer PSBlock : register(b0) {\n";
-  else if (api_type == APIType::OpenGL)
-    ss << "UBO_BINDING(std140, 1) uniform PSBlock {\n";
-  else if (api_type == APIType::Vulkan)
-    ss << "UBO_BINDING(std140, 1) uniform PSBlock {\n";
-  ss << "float2 u_rcp_viewport_size_mul2;\n";
-  ss << "};\n";
-
-  if (api_type == APIType::D3D)
-  {
-    ss << "void main(in float2 rawpos : POSITION,\n"
-       << "          in float2 rawtex0 : TEXCOORD,\n"
-       << "          in float4 rawcolor0 : COLOR,\n"
-       << "          out float2 frag_uv : TEXCOORD,\n"
-       << "          out float4 frag_color : COLOR,\n"
-       << "          out float4 out_pos : SV_Position)\n";
-  }
-  else
-  {
-    ss << "ATTRIBUTE_LOCATION(" << SHADER_POSITION_ATTRIB << ") in float2 rawpos;\n"
-       << "ATTRIBUTE_LOCATION(" << SHADER_TEXTURE0_ATTRIB << ") in float2 rawtex0;\n"
-       << "ATTRIBUTE_LOCATION(" << SHADER_COLOR0_ATTRIB << ") in float4 rawcolor0;\n"
-       << "VARYING_LOCATION(0) out float2 frag_uv;\n"
-       << "VARYING_LOCATION(1) out float4 frag_color;\n"
-       << "void main()\n";
-  }
-
-  ss << "{\n"
-     << "  frag_uv = rawtex0;\n"
-     << "  frag_color = rawcolor0;\n";
-
-  ss << "  " << (api_type == APIType::D3D ? "out_pos" : "gl_Position")
-     << "= float4(rawpos.x * u_rcp_viewport_size_mul2.x - 1.0, 1.0 - rawpos.y * "
-        "u_rcp_viewport_size_mul2.y, 0.0, 1.0);\n";
-
-  // Clip-space is flipped in Vulkan
-  if (api_type == APIType::Vulkan)
-    ss << "  gl_Position.y = -gl_Position.y;\n";
-
-  ss << "}\n";
-  return ss.str();
-}
-
-static std::string GenerateImGuiPixelShader()
-{
-  const APIType api_type = g_ActiveConfig.backend_info.api_type;
-
-  std::stringstream ss;
-  if (api_type == APIType::D3D)
-  {
-    ss << "Texture2DArray tex0 : register(t0);\n"
-       << "SamplerState samp0 : register(s0);\n"
-       << "void main(in float2 frag_uv : TEXCOORD,\n"
-       << "          in float4 frag_color : COLOR,\n"
-       << "          out float4 ocol0 : SV_Target)\n";
-  }
-  else
-  {
-    ss << "SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n"
-       << "VARYING_LOCATION(0) in float2 frag_uv; \n"
-       << "VARYING_LOCATION(1) in float4 frag_color;\n"
-       << "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n"
-       << "void main()\n";
-  }
-
-  ss << "{\n";
-
-  if (api_type == APIType::D3D)
-    ss << "  ocol0 = tex0.Sample(samp0, float3(frag_uv, 0.0)) * frag_color;\n";
-  else
-    ss << "  ocol0 = texture(samp0, float3(frag_uv, 0.0)) * frag_color;\n";
-
-  ss << "}\n";
-
-  return ss.str();
-}
-
-bool Renderer::InitializeImGui()
-{
-  if (!ImGui::CreateContext())
-  {
-    PanicAlert("Creating ImGui context failed");
-    return false;
-  }
-
-  // Don't create an ini file. TODO: Do we want this in the future?
-  ImGui::GetIO().IniFilename = nullptr;
-  ImGui::GetIO().DisplayFramebufferScale.x = m_backbuffer_scale;
-  ImGui::GetIO().DisplayFramebufferScale.y = m_backbuffer_scale;
-  ImGui::GetIO().FontGlobalScale = m_backbuffer_scale;
-  ImGui::GetStyle().ScaleAllSizes(m_backbuffer_scale);
-
-  PortableVertexDeclaration vdecl = {};
-  vdecl.position = {VAR_FLOAT, 2, offsetof(ImDrawVert, pos), true, false};
-  vdecl.texcoords[0] = {VAR_FLOAT, 2, offsetof(ImDrawVert, uv), true, false};
-  vdecl.colors[0] = {VAR_UNSIGNED_BYTE, 4, offsetof(ImDrawVert, col), true, false};
-  vdecl.stride = sizeof(ImDrawVert);
-  m_imgui_vertex_format = CreateNativeVertexFormat(vdecl);
-  if (!m_imgui_vertex_format)
-  {
-    PanicAlert("Failed to create imgui vertex format");
-    return false;
-  }
-
-  const std::string vertex_shader_source = GenerateImGuiVertexShader();
-  const std::string pixel_shader_source = GenerateImGuiPixelShader();
-  std::unique_ptr<AbstractShader> vertex_shader = CreateShaderFromSource(
-      ShaderStage::Vertex, vertex_shader_source.c_str(), vertex_shader_source.size());
-  std::unique_ptr<AbstractShader> pixel_shader = CreateShaderFromSource(
-      ShaderStage::Pixel, pixel_shader_source.c_str(), pixel_shader_source.size());
-  if (!vertex_shader || !pixel_shader)
-  {
-    PanicAlert("Failed to compile imgui shaders");
-    return false;
-  }
-
-  AbstractPipelineConfig pconfig = {};
-  pconfig.vertex_format = m_imgui_vertex_format.get();
-  pconfig.vertex_shader = vertex_shader.get();
-  pconfig.pixel_shader = pixel_shader.get();
-  pconfig.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
-  pconfig.depth_state = RenderState::GetNoDepthTestingDepthState();
-  pconfig.blending_state = RenderState::GetNoBlendingBlendState();
-  pconfig.blending_state.blendenable = true;
-  pconfig.blending_state.srcfactor = BlendMode::SRCALPHA;
-  pconfig.blending_state.dstfactor = BlendMode::INVSRCALPHA;
-  pconfig.blending_state.srcfactoralpha = BlendMode::ZERO;
-  pconfig.blending_state.dstfactoralpha = BlendMode::ONE;
-  pconfig.framebuffer_state.color_texture_format = m_backbuffer_format;
-  pconfig.framebuffer_state.depth_texture_format = AbstractTextureFormat::Undefined;
-  pconfig.framebuffer_state.samples = 1;
-  pconfig.framebuffer_state.per_sample_shading = false;
-  pconfig.usage = AbstractPipelineUsage::Utility;
-  m_imgui_pipeline = g_renderer->CreatePipeline(pconfig);
-  if (!m_imgui_pipeline)
-  {
-    PanicAlert("Failed to create imgui pipeline");
-    return false;
-  }
-
-  // Font texture(s).
-  {
-    ImGuiIO& io = ImGui::GetIO();
-    u8* font_tex_pixels;
-    int font_tex_width, font_tex_height;
-    io.Fonts->GetTexDataAsRGBA32(&font_tex_pixels, &font_tex_width, &font_tex_height);
-
-    TextureConfig font_tex_config(font_tex_width, font_tex_height, 1, 1, 1,
-                                  AbstractTextureFormat::RGBA8, 0);
-    std::unique_ptr<AbstractTexture> font_tex = CreateTexture(font_tex_config);
-    if (!font_tex)
-    {
-      PanicAlert("Failed to create imgui texture");
-      return false;
-    }
-    font_tex->Load(0, font_tex_width, font_tex_height, font_tex_width, font_tex_pixels,
-                   sizeof(u32) * font_tex_width * font_tex_height);
-
-    io.Fonts->TexID = font_tex.get();
-
-    m_imgui_textures.push_back(std::move(font_tex));
-  }
-
-  m_imgui_last_frame_time = Common::Timer::GetTimeUs();
-  BeginImGuiFrame();
-  return true;
-}
-
-void Renderer::ShutdownImGui()
-{
-  ImGui::EndFrame();
-  ImGui::DestroyContext();
-  m_imgui_pipeline.reset();
-  m_imgui_vertex_format.reset();
-  m_imgui_textures.clear();
-}
-
-void Renderer::BeginImGuiFrame()
-{
-  std::unique_lock<std::mutex> imgui_lock(m_imgui_mutex);
-
-  const u64 current_time_us = Common::Timer::GetTimeUs();
-  const u64 time_diff_us = current_time_us - m_imgui_last_frame_time;
-  const float time_diff_secs = static_cast<float>(time_diff_us / 1000000.0);
-  m_imgui_last_frame_time = current_time_us;
-
-  // Update I/O with window dimensions.
-  ImGuiIO& io = ImGui::GetIO();
-  io.DisplaySize =
-      ImVec2(static_cast<float>(m_backbuffer_width), static_cast<float>(m_backbuffer_height));
-  io.DeltaTime = time_diff_secs;
-
-  ImGui::NewFrame();
-}
-
-void Renderer::DrawImGui()
-{
-  ImDrawData* draw_data = ImGui::GetDrawData();
-  if (!draw_data)
-    return;
-
-  SetViewport(0.0f, 0.0f, static_cast<float>(m_backbuffer_width),
-              static_cast<float>(m_backbuffer_height), 0.0f, 1.0f);
-
-  // Uniform buffer for draws.
-  struct ImGuiUbo
-  {
-    float u_rcp_viewport_size_mul2[2];
-    float padding[2];
-  };
-  ImGuiUbo ubo = {{1.0f / m_backbuffer_width * 2.0f, 1.0f / m_backbuffer_height * 2.0f}};
-
-  // Set up common state for drawing.
-  SetPipeline(m_imgui_pipeline.get());
-  SetSamplerState(0, RenderState::GetPointSamplerState());
-  g_vertex_manager->UploadUtilityUniforms(&ubo, sizeof(ubo));
-
-  for (int i = 0; i < draw_data->CmdListsCount; i++)
-  {
-    const ImDrawList* cmdlist = draw_data->CmdLists[i];
-    if (cmdlist->VtxBuffer.empty() || cmdlist->IdxBuffer.empty())
-      return;
-
-    u32 base_vertex, base_index;
-    g_vertex_manager->UploadUtilityVertices(cmdlist->VtxBuffer.Data, sizeof(ImDrawVert),
-                                            cmdlist->VtxBuffer.Size, cmdlist->IdxBuffer.Data,
-                                            cmdlist->IdxBuffer.Size, &base_vertex, &base_index);
-
-    for (const ImDrawCmd& cmd : cmdlist->CmdBuffer)
-    {
-      if (cmd.UserCallback)
-      {
-        cmd.UserCallback(cmdlist, &cmd);
-        continue;
-      }
-
-      SetScissorRect(ConvertFramebufferRectangle(
-          MathUtil::Rectangle<int>(
-              static_cast<int>(cmd.ClipRect.x), static_cast<int>(cmd.ClipRect.y),
-              static_cast<int>(cmd.ClipRect.z), static_cast<int>(cmd.ClipRect.w)),
-          m_current_framebuffer));
-      SetTexture(0, reinterpret_cast<const AbstractTexture*>(cmd.TextureId));
-      DrawIndexed(base_index, cmd.ElemCount, base_vertex);
-      base_index += cmd.ElemCount;
-    }
-  }
-}
-
-std::unique_lock<std::mutex> Renderer::GetImGuiLock()
-{
-  return std::unique_lock<std::mutex>(m_imgui_mutex);
-}
-
 void Renderer::BeginUIFrame()
 {
   if (IsHeadless())
@@ -1137,21 +807,16 @@ void Renderer::BeginUIFrame()
 
 void Renderer::EndUIFrame()
 {
-  {
-    auto lock = GetImGuiLock();
-    ImGui::Render();
-  }
+  g_imgui_manager->Render();
 
   if (!IsHeadless())
   {
-    DrawImGui();
-
     std::lock_guard<std::mutex> guard(m_swap_mutex);
     PresentBackbuffer();
     EndUtilityDrawing();
   }
 
-  BeginImGuiFrame();
+  g_imgui_manager->EndFrame();
 }
 
 void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
@@ -1223,11 +888,8 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
 
       // Render any UI elements to the draw list.
       {
-        auto lock = GetImGuiLock();
-
-        DrawDebugText();
-        OSD::DrawMessages();
-        ImGui::Render();
+        auto lock = g_imgui_manager->GetStateLock();
+        g_imgui_manager->Draw();
       }
 
       // Render the XFB to the screen.
@@ -1237,7 +899,7 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
         BindBackbuffer({{0.0f, 0.0f, 0.0f, 1.0f}});
         UpdateDrawRectangle();
         RenderXFBToScreen(xfb_entry->texture.get(), xfb_rect);
-        DrawImGui();
+        g_imgui_manager->Render();
 
         // Present to the window system.
         {
@@ -1266,7 +928,7 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
       stats.ResetFrame();
       g_shader_cache->RetrieveAsyncShaders();
       g_vertex_manager->OnEndFrame();
-      BeginImGuiFrame();
+      g_imgui_manager->EndFrame();
 
       // We invalidate the pipeline object at the start of the frame.
       // This is for the rare case where only a single pipeline configuration is used,

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="HiresTextures.cpp" />
     <ClCompile Include="HiresTextures_DDSLoader.cpp" />
     <ClCompile Include="ImageWrite.cpp" />
+    <ClCompile Include="ImGuiManager.cpp" />
     <ClCompile Include="IndexGenerator.cpp" />
     <ClCompile Include="NetPlayChatUI.cpp" />
     <ClCompile Include="NetPlayGolfUI.cpp" />
@@ -122,6 +123,7 @@
     <ClInclude Include="FramebufferManager.h" />
     <ClInclude Include="FramebufferShaderGen.h" />
     <ClInclude Include="GXPipelineTypes.h" />
+    <ClInclude Include="ImGuiManager.h" />
     <ClInclude Include="NetPlayChatUI.h" />
     <ClInclude Include="NetPlayGolfUI.h" />
     <ClInclude Include="ShaderCache.h" />

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClCompile Include="NetPlayGolfUI.cpp">
       <Filter>Util</Filter>
     </ClCompile>
+    <ClCompile Include="ImGuiManager.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CommandProcessor.h" />
@@ -396,6 +399,9 @@
       <Filter>Util</Filter>
     </ClInclude>
     <ClInclude Include="NetPlayGolfUI.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="ImGuiManager.h">
       <Filter>Util</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This PR moves the imgui members/functions out of Renderer and into a separate class.

@iwubcode some of your pause screen logic could likely be moved within here, and tied into the Draw() function for different states.