### PR TITLE
Disable Deferred EFB Copies in We Cheer 1 and 2

### DIFF
--- a/Data/Sys/GameSettings/R6C.INI
+++ b/Data/Sys/GameSettings/R6C.INI
@@ -1,0 +1,18 @@
+# R6CEAF, R6CJAF - We Cheer 2
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Enhancements]
+
+[Video_Hacks]
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RCH.ini
+++ b/Data/Sys/GameSettings/RCH.ini
@@ -1,0 +1,19 @@
+# RCHEAF, RCHPGT, RCHJAF - We Cheer
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Enhancements]
+# Add graphics enhancements here.
+
+[Video_Hacks]
+DeferEFBCopies = False


### PR DESCRIPTION
They have issues with rendering character faces when it is enabled.