### PR TITLE
PixelShaderGen: Don't emit bounding box shader code for old UIDs when disabled

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -347,6 +347,10 @@ void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host
   // uint output when logic op is not supported (i.e. driver/device does not support D3D11.1).
   if (ApiType != APIType::D3D || !host_config.backend_logic_op)
     uid_data->uint_output = 0;
+
+  // If bounding box is enabled when a UID cache is created, then later disabled, we shouldn't
+  // emit the bounding box portion of the shader.
+  uid_data->bounding_box &= host_config.bounding_box;
 }
 
 void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texgens,

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -641,17 +641,19 @@ const AbstractPipeline* ShaderCache::InsertGXPipeline(const GXPipelineUid& confi
   auto& entry = m_gx_pipeline_cache[config];
   entry.second = false;
   if (!entry.first && pipeline)
+  {
     entry.first = std::move(pipeline);
 
-  if (g_ActiveConfig.bShaderCache)
-  {
-    auto cache_data = entry.first->GetCacheData();
-    if (!cache_data.empty())
+    if (g_ActiveConfig.bShaderCache)
     {
-      SerializedGXPipelineUid disk_uid;
-      SerializePipelineUid(config, disk_uid);
-      m_gx_pipeline_disk_cache.Append(disk_uid, cache_data.data(),
-                                      static_cast<u32>(cache_data.size()));
+      auto cache_data = entry.first->GetCacheData();
+      if (!cache_data.empty())
+      {
+        SerializedGXPipelineUid disk_uid;
+        SerializePipelineUid(config, disk_uid);
+        m_gx_pipeline_disk_cache.Append(disk_uid, cache_data.data(),
+                                        static_cast<u32>(cache_data.size()));
+      }
     }
   }
 
@@ -665,17 +667,19 @@ ShaderCache::InsertGXUberPipeline(const GXUberPipelineUid& config,
   auto& entry = m_gx_uber_pipeline_cache[config];
   entry.second = false;
   if (!entry.first && pipeline)
+  {
     entry.first = std::move(pipeline);
 
-  if (g_ActiveConfig.bShaderCache)
-  {
-    auto cache_data = entry.first->GetCacheData();
-    if (!cache_data.empty())
+    if (g_ActiveConfig.bShaderCache)
     {
-      SerializedGXUberPipelineUid disk_uid;
-      SerializePipelineUid(config, disk_uid);
-      m_gx_uber_pipeline_disk_cache.Append(disk_uid, cache_data.data(),
-                                           static_cast<u32>(cache_data.size()));
+      auto cache_data = entry.first->GetCacheData();
+      if (!cache_data.empty())
+      {
+        SerializedGXUberPipelineUid disk_uid;
+        SerializePipelineUid(config, disk_uid);
+        m_gx_uber_pipeline_disk_cache.Append(disk_uid, cache_data.data(),
+                                             static_cast<u32>(cache_data.size()));
+      }
     }
   }
 


### PR DESCRIPTION
If bounding box is enabled when a UID cache is created, then later disabled, we shouldn't emit the bounding box portion of the shader.

Fixes pipeline creation errors on D3D12 backend for this case.