### PR TITLE
Show Japanese GC games in Japanese when using TitleDatabase

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -680,7 +680,7 @@ void SConfig::LoadJitDebugSettings(IniFile& ini)
 
 void SConfig::ResetRunningGameMetadata()
 {
-  SetRunningGameMetadata("00000000", "", 0, 0);
+  SetRunningGameMetadata("00000000", "", 0, 0, DiscIO::Country::Unknown);
 }
 
 void SConfig::SetRunningGameMetadata(const DiscIO::Volume& volume,
@@ -689,13 +689,14 @@ void SConfig::SetRunningGameMetadata(const DiscIO::Volume& volume,
   if (partition == volume.GetGamePartition())
   {
     SetRunningGameMetadata(volume.GetGameID(), volume.GetGameTDBID(),
-                           volume.GetTitleID().value_or(0), volume.GetRevision().value_or(0));
+                           volume.GetTitleID().value_or(0), volume.GetRevision().value_or(0),
+                           volume.GetCountry());
   }
   else
   {
     SetRunningGameMetadata(volume.GetGameID(partition), volume.GetGameTDBID(),
                            volume.GetTitleID(partition).value_or(0),
-                           volume.GetRevision(partition).value_or(0));
+                           volume.GetRevision(partition).value_or(0), volume.GetCountry());
   }
 }
 
@@ -710,13 +711,16 @@ void SConfig::SetRunningGameMetadata(const IOS::ES::TMDReader& tmd)
   if (!DVDInterface::UpdateRunningGameMetadata(tmd_title_id))
   {
     // If not launching a disc game, just read everything from the TMD.
-    SetRunningGameMetadata(tmd.GetGameID(), tmd.GetGameTDBID(), tmd_title_id,
-                           tmd.GetTitleVersion());
+    const DiscIO::Country country =
+        DiscIO::CountryCodeToCountry(static_cast<u8>(tmd_title_id), DiscIO::Platform::WiiWAD,
+                                     tmd.GetRegion(), tmd.GetTitleVersion());
+    SetRunningGameMetadata(tmd.GetGameID(), tmd.GetGameTDBID(), tmd_title_id, tmd.GetTitleVersion(),
+                           country);
   }
 }
 
 void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::string& gametdb_id,
-                                     u64 title_id, u16 revision)
+                                     u64 title_id, u16 revision, DiscIO::Country country)
 {
   const bool was_changed = m_game_id != game_id || m_gametdb_id != gametdb_id ||
                            m_title_id != title_id || m_revision != revision;
@@ -749,7 +753,10 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   }
 
   const Core::TitleDatabase title_database;
-  m_title_description = title_database.Describe(m_gametdb_id, GetCurrentLanguage(bWii));
+  const DiscIO::Language language = !bWii && country == DiscIO::Country::Japan ?
+                                        DiscIO::Language::Japanese :
+                                        GetCurrentLanguage(bWii);
+  m_title_description = title_database.Describe(m_gametdb_id, language);
   NOTICE_LOG(CORE, "Active title: %s", m_title_description.c_str());
 
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -18,6 +18,7 @@
 
 namespace DiscIO
 {
+enum class Country;
 enum class Language;
 enum class Region;
 struct Partition;
@@ -368,7 +369,7 @@ private:
   void LoadJitDebugSettings(IniFile& ini);
 
   void SetRunningGameMetadata(const std::string& game_id, const std::string& gametdb_id,
-                              u64 title_id, u16 revision);
+                              u64 title_id, u16 revision, DiscIO::Country country);
 
   static SConfig* m_Instance;
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -14,7 +14,6 @@
 #include "Common/IniFile.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/SI/SI_Device.h"
-#include "Core/TitleDatabase.h"
 
 namespace DiscIO
 {

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -60,6 +60,9 @@ static bool UseGameCovers()
 
 DiscIO::Language GameFile::GetConfigLanguage() const
 {
+  if (m_platform == DiscIO::Platform::GameCubeDisc && m_country == DiscIO::Country::Japan)
+    return DiscIO::Language::Japanese;
+
 #ifdef ANDROID
   // TODO: Make the Android app load the config at app start instead of emulation start
   // so that we can access the user's preference here


### PR DESCRIPTION
Because the GC language setting cannot be set to Japanese, we need a special condition for Japanese GC games. I accidentally removed it in PR #7816, but here it is again in a new form.

We could do the same thing with Korean GC games if we want to (which we couldn't do before PR #7816), but due to how spotty GameTDB is with having Korean names for Korean GC releases, things will be more consistent if we just use English for them.