### PR TITLE
Make GameFile::GetUniqueIdentifier independent of language setting

### DIFF
--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -468,7 +468,12 @@ std::string GameFile::GetUniqueIdentifier() const
   if (GetRevision() != 0)
     info.push_back("Revision " + std::to_string(GetRevision()));
 
-  const std::string& name = GetName();
+  std::string name = GetLongName(DiscIO::Language::English);
+  if (name.empty())
+  {
+    // Use the file name as a fallback. Not necessarily consistent, but it's the best we have
+    name = m_file_name;
+  }
 
   int disc_number = GetDiscNumber() + 1;
 


### PR DESCRIPTION
My bad.

We need this in the situation where two users are using different languages and the game has a different name in each language.