### PR TITLE
ControllerInterface/DInput: Optimize cursor position updating.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
@@ -64,7 +64,7 @@ void PopulateDevices(HWND hwnd)
     return;
   }
 
-  InitKeyboardMouse(idi8);
+  InitKeyboardMouse(idi8, hwnd);
   InitJoystick(idi8, hwnd);
 
   idi8->Release();

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -32,7 +32,7 @@ static const struct
 // Prevent duplicate keyboard/mouse devices.
 static bool s_keyboard_mouse_exists = false;
 
-void InitKeyboardMouse(IDirectInput8* const idi8)
+void InitKeyboardMouse(IDirectInput8* const idi8, HWND hwnd)
 {
   if (s_keyboard_mouse_exists)
     return;
@@ -52,7 +52,7 @@ void InitKeyboardMouse(IDirectInput8* const idi8)
       SUCCEEDED(mo_device->SetDataFormat(&c_dfDIMouse2)) &&
       SUCCEEDED(mo_device->SetCooperativeLevel(nullptr, DISCL_BACKGROUND | DISCL_NONEXCLUSIVE)))
   {
-    g_controller_interface.AddDevice(std::make_shared<KeyboardMouse>(kb_device, mo_device));
+    g_controller_interface.AddDevice(std::make_shared<KeyboardMouse>(kb_device, mo_device, hwnd));
     return;
   }
 
@@ -75,17 +75,14 @@ KeyboardMouse::~KeyboardMouse()
 }
 
 KeyboardMouse::KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device,
-                             const LPDIRECTINPUTDEVICE8 mo_device)
-    : m_kb_device(kb_device), m_mo_device(mo_device)
+                             const LPDIRECTINPUTDEVICE8 mo_device, HWND hwnd)
+    : m_kb_device(kb_device), m_mo_device(mo_device), m_hwnd(hwnd), m_last_update(GetTickCount()),
+      m_state_in()
 {
   s_keyboard_mouse_exists = true;
 
   m_kb_device->Acquire();
   m_mo_device->Acquire();
-
-  m_last_update = GetTickCount();
-
-  ZeroMemory(&m_state_in, sizeof(m_state_in));
 
   // KEYBOARD
   // add keys
@@ -93,9 +90,7 @@ KeyboardMouse::KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device,
     AddInput(new Key(i, m_state_in.keyboard[named_keys[i].code]));
 
   // MOUSE
-  // get caps
-  DIDEVCAPS mouse_caps;
-  ZeroMemory(&mouse_caps, sizeof(mouse_caps));
+  DIDEVCAPS mouse_caps = {};
   mouse_caps.dwSize = sizeof(mouse_caps);
   m_mo_device->GetCapabilities(&mouse_caps);
   // mouse buttons
@@ -115,35 +110,26 @@ KeyboardMouse::KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device,
     AddInput(new Cursor(!!(i & 2), (&m_state_in.cursor.x)[i / 2], !!(i & 1)));
 }
 
-void GetMousePos(ControlState* const x, ControlState* const y)
+void KeyboardMouse::UpdateCursorInput()
 {
-  POINT point = {1, 1};
+  POINT point = {};
   GetCursorPos(&point);
-  // Get the cursor position relative to the upper left corner of the current window (separate or
-  // render to main)
-  HWND hwnd = WindowFromPoint(point);
-  DWORD processId;
-  GetWindowThreadProcessId(hwnd, &processId);
-  if (processId == GetCurrentProcessId())
-  {
-    ScreenToClient(hwnd, &point);
 
-    // Get the size of the current window. (In my case Rect.top and Rect.left was zero.)
-    RECT rect;
-    GetClientRect(hwnd, &rect);
-    // Width and height is the size of the rendering window
-    unsigned int win_width = rect.right - rect.left;
-    unsigned int win_height = rect.bottom - rect.top;
+  // Get the cursor position relative to the upper left corner of the current window
+  // (separate or render to main)
+  ScreenToClient(m_hwnd, &point);
 
-    // Return the mouse position as a range from -1 to 1
-    *x = (ControlState)point.x / (ControlState)win_width * 2 - 1;
-    *y = (ControlState)point.y / (ControlState)win_height * 2 - 1;
-  }
-  else
-  {
-    *x = (ControlState)1;
-    *y = (ControlState)1;
-  }
+  // Get the size of the current window. (In my case Rect.top and Rect.left was zero.)
+  RECT rect;
+  GetClientRect(m_hwnd, &rect);
+
+  // Width and height are the size of the rendering window.
+  const auto win_width = rect.right - rect.left;
+  const auto win_height = rect.bottom - rect.top;
+
+  // Convert the cursor position to a range from -1 to 1.
+  m_state_in.cursor.x = ControlState(point.x) / win_width * 2 - 1;
+  m_state_in.cursor.y = ControlState(point.y) / win_height * 2 - 1;
 }
 
 void KeyboardMouse::UpdateInput()
@@ -155,7 +141,7 @@ void KeyboardMouse::UpdateInput()
   if (cur_time - m_last_update > DROP_INPUT_TIME)
   {
     // set axes to zero
-    ZeroMemory(&m_state_in.mouse, sizeof(m_state_in.mouse));
+    m_state_in.mouse = {};
     // skip this input state
     m_mo_device->GetDeviceState(sizeof(tmp_mouse), &tmp_mouse);
   }
@@ -180,8 +166,7 @@ void KeyboardMouse::UpdateInput()
     // copy over the buttons
     memcpy(m_state_in.mouse.rgbButtons, tmp_mouse.rgbButtons, sizeof(m_state_in.mouse.rgbButtons));
 
-    // update mouse cursor
-    GetMousePos(&m_state_in.cursor.x, &m_state_in.cursor.y);
+    UpdateCursorInput();
   }
 }
 
@@ -235,12 +220,12 @@ ControlState KeyboardMouse::Button::GetState() const
 
 ControlState KeyboardMouse::Axis::GetState() const
 {
-  return std::max(0.0, ControlState(m_axis) / m_range);
+  return ControlState(m_axis) / m_range;
 }
 
 ControlState KeyboardMouse::Cursor::GetState() const
 {
-  return std::max(0.0, ControlState(m_axis) / (m_positive ? 1.0 : -1.0));
+  return m_axis / (m_positive ? 1.0 : -1.0);
 }
 }  // namespace DInput
 }  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -13,7 +13,7 @@ namespace ciface
 {
 namespace DInput
 {
-void InitKeyboardMouse(IDirectInput8* const idi8);
+void InitKeyboardMouse(IDirectInput8* const idi8, HWND hwnd);
 
 class KeyboardMouse : public Core::Device
 {
@@ -85,15 +85,20 @@ private:
 public:
   void UpdateInput() override;
 
-  KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device, const LPDIRECTINPUTDEVICE8 mo_device);
+  KeyboardMouse(const LPDIRECTINPUTDEVICE8 kb_device, const LPDIRECTINPUTDEVICE8 mo_device,
+                HWND hwnd);
   ~KeyboardMouse();
 
   std::string GetName() const override;
   std::string GetSource() const override;
 
 private:
+  void UpdateCursorInput();
+
   const LPDIRECTINPUTDEVICE8 m_kb_device;
   const LPDIRECTINPUTDEVICE8 m_mo_device;
+
+  const HWND m_hwnd;
 
   DWORD m_last_update;
   State m_state_in;


### PR DESCRIPTION
I measured `DInput::KeyboardMouse::UpdateInput` at 3.76% of CPU time.

I've made `KeyboardMouse` use the `HWND` passed to `Win32::PopulateDevices` rather than finding `HWND`s and looking up process IDs every frame based on the cursor position.

`UpdateInput` now measures at 0.29% of CPU time.

This also eliminates the jumping around of the cursor as you mouse over buttons/controls.

Also, minor cleanups.