### PR TITLE
WiimoteEmu/DolphinQt: Rename "IR" to "Point" and eliminate redundant Forward/Backward actions.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -204,7 +204,6 @@ void EmulateCursor(MotionState* state, ControllerEmu::Cursor* ir_group, float ti
 
   // Nintendo recommends a distance of 1-3 meters.
   constexpr float NEUTRAL_DISTANCE = 2.f;
-  constexpr float MOVE_DISTANCE = 1.f;
 
   // When the sensor bar position is on bottom, apply the "offset" setting negatively.
   // This is kinda odd but it does seem to maintain consistent cursor behavior.
@@ -215,25 +214,21 @@ void EmulateCursor(MotionState* state, ControllerEmu::Cursor* ir_group, float ti
   const float yaw_scale = ir_group->GetTotalYaw() / 2;
   const float pitch_scale = ir_group->GetTotalPitch() / 2;
 
-  // TODO: Move state out of ControllerEmu::Cursor
-  // TODO: Use ApproachPositionWithJerk
-  // TODO: Move forward/backward after rotation.
-  const auto new_position =
-      Common::Vec3(0, NEUTRAL_DISTANCE - MOVE_DISTANCE * float(cursor.z), -height);
+  // Just jump to the target position.
+  state->position = {0, NEUTRAL_DISTANCE, -height};
+  state->velocity = {};
+  state->acceleration = {};
 
   const auto target_angle = Common::Vec3(pitch_scale * -cursor.y, 0, yaw_scale * -cursor.x);
 
-  // If cursor was hidden, jump to the target position/angle immediately.
+  // If cursor was hidden, jump to the target angle immediately.
   if (state->position.y < 0)
   {
-    state->position = new_position;
     state->angle = target_angle;
+    state->angular_velocity = {};
 
     return;
   }
-
-  state->acceleration = new_position - state->position;
-  state->position = new_position;
 
   // Higher values will be more responsive but increase rate of M+ "desync".
   // I'd rather not expose this value in the UI if not needed.

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -138,7 +138,7 @@ void Wiimote::Reset()
 
 Wiimote::Wiimote(const unsigned int index) : m_index(index)
 {
-  // buttons
+  // Buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (const char* named_button : named_buttons)
   {
@@ -147,20 +147,14 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
         new ControllerEmu::Input(ControllerEmu::DoNotTranslate, named_button, ui_name));
   }
 
-  // ir
-  // i18n: IR stands for infrared and refers to the pointer functionality of Wii Remotes
-  groups.emplace_back(m_ir = new ControllerEmu::Cursor(_trans("IR")));
-
-  // swing
+  // Pointing (IR)
+  // i18n: "Point" refers to the action of pointing a Wii Remote.
+  groups.emplace_back(m_ir = new ControllerEmu::Cursor("IR", _trans("Point")));
   groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));
-
-  // tilt
   groups.emplace_back(m_tilt = new ControllerEmu::Tilt(_trans("Tilt")));
-
-  // shake
   groups.emplace_back(m_shake = new ControllerEmu::Shake(_trans("Shake")));
 
-  // extension
+  // Extension
   groups.emplace_back(m_attachments = new ControllerEmu::Attachments(_trans("Extension")));
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::None>());
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::Nunchuk>());
@@ -174,12 +168,12 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
 
   m_attachments->AddSetting(&m_motion_plus_setting, {_trans("Attach MotionPlus")}, true);
 
-  // rumble
+  // Rumble
   groups.emplace_back(m_rumble = new ControllerEmu::ControlGroup(_trans("Rumble")));
   m_rumble->controls.emplace_back(
       m_motor = new ControllerEmu::Output(ControllerEmu::Translate, _trans("Motor")));
 
-  // dpad
+  // D-Pad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
   for (const char* named_direction : named_directions)
   {
@@ -187,7 +181,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
         new ControllerEmu::Input(ControllerEmu::Translate, named_direction));
   }
 
-  // options
+  // Options
   groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));
 
   m_options->AddSetting(&m_speaker_pan_setting,
@@ -211,7 +205,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
                         {"Sideways Wiimote", nullptr, nullptr, _trans("Sideways Wii Remote")},
                         false);
 
-  // hotkeys
+  // Hotkeys
   groups.emplace_back(m_hotkeys = new ControllerEmu::ModifySettingsButton(_trans("Hotkeys")));
   // hotkeys to temporarily modify the Wii Remote orientation (sideways, upright)
   // this setting modifier is toggled
@@ -239,7 +233,7 @@ ControllerEmu::ControlGroup* Wiimote::GetWiimoteGroup(WiimoteGroup group)
     return m_dpad;
   case WiimoteGroup::Shake:
     return m_shake;
-  case WiimoteGroup::IR:
+  case WiimoteGroup::Point:
     return m_ir;
   case WiimoteGroup::Tilt:
     return m_tilt;
@@ -636,7 +630,7 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
   for (int i = 0; i < 3; ++i)
     m_shake->SetControlExpression(i, "Click 2");
 
-  // IR
+  // Pointing (IR)
   m_ir->SetControlExpression(0, "Cursor Y-");
   m_ir->SetControlExpression(1, "Cursor Y+");
   m_ir->SetControlExpression(2, "Cursor X-");
@@ -714,8 +708,6 @@ void Wiimote::StepDynamics()
 
 Common::Vec3 Wiimote::GetAcceleration()
 {
-  // TODO: Cursor forward/backward movement should produce acceleration.
-
   Common::Vec3 accel =
       GetOrientation() *
       GetTransformation().Transform(
@@ -750,7 +742,7 @@ Common::Matrix44 Wiimote::GetTransformation() const
   // Includes positional and rotational effects of:
   // Cursor, Swing, Tilt, Shake
 
-  // TODO: think about and clean up matrix order, make nunchuk match.
+  // TODO: Think about and clean up matrix order + make nunchuk match.
   return Common::Matrix44::Translate(-m_shake_state.position) *
          Common::Matrix44::FromMatrix33(GetRotationalMatrix(
              -m_tilt_state.angle - m_swing_state.angle - m_cursor_state.angle)) *

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -40,7 +40,7 @@ enum class WiimoteGroup
   Buttons,
   DPad,
   Shake,
-  IR,
+  Point,
   Tilt,
   Swing,
   Rumble,

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -212,29 +212,6 @@ void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
     return;
   }
 
-  // Deadzone for Z (forward/backward):
-  const double deadzone = cursor.GetDeadzonePercentage();
-  if (deadzone > 0.0)
-  {
-    p.setPen(GetDeadZonePen());
-    p.setBrush(GetDeadZoneBrush());
-    p.drawRect(QRectF(-scale, -deadzone * scale, scale * 2, deadzone * scale * 2));
-  }
-
-  // Raw Z:
-  p.setPen(Qt::NoPen);
-  p.setBrush(GetRawInputColor());
-  p.drawRect(
-      QRectF(-scale, raw_coord.z * scale - INPUT_DOT_RADIUS / 2, scale * 2, INPUT_DOT_RADIUS));
-
-  // Adjusted Z (if not hidden):
-  if (adj_coord.IsVisible())
-  {
-    p.setBrush(GetAdjustedInputColor());
-    p.drawRect(
-        QRectF(-scale, adj_coord.z * scale - INPUT_DOT_RADIUS / 2, scale * 2, INPUT_DOT_RADIUS));
-  }
-
   // TV screen or whatever you want to call this:
   constexpr double TV_SCALE = 0.75;
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -51,6 +51,11 @@ int MappingWidget::GetPort() const
   return m_parent->GetPort();
 }
 
+QGroupBox* MappingWidget::CreateGroupBox(ControllerEmu::ControlGroup* group)
+{
+  return CreateGroupBox(tr(group->ui_name.c_str()), group);
+}
+
 QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group)
 {
   QGroupBox* group_box = new QGroupBox(name);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -55,6 +55,8 @@ signals:
 
 protected:
   int GetPort() const;
+
+  QGroupBox* CreateGroupBox(ControllerEmu::ControlGroup* group);
   QGroupBox* CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group);
 
 private:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -348,8 +348,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     widget = new WiimoteEmuGeneral(this, extension);
     setWindowTitle(tr("Wii Remote %1").arg(GetPort() + 1));
     AddWidget(tr("General and Options"), widget);
-    // i18n: IR stands for infrared and refers to the pointer functionality of Wii Remotes
-    AddWidget(tr("Motion Controls and IR"), new WiimoteEmuMotionControl(this));
+    AddWidget(tr("Motion Controls"), new WiimoteEmuMotionControl(this));
     AddWidget(tr("Extension"), extension);
     break;
   }

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControl.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControl.cpp
@@ -23,14 +23,14 @@ void WiimoteEmuMotionControl::CreateMainLayout()
 {
   m_main_layout = new QHBoxLayout();
 
-  m_main_layout->addWidget(CreateGroupBox(
-      tr("Shake"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Shake)));
   m_main_layout->addWidget(
-      CreateGroupBox(tr("IR"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::IR)));
-  m_main_layout->addWidget(CreateGroupBox(
-      tr("Tilt"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Tilt)));
-  m_main_layout->addWidget(CreateGroupBox(
-      tr("Swing"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Swing)));
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Shake)));
+  m_main_layout->addWidget(
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Point)));
+  m_main_layout->addWidget(
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Tilt)));
+  m_main_layout->addWidget(
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Swing)));
 
   setLayout(m_main_layout);
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -15,14 +15,13 @@
 
 namespace ControllerEmu
 {
-ControlGroup::ControlGroup(const std::string& name_, const GroupType type_)
-    : name(name_), ui_name(name_), type(type_)
+ControlGroup::ControlGroup(std::string name_, const GroupType type_)
+    : name(name_), ui_name(std::move(name_)), type(type_)
 {
 }
 
-ControlGroup::ControlGroup(const std::string& name_, const std::string& ui_name_,
-                           const GroupType type_)
-    : name(name_), ui_name(ui_name_), type(type_)
+ControlGroup::ControlGroup(std::string name_, std::string ui_name_, const GroupType type_)
+    : name(std::move(name_)), ui_name(std::move(ui_name_)), type(type_)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -44,9 +44,8 @@ enum class GroupType
 class ControlGroup
 {
 public:
-  explicit ControlGroup(const std::string& name, GroupType type = GroupType::Other);
-  ControlGroup(const std::string& name, const std::string& ui_name,
-               GroupType type = GroupType::Other);
+  explicit ControlGroup(std::string name, GroupType type = GroupType::Other);
+  ControlGroup(std::string name, std::string ui_name, GroupType type = GroupType::Other);
   virtual ~ControlGroup();
 
   virtual void LoadConfig(IniFile::Section* sec, const std::string& defdev = "",

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -19,12 +19,11 @@ public:
   {
     ControlState x{};
     ControlState y{};
-    ControlState z{};
 
     bool IsVisible() const;
   };
 
-  explicit Cursor(const std::string& name);
+  Cursor(std::string name, std::string ui_name);
 
   ReshapeData GetReshapableState(bool adjusted) final override;
   ControlState GetGateRadiusAtAngle(double ang) const override;
@@ -44,9 +43,6 @@ private:
   // This is used to reduce the cursor speed for relative input
   // to something that makes sense with the default range.
   static constexpr double STEP_PER_SEC = 0.01 * 200;
-
-  // Smooth out forward/backward movements:
-  static constexpr double STEP_Z_PER_SEC = 0.05 * 200;
 
   static constexpr int AUTO_HIDE_MS = 2500;
   static constexpr double AUTO_HIDE_DEADZONE = 0.001;


### PR DESCRIPTION
The term "IR" (referring to infrared) for emulated wii remote mappings is:
1. Not representative of the actions performed. (The mappings twist the wiimote which in-turn affects IR (**and other**) data.
2. Is meaningless and confusing to users unfamiliar with the details of Wii Remote hardware.

I've renamed "IR" to "Point" (just in the UI, ini file remains unchanged).

The "Motion Controls" tab now has four groups:
Shake, Point, Tilt, and Swing
.. all physical movements of a wii remote. "IR" was wrong and out of place.

I've also eliminated the Forward/Backward mappings which are redundant and less configurable than the "Swing" mappings which now affect "IR" data.
Swing's "Forward"/"Backward" accomplish the same thing also with the ability to set the travel distance/speed.
This de-clutters the dialog a bit.

Screenshot: https://i.imgur.com/PAaqSxc.png