### PR TITLE
WIP -  WiimoteEmu/DolphinQt: Rename "Swing" to "Thrust" in the UI. 

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -136,7 +136,6 @@ Common::Matrix44 EmulateCursorMovement(ControllerEmu::Cursor* ir_group)
 
   // Nintendo recommends a distance of 1-3 meters.
   constexpr float NEUTRAL_DISTANCE = 2.f;
-  constexpr float MOVE_DISTANCE = 1.f;
 
   // When the sensor bar position is on bottom, apply the "offset" setting negatively.
   // This is kinda odd but it does seem to maintain consistent cursor behavior.
@@ -149,8 +148,7 @@ Common::Matrix44 EmulateCursorMovement(ControllerEmu::Cursor* ir_group)
 
   const auto cursor = ir_group->GetState(true);
 
-  return Matrix44::Translate({0, MOVE_DISTANCE * float(cursor.z), 0}) *
-         Matrix44::FromMatrix33(Matrix33::RotateX(pitch_scale * cursor.y) *
+  return Matrix44::FromMatrix33(Matrix33::RotateX(pitch_scale * cursor.y) *
                                 Matrix33::RotateZ(yaw_scale * cursor.x)) *
          Matrix44::Translate({0, -NEUTRAL_DISTANCE, height});
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -44,7 +44,7 @@ Nunchuk::Nunchuk() : EncryptedExtension(_trans("Nunchuk"))
                           new ControllerEmu::OctagonAnalogStick(_trans("Stick"), gate_radius));
 
   // swing
-  groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));
+  groups.emplace_back(m_swing = new ControllerEmu::Force("Swing", _trans("Thrust")));
 
   // tilt
   groups.emplace_back(m_tilt = new ControllerEmu::Tilt(_trans("Tilt")));

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -134,7 +134,7 @@ void Wiimote::Reset()
 
 Wiimote::Wiimote(const unsigned int index) : m_index(index)
 {
-  // buttons
+  // Buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (const char* named_button : named_buttons)
   {
@@ -143,20 +143,14 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
         new ControllerEmu::Input(ControllerEmu::DoNotTranslate, named_button, ui_name));
   }
 
-  // ir
-  // i18n: IR stands for infrared and refers to the pointer functionality of Wii Remotes
-  groups.emplace_back(m_ir = new ControllerEmu::Cursor(_trans("IR")));
-
-  // swing
+  // Pointing (IR)
+  // i18n: "Point" refers to the action of pointing a Wii Remote.
+  groups.emplace_back(m_ir = new ControllerEmu::Cursor("IR", _trans("Point")));
   groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));
-
-  // tilt
   groups.emplace_back(m_tilt = new ControllerEmu::Tilt(_trans("Tilt")));
-
-  // shake
   groups.emplace_back(m_shake = new ControllerEmu::Shake(_trans("Shake")));
 
-  // extension
+  // Extension
   groups.emplace_back(m_attachments = new ControllerEmu::Attachments(_trans("Extension")));
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::None>());
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::Nunchuk>());
@@ -165,12 +159,12 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::Drums>());
   m_attachments->AddAttachment(std::make_unique<WiimoteEmu::Turntable>());
 
-  // rumble
+  // Rumble
   groups.emplace_back(m_rumble = new ControllerEmu::ControlGroup(_trans("Rumble")));
   m_rumble->controls.emplace_back(
       m_motor = new ControllerEmu::Output(ControllerEmu::Translate, _trans("Motor")));
 
-  // dpad
+  // D-Pad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
   for (const char* named_direction : named_directions)
   {
@@ -178,7 +172,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
         new ControllerEmu::Input(ControllerEmu::Translate, named_direction));
   }
 
-  // options
+  // Options
   groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));
 
   m_options->AddSetting(&m_speaker_pan_setting,
@@ -204,7 +198,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
                         {"Sideways Wiimote", nullptr, nullptr, _trans("Sideways Wii Remote")},
                         false);
 
-  // hotkeys
+  // Hotkeys
   groups.emplace_back(m_hotkeys = new ControllerEmu::ModifySettingsButton(_trans("Hotkeys")));
   // hotkeys to temporarily modify the Wii Remote orientation (sideways, upright)
   // this setting modifier is toggled
@@ -232,7 +226,7 @@ ControllerEmu::ControlGroup* Wiimote::GetWiimoteGroup(WiimoteGroup group)
     return m_dpad;
   case WiimoteGroup::Shake:
     return m_shake;
-  case WiimoteGroup::IR:
+  case WiimoteGroup::Point:
     return m_ir;
   case WiimoteGroup::Tilt:
     return m_tilt;
@@ -586,7 +580,7 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
   for (int i = 0; i < 3; ++i)
     m_shake->SetControlExpression(i, "Click 2");
 
-  // IR
+  // Pointing (IR)
   m_ir->SetControlExpression(0, "Cursor Y-");
   m_ir->SetControlExpression(1, "Cursor Y+");
   m_ir->SetControlExpression(2, "Cursor X-");
@@ -667,7 +661,7 @@ void Wiimote::StepDynamics()
 Common::Vec3 Wiimote::GetAcceleration()
 {
   // Includes effects of:
-  // IR, Tilt, Swing, Orientation, Shake
+  // Pointing (IR), Tilt, Swing, Orientation, Shake
 
   auto orientation = Common::Matrix33::Identity();
 
@@ -690,7 +684,7 @@ Common::Vec3 Wiimote::GetAcceleration()
 Common::Matrix44 Wiimote::GetTransformation() const
 {
   // Includes positional and rotational effects of:
-  // IR, Swing, Tilt, Shake
+  // Pointing (IR), Swing, Tilt, Shake
 
   return Common::Matrix44::Translate(-m_shake_state.position) *
          Common::Matrix44::FromMatrix33(GetRotationalMatrix(-m_tilt_state.angle) *

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -146,7 +146,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
   // Pointing (IR)
   // i18n: "Point" refers to the action of pointing a Wii Remote.
   groups.emplace_back(m_ir = new ControllerEmu::Cursor("IR", _trans("Point")));
-  groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));
+  groups.emplace_back(m_swing = new ControllerEmu::Force("Swing", _trans("Thrust")));
   groups.emplace_back(m_tilt = new ControllerEmu::Tilt(_trans("Tilt")));
   groups.emplace_back(m_shake = new ControllerEmu::Shake(_trans("Shake")));
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -40,7 +40,7 @@ enum class WiimoteGroup
   Buttons,
   DPad,
   Shake,
-  IR,
+  Point,
   Tilt,
   Swing,
   Rumble,

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -157,29 +157,6 @@ void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
     return;
   }
 
-  // Deadzone for Z (forward/backward):
-  const double deadzone = cursor.GetDeadzonePercentage();
-  if (deadzone > 0.0)
-  {
-    p.setPen(DEADZONE_COLOR);
-    p.setBrush(DEADZONE_BRUSH);
-    p.drawRect(QRectF(-scale, -deadzone * scale, scale * 2, deadzone * scale * 2));
-  }
-
-  // Raw Z:
-  p.setPen(Qt::NoPen);
-  p.setBrush(RAW_INPUT_COLOR);
-  p.drawRect(
-      QRectF(-scale, raw_coord.z * scale - INPUT_DOT_RADIUS / 2, scale * 2, INPUT_DOT_RADIUS));
-
-  // Adjusted Z (if not hidden):
-  if (adj_coord.z && adj_coord.x < 10000)
-  {
-    p.setBrush(ADJ_INPUT_COLOR);
-    p.drawRect(
-        QRectF(-scale, adj_coord.z * scale - INPUT_DOT_RADIUS / 2, scale * 2, INPUT_DOT_RADIUS));
-  }
-
   // TV screen or whatever you want to call this:
   constexpr double TV_SCALE = 0.75;
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -74,6 +74,11 @@ int MappingWidget::GetPort() const
   return m_parent->GetPort();
 }
 
+QGroupBox* MappingWidget::CreateGroupBox(ControllerEmu::ControlGroup* group)
+{
+  return CreateGroupBox(tr(group->ui_name.c_str()), group);
+}
+
 QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group)
 {
   QGroupBox* group_box = new QGroupBox(name);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -58,6 +58,8 @@ signals:
 
 protected:
   int GetPort() const;
+
+  QGroupBox* CreateGroupBox(ControllerEmu::ControlGroup* group);
   QGroupBox* CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group);
 
 private:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -332,8 +332,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     widget = new WiimoteEmuGeneral(this, extension);
     setWindowTitle(tr("Wii Remote %1").arg(GetPort() + 1));
     AddWidget(tr("General and Options"), widget);
-    // i18n: IR stands for infrared and refers to the pointer functionality of Wii Remotes
-    AddWidget(tr("Motion Controls and IR"), new WiimoteEmuMotionControl(this));
+    AddWidget(tr("Motion Controls"), new WiimoteEmuMotionControl(this));
     AddWidget(tr("Extension"), extension);
     break;
   }

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControl.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMotionControl.cpp
@@ -23,14 +23,14 @@ void WiimoteEmuMotionControl::CreateMainLayout()
 {
   m_main_layout = new QHBoxLayout();
 
-  m_main_layout->addWidget(CreateGroupBox(
-      tr("Shake"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Shake)));
   m_main_layout->addWidget(
-      CreateGroupBox(tr("IR"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::IR)));
-  m_main_layout->addWidget(CreateGroupBox(
-      tr("Tilt"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Tilt)));
-  m_main_layout->addWidget(CreateGroupBox(
-      tr("Swing"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Swing)));
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Shake)));
+  m_main_layout->addWidget(
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Point)));
+  m_main_layout->addWidget(
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Tilt)));
+  m_main_layout->addWidget(
+      CreateGroupBox(Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Swing)));
 
   setLayout(m_main_layout);
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -15,14 +15,13 @@
 
 namespace ControllerEmu
 {
-ControlGroup::ControlGroup(const std::string& name_, const GroupType type_)
-    : name(name_), ui_name(name_), type(type_)
+ControlGroup::ControlGroup(std::string name_, const GroupType type_)
+    : name(name_), ui_name(std::move(name_)), type(type_)
 {
 }
 
-ControlGroup::ControlGroup(const std::string& name_, const std::string& ui_name_,
-                           const GroupType type_)
-    : name(name_), ui_name(ui_name_), type(type_)
+ControlGroup::ControlGroup(std::string name_, std::string ui_name_, const GroupType type_)
+    : name(std::move(name_)), ui_name(std::move(ui_name_)), type(type_)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -44,9 +44,8 @@ enum class GroupType
 class ControlGroup
 {
 public:
-  explicit ControlGroup(const std::string& name, GroupType type = GroupType::Other);
-  ControlGroup(const std::string& name, const std::string& ui_name,
-               GroupType type = GroupType::Other);
+  explicit ControlGroup(std::string name, GroupType type = GroupType::Other);
+  ControlGroup(std::string name, std::string ui_name, GroupType type = GroupType::Other);
   virtual ~ControlGroup();
 
   virtual void LoadConfig(IniFile::Section* sec, const std::string& defdev = "",

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -20,14 +20,13 @@
 
 namespace ControllerEmu
 {
-Cursor::Cursor(const std::string& name_)
-    : ReshapableInput(name_, name_, GroupType::Cursor), m_last_update(Clock::now())
+Cursor::Cursor(std::string name, std::string ui_name)
+    : ReshapableInput(std::move(name), std::move(ui_name), GroupType::Cursor),
+      m_last_update(Clock::now())
 {
   for (auto& named_direction : named_directions)
     controls.emplace_back(std::make_unique<Input>(Translate, named_direction));
 
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Forward")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Backward")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Hide")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
 
@@ -82,13 +81,11 @@ ControlState Cursor::GetGateRadiusAtAngle(double ang) const
 
 Cursor::StateData Cursor::GetState(const bool adjusted)
 {
-  ControlState z = controls[4]->control_ref->State() - controls[5]->control_ref->State();
-
   if (!adjusted)
   {
     const auto raw_input = GetReshapableState(false);
 
-    return {raw_input.x, raw_input.y, z};
+    return {raw_input.x, raw_input.y};
   }
 
   const auto input = GetReshapableState(true);
@@ -101,20 +98,12 @@ Cursor::StateData Cursor::GetState(const bool adjusted)
   m_last_update = now;
 
   const double max_step = STEP_PER_SEC / 1000.0 * ms_since_update;
-  const double max_z_step = STEP_Z_PER_SEC / 1000.0 * ms_since_update;
-
-  // Apply deadzone to z:
-  z = ApplyDeadzone(z, GetDeadzonePercentage());
-
-  // Smooth out z movement:
-  // FYI: Not using relative input for Z.
-  m_state.z += MathUtil::Clamp(z - m_state.z, -max_z_step, max_z_step);
 
   // Relative input:
   if (m_relative_setting.GetValue())
   {
     // Recenter:
-    if (controls[7]->control_ref->State() > BUTTON_THRESHOLD)
+    if (controls[5]->control_ref->State() > BUTTON_THRESHOLD)
     {
       m_state.x = 0.0;
       m_state.y = 0.0;
@@ -151,7 +140,7 @@ Cursor::StateData Cursor::GetState(const bool adjusted)
   m_prev_result = result;
 
   // If auto-hide time is up or hide button is held:
-  if (!m_auto_hide_timer || controls[6]->control_ref->State() > BUTTON_THRESHOLD)
+  if (!m_auto_hide_timer || controls[4]->control_ref->State() > BUTTON_THRESHOLD)
   {
     // TODO: Use NaN or something:
     result.x = 10000;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -19,10 +19,9 @@ public:
   {
     ControlState x{};
     ControlState y{};
-    ControlState z{};
   };
 
-  explicit Cursor(const std::string& name);
+  Cursor(std::string name, std::string ui_name);
 
   ReshapeData GetReshapableState(bool adjusted) final override;
   ControlState GetGateRadiusAtAngle(double ang) const override;
@@ -42,9 +41,6 @@ private:
   // This is used to reduce the cursor speed for relative input
   // to something that makes sense with the default range.
   static constexpr double STEP_PER_SEC = 0.01 * 200;
-
-  // Smooth out forward/backward movements:
-  static constexpr double STEP_Z_PER_SEC = 0.05 * 200;
 
   static constexpr int AUTO_HIDE_MS = 2500;
   static constexpr double AUTO_HIDE_DEADZONE = 0.001;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
@@ -16,7 +16,8 @@
 
 namespace ControllerEmu
 {
-Force::Force(const std::string& name_) : ReshapableInput(name_, name_, GroupType::Force)
+Force::Force(std::string name, std::string ui_name)
+    : ReshapableInput(std::move(name), std::move(ui_name), GroupType::Force)
 {
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Up")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Down")));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
@@ -17,7 +17,7 @@ class Force : public ReshapableInput
 public:
   using StateData = Common::Vec3;
 
-  explicit Force(const std::string& name);
+  Force(std::string name, std::string ui_name);
 
   ReshapeData GetReshapableState(bool adjusted) final override;
   ControlState GetGateRadiusAtAngle(double ang) const final override;


### PR DESCRIPTION
Based on PR #8016.

Rename "Swing" to "Thrust" for a more accurate description of the emulated actions.

Discussion is still being had on what is the best name.