### PR TITLE
GCMemcard: A little cleanup.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1387,3 +1387,26 @@ s32 GCMemcard::PSO_MakeSaveGameValid(const Header& cardheader, const DEntry& dir
 
   return 1;
 }
+
+Directory::Directory()
+{
+  memset(this, 0xFF, BLOCK_SIZE);
+  m_update_counter = 0;
+  m_checksum = BE16(0xF003);
+  m_checksum_inv = 0;
+}
+
+bool Directory::Replace(const DEntry& entry, size_t index)
+{
+  if (index >= m_dir_entries.size())
+    return false;
+
+  m_dir_entries[index] = entry;
+  FixChecksums();
+  return true;
+}
+
+void Directory::FixChecksums()
+{
+  calc_checksumsBE((u16*)this, 0xFFE, &m_checksum, &m_checksum_inv);
+}

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1470,6 +1470,20 @@ void Header::CalculateSerial(u32* serial1, u32* serial2) const
   *serial2 = serial[1] ^ serial[3] ^ serial[5] ^ serial[7];
 }
 
+DEntry::DEntry()
+{
+  memset(this, 0xFF, DENTRY_SIZE);
+}
+
+std::string DEntry::GCI_FileName() const
+{
+  std::string filename =
+      std::string(reinterpret_cast<const char*>(m_makercode.data()), m_makercode.size()) + '-' +
+      std::string(reinterpret_cast<const char*>(m_gamecode.data()), m_gamecode.size()) + '-' +
+      reinterpret_cast<const char*>(m_filename.data()) + ".gci";
+  return Common::EscapeFileName(filename);
+}
+
 Directory::Directory()
 {
   memset(this, 0xFF, BLOCK_SIZE);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1420,6 +1420,16 @@ s32 GCMemcard::PSO_MakeSaveGameValid(const Header& cardheader, const DEntry& dir
   return 1;
 }
 
+GCMBlock::GCMBlock()
+{
+  Erase();
+}
+
+void GCMBlock::Erase()
+{
+  memset(m_block.data(), 0xFF, m_block.size());
+}
+
 Header::Header(int slot, u16 size_mbits, bool shift_jis)
 {
   // Nintendo format algorithm.

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1275,12 +1275,6 @@ bool GCMemcard::Format(u8* card_data, bool shift_jis, u16 SizeMb)
 
 bool GCMemcard::Format(bool shift_jis, u16 SizeMb)
 {
-  memset(&m_header_block, 0xFF, BLOCK_SIZE);
-  memset(&m_directory_blocks[0], 0xFF, BLOCK_SIZE);
-  memset(&m_directory_blocks[1], 0xFF, BLOCK_SIZE);
-  memset(&m_bat_blocks[0], 0, BLOCK_SIZE);
-  memset(&m_bat_blocks[1], 0, BLOCK_SIZE);
-
   m_header_block = Header(SLOT_A, SizeMb, shift_jis);
   m_directory_blocks[0] = m_directory_blocks[1] = Directory();
   m_bat_blocks[0] = m_bat_blocks[1] = BlockAlloc(SizeMb);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -882,9 +882,9 @@ u32 GCMemcard::ImportGciInternal(File::IOFile&& gci, const std::string& inputFil
 
   DEntry tempDEntry;
   gci.ReadBytes(&tempDEntry, DENTRY_SIZE);
-  const int fStart = (int)gci.Tell();
+  const u64 fStart = gci.Tell();
   gci.Seek(0, SEEK_END);
-  const int length = (int)gci.Tell() - fStart;
+  const u64 length = gci.Tell() - fStart;
   gci.Seek(offset + DENTRY_SIZE, SEEK_SET);
 
   Gcs_SavConvert(tempDEntry, offset, length);
@@ -1022,7 +1022,7 @@ u32 GCMemcard::ExportGci(u8 index, const std::string& fileName, const std::strin
     return WRITEFAIL;
 }
 
-void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length)
+void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, u64 length)
 {
   switch (saveType)
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -60,8 +60,6 @@ enum class GCMemcardImportFileRetVal
   SAVFAIL,
   OPENFAIL,
   LENGTHFAIL,
-  WRITEFAIL,
-  GCS,
 };
 
 enum class GCMemcardExportFileRetVal
@@ -380,8 +378,7 @@ private:
   int m_active_directory;
   int m_active_bat;
 
-  GCMemcardImportFileRetVal ImportGciInternal(File::IOFile&& gci, const std::string& inputFile,
-                                              const std::string& outputFile);
+  GCMemcardImportFileRetVal ImportGciInternal(File::IOFile&& gci, const std::string& inputFile);
   void InitActiveDirBat();
 
   const Directory& GetActiveDirectory() const;
@@ -456,8 +453,8 @@ public:
   // reads a save from another memcard, and imports the data into this memcard
   GCMemcardImportFileRetVal CopyFrom(const GCMemcard& source, u8 index);
 
-  // reads a .gci/.gcs/.sav file and calls ImportFile or saves out a gci file
-  GCMemcardImportFileRetVal ImportGci(const std::string& inputFile, const std::string& outputFile);
+  // reads a .gci/.gcs/.sav file and calls ImportFile
+  GCMemcardImportFileRetVal ImportGci(const std::string& inputFile);
 
   // writes a .gci file to disk containing index
   GCMemcardExportFileRetVal ExportGci(u8 index, const std::string& fileName,

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -420,7 +420,7 @@ public:
 
   // GCI files are untouched, SAV files are byteswapped
   // GCS files have the block count set, default is 1 (For export as GCS)
-  static void Gcs_SavConvert(DEntry& tempDEntry, int saveType, int length = BLOCK_SIZE);
+  static void Gcs_SavConvert(DEntry& tempDEntry, int saveType, u64 length = BLOCK_SIZE);
 
   // reads the banner image
   bool ReadBannerRGBA8(u8 index, u32* buffer) const;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -40,7 +40,6 @@ enum
   LENGTHFAIL,
   INVALIDFILESIZE,
   TITLEPRESENT,
-  DIRLEN = 0x7F,
   SAV = 0x80,
   SAVFAIL,
   GCS = 0x110,
@@ -49,24 +48,41 @@ enum
   WRITEFAIL,
   DELETE_FAIL,
 
-  MC_FST_BLOCKS = 0x05,
-  MBIT_TO_BLOCKS = 0x10,
-  DENTRY_STRLEN = 0x20,
-  DENTRY_SIZE = 0x40,
-  BLOCK_SIZE = 0x2000,
-  BAT_SIZE = 0xFFB,
-
-  MemCard59Mb = 0x04,
-  MemCard123Mb = 0x08,
-  MemCard251Mb = 0x10,
-  Memcard507Mb = 0x20,
-  MemCard1019Mb = 0x40,
-  MemCard2043Mb = 0x80,
-
   CI8SHARED = 1,
   RGB5A3,
   CI8,
 };
+
+// size of a single memory card block in bytes
+constexpr u32 BLOCK_SIZE = 0x2000;
+
+// the amount of memory card blocks in a megabit of data
+constexpr u32 MBIT_TO_BLOCKS = (1024 * 1024) / (BLOCK_SIZE * 8);
+
+// number of metadata and filesystem blocks before the actual user data blocks
+constexpr u32 MC_FST_BLOCKS = 0x05;
+
+// maximum number of saves that can be stored on a single memory card
+constexpr u8 DIRLEN = 0x7F;
+
+// maximum size of memory card file comment in bytes
+constexpr u32 DENTRY_STRLEN = 0x20;
+
+// size of a single entry in the Directory in bytes
+constexpr u32 DENTRY_SIZE = 0x40;
+
+// number of block entries in the BAT; one entry uses 2 bytes
+constexpr u16 BAT_SIZE = 0xFFB;
+
+// possible sizes of memory cards in megabits
+// TODO: Do memory card sizes have to be power of two?
+// TODO: Are these all of them? A 4091 block card should work in theory at least.
+constexpr u16 MemCard59Mb = 0x04;
+constexpr u16 MemCard123Mb = 0x08;
+constexpr u16 MemCard251Mb = 0x10;
+constexpr u16 Memcard507Mb = 0x20;
+constexpr u16 MemCard1019Mb = 0x40;
+constexpr u16 MemCard2043Mb = 0x80;
 
 class MemoryCardBase
 {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -148,7 +148,7 @@ struct Header
   explicit Header(int slot = 0, u16 size_mbits = MemCard2043Mb, bool shift_jis = false);
 
   // Calculates the card serial numbers used for encrypting some save files.
-  void CalculateSerial(u32* serial1, u32* serial2) const;
+  std::pair<u32, u32> CalculateSerial() const;
 };
 static_assert(sizeof(Header) == BLOCK_SIZE);
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -32,25 +32,53 @@ enum
   SLOT_A = 0,
   SLOT_B = 1,
   GCI = 0,
-  SUCCESS,
-  NOMEMCARD,
-  OPENFAIL,
-  OUTOFBLOCKS,
-  OUTOFDIRENTRIES,
-  LENGTHFAIL,
-  INVALIDFILESIZE,
-  TITLEPRESENT,
   SAV = 0x80,
-  SAVFAIL,
   GCS = 0x110,
-  GCSFAIL,
-  FAIL,
-  WRITEFAIL,
-  DELETE_FAIL,
 
   CI8SHARED = 1,
   RGB5A3,
   CI8,
+};
+
+enum class GCMemcardGetSaveDataRetVal
+{
+  SUCCESS,
+  FAIL,
+  NOMEMCARD,
+};
+
+enum class GCMemcardImportFileRetVal
+{
+  SUCCESS,
+  FAIL,
+  NOMEMCARD,
+  OUTOFDIRENTRIES,
+  OUTOFBLOCKS,
+  TITLEPRESENT,
+  INVALIDFILESIZE,
+  GCSFAIL,
+  SAVFAIL,
+  OPENFAIL,
+  LENGTHFAIL,
+  WRITEFAIL,
+  GCS,
+};
+
+enum class GCMemcardExportFileRetVal
+{
+  SUCCESS,
+  FAIL,
+  NOMEMCARD,
+  OPENFAIL,
+  WRITEFAIL,
+  UNUSED,
+};
+
+enum class GCMemcardRemoveFileRetVal
+{
+  SUCCESS,
+  NOMEMCARD,
+  DELETE_FAIL,
 };
 
 // size of a single memory card block in bytes
@@ -352,8 +380,8 @@ private:
   int m_active_directory;
   int m_active_bat;
 
-  u32 ImportGciInternal(File::IOFile&& gci, const std::string& inputFile,
-                        const std::string& outputFile);
+  GCMemcardImportFileRetVal ImportGciInternal(File::IOFile&& gci, const std::string& inputFile,
+                                              const std::string& outputFile);
   void InitActiveDirBat();
 
   const Directory& GetActiveDirectory() const;
@@ -417,22 +445,23 @@ public:
   // Fetches a DEntry from the given file index.
   std::optional<DEntry> GetDEntry(u8 index) const;
 
-  u32 GetSaveData(u8 index, std::vector<GCMBlock>& saveBlocks) const;
+  GCMemcardGetSaveDataRetVal GetSaveData(u8 index, std::vector<GCMBlock>& saveBlocks) const;
 
   // adds the file to the directory and copies its contents
-  u32 ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlocks);
+  GCMemcardImportFileRetVal ImportFile(const DEntry& direntry, std::vector<GCMBlock>& saveBlocks);
 
   // delete a file from the directory
-  u32 RemoveFile(u8 index);
+  GCMemcardRemoveFileRetVal RemoveFile(u8 index);
 
   // reads a save from another memcard, and imports the data into this memcard
-  u32 CopyFrom(const GCMemcard& source, u8 index);
+  GCMemcardImportFileRetVal CopyFrom(const GCMemcard& source, u8 index);
 
   // reads a .gci/.gcs/.sav file and calls ImportFile or saves out a gci file
-  u32 ImportGci(const std::string& inputFile, const std::string& outputFile);
+  GCMemcardImportFileRetVal ImportGci(const std::string& inputFile, const std::string& outputFile);
 
   // writes a .gci file to disk containing index
-  u32 ExportGci(u8 index, const std::string& fileName, const std::string& directory) const;
+  GCMemcardExportFileRetVal ExportGci(u8 index, const std::string& fileName,
+                                      const std::string& directory) const;
 
   // GCI files are untouched, SAV files are byteswapped
   // GCS files have the block count set, default is 1 (For export as GCS)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -154,15 +154,10 @@ static_assert(sizeof(Header) == BLOCK_SIZE);
 
 struct DEntry
 {
-  DEntry() { memset(this, 0xFF, DENTRY_SIZE); }
-  std::string GCI_FileName() const
-  {
-    std::string filename =
-        std::string(reinterpret_cast<const char*>(m_makercode.data()), m_makercode.size()) + '-' +
-        std::string(reinterpret_cast<const char*>(m_gamecode.data()), m_gamecode.size()) + '-' +
-        reinterpret_cast<const char*>(m_filename.data()) + ".gci";
-    return Common::EscapeFileName(filename);
-  }
+  DEntry();
+
+  // TODO: This probably shouldn't be here at all?
+  std::string GCI_FileName() const;
 
   static constexpr std::array<u8, 4> UNINITIALIZED_GAMECODE{{0xFF, 0xFF, 0xFF, 0xFF}};
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -92,8 +92,8 @@ protected:
 
 struct GCMBlock
 {
-  GCMBlock() { Erase(); }
-  void Erase() { memset(m_block.data(), 0xFF, m_block.size()); }
+  GCMBlock();
+  void Erase();
   std::array<u8, BLOCK_SIZE> m_block;
 };
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -97,8 +97,6 @@ struct GCMBlock
   std::array<u8, BLOCK_SIZE> m_block;
 };
 
-void calc_checksumsBE(const u16* buf, u32 length, u16* csum, u16* inv_csum);
-
 #pragma pack(push, 1)
 struct Header
 {
@@ -149,6 +147,9 @@ struct Header
 
   // Calculates the card serial numbers used for encrypting some save files.
   std::pair<u32, u32> CalculateSerial() const;
+
+  void FixChecksums();
+  std::pair<u16, u16> CalculateChecksums() const;
 };
 static_assert(sizeof(Header) == BLOCK_SIZE);
 
@@ -257,6 +258,7 @@ struct Directory
   bool Replace(const DEntry& entry, size_t index);
 
   void FixChecksums();
+  std::pair<u16, u16> CalculateChecksums() const;
 };
 static_assert(sizeof(Directory) == BLOCK_SIZE);
 
@@ -285,8 +287,10 @@ struct BlockAlloc
   u16 GetNextBlock(u16 block) const;
   u16 NextFreeBlock(u16 max_block, u16 starting_block = MC_FST_BLOCKS) const;
   bool ClearBlocks(u16 starting_block, u16 block_count);
-  void FixChecksums();
   u16 AssignBlocksContiguous(u16 length);
+
+  void FixChecksums();
+  std::pair<u16, u16> CalculateChecksums() const;
 };
 static_assert(sizeof(BlockAlloc) == BLOCK_SIZE);
 #pragma pack(pop)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -285,37 +285,13 @@ struct BlockAlloc
   // 0x1ff8 bytes at 0x000a: Map of allocated Blocks
   std::array<Common::BigEndianValue<u16>, BAT_SIZE> m_map;
 
-  u16 GetNextBlock(u16 Block) const;
-  u16 NextFreeBlock(u16 MaxBlock, u16 StartingBlock = MC_FST_BLOCKS) const;
-  bool ClearBlocks(u16 StartingBlock, u16 Length);
-  void fixChecksums()
-  {
-    calc_checksumsBE((u16*)&m_update_counter, 0xFFE, &m_checksum, &m_checksum_inv);
-  }
-  explicit BlockAlloc(u16 sizeMb = MemCard2043Mb)
-  {
-    memset(this, 0, BLOCK_SIZE);
-    m_free_blocks = (sizeMb * MBIT_TO_BLOCKS) - MC_FST_BLOCKS;
-    m_last_allocated_block = 4;
-    fixChecksums();
-  }
-  u16 AssignBlocksContiguous(u16 length)
-  {
-    u16 starting = m_last_allocated_block + 1;
-    if (length > m_free_blocks)
-      return 0xFFFF;
-    u16 current = starting;
-    while ((current - starting + 1) < length)
-    {
-      m_map[current - 5] = current + 1;
-      current++;
-    }
-    m_map[current - 5] = 0xFFFF;
-    m_last_allocated_block = current;
-    m_free_blocks = m_free_blocks - length;
-    fixChecksums();
-    return starting;
-  }
+  explicit BlockAlloc(u16 size_mbits = MemCard2043Mb);
+
+  u16 GetNextBlock(u16 block) const;
+  u16 NextFreeBlock(u16 max_block, u16 starting_block = MC_FST_BLOCKS) const;
+  bool ClearBlocks(u16 starting_block, u16 block_count);
+  void FixChecksums();
+  u16 AssignBlocksContiguous(u16 length);
 };
 static_assert(sizeof(BlockAlloc) == BLOCK_SIZE);
 #pragma pack(pop)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -215,7 +215,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u
   }
 
   m_loaded_saves.clear();
-  m_dir1.fixChecksums();
+  m_dir1.FixChecksums();
   m_dir2 = m_dir1;
   m_bat2 = m_bat1;
 

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -300,7 +300,9 @@ void GCMemcardManager::ExportFiles(bool prompt)
              QStringLiteral("/%1").arg(QString::fromStdString(gci_filename));
     }
 
-    if (!memcard->ExportGci(file_index, path.toStdString(), ""))
+    // TODO: This is obviously intended to check for success instead.
+    const auto exportRetval = memcard->ExportGci(file_index, path.toStdString(), "");
+    if (exportRetval == GCMemcardExportFileRetVal::UNUSED)
     {
       File::Delete(path.toStdString());
     }
@@ -330,7 +332,7 @@ void GCMemcardManager::ImportFile()
 
   const auto result = m_slot_memcard[m_active_slot]->ImportGci(path.toStdString(), "");
 
-  if (result != SUCCESS)
+  if (result != GCMemcardImportFileRetVal::SUCCESS)
   {
     ModalMessageBox::critical(this, tr("Import failed"), tr("Failed to import \"%1\".").arg(path));
     return;
@@ -356,7 +358,7 @@ void GCMemcardManager::CopyFiles()
 
     const auto result = m_slot_memcard[!m_active_slot]->CopyFrom(*memcard, file_index);
 
-    if (result != SUCCESS)
+    if (result != GCMemcardImportFileRetVal::SUCCESS)
     {
       ModalMessageBox::warning(this, tr("Copy failed"), tr("Failed to copy file"));
     }
@@ -400,7 +402,7 @@ void GCMemcardManager::DeleteFiles()
 
   for (int file_index : file_indices)
   {
-    if (memcard->RemoveFile(file_index) != SUCCESS)
+    if (memcard->RemoveFile(file_index) != GCMemcardRemoveFileRetVal::SUCCESS)
     {
       ModalMessageBox::warning(this, tr("Remove failed"), tr("Failed to remove file"));
     }

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -330,7 +330,7 @@ void GCMemcardManager::ImportFile()
   if (path.isEmpty())
     return;
 
-  const auto result = m_slot_memcard[m_active_slot]->ImportGci(path.toStdString(), "");
+  const auto result = m_slot_memcard[m_active_slot]->ImportGci(path.toStdString());
 
   if (result != GCMemcardImportFileRetVal::SUCCESS)
   {


### PR DESCRIPTION
Cleans up the memory card code a bit more. Tries to get rid of undefined behavior, updates naming conventions, moves code out of the header into the code file, converts enum values into enum classes or constexpr as appropriate. Should have zero functional changes.