### PR TITLE
[WIP] GCMemcard: Header verification.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -192,6 +192,16 @@ struct Header
 
   void FixChecksums();
   std::pair<u16, u16> CalculateChecksums() const;
+
+  enum class ValidityCheckErrorCode
+  {
+    VALID,
+    INVALID_CHECKSUM,
+    INVALID_CARD_SIZE,
+    INVALID_ENCODING,
+    DATA_IN_UNUSED_AREA,
+  };
+  ValidityCheckErrorCode SeemsValid(u16 card_size_mbits) const;
 };
 static_assert(sizeof(Header) == BLOCK_SIZE);
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -311,6 +311,14 @@ struct Directory
 
   void FixChecksums();
   std::pair<u16, u16> CalculateChecksums() const;
+
+  enum class ValidityCheckErrorCode
+  {
+    VALID,
+    INVALID_CHECKSUM,
+    DATA_IN_UNUSED_AREA,
+  };
+  ValidityCheckErrorCode SeemsValid() const;
 };
 static_assert(sizeof(Directory) == BLOCK_SIZE);
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -351,6 +351,16 @@ struct BlockAlloc
 
   void FixChecksums();
   std::pair<u16, u16> CalculateChecksums() const;
+
+  enum class ValidityCheckErrorCode
+  {
+    VALID,
+    INVALID_CHECKSUM,
+    CARD_SIZE_TOO_LARGE,
+    FREE_BLOCK_MISMATCH,
+    DATA_IN_UNUSED_AREA,
+  };
+  ValidityCheckErrorCode SeemsValid(u16 size_mbits) const;
 };
 static_assert(sizeof(BlockAlloc) == BLOCK_SIZE);
 #pragma pack(pop)


### PR DESCRIPTION
Depends on #8019. This is the followup verification code for #7975.

Adds a bunch of sanity checks to identify possibly corrupted memory cards.

TODO:

- Are all of these checks sensible?
- Can we think of further checks?
- Should we differentiate between 'fatal errors' and 'questionable but probably doesn't affect anything'?
- Should we offer automatic fixes?
- Properly integrate the Dir and BAT checks into the GCMemcard constructor.
- Proper error messages for the different kind of errors (not through PanicAlert).
- `GCMemcard::TestChecksums()` is obsolete with this.