### PR TITLE
Qt: Fix add button not releasing

### DIFF
--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -162,7 +162,7 @@ void FIFOPlayerWindow::CreateWidgets()
 
 void FIFOPlayerWindow::ConnectWidgets()
 {
-  connect(m_load, &QPushButton::pressed, this, &FIFOPlayerWindow::LoadRecording);
+  connect(m_load, &QPushButton::clicked, this, &FIFOPlayerWindow::LoadRecording);
   connect(m_save, &QPushButton::pressed, this, &FIFOPlayerWindow::SaveRecording);
   connect(m_record, &QPushButton::pressed, this, &FIFOPlayerWindow::StartRecording);
   connect(m_stop, &QPushButton::pressed, this, &FIFOPlayerWindow::StopRecording);

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -128,7 +128,7 @@ void GCMemcardManager::ConnectWidgets()
   {
     connect(m_slot_file_edit[slot], &QLineEdit::textChanged, this,
             [this, slot](const QString& path) { SetSlotFile(slot, path); });
-    connect(m_slot_file_button[slot], &QPushButton::pressed, this,
+    connect(m_slot_file_button[slot], &QPushButton::clicked, this,
             [this, slot] { SetSlotFileInteractive(slot); });
     connect(m_slot_table[slot], &QTableWidget::itemSelectionChanged, this,
             &GCMemcardManager::UpdateActions);

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -143,7 +143,7 @@ QGroupBox* PathPane::MakeGameFolderBox()
   connect(auto_checkbox, &QCheckBox::toggled, &Settings::Instance(),
           &Settings::SetAutoRefreshEnabled);
 
-  connect(add, &QPushButton::pressed, this, &PathPane::Browse);
+  connect(add, &QPushButton::clicked, this, &PathPane::Browse);
   connect(m_remove_path, &QPushButton::pressed, this, &PathPane::RemovePath);
 
   game_box->setLayout(vlayout);

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -79,7 +79,7 @@ void WiiPane::ConnectLayout()
 
   // Whitelisted USB Passthrough Devices
   connect(m_whitelist_usb_list, &QListWidget::itemClicked, this, &WiiPane::ValidateSelectionState);
-  connect(m_whitelist_usb_add_button, &QPushButton::pressed, this,
+  connect(m_whitelist_usb_add_button, &QPushButton::clicked, this,
           &WiiPane::OnUSBWhitelistAddButton);
   connect(m_whitelist_usb_remove_button, &QPushButton::pressed, this,
           &WiiPane::OnUSBWhitelistRemoveButton);


### PR DESCRIPTION
The add button did not release and remained highlighted after exiting the QFileDialog because `&QPushButton::pressed` was used. 

The Wii settings pane, GCMemcardManager and FIFOPlayerWindow also have a similar issue and I can address them as well.