### PR TITLE
Fix the screen going black on pause after changing windows

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -52,6 +52,7 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
   });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
+    // Stop filling the background once emulation starts, but fill it until then (Bug 10958)
     SetFillBackground(Config::Get(Config::MAIN_RENDER_TO_MAIN) &&
                       state == Core::State::Uninitialized);
     if (state == Core::State::Running)
@@ -90,9 +91,15 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
 
 void RenderWidget::SetFillBackground(bool fill)
 {
+  setAutoFillBackground(fill);
   setAttribute(Qt::WA_OpaquePaintEvent, !fill);
   setAttribute(Qt::WA_NoSystemBackground, !fill);
-  setAutoFillBackground(fill);
+  setAttribute(Qt::WA_PaintOnScreen, !fill);
+}
+
+QPaintEngine* RenderWidget::paintEngine() const
+{
+  return autoFillBackground() ? QWidget::paintEngine() : nullptr;
 }
 
 void RenderWidget::dragEnterEvent(QDragEnterEvent* event)

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -19,6 +19,7 @@ public:
 
   bool event(QEvent* event) override;
   void showFullScreen();
+  QPaintEngine* paintEngine() const override;
 
 signals:
   void EscapePressed();


### PR DESCRIPTION
This solves the screen going black if the game is paused and then the output is switched to.  It also helps with games that stop outputting frames (e.g. the homebrew crash screen); it now continues to display the previous frame instead of rendering black.

WX used to keep the last output frame visible, but Qt replaced it with black as soon as the window was focused again (or rather, as soon as it repainted itself).  Telling Qt not to do this is sufficient to keep the last frame visible; this is done by setting `WA_PaintOnScreen` and making `paintEngine` return `nullptr`.  ([More info](https://zeduckmaster.frama.io/2016/how-to-create-a-custom-rendering-in-a-qt5-widget/)).

Note that the whole `SetFillBackground` system exists because of #6519 (which fixes [bug 10958](https://bugs.dolphin-emu.org/issues/10958)).  I've confirmed that it is still fixed with this change (and that removing `SetFillBackground` and always setting the attributes to true causes the issue to come back).

This does _not_ store the frame and manually re-render it.  So, it doesn't help with e.g. screenshots, or resizing the window (which for me causes weird effects but doesn't cause it to go black anymore).