### PR TITLE
Qt/NetPlayDialog: Move MD5 button into menubar

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -26,7 +26,6 @@ class QSpinBox;
 class QSplitter;
 class QTableWidget;
 class QTextEdit;
-class QToolButton;
 
 class NetPlayDialog : public QDialog, public NetPlay::NetPlayUI
 {
@@ -120,9 +119,9 @@ private:
   QMenuBar* m_menu_bar;
   QMenu* m_data_menu;
   QMenu* m_network_menu;
+  QMenu* m_md5_menu;
   QMenu* m_other_menu;
   QPushButton* m_game_button;
-  QToolButton* m_md5_button;
   QPushButton* m_start_button;
   QLabel* m_buffer_label;
   QSpinBox* m_buffer_size_box;


### PR DESCRIPTION
This removes the MD5 tool button from the netplay dialog and moves it into the menubar instead.

* It's more compact and everything is in one place now
* It reduces the amount of ``QToolButton``s in use
  * They don't render properly on macOS
  * They're not intuitive to use

Partially addresses https://bugs.dolphin-emu.org/issues/11292