### PR TITLE
Disable Defer EFB Copies to RAM for Baten Kaitos: Eternal Wings and t…

### DIFF
--- a/Data/Sys/GameSettings/GKB.ini
+++ b/Data/Sys/GameSettings/GKB.ini
@@ -17,5 +17,6 @@ CPUThread = 0
 ImmediateXFBEnable = False
 EFBAccessEnable = False
 EFBToTextureEnable = False
+DeferEFBCopies = False
 
 [Video_Settings]


### PR DESCRIPTION
…he Lost Ocean

The game crashes randomly after a fight against Kalas late in the game, if Defer EFB Copies to RAM is enabled.

Here's some more information about the crash, in case somebody wants to investigate it:
After the fight, Kalas' Wings fade, the background gradually darkens and there's one line of dialog. As soon as that dialog is confirmed, the game freezes with a constant noise. In my testing, i ran it about 7 times and different settings(graphics backends, IR, efb access enabled/disabled), and it crashed 6 out of 7 times. I think it also was on 1x IR when it didn't crash. I've also attached a savegame for the PAL version, right before the fight. (thanks to Botulix for uploading the save game to the forums, the cards were edited by me to make the fight faster)

[AF-GKBP-BKData-000.zip](https://github.com/dolphin-emu/dolphin/files/3123004/AF-GKBP-BKData-000.zip)

It should be considered to disable this for the 2nd Baten Kaitos game as well. It's likely that it uses the same engine and might crash somewhere.