### PR TITLE
CommandProcessor: Don't reset gather pipe on write the high distance bit (fixes monster lab)

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -276,15 +276,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::ComplexWrite<u16>([WMASK_HI_RESTRICT](u32, u16 val) {
                    WriteHigh(fifo.CPReadWriteDistance, val & WMASK_HI_RESTRICT);
                    Fifo::SyncGPU(Fifo::SyncGPUReason::Other);
-                   if (fifo.CPReadWriteDistance == 0)
-                   {
-                     GPFifo::ResetGatherPipe();
-                     Fifo::ResetVideoBuffer();
-                   }
-                   else
-                   {
-                     Fifo::ResetVideoBuffer();
-                   }
+                   Fifo::ResetVideoBuffer();
                    Fifo::RunGpu();
                  }));
   mmio->Register(


### PR DESCRIPTION
On investigating why _Monster Lab_ would not boot, I noticed some extra commands in the last commit that broke the game.  Removing this line allowed game to boot normally.

After discussion, it turns out the current code isn't following the hardware's behavior.  On real hardware the gather-pipe or WPAR buffer will only be reset upon receiving 32bytes.

Big thanks to @booto for help explaining the hardware side of it and doing the hardware test that confirms this.

Fixes [issue 9249](https://bugs.dolphin-emu.org/issues/9249)
Fixes [issue 10826](https://bugs.dolphin-emu.org/issues/10826)