### PR TITLE
Fix uninitialized powerpc.xer_* variables

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -169,6 +169,7 @@ static void ResetRegisters()
   {
     v = 0x8000000000000001;
   }
+  SetXER({});
 
   DBATUpdated();
   IBATUpdated();


### PR DESCRIPTION
I looked everywhere and I couldn't see them initialized anywhere, though chances are most emulated code would set them before using them.

