### PR TITLE
DolphinQt: Fix "Default" and "Clear" buttons not updating the displayed extension.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -117,7 +117,7 @@ void IOWindow::CreateMainLayout()
 
 void IOWindow::ConfigChanged()
 {
-  const auto old_state = blockSignals(true);
+  const QSignalBlocker blocker(this);
 
   m_expression_text->setPlainText(QString::fromStdString(m_reference->GetExpression()));
   m_expression_text->moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
@@ -128,8 +128,6 @@ void IOWindow::ConfigChanged()
 
   UpdateDeviceList();
   UpdateOptionList();
-
-  blockSignals(old_state);
 }
 
 void IOWindow::ConnectWidgets()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -38,9 +38,8 @@ void MappingDouble::fixup(QString& input) const
 
 void MappingDouble::ConfigChanged()
 {
-  const bool old_state = blockSignals(true);
+  const QSignalBlocker blocker(this);
   setValue(m_setting.GetValue());
-  blockSignals(old_state);
 }
 
 MappingBool::MappingBool(MappingWidget* parent, ControllerEmu::NumericSetting<bool>* setting)
@@ -56,7 +55,6 @@ MappingBool::MappingBool(MappingWidget* parent, ControllerEmu::NumericSetting<bo
 
 void MappingBool::ConfigChanged()
 {
-  const bool old_state = blockSignals(true);
+  const QSignalBlocker blocker(this);
   setChecked(m_setting.GetValue());
-  blockSignals(old_state);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -258,7 +258,7 @@ void MappingWindow::RefreshDevices()
 
 void MappingWindow::OnGlobalDevicesChanged()
 {
-  const auto old_state = m_devices_combo->blockSignals(true);
+  const QSignalBlocker blocker(m_devices_combo);
 
   m_devices_combo->clear();
 
@@ -292,8 +292,6 @@ void MappingWindow::OnGlobalDevicesChanged()
   }
 
   m_devices_combo->addItem(tr("All devices"));
-
-  m_devices_combo->blockSignals(old_state);
 }
 
 void MappingWindow::SetMappingType(MappingWindow::Type type)

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -29,7 +29,7 @@ WiimoteEmuExtension::WiimoteEmuExtension(MappingWindow* window) : MappingWidget(
   CreateTurntableLayout();
   CreateMainLayout();
 
-  ChangeExtensionType(Type::NONE);
+  ChangeExtensionType(WiimoteEmu::ExtensionNumber::NONE);
 }
 
 void WiimoteEmuExtension::CreateClassicLayout()
@@ -212,12 +212,14 @@ InputConfig* WiimoteEmuExtension::GetConfig()
   return Wiimote::GetConfig();
 }
 
-void WiimoteEmuExtension::ChangeExtensionType(WiimoteEmuExtension::Type type)
+void WiimoteEmuExtension::ChangeExtensionType(u32 type)
 {
-  m_classic_box->setHidden(type != Type::CLASSIC_CONTROLLER);
-  m_drums_box->setHidden(type != Type::DRUMS);
-  m_guitar_box->setHidden(type != Type::GUITAR);
-  m_none_box->setHidden(type != Type::NONE);
-  m_nunchuk_box->setHidden(type != Type::NUNCHUK);
-  m_turntable_box->setHidden(type != Type::TURNTABLE);
+  using WiimoteEmu::ExtensionNumber;
+
+  m_none_box->setHidden(type != ExtensionNumber::NONE);
+  m_nunchuk_box->setHidden(type != ExtensionNumber::NUNCHUK);
+  m_classic_box->setHidden(type != ExtensionNumber::CLASSIC);
+  m_guitar_box->setHidden(type != ExtensionNumber::GUITAR);
+  m_drums_box->setHidden(type != ExtensionNumber::DRUMS);
+  m_turntable_box->setHidden(type != ExtensionNumber::TURNTABLE);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.h
@@ -6,6 +6,8 @@
 
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 
+#include "Core/HW/WiimoteEmu/ExtensionPort.h"
+
 class QGroupBox;
 class QHBoxLayout;
 
@@ -13,21 +15,11 @@ class WiimoteEmuExtension final : public MappingWidget
 {
   Q_OBJECT
 public:
-  enum class Type
-  {
-    NONE,
-    CLASSIC_CONTROLLER,
-    DRUMS,
-    GUITAR,
-    NUNCHUK,
-    TURNTABLE
-  };
-
   explicit WiimoteEmuExtension(MappingWindow* window);
 
   InputConfig* GetConfig() override;
 
-  void ChangeExtensionType(Type type);
+  void ChangeExtensionType(u32 type);
 
 private:
   void LoadSettings() override;

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -48,10 +48,7 @@ void WiimoteEmuGeneral::CreateMainLayout()
   m_extension_combo = new QComboBox();
 
   for (const auto& attachment : ce_extension->GetAttachmentList())
-  {
-    // TODO: Figure out how to localize this
-    m_extension_combo->addItem(QString::fromStdString(attachment->GetName()));
-  }
+    m_extension_combo->addItem(tr(attachment->GetName().c_str()));
 
   extension->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
@@ -74,30 +71,21 @@ void WiimoteEmuGeneral::Connect(MappingWindow* window)
 {
   connect(m_extension_combo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
           this, &WiimoteEmuGeneral::OnAttachmentChanged);
-  connect(window, &MappingWindow::Update, this, &WiimoteEmuGeneral::Update);
+  connect(window, &MappingWindow::ConfigChanged, this, &WiimoteEmuGeneral::ConfigChanged);
 }
 
 void WiimoteEmuGeneral::OnAttachmentChanged(int extension)
 {
-  const QString value = m_extension_combo->currentText();
-
-  static const QMap<QString, WiimoteEmuExtension::Type> value_map = {
-      {QStringLiteral("None"), WiimoteEmuExtension::Type::NONE},
-      {QStringLiteral("Classic"), WiimoteEmuExtension::Type::CLASSIC_CONTROLLER},
-      {QStringLiteral("Drums"), WiimoteEmuExtension::Type::DRUMS},
-      {QStringLiteral("Guitar"), WiimoteEmuExtension::Type::GUITAR},
-      {QStringLiteral("Nunchuk"), WiimoteEmuExtension::Type::NUNCHUK},
-      {QStringLiteral("Turntable"), WiimoteEmuExtension::Type::TURNTABLE}};
-
-  m_extension_widget->ChangeExtensionType(value_map[value]);
+  m_extension_widget->ChangeExtensionType(extension);
 
   auto* ce_extension = static_cast<ControllerEmu::Attachments*>(
       Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Attachments));
   ce_extension->SetSelectedAttachment(extension);
+
   SaveSettings();
 }
 
-void WiimoteEmuGeneral::Update()
+void WiimoteEmuGeneral::ConfigChanged()
 {
   auto* ce_extension = static_cast<ControllerEmu::Attachments*>(
       Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Attachments));
@@ -107,7 +95,6 @@ void WiimoteEmuGeneral::Update()
 
 void WiimoteEmuGeneral::LoadSettings()
 {
-  Update();
   Wiimote::LoadConfig();
 }
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.h
@@ -23,7 +23,7 @@ private:
   void CreateMainLayout();
   void Connect(MappingWindow* window);
   void OnAttachmentChanged(int index);
-  void Update();
+  void ConfigChanged();
 
   // Extensions
   QComboBox* m_extension_combo;


### PR DESCRIPTION
Because the wrong signal was connected an extension change was not shown in the UI on "Default" or "Clear" press.

I eliminated the redundant enum of emulated wii remote extensions types.

Extension names should now be translated.

I also changed some explicit `blockSignals` calls to use `QSignalBlocker`.