### PR TITLE
DolphinQt: Fix mapping of space, return, and mouse-clicks.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -56,7 +56,7 @@ MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref, bool 
   setToolTip(
       tr("Left-click to detect input.\nMiddle-click to clear.\nRight-click for more options."));
 
-  connect(this, &MappingButton::pressed, this, &MappingButton::Detect);
+  connect(this, &MappingButton::clicked, this, &MappingButton::Detect);
 
   if (indicator)
     connect(parent, &MappingWidget::Update, this, &MappingButton::UpdateIndicator);

--- a/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.cpp
+++ b/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.cpp
@@ -6,12 +6,6 @@
 
 #include <QEvent>
 
-BlockUserInputFilter* BlockUserInputFilter::Instance()
-{
-  static BlockUserInputFilter s_block_user_input_filter;
-  return &s_block_user_input_filter;
-}
-
 bool BlockUserInputFilter::eventFilter(QObject* object, QEvent* event)
 {
   const QEvent::Type event_type = event->type();

--- a/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.h
+++ b/Source/Core/DolphinQt/QtUtils/BlockUserInputFilter.h
@@ -12,9 +12,8 @@ class BlockUserInputFilter : public QObject
 {
   Q_OBJECT
 public:
-  static BlockUserInputFilter* Instance();
+  using QObject::QObject;
 
 private:
-  BlockUserInputFilter() = default;
   bool eventFilter(QObject* object, QEvent* event) override;
 };


### PR DESCRIPTION
When mapping "space" or "return" it immediately re-activated input detection which was annoying and confusing to users.

I've inserted a delay in the removal of the event blocking filter to mostly eliminate this.

I made `BlockUserInputFilter` no longer a singleton.