### PR TITLE
DolphinQt: Move mapping indicators to top of UI.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/GCPadEmu.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadEmu.cpp
@@ -23,15 +23,14 @@ void GCPadEmu::CreateMainLayout()
   auto* layout = new QGridLayout;
 
   layout->addWidget(CreateGroupBox(tr("Buttons"), Pad::GetGroup(GetPort(), PadGroup::Buttons)), 0,
-                    0, -1, 1);
+                    0);
+  layout->addWidget(CreateGroupBox(tr("D-Pad"), Pad::GetGroup(GetPort(), PadGroup::DPad)), 1, 0, -1,
+                    1);
   layout->addWidget(
       CreateGroupBox(tr("Control Stick"), Pad::GetGroup(GetPort(), PadGroup::MainStick)), 0, 1, -1,
       1);
   layout->addWidget(CreateGroupBox(tr("C Stick"), Pad::GetGroup(GetPort(), PadGroup::CStick)), 0, 2,
                     -1, 1);
-  layout->addWidget(CreateGroupBox(tr("D-Pad"), Pad::GetGroup(GetPort(), PadGroup::DPad)), 0, 3, -1,
-                    1);
-
   layout->addWidget(CreateGroupBox(tr("Triggers"), Pad::GetGroup(GetPort(), PadGroup::Triggers)), 0,
                     4);
   layout->addWidget(CreateGroupBox(tr("Rumble"), Pad::GetGroup(GetPort(), PadGroup::Rumble)), 1, 4);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -97,7 +97,18 @@ QColor MappingIndicator::GetGateColor() const
 
 MappingIndicator::MappingIndicator(ControllerEmu::ControlGroup* group) : m_group(group)
 {
-  setMinimumHeight(128);
+  // TODO: Make these magic numbers less ugly.
+  int required_height = 106;
+
+  if (ControllerEmu::GroupType::MixedTriggers == group->type)
+    required_height = 64 + 1;
+
+  setFixedHeight(required_height);
+}
+
+double MappingIndicator::GetScale() const
+{
+  return height() / 2 - 2;
 }
 
 namespace
@@ -178,7 +189,7 @@ void MappingIndicator::DrawCursor(ControllerEmu::Cursor& cursor)
   UpdateCalibrationWidget({raw_coord.x, raw_coord.y});
 
   // Bounding box size:
-  const double scale = height() / 2.5;
+  const double scale = GetScale();
 
   QPainter p(this);
   p.translate(width() / 2, height() / 2);
@@ -291,7 +302,7 @@ void MappingIndicator::DrawReshapableInput(ControllerEmu::ReshapableInput& stick
   UpdateCalibrationWidget(raw_coord);
 
   // Bounding box size:
-  const double scale = height() / 2.5;
+  const double scale = GetScale();
 
   QPainter p(this);
   p.translate(width() / 2, height() / 2);
@@ -453,7 +464,7 @@ void MappingIndicator::DrawForce(ControllerEmu::Force& force)
   UpdateCalibrationWidget({raw_coord.x, raw_coord.y});
 
   // Bounding box size:
-  const double scale = height() / 2.5;
+  const double scale = GetScale();
 
   QPainter p(this);
   p.translate(width() / 2, height() / 2);
@@ -592,7 +603,7 @@ void ShakeMappingIndicator::DrawShake()
     m_position_samples.pop_back();
 
   // Bounding box size:
-  const double scale = height() / 2.5;
+  const double scale = GetScale();
 
   QPainter p(this);
   p.translate(width() / 2, height() / 2);
@@ -657,8 +668,8 @@ void ShakeMappingIndicator::DrawShake()
 
 void MappingIndicator::DrawCalibration(QPainter& p, Common::DVec2 point)
 {
-  // TODO: Ugly magic number used in a few places in this file.
-  const double scale = height() / 2.5;
+  // Bounding box size:
+  const double scale = GetScale();
 
   // Input shape.
   p.setPen(GetInputShapePen());

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -48,6 +48,8 @@ protected:
   QColor GetAltTextColor() const;
   QColor GetGateColor() const;
 
+  double GetScale() const;
+
 private:
   void DrawCursor(ControllerEmu::Cursor& cursor);
   void DrawReshapableInput(ControllerEmu::ReshapableInput& stick);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -70,6 +70,34 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
                                 group->type == ControllerEmu::GroupType::Tilt ||
                                 group->type == ControllerEmu::GroupType::Force;
 
+  if (need_indicator)
+  {
+    MappingIndicator* indicator;
+
+    switch (group->type)
+    {
+    case ControllerEmu::GroupType::Shake:
+      indicator = new ShakeMappingIndicator(static_cast<ControllerEmu::Shake*>(group));
+      break;
+
+    default:
+      indicator = new MappingIndicator(group);
+      break;
+    }
+
+    form_layout->addRow(indicator);
+
+    connect(this, &MappingWidget::Update, indicator, QOverload<>::of(&MappingIndicator::update));
+
+    if (need_calibration)
+    {
+      const auto calibrate =
+          new CalibrationWidget(*static_cast<ControllerEmu::ReshapableInput*>(group), *indicator);
+
+      form_layout->addRow(calibrate);
+    }
+  }
+
   for (auto& control : group->controls)
   {
     auto* button = new MappingButton(this, control->control_ref.get(), !need_indicator);
@@ -103,34 +131,6 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
 
     if (setting_widget)
       form_layout->addRow(tr(setting->GetUIName()), setting_widget);
-  }
-
-  if (need_indicator)
-  {
-    MappingIndicator* indicator;
-
-    switch (group->type)
-    {
-    case ControllerEmu::GroupType::Shake:
-      indicator = new ShakeMappingIndicator(static_cast<ControllerEmu::Shake*>(group));
-      break;
-
-    default:
-      indicator = new MappingIndicator(group);
-      break;
-    }
-
-    connect(this, &MappingWidget::Update, indicator, QOverload<>::of(&MappingIndicator::update));
-
-    if (need_calibration)
-    {
-      const auto calibrate =
-          new CalibrationWidget(*static_cast<ControllerEmu::ReshapableInput*>(group), *indicator);
-
-      form_layout->addRow(calibrate);
-    }
-
-    form_layout->addRow(indicator);
   }
 
   return group_box;

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -40,7 +40,10 @@ void WiimoteEmuExtension::CreateClassicLayout()
   layout->addWidget(
       CreateGroupBox(tr("Buttons"),
                      Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Buttons)),
-      0, 0, -1, 1);
+      0, 0);
+  layout->addWidget(CreateGroupBox(tr("D-Pad"), Wiimote::GetClassicGroup(
+                                                    GetPort(), WiimoteEmu::ClassicGroup::DPad)),
+                    1, 0);
   layout->addWidget(
       CreateGroupBox(tr("Left Stick"),
                      Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::LeftStick)),
@@ -49,14 +52,10 @@ void WiimoteEmuExtension::CreateClassicLayout()
       CreateGroupBox(tr("Right Stick"),
                      Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::RightStick)),
       0, 2, -1, 1);
-
-  layout->addWidget(CreateGroupBox(tr("D-Pad"), Wiimote::GetClassicGroup(
-                                                    GetPort(), WiimoteEmu::ClassicGroup::DPad)),
-                    0, 3);
   layout->addWidget(
       CreateGroupBox(tr("Triggers"),
                      Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Triggers)),
-      1, 3);
+      0, 3, -1, 1);
 
   m_classic_box->setLayout(layout);
 }
@@ -97,23 +96,22 @@ void WiimoteEmuExtension::CreateNunchukLayout()
   auto* layout = new QGridLayout();
   m_nunchuk_box = new QGroupBox(tr("Nunchuk"), this);
 
-  layout->addWidget(CreateGroupBox(tr("Stick"), Wiimote::GetNunchukGroup(
-                                                    GetPort(), WiimoteEmu::NunchukGroup::Stick)),
-                    0, 0, -1, 1);
-  layout->addWidget(CreateGroupBox(tr("Tilt"), Wiimote::GetNunchukGroup(
-                                                   GetPort(), WiimoteEmu::NunchukGroup::Tilt)),
-                    0, 1, -1, 1);
-  layout->addWidget(CreateGroupBox(tr("Swing"), Wiimote::GetNunchukGroup(
-                                                    GetPort(), WiimoteEmu::NunchukGroup::Swing)),
-                    0, 2, -1, 1);
-
+  layout->addWidget(CreateGroupBox(tr("Shake"), Wiimote::GetNunchukGroup(
+                                                    GetPort(), WiimoteEmu::NunchukGroup::Shake)),
+                    0, 0);
   layout->addWidget(
       CreateGroupBox(tr("Buttons"),
                      Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Buttons)),
-      0, 3);
-  layout->addWidget(CreateGroupBox(tr("Shake"), Wiimote::GetNunchukGroup(
-                                                    GetPort(), WiimoteEmu::NunchukGroup::Shake)),
-                    1, 3);
+      1, 0);
+  layout->addWidget(CreateGroupBox(tr("Stick"), Wiimote::GetNunchukGroup(
+                                                    GetPort(), WiimoteEmu::NunchukGroup::Stick)),
+                    0, 1, -1, 1);
+  layout->addWidget(CreateGroupBox(tr("Tilt"), Wiimote::GetNunchukGroup(
+                                                   GetPort(), WiimoteEmu::NunchukGroup::Tilt)),
+                    0, 2, -1, 1);
+  layout->addWidget(CreateGroupBox(tr("Swing"), Wiimote::GetNunchukGroup(
+                                                    GetPort(), WiimoteEmu::NunchukGroup::Swing)),
+                    0, 3, -1, 1);
 
   m_nunchuk_box->setLayout(layout);
 }


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/11701 (mockup screenshots inside)

I think this looks cleaner and perhaps it will allow troubled users to find the "Calibrate" button.

Rearranged some groups so all the indicators are on top.