### PR TITLE
D3D11: Fix Dolphin crashing on feature level 10.0 devices

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -40,6 +40,9 @@ void Destroy();
 // Returns a list of supported AA modes for the current device.
 std::vector<u32> GetAAModes(u32 adapter_index);
 
+// Checks for support of the given texture format.
+bool SupportsTextureFormat(DXGI_FORMAT format);
+
 }  // namespace D3D
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -87,6 +87,25 @@ void VideoBackend::FillBackendInfo()
 
   g_Config.backend_info.Adapters = D3DCommon::GetAdapterNames();
   g_Config.backend_info.AAModes = D3D::GetAAModes(g_Config.iAdapter);
+
+  // Override optional features if we are actually booting.
+  if (D3D::device)
+  {
+    g_Config.backend_info.bSupportsST3CTextures =
+        D3D::SupportsTextureFormat(DXGI_FORMAT_BC1_UNORM) &&
+        D3D::SupportsTextureFormat(DXGI_FORMAT_BC2_UNORM) &&
+        D3D::SupportsTextureFormat(DXGI_FORMAT_BC3_UNORM);
+    g_Config.backend_info.bSupportsBPTCTextures = D3D::SupportsTextureFormat(DXGI_FORMAT_BC7_UNORM);
+
+    // Features only supported with a FL11.0+ device.
+    const bool shader_model_5_supported = D3D::feature_level >= D3D_FEATURE_LEVEL_11_0;
+    g_Config.backend_info.bSupportsEarlyZ = shader_model_5_supported;
+    g_Config.backend_info.bSupportsBBox = shader_model_5_supported;
+    g_Config.backend_info.bSupportsFragmentStoresAndAtomics = shader_model_5_supported;
+    g_Config.backend_info.bSupportsGSInstancing = shader_model_5_supported;
+    g_Config.backend_info.bSupportsSSAA = shader_model_5_supported;
+    g_Config.backend_info.bSupportsGPUTextureDecoding = shader_model_5_supported;
+  }
 }
 
 bool VideoBackend::Initialize(const WindowSystemInfo& wsi)

--- a/Source/Core/VideoCommon/FramebufferShaderGen.cpp
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.cpp
@@ -410,10 +410,13 @@ std::string GenerateFormatConversionShader(EFBReinterpretType convtype, u32 samp
 {
   std::stringstream ss;
   EmitSamplerDeclarations(ss, 0, 1, samples > 1);
-  EmitPixelMainDeclaration(ss, 1, 0, "float4",
-                           GetAPIType() == APIType::D3D ?
-                               "in float4 ipos : SV_Position, in uint isample : SV_SampleIndex, " :
-                               "");
+  EmitPixelMainDeclaration(
+      ss, 1, 0, "float4",
+      GetAPIType() == APIType::D3D ?
+          (g_ActiveConfig.bSSAA ?
+               "in float4 ipos : SV_Position, in uint isample : SV_SampleIndex, " :
+               "in float4 ipos : SV_Position, ") :
+          "");
   ss << "{\n";
   ss << "  int layer = int(v_tex0.z);\n";
   if (GetAPIType() == APIType::D3D)


### PR DESCRIPTION
I doubt many people have hardware old enough to care.. but anyway, this should fix the crashes you would be getting if you did try.

Note that I haven't tested this on a real 10.0 device, as I don't have any on hand (I just restricted it to 10.0 and turned the debug layer on).

Regression from #7869 and/or #7753.