### PR TITLE
Vulkan: Don't set a negative offset in scissor rect

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -561,6 +561,19 @@ void Renderer::SetScissorRect(const MathUtil::Rectangle<int>& rc)
 {
   VkRect2D scissor = {{rc.left, rc.top},
                       {static_cast<u32>(rc.GetWidth()), static_cast<u32>(rc.GetHeight())}};
+
+  // See Vulkan spec for vkCmdSetScissor:
+  // The x and y members of offset must be greater than or equal to 0.
+  if (scissor.offset.x < 0)
+  {
+    scissor.extent.width -= -scissor.offset.x;
+    scissor.offset.x = 0;
+  }
+  if (scissor.offset.y < 0)
+  {
+    scissor.extent.height -= -scissor.offset.y;
+    scissor.offset.y = 0;
+  }
   StateTracker::GetInstance()->SetScissor(scissor);
 }
 

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -223,10 +223,7 @@ AbstractTexture* FramebufferManager::ResolveEFBColorTexture(const MathUtil::Rect
 {
   // Return the normal EFB texture if multisampling is off.
   if (!IsEFBMultisampled())
-  {
-    m_efb_color_texture->FinishedRendering();
     return m_efb_color_texture.get();
-  }
 
   // It's not valid to resolve an out-of-range rectangle.
   MathUtil::Rectangle<int> clamped_region = region;
@@ -246,10 +243,7 @@ AbstractTexture* FramebufferManager::ResolveEFBColorTexture(const MathUtil::Rect
 AbstractTexture* FramebufferManager::ResolveEFBDepthTexture(const MathUtil::Rectangle<int>& region)
 {
   if (!IsEFBMultisampled())
-  {
-    m_efb_depth_texture->FinishedRendering();
     return m_efb_depth_texture.get();
-  }
 
   // It's not valid to resolve an out-of-range rectangle.
   MathUtil::Rectangle<int> clamped_region = region;
@@ -566,6 +560,7 @@ void FramebufferManager::PopulateEFBCache(bool depth, u32 tile_index)
     // Downsample from internal resolution to 1x.
     // TODO: This won't produce correct results at IRs above 2x. More samples are required.
     // This is the same issue as with EFB copies.
+    src_texture->FinishedRendering();
     g_renderer->BeginUtilityDrawing();
 
     const float rcp_src_width = 1.0f / m_efb_framebuffer->GetWidth();

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2186,6 +2186,7 @@ void TextureCacheBase::CopyEFBToCacheEntry(TCacheEntry* entry, bool is_depth_cop
       is_depth_copy ? g_framebuffer_manager->ResolveEFBDepthTexture(framebuffer_rect) :
                       g_framebuffer_manager->ResolveEFBColorTexture(framebuffer_rect);
 
+  src_texture->FinishedRendering();
   g_renderer->BeginUtilityDrawing();
 
   // Fill uniform buffer.
@@ -2253,6 +2254,7 @@ void TextureCacheBase::CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams&
       params.depth ? g_framebuffer_manager->ResolveEFBDepthTexture(framebuffer_rect) :
                      g_framebuffer_manager->ResolveEFBColorTexture(framebuffer_rect);
 
+  src_texture->FinishedRendering();
   g_renderer->BeginUtilityDrawing();
 
   // Fill uniform buffer.


### PR DESCRIPTION
Spec says it's not allowed.

Also fixes a validation layer error regarding transitions when the EFB cache was used, and the IR was native.