### PR TITLE
Renderer: Adjust source rectangle when crop would draw off screen 

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -338,12 +338,14 @@ void Renderer::RenderXFBToScreen(const AbstractTexture* texture, const MathUtil:
   // Render to staging texture which is double the width of the backbuffer
   SetAndClearFramebuffer(m_3d_vision_framebuffer.get());
 
-  const auto target_rc = GetTargetRectangle();
-  m_post_processor->BlitFromTexture(target_rc, rc, texture, 0);
+  auto adjusted_rc = rc;
+  auto target_rc = GetTargetRectangle();
+  AdjustRectanglesToFitBounds(&target_rc, &adjusted_rc, m_backbuffer_width, m_backbuffer_height);
+  m_post_processor->BlitFromTexture(target_rc, adjusted_rc, texture, 0);
   m_post_processor->BlitFromTexture(
       MathUtil::Rectangle<int>(target_rc.left + m_backbuffer_width, target_rc.top,
                                target_rc.right + m_backbuffer_width, target_rc.bottom),
-      rc, texture, 1);
+      adjusted_rc, texture, 1);
 
   // Copy the left eye to the backbuffer, if Nvidia 3D Vision is enabled it should
   // recognize the signature and automatically include the right eye frame.

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -67,8 +67,9 @@ public:
   void Flush() override;
   void WaitForGPUIdle() override;
 
-  void RenderXFBToScreen(const AbstractTexture* texture,
-                         const MathUtil::Rectangle<int>& rc) override;
+  void RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
+                         const AbstractTexture* source_texture,
+                         const MathUtil::Rectangle<int>& source_rc) override;
   void OnConfigChanged(u32 bits) override;
 
 private:

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -984,13 +984,15 @@ void Renderer::RenderXFBToScreen(const AbstractTexture* texture, const MathUtil:
   if (g_ActiveConfig.stereo_mode != StereoMode::QuadBuffer)
     return ::Renderer::RenderXFBToScreen(texture, rc);
 
-  const auto target_rc = GetTargetRectangle();
+  auto adjusted_rc = rc;
+  auto target_rc = GetTargetRectangle();
+  AdjustRectanglesToFitBounds(&target_rc, &adjusted_rc, m_backbuffer_width, m_backbuffer_height);
 
   glDrawBuffer(GL_BACK_LEFT);
-  m_post_processor->BlitFromTexture(target_rc, rc, texture, 0);
+  m_post_processor->BlitFromTexture(target_rc, adjusted_rc, texture, 0);
 
   glDrawBuffer(GL_BACK_RIGHT);
-  m_post_processor->BlitFromTexture(target_rc, rc, texture, 1);
+  m_post_processor->BlitFromTexture(target_rc, adjusted_rc, texture, 1);
 
   glDrawBuffer(GL_BACK);
 }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -978,21 +978,19 @@ void Renderer::ClearScreen(const MathUtil::Rectangle<int>& rc, bool colorEnable,
   BPFunctions::SetScissor();
 }
 
-void Renderer::RenderXFBToScreen(const AbstractTexture* texture, const MathUtil::Rectangle<int>& rc)
+void Renderer::RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
+                                 const AbstractTexture* source_texture,
+                                 const MathUtil::Rectangle<int>& source_rc)
 {
   // Quad-buffered stereo is annoying on GL.
   if (g_ActiveConfig.stereo_mode != StereoMode::QuadBuffer)
-    return ::Renderer::RenderXFBToScreen(texture, rc);
-
-  auto adjusted_rc = rc;
-  auto target_rc = GetTargetRectangle();
-  AdjustRectanglesToFitBounds(&target_rc, &adjusted_rc, m_backbuffer_width, m_backbuffer_height);
+    return ::Renderer::RenderXFBToScreen(target_rc, source_texture, source_rc);
 
   glDrawBuffer(GL_BACK_LEFT);
-  m_post_processor->BlitFromTexture(target_rc, adjusted_rc, texture, 0);
+  m_post_processor->BlitFromTexture(target_rc, source_rc, source_texture, 0);
 
   glDrawBuffer(GL_BACK_RIGHT);
-  m_post_processor->BlitFromTexture(target_rc, adjusted_rc, texture, 1);
+  m_post_processor->BlitFromTexture(target_rc, source_rc, source_texture, 1);
 
   glDrawBuffer(GL_BACK);
 }

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -134,8 +134,9 @@ public:
 
   void Flush() override;
   void WaitForGPUIdle() override;
-  void RenderXFBToScreen(const AbstractTexture* texture,
-                         const MathUtil::Rectangle<int>& rc) override;
+  void RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
+                         const AbstractTexture* source_texture,
+                         const MathUtil::Rectangle<int>& source_rc) override;
   void OnConfigChanged(u32 bits) override;
 
   void ClearScreen(const MathUtil::Rectangle<int>& rc, bool colorEnable, bool alphaEnable,

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -94,11 +94,12 @@ std::unique_ptr<AbstractPipeline> SWRenderer::CreatePipeline(const AbstractPipel
 }
 
 // Called on the GPU thread
-void SWRenderer::RenderXFBToScreen(const AbstractTexture* texture,
-                                   const MathUtil::Rectangle<int>& xfb_region)
+void SWRenderer::RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
+                                   const AbstractTexture* source_texture,
+                                   const MathUtil::Rectangle<int>& source_rc)
 {
   if (!IsHeadless())
-    m_window->ShowImage(texture, xfb_region);
+    m_window->ShowImage(source_texture, source_rc);
 }
 
 u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -42,8 +42,9 @@ public:
   u16 BBoxRead(int index) override;
   void BBoxWrite(int index, u16 value) override;
 
-  void RenderXFBToScreen(const AbstractTexture* texture,
-                         const MathUtil::Rectangle<int>& rc) override;
+  void RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
+                         const AbstractTexture* source_texture,
+                         const MathUtil::Rectangle<int>& source_rc) override;
 
   void ClearScreen(const MathUtil::Rectangle<int>& rc, bool colorEnable, bool alphaEnable,
                    bool zEnable, u32 color, u32 z) override;

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -171,6 +171,13 @@ public:
   const MathUtil::Rectangle<int>& GetTargetRectangle() const { return m_target_rectangle; }
   float CalculateDrawAspectRatio() const;
 
+  // Crops the target rectangle to the framebuffer dimensions, reducing the size of the source
+  // rectangle if it is greater. Works even if the source and target rectangles don't have a
+  // 1:1 pixel mapping, scaling as appropriate.
+  void AdjustRectanglesToFitBounds(MathUtil::Rectangle<int>* target_rect,
+                                   MathUtil::Rectangle<int>* source_rect, int fb_width,
+                                   int fb_height);
+
   std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height) const;
   void UpdateDrawRectangle();
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -223,8 +223,9 @@ public:
 
   // Draws the specified XFB buffer to the screen, performing any post-processing.
   // Assumes that the backbuffer has already been bound and cleared.
-  virtual void RenderXFBToScreen(const AbstractTexture* texture,
-                                 const MathUtil::Rectangle<int>& rc);
+  virtual void RenderXFBToScreen(const MathUtil::Rectangle<int>& target_rc,
+                                 const AbstractTexture* source_texture,
+                                 const MathUtil::Rectangle<int>& source_rc);
 
   // Called when the configuration changes, and backend structures need to be updated.
   virtual void OnConfigChanged(u32 bits) {}


### PR DESCRIPTION
This prevents us from requiring an oversized and/or negative viewport by shrinking the source rectangle instead.

Should be tested by someone more familiar with the setting and its effects, as AFAICT it was producing the same results, but probably didn't check all scenarios.