### PR TITLE
Qt/AboutDialog: Remove "Check for updates" text

### DIFF
--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -30,9 +30,6 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent)
   text.append(small + tr("Revision: ") + QString::fromUtf8(Common::scm_rev_git_str.c_str()) +
               QStringLiteral("</p>"));
 
-  text.append(medium + tr("Check for updates: ") +
-              QStringLiteral(
-                  "<a href='https://dolphin-emu.org/download'>dolphin-emu.org/download</a></p>"));
   // i18n: The word "free" in the standard phrase "free and open source"
   // is "free" as in "freedom" - it refers to certain properties of the
   // software's license, not the software's price. (It is true that Dolphin


### PR DESCRIPTION
Now that the updater has been added to all intended platforms, this text is unnecessary.

If users still want to visit the Dolphin website, there is still a link to it in the Help menu.