### PR TITLE
DolphinQt: Profile combobox fixes.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -73,6 +73,8 @@ private:
   void OnDeleteProfilePressed();
   void OnLoadProfilePressed();
   void OnSaveProfilePressed();
+  void UpdateProfileIndex();
+
   void OnDefaultFieldsPressed();
   void OnClearFieldsPressed();
   void OnSelectDevice(int index);


### PR DESCRIPTION
Removed empty item from list. Fixes https://bugs.dolphin-emu.org/issues/11703

Set a minimum width on the widget.

Delete/load the proper profile when a name is manually typed.