### PR TITLE
WiimoteEmu: Report game quirk on direct read of EXT/IR input.

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -139,7 +139,8 @@ void DolphinAnalytics::ReportGameStart()
 
 // Keep in sync with enum class GameQuirk definition.
 static const char* GAME_QUIRKS_NAMES[] = {
-    "icache-matters",  // ICACHE_MATTERS
+    "icache-matters",
+    "directly-reads-wiimote-input",
 };
 static_assert(sizeof(GAME_QUIRKS_NAMES) / sizeof(GAME_QUIRKS_NAMES[0]) ==
                   static_cast<u32>(GameQuirk::COUNT),

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -24,6 +24,10 @@ enum class GameQuirk
   // Sometimes code run from ICache is different from its mirror in RAM.
   ICACHE_MATTERS = 0,
 
+  // The Wii remote hardware makes it possible to bypass normal data reporting and directly
+  // "read" extension or IR data. This would break our current TAS/NetPlay implementation.
+  DIRECTLY_READS_WIIMOTE_INPUT,
+
   COUNT,
 };
 

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.h
@@ -75,6 +75,7 @@ public:
   void SetEnabled(bool is_enabled);
 
   static constexpr u8 I2C_ADDR = 0x58;
+  static constexpr int CAMERA_DATA_BYTES = 36;
 
 private:
   // TODO: some of this memory is write-only and should return error 7.
@@ -89,7 +90,7 @@ private:
     u8 mode;
     u8 unk[3];
     // addr: 0x37
-    u8 camera_data[36];
+    u8 camera_data[CAMERA_DATA_BYTES];
     u8 unk2[165];
   };
 #pragma pack(pop)

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -62,6 +62,7 @@ class EncryptedExtension : public Extension
 {
 public:
   static constexpr u8 I2C_ADDR = 0x52;
+  static constexpr int CONTROLLER_DATA_BYTES = 21;
 
   using Extension::Extension;
 
@@ -76,7 +77,7 @@ protected:
   struct Register
   {
     // 21 bytes of possible extension data
-    u8 controller_data[21];
+    u8 controller_data[CONTROLLER_DATA_BYTES];
 
     u8 unknown2[11];
 


### PR DESCRIPTION
If games ever do this, TAS/NetPlay will desync as we only sync wiimote "data reports".

I don't think games ever do this but we should test for it in case we need to fix TAS/NetPlay.

Edit: Changed from an `INFO_LOG` to a `ReportGameQuirk`.