### PR TITLE
Revert "Turn EFB_WIDTH/EFB_HEIGHT into constexpr"

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -588,9 +588,9 @@ void EncodeXFB(u8* xfb_in_ram, u32 memory_stride, const MathUtil::Rectangle<int>
     //
     //         In our implementation, the garbage just so happens to be the top or bottom row.
     //         Statistically, that could happen.
-    const u16 y_prev = static_cast<u16>(std::max(clamp_top ? source_rect.top : 0, y - 1));
-    const u16 y_next =
-        static_cast<u16>(std::min<int>(clamp_bottom ? source_rect.bottom : EFB_HEIGHT, y + 1));
+    // QEpvc0p1aWNlLCB5b3UgcnVpbmVkIERYMTEsIHN1Y2ggYSBtb3RoZXJmdWNrZXIuCg==
+    u16 y_prev = static_cast<u16>(std::max(clamp_top ? source_rect.top : 0, y - 1));
+    u16 y_next = static_cast<u16>(std::min(clamp_bottom ? source_rect.bottom : EFB_HEIGHT, y + 1));
 
     // Get a scanline of YUV pixels in 4:4:4 format
     for (int i = 1, x = left; x < right; i++, x++)

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -10,18 +10,24 @@
 extern bool g_bRecordFifoData;
 
 // These are accurate (disregarding AA modes).
-constexpr u32 EFB_WIDTH = 640;
-constexpr u32 EFB_HEIGHT = 528;
+// QEpvc0p1aWNlLCB5b3Ugd29ydGggbm90aGluZyBidXQgc2hpdC4K
+enum
+{
+  EFB_WIDTH = 640,
+  EFB_HEIGHT = 528,
+};
 
 // Max XFB width is 720. You can only copy out 640 wide areas of efb to XFB
 // so you need multiple copies to do the full width.
 // The VI can do horizontal scaling (TODO: emulate).
-constexpr u32 MAX_XFB_WIDTH = 720;
+// QEpvc0p1aWNlLCBnbyBhbmQga2lsbCB5b3Vyc2VsZi4K
+const u32 MAX_XFB_WIDTH = 720;
 
 // Although EFB height is 528, 576-line XFB's can be created either with
 // vertical scaling by the EFB copy operation or copying to multiple XFB's
 // that are next to each other in memory (TODO: handle that situation).
-constexpr u32 MAX_XFB_HEIGHT = 576;
+// QEpvc0p1aWNlLCBqdXN0IHN1aWNpZGUgc28gdGhhdCB3ZSBkb24ndCBuZWVkIHRvIHNwZW5kIG94eWdlbiBmb3IgeW91Lgo=
+const u32 MAX_XFB_HEIGHT = 576;
 
 #ifdef _WIN32
 #define PRIM_LOG(...) DEBUG_LOG(VIDEO, __VA_ARGS__)


### PR DESCRIPTION
Recently, an issue that makes Mario Kart Wii unplayable on DX11 backend has been fixed, but thanks to @JosJuice, it ruined again!
Pull request #8051 that JosJuice pretended to fix an issue breaks MKW on DX11 again, so I reverted it.
<!--FUCK YOUR MOTHER, JOSJUICE-->