### PR TITLE
Port Casper's Scare School: Spooky Sports Day dcache hack to PAL

### DIFF
--- a/Data/Sys/GameSettings/RX4E4Z.ini
+++ b/Data/Sys/GameSettings/RX4E4Z.ini
@@ -1,4 +1,4 @@
-# Casper's Scare School: Spooky Sports Day (RX4E4Z)
+# RX4E4Z - Casper's Scare School: Spooky Sports Day
 
 [OnFrame]
 # Work around a dcache issue by preventing the game from doing something pointless.
@@ -17,7 +17,7 @@
 # .text:800D2E6C mr        r5, read_length # length
 # .text:800D2E70 mr        r6, read_offset # offset
 # .text:800D2E74 addi      r3, this, file.file_info # file_info
-# .text:800D2E78 addi      r4, r4, dvd_read_buf@l # addr
+# .text:800D2E78 subi      r4, r4, dvd_read_buf@l # addr
 # .text:800D2E7C addi      r7, r7, game_dvd_read_callback@l # callback
 # .text:800D2E80 li        r8, 2         # unknown
 # .text:800D2E84 bl        DVDReadAsync

--- a/Data/Sys/GameSettings/RX4PMT.ini
+++ b/Data/Sys/GameSettings/RX4PMT.ini
@@ -1,0 +1,26 @@
+# RX4PMT - Casper's Scare School: Spooky Sports Day
+
+[OnFrame]
+# Work around a dcache issue by preventing the game from doing something pointless.
+#
+# The game's DVD read function writes 0x87654321 to the entire read buffer and 0x12345678 to the
+# last 4 bytes. It then calls DVDReadAsync() and without waiting for the read to complete at all,
+# it checks if the last 4 bytes are still 0x12345678. If they are, then the game fails.
+#
+# The check always passes on console because DVDReadAsync() -> issueCommand() calls
+# DCInvalidateRange() (dcbi) on the read buffer.
+#
+# Dolphin cannot emulate this without an extremely significant performance hit.
+#
+# .text:80164B8C lis       r7, game_dvd_read_callback@ha
+# .text:80164B90 stw       r0, 0(r17) # write 0x12345678 to the end of the buffer
+# .text:80164B94 mr        r5, read_length # length
+# .text:80164B98 mr        r6, read_offset # offset
+# .text:80164B9C addi      r3, this, file.file_info # file_info
+# .text:80164BA0 subi      r4, r4, dvd_read_buf@l # addr
+# .text:80164BA4 addi      r7, r7, game_dvd_read_callback@l # callback
+# .text:80164BA8 li        r8, 2         # unknown
+# .text:80164BAC bl        DVDReadAsync
+#
+$Fix file reads (dcache bypass)
+0x80164b90:dword:0x60000000


### PR DESCRIPTION
It's the same hack as we already have for the NTSC version, except the instruction we overwrite is at a different location.

For the disassembly in the comment, the disassembly in RX4E4Z.ini seems to match the PAL code perfectly other than the different memory addresses and one addi being replaced with subi, so I just took the RX4E4Z.ini disassembly and modified those two things. (Is there any reason why an addi would have been changed to a subi, or is this a mistake in the RX4E4Z.ini disassembly?) This means that I didn't check that the symbol names make sense (e.g. dvd_read_buf), but I did check that the rest is correct. Even the register allocation is the same as on NTSC.