### PR TITLE
Disable Vulkan overrides for RADV driver

### DIFF
--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -86,7 +86,7 @@ static BugInfo m_known_bugs[] = {
      -1.0, true},
     {API_OPENGL, OS_ALL, VENDOR_MESA, DRIVER_I965, Family::UNKNOWN, BUG_BROKEN_CLIP_DISTANCE, -1.0,
      -1.0, true},
-    {API_VULKAN, OS_ALL, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN,
+    {API_VULKAN, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN,
      BUG_BROKEN_FRAGMENT_SHADER_INDEX_DECORATION, -1.0, -1.0, true},
     {API_OPENGL, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN,
      BUG_BROKEN_DUAL_SOURCE_BLENDING, -1.0, -1.0, true},
@@ -94,8 +94,8 @@ static BugInfo m_known_bugs[] = {
      BUG_BROKEN_DUAL_SOURCE_BLENDING, -1.0, -1.0, true},
     {API_OPENGL, OS_ALL, VENDOR_IMGTEC, DRIVER_IMGTEC, Family::UNKNOWN,
      BUG_BROKEN_BITWISE_OP_NEGATION, -1.0, 108.4693462, true},
-    {API_VULKAN, OS_ALL, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_PRIMITIVE_RESTART, -1.0, -1.0,
-     true},
+    {API_VULKAN, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_PRIMITIVE_RESTART, -1.0,
+     -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_ARM, DRIVER_ARM, Family::UNKNOWN, BUG_PRIMITIVE_RESTART, -1.0, -1.0,
      true},
     {API_OPENGL, OS_LINUX, VENDOR_MESA, DRIVER_I965, Family::UNKNOWN,
@@ -166,4 +166,4 @@ bool HasBug(Bug bug)
     return false;
   return it->second.m_hasbug;
 }
-}
+}  // namespace DriverDetails


### PR DESCRIPTION
Tbh I literally just deleted every single override for mesa/AMD including OpenGL and noticed no difference in games and everything seemed to work fine with my RX580 and mesa 19.0.3

Obviously a lot of these driver overrides are crusty af.

I think dolphin OpenGL with AMD/mesa is FUBAR anyway. I get 40fps in Metroid Prime 3 with OpenGL with almost no CPU/GPU usage at all, while in the same area with Vulkan I get constant 60.

I'd at least like to keep the Vulkan overrides for RADV clean though.