### PR TITLE
Call Host_NotifyMapLoaded when clearing g_symbolDB

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -42,6 +42,11 @@ void SymbolDB::List()
   INFO_LOG(OSHLE, "%zu functions known in this program above.", m_functions.size());
 }
 
+bool SymbolDB::IsEmpty() const
+{
+  return m_functions.empty();
+}
+
 void SymbolDB::Clear(const char* prefix)
 {
   // TODO: honor prefix

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -78,6 +78,7 @@ public:
 
   const XFuncMap& Symbols() const { return m_functions; }
   XFuncMap& AccessSymbols() { return m_functions; }
+  bool IsEmpty() const;
   void Clear(const char* prefix = "");
   void List();
   void Index();

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -383,7 +383,11 @@ bool CBoot::BootUp(std::unique_ptr<BootParameters> boot)
 {
   SConfig& config = SConfig::GetInstance();
 
-  g_symbolDB.Clear();
+  if (!g_symbolDB.IsEmpty())
+  {
+    g_symbolDB.Clear();
+    UpdateDebugger_MapLoaded();
+  }
 
   // PAL Wii uses NTSC framerate and linecount in 60Hz modes
   VideoInterface::Preset(DiscIO::IsNTSC(config.m_region) ||

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -35,6 +35,7 @@
 #include "Core/HLE/HLE.h"
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/SI/SI.h"
+#include "Core/Host.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/PatchEngine.h"
@@ -724,7 +725,11 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   if (Core::IsRunning())
   {
     // TODO: have a callback mechanism for title changes?
-    g_symbolDB.Clear();
+    if (!g_symbolDB.IsEmpty())
+    {
+      g_symbolDB.Clear();
+      Host_NotifyMapLoaded();
+    }
     CBoot::LoadMapFromFilename();
     HLE::Reload();
     PatchEngine::Reload();

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -20,6 +20,7 @@
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/Host.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
 
@@ -52,11 +53,16 @@ bool Load()
   NOTICE_LOG(IOS, "Reinitialised hardware.");
 
   // Load symbols for the IPL if they exist.
-  g_symbolDB.Clear();
+  if (!g_symbolDB.IsEmpty())
+  {
+    g_symbolDB.Clear();
+    Host_NotifyMapLoaded();
+  }
   if (g_symbolDB.LoadMap(File::GetUserPath(D_MAPS_IDX) + "mios-ipl.map"))
   {
     ::HLE::Clear();
     ::HLE::PatchFunctions();
+    Host_NotifyMapLoaded();
   }
 
   const PowerPC::CoreMode core_mode = PowerPC::GetMode();


### PR DESCRIPTION
Otherwise DolphinQt will have a stale symbol list and you can get nullptr dereferences when trying to use it.