### PR TITLE
WiimoteEmu/DolphinQt: Better extension display names.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -72,7 +72,7 @@ constexpr std::array<u16, 4> classic_dpad_bitmasks{{
     Classic::PAD_RIGHT,
 }};
 
-Classic::Classic() : Extension1stParty(_trans("Classic"))
+Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
 {
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -52,7 +52,7 @@ constexpr std::array<u8, 2> drum_button_bitmasks{{
     Drums::BUTTON_PLUS,
 }};
 
-Drums::Drums() : Extension1stParty(_trans("Drums"))
+Drums::Drums() : Extension1stParty("Drums", _trans("Drum Kit"))
 {
   // Pads.
   groups.emplace_back(m_pads = new ControllerEmu::Buttons(_trans("Pads")));

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
@@ -16,13 +16,23 @@
 
 namespace WiimoteEmu
 {
-Extension::Extension(const char* name) : m_name(name)
+Extension::Extension(const char* name) : Extension(name, name)
+{
+}
+
+Extension::Extension(const char* config_name, const char* display_name)
+    : m_config_name(config_name), m_display_name(display_name)
 {
 }
 
 std::string Extension::GetName() const
 {
-  return m_name;
+  return m_config_name;
+}
+
+std::string Extension::GetDisplayName() const
+{
+  return m_display_name;
 }
 
 None::None() : Extension("None")
@@ -62,10 +72,6 @@ int None::BusRead(u8 slave_addr, u8 addr, int count, u8* data_out)
 int None::BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in)
 {
   return 0;
-}
-
-EncryptedExtension::EncryptedExtension(const char* name) : Extension(name)
-{
 }
 
 bool EncryptedExtension::ReadDeviceDetectPin() const

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -21,8 +21,10 @@ class Extension : public ControllerEmu::EmulatedController, public I2CSlave
 {
 public:
   explicit Extension(const char* name);
+  Extension(const char* config_name, const char* display_name);
 
   std::string GetName() const override;
+  std::string GetDisplayName() const override;
 
   // Used by the wiimote to detect extension changes.
   // The normal extensions short this pin so it's always connected,
@@ -35,7 +37,8 @@ public:
   virtual void Update() = 0;
 
 private:
-  const char* const m_name;
+  const char* const m_config_name;
+  const char* const m_display_name;
 };
 
 class None : public Extension
@@ -60,7 +63,7 @@ class EncryptedExtension : public Extension
 public:
   static constexpr u8 I2C_ADDR = 0x52;
 
-  EncryptedExtension(const char* name);
+  using Extension::Extension;
 
   // TODO: This is public for TAS reasons.
   // TODO: TAS handles encryption poorly.

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -45,7 +45,7 @@ constexpr std::array<const char*, 6> turntable_button_names{{
     _trans("Blue Right"),
 }};
 
-Turntable::Turntable() : Extension1stParty(_trans("Turntable"))
+Turntable::Turntable() : Extension1stParty("Turntable", _trans("DJ Turntable"))
 {
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
@@ -31,7 +31,7 @@ constexpr std::array<const char*, 2> udraw_tablet_button_names{{
     _trans("Rocker Down"),
 }};
 
-UDrawTablet::UDrawTablet() : Extension3rdParty(_trans("uDraw"))
+UDrawTablet::UDrawTablet() : Extension3rdParty("uDraw", _trans("uDraw GameTablet"))
 {
   // Buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -65,7 +65,7 @@ void WiimoteEmuExtension::CreateClassicLayout()
 void WiimoteEmuExtension::CreateDrumsLayout()
 {
   auto* layout = new QGridLayout();
-  m_drums_box = new QGroupBox(tr("Drums"), this);
+  m_drums_box = new QGroupBox(tr("Drum Kit"), this);
 
   layout->addWidget(
       CreateGroupBox(tr("Stick"), Wiimote::GetDrumsGroup(GetPort(), WiimoteEmu::DrumsGroup::Stick)),
@@ -150,7 +150,7 @@ void WiimoteEmuExtension::CreateGuitarLayout()
 void WiimoteEmuExtension::CreateTurntableLayout()
 {
   auto* layout = new QGridLayout();
-  m_turntable_box = new QGroupBox(tr("Turntable"), this);
+  m_turntable_box = new QGroupBox(tr("DJ Turntable"), this);
 
   layout->addWidget(CreateGroupBox(tr("Stick"), Wiimote::GetTurntableGroup(
                                                     GetPort(), WiimoteEmu::TurntableGroup::Stick)),

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -48,7 +48,7 @@ void WiimoteEmuGeneral::CreateMainLayout()
   m_extension_combo = new QComboBox();
 
   for (const auto& attachment : ce_extension->GetAttachmentList())
-    m_extension_combo->addItem(tr(attachment->GetName().c_str()));
+    m_extension_combo->addItem(tr(attachment->GetDisplayName().c_str()));
 
   extension->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -20,6 +20,11 @@ namespace ControllerEmu
 {
 static std::recursive_mutex s_get_state_mutex;
 
+std::string EmulatedController::GetDisplayName() const
+{
+  return GetName();
+}
+
 EmulatedController::~EmulatedController() = default;
 
 // This should be called before calling GetState() or State() on a control reference

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -28,7 +28,9 @@ class EmulatedController
 {
 public:
   virtual ~EmulatedController();
+
   virtual std::string GetName() const = 0;
+  virtual std::string GetDisplayName() const;
 
   virtual void LoadDefaults(const ControllerInterface& ciface);
 


### PR DESCRIPTION
![screenshot](https://i.imgur.com/AW13StZ.png)

I've given more descriptive names to the Wii remote extensions.

The names in our ini files remain unchanged.