### PR TITLE
DolphinQt: Don't refresh devices on open of mapping UI.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -369,8 +369,6 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     SplitPath(filename, nullptr, &basename, nullptr);
     m_profiles_combo->addItem(QString::fromStdString(basename), QString::fromStdString(filename));
   }
-
-  RefreshDevices();
 }
 
 void MappingWindow::AddWidget(const QString& name, QWidget* widget)


### PR DESCRIPTION
There's no need for this.

Devices are populated on initialization of controller interface.

Hotplug is supported by all the normal input backends.