### PR TITLE
VideoCommon: Implement passive stereoscopic 3D

### DIFF
--- a/Data/Sys/Shaders/Passive/horizontal.glsl
+++ b/Data/Sys/Shaders/Passive/horizontal.glsl
@@ -1,0 +1,7 @@
+// Passive (horizontal rows) shader
+
+void main()
+{
+	float screen_row = GetWindowResolution().y * GetCoordinates().y;
+	SetOutput(SampleLayer(int(screen_row) % 2));
+}

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -62,6 +62,7 @@
 #define THEMES_DIR "Themes"
 #define STYLES_DIR "Styles"
 #define ANAGLYPH_DIR "Anaglyph"
+#define PASSIVE_DIR "Passive"
 #define PIPES_DIR "Pipes"
 #define WFSROOT_DIR "WFS"
 #define BACKUP_DIR "Backup"

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -94,6 +94,7 @@ public:
   virtual ~PostProcessing();
 
   static std::vector<std::string> GetShaderList();
+  static std::vector<std::string> GetPassiveShaderList();
   static std::vector<std::string> GetAnaglyphShaderList();
 
   PostProcessingConfiguration* GetConfig() { return &m_config; }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -39,7 +39,8 @@ enum class StereoMode : int
   TAB,
   Anaglyph,
   QuadBuffer,
-  Nvidia3DVision
+  Passive,
+  Nvidia3DVision,
 };
 
 enum class ShaderCompilationMode : int


### PR DESCRIPTION
Passive 3d support was suggested years ago when stereoscopic 3d was initially created but never implemented.  Users have since then created workarounds using external apps and shaders.  After pulling my passive 3d monitor out of the closet, I decided to finally implement it!