### PR TITLE
Fix loading screens on Metroid Prime Trilogy

### DIFF
--- a/Data/Sys/GameSettings/R3M.ini
+++ b/Data/Sys/GameSettings/R3M.ini
@@ -15,3 +15,5 @@
 [Video_Hacks]
 EFBToTextureEnable = False
 ImmediateXFBEnable = False
+XFBToTextureEnable = False
+DeferEFBCopies = False


### PR DESCRIPTION
XFB to texture causes magenta loading screens. Defer efb causes the game to flicker between metroid prime loading and the place you are loading in to and other loading screen errors.
Unsure about standalone Prime games