### PR TITLE
UICommon: Properly set user dir if ./user is a file (not a directory)

### DIFF
--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -253,7 +253,7 @@ void SetUserDirectory(const std::string& custom_path)
     user_path += DIR_SEP;
 
 #else
-  if (File::Exists(ROOT_DIR DIR_SEP USERDATA_DIR))
+  if (File::IsDirectory(ROOT_DIR DIR_SEP USERDATA_DIR))
   {
     user_path = ROOT_DIR DIR_SEP USERDATA_DIR DIR_SEP;
   }


### PR DESCRIPTION
Dolphin currently assumes that if `./user` exists then it should use it as the User Directory, and doesn't make sure it's a directory and not a file. Since Dolphin checks for `./user` before all other possible locations, if the user has a `./user` file then Dolphin fails to both load and save any user data.

This PR fixes it to check that `./user` is a directory, and not simply for its existence.