### PR TITLE
Qt/NetPlayDialog: Fix checksum menu being visible for everyone

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -542,10 +542,10 @@ void NetPlayDialog::show(std::string nickname, bool use_traversal)
 
   m_data_menu->menuAction()->setVisible(is_hosting);
   m_network_menu->menuAction()->setVisible(is_hosting);
+  m_md5_menu->menuAction()->setVisible(is_hosting);
   m_start_button->setHidden(!is_hosting);
   m_kick_button->setHidden(!is_hosting);
   m_assign_ports_button->setHidden(!is_hosting);
-  m_md5_menu->setHidden(!is_hosting);
   m_room_box->setHidden(!is_hosting);
   m_hostcode_label->setHidden(!is_hosting);
   m_hostcode_action_button->setHidden(!is_hosting);


### PR DESCRIPTION
The wrong function was used to attempt to hide the menu. Non-hosts will segfault upon trying to use it as they don't have a server instance.