### PR TITLE
Qt/Debugger: Fix register cell text vertical alignment

### DIFF
--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -365,12 +365,12 @@ void RegisterWidget::AddRegister(int row, int column, RegisterType type, std::st
 
     m_table->setItem(row, column, label);
     m_table->setItem(row, column + 1, value);
-    m_table->item(row, column + 1)->setTextAlignment(Qt::AlignRight);
+    m_table->item(row, column + 1)->setTextAlignment(Qt::AlignVCenter | Qt::AlignRight);
   }
   else
   {
     m_table->setItem(row, column, value);
-    m_table->item(row, column)->setTextAlignment(Qt::AlignRight);
+    m_table->item(row, column)->setTextAlignment(Qt::AlignVCenter | Qt::AlignRight);
   }
 
   connect(this, &RegisterWidget::UpdateTable, [value] { value->RefreshValue(); });


### PR DESCRIPTION
Looks better with the text vertically aligned.

Before:

![image](https://user-images.githubusercontent.com/4209061/57947688-da7a5080-78df-11e9-9f6b-46fc2eaee87f.png)

After:

![image](https://user-images.githubusercontent.com/4209061/57947695-e0703180-78df-11e9-8640-c97c2e4ad35f.png)
