### PR TITLE
Use [[fallthrough]] in DiscExtractor

### DIFF
--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -33,7 +33,7 @@ std::string NameForPartitionType(u32 partition_type, bool include_prefix)
     // wit doesn't recognize the name "INSTALL", so we can't use it when naming partition folders
     if (!include_prefix)
       return "INSTALL";
-    // [[fallthrough]]
+    [[fallthrough]];
   default:
     const std::string type_as_game_id{static_cast<char>((partition_type >> 24) & 0xFF),
                                       static_cast<char>((partition_type >> 16) & 0xFF),


### PR DESCRIPTION
This was missed in PR #6273 because the fallthrough was added to DiscExtractor after that PR was created.