### PR TITLE
Allow interacting with the render window while configuring controllers

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -426,7 +426,10 @@ void ControllersWindow::OnGCPadConfigure()
     return;
   }
 
-  MappingWindow(this, type, static_cast<int>(index)).exec();
+  MappingWindow* window = new MappingWindow(this, type, static_cast<int>(index));
+  window->setAttribute(Qt::WA_DeleteOnClose, true);
+  window->setWindowModality(Qt::WindowModality::WindowModal);
+  window->show();
 }
 
 void ControllersWindow::OnWiimoteConfigure()
@@ -451,7 +454,10 @@ void ControllersWindow::OnWiimoteConfigure()
     return;
   }
 
-  MappingWindow(this, type, static_cast<int>(index)).exec();
+  MappingWindow* window = new MappingWindow(this, type, static_cast<int>(index));
+  window->setAttribute(Qt::WA_DeleteOnClose, true);
+  window->setWindowModality(Qt::WindowModality::WindowModal);
+  window->show();
 }
 
 void ControllersWindow::LoadSettings()


### PR DESCRIPTION
This change enables interacting with the render window while configuring controllers.  This is useful for e.g. trying out different configurations without having to close and reopen the configuration window (note that the parent controller settings window is _not_ modal).  Note that as-is it does _not_ allow interacting when "render to main window" is enabled.

I've done this by making the controller configuration window `WindowModal`, which allows alt+tabing to the render window, but prohibits interaction with parent windows (controller settings window and the main dolphin window).  `exec` acts the same as if `ApplicationModal` were used and makes it impossible to switch to _any_ window, including the render window.  (It also blocks until the window is closed, which I assume is why a temporary variable could be used).

The main reason to even make it modal in the first place is that it prevents opening a second window by going to the configuration dialog and clicking the button again.  An alternative approach would be to do the same thing that is done for the hotkey window:

https://github.com/dolphin-emu/dolphin/blob/5ca993330729935ada1b7c2f027be77994e5fcdd/Source/Core/DolphinQt/MainWindow.cpp#L1092-L1103

This requires an array here, though, and I think it would get complicated.  Additionally, though it allows interacting with the parent windows (i.e. the game when "render to main window" is enabled), the actual dialog is still always on top.  But if that's preferable behavior, I can change to it.