### PR TITLE
Some minor fix

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -58,8 +58,6 @@ static unsigned char __LZO_MMODEL out[OUT_LEN];
 
 static HEAP_ALLOC(wrkmem, LZO1X_1_MEM_COMPRESS);
 
-static std::string g_last_filename;
-
 static AfterLoadCallbackFunc s_on_after_load_callback;
 
 // Temporary undo state buffer
@@ -412,8 +410,6 @@ void SaveAs(const std::string& filename, bool wait)
       Flush();
       g_save_thread = std::thread(CompressAndDumpState, save_args);
       g_compressAndDumpStateSyncEvent.Wait();
-
-      g_last_filename = filename;
     }
     else
     {

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -334,7 +334,7 @@ void CommandBufferManager::SubmitCommandBuffer(u32 command_buffer_index,
     submit_info.pCommandBuffers = &resources.command_buffers[1];
   }
 
-  if (resources.semaphore_used != VK_NULL_HANDLE)
+  if (resources.semaphore_used)
   {
     submit_info.pWaitSemaphores = &resources.semaphore;
     submit_info.waitSemaphoreCount = 1;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -350,7 +350,7 @@ void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host
 
   // If bounding box is enabled when a UID cache is created, then later disabled, we shouldn't
   // emit the bounding box portion of the shader.
-  uid_data->bounding_box &= host_config.bounding_box;
+  uid_data->bounding_box &= host_config.bounding_box & host_config.backend_bbox;
 }
 
 void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texgens,
@@ -463,15 +463,15 @@ SSBO_BINDING(0) buffer BBox {
 };
 #endif
 
-void UpdateBoundingBoxBuffer(float2 min_pos, float2 max_pos) {
-  if (bbox_left > int(min_pos.x))
-    atomicMin(bbox_left, int(min_pos.x));
-  if (bbox_right < int(max_pos.x))
-    atomicMax(bbox_right, int(max_pos.x));
-  if (bbox_top > int(min_pos.y))
-    atomicMin(bbox_top, int(min_pos.y));
-  if (bbox_bottom < int(max_pos.y))
-    atomicMax(bbox_bottom, int(max_pos.y));
+void UpdateBoundingBoxBuffer(int2 min_pos, int2 max_pos) {
+  if (bbox_left > min_pos.x)
+    atomicMin(bbox_left, min_pos.x);
+  if (bbox_right < max_pos.x)
+    atomicMax(bbox_right, max_pos.x);
+  if (bbox_top > min_pos.y)
+    atomicMin(bbox_top, min_pos.y);
+  if (bbox_bottom < max_pos.y)
+    atomicMax(bbox_bottom, max_pos.y);
 }
 
 void UpdateBoundingBox(float2 rawpos) {


### PR DESCRIPTION
remove unused `g_last_filename`;
`resources.semaphore_used` is a bool value;
enable bounding box if backend support;
use `int2` parameters;