### PR TITLE
CommandProcessor: Don't reset the video buffer when FIFO distance is changed

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -276,7 +276,6 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::ComplexWrite<u16>([WMASK_HI_RESTRICT](u32, u16 val) {
                    WriteHigh(fifo.CPReadWriteDistance, val & WMASK_HI_RESTRICT);
                    Fifo::SyncGPU(Fifo::SyncGPUReason::Other);
-                   Fifo::ResetVideoBuffer();
                    Fifo::RunGpu();
                  }));
   mmio->Register(


### PR DESCRIPTION
This prevents partially-processed commands from being lost when switching buffers.

Apparently this fixes some of the regressions introduced by #8039.