### PR TITLE
Core/AddressSpace & Qt/Debugger: Fix parameter order mixup

### DIFF
--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -82,13 +82,13 @@ struct EffectiveAddressSpaceAccessors : Accessors
 {
   bool IsValidAddress(u32 address) const override { return PowerPC::HostIsRAMAddress(address); }
   u8 ReadU8(u32 address) const override { return PowerPC::HostRead_U8(address); }
-  void WriteU8(u32 address, u8 value) override { PowerPC::HostWrite_U8(address, value); }
+  void WriteU8(u32 address, u8 value) override { PowerPC::HostWrite_U8(value, address); }
   u16 ReadU16(u32 address) const override { return PowerPC::HostRead_U16(address); }
-  void WriteU16(u32 address, u16 value) override { PowerPC::HostWrite_U16(address, value); }
+  void WriteU16(u32 address, u16 value) override { PowerPC::HostWrite_U16(value, address); }
   u32 ReadU32(u32 address) const override { return PowerPC::HostRead_U32(address); }
-  void WriteU32(u32 address, u32 value) override { PowerPC::HostWrite_U32(address, value); }
+  void WriteU32(u32 address, u32 value) override { PowerPC::HostWrite_U32(value, address); }
   u64 ReadU64(u32 address) const override { return PowerPC::HostRead_U64(address); }
-  void WriteU64(u32 address, u64 value) override { PowerPC::HostWrite_U64(address, value); }
+  void WriteU64(u32 address, u64 value) override { PowerPC::HostWrite_U64(value, address); }
   float ReadF32(u32 address) const override { return PowerPC::HostRead_F32(address); };
 
   bool Matches(u32 haystack_start, u8* needle_start, u32 needle_size) const

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -495,18 +495,18 @@ void MemoryWidget::OnSetValue()
 
     if (value == static_cast<u8>(value))
     {
-      accessors->WriteU8(static_cast<u8>(value), addr);
+      accessors->WriteU8(addr, static_cast<u8>(value));
     }
     else if (value == static_cast<u16>(value))
     {
-      accessors->WriteU16(static_cast<u16>(value), addr);
+      accessors->WriteU16(addr, static_cast<u16>(value));
     }
     else if (value == static_cast<u32>(value))
     {
-      accessors->WriteU32(static_cast<u32>(value), addr);
+      accessors->WriteU32(addr, static_cast<u32>(value));
     }
     else
-      accessors->WriteU64(value, addr);
+      accessors->WriteU64(addr, value);
   }
 
   Update();


### PR DESCRIPTION
Fixes two parameter order mixups. Ideally, we would be using strongly typed addresses to prevent these kinds of mistakes.