### PR TITLE
Qt/LogConfigWidget: Show log type short names

### DIFF
--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -91,7 +91,7 @@ LogManager::LogManager()
   // create log containers
   m_log[LogTypes::ACTIONREPLAY] = {"ActionReplay", "ActionReplay"};
   m_log[LogTypes::AUDIO] = {"Audio", "Audio Emulator"};
-  m_log[LogTypes::AUDIO_INTERFACE] = {"AI", "Audio Interface (AI)"};
+  m_log[LogTypes::AUDIO_INTERFACE] = {"AI", "Audio Interface"};
   m_log[LogTypes::BOOT] = {"BOOT", "Boot"};
   m_log[LogTypes::COMMANDPROCESSOR] = {"CP", "CommandProc"};
   m_log[LogTypes::COMMON] = {"COMMON", "Common"};
@@ -131,11 +131,11 @@ LogManager::LogManager()
   m_log[LogTypes::PIXELENGINE] = {"PE", "PixelEngine"};
   m_log[LogTypes::PROCESSORINTERFACE] = {"PI", "ProcessorInt"};
   m_log[LogTypes::POWERPC] = {"PowerPC", "IBM CPU"};
-  m_log[LogTypes::SERIALINTERFACE] = {"SI", "Serial Interface (SI)"};
+  m_log[LogTypes::SERIALINTERFACE] = {"SI", "Serial Interface"};
   m_log[LogTypes::SP1] = {"SP1", "Serial Port 1"};
   m_log[LogTypes::SYMBOLS] = {"SYMBOLS", "Symbols"};
   m_log[LogTypes::VIDEO] = {"Video", "Video Backend"};
-  m_log[LogTypes::VIDEOINTERFACE] = {"VI", "Video Interface (VI)"};
+  m_log[LogTypes::VIDEOINTERFACE] = {"VI", "Video Interface"};
   m_log[LogTypes::WIIMOTE] = {"Wiimote", "Wiimote"};
   m_log[LogTypes::WII_IPC] = {"WII_IPC", "WII IPC"};
 

--- a/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
@@ -64,8 +64,10 @@ void LogConfigWidget::CreateWidgets()
 
   for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++)
   {
-    QListWidgetItem* widget = new QListWidgetItem(QString::fromStdString(
-        LogManager::GetInstance()->GetFullName(static_cast<LogTypes::LOG_TYPE>(i))));
+    const auto log_type = static_cast<LogTypes::LOG_TYPE>(i);
+    const QString full_name = QString::fromUtf8(LogManager::GetInstance()->GetFullName(log_type));
+    const QString short_name = QString::fromUtf8(LogManager::GetInstance()->GetShortName(log_type));
+    auto* widget = new QListWidgetItem(QStringLiteral("%1 (%2)").arg(full_name, short_name));
     widget->setCheckState(Qt::Unchecked);
     m_types_list->addItem(widget);
   }


### PR DESCRIPTION
Makes it easier for users to determine which option they need to
enable/disable as log messages only show the short name.