### PR TITLE
Fix a race condition when shutting down audio stream

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -147,7 +147,9 @@ static void RunAdjacentSystems(bool running)
 {
   // NOTE: We're assuming these will not try to call Break or EnableStepping.
   Fifo::EmulatorState(running);
-  AudioCommon::SetSoundStreamRunning(running);
+  // Core is responsible for shutting down the sound stream.
+  if (s_state != State::PowerDown)
+    AudioCommon::SetSoundStreamRunning(running);
 }
 
 void Stop()


### PR DESCRIPTION
The main EmuThread (in Core) is responsible for both initialising the
audio stream and shutting it down properly.

When the core is shutting down (when state is State::PowerDown), it is
possible that the CPU or CPU-GPU thread and the UI thread will both
try to stop the audio stream at the same time, which is an issue
because some audio backends such as cubeb are not thread-safe.

This commit prevents the race from ever happening in the first place
by removing the call to AudioCommon::SetSoundStreamRunning from
CPU::RunAdjacentSystems, which is actually completely unnecessary when
shutting down because Core::EmuThread is going to stop the stream and
perform more cleanup anyway.

Should fix https://bugs.dolphin-emu.org/issues/11722