### PR TITLE
D3DCommon: Fallback to base CreateSwapChain on failure

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -23,7 +23,7 @@ namespace DX11
 static Common::DynamicLibrary s_d3d11_library;
 namespace D3D
 {
-ComPtr<IDXGIFactory2> dxgi_factory;
+ComPtr<IDXGIFactory> dxgi_factory;
 ComPtr<ID3D11Device> device;
 ComPtr<ID3D11Device1> device1;
 ComPtr<ID3D11DeviceContext> context;
@@ -173,7 +173,7 @@ std::vector<u32> GetAAModes(u32 adapter_index)
   ComPtr<ID3D11Device> temp_device = device;
   if (!temp_device)
   {
-    ComPtr<IDXGIFactory2> temp_dxgi_factory = D3DCommon::CreateDXGIFactory(false);
+    ComPtr<IDXGIFactory> temp_dxgi_factory = D3DCommon::CreateDXGIFactory(false);
     if (!temp_dxgi_factory)
       return {};
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -28,7 +28,7 @@ class SwapChain;
 
 namespace D3D
 {
-extern ComPtr<IDXGIFactory2> dxgi_factory;
+extern ComPtr<IDXGIFactory> dxgi_factory;
 extern ComPtr<ID3D11Device> device;
 extern ComPtr<ID3D11Device1> device1;
 extern ComPtr<ID3D11DeviceContext> context;

--- a/Source/Core/VideoBackends/D3D/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D/SwapChain.cpp
@@ -7,7 +7,7 @@
 
 namespace DX11
 {
-SwapChain::SwapChain(const WindowSystemInfo& wsi, IDXGIFactory2* dxgi_factory,
+SwapChain::SwapChain(const WindowSystemInfo& wsi, IDXGIFactory* dxgi_factory,
                      ID3D11Device* d3d_device)
     : D3DCommon::SwapChain(wsi, dxgi_factory, d3d_device)
 {

--- a/Source/Core/VideoBackends/D3D/SwapChain.h
+++ b/Source/Core/VideoBackends/D3D/SwapChain.h
@@ -23,7 +23,7 @@ class DXFramebuffer;
 class SwapChain : public D3DCommon::SwapChain
 {
 public:
-  SwapChain(const WindowSystemInfo& wsi, IDXGIFactory2* dxgi_factory, ID3D11Device* d3d_device);
+  SwapChain(const WindowSystemInfo& wsi, IDXGIFactory* dxgi_factory, ID3D11Device* d3d_device);
   ~SwapChain();
 
   static std::unique_ptr<SwapChain> Create(const WindowSystemInfo& wsi);

--- a/Source/Core/VideoBackends/D3D12/DXContext.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXContext.cpp
@@ -43,7 +43,7 @@ std::vector<u32> DXContext::GetAAModes(u32 adapter_index)
   ComPtr<ID3D12Device> temp_device = g_dx_context ? g_dx_context->m_device : nullptr;
   if (!temp_device)
   {
-    ComPtr<IDXGIFactory2> temp_dxgi_factory = D3DCommon::CreateDXGIFactory(false);
+    ComPtr<IDXGIFactory> temp_dxgi_factory = D3DCommon::CreateDXGIFactory(false);
     if (!temp_dxgi_factory)
       return {};
 
@@ -57,7 +57,8 @@ std::vector<u32> DXContext::GetAAModes(u32 adapter_index)
       return {};
     }
 
-    HRESULT hr = d3d12_create_device(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&temp_device));
+    HRESULT hr =
+        d3d12_create_device(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&temp_device));
     if (!SUCCEEDED(hr))
       return {};
   }

--- a/Source/Core/VideoBackends/D3D12/DXContext.h
+++ b/Source/Core/VideoBackends/D3D12/DXContext.h
@@ -14,7 +14,7 @@
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
 #include "VideoBackends/D3D12/StreamBuffer.h"
 
-struct IDXGIFactory2;
+struct IDXGIFactory;
 
 namespace DX12
 {
@@ -54,7 +54,7 @@ public:
   // Destroys active context.
   static void Destroy();
 
-  IDXGIFactory2* GetDXGIFactory() const { return m_dxgi_factory.Get(); }
+  IDXGIFactory* GetDXGIFactory() const { return m_dxgi_factory.Get(); }
   ID3D12Device* GetDevice() const { return m_device.Get(); }
   ID3D12CommandQueue* GetCommandQueue() const { return m_command_queue.Get(); }
 
@@ -159,7 +159,7 @@ private:
   void MoveToNextCommandList();
   void DestroyPendingResources(CommandListResources& cmdlist);
 
-  ComPtr<IDXGIFactory2> m_dxgi_factory;
+  ComPtr<IDXGIFactory> m_dxgi_factory;
   ComPtr<ID3D12Debug> m_debug_interface;
   ComPtr<ID3D12Device> m_device;
   ComPtr<ID3D12CommandQueue> m_command_queue;

--- a/Source/Core/VideoBackends/D3D12/DXContext.h
+++ b/Source/Core/VideoBackends/D3D12/DXContext.h
@@ -5,8 +5,6 @@
 #pragma once
 
 #include <array>
-#include <functional>
-#include <map>
 
 #include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/Common.h"

--- a/Source/Core/VideoBackends/D3D12/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3D12/SwapChain.cpp
@@ -8,7 +8,7 @@
 
 namespace DX12
 {
-SwapChain::SwapChain(const WindowSystemInfo& wsi, IDXGIFactory2* dxgi_factory,
+SwapChain::SwapChain(const WindowSystemInfo& wsi, IDXGIFactory* dxgi_factory,
                      ID3D12CommandQueue* d3d_command_queue)
     : D3DCommon::SwapChain(wsi, dxgi_factory, d3d_command_queue)
 {

--- a/Source/Core/VideoBackends/D3D12/SwapChain.h
+++ b/Source/Core/VideoBackends/D3D12/SwapChain.h
@@ -23,7 +23,7 @@ class DXFramebuffer;
 class SwapChain : public D3DCommon::SwapChain
 {
 public:
-  SwapChain(const WindowSystemInfo& wsi, IDXGIFactory2* dxgi_factory,
+  SwapChain(const WindowSystemInfo& wsi, IDXGIFactory* dxgi_factory,
             ID3D12CommandQueue* d3d_command_queue);
   ~SwapChain();
 

--- a/Source/Core/VideoBackends/D3DCommon/Common.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Common.cpp
@@ -72,9 +72,9 @@ void UnloadLibraries()
   s_libraries_loaded = false;
 }
 
-IDXGIFactory2* CreateDXGIFactory(bool debug_device)
+IDXGIFactory* CreateDXGIFactory(bool debug_device)
 {
-  IDXGIFactory2* factory;
+  IDXGIFactory* factory;
 
   // Use Win8.1 version if available.
   if (create_dxgi_factory2 &&

--- a/Source/Core/VideoBackends/D3DCommon/Common.h
+++ b/Source/Core/VideoBackends/D3DCommon/Common.h
@@ -12,7 +12,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/VideoCommon.h"
 
-struct IDXGIFactory2;
+struct IDXGIFactory;
 
 enum class AbstractTextureFormat : u32;
 
@@ -26,7 +26,7 @@ void UnloadLibraries();
 std::vector<std::string> GetAdapterNames();
 
 // Helper function which creates a DXGI factory.
-IDXGIFactory2* CreateDXGIFactory(bool debug_device);
+IDXGIFactory* CreateDXGIFactory(bool debug_device);
 
 // Globally-accessible D3DCompiler function.
 extern pD3DCompile d3d_compile;

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.h
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.h
@@ -17,7 +17,7 @@ namespace D3DCommon
 class SwapChain
 {
 public:
-  SwapChain(const WindowSystemInfo& wsi, IDXGIFactory2* dxgi_factory, IUnknown* d3d_device);
+  SwapChain(const WindowSystemInfo& wsi, IDXGIFactory* dxgi_factory, IUnknown* d3d_device);
   virtual ~SwapChain();
 
   // Sufficient buffers for triple buffering.
@@ -26,7 +26,7 @@ public:
   // Returns true if the stereo mode is quad-buffering.
   static bool WantsStereo();
 
-  IDXGISwapChain1* GetDXGISwapChain() const { return m_swap_chain.Get(); }
+  IDXGISwapChain* GetDXGISwapChain() const { return m_swap_chain.Get(); }
   AbstractTextureFormat GetFormat() const { return m_texture_format; }
   u32 GetWidth() const { return m_width; }
   u32 GetHeight() const { return m_height; }
@@ -57,8 +57,8 @@ protected:
   virtual void DestroySwapChainBuffers() = 0;
 
   WindowSystemInfo m_wsi;
-  Microsoft::WRL::ComPtr<IDXGIFactory2> m_dxgi_factory;
-  Microsoft::WRL::ComPtr<IDXGISwapChain1> m_swap_chain;
+  Microsoft::WRL::ComPtr<IDXGIFactory> m_dxgi_factory;
+  Microsoft::WRL::ComPtr<IDXGISwapChain> m_swap_chain;
   Microsoft::WRL::ComPtr<IUnknown> m_d3d_device;
   AbstractTextureFormat m_texture_format = AbstractTextureFormat::RGBA8;
 


### PR DESCRIPTION
It appears that some older drivers do not support CreateSwapChainForHwnd, resulting in DXGI_ERROR_INVALID_CALL. For these cases, fall back to the base CreateSwapChain() from DXGI 1.0.

In theory this should also let us run on Win7 without the platform update, but in reality we require the newer shader compiler so this probably won't work regardless. Also any hardware of this vintage is unlikely to run Dolphin well.