### PR TITLE
x64Emitter: Eliminate redundant logic using variadic templates.

### DIFF
--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -146,7 +146,7 @@ void DSPEmitter::FallBackToInterpreter(UDSPInstruction inst)
 
   m_gpr.PushRegs();
   ASSERT_MSG(DSPLLE, interpreter_function != nullptr, "No function for %04x", inst);
-  ABI_CallFunctionC16(interpreter_function, inst);
+  ABI_CallFunction(interpreter_function, inst);
   m_gpr.PopRegs();
 }
 
@@ -171,7 +171,7 @@ void DSPEmitter::EmitInstruction(UDSPInstruction inst)
       const auto interpreter_function = Interpreter::GetExtOp(inst);
 
       m_gpr.PushRegs();
-      ABI_CallFunctionC16(interpreter_function, inst);
+      ABI_CallFunction(interpreter_function, inst);
       m_gpr.PopRegs();
       INFO_LOG(DSPLLE, "Instruction not JITed(ext part): %04x", inst);
       ext_is_jit = false;
@@ -400,8 +400,7 @@ void DSPEmitter::CompileCurrent(DSPEmitter& emitter)
 const u8* DSPEmitter::CompileStub()
 {
   const u8* entryPoint = AlignCode16();
-  MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(this)));
-  ABI_CallFunction(CompileCurrent);
+  ABI_CallFunction(CompileCurrent, std::ref(*this));
   XOR(32, R(EAX), R(EAX));  // Return 0 cycles executed
   JMP(m_return_dispatcher);
   return entryPoint;

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitUtil.cpp
@@ -638,7 +638,7 @@ void DSPEmitter::dmem_read_imm(u16 address)
   case 0xf:  // Fxxx HW regs
   {
     m_gpr.PushRegs();
-    ABI_CallFunctionC16(gdsp_ifx_read, address);
+    ABI_CallFunction(gdsp_ifx_read, address);
     m_gpr.PopRegs();
     break;
   }

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -407,7 +407,7 @@ void Jit64::FallBackToInterpreter(UGeckoInstruction inst)
   }
   Interpreter::Instruction instr = PPCTables::GetInterpreterOp(inst);
   ABI_PushRegistersAndAdjustStack({}, 0);
-  ABI_CallFunctionC(instr, inst.hex);
+  ABI_CallFunction(instr, inst.hex);
   ABI_PopRegistersAndAdjustStack({}, 0);
   if (js.op->opinfo->flags & FL_ENDBLOCK)
   {
@@ -434,7 +434,7 @@ void Jit64::HLEFunction(UGeckoInstruction _inst)
   gpr.Flush();
   fpr.Flush();
   ABI_PushRegistersAndAdjustStack({}, 0);
-  ABI_CallFunctionCC(HLE::Execute, js.compilerPC, _inst.hex);
+  ABI_CallFunction(HLE::Execute, js.compilerPC, _inst.hex);
   ABI_PopRegistersAndAdjustStack({}, 0);
 }
 
@@ -488,8 +488,8 @@ bool Jit64::Cleanup()
   if (MMCR0.Hex || MMCR1.Hex)
   {
     ABI_PushRegistersAndAdjustStack({}, 0);
-    ABI_CallFunctionCCC(PowerPC::UpdatePerformanceMonitor, js.downcountAmount, js.numLoadStoreInst,
-                        js.numFloatingPointInst);
+    ABI_CallFunction(PowerPC::UpdatePerformanceMonitor, js.downcountAmount, js.numLoadStoreInst,
+                     js.numFloatingPointInst);
     ABI_PopRegistersAndAdjustStack({}, 0);
     did_something = true;
   }
@@ -850,8 +850,8 @@ u8* Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       const u8* target = GetCodePtr();
       MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
       ABI_PushRegistersAndAdjustStack({}, 0);
-      ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
-                        static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
+      ABI_CallFunction(JitInterface::CompileExceptionCheck,
+                       JitInterface::ExceptionType::PairedQuantize);
       ABI_PopRegistersAndAdjustStack({}, 0);
       JMP(asm_routines.dispatcher_no_check, true);
       SwitchToNearCode();
@@ -1138,8 +1138,8 @@ void Jit64::IntializeSpeculativeConstants()
         target = GetCodePtr();
         MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
         ABI_PushRegistersAndAdjustStack({}, 0);
-        ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
-                          static_cast<u32>(JitInterface::ExceptionType::SpeculativeConstants));
+        ABI_CallFunction(JitInterface::CompileExceptionCheck,
+                         JitInterface::ExceptionType::SpeculativeConstants);
         ABI_PopRegistersAndAdjustStack({}, 0);
         JMP(asm_routines.dispatcher, true);
         SwitchToNearCode();

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -157,8 +157,7 @@ void Jit64AsmRoutineManager::Generate()
 
   // Ok, no block, let's call the slow dispatcher
   ABI_PushRegistersAndAdjustStack({}, 0);
-  MOV(64, R(ABI_PARAM1), Imm64(reinterpret_cast<u64>(&m_jit)));
-  ABI_CallFunction(JitBase::Dispatch);
+  ABI_CallFunction(JitBase::Dispatch, std::ref(m_jit));
   ABI_PopRegistersAndAdjustStack({}, 0);
 
   TEST(64, R(ABI_RETURN), R(ABI_RETURN));

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -276,7 +276,7 @@ private:
   void CallLambda(int sbits, const std::function<T(u32)>* lambda)
   {
     m_code->ABI_PushRegistersAndAdjustStack(m_registers_in_use, 0);
-    m_code->ABI_CallLambdaC(lambda, m_address);
+    m_code->ABI_CallLambda(lambda, m_address);
     m_code->ABI_PopRegistersAndAdjustStack(m_registers_in_use, 0);
     MoveOpArgToReg(sbits, R(ABI_RETURN));
   }
@@ -458,16 +458,16 @@ void EmuCodeBlock::SafeLoadToRegImmediate(X64Reg reg_value, u32 address, int acc
   switch (accessSize)
   {
   case 64:
-    ABI_CallFunctionC(PowerPC::Read_U64, address);
+    ABI_CallFunction(PowerPC::Read_U64, address);
     break;
   case 32:
-    ABI_CallFunctionC(PowerPC::Read_U32, address);
+    ABI_CallFunction(PowerPC::Read_U32, address);
     break;
   case 16:
-    ABI_CallFunctionC(PowerPC::Read_U16_ZX, address);
+    ABI_CallFunction(PowerPC::Read_U16_ZX, address);
     break;
   case 8:
-    ABI_CallFunctionC(PowerPC::Read_U8_ZX, address);
+    ABI_CallFunction(PowerPC::Read_U8_ZX, address);
     break;
   }
   ABI_PopRegistersAndAdjustStack(registersInUse, 0);
@@ -655,16 +655,16 @@ bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address,
     switch (accessSize)
     {
     case 64:
-      ABI_CallFunctionAC(64, PowerPC::Write_U64, arg, address);
+      ABI_CallFunctionA(64, PowerPC::Write_U64, arg, address);
       break;
     case 32:
-      ABI_CallFunctionAC(32, PowerPC::Write_U32, arg, address);
+      ABI_CallFunctionA(32, PowerPC::Write_U32, arg, address);
       break;
     case 16:
-      ABI_CallFunctionAC(16, PowerPC::Write_U16, arg, address);
+      ABI_CallFunctionA(16, PowerPC::Write_U16, arg, address);
       break;
     case 8:
-      ABI_CallFunctionAC(8, PowerPC::Write_U8, arg, address);
+      ABI_CallFunctionA(8, PowerPC::Write_U8, arg, address);
       break;
     }
     ABI_PopRegistersAndAdjustStack(registersInUse, 0);


### PR DESCRIPTION
I've replaced some `ABI_CallFunction{C,C16,P}` permutations with variadic versions that can handle integer and pointer types in any order.

This eliminates some redundant code and should prevent the need to implement function types that might be used in the future.