### PR TITLE
Clear existing GCPadStatus when playing back DTM files

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1147,6 +1147,7 @@ void PlayController(GCPadStatus* PadStatus, int controllerID)
   PadStatus->substickX = s_padState.CStickX;
   PadStatus->substickY = s_padState.CStickY;
 
+  PadStatus->button = 0;
   PadStatus->button |= PAD_USE_ORIGIN;
 
   if (s_padState.A)


### PR DESCRIPTION
Sets the buttons on GCPadStatus to 0 while playing back a DTM file.

Should fix https://bugs.dolphin-emu.org/issues/11616