### PR TITLE
Qt/Debugger CodeWidget navigation unification

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -155,12 +155,11 @@ void CodeWidget::ConnectWidgets()
   connect(m_search_address, &QLineEdit::textChanged, this, &CodeWidget::OnSearchAddress);
   connect(m_search_symbols, &QLineEdit::textChanged, this, &CodeWidget::OnSearchSymbols);
 
-  connect(m_symbols_list, &QListWidget::itemClicked, this, &CodeWidget::OnSelectSymbol);
-  connect(m_callstack_list, &QListWidget::itemSelectionChanged, this,
-          &CodeWidget::OnSelectCallstack);
-  connect(m_function_calls_list, &QListWidget::itemSelectionChanged, this,
+  connect(m_symbols_list, &QListWidget::itemPressed, this, &CodeWidget::OnSelectSymbol);
+  connect(m_callstack_list, &QListWidget::itemPressed, this, &CodeWidget::OnSelectCallstack);
+  connect(m_function_calls_list, &QListWidget::itemPressed, this,
           &CodeWidget::OnSelectFunctionCalls);
-  connect(m_function_callers_list, &QListWidget::itemSelectionChanged, this,
+  connect(m_function_callers_list, &QListWidget::itemPressed, this,
           &CodeWidget::OnSelectFunctionCallers);
 
   connect(m_code_view, &CodeViewWidget::SymbolsChanged, this, &CodeWidget::UpdateSymbols);


### PR DESCRIPTION
### Summary:

Changed itemSelectionChanged and itemClicked signal to itemPressed in CodeWidget.
Holding mouse down and moving will only travel up/down the stack one time. 
This fixes the common occurrence of unintentionally traveling deeper down the stack or higher up the callstack than intended.

---------------------
### Details: 
**Behavior before:**
_symbols_
Clicking (and holding) item A, then moving mouse down to item B, then moving back to item A results in viewing item A.

_callstack/calls/callers_
Holding mouse down and moving mouse would result in continually triggering the OnSelectFunctionX, making it possible for debuggers to accidentally go up/down the callstack further than intended.

**Behavior after:**
_symbols_
Immediately jumps to item A regardless of hold.

_callstack/calls/callers_
Holding mouse down and moving will only travel up/down the stack one time. The issue of traveling too far will not occur.