### PR TITLE
Qt/InterfacePane: Rename "In-Game" to "Render Window"

### DIFF
--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -162,7 +162,7 @@ void InterfacePane::CreateUI()
 
 void InterfacePane::CreateInGame()
 {
-  auto* groupbox = new QGroupBox(tr("In-Game"));
+  auto* groupbox = new QGroupBox(tr("Render Window"));
   auto* groupbox_layout = new QVBoxLayout;
   groupbox->setLayout(groupbox_layout);
   m_main_layout->addWidget(groupbox);


### PR DESCRIPTION
This better reflects what the options do, as they only affect the render window and actual gameplay is completely unaffected.