### PR TITLE
Core/Boot/Boot: Amend use-after-move cases in GenerateFromFile()

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -155,7 +155,7 @@ BootParameters::GenerateFromFile(std::vector<std::string> paths,
     std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
   }
 
-  const std::string path = paths.front();
+  std::string path = paths.front();
   if (paths.size() == 1)
     paths.clear();
 
@@ -172,14 +172,16 @@ BootParameters::GenerateFromFile(std::vector<std::string> paths,
 
     if (extension == ".elf")
     {
-      return std::make_unique<BootParameters>(
-          Executable{std::move(path), std::make_unique<ElfReader>(path)}, savestate_path);
+      auto elf_reader = std::make_unique<ElfReader>(path);
+      return std::make_unique<BootParameters>(Executable{std::move(path), std::move(elf_reader)},
+                                              savestate_path);
     }
 
     if (extension == ".dol")
     {
-      return std::make_unique<BootParameters>(
-          Executable{std::move(path), std::make_unique<DolReader>(path)}, savestate_path);
+      auto dol_reader = std::make_unique<DolReader>(path);
+      return std::make_unique<BootParameters>(Executable{std::move(path), std::move(dol_reader)},
+                                              savestate_path);
     }
 
     if (is_drive)


### PR DESCRIPTION
In terms of order of operations, the move would occur first before the construction of the relevant reader would occur. However, given the local variable 'path' was declared const, this bug actually wouldn't occur, as std::move on a const variable does nothing (in a non-mutable context), resulting in a copy instead, masking this issue.

Given this is a bug waiting to happen, we can correct this.