### PR TITLE
IOS: USB fixes

### DIFF
--- a/Source/Core/Core/IOS/USB/Common.h
+++ b/Source/Core/Core/IOS/USB/Common.h
@@ -127,14 +127,14 @@ struct CtrlMessage : TransferCommand
 
 struct BulkMessage : TransferCommand
 {
-  u16 length = 0;
+  u32 length = 0;
   u8 endpoint = 0;
   using TransferCommand::TransferCommand;
 };
 
 struct IntrMessage : TransferCommand
 {
-  u16 length = 0;
+  u32 length = 0;
   u8 endpoint = 0;
   using TransferCommand::TransferCommand;
 };
@@ -143,7 +143,7 @@ struct IsoMessage : TransferCommand
 {
   u32 packet_sizes_addr = 0;
   std::vector<u16> packet_sizes;
-  u16 length = 0;
+  u32 length = 0;
   u8 num_packets = 0;
   u8 endpoint = 0;
   using TransferCommand::TransferCommand;

--- a/Source/Core/Core/IOS/USB/Common.h
+++ b/Source/Core/Core/IOS/USB/Common.h
@@ -15,6 +15,8 @@
 
 namespace IOS::HLE::USB
 {
+constexpr u8 DEFAULT_CONFIG_NUM = 0;
+
 enum StandardDeviceRequestCodes
 {
   REQUEST_GET_DESCRIPTOR = 6,
@@ -165,7 +167,13 @@ public:
   virtual std::vector<EndpointDescriptor> GetEndpoints(u8 config, u8 interface, u8 alt) const = 0;
 
   virtual std::string GetErrorName(int error_code) const;
-  virtual bool Attach(u8 interface) = 0;
+  /// Ensure the device is ready to use.
+  virtual bool Attach() = 0;
+  /// Ensure the device is ready to use and change the active interface (if needed).
+  ///
+  /// This may reset the active alt setting, so prefer using Attach when interface changes
+  /// are unnecessary (e.g. for control requests).
+  virtual bool AttachAndChangeInterface(u8 interface) = 0;
   virtual int CancelTransfer(u8 endpoint) = 0;
   virtual int ChangeInterface(u8 interface) = 0;
   virtual int GetNumberOfAltSettings(u8 interface) = 0;

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Event.h"
 #include "Common/Flag.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
@@ -76,5 +77,7 @@ private:
   // Device scanning thread
   Common::Flag m_scan_thread_running;
   std::thread m_scan_thread;
+  Common::Event m_first_scan_complete_event;
+  bool m_has_initialised = false;
 };
 }  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -42,10 +42,11 @@ LibusbDevice::LibusbDevice(Kernel& ios, libusb_device* device,
 
 LibusbDevice::~LibusbDevice()
 {
-  if (m_device_attached)
-    DetachInterface();
   if (m_handle != nullptr)
+  {
+    ReleaseAllInterfacesForCurrentConfig();
     libusb_close(m_handle);
+  }
   libusb_unref_device(m_device);
 }
 
@@ -124,25 +125,36 @@ std::string LibusbDevice::GetErrorName(const int error_code) const
   return libusb_error_name(error_code);
 }
 
-bool LibusbDevice::Attach(const u8 interface)
+bool LibusbDevice::Attach()
 {
-  if (m_device_attached && interface != m_active_interface)
-    return ChangeInterface(interface) == 0;
-
   if (m_device_attached)
     return true;
 
-  m_device_attached = false;
-  NOTICE_LOG(IOS_USB, "[%04x:%04x] Opening device", m_vid, m_pid);
-  const int ret = libusb_open(m_device, &m_handle);
-  if (ret != 0)
+  if (!m_handle)
   {
-    ERROR_LOG(IOS_USB, "[%04x:%04x] Failed to open: %s", m_vid, m_pid, libusb_error_name(ret));
-    return false;
+    NOTICE_LOG(IOS_USB, "[%04x:%04x] Opening device", m_vid, m_pid);
+    const int ret = libusb_open(m_device, &m_handle);
+    if (ret != 0)
+    {
+      ERROR_LOG(IOS_USB, "[%04x:%04x] Failed to open: %s", m_vid, m_pid, libusb_error_name(ret));
+      m_handle = nullptr;
+      return false;
+    }
   }
-  if (AttachInterface(interface) != 0)
+  if (ClaimAllInterfaces(DEFAULT_CONFIG_NUM) < 0)
     return false;
   m_device_attached = true;
+  return true;
+}
+
+bool LibusbDevice::AttachAndChangeInterface(const u8 interface)
+{
+  if (!Attach())
+    return false;
+
+  if (interface != m_active_interface)
+    return ChangeInterface(interface) == 0;
+
   return true;
 }
 
@@ -159,15 +171,10 @@ int LibusbDevice::CancelTransfer(const u8 endpoint)
 
 int LibusbDevice::ChangeInterface(const u8 interface)
 {
-  if (!m_device_attached || interface >= m_config_descriptors[0]->Get()->bNumInterfaces)
-    return LIBUSB_ERROR_NOT_FOUND;
-
   INFO_LOG(IOS_USB, "[%04x:%04x %d] Changing interface to %d", m_vid, m_pid, m_active_interface,
            interface);
-  const int ret = DetachInterface();
-  if (ret < 0)
-    return ret;
-  return AttachInterface(interface);
+  m_active_interface = interface;
+  return 0;
 }
 
 int LibusbDevice::SetAltSetting(const u8 alt_setting)
@@ -217,9 +224,13 @@ int LibusbDevice::SubmitTransfer(std::unique_ptr<CtrlMessage> cmd)
   {
     INFO_LOG(IOS_USB, "[%04x:%04x %d] REQUEST_SET_CONFIGURATION index=%04x value=%04x", m_vid,
              m_pid, m_active_interface, cmd->index, cmd->value);
+    ReleaseAllInterfacesForCurrentConfig();
     const int ret = libusb_set_configuration(m_handle, cmd->value);
     if (ret == 0)
+    {
+      ClaimAllInterfaces(cmd->value);
       m_ios.EnqueueIPCReply(cmd->ios_request, cmd->length);
+    }
     return ret;
   }
   }
@@ -395,50 +406,61 @@ int LibusbDevice::GetNumberOfAltSettings(const u8 interface_number)
   return m_config_descriptors[0]->Get()->interface[interface_number].num_altsetting;
 }
 
-int LibusbDevice::AttachInterface(const u8 interface)
+template <typename Configs, typename Function>
+static int DoForEachInterface(const Configs& configs, u8 config_num, Function action)
 {
-  if (m_handle == nullptr)
-  {
-    ERROR_LOG(IOS_USB, "[%04x:%04x] Cannot attach without a valid device handle", m_vid, m_pid);
-    return -1;
-  }
-
-  INFO_LOG(IOS_USB, "[%04x:%04x] Attaching interface %d", m_vid, m_pid, interface);
-  const int ret = libusb_detach_kernel_driver(m_handle, interface);
-  if (ret < 0 && ret != LIBUSB_ERROR_NOT_FOUND && ret != LIBUSB_ERROR_NOT_SUPPORTED)
-  {
-    ERROR_LOG(IOS_USB, "[%04x:%04x] Failed to detach kernel driver: %s", m_vid, m_pid,
-              libusb_error_name(ret));
+  int ret = LIBUSB_ERROR_NOT_FOUND;
+  if (configs.size() <= config_num || !configs[config_num]->IsValid())
     return ret;
-  }
-  const int r = libusb_claim_interface(m_handle, interface);
-  if (r < 0)
+  for (u8 i = 0; i < configs[config_num]->Get()->bNumInterfaces; ++i)
   {
-    ERROR_LOG(IOS_USB, "[%04x:%04x] Couldn't claim interface %d: %s", m_vid, m_pid, interface,
-              libusb_error_name(r));
-    return r;
+    ret = action(i);
+    if (ret < 0)
+      break;
   }
-  m_active_interface = interface;
-  return 0;
+  return ret;
 }
 
-int LibusbDevice::DetachInterface()
+int LibusbDevice::ClaimAllInterfaces(u8 config_num) const
 {
-  if (m_handle == nullptr)
+  const int ret = DoForEachInterface(m_config_descriptors, config_num, [this](u8 i) {
+    const int ret2 = libusb_detach_kernel_driver(m_handle, i);
+    if (ret2 < 0 && ret2 != LIBUSB_ERROR_NOT_FOUND && ret2 != LIBUSB_ERROR_NOT_SUPPORTED)
+    {
+      ERROR_LOG(IOS_USB, "[%04x:%04x] Failed to detach kernel driver: %s", m_vid, m_pid,
+                libusb_error_name(ret2));
+      return ret2;
+    }
+    return libusb_claim_interface(m_handle, i);
+  });
+  if (ret < 0)
   {
-    ERROR_LOG(IOS_USB, "[%04x:%04x] Cannot detach without a valid device handle", m_vid, m_pid);
-    return -1;
+    ERROR_LOG(IOS_USB, "[%04x:%04x] Failed to claim all interfaces (configuration %u)", m_vid,
+              m_pid, config_num);
   }
+  return ret;
+}
 
-  INFO_LOG(IOS_USB, "[%04x:%04x] Detaching interface %d", m_vid, m_pid, m_active_interface);
-  const int ret = libusb_release_interface(m_handle, m_active_interface);
-  if (ret < 0 && ret != LIBUSB_ERROR_NO_DEVICE)
+int LibusbDevice::ReleaseAllInterfaces(u8 config_num) const
+{
+  const int ret = DoForEachInterface(m_config_descriptors, config_num, [this](u8 i) {
+    return libusb_release_interface(m_handle, i);
+  });
+  if (ret < 0 && ret != LIBUSB_ERROR_NO_DEVICE && ret != LIBUSB_ERROR_NOT_FOUND)
   {
-    ERROR_LOG(IOS_USB, "[%04x:%04x] Failed to release interface %d: %s", m_vid, m_pid,
-              m_active_interface, libusb_error_name(ret));
-    return ret;
+    ERROR_LOG(IOS_USB, "[%04x:%04x] Failed to release all interfaces (configuration %u)", m_vid,
+              m_pid, config_num);
   }
-  return 0;
+  return ret;
+}
+
+int LibusbDevice::ReleaseAllInterfacesForCurrentConfig() const
+{
+  int config_num;
+  const int get_config_ret = libusb_get_configuration(m_handle, &config_num);
+  if (get_config_ret < 0)
+    return get_config_ret;
+  return ReleaseAllInterfaces(config_num);
 }
 
 LibusbConfigDescriptor::LibusbConfigDescriptor(libusb_device* device, const u8 config_num)

--- a/Source/Core/Core/IOS/USB/LibusbDevice.h
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.h
@@ -48,7 +48,8 @@ public:
   std::vector<InterfaceDescriptor> GetInterfaces(u8 config) const override;
   std::vector<EndpointDescriptor> GetEndpoints(u8 config, u8 interface, u8 alt) const override;
   std::string GetErrorName(int error_code) const override;
-  bool Attach(u8 interface) override;
+  bool Attach() override;
+  bool AttachAndChangeInterface(u8 interface) override;
   int CancelTransfer(u8 endpoint) override;
   int ChangeInterface(u8 interface) override;
   int GetNumberOfAltSettings(u8 interface) override;
@@ -85,8 +86,9 @@ private:
   static void CtrlTransferCallback(libusb_transfer* transfer);
   static void TransferCallback(libusb_transfer* transfer);
 
-  int AttachInterface(u8 interface);
-  int DetachInterface();
+  int ClaimAllInterfaces(u8 config_num) const;
+  int ReleaseAllInterfaces(u8 config_num) const;
+  int ReleaseAllInterfacesForCurrentConfig() const;
 };
 }  // namespace IOS::HLE::USB
 #endif

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -252,8 +252,10 @@ std::pair<ReturnCode, u64> OH0::DeviceOpen(const u16 vid, const u16 pid)
     has_device_with_vid_pid = true;
 
     if (m_opened_devices.find(device.second->GetId()) != m_opened_devices.cend() ||
-        !device.second->Attach(0))
+        !device.second->Attach())
+    {
       continue;
+    }
 
     m_opened_devices.emplace(device.second->GetId());
     return {IPC_SUCCESS, device.second->GetId()};

--- a/Source/Core/Core/IOS/USB/USBV4.cpp
+++ b/Source/Core/Core/IOS/USB/USBV4.cpp
@@ -87,7 +87,7 @@ V4IntrMessage::V4IntrMessage(Kernel& ios, const IOCtlRequest& ioctl) : IntrMessa
 {
   HIDRequest hid_request;
   Memory::CopyFromEmu(&hid_request, ioctl.buffer_in, sizeof(hid_request));
-  length = static_cast<u16>(Common::swap32(hid_request.interrupt.length));
+  length = Common::swap32(hid_request.interrupt.length);
   endpoint = static_cast<u8>(Common::swap32(hid_request.interrupt.endpoint));
   data_address = Common::swap32(hid_request.data_addr);
 }

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -140,7 +140,7 @@ IPCCommandResult USBV5ResourceManager::SetAlternateSetting(USBV5Device& device,
                                                            const IOCtlRequest& request)
 {
   const auto host_device = GetDeviceById(device.host_id);
-  if (!host_device->Attach(device.interface_number))
+  if (!host_device->AttachAndChangeInterface(device.interface_number))
     return GetDefaultReply(-1);
 
   const u8 alt_setting = Memory::Read_U8(request.buffer_in + 2 * sizeof(s32));

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -31,14 +31,14 @@ V5CtrlMessage::V5CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
 V5BulkMessage::V5BulkMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : BulkMessage(ios, ioctlv, ioctlv.GetVector(1)->address)
 {
-  length = static_cast<u16>(ioctlv.GetVector(1)->size);
+  length = ioctlv.GetVector(1)->size;
   endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address + 18);
 }
 
 V5IntrMessage::V5IntrMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : IntrMessage(ios, ioctlv, ioctlv.GetVector(1)->address)
 {
-  length = static_cast<u16>(ioctlv.GetVector(1)->size);
+  length = ioctlv.GetVector(1)->size;
   endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address + 14);
 }
 
@@ -50,7 +50,7 @@ V5IsoMessage::V5IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
   packet_sizes_addr = ioctlv.GetVector(1)->address;
   for (size_t i = 0; i < num_packets; ++i)
     packet_sizes.push_back(Memory::Read_U16(static_cast<u32>(packet_sizes_addr + i * sizeof(u16))));
-  length = static_cast<u16>(ioctlv.GetVector(2)->size);
+  length = ioctlv.GetVector(2)->size;
 }
 }  // namespace USB
 

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -55,7 +55,7 @@ IPCCommandResult USB_HIDv4::IOCtl(const IOCtlRequest& request)
     if (request.buffer_in == 0 || request.buffer_in_size != 32)
       return GetDefaultReply(IPC_EINVAL);
     const auto device = GetDeviceByIOSID(Memory::Read_U32(request.buffer_in + 16));
-    if (!device->Attach(0))
+    if (!device->Attach())
       return GetDefaultReply(IPC_EINVAL);
     return HandleTransfer(device, request.request,
                           [&, this]() { return SubmitTransfer(*device, request); });

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -67,7 +67,10 @@ IPCCommandResult USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
     if (!device)
       return GetDefaultReply(IPC_EINVAL);
     auto host_device = GetDeviceById(device->host_id);
-    host_device->Attach(device->interface_number);
+    if (request.request == USB::IOCTLV_USBV5_CTRLMSG)
+      host_device->Attach();
+    else
+      host_device->AttachAndChangeInterface(device->interface_number);
     return HandleTransfer(host_device, request.request,
                           [&, this]() { return SubmitTransfer(*device, *host_device, request); });
   }

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -104,7 +104,7 @@ s32 USB_VEN::SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv)
 
 IPCCommandResult USB_VEN::CancelEndpoint(USBV5Device& device, const IOCtlRequest& request)
 {
-  const u8 endpoint = static_cast<u8>(Memory::Read_U32(request.buffer_in + 8));
+  const u8 endpoint = Memory::Read_U8(request.buffer_in + 8);
   // IPC_EINVAL (-4) is returned when no transfer was cancelled.
   if (GetDeviceById(device.host_id)->CancelTransfer(endpoint) < 0)
     return GetDefaultReply(IPC_EINVAL);

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -105,7 +105,9 @@ s32 USB_VEN::SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv)
 IPCCommandResult USB_VEN::CancelEndpoint(USBV5Device& device, const IOCtlRequest& request)
 {
   const u8 endpoint = static_cast<u8>(Memory::Read_U32(request.buffer_in + 8));
-  GetDeviceById(device.host_id)->CancelTransfer(endpoint);
+  // IPC_EINVAL (-4) is returned when no transfer was cancelled.
+  if (GetDeviceById(device.host_id)->CancelTransfer(endpoint) < 0)
+    return GetDefaultReply(IPC_EINVAL);
   return GetDefaultReply(IPC_SUCCESS);
 }
 

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -76,7 +76,10 @@ IPCCommandResult USB_VEN::IOCtlV(const IOCtlVRequest& request)
     if (!device)
       return GetDefaultReply(IPC_EINVAL);
     auto host_device = GetDeviceById(device->host_id);
-    host_device->Attach(device->interface_number);
+    if (request.request == USB::IOCTLV_USBV5_CTRLMSG)
+      host_device->Attach();
+    else
+      host_device->AttachAndChangeInterface(device->interface_number);
     return HandleTransfer(host_device, request.request,
                           [&, this]() { return SubmitTransfer(*host_device, request); });
   }


### PR DESCRIPTION
(From #8070)

A set of small fixes to the USB code in IOS HLE.

JMC47 and I have tested OH0 (microphone, Wii Speak), VEN (microphone, camera) and HIDv4 (Internet Channel, Wii Shop Channel). HIDv5 wasn't tested but is very likely to work because it is pretty much a simpler version of VEN.

This fixes *Your Shape* hanging on shutdown and camera input in *Racquet Sports*.

Note: other commits from #8070 are needed to make everything work properly on Windows.