### PR TITLE
MoltenVK: Update to Vulkan SDK version 1.1.108.0

### DIFF
--- a/Externals/MoltenVK/version.txt
+++ b/Externals/MoltenVK/version.txt
@@ -1,3 +1,3 @@
-libMoltenVK.dylib from vulkansdk-macos-1.1.101.0, renamed to libvulkan.dylib
+libMoltenVK.dylib from vulkansdk-macos-1.1.108.0, renamed to libvulkan.dylib
 
-Downloaded from: https://sdk.lunarg.com/sdk/download/1.1.101.0/mac/vulkansdk-macos-1.1.101.0.tar.gz
+Downloaded from: https://sdk.lunarg.com/sdk/download/1.1.108.0/mac/vulkansdk-macos-1.1.108.0.tar.gz


### PR DESCRIPTION
Apparently this fixes a memory leak, see https://dolp.in/i11738/7

Untested, I just pulled the latest SDK.