### PR TITLE
Add BraceWrapping/AfterCaseLabel to .clang-format

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -20,6 +20,7 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
+  AfterCaseLabel:  true
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       true


### PR DESCRIPTION
This must be a new option that got missed in the recent clang-format update. The default value seems to false instead of true on msvc, causing obvious problems.