### PR TITLE
IniFile: Prevent potential out-of-bounds access in ParseLine()

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -20,7 +20,7 @@
 
 void IniFile::ParseLine(const std::string& line, std::string* keyOut, std::string* valueOut)
 {
-  if (line[0] == '#')
+  if (line.empty() || line.front() == '#')
     return;
 
   size_t firstEquals = line.find('=');


### PR DESCRIPTION
While current usages of ParseLine aren't problematic, this is still a public function that can be used for other purposes. This case should still be guarded against to avoid an out of bounds read attempt in the event an empty string is ever passed to this if any other uses of this function are added elsewhere in the future (or if the existing code using it is ever changed).