### PR TITLE
clang-format: revert 'AfterCaseLabel' setting

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -20,7 +20,6 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterCaseLabel:  true
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       true


### PR DESCRIPTION
Seems to break msvc and the buildbot's lint