### PR TITLE
Jit64: Make DoubleToSingle a common asm routine

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -236,6 +236,8 @@ void Jit64AsmRoutineManager::GenerateCommon()
   GenFres();
   mfcr = AlignCode4();
   GenMfcr();
+  cdts = AlignCode4();
+  GenConvertDoubleToSingle();
 
   GenQuantizedLoads();
   GenQuantizedSingleLoads();

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -115,7 +115,8 @@ void Jit64::stfXXX(UGeckoInstruction inst)
     {
       RCX64Reg Rs = fpr.Bind(s, RCMode::Read);
       RegCache::Realize(Rs);
-      ConvertDoubleToSingle(XMM0, Rs);
+      MOVAPD(XMM0, Rs);
+      CALL(asm_routines.cdts);
     }
     MOVD_xmm(R(RSCRATCH), XMM0);
   }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -110,6 +110,7 @@ void Jit64::stfXXX(UGeckoInstruction inst)
       RCOpArg Rs = fpr.Use(s, RCMode::Read);
       RegCache::Realize(Rs);
       CVTSD2SS(XMM0, Rs);
+      MOVD_xmm(R(RSCRATCH), XMM0);
     }
     else
     {
@@ -118,7 +119,6 @@ void Jit64::stfXXX(UGeckoInstruction inst)
       MOVAPD(XMM0, Rs);
       CALL(asm_routines.cdts);
     }
-    MOVD_xmm(R(RSCRATCH), XMM0);
   }
   else
   {

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -50,8 +50,8 @@ alignas(16) static const __m128i double_bottom_bits = _mm_set_epi64x(0, 0x07ffff
 
 void CommonAsmRoutines::GenConvertDoubleToSingle()
 {
-  // Input in XMM0, output to XMM0
-  // Clobbers RSCRATCH/RSCRATCH2/XMM1
+  // Input in XMM0, output to RSCRATCH
+  // Clobbers RSCRATCH/RSCRATCH2/XMM0/XMM1
 
   const void* start = GetCodePtr();
 
@@ -79,6 +79,7 @@ void CommonAsmRoutines::GenConvertDoubleToSingle()
 
   // OR them togther
   POR(XMM0, R(XMM1));
+  MOVD_xmm(R(RSCRATCH), XMM0);
   RET();
 
   // Denormalise
@@ -95,13 +96,13 @@ void CommonAsmRoutines::GenConvertDoubleToSingle()
 
   // fraction >> shift
   PSRLQ(XMM0, R(XMM1));
+  MOVD_xmm(R(RSCRATCH), XMM0);
 
   // OR the sign bit in.
   SHR(64, R(RSCRATCH2), Imm8(32));
   AND(32, R(RSCRATCH2), Imm32(0x80000000));
-  MOVQ_xmm(XMM1, R(RSCRATCH2));
 
-  POR(XMM0, R(XMM1));
+  OR(32, R(RSCRATCH), R(RSCRATCH2));
   RET();
 
   JitRegister::Register(start, GetCodePtr(), "JIT_cdts");

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.h
@@ -31,6 +31,7 @@ public:
   void GenMfcr();
 
 protected:
+  void GenConvertDoubleToSingle();
   const u8* GenQuantizedLoadRuntime(bool single, EQuantizeType type);
   const u8* GenQuantizedStoreRuntime(bool single, EQuantizeType type);
   void GenQuantizedLoads();

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -25,6 +25,7 @@ struct CommonAsmRoutinesBase
   const u8* frsqrte;
   const u8* fres;
   const u8* mfcr;
+  const u8* cdts;
 
   // In: array index: GQR to use.
   // In: ECX: Address to read from.

--- a/Source/UnitTests/Core/CMakeLists.txt
+++ b/Source/UnitTests/Core/CMakeLists.txt
@@ -15,5 +15,8 @@ add_dolphin_test(ESFormatsTest IOS/ES/FormatsTest.cpp IOS/ES/TestBinaryData.cpp)
 add_dolphin_test(FileSystemTest IOS/FS/FileSystemTest.cpp)
 
 if(_M_X86)
-  add_dolphin_test(PowerPCTest PowerPC/Jit64Common/Frsqrte.cpp)
+  add_dolphin_test(PowerPCTest
+    PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
+    PowerPC/Jit64Common/Frsqrte.cpp
+  )
 endif()

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
@@ -1,15 +1,15 @@
-// Copyright 2018 Dolphin Emulator Project
+// Copyright 2019 Dolphin Emulator Project
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <tuple>
 #include <vector>
 
-#include "Common/BitUtils.h"
 #include "Common/CommonTypes.h"
-#include "Common/FloatUtils.h"
 #include "Common/x64ABI.h"
 #include "Core/PowerPC/Gekko.h"
+#include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
@@ -28,38 +28,32 @@ public:
     AllocCodeSpace(4096);
     m_const_pool.Init(AllocChildCodeSpace(1024), 1024);
 
-    const auto raw_frsqrte = reinterpret_cast<double (*)(double)>(AlignCode4());
-    GenFrsqrte();
+    const auto raw_cdts = reinterpret_cast<double (*)(double)>(AlignCode4());
+    GenConvertDoubleToSingle();
 
-    wrapped_frsqrte = reinterpret_cast<u64 (*)(u64, UReg_FPSCR&)>(AlignCode4());
+    wrapped_cdts = reinterpret_cast<u32 (*)(u64)>(AlignCode4());
     ABI_PushRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
-
-    // We know the frsqrte implementation only accesses the fpscr. We manufacture a
-    // PPCSTATE pointer so we read/write to our provided fpscr argument instead.
-    XOR(32, R(RPPCSTATE), R(RPPCSTATE));
-    LEA(64, RSCRATCH, PPCSTATE(fpscr));
-    SUB(64, R(ABI_PARAM2), R(RSCRATCH));
-    MOV(64, R(RPPCSTATE), R(ABI_PARAM2));
 
     // Call
     MOVQ_xmm(XMM0, R(ABI_PARAM1));
-    ABI_CallFunction(raw_frsqrte);
+    ABI_CallFunction(raw_cdts);
     MOVQ_xmm(R(ABI_RETURN), XMM0);
 
     ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
     RET();
   }
 
-  u64 (*wrapped_frsqrte)(u64, UReg_FPSCR&);
+  u32 (*wrapped_cdts)(u64);
   Jit64 jit;
 };
 }  // namespace
 
-TEST(Jit64, Frsqrte)
+TEST(Jit64, ConvertDoubleToSingle)
 {
   TestCommonAsmRoutines routines;
 
-  const std::vector<u64> special_values{
+  const std::vector<u64> input_values{
+      // Special values
       0x0000'0000'0000'0000,  // positive zero
       0x0000'0000'0000'0001,  // smallest positive denormal
       0x0000'0000'0100'0000,
@@ -86,19 +80,36 @@ TEST(Jit64, Frsqrte)
       0xFFF7'FFFF'FFFF'FFFF,  // last negative SNaN
       0xFFF8'0000'0000'0000,  // first negative QNaN
       0xFFFF'FFFF'FFFF'FFFF,  // last negative QNaN
+
+      // (exp > 896) Boundary Case
+      0x3800'0000'0000'0000,  // 2^(-127) = Denormal in single-prec
+      0x3810'0000'0000'0000,  // 2^(-126) = Smallest single-prec normal
+      0xB800'0000'0000'0000,  // -2^(-127) = Denormal in single-prec
+      0xB810'0000'0000'0000,  // -2^(-126) = Smallest single-prec normal
+      0x3800'1234'5678'9ABC, 0x3810'1234'5678'9ABC, 0xB800'1234'5678'9ABC, 0xB810'1234'5678'9ABC,
+
+      // (exp >= 874) Boundary Case
+      0x3680'0000'0000'0000,  // 2^(-150) = Unrepresentable in single-prec
+      0x36A0'0000'0000'0000,  // 2^(-149) = Smallest single-prec denormal
+      0x36B0'0000'0000'0000,  // 2^(-148) = Single-prec denormal
+      0xB680'0000'0000'0000,  // -2^(-150) = Unrepresentable in single-prec
+      0xB6A0'0000'0000'0000,  // -2^(-149) = Smallest single-prec denormal
+      0xB6B0'0000'0000'0000,  // -2^(-148) = Single-prec denormal
+      0x3680'1234'5678'9ABC, 0x36A0'1234'5678'9ABC, 0x36B0'1234'5678'9ABC, 0xB680'1234'5678'9ABC,
+      0xB6A0'1234'5678'9ABC, 0xB6B0'1234'5678'9ABC,
+
+      // Some typical numbers
+      0x3FF8'0000'0000'0000,  // 1.5
+      0x408F'4000'0000'0000,  // 1000
+      0xC008'0000'0000'0000,  // -3
   };
 
-  UReg_FPSCR fpscr;
-
-  for (u64 ivalue : special_values)
+  for (const u64 input : input_values)
   {
-    double dvalue = Common::BitCast<double>(ivalue);
+    const u32 expected = ConvertToSingle(input);
+    const u32 actual = routines.wrapped_cdts(input);
 
-    u64 expected = Common::BitCast<u64>(Common::ApproximateReciprocalSquareRoot(dvalue));
-
-    u64 actual = routines.wrapped_frsqrte(ivalue, fpscr);
-
-    printf("%016llx -> %016llx == %016llx\n", ivalue, actual, expected);
+    printf("%016llx -> %08x == %08x\n", input, actual, expected);
 
     EXPECT_EQ(expected, actual);
   }

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
@@ -37,7 +37,7 @@ public:
     // Call
     MOVQ_xmm(XMM0, R(ABI_PARAM1));
     ABI_CallFunction(raw_cdts);
-    MOVQ_xmm(R(ABI_RETURN), XMM0);
+    MOV(32, R(ABI_RETURN), R(RSCRATCH));
 
     ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
     RET();


### PR DESCRIPTION
Apologies, @booto, there were bugs in the assembly I hastily wrote in #8111.

Decided to write a unit-test to test the generated code to ensure correctness.

Also decided to add ee0b678 to use the (obvious?) BMI2 instruction.