### PR TITLE
WIP: FrameDump: Multiple Upgrades, Reimplement API, Proper VFR, CFR and TAS Support

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -46,7 +46,7 @@ const ConfigInfo<bool> GFX_DUMP_FRAMES_AS_IMAGES{{System::GFX, "Settings", "Dump
                                                  false};
 const ConfigInfo<bool> GFX_FREE_LOOK{{System::GFX, "Settings", "FreeLook"}, false};
 const ConfigInfo<bool> GFX_USE_FFV1{{System::GFX, "Settings", "UseFFV1"}, false};
-const ConfigInfo<std::string> GFX_DUMP_FORMAT{{System::GFX, "Settings", "DumpFormat"}, "avi"};
+const ConfigInfo<std::string> GFX_DUMP_FORMAT{{System::GFX, "Settings", "DumpFormat"}, "ts"};
 const ConfigInfo<std::string> GFX_DUMP_CODEC{{System::GFX, "Settings", "DumpCodec"}, ""};
 const ConfigInfo<std::string> GFX_DUMP_ENCODER{{System::GFX, "Settings", "DumpEncoder"}, ""};
 const ConfigInfo<std::string> GFX_DUMP_PATH{{System::GFX, "Settings", "DumpPath"}, ""};


### PR DESCRIPTION
The FFmpeg external has to be updated for any of this to actually work on Windows. Currently it is not certain yet what kind of FFmpeg integration will be chosen, it's up to the community, I have initially provided the static method here #8123 while the other delayed-dynamic method is here #7110 

There is also a testing branch with all the dependent commits combined: https://github.com/altimumdelta/dolphin/tree/FrameDumpUpgradeCOMB
Which I'll keep up to date as development continues.

---
## Framedump Improvements Checklist

### Merged PRs:
- [x] #8128 - Code Refactor: Rename AVIDump to FrameDump
- [x] #9182 - FrameDump Fixes & Cleanup

### Merged Improvements:
- #9182 - Changes to frame dump timing code ("PTS code")
- #9182 - Output filename format standardized with the one used by screenshots (GAMEID + Timestamp), while the original timestamp from when the frame dump was manually started will be preserved,during automatic splits.
- #9182 - Framedump will now create a new file (restart) on VI refresh-rate change and savestate load
 

### PRs Pending Review:
- [ ] #9188 - FrameDump: Remove code for older versions of libavcodec

### PRs Ready To Merge:
- nothing yet


### Work In Progress (altimumdelta):
- [ ] Error messaging standardization

### Long-term ToDo Overview:
- [ ] Support different codec/container combinations separately, with their own defaults/configs.
- [ ] more to be added as development continues


----

## Variable frame rate (VFR) and video editor compatability support - MPEG-TS / Matroska

Similarly to the recent FFV1 BGRA->BRG0 patch tackling inoptimal output, the AVI container format it self is not optimal since it doesn't really support variable frame rate (VFR) and may lead to compatability and playback issues if there are any frame rate changes during dumping. It is possible only with hacks and those create a non-standard AVI file. The initial purpose of this PR was to support it if it does happen during the existing method of correcting for game-speed, not that the dump output has to be the same as original game-speed (variable FPS) according to performance, but with such support the original behavior can be dumped optionally for some other purpose, possibly testing and troubleshooting. 

If there were any hacks done within Dolphin to compensate for AVI limitations then those would need to be looked at, and probably removed. I'm merely speculating right now as I'm not sure if any of them exist at this moment, it does seem to work fine as is.

Optimally I chose Matroska as the container format which is actually designed for VFR and suitable for flexibility within Dolphin, with multiple encoders, in case more get added later as well (possibly even GPU Accelleration, etc).  

However Matroska still isn't supported as much with video editing softwares, but thankfully MPEG-TS, another container supporting VFR, is and it works right there in Adobe Premiere Pro CC 2019 along with Premiere's VFR support which was added back in 2018 https://www.premierebro.com/blog/premiere-pro-1201-update-variable-frame-rate-and-new-features

![FrameDump_MPEG-TS_AdobePremiereProCC2019](https://user-images.githubusercontent.com/48530820/58389392-7c114880-802a-11e9-94f1-c16926fdb9df.png)

However this is where the good news ends, MPEG-TS isn't as flexible in terms of codec support as Matroska is, which means FFV1 can't be used with it, it will need it's own defaults, and it makes things a bit more complicated for this PR than I initially estimated.

## TAS Videos Support - AVI

In addition, because there is also TAS videos which have their own specific need this will be a more dynamic solution which would satisfy multiple use cases, so AVI support will be kept no matter what for those that rely on it.

---

## Future Thoughts

One of the possible proper solutions is to simply defer encoding, so it doesn't need to encode in real-time and at full speed, including that the ffmpeg's/encoder's encoding threads shouldn't be allowed on the same CPU core-s which Dolphin's threads already occupy, but that depends on Dolphin's threads actually sticking to their own CPU core's as well (not just logical, but physical). Also the thread affinity separation could only be used when Dolphin is actually framedumping.

https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Common/Thread.cpp#L43

Furthermore it would also help to look at the ffmpeg and encoders them selfs for any already built-in throttling capabilities. And, any ideas if the throttling should be done on the externals outside this project or can/should it be done within Dolphin?

Such a solution would require additional storage space to save a temporary recording file, the deferr does not need to be absolute, meaning that it only starts encoding after the user is finished recording, but that it does encode at a certain speed and behavior (explained above) that does not slow Dolphin down, which can be used to help keep down the size of the temporary file as the old unnecessary frames which were already encoded can be deleted regularly (in batches, easier on FS).