### PR TITLE
DX11: Fix access violation on closing dolphin

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -133,6 +133,7 @@ void Destroy()
   context->ClearState();
   context->Flush();
 
+  dxgi_factory.Reset();
   context.Reset();
   device1.Reset();
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -111,7 +111,9 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   {
     PanicAlertT(
         "Failed to initialize Direct3D.\nMake sure your video card supports at least D3D 10.0");
+    dxgi_factory.Reset();
     D3DCommon::UnloadLibraries();
+    s_d3d11_library.Close();
     return false;
   }
 
@@ -133,7 +135,6 @@ void Destroy()
   context->ClearState();
   context->Flush();
 
-  dxgi_factory.Reset();
   context.Reset();
   device1.Reset();
 
@@ -156,6 +157,7 @@ void Destroy()
   else
     NOTICE_LOG(VIDEO, "Successfully released all device references!");
 
+  dxgi_factory.Reset();
   D3DCommon::UnloadLibraries();
   s_d3d11_library.Close();
 }


### PR DESCRIPTION
`DX11::D3D::Destroy()` did not reset `dxgi_factory`.  This causes (at least for me) crashes when exiting dolphin, which could be reproduced by simply starting while using DX11 and then closing dolphin (the crash happens on exit, regardless as to whether the game is allowed to stop normally or force-stopped).  DX12 was not affected.

[Here are some stacktraces from this issue](https://gist.github.com/Pokechu22/a6baf863f91f2f97bfb4c5ee1962e922).

I've tested this both off of the current master (f92c17e76f2bf07de270c0998c901777192348e3) and off of #8096 rebased off of master (I can only use my actual card with #8096, but this issue also happened with the microsoft basic render driver which works without it).