### PR TITLE
Common/HttpRequest: Minor changes and simplifications

### DIFF
--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -49,7 +49,7 @@ std::mutex HttpRequest::Impl::s_curl_was_inited_mutex;
 bool HttpRequest::Impl::s_curl_was_inited = false;
 
 HttpRequest::HttpRequest(std::chrono::milliseconds timeout_ms, ProgressCallback callback)
-    : m_impl(std::make_unique<Impl>(timeout_ms, callback))
+    : m_impl(std::make_unique<Impl>(timeout_ms, std::move(callback)))
 {
 }
 
@@ -107,7 +107,7 @@ int HttpRequest::Impl::CurlProgressCallback(Impl* impl, double dlnow, double dlt
 }
 
 HttpRequest::Impl::Impl(std::chrono::milliseconds timeout_ms, ProgressCallback callback)
-    : m_callback(callback)
+    : m_callback(std::move(callback))
 {
   {
     std::lock_guard<std::mutex> lk(s_curl_was_inited_mutex);

--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -197,14 +197,14 @@ HttpRequest::Response HttpRequest::Impl::Fetch(const std::string& url, Method me
 
   curl_slist* list = nullptr;
   Common::ScopeGuard list_guard{[&list] { curl_slist_free_all(list); }};
-  for (const std::pair<std::string, std::optional<std::string>>& header : headers)
+  for (const auto& [name, value] : headers)
   {
-    if (!header.second)
-      list = curl_slist_append(list, (header.first + ":").c_str());
-    else if (header.second->empty())
-      list = curl_slist_append(list, (header.first + ";").c_str());
+    if (!value)
+      list = curl_slist_append(list, (name + ':').c_str());
+    else if (value->empty())
+      list = curl_slist_append(list, (name + ';').c_str());
     else
-      list = curl_slist_append(list, (header.first + ": " + *header.second).c_str());
+      list = curl_slist_append(list, (name + ": " + *value).c_str());
   }
   curl_easy_setopt(m_curl.get(), CURLOPT_HTTPHEADER, list);
 


### PR DESCRIPTION
Just three minor changes. Mostly trivial avoidance of unnecessary copies, and simplifying of cURL's global initialization. Instead of managing the initialization and flags ourselves, we can kick it off to `std::call_once` to do that for us.