### PR TITLE
Core/GCMemcard: Remove obsolete TODO

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -20,9 +20,6 @@
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
 
-// TODO: Remove when on C++17 everywhere.
-constexpr std::array<u8, 4> DEntry::UNINITIALIZED_GAMECODE;
-
 static void ByteSwap(u8* valueA, u8* valueB)
 {
   u8 tmp = *valueA;


### PR DESCRIPTION
Now that we assume C++17, the in-file definition of the std::array can be removed. This is all that's necessary, as constexpr used on a static member variable implies inline (and so, automatically has C++17's static inline behavior).