### PR TITLE
UICommon/ResourcePack: Minor cleanup

### DIFF
--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -143,8 +143,6 @@ bool Remove(ResourcePack& pack)
   if (pack_iterator == packs.end())
     return false;
 
-  std::string filename;
-
   IniFile file = GetPackConfig();
 
   auto* order = file.GetOrCreateSection("Order");

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -197,9 +197,9 @@ bool ResourcePack::Install(const std::string& path)
       return false;
     }
 
+    const std::string texture_path = path + TEXTURE_PATH + texture;
     std::string m_full_dir;
-
-    SplitPath(path + TEXTURE_PATH + texture, &m_full_dir, nullptr, nullptr);
+    SplitPath(texture_path, &m_full_dir, nullptr, nullptr);
 
     if (!File::CreateFullPath(m_full_dir))
     {
@@ -217,7 +217,7 @@ bool ResourcePack::Install(const std::string& path)
       return false;
     }
 
-    std::ofstream out(path + TEXTURE_PATH + texture, std::ios::trunc | std::ios::binary);
+    std::ofstream out(texture_path, std::ios::trunc | std::ios::binary);
 
     if (!out.good())
     {
@@ -284,7 +284,8 @@ bool ResourcePack::Uninstall(const std::string& path)
     if (provided_by_other_pack)
       continue;
 
-    if (File::Exists(path + TEXTURE_PATH + texture) && !File::Delete(path + TEXTURE_PATH + texture))
+    const std::string texture_path = path + TEXTURE_PATH + texture;
+    if (File::Exists(texture_path) && !File::Delete(texture_path))
     {
       m_error = "Failed to delete texture " + texture;
       return false;
@@ -293,8 +294,7 @@ bool ResourcePack::Uninstall(const std::string& path)
     // Recursively delete empty directories
 
     std::string dir;
-
-    SplitPath(path + TEXTURE_PATH + texture, &dir, nullptr, nullptr);
+    SplitPath(texture_path, &dir, nullptr, nullptr);
 
     while (dir.length() > (path + TEXTURE_PATH).length())
     {

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -68,13 +68,9 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
   }
 
   unz_file_info manifest_info;
-
   unzGetCurrentFileInfo(file, &manifest_info, nullptr, 0, nullptr, 0, nullptr, 0);
 
-  std::vector<char> manifest_contents;
-
-  manifest_contents.resize(manifest_info.uncompressed_size);
-
+  std::vector<char> manifest_contents(manifest_info.uncompressed_size);
   if (!ReadCurrentFileUnlimited(file, manifest_contents))
   {
     m_valid = false;
@@ -114,13 +110,10 @@ ResourcePack::ResourcePack(const std::string& path) : m_path(path)
 
   do
   {
-    std::string filename;
-
-    filename.resize(256);
+    std::string filename(256, '\0');
 
     unz_file_info texture_info;
-
-    unzGetCurrentFileInfo(file, &texture_info, &filename[0], static_cast<uint16_t>(filename.size()),
+    unzGetCurrentFileInfo(file, &texture_info, filename.data(), static_cast<u16>(filename.size()),
                           nullptr, 0, nullptr, 0);
 
     if (filename.compare(0, 9, "textures/") != 0 || texture_info.uncompressed_size == 0)
@@ -215,12 +208,9 @@ bool ResourcePack::Install(const std::string& path)
     }
 
     unz_file_info texture_info;
-
     unzGetCurrentFileInfo(file, &texture_info, nullptr, 0, nullptr, 0, nullptr, 0);
 
-    std::vector<char> data;
-    data.resize(texture_info.uncompressed_size);
-
+    std::vector<char> data(texture_info.uncompressed_size);
     if (!ReadCurrentFileUnlimited(file, data))
     {
       m_error = "Failed to read texture " + texture;

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -15,10 +15,10 @@
 #include "UICommon/ResourcePack/Manager.h"
 #include "UICommon/ResourcePack/Manifest.h"
 
-static const char* TEXTURE_PATH = "Load/Textures/";
-
 namespace ResourcePack
 {
+constexpr char TEXTURE_PATH[] = "Load/Textures/";
+
 // Since minzip doesn't provide a way to unzip a file of a length > 65535, we have to implement
 // this ourselves
 static bool ReadCurrentFileUnlimited(unzFile file, std::vector<char>& destination)


### PR DESCRIPTION
Just performs some basic cleanups. Notably, the use of scope guards avoids resource leaks due to the file opened with unzOpen not having unzClose called on it in the failure paths. Also removes an unused variable in the closely related manager class.