### PR TITLE
UICommon/ResourcePack/Manager: Resolve use-after-move in Add()

### DIFF
--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -128,7 +128,7 @@ bool Add(const std::string& path, int offset)
 
   packs.insert(packs.begin() + offset, std::move(pack));
 
-  return pack.IsValid();
+  return true;
 }
 
 bool Remove(ResourcePack& pack)


### PR DESCRIPTION
The pack is already has its validity checked at the beginning of the function, so we don't need to check this again after inserting it.

Also resolves a use-after-move case.