### PR TITLE
Common/FileUtil: Use std::string_view with WriteStringToFile

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -887,7 +887,7 @@ std::string GetThemeDir(const std::string& theme_name)
   return GetSysDirectory() + THEMES_DIR "/" DEFAULT_THEME_DIR "/";
 }
 
-bool WriteStringToFile(const std::string& str, const std::string& filename)
+bool WriteStringToFile(const std::string& filename, const std::string& str)
 {
   return File::IOFile(filename, "wb").WriteBytes(str.data(), str.size());
 }

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -887,7 +887,7 @@ std::string GetThemeDir(const std::string& theme_name)
   return GetSysDirectory() + THEMES_DIR "/" DEFAULT_THEME_DIR "/";
 }
 
-bool WriteStringToFile(const std::string& filename, const std::string& str)
+bool WriteStringToFile(const std::string& filename, std::string_view str)
 {
   return File::IOFile(filename, "wb").WriteBytes(str.data(), str.size());
 }

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -900,7 +900,7 @@ bool ReadFileToString(const std::string& filename, std::string& str)
     return false;
 
   str.resize(file.GetSize());
-  return file.ReadArray(&str[0], str.size());
+  return file.ReadArray(str.data(), str.size());
 }
 
 }  // namespace File

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <fstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <sys/stat.h>
@@ -198,7 +199,7 @@ std::string GetBundleDirectory();
 std::string GetExePath();
 std::string GetExeDirectory();
 
-bool WriteStringToFile(const std::string& filename, const std::string& str);
+bool WriteStringToFile(const std::string& filename, std::string_view str);
 bool ReadFileToString(const std::string& filename, std::string& str);
 
 // To deal with Windows being dumb at unicode:

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -198,7 +198,7 @@ std::string GetBundleDirectory();
 std::string GetExePath();
 std::string GetExeDirectory();
 
-bool WriteStringToFile(const std::string& str, const std::string& filename);
+bool WriteStringToFile(const std::string& filename, const std::string& str);
 bool ReadFileToString(const std::string& filename, std::string& str);
 
 // To deal with Windows being dumb at unicode:

--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -141,7 +141,7 @@ bool SaveBinary(const std::vector<u16>& code, const std::string& filename)
 {
   const std::string buffer = CodeToBinaryStringBE(code);
 
-  return File::WriteStringToFile(buffer, filename);
+  return File::WriteStringToFile(filename, buffer);
 }
 
 bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc)
@@ -166,7 +166,7 @@ bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc)
   if (!Disassemble(code, true, text))
     return false;
 
-  return File::WriteStringToFile(text, text_file);
+  return File::WriteStringToFile(text_file, text);
 }
 
 }  // namespace DSP

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -265,7 +265,7 @@ void GameFile::DownloadDefaultCover()
   if (!response)
     return;
 
-  File::WriteStringToFile(std::string(response->begin(), response->end()), png_path);
+  File::WriteStringToFile(png_path, std::string(response->begin(), response->end()));
 }
 
 bool GameFile::DefaultCoverChanged()

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -255,7 +255,7 @@ bool DownloadContent(const std::vector<TodoList::DownloadOp>& to_download,
     std::optional<std::string> maybe_decompressed = GzipInflate(contents);
     if (!maybe_decompressed)
       return false;
-    std::string decompressed = std::move(*maybe_decompressed);
+    const std::string decompressed = std::move(*maybe_decompressed);
 
     // Check that the downloaded contents have the right hash.
     Manifest::Hash contents_hash = ComputeHash(decompressed);
@@ -265,8 +265,8 @@ bool DownloadContent(const std::vector<TodoList::DownloadOp>& to_download,
       return false;
     }
 
-    std::string out = temp_path + DIR_SEP + hash_filename;
-    if (!File::WriteStringToFile(decompressed, out))
+    const std::string out = temp_path + DIR_SEP + hash_filename;
+    if (!File::WriteStringToFile(out, decompressed))
     {
       fprintf(log_fp, "Could not write cache file %s.\n", out.c_str());
       return false;

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -217,7 +217,7 @@ static void PrintResults(const std::string& input_name, const std::string& outpu
   if (output_name.empty())
     printf("%s", results.c_str());
   else
-    File::WriteStringToFile(results, output_name.c_str());
+    File::WriteStringToFile(output_name, results);
 }
 
 static bool PerformDisassembly(const std::string& input_name, const std::string& output_name)
@@ -237,7 +237,7 @@ static bool PerformDisassembly(const std::string& input_name, const std::string&
   if (output_name.empty())
     printf("%s", text.c_str());
   else
-    File::WriteStringToFile(text, output_name);
+    File::WriteStringToFile(output_name, text);
 
   printf("Disassembly completed successfully!\n");
   return true;
@@ -314,7 +314,7 @@ static bool PerformAssembly(const std::string& input_name, const std::string& ou
       }
 
       const std::string header = CodesToHeader(codes, files);
-      File::WriteStringToFile(header, output_header_name + ".h");
+      File::WriteStringToFile(output_header_name + ".h", header);
     }
     else
     {
@@ -334,12 +334,12 @@ static bool PerformAssembly(const std::string& input_name, const std::string& ou
       if (!output_name.empty())
       {
         const std::string binary_code = DSP::CodeToBinaryStringBE(code);
-        File::WriteStringToFile(binary_code, output_name);
+        File::WriteStringToFile(output_name, binary_code);
       }
       if (!output_header_name.empty())
       {
         const std::string header = CodeToHeader(code, input_name);
-        File::WriteStringToFile(header, output_header_name + ".h");
+        File::WriteStringToFile(output_header_name + ".h", header);
       }
     }
   }


### PR DESCRIPTION
Allows writing out all main string types in a potentially non-allocating manner. e.g. C-strings can now be passed to the function without allocating a std::string copy of the string.

While we're at it, we can also make the parameter ordering the same as ReadFileToString for consistency.