### PR TITLE
x64Emitter: Emit shorter MOVs for 32-bit immediates

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -1591,8 +1591,9 @@ void XEmitter::XOR(int bits, const OpArg& a1, const OpArg& a2)
 }
 void XEmitter::MOV(int bits, const OpArg& a1, const OpArg& a2)
 {
-  if (bits == 64 && a1.IsSimpleReg() && a2.scale == SCALE_IMM64 &&
-      a2.offset == static_cast<u32>(a2.offset))
+  if (bits == 64 && a1.IsSimpleReg() &&
+      ((a2.scale == SCALE_IMM64 && a2.offset == static_cast<u32>(a2.offset)) ||
+       (a2.scale == SCALE_IMM32 && static_cast<s32>(a2.offset) >= 0)))
   {
     WriteNormalOp(32, NormalOp::MOV, a1, a2.AsImm32());
     return;

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -554,7 +554,7 @@ TWO_OP_ARITH_TEST(OR)
 TWO_OP_ARITH_TEST(XOR)
 TWO_OP_ARITH_TEST(MOV)
 
-TEST_F(x64EmitterTest, MOV_Imm64)
+TEST_F(x64EmitterTest, MOV64)
 {
   for (size_t i = 0; i < reg64names.size(); i++)
   {
@@ -569,6 +569,10 @@ TEST_F(x64EmitterTest, MOV_Imm64)
     emitter->MOV(64, R(reg64names[i].reg), Imm64(0xDEADBEEF));
     EXPECT_EQ(emitter->GetCodePtr(), code_buffer + 5 + (i > 7));
     ExpectDisassembly("mov " + reg32names[i].name + ", 0xdeadbeef");
+
+    emitter->MOV(64, R(reg64names[i].reg), Imm32(0x7FFFFFFF));
+    EXPECT_EQ(emitter->GetCodePtr(), code_buffer + 5 + (i > 7));
+    ExpectDisassembly("mov " + reg32names[i].name + ", 0x7fffffff");
   }
 }
 


### PR DESCRIPTION
Expands what we did in #7414 so it works for 32-bit immediates as well. We can emit a shorter 32-bit instruction for 32-bit immediates in [0, 0x7FFFFFFF]. 
We hit this in [cmpXX](https://github.com/dolphin-emu/dolphin/blob/2abe333ce94f63971cbee8ea51b22d1df4456ad4/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp#L565), and possibly some other places too.

Before:
```
0:  48 c7 c0 ff ff ff 7f    mov    rax,0x7fffffff
```
After:
```
0:  b8 ff ff ff 7f          mov    eax,0x7fffffff
```