### PR TITLE
CMakeLists: Specify header files in target sources

### DIFF
--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -1,18 +1,29 @@
 add_library(audiocommon
   AudioCommon.cpp
+  AudioCommon.h
   AudioStretcher.cpp
+  AudioStretcher.h
   CubebStream.cpp
+  CubebStream.h
   CubebUtils.cpp
+  CubebUtils.h
   Mixer.cpp
+  Mixer.h
   SurroundDecoder.cpp
+  SurroundDecoder.h
   NullSoundStream.cpp
+  NullSoundStream.h
   WaveFile.cpp
+  WaveFile.h
 )
 
 find_package(OpenSLES)
 if(OPENSLES_FOUND)
   message(STATUS "OpenSLES found, enabling OpenSLES sound backend")
-  target_sources(audiocommon PRIVATE OpenSLESStream.cpp)
+  target_sources(audiocommon PRIVATE
+    OpenSLESStream.cpp
+    OpenSLESStream.h
+  )
   target_link_libraries(audiocommon PRIVATE OpenSLES::OpenSLES)
 endif()
 
@@ -20,7 +31,10 @@ if(ENABLE_ALSA)
   find_package(ALSA)
   if(ALSA_FOUND)
     message(STATUS "ALSA found, enabling ALSA sound backend")
-    target_sources(audiocommon PRIVATE AlsaSoundStream.cpp)
+    target_sources(audiocommon PRIVATE
+      AlsaSoundStream.cpp
+      AlsaSoundStream.h
+    )
     target_link_libraries(audiocommon PRIVATE ALSA::ALSA)
     target_compile_definitions(audiocommon PRIVATE HAVE_ALSA=1)
   else()
@@ -36,7 +50,10 @@ if(ENABLE_PULSEAUDIO)
   find_package(PulseAudio MODULE QUIET)
   if(PULSEAUDIO_FOUND)
     message(STATUS "PulseAudio found, enabling PulseAudio sound backend")
-    target_sources(audiocommon PRIVATE PulseAudioStream.cpp)
+    target_sources(audiocommon PRIVATE
+      PulseAudioStream.cpp
+      PulseAudioStream.h
+    )
     target_link_libraries(audiocommon PRIVATE PulseAudio::PulseAudio)
     target_compile_definitions(audiocommon PRIVATE HAVE_PULSEAUDIO=1)
   else()
@@ -47,18 +64,26 @@ else()
 endif()
 
 if(WIN32)
-  target_sources(audiocommon PRIVATE WASAPIStream.cpp)
-  target_sources(audiocommon PRIVATE XAudio2Stream.cpp)
+  target_sources(audiocommon PRIVATE
+    # Dolphin loads openal32.dll at runtime
+    OpenALStream.cpp
+    OpenALStream.h
 
-  add_library(audiocommon_xaudio27 "XAudio2_7Stream.cpp")
+    WASAPIStream.cpp
+    WASAPIStream.h
+    XAudio2Stream.cpp
+    XAudio2Stream.h
+  )
+
+  add_library(audiocommon_xaudio27
+    XAudio2_7Stream.cpp
+    XAudio2_7Stream.h
+  )
   target_include_directories(audiocommon_xaudio27 PRIVATE
     ${PROJECT_SOURCE_DIR}/Externals
     ${PROJECT_SOURCE_DIR}/Externals/XAudio2_7
   )
   target_link_libraries(audiocommon PRIVATE audiocommon_xaudio27)
-
-  # Dolphin loads openal32.dll at runtime
-  target_sources(audiocommon PRIVATE OpenALStream.cpp)
 endif()
 
 target_link_libraries(audiocommon PRIVATE cubeb SoundTouch FreeSurround)

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -1,52 +1,131 @@
 add_library(common
   Analytics.cpp
+  Analytics.h
+  Assert.h
+  Atomic.h
+  BitField.h
+  BitSet.h
+  BitUtils.h
+  BlockingLoop.h
   CDUtils.cpp
+  CDUtils.h
+  ChunkFile.h
+  CodeBlock.h
   ColorUtil.cpp
+  ColorUtil.h
+  Common.h
   CommonFuncs.cpp
+  CommonFuncs.h
+  CommonPaths.h
+  CommonTypes.h
+  Compiler.h
   Config/Config.cpp
+  Config/Config.h
   Config/ConfigInfo.cpp
+  Config/ConfigInfo.h
+  Config/Enums.h
   Config/Layer.cpp
+  Config/Layer.h
+  CPUDetect.h
   Crypto/AES.cpp
+  Crypto/AES.h
   Crypto/bn.cpp
+  Crypto/bn.h
   Crypto/ec.cpp
+  Crypto/ec.h
   Debug/MemoryPatches.cpp
+  Debug/MemoryPatches.h
   Debug/Watches.cpp
+  Debug/Watches.h
+  DebugInterface.h
   DynamicLibrary.cpp
+  DynamicLibrary.h
   ENetUtil.cpp
+  ENetUtil.h
+  Event.h
   File.cpp
+  File.h
   FileSearch.cpp
+  FileSearch.h
   FileUtil.cpp
+  FileUtil.h
+  FixedSizeQueue.h
+  Flag.h
   FloatUtils.cpp
+  FloatUtils.h
+  FPURoundMode.h
   GekkoDisassembler.cpp
+  GekkoDisassembler.h
   Hash.cpp
+  Hash.h
   HttpRequest.cpp
+  HttpRequest.h
   Image.cpp
+  Image.h
   IniFile.cpp
+  IniFile.h
   JitRegister.cpp
+  JitRegister.h
+  Lazy.h
+  LinearDiskCache.h
+  Logging/ConsoleListener.h
+  Logging/Log.h
   Logging/LogManager.cpp
+  Logging/LogManager.h
   MathUtil.cpp
+  MathUtil.h
   Matrix.cpp
+  Matrix.h
   MD5.cpp
+  MD5.h
   MemArena.cpp
+  MemArena.h
   MemoryUtil.cpp
+  MemoryUtil.h
   MsgHandler.cpp
+  MsgHandler.h
   NandPaths.cpp
+  NandPaths.h
   Network.cpp
+  Network.h
   PcapFile.cpp
+  PcapFile.h
   PerformanceCounter.cpp
+  PerformanceCounter.h
   Profiler.cpp
+  Profiler.h
   QoSSession.cpp
+  QoSSession.h
   Random.cpp
+  Random.h
+  Result.h
+  ScopeGuard.h
   SDCardUtil.cpp
+  SDCardUtil.h
+  Semaphore.h
   SFMLHelper.cpp
+  SFMLHelper.h
   SettingsHandler.cpp
+  SettingsHandler.h
+  SPSCQueue.h
   StringUtil.cpp
+  StringUtil.h
   SymbolDB.cpp
+  SymbolDB.h
   Thread.cpp
+  Thread.h
   Timer.cpp
+  Timer.h
   TraversalClient.cpp
+  TraversalClient.h
+  TraversalProto.h
   UPnP.cpp
+  UPnP.h
+  VariantUtil.h
   Version.cpp
+  Version.h
+  WindowSystemInfo.h
+  WorkQueueThread.h
 )
 
 target_link_libraries(common
@@ -82,11 +161,13 @@ endif()
 if(ANDROID)
   target_sources(common PRIVATE
     AndroidAnalytics.cpp
+    AndroidAnalytics.h
     Logging/ConsoleListenerDroid.cpp
   )
 elseif(WIN32)
   target_sources(common PRIVATE
     LdrWatcher.cpp
+    LdrWatcher.h
     Logging/ConsoleListenerWin.cpp
   )
 else()
@@ -98,6 +179,8 @@ endif()
 if(_M_ARM_64)
   target_sources(common PRIVATE
     Arm64Emitter.cpp
+    Arm64Emitter.h
+    ArmCommon.h
     ArmCPUDetect.cpp
     GenericFPURoundMode.cpp
   )
@@ -105,9 +188,12 @@ else()
   if(_M_X86) #X86
     target_sources(common PRIVATE
       x64ABI.cpp
+      x64ABI.h
       x64Emitter.cpp
+      x64Emitter.h
       x64FPURoundMode.cpp
       x64CPUDetect.cpp
+      x64Reg.h
     )
   else() # Generic
     target_sources(common PRIVATE
@@ -119,17 +205,29 @@ endif()
 
 # OpenGL Interface
 target_sources(common PRIVATE
-  GL/GLUtil.cpp
-  GL/GLExtensions/GLExtensions.cpp
   GL/GLContext.cpp
+  GL/GLContext.h
+  GL/GLUtil.cpp
+  GL/GLUtil.h
+  GL/GLExtensions/GLExtensions.cpp
+  GL/GLExtensions/GLExtensions.h
 )
 
 if(ENABLE_EGL AND EGL_FOUND)
-  target_sources(common PRIVATE GL/GLInterface/EGL.cpp)
+  target_sources(common PRIVATE
+    GL/GLInterface/EGL.cpp
+    GL/GLInterface/EGL.h
+  )
   if(ANDROID)
-    target_sources(common PRIVATE GL/GLInterface/EGLAndroid.cpp)
+    target_sources(common PRIVATE
+      GL/GLInterface/EGLAndroid.cpp
+      GL/GLInterface/EGLAndroid.h
+    )
   elseif(ENABLE_X11 AND X11_FOUND)
-    target_sources(common PRIVATE GL/GLInterface/EGLX11.cpp)
+    target_sources(common PRIVATE
+      GL/GLInterface/EGLX11.cpp
+      GL/GLInterface/EGLX11.h
+    )
   endif()
   target_include_directories(common PRIVATE ${EGL_INCLUDE_DIRS})
   target_link_libraries(common PUBLIC ${EGL_LIBRARIES})
@@ -139,13 +237,20 @@ if(WIN32)
   target_sources(common PRIVATE
     CompatPatches.cpp
     GL/GLInterface/WGL.cpp
+    GL/GLInterface/WGL.h
   )
 elseif(APPLE)
-  target_sources(common PRIVATE GL/GLInterface/AGL.mm)
+  target_sources(common PRIVATE
+    GL/GLInterface/AGL.h
+    GL/GLInterface/AGL.mm
+  )
 elseif(ENABLE_X11 AND X11_FOUND)
   target_sources(common PRIVATE
     GL/GLX11Window.cpp
-    GL/GLInterface/GLX.cpp)
+    GL/GLX11Window.h
+    GL/GLInterface/GLX.cpp
+    GL/GLInterface/GLX.h
+  )
 
   # GLX has a hard dependency on libGL.
   # Make sure to link to it if using GLX.

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -1,170 +1,339 @@
 add_library(core
   ActionReplay.cpp
+  ActionReplay.h
   Analytics.cpp
+  Analytics.h
   ARDecrypt.cpp
+  ARDecrypt.h
   BootManager.cpp
+  BootManager.h
+  CommonTitles.h
   ConfigManager.cpp
+  ConfigManager.h
   Core.cpp
+  Core.h
   CoreTiming.cpp
+  CoreTiming.h
   DSPEmulator.cpp
+  DSPEmulator.h
   GeckoCodeConfig.cpp
+  GeckoCodeConfig.h
   GeckoCode.cpp
+  GeckoCode.h
+  Host.h
   HotkeyManager.cpp
+  HotkeyManager.h
   LibusbUtils.cpp
+  LibusbUtils.h
   MemTools.cpp
+  MemTools.h
   Movie.cpp
+  Movie.h
   NetPlayClient.cpp
+  NetPlayClient.h
   NetPlayServer.cpp
+  NetPlayServer.h
   PatchEngine.cpp
+  PatchEngine.h
   State.cpp
+  State.h
   SysConf.cpp
+  SysConf.h
   TitleDatabase.cpp
+  TitleDatabase.h
   WiiRoot.cpp
+  WiiRoot.h
   WiiUtils.cpp
+  WiiUtils.h
   Boot/Boot_BS2Emu.cpp
   Boot/Boot.cpp
+  Boot/Boot.h
   Boot/Boot_WiiWAD.cpp
   Boot/DolReader.cpp
+  Boot/DolReader.h
   Boot/ElfReader.cpp
+  Boot/ElfReader.h
+  Boot/ElfTypes.h
   Config/GraphicsSettings.cpp
+  Config/GraphicsSettings.h
   Config/MainSettings.cpp
+  Config/MainSettings.h
   Config/NetplaySettings.cpp
+  Config/NetplaySettings.h
   Config/SYSCONFSettings.cpp
+  Config/SYSCONFSettings.h
   Config/UISettings.cpp
+  Config/UISettings.h
   ConfigLoaders/BaseConfigLoader.cpp
+  ConfigLoaders/BaseConfigLoader.h
   ConfigLoaders/GameConfigLoader.cpp
+  ConfigLoaders/GameConfigLoader.h
   ConfigLoaders/IsSettingSaveable.cpp
+  ConfigLoaders/IsSettingSaveable.h
   ConfigLoaders/MovieConfigLoader.cpp
+  ConfigLoaders/MovieConfigLoader.h
   ConfigLoaders/NetPlayConfigLoader.cpp
+  ConfigLoaders/NetPlayConfigLoader.h
   Debugger/Debugger_SymbolMap.cpp
+  Debugger/Debugger_SymbolMap.h
   Debugger/Dump.cpp
+  Debugger/Dump.h
+  Debugger/GCELF.h
   Debugger/PPCDebugInterface.cpp
+  Debugger/PPCDebugInterface.h
   Debugger/RSO.cpp
+  Debugger/RSO.h
   DSP/DSPAccelerator.cpp
+  DSP/DSPAccelerator.h
   DSP/DSPAnalyzer.cpp
+  DSP/DSPAnalyzer.h
   DSP/DSPAssembler.cpp
+  DSP/DSPAssembler.h
   DSP/DSPCaptureLogger.cpp
+  DSP/DSPCaptureLogger.h
   DSP/DSPCodeUtil.cpp
+  DSP/DSPCodeUtil.h
+  DSP/DSPCommon.h
   DSP/DSPCore.cpp
+  DSP/DSPCore.h
   DSP/DSPDisassembler.cpp
+  DSP/DSPDisassembler.h
   DSP/DSPHWInterface.cpp
+  DSP/DSPHWInterface.h
   DSP/DSPMemoryMap.cpp
+  DSP/DSPMemoryMap.h
   DSP/DSPStacks.cpp
+  DSP/DSPStacks.h
   DSP/DSPTables.cpp
+  DSP/DSPTables.h
   DSP/LabelMap.cpp
+  DSP/LabelMap.h
   DSP/Interpreter/DSPIntArithmetic.cpp
   DSP/Interpreter/DSPIntBranch.cpp
   DSP/Interpreter/DSPIntCCUtil.cpp
+  DSP/Interpreter/DSPIntCCUtil.h
   DSP/Interpreter/DSPInterpreter.cpp
+  DSP/Interpreter/DSPInterpreter.h
   DSP/Interpreter/DSPIntExtOps.cpp
+  DSP/Interpreter/DSPIntExtOps.h
   DSP/Interpreter/DSPIntLoadStore.cpp
   DSP/Interpreter/DSPIntMisc.cpp
   DSP/Interpreter/DSPIntMultiplier.cpp
   DSP/Interpreter/DSPIntTables.cpp
+  DSP/Interpreter/DSPIntTables.h
+  DSP/Interpreter/DSPIntUtil.h
   DSP/Jit/DSPEmitterBase.cpp
+  DSP/Jit/DSPEmitterBase.h
   FifoPlayer/FifoAnalyzer.cpp
+  FifoPlayer/FifoAnalyzer.h
   FifoPlayer/FifoDataFile.cpp
+  FifoPlayer/FifoDataFile.h
   FifoPlayer/FifoPlaybackAnalyzer.cpp
+  FifoPlayer/FifoPlaybackAnalyzer.h
   FifoPlayer/FifoPlayer.cpp
+  FifoPlayer/FifoPlayer.h
   FifoPlayer/FifoRecordAnalyzer.cpp
+  FifoPlayer/FifoRecordAnalyzer.h
   FifoPlayer/FifoRecorder.cpp
+  FifoPlayer/FifoRecorder.h
   HLE/HLE.cpp
+  HLE/HLE.h
   HLE/HLE_Misc.cpp
+  HLE/HLE_Misc.h
   HLE/HLE_OS.cpp
+  HLE/HLE_OS.h
   HLE/HLE_VarArgs.cpp
+  HLE/HLE_VarArgs.h
   HW/AddressSpace.cpp
+  HW/AddressSpace.h
   HW/AudioInterface.cpp
+  HW/AudioInterface.h
   HW/CPU.cpp
+  HW/CPU.h
   HW/DSP.cpp
+  HW/DSP.h
   HW/DSPHLE/UCodes/AX.cpp
+  HW/DSPHLE/UCodes/AX.h
+  HW/DSPHLE/UCodes/AXStructs.h
+  HW/DSPHLE/UCodes/AXVoice.h
   HW/DSPHLE/UCodes/AXWii.cpp
+  HW/DSPHLE/UCodes/AXWii.h
   HW/DSPHLE/UCodes/CARD.cpp
+  HW/DSPHLE/UCodes/CARD.h
   HW/DSPHLE/UCodes/GBA.cpp
+  HW/DSPHLE/UCodes/GBA.h
   HW/DSPHLE/UCodes/INIT.cpp
+  HW/DSPHLE/UCodes/INIT.h
   HW/DSPHLE/UCodes/ROM.cpp
+  HW/DSPHLE/UCodes/ROM.h
   HW/DSPHLE/UCodes/UCodes.cpp
+  HW/DSPHLE/UCodes/UCodes.h
   HW/DSPHLE/UCodes/Zelda.cpp
+  HW/DSPHLE/UCodes/Zelda.h
   HW/DSPHLE/MailHandler.cpp
+  HW/DSPHLE/MailHandler.h
   HW/DSPHLE/DSPHLE.cpp
+  HW/DSPHLE/DSPHLE.h
   HW/DSPLLE/DSPDebugInterface.cpp
+  HW/DSPLLE/DSPDebugInterface.h
   HW/DSPLLE/DSPHost.cpp
   HW/DSPLLE/DSPSymbols.cpp
+  HW/DSPLLE/DSPSymbols.h
   HW/DSPLLE/DSPLLEGlobals.cpp
+  HW/DSPLLE/DSPLLEGlobals.h
   HW/DSPLLE/DSPLLE.cpp
+  HW/DSPLLE/DSPLLE.h
   HW/DVD/DVDInterface.cpp
+  HW/DVD/DVDInterface.h
   HW/DVD/DVDMath.cpp
+  HW/DVD/DVDMath.h
   HW/DVD/DVDThread.cpp
+  HW/DVD/DVDThread.h
   HW/DVD/FileMonitor.cpp
-  HW/EXI/EXI_Channel.cpp
+  HW/DVD/FileMonitor.h
   HW/EXI/EXI.cpp
+  HW/EXI/EXI.h
+  HW/EXI/EXI_Channel.cpp
+  HW/EXI/EXI_Channel.h
   HW/EXI/EXI_Device.cpp
+  HW/EXI/EXI_Device.h
   HW/EXI/EXI_DeviceAD16.cpp
+  HW/EXI/EXI_DeviceAD16.h
   HW/EXI/EXI_DeviceAGP.cpp
+  HW/EXI/EXI_DeviceAGP.h
   HW/EXI/EXI_DeviceDummy.cpp
+  HW/EXI/EXI_DeviceDummy.h
   HW/EXI/EXI_DeviceEthernet.cpp
+  HW/EXI/EXI_DeviceEthernet.h
   HW/EXI/EXI_DeviceGecko.cpp
+  HW/EXI/EXI_DeviceGecko.h
   HW/EXI/EXI_DeviceIPL.cpp
+  HW/EXI/EXI_DeviceIPL.h
   HW/EXI/EXI_DeviceMemoryCard.cpp
+  HW/EXI/EXI_DeviceMemoryCard.h
   HW/EXI/EXI_DeviceMic.cpp
+  HW/EXI/EXI_DeviceMic.h
   HW/GCKeyboard.cpp
+  HW/GCKeyboard.h
   HW/GCKeyboardEmu.cpp
+  HW/GCKeyboardEmu.h
   HW/GCMemcard/GCIFile.cpp
+  HW/GCMemcard/GCIFile.h
   HW/GCMemcard/GCMemcard.cpp
+  HW/GCMemcard/GCMemcard.h
   HW/GCMemcard/GCMemcardDirectory.cpp
+  HW/GCMemcard/GCMemcardDirectory.h
   HW/GCMemcard/GCMemcardRaw.cpp
+  HW/GCMemcard/GCMemcardRaw.h
   HW/GCPad.cpp
+  HW/GCPad.h
   HW/GCPadEmu.cpp
+  HW/GCPadEmu.h
   HW/GPFifo.cpp
+  HW/GPFifo.h
   HW/HW.cpp
+  HW/HW.h
   HW/Memmap.cpp
+  HW/Memmap.h
   HW/MemoryInterface.cpp
+  HW/MemoryInterface.h
   HW/MMIO.cpp
+  HW/MMIO.h
   HW/ProcessorInterface.cpp
+  HW/ProcessorInterface.h
   HW/SI/SI.cpp
+  HW/SI/SI.h
   HW/SI/SI_Device.cpp
+  HW/SI/SI_Device.h
   HW/SI/SI_DeviceDanceMat.cpp
+  HW/SI/SI_DeviceDanceMat.h
   HW/SI/SI_DeviceGBA.cpp
+  HW/SI/SI_DeviceGBA.h
   HW/SI/SI_DeviceGCAdapter.cpp
+  HW/SI/SI_DeviceGCAdapter.h
   HW/SI/SI_DeviceGCController.cpp
+  HW/SI/SI_DeviceGCController.h
   HW/SI/SI_DeviceGCSteeringWheel.cpp
+  HW/SI/SI_DeviceGCSteeringWheel.h
   HW/SI/SI_DeviceKeyboard.cpp
+  HW/SI/SI_DeviceKeyboard.h
   HW/SI/SI_DeviceNull.cpp
+  HW/SI/SI_DeviceNull.h
   HW/Sram.cpp
+  HW/Sram.h
   HW/StreamADPCM.cpp
+  HW/StreamADPCM.h
   HW/SystemTimers.cpp
+  HW/SystemTimers.h
   HW/VideoInterface.cpp
+  HW/VideoInterface.h
   HW/WII_IPC.cpp
+  HW/WII_IPC.h
   HW/Wiimote.cpp
+  HW/Wiimote.h
   HW/WiimoteCommon/DataReport.cpp
-  HW/WiimoteEmu/WiimoteEmu.cpp
+  HW/WiimoteCommon/DataReport.h
+  HW/WiimoteCommon/WiimoteConstants.h
+  HW/WiimoteCommon/WiimoteHid.h
+  HW/WiimoteCommon/WiimoteReport.h
   HW/WiimoteEmu/Camera.cpp
+  HW/WiimoteEmu/Camera.h
   HW/WiimoteEmu/Dynamics.cpp
+  HW/WiimoteEmu/Dynamics.h
   HW/WiimoteEmu/EmuSubroutines.cpp
   HW/WiimoteEmu/Encryption.cpp
+  HW/WiimoteEmu/Encryption.h
   HW/WiimoteEmu/ExtensionPort.cpp
+  HW/WiimoteEmu/ExtensionPort.h
   HW/WiimoteEmu/I2CBus.cpp
+  HW/WiimoteEmu/I2CBus.h
   HW/WiimoteEmu/MotionPlus.cpp
+  HW/WiimoteEmu/MotionPlus.h
   HW/WiimoteEmu/Speaker.cpp
+  HW/WiimoteEmu/Speaker.h
+  HW/WiimoteEmu/WiimoteEmu.cpp
+  HW/WiimoteEmu/WiimoteEmu.h
   HW/WiimoteEmu/Extension/Classic.cpp
+  HW/WiimoteEmu/Extension/Classic.h
   HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
-  HW/WiimoteEmu/Extension/Extension.cpp
-  HW/WiimoteEmu/Extension/Nunchuk.cpp
+  HW/WiimoteEmu/Extension/DrawsomeTablet.h
   HW/WiimoteEmu/Extension/Drums.cpp
+  HW/WiimoteEmu/Extension/Drums.h
+  HW/WiimoteEmu/Extension/Extension.cpp
+  HW/WiimoteEmu/Extension/Extension.h
+  HW/WiimoteEmu/Extension/Nunchuk.cpp
+  HW/WiimoteEmu/Extension/Nunchuk.h
   HW/WiimoteEmu/Extension/Guitar.cpp
+  HW/WiimoteEmu/Extension/Guitar.h
   HW/WiimoteEmu/Extension/TaTaCon.cpp
+  HW/WiimoteEmu/Extension/TaTaCon.h
   HW/WiimoteEmu/Extension/Turntable.cpp
+  HW/WiimoteEmu/Extension/Turntable.h
   HW/WiimoteEmu/Extension/UDrawTablet.cpp
+  HW/WiimoteEmu/Extension/UDrawTablet.h
   HW/WiimoteReal/WiimoteReal.cpp
+  HW/WiimoteReal/WiimoteReal.h
   HW/WiiSave.cpp
+  HW/WiiSave.h
+  HW/WiiSaveStructs.h
   IOS/Device.cpp
+  IOS/Device.h
   IOS/DeviceStub.cpp
+  IOS/DeviceStub.h
   IOS/IOS.cpp
+  IOS/IOS.h
   IOS/IOSC.cpp
+  IOS/IOSC.h
   IOS/MIOS.cpp
+  IOS/MIOS.h
   IOS/VersionInfo.cpp
+  IOS/VersionInfo.h
   IOS/DI/DI.cpp
+  IOS/DI/DI.h
   IOS/ES/ES.cpp
+  IOS/ES/ES.h
   IOS/ES/Formats.cpp
+  IOS/ES/Formats.h
   IOS/ES/Identity.cpp
   IOS/ES/NandUtils.cpp
   IOS/ES/TitleContents.cpp
@@ -172,83 +341,145 @@ add_library(core
   IOS/ES/TitleManagement.cpp
   IOS/ES/Views.cpp
   IOS/FS/FileSystem.cpp
+  IOS/FS/FileSystem.h
   IOS/FS/FileSystemProxy.cpp
+  IOS/FS/FileSystemProxy.h
   IOS/FS/HostBackend/File.cpp
   IOS/FS/HostBackend/FS.cpp
+  IOS/FS/HostBackend/FS.h
+  IOS/Network/ICMP.h
   IOS/Network/ICMPLin.cpp
   IOS/Network/MACUtils.cpp
+  IOS/Network/MACUtils.h
   IOS/Network/Socket.cpp
+  IOS/Network/Socket.h
   IOS/Network/SSL.cpp
+  IOS/Network/SSL.h
   IOS/Network/IP/Top.cpp
+  IOS/Network/IP/Top.h
   IOS/Network/KD/NetKDRequest.cpp
+  IOS/Network/KD/NetKDRequest.h
   IOS/Network/KD/NetKDTime.cpp
+  IOS/Network/KD/NetKDTime.h
   IOS/Network/KD/NWC24Config.cpp
+  IOS/Network/KD/NWC24Config.h
   IOS/Network/NCD/WiiNetConfig.cpp
+  IOS/Network/NCD/WiiNetConfig.h
   IOS/Network/NCD/Manage.cpp
+  IOS/Network/NCD/Manage.h
   IOS/Network/WD/Command.cpp
+  IOS/Network/WD/Command.h
   IOS/SDIO/SDIOSlot0.cpp
+  IOS/SDIO/SDIOSlot0.h
   IOS/STM/STM.cpp
+  IOS/STM/STM.h
   IOS/USB/Common.cpp
+  IOS/USB/Common.h
   IOS/USB/Host.cpp
+  IOS/USB/Host.h
   IOS/USB/OH0/OH0.cpp
+  IOS/USB/OH0/OH0.h
   IOS/USB/OH0/OH0Device.cpp
+  IOS/USB/OH0/OH0Device.h
   IOS/USB/USB_HID/HIDv4.cpp
+  IOS/USB/USB_HID/HIDv4.h
   IOS/USB/USB_HID/HIDv5.cpp
+  IOS/USB/USB_HID/HIDv5.h
   IOS/USB/USB_VEN/VEN.cpp
+  IOS/USB/USB_VEN/VEN.h
   IOS/USB/USBV0.cpp
+  IOS/USB/USBV0.h
   IOS/USB/USBV4.cpp
+  IOS/USB/USBV4.h
   IOS/USB/USBV5.cpp
+  IOS/USB/USBV5.h
   IOS/USB/USB_KBD.cpp
+  IOS/USB/USB_KBD.h
   IOS/USB/Bluetooth/BTBase.cpp
+  IOS/USB/Bluetooth/BTBase.h
   IOS/USB/Bluetooth/BTEmu.cpp
+  IOS/USB/Bluetooth/BTEmu.h
   IOS/USB/Bluetooth/BTStub.cpp
+  IOS/USB/Bluetooth/BTStub.h
+  IOS/USB/Bluetooth/hci.h
+  IOS/USB/Bluetooth/l2cap.h
   IOS/USB/Bluetooth/WiimoteDevice.cpp
+  IOS/USB/Bluetooth/WiimoteDevice.h
   IOS/USB/Bluetooth/WiimoteHIDAttr.cpp
+  IOS/USB/Bluetooth/WiimoteHIDAttr.h
   IOS/WFS/WFSSRV.cpp
+  IOS/WFS/WFSSRV.h
   IOS/WFS/WFSI.cpp
+  IOS/WFS/WFSI.h
   PowerPC/BreakPoints.cpp
-  PowerPC/MMU.cpp
-  PowerPC/PowerPC.cpp
-  PowerPC/PPCAnalyst.cpp
-  PowerPC/PPCCache.cpp
-  PowerPC/PPCSymbolDB.cpp
-  PowerPC/PPCTables.cpp
-  PowerPC/SignatureDB/CSVSignatureDB.cpp
-  PowerPC/SignatureDB/DSYSignatureDB.cpp
-  PowerPC/SignatureDB/MEGASignatureDB.cpp
-  PowerPC/SignatureDB/SignatureDB.cpp
-  PowerPC/JitInterface.cpp
-  PowerPC/CachedInterpreter/CachedInterpreter.cpp
-  PowerPC/CachedInterpreter/InterpreterBlockCache.cpp
+  PowerPC/BreakPoints.h
   PowerPC/ConditionRegister.cpp
+  PowerPC/ConditionRegister.h
+  PowerPC/JitInterface.cpp
+  PowerPC/JitInterface.h
+  PowerPC/MMU.cpp
+  PowerPC/MMU.h
+  PowerPC/PowerPC.cpp
+  PowerPC/PowerPC.h
+  PowerPC/PPCAnalyst.cpp
+  PowerPC/PPCAnalyst.h
+  PowerPC/PPCCache.cpp
+  PowerPC/PPCCache.h
+  PowerPC/PPCSymbolDB.cpp
+  PowerPC/PPCSymbolDB.h
+  PowerPC/PPCTables.cpp
+  PowerPC/PPCTables.h
+  PowerPC/Profiler.h
+  PowerPC/CachedInterpreter/CachedInterpreter.cpp
+  PowerPC/CachedInterpreter/CachedInterpreter.h
+  PowerPC/CachedInterpreter/InterpreterBlockCache.cpp
+  PowerPC/CachedInterpreter/InterpreterBlockCache.h
+  PowerPC/JitCommon/JitAsmCommon.cpp
+  PowerPC/JitCommon/JitAsmCommon.h
+  PowerPC/JitCommon/JitBase.cpp
+  PowerPC/JitCommon/JitBase.h
+  PowerPC/JitCommon/JitCache.cpp
+  PowerPC/JitCommon/JitCache.h
+  PowerPC/SignatureDB/CSVSignatureDB.cpp
+  PowerPC/SignatureDB/CSVSignatureDB.h
+  PowerPC/SignatureDB/DSYSignatureDB.cpp
+  PowerPC/SignatureDB/DSYSignatureDB.h
+  PowerPC/SignatureDB/MEGASignatureDB.cpp
+  PowerPC/SignatureDB/MEGASignatureDB.h
+  PowerPC/SignatureDB/SignatureDB.cpp
+  PowerPC/SignatureDB/SignatureDB.h
+  PowerPC/Interpreter/ExceptionUtils.h
   PowerPC/Interpreter/Interpreter_Branch.cpp
   PowerPC/Interpreter/Interpreter.cpp
+  PowerPC/Interpreter/Interpreter.h
   PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+  PowerPC/Interpreter/Interpreter_FPUtils.h
   PowerPC/Interpreter/Interpreter_Integer.cpp
   PowerPC/Interpreter/Interpreter_LoadStore.cpp
   PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
   PowerPC/Interpreter/Interpreter_Paired.cpp
   PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
   PowerPC/Interpreter/Interpreter_Tables.cpp
-  PowerPC/JitCommon/JitAsmCommon.cpp
-  PowerPC/JitCommon/JitBase.cpp
-  PowerPC/JitCommon/JitCache.cpp
 )
 
 if(_M_X86)
   target_sources(core PRIVATE
     DSP/Jit/x64/DSPEmitter.cpp
-    DSP/Jit/x64/DSPJitRegCache.cpp
-    DSP/Jit/x64/DSPJitExtOps.cpp
+    DSP/Jit/x64/DSPEmitter.h
+    DSP/Jit/x64/DSPJitArithmetic.cpp
     DSP/Jit/x64/DSPJitBranch.cpp
     DSP/Jit/x64/DSPJitCCUtil.cpp
-    DSP/Jit/x64/DSPJitArithmetic.cpp
+    DSP/Jit/x64/DSPJitExtOps.cpp
     DSP/Jit/x64/DSPJitLoadStore.cpp
     DSP/Jit/x64/DSPJitMisc.cpp
     DSP/Jit/x64/DSPJitMultiplier.cpp
+    DSP/Jit/x64/DSPJitRegCache.cpp
+    DSP/Jit/x64/DSPJitRegCache.h
     DSP/Jit/x64/DSPJitTables.cpp
+    DSP/Jit/x64/DSPJitTables.h
     DSP/Jit/x64/DSPJitUtil.cpp
     PowerPC/Jit64/Jit.cpp
+    PowerPC/Jit64/Jit.h
     PowerPC/Jit64/Jit64_Tables.cpp
     PowerPC/Jit64/Jit_Branch.cpp
     PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -259,33 +490,52 @@ if(_M_X86)
     PowerPC/Jit64/Jit_Paired.cpp
     PowerPC/Jit64/Jit_SystemRegisters.cpp
     PowerPC/Jit64/JitAsm.cpp
+    PowerPC/Jit64/JitAsm.h
+    PowerPC/Jit64/RegCache/CachedReg.h
     PowerPC/Jit64/RegCache/FPURegCache.cpp
+    PowerPC/Jit64/RegCache/FPURegCache.h
     PowerPC/Jit64/RegCache/GPRRegCache.cpp
+    PowerPC/Jit64/RegCache/GPRRegCache.h
     PowerPC/Jit64/RegCache/JitRegCache.cpp
+    PowerPC/Jit64/RegCache/JitRegCache.h
+    PowerPC/Jit64/RegCache/RCMode.h
     PowerPC/Jit64Common/BlockCache.cpp
+    PowerPC/Jit64Common/BlockCache.h
     PowerPC/Jit64Common/ConstantPool.cpp
+    PowerPC/Jit64Common/ConstantPool.h
     PowerPC/Jit64Common/EmuCodeBlock.cpp
+    PowerPC/Jit64Common/EmuCodeBlock.h
     PowerPC/Jit64Common/FarCodeCache.cpp
+    PowerPC/Jit64Common/FarCodeCache.h
     PowerPC/Jit64Common/Jit64AsmCommon.cpp
+    PowerPC/Jit64Common/Jit64AsmCommon.h
+    PowerPC/Jit64Common/Jit64Constants.h
+    PowerPC/Jit64Common/Jit64PowerPCState.h
     PowerPC/Jit64Common/TrampolineCache.cpp
+    PowerPC/Jit64Common/TrampolineCache.h
+    PowerPC/Jit64Common/TrampolineInfo.h
   )
 elseif(_M_ARM_64)
   target_sources(core PRIVATE
     PowerPC/JitArm64/Jit.cpp
+    PowerPC/JitArm64/Jit.h
     PowerPC/JitArm64/JitAsm.cpp
     PowerPC/JitArm64/JitArm64Cache.cpp
-    PowerPC/JitArm64/JitArm64_RegCache.cpp
     PowerPC/JitArm64/JitArm64_BackPatch.cpp
     PowerPC/JitArm64/JitArm64_Branch.cpp
     PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
     PowerPC/JitArm64/JitArm64_Integer.cpp
     PowerPC/JitArm64/JitArm64_LoadStore.cpp
     PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
-    PowerPC/JitArm64/JitArm64_Paired.cpp
     PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+    PowerPC/JitArm64/JitArm64_Paired.cpp
+    PowerPC/JitArm64/JitArm64_RegCache.cpp
+    PowerPC/JitArm64/JitArm64_RegCache.h
     PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
     PowerPC/JitArm64/Jit_Util.cpp
+    PowerPC/JitArm64/Jit_Util.h
     PowerPC/JitArm64/JitArm64_Tables.cpp
+    PowerPC/JitArmCommon/BackPatch.h
   )
 endif()
 
@@ -330,14 +580,18 @@ if(LIBUSB_FOUND)
   target_link_libraries(core PUBLIC ${LIBUSB_LIBRARIES})
   target_sources(core PRIVATE
     IOS/USB/LibusbDevice.cpp
+    IOS/USB/LibusbDevice.h
     IOS/USB/Bluetooth/BTReal.cpp
+    IOS/USB/Bluetooth/BTReal.h
   )
 endif()
 
 if(WIN32)
   target_sources(core PRIVATE
     HW/EXI/BBA-TAP/TAP_Win32.cpp
+    HW/EXI/BBA-TAP/TAP_Win32.h
     HW/WiimoteReal/IOWin.cpp
+    HW/WiimoteReal/IOWin.h
   )
   target_link_libraries(core PUBLIC
     videod3d
@@ -349,13 +603,20 @@ if(WIN32)
 elseif(APPLE)
   target_sources(core PRIVATE
     HW/EXI/BBA-TAP/TAP_Apple.cpp
+    HW/WiimoteReal/IOdarwin.h
+    HW/WiimoteReal/IOdarwin_private.h
     HW/WiimoteReal/IOdarwin.mm
   )
   target_link_libraries(core PUBLIC ${IOB_LIBRARY})
 elseif(UNIX)
-  target_sources(core PRIVATE HW/EXI/BBA-TAP/TAP_Unix.cpp)
+  target_sources(core PRIVATE
+    HW/EXI/BBA-TAP/TAP_Unix.cpp
+  )
   if(ANDROID)
-    target_sources(core PRIVATE HW/WiimoteReal/IOAndroid.cpp)
+    target_sources(core PRIVATE
+      HW/WiimoteReal/IOAndroid.cpp
+      HW/WiimoteReal/IOAndroid.h
+    )
   endif()
 endif()
 
@@ -366,7 +627,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(BlueZ)
     if(BLUEZ_FOUND)
       message(STATUS "BlueZ found, enabling bluetooth support")
-      target_sources(core PRIVATE HW/WiimoteReal/IOLinux.cpp)
+      target_sources(core PRIVATE
+        HW/WiimoteReal/IOLinux.cpp
+        HW/WiimoteReal/IOLinux.h
+      )
       target_link_libraries(core PUBLIC BlueZ::BlueZ)
       target_compile_definitions(core PRIVATE -DHAVE_BLUEZ=1)
     else()
@@ -378,15 +642,24 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 if(TARGET Hidapi::Hidapi)
-  target_sources(core PRIVATE HW/WiimoteReal/IOhidapi.cpp)
+  target_sources(core PRIVATE
+    HW/WiimoteReal/IOhidapi.cpp
+    HW/WiimoteReal/IOhidapi.h
+  )
   target_link_libraries(core PUBLIC Hidapi::Hidapi)
   target_compile_definitions(core PRIVATE -DHAVE_HIDAPI=1)
 endif()
 
 if(GDBSTUB)
-  target_sources(core PRIVATE PowerPC/GDBStub.cpp)
+  target_sources(core PRIVATE
+    PowerPC/GDBStub.cpp
+    PowerPC/GDBStub.h
+  )
 endif()
 
 if(UNIX)
-  target_sources(core PRIVATE MemoryWatcher.cpp)
+  target_sources(core PRIVATE
+    MemoryWatcher.cpp
+    MemoryWatcher.h
+  )
 endif()

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -1,26 +1,48 @@
 add_library(discio
   Blob.cpp
+  Blob.h
   CISOBlob.cpp
-  WbfsBlob.cpp
+  CISOBlob.h
   CompressedBlob.cpp
+  CompressedBlob.h
   DirectoryBlob.cpp
+  DirectoryBlob.h
   DiscExtractor.cpp
+  DiscExtractor.h
   DiscScrubber.cpp
+  DiscScrubber.h
   DriveBlob.cpp
+  DriveBlob.h
   Enums.cpp
+  Enums.h
   FileBlob.cpp
+  FileBlob.h
   FileSystemGCWii.cpp
+  FileSystemGCWii.h
   Filesystem.cpp
+  Filesystem.h
   NANDImporter.cpp
+  NANDImporter.h
   TGCBlob.cpp
+  TGCBlob.h
   Volume.cpp
+  Volume.h
   VolumeFileBlobReader.cpp
+  VolumeFileBlobReader.h
   VolumeGC.cpp
+  VolumeGC.h
   VolumeVerifier.cpp
+  VolumeVerifier.h
   VolumeWad.cpp
+  VolumeWad.h
   VolumeWii.cpp
+  VolumeWii.h
+  WbfsBlob.cpp
+  WbfsBlob.h
   WiiSaveBanner.cpp
+  WiiSaveBanner.h
   WiiWad.cpp
+  WiiWad.h
 )
 
 target_link_libraries(discio

--- a/Source/Core/DolphinNoGUI/CMakeLists.txt
+++ b/Source/Core/DolphinNoGUI/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(dolphin-nogui
   Platform.cpp
+  Platform.h
   PlatformHeadless.cpp
   MainNoGUI.cpp
 )

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -11,130 +11,250 @@ set(CMAKE_AUTOMOC ON)
 
 add_executable(dolphin-emu
   AboutDialog.cpp
+  AboutDialog.h
   CheatsManager.cpp
+  CheatsManager.h
   DiscordHandler.cpp
+  DiscordHandler.h
   DiscordJoinRequestDialog.cpp
+  DiscordJoinRequestDialog.h
   FIFO/FIFOPlayerWindow.cpp
+  FIFO/FIFOPlayerWindow.h
   FIFO/FIFOAnalyzer.cpp
-  HotkeyScheduler.cpp
+  FIFO/FIFOAnalyzer.h
   Host.cpp
+  Host.h
+  HotkeyScheduler.cpp
+  HotkeyScheduler.h
   Main.cpp
   MainWindow.cpp
+  MainWindow.h
   MenuBar.cpp
+  MenuBar.h
   RenderWidget.cpp
+  RenderWidget.h
   Resources.cpp
+  Resources.h
   SearchBar.cpp
+  SearchBar.h
   Settings.cpp
+  Settings.h
   ToolBar.cpp
+  ToolBar.h
   Translation.cpp
+  Translation.h
   WiiUpdate.cpp
   WiiUpdate.h
-  Config/CheatCodeEditor.cpp
   Config/ARCodeWidget.cpp
+  Config/ARCodeWidget.h
+  Config/CheatCodeEditor.cpp
+  Config/CheatCodeEditor.h
   Config/CheatWarningWidget.cpp
+  Config/CheatWarningWidget.h
   Config/ControllersWindow.cpp
+  Config/ControllersWindow.h
   Config/FilesystemWidget.cpp
+  Config/FilesystemWidget.h
   Config/GameConfigEdit.cpp
+  Config/GameConfigEdit.h
   Config/GameConfigHighlighter.cpp
+  Config/GameConfigHighlighter.h
   Config/GameConfigWidget.cpp
+  Config/GameConfigWidget.h
   Config/GeckoCodeWidget.cpp
+  Config/GeckoCodeWidget.h
   Config/Graphics/AdvancedWidget.cpp
+  Config/Graphics/AdvancedWidget.h
   Config/Graphics/EnhancementsWidget.cpp
+  Config/Graphics/EnhancementsWidget.h
   Config/Graphics/GeneralWidget.cpp
-  Config/Graphics/HacksWidget.cpp
+  Config/Graphics/GeneralWidget.h
   Config/Graphics/GraphicsBool.cpp
+  Config/Graphics/GraphicsBool.h
   Config/Graphics/GraphicsChoice.cpp
+  Config/Graphics/GraphicsChoice.h
   Config/Graphics/GraphicsRadio.cpp
+  Config/Graphics/GraphicsRadio.h
   Config/Graphics/GraphicsSlider.cpp
+  Config/Graphics/GraphicsSlider.h
   Config/Graphics/GraphicsWidget.cpp
+  Config/Graphics/GraphicsWidget.h
   Config/Graphics/GraphicsWindow.cpp
+  Config/Graphics/GraphicsWindow.h
+  Config/Graphics/HacksWidget.cpp
+  Config/Graphics/HacksWidget.h
   Config/Graphics/PostProcessingConfigWindow.cpp
+  Config/Graphics/PostProcessingConfigWindow.h
   Config/Graphics/SoftwareRendererWidget.cpp
+  Config/Graphics/SoftwareRendererWidget.h
   Config/InfoWidget.cpp
+  Config/InfoWidget.h
   Config/LogConfigWidget.cpp
+  Config/LogConfigWidget.h
   Config/LogWidget.cpp
+  Config/LogWidget.h
   Config/Mapping/GCKeyboardEmu.cpp
+  Config/Mapping/GCKeyboardEmu.h
   Config/Mapping/GCMicrophone.cpp
+  Config/Mapping/GCMicrophone.h
   Config/Mapping/GCPadEmu.cpp
+  Config/Mapping/GCPadEmu.h
   Config/Mapping/GCPadWiiUConfigDialog.cpp
+  Config/Mapping/GCPadWiiUConfigDialog.h
   Config/Mapping/Hotkey3D.cpp
+  Config/Mapping/Hotkey3D.h
   Config/Mapping/HotkeyControllerProfile.cpp
+  Config/Mapping/HotkeyControllerProfile.h
   Config/Mapping/HotkeyDebugging.cpp
+  Config/Mapping/HotkeyDebugging.h
   Config/Mapping/HotkeyGeneral.cpp
+  Config/Mapping/HotkeyGeneral.h
   Config/Mapping/HotkeyGraphics.cpp
+  Config/Mapping/HotkeyGraphics.h
   Config/Mapping/HotkeyStates.cpp
+  Config/Mapping/HotkeyStates.h
   Config/Mapping/HotkeyStatesOther.cpp
+  Config/Mapping/HotkeyStatesOther.h
   Config/Mapping/HotkeyTAS.cpp
+  Config/Mapping/HotkeyTAS.h
   Config/Mapping/HotkeyWii.cpp
+  Config/Mapping/HotkeyWii.h
   Config/Mapping/IOWindow.cpp
   Config/Mapping/MappingButton.cpp
+  Config/Mapping/MappingButton.h
   Config/Mapping/MappingCommon.cpp
+  Config/Mapping/MappingCommon.h
   Config/Mapping/MappingIndicator.cpp
+  Config/Mapping/MappingIndicator.h
   Config/Mapping/MappingNumeric.cpp
+  Config/Mapping/MappingNumeric.h
   Config/Mapping/MappingWidget.cpp
+  Config/Mapping/MappingWidget.h
   Config/Mapping/MappingWindow.cpp
+  Config/Mapping/MappingWindow.h
   Config/Mapping/WiimoteEmuExtension.cpp
+  Config/Mapping/WiimoteEmuExtension.h
   Config/Mapping/WiimoteEmuGeneral.cpp
+  Config/Mapping/WiimoteEmuGeneral.h
   Config/Mapping/WiimoteEmuMotionControl.cpp
+  Config/Mapping/WiimoteEmuMotionControl.h
   Config/NewPatchDialog.cpp
+  Config/NewPatchDialog.h
   Config/PatchesWidget.cpp
+  Config/PatchesWidget.h
   Config/PropertiesDialog.cpp
+  Config/PropertiesDialog.h
   Config/SettingsWindow.cpp
+  Config/SettingsWindow.h
   Config/VerifyWidget.cpp
+  Config/VerifyWidget.h
   Debugger/BreakpointWidget.cpp
+  Debugger/BreakpointWidget.h
   Debugger/CodeViewWidget.cpp
+  Debugger/CodeViewWidget.h
   Debugger/CodeWidget.cpp
+  Debugger/CodeWidget.h
   Debugger/JITWidget.cpp
+  Debugger/JITWidget.h
   Debugger/MemoryViewWidget.cpp
+  Debugger/MemoryViewWidget.h
   Debugger/MemoryWidget.cpp
+  Debugger/MemoryWidget.h
   Debugger/NewBreakpointDialog.cpp
+  Debugger/NewBreakpointDialog.h
   Debugger/PatchInstructionDialog.cpp
+  Debugger/PatchInstructionDialog.h
   Debugger/RegisterColumn.cpp
+  Debugger/RegisterColumn.h
   Debugger/RegisterWidget.cpp
+  Debugger/RegisterWidget.h
   Debugger/WatchWidget.cpp
+  Debugger/WatchWidget.h
   GameList/GameList.cpp
+  GameList/GameList.h
   GameList/GameListModel.cpp
+  GameList/GameListModel.h
   GameList/GameTracker.cpp
+  GameList/GameTracker.h
   GameList/GridProxyModel.cpp
+  GameList/GridProxyModel.h
   GameList/ListProxyModel.cpp
+  GameList/ListProxyModel.h
   GCMemcardManager.cpp
+  GCMemcardManager.h
   QtUtils/BlockUserInputFilter.cpp
+  QtUtils/BlockUserInputFilter.h
   NetPlay/ChunkedProgressDialog.cpp
+  NetPlay/ChunkedProgressDialog.h
   NetPlay/GameListDialog.cpp
+  NetPlay/GameListDialog.h
   NetPlay/MD5Dialog.cpp
+  NetPlay/MD5Dialog.h
   NetPlay/NetPlayBrowser.cpp
+  NetPlay/NetPlayBrowser.h
   NetPlay/NetPlayDialog.cpp
+  NetPlay/NetPlayDialog.h
   NetPlay/NetPlaySetupDialog.cpp
+  NetPlay/NetPlaySetupDialog.h
   NetPlay/PadMappingDialog.cpp
+  NetPlay/PadMappingDialog.h
   QtUtils/DoubleClickEventFilter.cpp
+  QtUtils/DoubleClickEventFilter.h
   QtUtils/ElidedButton.cpp
+  QtUtils/ElidedButton.h
   QtUtils/FlowLayout.cpp
+  QtUtils/FlowLayout.h
   QtUtils/ModalMessageBox.cpp
+  QtUtils/ModalMessageBox.h
   QtUtils/ImageConverter.cpp
+  QtUtils/ImageConverter.h
   QtUtils/WindowActivationEventFilter.cpp
+  QtUtils/WindowActivationEventFilter.h
   QtUtils/WinIconHelper.cpp
+  QtUtils/WinIconHelper.h
   QtUtils/WrapInScrollArea.cpp
+  QtUtils/WrapInScrollArea.h
   QtUtils/AspectRatioWidget.cpp
+  QtUtils/AspectRatioWidget.h
   ResourcePackManager.cpp
+  ResourcePackManager.h
   Settings/AdvancedPane.cpp
+  Settings/AdvancedPane.h
   Settings/AudioPane.cpp
+  Settings/AudioPane.h
   Settings/GameCubePane.cpp
+  Settings/GameCubePane.h
   Settings/GeneralPane.cpp
+  Settings/GeneralPane.h
   Settings/InterfacePane.cpp
+  Settings/InterfacePane.h
   Settings/PathPane.cpp
+  Settings/PathPane.h
   Settings/WiiPane.cpp
+  Settings/WiiPane.h
   Settings/USBDeviceAddToWhitelistDialog.cpp
+  Settings/USBDeviceAddToWhitelistDialog.h
   TAS/GCTASInputWindow.cpp
+  TAS/GCTASInputWindow.h
   TAS/WiiTASInputWindow.cpp
+  TAS/WiiTASInputWindow.h
   TAS/TASCheckBox.cpp
+  TAS/TASCheckBox.h
   TAS/TASInputWindow.cpp
+  TAS/TASInputWindow.h
   TAS/StickWidget.cpp
+  TAS/StickWidget.h
   TAS/IRWidget.cpp
+  TAS/IRWidget.h
   Updater.cpp
+  Updater.h
 )
 
 if (NOT WIN32)
-  target_sources(dolphin-emu PRIVATE QtUtils/SignalDaemon.cpp)
+  target_sources(dolphin-emu PRIVATE
+    QtUtils/SignalDaemon.cpp
+    QtUtils/SignalDaemon.h
+  )
 endif()
 
 target_compile_definitions(dolphin-emu

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -1,27 +1,50 @@
 add_library(inputcommon
   InputConfig.cpp
+  InputConfig.h
   InputProfile.cpp
+  InputProfile.h
   ControllerEmu/ControllerEmu.cpp
+  ControllerEmu/ControllerEmu.h
   ControllerEmu/StickGate.cpp
+  ControllerEmu/StickGate.h
   ControllerEmu/Control/Control.cpp
+  ControllerEmu/Control/Control.h
   ControllerEmu/Control/Input.cpp
+  ControllerEmu/Control/Input.h
   ControllerEmu/Control/Output.cpp
+  ControllerEmu/Control/Output.h
   ControllerEmu/ControlGroup/AnalogStick.cpp
+  ControllerEmu/ControlGroup/AnalogStick.h
   ControllerEmu/ControlGroup/Attachments.cpp
+  ControllerEmu/ControlGroup/Attachments.h
   ControllerEmu/ControlGroup/Buttons.cpp
+  ControllerEmu/ControlGroup/Buttons.h
   ControllerEmu/ControlGroup/ControlGroup.cpp
+  ControllerEmu/ControlGroup/ControlGroup.h
   ControllerEmu/ControlGroup/Cursor.cpp
+  ControllerEmu/ControlGroup/Cursor.h
   ControllerEmu/ControlGroup/Force.cpp
+  ControllerEmu/ControlGroup/Force.h
   ControllerEmu/ControlGroup/MixedTriggers.cpp
+  ControllerEmu/ControlGroup/MixedTriggers.h
   ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+  ControllerEmu/ControlGroup/ModifySettingsButton.h
   ControllerEmu/ControlGroup/Slider.cpp
+  ControllerEmu/ControlGroup/Slider.h
   ControllerEmu/ControlGroup/Tilt.cpp
+  ControllerEmu/ControlGroup/Tilt.h
   ControllerEmu/ControlGroup/Triggers.cpp
+  ControllerEmu/ControlGroup/Triggers.h
   ControllerEmu/Setting/NumericSetting.cpp
+  ControllerEmu/Setting/NumericSetting.h
   ControllerInterface/ControllerInterface.cpp
+  ControllerInterface/ControllerInterface.h
   ControllerInterface/Device.cpp
+  ControllerInterface/Device.h
   ControlReference/ControlReference.cpp
+  ControlReference/ControlReference.h
   ControlReference/ExpressionParser.cpp
+  ControlReference/ExpressionParser.h
 )
 
 target_link_libraries(inputcommon PUBLIC
@@ -31,20 +54,35 @@ target_link_libraries(inputcommon PUBLIC
 if(WIN32)
   target_sources(inputcommon PRIVATE
     ControllerInterface/DInput/DInput.cpp
+    ControllerInterface/DInput/DInput.h
+    ControllerInterface/DInput/DInput8.h
     ControllerInterface/DInput/DInputJoystick.cpp
+    ControllerInterface/DInput/DInputJoystick.h
     ControllerInterface/DInput/DInputKeyboardMouse.cpp
+    ControllerInterface/DInput/DInputKeyboardMouse.h
+    ControllerInterface/DInput/NamedKeys.h
     ControllerInterface/DInput/XInputFilter.cpp
+    ControllerInterface/DInput/XInputFilter.h
     ControllerInterface/Win32/Win32.cpp
+    ControllerInterface/Win32/Win32.h
     ControllerInterface/XInput/XInput.cpp
+    ControllerInterface/XInput/XInput.h
     ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
+    ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
   )
 elseif(APPLE)
   target_sources(inputcommon PRIVATE
+    ControllerInterface/OSX/OSX.h
     ControllerInterface/OSX/OSX.mm
+    ControllerInterface/OSX/OSXJoystick.h
     ControllerInterface/OSX/OSXJoystick.mm
+    ControllerInterface/OSX/RunLoopStopper.h
+    ControllerInterface/Quartz/Quartz.h
     ControllerInterface/Quartz/Quartz.mm
+    ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
     ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
     ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
+    ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
   )
   target_link_libraries(inputcommon PRIVATE
     ${COREFOUNDATION_LIBRARY}
@@ -56,6 +94,7 @@ elseif(APPLE)
 elseif(X11_FOUND)
   target_sources(inputcommon PRIVATE
     ControllerInterface/Xlib/XInput2.cpp
+    ControllerInterface/Xlib/XInput2.h
   )
   target_link_libraries(inputcommon PUBLIC
     ${X11_LIBRARIES}
@@ -65,13 +104,17 @@ elseif(ANDROID)
   target_compile_definitions(inputcommon PRIVATE -DCIFACE_USE_ANDROID)
   target_sources(inputcommon PRIVATE
     ControllerInterface/Android/Android.cpp
+    ControllerInterface/Android/Android.h
   )
 endif()
 
 if(ANDROID)
   target_sources(inputcommon PRIVATE GCAdapter_Android.cpp)
 else()
-  target_sources(inputcommon PRIVATE GCAdapter.cpp)
+  target_sources(inputcommon PRIVATE
+    GCAdapter.cpp
+    GCAdapter.h
+  )
   target_link_libraries(inputcommon PUBLIC ${LIBUSB_LIBRARIES})
 endif()
 
@@ -79,6 +122,7 @@ if(LIBEVDEV_FOUND AND LIBUDEV_FOUND)
   target_sources(inputcommon
   PRIVATE
     ControllerInterface/evdev/evdev.cpp
+    ControllerInterface/evdev/evdev.h
   )
   target_include_directories(inputcommon
   PRIVATE
@@ -95,6 +139,7 @@ endif()
 if(UNIX)
   target_sources(inputcommon PRIVATE
     ControllerInterface/Pipes/Pipes.cpp
+    ControllerInterface/Pipes/Pipes.h
   )
 endif()
 
@@ -115,7 +160,10 @@ if(ENABLE_SDL)
     endif()
   endif()
   if(SDL_TARGET AND TARGET ${SDL_TARGET})
-    target_sources(inputcommon PRIVATE ControllerInterface/SDL/SDL.cpp)
+    target_sources(inputcommon PRIVATE
+      ControllerInterface/SDL/SDL.cpp
+      ControllerInterface/SDL/SDL.h
+    )
     target_link_libraries(inputcommon PRIVATE ${SDL_TARGET})
     target_compile_definitions(inputcommon PRIVATE "CIFACE_USE_SDL=1")
   else()

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -1,17 +1,30 @@
 add_library(uicommon
   AutoUpdate.cpp
+  AutoUpdate.h
   CommandLineParse.cpp
+  CommandLineParse.h
   Disassembler.cpp
+  Disassembler.h
   DiscordPresence.cpp
+  DiscordPresence.h
   GameFile.cpp
+  GameFile.h
   GameFileCache.cpp
+  GameFileCache.h
   NetPlayIndex.cpp
+  NetPlayIndex.h
   ResourcePack/Manager.cpp
+  ResourcePack/Manager.h
   ResourcePack/Manifest.cpp
+  ResourcePack/Manifest.h
   ResourcePack/ResourcePack.cpp
+  ResourcePack/ResourcePack.h
   UICommon.cpp
+  UICommon.h
   USBUtils.cpp
+  USBUtils.h
   VideoUtils.cpp
+  VideoUtils.h
 )
 
 target_link_libraries(uicommon

--- a/Source/Core/UpdaterCommon/CMakeLists.txt
+++ b/Source/Core/UpdaterCommon/CMakeLists.txt
@@ -1,9 +1,13 @@
 add_library(updatercommon
-  UpdaterCommon.cpp)
-  
+  UI.h
+  UpdaterCommon.cpp
+  UpdaterCommon.h
+)
+
 target_link_libraries(updatercommon PRIVATE
   uicommon
   mbedtls
   z
   ed25519
-  cpp-optparse)
+  cpp-optparse
+)

--- a/Source/Core/VideoBackends/Null/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Null/CMakeLists.txt
@@ -1,8 +1,14 @@
 add_library(videonull
   NullBackend.cpp
   NullTexture.cpp
+  NullTexture.h
+  PerfQuery.h
   Render.cpp
+  Render.h
+  TextureCache.h
   VertexManager.cpp
+  VertexManager.h
+  VideoBackend.h
 )
 
 target_link_libraries(videonull

--- a/Source/Core/VideoBackends/OGL/CMakeLists.txt
+++ b/Source/Core/VideoBackends/OGL/CMakeLists.txt
@@ -1,16 +1,28 @@
 add_library(videoogl
   BoundingBox.cpp
+  BoundingBox.h
+  GPUTimer.h
   main.cpp
   NativeVertexFormat.cpp
   OGLPipeline.cpp
+  OGLPipeline.h
   OGLShader.cpp
+  OGLShader.h
   OGLTexture.cpp
+  OGLTexture.h
   PerfQuery.cpp
+  PerfQuery.h
   ProgramShaderCache.cpp
+  ProgramShaderCache.h
   Render.cpp
+  Render.h
   SamplerCache.cpp
+  SamplerCache.h
   StreamBuffer.cpp
+  StreamBuffer.h
   VertexManager.cpp
+  VertexManager.h
+  VideoBackend.h
 )
 
 target_link_libraries(videoogl

--- a/Source/Core/VideoBackends/Software/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Software/CMakeLists.txt
@@ -1,19 +1,37 @@
 add_library(videosoftware
   Clipper.cpp
+  Clipper.h
+  CopyRegion.h
   DebugUtil.cpp
+  DebugUtil.h
   EfbCopy.cpp
+  EfbCopy.h
   EfbInterface.cpp
+  EfbInterface.h
+  NativeVertexFormat.h
   Rasterizer.cpp
-  SWOGLWindow.cpp
-  SWRenderer.cpp
-  SWTexture.cpp
-  SWVertexLoader.cpp
-  SWmain.cpp
+  Rasterizer.h
   SetupUnit.cpp
+  SetupUnit.h
+  SWmain.cpp
+  SWOGLWindow.cpp
+  SWOGLWindow.h
+  SWRenderer.cpp
+  SWRenderer.h
+  SWTexture.cpp
+  SWTexture.h
+  SWVertexLoader.cpp
+  SWVertexLoader.h
   Tev.cpp
+  Tev.h
   TextureEncoder.cpp
+  TextureEncoder.h
   TextureSampler.cpp
+  TextureSampler.h
   TransformUnit.cpp
+  TransformUnit.h
+  Vec3.h
+  VideoBackend.h
 )
 
 target_link_libraries(videosoftware

--- a/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
@@ -1,22 +1,40 @@
 add_library(videovulkan
   BoundingBox.cpp
+  BoundingBox.h
   CommandBufferManager.cpp
-  ObjectCache.cpp
-  PerfQuery.cpp
-  Renderer.cpp
-  ShaderCompiler.cpp
-  StateTracker.cpp
-  StagingBuffer.cpp
-  StreamBuffer.cpp
-  SwapChain.cpp
-  VertexFormat.cpp
-  VertexManager.cpp
-  VKPipeline.cpp
-  VKShader.cpp
-  VKTexture.cpp
-  VulkanContext.cpp
-  VulkanLoader.cpp
+  CommandBufferManager.h
+  Constants.h
   main.cpp
+  ObjectCache.cpp
+  ObjectCache.h
+  PerfQuery.cpp
+  PerfQuery.h
+  Renderer.cpp
+  Renderer.h
+  ShaderCompiler.cpp
+  ShaderCompiler.h
+  StateTracker.cpp
+  StateTracker.h
+  StagingBuffer.cpp
+  StagingBuffer.h
+  StreamBuffer.cpp
+  StreamBuffer.h
+  SwapChain.cpp
+  SwapChain.h
+  VertexFormat.cpp
+  VertexFormat.h
+  VertexManager.cpp
+  VertexManager.h
+  VKPipeline.cpp
+  VKPipeline.h
+  VKShader.cpp
+  VKShader.h
+  VKTexture.cpp
+  VKTexture.h
+  VulkanContext.cpp
+  VulkanContext.h
+  VulkanLoader.cpp
+  VulkanLoader.h
 )
 
 target_link_libraries(videovulkan

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -1,64 +1,131 @@
 add_library(videocommon
   AbstractFramebuffer.cpp
+  AbstractFramebuffer.h
+  AbstractShader.h
   AbstractStagingTexture.cpp
+  AbstractStagingTexture.h
   AbstractTexture.cpp
+  AbstractTexture.h
   AsyncRequests.cpp
+  AsyncRequests.h
   AsyncShaderCompiler.cpp
+  AsyncShaderCompiler.h
   BoundingBox.cpp
+  BoundingBox.h
   BPFunctions.cpp
+  BPFunctions.h
   BPMemory.cpp
+  BPMemory.h
   BPStructs.cpp
-  CPMemory.cpp
+  BPStructs.h
   CommandProcessor.cpp
+  CommandProcessor.h
+  ConstantManager.h
+  CPMemory.cpp
+  CPMemory.h
   DriverDetails.cpp
+  DriverDetails.h
   Fifo.cpp
+  Fifo.h
   FPSCounter.cpp
+  FPSCounter.h
   FramebufferManager.cpp
+  FramebufferManager.h
   FramebufferShaderGen.cpp
+  FramebufferShaderGen.h
   GeometryShaderGen.cpp
+  GeometryShaderGen.h
   GeometryShaderManager.cpp
+  GeometryShaderManager.h
   HiresTextures.cpp
+  HiresTextures.h
   HiresTextures_DDSLoader.cpp
   ImageWrite.cpp
+  ImageWrite.h
   IndexGenerator.cpp
+  IndexGenerator.h
   LightingShaderGen.cpp
+  LightingShaderGen.h
+  LookUpTables.h
+  NativeVertexFormat.h
   NetPlayChatUI.cpp
+  NetPlayChatUI.h
   NetPlayGolfUI.cpp
+  NetPlayGolfUI.h
   OnScreenDisplay.cpp
+  OnScreenDisplay.h
   OpcodeDecoding.cpp
+  OpcodeDecoding.h
   PerfQueryBase.cpp
+  PerfQueryBase.h
   PixelEngine.cpp
+  PixelEngine.h
   PixelShaderGen.cpp
+  PixelShaderGen.h
   PixelShaderManager.cpp
+  PixelShaderManager.h
   PostProcessing.cpp
+  PostProcessing.h
   RenderBase.cpp
+  RenderBase.h
   RenderState.cpp
+  RenderState.h
+  SamplerCommon.h
   ShaderCache.cpp
+  ShaderCache.h
   ShaderGenCommon.cpp
+  ShaderGenCommon.h
   Statistics.cpp
-  UberShaderCommon.cpp
-  UberShaderPixel.cpp
-  UberShaderVertex.cpp
+  Statistics.h
   TextureCacheBase.cpp
+  TextureCacheBase.h
   TextureConfig.cpp
+  TextureConfig.h
   TextureConversionShader.cpp
+  TextureConversionShader.h
   TextureConverterShaderGen.cpp
+  TextureConverterShaderGen.h
+  TextureDecoder.h
   TextureDecoder_Common.cpp
+  TextureDecoder_Util.h
+  UberShaderCommon.cpp
+  UberShaderCommon.h
+  UberShaderPixel.cpp
+  UberShaderPixel.h
+  UberShaderVertex.cpp
+  UberShaderVertex.h
   VertexLoader.cpp
+  VertexLoader.h
   VertexLoaderBase.cpp
+  VertexLoaderBase.h
   VertexLoaderManager.cpp
+  VertexLoaderManager.h
+  VertexLoaderUtils.h
   VertexLoader_Color.cpp
+  VertexLoader_Color.h
   VertexLoader_Normal.cpp
+  VertexLoader_Normal.h
   VertexLoader_Position.cpp
+  VertexLoader_Position.h
   VertexLoader_TextCoord.cpp
+  VertexLoader_TextCoord.h
   VertexManagerBase.cpp
+  VertexManagerBase.h
   VertexShaderGen.cpp
+  VertexShaderGen.h
   VertexShaderManager.cpp
+  VertexShaderManager.h
   VideoBackendBase.cpp
+  VideoBackendBase.h
+  VideoCommon.h
   VideoConfig.cpp
+  VideoConfig.h
   VideoState.cpp
+  VideoState.h
   XFMemory.cpp
+  XFMemory.h
   XFStructs.cpp
+  XFStructs.h
 )
 
 target_link_libraries(videocommon
@@ -74,10 +141,12 @@ if(_M_X86)
   target_sources(videocommon PRIVATE
     TextureDecoder_x64.cpp
     VertexLoaderX64.cpp
+    VertexLoaderX64.h
   )
 elseif(_M_ARM_64)
   target_sources(videocommon PRIVATE
     VertexLoaderARM64.cpp
+    VertexLoaderARM64.h
     TextureDecoder_Generic.cpp
   )
 else()
@@ -87,7 +156,10 @@ else()
 endif()
 
 if(FFmpeg_FOUND)
-  target_sources(videocommon PRIVATE AVIDump.cpp)
+  target_sources(videocommon PRIVATE
+    AVIDump.cpp
+    AVIDump.h
+  )
   target_link_libraries(videocommon PRIVATE
     FFmpeg::avcodec
     FFmpeg::avformat


### PR DESCRIPTION
With the transition to CMake for Windows, one of the things lacking is that header files don't appear to be associated with their relevant projects like in the hand-rolled VS projects. This is unfortunate for several reasons:

1. It's more of a pain to find headers. You can toggle the header for the current translation unit. But if you need to find another header, it means going through a long list of external dependencies.

2. It can hinder VS extensions that operate on a by-project basis. If an extension doesn't know that a file is associated with a loaded project, it may not apply whatever it's supposed to do (e.g. extend highlighting, etc) to that source file.

3. We should have been specifying the headers to begin with (they're associated with the target, after all). e.g. If we ever needed to operate on a target or query headers from a target. It was previously impossible to do so. You'd need to directly query the file tree (slower, compared to just looking it up the respective target). Some CMakeLists already specify their headers as part of their target sources (e.g. D3D backends), so not every project needs to be touched.

This adds the headers that were missing in the respective CMakeLists files, which restores the inclusion of header files to generated IDE projects.