### PR TITLE
ControllerInterface/Device: Minor cleanup

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -256,7 +256,7 @@ bool DeviceContainer::HasConnectedDevice(const DeviceQualifier& qualifier) const
 // and also properly handles detection when using "FullAnalogSurface" inputs.
 // Upon input, return the detected Device and Input, else return nullptrs
 std::pair<std::shared_ptr<Device>, Device::Input*>
-DeviceContainer::DetectInput(u32 wait_ms, std::vector<std::string> device_strings)
+DeviceContainer::DetectInput(u32 wait_ms, const std::vector<std::string>& device_strings)
 {
   struct InputState
   {
@@ -273,7 +273,7 @@ DeviceContainer::DetectInput(u32 wait_ms, std::vector<std::string> device_string
 
   // Acquire devices and initial input states.
   std::vector<DeviceState> device_states;
-  for (auto& device_string : device_strings)
+  for (const auto& device_string : device_strings)
   {
     DeviceQualifier dq;
     dq.FromString(device_string);

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -256,7 +256,7 @@ bool DeviceContainer::HasConnectedDevice(const DeviceQualifier& qualifier) const
 // and also properly handles detection when using "FullAnalogSurface" inputs.
 // Upon input, return the detected Device and Input, else return nullptrs
 std::pair<std::shared_ptr<Device>, Device::Input*>
-DeviceContainer::DetectInput(u32 wait_ms, const std::vector<std::string>& device_strings)
+DeviceContainer::DetectInput(u32 wait_ms, const std::vector<std::string>& device_strings) const
 {
   struct InputState
   {

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -52,7 +52,7 @@ std::string Device::GetQualifiedName() const
   return StringFromFormat("%s/%i/%s", this->GetSource().c_str(), GetId(), this->GetName().c_str());
 }
 
-Device::Input* Device::FindInput(const std::string& name) const
+Device::Input* Device::FindInput(std::string_view name) const
 {
   for (Input* input : m_inputs)
   {
@@ -63,7 +63,7 @@ Device::Input* Device::FindInput(const std::string& name) const
   return nullptr;
 }
 
-Device::Output* Device::FindOutput(const std::string& name) const
+Device::Output* Device::FindOutput(std::string_view name) const
 {
   for (Output* output : m_outputs)
   {
@@ -74,7 +74,7 @@ Device::Output* Device::FindOutput(const std::string& name) const
   return nullptr;
 }
 
-bool Device::Control::IsMatchingName(const std::string& name) const
+bool Device::Control::IsMatchingName(std::string_view name) const
 {
   return GetName() == name;
 }
@@ -90,7 +90,7 @@ std::string Device::FullAnalogSurface::GetName() const
   return "Full " + m_high.GetName();
 }
 
-bool Device::FullAnalogSurface::IsMatchingName(const std::string& name) const
+bool Device::FullAnalogSurface::IsMatchingName(std::string_view name) const
 {
   if (Control::IsMatchingName(name))
     return true;
@@ -218,7 +218,7 @@ std::string DeviceContainer::GetDefaultDeviceString() const
   return device_qualifier.ToString();
 }
 
-Device::Input* DeviceContainer::FindInput(const std::string& name, const Device* def_dev) const
+Device::Input* DeviceContainer::FindInput(std::string_view name, const Device* def_dev) const
 {
   if (def_dev)
   {
@@ -239,7 +239,7 @@ Device::Input* DeviceContainer::FindInput(const std::string& name, const Device*
   return nullptr;
 }
 
-Device::Output* DeviceContainer::FindOutput(const std::string& name, const Device* def_dev) const
+Device::Output* DeviceContainer::FindOutput(std::string_view name, const Device* def_dev) const
 {
   return def_dev->FindOutput(name);
 }

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -156,8 +156,8 @@ class DeviceQualifier
 {
 public:
   DeviceQualifier() : cid(-1) {}
-  DeviceQualifier(const std::string& _source, const int _id, const std::string& _name)
-      : source(_source), cid(_id), name(_name)
+  DeviceQualifier(std::string source_, const int id_, std::string name_)
+      : source(std::move(source_)), cid(id_), name(std::move(name_))
   {
   }
   void FromDevice(const Device* const dev);

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -188,7 +188,7 @@ public:
   bool HasConnectedDevice(const DeviceQualifier& qualifier) const;
 
   std::pair<std::shared_ptr<Device>, Device::Input*>
-  DetectInput(u32 wait_ms, const std::vector<std::string>& device_strings);
+  DetectInput(u32 wait_ms, const std::vector<std::string>& device_strings) const;
 
 protected:
   mutable std::mutex m_devices_mutex;

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -42,14 +43,14 @@ public:
   class Control  // input or output
   {
   public:
+    virtual ~Control() = default;
     virtual std::string GetName() const = 0;
-    virtual ~Control() {}
     virtual Input* ToInput() { return nullptr; }
     virtual Output* ToOutput() { return nullptr; }
 
     // May be overridden to allow multiple valid names.
     // Useful for backwards-compatible configurations when names change.
-    virtual bool IsMatchingName(const std::string& name) const;
+    virtual bool IsMatchingName(std::string_view name) const;
   };
 
   //
@@ -111,8 +112,8 @@ public:
   const std::vector<Input*>& Inputs() const { return m_inputs; }
   const std::vector<Output*>& Outputs() const { return m_outputs; }
 
-  Input* FindInput(const std::string& name) const;
-  Output* FindOutput(const std::string& name) const;
+  Input* FindInput(std::string_view name) const;
+  Output* FindOutput(std::string_view name) const;
 
 protected:
   void AddInput(Input* const i);
@@ -124,7 +125,7 @@ protected:
     FullAnalogSurface(Input* low, Input* high) : m_low(*low), m_high(*high) {}
     ControlState GetState() const override;
     std::string GetName() const override;
-    bool IsMatchingName(const std::string& name) const override;
+    bool IsMatchingName(std::string_view name) const override;
 
   private:
     Input& m_low;
@@ -177,8 +178,8 @@ public:
 class DeviceContainer
 {
 public:
-  Device::Input* FindInput(const std::string& name, const Device* def_dev) const;
-  Device::Output* FindOutput(const std::string& name, const Device* def_dev) const;
+  Device::Input* FindInput(std::string_view name, const Device* def_dev) const;
+  Device::Output* FindOutput(std::string_view name, const Device* def_dev) const;
 
   std::vector<std::string> GetAllDeviceStrings() const;
   std::string GetDefaultDeviceString() const;

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -188,7 +188,7 @@ public:
   bool HasConnectedDevice(const DeviceQualifier& qualifier) const;
 
   std::pair<std::shared_ptr<Device>, Device::Input*>
-  DetectInput(u32 wait_ms, std::vector<std::string> device_strings);
+  DetectInput(u32 wait_ms, const std::vector<std::string>& device_strings);
 
 protected:
   mutable std::mutex m_devices_mutex;


### PR DESCRIPTION
Now that we're using C++17, a few parameters can be converted over to std::string_view instances, as they're only used in comparisons and not actually modified. While we're at it, we can make a few other minor touch-ups.