### PR TITLE
VideoCommon/VertexLoader_Normal: Construct look-up table at compile-time

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -23,11 +23,6 @@ namespace FifoAnalyzer
 bool s_DrawingObject;
 FifoAnalyzer::CPMemory s_CpMem;
 
-void Init()
-{
-  VertexLoader_Normal::Init();
-}
-
 u8 ReadFifo8(const u8*& data)
 {
   u8 value = data[0];

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -10,8 +10,6 @@
 
 namespace FifoAnalyzer
 {
-void Init();
-
 u8 ReadFifo8(const u8*& data);
 u16 ReadFifo16(const u8*& data);
 u32 ReadFifo32(const u8*& data);

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -49,7 +49,6 @@ bool FifoPlayer::Open(const std::string& filename)
 
   if (m_File)
   {
-    FifoAnalyzer::Init();
     FifoPlaybackAnalyzer::AnalyzeFrames(m_File.get(), m_FrameInfo);
 
     m_FrameRangeEnd = m_File->GetFrameCount();

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -22,8 +22,6 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
 {
   std::lock_guard<std::recursive_mutex> lk(m_mutex);
 
-  FifoAnalyzer::Init();
-
   m_File = std::make_unique<FifoDataFile>();
 
   // TODO: This, ideally, would be deallocated when done recording.

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -68,8 +68,6 @@ static void SkipVertex(VertexLoader* loader)
 VertexLoader::VertexLoader(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
     : VertexLoaderBase(vtx_desc, vtx_attr)
 {
-  VertexLoader_Normal::Init();
-
   CompileVertexTranslator();
 
   // generate frac factors

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -176,15 +176,12 @@ void VertexLoader_Normal::Init()
   m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT] = Normal_Index_Indices3<u16, float>();
 }
 
-unsigned int VertexLoader_Normal::GetSize(u64 _type, unsigned int _format, unsigned int _elements,
-                                          unsigned int _index3)
+u32 VertexLoader_Normal::GetSize(u64 type, u32 format, u32 elements, u32 index3)
 {
-  return m_Table[_type][_index3][_elements][_format].gc_size;
+  return m_Table[type][index3][elements][format].gc_size;
 }
 
-TPipelineFunction VertexLoader_Normal::GetFunction(u64 _type, unsigned int _format,
-                                                   unsigned int _elements, unsigned int _index3)
+TPipelineFunction VertexLoader_Normal::GetFunction(u64 type, u32 format, u32 elements, u32 index3)
 {
-  TPipelineFunction pFunc = m_Table[_type][_index3][_elements][_format].function;
-  return pFunc;
+  return m_Table[type][index3][elements][format].function;
 }

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -30,7 +30,7 @@ constexpr float FracAdjust(T val)
   // auto const U16FRAC = 1.f / (1u << 15);
 
   // TODO: is this right?
-  return val / float(1u << (sizeof(T) * 8 - std::is_signed<T>::value - 1));
+  return val / float(1u << (sizeof(T) * 8 - std::is_signed_v<T> - 1));
 }
 
 template <>
@@ -70,7 +70,7 @@ struct Normal_Direct
 template <typename I, typename T, u32 N, u32 Offset>
 void Normal_Index_Offset()
 {
-  static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
+  static_assert(std::is_unsigned_v<I>, "Only unsigned I is sane!");
 
   auto const index = DataRead<I>();
   auto const data = reinterpret_cast<const T*>(

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -4,11 +4,10 @@
 
 #include "VideoCommon/VertexLoader_Normal.h"
 
-#include <cmath>
+#include <array>
 #include <type_traits>
 
 #include "Common/CommonTypes.h"
-#include "Common/Compiler.h"
 
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoader.h"
@@ -20,13 +19,10 @@
                     // ((float*)g_vertex_manager_write_ptr)[-2],
                     // ((float*)g_vertex_manager_write_ptr)[-1]);
 
-VertexLoader_Normal::Set VertexLoader_Normal::m_Table[NUM_NRM_TYPE][NUM_NRM_INDICES]
-                                                     [NUM_NRM_ELEMENTS][NUM_NRM_FORMAT];
-
 namespace
 {
 template <typename T>
-DOLPHIN_FORCE_INLINE float FracAdjust(T val)
+constexpr float FracAdjust(T val)
 {
   // auto const S8FRAC = 1.f / (1u << 6);
   // auto const U8FRAC = 1.f / (1u << 7);
@@ -38,18 +34,18 @@ DOLPHIN_FORCE_INLINE float FracAdjust(T val)
 }
 
 template <>
-DOLPHIN_FORCE_INLINE float FracAdjust(float val)
+constexpr float FracAdjust(float val)
 {
   return val;
 }
 
-template <typename T, int N>
-DOLPHIN_FORCE_INLINE void ReadIndirect(const T* data)
+template <typename T, u32 N>
+void ReadIndirect(const T* data)
 {
   static_assert(3 == N || 9 == N, "N is only sane as 3 or 9!");
   DataReader dst(g_vertex_manager_write_ptr, nullptr);
 
-  for (int i = 0; i != N; ++i)
+  for (u32 i = 0; i < N; ++i)
   {
     dst.Write(FracAdjust(Common::FromBigEndian(data[i])));
   }
@@ -58,21 +54,21 @@ DOLPHIN_FORCE_INLINE void ReadIndirect(const T* data)
   LOG_NORM();
 }
 
-template <typename T, int N>
+template <typename T, u32 N>
 struct Normal_Direct
 {
-  static void function(VertexLoader* loader)
+  static void function([[maybe_unused]] VertexLoader* loader)
   {
     auto const source = reinterpret_cast<const T*>(DataGetPosition());
     ReadIndirect<T, N * 3>(source);
     DataSkip<N * 3 * sizeof(T)>();
   }
 
-  static const int size = sizeof(T) * N * 3;
+  static constexpr u32 size = sizeof(T) * N * 3;
 };
 
-template <typename I, typename T, int N, int Offset>
-DOLPHIN_FORCE_INLINE void Normal_Index_Offset()
+template <typename I, typename T, u32 N, u32 Offset>
+void Normal_Index_Offset()
 {
   static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
 
@@ -83,105 +79,163 @@ DOLPHIN_FORCE_INLINE void Normal_Index_Offset()
   ReadIndirect<T, N * 3>(data);
 }
 
-template <typename I, typename T, int N>
+template <typename I, typename T, u32 N>
 struct Normal_Index
 {
-  static void function(VertexLoader* loader) { Normal_Index_Offset<I, T, N, 0>(); }
-  static const int size = sizeof(I);
+  static void function([[maybe_unused]] VertexLoader* loader) { Normal_Index_Offset<I, T, N, 0>(); }
+  static constexpr u32 size = sizeof(I);
 };
 
 template <typename I, typename T>
 struct Normal_Index_Indices3
 {
-  static void function(VertexLoader* loader)
+  static void function([[maybe_unused]] VertexLoader* loader)
   {
     Normal_Index_Offset<I, T, 1, 0>();
     Normal_Index_Offset<I, T, 1, 1>();
     Normal_Index_Offset<I, T, 1, 2>();
   }
 
-  static const int size = sizeof(I) * 3;
+  static constexpr u32 size = sizeof(I) * 3;
 };
-}  // namespace
 
-void VertexLoader_Normal::Init()
+enum NormalType
 {
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_UBYTE] = Normal_Direct<u8, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_BYTE] = Normal_Direct<s8, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_USHORT] = Normal_Direct<u16, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_SHORT] = Normal_Direct<s16, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_FLOAT] = Normal_Direct<float, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_UBYTE] = Normal_Direct<u8, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_BYTE] = Normal_Direct<s8, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_USHORT] = Normal_Direct<u16, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_SHORT] = Normal_Direct<s16, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_FLOAT] = Normal_Direct<float, 3>();
+  NRM_NOT_PRESENT = 0,
+  NRM_DIRECT = 1,
+  NRM_INDEX8 = 2,
+  NRM_INDEX16 = 3,
+  NUM_NRM_TYPE
+};
+
+enum NormalFormat
+{
+  FORMAT_UBYTE = 0,
+  FORMAT_BYTE = 1,
+  FORMAT_USHORT = 2,
+  FORMAT_SHORT = 3,
+  FORMAT_FLOAT = 4,
+  NUM_NRM_FORMAT
+};
+
+enum NormalElements
+{
+  NRM_NBT = 0,
+  NRM_NBT3 = 1,
+  NUM_NRM_ELEMENTS
+};
+
+enum NormalIndices
+{
+  NRM_INDICES1 = 0,
+  NRM_INDICES3 = 1,
+  NUM_NRM_INDICES
+};
+
+struct Set
+{
+  template <typename T>
+  constexpr Set& operator=(const T&)
+  {
+    gc_size = T::size;
+    function = T::function;
+    return *this;
+  }
+
+  u32 gc_size;
+  TPipelineFunction function;
+};
+
+using Formats = std::array<Set, NUM_NRM_FORMAT>;
+using Elements = std::array<Formats, NUM_NRM_ELEMENTS>;
+using Indices = std::array<Elements, NUM_NRM_INDICES>;
+using Types = std::array<Indices, NUM_NRM_TYPE>;
+
+constexpr Types InitializeTable()
+{
+  Types table{};
+
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_UBYTE] = Normal_Direct<u8, 1>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_BYTE] = Normal_Direct<s8, 1>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_USHORT] = Normal_Direct<u16, 1>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_SHORT] = Normal_Direct<s16, 1>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT][FORMAT_FLOAT] = Normal_Direct<float, 1>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_UBYTE] = Normal_Direct<u8, 3>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_BYTE] = Normal_Direct<s8, 3>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_USHORT] = Normal_Direct<u16, 3>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_SHORT] = Normal_Direct<s16, 3>();
+  table[NRM_DIRECT][NRM_INDICES1][NRM_NBT3][FORMAT_FLOAT] = Normal_Direct<float, 3>();
 
   // Same as above
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_UBYTE] = Normal_Direct<u8, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_BYTE] = Normal_Direct<s8, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_USHORT] = Normal_Direct<u16, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_SHORT] = Normal_Direct<s16, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_FLOAT] = Normal_Direct<float, 1>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_UBYTE] = Normal_Direct<u8, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_BYTE] = Normal_Direct<s8, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_USHORT] = Normal_Direct<u16, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_SHORT] = Normal_Direct<s16, 3>();
-  m_Table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT] = Normal_Direct<float, 3>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_UBYTE] = Normal_Direct<u8, 1>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_BYTE] = Normal_Direct<s8, 1>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_USHORT] = Normal_Direct<u16, 1>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_SHORT] = Normal_Direct<s16, 1>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT][FORMAT_FLOAT] = Normal_Direct<float, 1>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_UBYTE] = Normal_Direct<u8, 3>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_BYTE] = Normal_Direct<s8, 3>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_USHORT] = Normal_Direct<u16, 3>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_SHORT] = Normal_Direct<s16, 3>();
+  table[NRM_DIRECT][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT] = Normal_Direct<float, 3>();
 
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u8, u8, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_BYTE] = Normal_Index<u8, s8, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_USHORT] = Normal_Index<u8, u16, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_SHORT] = Normal_Index<u8, s16, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u8, float, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_UBYTE] = Normal_Index<u8, u8, 3>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_BYTE] = Normal_Index<u8, s8, 3>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_USHORT] = Normal_Index<u8, u16, 3>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_SHORT] = Normal_Index<u8, s16, 3>();
-  m_Table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_FLOAT] = Normal_Index<u8, float, 3>();
-
-  // Same as above for NRM_NBT
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u8, u8, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_BYTE] = Normal_Index<u8, s8, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_USHORT] = Normal_Index<u8, u16, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_SHORT] = Normal_Index<u8, s16, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u8, float, 1>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_UBYTE] = Normal_Index_Indices3<u8, u8>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_BYTE] = Normal_Index_Indices3<u8, s8>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_USHORT] = Normal_Index_Indices3<u8, u16>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_SHORT] = Normal_Index_Indices3<u8, s16>();
-  m_Table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT] = Normal_Index_Indices3<u8, float>();
-
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u16, u8, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_BYTE] = Normal_Index<u16, s8, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_USHORT] = Normal_Index<u16, u16, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_SHORT] = Normal_Index<u16, s16, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u16, float, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_UBYTE] = Normal_Index<u16, u8, 3>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_BYTE] = Normal_Index<u16, s8, 3>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_USHORT] = Normal_Index<u16, u16, 3>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_SHORT] = Normal_Index<u16, s16, 3>();
-  m_Table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_FLOAT] = Normal_Index<u16, float, 3>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u8, u8, 1>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_BYTE] = Normal_Index<u8, s8, 1>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_USHORT] = Normal_Index<u8, u16, 1>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_SHORT] = Normal_Index<u8, s16, 1>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u8, float, 1>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_UBYTE] = Normal_Index<u8, u8, 3>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_BYTE] = Normal_Index<u8, s8, 3>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_USHORT] = Normal_Index<u8, u16, 3>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_SHORT] = Normal_Index<u8, s16, 3>();
+  table[NRM_INDEX8][NRM_INDICES1][NRM_NBT3][FORMAT_FLOAT] = Normal_Index<u8, float, 3>();
 
   // Same as above for NRM_NBT
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u16, u8, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_BYTE] = Normal_Index<u16, s8, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_USHORT] = Normal_Index<u16, u16, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_SHORT] = Normal_Index<u16, s16, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u16, float, 1>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_UBYTE] = Normal_Index_Indices3<u16, u8>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_BYTE] = Normal_Index_Indices3<u16, s8>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_USHORT] = Normal_Index_Indices3<u16, u16>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_SHORT] = Normal_Index_Indices3<u16, s16>();
-  m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT] = Normal_Index_Indices3<u16, float>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u8, u8, 1>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_BYTE] = Normal_Index<u8, s8, 1>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_USHORT] = Normal_Index<u8, u16, 1>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_SHORT] = Normal_Index<u8, s16, 1>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u8, float, 1>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_UBYTE] = Normal_Index_Indices3<u8, u8>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_BYTE] = Normal_Index_Indices3<u8, s8>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_USHORT] = Normal_Index_Indices3<u8, u16>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_SHORT] = Normal_Index_Indices3<u8, s16>();
+  table[NRM_INDEX8][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT] = Normal_Index_Indices3<u8, float>();
+
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u16, u8, 1>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_BYTE] = Normal_Index<u16, s8, 1>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_USHORT] = Normal_Index<u16, u16, 1>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_SHORT] = Normal_Index<u16, s16, 1>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u16, float, 1>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_UBYTE] = Normal_Index<u16, u8, 3>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_BYTE] = Normal_Index<u16, s8, 3>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_USHORT] = Normal_Index<u16, u16, 3>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_SHORT] = Normal_Index<u16, s16, 3>();
+  table[NRM_INDEX16][NRM_INDICES1][NRM_NBT3][FORMAT_FLOAT] = Normal_Index<u16, float, 3>();
+
+  // Same as above for NRM_NBT
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_UBYTE] = Normal_Index<u16, u8, 1>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_BYTE] = Normal_Index<u16, s8, 1>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_USHORT] = Normal_Index<u16, u16, 1>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_SHORT] = Normal_Index<u16, s16, 1>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT][FORMAT_FLOAT] = Normal_Index<u16, float, 1>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_UBYTE] = Normal_Index_Indices3<u16, u8>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_BYTE] = Normal_Index_Indices3<u16, s8>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_USHORT] = Normal_Index_Indices3<u16, u16>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_SHORT] = Normal_Index_Indices3<u16, s16>();
+  table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT] = Normal_Index_Indices3<u16, float>();
+
+  return table;
 }
+
+constexpr Types s_table = InitializeTable();
+}  // Anonymous namespace
 
 u32 VertexLoader_Normal::GetSize(u64 type, u32 format, u32 elements, u32 index3)
 {
-  return m_Table[type][index3][elements][format].gc_size;
+  return s_table[type][index3][elements][format].gc_size;
 }
 
 TPipelineFunction VertexLoader_Normal::GetFunction(u64 type, u32 format, u32 elements, u32 index3)
 {
-  return m_Table[type][index3][elements][format].function;
+  return s_table[type][index3][elements][format].function;
 }

--- a/Source/Core/VideoCommon/VertexLoader_Normal.h
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.h
@@ -17,7 +17,7 @@ public:
   static TPipelineFunction GetFunction(u64 type, u32 format, u32 elements, u32 index3);
 
 private:
-  enum ENormalType
+  enum NormalType
   {
     NRM_NOT_PRESENT = 0,
     NRM_DIRECT = 1,
@@ -26,7 +26,7 @@ private:
     NUM_NRM_TYPE
   };
 
-  enum ENormalFormat
+  enum NormalFormat
   {
     FORMAT_UBYTE = 0,
     FORMAT_BYTE = 1,
@@ -36,14 +36,14 @@ private:
     NUM_NRM_FORMAT
   };
 
-  enum ENormalElements
+  enum NormalElements
   {
     NRM_NBT = 0,
     NRM_NBT3 = 1,
     NUM_NRM_ELEMENTS
   };
 
-  enum ENormalIndices
+  enum NormalIndices
   {
     NRM_INDICES1 = 0,
     NRM_INDICES3 = 1,

--- a/Source/Core/VideoCommon/VertexLoader_Normal.h
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.h
@@ -10,58 +10,7 @@
 class VertexLoader_Normal
 {
 public:
-  static void Init();
-
   static u32 GetSize(u64 type, u32 format, u32 elements, u32 index3);
 
   static TPipelineFunction GetFunction(u64 type, u32 format, u32 elements, u32 index3);
-
-private:
-  enum NormalType
-  {
-    NRM_NOT_PRESENT = 0,
-    NRM_DIRECT = 1,
-    NRM_INDEX8 = 2,
-    NRM_INDEX16 = 3,
-    NUM_NRM_TYPE
-  };
-
-  enum NormalFormat
-  {
-    FORMAT_UBYTE = 0,
-    FORMAT_BYTE = 1,
-    FORMAT_USHORT = 2,
-    FORMAT_SHORT = 3,
-    FORMAT_FLOAT = 4,
-    NUM_NRM_FORMAT
-  };
-
-  enum NormalElements
-  {
-    NRM_NBT = 0,
-    NRM_NBT3 = 1,
-    NUM_NRM_ELEMENTS
-  };
-
-  enum NormalIndices
-  {
-    NRM_INDICES1 = 0,
-    NRM_INDICES3 = 1,
-    NUM_NRM_INDICES
-  };
-
-  struct Set
-  {
-    template <typename T>
-    void operator=(const T&)
-    {
-      gc_size = T::size;
-      function = T::function;
-    }
-
-    int gc_size;
-    TPipelineFunction function;
-  };
-
-  static Set m_Table[NUM_NRM_TYPE][NUM_NRM_INDICES][NUM_NRM_ELEMENTS][NUM_NRM_FORMAT];
 };

--- a/Source/Core/VideoCommon/VertexLoader_Normal.h
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.h
@@ -10,16 +10,11 @@
 class VertexLoader_Normal
 {
 public:
-  // Init
   static void Init();
 
-  // GetSize
-  static unsigned int GetSize(u64 _type, unsigned int _format, unsigned int _elements,
-                              unsigned int _index3);
+  static u32 GetSize(u64 type, u32 format, u32 elements, u32 index3);
 
-  // GetFunction
-  static TPipelineFunction GetFunction(u64 _type, unsigned int _format, unsigned int _elements,
-                                       unsigned int _index3);
+  static TPipelineFunction GetFunction(u64 type, u32 format, u32 elements, u32 index3);
 
 private:
   enum ENormalType


### PR DESCRIPTION
Removes the need for an `Init()` function from VertexLoader_Normal and makes it completely stateless, leaving it with only getters similar to the other VertexLoader_* types.

The elimination of the `Init()` function also allows for removal of FifoAnalyzer's `Init()` function, as the only reason it existed was to call VertexLoader_Normal's `Init()` function.