### PR TITLE
 VideoCommon/RenderBase: Use std::string_view with CreateShaderFromSource()

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -113,10 +113,10 @@ std::unique_ptr<AbstractFramebuffer> Renderer::CreateFramebuffer(AbstractTexture
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 const char* source, size_t length)
+                                                                 std::string_view source)
 {
   DXShader::BinaryData bytecode;
-  if (!DXShader::CompileShader(D3D::feature_level, &bytecode, stage, source, length))
+  if (!DXShader::CompileShader(D3D::feature_level, &bytecode, stage, source))
     return nullptr;
 
   return DXShader::CreateFromBytecode(stage, std::move(bytecode));

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <d3d11.h>
-#include <string>
+#include <string_view>
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoCommon/RenderBase.h"
 
@@ -28,8 +28,8 @@ public:
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, const char* source,
-                                                         size_t length) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
+                                                         std::string_view source) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/D3D12/DXShader.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXShader.cpp
@@ -24,11 +24,10 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
   return shader;
 }
 
-std::unique_ptr<DXShader> DXShader::CreateFromSource(ShaderStage stage, const char* source,
-                                                     size_t length)
+std::unique_ptr<DXShader> DXShader::CreateFromSource(ShaderStage stage, std::string_view source)
 {
   BinaryData bytecode;
-  if (!CompileShader(g_dx_context->GetFeatureLevel(), &bytecode, stage, source, length))
+  if (!CompileShader(g_dx_context->GetFeatureLevel(), &bytecode, stage, source))
     return nullptr;
 
   return CreateFromBytecode(stage, std::move(bytecode));

--- a/Source/Core/VideoBackends/D3D12/DXShader.h
+++ b/Source/Core/VideoBackends/D3D12/DXShader.h
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include <memory>
+#include <string_view>
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3DCommon/Shader.h"
 
@@ -18,8 +20,7 @@ public:
   D3D12_SHADER_BYTECODE GetD3DByteCode() const;
 
   static std::unique_ptr<DXShader> CreateFromBytecode(ShaderStage stage, BinaryData bytecode);
-  static std::unique_ptr<DXShader> CreateFromSource(ShaderStage stage, const char* source,
-                                                    size_t length);
+  static std::unique_ptr<DXShader> CreateFromSource(ShaderStage stage, std::string_view source);
 
 private:
   DXShader(ShaderStage stage, BinaryData bytecode);

--- a/Source/Core/VideoBackends/D3D12/Renderer.cpp
+++ b/Source/Core/VideoBackends/D3D12/Renderer.cpp
@@ -82,9 +82,9 @@ std::unique_ptr<AbstractFramebuffer> Renderer::CreateFramebuffer(AbstractTexture
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 const char* source, size_t length)
+                                                                 std::string_view source)
 {
-  return DXShader::CreateFromSource(stage, source, length);
+  return DXShader::CreateFromSource(stage, source);
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,

--- a/Source/Core/VideoBackends/D3D12/Renderer.h
+++ b/Source/Core/VideoBackends/D3D12/Renderer.h
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include <d3d12.h>
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
 #include "VideoCommon/RenderBase.h"
@@ -35,8 +36,8 @@ public:
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, const char* source,
-                                                         size_t length) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
+                                                         std::string_view source) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -90,7 +90,7 @@ static const char* GetCompileTarget(D3D_FEATURE_LEVEL feature_level, ShaderStage
 }
 
 bool Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_bytecode,
-                           ShaderStage stage, const char* source, size_t length)
+                           ShaderStage stage, std::string_view source)
 {
   static constexpr D3D_SHADER_MACRO macros[] = {{"API_D3D", "1"}, {nullptr, nullptr}};
   const UINT flags = g_ActiveConfig.bEnableValidationLayer ?
@@ -100,8 +100,8 @@ bool Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_byte
 
   Microsoft::WRL::ComPtr<ID3DBlob> code;
   Microsoft::WRL::ComPtr<ID3DBlob> errors;
-  HRESULT hr = d3d_compile(source, length, nullptr, macros, nullptr, "main", target, flags, 0,
-                           &code, &errors);
+  HRESULT hr = d3d_compile(source.data(), source.size(), nullptr, macros, nullptr, "main", target,
+                           flags, 0, &code, &errors);
   if (FAILED(hr))
   {
     static int num_failures = 0;
@@ -109,7 +109,7 @@ bool Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_byte
         "%sbad_%s_%04i.txt", File::GetUserPath(D_DUMP_IDX).c_str(), target, num_failures++);
     std::ofstream file;
     File::OpenFStream(file, filename, std::ios_base::out);
-    file.write(source, length);
+    file.write(source.data(), source.size());
     file << "\n";
     file.write(static_cast<const char*>(errors->GetBufferPointer()), errors->GetBufferSize());
     file.close();

--- a/Source/Core/VideoBackends/D3DCommon/Shader.h
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.h
@@ -3,7 +3,8 @@
 // Refer to the license.txt file included.
 
 #pragma once
-#include <memory>
+
+#include <string_view>
 #include "VideoBackends/D3DCommon/Common.h"
 #include "VideoCommon/AbstractShader.h"
 
@@ -19,7 +20,7 @@ public:
   BinaryData GetBinary() const override;
 
   static bool CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_bytecode,
-                            ShaderStage stage, const char* source, size_t length);
+                            ShaderStage stage, std::string_view source);
 
   static BinaryData CreateByteCode(const void* data, size_t length);
 

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -48,8 +48,8 @@ public:
   ~NullShader() = default;
 };
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 const char* source, size_t length)
+std::unique_ptr<AbstractShader>
+Renderer::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source)
 {
   return std::make_unique<NullShader>(stage);
 }

--- a/Source/Core/VideoBackends/Null/Render.h
+++ b/Source/Core/VideoBackends/Null/Render.h
@@ -22,8 +22,8 @@ public:
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, const char* source,
-                                                         size_t length) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
+                                                         std::string_view source) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/OGL/OGLShader.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLShader.cpp
@@ -45,10 +45,9 @@ OGLShader::~OGLShader()
     glDeleteProgram(m_gl_compute_program_id);
 }
 
-std::unique_ptr<OGLShader> OGLShader::CreateFromSource(ShaderStage stage, const char* source,
-                                                       size_t length)
+std::unique_ptr<OGLShader> OGLShader::CreateFromSource(ShaderStage stage, std::string_view source)
 {
-  std::string source_str(source, length);
+  std::string source_str(source);
   if (stage != ShaderStage::Compute)
   {
     GLenum shader_type = GetGLShaderTypeForStage(stage);

--- a/Source/Core/VideoBackends/OGL/OGLShader.h
+++ b/Source/Core/VideoBackends/OGL/OGLShader.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
@@ -26,8 +27,7 @@ public:
   GLuint GetGLComputeProgramID() const { return m_gl_compute_program_id; }
   const std::string& GetSource() const { return m_source; }
 
-  static std::unique_ptr<OGLShader> CreateFromSource(ShaderStage stage, const char* source,
-                                                     size_t length);
+  static std::unique_ptr<OGLShader> CreateFromSource(ShaderStage stage, std::string_view source);
 
 private:
   u64 m_id;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -832,9 +832,9 @@ std::unique_ptr<AbstractFramebuffer> Renderer::CreateFramebuffer(AbstractTexture
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 const char* source, size_t length)
+                                                                 std::string_view source)
 {
-  return OGLShader::CreateFromSource(stage, source, length);
+  return OGLShader::CreateFromSource(stage, source);
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -95,8 +95,8 @@ public:
   std::unique_ptr<AbstractTexture> CreateTexture(const TextureConfig& config) override;
   std::unique_ptr<AbstractStagingTexture>
   CreateStagingTexture(StagingTextureType type, const TextureConfig& config) override;
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, const char* source,
-                                                         size_t length) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
+                                                         std::string_view source) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -68,7 +68,7 @@ public:
 };
 
 std::unique_ptr<AbstractShader>
-SWRenderer::CreateShaderFromSource(ShaderStage stage, const char* source, size_t length)
+SWRenderer::CreateShaderFromSource(ShaderStage stage, [[maybe_unused]] std::string_view source)
 {
   return std::make_unique<SWShader>(stage);
 }

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -27,8 +27,8 @@ public:
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, const char* source,
-                                                         size_t length) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
+                                                         std::string_view source) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -95,9 +95,9 @@ std::unique_ptr<AbstractStagingTexture> Renderer::CreateStagingTexture(StagingTe
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 const char* source, size_t length)
+                                                                 std::string_view source)
 {
-  return VKShader::CreateFromSource(stage, source, length);
+  return VKShader::CreateFromSource(stage, source);
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -42,8 +42,8 @@ public:
   std::unique_ptr<AbstractFramebuffer>
   CreateFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment) override;
 
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage, const char* source,
-                                                         size_t length) override;
+  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
+                                                         std::string_view source) override;
   std::unique_ptr<AbstractShader> CreateShaderFromBinary(ShaderStage stage, const void* data,
                                                          size_t length) override;
   std::unique_ptr<NativeVertexFormat>

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -17,7 +17,6 @@
 #include "ShaderLang.h"
 #include "disassemble.h"
 
-#include "Common/CommonFuncs.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -127,7 +126,7 @@ std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage, const char*
   int pass_source_code_length = static_cast<int>(source.size());
   if (!header.empty())
   {
-    constexpr size_t subgroup_helper_header_length = ArraySize(SUBGROUP_HELPER_HEADER) - 1;
+    constexpr size_t subgroup_helper_header_length = std::size(SUBGROUP_HELPER_HEADER) - 1;
     full_source_code.reserve(header.size() + subgroup_helper_header_length + source.size());
     full_source_code.append(header);
     if (g_vulkan_context->SupportsShaderSubgroupOperations())

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.h
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string_view>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -18,20 +19,16 @@ using SPIRVCodeType = u32;
 using SPIRVCodeVector = std::vector<SPIRVCodeType>;
 
 // Compile a vertex shader to SPIR-V.
-bool CompileVertexShader(SPIRVCodeVector* out_code, const char* source_code,
-                         size_t source_code_length);
+bool CompileVertexShader(SPIRVCodeVector* out_code, std::string_view source_code);
 
 // Compile a geometry shader to SPIR-V.
-bool CompileGeometryShader(SPIRVCodeVector* out_code, const char* source_code,
-                           size_t source_code_length);
+bool CompileGeometryShader(SPIRVCodeVector* out_code, std::string_view source_code);
 
 // Compile a fragment shader to SPIR-V.
-bool CompileFragmentShader(SPIRVCodeVector* out_code, const char* source_code,
-                           size_t source_code_length);
+bool CompileFragmentShader(SPIRVCodeVector* out_code, std::string_view source_code);
 
 // Compile a compute shader to SPIR-V.
-bool CompileComputeShader(SPIRVCodeVector* out_code, const char* source_code,
-                          size_t source_code_length);
+bool CompileComputeShader(SPIRVCodeVector* out_code, std::string_view source_code);
 
 }  // namespace ShaderCompiler
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.h
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -19,16 +20,16 @@ using SPIRVCodeType = u32;
 using SPIRVCodeVector = std::vector<SPIRVCodeType>;
 
 // Compile a vertex shader to SPIR-V.
-bool CompileVertexShader(SPIRVCodeVector* out_code, std::string_view source_code);
+std::optional<SPIRVCodeVector> CompileVertexShader(std::string_view source_code);
 
 // Compile a geometry shader to SPIR-V.
-bool CompileGeometryShader(SPIRVCodeVector* out_code, std::string_view source_code);
+std::optional<SPIRVCodeVector> CompileGeometryShader(std::string_view source_code);
 
 // Compile a fragment shader to SPIR-V.
-bool CompileFragmentShader(SPIRVCodeVector* out_code, std::string_view source_code);
+std::optional<SPIRVCodeVector> CompileFragmentShader(std::string_view source_code);
 
 // Compile a compute shader to SPIR-V.
-bool CompileComputeShader(SPIRVCodeVector* out_code, std::string_view source_code);
+std::optional<SPIRVCodeVector> CompileComputeShader(std::string_view source_code);
 
 }  // namespace ShaderCompiler
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/VKShader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.cpp
@@ -88,31 +88,29 @@ static std::unique_ptr<VKShader> CreateShaderObject(ShaderStage stage,
 
 std::unique_ptr<VKShader> VKShader::CreateFromSource(ShaderStage stage, std::string_view source)
 {
-  ShaderCompiler::SPIRVCodeVector spv;
-  bool result;
+  std::optional<ShaderCompiler::SPIRVCodeVector> spv;
   switch (stage)
   {
   case ShaderStage::Vertex:
-    result = ShaderCompiler::CompileVertexShader(&spv, source);
+    spv = ShaderCompiler::CompileVertexShader(source);
     break;
   case ShaderStage::Geometry:
-    result = ShaderCompiler::CompileGeometryShader(&spv, source);
+    spv = ShaderCompiler::CompileGeometryShader(source);
     break;
   case ShaderStage::Pixel:
-    result = ShaderCompiler::CompileFragmentShader(&spv, source);
+    spv = ShaderCompiler::CompileFragmentShader(source);
     break;
   case ShaderStage::Compute:
-    result = ShaderCompiler::CompileComputeShader(&spv, source);
+    spv = ShaderCompiler::CompileComputeShader(source);
     break;
   default:
-    result = false;
     break;
   }
 
-  if (!result)
+  if (!spv)
     return nullptr;
 
-  return CreateShaderObject(stage, std::move(spv));
+  return CreateShaderObject(stage, std::move(*spv));
 }
 
 std::unique_ptr<VKShader> VKShader::CreateFromBinary(ShaderStage stage, const void* data,

--- a/Source/Core/VideoBackends/Vulkan/VKShader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.cpp
@@ -86,24 +86,23 @@ static std::unique_ptr<VKShader> CreateShaderObject(ShaderStage stage,
   return std::make_unique<VKShader>(std::move(spv), pipeline);
 }
 
-std::unique_ptr<VKShader> VKShader::CreateFromSource(ShaderStage stage, const char* source,
-                                                     size_t length)
+std::unique_ptr<VKShader> VKShader::CreateFromSource(ShaderStage stage, std::string_view source)
 {
   ShaderCompiler::SPIRVCodeVector spv;
   bool result;
   switch (stage)
   {
   case ShaderStage::Vertex:
-    result = ShaderCompiler::CompileVertexShader(&spv, source, length);
+    result = ShaderCompiler::CompileVertexShader(&spv, source);
     break;
   case ShaderStage::Geometry:
-    result = ShaderCompiler::CompileGeometryShader(&spv, source, length);
+    result = ShaderCompiler::CompileGeometryShader(&spv, source);
     break;
   case ShaderStage::Pixel:
-    result = ShaderCompiler::CompileFragmentShader(&spv, source, length);
+    result = ShaderCompiler::CompileFragmentShader(&spv, source);
     break;
   case ShaderStage::Compute:
-    result = ShaderCompiler::CompileComputeShader(&spv, source, length);
+    result = ShaderCompiler::CompileComputeShader(&spv, source);
     break;
   default:
     result = false;

--- a/Source/Core/VideoBackends/Vulkan/VKShader.h
+++ b/Source/Core/VideoBackends/Vulkan/VKShader.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -25,8 +26,7 @@ public:
   VkPipeline GetComputePipeline() const { return m_compute_pipeline; }
   BinaryData GetBinary() const override;
 
-  static std::unique_ptr<VKShader> CreateFromSource(ShaderStage stage, const char* source,
-                                                    size_t length);
+  static std::unique_ptr<VKShader> CreateFromSource(ShaderStage stage, std::string_view source);
   static std::unique_ptr<VKShader> CreateFromBinary(ShaderStage stage, const void* data,
                                                     size_t length);
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -148,12 +148,6 @@ void Renderer::SetAndClearFramebuffer(AbstractFramebuffer* framebuffer,
   m_current_framebuffer = framebuffer;
 }
 
-std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
-                                                                 const std::string& source)
-{
-  return CreateShaderFromSource(stage, source.c_str(), source.size());
-}
-
 bool Renderer::EFBHasAlphaChannel() const
 {
   return m_prev_efb_format == PEControl::RGBA6_Z24;
@@ -980,10 +974,10 @@ bool Renderer::InitializeImGui()
 
   const std::string vertex_shader_source = GenerateImGuiVertexShader();
   const std::string pixel_shader_source = GenerateImGuiPixelShader();
-  std::unique_ptr<AbstractShader> vertex_shader = CreateShaderFromSource(
-      ShaderStage::Vertex, vertex_shader_source.c_str(), vertex_shader_source.size());
-  std::unique_ptr<AbstractShader> pixel_shader = CreateShaderFromSource(
-      ShaderStage::Pixel, pixel_shader_source.c_str(), pixel_shader_source.size());
+  std::unique_ptr<AbstractShader> vertex_shader =
+      CreateShaderFromSource(ShaderStage::Vertex, vertex_shader_source);
+  std::unique_ptr<AbstractShader> pixel_shader =
+      CreateShaderFromSource(ShaderStage::Pixel, pixel_shader_source);
   if (!vertex_shader || !pixel_shader)
   {
     PanicAlert("Failed to compile imgui shaders");

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <tuple>
 #include <vector>
@@ -123,8 +124,8 @@ public:
   virtual void PresentBackbuffer() {}
 
   // Shader modules/objects.
-  virtual std::unique_ptr<AbstractShader>
-  CreateShaderFromSource(ShaderStage stage, const char* source, size_t length) = 0;
+  virtual std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
+                                                                 std::string_view source) = 0;
   virtual std::unique_ptr<AbstractShader>
   CreateShaderFromBinary(ShaderStage stage, const void* data, size_t length) = 0;
   virtual std::unique_ptr<NativeVertexFormat>
@@ -132,8 +133,6 @@ public:
   virtual std::unique_ptr<AbstractPipeline> CreatePipeline(const AbstractPipelineConfig& config,
                                                            const void* cache_data = nullptr,
                                                            size_t cache_data_length = 0) = 0;
-  std::unique_ptr<AbstractShader> CreateShaderFromSource(ShaderStage stage,
-                                                         const std::string& source);
 
   AbstractFramebuffer* GetCurrentFramebuffer() const { return m_current_framebuffer; }
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -392,32 +392,32 @@ void ShaderCache::CompileMissingPipelines()
 
 std::unique_ptr<AbstractShader> ShaderCache::CompileVertexShader(const VertexShaderUid& uid) const
 {
-  ShaderCode source_code = GenerateVertexShaderCode(m_api_type, m_host_config, uid.GetUidData());
-  return g_renderer->CreateShaderFromSource(ShaderStage::Vertex, source_code.GetBuffer().c_str(),
-                                            source_code.GetBuffer().size());
+  const ShaderCode source_code =
+      GenerateVertexShaderCode(m_api_type, m_host_config, uid.GetUidData());
+  return g_renderer->CreateShaderFromSource(ShaderStage::Vertex, source_code.GetBuffer());
 }
 
 std::unique_ptr<AbstractShader>
 ShaderCache::CompileVertexUberShader(const UberShader::VertexShaderUid& uid) const
 {
-  ShaderCode source_code = UberShader::GenVertexShader(m_api_type, m_host_config, uid.GetUidData());
-  return g_renderer->CreateShaderFromSource(ShaderStage::Vertex, source_code.GetBuffer().c_str(),
-                                            source_code.GetBuffer().size());
+  const ShaderCode source_code =
+      UberShader::GenVertexShader(m_api_type, m_host_config, uid.GetUidData());
+  return g_renderer->CreateShaderFromSource(ShaderStage::Vertex, source_code.GetBuffer());
 }
 
 std::unique_ptr<AbstractShader> ShaderCache::CompilePixelShader(const PixelShaderUid& uid) const
 {
-  ShaderCode source_code = GeneratePixelShaderCode(m_api_type, m_host_config, uid.GetUidData());
-  return g_renderer->CreateShaderFromSource(ShaderStage::Pixel, source_code.GetBuffer().c_str(),
-                                            source_code.GetBuffer().size());
+  const ShaderCode source_code =
+      GeneratePixelShaderCode(m_api_type, m_host_config, uid.GetUidData());
+  return g_renderer->CreateShaderFromSource(ShaderStage::Pixel, source_code.GetBuffer());
 }
 
 std::unique_ptr<AbstractShader>
 ShaderCache::CompilePixelUberShader(const UberShader::PixelShaderUid& uid) const
 {
-  ShaderCode source_code = UberShader::GenPixelShader(m_api_type, m_host_config, uid.GetUidData());
-  return g_renderer->CreateShaderFromSource(ShaderStage::Pixel, source_code.GetBuffer().c_str(),
-                                            source_code.GetBuffer().size());
+  const ShaderCode source_code =
+      UberShader::GenPixelShader(m_api_type, m_host_config, uid.GetUidData());
+  return g_renderer->CreateShaderFromSource(ShaderStage::Pixel, source_code.GetBuffer());
 }
 
 const AbstractShader* ShaderCache::InsertVertexShader(const VertexShaderUid& uid,
@@ -510,9 +510,10 @@ const AbstractShader* ShaderCache::InsertPixelUberShader(const UberShader::Pixel
 
 const AbstractShader* ShaderCache::CreateGeometryShader(const GeometryShaderUid& uid)
 {
-  ShaderCode source_code = GenerateGeometryShaderCode(m_api_type, m_host_config, uid.GetUidData());
-  std::unique_ptr<AbstractShader> shader = g_renderer->CreateShaderFromSource(
-      ShaderStage::Geometry, source_code.GetBuffer().c_str(), source_code.GetBuffer().size());
+  const ShaderCode source_code =
+      GenerateGeometryShaderCode(m_api_type, m_host_config, uid.GetUidData());
+  std::unique_ptr<AbstractShader> shader =
+      g_renderer->CreateShaderFromSource(ShaderStage::Geometry, source_code.GetBuffer());
 
   auto& entry = m_gs_cache.shader_map[uid];
   entry.pending = false;
@@ -1150,9 +1151,9 @@ const AbstractPipeline* ShaderCache::GetEFBCopyToRAMPipeline(const EFBCopyParams
   if (iter != m_efb_copy_to_ram_pipelines.end())
     return iter->second.get();
 
-  auto shader_code = TextureConversionShaderTiled::GenerateEncodingShader(uid, m_api_type);
-  auto shader =
-      g_renderer->CreateShaderFromSource(ShaderStage::Pixel, shader_code, std::strlen(shader_code));
+  const char* const shader_code =
+      TextureConversionShaderTiled::GenerateEncodingShader(uid, m_api_type);
+  const auto shader = g_renderer->CreateShaderFromSource(ShaderStage::Pixel, shader_code);
   if (!shader)
   {
     m_efb_copy_to_ram_pipelines.emplace(uid, nullptr);


### PR DESCRIPTION
Simplifies the overall interface when it comes to compiling shaders. Given std::string_view is quite literally a pointer and size, this essentially collapses two function parameters into one. It also allows getting rid of a `std::string` overload of the same name. Now `std::string` and `const char*` data both go through the same function.

Minor other simplifications were possible with the Vulkan shader compilation interface, that makes it much nicer to use (no out parameters).

