### PR TITLE
VertexLoader_*: Minor cleanup

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -16,14 +16,16 @@
 #include "VideoCommon/VertexLoaderUtils.h"
 #include "VideoCommon/VideoCommon.h"
 
+namespace
+{
 template <typename T>
-float PosScale(T val, float scale)
+constexpr float PosScale(T val, float scale)
 {
   return val * scale;
 }
 
 template <>
-float PosScale(float val, float scale)
+constexpr float PosScale(float val, [[maybe_unused]] float scale)
 {
   return val;
 }
@@ -32,13 +34,13 @@ template <typename T, int N>
 void Pos_ReadDirect(VertexLoader* loader)
 {
   static_assert(N <= 3, "N > 3 is not sane!");
-  auto const scale = loader->m_posScale;
+  const auto scale = loader->m_posScale;
   DataReader dst(g_vertex_manager_write_ptr, nullptr);
   DataReader src(g_video_buffer_read_ptr, nullptr);
 
   for (int i = 0; i < N; ++i)
   {
-    float value = PosScale(src.Read<T>(), scale);
+    const float value = PosScale(src.Read<T>(), scale);
     if (loader->m_counter < 3)
       VertexLoaderManager::position_cache[loader->m_counter][i] = value;
     dst.Write(value);
@@ -55,17 +57,17 @@ void Pos_ReadIndex(VertexLoader* loader)
   static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
   static_assert(N <= 3, "N > 3 is not sane!");
 
-  auto const index = DataRead<I>();
+  const auto index = DataRead<I>();
   loader->m_vertexSkip = index == std::numeric_limits<I>::max();
-  auto const data =
+  const auto data =
       reinterpret_cast<const T*>(VertexLoaderManager::cached_arraybases[ARRAY_POSITION] +
                                  (index * g_main_cp_state.array_strides[ARRAY_POSITION]));
-  auto const scale = loader->m_posScale;
+  const auto scale = loader->m_posScale;
   DataReader dst(g_vertex_manager_write_ptr, nullptr);
 
   for (int i = 0; i < N; ++i)
   {
-    float value = PosScale(Common::FromBigEndian(data[i]), scale);
+    const float value = PosScale(Common::FromBigEndian(data[i]), scale);
     if (loader->m_counter < 3)
       VertexLoaderManager::position_cache[loader->m_counter][i] = value;
     dst.Write(value);
@@ -75,7 +77,7 @@ void Pos_ReadIndex(VertexLoader* loader)
   LOG_VTX();
 }
 
-static TPipelineFunction tableReadPosition[4][8][2] = {
+TPipelineFunction tableReadPosition[4][8][2] = {
     {
         {
             nullptr,
@@ -166,96 +168,37 @@ static TPipelineFunction tableReadPosition[4][8][2] = {
     },
 };
 
-static int tableReadPositionVertexSize[4][8][2] = {
+int tableReadPositionVertexSize[4][8][2] = {
     {
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
+        {0, 0},
+        {0, 0},
+        {0, 0},
+        {0, 0},
+        {0, 0},
     },
     {
-        {
-            2,
-            3,
-        },
-        {
-            2,
-            3,
-        },
-        {
-            4,
-            6,
-        },
-        {
-            4,
-            6,
-        },
-        {
-            8,
-            12,
-        },
+        {2, 3},
+        {2, 3},
+        {4, 6},
+        {4, 6},
+        {8, 12},
     },
     {
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
+        {1, 1},
+        {1, 1},
+        {1, 1},
+        {1, 1},
+        {1, 1},
     },
     {
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
+        {2, 2},
+        {2, 2},
+        {2, 2},
+        {2, 2},
+        {2, 2},
     },
 };
+}  // Anonymous namespace
 
 unsigned int VertexLoader_Position::GetSize(u64 _type, unsigned int _format, unsigned int _elements)
 {

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -168,7 +168,7 @@ constexpr TPipelineFunction s_table_read_position[4][8][2] = {
     },
 };
 
-constexpr int s_table_read_position_vertex_size[4][8][2] = {
+constexpr u32 s_table_read_position_vertex_size[4][8][2] = {
     {
         {0, 0},
         {0, 0},
@@ -200,13 +200,12 @@ constexpr int s_table_read_position_vertex_size[4][8][2] = {
 };
 }  // Anonymous namespace
 
-unsigned int VertexLoader_Position::GetSize(u64 _type, unsigned int _format, unsigned int _elements)
+u32 VertexLoader_Position::GetSize(u64 type, u32 format, u32 elements)
 {
-  return s_table_read_position_vertex_size[_type][_format][_elements];
+  return s_table_read_position_vertex_size[type][format][elements];
 }
 
-TPipelineFunction VertexLoader_Position::GetFunction(u64 _type, unsigned int _format,
-                                                     unsigned int _elements)
+TPipelineFunction VertexLoader_Position::GetFunction(u64 type, u32 format, u32 elements)
 {
-  return s_table_read_position[_type][_format][_elements];
+  return s_table_read_position[type][format][elements];
 }

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -77,7 +77,7 @@ void Pos_ReadIndex(VertexLoader* loader)
   LOG_VTX();
 }
 
-TPipelineFunction tableReadPosition[4][8][2] = {
+constexpr TPipelineFunction s_table_read_position[4][8][2] = {
     {
         {
             nullptr,
@@ -168,7 +168,7 @@ TPipelineFunction tableReadPosition[4][8][2] = {
     },
 };
 
-int tableReadPositionVertexSize[4][8][2] = {
+constexpr int s_table_read_position_vertex_size[4][8][2] = {
     {
         {0, 0},
         {0, 0},
@@ -202,11 +202,11 @@ int tableReadPositionVertexSize[4][8][2] = {
 
 unsigned int VertexLoader_Position::GetSize(u64 _type, unsigned int _format, unsigned int _elements)
 {
-  return tableReadPositionVertexSize[_type][_format][_elements];
+  return s_table_read_position_vertex_size[_type][_format][_elements];
 }
 
 TPipelineFunction VertexLoader_Position::GetFunction(u64 _type, unsigned int _format,
                                                      unsigned int _elements)
 {
-  return tableReadPosition[_type][_format][_elements];
+  return s_table_read_position[_type][_format][_elements];
 }

--- a/Source/Core/VideoCommon/VertexLoader_Position.h
+++ b/Source/Core/VideoCommon/VertexLoader_Position.h
@@ -10,9 +10,7 @@
 class VertexLoader_Position
 {
 public:
-  // GetSize
-  static unsigned int GetSize(u64 _type, unsigned int _format, unsigned int _elements);
+  static u32 GetSize(u64 type, u32 format, u32 elements);
 
-  // GetFunction
-  static TPipelineFunction GetFunction(u64 _type, unsigned int _format, unsigned int _elements);
+  static TPipelineFunction GetFunction(u64 type, u32 format, u32 elements);
 };

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -88,7 +88,7 @@ void TexCoord_ReadIndex(VertexLoader* loader)
   ++loader->m_tcIndex;
 }
 
-TPipelineFunction tableReadTexCoord[4][8][2] = {
+constexpr TPipelineFunction s_table_read_tex_coord[4][8][2] = {
     {
         {
             nullptr,
@@ -179,7 +179,7 @@ TPipelineFunction tableReadTexCoord[4][8][2] = {
     },
 };
 
-int tableReadTexCoordVertexSize[4][8][2] = {
+constexpr int s_table_read_tex_coord_vertex_size[4][8][2] = {
     {
         {0, 0},
         {0, 0},
@@ -214,13 +214,13 @@ int tableReadTexCoordVertexSize[4][8][2] = {
 unsigned int VertexLoader_TextCoord::GetSize(u64 _type, unsigned int _format,
                                              unsigned int _elements)
 {
-  return tableReadTexCoordVertexSize[_type][_format][_elements];
+  return s_table_read_tex_coord_vertex_size[_type][_format][_elements];
 }
 
 TPipelineFunction VertexLoader_TextCoord::GetFunction(u64 _type, unsigned int _format,
                                                       unsigned int _elements)
 {
-  return tableReadTexCoord[_type][_format][_elements];
+  return s_table_read_tex_coord[_type][_format][_elements];
 }
 
 TPipelineFunction VertexLoader_TextCoord::GetDummyFunction()

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -14,6 +14,8 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
 
+namespace
+{
 template <int N>
 void LOG_TEX();
 
@@ -32,19 +34,19 @@ void LOG_TEX<2>()
   // ((float*)g_vertex_manager_write_ptr)[-1]);
 }
 
-static void TexCoord_Read_Dummy(VertexLoader* loader)
+void TexCoord_Read_Dummy(VertexLoader* loader)
 {
   loader->m_tcIndex++;
 }
 
 template <typename T>
-float TCScale(T val, float scale)
+constexpr float TCScale(T val, float scale)
 {
   return val * scale;
 }
 
 template <>
-float TCScale(float val, float scale)
+constexpr float TCScale(float val, [[maybe_unused]] float scale)
 {
   return val;
 }
@@ -52,7 +54,7 @@ float TCScale(float val, float scale)
 template <typename T, int N>
 void TexCoord_ReadDirect(VertexLoader* loader)
 {
-  auto const scale = loader->m_tcScale[loader->m_tcIndex];
+  const auto scale = loader->m_tcScale[loader->m_tcIndex];
   DataReader dst(g_vertex_manager_write_ptr, nullptr);
   DataReader src(g_video_buffer_read_ptr, nullptr);
 
@@ -71,11 +73,11 @@ void TexCoord_ReadIndex(VertexLoader* loader)
 {
   static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
 
-  auto const index = DataRead<I>();
-  auto const data = reinterpret_cast<const T*>(
+  const auto index = DataRead<I>();
+  const auto data = reinterpret_cast<const T*>(
       VertexLoaderManager::cached_arraybases[ARRAY_TEXCOORD0 + loader->m_tcIndex] +
       (index * g_main_cp_state.array_strides[ARRAY_TEXCOORD0 + loader->m_tcIndex]));
-  auto const scale = loader->m_tcScale[loader->m_tcIndex];
+  const auto scale = loader->m_tcScale[loader->m_tcIndex];
   DataReader dst(g_vertex_manager_write_ptr, nullptr);
 
   for (int i = 0; i != N; ++i)
@@ -86,7 +88,7 @@ void TexCoord_ReadIndex(VertexLoader* loader)
   ++loader->m_tcIndex;
 }
 
-static TPipelineFunction tableReadTexCoord[4][8][2] = {
+TPipelineFunction tableReadTexCoord[4][8][2] = {
     {
         {
             nullptr,
@@ -177,96 +179,37 @@ static TPipelineFunction tableReadTexCoord[4][8][2] = {
     },
 };
 
-static int tableReadTexCoordVertexSize[4][8][2] = {
+int tableReadTexCoordVertexSize[4][8][2] = {
     {
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
-        {
-            0,
-            0,
-        },
+        {0, 0},
+        {0, 0},
+        {0, 0},
+        {0, 0},
+        {0, 0},
     },
     {
-        {
-            1,
-            2,
-        },
-        {
-            1,
-            2,
-        },
-        {
-            2,
-            4,
-        },
-        {
-            2,
-            4,
-        },
-        {
-            4,
-            8,
-        },
+        {1, 2},
+        {1, 2},
+        {2, 4},
+        {2, 4},
+        {4, 8},
     },
     {
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
-        {
-            1,
-            1,
-        },
+        {1, 1},
+        {1, 1},
+        {1, 1},
+        {1, 1},
+        {1, 1},
     },
     {
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
-        {
-            2,
-            2,
-        },
+        {2, 2},
+        {2, 2},
+        {2, 2},
+        {2, 2},
+        {2, 2},
     },
 };
+}  // Anonymous namespace
 
 unsigned int VertexLoader_TextCoord::GetSize(u64 _type, unsigned int _format,
                                              unsigned int _elements)

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -179,7 +179,7 @@ constexpr TPipelineFunction s_table_read_tex_coord[4][8][2] = {
     },
 };
 
-constexpr int s_table_read_tex_coord_vertex_size[4][8][2] = {
+constexpr u32 s_table_read_tex_coord_vertex_size[4][8][2] = {
     {
         {0, 0},
         {0, 0},
@@ -211,16 +211,14 @@ constexpr int s_table_read_tex_coord_vertex_size[4][8][2] = {
 };
 }  // Anonymous namespace
 
-unsigned int VertexLoader_TextCoord::GetSize(u64 _type, unsigned int _format,
-                                             unsigned int _elements)
+u32 VertexLoader_TextCoord::GetSize(u64 type, u32 format, u32 elements)
 {
-  return s_table_read_tex_coord_vertex_size[_type][_format][_elements];
+  return s_table_read_tex_coord_vertex_size[type][format][elements];
 }
 
-TPipelineFunction VertexLoader_TextCoord::GetFunction(u64 _type, unsigned int _format,
-                                                      unsigned int _elements)
+TPipelineFunction VertexLoader_TextCoord::GetFunction(u64 type, u32 format, u32 elements)
 {
-  return s_table_read_tex_coord[_type][_format][_elements];
+  return s_table_read_tex_coord[type][format][elements];
 }
 
 TPipelineFunction VertexLoader_TextCoord::GetDummyFunction()

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.h
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.h
@@ -10,13 +10,10 @@
 class VertexLoader_TextCoord
 {
 public:
-  // GetSize
-  static unsigned int GetSize(u64 _type, unsigned int _format, unsigned int _elements);
+  static u32 GetSize(u64 type, u32 format, u32 elements);
 
-  // GetFunction
-  static TPipelineFunction GetFunction(u64 _type, unsigned int _format, unsigned int _elements);
+  static TPipelineFunction GetFunction(u64 type, u32 format, u32 elements);
 
-  // GetDummyFunction
   // It is important to synchronize tcIndex.
   static TPipelineFunction GetDummyFunction();
 };


### PR DESCRIPTION
Following in the footsteps of #8140, this amends the rest of the vertex loader code by performing similar tidying changes.