### PR TITLE
Common/x64Emitter: Resolve TODO in OpArg's operator==

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -120,10 +120,8 @@ struct OpArg
   }
   constexpr bool operator==(const OpArg& b) const
   {
-    // TODO: Use std::tie here once Dolphin requires C++17. (We can't do it immediately,
-    // (because we still support some older versions of GCC where std::tie is not constexpr.)
-    return operandReg == b.operandReg && scale == b.scale && offsetOrBaseReg == b.offsetOrBaseReg &&
-           indexReg == b.indexReg && offset == b.offset;
+    return std::tie(scale, offsetOrBaseReg, indexReg, offset, operandReg) ==
+           std::tie(b.scale, b.offsetOrBaseReg, b.indexReg, b.offset, b.operandReg);
   }
   constexpr bool operator!=(const OpArg& b) const { return !operator==(b); }
   u64 Imm64() const


### PR DESCRIPTION
We now require C++17, so we can use std::tie here.