### PR TITLE
VideoCommon/ShaderGenCommon: Fix memcmp size in ShaderUid operators

### DIFF
--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -69,7 +69,7 @@ public:
 
   bool operator==(const ShaderUid& obj) const
   {
-    return memcmp(&data, &obj.data, data.NumValues() * sizeof(data)) == 0;
+    return memcmp(GetUidData(), obj.GetUidData(), GetUidDataSize()) == 0;
   }
 
   bool operator!=(const ShaderUid& obj) const { return !operator==(obj); }
@@ -77,7 +77,7 @@ public:
   // determines the storage order inside STL containers
   bool operator<(const ShaderUid& obj) const
   {
-    return memcmp(&data, &obj.data, data.NumValues() * sizeof(data)) < 0;
+    return memcmp(GetUidData(), obj.GetUidData(), GetUidDataSize()) < 0;
   }
 
   // Returns a pointer to an internally stored object of the uid_data type.


### PR DESCRIPTION
Bit of an oversight there in #8141. Segfaulted on GCC, though somehow not on MSVC, probably caused weird behavior though. I also changed it to use the class' functions to eliminate redundancy.

This likely fixes https://bugs.dolphin-emu.org/issues/11744