### PR TITLE
VideoCommon: Constrain the array_base registers

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -138,12 +138,19 @@ void Init()
   et_UpdateInterrupts = CoreTiming::RegisterEvent("CPInterrupt", UpdateInterrupts_Wrapper);
 }
 
+u32 GetPhysicalAddressMask()
+{
+  // Physical addresses in CP seem to ignore some of the upper bits (depending on platform)
+  // This can be observed in CP MMIO registers by setting to 0xffffffff and then reading back.
+  return SConfig::GetInstance().bWii ? 0x1fffffff : 0x03ffffff;
+}
+
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 {
   constexpr u16 WMASK_NONE = 0x0000;
   constexpr u16 WMASK_ALL = 0xffff;
   constexpr u16 WMASK_LO_ALIGN_32BIT = 0xffe0;
-  const u16 WMASK_HI_RESTRICT = SConfig::GetInstance().bWii ? 0x1fff : 0x03ff;
+  const u16 WMASK_HI_RESTRICT = GetPhysicalAddressMask() >> 16;
 
   struct
   {

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -169,4 +169,6 @@ void SetCpStatusRegister();
 
 void HandleUnknownOpcode(u8 cmd_byte, void* buffer, bool preprocess);
 
+u32 GetPhysicalAddressMask();
+
 }  // namespace CommandProcessor

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -16,6 +16,7 @@
 #include "Core/HW/Memmap.h"
 
 #include "VideoCommon/BPMemory.h"
+#include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/NativeVertexFormat.h"
@@ -347,7 +348,7 @@ void LoadCPReg(u32 sub_cmd, u32 value, bool is_preprocess)
 
   // Pointers to vertex arrays in GC RAM
   case 0xA0:
-    state->array_bases[sub_cmd & 0xF] = value;
+    state->array_bases[sub_cmd & 0xF] = value & CommandProcessor::GetPhysicalAddressMask();
     state->bases_dirty = true;
     break;
 


### PR DESCRIPTION
The array_base registers as part of CP state do not seem to incorporate the upper bits in the physical addresses they try to access.

This reuses the same masks that apply to CP MMIO registers that contain physical addresses, but it's much easier to observe the behaviour there.