### PR TITLE
AudioCommon: Use std::string_view with feature querying functions

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -117,7 +117,7 @@ std::vector<std::string> GetSoundBackends()
   return backends;
 }
 
-bool SupportsDPL2Decoder(const std::string& backend)
+bool SupportsDPL2Decoder(std::string_view backend)
 {
 #ifndef __APPLE__
   if (backend == BACKEND_OPENAL)
@@ -132,12 +132,12 @@ bool SupportsDPL2Decoder(const std::string& backend)
   return false;
 }
 
-bool SupportsLatencyControl(const std::string& backend)
+bool SupportsLatencyControl(std::string_view backend)
 {
   return backend == BACKEND_OPENAL || backend == BACKEND_WASAPI;
 }
 
-bool SupportsVolumeChanges(const std::string& backend)
+bool SupportsVolumeChanges(std::string_view backend)
 {
   // FIXME: this one should ask the backend whether it supports it.
   //       but getting the backend from string etc. is probably

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -21,13 +21,13 @@
 // This shouldn't be a global, at least not here.
 std::unique_ptr<SoundStream> g_sound_stream;
 
+namespace AudioCommon
+{
 static bool s_audio_dump_start = false;
 static bool s_sound_stream_running = false;
 
-namespace AudioCommon
-{
-static const int AUDIO_VOLUME_MIN = 0;
-static const int AUDIO_VOLUME_MAX = 100;
+constexpr int AUDIO_VOLUME_MIN = 0;
+constexpr int AUDIO_VOLUME_MAX = 100;
 
 void InitSoundStream()
 {

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -99,20 +99,20 @@ std::vector<std::string> GetSoundBackends()
 {
   std::vector<std::string> backends;
 
-  backends.push_back(BACKEND_NULLSOUND);
-  backends.push_back(BACKEND_CUBEB);
+  backends.emplace_back(BACKEND_NULLSOUND);
+  backends.emplace_back(BACKEND_CUBEB);
   if (XAudio2_7::isValid() || XAudio2::isValid())
-    backends.push_back(BACKEND_XAUDIO2);
+    backends.emplace_back(BACKEND_XAUDIO2);
   if (AlsaSound::isValid())
-    backends.push_back(BACKEND_ALSA);
+    backends.emplace_back(BACKEND_ALSA);
   if (PulseAudio::isValid())
-    backends.push_back(BACKEND_PULSEAUDIO);
+    backends.emplace_back(BACKEND_PULSEAUDIO);
   if (OpenALStream::isValid())
-    backends.push_back(BACKEND_OPENAL);
+    backends.emplace_back(BACKEND_OPENAL);
   if (OpenSLESStream::isValid())
-    backends.push_back(BACKEND_OPENSLES);
+    backends.emplace_back(BACKEND_OPENSLES);
   if (WASAPIStream::isValid())
-    backends.push_back(BACKEND_WASAPI);
+    backends.emplace_back(BACKEND_WASAPI);
 
   return backends;
 }

--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "AudioCommon/SoundStream.h"
@@ -20,9 +21,9 @@ void InitSoundStream();
 void ShutdownSoundStream();
 std::string GetDefaultSoundBackend();
 std::vector<std::string> GetSoundBackends();
-bool SupportsDPL2Decoder(const std::string& backend);
-bool SupportsLatencyControl(const std::string& backend);
-bool SupportsVolumeChanges(const std::string& backend);
+bool SupportsDPL2Decoder(std::string_view backend);
+bool SupportsLatencyControl(std::string_view backend);
+bool SupportsVolumeChanges(std::string_view backend);
 void UpdateSoundStream();
 void SetSoundStreamRunning(bool running);
 void SendAIBuffer(const short* samples, unsigned int num_samples);


### PR DESCRIPTION
Provides the same behavior, but allows non-std::string arguments to be non-allocating in calling code. Also applies two other minor changes that were noticed in the same area.