### PR TITLE
IOS/SDIOSlot0: Remove unimplemented prototype

### DIFF
--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -138,7 +138,6 @@ private:
   s32 ExecuteCommand(const Request& request, u32 BufferIn, u32 BufferInSize, u32 BufferIn2,
                      u32 BufferInSize2, u32 _BufferOut, u32 BufferOutSize);
   void OpenInternal();
-  void InitStatus();
 
   u32 GetOCRegister() const;
 

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -135,8 +135,8 @@ private:
 
   IPCCommandResult SendCommand(const IOCtlVRequest& request);
 
-  s32 ExecuteCommand(const Request& request, u32 BufferIn, u32 BufferInSize, u32 BufferIn2,
-                     u32 BufferInSize2, u32 _BufferOut, u32 BufferOutSize);
+  s32 ExecuteCommand(const Request& request, u32 buffer_in, u32 buffer_in_size, u32 rw_buffer,
+                     u32 rw_buffer_size, u32 buffer_out, u32 buffer_out_size);
   void OpenInternal();
 
   u32 GetOCRegister() const;


### PR DESCRIPTION
`InitStatus` doesn't have an implementation, so we can remove it to make for less reading (and get rid of a linker error waiting to happen).

While we're in the same area, this tidies up the parameters of `ExecuteCommand` to follow our code formatting guidelines, as it's the only "straggler" in that regard