### PR TITLE
Common/CommonFuncs: Remove now-unneccessary ArraySize function

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -4,16 +4,8 @@
 
 #pragma once
 
-#include <cstddef>
 #include <string>
 #include "Common/CommonTypes.h"
-
-// Will fail to compile on a non-array:
-template <typename T, size_t N>
-constexpr size_t ArraySize(T (&arr)[N])
-{
-  return N;
-}
 
 #ifndef _WIN32
 

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -254,21 +254,23 @@ bool CBoot::FindMapFile(std::string* existing_map_file, std::string* writable_ma
   if (writable_map_file)
     *writable_map_file = File::GetUserPath(D_MAPS_IDX) + game_id + ".map";
 
-  bool found = false;
-  static const std::string maps_directories[] = {File::GetUserPath(D_MAPS_IDX),
-                                                 File::GetSysDirectory() + MAPS_DIR DIR_SEP};
-  for (size_t i = 0; !found && i < ArraySize(maps_directories); ++i)
+  static const std::array<std::string, 2> maps_directories{
+      File::GetUserPath(D_MAPS_IDX),
+      File::GetSysDirectory() + MAPS_DIR DIR_SEP,
+  };
+  for (const auto& directory : maps_directories)
   {
-    std::string path = maps_directories[i] + game_id + ".map";
+    std::string path = directory + game_id + ".map";
     if (File::Exists(path))
     {
-      found = true;
       if (existing_map_file)
-        *existing_map_file = path;
+        *existing_map_file = std::move(path);
+
+      return true;
     }
   }
 
-  return found;
+  return false;
 }
 
 bool CBoot::LoadMapFromFilename()

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -147,8 +147,8 @@ bool DSPCore_Init(const DSPInitOptions& opts)
 
   std::fill(std::begin(g_dsp.reg_stack_ptr), std::end(g_dsp.reg_stack_ptr), 0);
 
-  for (size_t i = 0; i < ArraySize(g_dsp.reg_stack); i++)
-    std::fill(std::begin(g_dsp.reg_stack[i]), std::end(g_dsp.reg_stack[i]), 0);
+  for (auto& stack : g_dsp.reg_stack)
+    std::fill(std::begin(stack), std::end(stack), 0);
 
   // Fill IRAM with HALT opcodes.
   std::fill(g_dsp.iram, g_dsp.iram + DSP_IRAM_SIZE, 0x0021);

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -5,6 +5,7 @@
 #include "Core/HLE/HLE.h"
 
 #include <algorithm>
+#include <array>
 #include <map>
 
 #include "Common/CommonTypes.h"
@@ -41,7 +42,7 @@ struct SPatch
 };
 
 // clang-format off
-static const SPatch OSPatches[] = {
+constexpr std::array<SPatch, 21> OSPatches{{
     // Placeholder, OSPatches[0] is the "non-existent function" index
     {"FAKE_TO_SKIP_0",               HLE_Misc::UnimplementedFunction,       HookType::Replace, HookFlag::Generic},
 
@@ -72,16 +73,16 @@ static const SPatch OSPatches[] = {
     {"GeckoCodehandler",             HLE_Misc::GeckoCodeHandlerICacheFlush, HookType::Start,   HookFlag::Fixed},
     {"GeckoHandlerReturnTrampoline", HLE_Misc::GeckoReturnTrampoline,       HookType::Replace, HookFlag::Fixed},
     {"AppLoaderReport",              HLE_OS::HLE_GeneralDebugPrint,         HookType::Replace, HookFlag::Fixed} // apploader needs OSReport-like function
-};
+}};
 
-static const SPatch OSBreakPoints[] = {
+constexpr std::array<SPatch, 1> OSBreakPoints{{
     {"FAKE_TO_SKIP_0", HLE_Misc::UnimplementedFunction, HookType::Start, HookFlag::Generic},
-};
+}};
 // clang-format on
 
 void Patch(u32 addr, const char* hle_func_name)
 {
-  for (u32 i = 1; i < ArraySize(OSPatches); ++i)
+  for (u32 i = 1; i < OSPatches.size(); ++i)
   {
     if (!strcmp(OSPatches[i].m_szPatchName, hle_func_name))
     {
@@ -126,7 +127,7 @@ void PatchFunctions()
     }
   }
 
-  for (u32 i = 1; i < ArraySize(OSPatches); ++i)
+  for (u32 i = 1; i < OSPatches.size(); ++i)
   {
     // Fixed hooks don't map to symbols
     if (OSPatches[i].flags == HookFlag::Fixed)
@@ -145,7 +146,7 @@ void PatchFunctions()
 
   if (SConfig::GetInstance().bEnableDebugging)
   {
-    for (size_t i = 1; i < ArraySize(OSBreakPoints); ++i)
+    for (size_t i = 1; i < OSBreakPoints.size(); ++i)
     {
       for (const auto& symbol : g_symbolDB.GetSymbolsFromName(OSBreakPoints[i].m_szPatchName))
       {
@@ -173,7 +174,7 @@ void Reload()
 void Execute(u32 _CurrentPC, u32 _Instruction)
 {
   unsigned int FunctionIndex = _Instruction & 0xFFFFF;
-  if (FunctionIndex > 0 && FunctionIndex < ArraySize(OSPatches))
+  if (FunctionIndex > 0 && FunctionIndex < OSPatches.size())
   {
     OSPatches[FunctionIndex].PatchFunction();
   }
@@ -216,14 +217,14 @@ bool IsEnabled(HookFlag flag)
 
 u32 UnPatch(const std::string& patch_name)
 {
-  auto* patch = std::find_if(std::begin(OSPatches), std::end(OSPatches),
-                             [&](const SPatch& p) { return patch_name == p.m_szPatchName; });
+  const auto patch = std::find_if(std::begin(OSPatches), std::end(OSPatches),
+                                  [&](const SPatch& p) { return patch_name == p.m_szPatchName; });
   if (patch == std::end(OSPatches))
     return 0;
 
   if (patch->flags == HookFlag::Fixed)
   {
-    u32 patch_idx = static_cast<u32>(patch - OSPatches);
+    const u32 patch_idx = static_cast<u32>(std::distance(OSPatches.begin(), patch));
     u32 addr = 0;
     // Reverse search by OSPatch key instead of address
     for (auto i = s_original_instructions.begin(); i != s_original_instructions.end();)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -2,9 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <algorithm>
-
 #include "Core/HW/DSPHLE/UCodes/AX.h"
+
+#include <algorithm>
+#include <array>
+#include <iterator>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -45,12 +47,14 @@ void AXUCode::LoadResamplingCoefficients()
 {
   m_coeffs_available = false;
 
-  std::string filenames[] = {File::GetUserPath(D_GCUSER_IDX) + "dsp_coef.bin",
-                             File::GetSysDirectory() + "/GC/dsp_coef.bin"};
+  const std::array<std::string, 2> filenames{
+      File::GetUserPath(D_GCUSER_IDX) + "dsp_coef.bin",
+      File::GetSysDirectory() + "/GC/dsp_coef.bin",
+  };
 
   size_t fidx;
   std::string filename;
-  for (fidx = 0; fidx < ArraySize(filenames); ++fidx)
+  for (fidx = 0; fidx < filenames.size(); ++fidx)
   {
     filename = filenames[fidx];
     if (File::GetSize(filename) != 0x1000)
@@ -59,7 +63,7 @@ void AXUCode::LoadResamplingCoefficients()
     break;
   }
 
-  if (fidx >= ArraySize(filenames))
+  if (fidx >= filenames.size())
     return;
 
   INFO_LOG(DSPHLE, "Loading polyphase resampling coeffs from %s", filename.c_str());
@@ -449,8 +453,8 @@ void AXUCode::ProcessPBList(u32 pb_addr)
                    m_coeffs_available ? m_coeffs : nullptr);
 
       // Forward the buffers
-      for (size_t i = 0; i < ArraySize(buffers.ptrs); ++i)
-        buffers.ptrs[i] += spms;
+      for (auto& ptr : buffers.ptrs)
+        ptr += spms;
     }
 
     WritePB(pb_addr, pb, m_crc);
@@ -587,13 +591,19 @@ void AXUCode::SendAUXAndMix(u32 main_auxa_up, u32 auxb_s_up, u32 main_l_dl, u32 
                             u32 auxb_l_dl, u32 auxb_r_dl)
 {
   // Buffers to upload first
-  int* up_buffers[] = {m_samples_auxA_left, m_samples_auxA_right, m_samples_auxA_surround};
+  const std::array<const int*, 3> up_buffers{
+      m_samples_auxA_left,
+      m_samples_auxA_right,
+      m_samples_auxA_surround,
+  };
 
   // Upload AUXA LRS
   int* ptr = (int*)HLEMemory_Get_Pointer(main_auxa_up);
-  for (auto& up_buffer : up_buffers)
+  for (const auto& up_buffer : up_buffers)
+  {
     for (u32 j = 0; j < 32 * 5; ++j)
       *ptr++ = Common::swap32(up_buffer[j]);
+  }
 
   // Upload AUXB S
   ptr = (int*)HLEMemory_Get_Pointer(auxb_s_up);
@@ -601,13 +611,23 @@ void AXUCode::SendAUXAndMix(u32 main_auxa_up, u32 auxb_s_up, u32 main_l_dl, u32 
     *ptr++ = Common::swap32(sample);
 
   // Download buffers and addresses
-  int* dl_buffers[] = {m_samples_left, m_samples_right, m_samples_auxB_left, m_samples_auxB_right};
-  u32 dl_addrs[] = {main_l_dl, main_r_dl, auxb_l_dl, auxb_r_dl};
+  const std::array<int*, 4> dl_buffers{
+      m_samples_left,
+      m_samples_right,
+      m_samples_auxB_left,
+      m_samples_auxB_right,
+  };
+  const std::array<u32, 4> dl_addrs{
+      main_l_dl,
+      main_r_dl,
+      auxb_l_dl,
+      auxb_r_dl,
+  };
 
   // Download and mix
-  for (size_t i = 0; i < ArraySize(dl_buffers); ++i)
+  for (size_t i = 0; i < dl_buffers.size(); ++i)
   {
-    int* dl_src = (int*)HLEMemory_Get_Pointer(dl_addrs[i]);
+    const int* dl_src = (int*)HLEMemory_Get_Pointer(dl_addrs[i]);
     for (size_t j = 0; j < 32 * 5; ++j)
       dl_buffers[i][j] += (int)Common::swap32(*dl_src++);
   }
@@ -666,7 +686,7 @@ void AXUCode::HandleMail(u32 mail)
 
 void AXUCode::CopyCmdList(u32 addr, u16 size)
 {
-  if (size >= ArraySize(m_cmdlist))
+  if (size >= std::size(m_cmdlist))
   {
     ERROR_LOG(DSPHLE, "Command list at %08x is too large: size=%d", addr, size);
     return;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -4,9 +4,10 @@
 //
 #define AX_WII  // Used in AXVoice.
 
-#include <algorithm>
-
 #include "Core/HW/DSPHLE/UCodes/AXWii.h"
+
+#include <algorithm>
+#include <array>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -466,8 +467,8 @@ void AXWiiUCode::ProcessPBList(u32 pb_addr)
                      m_coeffs_available ? m_coeffs : nullptr);
 
         // Forward the buffers
-        for (size_t i = 0; i < ArraySize(buffers.ptrs); ++i)
-          buffers.ptrs[i] += 32;
+        for (auto& ptr : buffers.ptrs)
+          ptr += 32;
       }
       ReinjectUpdatesFields(pb, num_updates, updates_addr);
     }
@@ -484,31 +485,41 @@ void AXWiiUCode::ProcessPBList(u32 pb_addr)
 
 void AXWiiUCode::MixAUXSamples(int aux_id, u32 write_addr, u32 read_addr, u16 volume)
 {
-  u16 volume_ramp[96];
-  GenerateVolumeRamp(volume_ramp, m_last_aux_volumes[aux_id], volume, ArraySize(volume_ramp));
+  std::array<u16, 96> volume_ramp;
+  GenerateVolumeRamp(volume_ramp.data(), m_last_aux_volumes[aux_id], volume, volume_ramp.size());
   m_last_aux_volumes[aux_id] = volume;
 
-  int* buffers[3] = {nullptr};
-  int* main_buffers[3] = {m_samples_left, m_samples_right, m_samples_surround};
+  std::array<int*, 3> main_buffers{
+      m_samples_left,
+      m_samples_right,
+      m_samples_surround,
+  };
 
+  std::array<const int*, 3> buffers{};
   switch (aux_id)
   {
   case 0:
-    buffers[0] = m_samples_auxA_left;
-    buffers[1] = m_samples_auxA_right;
-    buffers[2] = m_samples_auxA_surround;
+    buffers = {
+        m_samples_auxA_left,
+        m_samples_auxA_right,
+        m_samples_auxA_surround,
+    };
     break;
 
   case 1:
-    buffers[0] = m_samples_auxB_left;
-    buffers[1] = m_samples_auxB_right;
-    buffers[2] = m_samples_auxB_surround;
+    buffers = {
+        m_samples_auxB_left,
+        m_samples_auxB_right,
+        m_samples_auxB_surround,
+    };
     break;
 
   case 2:
-    buffers[0] = m_samples_auxC_left;
-    buffers[1] = m_samples_auxC_right;
-    buffers[2] = m_samples_auxC_surround;
+    buffers = {
+        m_samples_auxC_left,
+        m_samples_auxC_right,
+        m_samples_auxC_surround,
+    };
     break;
   }
 
@@ -516,20 +527,24 @@ void AXWiiUCode::MixAUXSamples(int aux_id, u32 write_addr, u32 read_addr, u16 vo
   if (write_addr)
   {
     int* ptr = (int*)HLEMemory_Get_Pointer(write_addr);
-    for (auto& buffer : buffers)
+    for (const auto& buffer : buffers)
+    {
       for (u32 j = 0; j < 3 * 32; ++j)
         *ptr++ = Common::swap32(buffer[j]);
+    }
   }
 
   // Then read the buffers from the CPU and add to our main buffers.
-  int* ptr = (int*)HLEMemory_Get_Pointer(read_addr);
+  const int* ptr = (int*)HLEMemory_Get_Pointer(read_addr);
   for (auto& main_buffer : main_buffers)
+  {
     for (u32 j = 0; j < 3 * 32; ++j)
     {
       s64 sample = (s64)(s32)Common::swap32(*ptr++);
       sample *= volume_ramp[j];
       main_buffer[j] += (s32)(sample >> 15);
     }
+  }
 }
 
 void AXWiiUCode::UploadAUXMixLRSC(int aux_id, u32* addresses, u16 volume)
@@ -573,28 +588,26 @@ void AXWiiUCode::UploadAUXMixLRSC(int aux_id, u32* addresses, u16 volume)
 
 void AXWiiUCode::OutputSamples(u32 lr_addr, u32 surround_addr, u16 volume, bool upload_auxc)
 {
-  u16 volume_ramp[96];
-  GenerateVolumeRamp(volume_ramp, m_last_main_volume, volume, ArraySize(volume_ramp));
+  std::array<u16, 96> volume_ramp;
+  GenerateVolumeRamp(volume_ramp.data(), m_last_main_volume, volume, volume_ramp.size());
   m_last_main_volume = volume;
 
-  int upload_buffer[3 * 32] = {0};
+  std::array<int, 3 * 32> upload_buffer{};
 
-  for (u32 i = 0; i < 3 * 32; ++i)
+  for (size_t i = 0; i < upload_buffer.size(); ++i)
     upload_buffer[i] = Common::swap32(m_samples_surround[i]);
-  memcpy(HLEMemory_Get_Pointer(surround_addr), upload_buffer, sizeof(upload_buffer));
+  memcpy(HLEMemory_Get_Pointer(surround_addr), upload_buffer.data(), sizeof(upload_buffer));
 
   if (upload_auxc)
   {
     surround_addr += sizeof(upload_buffer);
-    for (u32 i = 0; i < 3 * 32; ++i)
+    for (size_t i = 0; i < upload_buffer.size(); ++i)
       upload_buffer[i] = Common::swap32(m_samples_auxC_left[i]);
-    memcpy(HLEMemory_Get_Pointer(surround_addr), upload_buffer, sizeof(upload_buffer));
+    memcpy(HLEMemory_Get_Pointer(surround_addr), upload_buffer.data(), sizeof(upload_buffer));
   }
 
-  short buffer[3 * 32 * 2];
-
   // Clamp internal buffers to 16 bits.
-  for (u32 i = 0; i < 3 * 32; ++i)
+  for (size_t i = 0; i < volume_ramp.size(); ++i)
   {
     int left = m_samples_left[i];
     int right = m_samples_right[i];
@@ -607,13 +620,14 @@ void AXWiiUCode::OutputSamples(u32 lr_addr, u32 surround_addr, u16 volume, bool 
     m_samples_right[i] = std::clamp(right, -32767, 32767);
   }
 
-  for (u32 i = 0; i < 3 * 32; ++i)
+  std::array<s16, 3 * 32 * 2> buffer;
+  for (size_t i = 0; i < 3 * 32; ++i)
   {
     buffer[2 * i] = Common::swap16(m_samples_right[i]);
     buffer[2 * i + 1] = Common::swap16(m_samples_left[i]);
   }
 
-  memcpy(HLEMemory_Get_Pointer(lr_addr), buffer, sizeof(buffer));
+  memcpy(HLEMemory_Get_Pointer(lr_addr), buffer.data(), sizeof(buffer));
   m_mail_handler.PushMail(DSP_SYNC, true);
 }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/HW/EXI/EXI_DeviceGecko.h"
 
+#include <array>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -126,17 +127,17 @@ void GeckoSockServer::ClientThread()
       std::lock_guard<std::mutex> lk(transfer_lock);
 
       // what's an ideal buffer size?
-      char data[128];
+      std::array<char, 128> buffer;
       std::size_t got = 0;
 
-      if (client->receive(&data[0], ArraySize(data), got) == sf::Socket::Disconnected)
+      if (client->receive(buffer.data(), buffer.size(), got) == sf::Socket::Disconnected)
         client_running.Clear();
 
       if (got != 0)
       {
         did_nothing = false;
 
-        recv_fifo.insert(recv_fifo.end(), &data[0], &data[got]);
+        recv_fifo.insert(recv_fifo.end(), buffer.data(), &buffer[got]);
       }
 
       if (!send_fifo.empty())

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -153,9 +153,9 @@ CEXIMemoryCard::CEXIMemoryCard(const int index, bool gciFolder) : card_index(ind
   }
 
   memory_card_size = memorycard->GetCardId() * SIZE_TO_Mb;
-  u8 header[20] = {0};
-  memorycard->Read(0, static_cast<s32>(ArraySize(header)), header);
-  SetCardFlashID(header, card_index);
+  std::array<u8, 20> header{};
+  memorycard->Read(0, static_cast<s32>(header.size()), header.data());
+  SetCardFlashID(header.data(), card_index);
 }
 
 void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <fstream>
+#include <iterator>
 
 #include "Common/BitUtils.h"
 #include "Common/ChunkFile.h"
@@ -393,7 +394,7 @@ void Wiimote::HandleSpeakerData(const WiimoteCommon::OutputReportSpeakerData& rp
   // (important to keep decoder in proper state)
   if (!m_speaker_mute)
   {
-    if (rpt.length > ArraySize(rpt.data))
+    if (rpt.length > std::size(rpt.data))
     {
       ERROR_LOG(WIIMOTE, "Bad speaker data length: %d", rpt.length);
     }

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 
 #include <mbedtls/bignum.h>
 #include <zlib.h>
@@ -35,7 +36,7 @@ struct MPI : mbedtls_mpi
   template <std::size_t N>
   bool ReadBinary(const u8 (&in_data)[N])
   {
-    return 0 == mbedtls_mpi_read_binary(this, std::begin(in_data), ArraySize(in_data));
+    return 0 == mbedtls_mpi_read_binary(this, std::begin(in_data), std::size(in_data));
   }
 
   template <std::size_t N>

--- a/Source/Core/DiscIO/WiiSaveBanner.cpp
+++ b/Source/Core/DiscIO/WiiSaveBanner.cpp
@@ -4,11 +4,11 @@
 
 #include "DiscIO/WiiSaveBanner.h"
 
+#include <iterator>
 #include <string>
 #include <vector>
 
 #include "Common/ColorUtil.h"
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
 #include "Common/NandPaths.h"
@@ -47,12 +47,12 @@ WiiSaveBanner::WiiSaveBanner(const std::string& path) : m_path(path)
 
 std::string WiiSaveBanner::GetName() const
 {
-  return UTF16BEToUTF8(m_header.name, ArraySize(m_header.name));
+  return UTF16BEToUTF8(m_header.name, std::size(m_header.name));
 }
 
 std::string WiiSaveBanner::GetDescription() const
 {
-  return UTF16BEToUTF8(m_header.description, ArraySize(m_header.description));
+  return UTF16BEToUTF8(m_header.description, std::size(m_header.description));
 }
 
 std::vector<u32> WiiSaveBanner::GetBanner(u32* width, u32* height) const

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -2,6 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinQt/RenderWidget.h"
+
+#include <array>
+
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QDragEnterEvent>
@@ -25,7 +29,6 @@
 
 #include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/RenderWidget.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
@@ -277,7 +280,7 @@ void RenderWidget::PassEventToImGui(const QEvent* event)
     const bool is_down = event->type() == QEvent::KeyPress;
     const u32 key = static_cast<u32>(key_event->key() & 0x1FF);
     auto lock = g_renderer->GetImGuiLock();
-    if (key < ArraySize(ImGui::GetIO().KeysDown))
+    if (key < std::size(ImGui::GetIO().KeysDown))
       ImGui::GetIO().KeysDown[key] = is_down;
 
     if (is_down)
@@ -306,7 +309,7 @@ void RenderWidget::PassEventToImGui(const QEvent* event)
   {
     auto lock = g_renderer->GetImGuiLock();
     const u32 button_mask = static_cast<u32>(static_cast<const QMouseEvent*>(event)->buttons());
-    for (size_t i = 0; i < ArraySize(ImGui::GetIO().MouseDown); i++)
+    for (size_t i = 0; i < std::size(ImGui::GetIO().MouseDown); i++)
       ImGui::GetIO().MouseDown[i] = (button_mask & (1u << i)) != 0;
   }
   break;
@@ -318,28 +321,30 @@ void RenderWidget::PassEventToImGui(const QEvent* event)
 
 void RenderWidget::SetImGuiKeyMap()
 {
-  static const int key_map[][2] = {{ImGuiKey_Tab, Qt::Key_Tab},
-                                   {ImGuiKey_LeftArrow, Qt::Key_Left},
-                                   {ImGuiKey_RightArrow, Qt::Key_Right},
-                                   {ImGuiKey_UpArrow, Qt::Key_Up},
-                                   {ImGuiKey_DownArrow, Qt::Key_Down},
-                                   {ImGuiKey_PageUp, Qt::Key_PageUp},
-                                   {ImGuiKey_PageDown, Qt::Key_PageDown},
-                                   {ImGuiKey_Home, Qt::Key_Home},
-                                   {ImGuiKey_End, Qt::Key_End},
-                                   {ImGuiKey_Insert, Qt::Key_Insert},
-                                   {ImGuiKey_Delete, Qt::Key_Delete},
-                                   {ImGuiKey_Backspace, Qt::Key_Backspace},
-                                   {ImGuiKey_Space, Qt::Key_Space},
-                                   {ImGuiKey_Enter, Qt::Key_Return},
-                                   {ImGuiKey_Escape, Qt::Key_Escape},
-                                   {ImGuiKey_A, Qt::Key_A},
-                                   {ImGuiKey_C, Qt::Key_C},
-                                   {ImGuiKey_V, Qt::Key_V},
-                                   {ImGuiKey_X, Qt::Key_X},
-                                   {ImGuiKey_Y, Qt::Key_Y},
-                                   {ImGuiKey_Z, Qt::Key_Z}};
+  static constexpr std::array<std::array<int, 2>, 21> key_map{{
+      {ImGuiKey_Tab, Qt::Key_Tab},
+      {ImGuiKey_LeftArrow, Qt::Key_Left},
+      {ImGuiKey_RightArrow, Qt::Key_Right},
+      {ImGuiKey_UpArrow, Qt::Key_Up},
+      {ImGuiKey_DownArrow, Qt::Key_Down},
+      {ImGuiKey_PageUp, Qt::Key_PageUp},
+      {ImGuiKey_PageDown, Qt::Key_PageDown},
+      {ImGuiKey_Home, Qt::Key_Home},
+      {ImGuiKey_End, Qt::Key_End},
+      {ImGuiKey_Insert, Qt::Key_Insert},
+      {ImGuiKey_Delete, Qt::Key_Delete},
+      {ImGuiKey_Backspace, Qt::Key_Backspace},
+      {ImGuiKey_Space, Qt::Key_Space},
+      {ImGuiKey_Enter, Qt::Key_Return},
+      {ImGuiKey_Escape, Qt::Key_Escape},
+      {ImGuiKey_A, Qt::Key_A},
+      {ImGuiKey_C, Qt::Key_C},
+      {ImGuiKey_V, Qt::Key_V},
+      {ImGuiKey_X, Qt::Key_X},
+      {ImGuiKey_Y, Qt::Key_Y},
+      {ImGuiKey_Z, Qt::Key_Z},
+  }};
   auto lock = g_renderer->GetImGuiLock();
-  for (size_t i = 0; i < ArraySize(key_map); i++)
-    ImGui::GetIO().KeyMap[key_map[i][0]] = (key_map[i][1] & 0x1FF);
+  for (auto entry : key_map)
+    ImGui::GetIO().KeyMap[entry[0]] = entry[1] & 0x1FF;
 }

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -2,16 +2,17 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D/D3DBase.h"
+
 #include <algorithm>
+#include <array>
 
 #include "Common/CommonTypes.h"
 #include "Common/DynamicLibrary.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
-#include "Common/StringUtil.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
-#include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoBackends/D3D/DXTexture.h"
 #include "VideoBackends/D3DCommon/Common.h"
@@ -30,8 +31,11 @@ D3D_FEATURE_LEVEL feature_level;
 
 static ComPtr<ID3D11Debug> s_debug;
 
-static constexpr D3D_FEATURE_LEVEL s_supported_feature_levels[] = {
-    D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0};
+constexpr std::array<D3D_FEATURE_LEVEL, 3> s_supported_feature_levels{
+    D3D_FEATURE_LEVEL_11_0,
+    D3D_FEATURE_LEVEL_10_1,
+    D3D_FEATURE_LEVEL_10_0,
+};
 
 bool Create(u32 adapter_index, bool enable_debug_layer)
 {
@@ -72,8 +76,8 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   if (enable_debug_layer)
   {
     hr = d3d11_create_device(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
-                             D3D11_CREATE_DEVICE_DEBUG, s_supported_feature_levels,
-                             static_cast<UINT>(ArraySize(s_supported_feature_levels)),
+                             D3D11_CREATE_DEVICE_DEBUG, s_supported_feature_levels.data(),
+                             static_cast<UINT>(s_supported_feature_levels.size()),
                              D3D11_SDK_VERSION, &device, &feature_level, &context);
 
     // Debugbreak on D3D error
@@ -102,8 +106,8 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   if (!enable_debug_layer || FAILED(hr))
   {
     hr = d3d11_create_device(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, 0,
-                             s_supported_feature_levels,
-                             static_cast<UINT>(ArraySize(s_supported_feature_levels)),
+                             s_supported_feature_levels.data(),
+                             static_cast<UINT>(s_supported_feature_levels.size()),
                              D3D11_SDK_VERSION, &device, &feature_level, &context);
   }
 
@@ -184,8 +188,8 @@ std::vector<u32> GetAAModes(u32 adapter_index)
     }
 
     HRESULT hr = d3d11_create_device(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0,
-                                     s_supported_feature_levels,
-                                     static_cast<UINT>(ArraySize(s_supported_feature_levels)),
+                                     s_supported_feature_levels.data(),
+                                     static_cast<UINT>(s_supported_feature_levels.size()),
                                      D3D11_SDK_VERSION, &temp_device, nullptr, nullptr);
     if (FAILED(hr))
       return {};

--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/D3D/PerfQuery.h"
-#include "Common/CommonFuncs.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "VideoBackends/D3D/D3DBase.h"
@@ -63,7 +63,7 @@ void PerfQuery::DisableQuery(PerfQueryGroup type)
 void PerfQuery::ResetQuery()
 {
   m_query_count = 0;
-  std::fill_n(m_results, ArraySize(m_results), 0);
+  std::fill(std::begin(m_results), std::end(m_results), 0);
 }
 
 u32 PerfQuery::GetQueryResult(PerfQueryType type)

--- a/Source/Core/VideoBackends/D3D12/DXContext.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXContext.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D12/DXContext.h"
+
 #include <algorithm>
+#include <array>
 #include <dxgi1_2.h>
 #include <queue>
 #include <vector>
@@ -11,7 +14,6 @@
 #include "Common/DynamicLibrary.h"
 #include "Common/StringUtil.h"
 #include "VideoBackends/D3D12/Common.h"
-#include "VideoBackends/D3D12/DXContext.h"
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
 #include "VideoBackends/D3D12/StreamBuffer.h"
 #include "VideoCommon/VideoConfig.h"
@@ -183,14 +185,15 @@ bool DXContext::CreateDevice(u32 adapter_index, bool enable_debug_layer)
       info_queue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, TRUE);
 
       D3D12_INFO_QUEUE_FILTER filter = {};
-      D3D12_MESSAGE_ID id_list[] = {
+      std::array<D3D12_MESSAGE_ID, 5> id_list{
           D3D12_MESSAGE_ID_CLEARRENDERTARGETVIEW_MISMATCHINGCLEARVALUE,
           D3D12_MESSAGE_ID_CLEARDEPTHSTENCILVIEW_MISMATCHINGCLEARVALUE,
           D3D12_MESSAGE_ID_CREATEGRAPHICSPIPELINESTATE_RENDERTARGETVIEW_NOT_SET,
           D3D12_MESSAGE_ID_CREATEINPUTLAYOUT_TYPE_MISMATCH,
-          D3D12_MESSAGE_ID_DRAW_EMPTY_SCISSOR_RECTANGLE};
-      filter.DenyList.NumIDs = static_cast<UINT>(ArraySize(id_list));
-      filter.DenyList.pIDList = id_list;
+          D3D12_MESSAGE_ID_DRAW_EMPTY_SCISSOR_RECTANGLE,
+      };
+      filter.DenyList.NumIDs = static_cast<UINT>(id_list.size());
+      filter.DenyList.pIDList = id_list.data();
       info_queue->PushStorageFilter(&filter);
     }
   }
@@ -470,8 +473,9 @@ void DXContext::ExecuteCommandList(bool wait_for_completion)
   // Close and queue command list.
   HRESULT hr = res.command_list->Close();
   CHECK(SUCCEEDED(hr), "Close command list");
-  ID3D12CommandList* const execute_lists[] = {res.command_list.Get()};
-  m_command_queue->ExecuteCommandLists(static_cast<UINT>(ArraySize(execute_lists)), execute_lists);
+  const std::array<ID3D12CommandList*, 1> execute_lists{res.command_list.Get()};
+  m_command_queue->ExecuteCommandLists(static_cast<UINT>(execute_lists.size()),
+                                       execute_lists.data());
 
   // Update fence when GPU has completed.
   hr = m_command_queue->Signal(m_fence.Get(), m_current_fence_value);

--- a/Source/Core/VideoBackends/D3D12/DXContext.h
+++ b/Source/Core/VideoBackends/D3D12/DXContext.h
@@ -3,15 +3,16 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
+#include <array>
+#include <functional>
+#include <map>
+
 #include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3D12/DescriptorAllocator.h"
 #include "VideoBackends/D3D12/DescriptorHeapManager.h"
 #include "VideoBackends/D3D12/StreamBuffer.h"
-
-#include <array>
-#include <functional>
-#include <map>
 
 struct IDXGIFactory2;
 

--- a/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
@@ -93,7 +93,7 @@ void PerfQuery::ResetQuery()
   m_query_resolve_pos = 0;
   m_query_readback_pos = 0;
   m_query_next_pos = 0;
-  std::fill_n(m_results, ArraySize(m_results), 0);
+  std::fill(std::begin(m_results), std::end(m_results), 0);
   for (auto& entry : m_query_buffer)
   {
     entry.fence_value = 0;

--- a/Source/Core/VideoBackends/OGL/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/OGL/PerfQuery.cpp
@@ -4,7 +4,6 @@
 
 #include <memory>
 
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/GL/GLExtensions/GLExtensions.h"
 
@@ -54,7 +53,7 @@ void PerfQuery::FlushResults()
 void PerfQuery::ResetQuery()
 {
   m_query_count = 0;
-  std::fill_n(m_results, ArraySize(m_results), 0);
+  std::fill(std::begin(m_results), std::end(m_results), 0);
 }
 
 u32 PerfQuery::GetQueryResult(PerfQueryType type)

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -2,14 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <algorithm>
+#include "VideoBackends/Vulkan/CommandBufferManager.h"
+
+#include <array>
 #include <cstdint>
 
 #include "Common/Assert.h"
-#include "Common/CommonFuncs.h"
 #include "Common/MsgHandler.h"
 
-#include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
 namespace Vulkan
@@ -94,18 +94,22 @@ bool CommandBufferManager::CreateCommandBuffers()
     }
 
     // TODO: A better way to choose the number of descriptors.
-    VkDescriptorPoolSize pool_sizes[] = {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 500000},
-                                         {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 500000},
-                                         {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16},
-                                         {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 16384},
-                                         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 16384}};
+    const std::array<VkDescriptorPoolSize, 5> pool_sizes{{
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 500000},
+        {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 500000},
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16},
+        {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 16384},
+        {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 16384},
+    }};
 
-    VkDescriptorPoolCreateInfo pool_create_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-                                                   nullptr,
-                                                   0,
-                                                   100000,  // tweak this
-                                                   static_cast<u32>(ArraySize(pool_sizes)),
-                                                   pool_sizes};
+    const VkDescriptorPoolCreateInfo pool_create_info = {
+        VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        nullptr,
+        0,
+        100000,  // tweak this
+        static_cast<u32>(pool_sizes.size()),
+        pool_sizes.data(),
+    };
 
     res = vkCreateDescriptorPool(device, &pool_create_info, nullptr, &resources.descriptor_pool);
     if (res != VK_SUCCESS)

--- a/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
@@ -81,7 +81,7 @@ void PerfQuery::ResetQuery()
   m_query_count = 0;
   m_query_readback_pos = 0;
   m_query_next_pos = 0;
-  std::fill_n(m_results, ArraySize(m_results), 0);
+  std::fill(std::begin(m_results), std::end(m_results), 0);
 
   // Reset entire query pool, ensuring all queries are ready to write to.
   StateTracker::GetInstance()->EndRenderPass();

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -2,11 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/Vulkan/VKPipeline.h"
+
+#include <array>
+
 #include "Common/Assert.h"
 #include "Common/MsgHandler.h"
 
 #include "VideoBackends/Vulkan/ObjectCache.h"
-#include "VideoBackends/Vulkan/VKPipeline.h"
 #include "VideoBackends/Vulkan/VKShader.h"
 #include "VideoBackends/Vulkan/VKTexture.h"
 #include "VideoBackends/Vulkan/VertexFormat.h"
@@ -346,13 +349,15 @@ std::unique_ptr<VKPipeline> VKPipeline::Create(const AbstractPipelineConfig& con
   };
 
   // Set viewport and scissor dynamic state so we can change it elsewhere.
-  static const VkDynamicState dynamic_states[] = {VK_DYNAMIC_STATE_VIEWPORT,
-                                                  VK_DYNAMIC_STATE_SCISSOR};
+  static const std::array<VkDynamicState, 2> dynamic_states{
+      VK_DYNAMIC_STATE_VIEWPORT,
+      VK_DYNAMIC_STATE_SCISSOR,
+  };
   static const VkPipelineDynamicStateCreateInfo dynamic_state = {
       VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, nullptr,
-      0,                                            // VkPipelineDynamicStateCreateFlags    flags
-      static_cast<u32>(ArraySize(dynamic_states)),  // uint32_t dynamicStateCount
-      dynamic_states  // const VkDynamicState*                pDynamicStates
+      0,                                        // VkPipelineDynamicStateCreateFlags    flags
+      static_cast<u32>(dynamic_states.size()),  // uint32_t dynamicStateCount
+      dynamic_states.data()  // const VkDynamicState*                pDynamicStates
   };
 
   // Combine to full pipeline info structure.

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -2,12 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cmath>
-#include <cstring>
+#include "VideoCommon/PixelShaderManager.h"
+
+#include <iterator>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
@@ -114,7 +114,7 @@ void PixelShaderManager::SetConstants()
       constants.fogf[3] =
           static_cast<float>(g_renderer->EFBToScaledX(static_cast<int>(2.0f * xfmem.viewport.wd)));
 
-      for (size_t i = 0, vec_index = 0; i < ArraySize(bpmem.fogRange.K); i++)
+      for (size_t i = 0, vec_index = 0; i < std::size(bpmem.fogRange.K); i++)
       {
         constexpr float scale = 4.0f;
         constants.fogrange[vec_index / 4][vec_index % 4] = bpmem.fogRange.K[i].GetValue(0) * scale;

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/VertexLoaderManager.h"
+
 #include <algorithm>
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -11,7 +14,6 @@
 #include <vector>
 
 #include "Common/Assert.h"
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 
@@ -23,7 +25,6 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderBase.h"
-#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
 
@@ -168,21 +169,21 @@ NativeVertexFormat* GetUberVertexFormat(const PortableVertexDeclaration& decl)
     CopyAttribute(new_decl.position, decl.position);
   else
     MakeDummyAttribute(new_decl.position, VAR_FLOAT, 1, false);
-  for (size_t i = 0; i < ArraySize(new_decl.normals); i++)
+  for (size_t i = 0; i < std::size(new_decl.normals); i++)
   {
     if (decl.normals[i].enable)
       CopyAttribute(new_decl.normals[i], decl.normals[i]);
     else
       MakeDummyAttribute(new_decl.normals[i], VAR_FLOAT, 1, false);
   }
-  for (size_t i = 0; i < ArraySize(new_decl.colors); i++)
+  for (size_t i = 0; i < std::size(new_decl.colors); i++)
   {
     if (decl.colors[i].enable)
       CopyAttribute(new_decl.colors[i], decl.colors[i]);
     else
       MakeDummyAttribute(new_decl.colors[i], VAR_UNSIGNED_BYTE, 4, false);
   }
-  for (size_t i = 0; i < ArraySize(new_decl.texcoords); i++)
+  for (size_t i = 0; i < std::size(new_decl.texcoords); i++)
   {
     if (decl.texcoords[i].enable)
       CopyAttribute(new_decl.texcoords[i], decl.texcoords[i]);

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -2,15 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cfloat>
+#include "VideoCommon/VertexShaderManager.h"
+
+#include <array>
 #include <cmath>
 #include <cstring>
-#include <sstream>
-#include <string>
+#include <iterator>
 
 #include "Common/BitSet.h"
 #include "Common/ChunkFile.h"
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/Matrix.h"
@@ -22,7 +22,6 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
@@ -251,13 +250,14 @@ void VertexShaderManager::SetConstants()
   if (bTexMatricesChanged[0])
   {
     bTexMatricesChanged[0] = false;
-    const float* pos_matrix_ptrs[] = {
+    const std::array<const float*, 4> pos_matrix_ptrs{
         &xfmem.posMatrices[g_main_cp_state.matrix_index_a.Tex0MtxIdx * 4],
         &xfmem.posMatrices[g_main_cp_state.matrix_index_a.Tex1MtxIdx * 4],
         &xfmem.posMatrices[g_main_cp_state.matrix_index_a.Tex2MtxIdx * 4],
-        &xfmem.posMatrices[g_main_cp_state.matrix_index_a.Tex3MtxIdx * 4]};
+        &xfmem.posMatrices[g_main_cp_state.matrix_index_a.Tex3MtxIdx * 4],
+    };
 
-    for (size_t i = 0; i < ArraySize(pos_matrix_ptrs); ++i)
+    for (size_t i = 0; i < pos_matrix_ptrs.size(); ++i)
     {
       memcpy(constants.texmatrices[3 * i].data(), pos_matrix_ptrs[i], 3 * sizeof(float4));
     }
@@ -267,13 +267,14 @@ void VertexShaderManager::SetConstants()
   if (bTexMatricesChanged[1])
   {
     bTexMatricesChanged[1] = false;
-    const float* pos_matrix_ptrs[] = {
+    const std::array<const float*, 4> pos_matrix_ptrs{
         &xfmem.posMatrices[g_main_cp_state.matrix_index_b.Tex4MtxIdx * 4],
         &xfmem.posMatrices[g_main_cp_state.matrix_index_b.Tex5MtxIdx * 4],
         &xfmem.posMatrices[g_main_cp_state.matrix_index_b.Tex6MtxIdx * 4],
-        &xfmem.posMatrices[g_main_cp_state.matrix_index_b.Tex7MtxIdx * 4]};
+        &xfmem.posMatrices[g_main_cp_state.matrix_index_b.Tex7MtxIdx * 4],
+    };
 
-    for (size_t i = 0; i < ArraySize(pos_matrix_ptrs); ++i)
+    for (size_t i = 0; i < pos_matrix_ptrs.size(); ++i)
     {
       memcpy(constants.texmatrices[3 * i + 12].data(), pos_matrix_ptrs[i], 3 * sizeof(float4));
     }
@@ -461,9 +462,9 @@ void VertexShaderManager::SetConstants()
   {
     bTexMtxInfoChanged = false;
     constants.xfmem_dualTexInfo = xfmem.dualTexTrans.enabled;
-    for (size_t i = 0; i < ArraySize(xfmem.texMtxInfo); i++)
+    for (size_t i = 0; i < std::size(xfmem.texMtxInfo); i++)
       constants.xfmem_pack1[i][0] = xfmem.texMtxInfo[i].hex;
-    for (size_t i = 0; i < ArraySize(xfmem.postMtxInfo); i++)
+    for (size_t i = 0; i < std::size(xfmem.postMtxInfo); i++)
       constants.xfmem_pack1[i][1] = xfmem.postMtxInfo[i].hex;
 
     dirty = true;

--- a/Source/UnitTests/Common/CommonFuncsTest.cpp
+++ b/Source/UnitTests/Common/CommonFuncsTest.cpp
@@ -6,18 +6,6 @@
 
 #include "Common/CommonFuncs.h"
 
-TEST(CommonFuncs, ArraySizeFunction)
-{
-  char test[4];
-  u32 test2[42];
-
-  EXPECT_EQ(4u, ArraySize(test));
-  EXPECT_EQ(42u, ArraySize(test2));
-
-  (void)test;
-  (void)test2;
-}
-
 TEST(CommonFuncs, CrashMacro)
 {
   EXPECT_DEATH({ Crash(); }, "");


### PR DESCRIPTION
Since C++17, non-member [std::size()](https://en.cppreference.com/w/cpp/iterator/size) is present in the standard library which also operates on regular C arrays. Given that, we can just replace usages of ArraySize with that where applicable.

In many cases, we can just change the actual C array ArraySize() was called on into a `std::array` and use its `size()` member function instead. In some other cases, we can collapse the loops they were used in into a ranged-for loop, eliminating the need for en explicit bounds query.