### PR TITLE
{Common/Analytics, Core/Analytics}: Minor C++17 transitional changes

### DIFF
--- a/Source/Core/Common/Analytics.cpp
+++ b/Source/Core/Common/Analytics.cpp
@@ -198,7 +198,7 @@ void StdoutAnalyticsBackend::Send(std::string report)
          HexDump(reinterpret_cast<const u8*>(report.data()), report.size()).c_str());
 }
 
-HttpAnalyticsBackend::HttpAnalyticsBackend(const std::string& endpoint) : m_endpoint(endpoint)
+HttpAnalyticsBackend::HttpAnalyticsBackend(std::string endpoint) : m_endpoint(std::move(endpoint))
 {
 }
 

--- a/Source/Core/Common/Analytics.cpp
+++ b/Source/Core/Common/Analytics.cpp
@@ -76,15 +76,19 @@ AnalyticsReportBuilder::AnalyticsReportBuilder()
   m_report.push_back(WIRE_FORMAT_VERSION);
 }
 
-void AnalyticsReportBuilder::AppendSerializedValue(std::string* report, const std::string& v)
+void AnalyticsReportBuilder::AppendSerializedValue(std::string* report, std::string_view v)
 {
   AppendType(report, TypeId::STRING);
   AppendBytes(report, reinterpret_cast<const u8*>(v.data()), static_cast<u32>(v.size()));
 }
 
+// We can't remove this overload despite the string_view overload due to the fact that
+// pointers can implicitly convert to bool, so if we removed the overload, then all
+// const char strings passed in would begin forwarding to the bool overload,
+// which is definitely not what we want to occur.
 void AnalyticsReportBuilder::AppendSerializedValue(std::string* report, const char* v)
 {
-  AppendSerializedValue(report, std::string(v));
+  AppendSerializedValue(report, std::string_view(v));
 }
 
 void AnalyticsReportBuilder::AppendSerializedValue(std::string* report, bool v)

--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -46,7 +46,7 @@ namespace Common
 class AnalyticsReportingBackend
 {
 public:
-  virtual ~AnalyticsReportingBackend() {}
+  virtual ~AnalyticsReportingBackend() = default;
   // Called from the AnalyticsReporter backend thread.
   virtual void Send(std::string report) = 0;
 };

--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -86,7 +87,7 @@ public:
   }
 
   template <typename T>
-  AnalyticsReportBuilder& AddData(const std::string& key, const T& value)
+  AnalyticsReportBuilder& AddData(std::string_view key, const T& value)
   {
     std::lock_guard lk{m_lock};
     AppendSerializedValue(&m_report, key);
@@ -95,7 +96,7 @@ public:
   }
 
   template <typename T>
-  AnalyticsReportBuilder& AddData(const std::string& key, const std::vector<T>& value)
+  AnalyticsReportBuilder& AddData(std::string_view key, const std::vector<T>& value)
   {
     std::lock_guard lk{m_lock};
     AppendSerializedValue(&m_report, key);
@@ -117,7 +118,7 @@ public:
   }
 
 protected:
-  static void AppendSerializedValue(std::string* report, const std::string& v);
+  static void AppendSerializedValue(std::string* report, std::string_view v);
   static void AppendSerializedValue(std::string* report, const char* v);
   static void AppendSerializedValue(std::string* report, bool v);
   static void AppendSerializedValue(std::string* report, u64 v);

--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -184,7 +184,7 @@ public:
 class HttpAnalyticsBackend : public AnalyticsReportingBackend
 {
 public:
-  HttpAnalyticsBackend(const std::string& endpoint);
+  explicit HttpAnalyticsBackend(std::string endpoint);
   ~HttpAnalyticsBackend() override;
 
   void Send(std::string report) override;

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -101,11 +101,11 @@ void DolphinAnalytics::GenerateNewIdentity()
   SConfig::GetInstance().SaveSettings();
 }
 
-std::string DolphinAnalytics::MakeUniqueId(const std::string& data)
+std::string DolphinAnalytics::MakeUniqueId(std::string_view data)
 {
-  u8 digest[20];
-  std::string input = m_unique_id + data;
-  mbedtls_sha1(reinterpret_cast<const u8*>(input.c_str()), input.size(), digest);
+  std::array<u8, 20> digest;
+  const auto input = std::string{m_unique_id}.append(data);
+  mbedtls_sha1(reinterpret_cast<const u8*>(input.c_str()), input.size(), digest.data());
 
   // Convert to hex string and truncate to 64 bits.
   std::string out;
@@ -116,7 +116,7 @@ std::string DolphinAnalytics::MakeUniqueId(const std::string& data)
   return out;
 }
 
-void DolphinAnalytics::ReportDolphinStart(const std::string& ui_type)
+void DolphinAnalytics::ReportDolphinStart(std::string_view ui_type)
 {
   Common::AnalyticsReportBuilder builder(m_base_builder);
   builder.AddData("type", "dolphin-start");

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -1,5 +1,6 @@
 #include "Core/Analytics.h"
 
+#include <array>
 #include <cinttypes>
 #include <mbedtls/sha1.h>
 #include <memory>
@@ -138,12 +139,11 @@ void DolphinAnalytics::ReportGameStart()
 }
 
 // Keep in sync with enum class GameQuirk definition.
-static const char* GAME_QUIRKS_NAMES[] = {
+constexpr std::array<const char*, 2> GAME_QUIRKS_NAMES{
     "icache-matters",
     "directly-reads-wiimote-input",
 };
-static_assert(sizeof(GAME_QUIRKS_NAMES) / sizeof(GAME_QUIRKS_NAMES[0]) ==
-                  static_cast<u32>(GameQuirk::COUNT),
+static_assert(GAME_QUIRKS_NAMES.size() == static_cast<u32>(GameQuirk::COUNT),
               "Game quirks names and enum definition are out of sync.");
 
 void DolphinAnalytics::ReportGameQuirk(GameQuirk quirk)

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -36,7 +36,7 @@
 
 namespace
 {
-constexpr const char* ANALYTICS_ENDPOINT = "https://analytics.dolphin-emu.org/report";
+constexpr char ANALYTICS_ENDPOINT[] = "https://analytics.dolphin-emu.org/report";
 }  // namespace
 
 #if defined(ANDROID)

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -39,9 +39,6 @@ namespace
 constexpr const char* ANALYTICS_ENDPOINT = "https://analytics.dolphin-emu.org/report";
 }  // namespace
 
-std::mutex DolphinAnalytics::s_instance_mutex;
-std::shared_ptr<DolphinAnalytics> DolphinAnalytics::s_instance;
-
 #if defined(ANDROID)
 static std::function<std::string(std::string)> s_get_val_func;
 void DolphinAnalytics::AndroidSetGetValFunc(std::function<std::string(std::string)> func)

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -58,7 +58,7 @@ DolphinAnalytics::DolphinAnalytics()
 
 std::shared_ptr<DolphinAnalytics> DolphinAnalytics::Instance()
 {
-  std::lock_guard<std::mutex> lk(s_instance_mutex);
+  std::lock_guard lk{s_instance_mutex};
   if (!s_instance)
   {
     s_instance.reset(new DolphinAnalytics());
@@ -68,7 +68,7 @@ std::shared_ptr<DolphinAnalytics> DolphinAnalytics::Instance()
 
 void DolphinAnalytics::ReloadConfig()
 {
-  std::lock_guard<std::mutex> lk(m_reporter_mutex);
+  std::lock_guard lk{m_reporter_mutex};
 
   // Install the HTTP backend if analytics support is enabled.
   std::unique_ptr<Common::AnalyticsReportingBackend> new_backend;

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -101,7 +101,7 @@ void DolphinAnalytics::GenerateNewIdentity()
   SConfig::GetInstance().SaveSettings();
 }
 
-std::string DolphinAnalytics::MakeUniqueId(std::string_view data)
+std::string DolphinAnalytics::MakeUniqueId(std::string_view data) const
 {
   std::array<u8, 20> digest;
   const auto input = std::string{m_unique_id}.append(data);

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Common/Analytics.h"
@@ -49,7 +50,7 @@ public:
   void GenerateNewIdentity();
 
   // Reports a Dolphin start event.
-  void ReportDolphinStart(const std::string& ui_type);
+  void ReportDolphinStart(std::string_view ui_type);
 
   // Generates a base report for a "Game start" event. Also preseeds the
   // per-game base data.
@@ -88,7 +89,7 @@ private:
   // Returns a unique ID derived on the global unique ID, hashed with some
   // report-specific data. This avoid correlation between different types of
   // events.
-  std::string MakeUniqueId(const std::string& data);
+  std::string MakeUniqueId(std::string_view data);
 
   // Unique ID. This should never leave the application. Only used derived
   // values created by MakeUniqueId.

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -127,6 +127,6 @@ private:
 
   // Shared pointer in order to allow for multithreaded use of the instance and
   // avoid races at reinitialization time.
-  static std::mutex s_instance_mutex;
-  static std::shared_ptr<DolphinAnalytics> s_instance;
+  static inline std::mutex s_instance_mutex;
+  static inline std::shared_ptr<DolphinAnalytics> s_instance;
 };

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -89,7 +89,7 @@ private:
   // Returns a unique ID derived on the global unique ID, hashed with some
   // report-specific data. This avoid correlation between different types of
   // events.
-  std::string MakeUniqueId(std::string_view data);
+  std::string MakeUniqueId(std::string_view data) const;
 
   // Unique ID. This should never leave the application. Only used derived
   // values created by MakeUniqueId.

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -76,7 +76,7 @@ public:
   template <typename T>
   void Send(T report)
   {
-    std::lock_guard<std::mutex> lk(m_reporter_mutex);
+    std::lock_guard lk{m_reporter_mutex};
     m_reporter.Send(report);
   }
 


### PR DESCRIPTION
Given the transition to C++17, there's a few things we can do to the interface to make it slightly nicer resource-wise, such as using std::string_view instead of std::string, which makes many usages that would otherwise allocate be non-allocating. We can also simplify our usage of lock_guards with deduction guides, which allow removing the mutex type from the guard itself. A few other changes perform general related cleanup.

Each commit should be fairly separated to make reviewing much nicer.