### PR TITLE
Core/Movie: Store PAD_GET_ORIGIN bit in ControllerState

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -803,6 +803,8 @@ void CheckPadStatus(const GCPadStatus* PadStatus, int controllerID)
 
   s_padState.is_connected = PadStatus->isConnected;
 
+  s_padState.get_origin = (PadStatus->button & PAD_GET_ORIGIN) != 0;
+
   s_padState.disc = s_bDiscChange;
   s_bDiscChange = false;
   s_padState.reset = s_bReset;
@@ -1182,6 +1184,10 @@ void PlayController(GCPadStatus* PadStatus, int controllerID)
     PadStatus->button |= PAD_TRIGGER_L;
   if (s_padState.R)
     PadStatus->button |= PAD_TRIGGER_R;
+
+  if (s_padState.get_origin)
+    PadStatus->button |= PAD_GET_ORIGIN;
+
   if (s_padState.disc)
   {
     Core::RunAsCPUThread([] {

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -49,7 +49,7 @@ struct ControllerState
   bool disc : 1;          // Checks for disc being changed
   bool reset : 1;         // Console reset button
   bool is_connected : 1;  // Should controller be treated as connected
-  bool reserved : 1;      // Reserved bits used for padding, 1 bit
+  bool get_origin : 1;    // Special bit to indicate analog origin reset
 
   u8 TriggerL, TriggerR;          // Triggers, 16 bits
   u8 AnalogStickX, AnalogStickY;  // Main Stick, 16 bits


### PR DESCRIPTION
This fixes the desync on playback of start-from-boot input recordings made while using the GC adapter, as well as other desyncs that could potentially occur in other circumstances where this bit is used.

I used a previously reserved bit in the ControllerState to store the new data, so this shouldn't significantly break backwards compatibility. However, tools that aren't aware of this new bit may set it to 0, which will break input recordings that contain it.