### PR TITLE
Qt/ResourcePackManager: Remove column header bold text

### DIFF
--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -95,6 +95,7 @@ void ResourcePackManager::RepopulateTable()
     header->setSectionResizeMode(i, QHeaderView::ResizeToContents);
 
   header->setStretchLastSection(true);
+  header->setHighlightSections(false);
 
   int size = static_cast<int>(ResourcePack::GetPacks().size());
 


### PR DESCRIPTION
Was done elsewhere previously in #7967 and #7947.