### PR TITLE
HW/DI: Emulate rotational latency

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -1315,7 +1315,7 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
       // TODO: This calculation is slightly wrong when decrypt is true - it uses the size of
       // the copy from IOS to PPC but is supposed to model the copy from the disc drive to IOS.
       ticks_until_completion +=
-          static_cast<u64>(chunk_length) * SystemTimers::GetTicksPerSecond() / BUFFER_TRANSFER_RATE;
+          static_cast<u64>(chunk_length) * ticks_per_second / BUFFER_TRANSFER_RATE;
       buffered_blocks++;
     }
     else
@@ -1327,6 +1327,15 @@ void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u
         // Unbuffered seek+read
         ticks_until_completion += static_cast<u64>(
             ticks_per_second * DVDMath::CalculateSeekTime(head_position, dvd_offset));
+
+        // TODO: The above emulates seeking and then reading one ECC block of data,
+        // and then the below emulates the rotational latency. The rotational latency
+        // should actually happen before reading data from the disc.
+
+        const double time_after_seek =
+            (CoreTiming::GetTicks() + ticks_until_completion) / ticks_per_second;
+        ticks_until_completion += ticks_per_second * DVDMath::CalculateRotationalLatency(
+                                                         dvd_offset, time_after_seek, wii_disc);
 
         DEBUG_LOG(DVDINTERFACE, "Seek+read 0x%" PRIx32 " bytes @ 0x%" PRIx64 " ticks=%" PRId64,
                   chunk_length, offset, ticks_until_completion);

--- a/Source/Core/Core/HW/DVD/DVDMath.h
+++ b/Source/Core/Core/HW/DVD/DVDMath.h
@@ -10,6 +10,7 @@ namespace DVDMath
 {
 double CalculatePhysicalDiscPosition(u64 offset);
 double CalculateSeekTime(u64 offset_from, u64 offset_to);
+double CalculateRotationalLatency(u64 offset, double time, bool wii_disc);
 double CalculateRawDiscReadTime(u64 offset, u64 length, bool wii_disc);
 
 }  // namespace DVDMath


### PR DESCRIPTION
This aims to emulate rotational latency as part of the disc drive timings, which makes loading times have more variance (like on a real disc drive) ~~but should not affect the average loading times~~. (Correction: The loading times will be roughly unaffected for Wii but slightly longer for GameCube.)