### PR TITLE
Core/DSP/DSPTables: Make FindOpInfoByName/FindExtOpInfoByName use std::string_view

### DIFF
--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -511,7 +511,7 @@ std::array<const DSPOPCTemplate*, OPTABLE_SIZE> s_op_table;
 std::array<const DSPOPCTemplate*, EXT_OPTABLE_SIZE> s_ext_op_table;
 
 template <size_t N>
-auto FindByName(const std::string& name, const std::array<DSPOPCTemplate, N>& data)
+auto FindByName(std::string_view name, const std::array<DSPOPCTemplate, N>& data)
 {
   return std::find_if(data.cbegin(), data.cend(),
                       [&name](const auto& info) { return name == info.name; });
@@ -527,7 +527,7 @@ const DSPOPCTemplate* FindOpInfoByOpcode(UDSPInstruction opcode)
   return &*iter;
 }
 
-const DSPOPCTemplate* FindOpInfoByName(const std::string& name)
+const DSPOPCTemplate* FindOpInfoByName(std::string_view name)
 {
   const auto iter = FindByName(name, s_opcodes);
   if (iter == s_opcodes.cend())
@@ -545,7 +545,7 @@ const DSPOPCTemplate* FindExtOpInfoByOpcode(UDSPInstruction opcode)
   return &*iter;
 }
 
-const DSPOPCTemplate* FindExtOpInfoByName(const std::string& name)
+const DSPOPCTemplate* FindExtOpInfoByName(std::string_view name)
 {
   const auto iter = FindByName(name, s_opcodes_ext);
   if (iter == s_opcodes_ext.cend())

--- a/Source/Core/Core/DSP/DSPTables.h
+++ b/Source/Core/Core/DSP/DSPTables.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <string>
+#include <string_view>
 
 #include "Core/DSP/DSPCommon.h"
 
@@ -111,10 +111,10 @@ void ZeroWriteBackLogPreserveAcc(u8 acc);
 
 // Used by the assembler and disassembler for info retrieval.
 const DSPOPCTemplate* FindOpInfoByOpcode(UDSPInstruction opcode);
-const DSPOPCTemplate* FindOpInfoByName(const std::string& name);
+const DSPOPCTemplate* FindOpInfoByName(std::string_view name);
 
 const DSPOPCTemplate* FindExtOpInfoByOpcode(UDSPInstruction opcode);
-const DSPOPCTemplate* FindExtOpInfoByName(const std::string& name);
+const DSPOPCTemplate* FindExtOpInfoByName(std::string_view name);
 
 // Used by the interpreter and JIT for instruction emulation
 const DSPOPCTemplate* GetOpTemplate(UDSPInstruction inst);


### PR DESCRIPTION
These functions only ever compare against another string, so these can have their parameters turned into std::string_view to make them more flexible.