### PR TITLE
DSP/LabelMap: C++17 transitional changes/cleanup

### DIFF
--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -200,9 +200,9 @@ s32 DSPAssembler::ParseValue(const char* str)
     else  // Everything else is a label.
     {
       // Lookup label
-      u16 value;
-      if (m_labels.GetLabelValue(ptr, &value))
-        return value;
+      if (const std::optional<u16> value = m_labels.GetLabelValue(ptr))
+        return *value;
+
       if (m_cur_pass == 2)
         ShowError(AssemblerError::UnknownLabel, str);
     }

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -11,9 +11,9 @@
 
 namespace DSP
 {
-LabelMap::LabelMap()
-{
-}
+LabelMap::LabelMap() = default;
+
+LabelMap::~LabelMap() = default;
 
 void LabelMap::RegisterDefaults()
 {

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -12,6 +12,17 @@
 
 namespace DSP
 {
+struct LabelMap::Label
+{
+  Label(const std::string& lbl, s32 address, LabelType ltype)
+      : name(lbl), addr(address), type(ltype)
+  {
+  }
+  std::string name;
+  s32 addr;
+  LabelType type;
+};
+
 LabelMap::LabelMap() = default;
 
 LabelMap::~LabelMap() = default;

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/DSP/LabelMap.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -44,14 +45,13 @@ void LabelMap::RegisterLabel(const std::string& label, u16 lval, LabelType type)
 
 void LabelMap::DeleteLabel(const std::string& label)
 {
-  for (std::vector<label_t>::iterator iter = labels.begin(); iter != labels.end(); ++iter)
-  {
-    if (!label.compare(iter->name))
-    {
-      labels.erase(iter);
-      return;
-    }
-  }
+  const auto iter = std::find_if(labels.cbegin(), labels.cend(),
+                                 [&label](const auto& entry) { return entry.name == label; });
+
+  if (iter == labels.cend())
+    return;
+
+  labels.erase(iter);
 }
 
 bool LabelMap::GetLabelValue(const std::string& name, u16* value, LabelType type) const

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -33,11 +33,11 @@ void LabelMap::RegisterDefaults()
 
 void LabelMap::RegisterLabel(const std::string& label, u16 lval, LabelType type)
 {
-  u16 old_value;
-  if (GetLabelValue(label, &old_value) && old_value != lval)
+  const std::optional<u16> old_value = GetLabelValue(label);
+  if (old_value && old_value != lval)
   {
     printf("WARNING: Redefined label %s to %04x - old value %04x\n", label.c_str(), lval,
-           old_value);
+           *old_value);
     DeleteLabel(label);
   }
   labels.emplace_back(label, lval, type);
@@ -54,16 +54,15 @@ void LabelMap::DeleteLabel(const std::string& label)
   labels.erase(iter);
 }
 
-bool LabelMap::GetLabelValue(const std::string& name, u16* value, LabelType type) const
+std::optional<u16> LabelMap::GetLabelValue(const std::string& name, LabelType type) const
 {
-  for (auto& label : labels)
+  for (const auto& label : labels)
   {
-    if (!name.compare(label.name))
+    if (name == label.name)
     {
-      if (type & label.type)
+      if ((type & label.type) != 0)
       {
-        *value = label.addr;
-        return true;
+        return label.addr;
       }
       else
       {
@@ -71,7 +70,8 @@ bool LabelMap::GetLabelValue(const std::string& name, u16* value, LabelType type
       }
     }
   }
-  return false;
+
+  return std::nullopt;
 }
 
 void LabelMap::Clear()

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -14,8 +14,8 @@ namespace DSP
 {
 struct LabelMap::Label
 {
-  Label(const std::string& lbl, s32 address, LabelType ltype)
-      : name(lbl), addr(address), type(ltype)
+  Label(std::string lbl, s32 address, LabelType ltype)
+      : name(std::move(lbl)), addr(address), type(ltype)
   {
   }
   std::string name;
@@ -42,7 +42,7 @@ void LabelMap::RegisterDefaults()
   }
 }
 
-void LabelMap::RegisterLabel(const std::string& label, u16 lval, LabelType type)
+void LabelMap::RegisterLabel(std::string label, u16 lval, LabelType type)
 {
   const std::optional<u16> old_value = GetLabelValue(label);
   if (old_value && old_value != lval)
@@ -51,10 +51,10 @@ void LabelMap::RegisterLabel(const std::string& label, u16 lval, LabelType type)
            *old_value);
     DeleteLabel(label);
   }
-  labels.emplace_back(label, lval, type);
+  labels.emplace_back(std::move(label), lval, type);
 }
 
-void LabelMap::DeleteLabel(const std::string& label)
+void LabelMap::DeleteLabel(std::string_view label)
 {
   const auto iter = std::find_if(labels.cbegin(), labels.cend(),
                                  [&label](const auto& entry) { return entry.name == label; });

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -28,7 +29,7 @@ public:
   void RegisterDefaults();
   void RegisterLabel(const std::string& label, u16 lval, LabelType type = LABEL_VALUE);
   void DeleteLabel(const std::string& label);
-  bool GetLabelValue(const std::string& label, u16* value, LabelType type = LABEL_ANY) const;
+  std::optional<u16> GetLabelValue(const std::string& label, LabelType type = LABEL_ANY) const;
   void Clear();
 
 private:

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -21,6 +21,16 @@ enum LabelType
 
 class LabelMap
 {
+public:
+  LabelMap();
+  ~LabelMap() {}
+  void RegisterDefaults();
+  void RegisterLabel(const std::string& label, u16 lval, LabelType type = LABEL_VALUE);
+  void DeleteLabel(const std::string& label);
+  bool GetLabelValue(const std::string& label, u16* value, LabelType type = LABEL_ANY) const;
+  void Clear();
+
+private:
   struct label_t
   {
     label_t(const std::string& lbl, s32 address, LabelType ltype)
@@ -32,14 +42,5 @@ class LabelMap
     LabelType type;
   };
   std::vector<label_t> labels;
-
-public:
-  LabelMap();
-  ~LabelMap() {}
-  void RegisterDefaults();
-  void RegisterLabel(const std::string& label, u16 lval, LabelType type = LABEL_VALUE);
-  void DeleteLabel(const std::string& label);
-  bool GetLabelValue(const std::string& label, u16* value, LabelType type = LABEL_ANY) const;
-  void Clear();
 };
 }  // namespace DSP

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -27,8 +28,8 @@ public:
   ~LabelMap();
 
   void RegisterDefaults();
-  void RegisterLabel(const std::string& label, u16 lval, LabelType type = LABEL_VALUE);
-  void DeleteLabel(const std::string& label);
+  void RegisterLabel(std::string label, u16 lval, LabelType type = LABEL_VALUE);
+  void DeleteLabel(std::string_view label);
   std::optional<u16> GetLabelValue(const std::string& label, LabelType type = LABEL_ANY) const;
   void Clear();
 

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -33,16 +33,7 @@ public:
   void Clear();
 
 private:
-  struct label_t
-  {
-    label_t(const std::string& lbl, s32 address, LabelType ltype)
-        : name(lbl), addr(address), type(ltype)
-    {
-    }
-    std::string name;
-    s32 addr;
-    LabelType type;
-  };
-  std::vector<label_t> labels;
+  struct Label;
+  std::vector<Label> labels;
 };
 }  // namespace DSP

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -23,7 +23,8 @@ class LabelMap
 {
 public:
   LabelMap();
-  ~LabelMap() {}
+  ~LabelMap();
+
   void RegisterDefaults();
   void RegisterLabel(const std::string& label, u16 lval, LabelType type = LABEL_VALUE);
   void DeleteLabel(const std::string& label);


### PR DESCRIPTION
With C++17 we can tidy up the interface a little bit. We're also able to hide the definition of labels entirely from code that uses LabelMap. This makes for less files to rebuild if the label structure itself ever needs to change.