### PR TITLE
Game INI updates and additions

### DIFF
--- a/Data/Sys/GameSettings/D85.ini
+++ b/Data/Sys/GameSettings/D85.ini
@@ -1,0 +1,15 @@
+# D85E01 - Interactive Multi Game Demo Disc v12
+
+[Core]
+# Values set here will override the main Dolphin settings.
+FPRF = True
+MMU = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/D86.ini
+++ b/Data/Sys/GameSettings/D86.ini
@@ -1,0 +1,15 @@
+# D86P01 - Interactive Multi Game Demo Disc v12
+
+[Core]
+# Values set here will override the main Dolphin settings.
+FPRF = True
+MMU = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/D95.ini
+++ b/Data/Sys/GameSettings/D95.ini
@@ -1,0 +1,17 @@
+# D95P01, G95E01 - Interactive Multi Game Demo Disc v5
+
+[Core]
+# Values set here will override the main Dolphin settings.
+FPRF = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+FastDepthCalc = True

--- a/Data/Sys/GameSettings/D99.ini
+++ b/Data/Sys/GameSettings/D99.ini
@@ -1,0 +1,14 @@
+# G99E01, G99P01 - Interactive Multi Game Demo Disc v1
+
+[Core]
+# Values set here will override the main Dolphin settings.
+MMU = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/DAX.ini
+++ b/Data/Sys/GameSettings/DAX.ini
@@ -1,0 +1,18 @@
+# DAXP01, DAXE01 - The Legend of Zelda Skyward Sword
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+
+[ActionReplay]
+
+[Video_Hacks]
+EFBAccessEnable = True
+EFBEmulateFormatChanges = True
+
+[Video_Enhancements]
+ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/E62.ini
+++ b/Data/Sys/GameSettings/E62.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/E72.ini
+++ b/Data/Sys/GameSettings/E72.ini
@@ -1,0 +1,16 @@
+# E72JAF - StarBlade
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/G4P.ini
+++ b/Data/Sys/GameSettings/G4P.ini
@@ -1,0 +1,18 @@
+# G4PJ13 - The Sims
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/G4Z.ini
+++ b/Data/Sys/GameSettings/G4Z.ini
@@ -1,0 +1,14 @@
+# G4ZP69, G4ZE69 - The Sims 2
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/G96.ini
+++ b/Data/Sys/GameSettings/G96.ini
@@ -1,0 +1,14 @@
+# G96P01, G96E01 - Interactive Multi Game Demo Disc v4
+
+[Core]
+# Values set here will override the main Dolphin settings.
+GPUDeterminismMode = fake-completion
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/GCI.ini
+++ b/Data/Sys/GameSettings/GCI.ini
@@ -1,7 +1,18 @@
 # GCIE69, GCIP69 - The Sims
 [Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
 [OnFrame]
+# Add memory patches to be applied every frame here.
+
 [ActionReplay]
-[Gecko]
+# Add action replay cheats here.
+
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GGC.ini
+++ b/Data/Sys/GameSettings/GGC.ini
@@ -1,0 +1,14 @@
+# GGCP0A, GGCE0A - Goblin Commander: Unleash the Horde
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/GGE.ini
+++ b/Data/Sys/GameSettings/GGE.ini
@@ -12,9 +12,5 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-
-[Video_Hacks]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GIS.ini
+++ b/Data/Sys/GameSettings/GIS.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 MMU = 1
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GKB.ini
+++ b/Data/Sys/GameSettings/GKB.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = 0
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -14,9 +13,6 @@ CPUThread = 0
 # Add action replay cheats here.
 
 [Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
 EFBToTextureEnable = False
 DeferEFBCopies = False
-
-[Video_Settings]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GR6.ini
+++ b/Data/Sys/GameSettings/GR6.ini
@@ -1,0 +1,19 @@
+# GR6P78, GR6E78, GR6D78, GR6F78 - Bratz: Rock Angelz
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GT3.ini
+++ b/Data/Sys/GameSettings/GT3.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWT.ini
+++ b/Data/Sys/GameSettings/GWT.ini
@@ -5,6 +5,7 @@
 # This game does not work properly with large memorycards, use a 251 block card
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
 MemoryCard251 = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GYA.ini
+++ b/Data/Sys/GameSettings/GYA.ini
@@ -1,0 +1,15 @@
+# GYAP78, GYAD78, GYAE78, GYAX78 - Barnyard (GC)
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/HC4.ini
+++ b/Data/Sys/GameSettings/HC4.ini
@@ -1,0 +1,14 @@
+# HC4P01, HC4E9Z, HC4P9Z - Crunchyroll Channel
+
+[Core]
+# Values set here will override the main Dolphin settings.
+MMU = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/HCQ.ini
+++ b/Data/Sys/GameSettings/HCQ.ini
@@ -1,0 +1,16 @@
+# HCQEXB, HCQJXB - Hulu Plus Channel
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# Add any video settings here

--- a/Data/Sys/GameSettings/HCW.ini
+++ b/Data/Sys/GameSettings/HCW.ini
@@ -1,0 +1,14 @@
+# HCWPWD, HCWEWD - Amazon Instant Video Channel
+
+[Core]
+# Values set here will override the main Dolphin settings.
+MMU = True
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/MAK.ini
+++ b/Data/Sys/GameSettings/MAK.ini
@@ -1,6 +1,4 @@
 # MAKE8P - Shadow Dancer
 
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MB3.ini
+++ b/Data/Sys/GameSettings/MB3.ini
@@ -1,6 +1,4 @@
 # MB3E8P - Monster World IV
 
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MBA.ini
+++ b/Data/Sys/GameSettings/MBA.ini
@@ -1,6 +1,4 @@
 # MBAN8P - Pulseman
 
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCD.ini
+++ b/Data/Sys/GameSettings/MCD.ini
@@ -1,6 +1,16 @@
-# MCDE8P - Sonic & Knuckles
+# MCDE8P, MCDJ8P, MCDP8P - Sonic & Knuckles
 
-[Video_Settings]
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
 
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCS.ini
+++ b/Data/Sys/GameSettings/MCS.ini
@@ -1,6 +1,4 @@
 # MCSN8P - Monster Lair
 
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCV.ini
+++ b/Data/Sys/GameSettings/MCV.ini
@@ -1,6 +1,4 @@
 # MCVE8P - Pitfall
 
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCW.ini
+++ b/Data/Sys/GameSettings/MCW.ini
@@ -1,6 +1,4 @@
 # MCWE8P - Galaxy Force II
 
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCY.ini
+++ b/Data/Sys/GameSettings/MCY.ini
@@ -1,6 +1,4 @@
 # MCYE8P - Revenge of Shinobi
 
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCZ.ini
+++ b/Data/Sys/GameSettings/MCZ.ini
@@ -1,7 +1,4 @@
 # MCZE8P - Shanghai II
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 0
-
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/R5P.ini
+++ b/Data/Sys/GameSettings/R5P.ini
@@ -1,0 +1,14 @@
+# R5PJ13, R5PX69, R5PE69, R5PP69 - Harry Potter and The Order of The Phoenix
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/R64.ini
+++ b/Data/Sys/GameSettings/R64.ini
@@ -15,4 +15,3 @@ SyncGPU = True
 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
-

--- a/Data/Sys/GameSettings/R6B.ini
+++ b/Data/Sys/GameSettings/R6B.ini
@@ -12,9 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Enhancements]
-ForceFiltering = False
-
 [Video_Hacks]
 EFBToTextureEnable = False
-
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/R8A.ini
+++ b/Data/Sys/GameSettings/R8A.ini
@@ -1,4 +1,4 @@
-# R8AE01, R8AJ01, R8AP01 - PokéPark Wii
+﻿# R8AE01, R8AJ01, R8AP01 - PokéPark Wii
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -17,4 +17,3 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
 EFBToTextureEnable = False
-

--- a/Data/Sys/GameSettings/RBI.ini
+++ b/Data/Sys/GameSettings/RBI.ini
@@ -14,3 +14,6 @@
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RBK.ini
+++ b/Data/Sys/GameSettings/RBK.ini
@@ -14,13 +14,3 @@
 
 [Video_Settings]
 # Add any video settings here
-
-[Wiimote.Shake]
-Soft = 3.0
-Medium = 4.0
-Hard = 4.8
-
-[Wiimote.Swing]
-Slow = 3.5
-Medium = 4.8
-Fast = 6

--- a/Data/Sys/GameSettings/RBY.ini
+++ b/Data/Sys/GameSettings/RBY.ini
@@ -1,0 +1,15 @@
+# RBYP78, RBYJ78, RBYE78 - Barnyard (Wii)
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RDE.ini
+++ b/Data/Sys/GameSettings/RDE.ini
@@ -1,0 +1,16 @@
+# RDEJ0A - Zenkoku Dekotora Matsuri
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+FastDepthCalc = True

--- a/Data/Sys/GameSettings/RDF.ini
+++ b/Data/Sys/GameSettings/RDF.ini
@@ -14,3 +14,4 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RDZ.ini
+++ b/Data/Sys/GameSettings/RDZ.ini
@@ -1,0 +1,14 @@
+# RDZJ01, RDZE01, RDZP01 - Disaster: Day of Crisis
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/RFC.ini
+++ b/Data/Sys/GameSettings/RFC.ini
@@ -15,3 +15,5 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RH6.ini
+++ b/Data/Sys/GameSettings/RH6.ini
@@ -1,0 +1,14 @@
+# RH6E69, RH6P69, RH6K69 - Harry Potter and The Half-Blood Prince
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/RHA.ini
+++ b/Data/Sys/GameSettings/RHA.ini
@@ -1,0 +1,14 @@
+# RHAW01, RHAJ01, RHAE01, RHAK01, RHAP01 - Wii Play
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/RHO.ini
+++ b/Data/Sys/GameSettings/RHO.ini
@@ -1,9 +1,15 @@
 # RHOE8P, RHOJ8P, RHOP8P - House Of The Dead: OVERKILL
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
+
 [OnFrame]
+# Add memory patches to be applied every frame here.
+
 [ActionReplay]
+# Add action replay cheats here.
+
 [Video_Hacks]
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/RHT.ini
+++ b/Data/Sys/GameSettings/RHT.ini
@@ -1,0 +1,16 @@
+# RHTP54, RHTE54 - Manhunt 2
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RM6.ini
+++ b/Data/Sys/GameSettings/RM6.ini
@@ -1,0 +1,14 @@
+# RM6EEB, RM6P99 - Baroque
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/RMH.ini
+++ b/Data/Sys/GameSettings/RMH.ini
@@ -12,9 +12,5 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-
 [Video_Hacks]
-EFBAccessEnable = False
-EFBToTextureEnable = False
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/RNB.ini
+++ b/Data/Sys/GameSettings/RNB.ini
@@ -1,0 +1,17 @@
+# RNBE69, RNBP69, RNBX69 - NBA Live 08
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RNH.ini
+++ b/Data/Sys/GameSettings/RNH.ini
@@ -1,0 +1,19 @@
+# RNHJ99, RNHK8M, RNHP99, RNHE41, RNHP41 - No More Heroes
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# Add any video settings here
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RNL.ini
+++ b/Data/Sys/GameSettings/RNL.ini
@@ -1,0 +1,19 @@
+# RNLE54, RNLP54 - NHL 2K9
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# Add any video settings here
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/ROQ.ini
+++ b/Data/Sys/GameSettings/ROQ.ini
@@ -1,0 +1,14 @@
+# ROQJEP - Baroque
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/RPY.ini
+++ b/Data/Sys/GameSettings/RPY.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FPRF = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RSM.ini
+++ b/Data/Sys/GameSettings/RSM.ini
@@ -12,4 +12,3 @@ FPRF = True
 
 [ActionReplay]
 # Add action replay cheats here.
-

--- a/Data/Sys/GameSettings/RSP.ini
+++ b/Data/Sys/GameSettings/RSP.ini
@@ -12,4 +12,3 @@ CPUThread = False
 
 [ActionReplay]
 # Add action replay cheats here.
-

--- a/Data/Sys/GameSettings/RST.ini
+++ b/Data/Sys/GameSettings/RST.ini
@@ -1,0 +1,16 @@
+# RSTJ52, RSTP64, RSTE64 - Star Wars: The Force Unleashed
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RTB.ini
+++ b/Data/Sys/GameSettings/RTB.ini
@@ -1,4 +1,7 @@
 # RTBE52, RTBP52 - Rapala Fishing Frenzy
 
+[Core]
+CPUThread = False
+
 [Video_Settings]
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RTH.ini
+++ b/Data/Sys/GameSettings/RTH.ini
@@ -1,0 +1,19 @@
+# RTHP52, RTHE52 - Tony Hawk's Downhill Jam
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+EFBAccessEnable = False

--- a/Data/Sys/GameSettings/RW7.ini
+++ b/Data/Sys/GameSettings/RW7.ini
@@ -1,0 +1,17 @@
+# RW7E41 - Shaun White Snowboarding: Road Trip - Target Limited Edition
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RYB.ini
+++ b/Data/Sys/GameSettings/RYB.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -14,13 +15,3 @@
 
 [Video_Settings]
 # Add any video settings here
-
-[Wiimote.Shake]
-Soft = 3.0
-Medium = 4.0
-Hard = 4.8
-
-[Wiimote.Swing]
-Slow = 3.5
-Medium = 4.8
-Fast = 6

--- a/Data/Sys/GameSettings/SCI.ini
+++ b/Data/Sys/GameSettings/SCI.ini
@@ -1,0 +1,14 @@
+# SCIE41, SCIP41 - CSI: Fatal Conspiracy
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/SEC.ini
+++ b/Data/Sys/GameSettings/SEC.ini
@@ -1,0 +1,16 @@
+# SECP69, SECE69 - Create
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SL2.ini
+++ b/Data/Sys/GameSettings/SL2.ini
@@ -9,7 +9,5 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Gecko]
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -12,11 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-
 [Video_Stereoscopy]
 #Only affects overworld map
 StereoConvergence = 2211

--- a/Data/Sys/GameSettings/SNC.ini
+++ b/Data/Sys/GameSettings/SNC.ini
@@ -11,7 +11,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBAccessEnable = False
-

--- a/Data/Sys/GameSettings/SOM.ini
+++ b/Data/Sys/GameSettings/SOM.ini
@@ -12,11 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
-[Video_Settings]
-
 [Video_Hacks]
+EFBToTextureEnable = False
 ImmediateXFBEnable = False
-
-[Video_Enhancements]

--- a/Data/Sys/GameSettings/SQL.ini
+++ b/Data/Sys/GameSettings/SQL.ini
@@ -1,0 +1,14 @@
+# SQLE4Z, SQLPGN - Cartoon Network: Punch Time Explosion XL
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.

--- a/Data/Sys/GameSettings/SVM.ini
+++ b/Data/Sys/GameSettings/SVM.ini
@@ -1,4 +1,4 @@
-# SVME01, SVMJ01, SVMP01 - super mario collection
+# SVME01, SVMJ01, SVMP01 - Super Mario All-Stars: 25th Anniversary Edition
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,6 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
 [Video_Hacks]
 EFBToTextureEnable = False
-

--- a/Data/Sys/GameSettings/WL9.ini
+++ b/Data/Sys/GameSettings/WL9.ini
@@ -1,0 +1,19 @@
+# WL9EYD - Let's Create! Pottery
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+# Add any video settings here
+
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
An update to the Game INI's:
-Adds a few games.
-Disables Dual Core for a bunch of games that crashed with Dual Core enabled in a way that makes it unplayable/unfinishable or caused severe issues.
-Enables MMU for Crunchyroll Channel so it can boot and for Interactive Multi Game Demo Disc with demo's which require MMU.
-Disables defered EFB for games that crashed or showed weird behaviour with defered EFB enabled.
-Sets TextureCacheAccuracy to safe for a few games that need it.
-Sets EFB to texture and ram for a few games that need it.
-Removes Skip EFB access for some games that don't need it anymore.
-Removes Wiimote.Shake and Wiimote.Swing as those are no longer functional. 

I also removed TextureCacheAccuracy = Safe from NSMBW because accuracy on fast shows no issues.

