### PR TITLE
{Android/ButtonManager, ResourcePack/Manager}: Make file-scope variables/functions internally linked where applicable

### DIFF
--- a/Source/Android/jni/ButtonManager.cpp
+++ b/Source/Android/jni/ButtonManager.cpp
@@ -14,9 +14,10 @@
 
 namespace ButtonManager
 {
+namespace
+{
 const std::string touchScreenKey = "Touchscreen";
-std::unordered_map<std::string, InputDevice*> m_controllers;
-std::vector<std::string> configStrings = {
+const std::vector<std::string> configStrings = {
     // GC
     "InputA",
     "InputB",
@@ -169,7 +170,8 @@ std::vector<std::string> configStrings = {
     // Rumble
     "Rumble",
 };
-std::vector<ButtonType> configTypes = {
+
+const std::vector<ButtonType> configTypes = {
     // GC
     BUTTON_A,
     BUTTON_B,
@@ -323,7 +325,9 @@ std::vector<ButtonType> configTypes = {
     RUMBLE,
 };
 
-static void AddBind(const std::string& dev, sBind* bind)
+std::unordered_map<std::string, InputDevice*> m_controllers;
+
+void AddBind(const std::string& dev, sBind* bind)
 {
   auto it = m_controllers.find(dev);
   if (it != m_controllers.end())
@@ -334,6 +338,7 @@ static void AddBind(const std::string& dev, sBind* bind)
   m_controllers[dev] = new InputDevice(dev);
   m_controllers[dev]->AddBind(bind);
 }
+}  // Anonymous namespace
 
 void Init(const std::string& gameId)
 {

--- a/Source/Android/jni/ButtonManager.cpp
+++ b/Source/Android/jni/ButtonManager.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <array>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -16,8 +17,8 @@ namespace ButtonManager
 {
 namespace
 {
-const std::string touchScreenKey = "Touchscreen";
-const std::vector<std::string> configStrings = {
+constexpr char touchScreenKey[] = "Touchscreen";
+constexpr std::array<const char*, 143> configStrings{{
     // GC
     "InputA",
     "InputB",
@@ -169,9 +170,9 @@ const std::vector<std::string> configStrings = {
     "TurntableCrossRight",
     // Rumble
     "Rumble",
-};
+}};
 
-const std::vector<ButtonType> configTypes = {
+constexpr std::array<ButtonType, 143> configTypes{{
     // GC
     BUTTON_A,
     BUTTON_B,
@@ -323,7 +324,7 @@ const std::vector<ButtonType> configTypes = {
     TURNTABLE_CROSSFADE_RIGHT,
     // Rumble
     RUMBLE,
-};
+}};
 
 std::unordered_map<std::string, InputDevice*> m_controllers;
 

--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -11,15 +11,13 @@
 
 #include <algorithm>
 
-namespace
-{
-std::vector<ResourcePack::ResourcePack> packs;
-
-std::string packs_path;
-}  // namespace
-
 namespace ResourcePack
 {
+namespace
+{
+std::vector<ResourcePack> packs;
+std::string packs_path;
+
 IniFile GetPackConfig()
 {
   packs_path = File::GetUserPath(D_RESOURCEPACK_IDX) + "/Packs.ini";
@@ -29,6 +27,7 @@ IniFile GetPackConfig()
 
   return file;
 }
+}  // Anonymous namespace
 
 bool Init()
 {


### PR DESCRIPTION
Resolves -Wmissing-variable-declarations and -Wmissing-declarations warnings.

While we're at it, we can make some of the locals constexpr in Android's case.