### PR TITLE
Disallow changing the backend when running when software renderer is currently selected

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.h
@@ -28,6 +28,8 @@ private:
   void ConnectWidgets();
   void AddDescriptions();
 
+  void OnEmulationStateChanged(bool running);
+
   QComboBox* m_backend_combo;
   QCheckBox* m_show_statistics;
   QCheckBox* m_dump_textures;


### PR DESCRIPTION
It already is disabled for other backends, but this didn't happen with the software renderer.  Attempting to change it while running causes the change to visually happen (including switching to the normal render settings UI instead of the barren one for the software renderer), but doesn't actually change the backend itself (it'll still use the software renderer at the next launch).  This was super confusing since the only way to actually fix it was to change the backend to something else and then back to the one you want (which also involves waiting for the game to close a second time, because the software renderer is slow).