### PR TITLE
QtGui: Handle file open events

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -202,6 +202,8 @@ add_executable(dolphin-emu
   QtUtils/DoubleClickEventFilter.h
   QtUtils/ElidedButton.cpp
   QtUtils/ElidedButton.h
+  QtUtils/FileOpenEventFilter.cpp
+  QtUtils/FileOpenEventFilter.h
   QtUtils/FlowLayout.cpp
   QtUtils/FlowLayout.h
   QtUtils/ModalMessageBox.cpp

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -156,6 +156,7 @@
     <QtMoc Include="QtUtils\BlockUserInputFilter.h" />
     <QtMoc Include="QtUtils\DoubleClickEventFilter.h" />
     <QtMoc Include="QtUtils\ElidedButton.h" />
+    <QtMoc Include="QtUtils\FileOpenEventFilter.h" />
     <QtMoc Include="QtUtils\FlowLayout.h" />
     <QtMoc Include="QtUtils\ModalMessageBox.h" />
     <QtMoc Include="QtUtils\WindowActivationEventFilter.h" />
@@ -193,6 +194,7 @@
     <ClCompile Include="$(QtMocOutPrefix)EnhancementsWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FIFOAnalyzer.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FIFOPlayerWindow.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)FileOpenEventFilter.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)FilesystemWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GCKeyboardEmu.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GCMemcardManager.cpp" />
@@ -379,6 +381,7 @@
     <ClCompile Include="QtUtils\BlockUserInputFilter.cpp" />
     <ClCompile Include="QtUtils\DoubleClickEventFilter.cpp" />
     <ClCompile Include="QtUtils\ElidedButton.cpp" />
+    <ClCompile Include="QtUtils\FileOpenEventFilter.cpp" />
     <ClCompile Include="QtUtils\FlowLayout.cpp" />
     <ClCompile Include="QtUtils\ImageConverter.cpp" />
     <ClCompile Include="QtUtils\ModalMessageBox.cpp" />

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -84,6 +84,7 @@
 #include "DolphinQt/NetPlay/NetPlayBrowser.h"
 #include "DolphinQt/NetPlay/NetPlayDialog.h"
 #include "DolphinQt/NetPlay/NetPlaySetupDialog.h"
+#include "DolphinQt/QtUtils/FileOpenEventFilter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 #include "DolphinQt/QtUtils/RunOnObject.h"
@@ -336,6 +337,12 @@ void MainWindow::InitCoreCallbacks()
   });
   installEventFilter(this);
   m_render_widget->installEventFilter(this);
+
+  // Handle file open events
+  auto* filter = new FileOpenEventFilter(QGuiApplication::instance());
+  connect(filter, &FileOpenEventFilter::fileOpened, this, [=](const QString& file_name) {
+    StartGame(BootParameters::GenerateFromFile(file_name.toStdString()));
+  });
 }
 
 static void InstallHotkeyFilter(QWidget* dialog)

--- a/Source/Core/DolphinQt/QtUtils/FileOpenEventFilter.cpp
+++ b/Source/Core/DolphinQt/QtUtils/FileOpenEventFilter.cpp
@@ -1,0 +1,24 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QFileOpenEvent>
+
+#include "DolphinQt/QtUtils/FileOpenEventFilter.h"
+
+FileOpenEventFilter::FileOpenEventFilter(QObject* event_source) : QObject(event_source)
+{
+  event_source->installEventFilter(this);
+}
+
+bool FileOpenEventFilter::eventFilter(QObject* object, QEvent* event)
+{
+  if (event->type() == QEvent::FileOpen)
+  {
+    auto* openEvent = static_cast<QFileOpenEvent*>(event);
+    emit fileOpened(openEvent->file());
+    return true;
+  }
+
+  return false;
+}

--- a/Source/Core/DolphinQt/QtUtils/FileOpenEventFilter.h
+++ b/Source/Core/DolphinQt/QtUtils/FileOpenEventFilter.h
@@ -1,0 +1,20 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QObject>
+
+class FileOpenEventFilter : public QObject
+{
+  Q_OBJECT
+public:
+  explicit FileOpenEventFilter(QObject* event_source);
+
+signals:
+  void fileOpened(const QString& file_name);
+
+private:
+  bool eventFilter(QObject* object, QEvent* event) override;
+};


### PR DESCRIPTION
Handle file open events received by Dolphin. This allows Wii/GC files to be opened when double-clicked or dropped on the Dolphin application on macOS.

This feature [was](https://github.com/dolphin-emu/dolphin/blob/227290055d6685281c72fd1d2076b67fdfb1b858/Source/Core/DolphinWX/Main.cpp#L222) in DolphinWX but wasn’t implemented in the Qt GUI.