### PR TITLE
DiscordHandler: Don't delay shutdown by up to 2s

### DIFF
--- a/Source/Core/DolphinQt/DiscordHandler.cpp
+++ b/Source/Core/DolphinQt/DiscordHandler.cpp
@@ -6,6 +6,7 @@
 
 #include "DolphinQt/DiscordHandler.h"
 
+#include <chrono>
 #include <iterator>
 
 #include <QApplication>
@@ -35,10 +36,12 @@ void DiscordHandler::Start()
 
 void DiscordHandler::Stop()
 {
-  m_stop_requested.Set(true);
+  if (!m_thread.joinable())
+    return;
 
-  if (m_thread.joinable())
-    m_thread.join();
+  m_stop_requested.Set(true);
+  m_wakeup_event.Set();
+  m_thread.join();
 }
 
 void DiscordHandler::DiscordJoinRequest(const char* id, const std::string& discord_tag,
@@ -68,8 +71,7 @@ void DiscordHandler::Run()
 {
   while (!m_stop_requested.IsSet())
   {
-    if (m_thread.joinable())
-      Discord::CallPendingCallbacks();
+    Discord::CallPendingCallbacks();
 
     // close and remove dead requests
     {
@@ -91,7 +93,7 @@ void DiscordHandler::Run()
       }
     }
 
-    Common::SleepCurrentThread(1000 * 2);
+    m_wakeup_event.WaitFor(std::chrono::seconds{2});
   }
 }
 

--- a/Source/Core/DolphinQt/DiscordHandler.h
+++ b/Source/Core/DolphinQt/DiscordHandler.h
@@ -10,6 +10,7 @@
 
 #include <QObject>
 
+#include "Common/Event.h"
 #include "Common/Flag.h"
 
 #include "UICommon/DiscordPresence.h"
@@ -42,6 +43,7 @@ private:
   void Run();
   QWidget* m_parent;
   Common::Flag m_stop_requested;
+  Common::Event m_wakeup_event;
   std::thread m_thread;
   std::list<DiscordJoinRequestDialog> m_request_dialogs;
   std::mutex m_request_dialogs_mutex;


### PR DESCRIPTION
Currently, it is possible for the DiscordHandler thread to be in the
middle of sleeping when Dolphin is closing. This results in a very
noticeable delay of up to 2 seconds that is unacceptable, especially
for people who don't use the Discord integration.

This fixes the issue by making the thread wait on an Event instead
and signalling it when shutting down.