### PR TITLE
Set texture cache accuracy to safe for Mii Channel

### DIFF
--- a/Data/Sys/GameSettings/HAC.ini
+++ b/Data/Sys/GameSettings/HAC.ini
@@ -13,5 +13,5 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 0
 


### PR DESCRIPTION
The previous accuracy was medium.  As per [the wiki page](https://wiki.dolphin-emu.org/index.php?title=Mii_Channel#Corrupted_Mii_Faces):

> ### Corrupted Mii Faces
>
> The Mii Faces will miss some of their properties if **Texture Cache Accuracy** is not set to **Safe**. To fix, set it to **Safe**. Setting it to **Medium** also works, but the channel has to be reset once after it has started. 

I'm not entirely sure what the process for picking defaults is, but it seems like the default should be safe, as medium still causes issues (which, sure, can be worked around by resetting, but that seems silly to be the default).