### PR TITLE
Fix Gecko codes for G2RE52 (Shrek SuperSlam)

### DIFF
--- a/Data/Sys/GameSettings/G2RE52.ini
+++ b/Data/Sys/GameSettings/G2RE52.ini
@@ -11,8 +11,6 @@ $Unlock Everything [EIREXE]
 0447B200 00000001
 $Debug Camera [EIREXE]
 0447B20C 00000001
-$Fixes (DO NOT DISABLE) [EIREXE]
-041C7F3C 38600005
 # Stage Codes
 $Replace Dragon's Gate with Danger Room [kirby]
 C2051208 00000003
@@ -43,6 +41,7 @@ $Replace Dragon's Gate with FX Room [kirby]
 C2051208 00000003
 2C240006 40820008
 38800017 7C9E2378
+60000000 00000000
 $Replace Dragon's Gate with HavokPlayground [kirby]
 C2051208 00000003
 2C240006 40820008

--- a/Data/Sys/GameSettings/G3YP52.ini
+++ b/Data/Sys/GameSettings/G3YP52.ini
@@ -1,0 +1,7 @@
+# G3YP52 - Shrek SuperSlam (PAL)
+
+[Gecko]
+$Force PAL60 [EIREXE]
+041C7F3C 38600005
+$16:9 Widescreen [Kolano]
+04389A34 3FE38E39


### PR DESCRIPTION
Hi there, just a couple of small changes to the Shrek SuperSlam Gecko codes.

The "Replace Dragon's Gate with FX Room" code was missing a line, which lead to emulation crashing if it was enabled. The "Fixes (DO NOT DISABLE)" code is not needed, nobody seems to know what it does and it is causing confusion for netplay.

Thanks!