### PR TITLE
Qt/GCMemcardManager: Load configured memory cards by default

### DIFF
--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -20,10 +20,12 @@
 #include <QTableWidget>
 #include <QTimer>
 
+#include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/HW/GCMemcard/GCMemcard.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
@@ -46,6 +48,8 @@ GCMemcardManager::GCMemcardManager(QWidget* parent) : QDialog(parent)
   connect(m_timer, &QTimer::timeout, this, &GCMemcardManager::DrawIcons);
 
   m_timer->start(1000 / 8);
+
+  LoadDefaultMemcards();
 
   // Make the dimensions more reasonable on startup
   resize(650, 500);
@@ -132,6 +136,22 @@ void GCMemcardManager::ConnectWidgets()
             [this, slot] { SetSlotFileInteractive(slot); });
     connect(m_slot_table[slot], &QTableWidget::itemSelectionChanged, this,
             &GCMemcardManager::UpdateActions);
+  }
+}
+
+void GCMemcardManager::LoadDefaultMemcards()
+{
+  for (int i = 0; i < SLOT_COUNT; i++)
+  {
+    if (Config::Get(i == 0 ? Config::MAIN_SLOT_A : Config::MAIN_SLOT_B) !=
+        ExpansionInterface::EXIDEVICE_MEMORYCARD)
+    {
+      continue;
+    }
+
+    const QString path = QString::fromStdString(
+        Config::Get(i == 0 ? Config::MAIN_MEMCARD_A_PATH : Config::MAIN_MEMCARD_B_PATH));
+    SetSlotFile(i, path);
   }
 }
 

--- a/Source/Core/DolphinQt/GCMemcardManager.h
+++ b/Source/Core/DolphinQt/GCMemcardManager.h
@@ -32,6 +32,7 @@ public:
 private:
   void CreateWidgets();
   void ConnectWidgets();
+  void LoadDefaultMemcards();
 
   void UpdateActions();
   void UpdateSlotTable(int slot);


### PR DESCRIPTION
This just seems like a logical thing to do, as typically the user will want to mess with their currently configured memory card when using the memcard manager. They can still load a different memory card if they want, this doesn't change that functionality, just adds convenience for the common use case.