### PR TITLE
{Common/SymbolDB, Core/HLE/HLE}: Make use of std::string_view where applicable

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -63,7 +63,7 @@ void SymbolDB::Index()
   }
 }
 
-Symbol* SymbolDB::GetSymbolFromName(const std::string& name)
+Symbol* SymbolDB::GetSymbolFromName(std::string_view name)
 {
   for (auto& func : m_functions)
   {
@@ -74,7 +74,7 @@ Symbol* SymbolDB::GetSymbolFromName(const std::string& name)
   return nullptr;
 }
 
-std::vector<Symbol*> SymbolDB::GetSymbolsFromName(const std::string& name)
+std::vector<Symbol*> SymbolDB::GetSymbolsFromName(std::string_view name)
 {
   std::vector<Symbol*> symbols;
 

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -71,8 +72,8 @@ public:
   virtual Symbol* AddFunction(u32 start_addr) { return nullptr; }
   void AddCompleteSymbol(const Symbol& symbol);
 
-  Symbol* GetSymbolFromName(const std::string& name);
-  std::vector<Symbol*> GetSymbolsFromName(const std::string& name);
+  Symbol* GetSymbolFromName(std::string_view name);
+  std::vector<Symbol*> GetSymbolsFromName(std::string_view name);
   Symbol* GetSymbolFromHash(u32 hash);
   std::vector<Symbol*> GetSymbolsFromHash(u32 hash);
 

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -80,11 +80,11 @@ constexpr std::array<SPatch, 1> OSBreakPoints{{
 }};
 // clang-format on
 
-void Patch(u32 addr, const char* hle_func_name)
+void Patch(u32 addr, std::string_view func_name)
 {
   for (u32 i = 1; i < OSPatches.size(); ++i)
   {
-    if (!strcmp(OSPatches[i].m_szPatchName, hle_func_name))
+    if (OSPatches[i].m_szPatchName == func_name)
     {
       s_original_instructions[addr] = i;
       PowerPC::ppcState.iCache.Invalidate(addr);
@@ -215,7 +215,7 @@ bool IsEnabled(HookFlag flag)
          PowerPC::GetMode() == PowerPC::CoreMode::Interpreter;
 }
 
-u32 UnPatch(const std::string& patch_name)
+u32 UnPatch(std::string_view patch_name)
 {
   const auto patch = std::find_if(std::begin(OSPatches), std::end(OSPatches),
                                   [&](const SPatch& p) { return patch_name == p.m_szPatchName; });
@@ -258,7 +258,7 @@ u32 UnPatch(const std::string& patch_name)
   return 0;
 }
 
-bool UnPatch(u32 addr, const std::string& name)
+bool UnPatch(u32 addr, std::string_view name)
 {
   auto itr = s_original_instructions.find(addr);
   if (itr == s_original_instructions.end())

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 
@@ -29,9 +29,9 @@ void PatchFunctions();
 void Clear();
 void Reload();
 
-void Patch(u32 pc, const char* func_name);
-u32 UnPatch(const std::string& patchName);
-bool UnPatch(u32 addr, const std::string& name = {});
+void Patch(u32 pc, std::string_view func_name);
+u32 UnPatch(std::string_view patch_name);
+bool UnPatch(u32 addr, std::string_view name = {});
 void Execute(u32 _CurrentPC, u32 _Instruction);
 
 // Returns the HLE function index if the address is located in the function


### PR DESCRIPTION
With std::string_view available, we can now change the parameters of a few functions to operate with them instead of std::string, avoiding heap allocations in a few places. It also has the benefit of making the entire Patch/UnPatch interface completely uniform in terms of string types.