### PR TITLE
Fix thread safety issues with synchronous USB transfers

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -589,8 +589,7 @@ void BluetoothReal::HandleCtrlTransfer(libusb_transfer* tr)
   }
   const auto& command = m_current_transfers.at(tr).command;
   command->FillBuffer(libusb_control_transfer_get_data(tr), tr->actual_length);
-  m_ios.EnqueueIPCReply(command->ios_request, tr->actual_length, 0,
-                        CoreTiming::FromThread::NON_CPU);
+  m_ios.EnqueueIPCReply(command->ios_request, tr->actual_length, 0, CoreTiming::FromThread::ANY);
   m_current_transfers.erase(tr);
 }
 
@@ -638,8 +637,7 @@ void BluetoothReal::HandleBulkOrIntrTransfer(libusb_transfer* tr)
 
   const auto& command = m_current_transfers.at(tr).command;
   command->FillBuffer(tr->buffer, tr->actual_length);
-  m_ios.EnqueueIPCReply(command->ios_request, tr->actual_length, 0,
-                        CoreTiming::FromThread::NON_CPU);
+  m_ios.EnqueueIPCReply(command->ios_request, tr->actual_length, 0, CoreTiming::FromThread::ANY);
   m_current_transfers.erase(tr);
 }
 }  // namespace IOS::HLE::Device

--- a/Source/Core/Core/LibusbUtils.h
+++ b/Source/Core/Core/LibusbUtils.h
@@ -12,6 +12,8 @@
 struct libusb_config_descriptor;
 struct libusb_context;
 struct libusb_device;
+struct libusb_device_handle;
+struct libusb_transfer;
 
 namespace LibusbUtils
 {
@@ -20,6 +22,8 @@ using UniquePtr = std::unique_ptr<T, void (*)(T*)>;
 
 // Return false to stop iterating the device list.
 using GetDeviceListCallback = std::function<bool(libusb_device* device)>;
+
+using TransferCallback = std::function<void()>;
 
 class Context
 {
@@ -33,6 +37,24 @@ public:
   // Only valid if the context is valid.
   bool GetDeviceList(GetDeviceListCallback callback);
 
+  // Submit a transfer asynchronously.
+  // The callback may sometimes be invoked on the same thread.
+  // Returns a libusb error code.
+  int SubmitTransfer(libusb_transfer* transfer, TransferCallback callback);
+
+  // Submit a transfer and wait for it to complete before returning.
+  // Returns the transferred length (or a negative error code).
+  s64 SubmitTransferSync(libusb_transfer* transfer);
+
+  // Submit a control transfer synchronously.
+  s64 ControlTransfer(libusb_device_handle* handle, u8 bmRequestType, u8 bRequest, u16 wValue,
+                      u16 wIndex, u8* data, u16 wLength, u32 timeout);
+  // Submit an interrupt transfer synchronously.
+  s64 InterruptTransfer(libusb_device_handle* handle, u8 endpoint, u8* data, int length,
+                        u32 timeout);
+  // Submit a bulk transfer synchronously.
+  s64 BulkTransfer(libusb_device_handle* handle, u8 endpoint, u8* data, int length, u32 timeout);
+
 private:
   class Impl;
   std::unique_ptr<Impl> m_impl;
@@ -42,6 +64,9 @@ private:
 // because some libusb backends such as UsbDk only work properly with a single context.
 // Additionally, device lists must be retrieved using GetDeviceList for thread safety reasons.
 Context& GetContext();
+
+using Transfer = UniquePtr<libusb_transfer>;
+Transfer MakeTransfer(int num_isoc_packets = 0);
 
 using ConfigDescriptor = UniquePtr<libusb_config_descriptor>;
 ConfigDescriptor MakeConfigDescriptor(libusb_device* device, u8 config_num = 0);


### PR DESCRIPTION
Unfortunately, it appears that using libusb's synchronous transfer API
from several threads causes nasty race conditions in event handling and
can lead to deadlocks, despite the fact that libusb's synchronous API
is documented to be perfectly fine to use from several threads (only
the manual polling functionality requires special precautions).

To fix this issue, this adds transfer submission utils that ensure
events are only ever exclusively handled by our own thread.

SubmitTransfer provides a way to submit transfers asynchronously
and to pass callbacks and user data much more easily, while hiding
the ugly C-like userdata stuff from users.

SubmitTransferSync is a small wrapper around SubmitTransfer that makes
it easy to submit a transfer and wait for it to complete.
Along with {Control,Bulk,Interrupt}Transfer, this set of new functions is
intended to be a replacement for the libusb_{control,interrupt,...}
synchronous IO functions.

This PR also fixes an incorrect CoreTiming::FromThread value for BT passthrough transfers.