### PR TITLE
Android: Call UICommon::Init at app start instead of emulation start

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -349,10 +349,29 @@ public final class NativeLibrary
 
   public static native int DefaultCPUCore();
 
+  public static native void ReloadConfig();
+
+  /**
+   * Initializes the native parts of the app.
+   *
+   * Should be called at app start before running any other native code
+   * (other than the native methods in DirectoryInitialization).
+   */
+  public static native void Initialize();
+
+  /**
+   * Tells analytics that Dolphin has been started.
+   *
+   * Since users typically don't explicitly close Android apps, it's appropriate to
+   * call this not only when the app starts but also when the user returns to the app
+   * after not using it for a significant amount of time.
+   */
+  public static native void ReportStartToAnalytics();
+
   /**
    * Begins emulation.
    */
-  public static native void Run(String[] path, boolean firstOpen);
+  public static native void Run(String[] path);
 
   /**
    * Begins emulation from the specified savestate.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -2,6 +2,7 @@ package org.dolphinemu.dolphinemu.features.settings.model;
 
 import android.text.TextUtils;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivityView;
 import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
@@ -175,6 +176,9 @@ public class Settings
 
         SettingsFile.saveFile(fileName, iniSections, view);
       }
+
+      // Notify the native code of the changes
+      NativeLibrary.ReloadConfig();
     }
     else
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -82,12 +82,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
     mPreferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
     String[] gamePaths = getArguments().getStringArray(KEY_GAMEPATHS);
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-    boolean firstOpen = preferences.getBoolean(StartupHandler.NEW_SESSION, true);
-    SharedPreferences.Editor sPrefsEditor = preferences.edit();
-    sPrefsEditor.putBoolean(StartupHandler.NEW_SESSION, false);
-    sPrefsEditor.apply();
-    mEmulationState = new EmulationState(gamePaths, getTemporaryStateFilePath(), firstOpen);
+    mEmulationState = new EmulationState(gamePaths, getTemporaryStateFilePath());
   }
 
   /**
@@ -271,12 +266,10 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
     private Surface mSurface;
     private boolean mRunWhenSurfaceIsValid;
     private boolean loadPreviousTemporaryState;
-    private boolean firstOpen;
     private final String temporaryStatePath;
 
-    EmulationState(String[] gamePaths, String temporaryStatePath, boolean firstOpen)
+    EmulationState(String[] gamePaths, String temporaryStatePath)
     {
-      this.firstOpen = firstOpen;
       mGamePaths = gamePaths;
       this.temporaryStatePath = temporaryStatePath;
       // Starting state is stopped.
@@ -420,7 +413,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
           else
           {
             Log.debug("[EmulationFragment] Starting emulation thread.");
-            NativeLibrary.Run(mGamePaths, firstOpen);
+            NativeLibrary.Run(mGamePaths);
           }
         }, "NativeEmulation");
         mEmulationThread.start();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
@@ -8,6 +8,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import org.dolphinemu.dolphinemu.model.GameFile;
 import org.dolphinemu.dolphinemu.model.GameFileCache;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -94,7 +95,8 @@ public final class GameFileCacheService extends IntentService
    */
   public static void startLoad(Context context)
   {
-    startService(context, ACTION_LOAD);
+    new AfterDirectoryInitializationRunner().run(context,
+            () -> startService(context, ACTION_LOAD));
   }
 
   /**
@@ -104,7 +106,8 @@ public final class GameFileCacheService extends IntentService
    */
   public static void startRescan(Context context)
   {
-    startService(context, ACTION_RESCAN);
+    new AfterDirectoryInitializationRunner().run(context,
+            () -> startService(context, ACTION_RESCAN));
   }
 
   public static GameFile addOrGet(String gamePath)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/AfterDirectoryInitializationRunner.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/AfterDirectoryInitializationRunner.java
@@ -1,0 +1,50 @@
+package org.dolphinemu.dolphinemu.utils;
+
+import android.content.Context;
+import android.content.IntentFilter;
+import android.support.v4.content.LocalBroadcastManager;
+
+public class AfterDirectoryInitializationRunner
+{
+  private DirectoryStateReceiver directoryStateReceiver;
+
+  /**
+   * Executes a Runnable after directory initialization has finished.
+   *
+   * If this is called when directory initialization already is done,
+   * the Runnable will be executed immediately. If this is called before
+   * directory initialization is done, the Runnable will be executed
+   * after directory initialization finishes successfully, or never
+   * in case directory initialization doesn't finish successfully.
+   *
+   * Calling this function multiple times per object is not supported.
+   */
+  public void run(Context context, Runnable runnable)
+  {
+    if (!DirectoryInitialization.areDolphinDirectoriesReady())
+    {
+      // Wait for directories to get initialized
+      IntentFilter statusIntentFilter = new IntentFilter(
+              DirectoryInitialization.BROADCAST_ACTION);
+
+      directoryStateReceiver = new DirectoryStateReceiver(directoryInitializationState ->
+      {
+        if (directoryInitializationState ==
+                DirectoryInitialization.DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED)
+        {
+          LocalBroadcastManager.getInstance(context).unregisterReceiver(directoryStateReceiver);
+          directoryStateReceiver = null;
+          runnable.run();
+        }
+      });
+      // Registers the DirectoryStateReceiver and its intent filters
+      LocalBroadcastManager.getInstance(context).registerReceiver(
+              directoryStateReceiver,
+              statusIntentFilter);
+    }
+    else
+    {
+      runnable.run();
+    }
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -18,8 +18,6 @@ import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
 public class Analytics
 {
-  private static DirectoryStateReceiver directoryStateReceiver;
-
   private static final String analyticsAsked =
           Settings.SECTION_ANALYTICS + "_" + SettingsFile.KEY_ANALYTICS_PERMISSION_ASKED;
   private static final String analyticsEnabled =
@@ -35,31 +33,8 @@ public class Analytics
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
     if (!preferences.getBoolean(analyticsAsked, false))
     {
-      if (!DirectoryInitialization.areDolphinDirectoriesReady())
-      {
-        // Wait for directories to get initialized
-        IntentFilter statusIntentFilter = new IntentFilter(
-                DirectoryInitialization.BROADCAST_ACTION);
-
-        directoryStateReceiver = new DirectoryStateReceiver(directoryInitializationState ->
-        {
-          if (directoryInitializationState ==
-                  DirectoryInitialization.DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED)
-          {
-            LocalBroadcastManager.getInstance(context).unregisterReceiver(directoryStateReceiver);
-            directoryStateReceiver = null;
-            showMessage(context, preferences);
-          }
-        });
-        // Registers the DirectoryStateReceiver and its intent filters
-        LocalBroadcastManager.getInstance(context).registerReceiver(
-                directoryStateReceiver,
-                statusIntentFilter);
-      }
-      else
-      {
-        showMessage(context, preferences);
-      }
+      new AfterDirectoryInitializationRunner().run(context,
+              () -> showMessage(context, preferences));
     }
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -67,6 +67,8 @@ public final class DirectoryInitialization
         {
           initializeInternalStorage(context);
           initializeExternalStorage(context);
+          NativeLibrary.Initialize();
+          NativeLibrary.ReportStartToAnalytics();
 
           directoryState = DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED;
         }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -8,15 +8,15 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 
 import java.util.Date;
 
 public final class StartupHandler
 {
-  public static final String NEW_SESSION = "NEW_SESSION";
   public static final String LAST_CLOSED = "LAST_CLOSED";
-  public static final Long SESSION_TIMEOUT = 21600000L; // 6 hours in milliseconds
+  public static final long SESSION_TIMEOUT = 21600000L; // 6 hours in milliseconds
 
   public static void HandleInit(FragmentActivity parent)
   {
@@ -66,15 +66,13 @@ public final class StartupHandler
    */
   public static void checkSessionReset(Context context)
   {
-    Long currentTime = new Date(System.currentTimeMillis()).getTime();
+    long currentTime = new Date(System.currentTimeMillis()).getTime();
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    Long lastOpen = preferences.getLong(LAST_CLOSED, 0);
+    long lastOpen = preferences.getLong(LAST_CLOSED, 0);
     if (currentTime > (lastOpen + SESSION_TIMEOUT))
     {
-      // Passed at emulation start to trigger first open event.
-      SharedPreferences.Editor sPrefsEditor = preferences.edit();
-      sPrefsEditor.putBoolean(NEW_SESSION, true);
-      sPrefsEditor.apply();
+      new AfterDirectoryInitializationRunner().run(context,
+              () -> NativeLibrary.ReportStartToAnalytics());
     }
   }
 }

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -46,28 +46,11 @@ namespace
 constexpr char COVER_URL[] = "https://art.gametdb.com/wii/cover/%s/%s.png";
 
 const std::string EMPTY_STRING;
-
-bool UseGameCovers()
-{
-// We ifdef this out on Android because accessing the config before emulation start makes us crash.
-// The Android GUI handles covers in Java anyway, so this doesn't make us lose any functionality.
-#ifdef ANDROID
-  return false;
-#else
-  return Config::Get(Config::MAIN_USE_GAME_COVERS);
-#endif
-}
 }  // Anonymous namespace
 
 DiscIO::Language GameFile::GetConfigLanguage() const
 {
-#ifdef ANDROID
-  // TODO: Make the Android app load the config at app start instead of emulation start
-  // so that we can access the user's preference here
-  return DiscIO::Language::English;
-#else
   return SConfig::GetInstance().GetLanguageAdjustedForRegion(DiscIO::IsWii(m_platform), m_region);
-#endif
 }
 
 bool operator==(const GameBanner& lhs, const GameBanner& rhs)
@@ -174,7 +157,7 @@ bool GameFile::IsValid() const
 
 bool GameFile::CustomCoverChanged()
 {
-  if (!m_custom_cover.buffer.empty() || !UseGameCovers())
+  if (!m_custom_cover.buffer.empty() || !Config::Get(Config::MAIN_USE_GAME_COVERS))
     return false;
 
   std::string path, name;
@@ -201,7 +184,7 @@ bool GameFile::CustomCoverChanged()
 
 void GameFile::DownloadDefaultCover()
 {
-  if (!m_default_cover.buffer.empty() || !UseGameCovers())
+  if (!m_default_cover.buffer.empty() || !Config::Get(Config::MAIN_USE_GAME_COVERS))
     return;
 
   const auto cover_path = File::GetUserPath(D_COVERCACHE_IDX) + DIR_SEP;
@@ -267,7 +250,7 @@ void GameFile::DownloadDefaultCover()
 
 bool GameFile::DefaultCoverChanged()
 {
-  if (!m_default_cover.buffer.empty() || !UseGameCovers())
+  if (!m_default_cover.buffer.empty() || !Config::Get(Config::MAIN_USE_GAME_COVERS))
     return false;
 
   const auto cover_path = File::GetUserPath(D_COVERCACHE_IDX) + DIR_SEP;


### PR DESCRIPTION
Much of our native code assumes that `UICommon::Init` has been called (for reasons such as wanting to access the user's settings), so not calling it until emulation start heavily limits what native code we can use in the Android GUI (except during emulation).

This should not be merged before https://bugs.dolphin-emu.org/issues/11767 has been addressed, because the third commit of this PR makes that race condition worse if my thinking is correct.