### PR TITLE
Reorder graphics config

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -74,13 +74,16 @@ void AdvancedWidget::CreateWidgets()
   m_enable_freelook = new GraphicsBool(tr("Free Look"), Config::GFX_FREE_LOOK);
   m_dump_use_ffv1 = new GraphicsBool(tr("Frame Dumps Use FFV1"), Config::GFX_USE_FFV1);
 
-  utility_layout->addWidget(m_dump_textures, 0, 0);
-  utility_layout->addWidget(m_load_custom_textures, 0, 1);
-  utility_layout->addWidget(m_prefetch_custom_textures, 1, 0);
-  utility_layout->addWidget(m_use_fullres_framedumps, 1, 1);
-  utility_layout->addWidget(m_dump_efb_target, 2, 0);
-  utility_layout->addWidget(m_disable_vram_copies, 2, 1);
-  utility_layout->addWidget(m_enable_freelook, 3, 0);
+  utility_layout->addWidget(m_load_custom_textures, 0, 0);
+  utility_layout->addWidget(m_prefetch_custom_textures, 0, 1);
+
+  utility_layout->addWidget(m_enable_freelook, 1, 0);
+  utility_layout->addWidget(m_disable_vram_copies, 1, 1);
+
+  utility_layout->addWidget(m_dump_textures, 2, 0);
+  utility_layout->addWidget(m_dump_efb_target, 2, 1);
+
+  utility_layout->addWidget(m_use_fullres_framedumps, 3, 0);
 #if defined(HAVE_FFMPEG)
   utility_layout->addWidget(m_dump_use_ffv1, 3, 1);
 #endif

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -97,13 +97,13 @@ void GeneralWidget::CreateWidgets()
   m_options_box->setLayout(m_options_layout);
 
   m_options_layout->addWidget(m_show_fps, 0, 0);
-  m_options_layout->addWidget(m_show_ping, 0, 1);
+  m_options_layout->addWidget(m_log_render_time, 0, 1);
 
-  m_options_layout->addWidget(m_log_render_time, 1, 0);
+  m_options_layout->addWidget(m_render_main_window, 1, 0);
   m_options_layout->addWidget(m_autoadjust_window_size, 1, 1);
 
   m_options_layout->addWidget(m_show_messages, 2, 0);
-  m_options_layout->addWidget(m_render_main_window, 2, 1);
+  m_options_layout->addWidget(m_show_ping, 2, 1);
 
   // Other
   auto* shader_compilation_box = new QGroupBox(tr("Shader Compilation"));


### PR DESCRIPTION
This reorders the 'other' and 'utilities' layout in the graphics config. 

Old other tab:
![Old1](https://user-images.githubusercontent.com/47903084/59570615-5e6c5780-909b-11e9-9a45-801becb6efe9.PNG)
New other tab:
![New1](https://user-images.githubusercontent.com/47903084/59570617-6deba080-909b-11e9-937b-bfc8056e928a.PNG)

With this change, the first row is about render time, the second row about render window and the last row about Netplay.

Old utilities tab:
![OldSettings](https://user-images.githubusercontent.com/47903084/59570629-89ef4200-909b-11e9-849b-35531818e2d6.PNG)
New utilities tab:
![NewSettings](https://user-images.githubusercontent.com/47903084/59570628-852a8e00-909b-11e9-98e9-610abfdaf60a.PNG)

Load custom textures is now the first option (I think it is the most used utility) and Prefetch is now much more intuitively the seconde option besides Load custom textures. The second row isn't really logical as they both don't belong to the other options but this way, all the dump utilities are grouped together at the bottom. With Dump EFB and Textures as a pair and the frame dump options grouped. 
All in all, I think this ordering is more logical.

