### PR TITLE
Common/MsgHandler: Tidy up interface and namespace code

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -151,7 +151,7 @@ void Host_TitleChanged()
 {
 }
 
-static bool MsgAlert(const char* caption, const char* text, bool yes_no, MsgType /*style*/)
+static bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType /*style*/)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
@@ -630,7 +630,7 @@ static void Run(JNIEnv* env, const std::vector<std::string>& paths, bool first_o
   ASSERT(!paths.empty());
   __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Running : %s", paths[0].c_str());
 
-  RegisterMsgAlertHandler(&MsgAlert);
+  Common::RegisterMsgAlertHandler(&MsgAlert);
   Common::AndroidSetReportHandler(&ReportSend);
   DolphinAnalytics::AndroidSetGetValFunc(&GetAnalyticValue);
 

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -19,6 +19,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
+namespace Common
+{
 namespace
 {
 // Default non library dependent panic alert
@@ -129,3 +131,4 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
 
   return true;
 }
+}  // namespace Common

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -47,33 +47,33 @@ std::string DefaultStringTranslator(const char* text)
   return text;
 }
 
-MsgAlertHandler msg_handler = DefaultMsgHandler;
-StringTranslator str_translator = DefaultStringTranslator;
-bool AlertEnabled = true;
+MsgAlertHandler s_msg_handler = DefaultMsgHandler;
+StringTranslator s_str_translator = DefaultStringTranslator;
+bool s_alert_enabled = true;
 }  // Anonymous namespace
 
 // Select which of these functions that are used for message boxes. If
 // Qt is enabled we will use QtMsgAlertHandler() that is defined in Main.cpp
 void RegisterMsgAlertHandler(MsgAlertHandler handler)
 {
-  msg_handler = handler;
+  s_msg_handler = handler;
 }
 
 // Select translation function.
 void RegisterStringTranslator(StringTranslator translator)
 {
-  str_translator = translator;
+  s_str_translator = translator;
 }
 
 // enable/disable the alert handler
 void SetEnableAlert(bool enable)
 {
-  AlertEnabled = enable;
+  s_alert_enabled = enable;
 }
 
 std::string GetStringT(const char* string)
 {
-  return str_translator(string);
+  return s_str_translator(string);
 }
 
 // This is the first stop for gui alerts where the log is updated and the
@@ -91,10 +91,10 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
 
   if (!info_caption.length())
   {
-    info_caption = str_translator(_trans("Information"));
-    ques_caption = str_translator(_trans("Question"));
-    warn_caption = str_translator(_trans("Warning"));
-    crit_caption = str_translator(_trans("Critical"));
+    info_caption = s_str_translator(_trans("Information"));
+    ques_caption = s_str_translator(_trans("Question"));
+    warn_caption = s_str_translator(_trans("Warning"));
+    crit_caption = s_str_translator(_trans("Critical"));
   }
 
   switch (style)
@@ -115,14 +115,14 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
 
   va_list args;
   va_start(args, format);
-  CharArrayFromFormatV(buffer, sizeof(buffer) - 1, str_translator(format).c_str(), args);
+  CharArrayFromFormatV(buffer, sizeof(buffer) - 1, s_str_translator(format).c_str(), args);
   va_end(args);
 
   ERROR_LOG(MASTER_LOG, "%s: %s", caption.c_str(), buffer);
 
   // Don't ignore questions, especially AskYesNo, PanicYesNo could be ignored
-  if (msg_handler && (AlertEnabled || style == MsgType::Question || style == MsgType::Critical))
-    return msg_handler(caption.c_str(), buffer, yes_no, style);
+  if (s_msg_handler && (s_alert_enabled || style == MsgType::Question || style == MsgType::Critical))
+    return s_msg_handler(caption.c_str(), buffer, yes_no, style);
 
   return true;
 }

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -121,8 +121,11 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
   ERROR_LOG(MASTER_LOG, "%s: %s", caption.c_str(), buffer);
 
   // Don't ignore questions, especially AskYesNo, PanicYesNo could be ignored
-  if (s_msg_handler && (s_alert_enabled || style == MsgType::Question || style == MsgType::Critical))
+  if (s_msg_handler != nullptr &&
+      (s_alert_enabled || style == MsgType::Question || style == MsgType::Critical))
+  {
     return s_msg_handler(caption.c_str(), buffer, yes_no, style);
+  }
 
   return true;
 }

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -89,7 +89,7 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
   static std::string ques_caption;
   static std::string crit_caption;
 
-  if (!info_caption.length())
+  if (info_caption.empty())
   {
     info_caption = s_str_translator(_trans("Information"));
     ques_caption = s_str_translator(_trans("Question"));

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -2,19 +2,22 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/MsgHandler.h"
+
 #include <cstdarg>
-#include <cstdio>
 #include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <cstdio>
+#include <fmt/format.h>
+#endif
 
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
-
-#ifdef _WIN32
-#include <windows.h>
-#endif
 
 bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, MsgType style);
 static MsgAlertHandler msg_handler = DefaultMsgHandler;
@@ -111,7 +114,7 @@ bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, MsgTy
   return IDYES == MessageBox(0, UTF8ToTStr(text).c_str(), UTF8ToTStr(caption).c_str(),
                              window_style | (yes_no ? MB_YESNO : MB_OK));
 #else
-  fprintf(stderr, "%s\n", text);
+  fmt::print(stderr, "{}\n", text);
 
   // Return no to any question (which will in general crash the emulator)
   return false;

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -6,6 +6,8 @@
 
 #include <string>
 
+namespace Common
+{
 // Message alerts
 enum class MsgType
 {
@@ -28,30 +30,69 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
 #endif
     ;
 void SetEnableAlert(bool enable);
+}  // namespace Common
 
 #ifdef _WIN32
-#define SuccessAlert(format, ...) MsgAlert(false, MsgType::Information, format, __VA_ARGS__)
-#define PanicAlert(format, ...) MsgAlert(false, MsgType::Warning, format, __VA_ARGS__)
-#define PanicYesNo(format, ...) MsgAlert(true, MsgType::Warning, format, __VA_ARGS__)
-#define AskYesNo(format, ...) MsgAlert(true, MsgType::Question, format, __VA_ARGS__)
-#define CriticalAlert(format, ...) MsgAlert(false, MsgType::Critical, format, __VA_ARGS__)
+#define SuccessAlert(format, ...)                                                                  \
+  Common::MsgAlert(false, Common::MsgType::Information, format, __VA_ARGS__)
+
+#define PanicAlert(format, ...)                                                                    \
+  Common::MsgAlert(false, Common::MsgType::Warning, format, __VA_ARGS__)
+
+#define PanicYesNo(format, ...)                                                                    \
+  Common::MsgAlert(true, Common::MsgType::Warning, format, __VA_ARGS__)
+
+#define AskYesNo(format, ...) Common::MsgAlert(true, Common::MsgType::Question, format, __VA_ARGS__)
+
+#define CriticalAlert(format, ...)                                                                 \
+  Common::MsgAlert(false, Common::MsgType::Critical, format, __VA_ARGS__)
+
 // Use these macros (that do the same thing) if the message should be translated.
-#define SuccessAlertT(format, ...) MsgAlert(false, MsgType::Information, format, __VA_ARGS__)
-#define PanicAlertT(format, ...) MsgAlert(false, MsgType::Warning, format, __VA_ARGS__)
-#define PanicYesNoT(format, ...) MsgAlert(true, MsgType::Warning, format, __VA_ARGS__)
-#define AskYesNoT(format, ...) MsgAlert(true, MsgType::Question, format, __VA_ARGS__)
-#define CriticalAlertT(format, ...) MsgAlert(false, MsgType::Critical, format, __VA_ARGS__)
+
+#define SuccessAlertT(format, ...)                                                                 \
+  Common::MsgAlert(false, Common::MsgType::Information, format, __VA_ARGS__)
+
+#define PanicAlertT(format, ...)                                                                   \
+  Common::MsgAlert(false, Common::MsgType::Warning, format, __VA_ARGS__)
+
+#define PanicYesNoT(format, ...)                                                                   \
+  Common::MsgAlert(true, Common::MsgType::Warning, format, __VA_ARGS__)
+
+#define AskYesNoT(format, ...)                                                                     \
+  Common::MsgAlert(true, Common::MsgType::Question, format, __VA_ARGS__)
+
+#define CriticalAlertT(format, ...)                                                                \
+  Common::MsgAlert(false, Common::MsgType::Critical, format, __VA_ARGS__)
 
 #else
-#define SuccessAlert(format, ...) MsgAlert(false, MsgType::Information, format, ##__VA_ARGS__)
-#define PanicAlert(format, ...) MsgAlert(false, MsgType::Warning, format, ##__VA_ARGS__)
-#define PanicYesNo(format, ...) MsgAlert(true, MsgType::Warning, format, ##__VA_ARGS__)
-#define AskYesNo(format, ...) MsgAlert(true, MsgType::Question, format, ##__VA_ARGS__)
-#define CriticalAlert(format, ...) MsgAlert(false, MsgType::Critical, format, ##__VA_ARGS__)
+#define SuccessAlert(format, ...)                                                                  \
+  Common::MsgAlert(false, Common::MsgType::Information, format, ##__VA_ARGS__)
+
+#define PanicAlert(format, ...)                                                                    \
+  Common::MsgAlert(false, Common::MsgType::Warning, format, ##__VA_ARGS__)
+
+#define PanicYesNo(format, ...)                                                                    \
+  Common::MsgAlert(true, Common::MsgType::Warning, format, ##__VA_ARGS__)
+
+#define AskYesNo(format, ...)                                                                      \
+  Common::MsgAlert(true, Common::MsgType::Question, format, ##__VA_ARGS__)
+
+#define CriticalAlert(format, ...)                                                                 \
+  Common::MsgAlert(false, Common::MsgType::Critical, format, ##__VA_ARGS__)
+
 // Use these macros (that do the same thing) if the message should be translated.
-#define SuccessAlertT(format, ...) MsgAlert(false, MsgType::Information, format, ##__VA_ARGS__)
-#define PanicAlertT(format, ...) MsgAlert(false, MsgType::Warning, format, ##__VA_ARGS__)
-#define PanicYesNoT(format, ...) MsgAlert(true, MsgType::Warning, format, ##__VA_ARGS__)
-#define AskYesNoT(format, ...) MsgAlert(true, MsgType::Question, format, ##__VA_ARGS__)
-#define CriticalAlertT(format, ...) MsgAlert(false, MsgType::Critical, format, ##__VA_ARGS__)
+#define SuccessAlertT(format, ...)                                                                 \
+  Common::MsgAlert(false, Common::MsgType::Information, format, ##__VA_ARGS__)
+
+#define PanicAlertT(format, ...)                                                                   \
+  Common::MsgAlert(false, Common::MsgType::Warning, format, ##__VA_ARGS__)
+
+#define PanicYesNoT(format, ...)                                                                   \
+  Common::MsgAlert(true, Common::MsgType::Warning, format, ##__VA_ARGS__)
+
+#define AskYesNoT(format, ...)                                                                     \
+  Common::MsgAlert(true, Common::MsgType::Question, format, ##__VA_ARGS__)
+
+#define CriticalAlertT(format, ...)                                                                \
+  Common::MsgAlert(false, Common::MsgType::Critical, format, ##__VA_ARGS__)
 #endif

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -15,8 +15,8 @@ enum class MsgType
   Critical
 };
 
-typedef bool (*MsgAlertHandler)(const char* caption, const char* text, bool yes_no, MsgType style);
-typedef std::string (*StringTranslator)(const char* text);
+using MsgAlertHandler = bool (*)(const char* caption, const char* text, bool yes_no, MsgType style);
+using StringTranslator = std::string (*)(const char* text);
 
 void RegisterMsgAlertHandler(MsgAlertHandler handler);
 void RegisterStringTranslator(StringTranslator translator);

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -805,7 +805,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       if (m_sync_save_data_count == 0)
         SyncSaveDataResponse(true);
       else
-        m_dialog->AppendChat(GetStringT("Synchronizing save data..."));
+        m_dialog->AppendChat(Common::GetStringT("Synchronizing save data..."));
     }
     break;
 
@@ -1040,7 +1040,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
         SyncCodeResponse(true);
       }
       else
-        m_dialog->AppendChat(GetStringT("Synchronizing Gecko codes..."));
+        m_dialog->AppendChat(Common::GetStringT("Synchronizing Gecko codes..."));
     }
     break;
 
@@ -1109,7 +1109,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
         SyncCodeResponse(true);
       }
       else
-        m_dialog->AppendChat(GetStringT("Synchronizing AR codes..."));
+        m_dialog->AppendChat(Common::GetStringT("Synchronizing AR codes..."));
     }
     break;
 
@@ -1289,9 +1289,14 @@ void NetPlayClient::ThreadFunc()
     qos_session = Common::QoSSession(m_server);
 
     if (qos_session.Successful())
-      m_dialog->AppendChat(GetStringT("Quality of Service (QoS) was successfully enabled."));
+    {
+      m_dialog->AppendChat(
+          Common::GetStringT("Quality of Service (QoS) was successfully enabled."));
+    }
     else
-      m_dialog->AppendChat(GetStringT("Quality of Service (QoS) couldn't be enabled."));
+    {
+      m_dialog->AppendChat(Common::GetStringT("Quality of Service (QoS) couldn't be enabled."));
+    }
   }
 
   while (m_do_loop.IsSet())
@@ -1511,8 +1516,8 @@ bool NetPlayClient::StartGame(const std::string& path)
 
 void NetPlayClient::SyncSaveDataResponse(const bool success)
 {
-  m_dialog->AppendChat(success ? GetStringT("Data received!") :
-                                 GetStringT("Error processing data."));
+  m_dialog->AppendChat(success ? Common::GetStringT("Data received!") :
+                                 Common::GetStringT("Error processing data."));
 
   if (success)
   {
@@ -1540,7 +1545,7 @@ void NetPlayClient::SyncCodeResponse(const bool success)
   // If something failed, immediately report back that code sync failed
   if (!success)
   {
-    m_dialog->AppendChat(GetStringT("Error processing codes."));
+    m_dialog->AppendChat(Common::GetStringT("Error processing codes."));
 
     sf::Packet response_packet;
     response_packet << static_cast<MessageId>(NP_MSG_SYNC_CODES);
@@ -1553,7 +1558,7 @@ void NetPlayClient::SyncCodeResponse(const bool success)
   // If both gecko and AR codes have completely finished transferring, report back as successful
   if (m_sync_gecko_codes_complete && m_sync_ar_codes_complete)
   {
-    m_dialog->AppendChat(GetStringT("Codes received!"));
+    m_dialog->AppendChat(Common::GetStringT("Codes received!"));
 
     sf::Packet response_packet;
     response_packet << static_cast<MessageId>(NP_MSG_SYNC_CODES);

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1049,7 +1049,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
         m_save_data_synced_players++;
         if (m_save_data_synced_players >= m_players.size() - 1)
         {
-          m_dialog->AppendChat(GetStringT("All players' saves synchronized."));
+          m_dialog->AppendChat(Common::GetStringT("All players' saves synchronized."));
 
           // Saves are synced, check if codes are as well and attempt to start the game
           m_saves_synced = true;
@@ -1061,8 +1061,8 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
     case SYNC_SAVE_DATA_FAILURE:
     {
-      m_dialog->AppendChat(
-          StringFromFormat(GetStringT("%s failed to synchronize.").c_str(), player.name.c_str()));
+      m_dialog->AppendChat(StringFromFormat(Common::GetStringT("%s failed to synchronize.").c_str(),
+                                            player.name.c_str()));
       m_dialog->OnGameStartAborted();
       ChunkedDataAbort();
       m_start_pending = false;
@@ -1093,7 +1093,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
       {
         if (++m_codes_synced_players >= m_players.size() - 1)
         {
-          m_dialog->AppendChat(GetStringT("All players' codes synchronized."));
+          m_dialog->AppendChat(Common::GetStringT("All players' codes synchronized."));
 
           // Codes are synced, check if saves are as well and attempt to start the game
           m_codes_synced = true;
@@ -1105,8 +1105,8 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
     case SYNC_CODES_FAILURE:
     {
-      m_dialog->AppendChat(StringFromFormat(GetStringT("%s failed to synchronize codes.").c_str(),
-                                            player.name.c_str()));
+      m_dialog->AppendChat(StringFromFormat(
+          Common::GetStringT("%s failed to synchronize codes.").c_str(), player.name.c_str()));
       m_dialog->OnGameStartAborted();
       m_start_pending = false;
     }

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -437,11 +437,11 @@ std::string GetInfoStringOfSlot(int slot, bool translate)
 {
   std::string filename = MakeStateFilename(slot);
   if (!File::Exists(filename))
-    return translate ? GetStringT("Empty") : "Empty";
+    return translate ? Common::GetStringT("Empty") : "Empty";
 
   State::StateHeader header;
   if (!ReadHeader(filename, header))
-    return translate ? GetStringT("Unknown") : "Unknown";
+    return translate ? Common::GetStringT("Unknown") : "Unknown";
 
   return Common::Timer::GetDateTimeFormatted(header.time);
 }

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -78,7 +78,7 @@ TitleDatabase::TitleDatabase()
 
   // i18n: "Wii Menu" (or System Menu) refers to the Wii's main menu,
   // which is (usually) the first thing users see when a Wii console starts.
-  m_base_map.emplace("0000000100000002", GetStringT("Wii Menu"));
+  m_base_map.emplace("0000000100000002", Common::GetStringT("Wii Menu"));
   for (const auto& id : {"HAXX", "00010001af1bf516"})
     m_base_map.emplace(id, "The Homebrew Channel");
 }

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -200,7 +200,7 @@ bool CompressFileToBlob(const std::string& infile_path, const std::string& outfi
   if (deflateInit(&z, 9) != Z_OK)
     return false;
 
-  callback(GetStringT("Files opened, ready to compress."), 0, arg);
+  callback(Common::GetStringT("Files opened, ready to compress."), 0, arg);
 
   CompressedBlobHeader header;
   header.magic_cookie = GCZ_MAGIC;
@@ -239,8 +239,8 @@ bool CompressFileToBlob(const std::string& infile_path, const std::string& outfi
       if (inpos != 0)
         ratio = (int)(100 * position / inpos);
 
-      std::string temp =
-          StringFromFormat(GetStringT("%i of %i blocks. Compression ratio %i%%").c_str(), i,
+      const std::string temp =
+          StringFromFormat(Common::GetStringT("%i of %i blocks. Compression ratio %i%%").c_str(), i,
                            header.num_blocks, ratio);
       bool was_cancelled = !callback(temp, (float)i / (float)header.num_blocks, arg);
       if (was_cancelled)
@@ -332,7 +332,7 @@ bool CompressFileToBlob(const std::string& infile_path, const std::string& outfi
 
   if (success)
   {
-    callback(GetStringT("Done compressing disc image."), 1.0f, arg);
+    callback(Common::GetStringT("Done compressing disc image."), 1.0f, arg);
   }
   return success;
 }
@@ -381,7 +381,8 @@ bool DecompressBlobToFile(const std::string& infile_path, const std::string& out
   {
     if (i % progress_monitor == 0)
     {
-      bool was_cancelled = !callback(GetStringT("Unpacking"), (float)i / (float)num_buffers, arg);
+      const bool was_cancelled =
+          !callback(Common::GetStringT("Unpacking"), (float)i / (float)num_buffers, arg);
       if (was_cancelled)
       {
         success = false;

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -64,7 +64,7 @@ std::string GetName(Country country, bool translate)
     break;
   }
 
-  return translate ? GetStringT(name.c_str()) : name;
+  return translate ? Common::GetStringT(name.c_str()) : name;
 }
 
 std::string GetName(Language language, bool translate)
@@ -108,7 +108,7 @@ std::string GetName(Language language, bool translate)
     break;
   }
 
-  return translate ? GetStringT(name.c_str()) : name;
+  return translate ? Common::GetStringT(name.c_str()) : name;
 }
 
 bool IsDisc(Platform volume_type)

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -35,7 +35,8 @@
 #include "UICommon/CommandLineParse.h"
 #include "UICommon/UICommon.h"
 
-static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no, MsgType style)
+static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no,
+                              Common::MsgType style)
 {
   std::optional<bool> r = RunOnObject(QApplication::instance(), [&] {
     ModalMessageBox message_box(QApplication::activeWindow());
@@ -43,19 +44,19 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
     message_box.setText(QString::fromUtf8(text));
 
     message_box.setStandardButtons(yes_no ? QMessageBox::Yes | QMessageBox::No : QMessageBox::Ok);
-    if (style == MsgType::Warning)
+    if (style == Common::MsgType::Warning)
       message_box.addButton(QMessageBox::Ignore)->setText(QObject::tr("Ignore for this session"));
 
     message_box.setIcon([&] {
       switch (style)
       {
-      case MsgType::Information:
+      case Common::MsgType::Information:
         return QMessageBox::Information;
-      case MsgType::Question:
+      case Common::MsgType::Question:
         return QMessageBox::Question;
-      case MsgType::Warning:
+      case Common::MsgType::Warning:
         return QMessageBox::Warning;
-      case MsgType::Critical:
+      case Common::MsgType::Critical:
         return QMessageBox::Critical;
       }
       // appease MSVC
@@ -67,7 +68,7 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
       return true;
 
     if (button == QMessageBox::Ignore)
-      SetEnableAlert(false);
+      Common::SetEnableAlert(false);
 
     return false;
   });
@@ -137,7 +138,7 @@ int main(int argc, char* argv[])
   Settings::Instance().SetBatchModeEnabled(options.is_set("batch"));
 
   // Hook up alerts from core
-  RegisterMsgAlertHandler(QtMsgAlertHandler);
+  Common::RegisterMsgAlertHandler(QtMsgAlertHandler);
 
   // Hook up translations
   Translation::Initialize();

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -263,7 +263,7 @@ void InterfacePane::OnSaveConfig()
   settings.m_show_active_title = m_checkbox_show_active_title->isChecked();
   settings.m_PauseOnFocusLost = m_checkbox_pause_on_focus_lost->isChecked();
 
-  SetEnableAlert(settings.bUsePanicHandlers);
+  Common::SetEnableAlert(settings.bUsePanicHandlers);
 
   auto new_language = m_combobox_language->currentData().toString().toStdString();
   if (new_language != SConfig::GetInstance().m_InterfaceLanguage)

--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -292,7 +292,8 @@ static bool TryInstallTranslator(const QString& exact_language_code)
 void Translation::Initialize()
 {
   // Hook up Dolphin internal translation
-  RegisterStringTranslator([](const char* text) { return QObject::tr(text).toStdString(); });
+  Common::RegisterStringTranslator(
+      [](const char* text) { return QObject::tr(text).toStdString(); });
 
   // Hook up Qt translations
   auto& configured_language = SConfig::GetInstance().m_InterfaceLanguage;

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -84,7 +84,7 @@ void Init()
   GCAdapter::Init();
   VideoBackendBase::ActivateBackend(SConfig::GetInstance().m_strVideoBackend);
 
-  SetEnableAlert(SConfig::GetInstance().bUsePanicHandlers);
+  Common::SetEnableAlert(SConfig::GetInstance().bUsePanicHandlers);
 }
 
 void Shutdown()
@@ -440,7 +440,7 @@ std::string FormatSize(u64 bytes)
   const double unit_size = std::pow(2, unit * 10);
   std::stringstream ss;
   ss << std::fixed << std::setprecision(2);
-  ss << bytes / unit_size << ' ' << GetStringT(unit_symbols[unit]);
+  ss << bytes / unit_size << ' ' << Common::GetStringT(unit_symbols[unit]);
   return ss.str();
 }
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -157,7 +157,7 @@ void ShaderCache::WaitForAsyncCompiler()
 
       ImGui::SetNextWindowSize(ImVec2(400.0f * scale, 50.0f * scale), ImGuiCond_Always);
       ImGui::SetNextWindowPosCenter(ImGuiCond_Always);
-      if (ImGui::Begin(GetStringT("Compiling Shaders").c_str(), nullptr,
+      if (ImGui::Begin(Common::GetStringT("Compiling Shaders").c_str(), nullptr,
                        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
                            ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
                            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |


### PR DESCRIPTION
Performs a little cleanup of the message handler interface and finishes it off by namespacing the functions within the translation unit under the Common namespace, removing them from the global namespace, like most other files within the Common library do.

We can't namespace the macros, but that's to be expected.