### PR TITLE
VideoCommon/Statistics: Remove preprocessor macro

### DIFF
--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -2,14 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <string>
 #include <utility>
 
 #include "imgui.h"
 
-#include "Common/StringUtil.h"
 #include "VideoCommon/Statistics.h"
-#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VideoConfig.h"
 
 Statistics stats;

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -43,7 +43,7 @@ void Statistics::Display()
   ImGui::Columns(2, "Statistics", true);
 
   const auto draw_statistic = [](const char* name, const char* format, auto&&... args) {
-    ImGui::Text(name);
+    ImGui::TextUnformatted(name);
     ImGui::NextColumn();
     ImGui::Text(format, std::forward<decltype(args)>(args)...);
     ImGui::NextColumn();
@@ -103,7 +103,7 @@ void Statistics::DisplayProj()
     return;
   }
 
-  ImGui::Text("Projection #: X for Raw 6=0 (X for Raw 6!=0)");
+  ImGui::TextUnformatted("Projection #: X for Raw 6=0 (X for Raw 6!=0)");
   ImGui::NewLine();
   ImGui::Text("Projection 0: %f (%f) Raw 0: %f", stats.gproj_0, stats.g2proj_0, stats.proj_0);
   ImGui::Text("Projection 1: %f (%f)", stats.gproj_1, stats.g2proj_1);

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -42,53 +42,52 @@ void Statistics::Display()
 
   ImGui::Columns(2, "Statistics", true);
 
-#define DRAW_STAT(name, format, ...)                                                               \
-  ImGui::Text(name);                                                                               \
-  ImGui::NextColumn();                                                                             \
-  ImGui::Text(format, __VA_ARGS__);                                                                \
-  ImGui::NextColumn();
+  const auto draw_statistic = [](const char* name, const char* format, auto&&... args) {
+    ImGui::Text(name);
+    ImGui::NextColumn();
+    ImGui::Text(format, std::forward<decltype(args)>(args)...);
+    ImGui::NextColumn();
+  };
 
   if (g_ActiveConfig.backend_info.api_type == APIType::Nothing)
   {
-    DRAW_STAT("Objects", "%d", stats.thisFrame.numDrawnObjects);
-    DRAW_STAT("Vertices Loaded", "%d", stats.thisFrame.numVerticesLoaded);
-    DRAW_STAT("Triangles Input", "%d", stats.thisFrame.numTrianglesIn);
-    DRAW_STAT("Triangles Rejected", "%d", stats.thisFrame.numTrianglesRejected);
-    DRAW_STAT("Triangles Culled", "%d", stats.thisFrame.numTrianglesCulled);
-    DRAW_STAT("Triangles Clipped", "%d", stats.thisFrame.numTrianglesClipped);
-    DRAW_STAT("Triangles Drawn", "%d", stats.thisFrame.numTrianglesDrawn);
-    DRAW_STAT("Rasterized Pix", "%d", stats.thisFrame.rasterizedPixels);
-    DRAW_STAT("TEV Pix In", "%d", stats.thisFrame.tevPixelsIn);
-    DRAW_STAT("TEV Pix Out", "%d", stats.thisFrame.tevPixelsOut);
+    draw_statistic("Objects", "%d", stats.thisFrame.numDrawnObjects);
+    draw_statistic("Vertices Loaded", "%d", stats.thisFrame.numVerticesLoaded);
+    draw_statistic("Triangles Input", "%d", stats.thisFrame.numTrianglesIn);
+    draw_statistic("Triangles Rejected", "%d", stats.thisFrame.numTrianglesRejected);
+    draw_statistic("Triangles Culled", "%d", stats.thisFrame.numTrianglesCulled);
+    draw_statistic("Triangles Clipped", "%d", stats.thisFrame.numTrianglesClipped);
+    draw_statistic("Triangles Drawn", "%d", stats.thisFrame.numTrianglesDrawn);
+    draw_statistic("Rasterized Pix", "%d", stats.thisFrame.rasterizedPixels);
+    draw_statistic("TEV Pix In", "%d", stats.thisFrame.tevPixelsIn);
+    draw_statistic("TEV Pix Out", "%d", stats.thisFrame.tevPixelsOut);
   }
 
-  DRAW_STAT("Textures created", "%d", stats.numTexturesCreated);
-  DRAW_STAT("Textures uploaded", "%d", stats.numTexturesUploaded);
-  DRAW_STAT("Textures alive", "%d", stats.numTexturesAlive);
-  DRAW_STAT("pshaders created", "%d", stats.numPixelShadersCreated);
-  DRAW_STAT("pshaders alive", "%d", stats.numPixelShadersAlive);
-  DRAW_STAT("vshaders created", "%d", stats.numVertexShadersCreated);
-  DRAW_STAT("vshaders alive", "%d", stats.numVertexShadersAlive);
-  DRAW_STAT("shaders changes", "%d", stats.thisFrame.numShaderChanges);
-  DRAW_STAT("dlists called", "%d", stats.thisFrame.numDListsCalled);
-  DRAW_STAT("Primitive joins", "%d", stats.thisFrame.numPrimitiveJoins);
-  DRAW_STAT("Draw calls", "%d", stats.thisFrame.numDrawCalls);
-  DRAW_STAT("Primitives", "%d", stats.thisFrame.numPrims);
-  DRAW_STAT("Primitives (DL)", "%d", stats.thisFrame.numDLPrims);
-  DRAW_STAT("XF loads", "%d", stats.thisFrame.numXFLoads);
-  DRAW_STAT("XF loads (DL)", "%d", stats.thisFrame.numXFLoadsInDL);
-  DRAW_STAT("CP loads", "%d", stats.thisFrame.numCPLoads);
-  DRAW_STAT("CP loads (DL)", "%d", stats.thisFrame.numCPLoadsInDL);
-  DRAW_STAT("BP loads", "%d", stats.thisFrame.numBPLoads);
-  DRAW_STAT("BP loads (DL)", "%d", stats.thisFrame.numBPLoadsInDL);
-  DRAW_STAT("Vertex streamed", "%i kB", stats.thisFrame.bytesVertexStreamed / 1024);
-  DRAW_STAT("Index streamed", "%i kB", stats.thisFrame.bytesIndexStreamed / 1024);
-  DRAW_STAT("Uniform streamed", "%i kB", stats.thisFrame.bytesUniformStreamed / 1024);
-  DRAW_STAT("Vertex Loaders", "%d", stats.numVertexLoaders);
-  DRAW_STAT("EFB peeks:", "%d", stats.thisFrame.numEFBPeeks);
-  DRAW_STAT("EFB pokes:", "%d", stats.thisFrame.numEFBPokes);
-
-#undef DRAW_STAT
+  draw_statistic("Textures created", "%d", stats.numTexturesCreated);
+  draw_statistic("Textures uploaded", "%d", stats.numTexturesUploaded);
+  draw_statistic("Textures alive", "%d", stats.numTexturesAlive);
+  draw_statistic("pshaders created", "%d", stats.numPixelShadersCreated);
+  draw_statistic("pshaders alive", "%d", stats.numPixelShadersAlive);
+  draw_statistic("vshaders created", "%d", stats.numVertexShadersCreated);
+  draw_statistic("vshaders alive", "%d", stats.numVertexShadersAlive);
+  draw_statistic("shaders changes", "%d", stats.thisFrame.numShaderChanges);
+  draw_statistic("dlists called", "%d", stats.thisFrame.numDListsCalled);
+  draw_statistic("Primitive joins", "%d", stats.thisFrame.numPrimitiveJoins);
+  draw_statistic("Draw calls", "%d", stats.thisFrame.numDrawCalls);
+  draw_statistic("Primitives", "%d", stats.thisFrame.numPrims);
+  draw_statistic("Primitives (DL)", "%d", stats.thisFrame.numDLPrims);
+  draw_statistic("XF loads", "%d", stats.thisFrame.numXFLoads);
+  draw_statistic("XF loads (DL)", "%d", stats.thisFrame.numXFLoadsInDL);
+  draw_statistic("CP loads", "%d", stats.thisFrame.numCPLoads);
+  draw_statistic("CP loads (DL)", "%d", stats.thisFrame.numCPLoadsInDL);
+  draw_statistic("BP loads", "%d", stats.thisFrame.numBPLoads);
+  draw_statistic("BP loads (DL)", "%d", stats.thisFrame.numBPLoadsInDL);
+  draw_statistic("Vertex streamed", "%i kB", stats.thisFrame.bytesVertexStreamed / 1024);
+  draw_statistic("Index streamed", "%i kB", stats.thisFrame.bytesIndexStreamed / 1024);
+  draw_statistic("Uniform streamed", "%i kB", stats.thisFrame.bytesUniformStreamed / 1024);
+  draw_statistic("Vertex Loaders", "%d", stats.numVertexLoaders);
+  draw_statistic("EFB peeks:", "%d", stats.thisFrame.numEFBPeeks);
+  draw_statistic("EFB pokes:", "%d", stats.thisFrame.numEFBPokes);
 
   ImGui::Columns(1);
 

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -2,11 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/Statistics.h"
+
 #include <utility>
 
-#include "imgui.h"
+#include <imgui.h>
 
-#include "VideoCommon/Statistics.h"
 #include "VideoCommon/VideoConfig.h"
 
 Statistics stats;

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cstring>
 #include <string>
 #include <utility>
 
@@ -17,7 +16,7 @@ Statistics stats;
 
 void Statistics::ResetFrame()
 {
-  memset(&thisFrame, 0, sizeof(ThisFrame));
+  thisFrame = {};
 }
 
 void Statistics::SwapDL()

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <string>
-
 struct Statistics
 {
   int numPixelShadersCreated;


### PR DESCRIPTION
Removes a preprocessor macro and replaces it with a variadic lambda function instead that does the same thing.

While we're at it, we can do a bit of trivial cleanup in other areas as well.