### PR TITLE
General: Use nested namespace specifiers where applicable

### DIFF
--- a/Source/Core/Common/Crypto/AES.cpp
+++ b/Source/Core/Common/Crypto/AES.cpp
@@ -6,9 +6,7 @@
 
 #include "Common/Crypto/AES.h"
 
-namespace Common
-{
-namespace AES
+namespace Common::AES
 {
 std::vector<u8> DecryptEncrypt(const u8* key, u8* iv, const u8* src, size_t size, Mode mode)
 {
@@ -35,5 +33,4 @@ std::vector<u8> Encrypt(const u8* key, u8* iv, const u8* src, size_t size)
 {
   return DecryptEncrypt(key, iv, src, size, Mode::Encrypt);
 }
-}  // namespace AES
-}  // namespace Common
+}  // namespace Common::AES

--- a/Source/Core/Common/Crypto/AES.h
+++ b/Source/Core/Common/Crypto/AES.h
@@ -9,9 +9,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace Common
-{
-namespace AES
+namespace Common::AES
 {
 enum class Mode
 {
@@ -23,5 +21,4 @@ std::vector<u8> DecryptEncrypt(const u8* key, u8* iv, const u8* src, size_t size
 // Convenience functions
 std::vector<u8> Decrypt(const u8* key, u8* iv, const u8* src, size_t size);
 std::vector<u8> Encrypt(const u8* key, u8* iv, const u8* src, size_t size);
-}  // namespace AES
-}  // namespace Common
+}  // namespace Common::AES

--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -12,9 +12,7 @@
 #include "Core/DSP/DSPMemoryMap.h"
 #include "Core/DSP/DSPTables.h"
 
-namespace DSP
-{
-namespace Analyzer
+namespace DSP::Analyzer
 {
 namespace
 {
@@ -167,5 +165,4 @@ u8 GetCodeFlags(u16 address)
   return code_flags[address];
 }
 
-}  // namespace Analyzer
-}  // namespace DSP
+}  // namespace DSP::Analyzer

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -7,9 +7,7 @@
 #include "Common/CommonTypes.h"
 
 // Basic code analysis.
-namespace DSP
-{
-namespace Analyzer
+namespace DSP::Analyzer
 {
 // Useful things to detect:
 // * Loop endpoints - so that we can avoid checking for loops every cycle.
@@ -35,5 +33,4 @@ void Analyze();
 // Retrieves the flags set during analysis for code in memory.
 u8 GetCodeFlags(u16 address);
 
-}  // namespace Analyzer
-}  // namespace DSP
+}  // namespace DSP::Analyzer

--- a/Source/Core/Core/DSP/DSPHost.h
+++ b/Source/Core/Core/DSP/DSPHost.h
@@ -13,9 +13,7 @@
 // core isn't used, for example in an asm/disasm tool, then most of these
 // can be stubbed out.
 
-namespace DSP
-{
-namespace Host
+namespace DSP::Host
 {
 u8 ReadHostMemory(u32 addr);
 void WriteHostMemory(u8 value, u32 addr);
@@ -25,5 +23,4 @@ bool IsWiiHost();
 void InterruptRequest();
 void CodeLoaded(const u8* ptr, int size);
 void UpdateDebugger();
-}  // namespace Host
-}  // namespace DSP
+}  // namespace DSP::Host

--- a/Source/Core/Core/DSP/Interpreter/DSPIntArithmetic.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntArithmetic.cpp
@@ -12,9 +12,7 @@
 
 // Arithmetic and accumulator control.
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 // CLR $acR
 // 1000 r001 xxxx xxxx
@@ -1159,6 +1157,4 @@ void asrnr(const UDSPInstruction opc)
   dsp_set_long_acc(dreg, acc);
   Update_SR_Register64(dsp_get_long_acc(dreg));
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
@@ -11,9 +11,7 @@
 #include "Core/DSP/Interpreter/DSPIntUtil.h"
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 // Generic call implementation
 // CALLcc addressA
@@ -263,6 +261,4 @@ void bloopi(const UDSPInstruction opc)
     dsp_skip_inst();
   }
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPIntCCUtil.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntCCUtil.cpp
@@ -9,9 +9,7 @@
 #include "Core/DSP/Interpreter/DSPIntCCUtil.h"
 #include "Core/DSP/DSPCore.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 void Update_SR_Register64(s64 _Value, bool carry, bool overflow)
 {
@@ -182,6 +180,4 @@ bool CheckCondition(u8 _Condition)
     return true;
   }
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPIntCCUtil.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntCCUtil.h
@@ -10,9 +10,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 bool CheckCondition(u8 _Condition);
 
@@ -40,6 +38,4 @@ inline bool isOverS32(s64 acc)
 {
   return (acc != (s32)acc) ? true : false;
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPIntExtOps.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntExtOps.cpp
@@ -30,9 +30,7 @@ static void WriteToBackLog(int i, int idx, u16 value)
   writeBackLogIdx[i] = idx;
 }
 
-namespace Interpreter
-{
-namespace Ext
+namespace Interpreter::Ext
 {
 static bool IsSameMemArea(u16 a, u16 b)
 {
@@ -493,9 +491,7 @@ void ldaxnm(const UDSPInstruction opc)
 void nop(const UDSPInstruction opc)
 {
 }
-
-}  // namespace Ext
-}  // namespace Interpreter
+}  // namespace Interpreter::Ext
 
 // The ext ops are calculated in parallel with the actual op. That means that
 // both the main op and the ext op see the same register state as input. The

--- a/Source/Core/Core/DSP/Interpreter/DSPIntExtOps.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntExtOps.h
@@ -11,11 +11,7 @@
 // Many opcode have the lower 0xFF (some only 0x7f) free - there, an opcode extension
 // can be stored.
 
-namespace DSP
-{
-namespace Interpreter
-{
-namespace Ext
+namespace DSP::Interpreter::Ext
 {
 void l(UDSPInstruction opc);
 void ln(UDSPInstruction opc);
@@ -42,7 +38,4 @@ void dr(UDSPInstruction opc);
 void ir(UDSPInstruction opc);
 void nr(UDSPInstruction opc);
 void nop(UDSPInstruction opc);
-
-}  // namespace Ext
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter::Ext

--- a/Source/Core/Core/DSP/Interpreter/DSPIntLoadStore.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntLoadStore.cpp
@@ -8,9 +8,7 @@
 #include "Core/DSP/Interpreter/DSPIntUtil.h"
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 // SRS @M, $(0x18+S)
 // 0010 1sss mmmm mmmm
@@ -261,6 +259,4 @@ void ilrrn(const UDSPInstruction opc)
   dsp_conditional_extend_accum(dreg);
   g_dsp.r.ar[reg] = dsp_increase_addr_reg(reg, (s16)g_dsp.r.ix[reg]);
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
@@ -10,9 +10,7 @@
 #include "Core/DSP/Interpreter/DSPIntUtil.h"
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 // MRR $D, $S
 // 0001 11dd ddds ssss
@@ -159,6 +157,4 @@ void srbith(const UDSPInstruction opc)
     break;
   }
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPIntMultiplier.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntMultiplier.cpp
@@ -11,9 +11,7 @@
 #include "Core/DSP/Interpreter/DSPIntUtil.h"
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 namespace
 {
@@ -594,6 +592,4 @@ void msub(const UDSPInstruction opc)
 
   dsp_set_long_prod(prod);
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPIntUtil.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntUtil.h
@@ -11,9 +11,7 @@
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPStacks.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 // ---------------------------------------------------------------------------------------
 // --- SR
@@ -379,5 +377,4 @@ inline s16 dsp_get_ax_h(int _reg)
   return (s16)g_dsp.r.ax[_reg].h;
 }
 
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -14,9 +14,7 @@
 #include "Core/DSP/DSPTables.h"
 #include "Core/DSP/Interpreter/DSPIntTables.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 namespace
 {
@@ -237,6 +235,4 @@ void nop(const UDSPInstruction opc)
 
   ERROR_LOG(DSPLLE, "LLE: Unrecognized opcode 0x%04x", opc);
 }
-
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.h
@@ -6,9 +6,7 @@
 
 #include "Core/DSP/DSPCommon.h"
 
-namespace DSP
-{
-namespace Interpreter
+namespace DSP::Interpreter
 {
 void Step();
 
@@ -146,5 +144,4 @@ void xorc(UDSPInstruction opc);
 void xori(UDSPInstruction opc);
 void xorr(UDSPInstruction opc);
 
-}  // namespace Interpreter
-}  // namespace DSP
+}  // namespace DSP::Interpreter

--- a/Source/Core/Core/HLE/HLE_VarArgs.h
+++ b/Source/Core/Core/HLE/HLE_VarArgs.h
@@ -12,9 +12,7 @@
 
 #include <type_traits>
 
-namespace HLE
-{
-namespace SystemVABI
+namespace HLE::SystemVABI
 {
 // SFINAE
 template <typename T>
@@ -172,5 +170,4 @@ private:
   double GetFPR(u32 fpr) const override;
 };
 
-}  // namespace SystemVABI
-}  // namespace HLE
+}  // namespace HLE::SystemVABI

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -11,9 +11,7 @@
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/SystemTimers.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 DSPHLE::DSPHLE() = default;
 
@@ -216,5 +214,4 @@ u16 DSPHLE::DSP_ReadControlRegister()
 void DSPHLE::PauseAndLock(bool do_lock, bool unpause_on_unlock)
 {
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -13,9 +13,7 @@
 
 class PointerWrap;
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class UCodeInterface;
 
@@ -73,5 +71,4 @@ private:
   bool m_halt;
   bool m_assert_interrupt;
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -12,9 +12,7 @@
 #include "Common/MsgHandler.h"
 #include "Core/HW/DSP.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 CMailHandler::CMailHandler()
 {
@@ -135,5 +133,4 @@ void CMailHandler::DoState(PointerWrap& p)
     }
   }
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -11,9 +11,7 @@
 
 class PointerWrap;
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class CMailHandler
 {
@@ -35,5 +33,4 @@ private:
   // mail handler
   std::queue<std::pair<u32, bool>> m_Mails;
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -22,9 +22,7 @@
 #define AX_GC
 #include "Core/HW/DSPHLE/UCodes/AXVoice.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 AXUCode::AXUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc), m_cmdlist_size(0)
 {
@@ -727,5 +725,4 @@ void AXUCode::DoState(PointerWrap& p)
   DoStateShared(p);
   DoAXState(p);
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -15,9 +15,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class DSPHLE;
 
@@ -155,5 +153,4 @@ private:
     CMD_SEND_AUX_AND_MIX = 0x13,
   };
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXStructs.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXStructs.h
@@ -6,9 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 struct PBMixer
 {
@@ -337,5 +335,4 @@ enum
   FILTER_LOWPASS = 1,
   FILTER_BIQUAD = 2,
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -23,9 +23,7 @@
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 #include "Core/HW/Memmap.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 #ifdef AX_GC
 #define PB_TYPE AXPB
@@ -566,5 +564,4 @@ void ProcessVoice(PB_TYPE& pb, const AXBuffers& buffers, u16 count, AXMixControl
 }
 
 }  // namespace
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -19,9 +19,7 @@
 #include "Core/HW/DSPHLE/UCodes/AXVoice.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 AXWiiUCode::AXWiiUCode(DSPHLE* dsphle, u32 crc) : AXUCode(dsphle, crc), m_last_main_volume(0x8000)
 {
@@ -669,5 +667,4 @@ void AXWiiUCode::DoState(PointerWrap& p)
   p.Do(m_last_main_volume);
   p.Do(m_last_aux_volumes);
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -7,9 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 struct AXPBWii;
 class DSPHLE;
@@ -115,5 +113,4 @@ private:
     CMD_END_OLD = 0x0F
   };
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -10,9 +10,7 @@
 #include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 CARDUCode::CARDUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 {
@@ -52,5 +50,4 @@ void CARDUCode::HandleMail(u32 mail)
   m_mail_handler.PushMail(DSP_DONE);
   m_dsphle->SetUCode(UCODE_ROM);
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
@@ -7,9 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class DSPHLE;
 
@@ -23,5 +21,4 @@ public:
   void HandleMail(u32 mail) override;
   void Update() override;
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -12,9 +12,7 @@
 #include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 void ProcessGBACrypto(u32 address)
 {
@@ -137,5 +135,4 @@ void GBAUCode::HandleMail(u32 mail)
     WARN_LOG(DSPHLE, "GBAUCode - unknown command: %08x", mail);
   }
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
@@ -7,9 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class DSPHLE;
 
@@ -27,5 +25,4 @@ struct GBAUCode : public UCodeInterface
   void HandleMail(u32 mail) override;
   void Update() override;
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -10,9 +10,7 @@
 #include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 INITUCode::INITUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 {
@@ -39,5 +37,4 @@ void INITUCode::Update()
 void INITUCode::HandleMail(u32 mail)
 {
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
@@ -7,9 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class DSPHLE;
 
@@ -24,5 +22,4 @@ public:
   void Update() override;
   void Init();
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -20,9 +20,7 @@
 #include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 ROMUCode::ROMUCode(DSPHLE* dsphle, u32 crc)
     : UCodeInterface(dsphle, crc), m_current_ucode(), m_boot_task_num_steps(0), m_next_parameter(0)
@@ -130,5 +128,4 @@ void ROMUCode::DoState(PointerWrap& p)
 
   DoStateShared(p);
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -7,9 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class DSPHLE;
 
@@ -41,5 +39,4 @@ private:
 
   void BootUCode();
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -29,9 +29,7 @@
 #include "Core/HW/DSPHLE/UCodes/Zelda.h"
 #include "Core/HW/Memmap.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 constexpr bool ExramRead(u32 address)
 {
@@ -306,5 +304,4 @@ std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
 
   return nullptr;
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -11,9 +11,7 @@
 
 class PointerWrap;
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class CMailHandler;
 class DSPHLE;
@@ -106,5 +104,4 @@ private:
 };
 
 std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii);
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -18,9 +18,7 @@
 #include "Core/HW/DSPHLE/UCodes/GBA.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 // Uncomment this to have a strict version of the HLE implementation, which
 // PanicAlerts on recoverable unknown behaviors instead of silently ignoring
@@ -1854,5 +1852,4 @@ void ZeldaAudioRenderer::DoState(PointerWrap& p)
   p.Do(m_buf_front_left_reverb_last8);
   p.Do(m_buf_front_right_reverb_last8);
 }
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -10,9 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-namespace DSP
-{
-namespace HLE
+namespace DSP::HLE
 {
 class DSPHLE;
 
@@ -286,5 +284,4 @@ private:
   // Main object handling audio rendering logic and state.
   ZeldaAudioRenderer m_renderer;
 };
-}  // namespace HLE
-}  // namespace DSP
+}  // namespace DSP::HLE

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -13,9 +13,7 @@
 #include "Core/DSP/DSPMemoryMap.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
 
-namespace DSP
-{
-namespace LLE
+namespace DSP::LLE
 {
 void DSPPatches::Patch(std::size_t index)
 {
@@ -312,5 +310,4 @@ void DSPDebugInterface::Clear()
   ClearPatches();
   ClearWatches();
 }
-}  // namespace LLE
-}  // namespace DSP
+}  // namespace DSP::LLE

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -10,9 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 
-namespace DSP
-{
-namespace LLE
+namespace DSP::LLE
 {
 class DSPPatches : public Common::Debug::MemoryPatches
 {
@@ -79,5 +77,4 @@ private:
   Common::Debug::Watches m_watches;
   DSPPatches m_patches;
 };
-}  // namespace LLE
-}  // namespace DSP
+}  // namespace DSP::LLE

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -24,9 +24,7 @@
 // core isn't used, for example in an asm/disasm tool, then most of these
 // can be stubbed out.
 
-namespace DSP
-{
-namespace Host
+namespace DSP::Host
 {
 u8 ReadHostMemory(u32 addr)
 {
@@ -84,5 +82,4 @@ void UpdateDebugger()
 {
   Host_RefreshDSPDebuggerWindow();
 }
-}  // namespace Host
-}  // namespace DSP
+}  // namespace DSP::Host

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -30,9 +30,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/Host.h"
 
-namespace DSP
-{
-namespace LLE
+namespace DSP::LLE
 {
 static Common::Event s_dsp_event;
 static Common::Event s_ppc_event;
@@ -340,5 +338,4 @@ void DSPLLE::PauseAndLock(bool do_lock, bool unpause_on_unlock)
   else
     m_dsp_thread_mutex.unlock();
 }
-}  // namespace LLE
-}  // namespace DSP
+}  // namespace DSP::LLE

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.h
@@ -14,9 +14,7 @@
 
 class PointerWrap;
 
-namespace DSP
-{
-namespace LLE
+namespace DSP::LLE
 {
 class DSPLLE : public DSPEmulator
 {
@@ -49,5 +47,4 @@ private:
   Common::Flag m_is_running;
   std::atomic<u32> m_cycle_count{};
 };
-}  // namespace LLE
-}  // namespace DSP
+}  // namespace DSP::LLE

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -14,9 +14,7 @@
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPDisassembler.h"
 
-namespace DSP
-{
-namespace Symbols
+namespace DSP::Symbols
 {
 DSPSymbolDB g_dsp_symbol_db;
 
@@ -106,6 +104,4 @@ void Clear()
   lines.clear();
   line_counter = 0;
 }
-
-}  // namespace Symbols
-}  // namespace DSP
+}  // namespace DSP::Symbols

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
@@ -9,9 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/SymbolDB.h"
 
-namespace DSP
-{
-namespace Symbols
+namespace DSP::Symbols
 {
 class DSPSymbolDB : public Common::SymbolDB
 {
@@ -31,6 +29,4 @@ int Addr2Line(u16 address);
 int Line2Addr(int line);  // -1 for not found
 
 const char* GetLineText(int line);
-
-}  // namespace Symbols
-}  // namespace DSP
+}  // namespace DSP::Symbols

--- a/Source/Core/Core/HW/DVD/DVDThread.h
+++ b/Source/Core/Core/HW/DVD/DVDThread.h
@@ -15,23 +15,23 @@ namespace DiscIO
 {
 struct Partition;
 }
+
 namespace DVDInterface
 {
 enum class ReplyType : u32;
 }
+
 namespace DiscIO
 {
 enum class Platform;
 class Volume;
 }  // namespace DiscIO
-namespace IOS
-{
-namespace ES
+
+namespace IOS::ES
 {
 class TMDReader;
 class TicketReader;
-}  // namespace ES
-}  // namespace IOS
+}  // namespace IOS::ES
 
 namespace DVDThread
 {

--- a/Source/Core/Core/HW/WiiSave.h
+++ b/Source/Core/Core/HW/WiiSave.h
@@ -11,17 +11,14 @@
 
 #include "Common/CommonTypes.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace FS
 {
 class FileSystem;
 }
 class IOSC;
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE
 
 namespace WiiSave
 {

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -15,11 +15,7 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/FS/FileSystem.h"
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 using namespace IOS::HLE::FS;
 
@@ -587,6 +583,4 @@ IPCCommandResult FS::Shutdown(const Handle& handle, const IOCtlRequest& request)
   INFO_LOG(IOS_FS, "Shutdown");
   return GetFSReply(IPC_SUCCESS);
 }
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.h
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.h
@@ -15,11 +15,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
-{
-namespace Device
+namespace IOS::HLE::Device
 {
 constexpr IOS::HLE::FS::Fd INVALID_FD = 0xffffffff;
 
@@ -90,6 +86,4 @@ private:
   u16 m_cache_chain_index = 0;
   bool m_dirty_cache = false;
 };
-}  // namespace Device
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -57,9 +57,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/WiiRoot.h"
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 static std::unique_ptr<EmulationKernel> s_ios;
 
@@ -801,5 +799,4 @@ EmulationKernel* GetIOS()
 {
   return s_ios.get();
 }
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -19,9 +19,7 @@
 
 class PointerWrap;
 
-namespace IOS
-{
-namespace HLE
+namespace IOS::HLE
 {
 namespace FS
 {
@@ -146,5 +144,4 @@ void Init();
 void Shutdown();
 EmulationKernel* GetIOS();
 
-}  // namespace HLE
-}  // namespace IOS
+}  // namespace IOS::HLE

--- a/Source/Core/Core/WiiUtils.h
+++ b/Source/Core/Core/WiiUtils.h
@@ -17,13 +17,11 @@ namespace DiscIO
 {
 class WiiWAD;
 }
-namespace IOS
-{
-namespace HLE
+
+namespace IOS::HLE
 {
 class Kernel;
 }
-}  // namespace IOS
 
 namespace WiiUtils
 {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
@@ -11,14 +11,11 @@ class QString;
 class OutputReference;
 class QPushButton;
 
-namespace ciface
-{
-namespace Core
+namespace ciface::Core
 {
 class DeviceContainer;
 class DeviceQualifier;
-}  // namespace Core
-}  // namespace ciface
+}  // namespace ciface::Core
 
 namespace MappingCommon
 {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -25,13 +25,10 @@ class ControlGroup;
 class EmulatedController;
 }  // namespace ControllerEmu
 
-namespace ciface
-{
-namespace Core
+namespace ciface::Core
 {
 class Device;
-}
-}  // namespace ciface
+}  // namespace ciface::Core
 
 constexpr int INDICATOR_UPDATE_FREQ = 30;
 

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -13,12 +13,10 @@
 #include "Common/StringUtil.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
 
+namespace ciface::ExpressionParser
+{
 using namespace ciface::Core;
 
-namespace ciface
-{
-namespace ExpressionParser
-{
 enum TokenType
 {
   TOK_DISCARD,
@@ -557,5 +555,4 @@ std::pair<ParseStatus, std::unique_ptr<Expression>> ParseExpression(const std::s
                                                             std::move(complex_result.expr));
   return std::make_pair(complex_result.status, std::move(combined_expr));
 }
-}  // namespace ExpressionParser
-}  // namespace ciface
+}  // namespace ciface::ExpressionParser

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -9,9 +9,7 @@
 #include <utility>
 #include "InputCommon/ControllerInterface/Device.h"
 
-namespace ciface
-{
-namespace ExpressionParser
+namespace ciface::ExpressionParser
 {
 class ControlQualifier
 {
@@ -66,5 +64,4 @@ enum class ParseStatus
 };
 
 std::pair<ParseStatus, std::unique_ptr<Expression>> ParseExpression(const std::string& expr);
-}  // namespace ExpressionParser
-}  // namespace ciface
+}  // namespace ciface::ExpressionParser

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -8,9 +8,7 @@
 #include <thread>
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-namespace ciface
-{
-namespace Android
+namespace ciface::Android
 {
 void PopulateDevices()
 {
@@ -240,5 +238,4 @@ void Touchscreen::Motor::Rumble(int padID, double state)
   JNIEnv* env = IDCache::GetEnvForThread();
   env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(), IDCache::GetDoRumble(), padID, state);
 }
-}  // namespace Android
-}  // namespace ciface
+}  // namespace ciface::Android

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.h
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.h
@@ -7,11 +7,10 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "jni/ButtonManager.h"
 
-namespace ciface
-{
-namespace Android
+namespace ciface::Android
 {
 void PopulateDevices();
+
 class Touchscreen : public Core::Device
 {
 private:
@@ -65,5 +64,4 @@ public:
 private:
   const int _padID;
 };
-}  // namespace Android
-}  // namespace ciface
+}  // namespace ciface::Android

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
@@ -14,9 +14,7 @@
 #pragma comment(lib, "Dinput8.lib")
 #pragma comment(lib, "dxguid.lib")
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 BOOL CALLBACK DIEnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef)
 {
@@ -69,5 +67,4 @@ void PopulateDevices(HWND hwnd)
 
   idi8->Release();
 }
-}  // namespace DInput
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
@@ -12,9 +12,7 @@
 
 #include "InputCommon/ControllerInterface/DInput/DInput8.h"
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 // BOOL CALLBACK DIEnumEffectsCallback(LPCDIEFFECTINFO pdei, LPVOID pvRef);
 BOOL CALLBACK DIEnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);
@@ -22,5 +20,4 @@ BOOL CALLBACK DIEnumDevicesCallback(LPCDIDEVICEINSTANCE lpddi, LPVOID pvRef);
 std::string GetDeviceName(const LPDIRECTINPUTDEVICE8 device);
 
 void PopulateDevices(HWND hwnd);
-}  // namespace DInput
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -14,9 +14,7 @@
 #include "InputCommon/ControllerInterface/DInput/DInputJoystick.h"
 #include "InputCommon/ControllerInterface/DInput/XInputFilter.h"
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 constexpr DWORD DATA_BUFFER_SIZE = 32;
 
@@ -315,5 +313,4 @@ ControlState Joystick::Hat::GetState() const
 
   return (abs((int)(m_hat / 4500 - m_direction * 2 + 8) % 8 - 4) > 2);
 }
-}  // namespace DInput
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
@@ -7,9 +7,7 @@
 #include "InputCommon/ControllerInterface/Device.h"
 #include "InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h"
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 void InitJoystick(IDirectInput8* const idi8, HWND hwnd);
 
@@ -77,5 +75,4 @@ private:
 
   bool m_buffered;
 };
-}  // namespace DInput
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -17,9 +17,7 @@
 // otherwise it is just some crazy value
 #define DROP_INPUT_TIME 250
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 static const struct
 {
@@ -227,5 +225,4 @@ ControlState KeyboardMouse::Cursor::GetState() const
 {
   return m_axis / (m_positive ? 1.0 : -1.0);
 }
-}  // namespace DInput
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -9,9 +9,7 @@
 #include "InputCommon/ControllerInterface/DInput/DInput8.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 void InitKeyboardMouse(IDirectInput8* const idi8, HWND hwnd);
 
@@ -103,5 +101,4 @@ private:
   DWORD m_last_update;
   State m_state_in;
 };
-}  // namespace DInput
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.cpp
@@ -9,9 +9,7 @@
 #include <Windows.h>
 #include <SetupAPI.h>
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 // Code for enumerating hardware devices that use the XINPUT device driver.
 // The MSDN recommended code suffers from massive performance problems when using language packs,
@@ -76,5 +74,4 @@ std::unordered_set<DWORD> GetXInputGUIDS()
   SetupDiDestroyDeviceInfoList(setup_enum);
   return guids;
 }
-}  // namespace DInput
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.h
@@ -7,10 +7,7 @@
 #include <Windows.h>
 #include <unordered_set>
 
-namespace ciface
-{
-namespace DInput
+namespace ciface::DInput
 {
 std::unordered_set<DWORD> GetXInputGUIDS();
-}
-}  // namespace ciface
+}  // namespace ciface::DInput

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -14,9 +14,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 
-namespace ciface
-{
-namespace Core
+namespace ciface::Core
 {
 // Compared to an input's current state (ideally 1.0) minus abs(initial_state) (ideally 0.0).
 constexpr ControlState INPUT_DETECT_THRESHOLD = 0.55;
@@ -326,6 +324,4 @@ DeviceContainer::DetectInput(u32 wait_ms, const std::vector<std::string>& device
   // No input was detected. :'(
   return {};
 }
-
-}  // namespace Core
-}  // namespace ciface
+}  // namespace ciface::Core

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
@@ -9,9 +9,7 @@
 
 #include "Common/Thread.h"
 
-namespace ciface
-{
-namespace ForceFeedback
+namespace ciface::ForceFeedback
 {
 // Template instantiation:
 template class ForceFeedbackDevice::TypedForce<DICONSTANTFORCE>;
@@ -257,6 +255,4 @@ void ForceFeedbackDevice::Force::Release()
   m_effect->Unload();
   m_effect->Release();
 }
-
-}  // namespace ForceFeedback
-}  // namespace ciface
+}  // namespace ciface::ForceFeedback

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
@@ -19,9 +19,7 @@
 #include "InputCommon/ControllerInterface/ForceFeedback/OSX/DirectInputAdapter.h"
 #endif
 
-namespace ciface
-{
-namespace ForceFeedback
+namespace ciface::ForceFeedback
 {
 class ForceFeedbackDevice : public Core::Device
 {
@@ -83,6 +81,4 @@ private:
   Common::Event m_update_event;
   Common::Flag m_run_thread;
 };
-
-}  // namespace ForceFeedback
-}  // namespace ciface
+}  // namespace ciface::ForceFeedback

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/OSX/DirectInputAdapter.h
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/OSX/DirectInputAdapter.h
@@ -20,9 +20,7 @@ typedef LONG* LPLONG;  // Missing type for ForceFeedback.h
 #include "Common/CommonTypes.h"    // for LONG
 #include "DirectInputConstants.h"  // Not stricty necessary
 
-namespace ciface
-{
-namespace ForceFeedback
+namespace ciface::ForceFeedback
 {
 // Prototypes
 class IUnknownImpl;
@@ -196,5 +194,4 @@ public:
     return FFDeviceSetForceFeedbackProperty(m_device, property, &value);
   }
 };
-}  // namespace ForceFeedback
-}  // namespace ciface
+}  // namespace ciface::ForceFeedback

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSX.h
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSX.h
@@ -4,14 +4,11 @@
 
 #pragma once
 
-namespace ciface
-{
-namespace OSX
+namespace ciface::OSX
 {
 void Init(void* window);
 void PopulateDevices(void* window);
 void DeInit();
 
 void DeviceElementDebugPrint(const void*, void*);
-}  // namespace OSX
-}  // namespace ciface
+}  // namespace ciface::OSX

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
@@ -17,9 +17,7 @@
 #include "InputCommon/ControllerInterface/OSX/OSXJoystick.h"
 #include "InputCommon/ControllerInterface/OSX/RunLoopStopper.h"
 
-namespace ciface
-{
-namespace OSX
+namespace ciface::OSX
 {
 constexpr CFTimeInterval FOREVER = 1e20;
 static std::thread s_hotplug_thread;
@@ -227,5 +225,4 @@ void DeInit()
   IOHIDManagerClose(HIDManager, kIOHIDOptionsTypeNone);
   CFRelease(HIDManager);
 }
-}
-}
+}  // namespace ciface::OSX

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.h
@@ -11,9 +11,7 @@
 #include "InputCommon/ControllerInterface/Device.h"
 #include "InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h"
 
-namespace ciface
-{
-namespace OSX
+namespace ciface::OSX
 {
 class Joystick : public ForceFeedback::ForceFeedbackDevice
 {
@@ -90,5 +88,4 @@ private:
 
   ForceFeedback::FFDeviceAdapterReference m_ff_device;
 };
-}  // namespace OSX
-}  // namespace ciface
+}  // namespace ciface::OSX

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -13,9 +13,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
-namespace ciface
-{
-namespace OSX
+namespace ciface::OSX
 {
 void Joystick::AddElements(CFArrayRef elements, std::set<IOHIDElementCookie>& cookies)
 {
@@ -341,5 +339,4 @@ bool Joystick::IsSameDevice(const IOHIDDeviceRef other_device) const
 {
   return m_device == other_device;
 }
-}
-}
+}  // namespace ciface::OSX

--- a/Source/Core/InputCommon/ControllerInterface/OSX/RunLoopStopper.h
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/RunLoopStopper.h
@@ -6,9 +6,7 @@
 
 #include <Foundation/Foundation.h>
 
-namespace ciface
-{
-namespace OSX
+namespace ciface::OSX
 {
 class RunLoopStopper
 {
@@ -40,6 +38,4 @@ public:
     CFRunLoopRemoveSource(runloop, m_source, mode);
   }
 };
-
-}  // namespace OSX
-}  // namespace ciface
+}  // namespace ciface::OSX

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -20,9 +20,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/Pipes/Pipes.h"
 
-namespace ciface
-{
-namespace Pipes
+namespace ciface::Pipes
 {
 static const std::array<std::string, 12> s_button_tokens{
     {"A", "B", "X", "Y", "Z", "START", "L", "R", "D_UP", "D_DOWN", "D_LEFT", "D_RIGHT"}};
@@ -161,5 +159,4 @@ void PipeDevice::ParseCommand(const std::string& command)
     }
   }
 }
-}  // namespace Pipes
-}  // namespace ciface
+}  // namespace ciface::Pipes

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
@@ -8,9 +8,7 @@
 #include <string>
 #include <vector>
 
-namespace ciface
-{
-namespace Pipes
+namespace ciface::Pipes
 {
 // To create a piped controller input, create a named pipe in the
 // Pipes directory and write commands out to it. Commands are separated
@@ -58,5 +56,4 @@ private:
   std::map<std::string, PipeInput*> m_buttons;
   std::map<std::string, PipeInput*> m_axes;
 };
-}  // namespace Pipes
-}  // namespace ciface
+}  // namespace ciface::Pipes

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/Quartz.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/Quartz.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-namespace ciface
-{
-namespace Quartz
+namespace ciface::Quartz
 {
 void PopulateDevices(void* window);
 void DeInit();
-}  // namespace Quartz
-}  // namespace ciface
+}  // namespace ciface::Quartz

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/Quartz.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/Quartz.mm
@@ -6,9 +6,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h"
 
-namespace ciface
-{
-namespace Quartz
+namespace ciface::Quartz
 {
 void PopulateDevices(void* window)
 {
@@ -21,5 +19,4 @@ void PopulateDevices(void* window)
 void DeInit()
 {
 }
-}  // namespace Quartz
-}  // namespace ciface
+}  // namespace ciface::Quartz

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
@@ -8,9 +8,7 @@
 
 #include "InputCommon/ControllerInterface/Device.h"
 
-namespace ciface
-{
-namespace Quartz
+namespace ciface::Quartz
 {
 std::string KeycodeToName(const CGKeyCode keycode);
 
@@ -73,5 +71,4 @@ private:
 
   uint32_t m_windowid;
 };
-}  // namespace Quartz
-}  // namespace ciface
+}  // namespace ciface::Quartz

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -9,9 +9,7 @@
 #include <Carbon/Carbon.h>
 #include <Cocoa/Cocoa.h>
 
-namespace ciface
-{
-namespace Quartz
+namespace ciface::Quartz
 {
 std::string KeycodeToName(const CGKeyCode keycode)
 {
@@ -223,5 +221,4 @@ std::string KeyboardAndMouse::Button::GetName() const
     return "Right Click";
   return std::string("Click ") + char('0' + m_button);
 }
-}  // namespace Quartz
-}  // namespace ciface
+}  // namespace ciface::Quartz

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -19,9 +19,7 @@
 #pragma comment(lib, "SDL2.lib")
 #endif
 
-namespace ciface
-{
-namespace SDL
+namespace ciface::SDL
 {
 static std::string GetJoystickName(int index)
 {
@@ -491,5 +489,4 @@ ControlState Joystick::Hat::GetState() const
 {
   return (SDL_JoystickGetHat(m_js, m_index) & (1 << m_direction)) > 0;
 }
-}  // namespace SDL
-}  // namespace ciface
+}  // namespace ciface::SDL

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -16,9 +16,7 @@
 
 #include "InputCommon/ControllerInterface/Device.h"
 
-namespace ciface
-{
-namespace SDL
+namespace ciface::SDL
 {
 void Init();
 void DeInit();
@@ -158,5 +156,4 @@ private:
   SDL_Haptic* m_haptic;
 #endif
 };
-}  // namespace SDL
-}  // namespace ciface
+}  // namespace ciface::SDL

--- a/Source/Core/InputCommon/ControllerInterface/Win32/Win32.h
+++ b/Source/Core/InputCommon/ControllerInterface/Win32/Win32.h
@@ -4,12 +4,9 @@
 
 #pragma once
 
-namespace ciface
-{
-namespace Win32
+namespace ciface::Win32
 {
 void Init(void* hwnd);
 void PopulateDevices(void* hwnd);
 void DeInit();
-}  // namespace Win32
-}  // namespace ciface
+}  // namespace ciface::Win32

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -8,9 +8,7 @@
 #define XINPUT_GAMEPAD_GUIDE 0x0400
 #endif
 
-namespace ciface
-{
-namespace XInput
+namespace ciface::XInput
 {
 static const struct
 {
@@ -243,5 +241,4 @@ void Device::Motor::SetState(ControlState state)
   m_motor = (WORD)(state * m_range);
   m_parent->UpdateMotors();
 }
-}  // namespace XInput
-}  // namespace ciface
+}  // namespace ciface::XInput

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -18,9 +18,7 @@
 #error You are building this module against the wrong version of DirectX. You probably need to remove DXSDK_DIR from your include path and/or _WIN32_WINNT is wrong.
 #endif
 
-namespace ciface
-{
-namespace XInput
+namespace ciface::XInput
 {
 void Init();
 void PopulateDevices();
@@ -105,5 +103,4 @@ private:
   const BYTE m_subtype;
   const u8 m_index;
 };
-}  // namespace XInput
-}  // namespace ciface
+}  // namespace ciface::XInput

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -46,9 +46,7 @@
 // more responsive. This might be useful as a user-customizable option.
 #define MOUSE_AXIS_SMOOTHING 1.5f
 
-namespace ciface
-{
-namespace XInput2
+namespace ciface::XInput2
 {
 // This function will add zero or more KeyboardMouse objects to devices.
 void PopulateDevices(void* const hwnd)
@@ -369,5 +367,4 @@ ControlState KeyboardMouse::Axis::GetState() const
 {
   return std::max(0.0f, *m_axis / (m_positive ? MOUSE_AXIS_SENSITIVITY : -MOUSE_AXIS_SENSITIVITY));
 }
-}  // namespace XInput2
-}  // namespace ciface
+}  // namespace ciface::XInput2

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -14,9 +14,7 @@ extern "C" {
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-namespace ciface
-{
-namespace XInput2
+namespace ciface::XInput2
 {
 void PopulateDevices(void* const hwnd);
 
@@ -113,5 +111,4 @@ private:
   const int pointer_deviceid, keyboard_deviceid;
   std::string name;
 };
-}  // namespace XInput2
-}  // namespace ciface
+}  // namespace ciface::XInput2

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -23,9 +23,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/evdev/evdev.h"
 
-namespace ciface
-{
-namespace evdev
+namespace ciface::evdev
 {
 static std::thread s_hotplug_thread;
 static Common::Flag s_hotplug_thread_running;
@@ -499,5 +497,4 @@ evdevDevice::Effect::~Effect()
   m_effect.type = DISABLED_EFFECT_TYPE;
   UpdateEffect();
 }
-}  // namespace evdev
-}  // namespace ciface
+}  // namespace ciface::evdev

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -10,9 +10,7 @@
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-namespace ciface
-{
-namespace evdev
+namespace ciface::evdev
 {
 void Init();
 void PopulateDevices();
@@ -120,5 +118,4 @@ private:
   std::string m_name;
   bool m_interesting = false;
 };
-}  // namespace evdev
-}  // namespace ciface
+}  // namespace ciface::evdev

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -24,9 +24,7 @@
 
 #include "VideoCommon/VideoConfig.h"
 
-namespace Vulkan
-{
-namespace ShaderCompiler
+namespace Vulkan::ShaderCompiler
 {
 // Registers itself for cleanup via atexit
 bool InitializeGlslang();
@@ -375,6 +373,4 @@ std::optional<SPIRVCodeVector> CompileComputeShader(std::string_view source_code
 {
   return CompileShaderToSPV(EShLangCompute, "cs", source_code, COMPUTE_SHADER_HEADER);
 }
-
-}  // namespace ShaderCompiler
-}  // namespace Vulkan
+}  // namespace Vulkan::ShaderCompiler

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.h
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.h
@@ -11,9 +11,7 @@
 
 #include "Common/CommonTypes.h"
 
-namespace Vulkan
-{
-namespace ShaderCompiler
+namespace Vulkan::ShaderCompiler
 {
 // SPIR-V compiled code type
 using SPIRVCodeType = u32;
@@ -30,6 +28,4 @@ std::optional<SPIRVCodeVector> CompileFragmentShader(std::string_view source_cod
 
 // Compile a compute shader to SPIR-V.
 std::optional<SPIRVCodeVector> CompileComputeShader(std::string_view source_code);
-
-}  // namespace ShaderCompiler
-}  // namespace Vulkan
+}  // namespace Vulkan::ShaderCompiler


### PR DESCRIPTION
Now that we're capable of using C++17 language and library facilities, we can collapse quite a few nested namespaces together, tidying up code a little bit.