### PR TITLE
Automatically detach/reattach bluetooth driver in passthrough

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -555,11 +555,16 @@ bool BluetoothReal::OpenDevice(libusb_device* device)
 // Detaching always fails as a regular user on FreeBSD
 // https://lists.freebsd.org/pipermail/freebsd-usb/2016-March/014161.html
 #ifndef __FreeBSD__
-  const int result = libusb_detach_kernel_driver(m_handle, INTERFACE);
-  if (result < 0 && result != LIBUSB_ERROR_NOT_FOUND && result != LIBUSB_ERROR_NOT_SUPPORTED)
+  int result = libusb_set_auto_detach_kernel_driver(m_handle, 1);
+  if (result != 0)
   {
-    PanicAlertT("Failed to detach kernel driver for BT passthrough: %s", libusb_error_name(result));
-    return false;
+    result = libusb_detach_kernel_driver(m_handle, INTERFACE);
+    if (result < 0 && result != LIBUSB_ERROR_NOT_FOUND && result != LIBUSB_ERROR_NOT_SUPPORTED)
+    {
+      PanicAlertT("Failed to detach kernel driver for BT passthrough: %s",
+                  libusb_error_name(result));
+      return false;
+    }
   }
 #endif
   if (libusb_claim_interface(m_handle, INTERFACE) < 0)


### PR DESCRIPTION
When the bluetooth adapter device is opened/closed by dolphin, the
kernel driver is automatically detached/reattached.

This enables transparent sharing of the same bluetooth wiimotes and
bluetooth adapters between the hosts system and the emulated one using
the same.