### PR TITLE
General: Add missing header guards

### DIFF
--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.h
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <string>
 
 #include "Common/CommonTypes.h"

--- a/Source/Core/Common/VariantUtil.h
+++ b/Source/Core/Common/VariantUtil.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <variant>
 
 namespace detail

--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Win32.h
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Win32.h
@@ -31,6 +31,8 @@
 // the TAP-Win32 driver and contains definitions
 // common to both.
 //===============================================
+#pragma once
+
 #include <windows.h>
 #include <stdlib.h>
 #include <winioctl.h>

--- a/Source/Core/UICommon/CommandLineParse.h
+++ b/Source/Core/UICommon/CommandLineParse.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Adds header guards to our source files that are missing them. Prevents potential inclusion issues from occurring.