### PR TITLE
Android: Don't copy global INIs into game INIs

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -253,6 +253,8 @@ public final class NativeLibrary
     Rumble.checkRumble(padID, state);
   }
 
+  public static native void NewGameIniFile();
+
   public static native void LoadGameIniFile(String gameId);
 
   public static native void SaveGameIniFile(String gameId);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -103,7 +103,6 @@ public class Settings
     }
     else
     {
-      loadGenericGameSettings(gameId, view);
       loadCustomGameSettings(gameId, view);
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -97,31 +97,23 @@ public class Settings
   {
     sections = new Settings.SettingsSectionMap();
 
-    HashSet<String> filesToExclude = new HashSet<>();
-    if (!TextUtils.isEmpty(gameId))
+    if (TextUtils.isEmpty(gameId))
     {
-      // for per-game settings, don't load the WiiMoteNew.ini settings
-      filesToExclude.add(SettingsFile.FILE_NAME_WIIMOTE);
+      loadDolphinSettings(view);
     }
-
-    loadDolphinSettings(view, filesToExclude);
-
-    if (!TextUtils.isEmpty(gameId))
+    else
     {
       loadGenericGameSettings(gameId, view);
       loadCustomGameSettings(gameId, view);
     }
   }
 
-  private void loadDolphinSettings(SettingsActivityView view, HashSet<String> filesToExclude)
+  private void loadDolphinSettings(SettingsActivityView view)
   {
     for (Map.Entry<String, List<String>> entry : configFileSectionsMap.entrySet())
     {
       String fileName = entry.getKey();
-      if (filesToExclude == null || !filesToExclude.contains(fileName))
-      {
-        sections.putAll(SettingsFile.readFile(fileName, view));
-      }
+      sections.putAll(SettingsFile.readFile(fileName, view));
     }
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -184,4 +184,36 @@ public class Settings
       SettingsFile.saveCustomGameSettings(gameId, sections);
     }
   }
+
+  public void clearSettings()
+  {
+    sections.clear();
+  }
+
+  public boolean gameIniContainsJunk()
+  {
+    // Older versions of Android Dolphin would copy the entire contents of most of the global INIs
+    // into any game INI that got saved (with some of the sections renamed to match the game INI
+    // section names). The problems with this are twofold:
+    //
+    // 1. The user game INIs will contain entries that Dolphin doesn't support reading from
+    //    game INIs. This is annoying when editing game INIs manually but shouldn't really be
+    //    a problem for those who only use the GUI.
+    //
+    // 2. Global settings will stick around in user game INIs. For instance, if someone wants to
+    //    change the texture cache accuracy to safe for all games, they have to edit not only the
+    //    global settings but also every single game INI they have created, since the old value of
+    //    the texture cache accuracy setting has been copied into every user game INI.
+    //
+    // These problems are serious enough that we should detect and delete such INI files.
+    // Problem 1 is easy to detect, but due to the nature of problem 2, it's unfortunately not
+    // possible to know which lines were added intentionally by the user and which lines were added
+    // unintentionally, which is why we have to delete the whole file in order to fix everything.
+
+    if (TextUtils.isEmpty(gameId))
+      return false;
+
+    SettingSection interfaceSection = sections.get("Interface");
+    return interfaceSection != null && interfaceSection.getSetting("ThemeName") != null;
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -1,5 +1,6 @@
 package org.dolphinemu.dolphinemu.features.settings.ui;
 
+import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -181,6 +182,18 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   public void showExternalStorageNotMountedHint()
   {
     Toast.makeText(this, R.string.external_storage_not_mounted, Toast.LENGTH_SHORT)
+            .show();
+  }
+
+  @Override
+  public void showGameIniJunkDeletionQuestion()
+  {
+    new AlertDialog.Builder(this)
+            .setTitle(getString(R.string.game_ini_junk_title))
+            .setMessage(getString(R.string.game_ini_junk_question))
+            .setPositiveButton(R.string.yes, (dialogInterface, i) -> mPresenter.clearSettings())
+            .setNegativeButton(R.string.no, null)
+            .create()
             .show();
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -58,6 +58,11 @@ public final class SettingsActivityPresenter
       if (!TextUtils.isEmpty(gameId))
       {
         mSettings.loadSettings(gameId, mView);
+
+        if (mSettings.gameIniContainsJunk())
+        {
+          mView.showGameIniJunkDeletionQuestion();
+        }
       }
       else
       {
@@ -116,6 +121,12 @@ public final class SettingsActivityPresenter
   public Settings getSettings()
   {
     return mSettings;
+  }
+
+  public void clearSettings()
+  {
+    mSettings.clearSettings();
+    onSettingChanged();
   }
 
   public void onStop(boolean finishing)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -120,6 +120,11 @@ public interface SettingsActivityView
   void showExternalStorageNotMountedHint();
 
   /**
+   * Tell the user that there is junk in the game INI and ask if they want to delete the whole file.
+   */
+  void showGameIniJunkDeletionQuestion();
+
+  /**
    * Start the DirectoryInitialization and listen for the result.
    *
    * @param receiver the broadcast receiver for the DirectoryInitialization

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -452,7 +452,8 @@ public final class SettingsFile
           final HashMap<String, SettingSection> sections)
   {
     Set<String> sortedSections = new TreeSet<>(sections.keySet());
-    NativeLibrary.LoadGameIniFile(gameId);
+
+    NativeLibrary.NewGameIniFile();
     for (String sectionKey : sortedSections)
     {
       SettingSection section = sections.get(sectionKey);

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -274,6 +274,8 @@
     <string name="preferences_settings">Settings</string>
     <string name="preferences_game_settings">Game Settings</string>
     <string name="preferences_extensions">Extension Bindings</string>
+    <string name="game_ini_junk_title">Junk Data Found</string>
+    <string name="game_ini_junk_question">The settings file for this game contains junk data created by an old version of Dolphin. Would you like to fix this by deleting the settings file for this game? This cannot be undone.</string>
 
     <!-- Emulation Menu -->
     <string name="emulation_screenshot">Take Screenshot</string>

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -357,6 +357,12 @@ JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserSe
   return ToJString(env, value.c_str());
 }
 
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_NewGameIniFile(JNIEnv* env,
+                                                                                   jobject obj)
+{
+  s_ini = IniFile();
+}
+
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadGameIniFile(JNIEnv* env,
                                                                                     jobject obj,
                                                                                     jstring jGameID)


### PR DESCRIPTION
Android Dolphin currently copies the entire contents of most of the global INIs into any game INI that gets saved (with some of the sections renamed to match the game INI section names). The problems with this are twofold:

1. The user game INIs will contain entries that Dolphin doesn't support reading from game INIs. This is annoying when editing game INIs manually but shouldn't really be a problem for those who only use the GUI.

2. Global settings will stick around in user game INIs. For instance, if someone wants to change the texture cache accuracy to safe for all games, they have to edit not only the global settings but also every single game INI they have created, since the old value of the texture cache accuracy setting has been copied into every user game INI.

These problems are serious enough that we should detect and delete such INI files. Problem 1 is easy to detect, but due to the nature of problem 2, it's unfortunately not possible to know which lines were added intentionally by the user and which lines were added unintentionally, which is why we have to delete the whole file in order to fix everything.