### PR TITLE
VideoCommon/Statistics: Use std::array for projection values

### DIFF
--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -58,7 +58,7 @@ static void MultiplyVec3Mat34(const Vec3& vec, const float* mat, Vec3& result)
   result.z = mat[8] * vec.x + mat[9] * vec.y + mat[10] * vec.z + mat[11];
 }
 
-static void MultipleVec3Perspective(const Vec3& vec, const float* proj, Vec4& result)
+static void MultipleVec3Perspective(const Vec3& vec, const Projection::Raw& proj, Vec4& result)
 {
   result.x = proj[0] * vec.x + proj[1] * vec.z;
   result.y = proj[2] * vec.y + proj[3] * vec.z;
@@ -67,7 +67,7 @@ static void MultipleVec3Perspective(const Vec3& vec, const float* proj, Vec4& re
   result.w = -vec.z;
 }
 
-static void MultipleVec3Ortho(const Vec3& vec, const float* proj, Vec4& result)
+static void MultipleVec3Ortho(const Vec3& vec, const Projection::Raw& proj, Vec4& result)
 {
   result.x = proj[0] * vec.x + proj[1];
   result.y = proj[2] * vec.y + proj[3];

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -102,22 +102,22 @@ void Statistics::DisplayProj()
 
   ImGui::TextUnformatted("Projection #: X for Raw 6=0 (X for Raw 6!=0)");
   ImGui::NewLine();
-  ImGui::Text("Projection 0: %f (%f) Raw 0: %f", stats.gproj_0, stats.g2proj_0, stats.proj_0);
-  ImGui::Text("Projection 1: %f (%f)", stats.gproj_1, stats.g2proj_1);
-  ImGui::Text("Projection 2: %f (%f) Raw 1: %f", stats.gproj_2, stats.g2proj_2, stats.proj_1);
-  ImGui::Text("Projection 3: %f (%f)", stats.gproj_3, stats.g2proj_3);
-  ImGui::Text("Projection 4: %f (%f)", stats.gproj_4, stats.g2proj_4);
-  ImGui::Text("Projection 5: %f (%f) Raw 2: %f", stats.gproj_5, stats.g2proj_5, stats.proj_2);
-  ImGui::Text("Projection 6: %f (%f) Raw 3: %f", stats.gproj_6, stats.g2proj_6, stats.proj_3);
-  ImGui::Text("Projection 7: %f (%f)", stats.gproj_7, stats.g2proj_7);
-  ImGui::Text("Projection 8: %f (%f)", stats.gproj_8, stats.g2proj_8);
-  ImGui::Text("Projection 9: %f (%f)", stats.gproj_9, stats.g2proj_9);
-  ImGui::Text("Projection 10: %f (%f) Raw 4: %f", stats.gproj_10, stats.g2proj_10, stats.proj_4);
-  ImGui::Text("Projection 11: %f (%f) Raw 5: %f", stats.gproj_11, stats.g2proj_11, stats.proj_5);
-  ImGui::Text("Projection 12: %f (%f)", stats.gproj_12, stats.g2proj_12);
-  ImGui::Text("Projection 13: %f (%f)", stats.gproj_13, stats.g2proj_13);
-  ImGui::Text("Projection 14: %f (%f)", stats.gproj_14, stats.g2proj_14);
-  ImGui::Text("Projection 15: %f (%f)", stats.gproj_15, stats.g2proj_15);
+  ImGui::Text("Projection 0: %f (%f) Raw 0: %f", stats.gproj[0], stats.g2proj[0], stats.proj[0]);
+  ImGui::Text("Projection 1: %f (%f)", stats.gproj[1], stats.g2proj[1]);
+  ImGui::Text("Projection 2: %f (%f) Raw 1: %f", stats.gproj[2], stats.g2proj[2], stats.proj[1]);
+  ImGui::Text("Projection 3: %f (%f)", stats.gproj[3], stats.g2proj[3]);
+  ImGui::Text("Projection 4: %f (%f)", stats.gproj[4], stats.g2proj[4]);
+  ImGui::Text("Projection 5: %f (%f) Raw 2: %f", stats.gproj[5], stats.g2proj[5], stats.proj[2]);
+  ImGui::Text("Projection 6: %f (%f) Raw 3: %f", stats.gproj[6], stats.g2proj[6], stats.proj[3]);
+  ImGui::Text("Projection 7: %f (%f)", stats.gproj[7], stats.g2proj[7]);
+  ImGui::Text("Projection 8: %f (%f)", stats.gproj[8], stats.g2proj[8]);
+  ImGui::Text("Projection 9: %f (%f)", stats.gproj[9], stats.g2proj[9]);
+  ImGui::Text("Projection 10: %f (%f) Raw 4: %f", stats.gproj[10], stats.g2proj[10], stats.proj[4]);
+  ImGui::Text("Projection 11: %f (%f) Raw 5: %f", stats.gproj[11], stats.g2proj[11], stats.proj[5]);
+  ImGui::Text("Projection 12: %f (%f)", stats.gproj[12], stats.g2proj[12]);
+  ImGui::Text("Projection 13: %f (%f)", stats.gproj[13], stats.g2proj[13]);
+  ImGui::Text("Projection 14: %f (%f)", stats.gproj[14], stats.g2proj[14]);
+  ImGui::Text("Projection 15: %f (%f)", stats.gproj[15], stats.g2proj[15]);
 
   ImGui::End();
 }

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+
 struct Statistics
 {
   int numPixelShadersCreated;
@@ -17,14 +19,9 @@ struct Statistics
 
   int numVertexLoaders;
 
-  float proj_0, proj_1, proj_2, proj_3, proj_4, proj_5;
-  float gproj_0, gproj_1, gproj_2, gproj_3, gproj_4, gproj_5;
-  float gproj_6, gproj_7, gproj_8, gproj_9, gproj_10, gproj_11, gproj_12, gproj_13, gproj_14,
-      gproj_15;
-
-  float g2proj_0, g2proj_1, g2proj_2, g2proj_3, g2proj_4, g2proj_5;
-  float g2proj_6, g2proj_7, g2proj_8, g2proj_9, g2proj_10, g2proj_11, g2proj_12, g2proj_13,
-      g2proj_14, g2proj_15;
+  std::array<float, 6> proj;
+  std::array<float, 16> gproj;
+  std::array<float, 16> g2proj;
 
   struct ThisFrame
   {

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -76,8 +76,6 @@ extern Statistics stats;
 #define DECSTAT(a) (a)--;
 #define ADDSTAT(a, b) (a) += (b);
 #define SETSTAT(a, x) (a) = (int)(x);
-#define SETSTAT_UINT(a, x) (a) = (u32)(x);
-#define SETSTAT_FT(a, x) (a) = (float)(x);
 #else
 #define INCSTAT(a) ;
 #define ADDSTAT(a, b) ;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -384,15 +384,15 @@ void VertexManagerBase::Flush()
   // Track some stats used elsewhere by the anamorphic widescreen heuristic.
   if (!SConfig::GetInstance().bWii)
   {
-    float* rawProjection = xfmem.projection.rawProjection;
-    bool viewport_is_4_3 = AspectIs4_3(xfmem.viewport.wd, xfmem.viewport.ht);
-    if (AspectIs16_9(rawProjection[2], rawProjection[0]) && viewport_is_4_3)
+    const auto& raw_projection = xfmem.projection.rawProjection;
+    const bool viewport_is_4_3 = AspectIs4_3(xfmem.viewport.wd, xfmem.viewport.ht);
+    if (AspectIs16_9(raw_projection[2], raw_projection[0]) && viewport_is_4_3)
     {
       // Projection is 16:9 and viewport is 4:3, we are rendering an anamorphic
       // widescreen picture.
       m_flush_count_anamorphic++;
     }
-    else if (AspectIs4_3(rawProjection[2], rawProjection[0]) && viewport_is_4_3)
+    else if (AspectIs4_3(raw_projection[2], raw_projection[0]) && viewport_is_4_3)
     {
       // Projection and viewports are both 4:3, we are rendering a normal image.
       m_flush_count_4_3++;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -29,13 +29,17 @@
 alignas(16) static std::array<float, 16> g_fProjectionMatrix;
 
 // track changes
-static bool bTexMatricesChanged[2], bPosNormalMatrixChanged, bProjectionChanged, bViewportChanged;
-static bool bTexMtxInfoChanged, bLightingConfigChanged;
+static std::array<bool, 2> bTexMatricesChanged;
+static bool bPosNormalMatrixChanged;
+static bool bProjectionChanged;
+static bool bViewportChanged;
+static bool bTexMtxInfoChanged;
+static bool bLightingConfigChanged;
 static BitSet32 nMaterialsChanged;
-static int nTransformMatricesChanged[2];      // min,max
-static int nNormalMatricesChanged[2];         // min,max
-static int nPostTransformMatricesChanged[2];  // min,max
-static int nLightsChanged[2];                 // min,max
+static std::array<int, 2> nTransformMatricesChanged;      // min,max
+static std::array<int, 2> nNormalMatricesChanged;         // min,max
+static std::array<int, 2> nPostTransformMatricesChanged;  // min,max
+static std::array<int, 2> nLightsChanged;                 // min,max
 
 static Common::Matrix44 s_viewportCorrection;
 static Common::Matrix44 s_freelook_matrix;
@@ -95,17 +99,12 @@ static void ViewportCorrectionMatrix(Common::Matrix44& result)
 void VertexShaderManager::Init()
 {
   // Initialize state tracking variables
-  nTransformMatricesChanged[0] = -1;
-  nTransformMatricesChanged[1] = -1;
-  nNormalMatricesChanged[0] = -1;
-  nNormalMatricesChanged[1] = -1;
-  nPostTransformMatricesChanged[0] = -1;
-  nPostTransformMatricesChanged[1] = -1;
-  nLightsChanged[0] = -1;
-  nLightsChanged[1] = -1;
+  nTransformMatricesChanged.fill(-1);
+  nNormalMatricesChanged.fill(-1);
+  nPostTransformMatricesChanged.fill(-1);
+  nLightsChanged.fill(-1);
   nMaterialsChanged = BitSet32(0);
-  bTexMatricesChanged[0] = false;
-  bTexMatricesChanged[1] = false;
+  bTexMatricesChanged.fill(false);
   bPosNormalMatrixChanged = false;
   bProjectionChanged = true;
   bViewportChanged = false;
@@ -672,17 +671,17 @@ void VertexShaderManager::TransformToClipSpace(const float* data, float* out, u3
 
 void VertexShaderManager::DoState(PointerWrap& p)
 {
-  p.Do(g_fProjectionMatrix);
+  p.DoArray(g_fProjectionMatrix);
   p.Do(s_viewportCorrection);
   p.Do(s_freelook_matrix);
 
-  p.Do(nTransformMatricesChanged);
-  p.Do(nNormalMatricesChanged);
-  p.Do(nPostTransformMatricesChanged);
-  p.Do(nLightsChanged);
+  p.DoArray(nTransformMatricesChanged);
+  p.DoArray(nNormalMatricesChanged);
+  p.DoArray(nPostTransformMatricesChanged);
+  p.DoArray(nLightsChanged);
 
   p.Do(nMaterialsChanged);
-  p.Do(bTexMatricesChanged);
+  p.DoArray(bTexMatricesChanged);
   p.Do(bPosNormalMatrixChanged);
   p.Do(bProjectionChanged);
   p.Do(bViewportChanged);

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -349,12 +349,11 @@ void VertexShaderManager::SetConstants()
   {
     bProjectionChanged = false;
 
-    float* rawProjection = xfmem.projection.rawProjection;
+    const auto& rawProjection = xfmem.projection.rawProjection;
 
     switch (xfmem.projection.type)
     {
     case GX_PERSPECTIVE:
-
       g_fProjectionMatrix[0] = rawProjection[0] * g_ActiveConfig.fAspectRatioHackW;
       g_fProjectionMatrix[1] = 0.0f;
       g_fProjectionMatrix[2] = rawProjection[1] * g_ActiveConfig.fAspectRatioHackW;
@@ -376,26 +375,10 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[14] = -1.0f;
       g_fProjectionMatrix[15] = 0.0f;
 
-      SETSTAT_FT(stats.gproj_0, g_fProjectionMatrix[0]);
-      SETSTAT_FT(stats.gproj_1, g_fProjectionMatrix[1]);
-      SETSTAT_FT(stats.gproj_2, g_fProjectionMatrix[2]);
-      SETSTAT_FT(stats.gproj_3, g_fProjectionMatrix[3]);
-      SETSTAT_FT(stats.gproj_4, g_fProjectionMatrix[4]);
-      SETSTAT_FT(stats.gproj_5, g_fProjectionMatrix[5]);
-      SETSTAT_FT(stats.gproj_6, g_fProjectionMatrix[6]);
-      SETSTAT_FT(stats.gproj_7, g_fProjectionMatrix[7]);
-      SETSTAT_FT(stats.gproj_8, g_fProjectionMatrix[8]);
-      SETSTAT_FT(stats.gproj_9, g_fProjectionMatrix[9]);
-      SETSTAT_FT(stats.gproj_10, g_fProjectionMatrix[10]);
-      SETSTAT_FT(stats.gproj_11, g_fProjectionMatrix[11]);
-      SETSTAT_FT(stats.gproj_12, g_fProjectionMatrix[12]);
-      SETSTAT_FT(stats.gproj_13, g_fProjectionMatrix[13]);
-      SETSTAT_FT(stats.gproj_14, g_fProjectionMatrix[14]);
-      SETSTAT_FT(stats.gproj_15, g_fProjectionMatrix[15]);
+      stats.gproj = g_fProjectionMatrix;
       break;
 
     case GX_ORTHOGRAPHIC:
-
       g_fProjectionMatrix[0] = rawProjection[0];
       g_fProjectionMatrix[1] = 0.0f;
       g_fProjectionMatrix[2] = 0.0f;
@@ -417,28 +400,8 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[14] = 0.0f;
       g_fProjectionMatrix[15] = 1.0f;
 
-      SETSTAT_FT(stats.g2proj_0, g_fProjectionMatrix[0]);
-      SETSTAT_FT(stats.g2proj_1, g_fProjectionMatrix[1]);
-      SETSTAT_FT(stats.g2proj_2, g_fProjectionMatrix[2]);
-      SETSTAT_FT(stats.g2proj_3, g_fProjectionMatrix[3]);
-      SETSTAT_FT(stats.g2proj_4, g_fProjectionMatrix[4]);
-      SETSTAT_FT(stats.g2proj_5, g_fProjectionMatrix[5]);
-      SETSTAT_FT(stats.g2proj_6, g_fProjectionMatrix[6]);
-      SETSTAT_FT(stats.g2proj_7, g_fProjectionMatrix[7]);
-      SETSTAT_FT(stats.g2proj_8, g_fProjectionMatrix[8]);
-      SETSTAT_FT(stats.g2proj_9, g_fProjectionMatrix[9]);
-      SETSTAT_FT(stats.g2proj_10, g_fProjectionMatrix[10]);
-      SETSTAT_FT(stats.g2proj_11, g_fProjectionMatrix[11]);
-      SETSTAT_FT(stats.g2proj_12, g_fProjectionMatrix[12]);
-      SETSTAT_FT(stats.g2proj_13, g_fProjectionMatrix[13]);
-      SETSTAT_FT(stats.g2proj_14, g_fProjectionMatrix[14]);
-      SETSTAT_FT(stats.g2proj_15, g_fProjectionMatrix[15]);
-      SETSTAT_FT(stats.proj_0, rawProjection[0]);
-      SETSTAT_FT(stats.proj_1, rawProjection[1]);
-      SETSTAT_FT(stats.proj_2, rawProjection[2]);
-      SETSTAT_FT(stats.proj_3, rawProjection[3]);
-      SETSTAT_FT(stats.proj_4, rawProjection[4]);
-      SETSTAT_FT(stats.proj_5, rawProjection[5]);
+      stats.g2proj = g_fProjectionMatrix;
+      stats.proj = rawProjection;
       break;
 
     default:

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 #include "VideoCommon/CPMemory.h"
@@ -245,7 +247,9 @@ struct Viewport
 
 struct Projection
 {
-  float rawProjection[6];
+  using Raw = std::array<float, 6>;
+
+  Raw rawProjection;
   u32 type;  // only GX_PERSPECTIVE or GX_ORTHOGRAPHIC are allowed
 };
 


### PR DESCRIPTION
Allows us to greatly simplify how these values were being set from the vertex shader manager. Now it's as basic as assigning directly to the members as opposed to setting each member individually.