### PR TITLE
Core/IOS: Use fmt where applicable

### DIFF
--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -6,8 +6,10 @@
 
 #include <algorithm>
 #include <cstring>
+#include <string_view>
 
-#include "Common/Assert.h"
+#include <fmt/format.h>
+
 #include "Common/ChunkFile.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
@@ -45,16 +47,19 @@ void FS::DoState(PointerWrap& p)
   p.Do(m_dirty_cache);
 }
 
-static void LogResult(const std::string& command, ResultCode code)
+template <typename... Args>
+static void LogResult(ResultCode code, std::string_view format, Args&&... args)
 {
+  const std::string command = fmt::format(format, std::forward<Args>(args)...);
   GENERIC_LOG(LogTypes::IOS_FS, (code == ResultCode::Success ? LogTypes::LINFO : LogTypes::LERROR),
               "%s: result %d", command.c_str(), ConvertResult(code));
 }
 
-template <typename T>
-static void LogResult(const std::string& command, const Result<T>& result)
+template <typename T, typename... Args>
+static void LogResult(const Result<T>& result, std::string_view format, Args&&... args)
 {
-  LogResult(command, result.Succeeded() ? ResultCode::Success : result.Error());
+  const auto result_code = result.Succeeded() ? ResultCode::Success : result.Error();
+  LogResult(result_code, format, std::forward<Args>(args)...);
 }
 
 enum class FileLookupMode
@@ -108,7 +113,7 @@ IPCCommandResult FS::Open(const OpenRequest& request)
 
   auto backend_fd = m_ios.GetFS()->OpenFile(request.uid, request.gid, request.path,
                                             static_cast<Mode>(request.flags & 3));
-  LogResult(StringFromFormat("OpenFile(%s)", request.path.c_str()), backend_fd);
+  LogResult(backend_fd, "OpenFile({})", request.path);
   if (!backend_fd)
     return GetFSReply(ConvertResult(backend_fd.Error()), ticks);
 
@@ -132,7 +137,7 @@ IPCCommandResult FS::Close(u32 fd)
       ticks += SUPERBLOCK_WRITE_TICKS;
 
     const ResultCode result = m_ios.GetFS()->Close(m_fd_map[fd].fs_fd);
-    LogResult(StringFromFormat("Close(%s)", m_fd_map[fd].name.data()), result);
+    LogResult(result, "Close({})", m_fd_map[fd].name.data());
     m_fd_map.erase(fd);
     if (result != ResultCode::Success)
       return GetFSReply(ConvertResult(result));
@@ -227,9 +232,7 @@ IPCCommandResult FS::Read(const ReadWriteRequest& request)
 
   const Result<u32> result = m_ios.GetFS()->ReadBytesFromFile(
       handle.fs_fd, Memory::GetPointer(request.buffer), request.size);
-  LogResult(
-      StringFromFormat("Read(%s, 0x%08x, %u)", handle.name.data(), request.buffer, request.size),
-      result);
+  LogResult(result, "Read({}, 0x{:08x}, {})", handle.name.data(), request.buffer, request.size);
   if (!result)
     return GetFSReply(ConvertResult(result.Error()));
 
@@ -247,9 +250,7 @@ IPCCommandResult FS::Write(const ReadWriteRequest& request)
 
   const Result<u32> result = m_ios.GetFS()->WriteBytesToFile(
       handle.fs_fd, Memory::GetPointer(request.buffer), request.size);
-  LogResult(
-      StringFromFormat("Write(%s, 0x%08x, %u)", handle.name.data(), request.buffer, request.size),
-      result);
+  LogResult(result, "Write({}, 0x{:08x}, {})", handle.name.data(), request.buffer, request.size);
   if (!result)
     return GetFSReply(ConvertResult(result.Error()));
 
@@ -264,9 +265,7 @@ IPCCommandResult FS::Seek(const SeekRequest& request)
 
   const Result<u32> result =
       m_ios.GetFS()->SeekFile(handle.fs_fd, request.offset, IOS::HLE::FS::SeekMode(request.mode));
-  LogResult(
-      StringFromFormat("Seek(%s, 0x%08x, %u)", handle.name.data(), request.offset, request.mode),
-      result);
+  LogResult(result, "Seek({}, 0x{:08x}, {})", handle.name.data(), request.offset, request.mode);
   if (!result)
     return GetFSReply(ConvertResult(result.Error()));
   return GetFSReply(*result);
@@ -378,7 +377,7 @@ IPCCommandResult FS::GetStats(const Handle& handle, const IOCtlRequest& request)
     return GetFSReply(ConvertResult(ResultCode::Invalid));
 
   const Result<NandStats> stats = m_ios.GetFS()->GetNandStats();
-  LogResult("GetNandStats", stats);
+  LogResult(stats, "GetNandStats");
   if (!stats)
     return GetDefaultReply(ConvertResult(stats.Error()));
 
@@ -402,7 +401,7 @@ IPCCommandResult FS::CreateDirectory(const Handle& handle, const IOCtlRequest& r
 
   const ResultCode result = m_ios.GetFS()->CreateDirectory(handle.uid, handle.gid, params->path,
                                                            params->attribute, params->modes);
-  LogResult(StringFromFormat("CreateDirectory(%s)", params->path), result);
+  LogResult(result, "CreateDirectory({})", params->path);
   return GetReplyForSuperblockOperation(result);
 }
 
@@ -438,7 +437,7 @@ IPCCommandResult FS::ReadDirectory(const Handle& handle, const IOCtlVRequest& re
   const std::string directory = Memory::GetString(request.in_vectors[0].address, 64);
   const Result<std::vector<std::string>> list =
       m_ios.GetFS()->ReadDirectory(handle.uid, handle.gid, directory);
-  LogResult(StringFromFormat("ReadDirectory(%s)", directory.c_str()), list);
+  LogResult(list, "ReadDirectory({})", directory);
   if (!list)
     return GetFSReply(ConvertResult(list.Error()));
 
@@ -468,7 +467,7 @@ IPCCommandResult FS::SetAttribute(const Handle& handle, const IOCtlRequest& requ
 
   const ResultCode result = m_ios.GetFS()->SetMetadata(
       handle.uid, params->path, params->uid, params->gid, params->attribute, params->modes);
-  LogResult(StringFromFormat("SetMetadata(%s)", params->path), result);
+  LogResult(result, "SetMetadata({})", params->path);
   return GetReplyForSuperblockOperation(result);
 }
 
@@ -480,7 +479,7 @@ IPCCommandResult FS::GetAttribute(const Handle& handle, const IOCtlRequest& requ
   const std::string path = Memory::GetString(request.buffer_in, 64);
   const u64 ticks = EstimateFileLookupTicks(path, FileLookupMode::Split);
   const Result<Metadata> metadata = m_ios.GetFS()->GetMetadata(handle.uid, handle.gid, path);
-  LogResult(StringFromFormat("GetMetadata(%s)", path.c_str()), metadata);
+  LogResult(metadata, "GetMetadata({})", path);
   if (!metadata)
     return GetFSReply(ConvertResult(metadata.Error()), ticks);
 
@@ -503,7 +502,7 @@ IPCCommandResult FS::DeleteFile(const Handle& handle, const IOCtlRequest& reques
 
   const std::string path = Memory::GetString(request.buffer_in, 64);
   const ResultCode result = m_ios.GetFS()->Delete(handle.uid, handle.gid, path);
-  LogResult(StringFromFormat("Delete(%s)", path.c_str()), result);
+  LogResult(result, "Delete({})", path);
   return GetReplyForSuperblockOperation(result);
 }
 
@@ -515,7 +514,7 @@ IPCCommandResult FS::RenameFile(const Handle& handle, const IOCtlRequest& reques
   const std::string old_path = Memory::GetString(request.buffer_in, 64);
   const std::string new_path = Memory::GetString(request.buffer_in + 64, 64);
   const ResultCode result = m_ios.GetFS()->Rename(handle.uid, handle.gid, old_path, new_path);
-  LogResult(StringFromFormat("Rename(%s, %s)", old_path.c_str(), new_path.c_str()), result);
+  LogResult(result, "Rename({}, {})", old_path, new_path);
   return GetReplyForSuperblockOperation(result);
 }
 
@@ -527,7 +526,7 @@ IPCCommandResult FS::CreateFile(const Handle& handle, const IOCtlRequest& reques
 
   const ResultCode result = m_ios.GetFS()->CreateFile(handle.uid, handle.gid, params->path,
                                                       params->attribute, params->modes);
-  LogResult(StringFromFormat("CreateFile(%s)", params->path), result);
+  LogResult(result, "CreateFile({})", params->path);
   return GetReplyForSuperblockOperation(result);
 }
 
@@ -548,7 +547,7 @@ IPCCommandResult FS::GetFileStats(const Handle& handle, const IOCtlRequest& requ
     return GetFSReply(ConvertResult(ResultCode::Invalid));
 
   const Result<FileStatus> status = m_ios.GetFS()->GetFileStatus(handle.fs_fd);
-  LogResult(StringFromFormat("GetFileStatus(%s)", handle.name.data()), status);
+  LogResult(status, "GetFileStatus({})", handle.name.data());
   if (!status)
     return GetDefaultReply(ConvertResult(status.Error()));
 
@@ -569,7 +568,7 @@ IPCCommandResult FS::GetUsage(const Handle& handle, const IOCtlVRequest& request
 
   const std::string directory = Memory::GetString(request.in_vectors[0].address, 64);
   const Result<DirectoryStats> stats = m_ios.GetFS()->GetDirectoryStats(directory);
-  LogResult(StringFromFormat("GetDirectoryStats(%s)", directory.c_str()), stats);
+  LogResult(stats, "GetDirectoryStats({})", directory);
   if (!stats)
     return GetFSReply(ConvertResult(stats.Error()));
 

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
 #include <mbedtls/md.h>
 #include <mbedtls/rsa.h>
 #include <mbedtls/sha1.h>
@@ -24,7 +25,6 @@
 #include "Common/File.h"
 #include "Common/FileUtil.h"
 #include "Common/ScopeGuard.h"
-#include "Common/StringUtil.h"
 #include "Common/Swap.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/ES/Formats.h"
@@ -430,8 +430,8 @@ static CertECC MakeBlankEccCert(const std::string& issuer, const std::string& na
 
 CertECC IOSC::GetDeviceCertificate() const
 {
-  const std::string name = StringFromFormat("NG%08x", GetDeviceId());
-  auto cert = MakeBlankEccCert(StringFromFormat("Root-CA%08x-MS%08x", m_ca_id, m_ms_id), name,
+  const std::string name = fmt::format("NG{:08x}", GetDeviceId());
+  auto cert = MakeBlankEccCert(fmt::format("Root-CA{:08x}-MS{:08x}", m_ca_id, m_ms_id), name,
                                m_key_entries[HANDLE_CONSOLE_KEY].data.data(), m_console_key_id);
   cert.signature.sig = m_console_signature;
   return cert;
@@ -448,8 +448,8 @@ void IOSC::Sign(u8* sig_out, u8* ap_cert_out, u64 title_id, const u8* data, u32 
   // ap_priv[0] &= 1;
 
   const std::string signer =
-      StringFromFormat("Root-CA%08x-MS%08x-NG%08x", m_ca_id, m_ms_id, GetDeviceId());
-  const std::string name = StringFromFormat("AP%016" PRIx64, title_id);
+      fmt::format("Root-CA{:08x}-MS{:08x}-NG{:08x}", m_ca_id, m_ms_id, GetDeviceId());
+  const std::string name = fmt::format("AP{:016x}", title_id);
   CertECC cert = MakeBlankEccCert(signer, name, ap_priv.data(), 0);
   // Sign the AP cert.
   const size_t skip = offsetof(CertECC, signature.issuer);

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -18,6 +18,8 @@
 #include <poll.h>
 #endif
 
+#include <fmt/format.h>
+
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -697,9 +699,9 @@ IPCCommandResult NetIPTop::HandleGetHostByNameRequest(const IOCtlRequest& reques
 
   for (int i = 0; remoteHost->h_addr_list[i]; ++i)
   {
-    u32 ip = Common::swap32(*(u32*)(remoteHost->h_addr_list[i]));
-    std::string ip_s =
-        StringFromFormat("%i.%i.%i.%i", ip >> 24, (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
+    const u32 ip = Common::swap32(*(u32*)(remoteHost->h_addr_list[i]));
+    const std::string ip_s =
+        fmt::format("{}.{}.{}.{}", ip >> 24, (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
     DEBUG_LOG(IOS_NET, "addr%i:%s", i, ip_s.c_str());
   }
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -5,10 +5,11 @@
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
 
 #include <algorithm>
-#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <string>
+
+#include <fmt/format.h>
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
@@ -21,7 +22,6 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/HW/Wiimote.h"
-#include "Core/Host.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 #include "Core/SysConf.h"
@@ -1781,7 +1781,7 @@ void BluetoothEmu::DisplayDisconnectMessage(const int wiimote_number, const int 
   // mean
   // and display things like "Wii Remote %i disconnected due to inactivity!" etc.
   Core::DisplayMessage(
-      StringFromFormat("Wii Remote %i disconnected by emulated software", wiimote_number), 3000);
+      fmt::format("Wii Remote {} disconnected by emulated software", wiimote_number), 3000);
 }
 }  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Common.cpp
+++ b/Source/Core/Core/IOS/USB/Common.cpp
@@ -6,9 +6,10 @@
 
 #include <algorithm>
 
+#include <fmt/format.h>
+
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
-#include "Common/StringUtil.h"
 #include "Common/Swap.h"
 #include "Core/HW/Memmap.h"
 
@@ -89,6 +90,6 @@ void EndpointDescriptor::Swap()
 
 std::string Device::GetErrorName(const int error_code) const
 {
-  return StringFromFormat("unknown error %d", error_code);
+  return fmt::format("unknown error {}", error_code);
 }
 }  // namespace IOS::HLE::USB

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -8,13 +8,14 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
-#include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/WiiSave.h"
 #include "Core/IOS/ES/ES.h"
@@ -268,7 +269,7 @@ void CleanUpWiiFileSystemContents()
     const auto user_save = WiiSave::MakeNandStorage(configured_fs.get(), title_id);
 
     const std::string backup_path =
-        File::GetUserPath(D_BACKUP_IDX) + StringFromFormat("/%016" PRIx64 ".bin", title_id);
+        fmt::format("{}/{:016x}.bin", File::GetUserPath(D_BACKUP_IDX), title_id);
     const auto backup_save = WiiSave::MakeDataBinStorage(&ios->GetIOSC(), backup_path, "w+b");
 
     // Backup the existing save just in case it's still needed.

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -8,7 +8,6 @@
 #include <bitset>
 #include <cinttypes>
 #include <cstddef>
-#include <cstring>
 #include <map>
 #include <memory>
 #include <optional>
@@ -18,10 +17,10 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
 #include <pugixml.hpp>
 
 #include "Common/Assert.h"
-#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/HttpRequest.h"
@@ -43,7 +42,6 @@
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeFileBlobReader.h"
-#include "DiscIO/VolumeWii.h"
 #include "DiscIO/WiiWad.h"
 
 namespace WiiUtils
@@ -232,7 +230,7 @@ std::string SystemUpdater::GetDeviceId()
   u32 ios_device_id;
   if (m_ios.GetES()->GetDeviceId(&ios_device_id) < 0)
     return "";
-  return StringFromFormat("%" PRIu64, (u64(1) << 32) | ios_device_id);
+  return std::to_string((u64(1) << 32) | ios_device_id);
 }
 
 class OnlineSystemUpdater final : public SystemUpdater
@@ -531,10 +529,9 @@ UpdateResult OnlineSystemUpdater::InstallTitleFromNUS(const std::string& prefix_
 std::pair<IOS::ES::TMDReader, std::vector<u8>>
 OnlineSystemUpdater::DownloadTMD(const std::string& prefix_url, const TitleInfo& title)
 {
-  const std::string url =
-      (title.version == 0) ?
-          prefix_url + StringFromFormat("/%016" PRIx64 "/tmd", title.id) :
-          prefix_url + StringFromFormat("/%016" PRIx64 "/tmd.%u", title.id, title.version);
+  const std::string url = (title.version == 0) ?
+                              fmt::format("{}/{:016x}/tmd", prefix_url, title.id) :
+                              fmt::format("{}/{:016x}/tmd.{}", prefix_url, title.id, title.version);
   const Common::HttpRequest::Response response = m_http.Get(url);
   if (!response)
     return {};
@@ -559,7 +556,7 @@ OnlineSystemUpdater::DownloadTMD(const std::string& prefix_url, const TitleInfo&
 std::pair<std::vector<u8>, std::vector<u8>>
 OnlineSystemUpdater::DownloadTicket(const std::string& prefix_url, const TitleInfo& title)
 {
-  const std::string url = prefix_url + StringFromFormat("/%016" PRIx64 "/cetk", title.id);
+  const std::string url = fmt::format("{}/{:016x}/cetk", prefix_url, title.id);
   const Common::HttpRequest::Response response = m_http.Get(url);
   if (!response)
     return {};
@@ -576,7 +573,7 @@ OnlineSystemUpdater::DownloadTicket(const std::string& prefix_url, const TitleIn
 std::optional<std::vector<u8>> OnlineSystemUpdater::DownloadContent(const std::string& prefix_url,
                                                                     const TitleInfo& title, u32 cid)
 {
-  const std::string url = prefix_url + StringFromFormat("/%016" PRIx64 "/%08x", title.id, cid);
+  const std::string url = fmt::format("{}/{:016x}/{:08x}", prefix_url, title.id, cid);
   return m_http.Get(url);
 }
 


### PR DESCRIPTION
Continues the migration towards using fmt. This change tackles much of the IOS-specific code.