### PR TITLE
Common/HttpRequest: Use CURLOPT_ERRORBUFFER for error messages

### DIFF
--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -42,6 +42,7 @@ private:
   static inline std::once_flag s_curl_was_initialized;
   ProgressCallback m_callback;
   std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> m_curl{nullptr, curl_easy_cleanup};
+  std::string m_error_string;
 };
 
 HttpRequest::HttpRequest(std::chrono::milliseconds timeout_ms, ProgressCallback callback)
@@ -118,6 +119,10 @@ HttpRequest::Impl::Impl(std::chrono::milliseconds timeout_ms, ProgressCallback c
     curl_easy_setopt(m_curl.get(), CURLOPT_PROGRESSDATA, this);
     curl_easy_setopt(m_curl.get(), CURLOPT_PROGRESSFUNCTION, CurlProgressCallback);
   }
+
+  // Set up error buffer
+  m_error_string.resize(CURL_ERROR_SIZE);
+  curl_easy_setopt(m_curl.get(), CURLOPT_ERRORBUFFER, m_error_string.data());
 
   // libcurl may not have been built with async DNS support, so we disable
   // signal handlers to avoid a possible and likely crash if a resolve times out.
@@ -205,7 +210,7 @@ HttpRequest::Response HttpRequest::Impl::Fetch(const std::string& url, Method me
   const CURLcode res = curl_easy_perform(m_curl.get());
   if (res != CURLE_OK)
   {
-    ERROR_LOG(COMMON, "Failed to %s %s: %s", type, url.c_str(), curl_easy_strerror(res));
+    ERROR_LOG(COMMON, "Failed to %s %s: %s", type, url.c_str(), m_error_string.c_str());
     return {};
   }
 


### PR DESCRIPTION
Some errors will simply report ``Error`` using ``curl_easy_strerror``. This makes diagnosing the error unnecessarily difficult for us. We should now get meaningful error messages for *every* error.