### PR TITLE
Fixed various errors spotted with Application Verifier

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -639,7 +639,7 @@ static void Run(JNIEnv* env, const std::vector<std::string>& paths, bool first_o
 
   if (first_open)
   {
-    DolphinAnalytics::Instance()->ReportDolphinStart(GetAnalyticValue("DEVICE_TYPE"));
+    DolphinAnalytics::Instance().ReportDolphinStart(GetAnalyticValue("DEVICE_TYPE"));
   }
 
   WiimoteReal::InitAdapterClass();

--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -221,8 +221,8 @@ HttpRequest::Response HttpRequest::Impl::Fetch(const std::string& url, Method me
   curl_easy_getinfo(m_curl.get(), CURLINFO_RESPONSE_CODE, &response_code);
   if (response_code != 200)
   {
-    ERROR_LOG(COMMON, "Failed to %s %s: server replied with code %li and body\n\x1b[0m%s", type,
-              url.c_str(), response_code, buffer.data());
+    ERROR_LOG(COMMON, "Failed to %s %s: server replied with code %li and body\n\x1b[0m%.*s", type,
+              url.c_str(), response_code, static_cast<int>(buffer.size()), buffer.data());
     return {};
   }
 

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -53,14 +53,10 @@ DolphinAnalytics::DolphinAnalytics()
   MakeBaseBuilder();
 }
 
-std::shared_ptr<DolphinAnalytics> DolphinAnalytics::Instance()
+DolphinAnalytics& DolphinAnalytics::Instance()
 {
-  std::lock_guard lk{s_instance_mutex};
-  if (!s_instance)
-  {
-    s_instance.reset(new DolphinAnalytics());
-  }
-  return s_instance;
+  static DolphinAnalytics instance;
+  return instance;
 }
 
 void DolphinAnalytics::ReloadConfig()

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -36,7 +36,7 @@ class DolphinAnalytics
 {
 public:
   // Performs lazy-initialization of a singleton and returns the instance.
-  static std::shared_ptr<DolphinAnalytics> Instance();
+  static DolphinAnalytics& Instance();
 
 #if defined(ANDROID)
   // Get value from java.
@@ -124,9 +124,4 @@ private:
 
   std::mutex m_reporter_mutex;
   Common::AnalyticsReporter m_reporter;
-
-  // Shared pointer in order to allow for multithreaded use of the instance and
-  // avoid races at reinitialization time.
-  static inline std::mutex s_instance_mutex;
-  static inline std::shared_ptr<DolphinAnalytics> s_instance;
 };

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -745,7 +745,7 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
     HLE::Reload();
     PatchEngine::Reload();
     HiresTexture::Update();
-    DolphinAnalytics::Instance()->ReportGameStart();
+    DolphinAnalytics::Instance().ReportGameStart();
   }
 }
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -322,7 +322,7 @@ static void CpuThread(const std::optional<std::string>& savestate_path, bool del
     Common::SetCurrentThreadName("CPU-GPU thread");
 
   // This needs to be delayed until after the video backend is ready.
-  DolphinAnalytics::Instance()->ReportGameStart();
+  DolphinAnalytics::Instance().ReportGameStart();
 
   if (_CoreParameter.bFastmem)
     EMM::InstallExceptionHandler();  // Let's run under memory watch

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -520,7 +520,7 @@ bool Wiimote::ProcessReadDataRequest()
         m_read_request.address + m_read_request.size > CameraLogic::REPORT_DATA_OFFSET;
 
     if (is_reading_ext || is_reading_ir)
-      DolphinAnalytics::Instance()->ReportGameQuirk(GameQuirk::DIRECTLY_READS_WIIMOTE_INPUT);
+      DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::DIRECTLY_READS_WIIMOTE_INPUT);
 
     // Top byte of address is ignored on the bus, but it IS maintained in the read-reply.
     auto const bytes_read = m_i2c_bus.BusRead(

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -154,7 +154,7 @@ u32 InstructionCache::ReadInstruction(u32 addr)
   {
     INFO_LOG(POWERPC, "ICache read at %08x returned stale data: CACHED: %08x vs. RAM: %08x", addr,
              res, inmem);
-    DolphinAnalytics::Instance()->ReportGameQuirk(GameQuirk::ICACHE_MATTERS);
+    DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::ICACHE_MATTERS);
   }
   return res;
 }

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
   sigaction(SIGINT, &sa, nullptr);
   sigaction(SIGTERM, &sa, nullptr);
 
-  DolphinAnalytics::Instance()->ReportDolphinStart("nogui");
+  DolphinAnalytics::Instance().ReportDolphinStart("nogui");
 
   if (!BootManager::BootCore(std::move(boot), s_platform->GetWindowSystemInfo()))
   {

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -177,7 +177,7 @@ int main(int argc, char* argv[])
   int retval;
 
   {
-    DolphinAnalytics::Instance()->ReportDolphinStart("qt");
+    DolphinAnalytics::Instance().ReportDolphinStart("qt");
 
     MainWindow win{std::move(boot), static_cast<const char*>(options.get("movie"))};
     if (options.is_set("debugger"))
@@ -210,7 +210,7 @@ int main(int argc, char* argv[])
       SConfig::GetInstance().m_analytics_permission_asked = true;
       Settings::Instance().SetAnalyticsEnabled(answer == QMessageBox::Yes);
 
-      DolphinAnalytics::Instance()->ReloadConfig();
+      DolphinAnalytics::Instance().ReloadConfig();
     }
 #endif
 

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -300,7 +300,7 @@ void GeneralPane::OnSaveConfig()
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   Settings::Instance().SetAnalyticsEnabled(m_checkbox_enable_analytics->isChecked());
-  DolphinAnalytics::Instance()->ReloadConfig();
+  DolphinAnalytics::Instance().ReloadConfig();
 #endif
   settings.bCPUThread = m_checkbox_dualcore->isChecked();
   Config::SetBaseOrCurrent(Config::MAIN_CPU_THREAD, m_checkbox_dualcore->isChecked());
@@ -325,8 +325,8 @@ void GeneralPane::OnSaveConfig()
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
 void GeneralPane::GenerateNewIdentity()
 {
-  DolphinAnalytics::Instance()->GenerateNewIdentity();
-  DolphinAnalytics::Instance()->ReloadConfig();
+  DolphinAnalytics::Instance().GenerateNewIdentity();
+  DolphinAnalytics::Instance().ReloadConfig();
   ModalMessageBox message_box(this);
   message_box.setIcon(QMessageBox::Information);
   message_box.setWindowTitle(tr("Identity Generation"));

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1282,7 +1282,7 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
       perf_sample.speed_ratio = SystemTimers::GetEstimatedEmulationPerformance();
       perf_sample.num_prims = stats.thisFrame.numPrims + stats.thisFrame.numDLPrims;
       perf_sample.num_draw_calls = stats.thisFrame.numDrawCalls;
-      DolphinAnalytics::Instance()->ReportPerformanceInfo(std::move(perf_sample));
+      DolphinAnalytics::Instance().ReportPerformanceInfo(std::move(perf_sample));
 
       if (IsFrameDumping())
         DumpCurrentFrame(xfb_entry->texture.get(), xfb_rect, ticks);

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -400,21 +400,39 @@ int main(int argc, const char* argv[])
   {
     const std::string argument = argv[i];
     if (argument == "-d")
+    {
       disassemble = true;
+    }
     else if (argument == "-o")
-      output_name = argv[++i];
+    {
+      if (++i < argc)
+        output_name = argv[i];
+    }
     else if (argument == "-h")
-      output_header_name = argv[++i];
+    {
+      if (++i < argc)
+        output_header_name = argv[i];
+    }
     else if (argument == "-c")
+    {
       compare = true;
+    }
     else if (argument == "-s")
+    {
       outputSize = true;
+    }
     else if (argument == "-m")
+    {
       multiple = true;
+    }
     else if (argument == "-f")
+    {
       force = true;
+    }
     else if (argument == "-p")
+    {
       print_results = true;
+    }
     else if (argument == "-ps")
     {
       print_results = true;


### PR DESCRIPTION
First of all, I haven't found any notes about squashing commits in the Contribution Guidelines, so if I need to do so please let me know and I'll update this PR accordingly.

This PR consists of three separate bugfixes to crashes/defects I found while running Dolphin with Application Verifier on Windows. It also contains a code sanity change I consider optional, so in case of any doubts I'll just recall the last commit.

1. `DolphinAnalytics` has been made a true singleton now, unifying its `Instance()` method with the other singletons in the codebase. Previously, it used a mutex-protected `std::shared_ptr` allegedly to ensure proper behaviour in case of concurrent access. However, since C++11 static local variables are guaranteed to be initialized in a thread safe manner, as outlined here:
https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables
\
Additionally, not using static inline class fields here actually works around a known VS2017 compiler bug, where destructor for static inline class fields is invoked more than once - in the case of Dolphin, an already destroyed `std::shared_ptr` was destroyed again, which led to a possible crash on exit.
\
Reference to a VS2017 compiler bug, allegedly fixed in VS2019:
https://developercommunity.visualstudio.com/content/problem/300686/static-inline-class-variables-have-their-destructo.html

2. Fixed a possible infoleak/crash in `HttpRequest::Response HttpRequest::Impl::Fetch` if request fails. `ERROR_LOG` attempted to use the request body as if it was a null terminated string, but it's not - leading to a out-of-bounds read and possibly output such to a log file. I fixed it by specifying length as a format specifier, so there is no need for a temporary `std::string`.

3. Fixed a crash in `DSPTool` if `-h` or `-o` arguments were included without a following argument. As `argv[argc]` is guaranteed to be null, the code would try to assign such to an `std::string` - which is illegal.

4. ~Replaced `RtlGetVersion` with `GetVersionEx` again. Comments above this code hint this function has been removed after Win8, which is not true. I assume this change was made in the past before Dolphin was properly manifested for Windows 8.1 and Windows 10 - in which case `GetVersionEx` indeed "lied" to it. Since Dolphin is now properly manifested, there is no need for such workarounds anymore.
\
That said, if anybody thinks this change is not needed I can easily roll back this commit from the PR.~
EDIT: Following a discussion down below, this has been recalled from this PR, due to be further improved separately in the future (using a documented, non-deprecated way instead).