### PR TITLE
Fix CPU Clock Override checkbox not updating with GameINI

### DIFF
--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -136,6 +136,12 @@ void AdvancedPane::Update()
   const bool enable_cpu_clock_override_widgets = SConfig::GetInstance().m_OCEnable;
   const bool enable_custom_rtc_widgets = SConfig::GetInstance().bEnableCustomRTC && !running;
 
+  QFont bf = font();
+  bf.setBold(Config::GetActiveLayerForConfig(Config::MAIN_OVERCLOCK_ENABLE) !=
+             Config::LayerType::Base);
+  m_cpu_clock_override_checkbox->setFont(bf);
+  m_cpu_clock_override_checkbox->setChecked(enable_cpu_clock_override_widgets);
+
   m_cpu_clock_override_slider->setEnabled(enable_cpu_clock_override_widgets);
   m_cpu_clock_override_slider_label->setEnabled(enable_cpu_clock_override_widgets);
 


### PR DESCRIPTION
This tiny PR fixes and enhances the way "Enable Emulated CPU Clock Override" option works. Previously, it would not update according to GameINI game-specific overrides, creating an invalid state where clock override slider was unlocked and set, but the checkbox would not be marked. This PR corrects this **and** makes the checkbox description bold if GameINI overrides it - just like it's done with other overridable checkboxes in Graphics.

 # Reproduction steps

To observe broken behaviour, do the following:
1. Launch Dolphin.
2. Open Config menu, navigate to Advanced.
3. Ensure "Enable Emulated CPU Clock Overide" is **disabled**.
4. Open any game's Properties.
5. Edit game's User Config to include CPU clock overrides, eg.
```
[Core]
OverclockEnable = True
Overclock = 1.35
```
6. Launch the game.
7. Open Config menu again, navigate to Advanced.
8. Observe results.

## Observed behaviour
"Enable Emulated CPU Clock Override" is **disabled**, yet the slider is unlocked and set to 135%.

## Behaviour with fixes from this PR
"Enable Emulated CPU Clock Override" is **enabled** and bolded, like so:
![image](https://user-images.githubusercontent.com/7947461/59981801-2750f580-9609-11e9-91a0-e9166ac253e3.png)

On an unrelated note, I've noticed that the entire logic of bolding/unbolding Graphics options is located inside `QCheckBox` specializations for Graphics screen. Should this really be exclusive to Graphics? In this code I cannot spot anything specific to this screen, and other cases (like this one checkbox) could easily reuse this code. For now I made this fix checkbox-specific, but I think it would be very nice to have `GraphicsBool` (and others) generalized so **any** screen could benefit from those.

I'm open for feedback and if you think such generalization makes sense, I'd be willing to spend some time looking into it.