### PR TITLE
Updates to auto-updater on Windows

### DIFF
--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -95,6 +95,11 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info)
                                 AutoUpdateChecker::RestartMode::RESTART_AFTER_UPDATE);
 
     if (!later)
-      m_parent->close();
+    {
+      RunOnObject(m_parent, [this] {
+        m_parent->close();
+        return 0;
+      });
+    }
   }
 }

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -234,12 +234,16 @@ void AutoUpdateChecker::TriggerUpdate(const AutoUpdateChecker::NewVersionInforma
   INFO_LOG(COMMON, "Updater command line: %s", command_line.c_str());
 
 #ifdef _WIN32
-  STARTUPINFO sinfo = {sizeof(info)};
+  STARTUPINFO sinfo = {sizeof(sinfo)};
   sinfo.dwFlags = STARTF_FORCEOFFFEEDBACK;  // No hourglass cursor after starting the process.
   PROCESS_INFORMATION pinfo;
-  if (!CreateProcessW(UTF8ToUTF16(reloc_updater_path).c_str(),
-                      const_cast<wchar_t*>(UTF8ToUTF16(command_line).c_str()), nullptr, nullptr,
-                      FALSE, 0, nullptr, nullptr, &sinfo, &pinfo))
+  if (CreateProcessW(UTF8ToUTF16(reloc_updater_path).c_str(), UTF8ToUTF16(command_line).data(),
+                     nullptr, nullptr, FALSE, 0, nullptr, nullptr, &sinfo, &pinfo))
+  {
+    CloseHandle(pinfo.hThread);
+    CloseHandle(pinfo.hProcess);
+  }
+  else
   {
     ERROR_LOG(COMMON, "Could not start updater process: error=%d", GetLastError());
   }

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -16,6 +16,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/HttpRequest.h"
+#include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"
 #include "UpdaterCommon/UI.h"
 
@@ -498,7 +499,6 @@ void FatalError(const std::string& message)
 
   UI::SetVisible(true);
   UI::Error(message);
-  UI::Stop();
 }
 
 std::optional<Manifest> ParseManifest(const std::string& manifest)
@@ -686,6 +686,7 @@ bool RunUpdater(std::vector<std::string> args)
   UI::Init();
   UI::SetVisible(false);
 
+  Common::ScopeGuard ui_guard{[] { UI::Stop(); }};
   Options opts = std::move(*maybe_opts);
 
   if (opts.log_file)
@@ -776,8 +777,6 @@ bool RunUpdater(std::vector<std::string> args)
   {
     UI::LaunchApplication(opts.binary_to_restart.value());
   }
-
-  UI::Stop();
 
   return true;
 }

--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -251,8 +251,11 @@ void Sleep(int sleep)
 void WaitForPID(u32 pid)
 {
   HANDLE parent_handle = OpenProcess(SYNCHRONIZE, FALSE, static_cast<DWORD>(pid));
-  WaitForSingleObject(parent_handle, INFINITE);
-  CloseHandle(parent_handle);
+  if (parent_handle)
+  {
+    WaitForSingleObject(parent_handle, INFINITE);
+    CloseHandle(parent_handle);
+  }
 }
 
 void SetVisible(bool visible)


### PR DESCRIPTION
This PR brings several improvements to Updater, focusing mostly on Windows specific improvements (but not only those). Here's the list:

- **Generic**: Fixed an issue where `Updater::OnUpdateAvailable` invoked `m_parent->close()` from a wrong thread - debug builds threw an assertion error there.
- **Generic**: Removed manual `UI::Stop()` calls in favour of a scope guard. While this does not seem to matter much for Mac, changes to Windows specific logic made it extremely important that this function is called in all cases - so made this change to remove any risk that updater terminates without having called this function.
- **Windows**: Modified the flow of updater's UI thread and simplified synchronization between said thread and main thread. Now UI thread no longer spinlocks, instead relies on `GetMessage` to sleep when there is no new messages. Additionally, synchronization has been remade to account for this fact (no need to poll `request_stop`), with UI thread being properly joinable now - this has removed the need for a second synchronization flag. \
Thanks to this change, on my PC (with 8 logical cores) CPU usage of `Updater.exe` when idle has dropped from around 13-14% to nearly 0%.
- **Windows**: Spawning `Updater.exe` process kept process/thread handles opened in `Dolphin.exe` - while this doesn't matter much since this process is terminating shortly after spawning the updater, it's a good practice to close those handles when not using them. Also in a very unlikely case of `Updater.exe` terminating and `Dolphin.exe` still running (I don't know if this is actually possible) updater will no longer linger as a zombie process.
- **Windows**: Fixed a `STARTUPINFO sinfo = {sizeof(info)};` typo which could have had unknown consequences - worst case trashing the stack if `CreateProcess` behaviour changes in the future!
- **Windows**: Removed a `const_cast` in a call to `CreateProcess` - as of C++17, a non-const overload to `data()` exists which fits this use case perfectly.
- **Windows**: Replaced a `GetModuleFileName` call in WinUpdater with a custom `GetModuleName` function which doesn't impose a `MAX_PATH` limit. Also, the old call had a wrong size parameter passed, as size parameter in `GetModuleFileName` is supposed to be in characters, not in bytes.