### PR TITLE
Core: fix X11 includes and preprocessor nits

### DIFF
--- a/Source/Core/DolphinNoGUI/PlatformX11.cpp
+++ b/Source/Core/DolphinNoGUI/PlatformX11.cpp
@@ -18,6 +18,7 @@
 
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 #include <X11/keysym.h>
 #include "UICommon/X11Utils.h"
 #include "VideoCommon/RenderBase.h"

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -367,16 +367,15 @@ bool TriggerSTMPowerEvent()
   return true;
 }
 
-#if defined(HAVE_XRANDR) && HAVE_X11
-void EnableScreenSaver(Window win, bool enable)
-#else
+#if !defined(HAVE_XRANDR) || !HAVE_XRANDR
 void EnableScreenSaver(bool enable)
-#endif
+{
+#else
+void EnableScreenSaver(Window win, bool enable)
 {
   // Inhibit the screensaver. Depending on the operating system this may also
   // disable low-power states and/or screen dimming.
 
-#if defined(HAVE_X11) && HAVE_X11
   if (Config::Get(Config::MAIN_DISABLE_SCREENSAVER))
   {
     X11Utils::InhibitScreensaver(win, !enable);


### PR DESCRIPTION
This adds a missing Xlib include and fixes compilation to work when RandR support is not available.

With these changes and the one in #8220, Dolphin compiles successfully on Alpine! 🎉