### PR TITLE
TitleDatabase: Don't crash on unknown language

### DIFF
--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -73,6 +73,7 @@ TitleDatabase::TitleDatabase()
   AddLazyMap(DiscIO::Language::SimplifiedChinese, "zh_CN");
   AddLazyMap(DiscIO::Language::TraditionalChinese, "zh_TW");
   AddLazyMap(DiscIO::Language::Korean, "ko");
+  m_title_maps[DiscIO::Language::Unknown] = [] { return Map(); };
 
   // Titles that aren't part of the Wii TDB, but common enough to justify having entries for them.
 


### PR DESCRIPTION
This only happens if the GC or Wii language is set to an invalid value, but it's best to guard against it anyway.