### PR TITLE
Qt/ControllersWindow: Fix radio buttons not getting disabled

### DIFF
--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -71,6 +71,8 @@ ControllersWindow::ControllersWindow(QWidget* parent) : QDialog(parent)
   CreateMainLayout();
   LoadSettings();
   ConnectWidgets();
+
+  OnEmulationStateChanged(Core::GetState() != Core::State::Uninitialized);
 }
 
 void ControllersWindow::CreateGamecubeLayout()


### PR DESCRIPTION
Only happens if the controller window hasn't been opened before.