### PR TITLE
NetPlay: Remove 'reduce polling rate' option

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -102,7 +102,6 @@ const ConfigInfo<std::string> MAIN_PERF_MAP_DIR{{System::Main, "Core", "PerfMapD
 const ConfigInfo<bool> MAIN_CUSTOM_RTC_ENABLE{{System::Main, "Core", "EnableCustomRTC"}, false};
 // Default to seconds between 1.1.1970 and 1.1.2000
 const ConfigInfo<u32> MAIN_CUSTOM_RTC_VALUE{{System::Main, "Core", "CustomRTCValue"}, 946684800};
-const ConfigInfo<bool> MAIN_REDUCE_POLLING_RATE{{System::Main, "Core", "ReducePollingRate"}, false};
 const ConfigInfo<bool> MAIN_AUTO_DISC_CHANGE{{System::Main, "Core", "AutoDiscChange"}, false};
 
 // Main.Display

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -76,7 +76,6 @@ extern const ConfigInfo<std::string> MAIN_GPU_DETERMINISM_MODE;
 extern const ConfigInfo<std::string> MAIN_PERF_MAP_DIR;
 extern const ConfigInfo<bool> MAIN_CUSTOM_RTC_ENABLE;
 extern const ConfigInfo<u32> MAIN_CUSTOM_RTC_VALUE;
-extern const ConfigInfo<bool> MAIN_REDUCE_POLLING_RATE;
 extern const ConfigInfo<bool> MAIN_AUTO_DISC_CHANGE;
 
 // Main.DSP

--- a/Source/Core/Core/Config/NetplaySettings.cpp
+++ b/Source/Core/Core/Config/NetplaySettings.cpp
@@ -56,8 +56,6 @@ const ConfigInfo<bool> NETPLAY_LOAD_WII_SAVE{{System::Main, "NetPlay", "LoadWiiS
 const ConfigInfo<bool> NETPLAY_SYNC_SAVES{{System::Main, "NetPlay", "SyncSaves"}, true};
 const ConfigInfo<bool> NETPLAY_SYNC_CODES{{System::Main, "NetPlay", "SyncCodes"}, true};
 const ConfigInfo<bool> NETPLAY_RECORD_INPUTS{{System::Main, "NetPlay", "RecordInputs"}, false};
-const ConfigInfo<bool> NETPLAY_REDUCE_POLLING_RATE{{System::Main, "NetPlay", "ReducePollingRate"},
-                                                   false};
 const ConfigInfo<bool> NETPLAY_STRICT_SETTINGS_SYNC{{System::Main, "NetPlay", "StrictSettingsSync"},
                                                     false};
 const ConfigInfo<std::string> NETPLAY_NETWORK_MODE{{System::Main, "NetPlay", "NetworkMode"},

--- a/Source/Core/Core/Config/NetplaySettings.h
+++ b/Source/Core/Core/Config/NetplaySettings.h
@@ -47,7 +47,6 @@ extern const ConfigInfo<bool> NETPLAY_LOAD_WII_SAVE;
 extern const ConfigInfo<bool> NETPLAY_SYNC_SAVES;
 extern const ConfigInfo<bool> NETPLAY_SYNC_CODES;
 extern const ConfigInfo<bool> NETPLAY_RECORD_INPUTS;
-extern const ConfigInfo<bool> NETPLAY_REDUCE_POLLING_RATE;
 extern const ConfigInfo<bool> NETPLAY_STRICT_SETTINGS_SYNC;
 extern const ConfigInfo<std::string> NETPLAY_NETWORK_MODE;
 extern const ConfigInfo<bool> NETPLAY_SYNC_ALL_WII_SAVES;

--- a/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/MovieConfigLoader.cpp
@@ -33,7 +33,6 @@ static void LoadFromDTM(Config::Layer* config_layer, Movie::DTMHeader* dtm)
   config_layer->Set(Config::MAIN_CPU_CORE, static_cast<PowerPC::CPUCore>(dtm->CPUCore));
   config_layer->Set(Config::MAIN_SYNC_GPU, dtm->bSyncGPU);
   config_layer->Set(Config::MAIN_GFX_BACKEND, dtm->videoBackend.data());
-  config_layer->Set(Config::MAIN_REDUCE_POLLING_RATE, dtm->bReducePollingRate);
 
   config_layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, dtm->bProgressive);
   config_layer->Set(Config::SYSCONF_PAL60, dtm->bPAL60);
@@ -57,7 +56,6 @@ void SaveToDTM(Movie::DTMHeader* dtm)
   dtm->CPUCore = static_cast<u8>(Config::Get(Config::MAIN_CPU_CORE));
   dtm->bSyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
   const std::string video_backend = Config::Get(Config::MAIN_GFX_BACKEND);
-  dtm->bReducePollingRate = Config::Get(Config::MAIN_REDUCE_POLLING_RATE);
 
   dtm->bProgressive = Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN);
   dtm->bPAL60 = Config::Get(Config::SYSCONF_PAL60);

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -37,7 +37,6 @@ public:
     layer->Set(Config::MAIN_SLOT_B, static_cast<int>(m_settings.m_EXIDevice[1]));
     layer->Set(Config::MAIN_SERIAL_PORT_1, static_cast<int>(m_settings.m_EXIDevice[2]));
     layer->Set(Config::MAIN_WII_SD_CARD_WRITABLE, m_settings.m_WriteToMemcard);
-    layer->Set(Config::MAIN_REDUCE_POLLING_RATE, m_settings.m_ReducePollingRate);
     layer->Set(Config::MAIN_DSP_JIT, m_settings.m_DSPEnableJIT);
     layer->Set(Config::SYSCONF_PROGRESSIVE_SCAN, m_settings.m_ProgressiveScan);
     layer->Set(Config::SYSCONF_PAL60, m_settings.m_PAL60);

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -737,12 +737,7 @@ void Update(u64 ticks)
   {
     SerialInterface::UpdateDevices();
 
-    // If this setting is enabled, only poll twice per field instead of what the game wanted. It may
-    // be set during NetPlay or Movie playback.
-    if (Config::Get(Config::MAIN_REDUCE_POLLING_RATE))
-      s_half_line_of_next_si_poll += GetHalfLinesPerEvenField() / 2;
-    else
-      s_half_line_of_next_si_poll += 2 * SerialInterface::GetPollXLines();
+    s_half_line_of_next_si_poll += 2 * SerialInterface::GetPollXLines();
   }
   if (s_half_line_count == s_even_field_first_hl)
   {

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -107,7 +107,7 @@ struct DTMHeader
   bool bNetPlay;
   bool bPAL60;
   u8 language;
-  bool bReducePollingRate;
+  u8 reserved3;
   bool bFollowBranch;
   std::array<u8, 9> reserved;       // Padding for any new config options
   std::array<char, 40> discChange;  // Name of iso file to switch to, for two disc games.

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -640,7 +640,6 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_CopyWiiSave;
       packet >> m_net_settings.m_OCEnable;
       packet >> m_net_settings.m_OCFactor;
-      packet >> m_net_settings.m_ReducePollingRate;
 
       for (auto& device : m_net_settings.m_EXIDevice)
       {

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -33,7 +33,6 @@ struct NetSettings
   bool m_DSPEnableJIT;
   bool m_WriteToMemcard;
   bool m_CopyWiiSave;
-  bool m_ReducePollingRate;
   bool m_OCEnable;
   float m_OCFactor;
   std::array<ExpansionInterface::TEXIDevices, 3> m_EXIDevice;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1288,7 +1288,6 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_CopyWiiSave;
   spac << m_settings.m_OCEnable;
   spac << m_settings.m_OCFactor;
-  spac << m_settings.m_ReducePollingRate;
 
   for (auto& device : m_settings.m_EXIDevice)
     spac << device;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -124,13 +124,6 @@ void NetPlayDialog::CreateMainLayout()
 
   m_network_menu = m_menu_bar->addMenu(tr("Network"));
   m_network_menu->setToolTipsVisible(true);
-  m_reduce_polling_rate_action = m_network_menu->addAction(tr("Reduce Polling Rate"));
-  m_reduce_polling_rate_action->setToolTip(
-      tr("This will reduce bandwidth usage by polling GameCube controllers only twice per frame. "
-         "Does not affect Wii Remotes."));
-  m_reduce_polling_rate_action->setCheckable(true);
-
-  m_network_menu->addSeparator();
   m_fixed_delay_action = m_network_menu->addAction(tr("Fair Input Delay"));
   m_fixed_delay_action->setToolTip(
       tr("Each player sends their own inputs to the game, with equal buffer size for all players, "
@@ -359,7 +352,6 @@ void NetPlayDialog::ConnectWidgets()
   connect(m_sync_save_data_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_sync_codes_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_record_input_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
-  connect(m_reduce_polling_rate_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_strict_settings_sync_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_host_input_authority_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
   connect(m_sync_all_wii_saves_action, &QAction::toggled, this, &NetPlayDialog::SaveSettings);
@@ -452,7 +444,6 @@ void NetPlayDialog::OnStart()
   settings.m_CopyWiiSave = m_load_wii_action->isChecked();
   settings.m_OCEnable = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   settings.m_OCFactor = Config::Get(Config::MAIN_OVERCLOCK);
-  settings.m_ReducePollingRate = m_reduce_polling_rate_action->isChecked();
   settings.m_EXIDevice[0] =
       static_cast<ExpansionInterface::TEXIDevices>(Config::Get(Config::MAIN_SLOT_A));
   settings.m_EXIDevice[1] =
@@ -840,7 +831,6 @@ void NetPlayDialog::SetOptionsEnabled(bool enabled)
     m_sync_save_data_action->setEnabled(enabled);
     m_sync_codes_action->setEnabled(enabled);
     m_assign_ports_button->setEnabled(enabled);
-    m_reduce_polling_rate_action->setEnabled(enabled);
     m_strict_settings_sync_action->setEnabled(enabled);
     m_host_input_authority_action->setEnabled(enabled);
     m_sync_all_wii_saves_action->setEnabled(enabled && m_sync_save_data_action->isChecked());
@@ -1065,7 +1055,6 @@ void NetPlayDialog::LoadSettings()
   const bool sync_saves = Config::Get(Config::NETPLAY_SYNC_SAVES);
   const bool sync_codes = Config::Get(Config::NETPLAY_SYNC_CODES);
   const bool record_inputs = Config::Get(Config::NETPLAY_RECORD_INPUTS);
-  const bool reduce_polling_rate = Config::Get(Config::NETPLAY_REDUCE_POLLING_RATE);
   const bool strict_settings_sync = Config::Get(Config::NETPLAY_STRICT_SETTINGS_SYNC);
   const bool sync_all_wii_saves = Config::Get(Config::NETPLAY_SYNC_ALL_WII_SAVES);
   const bool golf_mode_overlay = Config::Get(Config::NETPLAY_GOLF_MODE_OVERLAY);
@@ -1076,7 +1065,6 @@ void NetPlayDialog::LoadSettings()
   m_sync_save_data_action->setChecked(sync_saves);
   m_sync_codes_action->setChecked(sync_codes);
   m_record_input_action->setChecked(record_inputs);
-  m_reduce_polling_rate_action->setChecked(reduce_polling_rate);
   m_strict_settings_sync_action->setChecked(strict_settings_sync);
   m_sync_all_wii_saves_action->setChecked(sync_all_wii_saves);
   m_golf_mode_overlay_action->setChecked(golf_mode_overlay);
@@ -1116,7 +1104,6 @@ void NetPlayDialog::SaveSettings()
   Config::SetBase(Config::NETPLAY_SYNC_SAVES, m_sync_save_data_action->isChecked());
   Config::SetBase(Config::NETPLAY_SYNC_CODES, m_sync_codes_action->isChecked());
   Config::SetBase(Config::NETPLAY_RECORD_INPUTS, m_record_input_action->isChecked());
-  Config::SetBase(Config::NETPLAY_REDUCE_POLLING_RATE, m_reduce_polling_rate_action->isChecked());
   Config::SetBase(Config::NETPLAY_STRICT_SETTINGS_SYNC, m_strict_settings_sync_action->isChecked());
   Config::SetBase(Config::NETPLAY_SYNC_ALL_WII_SAVES, m_sync_all_wii_saves_action->isChecked());
   Config::SetBase(Config::NETPLAY_GOLF_MODE_OVERLAY, m_golf_mode_overlay_action->isChecked());

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -133,7 +133,6 @@ private:
   QAction* m_sync_save_data_action;
   QAction* m_sync_codes_action;
   QAction* m_record_input_action;
-  QAction* m_reduce_polling_rate_action;
   QAction* m_strict_settings_sync_action;
   QAction* m_host_input_authority_action;
   QAction* m_sync_all_wii_saves_action;


### PR DESCRIPTION
With the SI poll line count fixed, pretty much all games are polling twice per frame anyways, making this option superfluous. Since it's a bit of a gross hack and makes DTMs incompatible with console, let's just bin it.

This is necessarily based on #8236, so don't merge this before that one.