### PR TITLE
DolphinQt: Don't update debug widgets when hidden

### DIFF
--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -9,9 +9,10 @@
 #include "Common/CommonTypes.h"
 
 class QAction;
+class QCloseEvent;
+class QShowEvent;
 class QTableWidget;
 class QToolBar;
-class QCloseEvent;
 
 class BreakpointWidget : public QDockWidget
 {
@@ -25,6 +26,7 @@ public:
                      bool do_break = true);
   void AddRangedMBP(u32 from, u32 to, bool do_read = true, bool do_write = true, bool do_log = true,
                     bool do_break = true);
+  void UpdateButtonsEnabled();
   void Update();
 
 signals:
@@ -33,6 +35,7 @@ signals:
 
 protected:
   void closeEvent(QCloseEvent*) override;
+  void showEvent(QShowEvent* event) override;
 
 private:
   void CreateWidgets();

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -92,6 +92,9 @@ void CodeViewWidget::FontBasedSizing()
 
 void CodeViewWidget::Update()
 {
+  if (!isVisible())
+    return;
+
   if (m_updating)
     return;
 
@@ -566,6 +569,11 @@ void CodeViewWidget::mousePressEvent(QMouseEvent* event)
   default:
     break;
   }
+}
+
+void CodeViewWidget::showEvent(QShowEvent* event)
+{
+  Update();
 }
 
 void CodeViewWidget::ToggleBreakpoint()

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -13,6 +13,7 @@
 class QKeyEvent;
 class QMouseEvent;
 class QResizeEvent;
+class QShowEvent;
 
 class CodeViewWidget : public QTableWidget
 {
@@ -56,6 +57,7 @@ private:
   void keyPressEvent(QKeyEvent* event) override;
   void mousePressEvent(QMouseEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;
+  void showEvent(QShowEvent* event) override;
 
   void OnContextMenu();
 

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -64,8 +64,6 @@ CodeWidget::CodeWidget(QWidget* parent) : QDockWidget(parent)
       settings.value(QStringLiteral("codewidget/codesplitter")).toByteArray());
   m_box_splitter->restoreState(
       settings.value(QStringLiteral("codewidget/boxsplitter")).toByteArray());
-
-  Update();
 }
 
 CodeWidget::~CodeWidget()
@@ -81,6 +79,11 @@ CodeWidget::~CodeWidget()
 void CodeWidget::closeEvent(QCloseEvent*)
 {
   Settings::Instance().SetCodeVisible(false);
+}
+
+void CodeWidget::showEvent(QShowEvent* event)
+{
+  Update();
 }
 
 void CodeWidget::CreateWidgets()
@@ -265,6 +268,9 @@ void CodeWidget::SetAddress(u32 address, CodeViewWidget::SetAddressUpdate update
 
 void CodeWidget::Update()
 {
+  if (!isVisible())
+    return;
+
   const Common::Symbol* symbol = g_symbolDB.GetSymbolFromAddr(m_code_view->GetAddress());
 
   UpdateCallstack();

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.h
@@ -12,6 +12,7 @@
 
 class QCloseEvent;
 class QLineEdit;
+class QShowEvent;
 class QSplitter;
 class QListWidget;
 class QTableWidget;
@@ -61,6 +62,7 @@ private:
   void OnSelectFunctionCalls();
 
   void closeEvent(QCloseEvent*) override;
+  void showEvent(QShowEvent* event) override;
 
   QLineEdit* m_search_address;
   QLineEdit* m_search_symbols;

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -57,8 +57,6 @@ JITWidget::JITWidget(QWidget* parent) : QDockWidget(parent)
 #else
   m_disassembler = GetNewDisassembler("UNK");
 #endif
-
-  Update();
 }
 
 JITWidget::~JITWidget()
@@ -126,6 +124,9 @@ void JITWidget::Compare(u32 address)
 
 void JITWidget::Update()
 {
+  if (!isVisible())
+    return;
+
   if (!m_address)
   {
     m_ppc_asm_widget->setHtml(QStringLiteral("<i>%1</i>").arg(tr("(ppc)")));
@@ -207,4 +208,9 @@ void JITWidget::Update()
 void JITWidget::closeEvent(QCloseEvent*)
 {
   Settings::Instance().SetJITVisible(false);
+}
+
+void JITWidget::showEvent(QShowEvent* event)
+{
+  Update();
 }

--- a/Source/Core/DolphinQt/Debugger/JITWidget.h
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.h
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 
 class QCloseEvent;
+class QShowEvent;
 class QSplitter;
 class QTextBrowser;
 class QTableWidget;
@@ -31,6 +32,7 @@ private:
   void ConnectWidgets();
 
   void closeEvent(QCloseEvent*) override;
+  void showEvent(QShowEvent* event) override;
 
   QTableWidget* m_table_widget;
   QTextBrowser* m_ppc_asm_widget;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -57,7 +57,6 @@ MemoryWidget::MemoryWidget(QWidget* parent) : QDockWidget(parent)
   LoadSettings();
 
   ConnectWidgets();
-  Update();
   OnAddressSpaceChanged();
   OnTypeChanged();
 }
@@ -258,8 +257,16 @@ void MemoryWidget::closeEvent(QCloseEvent*)
   Settings::Instance().SetMemoryVisible(false);
 }
 
+void MemoryWidget::showEvent(QShowEvent* event)
+{
+  Update();
+}
+
 void MemoryWidget::Update()
 {
+  if (!isVisible())
+    return;
+
   m_memory_view->Update();
   update();
 }

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -17,6 +17,7 @@ class QLabel;
 class QLineEdit;
 class QPushButton;
 class QRadioButton;
+class QShowEvent;
 class QSplitter;
 
 class MemoryWidget : public QDockWidget
@@ -61,6 +62,7 @@ private:
   void FindValue(bool next);
 
   void closeEvent(QCloseEvent*) override;
+  void showEvent(QShowEvent* event) override;
 
   MemoryViewWidget* m_memory_view;
   QSplitter* m_splitter;

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -38,14 +38,7 @@ RegisterWidget::RegisterWidget(QWidget* parent) : QDockWidget(parent)
   PopulateTable();
   ConnectWidgets();
 
-  connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, [this] {
-    if (Settings::Instance().IsDebugModeEnabled() && Core::GetState() == Core::State::Paused)
-    {
-      m_updating = true;
-      emit UpdateTable();
-      m_updating = false;
-    }
-  });
+  connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &RegisterWidget::Update);
 
   connect(&Settings::Instance(), &Settings::RegistersVisibilityChanged,
           [this](bool visible) { setHidden(!visible); });
@@ -66,6 +59,11 @@ RegisterWidget::~RegisterWidget()
 void RegisterWidget::closeEvent(QCloseEvent*)
 {
   Settings::Instance().SetRegistersVisible(false);
+}
+
+void RegisterWidget::showEvent(QShowEvent* event)
+{
+  Update();
 }
 
 void RegisterWidget::CreateWidgets()
@@ -374,4 +372,14 @@ void RegisterWidget::AddRegister(int row, int column, RegisterType type, std::st
   }
 
   connect(this, &RegisterWidget::UpdateTable, [value] { value->RefreshValue(); });
+}
+
+void RegisterWidget::Update()
+{
+  if (isVisible() && Core::GetState() == Core::State::Paused)
+  {
+    m_updating = true;
+    emit UpdateTable();
+    m_updating = false;
+  }
 }

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.h
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.h
@@ -13,6 +13,7 @@
 
 class QTableWidget;
 class QCloseEvent;
+class QShowEvent;
 
 class RegisterWidget : public QDockWidget
 {
@@ -30,6 +31,7 @@ signals:
 
 protected:
   void closeEvent(QCloseEvent*) override;
+  void showEvent(QShowEvent* event) override;
 
 private:
   void CreateWidgets();
@@ -41,6 +43,8 @@ private:
 
   void AddRegister(int row, int column, RegisterType type, std::string register_name,
                    std::function<u64()> get_reg, std::function<void(u64)> set_reg);
+
+  void Update();
 
   QTableWidget* m_table;
   bool m_updating = false;

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -43,12 +43,7 @@ WatchWidget::WatchWidget(QWidget* parent) : QDockWidget(parent)
   ConnectWidgets();
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, [this](Core::State state) {
-    if (!Settings::Instance().IsDebugModeEnabled())
-      return;
-
-    m_load->setEnabled(Core::IsRunning());
-    m_save->setEnabled(Core::IsRunning());
-
+    UpdateButtonsEnabled();
     if (state != Core::State::Starting)
       Update();
   });
@@ -61,8 +56,6 @@ WatchWidget::WatchWidget(QWidget* parent) : QDockWidget(parent)
 
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &WatchWidget::UpdateIcons);
   UpdateIcons();
-
-  Update();
 }
 
 WatchWidget::~WatchWidget()
@@ -117,8 +110,20 @@ void WatchWidget::UpdateIcons()
   m_save->setIcon(Resources::GetScaledThemeIcon("debugger_save"));
 }
 
+void WatchWidget::UpdateButtonsEnabled()
+{
+  if (!isVisible())
+    return;
+
+  m_load->setEnabled(Core::IsRunning());
+  m_save->setEnabled(Core::IsRunning());
+}
+
 void WatchWidget::Update()
 {
+  if (!isVisible())
+    return;
+
   m_updating = true;
 
   m_table->clear();
@@ -198,6 +203,12 @@ void WatchWidget::Update()
 void WatchWidget::closeEvent(QCloseEvent*)
 {
   Settings::Instance().SetWatchVisible(false);
+}
+
+void WatchWidget::showEvent(QShowEvent* event)
+{
+  UpdateButtonsEnabled();
+  Update();
 }
 
 void WatchWidget::OnLoad()

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.h
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.h
@@ -13,6 +13,7 @@ class QTableWidget;
 class QTableWidgetItem;
 class QToolBar;
 class QCloseEvent;
+class QShowEvent;
 
 class WatchWidget : public QDockWidget
 {
@@ -27,6 +28,7 @@ signals:
 
 protected:
   void closeEvent(QCloseEvent*) override;
+  void showEvent(QShowEvent* event) override;
 
 private:
   void CreateWidgets();
@@ -35,6 +37,7 @@ private:
   void OnLoad();
   void OnSave();
 
+  void UpdateButtonsEnabled();
   void Update();
 
   void ShowContextMenu();


### PR DESCRIPTION
Saves on CPU usage when pausing/unpausing with the debugger disabled. This is especially important when using frame advance rapidly.