### PR TITLE
Mark "WASAPI (Exclusive Mode)" as translatable

### DIFF
--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -54,7 +54,7 @@ struct BootParameters;
 #define BACKEND_PULSEAUDIO "Pulse"
 #define BACKEND_XAUDIO2 "XAudio2"
 #define BACKEND_OPENSLES "OpenSLES"
-#define BACKEND_WASAPI "WASAPI (Exclusive Mode)"
+#define BACKEND_WASAPI _trans("WASAPI (Exclusive Mode)")
 
 enum class GPUDeterminismMode
 {


### PR DESCRIPTION
While "WASAPI" doesn't need to be translated, "Exclusive Mode" does.