### PR TITLE
SI: Minor bugfixes

### DIFF
--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -37,15 +37,16 @@ SIDevices ISIDevice::GetDeviceType() const
   return m_device_type;
 }
 
-int ISIDevice::RunBuffer(u8* buffer, int length)
+int ISIDevice::RunBuffer(u8* buffer, int request_length)
 {
 #ifdef _DEBUG
-  DEBUG_LOG(SERIALINTERFACE, "Send Data Device(%i) - Length(%i)   ", m_device_number, length);
+  DEBUG_LOG(SERIALINTERFACE, "Send Data Device(%i) - Length(%i)   ", m_device_number,
+            request_length);
 
   std::string temp;
   int num = 0;
 
-  while (num < length)
+  while (num < request_length)
   {
     temp += StringFromFormat("0x%02x ", buffer[num]);
     num++;

--- a/Source/Core/Core/HW/SI/SI_Device.h
+++ b/Source/Core/Core/HW/SI/SI_Device.h
@@ -73,7 +73,7 @@ public:
   SIDevices GetDeviceType() const;
 
   // Run the SI Buffer
-  virtual int RunBuffer(u8* buffer, int length);
+  virtual int RunBuffer(u8* buffer, int request_length);
   virtual int TransferInterval();
 
   // Return true on new data

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -17,24 +17,19 @@ CSIDevice_DanceMat::CSIDevice_DanceMat(SIDevices device, int device_number)
 {
 }
 
-int CSIDevice_DanceMat::RunBuffer(u8* buffer, int length)
+int CSIDevice_DanceMat::RunBuffer(u8* buffer, int request_length)
 {
   // Read the command
   EBufferCommands command = static_cast<EBufferCommands>(buffer[0]);
-
   if (command == CMD_RESET)
   {
-    ISIDevice::RunBuffer(buffer, length);
+    ISIDevice::RunBuffer(buffer, request_length);
 
     u32 id = Common::swap32(SI_DANCEMAT);
     std::memcpy(buffer, &id, sizeof(id));
+    return sizeof(id);
   }
-  else
-  {
-    return CSIDevice_GCController::RunBuffer(buffer, length);
-  }
-
-  return length;
+  return CSIDevice_GCController::RunBuffer(buffer, request_length);
 }
 
 u32 CSIDevice_DanceMat::MapPadStatus(const GCPadStatus& pad_status)

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
@@ -16,7 +16,7 @@ class CSIDevice_DanceMat : public CSIDevice_GCController
 public:
   CSIDevice_DanceMat(SIDevices device, int device_number);
 
-  int RunBuffer(u8* buffer, int length) override;
+  int RunBuffer(u8* buffer, int request_length) override;
   u32 MapPadStatus(const GCPadStatus& pad_status) override;
   bool GetData(u32& hi, u32& low) override;
 };

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -290,7 +290,7 @@ CSIDevice_GBA::CSIDevice_GBA(SIDevices device, int device_number) : ISIDevice(de
 {
 }
 
-int CSIDevice_GBA::RunBuffer(u8* buffer, int length)
+int CSIDevice_GBA::RunBuffer(u8* buffer, int request_length)
 {
   switch (m_next_action)
   {

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.h
@@ -45,7 +45,7 @@ class CSIDevice_GBA : public ISIDevice
 public:
   CSIDevice_GBA(SIDevices device, int device_number);
 
-  int RunBuffer(u8* buffer, int length) override;
+  int RunBuffer(u8* buffer, int request_length) override;
   int TransferInterval() override;
   bool GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -49,7 +49,7 @@ GCPadStatus CSIDevice_GCAdapter::GetPadStatus()
   return pad_status;
 }
 
-int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int length)
+int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int request_length)
 {
   if (!Core::WantsDeterminism())
   {
@@ -66,7 +66,7 @@ int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int length)
       return 4;
     }
   }
-  return CSIDevice_GCController::RunBuffer(buffer, length);
+  return CSIDevice_GCController::RunBuffer(buffer, request_length);
 }
 
 bool CSIDevice_GCAdapter::GetData(u32& hi, u32& low)

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
@@ -16,7 +16,7 @@ public:
   CSIDevice_GCAdapter(SIDevices device, int device_number);
 
   GCPadStatus GetPadStatus() override;
-  int RunBuffer(u8* buffer, int length) override;
+  int RunBuffer(u8* buffer, int request_length) override;
 
   bool GetData(u32& hi, u32& low) override;
 

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -34,8 +34,6 @@ protected:
     u8 trigger_right;
     u8 unk_4;
     u8 unk_5;
-    u8 unk_6;
-    u8 unk_7;
   };
 
   enum EDirectCommands

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -84,7 +84,7 @@ public:
   CSIDevice_GCController(SIDevices device, int device_number);
 
   // Run the SI Buffer
-  int RunBuffer(u8* buffer, int length) override;
+  int RunBuffer(u8* buffer, int request_length) override;
 
   // Return true on new data
   bool GetData(u32& hi, u32& low) override;

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
@@ -20,10 +20,10 @@ CSIDevice_GCSteeringWheel::CSIDevice_GCSteeringWheel(SIDevices device, int devic
 {
 }
 
-int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int length)
+int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int request_length)
 {
   // For debug logging only
-  ISIDevice::RunBuffer(buffer, length);
+  ISIDevice::RunBuffer(buffer, request_length);
 
   // Read the command
   EBufferCommands command = static_cast<EBufferCommands>(buffer[0]);
@@ -36,14 +36,11 @@ int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int length)
   {
     u32 id = Common::swap32(SI_GC_STEERING);
     std::memcpy(buffer, &id, sizeof(id));
-    break;
+    return sizeof(id);
+  }
   }
 
-  default:
-    return CSIDevice_GCController::RunBuffer(buffer, length);
-  }
-
-  return length;
+  return CSIDevice_GCController::RunBuffer(buffer, request_length);
 }
 
 bool CSIDevice_GCSteeringWheel::GetData(u32& hi, u32& low)

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
@@ -13,7 +13,7 @@ class CSIDevice_GCSteeringWheel : public CSIDevice_GCController
 public:
   CSIDevice_GCSteeringWheel(SIDevices device, int device_number);
 
-  int RunBuffer(u8* buffer, int length) override;
+  int RunBuffer(u8* buffer, int request_length) override;
   bool GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;
 

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
@@ -21,10 +21,10 @@ CSIDevice_Keyboard::CSIDevice_Keyboard(SIDevices device, int device_number)
 {
 }
 
-int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
+int CSIDevice_Keyboard::RunBuffer(u8* buffer, int request_length)
 {
   // For debug logging only
-  ISIDevice::RunBuffer(buffer, length);
+  ISIDevice::RunBuffer(buffer, request_length);
 
   // Read the command
   EBufferCommands command = static_cast<EBufferCommands>(buffer[0]);
@@ -37,21 +37,21 @@ int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
   {
     u32 id = Common::swap32(SI_GC_KEYBOARD);
     std::memcpy(buffer, &id, sizeof(id));
-    break;
+    return sizeof(id);
   }
 
   case CMD_DIRECT:
   {
-    INFO_LOG(SERIALINTERFACE, "Keyboard - Direct (Length: %d)", length);
+    INFO_LOG(SERIALINTERFACE, "Keyboard - Direct (Request Length: %d)", request_length);
     u32 high, low;
     GetData(high, low);
-    for (int i = 0; i < (length - 1) / 2; i++)
+    for (int i = 0; i < 4; i++)
     {
       buffer[i + 0] = (high >> (24 - (i * 8))) & 0xff;
       buffer[i + 4] = (low >> (24 - (i * 8))) & 0xff;
     }
+    return sizeof(high) + sizeof(low);
   }
-  break;
 
   default:
   {
@@ -60,7 +60,7 @@ int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
   break;
   }
 
-  return length;
+  return 0;
 }
 
 KeyboardStatus CSIDevice_Keyboard::GetKeyboardStatus() const

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
@@ -18,7 +18,7 @@ public:
   CSIDevice_Keyboard(SIDevices device, int device_number);
 
   // Run the SI Buffer
-  int RunBuffer(u8* buffer, int length) override;
+  int RunBuffer(u8* buffer, int request_length) override;
 
   // Return true on new data
   bool GetData(u32& hi, u32& low) override;

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
@@ -14,11 +14,11 @@ CSIDevice_Null::CSIDevice_Null(SIDevices device, int device_number)
 {
 }
 
-int CSIDevice_Null::RunBuffer(u8* buffer, int length)
+int CSIDevice_Null::RunBuffer(u8* buffer, int request_length)
 {
   u32 reply = Common::swap32(SI_ERROR_NO_RESPONSE);
   std::memcpy(buffer, &reply, sizeof(reply));
-  return 4;
+  return sizeof(reply);
 }
 
 bool CSIDevice_Null::GetData(u32& hi, u32& low)

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.h
@@ -15,7 +15,7 @@ class CSIDevice_Null final : public ISIDevice
 public:
   CSIDevice_Null(SIDevices device, int device_number);
 
-  int RunBuffer(u8* buffer, int length) override;
+  int RunBuffer(u8* buffer, int request_length) override;
   bool GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;
 };

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -742,7 +742,7 @@ void Update(u64 ticks)
     if (Config::Get(Config::MAIN_REDUCE_POLLING_RATE))
       s_half_line_of_next_si_poll += GetHalfLinesPerEvenField() / 2;
     else
-      s_half_line_of_next_si_poll += SerialInterface::GetPollXLines();
+      s_half_line_of_next_si_poll += 2 * SerialInterface::GetPollXLines();
   }
   if (s_half_line_count == s_even_field_first_hl)
   {


### PR DESCRIPTION
- VI was using "lines" count from SI without converting to half lines.
- origin calibration structure for controllers is 10 bytes, not 12