### PR TITLE
VideoCommon/Statistics: Minor cleanup changes

### DIFF
--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -50,7 +50,7 @@ static void UpdateConstantBuffer(ID3D11Buffer* const buffer, const void* data, u
   memcpy(map.pData, data, data_size);
   D3D::context->Unmap(buffer, 0);
 
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 static ComPtr<ID3D11ShaderResourceView>
@@ -166,7 +166,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
 
   *out_offset = m_texel_buffer_offset / elem_size;
   std::memcpy(static_cast<u8*>(sr.pData) + m_texel_buffer_offset, data, data_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
   m_texel_buffer_offset += data_size;
 
   D3D::context->Unmap(m_texel_buffer.Get(), 0);
@@ -194,7 +194,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   std::memcpy(static_cast<u8*>(sr.pData) + m_texel_buffer_offset, data, data_size);
   std::memcpy(static_cast<u8*>(sr.pData) + m_texel_buffer_offset + palette_byte_offset,
               palette_data, palette_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, palette_byte_offset + palette_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   *out_offset = m_texel_buffer_offset / elem_size;
   *out_palette_offset = (m_texel_buffer_offset + palette_byte_offset) / palette_elem_size;
   m_texel_buffer_offset += palette_byte_offset + palette_size;
@@ -251,8 +251,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
 
   m_buffer_cursor = cursor + totalBufferSize;
 
-  ADDSTAT(stats.thisFrame.bytesVertexStreamed, vertexBufferSize);
-  ADDSTAT(stats.thisFrame.bytesIndexStreamed, indexBufferSize);
+  ADDSTAT(stats.this_frame.bytes_vertex_streamed, vertexBufferSize);
+  ADDSTAT(stats.this_frame.bytes_index_streamed, indexBufferSize);
 
   D3D::stateman->SetVertexBuffer(m_buffers[m_current_buffer].Get(), vertex_stride, 0);
   D3D::stateman->SetIndexBuffer(m_buffers[m_current_buffer].Get());

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -50,7 +50,7 @@ static void UpdateConstantBuffer(ID3D11Buffer* const buffer, const void* data, u
   memcpy(map.pData, data, data_size);
   D3D::context->Unmap(buffer, 0);
 
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 static ComPtr<ID3D11ShaderResourceView>
@@ -166,7 +166,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
 
   *out_offset = m_texel_buffer_offset / elem_size;
   std::memcpy(static_cast<u8*>(sr.pData) + m_texel_buffer_offset, data, data_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
   m_texel_buffer_offset += data_size;
 
   D3D::context->Unmap(m_texel_buffer.Get(), 0);
@@ -194,7 +194,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   std::memcpy(static_cast<u8*>(sr.pData) + m_texel_buffer_offset, data, data_size);
   std::memcpy(static_cast<u8*>(sr.pData) + m_texel_buffer_offset + palette_byte_offset,
               palette_data, palette_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   *out_offset = m_texel_buffer_offset / elem_size;
   *out_palette_offset = (m_texel_buffer_offset + palette_byte_offset) / palette_elem_size;
   m_texel_buffer_offset += palette_byte_offset + palette_size;
@@ -251,8 +251,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
 
   m_buffer_cursor = cursor + totalBufferSize;
 
-  ADDSTAT(stats.this_frame.bytes_vertex_streamed, vertexBufferSize);
-  ADDSTAT(stats.this_frame.bytes_index_streamed, indexBufferSize);
+  ADDSTAT(g_stats.this_frame.bytes_vertex_streamed, vertexBufferSize);
+  ADDSTAT(g_stats.this_frame.bytes_index_streamed, indexBufferSize);
 
   D3D::stateman->SetVertexBuffer(m_buffers[m_current_buffer].Get(), vertex_stride, 0);
   D3D::stateman->SetIndexBuffer(m_buffers[m_current_buffer].Get());

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -112,8 +112,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
   m_vertex_stream_buffer.CommitMemory(vertex_data_size);
   m_index_stream_buffer.CommitMemory(index_data_size);
 
-  ADDSTAT(stats.this_frame.bytes_vertex_streamed, static_cast<int>(vertex_data_size));
-  ADDSTAT(stats.this_frame.bytes_index_streamed, static_cast<int>(index_data_size));
+  ADDSTAT(g_stats.this_frame.bytes_vertex_streamed, static_cast<int>(vertex_data_size));
+  ADDSTAT(g_stats.this_frame.bytes_index_streamed, static_cast<int>(index_data_size));
 
   Renderer::GetInstance()->SetVertexBuffer(m_vertex_stream_buffer.GetGPUPointer(), vertex_stride,
                                            m_vertex_stream_buffer.GetSize());
@@ -137,7 +137,7 @@ void VertexManager::UpdateVertexShaderConstants()
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), &VertexShaderManager::constants,
               sizeof(VertexShaderConstants));
   m_uniform_stream_buffer.CommitMemory(sizeof(VertexShaderConstants));
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(VertexShaderConstants));
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, sizeof(VertexShaderConstants));
   VertexShaderManager::dirty = false;
 }
 
@@ -150,7 +150,7 @@ void VertexManager::UpdateGeometryShaderConstants()
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), &GeometryShaderManager::constants,
               sizeof(GeometryShaderConstants));
   m_uniform_stream_buffer.CommitMemory(sizeof(GeometryShaderConstants));
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(GeometryShaderConstants));
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, sizeof(GeometryShaderConstants));
   GeometryShaderManager::dirty = false;
 }
 
@@ -163,7 +163,7 @@ void VertexManager::UpdatePixelShaderConstants()
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), &PixelShaderManager::constants,
               sizeof(PixelShaderConstants));
   m_uniform_stream_buffer.CommitMemory(sizeof(PixelShaderConstants));
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(PixelShaderConstants));
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, sizeof(PixelShaderConstants));
   PixelShaderManager::dirty = false;
 }
 
@@ -227,7 +227,7 @@ void VertexManager::UploadAllConstants()
 
   // Finally, flush buffer memory after copying
   m_uniform_stream_buffer.CommitMemory(allocation_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, allocation_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, allocation_size);
 
   // Clear dirty flags
   VertexShaderManager::dirty = false;
@@ -250,7 +250,7 @@ void VertexManager::UploadUtilityUniforms(const void* data, u32 data_size)
   Renderer::GetInstance()->SetConstantBuffer(2, m_uniform_stream_buffer.GetCurrentGPUPointer());
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), data, data_size);
   m_uniform_stream_buffer.CommitMemory(data_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBufferFormat format,
@@ -275,7 +275,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   std::memcpy(m_texel_stream_buffer.GetCurrentHostPointer(), data, data_size);
   *out_offset = static_cast<u32>(m_texel_stream_buffer.GetCurrentOffset()) / elem_size;
   m_texel_stream_buffer.CommitMemory(data_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
   Renderer::GetInstance()->SetTextureDescriptor(0, m_texel_buffer_views[format].cpu_handle);
   return true;
 }
@@ -312,7 +312,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
       palette_elem_size;
 
   m_texel_stream_buffer.CommitMemory(palette_byte_offset + palette_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   Renderer::GetInstance()->SetTextureDescriptor(0, m_texel_buffer_views[format].cpu_handle);
   Renderer::GetInstance()->SetTextureDescriptor(1, m_texel_buffer_views[palette_format].cpu_handle);
   return true;

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -112,8 +112,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
   m_vertex_stream_buffer.CommitMemory(vertex_data_size);
   m_index_stream_buffer.CommitMemory(index_data_size);
 
-  ADDSTAT(stats.thisFrame.bytesVertexStreamed, static_cast<int>(vertex_data_size));
-  ADDSTAT(stats.thisFrame.bytesIndexStreamed, static_cast<int>(index_data_size));
+  ADDSTAT(stats.this_frame.bytes_vertex_streamed, static_cast<int>(vertex_data_size));
+  ADDSTAT(stats.this_frame.bytes_index_streamed, static_cast<int>(index_data_size));
 
   Renderer::GetInstance()->SetVertexBuffer(m_vertex_stream_buffer.GetGPUPointer(), vertex_stride,
                                            m_vertex_stream_buffer.GetSize());
@@ -137,7 +137,7 @@ void VertexManager::UpdateVertexShaderConstants()
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), &VertexShaderManager::constants,
               sizeof(VertexShaderConstants));
   m_uniform_stream_buffer.CommitMemory(sizeof(VertexShaderConstants));
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(VertexShaderConstants));
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(VertexShaderConstants));
   VertexShaderManager::dirty = false;
 }
 
@@ -150,7 +150,7 @@ void VertexManager::UpdateGeometryShaderConstants()
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), &GeometryShaderManager::constants,
               sizeof(GeometryShaderConstants));
   m_uniform_stream_buffer.CommitMemory(sizeof(GeometryShaderConstants));
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(GeometryShaderConstants));
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(GeometryShaderConstants));
   GeometryShaderManager::dirty = false;
 }
 
@@ -163,7 +163,7 @@ void VertexManager::UpdatePixelShaderConstants()
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), &PixelShaderManager::constants,
               sizeof(PixelShaderConstants));
   m_uniform_stream_buffer.CommitMemory(sizeof(PixelShaderConstants));
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(PixelShaderConstants));
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(PixelShaderConstants));
   PixelShaderManager::dirty = false;
 }
 
@@ -227,7 +227,7 @@ void VertexManager::UploadAllConstants()
 
   // Finally, flush buffer memory after copying
   m_uniform_stream_buffer.CommitMemory(allocation_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, allocation_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, allocation_size);
 
   // Clear dirty flags
   VertexShaderManager::dirty = false;
@@ -250,7 +250,7 @@ void VertexManager::UploadUtilityUniforms(const void* data, u32 data_size)
   Renderer::GetInstance()->SetConstantBuffer(2, m_uniform_stream_buffer.GetCurrentGPUPointer());
   std::memcpy(m_uniform_stream_buffer.GetCurrentHostPointer(), data, data_size);
   m_uniform_stream_buffer.CommitMemory(data_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBufferFormat format,
@@ -275,7 +275,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   std::memcpy(m_texel_stream_buffer.GetCurrentHostPointer(), data, data_size);
   *out_offset = static_cast<u32>(m_texel_stream_buffer.GetCurrentOffset()) / elem_size;
   m_texel_stream_buffer.CommitMemory(data_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
   Renderer::GetInstance()->SetTextureDescriptor(0, m_texel_buffer_views[format].cpu_handle);
   return true;
 }
@@ -312,7 +312,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
       palette_elem_size;
 
   m_texel_stream_buffer.CommitMemory(palette_byte_offset + palette_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, palette_byte_offset + palette_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   Renderer::GetInstance()->SetTextureDescriptor(0, m_texel_buffer_views[format].cpu_handle);
   Renderer::GetInstance()->SetTextureDescriptor(1, m_texel_buffer_views[palette_format].cpu_handle);
   return true;

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -158,7 +158,7 @@ void SHADER::Bind() const
 {
   if (CurrentProgram != glprogid)
   {
-    INCSTAT(stats.thisFrame.numShaderChanges);
+    INCSTAT(stats.this_frame.num_shader_changes);
     glUseProgram(glprogid);
     CurrentProgram = glprogid;
   }
@@ -248,7 +248,7 @@ void ProgramShaderCache::UploadConstants()
     VertexShaderManager::dirty = false;
     GeometryShaderManager::dirty = false;
 
-    ADDSTAT(stats.thisFrame.bytesUniformStreamed, s_ubo_buffer_size);
+    ADDSTAT(stats.this_frame.bytes_uniform_streamed, s_ubo_buffer_size);
   }
 }
 
@@ -264,7 +264,7 @@ void ProgramShaderCache::UploadConstants(const void* data, u32 data_size)
   for (u32 index = 1; index <= 3; index++)
     glBindBufferRange(GL_UNIFORM_BUFFER, index, s_buffer->m_buffer, buffer.second, data_size);
 
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 bool ProgramShaderCache::CompileComputeShader(SHADER& shader, const std::string& code)

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -158,7 +158,7 @@ void SHADER::Bind() const
 {
   if (CurrentProgram != glprogid)
   {
-    INCSTAT(stats.this_frame.num_shader_changes);
+    INCSTAT(g_stats.this_frame.num_shader_changes);
     glUseProgram(glprogid);
     CurrentProgram = glprogid;
   }
@@ -248,7 +248,7 @@ void ProgramShaderCache::UploadConstants()
     VertexShaderManager::dirty = false;
     GeometryShaderManager::dirty = false;
 
-    ADDSTAT(stats.this_frame.bytes_uniform_streamed, s_ubo_buffer_size);
+    ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, s_ubo_buffer_size);
   }
 }
 
@@ -264,7 +264,7 @@ void ProgramShaderCache::UploadConstants(const void* data, u32 data_size)
   for (u32 index = 1; index <= 3; index++)
     glBindBufferRange(GL_UNIFORM_BUFFER, index, s_buffer->m_buffer, buffer.second, data_size);
 
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 bool ProgramShaderCache::CompileComputeShader(SHADER& shader, const std::string& code)

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -105,7 +105,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   const u32 elem_size = GetTexelBufferElementSize(format);
   const auto dst = m_texel_buffer->Map(data_size, elem_size);
   std::memcpy(dst.first, data, data_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
   *out_offset = dst.second / elem_size;
   m_texel_buffer->Unmap(data_size);
 
@@ -130,7 +130,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   const u32 palette_byte_offset = Common::AlignUp(data_size, palette_elem_size);
   std::memcpy(dst.first, data, data_size);
   std::memcpy(dst.first + palette_byte_offset, palette_data, palette_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   *out_offset = dst.second / elem_size;
   *out_palette_offset = (dst.second + palette_byte_offset) / palette_elem_size;
   m_texel_buffer->Unmap(palette_byte_offset + palette_size);
@@ -181,8 +181,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
   m_vertex_buffer->Unmap(vertex_data_size);
   m_index_buffer->Unmap(index_data_size);
 
-  ADDSTAT(stats.this_frame.bytes_vertex_streamed, vertex_data_size);
-  ADDSTAT(stats.this_frame.bytes_index_streamed, index_data_size);
+  ADDSTAT(g_stats.this_frame.bytes_vertex_streamed, vertex_data_size);
+  ADDSTAT(g_stats.this_frame.bytes_index_streamed, index_data_size);
 }
 
 void VertexManager::UploadUniforms()

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -105,7 +105,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   const u32 elem_size = GetTexelBufferElementSize(format);
   const auto dst = m_texel_buffer->Map(data_size, elem_size);
   std::memcpy(dst.first, data, data_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
   *out_offset = dst.second / elem_size;
   m_texel_buffer->Unmap(data_size);
 
@@ -130,7 +130,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   const u32 palette_byte_offset = Common::AlignUp(data_size, palette_elem_size);
   std::memcpy(dst.first, data, data_size);
   std::memcpy(dst.first + palette_byte_offset, palette_data, palette_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, palette_byte_offset + palette_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   *out_offset = dst.second / elem_size;
   *out_palette_offset = (dst.second + palette_byte_offset) / palette_elem_size;
   m_texel_buffer->Unmap(palette_byte_offset + palette_size);
@@ -181,8 +181,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
   m_vertex_buffer->Unmap(vertex_data_size);
   m_index_buffer->Unmap(index_data_size);
 
-  ADDSTAT(stats.thisFrame.bytesVertexStreamed, vertex_data_size);
-  ADDSTAT(stats.thisFrame.bytesIndexStreamed, index_data_size);
+  ADDSTAT(stats.this_frame.bytes_vertex_streamed, vertex_data_size);
+  ADDSTAT(stats.this_frame.bytes_index_streamed, index_data_size);
 }
 
 void VertexManager::UploadUniforms()

--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -221,7 +221,7 @@ static void ClipTriangle(int* indices, int* numIndices)
       POLY_CLIP(CLIP_POS_Z_BIT, 0, 0, 0, 1);
       POLY_CLIP(CLIP_NEG_Z_BIT, 0, 0, 1, 1);
 
-      INCSTAT(stats.this_frame.num_triangles_clipped);
+      INCSTAT(g_stats.this_frame.num_triangles_clipped);
 
       // transform the poly in inlist into triangles
       indices[0] = inlist[0];
@@ -288,7 +288,7 @@ static void ClipLine(int* indices)
 
 void ProcessTriangle(OutputVertexData* v0, OutputVertexData* v1, OutputVertexData* v2)
 {
-  INCSTAT(stats.this_frame.num_triangles_in)
+  INCSTAT(g_stats.this_frame.num_triangles_in)
 
   bool backface;
 
@@ -410,7 +410,7 @@ bool CullTest(const OutputVertexData* v0, const OutputVertexData* v1, const Outp
 
   if (mask)
   {
-    INCSTAT(stats.this_frame.num_triangles_rejected)
+    INCSTAT(g_stats.this_frame.num_triangles_rejected)
     return false;
   }
 
@@ -430,13 +430,13 @@ bool CullTest(const OutputVertexData* v0, const OutputVertexData* v1, const Outp
 
   if ((bpmem.genMode.cullmode & 1) && !backface)  // cull frontfacing
   {
-    INCSTAT(stats.this_frame.num_triangles_culled)
+    INCSTAT(g_stats.this_frame.num_triangles_culled)
     return false;
   }
 
   if ((bpmem.genMode.cullmode & 2) && backface)  // cull backfacing
   {
-    INCSTAT(stats.this_frame.num_triangles_culled)
+    INCSTAT(g_stats.this_frame.num_triangles_culled)
     return false;
   }
 

--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -221,7 +221,7 @@ static void ClipTriangle(int* indices, int* numIndices)
       POLY_CLIP(CLIP_POS_Z_BIT, 0, 0, 0, 1);
       POLY_CLIP(CLIP_NEG_Z_BIT, 0, 0, 1, 1);
 
-      INCSTAT(stats.thisFrame.numTrianglesClipped);
+      INCSTAT(stats.this_frame.num_triangles_clipped);
 
       // transform the poly in inlist into triangles
       indices[0] = inlist[0];
@@ -288,7 +288,7 @@ static void ClipLine(int* indices)
 
 void ProcessTriangle(OutputVertexData* v0, OutputVertexData* v1, OutputVertexData* v2)
 {
-  INCSTAT(stats.thisFrame.numTrianglesIn)
+  INCSTAT(stats.this_frame.num_triangles_in)
 
   bool backface;
 
@@ -410,7 +410,7 @@ bool CullTest(const OutputVertexData* v0, const OutputVertexData* v1, const Outp
 
   if (mask)
   {
-    INCSTAT(stats.thisFrame.numTrianglesRejected)
+    INCSTAT(stats.this_frame.num_triangles_rejected)
     return false;
   }
 
@@ -430,13 +430,13 @@ bool CullTest(const OutputVertexData* v0, const OutputVertexData* v1, const Outp
 
   if ((bpmem.genMode.cullmode & 1) && !backface)  // cull frontfacing
   {
-    INCSTAT(stats.thisFrame.numTrianglesCulled)
+    INCSTAT(stats.this_frame.num_triangles_culled)
     return false;
   }
 
   if ((bpmem.genMode.cullmode & 2) && backface)  // cull backfacing
   {
-    INCSTAT(stats.thisFrame.numTrianglesCulled)
+    INCSTAT(stats.this_frame.num_triangles_culled)
     return false;
   }
 

--- a/Source/Core/VideoBackends/Software/DebugUtil.cpp
+++ b/Source/Core/VideoBackends/Software/DebugUtil.cpp
@@ -106,7 +106,7 @@ void DumpActiveTextures()
     {
       SaveTexture(StringFromFormat("%star%i_ind%i_map%i_mip%i.png",
                                    File::GetUserPath(D_DUMPTEXTURES_IDX).c_str(),
-                                   stats.thisFrame.numDrawnObjects, stageNum, texmap, mip),
+                                   stats.this_frame.num_drawn_objects, stageNum, texmap, mip),
                   texmap, mip);
     }
   }
@@ -124,7 +124,7 @@ void DumpActiveTextures()
     {
       SaveTexture(StringFromFormat("%star%i_stage%i_map%i_mip%i.png",
                                    File::GetUserPath(D_DUMPTEXTURES_IDX).c_str(),
-                                   stats.thisFrame.numDrawnObjects, stageNum, texmap, mip),
+                                   stats.this_frame.num_drawn_objects, stageNum, texmap, mip),
                   texmap, mip);
     }
   }
@@ -191,32 +191,38 @@ void CopyTempBuffer(s16 x, s16 y, int bufferBase, int subBuffer, const char* nam
 
 void OnObjectBegin()
 {
-  if (g_ActiveConfig.bDumpTextures && stats.thisFrame.numDrawnObjects >= g_ActiveConfig.drawStart &&
-      stats.thisFrame.numDrawnObjects < g_ActiveConfig.drawEnd)
+  if (g_ActiveConfig.bDumpTextures &&
+      stats.this_frame.num_drawn_objects >= g_ActiveConfig.drawStart &&
+      stats.this_frame.num_drawn_objects < g_ActiveConfig.drawEnd)
+  {
     DumpActiveTextures();
+  }
 }
 
 void OnObjectEnd()
 {
-  if (g_ActiveConfig.bDumpObjects && stats.thisFrame.numDrawnObjects >= g_ActiveConfig.drawStart &&
-      stats.thisFrame.numDrawnObjects < g_ActiveConfig.drawEnd)
+  if (g_ActiveConfig.bDumpObjects &&
+      stats.this_frame.num_drawn_objects >= g_ActiveConfig.drawStart &&
+      stats.this_frame.num_drawn_objects < g_ActiveConfig.drawEnd)
+  {
     DumpEfb(StringFromFormat("%sobject%i.png", File::GetUserPath(D_DUMPOBJECTS_IDX).c_str(),
-                             stats.thisFrame.numDrawnObjects));
+                             stats.this_frame.num_drawn_objects));
+  }
 
   for (int i = 0; i < NUM_OBJECT_BUFFERS; i++)
   {
     if (DrawnToBuffer[i])
     {
       DrawnToBuffer[i] = false;
-      std::string filename =
-          StringFromFormat("%sobject%i_%s(%i).png", File::GetUserPath(D_DUMPOBJECTS_IDX).c_str(),
-                           stats.thisFrame.numDrawnObjects, ObjectBufferName[i], i - BufferBase[i]);
+      std::string filename = StringFromFormat(
+          "%sobject%i_%s(%i).png", File::GetUserPath(D_DUMPOBJECTS_IDX).c_str(),
+          stats.this_frame.num_drawn_objects, ObjectBufferName[i], i - BufferBase[i]);
 
       TextureToPng((u8*)ObjectBuffer[i], EFB_WIDTH * 4, filename, EFB_WIDTH, EFB_HEIGHT, true);
       memset(ObjectBuffer[i], 0, EFB_WIDTH * EFB_HEIGHT * sizeof(u32));
     }
   }
 
-  stats.thisFrame.numDrawnObjects++;
+  stats.this_frame.num_drawn_objects++;
 }
 }  // namespace DebugUtil

--- a/Source/Core/VideoBackends/Software/DebugUtil.cpp
+++ b/Source/Core/VideoBackends/Software/DebugUtil.cpp
@@ -106,7 +106,7 @@ void DumpActiveTextures()
     {
       SaveTexture(StringFromFormat("%star%i_ind%i_map%i_mip%i.png",
                                    File::GetUserPath(D_DUMPTEXTURES_IDX).c_str(),
-                                   stats.this_frame.num_drawn_objects, stageNum, texmap, mip),
+                                   g_stats.this_frame.num_drawn_objects, stageNum, texmap, mip),
                   texmap, mip);
     }
   }
@@ -124,7 +124,7 @@ void DumpActiveTextures()
     {
       SaveTexture(StringFromFormat("%star%i_stage%i_map%i_mip%i.png",
                                    File::GetUserPath(D_DUMPTEXTURES_IDX).c_str(),
-                                   stats.this_frame.num_drawn_objects, stageNum, texmap, mip),
+                                   g_stats.this_frame.num_drawn_objects, stageNum, texmap, mip),
                   texmap, mip);
     }
   }
@@ -192,8 +192,8 @@ void CopyTempBuffer(s16 x, s16 y, int bufferBase, int subBuffer, const char* nam
 void OnObjectBegin()
 {
   if (g_ActiveConfig.bDumpTextures &&
-      stats.this_frame.num_drawn_objects >= g_ActiveConfig.drawStart &&
-      stats.this_frame.num_drawn_objects < g_ActiveConfig.drawEnd)
+      g_stats.this_frame.num_drawn_objects >= g_ActiveConfig.drawStart &&
+      g_stats.this_frame.num_drawn_objects < g_ActiveConfig.drawEnd)
   {
     DumpActiveTextures();
   }
@@ -202,11 +202,11 @@ void OnObjectBegin()
 void OnObjectEnd()
 {
   if (g_ActiveConfig.bDumpObjects &&
-      stats.this_frame.num_drawn_objects >= g_ActiveConfig.drawStart &&
-      stats.this_frame.num_drawn_objects < g_ActiveConfig.drawEnd)
+      g_stats.this_frame.num_drawn_objects >= g_ActiveConfig.drawStart &&
+      g_stats.this_frame.num_drawn_objects < g_ActiveConfig.drawEnd)
   {
     DumpEfb(StringFromFormat("%sobject%i.png", File::GetUserPath(D_DUMPOBJECTS_IDX).c_str(),
-                             stats.this_frame.num_drawn_objects));
+                             g_stats.this_frame.num_drawn_objects));
   }
 
   for (int i = 0; i < NUM_OBJECT_BUFFERS; i++)
@@ -216,13 +216,13 @@ void OnObjectEnd()
       DrawnToBuffer[i] = false;
       std::string filename = StringFromFormat(
           "%sobject%i_%s(%i).png", File::GetUserPath(D_DUMPOBJECTS_IDX).c_str(),
-          stats.this_frame.num_drawn_objects, ObjectBufferName[i], i - BufferBase[i]);
+          g_stats.this_frame.num_drawn_objects, ObjectBufferName[i], i - BufferBase[i]);
 
       TextureToPng((u8*)ObjectBuffer[i], EFB_WIDTH * 4, filename, EFB_WIDTH, EFB_HEIGHT, true);
       memset(ObjectBuffer[i], 0, EFB_WIDTH * EFB_HEIGHT * sizeof(u32));
     }
   }
 
-  stats.this_frame.num_drawn_objects++;
+  g_stats.this_frame.num_drawn_objects++;
 }
 }  // namespace DebugUtil

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -72,7 +72,7 @@ void SetTevReg(int reg, int comp, s16 color)
 
 static void Draw(s32 x, s32 y, s32 xi, s32 yi)
 {
-  INCSTAT(stats.thisFrame.rasterizedPixels);
+  INCSTAT(stats.this_frame.rasterized_pixels);
 
   float dx = vertexOffsetX + (float)(x - vertex0X);
   float dy = vertexOffsetY + (float)(y - vertex0Y);
@@ -267,7 +267,7 @@ static void BuildBlock(s32 blockX, s32 blockY)
 void DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1,
                            const OutputVertexData* v2)
 {
-  INCSTAT(stats.thisFrame.numTrianglesDrawn);
+  INCSTAT(stats.this_frame.num_triangles_drawn);
 
   // adapted from http://devmaster.net/posts/6145/advanced-rasterization
 

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -72,7 +72,7 @@ void SetTevReg(int reg, int comp, s16 color)
 
 static void Draw(s32 x, s32 y, s32 xi, s32 yi)
 {
-  INCSTAT(stats.this_frame.rasterized_pixels);
+  INCSTAT(g_stats.this_frame.rasterized_pixels);
 
   float dx = vertexOffsetX + (float)(x - vertex0X);
   float dy = vertexOffsetY + (float)(y - vertex0Y);
@@ -267,7 +267,7 @@ static void BuildBlock(s32 blockX, s32 blockY)
 void DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v1,
                            const OutputVertexData* v2)
 {
-  INCSTAT(stats.this_frame.num_triangles_drawn);
+  INCSTAT(g_stats.this_frame.num_triangles_drawn);
 
   // adapted from http://devmaster.net/posts/6145/advanced-rasterization
 

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -91,7 +91,7 @@ void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_
     // assemble and rasterize the primitive
     m_setup_unit.SetupVertex();
 
-    INCSTAT(stats.thisFrame.numVerticesLoaded)
+    INCSTAT(stats.this_frame.num_vertices_loaded)
   }
 
   DebugUtil::OnObjectEnd();

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -91,7 +91,7 @@ void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_
     // assemble and rasterize the primitive
     m_setup_unit.SetupVertex();
 
-    INCSTAT(stats.this_frame.num_vertices_loaded)
+    INCSTAT(g_stats.this_frame.num_vertices_loaded)
   }
 
   DebugUtil::OnObjectEnd();

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -568,7 +568,7 @@ void Tev::Draw()
   ASSERT(Position[0] >= 0 && Position[0] < EFB_WIDTH);
   ASSERT(Position[1] >= 0 && Position[1] < EFB_HEIGHT);
 
-  INCSTAT(stats.thisFrame.tevPixelsIn);
+  INCSTAT(stats.this_frame.tev_pixels_in);
 
   // initial color values
   for (int i = 0; i < 4; i++)
@@ -869,7 +869,7 @@ void Tev::Draw()
   }
 #endif
 
-  INCSTAT(stats.thisFrame.tevPixelsOut);
+  INCSTAT(stats.this_frame.tev_pixels_out);
   EfbInterface::IncPerfCounterQuadCount(PQ_BLEND_INPUT);
 
   EfbInterface::BlendTev(Position[0], Position[1], output);

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -568,7 +568,7 @@ void Tev::Draw()
   ASSERT(Position[0] >= 0 && Position[0] < EFB_WIDTH);
   ASSERT(Position[1] >= 0 && Position[1] < EFB_HEIGHT);
 
-  INCSTAT(stats.this_frame.tev_pixels_in);
+  INCSTAT(g_stats.this_frame.tev_pixels_in);
 
   // initial color values
   for (int i = 0; i < 4; i++)
@@ -869,7 +869,7 @@ void Tev::Draw()
   }
 #endif
 
-  INCSTAT(stats.this_frame.tev_pixels_out);
+  INCSTAT(g_stats.this_frame.tev_pixels_out);
   EfbInterface::IncPerfCounterQuadCount(PQ_BLEND_INPUT);
 
   EfbInterface::BlendTev(Position[0], Position[1], output);

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -181,8 +181,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
   m_vertex_stream_buffer->CommitMemory(vertex_data_size);
   m_index_stream_buffer->CommitMemory(index_data_size);
 
-  ADDSTAT(stats.thisFrame.bytesVertexStreamed, static_cast<int>(vertex_data_size));
-  ADDSTAT(stats.thisFrame.bytesIndexStreamed, static_cast<int>(index_data_size));
+  ADDSTAT(stats.this_frame.bytes_vertex_streamed, static_cast<int>(vertex_data_size));
+  ADDSTAT(stats.this_frame.bytes_index_streamed, static_cast<int>(index_data_size));
 
   StateTracker::GetInstance()->SetVertexBuffer(m_vertex_stream_buffer->GetBuffer(), 0);
   StateTracker::GetInstance()->SetIndexBuffer(m_index_stream_buffer->GetBuffer(), 0,
@@ -207,7 +207,7 @@ void VertexManager::UpdateVertexShaderConstants()
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), &VertexShaderManager::constants,
               sizeof(VertexShaderConstants));
   m_uniform_stream_buffer->CommitMemory(sizeof(VertexShaderConstants));
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(VertexShaderConstants));
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(VertexShaderConstants));
   VertexShaderManager::dirty = false;
 }
 
@@ -222,7 +222,7 @@ void VertexManager::UpdateGeometryShaderConstants()
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), &GeometryShaderManager::constants,
               sizeof(GeometryShaderConstants));
   m_uniform_stream_buffer->CommitMemory(sizeof(GeometryShaderConstants));
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(GeometryShaderConstants));
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(GeometryShaderConstants));
   GeometryShaderManager::dirty = false;
 }
 
@@ -237,7 +237,7 @@ void VertexManager::UpdatePixelShaderConstants()
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), &PixelShaderManager::constants,
               sizeof(PixelShaderConstants));
   m_uniform_stream_buffer->CommitMemory(sizeof(PixelShaderConstants));
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(PixelShaderConstants));
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(PixelShaderConstants));
   PixelShaderManager::dirty = false;
 }
 
@@ -302,7 +302,7 @@ void VertexManager::UploadAllConstants()
 
   // Finally, flush buffer memory after copying
   m_uniform_stream_buffer->CommitMemory(allocation_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, allocation_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, allocation_size);
 
   // Clear dirty flags
   VertexShaderManager::dirty = false;
@@ -324,7 +324,7 @@ void VertexManager::UploadUtilityUniforms(const void* data, u32 data_size)
       m_uniform_stream_buffer->GetBuffer(), m_uniform_stream_buffer->GetCurrentOffset(), data_size);
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), data, data_size);
   m_uniform_stream_buffer->CommitMemory(data_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBufferFormat format,
@@ -349,7 +349,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   std::memcpy(m_texel_stream_buffer->GetCurrentHostPointer(), data, data_size);
   *out_offset = static_cast<u32>(m_texel_stream_buffer->GetCurrentOffset()) / elem_size;
   m_texel_stream_buffer->CommitMemory(data_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, data_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
   StateTracker::GetInstance()->SetTexelBuffer(0, m_texel_buffer_views[format]);
   return true;
 }
@@ -386,7 +386,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
       palette_elem_size;
 
   m_texel_stream_buffer->CommitMemory(palette_byte_offset + palette_size);
-  ADDSTAT(stats.thisFrame.bytesUniformStreamed, palette_byte_offset + palette_size);
+  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   StateTracker::GetInstance()->SetTexelBuffer(0, m_texel_buffer_views[format]);
   StateTracker::GetInstance()->SetTexelBuffer(1, m_texel_buffer_views[palette_format]);
   return true;

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -181,8 +181,8 @@ void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_in
   m_vertex_stream_buffer->CommitMemory(vertex_data_size);
   m_index_stream_buffer->CommitMemory(index_data_size);
 
-  ADDSTAT(stats.this_frame.bytes_vertex_streamed, static_cast<int>(vertex_data_size));
-  ADDSTAT(stats.this_frame.bytes_index_streamed, static_cast<int>(index_data_size));
+  ADDSTAT(g_stats.this_frame.bytes_vertex_streamed, static_cast<int>(vertex_data_size));
+  ADDSTAT(g_stats.this_frame.bytes_index_streamed, static_cast<int>(index_data_size));
 
   StateTracker::GetInstance()->SetVertexBuffer(m_vertex_stream_buffer->GetBuffer(), 0);
   StateTracker::GetInstance()->SetIndexBuffer(m_index_stream_buffer->GetBuffer(), 0,
@@ -207,7 +207,7 @@ void VertexManager::UpdateVertexShaderConstants()
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), &VertexShaderManager::constants,
               sizeof(VertexShaderConstants));
   m_uniform_stream_buffer->CommitMemory(sizeof(VertexShaderConstants));
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(VertexShaderConstants));
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, sizeof(VertexShaderConstants));
   VertexShaderManager::dirty = false;
 }
 
@@ -222,7 +222,7 @@ void VertexManager::UpdateGeometryShaderConstants()
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), &GeometryShaderManager::constants,
               sizeof(GeometryShaderConstants));
   m_uniform_stream_buffer->CommitMemory(sizeof(GeometryShaderConstants));
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(GeometryShaderConstants));
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, sizeof(GeometryShaderConstants));
   GeometryShaderManager::dirty = false;
 }
 
@@ -237,7 +237,7 @@ void VertexManager::UpdatePixelShaderConstants()
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), &PixelShaderManager::constants,
               sizeof(PixelShaderConstants));
   m_uniform_stream_buffer->CommitMemory(sizeof(PixelShaderConstants));
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, sizeof(PixelShaderConstants));
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, sizeof(PixelShaderConstants));
   PixelShaderManager::dirty = false;
 }
 
@@ -302,7 +302,7 @@ void VertexManager::UploadAllConstants()
 
   // Finally, flush buffer memory after copying
   m_uniform_stream_buffer->CommitMemory(allocation_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, allocation_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, allocation_size);
 
   // Clear dirty flags
   VertexShaderManager::dirty = false;
@@ -324,7 +324,7 @@ void VertexManager::UploadUtilityUniforms(const void* data, u32 data_size)
       m_uniform_stream_buffer->GetBuffer(), m_uniform_stream_buffer->GetCurrentOffset(), data_size);
   std::memcpy(m_uniform_stream_buffer->GetCurrentHostPointer(), data, data_size);
   m_uniform_stream_buffer->CommitMemory(data_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
 }
 
 bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBufferFormat format,
@@ -349,7 +349,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   std::memcpy(m_texel_stream_buffer->GetCurrentHostPointer(), data, data_size);
   *out_offset = static_cast<u32>(m_texel_stream_buffer->GetCurrentOffset()) / elem_size;
   m_texel_stream_buffer->CommitMemory(data_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, data_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, data_size);
   StateTracker::GetInstance()->SetTexelBuffer(0, m_texel_buffer_views[format]);
   return true;
 }
@@ -386,7 +386,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
       palette_elem_size;
 
   m_texel_stream_buffer->CommitMemory(palette_byte_offset + palette_size);
-  ADDSTAT(stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
+  ADDSTAT(g_stats.this_frame.bytes_uniform_streamed, palette_byte_offset + palette_size);
   StateTracker::GetInstance()->SetTexelBuffer(0, m_texel_buffer_views[format]);
   StateTracker::GetInstance()->SetTexelBuffer(1, m_texel_buffer_views[palette_format]);
   return true;

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -117,7 +117,7 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
   {
   case Event::EFB_POKE_COLOR:
   {
-    INCSTAT(stats.thisFrame.numEFBPokes);
+    INCSTAT(stats.this_frame.num_efb_pokes);
     EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
     g_renderer->PokeEFB(EFBAccessType::PokeColor, &poke, 1);
   }
@@ -125,20 +125,20 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 
   case Event::EFB_POKE_Z:
   {
-    INCSTAT(stats.thisFrame.numEFBPokes);
+    INCSTAT(stats.this_frame.num_efb_pokes);
     EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
     g_renderer->PokeEFB(EFBAccessType::PokeZ, &poke, 1);
   }
   break;
 
   case Event::EFB_PEEK_COLOR:
-    INCSTAT(stats.thisFrame.numEFBPeeks);
+    INCSTAT(stats.this_frame.num_efb_peeks);
     *e.efb_peek.data =
         g_renderer->AccessEFB(EFBAccessType::PeekColor, e.efb_peek.x, e.efb_peek.y, 0);
     break;
 
   case Event::EFB_PEEK_Z:
-    INCSTAT(stats.thisFrame.numEFBPeeks);
+    INCSTAT(stats.this_frame.num_efb_peeks);
     *e.efb_peek.data = g_renderer->AccessEFB(EFBAccessType::PeekZ, e.efb_peek.x, e.efb_peek.y, 0);
     break;
 

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -117,7 +117,7 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
   {
   case Event::EFB_POKE_COLOR:
   {
-    INCSTAT(stats.this_frame.num_efb_pokes);
+    INCSTAT(g_stats.this_frame.num_efb_pokes);
     EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
     g_renderer->PokeEFB(EFBAccessType::PokeColor, &poke, 1);
   }
@@ -125,20 +125,20 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 
   case Event::EFB_POKE_Z:
   {
-    INCSTAT(stats.this_frame.num_efb_pokes);
+    INCSTAT(g_stats.this_frame.num_efb_pokes);
     EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
     g_renderer->PokeEFB(EFBAccessType::PokeZ, &poke, 1);
   }
   break;
 
   case Event::EFB_PEEK_COLOR:
-    INCSTAT(stats.this_frame.num_efb_peeks);
+    INCSTAT(g_stats.this_frame.num_efb_peeks);
     *e.efb_peek.data =
         g_renderer->AccessEFB(EFBAccessType::PeekColor, e.efb_peek.x, e.efb_peek.y, 0);
     break;
 
   case Event::EFB_PEEK_Z:
-    INCSTAT(stats.this_frame.num_efb_peeks);
+    INCSTAT(g_stats.this_frame.num_efb_peeks);
     *e.efb_peek.data = g_renderer->AccessEFB(EFBAccessType::PeekZ, e.efb_peek.x, e.efb_peek.y, 0);
     break;
 

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -51,13 +51,13 @@ static u32 InterpretDisplayList(u32 address, u32 size)
   if (startAddress != nullptr)
   {
     // temporarily swap dl and non-dl (small "hack" for the stats)
-    Statistics::SwapDL();
+    stats.SwapDL();
 
     Run(DataReader(startAddress, startAddress + size), &cycles, true);
     INCSTAT(stats.this_frame.num_dlists_called);
 
     // un-swap
-    Statistics::SwapDL();
+    stats.SwapDL();
   }
 
   return cycles;

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -54,7 +54,7 @@ static u32 InterpretDisplayList(u32 address, u32 size)
     Statistics::SwapDL();
 
     Run(DataReader(startAddress, startAddress + size), &cycles, true);
-    INCSTAT(stats.thisFrame.numDListsCalled);
+    INCSTAT(stats.this_frame.num_dlists_called);
 
     // un-swap
     Statistics::SwapDL();
@@ -114,7 +114,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       u32 value = src.Read<u32>();
       LoadCPReg(sub_cmd, value, is_preprocess);
       if (!is_preprocess)
-        INCSTAT(stats.thisFrame.numCPLoads);
+        INCSTAT(stats.this_frame.num_cp_loads);
     }
     break;
 
@@ -132,7 +132,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         u32 xf_address = Cmd2 & 0xFFFF;
         LoadXFReg(transfer_size, xf_address, src);
 
-        INCSTAT(stats.thisFrame.numXFLoads);
+        INCSTAT(stats.this_frame.num_xf_loads);
       }
       src.Skip<u32>(transfer_size);
     }
@@ -208,7 +208,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         else
         {
           LoadBPReg(bp_cmd);
-          INCSTAT(stats.thisFrame.numBPLoads);
+          INCSTAT(stats.this_frame.num_bp_loads);
         }
       }
       break;

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -51,13 +51,13 @@ static u32 InterpretDisplayList(u32 address, u32 size)
   if (startAddress != nullptr)
   {
     // temporarily swap dl and non-dl (small "hack" for the stats)
-    stats.SwapDL();
+    g_stats.SwapDL();
 
     Run(DataReader(startAddress, startAddress + size), &cycles, true);
-    INCSTAT(stats.this_frame.num_dlists_called);
+    INCSTAT(g_stats.this_frame.num_dlists_called);
 
     // un-swap
-    stats.SwapDL();
+    g_stats.SwapDL();
   }
 
   return cycles;
@@ -114,7 +114,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       u32 value = src.Read<u32>();
       LoadCPReg(sub_cmd, value, is_preprocess);
       if (!is_preprocess)
-        INCSTAT(stats.this_frame.num_cp_loads);
+        INCSTAT(g_stats.this_frame.num_cp_loads);
     }
     break;
 
@@ -132,7 +132,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         u32 xf_address = Cmd2 & 0xFFFF;
         LoadXFReg(transfer_size, xf_address, src);
 
-        INCSTAT(stats.this_frame.num_xf_loads);
+        INCSTAT(g_stats.this_frame.num_xf_loads);
       }
       src.Skip<u32>(transfer_size);
     }
@@ -208,7 +208,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         else
         {
           LoadBPReg(bp_cmd);
-          INCSTAT(stats.this_frame.num_bp_loads);
+          INCSTAT(g_stats.this_frame.num_bp_loads);
         }
       }
       break;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -524,7 +524,7 @@ void Renderer::DrawDebugText()
   }
 
   if (g_ActiveConfig.bOverlayStats)
-    Statistics::Display();
+    stats.Display();
 
   if (g_ActiveConfig.bShowNetPlayMessages && g_netplay_chat_ui)
     g_netplay_chat_ui->Display();
@@ -533,7 +533,7 @@ void Renderer::DrawDebugText()
     g_netplay_golf_ui->Display();
 
   if (g_ActiveConfig.bOverlayProjStats)
-    Statistics::DisplayProj();
+    stats.DisplayProj();
 }
 
 float Renderer::CalculateDrawAspectRatio() const

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -524,7 +524,7 @@ void Renderer::DrawDebugText()
   }
 
   if (g_ActiveConfig.bOverlayStats)
-    stats.Display();
+    g_stats.Display();
 
   if (g_ActiveConfig.bShowNetPlayMessages && g_netplay_chat_ui)
     g_netplay_chat_ui->Display();
@@ -533,7 +533,7 @@ void Renderer::DrawDebugText()
     g_netplay_golf_ui->Display();
 
   if (g_ActiveConfig.bOverlayProjStats)
-    stats.DisplayProj();
+    g_stats.DisplayProj();
 }
 
 float Renderer::CalculateDrawAspectRatio() const
@@ -1280,8 +1280,8 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
 
       DolphinAnalytics::PerformanceSample perf_sample;
       perf_sample.speed_ratio = SystemTimers::GetEstimatedEmulationPerformance();
-      perf_sample.num_prims = stats.this_frame.num_prims + stats.this_frame.num_dl_prims;
-      perf_sample.num_draw_calls = stats.this_frame.num_draw_calls;
+      perf_sample.num_prims = g_stats.this_frame.num_prims + g_stats.this_frame.num_dl_prims;
+      perf_sample.num_draw_calls = g_stats.this_frame.num_draw_calls;
       DolphinAnalytics::Instance().ReportPerformanceInfo(std::move(perf_sample));
 
       if (IsFrameDumping())
@@ -1289,7 +1289,7 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
 
       // Begin new frame
       m_frame_count++;
-      stats.ResetFrame();
+      g_stats.ResetFrame();
       g_shader_cache->RetrieveAsyncShaders();
       g_vertex_manager->OnEndFrame();
       BeginImGuiFrame();

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1280,8 +1280,8 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
 
       DolphinAnalytics::PerformanceSample perf_sample;
       perf_sample.speed_ratio = SystemTimers::GetEstimatedEmulationPerformance();
-      perf_sample.num_prims = stats.thisFrame.numPrims + stats.thisFrame.numDLPrims;
-      perf_sample.num_draw_calls = stats.thisFrame.numDrawCalls;
+      perf_sample.num_prims = stats.this_frame.num_prims + stats.this_frame.num_dl_prims;
+      perf_sample.num_draw_calls = stats.this_frame.num_draw_calls;
       DolphinAnalytics::Instance().ReportPerformanceInfo(std::move(perf_sample));
 
       if (IsFrameDumping())

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -221,12 +221,12 @@ void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, 
         switch (stage)
         {
         case ShaderStage::Vertex:
-          INCSTAT(stats.numVertexShadersCreated);
-          INCSTAT(stats.numVertexShadersAlive);
+          INCSTAT(stats.num_vertex_shaders_created);
+          INCSTAT(stats.num_vertex_shaders_alive);
           break;
         case ShaderStage::Pixel:
-          INCSTAT(stats.numPixelShadersCreated);
-          INCSTAT(stats.numPixelShadersAlive);
+          INCSTAT(stats.num_pixel_shaders_created);
+          INCSTAT(stats.num_pixel_shaders_alive);
           break;
         default:
           break;
@@ -369,10 +369,10 @@ void ShaderCache::ClearCaches()
   ClearShaderCache(m_uber_vs_cache);
   ClearShaderCache(m_uber_ps_cache);
 
-  SETSTAT(stats.numPixelShadersCreated, 0);
-  SETSTAT(stats.numPixelShadersAlive, 0);
-  SETSTAT(stats.numVertexShadersCreated, 0);
-  SETSTAT(stats.numVertexShadersAlive, 0);
+  SETSTAT(stats.num_pixel_shaders_created, 0);
+  SETSTAT(stats.num_pixel_shaders_alive, 0);
+  SETSTAT(stats.num_vertex_shaders_created, 0);
+  SETSTAT(stats.num_vertex_shaders_alive, 0);
 }
 
 void ShaderCache::CompileMissingPipelines()
@@ -434,8 +434,8 @@ const AbstractShader* ShaderCache::InsertVertexShader(const VertexShaderUid& uid
       if (!binary.empty())
         m_vs_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.numVertexShadersCreated);
-    INCSTAT(stats.numVertexShadersAlive);
+    INCSTAT(stats.num_vertex_shaders_created);
+    INCSTAT(stats.num_vertex_shaders_alive);
     entry.shader = std::move(shader);
   }
 
@@ -456,8 +456,8 @@ const AbstractShader* ShaderCache::InsertVertexUberShader(const UberShader::Vert
       if (!binary.empty())
         m_uber_vs_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.numVertexShadersCreated);
-    INCSTAT(stats.numVertexShadersAlive);
+    INCSTAT(stats.num_vertex_shaders_created);
+    INCSTAT(stats.num_vertex_shaders_alive);
     entry.shader = std::move(shader);
   }
 
@@ -478,8 +478,8 @@ const AbstractShader* ShaderCache::InsertPixelShader(const PixelShaderUid& uid,
       if (!binary.empty())
         m_ps_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.numPixelShadersCreated);
-    INCSTAT(stats.numPixelShadersAlive);
+    INCSTAT(stats.num_pixel_shaders_created);
+    INCSTAT(stats.num_pixel_shaders_alive);
     entry.shader = std::move(shader);
   }
 
@@ -500,8 +500,8 @@ const AbstractShader* ShaderCache::InsertPixelUberShader(const UberShader::Pixel
       if (!binary.empty())
         m_uber_ps_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.numPixelShadersCreated);
-    INCSTAT(stats.numPixelShadersAlive);
+    INCSTAT(stats.num_pixel_shaders_created);
+    INCSTAT(stats.num_pixel_shaders_alive);
     entry.shader = std::move(shader);
   }
 

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -221,12 +221,12 @@ void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, 
         switch (stage)
         {
         case ShaderStage::Vertex:
-          INCSTAT(stats.num_vertex_shaders_created);
-          INCSTAT(stats.num_vertex_shaders_alive);
+          INCSTAT(g_stats.num_vertex_shaders_created);
+          INCSTAT(g_stats.num_vertex_shaders_alive);
           break;
         case ShaderStage::Pixel:
-          INCSTAT(stats.num_pixel_shaders_created);
-          INCSTAT(stats.num_pixel_shaders_alive);
+          INCSTAT(g_stats.num_pixel_shaders_created);
+          INCSTAT(g_stats.num_pixel_shaders_alive);
           break;
         default:
           break;
@@ -369,10 +369,10 @@ void ShaderCache::ClearCaches()
   ClearShaderCache(m_uber_vs_cache);
   ClearShaderCache(m_uber_ps_cache);
 
-  SETSTAT(stats.num_pixel_shaders_created, 0);
-  SETSTAT(stats.num_pixel_shaders_alive, 0);
-  SETSTAT(stats.num_vertex_shaders_created, 0);
-  SETSTAT(stats.num_vertex_shaders_alive, 0);
+  SETSTAT(g_stats.num_pixel_shaders_created, 0);
+  SETSTAT(g_stats.num_pixel_shaders_alive, 0);
+  SETSTAT(g_stats.num_vertex_shaders_created, 0);
+  SETSTAT(g_stats.num_vertex_shaders_alive, 0);
 }
 
 void ShaderCache::CompileMissingPipelines()
@@ -434,8 +434,8 @@ const AbstractShader* ShaderCache::InsertVertexShader(const VertexShaderUid& uid
       if (!binary.empty())
         m_vs_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.num_vertex_shaders_created);
-    INCSTAT(stats.num_vertex_shaders_alive);
+    INCSTAT(g_stats.num_vertex_shaders_created);
+    INCSTAT(g_stats.num_vertex_shaders_alive);
     entry.shader = std::move(shader);
   }
 
@@ -456,8 +456,8 @@ const AbstractShader* ShaderCache::InsertVertexUberShader(const UberShader::Vert
       if (!binary.empty())
         m_uber_vs_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.num_vertex_shaders_created);
-    INCSTAT(stats.num_vertex_shaders_alive);
+    INCSTAT(g_stats.num_vertex_shaders_created);
+    INCSTAT(g_stats.num_vertex_shaders_alive);
     entry.shader = std::move(shader);
   }
 
@@ -478,8 +478,8 @@ const AbstractShader* ShaderCache::InsertPixelShader(const PixelShaderUid& uid,
       if (!binary.empty())
         m_ps_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.num_pixel_shaders_created);
-    INCSTAT(stats.num_pixel_shaders_alive);
+    INCSTAT(g_stats.num_pixel_shaders_created);
+    INCSTAT(g_stats.num_pixel_shaders_alive);
     entry.shader = std::move(shader);
   }
 
@@ -500,8 +500,8 @@ const AbstractShader* ShaderCache::InsertPixelUberShader(const UberShader::Pixel
       if (!binary.empty())
         m_uber_ps_cache.disk_cache.Append(uid, binary.data(), static_cast<u32>(binary.size()));
     }
-    INCSTAT(stats.num_pixel_shaders_created);
-    INCSTAT(stats.num_pixel_shaders_alive);
+    INCSTAT(g_stats.num_pixel_shaders_created);
+    INCSTAT(g_stats.num_pixel_shaders_alive);
     entry.shader = std::move(shader);
   }
 

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -19,13 +19,13 @@ void Statistics::ResetFrame()
 
 void Statistics::SwapDL()
 {
-  std::swap(stats.this_frame.num_dl_prims, stats.this_frame.num_prims);
-  std::swap(stats.this_frame.num_xf_loads_in_dl, stats.this_frame.num_xf_loads);
-  std::swap(stats.this_frame.num_cp_loads_in_dl, stats.this_frame.num_cp_loads);
-  std::swap(stats.this_frame.num_bp_loads_in_dl, stats.this_frame.num_bp_loads);
+  std::swap(this_frame.num_dl_prims, this_frame.num_prims);
+  std::swap(this_frame.num_xf_loads_in_dl, this_frame.num_xf_loads);
+  std::swap(this_frame.num_cp_loads_in_dl, this_frame.num_cp_loads);
+  std::swap(this_frame.num_bp_loads_in_dl, this_frame.num_bp_loads);
 }
 
-void Statistics::Display()
+void Statistics::Display() const
 {
   const float scale = ImGui::GetIO().DisplayFramebufferScale.x;
   ImGui::SetNextWindowPos(ImVec2(10.0f * scale, 10.0f * scale), ImGuiCond_FirstUseEver);
@@ -48,43 +48,43 @@ void Statistics::Display()
 
   if (g_ActiveConfig.backend_info.api_type == APIType::Nothing)
   {
-    draw_statistic("Objects", "%d", stats.this_frame.num_drawn_objects);
-    draw_statistic("Vertices Loaded", "%d", stats.this_frame.num_vertices_loaded);
-    draw_statistic("Triangles Input", "%d", stats.this_frame.num_triangles_in);
-    draw_statistic("Triangles Rejected", "%d", stats.this_frame.num_triangles_rejected);
-    draw_statistic("Triangles Culled", "%d", stats.this_frame.num_triangles_culled);
-    draw_statistic("Triangles Clipped", "%d", stats.this_frame.num_triangles_clipped);
-    draw_statistic("Triangles Drawn", "%d", stats.this_frame.num_triangles_drawn);
-    draw_statistic("Rasterized Pix", "%d", stats.this_frame.rasterized_pixels);
-    draw_statistic("TEV Pix In", "%d", stats.this_frame.tev_pixels_in);
-    draw_statistic("TEV Pix Out", "%d", stats.this_frame.tev_pixels_out);
+    draw_statistic("Objects", "%d", this_frame.num_drawn_objects);
+    draw_statistic("Vertices Loaded", "%d", this_frame.num_vertices_loaded);
+    draw_statistic("Triangles Input", "%d", this_frame.num_triangles_in);
+    draw_statistic("Triangles Rejected", "%d", this_frame.num_triangles_rejected);
+    draw_statistic("Triangles Culled", "%d", this_frame.num_triangles_culled);
+    draw_statistic("Triangles Clipped", "%d", this_frame.num_triangles_clipped);
+    draw_statistic("Triangles Drawn", "%d", this_frame.num_triangles_drawn);
+    draw_statistic("Rasterized Pix", "%d", this_frame.rasterized_pixels);
+    draw_statistic("TEV Pix In", "%d", this_frame.tev_pixels_in);
+    draw_statistic("TEV Pix Out", "%d", this_frame.tev_pixels_out);
   }
 
-  draw_statistic("Textures created", "%d", stats.num_textures_created);
-  draw_statistic("Textures uploaded", "%d", stats.num_textures_uploaded);
-  draw_statistic("Textures alive", "%d", stats.num_textures_alive);
-  draw_statistic("pshaders created", "%d", stats.num_pixel_shaders_created);
-  draw_statistic("pshaders alive", "%d", stats.num_pixel_shaders_alive);
-  draw_statistic("vshaders created", "%d", stats.num_vertex_shaders_created);
-  draw_statistic("vshaders alive", "%d", stats.num_vertex_shaders_alive);
-  draw_statistic("shaders changes", "%d", stats.this_frame.num_shader_changes);
-  draw_statistic("dlists called", "%d", stats.this_frame.num_dlists_called);
-  draw_statistic("Primitive joins", "%d", stats.this_frame.num_primitive_joins);
-  draw_statistic("Draw calls", "%d", stats.this_frame.num_draw_calls);
-  draw_statistic("Primitives", "%d", stats.this_frame.num_prims);
-  draw_statistic("Primitives (DL)", "%d", stats.this_frame.num_dl_prims);
-  draw_statistic("XF loads", "%d", stats.this_frame.num_xf_loads);
-  draw_statistic("XF loads (DL)", "%d", stats.this_frame.num_xf_loads_in_dl);
-  draw_statistic("CP loads", "%d", stats.this_frame.num_cp_loads);
-  draw_statistic("CP loads (DL)", "%d", stats.this_frame.num_cp_loads_in_dl);
-  draw_statistic("BP loads", "%d", stats.this_frame.num_bp_loads);
-  draw_statistic("BP loads (DL)", "%d", stats.this_frame.num_bp_loads_in_dl);
-  draw_statistic("Vertex streamed", "%i kB", stats.this_frame.bytes_vertex_streamed / 1024);
-  draw_statistic("Index streamed", "%i kB", stats.this_frame.bytes_index_streamed / 1024);
-  draw_statistic("Uniform streamed", "%i kB", stats.this_frame.bytes_uniform_streamed / 1024);
-  draw_statistic("Vertex Loaders", "%d", stats.num_vertex_loaders);
-  draw_statistic("EFB peeks:", "%d", stats.this_frame.num_efb_peeks);
-  draw_statistic("EFB pokes:", "%d", stats.this_frame.num_efb_pokes);
+  draw_statistic("Textures created", "%d", num_textures_created);
+  draw_statistic("Textures uploaded", "%d", num_textures_uploaded);
+  draw_statistic("Textures alive", "%d", num_textures_alive);
+  draw_statistic("pshaders created", "%d", num_pixel_shaders_created);
+  draw_statistic("pshaders alive", "%d", num_pixel_shaders_alive);
+  draw_statistic("vshaders created", "%d", num_vertex_shaders_created);
+  draw_statistic("vshaders alive", "%d", num_vertex_shaders_alive);
+  draw_statistic("shaders changes", "%d", this_frame.num_shader_changes);
+  draw_statistic("dlists called", "%d", this_frame.num_dlists_called);
+  draw_statistic("Primitive joins", "%d", this_frame.num_primitive_joins);
+  draw_statistic("Draw calls", "%d", this_frame.num_draw_calls);
+  draw_statistic("Primitives", "%d", this_frame.num_prims);
+  draw_statistic("Primitives (DL)", "%d", this_frame.num_dl_prims);
+  draw_statistic("XF loads", "%d", this_frame.num_xf_loads);
+  draw_statistic("XF loads (DL)", "%d", this_frame.num_xf_loads_in_dl);
+  draw_statistic("CP loads", "%d", this_frame.num_cp_loads);
+  draw_statistic("CP loads (DL)", "%d", this_frame.num_cp_loads_in_dl);
+  draw_statistic("BP loads", "%d", this_frame.num_bp_loads);
+  draw_statistic("BP loads (DL)", "%d", this_frame.num_bp_loads_in_dl);
+  draw_statistic("Vertex streamed", "%i kB", this_frame.bytes_vertex_streamed / 1024);
+  draw_statistic("Index streamed", "%i kB", this_frame.bytes_index_streamed / 1024);
+  draw_statistic("Uniform streamed", "%i kB", this_frame.bytes_uniform_streamed / 1024);
+  draw_statistic("Vertex Loaders", "%d", num_vertex_loaders);
+  draw_statistic("EFB peeks:", "%d", this_frame.num_efb_peeks);
+  draw_statistic("EFB pokes:", "%d", this_frame.num_efb_pokes);
 
   ImGui::Columns(1);
 
@@ -92,7 +92,7 @@ void Statistics::Display()
 }
 
 // Is this really needed?
-void Statistics::DisplayProj()
+void Statistics::DisplayProj() const
 {
   if (!ImGui::Begin("Projection Statistics", nullptr, ImGuiWindowFlags_NoNavInputs))
   {
@@ -102,22 +102,22 @@ void Statistics::DisplayProj()
 
   ImGui::TextUnformatted("Projection #: X for Raw 6=0 (X for Raw 6!=0)");
   ImGui::NewLine();
-  ImGui::Text("Projection 0: %f (%f) Raw 0: %f", stats.gproj[0], stats.g2proj[0], stats.proj[0]);
-  ImGui::Text("Projection 1: %f (%f)", stats.gproj[1], stats.g2proj[1]);
-  ImGui::Text("Projection 2: %f (%f) Raw 1: %f", stats.gproj[2], stats.g2proj[2], stats.proj[1]);
-  ImGui::Text("Projection 3: %f (%f)", stats.gproj[3], stats.g2proj[3]);
-  ImGui::Text("Projection 4: %f (%f)", stats.gproj[4], stats.g2proj[4]);
-  ImGui::Text("Projection 5: %f (%f) Raw 2: %f", stats.gproj[5], stats.g2proj[5], stats.proj[2]);
-  ImGui::Text("Projection 6: %f (%f) Raw 3: %f", stats.gproj[6], stats.g2proj[6], stats.proj[3]);
-  ImGui::Text("Projection 7: %f (%f)", stats.gproj[7], stats.g2proj[7]);
-  ImGui::Text("Projection 8: %f (%f)", stats.gproj[8], stats.g2proj[8]);
-  ImGui::Text("Projection 9: %f (%f)", stats.gproj[9], stats.g2proj[9]);
-  ImGui::Text("Projection 10: %f (%f) Raw 4: %f", stats.gproj[10], stats.g2proj[10], stats.proj[4]);
-  ImGui::Text("Projection 11: %f (%f) Raw 5: %f", stats.gproj[11], stats.g2proj[11], stats.proj[5]);
-  ImGui::Text("Projection 12: %f (%f)", stats.gproj[12], stats.g2proj[12]);
-  ImGui::Text("Projection 13: %f (%f)", stats.gproj[13], stats.g2proj[13]);
-  ImGui::Text("Projection 14: %f (%f)", stats.gproj[14], stats.g2proj[14]);
-  ImGui::Text("Projection 15: %f (%f)", stats.gproj[15], stats.g2proj[15]);
+  ImGui::Text("Projection 0: %f (%f) Raw 0: %f", gproj[0], g2proj[0], proj[0]);
+  ImGui::Text("Projection 1: %f (%f)", gproj[1], g2proj[1]);
+  ImGui::Text("Projection 2: %f (%f) Raw 1: %f", gproj[2], g2proj[2], proj[1]);
+  ImGui::Text("Projection 3: %f (%f)", gproj[3], g2proj[3]);
+  ImGui::Text("Projection 4: %f (%f)", gproj[4], g2proj[4]);
+  ImGui::Text("Projection 5: %f (%f) Raw 2: %f", gproj[5], g2proj[5], proj[2]);
+  ImGui::Text("Projection 6: %f (%f) Raw 3: %f", gproj[6], g2proj[6], proj[3]);
+  ImGui::Text("Projection 7: %f (%f)", gproj[7], g2proj[7]);
+  ImGui::Text("Projection 8: %f (%f)", gproj[8], g2proj[8]);
+  ImGui::Text("Projection 9: %f (%f)", gproj[9], g2proj[9]);
+  ImGui::Text("Projection 10: %f (%f) Raw 4: %f", gproj[10], g2proj[10], proj[4]);
+  ImGui::Text("Projection 11: %f (%f) Raw 5: %f", gproj[11], g2proj[11], proj[5]);
+  ImGui::Text("Projection 12: %f (%f)", gproj[12], g2proj[12]);
+  ImGui::Text("Projection 13: %f (%f)", gproj[13], g2proj[13]);
+  ImGui::Text("Projection 14: %f (%f)", gproj[14], g2proj[14]);
+  ImGui::Text("Projection 15: %f (%f)", gproj[15], g2proj[15]);
 
   ImGui::End();
 }

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -10,7 +10,7 @@
 
 #include "VideoCommon/VideoConfig.h"
 
-Statistics stats;
+Statistics g_stats;
 
 void Statistics::ResetFrame()
 {

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -14,15 +14,15 @@ Statistics stats;
 
 void Statistics::ResetFrame()
 {
-  thisFrame = {};
+  this_frame = {};
 }
 
 void Statistics::SwapDL()
 {
-  std::swap(stats.thisFrame.numDLPrims, stats.thisFrame.numPrims);
-  std::swap(stats.thisFrame.numXFLoadsInDL, stats.thisFrame.numXFLoads);
-  std::swap(stats.thisFrame.numCPLoadsInDL, stats.thisFrame.numCPLoads);
-  std::swap(stats.thisFrame.numBPLoadsInDL, stats.thisFrame.numBPLoads);
+  std::swap(stats.this_frame.num_dl_prims, stats.this_frame.num_prims);
+  std::swap(stats.this_frame.num_xf_loads_in_dl, stats.this_frame.num_xf_loads);
+  std::swap(stats.this_frame.num_cp_loads_in_dl, stats.this_frame.num_cp_loads);
+  std::swap(stats.this_frame.num_bp_loads_in_dl, stats.this_frame.num_bp_loads);
 }
 
 void Statistics::Display()
@@ -48,43 +48,43 @@ void Statistics::Display()
 
   if (g_ActiveConfig.backend_info.api_type == APIType::Nothing)
   {
-    draw_statistic("Objects", "%d", stats.thisFrame.numDrawnObjects);
-    draw_statistic("Vertices Loaded", "%d", stats.thisFrame.numVerticesLoaded);
-    draw_statistic("Triangles Input", "%d", stats.thisFrame.numTrianglesIn);
-    draw_statistic("Triangles Rejected", "%d", stats.thisFrame.numTrianglesRejected);
-    draw_statistic("Triangles Culled", "%d", stats.thisFrame.numTrianglesCulled);
-    draw_statistic("Triangles Clipped", "%d", stats.thisFrame.numTrianglesClipped);
-    draw_statistic("Triangles Drawn", "%d", stats.thisFrame.numTrianglesDrawn);
-    draw_statistic("Rasterized Pix", "%d", stats.thisFrame.rasterizedPixels);
-    draw_statistic("TEV Pix In", "%d", stats.thisFrame.tevPixelsIn);
-    draw_statistic("TEV Pix Out", "%d", stats.thisFrame.tevPixelsOut);
+    draw_statistic("Objects", "%d", stats.this_frame.num_drawn_objects);
+    draw_statistic("Vertices Loaded", "%d", stats.this_frame.num_vertices_loaded);
+    draw_statistic("Triangles Input", "%d", stats.this_frame.num_triangles_in);
+    draw_statistic("Triangles Rejected", "%d", stats.this_frame.num_triangles_rejected);
+    draw_statistic("Triangles Culled", "%d", stats.this_frame.num_triangles_culled);
+    draw_statistic("Triangles Clipped", "%d", stats.this_frame.num_triangles_clipped);
+    draw_statistic("Triangles Drawn", "%d", stats.this_frame.num_triangles_drawn);
+    draw_statistic("Rasterized Pix", "%d", stats.this_frame.rasterized_pixels);
+    draw_statistic("TEV Pix In", "%d", stats.this_frame.tev_pixels_in);
+    draw_statistic("TEV Pix Out", "%d", stats.this_frame.tev_pixels_out);
   }
 
-  draw_statistic("Textures created", "%d", stats.numTexturesCreated);
-  draw_statistic("Textures uploaded", "%d", stats.numTexturesUploaded);
-  draw_statistic("Textures alive", "%d", stats.numTexturesAlive);
-  draw_statistic("pshaders created", "%d", stats.numPixelShadersCreated);
-  draw_statistic("pshaders alive", "%d", stats.numPixelShadersAlive);
-  draw_statistic("vshaders created", "%d", stats.numVertexShadersCreated);
-  draw_statistic("vshaders alive", "%d", stats.numVertexShadersAlive);
-  draw_statistic("shaders changes", "%d", stats.thisFrame.numShaderChanges);
-  draw_statistic("dlists called", "%d", stats.thisFrame.numDListsCalled);
-  draw_statistic("Primitive joins", "%d", stats.thisFrame.numPrimitiveJoins);
-  draw_statistic("Draw calls", "%d", stats.thisFrame.numDrawCalls);
-  draw_statistic("Primitives", "%d", stats.thisFrame.numPrims);
-  draw_statistic("Primitives (DL)", "%d", stats.thisFrame.numDLPrims);
-  draw_statistic("XF loads", "%d", stats.thisFrame.numXFLoads);
-  draw_statistic("XF loads (DL)", "%d", stats.thisFrame.numXFLoadsInDL);
-  draw_statistic("CP loads", "%d", stats.thisFrame.numCPLoads);
-  draw_statistic("CP loads (DL)", "%d", stats.thisFrame.numCPLoadsInDL);
-  draw_statistic("BP loads", "%d", stats.thisFrame.numBPLoads);
-  draw_statistic("BP loads (DL)", "%d", stats.thisFrame.numBPLoadsInDL);
-  draw_statistic("Vertex streamed", "%i kB", stats.thisFrame.bytesVertexStreamed / 1024);
-  draw_statistic("Index streamed", "%i kB", stats.thisFrame.bytesIndexStreamed / 1024);
-  draw_statistic("Uniform streamed", "%i kB", stats.thisFrame.bytesUniformStreamed / 1024);
-  draw_statistic("Vertex Loaders", "%d", stats.numVertexLoaders);
-  draw_statistic("EFB peeks:", "%d", stats.thisFrame.numEFBPeeks);
-  draw_statistic("EFB pokes:", "%d", stats.thisFrame.numEFBPokes);
+  draw_statistic("Textures created", "%d", stats.num_textures_created);
+  draw_statistic("Textures uploaded", "%d", stats.num_textures_uploaded);
+  draw_statistic("Textures alive", "%d", stats.num_textures_alive);
+  draw_statistic("pshaders created", "%d", stats.num_pixel_shaders_created);
+  draw_statistic("pshaders alive", "%d", stats.num_pixel_shaders_alive);
+  draw_statistic("vshaders created", "%d", stats.num_vertex_shaders_created);
+  draw_statistic("vshaders alive", "%d", stats.num_vertex_shaders_alive);
+  draw_statistic("shaders changes", "%d", stats.this_frame.num_shader_changes);
+  draw_statistic("dlists called", "%d", stats.this_frame.num_dlists_called);
+  draw_statistic("Primitive joins", "%d", stats.this_frame.num_primitive_joins);
+  draw_statistic("Draw calls", "%d", stats.this_frame.num_draw_calls);
+  draw_statistic("Primitives", "%d", stats.this_frame.num_prims);
+  draw_statistic("Primitives (DL)", "%d", stats.this_frame.num_dl_prims);
+  draw_statistic("XF loads", "%d", stats.this_frame.num_xf_loads);
+  draw_statistic("XF loads (DL)", "%d", stats.this_frame.num_xf_loads_in_dl);
+  draw_statistic("CP loads", "%d", stats.this_frame.num_cp_loads);
+  draw_statistic("CP loads (DL)", "%d", stats.this_frame.num_cp_loads_in_dl);
+  draw_statistic("BP loads", "%d", stats.this_frame.num_bp_loads);
+  draw_statistic("BP loads (DL)", "%d", stats.this_frame.num_bp_loads_in_dl);
+  draw_statistic("Vertex streamed", "%i kB", stats.this_frame.bytes_vertex_streamed / 1024);
+  draw_statistic("Index streamed", "%i kB", stats.this_frame.bytes_index_streamed / 1024);
+  draw_statistic("Uniform streamed", "%i kB", stats.this_frame.bytes_uniform_streamed / 1024);
+  draw_statistic("Vertex Loaders", "%d", stats.num_vertex_loaders);
+  draw_statistic("EFB peeks:", "%d", stats.this_frame.num_efb_peeks);
+  draw_statistic("EFB pokes:", "%d", stats.this_frame.num_efb_pokes);
 
   ImGui::Columns(1);
 

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -67,7 +67,7 @@ struct Statistics
   void DisplayProj() const;
 };
 
-extern Statistics stats;
+extern Statistics g_stats;
 
 #define STATISTICS
 

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -8,16 +8,16 @@
 
 struct Statistics
 {
-  int numPixelShadersCreated;
-  int numPixelShadersAlive;
-  int numVertexShadersCreated;
-  int numVertexShadersAlive;
+  int num_pixel_shaders_created;
+  int num_pixel_shaders_alive;
+  int num_vertex_shaders_created;
+  int num_vertex_shaders_alive;
 
-  int numTexturesCreated;
-  int numTexturesUploaded;
-  int numTexturesAlive;
+  int num_textures_created;
+  int num_textures_uploaded;
+  int num_textures_alive;
 
-  int numVertexLoaders;
+  int num_vertex_loaders;
 
   std::array<float, 6> proj;
   std::array<float, 16> gproj;
@@ -25,42 +25,42 @@ struct Statistics
 
   struct ThisFrame
   {
-    int numBPLoads;
-    int numCPLoads;
-    int numXFLoads;
+    int num_bp_loads;
+    int num_cp_loads;
+    int num_xf_loads;
 
-    int numBPLoadsInDL;
-    int numCPLoadsInDL;
-    int numXFLoadsInDL;
+    int num_bp_loads_in_dl;
+    int num_cp_loads_in_dl;
+    int num_xf_loads_in_dl;
 
-    int numPrims;
-    int numDLPrims;
-    int numShaderChanges;
+    int num_prims;
+    int num_dl_prims;
+    int num_shader_changes;
 
-    int numPrimitiveJoins;
-    int numDrawCalls;
+    int num_primitive_joins;
+    int num_draw_calls;
 
-    int numDListsCalled;
+    int num_dlists_called;
 
-    int bytesVertexStreamed;
-    int bytesIndexStreamed;
-    int bytesUniformStreamed;
+    int bytes_vertex_streamed;
+    int bytes_index_streamed;
+    int bytes_uniform_streamed;
 
-    int numTrianglesClipped;
-    int numTrianglesIn;
-    int numTrianglesRejected;
-    int numTrianglesCulled;
-    int numDrawnObjects;
-    int rasterizedPixels;
-    int numTrianglesDrawn;
-    int numVerticesLoaded;
-    int tevPixelsIn;
-    int tevPixelsOut;
+    int num_triangles_clipped;
+    int num_triangles_in;
+    int num_triangles_rejected;
+    int num_triangles_culled;
+    int num_drawn_objects;
+    int rasterized_pixels;
+    int num_triangles_drawn;
+    int num_vertices_loaded;
+    int tev_pixels_in;
+    int tev_pixels_out;
 
-    int numEFBPeeks;
-    int numEFBPokes;
+    int num_efb_peeks;
+    int num_efb_pokes;
   };
-  ThisFrame thisFrame;
+  ThisFrame this_frame;
   void ResetFrame();
   static void SwapDL();
   static void Display();

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -62,9 +62,9 @@ struct Statistics
   };
   ThisFrame this_frame;
   void ResetFrame();
-  static void SwapDL();
-  static void Display();
-  static void DisplayProj();
+  void SwapDL();
+  void Display() const;
+  void DisplayProj() const;
 };
 
 extern Statistics stats;

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -73,7 +73,6 @@ extern Statistics g_stats;
 
 #ifdef STATISTICS
 #define INCSTAT(a) (a)++;
-#define DECSTAT(a) (a)--;
 #define ADDSTAT(a, b) (a) += (b);
 #define SETSTAT(a, x) (a) = (int)(x);
 #else

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1200,8 +1200,8 @@ TextureCacheBase::GetTexture(u32 address, u32 width, u32 height, const TextureFo
     }
   }
 
-  INCSTAT(stats.num_textures_uploaded);
-  SETSTAT(stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
+  INCSTAT(g_stats.num_textures_uploaded);
+  SETSTAT(g_stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
 
   entry = DoPartialTextureUpdates(iter->second, &texMem[tlutaddr], tlutfmt);
 
@@ -1277,8 +1277,8 @@ TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height, u32 stride,
 
   // Insert into the texture cache so we can re-use it next frame, if needed.
   textures_by_address.emplace(entry->addr, entry);
-  SETSTAT(stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
-  INCSTAT(stats.num_textures_uploaded);
+  SETSTAT(g_stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
+  INCSTAT(g_stats.num_textures_uploaded);
 
   if (g_ActiveConfig.bDumpXFBTarget)
   {
@@ -2017,7 +2017,7 @@ TextureCacheBase::AllocateTexture(const TextureConfig& config)
     }
   }
 
-  INCSTAT(stats.num_textures_created);
+  INCSTAT(g_stats.num_textures_created);
   return TexPoolEntry(std::move(texture), std::move(framebuffer));
 }
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1200,8 +1200,8 @@ TextureCacheBase::GetTexture(u32 address, u32 width, u32 height, const TextureFo
     }
   }
 
-  INCSTAT(stats.numTexturesUploaded);
-  SETSTAT(stats.numTexturesAlive, textures_by_address.size());
+  INCSTAT(stats.num_textures_uploaded);
+  SETSTAT(stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
 
   entry = DoPartialTextureUpdates(iter->second, &texMem[tlutaddr], tlutfmt);
 
@@ -1277,8 +1277,8 @@ TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height, u32 stride,
 
   // Insert into the texture cache so we can re-use it next frame, if needed.
   textures_by_address.emplace(entry->addr, entry);
-  SETSTAT(stats.numTexturesAlive, textures_by_address.size());
-  INCSTAT(stats.numTexturesUploaded);
+  SETSTAT(stats.num_textures_alive, static_cast<int>(textures_by_address.size()));
+  INCSTAT(stats.num_textures_uploaded);
 
   if (g_ActiveConfig.bDumpXFBTarget)
   {
@@ -2017,7 +2017,7 @@ TextureCacheBase::AllocateTexture(const TextureConfig& config)
     }
   }
 
-  INCSTAT(stats.numTexturesCreated);
+  INCSTAT(stats.num_textures_created);
   return TexPoolEntry(std::move(texture), std::move(framebuffer));
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -54,7 +54,7 @@ void Init()
     map_entry = nullptr;
   for (auto& map_entry : g_preprocess_cp_state.vertex_loaders)
     map_entry = nullptr;
-  SETSTAT(stats.num_vertex_loaders, 0);
+  SETSTAT(g_stats.num_vertex_loaders, 0);
 }
 
 void Clear()
@@ -223,7 +223,7 @@ static VertexLoaderBase* RefreshLoader(int vtx_attr_group, bool preprocess = fal
       s_vertex_loader_map[uid] =
           VertexLoaderBase::CreateVertexLoader(state->vtx_desc, state->vtx_attr[vtx_attr_group]);
       loader = s_vertex_loader_map[uid].get();
-      INCSTAT(stats.num_vertex_loaders);
+      INCSTAT(g_stats.num_vertex_loaders);
     }
     if (check_for_native_format)
     {
@@ -287,8 +287,8 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
 
   g_vertex_manager->FlushData(count, loader->m_native_vtx_decl.stride);
 
-  ADDSTAT(stats.this_frame.num_prims, count);
-  INCSTAT(stats.this_frame.num_primitive_joins);
+  ADDSTAT(g_stats.this_frame.num_prims, count);
+  INCSTAT(g_stats.this_frame.num_primitive_joins);
   return size;
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -54,7 +54,7 @@ void Init()
     map_entry = nullptr;
   for (auto& map_entry : g_preprocess_cp_state.vertex_loaders)
     map_entry = nullptr;
-  SETSTAT(stats.numVertexLoaders, 0);
+  SETSTAT(stats.num_vertex_loaders, 0);
 }
 
 void Clear()
@@ -223,7 +223,7 @@ static VertexLoaderBase* RefreshLoader(int vtx_attr_group, bool preprocess = fal
       s_vertex_loader_map[uid] =
           VertexLoaderBase::CreateVertexLoader(state->vtx_desc, state->vtx_attr[vtx_attr_group]);
       loader = s_vertex_loader_map[uid].get();
-      INCSTAT(stats.numVertexLoaders);
+      INCSTAT(stats.num_vertex_loaders);
     }
     if (check_for_native_format)
     {
@@ -287,8 +287,8 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
 
   g_vertex_manager->FlushData(count, loader->m_native_vtx_decl.stride);
 
-  ADDSTAT(stats.thisFrame.numPrims, count);
-  INCSTAT(stats.thisFrame.numPrimitiveJoins);
+  ADDSTAT(stats.this_frame.num_prims, count);
+  INCSTAT(stats.this_frame.num_primitive_joins);
   return size;
 }
 

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -442,7 +442,7 @@ void VertexManagerBase::Flush()
         g_perf_query->EnableQuery(bpmem.zcontrol.early_ztest ? PQG_ZCOMP_ZCOMPLOC : PQG_ZCOMP);
 
       DrawCurrentBatch(base_index, num_indices, base_vertex);
-      INCSTAT(stats.thisFrame.numDrawCalls);
+      INCSTAT(stats.this_frame.num_draw_calls);
 
       if (PerfQueryBase::ShouldEmulate())
         g_perf_query->DisableQuery(bpmem.zcontrol.early_ztest ? PQG_ZCOMP_ZCOMPLOC : PQG_ZCOMP);

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -442,7 +442,7 @@ void VertexManagerBase::Flush()
         g_perf_query->EnableQuery(bpmem.zcontrol.early_ztest ? PQG_ZCOMP_ZCOMPLOC : PQG_ZCOMP);
 
       DrawCurrentBatch(base_index, num_indices, base_vertex);
-      INCSTAT(stats.this_frame.num_draw_calls);
+      INCSTAT(g_stats.this_frame.num_draw_calls);
 
       if (PerfQueryBase::ShouldEmulate())
         g_perf_query->DisableQuery(bpmem.zcontrol.early_ztest ? PQG_ZCOMP_ZCOMPLOC : PQG_ZCOMP);

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -374,7 +374,7 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[14] = -1.0f;
       g_fProjectionMatrix[15] = 0.0f;
 
-      stats.gproj = g_fProjectionMatrix;
+      g_stats.gproj = g_fProjectionMatrix;
       break;
 
     case GX_ORTHOGRAPHIC:
@@ -399,8 +399,8 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[14] = 0.0f;
       g_fProjectionMatrix[15] = 1.0f;
 
-      stats.g2proj = g_fProjectionMatrix;
-      stats.proj = rawProjection;
+      g_stats.g2proj = g_fProjectionMatrix;
+      g_stats.proj = rawProjection;
       break;
 
     default:


### PR DESCRIPTION
Normalizes statistic variable names, and also renames the statistic global variable from `stats` to `g_stats`. The latter change makes it much more obvious in certain bits of code that a global variable is being accessed.

While we're at it, we can also make the functions in the `Statistics` interface non-static so that the behavior of the class itself is decoupled from the global variable (which also makes for less reading).