### PR TITLE
TextureCache: Support reinterpreting formats for VRAM textures

### DIFF
--- a/Source/Core/VideoCommon/FramebufferShaderGen.h
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.h
@@ -3,6 +3,7 @@
 #include "VideoCommon/VideoCommon.h"
 
 enum class EFBReinterpretType;
+enum class TextureFormat;
 
 namespace FramebufferShaderGen
 {
@@ -28,5 +29,6 @@ std::string GenerateClearVertexShader();
 std::string GenerateEFBPokeVertexShader();
 std::string GenerateColorPixelShader();
 std::string GenerateFormatConversionShader(EFBReinterpretType convtype, u32 samples);
+std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureFormat to_format);
 
 }  // namespace FramebufferShaderGen

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -34,6 +34,7 @@
 
 class NativeVertexFormat;
 enum class AbstractTextureFormat : u32;
+enum class TextureFormat;
 enum class TLUTFormat;
 
 namespace VideoCommon
@@ -103,6 +104,10 @@ public:
 
   // Palette texture conversion pipelines
   const AbstractPipeline* GetPaletteConversionPipeline(TLUTFormat format);
+
+  // Texture reinterpret pipelines
+  const AbstractPipeline* GetTextureReinterpretPipeline(TextureFormat from_format,
+                                                        TextureFormat to_format);
 
   // Texture decoding compute shaders
   const AbstractShader* GetTextureDecodingShader(TextureFormat format, TLUTFormat palette_format);
@@ -237,6 +242,10 @@ private:
   // Palette conversion pipelines
   std::array<std::unique_ptr<AbstractPipeline>, NUM_PALETTE_CONVERSION_SHADERS>
       m_palette_conversion_pipelines;
+
+  // Texture reinterpreting pipeline
+  std::map<std::pair<TextureFormat, TextureFormat>, std::unique_ptr<AbstractPipeline>>
+      m_texture_reinterpret_pipelines;
 
   // Texture decoding shaders
   std::map<std::pair<u32, u32>, std::unique_ptr<AbstractShader>> m_texture_decoding_shaders;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -228,10 +228,6 @@ public:
   static bool NeedsCopyFilterInShader(const EFBCopyFilterCoefficients& coefficients);
 
 protected:
-  // Applies a palette to an EFB copy/texture.
-  bool ConvertTexture(TCacheEntry* entry, TCacheEntry* unconverted, const void* palette,
-                      TLUTFormat format);
-
   // Decodes the specified data to the GPU texture specified by entry.
   // Returns false if the configuration is not supported.
   // width, height are the size of the image in pixels.

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -277,6 +277,8 @@ private:
 
   TCacheEntry* ApplyPaletteToEntry(TCacheEntry* entry, u8* palette, TLUTFormat tlutfmt);
 
+  TCacheEntry* ReinterpretEntry(const TCacheEntry* existing_entry, TextureFormat new_format);
+
   TCacheEntry* DoPartialTextureUpdates(TCacheEntry* entry_to_update, u8* palette,
                                        TLUTFormat tlutfmt);
   void StitchXFBCopy(TCacheEntry* entry_to_update);

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -824,13 +824,13 @@ const char* GenerateEncodingShader(const EFBCopyParams& params, APIType api_type
     if (params.depth)
       WriteZ16Encoder(p, api_type, params);  // Z16H
     else
-      WriteCC8Encoder(p, "rg", api_type, params);
+      WriteCC8Encoder(p, "gr", api_type, params);
     break;
   case EFBCopyFormat::GB8:
     if (params.depth)
       WriteZ16LEncoder(p, api_type, params);  // Z16L
     else
-      WriteCC8Encoder(p, "gb", api_type, params);
+      WriteCC8Encoder(p, "bg", api_type, params);
     break;
   case EFBCopyFormat::XFB:
     WriteXFBEncoder(p, api_type, params);

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -99,6 +99,47 @@ static inline bool IsValidTLUTFormat(TLUTFormat tlutfmt)
          tlutfmt == TLUTFormat::RGB5A3;
 }
 
+static inline bool IsCompatibleTextureFormat(TextureFormat from_format, TextureFormat to_format)
+{
+  if (from_format == to_format)
+    return true;
+
+  // Indexed and paletted formats are "compatible", that is do not require conversion.
+  switch (from_format)
+  {
+  case TextureFormat::I4:
+  case TextureFormat::C4:
+    return to_format == TextureFormat::I4 || to_format == TextureFormat::C4;
+
+  case TextureFormat::I8:
+  case TextureFormat::C8:
+    return to_format == TextureFormat::I8 || to_format == TextureFormat::C8;
+
+  default:
+    return false;
+  }
+}
+
+static inline bool CanReinterpretTextureOnGPU(TextureFormat from_format, TextureFormat to_format)
+{
+  // Currently, we can only reinterpret textures of the same width.
+  switch (from_format)
+  {
+  case TextureFormat::I8:
+  case TextureFormat::IA4:
+    return to_format == TextureFormat::I8 || to_format == TextureFormat::IA4;
+
+  case TextureFormat::IA8:
+  case TextureFormat::RGB565:
+  case TextureFormat::RGB5A3:
+    return to_format == TextureFormat::IA8 || to_format == TextureFormat::RGB565 ||
+           to_format == TextureFormat::RGB5A3;
+
+  default:
+    return false;
+  }
+}
+
 int TexDecoder_GetTexelSizeInNibbles(TextureFormat format);
 int TexDecoder_GetTextureSizeInBytes(int width, int height, TextureFormat format);
 int TexDecoder_GetBlockWidthInTexels(TextureFormat format);


### PR DESCRIPTION
Currently, Dolphin does not consider texture formats when looking up entries in the texture cache, and just returns the first match based on dimensions/RAM address.

Some formats are inherently compatible, as the channel and bit layout is identical (e.g. I8/C8). Others have the same number of bits per texel, and can be reinterpreted on the GPU (e.g. IA4 and I8 or RGB565 and RGB5A3).

Spiderman Shattered Dimensions creates a copy in B8 format, and samples it as a IA4 texture. This leads to a broken post-processing effect without this patch, as the texture has different colour values. It worked with EFB Copies to VRAM disabled, as this forced the correct layout to be reloaded from memory. But, for speed and upscaling, we can perform this conversion on the GPU.

The EFB2RAM shaders were also apparently incorrectly swapping the red/green and green/blue channels for RG/GB formats, leading to incorrect colours in the above case as well. Now the hardware backends match the software rasterizer.

This patch also supports IA8/RGB565/RGB5A3 reinterpreting, but we aren't aware of any games which do this. It would be possible to extend this to formats which don't have the same number of bits per texel, although it would add additional complexity, so instead we just fall back to the RAM version. If we find some games which do behave this way, then we can implement it.