### PR TITLE
EFB2Tex: Set alpha channel of Z24X8 copies to 1

### DIFF
--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -190,7 +190,7 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
       break;
 
     case EFBCopyFormat::RGBA8:  // Z24X8
-      out.Write("  ocol0 = float4(texcol.rgb, 0.0);\n");
+      out.Write("  ocol0 = float4(texcol.rgb, 1.0);\n");
       break;
 
     case EFBCopyFormat::G8:  // Z8M


### PR DESCRIPTION
Fifolog courtesy of @JMC47. Fixes Dekotora Matsuri on OpenGL. D3D and Vulkan are still broken, I suspect due to a separate issue. But EFB2Tex and EFB2RAM produce the same results, now.

Before:
![ct7PuBb](https://user-images.githubusercontent.com/11288319/61185085-5acaf100-a698-11e9-9e43-7df5c3da30b3.png)
After:
![aYb97oA](https://user-images.githubusercontent.com/11288319/61185086-5dc5e180-a698-11e9-8f5f-f7aa163c9b0f.png)
