### PR TITLE
Vulkan: Use reversed depth range in viewport

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -272,6 +272,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsPostProcessing = true;             // Assumed support.
   config->backend_info.bSupportsBackgroundCompiling = true;        // Assumed support.
   config->backend_info.bSupportsCopyToVram = true;                 // Assumed support.
+  config->backend_info.bSupportsReversedDepthRange = true;         // Assumed support.
   config->backend_info.bSupportsDualSourceBlend = false;           // Dependent on features.
   config->backend_info.bSupportsGeometryShaders = false;           // Dependent on features.
   config->backend_info.bSupportsGSInstancing = false;              // Dependent on features.
@@ -283,8 +284,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsBPTCTextures = false;              // Dependent on features.
   config->backend_info.bSupportsLogicOp = false;                   // Dependent on features.
   config->backend_info.bSupportsLargePoints = false;               // Dependent on features.
-  config->backend_info.bSupportsReversedDepthRange = false;  // No support yet due to driver bugs.
-  config->backend_info.bSupportsFramebufferFetch = false;    // No support.
+  config->backend_info.bSupportsFramebufferFetch = false;          // No support.
 }
 
 void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list)
@@ -340,6 +340,11 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   // Seems to be fine on GCN Gen 1-2, unconfirmed on GCN Gen 3, causes driver resets on GCN Gen 4.
   if (DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART))
     config->backend_info.bSupportsPrimitiveRestart = false;
+
+  // Reversed depth range is broken on some drivers, or is broken when used in combination
+  // with depth clamping. Fall back to inverted depth range for these.
+  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_REVERSED_DEPTH_RANGE))
+    config->backend_info.bSupportsReversedDepthRange = false;
 }
 
 void VulkanContext::PopulateBackendInfoMultisampleModes(

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -108,7 +108,10 @@ constexpr BugInfo m_known_bugs[] = {
      BUG_BROKEN_CLEAR_LOADOP_RENDERPASS, -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN, BUG_BROKEN_D32F_CLEAR,
      -1.0, -1.0, true},
-};
+    {API_VULKAN, OS_ALL, VENDOR_MESA, DRIVER_I965, Family::UNKNOWN, BUG_BROKEN_REVERSED_DEPTH_RANGE,
+     -1.0, -1.0, true},
+    {API_VULKAN, OS_ALL, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN,
+     BUG_BROKEN_REVERSED_DEPTH_RANGE, -1.0, -1.0, true}};
 
 static std::map<Bug, BugInfo> m_bugs;
 

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -276,6 +276,11 @@ enum Bug
   // Started version: -1
   // Ended version: -1
   BUG_BROKEN_D32F_CLEAR,
+
+  // BUG: Reversed viewport depth range does not work as intended on some Vulkan drivers.
+  // The Vulkan spec allows the minDepth/maxDepth fields in the viewport to be reversed,
+  // however the implementation is broken on some drivers.
+  BUG_BROKEN_REVERSED_DEPTH_RANGE,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
New version of #6067, apparently force-pushing to a branch before restoring it/re-opening the PR prevents you from re-opening the PR.. that or I'm a github newb.

Also adds a DriverDetails bug to disable on drivers where this is still broken. Only one I'm aware of is Mesa where it's broken when used in conjunction with depth clamping, but I haven't tested that in a while. Who knows about mobile drivers.