### PR TITLE
Core/FifoAnalyzer: Tidy up interface

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -188,7 +188,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
     int array = 0xc + (cmd - OpcodeDecoder::GX_LOAD_INDX_A) / 8;
     u32 value = ReadFifo32(data);
 
-    if (mode == DECODE_RECORD)
+    if (mode == DecodeMode::Record)
       FifoRecordAnalyzer::ProcessLoadIndexedXf(value, array);
     break;
   }
@@ -229,7 +229,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
       int vertexSize = offset;
       int numVertices = ReadFifo16(data);
 
-      if (mode == DECODE_RECORD && numVertices > 0)
+      if (mode == DecodeMode::Record && numVertices > 0)
       {
         for (int i = 0; i < 12; ++i)
         {

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -20,29 +20,129 @@
 
 namespace FifoAnalyzer
 {
-bool s_DrawingObject;
-FifoAnalyzer::CPMemory s_CpMem;
-
+namespace
+{
 u8 ReadFifo8(const u8*& data)
 {
-  u8 value = data[0];
+  const u8 value = data[0];
   data += 1;
   return value;
 }
 
 u16 ReadFifo16(const u8*& data)
 {
-  u16 value = Common::swap16(data);
+  const u16 value = Common::swap16(data);
   data += 2;
   return value;
 }
 
 u32 ReadFifo32(const u8*& data)
 {
-  u32 value = Common::swap32(data);
+  const u32 value = Common::swap32(data);
   data += 4;
   return value;
 }
+
+void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMem)
+{
+  const TVtxDesc& vtxDesc = cpMem.vtxDesc;
+  const VAT& vtxAttr = cpMem.vtxAttr[vatIndex];
+
+  // Colors
+  const u64 colDesc[2] = {vtxDesc.Color0, vtxDesc.Color1};
+  const u32 colComp[2] = {vtxAttr.g0.Color0Comp, vtxAttr.g0.Color1Comp};
+
+  const u32 tcElements[8] = {vtxAttr.g0.Tex0CoordElements, vtxAttr.g1.Tex1CoordElements,
+                             vtxAttr.g1.Tex2CoordElements, vtxAttr.g1.Tex3CoordElements,
+                             vtxAttr.g1.Tex4CoordElements, vtxAttr.g2.Tex5CoordElements,
+                             vtxAttr.g2.Tex6CoordElements, vtxAttr.g2.Tex7CoordElements};
+
+  const u32 tcFormat[8] = {vtxAttr.g0.Tex0CoordFormat, vtxAttr.g1.Tex1CoordFormat,
+                           vtxAttr.g1.Tex2CoordFormat, vtxAttr.g1.Tex3CoordFormat,
+                           vtxAttr.g1.Tex4CoordFormat, vtxAttr.g2.Tex5CoordFormat,
+                           vtxAttr.g2.Tex6CoordFormat, vtxAttr.g2.Tex7CoordFormat};
+
+  // Add position and texture matrix indices
+  u64 vtxDescHex = cpMem.vtxDesc.Hex;
+  for (int i = 0; i < 9; ++i)
+  {
+    sizes[i] = vtxDescHex & 1;
+    vtxDescHex >>= 1;
+  }
+
+  // Position
+  sizes[9] = VertexLoader_Position::GetSize(vtxDesc.Position, vtxAttr.g0.PosFormat,
+                                            vtxAttr.g0.PosElements);
+
+  // Normals
+  if (vtxDesc.Normal != NOT_PRESENT)
+  {
+    sizes[10] = VertexLoader_Normal::GetSize(vtxDesc.Normal, vtxAttr.g0.NormalFormat,
+                                             vtxAttr.g0.NormalElements, vtxAttr.g0.NormalIndex3);
+  }
+  else
+  {
+    sizes[10] = 0;
+  }
+
+  // Colors
+  for (int i = 0; i < 2; i++)
+  {
+    int size = 0;
+
+    switch (colDesc[i])
+    {
+    case NOT_PRESENT:
+      break;
+    case DIRECT:
+      switch (colComp[i])
+      {
+      case FORMAT_16B_565:
+        size = 2;
+        break;
+      case FORMAT_24B_888:
+        size = 3;
+        break;
+      case FORMAT_32B_888x:
+        size = 4;
+        break;
+      case FORMAT_16B_4444:
+        size = 2;
+        break;
+      case FORMAT_24B_6666:
+        size = 3;
+        break;
+      case FORMAT_32B_8888:
+        size = 4;
+        break;
+      default:
+        ASSERT(0);
+        break;
+      }
+      break;
+    case INDEX8:
+      size = 1;
+      break;
+    case INDEX16:
+      size = 2;
+      break;
+    }
+
+    sizes[11 + i] = size;
+  }
+
+  // Texture coordinates
+  vtxDescHex = vtxDesc.Hex >> 17;
+  for (int i = 0; i < 8; i++)
+  {
+    sizes[13 + i] = VertexLoader_TextCoord::GetSize(vtxDescHex & 3, tcFormat[i], tcElements[i]);
+    vtxDescHex >>= 2;
+  }
+}
+}  // Anonymous namespace
+
+bool s_DrawingObject;
+FifoAnalyzer::CPMemory s_CpMem;
 
 u32 AnalyzeCommand(const u8* data, DecodeMode mode)
 {
@@ -186,103 +286,6 @@ void LoadCPReg(u32 subCmd, u32 value, CPMemory& cpMem)
   case 0xB0:
     cpMem.arrayStrides[subCmd & 0xF] = value & 0xFF;
     break;
-  }
-}
-
-void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMem)
-{
-  const TVtxDesc& vtxDesc = cpMem.vtxDesc;
-  const VAT& vtxAttr = cpMem.vtxAttr[vatIndex];
-
-  // Colors
-  const u64 colDesc[2] = {vtxDesc.Color0, vtxDesc.Color1};
-  const u32 colComp[2] = {vtxAttr.g0.Color0Comp, vtxAttr.g0.Color1Comp};
-
-  const u32 tcElements[8] = {vtxAttr.g0.Tex0CoordElements, vtxAttr.g1.Tex1CoordElements,
-                             vtxAttr.g1.Tex2CoordElements, vtxAttr.g1.Tex3CoordElements,
-                             vtxAttr.g1.Tex4CoordElements, vtxAttr.g2.Tex5CoordElements,
-                             vtxAttr.g2.Tex6CoordElements, vtxAttr.g2.Tex7CoordElements};
-
-  const u32 tcFormat[8] = {vtxAttr.g0.Tex0CoordFormat, vtxAttr.g1.Tex1CoordFormat,
-                           vtxAttr.g1.Tex2CoordFormat, vtxAttr.g1.Tex3CoordFormat,
-                           vtxAttr.g1.Tex4CoordFormat, vtxAttr.g2.Tex5CoordFormat,
-                           vtxAttr.g2.Tex6CoordFormat, vtxAttr.g2.Tex7CoordFormat};
-
-  // Add position and texture matrix indices
-  u64 vtxDescHex = cpMem.vtxDesc.Hex;
-  for (int i = 0; i < 9; ++i)
-  {
-    sizes[i] = vtxDescHex & 1;
-    vtxDescHex >>= 1;
-  }
-
-  // Position
-  sizes[9] = VertexLoader_Position::GetSize(vtxDesc.Position, vtxAttr.g0.PosFormat,
-                                            vtxAttr.g0.PosElements);
-
-  // Normals
-  if (vtxDesc.Normal != NOT_PRESENT)
-  {
-    sizes[10] = VertexLoader_Normal::GetSize(vtxDesc.Normal, vtxAttr.g0.NormalFormat,
-                                             vtxAttr.g0.NormalElements, vtxAttr.g0.NormalIndex3);
-  }
-  else
-  {
-    sizes[10] = 0;
-  }
-
-  // Colors
-  for (int i = 0; i < 2; i++)
-  {
-    int size = 0;
-
-    switch (colDesc[i])
-    {
-    case NOT_PRESENT:
-      break;
-    case DIRECT:
-      switch (colComp[i])
-      {
-      case FORMAT_16B_565:
-        size = 2;
-        break;
-      case FORMAT_24B_888:
-        size = 3;
-        break;
-      case FORMAT_32B_888x:
-        size = 4;
-        break;
-      case FORMAT_16B_4444:
-        size = 2;
-        break;
-      case FORMAT_24B_6666:
-        size = 3;
-        break;
-      case FORMAT_32B_8888:
-        size = 4;
-        break;
-      default:
-        ASSERT(0);
-        break;
-      }
-      break;
-    case INDEX8:
-      size = 1;
-      break;
-    case INDEX16:
-      size = 2;
-      break;
-    }
-
-    sizes[11 + i] = size;
-  }
-
-  // Texture coordinates
-  vtxDescHex = vtxDesc.Hex >> 17;
-  for (int i = 0; i < 8; i++)
-  {
-    sizes[13 + i] = VertexLoader_TextCoord::GetSize(vtxDescHex & 3, tcFormat[i], tcElements[i]);
-    vtxDescHex >>= 2;
   }
 }
 }  // namespace FifoAnalyzer

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -4,10 +4,10 @@
 
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 
-#include <algorithm>
 #include <numeric>
 
 #include "Common/Assert.h"
+#include "Common/MsgHandler.h"
 #include "Common/Swap.h"
 
 #include "Core/FifoPlayer/FifoRecordAnalyzer.h"
@@ -43,24 +43,33 @@ u32 ReadFifo32(const u8*& data)
   return value;
 }
 
-void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMem)
+std::array<int, 21> CalculateVertexElementSizes(int vatIndex, const CPMemory& cpMem)
 {
   const TVtxDesc& vtxDesc = cpMem.vtxDesc;
   const VAT& vtxAttr = cpMem.vtxAttr[vatIndex];
 
   // Colors
-  const u64 colDesc[2] = {vtxDesc.Color0, vtxDesc.Color1};
-  const u32 colComp[2] = {vtxAttr.g0.Color0Comp, vtxAttr.g0.Color1Comp};
+  const std::array<u64, 2> colDesc{
+      vtxDesc.Color0,
+      vtxDesc.Color1,
+  };
+  const std::array<u32, 2> colComp{
+      vtxAttr.g0.Color0Comp,
+      vtxAttr.g0.Color1Comp,
+  };
 
-  const u32 tcElements[8] = {vtxAttr.g0.Tex0CoordElements, vtxAttr.g1.Tex1CoordElements,
-                             vtxAttr.g1.Tex2CoordElements, vtxAttr.g1.Tex3CoordElements,
-                             vtxAttr.g1.Tex4CoordElements, vtxAttr.g2.Tex5CoordElements,
-                             vtxAttr.g2.Tex6CoordElements, vtxAttr.g2.Tex7CoordElements};
+  const std::array<u32, 8> tcElements{
+      vtxAttr.g0.Tex0CoordElements, vtxAttr.g1.Tex1CoordElements, vtxAttr.g1.Tex2CoordElements,
+      vtxAttr.g1.Tex3CoordElements, vtxAttr.g1.Tex4CoordElements, vtxAttr.g2.Tex5CoordElements,
+      vtxAttr.g2.Tex6CoordElements, vtxAttr.g2.Tex7CoordElements,
+  };
+  const std::array<u32, 8> tcFormat{
+      vtxAttr.g0.Tex0CoordFormat, vtxAttr.g1.Tex1CoordFormat, vtxAttr.g1.Tex2CoordFormat,
+      vtxAttr.g1.Tex3CoordFormat, vtxAttr.g1.Tex4CoordFormat, vtxAttr.g2.Tex5CoordFormat,
+      vtxAttr.g2.Tex6CoordFormat, vtxAttr.g2.Tex7CoordFormat,
+  };
 
-  const u32 tcFormat[8] = {vtxAttr.g0.Tex0CoordFormat, vtxAttr.g1.Tex1CoordFormat,
-                           vtxAttr.g1.Tex2CoordFormat, vtxAttr.g1.Tex3CoordFormat,
-                           vtxAttr.g1.Tex4CoordFormat, vtxAttr.g2.Tex5CoordFormat,
-                           vtxAttr.g2.Tex6CoordFormat, vtxAttr.g2.Tex7CoordFormat};
+  std::array<int, 21> sizes{};
 
   // Add position and texture matrix indices
   u64 vtxDescHex = cpMem.vtxDesc.Hex;
@@ -86,7 +95,7 @@ void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMe
   }
 
   // Colors
-  for (int i = 0; i < 2; i++)
+  for (size_t i = 0; i < colDesc.size(); i++)
   {
     int size = 0;
 
@@ -133,11 +142,13 @@ void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMe
 
   // Texture coordinates
   vtxDescHex = vtxDesc.Hex >> 17;
-  for (int i = 0; i < 8; i++)
+  for (size_t i = 0; i < tcFormat.size(); i++)
   {
     sizes[13 + i] = VertexLoader_TextCoord::GetSize(vtxDescHex & 3, tcFormat[i], tcElements[i]);
     vtxDescHex >>= 2;
   }
+
+  return sizes;
 }
 }  // Anonymous namespace
 
@@ -213,27 +224,28 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
     {
       s_DrawingObject = true;
 
-      int sizes[21];
-      CalculateVertexElementSizes(sizes, cmd & OpcodeDecoder::GX_VAT_MASK, s_CpMem);
+      const std::array<int, 21> sizes =
+          CalculateVertexElementSizes(cmd & OpcodeDecoder::GX_VAT_MASK, s_CpMem);
 
       // Determine offset of each element that might be a vertex array
       // The first 9 elements are never vertex arrays so we just accumulate their sizes.
-      int offsets[12];
-      int offset = std::accumulate(&sizes[0], &sizes[9], 0u);
-      for (int i = 0; i < 12; ++i)
+      int offset = std::accumulate(sizes.begin(), sizes.begin() + 9, 0u);
+      std::array<int, 12> offsets;
+      for (size_t i = 0; i < offsets.size(); ++i)
       {
         offsets[i] = offset;
         offset += sizes[i + 9];
       }
 
-      int vertexSize = offset;
-      int numVertices = ReadFifo16(data);
+      const int vertexSize = offset;
+      const int numVertices = ReadFifo16(data);
 
       if (mode == DecodeMode::Record && numVertices > 0)
       {
-        for (int i = 0; i < 12; ++i)
+        for (size_t i = 0; i < offsets.size(); ++i)
         {
-          FifoRecordAnalyzer::WriteVertexArray(i, data + offsets[i], vertexSize, numVertices);
+          FifoRecordAnalyzer::WriteVertexArray(static_cast<int>(i), data + offsets[i], vertexSize,
+                                               numVertices);
         }
       }
 

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -10,10 +10,6 @@
 
 namespace FifoAnalyzer
 {
-u8 ReadFifo8(const u8*& data);
-u16 ReadFifo16(const u8*& data);
-u32 ReadFifo32(const u8*& data);
-
 enum DecodeMode
 {
   DECODE_RECORD,
@@ -31,8 +27,6 @@ struct CPMemory
 };
 
 void LoadCPReg(u32 subCmd, u32 value, CPMemory& cpMem);
-
-void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMem);
 
 extern bool s_DrawingObject;
 extern FifoAnalyzer::CPMemory s_CpMem;

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -10,10 +10,10 @@
 
 namespace FifoAnalyzer
 {
-enum DecodeMode
+enum class DecodeMode
 {
-  DECODE_RECORD,
-  DECODE_PLAYBACK,
+  Record,
+  Playback,
 };
 
 u32 AnalyzeCommand(const u8* data, DecodeMode mode);

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include "Common/CommonTypes.h"
+#include <array>
 
+#include "Common/CommonTypes.h"
 #include "VideoCommon/CPMemory.h"
 
 namespace FifoAnalyzer
@@ -21,9 +22,9 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode);
 struct CPMemory
 {
   TVtxDesc vtxDesc;
-  VAT vtxAttr[8];
-  u32 arrayBases[16];
-  u32 arrayStrides[16];
+  std::array<VAT, 8> vtxAttr;
+  std::array<u32, 16> arrayBases;
+  std::array<u32, 16> arrayStrides;
 };
 
 void LoadCPReg(u32 subCmd, u32 value, CPMemory& cpMem);

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
@@ -63,9 +63,9 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file,
         ++nextMemUpdate;
       }
 
-      bool wasDrawing = s_DrawingObject;
-
-      u32 cmdSize = FifoAnalyzer::AnalyzeCommand(&frame.fifoData[cmdStart], DECODE_PLAYBACK);
+      const bool wasDrawing = s_DrawingObject;
+      const u32 cmdSize =
+          FifoAnalyzer::AnalyzeCommand(&frame.fifoData[cmdStart], DecodeMode::Playback);
 
 #if LOG_FIFO_CMDS
       CmdData cmdData;

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -5,7 +5,6 @@
 #include "Core/FifoPlayer/FifoRecordAnalyzer.h"
 
 #include <algorithm>
-#include <cstring>
 
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
@@ -22,8 +21,13 @@ void FifoRecordAnalyzer::Initialize(const u32* cpMem)
   for (int i = 0; i < 8; ++i)
     FifoAnalyzer::LoadCPReg(0x70 + i, *(cpMem + 0x70 + i), s_CpMem);
 
-  memcpy(s_CpMem.arrayBases, cpMem + 0xA0, 16 * 4);
-  memcpy(s_CpMem.arrayStrides, cpMem + 0xB0, 16 * 4);
+  const u32* const bases_start = cpMem + 0xA0;
+  const u32* const bases_end = bases_start + s_CpMem.arrayBases.size();
+  std::copy(bases_start, bases_end, s_CpMem.arrayBases.begin());
+
+  const u32* const strides_start = cpMem + 0xB0;
+  const u32* const strides_end = strides_start + s_CpMem.arrayStrides.size();
+  std::copy(strides_start, strides_end, s_CpMem.arrayStrides.begin());
 }
 
 void FifoRecordAnalyzer::ProcessLoadIndexedXf(u32 val, int array)

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -77,12 +77,14 @@ void FifoRecorder::WriteGPCommand(const u8* data, u32 size)
   {
     // Assumes data contains all information for the command
     // Calls FifoRecorder::UseMemory
-    u32 analyzed_size = FifoAnalyzer::AnalyzeCommand(data, FifoAnalyzer::DECODE_RECORD);
+    const u32 analyzed_size = FifoAnalyzer::AnalyzeCommand(data, FifoAnalyzer::DecodeMode::Record);
 
     // Make sure FifoPlayer's command analyzer agrees about the size of the command.
     if (analyzed_size != size)
+    {
       PanicAlert("FifoRecorder: Expected command to be %i bytes long, we were given %i bytes",
                  analyzed_size, size);
+    }
 
     // Copy data to buffer
     size_t currentSize = m_FifoData.size();


### PR DESCRIPTION
Tidies up the interface by hiding functions that don't need to be exposed, making them internally linked. While we're at it, we can convert the `DecodeMode` enum over to be an enum class and make use of `std::array` to help with dehardcoding sizes (and prevent implicit array->pointer decay).

The diff is larger than usual for this change due to one function needing to be relocated once it was made internally linked. This is part of the first commit, so I'd suggest reviewing the final two commits by themselves.