### PR TITLE
Core/HW/AddressSpace: Remove unnecessary inclusion of Core.h

### DIFF
--- a/Source/Core/Core/HW/AddressSpace.h
+++ b/Source/Core/Core/HW/AddressSpace.h
@@ -6,7 +6,7 @@
 
 #include <optional>
 
-#include "Core/Core.h"
+#include "Common/CommonTypes.h"
 
 namespace AddressSpace
 {

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 
 #include "Core/Core.h"
+#include "Core/HW/AddressSpace.h"
 #include "Core/PowerPC/BreakPoints.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "DolphinQt/Resources.h"

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.h
@@ -7,7 +7,11 @@
 #include <QTableWidget>
 
 #include "Common/CommonTypes.h"
-#include "Core/HW/AddressSpace.h"
+
+namespace AddressSpace
+{
+enum class Type;
+}
 
 class MemoryViewWidget : public QTableWidget
 {
@@ -59,7 +63,7 @@ private:
   void OnCopyAddress();
   void OnCopyHex();
 
-  AddressSpace::Type m_address_space = AddressSpace::Type::Effective;
+  AddressSpace::Type m_address_space{};
   Type m_type = Type::U8;
   BPType m_bp_type = BPType::ReadWrite;
   bool m_do_log = true;

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -23,6 +23,7 @@
 #include "Common/File.h"
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
+#include "Core/HW/AddressSpace.h"
 #include "DolphinQt/Debugger/MemoryViewWidget.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Settings.h"

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.h
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.h
@@ -9,7 +9,6 @@
 #include <QDockWidget>
 
 #include "Common/CommonTypes.h"
-#include "Core/HW/AddressSpace.h"
 
 class MemoryViewWidget;
 class QCheckBox;


### PR DESCRIPTION
This is only included to satisfy the use of our type aliases. Given that, we can just include CommonTypes.h, lessening dependencies on core headers.

While we're at it, we can use a forward declaration to move inclusions of AddressSpace.h itself into cpp files where it's needed.