### PR TITLE
VideoCommon: Remove unused MathUtil.h include from VideoCommon.h

### DIFF
--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -8,6 +8,7 @@
 #include "Common/Logging/Log.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoCommon/RenderBase.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace DX11
 {

--- a/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
@@ -2,14 +2,16 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D12/PerfQuery.h"
+
 #include <algorithm>
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
 #include "VideoBackends/D3D12/Common.h"
 #include "VideoBackends/D3D12/DXContext.h"
-#include "VideoBackends/D3D12/PerfQuery.h"
 #include "VideoBackends/D3D12/Renderer.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace DX12
 {

--- a/Source/Core/VideoBackends/D3DCommon/Common.h
+++ b/Source/Core/VideoBackends/D3DCommon/Common.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "VideoCommon/VideoCommon.h"
 
 struct IDXGIFactory;
 

--- a/Source/Core/VideoBackends/OGL/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/OGL/PerfQuery.cpp
@@ -2,13 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/OGL/PerfQuery.h"
+
 #include <memory>
 
 #include "Common/CommonTypes.h"
 #include "Common/GL/GLExtensions/GLExtensions.h"
 
-#include "VideoBackends/OGL/PerfQuery.h"
 #include "VideoBackends/OGL/Render.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace OGL

--- a/Source/Core/VideoBackends/Software/DebugUtil.cpp
+++ b/Source/Core/VideoBackends/Software/DebugUtil.cpp
@@ -18,6 +18,7 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/Statistics.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DebugUtil

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -12,12 +12,12 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Common/Swap.h"
 
 #include "VideoBackends/Software/CopyRegion.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/PerfQueryBase.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace EfbInterface
 {

--- a/Source/Core/VideoBackends/Software/EfbInterface.h
+++ b/Source/Core/VideoBackends/Software/EfbInterface.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 #include "VideoCommon/PerfQueryBase.h"
-#include "VideoCommon/VideoCommon.h"
 
 namespace EfbInterface
 {

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -2,16 +2,18 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/Software/Rasterizer.h"
+
 #include <algorithm>
 #include <cstring>
 
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Software/EfbInterface.h"
 #include "VideoBackends/Software/NativeVertexFormat.h"
-#include "VideoBackends/Software/Rasterizer.h"
 #include "VideoBackends/Software/Tev.h"
 #include "VideoCommon/PerfQueryBase.h"
 #include "VideoCommon/Statistics.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 

--- a/Source/Core/VideoBackends/Software/SWOGLWindow.h
+++ b/Source/Core/VideoBackends/Software/SWOGLWindow.h
@@ -5,15 +5,12 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "Common/CommonTypes.h"
-#include "VideoCommon/VideoCommon.h"
-
-class GLContext;
+#include "Common/MathUtil.h"
 
 class AbstractTexture;
+class GLContext;
 struct WindowSystemInfo;
 
 class SWOGLWindow

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -9,7 +9,6 @@
 #include "Common/CommonTypes.h"
 #include "Common/GL/GLContext.h"
 
-#include "Core/Config/GraphicsSettings.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoBackends/Software/EfbCopy.h"
@@ -22,9 +21,8 @@
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/NativeVertexFormat.h"
-#include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoBackendBase.h"
-#include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace SW
 {

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/Software/Tev.h"
+
 #include <algorithm>
 #include <cmath>
 
@@ -9,13 +11,13 @@
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Software/DebugUtil.h"
 #include "VideoBackends/Software/EfbInterface.h"
-#include "VideoBackends/Software/Tev.h"
 #include "VideoBackends/Software/TextureSampler.h"
 
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/PerfQueryBase.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 

--- a/Source/Core/VideoBackends/Software/TextureEncoder.h
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 #include "VideoCommon/TextureCacheBase.h"
-#include "VideoCommon/VideoCommon.h"
 
 namespace TextureEncoder
 {

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -19,8 +19,6 @@
 #include "Common/Flag.h"
 #include "Common/Semaphore.h"
 
-#include "VideoCommon/VideoCommon.h"
-
 #include "VideoBackends/Vulkan/Constants.h"
 
 namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
@@ -16,6 +16,7 @@
 #include "VideoBackends/Vulkan/Renderer.h"
 #include "VideoBackends/Vulkan/StateTracker.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace Vulkan
 {

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -14,6 +14,7 @@
 
 #include "VideoBackends/Vulkan/VulkanContext.h"
 #include "VideoCommon/DriverDetails.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace Vulkan
 {

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -2,13 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/BPFunctions.h"
+
 #include <algorithm>
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
 #include "VideoCommon/AbstractFramebuffer.h"
-#include "VideoCommon/BPFunctions.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/RenderBase.h"

--- a/Source/Core/VideoCommon/BPFunctions.h
+++ b/Source/Core/VideoCommon/BPFunctions.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "VideoCommon/VideoCommon.h"
+#include "Common/MathUtil.h"
 
 struct BPCmd;
 

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/PostProcessing.h"
+
 #include <sstream>
 #include <string>
 
@@ -20,7 +22,6 @@
 #include "VideoCommon/AbstractShader.h"
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/FramebufferManager.h"
-#include "VideoCommon/PostProcessing.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/ShaderCache.h"
 #include "VideoCommon/VertexManagerBase.h"

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -5,17 +5,18 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 #include "Common/Timer.h"
 #include "VideoCommon/TextureConfig.h"
-#include "VideoCommon/VideoCommon.h"
 
-class AbstractTexture;
 class AbstractPipeline;
 class AbstractShader;
+class AbstractTexture;
 
 namespace VideoCommon
 {

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <tuple>
 
-#include "imgui.h"
+#include <imgui.h>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
@@ -74,6 +74,7 @@
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 
@@ -87,7 +88,9 @@ static float AspectToWidescreen(float aspect)
 Renderer::Renderer(int backbuffer_width, int backbuffer_height, float backbuffer_scale,
                    AbstractTextureFormat backbuffer_format)
     : m_backbuffer_width(backbuffer_width), m_backbuffer_height(backbuffer_height),
-      m_backbuffer_scale(backbuffer_scale), m_backbuffer_format(backbuffer_format)
+      m_backbuffer_scale(backbuffer_scale),
+      m_backbuffer_format(backbuffer_format), m_last_xfb_width{MAX_XFB_WIDTH}, m_last_xfb_height{
+                                                                                   MAX_XFB_HEIGHT}
 {
   UpdateActiveConfig();
   UpdateDrawRectangle();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -33,7 +33,6 @@
 #include "VideoCommon/FrameDump.h"
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/TextureConfig.h"
-#include "VideoCommon/VideoCommon.h"
 
 class AbstractFramebuffer;
 class AbstractPipeline;
@@ -359,8 +358,8 @@ private:
   u64 m_last_xfb_id = std::numeric_limits<u64>::max();
 
   // Note: Only used for auto-ir
-  u32 m_last_xfb_width = MAX_XFB_WIDTH;
-  u32 m_last_xfb_height = MAX_XFB_HEIGHT;
+  u32 m_last_xfb_width = 0;
+  u32 m_last_xfb_height = 0;
 
   // NOTE: The methods below are called on the framedumping thread.
   bool StartFrameDumpToFFMPEG(const FrameDumpConfig& config);

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -8,6 +8,7 @@
 
 #include <imgui.h>
 
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 Statistics g_stats;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -16,15 +16,15 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/MathUtil.h"
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/TextureConfig.h"
 #include "VideoCommon/TextureDecoder.h"
-#include "VideoCommon/VideoCommon.h"
 
-struct VideoConfig;
 class AbstractFramebuffer;
 class AbstractStagingTexture;
+struct VideoConfig;
 
 struct TextureAndTLUTFormat
 {

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -16,7 +16,6 @@
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
-#include "Core/Host.h"
 
 // TODO: ugly
 #ifdef _WIN32
@@ -35,7 +34,6 @@
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/GeometryShaderManager.h"
 #include "VideoCommon/IndexGenerator.h"
-#include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -43,6 +41,7 @@
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoState.h"
 

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -3,8 +3,8 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include "Common/CommonTypes.h"
-#include "Common/MathUtil.h"
 
 // Global flag to signal if FifoRecorder is active.
 extern bool g_bRecordFifoData;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -14,7 +14,8 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "VideoCommon/VideoCommon.h"
+
+enum class APIType;
 
 // Log in two categories, and save three other options in the same byte
 #define CONF_LOG 1


### PR DESCRIPTION
This header doesn't actually make use of MathUtil.h within itself, so this can be removed. Many other source files used VideoCommon.h as an indirect include to include MathUtil.h, so these includes can also be adjusted.

While we're at it, we can also migrate valid inclusions of VideoCommon.h into cpp files where it can feasibly be done to minimize propagating it via other headers.