### PR TITLE
Re-implement FixCommonKeyIndex for WAD files

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -767,11 +767,10 @@ ReturnCode ES::SetUpStreamKey(const u32 uid, const u8* ticket_view, const IOS::E
     return ret;
 
   const u8 index = ticket_bytes[offsetof(IOS::ES::Ticket, common_key_index)];
-  if (index > 1)
+  if (index >= IOSC::COMMON_KEY_HANDLES.size())
     return ES_INVALID_TICKET;
 
-  auto common_key_handle = index == 0 ? IOSC::HANDLE_COMMON_KEY : IOSC::HANDLE_NEW_COMMON_KEY;
-  return m_ios.GetIOSC().ImportSecretKey(*handle, common_key_handle, iv.data(),
+  return m_ios.GetIOSC().ImportSecretKey(*handle, IOSC::COMMON_KEY_HANDLES[index], iv.data(),
                                          &ticket_bytes[offsetof(IOS::ES::Ticket, title_key)],
                                          PID_ES);
 }

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -455,8 +455,8 @@ std::array<u8, 16> TicketReader::GetTitleKey(const HLE::IOSC& iosc) const
   u8 index = m_bytes.at(offsetof(Ticket, common_key_index));
   if (index >= HLE::IOSC::COMMON_KEY_HANDLES.size())
   {
-    WARN_LOG(IOS_ES, "Bad common key index for title %016" PRIx64 ": %u -- using common key 0",
-             GetTitleId(), index);
+    PanicAlert("Bad common key index for title %016" PRIx64 ": %u -- using common key 0",
+               GetTitleId(), index);
     index = 0;
   }
   auto common_key_handle = HLE::IOSC::COMMON_KEY_HANDLES[index];
@@ -533,11 +533,9 @@ HLE::ReturnCode TicketReader::Unpersonalise(HLE::IOSC& iosc)
   return ret;
 }
 
-void TicketReader::FixCommonKeyIndex()
+void TicketReader::OverwriteCommonKeyIndex(u8 index)
 {
-  u8& index = m_bytes[offsetof(Ticket, common_key_index)];
-  // Assume the ticket is using the normal common key if it's an invalid value.
-  index = index < HLE::IOSC::COMMON_KEY_HANDLES.size() ? index : 0;
+  m_bytes[offsetof(Ticket, common_key_index)] = index;
 }
 
 struct SharedContentMap::Entry

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -452,14 +452,14 @@ std::array<u8, 16> TicketReader::GetTitleKey(const HLE::IOSC& iosc) const
   u8 iv[16] = {};
   std::copy_n(&m_bytes[offsetof(Ticket, title_id)], sizeof(Ticket::title_id), iv);
 
-  const u8 index = m_bytes.at(offsetof(Ticket, common_key_index));
-  auto common_key_handle =
-      index != 1 ? HLE::IOSC::HANDLE_COMMON_KEY : HLE::IOSC::HANDLE_NEW_COMMON_KEY;
-  if (index != 0 && index != 1)
+  u8 index = m_bytes.at(offsetof(Ticket, common_key_index));
+  if (index >= HLE::IOSC::COMMON_KEY_HANDLES.size())
   {
     WARN_LOG(IOS_ES, "Bad common key index for title %016" PRIx64 ": %u -- using common key 0",
              GetTitleId(), index);
+    index = 0;
   }
+  auto common_key_handle = HLE::IOSC::COMMON_KEY_HANDLES[index];
 
   std::array<u8, 16> key;
   iosc.Decrypt(common_key_handle, iv, &m_bytes[offsetof(Ticket, title_key)], 16, key.data(),
@@ -537,7 +537,7 @@ void TicketReader::FixCommonKeyIndex()
 {
   u8& index = m_bytes[offsetof(Ticket, common_key_index)];
   // Assume the ticket is using the normal common key if it's an invalid value.
-  index = index <= 1 ? index : 0;
+  index = index < HLE::IOSC::COMMON_KEY_HANDLES.size() ? index : 0;
 }
 
 struct SharedContentMap::Entry

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -257,9 +257,8 @@ public:
   // and has a title key that must be decrypted first.
   HLE::ReturnCode Unpersonalise(HLE::IOSC& iosc);
 
-  // Reset the common key field back to 0 if it's an incorrect value.
   // Intended for use before importing fakesigned tickets, which tend to have a high bogus index.
-  void FixCommonKeyIndex();
+  void OverwriteCommonKeyIndex(u8 index);
 };
 
 class SharedContentMap final

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -198,12 +198,11 @@ static ReturnCode InitTitleImportKey(const std::vector<u8>& ticket_bytes, IOSC& 
   std::array<u8, 16> iv{};
   std::copy_n(&ticket_bytes[offsetof(IOS::ES::Ticket, title_id)], sizeof(u64), iv.begin());
   const u8 index = ticket_bytes[offsetof(IOS::ES::Ticket, common_key_index)];
-  if (index > 1)
+  if (index >= IOSC::COMMON_KEY_HANDLES.size())
     return ES_INVALID_TICKET;
 
-  return iosc.ImportSecretKey(
-      *handle, index == 0 ? IOSC::HANDLE_COMMON_KEY : IOSC::HANDLE_NEW_COMMON_KEY, iv.data(),
-      &ticket_bytes[offsetof(IOS::ES::Ticket, title_key)], PID_ES);
+  return iosc.ImportSecretKey(*handle, IOSC::COMMON_KEY_HANDLES[index], iv.data(),
+                              &ticket_bytes[offsetof(IOS::ES::Ticket, title_key)], PID_ES);
 }
 
 ReturnCode ES::ImportTitleInit(Context& context, const std::vector<u8>& tmd_bytes,

--- a/Source/Core/Core/IOS/IOSC.h
+++ b/Source/Core/Core/IOS/IOSC.h
@@ -165,6 +165,9 @@ public:
     HANDLE_ROOT_KEY = 0xfffffff,
   };
 
+  static constexpr std::array<DefaultHandle, 2> COMMON_KEY_HANDLES = {HANDLE_COMMON_KEY,
+                                                                      HANDLE_NEW_COMMON_KEY};
+
   enum ObjectType : u8
   {
     TYPE_SECRET_KEY = 0,

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -61,9 +61,8 @@ static bool ImportWAD(IOS::HLE::Kernel& ios, const DiscIO::VolumeWAD& wad)
   IOS::HLE::ReturnCode ret;
   const bool checks_enabled = SConfig::GetInstance().m_enable_signature_checks;
 
-  IOS::ES::TicketReader ticket = wad.GetTicket();
   // Ensure the common key index is correct, as it's checked by IOS.
-  ticket.FixCommonKeyIndex();
+  IOS::ES::TicketReader ticket = wad.GetTicketWithFixedCommonKey();
 
   while ((ret = es->ImportTicket(ticket.GetBytes(), wad.GetCertificateChain(),
                                  IOS::HLE::Device::ES::TicketImportType::Unpersonalised)) < 0 ||

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -76,6 +76,12 @@ public:
   }
   virtual std::vector<u8> GetContent(u16 index) const { return {}; }
   virtual std::vector<u64> GetContentOffsets() const { return {}; }
+  virtual bool CheckContentIntegrity(const IOS::ES::Content& content, u64 content_offset,
+                                     const IOS::ES::TicketReader& ticket) const
+  {
+    return false;
+  }
+  virtual IOS::ES::TicketReader GetTicketWithFixedCommonKey() const { return {}; }
   // Returns a non-owning pointer. Returns nullptr if the file system couldn't be read.
   virtual const FileSystem* GetFileSystem(const Partition& partition) const = 0;
   virtual u64 PartitionOffsetToRawOffset(u64 offset, const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <unordered_set>
 
-#include <mbedtls/aes.h>
 #include <mbedtls/md5.h>
 #include <mbedtls/sha1.h>
 #include <zlib.h>
@@ -604,29 +603,33 @@ void VolumeVerifier::CheckMisc()
     }
   }
 
-  const IOS::ES::TicketReader& ticket = m_volume.GetTicket(m_volume.GetGamePartition());
-  if (ticket.IsValid())
+  m_ticket = m_volume.GetTicket(m_volume.GetGamePartition());
+  if (m_ticket.IsValid())
   {
-    const u8 common_key = ticket.GetCommonKeyIndex();
+    const u8 specified_common_key_index = m_ticket.GetCommonKeyIndex();
 
-    if (common_key > IOS::HLE::IOSC::COMMON_KEY_HANDLES.size())
+    // Wii discs only use common key 0 (regular) and common key 1 (Korean), not common key 2 (vWii).
+    if (m_volume.GetVolumeType() == Platform::WiiDisc && specified_common_key_index > 1)
     {
-      // Many fakesigned WADs have the common key index set to a (random?) bogus value.
-      // For WADs, Dolphin will detect this and use common key 0 instead, making this low severity.
-      const Severity severity =
-          m_volume.GetVolumeType() == Platform::WiiWAD ? Severity::Low : Severity::High;
-      // i18n: This is "common" as in "shared", not the opposite of "uncommon"
-      AddProblem(severity, Common::GetStringT("This title is set to use an invalid common key."));
-    }
-
-    if (common_key == 1 && region != Region::NTSC_K)
-    {
-      // Apparently a certain pirate WAD of Chronos Twins DX unluckily got an index of 1,
-      // which Dolphin does not change to 0 because 1 is valid on Korean Wiis.
-      // https://forums.dolphin-emu.org/Thread-wiiware-chronos-twins-dx
       AddProblem(Severity::High,
                  // i18n: This is "common" as in "shared", not the opposite of "uncommon"
-                 Common::GetStringT("This non-Korean title is set to use the Korean common key."));
+                 Common::GetStringT("This title is set to use an invalid common key."));
+    }
+
+    if (m_volume.GetVolumeType() == Platform::WiiWAD)
+    {
+      m_ticket = m_volume.GetTicketWithFixedCommonKey();
+      const u8 fixed_common_key_index = m_ticket.GetCommonKeyIndex();
+      if (specified_common_key_index != fixed_common_key_index)
+      {
+        // Many fakesigned WADs have the common key index set to a (random?) bogus value.
+        // For WADs, Dolphin will detect this and use the correct key, making this low severity.
+        std::string text = StringFromFormat(
+            // i18n: This is "common" as in "shared", not the opposite of "uncommon"
+            Common::GetStringT("The specified common key index is %u but should be %u.").c_str(),
+            specified_common_key_index, fixed_common_key_index);
+        AddProblem(Severity::Low, std::move(text));
+      }
     }
   }
 
@@ -737,7 +740,7 @@ void VolumeVerifier::Process()
 
   if (content_read)
   {
-    if (!CheckContentIntegrity(content))
+    if (!m_volume.CheckContentIntegrity(content, m_content_offsets[m_content_index], m_ticket))
     {
       AddProblem(
           Severity::High,
@@ -766,27 +769,6 @@ void VolumeVerifier::Process()
     }
     m_block_index++;
   }
-}
-
-bool VolumeVerifier::CheckContentIntegrity(const IOS::ES::Content& content)
-{
-  std::vector<u8> encrypted_data = m_volume.GetContent(content.index);
-
-  mbedtls_aes_context context;
-  const std::array<u8, 16> key = m_volume.GetTicket(PARTITION_NONE).GetTitleKey();
-  mbedtls_aes_setkey_dec(&context, key.data(), 128);
-
-  std::array<u8, 16> iv{};
-  iv[0] = static_cast<u8>(content.index >> 8);
-  iv[1] = static_cast<u8>(content.index & 0xFF);
-
-  std::vector<u8> decrypted_data(Common::AlignUp(content.size, 0x40));
-  mbedtls_aes_crypt_cbc(&context, MBEDTLS_AES_DECRYPT, decrypted_data.size(), iv.data(),
-                        encrypted_data.data(), decrypted_data.data());
-
-  std::array<u8, 20> sha1;
-  mbedtls_sha1_ret(decrypted_data.data(), content.size, sha1.data());
-  return sha1 == content.sha1;
 }
 
 u64 VolumeVerifier::GetBytesProcessed() const

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -609,7 +609,7 @@ void VolumeVerifier::CheckMisc()
   {
     const u8 common_key = ticket.GetCommonKeyIndex();
 
-    if (common_key > 1)
+    if (common_key > IOS::HLE::IOSC::COMMON_KEY_HANDLES.size())
     {
       // Many fakesigned WADs have the common key index set to a (random?) bogus value.
       // For WADs, Dolphin will detect this and use common key 0 instead, making this low severity.

--- a/Source/Core/DiscIO/VolumeVerifier.h
+++ b/Source/Core/DiscIO/VolumeVerifier.h
@@ -13,6 +13,7 @@
 #include <mbedtls/sha1.h>
 
 #include "Common/CommonTypes.h"
+#include "Core/IOS/ES/Formats.h"
 #include "DiscIO/DiscScrubber.h"
 #include "DiscIO/Volume.h"
 
@@ -28,12 +29,6 @@
 // Start, Process and Finish may take some time to run.
 //
 // GetResult() can be called before the processing is finished, but the result will be incomplete.
-
-namespace IOS::ES
-{
-struct Content;
-class SignedBlobReader;
-}  // namespace IOS::ES
 
 namespace DiscIO
 {
@@ -103,7 +98,6 @@ private:
   u64 GetBiggestUsedOffset(const FileInfo& file_info) const;
   void CheckMisc();
   void SetUpHashing();
-  bool CheckContentIntegrity(const IOS::ES::Content& content);
 
   void AddProblem(Severity severity, std::string text);
 
@@ -120,6 +114,7 @@ private:
   mbedtls_sha1_context m_sha1_context;
 
   DiscScrubber m_scrubber;
+  IOS::ES::TicketReader m_ticket;
   std::vector<u64> m_content_offsets;
   u16 m_content_index = 0;
   std::vector<BlockToVerify> m_blocks;

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -39,6 +39,9 @@ public:
   GetCertificateChain(const Partition& partition = PARTITION_NONE) const override;
   std::vector<u8> GetContent(u16 index) const override;
   std::vector<u64> GetContentOffsets() const override;
+  bool CheckContentIntegrity(const IOS::ES::Content& content, u64 content_offset,
+                             const IOS::ES::TicketReader& ticket) const override;
+  IOS::ES::TicketReader GetTicketWithFixedCommonKey() const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameTDBID(const Partition& partition = PARTITION_NONE) const override;
   std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;
@@ -63,6 +66,9 @@ public:
   u64 GetRawSize() const override;
 
 private:
+  bool CheckContentIntegrity(const IOS::ES::Content& content, const std::vector<u8>& encrypted_data,
+                             const IOS::ES::TicketReader& ticket) const;
+
   std::unique_ptr<BlobReader> m_reader;
   IOS::ES::TicketReader m_ticket;
   IOS::ES::TMDReader m_tmd;


### PR DESCRIPTION
The old implementation of this was not able to distinguish between a title that had the common key index set to 1 because it actually was Korean and a title that had the common key index set to 1 due to fakesigning. This new implementation solves the problem by decrypting a content with each possible common key and checking which result matches the provided SHA-1 hash.

The problem that the old implementation causes has only been reported to affect a certain pirated WAD of Chronos Twins DX (WC6EUP), but it's possible that the problem would start affecting more WADs if we add support for the vWii common key (which uses index 2). Adding support for the vWii common key would also prevent us from using the simpler solution of always forcing the index to 0 if the title is not Korean.

~~Dependent on PR #8243 (its commits are included in this PR).~~