### PR TITLE
Disable install button when the wad is already installed

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -337,13 +337,13 @@ void GameList::ShowContextMenu(const QPoint&)
       connect(wad_install_action, &QAction::triggered, this, &GameList::InstallWAD);
       connect(wad_uninstall_action, &QAction::triggered, this, &GameList::UninstallWAD);
 
-      for (QAction* a : {wad_install_action, wad_uninstall_action})
-      {
-        a->setEnabled(!Core::IsRunning());
-        menu->addAction(a);
-      }
-      if (!Core::IsRunning())
-        wad_uninstall_action->setEnabled(WiiUtils::IsTitleInstalled(game->GetTitleID()));
+      wad_install_action->setEnabled(!Core::IsRunning() &&
+                                     !WiiUtils::IsTitleInstalled(game->GetTitleID()));
+      wad_uninstall_action->setEnabled(!Core::IsRunning() &&
+                                       WiiUtils::IsTitleInstalled(game->GetTitleID()));
+
+      menu->addAction(wad_install_action);
+      menu->addAction(wad_uninstall_action);
 
       connect(&Settings::Instance(), &Settings::EmulationStateChanged, menu,
               [=](Core::State state) {


### PR DESCRIPTION
This fixes the issue of the install button being enabled while the wad is installed.
Old:
![wad (3)](https://user-images.githubusercontent.com/47903084/61502807-abfb1d80-a9d5-11e9-8454-2c8939ec900d.png)
New:
![wad_new (3)](https://user-images.githubusercontent.com/47903084/61502967-43f90700-a9d6-11e9-88b4-8084a68c8d49.png)


