### PR TITLE
Fixes to assertions

### DIFF
--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -15,7 +15,7 @@
   {                                                                                                \
     if (!(_a_))                                                                                    \
     {                                                                                              \
-      if (!PanicYesNo(_fmt_ "\n\nIgnore and continue?", __VA_ARGS__))                              \
+      if (!PanicYesNo(_fmt_, __VA_ARGS__))                                                         \
         Crash();                                                                                   \
     }                                                                                              \
   } while (0)

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -83,35 +83,27 @@ std::string GetStringT(const char* string)
 bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
 {
   // Read message and write it to the log
-  std::string caption;
+  const char* caption = "";
   char buffer[2048];
 
-  static std::string info_caption;
-  static std::string warn_caption;
-  static std::string ques_caption;
-  static std::string crit_caption;
-
-  if (info_caption.empty())
-  {
-    info_caption = s_str_translator(_trans("Information"));
-    ques_caption = s_str_translator(_trans("Question"));
-    warn_caption = s_str_translator(_trans("Warning"));
-    crit_caption = s_str_translator(_trans("Critical"));
-  }
+  static const std::string info_caption = s_str_translator(_trans("Information"));
+  static const std::string warn_caption = s_str_translator(_trans("Question"));
+  static const std::string ques_caption = s_str_translator(_trans("Warning"));
+  static const std::string crit_caption = s_str_translator(_trans("Critical"));
 
   switch (style)
   {
   case MsgType::Information:
-    caption = info_caption;
+    caption = info_caption.c_str();
     break;
   case MsgType::Question:
-    caption = ques_caption;
+    caption = ques_caption.c_str();
     break;
   case MsgType::Warning:
-    caption = warn_caption;
+    caption = warn_caption.c_str();
     break;
   case MsgType::Critical:
-    caption = crit_caption;
+    caption = crit_caption.c_str();
     break;
   }
 
@@ -120,13 +112,13 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
   CharArrayFromFormatV(buffer, sizeof(buffer) - 1, s_str_translator(format).c_str(), args);
   va_end(args);
 
-  ERROR_LOG(MASTER_LOG, "%s: %s", caption.c_str(), buffer);
+  ERROR_LOG(MASTER_LOG, "%s: %s", caption, buffer);
 
   // Don't ignore questions, especially AskYesNo, PanicYesNo could be ignored
   if (s_msg_handler != nullptr &&
       (s_alert_enabled || style == MsgType::Question || style == MsgType::Critical))
   {
-    return s_msg_handler(caption.c_str(), buffer, yes_no, style);
+    return s_msg_handler(caption, buffer, yes_no, style);
   }
 
   return true;

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -68,7 +68,10 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
       return true;
 
     if (button == QMessageBox::Ignore)
+    {
       Common::SetEnableAlert(false);
+      return true;
+    }
 
     return false;
   });


### PR DESCRIPTION
This PR fixes a few issues related to assertions. It consists of the following:
* On Windows, each assertion showed a "Ignore and continue?" message showed twice. This has been fixes.
* Improved thread safety of `MsgAlert`. Translated strings are now instantiated in a thread safe fashion. I don't know if this function should be thread safe, but even if not - this change improves readability.
* Clicking "Ignore for this session" on assertions would still return false from a message handler, as if user pressed "No". This effectively breaks on a breakpoint (despite the user telling to ignore it), and without a debugger attached - it kills the process. This made ignoring assertions impossible without having a debugger attached.

Before:
![image](https://user-images.githubusercontent.com/7947461/61583170-b67ff900-ab34-11e9-9b26-6a6d69b6b4a9.png)

After:
![image](https://user-images.githubusercontent.com/7947461/61583141-407b9200-ab34-11e9-9b0c-ed5e71e35009.png)
