### PR TITLE
Vulkan: Disable reversed viewport depth on macOS/MoltenVK

### DIFF
--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -111,6 +111,8 @@ constexpr BugInfo m_known_bugs[] = {
     {API_VULKAN, OS_ALL, VENDOR_MESA, DRIVER_I965, Family::UNKNOWN, BUG_BROKEN_REVERSED_DEPTH_RANGE,
      -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN,
+     BUG_BROKEN_REVERSED_DEPTH_RANGE, -1.0, -1.0, true},
+    {API_VULKAN, OS_OSX, VENDOR_ALL, DRIVER_PORTABILITY, Family::UNKNOWN,
      BUG_BROKEN_REVERSED_DEPTH_RANGE, -1.0, -1.0, true}};
 
 static std::map<Bug, BugInfo> m_bugs;


### PR DESCRIPTION
Apparently this is broken despite being allowed by the spec.