### PR TITLE
ConfigManager: Include "Common/Common.h" for _trans macro

### DIFF
--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
 class IniFile;


### PR DESCRIPTION
Aims to fix https://github.com/dolphin-emu/dolphin/pull/8232#issuecomment-513913625