### PR TITLE
Fixed behaviour of some buttons by connecting functors to correct signals

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -222,10 +222,10 @@ void CheatsManager::ConnectWidgets()
 {
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-  connect(m_match_new, &QPushButton::pressed, this, &CheatsManager::NewSearch);
-  connect(m_match_next, &QPushButton::pressed, this, &CheatsManager::NextSearch);
-  connect(m_match_refresh, &QPushButton::pressed, this, &CheatsManager::Update);
-  connect(m_match_reset, &QPushButton::pressed, this, &CheatsManager::Reset);
+  connect(m_match_new, &QPushButton::clicked, this, &CheatsManager::NewSearch);
+  connect(m_match_next, &QPushButton::clicked, this, &CheatsManager::NextSearch);
+  connect(m_match_refresh, &QPushButton::clicked, this, &CheatsManager::Update);
+  connect(m_match_reset, &QPushButton::clicked, this, &CheatsManager::Reset);
 
   m_match_table->setContextMenuPolicy(Qt::CustomContextMenu);
   m_watch_table->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -80,9 +80,9 @@ void ARCodeWidget::ConnectWidgets()
   connect(m_code_list, &QListWidget::customContextMenuRequested, this,
           &ARCodeWidget::OnContextMenuRequested);
 
-  connect(m_code_add, &QPushButton::pressed, this, &ARCodeWidget::OnCodeAddPressed);
-  connect(m_code_edit, &QPushButton::pressed, this, &ARCodeWidget::OnCodeEditPressed);
-  connect(m_code_remove, &QPushButton::pressed, this, &ARCodeWidget::OnCodeRemovePressed);
+  connect(m_code_add, &QPushButton::clicked, this, &ARCodeWidget::OnCodeAddClicked);
+  connect(m_code_edit, &QPushButton::clicked, this, &ARCodeWidget::OnCodeEditClicked);
+  connect(m_code_remove, &QPushButton::clicked, this, &ARCodeWidget::OnCodeRemoveClicked);
 }
 
 void ARCodeWidget::OnItemChanged(QListWidgetItem* item)
@@ -183,7 +183,7 @@ void ARCodeWidget::AddCode(ActionReplay::ARCode code)
   SaveCodes();
 }
 
-void ARCodeWidget::OnCodeAddPressed()
+void ARCodeWidget::OnCodeAddClicked()
 {
   ActionReplay::ARCode ar;
   ar.active = true;
@@ -201,7 +201,7 @@ void ARCodeWidget::OnCodeAddPressed()
   }
 }
 
-void ARCodeWidget::OnCodeEditPressed()
+void ARCodeWidget::OnCodeEditClicked()
 {
   auto items = m_code_list->selectedItems();
 
@@ -228,7 +228,7 @@ void ARCodeWidget::OnCodeEditPressed()
   UpdateList();
 }
 
-void ARCodeWidget::OnCodeRemovePressed()
+void ARCodeWidget::OnCodeRemoveClicked()
 {
   auto items = m_code_list->selectedItems();
 

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -45,9 +45,9 @@ private:
   void SaveCodes();
   void SortAlphabetically();
 
-  void OnCodeAddPressed();
-  void OnCodeEditPressed();
-  void OnCodeRemovePressed();
+  void OnCodeAddClicked();
+  void OnCodeEditClicked();
+  void OnCodeRemoveClicked();
 
   void OnListReordered();
 

--- a/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
@@ -80,6 +80,6 @@ void CheatWarningWidget::Update(bool running)
 
 void CheatWarningWidget::ConnectWidgets()
 {
-  connect(m_config_button, &QPushButton::pressed, this,
+  connect(m_config_button, &QPushButton::clicked, this,
           &CheatWarningWidget::OpenCheatEnableSettings);
 }

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -204,7 +204,7 @@ void GameConfigWidget::CreateWidgets()
 void GameConfigWidget::ConnectWidgets()
 {
   // Buttons
-  connect(m_refresh_config, &QPushButton::pressed, this, &GameConfigWidget::LoadSettings);
+  connect(m_refresh_config, &QPushButton::clicked, this, &GameConfigWidget::LoadSettings);
 
   for (QCheckBox* box : {m_enable_dual_core, m_enable_mmu, m_enable_fprf, m_sync_gpu,
                          m_enable_fast_disc, m_use_dsp_hle, m_use_monoscopic_shadows})

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -125,10 +125,10 @@ void GeckoCodeWidget::ConnectWidgets()
   connect(m_code_list, &QListWidget::customContextMenuRequested, this,
           &GeckoCodeWidget::OnContextMenuRequested);
 
-  connect(m_add_code, &QPushButton::pressed, this, &GeckoCodeWidget::AddCode);
-  connect(m_remove_code, &QPushButton::pressed, this, &GeckoCodeWidget::RemoveCode);
-  connect(m_edit_code, &QPushButton::pressed, this, &GeckoCodeWidget::EditCode);
-  connect(m_download_codes, &QPushButton::pressed, this, &GeckoCodeWidget::DownloadCodes);
+  connect(m_add_code, &QPushButton::clicked, this, &GeckoCodeWidget::AddCode);
+  connect(m_remove_code, &QPushButton::clicked, this, &GeckoCodeWidget::RemoveCode);
+  connect(m_edit_code, &QPushButton::clicked, this, &GeckoCodeWidget::EditCode);
+  connect(m_download_codes, &QPushButton::clicked, this, &GeckoCodeWidget::DownloadCodes);
   connect(m_warning, &CheatWarningWidget::OpenCheatEnableSettings, this,
           &GeckoCodeWidget::OpenGeneralSettings);
 }

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -145,7 +145,7 @@ void EnhancementsWidget::ConnectWidgets()
 
             SaveSettings();
           });
-  connect(m_configure_pp_effect, &QPushButton::pressed, this,
+  connect(m_configure_pp_effect, &QPushButton::clicked, this,
           &EnhancementsWidget::ConfigurePostProcessingShader);
 }
 

--- a/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
+++ b/Source/Core/DolphinQt/Config/NewPatchDialog.cpp
@@ -71,7 +71,7 @@ void NewPatchDialog::ConnectWidgets()
   connect(m_name_edit, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textEdited),
           [this](const QString& name) { m_patch.name = name.toStdString(); });
 
-  connect(m_add_button, &QPushButton::pressed, this, &NewPatchDialog::AddEntry);
+  connect(m_add_button, &QPushButton::clicked, this, &NewPatchDialog::AddEntry);
 
   connect(m_button_box, &QDialogButtonBox::accepted, this, &NewPatchDialog::accept);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
@@ -164,7 +164,7 @@ QGroupBox* NewPatchDialog::CreateEntry(PatchEngine::PatchEntry& entry)
             value->setPalette(palette);
           });
 
-  connect(remove, &QPushButton::pressed, [this, box, entry] {
+  connect(remove, &QPushButton::clicked, [this, box, entry] {
     if (m_patch.entries.size() > 1)
     {
       box->setVisible(false);

--- a/Source/Core/DolphinQt/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.cpp
@@ -58,9 +58,9 @@ void PatchesWidget::ConnectWidgets()
 {
   connect(m_list, &QListWidget::itemSelectionChanged, this, &PatchesWidget::UpdateActions);
   connect(m_list, &QListWidget::itemChanged, this, &PatchesWidget::OnItemChanged);
-  connect(m_remove_button, &QPushButton::pressed, this, &PatchesWidget::OnRemove);
-  connect(m_add_button, &QPushButton::pressed, this, &PatchesWidget::OnAdd);
-  connect(m_edit_button, &QPushButton::pressed, this, &PatchesWidget::OnEdit);
+  connect(m_remove_button, &QPushButton::clicked, this, &PatchesWidget::OnRemove);
+  connect(m_add_button, &QPushButton::clicked, this, &PatchesWidget::OnAdd);
+  connect(m_edit_button, &QPushButton::clicked, this, &PatchesWidget::OnEdit);
 }
 
 void PatchesWidget::OnItemChanged(QListWidgetItem* item)

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -113,7 +113,7 @@ void JITWidget::CreateWidgets()
 
 void JITWidget::ConnectWidgets()
 {
-  connect(m_refresh_button, &QPushButton::pressed, this, &JITWidget::Update);
+  connect(m_refresh_button, &QPushButton::clicked, this, &JITWidget::Update);
 }
 
 void JITWidget::Compare(u32 address)

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -225,15 +225,15 @@ void MemoryWidget::ConnectWidgets()
   connect(m_find_ascii, &QRadioButton::toggled, this, &MemoryWidget::ValidateSearchValue);
   connect(m_find_hex, &QRadioButton::toggled, this, &MemoryWidget::ValidateSearchValue);
 
-  connect(m_set_value, &QPushButton::pressed, this, &MemoryWidget::OnSetValue);
+  connect(m_set_value, &QPushButton::clicked, this, &MemoryWidget::OnSetValue);
 
-  connect(m_dump_mram, &QPushButton::pressed, this, &MemoryWidget::OnDumpMRAM);
-  connect(m_dump_exram, &QPushButton::pressed, this, &MemoryWidget::OnDumpExRAM);
-  connect(m_dump_aram, &QPushButton::pressed, this, &MemoryWidget::OnDumpARAM);
-  connect(m_dump_fake_vmem, &QPushButton::pressed, this, &MemoryWidget::OnDumpFakeVMEM);
+  connect(m_dump_mram, &QPushButton::clicked, this, &MemoryWidget::OnDumpMRAM);
+  connect(m_dump_exram, &QPushButton::clicked, this, &MemoryWidget::OnDumpExRAM);
+  connect(m_dump_aram, &QPushButton::clicked, this, &MemoryWidget::OnDumpARAM);
+  connect(m_dump_fake_vmem, &QPushButton::clicked, this, &MemoryWidget::OnDumpFakeVMEM);
 
-  connect(m_find_next, &QPushButton::pressed, this, &MemoryWidget::OnFindNextValue);
-  connect(m_find_previous, &QPushButton::pressed, this, &MemoryWidget::OnFindPreviousValue);
+  connect(m_find_next, &QPushButton::clicked, this, &MemoryWidget::OnFindNextValue);
+  connect(m_find_previous, &QPushButton::clicked, this, &MemoryWidget::OnFindPreviousValue);
 
   for (auto* radio :
        {m_address_space_effective, m_address_space_auxiliary, m_address_space_physical})

--- a/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
+++ b/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
@@ -76,10 +76,10 @@ void DiscordJoinRequestDialog::CreateLayout(const std::string& discord_tag, cons
 
 void DiscordJoinRequestDialog::ConnectWidgets()
 {
-  connect(m_invite_button, &QPushButton::pressed, [this] { Reply(DISCORD_REPLY_YES); });
-  connect(m_decline_button, &QPushButton::pressed, [this] { Reply(DISCORD_REPLY_NO); });
-  connect(m_ignore_button, &QPushButton::pressed, [this] { Reply(DISCORD_REPLY_IGNORE); });
-  connect(this, &QDialog::rejected, this, [this] { Reply(DISCORD_REPLY_IGNORE); });
+  connect(m_invite_button, &QPushButton::clicked, [this] { Reply(DISCORD_REPLY_YES); });
+  connect(m_decline_button, &QPushButton::clicked, [this] { Reply(DISCORD_REPLY_NO); });
+  connect(m_ignore_button, &QPushButton::clicked, [this] { Reply(DISCORD_REPLY_IGNORE); });
+  connect(this, &QDialog::rejected, [this] { Reply(DISCORD_REPLY_IGNORE); });
 }
 
 void DiscordJoinRequestDialog::Reply(int reply)

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -109,9 +109,9 @@ void FIFOAnalyzer::ConnectWidgets()
   connect(m_detail_list, &QListWidget::itemSelectionChanged, this,
           &FIFOAnalyzer::UpdateDescription);
 
-  connect(m_search_new, &QPushButton::pressed, this, &FIFOAnalyzer::BeginSearch);
-  connect(m_search_next, &QPushButton::pressed, this, &FIFOAnalyzer::FindNext);
-  connect(m_search_previous, &QPushButton::pressed, this, &FIFOAnalyzer::FindPrevious);
+  connect(m_search_new, &QPushButton::clicked, this, &FIFOAnalyzer::BeginSearch);
+  connect(m_search_next, &QPushButton::clicked, this, &FIFOAnalyzer::FindNext);
+  connect(m_search_previous, &QPushButton::clicked, this, &FIFOAnalyzer::FindPrevious);
 }
 
 void FIFOAnalyzer::Update()

--- a/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOPlayerWindow.cpp
@@ -163,9 +163,9 @@ void FIFOPlayerWindow::CreateWidgets()
 void FIFOPlayerWindow::ConnectWidgets()
 {
   connect(m_load, &QPushButton::clicked, this, &FIFOPlayerWindow::LoadRecording);
-  connect(m_save, &QPushButton::pressed, this, &FIFOPlayerWindow::SaveRecording);
-  connect(m_record, &QPushButton::pressed, this, &FIFOPlayerWindow::StartRecording);
-  connect(m_stop, &QPushButton::pressed, this, &FIFOPlayerWindow::StopRecording);
+  connect(m_save, &QPushButton::clicked, this, &FIFOPlayerWindow::SaveRecording);
+  connect(m_record, &QPushButton::clicked, this, &FIFOPlayerWindow::StartRecording);
+  connect(m_stop, &QPushButton::clicked, this, &FIFOPlayerWindow::StopRecording);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &FIFOPlayerWindow::reject);
   connect(m_early_memory_updates, &QCheckBox::toggled, this,
           &FIFOPlayerWindow::OnEarlyMemoryUpdatesChanged);

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -116,19 +116,19 @@ void GCMemcardManager::CreateWidgets()
 void GCMemcardManager::ConnectWidgets()
 {
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  connect(m_select_button, &QPushButton::pressed, this, [this] { SetActiveSlot(!m_active_slot); });
-  connect(m_export_button, &QPushButton::pressed, this, [this] { ExportFiles(true); });
-  connect(m_export_all_button, &QPushButton::pressed, this, &GCMemcardManager::ExportAllFiles);
-  connect(m_delete_button, &QPushButton::pressed, this, &GCMemcardManager::DeleteFiles);
-  connect(m_import_button, &QPushButton::pressed, this, &GCMemcardManager::ImportFile);
-  connect(m_copy_button, &QPushButton::pressed, this, &GCMemcardManager::CopyFiles);
-  connect(m_fix_checksums_button, &QPushButton::pressed, this, &GCMemcardManager::FixChecksums);
+  connect(m_select_button, &QPushButton::clicked, [this] { SetActiveSlot(!m_active_slot); });
+  connect(m_export_button, &QPushButton::clicked, [this] { ExportFiles(true); });
+  connect(m_export_all_button, &QPushButton::clicked, this, &GCMemcardManager::ExportAllFiles);
+  connect(m_delete_button, &QPushButton::clicked, this, &GCMemcardManager::DeleteFiles);
+  connect(m_import_button, &QPushButton::clicked, this, &GCMemcardManager::ImportFile);
+  connect(m_copy_button, &QPushButton::clicked, this, &GCMemcardManager::CopyFiles);
+  connect(m_fix_checksums_button, &QPushButton::clicked, this, &GCMemcardManager::FixChecksums);
 
   for (int slot = 0; slot < SLOT_COUNT; slot++)
   {
-    connect(m_slot_file_edit[slot], &QLineEdit::textChanged, this,
+    connect(m_slot_file_edit[slot], &QLineEdit::textChanged,
             [this, slot](const QString& path) { SetSlotFile(slot, path); });
-    connect(m_slot_file_button[slot], &QPushButton::clicked, this,
+    connect(m_slot_file_button[slot], &QPushButton::clicked,
             [this, slot] { SetSlotFileInteractive(slot); });
     connect(m_slot_table[slot], &QTableWidget::itemSelectionChanged, this,
             &GCMemcardManager::UpdateActions);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -128,7 +128,7 @@ void NetPlayBrowser::ConnectWidgets()
 
   connect(m_button_box, &QDialogButtonBox::accepted, this, &NetPlayBrowser::accept);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &NetPlayBrowser::reject);
-  connect(m_button_refresh, &QPushButton::pressed, this, &NetPlayBrowser::Refresh);
+  connect(m_button_refresh, &QPushButton::clicked, this, &NetPlayBrowser::Refresh);
 
   connect(m_radio_all, &QRadioButton::toggled, this, &NetPlayBrowser::Refresh);
   connect(m_radio_private, &QRadioButton::toggled, this, &NetPlayBrowser::Refresh);

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -60,13 +60,13 @@ void ResourcePackManager::CreateWidgets()
 
 void ResourcePackManager::ConnectWidgets()
 {
-  connect(m_open_directory_button, &QPushButton::pressed, this,
+  connect(m_open_directory_button, &QPushButton::clicked, this,
           &ResourcePackManager::OpenResourcePackDir);
-  connect(m_refresh_button, &QPushButton::pressed, this, &ResourcePackManager::Refresh);
-  connect(m_change_button, &QPushButton::pressed, this, &ResourcePackManager::Change);
-  connect(m_remove_button, &QPushButton::pressed, this, &ResourcePackManager::Remove);
-  connect(m_priority_up_button, &QPushButton::pressed, this, &ResourcePackManager::PriorityUp);
-  connect(m_priority_down_button, &QPushButton::pressed, this, &ResourcePackManager::PriorityDown);
+  connect(m_refresh_button, &QPushButton::clicked, this, &ResourcePackManager::Refresh);
+  connect(m_change_button, &QPushButton::clicked, this, &ResourcePackManager::Change);
+  connect(m_remove_button, &QPushButton::clicked, this, &ResourcePackManager::Remove);
+  connect(m_priority_up_button, &QPushButton::clicked, this, &ResourcePackManager::PriorityUp);
+  connect(m_priority_down_button, &QPushButton::clicked, this, &ResourcePackManager::PriorityDown);
 
   connect(m_table_widget, &QTableWidget::itemSelectionChanged, this,
           &ResourcePackManager::SelectionChanged);

--- a/Source/Core/DolphinQt/SearchBar.cpp
+++ b/Source/Core/DolphinQt/SearchBar.cpp
@@ -62,7 +62,7 @@ void SearchBar::Hide()
 void SearchBar::ConnectWidgets()
 {
   connect(m_search_edit, &QLineEdit::textChanged, this, &SearchBar::Search);
-  connect(m_close_button, &QPushButton::pressed, this, &SearchBar::Hide);
+  connect(m_close_button, &QPushButton::clicked, this, &SearchBar::Hide);
 }
 
 bool SearchBar::eventFilter(QObject* object, QEvent* event)

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -142,7 +142,7 @@ void GameCubePane::ConnectWidgets()
             [this, i] { UpdateButton(i); });
     connect(m_slot_combos[i], QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &GameCubePane::SaveSettings);
-    connect(m_slot_buttons[i], &QPushButton::pressed, this, [this, i] { OnConfigPressed(i); });
+    connect(m_slot_buttons[i], &QPushButton::clicked, [this, i] { OnConfigPressed(i); });
   }
 }
 

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -120,7 +120,7 @@ void GeneralPane::ConnectLayout()
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   connect(&Settings::Instance(), &Settings::AnalyticsToggled, this, &GeneralPane::LoadConfig);
   connect(m_checkbox_enable_analytics, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
-  connect(m_button_generate_new_identity, &QPushButton::pressed, this,
+  connect(m_button_generate_new_identity, &QPushButton::clicked, this,
           &GeneralPane::GenerateNewIdentity);
 #endif
 }

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -135,7 +135,7 @@ QGroupBox* PathPane::MakeGameFolderBox()
   vlayout->addWidget(recursive_checkbox);
   vlayout->addWidget(auto_checkbox);
 
-  connect(recursive_checkbox, &QCheckBox::toggled, this, [](bool checked) {
+  connect(recursive_checkbox, &QCheckBox::toggled, [](bool checked) {
     SConfig::GetInstance().m_RecursiveISOFolder = checked;
     Settings::Instance().RefreshGameList();
   });
@@ -144,7 +144,7 @@ QGroupBox* PathPane::MakeGameFolderBox()
           &Settings::SetAutoRefreshEnabled);
 
   connect(add, &QPushButton::clicked, this, &PathPane::Browse);
-  connect(m_remove_path, &QPushButton::pressed, this, &PathPane::RemovePath);
+  connect(m_remove_path, &QPushButton::clicked, this, &PathPane::RemovePath);
 
   game_box->setLayout(vlayout);
   return game_box;
@@ -161,7 +161,7 @@ QGridLayout* PathPane::MakePathsLayout()
   connect(&Settings::Instance(), &Settings::DefaultGameChanged,
           [this](const QString& path) { m_game_edit->setText(path); });
   QPushButton* game_open = new QPushButton(QStringLiteral("..."));
-  connect(game_open, &QPushButton::pressed, this, &PathPane::BrowseDefaultGame);
+  connect(game_open, &QPushButton::clicked, this, &PathPane::BrowseDefaultGame);
   layout->addWidget(new QLabel(tr("Default ISO:")), 0, 0);
   layout->addWidget(m_game_edit, 0, 1);
   layout->addWidget(game_open, 0, 2);
@@ -169,7 +169,7 @@ QGridLayout* PathPane::MakePathsLayout()
   m_nand_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_FS_PATH)));
   connect(m_nand_edit, &QLineEdit::editingFinished, this, &PathPane::OnNANDPathChanged);
   QPushButton* nand_open = new QPushButton(QStringLiteral("..."));
-  connect(nand_open, &QPushButton::pressed, this, &PathPane::BrowseWiiNAND);
+  connect(nand_open, &QPushButton::clicked, this, &PathPane::BrowseWiiNAND);
   layout->addWidget(new QLabel(tr("Wii NAND Root:")), 1, 0);
   layout->addWidget(m_nand_edit, 1, 1);
   layout->addWidget(nand_open, 1, 2);
@@ -178,7 +178,7 @@ QGridLayout* PathPane::MakePathsLayout()
   connect(m_dump_edit, &QLineEdit::editingFinished,
           [=] { Config::SetBase(Config::MAIN_DUMP_PATH, m_dump_edit->text().toStdString()); });
   QPushButton* dump_open = new QPushButton(QStringLiteral("..."));
-  connect(dump_open, &QPushButton::pressed, this, &PathPane::BrowseDump);
+  connect(dump_open, &QPushButton::clicked, this, &PathPane::BrowseDump);
   layout->addWidget(new QLabel(tr("Dump Path:")), 2, 0);
   layout->addWidget(m_dump_edit, 2, 1);
   layout->addWidget(dump_open, 2, 2);
@@ -186,7 +186,7 @@ QGridLayout* PathPane::MakePathsLayout()
   m_sdcard_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_SD_PATH)));
   connect(m_sdcard_edit, &QLineEdit::editingFinished, this, &PathPane::OnSDCardPathChanged);
   QPushButton* sdcard_open = new QPushButton(QStringLiteral("..."));
-  connect(sdcard_open, &QPushButton::pressed, this, &PathPane::BrowseSDCard);
+  connect(sdcard_open, &QPushButton::clicked, this, &PathPane::BrowseSDCard);
   layout->addWidget(new QLabel(tr("SD Card Path:")), 3, 0);
   layout->addWidget(m_sdcard_edit, 3, 1);
   layout->addWidget(sdcard_open, 3, 2);

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -82,7 +82,7 @@ void WiiPane::ConnectLayout()
   connect(m_whitelist_usb_list, &QListWidget::itemClicked, this, &WiiPane::ValidateSelectionState);
   connect(m_whitelist_usb_add_button, &QPushButton::clicked, this,
           &WiiPane::OnUSBWhitelistAddButton);
-  connect(m_whitelist_usb_remove_button, &QPushButton::pressed, this,
+  connect(m_whitelist_usb_remove_button, &QPushButton::clicked, this,
           &WiiPane::OnUSBWhitelistRemoveButton);
 
   // Wii Remote Settings

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -78,7 +78,7 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info)
     layout->addWidget(update_later_check);
     layout->addWidget(buttons);
 
-    connect(never_btn, &QPushButton::pressed, [dialog] {
+    connect(never_btn, &QPushButton::clicked, [dialog] {
       Settings::Instance().SetAutoUpdateTrack(QStringLiteral(""));
       dialog->reject();
     });


### PR DESCRIPTION
This PR fixes a few UI buttons reacting to incorrect signals. Previously, a few buttons did not follow the standard UI behaviour and instead of reacting to button **click** (press & release), they executed their actions on **press**. This led to a bit inconsistent experience.

There's been too many changes to list them all, as lots of dialogs had those incorrectly connected buttons. Curiously, some of them had correct and incorrect buttons interleaved (e.g. Update Available dialog).

The easiest way to see why connecting to button press is bad is from a **FIFO Player** dialog - just launch the game and try to click **Record** without it instantly stopping (because Record button changes to Stop button, which instantly reacts on press).