### PR TITLE
Fix dubois anaglyph shaders on D3D11

### DIFF
--- a/Data/Sys/Shaders/Anaglyph/dubois-LCD-Amber-Blue.glsl
+++ b/Data/Sys/Shaders/Anaglyph/dubois-LCD-Amber-Blue.glsl
@@ -7,11 +7,14 @@ void main()
 {
 	float4 c0 = SampleLayer(0);
 	float4 c1 = SampleLayer(1);
-	mat3 l = mat3( 1.062,-0.205, 0.299,
-	              -0.026, 0.908, 0.068,
-	              -0.038,-0.173, 0.022);
-	mat3 r = mat3(-0.016,-0.123,-0.017,
-	               0.006, 0.062, 0.017,
-	              -0.094,-0.185, 0.991);
-	SetOutput(float4(c0.rgb * l + c1.rgb * r, c0.a));
+
+	float3 lr = float3( 1.062,-0.205, 0.299);
+	float3 lg = float3(-0.026, 0.908, 0.068);
+	float3 lb = float3(-0.038,-0.173, 0.022);
+
+	float3 rr = float3(-0.016,-0.123,-0.017);
+	float3 rg = float3( 0.006, 0.062, 0.017);
+	float3 rb = float3(-0.094,-0.185, 0.991);
+
+	SetOutput(float4(dot(lr, c0.rgb) + dot(rr, c1.rgb), dot(lg, c0.rgb) + dot(rg, c1.rgb), dot(lb, c0.rgb) + dot(rb, c1.rgb), c0.a));
 }

--- a/Data/Sys/Shaders/Anaglyph/dubois-LCD-Green-Magenta.glsl
+++ b/Data/Sys/Shaders/Anaglyph/dubois-LCD-Green-Magenta.glsl
@@ -7,11 +7,14 @@ void main()
 {
 	float4 c0 = SampleLayer(0);
 	float4 c1 = SampleLayer(1);
-	mat3 l = mat3(-0.062,-0.158,-0.039,
-	               0.284, 0.668, 0.143,
-	              -0.015,-0.027, 0.021);
-	mat3 r = mat3( 0.529, 0.705, 0.024,
-	              -0.016,-0.015, 0.065,
-	               0.009, 0.075, 0.937);
-	SetOutput(float4(c0.rgb * l + c1.rgb * r, c0.a));
+
+	float3 lr = float3(-0.062,-0.158,-0.039);
+	float3 lg = float3( 0.284, 0.668, 0.143);
+	float3 lb = float3(-0.015,-0.027, 0.021);
+
+	float3 rr = float3( 0.529, 0.705, 0.024);
+	float3 rg = float3(-0.016,-0.015, 0.065);
+	float3 rb = float3( 0.009, 0.075, 0.937);
+
+	SetOutput(float4(dot(lr, c0.rgb) + dot(rr, c1.rgb), dot(lg, c0.rgb) + dot(rg, c1.rgb), dot(lb, c0.rgb) + dot(rb, c1.rgb), c0.a));
 }

--- a/Data/Sys/Shaders/Anaglyph/dubois.glsl
+++ b/Data/Sys/Shaders/Anaglyph/dubois.glsl
@@ -8,11 +8,14 @@ void main()
 {
 	float4 c0 = SampleLayer(0);
 	float4 c1 = SampleLayer(1);
-	mat3 l = mat3( 0.437, 0.449, 0.164,
-	              -0.062,-0.062,-0.024,
-	              -0.048,-0.050,-0.017);
-	mat3 r = mat3(-0.011,-0.032,-0.007,
-	               0.377, 0.761, 0.009,
-	              -0.026,-0.093, 1.234);
-	SetOutput(float4(c0.rgb * l + c1.rgb * r, c0.a));
+
+	float3 lr = float3( 0.437, 0.449, 0.164);
+	float3 lg = float3(-0.062,-0.062,-0.024);
+	float3 lb = float3(-0.048,-0.050,-0.017);
+
+	float3 rr = float3(-0.011,-0.032,-0.007);
+	float3 rg = float3( 0.377, 0.761, 0.009);
+	float3 rb = float3(-0.026,-0.093, 1.234);
+
+	SetOutput(float4(dot(lr, c0.rgb) + dot(rr, c1.rgb), dot(lg, c0.rgb) + dot(rg, c1.rgb), dot(lb, c0.rgb) + dot(rb, c1.rgb), c0.a));
 }


### PR DESCRIPTION
Before, I would get `error X3000: unrecognized identifier 'mat3'` followed by `error X3000: unrecognized identifier 'l'`.

I've tested this in both D3D11 and OpenGL; I haven't tested it on the other backends.