### PR TITLE
OGL/ProgramShaderCache: Use std::string_view where applicable

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -519,7 +519,7 @@ PipelineProgram* ProgramShaderCache::GetPipelineProgram(const GLVertexFormat* ve
                             geometry_shader ? geometry_shader->GetID() : 0,
                             pixel_shader ? pixel_shader->GetID() : 0};
   {
-    std::lock_guard<std::mutex> guard(s_pipeline_program_lock);
+    std::lock_guard guard{s_pipeline_program_lock};
     auto iter = s_pipeline_programs.find(key);
     if (iter != s_pipeline_programs.end())
     {
@@ -597,7 +597,7 @@ PipelineProgram* ProgramShaderCache::GetPipelineProgram(const GLVertexFormat* ve
   }
 
   // Lock to insert. A duplicate program may have been created in the meantime.
-  std::lock_guard<std::mutex> guard(s_pipeline_program_lock);
+  std::lock_guard guard{s_pipeline_program_lock};
   auto iter = s_pipeline_programs.find(key);
   if (iter != s_pipeline_programs.end())
   {
@@ -627,8 +627,8 @@ void ProgramShaderCache::ReleasePipelineProgram(PipelineProgram* prog)
 
   prog->shader.Destroy();
 
-  std::lock_guard<std::mutex> guard(s_pipeline_program_lock);
-  auto iter = s_pipeline_programs.find(prog->key);
+  std::lock_guard guard{s_pipeline_program_lock};
+  const auto iter = s_pipeline_programs.find(prog->key);
   ASSERT(iter != s_pipeline_programs.end() && prog == iter->second.get());
   s_pipeline_programs.erase(iter);
 }

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <atomic>
-#include <limits>
 #include <memory>
 #include <string>
 
@@ -18,10 +17,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
-#include "Common/Timer.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Host.h"
 
 #include "VideoBackends/OGL/OGLShader.h"
 #include "VideoBackends/OGL/Render.h"
@@ -29,14 +26,11 @@
 #include "VideoBackends/OGL/VertexManager.h"
 
 #include "VideoCommon/AsyncShaderCompiler.h"
-#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/GeometryShaderManager.h"
-#include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"
-#include "VideoCommon/VideoCommon.h"
 
 namespace OGL
 {

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -7,7 +7,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
-#include <tuple>
+#include <string_view>
 #include <unordered_map>
 
 #include "Common/GL/GLUtil.h"
@@ -75,11 +75,11 @@ public:
   static void InvalidateVertexFormatIfBound(GLuint vao);
   static void InvalidateLastProgram();
 
-  static bool CompileComputeShader(SHADER& shader, const std::string& code);
-  static GLuint CompileSingleShader(GLenum type, const std::string& code);
-  static bool CheckShaderCompileResult(GLuint id, GLenum type, const std::string& code);
-  static bool CheckProgramLinkResult(GLuint id, const std::string* vcode, const std::string* pcode,
-                                     const std::string* gcode);
+  static bool CompileComputeShader(SHADER& shader, std::string_view code);
+  static GLuint CompileSingleShader(GLenum type, std::string_view code);
+  static bool CheckShaderCompileResult(GLuint id, GLenum type, std::string_view code);
+  static bool CheckProgramLinkResult(GLuint id, std::string_view vcode, std::string_view pcode,
+                                     std::string_view gcode);
   static StreamBuffer* GetUniformBuffer();
   static u32 GetUniformBufferAlignment();
   static void UploadConstants();

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -105,9 +105,9 @@ public:
   static void ReleasePipelineProgram(PipelineProgram* prog);
 
 private:
-  typedef std::unordered_map<PipelineProgramKey, std::unique_ptr<PipelineProgram>,
-                             PipelineProgramKeyHash>
-      PipelineProgramMap;
+  using PipelineProgramMap =
+      std::unordered_map<PipelineProgramKey, std::unique_ptr<PipelineProgram>,
+                         PipelineProgramKeyHash>;
 
   static void CreateAttributelessVAO();
 


### PR DESCRIPTION
Makes the relevant functions capable of being used with various other string types without requiring the use of std::strings to be constructed. Also performs a few other minor tidying changes while in the same area.