### PR TITLE
D3DCommon/Shader: Use std::optional where applicable

### DIFF
--- a/Source/Core/VideoBackends/D3D/DXShader.h
+++ b/Source/Core/VideoBackends/D3D/DXShader.h
@@ -16,8 +16,6 @@ public:
   DXShader(ShaderStage stage, BinaryData bytecode, ID3D11DeviceChild* shader);
   ~DXShader() override;
 
-  const BinaryData& GetByteCode() const { return m_bytecode; }
-
   ID3D11VertexShader* GetD3DVertexShader() const;
   ID3D11GeometryShader* GetD3DGeometryShader() const;
   ID3D11PixelShader* GetD3DPixelShader() const;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -115,11 +115,11 @@ std::unique_ptr<AbstractFramebuffer> Renderer::CreateFramebuffer(AbstractTexture
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromSource(ShaderStage stage,
                                                                  std::string_view source)
 {
-  DXShader::BinaryData bytecode;
-  if (!DXShader::CompileShader(D3D::feature_level, &bytecode, stage, source))
+  auto bytecode = DXShader::CompileShader(D3D::feature_level, stage, source);
+  if (!bytecode)
     return nullptr;
 
-  return DXShader::CreateFromBytecode(stage, std::move(bytecode));
+  return DXShader::CreateFromBytecode(stage, std::move(*bytecode));
 }
 
 std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage stage,

--- a/Source/Core/VideoBackends/D3D12/DXShader.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXShader.cpp
@@ -26,11 +26,11 @@ std::unique_ptr<DXShader> DXShader::CreateFromBytecode(ShaderStage stage, Binary
 
 std::unique_ptr<DXShader> DXShader::CreateFromSource(ShaderStage stage, std::string_view source)
 {
-  BinaryData bytecode;
-  if (!CompileShader(g_dx_context->GetFeatureLevel(), &bytecode, stage, source))
+  auto bytecode = CompileShader(g_dx_context->GetFeatureLevel(), stage, source);
+  if (!bytecode)
     return nullptr;
 
-  return CreateFromBytecode(stage, std::move(bytecode));
+  return CreateFromBytecode(stage, std::move(*bytecode));
 }
 
 D3D12_SHADER_BYTECODE DXShader::GetD3DByteCode() const

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -132,9 +132,10 @@ bool Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_byte
 
 AbstractShader::BinaryData Shader::CreateByteCode(const void* data, size_t length)
 {
-  BinaryData bytecode(length);
-  std::memcpy(bytecode.data(), data, length);
-  return bytecode;
+  const auto* const begin = static_cast<const u8*>(data);
+  const auto* const end = begin + length;
+
+  return {begin, end};
 }
 
 }  // namespace D3DCommon

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -89,8 +89,8 @@ static const char* GetCompileTarget(D3D_FEATURE_LEVEL feature_level, ShaderStage
   }
 }
 
-bool Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_bytecode,
-                           ShaderStage stage, std::string_view source)
+std::optional<Shader::BinaryData> Shader::CompileShader(D3D_FEATURE_LEVEL feature_level,
+                                                        ShaderStage stage, std::string_view source)
 {
   static constexpr D3D_SHADER_MACRO macros[] = {{"API_D3D", "1"}, {nullptr, nullptr}};
   const UINT flags = g_ActiveConfig.bEnableValidationLayer ?
@@ -116,7 +116,7 @@ bool Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_byte
 
     PanicAlert("Failed to compile %s:\nDebug info (%s):\n%s", filename.c_str(), target,
                static_cast<const char*>(errors->GetBufferPointer()));
-    return false;
+    return std::nullopt;
   }
 
   if (errors && errors->GetBufferSize() > 0)
@@ -125,9 +125,7 @@ bool Shader::CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_byte
              static_cast<const char*>(errors->GetBufferPointer()));
   }
 
-  out_bytecode->resize(code->GetBufferSize());
-  std::memcpy(out_bytecode->data(), code->GetBufferPointer(), code->GetBufferSize());
-  return true;
+  return CreateByteCode(code->GetBufferPointer(), code->GetBufferSize());
 }
 
 AbstractShader::BinaryData Shader::CreateByteCode(const void* data, size_t length)

--- a/Source/Core/VideoBackends/D3DCommon/Shader.h
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 #include "VideoBackends/D3DCommon/Common.h"
 #include "VideoCommon/AbstractShader.h"
@@ -19,8 +20,8 @@ public:
 
   BinaryData GetBinary() const override;
 
-  static bool CompileShader(D3D_FEATURE_LEVEL feature_level, BinaryData* out_bytecode,
-                            ShaderStage stage, std::string_view source);
+  static std::optional<BinaryData> CompileShader(D3D_FEATURE_LEVEL feature_level, ShaderStage stage,
+                                                 std::string_view source);
 
   static BinaryData CreateByteCode(const void* data, size_t length);
 


### PR DESCRIPTION
Minor individual changes that act as improvements to the existing interface. The latter commit is the main one that makes changes to the exposed interface.

The first one simply resolves a function shadowing case, while the second one provides equivalent behavior in a more efficient manner.