### PR TITLE
VideoBackends/Null: Minor cleanup

### DIFF
--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -13,6 +13,7 @@
 #include "VideoBackends/Null/VertexManager.h"
 #include "VideoBackends/Null/VideoBackend.h"
 
+#include "Common/Common.h"
 #include "Common/MsgHandler.h"
 
 #include "VideoCommon/FramebufferManager.h"
@@ -96,5 +97,11 @@ void VideoBackend::Shutdown()
   g_renderer.reset();
 
   ShutdownShared();
+}
+
+std::string VideoBackend::GetDisplayName() const
+{
+  // i18n: Null is referring to the null video backend, which renders nothing
+  return _trans("Null");
 }
 }  // namespace Null

--- a/Source/Core/VideoBackends/Null/NullTexture.h
+++ b/Source/Core/VideoBackends/Null/NullTexture.h
@@ -19,7 +19,6 @@ class NullTexture final : public AbstractTexture
 {
 public:
   explicit NullTexture(const TextureConfig& config);
-  ~NullTexture() = default;
 
   void CopyRectangleFromTexture(const AbstractTexture* src,
                                 const MathUtil::Rectangle<int>& src_rect, u32 src_layer,
@@ -58,7 +57,6 @@ public:
   explicit NullFramebuffer(AbstractTexture* color_attachment, AbstractTexture* depth_attachment,
                            AbstractTextureFormat color_format, AbstractTextureFormat depth_format,
                            u32 width, u32 height, u32 layers, u32 samples);
-  ~NullFramebuffer() override = default;
 
   static std::unique_ptr<NullFramebuffer> Create(NullTexture* color_attachment,
                                                  NullTexture* depth_attachment);

--- a/Source/Core/VideoBackends/Null/PerfQuery.h
+++ b/Source/Core/VideoBackends/Null/PerfQuery.h
@@ -8,7 +8,7 @@
 
 namespace Null
 {
-class PerfQuery : public PerfQueryBase
+class PerfQuery final : public PerfQueryBase
 {
 public:
   void EnableQuery(PerfQueryGroup type) override {}

--- a/Source/Core/VideoBackends/Null/PerfQuery.h
+++ b/Source/Core/VideoBackends/Null/PerfQuery.h
@@ -11,8 +11,6 @@ namespace Null
 class PerfQuery : public PerfQueryBase
 {
 public:
-  PerfQuery() {}
-  ~PerfQuery() override {}
   void EnableQuery(PerfQueryGroup type) override {}
   void DisableQuery(PerfQueryGroup type) override {}
   void ResetQuery() override {}

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -2,10 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Logging/Log.h"
+#include "VideoBackends/Null/Render.h"
 
 #include "VideoBackends/Null/NullTexture.h"
-#include "VideoBackends/Null/Render.h"
 
 #include "VideoCommon/AbstractPipeline.h"
 #include "VideoCommon/AbstractShader.h"

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -44,7 +44,6 @@ class NullShader final : public AbstractShader
 {
 public:
   explicit NullShader(ShaderStage stage) : AbstractShader(stage) {}
-  ~NullShader() = default;
 };
 
 std::unique_ptr<AbstractShader>
@@ -61,9 +60,6 @@ std::unique_ptr<AbstractShader> Renderer::CreateShaderFromBinary(ShaderStage sta
 
 class NullPipeline final : public AbstractPipeline
 {
-public:
-  NullPipeline() = default;
-  ~NullPipeline() override = default;
 };
 
 std::unique_ptr<AbstractPipeline> Renderer::CreatePipeline(const AbstractPipelineConfig& config,

--- a/Source/Core/VideoBackends/Null/Render.h
+++ b/Source/Core/VideoBackends/Null/Render.h
@@ -8,7 +8,7 @@
 
 namespace Null
 {
-class Renderer : public ::Renderer
+class Renderer final : public ::Renderer
 {
 public:
   Renderer();

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -8,7 +8,7 @@
 
 namespace Null
 {
-class TextureCache : public TextureCacheBase
+class TextureCache final : public TextureCacheBase
 {
 protected:
   void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include <memory>
-
-#include "VideoBackends/Null/NullTexture.h"
-
 #include "VideoCommon/TextureCacheBase.h"
-#include "VideoCommon/TextureConfig.h"
 
 namespace Null
 {

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -10,10 +10,6 @@ namespace Null
 {
 class TextureCache : public TextureCacheBase
 {
-public:
-  TextureCache() {}
-  ~TextureCache() {}
-
 protected:
   void CopyEFB(AbstractStagingTexture* dst, const EFBCopyParams& params, u32 native_width,
                u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,

--- a/Source/Core/VideoBackends/Null/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Null/VertexManager.cpp
@@ -3,10 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/Null/VertexManager.h"
-#include "VideoBackends/Null/Render.h"
-
-#include "VideoCommon/IndexGenerator.h"
-#include "VideoCommon/VertexLoaderManager.h"
 
 namespace Null
 {

--- a/Source/Core/VideoBackends/Null/VertexManager.h
+++ b/Source/Core/VideoBackends/Null/VertexManager.h
@@ -8,7 +8,7 @@
 
 namespace Null
 {
-class VertexManager : public VertexManagerBase
+class VertexManager final : public VertexManagerBase
 {
 public:
   VertexManager();

--- a/Source/Core/VideoBackends/Null/VertexManager.h
+++ b/Source/Core/VideoBackends/Null/VertexManager.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
-
 #include "VideoCommon/VertexManagerBase.h"
 
 namespace Null

--- a/Source/Core/VideoBackends/Null/VertexManager.h
+++ b/Source/Core/VideoBackends/Null/VertexManager.h
@@ -12,7 +12,7 @@ class VertexManager final : public VertexManagerBase
 {
 public:
   VertexManager();
-  ~VertexManager();
+  ~VertexManager() override;
 
 protected:
   void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex) override;

--- a/Source/Core/VideoBackends/Null/VideoBackend.h
+++ b/Source/Core/VideoBackends/Null/VideoBackend.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "Common/Common.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 namespace Null
@@ -15,11 +14,7 @@ class VideoBackend : public VideoBackendBase
   void Shutdown() override;
 
   std::string GetName() const override { return "Null"; }
-  std::string GetDisplayName() const override
-  {
-    // i18n: Null is referring to the null video backend, which renders nothing
-    return _trans("Null");
-  }
+  std::string GetDisplayName() const override;
   void InitBackendInfo() override;
 };
 }  // namespace Null

--- a/Source/Core/VideoBackends/Null/VideoBackend.h
+++ b/Source/Core/VideoBackends/Null/VideoBackend.h
@@ -8,7 +8,7 @@
 
 namespace Null
 {
-class VideoBackend : public VideoBackendBase
+class VideoBackend final : public VideoBackendBase
 {
   bool Initialize(const WindowSystemInfo& wsi) override;
   void Shutdown() override;


### PR DESCRIPTION
Mainly eliminates headers that are no longer necessary since the migration of many things to VideoCommon, removing a few header dependencies. Aside from that, the rest is mostly just general tidying up.