### PR TITLE
VideoCommon/OnScreenDisplay: Minor cleanup

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -150,7 +150,7 @@ std::string StopMessage(bool main_thread, const std::string& message)
                           Common::CurrentThreadId(), message.c_str());
 }
 
-void DisplayMessage(const std::string& message, int time_in_ms)
+void DisplayMessage(std::string message, int time_in_ms)
 {
   if (!IsRunning())
     return;
@@ -162,8 +162,8 @@ void DisplayMessage(const std::string& message, int time_in_ms)
       return;
   }
 
-  OSD::AddMessage(message, time_in_ms);
   Host_UpdateTitle(message);
+  OSD::AddMessage(std::move(message), time_in_ms);
 }
 
 bool IsRunning()

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -63,7 +63,7 @@ void SaveScreenShot(const std::string& name, bool wait_for_completion = false);
 void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const u8* data, u32 size);
 
 // This displays messages in a user-visible way.
-void DisplayMessage(const std::string& message, int time_in_ms);
+void DisplayMessage(std::string message, int time_in_ms);
 
 void FrameUpdateOnCPUThread();
 void OnFrameEnd();

--- a/Source/Core/Core/DSP/DSPHost.h
+++ b/Source/Core/Core/DSP/DSPHost.h
@@ -17,7 +17,7 @@ namespace DSP::Host
 {
 u8 ReadHostMemory(u32 addr);
 void WriteHostMemory(u8 value, u32 addr);
-void OSD_AddMessage(const std::string& str, u32 ms);
+void OSD_AddMessage(std::string str, u32 ms);
 bool OnThread();
 bool IsWiiHost();
 void InterruptRequest();

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -36,9 +36,9 @@ void WriteHostMemory(u8 value, u32 addr)
   DSP::WriteARAM(value, addr);
 }
 
-void OSD_AddMessage(const std::string& str, u32 ms)
+void OSD_AddMessage(std::string str, u32 ms)
 {
-  OSD::AddMessage(str, ms);
+  OSD::AddMessage(std::move(str), ms);
 }
 
 bool OnThread()

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -337,7 +337,7 @@ void HotkeyScheduler::Run()
           OSD::AddMessage("Internal Resolution: Native");
           break;
         default:
-          OSD::AddMessage("Internal Resolution: %dx", g_Config.iEFBScale);
+          OSD::AddMessage(StringFromFormat("Internal Resolution: %dx", g_Config.iEFBScale));
           break;
         }
       };

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -27,8 +27,8 @@ constexpr float WINDOW_PADDING = 4.0f;  // Pixels between subsequent OSD message
 struct Message
 {
   Message() = default;
-  Message(const std::string& text_, u32 timestamp_, u32 color_)
-      : text(text_), timestamp(timestamp_), color(color_)
+  Message(std::string text_, u32 timestamp_, u32 color_)
+      : text(std::move(text_)), timestamp(timestamp_), color(color_)
   {
   }
   std::string text;
@@ -79,18 +79,18 @@ static float DrawMessage(int index, const Message& msg, const ImVec2& position, 
   return window_height;
 }
 
-void AddTypedMessage(MessageType type, const std::string& message, u32 ms, u32 rgba)
+void AddTypedMessage(MessageType type, std::string message, u32 ms, u32 rgba)
 {
   std::lock_guard<std::mutex> lock(s_messages_mutex);
   s_messages.erase(type);
-  s_messages.emplace(type, Message(message, Common::Timer::GetTimeMs() + ms, rgba));
+  s_messages.emplace(type, Message(std::move(message), Common::Timer::GetTimeMs() + ms, rgba));
 }
 
-void AddMessage(const std::string& message, u32 ms, u32 rgba)
+void AddMessage(std::string message, u32 ms, u32 rgba)
 {
   std::lock_guard<std::mutex> lock(s_messages_mutex);
   s_messages.emplace(MessageType::Typeless,
-                     Message(message, Common::Timer::GetTimeMs() + ms, rgba));
+                     Message(std::move(message), Common::Timer::GetTimeMs() + ms, rgba));
 }
 
 void DrawMessages()

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -3,12 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <list>
 #include <map>
 #include <mutex>
 #include <string>
 
-#include "imgui.h"
+#include <imgui.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -26,14 +26,14 @@ constexpr float WINDOW_PADDING = 4.0f;  // Pixels between subsequent OSD message
 
 struct Message
 {
-  Message() {}
+  Message() = default;
   Message(const std::string& text_, u32 timestamp_, u32 color_)
       : text(text_), timestamp(timestamp_), color(color_)
   {
   }
   std::string text;
-  u32 timestamp;
-  u32 color;
+  u32 timestamp = 0;
+  u32 color = 0;
 };
 static std::multimap<MessageType, Message> s_messages;
 static std::mutex s_messages_mutex;

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -80,14 +80,14 @@ static float DrawMessage(int index, const Message& msg, const ImVec2& position, 
 
 void AddTypedMessage(MessageType type, std::string message, u32 ms, u32 rgba)
 {
-  std::lock_guard<std::mutex> lock(s_messages_mutex);
+  std::lock_guard lock{s_messages_mutex};
   s_messages.erase(type);
   s_messages.emplace(type, Message(std::move(message), Common::Timer::GetTimeMs() + ms, rgba));
 }
 
 void AddMessage(std::string message, u32 ms, u32 rgba)
 {
-  std::lock_guard<std::mutex> lock(s_messages_mutex);
+  std::lock_guard lock{s_messages_mutex};
   s_messages.emplace(MessageType::Typeless,
                      Message(std::move(message), Common::Timer::GetTimeMs() + ms, rgba));
 }
@@ -98,7 +98,7 @@ void DrawMessages()
     return;
 
   {
-    std::lock_guard<std::mutex> lock(s_messages_mutex);
+    std::lock_guard lock{s_messages_mutex};
 
     const u32 now = Common::Timer::GetTimeMs();
     float current_x = LEFT_MARGIN * ImGui::GetIO().DisplayFramebufferScale.x;
@@ -122,7 +122,7 @@ void DrawMessages()
 
 void ClearMessages()
 {
-  std::lock_guard<std::mutex> lock(s_messages_mutex);
+  std::lock_guard lock{s_messages_mutex};
   s_messages.clear();
 }
 }  // namespace OSD

--- a/Source/Core/VideoCommon/OnScreenDisplay.h
+++ b/Source/Core/VideoCommon/OnScreenDisplay.h
@@ -37,10 +37,11 @@ constexpr u32 VERY_LONG = 10000;
 };  // namespace Duration
 
 // On-screen message display (colored yellow by default)
-void AddMessage(const std::string& message, u32 ms = Duration::SHORT, u32 rgba = Color::YELLOW);
-void AddTypedMessage(MessageType type, const std::string& message, u32 ms = Duration::SHORT,
+void AddMessage(std::string message, u32 ms = Duration::SHORT, u32 rgba = Color::YELLOW);
+void AddTypedMessage(MessageType type, std::string message, u32 ms = Duration::SHORT,
                      u32 rgba = Color::YELLOW);
-void DrawMessages();  // draw the current messages on the screen. Only call once
-                      // per frame.
+
+// Draw the current messages on the screen. Only call once per frame.
+void DrawMessages();
 void ClearMessages();
 }  // namespace OSD

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -22,7 +22,7 @@ u8 DSP::Host::ReadHostMemory(u32 addr)
 void DSP::Host::WriteHostMemory(u8 value, u32 addr)
 {
 }
-void DSP::Host::OSD_AddMessage(const std::string& str, u32 ms)
+void DSP::Host::OSD_AddMessage(std::string str, u32 ms)
 {
 }
 bool DSP::Host::OnThread()


### PR DESCRIPTION
Performs some tidying up of the on screen display interface. Notably, it allows moving into the function, which would be the case for most usages of the functions, allowing copies to be avoided entirely in these scenarios.

This also fixes a format string within the hotkey scheduler. This string should have been within a `StringFromFormat` call rather than being passed directly to AddMessage().