### PR TITLE
DolphinQt: Once-off warning messages for unsupported graphics features

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -140,6 +140,10 @@ private:
   void ShowRenderWidget();
   void HideRenderWidget(bool reinit = true);
 
+  // Displays any warning message from the video backend based on the current config.
+  // Returns true if no message was displayed, or the user clicked yes to ignore.
+  bool ConfirmStartWithVideoBackendWarning();
+
   void ShowSettingsWindow();
   void ShowGeneralWindow();
   void ShowAudioWindow();

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -230,6 +230,16 @@ bool Settings::IsKeepWindowOnTopEnabled() const
   return Config::Get(Config::MAIN_KEEP_WINDOW_ON_TOP);
 }
 
+bool Settings::HasDisplayedGraphicsWarningMessage() const
+{
+  return GetQSettings().value(QStringLiteral("DisplayedGraphicsWarningMessage"), false).toBool();
+}
+
+void Settings::SetDisplayedGraphicsWarningMessage(bool displayed)
+{
+  GetQSettings().setValue(QStringLiteral("DisplayedGraphicsWarningMessage"), displayed);
+}
+
 int Settings::GetVolume() const
 {
   return SConfig::GetInstance().m_Volume;

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -97,6 +97,8 @@ public:
   bool GetHideCursor() const;
   void SetKeepWindowOnTop(bool top);
   bool IsKeepWindowOnTopEnabled() const;
+  bool HasDisplayedGraphicsWarningMessage() const;
+  void SetDisplayedGraphicsWarningMessage(bool displayed);
 
   // Audio
   int GetVolume() const;

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -62,6 +63,9 @@ public:
   // Fills the backend_info fields with the capabilities of the selected backend/device.
   // Called by the UI thread when the graphics config is opened.
   static void PopulateBackendInfo();
+
+  // Returns a warning message, if any, for the current config.
+  static std::optional<std::string> GetWarningMessage();
 
   // Wrapper function which pushes the event to the GPU thread.
   void DoState(PointerWrap& p);


### PR DESCRIPTION
This PR takes the concept in #8258 a step further and generalizes it to backend features, e.g. logic op, palette conversion, dual-source blending, etc.

One flaw with the design in #8258 is it only displays the message when switching backends. Therefore, if a user runs the default configuration of OpenGL, and features are missing, they will not be informed.

The idea is to make users aware that their system configurations may not support all the features required to run some games, or those which may effect performance (e.g. missing buffer_storage), but doing so in a non-intrusive and annoying way. This message will be displayed once, and if they choose to continue, it will not be displayed again. I'm not a fan of the long-running OSD message about "performance being terrible". I think we should inform users once of this fact, and if they choose to continue, not annoy them any more.

Some screenshots of what the warning currently looks like:
![m1](https://user-images.githubusercontent.com/11288319/62060268-29d9e700-b268-11e9-9885-0dc929aa0bc8.png)
![m2](https://user-images.githubusercontent.com/11288319/62060270-2a727d80-b268-11e9-9f32-4c6f742385ee.png)

TODO:

- [ ] Extend to buffer_storage detection
- [ ] Find some way to detect driver changes and reset the "seen" flag accordingly