### PR TITLE
DolphinQt: Replace unnecessary QStringLiterals with alternatives where applicable 

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -625,8 +625,7 @@ static QString GetResultString(const Result& result)
   case DataType::String:
     return QObject::tr("String Match");
   default:
-    // Make MSVC happy
-    return QStringLiteral("");
+    return {};
   }
 }
 
@@ -722,7 +721,7 @@ void CheatsManager::Reset()
   m_match_table->clear();
   m_watch_table->clear();
   m_match_decimal->setChecked(true);
-  m_result_label->setText(QStringLiteral(""));
+  m_result_label->clear();
 
   Update();
 }

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -152,8 +152,8 @@ void ARCodeWidget::UpdateList()
   {
     const auto& ar = m_ar_codes[i];
     auto* item = new QListWidgetItem(QString::fromStdString(ar.name)
-                                         .replace(QStringLiteral("&lt;"), QStringLiteral("<"))
-                                         .replace(QStringLiteral("&gt;"), QStringLiteral(">")));
+                                         .replace(QStringLiteral("&lt;"), QChar::fromLatin1('<'))
+                                         .replace(QStringLiteral("&gt;"), QChar::fromLatin1('>')));
 
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable |
                    Qt::ItemIsDragEnabled);

--- a/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
+++ b/Source/Core/DolphinQt/Config/CheatCodeEditor.cpp
@@ -124,7 +124,7 @@ bool CheatCodeEditor::AcceptAR()
   std::vector<ActionReplay::AREntry> entries;
   std::vector<std::string> encrypted_lines;
 
-  QStringList lines = m_code_edit->toPlainText().split(QStringLiteral("\n"));
+  QStringList lines = m_code_edit->toPlainText().split(QLatin1Char{'\n'});
 
   for (int i = 0; i < lines.size(); i++)
   {
@@ -133,7 +133,7 @@ bool CheatCodeEditor::AcceptAR()
     if (line.isEmpty())
       continue;
 
-    QStringList values = line.split(QStringLiteral(" "));
+    QStringList values = line.split(QLatin1Char{' '});
 
     bool good = true;
 
@@ -152,7 +152,7 @@ bool CheatCodeEditor::AcceptAR()
     }
     else
     {
-      QStringList blocks = line.split(QStringLiteral("-"));
+      QStringList blocks = line.split(QLatin1Char{'-'});
 
       if (blocks.size() == 3 && blocks[0].size() == 4 && blocks[1].size() == 4 &&
           blocks[2].size() == 5)
@@ -230,7 +230,7 @@ bool CheatCodeEditor::AcceptGecko()
 {
   std::vector<Gecko::GeckoCode::Code> entries;
 
-  QStringList lines = m_code_edit->toPlainText().split(QStringLiteral("\n"));
+  QStringList lines = m_code_edit->toPlainText().split(QLatin1Char{'\n'});
 
   for (int i = 0; i < lines.size(); i++)
   {
@@ -239,7 +239,7 @@ bool CheatCodeEditor::AcceptGecko()
     if (line.isEmpty())
       continue;
 
-    QStringList values = line.split(QStringLiteral(" "));
+    QStringList values = line.split(QLatin1Char{' '});
 
     bool good = values.size() == 2;
 
@@ -289,7 +289,7 @@ bool CheatCodeEditor::AcceptGecko()
   m_gecko_code->user_defined = true;
 
   std::vector<std::string> note_lines;
-  for (QString line : m_notes_edit->toPlainText().split(QStringLiteral("\n")))
+  for (const QString& line : m_notes_edit->toPlainText().split(QLatin1Char{'\n'}))
     note_lines.push_back(line.toStdString());
 
   m_gecko_code->notes = std::move(note_lines);

--- a/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FilesystemWidget.cpp
@@ -263,7 +263,7 @@ DiscIO::Partition FilesystemWidget::GetPartitionFromID(int id)
 
 void FilesystemWidget::ExtractPartition(const DiscIO::Partition& partition, const QString& out)
 {
-  ExtractDirectory(partition, QStringLiteral(""), out + QStringLiteral("/files"));
+  ExtractDirectory(partition, QString{}, out + QStringLiteral("/files"));
   ExtractSystemData(partition, out);
 }
 

--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -179,7 +179,7 @@ void GameConfigEdit::SetOption(const QString& section, const QString& key, const
     if (value_cursor.isNull())
     {
       section_cursor.clearSelection();
-      section_cursor.insertText(QStringLiteral("\n") + new_line);
+      section_cursor.insertText(QLatin1Char{'\n'} + new_line);
     }
     else
     {

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -280,8 +280,8 @@ void GeckoCodeWidget::UpdateList()
     const auto& code = m_gecko_codes[i];
 
     auto* item = new QListWidgetItem(QString::fromStdString(code.name)
-                                         .replace(QStringLiteral("&lt;"), QStringLiteral("<"))
-                                         .replace(QStringLiteral("&gt;"), QStringLiteral(">")));
+                                         .replace(QStringLiteral("&lt;"), QChar::fromLatin1('<'))
+                                         .replace(QStringLiteral("&gt;"), QChar::fromLatin1('>')));
 
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable |
                    Qt::ItemIsDragEnabled);

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -189,7 +189,7 @@ void EnhancementsWidget::LoadPPShaders()
   m_pp_effect->setEnabled(supports_postprocessing);
 
   m_pp_effect->setToolTip(supports_postprocessing ?
-                              QStringLiteral("") :
+                              QString{} :
                               tr("%1 doesn't support this feature.")
                                   .arg(tr(g_video_backend->GetDisplayName().c_str())));
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -299,7 +299,7 @@ void GeneralWidget::OnBackendChanged(const QString& backend_name)
   m_adapter_combo->setEnabled(supports_adapters && !Core::IsRunning());
 
   m_adapter_combo->setToolTip(supports_adapters ?
-                                  QStringLiteral("") :
+                                  QString{} :
                                   tr("%1 doesn't support this feature.")
                                       .arg(tr(g_video_backend->GetDisplayName().c_str())));
 }

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -129,8 +129,8 @@ void HacksWidget::OnBackendChanged(const QString& backend_name)
 
   const QString tooltip = tr("%1 doesn't support this feature on your system.").arg(backend_name);
 
-  m_gpu_texture_decoding->setToolTip(!gpu_texture_decoding ? tooltip : QStringLiteral(""));
-  m_disable_bounding_box->setToolTip(!bbox ? tooltip : QStringLiteral(""));
+  m_gpu_texture_decoding->setToolTip(!gpu_texture_decoding ? tooltip : QString{});
+  m_disable_bounding_box->setToolTip(!bbox ? tooltip : QString{});
 }
 
 void HacksWidget::ConnectWidgets()

--- a/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCKeyboardEmu.cpp
@@ -24,19 +24,19 @@ void GCKeyboardEmu::CreateMainLayout()
   m_main_layout = new QHBoxLayout();
 
   m_main_layout->addWidget(
-      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb0x)));
+      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb0x)));
   m_main_layout->addWidget(
-      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb1x)));
+      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb1x)));
   m_main_layout->addWidget(
-      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb2x)));
+      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb2x)));
   m_main_layout->addWidget(
-      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb3x)));
+      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb3x)));
   m_main_layout->addWidget(
-      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb4x)));
+      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb4x)));
 
   auto* vbox_layout = new QVBoxLayout();
   vbox_layout->addWidget(
-      CreateGroupBox(QStringLiteral(""), Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb5x)));
+      CreateGroupBox(QString{}, Keyboard::GetGroup(GetPort(), KeyboardGroup::Kb5x)));
 
   m_main_layout->addLayout(vbox_layout);
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -32,8 +32,8 @@ constexpr int SLIDER_TICK_COUNT = 100;
 // Escape ampersands and remove ticks
 static QString ToDisplayString(QString&& string)
 {
-  return string.replace(QStringLiteral("&"), QStringLiteral("&&"))
-      .replace(QStringLiteral("`"), QStringLiteral(""));
+  return string.replace(QLatin1Char{'&'}, QStringLiteral("&&"))
+      .replace(QLatin1Char{'`'}, QString{});
 }
 
 bool MappingButton::IsInput() const

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -33,7 +33,7 @@ QString GetExpressionForControl(const QString& control_name,
   if (control_device != default_device)
   {
     expr += QString::fromStdString(control_device.ToString());
-    expr += QStringLiteral(":");
+    expr += QLatin1Char{':'};
   }
 
   // append the control name

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -16,7 +16,7 @@ MappingDouble::MappingDouble(MappingWidget* parent, ControllerEmu::NumericSettin
   setDecimals(2);
 
   if (const auto ui_suffix = m_setting.GetUISuffix())
-    setSuffix(QStringLiteral(" ") + tr(ui_suffix));
+    setSuffix(QLatin1Char{' '} + tr(ui_suffix));
 
   if (const auto ui_description = m_setting.GetUIDescription())
     setToolTip(tr(ui_description));

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -308,8 +308,8 @@ void MappingWindow::OnGlobalDevicesChanged()
     {
       // Selected device is not currently attached.
       const auto qname = QString::fromStdString(default_device);
-      m_devices_combo->addItem(
-          QStringLiteral("[") + tr("disconnected") + QStringLiteral("] ") + qname, qname);
+      m_devices_combo->addItem(QLatin1Char{'['} + tr("disconnected") + QStringLiteral("] ") + qname,
+                               qname);
       m_devices_combo->setCurrentIndex(m_devices_combo->count() - 1);
     }
   }
@@ -339,7 +339,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
   case Type::MAPPING_GC_MICROPHONE:
     widget = new GCMicrophone(this);
     setWindowTitle(tr("GameCube Microphone Slot %1")
-                       .arg(GetPort() == 0 ? QStringLiteral("A") : QStringLiteral("B")));
+                       .arg(GetPort() == 0 ? QLatin1Char{'A'} : QLatin1Char{'B'}));
     AddWidget(tr("Microphone"), widget);
     break;
   case Type::MAPPING_WIIMOTE_EMU:

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -160,7 +160,7 @@ void BreakpointWidget::Update()
   int i = 0;
   m_table->setRowCount(i);
 
-  auto create_item = [](const QString string = QStringLiteral("")) {
+  const auto create_item = [](const QString string = {}) {
     QTableWidgetItem* item = new QTableWidgetItem(string);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     return item;
@@ -224,10 +224,10 @@ void BreakpointWidget::Update()
     QString flags;
 
     if (mbp.is_break_on_read)
-      flags.append(QStringLiteral("r"));
+      flags.append(QLatin1Char{'r'});
 
     if (mbp.is_break_on_write)
-      flags.append(QStringLiteral("w"));
+      flags.append(QLatin1Char{'w'});
 
     m_table->setItem(i, 4, create_item(flags));
 

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -422,7 +422,7 @@ void CodeViewWidget::OnSelectionChanged()
   }
   else if (!styleSheet().isEmpty())
   {
-    setStyleSheet(QStringLiteral(""));
+    setStyleSheet(QString{});
   }
 }
 

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -314,9 +314,9 @@ void CodeWidget::UpdateCallstack()
 
 void CodeWidget::UpdateSymbols()
 {
-  QString selection = m_symbols_list->selectedItems().isEmpty() ?
-                          QStringLiteral("") :
-                          m_symbols_list->selectedItems()[0]->text();
+  const QString selection = m_symbols_list->selectedItems().isEmpty() ?
+                                QString{} :
+                                m_symbols_list->selectedItems()[0]->text();
   m_symbols_list->clear();
 
   for (const auto& symbol : g_symbolDB.Symbols())

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -169,7 +169,8 @@ void MemoryViewWidget::Update()
     case Type::ASCII:
       update_values([&accessors](u32 address) {
         const char value = accessors->ReadU8(address);
-        return std::isprint(value) ? QString{QChar::fromLatin1(value)} : QStringLiteral(".");
+        return std::isprint(value) ? QString{QChar::fromLatin1(value)} :
+                                     QString{QChar::fromLatin1('.')};
       });
       break;
     case Type::U16:

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -81,7 +81,7 @@ void RegisterWidget::CreateWidgets()
   QStringList empty_list;
 
   for (auto i = 0; i < 9; i++)
-    empty_list << QStringLiteral("");
+    empty_list << QString{};
 
   m_table->setHorizontalHeaderLabels(empty_list);
 

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -475,7 +475,7 @@ void FIFOAnalyzer::UpdateDescription()
     text += name.empty() ?
                 QStringLiteral("UNKNOWN_%1").arg(*(cmddata + 1), 2, 16, QLatin1Char('0')) :
                 QString::fromStdString(name);
-    text += QStringLiteral("\n");
+    text += QLatin1Char{'\n'};
 
     if (desc.empty())
       text += tr("No description available");

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -165,13 +165,13 @@ void GCMemcardManager::UpdateSlotTable(int slot)
   auto& memcard = m_slot_memcard[slot];
   auto* table = m_slot_table[slot];
 
-  auto create_item = [](const QString string = QStringLiteral("")) {
+  const auto create_item = [](const QString& string = {}) {
     QTableWidgetItem* item = new QTableWidgetItem(string);
     item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     return item;
   };
 
-  auto strip_garbage = [](const std::string s) {
+  const auto strip_garbage = [](const std::string& s) {
     auto offset = s.find('\0');
     if (offset == std::string::npos)
       offset = s.length();

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -449,7 +449,7 @@ void GameList::ExportWiiSave()
   {
     QString failed_str;
     for (const std::string& str : failed)
-      failed_str.append(QStringLiteral("\n")).append(QString::fromStdString(str));
+      failed_str.append(QLatin1Char{'\n'}).append(QString::fromStdString(str));
     ModalMessageBox::critical(this, tr("Save Export"),
                               tr("Failed to export the following save files:") + failed_str);
   }
@@ -579,7 +579,7 @@ void GameList::CompressISO(bool decompress)
     if (decompress)
     {
       if (files.size() > 1)
-        progress_dialog.setLabelText(tr("Decompressing...") + QStringLiteral("\n") +
+        progress_dialog.setLabelText(tr("Decompressing...") + QLatin1Char{'\n'} +
                                      QFileInfo(QString::fromStdString(original_path)).fileName());
       good = DiscIO::DecompressBlobToFile(original_path, dst_path.toStdString(), &CompressCB,
                                           &progress_dialog);
@@ -587,7 +587,7 @@ void GameList::CompressISO(bool decompress)
     else
     {
       if (files.size() > 1)
-        progress_dialog.setLabelText(tr("Compressing...") + QStringLiteral("\n") +
+        progress_dialog.setLabelText(tr("Compressing...") + QLatin1Char{'\n'} +
                                      QFileInfo(QString::fromStdString(original_path)).fileName());
       good = DiscIO::CompressFileToBlob(original_path, dst_path.toStdString(),
                                         file->GetPlatform() == DiscIO::Platform::WiiDisc ? 1 : 0,

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -657,7 +657,7 @@ QStringList MainWindow::PromptFileNames()
   auto& settings = Settings::Instance().GetQSettings();
   QStringList paths = QFileDialog::getOpenFileNames(
       this, tr("Select a File"),
-      settings.value(QStringLiteral("mainwindow/lastdir"), QStringLiteral("")).toString(),
+      settings.value(QStringLiteral("mainwindow/lastdir"), QString{}).toString(),
       tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.tgc *.wbfs *.ciso *.gcz *.wad *.dff *.m3u);;"
          "All Files (*)"));
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -192,7 +192,7 @@ void MenuBar::AddFileMenu()
 {
   QMenu* file_menu = addMenu(tr("&File"));
   m_open_action = file_menu->addAction(tr("&Open..."), this, &MenuBar::Open,
-                                       QKeySequence(QStringLiteral("Ctrl+O")));
+                                       QKeySequence(Qt::CTRL + Qt::Key_O));
 
   file_menu->addSeparator();
 
@@ -203,8 +203,8 @@ void MenuBar::AddFileMenu()
 
   file_menu->addSeparator();
 
-  m_exit_action = file_menu->addAction(tr("E&xit"), this, &MenuBar::Exit,
-                                       QKeySequence(QStringLiteral("Alt+F4")));
+  m_exit_action =
+      file_menu->addAction(tr("E&xit"), this, &MenuBar::Exit, QKeySequence(Qt::ALT + Qt::Key_F4));
 }
 
 void MenuBar::AddToolsMenu()
@@ -244,8 +244,7 @@ void MenuBar::AddToolsMenu()
   tools_menu->addSeparator();
 
   // Label will be set by a NANDRefresh later
-  m_boot_sysmenu =
-      tools_menu->addAction(QStringLiteral(""), this, [this] { emit BootWiiSystemMenu(); });
+  m_boot_sysmenu = tools_menu->addAction(QString{}, this, [this] { emit BootWiiSystemMenu(); });
   m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, &MenuBar::InstallWAD);
   m_manage_nand_menu = tools_menu->addMenu(tr("Manage NAND"));
   m_import_backup = m_manage_nand_menu->addAction(tr("Import BootMii NAND Backup..."), this,
@@ -325,7 +324,7 @@ void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 
   for (int i = 1; i <= 10; i++)
   {
-    QAction* action = m_state_load_slots_menu->addAction(QStringLiteral(""));
+    QAction* action = m_state_load_slots_menu->addAction(QString{});
 
     connect(action, &QAction::triggered, this, [=]() { emit StateLoadSlotAt(i); });
   }
@@ -342,7 +341,7 @@ void MenuBar::AddStateSaveMenu(QMenu* emu_menu)
 
   for (int i = 1; i <= 10; i++)
   {
-    QAction* action = m_state_save_slots_menu->addAction(QStringLiteral(""));
+    QAction* action = m_state_save_slots_menu->addAction(QString{});
 
     connect(action, &QAction::triggered, this, [=]() { emit StateSaveSlotAt(i); });
   }
@@ -355,7 +354,7 @@ void MenuBar::AddStateSlotMenu(QMenu* emu_menu)
 
   for (int i = 1; i <= 10; i++)
   {
-    QAction* action = m_state_slot_menu->addAction(QStringLiteral(""));
+    QAction* action = m_state_slot_menu->addAction(QString{});
     action->setCheckable(true);
     action->setActionGroup(m_state_slots);
     if (Settings::Instance().GetStateSlot() == i)
@@ -479,7 +478,7 @@ void MenuBar::AddViewMenu()
   view_menu->addAction(tr("Purge Game List Cache"), this, &MenuBar::PurgeGameListCache);
   view_menu->addSeparator();
   view_menu->addAction(tr("Search"), this, &MenuBar::ShowSearch,
-                       QKeySequence(QStringLiteral("Ctrl+F")));
+                       QKeySequence(Qt::CTRL + Qt::Key_F));
 }
 
 void MenuBar::AddOptionsMenu()
@@ -939,7 +938,7 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
     const QString sysmenu_version =
         tmd.IsValid() ?
             QString::fromStdString(DiscIO::GetSysMenuVersionString(tmd.GetTitleVersion())) :
-            QStringLiteral("");
+            QString{};
     m_boot_sysmenu->setText(tr("Load Wii System Menu %1").arg(sysmenu_version));
 
     m_boot_sysmenu->setEnabled(tmd.IsValid());
@@ -1438,8 +1437,8 @@ void MenuBar::LogInstructions()
 void MenuBar::SearchInstruction()
 {
   bool good;
-  QString op = QInputDialog::getText(this, tr("Search instruction"), tr("Instruction:"),
-                                     QLineEdit::Normal, QStringLiteral(""), &good);
+  const QString op = QInputDialog::getText(this, tr("Search instruction"), tr("Instruction:"),
+                                           QLineEdit::Normal, QString{}, &good);
 
   if (!good)
     return;

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -349,10 +349,9 @@ void NetPlaySetupDialog::PopulateGameList()
 
   m_host_games->sortItems();
 
-  QString selected_game = Settings::GetQSettings()
-                              .value(QStringLiteral("netplay/hostgame"), QStringLiteral(""))
-                              .toString();
-  auto find_list = m_host_games->findItems(selected_game, Qt::MatchFlag::MatchExactly);
+  const QString selected_game =
+      Settings::GetQSettings().value(QStringLiteral("netplay/hostgame"), QString{}).toString();
+  const auto find_list = m_host_games->findItems(selected_game, Qt::MatchFlag::MatchExactly);
 
   if (find_list.count() > 0)
     m_host_games->setCurrentItem(find_list[0]);

--- a/Source/Core/DolphinQt/QtUtils/ElidedButton.h
+++ b/Source/Core/DolphinQt/QtUtils/ElidedButton.h
@@ -10,8 +10,7 @@ class ElidedButton : public QPushButton
 {
   Q_OBJECT
 public:
-  explicit ElidedButton(const QString& text = QStringLiteral(""),
-                        Qt::TextElideMode elide_mode = Qt::ElideRight);
+  explicit ElidedButton(const QString& text = {}, Qt::TextElideMode elide_mode = Qt::ElideRight);
 
   Qt::TextElideMode elideMode() const;
   void setElideMode(Qt::TextElideMode elide_mode);

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -86,8 +86,8 @@ void ResourcePackManager::RepopulateTable()
   m_table_widget->clear();
   m_table_widget->setColumnCount(6);
 
-  m_table_widget->setHorizontalHeaderLabels({QStringLiteral(""), tr("Name"), tr("Version"),
-                                             tr("Description"), tr("Author"), tr("Website")});
+  m_table_widget->setHorizontalHeaderLabels(
+      {QString{}, tr("Name"), tr("Version"), tr("Description"), tr("Author"), tr("Website")});
 
   auto* header = m_table_widget->horizontalHeader();
 

--- a/Source/Core/DolphinQt/Resources.cpp
+++ b/Source/Core/DolphinQt/Resources.cpp
@@ -24,7 +24,7 @@ QList<QPixmap> Resources::m_misc;
 
 QIcon Resources::GetIcon(const QString& name, const QString& dir)
 {
-  QString base_path = dir + QStringLiteral("/") + name;
+  QString base_path = dir + QLatin1Char{'/'} + name;
 
   const auto dpr = QGuiApplication::primaryScreen()->devicePixelRatio();
 

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -317,7 +317,7 @@ void GameCubePane::LoadSettings()
   }
 
   m_skip_main_menu->setEnabled(have_menu);
-  m_skip_main_menu->setToolTip(have_menu ? QStringLiteral("") :
+  m_skip_main_menu->setToolTip(have_menu ? QString{} :
                                            tr("Put Main Menu roms in User/GC/{region}."));
 
   // Device Settings

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -66,7 +66,7 @@ static QComboBox* MakeLanguageComboBox()
   };
 
   auto* combobox = new QComboBox();
-  combobox->addItem(QObject::tr("<System Language>"), QStringLiteral(""));
+  combobox->addItem(QObject::tr("<System Language>"), QString{});
   for (const auto& lang : languages)
     combobox->addItem(lang.name, QString::fromLatin1(lang.id));
 
@@ -135,7 +135,7 @@ void InterfacePane::CreateUI()
 
   auto userstyle_search_results = Common::DoFileSearch({File::GetUserPath(D_STYLES_IDX)});
 
-  m_combobox_userstyle->addItem(tr("(None)"), QStringLiteral(""));
+  m_combobox_userstyle->addItem(tr("(None)"), QString{});
 
   for (const std::string& filename : userstyle_search_results)
   {

--- a/Source/Core/DolphinQt/Updater.cpp
+++ b/Source/Core/DolphinQt/Updater.cpp
@@ -79,7 +79,7 @@ void Updater::OnUpdateAvailable(const NewVersionInformation& info)
     layout->addWidget(buttons);
 
     connect(never_btn, &QPushButton::clicked, [dialog] {
-      Settings::Instance().SetAutoUpdateTrack(QStringLiteral(""));
+      Settings::Instance().SetAutoUpdateTrack(QString{});
       dialog->reject();
     });
 


### PR DESCRIPTION
QStringLiterals generate a buffer so that during runtime there's very little cost to constructing a QString. However, this also means that duplicated strings cannot be optimized out into a single entry that gets referenced everywhere, taking up space in the binary.

Rather than use QStringLiteral(""), we can just use QString{} (the default constructor) to signify the empty string. This gets rid of an unnecessary string buffer from being created, saving a tiny bit of space (Qt devs also recommend not using QStringLiteral for empty strings on the project [blog](https://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/))

While we're at it, we can just use the character overloads of particular functions when they're available instead of using a QString overload. The characters in this case are Latin-1 to begin with, so we can just specify the characters as QLatin1Char instances to use those overloads. These will automatically convert to QChar if needed, so this is safe.