### PR TITLE
Threading fixes for config layers

### DIFF
--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -16,16 +16,12 @@
 
 namespace Config
 {
-using Layers = std::map<LayerType, std::unique_ptr<Layer>>;
 using ConfigChangedCallback = std::function<void()>;
 
 // Layer management
-Layers* GetLayers();
-void AddLayer(std::unique_ptr<Layer> layer);
 void AddLayer(std::unique_ptr<ConfigLayerLoader> loader);
-Layer* GetLayer(LayerType layer);
+std::shared_ptr<Layer> GetLayer(LayerType layer);
 void RemoveLayer(LayerType layer);
-bool LayerExists(LayerType layer);
 
 void AddConfigChangedCallback(ConfigChangedCallback func);
 void InvokeConfigChangedCallbacks();

--- a/Source/Core/Common/Config/Layer.cpp
+++ b/Source/Core/Common/Config/Layer.cpp
@@ -46,8 +46,14 @@ bool Layer::Exists(const ConfigLocation& location) const
 bool Layer::DeleteKey(const ConfigLocation& location)
 {
   m_is_dirty = true;
-  bool had_value = m_map[location].has_value();
-  m_map[location].reset();
+  bool had_value = false;
+  const auto iter = m_map.find(location);
+  if (iter != m_map.end() && iter->second.has_value())
+  {
+    iter->second.reset();
+    had_value = true;
+  }
+
   return had_value;
 }
 


### PR DESCRIPTION
This PR refactors Config Layouts functionality a bit, adding a layer of thread safety to them, as well as improving overall clarity. This fixes several "random" crashes on switching the game on/off and accessing configuration menus at the same time.

1) First commit revisits layer manager in `Config` namespace to make it thread safe. API has been made a bit stricter (`Config::GetLayers` was thankfully never used, though!) and some implementation details have been moved from the header file to the .cpp file. Now configuration layers are stored in a `shared_ptr` and not an `unique_ptr`, which cleanly solves an issue of one thread reading those, with another thread deleting them on terminating the game.
On top of that, any functions accessing `s_layers` have been protected with a read-write lock. It might seem like I added some redundant scopes, but that's not the case - `InvokeConfigChangedCallbacks` **must not** be protected with this mutex, else deadlocks occur!
2) Second commit revisits `LayerMap`. ~Previously, it was defined as `std::map<ConfigLocation, std::optional<std::string>>` and presence of a `nullopt` value was treated equally to lack of a value.~ I was able to remove this redundancy by replacing some uses of `operator[]` with `find()`. This also allowed me to mask `Get` functions as const, which was not possible before due to an implicit construction in `operator[]`. Additionally, I believe this may be a memory/performance improvement, since config layers will now **not** store redundant, empty entries for options they were probed on.
EDIT: This has been partially reverted to again store optionals in a map, since it's needed to achieve correct behaviour of deleting config keys. Fixes around `operator[]` persisted.

### Races fixed

I was unable to reproduce this race in Release mode, most likely due to very specific timing required to reproduce it. However, I was able to reproduce it in Debug:
1) Open Graphics options.
2) Launch the game, and quickly terminate it.
3) Repeat 2) until Dolphin crashes.

There were numerous reasons for those crashes - either one thread was reading from a `Layer` which was already deleted by another thread (that's what usage of `std::shared_ptr` fixes), or map's iterators get corrupted because one thread was iterating through it while the other was adding/removing entries to it (that's what a read-write lock fixes).

**NOTE:** There seems to be at least one more race on starting the game (`GetDSPProcessor()` returning null and being used without any validation), but this will **not** be fixed by this PR. If I find a fix better than "add a null check beforehand", I'll submit another PR.