### PR TITLE
DolphinQt/Config/GameConfigEdit: Pass parent pointer to base class

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -21,8 +21,8 @@
 #include "DolphinQt/Config/GameConfigHighlighter.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 
-GameConfigEdit::GameConfigEdit(QWidget* parent, const QString& path, bool read_only)
-    : m_path(path), m_read_only(read_only)
+GameConfigEdit::GameConfigEdit(QWidget* parent, QString path, bool read_only)
+    : QWidget{parent}, m_path(std::move(path)), m_read_only(read_only)
 {
   CreateWidgets();
 

--- a/Source/Core/DolphinQt/Config/GameConfigEdit.h
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.h
@@ -16,7 +16,7 @@ class QTextEdit;
 class GameConfigEdit : public QWidget
 {
 public:
-  explicit GameConfigEdit(QWidget* parent, const QString& path, bool read_only);
+  explicit GameConfigEdit(QWidget* parent, QString path, bool read_only);
 
 protected:
   void keyPressEvent(QKeyEvent* e) override;


### PR DESCRIPTION
Previously, the constructor of GameConfigEdit wasn't doing anything with the passed in parent pointer. This is dangerous because it can result in memory being leaked in certain scenarios. It can also affect layout decisions made by the parent. Instead, pass it through to the base class.

Current usages of the class pass in nullptr as the parent, so this is a safe change to make with regards to the class hierarchy.

While we're at it, we can std::move the passed in QString into the class member, allowing calling code to move strings into the constructor, avoiding copies.