### PR TITLE
NetPlay: Show a message in chat when a player joins or leaves

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -305,6 +305,8 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       m_players[player.pid] = player;
     }
 
+    m_dialog->OnPlayerConnect(player.name);
+
     m_dialog->Update();
   }
   break;
@@ -315,6 +317,8 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
     packet >> pid;
 
     INFO_LOG(NETPLAY, "Player %s (%d) left", m_players.find(pid)->second.name.c_str(), pid);
+
+    m_dialog->OnPlayerDisconnect(m_players.find(pid)->second.name);
 
     {
       std::lock_guard<std::recursive_mutex> lkp(m_crit.players);

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -316,12 +316,15 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
     PlayerId pid;
     packet >> pid;
 
-    INFO_LOG(NETPLAY, "Player %s (%d) left", m_players.find(pid)->second.name.c_str(), pid);
-
-    m_dialog->OnPlayerDisconnect(m_players.find(pid)->second.name);
-
     {
       std::lock_guard<std::recursive_mutex> lkp(m_crit.players);
+      const auto it = m_players.find(pid);
+      if (it == m_players.end())
+        break;
+
+      const auto& player = it->second;
+      INFO_LOG(NETPLAY, "Player %s (%d) left", player.name.c_str(), pid);
+      m_dialog->OnPlayerDisconnect(player.name);
       m_players.erase(m_players.find(pid));
     }
 

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -46,6 +46,8 @@ public:
   virtual void OnMsgStartGame() = 0;
   virtual void OnMsgStopGame() = 0;
   virtual void OnMsgPowerButton() = 0;
+  virtual void OnPlayerConnect(const std::string& player) = 0;
+  virtual void OnPlayerDisconnect(const std::string& player) = 0;
   virtual void OnPadBufferChanged(u32 buffer) = 0;
   virtual void OnHostInputAuthorityChanged(bool enabled) = 0;
   virtual void OnDesync(u32 frame, const std::string& player) = 0;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -887,6 +887,16 @@ void NetPlayDialog::OnMsgPowerButton()
   QueueOnObject(this, [] { UICommon::TriggerSTMPowerEvent(); });
 }
 
+void NetPlayDialog::OnPlayerConnect(const std::string& player)
+{
+  DisplayMessage(tr("%1 has joined").arg(QString::fromStdString(player)), "darkcyan");
+}
+
+void NetPlayDialog::OnPlayerDisconnect(const std::string& player)
+{
+  DisplayMessage(tr("%1 has left").arg(QString::fromStdString(player)), "darkcyan");
+}
+
 void NetPlayDialog::OnPadBufferChanged(u32 buffer)
 {
   QueueOnObject(this, [this, buffer] {

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -49,6 +49,8 @@ public:
   void OnMsgStartGame() override;
   void OnMsgStopGame() override;
   void OnMsgPowerButton() override;
+  void OnPlayerConnect(const std::string& player) override;
+  void OnPlayerDisconnect(const std::string& player) override;
   void OnPadBufferChanged(u32 buffer) override;
   void OnHostInputAuthorityChanged(bool enabled) override;
   void OnDesync(u32 frame, const std::string& player) override;


### PR DESCRIPTION
With this change, Dolphin will show a message in the chat when a player joins or leaves the NetPlay session. The message will appear on the host as well as the clients.

![Screenshot](https://user-images.githubusercontent.com/2292715/62181378-1cccfe80-b321-11e9-97eb-feeea56bd650.png)
