### PR TITLE
DolphinQt/Config/ARCodeWidget: Avoid unnecessary disk operations

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -21,6 +21,7 @@
 #include <QTableWidget>
 #include <QVBoxLayout>
 
+#include "Core/ActionReplay.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Debugger/PPCDebugInterface.h"

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -191,40 +191,43 @@ void ARCodeWidget::OnCodeAddClicked()
   ar.active = true;
 
   CheatCodeEditor ed(this);
-
   ed.SetARCode(&ar);
+  if (ed.exec() == QDialog::Rejected)
+    return;
 
-  if (ed.exec())
-  {
-    m_ar_codes.push_back(std::move(ar));
+  m_ar_codes.push_back(std::move(ar));
 
-    UpdateList();
-    SaveCodes();
-  }
+  UpdateList();
+  SaveCodes();
 }
 
 void ARCodeWidget::OnCodeEditClicked()
 {
-  auto items = m_code_list->selectedItems();
-
+  const auto items = m_code_list->selectedItems();
   if (items.empty())
     return;
 
-  const auto* selected = items[0];
-
+  const auto* const selected = items[0];
   auto& current_ar = m_ar_codes[m_code_list->row(selected)];
 
-  bool user_defined = current_ar.user_defined;
-
-  ActionReplay::ARCode ar = current_ar;
-
   CheatCodeEditor ed(this);
+  if (current_ar.user_defined)
+  {
+    ed.SetARCode(&current_ar);
 
-  ed.SetARCode(user_defined ? &current_ar : &ar);
-  ed.exec();
+    if (ed.exec() == QDialog::Rejected)
+      return;
+  }
+  else
+  {
+    ActionReplay::ARCode ar = current_ar;
+    ed.SetARCode(&ar);
 
-  if (!user_defined)
-    m_ar_codes.push_back(ar);
+    if (ed.exec() == QDialog::Rejected)
+      return;
+
+    m_ar_codes.push_back(std::move(ar));
+  }
 
   SaveCodes();
   UpdateList();

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -36,7 +36,7 @@ ARCodeWidget::ARCodeWidget(const UICommon::GameFile& game, bool restart_required
   // will always be stored in GS/${GAMEID}.ini
   game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
 
-  IniFile game_ini_default = SConfig::GetInstance().LoadDefaultGameIni(m_game_id, m_game_revision);
+  const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
   m_ar_codes = ActionReplay::LoadCodes(game_ini_default, game_ini_local);
 
   UpdateList();

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -43,6 +43,8 @@ ARCodeWidget::ARCodeWidget(const UICommon::GameFile& game, bool restart_required
   OnSelectionChanged();
 }
 
+ARCodeWidget::~ARCodeWidget() = default;
+
 void ARCodeWidget::CreateWidgets()
 {
   m_warning = new CheatWarningWidget(m_game_id, m_restart_required, this);

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -168,11 +168,13 @@ void ARCodeWidget::UpdateList()
 
 void ARCodeWidget::SaveCodes()
 {
-  IniFile game_ini_local;
-  game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
-  ActionReplay::SaveCodes(&game_ini_local, m_ar_codes);
+  const auto ini_path =
+      std::string(File::GetUserPath(D_GAMESETTINGS_IDX)).append(m_game_id).append(".ini");
 
-  game_ini_local.Save(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
+  IniFile game_ini_local;
+  game_ini_local.Load(ini_path);
+  ActionReplay::SaveCodes(&game_ini_local, m_ar_codes);
+  game_ini_local.Save(ini_path);
 }
 
 void ARCodeWidget::AddCode(ActionReplay::ARCode code)

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.h
@@ -10,7 +10,11 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Core/ActionReplay.h"
+
+namespace ActionReplay
+{
+struct ARCode;
+}
 
 namespace UICommon
 {
@@ -28,6 +32,7 @@ class ARCodeWidget : public QWidget
   Q_OBJECT
 public:
   explicit ARCodeWidget(const UICommon::GameFile& game, bool restart_required = true);
+  ~ARCodeWidget() override;
 
   void AddCode(ActionReplay::ARCode code);
 

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -229,12 +229,13 @@ void GeckoCodeWidget::RemoveCode()
 
 void GeckoCodeWidget::SaveCodes()
 {
+  const auto ini_path =
+      std::string(File::GetUserPath(D_GAMESETTINGS_IDX)).append(m_game_id).append(".ini");
+
   IniFile game_ini_local;
-  game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
-
+  game_ini_local.Load(ini_path);
   Gecko::SaveCodes(game_ini_local, m_gecko_codes);
-
-  game_ini_local.Save(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
+  game_ini_local.Save(ini_path);
 }
 
 void GeckoCodeWidget::OnContextMenuRequested()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -185,33 +185,29 @@ void GeckoCodeWidget::AddCode()
 
   CheatCodeEditor ed(this);
   ed.SetGeckoCode(&code);
+  if (ed.exec() == QDialog::Rejected)
+    return;
 
-  if (ed.exec())
-  {
-    m_gecko_codes.push_back(std::move(code));
-    SaveCodes();
-    UpdateList();
-  }
+  m_gecko_codes.push_back(std::move(code));
+  SaveCodes();
+  UpdateList();
 }
 
 void GeckoCodeWidget::EditCode()
 {
   const auto* item = m_code_list->currentItem();
-
   if (item == nullptr)
     return;
 
   const int index = item->data(Qt::UserRole).toInt();
 
   CheatCodeEditor ed(this);
-
   ed.SetGeckoCode(&m_gecko_codes[index]);
+  if (ed.exec() == QDialog::Rejected)
+    return;
 
-  if (ed.exec())
-  {
-    SaveCodes();
-    UpdateList();
-  }
+  SaveCodes();
+  UpdateList();
 }
 
 void GeckoCodeWidget::RemoveCode()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -19,6 +19,7 @@
 #include "Common/IniFile.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/GeckoCode.h"
 #include "Core/GeckoCodeConfig.h"
 
 #include "DolphinQt/Config/CheatCodeEditor.h"
@@ -45,6 +46,8 @@ GeckoCodeWidget::GeckoCodeWidget(const UICommon::GameFile& game, bool restart_re
 
   UpdateList();
 }
+
+GeckoCodeWidget::~GeckoCodeWidget() = default;
 
 void GeckoCodeWidget::CreateWidgets()
 {

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -40,7 +40,7 @@ GeckoCodeWidget::GeckoCodeWidget(const UICommon::GameFile& game, bool restart_re
   // will always be stored in GS/${GAMEID}.ini
   game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
 
-  IniFile game_ini_default = SConfig::GetInstance().LoadDefaultGameIni(m_game_id, m_game_revision);
+  const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
   m_gecko_codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
 
   UpdateList();

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Core/GeckoCode.h"
 
 class CheatWarningWidget;
 class QLabel;
@@ -18,6 +17,11 @@ class QListWidget;
 class QListWidgetItem;
 class QTextEdit;
 class QPushButton;
+
+namespace Gecko
+{
+class GeckoCode;
+}
 
 namespace UICommon
 {
@@ -29,6 +33,7 @@ class GeckoCodeWidget : public QWidget
   Q_OBJECT
 public:
   explicit GeckoCodeWidget(const UICommon::GameFile& game, bool restart_required = true);
+  ~GeckoCodeWidget() override;
 
 signals:
   void OpenGeneralSettings();


### PR DESCRIPTION
In a few cases we were writing out to disk, even when we didn't need to. e.g.

- If a user wanted to clone a code and then clicked cancel on the following edit dialog, we'd still create the code and write out to disk.
- If a user wanted to edit a code and then did nothing and hit cancel, we'd write that code out to disk (even though nothing changed).

This amends our code so that we're not unnecessarily writing out to the disk. While we're in this area, we can do a little bit of cleanup and also apply it to the Gecko code widget, as the code is somewhat similar to the AR code handling.