### PR TITLE
DolphinQt: Limit numeric widget width

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -49,7 +49,7 @@ MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref, bool 
   setFixedHeight(minimumSizeHint().height());
 
   // Make sure that long entries don't throw our layout out of whack.
-  setFixedWidth(112);
+  setFixedWidth(WIDGET_MAX_WIDTH);
 
   setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -15,6 +15,8 @@ MappingDouble::MappingDouble(MappingWidget* parent, ControllerEmu::NumericSettin
   setRange(m_setting.GetMinValue(), m_setting.GetMaxValue());
   setDecimals(2);
 
+  setFixedWidth(WIDGET_MAX_WIDTH);
+
   if (const auto ui_suffix = m_setting.GetUISuffix())
     setSuffix(QStringLiteral(" ") + tr(ui_suffix));
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -10,6 +10,8 @@
 #include <QString>
 #include <QWidget>
 
+constexpr int WIDGET_MAX_WIDTH = 112;
+
 class ControlGroupBox;
 class InputConfig;
 class IOWindow;


### PR DESCRIPTION
This limits the width of the numeric widget to the same maximum width as the mapping buttons.
Old:
![Long](https://user-images.githubusercontent.com/47903084/62297339-51e86680-b471-11e9-94cc-88cd9eb5afb8.JPG)
New:
![Short](https://user-images.githubusercontent.com/47903084/62297356-59a80b00-b471-11e9-8367-09a1a847a43b.JPG)
