### PR TITLE
Make alert messages application modal and not window modal

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -39,7 +39,7 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
                               Common::MsgType style)
 {
   std::optional<bool> r = RunOnObject(QApplication::instance(), [&] {
-    ModalMessageBox message_box(QApplication::activeWindow());
+    ModalMessageBox message_box(QApplication::activeWindow(), Qt::ApplicationModal);
     message_box.setWindowTitle(QString::fromUtf8(caption));
     message_box.setText(QString::fromUtf8(text));
 

--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
@@ -6,10 +6,10 @@
 
 #include <QApplication>
 
-ModalMessageBox::ModalMessageBox(QWidget* parent)
+ModalMessageBox::ModalMessageBox(QWidget* parent, Qt::WindowModality modality)
     : QMessageBox(parent != nullptr ? parent->window() : nullptr)
 {
-  setWindowModality(Qt::WindowModal);
+  setWindowModality(modality);
   setWindowFlags(Qt::Sheet | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
 
   // No parent is still preferable to showing a hidden parent here.

--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.h
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.h
@@ -10,7 +10,7 @@
 class ModalMessageBox : public QMessageBox
 {
 public:
-  explicit ModalMessageBox(QWidget* parent);
+  explicit ModalMessageBox(QWidget* parent, Qt::WindowModality modality = Qt::WindowModal);
 
   static int critical(QWidget* parent, const QString& title, const QString& text,
                       StandardButtons buttons = Ok, StandardButton default_button = NoButton);


### PR DESCRIPTION
This PR fixes a possible UI deadlock which can occur if the user is not careful enough when dealing with assertions (and possibly other messages using `MSG_ALERT`).
Previously, it was possible to deadlock Dolphin by attempting to close either the emulation window or the main window while the assert is on screen. Now, assertions are application modal and not window modal, which means they block input to **all** windows.

Easiest way to trigger the bug is as follows:

0. Have an assertion ready somewhere on game's startup flow. Any real or artificially added assert will do.

## First way
1. Boot the game and observe the assertion. Observe emulation window's navigation buttons are blocked (because of the message box).
2. Bring main Dolphin's window to front and and observe its navigation buttons are **not** blocked. Press X to close the window.
3. Observe assertion message box freezes and user is deadlocked.

## Second way
1. Boot the game and **quickly unfocus from a newly spawned emulation window**.
2. Observe the assertion. Bring emulation window to front and observe its navigation buttons are **not** blocked (because message box doesn't have it as parent now).
3. Press X to close the emulation window.
4. Observe assertion message box freezes and user is deadlocked.


Thanks to marking message alerts as application modal, both repro steps are fixed.