### PR TITLE
DolphinQt: Refactor render widget initialization

### DIFF
--- a/Source/Core/Common/GL/GLInterface/WGL.h
+++ b/Source/Core/Common/GL/GLInterface/WGL.h
@@ -21,6 +21,7 @@ public:
   bool ClearCurrent() override;
 
   void Update() override;
+  void UpdateSurface(void* window_handle) override;
 
   void Swap() override;
   void SwapInterval(int interval) override;
@@ -29,6 +30,7 @@ public:
 
 protected:
   bool Initialize(const WindowSystemInfo& wsi, bool stereo, bool core) override;
+  bool InitializeDC();
 
   static HGLRC CreateCoreContext(HDC dc, HGLRC share_context);
   static bool CreatePBuffer(HDC onscreen_dc, int width, int height, HANDLE* pbuffer_handle,
@@ -38,4 +40,5 @@ protected:
   HANDLE m_pbuffer_handle = nullptr;
   HDC m_dc = nullptr;
   HGLRC m_rc = nullptr;
+  bool m_stereo = false;
 };

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -23,6 +23,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
 #include "DolphinQt/Config/Graphics/GraphicsRadio.h"
 #include "DolphinQt/Config/Graphics/GraphicsWindow.h"
+#include "DolphinQt/Host.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Settings.h"
 
@@ -93,6 +94,8 @@ void GeneralWidget::CreateWidgets()
   m_show_messages =
       new GraphicsBool(tr("Show NetPlay Messages"), Config::GFX_SHOW_NETPLAY_MESSAGES);
   m_render_main_window = new GraphicsBool(tr("Render to Main Window"), Config::MAIN_RENDER_TO_MAIN);
+  connect(m_render_main_window, &GraphicsBool::stateChanged,
+          [](int) { Host::GetInstance()->UpdateRenderWidget(); });
 
   m_options_box->setLayout(m_options_layout);
 
@@ -185,7 +188,6 @@ void GeneralWidget::SaveSettings()
 void GeneralWidget::OnEmulationStateChanged(bool running)
 {
   m_backend_combo->setEnabled(!running);
-  m_render_main_window->setEnabled(!running);
 
   const bool supports_adapters = !g_Config.backend_info.Adapters.empty();
   m_adapter_combo->setEnabled(!running && supports_adapters);

--- a/Source/Core/DolphinQt/Host.h
+++ b/Source/Core/DolphinQt/Host.h
@@ -36,6 +36,7 @@ signals:
   void UpdateProgressDialog(QString label, int position, int maximum);
   void UpdateDisasmDialog();
   void NotifyMapLoaded();
+  void UpdateRenderWidget();
 
 private:
   Host();

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -113,7 +113,6 @@ private:
   void ConnectHost();
   void ConnectHotkeys();
   void ConnectMenuBar();
-  void ConnectRenderWidget();
   void ConnectStack();
   void ConnectToolBar();
 
@@ -137,8 +136,9 @@ private:
   void StartGame(const std::vector<std::string>& paths,
                  const std::optional<std::string>& savestate_path = {});
   void StartGame(std::unique_ptr<BootParameters>&& parameters);
-  void ShowRenderWidget();
-  void HideRenderWidget(bool reinit = true);
+  void CreateRenderWidget(bool render_to_main, bool fullscreen);
+  void UpdateRenderWidget(bool render_to_main, bool fullscreen);
+  void DestroyRenderWidget(bool reset_controller_interface);
 
   void ShowSettingsWindow();
   void ShowGeneralWindow();

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -42,6 +42,7 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
   setWindowIcon(Resources::GetAppIcon());
   setWindowRole(QStringLiteral("renderer"));
   setAcceptDrops(true);
+  setFocusPolicy(Qt::StrongFocus);
 
   QPalette p;
   p.setColor(QPalette::Window, Qt::black);
@@ -62,17 +63,6 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
     if (state == Core::State::Running)
       SetImGuiKeyMap();
   });
-
-  // We have to use Qt::DirectConnection here because we don't want those signals to get queued
-  // (which results in them not getting called)
-  connect(this, &RenderWidget::StateChanged, Host::GetInstance(), &Host::SetRenderFullscreen,
-          Qt::DirectConnection);
-  connect(this, &RenderWidget::HandleChanged, Host::GetInstance(), &Host::SetRenderHandle,
-          Qt::DirectConnection);
-  connect(this, &RenderWidget::SizeChanged, Host::GetInstance(), &Host::ResizeSurface,
-          Qt::DirectConnection);
-  connect(this, &RenderWidget::FocusChanged, Host::GetInstance(), &Host::SetRenderFocus,
-          Qt::DirectConnection);
 
   m_mouse_timer = new QTimer(this);
   connect(m_mouse_timer, &QTimer::timeout, this, &RenderWidget::HandleCursorTimer);


### PR DESCRIPTION
Changes the show/hide to always use new widgets, rather than reparenting and such. Hopefully will improve stability on platforms like Wayland. The added bonus is you can switch to/from the main window while emulation is running.

Marked WIP because there's still some issues with input not being switched over correctly.