### PR TITLE
RenderState: Approximate logic op with blending if unsupported

### DIFF
--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -68,6 +68,10 @@ union BlendingState
 {
   void Generate(const BPMemory& bp);
 
+  // HACK: Replaces logical operations with blend operations.
+  // Will not be bit-correct, and in some cases not even remotely in the same ballpark.
+  void ApproximateLogicOpWithBlending();
+
   BlendingState& operator=(const BlendingState& rhs);
 
   bool operator==(const BlendingState& rhs) const { return hex == rhs.hex; }

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -558,6 +558,13 @@ AbstractPipelineConfig ShaderCache::GetGXPipelineConfig(
   config.depth_state = depth_state;
   config.blending_state = blending_state;
   config.framebuffer_state = g_framebuffer_manager->GetEFBFramebufferState();
+
+  if (config.blending_state.logicopenable && !g_ActiveConfig.backend_info.bSupportsLogicOp)
+  {
+    WARN_LOG(VIDEO, "Approximating logic op with blending, this will produce incorrect rendering.");
+    config.blending_state.ApproximateLogicOpWithBlending();
+  }
+
   return config;
 }
 


### PR DESCRIPTION
This is a giant hack which was previously removed because it causes broken rendering. However, it seems that some devices still do not support logical operations (looking at you, Adreno/Mali). Therefore, for a handful of cases where the hack actually makes things slightly better, we can use it.

... but not without spamming the log with warnings. With my warning message PR, we can inform the users before emulation starts anyway.

Fixes MKWii on Win7 again after #8283 broke it, and phones which don't support this feature.