### PR TITLE
InputCommon/DInputJoystick: Correct force-feedback flag testing

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -164,9 +164,8 @@ Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVI
   if (SUCCEEDED(m_device->EnumObjects(DIEnumDeviceObjectsCallback, (LPVOID)&objects, DIDFT_AXIS)))
   {
     const int num_ff_axes =
-        std::count_if(std::begin(objects), std::end(objects), [](DIDEVICEOBJECTINSTANCE& pdidoi) {
-          return pdidoi.dwFlags && DIDOI_FFACTUATOR;
-        });
+        std::count_if(std::begin(objects), std::end(objects),
+                      [](const auto& pdidoi) { return (pdidoi.dwFlags & DIDOI_FFACTUATOR) != 0; });
     InitForceFeedback(m_device, num_ff_axes);
   }
 


### PR DESCRIPTION
Introduced in a995e2f5ba3bb55b4245675428bbdc3d34cb7355

We need to be performing a bitwise AND on the flags and not a logical AND, otherwise we could end up counting device objects that don't support forced feedback