### PR TITLE
FramebufferManager: Fix restoring of EFB depth buffer / upside-down in OpenGL

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -472,6 +472,7 @@ bool FramebufferManager::CompileReadbackPipelines()
   if (!restore_shader)
     return false;
 
+  config.depth_state = RenderState::GetAlwaysWriteDepthState();
   config.framebuffer_state = GetEFBFramebufferState();
   config.framebuffer_state.per_sample_shading = false;
   config.vertex_shader = g_shader_cache->GetScreenQuadVertexShader();

--- a/Source/Core/VideoCommon/FramebufferShaderGen.cpp
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.cpp
@@ -651,14 +651,11 @@ std::string GenerateEFBRestorePixelShader()
   EmitPixelMainDeclaration(ss, 1, 0, "float4",
                            GetAPIType() == APIType::D3D ? "out float depth : SV_Depth, " : "");
   ss << "{\n";
-  ss << "  float3 coords = float3(v_tex0.x, "
-     << (g_ActiveConfig.backend_info.bUsesLowerLeftOrigin ? "1.0 - " : "")
-     << "v_tex0.y, v_tex0.z);\n";
   ss << "  ocol0 = ";
-  EmitSampleTexture(ss, 0, "coords");
+  EmitSampleTexture(ss, 0, "v_tex0");
   ss << ";\n";
   ss << "  " << (GetAPIType() == APIType::D3D ? "depth" : "gl_FragDepth") << " = ";
-  EmitSampleTexture(ss, 1, "coords");
+  EmitSampleTexture(ss, 1, "v_tex0");
   ss << ".r;\n";
   ss << "}\n";
   return ss.str();


### PR DESCRIPTION
What the title says. The lower-left correction only worked when loading a save state created with a different backend with OpenGL, not with GL to GL. Now GL shouldn't flip the image.

Note that the EFB in the save states is not currently compatible between backends. That is a larger change. The lower-left origin is not the only concern here, we have to consider reversed depth range as well.