### PR TITLE
Fix for Android version crashing when changing rotation on settings screen

### DIFF
--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,7 @@
 
         <activity
             android:name=".features.settings.ui.SettingsActivity"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/DolphinSettingsBase"
             android:label="@string/preferences_settings"/>
 


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/10815

The "correct way" would be to fully save and restore data on onSaveInstanceState and restore it back on onCreate. I tried to do that first.

As there is various conflicts with doing this without some form of refactor due to how the lifecycle diverges and is baked-in to the application, ignoring Activity recreation on orientation change should work well enough and we don't draw anything different in settings on landscape mode anyway.