### PR TITLE
DolphinQt: Reorder nunchuk mapping

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -102,15 +102,15 @@ void WiimoteEmuExtension::CreateNunchukLayout()
   auto* layout = new QGridLayout();
   m_nunchuk_box = new QGroupBox(tr("Nunchuk"), this);
 
-  layout->addWidget(CreateGroupBox(tr("Shake"), Wiimote::GetNunchukGroup(
-                                                    GetPort(), WiimoteEmu::NunchukGroup::Shake)),
+  layout->addWidget(CreateGroupBox(tr("Stick"), Wiimote::GetNunchukGroup(
+                                                    GetPort(), WiimoteEmu::NunchukGroup::Stick)),
                     0, 0);
   layout->addWidget(
       CreateGroupBox(tr("Buttons"),
                      Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Buttons)),
       1, 0);
-  layout->addWidget(CreateGroupBox(tr("Stick"), Wiimote::GetNunchukGroup(
-                                                    GetPort(), WiimoteEmu::NunchukGroup::Stick)),
+  layout->addWidget(CreateGroupBox(tr("Shake"), Wiimote::GetNunchukGroup(
+                                                    GetPort(), WiimoteEmu::NunchukGroup::Shake)),
                     0, 1, -1, 1);
   layout->addWidget(CreateGroupBox(tr("Tilt"), Wiimote::GetNunchukGroup(
                                                    GetPort(), WiimoteEmu::NunchukGroup::Tilt)),


### PR DESCRIPTION
Switch shake and stick in the nunchuk mapping to seperate normal controls and motion controls better.
Currently, the stick mappings sits between shake and tilt which doesn't make a lot of sense.
New:
![New](https://user-images.githubusercontent.com/47903084/62423359-2c04d100-b6c0-11e9-86fe-771e88c5be56.PNG)
