### PR TITLE
UICommon/NetPlayIndex: Minor interface cleanup

### DIFF
--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -256,7 +256,7 @@ std::vector<std::pair<std::string, std::string>> NetPlayIndex::GetRegions()
 // It isn't very secure but is preferable to adding another dependency on mbedtls
 // The encrypted data is encoded as nibbles with the character 'A' as the base offset
 
-bool NetPlaySession::EncryptID(const std::string& password)
+bool NetPlaySession::EncryptID(std::string_view password)
 {
   if (password.empty())
     return false;
@@ -284,7 +284,7 @@ bool NetPlaySession::EncryptID(const std::string& password)
   return true;
 }
 
-std::optional<std::string> NetPlaySession::DecryptID(const std::string& password) const
+std::optional<std::string> NetPlaySession::DecryptID(std::string_view password) const
 {
   if (password.empty())
     return {};

--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -333,7 +333,7 @@ bool NetPlayIndex::HasActiveSession() const
   return !m_secret.empty();
 }
 
-void NetPlayIndex::SetErrorCallback(std::function<void()> function)
+void NetPlayIndex::SetErrorCallback(std::function<void()> callback)
 {
-  m_error_callback = function;
+  m_error_callback = std::move(callback);
 }

--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -25,13 +25,14 @@ NetPlayIndex::~NetPlayIndex()
     Remove();
 }
 
-static std::optional<picojson::value> ParseResponse(std::vector<u8> response)
+static std::optional<picojson::value> ParseResponse(const std::vector<u8>& response)
 {
-  std::string response_string(reinterpret_cast<char*>(response.data()), response.size());
+  const std::string response_string(reinterpret_cast<const char*>(response.data()),
+                                    response.size());
 
   picojson::value json;
 
-  auto error = picojson::parse(json, response_string);
+  const auto error = picojson::parse(json, response_string);
 
   if (!error.empty())
     return {};

--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -221,7 +221,7 @@ void NetPlayIndex::SetPlayerCount(int player_count)
   m_player_count = player_count;
 }
 
-void NetPlayIndex::SetGame(const std::string game)
+void NetPlayIndex::SetGame(std::string game)
 {
   m_game = std::move(game);
 }

--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -159,7 +159,7 @@ void NetPlayIndex::NotificationLoop()
   }
 }
 
-bool NetPlayIndex::Add(NetPlaySession session)
+bool NetPlayIndex::Add(const NetPlaySession& session)
 {
   Common::HttpRequest request;
   auto response = request.Get(

--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -86,8 +86,6 @@ NetPlayIndex::List(const std::map<std::string, std::string>& filters)
 
   for (const auto& entry : entries.get<picojson::array>())
   {
-    NetPlaySession session;
-
     const auto& name = entry.get("name");
     const auto& region = entry.get("region");
     const auto& method = entry.get("method");
@@ -107,6 +105,7 @@ NetPlayIndex::List(const std::map<std::string, std::string>& filters)
       continue;
     }
 
+    NetPlaySession session;
     session.name = name.to_str();
     session.region = region.to_str();
     session.game_id = game_id.to_str();

--- a/Source/Core/UICommon/NetPlayIndex.h
+++ b/Source/Core/UICommon/NetPlayIndex.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -29,8 +30,8 @@ struct NetPlaySession
   bool has_password;
   bool in_game;
 
-  bool EncryptID(const std::string& password);
-  std::optional<std::string> DecryptID(const std::string& password) const;
+  bool EncryptID(std::string_view password);
+  std::optional<std::string> DecryptID(std::string_view password) const;
 };
 
 class NetPlayIndex

--- a/Source/Core/UICommon/NetPlayIndex.h
+++ b/Source/Core/UICommon/NetPlayIndex.h
@@ -44,7 +44,7 @@ public:
 
   static std::vector<std::pair<std::string, std::string>> GetRegions();
 
-  bool Add(NetPlaySession session);
+  bool Add(const NetPlaySession& session);
   void Remove();
 
   bool HasActiveSession() const;


### PR DESCRIPTION
Tidies up bits of the interface a little, reducing the overall number of copies necessary in a few instances. It also makes use of `std::string_view` for two functions, given the strings are only ever read from in those functions, but not fully stored or copied elsewhere.