### PR TITLE
Use valid IR calibration data

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -76,14 +76,30 @@ void Wiimote::Reset()
   // EEPROM
   m_eeprom = {};
 
-  // IR calibration and maybe more unknown purposes:
-  // The meaning of this data needs more investigation.
-  // Last byte is a checksum.
+  // IR calibration:
   std::array<u8, 11> ir_calibration = {
-      0xA1, 0xAA, 0x8B, 0x99, 0xAE, 0x9E, 0x78, 0x30, 0xA7, 0x74, 0x00,
+      // Point 1
+      IR_LOW_X & 0xFF,
+      IR_LOW_Y & 0xFF,
+      // Mix
+      ((IR_LOW_Y & 0x300) >> 2) | ((IR_LOW_X & 0x300) >> 4) | ((IR_LOW_Y & 0x300) >> 6) |
+          ((IR_HIGH_X & 0x300) >> 8),
+      // Point 2
+      IR_HIGH_X & 0xFF,
+      IR_LOW_Y & 0xFF,
+      // Point 3
+      IR_HIGH_X & 0xFF,
+      IR_HIGH_Y & 0xFF,
+      // Mix
+      ((IR_HIGH_Y & 0x300) >> 2) | ((IR_HIGH_X & 0x300) >> 4) | ((IR_HIGH_Y & 0x300) >> 6) |
+          ((IR_LOW_X & 0x300) >> 8),
+      // Point 4
+      IR_LOW_X & 0xFF,
+      IR_HIGH_Y & 0xFF,
+      // Checksum
+      0x00,
   };
-  // Purposely not updating checksum because using this data results in a weird IR offset..
-  // UpdateCalibrationDataChecksum(ir_calibration, 1);
+  UpdateCalibrationDataChecksum(ir_calibration, 1);
   m_eeprom.ir_calibration_1 = ir_calibration;
   m_eeprom.ir_calibration_2 = ir_calibration;
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -83,6 +83,11 @@ void UpdateCalibrationDataChecksum(T& data, int cksum_bytes)
 class Wiimote : public ControllerEmu::EmulatedController
 {
 public:
+  static constexpr u16 IR_LOW_X = 0x7F;
+  static constexpr u16 IR_LOW_Y = 0x5D;
+  static constexpr u16 IR_HIGH_X = 0x380;
+  static constexpr u16 IR_HIGH_Y = 0x2A2;
+
   static constexpr u8 ACCEL_ZERO_G = 0x80;
   static constexpr u8 ACCEL_ONE_G = 0x9A;
 


### PR DESCRIPTION
Previously, IR calibration data with an invalid checksum was used, because the calibration produced a strange offset.  I've replaced it with calibration data that encodes the same values as the data Nintendo falls back to when the checksum is bad.

I've also updated the [documentation on wiibrew](https://wiibrew.org/wiki/Wiimote#EEPROM_Memory), though I'm not completely happy with the naming and I'm still not 100% sure what these values _mean_ &mdash; but I know enough to at least replace it with the defaults.

It's worth noting that dolphin doesn't use the same value for acceleration as Nintendo defaults to &mdash; but it's probably not worth changing that as that would cause issues with TAS and such.  Since IR already behaved as if it were the default, it's fine to change this one.