### PR TITLE
PixelShaderGen: fix OOB indirect texcoord indices

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -794,16 +794,14 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host
       unsigned int texcoord = uid_data->GetTevindirefCoord(i);
       unsigned int texmap = uid_data->GetTevindirefMap(i);
 
-      if (texcoord < uid_data->genMode_numtexgens)
-      {
-        out.SetConstantsUsed(C_INDTEXSCALE + i / 2, C_INDTEXSCALE + i / 2);
-        out.Write("\ttempcoord = fixpoint_uv%d >> " I_INDTEXSCALE "[%d].%s;\n", texcoord, i / 2,
-                  (i & 1) ? "zw" : "xy");
-      }
-      else
-      {
-        out.Write("\ttempcoord = int2(0, 0);\n");
-      }
+      // TODO: are out-of-range values set to zero or clamped?
+      // TODO: same thing probably with direct texcoord indices?
+      if (texcoord >= uid_data->genMode_numtexgens)
+        texcoord = 0;
+
+      out.SetConstantsUsed(C_INDTEXSCALE + i / 2, C_INDTEXSCALE + i / 2);
+      out.Write("\ttempcoord = fixpoint_uv%d >> " I_INDTEXSCALE "[%d].%s;\n", texcoord, i / 2,
+                (i & 1) ? "zw" : "xy");
 
       out.Write("\tint3 iindtex%d = ", i);
       SampleTexture(out, "float2(tempcoord)", "abg", texmap, stereo, ApiType);


### PR DESCRIPTION
Previously we set the indirect texture coordinate to zero, now we set the indirect texture coordinate *index* to zero. This fixes the ripple effect of the Mario painting in Luigi's Mansion ([issue 11462](https://bugs.dolphin-emu.org/issues/11462)).

Needs some hardware tests.