### PR TITLE
DolphinQt: Add bug tracker button

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -550,6 +550,11 @@ void MenuBar::AddHelpMenu()
   connect(github, &QAction::triggered, this, []() {
     QDesktopServices::openUrl(QUrl(QStringLiteral("https://github.com/dolphin-emu/dolphin")));
   });
+  QAction* bugtracker = help_menu->addAction(tr("&Bug Tracker"));
+  connect(bugtracker, &QAction::triggered, this, []() {
+    QDesktopServices::openUrl(
+        QUrl(QStringLiteral("https://bugs.dolphin-emu.org/projects/emulator")));
+  });
 
   if (AutoUpdateChecker::SystemSupportsAutoUpdates())
   {


### PR DESCRIPTION
This adds a 'Submit Bug Report' button in 'Help' as requested in: https://bugs.dolphin-emu.org/issues/11816.
![Bugreport](https://user-images.githubusercontent.com/47903084/62473764-bb35e580-b7a1-11e9-9673-55f8ccb81eb5.png)

I'm not sure if this is the best position and layout. 