### PR TITLE
WinUpdater: Properly hide window on startup as intended

### DIFF
--- a/Source/Core/WinUpdater/WinUI.cpp
+++ b/Source/Core/WinUpdater/WinUI.cpp
@@ -45,7 +45,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 };  // namespace
 
 constexpr int PROGRESSBAR_FLAGS = WS_VISIBLE | WS_CHILD | PBS_SMOOTH | PBS_SMOOTHREVERSE;
-constexpr int WINDOW_FLAGS = WS_VISIBLE | WS_CLIPCHILDREN;
+constexpr int WINDOW_FLAGS = WS_CLIPCHILDREN;
 constexpr int PADDING_HEIGHT = 5;
 
 namespace UI


### PR DESCRIPTION
This PR fixes two minor issues in Windows Updater:

1) Updater window is now created hidden, as UpdaterCommon attempts to hide it anyway just after creating:
```cpp
UI::Init();
UI::SetVisible(false);
```

However, creating it visible and hiding still made it flicker for a split second, which is not really useful and not aesthetic.

2) `UI::Init` was tweaked so it waits for the UI thread to exit from `InitWindow`, so after the window has either been created or it's been attempted to be created. This avoids "losing" information from calls to eg. `SetVisible` which could be made **before** the window creates. This for example caused an issue where updater was stuck as always on top, even when the user selected "Update after quitting Dolphin". This rendered this option basically useless, because updater window was stuck on top until the user has quit Dolphin.