### PR TITLE
Update WiiWare INIs

### DIFF
--- a/Data/Sys/GameSettings/WBK.ini
+++ b/Data/Sys/GameSettings/WBK.ini
@@ -1,8 +1,7 @@
-# WD9EA4, WD9JA4, WD9PA4 - Castlevania: The Adventure ReBirth
+# WBKJGD, WBKEGD, WBKPGD - Arkanoid Plus!
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -13,5 +12,8 @@ CPUThread = False
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+# Add any video settings here
+
 [Video_Hacks]
-DeferEFBCopies = False
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/WIC.ini
+++ b/Data/Sys/GameSettings/WIC.ini
@@ -1,8 +1,7 @@
-# WD9EA4, WD9JA4, WD9PA4 - Castlevania: The Adventure ReBirth
+# WICPKQ, WICEKQ, WICJKQ - NyxQuest: Kindred Spirits
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -14,4 +13,4 @@ CPUThread = False
 # Add action replay cheats here.
 
 [Video_Hacks]
-DeferEFBCopies = False
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/WKT.ini
+++ b/Data/Sys/GameSettings/WKT.ini
@@ -1,4 +1,4 @@
-# WD9EA4, WD9JA4, WD9PA4 - Castlevania: The Adventure ReBirth
+# WKTPA4, WKTEA4, WKTJA4 - Contra ReBirth
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/XHD.ini
+++ b/Data/Sys/GameSettings/XHD.ini
@@ -1,8 +1,7 @@
-# WD9EA4, WD9JA4, WD9PA4 - Castlevania: The Adventure ReBirth
+# XHDPKQ, XHDEKQ - NyxQuest: Kindred Spirits
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -14,4 +13,4 @@ CPUThread = False
 # Add action replay cheats here.
 
 [Video_Hacks]
-DeferEFBCopies = False
+EFBToTextureEnable = False


### PR DESCRIPTION
Taken from https://github.com/dolphin-emu/dolphin/pull/8164 which is maybe a bit to big to review with 79 INI files changed. 
This contains the importand INI changes for WiiWare titles:
-Castlevania: The Adventure ReBirth and Contra ReBirth need DeferEFBCopies and DualCore disabled to go in-game.
-Arkanoid Plus! needs EFB to Texture and Ram to defeat the boss.
-NyxQuest: Kindred Spirits needs EFB to Texture and Ram to render the ground.