### PR TITLE
Qt/GCMemcardManager: Fix icon animations displaying incorrectly.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -473,6 +473,15 @@ std::string GCMemcard::DEntry_BIFlags(u8 index) const
   return flags;
 }
 
+bool GCMemcard::DEntry_IsPingPong(u8 index) const
+{
+  if (!m_valid || index >= DIRLEN)
+    return false;
+
+  const int flags = GetActiveDirectory().m_dir_entries[index].m_banner_and_icon_flags;
+  return (flags & 0b0000'0100) != 0;
+}
+
 std::string GCMemcard::DEntry_FileName(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -438,6 +438,7 @@ public:
   std::string DEntry_GameCode(u8 index) const;
   std::string DEntry_Makercode(u8 index) const;
   std::string DEntry_BIFlags(u8 index) const;
+  bool DEntry_IsPingPong(u8 index) const;
   std::string DEntry_FileName(u8 index) const;
   u32 DEntry_ModTime(u8 index) const;
   u32 DEntry_ImageOffset(u8 index) const;

--- a/Source/Core/DolphinQt/GCMemcardManager.h
+++ b/Source/Core/DolphinQt/GCMemcardManager.h
@@ -11,6 +11,8 @@
 
 #include <QDialog>
 
+#include "Common/CommonTypes.h"
+
 class GCMemcard;
 class GCMemcardErrorCode;
 
@@ -34,6 +36,8 @@ public:
   static QString GetErrorMessagesForErrorCode(const GCMemcardErrorCode& code);
 
 private:
+  struct IconAnimationData;
+
   void CreateWidgets();
   void ConnectWidgets();
 
@@ -52,7 +56,8 @@ private:
   void DrawIcons();
 
   QPixmap GetBannerFromSaveFile(int file_index, int slot);
-  std::vector<QPixmap> GetIconFromSaveFile(int file_index, int slot);
+
+  IconAnimationData GetIconFromSaveFile(int file_index, int slot);
 
   // Actions
   QPushButton* m_select_button;
@@ -65,7 +70,7 @@ private:
 
   // Slots
   static constexpr int SLOT_COUNT = 2;
-  std::array<std::vector<std::pair<int, std::vector<QPixmap>>>, SLOT_COUNT> m_slot_active_icons;
+  std::array<std::vector<IconAnimationData>, SLOT_COUNT> m_slot_active_icons;
   std::array<std::unique_ptr<GCMemcard>, SLOT_COUNT> m_slot_memcard;
   std::array<QGroupBox*, SLOT_COUNT> m_slot_group;
   std::array<QLineEdit*, SLOT_COUNT> m_slot_file_edit;
@@ -74,7 +79,7 @@ private:
   std::array<QLabel*, SLOT_COUNT> m_slot_stat_label;
 
   int m_active_slot;
-  int m_current_frame;
+  u64 m_current_frame = 0;
 
   QDialogButtonBox* m_button_box;
   QTimer* m_timer;


### PR DESCRIPTION
The previous code had some odd assumptions that caused it to only show, at max, the first three frames of each animation. It also didn't handle the animation speed or the ping-pong frame order correctly. This should all be fixed with this.

The performance of this I mentioned in IRC is marginally improved by this due to the timer running less often, but it's still pretty poor; further investigation into that is necessary.