### PR TITLE
Input Profile Overhaul

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -135,6 +135,9 @@ void MappingButton::UpdateIndicator()
 void MappingButton::ConfigChanged()
 {
   setText(ToDisplayString(QString::fromStdString(m_reference->GetExpression())));
+
+  // Key changed, so clear any set profile
+  m_parent->GetParent()->ClearProfile();
 }
 
 void MappingButton::mouseReleaseEvent(QMouseEvent* event)

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -455,11 +455,12 @@ void MappingWindow::PopulateProfileSelection()
 
   const std::string profiles_path =
       File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR + m_config->GetProfileName();
-  for (const auto& filename : Common::DoFileSearch({profiles_path}, {".ini"}))
+  for (const auto& filename : Common::DoFileSearch({profile_path.string()}, {".ini"}, true))
   {
-    std::string basename;
-    SplitPath(filename, nullptr, &basename, nullptr);
-    m_profiles_combo->addItem(QString::fromStdString(basename), QString::fromStdString(filename));
+    const auto filename_path = std::filesystem::path{filename};
+    m_profiles_combo->addItem(
+        QString::fromStdString(std::filesystem::relative(filename_path, profile_path).string()),
+        QString::fromStdString(filename));
   }
 
   m_profiles_combo->insertSeparator(m_profiles_combo->count());

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -53,6 +53,7 @@ public:
   ControllerEmu::EmulatedController* GetController() const;
   bool IsMappingAllDevices() const;
   void ShowExtensionMotionTabs(bool show);
+  void ClearProfile();
 
 signals:
   // Emitted when config has changed so widgets can update to reflect the change.
@@ -123,4 +124,10 @@ private:
   Type m_mapping_type;
   const int m_port;
   InputConfig* m_config;
+
+  // Profile clears typically happen when setting a button's
+  // key expression unfortunately loading a profile emits a config
+  // change which causes all buttons to pretend they had
+  // their key expression set, we want to ignore these
+  bool m_ignore_profile_clears = false;
 };

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -22,6 +22,7 @@
 #include "Core/Core.h"
 #include "Core/FreeLookManager.h"
 #include "Core/Host.h"
+#include "Core/HW/Wiimote.h"
 #include "Core/HotkeyManager.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
@@ -272,44 +273,44 @@ void HotkeyScheduler::Run()
       }
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_1))
-        m_profile_cycler.PreviousWiimoteProfile(0);
+        Wiimote::GetConfig()->GetController(0)->GetProfileManager().PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_1))
-        m_profile_cycler.NextWiimoteProfile(0);
+        Wiimote::GetConfig()->GetController(0)->GetProfileManager().NextProfile();
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_2))
-        m_profile_cycler.PreviousWiimoteProfile(1);
+        Wiimote::GetConfig()->GetController(1)->GetProfileManager().PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_2))
-        m_profile_cycler.NextWiimoteProfile(1);
+        Wiimote::GetConfig()->GetController(1)->GetProfileManager().NextProfile();
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_3))
-        m_profile_cycler.PreviousWiimoteProfile(2);
+        Wiimote::GetConfig()->GetController(2)->GetProfileManager().PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_3))
-        m_profile_cycler.NextWiimoteProfile(2);
+        Wiimote::GetConfig()->GetController(2)->GetProfileManager().NextProfile();
 
       if (IsHotkey(HK_PREV_WIIMOTE_PROFILE_4))
-        m_profile_cycler.PreviousWiimoteProfile(3);
+        Wiimote::GetConfig()->GetController(3)->GetProfileManager().PreviousProfile();
       else if (IsHotkey(HK_NEXT_WIIMOTE_PROFILE_4))
-        m_profile_cycler.NextWiimoteProfile(3);
+        Wiimote::GetConfig()->GetController(3)->GetProfileManager().NextProfile();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_1))
-        m_profile_cycler.PreviousWiimoteProfileForGame(0);
+        Wiimote::GetConfig()->GetController(0)->GetProfileManager().PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_1))
-        m_profile_cycler.NextWiimoteProfileForGame(0);
+        Wiimote::GetConfig()->GetController(0)->GetProfileManager().NextProfileForGame();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_2))
-        m_profile_cycler.PreviousWiimoteProfileForGame(1);
+        Wiimote::GetConfig()->GetController(1)->GetProfileManager().PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_2))
-        m_profile_cycler.NextWiimoteProfileForGame(1);
+        Wiimote::GetConfig()->GetController(1)->GetProfileManager().NextProfileForGame();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_3))
-        m_profile_cycler.PreviousWiimoteProfileForGame(2);
+        Wiimote::GetConfig()->GetController(2)->GetProfileManager().PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_3))
-        m_profile_cycler.NextWiimoteProfileForGame(2);
+        Wiimote::GetConfig()->GetController(2)->GetProfileManager().NextProfileForGame();
 
       if (IsHotkey(HK_PREV_GAME_WIIMOTE_PROFILE_4))
-        m_profile_cycler.PreviousWiimoteProfileForGame(3);
+        Wiimote::GetConfig()->GetController(3)->GetProfileManager().PreviousProfileForGame();
       else if (IsHotkey(HK_NEXT_GAME_WIIMOTE_PROFILE_4))
-        m_profile_cycler.NextWiimoteProfileForGame(3);
+        Wiimote::GetConfig()->GetController(3)->GetProfileManager().NextProfileForGame();
 
       auto ShowVolume = []() {
         OSD::AddMessage(std::string("Volume: ") +

--- a/Source/Core/DolphinQt/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt/HotkeyScheduler.h
@@ -9,7 +9,6 @@
 #include <QObject>
 
 #include "Common/Flag.h"
-#include "InputCommon/InputProfile.h"
 
 class HotkeyScheduler : public QObject
 {
@@ -67,6 +66,4 @@ private:
 
   Common::Flag m_stop_requested;
   std::thread m_thread;
-
-  InputProfile::ProfileCycler m_profile_cycler;
 };

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(inputcommon
+  DeviceProfileContainer.cpp
+  DeviceProfileContainer.h
   DynamicInputTextureConfiguration.cpp
   DynamicInputTextureConfiguration.h
   DynamicInputTextureManager.cpp
@@ -11,6 +13,8 @@ add_library(inputcommon
   InputProfile.h
   ControllerEmu/ControllerEmu.cpp
   ControllerEmu/ControllerEmu.h
+  ControllerEmu/ProfileManager.cpp
+  ControllerEmu/ProfileManager.h
   ControllerEmu/StickGate.cpp
   ControllerEmu/StickGate.h
   ControllerEmu/Control/Control.cpp

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -16,6 +16,7 @@
 #include "Common/IniFile.h"
 #include "Common/MathUtil.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
+#include "InputCommon/ControllerEmu/ProfileManager.h"
 #include "InputCommon/ControllerInterface/Device.h"
 #include "InputCommon/DynamicInputTextureManager.h"
 
@@ -169,6 +170,7 @@ struct RawValue
 class EmulatedController
 {
 public:
+  EmulatedController();
   virtual ~EmulatedController();
 
   virtual std::string GetName() const = 0;
@@ -180,6 +182,7 @@ public:
   virtual void SaveConfig(IniFile::Section* sec, const std::string& base = "");
 
   bool IsDefaultDeviceConnected() const;
+  InputCommon::ProfileManager& GetProfileManager();
   const ciface::Core::DeviceQualifier& GetDefaultDevice() const;
   void SetDefaultDevice(const std::string& device);
   void SetDefaultDevice(ciface::Core::DeviceQualifier devq);
@@ -230,5 +233,6 @@ private:
   InputCommon::DynamicInputTextureManager* m_dynamic_input_tex_config_manager = nullptr;
   ciface::Core::DeviceQualifier m_default_device;
   bool m_default_device_is_connected{false};
+  InputCommon::ProfileManager m_profile_manager;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ProfileManager.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ProfileManager.cpp
@@ -1,0 +1,158 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "InputCommon/ControllerEmu/ProfileManager.h"
+#include "Core/Core.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+
+namespace InputCommon
+{
+namespace
+{
+void DisplayLoadMessage(const InputProfile profile,
+                        const ControllerEmu::EmulatedController& controller)
+{
+  Core::DisplayMessage("Loading game specific input profile '" + profile.GetRelativePathToRoot() +
+                           "' for device '" + controller.GetName() + "'",
+                       6000);
+}
+}  // namespace
+ProfileManager::ProfileManager(ControllerEmu::EmulatedController* owning_controller)
+    : m_controller(owning_controller)
+{
+}
+
+ProfileManager::~ProfileManager() = default;
+
+void ProfileManager::NextProfile()
+{
+  m_profile_index++;
+  m_profile = m_container->GetProfile(m_profile_index);
+  if (m_profile)
+  {
+    m_profile->Apply(m_controller);
+    DisplayLoadMessage(*m_profile, *m_controller);
+  }
+}
+
+void ProfileManager::PreviousProfile()
+{
+  m_profile_index--;
+  m_profile = m_container->GetProfile(m_profile_index);
+  if (m_profile)
+  {
+    m_profile->Apply(m_controller);
+    DisplayLoadMessage(*m_profile, *m_controller);
+  }
+}
+
+void ProfileManager::NextProfileForGame()
+{
+  m_profile_index++;
+  m_profile = m_container->GetProfile(m_profile_index, DeviceProfileContainer::Direction::Forward,
+                                      m_profile_search_filter);
+  if (m_profile)
+  {
+    m_profile->Apply(m_controller);
+    DisplayLoadMessage(*m_profile, *m_controller);
+  }
+}
+
+void ProfileManager::PreviousProfileForGame()
+{
+  m_profile_index--;
+  m_profile = m_container->GetProfile(m_profile_index, DeviceProfileContainer::Direction::Backward,
+                                      m_profile_search_filter);
+  if (m_profile)
+  {
+    m_profile->Apply(m_controller);
+    DisplayLoadMessage(*m_profile, *m_controller);
+  }
+}
+
+void ProfileManager::SetProfile(int profile_index)
+{
+  m_profile_index = profile_index;
+  m_profile = m_container->GetProfile(m_profile_index);
+  if (m_profile)
+  {
+    m_profile->Apply(m_controller);
+    DisplayLoadMessage(*m_profile, *m_controller);
+  }
+}
+
+void ProfileManager::SetProfile(const std::string& path)
+{
+  m_profile_index = m_container->GetIndexFromPath(path);
+  if (m_profile_index == -1)
+  {
+    m_profile = {};
+  }
+  else
+  {
+    m_profile = m_container->GetProfile(m_profile_index);
+  }
+
+  if (m_profile)
+  {
+    m_profile->Apply(m_controller);
+    DisplayLoadMessage(*m_profile, *m_controller);
+  }
+}
+
+void ProfileManager::SetProfileForGame(int profile_index)
+{
+  m_profile_index = profile_index;
+  m_profile = m_container->GetProfile(m_profile_index, DeviceProfileContainer::Direction::Forward,
+                                      m_profile_search_filter);
+  if (m_profile)
+  {
+    m_profile->Apply(m_controller);
+    DisplayLoadMessage(*m_profile, *m_controller);
+  }
+}
+
+const std::optional<InputProfile>& ProfileManager::GetProfile() const
+{
+  return m_profile;
+}
+
+void ProfileManager::ClearProfile()
+{
+  m_profile.reset();
+  m_profile_index = -1;
+}
+
+void ProfileManager::SetDeviceProfileContainer(DeviceProfileContainer* container)
+{
+  m_container = container;
+}
+
+int ProfileManager::GetProfileIndex()
+{
+  // Sync up the profile index if a profile exists
+  if (m_profile)
+  {
+    m_profile_index = m_container->GetIndexFromPath(m_profile->GetAbsolutePath());
+  }
+
+  return m_profile_index;
+}
+
+void ProfileManager::AddToProfileFilter(const std::string& path)
+{
+  m_profile_search_filter.insert(path);
+}
+
+void ProfileManager::ClearProfileFilter()
+{
+  m_profile_search_filter.clear();
+}
+
+std::size_t ProfileManager::ProfilesInFilter() const
+{
+  return m_profile_search_filter.size();
+}
+
+}  // namespace InputCommon

--- a/Source/Core/InputCommon/ControllerEmu/ProfileManager.h
+++ b/Source/Core/InputCommon/ControllerEmu/ProfileManager.h
@@ -1,0 +1,46 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <optional>
+#include <set>
+
+#include "InputCommon/DeviceProfileContainer.h"
+#include "InputCommon/InputProfile.h"
+
+namespace InputCommon
+{
+class ProfileManager
+{
+public:
+  explicit ProfileManager(ControllerEmu::EmulatedController* owning_controller);
+  ~ProfileManager();
+  void NextProfile();
+  void PreviousProfile();
+  void NextProfileForGame();
+  void PreviousProfileForGame();
+
+  void SetProfile(int profile_index);
+  void SetProfile(const std::string& path);
+  void SetProfileForGame(int profile_index);
+  const std::optional<InputProfile>& GetProfile() const;
+  void ClearProfile();
+
+  void SetDeviceProfileContainer(DeviceProfileContainer* container);
+
+  int GetProfileIndex();
+
+  void AddToProfileFilter(const std::string& path);
+  void ClearProfileFilter();
+  std::size_t ProfilesInFilter() const;
+
+private:
+  ControllerEmu::EmulatedController* m_controller;
+  int m_profile_index = -1;
+  std::optional<InputProfile> m_profile;
+  DeviceProfileContainer* m_container;
+  std::set<std::string> m_profile_search_filter;
+};
+}  // namespace InputCommon

--- a/Source/Core/InputCommon/DeviceProfileContainer.cpp
+++ b/Source/Core/InputCommon/DeviceProfileContainer.cpp
@@ -1,0 +1,125 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "InputCommon/DeviceProfileContainer.h"
+
+#include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
+
+namespace InputCommon
+{
+namespace
+{
+int ClampContainer(int index, std::size_t container_size)
+{
+  auto positive_modulo = [](int& i, int n) { i = (i % n + n) % n; };
+  positive_modulo(index, static_cast<int>(container_size));
+  return index;
+}
+}  // namespace
+
+void DeviceProfileContainer::Load(const std::string& profile_type)
+{
+  m_profiles.clear();
+  m_path_to_profile.clear();
+  const std::string device_profile_root_location(File::GetUserPath(D_CONFIG_IDX) + "Profiles/" +
+                                                 profile_type);
+  const auto profiles = Common::DoFileSearch({device_profile_root_location}, {".ini"}, true);
+  for (auto profile : profiles)
+  {
+    EnsureProfile(profile, device_profile_root_location);
+  }
+}
+
+const std::vector<InputProfile>& DeviceProfileContainer::GetAllProfiles() const
+{
+  return m_profiles;
+}
+
+std::optional<InputProfile> DeviceProfileContainer::GetProfile(int& index)
+{
+  if (m_profiles.empty())
+    return {};
+
+  index = ClampContainer(index, m_profiles.size());
+  return m_profiles[index];
+}
+
+std::optional<InputProfile> DeviceProfileContainer::GetProfile(int& index, Direction direction,
+                                                               std::set<std::string> filter_list)
+{
+  if (m_profiles.empty())
+    return {};
+
+  if (direction == Direction::Forward)
+  {
+    for (int i = index; i < static_cast<int>(m_profiles.size()); i++)
+    {
+      const auto profile = m_profiles[i];
+      if (filter_list.count(profile.GetAbsolutePath()))
+      {
+        index = i;
+        return m_profiles[index];
+      }
+    }
+
+    index = 0;
+  }
+  else
+  {
+    for (int i = index; i > 0; i--)
+    {
+      const auto profile = m_profiles[i];
+      if (filter_list.count(profile.GetAbsolutePath()))
+      {
+        index = i;
+        return m_profiles[index];
+      }
+    }
+
+    index = static_cast<int>(m_profiles.size()) - 1;
+  }
+
+  return GetProfile(index, direction, std::move(filter_list));
+}
+
+int DeviceProfileContainer::GetIndexFromPath(const std::string& profile_path)
+{
+  auto iter = m_path_to_profile.find(profile_path);
+  if (iter != m_path_to_profile.end())
+  {
+    return iter->second;
+  }
+
+  return -1;
+}
+
+void DeviceProfileContainer::EnsureProfile(const std::string& profile_path,
+                                           const std::string& profiles_root)
+{
+  auto iter = m_path_to_profile.find(profile_path);
+  if (iter != m_path_to_profile.end())
+  {
+    m_profiles[iter->second] = InputProfile{profile_path, profiles_root};
+    return;
+  }
+
+  m_profiles.emplace_back(InputProfile{profile_path, profiles_root});
+  m_path_to_profile.emplace(profile_path, static_cast<int>(m_profiles.size() - 1));
+}
+
+bool DeviceProfileContainer::DeleteProfile(const std::string& profile_path)
+{
+  auto iter = m_path_to_profile.find(profile_path);
+  if (iter == m_path_to_profile.end())
+  {
+    return false;
+  }
+
+  m_profiles.erase(m_profiles.begin() + iter->second);
+  m_path_to_profile.erase(iter);
+  File::Delete(profile_path);
+  return true;
+}
+}  // namespace InputCommon

--- a/Source/Core/InputCommon/DeviceProfileContainer.h
+++ b/Source/Core/InputCommon/DeviceProfileContainer.h
@@ -1,0 +1,38 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "InputProfile.h"
+
+#include <map>
+#include <optional>
+#include <set>
+#include <vector>
+
+namespace InputCommon
+{
+class DeviceProfileContainer
+{
+public:
+  enum class Direction
+  {
+    Forward,
+    Backward
+  };
+  void Load(const std::string& profile_type);
+  const std::vector<InputProfile>& GetAllProfiles() const;
+  std::optional<InputProfile> GetProfile(int& index);
+  std::optional<InputProfile> GetProfile(int& index, Direction direction,
+                                         std::set<std::string> filter_list);
+  int GetIndexFromPath(const std::string& profile_path);
+
+  void EnsureProfile(const std::string& profile_path, const std::string& profiles_root);
+  bool DeleteProfile(const std::string& profile_path);
+
+private:
+  std::vector<InputProfile> m_profiles;
+  std::map<std::string, int> m_path_to_profile;
+};
+}  // namespace InputCommon

--- a/Source/Core/InputCommon/InputCommon.vcxproj
+++ b/Source/Core/InputCommon/InputCommon.vcxproj
@@ -20,6 +20,7 @@
     <ClCompile Include="ControllerEmu\ControlGroup\IMUCursor.cpp" />
     <ClCompile Include="ControllerEmu\ControlGroup\IMUGyroscope.cpp" />
     <ClCompile Include="ControllerEmu\ControllerEmu.cpp" />
+    <ClCompile Include="ControllerEmu\ProfileManager.cpp" />
     <ClCompile Include="ControllerEmu\StickGate.cpp" />
     <ClCompile Include="ControllerEmu\Control\Control.cpp" />
     <ClCompile Include="ControllerEmu\Control\Input.cpp" />
@@ -50,6 +51,7 @@
     <ClCompile Include="ControllerInterface\Wiimote\Wiimote.cpp" />
     <ClCompile Include="ControllerInterface\XInput\XInput.cpp" />
     <ClCompile Include="ControlReference\FunctionExpression.cpp" />
+    <ClCompile Include="DeviceProfileContainer.cpp" />
     <ClCompile Include="DynamicInputTextureConfiguration.cpp" />
     <ClCompile Include="DynamicInputTextureManager.cpp" />
     <ClCompile Include="GCAdapter.cpp" />
@@ -62,6 +64,7 @@
     <ClInclude Include="ControllerEmu\ControlGroup\IMUCursor.h" />
     <ClInclude Include="ControllerEmu\ControlGroup\IMUGyroscope.h" />
     <ClInclude Include="ControllerEmu\ControllerEmu.h" />
+    <ClInclude Include="ControllerEmu\ProfileManager.h" />
     <ClInclude Include="ControllerEmu\StickGate.h" />
     <ClInclude Include="ControllerEmu\Control\Control.h" />
     <ClInclude Include="ControllerEmu\Control\Input.h" />
@@ -94,6 +97,7 @@
     <ClInclude Include="ControllerInterface\Win32\Win32.h" />
     <ClInclude Include="ControllerInterface\Wiimote\Wiimote.h" />
     <ClInclude Include="ControllerInterface\XInput\XInput.h" />
+    <ClInclude Include="DeviceProfileContainer.h" />
     <ClInclude Include="DynamicInputTextureConfiguration.h" />
     <ClInclude Include="DynamicInputTextureManager.h" />
     <ClInclude Include="GCAdapter.h" />

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "InputCommon/DeviceProfileContainer.h"
 #include "InputCommon/DynamicInputTextureManager.h"
 
 namespace ControllerEmu
@@ -25,6 +26,7 @@ public:
 
   ~InputConfig();
 
+  void LoadProfiles();
   bool LoadConfig(bool isGC);
   void SaveConfig();
 
@@ -43,6 +45,7 @@ public:
   std::string GetGUIName() const { return m_gui_name; }
   std::string GetProfileName() const { return m_profile_name; }
   std::size_t GetControllerCount() const;
+  InputCommon::DeviceProfileContainer& GetDeviceProfileContainer();
 
   // These should be used after creating all controllers and before clearing them, respectively.
   void RegisterHotplugCallback();
@@ -56,4 +59,5 @@ private:
   const std::string m_gui_name;
   const std::string m_profile_name;
   InputCommon::DynamicInputTextureManager m_dynamic_input_tex_config_manager;
+  InputCommon::DeviceProfileContainer m_device_profile_container;
 };

--- a/Source/Core/InputCommon/InputProfile.cpp
+++ b/Source/Core/InputCommon/InputProfile.cpp
@@ -3,211 +3,41 @@
 // Refer to the license.txt file included.
 
 #include "InputCommon/InputProfile.h"
-
-#include <algorithm>
-#include <iterator>
-
-#include <fmt/format.h>
-
-#include "Common/FileSearch.h"
-#include "Common/FileUtil.h"
-#include "Common/StringUtil.h"
-
-#include "Core/ConfigManager.h"
-#include "Core/Core.h"
-#include "Core/HW/Wiimote.h"
-#include "Core/HotkeyManager.h"
-
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
-#include "InputCommon/InputConfig.h"
 
-namespace InputProfile
+namespace InputCommon
 {
-namespace
+InputProfile::InputProfile(const std::string& profile_path, const std::string& root_directory)
+    : m_file_path(profile_path), m_root_directory(root_directory)
 {
-constexpr int display_message_ms = 3000;
+  m_ini.Load(m_file_path);
 }
 
-std::vector<std::string> GetProfilesFromSetting(const std::string& setting, const std::string& root)
+InputProfile::~InputProfile() = default;
+
+std::string InputProfile::GetRelativePathToRoot() const
 {
-  const auto& setting_choices = SplitString(setting, ',');
-
-  std::vector<std::string> result;
-  for (const std::string& setting_choice : setting_choices)
-  {
-    const std::string path = root + std::string(StripSpaces(setting_choice));
-    if (File::IsDirectory(path))
-    {
-      const auto files_under_directory = Common::DoFileSearch({path}, {".ini"}, true);
-      result.insert(result.end(), files_under_directory.begin(), files_under_directory.end());
-    }
-    else
-    {
-      const std::string file_path = path + ".ini";
-      if (File::Exists(file_path))
-      {
-        result.push_back(file_path);
-      }
-    }
-  }
-
-  return result;
+  std::string basename;
+  std::string basepath;
+  SplitPath(m_file_path, &basepath, &basename, nullptr);
+  return basepath.substr(m_root_directory.size() + 1) + basename;
 }
 
-std::vector<std::string> ProfileCycler::GetProfilesForDevice(InputConfig* device_configuration)
+const std::string& InputProfile::GetAbsolutePath() const
 {
-  const std::string device_profile_root_location(File::GetUserPath(D_CONFIG_IDX) + "Profiles/" +
-                                                 device_configuration->GetProfileName());
-  return Common::DoFileSearch({device_profile_root_location}, {".ini"}, true);
+  return m_file_path;
 }
 
-std::string ProfileCycler::GetProfile(CycleDirection cycle_direction, int& profile_index,
-                                      const std::vector<std::string>& profiles)
+void InputProfile::Apply(ControllerEmu::EmulatedController* controller)
 {
-  // update the index and bind it to the number of available strings
-  auto positive_modulo = [](int& i, int n) { i = (i % n + n) % n; };
-  profile_index += static_cast<int>(cycle_direction);
-  positive_modulo(profile_index, static_cast<int>(profiles.size()));
-
-  return profiles[profile_index];
+  controller->LoadConfig(GetProfileData());
+  controller->UpdateReferences(g_controller_interface);
 }
 
-void ProfileCycler::UpdateToProfile(const std::string& profile_filename,
-                                    ControllerEmu::EmulatedController* controller)
+IniFile::Section* InputProfile::GetProfileData()
 {
-  std::string base;
-  SplitPath(profile_filename, nullptr, &base, nullptr);
-
-  IniFile ini_file;
-  if (ini_file.Load(profile_filename))
-  {
-    Core::DisplayMessage("Loading input profile '" + base + "' for device '" +
-                             controller->GetName() + "'",
-                         display_message_ms);
-    controller->LoadConfig(ini_file.GetOrCreateSection("Profile"));
-    controller->UpdateReferences(g_controller_interface);
-  }
-  else
-  {
-    Core::DisplayMessage("Unable to load input profile '" + base + "' for device '" +
-                             controller->GetName() + "'",
-                         display_message_ms);
-  }
+  return m_ini.GetOrCreateSection("Profile");
 }
 
-std::vector<std::string>
-ProfileCycler::GetMatchingProfilesFromSetting(const std::string& setting,
-                                              const std::vector<std::string>& profiles,
-                                              InputConfig* device_configuration)
-{
-  const std::string device_profile_root_location(File::GetUserPath(D_CONFIG_IDX) + "Profiles/" +
-                                                 device_configuration->GetProfileName() + "/");
-
-  const auto& profiles_from_setting = GetProfilesFromSetting(setting, device_profile_root_location);
-  if (profiles_from_setting.empty())
-  {
-    return {};
-  }
-
-  std::vector<std::string> result;
-  std::set_intersection(profiles.begin(), profiles.end(), profiles_from_setting.begin(),
-                        profiles_from_setting.end(), std::back_inserter(result));
-  return result;
-}
-
-void ProfileCycler::CycleProfile(CycleDirection cycle_direction, InputConfig* device_configuration,
-                                 int& profile_index, int controller_index)
-{
-  const auto& profiles = GetProfilesForDevice(device_configuration);
-  if (profiles.empty())
-  {
-    Core::DisplayMessage("No input profiles found", display_message_ms);
-    return;
-  }
-  const std::string profile = GetProfile(cycle_direction, profile_index, profiles);
-
-  auto* controller = device_configuration->GetController(controller_index);
-  if (controller)
-  {
-    UpdateToProfile(profile, controller);
-  }
-  else
-  {
-    Core::DisplayMessage("No controller found for index: " + std::to_string(controller_index),
-                         display_message_ms);
-  }
-}
-
-void ProfileCycler::CycleProfileForGame(CycleDirection cycle_direction,
-                                        InputConfig* device_configuration, int& profile_index,
-                                        const std::string& setting, int controller_index)
-{
-  const auto& profiles = GetProfilesForDevice(device_configuration);
-  if (profiles.empty())
-  {
-    Core::DisplayMessage("No input profiles found", display_message_ms);
-    return;
-  }
-
-  if (setting.empty())
-  {
-    Core::DisplayMessage("No setting found for game", display_message_ms);
-    return;
-  }
-
-  const auto& profiles_for_game =
-      GetMatchingProfilesFromSetting(setting, profiles, device_configuration);
-  if (profiles_for_game.empty())
-  {
-    Core::DisplayMessage("No input profiles found for game", display_message_ms);
-    return;
-  }
-
-  const std::string profile = GetProfile(cycle_direction, profile_index, profiles_for_game);
-
-  auto* controller = device_configuration->GetController(controller_index);
-  if (controller)
-  {
-    UpdateToProfile(profile, controller);
-  }
-  else
-  {
-    Core::DisplayMessage("No controller found for index: " + std::to_string(controller_index),
-                         display_message_ms);
-  }
-}
-
-std::string ProfileCycler::GetWiimoteInputProfilesForGame(int controller_index)
-{
-  IniFile game_ini = SConfig::GetInstance().LoadGameIni();
-  const IniFile::Section* const control_section = game_ini.GetOrCreateSection("Controls");
-
-  std::string result;
-  control_section->Get(fmt::format("WiimoteProfile{}", controller_index + 1), &result);
-  return result;
-}
-
-void ProfileCycler::NextWiimoteProfile(int controller_index)
-{
-  CycleProfile(CycleDirection::Forward, Wiimote::GetConfig(), m_wiimote_profile_index,
-               controller_index);
-}
-
-void ProfileCycler::PreviousWiimoteProfile(int controller_index)
-{
-  CycleProfile(CycleDirection::Backward, Wiimote::GetConfig(), m_wiimote_profile_index,
-               controller_index);
-}
-
-void ProfileCycler::NextWiimoteProfileForGame(int controller_index)
-{
-  CycleProfileForGame(CycleDirection::Forward, Wiimote::GetConfig(), m_wiimote_profile_index,
-                      GetWiimoteInputProfilesForGame(controller_index), controller_index);
-}
-
-void ProfileCycler::PreviousWiimoteProfileForGame(int controller_index)
-{
-  CycleProfileForGame(CycleDirection::Backward, Wiimote::GetConfig(), m_wiimote_profile_index,
-                      GetWiimoteInputProfilesForGame(controller_index), controller_index);
-}
-}  // namespace InputProfile
+}  // namespace InputCommon

--- a/Source/Core/InputCommon/InputProfile.h
+++ b/Source/Core/InputCommon/InputProfile.h
@@ -4,50 +4,30 @@
 
 #pragma once
 
-class InputConfig;
+#include <string>
+
+#include "Common/IniFile.h"
 
 namespace ControllerEmu
 {
 class EmulatedController;
 }
 
-#include <string>
-#include <vector>
-
-namespace InputProfile
+namespace InputCommon
 {
-std::vector<std::string> GetProfilesFromSetting(const std::string& setting,
-                                                const std::string& root);
-
-enum class CycleDirection : int
-{
-  Forward = 1,
-  Backward = -1
-};
-
-class ProfileCycler
+class InputProfile
 {
 public:
-  void NextWiimoteProfile(int controller_index);
-  void PreviousWiimoteProfile(int controller_index);
-  void NextWiimoteProfileForGame(int controller_index);
-  void PreviousWiimoteProfileForGame(int controller_index);
+  explicit InputProfile(const std::string& profile_path, const std::string& root_directory);
+  ~InputProfile();
+  std::string GetRelativePathToRoot() const;
+  const std::string& GetAbsolutePath() const;
+  void Apply(ControllerEmu::EmulatedController* controller);
+  IniFile::Section* GetProfileData();
 
 private:
-  void CycleProfile(CycleDirection cycle_direction, InputConfig* device_configuration,
-                    int& profile_index, int controller_index);
-  void CycleProfileForGame(CycleDirection cycle_direction, InputConfig* device_configuration,
-                           int& profile_index, const std::string& setting, int controller_index);
-  std::vector<std::string> GetProfilesForDevice(InputConfig* device_configuration);
-  std::string GetProfile(CycleDirection cycle_direction, int& profile_index,
-                         const std::vector<std::string>& profiles);
-  std::vector<std::string> GetMatchingProfilesFromSetting(const std::string& setting,
-                                                          const std::vector<std::string>& profiles,
-                                                          InputConfig* device_configuration);
-  void UpdateToProfile(const std::string& profile_filename,
-                       ControllerEmu::EmulatedController* controller);
-  std::string GetWiimoteInputProfilesForGame(int controller_index);
-
-  int m_wiimote_profile_index = 0;
+  std::string m_file_path;
+  std::string m_root_directory;
+  IniFile m_ini;
 };
-}  // namespace InputProfile
+}  // namespace InputCommon


### PR DESCRIPTION
Input Profiles are vital to playing more than one or two wii games with emulated controllers.

The current profile system works but has a number of short comings:

- Having more than a handful of profiles and you quickly will need to organize them.  The current combo-box only lists profiles by name and assumes they will all be in that specific directory.  Sub-folders are not supported which is useful when needing to organize by game and then by device.
- The current OSD message that occurs when a profile is loaded is just the profile filename without extension, it gives you no context if a profile is loaded that has the same name as another profile (that exists in a different sub-directory)
- Trying to cycle profiles in multiple locations, won't work because the profile selected isn't stored on the controller (I ran into this when working on #7930 )

This PR addresses these issues.