### PR TITLE
Make --batch run Dolphin headless

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char* argv[])
   UICommon::CreateDirectories();
   UICommon::Init();
   Resources::Init();
-  Settings::Instance().SetBatchModeEnabled(options.is_set("batch"));
+  Settings::Instance().SetBatchModeEnabled(options.is_set("batch") && options.is_set("exec"));
 
   // Hook up alerts from core
   Common::RegisterMsgAlertHandler(QtMsgAlertHandler);
@@ -217,8 +217,11 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    auto* updater = new Updater(&win);
-    updater->start();
+    if (!Settings::Instance().IsBatchModeEnabled())
+    {
+      auto* updater = new Updater(&win);
+      updater->start();
+    }
 
     retval = app.exec();
   }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1714,7 +1714,8 @@ void MainWindow::OnUpdateProgressDialog(QString title, int progress, int total)
 
 void MainWindow::Show()
 {
-  QWidget::show();
+  if (!Settings::Instance().IsBatchModeEnabled())
+    QWidget::show();
 
   // If the booting of a game was requested on start up, do that now
   if (m_pending_boot != nullptr)

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -96,7 +96,9 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
         .action("store_true")
         .help("Show the debugger pane and additional View menu options");
     parser->add_option("-l", "--logger").action("store_true").help("Open the logger");
-    parser->add_option("-b", "--batch").action("store_true").help("Exit Dolphin with emulation");
+    parser->add_option("-b", "--batch")
+        .action("store_true")
+        .help("Run Dolphin without the user interface (Requires --exec)");
     parser->add_option("-c", "--confirm").action("store_true").help("Set Confirm on Stop");
   }
 

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -26,11 +26,10 @@ public:
       : ConfigLayerLoader(Config::LayerType::CommandLine)
   {
     if (!video_backend.empty())
-      m_values.emplace_back(std::make_tuple(Config::MAIN_GFX_BACKEND.location, video_backend));
+      m_values.emplace_back(Config::MAIN_GFX_BACKEND.location, video_backend);
 
     if (!audio_backend.empty())
-      m_values.emplace_back(
-          std::make_tuple(Config::MAIN_DSP_HLE.location, ValueToString(audio_backend == "HLE")));
+      m_values.emplace_back(Config::MAIN_DSP_HLE.location, ValueToString(audio_backend == "HLE"));
 
     // Arguments are in the format of <System>.<Section>.<Key>=Value
     for (const auto& arg : args)
@@ -45,7 +44,8 @@ public:
       if (system)
       {
         m_values.emplace_back(
-            std::make_tuple(Config::ConfigLocation{*system, section, key}, value));
+            Config::ConfigLocation{std::move(*system), std::move(section), std::move(key)},
+            std::move(value));
       }
     }
   }


### PR DESCRIPTION
This PR tweaks the way `--batch` commandline argument works to make Dolphin run fully headless provided user also specifies what game to run. This will be beneficial for "couch gaming" experience, eg. streaming or Steam Big Picture mode, where user may not have easy access to a keyboard and mouse to, for example, suppress an updater window.