### PR TITLE
Reimplement Cheat Search.

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(core
   ARDecrypt.h
   BootManager.cpp
   BootManager.h
+  CheatSearch.cpp
+  CheatSearch.h
   CommonTitles.h
   ConfigManager.cpp
   ConfigManager.h

--- a/Source/Core/Core/CheatSearch.cpp
+++ b/Source/Core/Core/CheatSearch.cpp
@@ -1,0 +1,344 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/CheatSearch.h"
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+
+#include "Common/BitUtils.h"
+
+#include "Core/Core.h"
+#include "Core/HW/Memmap.h"
+#include "Core/PowerPC/MMU.h"
+
+template <typename T>
+static bool Compare(const T& left_value, const T& right_value, Cheats::CompareType op)
+{
+  switch (op)
+  {
+  case Cheats::CompareType::Equal:
+    return left_value == right_value;
+  case Cheats::CompareType::NotEqual:
+    return left_value != right_value;
+  case Cheats::CompareType::Less:
+    return left_value < right_value;
+  case Cheats::CompareType::LessEqual:
+    return left_value <= right_value;
+  case Cheats::CompareType::More:
+    return left_value > right_value;
+  case Cheats::CompareType::MoreEqual:
+    return left_value >= right_value;
+  default:
+    return false;
+  }
+}
+
+template <typename NT, Cheats::DataType DT>
+static std::function<bool(const Cheats::SearchValue&, const Cheats::SearchValue&)>
+GetCompareFunction(Cheats::CompareType op)
+{
+  return [op](const Cheats::SearchValue& left, const Cheats::SearchValue& right) {
+    return DT == Cheats::GetDataType(left) && DT == Cheats::GetDataType(right) &&
+           Compare<NT>(std::get<NT>(left.m_value), std::get<NT>(right.m_value), op);
+  };
+}
+
+static std::function<bool(const Cheats::SearchValue&, const Cheats::SearchValue&)>
+CreateMatchFunction(Cheats::CompareType op, Cheats::DataType type)
+{
+  switch (type)
+  {
+  case Cheats::DataType::U8:
+    return GetCompareFunction<u8, Cheats::DataType::U8>(op);
+  case Cheats::DataType::U16:
+    return GetCompareFunction<u16, Cheats::DataType::U16>(op);
+  case Cheats::DataType::U32:
+    return GetCompareFunction<u32, Cheats::DataType::U32>(op);
+  case Cheats::DataType::U64:
+    return GetCompareFunction<u64, Cheats::DataType::U64>(op);
+  case Cheats::DataType::F32:
+    return GetCompareFunction<float, Cheats::DataType::F32>(op);
+  case Cheats::DataType::F64:
+    return GetCompareFunction<double, Cheats::DataType::F64>(op);
+  case Cheats::DataType::ByteArray:
+    return GetCompareFunction<std::vector<u8>, Cheats::DataType::ByteArray>(op);
+  default:
+    assert(0);
+    return nullptr;
+  }
+}
+
+static size_t GetDataSize(Cheats::DataType type)
+{
+  switch (type)
+  {
+  case Cheats::DataType::U8:
+    return sizeof(u8);
+  case Cheats::DataType::U16:
+    return sizeof(u16);
+  case Cheats::DataType::U32:
+    return sizeof(u32);
+  case Cheats::DataType::U64:
+    return sizeof(u64);
+  case Cheats::DataType::F32:
+    return sizeof(float);
+  case Cheats::DataType::F64:
+    return sizeof(double);
+  case Cheats::DataType::ByteArray:
+    return 0;
+  default:
+    assert(0);
+    return 0;
+  }
+}
+
+static size_t GetValueSize(const Cheats::SearchValue& value)
+{
+  Cheats::DataType type = Cheats::GetDataType(value);
+  if (type == Cheats::DataType::ByteArray)
+    return std::get<std::vector<u8>>(value.m_value).size();
+  return GetDataSize(type);
+}
+
+static Cheats::SearchValue ReadValueFromEmulatedMemory(u32 addr, Cheats::DataType type,
+                                                       size_t value_size)
+{
+  Cheats::SearchValue result_value;
+
+  // Note: If the CPU is currently paused in an exception state, the MMU is off, so reads in the
+  // typical memory range would go nowhere. To prevent this causing problems, we read under the
+  // assumption that the MMU is on even if it isn't.
+
+  switch (type)
+  {
+  case Cheats::DataType::U8:
+    result_value.m_value = PowerPC::HostRead_U8(addr, true);
+    break;
+  case Cheats::DataType::U16:
+    result_value.m_value = PowerPC::HostRead_U16(addr, true);
+    break;
+  case Cheats::DataType::U32:
+    result_value.m_value = PowerPC::HostRead_U32(addr, true);
+    break;
+  case Cheats::DataType::U64:
+    result_value.m_value = PowerPC::HostRead_U64(addr, true);
+    break;
+  case Cheats::DataType::F32:
+    result_value.m_value = PowerPC::HostRead_F32(addr, true);
+    break;
+  case Cheats::DataType::F64:
+    result_value.m_value = PowerPC::HostRead_F64(addr, true);
+    break;
+  case Cheats::DataType::ByteArray:
+  {
+    std::vector<u8> tmp;
+    tmp.reserve(value_size);
+    for (size_t i = 0; i < value_size; ++i)
+      tmp.push_back(PowerPC::HostRead_U8(static_cast<u32>(addr + i), true));
+    result_value.m_value = std::move(tmp);
+    break;
+  }
+  default:
+    assert(0);
+    break;
+  }
+
+  return result_value;
+}
+
+constexpr u32 MEMORY_BASE_ADDRESS = 0x80000000;
+
+static std::optional<std::vector<Cheats::SearchResult>> NewSearchInternal(
+    std::function<bool(const Cheats::SearchValue&, const Cheats::SearchValue&)> matches_func,
+    const Cheats::SearchValue& value, Cheats::DataType type, size_t value_size)
+{
+  if (value_size == 0)
+    return std::nullopt;
+
+  if (!Memory::m_pRAM)
+    return std::nullopt;
+
+  std::vector<Cheats::SearchResult> results;
+  Core::RunAsCPUThread([&] {
+    for (u32 i = 0; i < Memory::REALRAM_SIZE - (value_size - 1); ++i)
+    {
+      const u32 addr = MEMORY_BASE_ADDRESS + i;
+      if (!PowerPC::HostIsRAMAddress(addr, true))
+        continue;
+
+      const auto current_value = ReadValueFromEmulatedMemory(addr, type, value_size);
+      if (matches_func(current_value, value))
+      {
+        results.emplace_back();
+        results.back().m_address = addr;
+        results.back().m_value = current_value;
+      }
+    }
+  });
+
+  return results;
+}
+
+std::optional<std::vector<Cheats::SearchResult>> Cheats::NewSearch(DataType type)
+{
+  return NewSearch(type, GetDataSize(type));
+}
+
+std::optional<std::vector<Cheats::SearchResult>> Cheats::NewSearch(DataType type, size_t value_size)
+{
+  Cheats::SearchValue dummy_value;
+  auto matches_func = [](const Cheats::SearchValue&, const Cheats::SearchValue&) { return true; };
+  return NewSearchInternal(matches_func, dummy_value, type, value_size);
+}
+
+std::optional<std::vector<Cheats::SearchResult>> Cheats::NewSearch(Cheats::CompareType comparison,
+                                                                   const Cheats::SearchValue& value)
+{
+  const Cheats::DataType type = GetDataType(value);
+  const auto matches_func = CreateMatchFunction(comparison, type);
+  if (!matches_func)
+    return std::nullopt;
+
+  return NewSearchInternal(matches_func, value, type, GetValueSize(value));
+}
+
+static std::optional<std::vector<Cheats::SearchResult>>
+NextSearchInternal(const std::vector<Cheats::SearchResult>& previous_results,
+                   Cheats::CompareType comparison, const Cheats::SearchValue* value)
+{
+  if (!Memory::m_pRAM)
+    return std::nullopt;
+
+  std::vector<Cheats::SearchResult> results;
+  Core::RunAsCPUThread([&] {
+    for (const Cheats::SearchResult& previous_result : previous_results)
+    {
+      const u32 addr = previous_result.m_address;
+      if (!PowerPC::HostIsRAMAddress(addr, true))
+        continue;
+
+      const size_t value_size = GetValueSize(previous_result.m_value);
+      if (value_size == 0)
+        continue;
+
+      const Cheats::DataType type = Cheats::GetDataType(previous_result.m_value);
+      const auto matches_func = CreateMatchFunction(comparison, type);
+      if (!matches_func)
+        continue;
+
+      const auto current_value = ReadValueFromEmulatedMemory(addr, type, value_size);
+      if (matches_func(current_value, value ? *value : previous_result.m_value))
+      {
+        results.emplace_back();
+        results.back().m_address = addr;
+        results.back().m_value = current_value;
+      }
+    }
+  });
+
+  return results;
+}
+
+std::optional<std::vector<Cheats::SearchResult>>
+Cheats::NextSearch(const std::vector<Cheats::SearchResult>& previous_results,
+                   Cheats::CompareType comparison)
+{
+  return NextSearchInternal(previous_results, comparison, nullptr);
+}
+
+std::optional<std::vector<Cheats::SearchResult>>
+Cheats::NextSearch(const std::vector<Cheats::SearchResult>& previous_results,
+                   Cheats::CompareType comparison, const Cheats::SearchValue& value)
+{
+  return NextSearchInternal(previous_results, comparison, &value);
+}
+
+std::optional<std::vector<Cheats::SearchResult>>
+Cheats::UpdateValues(const std::vector<Cheats::SearchResult>& previous_results)
+{
+  if (!Memory::m_pRAM)
+    return std::nullopt;
+
+  std::vector<Cheats::SearchResult> results;
+  results.reserve(previous_results.size());
+  Core::RunAsCPUThread([&] {
+    for (const Cheats::SearchResult& previous_result : previous_results)
+    {
+      const u32 addr = previous_result.m_address;
+      if (!PowerPC::HostIsRAMAddress(addr, true))
+        continue;
+
+      const auto current_value = ReadValueFromEmulatedMemory(
+          addr, GetDataType(previous_result.m_value), GetValueSize(previous_result.m_value));
+      results.emplace_back();
+      results.back().m_address = addr;
+      results.back().m_value = current_value;
+    }
+  });
+
+  return results;
+}
+
+Cheats::DataType Cheats::GetDataType(const Cheats::SearchValue& value)
+{
+  // sanity checks that our enum matches with our std::variant
+  static_assert(std::is_same_v<u8, std::remove_cv_t<std::remove_reference_t<decltype(
+                                       std::get<static_cast<int>(DataType::U8)>(value.m_value))>>>);
+  static_assert(
+      std::is_same_v<u16, std::remove_cv_t<std::remove_reference_t<decltype(
+                              std::get<static_cast<int>(DataType::U16)>(value.m_value))>>>);
+  static_assert(
+      std::is_same_v<u32, std::remove_cv_t<std::remove_reference_t<decltype(
+                              std::get<static_cast<int>(DataType::U32)>(value.m_value))>>>);
+  static_assert(
+      std::is_same_v<u64, std::remove_cv_t<std::remove_reference_t<decltype(
+                              std::get<static_cast<int>(DataType::U64)>(value.m_value))>>>);
+  static_assert(
+      std::is_same_v<float, std::remove_cv_t<std::remove_reference_t<decltype(
+                                std::get<static_cast<int>(DataType::F32)>(value.m_value))>>>);
+  static_assert(
+      std::is_same_v<double, std::remove_cv_t<std::remove_reference_t<decltype(
+                                 std::get<static_cast<int>(DataType::F64)>(value.m_value))>>>);
+  static_assert(
+      std::is_same_v<std::vector<u8>,
+                     std::remove_cv_t<std::remove_reference_t<decltype(
+                         std::get<static_cast<int>(DataType::ByteArray)>(value.m_value))>>>);
+
+  return static_cast<DataType>(value.m_value.index());
+}
+
+template <typename T>
+static std::vector<u8> ToByteVector(const T val)
+{
+  const auto* const begin = reinterpret_cast<const u8*>(&val);
+  const auto* const end = begin + sizeof(T);
+  return {begin, end};
+}
+
+std::vector<u8> Cheats::GetValueAsByteVector(const Cheats::SearchValue& value)
+{
+  DataType type = GetDataType(value);
+  switch (type)
+  {
+  case Cheats::DataType::U8:
+    return {std::get<u8>(value.m_value)};
+  case Cheats::DataType::U16:
+    return ToByteVector(Common::swap16(std::get<u16>(value.m_value)));
+  case Cheats::DataType::U32:
+    return ToByteVector(Common::swap32(std::get<u32>(value.m_value)));
+  case Cheats::DataType::U64:
+    return ToByteVector(Common::swap64(std::get<u64>(value.m_value)));
+  case Cheats::DataType::F32:
+    return ToByteVector(Common::swap32(Common::BitCast<u32>(std::get<float>(value.m_value))));
+  case Cheats::DataType::F64:
+    return ToByteVector(Common::swap64(Common::BitCast<u64>(std::get<double>(value.m_value))));
+  case Cheats::DataType::ByteArray:
+    return std::get<std::vector<u8>>(value.m_value);
+  default:
+    assert(0);
+    return {};
+  }
+}

--- a/Source/Core/Core/CheatSearch.h
+++ b/Source/Core/Core/CheatSearch.h
@@ -1,0 +1,82 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+namespace Cheats
+{
+enum class CompareType
+{
+  Equal,
+  NotEqual,
+  Less,
+  LessEqual,
+  More,
+  MoreEqual
+};
+
+enum class DataType
+{
+  U8,
+  U16,
+  U32,
+  U64,
+  F32,
+  F64,
+  ByteArray
+};
+
+struct SearchValue
+{
+  std::variant<u8, u16, u32, u64, float, double, std::vector<u8>> m_value;
+};
+
+struct SearchResult
+{
+  SearchValue m_value;
+  u32 m_address;
+};
+
+// Do a new search across all memory, returning the entire memory as values of the given type.
+// This variant returns nullopt if the given type is ByteArray.
+std::optional<std::vector<SearchResult>> NewSearch(DataType type);
+
+// Do a new search across all memory, returning the entire memory as values of the given type.
+// This variant assumes the given value_size for the byte array if the given type is ByteArray.
+std::optional<std::vector<SearchResult>> NewSearch(DataType type, size_t value_size);
+
+// Do a new search across all memory, only returning results where the current value in memory
+// matches the given value with the given comparison operation.
+std::optional<std::vector<SearchResult>> NewSearch(CompareType comparison,
+                                                   const SearchValue& value);
+
+// Filter existing results and return only results where the current value in memory matches the
+// stored value in the results with the given comparison operation.
+std::optional<std::vector<SearchResult>>
+NextSearch(const std::vector<SearchResult>& previous_results, CompareType comparison);
+
+// Filter existing results and return only results where the current value in memory
+// matches the given value with the given comparison operation.
+std::optional<std::vector<SearchResult>>
+NextSearch(const std::vector<SearchResult>& previous_results, CompareType comparison,
+           const SearchValue& value);
+
+// Refresh the stored values of the given results with the values currently in the emulated memory.
+std::optional<std::vector<Cheats::SearchResult>>
+UpdateValues(const std::vector<SearchResult>& previous_results);
+
+// Returns the corresponding DataType enum for the value currently held by the given SearchValue.
+DataType GetDataType(const SearchValue& value);
+
+// Converts the given value to a std::vector<u8>, regardless of the actual stored value type.
+// Returned array is in big endian byte order for values where this matters, so it can be copied
+// directly into emulated memory for patches or action replay codes.
+std::vector<u8> GetValueAsByteVector(const SearchValue& value);
+}  // namespace Cheats

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="Boot\Boot_WiiWAD.cpp" />
     <ClCompile Include="Boot\DolReader.cpp" />
     <ClCompile Include="Boot\ElfReader.cpp" />
+    <ClCompile Include="CheatSearch.cpp" />
     <ClCompile Include="Config\GraphicsSettings.cpp" />
     <ClCompile Include="Config\MainSettings.cpp" />
     <ClCompile Include="Config\NetplaySettings.cpp" />
@@ -323,6 +324,7 @@
     <ClInclude Include="Boot\DolReader.h" />
     <ClInclude Include="Boot\ElfReader.h" />
     <ClInclude Include="Boot\ElfTypes.h" />
+    <ClInclude Include="CheatSearch.h" />
     <ClInclude Include="Config\GraphicsSettings.h" />
     <ClInclude Include="Config\MainSettings.h" />
     <ClInclude Include="Config\NetplaySettings.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -7,6 +7,9 @@
     <Filter Include="Boot">
       <UniqueIdentifier>{2472fb36-5473-4d49-ad2d-3699b78ab6e2}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Cheats">
+      <UniqueIdentifier>{a446fcc3-3d1a-44c8-b060-6a0a901ed744}</UniqueIdentifier>
+    </Filter>
     <Filter Include="ConfigLoader">
       <UniqueIdentifier>{259a11eb-ca07-4b31-b849-7286dbd4550a}</UniqueIdentifier>
     </Filter>
@@ -204,6 +207,9 @@
     </ClCompile>
     <ClCompile Include="Boot\ElfReader.cpp">
       <Filter>Boot</Filter>
+    </ClCompile>
+    <ClCompile Include="CheatSearch.cpp">
+      <Filter>Cheats</Filter>
     </ClCompile>
     <ClCompile Include="Debugger\Debugger_SymbolMap.cpp">
       <Filter>Debugger</Filter>
@@ -970,6 +976,9 @@
     </ClInclude>
     <ClInclude Include="Boot\ElfTypes.h">
       <Filter>Boot</Filter>
+    </ClInclude>
+    <ClInclude Include="CheatSearch.h">
+      <Filter>Cheats</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\Debugger_SymbolMap.h">
       <Filter>Debugger</Filter>

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -557,70 +557,130 @@ void Write_F64(const double var, const u32 address)
 
 u8 HostRead_U8(const u32 address)
 {
-  return ReadFromHardware<XCheckTLBFlag::NoException, u8>(address, MSR.DR);
+  return HostRead_U8(address, MSR.DR);
 }
 
 u16 HostRead_U16(const u32 address)
 {
-  return ReadFromHardware<XCheckTLBFlag::NoException, u16>(address, MSR.DR);
+  return HostRead_U16(address, MSR.DR);
 }
 
 u32 HostRead_U32(const u32 address)
 {
-  return ReadFromHardware<XCheckTLBFlag::NoException, u32>(address, MSR.DR);
+  return HostRead_U32(address, MSR.DR);
 }
 
 u64 HostRead_U64(const u32 address)
 {
-  return ReadFromHardware<XCheckTLBFlag::NoException, u64>(address, MSR.DR);
+  return HostRead_U64(address, MSR.DR);
 }
 
 float HostRead_F32(const u32 address)
 {
-  const u32 integral = HostRead_U32(address);
-
-  return Common::BitCast<float>(integral);
+  return HostRead_F32(address, MSR.DR);
 }
 
 double HostRead_F64(const u32 address)
 {
-  const u64 integral = HostRead_U64(address);
+  return HostRead_F64(address, MSR.DR);
+}
+
+u8 HostRead_U8(const u32 address, bool override_msr_dr)
+{
+  return ReadFromHardware<XCheckTLBFlag::NoException, u8>(address, override_msr_dr);
+}
+
+u16 HostRead_U16(const u32 address, bool override_msr_dr)
+{
+  return ReadFromHardware<XCheckTLBFlag::NoException, u16>(address, override_msr_dr);
+}
+
+u32 HostRead_U32(const u32 address, bool override_msr_dr)
+{
+  return ReadFromHardware<XCheckTLBFlag::NoException, u32>(address, override_msr_dr);
+}
+
+u64 HostRead_U64(const u32 address, bool override_msr_dr)
+{
+  return ReadFromHardware<XCheckTLBFlag::NoException, u64>(address, override_msr_dr);
+}
+
+float HostRead_F32(const u32 address, bool override_msr_dr)
+{
+  const u32 integral = HostRead_U32(address, override_msr_dr);
+
+  return Common::BitCast<float>(integral);
+}
+
+double HostRead_F64(const u32 address, bool override_msr_dr)
+{
+  const u64 integral = HostRead_U64(address, override_msr_dr);
 
   return Common::BitCast<double>(integral);
 }
 
 void HostWrite_U8(const u8 var, const u32 address)
 {
-  WriteToHardware<XCheckTLBFlag::NoException, u8>(address, var, MSR.DR);
+  HostWrite_U8(var, address, MSR.DR);
 }
 
 void HostWrite_U16(const u16 var, const u32 address)
 {
-  WriteToHardware<XCheckTLBFlag::NoException, u16>(address, var, MSR.DR);
+  HostWrite_U16(var, address, MSR.DR);
 }
 
 void HostWrite_U32(const u32 var, const u32 address)
 {
-  WriteToHardware<XCheckTLBFlag::NoException, u32>(address, var, MSR.DR);
+  HostWrite_U32(var, address, MSR.DR);
 }
 
 void HostWrite_U64(const u64 var, const u32 address)
 {
-  WriteToHardware<XCheckTLBFlag::NoException, u64>(address, var, MSR.DR);
+  HostWrite_U64(var, address, MSR.DR);
 }
 
 void HostWrite_F32(const float var, const u32 address)
 {
-  const u32 integral = Common::BitCast<u32>(var);
-
-  HostWrite_U32(integral, address);
+  HostWrite_F32(var, address, MSR.DR);
 }
 
 void HostWrite_F64(const double var, const u32 address)
 {
+  HostWrite_F64(var, address, MSR.DR);
+}
+
+void HostWrite_U8(const u8 var, const u32 address, bool override_msr_dr)
+{
+  WriteToHardware<XCheckTLBFlag::NoException, u8>(address, var, override_msr_dr);
+}
+
+void HostWrite_U16(const u16 var, const u32 address, bool override_msr_dr)
+{
+  WriteToHardware<XCheckTLBFlag::NoException, u16>(address, var, override_msr_dr);
+}
+
+void HostWrite_U32(const u32 var, const u32 address, bool override_msr_dr)
+{
+  WriteToHardware<XCheckTLBFlag::NoException, u32>(address, var, override_msr_dr);
+}
+
+void HostWrite_U64(const u64 var, const u32 address, bool override_msr_dr)
+{
+  WriteToHardware<XCheckTLBFlag::NoException, u64>(address, var, override_msr_dr);
+}
+
+void HostWrite_F32(const float var, const u32 address, bool override_msr_dr)
+{
+  const u32 integral = Common::BitCast<u32>(var);
+
+  HostWrite_U32(integral, address, override_msr_dr);
+}
+
+void HostWrite_F64(const double var, const u32 address, bool override_msr_dr)
+{
   const u64 integral = Common::BitCast<u64>(var);
 
-  HostWrite_U64(integral, address);
+  HostWrite_U64(integral, address, override_msr_dr);
 }
 
 std::string HostGetString(u32 address, size_t size)
@@ -680,7 +740,12 @@ static bool IsRAMAddress(u32 address, bool translate)
 
 bool HostIsRAMAddress(u32 address)
 {
-  return IsRAMAddress<XCheckTLBFlag::NoException>(address, MSR.DR);
+  return HostIsRAMAddress(address, MSR.DR);
+}
+
+bool HostIsRAMAddress(u32 address, bool override_msr_dr)
+{
+  return IsRAMAddress<XCheckTLBFlag::NoException>(address, override_msr_dr);
 }
 
 bool HostIsInstructionRAMAddress(u32 address)

--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -24,6 +24,13 @@ float HostRead_F32(u32 address);
 double HostRead_F64(u32 address);
 u32 HostRead_Instruction(u32 address);
 
+u8 HostRead_U8(u32 address, bool override_msr_dr);
+u16 HostRead_U16(u32 address, bool override_msr_dr);
+u32 HostRead_U32(u32 address, bool override_msr_dr);
+u64 HostRead_U64(u32 address, bool override_msr_dr);
+float HostRead_F32(u32 address, bool override_msr_dr);
+double HostRead_F64(u32 address, bool override_msr_dr);
+
 void HostWrite_U8(u8 var, u32 address);
 void HostWrite_U16(u16 var, u32 address);
 void HostWrite_U32(u32 var, u32 address);
@@ -31,11 +38,21 @@ void HostWrite_U64(u64 var, u32 address);
 void HostWrite_F32(float var, u32 address);
 void HostWrite_F64(double var, u32 address);
 
+void HostWrite_U8(u8 var, u32 address, bool override_msr_dr);
+void HostWrite_U16(u16 var, u32 address, bool override_msr_dr);
+void HostWrite_U32(u32 var, u32 address, bool override_msr_dr);
+void HostWrite_U64(u64 var, u32 address, bool override_msr_dr);
+void HostWrite_F32(float var, u32 address, bool override_msr_dr);
+void HostWrite_F64(double var, u32 address, bool override_msr_dr);
+
 std::string HostGetString(u32 address, size_t size = 0);
 
 // Returns whether a read or write to the given address will resolve to a RAM
 // access given the current CPU state.
 bool HostIsRAMAddress(u32 address);
+
+// Same as HostIsRAMAddress, but allows overriding the MSR.DR state.
+bool HostIsRAMAddress(u32 address, bool override_msr_dr);
 
 // Same as HostIsRAMAddress, but uses IBAT instead of DBAT.
 bool HostIsInstructionRAMAddress(u32 address);

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -81,6 +81,7 @@ private:
   QSplitter* m_table_splitter;
   QComboBox* m_match_length;
   QComboBox* m_match_operation;
+  QComboBox* m_match_value_ref;
   QLineEdit* m_match_value;
   QPushButton* m_match_new;
   QPushButton* m_match_next;

--- a/Source/Core/DolphinQt/CheatsManager.h
+++ b/Source/Core/DolphinQt/CheatsManager.h
@@ -6,11 +6,14 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <QDialog>
 
 #include "Common/CommonTypes.h"
+
+#include "Core/CheatSearch.h"
 
 class ARCodeWidget;
 class QComboBox;
@@ -48,20 +51,21 @@ private:
   void ConnectWidgets();
   void OnStateChanged(Core::State state);
 
-  size_t GetTypeSize() const;
-  std::function<bool(u32)> CreateMatchFunction();
-
   void Reset();
   void NewSearch();
   void NextSearch();
-  void Update();
+  void UpdateResults();
+  void UpdateGUI();
+  void UpdateResultsAndGUI();
   void GenerateARCode();
 
   void OnWatchContextMenu();
   void OnMatchContextMenu();
   void OnWatchItemChanged(QTableWidgetItem* item);
 
-  std::vector<Result> m_results;
+  std::optional<Cheats::SearchValue> ParseValue();
+
+  std::vector<Cheats::SearchResult> m_results;
   std::vector<Result> m_watch;
   std::shared_ptr<const UICommon::GameFile> m_game_file;
   QDialogButtonBox* m_button_box;


### PR DESCRIPTION
Reimplements the Cheat Search functionality in Core for doing the actual memory reading and comparing grunt work, moving it out of the GUI code in Qt/CheatsManager. There's still some functionality remaining in the Qt code (AR code creation, value freezing), but the basic memory searching functionality should now even be theoretically usable from Core.

Merge note: This includes the commits from #8310.

Fixes https://bugs.dolphin-emu.org/issues/11434 by giving explicit 'unknown value' and 'last value' search options.