### PR TITLE
Conformance fixes

### DIFF
--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -152,7 +152,7 @@ IMMDevice* WASAPIStream::GetDeviceByName(std::string name)
                        __uuidof(IMMDeviceEnumerator), reinterpret_cast<LPVOID*>(&enumerator));
 
   if (!HandleWinAPI("Failed to create MMDeviceEnumerator", result))
-    return false;
+    return nullptr;
 
   IMMDeviceCollection* devices;
   result = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -483,7 +483,7 @@ std::string UTF16ToCP(u32 code_page, std::wstring_view input)
     output.resize(size);
 
     if (size != WideCharToMultiByte(code_page, 0, input.data(), static_cast<int>(input.size()),
-                                    &output[0], static_cast<int>(output.size()), nullptr, false))
+                                    &output[0], static_cast<int>(output.size()), nullptr, nullptr))
     {
       const DWORD error_code = GetLastError();
       ERROR_LOG(COMMON, "WideCharToMultiByte Error in String '%s': %lu",

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -88,9 +88,9 @@
       <!--Enable latest C++ standard-->
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <!--Enable Standard Conformance-->
-      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
+      <ConformanceMode>true</ConformanceMode>
       <!--Enforce some behaviors as standards-conformant when they don't default as such-->
-      <AdditionalOptions>/Zc:inline /Zc:throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
       <!--Treat sources as utf-8-->
@@ -103,7 +103,7 @@
                 seem to be a way to only ignore the specific instance we don't care about...
       4351  new behavior: elements of array 'array' will be default initialized
       -->
-      <DisableSpecificWarnings>4996;4351</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4996;4351;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- Warnings one may want to ignore when using Level4.
       4201  nonstandard extension used : nameless struct/union
       4127  conditional expression is constant


### PR DESCRIPTION
This PR fixes false-to-nullptr conversions raised on the issue tracker here:
https://bugs.dolphin-emu.org/issues/11829

It also modifies the .props file to enable `/permissive-` explicitly, since VS2017 has a GUI option for it now. I initially thought it's not enabled because of this, so enabling it this way instead of `<AdditionalOptions>` should clear some confusion.