### PR TITLE
WASAPI code improvements

### DIFF
--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -45,12 +45,9 @@ WASAPIStream::WASAPIStream()
 
 WASAPIStream::~WASAPIStream()
 {
-  if (m_running)
-  {
-    m_running = false;
-    if (m_thread.joinable())
-      m_thread.join();
-  }
+  m_running = false;
+  if (m_thread.joinable())
+    m_thread.join();
 }
 
 bool WASAPIStream::isValid()
@@ -332,7 +329,6 @@ bool WASAPIStream::SetRunning(bool running)
 
     m_running = true;
     m_thread = std::thread([this] { SoundLoop(); });
-    m_thread.detach();
   }
   else
   {
@@ -340,10 +336,6 @@ bool WASAPIStream::SetRunning(bool running)
 
     if (m_thread.joinable())
       m_thread.join();
-
-    while (!m_stopped)
-    {
-    }
 
     m_need_data_event.reset();
     m_audio_renderer.Reset();
@@ -364,8 +356,6 @@ void WASAPIStream::SoundLoop()
     m_audio_renderer->ReleaseBuffer(m_frames_in_buffer, AUDCLNT_BUFFERFLAGS_SILENT);
   }
 
-  m_stopped = false;
-
   while (m_running)
   {
     if (!m_audio_renderer)
@@ -383,8 +373,6 @@ void WASAPIStream::SoundLoop()
 
     m_audio_renderer->ReleaseBuffer(m_frames_in_buffer, 0);
   }
-
-  m_stopped = true;
 }
 
 #endif  // _WIN32

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -353,17 +353,11 @@ void WASAPIStream::SoundLoop()
   Common::SetCurrentThreadName("WASAPI Handler");
   BYTE* data;
 
-  if (m_audio_renderer)
-  {
-    m_audio_renderer->GetBuffer(m_frames_in_buffer, &data);
-    m_audio_renderer->ReleaseBuffer(m_frames_in_buffer, AUDCLNT_BUFFERFLAGS_SILENT);
-  }
+  m_audio_renderer->GetBuffer(m_frames_in_buffer, &data);
+  m_audio_renderer->ReleaseBuffer(m_frames_in_buffer, AUDCLNT_BUFFERFLAGS_SILENT);
 
   while (m_running.load(std::memory_order_relaxed))
   {
-    if (!m_audio_renderer)
-      continue;
-
     WaitForSingleObject(m_need_data_event.get(), 1000);
 
     m_audio_renderer->GetBuffer(m_frames_in_buffer, &data);

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -300,7 +300,7 @@ bool WASAPIStream::SetRunning(bool running)
     m_need_data_event = std::move(need_data_event);
 
     m_running.store(true, std::memory_order_relaxed);
-    m_thread = std::thread([this] { SoundLoop(); });
+    m_thread = std::thread(&WASAPIStream::SoundLoop, this);
   }
   else
   {

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -62,7 +62,7 @@ bool WASAPIStream::isValid()
 
 static bool HandleWinAPI(std::string_view message, HRESULT result)
 {
-  if (result != S_OK)
+  if (FAILED(result))
   {
     _com_error err(result);
     std::string error = TStrToUTF8(err.ErrorMessage());
@@ -77,7 +77,7 @@ static bool HandleWinAPI(std::string_view message, HRESULT result)
     ERROR_LOG_FMT(AUDIO, "WASAPI: {}: {}", message, error);
   }
 
-  return result == S_OK;
+  return SUCCEEDED(result);
 }
 
 std::vector<std::string> WASAPIStream::GetAvailableDevices()

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -59,13 +59,15 @@ static bool HandleWinAPI(std::string_view message, HRESULT result)
 {
   if (FAILED(result))
   {
-    _com_error err(result);
-    std::string error = TStrToUTF8(err.ErrorMessage());
+    std::string error;
 
     switch (result)
     {
     case AUDCLNT_E_DEVICE_IN_USE:
       error = "Audio endpoint already in use!";
+      break;
+    default:
+      error = TStrToUTF8(_com_error(result).ErrorMessage()).c_str();
       break;
     }
 
@@ -74,6 +76,7 @@ static bool HandleWinAPI(std::string_view message, HRESULT result)
 
   return SUCCEEDED(result);
 }
+
 
 std::vector<std::string> WASAPIStream::GetAvailableDevices()
 {
@@ -131,7 +134,7 @@ std::vector<std::string> WASAPIStream::GetAvailableDevices()
   return device_names;
 }
 
-ComPtr<IMMDevice> WASAPIStream::GetDeviceByName(std::string name)
+ComPtr<IMMDevice> WASAPIStream::GetDeviceByName(std::string_view name)
 {
   HRESULT result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
   // RPC_E_CHANGED_MODE means that thread has COM already initialized with a different threading

--- a/Source/Core/AudioCommon/WASAPIStream.h
+++ b/Source/Core/AudioCommon/WASAPIStream.h
@@ -5,16 +5,19 @@
 #pragma once
 
 #ifdef _WIN32
+
 // clang-format off
 #include <Windows.h>
 #include <mmreg.h>
+#include <objbase.h>
+#include <wil/resource.h>
 // clang-format on
-#endif
 
 #include <atomic>
 #include <string>
 #include <thread>
 #include <vector>
+#include <wrl/client.h>
 
 #include "AudioCommon/SoundStream.h"
 
@@ -22,6 +25,8 @@ struct IAudioClient;
 struct IAudioRenderClient;
 struct IMMDevice;
 struct IMMDeviceEnumerator;
+
+#endif
 
 class WASAPIStream final : public SoundStream
 {
@@ -35,7 +40,7 @@ public:
 
   static bool isValid();
   static std::vector<std::string> GetAvailableDevices();
-  static IMMDevice* GetDeviceByName(std::string name);
+  static Microsoft::WRL::ComPtr<IMMDevice> GetDeviceByName(std::string name);
 
 private:
   u32 m_frames_in_buffer = 0;
@@ -43,10 +48,14 @@ private:
   std::atomic<bool> m_stopped = false;
   std::thread m_thread;
 
-  IAudioClient* m_audio_client = nullptr;
-  IAudioRenderClient* m_audio_renderer = nullptr;
-  IMMDeviceEnumerator* m_enumerator = nullptr;
-  HANDLE m_need_data_event = nullptr;
+  // CoUninitialize must be called after all WASAPI COM objects have been destroyed,
+  // therefore this member must be located before them, as first class fields are destructed last
+  wil::unique_couninitialize_call m_coinitialize{false};
+
+  Microsoft::WRL::ComPtr<IMMDeviceEnumerator> m_enumerator;
+  Microsoft::WRL::ComPtr<IAudioClient> m_audio_client;
+  Microsoft::WRL::ComPtr<IAudioRenderClient> m_audio_renderer;
+  wil::unique_event_nothrow m_need_data_event;
   WAVEFORMATEXTENSIBLE m_format;
 #endif  // _WIN32
 };

--- a/Source/Core/AudioCommon/WASAPIStream.h
+++ b/Source/Core/AudioCommon/WASAPIStream.h
@@ -45,7 +45,6 @@ public:
 private:
   u32 m_frames_in_buffer = 0;
   std::atomic<bool> m_running = false;
-  std::atomic<bool> m_stopped = false;
   std::thread m_thread;
 
   // CoUninitialize must be called after all WASAPI COM objects have been destroyed,

--- a/Source/Core/AudioCommon/WASAPIStream.h
+++ b/Source/Core/AudioCommon/WASAPIStream.h
@@ -40,7 +40,7 @@ public:
 
   static bool isValid();
   static std::vector<std::string> GetAvailableDevices();
-  static Microsoft::WRL::ComPtr<IMMDevice> GetDeviceByName(std::string name);
+  static Microsoft::WRL::ComPtr<IMMDevice> GetDeviceByName(std::string_view name);
 
 private:
   u32 m_frames_in_buffer = 0;


### PR DESCRIPTION
This PR brings numerous improvements to WASAPI code in Dolphin, improving code readability as well as fixing numerous issues.

As a preparation, [WIL](https://github.com/microsoft/wil) has been added, since it's very useful for ensuring proper RAII-based destruction for several WinAPI types - in my case it was proper scoped calls to `CoUninitialize` and proper destruction of previously leaking (in some cases) `PROPVARIANT`.

All COM objects have been moved to use WRL, which ensures their proper release. Previously, there were numerous code paths where functions would return without cleaning up their COM objects, effectively leaking references.

`device->GetId(&device_id);` was present in several places, never using the return value nor freeing it - leaking memory for no reason.

Thread synchronization model for WASAPI Handler thread has been simplified by not detaching said thread. Not only it improved code readability, but also fixed a spinlock occuring if `WASAPIStream::SetRunning(true)` failed in **any** way - a following call to `WASAPIStream::SetRunning(false)` would then spin endlessly checking for `m_stopped`. Now this boolean is gone, and so is the problem.

`std::string_view` is now used where applicable. I opted for constructing a `std::string` out of `std::string_view` in `HandleWinAPI`, because it happens in code path which is taken relatively rarely - in a perfect case it's never taken.

I modified `SoundLoop` not to do volume adjustment unless absolutely necessary, saving on a relatively costly loop. For 100% volume, volume adjustment is not needed, and for 0% volume a `AUDCLNT_BUFFERFLAGS_SILENT` is now specified instead of zeroing the buffer. I also removed several nullptr checks which were not thread safe anyway, so only brought a false sense of safety.