### PR TITLE
Fix "Muted%" OSD message when muting sounds via a hotkey

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -302,8 +302,7 @@ void HotkeyScheduler::Run()
         OSD::AddMessage(std::string("Volume: ") +
                         (SConfig::GetInstance().m_IsMuted ?
                              "Muted" :
-                             std::to_string(SConfig::GetInstance().m_Volume)) +
-                        "%");
+                             std::to_string(SConfig::GetInstance().m_Volume) + "%"));
       };
 
       // Volume


### PR DESCRIPTION
OSD message previously showed `Volume: Muted%` when muting sounds. Just moved some brackets around to fix that.