### PR TITLE
Jit64: fix mcrfs

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -635,7 +635,7 @@ void Jit64::mcrfs(UGeckoInstruction inst)
   u32 mask = 0xF << shift;
 
   // Only clear exception bits (but not FEX/VX).
-  mask &= 0x9FF87000;
+  mask &= FPSCR_FX | FPSCR_ANY_X;
 
   MOV(32, R(RSCRATCH), PPCSTATE(fpscr));
   if (cpu_info.bBMI1)
@@ -649,7 +649,7 @@ void Jit64::mcrfs(UGeckoInstruction inst)
     SHR(32, R(RSCRATCH2), Imm8(shift));
     AND(32, R(RSCRATCH2), Imm32(0xF));
   }
-  AND(32, R(RSCRATCH), Imm32(mask));
+  AND(32, R(RSCRATCH), Imm32(~mask));
   MOV(32, PPCSTATE(fpscr), R(RSCRATCH));
   LEA(64, RSCRATCH, MConst(PowerPC::ConditionRegister::s_crTable));
   MOV(64, R(RSCRATCH), MComplex(RSCRATCH, RSCRATCH2, SCALE_8, 0));


### PR DESCRIPTION
It was deleting the wrong bits. This fixes [issue 10074](https://bugs.dolphin-emu.org/issues/10074) (Super Monkey Ball 2 minigame). I introduced this regression in 0f2c65668746c739ad116fb8daa3c027ea429f41, exactly four years ago today :astonished:.

Someone who is good at this game should test whether this also fixes [issue 10640](https://bugs.dolphin-emu.org/issues/10640) (Super Monkey Ball Banana Blitz final boss freeze).