### PR TITLE
Do not yield to UI from PauseAndLock

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -183,10 +183,7 @@ void Stop()
 
   while (s_state_cpu_thread_active)
   {
-    std::cv_status status =
-        s_state_cpu_idle_cvar.wait_for(state_lock, std::chrono::milliseconds(100));
-    if (status == std::cv_status::timeout)
-      Host_YieldToUI();
+    s_state_cpu_idle_cvar.wait(state_lock);
   }
 
   RunAdjacentSystems(false);
@@ -252,10 +249,7 @@ void EnableStepping(bool stepping)
 
     while (s_state_cpu_thread_active)
     {
-      std::cv_status status =
-          s_state_cpu_idle_cvar.wait_for(state_lock, std::chrono::milliseconds(100));
-      if (status == std::cv_status::timeout)
-        Host_YieldToUI();
+      s_state_cpu_idle_cvar.wait(state_lock);
     }
 
     RunAdjacentSystems(false);
@@ -303,10 +297,7 @@ bool PauseAndLock(bool do_lock, bool unpause_on_unlock, bool control_adjacent)
 
     while (s_state_cpu_thread_active)
     {
-      std::cv_status status =
-          s_state_cpu_idle_cvar.wait_for(state_lock, std::chrono::milliseconds(100));
-      if (status == std::cv_status::timeout)
-        Host_YieldToUI();
+      s_state_cpu_idle_cvar.wait(state_lock);
     }
 
     if (control_adjacent)


### PR DESCRIPTION
This PR fixes a rare crash in Dolphin, easiest to reproduce by spamming volume up/down controls continuously in game. With a little bit of luck (and patience), it was possible to crash on recursive stepping mutex lock. It seems to be a lot easier to reproduce it after opening and closing Config window before running the game, so Audio settings window gets created and registers its config callbacks.

The underlying reason behind this crash was an infinite recursion caused by yielding to UI thread (processing Qt events) from `Core::RunAsCPUThread` running in a callback from another Qt event. Yielding was done only when `s_state_cpu_idle_cvar` wait timed out, which turned out to be **extremely** rare, so removing it does not impact UI responsiveness negatively.

The exact sequence of events here was as follows:
1. Volume control hotkey is triggered.
2. `AudioPane::OnVolumeChanged` is called.
3. `AudioPane::SaveSettings` is called.
4. `InvokeConfigChangedCallbacks` is called.
5. `VideoConfig::Refresh` is called on CPU thread (acquires stepping mutex).
6. `CPU::PauseAndLock` waits for `s_state_cpu_idle_cvar` which times out.
7. Timing out causes Dolphin to yield to UI and call `processEvents`.
8. `AudioPane::OnVolumeChanged` is called **again**, and so are further calls.
9. `VideoConfig::Refresh` attempts to call on CPU thread **again**.
10. Stepping mutex is **not** recursive, so attempting to acquire it again results in an exception.

Now, would making a stepping lock recursive help? Most likely not, since it would likely be possible to yield to UI recursively, eventually causing a stack overflow. Not yielding to UI at all here is safer, since it almost never happened anyway.