### PR TITLE
Enable adapter combo only if adapters are supported by current backend

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -187,7 +187,8 @@ void GeneralWidget::OnEmulationStateChanged(bool running)
   m_backend_combo->setEnabled(!running);
   m_render_main_window->setEnabled(!running);
 
-  m_adapter_combo->setEnabled(!running);
+  const bool supports_adapters = !g_Config.backend_info.Adapters.empty();
+  m_adapter_combo->setEnabled(!running && supports_adapters);
 }
 
 void GeneralWidget::AddDescriptions()


### PR DESCRIPTION
`GeneralWidget::OnEmulationStateChanged` enabled/disabled the Adapter combo regardless whether the current backend actually supports it or not.