### PR TITLE
Dualcore INI changes

### DIFF
--- a/Data/Sys/GameSettings/E62.ini
+++ b/Data/Sys/GameSettings/E62.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/G4Z.ini
+++ b/Data/Sys/GameSettings/G4Z.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# G4ZP69, G4ZE69 - The Sims 2
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/G96.ini
+++ b/Data/Sys/GameSettings/G96.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# G96P01, G96E01 - Interactive Multi Game Demo Disc v4
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/GGC.ini
+++ b/Data/Sys/GameSettings/GGC.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# GGCP0A, GGCE0A - Goblin Commander: Unleash the Horde
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/GIS.ini
+++ b/Data/Sys/GameSettings/GIS.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 MMU = 1
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GT3.ini
+++ b/Data/Sys/GameSettings/GT3.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWT.ini
+++ b/Data/Sys/GameSettings/GWT.ini
@@ -5,6 +5,7 @@
 # This game does not work properly with large memorycards, use a 251 block card
 # see https://www.nintendo.com/consumer/memorycard1019.jsp
 MemoryCard251 = True
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/R5P.ini
+++ b/Data/Sys/GameSettings/R5P.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# R5PJ13, R5PX69, R5PE69, R5PP69 - Harry Potter and The Order of The Phoenix
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/RDZ.ini
+++ b/Data/Sys/GameSettings/RDZ.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# RDZJ01, RDZE01, RDZP01 - Disaster: Day of Crisis
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/RH6.ini
+++ b/Data/Sys/GameSettings/RH6.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# RH6E69, RH6P69, RH6K69 - Harry Potter and The Half-Blood Prince
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/RHA.ini
+++ b/Data/Sys/GameSettings/RHA.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# RHAW01, RHAJ01, RHAE01, RHAK01, RHAP01 - Wii Play
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/RHO.ini
+++ b/Data/Sys/GameSettings/RHO.ini
@@ -1,9 +1,16 @@
 # RHOE8P, RHOJ8P, RHOP8P - House Of The Dead: OVERKILL
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
+
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
+
 [OnFrame]
+# Add memory patches to be applied every frame here.
+
 [ActionReplay]
+# Add action replay cheats here.
+
 [Video_Hacks]
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/RTB.ini
+++ b/Data/Sys/GameSettings/RTB.ini
@@ -1,4 +1,8 @@
 # RTBE52, RTBP52 - Rapala Fishing Frenzy
 
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
+
 [Video_Settings]
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RYB.ini
+++ b/Data/Sys/GameSettings/RYB.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SCI.ini
+++ b/Data/Sys/GameSettings/SCI.ini
@@ -1,7 +1,8 @@
-# GKBEAF, GKBJAF, GKBPAF - Baten Kaitos Eternal Wings and the Lost Ocean
+# SCIE41, SCIP41 - CSI: Fatal Conspiracy
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,11 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-ImmediateXFBEnable = False
-EFBAccessEnable = False
-EFBToTextureEnable = False
-DeferEFBCopies = False
-
-[Video_Settings]


### PR DESCRIPTION
Dualcore changes taken from #8164.
I have re-evaluated all the dualcore changes and only included the most important INI changes based on the wiki, issue tracker and forum. 
Dualcore has been enabled for 'Baten Kaitos Eternal Wings and the Lost Ocean' as tests on wiki show that it can safely be enabled.  