### PR TITLE
WiimoteEmu: Add option to use system battery level

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -291,6 +291,8 @@ add_library(core
   HW/WiimoteEmu/MotionPlus.h
   HW/WiimoteEmu/Speaker.cpp
   HW/WiimoteEmu/Speaker.h
+  HW/WiimoteEmu/SystemBattery.cpp
+  HW/WiimoteEmu/SystemBattery.h
   HW/WiimoteEmu/WiimoteEmu.cpp
   HW/WiimoteEmu/WiimoteEmu.h
   HW/WiimoteEmu/Extension/Classic.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="HW\WiimoteEmu\I2CBus.cpp" />
     <ClCompile Include="HW\WiimoteEmu\MotionPlus.cpp" />
     <ClCompile Include="HW\WiimoteEmu\Speaker.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\SystemBattery.cpp" />
     <ClCompile Include="HW\WiimoteEmu\WiimoteEmu.cpp" />
     <ClCompile Include="HW\WiimoteReal\IOWin.cpp" />
     <ClCompile Include="HW\WiimoteReal\WiimoteReal.cpp" />
@@ -465,6 +466,7 @@
     <ClInclude Include="HW\WiimoteEmu\I2CBus.h" />
     <ClInclude Include="HW\WiimoteEmu\MotionPlus.h" />
     <ClInclude Include="HW\WiimoteEmu\Speaker.h" />
+    <ClInclude Include="HW\WiimoteEmu\SystemBattery.h" />
     <ClInclude Include="HW\WiimoteEmu\WiimoteEmu.h" />
     <ClInclude Include="HW\WiimoteReal\WiimoteReal.h" />
     <ClInclude Include="HW\WiimoteReal\WiimoteRealBase.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -526,6 +526,9 @@
     <ClCompile Include="HW\WiimoteEmu\Encryption.cpp">
       <Filter>HW %28Flipper/Hollywood%29\Wiimote\Emu</Filter>
     </ClCompile>
+    <ClCompile Include="HW\WiimoteEmu\SystemBattery.cpp">
+      <Filter>HW %28Flipper/Hollywood%29\Wiimote\Emu</Filter>
+    </ClCompile>
     <ClCompile Include="HW\WiimoteEmu\WiimoteEmu.cpp">
       <Filter>HW %28Flipper/Hollywood%29\Wiimote\Emu</Filter>
     </ClCompile>
@@ -1236,6 +1239,9 @@
       <Filter>HW %28Flipper/Hollywood%29\VI - Video Interface</Filter>
     </ClInclude>
     <ClInclude Include="HW\WiimoteEmu\Encryption.h">
+      <Filter>HW %28Flipper/Hollywood%29\Wiimote\Emu</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\WiimoteEmu\SystemBattery.h">
       <Filter>HW %28Flipper/Hollywood%29\Wiimote\Emu</Filter>
     </ClInclude>
     <ClInclude Include="HW\WiimoteEmu\WiimoteEmu.h">

--- a/Source/Core/Core/HW/WiimoteEmu/SystemBattery.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/SystemBattery.cpp
@@ -1,0 +1,102 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/HW/WiimoteEmu/SystemBattery.h"
+
+#include "Common/ScopeGuard.h"
+
+#if defined(_WIN32)
+#include <Windows.h>
+#elif defined(__APPLE__)
+#include <CoreFoundation/CFDictionary.h>
+#include <IOKit/ps/IOPSKeys.h>
+#include <IOKit/ps/IOPowerSources.h>
+#endif
+
+namespace WiimoteEmu
+{
+
+#if defined(_WIN32)
+
+std::optional<float> GetSystemBatteryLevel()
+{
+  SYSTEM_POWER_STATUS power_status;
+  if (!GetSystemPowerStatus(&power_status))
+  {
+    return std::nullopt;
+  }
+
+  // Not on battery power, treat as 100%
+  if (power_status.ACLineStatus == 1)
+  {
+    return 1.0;
+  }
+
+  if (power_status.BatteryLifePercent != 255)
+  {
+    return power_status.BatteryLifePercent / 100.0f;
+  }
+
+  return std::nullopt;
+}
+
+#elif defined(__APPLE__)
+
+std::optional<float> GetSystemBatteryLevel()
+{
+  CFTypeRef power_blob = IOPSCopyPowerSourcesInfo();
+  if (!power_blob)
+  {
+    return std::nullopt;
+  }
+  Common::ScopeGuard power_blob_guard([power_blob] { CFRelease(power_blob); });
+
+  CFArrayRef power_sources = IOPSCopyPowerSourcesList(power_blob);
+  if (!power_sources)
+  {
+    return std::nullopt;
+  }
+  Common::ScopeGuard power_sources_guard([power_sources] { CFRelease(power_sources); });
+
+  CFStringRef current_power = IOPSGetProvidingPowerSourceType(power_blob);
+  // Not on battery power, treat as 100%
+  if (kCFCompareEqualTo != CFStringCompare(current_power, CFSTR(kIOPMBatteryPowerKey), 0))
+  {
+    return 1.0;
+  }
+
+  for (CFIndex i = 0; i < CFArrayGetCount(power_sources); i++)
+  {
+    CFTypeRef power_source = CFArrayGetValueAtIndex(power_sources, i);
+    CFDictionaryRef power_source_desc = IOPSGetPowerSourceDescription(power_blob, power_source);
+    if (!power_source_desc)
+    {
+      continue;
+    }
+
+    CFNumberRef capacity_current, capacity_max;
+    if (!CFDictionaryGetValueIfPresent(power_source_desc, CFSTR(kIOPSCurrentCapacityKey),
+                                       (const void**)&capacity_current) ||
+        !CFDictionaryGetValueIfPresent(power_source_desc, CFSTR(kIOPSMaxCapacityKey),
+                                       (const void**)&capacity_max))
+    {
+      continue;
+    }
+
+    float cur, max;
+    if (!CFNumberGetValue(capacity_current, kCFNumberFloat32Type, &cur) ||
+        !CFNumberGetValue(capacity_max, kCFNumberFloat32Type, &max))
+    {
+      continue;
+    }
+
+    return cur / max;
+  }
+
+  return std::nullopt;
+}
+
+#endif
+
+};

--- a/Source/Core/Core/HW/WiimoteEmu/SystemBattery.h
+++ b/Source/Core/Core/HW/WiimoteEmu/SystemBattery.h
@@ -1,0 +1,25 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <optional>
+
+namespace WiimoteEmu
+{
+
+#if defined(_WIN32) || defined(__APPLE__)
+
+std::optional<float> GetSystemBatteryLevel(void);
+
+#else
+
+static inline constexpr std::optional<float> GetSystemBatteryLevel(void)
+{
+	return std::nullopt;
+}
+
+#endif
+
+};

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -196,6 +196,9 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
                          _trans("%")},
                         95, 0, 100);
 
+  m_options->AddSetting(&m_system_battery_setting,
+                        {_trans("Use system battery status if possible")}, true);
+
   // Note: "Upright" and "Sideways" options can be enabled at the same time which produces an
   // orientation where the wiimote points towards the left with the buttons towards you.
   m_options->AddSetting(&m_upright_setting,

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -245,6 +245,7 @@ private:
   ControllerEmu::SettingValue<bool> m_sideways_setting;
   ControllerEmu::SettingValue<bool> m_upright_setting;
   ControllerEmu::SettingValue<double> m_battery_setting;
+  ControllerEmu::SettingValue<bool> m_system_battery_setting;
   ControllerEmu::SettingValue<double> m_speaker_pan_setting;
   ControllerEmu::SettingValue<bool> m_motion_plus_setting;
 


### PR DESCRIPTION
Only supports Windows and Mac right now.