### PR TITLE
Add enc_temp_folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Source/Core/Common/scmrev.h
 *.VC.opendb
 *.VC.db
 .vs/
+/Source/enc_temp_folder/
 # Ignore build info file created by QtCreator
 CMakeLists.txt.user
 # Ignore files created by posix people


### PR DESCRIPTION
Not quite sure what this is, but Visual Studio creates it occasionally.