### PR TITLE
DSPLLE: Put DSP thread in idle state when it's paused

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -336,8 +336,16 @@ u32 DSPLLE::DSP_UpdateRate()
 void DSPLLE::PauseAndLock(bool do_lock, bool unpause_on_unlock)
 {
   if (do_lock)
+  {
     m_dsp_thread_mutex.lock();
+  }
   else
+  {
     m_dsp_thread_mutex.unlock();
+
+    // Signal the DSP thread so it can perform any outstanding work now (if any)
+    s_ppc_event.Wait();
+    s_dsp_event.Set();
+  }
 }
 }  // namespace DSP::LLE


### PR DESCRIPTION
Fixes a deadlock when accessing Graphics config **immediately** after booting up the game when using a LLE DSP.

DSP thread is considered "idle" when it signals `s_ppc_event` and waits for `s_dsp_event`, without putting it in this state when `m_dsp_thread_mutex` is locked it was possible to create a deadlock between a DSP thread, emulation thread and Qt thread.