### PR TITLE
Core: Generate screenshot name with timestamps

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -369,12 +369,12 @@ Renderer::ConvertStereoRectangle(const MathUtil::Rectangle<int>& rc) const
   return std::make_tuple(left_rc, right_rc);
 }
 
-void Renderer::SaveScreenshot(const std::string& filename, bool wait_for_completion)
+void Renderer::SaveScreenshot(std::string filename, bool wait_for_completion)
 {
   // We must not hold the lock while waiting for the screenshot to complete.
   {
     std::lock_guard<std::mutex> lk(m_screenshot_lock);
-    m_screenshot_name = filename;
+    m_screenshot_name = std::move(filename);
     m_screenshot_request.Set();
   }
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -196,7 +196,7 @@ public:
   float EFBToScaledYf(float y) const;
 
   // Random utilities
-  void SaveScreenshot(const std::string& filename, bool wait_for_completion);
+  void SaveScreenshot(std::string filename, bool wait_for_completion);
   void DrawDebugText();
 
   // ImGui initialization depends on being able to create textures and pipelines, so do it last.


### PR DESCRIPTION
Screenshot names in format `GAMEID-YYYY-MM-DD_HH-MM-SS.png` are not only more intuitive for the user, but also remove the need for this hideous loop which kept re-checking every possible suffix starting with `GAMEID-1.png'. If the user had thousands of screenshots from the same name, I doubt checking those every time was healthy.

In an unlikely case of name collisions (eg. multiple screenshots within a second), an increasing number gets appended to the filename.