### PR TITLE
Add Dolphin version and current video backend to shader compilation logs

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -21,7 +21,9 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Common/Version.h"
 
+#include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace Vulkan::ShaderCompiler
@@ -142,9 +144,7 @@ std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage, const char*
 
   auto DumpBadShader = [&](const char* msg) {
     static int counter = 0;
-    std::string filename = StringFromFormat(
-        "%sbad_%s_%04i.txt", File::GetUserPath(D_DUMP_IDX).c_str(), stage_filename, counter++);
-
+    std::string filename = VideoBackendBase::BadShaderFilename(stage_filename, counter++);
     std::ofstream stream;
     File::OpenFStream(stream, filename, std::ios_base::out);
     if (stream.good())
@@ -161,6 +161,10 @@ std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage, const char*
         stream << program->getInfoDebugLog() << std::endl;
       }
     }
+
+    stream << "\n";
+    stream << "Dolphin Version: " + Common::scm_rev_str + "\n";
+    stream << "Video Backend: " + g_video_backend->GetDisplayName();
 
     PanicAlert("%s (written to %s)", msg, filename.c_str());
   };

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -10,10 +10,13 @@
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/Logging/Log.h"
+
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
@@ -67,6 +70,12 @@ extern "C" {
 __declspec(dllexport) DWORD NvOptimusEnablement = 1;
 }
 #endif
+
+std::string VideoBackendBase::BadShaderFilename(const char* shader_stage, int counter)
+{
+  return fmt::format("{}bad_{}_{}_{}.txt", File::GetUserPath(D_DUMP_IDX), shader_stage,
+                     g_video_backend->GetName(), counter);
+}
 
 void VideoBackendBase::Video_ExitLoop()
 {

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -49,6 +49,8 @@ public:
   // thread which owns the window.
   virtual void PrepareWindow(const WindowSystemInfo& wsi) {}
 
+  static std::string BadShaderFilename(const char* shader_stage, int counter);
+
   void Video_ExitLoop();
 
   void Video_BeginField(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u64 ticks);


### PR DESCRIPTION
Implements https://bugs.dolphin-emu.org/issues/9992

This makes it easier to quickly identify what version of Dolphin and video backend produced shader compilation issues.