### PR TITLE
Log widget improvements

### DIFF
--- a/Source/Core/Common/FixedSizeQueue.h
+++ b/Source/Core/Common/FixedSizeQueue.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 
 // STL-look-a-like interface, but name is mixed case to distinguish it clearly from the
@@ -19,6 +20,9 @@ class FixedSizeQueue
 public:
   void clear()
   {
+    if constexpr (!std::is_trivial_v<T>)
+      storage = {};
+
     head = 0;
     tail = 0;
     count = 0;
@@ -26,31 +30,47 @@ public:
 
   void push(T t)
   {
+    if (count == N)
+      head = (head + 1) % N;
+    else
+      count++;
+
     storage[tail] = std::move(t);
-    tail++;
-    if (tail == N)
-      tail = 0;
-    count++;
+    tail = (tail + 1) % N;
+  }
+
+  template <class... Args>
+  void emplace(Args&&... args)
+  {
+    if (count == N)
+      head = (head + 1) % N;
+    else
+      count++;
+
+    storage[tail] = T(std::forward<Args>(args)...);
+    tail = (tail + 1) % N;
   }
 
   void pop()
   {
-    head++;
-    if (head == N)
-      head = 0;
+    if constexpr (!std::is_trivial_v<T>)
+      storage[head] = {};
+
+    head = (head + 1) % N;
     count--;
   }
 
   T pop_front()
   {
-    T& temp = storage[head];
+    T temp = std::move(front());
     pop();
-    return std::move(temp);
+    return temp;
   }
 
-  T& front() { return storage[head]; }
-  const T& front() const { return storage[head]; }
-  size_t size() const { return count; }
+  T& front() noexcept { return storage[head]; }
+  const T& front() const noexcept { return storage[head]; }
+  size_t size() const noexcept { return count; }
+  bool empty() const noexcept { return size() == 0; }
 
 private:
   std::array<T, N> storage;

--- a/Source/Core/DolphinQt/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogWidget.cpp
@@ -46,7 +46,12 @@ LogWidget::LogWidget(QWidget* parent) : QDockWidget(parent), m_timer(new QTimer(
   ConnectWidgets();
 
   connect(m_timer, &QTimer::timeout, this, &LogWidget::UpdateLog);
-  m_timer->start(UPDATE_LOG_DELAY);
+  connect(this, &QDockWidget::visibilityChanged, [this](bool visible) {
+    if (visible)
+      m_timer->start(UPDATE_LOG_DELAY);
+    else
+      m_timer->stop();
+  });
 
   connect(&Settings::Instance(), &Settings::DebugFontChanged, this, &LogWidget::UpdateFont);
 

--- a/Source/Core/DolphinQt/Config/LogWidget.h
+++ b/Source/Core/DolphinQt/Config/LogWidget.h
@@ -14,9 +14,8 @@
 class QCheckBox;
 class QCloseEvent;
 class QComboBox;
+class QPlainTextEdit;
 class QPushButton;
-class QVBoxLayout;
-class QTextEdit;
 class QTimer;
 
 class LogWidget final : public QDockWidget, LogListener
@@ -43,9 +42,7 @@ private:
   QCheckBox* m_log_wrap;
   QComboBox* m_log_font;
   QPushButton* m_log_clear;
-  QVBoxLayout* m_main_layout;
-  QTextEdit* m_log_text;
-  QWidget* m_tab_log;
+  QPlainTextEdit* m_log_text;
 
   QTimer* m_timer;
 

--- a/Source/Core/DolphinQt/Config/LogWidget.h
+++ b/Source/Core/DolphinQt/Config/LogWidget.h
@@ -8,6 +8,7 @@
 
 #include <mutex>
 #include <queue>
+#include <string>
 
 #include "Common/Logging/LogManager.h"
 
@@ -46,6 +47,8 @@ private:
 
   QTimer* m_timer;
 
+  using LogEntry = std::pair<std::string, LogTypes::LOG_LEVELS>;
+
   std::mutex m_log_mutex;
-  std::queue<QString> m_log_queue;
+  std::queue<LogEntry> m_log_queue;
 };

--- a/Source/Core/DolphinQt/Config/LogWidget.h
+++ b/Source/Core/DolphinQt/Config/LogWidget.h
@@ -7,9 +7,9 @@
 #include <QDockWidget>
 
 #include <mutex>
-#include <queue>
 #include <string>
 
+#include "Common/FixedSizeQueue.h"
 #include "Common/Logging/LogManager.h"
 
 class QCheckBox;
@@ -49,6 +49,9 @@ private:
 
   using LogEntry = std::pair<std::string, LogTypes::LOG_LEVELS>;
 
+  // Maximum number of lines to show in log viewer
+  static constexpr int MAX_LOG_LINES = 5000;
+
   std::mutex m_log_mutex;
-  std::queue<LogEntry> m_log_queue;
+  FixedSizeQueue<LogEntry, MAX_LOG_LINES> m_log_ring_buffer;
 };

--- a/Source/UnitTests/Common/FixedSizeQueueTest.cpp
+++ b/Source/UnitTests/Common/FixedSizeQueueTest.cpp
@@ -31,3 +31,85 @@ TEST(FixedSizeQueue, Simple)
 
   EXPECT_EQ(0u, q.size());
 }
+
+TEST(FixedSizeQueue, RingBuffer)
+{
+  // Testing if queue works when used as a ring buffer
+  FixedSizeQueue<int, 5> q;
+
+  EXPECT_EQ(0u, q.size());
+
+  q.push(0);
+  q.push(1);
+  q.push(2);
+  q.push(3);
+  q.push(4);
+  q.push(5);
+
+  EXPECT_EQ(5u, q.size());
+  EXPECT_EQ(1, q.pop_front());
+
+  EXPECT_EQ(4u, q.size());
+}
+
+// Local classes cannot have static fields,
+// therefore this has to be declared in global scope.
+class NonTrivialTypeTestData
+{
+public:
+  static inline int num_objects = 0;
+  static inline int total_constructed = 0;
+  static inline int default_constructed = 0;
+  static inline int total_destructed = 0;
+
+  NonTrivialTypeTestData()
+  {
+    num_objects++;
+    total_constructed++;
+    default_constructed++;
+  }
+
+  NonTrivialTypeTestData(int /*val*/)
+  {
+    num_objects++;
+    total_constructed++;
+  }
+
+  ~NonTrivialTypeTestData()
+  {
+    num_objects--;
+    total_destructed++;
+  }
+};
+
+TEST(FixedSizeQueue, NonTrivialTypes)
+{
+  // Testing if construction/destruction of non-trivial types happens as expected
+  FixedSizeQueue<NonTrivialTypeTestData, 2> q;
+
+  EXPECT_EQ(0u, q.size());
+
+  EXPECT_EQ(2, NonTrivialTypeTestData::num_objects);
+  EXPECT_EQ(2, NonTrivialTypeTestData::total_constructed);
+  EXPECT_EQ(2, NonTrivialTypeTestData::default_constructed);
+  EXPECT_EQ(0, NonTrivialTypeTestData::total_destructed);
+
+  q.emplace(4);
+  q.emplace(6);
+  q.emplace(8);
+
+  EXPECT_EQ(2, NonTrivialTypeTestData::num_objects);
+  EXPECT_EQ(2 + 3, NonTrivialTypeTestData::total_constructed);
+  EXPECT_EQ(2, NonTrivialTypeTestData::default_constructed);
+  EXPECT_EQ(3, NonTrivialTypeTestData::total_destructed);
+  EXPECT_EQ(2u, q.size());
+
+  q.pop();
+  q.pop();
+
+  EXPECT_EQ(2, NonTrivialTypeTestData::num_objects);
+  EXPECT_EQ(2 + 3 + 2, NonTrivialTypeTestData::total_constructed);
+  EXPECT_EQ(2 + 2, NonTrivialTypeTestData::default_constructed);
+  EXPECT_EQ(3 + 2, NonTrivialTypeTestData::total_destructed);
+  EXPECT_EQ(0u, q.size());
+}


### PR DESCRIPTION
This PR largely overhauls LogWidget to drastically decrease its memory usage and negative impact on UI responsiveness.

In the worst case, spammy enough logs will cause LogWidget to lock up an entire Qt UI (as reported by @JMC47 and confirmed by my tests)). Additionally, both the widget itself and its log buffering functionality (designed so it never updates more than 200 lines in one go) were unbounded and could grow infinitely, taking GB's of RAM and maybe even causing Qt to run out of memory (I think that's why UI locked up eventually).

My changes include:
- **Most importantly**, removal of `QTextEdit` in favour of `QPlainTextEdit`. The former is a full WYSIWYG editor with support for images, tables and rich text features we **absolutely** don't need in a log viewer! `QPlainTextEdit` is closer in functionality to Notepad with syntax highlighting (whereas `QTextEdit` could be compared to WordPad), and Qt documentation recommends using it for log viewers.
- Removal of a synchronization mutex, because all calls to the buffer queue are done from the same thread.
- Reconstruction of `LogWidget::Log` to make as little memory allocations and string copies as reasonably possible.
- Removal of unused widgets (one of which was actually leaking) and class fields from `LogWidget`.
- Addition of `MAXIMUM_BLOCK_COUNT` constant, currently set to 5000. Both log viewer widget and the log queue are now limited to only store this many most recent messages. Not only this drastically improves performance, but also prevents memory usage from exploding with spammy enough logs. If there is a need to preview more than 5000 recent log lines, please log to file or to a console.
- Addition of additional constraints to widget updates. Now logs get appended to a Qt object only if widget is visible. This further improves UI responsiveness, making it completely fluid even with the most spammy logs, with hitches occuring **only** if Log tab is visible.