### PR TITLE
Enable EFB access in INI

### DIFF
--- a/Data/Sys/GameSettings/GKB.ini
+++ b/Data/Sys/GameSettings/GKB.ini
@@ -15,8 +15,5 @@ CPUThread = 0
 
 [Video_Hacks]
 ImmediateXFBEnable = False
-EFBAccessEnable = False
 EFBToTextureEnable = False
 DeferEFBCopies = False
-
-[Video_Settings]

--- a/Data/Sys/GameSettings/RMH.ini
+++ b/Data/Sys/GameSettings/RMH.ini
@@ -12,9 +12,5 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-
 [Video_Hacks]
-EFBAccessEnable = False
-EFBToTextureEnable = False
 ImmediateXFBEnable = False


### PR DESCRIPTION
Because of the EFB access optimization, games which were forced to skip EFB access in order to be playable don't need to be forced anymore. 
There are also reports of skip EFB access causing issues in Baten Kaitos: https://forums.dolphin-emu.org/Thread-gc-baten-kaitos-eternal-wings-and-the-lost-ocean?pid=493827#pid493827

Monster Hunter also doesn't need EFB to texture and ram. 