### PR TITLE
SI: Reduce logging.

### DIFF
--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -312,7 +312,7 @@ static void RunSIBuffer(u64 user_data, s64 cycles_late)
       {
         ss << std::hex << std::setw(2) << std::setfill('0') << (int)b << ' ';
       }
-      ERROR_LOG(
+      DEBUG_LOG(
           SERIALINTERFACE,
           "RunSIBuffer: expected_response_length(%u) != actual_response_length(%u): request: %s",
           expected_response_length, actual_response_length, ss.str().c_str());


### PR DESCRIPTION
An earlier SI PR added logging for SI devices that return the incorrect number of bytes for certain commands. It turns out pretty much every SI device in dolphin returns the wrong number of bytes (#8239 mostly fixes this). For the time being, it results in loads of non-actionable log spam for users that should probably be suppressed. 