### PR TITLE
DolphinQt: Don't overwrite >8x IR scale in ini, add maximum internal res option

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -61,6 +61,7 @@ const ConfigInfo<bool> GFX_FAST_DEPTH_CALC{{System::GFX, "Settings", "FastDepthC
 const ConfigInfo<u32> GFX_MSAA{{System::GFX, "Settings", "MSAA"}, 1};
 const ConfigInfo<bool> GFX_SSAA{{System::GFX, "Settings", "SSAA"}, false};
 const ConfigInfo<int> GFX_EFB_SCALE{{System::GFX, "Settings", "InternalResolution"}, 1};
+const ConfigInfo<int> GFX_MAX_EFB_SCALE{{System::GFX, "Settings", "MaxInternalResolution"}, 8};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_ENABLE{{System::GFX, "Settings", "TexFmtOverlayEnable"},
                                                  false};
 const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER{{System::GFX, "Settings", "TexFmtOverlayCenter"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -54,6 +54,7 @@ extern const ConfigInfo<bool> GFX_FAST_DEPTH_CALC;
 extern const ConfigInfo<u32> GFX_MSAA;
 extern const ConfigInfo<bool> GFX_SSAA;
 extern const ConfigInfo<int> GFX_EFB_SCALE;
+extern const ConfigInfo<int> GFX_MAX_EFB_SCALE;
 extern const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_ENABLE;
 extern const ConfigInfo<bool> GFX_TEXFMT_OVERLAY_CENTER;
 extern const ConfigInfo<bool> GFX_ENABLE_WIREFRAME;


### PR DESCRIPTION
This adds an ini-only setting under GFX.ini -> [Settings] -> MaxInternalResolution. Setting this will allow the user to select resolutions beyond the default 8x max scale in graphics options.

Also fixes the bug if a user had a >8xIR set, opening the graphics window would overwrite the value, and save it to the ini.

Requested by @MayImilae.