### PR TITLE
ConsoleListenerWin: Properly output console logging in UTF-16

### DIFF
--- a/Source/Core/Common/Logging/ConsoleListenerWin.cpp
+++ b/Source/Core/Common/Logging/ConsoleListenerWin.cpp
@@ -5,6 +5,7 @@
 #include <windows.h>
 
 #include "Common/Logging/ConsoleListener.h"
+#include "Common/StringUtil.h"
 
 ConsoleListener::ConsoleListener()
 {
@@ -16,5 +17,5 @@ ConsoleListener::~ConsoleListener()
 
 void ConsoleListener::Log(LogTypes::LOG_LEVELS level, const char* text)
 {
-  ::OutputDebugStringA(text);
+  ::OutputDebugStringW(UTF8ToUTF16(text).c_str());
 }


### PR DESCRIPTION
Minor fix, Windows builds used `OutputDebugStringA` for Console Logger which doesn't handle UTF-8 correctly (A functions assume a local (ACP) codepage). This change explicitly converts an input UTF-8 string to UTF-16 beforehand and passes it to `OutputDebugStringW' instead.

This will impact any logging with UTF-8 in it - the most possible scenario is user paths.

Before:
![image](https://user-images.githubusercontent.com/7947461/64054802-0668cb80-cb89-11e9-81be-264c9bf51b02.png)

After:
![image](https://user-images.githubusercontent.com/7947461/64054779-e33e1c00-cb88-11e9-9081-5a16853d7bc5.png)
