### PR TITLE
DolphinQt: GeckoCodeWidget remove double space

### DIFF
--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -165,9 +165,11 @@ void GeckoCodeWidget::OnSelectionChanged()
   m_code_view->clear();
 
   for (const auto& c : code.codes)
-    m_code_view->append(QStringLiteral("%1  %2")
+  {
+    m_code_view->append(QStringLiteral("%1 %2")
                             .arg(c.address, 8, 16, QLatin1Char('0'))
                             .arg(c.data, 8, 16, QLatin1Char('0')));
+  }
 }
 
 void GeckoCodeWidget::OnItemChanged(QListWidgetItem* item)


### PR DESCRIPTION
One line change.
Removes the double space in the read-only GeckoCodeWidget view.
```
Before:
XXXXXXXX  XXXXXXXX

After:
XXXXXXXX XXXXXXXX
```

The before is annoying for those trying to share GeckoCodes.