### PR TITLE
Align frame advance and movies to full field boundaries

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -839,9 +839,12 @@ void Callback_VideoCopiedToXFB(bool video_update)
 {
   if (video_update)
     s_drawn_frame++;
+}
 
+// Called at field boundaries in `VideoInterface::Update()`
+void FrameUpdate()
+{
   Movie::FrameUpdate();
-
   if (s_frame_step)
   {
     s_frame_step = false;

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -26,6 +26,7 @@ bool GetIsThrottlerTempDisabled();
 void SetIsThrottlerTempDisabled(bool disable);
 
 void Callback_VideoCopiedToXFB(bool video_update);
+void FrameUpdate();
 
 enum class State
 {

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -733,6 +733,12 @@ static void EndField()
 // Run when: When a frame is scanned (progressive/interlace)
 void Update(u64 ticks)
 {
+  // If this half-line is at a field boundary, potentially deal with frame-stepping
+  // and/or update movie state before dealing with anything else
+
+  if (s_half_line_count == 0 || s_half_line_count == GetHalfLinesPerEvenField())
+    Core::FrameUpdate();
+
   // If an SI poll is scheduled to happen on this half-line, do it!
 
   if (s_half_line_of_next_si_poll == s_half_line_count)


### PR DESCRIPTION
Currently, frame-stepping and `Movie::FrameUpdate()` are dealt with at the beginning of each "active video field" (see `Core::Callback_VideoCopiedToXFB()`). 

This is [conceptually] inconsistent with accurate SI polling emulation (#8236 and other WIP branches) because SI polls may occur in the space between active video fields. Here's some log output from a game that does SI polling four times in one field:

```
// Current behavior
Core/HW/VideoInterface.cpp:809 I[SI]: new video interrupt, half_line=0000
Core/HW/VideoInterface.cpp:741 I[SI]: new field, half_line=0000 (start of full field)
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=000f
VideoCommon/VideoBackendBase.cpp:73 I[SI]: Video_BeginField (start of active field)
!!!!!! Core/Core.cpp:843 I[SI]: <Movie::FrameUpdate() happens here>
VideoCommon/RenderBase.cpp:1336 I[SI]: Renderer::Swap() ended
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=00ab
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=0147
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=01e3

// New behavior
Core/HW/VideoInterface.cpp:809 I[SI]: new video interrupt, half_line=0000
Core/HW/VideoInterface.cpp:741 I[SI]: new field, half_line=0000 (start of full field)
!!!!!! Core/Movie.cpp:208 I[SI]: <new Movie::FrameUpdate() happens here>
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=000f
VideoCommon/VideoBackendBase.cpp:73 I[SI]: Video_BeginField called (start of active field)
Core/Core.cpp:843 I[SI]: Callback_VideoCopiedToXFB
VideoCommon/RenderBase.cpp:1336 I[SI]: Renderer::Swap() ended
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=00ab
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=0147
Core/HW/VideoInterface.cpp:749 I[SI]: new poll, half_line=01e3
```

This ensures that "a movie frame" (and the check for frame-stepping) starts at the same time as a "full field." 
