### PR TITLE
Android: Add GameID to Game Settings title

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameSettingsDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameSettingsDialog.java
@@ -40,7 +40,7 @@ public class GameSettingsDialog extends DialogFragment
     String gameId = getArguments().getString(ARG_GAMEID);
     int platform = getArguments().getInt(ARG_PLATFORM);
 
-    builder.setTitle(getActivity().getString(R.string.preferences_game_settings))
+    builder.setTitle(getActivity().getString(R.string.preferences_game_settings) + ": " + gameId)
             .setItems(platform == Platform.GAMECUBE.toInt() ?
                     R.array.gameSettingsMenusGC :
                     R.array.gameSettingsMenusWii, (dialog, which) ->


### PR DESCRIPTION
This helps users make sure they selected the correct game (and not accidentally clear game settings for the wrong game). This also matches the syntax of other titles within Game Settings.

![Screenshot_20190906-234250_Dolphin Emulator](https://user-images.githubusercontent.com/17330088/64470518-6fa88b80-d101-11e9-9b07-6fd011bb539f.jpg)
