### PR TITLE
.editorconfig: Use spaces for Java code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 indent_size = 2
 trim_trailing_whitespace = true
 
-[*.{c,cpp,h}]
+[*.{c,cpp,h,java}]
 indent_style = space
 insert_final_newline = true
 max_line_length = 100
@@ -19,10 +19,6 @@ insert_final_newline = true
 indent_size = 4
 indent_style = space
 insert_final_newline = false
-
-[*.java]
-indent_style = tab
-insert_final_newline = true
 
 [*.xml]
 indent_size = 4


### PR DESCRIPTION
We switched from tabs to spaces for Java code a year ago (PR #7364).