### PR TITLE
QtFifoPlayer: handle FIFO load before window creation

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<CPUCoreBase> FifoPlayer::GetCPUCore()
 
 void FifoPlayer::SetFileLoadedCallback(CallbackFunc callback)
 {
-  m_FileLoadedCb = callback;
+  m_FileLoadedCb = std::move(callback);
 
   // Trigger the callback immediatly if the file is already loaded.
   if (GetFile() != nullptr)

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -168,6 +168,17 @@ std::unique_ptr<CPUCoreBase> FifoPlayer::GetCPUCore()
   return std::make_unique<CPUCore>(this);
 }
 
+void FifoPlayer::SetFileLoadedCallback(CallbackFunc callback)
+{
+  m_FileLoadedCb = callback;
+
+  // Trigger the callback immediatly if the file is already loaded.
+  if (GetFile() != nullptr)
+  {
+    m_FileLoadedCb();
+  }
+}
+
 bool FifoPlayer::IsRunningWithFakeVideoInterfaceUpdates() const
 {
   if (!m_File || m_File->GetFrameCount() == 0)

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -93,7 +93,7 @@ public:
   // Default is disabled
   void SetEarlyMemoryUpdates(bool enabled) { m_EarlyMemoryUpdates = enabled; }
   // Callbacks
-  void SetFileLoadedCallback(CallbackFunc callback) { m_FileLoadedCb = callback; }
+  void SetFileLoadedCallback(CallbackFunc callback);
   void SetFrameWrittenCallback(CallbackFunc callback) { m_FrameWrittenCb = callback; }
   static FifoPlayer& GetInstance();
 

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -94,7 +94,7 @@ public:
   void SetEarlyMemoryUpdates(bool enabled) { m_EarlyMemoryUpdates = enabled; }
   // Callbacks
   void SetFileLoadedCallback(CallbackFunc callback);
-  void SetFrameWrittenCallback(CallbackFunc callback) { m_FrameWrittenCb = callback; }
+  void SetFrameWrittenCallback(CallbackFunc callback) { m_FrameWrittenCb = std::move(callback); }
   static FifoPlayer& GetInstance();
 
   bool IsRunningWithFakeVideoInterfaceUpdates() const;


### PR DESCRIPTION
Fixes a bug where if you loaded a fifo before opening the fifo
player window (which you can do by dragging a .dff onto dolphin's
main window) then the player's widgets wouldn't be initilized
correctly.

Importantly, the object range widgets would be broken.