### PR TITLE
WIP - ControllerInterface. Combine evdev devices with the same "uniq" name.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -104,18 +104,23 @@ public:
   void UpdateInput() override;
   bool IsValid() const override;
 
-  evdevDevice(const std::string& devnode);
+  evdevDevice();
   ~evdevDevice();
+
+  // Return true if node was "interesting".
+  bool AddNode(int fd, libevdev* dev);
+
+  const char* GetUniqueID() const;
 
   std::string GetName() const override { return m_name; }
   std::string GetSource() const override { return "evdev"; }
-  bool IsInteresting() const { return m_interesting; }
 
 private:
-  const std::string m_devfile;
-  int m_fd;
-  libevdev* m_dev;
+  std::vector<int> m_fds;
+  std::vector<libevdev*> m_devices;
   std::string m_name;
-  bool m_interesting = false;
+
+  u32 m_button_count = 0;
+  u32 m_axis_count = 0;
 };
 }  // namespace ciface::evdev


### PR DESCRIPTION
Unfortunately newer Linux drivers for DS4 (Playstation 4) controllers split the device into three separate event nodes.

On my system I get:
"Sony Interactive Entertainment Wireless Controller"
"Sony Interactive Entertainment Wireless Controller Touchpad"
"Sony Interactive Entertainment Wireless Controller Motion Sensors"

Apparently this is due to some evdev policy: "A device must not mix regular directional axes and accelerometer axes on the same event node."

Our input system does allow use of multiple devices via "All Devices" or so-called "absolute path" control expressions, but this is less than desirable especially when making use of multiple DS4s.

This PR combines evdev devices that return the same non-null unique ID (via `libevdev_get_uniq`).

Mapping of raw acceleration/gyroscope inputs in PR #8352 is less horrible this way.

I'm not entirely happy with this implementation. It gets pretty ugly, especially the parts that keep the button/axis names in the same deterministic order, but there doesn't seem to be a clean way to do it as evdev enumerates devices in a seemingly random order.