### PR TITLE
Always run as X11 app even under Wayland

### DIFF
--- a/Data/dolphin-emu.desktop
+++ b/Data/dolphin-emu.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Icon=dolphin-emu
-Exec=dolphin-emu
+Exec=env QT_QPA_PLATFORM=xcb dolphin-emu
 Terminal=false
 Type=Application
 Categories=Game;Emulator;


### PR DESCRIPTION
Dolphin doesn't have a working Wayland renderer (not even with `env SDL_VIDEODRIVER=wayland dolphin-emu`). By setting the `QT_QPA_PLATFORM` variable to "xcb" we ensure that Dolphin runs just fine in any Wayland-based desktop environment instead of displaying an error message.