### PR TITLE
Add option to report empty GC disc drive as closed (issue 11840)

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -29,6 +29,8 @@ const Info<bool> MAIN_DSP_HLE{{System::Main, "Core", "DSPHLE"}, true};
 const Info<int> MAIN_TIMING_VARIANCE{{System::Main, "Core", "TimingVariance"}, 40};
 const Info<bool> MAIN_CPU_THREAD{{System::Main, "Core", "CPUThread"}, true};
 const Info<bool> MAIN_SYNC_ON_SKIP_IDLE{{System::Main, "Core", "SyncOnSkipIdle"}, true};
+const Info<bool> MAIN_GC_EMPTY_DRIVE_IS_CLOSED{{System::Main, "Core", "GCEmptyDriveIsClosed"},
+                                               false};
 const Info<std::string> MAIN_DEFAULT_ISO{{System::Main, "Core", "DefaultISO"}, ""};
 const Info<bool> MAIN_ENABLE_CHEATS{{System::Main, "Core", "EnableCheats"}, false};
 const Info<int> MAIN_GC_LANGUAGE{{System::Main, "Core", "SelectedLanguage"}, 0};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -33,6 +33,7 @@ extern const Info<bool> MAIN_DSP_HLE;
 extern const Info<int> MAIN_TIMING_VARIANCE;
 extern const Info<bool> MAIN_CPU_THREAD;
 extern const Info<bool> MAIN_SYNC_ON_SKIP_IDLE;
+extern const Info<bool> MAIN_GC_EMPTY_DRIVE_IS_CLOSED;
 extern const Info<std::string> MAIN_DEFAULT_ISO;
 extern const Info<bool> MAIN_ENABLE_CHEATS;
 extern const Info<int> MAIN_GC_LANGUAGE;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -34,9 +34,10 @@ bool IsSettingSaveable(const Config::Location& config_location)
     }
   }
 
-  static constexpr std::array<const Config::Location*, 17> s_setting_saveable = {
+  static constexpr std::array<const Config::Location*, 18> s_setting_saveable = {
       // Main.Core
 
+      &Config::MAIN_GC_EMPTY_DRIVE_IS_CLOSED.GetLocation(),
       &Config::MAIN_DEFAULT_ISO.GetLocation(),
       &Config::MAIN_MEMCARD_A_PATH.GetLocation(),
       &Config::MAIN_MEMCARD_B_PATH.GetLocation(),

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -50,6 +50,9 @@ void GameCubePane::CreateWidgets()
 {
   QVBoxLayout* layout = new QVBoxLayout(this);
 
+  m_empty_drive_is_closed = new QCheckBox(
+      tr("Report disc drive as closed when empty (shows GameCube logo sequence)"), this);
+
   // IPL Settings
   QGroupBox* ipl_box = new QGroupBox(tr("IPL Settings"), this);
   QGridLayout* ipl_layout = new QGridLayout(ipl_box);
@@ -126,6 +129,7 @@ void GameCubePane::CreateWidgets()
 
   layout->addWidget(ipl_box);
   layout->addWidget(device_box);
+  layout->addWidget(m_empty_drive_is_closed);
 
   layout->addStretch();
 
@@ -134,6 +138,8 @@ void GameCubePane::CreateWidgets()
 
 void GameCubePane::ConnectWidgets()
 {
+  connect(m_empty_drive_is_closed, &QCheckBox::stateChanged, this, &GameCubePane::SaveSettings);
+
   // IPL Settings
   connect(m_skip_main_menu, &QCheckBox::stateChanged, this, &GameCubePane::SaveSettings);
   connect(m_language_combo, qOverload<int>(&QComboBox::currentIndexChanged), this,
@@ -317,6 +323,8 @@ void GameCubePane::LoadSettings()
 {
   const SConfig& params = SConfig::GetInstance();
 
+  m_empty_drive_is_closed->setChecked(Config::Get(Config::MAIN_GC_EMPTY_DRIVE_IS_CLOSED));
+
   // IPL Settings
   m_skip_main_menu->setChecked(params.bHLE_BS2);
   m_language_combo->setCurrentIndex(m_language_combo->findData(params.SelectedLanguage));
@@ -354,6 +362,9 @@ void GameCubePane::SaveSettings()
   Config::ConfigChangeCallbackGuard config_guard;
 
   SConfig& params = SConfig::GetInstance();
+
+  Config::SetBaseOrCurrent(Config::MAIN_GC_EMPTY_DRIVE_IS_CLOSED,
+                           m_empty_drive_is_closed->isChecked());
 
   // IPL Settings
   params.bHLE_BS2 = m_skip_main_menu->isChecked();

--- a/Source/Core/DolphinQt/Settings/GameCubePane.h
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.h
@@ -26,6 +26,7 @@ private:
   void UpdateButton(int slot);
   void OnConfigPressed(int slot);
 
+  QCheckBox* m_empty_drive_is_closed;
   QCheckBox* m_skip_main_menu;
   QComboBox* m_language_combo;
 


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/11840

This gives important doot-doot-doot music and bouncy cube.

Only problem: when an empty disc drive is reported as closed, the IPL encounters a read error:

> The disc could not be read.
>
> Please read the NINTENDO GAMECUBE  
> Instruction Booklet for more information.

This means the menu does not load afterwards.

I don't know why that happens. I wasn't able to fix it. So setting is off by default.