### PR TITLE
Resource packs: support dynamic input tex

### DIFF
--- a/Source/Core/DolphinQt/ResourcePackManager.h
+++ b/Source/Core/DolphinQt/ResourcePackManager.h
@@ -6,6 +6,8 @@
 
 #include <QDialog>
 
+#include "Common/CommonTypes.h"
+
 class QPushButton;
 class QTableWidget;
 class QTableWidgetItem;
@@ -27,6 +29,7 @@ private:
   void PriorityUp();
   void PriorityDown();
   void Refresh();
+  void OnPacksChanged(u32 types);
 
   void SelectionChanged();
   void ItemDoubleClicked(QTableWidgetItem* item);

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -226,7 +226,8 @@ bool ResourcePack::Install(const std::string& path)
       return false;
     }
 
-    std::ofstream out(output_path, std::ios::trunc | std::ios::binary);
+    std::ofstream out;
+    File::OpenFStream(out, output_path, std::ios::trunc | std::ios::binary);
 
     if (!out.good())
     {

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.h
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -17,6 +18,20 @@ namespace ResourcePack
 class ResourcePack
 {
 public:
+  enum class ResourceType : u32
+  {
+    TEXTURE = 0x01,
+    DYNAMIC_INPUT = 0x02
+  };
+  struct ResourceFile
+  {
+    std::string input_path;
+    std::string output_path;
+    ResourceType type;
+
+    bool operator<(const ResourcePack::ResourceFile& file) const;
+  };
+
   explicit ResourcePack(const std::string& path);
 
   bool IsValid() const;
@@ -25,7 +40,8 @@ public:
   const std::string& GetPath() const;
   const std::string& GetError() const;
   const Manifest* GetManifest() const;
-  const std::vector<std::string>& GetTextures() const;
+  const std::set<ResourceFile>& GetFiles() const;
+  u32 GetResourceTypesSupported() const;
 
   bool Install(const std::string& path);
   bool Uninstall(const std::string& path);
@@ -40,7 +56,9 @@ private:
   std::string m_error;
 
   std::shared_ptr<Manifest> m_manifest;
-  std::vector<std::string> m_textures;
+  std::set<ResourceFile> m_files;
+  u32 m_types_provided = 0;
   std::vector<char> m_logo_data;
 };
+
 }  // namespace ResourcePack

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -68,6 +68,7 @@ static void CreateLoadPath(const std::string& path)
   if (!path.empty())
     File::SetUserPath(D_LOAD_IDX, path + '/');
   File::CreateFullPath(File::GetUserPath(D_HIRESTEXTURES_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DYNAMICINPUT_IDX));
 }
 
 static void CreateResourcePackPath(const std::string& path)

--- a/docs/ResourcePacks.md
+++ b/docs/ResourcePacks.md
@@ -12,7 +12,11 @@ resource-pack.zip
 \__ textures (Directory)
     \__ GAMEID (Directory)
         \___ TEXTURES GO HERE
+\__ dynamic_input (Directory)
+    \__ GAMEID (Directory)
+        \___ JSON and PNG GO HERE
 ```
+> **_NOTE:_**  You can specify textures, dynamic_input ([Dynamic Input Textures](DynamicInputTextures.md)), or both in a pack
 
 **If you intend to use v1:** Your zip file may not be compressed or else **your pack will not load** (You can create uncompressed zips with software like 7-Zip).  
 (This is to ensure that loading textures *directly* from resource packs remains a viable option in the future)  


### PR DESCRIPTION
This builds on #8318 by adding support for Resource Packs.  It makes Resource Packs more generic so they deal with a file that is a particular "ResourceType" (currently just texture or dynamic input).

It also does two other things:

* In master, if you moved priority up/down of a pack.  It would uninstall the pack first but never reinstall it.  This seemed like an oversight and has been fixed
* A pack can be installed or uninstalled (or priority changed) when the game is running.  Texture only packs reload the textures and the cache is invalidated.  For dynamic texture packs, the textures are regenerated (and textures are reloaded / cache is invalidated).