### PR TITLE
Update game settings for all PWAA games

### DIFF
--- a/Data/Sys/GameSettings/W2G.ini
+++ b/Data/Sys/GameSettings/W2G.ini
@@ -5,4 +5,4 @@
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/W3G.ini
+++ b/Data/Sys/GameSettings/W3G.ini
@@ -5,4 +5,4 @@
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/WGS.ini
+++ b/Data/Sys/GameSettings/WGS.ini
@@ -8,4 +8,4 @@
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
This pull request is for all 3 PWAA game's ini to fix visual issues with the games. This simply changes SafeTextureCacheColorSamples from 512 to 0 (Safe) to ensure the following:

- Resolve visual issues with evidence previews
- Proper scene transitions when unlocking a new case
- (1st game DLC only) Resolve display issues when testing areas with luminol. Previously, blood would not turn blue when sprayed with luminol until after you inspected it, and pressing - to switch between sides of the room would result in luminol results being overlayed on the wrong side of the room