### PR TITLE
HLE: Fix patching functions with the same name

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -192,11 +192,13 @@ u32 GetFunctionIndex(u32 address)
 
 u32 GetFirstFunctionIndex(u32 address)
 {
-  u32 index = GetFunctionIndex(address);
-  auto first = std::find_if(
-      s_original_instructions.begin(), s_original_instructions.end(),
-      [=](const auto& entry) { return entry.second == index && entry.first < address; });
-  return first == std::end(s_original_instructions) ? index : 0;
+  const u32 index = GetFunctionIndex(address);
+  // Fixed hooks use a fixed address and don't patch the whole function
+  if (index == 0 || OSPatches[index].flags == HookFlag::Fixed)
+    return index;
+
+  const auto symbol = g_symbolDB.GetSymbolFromAddr(address);
+  return (symbol && symbol->address == address) ? index : 0;
 }
 
 HookType GetFunctionTypeByIndex(u32 index)


### PR DESCRIPTION
This PR address the following issue: https://bugs.dolphin-emu.org/issues/11811

When multiple functions with the same name were patched, only the first one (earliest memory address) was properly patched.

Here is an example: [unittest_hle_printf.zip](https://github.com/dolphin-emu/dolphin/files/3665521/unittest_hle_printf.zip)

The expected behaviour with this PR is to print twice each message after loading the symbol map. One from the `my_puts_*` functions renamed as `printf` and the original `printf` function itself. The "Boot to Pause" option might be used to clear the ELF symbol and loading the symbol map before running the executable.

Ready to be reviewed & merged.