### PR TITLE
Vulkan: Exclusive fullscreen support via VK_EXT_full_screen_exclusive

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -371,13 +371,16 @@ void CommandBufferManager::SubmitCommandBuffer(u32 command_buffer_index,
                                      &present_image_index,
                                      nullptr};
 
-    res = vkQueuePresentKHR(g_vulkan_context->GetPresentQueue(), &present_info);
-    if (res != VK_SUCCESS)
+    m_last_present_result = vkQueuePresentKHR(g_vulkan_context->GetPresentQueue(), &present_info);
+    if (m_last_present_result != VK_SUCCESS)
     {
       // VK_ERROR_OUT_OF_DATE_KHR is not fatal, just means we need to recreate our swap chain.
-      if (res != VK_ERROR_OUT_OF_DATE_KHR && res != VK_SUBOPTIMAL_KHR)
-        LOG_VULKAN_ERROR(res, "vkQueuePresentKHR failed: ");
-      m_present_failed_flag.Set();
+      if (m_last_present_result != VK_ERROR_OUT_OF_DATE_KHR && res != VK_SUBOPTIMAL_KHR &&
+          m_last_present_result != VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
+      {
+        LOG_VULKAN_ERROR(m_last_present_result, "vkQueuePresentKHR failed: ");
+      }
+      m_last_present_failed.Set();
     }
   }
 

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.h
@@ -79,7 +79,8 @@ public:
                            uint32_t present_image_index = 0xFFFFFFFF);
 
   // Was the last present submitted to the queue a failure? If so, we must recreate our swapchain.
-  bool CheckLastPresentFail() { return m_present_failed_flag.TestAndClear(); }
+  bool CheckLastPresentFail() { return m_last_present_failed.TestAndClear(); }
+  VkResult GetLastPresentResult() const { return m_last_present_result; }
 
   // Schedule a vulkan resource for destruction later on. This will occur when the command buffer
   // is next re-used, and the GPU has finished working with the specified resource.
@@ -136,7 +137,8 @@ private:
   VkSemaphore m_present_semaphore = VK_NULL_HANDLE;
   std::deque<PendingCommandBufferSubmit> m_pending_submits;
   std::mutex m_pending_submit_lock;
-  Common::Flag m_present_failed_flag;
+  Common::Flag m_last_present_failed;
+  VkResult m_last_present_result = VK_SUCCESS;
   bool m_use_threaded_submission = false;
 };
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -83,6 +83,8 @@ public:
                              u32 groups_z) override;
   void BindBackbuffer(const ClearColor& clear_color = {}) override;
   void PresentBackbuffer() override;
+  void SetFullscreen(bool enable_fullscreen) override;
+  bool IsFullscreen() const override;
 
   // Completes the current render pass, executes the command buffer, and restores state ready for
   // next render. Use when you want to kick the current buffer to make room for new data.

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.h
@@ -62,6 +62,17 @@ public:
   // Change vsync enabled state. This may fail as it causes a swapchain recreation.
   bool SetVSync(bool enabled);
 
+  // Is exclusive fullscreen supported?
+  bool IsFullscreenSupported() const { return m_fullscreen_supported; }
+
+  // Retrieves the "next" fullscreen state. Safe to call off-thread.
+  bool GetCurrentFullscreenState() const { return m_current_fullscreen_state; }
+  bool GetNextFullscreenState() const { return m_next_fullscreen_state; }
+  void SetNextFullscreenState(bool state) { m_next_fullscreen_state = state; }
+
+  // Updates the fullscreen state. Must call on-thread.
+  bool SetFullscreenState(bool state);
+
 private:
   bool SelectSurfaceFormat();
   bool SelectPresentMode();
@@ -86,7 +97,10 @@ private:
   VkSurfaceFormatKHR m_surface_format = {};
   VkPresentModeKHR m_present_mode = VK_PRESENT_MODE_RANGE_SIZE_KHR;
   AbstractTextureFormat m_texture_format = AbstractTextureFormat::Undefined;
-  bool m_vsync_enabled;
+  bool m_vsync_enabled = false;
+  bool m_fullscreen_supported = false;
+  bool m_current_fullscreen_state = false;
+  bool m_next_fullscreen_state = false;
 
   VkSwapchainKHR m_swap_chain = VK_NULL_HANDLE;
   std::vector<SwapChainImage> m_swap_chain_images;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -222,6 +222,8 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
   if (enable_debug_report && !AddExtension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, false))
     WARN_LOG(VIDEO, "Vulkan: Debug report requested, but extension is not available.");
 
+  AddExtension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, false);
+
   return true;
 }
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -88,7 +88,7 @@ bool VulkanContext::CheckValidationLayerAvailablility()
 VkInstance VulkanContext::CreateVulkanInstance(WindowSystemType wstype, bool enable_debug_report,
                                                bool enable_validation_layer)
 {
-  ExtensionList enabled_extensions;
+  std::vector<const char*> enabled_extensions;
   if (!SelectInstanceExtensions(&enabled_extensions, wstype, enable_debug_report))
     return VK_NULL_HANDLE;
 
@@ -143,8 +143,8 @@ VkInstance VulkanContext::CreateVulkanInstance(WindowSystemType wstype, bool ena
   return instance;
 }
 
-bool VulkanContext::SelectInstanceExtensions(ExtensionList* extension_list, WindowSystemType wstype,
-                                             bool enable_debug_report)
+bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension_list,
+                                             WindowSystemType wstype, bool enable_debug_report)
 {
   u32 extension_count = 0;
   VkResult res = vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
@@ -168,7 +168,7 @@ bool VulkanContext::SelectInstanceExtensions(ExtensionList* extension_list, Wind
   for (const auto& extension_properties : available_extension_list)
     INFO_LOG(VIDEO, "Available extension: %s", extension_properties.extensionName);
 
-  auto SupportsExtension = [&](const char* name, bool required) {
+  auto AddExtension = [&](const char* name, bool required) {
     if (std::find_if(available_extension_list.begin(), available_extension_list.end(),
                      [&](const VkExtensionProperties& properties) {
                        return !strcmp(name, properties.extensionName);
@@ -186,43 +186,40 @@ bool VulkanContext::SelectInstanceExtensions(ExtensionList* extension_list, Wind
   };
 
   // Common extensions
-  if (wstype != WindowSystemType::Headless &&
-      !SupportsExtension(VK_KHR_SURFACE_EXTENSION_NAME, true))
+  if (wstype != WindowSystemType::Headless && !AddExtension(VK_KHR_SURFACE_EXTENSION_NAME, true))
   {
     return false;
   }
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
   if (wstype == WindowSystemType::Windows &&
-      !SupportsExtension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME, true))
+      !AddExtension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME, true))
   {
     return false;
   }
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-  if (wstype == WindowSystemType::X11 &&
-      !SupportsExtension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME, true))
+  if (wstype == WindowSystemType::X11 && !AddExtension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME, true))
   {
     return false;
   }
 #endif
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
   if (wstype == WindowSystemType::Android &&
-      !SupportsExtension(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, true))
+      !AddExtension(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, true))
   {
     return false;
   }
 #endif
 #if defined(VK_USE_PLATFORM_MACOS_MVK)
-  if (wstype == WindowSystemType::MacOS &&
-      !SupportsExtension(VK_MVK_MACOS_SURFACE_EXTENSION_NAME, true))
+  if (wstype == WindowSystemType::MacOS && !AddExtension(VK_MVK_MACOS_SURFACE_EXTENSION_NAME, true))
   {
     return false;
   }
 #endif
 
   // VK_EXT_debug_report
-  if (enable_debug_report && !SupportsExtension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, false))
+  if (enable_debug_report && !AddExtension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, false))
     WARN_LOG(VIDEO, "Vulkan: Debug report requested, but extension is not available.");
 
   return true;
@@ -424,7 +421,7 @@ std::unique_ptr<VulkanContext> VulkanContext::Create(VkInstance instance, VkPhys
   return context;
 }
 
-bool VulkanContext::SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface)
+bool VulkanContext::SelectDeviceExtensions(bool enable_surface)
 {
   u32 extension_count = 0;
   VkResult res =
@@ -449,14 +446,14 @@ bool VulkanContext::SelectDeviceExtensions(ExtensionList* extension_list, bool e
   for (const auto& extension_properties : available_extension_list)
     INFO_LOG(VIDEO, "Available extension: %s", extension_properties.extensionName);
 
-  auto SupportsExtension = [&](const char* name, bool required) {
+  auto AddExtension = [&](const char* name, bool required) {
     if (std::find_if(available_extension_list.begin(), available_extension_list.end(),
                      [&](const VkExtensionProperties& properties) {
                        return !strcmp(name, properties.extensionName);
                      }) != available_extension_list.end())
     {
       INFO_LOG(VIDEO, "Enabling extension: %s", name);
-      extension_list->push_back(name);
+      m_device_extensions.push_back(name);
       return true;
     }
 
@@ -466,7 +463,7 @@ bool VulkanContext::SelectDeviceExtensions(ExtensionList* extension_list, bool e
     return false;
   };
 
-  if (enable_surface && !SupportsExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME, true))
+  if (enable_surface && !AddExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME, true))
     return false;
 
   return true;
@@ -606,14 +603,18 @@ bool VulkanContext::CreateDevice(VkSurfaceKHR surface, bool enable_validation_la
   }
   device_info.pQueueCreateInfos = queue_infos.data();
 
-  ExtensionList enabled_extensions;
-  if (!SelectDeviceExtensions(&enabled_extensions, surface != VK_NULL_HANDLE))
+  if (!SelectDeviceExtensions(surface != VK_NULL_HANDLE))
     return false;
+
+  // convert std::string list to a char pointer list which we can feed in
+  std::vector<const char*> extension_name_pointers;
+  for (const std::string& name : m_device_extensions)
+    extension_name_pointers.push_back(name.c_str());
 
   device_info.enabledLayerCount = 0;
   device_info.ppEnabledLayerNames = nullptr;
-  device_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
-  device_info.ppEnabledExtensionNames = enabled_extensions.data();
+  device_info.enabledExtensionCount = static_cast<uint32_t>(extension_name_pointers.size());
+  device_info.ppEnabledExtensionNames = extension_name_pointers.data();
 
   // Check for required features before creating.
   if (!SelectDeviceFeatures())
@@ -811,6 +812,12 @@ u32 VulkanContext::GetReadbackMemoryType(u32 bits, bool* is_coherent)
   // We should have at least one host visible memory type...
   PanicAlert("Unable to get memory type for upload.");
   return 0;
+}
+
+bool VulkanContext::SupportsDeviceExtension(const char* name) const
+{
+  return std::any_of(m_device_extensions.begin(), m_device_extensions.end(),
+                     [name](const std::string& extension) { return extension == name; });
 }
 
 void VulkanContext::InitDriverDetails()

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -107,11 +108,13 @@ public:
   u32 GetUploadMemoryType(u32 bits, bool* is_coherent = nullptr);
   u32 GetReadbackMemoryType(u32 bits, bool* is_coherent = nullptr);
 
+  // Returns true if the specified extension is supported and enabled.
+  bool SupportsDeviceExtension(const char* name) const;
+
 private:
-  using ExtensionList = std::vector<const char*>;
-  static bool SelectInstanceExtensions(ExtensionList* extension_list, WindowSystemType wstype,
-                                       bool enable_debug_report);
-  bool SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface);
+  static bool SelectInstanceExtensions(std::vector<const char*>* extension_list,
+                                       WindowSystemType wstype, bool enable_debug_report);
+  bool SelectDeviceExtensions(bool enable_surface);
   bool SelectDeviceFeatures();
   bool CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer);
   void InitDriverDetails();
@@ -135,6 +138,8 @@ private:
 
   u32 m_shader_subgroup_size = 1;
   bool m_supports_shader_subgroup_operations = false;
+
+  std::vector<std::string> m_device_extensions;
 };
 
 extern std::unique_ptr<VulkanContext> g_vulkan_context;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.h
@@ -111,6 +111,15 @@ public:
   // Returns true if the specified extension is supported and enabled.
   bool SupportsDeviceExtension(const char* name) const;
 
+  // Returns true if exclusive fullscreen is supported for the given surface.
+  bool SupportsExclusiveFullscreen(const WindowSystemInfo& wsi, VkSurfaceKHR surface);
+
+#ifdef WIN32
+  // Returns the platform-specific exclusive fullscreen structure.
+  VkSurfaceFullScreenExclusiveWin32InfoEXT
+  GetPlatformExclusiveFullscreenInfo(const WindowSystemInfo& wsi);
+#endif
+
 private:
   static bool SelectInstanceExtensions(std::vector<const char*>* extension_list,
                                        WindowSystemType wstype, bool enable_debug_report);

--- a/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+++ b/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
@@ -61,6 +61,7 @@ VULKAN_INSTANCE_ENTRY_POINT(vkCreateDebugReportCallbackEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkDestroyDebugReportCallbackEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkDebugReportMessageEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceProperties2, false)
+VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilities2KHR, false)
 
 #endif  // VULKAN_INSTANCE_ENTRY_POINT
 
@@ -191,5 +192,10 @@ VULKAN_DEVICE_ENTRY_POINT(vkDestroySwapchainKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkGetSwapchainImagesKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkAcquireNextImageKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkQueuePresentKHR, false)
+
+#ifdef SUPPORTS_VULKAN_EXCLUSIVE_FULLSCREEN
+VULKAN_DEVICE_ENTRY_POINT(vkAcquireFullScreenExclusiveModeEXT, false)
+VULKAN_DEVICE_ENTRY_POINT(vkReleaseFullScreenExclusiveModeEXT, false)
+#endif
 
 #endif  // VULKAN_DEVICE_ENTRY_POINT

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -24,6 +24,11 @@
 
 #include "vulkan/vulkan.h"
 
+// Currently, exclusive fullscreen is only supported on Windows.
+#if defined(WIN32)
+#define SUPPORTS_VULKAN_EXCLUSIVE_FULLSCREEN 1
+#endif
+
 // We abuse the preprocessor here to only need to specify function names once.
 #define VULKAN_MODULE_ENTRY_POINT(name, required) extern PFN_##name name;
 #define VULKAN_INSTANCE_ENTRY_POINT(name, required) extern PFN_##name name;

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -186,6 +186,8 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
                                              g_vulkan_context->GetDeviceFeatures());
   VulkanContext::PopulateBackendInfoMultisampleModes(
       &g_Config, g_vulkan_context->GetPhysicalDevice(), g_vulkan_context->GetDeviceProperties());
+  g_Config.backend_info.bSupportsExclusiveFullscreen =
+      enable_surface && g_vulkan_context->SupportsExclusiveFullscreen(wsi, surface);
 
   // With the backend information populated, we can now initialize videocommon.
   InitializeShared();


### PR DESCRIPTION
This PR uses the new `VK_EXT_full_screen_exclusive` extension to provide application-level control of the display. You can check if the extension is being used by looking at the log (enable "Video Backend", set to info level) to see if there is a message about "exclusive fullscreen being used", and acquired/released. Scary diff line count is due to the headers update, the actual changes are quite small (see the last 3 commits).

Unfortunately, the extension is (for now) Windows-only, sorry Linux users.. I hope your compositor is smart enough to scan out Dolphin's buffers directly...

I know the NVIDIA driver "attempts" to use exclusive fullscreen when it can, so this may not make a difference on such systems. However, the extension is also supported by AMD, and I'm not sure if their driver performs this "optimization" implicitly.  It would be interesting to get some feedback from AMD users to see if it makes any difference there.