### PR TITLE
Fix runtime stereoscopy mode switching

### DIFF
--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -1188,10 +1188,7 @@ const AbstractPipeline* ShaderCache::GetEFBCopyToRAMPipeline(const EFBCopyParams
   }
 
   AbstractPipelineConfig config = {};
-  config.vertex_format = nullptr;
   config.vertex_shader = m_screen_quad_vertex_shader.get();
-  config.geometry_shader =
-      UseGeometryShaderForEFBCopies() ? m_texcoord_geometry_shader.get() : nullptr;
   config.pixel_shader = shader.get();
   config.rasterization_state = RenderState::GetNoCullRasterizationState(PrimitiveType::Triangles);
   config.depth_state = RenderState::GetNoDepthTestingDepthState();

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -70,6 +70,9 @@ void ShaderCache::Reload()
   ClosePipelineUIDCache();
   ClearCaches();
 
+  if (!CompileSharedPipelines())
+    PanicAlert("Failed to compile shared pipelines after reload.");
+
   if (g_ActiveConfig.bShaderCache)
     LoadCaches();
 
@@ -368,6 +371,23 @@ void ShaderCache::ClearCaches()
   ClearPipelineCache(m_gx_uber_pipeline_cache, m_gx_uber_pipeline_disk_cache);
   ClearShaderCache(m_uber_vs_cache);
   ClearShaderCache(m_uber_ps_cache);
+
+  m_screen_quad_vertex_shader.reset();
+  m_texture_copy_vertex_shader.reset();
+  m_efb_copy_vertex_shader.reset();
+  m_texcoord_geometry_shader.reset();
+  m_color_geometry_shader.reset();
+  m_texture_copy_pixel_shader.reset();
+  m_color_pixel_shader.reset();
+
+  m_efb_copy_to_vram_pipelines.clear();
+  m_efb_copy_to_ram_pipelines.clear();
+  m_copy_rgba8_pipeline.reset();
+  m_rgba8_stereo_copy_pipeline.reset();
+  for (auto& pipeline : m_palette_conversion_pipelines)
+    pipeline.reset();
+  m_texture_reinterpret_pipelines.clear();
+  m_texture_decoding_shaders.clear();
 
   SETSTAT(g_stats.num_pixel_shaders_created, 0);
   SETSTAT(g_stats.num_pixel_shaders_alive, 0);


### PR DESCRIPTION
What the title says. Also removes the geometry shader in EFB2RAM pipelines, it was not needed as there is never a second layer for the RAM texture (only the left eye is used).