### PR TITLE
VerifyWidget: Handle Severity::None case in Verify()

### DIFF
--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -138,6 +138,8 @@ void VerifyWidget::Verify()
     case DiscIO::VolumeVerifier::Severity::High:
       severity = tr("High");
       break;
+    case DiscIO::VolumeVerifier::Severity::None:
+      break;
     }
 
     SetProblemCellText(i, 0, QString::fromStdString(problem.text));


### PR DESCRIPTION
The case body is empty because VolumeVerifier doesn't actually report
problems with severity of None.

Fixes "warning: enumeration value ‘None’ not handled in switch [-Wswitch]"
warning reported by gcc.