### PR TITLE
Another AVI fix for WinAPI importers

### DIFF
--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -191,6 +191,7 @@ bool FrameDump::CreateVideoFile()
   s_codec_context->time_base.num = 1;
   s_codec_context->time_base.den = VideoInterface::GetTargetRefreshRate();
   s_codec_context->gop_size = 1;
+  s_codec_context->level = 1;
   s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGR0 : AV_PIX_FMT_YUV420P;
 
   if (output_format->flags & AVFMT_GLOBALHEADER)


### PR DESCRIPTION
It looks like updated ffmpeg supports 2 versions of ffv1 (1 and 3), but we're not telling it what to use, so in the video it puts 0 if we dump at native resolution, but 3 if we dump at different resolution (not sure why).

I pass ffv1 version explicitly now, and using version 1 allows virtualdub/avisynth and similar VfW-based importers to decode it.