### PR TITLE
DolphinQt: Add ability to override ResourcePack and Load directory

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -135,6 +135,7 @@ const ConfigInfo<int> MAIN_AUDIO_VOLUME{{System::Main, "DSP", "Volume"}, 100};
 // Main.General
 
 const ConfigInfo<std::string> MAIN_DUMP_PATH{{System::Main, "General", "DumpPath"}, ""};
+const ConfigInfo<std::string> MAIN_LOAD_PATH{{System::Main, "General", "LoadPath"}, ""};
 const ConfigInfo<std::string> MAIN_FS_PATH{{System::Main, "General", "NANDRootPath"}, ""};
 const ConfigInfo<std::string> MAIN_SD_PATH{{System::Main, "General", "WiiSDCardPath"}, ""};
 

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -136,6 +136,8 @@ const ConfigInfo<int> MAIN_AUDIO_VOLUME{{System::Main, "DSP", "Volume"}, 100};
 
 const ConfigInfo<std::string> MAIN_DUMP_PATH{{System::Main, "General", "DumpPath"}, ""};
 const ConfigInfo<std::string> MAIN_LOAD_PATH{{System::Main, "General", "LoadPath"}, ""};
+const ConfigInfo<std::string> MAIN_RESOURCEPACK_PATH{{System::Main, "General", "ResourcePackPath"},
+                                                     ""};
 const ConfigInfo<std::string> MAIN_FS_PATH{{System::Main, "General", "NANDRootPath"}, ""};
 const ConfigInfo<std::string> MAIN_SD_PATH{{System::Main, "General", "WiiSDCardPath"}, ""};
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -104,6 +104,7 @@ extern const ConfigInfo<bool> MAIN_DISABLE_SCREENSAVER;
 // Main.General
 
 extern const ConfigInfo<std::string> MAIN_DUMP_PATH;
+extern const ConfigInfo<std::string> MAIN_LOAD_PATH;
 extern const ConfigInfo<std::string> MAIN_FS_PATH;
 extern const ConfigInfo<std::string> MAIN_SD_PATH;
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -105,6 +105,7 @@ extern const ConfigInfo<bool> MAIN_DISABLE_SCREENSAVER;
 
 extern const ConfigInfo<std::string> MAIN_DUMP_PATH;
 extern const ConfigInfo<std::string> MAIN_LOAD_PATH;
+extern const ConfigInfo<std::string> MAIN_RESOURCEPACK_PATH;
 extern const ConfigInfo<std::string> MAIN_FS_PATH;
 extern const ConfigInfo<std::string> MAIN_SD_PATH;
 

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -193,7 +193,7 @@ void ResourcePackManager::Install()
 
   auto& item = ResourcePack::GetPacks()[GetResourcePackIndex(items[0])];
 
-  bool success = item.Install(File::GetUserPath(D_USER_IDX));
+  bool success = item.Install(File::GetUserPath(D_LOAD_IDX));
 
   if (!success)
   {
@@ -214,7 +214,7 @@ void ResourcePackManager::Uninstall()
 
   auto& item = ResourcePack::GetPacks()[GetResourcePackIndex(items[0])];
 
-  bool success = item.Uninstall(File::GetUserPath(D_USER_IDX));
+  bool success = item.Uninstall(File::GetUserPath(D_LOAD_IDX));
 
   if (!success)
   {

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -72,6 +72,17 @@ void PathPane::BrowseDump()
   }
 }
 
+void PathPane::BrowseLoad()
+{
+  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+      this, tr("Select Load Path"), QString::fromStdString(Config::Get(Config::MAIN_LOAD_PATH))));
+  if (!dir.isEmpty())
+  {
+    m_load_edit->setText(dir);
+    Config::SetBase(Config::MAIN_LOAD_PATH, dir.toStdString());
+  }
+}
+
 void PathPane::BrowseSDCard()
 {
   QString file = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
@@ -183,13 +194,22 @@ QGridLayout* PathPane::MakePathsLayout()
   layout->addWidget(m_dump_edit, 2, 1);
   layout->addWidget(dump_open, 2, 2);
 
+  m_load_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_LOAD_PATH)));
+  connect(m_load_edit, &QLineEdit::editingFinished,
+          [=] { Config::SetBase(Config::MAIN_LOAD_PATH, m_load_edit->text().toStdString()); });
+  QPushButton* load_open = new QPushButton(QStringLiteral("..."));
+  connect(load_open, &QPushButton::clicked, this, &PathPane::BrowseLoad);
+  layout->addWidget(new QLabel(tr("Load Path:")), 3, 0);
+  layout->addWidget(m_load_edit, 3, 1);
+  layout->addWidget(load_open, 3, 2);
+
   m_sdcard_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_SD_PATH)));
   connect(m_sdcard_edit, &QLineEdit::editingFinished, this, &PathPane::OnSDCardPathChanged);
   QPushButton* sdcard_open = new QPushButton(QStringLiteral("..."));
   connect(sdcard_open, &QPushButton::clicked, this, &PathPane::BrowseSDCard);
-  layout->addWidget(new QLabel(tr("SD Card Path:")), 3, 0);
-  layout->addWidget(m_sdcard_edit, 3, 1);
-  layout->addWidget(sdcard_open, 3, 2);
+  layout->addWidget(new QLabel(tr("SD Card Path:")), 4, 0);
+  layout->addWidget(m_sdcard_edit, 4, 1);
+  layout->addWidget(sdcard_open, 4, 2);
 
   return layout;
 }

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -83,6 +83,18 @@ void PathPane::BrowseLoad()
   }
 }
 
+void PathPane::BrowseResourcePack()
+{
+  QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(
+      this, tr("Select Resource Pack Path"),
+      QString::fromStdString(Config::Get(Config::MAIN_RESOURCEPACK_PATH))));
+  if (!dir.isEmpty())
+  {
+    m_resource_pack_edit->setText(dir);
+    Config::SetBase(Config::MAIN_RESOURCEPACK_PATH, dir.toStdString());
+  }
+}
+
 void PathPane::BrowseSDCard()
 {
   QString file = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
@@ -203,13 +215,24 @@ QGridLayout* PathPane::MakePathsLayout()
   layout->addWidget(m_load_edit, 3, 1);
   layout->addWidget(load_open, 3, 2);
 
+  m_resource_pack_edit =
+      new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_RESOURCEPACK_PATH)));
+  connect(m_resource_pack_edit, &QLineEdit::editingFinished, [=] {
+    Config::SetBase(Config::MAIN_RESOURCEPACK_PATH, m_resource_pack_edit->text().toStdString());
+  });
+  QPushButton* resource_pack_open = new QPushButton(QStringLiteral("..."));
+  connect(resource_pack_open, &QPushButton::clicked, this, &PathPane::BrowseResourcePack);
+  layout->addWidget(new QLabel(tr("Resource Pack Path:")), 4, 0);
+  layout->addWidget(m_resource_pack_edit, 4, 1);
+  layout->addWidget(resource_pack_open, 4, 2);
+
   m_sdcard_edit = new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_SD_PATH)));
   connect(m_sdcard_edit, &QLineEdit::editingFinished, this, &PathPane::OnSDCardPathChanged);
   QPushButton* sdcard_open = new QPushButton(QStringLiteral("..."));
   connect(sdcard_open, &QPushButton::clicked, this, &PathPane::BrowseSDCard);
-  layout->addWidget(new QLabel(tr("SD Card Path:")), 4, 0);
-  layout->addWidget(m_sdcard_edit, 4, 1);
-  layout->addWidget(sdcard_open, 4, 2);
+  layout->addWidget(new QLabel(tr("SD Card Path:")), 5, 0);
+  layout->addWidget(m_sdcard_edit, 5, 1);
+  layout->addWidget(sdcard_open, 5, 2);
 
   return layout;
 }

--- a/Source/Core/DolphinQt/Settings/PathPane.h
+++ b/Source/Core/DolphinQt/Settings/PathPane.h
@@ -24,6 +24,7 @@ private:
   void BrowseWiiNAND();
   void BrowseDump();
   void BrowseLoad();
+  void BrowseResourcePack();
   void BrowseSDCard();
   QGroupBox* MakeGameFolderBox();
   QGridLayout* MakePathsLayout();
@@ -37,6 +38,7 @@ private:
   QLineEdit* m_nand_edit;
   QLineEdit* m_dump_edit;
   QLineEdit* m_load_edit;
+  QLineEdit* m_resource_pack_edit;
   QLineEdit* m_sdcard_edit;
 
   QPushButton* m_remove_path;

--- a/Source/Core/DolphinQt/Settings/PathPane.h
+++ b/Source/Core/DolphinQt/Settings/PathPane.h
@@ -23,6 +23,7 @@ private:
   void BrowseDefaultGame();
   void BrowseWiiNAND();
   void BrowseDump();
+  void BrowseLoad();
   void BrowseSDCard();
   QGroupBox* MakeGameFolderBox();
   QGridLayout* MakePathsLayout();
@@ -35,6 +36,7 @@ private:
   QLineEdit* m_game_edit;
   QLineEdit* m_nand_edit;
   QLineEdit* m_dump_edit;
+  QLineEdit* m_load_edit;
   QLineEdit* m_sdcard_edit;
 
   QPushButton* m_remove_path;

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -8,6 +8,7 @@
 
 #include <minizip/unzip.h>
 
+#include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/MinizipUtil.h"
@@ -19,7 +20,7 @@
 
 namespace ResourcePack
 {
-constexpr char TEXTURE_PATH[] = "Load/Textures/";
+constexpr char TEXTURE_PATH[] = HIRES_TEXTURES_DIR DIR_SEP;
 
 ResourcePack::ResourcePack(const std::string& path) : m_path(path)
 {

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -62,9 +62,17 @@ static void CreateDumpPath(const std::string& path)
   File::CreateFullPath(File::GetUserPath(D_DUMPTEXTURES_IDX));
 }
 
+static void CreateLoadPath(const std::string& path)
+{
+  if (!path.empty())
+    File::SetUserPath(D_LOAD_IDX, path + '/');
+  File::CreateFullPath(File::GetUserPath(D_HIRESTEXTURES_IDX));
+}
+
 static void InitCustomPaths()
 {
   File::SetUserPath(D_WIIROOT_IDX, Config::Get(Config::MAIN_FS_PATH));
+  CreateLoadPath(Config::Get(Config::MAIN_LOAD_PATH));
   CreateDumpPath(Config::Get(Config::MAIN_DUMP_PATH));
   const std::string sd_path = Config::Get(Config::MAIN_SD_PATH);
   if (!sd_path.empty())

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -69,11 +69,18 @@ static void CreateLoadPath(const std::string& path)
   File::CreateFullPath(File::GetUserPath(D_HIRESTEXTURES_IDX));
 }
 
+static void CreateResourcePackPath(const std::string& path)
+{
+  if (!path.empty())
+    File::SetUserPath(D_RESOURCEPACK_IDX, path + '/');
+}
+
 static void InitCustomPaths()
 {
   File::SetUserPath(D_WIIROOT_IDX, Config::Get(Config::MAIN_FS_PATH));
   CreateLoadPath(Config::Get(Config::MAIN_LOAD_PATH));
   CreateDumpPath(Config::Get(Config::MAIN_DUMP_PATH));
+  CreateResourcePackPath(Config::Get(Config::MAIN_RESOURCEPACK_PATH));
   const std::string sd_path = Config::Get(Config::MAIN_SD_PATH);
   if (!sd_path.empty())
     File::SetUserPath(F_WIISDCARD_IDX, sd_path);


### PR DESCRIPTION
If you have Dolphin installed on a SSD, you might not want to  have giant textures or giant zips installed in  your user directory.  Instead, you can delegate those folders to be off in another location.

Fixes:  https://bugs.dolphin-emu.org/issues/9970