### PR TITLE
FixedSizeQueue: Work around GCC generating large amounts of debug info

### DIFF
--- a/Source/Core/Common/FixedSizeQueue.h
+++ b/Source/Core/Common/FixedSizeQueue.h
@@ -21,7 +21,13 @@ public:
   void clear()
   {
     if constexpr (!std::is_trivial_v<T>)
-      storage = {};
+    {
+      // The clear of non-trivial objects previously used "storage = {}". However, this causes GCC
+      // to take a very long time to compile the file/function, as well as generating huge amounts
+      // of debug information (~2GB object file, ~600MB of debug info).
+      while (count > 0)
+        pop();
+    }
 
     head = 0;
     tail = 0;


### PR DESCRIPTION
The `storage = {};` statement in the `clear()` function causes GCC to blow up in memory usage when compiling LogWidget.cpp (approx. 16GB on my machine), and generate a 3.1GB assembly file in the `RelWithDebInfo` config. The `dolphin-emu` binary grows from ~300MB to ~900MB.

Not certain if this is a gcc bug or working as intended... I created a small repro program (albeit with a larger array size) which exhibits the same issue, and crashes gcc: https://pastebin.com/raw/iXrQEv0j