### PR TITLE
Socket: Abort pending ops on close

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -170,6 +170,12 @@ s32 WiiSocket::CloseFd()
     ReturnValue = WiiSockMan::GetNetErrorCode(EITHER(WSAENOTSOCK, EBADF), "CloseFd", false);
   }
   fd = -1;
+
+  for (auto it = pending_sockops.begin(); it != pending_sockops.end();)
+  {
+    GetIOS()->EnqueueIPCReply(it->request, -SO_ENOTCONN);
+    it = pending_sockops.erase(it);
+  }
   return ReturnValue;
 }
 


### PR DESCRIPTION
It seems there was a network regression, I'm investigating to find the root cause of it.

Meanwhile, here is a quick fix which prevent closesocket to hang forever and instead return -1 on close.

Do not merge.