### PR TITLE
WiimoteEmu: Tilt fixes.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -91,12 +91,9 @@ void EmulateTilt(RotationalState* state, ControllerEmu::Tilt* const tilt_group, 
   const ControlState roll = target.x * MathUtil::PI;
   const ControlState pitch = target.y * MathUtil::PI;
 
-  // Higher values will be more responsive but will increase rate of M+ "desync".
-  // I'd rather not expose this value in the UI if not needed.
-  // Desync caused by tilt seems not as severe as accelerometer data can estimate pitch/yaw.
-  constexpr auto MAX_ACCEL = float(MathUtil::TAU * 50);
+  const auto max_accel = std::pow(tilt_group->GetMaxRotationalVelocity(), 2) / MathUtil::TAU;
 
-  ApproachAngleWithAccel(state, Common::Vec3(pitch, -roll, 0), MAX_ACCEL, time_elapsed);
+  ApproachAngleWithAccel(state, Common::Vec3(pitch, -roll, 0), max_accel, time_elapsed);
 }
 
 void EmulateSwing(MotionState* state, ControllerEmu::Force* swing_group, float time_elapsed)

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -732,18 +732,6 @@ Common::Vec3 Wiimote::GetAcceleration()
   // Our shake effects have never been affected by orientation. Should they be?
   accel += m_shake_state.acceleration;
 
-  // Simulate centripetal acceleration caused by an offset of the accelerometer sensor.
-  // Estimate of sensor position based on an image of the wii remote board:
-  constexpr float ACCELEROMETER_Y_OFFSET = 0.1f;
-
-  const auto angular_velocity = GetAngularVelocity();
-  const auto centripetal_accel =
-      // TODO: Is this the proper way to combine the x and z angular velocities?
-      std::pow(std::abs(angular_velocity.x) + std::abs(angular_velocity.z), 2) *
-      ACCELEROMETER_Y_OFFSET;
-
-  accel.y += centripetal_accel;
-
   return accel;
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -31,7 +31,7 @@ Tilt::Tilt(const std::string& name_) : ReshapableInput(name_, name_, GroupType::
               _trans("°"),
               // i18n: Refers to emulated wii remote movement.
               _trans("Maximum tilt angle.")},
-             90, 0, 180);
+             85, 0, 180);
 
   AddSetting(&m_max_rotational_velocity,
              {_trans("Velocity"),

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/Common.h"
+#include "Common/MathUtil.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
@@ -31,6 +32,14 @@ Tilt::Tilt(const std::string& name_) : ReshapableInput(name_, name_, GroupType::
               // i18n: Refers to emulated wii remote movement.
               _trans("Maximum tilt angle.")},
              90, 0, 180);
+
+  AddSetting(&m_max_rotational_velocity,
+             {_trans("Velocity"),
+              // i18n: The symbol/abbreviation for hertz (cycles per second).
+              _trans("Hz"),
+              // i18n: Refers to emulated wii remote movement.
+              _trans("Peak complete turns per second.")},
+             7, 1, 50);
 }
 
 Tilt::ReshapeData Tilt::GetReshapableState(bool adjusted)
@@ -61,6 +70,11 @@ ControlState Tilt::GetGateRadiusAtAngle(double ang) const
 ControlState Tilt::GetDefaultInputRadiusAtAngle(double ang) const
 {
   return SquareStickGate(1.0).GetRadiusAtAngle(ang);
+}
+
+ControlState Tilt::GetMaxRotationalVelocity() const
+{
+  return m_max_rotational_velocity.GetValue() * MathUtil::TAU;
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -28,7 +28,11 @@ public:
 
   StateData GetState();
 
+  // Return peak rotational velocity (for a complete turn) in radians/sec
+  ControlState GetMaxRotationalVelocity() const;
+
 private:
   SettingValue<double> m_max_angle_setting;
+  SettingValue<double> m_max_rotational_velocity;
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
Fixes: https://bugs.dolphin-emu.org/issues/11776

I've exposed the emulated tilt acceleration. It is calculated from a value in hertz referring to the peak turns per second when making a complete turn. This makes for a friendly default value of 7 which is approximately what the old hardcoded acceleration was.

The default maximum tilt angle is now 85 degrees. A full 90 degrees (old default) causes issues in some games, especially when tilting in two directions: e.g. Up+Left. Flying in Skyward Sword is an example.

Simulating centripetal acceleration doesn't really seem to help with MotionPlus accuracy in Skyward Sword at all and it was causing tilt responsiveness issues. I've removed it.