### PR TITLE
Qt/CMake: Fix Qt5_DIR being set to the wrong directory

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT Qt5_DIR AND MSVC)
-set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt5.11.1/5.11.1/msvc2017_64/lib/cmake/Qt5")
+  set(Qt5_DIR "${CMAKE_SOURCE_DIR}/Externals/Qt/Qt5.11.1/5.11.1/msvc2017_64/lib/cmake/Qt5")
 endif()
 
 find_package(Qt5 5.9 REQUIRED COMPONENTS Gui Widgets)


### PR DESCRIPTION
Hello, I just checked out the repo for the first time, did `git submodule update --init` and tried to build using CMake on Windows (I use CLion), but got an error because Qt5_DIR was not pointing to the folder that was added by `git submodule update`. This commit fixes that so other Windows users who don't use Visual Studio shouldn't have the same problem in the future.