### PR TITLE
DolphinQt: When audio backend is invalid, show nothing in dropdown

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -181,12 +181,18 @@ void AudioPane::LoadSettings()
 
   // Backend
   const auto current = SConfig::GetInstance().sBackend;
+  bool selection_set = false;
   for (const auto& backend : AudioCommon::GetSoundBackends())
   {
     m_backend_combo->addItem(tr(backend.c_str()), QVariant(QString::fromStdString(backend)));
     if (backend == current)
+    {
       m_backend_combo->setCurrentIndex(m_backend_combo->count() - 1);
+      selection_set = true;
+    }
   }
+  if (!selection_set)
+    m_backend_combo->setCurrentIndex(-1);
 
   OnBackendChanged();
 


### PR DESCRIPTION
It used to show the first option, No Audio Output (but audio output would work correctly anyway since AudioCommon didn't use this logic.)