### PR TITLE
Support Windows 10 long paths

### DIFF
--- a/Source/Core/Common/CDUtils.cpp
+++ b/Source/Core/Common/CDUtils.cpp
@@ -26,6 +26,7 @@
 #include <IOKit/storage/IOMedia.h>
 #include <paths.h>
 #else
+#include <climits>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -211,7 +212,7 @@ bool IsCDROMDevice(std::string device)
 #ifndef _WIN32
   // Resolve symbolic links. This allows symbolic links to valid
   // drives to be passed from the command line with the -e flag.
-  char resolved_path[MAX_PATH];
+  char resolved_path[PATH_MAX];
   char* devname = realpath(device.c_str(), resolved_path);
   if (!devname)
     return false;

--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -30,12 +30,6 @@ struct CrtDebugBreak
 
 #endif
 
-// Windows compatibility
-#ifndef _WIN32
-#include <limits.h>
-#define MAX_PATH PATH_MAX
-#endif
-
 #ifdef _MSC_VER
 #define __getcwd _getcwd
 #define __chdir _chdir

--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -49,4 +49,27 @@ std::string GetLastErrorString()
                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), error_message, BUFFER_SIZE, nullptr);
   return std::string(error_message);
 }
+
+// Obtains a full path to the specified module.
+std::optional<std::wstring> GetModuleName(void* hInstance)
+{
+  DWORD max_size = 50;  // Start with space for 50 characters and grow if needed
+  std::wstring name(max_size, L'\0');
+
+  DWORD size;
+  while ((size = GetModuleFileNameW(static_cast<HMODULE>(hInstance), name.data(), max_size)) ==
+             max_size &&
+         GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+  {
+    max_size *= 2;
+    name.resize(max_size);
+  }
+
+  if (size == 0)
+  {
+    return std::nullopt;
+  }
+  name.resize(size);
+  return name;
+}
 #endif

--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include "Common/CommonTypes.h"
 
@@ -47,4 +48,7 @@ std::string LastStrerrorString();
 // Wrapper function to get GetLastError() string.
 // This function might change the error code.
 std::string GetLastErrorString();
+
+// Obtains a full path to the specified module.
+std::optional<std::wstring> GetModuleName(void* hInstance);
 #endif

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -639,19 +639,21 @@ std::string CreateTempDir()
 #endif
 }
 
-std::string GetTempFilenameForAtomicWrite(const std::string& path)
+std::string GetTempFilenameForAtomicWrite(std::string path)
 {
-  std::string abs = path;
 #ifdef _WIN32
-  TCHAR absbuf[MAX_PATH];
-  if (_tfullpath(absbuf, UTF8ToTStr(path).c_str(), MAX_PATH) != nullptr)
-    abs = TStrToUTF8(absbuf);
+  std::unique_ptr<TCHAR[], decltype(&std::free)> absbuf{
+      _tfullpath(nullptr, UTF8ToTStr(path).c_str(), 0), std::free};
+  if (absbuf != nullptr)
+  {
+    path = TStrToUTF8(absbuf.get());
+  }
 #else
   char absbuf[PATH_MAX];
   if (realpath(path.c_str(), absbuf) != nullptr)
-    abs = absbuf;
+    path = absbuf;
 #endif
-  return abs + ".xxx";
+  return std::move(path) + ".xxx";
 }
 
 #if defined(__APPLE__)

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -674,22 +674,26 @@ std::string GetBundleDirectory()
 
 std::string GetExePath()
 {
-  static std::string dolphin_path;
-  if (dolphin_path.empty())
-  {
+  static const std::string dolphin_path = [] {
+    std::string result;
 #ifdef _WIN32
-    TCHAR dolphin_exe_path[2048];
-    TCHAR dolphin_exe_expanded_path[MAX_PATH];
-    GetModuleFileName(nullptr, dolphin_exe_path, ARRAYSIZE(dolphin_exe_path));
-    if (_tfullpath(dolphin_exe_expanded_path, dolphin_exe_path,
-                   ARRAYSIZE(dolphin_exe_expanded_path)) != nullptr)
-      dolphin_path = TStrToUTF8(dolphin_exe_expanded_path);
-    else
-      dolphin_path = TStrToUTF8(dolphin_exe_path);
+    auto dolphin_exe_path = GetModuleName(nullptr);
+    if (dolphin_exe_path)
+    {
+      std::unique_ptr<TCHAR[], decltype(&std::free)> dolphin_exe_expanded_path{
+          _tfullpath(nullptr, dolphin_exe_path->c_str(), 0), std::free};
+      if (dolphin_exe_expanded_path)
+      {
+        result = TStrToUTF8(dolphin_exe_expanded_path.get());
+      }
+      else
+      {
+        result = TStrToUTF8(*dolphin_exe_path);
+      }
+    }
 #elif defined(__APPLE__)
-    dolphin_path = GetBundleDirectory();
-    dolphin_path =
-        dolphin_path.substr(0, dolphin_path.find_last_of("Dolphin.app/Contents/MacOS") + 1);
+    result = GetBundleDirectory();
+    result = result.substr(0, result.find_last_of("Dolphin.app/Contents/MacOS") + 1);
 #else
     char dolphin_exe_path[PATH_MAX];
     ssize_t len = ::readlink("/proc/self/exe", dolphin_exe_path, sizeof(dolphin_exe_path));
@@ -698,9 +702,10 @@ std::string GetExePath()
       len = 0;
     }
     dolphin_exe_path[len] = '\0';
-    dolphin_path = dolphin_exe_path;
+    result = dolphin_exe_path;
 #endif
-  }
+    return result;
+  }();
   return dolphin_path;
 }
 

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -172,7 +172,7 @@ bool SetCurrentDir(const std::string& directory);
 std::string CreateTempDir();
 
 // Get a filename that can hopefully be atomically renamed to the given path.
-std::string GetTempFilenameForAtomicWrite(const std::string& path);
+std::string GetTempFilenameForAtomicWrite(std::string path);
 
 // Gets a set user directory path
 // Don't call prior to setting the base user directory

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/PowerPC/Jit64/JitAsm.h"
 
+#include <climits>
+
 #include "Common/CommonTypes.h"
 #include "Common/JitRegister.h"
 #include "Common/x64ABI.h"

--- a/Source/Core/DolphinQt/DolphinQt.manifest
+++ b/Source/Core/DolphinQt/DolphinQt.manifest
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    <windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <dpiAware>true</dpiAware>
+      <longPathAware>true</longPathAware>
     </windowsSettings>
   </application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -211,46 +211,57 @@ void SetUserDirectory(const std::string& custom_path)
   //    -> Use GetExeDirectory()\User
 
   // Check our registry keys
+  // TODO: Maybe use WIL when it's available?
   HKEY hkey;
   DWORD local = 0;
-  TCHAR configPath[MAX_PATH] = {0};
+  std::unique_ptr<TCHAR[]> configPath;
   if (RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Dolphin Emulator"), 0, KEY_QUERY_VALUE,
                    &hkey) == ERROR_SUCCESS)
   {
     DWORD size = 4;
     if (RegQueryValueEx(hkey, TEXT("LocalUserConfig"), nullptr, nullptr,
                         reinterpret_cast<LPBYTE>(&local), &size) != ERROR_SUCCESS)
+    {
       local = 0;
+    }
 
-    size = MAX_PATH;
-    if (RegQueryValueEx(hkey, TEXT("UserConfigPath"), nullptr, nullptr, (LPBYTE)configPath,
-                        &size) != ERROR_SUCCESS)
-      configPath[0] = 0;
+    size = 0;
+    RegQueryValueEx(hkey, TEXT("UserConfigPath"), nullptr, nullptr, nullptr, &size);
+    configPath = std::make_unique<TCHAR[]>(size / sizeof(TCHAR));
+    if (RegQueryValueEx(hkey, TEXT("UserConfigPath"), nullptr, nullptr,
+                        reinterpret_cast<LPBYTE>(configPath.get()), &size) != ERROR_SUCCESS)
+    {
+      configPath.reset();
+    }
+
     RegCloseKey(hkey);
   }
 
-  local = local || File::Exists(File::GetExeDirectory() + DIR_SEP "portable.txt");
+  local = local != 0 || File::Exists(File::GetExeDirectory() + DIR_SEP "portable.txt");
 
-  // Get Program Files path in case we need it.
-  TCHAR my_documents[MAX_PATH];
-  bool my_documents_found = SUCCEEDED(
-      SHGetFolderPath(nullptr, CSIDL_MYDOCUMENTS, nullptr, SHGFP_TYPE_CURRENT, my_documents));
+  // Get Documents path in case we need it.
+  // TODO: Maybe use WIL when it's available?
+  PWSTR my_documents = nullptr;
+  bool my_documents_found =
+      SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_DEFAULT, nullptr, &my_documents));
 
   if (local)  // Case 1-2
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
-  else if (configPath[0])  // Case 3
-    user_path = TStrToUTF8(configPath);
+  else if (configPath)  // Case 3
+    user_path = TStrToUTF8(configPath.get());
   else if (my_documents_found)  // Case 4
     user_path = TStrToUTF8(my_documents) + DIR_SEP "Dolphin Emulator" DIR_SEP;
   else  // Case 5
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
 
+  CoTaskMemFree(my_documents);
+
   // Prettify the path: it will be displayed in some places, we don't want a mix
   // of \ and /.
-  user_path = ReplaceAll(user_path, "\\", DIR_SEP);
+  user_path = ReplaceAll(std::move(user_path), "\\", DIR_SEP);
 
   // Make sure it ends in DIR_SEP.
-  if (*user_path.rbegin() != DIR_SEP_CHR)
+  if (user_path.back() != DIR_SEP_CHR)
     user_path += DIR_SEP;
 
 #else
@@ -325,7 +336,7 @@ void SetUserDirectory(const std::string& custom_path)
 #endif
   }
 #endif
-  File::SetUserPath(D_USER_IDX, user_path);
+  File::SetUserPath(D_USER_IDX, std::move(user_path));
 }
 
 void SaveWiimoteSources()

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/CommonFuncs.h"
 #include "Common/StringUtil.h"
 
 #include "UpdaterCommon/UI.h"
@@ -32,28 +33,6 @@ std::vector<std::string> CommandLineToUtf8Argv(PCWSTR command_line)
 
   LocalFree(tokenized);
   return argv;
-}
-
-std::optional<std::wstring> GetModuleName(HINSTANCE hInstance)
-{
-  std::wstring name;
-  DWORD max_size = 50;  // Start with space for 50 characters and grow if needed
-  name.resize(max_size);
-
-  DWORD size;
-  while ((size = GetModuleFileNameW(hInstance, name.data(), max_size)) == max_size &&
-         GetLastError() == ERROR_INSUFFICIENT_BUFFER)
-  {
-    max_size *= 2;
-    name.resize(max_size);
-  }
-
-  if (size == 0)
-  {
-    return {};
-  }
-  name.resize(size);
-  return name;
 }
 };  // namespace
 

--- a/Source/Core/WinUpdater/Updater.exe.manifest
+++ b/Source/Core/WinUpdater/Updater.exe.manifest
@@ -29,8 +29,9 @@
 </compatibility>
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings
-       xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-    <dpiAware>True</dpiAware>
+       xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+    <dpiAware>true</dpiAware>
+    <longPathAware>true</longPathAware>
   </asmv3:windowsSettings>
 </asmv3:application>
 </assembly>


### PR DESCRIPTION
This PR makes Dolphin compatible with Windows 10 long paths. Windows 10 1607 and newer allows applications to lift MAX_PATH limitation via manifest, so with a few code changes I was able to remove MAX_PATH dependency from all non-Qt code paths and opt in to that.

I verified against games and settings located in a path which has over MAX_PATH characters - game showed in the list and booted, settings also seem to save.

The only function still using MAX_PATH (and not being a third party) is `CreateTempDir` but as far as I can tell that is only used in unit tests, so I didn't bother.