### PR TITLE
Fix FifoCI

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -25,7 +25,8 @@ AlsaSound::~AlsaSound()
   // Give the opportunity to the audio thread
   // to realize we are stopping the emulation
   cv.notify_one();
-  thread.join();
+  if (thread.joinable())
+    thread.join();
 }
 
 bool AlsaSound::Init()

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -64,6 +64,7 @@ void InitSoundStream()
     WARN_LOG(AUDIO, "Could not initialize backend %s, using %s instead.", backend.c_str(),
              BACKEND_NULLSOUND);
     g_sound_stream = std::make_unique<NullSound>();
+    g_sound_stream->Init();
   }
 
   UpdateSoundStream();


### PR DESCRIPTION
After #8361 instead of falling back to null sound, it falls back to the ALSA driver on Linux. Which failed on the fifoci runner, which would've been fine except for the fact that the destructor calls `std::thread::join` without checking if the thread was actually created, which in the case of initialization failing, it wasn't.

Also adds a missing `Init()` call to the null backend, even though it's a no-op in case it changes in the future.