### PR TITLE
Qt: Game Tracker fixes

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -79,6 +79,11 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
     case CommandType::PurgeCache:
       m_cache.Clear(UICommon::GameFileCache::DeleteOnDisk::Yes);
       break;
+    case CommandType::BeginRefresh:
+      for (auto& file : m_tracked_files.keys())
+        emit GameRemoved(file.toStdString());
+      m_tracked_files.clear();
+      break;
     }
   });
 
@@ -177,10 +182,7 @@ void GameTracker::RemoveDirectory(const QString& dir)
 
 void GameTracker::RefreshAll()
 {
-  for (auto& file : m_tracked_files.keys())
-    emit GameRemoved(file.toStdString());
-
-  m_tracked_files.clear();
+  m_load_thread.EmplaceItem(Command{CommandType::BeginRefresh});
 
   for (const QString& dir : Settings::Instance().GetPaths())
   {

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -56,6 +56,7 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
       break;
     case CommandType::Start:
       StartInternal();
+      break;
     case CommandType::AddDirectory:
       AddDirectoryInternal(command.path);
       break;

--- a/Source/Core/DolphinQt/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt/GameList/GameTracker.h
@@ -72,7 +72,8 @@ private:
     UpdateDirectory,
     UpdateFile,
     UpdateMetadata,
-    PurgeCache
+    PurgeCache,
+    BeginRefresh,
   };
 
   struct Command

--- a/Source/Core/DolphinQt/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt/GameList/GameTracker.h
@@ -74,6 +74,7 @@ private:
     UpdateMetadata,
     PurgeCache,
     BeginRefresh,
+    EndRefresh,
   };
 
   struct Command
@@ -91,6 +92,8 @@ private:
   Common::Event m_initial_games_emitted_event;
   bool m_initial_games_emitted = false;
   bool m_started = false;
+  // Count of currently running refresh jobs
+  u32 m_busy_count = 0;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<const UICommon::GameFile>)

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -141,6 +141,11 @@ void Settings::RefreshGameList()
   emit GameListRefreshRequested();
 }
 
+void Settings::NotifyRefreshGameListComplete()
+{
+  emit GameListRefreshCompleted();
+}
+
 void Settings::RefreshMetadata()
 {
   emit MetadataRefreshRequested();

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -75,6 +75,7 @@ public:
   QString GetDefaultGame() const;
   void SetDefaultGame(QString path);
   void RefreshGameList();
+  void NotifyRefreshGameListComplete();
   void RefreshMetadata();
   void NotifyMetadataRefreshComplete();
   void ReloadTitleDB();
@@ -150,6 +151,7 @@ signals:
   void PathRemoved(const QString&);
   void DefaultGameChanged(const QString&);
   void GameListRefreshRequested();
+  void GameListRefreshCompleted();
   void TitleDBReloadRequested();
   void MetadataRefreshRequested();
   void MetadataRefreshCompleted();

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -32,10 +32,10 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &ToolBar::UpdateIcons);
   UpdateIcons();
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged,
           [this](Core::State state) { OnEmulationStateChanged(state); });
 
-  connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this,
+  connect(Host::GetInstance(), &Host::UpdateDisasmDialog,
           [this] { OnEmulationStateChanged(Core::GetState()); });
 
   connect(&Settings::Instance(), &Settings::DebugModeToggled, this, &ToolBar::OnDebugModeToggled);
@@ -43,8 +43,11 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::ToolBarVisibilityChanged, this, &ToolBar::setVisible);
   connect(this, &ToolBar::visibilityChanged, &Settings::Instance(), &Settings::SetToolBarVisible);
 
-  connect(&Settings::Instance(), &Settings::WidgetLockChanged, this,
+  connect(&Settings::Instance(), &Settings::WidgetLockChanged,
           [this](bool locked) { setMovable(!locked); });
+
+  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted,
+          [this] { m_refresh_action->setEnabled(true); });
 
   OnEmulationStateChanged(Core::GetState());
   OnDebugModeToggled(Settings::Instance().IsDebugModeEnabled());
@@ -109,7 +112,10 @@ void ToolBar::MakeActions()
   m_set_pc_action = addAction(tr("Set PC"), this, &ToolBar::SetPCPressed);
 
   m_open_action = addAction(tr("Open"), this, &ToolBar::OpenPressed);
-  m_refresh_action = addAction(tr("Refresh"), this, &ToolBar::RefreshPressed);
+  m_refresh_action = addAction(tr("Refresh"), [this] {
+    m_refresh_action->setEnabled(false);
+    emit RefreshPressed();
+  });
 
   addSeparator();
 


### PR DESCRIPTION
This PR improves Game Tracker functionality by addressing the following:

* Fixes a race condition when rapidly clicking Refresh button - previously, game list would continuously be populated over and over, leaving itself in broken state where most entries were duplicated.
* Enables/disables Refresh button when refresh is already in place. While code technically should support "nested" refresh jobs, I don't know if you can actually end up in such state - maybe if you press Refresh button **and** use Refresh Game List hotkey at once? No idea.

This PR is generally finished, but I am marking it WIP because I am not satisfied with how it is possible to see _"Dolphin could not find any games..."_ for a split second while refreshing! Ideally, I would like it to just show something like _"Refreshing, please wait..."_