### PR TITLE
Add /Source/Android/app/.cxx/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ Source/Core/Common/scmrev.h
 /[Bb]uild*/
 /[Bb]inary/
 /obj/
-# Android cmake builds to here then copies to Source/Android.
+# Ignore files output by Android cmake build
+/Source/Android/app/.cxx/
 /libs/
 # Ignore various files created by visual studio/msbuild
 *.ipch


### PR DESCRIPTION
Recent versions of Android Studio seem to put stuff here.