### PR TITLE
Qt/Debugger/CodeWidget: Allow pressing 'enter' in address search box.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -156,6 +156,7 @@ void CodeWidget::CreateWidgets()
 void CodeWidget::ConnectWidgets()
 {
   connect(m_search_address, &QLineEdit::textChanged, this, &CodeWidget::OnSearchAddress);
+  connect(m_search_address, &QLineEdit::returnPressed, this, &CodeWidget::OnSearchAddress);
   connect(m_search_symbols, &QLineEdit::textChanged, this, &CodeWidget::OnSearchSymbols);
 
   connect(m_symbols_list, &QListWidget::itemPressed, this, &CodeWidget::OnSelectSymbol);


### PR DESCRIPTION
Pretty straightforward, connect the `returnPressed` signal to the same target as the `textChanged` one. This allows you to press Enter to go back to the address currently listed in the search box, which I feel like I need a surprising number of times while debugging...