### PR TITLE
ControllerEmu: Clamp results of trigger/slider states to prevent integer overflow later on.

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -48,7 +48,7 @@ void MixedTriggers::GetState(u16* const digital, const u16* bitmasks, ControlSta
   {
     const ControlState button_value = ApplyDeadzone(controls[i]->control_ref->State(), deadzone);
     ControlState analog_value =
-        ApplyDeadzone(controls[trigger_count + i]->control_ref->State(), deadzone);
+        std::min(ApplyDeadzone(controls[trigger_count + i]->control_ref->State(), deadzone), 1.0);
 
     // Apply threshold:
     if (button_value > threshold)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
@@ -34,6 +34,6 @@ Slider::StateData Slider::GetState()
   const ControlState deadzone = m_deadzone_setting.GetValue() / 100;
   const ControlState state = controls[1]->control_ref->State() - controls[0]->control_ref->State();
 
-  return {ApplyDeadzone(state, deadzone)};
+  return {std::clamp(ApplyDeadzone(state, deadzone), -1.0, 1.0)};
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.cpp
@@ -28,7 +28,7 @@ Triggers::StateData Triggers::GetState()
 
   StateData result(trigger_count);
   for (size_t i = 0; i < trigger_count; ++i)
-    result.data[i] = ApplyDeadzone(controls[i]->control_ref->State(), deadzone);
+    result.data[i] = std::min(ApplyDeadzone(controls[i]->control_ref->State(), deadzone), 1.0);
 
   return result;
 }


### PR DESCRIPTION
Fixes: https://bugs.dolphin-emu.org/issues/11878

If a user increased the "Range" setting for a more sensitive input (common for the DJ Turntable extension) integer overflow was possible.

This PR clamps the results of the Slider and Trigger groups to prevent that.
Similar clamping is already done for `ReshapableInput` (analog sticks et al.).