### PR TITLE
Qt: Move CPU Emulation Engine options to the Advanced tab

### DIFF
--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -47,7 +47,7 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
     wii_pane->OnEmulationStateChanged(state != Core::State::Uninitialized);
   });
 
-  m_tab_widget->addTab(new AdvancedPane(), tr("Advanced"));
+  m_tab_widget->addTab(GetWrappedWidget(new AdvancedPane, this, 125, 200), tr("Advanced"));
 
   // Dialog box buttons
   QDialogButtonBox* close_box = new QDialogButtonBox(QDialogButtonBox::Close);

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -4,12 +4,20 @@
 
 #pragma once
 
+#include <vector>
+
 #include <QWidget>
 
 class QCheckBox;
 class QLabel;
+class QRadioButton;
 class QSlider;
 class QDateTimeEdit;
+
+namespace Core
+{
+enum class State;
+}
 
 class AdvancedPane final : public QWidget
 {
@@ -21,6 +29,7 @@ private:
   void CreateLayout();
   void ConnectLayout();
   void Update();
+  void OnEmulationStateChanged(Core::State state);
 
   QCheckBox* m_cpu_clock_override_checkbox;
   QSlider* m_cpu_clock_override_slider;
@@ -29,4 +38,6 @@ private:
 
   QCheckBox* m_custom_rtc_checkbox;
   QDateTimeEdit* m_custom_rtc_datetime;
+
+  std::vector<QRadioButton*> m_cpu_cores;
 };

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 
 class QCheckBox;
+class QComboBox;
 class QLabel;
 class QRadioButton;
 class QSlider;
@@ -31,6 +32,7 @@ private:
   void Update();
   void OnEmulationStateChanged(Core::State state);
 
+  QComboBox* m_cpu_emulation_engine_combobox;
   QCheckBox* m_cpu_clock_override_checkbox;
   QSlider* m_cpu_clock_override_slider;
   QLabel* m_cpu_clock_override_slider_label;
@@ -38,6 +40,4 @@ private:
 
   QCheckBox* m_custom_rtc_checkbox;
   QDateTimeEdit* m_custom_rtc_datetime;
-
-  std::vector<QRadioButton*> m_cpu_cores;
 };

--- a/Source/Core/DolphinQt/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <vector>
-
 #include <QWidget>
 
 class QCheckBox;
@@ -32,7 +30,6 @@ private:
   void ConnectLayout();
   void CreateBasic();
   void CreateAutoUpdate();
-  void CreateAdvanced();
 
   void LoadConfig();
   void OnSaveConfig();
@@ -50,8 +47,6 @@ private:
   QCheckBox* m_checkbox_discord_presence;
 #endif
   QLabel* m_label_speedlimit;
-
-  std::vector<QRadioButton*> m_cpu_cores;
 
 // Analytics related
 #if defined(USE_ANALYTICS) && USE_ANALYTICS


### PR DESCRIPTION
Solves https://bugs.dolphin-emu.org/issues/11743

I changed the CPU Emulation options to a combobox selection and moved it over to the Advanced tab.