### PR TITLE
Fixing video for EA games like Fifa 07

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1198,7 +1198,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
         out.Write("\ttevcoord.xy = int2(0, 0);\n");
     }
     out.Write("\ttextemp = ");
-    SampleTexture(out, "float2(tevcoord.xy)", texswap, stage.tevorders_texmap, stereo, ApiType);
+    SampleTexture(out, "(float2(tevcoord.xy) + 0.05)", texswap, stage.tevorders_texmap, stereo, ApiType);
   }
   else
   {


### PR DESCRIPTION
This will remove the glitch (something like jailbars) in EA videos (like the opening "EA Sports, it's in the game" in Fifa 07).

Tested in OpenGL renderer.

Discussion: https://bugs.dolphin-emu.org/issues/7193#note-25