### PR TITLE
Core/HW: Fix some explicitly defaulted but implicitly deleted warnings.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -26,8 +26,8 @@ public:
 
   GCMemcardDirectory(const GCMemcardDirectory&) = delete;
   GCMemcardDirectory& operator=(const GCMemcardDirectory&) = delete;
-  GCMemcardDirectory(GCMemcardDirectory&&) = default;
-  GCMemcardDirectory& operator=(GCMemcardDirectory&&) = default;
+  GCMemcardDirectory(GCMemcardDirectory&&) = delete;
+  GCMemcardDirectory& operator=(GCMemcardDirectory&&) = delete;
 
   static std::vector<std::string> GetFileNamesForGameID(const std::string& directory,
                                                         const std::string& game_id);

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -51,8 +51,8 @@ class Wiimote
 public:
   Wiimote(const Wiimote&) = delete;
   Wiimote& operator=(const Wiimote&) = delete;
-  Wiimote(Wiimote&&) = default;
-  Wiimote& operator=(Wiimote&&) = default;
+  Wiimote(Wiimote&&) = delete;
+  Wiimote& operator=(Wiimote&&) = delete;
 
   virtual ~Wiimote() {}
   // This needs to be called in derived destructors!


### PR DESCRIPTION
These classes are not copyable or movable because they indirectly have std::atomic members.
Defaulting their constructors and move operators was producing warnings in clang.