### PR TITLE
DolphinQt: Mark ubershader setting names as translatable

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -110,10 +110,10 @@ void GeneralWidget::CreateWidgets()
   auto* shader_compilation_layout = new QGridLayout();
 
   const std::array<const char*, 4> modes = {{
-      "Synchronous",
-      "Synchronous (Ubershaders)",
-      "Asynchronous (Ubershaders)",
-      "Asynchronous (Skip Drawing)",
+      QT_TR_NOOP("Synchronous"),
+      QT_TR_NOOP("Synchronous (Ubershaders)"),
+      QT_TR_NOOP("Asynchronous (Ubershaders)"),
+      QT_TR_NOOP("Asynchronous (Skip Drawing)"),
   }};
   for (size_t i = 0; i < modes.size(); i++)
   {


### PR DESCRIPTION
These were marked as translatable in DolphinWX but not DolphinQt, yet both DolphinWX and DolphinQt tried to fetch translations for them. This meant that translations worked in both DolphinWX and DolphinQt back when DolphinWX existed, but that translations stopped working in DolphinQt once DolphinWX was removed (because the removal of DolphinWX triggered the removal of the strings from the .po files).