### PR TITLE
StringUtil: Require TryParse of float types to use the entire string.

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -61,7 +61,7 @@ static bool TryParse(const std::string& str, N* const output)
   iss.imbue(std::locale("C"));
 
   N tmp;
-  if (iss >> tmp)
+  if (iss >> tmp && iss.eof())
   {
     *output = tmp;
     return true;


### PR DESCRIPTION
Our `TryParse` for integer types checks `strtoull`'s `endptr` to make sure the entire string is parsed.
Failure is returned for things like "42 " or "123 foobar".

I've changed the `TryParse` overload used for floating point types to check the `eof` flag for the same behavior.
Previously things like "4.5foobar" would successfully parse as a double.