### PR TITLE
InputCommon: Allow controller settings specified with input expresions.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -330,8 +330,7 @@ void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_gr
   auto target_yaw = std::clamp(yaw, -max_yaw, max_yaw);
 
   // Handle the "Recenter" button being pressed.
-  if (imu_ir_group->controls[0]->control_ref->State() >
-      ControllerEmu::Buttons::ACTIVATION_THRESHOLD)
+  if (imu_ir_group->controls[0]->control_ref->GetState<bool>())
   {
     state->recentered_pitch = std::asin((inv_rotation * Common::Vec3{0, 1, 0}).z);
     target_yaw = 0;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -132,11 +132,9 @@ void MappingButton::UpdateIndicator()
   if (!isActiveWindow())
     return;
 
-  const auto state = m_reference->State();
-
   QFont f = m_parent->font();
 
-  if (state > ControllerEmu::Buttons::ACTIVATION_THRESHOLD)
+  if (m_reference->GetState<bool>())
     f.setBold(true);
 
   setFont(f);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -83,6 +83,8 @@ MappingBool::MappingBool(MappingWidget* parent, ControllerEmu::NumericSetting<bo
 
   connect(parent, &MappingWidget::ConfigChanged, this, &MappingBool::ConfigChanged);
   connect(parent, &MappingWidget::Update, this, &MappingBool::Update);
+
+  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Ignored);
 }
 
 void MappingBool::ConfigChanged()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -4,6 +4,8 @@
 
 #include "DolphinQt/Config/Mapping/MappingNumeric.h"
 
+#include <limits>
+
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
@@ -12,13 +14,7 @@
 MappingDouble::MappingDouble(MappingWidget* parent, ControllerEmu::NumericSetting<double>* setting)
     : QDoubleSpinBox(parent), m_setting(*setting)
 {
-  setRange(m_setting.GetMinValue(), m_setting.GetMaxValue());
   setDecimals(2);
-
-  setFixedWidth(WIDGET_MAX_WIDTH);
-
-  if (const auto ui_suffix = m_setting.GetUISuffix())
-    setSuffix(QLatin1Char{' '} + tr(ui_suffix));
 
   if (const auto ui_description = m_setting.GetUIDescription())
     setToolTip(tr(ui_description));
@@ -26,10 +22,12 @@ MappingDouble::MappingDouble(MappingWidget* parent, ControllerEmu::NumericSettin
   connect(this, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
           [this, parent](double value) {
             m_setting.SetValue(value);
+            ConfigChanged();
             parent->SaveSettings();
           });
 
   connect(parent, &MappingWidget::ConfigChanged, this, &MappingDouble::ConfigChanged);
+  connect(parent, &MappingWidget::Update, this, &MappingDouble::Update);
 }
 
 // Overriding QDoubleSpinBox's fixup to set the default value when input is cleared.
@@ -41,6 +39,36 @@ void MappingDouble::fixup(QString& input) const
 void MappingDouble::ConfigChanged()
 {
   const QSignalBlocker blocker(this);
+
+  QString suffix;
+
+  if (const auto ui_suffix = m_setting.GetUISuffix())
+    suffix += QLatin1Char{' '} + tr(ui_suffix);
+
+  if (m_setting.IsSimpleValue())
+  {
+    setRange(m_setting.GetMinValue(), m_setting.GetMaxValue());
+    setButtonSymbols(ButtonSymbols::UpDownArrows);
+  }
+  else
+  {
+    constexpr auto inf = std::numeric_limits<double>::infinity();
+    setRange(-inf, inf);
+    setButtonSymbols(ButtonSymbols::NoButtons);
+    suffix += QString::fromUtf8(" 🎮");
+  }
+
+  setSuffix(suffix);
+
+  setValue(m_setting.GetValue());
+}
+
+void MappingDouble::Update()
+{
+  if (m_setting.IsSimpleValue() || hasFocus())
+    return;
+
+  const QSignalBlocker blocker(this);
   setValue(m_setting.GetValue());
 }
 
@@ -49,14 +77,31 @@ MappingBool::MappingBool(MappingWidget* parent, ControllerEmu::NumericSetting<bo
 {
   connect(this, &QCheckBox::stateChanged, this, [this, parent](int value) {
     m_setting.SetValue(value != 0);
+    ConfigChanged();
     parent->SaveSettings();
   });
 
   connect(parent, &MappingWidget::ConfigChanged, this, &MappingBool::ConfigChanged);
+  connect(parent, &MappingWidget::Update, this, &MappingBool::Update);
 }
 
 void MappingBool::ConfigChanged()
 {
+  const QSignalBlocker blocker(this);
+
+  if (m_setting.IsSimpleValue())
+    setText({});
+  else
+    setText(QString::fromUtf8("🎮"));
+
+  setChecked(m_setting.GetValue());
+}
+
+void MappingBool::Update()
+{
+  if (m_setting.IsSimpleValue())
+    return;
+
   const QSignalBlocker blocker(this);
   setChecked(m_setting.GetValue());
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.h
@@ -21,6 +21,7 @@ private:
   void fixup(QString& input) const override;
 
   void ConfigChanged();
+  void Update();
 
   ControllerEmu::NumericSetting<double>& m_setting;
 };
@@ -32,6 +33,7 @@ public:
 
 private:
   void ConfigChanged();
+  void Update();
 
   ControllerEmu::NumericSetting<bool>& m_setting;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -17,6 +17,7 @@ class InputConfig;
 class MappingButton;
 class MappingNumeric;
 class MappingWindow;
+class QPushButton;
 class QGroupBox;
 
 namespace ControllerEmu
@@ -24,12 +25,8 @@ namespace ControllerEmu
 class Control;
 class ControlGroup;
 class EmulatedController;
+class NumericSettingBase;
 }  // namespace ControllerEmu
-
-namespace ciface::Core
-{
-class Device;
-}  // namespace ciface::Core
 
 constexpr int INDICATOR_UPDATE_FREQ = 30;
 
@@ -56,6 +53,7 @@ protected:
 
   QGroupBox* CreateGroupBox(ControllerEmu::ControlGroup* group);
   QGroupBox* CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group);
+  QPushButton* CreateSettingAdvancedMappingButton(ControllerEmu::NumericSettingBase& setting);
 
 private:
   MappingWindow* m_parent;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -14,7 +14,6 @@ constexpr int WIDGET_MAX_WIDTH = 112;
 
 class ControlGroupBox;
 class InputConfig;
-class IOWindow;
 class MappingButton;
 class MappingNumeric;
 class MappingWindow;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -11,6 +11,7 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QTabWidget>
+#include <QTimer>
 #include <QVBoxLayout>
 
 #include "Core/Core.h"
@@ -62,6 +63,15 @@ MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
   ConnectWidgets();
   SetMappingType(type);
 
+  const auto timer = new QTimer(this);
+  connect(timer, &QTimer::timeout, this, [this] {
+    const auto lock = GetController()->GetStateLock();
+    emit Update();
+  });
+
+  timer->start(1000 / INDICATOR_UPDATE_FREQ);
+
+  GetController()->GetStateLock();
   emit ConfigChanged();
 }
 
@@ -235,6 +245,7 @@ void MappingWindow::OnLoadProfilePressed()
   m_controller->LoadConfig(ini.GetOrCreateSection("Profile"));
   m_controller->UpdateReferences(g_controller_interface);
 
+  GetController()->GetStateLock();
   emit ConfigChanged();
 }
 
@@ -426,6 +437,8 @@ void MappingWindow::OnDefaultFieldsPressed()
 {
   m_controller->LoadDefaults(g_controller_interface);
   m_controller->UpdateReferences(g_controller_interface);
+
+  GetController()->GetStateLock();
   emit ConfigChanged();
   emit Save();
 }
@@ -441,6 +454,8 @@ void MappingWindow::OnClearFieldsPressed()
   m_controller->SetDefaultDevice(default_device);
 
   m_controller->UpdateReferences(g_controller_interface);
+
+  GetController()->GetStateLock();
   emit ConfigChanged();
   emit Save();
 }

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.h
@@ -7,6 +7,7 @@
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 
 class QComboBox;
+class QLabel;
 class WiimoteEmuExtension;
 
 class WiimoteEmuGeneral final : public MappingWidget
@@ -21,12 +22,19 @@ private:
   void LoadSettings() override;
   void SaveSettings() override;
   void CreateMainLayout();
-  void Connect(MappingWindow* window);
+  void Connect();
+
+  // Index changed by code/expression.
   void OnAttachmentChanged(int index);
+  // Selection chosen by user.
+  void OnAttachmentSelected(int index);
+
   void ConfigChanged();
+  void Update();
 
   // Extensions
   QComboBox* m_extension_combo;
+  QLabel* m_extension_combo_dynamic_indicator;
 
   WiimoteEmuExtension* m_extension_widget;
 };

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "InputCommon/ControlReference/ExpressionParser.h"
+#include "InputCommon/ControlReference/FunctionExpression.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 // ControlReference
@@ -30,6 +31,9 @@ public:
   virtual ControlState State(const ControlState state = 0) = 0;
   virtual bool IsInput() const = 0;
 
+  template <typename T>
+  T GetState();
+
   int BoundCount() const;
   ciface::ExpressionParser::ParseStatus GetParseStatus() const;
   void UpdateReference(ciface::ExpressionParser::ControlEnvironment& env);
@@ -44,6 +48,18 @@ protected:
   std::unique_ptr<ciface::ExpressionParser::Expression> m_parsed_expression;
   ciface::ExpressionParser::ParseStatus m_parse_status;
 };
+
+template <>
+inline bool ControlReference::GetState<bool>()
+{
+  return State() > ciface::ExpressionParser::CONDITION_THRESHOLD;
+}
+
+template <typename T>
+T ControlReference::GetState()
+{
+  return State();
+}
 
 //
 // InputReference

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -10,8 +10,6 @@
 
 namespace ciface::ExpressionParser
 {
-constexpr ControlState CONDITION_THRESHOLD = 0.5;
-
 using Clock = std::chrono::steady_clock;
 using FSec = std::chrono::duration<ControlState>;
 

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.h
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.h
@@ -15,6 +15,8 @@
 
 namespace ciface::ExpressionParser
 {
+constexpr ControlState CONDITION_THRESHOLD = 0.5;
+
 class FunctionExpression : public Expression
 {
 public:

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
@@ -17,12 +17,22 @@ void Attachments::AddAttachment(std::unique_ptr<EmulatedController> att)
 
 u32 Attachments::GetSelectedAttachment() const
 {
-  return m_selected_attachment;
+  const u32 value = m_selection_value.GetValue();
+
+  if (value < m_attachments.size())
+    return value;
+
+  return 0;
 }
 
 void Attachments::SetSelectedAttachment(u32 val)
 {
-  m_selected_attachment = val;
+  m_selection_setting.SetValue(val);
+}
+
+NumericSetting<int>& Attachments::GetSelectionSetting()
+{
+  return m_selection_setting;
 }
 
 const std::vector<std::unique_ptr<EmulatedController>>& Attachments::GetAttachmentList() const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.h
@@ -12,6 +12,7 @@
 #include "Common/CommonTypes.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {
@@ -27,11 +28,14 @@ public:
   u32 GetSelectedAttachment() const;
   void SetSelectedAttachment(u32 val);
 
+  NumericSetting<int>& GetSelectionSetting();
+
   const std::vector<std::unique_ptr<EmulatedController>>& GetAttachmentList() const;
 
 private:
-  std::vector<std::unique_ptr<EmulatedController>> m_attachments;
+  SettingValue<int> m_selection_value;
+  NumericSetting<int> m_selection_setting = {&m_selection_value, {""}, 0, 0, 0};
 
-  std::atomic<u32> m_selected_attachment = {};
+  std::vector<std::unique_ptr<EmulatedController>> m_attachments;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.h
@@ -24,13 +24,11 @@ public:
   {
     for (auto& control : controls)
     {
-      if (control->control_ref->State() > ACTIVATION_THRESHOLD)
+      if (control->control_ref->GetState<bool>())
         *buttons |= *bitmasks;
 
       bitmasks++;
     }
   }
-
-  static constexpr ControlState ACTIVATION_THRESHOLD = 0.5;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
@@ -35,19 +35,19 @@ void ModifySettingsButton::GetState()
 {
   for (size_t i = 0; i < controls.size(); ++i)
   {
-    ControlState state = controls[i]->control_ref->State();
+    const bool state = controls[i]->control_ref->GetState<bool>();
 
     if (!associated_settings_toggle[i])
     {
       // not toggled
-      associated_settings[i] = state > ACTIVATION_THRESHOLD;
+      associated_settings[i] = state;
     }
     else
     {
       // toggle (loading savestates does not en-/disable toggle)
       // after we passed the threshold, we en-/disable. but after that, we don't change it
       // anymore
-      if (!threshold_exceeded[i] && state > ACTIVATION_THRESHOLD)
+      if (!threshold_exceeded[i] && state)
       {
         associated_settings[i] = !associated_settings[i];
 
@@ -59,7 +59,7 @@ void ModifySettingsButton::GetState()
         threshold_exceeded[i] = true;
       }
 
-      if (state < ACTIVATION_THRESHOLD)
+      if (!state)
         threshold_exceeded[i] = false;
     }
   }

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -61,7 +61,11 @@ void EmulatedController::UpdateReferences(ciface::ExpressionParser::ControlEnvir
     // Attachments:
     if (ctrlGroup->type == GroupType::Attachments)
     {
-      for (auto& attachment : static_cast<Attachments*>(ctrlGroup.get())->GetAttachmentList())
+      auto* const attachments = static_cast<Attachments*>(ctrlGroup.get());
+
+      attachments->GetSelectionSetting().GetInputReference().UpdateReference(env);
+
+      for (auto& attachment : attachments->GetAttachmentList())
         attachment->UpdateReferences(env);
     }
   }

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -14,6 +14,7 @@
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace ControllerEmu
@@ -53,6 +54,9 @@ void EmulatedController::UpdateReferences(ciface::ExpressionParser::ControlEnvir
   {
     for (auto& control : ctrlGroup->controls)
       control->control_ref->UpdateReference(env);
+
+    for (auto& setting : ctrlGroup->numeric_settings)
+      setting->GetInputReference().UpdateReference(env);
 
     // Attachments:
     if (ctrlGroup->type == GroupType::Attachments)

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
@@ -4,6 +4,8 @@
 
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
+#include <sstream>
+
 namespace ControllerEmu
 {
 NumericSettingBase::NumericSettingBase(const NumericSettingDetails& details) : m_details(details)
@@ -23,6 +25,36 @@ const char* NumericSettingBase::GetUISuffix() const
 const char* NumericSettingBase::GetUIDescription() const
 {
   return m_details.ui_description;
+}
+
+template <>
+void NumericSetting<int>::SetExpressionFromValue()
+{
+  m_value.m_input.SetExpression(ValueToString(GetValue()));
+}
+
+template <>
+void NumericSetting<double>::SetExpressionFromValue()
+{
+  // We must use a dot decimal separator for expression parser.
+  std::ostringstream ss;
+  ss.imbue(std::locale::classic());
+  ss << GetValue();
+
+  m_value.m_input.SetExpression(ss.str());
+}
+
+template <>
+void NumericSetting<bool>::SetExpressionFromValue()
+{
+  // Cast bool to prevent "true"/"false" strings.
+  m_value.m_input.SetExpression(ValueToString(int(GetValue())));
+}
+
+template <>
+SettingType NumericSetting<int>::GetType() const
+{
+  return SettingType::Int;
 }
 
 template <>

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -9,6 +9,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
+#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
@@ -52,6 +53,15 @@ public:
   virtual void LoadFromIni(const IniFile::Section& section, const std::string& group_name) = 0;
   virtual void SaveToIni(IniFile::Section& section, const std::string& group_name) const = 0;
 
+  virtual InputReference& GetInputReference() = 0;
+  virtual const InputReference& GetInputReference() const = 0;
+
+  // Convert a literal expression e.g. "7.0" to a regular value. (disables expression parsing)
+  virtual void SimplifyIfPossible() = 0;
+
+  // Convert a regular value to an expression. (used before expression editing)
+  virtual void SetExpressionFromValue() = 0;
+
   virtual SettingType GetType() const = 0;
 
   const char* GetUIName() const;
@@ -84,15 +94,46 @@ public:
 
   void LoadFromIni(const IniFile::Section& section, const std::string& group_name) override
   {
-    ValueType value;
-    section.Get(group_name + m_details.ini_name, &value, m_default_value);
-    SetValue(value);
+    std::string str_value;
+    if (section.Get(group_name + m_details.ini_name, &str_value))
+    {
+      m_value.m_input.SetExpression(std::move(str_value));
+      SimplifyIfPossible();
+    }
+    else
+    {
+      SetValue(m_default_value);
+    }
   }
 
   void SaveToIni(IniFile::Section& section, const std::string& group_name) const override
   {
-    section.Set(group_name + m_details.ini_name, GetValue(), m_default_value);
+    if (IsSimpleValue())
+      section.Set(group_name + m_details.ini_name, GetValue(), m_default_value);
+    else
+      section.Set(group_name + m_details.ini_name, m_value.m_input.GetExpression(), "");
   }
+
+  bool IsSimpleValue() const { return m_value.IsSimpleValue(); }
+
+  void SimplifyIfPossible() override
+  {
+    ValueType value;
+    if (TryParse(m_value.m_input.GetExpression(), &value))
+      m_value.SetValue(value);
+  }
+
+  void SetExpressionFromValue() override
+  {
+    if (!IsSimpleValue())
+      return;
+
+    // Cast to double to prevent bool -> "true"/"false" strings.
+    m_value.m_input.SetExpression(ValueToString(static_cast<double>(GetValue())));
+  }
+
+  InputReference& GetInputReference() override { return m_value.m_input; }
+  const InputReference& GetInputReference() const override { return m_value.m_input; }
 
   ValueType GetValue() const { return m_value.GetValue(); }
   void SetValue(ValueType value) { m_value.SetValue(value); }
@@ -119,13 +160,30 @@ class SettingValue
   friend class NumericSetting<T>;
 
 public:
-  ValueType GetValue() const { return m_value; }
+  ValueType GetValue() const
+  {
+    if (IsSimpleValue())
+      return m_value;
+    else
+      return m_input.GetState<ValueType>();
+  }
+
+  bool IsSimpleValue() const { return m_input.GetExpression().empty(); }
 
 private:
-  void SetValue(ValueType value) { m_value = value; }
+  void SetValue(ValueType value)
+  {
+    m_value = value;
+
+    // Clear the expression to use our new "simple" value.
+    m_input.SetExpression("");
+  }
 
   // Values are R/W by both UI and CPU threads.
   std::atomic<ValueType> m_value = {};
+
+  // Unfortunately InputReference's state grabbing is non-const requiring mutable here.
+  mutable InputReference m_input;
 };
 
 }  // namespace ControllerEmu


### PR DESCRIPTION
I've added the ability for input expressions to be used for the values of controller settings.
This is an extension of functionality. Existing configurations remain valid.

A common use would be a button that adjusts the speed of emulated Wii Remote Tilt/Swing but the possibilities are as endless as our button mappings.

With the new `toggle()` function added in PR #7663 this provides a generic solution to the sideways/upright hotkeys and the "Relative Input Hold" mapping.
I plan on removing these in another PR with backwards compatibility by adapting them into these new "setting expressions".

Demonstration:
https://giant.gfycat.com/CompassionateAlienatedBobolink.webm
(controller icon has since been moved to the right of the spin-button text)

A button to the right of each setting opens the familiar advanced mapping dialog.
When an expression is in use the spin-button/checkbox is updated with the other indicators and a controller symbol is shown to signify the setting has a dynamic value, potentially supplied by user input.
Directly entering a value or checking a box will remove/disable an expression.

Edit: Rebase and added ability to set Wii remote extension with an input expression. This will be useful to "pass through" the attached extension with "Real Wii Remotes in Controller Interface".