### PR TITLE
ExpressionParser: Add XOR operator.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -234,6 +234,7 @@ void IOWindow::CreateMainLayout()
     m_operators_combo->addItem(tr("> Greater-than"));
     m_operators_combo->addItem(tr("< Less-than"));
     m_operators_combo->addItem(tr("& And"));
+    m_operators_combo->addItem(tr("^ Xor"));
   }
   m_operators_combo->addItem(tr("| Or"));
   if (m_type == Type::Input)

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -136,6 +136,8 @@ Token Lexer::NextToken()
     return Token(TOK_GTHAN);
   case ',':
     return Token(TOK_COMMA);
+  case '^':
+    return Token(TOK_XOR);
   case '\'':
     return GetDelimitedLiteral();
   case '$':
@@ -277,6 +279,12 @@ public:
       // Eval and discard lhs:
       lhs->GetValue();
       return rhs->GetValue();
+    }
+    case TOK_XOR:
+    {
+      const auto lval = lhs->GetValue();
+      const auto rval = rhs->GetValue();
+      return std::max(std::min(1 - lval, rval), std::min(lval, 1 - rval));
     }
     default:
       assert(false);
@@ -621,12 +629,14 @@ private:
       return 3;
     case TOK_AND:
       return 4;
-    case TOK_OR:
+    case TOK_XOR:
       return 5;
-    case TOK_ASSIGN:
+    case TOK_OR:
       return 6;
-    case TOK_COMMA:
+    case TOK_ASSIGN:
       return 7;
+    case TOK_COMMA:
+      return 8;
     default:
       assert(false);
       return 0;

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -39,6 +39,7 @@ enum TokenType
   TOK_LTHAN,
   TOK_GTHAN,
   TOK_COMMA,
+  TOK_XOR,
   TOK_BINARY_OPS_END,
 };
 


### PR DESCRIPTION
This adds support for the XOR operator `^` in input expressions.

While it might seem esoteric I often find myself needing it for things like:
``toggle(`Q`) ^ `E` ``
...where pressing `Q` toggles some action and holding `E` negates the state of the toggle.