### PR TITLE
EmulationActivity: Disable fullscreen immersive after pressing back

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -381,7 +381,12 @@ public final class EmulationActivity extends AppCompatActivity
       {
         backPressedOnce = true;
         Toast.makeText(this, "Press back again to exit", Toast.LENGTH_LONG).show();
-        new Handler().postDelayed(() -> backPressedOnce = false, 3000);
+        disableFullscreenImmersive();
+        new Handler().postDelayed(() ->
+        {
+          enableFullscreenImmersive();
+          backPressedOnce = false;
+        }, 3000);
       }
     }
   }
@@ -414,6 +419,16 @@ public final class EmulationActivity extends AppCompatActivity
                     View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
                     View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
                     View.SYSTEM_UI_FLAG_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_IMMERSIVE);
+  }
+
+  private void disableFullscreenImmersive()
+  {
+    mDecorView.setSystemUiVisibility(
+            View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
                     View.SYSTEM_UI_FLAG_IMMERSIVE);
   }
 


### PR DESCRIPTION
On Chromebook when in fullscreen immersive I can't open the toolbar.
I'm not sure if I swipe wrong or something but in any case it's not intuitive.
Showing toolbar when pressing back solves te problem neatly