### PR TITLE
Qt/GCMemcardManager: Fix incorrect placeholder frame timing.

### DIFF
--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -535,7 +535,7 @@ GCMemcardManager::IconAnimationData GCMemcardManager::GetIconFromSaveFile(int fi
   {
     // No Animation found, use an empty placeholder instead.
     frame_data.m_frames.emplace_back();
-    frame_data.m_frame_timing.push_back(1);
+    frame_data.m_frame_timing.push_back(0);
   }
 
   return frame_data;


### PR DESCRIPTION
Small thing I messed up in #8304; this then leads to an out-of-bounds error when drawing the blank icon. In practice this almost never happens because all official save files have icons, but might as well fix this.