### PR TITLE
Create necessary folder when using Redump.org integration

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -824,6 +824,7 @@ static void RebuildUserDirectories(unsigned int dir_index)
 
   case D_CACHE_IDX:
     s_user_paths[D_COVERCACHE_IDX] = s_user_paths[D_CACHE_IDX] + COVERCACHE_DIR DIR_SEP;
+    s_user_paths[D_REDUMPCACHE_IDX] = s_user_paths[D_CACHE_IDX] + REDUMPCACHE_DIR DIR_SEP;
     s_user_paths[D_SHADERCACHE_IDX] = s_user_paths[D_CACHE_IDX] + SHADERCACHE_DIR DIR_SEP;
     break;
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -153,7 +153,9 @@ RedumpVerifier::DownloadStatus RedumpVerifier::DownloadDatfile(const std::string
     return system_not_available_match ? DownloadStatus::SystemNotAvailable : DownloadStatus::Fail;
   }
 
-  File::IOFile(output_path, "wb").WriteBytes(result->data(), result->size());
+  File::CreateFullPath(output_path);
+  if (!File::IOFile(output_path, "wb").WriteBytes(result->data(), result->size()))
+    ERROR_LOG(DISCIO, "Failed to write downloaded datfile to %s", output_path.c_str());
   return DownloadStatus::Success;
 }
 


### PR DESCRIPTION
This was making it impossible to use the Redump.org integration without first manually creating a Redump folder in the Cache folder. https://bugs.dolphin-emu.org/issues/11885