### PR TITLE
Qt: Add "renderer" window role to render window

### DIFF
--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -40,6 +40,7 @@ RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
 {
   setWindowTitle(QStringLiteral("Dolphin"));
   setWindowIcon(Resources::GetAppIcon());
+  setWindowRole(QStringLiteral("renderer"));
   setAcceptDrops(true);
 
   QPalette p;


### PR DESCRIPTION
Under KDE, there's not really a good way to turn the desktop compositor off while a game is running in Dolphin. However, KWin (and most likely other window managers) can be configured to turn the compositor off when it sees a window with a certain window role (a string that can be attached to a window in X11). This 1-line change uses QWidget::setWindowRole to set the role of the render window to "renderer" on initialisation so the window manager can match it to a rule and is (I think) a non-op on other platforms (I don't know if it sets the app_id on Wayland though). I'm also trying to find a way to see if compositing can be blocked automatically, but I'm not sure it can be done without linking to another library (either dbus or libkf5windowsystem).