### PR TITLE
DolphinQt: Make HotkeyScheduler call UpdateInput when hotkeys are disabled.

### DIFF
--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -134,11 +134,11 @@ void HotkeyScheduler::Run()
   {
     Common::SleepCurrentThread(1000 / 60);
 
-    if (!HotkeyManagerEmu::IsEnabled())
-      continue;
-
     if (Core::GetState() == Core::State::Uninitialized || Core::GetState() == Core::State::Paused)
       g_controller_interface.UpdateInput();
+
+    if (!HotkeyManagerEmu::IsEnabled())
+      continue;
 
     if (Core::GetState() != Core::State::Stopping)
     {


### PR DESCRIPTION
When emulation is not running our controller interface is updated by the hotkey scheduler.

A filter is installed to prevent hotkeys from triggering when configuring them.
This was preventing the mapping buttons from showing their activation by turning bold.

`UpdateInput` is now called before checking if hotkeys are filtered.

Fixes: https://bugs.dolphin-emu.org/issues/11835