### PR TITLE
DolphinQt: Call OnEmulationStateChanged when creating config window panes

### DIFF
--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -39,14 +39,7 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   m_tab_widget->addTab(GetWrappedWidget(new AudioPane, this, 125, 100), tr("Audio"));
   m_tab_widget->addTab(GetWrappedWidget(new PathPane, this, 125, 100), tr("Paths"));
   m_tab_widget->addTab(GetWrappedWidget(new GameCubePane, this, 125, 100), tr("GameCube"));
-
-  auto* wii_pane = new WiiPane;
-  m_tab_widget->addTab(GetWrappedWidget(wii_pane, this, 125, 100), tr("Wii"));
-
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, [wii_pane](Core::State state) {
-    wii_pane->OnEmulationStateChanged(state != Core::State::Uninitialized);
-  });
-
+  m_tab_widget->addTab(GetWrappedWidget(new WiiPane, this, 125, 100), tr("Wii"));
   m_tab_widget->addTab(GetWrappedWidget(new AdvancedPane, this, 125, 200), tr("Advanced"));
 
   // Dialog box buttons

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -37,6 +37,8 @@ AudioPane::AudioPane()
   connect(&Settings::Instance(), &Settings::VolumeChanged, this, &AudioPane::OnVolumeChanged);
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           [=](Core::State state) { OnEmulationStateChanged(state != Core::State::Uninitialized); });
+
+  OnEmulationStateChanged(Core::GetState() != Core::State::Uninitialized);
 }
 
 void AudioPane::CreateWidgets()

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -50,6 +50,8 @@ GeneralPane::GeneralPane(QWidget* parent) : QWidget(parent)
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           &GeneralPane::OnEmulationStateChanged);
+
+  OnEmulationStateChanged(Core::GetState());
 }
 
 void GeneralPane::CreateLayout()

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -48,6 +48,7 @@ WiiPane::WiiPane(QWidget* parent) : QWidget(parent)
   LoadConfig();
   ConnectLayout();
   ValidateSelectionState();
+  OnEmulationStateChanged(Core::GetState() != Core::State::Uninitialized);
 }
 
 void WiiPane::CreateLayout()

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -93,6 +93,10 @@ void WiiPane::ConnectLayout()
   connect(m_wiimote_ir_sensitivity, &QSlider::valueChanged, this, &WiiPane::OnSaveConfig);
   connect(m_wiimote_speaker_volume, &QSlider::valueChanged, this, &WiiPane::OnSaveConfig);
   connect(m_wiimote_motor, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
+
+  // Emulation State
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged,
+          [=](Core::State state) { OnEmulationStateChanged(state != Core::State::Uninitialized); });
 }
 
 void WiiPane::CreateMisc()

--- a/Source/Core/DolphinQt/Settings/WiiPane.h
+++ b/Source/Core/DolphinQt/Settings/WiiPane.h
@@ -19,7 +19,6 @@ class WiiPane : public QWidget
   Q_OBJECT
 public:
   explicit WiiPane(QWidget* parent = nullptr);
-  void OnEmulationStateChanged(bool running);
 
 private:
   void PopulateUSBPassthroughListWidget();
@@ -31,6 +30,7 @@ private:
 
   void LoadConfig();
   void OnSaveConfig();
+  void OnEmulationStateChanged(bool running);
 
   void ValidateSelectionState();
 


### PR DESCRIPTION
Otherwise UI elements won't be disabled correctly if the config window is first opened while a game is running.