### PR TITLE
DolphinQt: Fix qt.qpa.plugin on MacOS

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -427,6 +427,11 @@ if(APPLE)
   # Update library references to make the bundle portable
   include(DolphinPostprocessBundle)
   dolphin_postprocess_bundle(dolphin-emu)
+  # Fix rpath
+  add_custom_command(TARGET dolphin-emu 
+    POST_BUILD COMMAND 
+    ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/../Frameworks/"
+    $<TARGET_FILE:dolphin-emu>)
 else()
   install(TARGETS dolphin-emu RUNTIME DESTINATION ${bindir})
 endif()


### PR DESCRIPTION
Got error after successful build using CMake on Mac OSX High Sierra. Qt5 was installed using Qt Online Installer for macOS.

The error message when running Dolphin:
```
qt.qpa.plugin: Could not load the Qt platform plugin "cocoa" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```
Available platform plugins are: cocoa.
After inspecting with otool the problem was the **@rpath** or
`LC_RPATH` which not set on the Dolphin executable (target **dolphin-emu**) which needed by `libqcocoa.dylib`.