### PR TITLE
VideoInterface: Don't crash when running Wii Freeloader

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -666,7 +666,9 @@ static void LogField(FieldType field, u32 xfb_address)
 static void BeginField(FieldType field, u64 ticks)
 {
   // Could we fit a second line of data in the stride?
+  // (Datel's Wii FreeLoaders are the only titles known to set WPL to 0)
   bool potentially_interlaced_xfb =
+      m_PictureConfiguration.WPL != 0 &&
       ((m_PictureConfiguration.STD / m_PictureConfiguration.WPL) == 2);
   // Are there an odd number of half-lines per field (definition of interlaced video)
   bool interlaced_video_mode = (GetHalfLinesPerEvenField() & 1) == 1;


### PR DESCRIPTION
Datel's Wii Freeloaders set `m_PictureConfiguration.WPL` to 0 for a while. Not sure if the fix in this commit is a proper fix or just a hack, since I'm not very familiar with this code.

With this change, it's possible to run a Wii Freeloader if you are running an old enough version of the Wii Menu, but the "coloured bars" that Datel reference in their documentation never show up. The screen just freezes for a few seconds instead.