### PR TITLE
Motion Input enhancements

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -325,6 +325,12 @@ void EmulateIMUCursor(std::optional<RotationalState>* state, ControllerEmu::IMUC
   // Avoid having to double dereference
   auto& st = *state;
 
+  if (!imu_ir_group->enabled)
+  {
+    st = std::nullopt;
+    return;
+  }
+
   auto accel = imu_accelerometer_group->GetState();
   auto ang_vel = imu_gyroscope_group->GetState();
 

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
@@ -29,10 +29,12 @@ void DualShockUDPClientWidget::CreateWidgets()
 
   m_server_address = new QLineEdit(
       QString::fromStdString(Config::Get(ciface::DualShockUDPClient::Settings::SERVER_ADDRESS)));
+  m_server_address->setEnabled(m_server_enabled->isChecked());
 
   m_server_port = new QSpinBox();
   m_server_port->setMaximum(65535);
   m_server_port->setValue(Config::Get(ciface::DualShockUDPClient::Settings::SERVER_PORT));
+  m_server_port->setEnabled(m_server_enabled->isChecked());
 
   auto* description =
       new QLabel(tr("DSU protocol enables the use of input and motion data from compatible "
@@ -58,8 +60,10 @@ void DualShockUDPClientWidget::CreateWidgets()
 void DualShockUDPClientWidget::ConnectWidgets()
 {
   connect(m_server_enabled, &QCheckBox::toggled, this, [this] {
-    Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVER_ENABLED,
-                             m_server_enabled->isChecked());
+    bool checked = m_server_enabled->isChecked();
+    Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVER_ENABLED, checked);
+    m_server_address->setEnabled(checked);
+    m_server_port->setEnabled(checked);
   });
 
   connect(m_server_address, &QLineEdit::editingFinished, this, [this] {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -4,8 +4,10 @@
 
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 
+#include <QCheckBox>
 #include <QFormLayout>
 #include <QGroupBox>
+#include <QLabel>
 #include <QPushButton>
 #include <QTimer>
 
@@ -136,6 +138,28 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
 
     if (setting_widget)
       form_layout->addRow(tr(setting->GetUIName()), setting_widget);
+  }
+
+  if (group->can_be_disabled)
+  {
+    QLabel* group_enable_label = new QLabel(tr("Enable"));
+    QCheckBox* group_enable_checkbox = new QCheckBox();
+    group_enable_checkbox->setChecked(group->enabled);
+    form_layout->insertRow(0, group_enable_label, group_enable_checkbox);
+    auto enable_group_by_checkbox = [group, form_layout, group_enable_label,
+                                     group_enable_checkbox] {
+      group->enabled = group_enable_checkbox->isChecked();
+      for (int i = 0; i < form_layout->count(); ++i)
+      {
+        QWidget* widget = form_layout->itemAt(i)->widget();
+        if (widget != nullptr && widget != group_enable_label && widget != group_enable_checkbox)
+          widget->setEnabled(group->enabled);
+      }
+    };
+    enable_group_by_checkbox();
+    connect(group_enable_checkbox, &QCheckBox::toggled, this, enable_group_by_checkbox);
+    connect(this, &MappingWidget::ConfigChanged, this,
+            [group_enable_checkbox, group] { group_enable_checkbox->setChecked(group->enabled); });
   }
 
   return group_box;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -15,13 +15,16 @@
 
 namespace ControllerEmu
 {
-ControlGroup::ControlGroup(std::string name_, const GroupType type_)
-    : name(name_), ui_name(std::move(name_)), type(type_)
+ControlGroup::ControlGroup(std::string name_, const GroupType type_, CanBeDisabled can_be_disabled_)
+    : name(name_), ui_name(std::move(name_)), type(type_),
+      can_be_disabled(can_be_disabled_ == CanBeDisabled::Yes)
 {
 }
 
-ControlGroup::ControlGroup(std::string name_, std::string ui_name_, const GroupType type_)
-    : name(std::move(name_)), ui_name(std::move(ui_name_)), type(type_)
+ControlGroup::ControlGroup(std::string name_, std::string ui_name_, const GroupType type_,
+                           CanBeDisabled can_be_disabled_)
+    : name(std::move(name_)), ui_name(std::move(ui_name_)), type(type_),
+      can_be_disabled(can_be_disabled_ == CanBeDisabled::Yes)
 {
 }
 
@@ -42,6 +45,10 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
                               const std::string& base)
 {
   const std::string group(base + name + "/");
+
+  // enabled
+  if (can_be_disabled)
+    sec->Get(group + "Enabled", &enabled, true);
 
   for (auto& setting : numeric_settings)
     setting->LoadFromIni(*sec, group);
@@ -87,6 +94,9 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
                               const std::string& base)
 {
   const std::string group(base + name + "/");
+
+  // enabled
+  sec->Set(group + "Enabled", enabled, true);
 
   for (auto& setting : numeric_settings)
     setting->SaveToIni(*sec, group);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -48,8 +48,16 @@ enum class GroupType
 class ControlGroup
 {
 public:
-  explicit ControlGroup(std::string name, GroupType type = GroupType::Other);
-  ControlGroup(std::string name, std::string ui_name, GroupType type = GroupType::Other);
+  enum class CanBeDisabled
+  {
+    No,
+    Yes,
+  };
+
+  explicit ControlGroup(std::string name, GroupType type = GroupType::Other,
+                        CanBeDisabled can_be_disabled = CanBeDisabled::No);
+  ControlGroup(std::string name, std::string ui_name, GroupType type = GroupType::Other,
+               CanBeDisabled can_be_disabled = CanBeDisabled::No);
   virtual ~ControlGroup();
 
   virtual void LoadConfig(IniFile::Section* sec, const std::string& defdev = "",
@@ -79,7 +87,9 @@ public:
   const std::string name;
   const std::string ui_name;
   const GroupType type;
+  const bool can_be_disabled;
 
+  bool enabled = true;
   std::vector<std::unique_ptr<Control>> controls;
   std::vector<std::unique_ptr<NumericSettingBase>> numeric_settings;
 };

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -18,7 +18,8 @@
 namespace ControllerEmu
 {
 IMUCursor::IMUCursor(std::string name, std::string ui_name)
-    : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUCursor)
+    : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUCursor,
+                   ControlGroup::CanBeDisabled::Yes)
 {
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
 


### PR DESCRIPTION
Small enhancements to PR #8352.

#### Motion Input tab
- ~Apply default accelerometer and gyroscope bindings (as shown) when loading an old input configuration.
**Reason:** If there exists a `WiimoteNew.ini` from an older Dolphin version, those bindings will be blank, and motion input won't work. You would have to either manually set each of the 12 controls (which is not hard, just time consuming) or press the `Default` button and lose all other bindings.
**Details:** This was accomplished by adding versioning to input config files, including input profiles.~
- Add checkbox for enabling/disabling the motion controlled pointer. This is useful if you want to control the pointer by other means, like a mouse or the DualShock 4's touch pad. 

![2019-11-01 03_38_00-vs2017 (1) - Remote Viewer - Copy](https://user-images.githubusercontent.com/47765059/67999038-f5a50680-fc5a-11e9-80a0-b89a17fb80e5.png)

#### DSU Client config
- Enable `Server IP Address` and `Server Port` fields only when `Enable` is checked.

![2019-10-29 21_39_37-vs2017 (1) - Remote Viewer](https://user-images.githubusercontent.com/47765059/67809030-36085700-fa98-11e9-94f8-e01402f56e62.png)
