### PR TITLE
Fix versionCode dummy value

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -123,5 +123,5 @@ def getBuildVersionCode() {
         logger.error('Cannot find git, defaulting to dummy version number')
     }
 
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
When `git` isn't installed to the terminal the `getVersion()` and `getBuildVersionCode()` will use dummy values.

The problem is the dummy value for `getBuildVersionCode()` causes gradle to complain with the following error.
```
ERROR: android.defaultConfig.versionCode is set to 0, but it should be a positive integer.
See https://developer.android.com/studio/publish/versioning#appversioning for more information.
Affected Modules: app
```

Changed the dummy versionCode number to 1.