### PR TITLE
Add /dev/dolphin for homebrew to get information about Dolphin

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -212,6 +212,11 @@ void ConfigCache::RestoreConfig(SConfig* config)
 
 static ConfigCache config_cache;
 
+void SetEmulationSpeedReset(bool value)
+{
+  config_cache.bSetEmulationSpeed = value;
+}
+
 static GPUDeterminismMode ParseGPUDeterminismMode(const std::string& mode)
 {
   if (mode == "auto")

--- a/Source/Core/Core/BootManager.h
+++ b/Source/Core/Core/BootManager.h
@@ -12,6 +12,7 @@ struct WindowSystemInfo;
 namespace BootManager
 {
 bool BootCore(std::unique_ptr<BootParameters> parameters, const WindowSystemInfo& wsi);
+void SetEmulationSpeedReset(bool value);
 
 // Synchronise Dolphin's configuration with the SYSCONF (which may have changed during emulation),
 // and restore settings that were overriden by per-game INIs or for some other reason.

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -320,6 +320,8 @@ add_library(core
   IOS/Device.h
   IOS/DeviceStub.cpp
   IOS/DeviceStub.h
+  IOS/DolphinDevice.cpp
+  IOS/DolphinDevice.h
   IOS/IOS.cpp
   IOS/IOS.h
   IOS/IOSC.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -197,6 +197,7 @@
     <ClCompile Include="HW\WiiSave.cpp" />
     <ClCompile Include="IOS\Device.cpp" />
     <ClCompile Include="IOS\DeviceStub.cpp" />
+    <ClCompile Include="IOS\DolphinDevice.cpp" />
     <ClCompile Include="IOS\IOS.cpp" />
     <ClCompile Include="IOS\IOSC.cpp" />
     <ClCompile Include="IOS\MIOS.cpp" />
@@ -473,6 +474,7 @@
     <ClInclude Include="HW\WII_IPC.h" />
     <ClInclude Include="IOS\Device.h" />
     <ClInclude Include="IOS\DeviceStub.h" />
+    <ClInclude Include="IOS\DolphinDevice.h" />
     <ClInclude Include="IOS\IOS.h" />
     <ClInclude Include="IOS\IOSC.h" />
     <ClInclude Include="IOS\MIOS.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -707,6 +707,9 @@
     <ClCompile Include="IOS\DeviceStub.cpp">
       <Filter>IOS</Filter>
     </ClCompile>
+    <ClCompile Include="IOS\DolphinDevice.cpp">
+      <Filter>IOS</Filter>
+    </ClCompile>
     <ClCompile Include="IOS\DI\DI.cpp">
       <Filter>IOS\DI</Filter>
     </ClCompile>
@@ -1433,6 +1436,9 @@
       <Filter>IOS\USB\Bluetooth</Filter>
     </ClInclude>
     <ClInclude Include="IOS\DeviceStub.h">
+      <Filter>IOS</Filter>
+    </ClInclude>
+    <ClInclude Include="IOS\DolphinDevice.h">
       <Filter>IOS</Filter>
     </ClInclude>
     <ClInclude Include="IOS\DI\DI.h">

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -1,0 +1,151 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <cstring>
+
+#include "Common/Logging/Log.h"
+#include "Common/Timer.h"
+#include "Common/scmrev.h"
+#include "Core/BootManager.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/HW/Memmap.h"
+#include "Core/IOS/DolphinDevice.h"
+
+namespace IOS::HLE::Device
+{
+namespace
+{
+enum
+{
+  IOCTL_DOLPHIN_GET_SYSTEM_TIME = 0x01,
+  IOCTL_DOLPHIN_GET_VERSION = 0x02,
+  IOCTL_DOLPHIN_GET_SPEED_LIMIT = 0x03,
+  IOCTL_DOLPHIN_SET_SPEED_LIMIT = 0x04,
+  IOCTL_DOLPHIN_GET_CPU_SPEED = 0x05,
+
+};
+
+IPCCommandResult GetSystemTime(const IOCtlVRequest& request)
+{
+  if (!request.HasNumberOfValidVectors(0, 1))
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  if (request.io_vectors[0].size != 4)
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  const u32 milliseconds = Common::Timer::GetTimeMs();
+
+  Memory::Write_U32(milliseconds, request.io_vectors[0].address);
+  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+}
+
+IPCCommandResult GetVersion(const IOCtlVRequest& request)
+{
+  if (!request.HasNumberOfValidVectors(0, 1))
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  const auto length = std::min(size_t(request.io_vectors[0].size), std::strlen(SCM_DESC_STR));
+
+  Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
+  Memory::CopyToEmu(request.io_vectors[0].address, SCM_DESC_STR, length);
+
+  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+}
+
+IPCCommandResult GetCPUSpeed(const IOCtlVRequest& request)
+{
+  if (!request.HasNumberOfValidVectors(0, 1))
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  if (request.io_vectors[0].size != 4)
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  const SConfig& config = SConfig::GetInstance();
+  const float oc = config.m_OCEnable ? config.m_OCFactor : 1.0f;
+
+  const u32 core_clock = u32(float(SystemTimers::GetTicksPerSecond()) * oc);
+
+  Memory::Write_U32(core_clock, request.io_vectors[0].address);
+
+  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+}
+
+IPCCommandResult GetSpeedLimit(const IOCtlVRequest& request)
+{
+  // get current speed limit
+  if (!request.HasNumberOfValidVectors(0, 1))
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  if (request.io_vectors[0].size != 4)
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  const SConfig& config = SConfig::GetInstance();
+  const u32 speed_percent = config.m_EmulationSpeed * 100;
+  Memory::Write_U32(speed_percent, request.io_vectors[0].address);
+
+  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+}
+
+IPCCommandResult SetSpeedLimit(const IOCtlVRequest& request)
+{
+  // set current speed limit
+  if (!request.HasNumberOfValidVectors(1, 0))
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  if (request.in_vectors[0].size != 4)
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EINVAL);
+  }
+
+  const float speed = float(Memory::Read_U32(request.in_vectors[0].address)) / 100.0f;
+  SConfig::GetInstance().m_EmulationSpeed = speed;
+  BootManager::SetEmulationSpeedReset(true);
+
+  return DolphinDevice::GetDefaultReply(IPC_SUCCESS);
+}
+
+}  // namespace
+
+IPCCommandResult DolphinDevice::IOCtlV(const IOCtlVRequest& request)
+{
+  if (Core::WantsDeterminism())
+  {
+    return DolphinDevice::GetDefaultReply(IPC_EACCES);
+  }
+
+  switch (request.request)
+  {
+  case IOCTL_DOLPHIN_GET_SYSTEM_TIME:
+    return GetSystemTime(request);
+  case IOCTL_DOLPHIN_GET_VERSION:
+    return GetVersion(request);
+  case IOCTL_DOLPHIN_GET_SPEED_LIMIT:
+    return GetSpeedLimit(request);
+  case IOCTL_DOLPHIN_SET_SPEED_LIMIT:
+    return SetSpeedLimit(request);
+  case IOCTL_DOLPHIN_GET_CPU_SPEED:
+    return GetCPUSpeed(request);
+  default:
+    return GetDefaultReply(IPC_EINVAL);
+  }
+}
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/DolphinDevice.h
+++ b/Source/Core/Core/IOS/DolphinDevice.h
@@ -1,0 +1,18 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Core/IOS/Device.h"
+
+namespace IOS::HLE::Device
+{
+class DolphinDevice final : public Device
+{
+public:
+  // Inherit the constructor from the Device class, since we don't need to do anything special.
+  using Device::Device;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+};
+}  // namespace IOS::HLE::Device

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -30,6 +30,7 @@
 #include "Core/IOS/DI/DI.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/DeviceStub.h"
+#include "Core/IOS/DolphinDevice.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/FS/FileSystemProxy.h"
@@ -372,6 +373,7 @@ void Kernel::AddCoreDevices()
   std::lock_guard<std::mutex> lock(m_device_map_mutex);
   AddDevice(std::make_unique<Device::FS>(*this, "/dev/fs"));
   AddDevice(std::make_unique<Device::ES>(*this, "/dev/es"));
+  AddDevice(std::make_unique<Device::DolphinDevice>(*this, "/dev/dolphin"));
 }
 
 void Kernel::AddStaticDevices()


### PR DESCRIPTION
I added some code to Dolphin, mainly a new device `/dev/dolphin` that can be used by Dolphin-aware software like homebrew to query certain information about Dolphin. 

Currently, that includes the real system time in ms (not the emulated system time), and the Dolphin version. Now I know from past conversations on the forum that there is no way for emulated software to detect real system time as that might confuse games when system time and emulated time run at different speeds. 

However, implementing this as an additional device /dev/dolphin means that no official game will ever know of this, as no official game would ever access /dev/dolphin. 

For Wiimmfi it would be pretty cool to let the game know that it lags (doesn't run at full 60fps), by comparing emulated time with this real time. Currently, when a player plays Mario Kart Wii online, they get a huge advantage when their Dolphin doesn't run at 60fps all time. If the game knew exactly how much it lags (that's the information that this PR gives the game) it can adapt the current racing timer, making that run at real-time. That would remove the advantage playing at <60fps gives you, and would allow players with slower computers to play on Wiimmfi as well. 

~Currently still a work in progress as I need to test it some more and might want to add another thing to the /dev/dolphin interface, but~ I wanted to create this PR to kinda ask the Dolphin team if there is a possibility for getting this merged at some point or if you'd have any objections against such an interface. 