### PR TITLE
RedumpVerifier: Show an error when datfile lacks serials or versions

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.h
+++ b/Source/Core/DiscIO/VolumeVerifier.h
@@ -88,7 +88,7 @@ private:
 
   static DownloadStatus DownloadDatfile(const std::string& system, DownloadStatus old_status);
   static std::vector<u8> ReadDatfile(const std::string& system);
-  std::vector<PotentialMatch> ScanDatfile(const std::vector<u8>& data);
+  std::vector<PotentialMatch> ScanDatfile(const std::vector<u8>& data, const std::string& system);
 
   std::string m_game_id;
   u16 m_revision;


### PR DESCRIPTION
This happens if someone manually downloads a regular datfile from redump.org and puts it where Dolphin stores datfiles. Dolphin needs "special" datfiles that contain fields for serials and versions.

Before this change, all discs (except Datel discs) would show up as "Unknown disc" when using a regular datfile.