### PR TITLE
[WIP] Attempt to fix av desync in segmented video

### DIFF
--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -78,15 +78,18 @@ static bool AVStreamCopyContext(AVStream* stream, AVCodecContext* codec_context)
 #endif
 }
 
-bool FrameDump::Start(int w, int h)
+bool FrameDump::Start(int w, int h, bool new_segment)
 {
   s_pix_fmt = AV_PIX_FMT_RGBA;
 
   s_width = w;
   s_height = h;
-
-  s_last_frame_is_valid = false;
   s_last_pts = 0;
+
+  if (!new_segment)
+  {
+    s_last_frame_is_valid = false;
+  }
 
   InitAVCodec();
   bool success = CreateVideoFile();
@@ -435,7 +438,7 @@ void FrameDump::CheckResolution(int width, int height)
     int temp_file_index = s_file_index;
     Stop();
     s_file_index = temp_file_index + 1;
-    Start(width, height);
+    Start(width, height, true);
   }
 }
 

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -392,6 +392,7 @@ void FrameDump::Stop()
   av_write_trailer(s_format_context);
   CloseVideoFile();
   s_file_index = 0;
+  s_start_dumping = false;
   NOTICE_LOG(VIDEO, "Stopping frame dump");
   OSD::AddMessage("Stopped dumping frames");
 }

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -78,18 +78,14 @@ static bool AVStreamCopyContext(AVStream* stream, AVCodecContext* codec_context)
 #endif
 }
 
-bool FrameDump::Start(int w, int h, bool new_segment)
+bool FrameDump::Start(int w, int h)
 {
   s_pix_fmt = AV_PIX_FMT_RGBA;
 
   s_width = w;
   s_height = h;
   s_last_pts = 0;
-
-  if (!new_segment)
-  {
-    s_last_frame_is_valid = false;
-  }
+  s_last_frame_is_valid = s_file_index != 0;
 
   InitAVCodec();
   bool success = CreateVideoFile();
@@ -438,7 +434,7 @@ void FrameDump::CheckResolution(int width, int height)
     int temp_file_index = s_file_index;
     Stop();
     s_file_index = temp_file_index + 1;
-    Start(width, height, true);
+    Start(width, height);
   }
 }
 

--- a/Source/Core/VideoCommon/FrameDump.h
+++ b/Source/Core/VideoCommon/FrameDump.h
@@ -22,7 +22,7 @@ public:
     int savestate_index = 0;
   };
 
-  static bool Start(int w, int h, bool new_segment = false);
+  static bool Start(int w, int h);
   static void AddFrame(const u8* data, int width, int height, int stride, const Frame& state);
   static void Stop();
   static void DoState();

--- a/Source/Core/VideoCommon/FrameDump.h
+++ b/Source/Core/VideoCommon/FrameDump.h
@@ -22,7 +22,7 @@ public:
     int savestate_index = 0;
   };
 
-  static bool Start(int w, int h);
+  static bool Start(int w, int h, bool new_segment = false);
   static void AddFrame(const u8* data, int width, int height, int stride, const Frame& state);
   static void Stop();
   static void DoState();


### PR DESCRIPTION
* Get latest Dolphin from master.
* Get this movie http://tasvideos.org/6501S.html
* Get this memory card http://files.tasvideos.org/common/SubmissionFiles/6501S/MemoryCardA_USA.7z
* Launch Dolphin
* Go to `Graphics -> Advanced`, disable `Dump at Internal Resolution`
* Enable `Movie -> Dump Frames`
* Replay the movie on _Resident Evil 4 (Disc 2)_
```
CRC32: 6C83A5FF
MD5: 2381ACD2199D6E7566932DF86901903D
SHA-1: C75F7936814636FFE03277F363FC3427C98602EE
```
* Stop the movie after the level starts
* Rename or move `framedump0.avi`
* Enable `Dump at Internal Resolution`
* Dump frames again.

If you splice the 2 dump segments that were done from _internal resolution_, you'll see that the level starts 68 frames earlier than in the single-segment dump that used the _window resolution_. It's because `s_last_frame_is_valid` gets reset, resulting in wrong frame duration timings and missing frames. This results in **heavy** audio-video desync if you dump the entire movie's audio and video and splice/mux everything together.

I tried to fix that by accounting for whether it's a new segment caused by video split, and now I consistently get 1 _extra frame_ on every split. I've been staring at the code for the entire day, and all the frame timings are now identical to the correct dump scenario (single-segment), but the output still doesn't match. I'm unable to figure out what else should be tweaked to get rid of the extra frame. Help!