### PR TITLE
Add motion input support to nunchuk

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -27,7 +27,8 @@ enum class NunchukGroup
   Stick,
   Tilt,
   Swing,
-  Shake
+  Shake,
+  IMUAccelerometer,
 };
 
 class Nunchuk : public Extension1stParty
@@ -96,6 +97,7 @@ private:
   ControllerEmu::Shake* m_shake;
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::AnalogStick* m_stick;
+  ControllerEmu::IMUAccelerometer* m_imu_accelerometer;
 
   // Dynamics:
   MotionState m_swing_state;

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -140,6 +140,10 @@ add_executable(dolphin-emu
   Config/Mapping/MappingWindow.h
   Config/Mapping/WiimoteEmuExtension.cpp
   Config/Mapping/WiimoteEmuExtension.h
+  Config/Mapping/WiimoteEmuExtensionMotionInput.cpp
+  Config/Mapping/WiimoteEmuExtensionMotionInput.h
+  Config/Mapping/WiimoteEmuExtensionMotionSimulation.cpp
+  Config/Mapping/WiimoteEmuExtensionMotionSimulation.h
   Config/Mapping/WiimoteEmuGeneral.cpp
   Config/Mapping/WiimoteEmuGeneral.h
   Config/Mapping/WiimoteEmuMotionControl.cpp

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -33,6 +33,8 @@
 #include "DolphinQt/Config/Mapping/HotkeyTAS.h"
 #include "DolphinQt/Config/Mapping/HotkeyWii.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
+#include "DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.h"
+#include "DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionSimulation.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuGeneral.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuMotionControl.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuMotionControlIMU.h"
@@ -346,12 +348,18 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
   case Type::MAPPING_WIIMOTE_EMU:
   {
     auto* extension = new WiimoteEmuExtension(this);
+    auto* extension_motion_input = new WiimoteEmuExtensionMotionInput(this);
+    auto* extension_motion_simulation = new WiimoteEmuExtensionMotionSimulation(this);
     widget = new WiimoteEmuGeneral(this, extension);
     setWindowTitle(tr("Wii Remote %1").arg(GetPort() + 1));
     AddWidget(tr("General and Options"), widget);
     AddWidget(tr("Motion Simulation"), new WiimoteEmuMotionControl(this));
     AddWidget(tr("Motion Input"), new WiimoteEmuMotionControlIMU(this));
     AddWidget(tr("Extension"), extension);
+    m_extension_motion_simulation_tab =
+        AddWidget(EXTENSION_MOTION_SIMULATION_TAB_NAME, extension_motion_simulation);
+    m_extension_motion_input_tab =
+        AddWidget(EXTENSION_MOTION_INPUT_TAB_NAME, extension_motion_input);
     break;
   }
   case Type::MAPPING_HOTKEYS:
@@ -395,9 +403,11 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
   m_profiles_combo->setCurrentIndex(-1);
 }
 
-void MappingWindow::AddWidget(const QString& name, QWidget* widget)
+QWidget* MappingWindow::AddWidget(const QString& name, QWidget* widget)
 {
-  m_tab_widget->addTab(GetWrappedWidget(widget, this, 150, 210), name);
+  QWidget* wrapper = GetWrappedWidget(widget, this, 150, 210);
+  m_tab_widget->addTab(wrapper, name);
+  return wrapper;
 }
 
 int MappingWindow::GetPort() const
@@ -431,4 +441,18 @@ void MappingWindow::OnClearFieldsPressed()
   m_controller->UpdateReferences(g_controller_interface);
   emit ConfigChanged();
   emit Save();
+}
+
+void MappingWindow::ShowExtensionMotionTabs(bool show)
+{
+  if (show)
+  {
+    m_tab_widget->addTab(m_extension_motion_simulation_tab, EXTENSION_MOTION_SIMULATION_TAB_NAME);
+    m_tab_widget->addTab(m_extension_motion_input_tab, EXTENSION_MOTION_INPUT_TAB_NAME);
+  }
+  else
+  {
+    m_tab_widget->removeTab(5);
+    m_tab_widget->removeTab(4);
+  }
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -50,6 +50,7 @@ public:
   int GetPort() const;
   ControllerEmu::EmulatedController* GetController() const;
   bool IsMappingAllDevices() const;
+  void ShowExtensionMotionTabs(bool show);
 
 signals:
   // Emitted when config has changed so widgets can update to reflect the change.
@@ -66,7 +67,7 @@ private:
   void CreateMainLayout();
   void ConnectWidgets();
 
-  void AddWidget(const QString& name, QWidget* widget);
+  QWidget* AddWidget(const QString& name, QWidget* widget);
 
   void RefreshDevices();
 
@@ -108,6 +109,10 @@ private:
   QPushButton* m_reset_clear;
 
   QTabWidget* m_tab_widget;
+  QWidget* m_extension_motion_input_tab;
+  QWidget* m_extension_motion_simulation_tab;
+  const QString EXTENSION_MOTION_INPUT_TAB_NAME = tr("Extension Motion Input");
+  const QString EXTENSION_MOTION_SIMULATION_TAB_NAME = tr("Extension Motion Simulation");
 
   Type m_mapping_type;
   const int m_port;

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -108,16 +108,7 @@ void WiimoteEmuExtension::CreateNunchukLayout()
   layout->addWidget(
       CreateGroupBox(tr("Buttons"),
                      Wiimote::GetNunchukGroup(GetPort(), WiimoteEmu::NunchukGroup::Buttons)),
-      1, 0);
-  layout->addWidget(CreateGroupBox(tr("Shake"), Wiimote::GetNunchukGroup(
-                                                    GetPort(), WiimoteEmu::NunchukGroup::Shake)),
-                    0, 1, -1, 1);
-  layout->addWidget(CreateGroupBox(tr("Tilt"), Wiimote::GetNunchukGroup(
-                                                   GetPort(), WiimoteEmu::NunchukGroup::Tilt)),
-                    0, 2, -1, 1);
-  layout->addWidget(CreateGroupBox(tr("Swing"), Wiimote::GetNunchukGroup(
-                                                    GetPort(), WiimoteEmu::NunchukGroup::Swing)),
-                    0, 3, -1, 1);
+      0, 1);
 
   m_nunchuk_box->setLayout(layout);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.cpp
@@ -1,0 +1,80 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.h"
+
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+
+#include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
+
+#include "InputCommon/InputConfig.h"
+
+WiimoteEmuExtensionMotionInput::WiimoteEmuExtensionMotionInput(MappingWindow* window)
+    : MappingWidget(window)
+{
+  CreateNunchukLayout();
+  CreateMainLayout();
+}
+
+void WiimoteEmuExtensionMotionInput::CreateNunchukLayout()
+{
+  auto* layout = new QGridLayout();
+  m_nunchuk_box = new QGroupBox(tr("Nunchuk"), this);
+
+  auto* warning_layout = new QHBoxLayout();
+  auto* warning_label = new QLabel(
+      tr("WARNING: These controls are designed to interface directly with motion "
+         "sensor hardware. They are not intended for mapping traditional buttons, triggers or "
+         "axes. You might need to configure alternate input sources before using these controls."));
+  warning_label->setWordWrap(true);
+  auto* warning_input_sources_button = new QPushButton(tr("Alternate Input Sources"));
+  warning_layout->addWidget(warning_label, 1);
+  warning_layout->addWidget(warning_input_sources_button, 0, Qt::AlignRight);
+  connect(warning_input_sources_button, &QPushButton::clicked, this, [this] {
+    ControllerInterfaceWindow* window = new ControllerInterfaceWindow(this);
+    window->setAttribute(Qt::WA_DeleteOnClose, true);
+    window->setWindowModality(Qt::WindowModality::WindowModal);
+    window->show();
+  });
+  layout->addLayout(warning_layout, 0, 0, 1, -1);
+
+  layout->addWidget(CreateGroupBox(tr("Accelerometer"),
+                                   Wiimote::GetNunchukGroup(
+                                       GetPort(), WiimoteEmu::NunchukGroup::IMUAccelerometer)),
+                    1, 0);
+
+  m_nunchuk_box->setLayout(layout);
+}
+
+void WiimoteEmuExtensionMotionInput::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  m_main_layout->addWidget(m_nunchuk_box);
+
+  setLayout(m_main_layout);
+}
+
+void WiimoteEmuExtensionMotionInput::LoadSettings()
+{
+  Wiimote::LoadConfig();
+}
+
+void WiimoteEmuExtensionMotionInput::SaveSettings()
+{
+  Wiimote::GetConfig()->SaveConfig();
+}
+
+InputConfig* WiimoteEmuExtensionMotionInput::GetConfig()
+{
+  return Wiimote::GetConfig();
+}

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionInput.h
@@ -1,0 +1,32 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinQt/Config/Mapping/MappingWidget.h"
+
+#include "Core/HW/WiimoteEmu/ExtensionPort.h"
+
+class QGroupBox;
+class QHBoxLayout;
+
+class WiimoteEmuExtensionMotionInput final : public MappingWidget
+{
+  Q_OBJECT
+public:
+  explicit WiimoteEmuExtensionMotionInput(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+
+  void CreateNunchukLayout();
+  void CreateMainLayout();
+
+  // Main
+  QHBoxLayout* m_main_layout;
+  QGroupBox* m_nunchuk_box;
+};

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionSimulation.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionSimulation.cpp
@@ -1,0 +1,65 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionSimulation.h"
+
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+
+#include "InputCommon/InputConfig.h"
+
+WiimoteEmuExtensionMotionSimulation::WiimoteEmuExtensionMotionSimulation(MappingWindow* window)
+    : MappingWidget(window)
+{
+  CreateNunchukLayout();
+  CreateMainLayout();
+}
+
+void WiimoteEmuExtensionMotionSimulation::CreateNunchukLayout()
+{
+  auto* layout = new QGridLayout();
+  m_nunchuk_box = new QGroupBox(tr("Nunchuk"), this);
+
+  layout->addWidget(CreateGroupBox(tr("Shake"), Wiimote::GetNunchukGroup(
+                                                    GetPort(), WiimoteEmu::NunchukGroup::Shake)),
+                    0, 0);
+  layout->addWidget(CreateGroupBox(tr("Tilt"), Wiimote::GetNunchukGroup(
+                                                   GetPort(), WiimoteEmu::NunchukGroup::Tilt)),
+                    0, 1);
+  layout->addWidget(CreateGroupBox(tr("Swing"), Wiimote::GetNunchukGroup(
+                                                    GetPort(), WiimoteEmu::NunchukGroup::Swing)),
+                    0, 2);
+
+  m_nunchuk_box->setLayout(layout);
+}
+
+void WiimoteEmuExtensionMotionSimulation::CreateMainLayout()
+{
+  m_main_layout = new QHBoxLayout();
+
+  m_main_layout->addWidget(m_nunchuk_box);
+
+  setLayout(m_main_layout);
+}
+
+void WiimoteEmuExtensionMotionSimulation::LoadSettings()
+{
+  Wiimote::LoadConfig();
+}
+
+void WiimoteEmuExtensionMotionSimulation::SaveSettings()
+{
+  Wiimote::GetConfig()->SaveConfig();
+}
+
+InputConfig* WiimoteEmuExtensionMotionSimulation::GetConfig()
+{
+  return Wiimote::GetConfig();
+}

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionSimulation.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtensionMotionSimulation.h
@@ -1,0 +1,32 @@
+// Copyright 2019 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinQt/Config/Mapping/MappingWidget.h"
+
+#include "Core/HW/WiimoteEmu/ExtensionPort.h"
+
+class QGroupBox;
+class QHBoxLayout;
+
+class WiimoteEmuExtensionMotionSimulation final : public MappingWidget
+{
+  Q_OBJECT
+public:
+  explicit WiimoteEmuExtensionMotionSimulation(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+
+  void CreateNunchukLayout();
+  void CreateMainLayout();
+
+  // Main
+  QHBoxLayout* m_main_layout;
+  QGroupBox* m_nunchuk_box;
+};

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuGeneral.cpp
@@ -76,6 +76,8 @@ void WiimoteEmuGeneral::Connect(MappingWindow* window)
 
 void WiimoteEmuGeneral::OnAttachmentChanged(int extension)
 {
+  GetParent()->ShowExtensionMotionTabs(extension == WiimoteEmu::ExtensionNumber::NUNCHUK);
+
   m_extension_widget->ChangeExtensionType(extension);
 
   auto* ce_extension = static_cast<ControllerEmu::Attachments*>(

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -93,6 +93,8 @@
     <QtMoc Include="Config\Mapping\MappingWidget.h" />
     <QtMoc Include="Config\Mapping\MappingWindow.h" />
     <QtMoc Include="Config\Mapping\WiimoteEmuExtension.h" />
+    <QtMoc Include="Config\Mapping\WiimoteEmuExtensionMotionInput.h" />
+    <QtMoc Include="Config\Mapping\WiimoteEmuExtensionMotionSimulation.h" />
     <QtMoc Include="Config\Mapping\WiimoteEmuGeneral.h" />
     <QtMoc Include="Config\Mapping\WiimoteEmuMotionControl.h" />
     <QtMoc Include="Config\Mapping\WiimoteEmuMotionControlIMU.h" />
@@ -292,6 +294,8 @@
     <ClCompile Include="$(QtMocOutPrefix)WiiPane.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WiiTASInputWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WiimoteEmuExtension.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)WiimoteEmuExtensionMotionInput.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)WiimoteEmuExtensionMotionSimulation.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WiimoteEmuGeneral.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WiimoteEmuMotionControl.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)WiimoteEmuMotionControlIMU.cpp" />
@@ -344,6 +348,8 @@
     <ClCompile Include="Config\Mapping\MappingWidget.cpp" />
     <ClCompile Include="Config\Mapping\MappingWindow.cpp" />
     <ClCompile Include="Config\Mapping\WiimoteEmuExtension.cpp" />
+    <ClCompile Include="Config\Mapping\WiimoteEmuExtensionMotionInput.cpp" />
+    <ClCompile Include="Config\Mapping\WiimoteEmuExtensionMotionSimulation.cpp" />
     <ClCompile Include="Config\Mapping\WiimoteEmuGeneral.cpp" />
     <ClCompile Include="Config\Mapping\WiimoteEmuMotionControl.cpp" />
     <ClCompile Include="Config\Mapping\WiimoteEmuMotionControlIMU.cpp" />


### PR DESCRIPTION
After discussions we ended up with the following UI layout. When (and only when) Nunchuk is selected as extension, two extra tabs appear: 'Extension Motion Simulation' and 'Extension Motion Input'.

![2019-11-06 18_43_04-vs2017 (1) - Remote Viewer](https://user-images.githubusercontent.com/47765059/68323410-aa10b380-00c5-11ea-8e6a-a979458a6d73.png)
![2019-11-06 18_43_27-vs2017 (1) - Remote Viewer](https://user-images.githubusercontent.com/47765059/68323417-ac730d80-00c5-11ea-8693-be56f26c9bfe.png)
![2019-11-06 18_55_52-vs2017 (1) - Remote Viewer](https://user-images.githubusercontent.com/47765059/68324178-25bf3000-00c7-11ea-9757-612f3344ffa3.png)

#### To preserve the context of the discussion that took place, the original version of this post is preserved below

The UI layout was slightly adjusted to allow fitting five control groups on a 1024 pixel wide screen.
Added the same warning text and `Alternate Input Sources` button as on the `Motion Input` tab.

![2019-11-04 18_48_38-vs2017 (1) - Remote Viewer](https://user-images.githubusercontent.com/47765059/68145593-72bfcc80-ff36-11e9-843a-e3bbb43a1f97.png)
