### PR TITLE
Android: Replace emulation rotation crash workaround with proper fix

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -400,6 +400,8 @@ public final class NativeLibrary
    */
   public static native void StopEmulation();
 
+  public static native void WaitUntilDoneBooting();
+
   /**
    * Returns true if emulation is running (or is paused).
    */

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -235,10 +235,6 @@ public final class EmulationActivity extends AppCompatActivity
   {
     super.onCreate(savedInstanceState);
 
-    // Find the EmulationFragment
-    mEmulationFragment = (EmulationFragment) getSupportFragmentManager()
-            .findFragmentById(R.id.frame_emulation_fragment);
-
     if (savedInstanceState == null)
     {
       // Get params we were passed
@@ -251,9 +247,7 @@ public final class EmulationActivity extends AppCompatActivity
     }
     else
     {
-      // Could have recreated the activity(rotate) before creating the fragment. If the fragment
-      // doesn't exist, treat this as a new start.
-      activityRecreated = mEmulationFragment != null;
+      activityRecreated = true;
       restoreState(savedInstanceState);
     }
 
@@ -311,9 +305,10 @@ public final class EmulationActivity extends AppCompatActivity
       setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
     }
 
-    if (!(mDeviceHasTouchScreen && lockLandscape &&
-            getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) &&
-            mEmulationFragment == null)
+    // Find or create the EmulationFragment
+    mEmulationFragment = (EmulationFragment) getSupportFragmentManager()
+            .findFragmentById(R.id.frame_emulation_fragment);
+    if (mEmulationFragment == null)
     {
       mEmulationFragment = EmulationFragment.newInstance(mPaths);
       getSupportFragmentManager().beginTransaction()

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -197,6 +197,8 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulati
                                                                                    jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulation(JNIEnv* env,
                                                                                   jobject obj);
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_NativeLibrary_WaitUntilDoneBooting(JNIEnv* env, jobject obj);
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunning(JNIEnv* env,
                                                                                   jobject obj);
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(
@@ -281,6 +283,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulatio
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
   Core::Stop();
   s_update_main_frame_event.Set();  // Kick the waiting event
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_NativeLibrary_WaitUntilDoneBooting(JNIEnv* env, jobject obj)
+{
+  Core::WaitUntilDoneBooting();
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunning(JNIEnv* env,

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -56,6 +56,7 @@ bool WantsDeterminism();
 // [NOT THREADSAFE] For use by Host only
 void SetState(State state);
 State GetState();
+void WaitUntilDoneBooting();
 
 void SaveScreenShot(bool wait_for_completion = false);
 void SaveScreenShot(std::string_view name, bool wait_for_completion = false);


### PR DESCRIPTION
The workaround was added in 0446a58.

The underlying problem is that we must not destroy the surface while the video backend is initializing, otherwise the video backend may reference nullptr.

I've also cleaned up the logic for when to destroy the surface. Note that the comment in EmulationFragment.java about only being able to destroy the surface when emulation is running is not true anymore (due to de632fc, it seems like).