### PR TITLE
Android: Expand the comment for NVidiaShieldWorkaroundView

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/NVidiaShieldWorkaroundView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/NVidiaShieldWorkaroundView.java
@@ -12,6 +12,9 @@ import android.view.View;
 
 /**
  * Work around a bug with the nVidia Shield.
+ *
+ * Without this View, the emulation SurfaceView acts like it has the
+ * highest Z-value, blocking any other View, such as the menu fragments.
  */
 public final class NVidiaShieldWorkaroundView extends View
 {


### PR DESCRIPTION
This text has been taken from the message of the commit that added the class. (I don't have an Nvidia Shield to reproduce the bug with.)