### PR TITLE
Git-Ignore: Also ignore other derivatives of VS output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ Thumbs.db
 Source/Core/Common/scmrev.h
 # Ignore files output by build
 /[Bb]uild*/
-/[Bb]inary/
+/[Bb]inary*/
 /obj/
 # Ignore files output by Android cmake build
 /Source/Android/app/.cxx/
@@ -21,7 +21,7 @@ Source/Core/Common/scmrev.h
 *.tlog
 *.VC.opendb
 *.VC.db
-.vs/
+.vs*/
 /Source/enc_temp_folder/
 # Ignore build info file created by QtCreator
 CMakeLists.txt.user


### PR DESCRIPTION
Someone already thought about it for the Build, but not the rest.

This helps with the trick of having  "_Branch Specific IDE Output Directories_", which can be created and managed with the following script I made originally for myself. https://gist.github.com/altimumdelta/1d43053f7373baae1066194b0f765a63