### PR TITLE
Android: Update to Gradle 3.5.2

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 


### PR DESCRIPTION
Android Studio recommends to update to Gradle 3.5.2.