### PR TITLE
DolphinQt: Hide unused buttons in the advanced mapping dialog.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -323,12 +323,24 @@ void IOWindow::CreateMainLayout()
   hbox->addLayout(button_vbox, 1);
 
   button_vbox->addWidget(m_select_button);
-  button_vbox->addWidget(m_type == Type::Input ? m_detect_button : m_test_button);
-  button_vbox->addWidget(m_operators_combo);
+
   if (m_type == Type::Input)
   {
-    button_vbox->addWidget(m_functions_combo);
+    m_test_button->hide();
+    button_vbox->addWidget(m_detect_button);
   }
+  else
+  {
+    m_detect_button->hide();
+    button_vbox->addWidget(m_test_button);
+  }
+
+  button_vbox->addWidget(m_operators_combo);
+
+  if (m_type == Type::Input)
+    button_vbox->addWidget(m_functions_combo);
+  else
+    m_functions_combo->hide();
 
   m_main_layout->addLayout(hbox, 2);
   m_main_layout->addWidget(m_expression_text, 1);


### PR DESCRIPTION
Fix regression from #8396.

Some widgets are conditionally added to the layout.

The unused ones were showing up in the top-left corner.

This hides the unused widgets.