### PR TITLE
Android: Update target Android SdkVersion to 28

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -22,7 +22,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
-        targetSdkVersion 27
+        targetSdkVersion 28
 
         versionCode(getBuildVersionCode())
 


### PR DESCRIPTION
Since 11/01/2019, Android requires SDK version 28 (aka Android 9). If you submit an update with SDK version 27 and below, Google will reject the update. Read more here: https://android-developers.googleblog.com/2019/02/expanding-target-api-level-requirements.html

I have tested this change on my phone and haven't encountered any issues.