### PR TITLE
Android:  update androidSupportVersion and compileSdkVersion to 28

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -76,7 +76,7 @@ android {
 }
 
 ext {
-    androidSupportVersion = '27.1.1'
+    androidSupportVersion = '28.0.0'
 }
 
 dependencies {


### PR DESCRIPTION
This is a suggested change by Android Studio. Depends on #8461.

I've tested this change on my device and didn't encounter any issues.