### PR TITLE
evdev: fix bad integer division.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -75,11 +75,11 @@ public:
     int value = 0;
     libevdev_fetch_event_value(m_dev, EV_ABS, m_code, &value);
 
-    return ControlState(value - m_base) / m_range;
+    return (value - m_base) / m_range;
   }
 
 protected:
-  int m_range;
+  ControlState m_range;
   int m_base;
 };
 


### PR DESCRIPTION
This should have been done in #8460.

`MotionDataInput` divides the integer resolution by a double. It should not be stored in m_range as an int.