### PR TITLE
Make shader precompilation interruptable

### DIFF
--- a/Source/Core/VideoCommon/AsyncShaderCompiler.h
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.h
@@ -49,11 +49,9 @@ public:
   bool HasPendingWork();
   bool HasCompletedWork();
 
-  // Simpler version without progress updates.
-  void WaitUntilCompletion();
-
   // Calls progress_callback periodically, with completed_items, and total_items.
-  void WaitUntilCompletion(const std::function<void(size_t, size_t)>& progress_callback);
+  // Returns false if interrupted.
+  bool WaitUntilCompletion(const std::function<void(size_t, size_t)>& progress_callback);
 
   // Needed because of calling virtual methods in shutdown procedure.
   bool StartWorkerThreads(u32 num_worker_threads);

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -157,9 +157,12 @@ const AbstractPipeline* ShaderCache::GetUberPipelineForUid(const GXUberPipelineU
 
 void ShaderCache::WaitForAsyncCompiler()
 {
-  while (m_async_shader_compiler->HasPendingWork() || m_async_shader_compiler->HasCompletedWork())
+  bool running = true;
+
+  while (running &&
+         (m_async_shader_compiler->HasPendingWork() || m_async_shader_compiler->HasCompletedWork()))
   {
-    m_async_shader_compiler->WaitUntilCompletion([](size_t completed, size_t total) {
+    running = m_async_shader_compiler->WaitUntilCompletion([](size_t completed, size_t total) {
       g_renderer->BeginUIFrame();
 
       const float center_x = ImGui::GetIO().DisplaySize.x * 0.5f;

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -159,35 +159,42 @@ void ShaderCache::WaitForAsyncCompiler()
 {
   bool running = true;
 
+  constexpr auto update_ui_progress = [](size_t completed, size_t total) {
+    g_renderer->BeginUIFrame();
+
+    const float center_x = ImGui::GetIO().DisplaySize.x * 0.5f;
+    const float center_y = ImGui::GetIO().DisplaySize.y * 0.5f;
+    const float scale = ImGui::GetIO().DisplayFramebufferScale.x;
+
+    ImGui::SetNextWindowSize(ImVec2(400.0f * scale, 50.0f * scale), ImGuiCond_Always);
+    ImGui::SetNextWindowPos(ImVec2(center_x, center_y), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    if (ImGui::Begin(Common::GetStringT("Compiling Shaders").c_str(), nullptr,
+                     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
+                         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
+                         ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
+                         ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
+    {
+      ImGui::Text("Compiling shaders: %zu/%zu", completed, total);
+      ImGui::ProgressBar(static_cast<float>(completed) /
+                             static_cast<float>(std::max(total, static_cast<size_t>(1))),
+                         ImVec2(-1.0f, 0.0f), "");
+    }
+    ImGui::End();
+
+    g_renderer->EndUIFrame();
+  };
+
   while (running &&
          (m_async_shader_compiler->HasPendingWork() || m_async_shader_compiler->HasCompletedWork()))
   {
-    running = m_async_shader_compiler->WaitUntilCompletion([](size_t completed, size_t total) {
-      g_renderer->BeginUIFrame();
+    running = m_async_shader_compiler->WaitUntilCompletion(update_ui_progress);
 
-      const float center_x = ImGui::GetIO().DisplaySize.x * 0.5f;
-      const float center_y = ImGui::GetIO().DisplaySize.y * 0.5f;
-      const float scale = ImGui::GetIO().DisplayFramebufferScale.x;
-
-      ImGui::SetNextWindowSize(ImVec2(400.0f * scale, 50.0f * scale), ImGuiCond_Always);
-      ImGui::SetNextWindowPos(ImVec2(center_x, center_y), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-      if (ImGui::Begin(Common::GetStringT("Compiling Shaders").c_str(), nullptr,
-                       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs |
-                           ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings |
-                           ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoNav |
-                           ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
-      {
-        ImGui::Text("Compiling shaders: %zu/%zu", completed, total);
-        ImGui::ProgressBar(static_cast<float>(completed) /
-                               static_cast<float>(std::max(total, static_cast<size_t>(1))),
-                           ImVec2(-1.0f, 0.0f), "");
-      }
-      ImGui::End();
-
-      g_renderer->EndUIFrame();
-    });
     m_async_shader_compiler->RetrieveWorkItems();
   }
+
+  // Just render nothing to clear the screen
+  g_renderer->BeginUIFrame();
+  g_renderer->EndUIFrame();
 }
 
 template <typename SerializedUidType, typename UidType>


### PR DESCRIPTION
This PR refactors shader precompilation ("Compile shaders before starting") to be interruptable. Previously, user was unable to close emulation gracefully during that step and had to either wait or forcibly terminate the process.

Additionally, UI window will now clear after finishing or aborting shader precompilation - so ImGui's message box will not linger until game renders something.