### PR TITLE
UI: Fixes for exit dialog

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -198,6 +198,7 @@ private:
   GameList* m_game_list;
   RenderWidget* m_render_widget = nullptr;
   bool m_rendering_to_main;
+  bool m_stop_confirm_showing = false;
   bool m_stop_requested = false;
   bool m_exit_requested = false;
   bool m_fullscreen_requested = false;

--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.cpp
@@ -19,9 +19,10 @@ ModalMessageBox::ModalMessageBox(QWidget* parent, Qt::WindowModality modality)
 
 static inline int ExecMessageBox(ModalMessageBox::Icon icon, QWidget* parent, const QString& title,
                                  const QString& text, ModalMessageBox::StandardButtons buttons,
-                                 ModalMessageBox::StandardButton default_button)
+                                 ModalMessageBox::StandardButton default_button,
+                                 Qt::WindowModality modality)
 {
-  ModalMessageBox msg(parent);
+  ModalMessageBox msg(parent, modality);
   msg.setIcon(icon);
   msg.setWindowTitle(title);
   msg.setText(text);
@@ -32,25 +33,33 @@ static inline int ExecMessageBox(ModalMessageBox::Icon icon, QWidget* parent, co
 }
 
 int ModalMessageBox::critical(QWidget* parent, const QString& title, const QString& text,
-                              StandardButtons buttons, StandardButton default_button)
+                              StandardButtons buttons, StandardButton default_button,
+                              Qt::WindowModality modality)
 {
-  return ExecMessageBox(QMessageBox::Critical, parent, title, text, buttons, default_button);
+  return ExecMessageBox(QMessageBox::Critical, parent, title, text, buttons, default_button,
+                        modality);
 }
 
 int ModalMessageBox::information(QWidget* parent, const QString& title, const QString& text,
-                                 StandardButtons buttons, StandardButton default_button)
+                                 StandardButtons buttons, StandardButton default_button,
+                                 Qt::WindowModality modality)
 {
-  return ExecMessageBox(QMessageBox::Information, parent, title, text, buttons, default_button);
+  return ExecMessageBox(QMessageBox::Information, parent, title, text, buttons, default_button,
+                        modality);
 }
 
 int ModalMessageBox::question(QWidget* parent, const QString& title, const QString& text,
-                              StandardButtons buttons, StandardButton default_button)
+                              StandardButtons buttons, StandardButton default_button,
+                              Qt::WindowModality modality)
 {
-  return ExecMessageBox(QMessageBox::Warning, parent, title, text, buttons, default_button);
+  return ExecMessageBox(QMessageBox::Warning, parent, title, text, buttons, default_button,
+                        modality);
 }
 
 int ModalMessageBox::warning(QWidget* parent, const QString& title, const QString& text,
-                             StandardButtons buttons, StandardButton default_button)
+                             StandardButtons buttons, StandardButton default_button,
+                             Qt::WindowModality modality)
 {
-  return ExecMessageBox(QMessageBox::Warning, parent, title, text, buttons, default_button);
+  return ExecMessageBox(QMessageBox::Warning, parent, title, text, buttons, default_button,
+                        modality);
 }

--- a/Source/Core/DolphinQt/QtUtils/ModalMessageBox.h
+++ b/Source/Core/DolphinQt/QtUtils/ModalMessageBox.h
@@ -13,11 +13,15 @@ public:
   explicit ModalMessageBox(QWidget* parent, Qt::WindowModality modality = Qt::WindowModal);
 
   static int critical(QWidget* parent, const QString& title, const QString& text,
-                      StandardButtons buttons = Ok, StandardButton default_button = NoButton);
+                      StandardButtons buttons = Ok, StandardButton default_button = NoButton,
+                      Qt::WindowModality modality = Qt::WindowModal);
   static int information(QWidget* parent, const QString& title, const QString& text,
-                         StandardButtons buttons = Ok, StandardButton default_button = NoButton);
+                         StandardButtons buttons = Ok, StandardButton default_button = NoButton,
+                         Qt::WindowModality modality = Qt::WindowModal);
   static int question(QWidget* parent, const QString& title, const QString& text,
-                      StandardButtons buttons = Yes | No, StandardButton default_button = NoButton);
+                      StandardButtons buttons = Yes | No, StandardButton default_button = NoButton,
+                      Qt::WindowModality modality = Qt::WindowModal);
   static int warning(QWidget* parent, const QString& title, const QString& text,
-                     StandardButtons buttons = Ok, StandardButton default_button = NoButton);
+                     StandardButtons buttons = Ok, StandardButton default_button = NoButton,
+                     Qt::WindowModality modality = Qt::WindowModal);
 };


### PR DESCRIPTION
As per discussion on IRC, this PR makes "Do you want to exit emulation?" application modal and ensures only a single instance of it exists. This fixes numerous issues, eg.:

- Being able to spam dialogs by pressing Escape
- Being able to close emulation window by just pressing X twice