### PR TITLE
Fix malformed manifests

### DIFF
--- a/Source/Core/DolphinQt/DolphinQt.manifest
+++ b/Source/Core/DolphinQt/DolphinQt.manifest
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-      <dpiAware>true</dpiAware>
-      <longPathAware>true</longPathAware>
-    </windowsSettings>
-  </application>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>

--- a/Source/Core/WinUpdater/Updater.exe.manifest
+++ b/Source/Core/WinUpdater/Updater.exe.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="amd64"
@@ -27,11 +27,10 @@
     <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
   </application>
 </compatibility>
-<asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <asmv3:windowsSettings
-       xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-    <dpiAware>true</dpiAware>
-    <longPathAware>true</longPathAware>
+<asmv3:application>
+  <asmv3:windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
   </asmv3:windowsSettings>
 </asmv3:application>
 </assembly>


### PR DESCRIPTION
Fixes a regression caused by #8393. 2016 manifest XML schema removed a 2005 `dpiAware` attribute, which caused Dolphin's manifest to silently ignore this attribute, but in the case of updater it exploded loudly instead.

This PR fixes both manifests. Sadly, since updater cannot launch it means that those unlucky people who updated during the past 1.5 days have to update manually.