### PR TITLE
x64: Handle Intel JCC Erratum

### DIFF
--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -54,6 +54,8 @@ struct CPUInfo
   bool bLAHFSAHF64 = false;
   bool bLongMode = false;
   bool bAtom = false;
+  // Intel Erratum SKX102
+  bool bJccErratum = false;
 
   // ARMv8 specific
   bool bFP = false;

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -113,6 +113,7 @@ void CPUInfo::Detect()
     __cpuid(cpu_id, 0x00000001);
     int family = ((cpu_id[0] >> 8) & 0xf) + ((cpu_id[0] >> 20) & 0xff);
     int model = ((cpu_id[0] >> 4) & 0xf) + ((cpu_id[0] >> 12) & 0xf0);
+    int stepping = cpu_id[0] & 0xf;
     // Detect people unfortunate enough to be running Dolphin on an Atom
     if (family == 6 &&
         (model == 0x1C || model == 0x26 || model == 0x27 || model == 0x35 || model == 0x36 ||
@@ -168,6 +169,18 @@ void CPUInfo::Detect()
         bBMI1 = true;
       if ((cpu_id[1] >> 8) & 1)
         bBMI2 = true;
+    }
+
+    // Detect processors affected by SKX102. See also Intel Whitepaper 341810-001.
+    if (family == 6 && ((model == 0x4E && stepping == 0x3) || (model == 0x55 && stepping == 0x4) ||
+                        (model == 0x55 && stepping == 0x7) || (model == 0x5E && stepping == 0x3) ||
+                        (model == 0x8E && stepping == 0x9) || (model == 0x8E && stepping == 0xA) ||
+                        (model == 0x8E && stepping == 0xB) || (model == 0x8E && stepping == 0xC) ||
+                        (model == 0x9E && stepping == 0x9) || (model == 0x9E && stepping == 0xA) ||
+                        (model == 0x9E && stepping == 0xB) || (model == 0x9E && stepping == 0xD) ||
+                        (model == 0xA6 && stepping == 0x0) || (model == 0xAE && stepping == 0xA)))
+    {
+      bJccErratum = true;
     }
   }
 
@@ -270,5 +283,7 @@ std::string CPUInfo::Summarize()
     sum += ", MOVBE";
   if (bLongMode)
     sum += ", 64-bit support";
+  if (bJccErratum)
+    sum += ", SKX102 bug";
   return sum;
 }

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -409,11 +409,29 @@ void XEmitter::Rex(int w, int r, int x, int b)
     Write8(rx);
 }
 
+void XEmitter::AddJccErratumPadding(size_t instruction_size)
+{
+  if (!cpu_info.bJccErratum)
+  {
+    return;
+  }
+
+  constexpr u64 cache_line_size = 32;  // bytes
+  const u64 remaining = cache_line_size - (reinterpret_cast<u64>(code) & (cache_line_size - 1));
+  if (remaining > instruction_size)
+  {
+    return;
+  }
+
+  NOP(remaining);
+}
+
 void XEmitter::JMP(const u8* addr, bool force5Bytes)
 {
   u64 fn = (u64)addr;
   if (!force5Bytes)
   {
+    AddJccErratumPadding(2);
     s64 distance = (s64)(fn - ((u64)code + 2));
     ASSERT_MSG(DYNA_REC, distance >= -0x80 && distance < 0x80,
                "Jump target too far away, needs force5Bytes = true");
@@ -423,6 +441,7 @@ void XEmitter::JMP(const u8* addr, bool force5Bytes)
   }
   else
   {
+    AddJccErratumPadding(5);
     s64 distance = (s64)(fn - ((u64)code + 5));
 
     ASSERT_MSG(DYNA_REC, distance >= -0x80000000LL && distance < 0x80000000LL,
@@ -434,35 +453,67 @@ void XEmitter::JMP(const u8* addr, bool force5Bytes)
 
 void XEmitter::JMPptr(const OpArg& arg2)
 {
-  OpArg arg = arg2;
-  if (arg.IsImm())
-    ASSERT_MSG(DYNA_REC, 0, "JMPptr - Imm argument");
-  arg.operandReg = 4;
-  arg.WriteREX(this, 0, 0);
-  Write8(0xFF);
-  arg.WriteRest(this);
+  const auto emit = [&] {
+    OpArg arg = arg2;
+    if (arg.IsImm())
+      ASSERT_MSG(DYNA_REC, 0, "JMPptr - Imm argument");
+    arg.operandReg = 4;
+    arg.WriteREX(this, 0, 0);
+    Write8(0xFF);
+    arg.WriteRest(this);
+  };
+
+  if (!cpu_info.bJccErratum)
+  {
+    emit();
+    return;
+  }
+
+  u8* instruction_begin = code;
+  emit();
+  u8* instruction_end = code;
+  code = instruction_begin;
+  AddJccErratumPadding(instruction_end - instruction_begin);
+  emit();
 }
 
 // Can be used to trap other processors, before overwriting their code
 // not used in Dolphin
 void XEmitter::JMPself()
 {
+  AddJccErratumPadding(2);
   Write8(0xEB);
   Write8(0xFE);
 }
 
 void XEmitter::CALLptr(OpArg arg)
 {
-  if (arg.IsImm())
-    ASSERT_MSG(DYNA_REC, 0, "CALLptr - Imm argument");
-  arg.operandReg = 2;
-  arg.WriteREX(this, 0, 0);
-  Write8(0xFF);
-  arg.WriteRest(this);
+  const auto emit = [&] {
+    if (arg.IsImm())
+      ASSERT_MSG(DYNA_REC, 0, "CALLptr - Imm argument");
+    arg.operandReg = 2;
+    arg.WriteREX(this, 0, 0);
+    Write8(0xFF);
+    arg.WriteRest(this);
+  };
+
+  if (!cpu_info.bJccErratum)
+  {
+    emit();
+    return;
+  }
+
+  u8* instruction_begin = code;
+  emit();
+  u8* instruction_end = code;
+  code = instruction_begin;
+  AddJccErratumPadding(instruction_end - instruction_begin);
+  emit();
 }
 
 void XEmitter::CALL(const void* fnptr)
 {
+  AddJccErratumPadding(5);
   u64 distance = u64(fnptr) - (u64(code) + 5);
   ASSERT_MSG(DYNA_REC, distance < 0x0000000080000000ULL || distance >= 0xFFFFFFFF80000000ULL,
              "CALL out of range (%p calls %p)", code, fnptr);
@@ -472,11 +523,12 @@ void XEmitter::CALL(const void* fnptr)
 
 FixupBranch XEmitter::CALL()
 {
+  AddJccErratumPadding(5);
   FixupBranch branch;
   branch.type = FixupBranch::Type::Branch32Bit;
-  branch.ptr = code + 5;
   Write8(0xE8);
   Write32(0);
+  branch.ptr = code;
   return branch;
 }
 
@@ -484,18 +536,20 @@ FixupBranch XEmitter::J(bool force5bytes)
 {
   FixupBranch branch;
   branch.type = force5bytes ? FixupBranch::Type::Branch32Bit : FixupBranch::Type::Branch8Bit;
-  branch.ptr = code + (force5bytes ? 5 : 2);
   if (!force5bytes)
   {
+    AddJccErratumPadding(2);
     // 8 bits will do
     Write8(0xEB);
     Write8(0);
   }
   else
   {
+    AddJccErratumPadding(5);
     Write8(0xE9);
     Write32(0);
   }
+  branch.ptr = code;
   return branch;
 }
 
@@ -503,28 +557,34 @@ FixupBranch XEmitter::J_CC(CCFlags conditionCode, bool force5bytes)
 {
   FixupBranch branch;
   branch.type = force5bytes ? FixupBranch::Type::Branch32Bit : FixupBranch::Type::Branch8Bit;
-  branch.ptr = code + (force5bytes ? 6 : 2);
   if (!force5bytes)
   {
+    AddJccErratumPadding(2);
     // 8 bits will do
     Write8(0x70 + conditionCode);
     Write8(0);
   }
   else
   {
+    AddJccErratumPadding(6);
     Write8(0x0F);
     Write8(0x80 + conditionCode);
     Write32(0);
   }
+  branch.ptr = code;
   return branch;
 }
 
 void XEmitter::J_CC(CCFlags conditionCode, const u8* addr)
 {
+  AddJccErratumPadding(2);
+
   u64 fn = (u64)addr;
   s64 distance = (s64)(fn - ((u64)code + 2));
+
   if (distance < -0x80 || distance >= 0x80)
   {
+    AddJccErratumPadding(6);
     distance = (s64)(fn - ((u64)code + 6));
     ASSERT_MSG(DYNA_REC, distance >= -0x80000000LL && distance < 0x80000000LL,
                "Jump target too far away, needs indirect register");
@@ -534,6 +594,7 @@ void XEmitter::J_CC(CCFlags conditionCode, const u8* addr)
   }
   else
   {
+    AddJccErratumPadding(2);
     Write8(0x70 + conditionCode);
     Write8((u8)(s8)distance);
   }
@@ -567,10 +628,12 @@ void XEmitter::INT3()
 }
 void XEmitter::RET()
 {
+  AddJccErratumPadding(1);
   Write8(0xC3);
 }
 void XEmitter::RET_FAST()
 {
+  AddJccErratumPadding(2);
   Write8(0xF3);
   Write8(0xC3);
 }  // two-byte return (rep ret) - recommended by AMD optimization manual for the case of jumping to

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -430,6 +430,14 @@ public:
   void PUSHF();
   void POPF();
 
+  // Intel CPU microcode migitations that fix Intel erratum SKX102 affect the caching of certain
+  // jmp/call/ret instructions: If such instructions (or such macrofused instruction pairs) span
+  // a 32-byte boundary, they will not be cached in the host CPU's micro-op cache. In order to
+  // reduce the performance impact of these micro-op cache misses / pipeline transitions, we add
+  // NOP instructions so such flow control instructions do not cross 32-byte boundaries or end on
+  // a 32-byte boundary. See also Intel White Paper 341810-001.
+  void AddJccErratumPadding(size_t instruction_size);
+
   // Flow control
   void RET();
   void RET_FAST();

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -81,6 +81,10 @@ void Jit64AsmRoutineManager::Generate()
   ResetStack(*this);
 
   SUB(32, PPCSTATE(downcount), R(RSCRATCH2));
+  // Prevent op-Jcc fusion by inserting a NOP. If this NOP wasn't here, the above SUB may be
+  // `memmove`-d by the emitter and this would invalidate the below `dispatcher` variable.
+  // (See also: AddJccErratumPaddingFusable)
+  NOP();
 
   dispatcher = GetCodePtr();
   // Expected result of SUB(32, PPCSTATE(downcount), Imm32(block_cycles)) is in RFLAGS.

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -325,6 +325,7 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, 
   if (m_jit.jo.fastmem && !(flags & (SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_UPDATE_PC)) &&
       !slowmem)
   {
+    AddJccErratumPadding(BACKPATCH_SIZE);
     u8* backpatchStart = GetWritableCodePtr();
     MovInfo mov;
     bool offsetAddedToAddress =
@@ -497,6 +498,7 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
   if (m_jit.jo.fastmem && !(flags & (SAFE_LOADSTORE_NO_FASTMEM | SAFE_LOADSTORE_NO_UPDATE_PC)) &&
       !slowmem)
   {
+    AddJccErratumPadding(BACKPATCH_SIZE);
     u8* backpatchStart = GetWritableCodePtr();
     MovInfo mov;
     UnsafeWriteRegToReg(reg_value, reg_addr, accessSize, offset, swap, &mov);


### PR DESCRIPTION
Also see [relevant white paper](https://www.intel.com/content/www/us/en/support/articles/000055650/processors.html).

This implementation adds NOP padding before all affected JCC/JMP/CALL/RET instructions.

~~**Please note:** This implementation will split macro-op fusable op-JCC pairs. An improved implementation would add padding before such pairs, instead of in between these instructions.~~