### PR TITLE
[EXPERIMENTAL] GCMemcardDirectory: Set card formatting timestamp to known value.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1536,7 +1536,7 @@ void GCMBlock::Erase()
   memset(m_block.data(), 0xFF, m_block.size());
 }
 
-Header::Header(int slot, u16 size_mbits, bool shift_jis)
+Header::Header(int slot, u16 size_mbits, bool shift_jis, std::optional<u64> timestamp)
 {
   // Nintendo format algorithm.
   // Constants are fixed by the GC SDK
@@ -1544,7 +1544,8 @@ Header::Header(int slot, u16 size_mbits, bool shift_jis)
   memset(this, 0xFF, BLOCK_SIZE);
   m_size_mb = size_mbits;
   m_encoding = shift_jis ? 1 : 0;
-  u64 rand = Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
+  u64 rand = timestamp.value_or(Common::Timer::GetLocalTimeSinceJan1970() -
+                                ExpansionInterface::CEXIIPL::GC_EPOCH);
   m_format_time = rand;
   for (int i = 0; i < 12; i++)
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -233,8 +233,8 @@ struct Header
   // 0x1e00 bytes at 0x0200: Unused (0xff)
   std::array<u8, 7680> m_unused_2;
 
-  explicit Header(int slot = 0, u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043,
-                  bool shift_jis = false);
+  explicit Header(int slot = 0, u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043, bool shift_jis = false,
+                  std::optional<u64> timestamp = std::nullopt);
 
   // Calculates the card serial numbers used for encrypting some save files.
   std::pair<u32, u32> CalculateSerial() const;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -78,6 +78,9 @@ bool GCMemcardDirectory::LoadGCI(GCIFile gci)
   }
   gci.m_gci_header.m_first_block = first_block;
 
+  INFO_LOG(EXPANSIONINTERFACE, "GCI Folder: Reserved blocks [0x%x, 0x%x) for %s.", first_block,
+           first_block + num_blocks, gci.m_filename.c_str());
+
   if (gci.HasCopyProtection())
   {
     GCMemcard::PSO_MakeSaveGameValid(m_hdr, gci.m_gci_header, gci.m_save_data);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -148,8 +148,8 @@ std::vector<std::string> GCMemcardDirectory::GetFileNamesForGameID(const std::st
 GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u16 size_mbits,
                                        bool shift_jis, int game_id)
     : MemoryCardBase(slot, size_mbits), m_game_id(game_id), m_last_block(-1),
-      m_hdr(slot, size_mbits, shift_jis), m_bat1(size_mbits), m_saves(0),
-      m_save_directory(directory), m_exiting(false)
+      m_hdr(slot, size_mbits, shift_jis, 60 * 60 * 24 * 365 * 2 + slot), m_bat1(size_mbits),
+      m_saves(0), m_save_directory(directory), m_exiting(false)
 {
   // Use existing header data if available
   {

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 115;  // Last changed in PR 8722
+constexpr u32 STATE_VERSION = 116;  // Last changed in PR 8476
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
TODO list for me being comfortable actually merging this:

- [ ] Assuming we don't want hardcoded IDs, store enough data to reproduce the same card serial number on savestate load.
- [ ] This data should not only be used for savestates, but also when switching from GCI folder to a different device (none/rawcard/mic/...) and back while the game is running.
- [ ] Send card eject/insert signals to the game when we provably have a different memory card now than we did on savestate creation.

---

This is a fix/workaround for issues like this one: https://bugs.dolphin-emu.org/issues/11849
Code will be made nicer if we decide to actually go with it.

To summarize, some games refuse to save to a memory card if they can detect that the card is not the same card the save was loaded from. They, or at least some of them, do this by comparing the `m_serial` field of the currently inserted memory card's header to the one remembered from the card they loaded the save from.

This field is pseudorandomly generated when the card is formatted based on the current timestamp of the GameCube's internal clock. This is also how we do it, with the wrinkle that our virtual GCI folder memory card is formatted every time a Dolphin game session starts. This means that the following sequence of tasks will cause a game to detect a changed memory card:

- Boot a game.
- Load a save.
- Make a savestate.
- Close the game.
- Boot the game again.
- Load the savestate.
- Try to save.

Assuming no one modified the contents of the GCI folder in the meantime, the save we're attempting to overwrite is still the exact same save we loaded from, yet the game detects it as a different one because the virtual memory card was reinitialized with a different timestamp on the second boot.

I've tested this for the game in the linked issue (Paper Mario TTYD) and it does indeed allow you to save now when you do this even though it didn't before. However, I'm pretty afraid of potential false positives. If a game thinks that the currently inserted card has not changed from the one it has loaded the data from, and doesn't bother to re-read the BAT of the card, it could corrupt data in the card if it has changed, for example when you added or removed a GCI file from the GCI folder between making the savestate and booting the game the second time. This is technically not impossible in real life, though somewhat convoluted (while game is running remove card, put it in second GC, copy around files, put it back in first GC), so you'd hope games would be able to deal with it, but you never know.

@JMC47 Since you requested this in the linked bug report, please test this with as many combinations of cases you can think of!