### PR TITLE
ControllerInterface/DSUClient: Minor cleanup.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPProto.h
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPProto.h
@@ -181,7 +181,7 @@ struct PadDataResponse
   u64 timestamp_us;
   float accelerometer_x_g;
   float accelerometer_y_g;
-  float accelerometer_z_inverted_g;
+  float accelerometer_z_g;
   float gyro_pitch_deg_s;
   float gyro_yaw_deg_s;
   float gyro_roll_deg_s;


### PR DESCRIPTION
Eliminate `m_accl`/`m_gyro` members by accessing the pad data directly like every other input.