### PR TITLE
Fixed #11874 (leading 0s ignored by debugger)

### DIFF
--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -379,7 +379,7 @@ void MemoryViewWidget::OnCopyHex()
   u64 value = accessors->ReadU64(addr);
 
   QApplication::clipboard()->setText(
-      QStringLiteral("%1").arg(value, length * 2, 16, QLatin1Char('0')).left(length * 2));
+      QStringLiteral("%1").arg(value, sizeof(u64) * 2, 16, QLatin1Char('0')).left(length * 2));
 }
 
 void MemoryViewWidget::OnContextMenu()

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -488,12 +488,15 @@ void MemoryWidget::OnSetValue()
     const QByteArray bytes = m_data_edit->text().toUtf8();
 
     for (char c : bytes)
-      accessors->WriteU8(static_cast<u8>(c), addr++);
+      accessors->WriteU8(addr++, static_cast<u8>(c));
   }
   else
   {
     bool good_value;
-    u64 value = m_data_edit->text().toULongLong(&good_value, 16);
+    const QString text = m_data_edit->text();
+    const int length =
+        text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive) ? text.size() - 2 : text.size();
+    const u64 value = text.toULongLong(&good_value, 16);
 
     if (!good_value)
     {
@@ -501,15 +504,15 @@ void MemoryWidget::OnSetValue()
       return;
     }
 
-    if (value == static_cast<u8>(value))
+    if (length <= 2)
     {
       accessors->WriteU8(addr, static_cast<u8>(value));
     }
-    else if (value == static_cast<u16>(value))
+    else if (length <= 4)
     {
       accessors->WriteU16(addr, static_cast<u16>(value));
     }
-    else if (value == static_cast<u32>(value))
+    else if (length <= 8)
     {
       accessors->WriteU32(addr, static_cast<u32>(value));
     }


### PR DESCRIPTION
Fixes both issues from the report.

For set value:
The original code converts the string into a value and then attempts to work out the size of the input by downcasting and comparing. This breaks for leading zeros as, for example, 0042 == (u8)0042. The fix calculates the correct length from the original string, taking into account the possibility that the string is prefixed by "0x".

For copy hex:
The code already attempts to take the first "length" characters, however incorrectly converts/pads the value and so copies the first "length" nonzero characters. This meant that copying the 01 of 01 23 would result in the string 12 being copied. The fix always fully pads the read value and then correctly takes the leftmost characters.