### PR TITLE
VolumeVerifier: Fix a copypaste error

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -1122,7 +1122,7 @@ void VolumeVerifier::Process()
   if (m_block_index < m_blocks.size() &&
       m_blocks[m_block_index].offset < m_progress + bytes_to_read)
   {
-    m_md5_future = std::async(
+    m_block_future = std::async(
         std::launch::async,
         [this, read_succeeded, bytes_to_read](size_t block_index, u64 progress) {
           while (block_index < m_blocks.size() &&


### PR DESCRIPTION
This was completely wrong, but I guess it happened to work correctly anyway due to timing reasons (MD5 is faster than SHA-1 + AES).