### PR TITLE
InputCommon/IMU*: Remove unnecessary includes

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
@@ -4,16 +4,13 @@
 
 #include "InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.h"
 
+#include <memory>
+
 #include "Common/Common.h"
-#include "Common/MathUtil.h"
-
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
-
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/Control/Input.h"
-#include "InputCommon/ControllerEmu/ControllerEmu.h"
-#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "Common/Matrix.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
-#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -4,6 +4,7 @@
 
 #include "InputCommon/ControllerEmu/ControlGroup/IMUCursor.h"
 
+#include <memory>
 #include <string>
 
 #include "Common/Common.h"
@@ -12,8 +13,6 @@
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/Control/Input.h"
-#include "InputCommon/ControllerEmu/ControllerEmu.h"
-#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include <chrono>
 #include <string>
 
-#include "InputCommon/ControllerEmu/StickGate.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -4,16 +4,13 @@
 
 #include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
 
-#include "Common/Common.h"
-#include "Common/MathUtil.h"
+#include <memory>
 
-#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "Common/Common.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/Control/Input.h"
-#include "InputCommon/ControllerEmu/ControllerEmu.h"
-#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "Common/Matrix.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
-#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {


### PR DESCRIPTION
Trims out unnecessary includes to avoid unnecessary header dependencies.

This also resolves indirect inclusions of `<optional>` within IMUAccelerometer.h and IMUGyroscope.h