### PR TITLE
InputCommon/DualShockUDPClient: Minor cleanup

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -200,7 +200,7 @@ static void HotplugThreadFunc()
       {
         const bool port_changed = !IsSameController(*port_info, s_port_info[port_info->pad_id]);
         {
-          std::lock_guard<std::mutex> lock(s_port_info_mutex);
+          std::lock_guard lock{s_port_info_mutex};
           s_port_info[port_info->pad_id] = *port_info;
         }
         if (port_changed)
@@ -283,7 +283,7 @@ void PopulateDevices()
   g_controller_interface.RemoveDevice(
       [](const auto* dev) { return dev->GetSource() == "DSUClient"; });
 
-  std::lock_guard<std::mutex> lock(s_port_info_mutex);
+  std::lock_guard lock{s_port_info_mutex};
   for (size_t port_index = 0; port_index < s_port_info.size(); port_index++)
   {
     const Proto::MessageType::PortInfo& port_info = s_port_info[port_index];

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -24,6 +24,19 @@
 
 namespace ciface::DualShockUDPClient
 {
+namespace Settings
+{
+constexpr char DEFAULT_SERVER_ADDRESS[] = "127.0.0.1";
+constexpr u16 DEFAULT_SERVER_PORT = 26760;
+
+const Config::ConfigInfo<bool> SERVER_ENABLED{
+    {Config::System::DualShockUDPClient, "Server", "Enabled"}, false};
+const Config::ConfigInfo<std::string> SERVER_ADDRESS{
+    {Config::System::DualShockUDPClient, "Server", "IPAddress"}, DEFAULT_SERVER_ADDRESS};
+const Config::ConfigInfo<int> SERVER_PORT{{Config::System::DualShockUDPClient, "Server", "Port"},
+                                          DEFAULT_SERVER_PORT};
+}  // namespace Settings
+
 class Device : public Core::Device
 {
 private:
@@ -110,22 +123,10 @@ private:
 };
 
 using MathUtil::GRAVITY_ACCELERATION;
-static constexpr char DEFAULT_SERVER_ADDRESS[] = "127.0.0.1";
-static constexpr u16 DEFAULT_SERVER_PORT = 26760;
-static constexpr auto SERVER_REREGISTER_INTERVAL = std::chrono::seconds{1};
-static constexpr auto SERVER_LISTPORTS_INTERVAL = std::chrono::seconds{1};
-static constexpr int TOUCH_X_AXIS_MAX = 1000;
-static constexpr int TOUCH_Y_AXIS_MAX = 500;
-
-namespace Settings
-{
-const Config::ConfigInfo<bool> SERVER_ENABLED{
-    {Config::System::DualShockUDPClient, "Server", "Enabled"}, false};
-const Config::ConfigInfo<std::string> SERVER_ADDRESS{
-    {Config::System::DualShockUDPClient, "Server", "IPAddress"}, DEFAULT_SERVER_ADDRESS};
-const Config::ConfigInfo<int> SERVER_PORT{{Config::System::DualShockUDPClient, "Server", "Port"},
-                                          DEFAULT_SERVER_PORT};
-}  // namespace Settings
+constexpr auto SERVER_REREGISTER_INTERVAL = std::chrono::seconds{1};
+constexpr auto SERVER_LISTPORTS_INTERVAL = std::chrono::seconds{1};
+constexpr int TOUCH_X_AXIS_MAX = 1000;
+constexpr int TOUCH_Y_AXIS_MAX = 500;
 
 static bool s_server_enabled;
 static std::string s_server_address;

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -96,16 +96,17 @@ public:
 private:
   const Proto::DsModel m_model;
   const int m_index;
-  u32 m_client_uid;
+  u32 m_client_uid = Common::Random::GenerateValue<u32>();
   sf::UdpSocket m_socket;
-  Common::DVec3 m_accel;
-  Common::DVec3 m_gyro;
-  std::chrono::steady_clock::time_point m_next_reregister;
-  Proto::MessageType::PadDataResponse m_pad_data;
-  Proto::Touch m_prev_touch;
-  bool m_prev_touch_valid;
-  int m_touch_x;
-  int m_touch_y;
+  Common::DVec3 m_accel{};
+  Common::DVec3 m_gyro{};
+  std::chrono::steady_clock::time_point m_next_reregister =
+      std::chrono::steady_clock::time_point::min();
+  Proto::MessageType::PadDataResponse m_pad_data{};
+  Proto::Touch m_prev_touch{};
+  bool m_prev_touch_valid = false;
+  int m_touch_x = 0;
+  int m_touch_y = 0;
 };
 
 using MathUtil::GRAVITY_ACCELERATION;
@@ -297,11 +298,7 @@ void DeInit()
   StopHotplugThread();
 }
 
-Device::Device(Proto::DsModel model, int index)
-    : m_model(model), m_index(index),
-      m_client_uid(Common::Random::GenerateValue<u32>()), m_accel{}, m_gyro{},
-      m_next_reregister(std::chrono::steady_clock::time_point::min()), m_pad_data{}, m_prev_touch{},
-      m_prev_touch_valid(false), m_touch_x(0), m_touch_y(0)
+Device::Device(Proto::DsModel model, int index) : m_model{model}, m_index{index}
 {
   m_socket.setBlocking(false);
 

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include "Common/Config/Config.h"
 
 namespace ciface::DualShockUDPClient

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPProto.h
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPProto.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <optional>
 
 #include <zlib.h>

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPProto.h
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPProto.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+#include <cstring>
 #include <optional>
 
 #include <zlib.h>
@@ -17,12 +19,12 @@ namespace ciface::DualShockUDPClient::Proto
 //
 // WARNING: Little endian host assumed
 
-static constexpr u16 CEMUHOOK_PROTOCOL_VERSION = 1001;
+constexpr u16 CEMUHOOK_PROTOCOL_VERSION = 1001;
 
-static constexpr int PORT_COUNT = 4;
+constexpr int PORT_COUNT = 4;
 
-static constexpr char CLIENT[] = "DSUC";
-static constexpr char SERVER[] = "DSUS";
+constexpr std::array<u8, 4> CLIENT{'D', 'S', 'U', 'C'};
+constexpr std::array<u8, 4> SERVER{'D', 'S', 'U', 'S'};
 
 #pragma pack(push, 1)
 
@@ -69,7 +71,7 @@ enum RegisterFlags : u8
 
 struct MessageHeader
 {
-  u8 source[4];
+  std::array<u8, 4> source;
   u16 protocol_version;
   u16 message_length;  // actually message size minus header size
   u32 crc32;
@@ -101,7 +103,7 @@ struct VersionResponse
   MessageHeader header;
   u32 message_type;
   u16 max_protocol_version;
-  u8 padding[2];
+  std::array<u8, 2> padding;
 };
 
 struct ListPorts
@@ -111,7 +113,7 @@ struct ListPorts
   MessageHeader header;
   u32 message_type;
   u32 pad_request_count;
-  u8 pad_id[4];
+  std::array<u8, 4> pad_id;
 };
 
 struct PortInfo
@@ -124,7 +126,7 @@ struct PortInfo
   DsState pad_state;
   DsModel model;
   DsConnection connection_type;
-  u8 pad_mac_address[6];
+  std::array<u8, 6> pad_mac_address;
   DsBattery battery_status;
   u8 padding;
 };
@@ -137,7 +139,7 @@ struct PadDataRequest
   u32 message_type;
   RegisterFlags register_flags;
   u8 pad_id_to_register;
-  u8 mac_address_to_register[6];
+  std::array<u8, 6> mac_address_to_register;
 };
 
 struct PadDataResponse
@@ -150,7 +152,7 @@ struct PadDataResponse
   DsState pad_state;
   DsModel model;
   DsConnection connection_type;
-  u8 pad_mac_address[6];
+  std::array<u8, 6> pad_mac_address;
   DsBattery battery_status;
   u8 active;
   u32 hid_packet_counter;
@@ -224,11 +226,11 @@ static inline u32 CRC32(const void* buffer, unsigned length)
 template <typename MsgType>
 struct Message
 {
-  Message() : m_message{} {}
+  Message() = default;
 
-  explicit Message(u32 source_uid) : m_message{}
+  explicit Message(u32 source_uid)
   {
-    memcpy((char*)m_message.header.source, MsgType::FROM, sizeof(m_message.header.source));
+    m_message.header.source = MsgType::FROM;
     m_message.header.protocol_version = CEMUHOOK_PROTOCOL_VERSION;
     m_message.header.message_length = sizeof(*this) - sizeof(m_message.header);
     m_message.header.source_uid = source_uid;
@@ -253,7 +255,7 @@ struct Message
     }
     if (m_message.header.protocol_version > CEMUHOOK_PROTOCOL_VERSION)
       return std::nullopt;
-    if (memcmp(m_message.header.source, ToMsgType::FROM, sizeof(m_message.header.source)))
+    if (m_message.header.source != ToMsgType::FROM)
       return std::nullopt;
     if (m_message.message_type != ToMsgType::TYPE)
       return std::nullopt;
@@ -265,7 +267,7 @@ struct Message
     return tomsg;
   }
 
-  MsgType m_message;
+  MsgType m_message{};
 };
 
 #pragma pack(pop)


### PR DESCRIPTION
Initially intended to be a change adding missing header guards, this kind of snowballed into a general cleanup change. Many of the changes are fairly bog-standard in terms of modifications done.

We leverage std::array to simplify comparisons and copying of data, which makes many of these cases much nicer to read.