### PR TITLE
VideoCommon: Make use of fmt outside of shader generators

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -8,9 +8,10 @@
 #include <cstring>
 #include <string>
 
+#include <fmt/format.h>
+
+#include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Common/StringUtil.h"
-#include "Common/Thread.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
@@ -921,19 +922,19 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     const char* logicmodes[] = {"0",     "s & d",  "s & ~d",   "s",        "~s & d", "d",
                                 "s ^ d", "s | d",  "~(s | d)", "~(s ^ d)", "~d",     "s | ~d",
                                 "~s",    "~s | d", "~(s & d)", "1"};
-    *desc = StringFromFormat(
-        "Enable: %s\n"
-        "Logic ops: %s\n"
-        "Dither: %s\n"
-        "Color write: %s\n"
-        "Alpha write: %s\n"
-        "Dest factor: %s\n"
-        "Source factor: %s\n"
-        "Subtract: %s\n"
-        "Logic mode: %s\n",
-        no_yes[mode.blendenable], no_yes[mode.logicopenable], no_yes[mode.dither],
-        no_yes[mode.colorupdate], no_yes[mode.alphaupdate], dstfactors[mode.dstfactor],
-        srcfactors[mode.srcfactor], no_yes[mode.subtract], logicmodes[mode.logicmode]);
+    *desc =
+        fmt::format("Enable: {}\n"
+                    "Logic ops: {}\n"
+                    "Dither: {}\n"
+                    "Color write: {}\n"
+                    "Alpha write: {}\n"
+                    "Dest factor: {}\n"
+                    "Source factor: {}\n"
+                    "Subtract: {}\n"
+                    "Logic mode: {}\n",
+                    no_yes[mode.blendenable], no_yes[mode.logicopenable], no_yes[mode.dither],
+                    no_yes[mode.colorupdate], no_yes[mode.alphaupdate], dstfactors[mode.dstfactor],
+                    srcfactors[mode.srcfactor], no_yes[mode.subtract], logicmodes[mode.logicmode]);
   }
   break;
 
@@ -952,11 +953,11 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     const char* zformats[] = {
         "linear",     "compressed (near)",     "compressed (mid)",     "compressed (far)",
         "inv linear", "compressed (inv near)", "compressed (inv mid)", "compressed (inv far)"};
-    *desc = StringFromFormat("EFB pixel format: %s\n"
-                             "Depth format: %s\n"
-                             "Early depth test: %s\n",
-                             pixel_formats[config.pixel_format], zformats[config.zformat],
-                             no_yes[config.early_ztest]);
+    *desc = fmt::format("EFB pixel format: {}\n"
+                        "Depth format: {}\n"
+                        "Early depth test: {}\n",
+                        pixel_formats[config.pixel_format], zformats[config.zformat],
+                        no_yes[config.early_ztest]);
   }
   break;
 
@@ -990,7 +991,7 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     SetRegName(BPMEM_EFB_TL);
     X10Y10 left_top;
     left_top.hex = cmddata;
-    *desc = StringFromFormat("Left: %d\nTop: %d", left_top.x, left_top.y);
+    *desc = fmt::format("Left: {}\nTop: {}", left_top.x, left_top.y);
   }
   break;
 
@@ -1000,13 +1001,13 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     SetRegName(BPMEM_EFB_BR);
     X10Y10 width_height;
     width_height.hex = cmddata;
-    *desc = StringFromFormat("Width: %d\nHeight: %d", width_height.x + 1, width_height.y + 1);
+    *desc = fmt::format("Width: {}\nHeight: {}", width_height.x + 1, width_height.y + 1);
   }
   break;
 
   case BPMEM_EFB_ADDR:  // 0x4B
     SetRegName(BPMEM_EFB_ADDR);
-    *desc = StringFromFormat("Target address (32 byte aligned): 0x%06X", cmddata << 5);
+    *desc = fmt::format("Target address (32 byte aligned): 0x{:06X}", cmddata << 5);
     break;
 
   case BPMEM_MIPMAP_STRIDE:  // 0x4D
@@ -1016,24 +1017,23 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
 
   case BPMEM_COPYYSCALE:  // 0x4E
     SetRegName(BPMEM_COPYYSCALE);
-    *desc = StringFromFormat("Scaling factor (XFB copy only): 0x%X (%f or inverted %f)", cmddata,
-                             (float)cmddata / 256.f, 256.f / (float)cmddata);
+    *desc = fmt::format("Scaling factor (XFB copy only): 0x{:X} ({} or inverted {})", cmddata,
+                        static_cast<float>(cmddata) / 256.f, 256.f / static_cast<float>(cmddata));
     break;
 
   case BPMEM_CLEAR_AR:  // 0x4F
     SetRegName(BPMEM_CLEAR_AR);
-    *desc = StringFromFormat("Alpha: 0x%02X\nRed: 0x%02X", (cmddata & 0xFF00) >> 8, cmddata & 0xFF);
+    *desc = fmt::format("Alpha: 0x{:02X}\nRed: 0x{:02X}", (cmddata & 0xFF00) >> 8, cmddata & 0xFF);
     break;
 
   case BPMEM_CLEAR_GB:  // 0x50
     SetRegName(BPMEM_CLEAR_GB);
-    *desc =
-        StringFromFormat("Green: 0x%02X\nBlue: 0x%02X", (cmddata & 0xFF00) >> 8, cmddata & 0xFF);
+    *desc = fmt::format("Green: 0x{:02X}\nBlue: 0x{:02X}", (cmddata & 0xFF00) >> 8, cmddata & 0xFF);
     break;
 
   case BPMEM_CLEAR_Z:  // 0x51
     SetRegName(BPMEM_CLEAR_Z);
-    *desc = StringFromFormat("Z value: 0x%06X", cmddata);
+    *desc = fmt::format("Z value: 0x{:06X}", cmddata);
     break;
 
   case BPMEM_TRIGGER_EFB_COPY:  // 0x52
@@ -1041,18 +1041,18 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     SetRegName(BPMEM_TRIGGER_EFB_COPY);
     UPE_Copy copy;
     copy.Hex = cmddata;
-    *desc = StringFromFormat(
-        "Clamping: %s\n"
-        "Converting from RGB to YUV: %s\n"
-        "Target pixel format: 0x%X\n"
-        "Gamma correction: %s\n"
-        "Mipmap filter: %s\n"
-        "Vertical scaling: %s\n"
-        "Clear: %s\n"
-        "Frame to field: 0x%01X\n"
-        "Copy to XFB: %s\n"
-        "Intensity format: %s\n"
-        "Automatic color conversion: %s",
+    *desc = fmt::format(
+        "Clamping: {}\n"
+        "Converting from RGB to YUV: {}\n"
+        "Target pixel format: 0x{:X}\n"
+        "Gamma correction: {}\n"
+        "Mipmap filter: {}\n"
+        "Vertical scaling: {}\n"
+        "Clear: {}\n"
+        "Frame to field: 0x{:01X}\n"
+        "Copy to XFB: {}\n"
+        "Intensity format: {}\n"
+        "Automatic color conversion: {}",
         (copy.clamp_top && copy.clamp_bottom) ?
             "Top and Bottom" :
             (copy.clamp_top) ? "Top only" : (copy.clamp_bottom) ? "Bottom only" : "None",
@@ -1061,7 +1061,7 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
             "1.0" :
             (copy.gamma == 1) ? "1.7" : (copy.gamma == 2) ? "2.2" : "Invalid value 0x3?",
         no_yes[copy.half_scale], no_yes[copy.scale_invert], no_yes[copy.clear],
-        (u32)copy.frame_to_field, no_yes[copy.copy_to_xfb], no_yes[copy.intensity_fmt],
+        static_cast<u32>(copy.frame_to_field), no_yes[copy.copy_to_xfb], no_yes[copy.intensity_fmt],
         no_yes[copy.auto_conv]);
   }
   break;
@@ -1181,11 +1181,11 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
         (cmd < BPMEM_TX_SETIMAGE0_4) ? cmd - BPMEM_TX_SETIMAGE0 : cmd - BPMEM_TX_SETIMAGE0_4 + 4;
     TexImage0 teximg;
     teximg.hex = cmddata;
-    *desc = StringFromFormat("Texture Unit: %i\n"
-                             "Width: %i\n"
-                             "Height: %i\n"
-                             "Format: %x\n",
-                             texnum, teximg.width + 1, teximg.height + 1, teximg.format);
+    *desc = fmt::format("Texture Unit: {}\n"
+                        "Width: {}\n"
+                        "Height: {}\n"
+                        "Format: {:x}\n",
+                        texnum, teximg.width + 1, teximg.height + 1, teximg.format);
   }
   break;
 
@@ -1203,13 +1203,13 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
         (cmd < BPMEM_TX_SETIMAGE1_4) ? cmd - BPMEM_TX_SETIMAGE1 : cmd - BPMEM_TX_SETIMAGE1_4 + 4;
     TexImage1 teximg;
     teximg.hex = cmddata;
-    *desc = StringFromFormat("Texture Unit: %i\n"
-                             "Even TMEM Offset: %x\n"
-                             "Even TMEM Width: %i\n"
-                             "Even TMEM Height: %i\n"
-                             "Cache is manually managed: %s\n",
-                             texnum, teximg.tmem_even, teximg.cache_width, teximg.cache_height,
-                             no_yes[teximg.image_type]);
+    *desc = fmt::format("Texture Unit: {}\n"
+                        "Even TMEM Offset: {:x}\n"
+                        "Even TMEM Width: {}\n"
+                        "Even TMEM Height: {}\n"
+                        "Cache is manually managed: {}\n",
+                        texnum, teximg.tmem_even, teximg.cache_width, teximg.cache_height,
+                        no_yes[teximg.image_type]);
   }
   break;
 
@@ -1227,11 +1227,11 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
         (cmd < BPMEM_TX_SETIMAGE2_4) ? cmd - BPMEM_TX_SETIMAGE2 : cmd - BPMEM_TX_SETIMAGE2_4 + 4;
     TexImage2 teximg;
     teximg.hex = cmddata;
-    *desc = StringFromFormat("Texture Unit: %i\n"
-                             "Odd TMEM Offset: %x\n"
-                             "Odd TMEM Width: %i\n"
-                             "Odd TMEM Height: %i\n",
-                             texnum, teximg.tmem_odd, teximg.cache_width, teximg.cache_height);
+    *desc = fmt::format("Texture Unit: {}\n"
+                        "Odd TMEM Offset: {:x}\n"
+                        "Odd TMEM Width: {}\n"
+                        "Odd TMEM Height: {}\n",
+                        texnum, teximg.tmem_odd, teximg.cache_width, teximg.cache_height);
   }
   break;
 
@@ -1249,8 +1249,8 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
         (cmd < BPMEM_TX_SETIMAGE3_4) ? cmd - BPMEM_TX_SETIMAGE3 : cmd - BPMEM_TX_SETIMAGE3_4 + 4;
     TexImage3 teximg;
     teximg.hex = cmddata;
-    *desc = StringFromFormat("Texture %i source address (32 byte aligned): 0x%06X", texnum,
-                             teximg.image_base << 5);
+    *desc = fmt::format("Texture {} source address (32 byte aligned): 0x{:06X}", texnum,
+                        teximg.image_base << 5);
   }
   break;
 
@@ -1293,19 +1293,19 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     const char* tevop[] = {"add", "sub"};
     const char* tevscale[] = {"1", "2", "4", "0.5"};
     const char* tevout[] = {"prev.rgb", "c0.rgb", "c1.rgb", "c2.rgb"};
-    *desc = StringFromFormat("Tev stage: %d\n"
-                             "a: %s\n"
-                             "b: %s\n"
-                             "c: %s\n"
-                             "d: %s\n"
-                             "Bias: %s\n"
-                             "Op: %s\n"
-                             "Clamp: %s\n"
-                             "Scale factor: %s\n"
-                             "Dest: %s\n",
-                             (data[0] - BPMEM_TEV_COLOR_ENV) / 2, tevin[cc.a], tevin[cc.b],
-                             tevin[cc.c], tevin[cc.d], tevbias[cc.bias], tevop[cc.op],
-                             no_yes[cc.clamp], tevscale[cc.shift], tevout[cc.dest]);
+    *desc = fmt::format("Tev stage: {}\n"
+                        "a: {}\n"
+                        "b: {}\n"
+                        "c: {}\n"
+                        "d: {}\n"
+                        "Bias: {}\n"
+                        "Op: {}\n"
+                        "Clamp: {}\n"
+                        "Scale factor: {}\n"
+                        "Dest: {}\n",
+                        (data[0] - BPMEM_TEV_COLOR_ENV) / 2, tevin[cc.a], tevin[cc.b], tevin[cc.c],
+                        tevin[cc.d], tevbias[cc.bias], tevop[cc.op], no_yes[cc.clamp],
+                        tevscale[cc.shift], tevout[cc.dest]);
     break;
   }
 
@@ -1336,22 +1336,21 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     const char* tevop[] = {"add", "sub"};
     const char* tevscale[] = {"1", "2", "4", "0.5"};
     const char* tevout[] = {"prev", "c0", "c1", "c2"};
-    *desc =
-        StringFromFormat("Tev stage: %d\n"
-                         "a: %s\n"
-                         "b: %s\n"
-                         "c: %s\n"
-                         "d: %s\n"
-                         "Bias: %s\n"
-                         "Op: %s\n"
-                         "Clamp: %s\n"
-                         "Scale factor: %s\n"
-                         "Dest: %s\n"
-                         "Ras sel: %d\n"
-                         "Tex sel: %d\n",
-                         (data[0] - BPMEM_TEV_ALPHA_ENV) / 2, tevin[ac.a], tevin[ac.b], tevin[ac.c],
-                         tevin[ac.d], tevbias[ac.bias], tevop[ac.op], no_yes[ac.clamp],
-                         tevscale[ac.shift], tevout[ac.dest], ac.rswap.Value(), ac.tswap.Value());
+    *desc = fmt::format("Tev stage: {}\n"
+                        "a: {}\n"
+                        "b: {}\n"
+                        "c: {}\n"
+                        "d: {}\n"
+                        "Bias: {}\n"
+                        "Op: {}\n"
+                        "Clamp: {}\n"
+                        "Scale factor: {}\n"
+                        "Dest: {}\n"
+                        "Ras sel: {}\n"
+                        "Tex sel: {}\n",
+                        (data[0] - BPMEM_TEV_ALPHA_ENV) / 2, tevin[ac.a], tevin[ac.b], tevin[ac.c],
+                        tevin[ac.d], tevbias[ac.bias], tevop[ac.op], no_yes[ac.clamp],
+                        tevscale[ac.shift], tevout[ac.dest], ac.rswap.Value(), ac.tswap.Value());
     break;
   }
 
@@ -1414,11 +1413,11 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
     const char* functions[] = {"NEVER",   "LESS",   "EQUAL",  "LEQUAL",
                                "GREATER", "NEQUAL", "GEQUAL", "ALWAYS"};
     const char* logic[] = {"AND", "OR", "XOR", "XNOR"};
-    *desc = StringFromFormat("Test 1: %s (ref: %#02x)\n"
-                             "Test 2: %s (ref: %#02x)\n"
-                             "Logic: %s\n",
-                             functions[test.comp0], (int)test.ref0, functions[test.comp1],
-                             (int)test.ref1, logic[test.logic]);
+    *desc = fmt::format("Test 1: {} (ref: 0x{:02x})\n"
+                        "Test 2: {} (ref: 0x{:02x})\n"
+                        "Logic: {}\n",
+                        functions[test.comp0], test.ref0.Value(), functions[test.comp1],
+                        test.ref1.Value(), logic[test.logic]);
     break;
   }
 

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -132,6 +132,7 @@ target_link_libraries(videocommon
 PUBLIC
   core
 PRIVATE
+  fmt::fmt
   png
   xxhash
   imgui

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -9,6 +9,8 @@
 #include <sstream>
 #include <string>
 
+#include <fmt/format.h>
+
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
@@ -233,9 +235,7 @@ bool FrameDump::CreateVideoFile()
     return false;
   }
 
-  OSD::AddMessage(
-      StringFromFormat("Dumping Frames to \"%s\" (%dx%d)", dump_path.c_str(), s_width, s_height));
-
+  OSD::AddMessage(fmt::format("Dumping Frames to \"{}\" ({}x{})", dump_path, s_width, s_height));
   return true;
 }
 

--- a/Source/Core/VideoCommon/NetPlayGolfUI.cpp
+++ b/Source/Core/VideoCommon/NetPlayGolfUI.cpp
@@ -2,13 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/StringUtil.h"
-
-#include "Core/NetPlayClient.h"
-
 #include "VideoCommon/NetPlayGolfUI.h"
 
+#include <fmt/format.h>
 #include <imgui.h>
+
+#include "Core/NetPlayClient.h"
 
 constexpr float DEFAULT_WINDOW_WIDTH = 220.0f;
 constexpr float DEFAULT_WINDOW_HEIGHT = 45.0f;
@@ -57,7 +56,7 @@ void NetPlayGolfUI::Display()
       if (client->IsLocalPlayer(player->pid) || !client->PlayerHasControllerMapped(player->pid))
         continue;
 
-      if (ImGui::Button(StringFromFormat("Give Control to %s", player->name.c_str()).c_str()))
+      if (ImGui::Button(fmt::format("Give Control to {}", player->name).c_str()))
       {
         client->RequestGolfControl(player->pid);
       }

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -2,20 +2,20 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/OnScreenDisplay.h"
+
 #include <algorithm>
 #include <map>
 #include <mutex>
 #include <string>
 
+#include <fmt/format.h>
 #include <imgui.h>
 
 #include "Common/CommonTypes.h"
-#include "Common/StringUtil.h"
 #include "Common/Timer.h"
 
 #include "Core/ConfigManager.h"
-
-#include "VideoCommon/OnScreenDisplay.h"
 
 namespace OSD
 {
@@ -49,7 +49,7 @@ static float DrawMessage(int index, const Message& msg, const ImVec2& position, 
 {
   // We have to provide a window name, and these shouldn't be duplicated.
   // So instead, we generate a name based on the number of messages drawn.
-  const std::string window_name = StringFromFormat("osd_%d", index);
+  const std::string window_name = fmt::format("osd_{}", index);
 
   // The size must be reset, otherwise the length of old messages could influence new ones.
   ImGui::SetNextWindowPos(position);

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <string_view>
 
+#include <fmt/format.h>
+
 #include "Common/Assert.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
@@ -286,8 +288,10 @@ void PostProcessingConfiguration::SaveOptionsConfiguration()
     {
       std::string value;
       for (size_t i = 0; i < it.second.m_integer_values.size(); ++i)
-        value += StringFromFormat("%d%s", it.second.m_integer_values[i],
-                                  i == (it.second.m_integer_values.size() - 1) ? "" : ", ");
+      {
+        value += fmt::format("{}{}", it.second.m_integer_values[i],
+                             i == (it.second.m_integer_values.size() - 1) ? "" : ", ");
+      }
       ini.GetOrCreateSection(section)->Set(it.second.m_option_name, value);
     }
     break;
@@ -453,7 +457,7 @@ std::string PostProcessing::GetUniformBufferHeader() const
     if (it.second.m_type ==
         PostProcessingConfiguration::ConfigurationOption::OptionType::OPTION_BOOL)
     {
-      ss << StringFromFormat("  int %s;\n", it.first.c_str());
+      ss << fmt::format("  int {};\n", it.first);
       for (u32 i = 0; i < 3; i++)
         ss << "  int ubo_align_" << unused_counter++ << "_;\n";
     }
@@ -462,9 +466,9 @@ std::string PostProcessing::GetUniformBufferHeader() const
     {
       u32 count = static_cast<u32>(it.second.m_integer_values.size());
       if (count == 1)
-        ss << StringFromFormat("  int %s;\n", it.first.c_str());
+        ss << fmt::format("  int {};\n", it.first);
       else
-        ss << StringFromFormat("  int%u %s;\n", count, it.first.c_str());
+        ss << fmt::format("  int{} {};\n", count, it.first);
 
       for (u32 i = count; i < 4; i++)
         ss << "  int ubo_align_" << unused_counter++ << "_;\n";
@@ -474,9 +478,9 @@ std::string PostProcessing::GetUniformBufferHeader() const
     {
       u32 count = static_cast<u32>(it.second.m_float_values.size());
       if (count == 1)
-        ss << StringFromFormat("  float %s;\n", it.first.c_str());
+        ss << fmt::format("  float {};\n", it.first);
       else
-        ss << StringFromFormat("  float%u %s;\n", count, it.first.c_str());
+        ss << fmt::format("  float{} {};\n", count, it.first);
 
       for (u32 i = count; i < 4; i++)
         ss << "  float ubo_align_" << unused_counter++ << "_;\n";

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <tuple>
 
+#include <fmt/format.h>
 #include <imgui.h>
 
 #include "Common/Assert.h"
@@ -1589,8 +1590,8 @@ void Renderer::StopFrameDumpToFFMPEG()
 
 std::string Renderer::GetFrameDumpNextImageFileName() const
 {
-  return StringFromFormat("%sframedump_%u.png", File::GetUserPath(D_DUMPFRAMES_IDX).c_str(),
-                          m_frame_dump_image_counter);
+  return fmt::format("{}framedump_{}.png", File::GetUserPath(D_DUMPFRAMES_IDX),
+                     m_frame_dump_image_counter);
 }
 
 bool Renderer::StartFrameDumpToImage(const FrameDumpConfig& config)

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "VideoCommon/ShaderGenCommon.h"
-#include "Common/CommonPaths.h"
+
+#include <fmt/format.h>
+
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 
@@ -76,7 +78,7 @@ std::string GetDiskShaderCacheFileName(APIType api_type, const char* type, bool 
   {
     // We're using 21 bits, so 6 hex characters.
     ShaderHostConfig host_config = ShaderHostConfig::GetCurrent();
-    filename += StringFromFormat("-%06X", host_config.bits);
+    filename += fmt::format("-{:06X}", host_config.bits);
   }
 
   filename += ".cache";

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/TextureCacheBase.h"
+
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -13,6 +15,8 @@
 #include <pmmintrin.h>
 #endif
 
+#include <fmt/format.h>
+
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
@@ -22,7 +26,6 @@
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "Common/MemoryUtil.h"
-#include "Common/StringUtil.h"
 
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/ConfigManager.h"
@@ -40,7 +43,6 @@
 #include "VideoCommon/SamplerCommon.h"
 #include "VideoCommon/ShaderCache.h"
 #include "VideoCommon/Statistics.h"
-#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/TextureConverterShaderGen.h"
 #include "VideoCommon/TextureDecoder.h"
@@ -917,13 +919,14 @@ void TextureCacheBase::DumpTexture(TCacheEntry* entry, std::string basename, uns
 
   if (level > 0)
   {
-    basename += StringFromFormat("_mip%i", level);
+    basename += fmt::format("_mip{}", level);
   }
 
-  std::string filename = szDir + "/" + basename + ".png";
+  const std::string filename = fmt::format("{}/{}.png", szDir, basename);
+  if (File::Exists(filename))
+    return;
 
-  if (!File::Exists(filename))
-    entry->texture->Save(filename, level);
+  entry->texture->Save(filename, level);
 }
 
 static u32 CalculateLevelSize(u32 level_0_size, u32 level)
@@ -1751,10 +1754,8 @@ TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height, u32 stride,
   {
     // While this isn't really an xfb copy, we can treat it as such for dumping purposes
     static int xfb_count = 0;
-    entry->texture->Save(StringFromFormat("%sxfb_loaded_%i.png",
-                                          File::GetUserPath(D_DUMPTEXTURES_IDX).c_str(),
-                                          xfb_count++),
-                         0);
+    entry->texture->Save(
+        fmt::format("{}xfb_loaded_{}.png", File::GetUserPath(D_DUMPTEXTURES_IDX), xfb_count++), 0);
   }
 
   GetDisplayRectForXFBEntry(entry, width, height, display_rect);
@@ -2164,19 +2165,17 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       if (g_ActiveConfig.bDumpEFBTarget && !is_xfb_copy)
       {
         static int efb_count = 0;
-        entry->texture->Save(StringFromFormat("%sefb_frame_%i.png",
-                                              File::GetUserPath(D_DUMPTEXTURES_IDX).c_str(),
-                                              efb_count++),
-                             0);
+        entry->texture->Save(
+            fmt::format("{}efb_frame_{}.png", File::GetUserPath(D_DUMPTEXTURES_IDX), efb_count++),
+            0);
       }
 
       if (g_ActiveConfig.bDumpXFBTarget && is_xfb_copy)
       {
         static int xfb_count = 0;
-        entry->texture->Save(StringFromFormat("%sxfb_copy_%i.png",
-                                              File::GetUserPath(D_DUMPTEXTURES_IDX).c_str(),
-                                              xfb_count++),
-                             0);
+        entry->texture->Save(
+            fmt::format("{}xfb_copy_{}.png", File::GetUserPath(D_DUMPTEXTURES_IDX), xfb_count++),
+            0);
       }
     }
   }

--- a/Source/Core/VideoCommon/UberShaderCommon.h
+++ b/Source/Core/VideoCommon/UberShaderCommon.h
@@ -4,6 +4,11 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -22,9 +27,9 @@ void WriteVertexLighting(ShaderCode& out, APIType api_type, const char* world_po
 
 // bitfieldExtract generator for BitField types
 template <typename T>
-std::string BitfieldExtract(const std::string& source, T type)
+std::string BitfieldExtract(std::string_view source, T type)
 {
-  return StringFromFormat("bitfieldExtract(%s, %u, %u)", source.c_str(),
-                          static_cast<u32>(type.StartBit()), static_cast<u32>(type.NumBits()));
+  return fmt::format("bitfieldExtract({}, {}, {})", source, static_cast<u32>(type.StartBit()),
+                     static_cast<u32>(type.NumBits()));
 }
 }  // namespace UberShader

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -11,10 +11,11 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
-#include "Common/StringUtil.h"
 
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoader.h"
@@ -107,37 +108,39 @@ std::string VertexLoaderBase::ToString() const
       "Inv",
   }};
 
-  dest += StringFromFormat("%ib skin: %i P: %i %s-%s ", m_VertexSize, (u32)m_VtxDesc.PosMatIdx,
-                           m_VtxAttr.PosElements ? 3 : 2, pos_mode[m_VtxDesc.Position],
-                           pos_formats[m_VtxAttr.PosFormat]);
+  dest += fmt::format("{}b skin: {} P: {} {}-{} ", m_VertexSize, m_VtxDesc.PosMatIdx,
+                      m_VtxAttr.PosElements ? 3 : 2, pos_mode[m_VtxDesc.Position],
+                      pos_formats[m_VtxAttr.PosFormat]);
 
   if (m_VtxDesc.Normal)
   {
-    dest += StringFromFormat("Nrm: %i %s-%s ", m_VtxAttr.NormalElements, pos_mode[m_VtxDesc.Normal],
-                             pos_formats[m_VtxAttr.NormalFormat]);
+    dest += fmt::format("Nrm: {} {}-{} ", m_VtxAttr.NormalElements, pos_mode[m_VtxDesc.Normal],
+                        pos_formats[m_VtxAttr.NormalFormat]);
   }
 
   const std::array<u64, 2> color_mode{{m_VtxDesc.Color0, m_VtxDesc.Color1}};
   for (size_t i = 0; i < color_mode.size(); i++)
   {
-    if (color_mode[i])
-    {
-      dest += StringFromFormat("C%zu: %i %s-%s ", i, m_VtxAttr.color[i].Elements,
-                               pos_mode[color_mode[i]], color_format[m_VtxAttr.color[i].Comp]);
-    }
+    if (color_mode[i] == 0)
+      continue;
+
+    const auto& color = m_VtxAttr.color[i];
+    dest += fmt::format("C{}: {} {}-{} ", i, color.Elements, pos_mode[color_mode[i]],
+                        color_format[color.Comp]);
   }
   const std::array<u64, 8> tex_mode{{m_VtxDesc.Tex0Coord, m_VtxDesc.Tex1Coord, m_VtxDesc.Tex2Coord,
                                      m_VtxDesc.Tex3Coord, m_VtxDesc.Tex4Coord, m_VtxDesc.Tex5Coord,
                                      m_VtxDesc.Tex6Coord, m_VtxDesc.Tex7Coord}};
   for (size_t i = 0; i < tex_mode.size(); i++)
   {
-    if (tex_mode[i])
-    {
-      dest += StringFromFormat("T%zu: %i %s-%s ", i, m_VtxAttr.texCoord[i].Elements,
-                               pos_mode[tex_mode[i]], pos_formats[m_VtxAttr.texCoord[i].Format]);
-    }
+    if (tex_mode[i] == 0)
+      continue;
+
+    const auto& tex_coord = m_VtxAttr.texCoord[i];
+    dest += fmt::format("T{}: {} {}-{} ", i, tex_coord.Elements, pos_mode[tex_mode[i]],
+                        pos_formats[tex_coord.Format]);
   }
-  dest += StringFromFormat(" - %i v", m_numLoadedVertices);
+  dest += fmt::format(" - {} v", m_numLoadedVertices);
   return dest;
 }
 


### PR DESCRIPTION
Migrates most of VideoCommon over to using fmt, with the exception being the shader generator code. The shader generators are quite large and have more corner cases to deal with in terms of conversion (shaders have braces in them, so we need to make sure to escape them).

Because of the large amount of code that would need to be converted, the conversion of VideoCommon will be in two parts:

- This change (which converts over the general case string formatting),
- A follow up change that will specifically deal with converting over the shader generators.