### PR TITLE
UICommon: Make use of fmt where applicable

### DIFF
--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -35,6 +35,7 @@ PUBLIC
   pugixml
 
 PRIVATE
+  fmt::fmt
   $<$<BOOL:APPLE>:${IOK_LIBRARY}>
 )
 

--- a/Source/Core/UICommon/Disassembler.cpp
+++ b/Source/Core/UICommon/Disassembler.cpp
@@ -1,20 +1,23 @@
+// Copyright 2008 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "UICommon/Disassembler.h"
+
+#include <sstream>
+
 #if defined(HAVE_LLVM)
 // PowerPC.h defines PC.
 // This conflicts with a function that has an argument named PC
 #undef PC
+#include <fmt/format.h>
 #include <llvm-c/Disassembler.h>
 #include <llvm-c/Target.h>
 #elif defined(_M_X86)
 #include <disasm.h>  // Bochs
 #endif
 
-#include "Common/StringUtil.h"
-
-#include "Core/PowerPC/JitCommon/JitBase.h"
-#include "Core/PowerPC/JitCommon/JitCache.h"
 #include "Core/PowerPC/JitInterface.h"
-
-#include "UICommon/Disassembler.h"
 
 #if defined(HAVE_LLVM)
 class HostDisassemblerLLVM : public HostDisassembler
@@ -85,7 +88,7 @@ std::string HostDisassemblerLLVM::DisassembleHostBlock(const u8* code_start, con
         // We can continue onward past this bad instruction.
         std::string inst_str;
         for (int i = 0; i < m_instruction_size; ++i)
-          inst_str += StringFromFormat("%02x", disasmPtr[i]);
+          inst_str += fmt::format("{:02x}", disasmPtr[i]);
 
         x86_disasm << inst_str << std::endl;
         disasmPtr += m_instruction_size;
@@ -96,7 +99,7 @@ std::string HostDisassemblerLLVM::DisassembleHostBlock(const u8* code_start, con
         // Dump the rest of the block instead
         std::string code_block;
         for (int i = 0; (disasmPtr + i) < end; ++i)
-          code_block += StringFromFormat("%02x", disasmPtr[i]);
+          code_block += fmt::format("{:02x}", disasmPtr[i]);
 
         x86_disasm << code_block << std::endl;
         break;

--- a/Source/Core/UICommon/Disassembler.h
+++ b/Source/Core/UICommon/Disassembler.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include "Common/CommonTypes.h"
 
 class HostDisassembler

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -4,9 +4,6 @@
 
 #include "UICommon/DiscordPresence.h"
 
-#include "Common/Hash.h"
-#include "Common/StringUtil.h"
-
 #include "Core/Config/NetplaySettings.h"
 #include "Core/Config/UISettings.h"
 #include "Core/ConfigManager.h"
@@ -16,8 +13,13 @@
 #include <algorithm>
 #include <cctype>
 #include <ctime>
-#include <discord-rpc/include/discord_rpc.h>
+#include <set>
 #include <string>
+
+#include <discord-rpc/include/discord_rpc.h>
+#include <fmt/format.h>
+
+#include "Common/Hash.h"
 
 #endif
 
@@ -39,7 +41,7 @@ void HandleDiscordJoinRequest(const DiscordUser* user)
   if (event_handler == nullptr)
     return;
 
-  const std::string discord_tag = StringFromFormat("%s#%s", user->username, user->discriminator);
+  const std::string discord_tag = fmt::format("{}#{}", user->username, user->discriminator);
   event_handler->DiscordJoinRequest(user->userId, discord_tag, user->avatar);
 }
 

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
 #include <pugixml.hpp>
 
 #include "Common/ChunkFile.h"
@@ -45,8 +46,6 @@ namespace UICommon
 {
 namespace
 {
-constexpr char COVER_URL[] = "https://art.gametdb.com/wii/cover/%s/%s.png";
-
 const std::string EMPTY_STRING;
 }  // Anonymous namespace
 
@@ -241,8 +240,8 @@ void GameFile::DownloadDefaultCover()
   }
 
   Common::HttpRequest request;
-  const auto response =
-      request.Get(StringFromFormat(COVER_URL, region_code.c_str(), m_gametdb_id.c_str()));
+  constexpr char cover_url[] = "https://art.gametdb.com/wii/cover/{}/{}.png";
+  const auto response = request.Get(fmt::format(cover_url, region_code, m_gametdb_id));
 
   if (!response)
     return;
@@ -541,8 +540,8 @@ std::string GameFile::GetUniqueIdentifier() const
   std::string lower_name = name;
   std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::tolower);
   if (disc_number > 1 &&
-      lower_name.find(StringFromFormat("disc %i", disc_number)) == std::string::npos &&
-      lower_name.find(StringFromFormat("disc%i", disc_number)) == std::string::npos)
+      lower_name.find(fmt::format("disc {}", disc_number)) == std::string::npos &&
+      lower_name.find(fmt::format("disc{}", disc_number)) == std::string::npos)
   {
     std::string disc_text = "Disc ";
     info.push_back(disc_text + std::to_string(disc_number));

--- a/Source/Core/UICommon/USBUtils.cpp
+++ b/Source/Core/UICommon/USBUtils.cpp
@@ -2,19 +2,22 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "UICommon/USBUtils.h"
+
+#include <string_view>
+
+#include <fmt/format.h>
 #ifdef __LIBUSB__
 #include <libusb.h>
 #endif
 
 #include "Common/CommonTypes.h"
-#include "Common/StringUtil.h"
 #include "Core/LibusbUtils.h"
-#include "UICommon/USBUtils.h"
 
 // Because opening and getting the device name from devices is slow, especially on Windows
 // with usbdk, we cannot do that for every single device. We should however still show
 // device names for known Wii peripherals.
-static const std::map<std::pair<u16, u16>, std::string> s_wii_peripherals = {{
+static const std::map<std::pair<u16, u16>, std::string_view> s_wii_peripherals{{
     {{0x046d, 0x0a03}, "Logitech Microphone"},
     {{0x057e, 0x0308}, "Wii Speak"},
     {{0x057e, 0x0309}, "Nintendo USB Microphone"},
@@ -54,7 +57,7 @@ std::map<std::pair<u16, u16>, std::string> GetInsertedDevices()
 std::string GetDeviceName(const std::pair<u16, u16> vid_pid)
 {
   const auto iter = s_wii_peripherals.find(vid_pid);
-  const std::string device_name = iter == s_wii_peripherals.cend() ? "Unknown" : iter->second;
-  return StringFromFormat("%04x:%04x - %s", vid_pid.first, vid_pid.second, device_name.c_str());
+  const std::string_view device_name = iter == s_wii_peripherals.cend() ? "Unknown" : iter->second;
+  return fmt::format("{:04x}:{:04x} - {}", vid_pid.first, vid_pid.second, device_name);
 }
 }  // namespace USBUtils

--- a/Source/Core/UICommon/X11Utils.cpp
+++ b/Source/Core/UICommon/X11Utils.cpp
@@ -13,6 +13,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <fmt/format.h>
+
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/Config/MainSettings.h"
@@ -156,7 +158,7 @@ void XRRConfiguration::Update()
             output_name = strdup(output_info->name);
             Config::SetBaseOrCurrent(
                 Config::MAIN_FULLSCREEN_DISPLAY_RES,
-                StringFromFormat("%s: %ux%u", output_info->name, fullWidth, fullHeight));
+                fmt::format("{}: {}x{}", output_info->name, fullWidth, fullHeight));
           }
           outputInfo = output_info;
           crtcInfo = crtc_info;


### PR DESCRIPTION
Continues the migration to using fmt.

Notably, this allows safely converting a map within USBUtils over to containing `std::string_view` instances, rather than `std::string` instances, as fmt safely handles the formatting of string views.