### PR TITLE
Android: Fix crash on enabling GC adapter

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/DolphinApplication.java
@@ -2,8 +2,11 @@ package org.dolphinemu.dolphinemu;
 
 import android.app.Application;
 import android.content.Context;
+import android.hardware.usb.UsbManager;
 
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
+import org.dolphinemu.dolphinemu.utils.Java_GCAdapter;
+import org.dolphinemu.dolphinemu.utils.Java_WiimoteAdapter;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
 import org.dolphinemu.dolphinemu.utils.VolleyUtil;
 
@@ -18,6 +21,9 @@ public class DolphinApplication extends Application
     application = this;
     VolleyUtil.init(getApplicationContext());
     System.loadLibrary("main");
+
+    Java_GCAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
+    Java_WiimoteAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
 
     if (PermissionsHandler.hasWriteAccess(getApplicationContext()))
       DirectoryInitialization.start(getApplicationContext());

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -1,11 +1,9 @@
 package org.dolphinemu.dolphinemu.activities;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
-import android.hardware.usb.UsbManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
@@ -48,8 +46,6 @@ import org.dolphinemu.dolphinemu.ui.main.MainActivity;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.utils.ControllerMappingHelper;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
-import org.dolphinemu.dolphinemu.utils.Java_GCAdapter;
-import org.dolphinemu.dolphinemu.utils.Java_WiimoteAdapter;
 import org.dolphinemu.dolphinemu.utils.MotionListener;
 import org.dolphinemu.dolphinemu.utils.Rumble;
 import org.dolphinemu.dolphinemu.utils.TvUtil;
@@ -304,8 +300,6 @@ public final class EmulationActivity extends AppCompatActivity
 
     setTheme(themeId);
 
-    Java_GCAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
-    Java_WiimoteAdapter.manager = (UsbManager) getSystemService(Context.USB_SERVICE);
     Rumble.initRumble(this);
 
     setContentView(R.layout.activity_emulation);


### PR DESCRIPTION
We must set `Java_GCAdapter.manager` before the GC adapter thread (C++) starts. We used to set it at emulation start, which was fine until PR #8190 made the GC adapter thread start much earlier.