### PR TITLE
Common: Unify logging namespace with Common

### DIFF
--- a/Source/Core/AudioCommon/CubebUtils.cpp
+++ b/Source/Core/AudioCommon/CubebUtils.cpp
@@ -18,7 +18,7 @@ static ptrdiff_t s_path_cutoff_point = 0;
 
 static void LogCallback(const char* format, ...)
 {
-  if (!LogManager::GetInstance())
+  if (!Common::Log::LogManager::GetInstance())
     return;
 
   va_list args;
@@ -28,8 +28,8 @@ static void LogCallback(const char* format, ...)
   int lineno = va_arg(args, int);
   std::string adapted_format(StripSpaces(format + strlen("%s:%d:")));
 
-  LogManager::GetInstance()->LogWithFullPath(LogTypes::LNOTICE, LogTypes::AUDIO, filename, lineno,
-                                             adapted_format.c_str(), args);
+  Common::Log::LogManager::GetInstance()->LogWithFullPath(
+      Common::Log::LNOTICE, Common::Log::AUDIO, filename, lineno, adapted_format.c_str(), args);
   va_end(args);
 }
 

--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -23,7 +23,7 @@
 #define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
   do                                                                                               \
   {                                                                                                \
-    if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG && !(_a_))                                    \
+    if (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG && !(_a_))                                 \
     {                                                                                              \
       ERROR_LOG(_t_, _msg_, __VA_ARGS__);                                                          \
       if (!PanicYesNo(_msg_, __VA_ARGS__))                                                         \
@@ -44,7 +44,7 @@
 #define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
   do                                                                                               \
   {                                                                                                \
-    if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG && !(_a_))                                    \
+    if (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG && !(_a_))                                 \
     {                                                                                              \
       ERROR_LOG(_t_, _msg_, ##__VA_ARGS__);                                                        \
       if (!PanicYesNo(_msg_, ##__VA_ARGS__))                                                       \
@@ -64,6 +64,6 @@
 #define DEBUG_ASSERT(_a_)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG)                                              \
+    if (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                                           \
       ASSERT(_a_);                                                                                 \
   } while (0)

--- a/Source/Core/Common/Logging/ConsoleListener.h
+++ b/Source/Core/Common/Logging/ConsoleListener.h
@@ -6,13 +6,13 @@
 
 #include "Common/Logging/LogManager.h"
 
-class ConsoleListener : public LogListener
+class ConsoleListener : public Common::Log::LogListener
 {
 public:
   ConsoleListener();
   ~ConsoleListener();
 
-  void Log(LogTypes::LOG_LEVELS, const char* text) override;
+  void Log(Common::Log::LOG_LEVELS level, const char* text) override;
 
 private:
   bool m_use_color;

--- a/Source/Core/Common/Logging/ConsoleListenerDroid.cpp
+++ b/Source/Core/Common/Logging/ConsoleListenerDroid.cpp
@@ -14,26 +14,26 @@ ConsoleListener::~ConsoleListener()
 {
 }
 
-void ConsoleListener::Log(LogTypes::LOG_LEVELS level, const char* text)
+void ConsoleListener::Log(Common::Log::LOG_LEVELS level, const char* text)
 {
   android_LogPriority logLevel = ANDROID_LOG_UNKNOWN;
 
   // Map dolphin's log levels to android's
   switch (level)
   {
-  case LogTypes::LOG_LEVELS::LDEBUG:
+  case Common::Log::LOG_LEVELS::LDEBUG:
     logLevel = ANDROID_LOG_DEBUG;
     break;
-  case LogTypes::LOG_LEVELS::LINFO:
+  case Common::Log::LOG_LEVELS::LINFO:
     logLevel = ANDROID_LOG_INFO;
     break;
-  case LogTypes::LOG_LEVELS::LWARNING:
+  case Common::Log::LOG_LEVELS::LWARNING:
     logLevel = ANDROID_LOG_WARN;
     break;
-  case LogTypes::LOG_LEVELS::LERROR:
+  case Common::Log::LOG_LEVELS::LERROR:
     logLevel = ANDROID_LOG_ERROR;
     break;
-  case LogTypes::LOG_LEVELS::LNOTICE:
+  case Common::Log::LOG_LEVELS::LNOTICE:
     logLevel = ANDROID_LOG_INFO;
     break;
   }

--- a/Source/Core/Common/Logging/ConsoleListenerNix.cpp
+++ b/Source/Core/Common/Logging/ConsoleListenerNix.cpp
@@ -22,7 +22,7 @@ ConsoleListener::~ConsoleListener()
   fflush(nullptr);
 }
 
-void ConsoleListener::Log(LogTypes::LOG_LEVELS level, const char* text)
+void ConsoleListener::Log(Common::Log::LOG_LEVELS level, const char* text)
 {
   char color_attr[16] = "";
   char reset_attr[16] = "";
@@ -32,15 +32,15 @@ void ConsoleListener::Log(LogTypes::LOG_LEVELS level, const char* text)
     strcpy(reset_attr, "\x1b[0m");
     switch (level)
     {
-    case LogTypes::LOG_LEVELS::LNOTICE:
+    case Common::Log::LOG_LEVELS::LNOTICE:
       // light green
       strcpy(color_attr, "\x1b[92m");
       break;
-    case LogTypes::LOG_LEVELS::LERROR:
+    case Common::Log::LOG_LEVELS::LERROR:
       // light red
       strcpy(color_attr, "\x1b[91m");
       break;
-    case LogTypes::LOG_LEVELS::LWARNING:
+    case Common::Log::LOG_LEVELS::LWARNING:
       // light yellow
       strcpy(color_attr, "\x1b[93m");
       break;

--- a/Source/Core/Common/Logging/ConsoleListenerWin.cpp
+++ b/Source/Core/Common/Logging/ConsoleListenerWin.cpp
@@ -15,7 +15,7 @@ ConsoleListener::~ConsoleListener()
 {
 }
 
-void ConsoleListener::Log(LogTypes::LOG_LEVELS level, const char* text)
+void ConsoleListener::Log([[maybe_unused]] Common::Log::LOG_LEVELS level, const char* text)
 {
   ::OutputDebugStringW(UTF8ToUTF16(text).c_str());
 }

--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-namespace LogTypes
+namespace Common::Log
 {
 enum LOG_TYPE
 {
@@ -72,20 +72,19 @@ enum LOG_LEVELS
 
 static const char LOG_LEVEL_TO_CHAR[7] = "-NEWID";
 
-}  // namespace LogTypes
-
-void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file, int line,
-                const char* fmt, ...)
+void GenericLog(Common::Log::LOG_LEVELS level, Common::Log::LOG_TYPE type, const char* file,
+                int line, const char* fmt, ...)
 #ifdef __GNUC__
     __attribute__((format(printf, 5, 6)))
 #endif
     ;
+}  // namespace Common::Log
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
-#define MAX_LOGLEVEL LogTypes::LOG_LEVELS::LDEBUG
+#define MAX_LOGLEVEL Common::Log::LOG_LEVELS::LDEBUG
 #else
 #ifndef MAX_LOGLEVEL
-#define MAX_LOGLEVEL LogTypes::LOG_LEVELS::LINFO
+#define MAX_LOGLEVEL Common::Log::LOG_LEVELS::LINFO
 #endif  // loglevel
 #endif  // logging
 
@@ -94,31 +93,31 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char*
   do                                                                                               \
   {                                                                                                \
     if (v <= MAX_LOGLEVEL)                                                                         \
-      GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__);                                           \
+      Common::Log::GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__);                              \
   } while (0)
 
 #define ERROR_LOG(t, ...)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__);                                       \
+    GENERIC_LOG(Common::Log::t, Common::Log::LERROR, __VA_ARGS__);                                 \
   } while (0)
 #define WARN_LOG(t, ...)                                                                           \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__);                                     \
+    GENERIC_LOG(Common::Log::t, Common::Log::LWARNING, __VA_ARGS__);                               \
   } while (0)
 #define NOTICE_LOG(t, ...)                                                                         \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__);                                      \
+    GENERIC_LOG(Common::Log::t, Common::Log::LNOTICE, __VA_ARGS__);                                \
   } while (0)
 #define INFO_LOG(t, ...)                                                                           \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__);                                        \
+    GENERIC_LOG(Common::Log::t, Common::Log::LINFO, __VA_ARGS__);                                  \
   } while (0)
 #define DEBUG_LOG(t, ...)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__);                                       \
+    GENERIC_LOG(Common::Log::t, Common::Log::LDEBUG, __VA_ARGS__);                                 \
   } while (0)

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -22,6 +22,8 @@
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
 
+namespace Common::Log
+{
 constexpr size_t MAX_MSGLEN = 1024;
 
 const Config::ConfigInfo<bool> LOGGER_WRITE_TO_FILE{
@@ -41,7 +43,7 @@ public:
     SetEnable(true);
   }
 
-  void Log(LogTypes::LOG_LEVELS, const char* msg) override
+  void Log(LOG_LEVELS, const char* msg) override
   {
     if (!IsEnabled() || !IsValid())
       return;
@@ -60,8 +62,7 @@ private:
   bool m_enable;
 };
 
-void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file, int line,
-                const char* fmt, ...)
+void GenericLog(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, const char* fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -92,55 +93,55 @@ static size_t DeterminePathCutOffPoint()
 LogManager::LogManager()
 {
   // create log containers
-  m_log[LogTypes::ACTIONREPLAY] = {"ActionReplay", "ActionReplay"};
-  m_log[LogTypes::AUDIO] = {"Audio", "Audio Emulator"};
-  m_log[LogTypes::AUDIO_INTERFACE] = {"AI", "Audio Interface"};
-  m_log[LogTypes::BOOT] = {"BOOT", "Boot"};
-  m_log[LogTypes::COMMANDPROCESSOR] = {"CP", "CommandProc"};
-  m_log[LogTypes::COMMON] = {"COMMON", "Common"};
-  m_log[LogTypes::CONSOLE] = {"CONSOLE", "Dolphin Console"};
-  m_log[LogTypes::CORE] = {"CORE", "Core"};
-  m_log[LogTypes::DISCIO] = {"DIO", "Disc IO"};
-  m_log[LogTypes::DSPHLE] = {"DSPHLE", "DSP HLE"};
-  m_log[LogTypes::DSPLLE] = {"DSPLLE", "DSP LLE"};
-  m_log[LogTypes::DSP_MAIL] = {"DSPMails", "DSP Mails"};
-  m_log[LogTypes::DSPINTERFACE] = {"DSP", "DSPInterface"};
-  m_log[LogTypes::DVDINTERFACE] = {"DVD", "DVD Interface"};
-  m_log[LogTypes::DYNA_REC] = {"JIT", "Dynamic Recompiler"};
-  m_log[LogTypes::EXPANSIONINTERFACE] = {"EXI", "Expansion Interface"};
-  m_log[LogTypes::FILEMON] = {"FileMon", "File Monitor"};
-  m_log[LogTypes::GDB_STUB] = {"GDB_STUB", "GDB Stub"};
-  m_log[LogTypes::GPFIFO] = {"GP", "GPFifo"};
-  m_log[LogTypes::HOST_GPU] = {"Host GPU", "Host GPU"};
-  m_log[LogTypes::IOS] = {"IOS", "IOS"};
-  m_log[LogTypes::IOS_DI] = {"IOS_DI", "IOS - Drive Interface"};
-  m_log[LogTypes::IOS_ES] = {"IOS_ES", "IOS - ETicket Services"};
-  m_log[LogTypes::IOS_FS] = {"IOS_FS", "IOS - Filesystem Services"};
-  m_log[LogTypes::IOS_SD] = {"IOS_SD", "IOS - SDIO"};
-  m_log[LogTypes::IOS_SSL] = {"IOS_SSL", "IOS - SSL"};
-  m_log[LogTypes::IOS_STM] = {"IOS_STM", "IOS - State Transition Manager"};
-  m_log[LogTypes::IOS_NET] = {"IOS_NET", "IOS - Network"};
-  m_log[LogTypes::IOS_USB] = {"IOS_USB", "IOS - USB"};
-  m_log[LogTypes::IOS_WC24] = {"IOS_WC24", "IOS - WiiConnect24"};
-  m_log[LogTypes::IOS_WFS] = {"IOS_WFS", "IOS - WFS"};
-  m_log[LogTypes::IOS_WIIMOTE] = {"IOS_WIIMOTE", "IOS - Wii Remote"};
-  m_log[LogTypes::MASTER_LOG] = {"MASTER", "Master Log"};
-  m_log[LogTypes::MEMCARD_MANAGER] = {"MemCard Manager", "MemCard Manager"};
-  m_log[LogTypes::MEMMAP] = {"MI", "MI & memmap"};
-  m_log[LogTypes::NETPLAY] = {"NETPLAY", "Netplay"};
-  m_log[LogTypes::OSHLE] = {"HLE", "HLE"};
-  m_log[LogTypes::OSREPORT] = {"OSREPORT", "OSReport"};
-  m_log[LogTypes::PAD] = {"PAD", "Pad"};
-  m_log[LogTypes::PIXELENGINE] = {"PE", "PixelEngine"};
-  m_log[LogTypes::PROCESSORINTERFACE] = {"PI", "ProcessorInt"};
-  m_log[LogTypes::POWERPC] = {"PowerPC", "IBM CPU"};
-  m_log[LogTypes::SERIALINTERFACE] = {"SI", "Serial Interface"};
-  m_log[LogTypes::SP1] = {"SP1", "Serial Port 1"};
-  m_log[LogTypes::SYMBOLS] = {"SYMBOLS", "Symbols"};
-  m_log[LogTypes::VIDEO] = {"Video", "Video Backend"};
-  m_log[LogTypes::VIDEOINTERFACE] = {"VI", "Video Interface"};
-  m_log[LogTypes::WIIMOTE] = {"Wiimote", "Wiimote"};
-  m_log[LogTypes::WII_IPC] = {"WII_IPC", "WII IPC"};
+  m_log[ACTIONREPLAY] = {"ActionReplay", "ActionReplay"};
+  m_log[AUDIO] = {"Audio", "Audio Emulator"};
+  m_log[AUDIO_INTERFACE] = {"AI", "Audio Interface"};
+  m_log[BOOT] = {"BOOT", "Boot"};
+  m_log[COMMANDPROCESSOR] = {"CP", "CommandProc"};
+  m_log[COMMON] = {"COMMON", "Common"};
+  m_log[CONSOLE] = {"CONSOLE", "Dolphin Console"};
+  m_log[CORE] = {"CORE", "Core"};
+  m_log[DISCIO] = {"DIO", "Disc IO"};
+  m_log[DSPHLE] = {"DSPHLE", "DSP HLE"};
+  m_log[DSPLLE] = {"DSPLLE", "DSP LLE"};
+  m_log[DSP_MAIL] = {"DSPMails", "DSP Mails"};
+  m_log[DSPINTERFACE] = {"DSP", "DSPInterface"};
+  m_log[DVDINTERFACE] = {"DVD", "DVD Interface"};
+  m_log[DYNA_REC] = {"JIT", "Dynamic Recompiler"};
+  m_log[EXPANSIONINTERFACE] = {"EXI", "Expansion Interface"};
+  m_log[FILEMON] = {"FileMon", "File Monitor"};
+  m_log[GDB_STUB] = {"GDB_STUB", "GDB Stub"};
+  m_log[GPFIFO] = {"GP", "GPFifo"};
+  m_log[HOST_GPU] = {"Host GPU", "Host GPU"};
+  m_log[IOS] = {"IOS", "IOS"};
+  m_log[IOS_DI] = {"IOS_DI", "IOS - Drive Interface"};
+  m_log[IOS_ES] = {"IOS_ES", "IOS - ETicket Services"};
+  m_log[IOS_FS] = {"IOS_FS", "IOS - Filesystem Services"};
+  m_log[IOS_SD] = {"IOS_SD", "IOS - SDIO"};
+  m_log[IOS_SSL] = {"IOS_SSL", "IOS - SSL"};
+  m_log[IOS_STM] = {"IOS_STM", "IOS - State Transition Manager"};
+  m_log[IOS_NET] = {"IOS_NET", "IOS - Network"};
+  m_log[IOS_USB] = {"IOS_USB", "IOS - USB"};
+  m_log[IOS_WC24] = {"IOS_WC24", "IOS - WiiConnect24"};
+  m_log[IOS_WFS] = {"IOS_WFS", "IOS - WFS"};
+  m_log[IOS_WIIMOTE] = {"IOS_WIIMOTE", "IOS - Wii Remote"};
+  m_log[MASTER_LOG] = {"MASTER", "Master Log"};
+  m_log[MEMCARD_MANAGER] = {"MemCard Manager", "MemCard Manager"};
+  m_log[MEMMAP] = {"MI", "MI & memmap"};
+  m_log[NETPLAY] = {"NETPLAY", "Netplay"};
+  m_log[OSHLE] = {"HLE", "HLE"};
+  m_log[OSREPORT] = {"OSREPORT", "OSReport"};
+  m_log[PAD] = {"PAD", "Pad"};
+  m_log[PIXELENGINE] = {"PE", "PixelEngine"};
+  m_log[PROCESSORINTERFACE] = {"PI", "ProcessorInt"};
+  m_log[POWERPC] = {"PowerPC", "IBM CPU"};
+  m_log[SERIALINTERFACE] = {"SI", "Serial Interface"};
+  m_log[SP1] = {"SP1", "Serial Port 1"};
+  m_log[SYMBOLS] = {"SYMBOLS", "Symbols"};
+  m_log[VIDEO] = {"Video", "Video Backend"};
+  m_log[VIDEOINTERFACE] = {"VI", "Video Interface"};
+  m_log[WIIMOTE] = {"Wiimote", "Wiimote"};
+  m_log[WII_IPC] = {"WII_IPC", "WII IPC"};
 
   RegisterListener(LogListener::FILE_LISTENER,
                    new FileLogListener(File::GetUserPath(F_MAINLOG_IDX)));
@@ -155,7 +156,7 @@ LogManager::LogManager()
   if (verbosity > MAX_LOGLEVEL)
     verbosity = MAX_LOGLEVEL;
 
-  SetLogLevel(static_cast<LogTypes::LOG_LEVELS>(verbosity));
+  SetLogLevel(static_cast<LOG_LEVELS>(verbosity));
   EnableListener(LogListener::FILE_LISTENER, Config::Get(LOGGER_WRITE_TO_FILE));
   EnableListener(LogListener::CONSOLE_LISTENER, Config::Get(LOGGER_WRITE_TO_CONSOLE));
   EnableListener(LogListener::LOG_WINDOW_LISTENER, Config::Get(LOGGER_WRITE_TO_WINDOW));
@@ -195,14 +196,14 @@ void LogManager::SaveSettings()
   Config::Save();
 }
 
-void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file,
-                     int line, const char* format, va_list args)
+void LogManager::Log(LOG_LEVELS level, LOG_TYPE type, const char* file, int line,
+                     const char* format, va_list args)
 {
   return LogWithFullPath(level, type, file + m_path_cutoff_point, line, format, args);
 }
 
-void LogManager::LogWithFullPath(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
-                                 const char* file, int line, const char* format, va_list args)
+void LogManager::LogWithFullPath(LOG_LEVELS level, LOG_TYPE type, const char* file, int line,
+                                 const char* format, va_list args)
 {
   if (!IsEnabled(type, level) || !static_cast<bool>(m_listener_ids))
     return;
@@ -212,39 +213,39 @@ void LogManager::LogWithFullPath(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE 
 
   const std::string msg =
       fmt::format("{} {}:{} {}[{}]: {}\n", Common::Timer::GetTimeFormatted(), file, line,
-                  LogTypes::LOG_LEVEL_TO_CHAR[(int)level], GetShortName(type), temp);
+                  LOG_LEVEL_TO_CHAR[static_cast<int>(level)], GetShortName(type), temp);
 
   for (auto listener_id : m_listener_ids)
     if (m_listeners[listener_id])
       m_listeners[listener_id]->Log(level, msg.c_str());
 }
 
-LogTypes::LOG_LEVELS LogManager::GetLogLevel() const
+LOG_LEVELS LogManager::GetLogLevel() const
 {
   return m_level;
 }
 
-void LogManager::SetLogLevel(LogTypes::LOG_LEVELS level)
+void LogManager::SetLogLevel(LOG_LEVELS level)
 {
   m_level = level;
 }
 
-void LogManager::SetEnable(LogTypes::LOG_TYPE type, bool enable)
+void LogManager::SetEnable(LOG_TYPE type, bool enable)
 {
   m_log[type].m_enable = enable;
 }
 
-bool LogManager::IsEnabled(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level) const
+bool LogManager::IsEnabled(LOG_TYPE type, LOG_LEVELS level) const
 {
   return m_log[type].m_enable && GetLogLevel() >= level;
 }
 
-const char* LogManager::GetShortName(LogTypes::LOG_TYPE type) const
+const char* LogManager::GetShortName(LOG_TYPE type) const
 {
   return m_log[type].m_short_name;
 }
 
-const char* LogManager::GetFullName(LogTypes::LOG_TYPE type) const
+const char* LogManager::GetFullName(LOG_TYPE type) const
 {
   return m_log[type].m_full_name;
 }
@@ -284,3 +285,4 @@ void LogManager::Shutdown()
   delete s_log_manager;
   s_log_manager = nullptr;
 }
+}  // namespace Common::Log

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -10,12 +10,14 @@
 #include "Common/BitSet.h"
 #include "Common/Logging/Log.h"
 
+namespace Common::Log
+{
 // pure virtual interface
 class LogListener
 {
 public:
-  virtual ~LogListener() {}
-  virtual void Log(LogTypes::LOG_LEVELS, const char* msg) = 0;
+  virtual ~LogListener() = default;
+  virtual void Log(LOG_LEVELS level, const char* msg) = 0;
 
   enum LISTENER
   {
@@ -34,19 +36,19 @@ public:
   static void Init();
   static void Shutdown();
 
-  void Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file, int line,
-           const char* fmt, va_list args);
-  void LogWithFullPath(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file,
-                       int line, const char* fmt, va_list args);
+  void Log(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, const char* fmt,
+           va_list args);
+  void LogWithFullPath(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, const char* fmt,
+                       va_list args);
 
-  LogTypes::LOG_LEVELS GetLogLevel() const;
-  void SetLogLevel(LogTypes::LOG_LEVELS level);
+  LOG_LEVELS GetLogLevel() const;
+  void SetLogLevel(LOG_LEVELS level);
 
-  void SetEnable(LogTypes::LOG_TYPE type, bool enable);
-  bool IsEnabled(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level = LogTypes::LNOTICE) const;
+  void SetEnable(LOG_TYPE type, bool enable);
+  bool IsEnabled(LOG_TYPE type, LOG_LEVELS level = LNOTICE) const;
 
-  const char* GetShortName(LogTypes::LOG_TYPE type) const;
-  const char* GetFullName(LogTypes::LOG_TYPE type) const;
+  const char* GetShortName(LOG_TYPE type) const;
+  const char* GetFullName(LOG_TYPE type) const;
 
   void RegisterListener(LogListener::LISTENER id, LogListener* listener);
   void EnableListener(LogListener::LISTENER id, bool enable);
@@ -70,9 +72,10 @@ private:
   LogManager(LogManager&&) = delete;
   LogManager& operator=(LogManager&&) = delete;
 
-  LogTypes::LOG_LEVELS m_level;
-  std::array<LogContainer, LogTypes::NUMBER_OF_LOGS> m_log{};
+  LOG_LEVELS m_level;
+  std::array<LogContainer, NUMBER_OF_LOGS> m_log{};
   std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners{};
   BitSet32 m_listener_ids;
   size_t m_path_cutoff_point = 0;
 };
+}  // namespace Common::Log

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -312,7 +312,7 @@ static void VLogInfo(std::string_view format, fmt::format_args args)
     return;
 
   const bool use_internal_log = s_use_internal_log.load(std::memory_order_relaxed);
-  if (MAX_LOGLEVEL < LogTypes::LINFO && !use_internal_log)
+  if (MAX_LOGLEVEL < Common::Log::LINFO && !use_internal_log)
     return;
 
   std::string text = fmt::vformat(format, args);

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -120,7 +120,7 @@ void PrintCallstack()
   });
 }
 
-void PrintCallstack(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level)
+void PrintCallstack(Common::Log::LOG_TYPE type, Common::Log::LOG_LEVELS level)
 {
   GENERIC_LOG(type, level, "== STACK TRACE - SP = %08x ==", PowerPC::ppcState.gpr[1]);
 
@@ -142,9 +142,10 @@ void PrintCallstack(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level)
   });
 }
 
-void PrintDataBuffer(LogTypes::LOG_TYPE type, const u8* data, size_t size, const std::string& title)
+void PrintDataBuffer(Common::Log::LOG_TYPE type, const u8* data, size_t size,
+                     const std::string& title)
 {
-  GENERIC_LOG(type, LogTypes::LDEBUG, "%s", title.c_str());
+  GENERIC_LOG(type, Common::Log::LDEBUG, "%s", title.c_str());
   for (u32 j = 0; j < size;)
   {
     std::string hex_line;
@@ -155,7 +156,7 @@ void PrintDataBuffer(LogTypes::LOG_TYPE type, const u8* data, size_t size, const
       if (j >= size)
         break;
     }
-    GENERIC_LOG(type, LogTypes::LDEBUG, "   Data: %s", hex_line.c_str());
+    GENERIC_LOG(type, Common::Log::LDEBUG, "   Data: %s", hex_line.c_str());
   }
 }
 

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.h
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.h
@@ -20,8 +20,8 @@ struct CallstackEntry
 
 bool GetCallstack(std::vector<CallstackEntry>& output);
 void PrintCallstack();
-void PrintCallstack(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level);
-void PrintDataBuffer(LogTypes::LOG_TYPE type, const u8* data, size_t size,
+void PrintCallstack(Common::Log::LOG_TYPE type, Common::Log::LOG_LEVELS level);
+void PrintDataBuffer(Common::Log::LOG_TYPE type, const u8* data, size_t size,
                      const std::string& title);
 void AddAutoBreakpoints();
 

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -54,8 +54,11 @@ static bool IsSoundFile(const std::string& filename)
 void Log(const DiscIO::Volume& volume, const DiscIO::Partition& partition, u64 offset)
 {
   // Do nothing if the log isn't selected
-  if (!LogManager::GetInstance()->IsEnabled(LogTypes::FILEMON, LogTypes::LWARNING))
+  if (!Common::Log::LogManager::GetInstance()->IsEnabled(Common::Log::FILEMON,
+                                                         Common::Log::LWARNING))
+  {
     return;
+  }
 
   const DiscIO::FileSystem* file_system = volume.GetFileSystem(partition);
 

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -338,10 +338,10 @@ int CSIDevice_GBA::RunBuffer(u8* buffer, int request_length)
       return sizeof(reply);
     }
 #ifdef _DEBUG
-    LogTypes::LOG_LEVELS log_level = (m_last_cmd == CMD_STATUS || m_last_cmd == CMD_RESET) ?
-                                         LogTypes::LERROR :
-                                         LogTypes::LWARNING;
-    GENERIC_LOG(LogTypes::SERIALINTERFACE, log_level,
+    const Common::Log::LOG_LEVELS log_level =
+        (m_last_cmd == CMD_STATUS || m_last_cmd == CMD_RESET) ? Common::Log::LERROR :
+                                                                Common::Log::LWARNING;
+    GENERIC_LOG(Common::Log::SERIALINTERFACE, log_level,
                 "%01d                              [< %02x%02x%02x%02x%02x] (%i)", m_device_number,
                 buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], num_data_received);
 #endif

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -115,7 +115,7 @@ IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
     break;
   }
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_DI);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_DI);
   }
   return GetDefaultReply(return_value);
 }

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -94,15 +94,15 @@ bool IOCtlVRequest::HasNumberOfValidVectors(const size_t in_count, const size_t 
          std::all_of(io_vectors.begin(), io_vectors.end(), IsValidVector);
 }
 
-void IOCtlRequest::Log(const std::string& device_name, LogTypes::LOG_TYPE type,
-                       LogTypes::LOG_LEVELS verbosity) const
+void IOCtlRequest::Log(const std::string& device_name, Common::Log::LOG_TYPE type,
+                       Common::Log::LOG_LEVELS verbosity) const
 {
   GENERIC_LOG(type, verbosity, "%s (fd %u) - IOCtl 0x%x (in_size=0x%x, out_size=0x%x)",
               device_name.c_str(), fd, request, buffer_in_size, buffer_out_size);
 }
 
-void IOCtlRequest::Dump(const std::string& description, LogTypes::LOG_TYPE type,
-                        LogTypes::LOG_LEVELS level) const
+void IOCtlRequest::Dump(const std::string& description, Common::Log::LOG_TYPE type,
+                        Common::Log::LOG_LEVELS level) const
 {
   Log("===== " + description, type, level);
   GENERIC_LOG(type, level, "In buffer\n%s",
@@ -111,14 +111,14 @@ void IOCtlRequest::Dump(const std::string& description, LogTypes::LOG_TYPE type,
               HexDump(Memory::GetPointer(buffer_out), buffer_out_size).c_str());
 }
 
-void IOCtlRequest::DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type,
-                               LogTypes::LOG_LEVELS level) const
+void IOCtlRequest::DumpUnknown(const std::string& description, Common::Log::LOG_TYPE type,
+                               Common::Log::LOG_LEVELS level) const
 {
   Dump("Unknown IOCtl - " + description, type, level);
 }
 
-void IOCtlVRequest::Dump(const std::string& description, LogTypes::LOG_TYPE type,
-                         LogTypes::LOG_LEVELS level) const
+void IOCtlVRequest::Dump(const std::string& description, Common::Log::LOG_TYPE type,
+                         Common::Log::LOG_LEVELS level) const
 {
   GENERIC_LOG(type, level, "===== %s (fd %u) - IOCtlV 0x%x (%zu in, %zu io)", description.c_str(),
               fd, request, in_vectors.size(), io_vectors.size());
@@ -133,8 +133,8 @@ void IOCtlVRequest::Dump(const std::string& description, LogTypes::LOG_TYPE type
     GENERIC_LOG(type, level, "io[%zu] (size=0x%x)", i++, vector.size);
 }
 
-void IOCtlVRequest::DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type,
-                                LogTypes::LOG_LEVELS level) const
+void IOCtlVRequest::DumpUnknown(const std::string& description, Common::Log::LOG_TYPE type,
+                                Common::Log::LOG_LEVELS level) const
 {
   Dump("Unknown IOCtlV - " + description, type, level);
 }

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -130,12 +130,12 @@ struct IOCtlRequest final : Request
   u32 buffer_out = 0;
   u32 buffer_out_size = 0;
   explicit IOCtlRequest(u32 address);
-  void Log(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
-           LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
-  void Dump(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
-            LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
-  void DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
-                   LogTypes::LOG_LEVELS level = LogTypes::LERROR) const;
+  void Log(const std::string& description, Common::Log::LOG_TYPE type = Common::Log::IOS,
+           Common::Log::LOG_LEVELS level = Common::Log::LINFO) const;
+  void Dump(const std::string& description, Common::Log::LOG_TYPE type = Common::Log::IOS,
+            Common::Log::LOG_LEVELS level = Common::Log::LINFO) const;
+  void DumpUnknown(const std::string& description, Common::Log::LOG_TYPE type = Common::Log::IOS,
+                   Common::Log::LOG_LEVELS level = Common::Log::LERROR) const;
 };
 
 struct IOCtlVRequest final : Request
@@ -157,10 +157,10 @@ struct IOCtlVRequest final : Request
   const IOVector* GetVector(size_t index) const;
   explicit IOCtlVRequest(u32 address);
   bool HasNumberOfValidVectors(size_t in_count, size_t io_count) const;
-  void Dump(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
-            LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
-  void DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
-                   LogTypes::LOG_LEVELS level = LogTypes::LERROR) const;
+  void Dump(const std::string& description, Common::Log::LOG_TYPE type = Common::Log::IOS,
+            Common::Log::LOG_LEVELS level = Common::Log::LINFO) const;
+  void DumpUnknown(const std::string& description, Common::Log::LOG_TYPE type = Common::Log::IOS,
+                   Common::Log::LOG_LEVELS level = Common::Log::LERROR) const;
 };
 
 namespace Device

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -541,7 +541,7 @@ IPCCommandResult ES::IOCtlV(const IOCtlVRequest& request)
   case IOCTL_ES_UNKNOWN_42:
     PanicAlert("IOS-ES: Unimplemented ioctlv 0x%x (%zu in vectors, %zu io vectors)",
                request.request, request.in_vectors.size(), request.io_vectors.size());
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_ES, LogTypes::LERROR);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_ES, Common::Log::LERROR);
     return GetDefaultReply(IPC_EINVAL);
 
   case IOCTL_ES_INVALID_3F:

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -51,7 +51,8 @@ template <typename... Args>
 static void LogResult(ResultCode code, std::string_view format, Args&&... args)
 {
   const std::string command = fmt::format(format, std::forward<Args>(args)...);
-  GENERIC_LOG(LogTypes::IOS_FS, (code == ResultCode::Success ? LogTypes::LINFO : LogTypes::LERROR),
+  GENERIC_LOG(Common::Log::IOS_FS,
+              (code == ResultCode::Success ? Common::Log::LINFO : Common::Log::LERROR),
               "%s: result %d", command.c_str(), ConvertResult(code));
 }
 

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -315,7 +315,7 @@ IPCCommandResult NetIPTop::IOCtl(const IOCtlRequest& request)
   case IOCTL_SO_ICMPCANCEL:
     return HandleICMPCancelRequest(request);
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_NET);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_NET);
     break;
   }
 
@@ -337,7 +337,7 @@ IPCCommandResult NetIPTop::IOCtlV(const IOCtlVRequest& request)
   case IOCTLV_SO_ICMPPING:
     return HandleICMPPingRequest(request);
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_NET);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_NET);
     break;
   }
 
@@ -351,7 +351,7 @@ void NetIPTop::Update()
 
 IPCCommandResult NetIPTop::HandleStartUpRequest(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+  request.Log(GetDeviceName(), Common::Log::IOS_WC24);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
@@ -404,7 +404,7 @@ IPCCommandResult NetIPTop::HandleDoSockRequest(const IOCtlRequest& request)
 
 IPCCommandResult NetIPTop::HandleShutdownRequest(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+  request.Log(GetDeviceName(), Common::Log::IOS_WC24);
 
   u32 fd = Memory::Read_U32(request.buffer_in);
   u32 how = Memory::Read_U32(request.buffer_in + 4);
@@ -419,7 +419,7 @@ IPCCommandResult NetIPTop::HandleListenRequest(const IOCtlRequest& request)
   u32 BACKLOG = Memory::Read_U32(request.buffer_in + 0x04);
   u32 ret = listen(WiiSockMan::GetInstance().GetHostSocket(fd), BACKLOG);
 
-  request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+  request.Log(GetDeviceName(), Common::Log::IOS_WC24);
   return GetDefaultReply(WiiSockMan::GetNetErrorCode(ret, "SO_LISTEN", false));
 }
 
@@ -429,7 +429,7 @@ IPCCommandResult NetIPTop::HandleGetSockOptRequest(const IOCtlRequest& request)
   u32 level = Memory::Read_U32(request.buffer_out + 4);
   u32 optname = Memory::Read_U32(request.buffer_out + 8);
 
-  request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+  request.Log(GetDeviceName(), Common::Log::IOS_WC24);
 
   // Do the level/optname translation
   int nat_level = MapWiiSockOptLevelToNative(level);
@@ -495,7 +495,7 @@ IPCCommandResult NetIPTop::HandleGetSockNameRequest(const IOCtlRequest& request)
 {
   u32 fd = Memory::Read_U32(request.buffer_in);
 
-  request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+  request.Log(GetDeviceName(), Common::Log::IOS_WC24);
 
   sockaddr sa;
   socklen_t sa_len = sizeof(sa);
@@ -544,7 +544,7 @@ IPCCommandResult NetIPTop::HandleGetPeerNameRequest(const IOCtlRequest& request)
 
 IPCCommandResult NetIPTop::HandleGetHostIDRequest(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+  request.Log(GetDeviceName(), Common::Log::IOS_WC24);
   const DefaultInterface interface = GetSystemDefaultInterfaceOrFallback();
   return GetDefaultReply(Common::swap32(interface.inet));
 }
@@ -1040,7 +1040,7 @@ IPCCommandResult NetIPTop::HandleGetAddressInfoRequest(const IOCtlVRequest& requ
     ret = SO_ERROR_HOST_NOT_FOUND;
   }
 
-  request.Dump(GetDeviceName(), LogTypes::IOS_NET, LogTypes::LINFO);
+  request.Dump(GetDeviceName(), Common::Log::IOS_NET, Common::Log::LINFO);
   return GetDefaultReply(ret);
 }
 

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -145,7 +145,7 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
     break;
 
   default:
-    request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+    request.Log(GetDeviceName(), Common::Log::IOS_WC24);
   }
 
   return GetDefaultReply(return_value);

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -67,7 +67,7 @@ IPCCommandResult NetKDTime::IOCtl(const IOCtlRequest& request)
     break;
 
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_WC24);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_WC24);
     break;
   }
 

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -82,7 +82,7 @@ int NetSSL::GetSSLFreeID() const
 
 IPCCommandResult NetSSL::IOCtl(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_SSL, LogTypes::LINFO);
+  request.Log(GetDeviceName(), Common::Log::IOS_SSL, Common::Log::LINFO);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
@@ -565,7 +565,7 @@ IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
     break;
   }
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_SSL);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_SSL);
   }
 
   // SSL return codes are written to BufferIn

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -268,7 +268,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
 
         ReturnValue = WiiSockMan::GetInstance().AddSocket(ret, true);
 
-        ioctl.Log("IOCTL_SO_ACCEPT", LogTypes::IOS_NET);
+        ioctl.Log("IOCTL_SO_ACCEPT", Common::Log::IOS_NET);
         break;
       }
       default:

--- a/Source/Core/Core/IOS/Network/WD/Command.cpp
+++ b/Source/Core/Core/IOS/Network/WD/Command.cpp
@@ -88,7 +88,7 @@ IPCCommandResult NetWDCommand::IOCtlV(const IOCtlVRequest& request)
   case IOCTLV_WD_RECV_FRAME:
   case IOCTLV_WD_RECV_NOTIFICATION:
   default:
-    request.Dump(GetDeviceName(), LogTypes::IOS_NET, LogTypes::LINFO);
+    request.Dump(GetDeviceName(), Common::Log::IOS_NET, Common::Log::LINFO);
   }
 
   return GetDefaultReply(return_value);

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -56,7 +56,7 @@ IPCCommandResult STMImmediate::IOCtl(const IOCtlRequest& request)
     break;
 
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_STM);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_STM);
   }
 
   return GetDefaultReply(return_value);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -206,7 +206,7 @@ IPCCommandResult BluetoothEmu::IOCtlV(const IOCtlVRequest& request)
   }
 
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_WIIMOTE);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_WIIMOTE);
   }
 
   return send_reply ? GetDefaultReply(IPC_SUCCESS) : GetNoReply();
@@ -1726,7 +1726,7 @@ void BluetoothEmu::CommandVendorSpecific_FC4F(const u8* input, u32 size)
   INFO_LOG(IOS_WIIMOTE, "Command: CommandVendorSpecific_FC4F: (callstack WUDiRemovePatch)");
   DEBUG_LOG(IOS_WIIMOTE, "Input (size 0x%x):", size);
 
-  Dolphin_Debugger::PrintDataBuffer(LogTypes::IOS_WIIMOTE, input, size, "Data: ");
+  Dolphin_Debugger::PrintDataBuffer(Common::Log::IOS_WIIMOTE, input, size, "Data: ");
 
   SendEventCommandComplete(0xFC4F, &reply, sizeof(hci_status_rp));
 }
@@ -1738,7 +1738,7 @@ void BluetoothEmu::CommandVendorSpecific_FC4C(const u8* input, u32 size)
 
   DEBUG_LOG(IOS_WIIMOTE, "Command: CommandVendorSpecific_FC4C:");
   DEBUG_LOG(IOS_WIIMOTE, "Input (size 0x%x):", size);
-  Dolphin_Debugger::PrintDataBuffer(LogTypes::IOS_WIIMOTE, input, size, "Data: ");
+  Dolphin_Debugger::PrintDataBuffer(Common::Log::IOS_WIIMOTE, input, size, "Data: ");
 
   SendEventCommandComplete(0xFC4C, &reply, sizeof(hci_status_rp));
 }

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -734,7 +734,7 @@ static int ParseAttribList(u8* attrib_id_list, u16& start_id, u16& end_id)
   const u8 type_id = attrib_list.Read8(attrib_offset);
   attrib_offset++;
 
-  if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG)
+  if constexpr (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)
   {
     DEBUG_ASSERT(sequence == SDP_SEQ8);
     (void)seq_size;
@@ -794,15 +794,10 @@ void WiimoteDevice::SDPSendServiceAttributeResponse(u16 cid, u16 transaction_id,
 
   header->length = (u16)(offset - sizeof(l2cap_hdr_t));
   m_host->SendACLPacket(GetConnectionHandle(), data_frame, header->length + sizeof(l2cap_hdr_t));
-
-  // Debugger::PrintDataBuffer(LogTypes::WIIMOTE, data_frame, header->length + sizeof(l2cap_hdr_t),
-  // "test response: ");
 }
 
 void WiimoteDevice::HandleSDP(u16 cid, u8* data, u32 size)
 {
-  // Debugger::PrintDataBuffer(LogTypes::WIIMOTE, data, size, "HandleSDP: ");
-
   CBigEndianBuffer buffer(data);
 
   switch (buffer.Read8(0))
@@ -889,9 +884,6 @@ void WiimoteDevice::SendCommandToACL(u8 ident, u8 code, u8 command_length, u8* c
 
   // send ....
   m_host->SendACLPacket(GetConnectionHandle(), data_frame, header->length + sizeof(l2cap_hdr_t));
-
-  // Debugger::PrintDataBuffer(LogTypes::WIIMOTE, data_frame, header->length + sizeof(l2cap_hdr_t),
-  // "m_pHost->SendACLPacket: ");
 }
 
 void WiimoteDevice::ReceiveL2capData(u16 scid, const void* data, u32 size)

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -40,7 +40,7 @@ IPCCommandResult OH0::Open(const OpenRequest& request)
 
 IPCCommandResult OH0::IOCtl(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_USB);
+  request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV0_GETRHDESCA:
@@ -136,7 +136,7 @@ IPCCommandResult OH0::GetRhDesca(const IOCtlRequest& request) const
 
   // Based on a hardware test, this ioctl seems to return a constant value
   Memory::Write_U32(0x02000302, request.buffer_out);
-  request.Dump(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LWARNING);
+  request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LWARNING);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
@@ -146,7 +146,7 @@ IPCCommandResult OH0::GetRhPortStatus(const IOCtlVRequest& request) const
     return GetDefaultReply(IPC_EINVAL);
 
   ERROR_LOG(IOS_USB, "Unimplemented IOCtlV: IOCTLV_USBV0_GETRHPORTSTATUS");
-  request.Dump(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LERROR);
+  request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
@@ -156,7 +156,7 @@ IPCCommandResult OH0::SetRhPortStatus(const IOCtlVRequest& request)
     return GetDefaultReply(IPC_EINVAL);
 
   ERROR_LOG(IOS_USB, "Unimplemented IOCtlV: IOCTLV_USBV0_SETRHPORTSTATUS");
-  request.Dump(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LERROR);
+  request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
@@ -209,7 +209,7 @@ IPCCommandResult OH0::RegisterClassChangeHook(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(1, 0))
     return GetDefaultReply(IPC_EINVAL);
   WARN_LOG(IOS_USB, "Unimplemented IOCtlV: USB::IOCTLV_USBV0_DEVICECLASSCHANGE (no reply)");
-  request.Dump(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LWARNING);
+  request.Dump(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LWARNING);
   return GetNoReply();
 }
 
@@ -308,7 +308,7 @@ IPCCommandResult OH0::DeviceIOCtlV(const u64 device_id, const IOCtlVRequest& req
     return HandleTransfer(device, request.request,
                           [&, this]() { return SubmitTransfer(*device, request); });
   case USB::IOCTLV_USBV0_UNKNOWN_32:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_USB);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB);
     return GetDefaultReply(IPC_SUCCESS);
   default:
     return GetDefaultReply(IPC_EINVAL);

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -33,7 +33,7 @@ USB_HIDv4::~USB_HIDv4()
 
 IPCCommandResult USB_HIDv4::IOCtl(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_USB);
+  request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV4_GETVERSION:
@@ -61,7 +61,7 @@ IPCCommandResult USB_HIDv4::IOCtl(const IOCtlRequest& request)
                           [&, this]() { return SubmitTransfer(*device, request); });
   }
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_USB);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB);
     return GetDefaultReply(IPC_SUCCESS);
   }
 }

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -22,7 +22,7 @@ USB_HIDv5::~USB_HIDv5() = default;
 
 IPCCommandResult USB_HIDv5::IOCtl(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_USB);
+  request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV5_GETVERSION:
@@ -44,14 +44,14 @@ IPCCommandResult USB_HIDv5::IOCtl(const IOCtlRequest& request)
     return HandleDeviceIOCtl(request,
                              [&](USBV5Device& device) { return CancelEndpoint(device, request); });
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LERROR);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
     return GetDefaultReply(IPC_SUCCESS);
   }
 }
 
 IPCCommandResult USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
 {
-  request.DumpUnknown(GetDeviceName(), LogTypes::IOS_USB);
+  request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   // TODO: HIDv5 seems to be able to queue transfers depending on the transfer length (unlike VEN).

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -22,7 +22,7 @@ USB_VEN::~USB_VEN() = default;
 
 IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
 {
-  request.Log(GetDeviceName(), LogTypes::IOS_USB);
+  request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV5_GETVERSION:
@@ -47,7 +47,7 @@ IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
     return HandleDeviceIOCtl(request,
                              [&](USBV5Device& device) { return CancelEndpoint(device, request); });
   default:
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LERROR);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS_USB, Common::Log::LERROR);
     return GetDefaultReply(IPC_SUCCESS);
   }
 }

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -543,7 +543,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
     // TODO(wfs): Should be returning an error. However until we have
     // everything properly stubbed it's easier to simulate the methods
     // succeeding.
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS, LogTypes::LWARNING);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS, Common::Log::LWARNING);
     Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
     break;
   }

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -355,7 +355,7 @@ IPCCommandResult WFSSRV::IOCtl(const IOCtlRequest& request)
   default:
     // TODO(wfs): Should be returning -3. However until we have everything
     // properly stubbed it's easier to simulate the methods succeeding.
-    request.DumpUnknown(GetDeviceName(), LogTypes::IOS, LogTypes::LWARNING);
+    request.DumpUnknown(GetDeviceName(), Common::Log::IOS, Common::Log::LWARNING);
     Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
     break;
   }

--- a/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogConfigWidget.cpp
@@ -62,11 +62,12 @@ void LogConfigWidget::CreateWidgets()
   m_types_toggle = new QPushButton(tr("Toggle All Log Types"));
   m_types_list = new QListWidget;
 
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++)
+  const auto* const log_manager = Common::Log::LogManager::GetInstance();
+  for (int i = 0; i < Common::Log::NUMBER_OF_LOGS; i++)
   {
-    const auto log_type = static_cast<LogTypes::LOG_TYPE>(i);
-    const QString full_name = QString::fromUtf8(LogManager::GetInstance()->GetFullName(log_type));
-    const QString short_name = QString::fromUtf8(LogManager::GetInstance()->GetShortName(log_type));
+    const auto log_type = static_cast<Common::Log::LOG_TYPE>(i);
+    const QString full_name = QString::fromUtf8(log_manager->GetFullName(log_type));
+    const QString short_name = QString::fromUtf8(log_manager->GetShortName(log_type));
     auto* widget = new QListWidgetItem(QStringLiteral("%1 (%2)").arg(full_name, short_name));
     widget->setCheckState(Qt::Unchecked);
     m_types_list->addItem(widget);
@@ -77,7 +78,7 @@ void LogConfigWidget::CreateWidgets()
   verbosity_layout->addWidget(m_verbosity_error);
   verbosity_layout->addWidget(m_verbosity_warning);
   verbosity_layout->addWidget(m_verbosity_info);
-  if (MAX_LOGLEVEL == LogTypes::LOG_LEVELS::LDEBUG)
+  if constexpr (MAX_LOGLEVEL == Common::Log::LOG_LEVELS::LDEBUG)
   {
     verbosity_layout->addWidget(m_verbosity_debug);
   }
@@ -132,29 +133,32 @@ void LogConfigWidget::ConnectWidgets()
 
 void LogConfigWidget::LoadSettings()
 {
-  auto* logmanager = LogManager::GetInstance();
-  auto& settings = Settings::GetQSettings();
+  const auto* const log_manager = Common::Log::LogManager::GetInstance();
+  const auto& settings = Settings::GetQSettings();
 
   restoreGeometry(settings.value(QStringLiteral("logconfigwidget/geometry")).toByteArray());
   setFloating(settings.value(QStringLiteral("logconfigwidget/floating")).toBool());
 
   // Config - Verbosity
-  const LogTypes::LOG_LEVELS verbosity = logmanager->GetLogLevel();
-  m_verbosity_notice->setChecked(verbosity == LogTypes::LOG_LEVELS::LNOTICE);
-  m_verbosity_error->setChecked(verbosity == LogTypes::LOG_LEVELS::LERROR);
-  m_verbosity_warning->setChecked(verbosity == LogTypes::LOG_LEVELS::LWARNING);
-  m_verbosity_info->setChecked(verbosity == LogTypes::LOG_LEVELS::LINFO);
-  m_verbosity_debug->setChecked(verbosity == LogTypes::LOG_LEVELS::LDEBUG);
+  const Common::Log::LOG_LEVELS verbosity = log_manager->GetLogLevel();
+  m_verbosity_notice->setChecked(verbosity == Common::Log::LOG_LEVELS::LNOTICE);
+  m_verbosity_error->setChecked(verbosity == Common::Log::LOG_LEVELS::LERROR);
+  m_verbosity_warning->setChecked(verbosity == Common::Log::LOG_LEVELS::LWARNING);
+  m_verbosity_info->setChecked(verbosity == Common::Log::LOG_LEVELS::LINFO);
+  m_verbosity_debug->setChecked(verbosity == Common::Log::LOG_LEVELS::LDEBUG);
 
   // Config - Outputs
-  m_out_file->setChecked(logmanager->IsListenerEnabled(LogListener::FILE_LISTENER));
-  m_out_console->setChecked(logmanager->IsListenerEnabled(LogListener::CONSOLE_LISTENER));
-  m_out_window->setChecked(logmanager->IsListenerEnabled(LogListener::LOG_WINDOW_LISTENER));
+  m_out_file->setChecked(log_manager->IsListenerEnabled(Common::Log::LogListener::FILE_LISTENER));
+  m_out_console->setChecked(
+      log_manager->IsListenerEnabled(Common::Log::LogListener::CONSOLE_LISTENER));
+  m_out_window->setChecked(
+      log_manager->IsListenerEnabled(Common::Log::LogListener::LOG_WINDOW_LISTENER));
 
   // Config - Log Types
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
+  for (int i = 0; i < Common::Log::NUMBER_OF_LOGS; ++i)
   {
-    bool log_enabled = LogManager::GetInstance()->IsEnabled(static_cast<LogTypes::LOG_TYPE>(i));
+    const auto log_type = static_cast<Common::Log::LOG_TYPE>(i);
+    const bool log_enabled = log_manager->IsEnabled(log_type);
 
     if (!log_enabled)
       m_all_enabled = false;
@@ -174,41 +178,43 @@ void LogConfigWidget::SaveSettings()
   settings.setValue(QStringLiteral("logconfigwidget/floating"), isFloating());
 
   // Config - Verbosity
-  LogTypes::LOG_LEVELS verbosity = LogTypes::LOG_LEVELS::LNOTICE;
+  auto verbosity = Common::Log::LOG_LEVELS::LNOTICE;
 
   if (m_verbosity_notice->isChecked())
-    verbosity = LogTypes::LOG_LEVELS::LNOTICE;
+    verbosity = Common::Log::LOG_LEVELS::LNOTICE;
 
   if (m_verbosity_error->isChecked())
-    verbosity = LogTypes::LOG_LEVELS::LERROR;
+    verbosity = Common::Log::LOG_LEVELS::LERROR;
 
   if (m_verbosity_warning->isChecked())
-    verbosity = LogTypes::LOG_LEVELS::LWARNING;
+    verbosity = Common::Log::LOG_LEVELS::LWARNING;
 
   if (m_verbosity_info->isChecked())
-    verbosity = LogTypes::LOG_LEVELS::LINFO;
+    verbosity = Common::Log::LOG_LEVELS::LINFO;
 
   if (m_verbosity_debug->isChecked())
-    verbosity = LogTypes::LOG_LEVELS::LDEBUG;
+    verbosity = Common::Log::LOG_LEVELS::LDEBUG;
+
+  auto* const log_manager = Common::Log::LogManager::GetInstance();
 
   // Config - Verbosity
-  LogManager::GetInstance()->SetLogLevel(verbosity);
+  log_manager->SetLogLevel(verbosity);
 
   // Config - Outputs
-  LogManager::GetInstance()->EnableListener(LogListener::FILE_LISTENER, m_out_file->isChecked());
-  LogManager::GetInstance()->EnableListener(LogListener::CONSOLE_LISTENER,
-                                            m_out_console->isChecked());
-  LogManager::GetInstance()->EnableListener(LogListener::LOG_WINDOW_LISTENER,
-                                            m_out_window->isChecked());
+  log_manager->EnableListener(Common::Log::LogListener::FILE_LISTENER, m_out_file->isChecked());
+  log_manager->EnableListener(Common::Log::LogListener::CONSOLE_LISTENER,
+                              m_out_console->isChecked());
+  log_manager->EnableListener(Common::Log::LogListener::LOG_WINDOW_LISTENER,
+                              m_out_window->isChecked());
   // Config - Log Types
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
+  for (int i = 0; i < Common::Log::NUMBER_OF_LOGS; ++i)
   {
-    const auto type = static_cast<LogTypes::LOG_TYPE>(i);
-    bool enabled = m_types_list->item(i)->checkState() == Qt::Checked;
-    bool was_enabled = LogManager::GetInstance()->IsEnabled(type);
+    const auto type = static_cast<Common::Log::LOG_TYPE>(i);
+    const bool enabled = m_types_list->item(i)->checkState() == Qt::Checked;
+    const bool was_enabled = log_manager->IsEnabled(type);
 
     if (enabled != was_enabled)
-      LogManager::GetInstance()->SetEnable(type, enabled);
+      log_manager->SetEnable(type, enabled);
   }
 }
 

--- a/Source/Core/DolphinQt/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogWidget.cpp
@@ -53,14 +53,15 @@ LogWidget::LogWidget(QWidget* parent) : QDockWidget(parent), m_timer(new QTimer(
 
   connect(&Settings::Instance(), &Settings::DebugFontChanged, this, &LogWidget::UpdateFont);
 
-  LogManager::GetInstance()->RegisterListener(LogListener::LOG_WINDOW_LISTENER, this);
+  Common::Log::LogManager::GetInstance()->RegisterListener(LogListener::LOG_WINDOW_LISTENER, this);
 }
 
 LogWidget::~LogWidget()
 {
   SaveSettings();
 
-  LogManager::GetInstance()->RegisterListener(LogListener::LOG_WINDOW_LISTENER, nullptr);
+  Common::Log::LogManager::GetInstance()->RegisterListener(LogListener::LOG_WINDOW_LISTENER,
+                                                           nullptr);
 }
 
 void LogWidget::UpdateLog()
@@ -80,21 +81,21 @@ void LogWidget::UpdateLog()
   for (auto& line : elements_to_push)
   {
     const char* color = "white";
-    switch (std::get<LogTypes::LOG_LEVELS>(line))
+    switch (std::get<Common::Log::LOG_LEVELS>(line))
     {
-    case LogTypes::LOG_LEVELS::LERROR:
+    case Common::Log::LOG_LEVELS::LERROR:
       color = "red";
       break;
-    case LogTypes::LOG_LEVELS::LWARNING:
+    case Common::Log::LOG_LEVELS::LWARNING:
       color = "yellow";
       break;
-    case LogTypes::LOG_LEVELS::LNOTICE:
+    case Common::Log::LOG_LEVELS::LNOTICE:
       color = "lime";
       break;
-    case LogTypes::LOG_LEVELS::LINFO:
+    case Common::Log::LOG_LEVELS::LINFO:
       color = "cyan";
       break;
-    case LogTypes::LOG_LEVELS::LDEBUG:
+    case Common::Log::LOG_LEVELS::LDEBUG:
       color = "lightgrey";
       break;
     }
@@ -207,7 +208,7 @@ void LogWidget::SaveSettings()
   UpdateFont();
 }
 
-void LogWidget::Log(LogTypes::LOG_LEVELS level, const char* text)
+void LogWidget::Log(Common::Log::LOG_LEVELS level, const char* text)
 {
   size_t text_length = strlen(text);
   while (text_length > 0 && text[text_length - 1] == '\n')

--- a/Source/Core/DolphinQt/Config/LogWidget.h
+++ b/Source/Core/DolphinQt/Config/LogWidget.h
@@ -19,7 +19,7 @@ class QPlainTextEdit;
 class QPushButton;
 class QTimer;
 
-class LogWidget final : public QDockWidget, LogListener
+class LogWidget final : public QDockWidget, Common::Log::LogListener
 {
   Q_OBJECT
 public:
@@ -37,7 +37,7 @@ private:
   void LoadSettings();
   void SaveSettings();
 
-  void Log(LogTypes::LOG_LEVELS level, const char* text) override;
+  void Log(Common::Log::LOG_LEVELS level, const char* text) override;
 
   // Log
   QCheckBox* m_log_wrap;
@@ -47,7 +47,7 @@ private:
 
   QTimer* m_timer;
 
-  using LogEntry = std::pair<std::string, LogTypes::LOG_LEVELS>;
+  using LogEntry = std::pair<std::string, Common::Log::LOG_LEVELS>;
 
   // Maximum number of lines to show in log viewer
   static constexpr int MAX_LOG_LINES = 5000;

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -93,7 +93,7 @@ void Init()
   Config::AddLayer(ConfigLoaders::GenerateBaseConfigLoader());
   SConfig::Init();
   Discord::Init();
-  LogManager::Init();
+  Common::Log::LogManager::Init();
   VideoBackendBase::PopulateList();
   WiimoteReal::LoadSettings();
   GCAdapter::Init();
@@ -107,7 +107,7 @@ void Shutdown()
   GCAdapter::Shutdown();
   WiimoteReal::Shutdown();
   VideoBackendBase::ClearList();
-  LogManager::Shutdown();
+  Common::Log::LogManager::Shutdown();
   Discord::Shutdown();
   SConfig::Shutdown();
   Config::Shutdown();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -702,7 +702,8 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
       glDebugMessageControlARB(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, true);
       glDebugMessageCallbackARB(ErrorCallback, nullptr);
     }
-    if (LogManager::GetInstance()->IsEnabled(LogTypes::HOST_GPU, LogTypes::LERROR))
+    if (Common::Log::LogManager::GetInstance()->IsEnabled(Common::Log::HOST_GPU,
+                                                          Common::Log::LERROR))
     {
       glEnable(GL_DEBUG_OUTPUT);
     }
@@ -1053,10 +1054,15 @@ void Renderer::PresentBackbuffer()
 {
   if (g_ogl_config.bSupportsDebug)
   {
-    if (LogManager::GetInstance()->IsEnabled(LogTypes::HOST_GPU, LogTypes::LERROR))
+    if (Common::Log::LogManager::GetInstance()->IsEnabled(Common::Log::HOST_GPU,
+                                                          Common::Log::LERROR))
+    {
       glEnable(GL_DEBUG_OUTPUT);
+    }
     else
+    {
       glDisable(GL_DEBUG_OUTPUT);
+    }
   }
 
   // Swap the back and front buffers, presenting the image.

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -669,13 +669,13 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugReportCallback(VkDebugReportFlagsEXT 
   std::string log_message =
       StringFromFormat("Vulkan debug report: (%s) %s", pLayerPrefix ? pLayerPrefix : "", pMessage);
   if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LERROR, "%s", log_message.c_str());
+    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LERROR, "%s", log_message.c_str());
   else if (flags & (VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT))
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LWARNING, "%s", log_message.c_str());
+    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LWARNING, "%s", log_message.c_str());
   else if (flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LINFO, "%s", log_message.c_str());
+    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LINFO, "%s", log_message.c_str());
   else
-    GENERIC_LOG(LogTypes::HOST_GPU, LogTypes::LDEBUG, "%s", log_message.c_str());
+    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LDEBUG, "%s", log_message.c_str());
 
   return VK_FALSE;
 }

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -216,7 +216,8 @@ void LogVulkanResult(int level, const char* func_name, VkResult res, const char*
   real_msg = StringFromFormat("(%s) %s (%d: %s)", func_name, real_msg.c_str(),
                               static_cast<int>(res), VkResultToString(res));
 
-  GENERIC_LOG(LogTypes::VIDEO, static_cast<LogTypes::LOG_LEVELS>(level), "%s", real_msg.c_str());
+  GENERIC_LOG(Common::Log::VIDEO, static_cast<Common::Log::LOG_LEVELS>(level), "%s",
+              real_msg.c_str());
 }
 
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -79,7 +79,8 @@ void VideoBackend::InitBackendInfo()
 // Helper method to check whether the Host GPU logging category is enabled.
 static bool IsHostGPULoggingEnabled()
 {
-  return LogManager::GetInstance()->IsEnabled(LogTypes::HOST_GPU, LogTypes::LERROR);
+  return Common::Log::LogManager::GetInstance()->IsEnabled(Common::Log::HOST_GPU,
+                                                           Common::Log::LERROR);
 }
 
 // Helper method to determine whether to enable the debug report extension.


### PR DESCRIPTION
Previously the logging was a in a little bit of a disarray. Some things were in namespaces, and other things were not. Given this code will feature a bit of restructuring during the transition over to fmt, this is a good time to unify it under a single namespace and also remove functions and types from the global namespace.

Now, all functions and types are under the Common::Log namespace; the only outliers being, of course, the preprocessor macros.