### PR TITLE
Core: Only reset wiimotes in Wii mode

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -290,7 +290,9 @@ void Stop()  // - Hammertime!
     g_video_backend->Video_ExitLoop();
   }
 
-  Wiimote::ResetAllWiimotes();
+  if (_CoreParameter.bWii)
+    Wiimote::ResetAllWiimotes();
+
   ResetRumble();
 
 #ifdef USE_MEMORYWATCHER


### PR DESCRIPTION
This was causing the FifoCI runners to crash, as the Wiimotes were not initialized in the first place.

The whole `g_wiimote_sources` setup seems kinda janky in the first place...