### PR TITLE
Fix flickering in Metroid Prime: Trilogy.

### DIFF
--- a/Data/Sys/GameSettings/R3M.ini
+++ b/Data/Sys/GameSettings/R3M.ini
@@ -1,7 +1,8 @@
-# R3ME01, R3MP01 - Metroid Prime Trilogy
+# R3ME01, R3MP01 - Metroid Prime: Trilogy
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -14,6 +15,6 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
-ImmediateXFBEnable = False
-XFBToTextureEnable = False
+ImmediateXFBEnable = True
+XFBToTextureEnable = True
 DeferEFBCopies = False

--- a/Data/Sys/GameSettings/R3M.ini
+++ b/Data/Sys/GameSettings/R3M.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
Enabled SyncGPU, this fixes the flickering and black bar issues that have plagued the game for the longest of times. At a pretty substantial performance cost unfortunately... SyncGPU is the only way to fix those issues, the wiki is wrong and lists them as already having been fixed.

Set ImmediateXFBEnable and XFBToTextureEnable to true, this way if the user chooses to disable SyncGPU manually for performance reasons, they will get the black bar instead of the horrible flickering.

Also updated the game name in the GameINI to read as Metroid Prime: Trilogy instead of Metroid Prime Trilogy. Metroid Prime: Trilogy is the correct name according to the name in the game list.

None of these changes interfere with the effectiveness of the previous PR that fixed the loading screens.