### PR TITLE
VideoCommon/TextureConversionShader: Migrate generation off sprintf

### DIFF
--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -1321,27 +1321,26 @@ const AbstractShader* ShaderCache::GetTextureDecodingShader(TextureFormat format
                                                             TLUTFormat palette_format)
 {
   const auto key = std::make_pair(static_cast<u32>(format), static_cast<u32>(palette_format));
-  auto iter = m_texture_decoding_shaders.find(key);
+  const auto iter = m_texture_decoding_shaders.find(key);
   if (iter != m_texture_decoding_shaders.end())
     return iter->second.get();
 
-  std::string shader_source =
-      TextureConversionShaderTiled::GenerateDecodingShader(format, palette_format, APIType::OpenGL);
+  const std::string shader_source =
+      TextureConversionShaderTiled::GenerateDecodingShader(format, palette_format);
   if (shader_source.empty())
   {
     m_texture_decoding_shaders.emplace(key, nullptr);
     return nullptr;
   }
 
-  std::unique_ptr<AbstractShader> shader =
-      g_renderer->CreateShaderFromSource(ShaderStage::Compute, shader_source);
+  auto shader = g_renderer->CreateShaderFromSource(ShaderStage::Compute, shader_source);
   if (!shader)
   {
     m_texture_decoding_shaders.emplace(key, nullptr);
     return nullptr;
   }
 
-  auto iiter = m_texture_decoding_shaders.emplace(key, std::move(shader));
+  const auto iiter = m_texture_decoding_shaders.emplace(key, std::move(shader));
   return iiter.first->second.get();
 }
 }  // namespace VideoCommon

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -1178,7 +1178,7 @@ const AbstractPipeline* ShaderCache::GetEFBCopyToRAMPipeline(const EFBCopyParams
   if (iter != m_efb_copy_to_ram_pipelines.end())
     return iter->second.get();
 
-  const char* const shader_code =
+  const std::string shader_code =
       TextureConversionShaderTiled::GenerateEncodingShader(uid, m_api_type);
   const auto shader = g_renderer->CreateShaderFromSource(ShaderStage::Pixel, shader_code);
   if (!shader)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2815,9 +2815,9 @@ bool TextureCacheBase::DecodeTextureOnGPU(TCacheEntry* entry, u32 dst_level, con
   g_vertex_manager->UploadUtilityUniforms(&uniforms, sizeof(uniforms));
   g_renderer->SetComputeImageTexture(m_decoding_texture.get(), false, true);
 
-  auto dispatch_groups =
-      TextureConversionShaderTiled::GetDispatchCount(info, aligned_width, aligned_height);
-  g_renderer->DispatchComputeShader(shader, dispatch_groups.first, dispatch_groups.second, 1);
+  const auto [dispatch_groups_x, dispatch_groups_y] =
+      info->GetDispatchCount(aligned_width, aligned_height);
+  g_renderer->DispatchComputeShader(shader, dispatch_groups_x, dispatch_groups_y, 1);
 
   // Copy from decoding texture -> final texture
   // This is because we don't want to have to create compute view for every layer

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -1417,7 +1417,7 @@ std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_form
   if (!info)
     return "";
 
-  std::stringstream ss;
+  std::ostringstream ss;
   switch (palette_format)
   {
   case TLUTFormat::IA8:
@@ -1439,7 +1439,7 @@ std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_form
 
 std::string GeneratePaletteConversionShader(TLUTFormat palette_format, APIType api_type)
 {
-  std::stringstream ss;
+  std::ostringstream ss;
 
   ss << R"(
 int Convert3To8(int v)

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -21,834 +21,15 @@
 
 #define WRITE p += sprintf
 
-static char text[16384];
-static bool IntensityConstantAdded = false;
-
 namespace TextureConversionShaderTiled
 {
-u16 GetEncodedSampleCount(EFBCopyFormat format)
+namespace
 {
-  switch (format)
-  {
-  case EFBCopyFormat::R4:
-    return 8;
-  case EFBCopyFormat::RA4:
-    return 4;
-  case EFBCopyFormat::RA8:
-    return 2;
-  case EFBCopyFormat::RGB565:
-    return 2;
-  case EFBCopyFormat::RGB5A3:
-    return 2;
-  case EFBCopyFormat::RGBA8:
-    return 1;
-  case EFBCopyFormat::A8:
-  case EFBCopyFormat::R8_0x1:
-  case EFBCopyFormat::R8:
-  case EFBCopyFormat::G8:
-  case EFBCopyFormat::B8:
-    return 4;
-  case EFBCopyFormat::RG8:
-  case EFBCopyFormat::GB8:
-    return 2;
-  case EFBCopyFormat::XFB:
-    return 2;
-  default:
-    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEncodedSampleCount)", static_cast<int>(format));
-    return 1;
-  }
-}
-
-static void WriteHeader(char*& p, APIType ApiType)
-{
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
-  {
-    // left, top, of source rectangle within source texture
-    // width of the destination rectangle, scale_factor (1 or 2)
-    WRITE(p, "UBO_BINDING(std140, 1) uniform PSBlock {\n");
-    WRITE(p, "  int4 position;\n");
-    WRITE(p, "  float y_scale;\n");
-    WRITE(p, "  float gamma_rcp;\n");
-    WRITE(p, "  float2 clamp_tb;\n");
-    WRITE(p, "  float3 filter_coefficients;\n");
-    WRITE(p, "};\n");
-    if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
-    {
-      WRITE(p, "VARYING_LOCATION(0) in VertexData {\n");
-      WRITE(p, "  float3 v_tex0;\n");
-      WRITE(p, "};\n");
-    }
-    else
-    {
-      WRITE(p, "VARYING_LOCATION(0) in float3 v_tex0;\n");
-    }
-    WRITE(p, "SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n");
-    WRITE(p, "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n");
-  }
-  else  // D3D
-  {
-    WRITE(p, "cbuffer PSBlock : register(b0) {\n");
-    WRITE(p, "  int4 position;\n");
-    WRITE(p, "  float y_scale;\n");
-    WRITE(p, "  float gamma_rcp;\n");
-    WRITE(p, "  float2 clamp_tb;\n");
-    WRITE(p, "  float3 filter_coefficients;\n");
-    WRITE(p, "};\n");
-    WRITE(p, "sampler samp0 : register(s0);\n");
-    WRITE(p, "Texture2DArray Tex0 : register(t0);\n");
-  }
-
-  // D3D does not have roundEven(), only round(), which is specified "to the nearest integer".
-  // This differs from the roundEven() behavior, but to get consistency across drivers in OpenGL
-  // we need to use roundEven().
-  if (ApiType == APIType::D3D)
-    WRITE(p, "#define roundEven(x) round(x)\n");
-
-  // Alpha channel in the copy is set to 1 the EFB format does not have an alpha channel.
-  WRITE(p, "float4 RGBA8ToRGB8(float4 src)\n");
-  WRITE(p, "{\n");
-  WRITE(p, "  return float4(src.xyz, 1.0);\n");
-  WRITE(p, "}\n");
-
-  WRITE(p, "float4 RGBA8ToRGBA6(float4 src)\n");
-  WRITE(p, "{\n");
-  WRITE(p, "  int4 val = int4(roundEven(src * 255.0)) >> 2;\n");
-  WRITE(p, "  return float4(val) / 63.0;\n");
-  WRITE(p, "}\n");
-
-  WRITE(p, "float4 RGBA8ToRGB565(float4 src)\n");
-  WRITE(p, "{\n");
-  WRITE(p, "  int4 val = int4(roundEven(src * 255.0));\n");
-  WRITE(p, "  val = int4(val.r >> 3, val.g >> 2, val.b >> 3, 1);\n");
-  WRITE(p, "  return float4(val) / float4(31.0, 63.0, 31.0, 1.0);\n");
-  WRITE(p, "}\n");
-}
-
-static void WriteSampleFunction(char*& p, const EFBCopyParams& params, APIType ApiType)
-{
-  auto WriteSampleOp = [&](int yoffset) {
-    if (!params.depth)
-    {
-      switch (params.efb_format)
-      {
-      case PEControl::RGB8_Z24:
-        WRITE(p, "RGBA8ToRGB8(");
-        break;
-      case PEControl::RGBA6_Z24:
-        WRITE(p, "RGBA8ToRGBA6(");
-        break;
-      case PEControl::RGB565_Z16:
-        WRITE(p, "RGBA8ToRGB565(");
-        break;
-      default:
-        WRITE(p, "(");
-        break;
-      }
-    }
-    else
-    {
-      // Handle D3D depth inversion.
-      if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange)
-        WRITE(p, "1.0 - (");
-      else
-        WRITE(p, "(");
-    }
-
-    if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
-      WRITE(p, "texture(samp0, float3(");
-    else
-      WRITE(p, "Tex0.Sample(samp0, float3(");
-
-    WRITE(p, "uv.x + float(xoffset) * pixel_size.x, ");
-
-    // Reverse the direction for OpenGL, since positive numbers are distance from the bottom row.
-    if (yoffset != 0)
-    {
-      if (ApiType == APIType::OpenGL)
-        WRITE(p, "clamp(uv.y - float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
-      else
-        WRITE(p, "clamp(uv.y + float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
-    }
-    else
-    {
-      WRITE(p, "uv.y");
-    }
-
-    WRITE(p, ", 0.0)))");
-  };
-
-  // The copy filter applies to both color and depth copies. This has been verified on hardware.
-  // The filter is only applied to the RGB channels, the alpha channel is left intact.
-  WRITE(p, "float4 SampleEFB(float2 uv, float2 pixel_size, int xoffset)\n");
-  WRITE(p, "{\n");
-  if (params.copy_filter)
-  {
-    WRITE(p, "  float4 prev_row = ");
-    WriteSampleOp(-1);
-    WRITE(p, ";\n");
-    WRITE(p, "  float4 current_row = ");
-    WriteSampleOp(0);
-    WRITE(p, ";\n");
-    WRITE(p, "  float4 next_row = ");
-    WriteSampleOp(1);
-    WRITE(p, ";\n");
-    WRITE(p, "  return float4(min(prev_row.rgb * filter_coefficients[0] +\n"
-             "                      current_row.rgb * filter_coefficients[1] +\n"
-             "                      next_row.rgb * filter_coefficients[2], \n"
-             "                    float3(1, 1, 1)), current_row.a);\n");
-  }
-  else
-  {
-    WRITE(p, "  float4 current_row = ");
-    WriteSampleOp(0);
-    WRITE(p, ";\n");
-    WRITE(p, "return float4(min(current_row.rgb * filter_coefficients[1], float3(1, 1, 1)),\n"
-             "              current_row.a);\n");
-  }
-  WRITE(p, "}\n");
-}
-
-// block dimensions : widthStride, heightStride
-// texture dims : width, height, x offset, y offset
-static void WriteSwizzler(char*& p, const EFBCopyParams& params, EFBCopyFormat format,
-                          APIType ApiType)
-{
-  WriteHeader(p, ApiType);
-  WriteSampleFunction(p, params, ApiType);
-
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
-  {
-    WRITE(p, "void main()\n");
-    WRITE(p, "{\n"
-             "  int2 sampleUv;\n"
-             "  int2 uv1 = int2(gl_FragCoord.xy);\n");
-  }
-  else  // D3D
-  {
-    WRITE(p, "void main(\n");
-    WRITE(p, "  in float3 v_tex0 : TEXCOORD0,\n");
-    WRITE(p, "  in float4 rawpos : SV_Position,\n");
-    WRITE(p, "  out float4 ocol0 : SV_Target)\n");
-    WRITE(p, "{\n"
-             "  int2 sampleUv;\n"
-             "  int2 uv1 = int2(rawpos.xy);\n");
-  }
-
-  int blkW = TexDecoder_GetEFBCopyBlockWidthInTexels(format);
-  int blkH = TexDecoder_GetEFBCopyBlockHeightInTexels(format);
-  int samples = GetEncodedSampleCount(format);
-
-  WRITE(p, "  int x_block_position = (uv1.x >> %d) << %d;\n", IntLog2(blkH * blkW / samples),
-        IntLog2(blkW));
-  WRITE(p, "  int y_block_position = uv1.y << %d;\n", IntLog2(blkH));
-  if (samples == 1)
-  {
-    // With samples == 1, we write out pairs of blocks; one A8R8, one G8B8.
-    WRITE(p, "  bool first = (uv1.x & %d) == 0;\n", blkH * blkW / 2);
-    samples = 2;
-  }
-  WRITE(p, "  int offset_in_block = uv1.x & %d;\n", (blkH * blkW / samples) - 1);
-  WRITE(p, "  int y_offset_in_block = offset_in_block >> %d;\n", IntLog2(blkW / samples));
-  WRITE(p, "  int x_offset_in_block = (offset_in_block & %d) << %d;\n", (blkW / samples) - 1,
-        IntLog2(samples));
-
-  WRITE(p, "  sampleUv.x = x_block_position + x_offset_in_block;\n");
-  WRITE(p, "  sampleUv.y = y_block_position + y_offset_in_block;\n");
-
-  WRITE(p,
-        "  float2 uv0 = float2(sampleUv);\n");  // sampleUv is the sample position in (int)gx_coords
-  WRITE(p, "  uv0 += float2(0.5, 0.5);\n");     // move to center of pixel
-  WRITE(p, "  uv0 *= float(position.w);\n");  // scale by two if needed (also move to pixel borders
-                                              // so that linear filtering will average adjacent
-                                              // pixel)
-  WRITE(p, "  uv0 += float2(position.xy);\n");                    // move to copied rect
-  WRITE(p, "  uv0 /= float2(%d, %d);\n", EFB_WIDTH, EFB_HEIGHT);  // normalize to [0:1]
-  WRITE(p, "  uv0 /= float2(1, y_scale);\n");                     // apply the y scaling
-  if (ApiType == APIType::OpenGL)                                 // ogl has to flip up and down
-  {
-    WRITE(p, "  uv0.y = 1.0-uv0.y;\n");
-  }
-
-  WRITE(p, "  float2 pixel_size = float2(position.w, position.w) / float2(%d, %d);\n", EFB_WIDTH,
-        EFB_HEIGHT);
-}
-
-static void WriteSampleColor(char*& p, const char* colorComp, const char* dest, int xoffset,
-                             APIType ApiType, const EFBCopyParams& params)
-{
-  WRITE(p, "  %s = SampleEFB(uv0, pixel_size, %d).%s;\n", dest, xoffset, colorComp);
-}
-
-static void WriteColorToIntensity(char*& p, const char* src, const char* dest)
-{
-  if (!IntensityConstantAdded)
-  {
-    WRITE(p, "  float4 IntensityConst = float4(0.257f,0.504f,0.098f,0.0625f);\n");
-    IntensityConstantAdded = true;
-  }
-  WRITE(p, "  %s = dot(IntensityConst.rgb, %s.rgb);\n", dest, src);
-  // don't add IntensityConst.a yet, because doing it later is faster and uses less instructions,
-  // due to vectorization
-}
-
-static void WriteToBitDepth(char*& p, u8 depth, const char* src, const char* dest)
-{
-  WRITE(p, "  %s = floor(%s * 255.0 / exp2(8.0 - %d.0));\n", dest, src, depth);
-}
-
-static void WriteEncoderEnd(char*& p)
-{
-  WRITE(p, "}\n");
-  IntensityConstantAdded = false;
-}
-
-static void WriteI8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::R8, ApiType);
-  WRITE(p, "  float3 texSample;\n");
-
-  WriteSampleColor(p, "rgb", "texSample", 0, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.b");
-
-  WriteSampleColor(p, "rgb", "texSample", 1, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.g");
-
-  WriteSampleColor(p, "rgb", "texSample", 2, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.r");
-
-  WriteSampleColor(p, "rgb", "texSample", 3, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.a");
-
-  WRITE(p, "  ocol0.rgba += IntensityConst.aaaa;\n");  // see WriteColorToIntensity
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteI4Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::R4, ApiType);
-  WRITE(p, "  float3 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
-
-  WriteSampleColor(p, "rgb", "texSample", 0, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.b");
-
-  WriteSampleColor(p, "rgb", "texSample", 1, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.b");
-
-  WriteSampleColor(p, "rgb", "texSample", 2, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.g");
-
-  WriteSampleColor(p, "rgb", "texSample", 3, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.g");
-
-  WriteSampleColor(p, "rgb", "texSample", 4, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.r");
-
-  WriteSampleColor(p, "rgb", "texSample", 5, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.r");
-
-  WriteSampleColor(p, "rgb", "texSample", 6, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.a");
-
-  WriteSampleColor(p, "rgb", "texSample", 7, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.a");
-
-  WRITE(p, "  color0.rgba += IntensityConst.aaaa;\n");
-  WRITE(p, "  color1.rgba += IntensityConst.aaaa;\n");
-
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
-
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteIA8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
-  WRITE(p, "  float4 texSample;\n");
-
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
-  WRITE(p, "  ocol0.b = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "ocol0.g");
-
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
-  WRITE(p, "  ocol0.r = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "ocol0.a");
-
-  WRITE(p, "  ocol0.ga += IntensityConst.aa;\n");
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteIA4Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RA4, ApiType);
-  WRITE(p, "  float4 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
-
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
-  WRITE(p, "  color0.b = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.b");
-
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
-  WRITE(p, "  color0.g = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.g");
-
-  WriteSampleColor(p, "rgba", "texSample", 2, ApiType, params);
-  WRITE(p, "  color0.r = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.r");
-
-  WriteSampleColor(p, "rgba", "texSample", 3, ApiType, params);
-  WRITE(p, "  color0.a = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.a");
-
-  WRITE(p, "  color1.rgba += IntensityConst.aaaa;\n");
-
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
-
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteRGB565Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RGB565, ApiType);
-  WRITE(p, "  float3 texSample0;\n");
-  WRITE(p, "  float3 texSample1;\n");
-
-  WriteSampleColor(p, "rgb", "texSample0", 0, ApiType, params);
-  WriteSampleColor(p, "rgb", "texSample1", 1, ApiType, params);
-  WRITE(p, "  float2 texRs = float2(texSample0.r, texSample1.r);\n");
-  WRITE(p, "  float2 texGs = float2(texSample0.g, texSample1.g);\n");
-  WRITE(p, "  float2 texBs = float2(texSample0.b, texSample1.b);\n");
-
-  WriteToBitDepth(p, 6, "texGs", "float2 gInt");
-  WRITE(p, "  float2 gUpper = floor(gInt / 8.0);\n");
-  WRITE(p, "  float2 gLower = gInt - gUpper * 8.0;\n");
-
-  WriteToBitDepth(p, 5, "texRs", "ocol0.br");
-  WRITE(p, "  ocol0.br = ocol0.br * 8.0 + gUpper;\n");
-  WriteToBitDepth(p, 5, "texBs", "ocol0.ga");
-  WRITE(p, "  ocol0.ga = ocol0.ga + gLower * 32.0;\n");
-
-  WRITE(p, "  ocol0 = ocol0 / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteRGB5A3Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RGB5A3, ApiType);
-
-  WRITE(p, "  float4 texSample;\n");
-  WRITE(p, "  float color0;\n");
-  WRITE(p, "  float gUpper;\n");
-  WRITE(p, "  float gLower;\n");
-
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
-
-  // 0.8784 = 224 / 255 which is the maximum alpha value that can be represented in 3 bits
-  WRITE(p, "if(texSample.a > 0.878f) {\n");
-
-  WriteToBitDepth(p, 5, "texSample.g", "color0");
-  WRITE(p, "  gUpper = floor(color0 / 8.0);\n");
-  WRITE(p, "  gLower = color0 - gUpper * 8.0;\n");
-
-  WriteToBitDepth(p, 5, "texSample.r", "ocol0.b");
-  WRITE(p, "  ocol0.b = ocol0.b * 4.0 + gUpper + 128.0;\n");
-  WriteToBitDepth(p, 5, "texSample.b", "ocol0.g");
-  WRITE(p, "  ocol0.g = ocol0.g + gLower * 32.0;\n");
-
-  WRITE(p, "} else {\n");
-
-  WriteToBitDepth(p, 4, "texSample.r", "ocol0.b");
-  WriteToBitDepth(p, 4, "texSample.b", "ocol0.g");
-
-  WriteToBitDepth(p, 3, "texSample.a", "color0");
-  WRITE(p, "ocol0.b = ocol0.b + color0 * 16.0;\n");
-  WriteToBitDepth(p, 4, "texSample.g", "color0");
-  WRITE(p, "ocol0.g = ocol0.g + color0 * 16.0;\n");
-
-  WRITE(p, "}\n");
-
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
-
-  WRITE(p, "if(texSample.a > 0.878f) {\n");
-
-  WriteToBitDepth(p, 5, "texSample.g", "color0");
-  WRITE(p, "  gUpper = floor(color0 / 8.0);\n");
-  WRITE(p, "  gLower = color0 - gUpper * 8.0;\n");
-
-  WriteToBitDepth(p, 5, "texSample.r", "ocol0.r");
-  WRITE(p, "  ocol0.r = ocol0.r * 4.0 + gUpper + 128.0;\n");
-  WriteToBitDepth(p, 5, "texSample.b", "ocol0.a");
-  WRITE(p, "  ocol0.a = ocol0.a + gLower * 32.0;\n");
-
-  WRITE(p, "} else {\n");
-
-  WriteToBitDepth(p, 4, "texSample.r", "ocol0.r");
-  WriteToBitDepth(p, 4, "texSample.b", "ocol0.a");
-
-  WriteToBitDepth(p, 3, "texSample.a", "color0");
-  WRITE(p, "ocol0.r = ocol0.r + color0 * 16.0;\n");
-  WriteToBitDepth(p, 4, "texSample.g", "color0");
-  WRITE(p, "ocol0.a = ocol0.a + color0 * 16.0;\n");
-
-  WRITE(p, "}\n");
-
-  WRITE(p, "  ocol0 = ocol0 / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteRGBA8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RGBA8, ApiType);
-
-  WRITE(p, "  float4 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
-
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
-  WRITE(p, "  color0.b = texSample.a;\n");
-  WRITE(p, "  color0.g = texSample.r;\n");
-  WRITE(p, "  color1.b = texSample.g;\n");
-  WRITE(p, "  color1.g = texSample.b;\n");
-
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
-  WRITE(p, "  color0.r = texSample.a;\n");
-  WRITE(p, "  color0.a = texSample.r;\n");
-  WRITE(p, "  color1.r = texSample.g;\n");
-  WRITE(p, "  color1.a = texSample.b;\n");
-
-  WRITE(p, "  ocol0 = first ? color0 : color1;\n");
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteC4Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::R4, ApiType);
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
-
-  WriteSampleColor(p, comp, "color0.b", 0, ApiType, params);
-  WriteSampleColor(p, comp, "color1.b", 1, ApiType, params);
-  WriteSampleColor(p, comp, "color0.g", 2, ApiType, params);
-  WriteSampleColor(p, comp, "color1.g", 3, ApiType, params);
-  WriteSampleColor(p, comp, "color0.r", 4, ApiType, params);
-  WriteSampleColor(p, comp, "color1.r", 5, ApiType, params);
-  WriteSampleColor(p, comp, "color0.a", 6, ApiType, params);
-  WriteSampleColor(p, comp, "color1.a", 7, ApiType, params);
-
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
-
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteC8Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::R8, ApiType);
-
-  WriteSampleColor(p, comp, "ocol0.b", 0, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.g", 1, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.r", 2, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.a", 3, ApiType, params);
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteCC4Encoder(char*& p, const char* comp, APIType ApiType,
-                            const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RA4, ApiType);
-  WRITE(p, "  float2 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
-
-  WriteSampleColor(p, comp, "texSample", 0, ApiType, params);
-  WRITE(p, "  color0.b = texSample.x;\n");
-  WRITE(p, "  color1.b = texSample.y;\n");
-
-  WriteSampleColor(p, comp, "texSample", 1, ApiType, params);
-  WRITE(p, "  color0.g = texSample.x;\n");
-  WRITE(p, "  color1.g = texSample.y;\n");
-
-  WriteSampleColor(p, comp, "texSample", 2, ApiType, params);
-  WRITE(p, "  color0.r = texSample.x;\n");
-  WRITE(p, "  color1.r = texSample.y;\n");
-
-  WriteSampleColor(p, comp, "texSample", 3, ApiType, params);
-  WRITE(p, "  color0.a = texSample.x;\n");
-  WRITE(p, "  color1.a = texSample.y;\n");
-
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
-
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteCC8Encoder(char*& p, const char* comp, APIType ApiType,
-                            const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
-
-  WriteSampleColor(p, comp, "ocol0.bg", 0, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.ra", 1, ApiType, params);
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteZ8Encoder(char*& p, const char* multiplier, APIType ApiType,
-                           const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::G8, ApiType);
-
-  WRITE(p, " float depth;\n");
-
-  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
-  WRITE(p, "ocol0.b = frac(depth * %s);\n", multiplier);
-
-  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
-  WRITE(p, "ocol0.g = frac(depth * %s);\n", multiplier);
-
-  WriteSampleColor(p, "r", "depth", 2, ApiType, params);
-  WRITE(p, "ocol0.r = frac(depth * %s);\n", multiplier);
-
-  WriteSampleColor(p, "r", "depth", 3, ApiType, params);
-  WRITE(p, "ocol0.a = frac(depth * %s);\n", multiplier);
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteZ16Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
-
-  WRITE(p, "  float depth;\n");
-  WRITE(p, "  float3 expanded;\n");
-
-  // byte order is reversed
-
-  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
-
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-
-  WRITE(p, "  ocol0.b = expanded.g / 255.0;\n");
-  WRITE(p, "  ocol0.g = expanded.r / 255.0;\n");
-
-  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
-
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-
-  WRITE(p, "  ocol0.r = expanded.g / 255.0;\n");
-  WRITE(p, "  ocol0.a = expanded.r / 255.0;\n");
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteZ16LEncoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::GB8, ApiType);
-
-  WRITE(p, "  float depth;\n");
-  WRITE(p, "  float3 expanded;\n");
-
-  // byte order is reversed
-
-  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
-
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-  WRITE(p, "  depth -= expanded.g * 256.0;\n");
-  WRITE(p, "  expanded.b = depth;\n");
-
-  WRITE(p, "  ocol0.b = expanded.b / 255.0;\n");
-  WRITE(p, "  ocol0.g = expanded.g / 255.0;\n");
-
-  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
-
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-  WRITE(p, "  depth -= expanded.g * 256.0;\n");
-  WRITE(p, "  expanded.b = depth;\n");
-
-  WRITE(p, "  ocol0.r = expanded.b / 255.0;\n");
-  WRITE(p, "  ocol0.a = expanded.g / 255.0;\n");
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteZ24Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RGBA8, ApiType);
-
-  WRITE(p, "  float depth0;\n");
-  WRITE(p, "  float depth1;\n");
-  WRITE(p, "  float3 expanded0;\n");
-  WRITE(p, "  float3 expanded1;\n");
-
-  WriteSampleColor(p, "r", "depth0", 0, ApiType, params);
-  WriteSampleColor(p, "r", "depth1", 1, ApiType, params);
-
-  for (int i = 0; i < 2; i++)
-  {
-    WRITE(p, "  depth%i *= 16777216.0;\n", i);
-
-    WRITE(p, "  expanded%i.r = floor(depth%i / (256.0 * 256.0));\n", i, i);
-    WRITE(p, "  depth%i -= expanded%i.r * 256.0 * 256.0;\n", i, i);
-    WRITE(p, "  expanded%i.g = floor(depth%i / 256.0);\n", i, i);
-    WRITE(p, "  depth%i -= expanded%i.g * 256.0;\n", i, i);
-    WRITE(p, "  expanded%i.b = depth%i;\n", i, i);
-  }
-
-  WRITE(p, "  if (!first) {\n");
-  // upper 16
-  WRITE(p, "     ocol0.b = expanded0.g / 255.0;\n");
-  WRITE(p, "     ocol0.g = expanded0.b / 255.0;\n");
-  WRITE(p, "     ocol0.r = expanded1.g / 255.0;\n");
-  WRITE(p, "     ocol0.a = expanded1.b / 255.0;\n");
-  WRITE(p, "  } else {\n");
-  // lower 8
-  WRITE(p, "     ocol0.b = 1.0;\n");
-  WRITE(p, "     ocol0.g = expanded0.r / 255.0;\n");
-  WRITE(p, "     ocol0.r = 1.0;\n");
-  WRITE(p, "     ocol0.a = expanded1.r / 255.0;\n");
-  WRITE(p, "  }\n");
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteXFBEncoder(char*& p, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::XFB, ApiType);
-
-  WRITE(p, "float3 color0, color1;\n");
-  WriteSampleColor(p, "rgb", "color0", 0, ApiType, params);
-  WriteSampleColor(p, "rgb", "color1", 1, ApiType, params);
-
-  // Gamma is only applied to XFB copies.
-  WRITE(p, "  color0 = pow(color0, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
-  WRITE(p, "  color1 = pow(color1, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
-
-  // Convert to YUV.
-  WRITE(p, "  const float3 y_const = float3(0.257, 0.504, 0.098);\n");
-  WRITE(p, "  const float3 u_const = float3(-0.148, -0.291, 0.439);\n");
-  WRITE(p, "  const float3 v_const = float3(0.439, -0.368, -0.071);\n");
-  WRITE(p, "  float3 average = (color0 + color1) * 0.5;\n");
-  WRITE(p, "  ocol0.b = dot(color0,  y_const) + 0.0625;\n");
-  WRITE(p, "  ocol0.g = dot(average, u_const) + 0.5;\n");
-  WRITE(p, "  ocol0.r = dot(color1,  y_const) + 0.0625;\n");
-  WRITE(p, "  ocol0.a = dot(average, v_const) + 0.5;\n");
-
-  WriteEncoderEnd(p);
-}
-
-const char* GenerateEncodingShader(const EFBCopyParams& params, APIType api_type)
-{
-  text[sizeof(text) - 1] = 0x7C;  // canary
-
-  char* p = text;
-
-  switch (params.copy_format)
-  {
-  case EFBCopyFormat::R4:
-    if (params.yuv)
-      WriteI4Encoder(p, api_type, params);
-    else
-      WriteC4Encoder(p, "r", api_type, params);
-    break;
-  case EFBCopyFormat::RA4:
-    if (params.yuv)
-      WriteIA4Encoder(p, api_type, params);
-    else
-      WriteCC4Encoder(p, "ar", api_type, params);
-    break;
-  case EFBCopyFormat::RA8:
-    if (params.yuv)
-      WriteIA8Encoder(p, api_type, params);
-    else
-      WriteCC8Encoder(p, "ar", api_type, params);
-    break;
-  case EFBCopyFormat::RGB565:
-    WriteRGB565Encoder(p, api_type, params);
-    break;
-  case EFBCopyFormat::RGB5A3:
-    WriteRGB5A3Encoder(p, api_type, params);
-    break;
-  case EFBCopyFormat::RGBA8:
-    if (params.depth)
-      WriteZ24Encoder(p, api_type, params);
-    else
-      WriteRGBA8Encoder(p, api_type, params);
-    break;
-  case EFBCopyFormat::A8:
-    WriteC8Encoder(p, "a", api_type, params);
-    break;
-  case EFBCopyFormat::R8_0x1:
-  case EFBCopyFormat::R8:
-    if (params.yuv)
-      WriteI8Encoder(p, api_type, params);
-    else
-      WriteC8Encoder(p, "r", api_type, params);
-    break;
-  case EFBCopyFormat::G8:
-    if (params.depth)
-      WriteZ8Encoder(p, "256.0", api_type, params);  // Z8M
-    else
-      WriteC8Encoder(p, "g", api_type, params);
-    break;
-  case EFBCopyFormat::B8:
-    if (params.depth)
-      WriteZ8Encoder(p, "65536.0", api_type, params);  // Z8L
-    else
-      WriteC8Encoder(p, "b", api_type, params);
-    break;
-  case EFBCopyFormat::RG8:
-    if (params.depth)
-      WriteZ16Encoder(p, api_type, params);  // Z16H
-    else
-      WriteCC8Encoder(p, "gr", api_type, params);
-    break;
-  case EFBCopyFormat::GB8:
-    if (params.depth)
-      WriteZ16LEncoder(p, api_type, params);  // Z16L
-    else
-      WriteCC8Encoder(p, "bg", api_type, params);
-    break;
-  case EFBCopyFormat::XFB:
-    WriteXFBEncoder(p, api_type, params);
-    break;
-  default:
-    PanicAlert("Invalid EFB Copy Format (0x%X)! (GenerateEncodingShader)",
-               static_cast<int>(params.copy_format));
-    break;
-  }
-
-  if (text[sizeof(text) - 1] != 0x7C)
-    PanicAlert("TextureConversionShader generator - buffer too small, canary has been eaten!");
-
-  return text;
-}
+char s_text[16384];
+bool s_intensity_constant_added = false;
 
 // NOTE: In these uniforms, a row refers to a row of blocks, not texels.
-static const char decoding_shader_header[] = R"(
+constexpr char s_decoding_shader_header[] = R"(
 #if defined(PALETTE_FORMAT_IA8) || defined(PALETTE_FORMAT_RGB565) || defined(PALETTE_FORMAT_RGB5A3)
 #define HAS_PALETTE 1
 #endif
@@ -997,7 +178,7 @@ float4 GetPaletteColorNormalized(uint index)
 
 )";
 
-static const std::map<TextureFormat, DecodingShaderInfo> s_decoding_shader_info{
+const std::map<TextureFormat, DecodingShaderInfo> s_decoding_shader_info{
     {TextureFormat::I4,
      {TEXEL_BUFFER_FORMAT_R8_UINT, 0, 8, 8, false,
       R"(
@@ -1367,7 +548,826 @@ static const std::map<TextureFormat, DecodingShaderInfo> s_decoding_shader_info{
         float4 rgba_norm = rgb / 255.0;
         imageStore(output_image, int3(int2(uv), 0), rgba_norm);
       }
-      )"}}};
+      )"}},
+};
+
+u16 GetEncodedSampleCount(EFBCopyFormat format)
+{
+  switch (format)
+  {
+  case EFBCopyFormat::R4:
+    return 8;
+  case EFBCopyFormat::RA4:
+    return 4;
+  case EFBCopyFormat::RA8:
+    return 2;
+  case EFBCopyFormat::RGB565:
+    return 2;
+  case EFBCopyFormat::RGB5A3:
+    return 2;
+  case EFBCopyFormat::RGBA8:
+    return 1;
+  case EFBCopyFormat::A8:
+  case EFBCopyFormat::R8_0x1:
+  case EFBCopyFormat::R8:
+  case EFBCopyFormat::G8:
+  case EFBCopyFormat::B8:
+    return 4;
+  case EFBCopyFormat::RG8:
+  case EFBCopyFormat::GB8:
+    return 2;
+  case EFBCopyFormat::XFB:
+    return 2;
+  default:
+    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEncodedSampleCount)", static_cast<int>(format));
+    return 1;
+  }
+}
+
+void WriteHeader(char*& p, APIType ApiType)
+{
+  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  {
+    // left, top, of source rectangle within source texture
+    // width of the destination rectangle, scale_factor (1 or 2)
+    WRITE(p, "UBO_BINDING(std140, 1) uniform PSBlock {\n");
+    WRITE(p, "  int4 position;\n");
+    WRITE(p, "  float y_scale;\n");
+    WRITE(p, "  float gamma_rcp;\n");
+    WRITE(p, "  float2 clamp_tb;\n");
+    WRITE(p, "  float3 filter_coefficients;\n");
+    WRITE(p, "};\n");
+    if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+    {
+      WRITE(p, "VARYING_LOCATION(0) in VertexData {\n");
+      WRITE(p, "  float3 v_tex0;\n");
+      WRITE(p, "};\n");
+    }
+    else
+    {
+      WRITE(p, "VARYING_LOCATION(0) in float3 v_tex0;\n");
+    }
+    WRITE(p, "SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n");
+    WRITE(p, "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n");
+  }
+  else  // D3D
+  {
+    WRITE(p, "cbuffer PSBlock : register(b0) {\n");
+    WRITE(p, "  int4 position;\n");
+    WRITE(p, "  float y_scale;\n");
+    WRITE(p, "  float gamma_rcp;\n");
+    WRITE(p, "  float2 clamp_tb;\n");
+    WRITE(p, "  float3 filter_coefficients;\n");
+    WRITE(p, "};\n");
+    WRITE(p, "sampler samp0 : register(s0);\n");
+    WRITE(p, "Texture2DArray Tex0 : register(t0);\n");
+  }
+
+  // D3D does not have roundEven(), only round(), which is specified "to the nearest integer".
+  // This differs from the roundEven() behavior, but to get consistency across drivers in OpenGL
+  // we need to use roundEven().
+  if (ApiType == APIType::D3D)
+    WRITE(p, "#define roundEven(x) round(x)\n");
+
+  // Alpha channel in the copy is set to 1 the EFB format does not have an alpha channel.
+  WRITE(p, "float4 RGBA8ToRGB8(float4 src)\n");
+  WRITE(p, "{\n");
+  WRITE(p, "  return float4(src.xyz, 1.0);\n");
+  WRITE(p, "}\n");
+
+  WRITE(p, "float4 RGBA8ToRGBA6(float4 src)\n");
+  WRITE(p, "{\n");
+  WRITE(p, "  int4 val = int4(roundEven(src * 255.0)) >> 2;\n");
+  WRITE(p, "  return float4(val) / 63.0;\n");
+  WRITE(p, "}\n");
+
+  WRITE(p, "float4 RGBA8ToRGB565(float4 src)\n");
+  WRITE(p, "{\n");
+  WRITE(p, "  int4 val = int4(roundEven(src * 255.0));\n");
+  WRITE(p, "  val = int4(val.r >> 3, val.g >> 2, val.b >> 3, 1);\n");
+  WRITE(p, "  return float4(val) / float4(31.0, 63.0, 31.0, 1.0);\n");
+  WRITE(p, "}\n");
+}
+
+void WriteSampleFunction(char*& p, const EFBCopyParams& params, APIType ApiType)
+{
+  auto WriteSampleOp = [&](int yoffset) {
+    if (!params.depth)
+    {
+      switch (params.efb_format)
+      {
+      case PEControl::RGB8_Z24:
+        WRITE(p, "RGBA8ToRGB8(");
+        break;
+      case PEControl::RGBA6_Z24:
+        WRITE(p, "RGBA8ToRGBA6(");
+        break;
+      case PEControl::RGB565_Z16:
+        WRITE(p, "RGBA8ToRGB565(");
+        break;
+      default:
+        WRITE(p, "(");
+        break;
+      }
+    }
+    else
+    {
+      // Handle D3D depth inversion.
+      if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange)
+        WRITE(p, "1.0 - (");
+      else
+        WRITE(p, "(");
+    }
+
+    if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+      WRITE(p, "texture(samp0, float3(");
+    else
+      WRITE(p, "Tex0.Sample(samp0, float3(");
+
+    WRITE(p, "uv.x + float(xoffset) * pixel_size.x, ");
+
+    // Reverse the direction for OpenGL, since positive numbers are distance from the bottom row.
+    if (yoffset != 0)
+    {
+      if (ApiType == APIType::OpenGL)
+        WRITE(p, "clamp(uv.y - float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
+      else
+        WRITE(p, "clamp(uv.y + float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
+    }
+    else
+    {
+      WRITE(p, "uv.y");
+    }
+
+    WRITE(p, ", 0.0)))");
+  };
+
+  // The copy filter applies to both color and depth copies. This has been verified on hardware.
+  // The filter is only applied to the RGB channels, the alpha channel is left intact.
+  WRITE(p, "float4 SampleEFB(float2 uv, float2 pixel_size, int xoffset)\n");
+  WRITE(p, "{\n");
+  if (params.copy_filter)
+  {
+    WRITE(p, "  float4 prev_row = ");
+    WriteSampleOp(-1);
+    WRITE(p, ";\n");
+    WRITE(p, "  float4 current_row = ");
+    WriteSampleOp(0);
+    WRITE(p, ";\n");
+    WRITE(p, "  float4 next_row = ");
+    WriteSampleOp(1);
+    WRITE(p, ";\n");
+    WRITE(p, "  return float4(min(prev_row.rgb * filter_coefficients[0] +\n"
+             "                      current_row.rgb * filter_coefficients[1] +\n"
+             "                      next_row.rgb * filter_coefficients[2], \n"
+             "                    float3(1, 1, 1)), current_row.a);\n");
+  }
+  else
+  {
+    WRITE(p, "  float4 current_row = ");
+    WriteSampleOp(0);
+    WRITE(p, ";\n");
+    WRITE(p, "return float4(min(current_row.rgb * filter_coefficients[1], float3(1, 1, 1)),\n"
+             "              current_row.a);\n");
+  }
+  WRITE(p, "}\n");
+}
+
+// block dimensions : widthStride, heightStride
+// texture dims : width, height, x offset, y offset
+void WriteSwizzler(char*& p, const EFBCopyParams& params, EFBCopyFormat format, APIType ApiType)
+{
+  WriteHeader(p, ApiType);
+  WriteSampleFunction(p, params, ApiType);
+
+  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  {
+    WRITE(p, "void main()\n");
+    WRITE(p, "{\n"
+             "  int2 sampleUv;\n"
+             "  int2 uv1 = int2(gl_FragCoord.xy);\n");
+  }
+  else  // D3D
+  {
+    WRITE(p, "void main(\n");
+    WRITE(p, "  in float3 v_tex0 : TEXCOORD0,\n");
+    WRITE(p, "  in float4 rawpos : SV_Position,\n");
+    WRITE(p, "  out float4 ocol0 : SV_Target)\n");
+    WRITE(p, "{\n"
+             "  int2 sampleUv;\n"
+             "  int2 uv1 = int2(rawpos.xy);\n");
+  }
+
+  int blkW = TexDecoder_GetEFBCopyBlockWidthInTexels(format);
+  int blkH = TexDecoder_GetEFBCopyBlockHeightInTexels(format);
+  int samples = GetEncodedSampleCount(format);
+
+  WRITE(p, "  int x_block_position = (uv1.x >> %d) << %d;\n", IntLog2(blkH * blkW / samples),
+        IntLog2(blkW));
+  WRITE(p, "  int y_block_position = uv1.y << %d;\n", IntLog2(blkH));
+  if (samples == 1)
+  {
+    // With samples == 1, we write out pairs of blocks; one A8R8, one G8B8.
+    WRITE(p, "  bool first = (uv1.x & %d) == 0;\n", blkH * blkW / 2);
+    samples = 2;
+  }
+  WRITE(p, "  int offset_in_block = uv1.x & %d;\n", (blkH * blkW / samples) - 1);
+  WRITE(p, "  int y_offset_in_block = offset_in_block >> %d;\n", IntLog2(blkW / samples));
+  WRITE(p, "  int x_offset_in_block = (offset_in_block & %d) << %d;\n", (blkW / samples) - 1,
+        IntLog2(samples));
+
+  WRITE(p, "  sampleUv.x = x_block_position + x_offset_in_block;\n");
+  WRITE(p, "  sampleUv.y = y_block_position + y_offset_in_block;\n");
+
+  WRITE(p,
+        "  float2 uv0 = float2(sampleUv);\n");  // sampleUv is the sample position in (int)gx_coords
+  WRITE(p, "  uv0 += float2(0.5, 0.5);\n");     // move to center of pixel
+  WRITE(p, "  uv0 *= float(position.w);\n");  // scale by two if needed (also move to pixel borders
+                                              // so that linear filtering will average adjacent
+                                              // pixel)
+  WRITE(p, "  uv0 += float2(position.xy);\n");                    // move to copied rect
+  WRITE(p, "  uv0 /= float2(%d, %d);\n", EFB_WIDTH, EFB_HEIGHT);  // normalize to [0:1]
+  WRITE(p, "  uv0 /= float2(1, y_scale);\n");                     // apply the y scaling
+  if (ApiType == APIType::OpenGL)                                 // ogl has to flip up and down
+  {
+    WRITE(p, "  uv0.y = 1.0-uv0.y;\n");
+  }
+
+  WRITE(p, "  float2 pixel_size = float2(position.w, position.w) / float2(%d, %d);\n", EFB_WIDTH,
+        EFB_HEIGHT);
+}
+
+void WriteSampleColor(char*& p, const char* colorComp, const char* dest, int xoffset,
+                      APIType ApiType, const EFBCopyParams& params)
+{
+  WRITE(p, "  %s = SampleEFB(uv0, pixel_size, %d).%s;\n", dest, xoffset, colorComp);
+}
+
+void WriteColorToIntensity(char*& p, const char* src, const char* dest)
+{
+  if (!s_intensity_constant_added)
+  {
+    WRITE(p, "  float4 IntensityConst = float4(0.257f,0.504f,0.098f,0.0625f);\n");
+    s_intensity_constant_added = true;
+  }
+  WRITE(p, "  %s = dot(IntensityConst.rgb, %s.rgb);\n", dest, src);
+  // don't add IntensityConst.a yet, because doing it later is faster and uses less instructions,
+  // due to vectorization
+}
+
+void WriteToBitDepth(char*& p, u8 depth, const char* src, const char* dest)
+{
+  WRITE(p, "  %s = floor(%s * 255.0 / exp2(8.0 - %d.0));\n", dest, src, depth);
+}
+
+void WriteEncoderEnd(char*& p)
+{
+  WRITE(p, "}\n");
+  s_intensity_constant_added = false;
+}
+
+void WriteI8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::R8, ApiType);
+  WRITE(p, "  float3 texSample;\n");
+
+  WriteSampleColor(p, "rgb", "texSample", 0, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "ocol0.b");
+
+  WriteSampleColor(p, "rgb", "texSample", 1, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "ocol0.g");
+
+  WriteSampleColor(p, "rgb", "texSample", 2, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "ocol0.r");
+
+  WriteSampleColor(p, "rgb", "texSample", 3, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "ocol0.a");
+
+  WRITE(p, "  ocol0.rgba += IntensityConst.aaaa;\n");  // see WriteColorToIntensity
+
+  WriteEncoderEnd(p);
+}
+
+void WriteI4Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::R4, ApiType);
+  WRITE(p, "  float3 texSample;\n");
+  WRITE(p, "  float4 color0;\n");
+  WRITE(p, "  float4 color1;\n");
+
+  WriteSampleColor(p, "rgb", "texSample", 0, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color0.b");
+
+  WriteSampleColor(p, "rgb", "texSample", 1, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color1.b");
+
+  WriteSampleColor(p, "rgb", "texSample", 2, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color0.g");
+
+  WriteSampleColor(p, "rgb", "texSample", 3, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color1.g");
+
+  WriteSampleColor(p, "rgb", "texSample", 4, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color0.r");
+
+  WriteSampleColor(p, "rgb", "texSample", 5, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color1.r");
+
+  WriteSampleColor(p, "rgb", "texSample", 6, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color0.a");
+
+  WriteSampleColor(p, "rgb", "texSample", 7, ApiType, params);
+  WriteColorToIntensity(p, "texSample", "color1.a");
+
+  WRITE(p, "  color0.rgba += IntensityConst.aaaa;\n");
+  WRITE(p, "  color1.rgba += IntensityConst.aaaa;\n");
+
+  WriteToBitDepth(p, 4, "color0", "color0");
+  WriteToBitDepth(p, 4, "color1", "color1");
+
+  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(p);
+}
+
+void WriteIA8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
+  WRITE(p, "  float4 texSample;\n");
+
+  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
+  WRITE(p, "  ocol0.b = texSample.a;\n");
+  WriteColorToIntensity(p, "texSample", "ocol0.g");
+
+  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
+  WRITE(p, "  ocol0.r = texSample.a;\n");
+  WriteColorToIntensity(p, "texSample", "ocol0.a");
+
+  WRITE(p, "  ocol0.ga += IntensityConst.aa;\n");
+
+  WriteEncoderEnd(p);
+}
+
+void WriteIA4Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RA4, ApiType);
+  WRITE(p, "  float4 texSample;\n");
+  WRITE(p, "  float4 color0;\n");
+  WRITE(p, "  float4 color1;\n");
+
+  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
+  WRITE(p, "  color0.b = texSample.a;\n");
+  WriteColorToIntensity(p, "texSample", "color1.b");
+
+  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
+  WRITE(p, "  color0.g = texSample.a;\n");
+  WriteColorToIntensity(p, "texSample", "color1.g");
+
+  WriteSampleColor(p, "rgba", "texSample", 2, ApiType, params);
+  WRITE(p, "  color0.r = texSample.a;\n");
+  WriteColorToIntensity(p, "texSample", "color1.r");
+
+  WriteSampleColor(p, "rgba", "texSample", 3, ApiType, params);
+  WRITE(p, "  color0.a = texSample.a;\n");
+  WriteColorToIntensity(p, "texSample", "color1.a");
+
+  WRITE(p, "  color1.rgba += IntensityConst.aaaa;\n");
+
+  WriteToBitDepth(p, 4, "color0", "color0");
+  WriteToBitDepth(p, 4, "color1", "color1");
+
+  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(p);
+}
+
+void WriteRGB565Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RGB565, ApiType);
+  WRITE(p, "  float3 texSample0;\n");
+  WRITE(p, "  float3 texSample1;\n");
+
+  WriteSampleColor(p, "rgb", "texSample0", 0, ApiType, params);
+  WriteSampleColor(p, "rgb", "texSample1", 1, ApiType, params);
+  WRITE(p, "  float2 texRs = float2(texSample0.r, texSample1.r);\n");
+  WRITE(p, "  float2 texGs = float2(texSample0.g, texSample1.g);\n");
+  WRITE(p, "  float2 texBs = float2(texSample0.b, texSample1.b);\n");
+
+  WriteToBitDepth(p, 6, "texGs", "float2 gInt");
+  WRITE(p, "  float2 gUpper = floor(gInt / 8.0);\n");
+  WRITE(p, "  float2 gLower = gInt - gUpper * 8.0;\n");
+
+  WriteToBitDepth(p, 5, "texRs", "ocol0.br");
+  WRITE(p, "  ocol0.br = ocol0.br * 8.0 + gUpper;\n");
+  WriteToBitDepth(p, 5, "texBs", "ocol0.ga");
+  WRITE(p, "  ocol0.ga = ocol0.ga + gLower * 32.0;\n");
+
+  WRITE(p, "  ocol0 = ocol0 / 255.0;\n");
+  WriteEncoderEnd(p);
+}
+
+void WriteRGB5A3Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RGB5A3, ApiType);
+
+  WRITE(p, "  float4 texSample;\n");
+  WRITE(p, "  float color0;\n");
+  WRITE(p, "  float gUpper;\n");
+  WRITE(p, "  float gLower;\n");
+
+  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
+
+  // 0.8784 = 224 / 255 which is the maximum alpha value that can be represented in 3 bits
+  WRITE(p, "if(texSample.a > 0.878f) {\n");
+
+  WriteToBitDepth(p, 5, "texSample.g", "color0");
+  WRITE(p, "  gUpper = floor(color0 / 8.0);\n");
+  WRITE(p, "  gLower = color0 - gUpper * 8.0;\n");
+
+  WriteToBitDepth(p, 5, "texSample.r", "ocol0.b");
+  WRITE(p, "  ocol0.b = ocol0.b * 4.0 + gUpper + 128.0;\n");
+  WriteToBitDepth(p, 5, "texSample.b", "ocol0.g");
+  WRITE(p, "  ocol0.g = ocol0.g + gLower * 32.0;\n");
+
+  WRITE(p, "} else {\n");
+
+  WriteToBitDepth(p, 4, "texSample.r", "ocol0.b");
+  WriteToBitDepth(p, 4, "texSample.b", "ocol0.g");
+
+  WriteToBitDepth(p, 3, "texSample.a", "color0");
+  WRITE(p, "ocol0.b = ocol0.b + color0 * 16.0;\n");
+  WriteToBitDepth(p, 4, "texSample.g", "color0");
+  WRITE(p, "ocol0.g = ocol0.g + color0 * 16.0;\n");
+
+  WRITE(p, "}\n");
+
+  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
+
+  WRITE(p, "if(texSample.a > 0.878f) {\n");
+
+  WriteToBitDepth(p, 5, "texSample.g", "color0");
+  WRITE(p, "  gUpper = floor(color0 / 8.0);\n");
+  WRITE(p, "  gLower = color0 - gUpper * 8.0;\n");
+
+  WriteToBitDepth(p, 5, "texSample.r", "ocol0.r");
+  WRITE(p, "  ocol0.r = ocol0.r * 4.0 + gUpper + 128.0;\n");
+  WriteToBitDepth(p, 5, "texSample.b", "ocol0.a");
+  WRITE(p, "  ocol0.a = ocol0.a + gLower * 32.0;\n");
+
+  WRITE(p, "} else {\n");
+
+  WriteToBitDepth(p, 4, "texSample.r", "ocol0.r");
+  WriteToBitDepth(p, 4, "texSample.b", "ocol0.a");
+
+  WriteToBitDepth(p, 3, "texSample.a", "color0");
+  WRITE(p, "ocol0.r = ocol0.r + color0 * 16.0;\n");
+  WriteToBitDepth(p, 4, "texSample.g", "color0");
+  WRITE(p, "ocol0.a = ocol0.a + color0 * 16.0;\n");
+
+  WRITE(p, "}\n");
+
+  WRITE(p, "  ocol0 = ocol0 / 255.0;\n");
+  WriteEncoderEnd(p);
+}
+
+void WriteRGBA8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RGBA8, ApiType);
+
+  WRITE(p, "  float4 texSample;\n");
+  WRITE(p, "  float4 color0;\n");
+  WRITE(p, "  float4 color1;\n");
+
+  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
+  WRITE(p, "  color0.b = texSample.a;\n");
+  WRITE(p, "  color0.g = texSample.r;\n");
+  WRITE(p, "  color1.b = texSample.g;\n");
+  WRITE(p, "  color1.g = texSample.b;\n");
+
+  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
+  WRITE(p, "  color0.r = texSample.a;\n");
+  WRITE(p, "  color0.a = texSample.r;\n");
+  WRITE(p, "  color1.r = texSample.g;\n");
+  WRITE(p, "  color1.a = texSample.b;\n");
+
+  WRITE(p, "  ocol0 = first ? color0 : color1;\n");
+
+  WriteEncoderEnd(p);
+}
+
+void WriteC4Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::R4, ApiType);
+  WRITE(p, "  float4 color0;\n");
+  WRITE(p, "  float4 color1;\n");
+
+  WriteSampleColor(p, comp, "color0.b", 0, ApiType, params);
+  WriteSampleColor(p, comp, "color1.b", 1, ApiType, params);
+  WriteSampleColor(p, comp, "color0.g", 2, ApiType, params);
+  WriteSampleColor(p, comp, "color1.g", 3, ApiType, params);
+  WriteSampleColor(p, comp, "color0.r", 4, ApiType, params);
+  WriteSampleColor(p, comp, "color1.r", 5, ApiType, params);
+  WriteSampleColor(p, comp, "color0.a", 6, ApiType, params);
+  WriteSampleColor(p, comp, "color1.a", 7, ApiType, params);
+
+  WriteToBitDepth(p, 4, "color0", "color0");
+  WriteToBitDepth(p, 4, "color1", "color1");
+
+  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(p);
+}
+
+void WriteC8Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::R8, ApiType);
+
+  WriteSampleColor(p, comp, "ocol0.b", 0, ApiType, params);
+  WriteSampleColor(p, comp, "ocol0.g", 1, ApiType, params);
+  WriteSampleColor(p, comp, "ocol0.r", 2, ApiType, params);
+  WriteSampleColor(p, comp, "ocol0.a", 3, ApiType, params);
+
+  WriteEncoderEnd(p);
+}
+
+void WriteCC4Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RA4, ApiType);
+  WRITE(p, "  float2 texSample;\n");
+  WRITE(p, "  float4 color0;\n");
+  WRITE(p, "  float4 color1;\n");
+
+  WriteSampleColor(p, comp, "texSample", 0, ApiType, params);
+  WRITE(p, "  color0.b = texSample.x;\n");
+  WRITE(p, "  color1.b = texSample.y;\n");
+
+  WriteSampleColor(p, comp, "texSample", 1, ApiType, params);
+  WRITE(p, "  color0.g = texSample.x;\n");
+  WRITE(p, "  color1.g = texSample.y;\n");
+
+  WriteSampleColor(p, comp, "texSample", 2, ApiType, params);
+  WRITE(p, "  color0.r = texSample.x;\n");
+  WRITE(p, "  color1.r = texSample.y;\n");
+
+  WriteSampleColor(p, comp, "texSample", 3, ApiType, params);
+  WRITE(p, "  color0.a = texSample.x;\n");
+  WRITE(p, "  color1.a = texSample.y;\n");
+
+  WriteToBitDepth(p, 4, "color0", "color0");
+  WriteToBitDepth(p, 4, "color1", "color1");
+
+  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(p);
+}
+
+void WriteCC8Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
+
+  WriteSampleColor(p, comp, "ocol0.bg", 0, ApiType, params);
+  WriteSampleColor(p, comp, "ocol0.ra", 1, ApiType, params);
+
+  WriteEncoderEnd(p);
+}
+
+void WriteZ8Encoder(char*& p, const char* multiplier, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::G8, ApiType);
+
+  WRITE(p, " float depth;\n");
+
+  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
+  WRITE(p, "ocol0.b = frac(depth * %s);\n", multiplier);
+
+  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
+  WRITE(p, "ocol0.g = frac(depth * %s);\n", multiplier);
+
+  WriteSampleColor(p, "r", "depth", 2, ApiType, params);
+  WRITE(p, "ocol0.r = frac(depth * %s);\n", multiplier);
+
+  WriteSampleColor(p, "r", "depth", 3, ApiType, params);
+  WRITE(p, "ocol0.a = frac(depth * %s);\n", multiplier);
+
+  WriteEncoderEnd(p);
+}
+
+void WriteZ16Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
+
+  WRITE(p, "  float depth;\n");
+  WRITE(p, "  float3 expanded;\n");
+
+  // byte order is reversed
+
+  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
+
+  WRITE(p, "  depth *= 16777216.0;\n");
+  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
+  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
+  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
+
+  WRITE(p, "  ocol0.b = expanded.g / 255.0;\n");
+  WRITE(p, "  ocol0.g = expanded.r / 255.0;\n");
+
+  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
+
+  WRITE(p, "  depth *= 16777216.0;\n");
+  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
+  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
+  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
+
+  WRITE(p, "  ocol0.r = expanded.g / 255.0;\n");
+  WRITE(p, "  ocol0.a = expanded.r / 255.0;\n");
+
+  WriteEncoderEnd(p);
+}
+
+void WriteZ16LEncoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::GB8, ApiType);
+
+  WRITE(p, "  float depth;\n");
+  WRITE(p, "  float3 expanded;\n");
+
+  // byte order is reversed
+
+  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
+
+  WRITE(p, "  depth *= 16777216.0;\n");
+  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
+  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
+  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
+  WRITE(p, "  depth -= expanded.g * 256.0;\n");
+  WRITE(p, "  expanded.b = depth;\n");
+
+  WRITE(p, "  ocol0.b = expanded.b / 255.0;\n");
+  WRITE(p, "  ocol0.g = expanded.g / 255.0;\n");
+
+  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
+
+  WRITE(p, "  depth *= 16777216.0;\n");
+  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
+  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
+  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
+  WRITE(p, "  depth -= expanded.g * 256.0;\n");
+  WRITE(p, "  expanded.b = depth;\n");
+
+  WRITE(p, "  ocol0.r = expanded.b / 255.0;\n");
+  WRITE(p, "  ocol0.a = expanded.g / 255.0;\n");
+
+  WriteEncoderEnd(p);
+}
+
+void WriteZ24Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::RGBA8, ApiType);
+
+  WRITE(p, "  float depth0;\n");
+  WRITE(p, "  float depth1;\n");
+  WRITE(p, "  float3 expanded0;\n");
+  WRITE(p, "  float3 expanded1;\n");
+
+  WriteSampleColor(p, "r", "depth0", 0, ApiType, params);
+  WriteSampleColor(p, "r", "depth1", 1, ApiType, params);
+
+  for (int i = 0; i < 2; i++)
+  {
+    WRITE(p, "  depth%i *= 16777216.0;\n", i);
+
+    WRITE(p, "  expanded%i.r = floor(depth%i / (256.0 * 256.0));\n", i, i);
+    WRITE(p, "  depth%i -= expanded%i.r * 256.0 * 256.0;\n", i, i);
+    WRITE(p, "  expanded%i.g = floor(depth%i / 256.0);\n", i, i);
+    WRITE(p, "  depth%i -= expanded%i.g * 256.0;\n", i, i);
+    WRITE(p, "  expanded%i.b = depth%i;\n", i, i);
+  }
+
+  WRITE(p, "  if (!first) {\n");
+  // upper 16
+  WRITE(p, "     ocol0.b = expanded0.g / 255.0;\n");
+  WRITE(p, "     ocol0.g = expanded0.b / 255.0;\n");
+  WRITE(p, "     ocol0.r = expanded1.g / 255.0;\n");
+  WRITE(p, "     ocol0.a = expanded1.b / 255.0;\n");
+  WRITE(p, "  } else {\n");
+  // lower 8
+  WRITE(p, "     ocol0.b = 1.0;\n");
+  WRITE(p, "     ocol0.g = expanded0.r / 255.0;\n");
+  WRITE(p, "     ocol0.r = 1.0;\n");
+  WRITE(p, "     ocol0.a = expanded1.r / 255.0;\n");
+  WRITE(p, "  }\n");
+
+  WriteEncoderEnd(p);
+}
+
+void WriteXFBEncoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+{
+  WriteSwizzler(p, params, EFBCopyFormat::XFB, ApiType);
+
+  WRITE(p, "float3 color0, color1;\n");
+  WriteSampleColor(p, "rgb", "color0", 0, ApiType, params);
+  WriteSampleColor(p, "rgb", "color1", 1, ApiType, params);
+
+  // Gamma is only applied to XFB copies.
+  WRITE(p, "  color0 = pow(color0, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
+  WRITE(p, "  color1 = pow(color1, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
+
+  // Convert to YUV.
+  WRITE(p, "  const float3 y_const = float3(0.257, 0.504, 0.098);\n");
+  WRITE(p, "  const float3 u_const = float3(-0.148, -0.291, 0.439);\n");
+  WRITE(p, "  const float3 v_const = float3(0.439, -0.368, -0.071);\n");
+  WRITE(p, "  float3 average = (color0 + color1) * 0.5;\n");
+  WRITE(p, "  ocol0.b = dot(color0,  y_const) + 0.0625;\n");
+  WRITE(p, "  ocol0.g = dot(average, u_const) + 0.5;\n");
+  WRITE(p, "  ocol0.r = dot(color1,  y_const) + 0.0625;\n");
+  WRITE(p, "  ocol0.a = dot(average, v_const) + 0.5;\n");
+
+  WriteEncoderEnd(p);
+}
+}  // Anonymous namespace
+
+const char* GenerateEncodingShader(const EFBCopyParams& params, APIType api_type)
+{
+  s_text[sizeof(s_text) - 1] = 0x7C;  // canary
+
+  char* p = s_text;
+
+  switch (params.copy_format)
+  {
+  case EFBCopyFormat::R4:
+    if (params.yuv)
+      WriteI4Encoder(p, api_type, params);
+    else
+      WriteC4Encoder(p, "r", api_type, params);
+    break;
+  case EFBCopyFormat::RA4:
+    if (params.yuv)
+      WriteIA4Encoder(p, api_type, params);
+    else
+      WriteCC4Encoder(p, "ar", api_type, params);
+    break;
+  case EFBCopyFormat::RA8:
+    if (params.yuv)
+      WriteIA8Encoder(p, api_type, params);
+    else
+      WriteCC8Encoder(p, "ar", api_type, params);
+    break;
+  case EFBCopyFormat::RGB565:
+    WriteRGB565Encoder(p, api_type, params);
+    break;
+  case EFBCopyFormat::RGB5A3:
+    WriteRGB5A3Encoder(p, api_type, params);
+    break;
+  case EFBCopyFormat::RGBA8:
+    if (params.depth)
+      WriteZ24Encoder(p, api_type, params);
+    else
+      WriteRGBA8Encoder(p, api_type, params);
+    break;
+  case EFBCopyFormat::A8:
+    WriteC8Encoder(p, "a", api_type, params);
+    break;
+  case EFBCopyFormat::R8_0x1:
+  case EFBCopyFormat::R8:
+    if (params.yuv)
+      WriteI8Encoder(p, api_type, params);
+    else
+      WriteC8Encoder(p, "r", api_type, params);
+    break;
+  case EFBCopyFormat::G8:
+    if (params.depth)
+      WriteZ8Encoder(p, "256.0", api_type, params);  // Z8M
+    else
+      WriteC8Encoder(p, "g", api_type, params);
+    break;
+  case EFBCopyFormat::B8:
+    if (params.depth)
+      WriteZ8Encoder(p, "65536.0", api_type, params);  // Z8L
+    else
+      WriteC8Encoder(p, "b", api_type, params);
+    break;
+  case EFBCopyFormat::RG8:
+    if (params.depth)
+      WriteZ16Encoder(p, api_type, params);  // Z16H
+    else
+      WriteCC8Encoder(p, "gr", api_type, params);
+    break;
+  case EFBCopyFormat::GB8:
+    if (params.depth)
+      WriteZ16LEncoder(p, api_type, params);  // Z16L
+    else
+      WriteCC8Encoder(p, "bg", api_type, params);
+    break;
+  case EFBCopyFormat::XFB:
+    WriteXFBEncoder(p, api_type, params);
+    break;
+  default:
+    PanicAlert("Invalid EFB Copy Format (0x%X)! (GenerateEncodingShader)",
+               static_cast<int>(params.copy_format));
+    break;
+  }
+
+  if (s_text[sizeof(s_text) - 1] != 0x7C)
+    PanicAlert("TextureConversionShader generator - buffer too small, canary has been eaten!");
+
+  return s_text;
+}
 
 const DecodingShaderInfo* GetDecodingShaderInfo(TextureFormat format)
 {
@@ -1406,7 +1406,7 @@ std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_form
     break;
   }
 
-  ss << decoding_shader_header;
+  ss << s_decoding_shader_header;
   ss << info->shader_body;
 
   return ss.str();

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -1410,8 +1410,7 @@ std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, 
           (height + (info->group_size_y - 1)) / info->group_size_y};
 }
 
-std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format,
-                                   APIType api_type)
+std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format)
 {
   const DecodingShaderInfo* info = GetDecodingShaderInfo(format);
   if (!info)

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -1400,14 +1400,14 @@ const DecodingShaderInfo* GetDecodingShaderInfo(TextureFormat format)
   return iter != s_decoding_shader_info.end() ? &iter->second : nullptr;
 }
 
-std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, u32 height)
+std::pair<u32, u32> DecodingShaderInfo::GetDispatchCount(u32 width, u32 height) const
 {
   // Flatten to a single dimension?
-  if (info->group_flatten)
-    return {(width * height + (info->group_size_x - 1)) / info->group_size_x, 1};
+  if (group_flatten)
+    return {(width * height + (group_size_x - 1)) / group_size_x, 1};
 
-  return {(width + (info->group_size_x - 1)) / info->group_size_x,
-          (height + (info->group_size_y - 1)) / info->group_size_y};
+  return {(width + (group_size_x - 1)) / group_size_x,
+          (height + (group_size_y - 1)) / group_size_y};
 }
 
 std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format)

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -18,9 +18,7 @@ struct EFBCopyParams;
 
 namespace TextureConversionShaderTiled
 {
-u16 GetEncodedSampleCount(EFBCopyFormat format);
-
-const char* GenerateEncodingShader(const EFBCopyParams& params, APIType ApiType);
+const char* GenerateEncodingShader(const EFBCopyParams& params, APIType api_type);
 
 // Information required to compile and dispatch a texture decoding shader.
 struct DecodingShaderInfo

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -11,14 +11,13 @@
 
 enum class APIType;
 enum class TextureFormat;
-enum class EFBCopyFormat;
 enum class TLUTFormat;
 enum TexelBufferFormat : u32;
 struct EFBCopyParams;
 
 namespace TextureConversionShaderTiled
 {
-const char* GenerateEncodingShader(const EFBCopyParams& params, APIType api_type);
+std::string GenerateEncodingShader(const EFBCopyParams& params, APIType api_type);
 
 // Information required to compile and dispatch a texture decoding shader.
 struct DecodingShaderInfo

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -38,11 +38,10 @@ const DecodingShaderInfo* GetDecodingShaderInfo(TextureFormat format);
 // First is the number of X groups, second is the number of Y groups, Z is always one.
 std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, u32 height);
 
-// Returns the GLSL string containing the texture decoding shader for the specified format.
-std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format,
-                                   APIType api_type);
+// Returns the string containing the texture decoding shader for the specified format.
+std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format);
 
-// Returns the GLSL string containing the palette conversion shader for the specified format.
+// Returns the string containing the palette conversion shader for the specified format.
 std::string GeneratePaletteConversionShader(TLUTFormat palette_format, APIType api_type);
 
 }  // namespace TextureConversionShaderTiled

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -28,15 +28,16 @@ struct DecodingShaderInfo
   u32 group_size_y;
   bool group_flatten;
   const char* shader_body;
+
+  // Determine how many thread groups should be dispatched for an image of the specified
+  // width/height.
+  // First is the number of X groups, second is the number of Y groups, Z is always one.
+  std::pair<u32, u32> GetDispatchCount(u32 width, u32 height) const;
 };
 
 // Obtain shader information for the specified texture format.
 // If this format does not have a shader written for it, returns nullptr.
 const DecodingShaderInfo* GetDecodingShaderInfo(TextureFormat format);
-
-// Determine how many thread groups should be dispatched for an image of the specified width/height.
-// First is the number of X groups, second is the number of Y groups, Z is always one.
-std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, u32 height);
 
 // Returns the string containing the texture decoding shader for the specified format.
 std::string GenerateDecodingShader(TextureFormat format, TLUTFormat palette_format);


### PR DESCRIPTION
Encapsulates all of the file-scope state into its own class, removing some global mutable state, while also converting the generator itself over to using fmt where applicable. This is one of the older shaders that still had a `WRITE` macro defined to perform the appending to a global string buffer (which essentially forwarded directly to `sprintf`)

This way, we don't need to care about inserting canary characters into a buffer and hope we don't overwrite them. In many cases, we didn't even need to use `std::sprintf`.

While we're in the same area, we can make minor clean-up related changes to the interfaces, which have been separated into their own commits.

