### PR TITLE
VideoCommon/OpcodeDecoding: Make use of if constexpr 

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -25,6 +25,7 @@
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/GeometryShaderManager.h"
+#include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/PerfQueryBase.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -343,7 +344,7 @@ static void BPWritten(const BPCmd& bp)
 
     Memory::CopyFromEmu(texMem + tlutTMemAddr, addr, tlutXferCount);
 
-    if (g_bRecordFifoData)
+    if (OpcodeDecoder::g_record_fifo_data)
       FifoRecorder::GetInstance().UseMemory(addr, tlutXferCount, MemoryUpdate::TMEM);
 
     TextureCacheBase::InvalidateAllBindPoints();
@@ -566,7 +567,7 @@ static void BPWritten(const BPCmd& bp)
         }
       }
 
-      if (g_bRecordFifoData)
+      if (OpcodeDecoder::g_record_fifo_data)
         FifoRecorder::GetInstance().UseMemory(src_addr, bytes_read, MemoryUpdate::TMEM);
 
       TextureCacheBase::InvalidateAllBindPoints();

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -136,7 +136,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         return finish_up();
 
       const u32 cmd2 = src.Read<u32>();
-      const int transfer_size = ((cmd2 >> 16) & 15) + 1;
+      const u32 transfer_size = ((cmd2 >> 16) & 15) + 1;
       if (src.size() < transfer_size * sizeof(u32))
         return finish_up();
 

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -30,8 +30,6 @@
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/XFMemory.h"
 
-bool g_bRecordFifoData = false;
-
 namespace OpcodeDecoder
 {
 static bool s_is_fifo_error_seen = false;
@@ -74,6 +72,8 @@ static void InterpretDisplayListPreprocess(u32 address, u32 size)
 
   Run<true>(DataReader(start_address, start_address + size), nullptr, true);
 }
+
+bool g_record_fifo_data = false;
 
 void Init()
 {
@@ -255,7 +255,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
     }
 
     // Display lists get added directly into the FIFO stream
-    if (!is_preprocess && g_bRecordFifoData && cmd_byte != GX_CMD_CALL_DL)
+    if (!is_preprocess && g_record_fifo_data && cmd_byte != GX_CMD_CALL_DL)
     {
       const u8* const opcode_end = src.GetPointer();
       FifoRecorder::GetInstance().WriteGPCommand(opcode_start, u32(opcode_end - opcode_start));

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -31,9 +31,11 @@
 
 namespace OpcodeDecoder
 {
-static bool s_is_fifo_error_seen = false;
+namespace
+{
+bool s_is_fifo_error_seen = false;
 
-static u32 InterpretDisplayList(u32 address, u32 size)
+u32 InterpretDisplayList(u32 address, u32 size)
 {
   u8* start_address;
 
@@ -60,7 +62,7 @@ static u32 InterpretDisplayList(u32 address, u32 size)
   return cycles;
 }
 
-static void InterpretDisplayListPreprocess(u32 address, u32 size)
+void InterpretDisplayListPreprocess(u32 address, u32 size)
 {
   u8* const start_address = Memory::GetPointer(address);
 
@@ -71,6 +73,7 @@ static void InterpretDisplayListPreprocess(u32 address, u32 size)
 
   Run<true>(DataReader(start_address, start_address + size), nullptr, true);
 }
+}  // Anonymous namespace
 
 bool g_record_fifo_data = false;
 

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -124,7 +124,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       const u8 sub_cmd = src.Read<u8>();
       const u32 value = src.Read<u32>();
       LoadCPReg(sub_cmd, value, is_preprocess);
-      if (!is_preprocess)
+      if constexpr (!is_preprocess)
         INCSTAT(g_stats.this_frame.num_cp_loads);
     }
     break;
@@ -141,7 +141,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
 
       total_cycles += 18 + 6 * transfer_size;
 
-      if (!is_preprocess)
+      if constexpr (!is_preprocess)
       {
         const u32 xf_address = cmd2 & 0xFFFF;
         LoadXFReg(transfer_size, xf_address, src);
@@ -169,7 +169,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       // GX_LOAD_INDX_D (56) -> 0xF
       const int ref_array = (cmd_byte / 8) + 8;
 
-      if (is_preprocess)
+      if constexpr (is_preprocess)
         PreprocessIndexedXF(src.Read<u32>(), ref_array);
       else
         LoadIndexedXF(src.Read<u32>(), ref_array);
@@ -191,7 +191,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       }
       else
       {
-        if (is_preprocess)
+        if constexpr (is_preprocess)
           InterpretDisplayListPreprocess(address, count);
         else
           total_cycles += 6 + InterpretDisplayList(address, count);
@@ -220,7 +220,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
         total_cycles += 12;
 
         const u32 bp_cmd = src.Read<u32>();
-        if (is_preprocess)
+        if constexpr (is_preprocess)
         {
           LoadBPRegPreprocess(bp_cmd);
         }
@@ -266,10 +266,13 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
     }
 
     // Display lists get added directly into the FIFO stream
-    if (!is_preprocess && g_record_fifo_data && cmd_byte != GX_CMD_CALL_DL)
+    if constexpr (!is_preprocess)
     {
-      const u8* const opcode_end = src.GetPointer();
-      FifoRecorder::GetInstance().WriteGPCommand(opcode_start, u32(opcode_end - opcode_start));
+      if (g_record_fifo_data && cmd_byte != GX_CMD_CALL_DL)
+      {
+        const u8* const opcode_end = src.GetPointer();
+        FifoRecorder::GetInstance().WriteGPCommand(opcode_start, u32(opcode_end - opcode_start));
+      }
     }
   }
 }

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -9,10 +9,9 @@
 //  Super Mario Galaxy has nearly all geometry and more than half of the state in DLs (great!)
 
 // Note that it IS NOT GENERALLY POSSIBLE to precompile display lists! You can compile them as they
-// are
-// while interpreting them, and hope that the vertex format doesn't change, though, if you do it
-// right
-// when they are called. The reason is that the vertex format affects the sizes of the vertices.
+// are while interpreting them, and hope that the vertex format doesn't change, though, if you do
+// it right when they are called. The reason is that the vertex format affects the sizes of the
+// vertices.
 
 #include "VideoCommon/OpcodeDecoding.h"
 #include "Common/CommonTypes.h"

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -14,9 +14,9 @@
 // vertices.
 
 #include "VideoCommon/OpcodeDecoding.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
 #include "VideoCommon/BPMemory.h"
@@ -26,7 +26,6 @@
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/XFMemory.h"
 
 namespace OpcodeDecoder

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -10,6 +10,9 @@ class DataReader;
 
 namespace OpcodeDecoder
 {
+// Global flag to signal if FifoRecorder is active.
+extern bool g_record_fifo_data;
+
 enum
 {
   GX_NOP = 0x00,

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -65,6 +65,7 @@
 #include "VideoCommon/NetPlayChatUI.h"
 #include "VideoCommon/NetPlayGolfUI.h"
 #include "VideoCommon/OnScreenDisplay.h"
+#include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/PostProcessing.h"
@@ -880,19 +881,18 @@ std::tuple<int, int> Renderer::CalculateOutputDimensions(int width, int height) 
 
 void Renderer::CheckFifoRecording()
 {
-  bool wasRecording = g_bRecordFifoData;
-  g_bRecordFifoData = FifoRecorder::GetInstance().IsRecording();
+  const bool was_recording = OpcodeDecoder::g_record_fifo_data;
+  OpcodeDecoder::g_record_fifo_data = FifoRecorder::GetInstance().IsRecording();
 
-  if (g_bRecordFifoData)
+  if (!OpcodeDecoder::g_record_fifo_data)
+    return;
+
+  if (!was_recording)
   {
-    if (!wasRecording)
-    {
-      RecordVideoMemory();
-    }
-
-    FifoRecorder::GetInstance().EndFrame(CommandProcessor::fifo.CPBase,
-                                         CommandProcessor::fifo.CPEnd);
+    RecordVideoMemory();
   }
+
+  FifoRecorder::GetInstance().EndFrame(CommandProcessor::fifo.CPBase, CommandProcessor::fifo.CPEnd);
 }
 
 void Renderer::RecordVideoMemory()

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -38,6 +38,7 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/HiresTextures.h"
+#include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/SamplerCommon.h"
@@ -1260,9 +1261,11 @@ TextureCacheBase::GetTexture(u32 address, u32 width, u32 height, const TextureFo
 
   // If we are recording a FifoLog, keep track of what memory we read. FifoRecorder does
   // its own memory modification tracking independent of the texture hashing below.
-  if (g_bRecordFifoData && !from_tmem)
+  if (OpcodeDecoder::g_record_fifo_data && !from_tmem)
+  {
     FifoRecorder::GetInstance().UseMemory(address, texture_size + additional_mips_size,
                                           MemoryUpdate::TEXTURE_MAP);
+  }
 
   // TODO: This doesn't hash GB tiles for preloaded RGBA8 textures (instead, it's hashing more data
   // from the low tmem bank than it should)
@@ -2294,7 +2297,7 @@ void TextureCacheBase::CopyRenderTargetToTexture(
     ++iter.first;
   }
 
-  if (g_bRecordFifoData)
+  if (OpcodeDecoder::g_record_fifo_data)
   {
     // Mark the memory behind this efb copy as dynamicly generated for the Fifo log
     u32 address = dstAddr;

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -6,9 +6,6 @@
 
 #include "Common/CommonTypes.h"
 
-// Global flag to signal if FifoRecorder is active.
-extern bool g_bRecordFifoData;
-
 // These are accurate (disregarding AA modes).
 constexpr u32 EFB_WIDTH = 640;
 constexpr u32 EFB_HEIGHT = 528;


### PR DESCRIPTION
Performs a bit of clean-up to the opcode decoder and removes some usages of goto so that if constexpr can be leveraged in some code paths. Each commit should be relatively isolated from one another.