### PR TITLE
VideoCommon/IndexGenerator: Eliminate static state

### DIFF
--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -210,7 +210,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
   m_base_buffer_pointer = m_cpu_vertex_buffer.data();
   m_cur_buffer_pointer = m_base_buffer_pointer;
   m_end_buffer_pointer = m_base_buffer_pointer + m_cpu_vertex_buffer.size();
-  IndexGenerator::Start(m_cpu_index_buffer.data());
+  m_index_generator.Start(m_cpu_index_buffer.data());
 }
 
 void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -96,7 +96,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
   m_base_buffer_pointer = m_vertex_stream_buffer.GetHostPointer();
   m_end_buffer_pointer = m_vertex_stream_buffer.GetCurrentHostPointer() + MAXVBUFFERSIZE;
   m_cur_buffer_pointer = m_vertex_stream_buffer.GetCurrentHostPointer();
-  IndexGenerator::Start(reinterpret_cast<u16*>(m_index_stream_buffer.GetCurrentHostPointer()));
+  m_index_generator.Start(reinterpret_cast<u16*>(m_index_stream_buffer.GetCurrentHostPointer()));
 }
 
 void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -786,7 +786,6 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
 
   if (g_ActiveConfig.backend_info.bSupportsPrimitiveRestart)
     GLUtil::EnablePrimitiveRestart(m_main_gl_context.get());
-  IndexGenerator::Init();
 
   UpdateActiveConfig();
 }

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -165,7 +165,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
   m_end_buffer_pointer = buffer.first + MAXVBUFFERSIZE;
 
   buffer = m_index_buffer->Map(MAXIBUFFERSIZE * sizeof(u16));
-  IndexGenerator::Start((u16*)buffer.first);
+  m_index_generator.Start(reinterpret_cast<u16*>(buffer.first));
 }
 
 void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -64,7 +64,7 @@ void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_
     Rasterizer::SetTevReg(i, Tev::ALP_C, PixelShaderManager::constants.kcolors[i][3]);
   }
 
-  for (u32 i = 0; i < IndexGenerator::GetIndexLen(); i++)
+  for (u32 i = 0; i < m_index_generator.GetIndexLen(); i++)
   {
     const u16 index = m_cpu_index_buffer[i];
     memset(static_cast<void*>(&m_vertex), 0, sizeof(m_vertex));

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -165,7 +165,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
   m_base_buffer_pointer = m_vertex_stream_buffer->GetHostPointer();
   m_end_buffer_pointer = m_vertex_stream_buffer->GetCurrentHostPointer() + MAXVBUFFERSIZE;
   m_cur_buffer_pointer = m_vertex_stream_buffer->GetCurrentHostPointer();
-  IndexGenerator::Start(reinterpret_cast<u16*>(m_index_stream_buffer->GetCurrentHostPointer()));
+  m_index_generator.Start(reinterpret_cast<u16*>(m_index_stream_buffer->GetCurrentHostPointer()));
 }
 
 void VertexManager::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -26,7 +26,7 @@ u16* WriteTriangle(u16* index_ptr, u32 index1, u32 index2, u32 index3)
   *index_ptr++ = index1;
   *index_ptr++ = index2;
   *index_ptr++ = index3;
-  if (pr)
+  if constexpr (pr)
     *index_ptr++ = s_primitive_restart;
   return index_ptr;
 }
@@ -44,7 +44,7 @@ u16* AddList(u16* index_ptr, u32 num_verts, u32 index)
 template <bool pr>
 u16* AddStrip(u16* index_ptr, u32 num_verts, u32 index)
 {
-  if (pr)
+  if constexpr (pr)
   {
     for (u32 i = 0; i < num_verts; ++i)
     {
@@ -89,7 +89,7 @@ u16* AddFan(u16* index_ptr, u32 num_verts, u32 index)
 {
   u32 i = 2;
 
-  if (pr)
+  if constexpr (pr)
   {
     for (; i + 3 <= num_verts; i += 3)
     {
@@ -141,7 +141,7 @@ u16* AddQuads(u16* index_ptr, u32 num_verts, u32 index)
   u32 i = 3;
   for (; i < num_verts; i += 4)
   {
-    if (pr)
+    if constexpr (pr)
     {
       *index_ptr++ = index + i - 2;
       *index_ptr++ = index + i - 1;

--- a/Source/Core/VideoCommon/IndexGenerator.h
+++ b/Source/Core/VideoCommon/IndexGenerator.h
@@ -26,28 +26,6 @@ public:
   static u32 GetRemainingIndices();
 
 private:
-  // Triangles
-  template <bool pr>
-  static u16* AddList(u16* Iptr, u32 numVerts, u32 index);
-  template <bool pr>
-  static u16* AddStrip(u16* Iptr, u32 numVerts, u32 index);
-  template <bool pr>
-  static u16* AddFan(u16* Iptr, u32 numVerts, u32 index);
-  template <bool pr>
-  static u16* AddQuads(u16* Iptr, u32 numVerts, u32 index);
-  template <bool pr>
-  static u16* AddQuads_nonstandard(u16* Iptr, u32 numVerts, u32 index);
-
-  // Lines
-  static u16* AddLineList(u16* Iptr, u32 numVerts, u32 index);
-  static u16* AddLineStrip(u16* Iptr, u32 numVerts, u32 index);
-
-  // Points
-  static u16* AddPoints(u16* Iptr, u32 numVerts, u32 index);
-
-  template <bool pr>
-  static u16* WriteTriangle(u16* Iptr, u32 index1, u32 index2, u32 index3);
-
   static u16* index_buffer_current;
   static u16* BASEIptr;
   static u32 base_index;

--- a/Source/Core/VideoCommon/IndexGenerator.h
+++ b/Source/Core/VideoCommon/IndexGenerator.h
@@ -7,26 +7,29 @@
 
 #pragma once
 
+#include <array>
 #include "Common/CommonTypes.h"
 
 class IndexGenerator
 {
 public:
-  // Init
-  static void Init();
-  static void Start(u16* Indexptr);
+  void Init();
+  void Start(u16* index_ptr);
 
-  static void AddIndices(int primitive, u32 numVertices);
+  void AddIndices(int primitive, u32 num_vertices);
 
-  static void AddExternalIndices(const u16* indices, u32 num_indices, u32 num_vertices);
+  void AddExternalIndices(const u16* indices, u32 num_indices, u32 num_vertices);
 
   // returns numprimitives
-  static u32 GetNumVerts() { return base_index; }
-  static u32 GetIndexLen() { return (u32)(index_buffer_current - BASEIptr); }
-  static u32 GetRemainingIndices();
+  u32 GetNumVerts() const { return m_base_index; }
+  u32 GetIndexLen() const { return static_cast<u32>(m_index_buffer_current - m_base_index_ptr); }
+  u32 GetRemainingIndices() const;
 
 private:
-  static u16* index_buffer_current;
-  static u16* BASEIptr;
-  static u32 base_index;
+  u16* m_index_buffer_current = nullptr;
+  u16* m_base_index_ptr = nullptr;
+  u32 m_base_index = 0;
+
+  using PrimitiveFunction = u16* (*)(u16*, u32, u32);
+  std::array<PrimitiveFunction, 8> m_primitive_table{};
 };

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -283,8 +283,7 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
 
   count = loader->RunVertices(src, dst, count);
 
-  IndexGenerator::AddIndices(primitive, count);
-
+  g_vertex_manager->AddIndices(primitive, count);
   g_vertex_manager->FlushData(count, loader->m_native_vtx_decl.stride);
 
   ADDSTAT(g_stats.this_frame.num_prims, count);

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -88,12 +88,18 @@ VertexManagerBase::~VertexManagerBase() = default;
 
 bool VertexManagerBase::Initialize()
 {
+  m_index_generator.Init();
   return true;
 }
 
 u32 VertexManagerBase::GetRemainingSize() const
 {
   return static_cast<u32>(m_end_buffer_pointer - m_cur_buffer_pointer);
+}
+
+void VertexManagerBase::AddIndices(int primitive, u32 num_vertices)
+{
+  m_index_generator.AddIndices(primitive, num_vertices);
 }
 
 DataReader VertexManagerBase::PrepareForAdditionalData(int primitive, u32 count, u32 stride,
@@ -120,12 +126,12 @@ DataReader VertexManagerBase::PrepareForAdditionalData(int primitive, u32 count,
 
   // Check for size in buffer, if the buffer gets full, call Flush()
   if (!m_is_flushed &&
-      (count > IndexGenerator::GetRemainingIndices() || count > GetRemainingIndices(primitive) ||
+      (count > m_index_generator.GetRemainingIndices() || count > GetRemainingIndices(primitive) ||
        needed_vertex_bytes > GetRemainingSize()))
   {
     Flush();
 
-    if (count > IndexGenerator::GetRemainingIndices())
+    if (count > m_index_generator.GetRemainingIndices())
       ERROR_LOG(VIDEO, "Too little remaining index values. Use 32-bit or reset them on flush.");
     if (count > GetRemainingIndices(primitive))
       ERROR_LOG(VIDEO, "VertexManager: Buffer not large enough for all indices! "
@@ -145,7 +151,7 @@ DataReader VertexManagerBase::PrepareForAdditionalData(int primitive, u32 count,
       // This buffer isn't getting sent to the GPU. Just allocate it on the cpu.
       m_cur_buffer_pointer = m_base_buffer_pointer = m_cpu_vertex_buffer.data();
       m_end_buffer_pointer = m_base_buffer_pointer + m_cpu_vertex_buffer.size();
-      IndexGenerator::Start(m_cpu_index_buffer.data());
+      m_index_generator.Start(m_cpu_index_buffer.data());
     }
     else
     {
@@ -163,9 +169,9 @@ void VertexManagerBase::FlushData(u32 count, u32 stride)
   m_cur_buffer_pointer += count * stride;
 }
 
-u32 VertexManagerBase::GetRemainingIndices(int primitive)
+u32 VertexManagerBase::GetRemainingIndices(int primitive) const
 {
-  u32 index_len = MAXIBUFFERSIZE - IndexGenerator::GetIndexLen();
+  const u32 index_len = MAXIBUFFERSIZE - m_index_generator.GetIndexLen();
 
   if (g_Config.backend_info.bSupportsPrimitiveRestart)
   {
@@ -234,7 +240,7 @@ void VertexManagerBase::ResetBuffer(u32 vertex_stride)
   m_base_buffer_pointer = m_cpu_vertex_buffer.data();
   m_cur_buffer_pointer = m_cpu_vertex_buffer.data();
   m_end_buffer_pointer = m_base_buffer_pointer + m_cpu_vertex_buffer.size();
-  IndexGenerator::Start(m_cpu_index_buffer.data());
+  m_index_generator.Start(m_cpu_index_buffer.data());
 }
 
 void VertexManagerBase::CommitBuffer(u32 num_vertices, u32 vertex_stride, u32 num_indices,
@@ -288,7 +294,7 @@ void VertexManagerBase::UploadUtilityVertices(const void* vertices, u32 vertex_s
     m_cur_buffer_pointer += copy_size;
   }
   if (indices)
-    IndexGenerator::AddExternalIndices(indices, num_indices, num_vertices);
+    m_index_generator.AddExternalIndices(indices, num_indices, num_vertices);
 
   CommitBuffer(num_vertices, vertex_stride, num_indices, out_base_vertex, out_base_index);
 }
@@ -413,9 +419,9 @@ void VertexManagerBase::Flush()
   {
     // Now the vertices can be flushed to the GPU. Everything following the CommitBuffer() call
     // must be careful to not upload any utility vertices, as the binding will be lost otherwise.
-    const u32 num_indices = IndexGenerator::GetIndexLen();
+    const u32 num_indices = m_index_generator.GetIndexLen();
     u32 base_vertex, base_index;
-    CommitBuffer(IndexGenerator::GetNumVerts(),
+    CommitBuffer(m_index_generator.GetNumVerts(),
                  VertexLoaderManager::GetCurrentVertexFormat()->GetVertexStride(), num_indices,
                  &base_vertex, &base_index);
 

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -9,6 +9,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+#include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/RenderState.h"
 #include "VideoCommon/ShaderCache.h"
 
@@ -65,6 +66,7 @@ public:
   virtual bool Initialize();
 
   PrimitiveType GetCurrentPrimitiveType() const { return m_current_primitive_type; }
+  void AddIndices(int primitive, u32 num_vertices);
   DataReader PrepareForAdditionalData(int primitive, u32 count, u32 stride, bool cullall);
   void FlushData(u32 count, u32 stride);
 
@@ -134,7 +136,7 @@ protected:
   virtual void DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_vertex);
 
   u32 GetRemainingSize() const;
-  static u32 GetRemainingIndices(int primitive);
+  u32 GetRemainingIndices(int primitive) const;
 
   void CalculateZSlope(NativeVertexFormat* format);
   void LoadTextures();
@@ -158,6 +160,8 @@ protected:
   bool m_depth_state_changed = true;
   bool m_blending_state_changed = true;
   bool m_cull_all = false;
+
+  IndexGenerator m_index_generator;
 
 private:
   // Minimum number of draws per command buffer when attempting to preempt a readback operation.

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -270,7 +270,6 @@ void VideoBackendBase::InitializeShared()
   PixelEngine::Init();
   BPInit();
   VertexLoaderManager::Init();
-  IndexGenerator::Init();
   VertexShaderManager::Init();
   GeometryShaderManager::Init();
   PixelShaderManager::Init();


### PR DESCRIPTION
Gets rid of the global state within the index generator and makes it a proper class. This can just be a member that sits within the vertex manager base class. By deglobalizing the state of the index generator we also get rid of the wonky dual-initializing that was going on within the OpenGL backend. (e.g. Initialize would be called once during initialization for general backend initialization, and then the OpenGL backend would call it again after checking whether or not primitive restart is supported).

Since the renderer is always initialized before the vertex manager, we now only call `IndexGenerator`'s `Init()` once throughout the execution lifecycle.