### PR TITLE
Common/Network: Make StringToMacAddress use a string_view 

### DIFF
--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -43,7 +43,7 @@ std::string MacAddressToString(const MACAddress& mac)
                      mac[4], mac[5]);
 }
 
-std::optional<MACAddress> StringToMacAddress(const std::string& mac_string)
+std::optional<MACAddress> StringToMacAddress(std::string_view mac_string)
 {
   if (mac_string.empty())
     return {};

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -44,7 +44,7 @@ std::string MacAddressToString(const MACAddress& mac)
 std::optional<MACAddress> StringToMacAddress(std::string_view mac_string)
 {
   if (mac_string.empty())
-    return {};
+    return std::nullopt;
 
   int x = 0;
   MACAddress mac{};
@@ -68,7 +68,7 @@ std::optional<MACAddress> StringToMacAddress(std::string_view mac_string)
   // nibble is a character in the MAC address, making 12 characters
   // in total.
   if (x / 2 != MAC_ADDRESS_SIZE)
-    return {};
+    return std::nullopt;
 
   return std::make_optional(mac);
 }

--- a/Source/Core/Common/Network.cpp
+++ b/Source/Core/Common/Network.cpp
@@ -6,8 +6,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cstring>
-#include <ctime>
 
 #include <fmt/format.h>
 

--- a/Source/Core/Common/Network.h
+++ b/Source/Core/Common/Network.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 
@@ -27,5 +28,5 @@ using MACAddress = std::array<u8, MAC_ADDRESS_SIZE>;
 
 MACAddress GenerateMacAddress(MACConsumer type);
 std::string MacAddressToString(const MACAddress& mac);
-std::optional<MACAddress> StringToMacAddress(const std::string& mac_string);
+std::optional<MACAddress> StringToMacAddress(std::string_view mac_string);
 }  // namespace Common


### PR DESCRIPTION
This function only ever reads the contents of the string in a non-owning manner, so we can change the parameter over to being a string view.