### PR TITLE
Android: update to Gradle 3.5.3

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 


### PR DESCRIPTION
Android Studio recommends updating to Gradle 3.5.3