### PR TITLE
Fix Vulkan and D3D12 video backends crashing on boot

### DIFF
--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -31,6 +31,9 @@ VertexManager::~VertexManager() = default;
 
 bool VertexManager::Initialize()
 {
+  if (!VertexManagerBase::Initialize())
+    return false;
+
   if (!m_vertex_stream_buffer.AllocateBuffer(VERTEX_STREAM_BUFFER_SIZE) ||
       !m_index_stream_buffer.AllocateBuffer(INDEX_STREAM_BUFFER_SIZE) ||
       !m_uniform_stream_buffer.AllocateBuffer(UNIFORM_STREAM_BUFFER_SIZE) ||

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -59,6 +59,9 @@ VertexManager::~VertexManager()
 
 bool VertexManager::Initialize()
 {
+  if (!VertexManagerBase::Initialize())
+    return false;
+
   m_vertex_stream_buffer =
       StreamBuffer::Create(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VERTEX_STREAM_BUFFER_SIZE);
   m_index_stream_buffer =


### PR DESCRIPTION
Apparently we weren't calling the base initialize method.. this was probably my mistake, and just exposed by #8512.