### PR TITLE
Core: Reset Wiimotes/rumble/memwatcher on emu thread

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -289,12 +289,6 @@ void Stop()  // - Hammertime!
 
     g_video_backend->Video_ExitLoop();
   }
-
-  if (_CoreParameter.bWii)
-    Wiimote::ResetAllWiimotes();
-
-  ResetRumble();
-
 }
 
 void DeclareAsCPUThread()
@@ -534,7 +528,12 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
       return;
 
     if (init_wiimotes)
+    {
+      Wiimote::ResetAllWiimotes();
       Wiimote::Shutdown();
+    }
+
+    ResetRumble();
 
     Keyboard::Shutdown();
     Pad::Shutdown();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -295,9 +295,6 @@ void Stop()  // - Hammertime!
 
   ResetRumble();
 
-#ifdef USE_MEMORYWATCHER
-  s_memory_watcher.reset();
-#endif
 }
 
 void DeclareAsCPUThread()
@@ -373,6 +370,10 @@ static void CpuThread(const std::optional<std::string>& savestate_path, bool del
 
   // Enter CPU run loop. When we leave it - we are done.
   CPU::Run();
+
+#ifdef USE_MEMORYWATCHER
+  s_memory_watcher.reset();
+#endif
 
   s_is_started = false;
 


### PR DESCRIPTION
This was causing a race which was crashing the FifoCI runners. The main thread called Stop() which in turn called ResetAllWiimotes() while the emu thread was still exiting, also shutting down the Wiimote class.

By shifting the reset to the emu thread, all cleanup operations happen on the same thread where they were initialized.

The whole startup/shutdown situation is not an ideal design anyway (e.g. the `join()` in `Start()`...). But at least this fixes the "random" crashes.

I'd make `Stop()` simply block until the emu thread shuts down, but if any part of the shutdown requires window messages to be pumped, as `Stop()` is called from the UI thread it'll deadlock. So probably requires some more thinking.