### PR TITLE
Boot: Optionally allow preserving region settings in setting.txt

### DIFF
--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -26,10 +26,10 @@ class IOFile;
 
 struct RegionSetting
 {
-  const std::string area;
-  const std::string video;
-  const std::string game;
-  const std::string code;
+  std::string area;
+  std::string video;
+  std::string game;
+  std::string code;
 };
 
 class BootExecutableReader;

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -233,7 +233,7 @@ bool CBoot::SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type)
       {DiscIO::Region::PAL, {"EUR", "PAL", "EU", "LE"}},
       {DiscIO::Region::NTSC_K, {"KOR", "NTSC", "KR", "LKH"}}};
   auto entryPos = region_settings.find(SConfig::GetInstance().m_region);
-  const RegionSetting& region_setting = entryPos->second;
+  RegionSetting region_setting = entryPos->second;
 
   Common::SettingsHandler gen;
   std::string serno;
@@ -250,6 +250,11 @@ bool CBoot::SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type)
     {
       gen.SetBytes(std::move(data));
       serno = gen.GetValue("SERNO");
+      if (SConfig::GetInstance().bOverrideRegionSettings)
+      {
+        region_setting = RegionSetting{gen.GetValue("AREA"), gen.GetValue("VIDEO"),
+                                       gen.GetValue("GAME"), gen.GetValue("CODE")};
+      }
       gen.Reset();
     }
   }


### PR DESCRIPTION
See the discussion in https://bugs.dolphin-emu.org/issues/11930. (This probably doesn't really fix that issue, but it's something I thought would make sense anyway.)