### PR TITLE
PowerPC/PPCAnalyst: Remove unimplemented LogFunctionCall prototype

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -220,7 +220,6 @@ private:
   u32 m_options = 0;
 };
 
-void LogFunctionCall(u32 addr);
 void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db);
 bool AnalyzeFunction(u32 startAddr, Common::Symbol& func, u32 max_size = 0);
 bool ReanalyzeFunction(u32 start_addr, Common::Symbol& func, u32 max_size = 0);


### PR DESCRIPTION
This doesn't have an implementation, so it can be removed