### PR TITLE
FrameDump: Set first_frame if movie frame number <= 1

### DIFF
--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -443,7 +443,7 @@ FrameDump::Frame FrameDump::FetchState(u64 ticks)
 {
   Frame state;
   state.ticks = ticks;
-  state.first_frame = Movie::GetCurrentFrame() < 1;
+  state.first_frame = Movie::GetCurrentFrame() <= 1;
   state.ticks_per_second = SystemTimers::GetTicksPerSecond();
   state.savestate_index = s_savestate_index;
   return state;


### PR DESCRIPTION
This appears to cause ffmpeg to create invalid video files on output if the emulator only runs for a single frame, breaking FifoCI.

Someone with frame dumping knowledge should probably review this, but I suspect the regression started with the VI changes a little while back...