### PR TITLE
MacOS: Fixes configuration hang; bump MacOS SDK.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,10 @@ cmake_minimum_required(VERSION 3.10)
 set(CMAKE_OSX_ARCHITECTURES "x86_64")
 # Minimum OS X version.
 # This is inserted into the Info.plist as well.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10.0" CACHE STRING "")
+
+# MacOS prior to 10.12 did not fully support C++17, which is used to
+# handle configuration options
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12.0" CACHE STRING "")
 
 project(dolphin-emu)
 

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 * OS
     * Windows (7 SP1 or higher is officially supported, but Vista SP2 might also work).
     * Linux.
-    * macOS (10.10 Yosemite or higher).
+    * macOS (10.12 Sierra or higher).
     * Unix-like systems other than Linux are not officially supported but might work.
 * Processor
     * A CPU with SSE2 support.

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -5,11 +5,7 @@
 #include <algorithm>
 #include <list>
 #include <map>
-#if __APPLE__
-#include <mutex>
-#else
 #include <shared_mutex>
-#endif
 
 #include "Common/Config/Config.h"
 
@@ -21,19 +17,10 @@ static Layers s_layers;
 static std::list<ConfigChangedCallback> s_callbacks;
 static u32 s_callback_guards = 0;
 
-// Mac supports shared_mutex since 10.12 and we're targeting 10.10,
-// so only use unique locks there...
-#if __APPLE__
-static std::mutex s_layers_rw_lock;
-
-using ReadLock = std::unique_lock<std::mutex>;
-using WriteLock = std::unique_lock<std::mutex>;
-#else
 static std::shared_mutex s_layers_rw_lock;
 
 using ReadLock = std::shared_lock<std::shared_mutex>;
 using WriteLock = std::unique_lock<std::shared_mutex>;
-#endif
 
 void AddLayerInternal(std::shared_ptr<Layer> layer)
 {


### PR DESCRIPTION
Removed conditional use of std::mutex instead of std::shared_mutex on MacOS.

Because MacOS < 10.12 did not support std::shared_mutex, a previous commit
naïvely substituted std::mutex, which does not have the same behavior.

Reverses PR #8273, which substitues std::mutex for std::shared_mutex on
macOS, and results in several bugs that seem to only affect MacOS

- https://bugs.dolphin-emu.org/issues/11919
- https://bugs.dolphin-emu.org/issues/11842
- https://bugs.dolphin-emu.org/issues/11845

This change eliminates conditional code for MacOS in the core configuration
layer code and enables the use of modern language features that are more
secure and thread-safe.