### PR TITLE
VideoCommon/ShaderGenCommon: Convert helper functions over to fmt where applicable

### DIFF
--- a/Source/Core/VideoBackends/D3D/DXPipeline.cpp
+++ b/Source/Core/VideoBackends/D3D/DXPipeline.cpp
@@ -2,9 +2,6 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <algorithm>
-#include <cstring>
-
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
 
@@ -15,6 +12,7 @@
 #include "VideoBackends/D3D/DXTexture.h"
 #include "VideoBackends/D3D/Render.h"
 #include "VideoBackends/D3D/VertexManager.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace DX11
 {

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -33,6 +33,7 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace OGL
 {

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -10,10 +10,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
-#include <tuple>
-#include <vector>
 
-#include "Common/Assert.h"
 #include "Common/Atomic.h"
 #include "Common/CommonTypes.h"
 #include "Common/GL/GLContext.h"
@@ -24,7 +21,6 @@
 #include "Common/StringUtil.h"
 
 #include "Core/Config/GraphicsSettings.h"
-#include "Core/Core.h"
 
 #include "VideoBackends/OGL/BoundingBox.h"
 #include "VideoBackends/OGL/OGLPipeline.h"
@@ -32,22 +28,16 @@
 #include "VideoBackends/OGL/OGLTexture.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/SamplerCache.h"
-#include "VideoBackends/OGL/StreamBuffer.h"
 #include "VideoBackends/OGL/VertexManager.h"
 
 #include "VideoCommon/BPFunctions.h"
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/FramebufferManager.h"
-#include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OnScreenDisplay.h"
-#include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PostProcessing.h"
 #include "VideoCommon/RenderState.h"
-#include "VideoCommon/ShaderGenCommon.h"
-#include "VideoCommon/VertexShaderManager.h"
-#include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
-#include "VideoCommon/XFMemory.h"
 
 namespace OGL
 {

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -55,6 +55,7 @@ Make AA apply instantly during gameplay if possible
 
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace OGL

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -21,7 +21,7 @@
 #include "VideoBackends/Vulkan/VKTexture.h"
 #include "VideoBackends/Vulkan/VertexFormat.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
-#include "VideoCommon/Statistics.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace Vulkan
 {

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -3,9 +3,8 @@
 // Refer to the license.txt file included.
 
 #include "VideoCommon/FramebufferManager.h"
+
 #include <memory>
-#include "VideoCommon/FramebufferShaderGen.h"
-#include "VideoCommon/VertexManagerBase.h"
 
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
@@ -17,7 +16,10 @@
 #include "VideoCommon/AbstractStagingTexture.h"
 #include "VideoCommon/AbstractTexture.h"
 #include "VideoCommon/DriverDetails.h"
+#include "VideoCommon/FramebufferShaderGen.h"
 #include "VideoCommon/RenderBase.h"
+#include "VideoCommon/VertexManagerBase.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 // Maximum number of pixels poked in one batch * 6

--- a/Source/Core/VideoCommon/FramebufferShaderGen.cpp
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.cpp
@@ -12,6 +12,8 @@
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VertexShaderGen.h"
+#include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace FramebufferShaderGen
 {

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -91,7 +91,7 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
             "};\n");
 
   out.Write("struct VS_OUTPUT {\n");
-  GenerateVSOutputMembers<ShaderCode>(out, ApiType, uid_data->numTexGens, host_config, "");
+  GenerateVSOutputMembers(out, ApiType, uid_data->numTexGens, host_config, "");
   out.Write("};\n");
 
   if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
@@ -100,13 +100,13 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& h
       out.Write("#define InstanceID gl_InvocationID\n");
 
     out.Write("VARYING_LOCATION(0) in VertexData {\n");
-    GenerateVSOutputMembers<ShaderCode>(out, ApiType, uid_data->numTexGens, host_config,
-                                        GetInterpolationQualifier(msaa, ssaa, true, true));
+    GenerateVSOutputMembers(out, ApiType, uid_data->numTexGens, host_config,
+                            GetInterpolationQualifier(msaa, ssaa, true, true));
     out.Write("} vs[%d];\n", vertex_in);
 
     out.Write("VARYING_LOCATION(0) out VertexData {\n");
-    GenerateVSOutputMembers<ShaderCode>(out, ApiType, uid_data->numTexGens, host_config,
-                                        GetInterpolationQualifier(msaa, ssaa, true, false));
+    GenerateVSOutputMembers(out, ApiType, uid_data->numTexGens, host_config,
+                            GetInterpolationQualifier(msaa, ssaa, true, false));
 
     if (stereo)
       out.Write("\tflat int layer;\n");

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -28,6 +28,7 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/ShaderCache.h"
 #include "VideoCommon/VertexManagerBase.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace VideoCommon

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -15,14 +15,19 @@
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
+#include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VideoConfig.h"
 
-#include "imgui.h"
+#include <imgui.h>
 
 std::unique_ptr<VideoCommon::ShaderCache> g_shader_cache;
 
 namespace VideoCommon
 {
-ShaderCache::ShaderCache() = default;
+ShaderCache::ShaderCache() : m_api_type{APIType::Nothing}
+{
+}
+
 ShaderCache::~ShaderCache()
 {
   ClearCaches();

--- a/Source/Core/VideoCommon/ShaderCache.h
+++ b/Source/Core/VideoCommon/ShaderCache.h
@@ -34,6 +34,7 @@
 
 class NativeVertexFormat;
 enum class AbstractTextureFormat : u32;
+enum class APIType;
 enum class TextureFormat;
 enum class TLUTFormat;
 
@@ -191,7 +192,7 @@ private:
   };
 
   // Configuration bits.
-  APIType m_api_type = APIType::Nothing;
+  APIType m_api_type;
   ShaderHostConfig m_host_config = {};
   std::unique_ptr<AsyncShaderCompiler> m_async_shader_compiler;
 

--- a/Source/Core/VideoCommon/ShaderGenCommon.cpp
+++ b/Source/Core/VideoCommon/ShaderGenCommon.cpp
@@ -8,6 +8,8 @@
 
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
+#include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VideoConfig.h"
 
 ShaderHostConfig ShaderHostConfig::GetCurrent()
 {
@@ -83,4 +85,101 @@ std::string GetDiskShaderCacheFileName(APIType api_type, const char* type, bool 
 
   filename += ".cache";
   return filename;
+}
+
+static void DefineOutputMember(ShaderCode& object, APIType api_type, std::string_view qualifier,
+                               std::string_view type, std::string_view name, int var_index,
+                               std::string_view semantic = {}, int semantic_index = -1)
+{
+  object.WriteFmt("\t{} {} {}", qualifier, type, name);
+
+  if (var_index != -1)
+    object.WriteFmt("{}", var_index);
+
+  if (api_type == APIType::D3D && !semantic.empty())
+  {
+    if (semantic_index != -1)
+      object.WriteFmt(" : {}{}", semantic, semantic_index);
+    else
+      object.WriteFmt(" : {}", semantic);
+  }
+
+  object.WriteFmt(";\n");
+}
+
+void GenerateVSOutputMembers(ShaderCode& object, APIType api_type, u32 texgens,
+                             const ShaderHostConfig& host_config, std::string_view qualifier)
+{
+  DefineOutputMember(object, api_type, qualifier, "float4", "pos", -1, "SV_Position");
+  DefineOutputMember(object, api_type, qualifier, "float4", "colors_", 0, "COLOR", 0);
+  DefineOutputMember(object, api_type, qualifier, "float4", "colors_", 1, "COLOR", 1);
+
+  for (unsigned int i = 0; i < texgens; ++i)
+    DefineOutputMember(object, api_type, qualifier, "float3", "tex", i, "TEXCOORD", i);
+
+  if (!host_config.fast_depth_calc)
+    DefineOutputMember(object, api_type, qualifier, "float4", "clipPos", -1, "TEXCOORD", texgens);
+
+  if (host_config.per_pixel_lighting)
+  {
+    DefineOutputMember(object, api_type, qualifier, "float3", "Normal", -1, "TEXCOORD",
+                       texgens + 1);
+    DefineOutputMember(object, api_type, qualifier, "float3", "WorldPos", -1, "TEXCOORD",
+                       texgens + 2);
+  }
+
+  if (host_config.backend_geometry_shaders)
+  {
+    DefineOutputMember(object, api_type, qualifier, "float", "clipDist", 0, "SV_ClipDistance", 0);
+    DefineOutputMember(object, api_type, qualifier, "float", "clipDist", 1, "SV_ClipDistance", 1);
+  }
+}
+
+void AssignVSOutputMembers(ShaderCode& object, std::string_view a, std::string_view b, u32 texgens,
+                           const ShaderHostConfig& host_config)
+{
+  object.WriteFmt("\t{}.pos = {}.pos;\n", a, b);
+  object.WriteFmt("\t{}.colors_0 = {}.colors_0;\n", a, b);
+  object.WriteFmt("\t{}.colors_1 = {}.colors_1;\n", a, b);
+
+  for (unsigned int i = 0; i < texgens; ++i)
+    object.WriteFmt("\t{}.tex{} = {}.tex{};\n", a, i, b, i);
+
+  if (!host_config.fast_depth_calc)
+    object.WriteFmt("\t{}.clipPos = {}.clipPos;\n", a, b);
+
+  if (host_config.per_pixel_lighting)
+  {
+    object.WriteFmt("\t{}.Normal = {}.Normal;\n", a, b);
+    object.WriteFmt("\t{}.WorldPos = {}.WorldPos;\n", a, b);
+  }
+
+  if (host_config.backend_geometry_shaders)
+  {
+    object.WriteFmt("\t{}.clipDist0 = {}.clipDist0;\n", a, b);
+    object.WriteFmt("\t{}.clipDist1 = {}.clipDist1;\n", a, b);
+  }
+}
+
+const char* GetInterpolationQualifier(bool msaa, bool ssaa, bool in_glsl_interface_block, bool in)
+{
+  if (!msaa)
+    return "";
+
+  // Without GL_ARB_shading_language_420pack support, the interpolation qualifier must be
+  // "centroid in" and not "centroid", even within an interface block.
+  if (in_glsl_interface_block && !g_ActiveConfig.backend_info.bSupportsBindingLayout)
+  {
+    if (!ssaa)
+      return in ? "centroid in" : "centroid out";
+    else
+      return in ? "sample in" : "sample out";
+  }
+  else
+  {
+    if (!ssaa)
+      return "centroid";
+    else
+      return "sample";
+  }
 }

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -194,29 +194,29 @@ std::string GetDiskShaderCacheFileName(APIType api_type, const char* type, bool 
                                        bool include_host_config, bool include_api = true);
 
 template <class T>
-inline void DefineOutputMember(T& object, APIType api_type, const char* qualifier, const char* type,
-                               const char* name, int var_index, const char* semantic = "",
-                               int semantic_index = -1)
+void DefineOutputMember(T& object, APIType api_type, std::string_view qualifier,
+                        std::string_view type, std::string_view name, int var_index,
+                        std::string_view semantic = {}, int semantic_index = -1)
 {
-  object.Write("\t%s %s %s", qualifier, type, name);
+  object.WriteFmt("\t{} {} {}", qualifier, type, name);
 
   if (var_index != -1)
-    object.Write("%d", var_index);
+    object.WriteFmt("{}", var_index);
 
-  if (api_type == APIType::D3D && strlen(semantic) > 0)
+  if (api_type == APIType::D3D && !semantic.empty())
   {
     if (semantic_index != -1)
-      object.Write(" : %s%d", semantic, semantic_index);
+      object.WriteFmt(" : {}{}", semantic, semantic_index);
     else
-      object.Write(" : %s", semantic);
+      object.WriteFmt(" : {}", semantic);
   }
 
-  object.Write(";\n");
+  object.WriteFmt(";\n");
 }
 
 template <class T>
-inline void GenerateVSOutputMembers(T& object, APIType api_type, u32 texgens,
-                                    const ShaderHostConfig& host_config, const char* qualifier)
+void GenerateVSOutputMembers(T& object, APIType api_type, u32 texgens,
+                             const ShaderHostConfig& host_config, std::string_view qualifier)
 {
   DefineOutputMember(object, api_type, qualifier, "float4", "pos", -1, "SV_Position");
   DefineOutputMember(object, api_type, qualifier, "float4", "colors_", 0, "COLOR", 0);
@@ -244,29 +244,29 @@ inline void GenerateVSOutputMembers(T& object, APIType api_type, u32 texgens,
 }
 
 template <class T>
-inline void AssignVSOutputMembers(T& object, const char* a, const char* b, u32 texgens,
-                                  const ShaderHostConfig& host_config)
+void AssignVSOutputMembers(T& object, std::string_view a, std::string_view b, u32 texgens,
+                           const ShaderHostConfig& host_config)
 {
-  object.Write("\t%s.pos = %s.pos;\n", a, b);
-  object.Write("\t%s.colors_0 = %s.colors_0;\n", a, b);
-  object.Write("\t%s.colors_1 = %s.colors_1;\n", a, b);
+  object.WriteFmt("\t{}.pos = {}.pos;\n", a, b);
+  object.WriteFmt("\t{}.colors_0 = {}.colors_0;\n", a, b);
+  object.WriteFmt("\t{}.colors_1 = {}.colors_1;\n", a, b);
 
   for (unsigned int i = 0; i < texgens; ++i)
-    object.Write("\t%s.tex%d = %s.tex%d;\n", a, i, b, i);
+    object.WriteFmt("\t{}.tex{} = {}.tex{};\n", a, i, b, i);
 
   if (!host_config.fast_depth_calc)
-    object.Write("\t%s.clipPos = %s.clipPos;\n", a, b);
+    object.WriteFmt("\t{}.clipPos = {}.clipPos;\n", a, b);
 
   if (host_config.per_pixel_lighting)
   {
-    object.Write("\t%s.Normal = %s.Normal;\n", a, b);
-    object.Write("\t%s.WorldPos = %s.WorldPos;\n", a, b);
+    object.WriteFmt("\t{}.Normal = {}.Normal;\n", a, b);
+    object.WriteFmt("\t{}.WorldPos = {}.WorldPos;\n", a, b);
   }
 
   if (host_config.backend_geometry_shaders)
   {
-    object.Write("\t%s.clipDist0 = %s.clipDist0;\n", a, b);
-    object.Write("\t%s.clipDist1 = %s.clipDist1;\n", a, b);
+    object.WriteFmt("\t{}.clipDist0 = {}.clipDist0;\n", a, b);
+    object.WriteFmt("\t{}.clipDist1 = {}.clipDist1;\n", a, b);
   }
 }
 

--- a/Source/Core/VideoCommon/UberShaderCommon.cpp
+++ b/Source/Core/VideoCommon/UberShaderCommon.cpp
@@ -4,7 +4,8 @@
 
 #include "VideoCommon/UberShaderCommon.h"
 #include "VideoCommon/NativeVertexFormat.h"
-#include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/ShaderGenCommon.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/XFMemory.h"
 
 namespace UberShader

--- a/Source/Core/VideoCommon/UberShaderCommon.h
+++ b/Source/Core/VideoCommon/UberShaderCommon.h
@@ -9,8 +9,11 @@
 
 #include <fmt/format.h>
 
-#include "VideoCommon/ShaderGenCommon.h"
-#include "VideoCommon/VideoCommon.h"
+#include "Common/CommonTypes.h"
+
+class ShaderCode;
+enum class APIType;
+union ShaderHostConfig;
 
 namespace UberShader
 {

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -3,10 +3,15 @@
 // Refer to the license.txt file included.
 
 #include "VideoCommon/UberShaderPixel.h"
+
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/NativeVertexFormat.h"
+#include "VideoCommon/PixelShaderGen.h"
+#include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/UberShaderCommon.h"
+#include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 
 namespace UberShader

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -5,7 +5,10 @@
 #pragma once
 
 #include <functional>
-#include "VideoCommon/PixelShaderGen.h"
+#include "Common/CommonTypes.h"
+#include "VideoCommon/ShaderGenCommon.h"
+
+enum class APIType;
 
 namespace UberShader
 {

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -3,11 +3,12 @@
 // Refer to the license.txt file included.
 
 #include "VideoCommon/UberShaderVertex.h"
+
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/UberShaderCommon.h"
 #include "VideoCommon/VertexShaderGen.h"
-#include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/XFMemory.h"
 
 namespace UberShader

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -34,6 +34,7 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 


### PR DESCRIPTION
These helper functions are fairly trivial to convert over: no fancy formatting, just simple renaming `Write` over to `WriteFmt` and converting formatting specifiers over to `{}`. This'll make it more straightforward when converting over the shader generators, since `std::string_view` can now be used with these functions without needing to call `.data()`.

While we're in the same area, we can also convert several template functions into normal functions, given the type of their argument is always the same type (`ShaderCode&`). This allows hiding details within the translation unit, allowing changes to the implementation of the functions without needing to recompile every single shader generator translation unit. This also uncovered quite a few indirect inclusions in the process, which have also been amended.

I've separated the formatting changes and the changes that migrate the template functions to regular functions to make reviewing the two changes nicer on the reader.