### PR TITLE
Fix several warnings

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -35,7 +35,7 @@ using ReadLock = std::shared_lock<std::shared_mutex>;
 using WriteLock = std::unique_lock<std::shared_mutex>;
 #endif
 
-void AddLayerInternal(std::shared_ptr<Layer> layer)
+static void AddLayerInternal(std::shared_ptr<Layer> layer)
 {
   {
     WriteLock lock(s_layers_rw_lock);

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -425,6 +425,8 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
         case DiscIO::Region::NTSC_K:
           Config::SetCurrent(Config::SYSCONF_COUNTRY, 0x88);  // South Korea
           break;
+        case DiscIO::Region::Unknown:
+          break;
         }
       }
     }

--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -303,7 +303,7 @@ private:
 
 struct SmallBlockAccessors : Accessors
 {
-  SmallBlockAccessors(u8** alloc_base, u32 size) : alloc_base(alloc_base), size(size) {}
+  SmallBlockAccessors(u8** alloc_base_, u32 size_) : alloc_base{alloc_base_}, size{size_} {}
 
   bool IsValidAddress(u32 address) const override
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -321,7 +321,7 @@ bool GCMemcard::Save()
   return mcdFile.Close();
 }
 
-std::pair<u16, u16> CalculateMemcardChecksums(const u8* data, size_t size)
+static std::pair<u16, u16> CalculateMemcardChecksums(const u8* data, size_t size)
 {
   assert(size % 2 == 0);
   u16 csum = 0;

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -211,7 +211,7 @@ void WiimoteDevice::Activate(bool ready)
 
 void WiimoteDevice::EventConnectionAccepted()
 {
-  DEBUG_LOG(IOS_WIIMOTE, "ConnectionState %x -> CONN_LINKING", m_connection_state);
+  DEBUG_LOG(IOS_WIIMOTE, "ConnectionState %x -> CONN_LINKING", int(m_connection_state));
   m_connection_state = ConnectionState::Linking;
 }
 

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -176,9 +176,9 @@ constexpr std::array<u8, 256> s_key_codes_azerty{};
 #endif
 }  // Anonymous namespace
 
-USB_KBD::MessageData::MessageData(MessageType type, u8 modifiers, PressedKeyData pressed_keys)
-    : msg_type{Common::swap32(static_cast<u32>(type))}, modifiers{modifiers}, pressed_keys{
-                                                                                  pressed_keys}
+USB_KBD::MessageData::MessageData(MessageType type, u8 modifiers_, PressedKeyData pressed_keys_)
+    : msg_type{Common::swap32(static_cast<u32>(type))}, modifiers{modifiers_}, pressed_keys{
+                                                                                   pressed_keys_}
 {
 }
 

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -53,7 +53,7 @@ public:
   {
     T temp;
     if (!Read(offset, sizeof(T), reinterpret_cast<u8*>(&temp)))
-      return {};
+      return std::nullopt;
     return Common::FromBigEndian(temp);
   }
 

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -451,7 +451,7 @@ void DirectoryBlobReader::SetWiiRegionData(const std::string& game_partition_roo
     ERROR_LOG(DISCIO, "Couldn't read age ratings from %s", region_bin_path.c_str());
 
   constexpr u64 WII_REGION_DATA_ADDRESS = 0x4E000;
-  constexpr u64 WII_REGION_DATA_SIZE = 0x20;
+  [[maybe_unused]] constexpr u64 WII_REGION_DATA_SIZE = 0x20;
   m_nonpartition_contents.Add(WII_REGION_DATA_ADDRESS, m_wii_region_data);
 }
 

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -50,7 +50,7 @@ public:
   {
     T temp;
     if (!Read(offset, sizeof(T), reinterpret_cast<u8*>(&temp), partition))
-      return {};
+      return std::nullopt;
     return Common::FromBigEndian(temp);
   }
   std::optional<u64> ReadSwappedAndShifted(u64 offset, const Partition& partition) const

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -88,11 +88,9 @@ void RedumpVerifier::Start(const Volume& volume)
       return {};
     }
 
-    DownloadStatus status;
     {
       std::lock_guard lk(download_state->mutex);
       download_state->status = DownloadDatfile(system, download_state->status);
-      status = download_state->status;
     }
 
     switch (download_state->status)


### PR DESCRIPTION
A small, nonexhaustive set of warning fixes. The DiscIO Volume change
is a workaround for a GCC bug [1] that causes returning an unengaged
std::optional to emit annoying -Wmaybe-uninitialized warnings.
This last change alone fixes pages upon pages of warnings since
Volume.h is included from several files.

-Wstringop-truncation is another irrelevant warning for us, but
unfortunately there seems to be no way to disable it without
adding ugly pragmas wherever the warning appears.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635