### PR TITLE
IOS/FS: Reimplement many functions in a more accurate way

### DIFF
--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -109,12 +109,6 @@ static std::vector<u64> GetTitlesInTitleOrImport(FS::FileSystem* fs, const std::
     }
   }
 
-  // On a real Wii, the title list is not in any particular order. However, because of how
-  // the flash filesystem works, titles such as 1-2 are *never* in the first position.
-  // We must keep this behaviour, or some versions of the System Menu may break.
-
-  std::sort(title_ids.begin(), title_ids.end(), std::greater<>());
-
   return title_ids;
 }
 

--- a/Source/Core/Core/IOS/FS/FileSystem.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystem.cpp
@@ -11,6 +11,17 @@
 
 namespace IOS::HLE::FS
 {
+bool IsValidPath(std::string_view path)
+{
+  return path == "/" || IsValidNonRootPath(path);
+}
+
+bool IsValidNonRootPath(std::string_view path)
+{
+  return path.length() > 1 && path.length() <= MaxPathLength && path[0] == '/' &&
+         path.back() != '/';
+}
+
 std::unique_ptr<FileSystem> MakeFileSystem(Location location)
 {
   const std::string nand_root =

--- a/Source/Core/Core/IOS/FS/FileSystem.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystem.cpp
@@ -22,6 +22,13 @@ bool IsValidNonRootPath(std::string_view path)
          path.back() != '/';
 }
 
+SplitPathResult SplitPathAndBasename(std::string_view path)
+{
+  const auto last_separator = path.rfind('/');
+  return {std::string(path.substr(0, std::max<size_t>(1, last_separator))),
+          std::string(path.substr(last_separator + 1))};
+}
+
 std::unique_ptr<FileSystem> MakeFileSystem(Location location)
 {
   const std::string nand_root =

--- a/Source/Core/Core/IOS/FS/FileSystem.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystem.cpp
@@ -84,12 +84,6 @@ Result<FileStatus> FileHandle::GetStatus() const
   return m_fs->GetFileStatus(*m_fd);
 }
 
-void FileSystem::Init()
-{
-  if (Delete(0, 0, "/tmp") == ResultCode::Success)
-    CreateDirectory(0, 0, "/tmp", 0, {Mode::ReadWrite, Mode::ReadWrite, Mode::ReadWrite});
-}
-
 Result<FileHandle> FileSystem::CreateAndOpenFile(Uid uid, Gid gid, const std::string& path,
                                                  Modes modes)
 {

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -77,6 +77,16 @@ struct Modes
 {
   Mode owner, group, other;
 };
+inline bool operator==(const Modes& lhs, const Modes& rhs)
+{
+  const auto fields = [](const Modes& obj) { return std::tie(obj.owner, obj.group, obj.other); };
+  return fields(lhs) == fields(rhs);
+}
+
+inline bool operator!=(const Modes& lhs, const Modes& rhs)
+{
+  return !(lhs == rhs);
+}
 
 struct Metadata
 {

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -216,9 +216,6 @@ public:
   virtual Result<NandStats> GetNandStats() = 0;
   /// Get usage information about a directory (used cluster and inode counts).
   virtual Result<DirectoryStats> GetDirectoryStats(const std::string& path) = 0;
-
-protected:
-  void Init();
 };
 
 template <typename T>

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifdef _WIN32
@@ -110,6 +111,13 @@ struct FileStatus
   u32 offset;
   u32 size;
 };
+
+/// The maximum number of characters a path can have.
+constexpr size_t MaxPathLength = 64;
+
+/// Returns whether a Wii path is valid.
+bool IsValidPath(std::string_view path);
+bool IsValidNonRootPath(std::string_view path);
 
 class FileSystem;
 class FileHandle final

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -112,12 +112,24 @@ struct FileStatus
   u32 size;
 };
 
+/// The maximum number of components a path can have.
+constexpr size_t MaxPathDepth = 8;
 /// The maximum number of characters a path can have.
 constexpr size_t MaxPathLength = 64;
 
 /// Returns whether a Wii path is valid.
 bool IsValidPath(std::string_view path);
 bool IsValidNonRootPath(std::string_view path);
+
+struct SplitPathResult
+{
+  std::string parent;
+  std::string file_name;
+};
+/// Split a path into a parent path and the file name. Takes a *valid non-root* path.
+///
+/// Example: /shared2/sys/SYSCONF => {/shared2/sys, SYSCONF}
+SplitPathResult SplitPathAndBasename(std::string_view path);
 
 class FileSystem;
 class FileHandle final

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -136,6 +136,19 @@ struct SplitPathResult
   std::string parent;
   std::string file_name;
 };
+inline bool operator==(const SplitPathResult& lhs, const SplitPathResult& rhs)
+{
+  const auto fields = [](const SplitPathResult& obj) {
+    return std::tie(obj.parent, obj.file_name);
+  };
+  return fields(lhs) == fields(rhs);
+}
+
+inline bool operator!=(const SplitPathResult& lhs, const SplitPathResult& rhs)
+{
+  return !(lhs == rhs);
+}
+
 /// Split a path into a parent path and the file name. Takes a *valid non-root* path.
 ///
 /// Example: /shared2/sys/SYSCONF => {/shared2/sys, SYSCONF}

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -16,6 +16,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/FS/FileSystem.h"
+#include "Core/IOS/Uids.h"
 
 namespace IOS::HLE::Device
 {
@@ -37,6 +38,11 @@ constexpr size_t CLUSTER_DATA_SIZE = 0x4000;
 
 FS::FS(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
+  if (ios.GetFS()->Delete(PID_KERNEL, PID_KERNEL, "/tmp") == ResultCode::Success)
+  {
+    ios.GetFS()->CreateDirectory(PID_KERNEL, PID_KERNEL, "/tmp", 0,
+                                 {Mode::ReadWrite, Mode::ReadWrite, Mode::ReadWrite});
+  }
 }
 
 void FS::DoState(PointerWrap& p)

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -103,7 +103,6 @@ bool HostFileSystem::FstEntry::CheckPermission(Uid caller_uid, Gid caller_gid,
 
 HostFileSystem::HostFileSystem(const std::string& root_path) : m_root_path{root_path}
 {
-  Init();
   ResetFst();
   LoadFst();
 }

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -15,11 +15,6 @@
 
 namespace IOS::HLE::FS
 {
-static bool IsValidWiiPath(const std::string& path)
-{
-  return path.compare(0, 1, "/") == 0;
-}
-
 std::string HostFileSystem::BuildFilename(const std::string& wii_path) const
 {
   if (wii_path.compare(0, 1, "/") == 0)
@@ -185,7 +180,7 @@ ResultCode HostFileSystem::CreateFile(Uid, Gid, const std::string& path, FileAtt
 
 ResultCode HostFileSystem::CreateDirectory(Uid, Gid, const std::string& path, FileAttribute, Modes)
 {
-  if (!IsValidWiiPath(path))
+  if (!IsValidPath(path))
     return ResultCode::Invalid;
 
   std::string name(BuildFilename(path));
@@ -199,7 +194,7 @@ ResultCode HostFileSystem::CreateDirectory(Uid, Gid, const std::string& path, Fi
 
 ResultCode HostFileSystem::Delete(Uid, Gid, const std::string& path)
 {
-  if (!IsValidWiiPath(path))
+  if (!IsValidPath(path))
     return ResultCode::Invalid;
 
   const std::string file_name = BuildFilename(path);
@@ -216,11 +211,11 @@ ResultCode HostFileSystem::Delete(Uid, Gid, const std::string& path)
 ResultCode HostFileSystem::Rename(Uid, Gid, const std::string& old_path,
                                   const std::string& new_path)
 {
-  if (!IsValidWiiPath(old_path))
+  if (!IsValidPath(old_path))
     return ResultCode::Invalid;
   const std::string old_name = BuildFilename(old_path);
 
-  if (!IsValidWiiPath(new_path))
+  if (!IsValidPath(new_path))
     return ResultCode::Invalid;
   const std::string new_name = BuildFilename(new_path);
 
@@ -252,7 +247,7 @@ ResultCode HostFileSystem::Rename(Uid, Gid, const std::string& old_path,
 
 Result<std::vector<std::string>> HostFileSystem::ReadDirectory(Uid, Gid, const std::string& path)
 {
-  if (!IsValidWiiPath(path))
+  if (!IsValidPath(path))
     return ResultCode::Invalid;
 
   // the Wii uses this function to define the type (dir or file)
@@ -301,7 +296,7 @@ Result<Metadata> HostFileSystem::GetMetadata(Uid, Gid, const std::string& path)
   metadata.gid = 0x3031;  // this is also known as makercd, 01 (0x3031) for nintendo and 08
                           // (0x3038) for MH3 etc
 
-  if (!IsValidWiiPath(path))
+  if (!IsValidPath(path))
     return ResultCode::Invalid;
 
   std::string file_name = BuildFilename(path);
@@ -330,7 +325,7 @@ Result<Metadata> HostFileSystem::GetMetadata(Uid, Gid, const std::string& path)
 ResultCode HostFileSystem::SetMetadata(Uid caller_uid, const std::string& path, Uid uid, Gid gid,
                                        FileAttribute, Modes)
 {
-  if (!IsValidWiiPath(path))
+  if (!IsValidPath(path))
     return ResultCode::Invalid;
   return ResultCode::Success;
 }
@@ -354,7 +349,7 @@ Result<NandStats> HostFileSystem::GetNandStats()
 
 Result<DirectoryStats> HostFileSystem::GetDirectoryStats(const std::string& wii_path)
 {
-  if (!IsValidWiiPath(wii_path))
+  if (!IsValidPath(wii_path))
     return ResultCode::Invalid;
 
   DirectoryStats stats{};

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -103,6 +103,7 @@ bool HostFileSystem::FstEntry::CheckPermission(Uid caller_uid, Gid caller_gid,
 
 HostFileSystem::HostFileSystem(const std::string& root_path) : m_root_path{root_path}
 {
+  File::CreateFullPath(m_root_path + "/");
   ResetFst();
   LoadFst();
 }

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -334,9 +334,17 @@ void HostFileSystem::DoState(PointerWrap& p)
 
 ResultCode HostFileSystem::Format(Uid uid)
 {
+  if (uid != 0)
+    return ResultCode::AccessDenied;
+  if (m_root_path.empty())
+    return ResultCode::AccessDenied;
   const std::string root = BuildFilename("/");
   if (!File::DeleteDirRecursively(root) || !File::CreateDir(root))
     return ResultCode::UnknownError;
+  ResetFst();
+  SaveFst();
+  // Reset and close all handles.
+  m_handles = {};
   return ResultCode::Success;
 }
 

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.h
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.h
@@ -87,6 +87,9 @@ private:
   std::string BuildFilename(const std::string& wii_path) const;
   std::shared_ptr<File::IOFile> OpenHostFile(const std::string& host_path);
 
+  ResultCode CreateFileOrDirectory(Uid uid, Gid gid, const std::string& path,
+                                   FileAttribute attribute, Modes modes, bool is_file);
+
   std::string GetFstFilePath() const;
   void ResetFst();
   void LoadFst();

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.h
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.h
@@ -89,6 +89,8 @@ private:
 
   ResultCode CreateFileOrDirectory(Uid uid, Gid gid, const std::string& path,
                                    FileAttribute attribute, Modes modes, bool is_file);
+  bool IsFileOpened(const std::string& path) const;
+  bool IsDirectoryInUse(const std::string& path) const;
 
   std::string GetFstFilePath() const;
   void ResetFst();

--- a/Source/Core/Core/IOS/FS/HostBackend/FS.h
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.h
@@ -58,6 +58,20 @@ public:
   Result<DirectoryStats> GetDirectoryStats(const std::string& path) override;
 
 private:
+  struct FstEntry
+  {
+    bool CheckPermission(Uid uid, Gid gid, Mode requested_mode) const;
+
+    std::string name;
+    Metadata data{};
+    /// Children of this FST entry. Only valid for directories.
+    ///
+    /// We use a vector rather than a list here because iterating over children
+    /// happens a lot more often than removals.
+    /// Newly created entries are added at the end.
+    std::vector<FstEntry> children;
+  };
+
   struct Handle
   {
     bool opened = false;
@@ -73,6 +87,24 @@ private:
   std::string BuildFilename(const std::string& wii_path) const;
   std::shared_ptr<File::IOFile> OpenHostFile(const std::string& host_path);
 
+  std::string GetFstFilePath() const;
+  void ResetFst();
+  void LoadFst();
+  void SaveFst();
+  /// Get the FST entry for a file (or directory).
+  /// Automatically creates fallback entries for parents if they do not exist.
+  /// Returns nullptr if the path is invalid or the file does not exist.
+  FstEntry* GetFstEntryForPath(const std::string& path);
+
+  /// FST entry for the filesystem root.
+  ///
+  /// Note that unlike a real Wii's FST, ours is the single source of truth only for
+  /// filesystem metadata and ordering. File existence must be checked by querying
+  /// the host filesystem.
+  /// The reasons for this design are twofold: existing users do not have a FST
+  /// and we do not want FS to break if the user adds or removes files in their
+  /// filesystem root manually.
+  FstEntry m_root_entry{};
   std::string m_root_path;
   std::map<std::string, std::weak_ptr<File::IOFile>> m_open_files;
   std::array<Handle, 16> m_handles{};

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -904,8 +904,8 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       {
         auto buffer = DecompressPacketIntoBuffer(packet);
 
-        temp_fs->CreateDirectory(IOS::PID_KERNEL, IOS::PID_KERNEL, "/shared2/menu/FaceLib", 0,
-                                 fs_modes);
+        temp_fs->CreateFullPath(IOS::PID_KERNEL, IOS::PID_KERNEL, "/shared2/menu/FaceLib/", 0,
+                                fs_modes);
         auto file = temp_fs->CreateAndOpenFile(IOS::PID_KERNEL, IOS::PID_KERNEL,
                                                Common::GetMiiDatabasePath(), fs_modes);
 
@@ -924,8 +924,8 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       {
         u64 title_id = Common::PacketReadU64(packet);
         titles.push_back(title_id);
-        temp_fs->CreateDirectory(IOS::PID_KERNEL, IOS::PID_KERNEL,
-                                 Common::GetTitleDataPath(title_id), 0, fs_modes);
+        temp_fs->CreateFullPath(IOS::PID_KERNEL, IOS::PID_KERNEL,
+                                Common::GetTitleDataPath(title_id) + '/', 0, fs_modes);
         auto save = WiiSave::MakeNandStorage(temp_fs.get(), title_id);
 
         bool exists;

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -34,9 +34,8 @@ static std::string s_temp_wii_root;
 
 static void CopySave(FS::FileSystem* source, FS::FileSystem* dest, const u64 title_id)
 {
-  dest->CreateDirectory(IOS::PID_KERNEL, IOS::PID_KERNEL, Common::GetTitleDataPath(title_id), 0,
-                        {IOS::HLE::FS::Mode::ReadWrite, IOS::HLE::FS::Mode::ReadWrite,
-                         IOS::HLE::FS::Mode::ReadWrite});
+  dest->CreateFullPath(IOS::PID_KERNEL, IOS::PID_KERNEL, Common::GetTitleDataPath(title_id) + '/',
+                       0, {FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite});
   const auto source_save = WiiSave::MakeNandStorage(source, title_id);
   const auto dest_save = WiiSave::MakeNandStorage(dest, title_id);
   WiiSave::Copy(source_save.get(), dest_save.get());
@@ -49,9 +48,8 @@ static bool CopyNandFile(FS::FileSystem* source_fs, const std::string& source_fi
   if (last_slash != std::string::npos && last_slash > 0)
   {
     const std::string dir = dest_file.substr(0, last_slash);
-    dest_fs->CreateDirectory(IOS::PID_KERNEL, IOS::PID_KERNEL, dir, 0,
-                             {IOS::HLE::FS::Mode::ReadWrite, IOS::HLE::FS::Mode::ReadWrite,
-                              IOS::HLE::FS::Mode::ReadWrite});
+    dest_fs->CreateFullPath(IOS::PID_KERNEL, IOS::PID_KERNEL, dir + '/', 0,
+                            {FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite});
   }
 
   auto source_handle =
@@ -190,7 +188,7 @@ static bool CopySysmenuFilesToFS(FS::FileSystem* fs, const std::string& host_sou
 
     if (entry.isDirectory)
     {
-      fs->CreateDirectory(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path, 0, public_modes);
+      fs->CreateFullPath(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path + '/', 0, public_modes);
       if (!CopySysmenuFilesToFS(fs, host_path, nand_path))
         return false;
     }
@@ -259,12 +257,8 @@ void CleanUpWiiFileSystemContents()
 
     // FS won't write the save if the directory doesn't exist
     const std::string title_path = Common::GetTitleDataPath(title_id);
-    if (!configured_fs->GetMetadata(IOS::PID_KERNEL, IOS::PID_KERNEL, title_path))
-    {
-      configured_fs->CreateDirectory(IOS::PID_KERNEL, IOS::PID_KERNEL, title_path, 0,
-                                     {IOS::HLE::FS::Mode::ReadWrite, IOS::HLE::FS::Mode::ReadWrite,
-                                      IOS::HLE::FS::Mode::ReadWrite});
-    }
+    configured_fs->CreateFullPath(IOS::PID_KERNEL, IOS::PID_KERNEL, title_path + '/', 0,
+                                  {FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::ReadWrite});
 
     const auto user_save = WiiSave::MakeNandStorage(configured_fs.get(), title_id);
 

--- a/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
+++ b/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
@@ -52,14 +52,18 @@ TEST_F(FileSystemTest, CreateFile)
 {
   const std::string PATH = "/tmp/f";
 
-  ASSERT_EQ(m_fs->CreateFile(Uid{0}, Gid{0}, PATH, 0, modes), ResultCode::Success);
+  constexpr u8 ArbitraryAttribute = 0xE1;
+
+  ASSERT_EQ(m_fs->CreateFile(Uid{0}, Gid{0}, PATH, ArbitraryAttribute, modes), ResultCode::Success);
 
   const Result<Metadata> stats = m_fs->GetMetadata(Uid{0}, Gid{0}, PATH);
   ASSERT_TRUE(stats.Succeeded());
   EXPECT_TRUE(stats->is_file);
   EXPECT_EQ(stats->size, 0u);
-  // TODO: After we start saving metadata correctly, check the UID, GID, permissions
-  // as well (issue 10234).
+  EXPECT_EQ(stats->uid, 0);
+  EXPECT_EQ(stats->gid, 0);
+  EXPECT_EQ(stats->modes, modes);
+  EXPECT_EQ(stats->attribute, ArbitraryAttribute);
 
   ASSERT_EQ(m_fs->CreateFile(Uid{0}, Gid{0}, PATH, 0, modes), ResultCode::AlreadyExists);
 
@@ -72,21 +76,24 @@ TEST_F(FileSystemTest, CreateDirectory)
 {
   const std::string PATH = "/tmp/d";
 
-  ASSERT_EQ(m_fs->CreateDirectory(Uid{0}, Gid{0}, PATH, 0, modes), ResultCode::Success);
+  constexpr u8 ArbitraryAttribute = 0x20;
+
+  ASSERT_EQ(m_fs->CreateDirectory(Uid{0}, Gid{0}, PATH, ArbitraryAttribute, modes),
+            ResultCode::Success);
 
   const Result<Metadata> stats = m_fs->GetMetadata(Uid{0}, Gid{0}, PATH);
   ASSERT_TRUE(stats.Succeeded());
   EXPECT_FALSE(stats->is_file);
-  // TODO: After we start saving metadata correctly, check the UID, GID, permissions
-  // as well (issue 10234).
+  EXPECT_EQ(stats->uid, 0);
+  EXPECT_EQ(stats->gid, 0);
+  EXPECT_EQ(stats->modes, modes);
+  EXPECT_EQ(stats->attribute, ArbitraryAttribute);
 
   const Result<std::vector<std::string>> children = m_fs->ReadDirectory(Uid{0}, Gid{0}, PATH);
   ASSERT_TRUE(children.Succeeded());
   EXPECT_TRUE(children->empty());
 
-  // TODO: uncomment this after the FS code is fixed to return AlreadyExists.
-  // EXPECT_EQ(m_fs->CreateDirectory(Uid{0}, Gid{0}, PATH, 0, Mode::Read, Mode::None, Mode::None),
-  //           ResultCode::AlreadyExists);
+  EXPECT_EQ(m_fs->CreateDirectory(Uid{0}, Gid{0}, PATH, 0, modes), ResultCode::AlreadyExists);
 }
 
 TEST_F(FileSystemTest, Delete)

--- a/Tools/print-fs-fst.py
+++ b/Tools/print-fs-fst.py
@@ -1,0 +1,58 @@
+import argparse
+import struct
+
+def read_entry(f) -> dict:
+    name = struct.unpack_from("12s", f.read(12))[0]
+    uid = struct.unpack_from(">I", f.read(4))[0]
+    gid = struct.unpack_from(">H", f.read(2))[0]
+    is_file = struct.unpack_from("?", f.read(1))[0]
+    modes = struct.unpack_from("BBB", f.read(3))
+    attr = struct.unpack_from("B", f.read(2))[0]
+    x3 = struct.unpack_from(">I", f.read(4))[0]
+    num_children = struct.unpack_from(">I", f.read(4))[0]
+
+    children = []
+    for i in range(num_children):
+        children.append(read_entry(f))
+
+    return {
+        "name": name,
+        "uid": uid,
+        "gid": gid,
+        "is_file": is_file,
+        "modes": modes,
+        "attr": attr,
+        "x3": x3,
+        "children": children,
+    }
+
+COLOR_RESET = "\x1b[0;00m"
+BOLD = "\x1b[0;37m"
+COLOR_BLUE = "\x1b[1;34m"
+COLOR_GREEN = "\x1b[0;32m"
+
+def print_entry(entry, indent) -> None:
+    mode_str = {0: "--", 1: "r-", 2: "-w", 3: "rw"}
+
+    sp = ' ' * indent
+    color = BOLD if entry["is_file"] else COLOR_BLUE
+
+    owner = f"{COLOR_GREEN}{entry['uid']:04x}{COLOR_RESET}:{entry['gid']:04x}"
+    attrs = f"{''.join(mode_str[mode] for mode in entry['modes'])}"
+    other_attrs = f"{entry['attr']} {entry['x3']}"
+
+    print(f"{sp}{color}{entry['name'].decode()}{COLOR_RESET} [{owner} {attrs} {other_attrs}]")
+    for child in entry["children"]:
+        print_entry(child, indent + 2)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prints a FST in a tree-like format.")
+    parser.add_argument("file")
+    args = parser.parse_args()
+
+    with open(args.file, "rb") as f:
+        root = read_entry(f)
+
+    print_entry(root, 0)
+
+main()


### PR DESCRIPTION
Some official titles rely on implementation details of Nintendo's FS sysmodule and will not work properly if those are changed. Notably, some games and older versions of the System Menu appear to be relying on the order of files returned by FS::ReadDirectory and will either fail to find their save data (for [Bolt](https://wiki.dolphin-emu.org/index.php?title=Bolt)) or outright crash (for the [System Menu](https://wiki.dolphin-emu.org/index.php?title=Wii_Menu)).

Some titles also actually expect filesystem metadata to be correct. One title that has been confirmed to do this is [DQX](https://wiki.dolphin-emu.org/index.php?title=Dragon_Quest_X), which generates paths based on the GID of files within its own title directory.

While it is easy to make workarounds for these issues -- and in fact we already do have some for the sysmenu and DQX, having hacks is obviously nonideal and adding yet another hack would be required to fix Bolt -- one that would be even uglier.

Furthermore, while it is currently unknown whether any official title cares about permissions, the lack of FS metadata means that we are unable to implement them if that turns out to be desirable or necessary.

By adding a FST, we can implement things correctly and solve all those problems without adding hacks. In fact, this PR even *gets rid* of two hacks in the FS code.

For simplicity, a binary format that is inspired from Nintendo's FST structure was chosen for serialization. It is not expected to ever receive an update.

Most of the new code that is added by this PR is additional checks or necessary logic which were missing from the previous implementation. I've also seized this opportunity to even implement permission checks, since obscure IOS features have a history of coming into play at unexpected times...

The last few commits are mostly unit test fixes or additions. All tests passed.

### Results

This PR fixes Bolt, which is now able to find its save files:

![RLUE4Q_2019-12-29_19-42-55](https://user-images.githubusercontent.com/4209061/71563289-2653c180-2a8d-11ea-8934-937aed4c2cff.png)

Two hacks were removed.

Apart from DQX, the sysmenu and Bolt, this PR also happens to fix the [Photo Channel](https://wiki.dolphin-emu.org/index.php?title=Photo_Channel) complaining about corrupted system files on the initial launch.

Before (initial boot):

![HAAA01_2019-12-29_19-40-00](https://user-images.githubusercontent.com/4209061/71563290-379cce00-2a8d-11ea-80aa-82dd71ab0d85.png)

After (initial boot):

![HAAA01_2019-12-29_19-43-20](https://user-images.githubusercontent.com/4209061/71563291-3b305500-2a8d-11ea-90ca-eafeea5333f3.png)

### An update on the NAND image backend

A long time ago I had planned to add another FS backend which would be using a NAND image/blob as the storage. While I have already written an implementation that has been tested, solves all the aforementioned issues and more, produces images that are fully compatible with IOS's FS driver, I feel like NAND images raise too many issues: savestate sizes, code complexity and maintenance cost.

Since many fixes and additions that are part of that branch (e.g. FS timings, utility structures, FST) have already been merged or submitted as part of this PR, I will likely not submit it.