### PR TITLE
Fix Gecko codes loading

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -85,6 +85,11 @@ std::vector<GeckoCode> DownloadCodes(std::string gametdb_id, bool* succeeded)
     {
       std::istringstream ssline(line);
       std::string addr, data;
+
+      // Some locales (e.g. fr_FR.UTF-8) don't split the string stream on space
+      // Use the C locale to workaround this behavior
+      ssline.imbue(std::locale::classic());
+
       ssline >> addr >> data;
       ssline.seekg(0);
 
@@ -138,6 +143,10 @@ std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localI
     for (auto& line : lines)
     {
       std::istringstream ss(line);
+
+      // Some locales (e.g. fr_FR.UTF-8) don't split the string stream on space
+      // Use the C locale to workaround this behavior
+      ss.imbue(std::locale::classic());
 
       switch ((line)[0])
       {


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/11809

I found on my system (Archlinux) that using a locale with UTF-8 was breaking loading of Gecko codes. Hopefully forcing the C locale on this string stream should be enough without breaking it on other systems.