### PR TITLE
Core/GeckoCode: Fix DownloadCodes function assuming HTTP data is null terminated.

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -36,7 +36,7 @@ std::vector<GeckoCode> DownloadCodes(std::string gametdb_id, bool* succeeded)
   std::vector<GeckoCode> gcodes;
 
   // parse the codes
-  std::istringstream ss(reinterpret_cast<const char*>(response->data()));
+  std::istringstream ss(std::string(response->begin(), response->end()));
 
   std::string line;
 


### PR DESCRIPTION
A `std::string` is constructed from a `vector<u8>` data pointer casted to `char*`. This assumes the data is null terminated which is probably not the case.

Potential out-of-bounds access is fixed.

I looked at our other usages of `Common::HttpRequest` and they seem correct unlike this one.