### PR TITLE
MacOS: Dispatch GL calls to main thread to prevent crashes on Catalina

### DIFF
--- a/Source/Core/Common/GL/GLInterface/AGL.mm
+++ b/Source/Core/Common/GL/GLInterface/AGL.mm
@@ -36,10 +36,12 @@ static bool AttachContextToView(NSOpenGLContext* context, NSView* view, u32* wid
 
   (void)UpdateCachedDimensions(view, width, height);
 
-  [window makeFirstResponder:view];
-  [context setView:view];
-  [window makeKeyAndOrderFront:nil];
-
+  // the following calls can crash if not called from the main thread on macOS 10.15
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [window makeFirstResponder:view];
+    [context setView:view];
+    [window makeKeyAndOrderFront:nil];
+  });
   return true;
 }
 
@@ -140,7 +142,10 @@ void GLContextAGL::Update()
     return;
 
   if (UpdateCachedDimensions(m_view, &m_backbuffer_width, &m_backbuffer_height))
-    [m_context update];
+    // the following calls can crash if not called from the main thread on macOS 10.15
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      [m_context update];
+    });
 }
 
 void GLContextAGL::SwapInterval(int interval)


### PR DESCRIPTION
Hello, everybody.  First time here.

I discovered Dolphin today and tried out the development build on Catalina.  It didn't work too well with a bunch of hanging, so I built it up and pulled in #8530 to fix some of the chronic hangs and non-responsive controllers.

After configuring my controllers, selecting a ROM immediately led to this crash in AttachContextToView:

```
Process:               Dolphin [78328]
Path:                  /Users/USER/*/Dolphin.app/Contents/MacOS/Dolphin
Identifier:            org.dolphin-emu.dolphin
Version:               5.0-11422 (5.0)
Code Type:             X86-64 (Native)
Parent Process:        zsh [12794]
Responsible:           Terminal [2118]
User ID:               501

Date/Time:             2020-01-01 21:26:09.146 -0500
OS Version:            Mac OS X 10.15.3 (19D49f)
Report Version:        12
Anonymous UUID:        82114560-50F3-87D4-9575-CCC256799B8D


Time Awake Since Boot: 1100000 seconds

System Integrity Protection: enabled

Crashed Thread:        21  Emuthread - Starting

Exception Type:        EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Illegal instruction: 4
Termination Reason:    Namespace SIGNAL, Code 0x4
Terminating Process:   exc handler [78328]

Application Specific Information:
-[NSOpenGLContext setView:] must be called from the main thread.

Thread 0:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   com.apple.HIToolbox           	0x00007fff2a96765d RunCurrentEventLoopInMode + 292
6   com.apple.HIToolbox           	0x00007fff2a96739d ReceiveNextEventCommon + 600
7   com.apple.HIToolbox           	0x00007fff2a967127 _BlockUntilNextEventMatchingListInModeWithFilter + 64
8   com.apple.AppKit              	0x00007fff28febeb4 _DPSNextEvent + 990
9   com.apple.AppKit              	0x00007fff28fea690 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1352
10  com.apple.AppKit              	0x00007fff28fdc3ae -[NSApplication run] + 658
11  libqcocoa.dylib               	0x0000000109a33698 0x109a00000 + 210584
12  org.qt-project.QtCore         	0x0000000106814ddf QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 431
13  org.qt-project.QtCore         	0x0000000106819e82 QCoreApplication::exec() + 130

Thread 1:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 2:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 3:: org.libusb.device-hotplug
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   com.apple.CoreFoundation      	0x00007fff2be9a19a CFRunLoopRun + 40
6   org.dolphin-emu.dolphin       	0x000000010292d7bf darwin_event_thread_main + 351
7   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 4:: libusb thread
0   libsystem_kernel.dylib        	0x00007fff63a70896 poll + 10
1   org.dolphin-emu.dolphin       	0x0000000102929755 handle_events + 437

Thread 5:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 6:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 7:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 8:
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45cc1 std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 93
3   org.dolphin-emu.dolphin       	0x000000010293ed3e void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, IoThreadHolder::Start()::'lambda'()> >(void*) + 190 (__mutex_base:419)
4   ???                           	0x000000004d55545a 0 + 1297437786

Thread 9:: Analytics
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18

Thread 10:
0   libsystem_kernel.dylib        	0x00007fff63a6cbba __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff639f00fa nanosleep + 196
2   libSDL2-2.0.0.dylib           	0x000000010461d861 SDL_Delay_REAL + 83
3   libSDL2-2.0.0.dylib           	0x0000000104582eda SDL_WaitEventTimeout_REAL + 70
4   org.dolphin-emu.dolphin       	0x0000000102754a08 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ciface::SDL::Init()::$_1> >(void*) + 360
5   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 11:: IOHIDManager Hotplug Thread
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   org.dolphin-emu.dolphin       	0x000000010274a825 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ciface::OSX::Init(void*)::$_1> >(void*) + 165
6   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 12:: Wiimote Scanning Thread
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45cc1 std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 93
3   org.dolphin-emu.dolphin       	0x000000010237a5b5 bool Common::Event::WaitFor<long long, std::__1::ratio<1l, 1000l> >(std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000l> > const&) + 213

Thread 13:
0   libsystem_kernel.dylib        	0x00007fff63a6cbba __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff639f00fa nanosleep + 196
2   libsystem_c.dylib             	0x00007fff639efff4 usleep + 53
3   org.dolphin-emu.dolphin       	0x00000001022e235a HotkeyScheduler::Run() + 4538
4   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 14:
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18
3   org.dolphin-emu.dolphin       	0x00000001023a1e8b Common::WorkQueueThread<GameTracker::Command>::ThreadLoop() + 107
4   ???                           	0x8000000000000000 0 + 9223372036854775808

Thread 15:
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45cc1 std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 93
3   org.dolphin-emu.dolphin       	0x00000001022d9b25 bool Common::Event::WaitFor<long long, std::__1::ratio<1l, 1l> >(std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> > const&) + 213

Thread 16:: com.apple.CFSocket.private
0   libsystem_kernel.dylib        	0x00007fff63a725be __select + 10
1   com.apple.CoreFoundation      	0x00007fff2be3cd8a __CFSocketManager + 632
2   libsystem_pthread.dylib       	0x00007fff63b2de65 _pthread_start + 148
3   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 17:: Dispatch queue: com.apple.root.utility-qos
0   com.apple.CoreFoundation      	0x00007fff2bedf4d4 _CFRelease + 309
1   com.apple.CoreFoundation      	0x00007fff2bdde0de _CFBundleCopyFindResources + 2637
2   com.apple.CoreFoundation      	0x00007fff2bddd688 CFBundleCopyResourceURL + 31
3   com.apple.CoreFoundation      	0x00007fff2bddd575 CFBundleGetLocalInfoDictionary + 139
4   com.apple.CoreFoundation      	0x00007fff2bddd4b0 CFBundleGetValueForInfoDictionaryKey + 30
5   com.apple.opengl              	0x00007fff36a80ab4 0x7fff36a73000 + 55988
6   com.apple.opengl              	0x00007fff36a806e0 0x7fff36a73000 + 55008
7   libdispatch.dylib             	0x00007fff638cf583 _dispatch_call_block_and_release + 12
8   libdispatch.dylib             	0x00007fff638d050e _dispatch_client_callout + 8
9   libdispatch.dylib             	0x00007fff638de933 _dispatch_root_queue_drain + 663
10  libdispatch.dylib             	0x00007fff638def22 _dispatch_worker_thread2 + 92
11  libsystem_pthread.dylib       	0x00007fff63b2a6b6 _pthread_wqthread + 220
12  libsystem_pthread.dylib       	0x00007fff63b29827 start_wqthread + 15

Thread 18:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 19:: com.apple.NSEventThread
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   com.apple.AppKit              	0x00007fff2918ea72 _NSEventThread + 132
6   libsystem_pthread.dylib       	0x00007fff63b2de65 _pthread_start + 148
7   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 20:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 21 Crashed:: Emuthread - Starting
0   com.apple.AppKit              	0x00007fff2938fd9c -[NSOpenGLContext setView:] + 229
1   org.dolphin-emu.dolphin       	0x000000010289c6f4 GLContextAGL::Initialize(WindowSystemInfo const&, bool, bool) + 436
2   ???                           	0x00007fcb727c4230 0 + 140511775834672

Thread 22:: Memcard 0 flushing thread
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18
3   org.dolphin-emu.dolphin       	0x00000001024bfb6b GCMemcardDirectory::FlushThread() + 235
4   ???                           	0x0000000000000001 0 + 1
5   ???                           	0x000020a000000000 0 + 35871566856192

Thread 23:: DVD thread
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18

Thread 24:: libusb thread
0   libsystem_kernel.dylib        	0x00007fff63a70896 poll + 10
1   org.dolphin-emu.dolphin       	0x0000000102929755 handle_events + 437

Thread 25:: libusb thread
0   libsystem_kernel.dylib        	0x00007fff63a70896 poll + 10
1   org.dolphin-emu.dolphin       	0x0000000102929755 handle_events + 437

Thread 21 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x00007fcb3360a880  rcx: 0x0000000000000000  rdx: 0x0000000000000000
  rdi: 0x0000000000000000  rsi: 0x000000001f08000c  rbp: 0x0000700007016c20  rsp: 0x0000700007016bd0
   r8: 0x0000000000000000   r9: 0x0000000000000000  r10: 0x0000000000000000  r11: 0x0000000000000000
  r12: 0x00007fcb727c4230  r13: 0x00007fff625af000  r14: 0x00007fcb727d3470  r15: 0x00007fcb336164c0
  rip: 0x00007fff2938fd9c  rfl: 0x0000000000010206  cr2: 0x000000010c8c7000
  
Logical CPU:     1
Error Code:      0x00000000
Trap Number:     6


Binary Images:
       0x1022b8000 -        0x102a7dff7 +org.dolphin-emu.dolphin (5.0-11422 - 5.0) <FB3F70A2-26F6-3349-A613-4E5AB7865B45> /Users/USER/*/Dolphin.app/Contents/MacOS/Dolphin
       0x103fbb000 -        0x1043fdff3 +org.qt-project.QtWidgets (5.13 - 5.13.1) <4F9FB2B1-EFA5-3D1E-9CAD-FB0C924945EF> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtWidgets.framework/Versions/5/QtWidgets
       0x104566000 -        0x104641fff +libSDL2-2.0.0.dylib (0) <3A751D21-CECC-37E2-B03B-AD0D4092ED08> /Users/USER/*/Dolphin.app/Contents/Frameworks/libSDL2-2.0.0.dylib
       0x104687000 -        0x104689fff +libhidapi.0.dylib (0) <DE0220FC-E027-3032-A1CE-50C8978887A5> /Users/USER/*/Dolphin.app/Contents/Frameworks/libhidapi.0.dylib
       0x104694000 -        0x104813fff +libavformat.58.20.100.dylib (0) <712262F2-4ACD-35CB-BF7F-33CAE094AD67> /Users/USER/*/Dolphin.app/Contents/Frameworks/libavformat.58.20.100.dylib
       0x10485b000 -        0x1056afff7 +libavcodec.58.35.100.dylib (0) <B9B7D8FF-2AED-3329-A305-90C93A3117E1> /Users/USER/*/Dolphin.app/Contents/Frameworks/libavcodec.58.35.100.dylib
       0x106050000 -        0x1060c0ff7 +libswscale.5.3.100.dylib (0) <D862A50D-B179-3B1D-A3D8-811ACADFCE44> /Users/USER/*/Dolphin.app/Contents/Frameworks/libswscale.5.3.100.dylib
       0x1060d2000 -        0x10652cfe7 +org.qt-project.QtGui (5.13 - 5.13.1) <45C7BF76-E87C-30FB-864D-FD65F399D520> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtGui.framework/Versions/5/QtGui
       0x106636000 -        0x106b59fff +org.qt-project.QtCore (5.13 - 5.13.1) <0B3FF8A2-5042-3335-A1D7-2F6D99B08266> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtCore.framework/Versions/5/QtCore
       0x106c1d000 -        0x106c34fef +libswresample.3.3.100.dylib (0) <09B81BA2-CFAE-3417-88E2-0804EEFF2405> /Users/USER/*/Dolphin.app/Contents/Frameworks/libswresample.3.3.100.dylib
       0x106c3d000 -        0x106c79fef +libavutil.56.22.100.dylib (0) <8E7706F5-16A4-34E6-A9ED-7D63D0ECAD6B> /Users/USER/*/Dolphin.app/Contents/Frameworks/libavutil.56.22.100.dylib
       0x106ca3000 -        0x106cdbfff +libbluray.2.dylib (0) <930DD703-F9D2-3C15-8810-B4676499C2DD> /Users/USER/*/Dolphin.app/Contents/Frameworks/libbluray.2.dylib
       0x106ced000 -        0x106e36fff +libgnutls.30.dylib (0) <F0FD90B9-189A-38ED-909D-3686A757B8F1> /Users/USER/*/Dolphin.app/Contents/Frameworks/libgnutls.30.dylib
       0x106e80000 -        0x106e93fff +librtmp.1.dylib (0) <1509FC17-6340-3DC3-BC60-CA815B248042> /Users/USER/*/Dolphin.app/Contents/Frameworks/librtmp.1.dylib
       0x106ea0000 -        0x106ee0ff7 +libssl.1.0.0.dylib (0) <B4719A46-019C-3F07-9E5E-D62D3768CD14> /Users/USER/*/Dolphin.app/Contents/Frameworks/libssl.1.0.0.dylib
       0x106eff000 -        0x107052eaf +libcrypto.1.0.0.dylib (0) <A80F77EF-A996-3CA6-98CB-287A9C76C124> /Users/USER/*/Dolphin.app/Contents/Frameworks/libcrypto.1.0.0.dylib
       0x1070ce000 -        0x1070e9ff7 +liblzma.5.dylib (0) <423B98CF-7AF0-325D-AB6A-3F44B56B90C2> /Users/USER/*/Dolphin.app/Contents/Frameworks/liblzma.5.dylib
       0x1070f4000 -        0x107105ff7 +libopencore-amrwb.0.dylib (0) <12737D90-9518-3186-B09B-BFD651D7E31A> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopencore-amrwb.0.dylib
       0x10710b000 -        0x10710ffeb +libsnappy.1.1.7.dylib (0) <12A38208-34C5-3599-BD68-BC842E9FEBF5> /Users/USER/*/Dolphin.app/Contents/Frameworks/libsnappy.1.1.7.dylib
       0x107115000 -        0x10714cffb +libmp3lame.0.dylib (0) <B69319FA-C9B7-3A7C-A150-E511F8D792BF> /Users/USER/*/Dolphin.app/Contents/Frameworks/libmp3lame.0.dylib
       0x107189000 -        0x1071aafff +libopencore-amrnb.0.dylib (0) <F82300B4-A85D-398D-A20B-2873006D7329> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopencore-amrnb.0.dylib
       0x1071b5000 -        0x1071edffb +libopenjp2.2.3.1.dylib (0) <C43F22CC-3F4C-3CE1-BA54-554BA28B8F78> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopenjp2.2.3.1.dylib
       0x1071f9000 -        0x107241ff3 +libopus.0.dylib (0) <0D5C4A88-2412-3D3B-B49A-F11C00BA8C05> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopus.0.dylib
       0x107250000 -        0x107261ff3 +libspeex.1.dylib (0) <1EFB0C34-78D6-392E-912D-2E0A075FA834> /Users/USER/*/Dolphin.app/Contents/Frameworks/libspeex.1.dylib
       0x10726d000 -        0x107294ff7 +libtheoraenc.1.dylib (0) <6C26ECBB-A8D4-3B5C-822F-76FEC355B0D2> /Users/USER/*/Dolphin.app/Contents/Frameworks/libtheoraenc.1.dylib
       0x1072a0000 -        0x1072acfff +libtheoradec.1.dylib (0) <D0E1513B-4003-3C4D-95FC-5796DD6DD094> /Users/USER/*/Dolphin.app/Contents/Frameworks/libtheoradec.1.dylib
       0x1072b6000 -        0x1072b9fff +libogg.0.dylib (0) <70E116A3-5EA5-3B75-AD66-35B0F0298639> /Users/USER/*/Dolphin.app/Contents/Frameworks/libogg.0.dylib
       0x1072bd000 -        0x1072dffff +libvorbis.0.dylib (0) <17074AE1-B95D-3BBE-A50A-739F32F95413> /Users/USER/*/Dolphin.app/Contents/Frameworks/libvorbis.0.dylib
       0x1072ea000 -        0x107361fff +libvorbisenc.2.dylib (0) <346B6C8D-D8FF-3D3E-8C47-AEA47C0BE159> /Users/USER/*/Dolphin.app/Contents/Frameworks/libvorbisenc.2.dylib
       0x107399000 -        0x10752dfdf +libx264.155.dylib (0) <F405A367-C814-330B-8741-608E717A642A> /Users/USER/*/Dolphin.app/Contents/Frameworks/libx264.155.dylib
       0x107655000 -        0x1084cdfd3 +libx265.176.dylib (0) <9EA96905-B41F-3D50-90B9-25BF8EBA9187> /Users/USER/*/Dolphin.app/Contents/Frameworks/libx265.176.dylib
       0x1086cb000 -        0x1086f0ff3 +libsoxr.0.1.2.dylib (0) <1C380A7A-FE3E-3606-9466-3168DDD81686> /Users/USER/*/Dolphin.app/Contents/Frameworks/libsoxr.0.1.2.dylib
       0x10872e000 -        0x10875dfff +libfontconfig.1.dylib (0) <DF644C1F-4C8C-372F-A0B4-B03BCB76AEDE> /Users/USER/*/Dolphin.app/Contents/Frameworks/libfontconfig.1.dylib
       0x10876c000 -        0x1087e7fff +libfreetype.6.dylib (0) <02EE484C-8D5B-36C3-988B-00DD0C7369FE> /Users/USER/*/Dolphin.app/Contents/Frameworks/libfreetype.6.dylib
       0x108802000 -        0x108825ff7 +libpng16.16.dylib (0) <B7CE95CF-E67E-39EB-8DF5-B89849A02BDA> /Users/USER/*/Dolphin.app/Contents/Frameworks/libpng16.16.dylib
       0x10882f000 -        0x1088d6ff3 +libp11-kit.0.dylib (0) <2C68B3C9-42B9-3F59-8677-B8FC46A7A1DF> /Users/USER/*/Dolphin.app/Contents/Frameworks/libp11-kit.0.dylib
       0x108925000 -        0x108941ffb +libidn2.0.dylib (0) <5D11E999-01AA-348E-80A4-C98017A88F95> /Users/USER/*/Dolphin.app/Contents/Frameworks/libidn2.0.dylib
       0x10894b000 -        0x108aaefff +libunistring.2.dylib (0) <A4545916-E2F4-3D6A-862B-528A6806E9FC> /Users/USER/*/Dolphin.app/Contents/Frameworks/libunistring.2.dylib
       0x108ac4000 -        0x108ad0fff +libtasn1.6.dylib (0) <C27BBF20-E800-3ABE-9830-8E2FA9A2B33C> /Users/USER/*/Dolphin.app/Contents/Frameworks/libtasn1.6.dylib
       0x108ad8000 -        0x108afdff7 +libnettle.6.5.dylib (0) <F07C4E8D-7087-384C-AC93-46234AEB2391> /Users/USER/*/Dolphin.app/Contents/Frameworks/libnettle.6.5.dylib
       0x108b0e000 -        0x108b37ffb +libhogweed.4.5.dylib (0) <E0C32E51-C7D4-3C15-A269-272AD3BC3BBE> /Users/USER/*/Dolphin.app/Contents/Frameworks/libhogweed.4.5.dylib
       0x108b42000 -        0x108b9efcf +libgmp.10.dylib (0) <7D2A1AB0-B206-3196-954C-5A0E17049998> /Users/USER/*/Dolphin.app/Contents/Frameworks/libgmp.10.dylib
       0x108bae000 -        0x108bb6ffb +libintl.8.dylib (0) <CD236902-DB50-39BB-86BB-E9F0D22E5649> /Users/USER/*/Dolphin.app/Contents/Frameworks/libintl.8.dylib
       0x108bbf000 -        0x108bc3ff7 +libffi.6.dylib (0) <986DC089-727D-3563-935B-652AB8C97396> /Users/USER/*/Dolphin.app/Contents/Frameworks/libffi.6.dylib
       0x108c0f000 -        0x108c16ff3  com.apple.iokit.IOUSBLib (900.4.2 - 900.4.2) <F7F9D6DD-6137-3849-9CDD-8E198228CC37> /System/Library/Extensions/IOUSBFamily.kext/Contents/PlugIns/IOUSBLib.bundle/Contents/MacOS/IOUSBLib
       0x108c27000 -        0x108c2fff3  com.apple.iokit.IOUSBLib (900.4.2 - 900.4.2) <6C376796-C56A-3A4A-8EA6-440CFE4CB1A5> /System/Library/Extensions/IOUSBHostFamily.kext/Contents/PlugIns/IOUSBLib.bundle/Contents/MacOS/IOUSBLib
       0x108cc8000 -        0x108d26ffb +org.qt-project.QtDBus (5.13 - 5.13.1) <6BBA8F9F-3C83-3AD0-B036-02681FDE2D56> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtDBus.framework/Versions/5/QtDBus
       0x108d3f000 -        0x108d68ffb +org.qt-project.QtPrintSupport (5.13 - 5.13.1) <419EB6E8-E917-3D57-B067-143101AE58D5> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
       0x109a00000 -        0x109b5ffff +libqcocoa.dylib (0) <345EC8D4-53B3-391C-BFD3-5ABE706107D8> /Users/USER/*/Dolphin.app/Contents/MacOS/platforms/libqcocoa.dylib
       0x10a5ac000 -        0x10a5af047  libobjc-trampolines.dylib (781.2) <CDB44285-147A-304A-8698-E6A5EE45BB3E> /usr/lib/libobjc-trampolines.dylib
       0x10a5bf000 -        0x10a64fcb7  dyld (733.8) <53DC4089-3912-367E-9C70-E9721ECC4A60> /usr/lib/dyld
       0x10c2c7000 -        0x10c2daff3  com.apple.iokit.IOHIDLib (2.0.0 - 2.0.0) <D81EB948-2E5D-39D7-9961-EDAB37D45049> /System/Library/Extensions/IOHIDFamily.kext/Contents/PlugIns/IOHIDLib.plugin/Contents/MacOS/IOHIDLib
       0x10d9f9000 -        0x10da1dfff +libqmacstyle.dylib (0) <52899D99-03F5-35FB-B10B-4B5E3AADF667> /Users/USER/*/Dolphin.app/Contents/MacOS/styles/libqmacstyle.dylib
       0x117c63000 -        0x117d2bfff  com.apple.AMDRadeonX4000GLDriver (3.5.1 - 3.0.5) <EF8D3F7E-E0EC-3609-A006-05419C5DCB42> /System/Library/Extensions/AMDRadeonX4000GLDriver.bundle/Contents/MacOS/AMDRadeonX4000GLDriver
    0x7fff205d2000 -     0x7fff206f2ff5  com.apple.AMDMTLBronzeDriver (3.5.1 - 3.0.5) <946307F2-008E-31ED-802E-1617C6A8F3A9> /System/Library/Extensions/AMDMTLBronzeDriver.bundle/Contents/MacOS/AMDMTLBronzeDriver
    0x7fff206f3000 -     0x7fff20729ff7  ATIRadeonX4000SCLib.dylib (3.5.1) <7BE8482B-C2DB-35F7-892D-6FB778DBCC72> /System/Library/Extensions/AMDRadeonX4000GLDriver.bundle/Contents/MacOS/ATIRadeonX4000SCLib.dylib
    0x7fff21d18000 -     0x7fff22996ff7  libSC.dylib (3.5.1) <804415D2-8365-3622-8CA7-B26AA4730E1D> /System/Library/Extensions/AMDShared.bundle/Contents/PlugIns/libSC.dylib
    0x7fff276fc000 -     0x7fff27700ffb  com.apple.agl (3.3.3 - AGL-3.3.3) <FDF13A53-6BFE-3857-837F-34F29CFDCBD1> /System/Library/Frameworks/AGL.framework/Versions/A/AGL
    0x7fff27b4a000 -     0x7fff27b4afff  com.apple.Accelerate (1.11 - Accelerate 1.11) <EEBE6680-1AAB-3192-AA7C-450537B07F27> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
    0x7fff27b4b000 -     0x7fff27b61fff  libCGInterfaces.dylib (524.2) <90EB259D-0EEE-30BA-829C-CD7EB0AA47F4> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/Libraries/libCGInterfaces.dylib
    0x7fff27b62000 -     0x7fff281cdfef  com.apple.vImage (8.1 - 524.2) <E1674B78-9F1C-3963-B5FB-446D5215E34B> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
    0x7fff281ce000 -     0x7fff28437fff  libBLAS.dylib (1303.60.1) <1FCB122D-6FC9-3E93-B750-D6081EE29EB0> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
    0x7fff28438000 -     0x7fff28727ff7  libBNNS.dylib (144.40.3) <3C512A9F-7F02-3E60-AFCD-DC1689D53856> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
    0x7fff28729000 -     0x7fff28acefff  libLAPACK.dylib (1303.60.1) <DCC36295-FF39-35A1-8DF1-1E8A714E2265> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
    0x7fff28acf000 -     0x7fff28ae4ff8  libLinearAlgebra.dylib (1303.60.1) <E1E40FFB-3E4E-3B75-97E0-9A8590C1AF6C> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
    0x7fff28ae5000 -     0x7fff28aeaff3  libQuadrature.dylib (7) <09CDAECD-9832-3B76-9D75-927C52B9FBAC> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
    0x7fff28aeb000 -     0x7fff28b5bfff  libSparse.dylib (103) <EADC594A-5BBD-3E9A-A6F5-301E88766833> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
    0x7fff28b5c000 -     0x7fff28b6efef  libSparseBLAS.dylib (1303.60.1) <26657CBC-A7E1-3A79-8F48-0AC04709DF24> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
    0x7fff28b6f000 -     0x7fff28d48ffb  libvDSP.dylib (735.40.1) <BD49856D-39CE-397F-A069-63B2F0D79529> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
    0x7fff28d49000 -     0x7fff28e04fd7  libvMisc.dylib (735.40.1) <FDD3C940-7057-3C6B-B5E2-AC822FD82528> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
    0x7fff28e05000 -     0x7fff28e05fff  com.apple.Accelerate.vecLib (3.11 - vecLib 3.11) <A8B35A80-7217-38B1-8A20-E8B4F73124F0> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
    0x7fff28e06000 -     0x7fff28e65ffc  com.apple.Accounts (113 - 113) <265C6D52-9EC6-34BE-AB24-606772BDF294> /System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
    0x7fff28fab000 -     0x7fff29d66fff  com.apple.AppKit (6.9 - 1894.20.140) <283A018C-D35D-366D-8E14-EF6A05ED6636> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
    0x7fff29db6000 -     0x7fff29db6fff  com.apple.ApplicationServices (48 - 50) <F72D49D1-CD91-362D-B79D-762BE9B6939C> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
    0x7fff29db7000 -     0x7fff29e22fff  com.apple.ApplicationServices.ATS (377 - 493.0.2.1) <EE49694B-9DBB-3EF6-BFF0-E3C2837803AA> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
    0x7fff29ebb000 -     0x7fff29ef9ff8  libFontRegistry.dylib (274.0.2.3) <BBF7C42A-2B1D-3CEC-ABD9-514A52D8FC29> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
    0x7fff29f54000 -     0x7fff29f83ff7  com.apple.ATSUI (1.0 - 1) <D84AA8ED-CAEF-3F64-9601-14537547DBE3> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATSUI.framework/Versions/A/ATSUI
    0x7fff29f84000 -     0x7fff29f88ff3  com.apple.ColorSyncLegacy (4.13.0 - 1) <BD3BF303-CF2C-3CC1-91E1-F05EBC9D58ED> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
    0x7fff2a023000 -     0x7fff2a079ff2  com.apple.HIServices (1.22 - 674.1) <9F970202-2423-36B6-AA9B-2C9A9988446C> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
    0x7fff2a07a000 -     0x7fff2a088fff  com.apple.LangAnalysis (1.7.0 - 1.7.0) <97FFB29E-94CD-3058-B6E6-81532645FAD3> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
    0x7fff2a089000 -     0x7fff2a0ceff2  com.apple.print.framework.PrintCore (15 - 516) <0AE0DF29-5807-35D3-9807-2FF3DCCCA683> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
    0x7fff2a0cf000 -     0x7fff2a0d9fff  com.apple.QD (4.0 - 413) <D8C67B36-3ED7-33A1-A565-D8417230A81F> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
    0x7fff2a0da000 -     0x7fff2a0e7ff0  com.apple.speech.synthesis.framework (9.0.24 - 9.0.24) <9F79D1B6-51BD-3409-8B80-F0D5EDBDDE83> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
    0x7fff2a0e8000 -     0x7fff2a1b5ffa  com.apple.audio.toolbox.AudioToolbox (1.14 - 1.14) <9AFAE780-C286-39B3-B5FB-A2AD221A3A0E> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
    0x7fff2a1b7000 -     0x7fff2a1b7fff  com.apple.audio.units.AudioUnit (1.14 - 1.14) <22A443ED-28B0-3161-9CF6-890FD03275D3> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
    0x7fff2a52d000 -     0x7fff2a8b9ff6  com.apple.CFNetwork (1121.1.2 - 1121.1.2) <DD6C93C3-3FF7-3F38-833D-63A01EC1C8D4> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
    0x7fff2a933000 -     0x7fff2a933fff  com.apple.Carbon (160 - 162) <939603EB-C340-34E1-95EA-83A9F210A2C2> /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
    0x7fff2a934000 -     0x7fff2a937ffb  com.apple.CommonPanels (1.2.6 - 101) <DB282141-674C-3F67-98F8-0C1A0CA66F39> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
    0x7fff2a938000 -     0x7fff2ac2cffb  com.apple.HIToolbox (2.1.1 - 994) <0E588DC9-36CD-36AB-A2D3-204381FB7065> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
    0x7fff2ac2d000 -     0x7fff2ac30ff3  com.apple.help (1.3.8 - 68) <7B9FB204-D822-3931-8563-CFBBEBC95E0C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
    0x7fff2ac31000 -     0x7fff2ac36ff7  com.apple.ImageCapture (9.0 - 1600.27) <6F329896-5B97-3D13-BA9C-0E762870C875> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
    0x7fff2ac37000 -     0x7fff2ac37fff  com.apple.ink.framework (10.15 - 227) <3FBCC0F7-B9BC-3841-94EB-08509DAD811C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
    0x7fff2ac38000 -     0x7fff2ac52ff2  com.apple.openscripting (1.7 - 185.1) <9E755875-EB45-33E0-899A-6251861A3610> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
    0x7fff2ac73000 -     0x7fff2ac73fff  com.apple.print.framework.Print (15 - 271) <7A477F2C-BB3E-3CCB-9352-920948AD26C0> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
    0x7fff2ac74000 -     0x7fff2ac76ff7  com.apple.securityhi (9.0 - 55008) <70A136DB-CFEF-3145-BAC2-1832D7AF4A29> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
    0x7fff2ac77000 -     0x7fff2ac7dff7  com.apple.speech.recognition.framework (6.0.3 - 6.0.3) <F3944B0A-1A81-3BE3-89EC-A2DFDBC8886C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
    0x7fff2ae18000 -     0x7fff2ae18fff  com.apple.Cocoa (6.11 - 23) <8679A53F-D9D6-3EEF-846A-FEE20791B940> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
    0x7fff2ae26000 -     0x7fff2b011ff7  com.apple.ColorSync (4.13.0 - 3394.3) <4D3CDFB9-8309-3F22-B453-63308A245888> /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
    0x7fff2b301000 -     0x7fff2b810ffa  com.apple.audio.CoreAudio (5.0 - 5.0) <1721C8CC-31FC-317B-97AC-C77F7AACA764> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
    0x7fff2b863000 -     0x7fff2b89aff0  com.apple.CoreBluetooth (1.0 - 1) <2D1FAB07-825E-3B1D-BE90-0EEFF8110701> /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
    0x7fff2b89b000 -     0x7fff2bc7dffe  com.apple.CoreData (120 - 977.1) <AD121806-6F55-3217-8056-80C6877C2EB6> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
    0x7fff2bc7e000 -     0x7fff2bd8eff6  com.apple.CoreDisplay (1.0 - 186.3.9) <25785224-FDA2-3583-96F9-FBF1E1A1855D> /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
    0x7fff2bd8f000 -     0x7fff2c20ffe7  com.apple.CoreFoundation (6.9 - 1674.114) <8BE15BD5-FAF2-3419-B80C-2C7425FDDDC6> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7fff2c211000 -     0x7fff2c88aff0  com.apple.CoreGraphics (2.0 - 1348.16) <9330B549-787E-3B43-80E5-D8F3FDB3E700> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
    0x7fff2c898000 -     0x7fff2cbf5ff5  com.apple.CoreImage (15.0.0 - 920.9) <59E381BD-A4C6-3FB9-A58A-773C14829220> /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
    0x7fff2cfb9000 -     0x7fff2d129ff4  com.apple.CoreMedia (1.0 - 2530.3) <C16BA330-2F70-3B47-A61D-33D315FDB117> /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
    0x7fff2d215000 -     0x7fff2d215fff  com.apple.CoreServices (1069.11 - 1069.11) <331A6E28-FDA7-3791-90BD-186B0E7A177C> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
    0x7fff2d216000 -     0x7fff2d29bfff  com.apple.AE (838 - 838) <F2349762-D21C-3ACA-9DD9-33E4ED3E4EC8> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
    0x7fff2d29c000 -     0x7fff2d57dff7  com.apple.CoreServices.CarbonCore (1217 - 1217) <D1DB5175-A92D-309F-998B-4A1B7C6CA9C1> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
    0x7fff2d57e000 -     0x7fff2d5cbffd  com.apple.DictionaryServices (1.2 - 323.3) <07571F1A-54AE-3361-BFA7-08BB9B7F8F7B> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
    0x7fff2d5cc000 -     0x7fff2d5d4fff  com.apple.CoreServices.FSEvents (1268.60.1 - 1268.60.1) <FCAAB1DF-9F4B-3DAC-AF07-05028691B2A6> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
    0x7fff2d5d5000 -     0x7fff2d80eff0  com.apple.LaunchServices (1069.11 - 1069.11) <321B6187-2FA2-345F-8B38-5EFB2DB1BB88> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
    0x7fff2d80f000 -     0x7fff2d8a7ff9  com.apple.Metadata (10.7.0 - 2075.6) <DECF9AC0-F633-30D1-8171-AD4D81FDD925> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
    0x7fff2d8a8000 -     0x7fff2d8d5ff7  com.apple.CoreServices.OSServices (1069.11 - 1069.11) <BF07F11F-A948-3EC5-ADFB-196522275B32> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
    0x7fff2d8d6000 -     0x7fff2d93dfff  com.apple.SearchKit (1.4.1 - 1.4.1) <A756912A-CC23-3C13-B7F6-CDE3898BFA0C> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
    0x7fff2d93e000 -     0x7fff2d962ff5  com.apple.coreservices.SharedFileList (131.3 - 131.3) <1648EAF4-0A94-3CE6-A26D-8F728E9B9FE6> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
    0x7fff2dc94000 -     0x7fff2de48ffe  com.apple.CoreText (643.1.2.3 - 643.1.2.3) <CF484DDE-C0B5-36B9-8A74-84C7142B8867> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
    0x7fff2de49000 -     0x7fff2de8dfff  com.apple.CoreVideo (1.8 - 334.0) <85729B1D-2A69-3B38-A50A-63F535F687DC> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
    0x7fff2de8e000 -     0x7fff2df1bff9  com.apple.framework.CoreWLAN (13.0 - 1455.3) <CEADF97E-03C2-30BE-864B-B8782B63915A> /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
    0x7fff2e1bb000 -     0x7fff2e1c1fff  com.apple.DiskArbitration (2.7 - 2.7) <FEBCAF40-A339-3A89-AB31-4FC82C8EEC6C> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
    0x7fff2e3b5000 -     0x7fff2e4dbff6  com.apple.FileProvider (265.1 - 265.1) <A557EA5B-3349-3B99-B39C-170D711E69D4> /System/Library/Frameworks/FileProvider.framework/Versions/A/FileProvider
    0x7fff2e4f0000 -     0x7fff2e4f2ff3  com.apple.ForceFeedback (1.0.6 - 1.0.6) <5BB37F22-8A0B-38E6-98C9-91628AAB94FD> /System/Library/Frameworks/ForceFeedback.framework/Versions/A/ForceFeedback
    0x7fff2e4f3000 -     0x7fff2e8bbffc  com.apple.Foundation (6.9 - 1674.114) <72780AD6-F601-353A-A1C9-C9CE680CCBE5> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
    0x7fff2e928000 -     0x7fff2e978ff7  com.apple.GSS (4.0 - 2.0) <7A96B860-FE9E-33D7-B8B6-EA05B020D40E> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
    0x7fff2eab3000 -     0x7fff2ebcbff8  com.apple.Bluetooth (7.0.2 - 7.0.2f5) <5DA09892-31D5-3DA8-A01F-EB8094F884FF> /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
    0x7fff2ec32000 -     0x7fff2ecd5ffb  com.apple.framework.IOKit (2.0.2 - 1726.80.1) <52FD85B9-C482-3731-A83A-3E72BA4872AE> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
    0x7fff2ecd7000 -     0x7fff2ece7ffc  com.apple.IOSurface (269.6 - 269.6) <C043DD85-CCA0-3D1D-B69B-0DFA57BD9700> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
    0x7fff2ed5d000 -     0x7fff2eebafee  com.apple.ImageIO.framework (3.3.0 - 1972.17) <71DE8FCC-D24D-3B2B-8439-05CF7175D20C> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
    0x7fff2eebb000 -     0x7fff2eebefff  libGIF.dylib (1972.17) <0D1C7BFA-DC3C-3711-AB20-4A62500F90BD> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
    0x7fff2eebf000 -     0x7fff2ef79fe7  libJP2.dylib (1972.17) <D3AA84D6-C435-3A7E-A07A-1C96DA204433> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
    0x7fff2ef7a000 -     0x7fff2ef9efef  libJPEG.dylib (1972.17) <EA38DD91-EE5D-3FD5-8CC5-47CA1B0781BB> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
    0x7fff2f21c000 -     0x7fff2f236fef  libPng.dylib (1972.17) <72986071-2D02-3767-8057-16E23B7CFBBA> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
    0x7fff2f237000 -     0x7fff2f238fff  libRadiance.dylib (1972.17) <C4D68B5A-DAF7-3280-9AF8-209F24364360> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
    0x7fff2f239000 -     0x7fff2f282feb  libTIFF.dylib (1972.17) <D1C99932-37DE-3C9B-BB28-ADC255705CB3> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
    0x7fff306a7000 -     0x7fff306b9ff3  com.apple.Kerberos (3.0 - 1) <EC1AFDD1-ADE9-3311-934E-93926031D11D> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
    0x7fff306ba000 -     0x7fff306bafff  libHeimdalProxy.dylib (77) <CB20F0B8-EDC1-3592-8B2D-6AEF80BE080B> /System/Library/Frameworks/Kerberos.framework/Versions/A/Libraries/libHeimdalProxy.dylib
    0x7fff306bb000 -     0x7fff306f1fff  com.apple.LDAPFramework (2.4.28 - 194.5) <7A4B4877-E9F1-34ED-AAED-4EF1CA2606B8> /System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
    0x7fff30a4d000 -     0x7fff30a57ff3  com.apple.MediaAccessibility (1.0 - 125) <04725517-EB68-3218-BEB4-6090E0B9CFF8> /System/Library/Frameworks/MediaAccessibility.framework/Versions/A/MediaAccessibility
    0x7fff30b23000 -     0x7fff315f0ffb  com.apple.MediaToolbox (1.0 - 2530.3) <A4F5E9D1-39E5-3184-957A-1FA5A8AD7207> /System/Library/Frameworks/MediaToolbox.framework/Versions/A/MediaToolbox
    0x7fff315f2000 -     0x7fff316b5ff1  com.apple.Metal (212.2.4 - 212.2.4) <E032AA9B-9ED9-39F7-8BB3-535CA297B9B2> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
    0x7fff316d2000 -     0x7fff3170eff3  com.apple.MetalPerformanceShaders.MPSCore (1.0 - 1) <52A43529-85E1-365B-9A93-851E663B1DC3> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSCore.framework/Versions/A/MPSCore
    0x7fff3170f000 -     0x7fff31795fe6  com.apple.MetalPerformanceShaders.MPSImage (1.0 - 1) <92E69F78-2F84-32A2-863D-FD4DF9343081> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSImage.framework/Versions/A/MPSImage
    0x7fff31796000 -     0x7fff317baff8  com.apple.MetalPerformanceShaders.MPSMatrix (1.0 - 1) <C1B2EDBB-BD2D-3736-A5CB-E09DE6733697> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
    0x7fff317bb000 -     0x7fff317d0fff  com.apple.MetalPerformanceShaders.MPSNDArray (1.0 - 1) <CA397A37-F622-3DE9-A650-C95FF4F1AE29> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNDArray.framework/Versions/A/MPSNDArray
    0x7fff317d1000 -     0x7fff31930ff4  com.apple.MetalPerformanceShaders.MPSNeuralNetwork (1.0 - 1) <FCC21518-5708-34DB-AB4E-F5CD1F07972E> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
    0x7fff31931000 -     0x7fff3197ffff  com.apple.MetalPerformanceShaders.MPSRayIntersector (1.0 - 1) <98B296B7-AF73-3621-AD7E-BAF2569DB0EA> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
    0x7fff31980000 -     0x7fff31981ff5  com.apple.MetalPerformanceShaders.MetalPerformanceShaders (1.0 - 1) <E0F09A3D-A25A-33C6-95EE-211C2A9446F1> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
    0x7fff328c7000 -     0x7fff328d3ffe  com.apple.NetFS (6.0 - 4.0) <02E8E40E-ED8E-32A0-839C-BF05F6152629> /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
    0x7fff328d4000 -     0x7fff32a17ff6  com.apple.Network (1.0 - 1) <01CDE553-02C3-3EE3-932F-DBF4A8E64411> /System/Library/Frameworks/Network.framework/Versions/A/Network
    0x7fff35437000 -     0x7fff3543ffff  libcldcpuengine.dylib (2.12.7) <B41C465E-91BE-34B2-8D43-F9822E70ABA2> /System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
    0x7fff35440000 -     0x7fff35498ff7  com.apple.opencl (3.5 - 3.5) <628CB162-98C9-3836-8D34-398B1446DE5A> /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
    0x7fff35499000 -     0x7fff354b5fff  com.apple.CFOpenDirectory (10.15 - 220.40.1) <ACFBDD47-A29E-3E4E-A556-49EE9B6A8F30> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
    0x7fff354b6000 -     0x7fff354c1ff7  com.apple.OpenDirectory (10.15 - 220.40.1) <4B3723D2-F79C-3A63-A364-E5582DA5FE7D> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
    0x7fff35e1c000 -     0x7fff35e1efff  libCVMSPluginSupport.dylib (17.10.22) <E0715E79-411B-3442-9520-9527B3012CBB> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
    0x7fff35e1f000 -     0x7fff35e24fff  libCoreFSCache.dylib (176.10) <5C5720A6-B2A2-3983-8631-B5B74EC77201> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
    0x7fff35e25000 -     0x7fff35e29fff  libCoreVMClient.dylib (176.10) <C0FBCD1D-E8CC-3B1B-B542-30014C3B7007> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
    0x7fff35e2a000 -     0x7fff35e32ff7  libGFXShared.dylib (17.10.22) <DC81AEEA-C142-325D-BEA5-32B57FF97290> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
    0x7fff35e33000 -     0x7fff35e3dfff  libGL.dylib (17.10.22) <74B11657-CF86-3DE6-BB65-DFF41207E6DD> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
    0x7fff35e3e000 -     0x7fff35e73fff  libGLImage.dylib (17.10.22) <48240CAD-E1E7-39C1-B9EE-8ECAF4AC0AD8> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
    0x7fff35e74000 -     0x7fff36006ff7  libGLProgrammability.dylib (17.10.22) <BF2933DD-B16F-3EB5-9953-C9F1585BB0EA> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
    0x7fff36007000 -     0x7fff36043fff  libGLU.dylib (17.10.22) <C6903450-8CE0-3B74-A0A5-9B5A11ED408D> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
    0x7fff36a73000 -     0x7fff36a82ff7  com.apple.opengl (17.10.22 - 17.10.22) <FD797605-A94F-32FE-860E-D64A9DAE2206> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
    0x7fff36a83000 -     0x7fff36bfcff7  GLEngine (17.10.22) <68F2CF34-F5AA-3CF5-814F-F9FB12D7AE37> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
    0x7fff36bfd000 -     0x7fff36c25fff  GLRendererFloat (17.10.22) <7188203A-C498-3749-B8F1-48C984C02024> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
    0x7fff37a3d000 -     0x7fff37cbcff1  com.apple.QuartzCore (1.11 - 820.2) <34085113-44A8-3003-9A60-9E827355CBC2> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
    0x7fff3880c000 -     0x7fff38b5effa  com.apple.security (7.0 - 59306.61.1) <FFC1561F-C381-3FC3-9C11-A1B143EF011E> /System/Library/Frameworks/Security.framework/Versions/A/Security
    0x7fff38b5f000 -     0x7fff38be8ff7  com.apple.securityfoundation (6.0 - 55236.60.1) <C4E84DE2-89EE-34BF-928B-30B33A8CB9FA> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
    0x7fff38c17000 -     0x7fff38c1bff0  com.apple.xpc.ServiceManagement (1.0 - 1) <45D8B425-BB35-3773-8330-E28340408C3A> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
    0x7fff399ac000 -     0x7fff39a16fff  com.apple.SystemConfiguration (1.19 - 1.19) <3AB8F246-08D3-3A1A-91C9-1B90A1928700> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
    0x7fff39c92000 -     0x7fff3a039ff4  com.apple.VideoToolbox (1.0 - 2530.3) <B5AD8874-0046-3000-89AD-C983787D600D> /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
    0x7fff3d7ce000 -     0x7fff3d892fe7  com.apple.APFS (1412.80.1 - 1412.80.1) <081A62D9-8177-31CC-99CD-F5721737810C> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
    0x7fff3e991000 -     0x7fff3e992ff1  com.apple.AggregateDictionary (1.0 - 1) <7CB0CE87-538B-33E4-86AD-72E497ECE624> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
    0x7fff3eea2000 -     0x7fff3eebfffc  com.apple.AppContainer (4.0 - 448.60.2) <B04AFD76-4F73-3531-84A5-BE3766769667> /System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
    0x7fff3ef14000 -     0x7fff3ef22ff7  com.apple.AppSandbox (4.0 - 448.60.2) <F1965C41-AB9B-326B-9559-272432DC72CE> /System/Library/PrivateFrameworks/AppSandbox.framework/Versions/A/AppSandbox
    0x7fff3f3b1000 -     0x7fff3f3d5ff3  com.apple.framework.Apple80211 (13.0 - 1460.1) <28E28667-6E9F-3B4E-8454-2182F28C9C88> /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
    0x7fff3f50b000 -     0x7fff3f51afef  com.apple.AppleFSCompression (119 - 1.0) <06745DE6-5C79-398F-BCFB-8CCA270F6DF8> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
    0x7fff3f619000 -     0x7fff3f624ff7  com.apple.AppleIDAuthSupport (1.0 - 1) <C686D75D-F13D-37C5-86C6-5164C89174DD> /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
    0x7fff3f666000 -     0x7fff3f6aefff  com.apple.AppleJPEG (1.0 - 1) <E6C9AF3D-D959-34A4-8A65-695A4694DA49> /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
    0x7fff3fa89000 -     0x7fff3fa8dff7  com.apple.AppleSRP (5.0 - 1) <3A938B5E-7FF2-3BD5-98C2-CF4AC47B08C4> /System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
    0x7fff3fa8e000 -     0x7fff3fab0fff  com.apple.applesauce (1.0 - 16.22) <3873AE4F-6910-3555-8DF9-5334D62396F1> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
    0x7fff3fb70000 -     0x7fff3fb73ffb  com.apple.AppleSystemInfo (3.1.5 - 3.1.5) <48612FF0-3775-3BBD-BBFD-31A5035DB978> /System/Library/PrivateFrameworks/AppleSystemInfo.framework/Versions/A/AppleSystemInfo
    0x7fff3fb74000 -     0x7fff3fbc4ff7  com.apple.AppleVAFramework (6.1.2 - 6.1.2) <6E61686C-1E11-3534-866B-B110A4A8609E> /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
    0x7fff3fc0d000 -     0x7fff3fc1cff9  com.apple.AssertionServices (1.0 - 223.60.4) <3ECAF762-F1BA-3E26-8EF9-09BDAECB8484> /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
    0x7fff4015b000 -     0x7fff40559ff4  com.apple.audio.AudioResourceArbitration (1.0 - 1) <7AF3746F-76BE-3472-9150-7EB352EC4ACB> /System/Library/PrivateFrameworks/AudioResourceArbitration.framework/Versions/A/AudioResourceArbitration
    0x7fff407b0000 -     0x7fff409e6ff7  com.apple.audio.AudioToolboxCore (1.0 - 1104.30) <F33BEC81-9182-3C55-A011-2D20990DD6D4> /System/Library/PrivateFrameworks/AudioToolboxCore.framework/Versions/A/AudioToolboxCore
    0x7fff409e7000 -     0x7fff40b00ff4  com.apple.AuthKit (1.0 - 1) <6DC685EF-6CC0-3E72-98CF-43ED5AE1EC42> /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
    0x7fff40cbb000 -     0x7fff40cc4ff3  com.apple.coreservices.BackgroundTaskManagement (1.0 - 104) <78A511E6-BB5C-35CC-B925-3AF06B655258> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
    0x7fff40cc5000 -     0x7fff40d66ff8  com.apple.backup.framework (1.11.2 - 1298.2.10) <3B4BB49B-5CAD-3EF8-8882-70167C051A1B> /System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
    0x7fff40d67000 -     0x7fff40de8ffd  com.apple.BaseBoard (464.1 - 464.1) <9FABACF0-427C-3985-BF93-E4F669C11AC2> /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
    0x7fff40eea000 -     0x7fff40f26fff  com.apple.bom (14.0 - 219.2) <3392CB7A-99A5-3132-9945-4C2E772B8D20> /System/Library/PrivateFrameworks/Bom.framework/Versions/A/Bom
    0x7fff41aac000 -     0x7fff41afbfff  com.apple.ChunkingLibrary (302 - 302) <F432D506-0E34-3A0D-A0F2-735005F4A031> /System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
    0x7fff429bb000 -     0x7fff429ccfff  com.apple.CommonAuth (4.0 - 2.0) <B7D5A0B6-C320-3E3B-B109-2477EC49C293> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
    0x7fff429e0000 -     0x7fff429f7fff  com.apple.commonutilities (8.0 - 900) <5512F29D-93B0-3EEC-904B-C7B3EA04BE40> /System/Library/PrivateFrameworks/CommonUtilities.framework/Versions/A/CommonUtilities
    0x7fff430ee000 -     0x7fff434c3fc8  com.apple.CoreAUC (283.0.0 - 283.0.0) <5533E153-943E-38EA-B004-7BB57F264610> /System/Library/PrivateFrameworks/CoreAUC.framework/Versions/A/CoreAUC
    0x7fff434c4000 -     0x7fff434f2ffb  com.apple.CoreAVCHD (6.1.0 - 6100.4.1) <450FB0F0-B665-3C4C-A017-EB23DF9D25C3> /System/Library/PrivateFrameworks/CoreAVCHD.framework/Versions/A/CoreAVCHD
    0x7fff43515000 -     0x7fff43534ff0  com.apple.analyticsd (1.0 - 1) <A3ABE405-B830-3A3D-9F54-BECE011C9BD3> /System/Library/PrivateFrameworks/CoreAnalytics.framework/Versions/A/CoreAnalytics
    0x7fff437ff000 -     0x7fff4380aff7  com.apple.frameworks.CoreDaemon (1.3 - 1.3) <70BF0B3C-F6A6-32B0-AFCC-965D54110777> /System/Library/PrivateFrameworks/CoreDaemon.framework/Versions/B/CoreDaemon
    0x7fff43a8b000 -     0x7fff43a9bff3  com.apple.CoreEmoji (1.0 - 107) <FE70B537-EA7E-3FE6-ADDB-1A8385C99566> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
    0x7fff440ef000 -     0x7fff44159ff0  com.apple.CoreNLP (1.0 - 213) <FC141D6D-EFE4-3FBF-9DA2-577DD2D730E3> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
    0x7fff445cb000 -     0x7fff445d3ff0  com.apple.CorePhoneNumbers (1.0 - 1) <9A7F1261-9AE2-362B-B2CD-F608A0B44845> /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
    0x7fff44d20000 -     0x7fff44d43ff7  com.apple.CoreSVG (1.0 - 129) <C3C50FB0-0063-32F8-B715-60C131EC0F7D> /System/Library/PrivateFrameworks/CoreSVG.framework/Versions/A/CoreSVG
    0x7fff44d44000 -     0x7fff44d77ff7  com.apple.CoreServicesInternal (446.6 - 446.6) <72D80F4F-3B99-359F-97C3-84AC32DB1D00> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
    0x7fff44d78000 -     0x7fff44da6ff7  com.apple.CSStore (1069.11 - 1069.11) <6783BB89-92A1-3B56-8BBA-DC26D6595AAA> /System/Library/PrivateFrameworks/CoreServicesStore.framework/Versions/A/CoreServicesStore
    0x7fff452a9000 -     0x7fff45330fff  com.apple.CoreSymbolication (11.0 - 64509.98.1) <18FA25B4-4217-32BB-A8D4-DE97B4DC1406> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
    0x7fff453c8000 -     0x7fff454f4ff4  com.apple.coreui (2.1 - 608.3) <17D26A62-83F4-39E7-B24D-ADC085C3A86B> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
    0x7fff454f5000 -     0x7fff45690ff6  com.apple.CoreUtils (6.1 - 610.19) <1FE7790A-EF43-3667-B65D-04C09CA7C716> /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
    0x7fff457c5000 -     0x7fff457d8ff1  com.apple.CrashReporterSupport (10.13 - 15011) <514FE3C8-06A9-3726-8767-56A432250F0C> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
    0x7fff45a42000 -     0x7fff45a54ffc  com.apple.framework.DFRFoundation (1.0 - 252) <9EE70E63-2E6F-393C-803D-FE46573B06A9> /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
    0x7fff45a55000 -     0x7fff45a5afff  com.apple.DSExternalDisplay (3.1 - 380) <32542382-4705-306A-9D26-6D328A6C1085> /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
    0x7fff45ac3000 -     0x7fff45b3eff8  com.apple.datadetectorscore (8.0 - 659) <023ACB83-76D9-38DE-B1A0-F0B22E50AB82> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
    0x7fff45b8a000 -     0x7fff45bc8ff0  com.apple.DebugSymbols (194 - 194) <48B26454-58BC-3E52-807A-5F92A56DC0BD> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
    0x7fff45bc9000 -     0x7fff45d25ffe  com.apple.desktopservices (1.14.2 - 1281.2.6) <988E169C-6ED0-369A-84E8-2D3C53887387> /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
    0x7fff47566000 -     0x7fff47981ff9  com.apple.vision.FaceCore (4.3.0 - 4.3.0) <60110768-AF18-3A6C-8342-52F70B0EDC1F> /System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
    0x7fff47fe5000 -     0x7fff4811cffc  libFontParser.dylib (277.2.1.2) <1FED61E5-5373-3BDB-8689-95133DA7C7C1> /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
    0x7fff4811d000 -     0x7fff48151fff  libTrueTypeScaler.dylib (277.2.1.2) <76241244-D269-38CB-95DD-00295E4F0E73> /System/Library/PrivateFrameworks/FontServices.framework/libTrueTypeScaler.dylib
    0x7fff481b6000 -     0x7fff481c6ff6  libhvf.dylib (1.0 - $[CURRENT_PROJECT_VERSION]) <324D7792-6BE0-3FC8-86C7-1F47CD835B3D> /System/Library/PrivateFrameworks/FontServices.framework/libhvf.dylib
    0x7fff4b68b000 -     0x7fff4b68cfff  libmetal_timestamp.dylib (902.11.1) <5FFE4453-C35A-3F88-ADEA-8DDAF616E5C1> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/3902/Libraries/libmetal_timestamp.dylib
    0x7fff4cd27000 -     0x7fff4cd32ff7  libGPUSupportMercury.dylib (17.10.22) <F2060EB1-948A-3FA8-96CA-4BD88B0723E0> /System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
    0x7fff4cd33000 -     0x7fff4cd39fff  com.apple.GPUWrangler (4.5.21 - 4.5.21) <448A1EA8-B3E0-3F39-986A-088147FD78F9> /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
    0x7fff4d057000 -     0x7fff4d07dffb  com.apple.GenerationalStorage (2.0 - 313) <2A24B800-9696-301B-AB00-85F070EE0ABE> /System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
    0x7fff4e1a1000 -     0x7fff4e1afffb  com.apple.GraphVisualizer (1.0 - 100.1) <5E564186-43A8-36FB-98E1-D8E0E87B7B4E> /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
    0x7fff4e341000 -     0x7fff4e3feff4  com.apple.Heimdal (4.0 - 2.0) <138A27BD-9C9E-3C47-837B-036F88B61D96> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
    0x7fff50533000 -     0x7fff5053cffe  com.apple.IOAccelMemoryInfo (1.0 - 1) <A6C7F7F0-4DA1-3F9C-A5C7-AE4D919D955C> /System/Library/PrivateFrameworks/IOAccelMemoryInfo.framework/Versions/A/IOAccelMemoryInfo
    0x7fff5053d000 -     0x7fff50545ffd  com.apple.IOAccelerator (438.2.8 - 438.2.8) <A6D474C9-D742-3039-BAF5-AD6C59E2C288> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
    0x7fff50548000 -     0x7fff5055eff7  com.apple.IOPresentment (1.0 - 37) <F11B29DF-F02D-3895-BE95-0656C43458AD> /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
    0x7fff508e8000 -     0x7fff50933ff4  com.apple.IconServices (438.3 - 438.3) <4EF74900-E91B-389F-8953-00E2CD337C8C> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
    0x7fff50af1000 -     0x7fff50af7ffc  com.apple.InternationalSupport (1.0 - 45) <427FCCE3-EAD5-3BFE-8D34-C89BE3A04A78> /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
    0x7fff50d38000 -     0x7fff50d58ff6  com.apple.security.KeychainCircle.KeychainCircle (1.0 - 1) <5B2E374F-247B-38FD-B169-E0A7AEE5E5CE> /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
    0x7fff50eb0000 -     0x7fff50f7eff5  com.apple.LanguageModeling (1.0 - 215.1) <6A639816-14EE-3621-84E4-C2F30D094F29> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
    0x7fff50f7f000 -     0x7fff50fc7ff7  com.apple.Lexicon-framework (1.0 - 72) <FFE4A4F0-9A60-3EF4-AD48-20EDE74428C2> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
    0x7fff50fce000 -     0x7fff50fd2ff2  com.apple.LinguisticData (1.0 - 353.6) <01563C8E-ABE1-3FB0-A465-0E26FBFA6B35> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
    0x7fff5186d000 -     0x7fff51870fff  com.apple.Mangrove (1.0 - 25) <43AF3A46-4AB8-37AE-9846-E6B60E54932C> /System/Library/PrivateFrameworks/Mangrove.framework/Versions/A/Mangrove
    0x7fff51ad9000 -     0x7fff51b8dff0  com.apple.MediaExperience (1.0 - 1) <6F71DA9B-E8CD-3CC1-A2CE-8824FDAC94B2> /System/Library/PrivateFrameworks/MediaExperience.framework/Versions/A/MediaExperience
    0x7fff52357000 -     0x7fff523a3fff  com.apple.spotlight.metadata.utilities (1.0 - 2075.6) <46AD9D44-675B-368B-809C-0F282871EFC3> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
    0x7fff523a4000 -     0x7fff52472ffd  com.apple.gpusw.MetalTools (1.0 - 1) <AE5444B4-0B73-30BF-9A88-C4FD76B3CCD3> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
    0x7fff526a2000 -     0x7fff526c0ff7  com.apple.MobileKeyBag (2.0 - 1.0) <C052DE34-86EF-3016-8345-D0C22A0E0E08> /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
    0x7fff52927000 -     0x7fff52957fff  com.apple.MultitouchSupport.framework (3430.1 - 3430.1) <85F77349-EA41-39F0-BB90-E0062CEFFA41> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
    0x7fff52e54000 -     0x7fff52e5efff  com.apple.NetAuth (6.2 - 6.2) <12EAFDA8-DC7C-337B-BBDB-7EAFD5AAD25D> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
    0x7fff5384f000 -     0x7fff5389bff7  com.apple.OTSVG (1.0 - 643.1.2.3) <5FDB2233-39F6-3A05-A823-0903F4AA7CF3> /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
    0x7fff54a31000 -     0x7fff54a3cffe  com.apple.PerformanceAnalysis (1.243.1 - 243.1) <1A1434AE-1A83-3ADD-8FE4-470A72FB3C96> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
    0x7fff54a3d000 -     0x7fff54a65ffb  com.apple.persistentconnection (1.0 - 1.0) <96550B23-39DC-3979-8D83-D3375E5327ED> /System/Library/PrivateFrameworks/PersistentConnection.framework/Versions/A/PersistentConnection
    0x7fff573c0000 -     0x7fff573d9fff  com.apple.ProtocolBuffer (1 - 274.20.7.15.1) <F10E05AA-88EB-3FA1-AA79-A5032E9B5EF8> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
    0x7fff577e2000 -     0x7fff5780bff9  com.apple.RemoteViewServices (2.0 - 148) <4DC357D6-4CBB-39CE-92A3-60DDE376774E> /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
    0x7fff57971000 -     0x7fff579acff4  com.apple.RunningBoardServices (1.0 - 223.60.4) <5EE4AB2B-B57D-38F2-A1E7-D5E6B2CFDD2C> /System/Library/PrivateFrameworks/RunningBoardServices.framework/Versions/A/RunningBoardServices
    0x7fff592f4000 -     0x7fff592f7ff9  com.apple.SecCodeWrapper (4.0 - 448.60.2) <32112D4B-FC08-314C-8301-9DA3C38C7B96> /System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
    0x7fff5946a000 -     0x7fff5958eff4  com.apple.Sharing (1506.6 - 1506.6) <E1983712-B65E-31D7-9132-EA65D532628D> /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
    0x7fff5a5a6000 -     0x7fff5a89effa  com.apple.SkyLight (1.600.0 - 450.1) <95192F00-C637-3B7E-BAF6-5105E0986F39> /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
    0x7fff5b0e6000 -     0x7fff5b0f4fff  com.apple.SpeechRecognitionCore (6.0.91 - 6.0.91) <B7EE92CE-EC7C-370D-BAC7-E535EE790C24> /System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
    0x7fff5b921000 -     0x7fff5b92aff7  com.apple.SymptomDiagnosticReporter (1.0 - 1238.60.1) <033BBEB6-2D37-3AE3-AB3A-A6CD55B2C09F> /System/Library/PrivateFrameworks/SymptomDiagnosticReporter.framework/Versions/A/SymptomDiagnosticReporter
    0x7fff5bbe0000 -     0x7fff5bbf0ff3  com.apple.TCC (1.0 - 1) <9CE00989-775D-3589-91EF-670CA501AF8A> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
    0x7fff5c0e5000 -     0x7fff5c1acff4  com.apple.TextureIO (3.10.9 - 3.10.9) <B3C12867-3DA6-36B3-82CF-DFE0610C0CE2> /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
    0x7fff5c328000 -     0x7fff5c329fff  com.apple.TrustEvaluationAgent (2.0 - 33) <46A7C8B1-C2FE-3500-8399-76ED4A48BA4F> /System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
    0x7fff5d002000 -     0x7fff5d25cff2  com.apple.UIFoundation (1.0 - 660) <4A6FF9CC-D3EF-36EE-B621-189A123503CC> /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
    0x7fff5de50000 -     0x7fff5de70fff  com.apple.UserManagement (1.0 - 1) <B7BC4D55-6DCB-331D-A6CD-E4F3E0C4F166> /System/Library/PrivateFrameworks/UserManagement.framework/Versions/A/UserManagement
    0x7fff5ec26000 -     0x7fff5ed10ffe  com.apple.ViewBridge (462 - 462) <AD1553E2-FD27-3008-ABD7-E88BC388DE66> /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
    0x7fff5eeb6000 -     0x7fff5eeb7fff  com.apple.WatchdogClient.framework (1.0 - 67.60.1) <63C179F1-F432-3666-A690-9B2B0316FE35> /System/Library/PrivateFrameworks/WatchdogClient.framework/Versions/A/WatchdogClient
    0x7fff5fa94000 -     0x7fff5fa97ffa  com.apple.dt.XCTTargetBootstrap (1.0 - 15700) <7D475E3B-B76F-30F0-95F1-008AAD1365BC> /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
    0x7fff5fb10000 -     0x7fff5fb1eff5  com.apple.audio.caulk (1.0 - 32.3) <42471A03-A388-376A-923E-E38AAACDC95E> /System/Library/PrivateFrameworks/caulk.framework/Versions/A/caulk
    0x7fff5fe5f000 -     0x7fff5fe61ff3  com.apple.loginsupport (1.0 - 1) <969341B2-06F0-3582-8430-471F1470C5A2> /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
    0x7fff5fe62000 -     0x7fff5fe75ffd  com.apple.login (3.0 - 3.0) <4D7ED0AF-867C-39A7-8D40-684CDDD4538C> /System/Library/PrivateFrameworks/login.framework/Versions/A/login
    0x7fff60183000 -     0x7fff601b9ffa  libAudioToolboxUtility.dylib (1104.30) <1AF0E0B2-D2DD-35C5-8984-11A2A720863D> /usr/lib/libAudioToolboxUtility.dylib
    0x7fff601c0000 -     0x7fff601f5ff7  libCRFSuite.dylib (48) <80F9320E-B18F-3E09-955E-5C1E56D29428> /usr/lib/libCRFSuite.dylib
    0x7fff601f8000 -     0x7fff60202ff3  libChineseTokenizer.dylib (34) <EF4D5593-20E5-34D7-ACBE-EBEA66E0F427> /usr/lib/libChineseTokenizer.dylib
    0x7fff6028f000 -     0x7fff60291ff7  libDiagnosticMessagesClient.dylib (112) <AFEB64B9-4439-3BFF-A521-ED5A939CD1E3> /usr/lib/libDiagnosticMessagesClient.dylib
    0x7fff602d6000 -     0x7fff6048dff3  libFosl_dynamic.dylib (100.4) <84A5F946-01EE-3740-BD2F-4C2A6B1FE82B> /usr/lib/libFosl_dynamic.dylib
    0x7fff604b4000 -     0x7fff604baff3  libIOReport.dylib (54) <B1B35705-BBF0-363D-A9F8-B80D9480B90F> /usr/lib/libIOReport.dylib
    0x7fff6059a000 -     0x7fff605a1fff  libMatch.1.dylib (36) <07F75921-1584-3723-BD0E-7AFE1AD36883> /usr/lib/libMatch.1.dylib
    0x7fff605d1000 -     0x7fff605f0fff  libMobileGestalt.dylib (826.80.1) <7F0DC9DE-BA4E-38C8-B93E-BBB6BA5B2949> /usr/lib/libMobileGestalt.dylib
    0x7fff60757000 -     0x7fff60758ff3  libSystem.B.dylib (1281) <D1FA14E5-71AE-3F55-B7F3-2C4030BF2D64> /usr/lib/libSystem.B.dylib
    0x7fff607e8000 -     0x7fff607e9fff  libThaiTokenizer.dylib (3) <C229130F-0BC2-3A4D-9792-25A726E9721A> /usr/lib/libThaiTokenizer.dylib
    0x7fff60801000 -     0x7fff60817fff  libapple_nghttp2.dylib (1.39.2) <64529A87-3D1D-331E-84EE-11303FE51E78> /usr/lib/libapple_nghttp2.dylib
    0x7fff6084c000 -     0x7fff608beff7  libarchive.2.dylib (72.40.2) <FB5BF2E0-2F4C-3EDF-A8FC-1DEF7EC95F31> /usr/lib/libarchive.2.dylib
    0x7fff608bf000 -     0x7fff60955fc5  libate.dylib (2.0.9) <D610C2C5-119A-35B6-BF62-4A6B0FB9BAD9> /usr/lib/libate.dylib
    0x7fff60959000 -     0x7fff60959ff3  libauto.dylib (187) <9AA72156-47CE-3150-836D-A71538F438FD> /usr/lib/libauto.dylib
    0x7fff60a20000 -     0x7fff60a30ff3  libbsm.0.dylib (60) <4BDE44B7-3BC3-31A6-901F-48B6ACFADA0A> /usr/lib/libbsm.0.dylib
    0x7fff60a31000 -     0x7fff60a3dfff  libbz2.1.0.dylib (44) <9A6BD380-46EF-3809-BA75-AF14FCAAA58E> /usr/lib/libbz2.1.0.dylib
    0x7fff60a3e000 -     0x7fff60a91ff7  libc++.1.dylib (800.7) <759F16C5-2D16-3ECD-AC46-1C7902607205> /usr/lib/libc++.1.dylib
    0x7fff60a92000 -     0x7fff60aa6fff  libc++abi.dylib (800.7) <BC59F72A-42F5-3F45-B15C-87324B9D556A> /usr/lib/libc++abi.dylib
    0x7fff60aa7000 -     0x7fff60aa7ffb  libcharset.1.dylib (59) <2ECDB43B-F6F7-30FE-83EB-B88FEA7D1616> /usr/lib/libcharset.1.dylib
    0x7fff60aa8000 -     0x7fff60ab9ffb  libcmph.dylib (8) <9B949AB0-3E0C-332F-BC23-C319E415A5EC> /usr/lib/libcmph.dylib
    0x7fff60aba000 -     0x7fff60ad1fe7  libcompression.dylib (87) <1C7E9A97-E841-3B71-8B09-BC72F6BA364A> /usr/lib/libcompression.dylib
    0x7fff60da1000 -     0x7fff60db7ff7  libcoretls.dylib (167) <A7BE4922-98AD-3923-8EBB-C3E5502B4D89> /usr/lib/libcoretls.dylib
    0x7fff60db8000 -     0x7fff60db9fff  libcoretls_cfhelpers.dylib (167) <13DBAF4C-FAC2-3834-940A-0FAC48C23A79> /usr/lib/libcoretls_cfhelpers.dylib
    0x7fff60f5c000 -     0x7fff61056fff  libcrypto.35.dylib (47.11.1) <8A1C9C0D-427B-3B7A-B17A-ECAC558B83B7> /usr/lib/libcrypto.35.dylib
    0x7fff6125d000 -     0x7fff61361fe7  libcrypto.44.dylib (47.11.1) <30DA518F-1B8D-39B3-AFC9-44FCFC979871> /usr/lib/libcrypto.44.dylib
    0x7fff61377000 -     0x7fff613d6fff  libcups.2.dylib (483.2) <553FAB5D-D429-3470-8139-88DE3C615D32> /usr/lib/libcups.2.dylib
    0x7fff613d8000 -     0x7fff6143ffff  libcurl.4.dylib (118) <B5803527-CB9E-38B4-8E0B-095354A36746> /usr/lib/libcurl.4.dylib
    0x7fff614e2000 -     0x7fff614e2fff  libenergytrace.dylib (21) <F4D773CE-5F2E-382C-AA3F-03AACE0D414B> /usr/lib/libenergytrace.dylib
    0x7fff614e3000 -     0x7fff614fcff7  libexpat.1.dylib (19.60.2) <E1CCCBF4-D28A-300F-A3F6-5754353DFA56> /usr/lib/libexpat.1.dylib
    0x7fff6150a000 -     0x7fff6150cfff  libfakelink.dylib (149) <686B9C02-D420-344F-BDAB-82CF2781E9B8> /usr/lib/libfakelink.dylib
    0x7fff6151b000 -     0x7fff61520fff  libgermantok.dylib (24) <9B25B6C2-0332-37A6-959F-621333901A7F> /usr/lib/libgermantok.dylib
    0x7fff61521000 -     0x7fff6152aff7  libheimdal-asn1.dylib (564.60.2) <AFF6F368-9E82-32D4-9BB8-F7F24D7B8DA3> /usr/lib/libheimdal-asn1.dylib
    0x7fff6152b000 -     0x7fff6161bff7  libiconv.2.dylib (59) <BA467D75-7A87-337A-BB8D-E864079B4D4D> /usr/lib/libiconv.2.dylib
    0x7fff6161c000 -     0x7fff61874ff7  libicucore.A.dylib (64252.0.1) <9997A41E-4489-37CF-B8CD-414C18CCD9A8> /usr/lib/libicucore.A.dylib
    0x7fff6188e000 -     0x7fff6188ffff  liblangid.dylib (133) <3A3D756D-285C-3AAF-BD93-9460F796838C> /usr/lib/liblangid.dylib
    0x7fff61890000 -     0x7fff618a8ff3  liblzma.5.dylib (16) <45ED5DEA-B892-3085-8E92-ADE65F4D020F> /usr/lib/liblzma.5.dylib
    0x7fff618c0000 -     0x7fff61967fff  libmecab.dylib (883.1.1) <1D19A5AE-4FF4-3F1C-AD1C-C470D1A72B34> /usr/lib/libmecab.dylib
    0x7fff61968000 -     0x7fff61bcafe1  libmecabra.dylib (883.1.1) <9F7FBBD3-66C0-39F7-8C24-7A37533C220E> /usr/lib/libmecabra.dylib
    0x7fff61f36000 -     0x7fff61f65ff7  libncurses.5.4.dylib (57) <5745F57B-1334-3397-B5D4-F4AF815E7AAE> /usr/lib/libncurses.5.4.dylib
    0x7fff62094000 -     0x7fff6250aff7  libnetwork.dylib (1880.60.5) <35E60A75-4871-3C42-95E5-F9F21CC9EB4D> /usr/lib/libnetwork.dylib
    0x7fff625a9000 -     0x7fff625dafc6  libobjc.A.dylib (781.2) <29315657-EFFF-3F00-9390-30D64758FDB1> /usr/lib/libobjc.A.dylib
    0x7fff625ed000 -     0x7fff625f1fff  libpam.2.dylib (25) <B1686A6C-6AD2-3AF9-A3D2-F5DAE6127764> /usr/lib/libpam.2.dylib
    0x7fff625f4000 -     0x7fff6262aff7  libpcap.A.dylib (89.60.2) <EE5AA74F-6B67-3CF0-AA89-349569F58B32> /usr/lib/libpcap.A.dylib
    0x7fff626ac000 -     0x7fff626c4ff7  libresolv.9.dylib (67.40.1) <8F1219C4-418B-3B7B-9077-77B6549FE610> /usr/lib/libresolv.9.dylib
    0x7fff626c6000 -     0x7fff6270afff  libsandbox.1.dylib (1217.80.1) <6B517A94-DEF6-3DCE-B046-DF8DB5C1BC10> /usr/lib/libsandbox.1.dylib
    0x7fff6270b000 -     0x7fff6271dfff  libsasl2.2.dylib (213) <F5CB77F4-45B8-3F19-AB98-ED943BCDA467> /usr/lib/libsasl2.2.dylib
    0x7fff6271e000 -     0x7fff6271fff7  libspindump.dylib (281.2) <C1262DA3-C9B4-3AF4-9F9A-9B7B0AD17778> /usr/lib/libspindump.dylib
    0x7fff62720000 -     0x7fff6290dff7  libsqlite3.dylib (308.4) <6B1280A6-66C9-3C56-9A40-0655D2510C0E> /usr/lib/libsqlite3.dylib
    0x7fff62a01000 -     0x7fff62a2effb  libssl.46.dylib (47.11.1) <E827890A-B28D-32D4-B306-0C6F559CC18D> /usr/lib/libssl.46.dylib
    0x7fff62b5f000 -     0x7fff62b62ffb  libutil.dylib (57) <69AA06A8-308A-3364-AC8F-9D172545B4A7> /usr/lib/libutil.dylib
    0x7fff62b63000 -     0x7fff62b70fff  libxar.1.dylib (420) <5D2A571F-F127-3EF7-8E96-817A8749A40D> /usr/lib/libxar.1.dylib
    0x7fff62b76000 -     0x7fff62c58ff7  libxml2.2.dylib (32.14) <C413E600-03F3-35EF-BCAA-E06A04D05676> /usr/lib/libxml2.2.dylib
    0x7fff62c5c000 -     0x7fff62c84fff  libxslt.1.dylib (16.7) <6FE38275-A3F5-3152-948D-0947C729AF02> /usr/lib/libxslt.1.dylib
    0x7fff62c85000 -     0x7fff62c97ffb  libz.1.dylib (76) <941B9789-D532-3278-AD52-ECFB86D57690> /usr/lib/libz.1.dylib
    0x7fff636fb000 -     0x7fff63700ff3  libcache.dylib (83) <BFCDF745-55BA-3F9F-8E0E-B8A7C438D972> /usr/lib/system/libcache.dylib
    0x7fff63701000 -     0x7fff6370cfff  libcommonCrypto.dylib (60165) <AF856633-9465-3830-B043-54642847F38A> /usr/lib/system/libcommonCrypto.dylib
    0x7fff6370d000 -     0x7fff63714fff  libcompiler_rt.dylib (101.2) <1A513A39-3BA8-3970-8242-D9D7E9B9793C> /usr/lib/system/libcompiler_rt.dylib
    0x7fff63715000 -     0x7fff6371efff  libcopyfile.dylib (166.40.1) <CFACC087-082A-3497-AA1B-F15D42287098> /usr/lib/system/libcopyfile.dylib
    0x7fff6371f000 -     0x7fff637b6fdb  libcorecrypto.dylib (866.80.2) <FE614062-B51A-392D-A524-722BB127D181> /usr/lib/system/libcorecrypto.dylib
    0x7fff638cd000 -     0x7fff6390eff0  libdispatch.dylib (1173.60.1) <712B16B2-5DF4-32D6-A7F8-C94D520CA048> /usr/lib/system/libdispatch.dylib
    0x7fff6390f000 -     0x7fff63944ff7  libdyld.dylib (733.8) <27C81D06-D8D4-3FCB-9519-2410949F63A9> /usr/lib/system/libdyld.dylib
    0x7fff63945000 -     0x7fff63945ffb  libkeymgr.dylib (30) <D7704043-2DBB-32A2-B364-FDE0226C306B> /usr/lib/system/libkeymgr.dylib
    0x7fff63946000 -     0x7fff63952ff7  libkxld.dylib (6153.80.8.0.1) <49B88D03-2549-3C74-A45C-028E9061249C> /usr/lib/system/libkxld.dylib
    0x7fff63953000 -     0x7fff63953ff7  liblaunch.dylib (1738.80.6) <570835AC-A304-3A87-A2A9-042DD4AF7838> /usr/lib/system/liblaunch.dylib
    0x7fff63954000 -     0x7fff63959ff7  libmacho.dylib (949.0.1) <45DFCAE9-10CC-369C-8591-3C1BF5613712> /usr/lib/system/libmacho.dylib
    0x7fff6395a000 -     0x7fff6395cff7  libquarantine.dylib (110.40.3) <99690BA3-F851-397F-895F-CB384173B528> /usr/lib/system/libquarantine.dylib
    0x7fff6395d000 -     0x7fff6395eff7  libremovefile.dylib (48) <BE0A7FC3-2D7E-3448-8748-D2B80E3488E4> /usr/lib/system/libremovefile.dylib
    0x7fff6395f000 -     0x7fff63976fff  libsystem_asl.dylib (377.60.2) <4B58BD5F-25F1-3AB5-8395-DC846975B0E6> /usr/lib/system/libsystem_asl.dylib
    0x7fff63977000 -     0x7fff63977fff  libsystem_blocks.dylib (74) <11313167-96B8-3BB2-87FA-397AFEBC2F9C> /usr/lib/system/libsystem_blocks.dylib
    0x7fff63978000 -     0x7fff639ffff7  libsystem_c.dylib (1353.60.8) <CCCE05E4-5F29-3901-B73C-AB71CD870799> /usr/lib/system/libsystem_c.dylib
    0x7fff63a00000 -     0x7fff63a03ffb  libsystem_configuration.dylib (1061.80.3) <12E5F8D2-7224-3B21-81C7-B8CAD0B23218> /usr/lib/system/libsystem_configuration.dylib
    0x7fff63a04000 -     0x7fff63a07ff7  libsystem_coreservices.dylib (114) <B43B9FC9-925C-39E8-967F-CE9003EE56F4> /usr/lib/system/libsystem_coreservices.dylib
    0x7fff63a08000 -     0x7fff63a10fff  libsystem_darwin.dylib (1353.60.8) <6AE7CF6D-AFD8-3A42-A034-7B2D60189E9E> /usr/lib/system/libsystem_darwin.dylib
    0x7fff63a11000 -     0x7fff63a18ffb  libsystem_dnssd.dylib (1096.60.2) <2A378EE0-62AB-3D39-9954-53684F8EA099> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff63a19000 -     0x7fff63a1affb  libsystem_featureflags.dylib (17) <567BB381-ECE8-353E-8C47-B6F1B9F360C0> /usr/lib/system/libsystem_featureflags.dylib
    0x7fff63a1b000 -     0x7fff63a68fff  libsystem_info.dylib (538) <BBCE9741-E3BD-3604-AE35-45FC2CDADBF8> /usr/lib/system/libsystem_info.dylib
    0x7fff63a69000 -     0x7fff63a95ff7  libsystem_kernel.dylib (6153.80.8.0.1) <17324BCB-9D2B-39AF-9743-B46731CF46B3> /usr/lib/system/libsystem_kernel.dylib
    0x7fff63a96000 -     0x7fff63addfcf  libsystem_m.dylib (3178) <3B654DDB-C941-3E2D-B936-E2E9CF8BE9EA> /usr/lib/system/libsystem_m.dylib
    0x7fff63ade000 -     0x7fff63b05fff  libsystem_malloc.dylib (283.60.1) <B40AE0C4-A19D-36B2-8CF7-D4CBE13C9CDF> /usr/lib/system/libsystem_malloc.dylib
    0x7fff63b06000 -     0x7fff63b13ffb  libsystem_networkextension.dylib (1095.60.2) <6CD1CB1A-D92A-33F1-A7E5-6F00E26CBA45> /usr/lib/system/libsystem_networkextension.dylib
    0x7fff63b14000 -     0x7fff63b1dff3  libsystem_notify.dylib (241) <43CC0CAF-1C2E-3626-BCBC-46236ECA9E3C> /usr/lib/system/libsystem_notify.dylib
    0x7fff63b1e000 -     0x7fff63b27fef  libsystem_platform.dylib (220) <D34EA8A4-F6D4-325C-9429-8520DA8AE33B> /usr/lib/system/libsystem_platform.dylib
    0x7fff63b28000 -     0x7fff63b32fff  libsystem_pthread.dylib (416.60.2) <FAE24806-9767-3B9D-9E85-842D7B960F88> /usr/lib/system/libsystem_pthread.dylib
    0x7fff63b33000 -     0x7fff63b37fff  libsystem_sandbox.dylib (1217.80.1) <FBA5624C-D855-35FC-8A93-4ADDB6961028> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff63b38000 -     0x7fff63b3afff  libsystem_secinit.dylib (62.80.1) <000C66FF-26DE-33DB-B114-70D121422E3F> /usr/lib/system/libsystem_secinit.dylib
    0x7fff63b3b000 -     0x7fff63b42ffb  libsystem_symptoms.dylib (1238.60.1) <2F569E7E-0017-3919-98CB-CC9EEE8650C2> /usr/lib/system/libsystem_symptoms.dylib
    0x7fff63b43000 -     0x7fff63b59ff2  libsystem_trace.dylib (1147.80.2) <F5CBE93C-72C2-3546-999E-E09A8DEE60FD> /usr/lib/system/libsystem_trace.dylib
    0x7fff63b5b000 -     0x7fff63b60ffb  libunwind.dylib (35.4) <AC9B975A-8FB4-38E8-89AA-D105F96E41A6> /usr/lib/system/libunwind.dylib
    0x7fff63b61000 -     0x7fff63b96ffe  libxpc.dylib (1738.80.6) <4EB65320-241F-39E3-8488-05B64C80F1A7> /usr/lib/system/libxpc.dylib

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 991345
    thread_create: 2
    thread_set_state: 0

VM Region Summary:
ReadOnly portion of Libraries: Total=633.6M resident=0K(0%) swapped_out_or_unallocated=633.6M(100%)
Writable regions: Total=1.1G written=0K(0%) resident=0K(0%) swapped_out=0K(0%) unallocated=1.1G(100%)
 
                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Accelerate framework               256K        2 
Activity Tracing                   256K        1 
CG backing stores                 1760K        2 
CG image                           244K       11 
CoreAnimation                      300K       20 
CoreGraphics                         8K        1 
CoreImage                           24K        2 
CoreServices                       216K        1 
CoreUI image data                 1496K       13 
Dispatch continuations            12.0M        1 
Foundation                           4K        1 
Kernel Alloc Once                    8K        1 
MALLOC                           218.2M       60 
MALLOC guard page                   48K       12 
MALLOC_MEDIUM (reserved)         672.0M        6         reserved VM address space (unallocated)
Memory Tag 242                      12K        1 
STACK GUARD                       56.1M       26 
Stack                             20.7M       26 
VM_ALLOCATE                       48.3M       20 
VM_ALLOCATE (reserved)            1920K        2         reserved VM address space (unallocated)
__DATA                            71.5M      369 
__DATA_CONST                        88K        5 
__FONT_DATA                          4K        1 
__GLSLBUILTINS                    5176K        1 
__LINKEDIT                       363.4M       55 
__OBJC_RO                         32.0M        1 
__OBJC_RW                         1776K        1 
__TEXT                           270.2M      349 
__UNICODE                          564K        1 
mapped file                       65.1M       24 
shared memory                     96.9M       18 
===========                     =======  ======= 
TOTAL                              1.9G     1034 
TOTAL, minus reserved VM space     1.2G     1034 

Model: iMac19,1, BootROM 1037.60.50.0.0, 6 processors, 6-Core Intel Core i5, 3.7 GHz, 32 GB, SMC 2.46f12
Graphics: kHW_AMDRadeonPro580XItem, Radeon Pro 580X, spdisplays_pcie_device, 8 GB
Memory Module: BANK 2/ChannelB-DIMM0, 16 GB, DDR4, 2667 MHz, Kingston, KHX2666C15S4/16G
Memory Module: BANK 3/ChannelB-DIMM1, 16 GB, DDR4, 2667 MHz, Kingston, KHX2666C15S4/16G
AirPort: spairport_wireless_card_type_airport_extreme (0x14E4, 0x7BF), wl0: Oct 26 2019 10:18:37 version 9.112.2.0.32.5.40 FWID 01-66dd2dcb
Bluetooth: Version 7.0.2f5, 3 services, 27 devices, 1 incoming serial ports
Network Service: Ethernet, Ethernet, en0
Network Service: AirPort, AirPort, en1
Network Service: RNDIS/Ethernet Gadget, Ethernet, en7
Network Service: nyc-a06.wlvpn.com, PPP (L2TP), ppp0
Network Service: Kobo, IPSec, utun4
USB Device: USB 3.1 Bus
USB Device: USB3.0 Hub
USB Device: NS1066
USB Device: USB3.0 Card Reader
USB Device: FaceTime HD Camera (Built-in)
USB Device: USB 2.0 Hub
USB Device: USB 2.0 Hub
USB Device: powerUART zero
USB Device: USB2.0 Hub
Thunderbolt Bus: iMac, Apple Inc., 47.1
```

After fixing that, I was confronted with this crash in GLContextAGL::Update:

```
Process:               Dolphin [79841]
Path:                  /Users/USER/*/Dolphin.app/Contents/MacOS/Dolphin
Identifier:            org.dolphin-emu.dolphin
Version:               5.0-11422 (5.0)
Code Type:             X86-64 (Native)
Parent Process:        ??? [1]
Responsible:           Dolphin [79841]
User ID:               501

Date/Time:             2020-01-01 21:35:06.176 -0500
OS Version:            Mac OS X 10.15.3 (19D49f)
Report Version:        12
Anonymous UUID:        82114560-50F3-87D4-9575-CCC256799B8D


Time Awake Since Boot: 1100000 seconds

System Integrity Protection: enabled

Crashed Thread:        15  Video thread

Exception Type:        EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Illegal instruction: 4
Termination Reason:    Namespace SIGNAL, Code 0x4
Terminating Process:   exc handler [79841]

Application Specific Information:
-[NSOpenGLContext update] must be called from the main thread if the context has a view.

Thread 0:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   com.apple.HIToolbox           	0x00007fff2a96765d RunCurrentEventLoopInMode + 292
6   com.apple.HIToolbox           	0x00007fff2a96739d ReceiveNextEventCommon + 600
7   com.apple.HIToolbox           	0x00007fff2a967127 _BlockUntilNextEventMatchingListInModeWithFilter + 64
8   com.apple.AppKit              	0x00007fff28febeb4 _DPSNextEvent + 990
9   com.apple.AppKit              	0x00007fff28fea690 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1352
10  com.apple.AppKit              	0x00007fff293ce6b9 -[NSView _getNextResizeEventFromMask:invalidatingLiveResizeCacheIfNecessary:] + 102
11  com.apple.AppKit              	0x00007fff293cdbe1 -[NSWindow(NSWindowResizing) _resizeWithEvent:] + 1007
12  com.apple.AppKit              	0x00007fff292a6976 -[NSTitledFrame attemptResizeWithEvent:] + 177
13  com.apple.AppKit              	0x00007fff292a6657 -[NSThemeFrame handleMouseDown:] + 294
14  com.apple.AppKit              	0x00007fff293412d4 -[NSThemeFrame mouseDown:] + 30
15  com.apple.AppKit              	0x00007fff29228ded -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:] + 4907
16  com.apple.AppKit              	0x00007fff29192f3c -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:] + 2612
17  com.apple.AppKit              	0x00007fff291922e5 -[NSWindow(NSEventRouting) sendEvent:] + 349
18  libqcocoa.dylib               	0x000000010bdebf9d 0x10bdbc000 + 196509
19  com.apple.AppKit              	0x00007fff2919065c -[NSApplication(NSEvent) sendEvent:] + 352
20  libqcocoa.dylib               	0x000000010bdf2baa 0x10bdbc000 + 224170
21  com.apple.AppKit              	0x00007fff28fdc3df -[NSApplication run] + 707
22  libqcocoa.dylib               	0x000000010bdef698 0x10bdbc000 + 210584
23  org.qt-project.QtCore         	0x0000000107f08ddf QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 431
24  org.qt-project.QtCore         	0x0000000107f0de82 QCoreApplication::exec() + 130

Thread 1:: org.libusb.device-hotplug
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   com.apple.CoreFoundation      	0x00007fff2be9a19a CFRunLoopRun + 40
6   org.dolphin-emu.dolphin       	0x0000000103df87af darwin_event_thread_main + 351
7   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 2:: libusb thread
0   libsystem_kernel.dylib        	0x00007fff63a70896 poll + 10
1   org.dolphin-emu.dolphin       	0x0000000103df4745 handle_events + 437

Thread 3:: Dispatch queue: NSCGSDisableUpdates
0   libsystem_kernel.dylib        	0x00007fff63a6a2ae semaphore_timedwait_trap + 10
1   com.apple.SkyLight            	0x00007fff5a5ea6b0 CGSUpdateManager::enable_updates_common() + 302
2   com.apple.SkyLight            	0x00007fff5a5eade7 SLSReenableUpdateTokenWithSeed + 121
3   libdispatch.dylib             	0x00007fff638cf583 _dispatch_call_block_and_release + 12
4   libdispatch.dylib             	0x00007fff638d050e _dispatch_client_callout + 8
5   libdispatch.dylib             	0x00007fff638d5ace _dispatch_lane_serial_drain + 597
6   libdispatch.dylib             	0x00007fff638d6452 _dispatch_lane_invoke + 363
7   libdispatch.dylib             	0x00007fff638dfa9e _dispatch_workloop_worker_thread + 598
8   libsystem_pthread.dylib       	0x00007fff63b2a6fc _pthread_wqthread + 290
9   libsystem_pthread.dylib       	0x00007fff63b29827 start_wqthread + 15

Thread 4:
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45cc1 std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 93
3   org.dolphin-emu.dolphin       	0x0000000103e09d2e void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, IoThreadHolder::Start()::'lambda'()> >(void*) + 190 (__mutex_base:419)

Thread 5:: Analytics
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18

Thread 6:
0   libsystem_kernel.dylib        	0x00007fff63a6cbba __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff639f00fa nanosleep + 196
2   libSDL2-2.0.0.dylib           	0x0000000105ae0861 SDL_Delay_REAL + 83
3   libSDL2-2.0.0.dylib           	0x0000000105a45eda SDL_WaitEventTimeout_REAL + 70
4   org.dolphin-emu.dolphin       	0x0000000103c1f8f8 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ciface::SDL::Init()::$_1> >(void*) + 360
5   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 7:: Wiimote Scanning Thread
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45cc1 std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 93
3   org.dolphin-emu.dolphin       	0x00000001038454a5 bool Common::Event::WaitFor<long long, std::__1::ratio<1l, 1000l> >(std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000l> > const&) + 213

Thread 8:
0   libsystem_kernel.dylib        	0x00007fff63a6cbba __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff639f00fa nanosleep + 196
2   libsystem_c.dylib             	0x00007fff639efff4 usleep + 53
3   org.dolphin-emu.dolphin       	0x00000001037ad24a HotkeyScheduler::Run() + 4538

Thread 9:
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18
3   org.dolphin-emu.dolphin       	0x000000010386cd7b Common::WorkQueueThread<GameTracker::Command>::ThreadLoop() + 107
4   ???                           	0x8000000000000000 0 + 9223372036854775808

Thread 10:
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45cc1 std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 93
3   org.dolphin-emu.dolphin       	0x00000001037a4a15 bool Common::Event::WaitFor<long long, std::__1::ratio<1l, 1l> >(std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> > const&) + 213

Thread 11:: com.apple.CFSocket.private
0   libsystem_kernel.dylib        	0x00007fff63a725be __select + 10
1   com.apple.CoreFoundation      	0x00007fff2be3cd8a __CFSocketManager + 632
2   libsystem_pthread.dylib       	0x00007fff63b2de65 _pthread_start + 148
3   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 12:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 13:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 14:: com.apple.NSEventThread
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   com.apple.AppKit              	0x00007fff2918ea72 _NSEventThread + 132
6   libsystem_pthread.dylib       	0x00007fff63b2de65 _pthread_start + 148
7   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 15 Crashed:: Video thread
0   com.apple.AppKit              	0x00007fff29396360 -[NSOpenGLContext update] + 520
1   org.dolphin-emu.dolphin       	0x0000000103d6789e GLContextAGL::Update() + 174

Thread 16:: Memcard 0 flushing thread
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18
3   org.dolphin-emu.dolphin       	0x000000010398aa5b GCMemcardDirectory::FlushThread() + 235
4   ???                           	0x0000000000000001 0 + 1
5   ???                           	0x000020a000000000 0 + 35871566856192

Thread 17:
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18

Thread 18:: IOHIDManager Hotplug Thread
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff2be13d0b __CFRunLoopServiceMachPort + 322
3   com.apple.CoreFoundation      	0x00007fff2be128e7 __CFRunLoopRun + 1695
4   com.apple.CoreFoundation      	0x00007fff2be11bd3 CFRunLoopRunSpecific + 499
5   org.dolphin-emu.dolphin       	0x0000000103c15715 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ciface::OSX::Init(void*)::$_1> >(void*) + 165
6   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 19:: AMCP Logging Spool
0   libsystem_kernel.dylib        	0x00007fff63a6a296 semaphore_wait_trap + 10
1   com.apple.audio.caulk         	0x00007fff5fb12a96 caulk::mach::semaphore::wait() + 16
2   com.apple.audio.caulk         	0x00007fff5fb12922 caulk::semaphore::timed_wait(double) + 106
3   com.apple.audio.caulk         	0x00007fff5fb12734 caulk::concurrent::details::worker_thread::run() + 30
4   com.apple.audio.caulk         	0x00007fff5fb12174 void* caulk::thread_proxy<std::__1::tuple<caulk::thread::attributes, void (caulk::concurrent::details::worker_thread::*)(), std::__1::tuple<caulk::concurrent::details::worker_thread*> > >(void*) + 45
5   libsystem_pthread.dylib       	0x00007fff63b2de65 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 20:
0   libsystem_kernel.dylib        	0x00007fff63a6a296 semaphore_wait_trap + 10
1   com.apple.audio.caulk         	0x00007fff5fb12a96 caulk::mach::semaphore::wait() + 16
2   com.apple.audio.caulk         	0x00007fff5fb12922 caulk::semaphore::timed_wait(double) + 106
3   com.apple.audio.caulk         	0x00007fff5fb12734 caulk::concurrent::details::worker_thread::run() + 30
4   com.apple.audio.caulk         	0x00007fff5fb12174 void* caulk::thread_proxy<std::__1::tuple<caulk::thread::attributes, void (caulk::concurrent::details::worker_thread::*)(), std::__1::tuple<caulk::concurrent::details::worker_thread*> > >(void*) + 45
5   libsystem_pthread.dylib       	0x00007fff63b2de65 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 21:: libusb thread
0   libsystem_kernel.dylib        	0x00007fff63a70896 poll + 10
1   org.dolphin-emu.dolphin       	0x0000000103df4745 handle_events + 437

Thread 22:: libusb thread
0   libsystem_kernel.dylib        	0x00007fff63a70896 poll + 10
1   org.dolphin-emu.dolphin       	0x0000000103df4745 handle_events + 437

Thread 23:: DVD thread
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18

Thread 24:: CPU thread
0   libsystem_kernel.dylib        	0x00007fff63a6cce6 __psynch_cvwait + 10
1   libsystem_pthread.dylib       	0x00007fff63b2e185 _pthread_cond_wait + 701
2   libc++.1.dylib                	0x00007fff60a45c2a std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18

Thread 25:: Mach exception thread
0   libsystem_kernel.dylib        	0x00007fff63a6a266 mach_msg_overwrite_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a70972 mach_msg_overwrite + 71
2   org.dolphin-emu.dolphin       	0x00000001038d1b80 EMM::ExceptionThread(unsigned int) + 352

Thread 26:: com.apple.audio.IOThread.client
0   libsystem_kernel.dylib        	0x00007fff63a6a25a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff63a6a5d0 mach_msg + 60
2   com.apple.audio.CoreAudio     	0x00007fff2b51e0c3 HALB_MachPort::SendSimpleMessageWithSimpleReply(unsigned int, unsigned int, int, int&, bool, unsigned int) + 111
3   com.apple.audio.CoreAudio     	0x00007fff2b418462 invocation function for block in HALC_ProxyIOContext::HALC_ProxyIOContext(unsigned int, unsigned int) + 2677
4   com.apple.audio.CoreAudio     	0x00007fff2b54e61c HALB_IOThread::Entry(void*) + 72
5   libsystem_pthread.dylib       	0x00007fff63b2de65 _pthread_start + 148
6   libsystem_pthread.dylib       	0x00007fff63b2983b thread_start + 15

Thread 27:
0   libsystem_pthread.dylib       	0x00007fff63b29818 start_wqthread + 0

Thread 15 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x00007fe3be066d90  rcx: 0x0000000000000000  rdx: 0x0000000000000000
  rdi: 0x0000000000000000  rsi: 0x000000001f08000c  rbp: 0x000070000f641b50  rsp: 0x000070000f641b10
   r8: 0x0000000000000000   r9: 0x0000000000000000  r10: 0x0000000000000000  r11: 0x0000000000000000
  r12: 0x000060000340a640  r13: 0x0000000000000280  r14: 0x0000600003b36670  r15: 0x00007fe3be04dc70
  rip: 0x00007fff29396360  rfl: 0x0000000000010202  cr2: 0x000000010e1ba000
  
Logical CPU:     1
Error Code:      0x00000000
Trap Number:     6


Binary Images:
       0x103783000 -        0x103f48fff +org.dolphin-emu.dolphin (5.0-11422 - 5.0) <C25F907E-BE0C-3847-AB51-A16C312E03BA> /Users/USER/*/Dolphin.app/Contents/MacOS/Dolphin
       0x105484000 -        0x1058c6ff3 +org.qt-project.QtWidgets (5.13 - 5.13.1) <4F9FB2B1-EFA5-3D1E-9CAD-FB0C924945EF> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtWidgets.framework/Versions/5/QtWidgets
       0x105a29000 -        0x105b04fff +libSDL2-2.0.0.dylib (0) <3A751D21-CECC-37E2-B03B-AD0D4092ED08> /Users/USER/*/Dolphin.app/Contents/Frameworks/libSDL2-2.0.0.dylib
       0x105b44000 -        0x105b46fff +libhidapi.0.dylib (0) <DE0220FC-E027-3032-A1CE-50C8978887A5> /Users/USER/*/Dolphin.app/Contents/Frameworks/libhidapi.0.dylib
       0x105b50000 -        0x105ccffff +libavformat.58.20.100.dylib (0) <712262F2-4ACD-35CB-BF7F-33CAE094AD67> /Users/USER/*/Dolphin.app/Contents/Frameworks/libavformat.58.20.100.dylib
       0x105d12000 -        0x106b66ff7 +libavcodec.58.35.100.dylib (0) <B9B7D8FF-2AED-3329-A305-90C93A3117E1> /Users/USER/*/Dolphin.app/Contents/Frameworks/libavcodec.58.35.100.dylib
       0x107508000 -        0x107578ff7 +libswscale.5.3.100.dylib (0) <D862A50D-B179-3B1D-A3D8-811ACADFCE44> /Users/USER/*/Dolphin.app/Contents/Frameworks/libswscale.5.3.100.dylib
       0x107585000 -        0x10759cfef +libswresample.3.3.100.dylib (0) <09B81BA2-CFAE-3417-88E2-0804EEFF2405> /Users/USER/*/Dolphin.app/Contents/Frameworks/libswresample.3.3.100.dylib
       0x1075a1000 -        0x1075ddfef +libavutil.56.22.100.dylib (0) <8E7706F5-16A4-34E6-A9ED-7D63D0ECAD6B> /Users/USER/*/Dolphin.app/Contents/Frameworks/libavutil.56.22.100.dylib
       0x107600000 -        0x107638fff +libbluray.2.dylib (0) <930DD703-F9D2-3C15-8810-B4676499C2DD> /Users/USER/*/Dolphin.app/Contents/Frameworks/libbluray.2.dylib
       0x107643000 -        0x107656fff +librtmp.1.dylib (0) <1509FC17-6340-3DC3-BC60-CA815B248042> /Users/USER/*/Dolphin.app/Contents/Frameworks/librtmp.1.dylib
       0x10765c000 -        0x10769cff7 +libssl.1.0.0.dylib (0) <B4719A46-019C-3F07-9E5E-D62D3768CD14> /Users/USER/*/Dolphin.app/Contents/Frameworks/libssl.1.0.0.dylib
       0x1076bb000 -        0x1076bffeb +libsnappy.1.1.7.dylib (0) <12A38208-34C5-3599-BD68-BC842E9FEBF5> /Users/USER/*/Dolphin.app/Contents/Frameworks/libsnappy.1.1.7.dylib
       0x1076c7000 -        0x107757cb7  dyld (733.8) <53DC4089-3912-367E-9C70-E9721ECC4A60> /usr/lib/dyld
       0x1077cb000 -        0x107c25fe7 +org.qt-project.QtGui (5.13 - 5.13.1) <45C7BF76-E87C-30FB-864D-FD65F399D520> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtGui.framework/Versions/5/QtGui
       0x107d2a000 -        0x10824dfff +org.qt-project.QtCore (5.13 - 5.13.1) <0B3FF8A2-5042-3335-A1D7-2F6D99B08266> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtCore.framework/Versions/5/QtCore
       0x10830c000 -        0x108455fff +libgnutls.30.dylib (0) <F0FD90B9-189A-38ED-909D-3686A757B8F1> /Users/USER/*/Dolphin.app/Contents/Frameworks/libgnutls.30.dylib
       0x10849b000 -        0x1085eeeaf +libcrypto.1.0.0.dylib (0) <A80F77EF-A996-3CA6-98CB-287A9C76C124> /Users/USER/*/Dolphin.app/Contents/Frameworks/libcrypto.1.0.0.dylib
       0x108667000 -        0x108682ff7 +liblzma.5.dylib (0) <423B98CF-7AF0-325D-AB6A-3F44B56B90C2> /Users/USER/*/Dolphin.app/Contents/Frameworks/liblzma.5.dylib
       0x108688000 -        0x108699ff7 +libopencore-amrwb.0.dylib (0) <12737D90-9518-3186-B09B-BFD651D7E31A> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopencore-amrwb.0.dylib
       0x10869d000 -        0x1086d4ffb +libmp3lame.0.dylib (0) <B69319FA-C9B7-3A7C-A150-E511F8D792BF> /Users/USER/*/Dolphin.app/Contents/Frameworks/libmp3lame.0.dylib
       0x10870b000 -        0x10872cfff +libopencore-amrnb.0.dylib (0) <F82300B4-A85D-398D-A20B-2873006D7329> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopencore-amrnb.0.dylib
       0x108731000 -        0x108769ffb +libopenjp2.2.3.1.dylib (0) <C43F22CC-3F4C-3CE1-BA54-554BA28B8F78> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopenjp2.2.3.1.dylib
       0x108772000 -        0x1087baff3 +libopus.0.dylib (0) <0D5C4A88-2412-3D3B-B49A-F11C00BA8C05> /Users/USER/*/Dolphin.app/Contents/Frameworks/libopus.0.dylib
       0x1087c2000 -        0x1087d3ff3 +libspeex.1.dylib (0) <1EFB0C34-78D6-392E-912D-2E0A075FA834> /Users/USER/*/Dolphin.app/Contents/Frameworks/libspeex.1.dylib
       0x1087d8000 -        0x1087ffff7 +libtheoraenc.1.dylib (0) <6C26ECBB-A8D4-3B5C-822F-76FEC355B0D2> /Users/USER/*/Dolphin.app/Contents/Frameworks/libtheoraenc.1.dylib
       0x108804000 -        0x108810fff +libtheoradec.1.dylib (0) <D0E1513B-4003-3C4D-95FC-5796DD6DD094> /Users/USER/*/Dolphin.app/Contents/Frameworks/libtheoradec.1.dylib
       0x108814000 -        0x108817fff +libogg.0.dylib (0) <70E116A3-5EA5-3B75-AD66-35B0F0298639> /Users/USER/*/Dolphin.app/Contents/Frameworks/libogg.0.dylib
       0x10881b000 -        0x10883dfff +libvorbis.0.dylib (0) <17074AE1-B95D-3BBE-A50A-739F32F95413> /Users/USER/*/Dolphin.app/Contents/Frameworks/libvorbis.0.dylib
       0x108842000 -        0x1088b9fff +libvorbisenc.2.dylib (0) <346B6C8D-D8FF-3D3E-8C47-AEA47C0BE159> /Users/USER/*/Dolphin.app/Contents/Frameworks/libvorbisenc.2.dylib
       0x1088ea000 -        0x108a7efdf +libx264.155.dylib (0) <F405A367-C814-330B-8741-608E717A642A> /Users/USER/*/Dolphin.app/Contents/Frameworks/libx264.155.dylib
       0x108ba1000 -        0x109a19fd3 +libx265.176.dylib (0) <9EA96905-B41F-3D50-90B9-25BF8EBA9187> /Users/USER/*/Dolphin.app/Contents/Frameworks/libx265.176.dylib
       0x109c15000 -        0x109c3aff3 +libsoxr.0.1.2.dylib (0) <1C380A7A-FE3E-3606-9466-3168DDD81686> /Users/USER/*/Dolphin.app/Contents/Frameworks/libsoxr.0.1.2.dylib
       0x109c76000 -        0x109ca5fff +libfontconfig.1.dylib (0) <DF644C1F-4C8C-372F-A0B4-B03BCB76AEDE> /Users/USER/*/Dolphin.app/Contents/Frameworks/libfontconfig.1.dylib
       0x109cb2000 -        0x109d2dfff +libfreetype.6.dylib (0) <02EE484C-8D5B-36C3-988B-00DD0C7369FE> /Users/USER/*/Dolphin.app/Contents/Frameworks/libfreetype.6.dylib
       0x109d46000 -        0x109d69ff7 +libpng16.16.dylib (0) <B7CE95CF-E67E-39EB-8DF5-B89849A02BDA> /Users/USER/*/Dolphin.app/Contents/Frameworks/libpng16.16.dylib
       0x109d72000 -        0x109e19ff3 +libp11-kit.0.dylib (0) <2C68B3C9-42B9-3F59-8677-B8FC46A7A1DF> /Users/USER/*/Dolphin.app/Contents/Frameworks/libp11-kit.0.dylib
       0x109e63000 -        0x109e7fffb +libidn2.0.dylib (0) <5D11E999-01AA-348E-80A4-C98017A88F95> /Users/USER/*/Dolphin.app/Contents/Frameworks/libidn2.0.dylib
       0x109e83000 -        0x109fe6fff +libunistring.2.dylib (0) <A4545916-E2F4-3D6A-862B-528A6806E9FC> /Users/USER/*/Dolphin.app/Contents/Frameworks/libunistring.2.dylib
       0x109ff9000 -        0x10a005fff +libtasn1.6.dylib (0) <C27BBF20-E800-3ABE-9830-8E2FA9A2B33C> /Users/USER/*/Dolphin.app/Contents/Frameworks/libtasn1.6.dylib
       0x10a009000 -        0x10a02eff7 +libnettle.6.5.dylib (0) <F07C4E8D-7087-384C-AC93-46234AEB2391> /Users/USER/*/Dolphin.app/Contents/Frameworks/libnettle.6.5.dylib
       0x10a038000 -        0x10a061ffb +libhogweed.4.5.dylib (0) <E0C32E51-C7D4-3C15-A269-272AD3BC3BBE> /Users/USER/*/Dolphin.app/Contents/Frameworks/libhogweed.4.5.dylib
       0x10a06a000 -        0x10a0c6fcf +libgmp.10.dylib (0) <7D2A1AB0-B206-3196-954C-5A0E17049998> /Users/USER/*/Dolphin.app/Contents/Frameworks/libgmp.10.dylib
       0x10a0d2000 -        0x10a0daffb +libintl.8.dylib (0) <CD236902-DB50-39BB-86BB-E9F0D22E5649> /Users/USER/*/Dolphin.app/Contents/Frameworks/libintl.8.dylib
       0x10a0df000 -        0x10a0e3ff7 +libffi.6.dylib (0) <986DC089-727D-3563-935B-652AB8C97396> /Users/USER/*/Dolphin.app/Contents/Frameworks/libffi.6.dylib
       0x10bd03000 -        0x10bd0aff3  com.apple.iokit.IOUSBLib (900.4.2 - 900.4.2) <F7F9D6DD-6137-3849-9CDD-8E198228CC37> /System/Library/Extensions/IOUSBFamily.kext/Contents/PlugIns/IOUSBLib.bundle/Contents/MacOS/IOUSBLib
       0x10bd1b000 -        0x10bd23ff3  com.apple.iokit.IOUSBLib (900.4.2 - 900.4.2) <6C376796-C56A-3A4A-8EA6-440CFE4CB1A5> /System/Library/Extensions/IOUSBHostFamily.kext/Contents/PlugIns/IOUSBLib.bundle/Contents/MacOS/IOUSBLib
       0x10bdbc000 -        0x10bf1bfff +libqcocoa.dylib (0) <345EC8D4-53B3-391C-BFD3-5ABE706107D8> /Users/USER/*/Dolphin.app/Contents/MacOS/platforms/libqcocoa.dylib
       0x10bf68000 -        0x10bfc6ffb +org.qt-project.QtDBus (5.13 - 5.13.1) <6BBA8F9F-3C83-3AD0-B036-02681FDE2D56> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtDBus.framework/Versions/5/QtDBus
       0x10bfdf000 -        0x10c008ffb +org.qt-project.QtPrintSupport (5.13 - 5.13.1) <419EB6E8-E917-3D57-B067-143101AE58D5> /Users/USER/*/Dolphin.app/Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
       0x10c3f3000 -        0x10c3f6047  libobjc-trampolines.dylib (781.2) <CDB44285-147A-304A-8698-E6A5EE45BB3E> /usr/lib/libobjc-trampolines.dylib
       0x10c46f000 -        0x10c482ff3  com.apple.iokit.IOHIDLib (2.0.0 - 2.0.0) <D81EB948-2E5D-39D7-9961-EDAB37D45049> /System/Library/Extensions/IOHIDFamily.kext/Contents/PlugIns/IOHIDLib.plugin/Contents/MacOS/IOHIDLib
       0x10e2ae000 -        0x10e2d2fff +libqmacstyle.dylib (0) <52899D99-03F5-35FB-B10B-4B5E3AADF667> /Users/USER/*/Dolphin.app/Contents/MacOS/styles/libqmacstyle.dylib
       0x10e9a2000 -        0x10ea6afff  com.apple.AMDRadeonX4000GLDriver (3.5.1 - 3.0.5) <EF8D3F7E-E0EC-3609-A006-05419C5DCB42> /System/Library/Extensions/AMDRadeonX4000GLDriver.bundle/Contents/MacOS/AMDRadeonX4000GLDriver
       0x10ec35000 -        0x10ec39fff  com.apple.audio.AppleHDAHALPlugIn (283.15 - 283.15) <875C7A46-4E2B-39A5-AB5A-87A7EDBE576F> /System/Library/Extensions/AppleHDA.kext/Contents/PlugIns/AppleHDAHALPlugIn.bundle/Contents/MacOS/AppleHDAHALPlugIn
       0x10f3b6000 -        0x10f3ccff7  com.apple.security.csparser (3.0 - 59306.61.1) <0D56BBA6-463E-3271-91FC-F918000B6FFE> /System/Library/Frameworks/Security.framework/PlugIns/csparser.bundle/Contents/MacOS/csparser
       0x126803000 -        0x126950ff7  com.apple.audio.units.Components (1.14 - 1.14) <8A39B866-E965-3516-A9FD-2204624004C4> /System/Library/Components/CoreAudio.component/Contents/MacOS/CoreAudio
    0x7fff205d2000 -     0x7fff206f2ff5  com.apple.AMDMTLBronzeDriver (3.5.1 - 3.0.5) <946307F2-008E-31ED-802E-1617C6A8F3A9> /System/Library/Extensions/AMDMTLBronzeDriver.bundle/Contents/MacOS/AMDMTLBronzeDriver
    0x7fff206f3000 -     0x7fff20729ff7  ATIRadeonX4000SCLib.dylib (3.5.1) <7BE8482B-C2DB-35F7-892D-6FB778DBCC72> /System/Library/Extensions/AMDRadeonX4000GLDriver.bundle/Contents/MacOS/ATIRadeonX4000SCLib.dylib
    0x7fff21d18000 -     0x7fff22996ff7  libSC.dylib (3.5.1) <804415D2-8365-3622-8CA7-B26AA4730E1D> /System/Library/Extensions/AMDShared.bundle/Contents/PlugIns/libSC.dylib
    0x7fff276fc000 -     0x7fff27700ffb  com.apple.agl (3.3.3 - AGL-3.3.3) <FDF13A53-6BFE-3857-837F-34F29CFDCBD1> /System/Library/Frameworks/AGL.framework/Versions/A/AGL
    0x7fff27b4a000 -     0x7fff27b4afff  com.apple.Accelerate (1.11 - Accelerate 1.11) <EEBE6680-1AAB-3192-AA7C-450537B07F27> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
    0x7fff27b4b000 -     0x7fff27b61fff  libCGInterfaces.dylib (524.2) <90EB259D-0EEE-30BA-829C-CD7EB0AA47F4> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/Libraries/libCGInterfaces.dylib
    0x7fff27b62000 -     0x7fff281cdfef  com.apple.vImage (8.1 - 524.2) <E1674B78-9F1C-3963-B5FB-446D5215E34B> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
    0x7fff281ce000 -     0x7fff28437fff  libBLAS.dylib (1303.60.1) <1FCB122D-6FC9-3E93-B750-D6081EE29EB0> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
    0x7fff28438000 -     0x7fff28727ff7  libBNNS.dylib (144.40.3) <3C512A9F-7F02-3E60-AFCD-DC1689D53856> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBNNS.dylib
    0x7fff28729000 -     0x7fff28acefff  libLAPACK.dylib (1303.60.1) <DCC36295-FF39-35A1-8DF1-1E8A714E2265> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
    0x7fff28acf000 -     0x7fff28ae4ff8  libLinearAlgebra.dylib (1303.60.1) <E1E40FFB-3E4E-3B75-97E0-9A8590C1AF6C> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLinearAlgebra.dylib
    0x7fff28ae5000 -     0x7fff28aeaff3  libQuadrature.dylib (7) <09CDAECD-9832-3B76-9D75-927C52B9FBAC> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libQuadrature.dylib
    0x7fff28aeb000 -     0x7fff28b5bfff  libSparse.dylib (103) <EADC594A-5BBD-3E9A-A6F5-301E88766833> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparse.dylib
    0x7fff28b5c000 -     0x7fff28b6efef  libSparseBLAS.dylib (1303.60.1) <26657CBC-A7E1-3A79-8F48-0AC04709DF24> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libSparseBLAS.dylib
    0x7fff28b6f000 -     0x7fff28d48ffb  libvDSP.dylib (735.40.1) <BD49856D-39CE-397F-A069-63B2F0D79529> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
    0x7fff28d49000 -     0x7fff28e04fd7  libvMisc.dylib (735.40.1) <FDD3C940-7057-3C6B-B5E2-AC822FD82528> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
    0x7fff28e05000 -     0x7fff28e05fff  com.apple.Accelerate.vecLib (3.11 - vecLib 3.11) <A8B35A80-7217-38B1-8A20-E8B4F73124F0> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
    0x7fff28e06000 -     0x7fff28e65ffc  com.apple.Accounts (113 - 113) <265C6D52-9EC6-34BE-AB24-606772BDF294> /System/Library/Frameworks/Accounts.framework/Versions/A/Accounts
    0x7fff28fab000 -     0x7fff29d66fff  com.apple.AppKit (6.9 - 1894.20.140) <283A018C-D35D-366D-8E14-EF6A05ED6636> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
    0x7fff29db6000 -     0x7fff29db6fff  com.apple.ApplicationServices (48 - 50) <F72D49D1-CD91-362D-B79D-762BE9B6939C> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
    0x7fff29db7000 -     0x7fff29e22fff  com.apple.ApplicationServices.ATS (377 - 493.0.2.1) <EE49694B-9DBB-3EF6-BFF0-E3C2837803AA> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
    0x7fff29ebb000 -     0x7fff29ef9ff8  libFontRegistry.dylib (274.0.2.3) <BBF7C42A-2B1D-3CEC-ABD9-514A52D8FC29> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
    0x7fff29f54000 -     0x7fff29f83ff7  com.apple.ATSUI (1.0 - 1) <D84AA8ED-CAEF-3F64-9601-14537547DBE3> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATSUI.framework/Versions/A/ATSUI
    0x7fff29f84000 -     0x7fff29f88ff3  com.apple.ColorSyncLegacy (4.13.0 - 1) <BD3BF303-CF2C-3CC1-91E1-F05EBC9D58ED> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSyncLegacy.framework/Versions/A/ColorSyncLegacy
    0x7fff2a023000 -     0x7fff2a079ff2  com.apple.HIServices (1.22 - 674.1) <9F970202-2423-36B6-AA9B-2C9A9988446C> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
    0x7fff2a07a000 -     0x7fff2a088fff  com.apple.LangAnalysis (1.7.0 - 1.7.0) <97FFB29E-94CD-3058-B6E6-81532645FAD3> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
    0x7fff2a089000 -     0x7fff2a0ceff2  com.apple.print.framework.PrintCore (15 - 516) <0AE0DF29-5807-35D3-9807-2FF3DCCCA683> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
    0x7fff2a0cf000 -     0x7fff2a0d9fff  com.apple.QD (4.0 - 413) <D8C67B36-3ED7-33A1-A565-D8417230A81F> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
    0x7fff2a0da000 -     0x7fff2a0e7ff0  com.apple.speech.synthesis.framework (9.0.24 - 9.0.24) <9F79D1B6-51BD-3409-8B80-F0D5EDBDDE83> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
    0x7fff2a0e8000 -     0x7fff2a1b5ffa  com.apple.audio.toolbox.AudioToolbox (1.14 - 1.14) <9AFAE780-C286-39B3-B5FB-A2AD221A3A0E> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
    0x7fff2a1b7000 -     0x7fff2a1b7fff  com.apple.audio.units.AudioUnit (1.14 - 1.14) <22A443ED-28B0-3161-9CF6-890FD03275D3> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
    0x7fff2a52d000 -     0x7fff2a8b9ff6  com.apple.CFNetwork (1121.1.2 - 1121.1.2) <DD6C93C3-3FF7-3F38-833D-63A01EC1C8D4> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
    0x7fff2a933000 -     0x7fff2a933fff  com.apple.Carbon (160 - 162) <939603EB-C340-34E1-95EA-83A9F210A2C2> /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
    0x7fff2a934000 -     0x7fff2a937ffb  com.apple.CommonPanels (1.2.6 - 101) <DB282141-674C-3F67-98F8-0C1A0CA66F39> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
    0x7fff2a938000 -     0x7fff2ac2cffb  com.apple.HIToolbox (2.1.1 - 994) <0E588DC9-36CD-36AB-A2D3-204381FB7065> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
    0x7fff2ac2d000 -     0x7fff2ac30ff3  com.apple.help (1.3.8 - 68) <7B9FB204-D822-3931-8563-CFBBEBC95E0C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
    0x7fff2ac31000 -     0x7fff2ac36ff7  com.apple.ImageCapture (9.0 - 1600.27) <6F329896-5B97-3D13-BA9C-0E762870C875> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
    0x7fff2ac37000 -     0x7fff2ac37fff  com.apple.ink.framework (10.15 - 227) <3FBCC0F7-B9BC-3841-94EB-08509DAD811C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
    0x7fff2ac38000 -     0x7fff2ac52ff2  com.apple.openscripting (1.7 - 185.1) <9E755875-EB45-33E0-899A-6251861A3610> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
    0x7fff2ac73000 -     0x7fff2ac73fff  com.apple.print.framework.Print (15 - 271) <7A477F2C-BB3E-3CCB-9352-920948AD26C0> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
    0x7fff2ac74000 -     0x7fff2ac76ff7  com.apple.securityhi (9.0 - 55008) <70A136DB-CFEF-3145-BAC2-1832D7AF4A29> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
    0x7fff2ac77000 -     0x7fff2ac7dff7  com.apple.speech.recognition.framework (6.0.3 - 6.0.3) <F3944B0A-1A81-3BE3-89EC-A2DFDBC8886C> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
    0x7fff2ae18000 -     0x7fff2ae18fff  com.apple.Cocoa (6.11 - 23) <8679A53F-D9D6-3EEF-846A-FEE20791B940> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
    0x7fff2ae26000 -     0x7fff2b011ff7  com.apple.ColorSync (4.13.0 - 3394.3) <4D3CDFB9-8309-3F22-B453-63308A245888> /System/Library/Frameworks/ColorSync.framework/Versions/A/ColorSync
    0x7fff2b301000 -     0x7fff2b810ffa  com.apple.audio.CoreAudio (5.0 - 5.0) <1721C8CC-31FC-317B-97AC-C77F7AACA764> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
    0x7fff2b863000 -     0x7fff2b89aff0  com.apple.CoreBluetooth (1.0 - 1) <2D1FAB07-825E-3B1D-BE90-0EEFF8110701> /System/Library/Frameworks/CoreBluetooth.framework/Versions/A/CoreBluetooth
    0x7fff2b89b000 -     0x7fff2bc7dffe  com.apple.CoreData (120 - 977.1) <AD121806-6F55-3217-8056-80C6877C2EB6> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
    0x7fff2bc7e000 -     0x7fff2bd8eff6  com.apple.CoreDisplay (1.0 - 186.3.9) <25785224-FDA2-3583-96F9-FBF1E1A1855D> /System/Library/Frameworks/CoreDisplay.framework/Versions/A/CoreDisplay
    0x7fff2bd8f000 -     0x7fff2c20ffe7  com.apple.CoreFoundation (6.9 - 1674.114) <8BE15BD5-FAF2-3419-B80C-2C7425FDDDC6> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7fff2c211000 -     0x7fff2c88aff0  com.apple.CoreGraphics (2.0 - 1348.16) <9330B549-787E-3B43-80E5-D8F3FDB3E700> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
    0x7fff2c898000 -     0x7fff2cbf5ff5  com.apple.CoreImage (15.0.0 - 920.9) <59E381BD-A4C6-3FB9-A58A-773C14829220> /System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage
    0x7fff2cfb9000 -     0x7fff2d129ff4  com.apple.CoreMedia (1.0 - 2530.3) <C16BA330-2F70-3B47-A61D-33D315FDB117> /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia
    0x7fff2d215000 -     0x7fff2d215fff  com.apple.CoreServices (1069.11 - 1069.11) <331A6E28-FDA7-3791-90BD-186B0E7A177C> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
    0x7fff2d216000 -     0x7fff2d29bfff  com.apple.AE (838 - 838) <F2349762-D21C-3ACA-9DD9-33E4ED3E4EC8> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
    0x7fff2d29c000 -     0x7fff2d57dff7  com.apple.CoreServices.CarbonCore (1217 - 1217) <D1DB5175-A92D-309F-998B-4A1B7C6CA9C1> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
    0x7fff2d57e000 -     0x7fff2d5cbffd  com.apple.DictionaryServices (1.2 - 323.3) <07571F1A-54AE-3361-BFA7-08BB9B7F8F7B> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices
    0x7fff2d5cc000 -     0x7fff2d5d4fff  com.apple.CoreServices.FSEvents (1268.60.1 - 1268.60.1) <FCAAB1DF-9F4B-3DAC-AF07-05028691B2A6> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents
    0x7fff2d5d5000 -     0x7fff2d80eff0  com.apple.LaunchServices (1069.11 - 1069.11) <321B6187-2FA2-345F-8B38-5EFB2DB1BB88> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
    0x7fff2d80f000 -     0x7fff2d8a7ff9  com.apple.Metadata (10.7.0 - 2075.6) <DECF9AC0-F633-30D1-8171-AD4D81FDD925> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
    0x7fff2d8a8000 -     0x7fff2d8d5ff7  com.apple.CoreServices.OSServices (1069.11 - 1069.11) <BF07F11F-A948-3EC5-ADFB-196522275B32> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
    0x7fff2d8d6000 -     0x7fff2d93dfff  com.apple.SearchKit (1.4.1 - 1.4.1) <A756912A-CC23-3C13-B7F6-CDE3898BFA0C> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
    0x7fff2d93e000 -     0x7fff2d962ff5  com.apple.coreservices.SharedFileList (131.3 - 131.3) <1648EAF4-0A94-3CE6-A26D-8F728E9B9FE6> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SharedFileList.framework/Versions/A/SharedFileList
    0x7fff2dc94000 -     0x7fff2de48ffe  com.apple.CoreText (643.1.2.3 - 643.1.2.3) <CF484DDE-C0B5-36B9-8A74-84C7142B8867> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
    0x7fff2de49000 -     0x7fff2de8dfff  com.apple.CoreVideo (1.8 - 334.0) <85729B1D-2A69-3B38-A50A-63F535F687DC> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
    0x7fff2de8e000 -     0x7fff2df1bff9  com.apple.framework.CoreWLAN (13.0 - 1455.3) <CEADF97E-03C2-30BE-864B-B8782B63915A> /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
    0x7fff2e1bb000 -     0x7fff2e1c1fff  com.apple.DiskArbitration (2.7 - 2.7) <FEBCAF40-A339-3A89-AB31-4FC82C8EEC6C> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
    0x7fff2e3b5000 -     0x7fff2e4dbff6  com.apple.FileProvider (265.1 - 265.1) <A557EA5B-3349-3B99-B39C-170D711E69D4> /System/Library/Frameworks/FileProvider.framework/Versions/A/FileProvider
    0x7fff2e4f0000 -     0x7fff2e4f2ff3  com.apple.ForceFeedback (1.0.6 - 1.0.6) <5BB37F22-8A0B-38E6-98C9-91628AAB94FD> /System/Library/Frameworks/ForceFeedback.framework/Versions/A/ForceFeedback
    0x7fff2e4f3000 -     0x7fff2e8bbffc  com.apple.Foundation (6.9 - 1674.114) <72780AD6-F601-353A-A1C9-C9CE680CCBE5> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
    0x7fff2e928000 -     0x7fff2e978ff7  com.apple.GSS (4.0 - 2.0) <7A96B860-FE9E-33D7-B8B6-EA05B020D40E> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
    0x7fff2eab3000 -     0x7fff2ebcbff8  com.apple.Bluetooth (7.0.2 - 7.0.2f5) <5DA09892-31D5-3DA8-A01F-EB8094F884FF> /System/Library/Frameworks/IOBluetooth.framework/Versions/A/IOBluetooth
    0x7fff2ec32000 -     0x7fff2ecd5ffb  com.apple.framework.IOKit (2.0.2 - 1726.80.1) <52FD85B9-C482-3731-A83A-3E72BA4872AE> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
    0x7fff2ecd7000 -     0x7fff2ece7ffc  com.apple.IOSurface (269.6 - 269.6) <C043DD85-CCA0-3D1D-B69B-0DFA57BD9700> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
    0x7fff2ed5d000 -     0x7fff2eebafee  com.apple.ImageIO.framework (3.3.0 - 1972.17) <71DE8FCC-D24D-3B2B-8439-05CF7175D20C> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
    0x7fff2eebb000 -     0x7fff2eebefff  libGIF.dylib (1972.17) <0D1C7BFA-DC3C-3711-AB20-4A62500F90BD> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
    0x7fff2eebf000 -     0x7fff2ef79fe7  libJP2.dylib (1972.17) <D3AA84D6-C435-3A7E-A07A-1C96DA204433> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
    0x7fff2ef7a000 -     0x7fff2ef9efef  libJPEG.dylib (1972.17) <EA38DD91-EE5D-3FD5-8CC5-47CA1B0781BB> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
    0x7fff2f21c000 -     0x7fff2f236fef  libPng.dylib (1972.17) <72986071-2D02-3767-8057-16E23B7CFBBA> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
    0x7fff2f237000 -     0x7fff2f238fff  libRadiance.dylib (1972.17) <C4D68B5A-DAF7-3280-9AF8-209F24364360> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
    0x7fff2f239000 -     0x7fff2f282feb  libTIFF.dylib (1972.17) <D1C99932-37DE-3C9B-BB28-ADC255705CB3> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
    0x7fff306a7000 -     0x7fff306b9ff3  com.apple.Kerberos (3.0 - 1) <EC1AFDD1-ADE9-3311-934E-93926031D11D> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
    0x7fff306ba000 -     0x7fff306bafff  libHeimdalProxy.dylib (77) <CB20F0B8-EDC1-3592-8B2D-6AEF80BE080B> /System/Library/Frameworks/Kerberos.framework/Versions/A/Libraries/libHeimdalProxy.dylib
    0x7fff306bb000 -     0x7fff306f1fff  com.apple.LDAPFramework (2.4.28 - 194.5) <7A4B4877-E9F1-34ED-AAED-4EF1CA2606B8> /System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
    0x7fff315f2000 -     0x7fff316b5ff1  com.apple.Metal (212.2.4 - 212.2.4) <E032AA9B-9ED9-39F7-8BB3-535CA297B9B2> /System/Library/Frameworks/Metal.framework/Versions/A/Metal
    0x7fff316d2000 -     0x7fff3170eff3  com.apple.MetalPerformanceShaders.MPSCore (1.0 - 1) <52A43529-85E1-365B-9A93-851E663B1DC3> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSCore.framework/Versions/A/MPSCore
    0x7fff3170f000 -     0x7fff31795fe6  com.apple.MetalPerformanceShaders.MPSImage (1.0 - 1) <92E69F78-2F84-32A2-863D-FD4DF9343081> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSImage.framework/Versions/A/MPSImage
    0x7fff31796000 -     0x7fff317baff8  com.apple.MetalPerformanceShaders.MPSMatrix (1.0 - 1) <C1B2EDBB-BD2D-3736-A5CB-E09DE6733697> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSMatrix.framework/Versions/A/MPSMatrix
    0x7fff317bb000 -     0x7fff317d0fff  com.apple.MetalPerformanceShaders.MPSNDArray (1.0 - 1) <CA397A37-F622-3DE9-A650-C95FF4F1AE29> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNDArray.framework/Versions/A/MPSNDArray
    0x7fff317d1000 -     0x7fff31930ff4  com.apple.MetalPerformanceShaders.MPSNeuralNetwork (1.0 - 1) <FCC21518-5708-34DB-AB4E-F5CD1F07972E> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSNeuralNetwork.framework/Versions/A/MPSNeuralNetwork
    0x7fff31931000 -     0x7fff3197ffff  com.apple.MetalPerformanceShaders.MPSRayIntersector (1.0 - 1) <98B296B7-AF73-3621-AD7E-BAF2569DB0EA> /System/Library/Frameworks/MetalPerformanceShaders.framework/Frameworks/MPSRayIntersector.framework/Versions/A/MPSRayIntersector
    0x7fff31980000 -     0x7fff31981ff5  com.apple.MetalPerformanceShaders.MetalPerformanceShaders (1.0 - 1) <E0F09A3D-A25A-33C6-95EE-211C2A9446F1> /System/Library/Frameworks/MetalPerformanceShaders.framework/Versions/A/MetalPerformanceShaders
    0x7fff328c7000 -     0x7fff328d3ffe  com.apple.NetFS (6.0 - 4.0) <02E8E40E-ED8E-32A0-839C-BF05F6152629> /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
    0x7fff328d4000 -     0x7fff32a17ff6  com.apple.Network (1.0 - 1) <01CDE553-02C3-3EE3-932F-DBF4A8E64411> /System/Library/Frameworks/Network.framework/Versions/A/Network
    0x7fff35437000 -     0x7fff3543ffff  libcldcpuengine.dylib (2.12.7) <B41C465E-91BE-34B2-8D43-F9822E70ABA2> /System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
    0x7fff35440000 -     0x7fff35498ff7  com.apple.opencl (3.5 - 3.5) <628CB162-98C9-3836-8D34-398B1446DE5A> /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
    0x7fff35499000 -     0x7fff354b5fff  com.apple.CFOpenDirectory (10.15 - 220.40.1) <ACFBDD47-A29E-3E4E-A556-49EE9B6A8F30> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
    0x7fff354b6000 -     0x7fff354c1ff7  com.apple.OpenDirectory (10.15 - 220.40.1) <4B3723D2-F79C-3A63-A364-E5582DA5FE7D> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
    0x7fff35e1c000 -     0x7fff35e1efff  libCVMSPluginSupport.dylib (17.10.22) <E0715E79-411B-3442-9520-9527B3012CBB> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
    0x7fff35e1f000 -     0x7fff35e24fff  libCoreFSCache.dylib (176.10) <5C5720A6-B2A2-3983-8631-B5B74EC77201> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreFSCache.dylib
    0x7fff35e25000 -     0x7fff35e29fff  libCoreVMClient.dylib (176.10) <C0FBCD1D-E8CC-3B1B-B542-30014C3B7007> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
    0x7fff35e2a000 -     0x7fff35e32ff7  libGFXShared.dylib (17.10.22) <DC81AEEA-C142-325D-BEA5-32B57FF97290> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
    0x7fff35e33000 -     0x7fff35e3dfff  libGL.dylib (17.10.22) <74B11657-CF86-3DE6-BB65-DFF41207E6DD> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
    0x7fff35e3e000 -     0x7fff35e73fff  libGLImage.dylib (17.10.22) <48240CAD-E1E7-39C1-B9EE-8ECAF4AC0AD8> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
    0x7fff35e74000 -     0x7fff36006ff7  libGLProgrammability.dylib (17.10.22) <BF2933DD-B16F-3EB5-9953-C9F1585BB0EA> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
    0x7fff36007000 -     0x7fff36043fff  libGLU.dylib (17.10.22) <C6903450-8CE0-3B74-A0A5-9B5A11ED408D> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
    0x7fff36a73000 -     0x7fff36a82ff7  com.apple.opengl (17.10.22 - 17.10.22) <FD797605-A94F-32FE-860E-D64A9DAE2206> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
    0x7fff36a83000 -     0x7fff36bfcff7  GLEngine (17.10.22) <68F2CF34-F5AA-3CF5-814F-F9FB12D7AE37> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
    0x7fff36bfd000 -     0x7fff36c25fff  GLRendererFloat (17.10.22) <7188203A-C498-3749-B8F1-48C984C02024> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
    0x7fff37a3d000 -     0x7fff37cbcff1  com.apple.QuartzCore (1.11 - 820.2) <34085113-44A8-3003-9A60-9E827355CBC2> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
    0x7fff3880c000 -     0x7fff38b5effa  com.apple.security (7.0 - 59306.61.1) <FFC1561F-C381-3FC3-9C11-A1B143EF011E> /System/Library/Frameworks/Security.framework/Versions/A/Security
    0x7fff38b5f000 -     0x7fff38be8ff7  com.apple.securityfoundation (6.0 - 55236.60.1) <C4E84DE2-89EE-34BF-928B-30B33A8CB9FA> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
    0x7fff38c17000 -     0x7fff38c1bff0  com.apple.xpc.ServiceManagement (1.0 - 1) <45D8B425-BB35-3773-8330-E28340408C3A> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
    0x7fff399ac000 -     0x7fff39a16fff  com.apple.SystemConfiguration (1.19 - 1.19) <3AB8F246-08D3-3A1A-91C9-1B90A1928700> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
    0x7fff39c92000 -     0x7fff3a039ff4  com.apple.VideoToolbox (1.0 - 2530.3) <B5AD8874-0046-3000-89AD-C983787D600D> /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox
    0x7fff3d7ce000 -     0x7fff3d892fe7  com.apple.APFS (1412.80.1 - 1412.80.1) <081A62D9-8177-31CC-99CD-F5721737810C> /System/Library/PrivateFrameworks/APFS.framework/Versions/A/APFS
    0x7fff3e991000 -     0x7fff3e992ff1  com.apple.AggregateDictionary (1.0 - 1) <7CB0CE87-538B-33E4-86AD-72E497ECE624> /System/Library/PrivateFrameworks/AggregateDictionary.framework/Versions/A/AggregateDictionary
    0x7fff3eea2000 -     0x7fff3eebfffc  com.apple.AppContainer (4.0 - 448.60.2) <B04AFD76-4F73-3531-84A5-BE3766769667> /System/Library/PrivateFrameworks/AppContainer.framework/Versions/A/AppContainer
    0x7fff3ef14000 -     0x7fff3ef22ff7  com.apple.AppSandbox (4.0 - 448.60.2) <F1965C41-AB9B-326B-9559-272432DC72CE> /System/Library/PrivateFrameworks/AppSandbox.framework/Versions/A/AppSandbox
    0x7fff3f3b1000 -     0x7fff3f3d5ff3  com.apple.framework.Apple80211 (13.0 - 1460.1) <28E28667-6E9F-3B4E-8454-2182F28C9C88> /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Apple80211
    0x7fff3f50b000 -     0x7fff3f51afef  com.apple.AppleFSCompression (119 - 1.0) <06745DE6-5C79-398F-BCFB-8CCA270F6DF8> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
    0x7fff3f619000 -     0x7fff3f624ff7  com.apple.AppleIDAuthSupport (1.0 - 1) <C686D75D-F13D-37C5-86C6-5164C89174DD> /System/Library/PrivateFrameworks/AppleIDAuthSupport.framework/Versions/A/AppleIDAuthSupport
    0x7fff3f666000 -     0x7fff3f6aefff  com.apple.AppleJPEG (1.0 - 1) <E6C9AF3D-D959-34A4-8A65-695A4694DA49> /System/Library/PrivateFrameworks/AppleJPEG.framework/Versions/A/AppleJPEG
    0x7fff3fa89000 -     0x7fff3fa8dff7  com.apple.AppleSRP (5.0 - 1) <3A938B5E-7FF2-3BD5-98C2-CF4AC47B08C4> /System/Library/PrivateFrameworks/AppleSRP.framework/Versions/A/AppleSRP
    0x7fff3fa8e000 -     0x7fff3fab0fff  com.apple.applesauce (1.0 - 16.22) <3873AE4F-6910-3555-8DF9-5334D62396F1> /System/Library/PrivateFrameworks/AppleSauce.framework/Versions/A/AppleSauce
    0x7fff3fb70000 -     0x7fff3fb73ffb  com.apple.AppleSystemInfo (3.1.5 - 3.1.5) <48612FF0-3775-3BBD-BBFD-31A5035DB978> /System/Library/PrivateFrameworks/AppleSystemInfo.framework/Versions/A/AppleSystemInfo
    0x7fff3fb74000 -     0x7fff3fbc4ff7  com.apple.AppleVAFramework (6.1.2 - 6.1.2) <6E61686C-1E11-3534-866B-B110A4A8609E> /System/Library/PrivateFrameworks/AppleVA.framework/Versions/A/AppleVA
    0x7fff3fc0d000 -     0x7fff3fc1cff9  com.apple.AssertionServices (1.0 - 223.60.4) <3ECAF762-F1BA-3E26-8EF9-09BDAECB8484> /System/Library/PrivateFrameworks/AssertionServices.framework/Versions/A/AssertionServices
    0x7fff40698000 -     0x7fff406e9ffd  com.apple.audio.AudioSession (1.0 - 17) <A34E594B-31A1-378B-BC18-3F120CE6AD67> /System/Library/PrivateFrameworks/AudioSession.framework/Versions/A/AudioSession
    0x7fff406ea000 -     0x7fff40717ff7  libSessionUtility.dylib (17) <3837B689-09F4-33EA-AA9A-94823652504A> /System/Library/PrivateFrameworks/AudioSession.framework/libSessionUtility.dylib
    0x7fff407b0000 -     0x7fff409e6ff7  com.apple.audio.AudioToolboxCore (1.0 - 1104.30) <F33BEC81-9182-3C55-A011-2D20990DD6D4> /System/Library/PrivateFrameworks/AudioToolboxCore.framework/Versions/A/AudioToolboxCore
    0x7fff409e7000 -     0x7fff40b00ff4  com.apple.AuthKit (1.0 - 1) <6DC685EF-6CC0-3E72-98CF-43ED5AE1EC42> /System/Library/PrivateFrameworks/AuthKit.framework/Versions/A/AuthKit
    0x7fff40cbb000 -     0x7fff40cc4ff3  com.apple.coreservices.BackgroundTaskManagement (1.0 - 104) <78A511E6-BB5C-35CC-B925-3AF06B655258> /System/Library/PrivateFrameworks/BackgroundTaskManagement.framework/Versions/A/BackgroundTaskManagement
    0x7fff40cc5000 -     0x7fff40d66ff8  com.apple.backup.framework (1.11.2 - 1298.2.10) <3B4BB49B-5CAD-3EF8-8882-70167C051A1B> /System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
    0x7fff40d67000 -     0x7fff40de8ffd  com.apple.BaseBoard (464.1 - 464.1) <9FABACF0-427C-3985-BF93-E4F669C11AC2> /System/Library/PrivateFrameworks/BaseBoard.framework/Versions/A/BaseBoard
    0x7fff40eea000 -     0x7fff40f26fff  com.apple.bom (14.0 - 219.2) <3392CB7A-99A5-3132-9945-4C2E772B8D20> /System/Library/PrivateFrameworks/Bom.framework/Versions/A/Bom
    0x7fff41aac000 -     0x7fff41afbfff  com.apple.ChunkingLibrary (302 - 302) <F432D506-0E34-3A0D-A0F2-735005F4A031> /System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
    0x7fff429bb000 -     0x7fff429ccfff  com.apple.CommonAuth (4.0 - 2.0) <B7D5A0B6-C320-3E3B-B109-2477EC49C293> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
    0x7fff429e0000 -     0x7fff429f7fff  com.apple.commonutilities (8.0 - 900) <5512F29D-93B0-3EEC-904B-C7B3EA04BE40> /System/Library/PrivateFrameworks/CommonUtilities.framework/Versions/A/CommonUtilities
    0x7fff43515000 -     0x7fff43534ff0  com.apple.analyticsd (1.0 - 1) <A3ABE405-B830-3A3D-9F54-BECE011C9BD3> /System/Library/PrivateFrameworks/CoreAnalytics.framework/Versions/A/CoreAnalytics
    0x7fff437ff000 -     0x7fff4380aff7  com.apple.frameworks.CoreDaemon (1.3 - 1.3) <70BF0B3C-F6A6-32B0-AFCC-965D54110777> /System/Library/PrivateFrameworks/CoreDaemon.framework/Versions/B/CoreDaemon
    0x7fff43a8b000 -     0x7fff43a9bff3  com.apple.CoreEmoji (1.0 - 107) <FE70B537-EA7E-3FE6-ADDB-1A8385C99566> /System/Library/PrivateFrameworks/CoreEmoji.framework/Versions/A/CoreEmoji
    0x7fff440ef000 -     0x7fff44159ff0  com.apple.CoreNLP (1.0 - 213) <FC141D6D-EFE4-3FBF-9DA2-577DD2D730E3> /System/Library/PrivateFrameworks/CoreNLP.framework/Versions/A/CoreNLP
    0x7fff445cb000 -     0x7fff445d3ff0  com.apple.CorePhoneNumbers (1.0 - 1) <9A7F1261-9AE2-362B-B2CD-F608A0B44845> /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/Versions/A/CorePhoneNumbers
    0x7fff44d20000 -     0x7fff44d43ff7  com.apple.CoreSVG (1.0 - 129) <C3C50FB0-0063-32F8-B715-60C131EC0F7D> /System/Library/PrivateFrameworks/CoreSVG.framework/Versions/A/CoreSVG
    0x7fff44d44000 -     0x7fff44d77ff7  com.apple.CoreServicesInternal (446.6 - 446.6) <72D80F4F-3B99-359F-97C3-84AC32DB1D00> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
    0x7fff44d78000 -     0x7fff44da6ff7  com.apple.CSStore (1069.11 - 1069.11) <6783BB89-92A1-3B56-8BBA-DC26D6595AAA> /System/Library/PrivateFrameworks/CoreServicesStore.framework/Versions/A/CoreServicesStore
    0x7fff452a9000 -     0x7fff45330fff  com.apple.CoreSymbolication (11.0 - 64509.98.1) <18FA25B4-4217-32BB-A8D4-DE97B4DC1406> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
    0x7fff453c8000 -     0x7fff454f4ff4  com.apple.coreui (2.1 - 608.3) <17D26A62-83F4-39E7-B24D-ADC085C3A86B> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
    0x7fff454f5000 -     0x7fff45690ff6  com.apple.CoreUtils (6.1 - 610.19) <1FE7790A-EF43-3667-B65D-04C09CA7C716> /System/Library/PrivateFrameworks/CoreUtils.framework/Versions/A/CoreUtils
    0x7fff457c5000 -     0x7fff457d8ff1  com.apple.CrashReporterSupport (10.13 - 15011) <514FE3C8-06A9-3726-8767-56A432250F0C> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
    0x7fff45a42000 -     0x7fff45a54ffc  com.apple.framework.DFRFoundation (1.0 - 252) <9EE70E63-2E6F-393C-803D-FE46573B06A9> /System/Library/PrivateFrameworks/DFRFoundation.framework/Versions/A/DFRFoundation
    0x7fff45a55000 -     0x7fff45a5afff  com.apple.DSExternalDisplay (3.1 - 380) <32542382-4705-306A-9D26-6D328A6C1085> /System/Library/PrivateFrameworks/DSExternalDisplay.framework/Versions/A/DSExternalDisplay
    0x7fff45ac3000 -     0x7fff45b3eff8  com.apple.datadetectorscore (8.0 - 659) <023ACB83-76D9-38DE-B1A0-F0B22E50AB82> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
    0x7fff45b8a000 -     0x7fff45bc8ff0  com.apple.DebugSymbols (194 - 194) <48B26454-58BC-3E52-807A-5F92A56DC0BD> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
    0x7fff45bc9000 -     0x7fff45d25ffe  com.apple.desktopservices (1.14.2 - 1281.2.6) <988E169C-6ED0-369A-84E8-2D3C53887387> /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
    0x7fff47566000 -     0x7fff47981ff9  com.apple.vision.FaceCore (4.3.0 - 4.3.0) <60110768-AF18-3A6C-8342-52F70B0EDC1F> /System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
    0x7fff47fe5000 -     0x7fff4811cffc  libFontParser.dylib (277.2.1.2) <1FED61E5-5373-3BDB-8689-95133DA7C7C1> /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
    0x7fff4811d000 -     0x7fff48151fff  libTrueTypeScaler.dylib (277.2.1.2) <76241244-D269-38CB-95DD-00295E4F0E73> /System/Library/PrivateFrameworks/FontServices.framework/libTrueTypeScaler.dylib
    0x7fff481b6000 -     0x7fff481c6ff6  libhvf.dylib (1.0 - $[CURRENT_PROJECT_VERSION]) <324D7792-6BE0-3FC8-86C7-1F47CD835B3D> /System/Library/PrivateFrameworks/FontServices.framework/libhvf.dylib
    0x7fff4b68b000 -     0x7fff4b68cfff  libmetal_timestamp.dylib (902.11.1) <5FFE4453-C35A-3F88-ADEA-8DDAF616E5C1> /System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/3902/Libraries/libmetal_timestamp.dylib
    0x7fff4cd27000 -     0x7fff4cd32ff7  libGPUSupportMercury.dylib (17.10.22) <F2060EB1-948A-3FA8-96CA-4BD88B0723E0> /System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
    0x7fff4cd33000 -     0x7fff4cd39fff  com.apple.GPUWrangler (4.5.21 - 4.5.21) <448A1EA8-B3E0-3F39-986A-088147FD78F9> /System/Library/PrivateFrameworks/GPUWrangler.framework/Versions/A/GPUWrangler
    0x7fff4d057000 -     0x7fff4d07dffb  com.apple.GenerationalStorage (2.0 - 313) <2A24B800-9696-301B-AB00-85F070EE0ABE> /System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
    0x7fff4e1a1000 -     0x7fff4e1afffb  com.apple.GraphVisualizer (1.0 - 100.1) <5E564186-43A8-36FB-98E1-D8E0E87B7B4E> /System/Library/PrivateFrameworks/GraphVisualizer.framework/Versions/A/GraphVisualizer
    0x7fff4e341000 -     0x7fff4e3feff4  com.apple.Heimdal (4.0 - 2.0) <138A27BD-9C9E-3C47-837B-036F88B61D96> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
    0x7fff50533000 -     0x7fff5053cffe  com.apple.IOAccelMemoryInfo (1.0 - 1) <A6C7F7F0-4DA1-3F9C-A5C7-AE4D919D955C> /System/Library/PrivateFrameworks/IOAccelMemoryInfo.framework/Versions/A/IOAccelMemoryInfo
    0x7fff5053d000 -     0x7fff50545ffd  com.apple.IOAccelerator (438.2.8 - 438.2.8) <A6D474C9-D742-3039-BAF5-AD6C59E2C288> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
    0x7fff50548000 -     0x7fff5055eff7  com.apple.IOPresentment (1.0 - 37) <F11B29DF-F02D-3895-BE95-0656C43458AD> /System/Library/PrivateFrameworks/IOPresentment.framework/Versions/A/IOPresentment
    0x7fff508e8000 -     0x7fff50933ff4  com.apple.IconServices (438.3 - 438.3) <4EF74900-E91B-389F-8953-00E2CD337C8C> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
    0x7fff50af1000 -     0x7fff50af7ffc  com.apple.InternationalSupport (1.0 - 45) <427FCCE3-EAD5-3BFE-8D34-C89BE3A04A78> /System/Library/PrivateFrameworks/InternationalSupport.framework/Versions/A/InternationalSupport
    0x7fff50d38000 -     0x7fff50d58ff6  com.apple.security.KeychainCircle.KeychainCircle (1.0 - 1) <5B2E374F-247B-38FD-B169-E0A7AEE5E5CE> /System/Library/PrivateFrameworks/KeychainCircle.framework/Versions/A/KeychainCircle
    0x7fff50eb0000 -     0x7fff50f7eff5  com.apple.LanguageModeling (1.0 - 215.1) <6A639816-14EE-3621-84E4-C2F30D094F29> /System/Library/PrivateFrameworks/LanguageModeling.framework/Versions/A/LanguageModeling
    0x7fff50f7f000 -     0x7fff50fc7ff7  com.apple.Lexicon-framework (1.0 - 72) <FFE4A4F0-9A60-3EF4-AD48-20EDE74428C2> /System/Library/PrivateFrameworks/Lexicon.framework/Versions/A/Lexicon
    0x7fff50fce000 -     0x7fff50fd2ff2  com.apple.LinguisticData (1.0 - 353.6) <01563C8E-ABE1-3FB0-A465-0E26FBFA6B35> /System/Library/PrivateFrameworks/LinguisticData.framework/Versions/A/LinguisticData
    0x7fff52357000 -     0x7fff523a3fff  com.apple.spotlight.metadata.utilities (1.0 - 2075.6) <46AD9D44-675B-368B-809C-0F282871EFC3> /System/Library/PrivateFrameworks/MetadataUtilities.framework/Versions/A/MetadataUtilities
    0x7fff523a4000 -     0x7fff52472ffd  com.apple.gpusw.MetalTools (1.0 - 1) <AE5444B4-0B73-30BF-9A88-C4FD76B3CCD3> /System/Library/PrivateFrameworks/MetalTools.framework/Versions/A/MetalTools
    0x7fff526a2000 -     0x7fff526c0ff7  com.apple.MobileKeyBag (2.0 - 1.0) <C052DE34-86EF-3016-8345-D0C22A0E0E08> /System/Library/PrivateFrameworks/MobileKeyBag.framework/Versions/A/MobileKeyBag
    0x7fff52927000 -     0x7fff52957fff  com.apple.MultitouchSupport.framework (3430.1 - 3430.1) <85F77349-EA41-39F0-BB90-E0062CEFFA41> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
    0x7fff52e54000 -     0x7fff52e5efff  com.apple.NetAuth (6.2 - 6.2) <12EAFDA8-DC7C-337B-BBDB-7EAFD5AAD25D> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
    0x7fff5384f000 -     0x7fff5389bff7  com.apple.OTSVG (1.0 - 643.1.2.3) <5FDB2233-39F6-3A05-A823-0903F4AA7CF3> /System/Library/PrivateFrameworks/OTSVG.framework/Versions/A/OTSVG
    0x7fff54a31000 -     0x7fff54a3cffe  com.apple.PerformanceAnalysis (1.243.1 - 243.1) <1A1434AE-1A83-3ADD-8FE4-470A72FB3C96> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
    0x7fff54a3d000 -     0x7fff54a65ffb  com.apple.persistentconnection (1.0 - 1.0) <96550B23-39DC-3979-8D83-D3375E5327ED> /System/Library/PrivateFrameworks/PersistentConnection.framework/Versions/A/PersistentConnection
    0x7fff573c0000 -     0x7fff573d9fff  com.apple.ProtocolBuffer (1 - 274.20.7.15.1) <F10E05AA-88EB-3FA1-AA79-A5032E9B5EF8> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/Versions/A/ProtocolBuffer
    0x7fff577e2000 -     0x7fff5780bff9  com.apple.RemoteViewServices (2.0 - 148) <4DC357D6-4CBB-39CE-92A3-60DDE376774E> /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
    0x7fff57971000 -     0x7fff579acff4  com.apple.RunningBoardServices (1.0 - 223.60.4) <5EE4AB2B-B57D-38F2-A1E7-D5E6B2CFDD2C> /System/Library/PrivateFrameworks/RunningBoardServices.framework/Versions/A/RunningBoardServices
    0x7fff592f4000 -     0x7fff592f7ff9  com.apple.SecCodeWrapper (4.0 - 448.60.2) <32112D4B-FC08-314C-8301-9DA3C38C7B96> /System/Library/PrivateFrameworks/SecCodeWrapper.framework/Versions/A/SecCodeWrapper
    0x7fff5946a000 -     0x7fff5958eff4  com.apple.Sharing (1506.6 - 1506.6) <E1983712-B65E-31D7-9132-EA65D532628D> /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
    0x7fff5a5a6000 -     0x7fff5a89effa  com.apple.SkyLight (1.600.0 - 450.1) <95192F00-C637-3B7E-BAF6-5105E0986F39> /System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight
    0x7fff5b0e6000 -     0x7fff5b0f4fff  com.apple.SpeechRecognitionCore (6.0.91 - 6.0.91) <B7EE92CE-EC7C-370D-BAC7-E535EE790C24> /System/Library/PrivateFrameworks/SpeechRecognitionCore.framework/Versions/A/SpeechRecognitionCore
    0x7fff5b921000 -     0x7fff5b92aff7  com.apple.SymptomDiagnosticReporter (1.0 - 1238.60.1) <033BBEB6-2D37-3AE3-AB3A-A6CD55B2C09F> /System/Library/PrivateFrameworks/SymptomDiagnosticReporter.framework/Versions/A/SymptomDiagnosticReporter
    0x7fff5bbe0000 -     0x7fff5bbf0ff3  com.apple.TCC (1.0 - 1) <9CE00989-775D-3589-91EF-670CA501AF8A> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
    0x7fff5c0e5000 -     0x7fff5c1acff4  com.apple.TextureIO (3.10.9 - 3.10.9) <B3C12867-3DA6-36B3-82CF-DFE0610C0CE2> /System/Library/PrivateFrameworks/TextureIO.framework/Versions/A/TextureIO
    0x7fff5c328000 -     0x7fff5c329fff  com.apple.TrustEvaluationAgent (2.0 - 33) <46A7C8B1-C2FE-3500-8399-76ED4A48BA4F> /System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
    0x7fff5d002000 -     0x7fff5d25cff2  com.apple.UIFoundation (1.0 - 660) <4A6FF9CC-D3EF-36EE-B621-189A123503CC> /System/Library/PrivateFrameworks/UIFoundation.framework/Versions/A/UIFoundation
    0x7fff5de50000 -     0x7fff5de70fff  com.apple.UserManagement (1.0 - 1) <B7BC4D55-6DCB-331D-A6CD-E4F3E0C4F166> /System/Library/PrivateFrameworks/UserManagement.framework/Versions/A/UserManagement
    0x7fff5ec26000 -     0x7fff5ed10ffe  com.apple.ViewBridge (462 - 462) <AD1553E2-FD27-3008-ABD7-E88BC388DE66> /System/Library/PrivateFrameworks/ViewBridge.framework/Versions/A/ViewBridge
    0x7fff5eeb6000 -     0x7fff5eeb7fff  com.apple.WatchdogClient.framework (1.0 - 67.60.1) <63C179F1-F432-3666-A690-9B2B0316FE35> /System/Library/PrivateFrameworks/WatchdogClient.framework/Versions/A/WatchdogClient
    0x7fff5fa94000 -     0x7fff5fa97ffa  com.apple.dt.XCTTargetBootstrap (1.0 - 15700) <7D475E3B-B76F-30F0-95F1-008AAD1365BC> /System/Library/PrivateFrameworks/XCTTargetBootstrap.framework/Versions/A/XCTTargetBootstrap
    0x7fff5fb10000 -     0x7fff5fb1eff5  com.apple.audio.caulk (1.0 - 32.3) <42471A03-A388-376A-923E-E38AAACDC95E> /System/Library/PrivateFrameworks/caulk.framework/Versions/A/caulk
    0x7fff5fe5f000 -     0x7fff5fe61ff3  com.apple.loginsupport (1.0 - 1) <969341B2-06F0-3582-8430-471F1470C5A2> /System/Library/PrivateFrameworks/login.framework/Versions/A/Frameworks/loginsupport.framework/Versions/A/loginsupport
    0x7fff5fe62000 -     0x7fff5fe75ffd  com.apple.login (3.0 - 3.0) <4D7ED0AF-867C-39A7-8D40-684CDDD4538C> /System/Library/PrivateFrameworks/login.framework/Versions/A/login
    0x7fff60183000 -     0x7fff601b9ffa  libAudioToolboxUtility.dylib (1104.30) <1AF0E0B2-D2DD-35C5-8984-11A2A720863D> /usr/lib/libAudioToolboxUtility.dylib
    0x7fff601c0000 -     0x7fff601f5ff7  libCRFSuite.dylib (48) <80F9320E-B18F-3E09-955E-5C1E56D29428> /usr/lib/libCRFSuite.dylib
    0x7fff601f8000 -     0x7fff60202ff3  libChineseTokenizer.dylib (34) <EF4D5593-20E5-34D7-ACBE-EBEA66E0F427> /usr/lib/libChineseTokenizer.dylib
    0x7fff6028f000 -     0x7fff60291ff7  libDiagnosticMessagesClient.dylib (112) <AFEB64B9-4439-3BFF-A521-ED5A939CD1E3> /usr/lib/libDiagnosticMessagesClient.dylib
    0x7fff602d6000 -     0x7fff6048dff3  libFosl_dynamic.dylib (100.4) <84A5F946-01EE-3740-BD2F-4C2A6B1FE82B> /usr/lib/libFosl_dynamic.dylib
    0x7fff604b4000 -     0x7fff604baff3  libIOReport.dylib (54) <B1B35705-BBF0-363D-A9F8-B80D9480B90F> /usr/lib/libIOReport.dylib
    0x7fff6059a000 -     0x7fff605a1fff  libMatch.1.dylib (36) <07F75921-1584-3723-BD0E-7AFE1AD36883> /usr/lib/libMatch.1.dylib
    0x7fff605d1000 -     0x7fff605f0fff  libMobileGestalt.dylib (826.80.1) <7F0DC9DE-BA4E-38C8-B93E-BBB6BA5B2949> /usr/lib/libMobileGestalt.dylib
    0x7fff60757000 -     0x7fff60758ff3  libSystem.B.dylib (1281) <D1FA14E5-71AE-3F55-B7F3-2C4030BF2D64> /usr/lib/libSystem.B.dylib
    0x7fff607e8000 -     0x7fff607e9fff  libThaiTokenizer.dylib (3) <C229130F-0BC2-3A4D-9792-25A726E9721A> /usr/lib/libThaiTokenizer.dylib
    0x7fff60801000 -     0x7fff60817fff  libapple_nghttp2.dylib (1.39.2) <64529A87-3D1D-331E-84EE-11303FE51E78> /usr/lib/libapple_nghttp2.dylib
    0x7fff6084c000 -     0x7fff608beff7  libarchive.2.dylib (72.40.2) <FB5BF2E0-2F4C-3EDF-A8FC-1DEF7EC95F31> /usr/lib/libarchive.2.dylib
    0x7fff608bf000 -     0x7fff60955fc5  libate.dylib (2.0.9) <D610C2C5-119A-35B6-BF62-4A6B0FB9BAD9> /usr/lib/libate.dylib
    0x7fff60959000 -     0x7fff60959ff3  libauto.dylib (187) <9AA72156-47CE-3150-836D-A71538F438FD> /usr/lib/libauto.dylib
    0x7fff60a20000 -     0x7fff60a30ff3  libbsm.0.dylib (60) <4BDE44B7-3BC3-31A6-901F-48B6ACFADA0A> /usr/lib/libbsm.0.dylib
    0x7fff60a31000 -     0x7fff60a3dfff  libbz2.1.0.dylib (44) <9A6BD380-46EF-3809-BA75-AF14FCAAA58E> /usr/lib/libbz2.1.0.dylib
    0x7fff60a3e000 -     0x7fff60a91ff7  libc++.1.dylib (800.7) <759F16C5-2D16-3ECD-AC46-1C7902607205> /usr/lib/libc++.1.dylib
    0x7fff60a92000 -     0x7fff60aa6fff  libc++abi.dylib (800.7) <BC59F72A-42F5-3F45-B15C-87324B9D556A> /usr/lib/libc++abi.dylib
    0x7fff60aa7000 -     0x7fff60aa7ffb  libcharset.1.dylib (59) <2ECDB43B-F6F7-30FE-83EB-B88FEA7D1616> /usr/lib/libcharset.1.dylib
    0x7fff60aa8000 -     0x7fff60ab9ffb  libcmph.dylib (8) <9B949AB0-3E0C-332F-BC23-C319E415A5EC> /usr/lib/libcmph.dylib
    0x7fff60aba000 -     0x7fff60ad1fe7  libcompression.dylib (87) <1C7E9A97-E841-3B71-8B09-BC72F6BA364A> /usr/lib/libcompression.dylib
    0x7fff60da1000 -     0x7fff60db7ff7  libcoretls.dylib (167) <A7BE4922-98AD-3923-8EBB-C3E5502B4D89> /usr/lib/libcoretls.dylib
    0x7fff60db8000 -     0x7fff60db9fff  libcoretls_cfhelpers.dylib (167) <13DBAF4C-FAC2-3834-940A-0FAC48C23A79> /usr/lib/libcoretls_cfhelpers.dylib
    0x7fff60f5c000 -     0x7fff61056fff  libcrypto.35.dylib (47.11.1) <8A1C9C0D-427B-3B7A-B17A-ECAC558B83B7> /usr/lib/libcrypto.35.dylib
    0x7fff6125d000 -     0x7fff61361fe7  libcrypto.44.dylib (47.11.1) <30DA518F-1B8D-39B3-AFC9-44FCFC979871> /usr/lib/libcrypto.44.dylib
    0x7fff61377000 -     0x7fff613d6fff  libcups.2.dylib (483.2) <553FAB5D-D429-3470-8139-88DE3C615D32> /usr/lib/libcups.2.dylib
    0x7fff613d8000 -     0x7fff6143ffff  libcurl.4.dylib (118) <B5803527-CB9E-38B4-8E0B-095354A36746> /usr/lib/libcurl.4.dylib
    0x7fff614e2000 -     0x7fff614e2fff  libenergytrace.dylib (21) <F4D773CE-5F2E-382C-AA3F-03AACE0D414B> /usr/lib/libenergytrace.dylib
    0x7fff614e3000 -     0x7fff614fcff7  libexpat.1.dylib (19.60.2) <E1CCCBF4-D28A-300F-A3F6-5754353DFA56> /usr/lib/libexpat.1.dylib
    0x7fff6150a000 -     0x7fff6150cfff  libfakelink.dylib (149) <686B9C02-D420-344F-BDAB-82CF2781E9B8> /usr/lib/libfakelink.dylib
    0x7fff6151b000 -     0x7fff61520fff  libgermantok.dylib (24) <9B25B6C2-0332-37A6-959F-621333901A7F> /usr/lib/libgermantok.dylib
    0x7fff61521000 -     0x7fff6152aff7  libheimdal-asn1.dylib (564.60.2) <AFF6F368-9E82-32D4-9BB8-F7F24D7B8DA3> /usr/lib/libheimdal-asn1.dylib
    0x7fff6152b000 -     0x7fff6161bff7  libiconv.2.dylib (59) <BA467D75-7A87-337A-BB8D-E864079B4D4D> /usr/lib/libiconv.2.dylib
    0x7fff6161c000 -     0x7fff61874ff7  libicucore.A.dylib (64252.0.1) <9997A41E-4489-37CF-B8CD-414C18CCD9A8> /usr/lib/libicucore.A.dylib
    0x7fff6188e000 -     0x7fff6188ffff  liblangid.dylib (133) <3A3D756D-285C-3AAF-BD93-9460F796838C> /usr/lib/liblangid.dylib
    0x7fff61890000 -     0x7fff618a8ff3  liblzma.5.dylib (16) <45ED5DEA-B892-3085-8E92-ADE65F4D020F> /usr/lib/liblzma.5.dylib
    0x7fff618c0000 -     0x7fff61967fff  libmecab.dylib (883.1.1) <1D19A5AE-4FF4-3F1C-AD1C-C470D1A72B34> /usr/lib/libmecab.dylib
    0x7fff61968000 -     0x7fff61bcafe1  libmecabra.dylib (883.1.1) <9F7FBBD3-66C0-39F7-8C24-7A37533C220E> /usr/lib/libmecabra.dylib
    0x7fff61f36000 -     0x7fff61f65ff7  libncurses.5.4.dylib (57) <5745F57B-1334-3397-B5D4-F4AF815E7AAE> /usr/lib/libncurses.5.4.dylib
    0x7fff62094000 -     0x7fff6250aff7  libnetwork.dylib (1880.60.5) <35E60A75-4871-3C42-95E5-F9F21CC9EB4D> /usr/lib/libnetwork.dylib
    0x7fff625a9000 -     0x7fff625dafc6  libobjc.A.dylib (781.2) <29315657-EFFF-3F00-9390-30D64758FDB1> /usr/lib/libobjc.A.dylib
    0x7fff625ed000 -     0x7fff625f1fff  libpam.2.dylib (25) <B1686A6C-6AD2-3AF9-A3D2-F5DAE6127764> /usr/lib/libpam.2.dylib
    0x7fff625f4000 -     0x7fff6262aff7  libpcap.A.dylib (89.60.2) <EE5AA74F-6B67-3CF0-AA89-349569F58B32> /usr/lib/libpcap.A.dylib
    0x7fff626ac000 -     0x7fff626c4ff7  libresolv.9.dylib (67.40.1) <8F1219C4-418B-3B7B-9077-77B6549FE610> /usr/lib/libresolv.9.dylib
    0x7fff626c6000 -     0x7fff6270afff  libsandbox.1.dylib (1217.80.1) <6B517A94-DEF6-3DCE-B046-DF8DB5C1BC10> /usr/lib/libsandbox.1.dylib
    0x7fff6270b000 -     0x7fff6271dfff  libsasl2.2.dylib (213) <F5CB77F4-45B8-3F19-AB98-ED943BCDA467> /usr/lib/libsasl2.2.dylib
    0x7fff6271e000 -     0x7fff6271fff7  libspindump.dylib (281.2) <C1262DA3-C9B4-3AF4-9F9A-9B7B0AD17778> /usr/lib/libspindump.dylib
    0x7fff62720000 -     0x7fff6290dff7  libsqlite3.dylib (308.4) <6B1280A6-66C9-3C56-9A40-0655D2510C0E> /usr/lib/libsqlite3.dylib
    0x7fff62a01000 -     0x7fff62a2effb  libssl.46.dylib (47.11.1) <E827890A-B28D-32D4-B306-0C6F559CC18D> /usr/lib/libssl.46.dylib
    0x7fff62b5f000 -     0x7fff62b62ffb  libutil.dylib (57) <69AA06A8-308A-3364-AC8F-9D172545B4A7> /usr/lib/libutil.dylib
    0x7fff62b63000 -     0x7fff62b70fff  libxar.1.dylib (420) <5D2A571F-F127-3EF7-8E96-817A8749A40D> /usr/lib/libxar.1.dylib
    0x7fff62b76000 -     0x7fff62c58ff7  libxml2.2.dylib (32.14) <C413E600-03F3-35EF-BCAA-E06A04D05676> /usr/lib/libxml2.2.dylib
    0x7fff62c5c000 -     0x7fff62c84fff  libxslt.1.dylib (16.7) <6FE38275-A3F5-3152-948D-0947C729AF02> /usr/lib/libxslt.1.dylib
    0x7fff62c85000 -     0x7fff62c97ffb  libz.1.dylib (76) <941B9789-D532-3278-AD52-ECFB86D57690> /usr/lib/libz.1.dylib
    0x7fff636fb000 -     0x7fff63700ff3  libcache.dylib (83) <BFCDF745-55BA-3F9F-8E0E-B8A7C438D972> /usr/lib/system/libcache.dylib
    0x7fff63701000 -     0x7fff6370cfff  libcommonCrypto.dylib (60165) <AF856633-9465-3830-B043-54642847F38A> /usr/lib/system/libcommonCrypto.dylib
    0x7fff6370d000 -     0x7fff63714fff  libcompiler_rt.dylib (101.2) <1A513A39-3BA8-3970-8242-D9D7E9B9793C> /usr/lib/system/libcompiler_rt.dylib
    0x7fff63715000 -     0x7fff6371efff  libcopyfile.dylib (166.40.1) <CFACC087-082A-3497-AA1B-F15D42287098> /usr/lib/system/libcopyfile.dylib
    0x7fff6371f000 -     0x7fff637b6fdb  libcorecrypto.dylib (866.80.2) <FE614062-B51A-392D-A524-722BB127D181> /usr/lib/system/libcorecrypto.dylib
    0x7fff638cd000 -     0x7fff6390eff0  libdispatch.dylib (1173.60.1) <712B16B2-5DF4-32D6-A7F8-C94D520CA048> /usr/lib/system/libdispatch.dylib
    0x7fff6390f000 -     0x7fff63944ff7  libdyld.dylib (733.8) <27C81D06-D8D4-3FCB-9519-2410949F63A9> /usr/lib/system/libdyld.dylib
    0x7fff63945000 -     0x7fff63945ffb  libkeymgr.dylib (30) <D7704043-2DBB-32A2-B364-FDE0226C306B> /usr/lib/system/libkeymgr.dylib
    0x7fff63946000 -     0x7fff63952ff7  libkxld.dylib (6153.80.8.0.1) <49B88D03-2549-3C74-A45C-028E9061249C> /usr/lib/system/libkxld.dylib
    0x7fff63953000 -     0x7fff63953ff7  liblaunch.dylib (1738.80.6) <570835AC-A304-3A87-A2A9-042DD4AF7838> /usr/lib/system/liblaunch.dylib
    0x7fff63954000 -     0x7fff63959ff7  libmacho.dylib (949.0.1) <45DFCAE9-10CC-369C-8591-3C1BF5613712> /usr/lib/system/libmacho.dylib
    0x7fff6395a000 -     0x7fff6395cff7  libquarantine.dylib (110.40.3) <99690BA3-F851-397F-895F-CB384173B528> /usr/lib/system/libquarantine.dylib
    0x7fff6395d000 -     0x7fff6395eff7  libremovefile.dylib (48) <BE0A7FC3-2D7E-3448-8748-D2B80E3488E4> /usr/lib/system/libremovefile.dylib
    0x7fff6395f000 -     0x7fff63976fff  libsystem_asl.dylib (377.60.2) <4B58BD5F-25F1-3AB5-8395-DC846975B0E6> /usr/lib/system/libsystem_asl.dylib
    0x7fff63977000 -     0x7fff63977fff  libsystem_blocks.dylib (74) <11313167-96B8-3BB2-87FA-397AFEBC2F9C> /usr/lib/system/libsystem_blocks.dylib
    0x7fff63978000 -     0x7fff639ffff7  libsystem_c.dylib (1353.60.8) <CCCE05E4-5F29-3901-B73C-AB71CD870799> /usr/lib/system/libsystem_c.dylib
    0x7fff63a00000 -     0x7fff63a03ffb  libsystem_configuration.dylib (1061.80.3) <12E5F8D2-7224-3B21-81C7-B8CAD0B23218> /usr/lib/system/libsystem_configuration.dylib
    0x7fff63a04000 -     0x7fff63a07ff7  libsystem_coreservices.dylib (114) <B43B9FC9-925C-39E8-967F-CE9003EE56F4> /usr/lib/system/libsystem_coreservices.dylib
    0x7fff63a08000 -     0x7fff63a10fff  libsystem_darwin.dylib (1353.60.8) <6AE7CF6D-AFD8-3A42-A034-7B2D60189E9E> /usr/lib/system/libsystem_darwin.dylib
    0x7fff63a11000 -     0x7fff63a18ffb  libsystem_dnssd.dylib (1096.60.2) <2A378EE0-62AB-3D39-9954-53684F8EA099> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff63a19000 -     0x7fff63a1affb  libsystem_featureflags.dylib (17) <567BB381-ECE8-353E-8C47-B6F1B9F360C0> /usr/lib/system/libsystem_featureflags.dylib
    0x7fff63a1b000 -     0x7fff63a68fff  libsystem_info.dylib (538) <BBCE9741-E3BD-3604-AE35-45FC2CDADBF8> /usr/lib/system/libsystem_info.dylib
    0x7fff63a69000 -     0x7fff63a95ff7  libsystem_kernel.dylib (6153.80.8.0.1) <17324BCB-9D2B-39AF-9743-B46731CF46B3> /usr/lib/system/libsystem_kernel.dylib
    0x7fff63a96000 -     0x7fff63addfcf  libsystem_m.dylib (3178) <3B654DDB-C941-3E2D-B936-E2E9CF8BE9EA> /usr/lib/system/libsystem_m.dylib
    0x7fff63ade000 -     0x7fff63b05fff  libsystem_malloc.dylib (283.60.1) <B40AE0C4-A19D-36B2-8CF7-D4CBE13C9CDF> /usr/lib/system/libsystem_malloc.dylib
    0x7fff63b06000 -     0x7fff63b13ffb  libsystem_networkextension.dylib (1095.60.2) <6CD1CB1A-D92A-33F1-A7E5-6F00E26CBA45> /usr/lib/system/libsystem_networkextension.dylib
    0x7fff63b14000 -     0x7fff63b1dff3  libsystem_notify.dylib (241) <43CC0CAF-1C2E-3626-BCBC-46236ECA9E3C> /usr/lib/system/libsystem_notify.dylib
    0x7fff63b1e000 -     0x7fff63b27fef  libsystem_platform.dylib (220) <D34EA8A4-F6D4-325C-9429-8520DA8AE33B> /usr/lib/system/libsystem_platform.dylib
    0x7fff63b28000 -     0x7fff63b32fff  libsystem_pthread.dylib (416.60.2) <FAE24806-9767-3B9D-9E85-842D7B960F88> /usr/lib/system/libsystem_pthread.dylib
    0x7fff63b33000 -     0x7fff63b37fff  libsystem_sandbox.dylib (1217.80.1) <FBA5624C-D855-35FC-8A93-4ADDB6961028> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff63b38000 -     0x7fff63b3afff  libsystem_secinit.dylib (62.80.1) <000C66FF-26DE-33DB-B114-70D121422E3F> /usr/lib/system/libsystem_secinit.dylib
    0x7fff63b3b000 -     0x7fff63b42ffb  libsystem_symptoms.dylib (1238.60.1) <2F569E7E-0017-3919-98CB-CC9EEE8650C2> /usr/lib/system/libsystem_symptoms.dylib
    0x7fff63b43000 -     0x7fff63b59ff2  libsystem_trace.dylib (1147.80.2) <F5CBE93C-72C2-3546-999E-E09A8DEE60FD> /usr/lib/system/libsystem_trace.dylib
    0x7fff63b5b000 -     0x7fff63b60ffb  libunwind.dylib (35.4) <AC9B975A-8FB4-38E8-89AA-D105F96E41A6> /usr/lib/system/libunwind.dylib
    0x7fff63b61000 -     0x7fff63b96ffe  libxpc.dylib (1738.80.6) <4EB65320-241F-39E3-8488-05B64C80F1A7> /usr/lib/system/libxpc.dylib

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 991887
    thread_create: 2
    thread_set_state: 0

VM Region Summary:
ReadOnly portion of Libraries: Total=616.1M resident=0K(0%) swapped_out_or_unallocated=616.1M(100%)
Writable regions: Total=1.9G written=0K(0%) resident=0K(0%) swapped_out=0K(0%) unallocated=1.9G(100%)
 
                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Accelerate framework               384K        3 
Activity Tracing                   256K        1 
CG backing stores                 1760K        2 
CG image                           328K       13 
CoreAnimation                      900K       26 
CoreGraphics                         8K        1 
CoreImage                           24K        2 
CoreUI image data                 2532K       21 
Foundation                           4K        1 
Kernel Alloc Once                    8K        1 
MALLOC                           797.5M       69 
MALLOC guard page                   48K        9 
MALLOC_MEDIUM (reserved)         640.0M        6         reserved VM address space (unallocated)
Memory Tag 242                      12K        1 
OpenGL GLSL                        384K        5 
STACK GUARD                       56.1M       27 
Stack                             21.7M       28 
Stack Guard                          4K        1 
VM_ALLOCATE                      174.6M       48 
VM_ALLOCATE (reserved)            1444K        2         reserved VM address space (unallocated)
__DATA                            70.8M      368 
__DATA_CONST                       184K        8 
__FONT_DATA                          4K        1 
__GLSLBUILTINS                    5176K        1 
__LINKEDIT                       363.6M       58 
__OBJC_RO                         32.0M        1 
__OBJC_RW                         1776K        1 
__TEXT                           252.5M      347 
__UNICODE                          564K        1 
mapped file                       66.9M       30 
shared memory                    265.1M       23 
===========                     =======  ======= 
TOTAL                              2.7G     1106 
TOTAL, minus reserved VM space     2.1G     1106 

Model: iMac19,1, BootROM 1037.60.50.0.0, 6 processors, 6-Core Intel Core i5, 3.7 GHz, 32 GB, SMC 2.46f12
Graphics: kHW_AMDRadeonPro580XItem, Radeon Pro 580X, spdisplays_pcie_device, 8 GB
Memory Module: BANK 2/ChannelB-DIMM0, 16 GB, DDR4, 2667 MHz, Kingston, KHX2666C15S4/16G
Memory Module: BANK 3/ChannelB-DIMM1, 16 GB, DDR4, 2667 MHz, Kingston, KHX2666C15S4/16G
AirPort: spairport_wireless_card_type_airport_extreme (0x14E4, 0x7BF), wl0: Oct 26 2019 10:18:37 version 9.112.2.0.32.5.40 FWID 01-66dd2dcb
Bluetooth: Version 7.0.2f5, 3 services, 27 devices, 1 incoming serial ports
Network Service: Ethernet, Ethernet, en0
Network Service: AirPort, AirPort, en1
Network Service: RNDIS/Ethernet Gadget, Ethernet, en7
Network Service: nyc-a06.wlvpn.com, PPP (L2TP), ppp0
Network Service: Kobo, IPSec, utun4
USB Device: USB 3.1 Bus
USB Device: USB3.0 Hub
USB Device: NS1066
USB Device: USB3.0 Card Reader
USB Device: FaceTime HD Camera (Built-in)
USB Device: USB 2.0 Hub
USB Device: USB 2.0 Hub
USB Device: powerUART zero
USB Device: USB2.0 Hub
Thunderbolt Bus: iMac, Apple Inc., 47.1
```
This pull request addresses both crashes, and I can play a ROM with my 8bitDo SN30 on Catalina.