### PR TITLE
HW: Add ticks to default mappings that are valid numeric literals.

### DIFF
--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -157,16 +157,16 @@ void GCKeyboard::LoadDefaults(const ControllerInterface& ciface)
   m_keys1x->SetControlExpression(13, "Y");
   m_keys1x->SetControlExpression(14, "Z");
 
-  m_keys1x->SetControlExpression(15, "1");
-  m_keys2x->SetControlExpression(0, "2");
-  m_keys2x->SetControlExpression(1, "3");
-  m_keys2x->SetControlExpression(2, "4");
-  m_keys2x->SetControlExpression(3, "5");
-  m_keys2x->SetControlExpression(4, "6");
-  m_keys2x->SetControlExpression(5, "7");
-  m_keys2x->SetControlExpression(6, "8");
-  m_keys2x->SetControlExpression(7, "9");
-  m_keys2x->SetControlExpression(8, "0");
+  m_keys1x->SetControlExpression(15, "`1`");
+  m_keys2x->SetControlExpression(0, "`2`");
+  m_keys2x->SetControlExpression(1, "`3`");
+  m_keys2x->SetControlExpression(2, "`4`");
+  m_keys2x->SetControlExpression(3, "`5`");
+  m_keys2x->SetControlExpression(4, "`6`");
+  m_keys2x->SetControlExpression(5, "`7`");
+  m_keys2x->SetControlExpression(6, "`8`");
+  m_keys2x->SetControlExpression(7, "`9`");
+  m_keys2x->SetControlExpression(8, "`0`");
 
   m_keys3x->SetControlExpression(5, "F1");
   m_keys3x->SetControlExpression(6, "F2");

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -685,10 +685,10 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
   // B
   m_buttons->SetControlExpression(1, "Click 1");
 #endif
-  m_buttons->SetControlExpression(2, "1");  // 1
-  m_buttons->SetControlExpression(3, "2");  // 2
-  m_buttons->SetControlExpression(4, "Q");  // -
-  m_buttons->SetControlExpression(5, "E");  // +
+  m_buttons->SetControlExpression(2, "`1`");  // 1
+  m_buttons->SetControlExpression(3, "`2`");  // 2
+  m_buttons->SetControlExpression(4, "Q");    // -
+  m_buttons->SetControlExpression(5, "E");    // +
 
 #ifdef _WIN32
   m_buttons->SetControlExpression(6, "!LMENU & RETURN");  // Home


### PR DESCRIPTION
Now that input expressions support numeric literals some of our default mappings result in always pressed buttons when the device is changed from the default keyboard without clearing mappings.

e.g. The Wii Remote default mapping for "1" was `1`. This expression binds to an input called "1" so long as it exists. When this input doesn't exist it is evaluated as a literal value of 1, which is problematic.

This adds backticks to these default mappings to force interpretation as input names and prevent the problem.