### PR TITLE
Core/WiimoteReal: Wii remote connection pool and source change cleanup.

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -25,6 +25,38 @@
 // Limit the amount of wiimote connect requests, when a button is pressed in disconnected state
 static std::array<u8, MAX_BBMOTES> s_last_connect_request_counter;
 
+namespace WiimoteCommon
+{
+static std::array<std::atomic<WiimoteSource>, MAX_BBMOTES> s_wiimote_sources;
+
+WiimoteSource GetSource(unsigned int index)
+{
+  return s_wiimote_sources[index];
+}
+
+void SetSource(unsigned int index, WiimoteSource source)
+{
+  const WiimoteSource previous_source = s_wiimote_sources[index].exchange(source);
+
+  if (previous_source == source)
+  {
+    // No change. Do nothing.
+    return;
+  }
+
+  WiimoteReal::HandleWiimoteSourceChange(index);
+
+  // Reconnect to the emulator.
+  Core::RunAsCPUThread([index, previous_source, source] {
+    if (previous_source != WiimoteSource::None)
+      ::Wiimote::Connect(index, false);
+
+    if (source == WiimoteSource::Emulated)
+      ::Wiimote::Connect(index, true);
+  });
+}
+}  // namespace WiimoteCommon
+
 namespace Wiimote
 {
 static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wii Remote"), "Wiimote");
@@ -155,7 +187,7 @@ void Pause()
 // An L2CAP packet is passed from the Core to the Wiimote on the HID CONTROL channel.
 void ControlChannel(int number, u16 channel_id, const void* data, u32 size)
 {
-  if (WIIMOTE_SRC_EMU == g_wiimote_sources[number])
+  if (WiimoteCommon::GetSource(number) == WiimoteSource::Emulated)
   {
     static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
         ->ControlChannel(channel_id, data, size);
@@ -169,7 +201,7 @@ void ControlChannel(int number, u16 channel_id, const void* data, u32 size)
 // An L2CAP packet is passed from the Core to the Wiimote on the HID INTERRUPT channel.
 void InterruptChannel(int number, u16 channel_id, const void* data, u32 size)
 {
-  if (WIIMOTE_SRC_EMU == g_wiimote_sources[number])
+  if (WiimoteCommon::GetSource(number) == WiimoteSource::Emulated)
   {
     static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
         ->InterruptChannel(channel_id, data, size);
@@ -182,24 +214,26 @@ void InterruptChannel(int number, u16 channel_id, const void* data, u32 size)
 
 bool ButtonPressed(int number)
 {
+  const WiimoteSource source = WiimoteCommon::GetSource(number);
+
   if (s_last_connect_request_counter[number] > 0)
   {
     --s_last_connect_request_counter[number];
-    if (g_wiimote_sources[number] && NetPlay::IsNetPlayRunning())
+    if (source != WiimoteSource::None && NetPlay::IsNetPlayRunning())
       Wiimote::NetPlay_GetButtonPress(number, false);
     return false;
   }
 
   bool button_pressed = false;
 
-  if (WIIMOTE_SRC_EMU & g_wiimote_sources[number])
+  if (source == WiimoteSource::Emulated)
     button_pressed =
         static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->CheckForButtonPress();
 
-  if (WIIMOTE_SRC_REAL & g_wiimote_sources[number])
+  if (source == WiimoteSource::Real)
     button_pressed = WiimoteReal::CheckForButtonPress(number);
 
-  if (g_wiimote_sources[number] && NetPlay::IsNetPlayRunning())
+  if (source != WiimoteSource::None && NetPlay::IsNetPlayRunning())
     button_pressed = Wiimote::NetPlay_GetButtonPress(number, button_pressed);
 
   return button_pressed;
@@ -210,7 +244,7 @@ void Update(int number, bool connected)
 {
   if (connected)
   {
-    if (WIIMOTE_SRC_EMU & g_wiimote_sources[number])
+    if (WiimoteCommon::GetSource(number) == WiimoteSource::Emulated)
       static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->Update();
     else
       WiimoteReal::Update(number);
@@ -227,25 +261,16 @@ void Update(int number, bool connected)
   }
 }
 
-// Get a mask of attached the pads (eg: controller 1 & 4 -> 0x9)
-unsigned int GetAttached()
-{
-  unsigned int attached = 0;
-  for (unsigned int i = 0; i < MAX_BBMOTES; ++i)
-    if (g_wiimote_sources[i])
-      attached |= (1 << i);
-  return attached;
-}
-
 // Save/Load state
 void DoState(PointerWrap& p)
 {
   for (int i = 0; i < MAX_BBMOTES; ++i)
   {
-    auto state_wiimote_source = u8(g_wiimote_sources[i]);
+    const WiimoteSource source = WiimoteCommon::GetSource(i);
+    auto state_wiimote_source = u8(source);
     p.Do(state_wiimote_source);
 
-    if (WIIMOTE_SRC_EMU == state_wiimote_source)
+    if (WiimoteSource(state_wiimote_source) == WiimoteSource::Emulated)
     {
       // Sync complete state of emulated wiimotes.
       static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);
@@ -255,7 +280,7 @@ void DoState(PointerWrap& p)
     {
       // If using a real wiimote or the save-state source does not match the current source,
       // then force a reconnection on load.
-      if (WIIMOTE_SRC_REAL == g_wiimote_sources[i] || state_wiimote_source != g_wiimote_sources[i])
+      if (source == WiimoteSource::Real || source != WiimoteSource(state_wiimote_source))
       {
         Connect(i, false);
         Connect(i, true);

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -44,14 +44,18 @@ enum
 
 #define WIIMOTE_INI_NAME "WiimoteNew"
 
-enum
+enum class WiimoteSource
 {
-  WIIMOTE_SRC_NONE = 0,
-  WIIMOTE_SRC_EMU = 1,
-  WIIMOTE_SRC_REAL = 2,
+  None = 0,
+  Emulated = 1,
+  Real = 2,
 };
 
-extern std::array<std::atomic<u32>, MAX_BBMOTES> g_wiimote_sources;
+namespace WiimoteCommon
+{
+WiimoteSource GetSource(unsigned int index);
+void SetSource(unsigned int index, WiimoteSource source);
+}  // namespace WiimoteCommon
 
 namespace Wiimote
 {
@@ -74,7 +78,6 @@ void LoadConfig();
 void Resume();
 void Pause();
 
-unsigned int GetAttached();
 void DoState(PointerWrap& p);
 InputConfig* GetConfig();
 ControllerEmu::ControlGroup* GetWiimoteGroup(int number, WiimoteEmu::WiimoteGroup group);
@@ -105,4 +108,5 @@ void Pause();
 void Refresh();
 
 void LoadSettings();
+
 }  // namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -192,11 +192,11 @@ void ControlChannel(int wiimote_number, u16 channel_id, const void* data, u32 si
 void Update(int wiimote_number);
 bool CheckForButtonPress(int wiimote_number);
 
-void ChangeWiimoteSource(unsigned int index, int source);
-
 bool IsValidDeviceName(const std::string& name);
 bool IsBalanceBoardName(const std::string& name);
 bool IsNewWiimote(const std::string& identifier);
+
+void HandleWiimoteSourceChange(unsigned int wiimote_number);
 
 #ifdef ANDROID
 void InitAdapterClass();

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -67,7 +67,7 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
 
     DEBUG_LOG(IOS_WIIMOTE, "Wii Remote %d BT ID %x,%x,%x,%x,%x,%x", i, tmp_bd[0], tmp_bd[1],
               tmp_bd[2], tmp_bd[3], tmp_bd[4], tmp_bd[5]);
-    m_wiimotes.emplace_back(this, i, tmp_bd, g_wiimote_sources[i] != WIIMOTE_SRC_NONE);
+    m_wiimotes.emplace_back(this, i, tmp_bd, WiimoteCommon::GetSource(i) != WiimoteSource::None);
     i++;
   }
 

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -160,7 +160,7 @@ std::string GetInputDisplay()
     {
       if (SerialInterface::GetDeviceType(i) != SerialInterface::SIDEVICE_NONE)
         s_controllers |= (1 << i);
-      if (g_wiimote_sources[i] != WIIMOTE_SRC_NONE)
+      if (WiimoteCommon::GetSource(i) != WiimoteSource::None)
         s_controllers |= (1 << (i + 4));
     }
   }
@@ -463,7 +463,7 @@ void ChangeWiiPads(bool instantly)
   int controllers = 0;
 
   for (int i = 0; i < MAX_WIIMOTES; ++i)
-    if (g_wiimote_sources[i] != WIIMOTE_SRC_NONE)
+    if (WiimoteCommon::GetSource(i) != WiimoteSource::None)
       controllers |= (1 << i);
 
   // This is important for Wiimotes, because they can desync easily if they get re-activated
@@ -478,7 +478,7 @@ void ChangeWiiPads(bool instantly)
   {
     const bool is_using_wiimote = IsUsingWiimote(i);
 
-    g_wiimote_sources[i] = is_using_wiimote ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE;
+    WiimoteCommon::SetSource(i, is_using_wiimote ? WiimoteSource::Emulated : WiimoteSource::None);
     if (!SConfig::GetInstance().m_bt_passthrough_enabled && bt)
       bt->AccessWiimoteByIndex(i)->Activate(is_using_wiimote);
   }

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1510,7 +1510,10 @@ bool NetPlayClient::StartGame(const std::string& path)
   }
 
   for (unsigned int i = 0; i < 4; ++i)
-    WiimoteReal::ChangeWiimoteSource(i, m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
+  {
+    WiimoteCommon::SetSource(i,
+                             m_wiimote_map[i] > 0 ? WiimoteSource::Emulated : WiimoteSource::None);
+  }
 
   // boot game
   m_dialog->BootGame(path);

--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -489,11 +489,13 @@ void ControllersWindow::LoadSettings()
       m_gc_controller_boxes[i]->setCurrentIndex(*gc_index);
       m_gc_buttons[i]->setEnabled(*gc_index != 0 && *gc_index != 6);
     }
-    m_wiimote_boxes[i]->setCurrentIndex(g_wiimote_sources[i]);
-    m_wiimote_buttons[i]->setEnabled(g_wiimote_sources[i] != 0 && g_wiimote_sources[i] != 2);
+
+    const WiimoteSource source = WiimoteCommon::GetSource(int(i));
+    m_wiimote_boxes[i]->setCurrentIndex(int(source));
+    m_wiimote_buttons[i]->setEnabled(source == WiimoteSource::Emulated);
   }
-  m_wiimote_real_balance_board->setChecked(g_wiimote_sources[WIIMOTE_BALANCE_BOARD] ==
-                                           WIIMOTE_SRC_REAL);
+  m_wiimote_real_balance_board->setChecked(WiimoteCommon::GetSource(WIIMOTE_BALANCE_BOARD) ==
+                                           WiimoteSource::Real);
   m_wiimote_speaker_data->setChecked(SConfig::GetInstance().m_WiimoteEnableSpeaker);
   m_wiimote_continuous_scanning->setChecked(SConfig::GetInstance().m_WiimoteContinuousScanning);
 
@@ -514,15 +516,15 @@ void ControllersWindow::SaveSettings()
   SConfig::GetInstance().m_bt_passthrough_enabled = m_wiimote_passthrough->isChecked();
   SConfig::GetInstance().m_BackgroundInput = m_common_bg_input->isChecked();
 
-  WiimoteReal::ChangeWiimoteSource(WIIMOTE_BALANCE_BOARD,
-                                   m_wiimote_real_balance_board->isChecked() ? WIIMOTE_SRC_REAL :
-                                                                               WIIMOTE_SRC_NONE);
+  WiimoteCommon::SetSource(WIIMOTE_BALANCE_BOARD, m_wiimote_real_balance_board->isChecked() ?
+                                                      WiimoteSource::Real :
+                                                      WiimoteSource::None);
 
   for (size_t i = 0; i < m_wiimote_groups.size(); i++)
   {
-    const int index = m_wiimote_boxes[i]->currentIndex();
-    m_wiimote_buttons[i]->setEnabled(index != 0 && index != 2);
-    WiimoteReal::ChangeWiimoteSource(static_cast<u32>(i), index);
+    const auto source = WiimoteSource(m_wiimote_boxes[i]->currentIndex());
+    m_wiimote_buttons[i]->setEnabled(source == WiimoteSource::Emulated);
+    WiimoteCommon::SetSource(static_cast<u32>(i), source);
   }
 
   UICommon::SaveWiimoteSources();

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -115,6 +115,8 @@
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 #include "UICommon/X11Utils.h"
+// This #define within X11/X.h conflicts with our WiimoteSource enum.
+#undef None
 #endif
 
 #if defined(__unix__) || defined(__unix) || defined(__APPLE__)
@@ -1593,7 +1595,7 @@ void MainWindow::OnStartRecording()
     if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
       controllers |= (1 << i);
 
-    if (g_wiimote_sources[i] != WIIMOTE_SRC_NONE)
+    if (WiimoteCommon::GetSource(i) != WiimoteSource::None)
       controllers |= (1 << (i + 4));
   }
 
@@ -1660,7 +1662,7 @@ void MainWindow::ShowTASInput()
 
   for (int i = 0; i < num_wii_controllers; i++)
   {
-    if (g_wiimote_sources[i] == WIIMOTE_SRC_EMU &&
+    if (WiimoteCommon::GetSource(i) == WiimoteSource::Emulated &&
         (!Core::IsRunning() || SConfig::GetInstance().bWii))
     {
       m_wii_tas_input_windows[i]->show();

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -367,12 +367,12 @@ void SaveWiimoteSources()
     secname += (char)('1' + i);
     IniFile::Section& sec = *inifile.GetOrCreateSection(secname);
 
-    sec.Set("Source", (int)g_wiimote_sources[i]);
+    sec.Set("Source", int(WiimoteCommon::GetSource(i)));
   }
 
   std::string secname("BalanceBoard");
   IniFile::Section& sec = *inifile.GetOrCreateSection(secname);
-  sec.Set("Source", (int)g_wiimote_sources[WIIMOTE_BALANCE_BOARD]);
+  sec.Set("Source", int(WiimoteCommon::GetSource(WIIMOTE_BALANCE_BOARD)));
 
   inifile.Save(ini_filename);
 }


### PR DESCRIPTION
Replaced wide usages of `g_wiimote_sources` with get/set functions.
Made the unnamed enum type an enum class, `WiimoteSource`.

Connected real Wii remotes are now added to a "pool" when no open slot is available.
Wii remotes in the pool have LEDs 1 and 4 lit to make it apparent they are not active.
They are disconnected per normal after 5 seconds.
This allows reassigning sources and reordering remotes without the hassle of Bluetooth re-connections.

This is mainly in preparation for Wii remotes in controller interface.
My plan is an option on the Wii remote dialog, "Connect Wii Remotes for input configuration" (or something with a better name).
Enabling it will first fill any "Real" slots but additional remotes will be sent to controller interface.
Disabling the option will send spurious remotes to the pool.

I think this "pool" will make things less horrible for users that are playing around with options.
Making Wii remote connections can be not-fun, especially on Windows/macOS.
Holding on to a connection for a few seconds when between configurations will give users a better experience

Perhaps someone ambitious might make a UI for the pool.
Remotes could be identified with rumble and sent to a slot or controller interface.

This all of course only affects emulated Bluetooth.