### PR TITLE
Jit64: addx optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1342,6 +1342,14 @@ void Jit64::addx(UGeckoInstruction inst)
     {
       LEA(32, Rd, MRegSum(Ra.GetSimpleReg(), Rb.GetSimpleReg()));
     }
+    else if (Ra.IsSimpleReg() && Rb.IsImm() && !inst.OE)
+    {
+      LEA(32, Rd, MDisp(Ra.GetSimpleReg(), Rb.SImm32()));
+    }
+    else if (Rb.IsSimpleReg() && Ra.IsImm() && !inst.OE)
+    {
+      LEA(32, Rd, MDisp(Rb.GetSimpleReg(), Ra.SImm32()));
+    }
     else
     {
       MOV(32, Rd, Ra);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1330,18 +1330,21 @@ void Jit64::addx(UGeckoInstruction inst)
     RCX64Reg Rd = gpr.Bind(d, RCMode::Write);
     RegCache::Realize(Ra, Rb, Rd);
 
-    if (Ra.IsSimpleReg() && Rb.IsSimpleReg() && !inst.OE)
+    if (d == a)
     {
-      LEA(32, Rd, MRegSum(Ra.GetSimpleReg(), Rb.GetSimpleReg()));
+      ADD(32, Rd, Rb);
     }
     else if (d == b)
     {
       ADD(32, Rd, Ra);
     }
+    else if (Ra.IsSimpleReg() && Rb.IsSimpleReg() && !inst.OE)
+    {
+      LEA(32, Rd, MRegSum(Ra.GetSimpleReg(), Rb.GetSimpleReg()));
+    }
     else
     {
-      if (d != a)
-        MOV(32, Rd, Ra);
+      MOV(32, Rd, Ra);
       ADD(32, Rd, Rb);
     }
     if (inst.OE)


### PR DESCRIPTION
* Avoid `LEA` when one of the source registers matches the destination (a simple `ADD` will do in those cases).

Before:
```
45 8D 6C 35 00       lea         r13d,[r13+rsi]
```
After:
```
44 03 EE             add         r13d,esi
```

---

* Use `LEA` with displacement to handle immediate values.

Before:
```
44 8B EE             mov         r13d,esi
41 83 C5 20          add         r13d,20h
```

After:
```
44 8D 6E 20          lea         r13d,[rsi+20h]
```