### PR TITLE
DiscIO: Add out of bounds checks for blob reading

### DIFF
--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -96,6 +96,9 @@ const SectorReader::Cache* SectorReader::GetCacheLine(u64 block_num)
 
 bool SectorReader::Read(u64 offset, u64 size, u8* out_ptr)
 {
+  if (offset + size > GetDataSize())
+    return false;
+
   u64 remain = size;
   u64 block = 0;
   u32 position_in_block = static_cast<u32>(offset % m_block_size);

--- a/Source/Core/DiscIO/CISOBlob.cpp
+++ b/Source/Core/DiscIO/CISOBlob.cpp
@@ -49,6 +49,9 @@ u64 CISOFileReader::GetRawSize() const
 
 bool CISOFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 {
+  if (offset + nbytes > GetDataSize())
+    return false;
+
   while (nbytes != 0)
   {
     u64 const block = offset / m_block_size;

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -375,6 +375,9 @@ DirectoryBlobReader::DirectoryBlobReader(const std::string& game_partition_root,
 
 bool DirectoryBlobReader::Read(u64 offset, u64 length, u8* buffer)
 {
+  if (offset + length > m_data_size)
+    return false;
+
   // TODO: We don't handle raw access to the encrypted area of Wii discs correctly.
   return (m_is_wii ? m_nonpartition_contents : m_gamecube_pseudopartition.GetContents())
       .Read(offset, length, buffer);
@@ -392,6 +395,9 @@ bool DirectoryBlobReader::ReadWiiDecrypted(u64 offset, u64 size, u8* buffer, u64
 
   auto it = m_partitions.find(partition_offset);
   if (it == m_partitions.end())
+    return false;
+
+  if (offset + size > it->second.GetDataSize())
     return false;
 
   return it->second.GetContents().Read(offset, size, buffer);

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -115,6 +115,9 @@ bool WbfsFileReader::ReadHeader()
 
 bool WbfsFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 {
+  if (offset + nbytes > GetDataSize())
+    return false;
+
   while (nbytes)
   {
     u64 read_size;


### PR DESCRIPTION
Fixes the same problem as PR #8557 but for other formats. (No hacks this time!)