### PR TITLE
DolphinQt: Properly hide Wii remote extension motion tabs when no extension is selected.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -360,6 +360,8 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
         AddWidget(EXTENSION_MOTION_SIMULATION_TAB_NAME, extension_motion_simulation);
     m_extension_motion_input_tab =
         AddWidget(EXTENSION_MOTION_INPUT_TAB_NAME, extension_motion_input);
+    // Hide tabs by default. "Nunchuk" selection triggers an event to show them.
+    ShowExtensionMotionTabs(false);
     break;
   }
   case Type::MAPPING_HOTKEYS:


### PR DESCRIPTION
When opening the dialog with extension set to "None" the tabs were incorrectly shown.
The tabs should only be shown when "Nunchuk" is selected (which triggers an event that unhides the tabs).