### PR TITLE
DI MIOS crash fixes

### DIFF
--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -34,7 +34,10 @@ static void ReinitHardware()
   // IOS clears mem2 and overwrites it with pseudo-random data (for security).
   std::memset(Memory::m_pEXRAM, 0, Memory::EXRAM_SIZE);
   // MIOS appears to only reset the DI and the PPC.
-  DVDInterface::Reset();
+  // HACK However, resetting DI will reset the DTK config, which is set by the system menu
+  // (and not by MIOS), causing games that use DTK to break.  Perhaps MIOS doesn't actually
+  // reset DI fully, in such a way that the DTK config isn't cleared?
+  // DVDInterface::Reset();
   PowerPC::Reset();
   Wiimote::ResetAllWiimotes();
   // Note: this is specific to Dolphin and is required because we initialised it in Wii mode.


### PR DESCRIPTION
This should the problem with launching Gamecube games from the Wii menu (through MIOS) that @Miksel12 mentioned on #8394.

My mistake was that `IOS::HLE::GetIOS()` can be empty, and is when launching with MIOS.  This was obscured by the existing checks, which assumed that `IOS::HLE::GetIOS()->GetDeviceByName("/dev/di")` could fail, but only with `GetDeviceByName` returning nothing.  As noted in the (existing!) comment about that behavior, it is hit from `UpdateRunningGameMetadata`, which MIOS calls:

https://github.com/dolphin-emu/dolphin/blob/9596fe75f12b9199057e357dc6ae78f150b1981f/Source/Core/Core/IOS/MIOS.cpp#L85

What tricked me was that `UpdateRunningGameMetadata` is not hit when launching Gamecube games directly (which might be a bug, perhaps explaining [issue 11503](https://bugs.dolphin-emu.org/issues/11503) but I'm not sure), so I never ran into this in my testing.  I do think I tested MIOS at some point, but it must have been before the partition changes that added the `IOS::HLE::GetIOS()` call.

-----

The second change, which is much more hacky, removes the call to `DVDInterface::Reset()` from MIOS.  Resetting it resets the DTK configuration, which causes games that try to use DTK to fail.  Removing the reset completely seems like it's probably incorrect (perhaps the way MIOS resets DI only resets some things but not DTK, but I'm not sure what that actually would look like), but it's better to have the games work.  (Furthermore, the normal gamecube IPL doesn't reset DI after it's finished setting things up to my understanding, so it seems odd for MIOS to do so).