### PR TITLE
Core/DolphinQt: Fix IR Sensitivity slider.

### DIFF
--- a/Source/Core/Core/SysConf.h
+++ b/Source/Core/Core/SysConf.h
@@ -14,6 +14,7 @@
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/NandPaths.h"
+#include "Common/Swap.h"
 
 namespace IOS::HLE::FS
 {
@@ -55,14 +56,17 @@ public:
     {
       if (bytes.size() != sizeof(T))
         return default_value;
+
       T value;
       std::memcpy(&value, bytes.data(), bytes.size());
-      return value;
+      return Common::FromBigEndian(value);
     }
     template <typename T>
     void SetData(T value)
     {
       ASSERT(sizeof(value) == bytes.size());
+
+      value = Common::FromBigEndian(value);
       std::memcpy(bytes.data(), &value, bytes.size());
     }
 

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -177,8 +177,9 @@ void WiiPane::CreateWiiRemoteSettings()
   // i18n: IR stands for infrared and refers to the pointer functionality of Wii Remotes
   m_wiimote_ir_sensitivity_label = new QLabel(tr("IR Sensitivity:"));
   m_wiimote_ir_sensitivity = new QSlider(Qt::Horizontal);
-  m_wiimote_ir_sensitivity->setMinimum(4);
-  m_wiimote_ir_sensitivity->setMaximum(127);
+  // Wii menu saves values from 1 to 5.
+  m_wiimote_ir_sensitivity->setMinimum(1);
+  m_wiimote_ir_sensitivity->setMaximum(5);
 
   // Speaker Volume Slider
   m_wiimote_speaker_volume_label = new QLabel(tr("Speaker Volume:"));


### PR DESCRIPTION
Big-endian values were not converted and the wrong limits were set in the UI.