### PR TITLE
GameSettings: fix Cook Wars main menu

### DIFF
--- a/Data/Sys/GameSettings/RZL.ini
+++ b/Data/Sys/GameSettings/RZL.ini
@@ -1,0 +1,5 @@
+# RZL - Cook Wars
+
+[Video_Settings]
+# main menu text has scrambled letters otherwise
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
The main menu requires safe texture cache or some letters will look scrambled.