### PR TITLE
Use retail console type for GC, instead of devkit

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -174,10 +174,8 @@ void CBoot::SetupGCMemory()
   // Physical Memory Size (24MB on retail)
   PowerPC::HostWrite_U32(Memory::GetRamSizeReal(), 0x80000028);
 
-  // Console type - DevKit  (retail ID == 0x00000003) see YAGCD 4.2.1.1.2
-  // TODO: determine why some games fail when using a retail ID.
-  // (Seem to take different EXI paths, see Ikaruga for example)
-  const u32 console_type = static_cast<u32>(Core::ConsoleType::LatestDevkit);
+  // Console type - Retail (YAGCD 4.2.1.1.2)
+  const u32 console_type = static_cast<u32>(Core::ConsoleType::LatestProductionBoard);
   PowerPC::HostWrite_U32(console_type, 0x8000002C);
 
   // Fake the VI Init of the IPL (YAGCD 4.2.1.4)


### PR DESCRIPTION
This removes some old hack where Gamecube games are marked as running on a devkit; [YAGCD §4.2.1.1.2](http://hitmen.c02.at/files/yagcd/yagcd/chap4.html#sec4.2.1.1.2) explains the different values for 0x8000002C.  Note that Wii titles already use the production version (except when actually running development titles):

https://github.com/dolphin-emu/dolphin/blob/1cc7ef356b9a33814efb290368150a1cceb0a3ed/Source/Core/Core/Boot/Boot_BS2Emu.cpp#L330-L331

I don't know too much of the context of the old hack, but blaming does give [some very old comments](https://github.com/dolphin-emu/dolphin/blame/feea7ebed50313e5986a36b1de8baa03158fff7d/Source/Core/Core/Src/Boot/Boot_BS2Emu.cpp#L75-L80) that claim it is related to DSP timing.  Since that's improved a lot in the past decade, I doubt this hack is no longer needed.

I have not tested this myself, as I do not own Ikaruga.