### PR TITLE
InputCommon: List IMUAccelerometer's Up/Down inputs first for consistency.

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
@@ -17,25 +17,24 @@ namespace ControllerEmu
 IMUAccelerometer::IMUAccelerometer(std::string name, std::string ui_name)
     : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUAccelerometer)
 {
+  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Up")));
+  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Down")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Left")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Right")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Forward")));
   controls.emplace_back(std::make_unique<Input>(Translate, _trans("Backward")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Up")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Down")));
 }
 
 std::optional<IMUAccelerometer::StateData> IMUAccelerometer::GetState() const
 {
-  StateData state;
-  state.x = (controls[0]->control_ref->State() - controls[1]->control_ref->State());
-  state.y = (controls[3]->control_ref->State() - controls[2]->control_ref->State());
-  state.z = (controls[4]->control_ref->State() - controls[5]->control_ref->State());
-
-  if (controls[0]->control_ref->BoundCount() != 0)
-    return state;
-  else
+  if (controls[0]->control_ref->BoundCount() == 0)
     return std::nullopt;
+
+  StateData state;
+  state.x = (controls[2]->control_ref->State() - controls[3]->control_ref->State());
+  state.y = (controls[5]->control_ref->State() - controls[4]->control_ref->State());
+  state.z = (controls[0]->control_ref->State() - controls[1]->control_ref->State());
+  return state;
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -27,15 +27,14 @@ IMUGyroscope::IMUGyroscope(std::string name, std::string ui_name)
 
 std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState() const
 {
+  if (controls[0]->control_ref->BoundCount() == 0)
+    return std::nullopt;
+
   StateData state;
   state.x = (controls[1]->control_ref->State() - controls[0]->control_ref->State());
   state.y = (controls[2]->control_ref->State() - controls[3]->control_ref->State());
   state.z = (controls[4]->control_ref->State() - controls[5]->control_ref->State());
-
-  if (controls[0]->control_ref->BoundCount() != 0)
-    return state;
-  else
-    return std::nullopt;
+  return state;
 }
 
 }  // namespace ControllerEmu


### PR DESCRIPTION
Up and Down inputs are listed first for every other control group: point, tilt, swing, gyro, d-pads and analog-sticks.
This makes `IMUAccelerometer` match.