### PR TITLE
Fix gamecube games not noticing disc changes

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -250,8 +250,9 @@ bool CBoot::DVDReadDiscID(const DiscIO::VolumeDisc& disc, u32 output_address)
   if (!disc.Read(0, buffer.size(), buffer.data(), DiscIO::PARTITION_NONE))
     return false;
   Memory::CopyToEmu(output_address, buffer.data(), buffer.size());
-  // Clear ERROR_NO_DISKID_L, probably should check if that's currently set
-  DVDInterface::SetLowError(DVDInterface::ERROR_READY);
+  // Transition out of the DiscIdNotRead state (which the drive should be in at this point,
+  // on the assumption that this is only used for the first read)
+  DVDInterface::SetDriveState(DVDInterface::DriveState::ReadyNoReadsMade);
   return true;
 }
 

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -855,11 +855,7 @@ void ExecuteCommand(ReplyType reply_type)
 
     case 0x40:  // Read DiscID
       INFO_LOG(DVDINTERFACE, "Read DiscID: buffer %08x", s_DIMAR);
-      // TODO: It doesn't make sense to include DiscChangeDetected here, as it implies that the
-      // drive is not spinning and reading the disc ID shouldn't change it.  However, the Wii Menu
-      // breaks without it.
-      if (s_drive_state == DriveState::DiscIdNotRead ||
-          s_drive_state == DriveState::DiscChangeDetected)
+      if (s_drive_state == DriveState::DiscIdNotRead)
       {
         SetDriveState(DriveState::ReadyNoReadsMade);
       }

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -345,26 +345,8 @@ void Init()
 
   DVDThread::Start();
 
-  Reset();
-  s_DICVR.Hex = 1;  // Disc Channel relies on cover being open when no disc is inserted
-
-  s_auto_change_disc = CoreTiming::RegisterEvent("AutoChangeDisc", AutoChangeDiscCallback);
-  s_eject_disc = CoreTiming::RegisterEvent("EjectDisc", EjectDiscCallback);
-  s_insert_disc = CoreTiming::RegisterEvent("InsertDisc", InsertDiscCallback);
-
-  s_finish_executing_command =
-      CoreTiming::RegisterEvent("FinishExecutingCommand", FinishExecutingCommandCallback);
-
-  u64 userdata = PackFinishExecutingCommandUserdata(ReplyType::DTK, DIInterruptType::TCINT);
-  CoreTiming::ScheduleEvent(0, s_finish_executing_command, userdata);
-}
-
-// This doesn't reset any inserted disc or the cover state.
-void Reset(bool spinup)
-{
-  INFO_LOG(DVDINTERFACE, "Reset %s spinup", spinup ? "with" : "without");
-
   s_DISR.Hex = 0;
+  s_DICVR.Hex = 1;  // Disc Channel relies on cover being open when no disc is inserted
   s_DICMDBUF[0] = 0;
   s_DICMDBUF[1] = 0;
   s_DICMDBUF[2] = 0;
@@ -375,7 +357,17 @@ void Reset(bool spinup)
   s_DICFG.Hex = 0;
   s_DICFG.CONFIG = 1;  // Disable bootrom descrambler
 
-  ResetDrive(spinup);
+  ResetDrive(false);
+
+  s_auto_change_disc = CoreTiming::RegisterEvent("AutoChangeDisc", AutoChangeDiscCallback);
+  s_eject_disc = CoreTiming::RegisterEvent("EjectDisc", EjectDiscCallback);
+  s_insert_disc = CoreTiming::RegisterEvent("InsertDisc", InsertDiscCallback);
+
+  s_finish_executing_command =
+      CoreTiming::RegisterEvent("FinishExecutingCommand", FinishExecutingCommandCallback);
+
+  u64 userdata = PackFinishExecutingCommandUserdata(ReplyType::DTK, DIInterruptType::TCINT);
+  CoreTiming::ScheduleEvent(0, s_finish_executing_command, userdata);
 }
 
 // Resets state on the MN102 chip in the drive itself, but not the DI registers exposed on the

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -1283,8 +1283,11 @@ void FinishExecutingCommand(ReplyType reply_type, DIInterruptType interrupt_type
   else if (reply_type == ReplyType::Interrupt || reply_type == ReplyType::IOS)
     transfer_size = s_DILENGTH;
 
-  s_DIMAR += transfer_size;
-  s_DILENGTH -= transfer_size;
+  if (interrupt_type == DIInterruptType::TCINT)
+  {
+    s_DIMAR += transfer_size;
+    s_DILENGTH -= transfer_size;
+  }
 
   switch (reply_type)
   {

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -375,6 +375,13 @@ void Reset(bool spinup)
   s_DICFG.Hex = 0;
   s_DICFG.CONFIG = 1;  // Disable bootrom descrambler
 
+  ResetDrive(spinup);
+}
+
+// Resets state on the MN102 chip in the drive itself, but not the DI registers exposed on the
+// emulated device, or any inserted disc.
+void ResetDrive(bool spinup)
+{
   s_stream = false;
   s_stop_at_track_end = false;
   s_audio_position = 0;
@@ -453,7 +460,7 @@ void SetDisc(std::unique_ptr<DiscIO::VolumeDisc> disc,
   DVDThread::SetDisc(std::move(disc));
   SetLidOpen();
 
-  Reset(false);
+  ResetDrive(false);
 }
 
 bool IsDiscInside()

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -186,19 +186,19 @@ static void EjectDiscCallback(u64 userdata, s64 cyclesLate);
 static void InsertDiscCallback(u64 userdata, s64 cyclesLate);
 static void FinishExecutingCommandCallback(u64 userdata, s64 cycles_late);
 
-void SetLidOpen();
+static void SetLidOpen();
 
-void UpdateInterrupts();
-void GenerateDIInterrupt(DIInterruptType _DVDInterrupt);
+static void UpdateInterrupts();
+static void GenerateDIInterrupt(DIInterruptType dvd_interrupt);
 
-bool ExecuteReadCommand(u64 dvd_offset, u32 output_address, u32 dvd_length, u32 output_length,
-                        const DiscIO::Partition& partition, ReplyType reply_type,
-                        DIInterruptType* interrupt_type);
+static bool ExecuteReadCommand(u64 dvd_offset, u32 output_address, u32 dvd_length,
+                               u32 output_length, const DiscIO::Partition& partition,
+                               ReplyType reply_type, DIInterruptType* interrupt_type);
 
-u64 PackFinishExecutingCommandUserdata(ReplyType reply_type, DIInterruptType interrupt_type);
+static u64 PackFinishExecutingCommandUserdata(ReplyType reply_type, DIInterruptType interrupt_type);
 
-void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u32 output_address,
-                   ReplyType reply_type);
+static void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition,
+                          u32 output_address, ReplyType reply_type);
 
 void DoState(PointerWrap& p)
 {
@@ -542,7 +542,7 @@ bool AutoChangeDisc()
   return true;
 }
 
-void SetLidOpen()
+static void SetLidOpen()
 {
   u32 old_value = s_DICVR.CVR;
   s_DICVR.CVR = IsDiscInside() ? 0 : 1;
@@ -631,7 +631,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::InvalidWrite<u32>());
 }
 
-void UpdateInterrupts()
+static void UpdateInterrupts()
 {
   const bool set_mask = (s_DISR.DEINT & s_DISR.DEINTMASK) || (s_DISR.TCINT & s_DISR.TCINTMASK) ||
                         (s_DISR.BRKINT & s_DISR.BRKINTMASK) ||
@@ -643,7 +643,7 @@ void UpdateInterrupts()
   CoreTiming::ForceExceptionCheck(50);
 }
 
-void GenerateDIInterrupt(DIInterruptType dvd_interrupt)
+static void GenerateDIInterrupt(DIInterruptType dvd_interrupt)
 {
   switch (dvd_interrupt)
   {
@@ -735,9 +735,9 @@ static bool CheckReadPreconditions()
 }
 
 // Iff false is returned, ScheduleEvent must be used to finish executing the command
-bool ExecuteReadCommand(u64 dvd_offset, u32 output_address, u32 dvd_length, u32 output_length,
-                        const DiscIO::Partition& partition, ReplyType reply_type,
-                        DIInterruptType* interrupt_type)
+static bool ExecuteReadCommand(u64 dvd_offset, u32 output_address, u32 dvd_length,
+                               u32 output_length, const DiscIO::Partition& partition,
+                               ReplyType reply_type, DIInterruptType* interrupt_type)
 {
   if (!CheckReadPreconditions())
   {
@@ -1244,7 +1244,7 @@ void AudioBufferConfig(bool enable_dtk, u8 dtk_buffer_length)
     INFO_LOG(DVDINTERFACE, "DTK disabled");
 }
 
-u64 PackFinishExecutingCommandUserdata(ReplyType reply_type, DIInterruptType interrupt_type)
+static u64 PackFinishExecutingCommandUserdata(ReplyType reply_type, DIInterruptType interrupt_type)
 {
   return (static_cast<u64>(reply_type) << 32) + static_cast<u32>(interrupt_type);
 }
@@ -1317,8 +1317,8 @@ void FinishExecutingCommand(ReplyType reply_type, DIInterruptType interrupt_type
 
 // Determines from a given read request how much of the request is buffered,
 // and how much is required to be read from disc.
-void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u32 output_address,
-                   ReplyType reply_type)
+static void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition,
+                          u32 output_address, ReplyType reply_type)
 {
   // The drive continues to read 1 MiB beyond the last read position when idle.
   // If a future read falls within this window, part of the read may be returned

--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -111,6 +111,7 @@ enum class EjectCause
 
 void Init();
 void Reset(bool spinup = true);
+void ResetDrive(bool spinup);
 void Shutdown();
 void DoState(PointerWrap& p);
 

--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -51,33 +51,41 @@ enum class DICommand : u8
   UnknownEE = 0xee,
 };
 
-// "low" error codes
-constexpr u32 ERROR_READY = 0x0000000;          // Ready.
-constexpr u32 ERROR_COVER = 0x01000000;         // Cover is opened.
-constexpr u32 ERROR_CHANGE_DISK = 0x02000000;   // Disk change.
-constexpr u32 ERROR_NO_DISK_L = 0x03000000;     // No disk.
-constexpr u32 ERROR_MOTOR_STOP_L = 0x04000000;  // Motor stop.
-constexpr u32 ERROR_NO_DISKID_L = 0x05000000;   // Disk ID not read.
-constexpr u32 LOW_ERROR_MASK = 0xff000000;
+// Disc drive state.
+// Reported in error codes as 0 for Ready, and value-1 for the rest
+// (i.e. Ready and ReadyNoReadsMade are both reported as 0)
+enum class DriveState : u8
+{
+  Ready = 0,
+  ReadyNoReadsMade = 1,
+  CoverOpened = 2,
+  DiscChangeDetected = 3,
+  NoMediumPresent = 4,
+  MotorStopped = 5,
+  DiscIdNotRead = 6
+};
 
-// "high" error codes
-constexpr u32 ERROR_NONE = 0x000000;          // No error.
-constexpr u32 ERROR_MOTOR_STOP_H = 0x020400;  // Motor stopped.
-constexpr u32 ERROR_NO_DISKID_H = 0x020401;   // Disk ID not read.
-constexpr u32 ERROR_NO_DISK_H = 0x023a00;     // Medium not present / Cover opened.
-constexpr u32 ERROR_SEEK_NDONE = 0x030200;    // No seek complete.
-constexpr u32 ERROR_READ = 0x031100;          // Unrecovered read error.
-constexpr u32 ERROR_PROTOCOL = 0x040800;      // Transfer protocol error.
-constexpr u32 ERROR_INV_CMD = 0x052000;       // Invalid command operation code.
-constexpr u32 ERROR_AUDIO_BUF = 0x052001;     // Audio Buffer not set.
-constexpr u32 ERROR_BLOCK_OOB = 0x052100;     // Logical block address out of bounds.
-constexpr u32 ERROR_INV_FIELD = 0x052400;     // Invalid field in command packet.
-constexpr u32 ERROR_INV_AUDIO = 0x052401;     // Invalid audio command.
-constexpr u32 ERROR_INV_PERIOD = 0x052402;    // Configuration out of permitted period.
-constexpr u32 ERROR_END_USR_AREA = 0x056300;  // End of user area encountered on this track.
-constexpr u32 ERROR_MEDIUM = 0x062800;        // Medium may have changed.
-constexpr u32 ERROR_MEDIUM_REQ = 0x0b5a01;    // Operator medium removal request.
-constexpr u32 HIGH_ERROR_MASK = 0x00ffffff;
+// Actual drive error codes, which fill the remaining 3 bytes
+// Numbers more or less match a SCSI sense key (1 nybble) followed by SCSI ASC/ASCQ (2 bytes).
+enum class DriveError : u32
+{
+  None = 0x00000,                  // No error.
+  MotorStopped = 0x20400,          // Motor stopped.
+  NoDiscID = 0x20401,              // Disk ID not read.
+  MediumNotPresent = 0x23a00,      // Medium not present / Cover opened.
+  SeekNotDone = 0x30200,           // No seek complete.
+  ReadError = 0x31100,             // Unrecovered read error.
+  ProtocolError = 0x40800,         // Transfer protocol error.
+  InvalidCommand = 0x52000,        // Invalid command operation code.
+  NoAudioBuf = 0x52001,            // Audio Buffer not set.
+  BlockOOB = 0x52100,              // Logical block address out of bounds.
+  InvalidField = 0x52400,          // Invalid field in command packet.
+  InvalidAudioCommand = 0x52401,   // Invalid audio command.
+  InvalidPeriod = 0x52402,         // Configuration out of permitted period.
+  EndOfUserArea = 0x56300,         // End of user area encountered on this track.
+  MediumChanged = 0x62800,         // Medium may have changed.
+  MediumRemovalRequest = 0xb5a01,  // Operator medium removal request.
+};
 
 enum class DIInterruptType : int
 {
@@ -130,8 +138,8 @@ void PerformDecryptingRead(u32 position, u32 length, u32 output_address,
 // Exposed for use by emulated BS2; does not perform any checks on drive state
 void AudioBufferConfig(bool enable_dtk, u8 dtk_buffer_length);
 
-void SetLowError(u32 low_error);
-void SetHighError(u32 high_error);
+void SetDriveState(DriveState state);
+void SetDriveError(DriveError error);
 
 // Used by DVDThread
 void FinishExecutingCommand(ReplyType reply_type, DIInterruptType interrupt_type, s64 cycles_late,

--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -110,7 +110,6 @@ enum class EjectCause
 };
 
 void Init();
-void Reset(bool spinup = true);
 void ResetDrive(bool spinup);
 void Shutdown();
 void DoState(PointerWrap& p);

--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -348,7 +348,7 @@ static void FinishRead(u64 id, s64 cycles_late)
     PanicAlertT("The disc could not be read (at 0x%" PRIx64 " - 0x%" PRIx64 ").",
                 request.dvd_offset, request.dvd_offset + request.length);
 
-    DVDInterface::SetHighError(DVDInterface::ERROR_BLOCK_OOB);
+    DVDInterface::SetDriveError(DVDInterface::DriveError::BlockOOB);
     interrupt = DVDInterface::DIInterruptType::DEINT;
   }
   else

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -266,7 +266,7 @@ std::optional<DI::DIResult> DI::StartIOCtl(const IOCtlRequest& request)
     return DIResult::Success;
   case DIIoctl::DVDLowReset:
   {
-    const bool spinup = Memory::Read_U32(request.address + 4);
+    const bool spinup = Memory::Read_U32(request.buffer_in + 4);
     INFO_LOG(IOS_DI, "DVDLowReset %s spinup", spinup ? "with" : "without");
     DVDInterface::ResetDrive(spinup);
     ResetDIRegisters();

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -268,7 +268,7 @@ std::optional<DI::DIResult> DI::StartIOCtl(const IOCtlRequest& request)
   {
     const bool spinup = Memory::Read_U32(request.address + 4);
     INFO_LOG(IOS_DI, "DVDLowReset %s spinup", spinup ? "with" : "without");
-    DVDInterface::Reset(spinup);
+    DVDInterface::ResetDrive(spinup);
     ResetDIRegisters();
     return DIResult::Success;
   }

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -37,7 +37,7 @@ static void ReinitHardware()
   // HACK However, resetting DI will reset the DTK config, which is set by the system menu
   // (and not by MIOS), causing games that use DTK to break.  Perhaps MIOS doesn't actually
   // reset DI fully, in such a way that the DTK config isn't cleared?
-  // DVDInterface::Reset();
+  // DVDInterface::ResetDrive(true);
   PowerPC::Reset();
   Wiimote::ResetAllWiimotes();
   // Note: this is specific to Dolphin and is required because we initialised it in Wii mode.

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 121;  // Last changed in PR 8988
+constexpr u32 STATE_VERSION = 122;  // Last changed in PR 8571
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Fixes [issue 9019](https://bugs.dolphin-emu.org/issues/9019).

The problems:

* Changing a disc reset the drive state completely (which was something I added in 55a88ba2ed).  This included the DI registers, meaning interrupts would no longer be sent (so the drive errors that were supposed to be sent in that case just weren't making it anywhere).  Now it only resets "internal" properties.  I don't know if this is 100% accurate behavior (and I only changed it for disc changes; other places that reset it were not changed)
* Although that allowed games to detect disc errors if they happened on e.g. request stream status, they still didn't care about errors on the read command (which are far more likely).  This happened to be because games look at `DILENGTH`, and if it's 0 they assume the read was successful even if `DEINT` was fired instead of `TCINT`.  I touched related code in 31105995591 but didn't actually think about the error case.  Note that YAGCD mentions that DILENGTH can indicate the amount of data left over for transfer, but it isn't explicit about that being used in errors.
  
  One possible change here is that it might be possible for commands (especially reads) to fail partway through, in which case DILENGTH would maybe be half-updated instead of the current all-or-nothing situation.  But all-or-nothing seems sufficient for most games.

* There were some other inaccuracies with drive state behavior, based on attempts at reverse-engineering the drive firmware.  There are some old half-archived notes [here](https://web.archive.org/web/20070708050203/http://tmb.elitedvb.net/dvd-game/index.php/StateMachines), which was enough for me to get started (but it's very hard to understand).  These changes required a savestate version bump.
  
  One thing this fixes (when combined with the other changes) is the AudioStream command, which gave the wrong error code in some states, which games wouldn't know what to do with and would then crash.

  A note: at least with Alien Hominid, if a game using DTK is ejected while it is streaming, upon reinsertion it'll start the stream from the beginning again.  I tested and confirmed this behavior on console (specifically my Wii).