### PR TITLE
Update Readme.md to remove mention of Vista.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 ### Desktop
 
 * OS
-    * Windows (7 SP1 or higher is officially supported, but Vista SP2 might also work).
+    * Windows (7 SP1 or higher).
     * Linux.
     * macOS (10.12 Sierra or higher).
     * Unix-like systems other than Linux are not officially supported but might work.


### PR DESCRIPTION
Qt no longer supports Vista.
https://doc.qt.io/qt-5.12/windows.html

Dolphin fails to run on Vista.
https://bugs.dolphin-emu.org/issues/11961