### PR TITLE
VideoCommon/TextureConversionShader: Convert over to using ShaderCode 

### DIFF
--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -1178,7 +1178,7 @@ const AbstractPipeline* ShaderCache::GetEFBCopyToRAMPipeline(const EFBCopyParams
   if (iter != m_efb_copy_to_ram_pipelines.end())
     return iter->second.get();
 
-  const char* const shader_code =
+  const std::string shader_code =
       TextureConversionShaderTiled::GenerateEncodingShader(uid, m_api_type);
   const auto shader = g_renderer->CreateShaderFromSource(ShaderStage::Pixel, shader_code);
   if (!shader)

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -2,30 +2,24 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <array>
-#include <cmath>
-#include <cstdio>
+#include "VideoCommon/TextureConversionShader.h"
+
 #include <map>
 #include <sstream>
 
-#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Common/MsgHandler.h"
-#include "VideoCommon/RenderBase.h"
+#include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/TextureCacheBase.h"
-#include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
-#define WRITE p += sprintf
-
-static char text[16384];
-static bool IntensityConstantAdded = false;
-
 namespace TextureConversionShaderTiled
 {
+static bool IntensityConstantAdded = false;
+
 u16 GetEncodedSampleCount(EFBCopyFormat format)
 {
   switch (format)
@@ -59,89 +53,89 @@ u16 GetEncodedSampleCount(EFBCopyFormat format)
   }
 }
 
-static void WriteHeader(char*& p, APIType ApiType)
+static void WriteHeader(ShaderCode& code, APIType api_type)
 {
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
     // left, top, of source rectangle within source texture
     // width of the destination rectangle, scale_factor (1 or 2)
-    WRITE(p, "UBO_BINDING(std140, 1) uniform PSBlock {\n");
-    WRITE(p, "  int4 position;\n");
-    WRITE(p, "  float y_scale;\n");
-    WRITE(p, "  float gamma_rcp;\n");
-    WRITE(p, "  float2 clamp_tb;\n");
-    WRITE(p, "  float3 filter_coefficients;\n");
-    WRITE(p, "};\n");
+    code.Write("UBO_BINDING(std140, 1) uniform PSBlock {\n"
+               "  int4 position;\n"
+               "  float y_scale;\n"
+               "  float gamma_rcp;\n"
+               "  float2 clamp_tb;\n"
+               "  float3 filter_coefficients;\n"
+               "};\n");
     if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
     {
-      WRITE(p, "VARYING_LOCATION(0) in VertexData {\n");
-      WRITE(p, "  float3 v_tex0;\n");
-      WRITE(p, "};\n");
+      code.Write("VARYING_LOCATION(0) in VertexData {\n"
+                 "  float3 v_tex0;\n"
+                 "};\n");
     }
     else
     {
-      WRITE(p, "VARYING_LOCATION(0) in float3 v_tex0;\n");
+      code.Write("VARYING_LOCATION(0) in float3 v_tex0;\n");
     }
-    WRITE(p, "SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n");
-    WRITE(p, "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n");
+    code.Write("SAMPLER_BINDING(0) uniform sampler2DArray samp0;\n"
+               "FRAGMENT_OUTPUT_LOCATION(0) out float4 ocol0;\n");
   }
   else  // D3D
   {
-    WRITE(p, "cbuffer PSBlock : register(b0) {\n");
-    WRITE(p, "  int4 position;\n");
-    WRITE(p, "  float y_scale;\n");
-    WRITE(p, "  float gamma_rcp;\n");
-    WRITE(p, "  float2 clamp_tb;\n");
-    WRITE(p, "  float3 filter_coefficients;\n");
-    WRITE(p, "};\n");
-    WRITE(p, "sampler samp0 : register(s0);\n");
-    WRITE(p, "Texture2DArray Tex0 : register(t0);\n");
+    code.Write("cbuffer PSBlock : register(b0) {\n"
+               "  int4 position;\n"
+               "  float y_scale;\n"
+               "  float gamma_rcp;\n"
+               "  float2 clamp_tb;\n"
+               "  float3 filter_coefficients;\n"
+               "};\n"
+               "sampler samp0 : register(s0);\n"
+               "Texture2DArray Tex0 : register(t0);\n");
   }
 
   // D3D does not have roundEven(), only round(), which is specified "to the nearest integer".
   // This differs from the roundEven() behavior, but to get consistency across drivers in OpenGL
   // we need to use roundEven().
-  if (ApiType == APIType::D3D)
-    WRITE(p, "#define roundEven(x) round(x)\n");
+  if (api_type == APIType::D3D)
+    code.Write("#define roundEven(x) round(x)\n");
 
   // Alpha channel in the copy is set to 1 the EFB format does not have an alpha channel.
-  WRITE(p, "float4 RGBA8ToRGB8(float4 src)\n");
-  WRITE(p, "{\n");
-  WRITE(p, "  return float4(src.xyz, 1.0);\n");
-  WRITE(p, "}\n");
+  code.Write("float4 RGBA8ToRGB8(float4 src)\n"
+             "{\n"
+             "  return float4(src.xyz, 1.0);\n"
+             "}\n"
 
-  WRITE(p, "float4 RGBA8ToRGBA6(float4 src)\n");
-  WRITE(p, "{\n");
-  WRITE(p, "  int4 val = int4(roundEven(src * 255.0)) >> 2;\n");
-  WRITE(p, "  return float4(val) / 63.0;\n");
-  WRITE(p, "}\n");
+             "float4 RGBA8ToRGBA6(float4 src)\n"
+             "{\n"
+             "  int4 val = int4(roundEven(src * 255.0)) >> 2;\n"
+             "  return float4(val) / 63.0;\n"
+             "}\n"
 
-  WRITE(p, "float4 RGBA8ToRGB565(float4 src)\n");
-  WRITE(p, "{\n");
-  WRITE(p, "  int4 val = int4(roundEven(src * 255.0));\n");
-  WRITE(p, "  val = int4(val.r >> 3, val.g >> 2, val.b >> 3, 1);\n");
-  WRITE(p, "  return float4(val) / float4(31.0, 63.0, 31.0, 1.0);\n");
-  WRITE(p, "}\n");
+             "float4 RGBA8ToRGB565(float4 src)\n"
+             "{\n"
+             "  int4 val = int4(roundEven(src * 255.0));\n"
+             "  val = int4(val.r >> 3, val.g >> 2, val.b >> 3, 1);\n"
+             "  return float4(val) / float4(31.0, 63.0, 31.0, 1.0);\n"
+             "}\n");
 }
 
-static void WriteSampleFunction(char*& p, const EFBCopyParams& params, APIType ApiType)
+static void WriteSampleFunction(ShaderCode& code, const EFBCopyParams& params, APIType api_type)
 {
-  auto WriteSampleOp = [&](int yoffset) {
+  const auto WriteSampleOp = [api_type, &code, &params](int yoffset) {
     if (!params.depth)
     {
       switch (params.efb_format)
       {
       case PEControl::RGB8_Z24:
-        WRITE(p, "RGBA8ToRGB8(");
+        code.Write("RGBA8ToRGB8(");
         break;
       case PEControl::RGBA6_Z24:
-        WRITE(p, "RGBA8ToRGBA6(");
+        code.Write("RGBA8ToRGBA6(");
         break;
       case PEControl::RGB565_Z16:
-        WRITE(p, "RGBA8ToRGB565(");
+        code.Write("RGBA8ToRGB565(");
         break;
       default:
-        WRITE(p, "(");
+        code.Write("(");
         break;
       }
     }
@@ -149,691 +143,699 @@ static void WriteSampleFunction(char*& p, const EFBCopyParams& params, APIType A
     {
       // Handle D3D depth inversion.
       if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange)
-        WRITE(p, "1.0 - (");
+        code.Write("1.0 - (");
       else
-        WRITE(p, "(");
+        code.Write("(");
     }
 
-    if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
-      WRITE(p, "texture(samp0, float3(");
+    if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
+      code.Write("texture(samp0, float3(");
     else
-      WRITE(p, "Tex0.Sample(samp0, float3(");
+      code.Write("Tex0.Sample(samp0, float3(");
 
-    WRITE(p, "uv.x + float(xoffset) * pixel_size.x, ");
+    code.Write("uv.x + float(xoffset) * pixel_size.x, ");
 
     // Reverse the direction for OpenGL, since positive numbers are distance from the bottom row.
     if (yoffset != 0)
     {
-      if (ApiType == APIType::OpenGL)
-        WRITE(p, "clamp(uv.y - float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
+      if (api_type == APIType::OpenGL)
+        code.Write("clamp(uv.y - float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
       else
-        WRITE(p, "clamp(uv.y + float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
+        code.Write("clamp(uv.y + float(%d) * pixel_size.y, clamp_tb.x, clamp_tb.y)", yoffset);
     }
     else
     {
-      WRITE(p, "uv.y");
+      code.Write("uv.y");
     }
 
-    WRITE(p, ", 0.0)))");
+    code.Write(", 0.0)))");
   };
 
   // The copy filter applies to both color and depth copies. This has been verified on hardware.
   // The filter is only applied to the RGB channels, the alpha channel is left intact.
-  WRITE(p, "float4 SampleEFB(float2 uv, float2 pixel_size, int xoffset)\n");
-  WRITE(p, "{\n");
+  code.Write("float4 SampleEFB(float2 uv, float2 pixel_size, int xoffset)\n"
+             "{\n");
   if (params.copy_filter)
   {
-    WRITE(p, "  float4 prev_row = ");
+    code.Write("  float4 prev_row = ");
     WriteSampleOp(-1);
-    WRITE(p, ";\n");
-    WRITE(p, "  float4 current_row = ");
+    code.Write(";\n"
+               "  float4 current_row = ");
     WriteSampleOp(0);
-    WRITE(p, ";\n");
-    WRITE(p, "  float4 next_row = ");
+    code.Write(";\n"
+               "  float4 next_row = ");
     WriteSampleOp(1);
-    WRITE(p, ";\n");
-    WRITE(p, "  return float4(min(prev_row.rgb * filter_coefficients[0] +\n"
-             "                      current_row.rgb * filter_coefficients[1] +\n"
-             "                      next_row.rgb * filter_coefficients[2], \n"
-             "                    float3(1, 1, 1)), current_row.a);\n");
+    code.Write(";\n"
+               "  return float4(min(prev_row.rgb * filter_coefficients[0] +\n"
+               "                      current_row.rgb * filter_coefficients[1] +\n"
+               "                      next_row.rgb * filter_coefficients[2], \n"
+               "                    float3(1, 1, 1)), current_row.a);\n");
   }
   else
   {
-    WRITE(p, "  float4 current_row = ");
+    code.Write("  float4 current_row = ");
     WriteSampleOp(0);
-    WRITE(p, ";\n");
-    WRITE(p, "return float4(min(current_row.rgb * filter_coefficients[1], float3(1, 1, 1)),\n"
-             "              current_row.a);\n");
+    code.Write(";\n"
+               "return float4(min(current_row.rgb * filter_coefficients[1], float3(1, 1, 1)),\n"
+               "              current_row.a);\n");
   }
-  WRITE(p, "}\n");
+  code.Write("}\n");
 }
 
-// block dimensions : widthStride, heightStride
-// texture dims : width, height, x offset, y offset
-static void WriteSwizzler(char*& p, const EFBCopyParams& params, EFBCopyFormat format,
-                          APIType ApiType)
+// Block dimensions   : widthStride, heightStride
+// Texture dimensions : width, height, x offset, y offset
+static void WriteSwizzler(ShaderCode& code, const EFBCopyParams& params, EFBCopyFormat format,
+                          APIType api_type)
 {
-  WriteHeader(p, ApiType);
-  WriteSampleFunction(p, params, ApiType);
+  WriteHeader(code, api_type);
+  WriteSampleFunction(code, params, api_type);
 
-  if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
+  if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
-    WRITE(p, "void main()\n");
-    WRITE(p, "{\n"
-             "  int2 sampleUv;\n"
-             "  int2 uv1 = int2(gl_FragCoord.xy);\n");
+    code.Write("void main()\n"
+               "{\n"
+               "  int2 sampleUv;\n"
+               "  int2 uv1 = int2(gl_FragCoord.xy);\n");
   }
   else  // D3D
   {
-    WRITE(p, "void main(\n");
-    WRITE(p, "  in float3 v_tex0 : TEXCOORD0,\n");
-    WRITE(p, "  in float4 rawpos : SV_Position,\n");
-    WRITE(p, "  out float4 ocol0 : SV_Target)\n");
-    WRITE(p, "{\n"
-             "  int2 sampleUv;\n"
-             "  int2 uv1 = int2(rawpos.xy);\n");
+    code.Write("void main(\n"
+               "  in float3 v_tex0 : TEXCOORD0,\n"
+               "  in float4 rawpos : SV_Position,\n"
+               "  out float4 ocol0 : SV_Target)\n"
+               "{\n"
+               "  int2 sampleUv;\n"
+               "  int2 uv1 = int2(rawpos.xy);\n");
   }
 
-  int blkW = TexDecoder_GetEFBCopyBlockWidthInTexels(format);
-  int blkH = TexDecoder_GetEFBCopyBlockHeightInTexels(format);
+  const int blkW = TexDecoder_GetEFBCopyBlockWidthInTexels(format);
+  const int blkH = TexDecoder_GetEFBCopyBlockHeightInTexels(format);
   int samples = GetEncodedSampleCount(format);
 
-  WRITE(p, "  int x_block_position = (uv1.x >> %d) << %d;\n", IntLog2(blkH * blkW / samples),
-        IntLog2(blkW));
-  WRITE(p, "  int y_block_position = uv1.y << %d;\n", IntLog2(blkH));
+  code.Write("  int x_block_position = (uv1.x >> %d) << %d;\n", IntLog2(blkH * blkW / samples),
+             IntLog2(blkW));
+  code.Write("  int y_block_position = uv1.y << %d;\n", IntLog2(blkH));
   if (samples == 1)
   {
     // With samples == 1, we write out pairs of blocks; one A8R8, one G8B8.
-    WRITE(p, "  bool first = (uv1.x & %d) == 0;\n", blkH * blkW / 2);
+    code.Write("  bool first = (uv1.x & %d) == 0;\n", blkH * blkW / 2);
     samples = 2;
   }
-  WRITE(p, "  int offset_in_block = uv1.x & %d;\n", (blkH * blkW / samples) - 1);
-  WRITE(p, "  int y_offset_in_block = offset_in_block >> %d;\n", IntLog2(blkW / samples));
-  WRITE(p, "  int x_offset_in_block = (offset_in_block & %d) << %d;\n", (blkW / samples) - 1,
-        IntLog2(samples));
+  code.Write("  int offset_in_block = uv1.x & %d;\n", (blkH * blkW / samples) - 1);
+  code.Write("  int y_offset_in_block = offset_in_block >> %d;\n", IntLog2(blkW / samples));
+  code.Write("  int x_offset_in_block = (offset_in_block & %d) << %d;\n", (blkW / samples) - 1,
+             IntLog2(samples));
 
-  WRITE(p, "  sampleUv.x = x_block_position + x_offset_in_block;\n");
-  WRITE(p, "  sampleUv.y = y_block_position + y_offset_in_block;\n");
+  code.Write("  sampleUv.x = x_block_position + x_offset_in_block;\n"
+             "  sampleUv.y = y_block_position + y_offset_in_block;\n");
 
-  WRITE(p,
-        "  float2 uv0 = float2(sampleUv);\n");  // sampleUv is the sample position in (int)gx_coords
-  WRITE(p, "  uv0 += float2(0.5, 0.5);\n");     // move to center of pixel
-  WRITE(p, "  uv0 *= float(position.w);\n");  // scale by two if needed (also move to pixel borders
-                                              // so that linear filtering will average adjacent
-                                              // pixel)
-  WRITE(p, "  uv0 += float2(position.xy);\n");                    // move to copied rect
-  WRITE(p, "  uv0 /= float2(%d, %d);\n", EFB_WIDTH, EFB_HEIGHT);  // normalize to [0:1]
-  WRITE(p, "  uv0 /= float2(1, y_scale);\n");                     // apply the y scaling
-  if (ApiType == APIType::OpenGL)                                 // ogl has to flip up and down
+  // sampleUv is the sample position in (int)gx_coords
+  code.Write("  float2 uv0 = float2(sampleUv);\n");
+  // Move to center of pixel
+  code.Write("  uv0 += float2(0.5, 0.5);\n");
+  // Scale by two if needed (also move to pixel borders
+  // so that linear filtering will average adjacent
+  // pixel)
+  code.Write("  uv0 *= float(position.w);\n");
+
+  // Move to copied rect
+  code.Write("  uv0 += float2(position.xy);\n");
+  // Normalize to [0:1]
+  code.Write("  uv0 /= float2(%d, %d);\n", EFB_WIDTH, EFB_HEIGHT);
+  // Apply the y scaling
+  code.Write("  uv0 /= float2(1, y_scale);\n");
+  // OGL has to flip up and down
+  if (api_type == APIType::OpenGL)
   {
-    WRITE(p, "  uv0.y = 1.0-uv0.y;\n");
+    code.Write("  uv0.y = 1.0-uv0.y;\n");
   }
 
-  WRITE(p, "  float2 pixel_size = float2(position.w, position.w) / float2(%d, %d);\n", EFB_WIDTH,
-        EFB_HEIGHT);
+  code.Write("  float2 pixel_size = float2(position.w, position.w) / float2(%d, %d);\n", EFB_WIDTH,
+             EFB_HEIGHT);
 }
 
-static void WriteSampleColor(char*& p, const char* colorComp, const char* dest, int xoffset,
-                             APIType ApiType, const EFBCopyParams& params)
+static void WriteSampleColor(ShaderCode& code, const char* colorComp, const char* dest, int xoffset,
+                             APIType api_type, const EFBCopyParams& params)
 {
-  WRITE(p, "  %s = SampleEFB(uv0, pixel_size, %d).%s;\n", dest, xoffset, colorComp);
+  code.Write("  %s = SampleEFB(uv0, pixel_size, %d).%s;\n", dest, xoffset, colorComp);
 }
 
-static void WriteColorToIntensity(char*& p, const char* src, const char* dest)
+static void WriteColorToIntensity(ShaderCode& code, const char* src, const char* dest)
 {
   if (!IntensityConstantAdded)
   {
-    WRITE(p, "  float4 IntensityConst = float4(0.257f,0.504f,0.098f,0.0625f);\n");
+    code.Write("  float4 IntensityConst = float4(0.257f,0.504f,0.098f,0.0625f);\n");
     IntensityConstantAdded = true;
   }
-  WRITE(p, "  %s = dot(IntensityConst.rgb, %s.rgb);\n", dest, src);
+  code.Write("  %s = dot(IntensityConst.rgb, %s.rgb);\n", dest, src);
   // don't add IntensityConst.a yet, because doing it later is faster and uses less instructions,
   // due to vectorization
 }
 
-static void WriteToBitDepth(char*& p, u8 depth, const char* src, const char* dest)
+static void WriteToBitDepth(ShaderCode& code, u8 depth, const char* src, const char* dest)
 {
-  WRITE(p, "  %s = floor(%s * 255.0 / exp2(8.0 - %d.0));\n", dest, src, depth);
+  code.Write("  %s = floor(%s * 255.0 / exp2(8.0 - %d.0));\n", dest, src, depth);
 }
 
-static void WriteEncoderEnd(char*& p)
+static void WriteEncoderEnd(ShaderCode& code)
 {
-  WRITE(p, "}\n");
+  code.Write("}\n");
   IntensityConstantAdded = false;
 }
 
-static void WriteI8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteI8Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::R8, ApiType);
-  WRITE(p, "  float3 texSample;\n");
+  WriteSwizzler(code, params, EFBCopyFormat::R8, api_type);
+  code.Write("  float3 texSample;\n");
 
-  WriteSampleColor(p, "rgb", "texSample", 0, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.b");
+  WriteSampleColor(code, "rgb", "texSample", 0, api_type, params);
+  WriteColorToIntensity(code, "texSample", "ocol0.b");
 
-  WriteSampleColor(p, "rgb", "texSample", 1, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.g");
+  WriteSampleColor(code, "rgb", "texSample", 1, api_type, params);
+  WriteColorToIntensity(code, "texSample", "ocol0.g");
 
-  WriteSampleColor(p, "rgb", "texSample", 2, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.r");
+  WriteSampleColor(code, "rgb", "texSample", 2, api_type, params);
+  WriteColorToIntensity(code, "texSample", "ocol0.r");
 
-  WriteSampleColor(p, "rgb", "texSample", 3, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "ocol0.a");
+  WriteSampleColor(code, "rgb", "texSample", 3, api_type, params);
+  WriteColorToIntensity(code, "texSample", "ocol0.a");
 
-  WRITE(p, "  ocol0.rgba += IntensityConst.aaaa;\n");  // see WriteColorToIntensity
+  // See WriteColorToIntensity
+  code.Write("  ocol0.rgba += IntensityConst.aaaa;\n");
 
-  WriteEncoderEnd(p);
+  WriteEncoderEnd(code);
 }
 
-static void WriteI4Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteI4Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::R4, ApiType);
-  WRITE(p, "  float3 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
+  WriteSwizzler(code, params, EFBCopyFormat::R4, api_type);
+  code.Write("  float3 texSample;\n"
+             "  float4 color0;\n"
+             "  float4 color1;\n");
 
-  WriteSampleColor(p, "rgb", "texSample", 0, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.b");
+  WriteSampleColor(code, "rgb", "texSample", 0, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color0.b");
 
-  WriteSampleColor(p, "rgb", "texSample", 1, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.b");
+  WriteSampleColor(code, "rgb", "texSample", 1, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color1.b");
 
-  WriteSampleColor(p, "rgb", "texSample", 2, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.g");
+  WriteSampleColor(code, "rgb", "texSample", 2, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color0.g");
 
-  WriteSampleColor(p, "rgb", "texSample", 3, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.g");
+  WriteSampleColor(code, "rgb", "texSample", 3, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color1.g");
 
-  WriteSampleColor(p, "rgb", "texSample", 4, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.r");
+  WriteSampleColor(code, "rgb", "texSample", 4, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color0.r");
 
-  WriteSampleColor(p, "rgb", "texSample", 5, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.r");
+  WriteSampleColor(code, "rgb", "texSample", 5, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color1.r");
 
-  WriteSampleColor(p, "rgb", "texSample", 6, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color0.a");
+  WriteSampleColor(code, "rgb", "texSample", 6, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color0.a");
 
-  WriteSampleColor(p, "rgb", "texSample", 7, ApiType, params);
-  WriteColorToIntensity(p, "texSample", "color1.a");
+  WriteSampleColor(code, "rgb", "texSample", 7, api_type, params);
+  WriteColorToIntensity(code, "texSample", "color1.a");
 
-  WRITE(p, "  color0.rgba += IntensityConst.aaaa;\n");
-  WRITE(p, "  color1.rgba += IntensityConst.aaaa;\n");
+  code.Write("  color0.rgba += IntensityConst.aaaa;\n"
+             "  color1.rgba += IntensityConst.aaaa;\n");
 
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
+  WriteToBitDepth(code, 4, "color0", "color0");
+  WriteToBitDepth(code, 4, "color1", "color1");
 
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
+  code.Write("  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(code);
 }
 
-static void WriteIA8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteIA8Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
-  WRITE(p, "  float4 texSample;\n");
+  WriteSwizzler(code, params, EFBCopyFormat::RA8, api_type);
+  code.Write("  float4 texSample;\n");
 
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
-  WRITE(p, "  ocol0.b = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "ocol0.g");
+  WriteSampleColor(code, "rgba", "texSample", 0, api_type, params);
+  code.Write("  ocol0.b = texSample.a;\n");
+  WriteColorToIntensity(code, "texSample", "ocol0.g");
 
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
-  WRITE(p, "  ocol0.r = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "ocol0.a");
+  WriteSampleColor(code, "rgba", "texSample", 1, api_type, params);
+  code.Write("  ocol0.r = texSample.a;\n");
+  WriteColorToIntensity(code, "texSample", "ocol0.a");
 
-  WRITE(p, "  ocol0.ga += IntensityConst.aa;\n");
+  code.Write("  ocol0.ga += IntensityConst.aa;\n");
 
-  WriteEncoderEnd(p);
+  WriteEncoderEnd(code);
 }
 
-static void WriteIA4Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteIA4Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::RA4, ApiType);
-  WRITE(p, "  float4 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
+  WriteSwizzler(code, params, EFBCopyFormat::RA4, api_type);
+  code.Write("  float4 texSample;\n"
+             "  float4 color0;\n"
+             "  float4 color1;\n");
 
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
-  WRITE(p, "  color0.b = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.b");
+  WriteSampleColor(code, "rgba", "texSample", 0, api_type, params);
+  code.Write("  color0.b = texSample.a;\n");
+  WriteColorToIntensity(code, "texSample", "color1.b");
 
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
-  WRITE(p, "  color0.g = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.g");
+  WriteSampleColor(code, "rgba", "texSample", 1, api_type, params);
+  code.Write("  color0.g = texSample.a;\n");
+  WriteColorToIntensity(code, "texSample", "color1.g");
 
-  WriteSampleColor(p, "rgba", "texSample", 2, ApiType, params);
-  WRITE(p, "  color0.r = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.r");
+  WriteSampleColor(code, "rgba", "texSample", 2, api_type, params);
+  code.Write("  color0.r = texSample.a;\n");
+  WriteColorToIntensity(code, "texSample", "color1.r");
 
-  WriteSampleColor(p, "rgba", "texSample", 3, ApiType, params);
-  WRITE(p, "  color0.a = texSample.a;\n");
-  WriteColorToIntensity(p, "texSample", "color1.a");
+  WriteSampleColor(code, "rgba", "texSample", 3, api_type, params);
+  code.Write("  color0.a = texSample.a;\n");
+  WriteColorToIntensity(code, "texSample", "color1.a");
 
-  WRITE(p, "  color1.rgba += IntensityConst.aaaa;\n");
+  code.Write("  color1.rgba += IntensityConst.aaaa;\n");
 
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
+  WriteToBitDepth(code, 4, "color0", "color0");
+  WriteToBitDepth(code, 4, "color1", "color1");
 
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
+  code.Write("  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(code);
 }
 
-static void WriteRGB565Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteRGB565Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::RGB565, ApiType);
-  WRITE(p, "  float3 texSample0;\n");
-  WRITE(p, "  float3 texSample1;\n");
+  WriteSwizzler(code, params, EFBCopyFormat::RGB565, api_type);
+  code.Write("  float3 texSample0;\n"
+             "  float3 texSample1;\n");
 
-  WriteSampleColor(p, "rgb", "texSample0", 0, ApiType, params);
-  WriteSampleColor(p, "rgb", "texSample1", 1, ApiType, params);
-  WRITE(p, "  float2 texRs = float2(texSample0.r, texSample1.r);\n");
-  WRITE(p, "  float2 texGs = float2(texSample0.g, texSample1.g);\n");
-  WRITE(p, "  float2 texBs = float2(texSample0.b, texSample1.b);\n");
+  WriteSampleColor(code, "rgb", "texSample0", 0, api_type, params);
+  WriteSampleColor(code, "rgb", "texSample1", 1, api_type, params);
+  code.Write("  float2 texRs = float2(texSample0.r, texSample1.r);\n"
+             "  float2 texGs = float2(texSample0.g, texSample1.g);\n"
+             "  float2 texBs = float2(texSample0.b, texSample1.b);\n");
 
-  WriteToBitDepth(p, 6, "texGs", "float2 gInt");
-  WRITE(p, "  float2 gUpper = floor(gInt / 8.0);\n");
-  WRITE(p, "  float2 gLower = gInt - gUpper * 8.0;\n");
+  WriteToBitDepth(code, 6, "texGs", "float2 gInt");
+  code.Write("  float2 gUpper = floor(gInt / 8.0);\n"
+             "  float2 gLower = gInt - gUpper * 8.0;\n");
 
-  WriteToBitDepth(p, 5, "texRs", "ocol0.br");
-  WRITE(p, "  ocol0.br = ocol0.br * 8.0 + gUpper;\n");
-  WriteToBitDepth(p, 5, "texBs", "ocol0.ga");
-  WRITE(p, "  ocol0.ga = ocol0.ga + gLower * 32.0;\n");
+  WriteToBitDepth(code, 5, "texRs", "ocol0.br");
+  code.Write("  ocol0.br = ocol0.br * 8.0 + gUpper;\n");
+  WriteToBitDepth(code, 5, "texBs", "ocol0.ga");
+  code.Write("  ocol0.ga = ocol0.ga + gLower * 32.0;\n");
 
-  WRITE(p, "  ocol0 = ocol0 / 255.0;\n");
-  WriteEncoderEnd(p);
+  code.Write("  ocol0 = ocol0 / 255.0;\n");
+  WriteEncoderEnd(code);
 }
 
-static void WriteRGB5A3Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteRGB5A3Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::RGB5A3, ApiType);
+  WriteSwizzler(code, params, EFBCopyFormat::RGB5A3, api_type);
 
-  WRITE(p, "  float4 texSample;\n");
-  WRITE(p, "  float color0;\n");
-  WRITE(p, "  float gUpper;\n");
-  WRITE(p, "  float gLower;\n");
+  code.Write("  float4 texSample;\n"
+             "  float color0;\n"
+             "  float gUpper;\n"
+             "  float gLower;\n");
 
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
+  WriteSampleColor(code, "rgba", "texSample", 0, api_type, params);
 
   // 0.8784 = 224 / 255 which is the maximum alpha value that can be represented in 3 bits
-  WRITE(p, "if(texSample.a > 0.878f) {\n");
+  code.Write("if(texSample.a > 0.878f) {\n");
 
-  WriteToBitDepth(p, 5, "texSample.g", "color0");
-  WRITE(p, "  gUpper = floor(color0 / 8.0);\n");
-  WRITE(p, "  gLower = color0 - gUpper * 8.0;\n");
+  WriteToBitDepth(code, 5, "texSample.g", "color0");
+  code.Write("  gUpper = floor(color0 / 8.0);\n"
+             "  gLower = color0 - gUpper * 8.0;\n");
 
-  WriteToBitDepth(p, 5, "texSample.r", "ocol0.b");
-  WRITE(p, "  ocol0.b = ocol0.b * 4.0 + gUpper + 128.0;\n");
-  WriteToBitDepth(p, 5, "texSample.b", "ocol0.g");
-  WRITE(p, "  ocol0.g = ocol0.g + gLower * 32.0;\n");
+  WriteToBitDepth(code, 5, "texSample.r", "ocol0.b");
+  code.Write("  ocol0.b = ocol0.b * 4.0 + gUpper + 128.0;\n");
+  WriteToBitDepth(code, 5, "texSample.b", "ocol0.g");
+  code.Write("  ocol0.g = ocol0.g + gLower * 32.0;\n");
 
-  WRITE(p, "} else {\n");
+  code.Write("} else {\n");
 
-  WriteToBitDepth(p, 4, "texSample.r", "ocol0.b");
-  WriteToBitDepth(p, 4, "texSample.b", "ocol0.g");
+  WriteToBitDepth(code, 4, "texSample.r", "ocol0.b");
+  WriteToBitDepth(code, 4, "texSample.b", "ocol0.g");
 
-  WriteToBitDepth(p, 3, "texSample.a", "color0");
-  WRITE(p, "ocol0.b = ocol0.b + color0 * 16.0;\n");
-  WriteToBitDepth(p, 4, "texSample.g", "color0");
-  WRITE(p, "ocol0.g = ocol0.g + color0 * 16.0;\n");
+  WriteToBitDepth(code, 3, "texSample.a", "color0");
+  code.Write("ocol0.b = ocol0.b + color0 * 16.0;\n");
+  WriteToBitDepth(code, 4, "texSample.g", "color0");
+  code.Write("ocol0.g = ocol0.g + color0 * 16.0;\n");
 
-  WRITE(p, "}\n");
+  code.Write("}\n");
 
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
+  WriteSampleColor(code, "rgba", "texSample", 1, api_type, params);
 
-  WRITE(p, "if(texSample.a > 0.878f) {\n");
+  code.Write("if(texSample.a > 0.878f) {\n");
 
-  WriteToBitDepth(p, 5, "texSample.g", "color0");
-  WRITE(p, "  gUpper = floor(color0 / 8.0);\n");
-  WRITE(p, "  gLower = color0 - gUpper * 8.0;\n");
+  WriteToBitDepth(code, 5, "texSample.g", "color0");
+  code.Write("  gUpper = floor(color0 / 8.0);\n"
+             "  gLower = color0 - gUpper * 8.0;\n");
 
-  WriteToBitDepth(p, 5, "texSample.r", "ocol0.r");
-  WRITE(p, "  ocol0.r = ocol0.r * 4.0 + gUpper + 128.0;\n");
-  WriteToBitDepth(p, 5, "texSample.b", "ocol0.a");
-  WRITE(p, "  ocol0.a = ocol0.a + gLower * 32.0;\n");
+  WriteToBitDepth(code, 5, "texSample.r", "ocol0.r");
+  code.Write("  ocol0.r = ocol0.r * 4.0 + gUpper + 128.0;\n");
+  WriteToBitDepth(code, 5, "texSample.b", "ocol0.a");
+  code.Write("  ocol0.a = ocol0.a + gLower * 32.0;\n");
 
-  WRITE(p, "} else {\n");
+  code.Write("} else {\n");
 
-  WriteToBitDepth(p, 4, "texSample.r", "ocol0.r");
-  WriteToBitDepth(p, 4, "texSample.b", "ocol0.a");
+  WriteToBitDepth(code, 4, "texSample.r", "ocol0.r");
+  WriteToBitDepth(code, 4, "texSample.b", "ocol0.a");
 
-  WriteToBitDepth(p, 3, "texSample.a", "color0");
-  WRITE(p, "ocol0.r = ocol0.r + color0 * 16.0;\n");
-  WriteToBitDepth(p, 4, "texSample.g", "color0");
-  WRITE(p, "ocol0.a = ocol0.a + color0 * 16.0;\n");
+  WriteToBitDepth(code, 3, "texSample.a", "color0");
+  code.Write("ocol0.r = ocol0.r + color0 * 16.0;\n");
+  WriteToBitDepth(code, 4, "texSample.g", "color0");
+  code.Write("ocol0.a = ocol0.a + color0 * 16.0;\n");
 
-  WRITE(p, "}\n");
+  code.Write("}\n");
 
-  WRITE(p, "  ocol0 = ocol0 / 255.0;\n");
-  WriteEncoderEnd(p);
+  code.Write("  ocol0 = ocol0 / 255.0;\n");
+  WriteEncoderEnd(code);
 }
 
-static void WriteRGBA8Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteRGBA8Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::RGBA8, ApiType);
+  WriteSwizzler(code, params, EFBCopyFormat::RGBA8, api_type);
 
-  WRITE(p, "  float4 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
+  code.Write("  float4 texSample;\n"
+             "  float4 color0;\n"
+             "  float4 color1;\n");
 
-  WriteSampleColor(p, "rgba", "texSample", 0, ApiType, params);
-  WRITE(p, "  color0.b = texSample.a;\n");
-  WRITE(p, "  color0.g = texSample.r;\n");
-  WRITE(p, "  color1.b = texSample.g;\n");
-  WRITE(p, "  color1.g = texSample.b;\n");
+  WriteSampleColor(code, "rgba", "texSample", 0, api_type, params);
+  code.Write("  color0.b = texSample.a;\n"
+             "  color0.g = texSample.r;\n"
+             "  color1.b = texSample.g;\n"
+             "  color1.g = texSample.b;\n");
 
-  WriteSampleColor(p, "rgba", "texSample", 1, ApiType, params);
-  WRITE(p, "  color0.r = texSample.a;\n");
-  WRITE(p, "  color0.a = texSample.r;\n");
-  WRITE(p, "  color1.r = texSample.g;\n");
-  WRITE(p, "  color1.a = texSample.b;\n");
+  WriteSampleColor(code, "rgba", "texSample", 1, api_type, params);
+  code.Write("  color0.r = texSample.a;\n"
+             "  color0.a = texSample.r;\n"
+             "  color1.r = texSample.g;\n"
+             "  color1.a = texSample.b;\n");
 
-  WRITE(p, "  ocol0 = first ? color0 : color1;\n");
+  code.Write("  ocol0 = first ? color0 : color1;\n");
 
-  WriteEncoderEnd(p);
+  WriteEncoderEnd(code);
 }
 
-static void WriteC4Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::R4, ApiType);
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
-
-  WriteSampleColor(p, comp, "color0.b", 0, ApiType, params);
-  WriteSampleColor(p, comp, "color1.b", 1, ApiType, params);
-  WriteSampleColor(p, comp, "color0.g", 2, ApiType, params);
-  WriteSampleColor(p, comp, "color1.g", 3, ApiType, params);
-  WriteSampleColor(p, comp, "color0.r", 4, ApiType, params);
-  WriteSampleColor(p, comp, "color1.r", 5, ApiType, params);
-  WriteSampleColor(p, comp, "color0.a", 6, ApiType, params);
-  WriteSampleColor(p, comp, "color1.a", 7, ApiType, params);
-
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
-
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteC8Encoder(char*& p, const char* comp, APIType ApiType, const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::R8, ApiType);
-
-  WriteSampleColor(p, comp, "ocol0.b", 0, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.g", 1, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.r", 2, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.a", 3, ApiType, params);
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteCC4Encoder(char*& p, const char* comp, APIType ApiType,
-                            const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RA4, ApiType);
-  WRITE(p, "  float2 texSample;\n");
-  WRITE(p, "  float4 color0;\n");
-  WRITE(p, "  float4 color1;\n");
-
-  WriteSampleColor(p, comp, "texSample", 0, ApiType, params);
-  WRITE(p, "  color0.b = texSample.x;\n");
-  WRITE(p, "  color1.b = texSample.y;\n");
-
-  WriteSampleColor(p, comp, "texSample", 1, ApiType, params);
-  WRITE(p, "  color0.g = texSample.x;\n");
-  WRITE(p, "  color1.g = texSample.y;\n");
-
-  WriteSampleColor(p, comp, "texSample", 2, ApiType, params);
-  WRITE(p, "  color0.r = texSample.x;\n");
-  WRITE(p, "  color1.r = texSample.y;\n");
-
-  WriteSampleColor(p, comp, "texSample", 3, ApiType, params);
-  WRITE(p, "  color0.a = texSample.x;\n");
-  WRITE(p, "  color1.a = texSample.y;\n");
-
-  WriteToBitDepth(p, 4, "color0", "color0");
-  WriteToBitDepth(p, 4, "color1", "color1");
-
-  WRITE(p, "  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
-  WriteEncoderEnd(p);
-}
-
-static void WriteCC8Encoder(char*& p, const char* comp, APIType ApiType,
-                            const EFBCopyParams& params)
-{
-  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
-
-  WriteSampleColor(p, comp, "ocol0.bg", 0, ApiType, params);
-  WriteSampleColor(p, comp, "ocol0.ra", 1, ApiType, params);
-
-  WriteEncoderEnd(p);
-}
-
-static void WriteZ8Encoder(char*& p, const char* multiplier, APIType ApiType,
+static void WriteC4Encoder(ShaderCode& code, const char* comp, APIType api_type,
                            const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::G8, ApiType);
+  WriteSwizzler(code, params, EFBCopyFormat::R4, api_type);
+  code.Write("  float4 color0;\n"
+             "  float4 color1;\n");
 
-  WRITE(p, " float depth;\n");
+  WriteSampleColor(code, comp, "color0.b", 0, api_type, params);
+  WriteSampleColor(code, comp, "color1.b", 1, api_type, params);
+  WriteSampleColor(code, comp, "color0.g", 2, api_type, params);
+  WriteSampleColor(code, comp, "color1.g", 3, api_type, params);
+  WriteSampleColor(code, comp, "color0.r", 4, api_type, params);
+  WriteSampleColor(code, comp, "color1.r", 5, api_type, params);
+  WriteSampleColor(code, comp, "color0.a", 6, api_type, params);
+  WriteSampleColor(code, comp, "color1.a", 7, api_type, params);
 
-  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
-  WRITE(p, "ocol0.b = frac(depth * %s);\n", multiplier);
+  WriteToBitDepth(code, 4, "color0", "color0");
+  WriteToBitDepth(code, 4, "color1", "color1");
 
-  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
-  WRITE(p, "ocol0.g = frac(depth * %s);\n", multiplier);
-
-  WriteSampleColor(p, "r", "depth", 2, ApiType, params);
-  WRITE(p, "ocol0.r = frac(depth * %s);\n", multiplier);
-
-  WriteSampleColor(p, "r", "depth", 3, ApiType, params);
-  WRITE(p, "ocol0.a = frac(depth * %s);\n", multiplier);
-
-  WriteEncoderEnd(p);
+  code.Write("  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(code);
 }
 
-static void WriteZ16Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteC8Encoder(ShaderCode& code, const char* comp, APIType api_type,
+                           const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::RA8, ApiType);
+  WriteSwizzler(code, params, EFBCopyFormat::R8, api_type);
 
-  WRITE(p, "  float depth;\n");
-  WRITE(p, "  float3 expanded;\n");
+  WriteSampleColor(code, comp, "ocol0.b", 0, api_type, params);
+  WriteSampleColor(code, comp, "ocol0.g", 1, api_type, params);
+  WriteSampleColor(code, comp, "ocol0.r", 2, api_type, params);
+  WriteSampleColor(code, comp, "ocol0.a", 3, api_type, params);
 
-  // byte order is reversed
-
-  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
-
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-
-  WRITE(p, "  ocol0.b = expanded.g / 255.0;\n");
-  WRITE(p, "  ocol0.g = expanded.r / 255.0;\n");
-
-  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
-
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-
-  WRITE(p, "  ocol0.r = expanded.g / 255.0;\n");
-  WRITE(p, "  ocol0.a = expanded.r / 255.0;\n");
-
-  WriteEncoderEnd(p);
+  WriteEncoderEnd(code);
 }
 
-static void WriteZ16LEncoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteCC4Encoder(ShaderCode& code, const char* comp, APIType api_type,
+                            const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::GB8, ApiType);
+  WriteSwizzler(code, params, EFBCopyFormat::RA4, api_type);
+  code.Write("  float2 texSample;\n"
+             "  float4 color0;\n"
+             "  float4 color1;\n");
 
-  WRITE(p, "  float depth;\n");
-  WRITE(p, "  float3 expanded;\n");
+  WriteSampleColor(code, comp, "texSample", 0, api_type, params);
+  code.Write("  color0.b = texSample.x;\n"
+             "  color1.b = texSample.y;\n");
 
-  // byte order is reversed
+  WriteSampleColor(code, comp, "texSample", 1, api_type, params);
+  code.Write("  color0.g = texSample.x;\n"
+             "  color1.g = texSample.y;\n");
 
-  WriteSampleColor(p, "r", "depth", 0, ApiType, params);
+  WriteSampleColor(code, comp, "texSample", 2, api_type, params);
+  code.Write("  color0.r = texSample.x;\n"
+             "  color1.r = texSample.y;\n");
 
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-  WRITE(p, "  depth -= expanded.g * 256.0;\n");
-  WRITE(p, "  expanded.b = depth;\n");
+  WriteSampleColor(code, comp, "texSample", 3, api_type, params);
+  code.Write("  color0.a = texSample.x;\n"
+             "  color1.a = texSample.y;\n");
 
-  WRITE(p, "  ocol0.b = expanded.b / 255.0;\n");
-  WRITE(p, "  ocol0.g = expanded.g / 255.0;\n");
+  WriteToBitDepth(code, 4, "color0", "color0");
+  WriteToBitDepth(code, 4, "color1", "color1");
 
-  WriteSampleColor(p, "r", "depth", 1, ApiType, params);
-
-  WRITE(p, "  depth *= 16777216.0;\n");
-  WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
-  WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
-  WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
-  WRITE(p, "  depth -= expanded.g * 256.0;\n");
-  WRITE(p, "  expanded.b = depth;\n");
-
-  WRITE(p, "  ocol0.r = expanded.b / 255.0;\n");
-  WRITE(p, "  ocol0.a = expanded.g / 255.0;\n");
-
-  WriteEncoderEnd(p);
+  code.Write("  ocol0 = (color0 * 16.0 + color1) / 255.0;\n");
+  WriteEncoderEnd(code);
 }
 
-static void WriteZ24Encoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteCC8Encoder(ShaderCode& code, const char* comp, APIType api_type,
+                            const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::RGBA8, ApiType);
+  WriteSwizzler(code, params, EFBCopyFormat::RA8, api_type);
 
-  WRITE(p, "  float depth0;\n");
-  WRITE(p, "  float depth1;\n");
-  WRITE(p, "  float3 expanded0;\n");
-  WRITE(p, "  float3 expanded1;\n");
+  WriteSampleColor(code, comp, "ocol0.bg", 0, api_type, params);
+  WriteSampleColor(code, comp, "ocol0.ra", 1, api_type, params);
 
-  WriteSampleColor(p, "r", "depth0", 0, ApiType, params);
-  WriteSampleColor(p, "r", "depth1", 1, ApiType, params);
+  WriteEncoderEnd(code);
+}
+
+static void WriteZ8Encoder(ShaderCode& code, const char* multiplier, APIType api_type,
+                           const EFBCopyParams& params)
+{
+  WriteSwizzler(code, params, EFBCopyFormat::G8, api_type);
+
+  code.Write(" float depth;\n");
+
+  WriteSampleColor(code, "r", "depth", 0, api_type, params);
+  code.Write("ocol0.b = frac(depth * %s);\n", multiplier);
+
+  WriteSampleColor(code, "r", "depth", 1, api_type, params);
+  code.Write("ocol0.g = frac(depth * %s);\n", multiplier);
+
+  WriteSampleColor(code, "r", "depth", 2, api_type, params);
+  code.Write("ocol0.r = frac(depth * %s);\n", multiplier);
+
+  WriteSampleColor(code, "r", "depth", 3, api_type, params);
+  code.Write("ocol0.a = frac(depth * %s);\n", multiplier);
+
+  WriteEncoderEnd(code);
+}
+
+static void WriteZ16Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
+{
+  WriteSwizzler(code, params, EFBCopyFormat::RA8, api_type);
+
+  code.Write("  float depth;\n"
+             "  float3 expanded;\n");
+
+  // Byte order is reversed
+
+  WriteSampleColor(code, "r", "depth", 0, api_type, params);
+
+  code.Write("  depth *= 16777216.0;\n"
+             "  expanded.r = floor(depth / (256.0 * 256.0));\n"
+             "  depth -= expanded.r * 256.0 * 256.0;\n"
+             "  expanded.g = floor(depth / 256.0);\n");
+
+  code.Write("  ocol0.b = expanded.g / 255.0;\n"
+             "  ocol0.g = expanded.r / 255.0;\n");
+
+  WriteSampleColor(code, "r", "depth", 1, api_type, params);
+
+  code.Write("  depth *= 16777216.0;\n"
+             "  expanded.r = floor(depth / (256.0 * 256.0));\n"
+             "  depth -= expanded.r * 256.0 * 256.0;\n"
+             "  expanded.g = floor(depth / 256.0);\n");
+
+  code.Write("  ocol0.r = expanded.g / 255.0;\n"
+             "  ocol0.a = expanded.r / 255.0;\n");
+
+  WriteEncoderEnd(code);
+}
+
+static void WriteZ16LEncoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
+{
+  WriteSwizzler(code, params, EFBCopyFormat::GB8, api_type);
+
+  code.Write("  float depth;\n"
+             "  float3 expanded;\n");
+
+  // Byte order is reversed
+
+  WriteSampleColor(code, "r", "depth", 0, api_type, params);
+
+  code.Write("  depth *= 16777216.0;\n"
+             "  expanded.r = floor(depth / (256.0 * 256.0));\n"
+             "  depth -= expanded.r * 256.0 * 256.0;\n"
+             "  expanded.g = floor(depth / 256.0);\n"
+             "  depth -= expanded.g * 256.0;\n"
+             "  expanded.b = depth;\n");
+
+  code.Write("  ocol0.b = expanded.b / 255.0;\n"
+             "  ocol0.g = expanded.g / 255.0;\n");
+
+  WriteSampleColor(code, "r", "depth", 1, api_type, params);
+
+  code.Write("  depth *= 16777216.0;\n"
+             "  expanded.r = floor(depth / (256.0 * 256.0));\n"
+             "  depth -= expanded.r * 256.0 * 256.0;\n"
+             "  expanded.g = floor(depth / 256.0);\n"
+             "  depth -= expanded.g * 256.0;\n"
+             "  expanded.b = depth;\n");
+
+  code.Write("  ocol0.r = expanded.b / 255.0;\n"
+             "  ocol0.a = expanded.g / 255.0;\n");
+
+  WriteEncoderEnd(code);
+}
+
+static void WriteZ24Encoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
+{
+  WriteSwizzler(code, params, EFBCopyFormat::RGBA8, api_type);
+
+  code.Write("  float depth0;\n"
+             "  float depth1;\n"
+             "  float3 expanded0;\n"
+             "  float3 expanded1;\n");
+
+  WriteSampleColor(code, "r", "depth0", 0, api_type, params);
+  WriteSampleColor(code, "r", "depth1", 1, api_type, params);
 
   for (int i = 0; i < 2; i++)
   {
-    WRITE(p, "  depth%i *= 16777216.0;\n", i);
+    code.Write("  depth%i *= 16777216.0;\n", i);
 
-    WRITE(p, "  expanded%i.r = floor(depth%i / (256.0 * 256.0));\n", i, i);
-    WRITE(p, "  depth%i -= expanded%i.r * 256.0 * 256.0;\n", i, i);
-    WRITE(p, "  expanded%i.g = floor(depth%i / 256.0);\n", i, i);
-    WRITE(p, "  depth%i -= expanded%i.g * 256.0;\n", i, i);
-    WRITE(p, "  expanded%i.b = depth%i;\n", i, i);
+    code.Write("  expanded%i.r = floor(depth%i / (256.0 * 256.0));\n", i, i);
+    code.Write("  depth%i -= expanded%i.r * 256.0 * 256.0;\n", i, i);
+    code.Write("  expanded%i.g = floor(depth%i / 256.0);\n", i, i);
+    code.Write("  depth%i -= expanded%i.g * 256.0;\n", i, i);
+    code.Write("  expanded%i.b = depth%i;\n", i, i);
   }
 
-  WRITE(p, "  if (!first) {\n");
-  // upper 16
-  WRITE(p, "     ocol0.b = expanded0.g / 255.0;\n");
-  WRITE(p, "     ocol0.g = expanded0.b / 255.0;\n");
-  WRITE(p, "     ocol0.r = expanded1.g / 255.0;\n");
-  WRITE(p, "     ocol0.a = expanded1.b / 255.0;\n");
-  WRITE(p, "  } else {\n");
-  // lower 8
-  WRITE(p, "     ocol0.b = 1.0;\n");
-  WRITE(p, "     ocol0.g = expanded0.r / 255.0;\n");
-  WRITE(p, "     ocol0.r = 1.0;\n");
-  WRITE(p, "     ocol0.a = expanded1.r / 255.0;\n");
-  WRITE(p, "  }\n");
+  code.Write("  if (!first) {\n");
+  // Upper 16
+  code.Write("     ocol0.b = expanded0.g / 255.0;\n"
+             "     ocol0.g = expanded0.b / 255.0;\n"
+             "     ocol0.r = expanded1.g / 255.0;\n"
+             "     ocol0.a = expanded1.b / 255.0;\n"
+             "  } else {\n");
+  // Lower 8
+  code.Write("     ocol0.b = 1.0;\n"
+             "     ocol0.g = expanded0.r / 255.0;\n"
+             "     ocol0.r = 1.0;\n"
+             "     ocol0.a = expanded1.r / 255.0;\n"
+             "  }\n");
 
-  WriteEncoderEnd(p);
+  WriteEncoderEnd(code);
 }
 
-static void WriteXFBEncoder(char*& p, APIType ApiType, const EFBCopyParams& params)
+static void WriteXFBEncoder(ShaderCode& code, APIType api_type, const EFBCopyParams& params)
 {
-  WriteSwizzler(p, params, EFBCopyFormat::XFB, ApiType);
+  WriteSwizzler(code, params, EFBCopyFormat::XFB, api_type);
 
-  WRITE(p, "float3 color0, color1;\n");
-  WriteSampleColor(p, "rgb", "color0", 0, ApiType, params);
-  WriteSampleColor(p, "rgb", "color1", 1, ApiType, params);
+  code.Write("float3 color0, color1;\n");
+  WriteSampleColor(code, "rgb", "color0", 0, api_type, params);
+  WriteSampleColor(code, "rgb", "color1", 1, api_type, params);
 
   // Gamma is only applied to XFB copies.
-  WRITE(p, "  color0 = pow(color0, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
-  WRITE(p, "  color1 = pow(color1, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
+  code.Write("  color0 = pow(color0, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n"
+             "  color1 = pow(color1, float3(gamma_rcp, gamma_rcp, gamma_rcp));\n");
 
   // Convert to YUV.
-  WRITE(p, "  const float3 y_const = float3(0.257, 0.504, 0.098);\n");
-  WRITE(p, "  const float3 u_const = float3(-0.148, -0.291, 0.439);\n");
-  WRITE(p, "  const float3 v_const = float3(0.439, -0.368, -0.071);\n");
-  WRITE(p, "  float3 average = (color0 + color1) * 0.5;\n");
-  WRITE(p, "  ocol0.b = dot(color0,  y_const) + 0.0625;\n");
-  WRITE(p, "  ocol0.g = dot(average, u_const) + 0.5;\n");
-  WRITE(p, "  ocol0.r = dot(color1,  y_const) + 0.0625;\n");
-  WRITE(p, "  ocol0.a = dot(average, v_const) + 0.5;\n");
+  code.Write("  const float3 y_const = float3(0.257, 0.504, 0.098);\n"
+             "  const float3 u_const = float3(-0.148, -0.291, 0.439);\n"
+             "  const float3 v_const = float3(0.439, -0.368, -0.071);\n"
+             "  float3 average = (color0 + color1) * 0.5;\n"
+             "  ocol0.b = dot(color0,  y_const) + 0.0625;\n"
+             "  ocol0.g = dot(average, u_const) + 0.5;\n"
+             "  ocol0.r = dot(color1,  y_const) + 0.0625;\n"
+             "  ocol0.a = dot(average, v_const) + 0.5;\n");
 
-  WriteEncoderEnd(p);
+  WriteEncoderEnd(code);
 }
 
-const char* GenerateEncodingShader(const EFBCopyParams& params, APIType api_type)
+std::string GenerateEncodingShader(const EFBCopyParams& params, APIType api_type)
 {
-  text[sizeof(text) - 1] = 0x7C;  // canary
-
-  char* p = text;
+  ShaderCode code;
 
   switch (params.copy_format)
   {
   case EFBCopyFormat::R4:
     if (params.yuv)
-      WriteI4Encoder(p, api_type, params);
+      WriteI4Encoder(code, api_type, params);
     else
-      WriteC4Encoder(p, "r", api_type, params);
+      WriteC4Encoder(code, "r", api_type, params);
     break;
   case EFBCopyFormat::RA4:
     if (params.yuv)
-      WriteIA4Encoder(p, api_type, params);
+      WriteIA4Encoder(code, api_type, params);
     else
-      WriteCC4Encoder(p, "ar", api_type, params);
+      WriteCC4Encoder(code, "ar", api_type, params);
     break;
   case EFBCopyFormat::RA8:
     if (params.yuv)
-      WriteIA8Encoder(p, api_type, params);
+      WriteIA8Encoder(code, api_type, params);
     else
-      WriteCC8Encoder(p, "ar", api_type, params);
+      WriteCC8Encoder(code, "ar", api_type, params);
     break;
   case EFBCopyFormat::RGB565:
-    WriteRGB565Encoder(p, api_type, params);
+    WriteRGB565Encoder(code, api_type, params);
     break;
   case EFBCopyFormat::RGB5A3:
-    WriteRGB5A3Encoder(p, api_type, params);
+    WriteRGB5A3Encoder(code, api_type, params);
     break;
   case EFBCopyFormat::RGBA8:
     if (params.depth)
-      WriteZ24Encoder(p, api_type, params);
+      WriteZ24Encoder(code, api_type, params);
     else
-      WriteRGBA8Encoder(p, api_type, params);
+      WriteRGBA8Encoder(code, api_type, params);
     break;
   case EFBCopyFormat::A8:
-    WriteC8Encoder(p, "a", api_type, params);
+    WriteC8Encoder(code, "a", api_type, params);
     break;
   case EFBCopyFormat::R8_0x1:
   case EFBCopyFormat::R8:
     if (params.yuv)
-      WriteI8Encoder(p, api_type, params);
+      WriteI8Encoder(code, api_type, params);
     else
-      WriteC8Encoder(p, "r", api_type, params);
+      WriteC8Encoder(code, "r", api_type, params);
     break;
   case EFBCopyFormat::G8:
     if (params.depth)
-      WriteZ8Encoder(p, "256.0", api_type, params);  // Z8M
+      WriteZ8Encoder(code, "256.0", api_type, params);  // Z8M
     else
-      WriteC8Encoder(p, "g", api_type, params);
+      WriteC8Encoder(code, "g", api_type, params);
     break;
   case EFBCopyFormat::B8:
     if (params.depth)
-      WriteZ8Encoder(p, "65536.0", api_type, params);  // Z8L
+      WriteZ8Encoder(code, "65536.0", api_type, params);  // Z8L
     else
-      WriteC8Encoder(p, "b", api_type, params);
+      WriteC8Encoder(code, "b", api_type, params);
     break;
   case EFBCopyFormat::RG8:
     if (params.depth)
-      WriteZ16Encoder(p, api_type, params);  // Z16H
+      WriteZ16Encoder(code, api_type, params);  // Z16H
     else
-      WriteCC8Encoder(p, "gr", api_type, params);
+      WriteCC8Encoder(code, "gr", api_type, params);
     break;
   case EFBCopyFormat::GB8:
     if (params.depth)
-      WriteZ16LEncoder(p, api_type, params);  // Z16L
+      WriteZ16LEncoder(code, api_type, params);  // Z16L
     else
-      WriteCC8Encoder(p, "bg", api_type, params);
+      WriteCC8Encoder(code, "bg", api_type, params);
     break;
   case EFBCopyFormat::XFB:
-    WriteXFBEncoder(p, api_type, params);
+    WriteXFBEncoder(code, api_type, params);
     break;
   default:
     PanicAlert("Invalid EFB Copy Format (0x%X)! (GenerateEncodingShader)",
@@ -841,10 +843,7 @@ const char* GenerateEncodingShader(const EFBCopyParams& params, APIType api_type
     break;
   }
 
-  if (text[sizeof(text) - 1] != 0x7C)
-    PanicAlert("TextureConversionShader generator - buffer too small, canary has been eaten!");
-
-  return text;
+  return code.GetBuffer();
 }
 
 // NOTE: In these uniforms, a row refers to a row of blocks, not texels.

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -20,7 +20,7 @@ namespace TextureConversionShaderTiled
 {
 u16 GetEncodedSampleCount(EFBCopyFormat format);
 
-const char* GenerateEncodingShader(const EFBCopyParams& params, APIType ApiType);
+std::string GenerateEncodingShader(const EFBCopyParams& params, APIType api_type);
 
 // Information required to compile and dispatch a texture decoding shader.
 struct DecodingShaderInfo


### PR DESCRIPTION
Previously the shader generation used a global text buffer to contain the generated text and then returned a pointer into the buffer. This was what a few of the other shader generators used to do until `ShaderCode` was introduced.

We can convert this over to use `ShaderCode` to make it consistent with the other generators and then convert it over to making use of the fmt-capable `WriteFmt`. I've done this in two parts to make it easier to review the initial conversion over to `ShaderCode` and the subsequent conversion over to making use of fmt.