### PR TITLE
Common/ChunkFile: Use std::is_trivially_copyable directly.

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -32,11 +32,6 @@
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
 
-// XXX: Replace this with std::is_trivially_copyable<T> once we stop using volatile
-// on things that are put in savestates, as volatile types are not trivially copyable.
-template <typename T>
-constexpr bool IsTriviallyCopyable = std::is_trivially_copyable<std::remove_volatile_t<T>>::value;
-
 // Wrapper class
 class PointerWrap
 {
@@ -181,14 +176,14 @@ public:
     DoArray(x.data(), static_cast<u32>(x.size()));
   }
 
-  template <typename T, typename std::enable_if_t<IsTriviallyCopyable<T>, int> = 0>
-  void DoArray(T* x, u32 count)
+  template <typename T>
+  auto DoArray(T* x, u32 count) -> std::enable_if_t<std::is_trivially_copyable_v<T>>
   {
     DoVoid(x, count * sizeof(T));
   }
 
-  template <typename T, typename std::enable_if_t<!IsTriviallyCopyable<T>, int> = 0>
-  void DoArray(T* x, u32 count)
+  template <typename T>
+  auto DoArray(T* x, u32 count) -> std::enable_if_t<!std::is_trivially_copyable_v<T>>
   {
     for (u32 i = 0; i < count; ++i)
       Do(x[i]);
@@ -220,7 +215,7 @@ public:
   template <typename T>
   void Do(T& x)
   {
-    static_assert(IsTriviallyCopyable<T>, "Only sane for trivially copyable types");
+    static_assert(std::is_trivially_copyable<T>(), "Only sane for trivially copyable types");
     // Note:
     // Usually we can just use x = **ptr, etc.  However, this doesn't work
     // for unions containing BitFields (long story, stupid language rules)


### PR DESCRIPTION
The `TriviallyCopyable` requirement no longer requires types be non-volatile.
https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable
https://wg21.cmeerw.net/cwg/issue2094