### PR TITLE
Common/Core: Minor rvalue reference related cleanups.

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -185,13 +185,7 @@ bool IniFile::Exists(std::string_view section_name, std::string_view key) const
   return section->Exists(key);
 }
 
-void IniFile::SetLines(std::string_view section_name, const std::vector<std::string>& lines)
-{
-  Section* section = GetOrCreateSection(section_name);
-  section->SetLines(lines);
-}
-
-void IniFile::SetLines(std::string_view section_name, std::vector<std::string>&& lines)
+void IniFile::SetLines(std::string_view section_name, std::vector<std::string> lines)
 {
   Section* section = GetOrCreateSection(section_name);
   section->SetLines(std::move(lines));

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -143,8 +143,7 @@ public:
 
   bool GetKeys(std::string_view section_name, std::vector<std::string>* keys) const;
 
-  void SetLines(std::string_view section_name, const std::vector<std::string>& lines);
-  void SetLines(std::string_view section_name, std::vector<std::string>&& lines);
+  void SetLines(std::string_view section_name, std::vector<std::string> lines);
   bool GetLines(std::string_view section_name, std::vector<std::string>* lines,
                 bool remove_comments = true) const;
 

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -79,11 +79,7 @@ bool operator!=(const Content& lhs, const Content& rhs)
   return !operator==(lhs, rhs);
 }
 
-SignedBlobReader::SignedBlobReader(const std::vector<u8>& bytes) : m_bytes(bytes)
-{
-}
-
-SignedBlobReader::SignedBlobReader(std::vector<u8>&& bytes) : m_bytes(std::move(bytes))
+SignedBlobReader::SignedBlobReader(std::vector<u8> bytes) : m_bytes(std::move(bytes))
 {
 }
 
@@ -92,12 +88,7 @@ const std::vector<u8>& SignedBlobReader::GetBytes() const
   return m_bytes;
 }
 
-void SignedBlobReader::SetBytes(const std::vector<u8>& bytes)
-{
-  m_bytes = bytes;
-}
-
-void SignedBlobReader::SetBytes(std::vector<u8>&& bytes)
+void SignedBlobReader::SetBytes(std::vector<u8> bytes)
 {
   m_bytes = std::move(bytes);
 }
@@ -213,11 +204,7 @@ bool IsValidTMDSize(size_t size)
   return size <= 0x49e4;
 }
 
-TMDReader::TMDReader(const std::vector<u8>& bytes) : SignedBlobReader(bytes)
-{
-}
-
-TMDReader::TMDReader(std::vector<u8>&& bytes) : SignedBlobReader(std::move(bytes))
+TMDReader::TMDReader(std::vector<u8> bytes) : SignedBlobReader(std::move(bytes))
 {
 }
 
@@ -376,11 +363,7 @@ bool TMDReader::FindContentById(u32 id, Content* content) const
   return false;
 }
 
-TicketReader::TicketReader(const std::vector<u8>& bytes) : SignedBlobReader(bytes)
-{
-}
-
-TicketReader::TicketReader(std::vector<u8>&& bytes) : SignedBlobReader(std::move(bytes))
+TicketReader::TicketReader(std::vector<u8> bytes) : SignedBlobReader(std::move(bytes))
 {
 }
 

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -155,12 +155,10 @@ class SignedBlobReader
 {
 public:
   SignedBlobReader() = default;
-  explicit SignedBlobReader(const std::vector<u8>& bytes);
-  explicit SignedBlobReader(std::vector<u8>&& bytes);
+  explicit SignedBlobReader(std::vector<u8> bytes);
 
   const std::vector<u8>& GetBytes() const;
-  void SetBytes(const std::vector<u8>& bytes);
-  void SetBytes(std::vector<u8>&& bytes);
+  void SetBytes(std::vector<u8> bytes);
 
   /// Get the SHA1 hash for this signed blob (starting at the issuer).
   std::array<u8, 20> GetSha1() const;
@@ -187,8 +185,7 @@ class TMDReader final : public SignedBlobReader
 {
 public:
   TMDReader() = default;
-  explicit TMDReader(const std::vector<u8>& bytes);
-  explicit TMDReader(std::vector<u8>&& bytes);
+  explicit TMDReader(std::vector<u8> bytes);
 
   bool IsValid() const;
 
@@ -224,8 +221,7 @@ class TicketReader final : public SignedBlobReader
 {
 public:
   TicketReader() = default;
-  explicit TicketReader(const std::vector<u8>& bytes);
-  explicit TicketReader(std::vector<u8>&& bytes);
+  explicit TicketReader(std::vector<u8> bytes);
 
   bool IsValid() const;
 

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -217,12 +217,7 @@ SysConf::Entry::Entry(Type type_, const std::string& name_) : type(type_), name(
     bytes.resize(GetNonArrayEntrySize(type));
 }
 
-SysConf::Entry::Entry(Type type_, const std::string& name_, const std::vector<u8>& bytes_)
-    : type(type_), name(name_), bytes(bytes_)
-{
-}
-
-SysConf::Entry::Entry(Type type_, const std::string& name_, std::vector<u8>&& bytes_)
+SysConf::Entry::Entry(Type type_, const std::string& name_, std::vector<u8> bytes_)
     : type(type_), name(name_), bytes(std::move(bytes_))
 {
 }

--- a/Source/Core/Core/SysConf.h
+++ b/Source/Core/Core/SysConf.h
@@ -47,8 +47,7 @@ public:
     };
 
     Entry(Type type_, const std::string& name_);
-    Entry(Type type_, const std::string& name_, const std::vector<u8>& bytes_);
-    Entry(Type type_, const std::string& name_, std::vector<u8>&& bytes_);
+    Entry(Type type_, const std::string& name_, std::vector<u8> bytes_);
 
     // Intended for use with the non array types.
     template <typename T>


### PR DESCRIPTION
I found a few functions with overloads for both `const T&` and `T&&` parameters intending to take ownership either by-copy or by-move.

These functions can pass `T` by-value and `std::move` within the function body to handle both situations with one implementation.