### PR TITLE
DolphinQt: Add "File Path" column to Game Grid

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -188,6 +188,7 @@ void SConfig::SaveGameListSettings(IniFile& ini)
   gamelist->Set("ColumnTitle", m_showTitleColumn);
   gamelist->Set("ColumnNotes", m_showMakerColumn);
   gamelist->Set("ColumnFileName", m_showFileNameColumn);
+  gamelist->Set("ColumnFilePath", m_showFilePathColumn);
   gamelist->Set("ColumnID", m_showIDColumn);
   gamelist->Set("ColumnRegion", m_showRegionColumn);
   gamelist->Set("ColumnSize", m_showSizeColumn);
@@ -464,6 +465,7 @@ void SConfig::LoadGameListSettings(IniFile& ini)
   gamelist->Get("ColumnTitle", &m_showTitleColumn, true);
   gamelist->Get("ColumnNotes", &m_showMakerColumn, true);
   gamelist->Get("ColumnFileName", &m_showFileNameColumn, false);
+  gamelist->Get("ColumnFilePath", &m_showFilePathColumn, false);
   gamelist->Get("ColumnID", &m_showIDColumn, false);
   gamelist->Get("ColumnRegion", &m_showRegionColumn, true);
   gamelist->Get("ColumnSize", &m_showSizeColumn, true);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -268,6 +268,7 @@ struct SConfig
   bool m_showTitleColumn;
   bool m_showMakerColumn;
   bool m_showFileNameColumn;
+  bool m_showFilePathColumn;
   bool m_showIDColumn;
   bool m_showRegionColumn;
   bool m_showSizeColumn;

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -145,6 +145,7 @@ void GameList::MakeListView()
   hor_header->setSectionResizeMode(GameListModel::COL_COUNTRY, QHeaderView::Fixed);
   hor_header->setSectionResizeMode(GameListModel::COL_SIZE, QHeaderView::Fixed);
   hor_header->setSectionResizeMode(GameListModel::COL_FILE_NAME, QHeaderView::Interactive);
+  hor_header->setSectionResizeMode(GameListModel::COL_FILE_PATH, QHeaderView::Interactive);
   hor_header->setSectionResizeMode(GameListModel::COL_TAGS, QHeaderView::Interactive);
 
   // There's some odd platform-specific behavior with default minimum section size
@@ -188,6 +189,8 @@ void GameList::UpdateColumnVisibility()
   m_list->setColumnHidden(GameListModel::COL_SIZE, !SConfig::GetInstance().m_showSizeColumn);
   m_list->setColumnHidden(GameListModel::COL_FILE_NAME,
                           !SConfig::GetInstance().m_showFileNameColumn);
+  m_list->setColumnHidden(GameListModel::COL_FILE_PATH,
+                          !SConfig::GetInstance().m_showFilePathColumn);
   m_list->setColumnHidden(GameListModel::COL_TAGS, !SConfig::GetInstance().m_showTagsColumn);
 }
 
@@ -908,6 +911,7 @@ void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)
       {tr("Description"), GameListModel::COL_DESCRIPTION},
       {tr("Maker"), GameListModel::COL_MAKER},
       {tr("File Name"), GameListModel::COL_FILE_NAME},
+      {tr("File Path"), GameListModel::COL_FILE_PATH},
       {tr("Game ID"), GameListModel::COL_ID},
       {tr("Region"), GameListModel::COL_COUNTRY},
       {tr("File Size"), GameListModel::COL_SIZE},

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -5,6 +5,7 @@
 #include "DolphinQt/GameList/GameListModel.h"
 
 #include <QDir>
+#include <QFileInfo>
 #include <QPixmap>
 
 #include "Core/ConfigManager.h"
@@ -144,21 +145,10 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_FILE_PATH:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
-      QString file_path = QDir::cleanPath(QString::fromStdString(game.GetFilePath()));
-      for (QString dir : Settings::Instance().GetPaths())
-      {
-        dir = QDir::cleanPath(dir);
-        if (file_path.startsWith(dir))
-        {
-          int path_index = dir.lastIndexOf(QLatin1Char('/'), -2);
-          if (path_index > -1)
-          {
-            file_path = file_path.mid(path_index + 1);
-            break;
-          }
-        }
-      }
-      return QDir::toNativeSeparators(file_path);
+      QString file_path = QFileInfo(QString::fromStdString(game.GetFilePath())).canonicalPath();
+      if (!file_path.endsWith(QDir::separator()))
+        file_path.append(QDir::separator());
+      return file_path;
     }
     break;
   case COL_SIZE:

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -4,6 +4,7 @@
 
 #include "DolphinQt/GameList/GameListModel.h"
 
+#include <QDir>
 #include <QPixmap>
 
 #include "Core/ConfigManager.h"
@@ -140,6 +141,26 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
       return QString::fromStdString(game.GetFileName());
     break;
+  case COL_FILE_PATH:
+    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    {
+      QString file_path = QDir::cleanPath(QString::fromStdString(game.GetFilePath()));
+      for (QString dir : Settings::Instance().GetPaths())
+      {
+        dir = QDir::cleanPath(dir);
+        if (file_path.startsWith(dir))
+        {
+          int path_index = dir.lastIndexOf(QLatin1Char('/'), -2);
+          if (path_index > -1)
+          {
+            file_path = file_path.mid(path_index + 1);
+            break;
+          }
+        }
+      }
+      return QDir::toNativeSeparators(file_path);
+    }
+    break;
   case COL_SIZE:
     if (role == Qt::DisplayRole)
     {
@@ -186,6 +207,8 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
     return tr("Maker");
   case COL_FILE_NAME:
     return tr("File Name");
+  case COL_FILE_PATH:
+    return tr("File Path");
   case COL_SIZE:
     return tr("Size");
   case COL_TAGS:

--- a/Source/Core/DolphinQt/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt/GameList/GameListModel.h
@@ -55,6 +55,7 @@ public:
     COL_COUNTRY,
     COL_SIZE,
     COL_FILE_NAME,
+    COL_FILE_PATH,
     COL_TAGS,
     NUM_COLS
   };

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -606,6 +606,7 @@ void MenuBar::AddListColumnsMenu(QMenu* view_menu)
       {tr("Description"), &SConfig::GetInstance().m_showDescriptionColumn},
       {tr("Maker"), &SConfig::GetInstance().m_showMakerColumn},
       {tr("File Name"), &SConfig::GetInstance().m_showFileNameColumn},
+      {tr("File Path"), &SConfig::GetInstance().m_showFilePathColumn},
       {tr("Game ID"), &SConfig::GetInstance().m_showIDColumn},
       {tr("Region"), &SConfig::GetInstance().m_showRegionColumn},
       {tr("File Size"), &SConfig::GetInstance().m_showSizeColumn},


### PR DESCRIPTION
The path is generated by finding a file path that contains the filename, then removing the path to that path.

Example:
File paths: `/home/foo/games`, `/home/foo/Desktop/wii`
Game path: `/home/foo/games/gcn/ntsc/fun game.gcn`
~~File name listed: `gcn/ntsc/fun game.gcn`~~
File name listed: `games/gcn/ntsc/fun game.gcn`

`dir.lastIndexOf` uses `-2` in the case that the file path ends with a trailing slash.

Fixes https://bugs.dolphin-emu.org/issues/10567

This is my first PR to Dolphin, so a thorough review would be awesome, ~~and let me know if this would be better as its' own column instead of replacing "File name".~~