### PR TITLE
InputCommon: Make "Cursor" inputs aware of the rendered aspect ratio.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -257,6 +257,21 @@ void ControllerInterface::UpdateInput()
   }
 }
 
+void ControllerInterface::SetAspectRatioAdjustment(float value)
+{
+  m_aspect_ratio_adjustment = value;
+}
+
+Common::Vec2 ControllerInterface::GetWindowInputScale() const
+{
+  const auto ar = m_aspect_ratio_adjustment.load();
+
+  if (ar > 1)
+    return {1.f, ar};
+  else
+    return {1 / ar, 1.f};
+}
+
 // Register a callback to be called when a device is added or removed (as from the input backends'
 // hotplug thread), or when devices are refreshed
 // Returns a handle for later removing the callback.

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 
+#include "Common/Matrix.h"
 #include "Common/WindowSystemInfo.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
@@ -52,6 +53,14 @@ public:
   bool IsInit() const { return m_is_init; }
   void UpdateInput();
 
+  // Set adjustment from the full render window aspect-ratio to the drawn aspect-ratio.
+  // Used to fit mouse cursor inputs to the relevant region of the render window.
+  void SetAspectRatioAdjustment(float);
+
+  // Calculated from the aspect-ratio adjustment.
+  // Inputs based on window coordinates should be multiplied by this.
+  Common::Vec2 GetWindowInputScale() const;
+
   HotplugCallbackHandle RegisterDevicesChangedCallback(std::function<void(void)> callback);
   void UnregisterDevicesChangedCallback(const HotplugCallbackHandle& handle);
   void InvokeDevicesChangedCallbacks() const;
@@ -62,6 +71,7 @@ private:
   std::atomic<bool> m_is_init;
   std::atomic<bool> m_is_populating_devices{false};
   WindowSystemInfo m_wsi;
+  std::atomic<float> m_aspect_ratio_adjustment = 1;
 };
 
 extern ControllerInterface g_controller_interface;

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -125,9 +125,11 @@ void KeyboardMouse::UpdateCursorInput()
   const auto win_width = rect.right - rect.left;
   const auto win_height = rect.bottom - rect.top;
 
+  const auto window_scale = g_controller_interface.GetWindowInputScale();
+
   // Convert the cursor position to a range from -1 to 1.
-  m_state_in.cursor.x = ControlState(point.x) / win_width * 2 - 1;
-  m_state_in.cursor.y = ControlState(point.y) / win_height * 2 - 1;
+  m_state_in.cursor.x = (ControlState(point.x) / win_width * 2 - 1) * window_scale.x;
+  m_state_in.cursor.y = (ControlState(point.y) / win_height * 2 - 1) * window_scale.y;
 }
 
 void KeyboardMouse::UpdateInput()

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -6,6 +6,7 @@
 
 #include <windows.h>
 
+#include "Common/Matrix.h"
 #include "InputCommon/ControllerInterface/DInput/DInput8.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
@@ -20,10 +21,7 @@ private:
   {
     BYTE keyboard[256];
     DIMOUSESTATE2 mouse;
-    struct
-    {
-      ControlState x, y;
-    } cursor;
+    Common::TVec2<ControlState> cursor;
   };
 
   class Key : public Input

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
@@ -6,6 +6,7 @@
 
 #include <QuartzCore/QuartzCore.h>
 
+#include "Common/Matrix.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 namespace ciface::Quartz
@@ -64,10 +65,7 @@ public:
   std::string GetSource() const override;
 
 private:
-  struct
-  {
-    float x, y;
-  } m_cursor;
+  Common::Vec2 m_cursor;
 
   uint32_t m_windowid;
 };

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -9,6 +9,8 @@
 #include <Carbon/Carbon.h>
 #include <Cocoa/Cocoa.h>
 
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+
 namespace ciface::Quartz
 {
 std::string KeycodeToName(const CGKeyCode keycode)
@@ -177,10 +179,12 @@ void KeyboardAndMouse::UpdateInput()
   CGPoint loc = CGEventGetLocation(event);
   CFRelease(event);
 
+  const auto window_scale = g_controller_interface.GetWindowInputScale();
+
   loc.x -= bounds.origin.x;
   loc.y -= bounds.origin.y;
-  m_cursor.x = loc.x / bounds.size.width * 2 - 1.0;
-  m_cursor.y = loc.y / bounds.size.height * 2 - 1.0;
+  m_cursor.x = (loc.x / bounds.size.width * 2 - 1.0) * window_scale.x;
+  m_cursor.y = (loc.y / bounds.size.height * 2 - 1.0) * window_scale.y;
 }
 
 std::string KeyboardAndMouse::GetName() const

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -212,9 +212,11 @@ void KeyboardMouse::UpdateCursor()
   XWindowAttributes win_attribs;
   XGetWindowAttributes(m_display, m_window, &win_attribs);
 
+  const auto window_scale = g_controller_interface.GetWindowInputScale();
+
   // the mouse position as a range from -1 to 1
-  m_state.cursor.x = win_x / (float)win_attribs.width * 2 - 1;
-  m_state.cursor.y = win_y / (float)win_attribs.height * 2 - 1;
+  m_state.cursor.x = (win_x / win_attribs.width * 2 - 1) * window_scale.x;
+  m_state.cursor.y = (win_y / win_attribs.height * 2 - 1) * window_scale.y;
 }
 
 void KeyboardMouse::UpdateInput()

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -12,6 +12,7 @@ extern "C" {
 #include <X11/keysym.h>
 }
 
+#include "Common/Matrix.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace ciface::XInput2
@@ -25,10 +26,8 @@ private:
   {
     char keyboard[32];
     unsigned int buttons;
-    struct
-    {
-      float x, y;
-    } cursor, axis;
+    Common::Vec2 cursor;
+    Common::Vec2 axis;
   };
 
   class Key : public Input


### PR DESCRIPTION
This adjusts ControllerInterface's mouse cursor inputs to the region of the render window actually being used.

Previously, the mouse cursor and in-game pointer diverged with any letterboxing/pillarboxing.
Adjustments to "Total Yaw" and "Total Pitch" could be used to compensate but that is no longer necessary.

Before: https://i.imgur.com/2Lb8MOt.png
After: https://i.imgur.com/K7PfLKn.png