### PR TITLE
DolphinQt/TASCheckBox: Mark GetValue() as const

### DIFF
--- a/Source/Core/DolphinQt/TAS/TASCheckBox.cpp
+++ b/Source/Core/DolphinQt/TAS/TASCheckBox.cpp
@@ -13,7 +13,7 @@ TASCheckBox::TASCheckBox(const QString& text) : QCheckBox(text)
   setTristate(true);
 }
 
-bool TASCheckBox::GetValue()
+bool TASCheckBox::GetValue() const
 {
   if (checkState() == Qt::PartiallyChecked)
     return Movie::GetCurrentFrame() % 2 == static_cast<u64>(m_trigger_on_odd);

--- a/Source/Core/DolphinQt/TAS/TASCheckBox.h
+++ b/Source/Core/DolphinQt/TAS/TASCheckBox.h
@@ -14,7 +14,7 @@ class TASCheckBox : public QCheckBox
 public:
   explicit TASCheckBox(const QString& text);
 
-  bool GetValue();
+  bool GetValue() const;
 
 protected:
   void mousePressEvent(QMouseEvent* event) override;


### PR DESCRIPTION
This doesn't actually modify the checkbox's state, so this can be marked as a const-qualified member function.

