### PR TITLE
DolphinQt: Remove unimplemented function prototypes

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigEdit.h
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.h
@@ -34,8 +34,6 @@ private:
   void OnAutoComplete(const QString& completion);
   void OpenExternalEditor();
 
-  void SetReadOnly(bool read_only);
-
   QString GetTextUnderCursor();
 
   void AddBoolOption(QMenu* menu, const QString& name, const QString& section, const QString& key);

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.h
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.h
@@ -36,8 +36,6 @@ private:
   void LoadSettings();
   void SaveSettings();
 
-  void EditUserConfig();
-
   void SaveCheckBox(QCheckBox* checkbox, const std::string& section, const std::string& key);
   void LoadCheckBox(QCheckBox* checkbox, const std::string& section, const std::string& key);
 

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -162,7 +162,10 @@ private:
   void OnBootGameCubeIPL(DiscIO::Region region);
   void OnImportNANDBackup();
   void OnConnectWiiRemote(int id);
+
+#if defined(__unix__) || defined(__unix) || defined(__APPLE__)
   void OnSignal();
+#endif
 
   void OnUpdateProgressDialog(QString label, int progress, int total);
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -99,8 +99,6 @@ private:
   void GameStatusChanged(bool running);
   void SetOptionsEnabled(bool enabled);
 
-  void SetGame(const QString& game_path);
-
   void SendMessage(const std::string& message);
 
   // Chat


### PR DESCRIPTION
Removes three unimplemented function prototypes and also surrounds `OnSignal()` within MainWindow with a relevant ifdef (like its implementation is), so that it's not mistakenly considered an unimplemented function prototype on Windows.