### PR TITLE
DolphinQt/GCMemcardManager: Mark string as translatable within GetErrorMessagesForErrorCode()

### DIFF
--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -597,7 +597,7 @@ QString GCMemcardManager::GetErrorMessagesForErrorCode(const GCMemcardErrorCode&
     sl.push_back(tr("Data in area of file that should be unused."));
 
   if (sl.empty())
-    return QStringLiteral("No errors.");
+    return tr("No errors.");
 
   return sl.join(QStringLiteral("\n"));
 }

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -599,5 +599,5 @@ QString GCMemcardManager::GetErrorMessagesForErrorCode(const GCMemcardErrorCode&
   if (sl.empty())
     return tr("No errors.");
 
-  return sl.join(QStringLiteral("\n"));
+  return sl.join(QLatin1Char{'\n'});
 }


### PR DESCRIPTION
This is a string that can potentially be seen by a user, so it should be marked as translatable like the other strings are.

While we're in the same area, we can also make use of `QLatin1Char` instead of `QStringLiteral` in the following `join()` call. It provides the same behavior, but without the need for program-lifetime QString data.