### PR TITLE
WiiRoot: Fix CopySysmenuFilesToFS directory creation

### DIFF
--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -188,7 +188,7 @@ static bool CopySysmenuFilesToFS(FS::FileSystem* fs, const std::string& host_sou
 
     if (entry.isDirectory)
     {
-      fs->CreateFullPath(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path + '/', 0, public_modes);
+      fs->CreateDirectory(IOS::SYSMENU_UID, IOS::SYSMENU_GID, nand_path, 0, public_modes);
       if (!CopySysmenuFilesToFS(fs, host_path, nand_path))
         return false;
     }


### PR DESCRIPTION
Fixes a regression from #8539.

CreateDirectory was the correct function to use for creating
directories since parent directories already exist.

While using CreateFullPath would have worked, that currently fails because parent directories are not owned by the system menu. I will fix CreateFullPath to handle that case in a few hours, but for now this PR fixes the most urgent issue.