### PR TITLE
IOS/FS: Fix CreateFullPath to not create directories that already exist

### DIFF
--- a/Source/Core/Core/IOS/FS/FileSystem.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystem.cpp
@@ -115,9 +115,12 @@ ResultCode FileSystem::CreateFullPath(Uid uid, Gid gid, const std::string& path,
     if (metadata && metadata->is_file)
       return ResultCode::Invalid;
 
-    const ResultCode result = CreateDirectory(uid, gid, subpath, attribute, modes);
-    if (result != ResultCode::Success && result != ResultCode::AlreadyExists)
-      return result;
+    if (!metadata)
+    {
+      const ResultCode result = CreateDirectory(uid, gid, subpath, attribute, modes);
+      if (result != ResultCode::Success)
+        return result;
+    }
 
     ++position;
   }


### PR DESCRIPTION
Follow up to #8593.

This fixes CreateFullPath to not create directories when it is known
that they already exist, instead of calling CreateDirectory anyway
and checking if the error is AlreadyExists. (That doesn't work
now that we have an accurate implementation of CreateDirectory
that performs permission checks before checking for existence.)

I'm not sure what I was thinking when I wrote that function.

Also adds some tests for CreateFullPath.