### PR TITLE
Vulkan: Treat VK_SUBOPTIMAL_KHR as VK_SUCCESS on Android

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -375,12 +375,21 @@ void CommandBufferManager::SubmitCommandBuffer(u32 command_buffer_index,
     if (m_last_present_result != VK_SUCCESS)
     {
       // VK_ERROR_OUT_OF_DATE_KHR is not fatal, just means we need to recreate our swap chain.
-      if (m_last_present_result != VK_ERROR_OUT_OF_DATE_KHR && res != VK_SUBOPTIMAL_KHR &&
+      if (m_last_present_result != VK_ERROR_OUT_OF_DATE_KHR &&
+          m_last_present_result != VK_SUBOPTIMAL_KHR &&
           m_last_present_result != VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
       {
         LOG_VULKAN_ERROR(m_last_present_result, "vkQueuePresentKHR failed: ");
       }
+
+      // Don't treat VK_SUBOPTIMAL_KHR as fatal on Android. Android 10+ requires prerotation.
+      // See https://twitter.com/Themaister/status/1207062674011574273
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+      if (m_last_present_result != VK_SUBOPTIMAL_KHR)
+        m_last_present_failed.Set();
+#else
       m_last_present_failed.Set();
+#endif
     }
   }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -305,6 +305,7 @@ void Renderer::BindBackbuffer(const ClearColor& clear_color)
     }
     else if (res == VK_SUBOPTIMAL_KHR || res == VK_ERROR_OUT_OF_DATE_KHR)
     {
+      INFO_LOG(VIDEO, "Resizing swap chain due to suboptimal/out-of-date");
       m_swap_chain->ResizeSwapChain();
     }
     else


### PR DESCRIPTION
Android 10 seems to expect a prerotated/transformed swap chain for optimal presentation. For now, until we implement that, just ignore the hint.

See: https://twitter.com/Themaister/status/1207062674011574273

This was causing us to recreate the swap chain every frame, with an identity pretransform which would return suboptimal for the next presentation, repeat. Hence performance loss, since it's not cheap. I'm surprised the hit wasn't higher to be honest.

Fixes https://bugs.dolphin-emu.org/issues/11946

