### PR TITLE
Android: More robust check for whether to sync channels

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -59,8 +59,6 @@ public final class TvMainActivity extends FragmentActivity implements MainView
     {
       StartupHandler.HandleInit(this);
     }
-    // Setup and/or sync channels
-    TvUtil.scheduleSyncingChannel(getApplicationContext());
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -27,6 +27,10 @@ public final class StartupHandler
     // Ask the user if he wants to enable analytics if we haven't yet.
     Analytics.checkAnalyticsInit(parent);
 
+    // Set up and/or sync Android TV channels
+    if (TvUtil.isLeanback(parent))
+      TvUtil.scheduleSyncingChannel(parent);
+
     String[] start_files = null;
     Bundle extras = parent.getIntent().getExtras();
     if (extras != null)


### PR DESCRIPTION
This changes channel syncing to happen when the operating system is Android TV rather than when TvMainActivity is launched. (You can run TvMainActivity on a phone by specifying a launch activity manually in Android Studio, which I do sometimes for testing purposes. Without this change, you get an exception when channel syncing runs.)

I have tested this on my phone but not on Android TV.