### PR TITLE
DolphinQt/Mapping: Change "Dead Zone" color to a transparent black.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -72,7 +72,9 @@ QColor MappingIndicator::GetCenterColor() const
 
 QColor MappingIndicator::GetDeadZoneColor() const
 {
-  return palette().shadow().color();
+  QColor color = Qt::black;
+  color.setAlphaF(1 / 3.f);
+  return color;
 }
 
 QPen MappingIndicator::GetDeadZonePen() const


### PR DESCRIPTION
The previously used "shadow" color is inconsistent across system color palettes and often looks bad against some of our indicator backgrounds.

Before:
Notice the hideous dark lines on the yellow background. The contrast is so high it draws attention from the much more relevant raw and adjusted input dots.
https://i.imgur.com/aUriQaT.png

After:
Consistent subtle dead zone.
https://i.imgur.com/FFbmO2B.png