### PR TITLE
DolphinQt/Mapping: Tweak "Dead Zone" and "Gate" colors.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -44,7 +44,7 @@ public:
   QBrush GetDeadZoneBrush() const;
   QColor GetTextColor() const;
   QColor GetAltTextColor() const;
-  QColor GetGateColor() const;
+  void AdjustGateColor(QColor*);
 
 protected:
   double GetScale() const;


### PR DESCRIPTION
Changed "dead zone" color to a transparent black or white depending on theme.
Inverted value of "gate" colors when active theme has a dark background.
Tweaked order of "shake" indicator axis colors so red is more often shown.

Indicators now look less horrible with dark themes and the dead zone is more subtle as it should be.

Before:
https://i.imgur.com/aUriQaT.png
https://i.imgur.com/aHCSYCj.png

After:
https://i.imgur.com/cWZu4IS.png
https://i.imgur.com/JR8anBW.png