### PR TITLE
Core/NetPlayServer: Fix session not being added to index on direct connection type

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -101,8 +101,9 @@ NetPlayServer::~NetPlayServer()
 }
 
 // called from ---GUI--- thread
-NetPlayServer::NetPlayServer(const u16 port, const bool forward_port,
+NetPlayServer::NetPlayServer(const u16 port, const bool forward_port, NetPlayUI* dialog,
                              const NetTraversalConfig& traversal_config)
+    : m_dialog(dialog)
 {
   //--use server time
   if (enet_initialize() != 0)
@@ -209,11 +210,9 @@ void NetPlayServer::SetupIndex()
 
   session.EncryptID(Config::Get(Config::NETPLAY_INDEX_PASSWORD));
 
+  bool success = m_index.Add(session);
   if (m_dialog != nullptr)
-  {
-    bool success = m_index.Add(session);
     m_dialog->OnIndexAdded(success, success ? "" : m_index.GetLastError());
-  }
 
   m_index.SetErrorCallback([this] {
     if (m_dialog != nullptr)
@@ -1931,11 +1930,6 @@ bool NetPlayServer::PlayerHasControllerMapped(const PlayerId pid) const
 u16 NetPlayServer::GetPort() const
 {
   return m_server->address.port;
-}
-
-void NetPlayServer::SetNetPlayUI(NetPlayUI* dialog)
-{
-  m_dialog = dialog;
 }
 
 // called from ---GUI--- thread

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -39,7 +39,8 @@ public:
   void SendChunkedToClients(sf::Packet&& packet, PlayerId skip_pid = 0,
                             const std::string& title = "");
 
-  NetPlayServer(u16 port, bool forward_port, const NetTraversalConfig& traversal_config);
+  NetPlayServer(u16 port, bool forward_port, NetPlayUI* dialog,
+                const NetTraversalConfig& traversal_config);
   ~NetPlayServer();
 
   bool ChangeGame(const std::string& game);
@@ -67,7 +68,6 @@ public:
 
   u16 GetPort() const;
 
-  void SetNetPlayUI(NetPlayUI* dialog);
   std::unordered_set<std::string> GetInterfaceSet() const;
   std::string GetInterfaceHost(const std::string& inter) const;
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1336,9 +1336,6 @@ bool MainWindow::NetPlayJoin()
     return false;
   }
 
-  if (server != nullptr)
-    server->SetNetPlayUI(m_netplay_dialog);
-
   m_netplay_setup_dialog->close();
   m_netplay_dialog->show(nickname, is_traversal);
 
@@ -1376,7 +1373,7 @@ bool MainWindow::NetPlayHost(const QString& game_id)
 
   // Create Server
   Settings::Instance().ResetNetPlayServer(new NetPlay::NetPlayServer(
-      host_port, use_upnp,
+      host_port, use_upnp, m_netplay_dialog,
       NetPlay::NetTraversalConfig{is_traversal, traversal_host, traversal_port}));
 
   if (!Settings::Instance().GetNetPlayServer()->is_connected)


### PR DESCRIPTION
Order of operations issue. I also made `SetupIndex` not hard dependent on `m_dialog` just in case.