### PR TITLE
DolphinQt: setTabKeyNavigation(false) on QTableWidget and QTableView.

### DIFF
--- a/Source/Core/DolphinQt/CheatsManager.cpp
+++ b/Source/Core/DolphinQt/CheatsManager.cpp
@@ -368,6 +368,9 @@ QWidget* CheatsManager::CreateCheatSearch()
   m_match_table = new QTableWidget;
   m_watch_table = new QTableWidget;
 
+  m_match_table->setTabKeyNavigation(false);
+  m_watch_table->setTabKeyNavigation(false);
+
   m_match_table->verticalHeader()->hide();
   m_watch_table->verticalHeader()->hide();
 

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -295,6 +295,8 @@ void IOWindow::CreateMainLayout()
 
   // Options (Buttons, Outputs) and action buttons
 
+  m_option_list->setTabKeyNavigation(false);
+
   if (m_type == Type::Input)
   {
     m_option_list->setColumnCount(2);

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -41,6 +41,7 @@ VerifyWidget::VerifyWidget(std::shared_ptr<DiscIO::Volume> volume) : m_volume(st
 void VerifyWidget::CreateWidgets()
 {
   m_problems = new QTableWidget(0, 2, this);
+  m_problems->setTabKeyNavigation(false);
   m_problems->setHorizontalHeaderLabels({tr("Problem"), tr("Severity")});
   m_problems->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
   m_problems->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -76,6 +76,7 @@ void BreakpointWidget::CreateWidgets()
   m_toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
   m_table = new QTableWidget;
+  m_table->setTabKeyNavigation(false);
   m_table->setContentsMargins(0, 0, 0, 0);
   m_table->setColumnCount(5);
   m_table->setSelectionMode(QAbstractItemView::SingleSelection);

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -73,6 +73,7 @@ void JITWidget::CreateWidgets()
 {
   m_table_widget = new QTableWidget;
 
+  m_table_widget->setTabKeyNavigation(false);
   m_table_widget->setColumnCount(7);
   m_table_widget->setHorizontalHeaderLabels(
       {tr("Address"), tr("PPC Size"), tr("Host Size"),

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -69,6 +69,7 @@ void RegisterWidget::showEvent(QShowEvent* event)
 void RegisterWidget::CreateWidgets()
 {
   m_table = new QTableWidget;
+  m_table->setTabKeyNavigation(false);
 
   m_table->setColumnCount(9);
 

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -73,6 +73,7 @@ void WatchWidget::CreateWidgets()
   m_toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 
   m_table = new QTableWidget;
+  m_table->setTabKeyNavigation(false);
 
   m_table->setContentsMargins(0, 0, 0, 0);
   m_table->setColumnCount(NUM_COLUMNS);

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -93,6 +93,7 @@ void GCMemcardManager::CreateWidgets()
     m_slot_file_edit[i] = new QLineEdit;
     m_slot_file_button[i] = new QPushButton(tr("&Browse..."));
     m_slot_table[i] = new QTableWidget;
+    m_slot_table[i]->setTabKeyNavigation(false);
     m_slot_stat_label[i] = new QLabel;
 
     m_slot_table[i]->setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -102,6 +102,7 @@ void GameList::MakeListView()
   m_list = new QTableView(this);
   m_list->setModel(m_list_proxy);
 
+  m_list->setTabKeyNavigation(false);
   m_list->setSelectionMode(QAbstractItemView::ExtendedSelection);
   m_list->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_list->setAlternatingRowColors(true);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -61,6 +61,7 @@ void NetPlayBrowser::CreateWidgets()
   auto* layout = new QVBoxLayout;
 
   m_table_widget = new QTableWidget;
+  m_table_widget->setTabKeyNavigation(false);
 
   m_table_widget->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_table_widget->setSelectionMode(QAbstractItemView::SingleSelection);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -231,6 +231,7 @@ void NetPlayDialog::CreatePlayersLayout()
   m_kick_button = new QPushButton(tr("Kick Player"));
   m_assign_ports_button = new QPushButton(tr("Assign Controller Ports"));
 
+  m_players_list->setTabKeyNavigation(false);
   m_players_list->setColumnCount(5);
   m_players_list->verticalHeader()->hide();
   m_players_list->setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/Source/Core/DolphinQt/ResourcePackManager.cpp
+++ b/Source/Core/DolphinQt/ResourcePackManager.cpp
@@ -33,6 +33,7 @@ void ResourcePackManager::CreateWidgets()
   auto* layout = new QGridLayout;
 
   m_table_widget = new QTableWidget;
+  m_table_widget->setTabKeyNavigation(false);
 
   m_open_directory_button = new QPushButton(tr("Open Directory..."));
   m_change_button = new QPushButton(tr("Install"));


### PR DESCRIPTION
This allows tab-navigation to escape tables.
Arrow navigation within the table is still possible.

Fixes: https://bugs.dolphin-emu.org/issues/11790

See: https://stackoverflow.com/questions/46399167/how-to-move-from-a-qtablewidget-to-the-next-widget-using-the-tab-key