### PR TITLE
DolphinQt: Give hotkeys their own "background input" setting.

### DIFF
--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -12,4 +12,6 @@ const ConfigInfo<bool> MAIN_USE_DISCORD_PRESENCE{{System::Main, "General", "UseD
                                                  true};
 const ConfigInfo<bool> MAIN_USE_GAME_COVERS{{System::Main, "General", "UseGameCovers"}, false};
 
+const ConfigInfo<bool> MAIN_FOCUSED_HOTKEYS{{System::Main, "General", "HotkeysRequireFocus"}, true};
+
 }  // namespace Config

--- a/Source/Core/Core/Config/UISettings.h
+++ b/Source/Core/Core/Config/UISettings.h
@@ -18,5 +18,6 @@ namespace Config
 
 extern const ConfigInfo<bool> MAIN_USE_DISCORD_PRESENCE;
 extern const ConfigInfo<bool> MAIN_USE_GAME_COVERS;
+extern const ConfigInfo<bool> MAIN_FOCUSED_HOTKEYS;
 
 }  // namespace Config

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -1050,11 +1050,10 @@ void DoFrameStep()
   }
 }
 
-void UpdateInputGate()
+void UpdateInputGate(bool require_focus)
 {
-  ControlReference::SetInputGate(
-      (SConfig::GetInstance().m_BackgroundInput || Host_RendererHasFocus()) &&
-      !Host_UIBlocksControllerState());
+  ControlReference::SetInputGate((!require_focus || Host_RendererHasFocus()) &&
+                                 !Host_UIBlocksControllerState());
 }
 
 }  // namespace Core

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -112,6 +112,6 @@ void HostDispatchJobs();
 
 void DoFrameStep();
 
-void UpdateInputGate();
+void UpdateInputGate(bool require_focus);
 
 }  // namespace Core

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -826,7 +826,7 @@ void Update(u64 ticks)
 
   if (s_half_line_of_next_si_poll == s_half_line_count)
   {
-    Core::UpdateInputGate();
+    Core::UpdateInputGate(!SConfig::GetInstance().m_BackgroundInput);
     SerialInterface::UpdateDevices();
     s_half_line_of_next_si_poll += 2 * SerialInterface::GetPollXLines();
   }

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -16,8 +16,10 @@
 #include "Common/Thread.h"
 
 #include "Core/Config/GraphicsSettings.h"
+#include "Core/Config/UISettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/Host.h"
 #include "Core/HotkeyManager.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/Bluetooth/BTBase.h"
@@ -143,8 +145,8 @@ void HotkeyScheduler::Run()
 
     if (Core::GetState() != Core::State::Stopping)
     {
-      // Obey window focus before checking hotkeys.
-      Core::UpdateInputGate();
+      // Obey window focus (config permitting) before checking hotkeys.
+      Core::UpdateInputGate(Config::Get(Config::MAIN_FOCUSED_HOTKEYS));
 
       HotkeyManagerEmu::GetStatus();
 

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -151,11 +151,13 @@ void InterfacePane::CreateUI()
   m_checkbox_use_covers =
       new QCheckBox(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"));
   m_checkbox_show_debugging_ui = new QCheckBox(tr("Show Debugging UI"));
+  m_checkbox_focused_hotkeys = new QCheckBox(tr("Hotkeys Require Window Focus"));
 
   groupbox_layout->addWidget(m_checkbox_use_builtin_title_database);
   groupbox_layout->addWidget(m_checkbox_use_userstyle);
   groupbox_layout->addWidget(m_checkbox_use_covers);
   groupbox_layout->addWidget(m_checkbox_show_debugging_ui);
+  groupbox_layout->addWidget(m_checkbox_focused_hotkeys);
 }
 
 void InterfacePane::CreateInGame()
@@ -188,6 +190,7 @@ void InterfacePane::ConnectLayout()
           &InterfacePane::OnSaveConfig);
   connect(m_checkbox_use_covers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
+  connect(m_checkbox_focused_hotkeys, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_combobox_theme,
           static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
           &Settings::Instance(), &Settings::SetThemeName);
@@ -239,6 +242,7 @@ void InterfacePane::LoadConfig()
   m_checkbox_show_active_title->setChecked(startup_params.m_show_active_title);
   m_checkbox_pause_on_focus_lost->setChecked(startup_params.m_PauseOnFocusLost);
   m_checkbox_use_covers->setChecked(Config::Get(Config::MAIN_USE_GAME_COVERS));
+  m_checkbox_focused_hotkeys->setChecked(Config::Get(Config::MAIN_FOCUSED_HOTKEYS));
   m_checkbox_hide_mouse->setChecked(Settings::Instance().GetHideCursor());
 }
 
@@ -281,6 +285,8 @@ void InterfacePane::OnSaveConfig()
     Config::SetBase(Config::MAIN_USE_GAME_COVERS, use_covers);
     Settings::Instance().RefreshMetadata();
   }
+
+  Config::SetBase(Config::MAIN_FOCUSED_HOTKEYS, m_checkbox_focused_hotkeys->isChecked());
 
   settings.SaveSettings();
 }

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -35,6 +35,7 @@ private:
   QCheckBox* m_checkbox_use_builtin_title_database;
   QCheckBox* m_checkbox_use_userstyle;
   QCheckBox* m_checkbox_show_debugging_ui;
+  QCheckBox* m_checkbox_focused_hotkeys;
   QCheckBox* m_checkbox_use_covers;
 
   QCheckBox* m_checkbox_confirm_on_stop;


### PR DESCRIPTION
Setting is named "Hotkeys Require Window Focus".
Please give opinions on the naming in the UI+INI and whether the checked state should be enabled or disabled.
![image](https://user-images.githubusercontent.com/1768214/74074439-a269ef00-49d3-11ea-9957-f68f49e491d8.png)
Fixes: https://bugs.dolphin-emu.org/issues/8262