### PR TITLE
InputCommon: Add "Dead Zone" and "Calibration Period" to raw gyro inputs.

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -91,6 +92,45 @@ struct Rectangle
     top = std::clamp(top, y1, y2);
     bottom = std::clamp(bottom, y1, y2);
   }
+};
+
+template <typename T>
+class RunningMean
+{
+public:
+  constexpr void Clear() { *this = {}; }
+
+  constexpr void Push(T x) { m_mean = m_mean + (x - m_mean) / ++m_count; }
+
+  constexpr size_t Count() const { return m_count; }
+  constexpr T Mean() const { return m_mean; }
+
+private:
+  size_t m_count = 0;
+  T m_mean{};
+};
+
+template <typename T>
+class RunningVariance
+{
+public:
+  constexpr void Clear() { *this = {}; }
+
+  constexpr void Push(T x)
+  {
+    const auto old_mean = m_running_mean.Mean();
+    m_running_mean.Push(x);
+    m_variance += (x - old_mean) * (x - m_running_mean.Mean());
+  }
+
+  constexpr size_t Count() const { return m_running_mean.Count(); }
+  constexpr T Mean() const { return m_running_mean.Mean(); }
+  constexpr T Variance() const { return m_variance / (Count() - 1); }
+  constexpr T StandardDeviation() const { return std::sqrt(Variance()); }
+
+private:
+  RunningMean<T> m_running_mean;
+  T m_variance{};
 };
 
 }  // namespace MathUtil

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -101,6 +101,7 @@ public:
 private:
   ControllerEmu::IMUGyroscope& m_gyro_group;
   Common::Matrix33 m_state;
+  Common::Vec3 m_previous_velocity = {};
   u32 m_stable_steps = 0;
 };
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -15,6 +15,15 @@
 
 namespace ControllerEmu
 {
+// Maximum period for calculating an average stable value.
+// Just to prevent failures due to timer overflow.
+static constexpr auto MAXIMUM_CALIBRATION_DURATION = std::chrono::hours(1);
+
+// If calibration updates do not happen at this rate, restart calibration period.
+// This prevents calibration across periods of no regular updates. (e.g. between game sessions)
+// This is made slightly lower than the UI update frequency of 30.
+static constexpr auto WORST_ACCEPTABLE_CALIBRATION_UPDATE_FREQUENCY = 25;
+
 IMUGyroscope::IMUGyroscope(std::string name, std::string ui_name)
     : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUGyroscope)
 {
@@ -31,7 +40,79 @@ IMUGyroscope::IMUGyroscope(std::string name, std::string ui_name)
               _trans("°/s"),
               // i18n: Refers to the dead-zone setting of gyroscope input.
               _trans("Angular velocity to ignore.")},
-             1, 0, 180);
+             2, 0, 180);
+
+  AddSetting(&m_calibration_period_setting,
+             {_trans("Calibration Period"),
+              // i18n: "s" is the symbol for seconds.
+              _trans("s"),
+              // i18n: Refers to the "Calibration" setting of gyroscope input.
+              _trans("Time period of stable input to trigger calibration. (zero to disable)")},
+             3, 0, 30);
+}
+
+void IMUGyroscope::RestartCalibration() const
+{
+  m_calibration_period_start = Clock::now();
+  m_running_calibration.Clear();
+}
+
+void IMUGyroscope::UpdateCalibration(const StateData& state) const
+{
+  const auto now = Clock::now();
+  const auto calibration_period = m_calibration_period_setting.GetValue();
+
+  // If calibration time is zero. User is choosing to not calibrate.
+  if (!calibration_period)
+  {
+    // Set calibration to zero.
+    m_calibration = {};
+    RestartCalibration();
+    return;
+  }
+
+  // If there is no running calibration a new gyro was just mapped or calibration was just enabled,
+  // apply the current state as calibration, it's often better than zeros.
+  if (!m_running_calibration.Count())
+  {
+    m_calibration = state;
+  }
+  else
+  {
+    const auto calibration_freq =
+        m_running_calibration.Count() /
+        std::chrono::duration_cast<std::chrono::duration<double>>(now - m_calibration_period_start)
+            .count();
+
+    const auto potential_calibration = m_running_calibration.Mean();
+    const auto current_difference = state - potential_calibration;
+    const auto deadzone = GetDeadzone();
+
+    // Check for required calibration update frequency
+    // and if current data is within deadzone distance of mean stable value.
+    if (calibration_freq < WORST_ACCEPTABLE_CALIBRATION_UPDATE_FREQUENCY ||
+        std::any_of(current_difference.data.begin(), current_difference.data.end(),
+                    [&](auto c) { return std::abs(c) > deadzone; }))
+    {
+      RestartCalibration();
+    }
+  }
+
+  // Update running mean stable value.
+  m_running_calibration.Push(state);
+
+  // Apply calibration after configured time.
+  const auto calibration_duration = now - m_calibration_period_start;
+  if (calibration_duration >= std::chrono::duration<double>(calibration_period))
+  {
+    m_calibration = m_running_calibration.Mean();
+
+    if (calibration_duration >= MAXIMUM_CALIBRATION_DURATION)
+    {
+      RestartCalibration();
+      m_running_calibration.Push(m_calibration);
+    }
+  }
 }
 
 auto IMUGyroscope::GetRawState() const -> StateData
@@ -44,9 +125,20 @@ auto IMUGyroscope::GetRawState() const -> StateData
 std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState() const
 {
   if (controls[0]->control_ref->BoundCount() == 0)
+  {
+    // Set calibration to zero.
+    m_calibration = {};
+    RestartCalibration();
     return std::nullopt;
+  }
 
   auto state = GetRawState();
+
+  // If the input gate is disabled, miscalibration to zero values would occur.
+  if (ControlReference::GetInputGate())
+    UpdateCalibration(state);
+
+  state -= m_calibration;
 
   // Apply "deadzone".
   for (auto& c : state.data)
@@ -58,6 +150,13 @@ std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState() const
 ControlState IMUGyroscope::GetDeadzone() const
 {
   return m_deadzone_setting.GetValue() / 360 * MathUtil::TAU;
+}
+
+bool IMUGyroscope::IsCalibrating() const
+{
+  const auto calibration_period = m_calibration_period_setting.GetValue();
+  return calibration_period && (Clock::now() - m_calibration_period_start) >=
+                                   std::chrono::duration<double>(calibration_period);
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "Common/Common.h"
+#include "Common/MathUtil.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
@@ -23,6 +24,21 @@ IMUGyroscope::IMUGyroscope(std::string name, std::string ui_name)
   AddInput(Translate, _trans("Roll Right"));
   AddInput(Translate, _trans("Yaw Left"));
   AddInput(Translate, _trans("Yaw Right"));
+
+  AddSetting(&m_deadzone_setting,
+             {_trans("Dead Zone"),
+              // i18n: "°/s" is the symbol for degrees (angular measurement) divided by seconds.
+              _trans("°/s"),
+              // i18n: Refers to the dead-zone setting of gyroscope input.
+              _trans("Angular velocity to ignore.")},
+             1, 0, 180);
+}
+
+auto IMUGyroscope::GetRawState() const -> StateData
+{
+  return StateData(controls[1]->GetState() - controls[0]->GetState(),
+                   controls[2]->GetState() - controls[3]->GetState(),
+                   controls[4]->GetState() - controls[5]->GetState());
 }
 
 std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState() const
@@ -30,11 +46,18 @@ std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState() const
   if (controls[0]->control_ref->BoundCount() == 0)
     return std::nullopt;
 
-  StateData state;
-  state.x = (controls[1]->GetState() - controls[0]->GetState());
-  state.y = (controls[2]->GetState() - controls[3]->GetState());
-  state.z = (controls[4]->GetState() - controls[5]->GetState());
+  auto state = GetRawState();
+
+  // Apply "deadzone".
+  for (auto& c : state.data)
+    c *= std::abs(c) > GetDeadzone();
+
   return state;
+}
+
+ControlState IMUGyroscope::GetDeadzone() const
+{
+  return m_deadzone_setting.GetValue() / 360 * MathUtil::TAU;
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include <chrono>
 #include <optional>
 #include <string>
 
+#include "Common/MathUtil.h"
 #include "Common/Matrix.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
@@ -26,7 +28,19 @@ public:
   // Value is in rad/s.
   ControlState GetDeadzone() const;
 
+  bool IsCalibrating() const;
+
 private:
+  using Clock = std::chrono::steady_clock;
+
+  void RestartCalibration() const;
+  void UpdateCalibration(const StateData&) const;
+
   SettingValue<double> m_deadzone_setting;
+  SettingValue<double> m_calibration_period_setting;
+
+  mutable StateData m_calibration = {};
+  mutable MathUtil::RunningMean<StateData> m_running_calibration;
+  mutable Clock::time_point m_calibration_period_start = Clock::now();
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
@@ -9,6 +9,7 @@
 
 #include "Common/Matrix.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {
@@ -19,6 +20,13 @@ public:
 
   IMUGyroscope(std::string name, std::string ui_name);
 
+  StateData GetRawState() const;
   std::optional<StateData> GetState() const;
+
+  // Value is in rad/s.
+  ControlState GetDeadzone() const;
+
+private:
+  SettingValue<double> m_deadzone_setting;
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
Mapping indicator draws a line representing the angular velocity relative to the configured dead zone assisting configuration.
Sphere outline turns blue during calibration which occurs after the configured period of data is as stable as the configured dead zone.
![image](https://user-images.githubusercontent.com/1768214/74392477-e9d5ee00-4dcc-11ea-84c2-fa90bd6bf20e.png)

This fixes horizontal drift of IMU pointing with imperfectly calibrated controllers.
https://bugs.dolphin-emu.org/issues/11971