### PR TITLE
HW/WiimoteEmu: Allow emulating the "Classic Controller Pro".

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -200,7 +200,8 @@ void Wiimote::HandleExtensionSwap()
     }
   }
 
-  if (GetActiveExtensionNumber() != desired_extension_number)
+  if (GetActiveExtensionNumber() != desired_extension_number ||
+      GetActiveExtension()->IsResetNeeded())
   {
     // A different extension is wanted (either by user or by the M+ logic above)
     if (GetActiveExtensionNumber() != ExtensionNumber::NONE)

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
@@ -6,6 +6,7 @@
 
 #include "Core/HW/WiimoteCommon/WiimoteReport.h"
 #include "Core/HW/WiimoteEmu/Extension/Extension.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace ControllerEmu
 {
@@ -23,7 +24,8 @@ enum class ClassicGroup
   Triggers,
   DPad,
   LeftStick,
-  RightStick
+  RightStick,
+  Options,
 };
 
 class Classic : public Extension1stParty
@@ -86,6 +88,8 @@ public:
   bool IsButtonPressed() const override;
   void Reset() override;
 
+  bool IsResetNeeded() const override;
+
   ControllerEmu::ControlGroup* GetGroup(ClassicGroup group);
 
   static constexpr u16 PAD_RIGHT = 0x80;
@@ -123,10 +127,15 @@ public:
   static constexpr u8 TRIGGER_RANGE = 0x1F;
 
 private:
+  bool IsCurrentlyClassicControllerPro() const;
+
   ControllerEmu::Buttons* m_buttons;
   ControllerEmu::MixedTriggers* m_triggers;
   ControllerEmu::Buttons* m_dpad;
   ControllerEmu::AnalogStick* m_left_stick;
   ControllerEmu::AnalogStick* m_right_stick;
+  ControllerEmu::ControlGroup* m_options;
+
+  ControllerEmu::SettingValue<bool> m_cc_pro_setting;
 };
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
@@ -35,6 +35,11 @@ std::string Extension::GetDisplayName() const
   return m_display_name;
 }
 
+bool Extension::IsResetNeeded() const
+{
+  return false;
+}
+
 None::None() : Extension("None")
 {
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -36,6 +36,9 @@ public:
   virtual void DoState(PointerWrap& p) = 0;
   virtual void Update() = 0;
 
+  // Wii Remote checks this in case config changes require a re-connection of the extension.
+  virtual bool IsResetNeeded() const;
+
 private:
   const char* const m_config_name;
   const char* const m_display_name;

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuExtension.cpp
@@ -59,9 +59,10 @@ void WiimoteEmuExtension::CreateClassicLayout()
                      Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::RightStick)),
       0, 2, -1, 1);
   layout->addWidget(
-      CreateGroupBox(tr("Triggers"),
-                     Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Triggers)),
-      0, 3, -1, 1);
+      CreateGroupBox(Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Triggers)), 0,
+      3);
+  layout->addWidget(
+      CreateGroupBox(Wiimote::GetClassicGroup(GetPort(), WiimoteEmu::ClassicGroup::Options)), 1, 3);
 
   m_classic_box->setLayout(layout);
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
@@ -16,11 +16,17 @@ class MixedTriggers : public ControlGroup
 public:
   explicit MixedTriggers(const std::string& name);
 
-  void GetState(u16* digital, const u16* bitmasks, ControlState* analog,
-                bool adjusted = true) const;
+  size_t GetTriggerCount() const;
+
+  void GetState(u16* digital, const u16* bitmasks, ControlState* analog) const;
+
+  ControlState GetRawDigitalState(size_t index) const;
+  ControlState GetRawAnalogState(size_t index) const;
 
   ControlState GetDeadzone() const;
   ControlState GetThreshold() const;
+
+  virtual bool IsAnalogEnabled() const;
 
 private:
   SettingValue<double> m_threshold_setting;


### PR DESCRIPTION
The "Pro" version does not have analog triggers.
Apparently some games are aware of this and change their controls.
The mapping indicator changes appropriately when enabled.
![image](https://user-images.githubusercontent.com/1768214/74079386-58493380-49fc-11ea-8164-e3f1334f69ef.png)
Setting name good as just "Classic Controller Pro" ?