### PR TITLE
Cleanup: Use std::abs instead of abs.

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -70,8 +70,8 @@ struct Rectangle
     return left == r.left && top == r.top && right == r.right && bottom == r.bottom;
   }
 
-  T GetWidth() const { return abs(right - left); }
-  T GetHeight() const { return abs(bottom - top); }
+  T GetWidth() const { return std::abs(right - left); }
+  T GetHeight() const { return std::abs(bottom - top); }
   // If the rectangle is in a coordinate system with a lower-left origin, use
   // this Clamp.
   void ClampLL(T x1, T y1, T x2, T y2)

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -191,10 +191,10 @@ void ThrottleCallback(u64 last_time, s64 cyclesLate)
     if (config.m_EmulationSpeed != 1.0f)
       next_event = u32(next_event * config.m_EmulationSpeed);
     const s64 max_fallback = config.iTimingVariance * 1000;
-    if (abs(diff) > max_fallback)
+    if (std::abs(diff) > max_fallback)
     {
       DEBUG_LOG(COMMON, "system too %s, %" PRIi64 " ms skipped", diff < 0 ? "slow" : "fast",
-                abs(diff) - max_fallback);
+                std::abs(diff) - max_fallback);
       last_time = time - max_fallback;
     }
     else if (diff > 1000)

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -310,6 +310,6 @@ ControlState Joystick::Hat::GetState() const
   if (is_centered)
     return 0;
 
-  return (abs((int)(m_hat / 4500 - m_direction * 2 + 8) % 8 - 4) > 2);
+  return (std::abs(int(m_hat / 4500 - m_direction * 2 + 8) % 8 - 4) > 2);
 }
 }  // namespace ciface::DInput


### PR DESCRIPTION
`std::abs` is the proper function.
This fixes some value truncation warnings.