### PR TITLE
InputCommon: Clean up creation of inputs.

### DIFF
--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -55,27 +55,27 @@ GCKeyboard::GCKeyboard(const unsigned int index) : m_index(index)
   // buttons
   groups.emplace_back(m_keys0x = new ControllerEmu::Buttons(_trans("Keys")));
   for (const char* key : named_keys0)
-    m_keys0x->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, key));
+    m_keys0x->AddInput(ControllerEmu::DoNotTranslate, key);
 
   groups.emplace_back(m_keys1x = new ControllerEmu::Buttons(_trans("Keys")));
   for (const char* key : named_keys1)
-    m_keys1x->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, key));
+    m_keys1x->AddInput(ControllerEmu::DoNotTranslate, key);
 
   groups.emplace_back(m_keys2x = new ControllerEmu::Buttons(_trans("Keys")));
   for (const char* key : named_keys2)
-    m_keys2x->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, key));
+    m_keys2x->AddInput(ControllerEmu::DoNotTranslate, key);
 
   groups.emplace_back(m_keys3x = new ControllerEmu::Buttons(_trans("Keys")));
   for (const char* key : named_keys3)
-    m_keys3x->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, key));
+    m_keys3x->AddInput(ControllerEmu::DoNotTranslate, key);
 
   groups.emplace_back(m_keys4x = new ControllerEmu::Buttons(_trans("Keys")));
   for (const char* key : named_keys4)
-    m_keys4x->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, key));
+    m_keys4x->AddInput(ControllerEmu::DoNotTranslate, key);
 
   groups.emplace_back(m_keys5x = new ControllerEmu::Buttons(_trans("Keys")));
   for (const char* key : named_keys5)
-    m_keys5x->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, key));
+    m_keys5x->AddInput(ControllerEmu::DoNotTranslate, key);
 
   // options
   groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -59,8 +59,8 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
     const ControllerEmu::Translatability translate =
         is_start ? ControllerEmu::Translate : ControllerEmu::DoNotTranslate;
     // i18n: The START/PAUSE button on GameCube controllers
-    const std::string& ui_name = is_start ? _trans("START") : named_button;
-    m_buttons->controls.emplace_back(new ControllerEmu::Input(translate, named_button, ui_name));
+    std::string ui_name = is_start ? _trans("START") : named_button;
+    m_buttons->AddInput(translate, named_button, std::move(ui_name));
   }
 
   // sticks
@@ -77,26 +77,22 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
   groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
   for (const char* named_trigger : named_triggers)
   {
-    m_triggers->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, named_trigger));
+    m_triggers->AddInput(ControllerEmu::Translate, named_trigger);
   }
 
   // rumble
   groups.emplace_back(m_rumble = new ControllerEmu::ControlGroup(_trans("Rumble")));
-  m_rumble->controls.emplace_back(
-      new ControllerEmu::Output(ControllerEmu::Translate, _trans("Motor")));
+  m_rumble->AddOutput(ControllerEmu::Translate, _trans("Motor"));
 
   // Microphone
   groups.emplace_back(m_mic = new ControllerEmu::Buttons(_trans("Microphone")));
-  m_mic->controls.emplace_back(
-      new ControllerEmu::Input(ControllerEmu::Translate, _trans("Button")));
+  m_mic->AddInput(ControllerEmu::Translate, _trans("Button"));
 
   // dpad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
   for (const char* named_direction : named_directions)
   {
-    m_dpad->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, named_direction));
+    m_dpad->AddInput(ControllerEmu::Translate, named_direction);
   }
 
   // options

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cassert>
+#include <string_view>
 
 #include "Common/BitUtils.h"
 #include "Common/Common.h"
@@ -37,7 +38,7 @@ constexpr std::array<u16, 9> classic_button_bitmasks{{
     Classic::BUTTON_HOME,
 }};
 
-constexpr std::array<const char*, 9> classic_button_names{{
+constexpr std::array<std::string_view, 9> classic_button_names{{
     "A",
     "B",
     "X",
@@ -76,11 +77,11 @@ Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
 {
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (const char* button_name : classic_button_names)
+  for (auto& button_name : classic_button_names)
   {
-    const std::string& ui_name = (button_name == std::string("Home")) ? "HOME" : button_name;
-    m_buttons->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::DoNotTranslate, button_name, ui_name));
+    std::string_view ui_name = (button_name == "Home") ? "HOME" : button_name;
+    m_buttons->AddInput(ControllerEmu::DoNotTranslate, std::string(button_name),
+                        std::string(ui_name));
   }
 
   // sticks
@@ -94,16 +95,14 @@ Classic::Classic() : Extension1stParty("Classic", _trans("Classic Controller"))
   groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
   for (const char* trigger_name : classic_trigger_names)
   {
-    m_triggers->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, trigger_name));
+    m_triggers->AddInput(ControllerEmu::Translate, trigger_name);
   }
 
   // dpad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
   for (const char* named_direction : named_directions)
   {
-    m_dpad->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, named_direction));
+    m_dpad->AddInput(ControllerEmu::Translate, named_direction);
   }
 }
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -29,8 +29,7 @@ DrawsomeTablet::DrawsomeTablet() : Extension3rdParty("Drawsome", _trans("Drawsom
 
   // Touch
   groups.emplace_back(m_touch = new ControllerEmu::Triggers(_trans("Touch")));
-  m_touch->controls.emplace_back(
-      new ControllerEmu::Input(ControllerEmu::Translate, _trans("Pressure")));
+  m_touch->AddInput(ControllerEmu::Translate, _trans("Pressure"));
 }
 
 void DrawsomeTablet::Update()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -58,8 +58,7 @@ Drums::Drums() : Extension1stParty("Drums", _trans("Drum Kit"))
   groups.emplace_back(m_pads = new ControllerEmu::Buttons(_trans("Pads")));
   for (auto& drum_pad_name : drum_pad_names)
   {
-    m_pads->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, drum_pad_name));
+    m_pads->AddInput(ControllerEmu::Translate, drum_pad_name);
   }
 
   m_pads->AddSetting(&m_hit_strength_setting,
@@ -75,8 +74,8 @@ Drums::Drums() : Extension1stParty("Drums", _trans("Drum Kit"))
 
   // Buttons.
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "-"));
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "+"));
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "-");
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "+");
 }
 
 void Drums::Update()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -68,20 +68,18 @@ Guitar::Guitar() : Extension1stParty(_trans("Guitar"))
   groups.emplace_back(m_frets = new ControllerEmu::Buttons(_trans("Frets")));
   for (auto& guitar_fret_name : guitar_fret_names)
   {
-    m_frets->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, guitar_fret_name));
+    m_frets->AddInput(ControllerEmu::Translate, guitar_fret_name);
   }
 
   // strum
   groups.emplace_back(m_strum = new ControllerEmu::Buttons(_trans("Strum")));
-  m_strum->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::Translate, _trans("Up")));
-  m_strum->controls.emplace_back(
-      new ControllerEmu::Input(ControllerEmu::Translate, _trans("Down")));
+  m_strum->AddInput(ControllerEmu::Translate, _trans("Up"));
+  m_strum->AddInput(ControllerEmu::Translate, _trans("Down"));
 
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "-"));
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "+"));
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "-");
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "+");
 
   // stick
   constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
@@ -90,8 +88,7 @@ Guitar::Guitar() : Extension1stParty(_trans("Guitar"))
 
   // whammy
   groups.emplace_back(m_whammy = new ControllerEmu::Triggers(_trans("Whammy")));
-  m_whammy->controls.emplace_back(
-      new ControllerEmu::Input(ControllerEmu::Translate, _trans("Bar")));
+  m_whammy->AddInput(ControllerEmu::Translate, _trans("Bar"));
 
   // slider bar
   groups.emplace_back(m_slider_bar = new ControllerEmu::Slider(_trans("Slider Bar")));

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -37,8 +37,8 @@ Nunchuk::Nunchuk() : Extension1stParty(_trans("Nunchuk"))
 {
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "C"));
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "Z"));
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "C");
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "Z");
 
   // stick
   constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
@@ -41,12 +41,12 @@ TaTaCon::TaTaCon() : Extension3rdParty("TaTaCon", _trans("Taiko Drum"))
   // i18n: Refers to the "center" of a TaTaCon drum.
   groups.emplace_back(m_center = new ControllerEmu::Buttons(_trans("Center")));
   for (auto& name : position_names)
-    m_center->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::Translate, name));
+    m_center->AddInput(ControllerEmu::Translate, name);
 
   // i18n: Refers to the "rim" of a TaTaCon drum.
   groups.emplace_back(m_rim = new ControllerEmu::Buttons(_trans("Rim")));
   for (auto& name : position_names)
-    m_rim->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::Translate, name));
+    m_rim->AddInput(ControllerEmu::Translate, name);
 }
 
 void TaTaCon::Update()

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -51,16 +51,14 @@ Turntable::Turntable() : Extension1stParty("Turntable", _trans("DJ Turntable"))
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (auto& turntable_button_name : turntable_button_names)
   {
-    m_buttons->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, turntable_button_name));
+    m_buttons->AddInput(ControllerEmu::Translate, turntable_button_name);
   }
 
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "-"));
-  m_buttons->controls.emplace_back(new ControllerEmu::Input(ControllerEmu::DoNotTranslate, "+"));
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "-");
+  m_buttons->AddInput(ControllerEmu::DoNotTranslate, "+");
 
-  m_buttons->controls.emplace_back(
-      // i18n: This button name refers to a gameplay element in DJ Hero
-      new ControllerEmu::Input(ControllerEmu::Translate, _trans("Euphoria")));
+  // i18n: This button name refers to a gameplay element in DJ Hero
+  m_buttons->AddInput(ControllerEmu::Translate, _trans("Euphoria"));
 
   // turntables
   // i18n: "Table" refers to a turntable

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
@@ -37,8 +37,7 @@ UDrawTablet::UDrawTablet() : Extension3rdParty("uDraw", _trans("uDraw GameTablet
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (auto& button_name : udraw_tablet_button_names)
   {
-    m_buttons->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, button_name));
+    m_buttons->AddInput(ControllerEmu::Translate, button_name);
   }
 
   // Stylus
@@ -47,8 +46,7 @@ UDrawTablet::UDrawTablet() : Extension3rdParty("uDraw", _trans("uDraw GameTablet
 
   // Touch
   groups.emplace_back(m_touch = new ControllerEmu::Triggers(_trans("Touch")));
-  m_touch->controls.emplace_back(
-      new ControllerEmu::Input(ControllerEmu::Translate, _trans("Pressure")));
+  m_touch->AddInput(ControllerEmu::Translate, _trans("Pressure"));
 }
 
 void UDrawTablet::Update()

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
+#include <string_view>
 
 #include <fmt/format.h>
 
@@ -62,7 +63,7 @@ static const u16 dpad_bitmasks[] = {Wiimote::PAD_UP, Wiimote::PAD_DOWN, Wiimote:
 static const u16 dpad_sideways_bitmasks[] = {Wiimote::PAD_RIGHT, Wiimote::PAD_LEFT, Wiimote::PAD_UP,
                                              Wiimote::PAD_DOWN};
 
-static const char* const named_buttons[] = {
+constexpr std::array<std::string_view, 7> named_buttons{
     "A", "B", "1", "2", "-", "+", "Home",
 };
 
@@ -198,11 +199,11 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
 {
   // Buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
-  for (const char* named_button : named_buttons)
+  for (auto& named_button : named_buttons)
   {
-    const std::string& ui_name = (named_button == std::string("Home")) ? "HOME" : named_button;
-    m_buttons->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::DoNotTranslate, named_button, ui_name));
+    std::string_view ui_name = (named_button == "Home") ? "HOME" : named_button;
+    m_buttons->AddInput(ControllerEmu::DoNotTranslate, std::string(named_button),
+                        std::string(ui_name));
   }
 
   // Pointing (IR)
@@ -233,15 +234,13 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
 
   // Rumble
   groups.emplace_back(m_rumble = new ControllerEmu::ControlGroup(_trans("Rumble")));
-  m_rumble->controls.emplace_back(
-      m_motor = new ControllerEmu::Output(ControllerEmu::Translate, _trans("Motor")));
+  m_rumble->AddOutput(ControllerEmu::Translate, _trans("Motor"));
 
   // D-Pad
   groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
   for (const char* named_direction : named_directions)
   {
-    m_dpad->controls.emplace_back(
-        new ControllerEmu::Input(ControllerEmu::Translate, named_direction));
+    m_dpad->AddInput(ControllerEmu::Translate, named_direction);
   }
 
   // Options
@@ -780,7 +779,7 @@ bool Wiimote::IsUpright() const
 void Wiimote::SetRumble(bool on)
 {
   const auto lock = GetStateLock();
-  m_motor->control_ref->State(on);
+  m_rumble->controls.front()->control_ref->State(on);
 }
 
 void Wiimote::StepDynamics()

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -253,7 +253,6 @@ private:
   ControllerEmu::Tilt* m_tilt;
   ControllerEmu::Force* m_swing;
   ControllerEmu::ControlGroup* m_rumble;
-  ControllerEmu::Output* m_motor;
   ControllerEmu::Attachments* m_attachments;
   ControllerEmu::ControlGroup* m_options;
   ControllerEmu::ModifySettingsButton* m_hotkeys;

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -310,8 +310,7 @@ HotkeyManager::HotkeyManager()
     groups.emplace_back(m_hotkey_groups[group]);
     for (int key = s_groups_info[group].first; key <= s_groups_info[group].last; key++)
     {
-      m_keys[group]->controls.emplace_back(
-          new ControllerEmu::Input(ControllerEmu::Translate, s_hotkey_labels[key]));
+      m_keys[group]->AddInput(ControllerEmu::Translate, s_hotkey_labels[key]);
     }
   }
 }

--- a/Source/Core/InputCommon/ControllerEmu/Control/Control.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Control.cpp
@@ -10,14 +10,15 @@
 namespace ControllerEmu
 {
 Control::Control(std::unique_ptr<ControlReference> ref, Translatability translate_,
-                 const std::string& name_, const std::string& ui_name_)
-    : control_ref(std::move(ref)), translate(translate_), name(name_), ui_name(ui_name_)
+                 std::string name_, std::string ui_name_)
+    : control_ref(std::move(ref)), translate(translate_), name(std::move(name_)),
+      ui_name(std::move(ui_name_))
 {
 }
 
 Control::Control(std::unique_ptr<ControlReference> ref, Translatability translate_,
-                 const std::string& name_)
-    : Control(std::move(ref), translate_, name_, name_)
+                 std::string name_)
+    : control_ref(std::move(ref)), translate(translate_), name(name_), ui_name(std::move(name_))
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/Control/Control.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Control.h
@@ -34,10 +34,9 @@ public:
   const std::string ui_name;
 
 protected:
-  Control(std::unique_ptr<ControlReference> ref, Translatability translate, const std::string& name,
-          const std::string& ui_name);
-  Control(std::unique_ptr<ControlReference> ref, Translatability translate,
-          const std::string& name);
+  Control(std::unique_ptr<ControlReference> ref, Translatability translate, std::string name,
+          std::string ui_name);
+  Control(std::unique_ptr<ControlReference> ref, Translatability translate, std::string name);
 };
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
@@ -10,13 +10,13 @@
 
 namespace ControllerEmu
 {
-Input::Input(Translatability translate_, const std::string& name_, const std::string& ui_name_)
-    : Control(std::make_unique<InputReference>(), translate_, name_, ui_name_)
+Input::Input(Translatability translate_, std::string name_, std::string ui_name_)
+    : Control(std::make_unique<InputReference>(), translate_, std::move(name_), std::move(ui_name_))
 {
 }
 
-Input::Input(Translatability translate_, const std::string& name_)
-    : Control(std::make_unique<InputReference>(), translate_, name_)
+Input::Input(Translatability translate_, std::string name_)
+    : Control(std::make_unique<InputReference>(), translate_, std::move(name_))
 {
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Input.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Input.h
@@ -12,7 +12,7 @@ namespace ControllerEmu
 class Input : public Control
 {
 public:
-  Input(Translatability translate, const std::string& name, const std::string& ui_name);
-  Input(Translatability translate, const std::string& name);
+  Input(Translatability translate, std::string name, std::string ui_name);
+  Input(Translatability translate, std::string name);
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Output.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Output.cpp
@@ -10,8 +10,8 @@
 
 namespace ControllerEmu
 {
-Output::Output(Translatability translate_, const std::string& name_)
-    : Control(std::make_unique<OutputReference>(), translate_, name_)
+Output::Output(Translatability translate_, std::string name_)
+    : Control(std::make_unique<OutputReference>(), translate_, std::move(name_))
 {
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Output.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Output.h
@@ -12,6 +12,6 @@ namespace ControllerEmu
 class Output : public Control
 {
 public:
-  Output(Translatability translate, const std::string& name);
+  Output(Translatability translate, std::string name);
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -27,9 +27,9 @@ AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
     : ReshapableInput(name_, ui_name_, GroupType::Stick), m_stick_gate(std::move(stick_gate))
 {
   for (auto& named_direction : named_directions)
-    controls.emplace_back(std::make_unique<Input>(Translate, named_direction));
+    AddInput(Translate, named_direction);
 
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Modifier")));
+  AddInput(Translate, _trans("Modifier"));
 }
 
 AnalogStick::ReshapeData AnalogStick::GetReshapableState(bool adjusted)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -8,7 +8,8 @@
 #include "Common/IniFile.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
-#include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Control/Input.h"
+#include "InputCommon/ControllerEmu/Control/Output.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
@@ -138,4 +139,20 @@ void ControlGroup::SetControlExpression(int index, const std::string& expression
 {
   controls.at(index)->control_ref->SetExpression(expression);
 }
+
+void ControlGroup::AddInput(Translatability translate, std::string name_)
+{
+  controls.emplace_back(std::make_unique<Input>(translate, std::move(name_)));
+}
+
+void ControlGroup::AddInput(Translatability translate, std::string name_, std::string ui_name_)
+{
+  controls.emplace_back(std::make_unique<Input>(translate, std::move(name_), std::move(ui_name_)));
+}
+
+void ControlGroup::AddOutput(Translatability translate, std::string name_)
+{
+  controls.emplace_back(std::make_unique<Output>(translate, std::move(name_)));
+}
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -13,6 +13,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
+#include "InputCommon/ControllerEmu/Control/Control.h"
 
 namespace ControllerEmu
 {
@@ -66,6 +67,10 @@ public:
                           const std::string& base = "");
 
   void SetControlExpression(int index, const std::string& expression);
+
+  void AddInput(Translatability translate, std::string name);
+  void AddInput(Translatability translate, std::string name, std::string ui_name);
+  void AddOutput(Translatability translate, std::string name);
 
   template <typename T>
   void AddSetting(SettingValue<T>* value, const NumericSettingDetails& details,

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -26,12 +26,12 @@ Cursor::Cursor(std::string name, std::string ui_name)
       m_last_update(Clock::now())
 {
   for (auto& named_direction : named_directions)
-    controls.emplace_back(std::make_unique<Input>(Translate, named_direction));
+    AddInput(Translate, named_direction);
 
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Hide")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
+  AddInput(Translate, _trans("Hide"));
+  AddInput(Translate, _trans("Recenter"));
 
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Relative Input Hold")));
+  AddInput(Translate, _trans("Relative Input Hold"));
 
   // Default values are optimized for "Super Mario Galaxy 2".
   // This seems to be acceptable for a good number of games.

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
@@ -18,12 +18,12 @@ namespace ControllerEmu
 {
 Force::Force(const std::string& name_) : ReshapableInput(name_, name_, GroupType::Force)
 {
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Up")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Down")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Left")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Right")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Forward")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Backward")));
+  AddInput(Translate, _trans("Up"));
+  AddInput(Translate, _trans("Down"));
+  AddInput(Translate, _trans("Left"));
+  AddInput(Translate, _trans("Right"));
+  AddInput(Translate, _trans("Forward"));
+  AddInput(Translate, _trans("Backward"));
 
   AddSetting(&m_distance_setting,
              {_trans("Distance"),
@@ -127,11 +127,11 @@ Shake::Shake(const std::string& name_, ControlState default_intensity_scale)
     : ControlGroup(name_, name_, GroupType::Shake)
 {
   // i18n: Refers to a 3D axis (used when mapping motion controls)
-  controls.emplace_back(new ControllerEmu::Input(ControllerEmu::Translate, _trans("X")));
+  AddInput(ControllerEmu::Translate, _trans("X"));
   // i18n: Refers to a 3D axis (used when mapping motion controls)
-  controls.emplace_back(new ControllerEmu::Input(ControllerEmu::Translate, _trans("Y")));
+  AddInput(ControllerEmu::Translate, _trans("Y"));
   // i18n: Refers to a 3D axis (used when mapping motion controls)
-  controls.emplace_back(new ControllerEmu::Input(ControllerEmu::Translate, _trans("Z")));
+  AddInput(ControllerEmu::Translate, _trans("Z"));
 
   AddDeadzoneSetting(&m_deadzone_setting, 50);
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
@@ -17,12 +17,12 @@ namespace ControllerEmu
 IMUAccelerometer::IMUAccelerometer(std::string name, std::string ui_name)
     : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUAccelerometer)
 {
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Up")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Down")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Left")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Right")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Forward")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Backward")));
+  AddInput(Translate, _trans("Up"));
+  AddInput(Translate, _trans("Down"));
+  AddInput(Translate, _trans("Left"));
+  AddInput(Translate, _trans("Right"));
+  AddInput(Translate, _trans("Forward"));
+  AddInput(Translate, _trans("Backward"));
 }
 
 std::optional<IMUAccelerometer::StateData> IMUAccelerometer::GetState() const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -20,7 +20,7 @@ IMUCursor::IMUCursor(std::string name, std::string ui_name)
     : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUCursor,
                    ControlGroup::CanBeDisabled::Yes)
 {
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Recenter")));
+  AddInput(Translate, _trans("Recenter"));
 
   // Default values are optimized for "Super Mario Galaxy 2".
   // This seems to be acceptable for a good number of games.

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -17,12 +17,12 @@ namespace ControllerEmu
 IMUGyroscope::IMUGyroscope(std::string name, std::string ui_name)
     : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUGyroscope)
 {
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Pitch Up")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Pitch Down")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Roll Left")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Roll Right")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Yaw Left")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Yaw Right")));
+  AddInput(Translate, _trans("Pitch Up"));
+  AddInput(Translate, _trans("Pitch Down"));
+  AddInput(Translate, _trans("Roll Left"));
+  AddInput(Translate, _trans("Roll Right"));
+  AddInput(Translate, _trans("Yaw Left"));
+  AddInput(Translate, _trans("Yaw Right"));
 }
 
 std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState() const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
@@ -25,7 +25,7 @@ ModifySettingsButton::ModifySettingsButton(std::string button_name)
 
 void ModifySettingsButton::AddInput(std::string button_name, bool toggle)
 {
-  controls.emplace_back(std::make_unique<Input>(Translate, std::move(button_name)));
+  ControlGroup::AddInput(Translate, std::move(button_name));
   threshold_exceeded.emplace_back(false);
   associated_settings.emplace_back(false);
   associated_settings_toggle.emplace_back(toggle);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
@@ -19,8 +19,8 @@ namespace ControllerEmu
 Slider::Slider(const std::string& name_, const std::string& ui_name_)
     : ControlGroup(name_, ui_name_, GroupType::Slider)
 {
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Left")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Right")));
+  AddInput(Translate, _trans("Left"));
+  AddInput(Translate, _trans("Right"));
 
   AddDeadzoneSetting(&m_deadzone_setting, 50);
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -18,12 +18,12 @@ namespace ControllerEmu
 {
 Tilt::Tilt(const std::string& name_) : ReshapableInput(name_, name_, GroupType::Tilt)
 {
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Forward")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Backward")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Left")));
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Right")));
+  AddInput(Translate, _trans("Forward"));
+  AddInput(Translate, _trans("Backward"));
+  AddInput(Translate, _trans("Left"));
+  AddInput(Translate, _trans("Right"));
 
-  controls.emplace_back(std::make_unique<Input>(Translate, _trans("Modifier")));
+  AddInput(Translate, _trans("Modifier"));
 
   AddSetting(&m_max_angle_setting,
              {_trans("Angle"),


### PR DESCRIPTION
Greatly simplifies creation of `Input` objects.
Eliminates `new` and `make_unique` calls all over the place.
`std::move` `std::string` arguments.