### PR TITLE
DiscIO: Check for DirectoryBlob seek failure

### DIFF
--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -104,8 +104,7 @@ bool DiscContent::Read(u64* offset, u64* length, u8** buffer) const
     if (std::holds_alternative<std::string>(m_content_source))
     {
       File::IOFile file(std::get<std::string>(m_content_source), "rb");
-      file.Seek(offset_in_content, SEEK_SET);
-      if (!file.ReadBytes(*buffer, bytes_to_read))
+      if (!file.Seek(offset_in_content, SEEK_SET) || !file.ReadBytes(*buffer, bytes_to_read))
         return false;
     }
     else


### PR DESCRIPTION
Someone reported a problem with DirectoryBlob at https://forums.dolphin-emu.org/Thread-feature-request-thread?pid=502820#pid502820. I'm not sure if the change in this commit actually fixes that problem, but it's something I found that should be changed regardless.