### PR TITLE
WIP: WiimoteReal: Attempt to fix M+ detection problems.

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -143,6 +143,8 @@ private:
   // And we track the rumble state to drop unnecessary rumble reports.
   bool m_rumble_state = false;
 
+  bool m_is_performing_mplus_detection_fix = false;
+
   std::thread m_wiimote_thread;
   // Whether to keep running the thread.
   Common::Flag m_run_thread;


### PR DESCRIPTION
This is an attempt to fix: https://bugs.dolphin-emu.org/issues/7444

MotionPlus detection sometimes fails in Real Wii Remote mode for the same reason speaker data doesn't work well.  Not enabling "sniff mode" keeps the remote in a 100hz (vs 200hz) input loop.
MotionPlus initialization quickly cycles the extension port from connected->disconnected->connected. At 100hz that signal is sometimes missed.

This hack-fix requests two status reports when it sees a game send the M+ activation signal and overwrites the first response to show the "disconnected" state.

I can almost never reproduce this issue myself but having just dealt with M+ in PR #8575 I can see how a trick like this might be needed.

Here's one report that it works around the problem. Yay.
https://www.reddit.com/r/DolphinEmulator/comments/iwa9h2/how_do_i_get_dolphin_to_recognize_motion_plus/