### PR TITLE
VideoCommon: Allow texture folders to be determined by a <gameid>.txt

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -53,7 +54,7 @@ private:
   static bool LoadTexture(Level& level, const std::vector<u8>& buffer);
   static void Prefetch();
 
-  static std::string GetTextureDirectory(const std::string& game_id);
+  static std::set<std::string> GetTextureDirectories(const std::string& game_id);
 
   HiresTexture() {}
   bool m_has_arbitrary_mipmaps;


### PR DESCRIPTION
Currently, in your "Load" folder, you have a bunch of 3 letter or possibly more folders that reference some game.  Wouldn't it be nice if you instead could have a nice native language name instead?  Instead of "SLS", you could have "The Last Story".

Well now you can!

You only need to put a "SLS.txt" file in your directory and that's enough to tell Dolphin that is a directory of textures for "The Last Story".

This resolves two issues, neither were made on the issue tracker as far as I know:

* A user on the forum made a post in feature requests and they wanted the ability to have textures be read from subfolders.  They referenced a pack that might be stored on github where downloading automatically adds a subfolder.
* Admentus currently has to add multiple symlinks for his Majora's Mask / Ocarina of Time project so that all the textures can be shared.  Now he can just add multiple <gameid>.txt to the folder and all will be picked up on load.