### PR TITLE
Common/FileSearch: Portable DoFileSearch std::filesystem implementation.

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -20,6 +20,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Make sure std::filesystem usage actually compiles and links. *rolls eyes at android*
+check_cxx_source_compiles("
+	#include <filesystem>
+	int main() { std::filesystem::current_path(); }"
+	STD_FILESYSTEM_OK)
+
+if(STD_FILESYSTEM_OK)
+  message(STATUS "Environment supports std::filesystem.")
+  add_definitions(-DHAS_STD_FILESYSTEM)
+else()
+  message(STATUS "Environment does not support std::filesystem.")
+endif()
+
 if (MSVC)
 	# TODO: Use https://cmake.org/cmake/help/latest/policy/CMP0092.html instead (once we can require CMake >= 3.15)
   # Taken from http://www.cmake.org/Wiki/CMake_FAQ#Dynamic_Replace.

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -16,9 +16,8 @@
 
 #include "Common/CommonTypes.h"
 
-#ifdef _MSC_VER
+#ifdef HAS_STD_FILESYSTEM
 #include <filesystem>
-#define HAS_STD_FILESYSTEM
 #endif
 
 std::string StringFromFormatV(const char* format, va_list args);

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -4,10 +4,9 @@
 
 #include "Core/Boot/Boot.h"
 
-#ifdef _MSC_VER
+#ifdef HAS_STD_FILESYSTEM
 #include <filesystem>
 namespace fs = std::filesystem;
-#define HAS_STD_FILESYSTEM
 #endif
 
 #include <algorithm>

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -68,7 +68,7 @@
       <!--
       Make sure we include a clean version of windows.h.
       -->
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;HAS_STD_FILESYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!--
       This numeral indicates the "minimum system required" to run the resulting
       program. Dolphin targets Vista+, so it should be 0x0600. However in practice,


### PR DESCRIPTION
Instead of the Windows specific `CompareStringOrdinal`, case-insensitive file-extension matching is now performed by a `std::basic_regex` which will use the current locale.
Note that Qt appears to use the current locale to decode filenames by default so this seems sensible: https://doc.qt.io/archives/qt-4.8/qfile.html#setDecodingFunction

Used `std::error_code` versions of `std::filesystem` features to prevent exceptions from being thrown if say.. a directory happens to be deleted during a search.

Added `directory_options::follow_directory_symlink` flag to the recursive search.

Normalized paths to ensure proper uniqueness function.