### PR TITLE
Common: Avoid std::function overhead in ScopeGuard

### DIFF
--- a/Source/Core/Common/ScopeGuard.h
+++ b/Source/Core/Common/ScopeGuard.h
@@ -4,17 +4,15 @@
 
 #pragma once
 
-#include <functional>
+#include <optional>
 
 namespace Common
 {
+template <typename Callable>
 class ScopeGuard final
 {
 public:
-  template <class Callable>
-  ScopeGuard(Callable&& finalizer) : m_finalizer(std::forward<Callable>(finalizer))
-  {
-  }
+  ScopeGuard(Callable&& finalizer) : m_finalizer(std::forward<Callable>(finalizer)) {}
 
   ScopeGuard(ScopeGuard&& other) : m_finalizer(std::move(other.m_finalizer))
   {
@@ -22,13 +20,13 @@ public:
   }
 
   ~ScopeGuard() { Exit(); }
-  void Dismiss() { m_finalizer = nullptr; }
+  void Dismiss() { m_finalizer.reset(); }
   void Exit()
   {
     if (m_finalizer)
     {
-      m_finalizer();  // must not throw
-      m_finalizer = nullptr;
+      (*m_finalizer)();  // must not throw
+      m_finalizer.reset();
     }
   }
 
@@ -37,7 +35,7 @@ public:
   void operator=(const ScopeGuard&) = delete;
 
 private:
-  std::function<void()> m_finalizer;
+  std::optional<Callable> m_finalizer;
 };
 
 }  // Namespace Common

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -434,7 +434,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   s_frame_step = false;
 
   Movie::Init(*boot);
-  Common::ScopeGuard movie_guard{Movie::Shutdown};
+  Common::ScopeGuard movie_guard{&Movie::Shutdown};
 
   HW::Init();
 
@@ -539,7 +539,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   }};
 
   AudioCommon::InitSoundStream();
-  Common::ScopeGuard audio_guard{AudioCommon::ShutdownSoundStream};
+  Common::ScopeGuard audio_guard{&AudioCommon::ShutdownSoundStream};
 
   // The hardware is initialized.
   s_hardware_initialized = true;
@@ -565,7 +565,7 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   // Initialise Wii filesystem contents.
   // This is done here after Boot and not in HW to ensure that we operate
   // with the correct title context since save copying requires title directories to exist.
-  Common::ScopeGuard wiifs_guard{Core::CleanUpWiiFileSystemContents};
+  Common::ScopeGuard wiifs_guard{&Core::CleanUpWiiFileSystemContents};
   if (SConfig::GetInstance().bWii)
     Core::InitializeWiiFileSystemContents();
   else


### PR DESCRIPTION
So far in all our uses of ScopeGuard, the type of the callable is
usually just a lambda or a function pointer, so there is no need
to rely on std::function's type erasure.

While the cost of using std::function is probably negligible, it still
causes some unnecessary overhead that can be avoided by making
ScopeGuard a templated class. Thanks to class template argument
deduction in C++17 most existing usages do not even need to be changed.

See https://godbolt.org/z/KcoPni for a comparison between
a ScopeGuard that uses std::function and one that doesn't