### PR TITLE
InputCommon: Change default yaw/pitch to reach all corners

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -33,7 +33,7 @@ Cursor::Cursor(std::string name, std::string ui_name)
 
   AddInput(Translate, _trans("Relative Input Hold"));
 
-  // Default values are optimized for "Super Mario Galaxy 2".
+  // Default values are optimized for the Wii System Menu.
   // This seems to be acceptable for a good number of games.
 
   AddSetting(&m_vertical_offset_setting,
@@ -50,7 +50,7 @@ Cursor::Cursor(std::string name, std::string ui_name)
               _trans("°"),
               // i18n: Refers to emulated wii remote movements.
               _trans("Total rotation about the yaw axis.")},
-             15, 0, 360);
+             20, 0, 360);
 
   AddSetting(&m_pitch_setting,
              // i18n: Refers to an amount of rotational movement about the "pitch" axis.


### PR DESCRIPTION
The old default did not allow pointing (with the mouse) to all parts
of the screen, and notably, even the System Menu has controls that
were out-of-reach with them.

With this, yaw is changed to a default of 19° and pitch changed to a
default of 12°.  This overshoots the screen in either 16:9 or 4:3
aspect ratios, but allows the complete screen to be pointed to in
either one.