### PR TITLE
Qt/TAS: Improve TAS windows

### DIFF
--- a/Source/Core/DolphinQt/TAS/IRWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/IRWidget.cpp
@@ -12,11 +12,16 @@
 
 #include "Common/CommonTypes.h"
 
+constexpr int PADDING = 1;
+
 IRWidget::IRWidget(QWidget* parent) : QWidget(parent)
 {
   setMouseTracking(false);
   setToolTip(tr("Left click to set the IR value.\n"
                 "Right click to re-center it."));
+
+  // If the widget gets too small, it will get deformed.
+  setMinimumSize(QSize(64, 48));
 }
 
 void IRWidget::SetX(u16 x)
@@ -40,20 +45,23 @@ void IRWidget::paintEvent(QPaintEvent* event)
   painter.setRenderHint(QPainter::Antialiasing, true);
   painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
-  painter.setBrush(Qt::white);
-  painter.drawRect(0, 0, width() - 1, height() - 1);
+  const int w = width() - PADDING * 2;
+  const int h = height() - PADDING * 2;
 
-  painter.drawLine(0, height() / 2, width(), height() / 2);
-  painter.drawLine(width() / 2, 0, width() / 2, height());
+  painter.setBrush(Qt::white);
+  painter.drawRect(PADDING, PADDING, w, h);
+
+  painter.drawLine(PADDING, PADDING + h / 2, PADDING + w, PADDING + h / 2);
+  painter.drawLine(PADDING + w / 2, PADDING, PADDING + w / 2, PADDING + h);
 
   // convert from value space to widget space
-  u16 x = width() - (m_x * width()) / ir_max_x;
-  u16 y = (m_y * height()) / ir_max_y;
+  u16 x = PADDING + (w - (m_x * w) / ir_max_x);
+  u16 y = PADDING + ((m_y * h) / ir_max_y);
 
-  painter.drawLine(width() / 2, height() / 2, x, y);
+  painter.drawLine(PADDING + w / 2, PADDING + h / 2, x, y);
 
   painter.setBrush(Qt::blue);
-  int wh_avg = (width() + height()) / 2;
+  int wh_avg = (w + h) / 2;
   int radius = wh_avg / 30;
   painter.drawEllipse(x - radius, y - radius, radius * 2, radius * 2);
 }

--- a/Source/Core/DolphinQt/TAS/StickWidget.cpp
+++ b/Source/Core/DolphinQt/TAS/StickWidget.cpp
@@ -12,12 +12,17 @@
 
 #include "Common/CommonTypes.h"
 
+constexpr int PADDING = 1;
+
 StickWidget::StickWidget(QWidget* parent, u16 max_x, u16 max_y)
     : QWidget(parent), m_max_x(max_x), m_max_y(max_y)
 {
   setMouseTracking(false);
   setToolTip(tr("Left click to set the stick value.\n"
                 "Right click to re-center it."));
+
+  // If the widget gets too small, it will get deformed.
+  setMinimumSize(QSize(64, 64));
 }
 
 void StickWidget::SetX(u16 x)
@@ -41,22 +46,24 @@ void StickWidget::paintEvent(QPaintEvent* event)
   painter.setRenderHint(QPainter::Antialiasing, true);
   painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
 
-  painter.setBrush(Qt::white);
-  painter.drawEllipse(0, 0, width() - 1, height() - 1);
+  const int diameter = std::min(width(), height()) - PADDING * 2;
 
-  painter.drawLine(0, height() / 2, width(), height() / 2);
-  painter.drawLine(width() / 2, 0, width() / 2, height());
+  painter.setBrush(Qt::white);
+  painter.drawEllipse(PADDING, PADDING, diameter, diameter);
+
+  painter.drawLine(PADDING, PADDING + diameter / 2, PADDING + diameter, PADDING + diameter / 2);
+  painter.drawLine(PADDING + diameter / 2, PADDING, PADDING + diameter / 2, PADDING + diameter);
 
   // convert from value space to widget space
-  u16 x = (m_x * width()) / m_max_x;
-  u16 y = height() - (m_y * height()) / m_max_y;
+  u16 x = PADDING + ((m_x * diameter) / m_max_x);
+  u16 y = PADDING + (diameter - (m_y * diameter) / m_max_y);
 
-  painter.drawLine(width() / 2, height() / 2, x, y);
+  painter.drawLine(PADDING + diameter / 2, PADDING + diameter / 2, x, y);
 
   painter.setBrush(Qt::blue);
-  int wh_avg = (width() + height()) / 2;
-  int radius = wh_avg / 30;
-  painter.drawEllipse(x - radius, y - radius, radius * 2, radius * 2);
+  int neutral_radius = diameter / 30;
+  painter.drawEllipse(x - neutral_radius, y - neutral_radius, neutral_radius * 2,
+                      neutral_radius * 2);
 }
 
 void StickWidget::mousePressEvent(QMouseEvent* event)

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -17,6 +17,7 @@
 
 #include "DolphinQt/QtUtils/AspectRatioWidget.h"
 #include "DolphinQt/QtUtils/QueueOnObject.h"
+#include "DolphinQt/Resources.h"
 #include "DolphinQt/TAS/StickWidget.h"
 #include "DolphinQt/TAS/TASCheckBox.h"
 #include "DolphinQt/TAS/TASInputWindow.h"
@@ -26,6 +27,8 @@
 TASInputWindow::TASInputWindow(QWidget* parent) : QDialog(parent)
 {
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+  setWindowIcon(Resources::GetAppIcon());
+
   m_use_controller = new QCheckBox(QStringLiteral("Enable Controller Inpu&t"));
   m_use_controller->setToolTip(tr("Warning: Analog inputs may reset to controller values at "
                                   "random. In some cases this can be fixed by adding a deadzone."));


### PR DESCRIPTION
- Use the Dolphin Icon in TAS Windows
- Prevent deformation of the stick widget (Bug #11988)
- Improve visual appearance
- Set a reasonable minimum size

**Before**:  
![Before](https://i.imgur.com/tFahN2h.png)
![Before](https://i.imgur.com/ushWO9y.png)
**After**:
![After](https://i.imgur.com/9OqOFg9.png)
![After](https://i.imgur.com/96iaOux.png)