### PR TITLE
Fix Sonic Colors/Unleashed gui (again)

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -5,6 +5,7 @@
 #include "VideoCommon/VertexShaderManager.h"
 
 #include <array>
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 #include <iterator>
@@ -371,7 +372,8 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[12] = 0.0f;
       g_fProjectionMatrix[13] = 0.0f;
 
-      g_fProjectionMatrix[14] = -1.0f;
+      // Hack to fix depth clipping precision issues (such as Sonic Adventure UI)
+      g_fProjectionMatrix[14] = -(1.0f + FLT_EPSILON);
       g_fProjectionMatrix[15] = 0.0f;
 
       g_stats.gproj = g_fProjectionMatrix;
@@ -397,7 +399,8 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[13] = 0.0f;
 
       g_fProjectionMatrix[14] = 0.0f;
-      g_fProjectionMatrix[15] = 1.0f;
+      // Hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
+      g_fProjectionMatrix[15] = 1.0f + FLT_EPSILON;
 
       g_stats.g2proj = g_fProjectionMatrix;
       g_stats.proj = rawProjection;


### PR DESCRIPTION
See: https://bugs.dolphin-emu.org/issues/11897
When running Sonic using OpenGL ES the gui elements are not rendered at all.

I've confirmed this on two mobiles phones (Samsung Galaxy S9 and Oneplus 7t Pro).
But it can also easily be reproduced on Linux by setting "PreferGLES = True" in GFX.ini.

It renders fine using Vulkan and regular OpenGL without this hack.
However only OpenGL ES seems to run most games at acceptable speeds on Android phones.