### PR TITLE
Add android gamepad profile loading and saving

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -163,7 +163,8 @@ public class Settings
   {
     if (TextUtils.isEmpty(gameId))
     {
-      view.showToastMessage("Saved settings to INI files");
+      if (view != null)
+        view.showToastMessage("Saved settings to INI files");
 
       for (Map.Entry<String, List<String>> entry : configFileSectionsMap.entrySet())
       {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/CustomFilePickerFragment.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public class CustomFilePickerFragment extends FilePickerFragment
 {
   private static final Set<String> extensions = new HashSet<>(Arrays.asList(
-          "gcm", "tgc", "iso", "ciso", "gcz", "wbfs", "wad", "dol", "elf", "dff"));
+          "gcm", "tgc", "iso", "ciso", "gcz", "wbfs", "wad", "dol", "elf", "dff", "ini"));
 
   @NonNull
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -29,6 +29,7 @@ import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesView;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
+import org.dolphinemu.dolphinemu.utils.GamePadHandler;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
 import org.dolphinemu.dolphinemu.utils.StartupHandler;
 
@@ -154,6 +155,18 @@ public final class MainActivity extends AppCompatActivity implements MainView
     FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_OPEN_FILE, true);
   }
 
+  @Override
+  public void launchOpenGamePadActivity()
+  {
+    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_OPEN_GAME_PAD, false);
+  }
+
+  @Override
+  public void launchSaveGamePadActivity()
+  {
+    FileBrowserHelper.openFileSavePicker(this, MainPresenter.REQUEST_SAVE_GAME_PAD);
+  }
+
   /**
    * @param requestCode An int describing whether the Activity that is returning did so successfully.
    * @param resultCode  An int describing what Activity is giving us this callback.
@@ -177,6 +190,22 @@ public final class MainActivity extends AppCompatActivity implements MainView
         if (resultCode == MainActivity.RESULT_OK)
         {
           EmulationActivity.launchFile(this, FileBrowserHelper.getSelectedFiles(result));
+        }
+        break;
+
+      case MainPresenter.REQUEST_OPEN_GAME_PAD:
+        // If the user picked a file, as opposed to just backing out.
+        if (resultCode == MainActivity.RESULT_OK)
+        {
+          GamePadHandler.load(FileBrowserHelper.getSelectedFiles(result)[0]);
+        }
+        break;
+
+      case MainPresenter.REQUEST_SAVE_GAME_PAD:
+        // If the user picked a file, as opposed to just backing out.
+        if (resultCode == MainActivity.RESULT_OK)
+        {
+          GamePadHandler.save(FileBrowserHelper.getSelectedFiles(result)[0]);
         }
         break;
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -17,6 +17,8 @@ public final class MainPresenter
 {
   public static final int REQUEST_ADD_DIRECTORY = 1;
   public static final int REQUEST_OPEN_FILE = 2;
+  public static final int REQUEST_OPEN_GAME_PAD = 3;
+  public static final int REQUEST_SAVE_GAME_PAD = 4;
 
   private final MainView mView;
   private final Context mContext;
@@ -90,6 +92,14 @@ public final class MainPresenter
 
       case R.id.menu_open_file:
         mView.launchOpenFileActivity();
+        return true;
+
+      case R.id.menu_open_game_pad:
+        mView.launchOpenGamePadActivity();
+        return true;
+
+      case R.id.menu_save_game_pad:
+        mView.launchSaveGamePadActivity();
         return true;
     }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainView.java
@@ -23,6 +23,10 @@ public interface MainView
 
   void launchOpenFileActivity();
 
+  void launchOpenGamePadActivity();
+
+  void launchSaveGamePadActivity();
+
   /**
    * To be called when the game file cache is updated.
    */

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -29,6 +29,7 @@ import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
+import org.dolphinemu.dolphinemu.utils.GamePadHandler;
 import org.dolphinemu.dolphinemu.utils.PermissionsHandler;
 import org.dolphinemu.dolphinemu.utils.StartupHandler;
 import org.dolphinemu.dolphinemu.utils.TvUtil;
@@ -153,6 +154,18 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   }
 
   @Override
+  public void launchOpenGamePadActivity()
+  {
+    FileBrowserHelper.openFilePicker(this, MainPresenter.REQUEST_OPEN_GAME_PAD, false);
+  }
+
+  @Override
+  public void launchSaveGamePadActivity()
+  {
+    FileBrowserHelper.openFileSavePicker(this, MainPresenter.REQUEST_SAVE_GAME_PAD);
+  }
+
+  @Override
   public void showGames()
   {
     // Kicks off the program services to update all channels
@@ -186,6 +199,14 @@ public final class TvMainActivity extends FragmentActivity implements MainView
         if (resultCode == MainActivity.RESULT_OK)
         {
           EmulationActivity.launchFile(this, FileBrowserHelper.getSelectedFiles(result));
+        }
+        break;
+
+      case MainPresenter.REQUEST_OPEN_GAME_PAD:
+        // If the user picked a file, as opposed to just backing out.
+        if (resultCode == MainActivity.RESULT_OK)
+        {
+          GamePadHandler.load(FileBrowserHelper.getSelectedFiles(result)[0]);
         }
         break;
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/FileBrowserHelper.java
@@ -44,6 +44,19 @@ public final class FileBrowserHelper
     activity.startActivityForResult(i, requestCode);
   }
 
+  public static void openFileSavePicker(FragmentActivity activity, int requestCode)
+  {
+    Intent i = new Intent(activity, CustomFilePickerActivity.class);
+
+    i.putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false);
+    i.putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, true);
+    i.putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_NEW_FILE);
+    i.putExtra(FilePickerActivity.EXTRA_START_PATH,
+            Environment.getExternalStorageDirectory().getPath());
+
+    activity.startActivityForResult(i, requestCode);
+  }
+
   @Nullable
   public static String getSelectedDirectory(Intent result)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/GamePadHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/GamePadHandler.java
@@ -1,0 +1,323 @@
+package org.dolphinemu.dolphinemu.utils;
+
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.Setting;
+import org.dolphinemu.dolphinemu.features.settings.model.SettingSection;
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
+import org.dolphinemu.dolphinemu.features.settings.model.StringSetting;
+import org.dolphinemu.dolphinemu.features.settings.model.view.InputBindingSetting;
+import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class GamePadHandler
+{
+  private static Map<String, Integer> inputs = new HashMap<>();
+
+  public static void load(String filePath)
+  {
+    Settings settings = new Settings();
+    settings.loadSettings(null);
+    File file = new File(filePath);
+    String fileName = file.getName();
+    int iniIndex = fileName.indexOf(".ini");
+    if  (iniIndex != -1)
+    {
+      fileName = fileName.substring(0, iniIndex);
+    }
+    List<String> contents = readIniFile(file);
+    if (contents.isEmpty())
+    {
+      return;
+    }
+    for (String input : inputs.keySet())
+    {
+      for (int i = 0; i < 8; i++)
+      {
+        clearValue(input + i, settings);
+      }
+      for (String line : contents)
+      {
+        if (line.indexOf('=') == -1)
+        {
+          continue;
+        }
+        if (!line.startsWith(input))
+        {
+          continue;
+        }
+        String[] entry = line.split("=", 2);
+        String key = entry[0].trim();
+        String value = entry[1].trim();
+        setValue(fileName, key, value, settings);
+        break;
+      }
+    }
+    settings.saveSettings(null);
+  }
+
+  public static void save(String filePath)
+  {
+    Settings settings = new Settings();
+    settings.loadSettings(null);
+    SettingSection bindingsSection = settings.getSection(Settings.SECTION_BINDINGS);
+    List<String> contents = new ArrayList<>();
+    contents.add("[Profile]");
+    for (String input : inputs.keySet())
+    {
+      for (int i = 0; i < 8; i++)
+      {
+        Setting setting = bindingsSection.getSetting(input + i);
+        if (setting == null)
+        {
+          continue;
+        }
+        contents.add(setting.getKey() + " = " + setting.getValueAsString());
+      }
+    }
+    if (contents.size() == 1)
+    {
+      return;
+    }
+    saveIniFile(new File(filePath), contents);
+  }
+
+  private static void setValue(String deviceName, String key, String value, Settings settings)
+  {
+    InputBindingSetting binding = getBinding(key, settings);
+    if (binding == null)
+    {
+      return;
+    }
+    String ui = deviceName + ": Button " +  value.substring(value.indexOf("'-") + 1);
+    binding.setValue(value, ui);
+    putSetting(binding, settings);
+  }
+
+  private static void clearValue(String key, Settings settings)
+  {
+    InputBindingSetting binding = getBinding(key, settings);
+    if (binding == null)
+    {
+      return;
+    }
+    binding.setValue("", "");
+    putSetting(binding, settings);
+  }
+
+  private static InputBindingSetting getBinding(String key, Settings settings)
+  {
+    String basicKey = getBasicKeyName(key);
+    Integer inputPos = inputs.get(basicKey);
+    if (inputPos == null)
+    {
+      return null;
+    }
+    Setting sectionSetting = settings.getSection(Settings.SECTION_BINDINGS).getSetting(key);
+    return new InputBindingSetting(key, Settings.SECTION_BINDINGS, inputPos, sectionSetting, "");
+  }
+
+  private static void putSetting(InputBindingSetting binding, Settings settings)
+  {
+    StringSetting setting = new StringSetting(binding.getKey(), binding.getSection(),
+            binding.getValue());
+    settings.getSection(setting.getSection()).putSetting(setting);
+  }
+
+  private static String getBasicKeyName(String key)
+  {
+    int underscoreIndex = key.lastIndexOf('_');
+    if (underscoreIndex != -1)
+    {
+      key = key.substring(0, key.lastIndexOf('_') + 1);
+    }
+    if (key.matches(".*[0-9]"))
+    {
+      key = key.substring(0, key.length() - 1);
+    }
+    return key;
+  }
+
+  private static List<String> readIniFile(File file)
+  {
+    if (!file.exists())
+    {
+      return null;
+    }
+    List<String> contents = new ArrayList<>();
+    try (BufferedReader br = new BufferedReader(new FileReader(file)))
+    {
+      String line;
+      while ((line = br.readLine()) != null)
+      {
+        contents.add(line);
+      }
+    }
+    catch (FileNotFoundException e)
+    {
+      e.printStackTrace();
+    }
+    catch (IOException e)
+    {
+      e.printStackTrace();
+    }
+    return contents;
+  }
+
+  public static void saveIniFile(File file, List<String> contents)
+  {
+    if (!file.getName().endsWith(".ini"))
+    {
+      file = new File(file.getAbsolutePath() + ".ini");
+    }
+    try (BufferedWriter bw = new BufferedWriter(new FileWriter(file)))
+    {
+      for (String line : contents)
+      {
+        bw.append(line);
+        bw.newLine();
+      }
+      bw.flush();
+    }
+    catch (IOException e)
+    {
+      e.printStackTrace();
+    }
+  }
+
+  static
+  {
+    inputs.put(SettingsFile.KEY_GCBIND_A, R.string.button_a);
+    inputs.put(SettingsFile.KEY_GCBIND_B, R.string.button_b);
+    inputs.put(SettingsFile.KEY_GCBIND_X, R.string.button_x);
+    inputs.put(SettingsFile.KEY_GCBIND_Y, R.string.button_y);
+    inputs.put(SettingsFile.KEY_GCBIND_Z, R.string.button_z);
+    inputs.put(SettingsFile.KEY_GCBIND_START, R.string.button_start);
+
+    inputs.put(SettingsFile.KEY_GCBIND_CONTROL_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_GCBIND_CONTROL_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_GCBIND_CONTROL_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_GCBIND_CONTROL_RIGHT, R.string.generic_right);
+
+    inputs.put(SettingsFile.KEY_GCBIND_C_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_GCBIND_C_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_GCBIND_C_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_GCBIND_C_RIGHT, R.string.generic_right);
+
+    inputs.put(SettingsFile.KEY_GCBIND_TRIGGER_L, R.string.trigger_left);
+    inputs.put(SettingsFile.KEY_GCBIND_TRIGGER_R, R.string.trigger_right);
+
+    inputs.put(SettingsFile.KEY_GCBIND_DPAD_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_GCBIND_DPAD_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_GCBIND_DPAD_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_GCBIND_DPAD_RIGHT, R.string.generic_right);
+    inputs.put(SettingsFile.KEY_EMU_RUMBLE, R.string.emulation_control_rumble);
+
+
+    inputs.put(SettingsFile.KEY_WIIMOTE_EXTENSION, R.string.wiimote_extensions);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_A, R.string.button_a);
+    inputs.put(SettingsFile.KEY_WIIBIND_B, R.string.button_b);
+    inputs.put(SettingsFile.KEY_WIIBIND_1, R.string.button_one);
+    inputs.put(SettingsFile.KEY_WIIBIND_2, R.string.button_two);
+    inputs.put(SettingsFile.KEY_WIIBIND_MINUS, R.string.button_minus);
+    inputs.put(SettingsFile.KEY_WIIBIND_PLUS, R.string.button_plus);
+    inputs.put(SettingsFile.KEY_WIIBIND_HOME, R.string.button_home);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_IR_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_IR_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_IR_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_IR_RIGHT, R.string.generic_right);
+    inputs.put(SettingsFile.KEY_WIIBIND_IR_FORWARD, R.string.generic_forward);
+    inputs.put(SettingsFile.KEY_WIIBIND_IR_BACKWARD, R.string.generic_backward);
+    inputs.put(SettingsFile.KEY_WIIBIND_IR_HIDE, R.string.ir_hide);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_SWING_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_SWING_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_SWING_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_SWING_RIGHT, R.string.generic_right);
+    inputs.put(SettingsFile.KEY_WIIBIND_SWING_FORWARD, R.string.generic_forward);
+    inputs.put(SettingsFile.KEY_WIIBIND_SWING_BACKWARD, R.string.generic_backward);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_TILT_FORWARD, R.string.generic_forward);
+    inputs.put(SettingsFile.KEY_WIIBIND_TILT_BACKWARD, R.string.generic_backward);
+    inputs.put(SettingsFile.KEY_WIIBIND_TILT_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_TILT_RIGHT, R.string.generic_right);
+    inputs.put(SettingsFile.KEY_WIIBIND_TILT_MODIFIER, R.string.tilt_modifier);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_SHAKE_X, R.string.shake_x);
+    inputs.put(SettingsFile.KEY_WIIBIND_SHAKE_Y, R.string.shake_y);
+    inputs.put(SettingsFile.KEY_WIIBIND_SHAKE_Z, R.string.shake_z);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_DPAD_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_DPAD_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_DPAD_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_DPAD_RIGHT, R.string.generic_right);
+    inputs.put(SettingsFile.KEY_EMU_RUMBLE, R.string.emulation_control_rumble);
+
+
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_C, R.string.nunchuk_button_c);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_Z, R.string.button_z);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_RIGHT, R.string.generic_right);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SWING_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SWING_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SWING_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SWING_RIGHT, R.string.generic_right);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SWING_FORWARD, R.string.generic_forward);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SWING_BACKWARD, R.string.generic_backward);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_TILT_FORWARD, R.string.generic_forward);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_TILT_BACKWARD, R.string.generic_backward);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_TILT_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_TILT_RIGHT, R.string.generic_right);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_TILT_MODIFIER, R.string.tilt_modifier);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SHAKE_X, R.string.shake_x);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SHAKE_Y, R.string.shake_y);
+    inputs.put(SettingsFile.KEY_WIIBIND_NUNCHUK_SHAKE_Z, R.string.shake_z);
+
+
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_A, R.string.button_a);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_B, R.string.button_b);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_X, R.string.button_x);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_Y, R.string.button_y);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_ZL, R.string.classic_button_zl);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_ZR, R.string.classic_button_zr);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_MINUS, R.string.button_minus);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_PLUS, R.string.button_plus);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_HOME, R.string.button_home);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_LEFT_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_LEFT_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_LEFT_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_LEFT_RIGHT, R.string.generic_right);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_RIGHT_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_RIGHT_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_RIGHT_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_RIGHT_RIGHT, R.string.generic_right);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_TRIGGER_L, R.string.trigger_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_TRIGGER_R, R.string.trigger_right);
+
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_DPAD_UP, R.string.generic_up);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_DPAD_DOWN, R.string.generic_down);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_DPAD_LEFT, R.string.generic_left);
+    inputs.put(SettingsFile.KEY_WIIBIND_CLASSIC_DPAD_RIGHT, R.string.generic_right);
+  }
+}

--- a/Source/Android/app/src/main/res/menu/menu_game_grid.xml
+++ b/Source/Android/app/src/main/res/menu/menu_game_grid.xml
@@ -36,5 +36,15 @@
         android:icon="@android:drawable/ic_media_play"
         android:title="Open File"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/menu_open_game_pad"
+        android:icon="@android:drawable/ic_media_play"
+        android:title="Open Gamepad Profile"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/menu_save_game_pad"
+        android:icon="@android:drawable/ic_media_play"
+        android:title="Save Gamepad Profile"
+        app:showAsAction="ifRoom" />
 
 </menu>


### PR DESCRIPTION
This adds an "Open Gamepad Profile" and "Save Gamepad Profile" in the main menu under "Refresh Library" and "Open File."

I suspect this isn't the best way to do it, and I've never worked on an Android app before and had some trouble maneuvering around the menu system to add these options deeper in the settings instead of the main menu.  Hopefully, this will at least get some inspiration rolling to add controller profiles to the Android version.

If anyone wants to take parts from this to make a better system, please feel free to do so.

**How it works:**
Configure your emulated controls for Game Cube, Wii, etc with a specific gamepad. You can configure the controls for all the different emulated controllers for saving to a single profile, such as if you want to save a standard config for an Xbox controller with GC, WII remote, classic controller, etc.

Select save gamepad profile, choose a location, and name it. This saves all the Android-based controller settings into the file.

Select load gamepad profile and all your current emulated controls will be cleared and set to what is in the file you pick.

Sample contents of a saved profile:
```
[Profile]
InputL_0 = Device 'xyz'-Button 104

```
In emulated input, it'll be displayed as the file's name followed by the input (EX: xbox_controller.ini profile loaded, displays as "xbox_controller:  Button 104").

**Uses**
In my specific case, I have an LG G8X. I have my second screen to use when I'm out and about. I then have a gamepad that wraps around my phone for in bed. On top of this, I have an Xbox controller for when I'm playing on a TV. With this pull request, I'm able to create a profile for each controller, and then just quickly load that profile when I swap to a different controller, opposed to previously having to reconfigure each button whenever I change controllers.