### PR TITLE
TitleDatabase: Added custom developer ("maker") database option.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,14 @@
 # Dolphin - A GameCube and Wii Emulator
+# 128MB RAM Special Buid
 
 [Homepage](https://dolphin-emu.org/) | [Project Site](https://github.com/dolphin-emu/dolphin) | [Forums](https://forums.dolphin-emu.org/) | [Wiki](https://wiki.dolphin-emu.org/) | [Issue Tracker](https://bugs.dolphin-emu.org/projects/emulator/issues) | [Coding Style](https://github.com/dolphin-emu/dolphin/blob/master/Contributing.md) | [Transifex Page](https://www.transifex.com/projects/p/dolphin-emu/)
 
 Dolphin is an emulator for running GameCube and Wii games on Windows,
 Linux, macOS, and recent Android devices. It's licensed under the terms
 of the GNU General Public License, version 2 or later (GPLv2+).
+
+This particular build is for running the Metroid Prime 3 E3 2006 Demo. Using
+notes from [Hakairyu](https://forums.dolphin-emu.org/User-hakairyu) [here](https://forums.dolphin-emu.org/Thread-unofficial-build-for-metroid-prime-3-2006-prototype) I have changed the virtual RAM allocation to 128**MB**.
 
 Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -67,6 +67,9 @@ TitleDatabase::TitleDatabase()
   if (m_user_title_map.empty())
     m_user_title_map = LoadMap(load_directory + "titles.txt");
 
+  // Custom developer ("maker") index
+  m_user_developer_map = LoadMap(load_directory + "developers.txt");
+
   // Pre-defined databases (one per language)
   AddLazyMap(DiscIO::Language::Japanese, "ja");
   AddLazyMap(DiscIO::Language::English, "en");
@@ -91,8 +94,26 @@ TitleDatabase::TitleDatabase()
 
 TitleDatabase::~TitleDatabase() = default;
 
+const std::string& TitleDatabase::GetDeveloper(const std::string& gametdb_id) const
+
+{
+  auto it = m_user_developer_map.find(gametdb_id);
+  if (it != m_user_developer_map.end())
+    return it->second;
+
+  if (!SConfig::GetInstance().m_use_builtin_title_database)
+    return EMPTY_STRING;
+
+  it = m_base_map.find(gametdb_id);
+  if (it != m_base_map.end())
+    return it->second;
+
+  return EMPTY_STRING;
+}
+
 const std::string& TitleDatabase::GetTitleName(const std::string& gametdb_id,
                                                DiscIO::Language language) const
+
 {
   auto it = m_user_title_map.find(gametdb_id);
   if (it != m_user_title_map.end())

--- a/Source/Core/Core/TitleDatabase.h
+++ b/Source/Core/Core/TitleDatabase.h
@@ -26,6 +26,7 @@ public:
 
   // Get a user friendly title name for a GameTDB ID.
   // This falls back to returning an empty string if none could be found.
+  const std::string& GetDeveloper(const std::string& gametdb_id) const;
   const std::string& GetTitleName(const std::string& gametdb_id, DiscIO::Language language) const;
 
   // Same as above, but takes a title ID instead of a GameTDB ID, and only works for channels.
@@ -37,9 +38,9 @@ public:
 private:
   void AddLazyMap(DiscIO::Language language, const std::string& language_code);
 
-  std::unordered_map<DiscIO::Language, Common::Lazy<std::unordered_map<std::string, std::string>>>
-      m_title_maps;
+  std::unordered_map<DiscIO::Language, Common::Lazy<std::unordered_map<std::string, std::string>>> m_title_maps;
   std::unordered_map<std::string, std::string> m_base_map;
+  std::unordered_map<std::string, std::string> m_user_developer_map;
   std::unordered_map<std::string, std::string> m_user_title_map;
 };
 }  // namespace Core

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -132,8 +132,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_MAKER:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
-      return QString::fromStdString(
-          game.GetMaker(UICommon::GameFile::Variant::LongAndPossiblyCustom));
+      return QString::fromStdString(game.GetMaker(m_title_database));
     }
     break;
   case COL_FILE_NAME:
@@ -183,7 +182,7 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
   case COL_DESCRIPTION:
     return tr("Description");
   case COL_MAKER:
-    return tr("Maker");
+    return tr("Developer");
   case COL_FILE_NAME:
     return tr("File Name");
   case COL_SIZE:

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -487,6 +487,15 @@ const std::string& GameFile::GetName(Variant variant) const
   return m_file_name;
 }
 
+const std::string& GameFile::GetMaker(const Core::TitleDatabase& title_database) const
+{
+  if (!m_custom_maker.empty())
+    return m_custom_maker;
+
+  const std::string& database_name = title_database.GetDeveloper(m_gametdb_id);
+  return database_name.empty() ? GetMaker(Variant::LongAndPossiblyCustom) : database_name;
+}
+
 const std::string& GameFile::GetMaker(Variant variant) const
 {
   if (variant == Variant::LongAndPossiblyCustom && !m_custom_maker.empty())

--- a/Source/Core/UICommon/GameFile.h
+++ b/Source/Core/UICommon/GameFile.h
@@ -60,6 +60,7 @@ public:
   const std::string& GetFileName() const { return m_file_name; }
   const std::string& GetName(const Core::TitleDatabase& title_database) const;
   const std::string& GetName(Variant variant) const;
+  const std::string& GetMaker(const Core::TitleDatabase& title_database) const;
   const std::string& GetMaker(Variant variant) const;
   const std::string& GetShortName(DiscIO::Language l) const { return Lookup(l, m_short_names); }
   const std::string& GetShortName() const { return LookupUsingConfigLanguage(m_short_names); }


### PR DESCRIPTION
Functions identically to `titles.txt`, but uses `publishers.txt` instead. I also think that _"Maker"_ should be changed to _"Publisher"_ in the UI. This will make more sense to end-users, but the code should stick to _"maker"_ as it's the official metadata tag and would require more work to rename everything. In accordance, the title database load option has been re-labeled to `Use Built-In Database of Metadata`. Note that the ability to load the title database is already broken if a custom title file is present, it seems that the custom titles aren't unloaded if the `Use Built-In Database of Titles` option is enabled. Unless I'm mistaken, the title database strings should be predominant if the option is enabled for all titles even if a custom titles file is present. Furthermore, the entire metadata load implementation would have to be completely re-written to fix this bug.

![Comparison](https://user-images.githubusercontent.com/47702158/75090277-11882d00-5516-11ea-95be-8ecb71a52368.png)