### PR TITLE
Qt: Re-enable Dark Mode support

### DIFF
--- a/Source/Core/DolphinQt/Info.plist.in
+++ b/Source/Core/DolphinQt/Info.plist.in
@@ -50,7 +50,5 @@
     <true/>
     <key>CSResourcesFileMapped</key>
     <true/>
-    <key>NSRequiresAquaSystemAppearance</key>
-    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
The Qt version we use now should support Dark Mode properly.