### PR TITLE
Qt/CodeViewWidget: Implement branch arrows.

### DIFF
--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -36,9 +36,16 @@ constexpr double SCROLL_FRACTION_DEGREES = 15.;
 
 constexpr size_t VALID_BRANCH_LENGTH = 10;
 
+constexpr int CODE_VIEW_COLUMN_BREAKPOINT = 0;
+constexpr int CODE_VIEW_COLUMN_ADDRESS = 1;
+constexpr int CODE_VIEW_COLUMN_INSTRUCTION = 2;
+constexpr int CODE_VIEW_COLUMN_PARAMETERS = 3;
+constexpr int CODE_VIEW_COLUMN_DESCRIPTION = 4;
+constexpr int CODE_VIEW_COLUMNCOUNT = 5;
+
 CodeViewWidget::CodeViewWidget()
 {
-  setColumnCount(5);
+  setColumnCount(CODE_VIEW_COLUMNCOUNT);
   setShowGrid(false);
   setContextMenuPolicy(Qt::CustomContextMenu);
   setSelectionMode(QAbstractItemView::SingleSelection);
@@ -86,7 +93,7 @@ void CodeViewWidget::FontBasedSizing()
   const int rowh = fm.height() + 1;
   verticalHeader()->setMaximumSectionSize(rowh);
   horizontalHeader()->setMinimumSectionSize(rowh + 5);
-  setColumnWidth(0, rowh + 5);
+  setColumnWidth(CODE_VIEW_COLUMN_BREAKPOINT, rowh + 5);
   Update();
 }
 
@@ -189,11 +196,11 @@ void CodeViewWidget::Update()
           Resources::GetScaledThemeIcon("debugger_breakpoint").pixmap(QSize(rowh - 2, rowh - 2)));
     }
 
-    setItem(i, 0, bp_item);
-    setItem(i, 1, addr_item);
-    setItem(i, 2, ins_item);
-    setItem(i, 3, param_item);
-    setItem(i, 4, description_item);
+    setItem(i, CODE_VIEW_COLUMN_BREAKPOINT, bp_item);
+    setItem(i, CODE_VIEW_COLUMN_ADDRESS, addr_item);
+    setItem(i, CODE_VIEW_COLUMN_INSTRUCTION, ins_item);
+    setItem(i, CODE_VIEW_COLUMN_PARAMETERS, param_item);
+    setItem(i, CODE_VIEW_COLUMN_DESCRIPTION, description_item);
 
     if (addr == GetAddress())
     {
@@ -559,7 +566,7 @@ void CodeViewWidget::mousePressEvent(QMouseEvent* event)
   switch (event->button())
   {
   case Qt::LeftButton:
-    if (column(item) == 0)
+    if (column(item) == CODE_VIEW_COLUMN_BREAKPOINT)
       ToggleBreakpoint();
     else
       SetAddress(addr, SetAddressUpdate::WithUpdate);

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -15,6 +15,9 @@ class QMouseEvent;
 class QResizeEvent;
 class QShowEvent;
 
+struct CodeViewBranch;
+class BranchDisplayDelegate;
+
 class CodeViewWidget : public QTableWidget
 {
   Q_OBJECT
@@ -26,6 +29,7 @@ public:
   };
 
   explicit CodeViewWidget();
+  ~CodeViewWidget() override;
 
   u32 GetAddress() const;
   u32 GetContextAddress() const;
@@ -37,6 +41,8 @@ public:
 
   void ToggleBreakpoint();
   void AddBreakpoint();
+
+  u32 AddressForRow(int row) const;
 
 signals:
   void RequestPPCComparison(u32 addr);
@@ -83,4 +89,8 @@ private:
 
   u32 m_address = 0;
   u32 m_context_address = 0;
+
+  std::vector<CodeViewBranch> m_branches;
+
+  friend class BranchDisplayDelegate;
 };

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.h
@@ -85,6 +85,8 @@ private:
   void OnReplaceInstruction();
   void OnRestoreInstruction();
 
+  void CalculateBranchIndentation();
+
   bool m_updating = false;
 
   u32 m_address = 0;


### PR DESCRIPTION
Back in WX, the debugger would draw arrows to indicate branches, like this:
https://user-images.githubusercontent.com/4522237/75113262-83629280-564c-11ea-857e-b86459b47c08.png
https://user-images.githubusercontent.com/4522237/75113263-83629280-564c-11ea-865e-e672b01c57a6.png

I found this pretty useful at quickly determining conditionals and loops, but during the transition to Qt this feature was lost. This PR is a implementation of this feature for Qt.

Screenshots:
https://user-images.githubusercontent.com/4522237/75113260-82316580-564c-11ea-9057-bf7dc6cc169a.png
https://user-images.githubusercontent.com/4522237/75202872-eb0fff00-576c-11ea-869c-0a9ca0b208ef.png

One thing I'm not sure here is if I have to make sure `BranchDisplayDelegate::paint()` and `CodeViewWidget::Update()` don't run at the same time in different threads, or if those two are both only already allowed on the GUI thread anyway. Does anyone know?