### PR TITLE
InputCommon/DolphinQt: Mapping related race fixes and cleanups.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -544,7 +544,7 @@ void InputStateDelegate::paint(QPainter* painter, const QStyleOptionViewItem& op
   rect.setWidth(rect.width() * std::clamp(state, 0.0, 1.0));
 
   // Create a temporary indicator object to retreive color constants.
-  MappingIndicator indicator(nullptr);
+  MappingIndicator indicator;
 
   painter->save();
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -72,7 +72,9 @@ QBrush MappingIndicator::GetBBoxBrush() const
 
 QColor MappingIndicator::GetRawInputColor() const
 {
-  return palette().shadow().color();
+  QColor color = palette().text().color();
+  color.setAlphaF(0.5);
+  return color;
 }
 
 QPen MappingIndicator::GetInputShapePen() const
@@ -82,8 +84,6 @@ QPen MappingIndicator::GetInputShapePen() const
 
 QColor MappingIndicator::GetAdjustedInputColor() const
 {
-  // Using highlight color works (typically blue) but the contrast is pretty low.
-  // return palette().highlight().color();
   return Qt::red;
 }
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -60,9 +60,8 @@ public:
   void SetCalibrationWidget(CalibrationWidget* widget);
 
 protected:
-  void DrawReshapableInput(ControllerEmu::ReshapableInput& group,
-                           const ControllerEmu::ReshapableInput::ReshapeData& adj_coord,
-                           QColor gate_color);
+  void DrawReshapableInput(ControllerEmu::ReshapableInput& group, QColor gate_color,
+                           std::optional<ControllerEmu::ReshapableInput::ReshapeData> adj_coord);
 
   bool IsCalibrating() const;
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -30,8 +30,6 @@ class CalibrationWidget;
 class MappingIndicator : public QWidget
 {
 public:
-  MappingIndicator();
-
   QPen GetBBoxPen() const;
   QBrush GetBBoxBrush() const;
   QColor GetRawInputColor() const;
@@ -40,21 +38,29 @@ public:
   QColor GetAdjustedInputColor() const;
   QColor GetDeadZoneColor() const;
   QPen GetDeadZonePen() const;
-  QBrush GetDeadZoneBrush() const;
+  QBrush GetDeadZoneBrush(QPainter&) const;
   QColor GetTextColor() const;
   QColor GetAltTextColor() const;
   void AdjustGateColor(QColor*);
 
 protected:
-  double GetScale() const;
-
   virtual void Draw() {}
 
 private:
   void paintEvent(QPaintEvent*) override;
 };
 
-class ReshapableInputIndicator : public MappingIndicator
+class SquareIndicator : public MappingIndicator
+{
+protected:
+  SquareIndicator();
+
+  qreal GetContentsScale() const;
+  void DrawBoundingBox(QPainter&);
+  void TransformPainter(QPainter&);
+};
+
+class ReshapableInputIndicator : public SquareIndicator
 {
 public:
   void SetCalibrationWidget(CalibrationWidget* widget);
@@ -129,7 +135,7 @@ private:
   WiimoteEmu::MotionState m_motion_state{};
 };
 
-class ShakeMappingIndicator : public MappingIndicator
+class ShakeMappingIndicator : public SquareIndicator
 {
 public:
   explicit ShakeMappingIndicator(ControllerEmu::Shake& shake) : m_shake_group(shake) {}
@@ -143,7 +149,7 @@ private:
   int m_grid_line_position = 0;
 };
 
-class AccelerometerMappingIndicator : public MappingIndicator
+class AccelerometerMappingIndicator : public SquareIndicator
 {
 public:
   explicit AccelerometerMappingIndicator(ControllerEmu::IMUAccelerometer& accel)
@@ -157,7 +163,7 @@ private:
   ControllerEmu::IMUAccelerometer& m_accel_group;
 };
 
-class GyroMappingIndicator : public MappingIndicator
+class GyroMappingIndicator : public SquareIndicator
 {
 public:
   explicit GyroMappingIndicator(ControllerEmu::IMUGyroscope& gyro) : m_gyro_group(gyro) {}

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -69,6 +69,8 @@ protected:
   void DrawReshapableInput(ControllerEmu::ReshapableInput& group, QColor gate_color,
                            std::optional<ControllerEmu::ReshapableInput::ReshapeData> adj_coord);
 
+  virtual void DrawUnderGate(QPainter&) {}
+
   bool IsCalibrating() const;
 
   void DrawCalibration(QPainter& p, Common::DVec2 point);
@@ -130,6 +132,8 @@ public:
 
 private:
   void Draw() override;
+
+  void DrawUnderGate(QPainter& p) override;
 
   ControllerEmu::Force& m_swing_group;
   WiimoteEmu::MotionState m_motion_state{};

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -96,7 +96,10 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
 
   if (indicator)
   {
-    form_layout->addRow(indicator);
+    const auto indicator_layout = new QBoxLayout(QBoxLayout::Direction::Down);
+    indicator_layout->addWidget(indicator);
+    indicator_layout->setAlignment(Qt::AlignCenter);
+    form_layout->addRow(indicator_layout);
 
     connect(this, &MappingWidget::Update, indicator, QOverload<>::of(&MappingIndicator::update));
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -71,7 +71,7 @@ MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
 
   timer->start(1000 / INDICATOR_UPDATE_FREQ);
 
-  GetController()->GetStateLock();
+  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
 }
 
@@ -245,7 +245,7 @@ void MappingWindow::OnLoadProfilePressed()
   m_controller->LoadConfig(ini.GetOrCreateSection("Profile"));
   m_controller->UpdateReferences(g_controller_interface);
 
-  GetController()->GetStateLock();
+  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
 }
 
@@ -438,7 +438,7 @@ void MappingWindow::OnDefaultFieldsPressed()
   m_controller->LoadDefaults(g_controller_interface);
   m_controller->UpdateReferences(g_controller_interface);
 
-  GetController()->GetStateLock();
+  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
   emit Save();
 }
@@ -455,7 +455,7 @@ void MappingWindow::OnClearFieldsPressed()
 
   m_controller->UpdateReferences(g_controller_interface);
 
-  GetController()->GetStateLock();
+  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
   emit Save();
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -74,4 +74,9 @@ ControlState MixedTriggers::GetThreshold() const
   return m_threshold_setting.GetValue() / 100;
 }
 
+size_t MixedTriggers::GetTriggerCount() const
+{
+  return controls.size() / 2;
+}
+
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
@@ -22,6 +22,8 @@ public:
   ControlState GetDeadzone() const;
   ControlState GetThreshold() const;
 
+  size_t GetTriggerCount() const;
+
 private:
   SettingValue<double> m_threshold_setting;
   SettingValue<double> m_deadzone_setting;

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -153,7 +153,7 @@ public:
   // references and GetState(), by extension. This prevents a race condition
   // which happens while handling a hotplug event because a control reference's State()
   // could be called before we have finished updating the reference.
-  static std::unique_lock<std::recursive_mutex> GetStateLock();
+  [[nodiscard]] static std::unique_lock<std::recursive_mutex> GetStateLock();
 
   std::vector<std::unique_ptr<ControlGroup>> groups;
 

--- a/Source/Core/InputCommon/ControllerInterface/Device.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Device.cpp
@@ -309,7 +309,6 @@ DeviceContainer::DetectInput(u32 wait_ms, const std::vector<std::string>& device
 
     for (auto& device_state : device_states)
     {
-      device_state.device->UpdateInput();
       for (auto& input_state : device_state.input_states)
       {
         // We want an input that was initially 0.0 and currently 1.0.


### PR DESCRIPTION
Eliminate racy `UpdateInput` call within `DetectInput`.
(HotkeyManager/Core will already be doing this)

Split separate mapping indicator types into their own classes.

The "Point" indicator now uses the entire bounding box for drawing the "red dot".
The reduced box seemed to confuse some people into thinking it needed some kind of calibration.
![image](https://user-images.githubusercontent.com/1768214/75118869-8a38d780-5643-11ea-86d3-49b4f8417539.png)

Ensure the "state lock" is held when updating indicators.
Previously it was not held on a redraw invoked from Qt.

Cleaned up indicator code to eliminate some redundant logic and scalar multiplication all over the place.

Minor change to indicator colors for better contrast on some dark themes.
![image](https://user-images.githubusercontent.com/1768214/75196511-cc384b00-5721-11ea-8985-317704fa6043.png)
