### PR TITLE
DiscIO: Rework the implementation of TGC reading

### DIFF
--- a/Source/Core/DiscIO/TGCBlob.h
+++ b/Source/Core/DiscIO/TGCBlob.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <array>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
@@ -56,12 +56,10 @@ public:
 private:
   TGCFileReader(File::IOFile file);
 
-  bool InternalRead(u64 offset, u64 nbytes, u8* out_ptr);
-
   File::IOFile m_file;
   u64 m_size;
 
-  s64 m_file_area_shift;
+  std::vector<u8> m_fst;
 
   // Stored as big endian in memory, regardless of the host endianness
   TGCHeader m_header = {};

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -259,10 +259,7 @@ void GameList::ShowContextMenu(const QPoint&)
     const auto selected_games = GetSelectedGames();
 
     if (std::all_of(selected_games.begin(), selected_games.end(), [](const auto& game) {
-          // Converting from TGC is temporarily disabled because PR #8738 was merged prematurely.
-          // The TGC check will be removed by PR #8644.
-          return DiscIO::IsDisc(game->GetPlatform()) && game->IsVolumeSizeAccurate() &&
-                 game->GetBlobType() != DiscIO::BlobType::TGC;
+          return DiscIO::IsDisc(game->GetPlatform()) && game->IsVolumeSizeAccurate();
         }))
     {
       menu->addAction(tr("Convert Selected Files..."), this, &GameList::ConvertFile);

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -254,18 +254,16 @@ void GameList::ShowContextMenu(const QPoint&)
 
   QMenu* menu = new QMenu(this);
 
-  const auto can_convert = [](const std::shared_ptr<const UICommon::GameFile>& game) {
-    // Converting from TGC is temporarily disabled because PR #8738 was merged prematurely.
-    // The TGC check will be removed by PR #8644.
-    return DiscIO::IsDisc(game->GetPlatform()) && game->IsVolumeSizeAccurate() &&
-           game->GetBlobType() != DiscIO::BlobType::TGC;
-  };
-
   if (HasMultipleSelected())
   {
     const auto selected_games = GetSelectedGames();
 
-    if (std::all_of(selected_games.begin(), selected_games.end(), can_convert))
+    if (std::all_of(selected_games.begin(), selected_games.end(), [](const auto& game) {
+          // Converting from TGC is temporarily disabled because PR #8738 was merged prematurely.
+          // The TGC check will be removed by PR #8644.
+          return DiscIO::IsDisc(game->GetPlatform()) && game->IsVolumeSizeAccurate() &&
+                 game->GetBlobType() != DiscIO::BlobType::TGC;
+        }))
     {
       menu->addAction(tr("Convert Selected Files..."), this, &GameList::ConvertFile);
       menu->addSeparator();
@@ -298,7 +296,7 @@ void GameList::ShowContextMenu(const QPoint&)
       menu->addAction(tr("Set as &Default ISO"), this, &GameList::SetDefaultISO);
       const auto blob_type = game->GetBlobType();
 
-      if (can_convert(game))
+      if (game->IsVolumeSizeAccurate())
         menu->addAction(tr("Convert File..."), this, &GameList::ConvertFile);
 
       QAction* change_disc = menu->addAction(tr("Change &Disc"), this, &GameList::ChangeDisc);


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10654.

To quote the documenation file included with the program tgctogcm:

> TGC's are miniaturized .gcm images with a 32kB header.
> The embedded gcm contains some bogus data, namely:
> -FST Location (0x424 in gcm)
> -DOL Location (0x420 in gcm)
> -FST File offsets (all files are offset/spoofed by a certain amount)

Dolphin has been handling the values at 0x420 and 0x424 by simply overwriting them with a working value (just like tgctogcm does), but it has used a different approach for the file offsets in the FST. Instead of changing the offsets that are stored in the FST, Dolphin changed where the files actually are placed on the virtual disc. My hope was that this would make the loading times more accurate to how they are when running a TGC file as part of a larger disc. However, there are TGC files where we would need to move files backwards on the disc in order to do this (this is what [issue 10654](https://bugs.dolphin-emu.org/issues/10654) is about), so the approach we have been using is flawed.

This change makes Dolphin overwrite offsets in the FST instead, like tgctogcm does. Other than making Dolphin handle the affected TGC files correctly, this change also makes it so that unnecessary padding data isn't written if you use Dolphin to convert a TGC file to an ISO file. ~This feature is not actually implemented in Dolphin as of now, but I'm planning to add it in the near future as part of a larger feature.~