### PR TITLE
Add option to force texture filtering off

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -14,7 +14,12 @@
 #include <type_traits>
 #include <vector>
 
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+
+#ifndef _WIN32
+#include <strings.h>
+#endif
 
 #ifdef _MSC_VER
 #include <filesystem>
@@ -59,6 +64,17 @@ template <typename T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T
 bool TryParse(const std::string& str, T* output, int base = 0)
 {
   char* end_ptr = nullptr;
+
+  if (!strcasecmp("true", str.c_str()))
+  {
+    *output = static_cast<T>(1);
+    return true;
+  }
+  else if (!strcasecmp("false", str.c_str()))
+  {
+    *output = static_cast<T>(0);
+    return true;
+  }
 
   // Set errno to a clean slate.
   errno = 0;

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -102,8 +102,8 @@ const Info<bool> GFX_PREFER_GLES{{System::GFX, "Settings", "PreferGLES"}, false}
 
 // Graphics.Enhancements
 
-const Info<bool> GFX_ENHANCE_FORCE_FILTERING{{System::GFX, "Enhancements", "ForceFiltering"},
-                                             false};
+const Info<ForceFilteringMode> GFX_ENHANCE_FORCE_FILTERING{
+    {System::GFX, "Enhancements", "ForceFiltering"}, ForceFilteringMode::Default};
 const Info<int> GFX_ENHANCE_MAX_ANISOTROPY{{System::GFX, "Enhancements", "MaxAnisotropy"}, 0};
 const Info<std::string> GFX_ENHANCE_POST_SHADER{
     {System::GFX, "Enhancements", "PostProcessingShader"}, ""};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -9,6 +9,7 @@
 
 enum class AspectMode : int;
 enum class ShaderCompilationMode : int;
+enum class ForceFilteringMode : int;
 enum class StereoMode : int;
 enum class FreelookControlType : int;
 
@@ -83,7 +84,7 @@ extern const Info<bool> GFX_PREFER_GLES;
 
 // Graphics.Enhancements
 
-extern const Info<bool> GFX_ENHANCE_FORCE_FILTERING;
+extern const Info<ForceFilteringMode> GFX_ENHANCE_FORCE_FILTERING;
 extern const Info<int> GFX_ENHANCE_MAX_ANISOTROPY;  // NOTE - this is x in (1 << x)
 extern const Info<std::string> GFX_ENHANCE_POST_SHADER;
 extern const Info<bool> GFX_ENHANCE_FORCE_TRUE_COLOR;

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -101,7 +101,8 @@ public:
       layer->Set(Config::GFX_FAST_DEPTH_CALC, m_settings.m_FastDepthCalc);
       layer->Set(Config::GFX_ENABLE_PIXEL_LIGHTING, m_settings.m_EnablePixelLighting);
       layer->Set(Config::GFX_WIDESCREEN_HACK, m_settings.m_WidescreenHack);
-      layer->Set(Config::GFX_ENHANCE_FORCE_FILTERING, m_settings.m_ForceFiltering);
+      layer->Set(Config::GFX_ENHANCE_FORCE_FILTERING,
+                 static_cast<ForceFilteringMode>(m_settings.m_ForceFiltering));
       layer->Set(Config::GFX_ENHANCE_MAX_ANISOTROPY, m_settings.m_MaxAnisotropy);
       layer->Set(Config::GFX_ENHANCE_FORCE_TRUE_COLOR, m_settings.m_ForceTrueColor);
       layer->Set(Config::GFX_ENHANCE_DISABLE_COPY_FILTER, m_settings.m_DisableCopyFilter);

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -80,7 +80,7 @@ struct NetSettings
   bool m_FastDepthCalc = false;
   bool m_EnablePixelLighting = false;
   bool m_WidescreenHack = false;
-  bool m_ForceFiltering = false;
+  int m_ForceFiltering = 0;
   int m_MaxAnisotropy = 0;
   bool m_ForceTrueColor = false;
   bool m_DisableCopyFilter = false;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1352,7 +1352,7 @@ bool NetPlayServer::SetupNetSettings()
   settings.m_FastDepthCalc = Config::Get(Config::GFX_FAST_DEPTH_CALC);
   settings.m_EnablePixelLighting = Config::Get(Config::GFX_ENABLE_PIXEL_LIGHTING);
   settings.m_WidescreenHack = Config::Get(Config::GFX_WIDESCREEN_HACK);
-  settings.m_ForceFiltering = Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING);
+  settings.m_ForceFiltering = static_cast<int>(Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING));
   settings.m_MaxAnisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
   settings.m_ForceTrueColor = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
   settings.m_DisableCopyFilter = Config::Get(Config::GFX_ENHANCE_DISABLE_COPY_FILTER);

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -77,11 +77,12 @@ void EnhancementsWidget::CreateWidgets()
 
   m_pp_effect = new ToolTipComboBox();
   m_configure_pp_effect = new QPushButton(tr("Configure"));
+  m_force_texture_filtering = new GraphicsChoice({tr("Default"), tr("Force Bilinear/Trilinear"),
+                                                  tr("Force Nearest Neighbor")},
+                                                 Config::GFX_ENHANCE_FORCE_FILTERING);
   m_scaled_efb_copy = new GraphicsBool(tr("Scaled EFB Copy"), Config::GFX_HACK_COPY_EFB_SCALED);
   m_per_pixel_lighting =
       new GraphicsBool(tr("Per-Pixel Lighting"), Config::GFX_ENABLE_PIXEL_LIGHTING);
-  m_force_texture_filtering =
-      new GraphicsBool(tr("Force Texture Filtering"), Config::GFX_ENHANCE_FORCE_FILTERING);
   m_widescreen_hack = new GraphicsBool(tr("Widescreen Hack"), Config::GFX_WIDESCREEN_HACK);
   m_disable_fog = new GraphicsBool(tr("Disable Fog"), Config::GFX_DISABLE_FOG);
   m_force_24bit_color =
@@ -102,14 +103,16 @@ void EnhancementsWidget::CreateWidgets()
   enhancements_layout->addWidget(m_pp_effect, 4, 1);
   enhancements_layout->addWidget(m_configure_pp_effect, 4, 2);
 
-  enhancements_layout->addWidget(m_scaled_efb_copy, 5, 0);
-  enhancements_layout->addWidget(m_per_pixel_lighting, 5, 1);
-  enhancements_layout->addWidget(m_force_texture_filtering, 6, 0);
-  enhancements_layout->addWidget(m_widescreen_hack, 6, 1);
-  enhancements_layout->addWidget(m_disable_fog, 7, 0);
-  enhancements_layout->addWidget(m_force_24bit_color, 7, 1);
-  enhancements_layout->addWidget(m_disable_copy_filter, 8, 0);
-  enhancements_layout->addWidget(m_arbitrary_mipmap_detection, 8, 1);
+  enhancements_layout->addWidget(new QLabel(tr("Texture Filtering:")), 5, 0);
+  enhancements_layout->addWidget(m_force_texture_filtering, 5, 1, 1, -1);
+
+  enhancements_layout->addWidget(m_scaled_efb_copy, 6, 0);
+  enhancements_layout->addWidget(m_per_pixel_lighting, 6, 1);
+  enhancements_layout->addWidget(m_widescreen_hack, 7, 0);
+  enhancements_layout->addWidget(m_disable_fog, 7, 1);
+  enhancements_layout->addWidget(m_force_24bit_color, 8, 0);
+  enhancements_layout->addWidget(m_disable_copy_filter, 8, 1);
+  enhancements_layout->addWidget(m_arbitrary_mipmap_detection, 9, 0);
 
   // Stereoscopy
   auto* stereoscopy_box = new QGroupBox(tr("Stereoscopy"));
@@ -354,8 +357,8 @@ void EnhancementsWidget::AddDescriptions()
   static const char TR_FORCE_TEXTURE_FILTERING_DESCRIPTION[] =
       QT_TR_NOOP("Filters all textures, including any that the game explicitly set as "
                  "unfiltered.<br><br>May improve quality of certain textures in some games, but "
-                 "will cause issues in others.<br><br><dolphin_emphasis>If unsure, leave this "
-                 "unchecked.</dolphin_emphasis>");
+                 "will cause issues in others.<br><br><dolphin_emphasis>If unsure, select "
+                 "Default.</dolphin_emphasis>");
   static const char TR_DISABLE_COPY_FILTER_DESCRIPTION[] = QT_TR_NOOP(
       "Disables the blending of adjacent rows when copying the EFB. This is known in "
       "some games as \"deflickering\" or \"smoothing\".<br><br>Disabling the filter has no "
@@ -383,6 +386,9 @@ void EnhancementsWidget::AddDescriptions()
   m_pp_effect->SetTitle(tr("Post-Processing Effect"));
   m_pp_effect->SetDescription(tr(TR_POSTPROCESSING_DESCRIPTION));
 
+  m_force_texture_filtering->SetTitle(tr("Texture Filtering"));
+  m_force_texture_filtering->SetDescription(tr(TR_FORCE_TEXTURE_FILTERING_DESCRIPTION));
+
   m_scaled_efb_copy->SetDescription(tr(TR_SCALED_EFB_COPY_DESCRIPTION));
 
   m_per_pixel_lighting->SetDescription(tr(TR_PER_PIXEL_LIGHTING_DESCRIPTION));
@@ -392,8 +398,6 @@ void EnhancementsWidget::AddDescriptions()
   m_disable_fog->SetDescription(tr(TR_REMOVE_FOG_DESCRIPTION));
 
   m_force_24bit_color->SetDescription(tr(TR_FORCE_24BIT_DESCRIPTION));
-
-  m_force_texture_filtering->SetDescription(tr(TR_FORCE_TEXTURE_FILTERING_DESCRIPTION));
 
   m_disable_copy_filter->SetDescription(tr(TR_DISABLE_COPY_FILTER_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -39,7 +39,7 @@ private:
   QPushButton* m_configure_pp_effect;
   GraphicsBool* m_scaled_efb_copy;
   GraphicsBool* m_per_pixel_lighting;
-  GraphicsBool* m_force_texture_filtering;
+  GraphicsChoice* m_force_texture_filtering;
   GraphicsBool* m_widescreen_hack;
   GraphicsBool* m_disable_fog;
   GraphicsBool* m_force_24bit_color;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -456,7 +456,7 @@ void Renderer::CheckForConfigChanges()
   const u32 old_multisamples = g_ActiveConfig.iMultisamples;
   const int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
   const int old_efb_access_tile_size = g_ActiveConfig.iEFBAccessTileSize;
-  const bool old_force_filtering = g_ActiveConfig.bForceFiltering;
+  const ForceFilteringMode old_force_filtering = g_ActiveConfig.iForceFiltering;
   const bool old_vsync = g_ActiveConfig.bVSyncActive;
   const bool old_bbox = g_ActiveConfig.bBBoxEnable;
 
@@ -493,7 +493,7 @@ void Renderer::CheckForConfigChanges()
     changed_bits |= CONFIG_CHANGE_BIT_MULTISAMPLES;
   if (old_anisotropy != g_ActiveConfig.iMaxAnisotropy)
     changed_bits |= CONFIG_CHANGE_BIT_ANISOTROPY;
-  if (old_force_filtering != g_ActiveConfig.bForceFiltering)
+  if (old_force_filtering != g_ActiveConfig.iForceFiltering)
     changed_bits |= CONFIG_CHANGE_BIT_FORCE_TEXTURE_FILTERING;
   if (old_vsync != g_ActiveConfig.bVSyncActive)
     changed_bits |= CONFIG_CHANGE_BIT_VSYNC;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -986,12 +986,18 @@ static void SetSamplerState(u32 index, float custom_tex_scale, bool custom_tex,
   state.Generate(bpmem, index);
 
   // Force texture filtering config option.
-  if (g_ActiveConfig.bForceFiltering)
+  if (g_ActiveConfig.iForceFiltering == ForceFilteringMode::ForceLinear)
   {
     state.tm0.min_filter = FilterMode::Linear;
     state.tm0.mag_filter = FilterMode::Linear;
     state.tm0.mipmap_filter =
         tm0.mipmap_filter != MipMode::None ? FilterMode::Linear : FilterMode::Near;
+  }
+  else if (g_ActiveConfig.iForceFiltering == ForceFilteringMode::ForceNear)
+  {
+    state.tm0.min_filter = FilterMode::Near;
+    state.tm0.mag_filter = FilterMode::Near;
+    state.tm0.mipmap_filter = FilterMode::Near;
   }
 
   // Custom textures may have a greater number of mips

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -103,7 +103,7 @@ void VideoConfig::Refresh()
   drawStart = Config::Get(Config::GFX_SW_DRAW_START);
   drawEnd = Config::Get(Config::GFX_SW_DRAW_END);
 
-  bForceFiltering = Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING);
+  iForceFiltering = Config::Get(Config::GFX_ENHANCE_FORCE_FILTERING);
   iMaxAnisotropy = Config::Get(Config::GFX_ENHANCE_MAX_ANISOTROPY);
   sPostProcessingShader = Config::Get(Config::GFX_ENHANCE_POST_SHADER);
   bForceTrueColor = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -49,6 +49,13 @@ enum class ShaderCompilationMode : int
   AsynchronousSkipRendering
 };
 
+enum class ForceFilteringMode : int
+{
+  Default,
+  ForceLinear,
+  ForceNear
+};
+
 // NEVER inherit from this class.
 struct VideoConfig final
 {
@@ -69,7 +76,7 @@ struct VideoConfig final
   u32 iMultisamples = 0;
   bool bSSAA = false;
   int iEFBScale = 0;
-  bool bForceFiltering = false;
+  ForceFilteringMode iForceFiltering{};
   int iMaxAnisotropy = 0;
   std::string sPostProcessingShader;
   bool bForceTrueColor = false;


### PR DESCRIPTION
I saw this requested on Reddit. I thought it would look horrible, but I think I might actually prefer it to bilinear filtering.
Menu (ignore the titlebar, that's a bug with my screenshot tool):
![Menu](https://user-images.githubusercontent.com/8355305/75121378-7308e280-5661-11ea-8e72-d46f3c6ab21b.png)
Default:
![Default](https://user-images.githubusercontent.com/8355305/75121386-7bf9b400-5661-11ea-804d-a3ebe7dc0a65.png)
Force:
![Force](https://user-images.githubusercontent.com/8355305/75121389-83b95880-5661-11ea-98c3-77275516033e.png)
None:
![None](https://user-images.githubusercontent.com/8355305/75121393-8d42c080-5661-11ea-9c68-9122ca82ed09.png)