### PR TITLE
InputCommon: Minor ReshapableInput related cleanups.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -203,7 +203,5 @@ private:
   QAction* m_completion_action;
   ControllerEmu::ReshapableInput::CalibrationData m_calibration_data;
   QTimer* m_informative_timer;
-
-  bool m_is_centering = false;
-  Common::DVec2 m_new_center;
+  std::optional<Common::DVec2> m_new_center;
 };

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -54,7 +54,7 @@ constexpr int ReshapableInput::CALIBRATION_SAMPLE_COUNT;
 
 std::optional<u32> StickGate::GetIdealCalibrationSampleCount() const
 {
-  return {};
+  return std::nullopt;
 }
 
 OctagonStickGate::OctagonStickGate(ControlState radius) : m_radius(radius)
@@ -84,6 +84,12 @@ RoundStickGate::RoundStickGate(ControlState radius) : m_radius(radius)
 ControlState RoundStickGate::GetRadiusAtAngle(double) const
 {
   return m_radius;
+}
+
+std::optional<u32> RoundStickGate::GetIdealCalibrationSampleCount() const
+{
+  // The "radius" is the same at every angle so a single sample is enough.
+  return 1;
 }
 
 SquareStickGate::SquareStickGate(ControlState half_width) : m_half_width(half_width)

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -282,10 +282,11 @@ void ReshapableInput::SaveConfig(IniFile::Section* section, const std::string& d
       [](ControlState val) { return fmt::format("{:.2f}", val * CALIBRATION_CONFIG_SCALE); });
   section->Set(group + CALIBRATION_CONFIG_NAME, JoinStrings(save_data, " "), "");
 
-  const auto center_data = fmt::format("{:.2f} {:.2f}", m_center.x * CENTER_CONFIG_SCALE,
+  // Save center value.
+  static constexpr char center_format[] = "{:.2f} {:.2f}";
+  const auto center_data = fmt::format(center_format, m_center.x * CENTER_CONFIG_SCALE,
                                        m_center.y * CENTER_CONFIG_SCALE);
-
-  section->Set(group + CENTER_CONFIG_NAME, center_data, "");
+  section->Set(group + CENTER_CONFIG_NAME, center_data, fmt::format(center_format, 0.0, 0.0));
 }
 
 ReshapableInput::ReshapeData ReshapableInput::Reshape(ControlState x, ControlState y,

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -183,7 +183,8 @@ void ReshapableInput::UpdateCalibrationData(CalibrationData& data, Common::DVec2
   auto& calibration_sample = data[calibration_index];
 
   // Update closest sample from provided x,y.
-  calibration_sample = std::max(calibration_sample, point.Length());
+  calibration_sample = std::clamp(point.Length(), calibration_sample,
+                                  SquareStickGate(1).GetRadiusAtAngle(calibration_angle));
 
   // Here we update all other samples in our calibration vector to maintain
   // a convex polygon containing our new calibration point.

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -48,6 +48,7 @@ class RoundStickGate : public StickGate
 public:
   explicit RoundStickGate(ControlState radius);
   ControlState GetRadiusAtAngle(double ang) const override final;
+  std::optional<u32> GetIdealCalibrationSampleCount() const override final;
 
 private:
   const ControlState m_radius;


### PR DESCRIPTION
Because of poor math, calibration sometimes ends up being drawn outside of the mapping indicator.
Calibration values are now clamped within the square shape to prevent this.

Specify the default value when saving calibration center to prevent saving default values.
The eliminates a bunch of irrelevant entries in the ini file for extensions that aren't even configured...
> Drums/Stick/Center = 0.00 0.00
> Turntable/Stick/Center = 0.00 0.00
> uDraw/Stylus/Center = 0.00 0.00
> Drawsome/Stylus/Center = 0.00 0.00

`RoundStickGate::GetIdealCalibrationSampleCount` can return 1.
This makes swing's reshaping math use an actual circle rather than an n-gon.

Fix "Calibration" routine from always setting center value to {0,0} even on cancellation.