### PR TITLE
Android: Update Gradle Plugin to 3.6.0

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.0'
     }
 }
 


### PR DESCRIPTION
Android Studio recommends updating to version 3.6.0