### PR TITLE
[RFC] .gitmodules: Make Externals/Qt clone shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = Externals/Qt
 	url = https://github.com/dolphin-emu/ext-win-qt.git
 	branch = master
+	shallow = true


### PR DESCRIPTION
Instead of cloning the entire history of the submodule, only fetch the latest commit. This saves about 300M of disk space currently and will only save more in the future.

**Caveats:**
* A shallow clone might be slower under some circumstances such as a very fast internet connection ([Try this test](https://gist.github.com/spycrab/41f994b015e4bf8efb64b8b2cf7e0e96))
* If you want to change anything in the Externals you will have to unshallow the clone (realistically only about 5 people ever needed to do this)