### PR TITLE
HW/WiimoteEmu: Fix Classic Controller triggers.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -130,10 +130,12 @@ void Classic::Update()
     classic_data.SetRightStick({x, y});
   }
 
+  u16 buttons = 0;
+
   // triggers
   {
     ControlState trigs[2] = {0, 0};
-    m_triggers->GetState(&classic_data.bt.hex, classic_trigger_bitmasks.data(), trigs);
+    m_triggers->GetState(&buttons, classic_trigger_bitmasks.data(), trigs);
 
     const u8 lt = static_cast<u8>(trigs[0] * TRIGGER_RANGE);
     const u8 rt = static_cast<u8>(trigs[1] * TRIGGER_RANGE);
@@ -143,9 +145,9 @@ void Classic::Update()
   }
 
   // buttons and dpad
-  u16 buttons = 0;
   m_buttons->GetState(&buttons, classic_button_bitmasks.data());
   m_dpad->GetState(&buttons, classic_dpad_bitmasks.data());
+
   classic_data.SetButtons(buttons);
 
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = classic_data;


### PR DESCRIPTION
Digital button bits were not being set.
Fixes regression from #8575.
https://bugs.dolphin-emu.org/issues/11992