### PR TITLE
Core/HotkeyManager: Fix group names in config

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -176,6 +176,11 @@ bool IniFile::DeleteSection(std::string_view section_name)
   return false;
 }
 
+bool IniFile::Exists(std::string_view section_name) const
+{
+  return GetSection(section_name) != nullptr;
+}
+
 bool IniFile::Exists(std::string_view section_name, std::string_view key) const
 {
   const Section* section = GetSection(section_name);

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -119,6 +119,7 @@ public:
 
   bool Save(const std::string& filename);
 
+  bool Exists(std::string_view section_name) const;
   // Returns true if key exists in section
   bool Exists(std::string_view section_name, std::string_view key) const;
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -13,6 +13,8 @@
 
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
+#include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -237,6 +239,43 @@ bool IsPressed(int id, bool held)
   return false;
 }
 
+// This function exists to load the old "Keys" group so pre-existing configs don't break.
+// TODO: Remove this at a future date when we're confident most configs are migrated.
+static void LoadLegacyConfig(ControllerEmu::EmulatedController* controller)
+{
+  IniFile inifile;
+  if (inifile.Load(File::GetUserPath(D_CONFIG_IDX) + "Hotkeys.ini"))
+  {
+    if (!inifile.Exists("Hotkeys") && inifile.Exists("Hotkeys1"))
+    {
+      auto sec = inifile.GetOrCreateSection("Hotkeys1");
+
+      {
+        std::string defdev;
+        sec->Get("Device", &defdev, "");
+        controller->SetDefaultDevice(defdev);
+      }
+
+      for (auto& group : controller->groups)
+      {
+        for (auto& control : group->controls)
+        {
+          std::string key("Keys/" + control->name);
+
+          if (sec->Exists(key))
+          {
+            std::string expression;
+            sec->Get(key, &expression, "");
+            control->control_ref->SetExpression(std::move(expression));
+          }
+        }
+      }
+
+      controller->UpdateReferences(g_controller_interface);
+    }
+  }
+}
+
 void Initialize()
 {
   if (s_config.ControllersNeedToBeCreated())
@@ -245,7 +284,7 @@ void Initialize()
   s_config.RegisterHotplugCallback();
 
   // load the saved controller config
-  s_config.LoadConfig(true);
+  LoadConfig();
 
   s_hotkey_down = {};
 
@@ -255,6 +294,7 @@ void Initialize()
 void LoadConfig()
 {
   s_config.LoadConfig(true);
+  LoadLegacyConfig(s_config.GetController(0));
 }
 
 ControllerEmu::ControlGroup* GetHotkeyGroup(HotkeyGroup group)
@@ -306,7 +346,7 @@ HotkeyManager::HotkeyManager()
   for (std::size_t group = 0; group < m_hotkey_groups.size(); group++)
   {
     m_hotkey_groups[group] =
-        (m_keys[group] = new ControllerEmu::Buttons("Keys", s_groups_info[group].name));
+        (m_keys[group] = new ControllerEmu::Buttons(s_groups_info[group].name));
     groups.emplace_back(m_hotkey_groups[group]);
     for (int key = s_groups_info[group].first; key <= s_groups_info[group].last; key++)
     {
@@ -321,7 +361,7 @@ HotkeyManager::~HotkeyManager()
 
 std::string HotkeyManager::GetName() const
 {
-  return std::string("Hotkeys") + char('1' + 0);
+  return "Hotkeys";
 }
 
 void HotkeyManager::GetInput(HotkeyStatus* const kb)


### PR DESCRIPTION
For some reason every button group was shoved into the same config group called "Keys" which caused buggy behavior once someone tried to have hotkeys with the same name in different groups. This fixes that, and converts existing configs to the new group names so they don't get reset.