### PR TITLE
Qt: Minor UI Enhancements

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -113,8 +113,13 @@ void GameConfigWidget::CreateWidgets()
   core_layout->addWidget(m_sync_gpu, 3, 0);
   core_layout->addWidget(m_enable_fast_disc, 4, 0);
   core_layout->addWidget(m_use_dsp_hle, 5, 0);
-  core_layout->addWidget(new QLabel(tr("Deterministic dual core:")), 6, 0);
-  core_layout->addWidget(m_deterministic_dual_core, 6, 1);
+
+  auto* dual_core_layout = new QGridLayout;
+  dual_core_layout->addWidget(new QLabel(tr("Deterministic dual core:")), 0, 0);
+  dual_core_layout->addWidget(m_deterministic_dual_core, 0, 1);
+  dual_core_layout->setColumnStretch(1, 1);
+
+  core_layout->addLayout(dual_core_layout, 6, 0, 1, 1);
 
   // Stereoscopy
   auto* stereoscopy_box = new QGroupBox(tr("Stereoscopy"));
@@ -139,10 +144,17 @@ void GameConfigWidget::CreateWidgets()
   m_use_monoscopic_shadows->setToolTip(
       tr("Use a single depth buffer for both eyes. Needed for a few games."));
 
-  stereoscopy_layout->addWidget(new QLabel(tr("Depth Percentage:")), 0, 0);
-  stereoscopy_layout->addWidget(m_depth_slider, 0, 1);
-  stereoscopy_layout->addWidget(new QLabel(tr("Convergence:")), 1, 0);
-  stereoscopy_layout->addWidget(m_convergence_spin, 1, 1);
+  auto* stereoscopy_slider_layout = new QGridLayout;
+
+  stereoscopy_slider_layout->addWidget(new QLabel(tr("Depth Percentage:")), 0, 0);
+  stereoscopy_slider_layout->addWidget(m_depth_slider, 0, 1);
+  stereoscopy_slider_layout->addWidget(new QLabel(tr("Convergence:")), 1, 0);
+  stereoscopy_slider_layout->addWidget(m_convergence_spin, 1, 1);
+
+  stereoscopy_slider_layout->setColumnStretch(1, 1);
+
+  stereoscopy_layout->addLayout(stereoscopy_slider_layout, 0, 0, 1, 1);
+
   stereoscopy_layout->addWidget(m_use_monoscopic_shadows, 2, 0);
 
   auto* settings_box = new QGroupBox(tr("Game-Specific Settings"));

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -84,6 +84,7 @@ void GameConfigWidget::CreateWidgets()
   auto* core_box = new QGroupBox(tr("Core"));
   auto* core_layout = new QGridLayout;
   core_box->setLayout(core_layout);
+  core_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
   m_enable_dual_core = new QCheckBox(tr("Enable Dual Core"));
   m_enable_mmu = new QCheckBox(tr("Enable MMU"));
@@ -119,6 +120,7 @@ void GameConfigWidget::CreateWidgets()
   auto* stereoscopy_box = new QGroupBox(tr("Stereoscopy"));
   auto* stereoscopy_layout = new QGridLayout;
   stereoscopy_box->setLayout(stereoscopy_layout);
+  stereoscopy_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
   m_depth_slider = new QSlider(Qt::Horizontal);
 
@@ -146,6 +148,7 @@ void GameConfigWidget::CreateWidgets()
   auto* settings_box = new QGroupBox(tr("Game-Specific Settings"));
   auto* settings_layout = new QVBoxLayout;
   settings_box->setLayout(settings_layout);
+  settings_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
   settings_layout->addWidget(
       new QLabel(tr("These settings override core Dolphin settings.\nUndetermined means the game "
@@ -154,10 +157,9 @@ void GameConfigWidget::CreateWidgets()
   settings_layout->addWidget(stereoscopy_box);
 
   auto* general_layout = new QGridLayout;
-
   general_layout->addWidget(settings_box, 0, 0, 1, -1);
-
   general_layout->addWidget(m_refresh_config, 1, 0, 1, -1);
+  general_layout->setRowStretch(2, 1);
 
   for (QCheckBox* item : {m_enable_dual_core, m_enable_mmu, m_enable_fprf, m_sync_gpu,
                           m_enable_fast_disc, m_use_dsp_hle, m_use_monoscopic_shadows})

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -96,8 +96,14 @@ void AdvancedWidget::CreateWidgets()
   dump_layout->addWidget(m_use_fullres_framedumps, 0, 0);
 #if defined(HAVE_FFMPEG)
   dump_layout->addWidget(m_dump_use_ffv1, 0, 1);
-  dump_layout->addWidget(new QLabel(tr("Bitrate (kbps):")), 1, 0);
-  dump_layout->addWidget(m_dump_bitrate, 1, 1);
+
+  auto* bitrate_layout = new QGridLayout;
+
+  bitrate_layout->addWidget(new QLabel(tr("Bitrate (kbps):")), 0, 0);
+  bitrate_layout->addWidget(m_dump_bitrate, 0, 1);
+  bitrate_layout->setColumnStretch(1, 1);
+
+  dump_layout->addLayout(bitrate_layout, 1, 0, 1, 0);
 #endif
 
   // Misc.

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -85,16 +85,21 @@ void EnhancementsWidget::CreateWidgets()
   m_arbitrary_mipmap_detection = new GraphicsBool(tr("Arbitrary Mipmap Detection"),
                                                   Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
 
-  enhancements_layout->addWidget(new QLabel(tr("Internal Resolution:")), 0, 0);
-  enhancements_layout->addWidget(m_ir_combo, 0, 1, 1, -1);
-  enhancements_layout->addWidget(new QLabel(tr("Anti-Aliasing:")), 1, 0);
-  enhancements_layout->addWidget(m_aa_combo, 1, 1, 1, -1);
-  enhancements_layout->addWidget(new QLabel(tr("Anisotropic Filtering:")), 2, 0);
-  enhancements_layout->addWidget(m_af_combo, 2, 1, 1, -1);
+  auto* enhancements_combo_layout = new QGridLayout;
 
-  enhancements_layout->addWidget(new QLabel(tr("Post-Processing Effect:")), 4, 0);
-  enhancements_layout->addWidget(m_pp_effect, 4, 1);
-  enhancements_layout->addWidget(m_configure_pp_effect, 4, 2);
+  enhancements_combo_layout->addWidget(new QLabel(tr("Internal Resolution:")), 0, 0);
+  enhancements_combo_layout->addWidget(m_ir_combo, 0, 1, 1, -1);
+  enhancements_combo_layout->addWidget(new QLabel(tr("Anti-Aliasing:")), 1, 0);
+  enhancements_combo_layout->addWidget(m_aa_combo, 1, 1, 1, -1);
+  enhancements_combo_layout->addWidget(new QLabel(tr("Anisotropic Filtering:")), 2, 0);
+  enhancements_combo_layout->addWidget(m_af_combo, 2, 1, 1, -1);
+
+  enhancements_combo_layout->addWidget(new QLabel(tr("Post-Processing Effect:")), 4, 0);
+  enhancements_combo_layout->addWidget(m_pp_effect, 4, 1);
+  enhancements_combo_layout->addWidget(m_configure_pp_effect, 4, 2);
+
+  enhancements_combo_layout->setColumnStretch(1, 1);
+  enhancements_layout->addLayout(enhancements_combo_layout, 0, 0, 1, 0);
 
   enhancements_layout->addWidget(m_scaled_efb_copy, 5, 0);
   enhancements_layout->addWidget(m_per_pixel_lighting, 5, 1);

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -68,14 +68,20 @@ void GeneralWidget::CreateWidgets()
     m_backend_combo->addItem(tr(backend->GetDisplayName().c_str()),
                              QVariant(QString::fromStdString(backend->GetName())));
 
-  m_video_layout->addWidget(new QLabel(tr("Backend:")), 0, 0);
-  m_video_layout->addWidget(m_backend_combo, 0, 1);
+  auto* m_combobox_layout = new QGridLayout;
 
-  m_video_layout->addWidget(new QLabel(tr("Adapter:")), 1, 0);
-  m_video_layout->addWidget(m_adapter_combo, 1, 1);
+  m_combobox_layout->addWidget(new QLabel(tr("Backend:")), 0, 0);
+  m_combobox_layout->addWidget(m_backend_combo, 0, 1);
 
-  m_video_layout->addWidget(new QLabel(tr("Aspect Ratio:")), 3, 0);
-  m_video_layout->addWidget(m_aspect_combo, 3, 1);
+  m_combobox_layout->addWidget(new QLabel(tr("Adapter:")), 1, 0);
+  m_combobox_layout->addWidget(m_adapter_combo, 1, 1);
+
+  m_combobox_layout->addWidget(new QLabel(tr("Aspect Ratio:")), 3, 0);
+  m_combobox_layout->addWidget(m_aspect_combo, 3, 1);
+
+  m_combobox_layout->setColumnStretch(1, 1);
+
+  m_video_layout->addLayout(m_combobox_layout, 0, 0, 1, 0);
 
   m_video_layout->addWidget(m_enable_vsync, 4, 0);
   m_video_layout->addWidget(m_enable_fullscreen, 4, 1);

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -298,7 +298,7 @@ void GameList::ShowContextMenu(const QPoint&)
 
     if (platform != DiscIO::Platform::ELFOrDOL)
     {
-      menu->addAction(tr("&Properties"), this, &GameList::OpenProperties);
+      menu->addAction(tr("&Properties..."), this, &GameList::OpenProperties);
       menu->addAction(tr("&Wiki"), this, &GameList::OpenWiki);
 
       menu->addSeparator();
@@ -310,9 +310,9 @@ void GameList::ShowContextMenu(const QPoint&)
       const auto blob_type = game->GetBlobType();
 
       if (blob_type == DiscIO::BlobType::GCZ)
-        menu->addAction(tr("Decompress ISO..."), this, [this] { CompressISO(true); });
+        menu->addAction(tr("&Decompress ISO..."), this, [this] { CompressISO(true); });
       else if (blob_type == DiscIO::BlobType::PLAIN)
-        menu->addAction(tr("Compress ISO..."), this, [this] { CompressISO(false); });
+        menu->addAction(tr("&Compress ISO..."), this, [this] { CompressISO(false); });
 
       QAction* change_disc = menu->addAction(tr("Change &Disc"), this, &GameList::ChangeDisc);
 
@@ -325,7 +325,7 @@ void GameList::ShowContextMenu(const QPoint&)
 
     if (platform == DiscIO::Platform::WiiDisc)
     {
-      auto* perform_disc_update = menu->addAction(tr("Perform System Update"), this,
+      auto* perform_disc_update = menu->addAction(tr("Perform &Wii System Update"), this,
                                                   [this, file_path = game->GetFilePath()] {
                                                     WiiUpdate::PerformDiscUpdate(file_path, this);
                                                   });
@@ -334,8 +334,8 @@ void GameList::ShowContextMenu(const QPoint&)
 
     if (platform == DiscIO::Platform::WiiWAD)
     {
-      QAction* wad_install_action = new QAction(tr("Install to the NAND"), menu);
-      QAction* wad_uninstall_action = new QAction(tr("Uninstall from the NAND"), menu);
+      QAction* wad_install_action = new QAction(tr("&Install to the NAND"), menu);
+      QAction* wad_uninstall_action = new QAction(tr("&Uninstall from the NAND"), menu);
 
       connect(wad_install_action, &QAction::triggered, this, &GameList::InstallWAD);
       connect(wad_uninstall_action, &QAction::triggered, this, &GameList::UninstallWAD);
@@ -361,7 +361,7 @@ void GameList::ShowContextMenu(const QPoint&)
     if (platform == DiscIO::Platform::WiiWAD || platform == DiscIO::Platform::WiiDisc)
     {
       menu->addAction(tr("Open Wii &Save Folder"), this, &GameList::OpenWiiSaveFolder);
-      menu->addAction(tr("Export Wii Save"), this, &GameList::ExportWiiSave);
+      menu->addAction(tr("&Export Wii Save"), this, &GameList::ExportWiiSave);
       menu->addSeparator();
     }
 
@@ -372,13 +372,13 @@ void GameList::ShowContextMenu(const QPoint&)
     }
 
     menu->addAction(tr("Open &Containing Folder"), this, &GameList::OpenContainingFolder);
-    menu->addAction(tr("Delete File..."), this, &GameList::DeleteFile);
+    menu->addAction(tr("&Delete File..."), this, &GameList::DeleteFile);
 
     menu->addSeparator();
 
     auto* model = Settings::Instance().GetGameListModel();
 
-    auto* tags_menu = menu->addMenu(tr("Tags"));
+    auto* tags_menu = menu->addMenu(tr("&Tags"));
 
     auto path = game->GetFilePath();
     auto game_tags = model->GetGameTags(path);
@@ -398,12 +398,12 @@ void GameList::ShowContextMenu(const QPoint&)
       });
     }
 
-    menu->addAction(tr("New Tag..."), this, &GameList::NewTag);
-    menu->addAction(tr("Remove Tag..."), this, &GameList::DeleteTag);
+    tags_menu->addAction(tr("&New Tag..."), this, &GameList::NewTag);
+    tags_menu->addAction(tr("&Remove Tag..."), this, &GameList::DeleteTag);
 
     menu->addSeparator();
 
-    QAction* netplay_host = new QAction(tr("Host with NetPlay"), menu);
+    QAction* netplay_host = new QAction(tr("Host with &NetPlay"), menu);
 
     connect(netplay_host, &QAction::triggered, [this, game] {
       emit NetPlayHost(QString::fromStdString(game->GetUniqueIdentifier()));

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -23,7 +23,7 @@
 #include <QProgressDialog>
 #include <QShortcut>
 #include <QSortFilterProxyModel>
-#include <QTableView>
+#include <QTableWidget>
 #include <QUrl>
 
 #include "Common/FileUtil.h"
@@ -102,7 +102,7 @@ void GameList::MakeListView()
   m_list = new QTableView(this);
   m_list->setModel(m_list_proxy);
 
-  m_list->setTabKeyNavigation(false);
+  m_list->setTabKeyNavigation(true);
   m_list->setSelectionMode(QAbstractItemView::ExtendedSelection);
   m_list->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_list->setAlternatingRowColors(true);
@@ -146,6 +146,8 @@ void GameList::MakeListView()
   hor_header->setSectionResizeMode(GameListModel::COL_SIZE, QHeaderView::Fixed);
   hor_header->setSectionResizeMode(GameListModel::COL_FILE_NAME, QHeaderView::Interactive);
   hor_header->setSectionResizeMode(GameListModel::COL_TAGS, QHeaderView::Interactive);
+
+
 
   // There's some odd platform-specific behavior with default minimum section size
   hor_header->setMinimumSectionSize(38);

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -361,7 +361,7 @@ void GameList::ShowContextMenu(const QPoint&)
     if (platform == DiscIO::Platform::WiiWAD || platform == DiscIO::Platform::WiiDisc)
     {
       menu->addAction(tr("Open Wii &Save Folder"), this, &GameList::OpenWiiSaveFolder);
-      menu->addAction(tr("&Export Wii Save"), this, &GameList::ExportWiiSave);
+      menu->addAction(tr("&Export Wii Save..."), this, &GameList::ExportWiiSave);
       menu->addSeparator();
     }
 
@@ -403,7 +403,7 @@ void GameList::ShowContextMenu(const QPoint&)
 
     menu->addSeparator();
 
-    QAction* netplay_host = new QAction(tr("Host with &NetPlay"), menu);
+    QAction* netplay_host = new QAction(tr("Host with &NetPlay..."), menu);
 
     connect(netplay_host, &QAction::triggered, [this, game] {
       emit NetPlayHost(QString::fromStdString(game->GetUniqueIdentifier()));

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -16,6 +16,7 @@
 #include <QStackedWidget>
 #include <QVBoxLayout>
 #include <QWindow>
+#include <QScreen>
 
 #include <future>
 #include <optional>
@@ -1649,11 +1650,21 @@ void MainWindow::OnRequestGolfControl()
 
 void MainWindow::ShowTASInput()
 {
+  // Used to position TAS windows in a more friendly way
+  QSize desktop_size = this->screen()->size();
+  int pad = 120;
+
   for (int i = 0; i < num_gc_controllers; i++)
   {
     if (SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_NONE &&
         SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_GC_GBA)
     {
+      int win_width = m_gc_tas_input_windows[i]->width();
+      int win_height = m_gc_tas_input_windows[i]->height();
+
+      int win_y = pad + (i * 15);
+
+      m_gc_tas_input_windows[i]->setGeometry(pad, win_y, win_width, win_height);
       m_gc_tas_input_windows[i]->show();
       m_gc_tas_input_windows[i]->raise();
       m_gc_tas_input_windows[i]->activateWindow();
@@ -1665,6 +1676,13 @@ void MainWindow::ShowTASInput()
     if (WiimoteCommon::GetSource(i) == WiimoteSource::Emulated &&
         (!Core::IsRunning() || SConfig::GetInstance().bWii))
     {
+      int win_width = m_wii_tas_input_windows[i]->width();
+      int win_height = m_wii_tas_input_windows[i]->height();
+
+      int win_x = (desktop_size.width() - win_width) - pad;
+      int win_y = pad + (i * 15);
+
+      m_wii_tas_input_windows[i]->setGeometry(win_x, win_y, win_width, win_height);
       m_wii_tas_input_windows[i]->show();
       m_wii_tas_input_windows[i]->raise();
       m_wii_tas_input_windows[i]->activateWindow();

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -238,7 +238,7 @@ void MenuBar::AddToolsMenu()
 
   tools_menu->addSeparator();
 
-  QMenu* gc_ipl = tools_menu->addMenu(tr("Load GameCube Main Menu"));
+  QMenu* gc_ipl = tools_menu->addMenu(tr("Load &GameCube Main Menu"));
 
   m_ntscj_ipl = gc_ipl->addAction(tr("NTSC-J"), this,
                                   [this] { emit BootGameCubeIPL(DiscIO::Region::NTSC_J); });
@@ -247,7 +247,7 @@ void MenuBar::AddToolsMenu()
   m_pal_ipl =
       gc_ipl->addAction(tr("PAL"), this, [this] { emit BootGameCubeIPL(DiscIO::Region::PAL); });
 
-  tools_menu->addAction(tr("Memory Card &Manager"), this, [this] { emit ShowMemcardManager(); });
+  tools_menu->addAction(tr("&Memory Card Manager"), this, [this] { emit ShowMemcardManager(); });
 
   tools_menu->addSeparator();
 
@@ -280,17 +280,17 @@ void MenuBar::AddToolsMenu()
 
   tools_menu->addSeparator();
 
-  tools_menu->addAction(tr("Import Wii Save..."), this, &MenuBar::ImportWiiSave);
-  tools_menu->addAction(tr("Export All Wii Saves"), this, &MenuBar::ExportWiiSaves);
+  tools_menu->addAction(tr("&Import Wii Save..."), this, &MenuBar::ImportWiiSave);
+  tools_menu->addAction(tr("E&xport All Wii Saves"), this, &MenuBar::ExportWiiSaves);
 
-  QMenu* menu = new QMenu(tr("Connect Wii Remotes"), tools_menu);
+  QMenu* menu = new QMenu(tr("&Connect Wii Remotes"), tools_menu);
 
   tools_menu->addSeparator();
   tools_menu->addMenu(menu);
 
   for (int i = 0; i < 4; i++)
   {
-    m_wii_remotes[i] = menu->addAction(tr("Connect Wii Remote %1").arg(i + 1), this,
+    m_wii_remotes[i] = menu->addAction(tr("Connect Wii Remote &%1").arg(i + 1), this,
                                        [this, i] { emit ConnectWiiRemote(i); });
     m_wii_remotes[i]->setCheckable(true);
   }
@@ -298,7 +298,7 @@ void MenuBar::AddToolsMenu()
   menu->addSeparator();
 
   m_wii_remotes[4] =
-      menu->addAction(tr("Connect Balance Board"), this, [this] { emit ConnectWiiRemote(4); });
+      menu->addAction(tr("Connect Balance &Board"), this, [this] { emit ConnectWiiRemote(4); });
   m_wii_remotes[4]->setCheckable(true);
 }
 
@@ -328,8 +328,8 @@ void MenuBar::AddEmulationMenu()
 void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 {
   m_state_load_menu = emu_menu->addMenu(tr("&Load State"));
-  m_state_load_menu->addAction(tr("Load State from File"), this, &MenuBar::StateLoad);
-  m_state_load_menu->addAction(tr("Load State from Selected Slot"), this, &MenuBar::StateLoadSlot);
+  m_state_load_menu->addAction(tr("Load State from &File"), this, &MenuBar::StateLoad);
+  m_state_load_menu->addAction(tr("Load State from &Selected Slot"), this, &MenuBar::StateLoadSlot);
   m_state_load_slots_menu = m_state_load_menu->addMenu(tr("Load State from Slot"));
   m_state_load_menu->addAction(tr("&Undo Load State"), this, &MenuBar::StateLoadUndo);
 
@@ -344,11 +344,11 @@ void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
 void MenuBar::AddStateSaveMenu(QMenu* emu_menu)
 {
   m_state_save_menu = emu_menu->addMenu(tr("Sa&ve State"));
-  m_state_save_menu->addAction(tr("Save State to File"), this, &MenuBar::StateSave);
-  m_state_save_menu->addAction(tr("Save State to Selected Slot"), this, &MenuBar::StateSaveSlot);
-  m_state_save_menu->addAction(tr("Save State to Oldest Slot"), this, &MenuBar::StateSaveOldest);
+  m_state_save_menu->addAction(tr("Save State to &File"), this, &MenuBar::StateSave);
+  m_state_save_menu->addAction(tr("Save State to &Selected Slot"), this, &MenuBar::StateSaveSlot);
+  m_state_save_menu->addAction(tr("Save State to &Oldest Slot"), this, &MenuBar::StateSaveOldest);
   m_state_save_slots_menu = m_state_save_menu->addMenu(tr("Save State to Slot"));
-  m_state_save_menu->addAction(tr("Undo Save State"), this, &MenuBar::StateSaveUndo);
+  m_state_save_menu->addAction(tr("&Undo Save State"), this, &MenuBar::StateSaveUndo);
 
   for (int i = 1; i <= 10; i++)
   {
@@ -579,10 +579,10 @@ void MenuBar::AddHelpMenu()
 
 void MenuBar::AddGameListTypeSection(QMenu* view_menu)
 {
-  QAction* list_view = view_menu->addAction(tr("List View"));
+  QAction* list_view = view_menu->addAction(tr("&List View"));
   list_view->setCheckable(true);
 
-  QAction* grid_view = view_menu->addAction(tr("Grid View"));
+  QAction* grid_view = view_menu->addAction(tr("&Grid View"));
   grid_view->setCheckable(true);
 
   QActionGroup* list_group = new QActionGroup(this);
@@ -600,19 +600,19 @@ void MenuBar::AddGameListTypeSection(QMenu* view_menu)
 void MenuBar::AddListColumnsMenu(QMenu* view_menu)
 {
   static const QMap<QString, bool*> columns{
-      {tr("Platform"), &SConfig::GetInstance().m_showSystemColumn},
-      {tr("Banner"), &SConfig::GetInstance().m_showBannerColumn},
-      {tr("Title"), &SConfig::GetInstance().m_showTitleColumn},
-      {tr("Description"), &SConfig::GetInstance().m_showDescriptionColumn},
-      {tr("Maker"), &SConfig::GetInstance().m_showMakerColumn},
-      {tr("File Name"), &SConfig::GetInstance().m_showFileNameColumn},
-      {tr("Game ID"), &SConfig::GetInstance().m_showIDColumn},
-      {tr("Region"), &SConfig::GetInstance().m_showRegionColumn},
-      {tr("File Size"), &SConfig::GetInstance().m_showSizeColumn},
-      {tr("Tags"), &SConfig::GetInstance().m_showTagsColumn}};
+      {tr("&Platform"), &SConfig::GetInstance().m_showSystemColumn},
+      {tr("&Banner"), &SConfig::GetInstance().m_showBannerColumn},
+      {tr("&Title"), &SConfig::GetInstance().m_showTitleColumn},
+      {tr("&Description"), &SConfig::GetInstance().m_showDescriptionColumn},
+      {tr("&Maker"), &SConfig::GetInstance().m_showMakerColumn},
+      {tr("File &Name"), &SConfig::GetInstance().m_showFileNameColumn},
+      {tr("Game &ID"), &SConfig::GetInstance().m_showIDColumn},
+      {tr("&Region"), &SConfig::GetInstance().m_showRegionColumn},
+      {tr("File &Size"), &SConfig::GetInstance().m_showSizeColumn},
+      {tr("&Tags"), &SConfig::GetInstance().m_showTagsColumn}};
 
   QActionGroup* column_group = new QActionGroup(this);
-  m_cols_menu = view_menu->addMenu(tr("List Columns"));
+  m_cols_menu = view_menu->addMenu(tr("List &Columns"));
   column_group->setExclusive(false);
 
   for (const auto& key : columns.keys())
@@ -631,10 +631,10 @@ void MenuBar::AddListColumnsMenu(QMenu* view_menu)
 void MenuBar::AddShowPlatformsMenu(QMenu* view_menu)
 {
   static const QMap<QString, bool*> platform_map{
-      {tr("Show Wii"), &SConfig::GetInstance().m_ListWii},
-      {tr("Show GameCube"), &SConfig::GetInstance().m_ListGC},
-      {tr("Show WAD"), &SConfig::GetInstance().m_ListWad},
-      {tr("Show ELF/DOL"), &SConfig::GetInstance().m_ListElfDol}};
+      {tr("Show &Wii"), &SConfig::GetInstance().m_ListWii},
+      {tr("Show &GameCube"), &SConfig::GetInstance().m_ListGC},
+      {tr("Show W&AD"), &SConfig::GetInstance().m_ListWad},
+      {tr("Show &ELF/DOL"), &SConfig::GetInstance().m_ListElfDol}};
 
   QActionGroup* platform_group = new QActionGroup(this);
   QMenu* plat_menu = view_menu->addMenu(tr("Show Platforms"));
@@ -656,23 +656,23 @@ void MenuBar::AddShowPlatformsMenu(QMenu* view_menu)
 void MenuBar::AddShowRegionsMenu(QMenu* view_menu)
 {
   static const QMap<QString, bool*> region_map{
-      {tr("Show JAP"), &SConfig::GetInstance().m_ListJap},
-      {tr("Show PAL"), &SConfig::GetInstance().m_ListPal},
-      {tr("Show USA"), &SConfig::GetInstance().m_ListUsa},
-      {tr("Show Australia"), &SConfig::GetInstance().m_ListAustralia},
-      {tr("Show France"), &SConfig::GetInstance().m_ListFrance},
-      {tr("Show Germany"), &SConfig::GetInstance().m_ListGermany},
-      {tr("Show Italy"), &SConfig::GetInstance().m_ListItaly},
-      {tr("Show Korea"), &SConfig::GetInstance().m_ListKorea},
-      {tr("Show Netherlands"), &SConfig::GetInstance().m_ListNetherlands},
-      {tr("Show Russia"), &SConfig::GetInstance().m_ListRussia},
-      {tr("Show Spain"), &SConfig::GetInstance().m_ListSpain},
-      {tr("Show Taiwan"), &SConfig::GetInstance().m_ListTaiwan},
-      {tr("Show World"), &SConfig::GetInstance().m_ListWorld},
-      {tr("Show Unknown"), &SConfig::GetInstance().m_ListUnknown}};
+      {tr("Show &JAP"), &SConfig::GetInstance().m_ListJap},
+      {tr("Show &PAL"), &SConfig::GetInstance().m_ListPal},
+      {tr("Show &USA"), &SConfig::GetInstance().m_ListUsa},
+      {tr("Show &Australia"), &SConfig::GetInstance().m_ListAustralia},
+      {tr("Show &France"), &SConfig::GetInstance().m_ListFrance},
+      {tr("Show &Germany"), &SConfig::GetInstance().m_ListGermany},
+      {tr("Show &Italy"), &SConfig::GetInstance().m_ListItaly},
+      {tr("Show &Korea"), &SConfig::GetInstance().m_ListKorea},
+      {tr("Show &Netherlands"), &SConfig::GetInstance().m_ListNetherlands},
+      {tr("Show &Russia"), &SConfig::GetInstance().m_ListRussia},
+      {tr("Show &Spain"), &SConfig::GetInstance().m_ListSpain},
+      {tr("Show &Taiwan"), &SConfig::GetInstance().m_ListTaiwan},
+      {tr("Show &World"), &SConfig::GetInstance().m_ListWorld},
+      {tr("Show &Unknown"), &SConfig::GetInstance().m_ListUnknown}};
 
   QActionGroup* region_group = new QActionGroup(this);
-  QMenu* region_menu = view_menu->addMenu(tr("Show Regions"));
+  QMenu* region_menu = view_menu->addMenu(tr("Show &Regions"));
   region_group->setExclusive(false);
 
   for (const auto& key : region_map.keys())
@@ -714,31 +714,31 @@ void MenuBar::AddMovieMenu()
 
   movie_menu->addSeparator();
 
-  auto* pause_at_end = movie_menu->addAction(tr("Pause at End of Movie"));
+  auto* pause_at_end = movie_menu->addAction(tr("Pa&use at End of Movie"));
   pause_at_end->setCheckable(true);
   pause_at_end->setChecked(SConfig::GetInstance().m_PauseMovie);
   connect(pause_at_end, &QAction::toggled,
           [](bool value) { SConfig::GetInstance().m_PauseMovie = value; });
 
-  auto* lag_counter = movie_menu->addAction(tr("Show Lag Counter"));
+  auto* lag_counter = movie_menu->addAction(tr("Show L&ag Counter"));
   lag_counter->setCheckable(true);
   lag_counter->setChecked(SConfig::GetInstance().m_ShowLag);
   connect(lag_counter, &QAction::toggled,
           [](bool value) { SConfig::GetInstance().m_ShowLag = value; });
 
-  auto* frame_counter = movie_menu->addAction(tr("Show Frame Counter"));
+  auto* frame_counter = movie_menu->addAction(tr("Show &Frame Counter"));
   frame_counter->setCheckable(true);
   frame_counter->setChecked(SConfig::GetInstance().m_ShowFrameCount);
   connect(frame_counter, &QAction::toggled,
           [](bool value) { SConfig::GetInstance().m_ShowFrameCount = value; });
 
-  auto* input_display = movie_menu->addAction(tr("Show Input Display"));
+  auto* input_display = movie_menu->addAction(tr("Show &Input Display"));
   input_display->setCheckable(true);
   input_display->setChecked(SConfig::GetInstance().m_ShowInputDisplay);
   connect(input_display, &QAction::toggled,
           [](bool value) { SConfig::GetInstance().m_ShowInputDisplay = value; });
 
-  auto* system_clock = movie_menu->addAction(tr("Show System Clock"));
+  auto* system_clock = movie_menu->addAction(tr("Show &System Clock"));
   system_clock->setCheckable(true);
   system_clock->setChecked(SConfig::GetInstance().m_ShowRTC);
   connect(system_clock, &QAction::toggled,
@@ -746,13 +746,13 @@ void MenuBar::AddMovieMenu()
 
   movie_menu->addSeparator();
 
-  auto* dump_frames = movie_menu->addAction(tr("Dump Frames"));
+  auto* dump_frames = movie_menu->addAction(tr("Dump &Frames"));
   dump_frames->setCheckable(true);
   dump_frames->setChecked(SConfig::GetInstance().m_DumpFrames);
   connect(dump_frames, &QAction::toggled,
           [](bool value) { SConfig::GetInstance().m_DumpFrames = value; });
 
-  auto* dump_audio = movie_menu->addAction(tr("Dump Audio"));
+  auto* dump_audio = movie_menu->addAction(tr("Dump &Audio"));
   dump_audio->setCheckable(true);
   dump_audio->setChecked(SConfig::GetInstance().m_DumpAudio);
   connect(dump_audio, &QAction::toggled,
@@ -963,7 +963,7 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
         tmd.IsValid() ?
             QString::fromStdString(DiscIO::GetSysMenuVersionString(tmd.GetTitleVersion())) :
             QString{};
-    m_boot_sysmenu->setText(tr("Load Wii System Menu %1").arg(sysmenu_version));
+    m_boot_sysmenu->setText(tr("&Load Wii System Menu %1").arg(sysmenu_version));
 
     m_boot_sysmenu->setEnabled(tmd.IsValid());
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -233,7 +233,7 @@ void MenuBar::AddToolsMenu()
 
   tools_menu->addSeparator();
 
-  QMenu* ntpl_atns = tools_menu->addMenu(tr("&Netplay"));
+  QMenu* ntpl_atns = tools_menu->addMenu(tr("&NetPlay"));
 
   ntpl_atns->addAction(tr("Start &NetPlay..."), this, &MenuBar::StartNetPlay);
   ntpl_atns->addAction(tr("Browse &NetPlay Sessions..."), this, &MenuBar::BrowseNetPlay);

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -233,8 +233,10 @@ void MenuBar::AddToolsMenu()
 
   tools_menu->addSeparator();
 
-  tools_menu->addAction(tr("Start &NetPlay..."), this, &MenuBar::StartNetPlay);
-  tools_menu->addAction(tr("Browse &NetPlay Sessions...."), this, &MenuBar::BrowseNetPlay);
+  QMenu* ntpl_atns = tools_menu->addMenu(tr("&Netplay"));
+
+  ntpl_atns->addAction(tr("Start &NetPlay..."), this, &MenuBar::StartNetPlay);
+  ntpl_atns->addAction(tr("Browse &NetPlay Sessions..."), this, &MenuBar::BrowseNetPlay);
 
   tools_menu->addSeparator();
 
@@ -265,17 +267,17 @@ void MenuBar::AddToolsMenu()
 
   connect(&Settings::Instance(), &Settings::NANDRefresh, [this] { UpdateToolsMenu(false); });
 
-  m_perform_online_update_menu = tools_menu->addMenu(tr("Perform Online System Update"));
+  m_perform_online_update_menu = tools_menu->addMenu(tr("Perform Online System &Update"));
   m_perform_online_update_for_current_region = m_perform_online_update_menu->addAction(
-      tr("Current Region"), this, [this] { emit PerformOnlineUpdate(""); });
+      tr("&Current Region"), this, [this] { emit PerformOnlineUpdate(""); });
   m_perform_online_update_menu->addSeparator();
-  m_perform_online_update_menu->addAction(tr("Europe"), this,
+  m_perform_online_update_menu->addAction(tr("&Europe"), this,
                                           [this] { emit PerformOnlineUpdate("EUR"); });
-  m_perform_online_update_menu->addAction(tr("Japan"), this,
+  m_perform_online_update_menu->addAction(tr("&Japan"), this,
                                           [this] { emit PerformOnlineUpdate("JPN"); });
-  m_perform_online_update_menu->addAction(tr("Korea"), this,
+  m_perform_online_update_menu->addAction(tr("&Korea"), this,
                                           [this] { emit PerformOnlineUpdate("KOR"); });
-  m_perform_online_update_menu->addAction(tr("United States"), this,
+  m_perform_online_update_menu->addAction(tr("&United States"), this,
                                           [this] { emit PerformOnlineUpdate("USA"); });
 
   tools_menu->addSeparator();
@@ -384,9 +386,9 @@ void MenuBar::UpdateStateSlotMenu()
   {
     int slot = i + 1;
     QString info = QString::fromStdString(State::GetInfoStringOfSlot(slot));
-    actions_load.at(i)->setText(tr("Load from Slot %1 - %2").arg(slot).arg(info));
-    actions_save.at(i)->setText(tr("Save to Slot %1 - %2").arg(slot).arg(info));
-    actions_slot.at(i)->setText(tr("Select Slot %1 - %2").arg(slot).arg(info));
+    actions_load.at(i)->setText(tr("Load from Slot &%1 - %2").arg(slot).arg(info));
+    actions_save.at(i)->setText(tr("Save to Slot &%1 - %2").arg(slot).arg(info));
+    actions_slot.at(i)->setText(tr("Select Slot &%1 - %2").arg(slot).arg(info));
   }
 }
 
@@ -637,7 +639,7 @@ void MenuBar::AddShowPlatformsMenu(QMenu* view_menu)
       {tr("Show &ELF/DOL"), &SConfig::GetInstance().m_ListElfDol}};
 
   QActionGroup* platform_group = new QActionGroup(this);
-  QMenu* plat_menu = view_menu->addMenu(tr("Show Platforms"));
+  QMenu* plat_menu = view_menu->addMenu(tr("Show &Platforms"));
   platform_group->setExclusive(false);
 
   for (const auto& key : platform_map.keys())

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -229,7 +229,7 @@ void MenuBar::AddToolsMenu()
     m_show_cheat_manager->setEnabled(Core::GetState() != Core::State::Uninitialized && enabled);
   });
 
-  tools_menu->addAction(tr("FIFO Player"), this, &MenuBar::ShowFIFOPlayer);
+  tools_menu->addAction(tr("&FIFO Player"), this, &MenuBar::ShowFIFOPlayer);
 
   tools_menu->addSeparator();
 
@@ -247,14 +247,14 @@ void MenuBar::AddToolsMenu()
   m_pal_ipl =
       gc_ipl->addAction(tr("PAL"), this, [this] { emit BootGameCubeIPL(DiscIO::Region::PAL); });
 
-  tools_menu->addAction(tr("Memory Card Manager"), this, [this] { emit ShowMemcardManager(); });
+  tools_menu->addAction(tr("Memory Card &Manager"), this, [this] { emit ShowMemcardManager(); });
 
   tools_menu->addSeparator();
 
   // Label will be set by a NANDRefresh later
   m_boot_sysmenu = tools_menu->addAction(QString{}, this, [this] { emit BootWiiSystemMenu(); });
-  m_wad_install_action = tools_menu->addAction(tr("Install WAD..."), this, &MenuBar::InstallWAD);
-  m_manage_nand_menu = tools_menu->addMenu(tr("Manage NAND"));
+  m_wad_install_action = tools_menu->addAction(tr("Install &WAD..."), this, &MenuBar::InstallWAD);
+  m_manage_nand_menu = tools_menu->addMenu(tr("Manage &NAND"));
   m_import_backup = m_manage_nand_menu->addAction(tr("Import BootMii NAND Backup..."), this,
                                                   [this] { emit ImportNANDBackup(); });
   m_check_nand = m_manage_nand_menu->addAction(tr("Check NAND..."), this, &MenuBar::CheckNAND);
@@ -312,7 +312,7 @@ void MenuBar::AddEmulationMenu()
   m_fullscreen_action = emu_menu->addAction(tr("Toggle &Fullscreen"), this, &MenuBar::Fullscreen);
   m_frame_advance_action = emu_menu->addAction(tr("&Frame Advance"), this, &MenuBar::FrameAdvance);
 
-  m_screenshot_action = emu_menu->addAction(tr("Take Screenshot"), this, &MenuBar::Screenshot);
+  m_screenshot_action = emu_menu->addAction(tr("Take &Screenshot"), this, &MenuBar::Screenshot);
 
   emu_menu->addSeparator();
 
@@ -331,7 +331,7 @@ void MenuBar::AddStateLoadMenu(QMenu* emu_menu)
   m_state_load_menu->addAction(tr("Load State from File"), this, &MenuBar::StateLoad);
   m_state_load_menu->addAction(tr("Load State from Selected Slot"), this, &MenuBar::StateLoadSlot);
   m_state_load_slots_menu = m_state_load_menu->addMenu(tr("Load State from Slot"));
-  m_state_load_menu->addAction(tr("Undo Load State"), this, &MenuBar::StateLoadUndo);
+  m_state_load_menu->addAction(tr("&Undo Load State"), this, &MenuBar::StateLoadUndo);
 
   for (int i = 1; i <= 10; i++)
   {
@@ -360,7 +360,7 @@ void MenuBar::AddStateSaveMenu(QMenu* emu_menu)
 
 void MenuBar::AddStateSlotMenu(QMenu* emu_menu)
 {
-  m_state_slot_menu = emu_menu->addMenu(tr("Select State Slot"));
+  m_state_slot_menu = emu_menu->addMenu(tr("Select S&tate Slot"));
   m_state_slots = new QActionGroup(this);
 
   for (int i = 1; i <= 10; i++)
@@ -694,11 +694,11 @@ void MenuBar::AddMovieMenu()
   m_recording_start =
       movie_menu->addAction(tr("Start Re&cording Input"), this, [this] { emit StartRecording(); });
   m_recording_play =
-      movie_menu->addAction(tr("P&lay Input Recording..."), this, [this] { emit PlayRecording(); });
-  m_recording_stop = movie_menu->addAction(tr("Stop Playing/Recording Input"), this,
+      movie_menu->addAction(tr("P&lay Input Recording"), this, [this] { emit PlayRecording(); });
+  m_recording_stop = movie_menu->addAction(tr("S&top Playing/Recording Input"), this,
                                            [this] { emit StopRecording(); });
   m_recording_export =
-      movie_menu->addAction(tr("Export Recording..."), this, [this] { emit ExportRecording(); });
+      movie_menu->addAction(tr("E&xport Recording"), this, [this] { emit ExportRecording(); });
 
   m_recording_start->setEnabled(false);
   m_recording_play->setEnabled(false);
@@ -710,7 +710,7 @@ void MenuBar::AddMovieMenu()
   m_recording_read_only->setChecked(Movie::IsReadOnly());
   connect(m_recording_read_only, &QAction::toggled, [](bool value) { Movie::SetReadOnly(value); });
 
-  movie_menu->addAction(tr("TAS Input"), this, [this] { emit ShowTASInput(); });
+  movie_menu->addAction(tr("TAS &Input"), this, [this] { emit ShowTASInput(); });
 
   movie_menu->addSeparator();
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -495,7 +495,7 @@ void MenuBar::AddViewMenu()
 void MenuBar::AddOptionsMenu()
 {
   QMenu* options_menu = addMenu(tr("&Options"));
-  options_menu->addAction(tr("Co&nfiguration"), this, &MenuBar::Configure);
+  options_menu->addAction(tr("&Settings"), this, &MenuBar::Configure);
   options_menu->addSeparator();
   options_menu->addAction(tr("&Graphics Settings"), this, &MenuBar::ConfigureGraphics);
   options_menu->addAction(tr("&Audio Settings"), this, &MenuBar::ConfigureAudio);

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -219,17 +219,17 @@ void MenuBar::AddToolsMenu()
 {
   QMenu* tools_menu = addMenu(tr("&Tools"));
 
-  tools_menu->addAction(tr("&Resource Pack Manager"), this,
+  tools_menu->addAction(tr("&Resource Pack Manager..."), this,
                         [this] { emit ShowResourcePackManager(); });
 
   m_show_cheat_manager =
-      tools_menu->addAction(tr("&Cheats Manager"), this, [this] { emit ShowCheatsManager(); });
+      tools_menu->addAction(tr("&Cheats Manager..."), this, [this] { emit ShowCheatsManager(); });
 
   connect(&Settings::Instance(), &Settings::EnableCheatsChanged, [this](bool enabled) {
     m_show_cheat_manager->setEnabled(Core::GetState() != Core::State::Uninitialized && enabled);
   });
 
-  tools_menu->addAction(tr("&FIFO Player"), this, &MenuBar::ShowFIFOPlayer);
+  tools_menu->addAction(tr("&FIFO Player..."), this, &MenuBar::ShowFIFOPlayer);
 
   tools_menu->addSeparator();
 
@@ -242,14 +242,14 @@ void MenuBar::AddToolsMenu()
 
   QMenu* gc_ipl = tools_menu->addMenu(tr("Load &GameCube Main Menu"));
 
-  m_ntscj_ipl = gc_ipl->addAction(tr("NTSC-J"), this,
+  m_ntscj_ipl = gc_ipl->addAction(tr("NTSC-&J"), this,
                                   [this] { emit BootGameCubeIPL(DiscIO::Region::NTSC_J); });
-  m_ntscu_ipl = gc_ipl->addAction(tr("NTSC-U"), this,
+  m_ntscu_ipl = gc_ipl->addAction(tr("NTSC-&U"), this,
                                   [this] { emit BootGameCubeIPL(DiscIO::Region::NTSC_U); });
   m_pal_ipl =
-      gc_ipl->addAction(tr("PAL"), this, [this] { emit BootGameCubeIPL(DiscIO::Region::PAL); });
+      gc_ipl->addAction(tr("&PAL"), this, [this] { emit BootGameCubeIPL(DiscIO::Region::PAL); });
 
-  tools_menu->addAction(tr("&Memory Card Manager"), this, [this] { emit ShowMemcardManager(); });
+  tools_menu->addAction(tr("&Memory Card Manager..."), this, [this] { emit ShowMemcardManager(); });
 
   tools_menu->addSeparator();
 
@@ -283,7 +283,7 @@ void MenuBar::AddToolsMenu()
   tools_menu->addSeparator();
 
   tools_menu->addAction(tr("&Import Wii Save..."), this, &MenuBar::ImportWiiSave);
-  tools_menu->addAction(tr("E&xport All Wii Saves"), this, &MenuBar::ExportWiiSaves);
+  tools_menu->addAction(tr("E&xport All Wii Saves..."), this, &MenuBar::ExportWiiSaves);
 
   QMenu* menu = new QMenu(tr("&Connect Wii Remotes"), tools_menu);
 
@@ -497,13 +497,13 @@ void MenuBar::AddViewMenu()
 void MenuBar::AddOptionsMenu()
 {
   QMenu* options_menu = addMenu(tr("&Options"));
-  options_menu->addAction(tr("&Settings"), this, &MenuBar::Configure);
+  options_menu->addAction(tr("&Settings..."), this, &MenuBar::Configure);
   options_menu->addSeparator();
-  options_menu->addAction(tr("&Graphics Settings"), this, &MenuBar::ConfigureGraphics);
-  options_menu->addAction(tr("&Audio Settings"), this, &MenuBar::ConfigureAudio);
+  options_menu->addAction(tr("&Graphics Settings..."), this, &MenuBar::ConfigureGraphics);
+  options_menu->addAction(tr("&Audio Settings..."), this, &MenuBar::ConfigureAudio);
   m_controllers_action =
-      options_menu->addAction(tr("&Controller Settings"), this, &MenuBar::ConfigureControllers);
-  options_menu->addAction(tr("&Hotkey Settings"), this, &MenuBar::ConfigureHotkeys);
+      options_menu->addAction(tr("&Controller Settings..."), this, &MenuBar::ConfigureControllers);
+  options_menu->addAction(tr("&Hotkey Settings..."), this, &MenuBar::ConfigureHotkeys);
 
   options_menu->addSeparator();
 
@@ -712,7 +712,7 @@ void MenuBar::AddMovieMenu()
   m_recording_read_only->setChecked(Movie::IsReadOnly());
   connect(m_recording_read_only, &QAction::toggled, [](bool value) { Movie::SetReadOnly(value); });
 
-  movie_menu->addAction(tr("TAS &Input"), this, [this] { emit ShowTASInput(); });
+  movie_menu->addAction(tr("TAS &Input..."), this, [this] { emit ShowTASInput(); });
 
   movie_menu->addSeparator();
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -267,7 +267,7 @@ void MenuBar::AddToolsMenu()
 
   connect(&Settings::Instance(), &Settings::NANDRefresh, [this] { UpdateToolsMenu(false); });
 
-  m_perform_online_update_menu = tools_menu->addMenu(tr("Perform Online System &Update"));
+  m_perform_online_update_menu = tools_menu->addMenu(tr("Perform Online Wii System &Update"));
   m_perform_online_update_for_current_region = m_perform_online_update_menu->addAction(
       tr("&Current Region"), this, [this] { emit PerformOnlineUpdate(""); });
   m_perform_online_update_menu->addSeparator();

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -59,8 +59,10 @@ void AdvancedPane::CreateLayout()
   {
     m_cpu_emulation_engine_combobox->addItem(tr(CPU_CORE_NAMES.at(cpu_core)));
   }
+
   cpu_emulation_layout->addWidget(cpu_emulation_engine_label, 0, 0);
-  cpu_emulation_layout->addWidget(m_cpu_emulation_engine_combobox, 0, 1, Qt::AlignLeft);
+  cpu_emulation_layout->addWidget(m_cpu_emulation_engine_combobox, 0, 1);
+  cpu_emulation_layout->setColumnStretch(1, 1);
   cpu_options_layout->addLayout(cpu_emulation_layout);
 
   m_enable_mmu_checkbox = new QCheckBox(tr("Enable MMU"));

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -155,18 +155,19 @@ void AudioPane::CreateWidgets()
   stretching_layout->addWidget(m_stretching_buffer_slider, 1, 1);
   stretching_layout->addWidget(m_stretching_buffer_indicator, 1, 2);
 
-  stretching_layout->setRowStretch(2, 1);
+//  stretching_layout->setRowStretch(2, 1);
 
   m_main_layout = new QGridLayout;
 
-  m_main_layout->setRowStretch(0, 0);
-
   dsp_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  backend_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  stretching_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
   m_main_layout->addWidget(dsp_box, 0, 0);
   m_main_layout->addWidget(volume_box, 0, 1, -1, 1);
   m_main_layout->addWidget(backend_box, 1, 0);
   m_main_layout->addWidget(stretching_box, 2, 0);
+  m_main_layout->setRowStretch(3, 1);
 
   setLayout(m_main_layout);
 }

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -155,6 +155,8 @@ void AudioPane::CreateWidgets()
   stretching_layout->addWidget(m_stretching_buffer_slider, 1, 1);
   stretching_layout->addWidget(m_stretching_buffer_indicator, 1, 2);
 
+  stretching_layout->setRowStretch(2, 1);
+
   m_main_layout = new QGridLayout;
 
   m_main_layout->setRowStretch(0, 0);

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -70,6 +70,7 @@ void GameCubePane::CreateWidgets()
   ipl_layout->addWidget(m_skip_main_menu, 0, 0);
   ipl_layout->addWidget(new QLabel(tr("System Language:")), 1, 0);
   ipl_layout->addWidget(m_language_combo, 1, 1);
+  ipl_layout->setColumnStretch(1, 1);
 
   // Device Settings
   QGroupBox* device_box = new QGroupBox(tr("Device Settings"), this);
@@ -82,6 +83,8 @@ void GameCubePane::CreateWidgets()
     m_slot_buttons[i] = new QPushButton(tr("..."), device_box);
     m_slot_buttons[i]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   }
+
+  device_layout->setColumnStretch(1, 1);
 
   // Add slot devices
 

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -163,13 +163,20 @@ void WiiPane::CreateWhitelistedUSBPassthroughDevices()
       new QGroupBox(tr("Whitelisted USB Passthrough Devices"));
   auto* whitelist_layout = new QGridLayout();
   m_whitelist_usb_list = new QListWidget();
+
   whitelist_layout->addWidget(m_whitelist_usb_list, 0, 0, 1, -1);
-  whitelist_layout->setColumnStretch(0, 1);
+
   m_whitelist_usb_add_button = new QPushButton(tr("Add..."));
   m_whitelist_usb_remove_button = new QPushButton(tr("Remove"));
-  whitelist_layout->addWidget(m_whitelist_usb_add_button, 1, 1);
-  whitelist_layout->addWidget(m_whitelist_usb_remove_button, 1, 2);
-  whitelist_layout->addWidget(m_whitelist_usb_list, 0, 0);
+
+//  whitelist_layout->setRowStretch(1, 1);
+  auto* add_remove_button_layout = new QHBoxLayout;
+
+  add_remove_button_layout->addWidget(m_whitelist_usb_add_button);
+  add_remove_button_layout->addWidget(m_whitelist_usb_remove_button);
+
+  whitelist_layout->addLayout(add_remove_button_layout, 1, 0, Qt::AlignRight);
+
   whitelisted_usb_passthrough_devices_group->setLayout(whitelist_layout);
   m_main_layout->addWidget(whitelisted_usb_passthrough_devices_group);
 }

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -103,18 +103,23 @@ void WiiPane::CreateMisc()
 {
   auto* misc_settings_group = new QGroupBox(tr("Misc Settings"));
   auto* misc_settings_group_layout = new QGridLayout();
+
   misc_settings_group->setLayout(misc_settings_group_layout);
   m_main_layout->addWidget(misc_settings_group);
+
   m_pal60_mode_checkbox = new QCheckBox(tr("Use PAL60 Mode (EuRGB60)"));
   m_screensaver_checkbox = new QCheckBox(tr("Enable Screen Saver"));
   m_sd_card_checkbox = new QCheckBox(tr("Insert SD Card"));
   m_connect_keyboard_checkbox = new QCheckBox(tr("Connect USB Keyboard"));
   m_aspect_ratio_choice_label = new QLabel(tr("Aspect Ratio:"));
   m_aspect_ratio_choice = new QComboBox();
+
   m_aspect_ratio_choice->addItem(tr("4:3"));
   m_aspect_ratio_choice->addItem(tr("16:9"));
+
   m_system_language_choice_label = new QLabel(tr("System Language:"));
   m_system_language_choice = new QComboBox();
+
   m_system_language_choice->addItem(tr("Japanese"));
   m_system_language_choice->addItem(tr("English"));
   m_system_language_choice->addItem(tr("German"));
@@ -137,10 +142,19 @@ void WiiPane::CreateMisc()
   misc_settings_group_layout->addWidget(m_sd_card_checkbox, 0, 1, 1, 1);
   misc_settings_group_layout->addWidget(m_screensaver_checkbox, 1, 0, 1, 1);
   misc_settings_group_layout->addWidget(m_connect_keyboard_checkbox, 1, 1, 1, 1);
-  misc_settings_group_layout->addWidget(m_aspect_ratio_choice_label, 2, 0, 1, 1);
-  misc_settings_group_layout->addWidget(m_aspect_ratio_choice, 2, 1, 1, 1);
-  misc_settings_group_layout->addWidget(m_system_language_choice_label, 3, 0, 1, 1);
-  misc_settings_group_layout->addWidget(m_system_language_choice, 3, 1, 1, 1);
+
+  misc_settings_group_layout->setRowStretch(1, 1);
+
+  auto* m_aspect_system_layout = new QGridLayout;
+  // Allows stretching of comboboxes to match position of labels
+  m_aspect_system_layout->addWidget(m_aspect_ratio_choice_label, 0, 0, 1, 1);
+  m_aspect_system_layout->addWidget(m_aspect_ratio_choice, 0, 1, 1, 1);
+  m_aspect_system_layout->addWidget(m_system_language_choice_label, 1, 0, 1, 1);
+  m_aspect_system_layout->addWidget(m_system_language_choice, 1, 1, 1, 1);
+
+  m_aspect_system_layout->setColumnStretch(1, 1);
+
+  misc_settings_group_layout->addLayout(m_aspect_system_layout, 2, 0, 1, 0);
 }
 
 void WiiPane::CreateWhitelistedUSBPassthroughDevices()

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -122,12 +122,12 @@ void ToolBar::MakeActions()
   m_pause_play_action = addAction(tr("Play"), this, &ToolBar::PlayPressed);
 
   m_stop_action = addAction(tr("Stop"), this, &ToolBar::StopPressed);
-  m_fullscreen_action = addAction(tr("FullScr"), this, &ToolBar::FullScreenPressed);
-  m_screenshot_action = addAction(tr("ScrShot"), this, &ToolBar::ScreenShotPressed);
+  m_fullscreen_action = addAction(tr("Fullscreen"), this, &ToolBar::FullScreenPressed);
+  m_screenshot_action = addAction(tr("Screenshot"), this, &ToolBar::ScreenShotPressed);
 
   addSeparator();
 
-  m_config_action = addAction(tr("Config"), this, &ToolBar::SettingsPressed);
+  m_config_action = addAction(tr("Settings"), this, &ToolBar::SettingsPressed);
   m_graphics_action = addAction(tr("Graphics"), this, &ToolBar::GraphicsPressed);
   m_controllers_action = addAction(tr("Controllers"), this, &ToolBar::ControllersPressed);
   m_controllers_action->setEnabled(true);

--- a/Source/Core/DolphinQt/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt/WiiUpdate.cpp
@@ -135,8 +135,8 @@ static WiiUtils::UpdateResult ShowProgress(QWidget* parent, Callable function, A
 void PerformOnlineUpdate(const std::string& region, QWidget* parent)
 {
   const int confirm = ModalMessageBox::question(
-      parent, QObject::tr("Confirm"),
-      QObject::tr("Connect to the Internet and perform an online system update?"));
+      parent, QObject::tr("Confirm Wii System Update"),
+      QObject::tr("Connect to the Internet and perform an online Wii system update?"));
   if (confirm != QMessageBox::Yes)
     return;
 


### PR DESCRIPTION
A number of changes have been made across the UI, to make it (hopefully) a tad more user friendly. There's a theme of stretching widgets to match their labels 😁

Here's an overall list of the changes:

**MainWindow**
- Change "FullScr" to "Fullscreen"
- Change "ScrShot" to "Screenshot"
- Change "Config" to "Settings"

**GameList**
- Add shortcut hints to context menu
- Fix context menu tag actions not being added to tag_menu
- Add ellipsis to context menu items, similar to the MenuBar items
- Add "Perform Wii System Update" to reflect MenuBar change

**PropertiesDialog**
- Add Sizing Policy to properly stretch dialog window. Now it no longer centers the Game-Specific Settings text when stretched out.
- Stretch Deterministic Dual Core combobox to match its label
- Stretch Stereoscopy depth slider and convergence box to match their labels

**MenuBar**
- Add shortcut hints to menu/submenu items. Only some of the menu had these hints, but now all of them should
- Add ellipsis to menu items appropriately. This would mean items which open additional information windows such as a file selection dialogs, or the likes of the Settings screen
- Move NetPlay items into separate submenu
- Change "Perform Online System Update" to "Perform Online Wii System Update" for more user clarity

**TASInput**
- Separate GameCube and Wii controller windows so that they don't completely overlap

**Settings**
- Change window title from "Configuration" to "Settings"
- Audio: Change boxes to have `QSizePolicy::Expanding, QSizePolicy::Fixed` to stop them filling the entire window. This matches the rest of the Settings UI more consistently
- GameCube: Device Settings comboboxes stretch to match position of their labels (Slot A, Slot B, SP1)
- Wii: Aspect Ratio, System Language comboboxes stretch to match position of their respective labels
- Wii: Fix USB Passthrough ListView displaying incorrectly when resized
- Advanced: Stretch combobox to match its label

**Configuration**
- Stretch Basic box combos to match size of their labels
- Stretch Enhancements box combos to match size of their labels
- Stretch Bitrate box to match size of its label

**Online System Update**
- Rename dialog title to "Confirm Wii System Update"
- Update dialog text to include "Wii", reflecting the theme of these changes

Phew. If there are any other parts of the UI that need changing which I happened to miss, just point them out to me!