### PR TITLE
Qt: Tweak Toolbar Text

### DIFF
--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -503,8 +503,7 @@ void MenuBar::AddViewMenu()
 void MenuBar::AddOptionsMenu()
 {
   QMenu* options_menu = addMenu(tr("&Options"));
-  options_menu->addAction(tr("Co&nfiguration"), this, &MenuBar::Configure,
-                          QKeySequence::Preferences);
+  options_menu->addAction(tr("&Settings"), this, &MenuBar::Configure, QKeySequence::Preferences);
   options_menu->addSeparator();
   options_menu->addAction(tr("&Graphics Settings"), this, &MenuBar::ConfigureGraphics);
   options_menu->addAction(tr("&Audio Settings"), this, &MenuBar::ConfigureAudio);

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -122,12 +122,12 @@ void ToolBar::MakeActions()
   m_pause_play_action = addAction(tr("Play"), this, &ToolBar::PlayPressed);
 
   m_stop_action = addAction(tr("Stop"), this, &ToolBar::StopPressed);
-  m_fullscreen_action = addAction(tr("FullScr"), this, &ToolBar::FullScreenPressed);
-  m_screenshot_action = addAction(tr("ScrShot"), this, &ToolBar::ScreenShotPressed);
+  m_fullscreen_action = addAction(tr("Fullscreen"), this, &ToolBar::FullScreenPressed);
+  m_screenshot_action = addAction(tr("Screenshot"), this, &ToolBar::ScreenShotPressed);
 
   addSeparator();
 
-  m_config_action = addAction(tr("Config"), this, &ToolBar::SettingsPressed);
+  m_config_action = addAction(tr("Settings"), this, &ToolBar::SettingsPressed);
   m_graphics_action = addAction(tr("Graphics"), this, &ToolBar::GraphicsPressed);
   m_controllers_action = addAction(tr("Controllers"), this, &ToolBar::ControllersPressed);
   m_controllers_action->setEnabled(true);


### PR DESCRIPTION
Currently the Toolbar has some unnecessary abbreviations, which I believe are holdovers from the wxWidgets UI. Also, the text for the Settings menu says "Config", however in code this is referred to as "Settings". It is also ambiguous as the "Configuration" screen for the graphics backend shares the same name on the UI.

"FullScr", "ScrShot" and "Config" have been changed to say "Fullscreen", "Screenshot" and "Settings". The MenuBar text and Settings dialog window have also been updated to reflect the change.

Master branch:
![Screenshot_20200301_235717](https://user-images.githubusercontent.com/7917345/75636656-7a5b5d80-5c18-11ea-83f4-28030e275b64.png)

Pull Request:
![Screenshot_20200301_235826](https://user-images.githubusercontent.com/7917345/75636670-97902c00-5c18-11ea-97c4-c50ebb784585.png)