### PR TITLE
Android: Set up Day/Night mode for system-compatible optional dark theme

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0'
 
     // Android TV UI libraries.
     implementation 'androidx.leanback:leanback:1.0.0'

--- a/Source/Android/app/src/main/res/layout/activity_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_main.xml
@@ -13,10 +13,11 @@
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar_main"
+            android:background="?colorPrimary"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:layout_scrollFlags="scroll|enterAlways"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+            app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"/>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs_platforms"

--- a/Source/Android/app/src/main/res/layout/fragment_settings.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_settings.xml
@@ -5,7 +5,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/list_settings"
-        android:background="@android:color/white"
+        android:background="?android:attr/colorBackground"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 

--- a/Source/Android/app/src/main/res/values-night/colors.xml
+++ b/Source/Android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="dolphin_purple">#A277FF</color>
+</resources>

--- a/Source/Android/app/src/main/res/values-night/styles_filepicker.xml
+++ b/Source/Android/app/src/main/res/values-night/styles_filepicker.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="FilePickerBaseTheme" parent="NNF_BaseTheme" />
+</resources>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <!-- Inherit from the material theme -->
-    <style name="DolphinBase" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="DolphinBase" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Main theme colors -->
         <!-- Branding color for the app bar -->
         <item name="colorPrimary">@color/dolphin_blue</item>
@@ -19,7 +19,7 @@
     </style>
 
     <!-- Same as above, but use default action bar, and mandate margins. -->
-    <style name="DolphinSettingsBase" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="DolphinSettingsBase" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_purple</item>
@@ -29,7 +29,7 @@
 
     <!-- Inherit from the Base Dolphin Dialog Theme -->
 
-    <style name="DolphinEmulationBase" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="DolphinEmulationBase" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_purple</item>
@@ -43,7 +43,7 @@
         <item name="android:windowAllowReturnTransitionOverlap">true</item>
     </style>
 
-    <style name="DolphinEmulationTvBase" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="DolphinEmulationTvBase" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_purple</item>
@@ -94,8 +94,8 @@
         <item name="android:textColor">@color/button_text_color</item>
     </style>
 
-    <!-- You can also inherit from NNF_BaseTheme.Light -->
-    <style name="FilePickerTheme" parent="NNF_BaseTheme.Light">
+    <!-- Inherit from a base file picker theme that handles day/night -->
+    <style name="FilePickerTheme" parent="FilePickerBaseTheme">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_accent_gamecube</item>
@@ -111,7 +111,7 @@
         <item name="nnf_toolbarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
     </style>
 
-    <style name="FilePickerAlertDialogTheme" parent="Theme.AppCompat.Dialog.Alert">
+    <style name="FilePickerAlertDialogTheme" parent="Theme.AppCompat.DayNight.Dialog.Alert">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="colorAccent">@color/dolphin_accent_gamecube</item>

--- a/Source/Android/app/src/main/res/values/styles_filepicker.xml
+++ b/Source/Android/app/src/main/res/values/styles_filepicker.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="FilePickerBaseTheme" parent="NNF_BaseTheme.Light" />
+</resources>


### PR DESCRIPTION
Updated Material Components dependency and implemented System-controlled Day/Night (Light/Dark) theming

Testing notes: Dark theme can be toggled through system settings in Android 10 (Q) and higher, or through an app like [Night Mode](https://f-droid.org/en/packages/io.github.subhamtyagi.nightmode/) for earlier Android versions.

Light Mode vs Dark Mode Screenshots:
<img src="https://user-images.githubusercontent.com/6434386/75958411-2b1c6380-5e8a-11ea-8179-7add8a91c7dc.png" height="350" /><img src="https://user-images.githubusercontent.com/6434386/75958415-2bb4fa00-5e8a-11ea-8faf-a19959cbe950.png" height="350" />
<img src="https://user-images.githubusercontent.com/6434386/75958412-2b1c6380-5e8a-11ea-8028-3314286da5a0.png" height="350" /><img src="https://user-images.githubusercontent.com/6434386/75958416-2c4d9080-5e8a-11ea-979c-9eca9a285a80.png" height="350" />
<img src="https://user-images.githubusercontent.com/6434386/75958413-2bb4fa00-5e8a-11ea-9fcc-14889eefa24a.png" height="350" /><img src="https://user-images.githubusercontent.com/6434386/75958418-2c4d9080-5e8a-11ea-87d3-8167f0616c3c.png" height="350" />
<img src="https://user-images.githubusercontent.com/6434386/75958414-2bb4fa00-5e8a-11ea-97d7-e054011d2a21.png" height="350" /><img src="https://user-images.githubusercontent.com/6434386/75958419-2c4d9080-5e8a-11ea-95b3-f4904d931ae7.png" height="350" />
<img src="https://user-images.githubusercontent.com/6434386/75958421-2ce62700-5e8a-11ea-87c3-05298e752d21.png" height="350" /><img src="https://user-images.githubusercontent.com/6434386/75958420-2c4d9080-5e8a-11ea-9d51-7148c743ec8d.png" height="350" />





