### PR TITLE
Externals: Update MoltenVK to SDK version 1.2.131.2

### DIFF
--- a/Externals/MoltenVK/version.txt
+++ b/Externals/MoltenVK/version.txt
@@ -1,3 +1,3 @@
-libMoltenVK.dylib from vulkansdk-macos-1.1.108.0, renamed to libvulkan.dylib
+libMoltenVK.dylib from vulkansdk-macos-1.2.131.2, renamed to libvulkan.dylib
 
-Downloaded from: https://sdk.lunarg.com/sdk/download/1.1.108.0/mac/vulkansdk-macos-1.1.108.0.tar.gz
+Downloaded from: https://sdk.lunarg.com/sdk/download/1.2.131.2/mac/vulkansdk-macos-1.2.131.2.tar.gz


### PR DESCRIPTION
Apparently it's broken on macOS at the moment...

I don't currently have access to a Mac to debug, so let's try this.