### PR TITLE
AudioPane: Do not enable DPLII quality slider if DPLII is off

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -337,7 +337,8 @@ void AudioPane::OnDspChanged()
 
   m_dolby_pro_logic->setEnabled(AudioCommon::SupportsDPL2Decoder(backend) &&
                                 !m_dsp_hle->isChecked());
-  EnableDolbyQualityWidgets(AudioCommon::SupportsDPL2Decoder(backend) && !m_dsp_hle->isChecked());
+  EnableDolbyQualityWidgets(AudioCommon::SupportsDPL2Decoder(backend) && !m_dsp_hle->isChecked() &&
+                            m_dolby_pro_logic->isChecked());
 }
 
 void AudioPane::OnBackendChanged()
@@ -346,7 +347,8 @@ void AudioPane::OnBackendChanged()
 
   m_dolby_pro_logic->setEnabled(AudioCommon::SupportsDPL2Decoder(backend) &&
                                 !m_dsp_hle->isChecked());
-  EnableDolbyQualityWidgets(AudioCommon::SupportsDPL2Decoder(backend) && !m_dsp_hle->isChecked());
+  EnableDolbyQualityWidgets(AudioCommon::SupportsDPL2Decoder(backend) && !m_dsp_hle->isChecked() &&
+                            m_dolby_pro_logic->isChecked());
   if (m_latency_control_supported)
   {
     m_latency_label->setEnabled(AudioCommon::SupportsLatencyControl(backend));
@@ -382,7 +384,7 @@ void AudioPane::OnEmulationStateChanged(bool running)
   if (AudioCommon::SupportsDPL2Decoder(SConfig::GetInstance().sBackend) && !m_dsp_hle->isChecked())
   {
     m_dolby_pro_logic->setEnabled(!running);
-    EnableDolbyQualityWidgets(!running);
+    EnableDolbyQualityWidgets(!running && m_dolby_pro_logic->isChecked());
   }
   if (m_latency_control_supported)
   {


### PR DESCRIPTION
This fixes the case when upon opening the Audio tab for the first time with LLE Audio selected, Dolby Pro Logic II quality slider would be enabled even if Dolby Pro Logic II itself wasn't.

![image](https://user-images.githubusercontent.com/7947461/76119507-df83ca00-5fef-11ea-8de3-2997756527d5.png)