### PR TITLE
Breakpoints: Fix crash after clearing all memory breakpoints

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -196,6 +196,15 @@ void MemChecks::Remove(u32 address)
   });
 }
 
+void MemChecks::Clear()
+{
+  Core::RunAsCPUThread([&] {
+    m_mem_checks.clear();
+    JitInterface::ClearCache();
+    PowerPC::DBATUpdated();
+  });
+}
+
 TMemCheck* MemChecks::GetMemCheck(u32 address, size_t size)
 {
   const auto iter =

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -88,7 +88,7 @@ public:
   bool OverlapsMemcheck(u32 address, u32 length) const;
   void Remove(u32 address);
 
-  void Clear() { m_mem_checks.clear(); }
+  void Clear();
   bool HasAny() const { return !m_mem_checks.empty(); }
 
 private:


### PR DESCRIPTION
This PR fixes crash after clearing memory breakpoints by pressing Clear button.