### PR TITLE
Fix settings.txt parsing in case of weird line endings

### DIFF
--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -41,7 +41,7 @@ void SettingsHandler::SetBytes(Buffer&& buffer)
 
 std::string SettingsHandler::GetValue(std::string_view key) const
 {
-  constexpr char delim[] = "\r\n";
+  constexpr char delim[] = "\n";
   std::string toFind = std::string(delim).append(key).append("=");
   size_t found = decoded.find(toFind);
 
@@ -80,6 +80,14 @@ void SettingsHandler::Decrypt()
     str++;
     m_key = (m_key >> 31) | (m_key << 1);
   }
+
+  // Decryption done. Now get rid of all CR in the output.
+  // The decoded file is supposed to contain Windows line endings
+  // (CR-LF), but sometimes also contains CR-LF-LF endings which
+  // confuse the parsing code, so let's just get rid of all CR
+  // line endings.
+
+  decoded.erase(std::remove(decoded.begin(), decoded.end(), '\x0d'), decoded.end());
 }
 
 void SettingsHandler::Reset()


### PR DESCRIPTION
Related to bug 11930: https://bugs.dolphin-emu.org/issues/11930

The settings.txt file straight from a Wii NAND does sometimes contain one weird line ending - CR-LF-LF instead of CR-LF (0d0a0a). The current parsing code only searches for 0d0a, and doesn't find the line immediately after the broken line ending. 

This causes the bug described in issue 11930 - the serial number in the file is ignored and regenerated, until the file is re-written by Dolphin, with correct line endings. This causes problems, because it makes Dolphin regenerate the serial number when importing a NAND. 

My change makes a temporary copy of the decoded string, then removes all CR bytes from the string, leaving only LF line endings in the copy. This also replaces the broken CR-LF-LF line feed with LF-LF, making it look like a normal empty line. This way, the current code to search for a settings element correctly finds that entry. 

With that change applied, re-importing a NAND from the same console over and over again doesn't cause any identifier change anymore, this means, re-importing a NAND no longer creates a new console identity on Wiimmfi anymore, meaning, the 7-day wait isn't always restarted. 

Hoping this change doesn't break anything else, but it doesn't look like it. 