### PR TITLE
DolphinQt: Fix gyro mapping indicator's "jitter" drawing.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -689,7 +689,7 @@ void GyroMappingIndicator::Draw()
       const auto jitter_line_y =
           std::min(max_jitter / deadzone_value * DEADZONE_DRAW_SIZE - DEADZONE_DRAW_BOTTOM, 1.0);
       p.setPen(GetCosmeticPen(QPen(GetRawInputColor(), INPUT_DOT_RADIUS)));
-      p.drawLine(-1.0, jitter_line_y * -1.0, 1.0, jitter_line_y * -1.0);
+      p.drawLine(QLineF(-1.0, jitter_line_y * -1.0, 1.0, jitter_line_y * -1.0));
 
       // Sphere background.
       p.setPen(Qt::NoPen);


### PR DESCRIPTION
The "jitter" line which helps in configuration of the "Dead Zone" setting was broken.
A `QPainter::drawLine` overload taking `int` was inadvertently being used.
There is no four parameter overload that takes `float`.