### PR TITLE
Fix Load Wii System Menu not updating after performing a disc update

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -329,6 +329,9 @@ void GameList::ShowContextMenu(const QPoint&)
       auto* perform_disc_update = menu->addAction(tr("Perform System Update"), this,
                                                   [this, file_path = game->GetFilePath()] {
                                                     WiiUpdate::PerformDiscUpdate(file_path, this);
+                                                    // Since the update may have installed a newer
+                                                    // system menu, trigger a refresh.
+                                                    Settings::Instance().NANDRefresh();
                                                   });
       perform_disc_update->setEnabled(!Core::IsRunning() || !SConfig::GetInstance().bWii);
     }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1245,8 +1245,8 @@ void MainWindow::SetStateSlot(int slot)
 void MainWindow::PerformOnlineUpdate(const std::string& region)
 {
   WiiUpdate::PerformOnlineUpdate(region, this);
-  // Since the update may have installed a newer system menu, refresh the tools menu.
-  m_menu_bar->UpdateToolsMenu(false);
+  // Since the update may have installed a newer system menu, trigger a refresh.
+  Settings::Instance().NANDRefresh();
 }
 
 void MainWindow::BootWiiSystemMenu()


### PR DESCRIPTION
This fixes an annoying case where installing the system menu via "Perform System Update" on a disc would fail to enable the Load Wii System Menu item in the tools menu until Dolphin is restarted.  If a system menu was already installed, then the old version would still be displayed, but the button was usable.

I also replace the call the "Perform Online Update" function uses to avoid this with a more general one.  Note that `NANDRefresh` is connected to `UpdateToolsMenu`:

https://github.com/dolphin-emu/dolphin/blob/0461170363693efec7d6a8a34baaa5fb2deb8954/Source/Core/DolphinQt/MenuBar.cpp#L265