### PR TITLE
TitleDatabase: Added custom publisher database option.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -150,7 +150,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("LanguageCode", m_InterfaceLanguage);
   interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
   interface->Set("ShowActiveTitle", m_show_active_title);
-  interface->Set("UseBuiltinTitleDatabase", m_use_builtin_title_database);
+  interface->Set("UseBuiltinTitleDatabase", m_use_builtin_metadata_database);
   interface->Set("ThemeName", theme_name);
   interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
   interface->Set("DebugModeEnabled", bEnableDebugging);
@@ -423,7 +423,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("LanguageCode", &m_InterfaceLanguage, "");
   interface->Get("ExtendedFPSInfo", &m_InterfaceExtendedFPSInfo, false);
   interface->Get("ShowActiveTitle", &m_show_active_title, true);
-  interface->Get("UseBuiltinTitleDatabase", &m_use_builtin_title_database, true);
+  interface->Get("UseBuiltinTitleDatabase", &m_use_builtin_metadata_database, true);
   interface->Get("ThemeName", &theme_name, DEFAULT_THEME_DIR);
   interface->Get("PauseOnFocusLost", &m_PauseOnFocusLost, false);
   interface->Get("DebugModeEnabled", &bEnableDebugging, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -236,7 +236,7 @@ struct SConfig
   // other interface settings
   bool m_InterfaceExtendedFPSInfo;
   bool m_show_active_title = false;
-  bool m_use_builtin_title_database = true;
+  bool m_use_builtin_metadata_database = true;
 
   bool m_ListDrives;
   bool m_ListWad;

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -68,7 +68,7 @@ TitleDatabase::TitleDatabase()
     m_user_title_map = LoadMap(load_directory + "titles.txt");
 
   // Custom developer ("maker") index
-  m_user_developer_map = LoadMap(load_directory + "developers.txt");
+  m_user_publisher_map = LoadMap(load_directory + "publishers.txt");
 
   // Pre-defined databases (one per language)
   AddLazyMap(DiscIO::Language::Japanese, "ja");
@@ -94,32 +94,14 @@ TitleDatabase::TitleDatabase()
 
 TitleDatabase::~TitleDatabase() = default;
 
-const std::string& TitleDatabase::GetDeveloper(const std::string& gametdb_id) const
-
-{
-  auto it = m_user_developer_map.find(gametdb_id);
-  if (it != m_user_developer_map.end())
-    return it->second;
-
-  if (!SConfig::GetInstance().m_use_builtin_title_database)
-    return EMPTY_STRING;
-
-  it = m_base_map.find(gametdb_id);
-  if (it != m_base_map.end())
-    return it->second;
-
-  return EMPTY_STRING;
-}
-
 const std::string& TitleDatabase::GetTitleName(const std::string& gametdb_id,
                                                DiscIO::Language language) const
-
 {
   auto it = m_user_title_map.find(gametdb_id);
   if (it != m_user_title_map.end())
     return it->second;
 
-  if (!SConfig::GetInstance().m_use_builtin_title_database)
+  if (!SConfig::GetInstance().m_use_builtin_metadata_database)
     return EMPTY_STRING;
 
   const Map& map = *m_title_maps.at(language);
@@ -156,5 +138,14 @@ std::string TitleDatabase::Describe(const std::string& gametdb_id, DiscIO::Langu
   if (title_name.empty())
     return gametdb_id;
   return fmt::format("{} ({})", title_name, gametdb_id);
+}
+
+const std::string& TitleDatabase::GetPublisher(const std::string& gametdb_id) const
+{
+  auto it = m_user_publisher_map.find(gametdb_id);
+  if (it != m_user_publisher_map.end())
+    return it->second;
+
+  return EMPTY_STRING;
 }
 }  // namespace Core

--- a/Source/Core/Core/TitleDatabase.cpp
+++ b/Source/Core/Core/TitleDatabase.cpp
@@ -67,6 +67,9 @@ TitleDatabase::TitleDatabase()
   if (m_user_title_map.empty())
     m_user_title_map = LoadMap(load_directory + "titles.txt");
 
+  // Custom developer ("maker") index
+  m_user_developer_map = LoadMap(load_directory + "developers.txt");
+
   // Pre-defined databases (one per language)
   AddLazyMap(DiscIO::Language::Japanese, "ja");
   AddLazyMap(DiscIO::Language::English, "en");
@@ -91,8 +94,26 @@ TitleDatabase::TitleDatabase()
 
 TitleDatabase::~TitleDatabase() = default;
 
+const std::string& TitleDatabase::GetDeveloper(const std::string& gametdb_id) const
+
+{
+  auto it = m_user_developer_map.find(gametdb_id);
+  if (it != m_user_developer_map.end())
+    return it->second;
+
+  if (!SConfig::GetInstance().m_use_builtin_title_database)
+    return EMPTY_STRING;
+
+  it = m_base_map.find(gametdb_id);
+  if (it != m_base_map.end())
+    return it->second;
+
+  return EMPTY_STRING;
+}
+
 const std::string& TitleDatabase::GetTitleName(const std::string& gametdb_id,
                                                DiscIO::Language language) const
+
 {
   auto it = m_user_title_map.find(gametdb_id);
   if (it != m_user_title_map.end())

--- a/Source/Core/Core/TitleDatabase.h
+++ b/Source/Core/Core/TitleDatabase.h
@@ -26,6 +26,7 @@ public:
 
   // Get a user friendly title name for a GameTDB ID.
   // This falls back to returning an empty string if none could be found.
+  const std::string& GetDeveloper(const std::string& gametdb_id) const;
   const std::string& GetTitleName(const std::string& gametdb_id, DiscIO::Language language) const;
 
   // Same as above, but takes a title ID instead of a GameTDB ID, and only works for channels.
@@ -37,9 +38,9 @@ public:
 private:
   void AddLazyMap(DiscIO::Language language, const std::string& language_code);
 
-  std::unordered_map<DiscIO::Language, Common::Lazy<std::unordered_map<std::string, std::string>>>
-      m_title_maps;
+  std::unordered_map<DiscIO::Language, Common::Lazy<std::unordered_map<std::string, std::string>>> m_title_maps;
   std::unordered_map<std::string, std::string> m_base_map;
+  std::unordered_map<std::string, std::string> m_user_developer_map;
   std::unordered_map<std::string, std::string> m_user_title_map;
 };
 }  // namespace Core

--- a/Source/Core/Core/TitleDatabase.h
+++ b/Source/Core/Core/TitleDatabase.h
@@ -26,8 +26,8 @@ public:
 
   // Get a user friendly title name for a GameTDB ID.
   // This falls back to returning an empty string if none could be found.
-  const std::string& GetDeveloper(const std::string& gametdb_id) const;
   const std::string& GetTitleName(const std::string& gametdb_id, DiscIO::Language language) const;
+  const std::string& GetPublisher(const std::string& gametdb_id) const;
 
   // Same as above, but takes a title ID instead of a GameTDB ID, and only works for channels.
   const std::string& GetChannelName(u64 title_id, DiscIO::Language language) const;
@@ -40,7 +40,7 @@ private:
 
   std::unordered_map<DiscIO::Language, Common::Lazy<std::unordered_map<std::string, std::string>>> m_title_maps;
   std::unordered_map<std::string, std::string> m_base_map;
-  std::unordered_map<std::string, std::string> m_user_developer_map;
   std::unordered_map<std::string, std::string> m_user_title_map;
+  std::unordered_map<std::string, std::string> m_user_publisher_map;
 };
 }  // namespace Core

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -96,13 +96,13 @@ public:
   }
   virtual std::string GetGameID(const Partition& partition = PARTITION_NONE) const = 0;
   virtual std::string GetGameTDBID(const Partition& partition = PARTITION_NONE) const = 0;
-  virtual std::string GetMakerID(const Partition& partition = PARTITION_NONE) const = 0;
+  virtual std::string GetPublisherID(const Partition& partition = PARTITION_NONE) const = 0;
   virtual std::optional<u16> GetRevision(const Partition& partition = PARTITION_NONE) const = 0;
   virtual std::string GetInternalName(const Partition& partition = PARTITION_NONE) const = 0;
   virtual std::map<Language, std::string> GetShortNames() const { return {}; }
   virtual std::map<Language, std::string> GetLongNames() const { return {}; }
-  virtual std::map<Language, std::string> GetShortMakers() const { return {}; }
-  virtual std::map<Language, std::string> GetLongMakers() const { return {}; }
+  virtual std::map<Language, std::string> GetShortMakerPublishers() const { return {}; }
+  virtual std::map<Language, std::string> GetLongPublishers() const { return {}; }
   virtual std::map<Language, std::string> GetDescriptions() const { return {}; }
   virtual std::vector<u32> GetBanner(u32* width, u32* height) const = 0;
   std::string GetApploaderDate() const { return GetApploaderDate(GetGamePartition()); }

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -103,7 +103,7 @@ Country VolumeGC::GetCountry(const Partition& partition) const
   return CountryCodeToCountry(country, Platform::GameCubeDisc, region, revision);
 }
 
-std::string VolumeGC::GetMakerID(const Partition& partition) const
+std::string VolumeGC::GetPublisherID(const Partition& partition) const
 {
   char maker_id[2];
   if (!Read(0x4, sizeof(maker_id), reinterpret_cast<u8*>(&maker_id), partition))
@@ -137,12 +137,12 @@ std::map<Language, std::string> VolumeGC::GetLongNames() const
   return m_converted_banner->long_names;
 }
 
-std::map<Language, std::string> VolumeGC::GetShortMakers() const
+std::map<Language, std::string> VolumeGC::GetShortMakerPublishers() const
 {
   return m_converted_banner->short_makers;
 }
 
-std::map<Language, std::string> VolumeGC::GetLongMakers() const
+std::map<Language, std::string> VolumeGC::GetLongPublishers() const
 {
   return m_converted_banner->long_makers;
 }

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -35,13 +35,13 @@ public:
   const FileSystem* GetFileSystem(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameTDBID(const Partition& partition = PARTITION_NONE) const override;
-  std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetPublisherID(const Partition& partition = PARTITION_NONE) const override;
   std::optional<u16> GetRevision(const Partition& partition = PARTITION_NONE) const override;
   std::string GetInternalName(const Partition& partition = PARTITION_NONE) const override;
   std::map<Language, std::string> GetShortNames() const override;
   std::map<Language, std::string> GetLongNames() const override;
-  std::map<Language, std::string> GetShortMakers() const override;
-  std::map<Language, std::string> GetLongMakers() const override;
+  std::map<Language, std::string> GetShortMakerPublishers() const override;
+  std::map<Language, std::string> GetLongPublishers() const override;
   std::map<Language, std::string> GetDescriptions() const override;
   std::vector<u32> GetBanner(u32* width, u32* height) const override;
   std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -253,7 +253,7 @@ std::string VolumeWAD::GetGameTDBID(const Partition& partition) const
   return m_tmd.GetGameTDBID();
 }
 
-std::string VolumeWAD::GetMakerID(const Partition& partition) const
+std::string VolumeWAD::GetPublisherID(const Partition& partition) const
 {
   char temp[2];
   if (!Read(0x198 + m_tmd_offset, 2, (u8*)temp, partition))

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -46,7 +46,7 @@ public:
   IOS::ES::TicketReader GetTicketWithFixedCommonKey() const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameTDBID(const Partition& partition = PARTITION_NONE) const override;
-  std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetPublisherID(const Partition& partition = PARTITION_NONE) const override;
   std::optional<u16> GetRevision(const Partition& partition = PARTITION_NONE) const override;
   std::string GetInternalName(const Partition& partition = PARTITION_NONE) const override
   {

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -342,7 +342,7 @@ Country VolumeWii::GetCountry(const Partition& partition) const
   return CountryCodeToCountry(country_byte, Platform::WiiDisc, region, revision);
 }
 
-std::string VolumeWii::GetMakerID(const Partition& partition) const
+std::string VolumeWii::GetPublisherID(const Partition& partition) const
 {
   char maker_id[2];
 

--- a/Source/Core/DiscIO/VolumeWii.h
+++ b/Source/Core/DiscIO/VolumeWii.h
@@ -47,7 +47,7 @@ public:
   u64 PartitionOffsetToRawOffset(u64 offset, const Partition& partition) const override;
   std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
   std::string GetGameTDBID(const Partition& partition = PARTITION_NONE) const override;
-  std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetPublisherID(const Partition& partition = PARTITION_NONE) const override;
   std::optional<u16> GetRevision(const Partition& partition = PARTITION_NONE) const override;
   std::string GetInternalName(const Partition& partition = PARTITION_NONE) const override;
   std::map<Language, std::string> GetLongNames() const override;

--- a/Source/Core/DolphinQt/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt/Config/InfoWidget.cpp
@@ -73,11 +73,11 @@ QGroupBox* InfoWidget::CreateISODetails()
 
   QLineEdit* country = CreateValueDisplay(DiscIO::GetName(m_game.GetCountry(), true));
 
-  const std::string game_maker = m_game.GetMaker(UICommon::GameFile::Variant::LongAndNotCustom);
+  const std::string game_maker = m_game.GetPublisher(UICommon::GameFile::Variant::LongAndNotCustom);
 
   QLineEdit* maker =
       CreateValueDisplay((game_maker.empty() ? UNKNOWN_NAME.toStdString() : game_maker) + " (" +
-                         m_game.GetMakerID() + ")");
+                         m_game.GetPublisherID() + ")");
 
   layout->addRow(tr("Name:"), internal_name);
   layout->addRow(tr("File:"), file_path);
@@ -190,7 +190,7 @@ void InfoWidget::ChangeLanguage()
     m_name->setText(QString::fromStdString(m_game.GetLongName(language)));
 
   if (m_maker)
-    m_maker->setText(QString::fromStdString(m_game.GetLongMaker(language)));
+    m_maker->setText(QString::fromStdString(m_game.GetLongPublisher(language)));
 
   if (m_description)
     m_description->setText(QString::fromStdString(m_game.GetDescription(language)));

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -712,7 +712,7 @@ void GameList::OpenGCSaveFolder()
       QDir dir(QString::fromStdString(path));
 
       if (!dir.entryList({QStringLiteral("%1-%2-*.gci")
-                              .arg(QString::fromStdString(game->GetMakerID()))
+                              .arg(QString::fromStdString(game->GetPublisherID()))
                               .arg(QString::fromStdString(game->GetGameID().substr(0, 4)))})
                .empty())
       {

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -132,7 +132,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_MAKER:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
-      return QString::fromStdString(game.GetMaker(m_title_database));
+      return QString::fromStdString(game.GetPublisher(m_title_database));
     }
     break;
   case COL_FILE_NAME:
@@ -182,7 +182,7 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
   case COL_DESCRIPTION:
     return tr("Description");
   case COL_MAKER:
-    return tr("Developer");
+    return tr("Publisher");
   case COL_FILE_NAME:
     return tr("File Name");
   case COL_SIZE:

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -132,8 +132,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_MAKER:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
-      return QString::fromStdString(
-          game.GetMaker(UICommon::GameFile::Variant::LongAndPossiblyCustom));
+      return QString::fromStdString(game.GetMaker(m_title_database));
     }
     break;
   case COL_FILE_NAME:
@@ -183,7 +182,7 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
   case COL_DESCRIPTION:
     return tr("Description");
   case COL_MAKER:
-    return tr("Maker");
+    return tr("Developer");
   case COL_FILE_NAME:
     return tr("File Name");
   case COL_SIZE:

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -146,13 +146,13 @@ void InterfacePane::CreateUI()
   }
 
   // Checkboxes
-  m_checkbox_use_builtin_title_database = new QCheckBox(tr("Use Built-In Database of Game Names"));
+  m_checkbox_use_builtin_metadata_database = new QCheckBox(tr("Use Built-In Database of Metadata"));
   m_checkbox_use_userstyle = new QCheckBox(tr("Use Custom User Style"));
   m_checkbox_use_covers =
       new QCheckBox(tr("Download Game Covers from GameTDB.com for Use in Grid Mode"));
   m_checkbox_show_debugging_ui = new QCheckBox(tr("Show Debugging UI"));
 
-  groupbox_layout->addWidget(m_checkbox_use_builtin_title_database);
+  groupbox_layout->addWidget(m_checkbox_use_builtin_metadata_database);
   groupbox_layout->addWidget(m_checkbox_use_userstyle);
   groupbox_layout->addWidget(m_checkbox_use_covers);
   groupbox_layout->addWidget(m_checkbox_show_debugging_ui);
@@ -184,7 +184,7 @@ void InterfacePane::CreateInGame()
 
 void InterfacePane::ConnectLayout()
 {
-  connect(m_checkbox_use_builtin_title_database, &QCheckBox::toggled, this,
+  connect(m_checkbox_use_builtin_metadata_database, &QCheckBox::toggled, this,
           &InterfacePane::OnSaveConfig);
   connect(m_checkbox_use_covers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
@@ -211,7 +211,7 @@ void InterfacePane::ConnectLayout()
 void InterfacePane::LoadConfig()
 {
   const SConfig& startup_params = SConfig::GetInstance();
-  m_checkbox_use_builtin_title_database->setChecked(startup_params.m_use_builtin_title_database);
+  m_checkbox_use_builtin_metadata_database->setChecked(startup_params.m_use_builtin_metadata_database);
   m_checkbox_show_debugging_ui->setChecked(Settings::Instance().IsDebugModeEnabled());
   m_combobox_language->setCurrentIndex(m_combobox_language->findData(
       QString::fromStdString(SConfig::GetInstance().m_InterfaceLanguage)));
@@ -245,7 +245,7 @@ void InterfacePane::LoadConfig()
 void InterfacePane::OnSaveConfig()
 {
   SConfig& settings = SConfig::GetInstance();
-  settings.m_use_builtin_title_database = m_checkbox_use_builtin_title_database->isChecked();
+  settings.m_use_builtin_metadata_database = m_checkbox_use_builtin_metadata_database->isChecked();
   Settings::Instance().SetDebugModeEnabled(m_checkbox_show_debugging_ui->isChecked());
   Settings::Instance().SetUserStylesEnabled(m_checkbox_use_userstyle->isChecked());
   Settings::Instance().SetCurrentUserStyle(m_combobox_userstyle->currentData().toString());

--- a/Source/Core/DolphinQt/Settings/InterfacePane.h
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.h
@@ -32,7 +32,7 @@ private:
   QComboBox* m_combobox_userstyle;
   QLabel* m_label_userstyle;
   QCheckBox* m_checkbox_top_window;
-  QCheckBox* m_checkbox_use_builtin_title_database;
+  QCheckBox* m_checkbox_use_builtin_metadata_database;
   QCheckBox* m_checkbox_use_userstyle;
   QCheckBox* m_checkbox_show_debugging_ui;
   QCheckBox* m_checkbox_use_covers;

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -109,8 +109,8 @@ GameFile::GameFile(std::string path) : m_file_path(std::move(path))
 
       m_short_names = volume->GetShortNames();
       m_long_names = volume->GetLongNames();
-      m_short_makers = volume->GetShortMakers();
-      m_long_makers = volume->GetLongMakers();
+      m_short_makers = volume->GetShortMakerPublishers();
+      m_long_makers = volume->GetLongPublishers();
       m_descriptions = volume->GetDescriptions();
 
       m_region = volume->GetRegion();
@@ -123,7 +123,7 @@ GameFile::GameFile(std::string path) : m_file_path(std::move(path))
       m_game_id = volume->GetGameID();
       m_gametdb_id = volume->GetGameTDBID();
       m_title_id = volume->GetTitleID().value_or(0);
-      m_maker_id = volume->GetMakerID();
+      m_maker_id = volume->GetPublisherID();
       m_revision = volume->GetRevision().value_or(0);
       m_disc_number = volume->GetDiscNumber().value_or(0);
       m_apploader_date = volume->GetApploaderDate();
@@ -487,22 +487,22 @@ const std::string& GameFile::GetName(Variant variant) const
   return m_file_name;
 }
 
-const std::string& GameFile::GetMaker(const Core::TitleDatabase& title_database) const
+const std::string& GameFile::GetPublisher(const Core::TitleDatabase& title_database) const
 {
   if (!m_custom_maker.empty())
     return m_custom_maker;
 
-  const std::string& database_name = title_database.GetDeveloper(m_gametdb_id);
-  return database_name.empty() ? GetMaker(Variant::LongAndPossiblyCustom) : database_name;
+  const std::string& database_name = title_database.GetPublisher(m_gametdb_id);
+  return database_name.empty() ? GetPublisher(Variant::LongAndPossiblyCustom) : database_name;
 }
 
-const std::string& GameFile::GetMaker(Variant variant) const
+const std::string& GameFile::GetPublisher(Variant variant) const
 {
   if (variant == Variant::LongAndPossiblyCustom && !m_custom_maker.empty())
     return m_custom_maker;
 
   const std::string& maker =
-      variant == Variant::ShortAndNotCustom ? GetShortMaker() : GetLongMaker();
+      variant == Variant::ShortAndNotCustom ? GetShortMakerPublisher() : GetLongPublisher();
   if (!maker.empty())
     return maker;
 

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -487,6 +487,15 @@ const std::string& GameFile::GetName(Variant variant) const
   return m_file_name;
 }
 
+const std::string& GameFile::GetMaker(const Core::TitleDatabase& title_database) const
+{
+  if (!m_custom_maker.empty())
+    return m_custom_maker;
+
+  const std::string& database_name = title_database.GetDeveloper(m_gametdb_id);
+  return database_name.empty() ? GetMaker(Variant::LongAndPossiblyCustom) : database_name;
+}
+
 const std::string& GameFile::GetMaker(Variant variant) const
 {
   if (variant == Variant::LongAndPossiblyCustom && !m_custom_maker.empty())

--- a/Source/Core/UICommon/GameFile.h
+++ b/Source/Core/UICommon/GameFile.h
@@ -60,16 +60,16 @@ public:
   const std::string& GetFileName() const { return m_file_name; }
   const std::string& GetName(const Core::TitleDatabase& title_database) const;
   const std::string& GetName(Variant variant) const;
-  const std::string& GetMaker(const Core::TitleDatabase& title_database) const;
-  const std::string& GetMaker(Variant variant) const;
+  const std::string& GetPublisher(const Core::TitleDatabase& title_database) const;
+  const std::string& GetPublisher(Variant variant) const;
   const std::string& GetShortName(DiscIO::Language l) const { return Lookup(l, m_short_names); }
   const std::string& GetShortName() const { return LookupUsingConfigLanguage(m_short_names); }
   const std::string& GetLongName(DiscIO::Language l) const { return Lookup(l, m_long_names); }
   const std::string& GetLongName() const { return LookupUsingConfigLanguage(m_long_names); }
-  const std::string& GetShortMaker(DiscIO::Language l) const { return Lookup(l, m_short_makers); }
-  const std::string& GetShortMaker() const { return LookupUsingConfigLanguage(m_short_makers); }
-  const std::string& GetLongMaker(DiscIO::Language l) const { return Lookup(l, m_long_makers); }
-  const std::string& GetLongMaker() const { return LookupUsingConfigLanguage(m_long_makers); }
+  const std::string& GetShortMakerPublisher(DiscIO::Language l) const { return Lookup(l, m_short_makers); }
+  const std::string& GetShortMakerPublisher() const { return LookupUsingConfigLanguage(m_short_makers); }
+  const std::string& GetLongPublisher(DiscIO::Language l) const { return Lookup(l, m_long_makers); }
+  const std::string& GetLongPublisher() const { return LookupUsingConfigLanguage(m_long_makers); }
   const std::string& GetDescription(DiscIO::Language l) const { return Lookup(l, m_descriptions); }
   const std::string& GetDescription(Variant variant) const;
   std::vector<DiscIO::Language> GetLanguages() const;
@@ -77,7 +77,7 @@ public:
   const std::string& GetGameID() const { return m_game_id; }
   const std::string& GetGameTDBID() const { return m_gametdb_id; }
   u64 GetTitleID() const { return m_title_id; }
-  const std::string& GetMakerID() const { return m_maker_id; }
+  const std::string& GetPublisherID() const { return m_maker_id; }
   u16 GetRevision() const { return m_revision; }
   // 0 is the first disc, 1 is the second disc
   u8 GetDiscNumber() const { return m_disc_number; }

--- a/Source/Core/UICommon/GameFile.h
+++ b/Source/Core/UICommon/GameFile.h
@@ -60,6 +60,7 @@ public:
   const std::string& GetFileName() const { return m_file_name; }
   const std::string& GetName(const Core::TitleDatabase& title_database) const;
   const std::string& GetName(Variant variant) const;
+  const std::string& GetMaker(const Core::TitleDatabase& title_database) const;
   const std::string& GetMaker(Variant variant) const;
   const std::string& GetShortName(DiscIO::Language l) const { return Lookup(l, m_short_names); }
   const std::string& GetShortName() const { return LookupUsingConfigLanguage(m_short_names); }


### PR DESCRIPTION
Copied and updated from #8637.

Functions identically to `titles.txt`, but uses `publishers.txt` instead. I also think that _"Maker"_ should be changed to _"Publisher"_ in the UI. I believe this will make more sense to the end-users, but the code should stick to _"maker"_ as it's the official tag and would require. It would also more work to rename everything id it is changed. In accordance, the title database load option has been re-labeled to `Use Built-In Database of Metadata`. Note that the ability to load the title database is already broken if a custom title file is present, it seems that the custom titles aren't unloaded if the `Use Built-In Database of Titles` option is enabled. The discovery of this bug was made during development of this update and it is unknown how far back it goes. Unless I'm mistaken, the title database strings should be predominant if the option is enabled for all titles even if a custom titles file is present. Furthermore, the entire metadata load implementation would have to be completely re-written to fix this bug.

![Comparison](https://user-images.githubusercontent.com/47702158/76954782-29ad5b00-68ce-11ea-8743-5dc96aa92d3b.png)
