### PR TITLE
Android/JNI: Remove odd usage of the comma operator

### DIFF
--- a/Source/Android/jni/GameList/GameFile.cpp
+++ b/Source/Android/jni/GameList/GameFile.cpp
@@ -134,13 +134,13 @@ JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getGameT
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getDiscNumber(JNIEnv* env,
                                                                                    jobject obj)
 {
-  return env, GetRef(env, obj)->GetDiscNumber();
+  return GetRef(env, obj)->GetDiscNumber();
 }
 
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getRevision(JNIEnv* env,
                                                                                  jobject obj)
 {
-  return env, GetRef(env, obj)->GetRevision();
+  return GetRef(env, obj)->GetRevision();
 }
 
 JNIEXPORT jintArray JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_getBanner(JNIEnv* env,


### PR DESCRIPTION
This was probably a copypaste mistake of mine. (`env` is used as the first argument when calling `ToJString`.)