### PR TITLE
Qt/GameListModel: Use native separators in File Path column

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -145,7 +145,8 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_FILE_PATH:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
-      QString file_path = QFileInfo(QString::fromStdString(game.GetFilePath())).canonicalPath();
+      QString file_path = QDir::toNativeSeparators(
+          QFileInfo(QString::fromStdString(game.GetFilePath())).canonicalPath());
       if (!file_path.endsWith(QDir::separator()))
         file_path.append(QDir::separator());
       return file_path;


### PR DESCRIPTION
This is a fixup for #8580 - column now displays native separators consistently. Before the PR, on Windows paths would be displayed like:

```
C:/path/to/game\
```

Now separators are consistent.