### PR TITLE
SettingsHandler: Always decode the whole settings.txt file

### DIFF
--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -71,10 +71,8 @@ std::string SettingsHandler::GetValue(std::string_view key) const
 void SettingsHandler::Decrypt()
 {
   const u8* str = m_buffer.data();
-  while (*str != 0)
+  while (m_position < m_buffer.size())
   {
-    if (m_position >= m_buffer.size())
-      return;
     decoded.push_back((u8)(m_buffer[m_position] ^ m_key));
     m_position++;
     str++;


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12019
Related to https://bugs.dolphin-emu.org/issues/11930 and to #8673 and #8670

The encrypted settings.txt can contain nullbytes - it's a binary file. The old code assumed a null byte means "end of file". That's not the case - for some files, the current code stops parsing in the middle of the file. (That took me a while to figure out ...)

This approach decrypts the junk data at the end of the file, too, but because the valid data always ends with a newline, all the junk ends up on new line(s) at the end, meaning, the parsing code should just ignore that junk. The decrypted data unfortunately doesn't end with a null byte, and we don't know the length of the decrypted data, so I don't see any way to detect and remove that junk data. 

Please merge this prior to #8673. 