### PR TITLE
[RFC] MMU: Allow specifying whether to translate an address via the BAT when calling the Host functions.

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.h
+++ b/Source/Core/Core/PowerPC/MMU.h
@@ -13,32 +13,41 @@
 
 namespace PowerPC
 {
+enum class TranslateFlag
+{
+  CheckMSR,
+  AlwaysTranslate,
+  NeverTranslate,
+};
+
 // Routines for debugger UI, cheats, etc. to access emulated memory from the
 // perspective of the CPU.  Not for use by core emulation routines.
 // Use "Host_" prefix.
-u8 HostRead_U8(u32 address);
-u16 HostRead_U16(u32 address);
-u32 HostRead_U32(u32 address);
-u64 HostRead_U64(u32 address);
-float HostRead_F32(u32 address);
-double HostRead_F64(u32 address);
-u32 HostRead_Instruction(u32 address);
+u8 HostRead_U8(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+u16 HostRead_U16(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+u32 HostRead_U32(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+u64 HostRead_U64(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+float HostRead_F32(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+double HostRead_F64(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+u32 HostRead_Instruction(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
 
-void HostWrite_U8(u8 var, u32 address);
-void HostWrite_U16(u16 var, u32 address);
-void HostWrite_U32(u32 var, u32 address);
-void HostWrite_U64(u64 var, u32 address);
-void HostWrite_F32(float var, u32 address);
-void HostWrite_F64(double var, u32 address);
+void HostWrite_U8(u8 var, u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+void HostWrite_U16(u16 var, u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+void HostWrite_U32(u32 var, u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+void HostWrite_U64(u64 var, u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+void HostWrite_F32(float var, u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
+void HostWrite_F64(double var, u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
 
-std::string HostGetString(u32 address, size_t size = 0);
+std::string HostGetString(u32 address, size_t size = 0,
+                          TranslateFlag translate_flag = TranslateFlag::CheckMSR);
 
 // Returns whether a read or write to the given address will resolve to a RAM
 // access given the current CPU state.
-bool HostIsRAMAddress(u32 address);
+bool HostIsRAMAddress(u32 address, TranslateFlag translate_flag = TranslateFlag::CheckMSR);
 
 // Same as HostIsRAMAddress, but uses IBAT instead of DBAT.
-bool HostIsInstructionRAMAddress(u32 address);
+bool HostIsInstructionRAMAddress(u32 address,
+                                 TranslateFlag translate_flag = TranslateFlag::CheckMSR);
 
 // Routines for the CPU core to access memory.
 


### PR DESCRIPTION
So after the code debugger is now in a pretty good state I figured I'd check out the other debugging facilities, starting with the Memory viewer. This made me run across this issue again so I figured I'd bring it up once more -- see also #8310, #6913. This is also relevant for the Cheat Search functionality which is currently a bit broken, see #8311.

In short, we have a bunch of HostRead/Write() functions that allow the emulator to look at and modify the emulated game RAM. These are currently written to always respect the `MSR.DR` processor flag on whether to translate an address using the BAT or not before using it to access memory. However, there are situations where you'd rather specify whether to translate or not (otherwise it feels random when you pause the game at an arbitrary point in time), and this PR would make that pretty flexible.

An alternative to forcing the translation would be to let the caller say whether they expect the address to be translated or not, and then bounce with an std::nullopt or similar when the actual CPU state mismatches what the caller wants. That might be a bit cleaner, but makes the calling code and potentially the GUI itself more complex -- thinking specifically of the Cheat Search here. It would prevent the case of the caller saying AlwaysTranslate while the CPU state has translation off and the BAT is in an invalid state, which sounds like a rare and hard to debug issue... hmm. Y'know, now that I've written this up, I actually like that better I think, I think I'll put up an alternate PR for that.

Still, in case we end up preferring this method, here's this PR.