### PR TITLE
Parse arguments before Qt

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -92,6 +92,10 @@ int main(int argc, char* argv[])
   }
 #endif
 
+  auto parser = CommandLineParse::CreateParser(CommandLineParse::ParserOptions::IncludeGUIOptions);
+  const optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
+  const std::vector<std::string> args = parser->args();
+
   QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
   QCoreApplication::setOrganizationName(QStringLiteral("Dolphin Emulator"));
@@ -108,10 +112,6 @@ int main(int argc, char* argv[])
   // This code will become unnecessary and obsolete once we switch to Qt 6.
   QApplication::setFont(QApplication::font("QMenu"));
 #endif
-
-  auto parser = CommandLineParse::CreateParser(CommandLineParse::ParserOptions::IncludeGUIOptions);
-  const optparse::Values& options = CommandLineParse::ParseArguments(parser.get(), argc, argv);
-  const std::vector<std::string> args = parser->args();
 
 #ifdef _WIN32
   FreeConsole();


### PR DESCRIPTION
This is so commands like `dolphin-emu --help` don't initialise Qt, which wastes memory and prints logs that shouldn't be printed

Before:
```
$ dolphin-emu --help
qt5ct: using qt5ct plugin
qt5ct: D-Bus global menu: no
Usage: dolphin-emu [options]... [FILE]...

Options:
  --version             show program's version number and exit
...
  -a AUDIO_EMULATION, --audio_emulation=AUDIO_EMULATION
                        Choose audio emulation from [HLE|LLE]
```

After:
```
$ dolphin-emu --help
Usage: dolphin-emu [options]... [FILE]...

Options:
  --version             show program's version number and exit
...
  -a AUDIO_EMULATION, --audio_emulation=AUDIO_EMULATION
                        Choose audio emulation from [HLE|LLE]
```