### PR TITLE
Jit: remove warning -Winvalid-offsetof

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -138,7 +138,8 @@ void Jit64AsmRoutineManager::Generate()
     SHL(64, R(RSCRATCH2), Imm8(32));
     // RSCRATCH_EXTRA still has the PC.
     OR(64, R(RSCRATCH2), R(RSCRATCH_EXTRA));
-    CMP(64, R(RSCRATCH2), MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlock, effectiveAddress))));
+    CMP(64, R(RSCRATCH2),
+        MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlockData, effectiveAddress))));
     FixupBranch state_mismatch = J_CC(CC_NE);
 
     // Success; branch to the block we found.
@@ -146,10 +147,10 @@ void Jit64AsmRoutineManager::Generate()
     TEST(32, PPCSTATE(msr), Imm32(1 << (31 - 27)));
     FixupBranch physmem = J_CC(CC_Z);
     MOV(64, R(RMEM), ImmPtr(Memory::logical_base));
-    JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlock, normalEntry))));
+    JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlockData, normalEntry))));
     SetJumpTarget(physmem);
     MOV(64, R(RMEM), ImmPtr(Memory::physical_base));
-    JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlock, normalEntry))));
+    JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlockData, normalEntry))));
 
     SetJumpTarget(not_found);
     SetJumpTarget(state_mismatch);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -11,23 +11,17 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <type_traits>
 #include <vector>
 
 #include "Common/CommonTypes.h"
 
 class JitBase;
 
-// A JitBlock is block of compiled code which corresponds to the PowerPC
-// code at a given address.
-//
-// The notion of the address of a block is a bit complicated because of the
-// way address translation works, but basically it's the combination of an
-// effective address, the address translation bits in MSR, and the physical
-// address.
-struct JitBlock
+// offsetof is only conditionally supported for non-standard layout types,
+// so this struct needs to have a standard layout.
+struct JitBlockData
 {
-  bool OverlapsPhysicalRange(u32 address, u32 length) const;
-
   // A special entry point for block linking; usually used to check the
   // downcount.
   u8* checkedEntry;
@@ -49,6 +43,22 @@ struct JitBlock
   // The number of PPC instructions represented by this block. Mostly
   // useful for logging.
   u32 originalSize;
+  // This tracks the position if this block within the fast block cache.
+  // We allow each block to have only one map entry.
+  size_t fast_block_map_index;
+};
+static_assert(std::is_standard_layout_v<JitBlockData>, "JitBlockData must have a standard layout");
+
+// A JitBlock is a block of compiled code which corresponds to the PowerPC
+// code at a given address.
+//
+// The notion of the address of a block is a bit complicated because of the
+// way address translation works, but basically it's the combination of an
+// effective address, the address translation bits in MSR, and the physical
+// address.
+struct JitBlock : public JitBlockData
+{
+  bool OverlapsPhysicalRange(u32 address, u32 length) const;
 
   // Information about exits to a known address from this block.
   // This is used to implement block linking.
@@ -73,10 +83,6 @@ struct JitBlock
     u64 ticStart;
     u64 ticStop;
   } profile_data = {};
-
-  // This tracks the position if this block within the fast block cache.
-  // We allow each block to have only one map entry.
-  size_t fast_block_map_index;
 };
 
 typedef void (*CompiledCode)();


### PR DESCRIPTION
Remove the warning:
warning: offsetof within non-standard-layout type ‘JitBlock’ is conditionally-supported
JitBlock contains non-trival types now. Split the fields with trival
types that needs to be access from JIT code into JitBlockData structure.