### PR TITLE
Remove warning of -Wstringop-truncation

### DIFF
--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Unix.cpp
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Unix.cpp
@@ -50,7 +50,7 @@ bool CEXIETHERNET::Activate()
   const int MAX_INTERFACES = 32;
   for (int i = 0; i < MAX_INTERFACES; ++i)
   {
-    strncpy(ifr.ifr_name, StringFromFormat("Dolphin%d", i).c_str(), IFNAMSIZ);
+    strncpy(ifr.ifr_name, StringFromFormat("Dolphin%d", i).c_str(), IFNAMSIZ - 1);
 
     int err;
     if ((err = ioctl(fd, TUNSETIFF, (void*)&ifr)) < 0)

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -420,9 +420,9 @@ static CertECC MakeBlankEccCert(const std::string& issuer, const std::string& na
 {
   CertECC cert{};
   cert.signature.type = SignatureType(Common::swap32(u32(SignatureType::ECC)));
-  std::strncpy(cert.signature.issuer, issuer.c_str(), 0x40);
+  issuer.copy(cert.signature.issuer, sizeof(cert.signature.issuer) - 1);
   cert.header.public_key_type = PublicKeyType(Common::swap32(u32(PublicKeyType::ECC)));
-  std::strncpy(cert.header.name, name.c_str(), 0x40);
+  name.copy(cert.header.name, sizeof(cert.header.name) - 1);
   cert.header.id = Common::swap32(key_id);
   cert.public_key = Common::ec::PrivToPub(private_key);
   return cert;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -341,8 +341,8 @@ static void CompressAndDumpState(CompressAndDumpState_args save_args)
   }
 
   // Setting up the header
-  StateHeader header;
-  strncpy(header.gameID, SConfig::GetInstance().GetGameID().c_str(), 6);
+  StateHeader header{};
+  SConfig::GetInstance().GetGameID().copy(header.gameID, std::size(header.gameID));
   header.size = g_use_compression ? (u32)buffer_size : 0;
   header.time = Common::Timer::GetDoubleTime();
 


### PR DESCRIPTION
Fix the right length when strncpy. And use specific version of copy
to copy GameID.