### PR TITLE
Remove warnings of -Wsign-compare

### DIFF
--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -177,10 +177,10 @@ void AdvancedPane::Update()
   const bool enable_custom_rtc_widgets = SConfig::GetInstance().bEnableCustomRTC && !running;
 
   const std::vector<PowerPC::CPUCore>& available_cpu_cores = PowerPC::AvailableCPUCores();
-  for (int i = 0; i < available_cpu_cores.size(); ++i)
+  for (size_t i = 0; i < available_cpu_cores.size(); ++i)
   {
     if (available_cpu_cores[i] == SConfig::GetInstance().cpu_core)
-      m_cpu_emulation_engine_combobox->setCurrentIndex(i);
+      m_cpu_emulation_engine_combobox->setCurrentIndex(int(i));
   }
   m_cpu_emulation_engine_combobox->setEnabled(!running);
 

--- a/Source/Core/VideoBackends/Software/DebugUtil.cpp
+++ b/Source/Core/VideoBackends/Software/DebugUtil.cpp
@@ -136,9 +136,9 @@ static void DumpEfb(const std::string& filename)
   u8* data = new u8[EFB_WIDTH * EFB_HEIGHT * 4];
   u8* writePtr = data;
 
-  for (int y = 0; y < EFB_HEIGHT; y++)
+  for (u32 y = 0; y < EFB_HEIGHT; y++)
   {
-    for (int x = 0; x < EFB_WIDTH; x++)
+    for (u32 x = 0; x < EFB_WIDTH; x++)
     {
       // ABGR to RGBA
       const u32 sample = Common::swap32(EfbInterface::GetColor(x, y));

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -320,11 +320,11 @@ void DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertexData* v
     scissorTop = 0;
 
   s32 scissorRight = bpmem.scissorBR.x - xoff - 341;
-  if (scissorRight > EFB_WIDTH)
+  if (scissorRight > s32(EFB_WIDTH))
     scissorRight = EFB_WIDTH;
 
   s32 scissorBottom = bpmem.scissorBR.y - yoff - 341;
-  if (scissorBottom > EFB_HEIGHT)
+  if (scissorBottom > s32(EFB_HEIGHT))
     scissorBottom = EFB_HEIGHT;
 
   minx = std::max(minx, scissorLeft);

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -567,8 +567,8 @@ void Tev::Indirect(unsigned int stageNum, s32 s, s32 t)
 
 void Tev::Draw()
 {
-  ASSERT(Position[0] >= 0 && Position[0] < EFB_WIDTH);
-  ASSERT(Position[1] >= 0 && Position[1] < EFB_HEIGHT);
+  ASSERT(Position[0] >= 0 && Position[0] < s32(EFB_WIDTH));
+  ASSERT(Position[1] >= 0 && Position[1] < s32(EFB_HEIGHT));
 
   INCSTAT(g_stats.this_frame.tev_pixels_in);
 

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -241,19 +241,19 @@ static void BPWritten(const BPCmd& bp)
     // known for configuring these out-of-range copies.
     int copy_width = srcRect.GetWidth();
     int copy_height = srcRect.GetHeight();
-    if (srcRect.right > EFB_WIDTH || srcRect.bottom > EFB_HEIGHT)
+    if (srcRect.right > s32(EFB_WIDTH) || srcRect.bottom > s32(EFB_HEIGHT))
     {
       WARN_LOG(VIDEO, "Oversized EFB copy: %dx%d (offset %d,%d stride %u)", copy_width, copy_height,
                srcRect.left, srcRect.top, destStride);
 
       // Adjust the copy size to fit within the EFB. So that we don't end up with a stretched image,
       // instead of clamping the source rectangle, we reduce it by the over-sized amount.
-      if (copy_width > EFB_WIDTH)
+      if (copy_width > s32(EFB_WIDTH))
       {
         srcRect.right -= copy_width - EFB_WIDTH;
         copy_width = EFB_WIDTH;
       }
-      if (copy_height > EFB_HEIGHT)
+      if (copy_height > s32(EFB_HEIGHT))
       {
         srcRect.bottom -= copy_height - EFB_HEIGHT;
         copy_height = EFB_HEIGHT;


### PR DESCRIPTION
Cast the variable to the coresponding type.