### PR TITLE
HW: cleanup warnings of -Wtype-limits

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -314,7 +314,7 @@ void CEXIIPL::TransferByte(u8& data)
       }
     };
 
-    if (IN_RANGE(ROM))
+    if (address < ROM_BASE + ROM_SIZE)
     {
       if (!m_command.is_write())
       {


### PR DESCRIPTION
address is unsigned, it is always greater or equal than zero.
Remove the asert of zero compare.