### PR TITLE
Cleanup warnings of -Wpessimizing-move

### DIFF
--- a/Source/Core/DolphinQt/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogWidget.cpp
@@ -75,7 +75,7 @@ void LogWidget::UpdateLog()
     elements_to_push.reserve(std::min(MAX_LOG_LINES_TO_UPDATE, m_log_ring_buffer.size()));
 
     for (size_t i = 0; !m_log_ring_buffer.empty() && i < MAX_LOG_LINES_TO_UPDATE; i++)
-      elements_to_push.push_back(std::move(m_log_ring_buffer.pop_front()));
+      elements_to_push.push_back(m_log_ring_buffer.pop_front());
   }
 
   for (auto& line : elements_to_push)


### PR DESCRIPTION
moving a temporary object prevents copy elision. Remove std::move.