### PR TITLE
Fix build with Qt 5.15+

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -13,6 +13,7 @@
 #include <QAction>
 #include <QDateTime>
 #include <QPainter>
+#include <QPainterPath>
 #include <QTimer>
 
 #include "Common/MathUtil.h"


### PR DESCRIPTION
Fix build with Qt 5.15

~~~
 95%] Building CXX object Source/Core/DolphinQt/CMakeFiles/dolphin-emu.dir/NetPlay/GameListDialog.cpp.o
/tmp/makepkg/sl1-dolphin-emu-git/src/dolphin-emu/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp: En la función miembro ‘virtual void SwingIndicator::DrawUnderGate(QPainter&)’:
/tmp/makepkg/sl1-dolphin-emu-git/src/dolphin-emu/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp:485:18: error: el agregado ‘QPainterPath path’ tiene un tipo incompleto y no se puede definir
  485 |     QPainterPath path;
      |                  ^~~~
~~~