### PR TITLE
Match path type to BundleUtilities when running fixup_bundle

### DIFF
--- a/CMake/DolphinPostprocessBundle.cmake
+++ b/CMake/DolphinPostprocessBundle.cmake
@@ -21,7 +21,7 @@ if(CMAKE_GENERATOR)
 	return()
 endif()
 
-get_filename_component(DOLPHIN_BUNDLE_PATH "${DOLPHIN_BUNDLE_PATH}" REALPATH)
+get_filename_component(DOLPHIN_BUNDLE_PATH "${DOLPHIN_BUNDLE_PATH}" ABSOLUTE)
 message(STATUS "Fixing up application bundle: ${DOLPHIN_BUNDLE_PATH}")
 
 # Make sure to fix up any additional shared libraries (like plugins) that are


### PR DESCRIPTION
Both `/tmp` and `/private/tmp` resolve to `/tmp` with `ABSOLUTE` and `/private/tmp` with `REALPATH` (details [here](https://gitlab.kitware.com/cmake/cmake/-/issues/20515))
BundleUtilities uses `ABSOLUTE` internally, so if you give it a `REALPATH` and compile from `/tmp` (which is a symlink to `/private/tmp`), BundleUtilities will complain about things not being inside the main app bundle because some paths don't match