### PR TITLE
Set Insert SD Card default value to true

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -74,7 +74,7 @@ ConfigInfo<bool> GetInfoForSimulateKonga(u32 channel)
   return {{System::Main, "Core", fmt::format("SimulateKonga{}", channel)}, false};
 }
 
-const ConfigInfo<bool> MAIN_WII_SD_CARD{{System::Main, "Core", "WiiSDCard"}, false};
+const ConfigInfo<bool> MAIN_WII_SD_CARD{{System::Main, "Core", "WiiSDCard"}, true};
 const ConfigInfo<bool> MAIN_WII_SD_CARD_WRITABLE{{System::Main, "Core", "WiiSDCardWritable"}, true};
 const ConfigInfo<bool> MAIN_WII_KEYBOARD{{System::Main, "Core", "WiiKeyboard"}, false};
 const ConfigInfo<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING{

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -510,7 +510,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
     core->Get(fmt::format("AdapterRumble{}", i), &m_AdapterRumble[i], true);
     core->Get(fmt::format("SimulateKonga{}", i), &m_AdapterKonga[i], false);
   }
-  core->Get("WiiSDCard", &m_WiiSDCard, false);
+  core->Get("WiiSDCard", &m_WiiSDCard, true);
   core->Get("WiiKeyboard", &m_WiiKeyboard, false);
   core->Get("WiimoteContinuousScanning", &m_WiimoteContinuousScanning, false);
   core->Get("WiimoteEnableSpeaker", &m_WiimoteEnableSpeaker, false);


### PR DESCRIPTION
Enabling the SD card is useful for loading / saving data for games such as Super Smash Bros. Brawl. I assume most users won't encounter any problems with this setting enabled. Was there a reason why the default was set to false? Also, the virtual SD card is created regardless of this setting.