### PR TITLE
Boot: Add ConsoleType enum class

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -177,7 +177,8 @@ void CBoot::SetupGCMemory()
   // Console type - DevKit  (retail ID == 0x00000003) see YAGCD 4.2.1.1.2
   // TODO: determine why some games fail when using a retail ID.
   // (Seem to take different EXI paths, see Ikaruga for example)
-  PowerPC::HostWrite_U32(0x10000006, 0x8000002C);
+  const u32 console_type = static_cast<u32>(Core::ConsoleType::LatestDevkit);
+  PowerPC::HostWrite_U32(console_type, 0x8000002C);
 
   // Fake the VI Init of the IPL (YAGCD 4.2.1.4)
   PowerPC::HostWrite_U32(DiscIO::IsNTSC(SConfig::GetInstance().m_region) ? 0 : 1, 0x800000CC);
@@ -372,10 +373,12 @@ bool CBoot::SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type)
   Memory::Write_U32(0x0D15EA5E, 0x00000020);                // Another magic word
   Memory::Write_U32(0x00000001, 0x00000024);                // Unknown
   Memory::Write_U32(Memory::GetRamSizeReal(), 0x00000028);  // MEM1 size 24MB
-  u32 board_model = console_type == IOS::HLE::IOSC::ConsoleType::RVT ? 0x10000021 : 0x00000023;
-  Memory::Write_U32(board_model, 0x0000002c);  // Board Model
-  Memory::Write_U32(0x00000000, 0x00000030);   // Init
-  Memory::Write_U32(0x817FEC60, 0x00000034);   // Init
+  const Core::ConsoleType board_model = console_type == IOS::HLE::IOSC::ConsoleType::RVT ?
+                                            Core::ConsoleType::NDEV2_1 :
+                                            Core::ConsoleType::RVL_Retail3;
+  Memory::Write_U32(static_cast<u32>(board_model), 0x0000002c);  // Board Model
+  Memory::Write_U32(0x00000000, 0x00000030);                     // Init
+  Memory::Write_U32(0x817FEC60, 0x00000034);                     // Init
   // 38, 3C should get start, size of FST through apploader
   Memory::Write_U32(0x8008f7b8, 0x000000e4);                // Thread Init
   Memory::Write_U32(Memory::GetRamSizeReal(), 0x000000f0);  // "Simulated memory size" (debug mode?)

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -37,6 +37,59 @@ enum class State
   Starting,
 };
 
+// Console type values based on:
+//  - YAGCD 4.2.1.1.2
+//  - OSInit (GameCube ELF from Finding Nemo)
+//  - OSReportInfo (Wii ELF from Rayman Raving Rabbids)
+enum class ConsoleType : u32
+{
+  // 0x0XXXXXXX Retail units - Gamecube
+  HW1 = 1,
+  HW2 = 2,
+  LatestProductionBoard = 3,
+  Reserved = 4,
+
+  // 0x0XXXXXXX Retail units - Wii
+  PreProductionBoard0 = 0x10,    // Pre-production board 0
+  PreProductionBoard1 = 0x11,    // Pre-production board 1
+  PreProductionBoard2_1 = 0x12,  // Pre-production board 2-1
+  PreProductionBoard2_2 = 0x20,  // Pre-production board 2-2
+  RVL_Retail1 = 0x21,
+  RVL_Retail2 = 0x22,
+  RVL_Retail3 = 0x23,
+  RVA1 = 0x100,  // Revolution Arcade
+
+  // 0x1XXXXXXX Devkits - Gamecube
+  // Emulators
+  MacEmulator = 0x10000000,  // Mac Emulator
+  PcEmulator = 0x10000001,   // PC Emulator
+
+  // Embedded PowerPC series
+  Arthur = 0x10000002,  // EPPC Arthur
+  Minnow = 0x10000003,  // EPPC Minnow
+
+  // Development HW
+  // Version = (console_type & 0x0fffffff) - 3
+  FirstDevkit = 0x10000004,
+  SecondDevkit = 0x10000005,
+  LatestDevkit = 0x10000006,
+  ReservedDevkit = 0x10000007,
+
+  // 0x1XXXXXXX Devkits - Wii
+  RevolutionEmulator = 0x10000008,  // Revolution Emulator
+  NDEV1_0 = 0x10000010,             // NDEV 1.0
+  NDEV1_1 = 0x10000011,             // NDEV 1.1
+  NDEV1_2 = 0x10000012,             // NDEV 1.2
+  NDEV2_0 = 0x10000020,             // NDEV 2.0
+  NDEV2_1 = 0x10000021,             // NDEV 2.1
+
+  // 0x2XXXXXXX TDEV-based emulation HW
+  // Version = (console_type & 0x0fffffff) - 3
+  HW2TDEVSystem = 0x20000005,
+  LatestTDEVSystem = 0x20000006,
+  ReservedTDEVSystem = 0x20000007,
+};
+
 bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi);
 void Stop();
 void Shutdown();


### PR DESCRIPTION
This PR adds a ConsoleType enum class and replace the magic number (console type) used in boot.

Ready to be reviewed & merged.