### PR TITLE
Delete properties dialog on close

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -431,6 +431,9 @@ void GameList::OpenProperties()
     return;
 
   PropertiesDialog* properties = new PropertiesDialog(this, *game);
+  // Since the properties dialog locks the game file, it's important to free it as soon as it's
+  // closed so that the file can be moved or deleted.
+  properties->setAttribute(Qt::WA_DeleteOnClose, true);
 
   connect(properties, &PropertiesDialog::OpenGeneralSettings, this, &GameList::OpenGeneralSettings);
 


### PR DESCRIPTION
Fixes the game file being locked until Dolphin closes.  The properties dialog *technically* didn't leak before this, since Qt will close it when its parent window closes, but that only happens when dolphin itself exits and that's way longer than it needs to be.  (See also: https://github.com/dolphin-emu/dolphin/pull/8088#issuecomment-491452256)