### PR TITLE
Android TV: Fix crash when long pressing a game

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -463,7 +463,8 @@ public final class NativeLibrary
     {
       // Create object used for waiting.
       final Object lock = new Object();
-      AlertDialog.Builder builder = new AlertDialog.Builder(emulationActivity)
+      AlertDialog.Builder builder = new AlertDialog.Builder(emulationActivity,
+              R.style.DolphinDialogBase)
               .setTitle(caption)
               .setMessage(text);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -738,7 +738,7 @@ public final class EmulationActivity extends AppCompatActivity
   {
     final SharedPreferences.Editor editor = mPreferences.edit();
     boolean[] enabledButtons = new boolean[14];
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
     builder.setTitle(R.string.emulation_toggle_controls);
     if (sIsGameCubeGame || mPreferences.getInt("wiiController", 3) == 0)
     {
@@ -795,7 +795,7 @@ public final class EmulationActivity extends AppCompatActivity
   public void chooseDoubleTapButton()
   {
     final SharedPreferences.Editor editor = mPreferences.edit();
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
 
     int currentController =
             mPreferences.getInt("wiiController", InputOverlay.OVERLAY_WIIMOTE_NUNCHUCK);
@@ -857,7 +857,7 @@ public final class EmulationActivity extends AppCompatActivity
     value.setText(String.valueOf(seekbar.getProgress() + 50));
     units.setText("%");
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
     builder.setTitle(R.string.emulation_control_scale);
     builder.setView(view);
     builder.setPositiveButton(getString(R.string.ok), (dialogInterface, i) ->
@@ -876,7 +876,7 @@ public final class EmulationActivity extends AppCompatActivity
   private void chooseController()
   {
     final SharedPreferences.Editor editor = mPreferences.edit();
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
     builder.setTitle(R.string.emulation_choose_controller);
     builder.setSingleChoiceItems(R.array.controllersEntries,
             mPreferences.getInt("wiiController", 3),
@@ -902,7 +902,7 @@ public final class EmulationActivity extends AppCompatActivity
   private void showMotionControlsOptions()
   {
     final SharedPreferences.Editor editor = mPreferences.edit();
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
     builder.setTitle(R.string.emulation_motion_controls);
     builder.setSingleChoiceItems(R.array.motionControlsEntries,
             mPreferences.getInt("motionControlsEnabled", 0),
@@ -938,7 +938,7 @@ public final class EmulationActivity extends AppCompatActivity
     }
 
     final SharedPreferences.Editor editor = mPreferences.edit();
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
     builder.setTitle(R.string.emulation_screen_orientation);
     builder.setSingleChoiceItems(R.array.orientationEntries, initialIndex,
             (dialog, indexSelected) ->
@@ -1055,7 +1055,7 @@ public final class EmulationActivity extends AppCompatActivity
       }
     });
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
     builder.setTitle(getString(R.string.emulation_ir_sensitivity));
     builder.setView(view);
     builder.setPositiveButton(R.string.ok, (dialogInterface, i) ->
@@ -1090,7 +1090,7 @@ public final class EmulationActivity extends AppCompatActivity
 
   private void resetOverlay()
   {
-    new AlertDialog.Builder(this)
+    new AlertDialog.Builder(this, R.style.DolphinDialogBase)
             .setTitle(getString(R.string.emulation_touch_overlay_reset))
             .setPositiveButton(R.string.yes, (dialogInterface, i) ->
             {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -137,7 +137,7 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 
     if (gameId.isEmpty())
     {
-      AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+      AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.DolphinDialogBase);
       builder.setTitle("Game Settings");
       builder.setMessage("Files without game IDs don't support game-specific settings.");
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -82,7 +82,7 @@ public final class GameRowPresenter extends Presenter
 
       if (gameId.isEmpty())
       {
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.DolphinDialogBase);
         builder.setTitle("Game Settings");
         builder.setMessage("Files without game IDs don't support game-specific settings.");
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameDetailsDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GameDetailsDialog.java
@@ -35,7 +35,8 @@ public final class GameDetailsDialog extends DialogFragment
   {
     GameFile gameFile = GameFileCacheService.addOrGet(getArguments().getString(ARG_GAME_PATH));
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
+    AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
+            R.style.DolphinDialogBase);
     ViewGroup contents = (ViewGroup) getActivity().getLayoutInflater()
             .inflate(R.layout.dialog_game_details, null);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
@@ -45,7 +45,8 @@ public class GamePropertiesDialog extends DialogFragment
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState)
   {
-    AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
+    AlertDialog.Builder builder = new AlertDialog.Builder(requireContext(),
+            R.style.DolphinDialogBase);
 
     String path = requireArguments().getString(ARG_PATH);
     String gameId = requireArguments().getString(ARG_GAMEID);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -218,7 +218,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   @Override
   public void showGameIniJunkDeletionQuestion()
   {
-    new AlertDialog.Builder(this)
+    new AlertDialog.Builder(this, R.style.DolphinDialogBase)
             .setTitle(getString(R.string.game_ini_junk_title))
             .setMessage(getString(R.string.game_ini_junk_question))
             .setPositiveButton(R.string.yes, (dialogInterface, i) -> mPresenter.clearSettings())

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -192,7 +192,8 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 
     int value = getSelectionForSingleChoiceValue(item);
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity());
+    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity(),
+            R.style.DolphinDialogBase);
 
     builder.setTitle(item.getNameId());
     builder.setSingleChoiceItems(item.getChoicesId(), value, this);
@@ -205,7 +206,8 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     mClickedItem = item;
     mClickedPosition = position;
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity());
+    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity(),
+            R.style.DolphinDialogBase);
 
     builder.setTitle(item.getNameId());
     builder.setSingleChoiceItems(item.getChoicesId(), item.getSelectValueIndex(), this);
@@ -221,7 +223,8 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 
     int value = getSelectionForSingleChoiceDynamicDescriptionsValue(item);
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity());
+    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity(),
+            R.style.DolphinDialogBase);
 
     builder.setTitle(item.getNameId());
     builder.setSingleChoiceItems(item.getChoicesId(), value, this);
@@ -234,7 +237,8 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     mClickedItem = item;
     mClickedPosition = position;
     mSeekbarProgress = item.getSelectedValue();
-    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity());
+    AlertDialog.Builder builder = new AlertDialog.Builder(mView.getActivity(),
+            R.style.DolphinDialogBase);
 
     LayoutInflater inflater = LayoutInflater.from(mView.getActivity());
     View view = inflater.inflate(R.layout.dialog_seekbar, null);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
@@ -58,7 +58,7 @@ public final class ConfirmRunnableViewHolder extends SettingViewHolder
     String alertTitle = mContext.getString(mItem.getNameId());
     String alertText = mContext.getString(mItem.getAlertText());
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(mContext)
+    AlertDialog.Builder builder = new AlertDialog.Builder(mContext, R.style.DolphinDialogBase)
             .setTitle(alertTitle)
             .setMessage(alertText);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -44,7 +44,7 @@ public class Analytics
     sPrefsEditor.putBoolean(analyticsAsked, true);
     sPrefsEditor.apply();
 
-    new AlertDialog.Builder(context, R.style.Theme_AppCompat_Dialog_Alert)
+    new AlertDialog.Builder(context, R.style.DolphinDialogBase)
             .setTitle(context.getString(R.string.analytics))
             .setMessage(context.getString(R.string.analytics_desc))
             .setPositiveButton(R.string.yes, (dialogInterface, i) ->

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PermissionsHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PermissionsHandler.java
@@ -62,7 +62,7 @@ public class PermissionsHandler
   private static void showMessageOKCancel(final FragmentActivity activity, String message,
           DialogInterface.OnClickListener okListener)
   {
-    new AlertDialog.Builder(activity)
+    new AlertDialog.Builder(activity, R.style.DolphinDialogBase)
             .setMessage(message)
             .setPositiveButton(android.R.string.ok, okListener)
             .setNegativeButton(android.R.string.cancel, (dialogInterface, i) ->

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -27,7 +27,7 @@
 
     <!-- Themes for Dialogs -->
 
-    <!-- Inherit from the Base Dolphin Dialog Theme -->
+    <style name="DolphinDialogBase" parent="Theme.AppCompat.DayNight.Dialog.Alert" />
 
     <style name="DolphinEmulationBase" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <item name="colorPrimary">@color/dolphin_blue</item>


### PR DESCRIPTION
Also fixes the same crash when accessing the game details (which only can be accessed after long pressing a game). The problem was that we were not using a theme that had an AppCompat theme as a parent.

After fixing the crashes, I discovered that the game details dialog unfortunately uses white on white on Android TV, and I don't know how to fix this in a clean way. But I guess that can be left for another PR?