### PR TITLE
AudioPane: Do not enable DPL II quality slider with HLE audio on init

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -234,7 +234,7 @@ void AudioPane::LoadSettings()
   m_dolby_quality_slider->setValue(int(Config::Get(Config::MAIN_DPL2_QUALITY)));
   m_dolby_quality_latency_label->setText(
       GetDPL2ApproximateLatencyLabel(Config::Get(Config::MAIN_DPL2_QUALITY)));
-  if (AudioCommon::SupportsDPL2Decoder(current))
+  if (AudioCommon::SupportsDPL2Decoder(current) && !m_dsp_hle->isChecked())
   {
     EnableDolbyQualityWidgets(m_dolby_pro_logic->isChecked());
   }


### PR DESCRIPTION
This PR is a de facto follow up to #8664, since there was one more case where DPL II audio quality slider was enabled when it shouldn't be - if Audio panel was opened with HLE audio selected and DPL II checkbox checked (as a "leftover" from using LLE audio, most likely), slider would be enabled while the checkbox itself was disabled. Now it's back in sync, as only this one code path seemed to be out of sync (for this reason candidate for refactor maybe?)

![image](https://user-images.githubusercontent.com/7947461/78184637-18d21d00-746a-11ea-87a8-050428a42dc7.png)
