### PR TITLE
Allow modifying MEM1 and MEM2 sizes at runtime via Dolphin.ini

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -95,6 +95,9 @@ private:
   float m_EmulationSpeed;
   float m_OCFactor;
   bool m_OCEnable;
+  bool m_RAMOverrideEnable;
+  u32 m_MEM1Size;
+  u32 m_MEM2Size;
   bool m_bt_passthrough_enabled;
   std::string strBackend;
   std::string sBackend;
@@ -132,6 +135,9 @@ void ConfigCache::SaveConfig(const SConfig& config)
   m_strGPUDeterminismMode = config.m_strGPUDeterminismMode;
   m_OCFactor = config.m_OCFactor;
   m_OCEnable = config.m_OCEnable;
+  m_RAMOverrideEnable = config.m_RAMOverrideEnable;
+  m_MEM1Size = config.m_MEM1Size;
+  m_MEM2Size = config.m_MEM2Size;
   m_bt_passthrough_enabled = config.m_bt_passthrough_enabled;
 
   for (int i = 0; i != MAX_BBMOTES; ++i)
@@ -207,6 +213,9 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->m_strGPUDeterminismMode = m_strGPUDeterminismMode;
   config->m_OCFactor = m_OCFactor;
   config->m_OCEnable = m_OCEnable;
+  config->m_RAMOverrideEnable = m_RAMOverrideEnable;
+  config->m_MEM1Size = m_MEM1Size;
+  config->m_MEM2Size = m_MEM2Size;
   config->m_bt_passthrough_enabled = m_bt_passthrough_enabled;
   VideoBackendBase::ActivateBackend(config->m_strVideoBackend);
 }
@@ -285,6 +294,9 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
                       StartUp.m_strGPUDeterminismMode);
     core_section->Get("Overclock", &StartUp.m_OCFactor, StartUp.m_OCFactor);
     core_section->Get("OverclockEnable", &StartUp.m_OCEnable, StartUp.m_OCEnable);
+    core_section->Get("RAMOverrideEnable", &StartUp.m_RAMOverrideEnable, StartUp.m_RAMOverrideEnable);
+    core_section->Get("MEM1Size", &StartUp.m_MEM1Size, StartUp.m_MEM1Size);
+    core_section->Get("MEM2Size", &StartUp.m_MEM2Size, StartUp.m_MEM2Size);
 
     for (unsigned int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
     {
@@ -369,6 +381,9 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     StartUp.m_DSPEnableJIT = netplay_settings.m_DSPEnableJIT;
     StartUp.m_OCEnable = netplay_settings.m_OCEnable;
     StartUp.m_OCFactor = netplay_settings.m_OCFactor;
+    StartUp.m_RAMOverrideEnable = netplay_settings.m_RAMOverrideEnable;
+    StartUp.m_MEM1Size = netplay_settings.m_MEM1Size;
+    StartUp.m_MEM2Size = netplay_settings.m_MEM2Size;
     StartUp.m_EXIDevice[0] = netplay_settings.m_EXIDevice[0];
     StartUp.m_EXIDevice[1] = netplay_settings.m_EXIDevice[1];
     StartUp.m_EXIDevice[2] = netplay_settings.m_EXIDevice[2];

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -98,6 +98,9 @@ const ConfigInfo<bool> MAIN_ACCURATE_NANS{{System::Main, "Core", "AccurateNaNs"}
 const ConfigInfo<float> MAIN_EMULATION_SPEED{{System::Main, "Core", "EmulationSpeed"}, 1.0f};
 const ConfigInfo<float> MAIN_OVERCLOCK{{System::Main, "Core", "Overclock"}, 1.0f};
 const ConfigInfo<bool> MAIN_OVERCLOCK_ENABLE{{System::Main, "Core", "OverclockEnable"}, false};
+const ConfigInfo<bool> MAIN_RAM_OVERRIDE_ENABLE{{System::Main, "Core", "RAMOverrideEnable"}, false};
+const ConfigInfo<u32> MAIN_MEM1_SIZE{{System::Main, "Core", "MEM1Size"}, 0x01800000};
+const ConfigInfo<u32> MAIN_MEM2_SIZE{{System::Main, "Core", "MEM2Size"}, 0x04000000};
 const ConfigInfo<std::string> MAIN_GFX_BACKEND{{System::Main, "Core", "GFXBackend"}, ""};
 const ConfigInfo<std::string> MAIN_GPU_DETERMINISM_MODE{
     {System::Main, "Core", "GPUDeterminismMode"}, "auto"};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -76,6 +76,9 @@ extern const ConfigInfo<bool> MAIN_ACCURATE_NANS;
 extern const ConfigInfo<float> MAIN_EMULATION_SPEED;
 extern const ConfigInfo<float> MAIN_OVERCLOCK;
 extern const ConfigInfo<bool> MAIN_OVERCLOCK_ENABLE;
+extern const ConfigInfo<bool> MAIN_RAM_OVERRIDE_ENABLE;
+extern const ConfigInfo<u32> MAIN_MEM1_SIZE;
+extern const ConfigInfo<u32> MAIN_MEM2_SIZE;
 // Should really be part of System::GFX, but again, we're stuck with past mistakes.
 extern const ConfigInfo<std::string> MAIN_GFX_BACKEND;
 extern const ConfigInfo<std::string> MAIN_GPU_DETERMINISM_MODE;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -242,6 +242,9 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("EmulationSpeed", m_EmulationSpeed);
   core->Set("Overclock", m_OCFactor);
   core->Set("OverclockEnable", m_OCEnable);
+  core->Set("RAMOverrideEnable", m_RAMOverrideEnable);
+  core->Set("MEM1Size", m_MEM1Size);
+  core->Set("MEM2Size", m_MEM2Size);
   core->Set("GFXBackend", m_strVideoBackend);
   core->Set("GPUDeterminismMode", m_strGPUDeterminismMode);
   core->Set("PerfMapDir", m_perfDir);
@@ -530,6 +533,9 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("EmulationSpeed", &m_EmulationSpeed, 1.0f);
   core->Get("Overclock", &m_OCFactor, 1.0f);
   core->Get("OverclockEnable", &m_OCEnable, false);
+  core->Get("RAMOverrideEnable", &m_RAMOverrideEnable, false);
+  core->Get("MEM1Size", &m_MEM1Size, 0x01800000);
+  core->Get("MEM2Size", &m_MEM2Size, 0x04000000);
   core->Get("GFXBackend", &m_strVideoBackend, "");
   core->Get("GPUDeterminismMode", &m_strGPUDeterminismMode, "auto");
   core->Get("PerfMapDir", &m_perfDir, "");

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -234,6 +234,9 @@ struct SConfig
   float m_EmulationSpeed;
   bool m_OCEnable;
   float m_OCFactor;
+  bool m_RAMOverrideEnable;
+  u32 m_MEM1Size;
+  u32 m_MEM2Size;
   // other interface settings
   bool m_InterfaceExtendedFPSInfo;
   bool m_show_active_title = false;

--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -366,7 +366,7 @@ struct NullAccessors : Accessors
 static EffectiveAddressSpaceAccessors s_effective_address_space_accessors;
 static AuxiliaryAddressSpaceAccessors s_auxiliary_address_space_accessors;
 static SmallBlockAccessors s_mem1_address_space_accessors{&Memory::m_pRAM, Memory::REALRAM_SIZE};
-static SmallBlockAccessors s_mem2_address_space_accessors{&Memory::m_pEXRAM, Memory::EXRAM_SIZE};
+static SmallBlockAccessors s_mem2_address_space_accessors{&Memory::m_pEXRAM, Memory::REALEXRAM_SIZE};
 static SmallBlockAccessors s_fake_address_space_accessors{&Memory::m_pFakeVMEM,
                                                           Memory::FAKEVMEM_SIZE};
 static CompositeAddressSpaceAccessors s_physical_address_space_accessors_gcn{

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -193,7 +193,7 @@ void Reinit(bool hle)
   if (SConfig::GetInstance().bWii)
   {
     s_ARAM.wii_mode = true;
-    s_ARAM.size = Memory::EXRAM_SIZE;
+    s_ARAM.size = Memory::REALEXRAM_SIZE;
     s_ARAM.mask = Memory::EXRAM_MASK;
     s_ARAM.ptr = Memory::m_pEXRAM;
   }

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -37,23 +37,21 @@ extern u8* m_pEXRAM;
 extern u8* m_pL1Cache;
 extern u8* m_pFakeVMEM;
 
-enum
-{
-  // RAM_SIZE is the amount allocated by the emulator, whereas REALRAM_SIZE is
-  // what will be reported in lowmem, and thus used by emulated software.
-  // Note: Writing to lowmem is done by IPL. If using retail IPL, it will
-  // always be set to 24MB.
-  REALRAM_SIZE = 0x01800000,
-  RAM_SIZE = MathUtil::NextPowerOf2(REALRAM_SIZE),
-  RAM_MASK = RAM_SIZE - 1,
-  FAKEVMEM_SIZE = 0x02000000,
-  FAKEVMEM_MASK = FAKEVMEM_SIZE - 1,
-  L1_CACHE_SIZE = 0x00040000,
-  L1_CACHE_MASK = L1_CACHE_SIZE - 1,
-  IO_SIZE = 0x00010000,
-  EXRAM_SIZE = 0x04000000,
-  EXRAM_MASK = EXRAM_SIZE - 1,
-};
+// RAM_SIZE is the amount allocated by the emulator, whereas REALRAM_SIZE is
+// what will be reported in lowmem, and thus used by emulated software.
+// Note: Writing to lowmem is done by IPL. If using retail IPL, it will
+// always be set to 24MB.
+extern u32 REALRAM_SIZE;
+extern u32 RAM_SIZE;
+extern u32 RAM_MASK;
+extern u32 FAKEVMEM_SIZE;
+extern u32 FAKEVMEM_MASK;
+extern u32 L1_CACHE_SIZE;
+extern u32 L1_CACHE_MASK;
+extern u32 IO_SIZE;
+extern u32 REALEXRAM_SIZE;
+extern u32 EXRAM_SIZE;
+extern u32 EXRAM_MASK;
 
 // MMIO mapping object.
 extern std::unique_ptr<MMIO::Mapping> mmio_mapping;

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -32,7 +32,7 @@ static void ReinitHardware()
   SConfig::GetInstance().bWii = false;
 
   // IOS clears mem2 and overwrites it with pseudo-random data (for security).
-  std::memset(Memory::m_pEXRAM, 0, Memory::EXRAM_SIZE);
+  std::memset(Memory::m_pEXRAM, 0, Memory::REALEXRAM_SIZE);
   // MIOS appears to only reset the DI and the PPC.
   // HACK However, resetting DI will reset the DTK config, which is set by the system menu
   // (and not by MIOS), causing games that use DTK to break.  Perhaps MIOS doesn't actually

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -35,6 +35,9 @@ struct NetSettings
   bool m_CopyWiiSave;
   bool m_OCEnable;
   float m_OCFactor;
+  bool m_RAMOverrideEnable;
+  u32 m_MEM1Size;
+  u32 m_MEM2Size;
   std::array<ExpansionInterface::TEXIDevices, 3> m_EXIDevice;
   bool m_EFBAccessEnable;
   bool m_BBoxEnable;

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -218,7 +218,7 @@ static T ReadFromHardware(u32 em_address)
   }
 
   if (Memory::m_pEXRAM && (em_address >> 28) == 0x1 &&
-      (em_address & 0x0FFFFFFF) < Memory::EXRAM_SIZE)
+      (em_address & 0x0FFFFFFF) < Memory::REALEXRAM_SIZE)
   {
     T value;
     std::memcpy(&value, &Memory::m_pEXRAM[em_address & 0x0FFFFFFF], sizeof(T));
@@ -307,7 +307,7 @@ static void WriteToHardware(u32 em_address, const T data)
   }
 
   if (Memory::m_pEXRAM && (em_address >> 28) == 0x1 &&
-      (em_address & 0x0FFFFFFF) < Memory::EXRAM_SIZE)
+      (em_address & 0x0FFFFFFF) < Memory::REALEXRAM_SIZE)
   {
     const T swapped_data = bswap(data);
     std::memcpy(&Memory::m_pEXRAM[em_address & 0x0FFFFFFF], &swapped_data, sizeof(T));
@@ -669,7 +669,7 @@ static bool IsRAMAddress(u32 address, bool translate)
   u32 segment = address >> 28;
   if (segment == 0x0 && (address & 0x0FFFFFFF) < Memory::REALRAM_SIZE)
     return true;
-  else if (Memory::m_pEXRAM && segment == 0x1 && (address & 0x0FFFFFFF) < Memory::EXRAM_SIZE)
+  else if (Memory::m_pEXRAM && segment == 0x1 && (address & 0x0FFFFFFF) < Memory::REALEXRAM_SIZE)
     return true;
   else if (Memory::m_pFakeVMEM && ((address & 0xFE000000) == 0x7E000000))
     return true;
@@ -1215,7 +1215,7 @@ static void UpdateBATs(BatTable& bat_table, u32 base_spr)
         else if (physical_address < Memory::REALRAM_SIZE)
           valid_bit |= BAT_PHYSICAL_BIT;
         else if (Memory::m_pEXRAM && physical_address >> 28 == 0x1 &&
-                 (physical_address & 0x0FFFFFFF) < Memory::EXRAM_SIZE)
+                 (physical_address & 0x0FFFFFFF) < Memory::REALEXRAM_SIZE)
           valid_bit |= BAT_PHYSICAL_BIT;
         else if (physical_address >> 28 == 0xE &&
                  physical_address < 0xE0000000 + Memory::L1_CACHE_SIZE)

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -96,6 +96,45 @@ void AdvancedPane::CreateLayout()
   cpu_clock_override_description->setWordWrap(true);
   clock_override_layout->addWidget(cpu_clock_override_description);
 
+  auto* ram_override = new QGroupBox(tr("Memory Override"));
+  auto* ram_override_layout = new QVBoxLayout();
+  ram_override->setLayout(ram_override_layout);
+  main_layout->addWidget(ram_override);
+
+  m_ram_override_checkbox = new QCheckBox(tr("Enable Emulated Memory Override"));
+  ram_override_layout->addWidget(m_ram_override_checkbox);
+
+  auto* mem1_override_slider_layout = new QHBoxLayout();
+  mem1_override_slider_layout->setContentsMargins(0, 0, 0, 0);
+  ram_override_layout->addLayout(mem1_override_slider_layout);
+
+  m_mem1_override_slider = new QSlider(Qt::Horizontal);
+  m_mem1_override_slider->setRange(24, 64);
+  mem1_override_slider_layout->addWidget(m_mem1_override_slider);
+
+  m_mem1_override_slider_label = new QLabel();
+  mem1_override_slider_layout->addWidget(m_mem1_override_slider_label);
+
+  auto* mem2_override_slider_layout = new QHBoxLayout();
+  mem2_override_slider_layout->setContentsMargins(0, 0, 0, 0);
+  ram_override_layout->addLayout(mem2_override_slider_layout);
+
+  m_mem2_override_slider = new QSlider(Qt::Horizontal);
+  m_mem2_override_slider->setRange(64, 128);
+  mem2_override_slider_layout->addWidget(m_mem2_override_slider);
+
+  m_mem2_override_slider_label = new QLabel();
+  mem2_override_slider_layout->addWidget(m_mem2_override_slider_label);
+
+  auto* ram_override_description =
+      new QLabel(tr("Adjusts the emulated sizes of MEM1 and MEM2.  Restart Dolphin for it to take effect.\n\n"
+                    "Some titles may recognize the larger memory arena(s) and take advantage of it, though "
+                    "(most) retail games are properly optimized for the retail memory limitations.\n\n"
+                    "WARNING: Changing these from the defaults (24MB and 64MB) can and will break games and cause "
+                    "glitches. Do so at your own risk.  Please do not report bugs that occur with non-default values."));
+ram_override_description->setWordWrap(true);
+  ram_override_layout->addWidget(ram_override_description);
+
   auto* rtc_options = new QGroupBox(tr("Custom RTC Options"));
   rtc_options->setLayout(new QVBoxLayout());
   main_layout->addWidget(rtc_options);
@@ -154,6 +193,27 @@ void AdvancedPane::ConnectLayout()
     Update();
   });
 
+  m_ram_override_checkbox->setChecked(SConfig::GetInstance().m_RAMOverrideEnable);
+  connect(m_ram_override_checkbox, &QCheckBox::toggled, [this](bool enable_ram_override) {
+    SConfig::GetInstance().m_RAMOverrideEnable = enable_ram_override;
+    Config::SetBaseOrCurrent(Config::MAIN_RAM_OVERRIDE_ENABLE, enable_ram_override);
+    Update();
+  });
+
+  connect(m_mem1_override_slider, &QSlider::valueChanged, [this](int slider_value) {
+    const u32 MEM1_Size = m_mem1_override_slider->value() * 0x100000;
+    SConfig::GetInstance().m_MEM1Size = MEM1_Size;
+    Config::SetBaseOrCurrent(Config::MAIN_MEM1_SIZE, MEM1_Size);
+    Update();
+  });
+
+  connect(m_mem2_override_slider, &QSlider::valueChanged, [this](int slider_value) {
+    const u32 MEM2_Size = m_mem2_override_slider->value() * 0x100000;
+    SConfig::GetInstance().m_MEM2Size = MEM2_Size;
+    Config::SetBaseOrCurrent(Config::MAIN_MEM2_SIZE, MEM2_Size);
+    Update();
+  });
+
   m_custom_rtc_checkbox->setChecked(SConfig::GetInstance().bEnableCustomRTC);
   connect(m_custom_rtc_checkbox, &QCheckBox::toggled, [this](bool enable_custom_rtc) {
     SConfig::GetInstance().bEnableCustomRTC = enable_custom_rtc;
@@ -173,6 +233,7 @@ void AdvancedPane::Update()
 {
   const bool running = Core::GetState() != Core::State::Uninitialized;
   const bool enable_cpu_clock_override_widgets = SConfig::GetInstance().m_OCEnable;
+  const bool enable_ram_override_widgets = SConfig::GetInstance().m_RAMOverrideEnable;
   const bool enable_custom_rtc_widgets = SConfig::GetInstance().bEnableCustomRTC && !running;
 
   const std::vector<PowerPC::CPUCore>& available_cpu_cores = PowerPC::AvailableCPUCores();
@@ -206,6 +267,34 @@ void AdvancedPane::Update()
     int percent = static_cast<int>(std::round(SConfig::GetInstance().m_OCFactor * 100.f));
     int clock = static_cast<int>(std::round(SConfig::GetInstance().m_OCFactor * core_clock));
     return tr("%1 % (%2 MHz)").arg(QString::number(percent), QString::number(clock));
+  }());
+
+  m_mem1_override_slider->setEnabled(enable_ram_override_widgets);
+  m_mem1_override_slider_label->setEnabled(enable_ram_override_widgets);
+
+  {
+    const QSignalBlocker blocker(m_mem1_override_slider);
+    int MEM1_Size = SConfig::GetInstance().m_MEM1Size / 0x100000;
+    m_mem1_override_slider->setValue(MEM1_Size);
+  }
+
+  m_mem1_override_slider_label->setText([] {
+    int MEM1_Size = SConfig::GetInstance().m_MEM1Size / 0x100000;
+    return tr("%1MB (MEM1)").arg(QString::number(MEM1_Size));
+  }());
+
+  m_mem2_override_slider->setEnabled(enable_ram_override_widgets);
+  m_mem2_override_slider_label->setEnabled(enable_ram_override_widgets);
+
+  {
+    const QSignalBlocker blocker(m_mem2_override_slider);
+    int MEM2_Size = SConfig::GetInstance().m_MEM2Size / 0x100000;
+    m_mem2_override_slider->setValue(MEM2_Size);
+  }
+
+  m_mem2_override_slider_label->setText([] {
+    int MEM2_Size = SConfig::GetInstance().m_MEM2Size / 0x100000;
+    return tr("%1MB (MEM2)").arg(QString::number(MEM2_Size));
   }());
 
   m_custom_rtc_checkbox->setEnabled(!running);

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -40,4 +40,11 @@ private:
 
   QCheckBox* m_custom_rtc_checkbox;
   QDateTimeEdit* m_custom_rtc_datetime;
+
+  QCheckBox* m_ram_override_checkbox;
+  QSlider* m_mem1_override_slider;
+  QLabel* m_mem1_override_slider_label;
+  QSlider* m_mem2_override_slider;
+  QLabel* m_mem2_override_slider_label;
+  QLabel* m_ram_override_description;
 };


### PR DESCRIPTION
Changing those enumerated values in the Memory namespace (REALRAM_SIZE, EXRAM_SIZE, etc) to global u32s seems to have actually boosted performance a bit.  A more thorough test is worth doing.