### PR TITLE
Qt/GameList: Use KeyPress instead of KeyRelease

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -897,12 +897,12 @@ void GameList::ConsiderViewChange()
     setCurrentWidget(m_empty);
   }
 }
-void GameList::keyReleaseEvent(QKeyEvent* event)
+void GameList::keyPressEvent(QKeyEvent* event)
 {
   if (event->key() == Qt::Key_Return && GetSelectedGame() != nullptr)
     emit GameSelected();
   else
-    QStackedWidget::keyReleaseEvent(event);
+    QStackedWidget::keyPressEvent(event);
 }
 
 void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -94,5 +94,5 @@ private:
   bool m_prefer_list;
 
 protected:
-  void keyReleaseEvent(QKeyEvent* event) override;
+  void keyPressEvent(QKeyEvent* event) override;
 };


### PR DESCRIPTION
This fixes a bug where pressing Enter in the "Do you want to stop the current emulation?" confirmation popup also triggers a KeyRelease in GameList, which starts a new game. This is because the popup closes on KeyPress with the Enter key (I believe because of the Qt autodefault Yes button), which gives focus back to the main window, which receives the KeyRelease event. I have encountered this bug on both Arch Linux and Ubuntu 18.04 -- I'm not sure if this affects other systems.

Listening for KeyPress instead of KeyRelease in GameList fixes this issue. I think it makes more sense this way because we don't want to trigger a key event for the GameList when the key was pressed somewhere else. Please let me know if this fix is acceptable, thanks!