### PR TITLE
macOS: fix initializing Vulkan surface when using gfx-portability

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -111,7 +111,7 @@ VkSurfaceKHR SwapChain::CreateVulkanSurface(VkInstance instance, const WindowSys
   if (wsi.type == WindowSystemType::MacOS)
   {
     VkMacOSSurfaceCreateInfoMVK surface_create_info = {
-        VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK, nullptr, 0, wsi.render_surface};
+        VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK, nullptr, 0, wsi.render_window};
 
     VkSurfaceKHR surface;
     VkResult res = vkCreateMacOSSurfaceMVK(instance, &surface_create_info, nullptr, &surface);


### PR DESCRIPTION
Since #8666, when running Dolphin using [gfx-portability](https://github.com/gfx-rs/portability/) instead of MoltenVK, it crashes with an exception:

```
$ LIBVULKAN_PATH=/usr/local/lib/libportability.dylib /Applications/Dolphin.app/Contents/MacOS/Dolphin
2020-04-05 21:05:53.416 Dolphin[73210:890862] -[CAMetalLayer layer]: unrecognized selector sent to instance 0x7fa0be67a710
2020-04-05 21:05:53.436 Dolphin[73210:890862] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[CAMetalLayer layer]: unrecognized selector sent to instance 0x7fa0be67a710'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff30a16acd __exceptionPreprocess + 256
	1   libobjc.A.dylib                     0x00007fff5b11aa17 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff30a908d6 -[NSObject(NSObject) __retain_OA] + 0
	3   CoreFoundation                      0x00007fff309b893f ___forwarding___ + 1485
	4   CoreFoundation                      0x00007fff309b82e8 _CF_forwarding_prep_0 + 120
	5   libportability.dylib                0x000000010c315758 _ZN17gfx_backend_metal8Instance26create_surface_from_nsview17h127760c1704de68dE + 72
	6   libportability.dylib                0x000000010c284cff _ZN15portability_gfx5impls24gfxCreateMacOSSurfaceMVK17h9f931ad376c6842eE + 207
	7   Dolphin                             0x00000001009c8fd1 _ZN6Vulkan9SwapChain19CreateVulkanSurfaceEP12VkInstance_TRK16WindowSystemInfo + 65
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

This seems to be because `vkCreateWin32SurfaceKHR` expects an NSView (per the documentation), but after #8666 it receives a CAMetalLayer.

This PR fixes the crash by passing the CAMetalLayer-backed NSView instead. Running Dolphin with gfx-portability runs fine after this.

### Note of gfx-portability

On a 2013 Macbook / Iris 5100, gfx-portability gives a substantially better framerate than MoltenVK (around ~10 FPS). At some point I remember it also had better frame pacing. So I'm quite eager to keep Dophin working with gfx-portability :)