### PR TITLE
Respect Core::WantsDeterminism for DNS servers on Linux

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -860,10 +860,13 @@ IPCCommandResult NetIPTop::HandleGetInterfaceOptRequest(const IOCtlVRequest& req
       }
     }
 #elif defined(__linux__) && !defined(__ANDROID__)
-    if (res_init() == 0)
-      address = ntohl(_res.nsaddr_list[0].sin_addr.s_addr);
-    else
-      WARN_LOG(IOS_NET, "Call to res_init failed");
+    if (!Core::WantsDeterminism())
+    {
+      if (res_init() == 0)
+        address = ntohl(_res.nsaddr_list[0].sin_addr.s_addr);
+      else
+        WARN_LOG(IOS_NET, "Call to res_init failed");
+    }
 #endif
     if (address == 0)
       address = default_main_dns_resolver;


### PR DESCRIPTION
Previously Core::WantsDeterminism was only checked for pulling in the DNS servers on WIN32.
Same check should apply to Linux too.