### PR TITLE
Android: Use touch emulation of IR by default

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -905,7 +905,7 @@ public final class EmulationActivity extends AppCompatActivity
     AlertDialog.Builder builder = new AlertDialog.Builder(this);
     builder.setTitle(R.string.emulation_motion_controls);
     builder.setSingleChoiceItems(R.array.motionControlsEntries,
-            mPreferences.getInt("motionControlsEnabled", 0),
+            mPreferences.getInt("motionControlsEnabled", 1),
             (dialog, indexSelected) ->
             {
               editor.putInt("motionControlsEnabled", indexSelected);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -162,7 +162,7 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     }
   }
 
-  if (group->can_be_disabled)
+  if (group->default_value != ControllerEmu::ControlGroup::DefaultValue::AlwaysEnabled)
   {
     QLabel* group_enable_label = new QLabel(tr("Enable"));
     QCheckBox* group_enable_checkbox = new QCheckBox();

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -16,16 +16,15 @@
 
 namespace ControllerEmu
 {
-ControlGroup::ControlGroup(std::string name_, const GroupType type_, CanBeDisabled can_be_disabled_)
-    : name(name_), ui_name(std::move(name_)), type(type_),
-      can_be_disabled(can_be_disabled_ == CanBeDisabled::Yes)
+ControlGroup::ControlGroup(std::string name_, const GroupType type_, DefaultValue default_value_)
+    : name(name_), ui_name(std::move(name_)), type(type_), default_value(default_value_)
 {
 }
 
 ControlGroup::ControlGroup(std::string name_, std::string ui_name_, const GroupType type_,
-                           CanBeDisabled can_be_disabled_)
+                           DefaultValue default_value_)
     : name(std::move(name_)), ui_name(std::move(ui_name_)), type(type_),
-      can_be_disabled(can_be_disabled_ == CanBeDisabled::Yes)
+      default_value(default_value_)
 {
 }
 
@@ -48,8 +47,8 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
   const std::string group(base + name + "/");
 
   // enabled
-  if (can_be_disabled)
-    sec->Get(group + "Enabled", &enabled, true);
+  if (default_value != DefaultValue::AlwaysEnabled)
+    sec->Get(group + "Enabled", &enabled, default_value == DefaultValue::Enabled);
 
   for (auto& setting : numeric_settings)
     setting->LoadFromIni(*sec, group);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -49,16 +49,17 @@ enum class GroupType
 class ControlGroup
 {
 public:
-  enum class CanBeDisabled
+  enum class DefaultValue
   {
-    No,
-    Yes,
+    AlwaysEnabled,
+    Enabled,
+    Disabled,
   };
 
   explicit ControlGroup(std::string name, GroupType type = GroupType::Other,
-                        CanBeDisabled can_be_disabled = CanBeDisabled::No);
+                        DefaultValue default_value = DefaultValue::AlwaysEnabled);
   ControlGroup(std::string name, std::string ui_name, GroupType type = GroupType::Other,
-               CanBeDisabled can_be_disabled = CanBeDisabled::No);
+               DefaultValue default_value = DefaultValue::AlwaysEnabled);
   virtual ~ControlGroup();
 
   virtual void LoadConfig(IniFile::Section* sec, const std::string& defdev = "",
@@ -92,7 +93,7 @@ public:
   const std::string name;
   const std::string ui_name;
   const GroupType type;
-  const bool can_be_disabled;
+  const DefaultValue default_value;
 
   bool enabled = true;
   std::vector<std::unique_ptr<Control>> controls;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -17,8 +17,15 @@
 namespace ControllerEmu
 {
 IMUCursor::IMUCursor(std::string name, std::string ui_name)
-    : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUCursor,
-                   ControlGroup::CanBeDisabled::Yes)
+    : ControlGroup(
+          std::move(name), std::move(ui_name), GroupType::IMUCursor,
+#ifdef ANDROID
+          // Enabling this on Android devices which have an accelerometer and gyroscope prevents
+          // touch controls from being used for pointing, and touch controls generally work better
+          ControlGroup::DefaultValue::Disabled)
+#else
+          ControlGroup::DefaultValue::Enabled)
+#endif
 {
   AddInput(Translate, _trans("Recenter"));
 


### PR DESCRIPTION
While having motion control emulation of IR enabled by default makes sense in situations like using a DualShock 4 on a PC, Android has the additional option of touch emulation of IR which seems to be better liked, and the default value which was chosen with PC in mind was carried over to Android without any particular consideration. This change disables motion control emulation of IR by default on Android only.