### PR TITLE
Core: Skip duplicate frames when using frame advance

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -77,6 +77,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCAdapter.h"
 
+#include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/RenderBase.h"
@@ -104,6 +105,7 @@ static std::thread s_cpu_thread;
 static bool s_request_refresh_info = false;
 static bool s_is_throttler_temp_disabled = false;
 static bool s_frame_step = false;
+static std::atomic<bool> s_stop_frame_step;
 
 #ifdef USE_MEMORYWATCHER
 static std::unique_ptr<MemoryWatcher> s_memory_watcher;
@@ -863,18 +865,28 @@ void VideoThrottle()
 void Callback_FramePresented()
 {
   s_drawn_frame++;
+  s_stop_frame_step.store(true);
 }
 
 // Called from VideoInterface::Update (CPU thread) at emulated field boundaries
 void Callback_NewField()
 {
-  Movie::FrameUpdate();
   if (s_frame_step)
   {
-    s_frame_step = false;
-    CPU::Break();
-    if (s_on_state_changed_callback)
-      s_on_state_changed_callback(Core::GetState());
+    // To ensure that s_stop_frame_step is up to date, wait for the GPU thread queue to empty,
+    // since it is may contain a swap event (which will call Callback_FramePresented). This hurts
+    // the performance a little, but luckily, performance matters less when using frame stepping.
+    AsyncRequests::GetInstance()->WaitForEmptyQueue();
+
+    // Only stop the frame stepping if a new frame was displayed
+    // (as opposed to the previous frame being displayed for another frame).
+    if (s_stop_frame_step.load())
+    {
+      s_frame_step = false;
+      CPU::Break();
+      if (s_on_state_changed_callback)
+        s_on_state_changed_callback(Core::GetState());
+    }
   }
 }
 
@@ -1045,6 +1057,7 @@ void DoFrameStep()
   if (GetState() == State::Paused)
   {
     // if already paused, frame advance for 1 frame
+    s_stop_frame_step = false;
     s_frame_step = true;
     RequestRefreshInfo();
     SetState(State::Running);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -858,15 +858,15 @@ void VideoThrottle()
 
 // --- Callbacks for backends / engine ---
 
-// Should be called from GPU thread when a frame is drawn
-void Callback_VideoCopiedToXFB(bool video_update)
+// Called from Renderer::Swap (GPU thread) when a new (non-duplicate)
+// frame is presented to the host screen
+void Callback_FramePresented()
 {
-  if (video_update)
-    s_drawn_frame++;
+  s_drawn_frame++;
 }
 
-// Called at field boundaries in `VideoInterface::Update()`
-void FrameUpdate()
+// Called from VideoInterface::Update (CPU thread) at emulated field boundaries
+void Callback_NewField()
 {
   Movie::FrameUpdate();
   if (s_frame_step)

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -25,8 +25,8 @@ namespace Core
 bool GetIsThrottlerTempDisabled();
 void SetIsThrottlerTempDisabled(bool disable);
 
-void Callback_VideoCopiedToXFB(bool video_update);
-void FrameUpdate();
+void Callback_FramePresented();
+void Callback_NewField();
 
 enum class State
 {

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -820,7 +820,7 @@ void Update(u64 ticks)
   // and/or update movie state before dealing with anything else
 
   if (s_half_line_count == 0 || s_half_line_count == GetHalfLinesPerEvenField())
-    Core::FrameUpdate();
+    Core::Callback_NewField();
 
   // If an SI poll is scheduled to happen on this half-line, do it!
 

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -97,6 +97,12 @@ void AsyncRequests::PushEvent(const AsyncRequests::Event& event, bool blocking)
   }
 }
 
+void AsyncRequests::WaitForEmptyQueue()
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  m_cond.wait(lock, [this] { return m_queue.empty(); });
+}
+
 void AsyncRequests::SetEnable(bool enable)
 {
   std::unique_lock<std::mutex> lock(m_mutex);

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -82,6 +82,7 @@ public:
       PullEventsInternal();
   }
   void PushEvent(const Event& event, bool blocking = false);
+  void WaitForEmptyQueue();
   void SetEnable(bool enable);
   void SetPassthrough(bool enable);
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1283,7 +1283,7 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
       {
         // Remove stale EFB/XFB copies.
         g_texture_cache->Cleanup(m_frame_count);
-        Core::Callback_VideoCopiedToXFB(true);
+        Core::Callback_FramePresented();
       }
 
       // Handle any config changes, this gets propogated to the backend.


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/12025

It used to be the case that frame advance skipped duplicate frames (i.e. it would take 30 frame advances to get through one second of emulated time in a 30 fps game), but this broke in PR #8347. Skipping duplicate frames making TASing less annoying.