### PR TITLE
Fix crash when using DSP LLE with CPU interpreter (or fastmem off)

### DIFF
--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -95,7 +95,7 @@ u32 HashAdler32(const u8* data, size_t len)
 
 // Stupid hash - but can't go back now :)
 // Don't use for new things. At least it's reasonably fast.
-u32 HashEctor(const u8* ptr, int length)
+u32 HashEctor(const u8* ptr, size_t length)
 {
   u32 crc = 0;
 

--- a/Source/Core/Common/Hash.h
+++ b/Source/Core/Common/Hash.h
@@ -12,7 +12,7 @@ namespace Common
 {
 u32 HashFletcher(const u8* data_u8, size_t length);  // FAST. Length & 1 == 0.
 u32 HashAdler32(const u8* data, size_t len);         // Fairly accurate, slightly slower
-u32 HashEctor(const u8* ptr, int length);            // JUNK. DO NOT USE FOR NEW THINGS
+u32 HashEctor(const u8* ptr, size_t length);         // JUNK. DO NOT USE FOR NEW THINGS
 u64 GetHash64(const u8* src, u32 len, u32 samples);
 void SetHash64Function();
 }  // namespace Common

--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -68,11 +68,11 @@ bool Compare(const std::vector<u16>& code1, const std::vector<u16>& code2)
   if (code1.size() != code2.size())
     printf("Size difference! 1=%zu 2=%zu\n", code1.size(), code2.size());
   u32 count_equal = 0;
-  const int min_size = std::min<int>((int)code1.size(), (int)code2.size());
+  const u16 min_size = static_cast<u16>(std::min(code1.size(), code2.size()));
 
   AssemblerSettings settings;
   DSPDisassembler disassembler(settings);
-  for (int i = 0; i < min_size; i++)
+  for (u16 i = 0; i < min_size; i++)
   {
     if (code1[i] == code2[i])
     {
@@ -93,7 +93,7 @@ bool Compare(const std::vector<u16>& code1, const std::vector<u16>& code2)
   {
     printf("Extra code words:\n");
     const std::vector<u16>& longest = code1.size() > code2.size() ? code1 : code2;
-    for (int i = min_size; i < (int)longest.size(); i++)
+    for (u16 i = min_size; i < longest.size(); i++)
     {
       u16 pc = i;
       std::string line;
@@ -146,7 +146,7 @@ bool SaveBinary(const std::vector<u16>& code, const std::string& filename)
   return File::WriteStringToFile(filename, buffer);
 }
 
-bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc)
+bool DumpDSPCode(const u8* code_be, size_t size_in_bytes, u32 crc)
 {
   const std::string root_name =
       File::GetUserPath(D_DUMPDSP_IDX) + fmt::format("DSP_UC_{:08X}", crc);

--- a/Source/Core/Core/DSP/DSPCodeUtil.h
+++ b/Source/Core/Core/DSP/DSPCodeUtil.h
@@ -24,5 +24,5 @@ std::vector<u16> BinaryStringBEToCode(const std::string& str);
 std::optional<std::vector<u16>> LoadBinary(const std::string& filename);
 bool SaveBinary(const std::vector<u16>& code, const std::string& filename);
 
-bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc);
+bool DumpDSPCode(const u8* code_be, size_t size_in_bytes, u32 crc);
 }  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -306,9 +306,6 @@ struct SDSP
   u16* dram;
   u16* irom;
   u16* coef;
-
-  // This one doesn't really belong here.
-  u8* cpu_ram;
 };
 
 extern SDSP g_dsp;

--- a/Source/Core/Core/DSP/DSPHost.h
+++ b/Source/Core/Core/DSP/DSPHost.h
@@ -17,10 +17,13 @@ namespace DSP::Host
 {
 u8 ReadHostMemory(u32 addr);
 void WriteHostMemory(u8 value, u32 addr);
+void DMAToDSP(u16* dst, u32 addr, u32 size);
+void DMAFromDSP(const u16* src, u32 addr, u32 size);
 void OSD_AddMessage(std::string str, u32 ms);
 bool OnThread();
 bool IsWiiHost();
 void InterruptRequest();
+void CodeLoaded(u32 addr, size_t size);
 void CodeLoaded(const u8* ptr, size_t size);
 void UpdateDebugger();
 }  // namespace DSP::Host

--- a/Source/Core/Core/DSP/DSPHost.h
+++ b/Source/Core/Core/DSP/DSPHost.h
@@ -21,6 +21,6 @@ void OSD_AddMessage(std::string str, u32 ms);
 bool OnThread();
 bool IsWiiHost();
 void InterruptRequest();
-void CodeLoaded(const u8* ptr, int size);
+void CodeLoaded(const u8* ptr, size_t size);
 void UpdateDebugger();
 }  // namespace DSP::Host

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -16,6 +16,7 @@
 #include "Core/DSP/Jit/x64/DSPEmitter.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
+#include "Core/HW/Memmap.h"
 #include "Core/Host.h"
 #include "VideoCommon/OnScreenDisplay.h"
 
@@ -34,6 +35,16 @@ u8 ReadHostMemory(u32 addr)
 void WriteHostMemory(u8 value, u32 addr)
 {
   DSP::WriteARAM(value, addr);
+}
+
+void DMAToDSP(u16* dst, u32 addr, u32 size)
+{
+  Memory::CopyFromEmuSwapped(dst, addr, size);
+}
+
+void DMAFromDSP(const u16* src, u32 addr, u32 size)
+{
+  Memory::CopyToEmuSwapped(addr, src, size);
 }
 
 void OSD_AddMessage(std::string str, u32 ms)
@@ -57,8 +68,14 @@ void InterruptRequest()
   DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
 }
 
+void CodeLoaded(u32 addr, size_t size)
+{
+  CodeLoaded(Memory::GetPointer(addr), size);
+}
+
 void CodeLoaded(const u8* ptr, size_t size)
 {
+  g_dsp.iram_crc = Common::HashEctor(ptr, size);
   if (SConfig::GetInstance().m_DumpUCode)
   {
     DSP::DumpDSPCode(ptr, size, g_dsp.iram_crc);

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -57,7 +57,7 @@ void InterruptRequest()
   DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
 }
 
-void CodeLoaded(const u8* ptr, int size)
+void CodeLoaded(const u8* ptr, size_t size)
 {
   if (SConfig::GetInstance().m_DumpUCode)
   {

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -78,8 +78,10 @@ void DSPLLE::DoState(PointerWrap& p)
   Common::UnWriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
   p.DoArray(g_dsp.iram, DSP_IRAM_SIZE);
   Common::WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
+  // TODO: This uses the wrong endianness (producing bad disassembly)
+  // and a bogus byte count (producing bad hashes)
   if (p.GetMode() == PointerWrap::MODE_READ)
-    Host::CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
+    Host::CodeLoaded(reinterpret_cast<const u8*>(g_dsp.iram), DSP_IRAM_BYTE_SIZE);
   p.DoArray(g_dsp.dram, DSP_DRAM_SIZE);
   p.Do(g_init_hax);
   p.Do(m_cycle_count);
@@ -186,10 +188,6 @@ bool DSPLLE::Initialize(bool wii, bool dsp_thread)
   m_wii = wii;
   m_is_dsp_on_thread = dsp_thread;
 
-  // DSPLLE directly accesses the fastmem arena.
-  // TODO: The fastmem arena is only supposed to be used by the JIT:
-  // among other issues, its size is only 1GB on 32-bit targets.
-  g_dsp.cpu_ram = Memory::physical_base;
   DSPCore_Reset();
 
   InitInstructionTable();

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -22,6 +22,12 @@ u8 DSP::Host::ReadHostMemory(u32 addr)
 void DSP::Host::WriteHostMemory(u8 value, u32 addr)
 {
 }
+void DSP::Host::DMAToDSP(u16* dst, u32 addr, u32 size)
+{
+}
+void DSP::Host::DMAFromDSP(const u16* src, u32 addr, u32 size)
+{
+}
 void DSP::Host::OSD_AddMessage(std::string str, u32 ms)
 {
 }
@@ -32,6 +38,9 @@ bool DSP::Host::OnThread()
 bool DSP::Host::IsWiiHost()
 {
   return false;
+}
+void DSP::Host::CodeLoaded(u32 addr, size_t size)
+{
 }
 void DSP::Host::CodeLoaded(const u8* ptr, size_t size)
 {

--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -33,7 +33,7 @@ bool DSP::Host::IsWiiHost()
 {
   return false;
 }
-void DSP::Host::CodeLoaded(const u8* ptr, int size)
+void DSP::Host::CodeLoaded(const u8* ptr, size_t size)
 {
 }
 void DSP::Host::InterruptRequest()


### PR DESCRIPTION
Fixes [#11980](https://bugs.dolphin-emu.org/issues/11980).  `Memory::physical_base` does not exist when fastmem is disabled.

Note that I remove some SSSE3 code (originally added 9 years ago in 559fb7434e404e81bf2c742f076a630cc6999d78).  My machine is too old to support SSSE3, so I haven't tested the performance impact, but I don't think it's likely to make a difference in this one case (since it's not used by DSP HLE).  If it actually does matter, then `CopyFromEmuSwapped` and `CopyToEmuSwapped` should be changed to use it instead.