### PR TITLE
Android: Reload Wii Remote settings upon saving them

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -181,6 +181,7 @@ public class Settings
 
       // Notify the native code of the changes
       NativeLibrary.ReloadConfig();
+      NativeLibrary.ReloadWiimoteConfig();
     }
     else
     {

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -597,6 +597,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_RefreshWiimo
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ReloadWiimoteConfig(JNIEnv* env,
                                                                                         jobject obj)
 {
+  WiimoteReal::LoadSettings();
   Wiimote::LoadConfig();
 }
 


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12043.

@JosJuice thanks for the help.