### PR TITLE
Fix bug 11920

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -343,9 +343,12 @@ void DSPLLE::PauseAndLock(bool do_lock, bool unpause_on_unlock)
   {
     m_dsp_thread_mutex.unlock();
 
-    // Signal the DSP thread so it can perform any outstanding work now (if any)
-    s_ppc_event.Wait();
-    s_dsp_event.Set();
+    if (m_is_dsp_on_thread)
+    {
+      // Signal the DSP thread so it can perform any outstanding work now (if any)
+      s_ppc_event.Wait();
+      s_dsp_event.Set();
+    }
   }
 }
 }  // namespace DSP::LLE


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/11920 - DSP LLE Interpreter does not have a DSP thread, so trying to wait would hang.  (DSP LLE recompiler also has no thread when in determinism mode).