### PR TITLE
IOS KD: Added WC24 Download IOCTL to prevent errors

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -143,6 +143,13 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
     // if ya set the IOS version to a very high value this happens ...
     INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_SHUTDOWN - NI");
     break;
+          
+   case IOCTL_NWC24_DOWNLOAD_NOW_EX:
+    // Writing a non-zero return value to this ioctl prevents Nintendo Channel crashing.
+    // For more information, see https://bugs.dolphin-emu.org/issues/11978.
+    INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_DOWNLOAD_NOW_EX - NI");
+    WriteReturnValue(NWC24::WC24_ERR_FATAL, request.buffer_out);
+    break;
 
   default:
     request.Log(GetDeviceName(), Common::Log::IOS_WC24);

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -24,6 +24,56 @@ public:
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
 private:
+    ///Information from http://forum.wiibrew.org/read.php?27,2146,3605
+    #pragma pack(push, 1)
+    struct WC24Record final
+    {
+        short record_index;
+        short unknown_value_1;
+        int unknown_value_2;
+        char game_title[4];
+        int unknown_value_3;
+        int unknown_value_4;
+        int unknown_value_5;
+        int unknown_value_6;
+        int unknown_value_7;
+        int unknown_value_8;
+        int unknown_value_9;
+        int unknown_value_10;
+        int unknown_value_11;
+        int unknown_value_12;
+        char unknown_value_13[128];
+        char wc24_main_url[236];
+        char wc24_sub_url_files[96];
+    };
+    #pragma pack(pop)
+    #pragma pack(push, 1)
+    struct WC24File final
+    {
+        char magic_word[4]; // 'WcDl'
+        int unknown_value_1;
+        int unknown_value_2;
+        int unknown_value_3;
+        short unknown_value_4;
+        short wc24_header_file_offset;
+        short wc24_record_count;
+        short unknown_value_5;
+    };
+    #pragma pack(pop)
+    #pragma pack(push, 1)
+    struct WC24Header final
+    {
+        char game_title[4];
+        u32 memory_address_1;
+        u32 memory_address_2;
+        u8 record_pointer;
+        u8 padding[3];
+    };
+    #pragma pack(pop)
+    WC24File WC24FileHeader;
+    WC24Header WC24RecordHeader;
+    WC24Record WC24Log;
+
   enum
   {
     IOCTL_NWC24_SUSPEND_SCHEDULAR = 0x01,


### PR DESCRIPTION
All this PR does is write a non-zero return code from IOCTL_NWC24_DOWNLOAD_NOW_EX to indicate to the channel that downloading from WC24 failed.

This is to allow the Nintendo Channel to exit gracefully without the corrupted file message. Other channels might be able to benefit, but I haven't found any others that used the ioctl yet.

See https://bugs.dolphin-emu.org/issues/11978 for more details.

