### PR TITLE
Android: Separate GameCube overlay refresh logic

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -798,7 +798,7 @@ public final class EmulationActivity extends AppCompatActivity
     AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
 
     int currentController =
-            mPreferences.getInt("wiiController", InputOverlay.OVERLAY_WIIMOTE_NUNCHUCK);
+            mPreferences.getInt("wiiController", InputOverlay.OVERLAY_WIIMOTE_NUNCHUK);
 
     int currentValue = mPreferences.getInt("doubleTapButton",
             InputOverlayPointer.DOUBLE_TAP_OPTIONS.get(InputOverlayPointer.DOUBLE_TAP_A));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -119,6 +119,7 @@ public final class SettingsFile
   public static final String KEY_DEBUG_JITREGISTERCACHEOFF = "JitRegisterCacheOff";
 
   public static final String KEY_GCPAD_TYPE = "SIDevice";
+  public static final String KEY_GCPAD_PLAYER_1 = "SIDevice0";
   public static final String KEY_GCPAD_G_TYPE = "PadType";
 
   public static final String KEY_GCBIND_A = "InputA_";

--- a/Source/Android/app/src/main/res/menu/menu_emulation.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation.xml
@@ -82,9 +82,9 @@
     </item>
 
     <item
-        android:id="@+id/menu_emulation_configure_controls"
+        android:id="@+id/menu_emulation_overlay_controls"
         app:showAsAction="never"
-        android:title="@string/emulation_configure_controls">
+        android:title="@string/emulation_overlay_controls">
         <menu>
             <item
                 android:id="@+id/menu_emulation_edit_layout"

--- a/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
@@ -82,9 +82,9 @@
     </item>
 
     <item
-        android:id="@+id/menu_emulation_configure_controls"
+        android:id="@+id/menu_emulation_overlay_controls"
         app:showAsAction="never"
-        android:title="@string/emulation_configure_controls">
+        android:title="@string/emulation_overlay_controls">
         <menu>
             <item
                 android:id="@+id/menu_emulation_edit_layout"

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -277,6 +277,7 @@
         <item>Horizontal Wii Remote</item>
         <item>Wii Remote + Nunchuk</item>
         <item>Classic Controller</item>
+        <item>None</item>
     </string-array>
     <string-array name="controllersValues">
         <item>None</item>
@@ -284,6 +285,7 @@
         <item>None</item>
         <item>Nunchuk</item>
         <item>Classic</item>
+        <item>None</item>
     </string-array>
 
     <string-array name="gcpadButtons">

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -332,7 +332,7 @@
     <string name="emulation_quicksave">Quick Save</string>
     <string name="emulation_quickload">Quick Load</string>
     <string name="emulation_refresh_wiimotes">Refresh Wii Remotes</string>
-    <string name="emulation_configure_controls">Configure Controls</string>
+    <string name="emulation_overlay_controls">Overlay Controls</string>
     <string name="emulation_edit_layout">Edit Layout</string>
     <string name="emulation_done">Done</string>
     <string name="emulation_toggle_controls">Toggle Controls</string>
@@ -378,5 +378,6 @@
     <string name="yaw">Total Yaw</string>
     <string name="vertical_offset">Vertical Offset</string>
     <string name="disc_number">Disc %1$d</string>
+    <string name="disabled_gc_overlay_notice">GameCube Controller 1 is set to \"None\"</string>
 
 </resources>


### PR DESCRIPTION
Wii overlay changes will be made in a subsequent PR.

Other minor changes:
- Renamed emulation menu's "Configure Controls" to "Overlay Controls", since the former could be misinterpreted as applying to all players.
- Added a "None" controller. It is primarily used for disabled controllers and real controllers (as an overlay is useless if Player 1 is using a real controller).