### PR TITLE
DolphinQt: Added checkbox to filter out NetPlay sessions that are already in-game.

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -86,6 +86,7 @@ void NetPlayBrowser::CreateWidgets()
   m_edit_name = new QLineEdit;
   m_edit_game_id = new QLineEdit;
   m_check_hide_incompatible = new QCheckBox(tr("Hide Incompatible Sessions"));
+  m_check_hide_ingame = new QCheckBox(tr("Hide In-Game Sessions"));
 
   m_check_hide_incompatible->setChecked(true);
 
@@ -110,6 +111,7 @@ void NetPlayBrowser::CreateWidgets()
   filter_layout->addWidget(m_radio_private, 3, 3);
   filter_layout->addItem(new QSpacerItem(4, 1, QSizePolicy::Expanding), 3, 4);
   filter_layout->addWidget(m_check_hide_incompatible, 4, 1, 1, -1);
+  filter_layout->addWidget(m_check_hide_ingame, 5, 1, 1, -1);
 
   layout->addWidget(m_table_widget);
   layout->addWidget(filter_box);
@@ -134,6 +136,7 @@ void NetPlayBrowser::ConnectWidgets()
   connect(m_radio_all, &QRadioButton::toggled, this, &NetPlayBrowser::Refresh);
   connect(m_radio_private, &QRadioButton::toggled, this, &NetPlayBrowser::Refresh);
   connect(m_check_hide_incompatible, &QRadioButton::toggled, this, &NetPlayBrowser::Refresh);
+  connect(m_check_hide_ingame, &QRadioButton::toggled, this, &NetPlayBrowser::Refresh);
 
   connect(m_edit_name, &QLineEdit::textChanged, this, &NetPlayBrowser::Refresh);
   connect(m_edit_game_id, &QLineEdit::textChanged, this, &NetPlayBrowser::Refresh);
@@ -161,6 +164,9 @@ void NetPlayBrowser::Refresh()
 
   if (m_region_combo->currentIndex() != 0)
     filters["region"] = m_region_combo->currentData().toString().toStdString();
+
+  if (m_check_hide_ingame->isChecked())
+    filters["in_game"] = "0";
 
   std::unique_lock<std::mutex> lock(m_refresh_filters_mutex);
   m_refresh_filters = std::move(filters);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.h
@@ -54,6 +54,7 @@ private:
   QLineEdit* m_edit_name;
   QLineEdit* m_edit_game_id;
   QCheckBox* m_check_hide_incompatible;
+  QCheckBox* m_check_hide_ingame;
 
   QRadioButton* m_radio_all;
   QRadioButton* m_radio_private;


### PR DESCRIPTION
A checkbox has been added to the **NetPlay Session Browser** dialog, so that in-game sessions can be filtered out from the list.

![HideInGameSessions](https://user-images.githubusercontent.com/1853278/79081941-3df44480-7d22-11ea-84d2-0203608ff6e7.gif)