### PR TITLE
IOS/USBHost: Skip starting threads when determinism is enabled

### DIFF
--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -35,7 +35,7 @@ USBHost::~USBHost() = default;
 
 IPCCommandResult USBHost::Open(const OpenRequest& request)
 {
-  if (!m_has_initialised)
+  if (!m_has_initialised && !Core::WantsDeterminism())
   {
     StartThreads();
     // Force a device scan to complete, because some games (including Your Shape) only care


### PR DESCRIPTION
The threads can't actually be started when determinism is enabled, as the behavior would not be deterministic, but Open() still tries to start the threads and wait, resulting in a deadlock when booting certain games and homebrew in NetPlay.