### PR TITLE
VideoBackends: Disable GPU Texture Decoding under MoltenVK

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -346,6 +346,10 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   // with depth clamping. Fall back to inverted depth range for these.
   if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_REVERSED_DEPTH_RANGE))
     config->backend_info.bSupportsReversedDepthRange = false;
+
+  // GPU Texture Decoding is broken under MoltenVK.
+  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_GPU_TEXTURE_DECODING))
+    config->backend_info.bSupportsGPUTextureDecoding = false;
 }
 
 void VulkanContext::PopulateBackendInfoMultisampleModes(

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -117,7 +117,10 @@ constexpr BugInfo m_known_bugs[] = {
     {API_VULKAN, OS_ALL, VENDOR_ARM, DRIVER_ARM, Family::UNKNOWN, BUG_SLOW_CACHED_READBACK_MEMORY,
      -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN,
-     BUG_SLOW_CACHED_READBACK_MEMORY, -1.0, -1.0, true}};
+     BUG_SLOW_CACHED_READBACK_MEMORY, -1.0, -1.0, true},
+    {API_VULKAN, OS_OSX, VENDOR_ALL, DRIVER_PORTABILITY, Family::UNKNOWN,
+     BUG_BROKEN_GPU_TEXTURE_DECODING, -1.0, -1.0, true},
+};
 
 static std::map<Bug, BugInfo> m_bugs;
 

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -286,6 +286,10 @@ enum Bug
   // Mali Vulkan driver, causing high CPU usage in the __pi___inval_cache_range kernel
   // function. This flag causes readback buffers to select the coherent type.
   BUG_SLOW_CACHED_READBACK_MEMORY,
+
+  // BUG: GPU Texture Decoding produces a spectacular mess or just outright crashes when using
+  // Vulkan on macOS through MoltenVK.
+  BUG_BROKEN_GPU_TEXTURE_DECODING,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
It's broken and causes spectacular artifacts and crashes. Here's an example of what those look like: ![](https://dolphin-emu.org/m/user/blog/progress-report/2018-november/gputexturedecoding-melee_thumb.jpg)

I don't know if the problem has been fixed upstream in MoltenVK. If someone else wants to look into that, by all means, I lack the in-depth knowledge of the video backends to do that myself. In the meantime this seems like a reasonable solution to most of the reports of crashes when using Vulkan on MacOS, due to users not being aware the feature is broken.