### PR TITLE
DolphinQt: Saving and restoring NetPlay Session Browser dialog's settings.

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1162,6 +1162,7 @@ void MainWindow::ShowNetPlaySetupDialog()
 void MainWindow::ShowNetPlayBrowser()
 {
   auto* browser = new NetPlayBrowser(this);
+  browser->setAttribute(Qt::WA_DeleteOnClose, true);
   connect(browser, &NetPlayBrowser::Join, this, &MainWindow::NetPlayJoin);
   browser->exec();
 }

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.h
@@ -46,6 +46,9 @@ private:
 
   void OnSelectionChanged();
 
+  void SaveSettings() const;
+  void RestoreSettings();
+
   QComboBox* m_region_combo;
   QLabel* m_status_label;
   QPushButton* m_button_refresh;


### PR DESCRIPTION
The **NetPlay Session Browser** dialog's settings are now saved and restored when the widget is created/destroyed. This includes the widget's geometry, as well as the filter settings.