### PR TITLE
Support controlling Free Look via input bindings (motion controls, gamepad, etc!)

### DIFF
--- a/Source/Core/Common/Matrix.cpp
+++ b/Source/Core/Common/Matrix.cpp
@@ -4,6 +4,8 @@
 
 #include "Common/Matrix.h"
 
+#include "Common/MathUtil.h"
+
 #include <algorithm>
 #include <cmath>
 
@@ -119,6 +121,32 @@ Vec3 operator*(const Quaternion& lhs, const Vec3& rhs)
 {
   const auto result = lhs * Quaternion(0, rhs.x, rhs.y, rhs.z) * lhs.Conjugate();
   return Vec3(result.data.x, result.data.y, result.data.z);
+}
+
+Vec3 FromQuaternionToEuler(const Quaternion& q)
+{
+  Vec3 result;
+
+  const float qx = q.data.x;
+  const float qy = q.data.y;
+  const float qz = q.data.z;
+  const float qw = q.data.w;
+
+  const float sinr_cosp = 2 * (qw * qx + qy * qz);
+  const float cosr_cosp = 1 - 2 * (qx * qx + qy * qy);
+  result.x = std::atan2(sinr_cosp, cosr_cosp);
+
+  const float sinp = 2 * (qw * qy - qz * qx);
+  if (std::abs(sinp) >= 1)
+    result.y = std::copysign(MathUtil::PI / 2, sinp);  // use 90 degrees if out of range
+  else
+    result.y = std::asin(sinp);
+
+  const float siny_cosp = 2 * (qw * qz + qx * qy);
+  const float cosy_cosp = 1 - 2 * (qy * qy + qz * qz);
+  result.z = std::atan2(siny_cosp, cosy_cosp);
+
+  return result;
 }
 
 Matrix33 Matrix33::Identity()

--- a/Source/Core/Common/Matrix.h
+++ b/Source/Core/Common/Matrix.h
@@ -359,6 +359,8 @@ public:
 Quaternion operator*(Quaternion lhs, const Quaternion& rhs);
 Vec3 operator*(const Quaternion& lhs, const Vec3& rhs);
 
+Vec3 FromQuaternionToEuler(const Quaternion& q);
+
 class Matrix33
 {
 public:

--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -222,40 +222,40 @@ void FreeLookController::Update()
 
   g_freelook_camera.Rotate(gyro_motion_quat);
   if (m_move_buttons->controls[MoveButtons::Up]->GetState<bool>())
-    g_freelook_camera.MoveVertical(-g_freelook_camera.GetSpeed());
+    g_freelook_camera.MoveVertical(-g_freelook_camera.GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Down]->GetState<bool>())
-    g_freelook_camera.MoveVertical(g_freelook_camera.GetSpeed());
+    g_freelook_camera.MoveVertical(g_freelook_camera.GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Left]->GetState<bool>())
-    g_freelook_camera.MoveHorizontal(g_freelook_camera.GetSpeed());
+    g_freelook_camera.MoveHorizontal(g_freelook_camera.GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Right]->GetState<bool>())
-    g_freelook_camera.MoveHorizontal(-g_freelook_camera.GetSpeed());
+    g_freelook_camera.MoveHorizontal(-g_freelook_camera.GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Forward]->GetState<bool>())
-    g_freelook_camera.MoveForward(g_freelook_camera.GetSpeed());
+    g_freelook_camera.MoveForward(g_freelook_camera.GetSpeed() * dt);
 
   if (m_move_buttons->controls[MoveButtons::Backward]->GetState<bool>())
-    g_freelook_camera.MoveForward(-g_freelook_camera.GetSpeed());
+    g_freelook_camera.MoveForward(-g_freelook_camera.GetSpeed() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::IncreaseX]->GetState<bool>())
-    g_freelook_camera.IncreaseFovX(g_freelook_camera.GetFovStepSize());
+    g_freelook_camera.IncreaseFovX(g_freelook_camera.GetFovStepSize() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::DecreaseX]->GetState<bool>())
-    g_freelook_camera.IncreaseFovX(-1.0f * g_freelook_camera.GetFovStepSize());
+    g_freelook_camera.IncreaseFovX(-1.0f * g_freelook_camera.GetFovStepSize() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::IncreaseY]->GetState<bool>())
-    g_freelook_camera.IncreaseFovY(g_freelook_camera.GetFovStepSize());
+    g_freelook_camera.IncreaseFovY(g_freelook_camera.GetFovStepSize() * dt);
 
   if (m_fov_buttons->controls[FieldOfViewButtons::DecreaseY]->GetState<bool>())
-    g_freelook_camera.IncreaseFovY(-1.0f * g_freelook_camera.GetFovStepSize());
+    g_freelook_camera.IncreaseFovY(-1.0f * g_freelook_camera.GetFovStepSize() * dt);
 
   if (m_speed_buttons->controls[SpeedButtons::Decrease]->GetState<bool>())
-    g_freelook_camera.ModifySpeed(1.0f / 1.1f);
+    g_freelook_camera.ModifySpeed(g_freelook_camera.GetSpeed() * -0.9 * dt);
 
   if (m_speed_buttons->controls[SpeedButtons::Increase]->GetState<bool>())
-    g_freelook_camera.ModifySpeed(1.1f);
+    g_freelook_camera.ModifySpeed(g_freelook_camera.GetSpeed() * 1.1 * dt);
 
   if (m_speed_buttons->controls[SpeedButtons::Reset]->GetState<bool>())
     g_freelook_camera.ResetSpeed();

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <chrono>
+#include <optional>
+
 #include "Common/CommonTypes.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 
@@ -13,6 +16,7 @@ namespace ControllerEmu
 {
 class ControlGroup;
 class Buttons;
+class IMUGyroscope;
 }  // namespace ControllerEmu
 
 enum class FreeLookGroup
@@ -20,7 +24,8 @@ enum class FreeLookGroup
   Move,
   Speed,
   FieldOfView,
-  Other
+  Other,
+  Rotation,
 };
 
 namespace FreeLook
@@ -52,6 +57,8 @@ private:
   ControllerEmu::Buttons* m_speed_buttons;
   ControllerEmu::Buttons* m_fov_buttons;
   ControllerEmu::Buttons* m_other_buttons;
+  ControllerEmu::IMUGyroscope* m_rotation_gyro;
 
   const unsigned int m_index;
+  std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;
 };

--- a/Source/Core/Core/HW/SI/SI.cpp
+++ b/Source/Core/Core/HW/SI/SI.cpp
@@ -655,6 +655,7 @@ void UpdateDevices()
 
   // Update inputs at the rate of SI
   // Typically 120hz but is variable
+  g_controller_interface.SetCurrentInputChannel(ciface::InputChannel::SerialInterface);
   g_controller_interface.UpdateInput();
 
   // Update channels and set the status bit if there's new data

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -339,6 +339,7 @@ void BluetoothEmuDevice::Update()
 
   if (now - m_last_ticks > interval)
   {
+    g_controller_interface.SetCurrentInputChannel(ciface::InputChannel::Bluetooth);
     g_controller_interface.UpdateInput();
     for (auto& wiimote : m_wiimotes)
       wiimote->UpdateInput();

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -122,6 +122,8 @@ add_executable(dolphin-emu
   Config/LogWidget.h
   Config/Mapping/FreeLookGeneral.cpp
   Config/Mapping/FreeLookGeneral.h
+  Config/Mapping/FreeLookRotation.cpp
+  Config/Mapping/FreeLookRotation.h
   Config/Mapping/GCKeyboardEmu.cpp
   Config/Mapping/GCKeyboardEmu.h
   Config/Mapping/GCMicrophone.cpp

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.cpp
@@ -1,0 +1,62 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Mapping/FreeLookRotation.h"
+
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+
+#include "Core/FreeLookManager.h"
+#include "DolphinQt/Config/ControllerInterface/ControllerInterfaceWindow.h"
+#include "InputCommon/InputConfig.h"
+
+FreeLookRotation::FreeLookRotation(MappingWindow* window) : MappingWidget(window)
+{
+  CreateMainLayout();
+}
+
+void FreeLookRotation::CreateMainLayout()
+{
+  m_main_layout = new QGridLayout;
+
+  auto* alternate_input_layout = new QHBoxLayout();
+  auto* note_label = new QLabel(
+      tr("Note: motion input may require configuring alternate input sources before use."));
+  note_label->setWordWrap(true);
+  auto* alternate_input_sources_button = new QPushButton(tr("Alternate Input Sources"));
+  alternate_input_layout->addWidget(note_label, 1);
+  alternate_input_layout->addWidget(alternate_input_sources_button, 0, Qt::AlignRight);
+  connect(alternate_input_sources_button, &QPushButton::clicked, this, [this] {
+    ControllerInterfaceWindow* window = new ControllerInterfaceWindow(this);
+    window->setAttribute(Qt::WA_DeleteOnClose, true);
+    window->setWindowModality(Qt::WindowModality::WindowModal);
+    window->show();
+  });
+  m_main_layout->addLayout(alternate_input_layout, 0, 0, 1, -1);
+
+  m_main_layout->addWidget(
+      CreateGroupBox(tr("Incremental Rotation (rad/sec)"),
+                     FreeLook::GetInputGroup(GetPort(), FreeLookGroup::Rotation)),
+      1, 0);
+
+  setLayout(m_main_layout);
+}
+
+InputConfig* FreeLookRotation::GetConfig()
+{
+  return FreeLook::GetInputConfig();
+}
+
+void FreeLookRotation::LoadSettings()
+{
+  FreeLook::LoadInputConfig();
+}
+
+void FreeLookRotation::SaveSettings()
+{
+  FreeLook::GetInputConfig()->SaveConfig();
+}

--- a/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.h
+++ b/Source/Core/DolphinQt/Config/Mapping/FreeLookRotation.h
@@ -1,0 +1,26 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinQt/Config/Mapping/MappingWidget.h"
+
+class QGridLayout;
+
+class FreeLookRotation final : public MappingWidget
+{
+  Q_OBJECT
+public:
+  explicit FreeLookRotation(MappingWindow* window);
+
+  InputConfig* GetConfig() override;
+
+private:
+  void LoadSettings() override;
+  void SaveSettings() override;
+  void CreateMainLayout();
+
+  // Main
+  QGridLayout* m_main_layout;
+};

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -23,6 +23,7 @@
 #include "Common/StringUtil.h"
 
 #include "DolphinQt/Config/Mapping/FreeLookGeneral.h"
+#include "DolphinQt/Config/Mapping/FreeLookRotation.h"
 #include "DolphinQt/Config/Mapping/GCKeyboardEmu.h"
 #include "DolphinQt/Config/Mapping/GCMicrophone.h"
 #include "DolphinQt/Config/Mapping/GCPadEmu.h"
@@ -436,6 +437,7 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
   {
     widget = new FreeLookGeneral(this);
     AddWidget(tr("General"), widget);
+    AddWidget(tr("Rotation"), new FreeLookRotation(this));
     setWindowTitle(tr("Free Look Controller %1").arg(GetPort() + 1));
   }
   break;

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="Config\LogConfigWidget.cpp" />
     <ClCompile Include="Config\LogWidget.cpp" />
     <ClCompile Include="Config\Mapping\FreeLookGeneral.cpp" />
+    <ClCompile Include="Config\Mapping\FreeLookRotation.cpp" />
     <ClCompile Include="Config\Mapping\GCKeyboardEmu.cpp" />
     <ClCompile Include="Config\Mapping\GCMicrophone.cpp" />
     <ClCompile Include="Config\Mapping\GCPadEmu.cpp" />
@@ -254,6 +255,7 @@
     <QtMoc Include="Config\LogConfigWidget.h" />
     <QtMoc Include="Config\LogWidget.h" />
     <QtMoc Include="Config\Mapping\FreeLookGeneral.h" />
+    <QtMoc Include="Config\Mapping\FreeLookRotation.h" />
     <QtMoc Include="Config\Mapping\GCKeyboardEmu.h" />
     <QtMoc Include="Config\Mapping\GCMicrophone.h" />
     <QtMoc Include="Config\Mapping\GCPadEmu.h" />

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -141,6 +141,10 @@ void HotkeyScheduler::Run()
   {
     Common::SleepCurrentThread(1000 / 60);
 
+    g_controller_interface.SetCurrentInputChannel(ciface::InputChannel::FreeLook);
+    g_controller_interface.UpdateInput();
+    FreeLook::UpdateInput();
+
     g_controller_interface.SetCurrentInputChannel(ciface::InputChannel::Host);
     g_controller_interface.UpdateInput();
 
@@ -545,8 +549,6 @@ void HotkeyScheduler::Run()
       Config::SetCurrent(Config::FREE_LOOK_ENABLED, new_value);
       OSD::AddMessage(StringFromFormat("Free Look: %s", new_value ? "Enabled" : "Disabled"));
     }
-
-    FreeLook::UpdateInput();
 
     // Savestates
     for (u32 i = 0; i < State::NUM_STATES; i++)

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -141,8 +141,8 @@ void HotkeyScheduler::Run()
   {
     Common::SleepCurrentThread(1000 / 60);
 
-    if (Core::GetState() == Core::State::Uninitialized || Core::GetState() == Core::State::Paused)
-      g_controller_interface.UpdateInput();
+    g_controller_interface.SetCurrentInputChannel(ciface::InputChannel::Host);
+    g_controller_interface.UpdateInput();
 
     if (!HotkeyManagerEmu::IsEnabled())
       continue;

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -139,7 +139,7 @@ void HotkeyScheduler::Run()
 
   while (!m_stop_requested.IsSet())
   {
-    Common::SleepCurrentThread(1000 / 60);
+    Common::SleepCurrentThread(5);
 
     g_controller_interface.SetCurrentInputChannel(ciface::InputChannel::FreeLook);
     g_controller_interface.UpdateInput();

--- a/Source/Core/DolphinQt/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt/HotkeyScheduler.h
@@ -8,6 +8,7 @@
 
 #include <QObject>
 
+#include "Common/CommonTypes.h"
 #include "Common/Flag.h"
 #include "InputCommon/InputProfile.h"
 

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -32,9 +32,7 @@
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
-#include "VideoCommon/FreeLookCamera.h"
 #include "VideoCommon/RenderBase.h"
-#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
 
 RenderWidget::RenderWidget(QWidget* parent) : QWidget(parent)
@@ -180,11 +178,6 @@ bool RenderWidget::event(QEvent* event)
 
     break;
   }
-  case QEvent::MouseMove:
-    if (g_freelook_camera.IsActive())
-      OnFreeLookMouseMove(static_cast<QMouseEvent*>(event));
-    [[fallthrough]];
-
   case QEvent::MouseButtonPress:
     if (!Settings::Instance().GetHideCursor() && isActiveWindow())
     {
@@ -235,23 +228,6 @@ bool RenderWidget::event(QEvent* event)
     break;
   }
   return QWidget::event(event);
-}
-
-void RenderWidget::OnFreeLookMouseMove(QMouseEvent* event)
-{
-  const auto mouse_move = event->pos() - m_last_mouse;
-  m_last_mouse = event->pos();
-
-  if (event->buttons() & Qt::RightButton)
-  {
-    // Camera Pitch and Yaw:
-    g_freelook_camera.Rotate(Common::Vec3{mouse_move.y() / 200.f, mouse_move.x() / 200.f, 0.f});
-  }
-  else if (event->buttons() & Qt::MiddleButton)
-  {
-    // Camera Roll:
-    g_freelook_camera.Rotate({0.f, 0.f, mouse_move.x() / 200.f});
-  }
 }
 
 void RenderWidget::PassEventToImGui(const QEvent* event)

--- a/Source/Core/DolphinQt/RenderWidget.h
+++ b/Source/Core/DolphinQt/RenderWidget.h
@@ -33,7 +33,6 @@ private:
   void HandleCursorTimer();
   void OnHideCursorChanged();
   void OnKeepOnTopChanged(bool top);
-  void OnFreeLookMouseMove(QMouseEvent* event);
   void PassEventToImGui(const QEvent* event);
   void SetImGuiKeyMap();
   void dragEnterEvent(QDragEnterEvent* event) override;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -4,6 +4,7 @@
 
 #include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "Common/Common.h"
@@ -124,7 +125,8 @@ auto IMUGyroscope::GetRawState() const -> StateData
 
 std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState() const
 {
-  if (controls[0]->control_ref->BoundCount() == 0)
+  if (std::all_of(controls.begin(), controls.end(),
+                  [](const auto& control) { return control->control_ref->BoundCount() == 0; }))
   {
     // Set calibration to zero.
     m_calibration = {};

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -37,6 +37,8 @@
 
 ControllerInterface g_controller_interface;
 
+static thread_local ciface::InputChannel tls_input_channel = ciface::InputChannel::Host;
+
 void ControllerInterface::Initialize(const WindowSystemInfo& wsi)
 {
   if (m_is_init)
@@ -272,6 +274,16 @@ void ControllerInterface::UpdateInput()
     for (const auto& d : m_devices)
       d->UpdateInput();
   }
+}
+
+void ControllerInterface::SetCurrentInputChannel(ciface::InputChannel input_channel)
+{
+  tls_input_channel = input_channel;
+}
+
+ciface::InputChannel ControllerInterface::GetCurrentInputChannel()
+{
+  return tls_input_channel;
 }
 
 void ControllerInterface::SetAspectRatioAdjustment(float value)

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -93,6 +93,12 @@ public:
     virtual bool IsChild(const Input*) const { return false; }
   };
 
+  class RelativeInput : public Input
+  {
+  public:
+    bool IsDetectable() const override { return false; }
+  };
+
   //
   // Output
   //

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -7,6 +7,7 @@
 #include <windows.h>
 
 #include "Common/Matrix.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 #include "InputCommon/ControllerInterface/DInput/DInput8.h"
 
@@ -14,14 +15,23 @@ namespace ciface::DInput
 {
 void InitKeyboardMouse(IDirectInput8* const idi8, HWND hwnd);
 
+using RelativeMouseState = RelativeInputState<Common::TVec3<LONG>>;
+
 class KeyboardMouse : public Core::Device
 {
 private:
   struct State
   {
     BYTE keyboard[256];
+
+    // Old smoothed relative mouse movement.
     DIMOUSESTATE2 mouse;
+
+    // Normalized mouse cursor position.
     Common::TVec2<ControlState> cursor;
+
+    // Raw relative mouse movement.
+    RelativeMouseState relative_mouse;
   };
 
   class Key : public Input
@@ -53,6 +63,7 @@ private:
   public:
     Axis(u8 index, const LONG& axis, LONG range) : m_axis(axis), m_range(range), m_index(index) {}
     std::string GetName() const override;
+    bool IsDetectable() const override { return false; }
     ControlState GetState() const override;
 
   private:

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -30,6 +30,7 @@ private:
     unsigned int buttons;
     Common::Vec2 cursor;
     Common::Vec2 axis;
+    Common::Vec2 relative_mouse;
   };
 
   class Key : public Input
@@ -82,6 +83,21 @@ private:
     std::string GetName() const override { return name; }
     bool IsDetectable() const override { return false; }
     Axis(u8 index, bool positive, const float* axis);
+    ControlState GetState() const override;
+
+  private:
+    const float* m_axis;
+    const u8 m_index;
+    const bool m_positive;
+    std::string name;
+  };
+
+  class RelativeMouse : public Input
+  {
+  public:
+    std::string GetName() const override { return name; }
+    bool IsDetectable() const override { return false; }
+    RelativeMouse(u8 index, bool positive, const float* axis);
     ControlState GetState() const override;
 
   private:

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -265,18 +265,18 @@ void FreeLookCamera::Rotate(const Common::Quaternion& amt)
 void FreeLookCamera::IncreaseFovX(float fov)
 {
   m_fov_x += fov;
-  m_fov_x = std::clamp(m_fov_x, m_fov_step_size, m_fov_x);
+  m_fov_x = std::clamp(m_fov_x, m_min_fov_multiplier, m_fov_x);
 }
 
 void FreeLookCamera::IncreaseFovY(float fov)
 {
   m_fov_y += fov;
-  m_fov_y = std::clamp(m_fov_y, m_fov_step_size, m_fov_y);
+  m_fov_y = std::clamp(m_fov_y, m_min_fov_multiplier, m_fov_y);
 }
 
 float FreeLookCamera::GetFovStepSize() const
 {
-  return m_fov_step_size;
+  return 1.5f;
 }
 
 void FreeLookCamera::Reset()
@@ -287,14 +287,15 @@ void FreeLookCamera::Reset()
   m_dirty = true;
 }
 
-void FreeLookCamera::ModifySpeed(float multiplier)
+void FreeLookCamera::ModifySpeed(float amt)
 {
-  m_speed *= multiplier;
+  m_speed += amt;
+  m_speed = std::clamp(m_speed, 0.0f, m_speed);
 }
 
 void FreeLookCamera::ResetSpeed()
 {
-  m_speed = 1.0f;
+  m_speed = 60.0f;
 }
 
 float FreeLookCamera::GetSpeed() const

--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -102,15 +102,20 @@ public:
 
   void Rotate(const Common::Vec3& amt) override
   {
+    if (amt.Length() == 0)
+      return;
+
     m_rotation += amt;
 
     using Common::Quaternion;
-    const auto quat =
+    m_rotate_quat =
         (Quaternion::RotateX(m_rotation.x) * Quaternion::RotateY(m_rotation.y)).Normalized();
-    Rotate(quat);
   }
 
-  void Rotate(const Common::Quaternion& quat) override { m_rotate_quat = quat; }
+  void Rotate(const Common::Quaternion& quat) override
+  {
+    Rotate(Common::FromQuaternionToEuler(quat));
+  }
 
   void Reset() override
   {
@@ -153,15 +158,20 @@ public:
 
   void Rotate(const Common::Vec3& amt) override
   {
+    if (amt.Length() == 0)
+      return;
+
     m_rotation += amt;
 
     using Common::Quaternion;
-    const auto quat =
+    m_rotate_quat =
         (Quaternion::RotateX(m_rotation.x) * Quaternion::RotateY(m_rotation.y)).Normalized();
-    Rotate(quat);
   }
 
-  void Rotate(const Common::Quaternion& quat) override { m_rotate_quat = quat; }
+  void Rotate(const Common::Quaternion& quat) override
+  {
+    Rotate(Common::FromQuaternionToEuler(quat));
+  }
 
   void Reset() override
   {
@@ -241,6 +251,12 @@ void FreeLookCamera::MoveForward(float amt)
 }
 
 void FreeLookCamera::Rotate(const Common::Vec3& amt)
+{
+  m_camera_controller->Rotate(amt);
+  m_dirty = true;
+}
+
+void FreeLookCamera::Rotate(const Common::Quaternion& amt)
 {
   m_camera_controller->Rotate(amt);
   m_dirty = true;

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -52,6 +52,7 @@ public:
   void MoveForward(float amt);
 
   void Rotate(const Common::Vec3& amt);
+  void Rotate(const Common::Quaternion& amt);
 
   void IncreaseFovX(float fov);
   void IncreaseFovY(float fov);

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -78,8 +78,8 @@ private:
   std::optional<FreeLook::ControlType> m_current_type;
   std::unique_ptr<CameraController> m_camera_controller;
 
-  float m_fov_step_size = 0.025f;
-  float m_speed = 1.0f;
+  float m_min_fov_multiplier = 0.025f;
+  float m_speed = 60.0f;
 };
 
 extern FreeLookCamera g_freelook_camera;


### PR DESCRIPTION
I've always thought Free Look was such a cool and underutilized feature.  In an effort to make it more mainstream, I've removed the shackles of requiring to use the mouse.  Now you can assign motion controls (or gamepad) to the Free Look rotation movement.

_Rotation Free Look settings (mouse, gamepad, DSU or bluetooth emulated wiimote!)_
![image](https://user-images.githubusercontent.com/15224722/110973363-c8726900-8322-11eb-83cb-d53d545e1ecd.png)
