### PR TITLE
IOS/FS: Fix FST write failure on some platforms

### DIFF
--- a/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
+++ b/Source/Core/Core/IOS/FS/HostBackend/FS.cpp
@@ -177,9 +177,17 @@ void HostFileSystem::SaveFst()
 
   const std::string dest_path = GetFstFilePath();
   const std::string temp_path = File::GetTempFilenameForAtomicWrite(dest_path);
-  File::IOFile file{temp_path, "wb"};
-  if (!file.WriteArray(to_write.data(), to_write.size()) || !File::Rename(temp_path, dest_path))
-    ERROR_LOG(IOS_FS, "Failed to write new FST");
+  {
+    // This temporary file must be closed before it can be renamed.
+    File::IOFile file{temp_path, "wb"};
+    if (!file.WriteArray(to_write.data(), to_write.size()))
+    {
+      PanicAlert("IOS_FS: Failed to write new FST");
+      return;
+    }
+  }
+  if (!File::Rename(temp_path, dest_path))
+    PanicAlert("IOS_FS: Failed to rename temporary FST file");
 }
 
 HostFileSystem::FstEntry* HostFileSystem::GetFstEntryForPath(const std::string& path)


### PR DESCRIPTION
On some platforms (like Windows), the temporary file must be closed
before it can be renamed.

I guess nobody noticed this for so long because (1) the FS code has a
failsafe for missing FST entries (because existing users do not have
a FST), and most games do not care about file metadata;
(2) the write failures can only be seen in the logs.

Because we don't want this to break, I have turned the ERROR_LOGs into
PanicAlerts.