### PR TITLE
WiimoteEmu: Apply "Tilt" and "Point" rotations separately for proper tilted pointing.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -216,7 +216,7 @@ WiimoteCommon::AccelData ConvertAccelData(const Common::Vec3& accel, u16 zero_g,
        u16(std::clamp(std::lround(scaled_accel.z + zero_g), 0l, MAX_VALUE))});
 }
 
-void EmulateCursor(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed)
+void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed)
 {
   const auto cursor = ir_group->GetState(true);
 

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.h
@@ -83,7 +83,7 @@ void ApproachAngleWithAccel(RotationalState* state, const Common::Vec3& target, 
 void EmulateShake(PositionalState* state, ControllerEmu::Shake* shake_group, float time_elapsed);
 void EmulateTilt(RotationalState* state, ControllerEmu::Tilt* tilt_group, float time_elapsed);
 void EmulateSwing(MotionState* state, ControllerEmu::Force* swing_group, float time_elapsed);
-void EmulateCursor(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed);
+void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed);
 void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_group,
                       ControllerEmu::IMUAccelerometer* imu_accelerometer_group,
                       ControllerEmu::IMUGyroscope* imu_gyroscope_group, float time_elapsed);

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -588,7 +588,7 @@ void Wiimote::DoState(PointerWrap& p)
   // Dynamics
   p.Do(m_swing_state);
   p.Do(m_tilt_state);
-  p.Do(m_cursor_state);
+  p.Do(m_point_state);
   p.Do(m_shake_state);
 
   // We'll consider the IMU state part of the user's physical controller state and not sync it.

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -96,7 +96,8 @@ void Nunchuk::Update()
   EmulateTilt(&m_tilt_state, m_tilt, 1.f / ::Wiimote::UPDATE_FREQ);
   EmulateShake(&m_shake_state, m_shake, 1.f / ::Wiimote::UPDATE_FREQ);
 
-  const auto transformation = GetRotationalMatrix(-m_tilt_state.angle - m_swing_state.angle);
+  const auto transformation =
+      GetRotationalMatrix(-m_tilt_state.angle) * GetRotationalMatrix(-m_swing_state.angle);
 
   Common::Vec3 accel =
       transformation *

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -823,9 +823,9 @@ Common::Matrix44 Wiimote::GetTransformation(const Common::Matrix33& extra_rotati
 
   // TODO: Think about and clean up matrix order + make nunchuk match.
   return Common::Matrix44::Translate(-m_shake_state.position) *
-         Common::Matrix44::FromMatrix33(
-             extra_rotation * GetRotationalMatrix(-m_tilt_state.angle - m_swing_state.angle -
-                                                  m_cursor_state.angle)) *
+         Common::Matrix44::FromMatrix33(extra_rotation * GetRotationalMatrix(-m_tilt_state.angle) *
+                                        GetRotationalMatrix(-m_cursor_state.angle) *
+                                        GetRotationalMatrix(-m_swing_state.angle)) *
          Common::Matrix44::Translate(-m_swing_state.position - m_cursor_state.position);
 }
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -189,7 +189,7 @@ void Wiimote::Reset()
   // Dynamics:
   m_swing_state = {};
   m_tilt_state = {};
-  m_cursor_state = {};
+  m_point_state = {};
   m_shake_state = {};
 
   m_imu_cursor_state = {};
@@ -793,7 +793,7 @@ void Wiimote::StepDynamics()
 {
   EmulateSwing(&m_swing_state, m_swing, 1.f / ::Wiimote::UPDATE_FREQ);
   EmulateTilt(&m_tilt_state, m_tilt, 1.f / ::Wiimote::UPDATE_FREQ);
-  EmulateCursor(&m_cursor_state, m_ir, 1.f / ::Wiimote::UPDATE_FREQ);
+  EmulatePoint(&m_point_state, m_ir, 1.f / ::Wiimote::UPDATE_FREQ);
   EmulateShake(&m_shake_state, m_shake, 1.f / ::Wiimote::UPDATE_FREQ);
   EmulateIMUCursor(&m_imu_cursor_state, m_imu_ir, m_imu_accelerometer, m_imu_gyroscope,
                    1.f / ::Wiimote::UPDATE_FREQ);
@@ -813,7 +813,7 @@ Common::Vec3 Wiimote::GetAcceleration(Common::Vec3 extra_acceleration)
 Common::Vec3 Wiimote::GetAngularVelocity(Common::Vec3 extra_angular_velocity)
 {
   return GetOrientation() * (m_tilt_state.angular_velocity + m_swing_state.angular_velocity +
-                             m_cursor_state.angular_velocity + extra_angular_velocity);
+                             m_point_state.angular_velocity + extra_angular_velocity);
 }
 
 Common::Matrix44 Wiimote::GetTransformation(const Common::Matrix33& extra_rotation) const
@@ -824,9 +824,9 @@ Common::Matrix44 Wiimote::GetTransformation(const Common::Matrix33& extra_rotati
   // TODO: Think about and clean up matrix order + make nunchuk match.
   return Common::Matrix44::Translate(-m_shake_state.position) *
          Common::Matrix44::FromMatrix33(extra_rotation * GetRotationalMatrix(-m_tilt_state.angle) *
-                                        GetRotationalMatrix(-m_cursor_state.angle) *
+                                        GetRotationalMatrix(-m_point_state.angle) *
                                         GetRotationalMatrix(-m_swing_state.angle)) *
-         Common::Matrix44::Translate(-m_swing_state.position - m_cursor_state.position);
+         Common::Matrix44::Translate(-m_swing_state.position - m_point_state.position);
 }
 
 Common::Matrix33 Wiimote::GetOrientation() const

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -296,7 +296,7 @@ private:
   // Dynamics:
   MotionState m_swing_state;
   RotationalState m_tilt_state;
-  MotionState m_cursor_state;
+  MotionState m_point_state;
   PositionalState m_shake_state;
 
   IMUCursorState m_imu_cursor_state;


### PR DESCRIPTION
This should fix: https://bugs.dolphin-emu.org/issues/12058
Made the same changes to emulated Nunchuk to fix a probably rarely used tilted swinging.