### PR TITLE
Remove unnecessary EFB to Texture disabling for Spider-Man 2

### DIFF
--- a/Data/Sys/GameSettings/GK2.ini
+++ b/Data/Sys/GameSettings/GK2.ini
@@ -2,10 +2,3 @@
 
 [Core]
 MMU = 1
-
-[OnFrame]
-
-[ActionReplay]
-
-[Video_Hacks]
-EFBToTextureEnable = False


### PR DESCRIPTION
Removed unnecessary EFBToTextureEnable=False for Spider-Man 2 from GK2.ini, as the game no longer requires it
Also removed empty config blocks

I've been testing with EFB to Texture enabled extensively for some time, and the game works just fine.