### PR TITLE
Jit64: More addx and subfx optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1346,7 +1346,15 @@ void Jit64::addx(UGeckoInstruction inst)
     {
       RCOpArg& Rimm = Ra.IsImm() ? Ra : Rb;
       RCOpArg& Rreg = Ra.IsImm() ? Rb : Ra;
-      LEA(32, Rd, MDisp(Rreg.GetSimpleReg(), Rimm.SImm32()));
+
+      if (Rimm.IsZero())
+      {
+        MOV(32, Rd, Rreg);
+      }
+      else
+      {
+        LEA(32, Rd, MDisp(Rreg.GetSimpleReg(), Rimm.SImm32()));
+      }
     }
     else
     {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1365,7 +1365,10 @@ void Jit64::addx(UGeckoInstruction inst)
       if (imm >= -128 && imm <= 127)
       {
         MOV(32, Rd, Rother);
-        ADD(32, Rd, Rimm);
+        if (imm != 0 || inst.OE)
+        {
+          ADD(32, Rd, Rimm);
+        }
       }
       else
       {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1333,7 +1333,10 @@ void Jit64::addx(UGeckoInstruction inst)
     if ((d == a) || (d == b))
     {
       RCOpArg& Rnotd = (d == a) ? Rb : Ra;
-      ADD(32, Rd, Rnotd);
+      if (!Rnotd.IsZero() || inst.OE)
+      {
+        ADD(32, Rd, Rnotd);
+      }
     }
     else if (Ra.IsSimpleReg() && Rb.IsSimpleReg() && !inst.OE)
     {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1356,6 +1356,23 @@ void Jit64::addx(UGeckoInstruction inst)
         LEA(32, Rd, MDisp(Rreg.GetSimpleReg(), Rimm.SImm32()));
       }
     }
+    else if (Ra.IsImm() || Rb.IsImm())
+    {
+      RCOpArg& Rimm = Ra.IsImm() ? Ra : Rb;
+      RCOpArg& Rother = Ra.IsImm() ? Rb : Ra;
+
+      s32 imm = Rimm.SImm32();
+      if (imm >= -128 && imm <= 127)
+      {
+        MOV(32, Rd, Rother);
+        ADD(32, Rd, Rimm);
+      }
+      else
+      {
+        MOV(32, Rd, Rimm);
+        ADD(32, Rd, Rother);
+      }
+    }
     else
     {
       MOV(32, Rd, Ra);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -932,6 +932,10 @@ void Jit64::subfx(UGeckoInstruction inst)
       MOV(32, Rd, Rb);
       SUB(32, Rd, R(RSCRATCH));
     }
+    else if (Rb.IsSimpleReg() && Ra.IsImm() && !inst.OE)
+    {
+      LEA(32, Rd, MDisp(Rb.GetSimpleReg(), -Ra.SImm32()));
+    }
     else
     {
       MOV(32, Rd, Rb);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1330,13 +1330,10 @@ void Jit64::addx(UGeckoInstruction inst)
     RCX64Reg Rd = gpr.Bind(d, RCMode::Write);
     RegCache::Realize(Ra, Rb, Rd);
 
-    if (d == a)
+    if ((d == a) || (d == b))
     {
-      ADD(32, Rd, Rb);
-    }
-    else if (d == b)
-    {
-      ADD(32, Rd, Ra);
+      RCOpArg& Rnotd = (d == a) ? Rb : Ra;
+      ADD(32, Rd, Rnotd);
     }
     else if (Ra.IsSimpleReg() && Rb.IsSimpleReg() && !inst.OE)
     {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1339,13 +1339,11 @@ void Jit64::addx(UGeckoInstruction inst)
     {
       LEA(32, Rd, MRegSum(Ra.GetSimpleReg(), Rb.GetSimpleReg()));
     }
-    else if (Ra.IsSimpleReg() && Rb.IsImm() && !inst.OE)
+    else if ((Ra.IsSimpleReg() || Rb.IsSimpleReg()) && (Ra.IsImm() || Rb.IsImm()) && !inst.OE)
     {
-      LEA(32, Rd, MDisp(Ra.GetSimpleReg(), Rb.SImm32()));
-    }
-    else if (Rb.IsSimpleReg() && Ra.IsImm() && !inst.OE)
-    {
-      LEA(32, Rd, MDisp(Rb.GetSimpleReg(), Ra.SImm32()));
+      RCOpArg& Rimm = Ra.IsImm() ? Ra : Rb;
+      RCOpArg& Rreg = Ra.IsImm() ? Rb : Ra;
+      LEA(32, Rd, MDisp(Rreg.GetSimpleReg(), Rimm.SImm32()));
     }
     else
     {


### PR DESCRIPTION
Similar to #8551. We start by deduplicating some of the existing logic so the optimizations don't have to be repeated. We then add special handling for constant 0 in several places, carefully swap operands around if it can get us shorter instructions, and use LEA for subfx too.

---
**addx - Emit nothing when possible**

Before:
```
83 C7 00             add         edi,0
```
After:
```
```
---
**addx - Emit MOV when possible**

Before:
```
41 8D 7D 00          lea         edi,[r13]
```
After:
```
41 8B FD             mov         edi,r13d
```
---
**addx - Prefer smaller MOV+ADD sequence**

Before:
```
41 BE 40 00 00 00    mov         r14d,40h
44 03 75 A8          add         r14d,dword ptr [rbp-58h]
```
After:
```
44 8B 75 A8          mov         r14d,dword ptr [rbp-58h]
41 83 C6 40          add         r14d,40h
```

Before:
```
44 8B 7D F8          mov         r15d,dword ptr [rbp-8]
41 81 C7 00 68 00 CC add         r15d,0CC006800h
```
After:
```
41 BF 00 68 00 CC    mov         r15d,0CC006800h
44 03 7D F8          add         r15d,dword ptr [rbp-8]
```
---
**addx - Skip ADD after MOV when possible**

Before:
```
8B 7D F8             mov         edi,dword ptr [rbp-8]
83 C7 00             add         edi,0
```
After:
```
8B 7D F8             mov         edi,dword ptr [rbp-8]
```
---
**subfx - Use LEA when possible**

Before:
```
45 8B EE             mov         r13d,r14d
41 83 ED 08          sub         r13d,8
```
After:
```
45 8D 6E F8          lea         r13d,[r14-8]
```