### PR TITLE
[WIP] Fix network hanging issues

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -301,6 +301,7 @@ void SConfig::SaveNetworkSettings(IniFile& ini)
   network->Set("SSLVerifyCertificates", m_SSLVerifyCert);
   network->Set("SSLDumpRootCA", m_SSLDumpRootCA);
   network->Set("SSLDumpPeerCert", m_SSLDumpPeerCert);
+  network->Set("NetworkTimeout", m_NetworkTimeout);
 }
 
 void SConfig::SaveAnalyticsSettings(IniFile& ini)
@@ -592,6 +593,7 @@ void SConfig::LoadNetworkSettings(IniFile& ini)
   network->Get("SSLVerifyCertificates", &m_SSLVerifyCert, true);
   network->Get("SSLDumpRootCA", &m_SSLDumpRootCA, false);
   network->Get("SSLDumpPeerCert", &m_SSLDumpPeerCert, false);
+  network->Get("NetworkTimeout", &m_NetworkTimeout, 190);
 }
 
 void SConfig::LoadAnalyticsSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -312,6 +312,7 @@ struct SConfig
   bool m_SSLVerifyCert;
   bool m_SSLDumpRootCA;
   bool m_SSLDumpPeerCert;
+  s32 m_NetworkTimeout;
 
   // Auto-update settings
   std::string m_auto_update_track;

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -408,7 +408,8 @@ IPCCommandResult NetIPTop::HandleShutdownRequest(const IOCtlRequest& request)
 
   u32 fd = Memory::Read_U32(request.buffer_in);
   u32 how = Memory::Read_U32(request.buffer_in + 4);
-  int ret = shutdown(WiiSockMan::GetInstance().GetHostSocket(fd), how);
+  WiiSockMan& sm = WiiSockMan::GetInstance();
+  int ret = sm.ShutdownSocket(fd, how);
 
   return GetDefaultReply(WiiSockMan::GetNetErrorCode(ret, "SO_SHUTDOWN", false));
 }

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -61,6 +61,7 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
 
   case IOCTL_NWC24_CLEANUP_SOCKET:
     INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_CLEANUP_SOCKET - NI");
+    WiiSockMan::GetInstance().Clean();
     break;
 
   case IOCTL_NWC24_LOCK_SOCKET:  // WiiMenu

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -196,6 +196,7 @@ private:
   friend class WiiSockMan;
   void SetFd(s32 s);
   void SetWiiFd(s32 s);
+  s32 Shutdown(s32 how);
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 
@@ -234,7 +235,8 @@ public:
   s32 NewSocket(s32 af, s32 type, s32 protocol);
   s32 AddSocket(s32 fd, bool is_rw);
   s32 GetHostSocket(s32 wii_fd) const;
-  s32 DeleteSocket(s32 s);
+  s32 ShutdownSocket(s32 wii_fd, s32 how);
+  s32 DeleteSocket(s32 wii_fd);
   s32 GetLastNetError() const { return errno_last; }
   void SetLastNetError(s32 error) { errno_last = error; }
   void Clean() { WiiSockets.clear(); }

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -42,8 +42,10 @@ typedef struct pollfd pollfd_t;
 #endif
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <list>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -197,14 +199,21 @@ private:
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 
+  bool HasTimeout();
+  void ResetTimeout();
+
   void DoSock(Request request, NET_IOCTL type);
   void DoSock(Request request, SSL_IOCTL type);
   void Update(bool read, bool write, bool except);
   bool IsValid() const { return fd >= 0; }
+
   s32 fd = -1;
   s32 wii_fd = -1;
   bool nonBlock = false;
   std::list<sockop> pending_sockops;
+
+  using timeout_t = std::chrono::time_point<std::chrono::system_clock>;
+  std::optional<timeout_t> timeout;
 };
 
 class WiiSockMan


### PR DESCRIPTION
This PR should truly fix: https://dolp.in/i11867

What happened (assuming there is no timing issues):
  1. The receive thread is on a blocking `RecvFrom` call
  2. The game calls `SOCleanup` which:
       * fires `IOCTL_NWC24_CLEANUP_SOCKET`
       * calls `IOS_Close` on the network handle
       * sets `soState = 1` (`soState = 2` before this)
  3. The game calls `SOClose` but `ioctlv` isn't fired because `soState = 1`

In other words, `RecvFrom` won't get a response and will wait forever (since Dolphin doesn't receive `IOCTL_SO_CLOSE`), again... 

It might require a hardware test to confirm that's the intended behaviour.

Ready to be reviewed.
