### PR TITLE
IOS/KD: Cleanup sockets on IOCTL_NWC24_CLEANUP_SOCKET

### DIFF
--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -60,7 +60,8 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
     break;
 
   case IOCTL_NWC24_CLEANUP_SOCKET:
-    INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_CLEANUP_SOCKET - NI");
+    INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_CLEANUP_SOCKET");
+    WiiSockMan::GetInstance().Clean();
     break;
 
   case IOCTL_NWC24_LOCK_SOCKET:  // WiiMenu


### PR DESCRIPTION
This PR will need a hardware test (similar #8389) to confirm this behaviour.

Ready to be reviewed.