### PR TITLE
Socket: Abort pending operations on shutdown

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -186,16 +186,19 @@ private:
   {
     Request request;
     bool is_ssl;
+    bool is_aborted = false;
     union
     {
       NET_IOCTL net_type;
       SSL_IOCTL ssl_type;
     };
+    void Abort(s32 value);
   };
 
   friend class WiiSockMan;
   void SetFd(s32 s);
   void SetWiiFd(s32 s);
+  s32 Shutdown(u32 how);
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 
@@ -246,7 +249,8 @@ public:
   s32 AddSocket(s32 fd, bool is_rw);
   bool IsSocketBlocking(s32 wii_fd) const;
   s32 GetHostSocket(s32 wii_fd) const;
-  s32 DeleteSocket(s32 s);
+  s32 ShutdownSocket(s32 wii_fd, u32 how);
+  s32 DeleteSocket(s32 wii_fd);
   s32 GetLastNetError() const { return errno_last; }
   void SetLastNetError(s32 error) { errno_last = error; }
   void Clean() { WiiSockets.clear(); }


### PR DESCRIPTION
~~This PR will need a hardware test (similar #8389) to confirm this behaviour.~~

## PR goal
This PR tries to fix inconsistencies regarding `shutdown` implementation (on a socket) and be as close as possible to what the Wii does *(not sure about the GC behaviour)*.

### What it fixes
It fixes crashes/hangs in some Just Dance games : https://dolp.in/i11910

### What it doesn't fix
 * Dolphin not getting the right network interface on :
   - Android (https://github.com/dolphin-emu/dolphin/pull/9191)
   - MacOS (https://github.com/dolphin-emu/dolphin/pull/9214)
 * Return values of other network functions

## Hardware test
I created 2 hardware tests:
1. one that fires `shutdown` on blocking operations
2. the second one that checks return values of network functions after `shutdown` was called

### How-to run
1. Get the latest version of Dolphin (at least after https://github.com/dolphin-emu/dolphin/pull/9099)
2. Enable Dolphin debugging interface under `Options > Config > Interface` then tick `Show Debugging UI`
3. Enable the Dolphin Log window
4. In the Log configuration tab
   * Tick "Write to File" in Logger Outputs
   * Tick "OSREPORT" and "HLE"
   * Set the verbosity level to `Info` or `Debug`
5. Make sure you run the ELF (not the DOL) hardware tests
*(On top of that, you can also grab the result using netcat on your local IP address and the result port displayed at the end of the test)*

### Hardware tests results
Dolphin results are based on ~~this build #8796~~ latest master and https://github.com/dolphin-emu/dolphin/pull/9191 for Android.

#### Results of the [first hwtest](https://github.com/dolphin-emu/dolphin/files/4605323/wii-shutdown-v2.zip)
 - [x] [Wii](https://gist.github.com/sepalani/d1a9514cf410a139f280681bf76f8e99)
 - [x] [Dolphin (Windows 10)](https://gist.github.com/sepalani/820928366b670c20a843186cc55cba5b)
 - [x] Dolphin (Linux) | [Parrot](https://gist.github.com/sepalani/8566d82614c36ae38ec402e6e2be166b)
 - [x] Dolphin (Mac) | [macOS 11](https://gist.github.com/sepalani/427c866bd0febd514ae12dc2cd808e59)
 - [x] Dolphin (Android) | [ASUS RoG Phone II](https://gist.github.com/sepalani/e42880547e96d66864d1c69d0c8f7af3)

#### Results of the [second hwtest](https://github.com/dolphin-emu/dolphin/files/4605383/wii-shutdown-v2p2.zip)
 - [x] [Wii](https://gist.github.com/sepalani/ccf2bc4d4104e5f68ac18ba2287cdd07)
 - [x] [Dolphin (Windows 10)](https://gist.github.com/sepalani/d93ecfd9c1e58c598a8ff8f8de1224e6)
 - [x] Dolphin (Linux) | [Parrot](https://gist.github.com/sepalani/963c6ed916f18a90a5a98b861b679e61)
 - [x] Dolphin (Mac) | [macOS 11](https://gist.github.com/sepalani/35b3770773508622265dbb1025e7f6d0)
 - [x] Dolphin (Android) | [ASUS RoG Phone II](https://gist.github.com/sepalani/3314b6bdf8af7ff4717e74f818c8b38a)

### Analysis
#### Result value
 - **NO STATE**: Failed to reach wanted state
 - **TIMEOUT** or **--**: State reached but last task didn't finish
 - **DEADLOCK**: Same as timeout but cleanup didn't interrupt the ioctl call (i.e. impossible to join/stop thread)
 - **shutdown** / **callback**: return values (based on devkitPPC `errno.h`)

#### Code changes
The code was changed based on the wanted Wii results, my reasoning was done as follow:
 - `The Wii does nothing and returns 0 for IP_PROTO_UDP`
   * based on IOS reverse-engineering
 - `Adjust pending operations`
   * **IOCTL_SO_ACCEPT**:
      - [hwtest-1](https://gist.github.com/sepalani/d1a9514cf410a139f280681bf76f8e99): `B/BIND/LISTEN/ACCEPT`
      - `#define EINVAL 22 /* Invalid argument */`
   * **IOCTL_SO_CONNECT**:
      - [hwtest-1](https://gist.github.com/sepalani/d1a9514cf410a139f280681bf76f8e99): `B/CONNECT`
      - `#define ENETUNREACH 114 /* Network is unreachable */`
   * **IOCTLV_SO_RECVFROM**: 
      - [hwtest-1](https://gist.github.com/sepalani/d1a9514cf410a139f280681bf76f8e99): `B/CONNECT/RECV`, `B/BIND/LISTEN/ACCEPT'D/RECV`
      - [hwtest-2](https://github.com/dolphin-emu/dolphin/files/4605383/wii-shutdown-v2p2.zip): `B/BIND/LISTEN/ACCEPT'D/SHUT/RECV`, `B/CONNECT/SHUT/RECV`
      - `#define ENOTCONN 128 /* Socket is not connected */`
   * **IOCTLV_SO_SENDTO**: 
      - [hwtest-2](https://github.com/dolphin-emu/dolphin/files/4605383/wii-shutdown-v2p2.zip): `B/BIND/LISTEN/ACCEPT'D/SHUT/SEND`, `B/CONNECT/SHUT/SEND`
      - `#define ENOTCONN 128 /* Socket is not connected */`

Ready to be reviewed & merged.