### PR TITLE
IOS/NET: Add timeout on blocking connect

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -157,6 +157,10 @@ const Info<bool> MAIN_NETWORK_SSL_DUMP_ROOT_CA{{System::Main, "Network", "SSLDum
 const Info<bool> MAIN_NETWORK_SSL_DUMP_PEER_CERT{{System::Main, "Network", "SSLDumpPeerCert"},
                                                  false};
 const Info<bool> MAIN_NETWORK_DUMP_AS_PCAP{{System::Main, "Network", "DumpAsPCAP"}, false};
+// Default value based on:
+//  - [RFC 1122] 4.2.3.5 TCP Connection Failures (at least 3 minutes)
+//  - https://dolp.in/pr8759 hwtest (3 minutes and 10 seconds)
+const Info<int> MAIN_NETWORK_TIMEOUT{{System::Main, "Network", "NetworkTimeout"}, 190};
 
 // Main.Interface
 

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -130,6 +130,7 @@ extern const Info<bool> MAIN_NETWORK_SSL_VERIFY_CERTIFICATES;
 extern const Info<bool> MAIN_NETWORK_SSL_DUMP_ROOT_CA;
 extern const Info<bool> MAIN_NETWORK_SSL_DUMP_PEER_CERT;
 extern const Info<bool> MAIN_NETWORK_DUMP_AS_PCAP;
+extern const Info<int> MAIN_NETWORK_TIMEOUT;
 
 // Main.Interface
 

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -43,8 +43,10 @@ typedef struct pollfd pollfd_t;
 #endif
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <list>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -184,6 +186,7 @@ public:
   WiiSocket& operator=(WiiSocket&&) = default;
 
 private:
+  using Timeout = std::chrono::time_point<std::chrono::steady_clock>;
   struct sockop
   {
     Request request;
@@ -204,14 +207,20 @@ private:
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 
+  const Timeout& GetTimeout();
+  void ResetTimeout();
+
   void DoSock(Request request, NET_IOCTL type);
   void DoSock(Request request, SSL_IOCTL type);
   void Update(bool read, bool write, bool except);
   bool IsValid() const { return fd >= 0; }
+
   s32 fd = -1;
   s32 wii_fd = -1;
   bool nonBlock = false;
   std::list<sockop> pending_sockops;
+
+  std::optional<Timeout> timeout;
 };
 
 class WiiSockMan


### PR DESCRIPTION
This PR adds a timeout on connect for blocking sockets based on this hardware test. Beware that it tries to connect to an ubisoft server (which timeout after ~3 minutes on hardware).

[wii-connect-timeout.zip](https://github.com/dolphin-emu/dolphin/files/4516755/wii-connect-timeout.zip)

I'll need to reverse IOS to confirm that behaviour, however. The timeout value (in second) can also be changed in the config file under the `[Network]` section.

