### PR TITLE
Analytics: Report correct quirk for mismatched xf/bp colors

### DIFF
--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -373,7 +373,7 @@ void VertexManagerBase::Flush()
     if (xfmem.numChan.numColorChans != bpmem.genMode.numcolchans)
     {
       DolphinAnalytics::Instance().ReportGameQuirk(
-          GameQuirk::MISMATCHED_GPU_TEXGENS_BETWEEN_XF_AND_BP);
+          GameQuirk::MISMATCHED_GPU_COLORS_BETWEEN_XF_AND_BP);
     }
 
     return;


### PR DESCRIPTION
With #8717 @stenzek introduced two new quirks. However, @sebastiaangoossens noticed that the mismatched xf/bp texgens quirk was referenced twice, while the other went unused. This PR takes care of this.