### PR TITLE
DolphinQt: Fix the panic alert deadlock, dual core edition

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -127,6 +127,7 @@ static std::queue<HostJob> s_host_jobs_queue;
 static Common::Event s_cpu_thread_job_finished;
 
 static thread_local bool tls_is_cpu_thread = false;
+static thread_local bool tls_is_gpu_thread = false;
 
 static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi);
 
@@ -203,14 +204,7 @@ bool IsCPUThread()
 
 bool IsGPUThread()
 {
-  if (Core::System::GetInstance().IsDualCoreMode())
-  {
-    return (s_emu_thread.joinable() && (s_emu_thread.get_id() == std::this_thread::get_id()));
-  }
-  else
-  {
-    return IsCPUThread();
-  }
+  return tls_is_gpu_thread;
 }
 
 bool WantsDeterminism()
@@ -311,6 +305,16 @@ void DeclareAsCPUThread()
 void UndeclareAsCPUThread()
 {
   tls_is_cpu_thread = false;
+}
+
+void DeclareAsGPUThread()
+{
+  tls_is_gpu_thread = true;
+}
+
+void UndeclareAsGPUThread()
+{
+  tls_is_gpu_thread = false;
 }
 
 // For the CPU Thread only.
@@ -458,6 +462,8 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   }};
 
   Common::SetCurrentThreadName("Emuthread - Starting");
+
+  DeclareAsGPUThread();
 
   // For a time this acts as the CPU thread...
   DeclareAsCPUThread();

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -98,6 +98,8 @@ void Shutdown();
 
 void DeclareAsCPUThread();
 void UndeclareAsCPUThread();
+void DeclareAsGPUThread();
+void UndeclareAsGPUThread();
 
 std::string StopMessage(bool main_thread, std::string_view message);
 

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -44,6 +44,11 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
   const bool called_from_gpu_thread = Core::IsGPUThread();
 
   std::optional<bool> r = RunOnObject(QApplication::instance(), [&] {
+    // If we were called from the CPU/GPU thread, set us as the CPU/GPU thread.
+    // This information is used in order to avoid deadlocks when calling e.g.
+    // Host::SetRenderFocus or Core::RunAsCPUThread. (Host::SetRenderFocus
+    // can get called automatically when a dialog steals the focus.)
+
     Common::ScopeGuard cpu_scope_guard(&Core::UndeclareAsCPUThread);
     Common::ScopeGuard gpu_scope_guard(&Core::UndeclareAsGPUThread);
 
@@ -53,20 +58,9 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
       gpu_scope_guard.Dismiss();
 
     if (called_from_cpu_thread)
-    {
-      // If the panic alert that we are about to create steals the focus from RenderWidget,
-      // Host::SetRenderFocus gets called, which can attempt to use RunAsCPUThread to get us out
-      // of exclusive fullscreen. If we don't declare ourselves as the CPU thread, RunAsCPUThread
-      // calls PauseAndLock, which causes a deadlock if the CPU thread is waiting on us returning.
       Core::DeclareAsCPUThread();
-    }
     if (called_from_gpu_thread)
-    {
-      // We also need to avoid getting a deadlock when the GPU thread is waiting on us returning.
-      // Declaring ourselves as the GPU thread does not alter the behavior of RunAsCPUThread or
-      // PauseAndLock, but it does make Host::SetRenderFocus not call RunAsCPUThread.
       Core::DeclareAsGPUThread();
-    }
 
     ModalMessageBox message_box(QApplication::activeWindow(), Qt::ApplicationModal);
     message_box.setWindowTitle(QString::fromUtf8(caption));

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -421,10 +421,10 @@ bool RenderWidget::event(QEvent* event)
 
     if (Config::Get(Config::MAIN_PAUSE_ON_FOCUS_LOST) && Core::GetState() == Core::State::Running)
     {
-      // If we are declared as the CPU thread, it means that the real CPU thread is waiting
-      // for us to finish showing a panic alert (with that panic alert likely being the cause
-      // of this event), so trying to pause the real CPU thread would cause a deadlock
-      if (!Core::IsCPUThread())
+      // If we are declared as the CPU or GPU thread, it means that the real CPU or GPU thread
+      // is waiting for us to finish showing a panic alert (with that panic alert likely being
+      // the cause of this event), so trying to pause the core would cause a deadlock
+      if (!Core::IsCPUThread() && !Core::IsGPUThread())
         Core::SetState(Core::State::Paused);
     }
 


### PR DESCRIPTION
The fix in PR #8715 worked for panic alerts from the CPU thread, but there were still problems with panic alerts from the GPU thread in dual core mode. This change attempts to fix those.

I have assumed that the reason we use `RunAsCPUThread` when calling `SetFullscreen` is because we want to wait for the GPU thread to be inactive. (Because it can't be the CPU thread itself that we're waiting for, right? The CPU thread shouldn't directly interact with `g_renderer`.) However, I'm not entirely sure about this. If my assumption was wrong, then this PR is probably not the best solution.