### PR TITLE
Don't defer EFB Copies to RAM - PMTTYD Issues

### DIFF
--- a/Data/Sys/GameSettings/G8M.ini
+++ b/Data/Sys/GameSettings/G8M.ini
@@ -16,6 +16,7 @@
 EFBToTextureEnable = False
 BBoxEnable = True
 ImmediateXFBEnable = False
+DeferEFBCopies = False
 
 [Video_Stereoscopy]
 StereoConvergence = 545


### PR DESCRIPTION
This resolves a few issues with bounding box animations and others. Most noticably, it greatly reduces the bounding box slowdown seen on some NVIDIA cards and also fixes the odd overlay glitches when moving between rooms on the Excess Express.