### PR TITLE
Android: Add DSP Emulation Engine

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -33,6 +33,10 @@ public class Settings
   public static final String SECTION_CONTROLS = "Controls";
   public static final String SECTION_PROFILE = "Profile";
 
+  private static final String DSP_HLE = "0";
+  private static final String DSP_LLE_RECOMPILER = "1";
+  private static final String DSP_LLE_INTERPRETER = "2";
+
   public static final String SECTION_ANALYTICS = "Analytics";
 
   private String gameId;
@@ -177,6 +181,35 @@ public class Settings
         }
 
         SettingsFile.saveFile(fileName, iniSections, view);
+      }
+
+      switch (NativeLibrary
+              .GetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_DSP,
+                      SettingsFile.KEY_DSP_ENGINE, DSP_HLE))
+      {
+        case DSP_HLE:
+          NativeLibrary
+                  .SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_CORE,
+                          SettingsFile.KEY_DSP_HLE, "True");
+          NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_DSP,
+                  SettingsFile.KEY_DSP_ENABLE_JIT, "True");
+          break;
+
+        case DSP_LLE_RECOMPILER:
+          NativeLibrary
+                  .SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_CORE,
+                          SettingsFile.KEY_DSP_HLE, "False");
+          NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_DSP,
+                  SettingsFile.KEY_DSP_ENABLE_JIT, "True");
+          break;
+
+        case DSP_LLE_INTERPRETER:
+          NativeLibrary
+                  .SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_CORE,
+                          SettingsFile.KEY_DSP_HLE, "False");
+          NativeLibrary.SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_DSP,
+                  SettingsFile.KEY_DSP_ENABLE_JIT, "False");
+          break;
       }
 
       // Notify the native code of the changes

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -280,14 +280,35 @@ public final class SettingsFragmentPresenter
 
   private void addAudioSettings(ArrayList<SettingsItem> sl)
   {
+    Setting dspEmulationEngine = null;
     Setting audioStretch = null;
     Setting audioVolume = null;
 
     SettingSection coreSection = mSettings.getSection(Settings.SECTION_INI_CORE);
     SettingSection dspSection = mSettings.getSection(Settings.SECTION_INI_DSP);
+    dspEmulationEngine = dspSection.getSetting(SettingsFile.KEY_DSP_ENGINE);
     audioStretch = coreSection.getSetting(SettingsFile.KEY_AUDIO_STRETCH);
     audioVolume = dspSection.getSetting(SettingsFile.KEY_AUDIO_VOLUME);
 
+    // TODO: Exclude values from arrays instead of having multiple arrays.
+    int defaultCpuCore = NativeLibrary.DefaultCPUCore();
+    int dspEngineEntries;
+    int dspEngineValues;
+    if (defaultCpuCore == 1)  // x86-64
+    {
+      dspEngineEntries = R.array.dspEngineEntriesX86_64;
+      dspEngineValues = R.array.dspEngineValuesX86_64;
+    }
+    else  // Generic
+    {
+      dspEngineEntries = R.array.dspEngineEntriesGeneric;
+      dspEngineValues = R.array.dspEngineValuesGeneric;
+    }
+    // DSP Emulation Engine controls two settings.
+    // DSP Emulation Engine is read by Settings.saveSettings to modify the relevant settings.
+    sl.add(new SingleChoiceSetting(SettingsFile.KEY_DSP_ENGINE, Settings.SECTION_INI_DSP,
+            R.string.dsp_emulation_engine, 0, dspEngineEntries, dspEngineValues, 0,
+            dspEmulationEngine));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_AUDIO_STRETCH, Settings.SECTION_INI_CORE,
             R.string.audio_stretch, R.string.audio_stretch_description, false, audioStretch));
     sl.add(new SliderSetting(SettingsFile.KEY_AUDIO_VOLUME, Settings.SECTION_INI_DSP,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -46,8 +46,13 @@ public final class SettingsFile
   public static final String KEY_OVERCLOCK_PERCENT = "Overclock";
   public static final String KEY_SPEED_LIMIT = "EmulationSpeed";
   public static final String KEY_VIDEO_BACKEND = "GFXBackend";
+
+  public static final String KEY_DSP_ENGINE = "DSPEngine";
+  public static final String KEY_DSP_HLE = "DSPHLE";
+  public static final String KEY_DSP_ENABLE_JIT = "EnableJIT";
   public static final String KEY_AUDIO_STRETCH = "AudioStretch";
   public static final String KEY_AUDIO_VOLUME = "Volume";
+
   public static final String KEY_AUTO_DISC_CHANGE = "AutoDiscChange";
   public static final String KEY_GAME_CUBE_LANGUAGE = "SelectedLanguage";
   public static final String KEY_OVERRIDE_REGION_SETTINGS = "OverrideRegionSettings";

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -33,6 +33,26 @@
         <item>0</item>
     </integer-array>
 
+    <!-- DSP Emulation Engine -->
+    <string-array name="dspEngineEntriesX86_64" translatable="false">
+        <item>DSP HLE Emulation (fast)</item>
+        <item>DSP LLE Recompiler</item>
+        <item>DSP LLE Interpreter (slow)</item>
+    </string-array>
+    <integer-array name="dspEngineValuesX86_64" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+    <string-array name="dspEngineEntriesGeneric" translatable="false">
+        <item>DSP HLE Emulation (fast)</item>
+        <item>DSP LLE Interpreter (slow)</item>
+    </string-array>
+    <integer-array name="dspEngineValuesGeneric" translatable="false">
+        <item>0</item>
+        <item>2</item>
+    </integer-array>
+
     <!-- GameCube System Languages -->
     <string-array name="gameCubeSystemLanguageEntries" translatable="false">
         <item>English</item>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@
 
     <!-- Audio Settings -->
     <string name="audio_submenu">Audio</string>
+    <string name="dsp_emulation_engine">DSP Emulation Engine</string>
     <string name="audio_stretch">Audio Stretching</string>
     <string name="audio_stretch_description">Stretches audio to reduce stuttering. Increases latency.</string>
     <string name="audio_volume">Audio Volume</string>


### PR DESCRIPTION
Has multiple uses, including a temporary workaround for https://bugs.dolphin-emu.org/issues/10791

DSP Emulation Engine is actually two settings, so this is a `SingleChoiceSetting` special case.