### PR TITLE
Require minizip 2.0.0 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,7 +610,7 @@ else()
   add_subdirectory(Externals/zlib)
 endif()
 
-pkg_check_modules(MINIZIP minizip)
+pkg_check_modules(MINIZIP minizip>=2.0.0)
 if(MINIZIP_FOUND)
   message(STATUS "Using shared minizip")
 else()


### PR DESCRIPTION
Minizip 1.x is the old broken version, while 2.x is the newer fork we use. Many distros ship the old version which is causing stack smashing in RedumpVerifier, so we'll only use the shared lib if it's the newer version.