### PR TITLE
GC IPL Hack for Configurable MEM1 Size.

### DIFF
--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -105,7 +105,6 @@ struct BootParameters
   {
     explicit IPL(DiscIO::Region region_);
     IPL(DiscIO::Region region_, Disc&& disc_);
-    std::string path;
     DiscIO::Region region;
     // It is possible to boot the IPL with a disc inserted (with "skip IPL" disabled).
     std::optional<Disc> disc;
@@ -169,7 +168,6 @@ private:
                               const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
   static bool EmulatedBS2(bool is_wii, const DiscIO::VolumeDisc& volume,
                           const std::vector<DiscIO::Riivolution::Patch>& riivolution_patches);
-  static bool Load_BS2(const std::string& boot_rom_filename);
 
   static void SetupGCMemory();
   static bool SetupWiiMemory(IOS::HLE::IOSC::ConsoleType console_type);

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -175,6 +175,8 @@ const Info<float> MAIN_EMULATION_SPEED{{System::Main, "Core", "EmulationSpeed"},
 const Info<float> MAIN_OVERCLOCK{{System::Main, "Core", "Overclock"}, 1.0f};
 const Info<bool> MAIN_OVERCLOCK_ENABLE{{System::Main, "Core", "OverclockEnable"}, false};
 const Info<bool> MAIN_RAM_OVERRIDE_ENABLE{{System::Main, "Core", "RAMOverrideEnable"}, false};
+const Info<bool> MAIN_IPL_PATCH_RAM_SIZE_ENABLE{{System::Main, "Core", "IPLPatchRAMSizeEnable"},
+                                                false};
 const Info<u32> MAIN_MEM1_SIZE{{System::Main, "Core", "MEM1Size"}, Memory::MEM1_SIZE_RETAIL};
 const Info<u32> MAIN_MEM2_SIZE{{System::Main, "Core", "MEM2Size"}, Memory::MEM2_SIZE_RETAIL};
 const Info<std::string> MAIN_GFX_BACKEND{{System::Main, "Core", "GFXBackend"},

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -106,6 +106,7 @@ extern const Info<float> MAIN_EMULATION_SPEED;
 extern const Info<float> MAIN_OVERCLOCK;
 extern const Info<bool> MAIN_OVERCLOCK_ENABLE;
 extern const Info<bool> MAIN_RAM_OVERRIDE_ENABLE;
+extern const Info<bool> MAIN_IPL_PATCH_RAM_SIZE_ENABLE;
 extern const Info<u32> MAIN_MEM1_SIZE;
 extern const Info<u32> MAIN_MEM2_SIZE;
 // Should really be part of System::GFX, but again, we're stuck with past mistakes.

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -67,6 +67,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_OVERCLOCK.GetLocation(),
       &Config::MAIN_OVERCLOCK_ENABLE.GetLocation(),
       &Config::MAIN_RAM_OVERRIDE_ENABLE.GetLocation(),
+      &Config::MAIN_IPL_PATCH_RAM_SIZE_ENABLE.GetLocation(),
       &Config::MAIN_MEM1_SIZE.GetLocation(),
       &Config::MAIN_MEM2_SIZE.GetLocation(),
       &Config::MAIN_GFX_BACKEND.GetLocation(),

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
@@ -26,15 +26,34 @@ public:
   static constexpr u32 UNIX_EPOCH = 0;         // 1970-01-01 00:00:00
   static constexpr u32 GC_EPOCH = 0x386D4380;  // 2000-01-01 00:00:00
 
+  // CRC32 hashes of the IPL file, obtained from Redump
+  static constexpr u32 CRC32_RETAIL_NTSC_1_0 = 0x6dac1f2a;
+  static constexpr u32 CRC32_RETAIL_NTSC_1_1 = 0xd5e6feea;
+  static constexpr u32 CRC32_RETAIL_NTSC_1_2_001 = 0xd235e3f9;
+  static constexpr u32 CRC32_RETAIL_NTSC_1_2_101 = 0x86573808;
+  static constexpr u32 CRC32_RETAIL_PAL_1_0 = 0x4f319f43;
+  static constexpr u32 CRC32_RETAIL_MPAL_1_1 = 0x667d0b64;  // Brazil
+  static constexpr u32 CRC32_RETAIL_PAL_1_2 = 0xad1b7f16;
+  static constexpr u32 CRC32_NPDP_READER_NTSC_1_0 = 0x773d9a5d;
+  static constexpr u32 CRC32_NPDP_READER_PAL_1_0 = 0x7fcf6fc5;
+  static constexpr u32 CRC32_TDEV = 0xd5b49679;
+  static constexpr u32 CRC32_NPDP_GDEV_0_93a = 0x48df4dcf;
+
   static u32 GetEmulatedTime(u32 epoch);
   static u64 NetPlay_GetEmulatedTime();
 
   static void Descrambler(u8* data, u32 size);
+  static void Patcher(u8* data, const u32 rom_crc32);
 
   static bool HasIPLDump();
 
+  // These two methods are used by a HLE hack to boot the IPL.
+  bool IsROMLoaded() { return m_is_rom_loaded; }
+  const u8* GetROM() { return m_rom.get(); }
+
 private:
   std::unique_ptr<u8[]> m_rom;
+  bool m_is_rom_loaded;
 
   // TODO these ranges are highly suspect
   enum

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -36,6 +36,7 @@ void Init()
   State::Init();
 
   // Init the whole Hardware
+  Memory::PreInit();  // Set some constants very early on so Memory Override works everywhere.
   AudioInterface::Init();
   VideoInterface::Init();
   SerialInterface::Init();

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -60,6 +60,7 @@ extern std::unique_ptr<MMIO::Mapping> mmio_mapping;
 
 // Init and Shutdown
 bool IsInitialized();
+void PreInit();
 void Init();
 void Shutdown();
 bool InitFastmemArena();

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -106,6 +106,9 @@ void AdvancedPane::CreateLayout()
   m_ram_override_checkbox = new QCheckBox(tr("Enable Emulated Memory Size Override"));
   ram_override_layout->addWidget(m_ram_override_checkbox);
 
+  m_ipl_patch_ram_size_checkbox = new QCheckBox(tr("Enable Known IPL RAM Size Patch"));
+  ram_override_layout->addWidget(m_ipl_patch_ram_size_checkbox);
+
   auto* mem1_override_slider_layout = new QHBoxLayout();
   mem1_override_slider_layout->setContentsMargins(0, 0, 0, 0);
   ram_override_layout->addLayout(mem1_override_slider_layout);
@@ -199,6 +202,13 @@ void AdvancedPane::ConnectLayout()
     Update();
   });
 
+  m_ipl_patch_ram_size_checkbox->setChecked(Config::Get(Config::MAIN_IPL_PATCH_RAM_SIZE_ENABLE));
+  connect(
+      m_ipl_patch_ram_size_checkbox, &QCheckBox::toggled, [this](bool enable_ipl_patch_ram_size) {
+        Config::SetBaseOrCurrent(Config::MAIN_IPL_PATCH_RAM_SIZE_ENABLE, enable_ipl_patch_ram_size);
+        Update();
+      });
+
   connect(m_mem1_override_slider, &QSlider::valueChanged, [this](int slider_value) {
     const u32 mem1_size = m_mem1_override_slider->value() * 0x100000;
     Config::SetBaseOrCurrent(Config::MAIN_MEM1_SIZE, mem1_size);
@@ -269,6 +279,8 @@ void AdvancedPane::Update()
   }());
 
   m_ram_override_checkbox->setEnabled(!running);
+
+  m_ipl_patch_ram_size_checkbox->setEnabled(!running);
 
   m_mem1_override_slider->setEnabled(enable_ram_override_widgets && !running);
   m_mem1_override_slider_label->setEnabled(enable_ram_override_widgets && !running);

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -41,6 +41,7 @@ private:
   QDateTimeEdit* m_custom_rtc_datetime;
 
   QCheckBox* m_ram_override_checkbox;
+  QCheckBox* m_ipl_patch_ram_size_checkbox;
   QSlider* m_mem1_override_slider;
   QLabel* m_mem1_override_slider_label;
   QSlider* m_mem2_override_slider;


### PR DESCRIPTION
A follow up to my prior Pull Request (Configurable MEM1 and MEM2 sizes at runtime via Dolphin.ini #8722).  This is a hack to assembly edit retail IPLs to support different MEM1 sizes before they are copied into Emulator Memory.  As with any other Emulated Memory Size Overrides, this change does nothing if the MAIN_RAM_OVERRIDE_ENABLE config setting is false.
I also updated a comment in Memmap.cpp to reflect new behavior from this commit and my prior one as well.