### PR TITLE
Externals: Do not expose the externals directory itself as include path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -755,6 +755,7 @@ endif()
 if(USE_DISCORD_PRESENCE)
   message(STATUS "Using static DiscordRPC from Externals")
   add_subdirectory(Externals/discord-rpc)
+  include_directories(Externals/discord-rpc/include)
 endif()
 
 find_package(Libsystemd)
@@ -764,6 +765,8 @@ if(SYSTEMD_FOUND)
 else()
   message(STATUS "libsystemd not found, disabling traversal server watchdog support")
 endif()
+
+include_directories(Externals/picojson)
 
 ########################################
 # Pre-build events: Define configuration variables and write SCM info header

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,6 +649,7 @@ add_subdirectory(Externals/FreeSurround)
 if (APPLE OR WIN32)
   message(STATUS "Using ed25519 from Externals")
   add_subdirectory(Externals/ed25519)
+  include_directories(Externals/ed25519)
 endif()
 
 # Using static soundtouch from Externals

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,7 +654,7 @@ endif()
 # Using static soundtouch from Externals
 # Unable to use system soundtouch library: We require shorts, not floats.
 add_subdirectory(Externals/soundtouch)
-include_directories(Externals)
+include_directories(Externals/soundtouch)
 
 find_package(Cubeb)
 if(CUBEB_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,6 +767,10 @@ else()
   message(STATUS "libsystemd not found, disabling traversal server watchdog support")
 endif()
 
+if (WIN32)
+  include_directories(Externals/OpenAL/include)
+endif()
+
 include_directories(Externals/picojson)
 
 ########################################

--- a/Source/Core/AudioCommon/AudioStretcher.h
+++ b/Source/Core/AudioCommon/AudioStretcher.h
@@ -6,7 +6,7 @@
 
 #include <array>
 
-#include <soundtouch/SoundTouch.h>
+#include <SoundTouch.h>
 
 namespace AudioCommon
 {

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -13,9 +13,9 @@
 #include "Core/HW/SystemTimers.h"
 
 #ifdef _WIN32
-#include <OpenAL/include/al.h>
-#include <OpenAL/include/alc.h>
-#include <OpenAL/include/alext.h>
+#include <al.h>
+#include <alc.h>
+#include <alext.h>
 
 // OpenAL requires a minimum of two buffers, three or more recommended
 #define OAL_BUFFERS 3

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -297,7 +297,7 @@
     <ProjectReference Include="$(ExternalsDir)libpng\png\png.vcxproj">
       <Project>{4c9f135b-a85e-430c-bad4-4c67ef5fc12c}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Externals\curl\curl.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)curl\curl.vcxproj">
       <Project>{bb00605c-125f-4a21-b33b-7bf418322dcb}</Project>
     </ProjectReference>
     <ProjectReference Include="SCMRevGen.vcxproj">

--- a/Source/Core/Common/MinizipUtil.h
+++ b/Source/Core/Common/MinizipUtil.h
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 
-#include <minizip/unzip.h>
+#include <unzip.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/ScopeGuard.h"

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -18,8 +18,8 @@
 
 #include <mbedtls/md5.h>
 #include <mbedtls/sha1.h>
-#include <minizip/unzip.h>
 #include <pugixml.hpp>
+#include <unzip.h>
 #include <zlib.h>
 
 #include "Common/Align.h"

--- a/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
+++ b/Source/Core/DolphinQt/DiscordJoinRequestDialog.cpp
@@ -11,7 +11,7 @@
 #include <QPixmap>
 #include <QPushButton>
 
-#include <discord-rpc/include/discord_rpc.h>
+#include <discord_rpc.h>
 
 #include "Common/HttpRequest.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/UICommon/AutoUpdate.cpp
+++ b/Source/Core/UICommon/AutoUpdate.cpp
@@ -4,7 +4,7 @@
 
 #include "UICommon/AutoUpdate.h"
 
-#include <picojson/picojson.h>
+#include <picojson.h>
 #include <string>
 
 #include "Common/CommonPaths.h"

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -16,7 +16,7 @@
 #include <set>
 #include <string>
 
-#include <discord-rpc/include/discord_rpc.h>
+#include <discord_rpc.h>
 #include <fmt/format.h>
 
 #include "Common/Hash.h"

--- a/Source/Core/UICommon/NetPlayIndex.cpp
+++ b/Source/Core/UICommon/NetPlayIndex.cpp
@@ -8,7 +8,7 @@
 #include <numeric>
 #include <string>
 
-#include <picojson/picojson.h>
+#include <picojson.h>
 
 #include "Common/Common.h"
 #include "Common/HttpRequest.h"

--- a/Source/Core/UICommon/ResourcePack/Manifest.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manifest.cpp
@@ -4,7 +4,7 @@
 
 #include "UICommon/ResourcePack/Manifest.h"
 
-#include <picojson/picojson.h>
+#include <picojson.h>
 
 namespace ResourcePack
 {

--- a/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
+++ b/Source/Core/UICommon/ResourcePack/ResourcePack.cpp
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 
-#include <minizip/unzip.h>
+#include <unzip.h>
 
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"

--- a/Source/Core/UICommon/UICommon.vcxproj
+++ b/Source/Core/UICommon/UICommon.vcxproj
@@ -50,7 +50,7 @@
     <ProjectReference Include="$(CoreDir)Core\Core.vcxproj">
       <Project>{E54CF649-140E-4255-81A5-30A673C1FB36}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Externals\picojson\picojson.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)picojson\picojson.vcxproj">
       <Project>{2c0d058e-de35-4471-ad99-e68a2caf9e18}</Project>
     </ProjectReference>
     <ProjectReference Include="$(ExternalsDir)discord-rpc\src\discord-rpc.vcxproj">

--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -8,7 +8,7 @@
 #include <optional>
 
 #include <OptionParser.h>
-#include <ed25519/ed25519.h>
+#include <ed25519.h>
 #include <mbedtls/base64.h>
 #include <mbedtls/sha256.h>
 #include <zlib.h>

--- a/Source/Core/UpdaterCommon/UpdaterCommon.vcxproj
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.vcxproj
@@ -48,22 +48,22 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
   <ItemGroup>
-    <ProjectReference Include="..\Common\Common.vcxproj">
+    <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
       <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Externals\curl\curl.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)curl\curl.vcxproj">
       <Project>{bb00605c-125f-4a21-b33b-7bf418322dcb}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\externals\ed25519\ed25519.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)ed25519\ed25519.vcxproj">
       <Project>{5bdf4b91-1491-4fb0-bc27-78e9a8e97dc3}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Externals\mbedtls\mbedTLS.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)mbedtls\mbedTLS.vcxproj">
       <Project>{bdb6578b-0691-4e80-a46c-df21639fd3b8}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Externals\zlib\zlib.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)zlib\zlib.vcxproj">
       <Project>{ff213b23-2c26-4214-9f88-85271e557e87}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Externals\cpp-optparse\cpp-optparse.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)cpp-optparse\cpp-optparse.vcxproj">
       <Project>{c636d9d1-82fe-42b5-9987-63b7d4836341}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
+++ b/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
@@ -91,7 +91,7 @@
     <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
       <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\Externals\glslang\glslang.vcxproj">
+    <ProjectReference Include="$(ExternalsDir)glslang\glslang.vcxproj">
       <Project>{d178061b-84d3-44f9-beed-efd18d9033f0}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -198,6 +198,9 @@
     <Text Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(ExternalsDir)imgui\imgui.vcxproj">
+      <Project>{4c3b2264-ea73-4a7b-9cfe-65b0fd635ebb}</Project>
+    </ProjectReference>
     <ProjectReference Include="$(ExternalsDir)libpng\png\png.vcxproj">
       <Project>{4c9f135b-a85e-430c-bad4-4c67ef5fc12c}</Project>
     </ProjectReference>
@@ -209,9 +212,6 @@
     </ProjectReference>
     <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
       <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\Externals\imgui\imgui.vcxproj">
-      <Project>{4c3b2264-ea73-4a7b-9cfe-65b0fd635ebb}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -54,6 +54,7 @@
       <AdditionalIncludeDirectories>$(ExternalsDir)miniupnpc\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)minizip;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)mbedtls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)OpenAL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)picojson;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)pugixml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)SFML\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -33,13 +33,14 @@
         Note: Directory containing source file being compiled is always searched first.
       -->
       <AdditionalIncludeDirectories>$(CoreDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories>$(ExternalsDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)Bochs_disasm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)bzip2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)cpp-optparse;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)FreeSurround\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)cubeb\include;$(ExternalsDir)cubeb\msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)curl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)discord-rpc\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)ed25519;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)enet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)ffmpeg\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)fmt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -51,9 +52,12 @@
       <AdditionalIncludeDirectories>$(ExternalsDir)libusb\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)LZO;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)miniupnpc\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)minizip;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)mbedtls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)picojson;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)pugixml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)SFML\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ExternalsDir)soundtouch;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)Vulkan\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)WIL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)xxhash;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -59,7 +59,7 @@
         in order to prevent the trailing slash from escaping the doublequote after value replacement.
         -->
     <MocIncludes>"-I$(QtIncludeDir)QtWidgets" "-I$(QtIncludeDir)QtGui" "-I$(QtIncludeDir)QtCore" "-I$(QtIncludeDir) " "-I$(QtToolOutDir) " -I.</MocIncludes>
-    <MocIncludes>"-I$(ExternalsDir)xxhash" "-I$(ExternalsDir)zlib" "-I$(ExternalsDir)SFML\include" "-I$(ExternalsDir)mbedtls\include" "-I$(ExternalsDir)miniupnpc\src" "-I$(ExternalsDir)LZO" "-I$(ExternalsDir)libusbx\libusb" "-I$(ExternalsDir)libpng" "-I$(ExternalsDir)GL" "-I$(ExternalsDir)Bochs_disasm" "-I$(ExternalsDir) " "-I$(CoreDir) " $(MocIncludes)</MocIncludes>
+    <MocIncludes>"-I$(ExternalsDir)xxhash" "-I$(ExternalsDir)zlib" "-I$(ExternalsDir)SFML\include" "-I$(ExternalsDir)mbedtls\include" "-I$(ExternalsDir)miniupnpc\src" "-I$(ExternalsDir)LZO" "-I$(ExternalsDir)libusbx\libusb" "-I$(ExternalsDir)libpng" "-I$(ExternalsDir)GL" "-I$(ExternalsDir)Bochs_disasm" "-I$(CoreDir) " $(MocIncludes)</MocIncludes>
   </PropertyGroup>
   <Target Name="QtMoc"
     BeforeTargets="ClCompile"


### PR DESCRIPTION
We must not provide the /Externals directory as global include directory.
Here, this yield a crash because of external minizip header and system library mismatch.
The wrong usage was written for soundtouch, and many libraries afterwards have been linked wrong.

Soundtouch itself recormends to include it with <SoundTouch.h> and -I/usr/include/soundtouch, so this should fit better.