### PR TITLE
Explain how to fix "Serial and/or version data is missing"

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -313,7 +313,11 @@ std::vector<RedumpVerifier::PotentialMatch> RedumpVerifier::ScanDatfile(const st
     // so show a panic alert rather than just using ERROR_LOG
 
     // i18n: "Serial" refers to serial numbers, e.g. RVL-RSBE-USA
-    PanicAlertT("Serial and/or version data is missing from %s", GetPathForSystem(system).c_str());
+    PanicAlertT("Serial and/or version data is missing from %s\n"
+                "Please append \"%s\" (without the quotes) to the datfile URL when downloading\n"
+                "Example: %s",
+                GetPathForSystem(system).c_str(), "serial,version",
+                "http://redump.org/datfile/gc/serial,version");
     m_result = {Status::Error, Common::GetStringT("Failed to parse Redump.org data")};
     return {};
   }


### PR DESCRIPTION
The downloads page on redump doesn't link to the version that has serials and versions.  Since the Wii data needs to be manually downloaded, it's easy to download the version without them (if you have access to them, of course), and it's not immediately obvious how to get the right version.  I only found out by looking at the code that does the downloading for GC data.  This PR amends the message to explain how to include that data in the download.