### PR TITLE
DolphinQt: Split Config > Advanced into Misc and Advanced

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -343,6 +343,8 @@ add_executable(dolphin-emu
   Settings/GeneralPane.h
   Settings/InterfacePane.cpp
   Settings/InterfacePane.h
+  Settings/MiscPane.cpp
+  Settings/MiscPane.h
   Settings/PathPane.cpp
   Settings/PathPane.h
   Settings/USBDeviceAddToWhitelistDialog.cpp

--- a/Source/Core/DolphinQt/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/SettingsWindow.cpp
@@ -16,6 +16,7 @@
 #include "DolphinQt/Settings/GameCubePane.h"
 #include "DolphinQt/Settings/GeneralPane.h"
 #include "DolphinQt/Settings/InterfacePane.h"
+#include "DolphinQt/Settings/MiscPane.h"
 #include "DolphinQt/Settings/PathPane.h"
 #include "DolphinQt/Settings/WiiPane.h"
 
@@ -40,6 +41,7 @@ SettingsWindow::SettingsWindow(QWidget* parent) : QDialog(parent)
   m_tab_widget->addTab(GetWrappedWidget(new PathPane, this, 125, 100), tr("Paths"));
   m_tab_widget->addTab(GetWrappedWidget(new GameCubePane, this, 125, 100), tr("GameCube"));
   m_tab_widget->addTab(GetWrappedWidget(new WiiPane, this, 125, 100), tr("Wii"));
+  m_tab_widget->addTab(GetWrappedWidget(new MiscPane, this, 125, 200), tr("Misc"));
   m_tab_widget->addTab(GetWrappedWidget(new AdvancedPane, this, 125, 200), tr("Advanced"));
 
   // Dialog box buttons

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -210,6 +210,7 @@
     <ClCompile Include="Settings\GameCubePane.cpp" />
     <ClCompile Include="Settings\GeneralPane.cpp" />
     <ClCompile Include="Settings\InterfacePane.cpp" />
+    <ClCompile Include="Settings\MiscPane.cpp" />
     <ClCompile Include="Settings\PathPane.cpp" />
     <ClCompile Include="Settings\USBDeviceAddToWhitelistDialog.cpp" />
     <ClCompile Include="Settings\WiiPane.cpp" />
@@ -409,6 +410,7 @@
     <QtMoc Include="Settings\GameCubePane.h" />
     <QtMoc Include="Settings\GeneralPane.h" />
     <QtMoc Include="Settings\InterfacePane.h" />
+    <QtMoc Include="Settings\MiscPane.h" />
     <QtMoc Include="Settings\PathPane.h" />
     <QtMoc Include="Settings\USBDeviceAddToWhitelistDialog.h" />
     <QtMoc Include="Settings\WiiPane.h" />

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -4,9 +4,6 @@
 #include "DolphinQt/Settings/AdvancedPane.h"
 
 #include <QCheckBox>
-#include <QComboBox>
-#include <QDateTimeEdit>
-#include <QFormLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -17,22 +14,13 @@
 #include <cmath>
 
 #include "Core/Config/MainSettings.h"
-#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/SystemTimers.h"
-#include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
 
 #include "DolphinQt/Config/ConfigControls/ConfigBool.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
-
-static const std::map<PowerPC::CPUCore, const char*> CPU_CORE_NAMES = {
-    {PowerPC::CPUCore::Interpreter, QT_TR_NOOP("Interpreter (slowest)")},
-    {PowerPC::CPUCore::CachedInterpreter, QT_TR_NOOP("Cached Interpreter (slower)")},
-    {PowerPC::CPUCore::JIT64, QT_TR_NOOP("JIT Recompiler for x86-64 (recommended)")},
-    {PowerPC::CPUCore::JITARM64, QT_TR_NOOP("JIT Recompiler for ARM64 (recommended)")},
-};
 
 AdvancedPane::AdvancedPane(QWidget* parent) : QWidget(parent)
 {
@@ -48,44 +36,6 @@ void AdvancedPane::CreateLayout()
 {
   auto* main_layout = new QVBoxLayout();
   setLayout(main_layout);
-
-  auto* cpu_options_group = new QGroupBox(tr("CPU Options"));
-  auto* cpu_options_group_layout = new QVBoxLayout();
-  cpu_options_group->setLayout(cpu_options_group_layout);
-  main_layout->addWidget(cpu_options_group);
-
-  auto* cpu_emulation_engine_layout = new QFormLayout;
-  cpu_emulation_engine_layout->setFormAlignment(Qt::AlignLeft | Qt::AlignTop);
-  cpu_emulation_engine_layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
-  cpu_options_group_layout->addLayout(cpu_emulation_engine_layout);
-
-  m_cpu_emulation_engine_combobox = new QComboBox(this);
-  cpu_emulation_engine_layout->addRow(tr("CPU Emulation Engine:"), m_cpu_emulation_engine_combobox);
-  for (PowerPC::CPUCore cpu_core : PowerPC::AvailableCPUCores())
-  {
-    m_cpu_emulation_engine_combobox->addItem(tr(CPU_CORE_NAMES.at(cpu_core)));
-  }
-
-  m_enable_mmu_checkbox = new ConfigBool(tr("Enable MMU"), Config::MAIN_MMU);
-  m_enable_mmu_checkbox->SetDescription(
-      tr("Enables the Memory Management Unit, needed for some games. (ON = Compatible, OFF = "
-         "Fast)<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
-  cpu_options_group_layout->addWidget(m_enable_mmu_checkbox);
-
-  m_pause_on_panic_checkbox = new ConfigBool(tr("Pause on Panic"), Config::MAIN_PAUSE_ON_PANIC);
-  m_pause_on_panic_checkbox->SetDescription(
-      tr("Pauses the emulation if a Read/Write or Unknown Instruction panic occurs.<br>Enabling "
-         "will affect performance.<br>The performance impact is the same as having Enable MMU "
-         "on.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
-  cpu_options_group_layout->addWidget(m_pause_on_panic_checkbox);
-
-  m_accurate_cpu_cache_checkbox =
-      new ConfigBool(tr("Enable Write-Back Cache (slow)"), Config::MAIN_ACCURATE_CPU_CACHE);
-  m_accurate_cpu_cache_checkbox->SetDescription(
-      tr("Enables emulation of the CPU write-back cache.<br>Enabling will have a significant "
-         "impact on performance.<br>This should be left disabled unless absolutely "
-         "needed.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
-  cpu_options_group_layout->addWidget(m_accurate_cpu_cache_checkbox);
 
   auto* clock_override = new QGroupBox(tr("Clock Override"));
   auto* clock_override_layout = new QVBoxLayout();
@@ -155,48 +105,11 @@ void AdvancedPane::CreateLayout()
   ram_override_description->setWordWrap(true);
   ram_override_layout->addWidget(ram_override_description);
 
-  auto* rtc_options = new QGroupBox(tr("Custom RTC Options"));
-  rtc_options->setLayout(new QVBoxLayout());
-  main_layout->addWidget(rtc_options);
-
-  m_custom_rtc_checkbox = new QCheckBox(tr("Enable Custom RTC"));
-  rtc_options->layout()->addWidget(m_custom_rtc_checkbox);
-
-  m_custom_rtc_datetime = new QDateTimeEdit();
-
-  // Show seconds
-  m_custom_rtc_datetime->setDisplayFormat(m_custom_rtc_datetime->displayFormat().replace(
-      QStringLiteral("mm"), QStringLiteral("mm:ss")));
-
-  if (!m_custom_rtc_datetime->displayFormat().contains(QStringLiteral("yyyy")))
-  {
-    // Always show the full year, no matter what the locale specifies. Otherwise, two-digit years
-    // will always be interpreted as in the 21st century.
-    m_custom_rtc_datetime->setDisplayFormat(m_custom_rtc_datetime->displayFormat().replace(
-        QStringLiteral("yy"), QStringLiteral("yyyy")));
-  }
-  m_custom_rtc_datetime->setDateTimeRange(QDateTime({2000, 1, 1}, {0, 0, 0}, Qt::UTC),
-                                          QDateTime({2099, 12, 31}, {23, 59, 59}, Qt::UTC));
-  m_custom_rtc_datetime->setTimeSpec(Qt::UTC);
-  rtc_options->layout()->addWidget(m_custom_rtc_datetime);
-
-  auto* custom_rtc_description =
-      new QLabel(tr("This setting allows you to set a custom real time clock (RTC) separate from "
-                    "your current system time.\n\nIf unsure, leave this unchecked."));
-  custom_rtc_description->setWordWrap(true);
-  rtc_options->layout()->addWidget(custom_rtc_description);
-
   main_layout->addStretch(1);
 }
 
 void AdvancedPane::ConnectLayout()
 {
-  connect(m_cpu_emulation_engine_combobox, &QComboBox::currentIndexChanged, [](int index) {
-    const auto cpu_cores = PowerPC::AvailableCPUCores();
-    if (index >= 0 && static_cast<size_t>(index) < cpu_cores.size())
-      Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, cpu_cores[index]);
-  });
-
   connect(m_cpu_clock_override_checkbox, &QCheckBox::toggled, [this](bool enable_clock_override) {
     Config::SetBaseOrCurrent(Config::MAIN_OVERCLOCK_ENABLE, enable_clock_override);
     Update();
@@ -225,17 +138,6 @@ void AdvancedPane::ConnectLayout()
     Config::SetBaseOrCurrent(Config::MAIN_MEM2_SIZE, mem2_size);
     Update();
   });
-
-  connect(m_custom_rtc_checkbox, &QCheckBox::toggled, [this](bool enable_custom_rtc) {
-    Config::SetBaseOrCurrent(Config::MAIN_CUSTOM_RTC_ENABLE, enable_custom_rtc);
-    Update();
-  });
-
-  connect(m_custom_rtc_datetime, &QDateTimeEdit::dateTimeChanged, [this](QDateTime date_time) {
-    Config::SetBaseOrCurrent(Config::MAIN_CUSTOM_RTC_VALUE,
-                             static_cast<u32>(date_time.toSecsSinceEpoch()));
-    Update();
-  });
 }
 
 void AdvancedPane::Update()
@@ -243,18 +145,6 @@ void AdvancedPane::Update()
   const bool running = Core::GetState() != Core::State::Uninitialized;
   const bool enable_cpu_clock_override_widgets = Config::Get(Config::MAIN_OVERCLOCK_ENABLE);
   const bool enable_ram_override_widgets = Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE);
-  const bool enable_custom_rtc_widgets = Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE) && !running;
-
-  const auto available_cpu_cores = PowerPC::AvailableCPUCores();
-  const auto cpu_core = Config::Get(Config::MAIN_CPU_CORE);
-  for (size_t i = 0; i < available_cpu_cores.size(); ++i)
-  {
-    if (available_cpu_cores[i] == cpu_core)
-      m_cpu_emulation_engine_combobox->setCurrentIndex(int(i));
-  }
-  m_cpu_emulation_engine_combobox->setEnabled(!running);
-  m_enable_mmu_checkbox->setEnabled(!running);
-  m_pause_on_panic_checkbox->setEnabled(!running);
 
   {
     QFont bf = font();
@@ -313,12 +203,4 @@ void AdvancedPane::Update()
     const u32 mem2_size = Config::Get(Config::MAIN_MEM2_SIZE) / 0x100000;
     return tr("%1 MB (MEM2)").arg(QString::number(mem2_size));
   }());
-
-  m_custom_rtc_checkbox->setEnabled(!running);
-  SignalBlocking(m_custom_rtc_checkbox)->setChecked(Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE));
-
-  QDateTime initial_date_time;
-  initial_date_time.setSecsSinceEpoch(Config::Get(Config::MAIN_CUSTOM_RTC_VALUE));
-  m_custom_rtc_datetime->setEnabled(enable_custom_rtc_widgets);
-  SignalBlocking(m_custom_rtc_datetime)->setDateTime(initial_date_time);
 }

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.h
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.h
@@ -3,22 +3,13 @@
 
 #pragma once
 
-#include <vector>
-
 #include <QWidget>
 
 class ConfigBool;
 class QCheckBox;
-class QComboBox;
 class QLabel;
 class QRadioButton;
 class QSlider;
-class QDateTimeEdit;
-
-namespace Core
-{
-enum class State;
-}
 
 class AdvancedPane final : public QWidget
 {
@@ -31,17 +22,10 @@ private:
   void ConnectLayout();
   void Update();
 
-  QComboBox* m_cpu_emulation_engine_combobox;
-  ConfigBool* m_enable_mmu_checkbox;
-  ConfigBool* m_pause_on_panic_checkbox;
-  ConfigBool* m_accurate_cpu_cache_checkbox;
   QCheckBox* m_cpu_clock_override_checkbox;
   QSlider* m_cpu_clock_override_slider;
   QLabel* m_cpu_clock_override_slider_label;
   QLabel* m_cpu_clock_override_description;
-
-  QCheckBox* m_custom_rtc_checkbox;
-  QDateTimeEdit* m_custom_rtc_datetime;
 
   QCheckBox* m_ram_override_checkbox;
   QSlider* m_mem1_override_slider;

--- a/Source/Core/DolphinQt/Settings/MiscPane.cpp
+++ b/Source/Core/DolphinQt/Settings/MiscPane.cpp
@@ -1,0 +1,159 @@
+// Copyright 2020 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "DolphinQt/Settings/MiscPane.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDateTimeEdit>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QVBoxLayout>
+
+#include "Core/Config/MainSettings.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/PowerPC/PowerPC.h"
+
+#include "DolphinQt/QtUtils/SignalBlocking.h"
+#include "DolphinQt/Settings.h"
+
+static const std::map<PowerPC::CPUCore, const char*> CPU_CORE_NAMES = {
+    {PowerPC::CPUCore::Interpreter, QT_TR_NOOP("Interpreter (slowest)")},
+    {PowerPC::CPUCore::CachedInterpreter, QT_TR_NOOP("Cached Interpreter (slower)")},
+    {PowerPC::CPUCore::JIT64, QT_TR_NOOP("JIT Recompiler for x86-64 (recommended)")},
+    {PowerPC::CPUCore::JITARM64, QT_TR_NOOP("JIT Recompiler for ARM64 (recommended)")},
+};
+
+MiscPane::MiscPane(QWidget* parent) : QWidget(parent)
+{
+  CreateLayout();
+  Update();
+
+  ConnectLayout();
+
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, &MiscPane::Update);
+}
+
+void MiscPane::CreateLayout()
+{
+  auto* main_layout = new QVBoxLayout();
+  setLayout(main_layout);
+
+  auto* cpu_options_group = new QGroupBox(tr("CPU Options"));
+  auto* cpu_options_group_layout = new QVBoxLayout();
+  cpu_options_group->setLayout(cpu_options_group_layout);
+  main_layout->addWidget(cpu_options_group);
+
+  auto* cpu_emulation_engine_layout = new QFormLayout;
+  cpu_emulation_engine_layout->setFormAlignment(Qt::AlignLeft | Qt::AlignTop);
+  cpu_emulation_engine_layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+  cpu_options_group_layout->addLayout(cpu_emulation_engine_layout);
+
+  m_cpu_emulation_engine_combobox = new QComboBox(this);
+  cpu_emulation_engine_layout->addRow(tr("CPU Emulation Engine:"), m_cpu_emulation_engine_combobox);
+  for (PowerPC::CPUCore cpu_core : PowerPC::AvailableCPUCores())
+  {
+    m_cpu_emulation_engine_combobox->addItem(tr(CPU_CORE_NAMES.at(cpu_core)));
+  }
+
+  m_enable_mmu_checkbox = new ConfigBool(tr("Enable MMU"), Config::MAIN_MMU);
+  m_enable_mmu_checkbox->SetDescription(
+      tr("Enables the Memory Management Unit, needed for some games. (ON = Compatible, OFF = "
+         "Fast)<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
+  cpu_options_group_layout->addWidget(m_enable_mmu_checkbox);
+
+  m_pause_on_panic_checkbox = new ConfigBool(tr("Pause on Panic"), Config::MAIN_PAUSE_ON_PANIC);
+  m_pause_on_panic_checkbox->SetDescription(
+      tr("Pauses the emulation if a Read/Write or Unknown Instruction panic occurs.<br>Enabling "
+         "will affect performance.<br>The performance impact is the same as having Enable MMU "
+         "on.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
+  cpu_options_group_layout->addWidget(m_pause_on_panic_checkbox);
+
+  m_accurate_cpu_cache_checkbox =
+      new ConfigBool(tr("Enable Write-Back Cache (slow)"), Config::MAIN_ACCURATE_CPU_CACHE);
+  m_accurate_cpu_cache_checkbox->SetDescription(
+      tr("Enables emulation of the CPU write-back cache.<br>Enabling will have a significant "
+         "impact on performance.<br>This should be left disabled unless absolutely "
+         "needed.<br><br><dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>"));
+  cpu_options_group_layout->addWidget(m_accurate_cpu_cache_checkbox);
+
+  auto* rtc_options = new QGroupBox(tr("Custom RTC Options"));
+  rtc_options->setLayout(new QVBoxLayout());
+  main_layout->addWidget(rtc_options);
+
+  m_custom_rtc_checkbox = new QCheckBox(tr("Enable Custom RTC"));
+  rtc_options->layout()->addWidget(m_custom_rtc_checkbox);
+
+  m_custom_rtc_datetime = new QDateTimeEdit();
+
+  // Show seconds
+  m_custom_rtc_datetime->setDisplayFormat(m_custom_rtc_datetime->displayFormat().replace(
+      QStringLiteral("mm"), QStringLiteral("mm:ss")));
+
+  if (!m_custom_rtc_datetime->displayFormat().contains(QStringLiteral("yyyy")))
+  {
+    // Always show the full year, no matter what the locale specifies. Otherwise, two-digit years
+    // will always be interpreted as in the 21st century.
+    m_custom_rtc_datetime->setDisplayFormat(m_custom_rtc_datetime->displayFormat().replace(
+        QStringLiteral("yy"), QStringLiteral("yyyy")));
+  }
+  m_custom_rtc_datetime->setDateTimeRange(QDateTime({2000, 1, 1}, {0, 0, 0}, Qt::UTC),
+                                          QDateTime({2099, 12, 31}, {23, 59, 59}, Qt::UTC));
+  m_custom_rtc_datetime->setTimeSpec(Qt::UTC);
+  rtc_options->layout()->addWidget(m_custom_rtc_datetime);
+
+  auto* custom_rtc_description =
+      new QLabel(tr("This setting allows you to set a custom real time clock (RTC) separate from "
+                    "your current system time.\n\nIf unsure, leave this unchecked."));
+  custom_rtc_description->setWordWrap(true);
+  rtc_options->layout()->addWidget(custom_rtc_description);
+
+  main_layout->addStretch(1);
+}
+
+void MiscPane::ConnectLayout()
+{
+  connect(m_cpu_emulation_engine_combobox, &QComboBox::currentIndexChanged, [](int index) {
+    const auto cpu_cores = PowerPC::AvailableCPUCores();
+    if (index >= 0 && static_cast<size_t>(index) < cpu_cores.size())
+      Config::SetBaseOrCurrent(Config::MAIN_CPU_CORE, cpu_cores[index]);
+  });
+
+  connect(m_custom_rtc_checkbox, &QCheckBox::toggled, [this](bool enable_custom_rtc) {
+    Config::SetBaseOrCurrent(Config::MAIN_CUSTOM_RTC_ENABLE, enable_custom_rtc);
+    Update();
+  });
+
+  connect(m_custom_rtc_datetime, &QDateTimeEdit::dateTimeChanged, [this](QDateTime date_time) {
+    Config::SetBaseOrCurrent(Config::MAIN_CUSTOM_RTC_VALUE,
+                             static_cast<u32>(date_time.toSecsSinceEpoch()));
+    Update();
+  });
+}
+
+void MiscPane::Update()
+{
+  const bool running = Core::GetState() != Core::State::Uninitialized;
+  const bool enable_custom_rtc_widgets = Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE) && !running;
+
+  const auto available_cpu_cores = PowerPC::AvailableCPUCores();
+  const auto cpu_core = Config::Get(Config::MAIN_CPU_CORE);
+  for (size_t i = 0; i < available_cpu_cores.size(); ++i)
+  {
+    if (available_cpu_cores[i] == cpu_core)
+      m_cpu_emulation_engine_combobox->setCurrentIndex(int(i));
+  }
+  m_cpu_emulation_engine_combobox->setEnabled(!running);
+  m_enable_mmu_checkbox->setEnabled(!running);
+  m_pause_on_panic_checkbox->setEnabled(!running);
+
+  m_custom_rtc_checkbox->setEnabled(!running);
+  SignalBlocking(m_custom_rtc_checkbox)->setChecked(Config::Get(Config::MAIN_CUSTOM_RTC_ENABLE));
+
+  QDateTime initial_date_time;
+  initial_date_time.setSecsSinceEpoch(Config::Get(Config::MAIN_CUSTOM_RTC_VALUE));
+  m_custom_rtc_datetime->setEnabled(enable_custom_rtc_widgets);
+  SignalBlocking(m_custom_rtc_datetime)->setDateTime(initial_date_time);
+}

--- a/Source/Core/DolphinQt/Settings/MiscPane.h
+++ b/Source/Core/DolphinQt/Settings/MiscPane.h
@@ -1,0 +1,33 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QWidget>
+
+#include "DolphinQt/Config/ConfigControls/ConfigBool.h"
+
+class QCheckBox;
+class QComboBox;
+class QDateTimeEdit;
+
+class MiscPane final : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit MiscPane(QWidget* parent = nullptr);
+
+private:
+  void CreateLayout();
+  void ConnectLayout();
+  void Update();
+
+  QComboBox* m_cpu_emulation_engine_combobox;
+  ConfigBool* m_enable_mmu_checkbox;
+  ConfigBool* m_pause_on_panic_checkbox;
+  ConfigBool* m_accurate_cpu_cache_checkbox;
+
+  QCheckBox* m_custom_rtc_checkbox;
+  QDateTimeEdit* m_custom_rtc_datetime;
+};


### PR DESCRIPTION
It has gotten too tall.

Before:

![image](https://user-images.githubusercontent.com/6716818/80807411-681c8200-8bbd-11ea-9cf3-21703ecf2ab5.png)

After:

![image](https://user-images.githubusercontent.com/6716818/80807421-6f439000-8bbd-11ea-9f45-91864b6229e6.png)

![image](https://user-images.githubusercontent.com/6716818/80807424-723e8080-8bbd-11ea-97a0-0f2721f5676b.png)

Suggestions for alternative names for the two tabs are welcome. I was considering "Hardware" or "Specs" for the one with the CPU clock override and the memory override, since the tab contains settings that change the specifications of the emulated hardware, but maybe naming the tab like that could make people think that the tab is about the hardware/specs of the host computer...