### PR TITLE
NetPlay: Reuse WiiSave code for save syncing

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -613,6 +613,19 @@ bool SetCurrentDir(const std::string& directory)
   return __chdir(directory.c_str()) == 0;
 }
 
+ScopedTemporaryDirectory::ScopedTemporaryDirectory()
+{
+  m_path = CreateTempDir();
+  ASSERT(!m_path.empty());
+  m_valid = !m_path.empty();
+}
+
+ScopedTemporaryDirectory::~ScopedTemporaryDirectory()
+{
+  if (m_valid)
+    DeleteDirRecursively(m_path);
+}
+
 std::string CreateTempDir()
 {
 #ifdef _WIN32

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -111,6 +111,37 @@ private:
   bool m_exists;
 };
 
+class ScopedTemporaryDirectory
+{
+public:
+  // Create a temporary directory.
+  ScopedTemporaryDirectory();
+  ScopedTemporaryDirectory(const ScopedTemporaryDirectory&) = delete;
+  ScopedTemporaryDirectory(ScopedTemporaryDirectory&& other) { *this = std::move(other); }
+  ScopedTemporaryDirectory& operator=(const ScopedTemporaryDirectory&) = delete;
+  ScopedTemporaryDirectory& operator=(ScopedTemporaryDirectory&& other)
+  {
+    m_valid = other.m_valid;
+    m_path = std::move(other.m_path);
+    other.m_valid = false;
+    return *this;
+  }
+
+  // Delete the temporary directory.
+  ~ScopedTemporaryDirectory();
+
+  const std::string& GetPath() const { return m_path; }
+  std::string Release()
+  {
+    m_valid = false;
+    return m_path;
+  }
+
+private:
+  bool m_valid = false;
+  std::string m_path;
+};
+
 // Returns true if the path exists
 bool Exists(const std::string& path);
 

--- a/Source/Core/Core/HW/WiiSave.h
+++ b/Source/Core/Core/HW/WiiSave.h
@@ -28,9 +28,16 @@ struct StorageDeleter
   void operator()(Storage* p) const;
 };
 
+enum class DataBinType
+{
+  Encrypted,
+  Unencrypted,
+};
+
 using StoragePointer = std::unique_ptr<Storage, StorageDeleter>;
 StoragePointer MakeNandStorage(IOS::HLE::FS::FileSystem* fs, u64 tid);
-StoragePointer MakeDataBinStorage(IOS::HLE::IOSC* iosc, const std::string& path, const char* mode);
+StoragePointer MakeDataBinStorage(IOS::HLE::IOSC* iosc, const std::string& path, const char* mode,
+                                  DataBinType type = DataBinType::Encrypted);
 
 bool Copy(Storage* source, Storage* destination);
 


### PR DESCRIPTION
It's simpler to just reuse the existing WiiSave serialization
and deserialization code and treat the saves as binary blobs,
especially when netplay doesn't actually look at any of the information
in the WiiSave structures.

To ensure save blobs can be compressed well, this adds an option to
WiiSave to disable encryption.

Bonus: we don't need to hold every single save file in memory at the
same time, and compressing entire save blobs will probably result in
smaller sizes compared to compressing each file separately.