### PR TITLE
Fix Windows CMake build errors

### DIFF
--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -139,26 +139,26 @@ void VerifyWidget::Verify()
   progress.GetRaw()->setMinimumDuration(500);
   progress.GetRaw()->setWindowModality(Qt::WindowModal);
 
-  auto future =
-      std::async(std::launch::async,
-                 [&verifier, &progress]() -> std::optional<DiscIO::VolumeVerifier::Result> {
-                   progress.SetValue(0);
-                   verifier.Start();
-                   while (verifier.GetBytesProcessed() != verifier.GetTotalBytes())
-                   {
-                     progress.SetValue(static_cast<int>(verifier.GetBytesProcessed() / DIVISOR));
-                     if (progress.WasCanceled())
-                       return std::nullopt;
+  auto future = std::async(
+      std::launch::async,
+      [&verifier, &progress, DIVISOR]() -> std::optional<DiscIO::VolumeVerifier::Result> {
+        progress.SetValue(0);
+        verifier.Start();
+        while (verifier.GetBytesProcessed() != verifier.GetTotalBytes())
+        {
+          progress.SetValue(static_cast<int>(verifier.GetBytesProcessed() / DIVISOR));
+          if (progress.WasCanceled())
+            return std::nullopt;
 
-                     verifier.Process();
-                   }
-                   verifier.Finish();
+          verifier.Process();
+        }
+        verifier.Finish();
 
-                   const DiscIO::VolumeVerifier::Result result = verifier.GetResult();
-                   progress.Reset();
+        const DiscIO::VolumeVerifier::Result result = verifier.GetResult();
+        progress.Reset();
 
-                   return result;
-                 });
+        return result;
+      });
   progress.GetRaw()->exec();
 
   std::optional<DiscIO::VolumeVerifier::Result> result = future.get();

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -194,11 +194,20 @@ void CodeViewWidget::FontBasedSizing()
   constexpr int extra_text_width = 8;
 
   const QFontMetrics fm(Settings::Instance().GetDebugFont());
+
+  const auto width = [&fm](QString text) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    return fm.horizontalAdvance(text);
+#else
+    return fm.width(text);
+#endif
+  };
+
   const int rowh = fm.height() + 1;
   verticalHeader()->setMaximumSectionSize(rowh);
   horizontalHeader()->setMinimumSectionSize(rowh + 5);
   setColumnWidth(CODE_VIEW_COLUMN_BREAKPOINT, rowh + 5);
-  setColumnWidth(CODE_VIEW_COLUMN_ADDRESS, fm.width(QStringLiteral("80000000")) + extra_text_width);
+  setColumnWidth(CODE_VIEW_COLUMN_ADDRESS, width(QStringLiteral("80000000")) + extra_text_width);
 
   // The longest instruction is technically 'ps_merge00' (0x10000420u), but those instructions are
   // very rare and would needlessly increase the column size, so let's go with 'rlwinm.' instead.
@@ -210,11 +219,10 @@ void CodeViewWidget::FontBasedSizing()
   const std::string ins = (split == std::string::npos ? disas : disas.substr(0, split));
   const std::string param = (split == std::string::npos ? "" : disas.substr(split + 1));
   setColumnWidth(CODE_VIEW_COLUMN_INSTRUCTION,
-                 fm.width(QString::fromStdString(ins)) + extra_text_width);
+                 width(QString::fromStdString(ins)) + extra_text_width);
   setColumnWidth(CODE_VIEW_COLUMN_PARAMETERS,
-                 fm.width(QString::fromStdString(param)) + extra_text_width);
-  setColumnWidth(CODE_VIEW_COLUMN_DESCRIPTION,
-                 fm.width(QStringLiteral("0")) * 25 + extra_text_width);
+                 width(QString::fromStdString(param)) + extra_text_width);
+  setColumnWidth(CODE_VIEW_COLUMN_DESCRIPTION, width(QStringLiteral("0")) * 25 + extra_text_width);
 
   Update();
 }

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -196,7 +196,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 
   mmio->Register(base | FIFO_BP_LO, MMIO::DirectRead<u16>(MMIO::Utils::LowPart(&fifo.CPBreakpoint)),
-                 MMIO::ComplexWrite<u16>([](u32, u16 val) {
+                 MMIO::ComplexWrite<u16>([WMASK_LO_ALIGN_32BIT](u32, u16 val) {
                    WriteLow(fifo.CPBreakpoint, val & WMASK_LO_ALIGN_32BIT);
                  }));
   mmio->Register(base | FIFO_BP_HI,


### PR DESCRIPTION
Lambda expressions with uncaptured constants were leading to errors, and there were also some warnings about deprecated functions (QFontMetrics::width and inet_ntoa).