### PR TITLE
Remove redundant "Emulation" from "DSP HLE Emulation"

### DIFF
--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -35,7 +35,7 @@
 
     <!-- DSP Emulation Engine -->
     <string-array name="dspEngineEntriesX86_64" translatable="false">
-        <item>DSP HLE Emulation (fast)</item>
+        <item>DSP HLE (fast)</item>
         <item>DSP LLE Recompiler</item>
         <item>DSP LLE Interpreter (slow)</item>
     </string-array>
@@ -45,7 +45,7 @@
         <item>2</item>
     </integer-array>
     <string-array name="dspEngineEntriesGeneric" translatable="false">
-        <item>DSP HLE Emulation (fast)</item>
+        <item>DSP HLE (fast)</item>
         <item>DSP LLE Interpreter (slow)</item>
     </string-array>
     <integer-array name="dspEngineValuesGeneric" translatable="false">

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.cpp
@@ -90,7 +90,7 @@ void GameConfigWidget::CreateWidgets()
   m_enable_fprf = new QCheckBox(tr("Enable FPRF"));
   m_sync_gpu = new QCheckBox(tr("Synchronize GPU thread"));
   m_enable_fast_disc = new QCheckBox(tr("Speed up Disc Transfer Rate"));
-  m_use_dsp_hle = new QCheckBox(tr("DSP HLE Emulation (fast)"));
+  m_use_dsp_hle = new QCheckBox(tr("DSP HLE (fast)"));
   m_deterministic_dual_core = new QComboBox;
 
   for (const auto& item : {tr("Not Set"), tr("auto"), tr("none"), tr("fake-completion")})

--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -48,7 +48,7 @@ void AudioPane::CreateWidgets()
   auto* dsp_layout = new QVBoxLayout;
 
   dsp_box->setLayout(dsp_layout);
-  m_dsp_hle = new QRadioButton(tr("DSP HLE Emulation (fast)"));
+  m_dsp_hle = new QRadioButton(tr("DSP HLE (fast)"));
   m_dsp_lle = new QRadioButton(tr("DSP LLE Recompiler"));
   m_dsp_interpreter = new QRadioButton(tr("DSP LLE Interpreter (slow)"));
 


### PR DESCRIPTION
HLE stands for "high-level emulation", so "DSP HLE Emulation" would
mean "DSP High-Level Emulation Emulation"