### PR TITLE
VideoCommon: Break build dependency cycle

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -553,10 +553,6 @@ PUBLIC
   pugixml
   sfml-network
   sfml-system
-  videonull
-  videoogl
-  videosoftware
-  videovulkan
 
 PRIVATE
   fmt::fmt

--- a/Source/Core/UICommon/CMakeLists.txt
+++ b/Source/Core/UICommon/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(uicommon
   UICommon.h
   USBUtils.cpp
   USBUtils.h
+  VideoBackends.cpp
+  VideoBackends.h
   VideoUtils.cpp
   VideoUtils.h
 )
@@ -30,6 +32,10 @@ add_library(uicommon
 target_link_libraries(uicommon
 PUBLIC
   common
+  videonull
+  videoogl
+  videosoftware
+  videovulkan
   cpp-optparse
   minizip
   pugixml
@@ -38,6 +44,14 @@ PRIVATE
   fmt::fmt
   $<$<BOOL:APPLE>:${IOK_LIBRARY}>
 )
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_link_libraries(uicommon
+  PUBLIC
+    videod3d
+    videod3d12
+  )
+endif()
 
 if ((DEFINED CMAKE_ANDROID_ARCH_ABI AND CMAKE_ANDROID_ARCH_ABI MATCHES "x86|x86_64") OR
     (NOT DEFINED CMAKE_ANDROID_ARCH_ABI AND _M_X86))

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -38,6 +38,7 @@
 #include "UICommon/DiscordPresence.h"
 #include "UICommon/UICommon.h"
 #include "UICommon/USBUtils.h"
+#include "UICommon/VideoBackends.h"
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 #include "UICommon/X11Utils.h"
@@ -97,7 +98,7 @@ void Init()
   SConfig::Init();
   Discord::Init();
   Common::Log::LogManager::Init();
-  VideoBackendBase::PopulateList();
+  RegisterVideoBackends();
   WiimoteReal::LoadSettings();
   GCAdapter::Init();
   VideoBackendBase::ActivateBackend(SConfig::GetInstance().m_strVideoBackend);

--- a/Source/Core/UICommon/UICommon.vcxproj
+++ b/Source/Core/UICommon/UICommon.vcxproj
@@ -73,6 +73,7 @@
     <ClCompile Include="USBUtils.cpp">
       <DisableSpecificWarnings>4200;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
+    <ClCompile Include="VideoBackends.cpp" />
     <ClCompile Include="VideoUtils.cpp" />
     <ClCompile Include="GameFile.cpp" />
     <ClCompile Include="GameFileCache.cpp" />
@@ -88,6 +89,8 @@
     <ClInclude Include="UICommon.h" />
     <ClInclude Include="Disassembler.h" />
     <ClInclude Include="USBUtils.h" />
+    <ClInclude Include="VideoBackends.h" />
+    <ClCompile Include="VideoUtils.h" />
     <ClInclude Include="GameFile.h" />
     <ClInclude Include="GameFileCache.h" />
   </ItemGroup>

--- a/Source/Core/UICommon/VideoBackends.cpp
+++ b/Source/Core/UICommon/VideoBackends.cpp
@@ -1,0 +1,45 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "UICommon/VideoBackends.h"
+
+// OpenGL is not available on Windows-on-ARM64
+#if !defined(_WIN32) || !defined(_M_ARM64)
+#define HAS_OPENGL 1
+#endif
+
+#ifdef _WIN32
+#include "VideoBackends/D3D/VideoBackend.h"
+#include "VideoBackends/D3D12/VideoBackend.h"
+#endif
+#include "VideoBackends/Null/VideoBackend.h"
+#ifdef HAS_OPENGL
+#include "VideoBackends/OGL/VideoBackend.h"
+#include "VideoBackends/Software/VideoBackend.h"
+#endif
+#include "VideoBackends/Vulkan/VideoBackend.h"
+
+#include <algorithm>
+
+namespace UICommon {
+
+// This function has to exit outside of videocommon to prevent circular dependencies
+void RegisterVideoBackends()
+{
+  // OGL > D3D11 > Vulkan > SW > Null
+#ifdef HAS_OPENGL
+  VideoBackendBase::RegisterBackend(std::make_unique<OGL::VideoBackend>());
+#endif
+#ifdef _WIN32
+  VideoBackendBase::RegisterBackend(std::make_unique<DX11::VideoBackend>());
+  VideoBackendBase::RegisterBackend(std::make_unique<DX12::VideoBackend>());
+#endif
+  VideoBackendBase::RegisterBackend(std::make_unique<Vulkan::VideoBackend>());
+#ifdef HAS_OPENGL
+  VideoBackendBase::RegisterBackend(std::make_unique<SW::VideoSoftware>());
+#endif
+  VideoBackendBase::RegisterBackend(std::make_unique<Null::VideoBackend>());
+}
+
+}

--- a/Source/Core/UICommon/VideoBackends.h
+++ b/Source/Core/UICommon/VideoBackends.h
@@ -1,0 +1,11 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace UICommon {
+
+void RegisterVideoBackends();
+
+}

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -130,7 +130,7 @@ add_library(videocommon
 
 target_link_libraries(videocommon
 PUBLIC
-  core
+  common
 PRIVATE
   fmt::fmt
   png

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -20,22 +20,6 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
-// OpenGL is not available on Windows-on-ARM64
-#if !defined(_WIN32) || !defined(_M_ARM64)
-#define HAS_OPENGL 1
-#endif
-
-// TODO: ugly
-#ifdef _WIN32
-#include "VideoBackends/D3D/VideoBackend.h"
-#include "VideoBackends/D3D12/VideoBackend.h"
-#endif
-#include "VideoBackends/Null/VideoBackend.h"
-#ifdef HAS_OPENGL
-#include "VideoBackends/OGL/VideoBackend.h"
-#include "VideoBackends/Software/VideoBackend.h"
-#endif
-#include "VideoBackends/Vulkan/VideoBackend.h"
 
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/BPStructs.h"
@@ -195,21 +179,9 @@ u16 VideoBackendBase::Video_GetBoundingBox(int index)
   return result;
 }
 
-void VideoBackendBase::PopulateList()
+void VideoBackendBase::RegisterBackend(std::unique_ptr<VideoBackendBase> backend)
 {
-  // OGL > D3D11 > Vulkan > SW > Null
-#ifdef HAS_OPENGL
-  g_available_video_backends.push_back(std::make_unique<OGL::VideoBackend>());
-#endif
-#ifdef _WIN32
-  g_available_video_backends.push_back(std::make_unique<DX11::VideoBackend>());
-  g_available_video_backends.push_back(std::make_unique<DX12::VideoBackend>());
-#endif
-  g_available_video_backends.push_back(std::make_unique<Vulkan::VideoBackend>());
-#ifdef HAS_OPENGL
-  g_available_video_backends.push_back(std::make_unique<SW::VideoSoftware>());
-#endif
-  g_available_video_backends.push_back(std::make_unique<Null::VideoBackend>());
+  g_available_video_backends.push_back(std::move(backend));
 
   const auto iter =
       std::find_if(g_available_video_backends.begin(), g_available_video_backends.end(),

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -59,7 +59,7 @@ public:
   u32 Video_GetQueryResult(PerfQueryType type);
   u16 Video_GetBoundingBox(int index);
 
-  static void PopulateList();
+  static void RegisterBackend(std::unique_ptr<VideoBackendBase> backend);
   static void ClearList();
   static void ActivateBackend(const std::string& name);
 


### PR DESCRIPTION
In cmake, VideoCommon was depending on it's video
backends by depending on all of core.
Not only was this a cycle, with the video backends
depending on VideoCommon again, but VideoCommon
really shouldn't be depending on core.

So we move the initialization of the video backends into UICommon