### PR TITLE
DolphinQt / VideoCommon: Add additional texture dumping options

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -35,6 +35,8 @@ const Info<bool> GFX_LOG_RENDER_TIME_TO_FILE{{System::GFX, "Settings", "LogRende
 const Info<bool> GFX_OVERLAY_STATS{{System::GFX, "Settings", "OverlayStats"}, false};
 const Info<bool> GFX_OVERLAY_PROJ_STATS{{System::GFX, "Settings", "OverlayProjStats"}, false};
 const Info<bool> GFX_DUMP_TEXTURES{{System::GFX, "Settings", "DumpTextures"}, false};
+const Info<bool> GFX_DUMP_MIP_TEXTURES{{System::GFX, "Settings", "DumpMipTextures"}, true};
+const Info<bool> GFX_DUMP_BASE_TEXTURES{{System::GFX, "Settings", "DumpBaseTextures"}, true};
 const Info<bool> GFX_HIRES_TEXTURES{{System::GFX, "Settings", "HiresTextures"}, false};
 const Info<bool> GFX_CACHE_HIRES_TEXTURES{{System::GFX, "Settings", "CacheHiresTextures"}, false};
 const Info<bool> GFX_DUMP_EFB_TARGET{{System::GFX, "Settings", "DumpEFBTarget"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -36,6 +36,8 @@ extern const Info<bool> GFX_LOG_RENDER_TIME_TO_FILE;
 extern const Info<bool> GFX_OVERLAY_STATS;
 extern const Info<bool> GFX_OVERLAY_PROJ_STATS;
 extern const Info<bool> GFX_DUMP_TEXTURES;
+extern const Info<bool> GFX_DUMP_MIP_TEXTURES;
+extern const Info<bool> GFX_DUMP_BASE_TEXTURES;
 extern const Info<bool> GFX_HIRES_TEXTURES;
 extern const Info<bool> GFX_CACHE_HIRES_TEXTURES;
 extern const Info<bool> GFX_DUMP_EFB_TARGET;

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -65,7 +65,6 @@ void AdvancedWidget::CreateWidgets()
   auto* utility_layout = new QGridLayout();
   utility_box->setLayout(utility_layout);
 
-  m_dump_textures = new GraphicsBool(tr("Dump Textures"), Config::GFX_DUMP_TEXTURES);
   m_load_custom_textures = new GraphicsBool(tr("Load Custom Textures"), Config::GFX_HIRES_TEXTURES);
   m_prefetch_custom_textures =
       new GraphicsBool(tr("Prefetch Custom Textures"), Config::GFX_CACHE_HIRES_TEXTURES);
@@ -77,9 +76,8 @@ void AdvancedWidget::CreateWidgets()
   utility_layout->addWidget(m_prefetch_custom_textures, 0, 1);
 
   utility_layout->addWidget(m_disable_vram_copies, 1, 0);
-  utility_layout->addWidget(m_dump_textures, 1, 1);
 
-  utility_layout->addWidget(m_dump_efb_target, 2, 0);
+  utility_layout->addWidget(m_dump_efb_target, 1, 1);
 
   // Freelook
   auto* freelook_box = new QGroupBox(tr("Free Look"));
@@ -93,6 +91,19 @@ void AdvancedWidget::CreateWidgets()
   freelook_layout->addWidget(m_enable_freelook, 0, 0);
   freelook_layout->addWidget(new QLabel(tr("Control Type:")), 1, 0);
   freelook_layout->addWidget(m_freelook_control_type, 1, 1);
+
+  // Texture dumping
+  auto* texture_dump_box = new QGroupBox(tr("Texture Dumping"));
+  auto* texture_dump_layout = new QGridLayout();
+  texture_dump_box->setLayout(texture_dump_layout);
+  m_dump_textures = new GraphicsBool(tr("Enable"), Config::GFX_DUMP_TEXTURES);
+  m_dump_base_textures = new GraphicsBool(tr("Dump Base Textures"), Config::GFX_DUMP_BASE_TEXTURES);
+  m_dump_mip_textures = new GraphicsBool(tr("Dump Mip Maps"), Config::GFX_DUMP_MIP_TEXTURES);
+
+  texture_dump_layout->addWidget(m_dump_textures, 0, 0);
+
+  texture_dump_layout->addWidget(m_dump_base_textures, 1, 0);
+  texture_dump_layout->addWidget(m_dump_mip_textures, 1, 1);
 
   // Frame dumping
   auto* dump_box = new QGroupBox(tr("Frame Dumping"));
@@ -144,6 +155,7 @@ void AdvancedWidget::CreateWidgets()
   main_layout->addWidget(debugging_box);
   main_layout->addWidget(utility_box);
   main_layout->addWidget(freelook_box);
+  main_layout->addWidget(texture_dump_box);
   main_layout->addWidget(dump_box);
   main_layout->addWidget(misc_box);
   main_layout->addWidget(experimental_box);
@@ -158,6 +170,7 @@ void AdvancedWidget::ConnectWidgets()
   connect(m_dump_use_ffv1, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
   connect(m_enable_prog_scan, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
   connect(m_enable_freelook, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
+  connect(m_dump_textures, &QCheckBox::toggled, this, &AdvancedWidget::SaveSettings);
 }
 
 void AdvancedWidget::LoadSettings()
@@ -168,6 +181,8 @@ void AdvancedWidget::LoadSettings()
   m_enable_prog_scan->setChecked(Config::Get(Config::SYSCONF_PROGRESSIVE_SCAN));
 
   m_freelook_control_type->setEnabled(Config::Get(Config::GFX_FREE_LOOK));
+  m_dump_mip_textures->setEnabled(Config::Get(Config::GFX_DUMP_TEXTURES));
+  m_dump_base_textures->setEnabled(Config::Get(Config::GFX_DUMP_TEXTURES));
 }
 
 void AdvancedWidget::SaveSettings()
@@ -178,6 +193,8 @@ void AdvancedWidget::SaveSettings()
   Config::SetBase(Config::SYSCONF_PROGRESSIVE_SCAN, m_enable_prog_scan->isChecked());
 
   m_freelook_control_type->setEnabled(Config::Get(Config::GFX_FREE_LOOK));
+  m_dump_mip_textures->setEnabled(Config::Get(Config::GFX_DUMP_TEXTURES));
+  m_dump_base_textures->setEnabled(Config::Get(Config::GFX_DUMP_TEXTURES));
 }
 
 void AdvancedWidget::OnBackendChanged()
@@ -201,9 +218,20 @@ void AdvancedWidget::AddDescriptions()
   static const char TR_VALIDATION_LAYER_DESCRIPTION[] =
       QT_TR_NOOP("Enables validation of API calls made by the video backend, which may assist in "
                  "debugging graphical issues.\n\nIf unsure, leave this unchecked.");
-  static const char TR_DUMP_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
-      "Dumps decoded game textures to User/Dump/Textures/<game_id>/.\n\nIf unsure, leave "
-      "this unchecked.");
+  static const char TR_DUMP_TEXTURE_DESCRIPTION[] =
+      QT_TR_NOOP("Dumps decoded game textures based on the other flags to "
+                 "User/Dump/Textures/<game_id>/.\n\nIf unsure, leave "
+                 "this unchecked.");
+  static const char TR_DUMP_MIP_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
+      "Whether to dump mipmapped game textures to "
+      "User/Dump/Textures/<game_id>/.  This includes arbitrary mipmapped textures if 'Arbitrary "
+      "Mipmap Detection' is enabled in Enhancements.\n\nIf unsure, leave "
+      "this checked.");
+  static const char TR_DUMP_BASE_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
+      "Whether to dump base game textures to "
+      "User/Dump/Textures/<game_id>/.  This includes arbitrary base textures if 'Arbitrary "
+      "Mipmap Detection' is enabled in Enhancements.\n\nIf unsure, leave "
+      "this checked.");
   static const char TR_LOAD_CUSTOM_TEXTURE_DESCRIPTION[] = QT_TR_NOOP(
       "Loads custom textures from User/Load/Textures/<game_id>/.\n\nIf unsure, leave this "
       "unchecked.");
@@ -268,6 +296,8 @@ void AdvancedWidget::AddDescriptions()
   AddDescription(m_enable_format_overlay, TR_TEXTURE_FORMAT_DESCRIPTION);
   AddDescription(m_enable_api_validation, TR_VALIDATION_LAYER_DESCRIPTION);
   AddDescription(m_dump_textures, TR_DUMP_TEXTURE_DESCRIPTION);
+  AddDescription(m_dump_mip_textures, TR_DUMP_MIP_TEXTURE_DESCRIPTION);
+  AddDescription(m_dump_base_textures, TR_DUMP_BASE_TEXTURE_DESCRIPTION);
   AddDescription(m_load_custom_textures, TR_LOAD_CUSTOM_TEXTURE_DESCRIPTION);
   AddDescription(m_prefetch_custom_textures, TR_CACHE_CUSTOM_TEXTURE_DESCRIPTION);
   AddDescription(m_dump_efb_target, TR_DUMP_EFB_DESCRIPTION);

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -34,13 +34,17 @@ private:
   QCheckBox* m_enable_api_validation;
 
   // Utility
-  QCheckBox* m_dump_textures;
   QCheckBox* m_prefetch_custom_textures;
   QCheckBox* m_dump_efb_target;
   QCheckBox* m_disable_vram_copies;
   QCheckBox* m_load_custom_textures;
   QCheckBox* m_enable_freelook;
   QComboBox* m_freelook_control_type;
+
+  // Texture dumping
+  QCheckBox* m_dump_textures;
+  QCheckBox* m_dump_mip_textures;
+  QCheckBox* m_dump_base_textures;
 
   // Frame dumping
   QCheckBox* m_dump_use_ffv1;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -920,7 +920,14 @@ void TextureCacheBase::DumpTexture(TCacheEntry* entry, std::string basename, uns
 
   if (level > 0)
   {
+    if (!g_ActiveConfig.bDumpMipmapTextures)
+      return;
     basename += fmt::format("_mip{}", level);
+  }
+  else
+  {
+    if (!g_ActiveConfig.bDumpBaseTextures)
+      return;
   }
 
   const std::string filename = fmt::format("{}/{}.png", szDir, basename);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -85,6 +85,8 @@ void VideoConfig::Refresh()
   bOverlayStats = Config::Get(Config::GFX_OVERLAY_STATS);
   bOverlayProjStats = Config::Get(Config::GFX_OVERLAY_PROJ_STATS);
   bDumpTextures = Config::Get(Config::GFX_DUMP_TEXTURES);
+  bDumpMipmapTextures = Config::Get(Config::GFX_DUMP_MIP_TEXTURES);
+  bDumpBaseTextures = Config::Get(Config::GFX_DUMP_BASE_TEXTURES);
   bHiresTextures = Config::Get(Config::GFX_HIRES_TEXTURES);
   bCacheHiresTextures = Config::Get(Config::GFX_CACHE_HIRES_TEXTURES);
   bDumpEFBTarget = Config::Get(Config::GFX_DUMP_EFB_TARGET);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -102,6 +102,8 @@ struct VideoConfig final
 
   // Utility
   bool bDumpTextures;
+  bool bDumpMipmapTextures;
+  bool bDumpBaseTextures;
   bool bHiresTextures;
   bool bCacheHiresTextures;
   bool bDumpEFBTarget;


### PR DESCRIPTION
Specifically, this enables users to choose whether to dump mip maps, or base level textures.

![image](https://user-images.githubusercontent.com/15224722/87733743-35366300-c796-11ea-9b0f-2bb83a7807cc.png)

