### PR TITLE
InputCommon: Use the Window handle when initializing DirectInput.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -105,18 +105,17 @@ void ControllerInterface::RefreshDevices()
   InvokeDevicesChangedCallbacks();
 
 #ifdef CIFACE_USE_WIN32
-  // Should this be changed for other platforms? I don't have the means to test...
   ciface::Win32::PopulateDevices(m_wsi.render_window);
 #endif
 #ifdef CIFACE_USE_XLIB
   if (m_wsi.type == WindowSystemType::X11)
-    ciface::XInput2::PopulateDevices(m_wsi.render_surface);
+    ciface::XInput2::PopulateDevices(m_wsi.render_window);
 #endif
 #ifdef CIFACE_USE_OSX
   if (m_wsi.type == WindowSystemType::MacOS)
   {
-    ciface::OSX::PopulateDevices(m_wsi.render_surface);
-    ciface::Quartz::PopulateDevices(m_wsi.render_surface);
+    ciface::OSX::PopulateDevices(m_wsi.render_window);
+    ciface::Quartz::PopulateDevices(m_wsi.render_window);
   }
 #endif
 #ifdef CIFACE_USE_SDL

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -105,7 +105,8 @@ void ControllerInterface::RefreshDevices()
   InvokeDevicesChangedCallbacks();
 
 #ifdef CIFACE_USE_WIN32
-  ciface::Win32::PopulateDevices(m_wsi.render_surface);
+  // Should this be changed for other platforms? I don't have the means to test...
+  ciface::Win32::PopulateDevices(m_wsi.render_window);
 #endif
 #ifdef CIFACE_USE_XLIB
   if (m_wsi.type == WindowSystemType::X11)


### PR DESCRIPTION
Previously, when initializing the Win32 input layer (and as a result DirectInput), Dolphin would use the handle of the render widget, which isn't updated when `ControllerInterface::ChangeWindow` is called. This had the annoying side effect of making all mouse input to Dolphin on Windows relative to the main Dolphin window, not the actual render target or render window. 

This PR makes sure the Win32 controller interface is initialized using the actual window handle, which in turn makes mouse input relative to the render target itself, not the main window.