### PR TITLE
IOS/KD: Implement IOCTL_NWC24_REQUEST_SHUTDOWN

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -274,8 +274,8 @@ IPCCommandResult NetIPTop::IOCtl(const IOCtlRequest& request)
 
   switch (request.request)
   {
-  case IOCTL_SO_STARTUP:
-    return HandleStartUpRequest(request);
+  case IOCTL_SO_INITINTERFACE:
+    return HandleInitInterfaceRequest(request);
   case IOCTL_SO_SOCKET:
     return HandleSocketRequest(request);
   case IOCTL_SO_ICMPSOCKET:
@@ -349,7 +349,7 @@ void NetIPTop::Update()
   WiiSockMan::GetInstance().Update();
 }
 
-IPCCommandResult NetIPTop::HandleStartUpRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTop::HandleInitInterfaceRequest(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_WC24);
   return GetDefaultReply(IPC_SUCCESS);

--- a/Source/Core/Core/IOS/Network/IP/Top.h
+++ b/Source/Core/Core/IOS/Network/IP/Top.h
@@ -36,18 +36,18 @@ enum NET_IOCTL
   IOCTL_SO_GETHOSTBYNAME,
   IOCTL_SO_GETHOSTBYADDR,
   IOCTLV_SO_GETNAMEINFO,
-  IOCTL_SO_UNK14,
+  IOCTL_SO_GETLASTERROR,
   IOCTL_SO_INETATON,
   IOCTL_SO_INETPTON,
   IOCTL_SO_INETNTOP,
   IOCTLV_SO_GETADDRINFO,
   IOCTL_SO_SOCKATMARK,
-  IOCTLV_SO_UNK1A,
-  IOCTLV_SO_UNK1B,
+  IOCTLV_SO_STARTUP,
+  IOCTLV_SO_CLEANUP,
   IOCTLV_SO_GETINTERFACEOPT,
   IOCTLV_SO_SETINTERFACEOPT,
   IOCTL_SO_SETINTERFACE,
-  IOCTL_SO_STARTUP,
+  IOCTL_SO_INITINTERFACE,
   IOCTL_SO_ICMPSOCKET = 0x30,
   IOCTLV_SO_ICMPPING,
   IOCTL_SO_ICMPCANCEL,
@@ -68,7 +68,7 @@ public:
   void Update() override;
 
 private:
-  IPCCommandResult HandleStartUpRequest(const IOCtlRequest& request);
+  IPCCommandResult HandleInitInterfaceRequest(const IOCtlRequest& request);
   IPCCommandResult HandleSocketRequest(const IOCtlRequest& request);
   IPCCommandResult HandleICMPSocketRequest(const IOCtlRequest& request);
   IPCCommandResult HandleCloseRequest(const IOCtlRequest& request);

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -141,9 +141,29 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
     break;
 
   case IOCTL_NWC24_REQUEST_SHUTDOWN:
-    // if ya set the IOS version to a very high value this happens ...
-    INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_SHUTDOWN - NI");
+  {
+    if (request.buffer_in == 0 || request.buffer_in % 4 != 0 || request.buffer_in_size < 8 ||
+        request.buffer_out == 0 || request.buffer_out % 4 != 0 || request.buffer_out_size < 4)
+    {
+      return_value = IPC_EINVAL;
+      ERROR_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_SHUTDOWN = IPC_EINVAL");
+      break;
+    }
+
+    INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_SHUTDOWN");
+    [[maybe_unused]] const u32 event = Memory::Read_U32(request.buffer_in);
+    // TODO: Advertise shutdown event
+    // TODO: Shutdown USB keyboard LEDs if event == 3
+    // TODO: IOCTLV_NCD_SETCONFIG
+    // TODO: DHCP related features
+    // SOGetInterfaceOpt(0xfffe,0x4003);  // IP settings
+    // SOGetInterfaceOpt(0xfffe,0xc001);  // DHCP lease time remaining?
+    // SOGetInterfaceOpt(0xfffe,0x1003);  // Error
+    // Call /dev/net/ip/top 0x1b (SOCleanup), it closes all sockets
+    WiiSockMan::GetInstance().Clean();
+    return_value = IPC_SUCCESS;
     break;
+  }
 
   default:
     request.Log(GetDeviceName(), Common::Log::IOS_WC24);


### PR DESCRIPTION
This PR implements IOCTL_NWC24_REQUEST_SHUTDOWN and renames some IOCTL names.

As far as I know, it's called during shutdown (when the stop button is pressed).

Based on IOS59 v9249.

Regarding the naming:
 - **IOCTL_SO_GETLASTERROR** comes from the fact it grabs the IOS SO thread error value
 - **IOCTLV_SO_STARTUP**/**IOCTLV_SO_CLEANUP** come from IOS KD strings
 - **IOCTL_SO_INITINTERFACE** educated guess since it's not SOStartup and initialises global variables only used by **SO INTERFACE** ioctl(v)s.

Ready to be reviewed & merged.