### PR TITLE
Android: Android INI section and make platform tab selection an INI setting

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -17,6 +17,7 @@ import java.util.TreeMap;
 
 public class Settings
 {
+  public static final String SECTION_INI_ANDROID = "Android";
   public static final String SECTION_INI_GENERAL = "General";
   public static final String SECTION_INI_CORE = "Core";
   public static final String SECTION_INI_INTERFACE = "Interface";
@@ -49,9 +50,10 @@ public class Settings
   static
   {
     configFileSectionsMap.put(SettingsFile.FILE_NAME_DOLPHIN,
-            Arrays.asList(SECTION_INI_GENERAL, SECTION_INI_CORE, SECTION_INI_INTERFACE,
-                    SECTION_INI_DSP,
-                    SECTION_BINDINGS, SECTION_ANALYTICS, SECTION_DEBUG));
+            Arrays
+                    .asList(SECTION_INI_ANDROID, SECTION_INI_GENERAL, SECTION_INI_CORE,
+                            SECTION_INI_INTERFACE,
+                            SECTION_INI_DSP, SECTION_BINDINGS, SECTION_ANALYTICS, SECTION_DEBUG));
     configFileSectionsMap.put(SettingsFile.FILE_NAME_GFX,
             Arrays.asList(SECTION_GFX_SETTINGS, SECTION_GFX_ENHANCEMENTS, SECTION_GFX_HACKS,
                     SECTION_STEREOSCOPY));
@@ -189,7 +191,7 @@ public class Settings
       if (modifiedSettings.contains(SettingsFile.KEY_DSP_ENGINE))
       {
         switch (NativeLibrary
-                .GetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_DSP,
+                .GetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_ANDROID,
                         SettingsFile.KEY_DSP_ENGINE, DSP_HLE))
         {
           case DSP_HLE:

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -284,9 +284,10 @@ public final class SettingsFragmentPresenter
     Setting audioStretch = null;
     Setting audioVolume = null;
 
+    SettingSection androidSection = mSettings.getSection(Settings.SECTION_INI_ANDROID);
     SettingSection coreSection = mSettings.getSection(Settings.SECTION_INI_CORE);
     SettingSection dspSection = mSettings.getSection(Settings.SECTION_INI_DSP);
-    dspEmulationEngine = dspSection.getSetting(SettingsFile.KEY_DSP_ENGINE);
+    dspEmulationEngine = androidSection.getSetting(SettingsFile.KEY_DSP_ENGINE);
     audioStretch = coreSection.getSetting(SettingsFile.KEY_AUDIO_STRETCH);
     audioVolume = dspSection.getSetting(SettingsFile.KEY_AUDIO_VOLUME);
 
@@ -306,7 +307,7 @@ public final class SettingsFragmentPresenter
     }
     // DSP Emulation Engine controls two settings.
     // DSP Emulation Engine is read by Settings.saveSettings to modify the relevant settings.
-    sl.add(new SingleChoiceSetting(SettingsFile.KEY_DSP_ENGINE, Settings.SECTION_INI_DSP,
+    sl.add(new SingleChoiceSetting(SettingsFile.KEY_DSP_ENGINE, Settings.SECTION_INI_ANDROID,
             R.string.dsp_emulation_engine, 0, dspEngineEntries, dspEngineValues, 0,
             dspEmulationEngine));
     sl.add(new CheckBoxSetting(SettingsFile.KEY_AUDIO_STRETCH, Settings.SECTION_INI_CORE,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/utils/SettingsFile.java
@@ -39,6 +39,8 @@ public final class SettingsFile
   public static final String FILE_NAME_GCPAD = "GCPadNew";
   public static final String FILE_NAME_WIIMOTE = "WiimoteNew";
 
+  public static final String KEY_DSP_ENGINE = "DSPEngine";
+  public static final String KEY_LAST_PLATFORM_TAB = "LastPlatformTab";
 
   public static final String KEY_CPU_CORE = "CPUCore";
   public static final String KEY_DUAL_CORE = "CPUThread";
@@ -47,7 +49,6 @@ public final class SettingsFile
   public static final String KEY_SPEED_LIMIT = "EmulationSpeed";
   public static final String KEY_VIDEO_BACKEND = "GFXBackend";
 
-  public static final String KEY_DSP_ENGINE = "DSPEngine";
   public static final String KEY_DSP_HLE = "DSPHLE";
   public static final String KEY_DSP_ENABLE_JIT = "EnableJIT";
   public static final String KEY_AUDIO_STRETCH = "AudioStretch";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -16,14 +17,17 @@ import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.View;
 import android.widget.Toast;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.adapters.PlatformPagerAdapter;
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.ui.MenuTag;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsActivity;
+import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
+import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
 import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
@@ -55,8 +59,6 @@ public final class MainActivity extends AppCompatActivity implements MainView
 
     setSupportActionBar(mToolbar);
 
-    mTabLayout.setupWithViewPager(mViewPager);
-
     // Set up the FAB.
     mFab.setOnClickListener(view -> mPresenter.onFabClick());
 
@@ -68,16 +70,8 @@ public final class MainActivity extends AppCompatActivity implements MainView
 
     if (PermissionsHandler.hasWriteAccess(this))
     {
-      PlatformPagerAdapter platformPagerAdapter = new PlatformPagerAdapter(
-              getSupportFragmentManager(), this);
-      mViewPager.setAdapter(platformPagerAdapter);
-      mViewPager.setOffscreenPageLimit(platformPagerAdapter.getCount());
-      showGames();
-      GameFileCacheService.startLoad(this);
-    }
-    else
-    {
-      mViewPager.setVisibility(View.INVISIBLE);
+      new AfterDirectoryInitializationRunner()
+              .run(this, this::setPlatformTabsAndStartGameFileCacheService);
     }
   }
 
@@ -202,29 +196,22 @@ public final class MainActivity extends AppCompatActivity implements MainView
   @Override
   public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults)
   {
-    switch (requestCode)
+    if (requestCode == PermissionsHandler.REQUEST_CODE_WRITE_PERMISSION)
     {
-      case PermissionsHandler.REQUEST_CODE_WRITE_PERMISSION:
-        if (grantResults[0] == PackageManager.PERMISSION_GRANTED)
-        {
-          DirectoryInitialization.start(this);
-          PlatformPagerAdapter platformPagerAdapter = new PlatformPagerAdapter(
-                  getSupportFragmentManager(), this);
-          mViewPager.setAdapter(platformPagerAdapter);
-          mViewPager.setOffscreenPageLimit(platformPagerAdapter.getCount());
-          mTabLayout.setupWithViewPager(mViewPager);
-          mViewPager.setVisibility(View.VISIBLE);
-          GameFileCacheService.startLoad(this);
-        }
-        else
-        {
-          Toast.makeText(this, R.string.write_permission_needed, Toast.LENGTH_SHORT)
-                  .show();
-        }
-        break;
-      default:
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        break;
+      if (grantResults[0] == PackageManager.PERMISSION_GRANTED)
+      {
+        DirectoryInitialization.start(this);
+        new AfterDirectoryInitializationRunner()
+                .run(this, this::setPlatformTabsAndStartGameFileCacheService);
+      }
+      else
+      {
+        Toast.makeText(this, R.string.write_permission_needed, Toast.LENGTH_SHORT).show();
+      }
+    }
+    else
+    {
+      super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
   }
 
@@ -258,5 +245,42 @@ public final class MainActivity extends AppCompatActivity implements MainView
     String fragmentTag = "android:switcher:" + mViewPager.getId() + ":" + platform.toInt();
 
     return (PlatformGamesView) getSupportFragmentManager().findFragmentByTag(fragmentTag);
+  }
+
+  // Don't call this before DirectoryInitialization completes.
+  private void setPlatformTabsAndStartGameFileCacheService()
+  {
+    PlatformPagerAdapter platformPagerAdapter = new PlatformPagerAdapter(
+            getSupportFragmentManager(), this);
+    mViewPager.setAdapter(platformPagerAdapter);
+    mViewPager.setOffscreenPageLimit(platformPagerAdapter.getCount());
+    mTabLayout.setupWithViewPager(mViewPager);
+    mTabLayout.addOnTabSelectedListener(new TabLayout.ViewPagerOnTabSelectedListener(mViewPager)
+    {
+      @Override
+      public void onTabSelected(@NonNull TabLayout.Tab tab)
+      {
+        super.onTabSelected(tab);
+        NativeLibrary
+                .SetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_ANDROID,
+                        SettingsFile.KEY_LAST_PLATFORM_TAB, Integer.toString(tab.getPosition()));
+      }
+    });
+
+    String platformTab = NativeLibrary
+            .GetConfig(SettingsFile.FILE_NAME_DOLPHIN + ".ini", Settings.SECTION_INI_ANDROID,
+                    SettingsFile.KEY_LAST_PLATFORM_TAB, "0");
+
+    try
+    {
+      mViewPager.setCurrentItem(Integer.parseInt(platformTab));
+    }
+    catch (NumberFormatException ex)
+    {
+      mViewPager.setCurrentItem(0);
+    }
+
+    showGames();
+    GameFileCacheService.startLoad(this);
   }
 }


### PR DESCRIPTION
Implements https://bugs.dolphin-emu.org/issues/10793
Prerequisite for https://bugs.dolphin-emu.org/issues/10957

Android-specific settings should be moved away from SharedPreferences and use INI settings. This allows these settings to be retained across multiple builds of Dolphin. I added an Android section to Dolphin.ini to make these settings easy to find. Most of the setting changes will happen in future PRs.

Android: Make last platform tab selection an INI setting was a test case. Now Dolphin will remember which platform tab was selected when (re)installing or starting Dolphin.