### PR TITLE
Core/UICommon: Fix EnableScreenSaver preprocessor directive

### DIFF
--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -396,7 +396,7 @@ bool TriggerSTMPowerEvent()
   return true;
 }
 
-#if defined(HAVE_XRANDR) && HAVE_X11
+#if defined(HAVE_XRANDR) && HAVE_XRANDR
 void EnableScreenSaver(Window win, bool enable)
 #else
 void EnableScreenSaver(bool enable)


### PR DESCRIPTION
The include for X11Utils.h (and by extension Xlib.h) is gated behind HAVE_XRANDR, as well as the declaration for this function, but its definition was mistakenly gated behind HAVE_X11. Therefore, if we have X11 but not Xrandr, the build will fail due to declaration/definition mismatch and the missing Window type.