### PR TITLE
Make SO_POLL complete asynchronously in IOS_NET SO

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.h
+++ b/Source/Core/Core/IOS/Network/IP/Top.h
@@ -13,6 +13,13 @@
 #include <ws2tcpip.h>
 #endif
 
+// WSAPoll doesn't support POLLPRI and POLLWRBAND flags
+#ifdef _WIN32
+constexpr int UNSUPPORTED_WSAPOLL = POLLPRI | POLLWRBAND;
+#else
+constexpr int UNSUPPORTED_WSAPOLL = 0;
+#endif
+
 namespace IOS::HLE
 {
 enum NET_IOCTL
@@ -62,6 +69,7 @@ public:
   NetIPTop(Kernel& ios, const std::string& device_name);
   virtual ~NetIPTop();
 
+  void DoState(PointerWrap& p) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -6,6 +6,8 @@
 #include "Core/IOS/Network/Socket.h"
 
 #include <algorithm>
+#include <numeric>
+
 #include <mbedtls/error.h>
 #ifndef _WIN32
 #include <arpa/inet.h>
@@ -697,7 +699,7 @@ void WiiSockMan::Update()
 
   while (socket_iter != end_socks)
   {
-    WiiSocket& sock = socket_iter->second;
+    const WiiSocket& sock = socket_iter->second;
     if (sock.IsValid())
     {
       FD_SET(sock.fd, &read_fds);
@@ -712,7 +714,8 @@ void WiiSockMan::Update()
       socket_iter = WiiSockets.erase(socket_iter);
     }
   }
-  s32 ret = select(nfds, &read_fds, &write_fds, &except_fds, &t);
+
+  const s32 ret = select(nfds, &read_fds, &write_fds, &except_fds, &t);
 
   if (ret >= 0)
   {
@@ -730,6 +733,87 @@ void WiiSockMan::Update()
       elem.second.Update(false, false, false);
     }
   }
+  UpdatePollCommands();
+}
+
+void WiiSockMan::UpdatePollCommands()
+{
+  static constexpr int error_event = (POLLHUP | POLLERR);
+
+  if (pending_polls.empty())
+    return;
+
+  const auto now = std::chrono::high_resolution_clock::now();
+  const auto elapsed_d = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_time);
+  const auto elapsed = elapsed_d.count();
+  last_time = now;
+
+  for (auto& pcmd : pending_polls)
+  {
+    // Don't touch negative timeouts
+    if (pcmd.timeout > 0)
+      pcmd.timeout = std::max<s64>(0, pcmd.timeout - elapsed);
+  }
+
+  pending_polls.erase(
+      std::remove_if(
+          pending_polls.begin(), pending_polls.end(),
+          [this](auto& pcmd) {
+            const auto request = Request(pcmd.request_addr);
+            auto& pfds = pcmd.wii_fds;
+            int ret = 0;
+
+            // Happens only on savestate load
+            if (pfds[0].revents & error_event)
+            {
+              ret = static_cast<int>(pfds.size());
+            }
+            else
+            {
+              // Make the behavior of poll consistent across platforms by not passing:
+              //  - Set with invalid fds, revents is set to 0 (Linux) or POLLNVAL (Windows)
+              //  - Set without a valid socket, raises an error on Windows
+              std::vector<int> original_order(pfds.size());
+              std::iota(original_order.begin(), original_order.end(), 0);
+              // Select indices with valid fds
+              auto mid = std::partition(original_order.begin(), original_order.end(), [&](auto i) {
+                return GetHostSocket(Memory::Read_U32(pcmd.buffer_out + 0xc * i)) >= 0;
+              });
+              const auto n_valid = std::distance(original_order.begin(), mid);
+
+              // Move all the valid pollfds to the front of the vector
+              for (auto i = 0; i < n_valid; ++i)
+                std::swap(pfds[i], pfds[original_order[i]]);
+
+              if (n_valid > 0)
+                ret = poll(pfds.data(), n_valid, 0);
+              if (ret < 0)
+                ret = GetNetErrorCode(ret, "UpdatePollCommands", false);
+
+              // Move everything back to where they were
+              for (auto i = 0; i < n_valid; ++i)
+                std::swap(pfds[i], pfds[original_order[i]]);
+            }
+
+            if (ret == 0 && pcmd.timeout)
+              return false;
+
+            // Translate native to Wii events,
+            for (u32 i = 0; i < pfds.size(); ++i)
+            {
+              const int revents = ConvertEvents(pfds[i].revents, ConvertDirection::NativeToWii);
+
+              // No need to change fd or events as they are input only.
+              // Memory::Write_U32(ufds[i].fd, request.buffer_out + 0xc*i); //fd
+              // Memory::Write_U32(events, request.buffer_out + 0xc*i + 4); //events
+              Memory::Write_U32(revents, pcmd.buffer_out + 0xc * i + 8);  // revents
+              DEBUG_LOG(IOS_NET, "IOCTL_SO_POLL socket %d wevents %08X events %08X revents %08X", i,
+                        revents, pfds[i].events, pfds[i].revents);
+            }
+            GetIOS()->EnqueueIPCReply(request, ret);
+            return true;
+          }),
+      pending_polls.end());
 }
 
 void WiiSockMan::Convert(WiiSockAddrIn const& from, sockaddr_in& to)
@@ -737,6 +821,43 @@ void WiiSockMan::Convert(WiiSockAddrIn const& from, sockaddr_in& to)
   to.sin_addr.s_addr = from.addr.addr;
   to.sin_family = from.family;
   to.sin_port = from.port;
+}
+
+s32 WiiSockMan::ConvertEvents(s32 events, ConvertDirection dir)
+{
+  constexpr struct
+  {
+    int native;
+    int wii;
+  } mapping[] = {
+      {POLLRDNORM, 0x0001}, {POLLRDBAND, 0x0002}, {POLLPRI, 0x0004}, {POLLWRNORM, 0x0008},
+      {POLLWRBAND, 0x0010}, {POLLERR, 0x0020},    {POLLHUP, 0x0040}, {POLLNVAL, 0x0080},
+  };
+
+  s32 converted_events = 0;
+  s32 unhandled_events = 0;
+
+  if (dir == ConvertDirection::NativeToWii)
+  {
+    for (const auto& map : mapping)
+    {
+      if (events & map.native)
+        converted_events |= map.wii;
+    }
+  }
+  else
+  {
+    unhandled_events = events;
+    for (const auto& map : mapping)
+    {
+      if (events & map.wii)
+        converted_events |= map.native;
+      unhandled_events &= ~map.wii;
+    }
+  }
+  if (unhandled_events)
+    ERROR_LOG(IOS_NET, "SO_POLL: unhandled Wii event types: %04x", unhandled_events);
+  return converted_events;
 }
 
 void WiiSockMan::Convert(sockaddr_in const& from, WiiSockAddrIn& to, s32 addrlen)
@@ -748,6 +869,35 @@ void WiiSockMan::Convert(sockaddr_in const& from, WiiSockAddrIn& to, s32 addrlen
     to.len = sizeof(WiiSockAddrIn);
   else
     to.len = addrlen;
+}
+
+void WiiSockMan::DoState(PointerWrap& p)
+{
+  bool saving =
+      p.mode == PointerWrap::Mode::MODE_WRITE || p.mode == PointerWrap::Mode::MODE_MEASURE;
+  auto size = pending_polls.size();
+  p.Do(size);
+  if (!saving)
+    pending_polls.resize(size);
+  for (auto& pcmd : pending_polls)
+  {
+    p.Do(pcmd.request_addr);
+    p.Do(pcmd.buffer_out);
+    p.Do(pcmd.wii_fds);
+  }
+
+  if (saving)
+    return;
+  for (auto& pcmd : pending_polls)
+  {
+    for (auto& wfd : pcmd.wii_fds)
+      wfd.revents = (POLLHUP | POLLERR);
+  }
+}
+
+void WiiSockMan::AddPollCommand(const PollCommand& cmd)
+{
+  pending_polls.push_back(cmd);
 }
 
 void WiiSockMan::UpdateWantDeterminism(bool want)

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 117;  // Last changed in PR 7396
+constexpr u32 STATE_VERSION = 118;  // Last changed in PR 8813
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This is to make the behavior more consistent with the behavior on console.

Currently, SO_POLL blocks the PPC until poll() completes, so this prevents PPC threads on DolphinOS and libogc's LWP from running while waiting for the call to complete, while on a real console, IOS lets the PPC run, as with most other calls, and notifies the PPC through the usual mechanism.

I don't know if how I implemented it is the preferred way in regard to Dolphin's internals: Basically each SO_POLL operation gets queued into a poll table with the associated request, and when an event happens on a socket that is referenced in a poll table in WiiSockMan::Update, an IPC reply is generated for the request.