### PR TITLE
DolphinQt: Remove another usage of QFontMetrics::width

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -230,6 +230,7 @@ add_executable(dolphin-emu
   QtUtils/FileOpenEventFilter.h
   QtUtils/FlowLayout.cpp
   QtUtils/FlowLayout.h
+  QtUtils/FontMetricsHelper.h
   QtUtils/ModalMessageBox.cpp
   QtUtils/ModalMessageBox.h
   QtUtils/ParallelProgressDialog.h

--- a/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeViewWidget.cpp
@@ -31,6 +31,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "DolphinQt/Debugger/PatchInstructionDialog.h"
 #include "DolphinQt/Host.h"
+#include "DolphinQt/QtUtils/FontMetricsHelper.h"
 #include "DolphinQt/Resources.h"
 #include "DolphinQt/Settings.h"
 
@@ -195,19 +196,12 @@ void CodeViewWidget::FontBasedSizing()
 
   const QFontMetrics fm(Settings::Instance().GetDebugFont());
 
-  const auto width = [&fm](QString text) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-    return fm.horizontalAdvance(text);
-#else
-    return fm.width(text);
-#endif
-  };
-
   const int rowh = fm.height() + 1;
   verticalHeader()->setMaximumSectionSize(rowh);
   horizontalHeader()->setMinimumSectionSize(rowh + 5);
   setColumnWidth(CODE_VIEW_COLUMN_BREAKPOINT, rowh + 5);
-  setColumnWidth(CODE_VIEW_COLUMN_ADDRESS, width(QStringLiteral("80000000")) + extra_text_width);
+  setColumnWidth(CODE_VIEW_COLUMN_ADDRESS,
+                 FontMetricsWidth(fm, QStringLiteral("80000000")) + extra_text_width);
 
   // The longest instruction is technically 'ps_merge00' (0x10000420u), but those instructions are
   // very rare and would needlessly increase the column size, so let's go with 'rlwinm.' instead.
@@ -219,10 +213,11 @@ void CodeViewWidget::FontBasedSizing()
   const std::string ins = (split == std::string::npos ? disas : disas.substr(0, split));
   const std::string param = (split == std::string::npos ? "" : disas.substr(split + 1));
   setColumnWidth(CODE_VIEW_COLUMN_INSTRUCTION,
-                 width(QString::fromStdString(ins)) + extra_text_width);
+                 FontMetricsWidth(fm, QString::fromStdString(ins)) + extra_text_width);
   setColumnWidth(CODE_VIEW_COLUMN_PARAMETERS,
-                 width(QString::fromStdString(param)) + extra_text_width);
-  setColumnWidth(CODE_VIEW_COLUMN_DESCRIPTION, width(QStringLiteral("0")) * 25 + extra_text_width);
+                 FontMetricsWidth(fm, QString::fromStdString(param)) + extra_text_width);
+  setColumnWidth(CODE_VIEW_COLUMN_DESCRIPTION,
+                 FontMetricsWidth(fm, QStringLiteral("0")) * 25 + extra_text_width);
 
   Update();
 }

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -17,6 +17,7 @@
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "DolphinQt/Host.h"
+#include "DolphinQt/QtUtils/FontMetricsHelper.h"
 #include "DolphinQt/Settings.h"
 
 ThreadWidget::ThreadWidget(QWidget* parent) : QDockWidget(parent)
@@ -133,7 +134,8 @@ QLineEdit* ThreadWidget::CreateLineEdit() const
 {
   QLineEdit* line_edit = new QLineEdit(QLatin1Literal("00000000"));
   line_edit->setReadOnly(true);
-  line_edit->setFixedWidth(line_edit->fontMetrics().width(QLatin1Literal(" 00000000 ")));
+  line_edit->setFixedWidth(
+      FontMetricsWidth(line_edit->fontMetrics(), QLatin1Literal(" 00000000 ")));
   return line_edit;
 }
 

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -457,6 +457,7 @@
     <ClInclude Include="Config\Mapping\MappingCommon.h" />
     <ClInclude Include="Debugger\RegisterColumn.h" />
     <ClInclude Include="QtUtils\ActionHelper.h" />
+    <ClInclude Include="QtUtils\FontMetricsHelper.h" />
     <ClInclude Include="QtUtils\ImageConverter.h" />
     <ClInclude Include="QtUtils\QueueOnObject.h" />
     <ClInclude Include="QtUtils\RunOnObject.h" />

--- a/Source/Core/DolphinQt/QtUtils/FontMetricsHelper.h
+++ b/Source/Core/DolphinQt/QtUtils/FontMetricsHelper.h
@@ -1,0 +1,20 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <utility>
+
+#include <QFontMetrics>
+
+// This exists purely to get rid of deprecation warnings while still supporting older Qt versions
+template <typename... Args>
+int FontMetricsWidth(const QFontMetrics& fm, Args&&... args)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+  return fm.horizontalAdvance(std::forward<Args>(args)...);
+#else
+  return fm.width(std::forward<Args>(args)...);
+#endif
+}


### PR DESCRIPTION
QFontMetrics::width breaks building with CMake on Windows, due to a deprecation warning which gets promoted to an error.