### PR TITLE
CMake: support using system-wide zstd library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,7 @@ else()
   add_subdirectory(Externals/liblzma)
 endif()
 
-find_package(zstd)
+pkg_search_module(ZSTD QUIET libzstd)
 if(ZSTD_FOUND)
   message(STATUS "Using shared zstd")
 else()

--- a/Externals/zstd/CMakeLists.txt
+++ b/Externals/zstd/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(bzip2 C)
+project(zstd C)
 
 include(CheckTypeSize)
 include(CheckFunctionExists)


### PR DESCRIPTION
CMake does not have native support for zstd yet, so find_package() doesn't work out of the box.

@JosJuice: Note that #8538 will need to link against `zstd` instead of `zstd::zstd` since CMake's FindPkgConfig module doesn't add an alias like Externals/zstd/CMakeLists.txt does.