### PR TITLE
DolphinQt: Replace setting windows with unified settings window!

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -238,6 +238,8 @@ add_executable(dolphin-emu
   GCMemcardCreateNewDialog.h
   GCMemcardManager.cpp
   GCMemcardManager.h
+  GrandSettingsWindow.cpp
+  GrandSettingsWindow.h
   Host.cpp
   Host.h
   HotkeyScheduler.cpp

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -79,6 +79,8 @@ add_executable(dolphin-emu
   Config/Graphics/GraphicsBool.h
   Config/Graphics/GraphicsChoice.cpp
   Config/Graphics/GraphicsChoice.h
+  Config/Graphics/GraphicsDialog.cpp
+  Config/Graphics/GraphicsDialog.h
   Config/Graphics/GraphicsInteger.cpp
   Config/Graphics/GraphicsInteger.h
   Config/Graphics/GraphicsRadio.cpp

--- a/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
+++ b/Source/Core/DolphinQt/Config/FreeLookWidget.cpp
@@ -29,6 +29,7 @@ FreeLookWidget::FreeLookWidget(QWidget* parent) : QWidget(parent)
 void FreeLookWidget::CreateLayout()
 {
   auto* layout = new QVBoxLayout();
+  layout->setAlignment(Qt::AlignTop);
 
   m_enable_freelook = new ToolTipCheckBox(tr("Enable"));
   m_enable_freelook->setChecked(Config::Get(Config::FREE_LOOK_ENABLED));

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.cpp
@@ -17,22 +17,22 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/Graphics/GraphicsDialog.h"
 #include "DolphinQt/Config/Graphics/GraphicsInteger.h"
-#include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipCheckBox.h"
 #include "DolphinQt/QtUtils/SignalBlocking.h"
 #include "DolphinQt/Settings.h"
 
 #include "VideoCommon/VideoConfig.h"
 
-AdvancedWidget::AdvancedWidget(GraphicsWindow* parent)
+AdvancedWidget::AdvancedWidget(GraphicsDialog* parent)
 {
   CreateWidgets();
   LoadSettings();
   ConnectWidgets();
   AddDescriptions();
 
-  connect(parent, &GraphicsWindow::BackendChanged, this, &AdvancedWidget::OnBackendChanged);
+  connect(parent, &GraphicsDialog::BackendChanged, this, &AdvancedWidget::OnBackendChanged);
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     OnEmulationStateChanged(state != Core::State::Uninitialized);
   });

--- a/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/AdvancedWidget.h
@@ -7,8 +7,8 @@
 
 class GraphicsBool;
 class GraphicsChoice;
+class GraphicsDialog;
 class GraphicsInteger;
-class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
 class QSpinBox;
@@ -18,7 +18,7 @@ class AdvancedWidget final : public GraphicsWidget
 {
   Q_OBJECT
 public:
-  explicit AdvancedWidget(GraphicsWindow* parent);
+  explicit AdvancedWidget(GraphicsDialog* parent);
 
 private:
   void LoadSettings() override;

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -16,8 +16,8 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/Graphics/GraphicsDialog.h"
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
-#include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/Graphics/PostProcessingConfigWindow.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 #include "DolphinQt/Settings.h"
@@ -29,13 +29,13 @@
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
-EnhancementsWidget::EnhancementsWidget(GraphicsWindow* parent) : m_block_save(false)
+EnhancementsWidget::EnhancementsWidget(GraphicsDialog* parent) : m_block_save(false)
 {
   CreateWidgets();
   LoadSettings();
   ConnectWidgets();
   AddDescriptions();
-  connect(parent, &GraphicsWindow::BackendChanged,
+  connect(parent, &GraphicsDialog::BackendChanged,
           [this](const QString& backend) { LoadSettings(); });
 }
 

--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.h
@@ -7,8 +7,8 @@
 
 class GraphicsBool;
 class GraphicsChoice;
+class GraphicsDialog;
 class GraphicsSlider;
-class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
 class QPushButton;
@@ -19,7 +19,7 @@ class EnhancementsWidget final : public GraphicsWidget
 {
   Q_OBJECT
 public:
-  explicit EnhancementsWidget(GraphicsWindow* parent);
+  explicit EnhancementsWidget(GraphicsDialog* parent);
 
 private:
   void LoadSettings() override;

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -20,8 +20,8 @@
 
 #include "DolphinQt/Config/Graphics/GraphicsBool.h"
 #include "DolphinQt/Config/Graphics/GraphicsChoice.h"
+#include "DolphinQt/Config/Graphics/GraphicsDialog.h"
 #include "DolphinQt/Config/Graphics/GraphicsRadio.h"
-#include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipComboBox.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/Settings.h"
@@ -31,7 +31,7 @@
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
-GeneralWidget::GeneralWidget(X11Utils::XRRConfiguration* xrr_config, GraphicsWindow* parent)
+GeneralWidget::GeneralWidget(X11Utils::XRRConfiguration* xrr_config, GraphicsDialog* parent)
     : m_xrr_config(xrr_config)
 {
   CreateWidgets();
@@ -40,7 +40,7 @@ GeneralWidget::GeneralWidget(X11Utils::XRRConfiguration* xrr_config, GraphicsWin
   AddDescriptions();
   emit BackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
 
-  connect(parent, &GraphicsWindow::BackendChanged, this, &GeneralWidget::OnBackendChanged);
+  connect(parent, &GraphicsDialog::BackendChanged, this, &GeneralWidget::OnBackendChanged);
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     OnEmulationStateChanged(state != Core::State::Uninitialized);
   });

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -8,8 +8,8 @@
 
 class GraphicsBool;
 class GraphicsChoice;
+class GraphicsDialog;
 class GraphicsRadioInt;
-class GraphicsWindow;
 class QCheckBox;
 class QComboBox;
 class QRadioButton;
@@ -25,7 +25,7 @@ class GeneralWidget final : public GraphicsWidget
 {
   Q_OBJECT
 public:
-  explicit GeneralWidget(X11Utils::XRRConfiguration* xrr_config, GraphicsWindow* parent);
+  explicit GeneralWidget(X11Utils::XRRConfiguration* xrr_config, GraphicsDialog* parent);
 signals:
   void BackendChanged(const QString& backend);
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsDialog.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsDialog.cpp
@@ -1,0 +1,11 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/Graphics/GraphicsDialog.h"
+
+#include <QDialog>
+
+GraphicsDialog::GraphicsDialog(QWidget* parent) : QDialog(parent)
+{
+}

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsDialog.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsDialog.h
@@ -1,0 +1,16 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+class GraphicsDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit GraphicsDialog(QWidget* parent = nullptr);
+signals:
+  void BackendChanged(const QString& backend);
+};

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.cpp
@@ -17,6 +17,7 @@
 #include "DolphinQt/Config/Graphics/AdvancedWidget.h"
 #include "DolphinQt/Config/Graphics/EnhancementsWidget.h"
 #include "DolphinQt/Config/Graphics/GeneralWidget.h"
+#include "DolphinQt/Config/Graphics/GraphicsDialog.h"
 #include "DolphinQt/Config/Graphics/HacksWidget.h"
 #include "DolphinQt/MainWindow.h"
 #include "DolphinQt/QtUtils/WrapInScrollArea.h"
@@ -25,7 +26,7 @@
 #include "VideoCommon/VideoConfig.h"
 
 GraphicsWindow::GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent)
-    : QDialog(parent), m_xrr_config(xrr_config)
+    : GraphicsDialog(parent), m_xrr_config(xrr_config)
 {
   CreateMainLayout();
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsWindow.h
@@ -6,6 +6,8 @@
 #include <QDialog>
 #include <QHash>
 
+#include "GraphicsDialog.h"
+
 class AdvancedWidget;
 class EnhancementsWidget;
 class HacksWidget;
@@ -21,14 +23,11 @@ namespace X11Utils
 class XRRConfiguration;
 }
 
-class GraphicsWindow final : public QDialog
+class GraphicsWindow final : public GraphicsDialog
 {
   Q_OBJECT
 public:
   explicit GraphicsWindow(X11Utils::XRRConfiguration* xrr_config, MainWindow* parent);
-
-signals:
-  void BackendChanged(const QString& backend);
 
 private:
   void CreateMainLayout();

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -14,21 +14,21 @@
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt/Config/Graphics/GraphicsBool.h"
+#include "DolphinQt/Config/Graphics/GraphicsDialog.h"
 #include "DolphinQt/Config/Graphics/GraphicsSlider.h"
-#include "DolphinQt/Config/Graphics/GraphicsWindow.h"
 #include "DolphinQt/Config/ToolTipControls/ToolTipSlider.h"
 #include "DolphinQt/Settings.h"
 
 #include "VideoCommon/VideoConfig.h"
 
-HacksWidget::HacksWidget(GraphicsWindow* parent)
+HacksWidget::HacksWidget(GraphicsDialog* parent)
 {
   CreateWidgets();
   LoadSettings();
   ConnectWidgets();
   AddDescriptions();
 
-  connect(parent, &GraphicsWindow::BackendChanged, this, &HacksWidget::OnBackendChanged);
+  connect(parent, &GraphicsDialog::BackendChanged, this, &HacksWidget::OnBackendChanged);
   OnBackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, &HacksWidget::LoadSettings);
 }

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -6,7 +6,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
 class GraphicsBool;
-class GraphicsWindow;
+class GraphicsDialog;
 class QLabel;
 class ToolTipSlider;
 
@@ -14,7 +14,7 @@ class HacksWidget final : public GraphicsWidget
 {
   Q_OBJECT
 public:
-  explicit HacksWidget(GraphicsWindow* parent);
+  explicit HacksWidget(GraphicsDialog* parent);
 
 private:
   void LoadSettings() override;

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -154,6 +154,7 @@
     <ClCompile Include="GBAWidget.cpp" />
     <ClCompile Include="GCMemcardCreateNewDialog.cpp" />
     <ClCompile Include="GCMemcardManager.cpp" />
+    <ClCompile Include="GrandSettingsWindow.cpp" />
     <ClCompile Include="Host.cpp" />
     <ClCompile Include="HotkeyScheduler.cpp" />
     <ClCompile Include="Main.cpp" />
@@ -345,6 +346,7 @@
     <QtMoc Include="GBAWidget.h" />
     <QtMoc Include="GCMemcardCreateNewDialog.h" />
     <QtMoc Include="GCMemcardManager.h" />
+    <QtMoc Include="GrandSettingsWindow.h" />
     <QtMoc Include="Host.h" />
     <QtMoc Include="HotkeyScheduler.h" />
     <QtMoc Include="MainWindow.h" />

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -73,6 +73,7 @@
     <ClCompile Include="Config\Graphics\GeneralWidget.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsBool.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsChoice.cpp" />
+    <ClCompile Include="Config\Graphics\GraphicsDialog.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsInteger.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsRadio.cpp" />
     <ClCompile Include="Config\Graphics\GraphicsSlider.cpp" />
@@ -268,6 +269,7 @@
     <QtMoc Include="Config\Graphics\GeneralWidget.h" />
     <QtMoc Include="Config\Graphics\GraphicsBool.h" />
     <QtMoc Include="Config\Graphics\GraphicsChoice.h" />
+    <QtMoc Include="Config\Graphics\GraphicsDialog.h" />
     <QtMoc Include="Config\Graphics\GraphicsInteger.h" />
     <QtMoc Include="Config\Graphics\GraphicsRadio.h" />
     <QtMoc Include="Config\Graphics\GraphicsSlider.h" />

--- a/Source/Core/DolphinQt/GrandSettingsWindow.cpp
+++ b/Source/Core/DolphinQt/GrandSettingsWindow.cpp
@@ -1,0 +1,233 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QCompleter>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QLineEdit>
+#include <QStackedWidget>
+#include <QString>
+#include <QTreeWidget>
+
+#include "Common/Config/Config.h"
+#include "Core/Config/MainSettings.h"
+#include "Core/ConfigManager.h"
+
+#include "DolphinQt/Config/CommonControllersWidget.h"
+#include "DolphinQt/Config/FreeLookWidget.h"
+#include "DolphinQt/Config/GamecubeControllersWidget.h"
+#include "DolphinQt/Config/Graphics/AdvancedWidget.h"
+#include "DolphinQt/Config/Graphics/EnhancementsWidget.h"
+#include "DolphinQt/Config/Graphics/GeneralWidget.h"
+#include "DolphinQt/Config/Graphics/HacksWidget.h"
+#include "DolphinQt/Config/Graphics/SoftwareRendererWidget.h"
+#include "DolphinQt/Config/WiimoteControllersWidget.h"
+#include "DolphinQt/GrandSettingsWindow.h"
+#include "DolphinQt/Settings/AdvancedPane.h"
+#include "DolphinQt/Settings/AudioPane.h"
+#include "DolphinQt/Settings/GameCubePane.h"
+#include "DolphinQt/Settings/GeneralPane.h"
+#include "DolphinQt/Settings/InterfacePane.h"
+#include "DolphinQt/Settings/PathPane.h"
+#include "DolphinQt/Settings/WiiPane.h"
+
+#include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoConfig.h"
+
+GrandSettingsWindow::GrandSettingsWindow(X11Utils::XRRConfiguration* xrr_config, QWidget* parent)
+    : GraphicsDialog(parent), m_xrr_config(xrr_config)
+{
+  // Set Window Properties
+  setWindowTitle(tr("Grand Settings"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+  m_search_bar = new QLineEdit();
+  m_search_bar->setPlaceholderText(tr("Search settings"));
+  m_search_bar->setClearButtonEnabled(true);
+
+  m_widget_stack = new QStackedWidget();
+
+  m_tree = new QTreeWidget();
+  m_tree->setHeaderHidden(true);
+
+  PopulateWidgets();
+  OnBackendChanged(QString::fromStdString(Config::Get(Config::MAIN_GFX_BACKEND)));
+
+  connect(m_search_bar, &QLineEdit::textChanged, this, &GrandSettingsWindow::OnSearch);
+
+  // Main Layout
+  QGridLayout* layout = new QGridLayout;
+
+  // Add content to layout before dialog buttons.
+  layout->addWidget(m_search_bar, 0, 0, 1, 1);
+  layout->addWidget(m_tree, 1, 0, 1, 1);
+  layout->addWidget(m_widget_stack, 0, 1, 2, 1);
+
+  // Dialog box buttons
+  QDialogButtonBox* close_box = new QDialogButtonBox(QDialogButtonBox::Close);
+
+  connect(close_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  layout->addWidget(close_box, 2, 0, 1, 2, Qt::AlignRight);
+
+  setLayout(layout);
+}
+
+void GrandSettingsWindow::PopulateWidgets()
+{
+  m_tree->clear();
+
+  QStringList all_tags;
+
+  auto create_item = [this](QTreeWidgetItem* parent, const QString& name,
+                            QStringList tags) -> QTreeWidgetItem* {
+    QTreeWidgetItem* tree_item = new QTreeWidgetItem();
+    tree_item->setData(0, Qt::UserRole, QVariant{tags});
+    tree_item->setText(0, name);
+    if (parent)
+      parent->addChild(tree_item);
+    else
+      m_tree->addTopLevelItem(tree_item);
+    return tree_item;
+  };
+
+  auto create_item_with_widget = [this, &create_item](QTreeWidgetItem* parent, const QString& name,
+                                                      QStringList tags,
+                                                      QWidget* widget) -> QTreeWidgetItem* {
+    auto child = create_item(parent, name, tags);
+    if (!child)
+      return nullptr;
+    if (!widget)
+      return child;
+    child->setData(1, Qt::UserRole, QVariant(m_widget_stack->addWidget(widget)));
+    return child;
+  };
+
+  connect(m_tree, &QTreeWidget::itemClicked, this, [this](QTreeWidgetItem* item, int column) {
+    auto the_data = item->data(1, Qt::UserRole);
+    if (!the_data.isValid() || the_data.isNull())
+      return;
+    m_widget_stack->setCurrentIndex(the_data.toInt());
+  });
+
+  auto emulator = create_item(nullptr, tr("Emulator"), {});
+  emulator->setExpanded(true);
+  auto general = create_item_with_widget(emulator, tr("General"), {}, new GeneralPane);
+  general->setSelected(true);
+  create_item_with_widget(emulator, tr("Interface"), {}, new InterfacePane);
+  create_item_with_widget(emulator, tr("Paths"), {}, new PathPane);
+
+  auto console = create_item(nullptr, tr("Console"), {});
+
+  QStringList gamecube_console_tags = {QStringLiteral("GC")};
+  all_tags.append(gamecube_console_tags);
+  create_item_with_widget(console, tr("Gamecube"), gamecube_console_tags, new GameCubePane);
+  create_item_with_widget(console, tr("Wii"), {}, new WiiPane);
+
+  create_item_with_widget(nullptr, tr("Audio"), {}, new AudioPane);
+
+  create_item_with_widget(nullptr, tr("Advanced"), {}, new AdvancedPane);
+
+  auto graphics = create_item(nullptr, tr("Graphics"), {});
+
+  if (Config::Get(Config::MAIN_GFX_BACKEND) != "Software Renderer")
+  {
+    auto* general_widget = new GeneralWidget(m_xrr_config, this);
+    auto* enhancements_widget = new EnhancementsWidget(this);
+    auto* hacks_widget = new HacksWidget(this);
+    auto* advanced_widget = new AdvancedWidget(this);
+
+    connect(general_widget, &GeneralWidget::BackendChanged, this,
+            &GrandSettingsWindow::OnBackendChanged);
+
+    create_item_with_widget(graphics, tr("General"), {}, general_widget);
+    create_item_with_widget(graphics, tr("Enhancements"), {}, enhancements_widget);
+    create_item_with_widget(graphics, tr("Hacks"), {}, hacks_widget);
+    create_item_with_widget(graphics, tr("Advanced"), {}, advanced_widget);
+  }
+  else
+  {
+    auto* software_renderer = new SoftwareRendererWidget(this);
+
+    connect(software_renderer, &SoftwareRendererWidget::BackendChanged, this,
+            &GrandSettingsWindow::OnBackendChanged);
+
+    create_item_with_widget(graphics, tr("Software Renderer"), {}, software_renderer);
+  }
+
+  auto inputs = create_item(nullptr, tr("Inputs"), {});
+
+  auto gamecube_inputs = new GamecubeControllersWidget(this);
+  create_item_with_widget(inputs, tr("Gamecube"), {}, gamecube_inputs);
+
+  auto wii_inputs = new WiimoteControllersWidget(this);
+  create_item_with_widget(inputs, tr("Wii"), {}, wii_inputs);
+
+  QStringList common_tags = {QStringLiteral("DSU"), QStringLiteral("Background"),
+                             QStringLiteral("DS4"), QStringLiteral("Joycons")};
+  all_tags.append(common_tags);
+  auto common_inputs = new CommonControllersWidget(this);
+  create_item_with_widget(inputs, tr("Common"), common_tags, common_inputs);
+
+  create_item_with_widget(nullptr, tr("FreeLook"), {}, new FreeLookWidget(this));
+
+  QCompleter* tags_completer = new QCompleter(all_tags, this);
+  tags_completer->setCaseSensitivity(Qt::CaseInsensitive);
+  tags_completer->setCompletionMode(QCompleter::CompletionMode::PopupCompletion);
+  m_search_bar->setCompleter(tags_completer);
+}
+
+void GrandSettingsWindow::OnSearch(const QString& text)
+{
+  QTreeWidgetItemIterator it(m_tree);
+  while (*it)
+  {
+    TreeNodeContainsText(text, *it);
+    ++it;
+  }
+}
+
+bool GrandSettingsWindow::TreeNodeContainsText(const QString& text, QTreeWidgetItem* item)
+{
+  if (item->text(0).contains(text))
+  {
+    item->setHidden(false);
+    return true;
+  }
+
+  auto the_data = item->data(0, Qt::UserRole);
+  if (the_data.isValid() && !the_data.isNull())
+  {
+    auto tags = the_data.toStringList();
+    if (!tags.filter(text, Qt::CaseInsensitive).empty())
+    {
+      item->setHidden(false);
+      return true;
+    }
+  }
+
+  bool item_children_contains_text = false;
+  for (int i = 0; i < item->childCount(); i++)
+  {
+    item_children_contains_text |= TreeNodeContainsText(text, item->child(i));
+  }
+
+  item->setHidden(!item_children_contains_text);
+  if (item_children_contains_text)
+  {
+    item->setExpanded(true);
+  }
+
+  return item_children_contains_text;
+}
+
+void GrandSettingsWindow::OnBackendChanged(const QString& backend_name)
+{
+  Config::SetBase(Config::MAIN_GFX_BACKEND, backend_name.toStdString());
+  VideoBackendBase::PopulateBackendInfoFromUI();
+
+  PopulateWidgets();
+
+  emit BackendChanged(backend_name);
+}

--- a/Source/Core/DolphinQt/GrandSettingsWindow.cpp
+++ b/Source/Core/DolphinQt/GrandSettingsWindow.cpp
@@ -21,7 +21,6 @@
 #include "DolphinQt/Config/Graphics/EnhancementsWidget.h"
 #include "DolphinQt/Config/Graphics/GeneralWidget.h"
 #include "DolphinQt/Config/Graphics/HacksWidget.h"
-#include "DolphinQt/Config/Graphics/SoftwareRendererWidget.h"
 #include "DolphinQt/Config/WiimoteControllersWidget.h"
 #include "DolphinQt/GrandSettingsWindow.h"
 #include "DolphinQt/Settings/AdvancedPane.h"
@@ -140,44 +139,31 @@ void GrandSettingsWindow::PopulateWidgets()
 
   auto graphics = create_item(nullptr, tr("Graphics"), {});
 
-  if (Config::Get(Config::MAIN_GFX_BACKEND) != "Software Renderer")
+  auto* general_widget = new GeneralWidget(m_xrr_config, this);
+  auto* enhancements_widget = new EnhancementsWidget(this);
+  auto* hacks_widget = new HacksWidget(this);
+  auto* advanced_widget = new AdvancedWidget(this);
+
+  connect(general_widget, &GeneralWidget::BackendChanged, this,
+          &GrandSettingsWindow::OnBackendChanged);
+
+  auto* graphics_pane = create_item_with_widget(graphics, tr("General"), {}, general_widget);
+  QVariant pane_index_data = graphics_pane->data(1, Qt::UserRole);
+  if (pane_index_data.isValid() && !pane_index_data.isNull() &&
+      m_selected_pane == SelectedPane::Graphics)
   {
-    auto* general_widget = new GeneralWidget(m_xrr_config, this);
-    auto* enhancements_widget = new EnhancementsWidget(this);
-    auto* hacks_widget = new HacksWidget(this);
-    auto* advanced_widget = new AdvancedWidget(this);
-
-    connect(general_widget, &GeneralWidget::BackendChanged, this,
-            &GrandSettingsWindow::OnBackendChanged);
-
-    auto* graphics_pane = create_item_with_widget(graphics, tr("General"), {}, general_widget);
-    QVariant pane_index_data = graphics_pane->data(1, Qt::UserRole);
-    if (pane_index_data.isValid() && !pane_index_data.isNull() &&
-        m_selected_pane == SelectedPane::Graphics)
-    {
-      m_widget_stack->setCurrentIndex(pane_index_data.toInt());
-      graphics_pane->setSelected(true);
-      graphics_pane->parent()->setExpanded(true);
-    }
-    create_item_with_widget(graphics, tr("Enhancements"), {}, enhancements_widget);
-    create_item_with_widget(graphics, tr("Hacks"), {}, hacks_widget);
-    create_item_with_widget(graphics, tr("Advanced"), {}, advanced_widget);
+    m_widget_stack->setCurrentIndex(pane_index_data.toInt());
+    graphics_pane->setSelected(true);
+    graphics_pane->parent()->setExpanded(true);
   }
-  else
-  {
-    auto* software_renderer = new SoftwareRendererWidget(this);
-
-    connect(software_renderer, &SoftwareRendererWidget::BackendChanged, this,
-            &GrandSettingsWindow::OnBackendChanged);
-
-    create_item_with_widget(graphics, tr("Software Renderer"), {}, software_renderer);
-  }
+  create_item_with_widget(graphics, tr("Enhancements"), {}, enhancements_widget);
+  create_item_with_widget(graphics, tr("Hacks"), {}, hacks_widget);
+  create_item_with_widget(graphics, tr("Advanced"), {}, advanced_widget);
 
   auto inputs = create_item(nullptr, tr("Inputs"), {});
 
   auto gamecube_inputs = new GamecubeControllersWidget(this);
   auto gamecube_pane = create_item_with_widget(inputs, tr("Gamecube"), {}, gamecube_inputs);
-  QVariant pane_index_data = gamecube_pane->data(1, Qt::UserRole);
   if (pane_index_data.isValid() && !pane_index_data.isNull() &&
       m_selected_pane == SelectedPane::Controllers && m_controllers_enabled)
   {

--- a/Source/Core/DolphinQt/GrandSettingsWindow.h
+++ b/Source/Core/DolphinQt/GrandSettingsWindow.h
@@ -1,0 +1,37 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+#include "DolphinQt/Config/Graphics/GraphicsDialog.h"
+
+class QLineEdit;
+class QStackedWidget;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+namespace X11Utils
+{
+class XRRConfiguration;
+}
+
+class GrandSettingsWindow final : public GraphicsDialog
+{
+  Q_OBJECT
+public:
+  explicit GrandSettingsWindow(X11Utils::XRRConfiguration* xrr_config, QWidget* parent = nullptr);
+
+private:
+  void PopulateWidgets();
+  void OnSearch(const QString& text);
+  bool TreeNodeContainsText(const QString& text, QTreeWidgetItem* item);
+  void OnBackendChanged(const QString& backend_name);
+
+  X11Utils::XRRConfiguration* m_xrr_config;
+  QTreeWidget* m_tree;
+  QLineEdit* m_search_bar;
+  QStackedWidget* m_widget_stack;
+};

--- a/Source/Core/DolphinQt/GrandSettingsWindow.h
+++ b/Source/Core/DolphinQt/GrandSettingsWindow.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QDialog>
 
 #include "DolphinQt/Config/Graphics/GraphicsDialog.h"
@@ -23,8 +25,18 @@ class GrandSettingsWindow final : public GraphicsDialog
   Q_OBJECT
 public:
   explicit GrandSettingsWindow(X11Utils::XRRConfiguration* xrr_config, QWidget* parent = nullptr);
+  void SetDefaultPane();
+  void SetControllersPane();
+  void SetGraphicsPane();
+  void SetControllersEnabled(bool enable);
 
 private:
+  enum class SelectedPane
+  {
+    Default,
+    Graphics,
+    Controllers
+  };
   void PopulateWidgets();
   void OnSearch(const QString& text);
   bool TreeNodeContainsText(const QString& text, QTreeWidgetItem* item);
@@ -34,4 +46,7 @@ private:
   QTreeWidget* m_tree;
   QLineEdit* m_search_bar;
   QStackedWidget* m_widget_stack;
+
+  SelectedPane m_selected_pane = SelectedPane::Default;
+  bool m_controllers_enabled = true;
 };

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -364,6 +364,10 @@ void MainWindow::InitCoreCallbacks()
     if (state == Core::State::Uninitialized)
       OnStopComplete();
 
+    const bool should_disable_controllers =
+        state != Core::State::Uninitialized && NetPlay::IsNetPlayRunning();
+    m_settings_window->SetControllersEnabled(!should_disable_controllers);
+
     if (state == Core::State::Running && m_fullscreen_requested)
     {
       FullScreen();
@@ -498,12 +502,7 @@ void MainWindow::ConnectMenuBar()
 
   // Options
   connect(m_menu_bar, &MenuBar::Configure, this, &MainWindow::ShowSettingsWindow);
-  connect(m_menu_bar, &MenuBar::ConfigureGraphics, this, &MainWindow::ShowGraphicsWindow);
-  connect(m_menu_bar, &MenuBar::ConfigureAudio, this, &MainWindow::ShowAudioWindow);
-  connect(m_menu_bar, &MenuBar::ConfigureControllers, this, &MainWindow::ShowControllersWindow);
   connect(m_menu_bar, &MenuBar::ConfigureHotkeys, this, &MainWindow::ShowHotkeyDialog);
-  connect(m_menu_bar, &MenuBar::ConfigureFreelook, this, &MainWindow::ShowFreeLookWindow);
-  connect(m_menu_bar, &MenuBar::ConfigureGrandSettings, this, &MainWindow::ShowGrandSettingsDialog);
 
   // Tools
   connect(m_menu_bar, &MenuBar::ShowMemcardManager, this, &MainWindow::ShowMemcardManager);
@@ -650,7 +649,7 @@ void MainWindow::ConnectGameList()
   connect(m_game_list, &GameList::OnStartWithRiivolution, this,
           &MainWindow::ShowRiivolutionBootWidget);
 
-  connect(m_game_list, &GameList::OpenGeneralSettings, this, &MainWindow::ShowGeneralWindow);
+  // connect(m_game_list, &GameList::OpenGeneralSettings, this, &MainWindow::ShowGeneralWindow);
   connect(m_game_list, &GameList::OpenGraphicsSettings, this, &MainWindow::ShowGraphicsWindow);
 }
 
@@ -1166,37 +1165,22 @@ void MainWindow::HideRenderWidget(bool reinit, bool is_exit)
   }
 }
 
-void MainWindow::ShowControllersWindow()
-{
-  if (!m_controllers_window)
-  {
-    m_controllers_window = new ControllersWindow(this);
-    InstallHotkeyFilter(m_controllers_window);
-  }
-
-  m_controllers_window->show();
-  m_controllers_window->raise();
-  m_controllers_window->activateWindow();
-}
-
-void MainWindow::ShowFreeLookWindow()
-{
-  if (!m_freelook_window)
-  {
-    m_freelook_window = new FreeLookWindow(this);
-    InstallHotkeyFilter(m_freelook_window);
-  }
-
-  m_freelook_window->show();
-  m_freelook_window->raise();
-  m_freelook_window->activateWindow();
-}
-
 void MainWindow::ShowSettingsWindow()
 {
   if (!m_settings_window)
   {
-    m_settings_window = new SettingsWindow(this);
+#ifdef HAVE_XRANDR
+    if (GetWindowSystemType() == WindowSystemType::X11 && m_xrr_config != nullptr)
+    {
+      m_xrr_config = std::make_unique<X11Utils::XRRConfiguration>(
+          static_cast<Display*>(QGuiApplication::platformNativeInterface()->nativeResourceForWindow(
+              "display", windowHandle())),
+          winId());
+    }
+    m_settings_window = new GrandSettingsWindow(m_xrr_config.get(), this);
+#else
+    m_settings_window = new GrandSettingsWindow(nullptr, this);
+#endif
     InstallHotkeyFilter(m_settings_window);
   }
 
@@ -1205,16 +1189,10 @@ void MainWindow::ShowSettingsWindow()
   m_settings_window->activateWindow();
 }
 
-void MainWindow::ShowAudioWindow()
+void MainWindow::ShowControllersWindow()
 {
   ShowSettingsWindow();
-  m_settings_window->SelectAudioPane();
-}
-
-void MainWindow::ShowGeneralWindow()
-{
-  ShowSettingsWindow();
-  m_settings_window->SelectGeneralPane();
+  m_settings_window->SetControllersPane();
 }
 
 void MainWindow::ShowAboutDialog()
@@ -1236,45 +1214,16 @@ void MainWindow::ShowHotkeyDialog()
   m_hotkey_window->activateWindow();
 }
 
-void MainWindow::ShowGrandSettingsDialog()
+void MainWindow::ShowGeneralWindow()
 {
-#if defined(HAVE_XRANDR) && HAVE_XRANDR
-  if (GetWindowSystemType() == WindowSystemType::X11 && m_xrr_config != nullptr)
-  {
-    m_xrr_config = std::make_unique<X11Utils::XRRConfiguration>(
-        static_cast<Display*>(QGuiApplication::platformNativeInterface()->nativeResourceForWindow(
-            "display", windowHandle())),
-        winId());
-  }
-  GrandSettingsWindow grand{m_xrr_config.get(), this};
-#else
-  GrandSettingsWindow grand{nullptr, this};
-#endif
-  grand.exec();
+  ShowSettingsWindow();
+  m_settings_window->SetDefaultPane();
 }
 
 void MainWindow::ShowGraphicsWindow()
 {
-  if (!m_graphics_window)
-  {
-#ifdef HAVE_XRANDR
-    if (GetWindowSystemType() == WindowSystemType::X11 && m_xrr_config != nullptr)
-    {
-      m_xrr_config = std::make_unique<X11Utils::XRRConfiguration>(
-          static_cast<Display*>(QGuiApplication::platformNativeInterface()->nativeResourceForWindow(
-              "display", windowHandle())),
-          winId());
-    }
-    m_graphics_window = new GraphicsWindow(m_xrr_config.get(), this);
-#else
-    m_graphics_window = new GraphicsWindow(nullptr, this);
-#endif
-    InstallHotkeyFilter(m_graphics_window);
-  }
-
-  m_graphics_window->show();
-  m_graphics_window->raise();
-  m_graphics_window->activateWindow();
+  ShowSettingsWindow();
+  m_settings_window->SetGraphicsPane();
 }
 
 void MainWindow::ShowNetPlaySetupDialog()

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -155,6 +155,7 @@ private:
   void ShowFreeLookWindow();
   void ShowAboutDialog();
   void ShowHotkeyDialog();
+  void ShowGrandSettingsDialog();
   void ShowNetPlaySetupDialog();
   void ShowNetPlayBrowser();
   void ShowFIFOPlayer();

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -28,6 +28,7 @@ class FreeLookWindow;
 class GameList;
 class GCTASInputWindow;
 class GraphicsWindow;
+class GrandSettingsWindow;
 class HotkeyScheduler;
 class JITWidget;
 class LogConfigWidget;
@@ -148,14 +149,11 @@ private:
   void HideRenderWidget(bool reinit = true, bool is_exit = false);
 
   void ShowSettingsWindow();
-  void ShowGeneralWindow();
-  void ShowAudioWindow();
   void ShowControllersWindow();
+  void ShowGeneralWindow();
   void ShowGraphicsWindow();
-  void ShowFreeLookWindow();
   void ShowAboutDialog();
   void ShowHotkeyDialog();
-  void ShowGrandSettingsDialog();
   void ShowNetPlaySetupDialog();
   void ShowNetPlayBrowser();
   void ShowFIFOPlayer();
@@ -216,12 +214,9 @@ private:
   int m_state_slot = 1;
   std::unique_ptr<BootParameters> m_pending_boot;
 
-  ControllersWindow* m_controllers_window = nullptr;
-  SettingsWindow* m_settings_window = nullptr;
-  GraphicsWindow* m_graphics_window = nullptr;
+  GrandSettingsWindow* m_settings_window = nullptr;
   FIFOPlayerWindow* m_fifo_window = nullptr;
   MappingWindow* m_hotkey_window = nullptr;
-  FreeLookWindow* m_freelook_window = nullptr;
 
   HotkeyScheduler* m_hotkey_scheduler;
   NetPlayDialog* m_netplay_dialog;

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -518,16 +518,7 @@ void MenuBar::AddOptionsMenu()
   options_menu->addAction(tr("Co&nfiguration"), this, &MenuBar::Configure,
                           QKeySequence::Preferences);
   options_menu->addSeparator();
-  options_menu->addAction(tr("&Graphics Settings"), this, &MenuBar::ConfigureGraphics);
-  options_menu->addAction(tr("&Audio Settings"), this, &MenuBar::ConfigureAudio);
-  m_controllers_action =
-      options_menu->addAction(tr("&Controller Settings"), this, &MenuBar::ConfigureControllers);
   options_menu->addAction(tr("&Hotkey Settings"), this, &MenuBar::ConfigureHotkeys);
-  options_menu->addAction(tr("&Free Look Settings"), this, &MenuBar::ConfigureFreelook);
-
-  options_menu->addSeparator();
-
-  options_menu->addAction(tr("Grand Settings"), this, &MenuBar::ConfigureGrandSettings);
 
   options_menu->addSeparator();
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -527,6 +527,10 @@ void MenuBar::AddOptionsMenu()
 
   options_menu->addSeparator();
 
+  options_menu->addAction(tr("Grand Settings"), this, &MenuBar::ConfigureGrandSettings);
+
+  options_menu->addSeparator();
+
   // Debugging mode only
   m_boot_to_pause = options_menu->addAction(tr("Boot to Pause"));
   m_boot_to_pause->setCheckable(true);

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -237,7 +237,6 @@ private:
   QAction* m_automatic_start;
   QAction* m_reset_ignore_panic_handler;
   QAction* m_change_font;
-  QAction* m_controllers_action;
 
   // View
   QAction* m_show_code;

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -98,6 +98,7 @@ signals:
   void ConfigureControllers();
   void ConfigureHotkeys();
   void ConfigureFreelook();
+  void ConfigureGrandSettings();
 
   // View
   void ShowList();


### PR DESCRIPTION
This was loosely based off of @mbc07 's comment on #8785 .

I patterned it after Visual Studio's options window.  Ex:

![image](https://user-images.githubusercontent.com/15224722/83488156-fa8c9b80-a471-11ea-9305-854f83035a3e.png)

I think the multi-tiered approach may be useful for the future, as we add more and more settings.

**Opening the window:**

![image](https://user-images.githubusercontent.com/15224722/106236912-64a53e00-61c3-11eb-8e9a-9952d2fa3400.png)


**Search:**

![image](https://user-images.githubusercontent.com/15224722/106236973-7a1a6800-61c3-11eb-9859-c8093acfacad.png)
