### PR TITLE
Common / Core: Update StringUtil to allow specifying the base

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -55,7 +55,7 @@ std::string ReplaceAll(std::string result, std::string_view src, std::string_vie
 bool TryParse(const std::string& str, bool* output);
 
 template <typename T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>* = nullptr>
-bool TryParse(const std::string& str, T* output)
+bool TryParse(const std::string& str, T* output, int base = 0)
 {
   char* end_ptr = nullptr;
 
@@ -67,9 +67,9 @@ bool TryParse(const std::string& str, T* output)
   ReadType value;
 
   if constexpr (std::is_unsigned_v<T>)
-    value = std::strtoull(str.c_str(), &end_ptr, 0);
+    value = std::strtoull(str.c_str(), &end_ptr, base);
   else
-    value = std::strtoll(str.c_str(), &end_ptr, 0);
+    value = std::strtoll(str.c_str(), &end_ptr, base);
 
   // Fail if the end of the string wasn't reached.
   if (end_ptr == nullptr || *end_ptr != '\0')

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -236,8 +236,8 @@ std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_in
         if (pieces.size() == 2 && pieces[0].size() == 8 && pieces[1].size() == 8)
         {
           AREntry op;
-          bool success_addr = TryParse(std::string("0x") + pieces[0], &op.cmd_addr);
-          bool success_val = TryParse(std::string("0x") + pieces[1], &op.value);
+          bool success_addr = TryParse(pieces[0], &op.cmd_addr, 16);
+          bool success_val = TryParse(pieces[1], &op.value, 16);
 
           if (success_addr && success_val)
           {


### PR DESCRIPTION
In addition to updating 'TryParse' to support any base, this fixes the ActionReplay usage to specify base 16 instead of prepending a '0x' in front of the string.