### PR TITLE
Android: Use DialogFragment for AlertMessage

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -446,7 +446,7 @@ public final class NativeLibrary
   public static native void SetObscuredPixelsTop(int height);
 
   public static boolean displayAlertMsg(final String caption, final String text,
-          final boolean yesNo)
+          final boolean yesNo, final boolean isWarning)
   {
     Log.error("[NativeLibrary] Alert: " + text);
     final EmulationActivity emulationActivity = sEmulationActivity.get();
@@ -454,6 +454,10 @@ public final class NativeLibrary
     if (emulationActivity == null)
     {
       Log.warning("[NativeLibrary] EmulationActivity is null, can't do panic alert.");
+    }
+    else if (emulationActivity.isIgnoringWarnings() && isWarning)
+    {
+      return true;
     }
     else
     {
@@ -470,8 +474,9 @@ public final class NativeLibrary
       {
         sIsShowingAlertMessage = true;
 
-        emulationActivity.runOnUiThread(() -> AlertMessage.newInstance(caption, text, yesNo)
-                .show(emulationActivity.getSupportFragmentManager(), "AlertMessage"));
+        emulationActivity.runOnUiThread(
+                () -> AlertMessage.newInstance(caption, text, yesNo, isWarning)
+                        .show(emulationActivity.getSupportFragmentManager(), "AlertMessage"));
 
         // Wait for the lock to notify that it is complete.
         synchronized (sAlertMessageLock)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -274,6 +274,7 @@ public final class EmulationActivity extends AppCompatActivity
       mPlatform = gameToEmulate.getIntExtra(EXTRA_PLATFORM, 0);
       sUserPausedEmulation = gameToEmulate.getBooleanExtra(EXTRA_USER_PAUSED_EMULATION, false);
       activityRecreated = false;
+      Toast.makeText(this, R.string.emulation_menu_help, Toast.LENGTH_LONG).show();
     }
     else
     {
@@ -296,8 +297,6 @@ public final class EmulationActivity extends AppCompatActivity
 
     // Set these options now so that the SurfaceView the game renders into is the right size.
     enableFullscreenImmersive();
-
-    Toast.makeText(this, getString(R.string.emulation_menu_help), Toast.LENGTH_LONG).show();
 
     Rumble.initRumble(this);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -85,12 +85,14 @@ public final class EmulationActivity extends AppCompatActivity
   private String mSelectedGameId;
   private int mPlatform;
   private String[] mPaths;
+  private boolean mIgnoreWarnings;
   private static boolean sUserPausedEmulation;
 
   public static final String EXTRA_SELECTED_GAMES = "SelectedGames";
   public static final String EXTRA_SELECTED_TITLE = "SelectedTitle";
   public static final String EXTRA_SELECTED_GAMEID = "SelectedGameId";
   public static final String EXTRA_PLATFORM = "Platform";
+  public static final String EXTRA_IGNORE_WARNINGS = "IgnoreWarnings";
   public static final String EXTRA_USER_PAUSED_EMULATION = "sUserPausedEmulation";
 
   @Retention(SOURCE)
@@ -272,6 +274,7 @@ public final class EmulationActivity extends AppCompatActivity
       mSelectedTitle = gameToEmulate.getStringExtra(EXTRA_SELECTED_TITLE);
       mSelectedGameId = gameToEmulate.getStringExtra(EXTRA_SELECTED_GAMEID);
       mPlatform = gameToEmulate.getIntExtra(EXTRA_PLATFORM, 0);
+      mIgnoreWarnings = gameToEmulate.getBooleanExtra(EXTRA_IGNORE_WARNINGS, false);
       sUserPausedEmulation = gameToEmulate.getBooleanExtra(EXTRA_USER_PAUSED_EMULATION, false);
       activityRecreated = false;
       Toast.makeText(this, R.string.emulation_menu_help, Toast.LENGTH_LONG).show();
@@ -327,6 +330,7 @@ public final class EmulationActivity extends AppCompatActivity
     outState.putString(EXTRA_SELECTED_TITLE, mSelectedTitle);
     outState.putString(EXTRA_SELECTED_GAMEID, mSelectedGameId);
     outState.putInt(EXTRA_PLATFORM, mPlatform);
+    outState.putBoolean(EXTRA_USER_PAUSED_EMULATION, mIgnoreWarnings);
     outState.putBoolean(EXTRA_USER_PAUSED_EMULATION, sUserPausedEmulation);
     super.onSaveInstanceState(outState);
   }
@@ -337,6 +341,7 @@ public final class EmulationActivity extends AppCompatActivity
     mSelectedTitle = savedInstanceState.getString(EXTRA_SELECTED_TITLE);
     mSelectedGameId = savedInstanceState.getString(EXTRA_SELECTED_GAMEID);
     mPlatform = savedInstanceState.getInt(EXTRA_PLATFORM);
+    mIgnoreWarnings = savedInstanceState.getBoolean(EXTRA_IGNORE_WARNINGS);
     sUserPausedEmulation = savedInstanceState.getBoolean(EXTRA_USER_PAUSED_EMULATION);
   }
 
@@ -669,6 +674,16 @@ public final class EmulationActivity extends AppCompatActivity
         finish();
         return;
     }
+  }
+
+  public boolean isIgnoringWarnings()
+  {
+    return mIgnoreWarnings;
+  }
+
+  public void setIgnoreWarnings(boolean value)
+  {
+    mIgnoreWarnings = value;
   }
 
   public static boolean getHasUserPausedEmulation()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AlertMessage.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AlertMessage.java
@@ -17,8 +17,10 @@ public final class AlertMessage extends DialogFragment
   private static final String ARG_TITLE = "title";
   private static final String ARG_MESSAGE = "message";
   private static final String ARG_YES_NO = "yesNo";
+  private static final String ARG_IS_WARNING = "isWarning";
 
-  public static AlertMessage newInstance(String title, String message, boolean yesNo)
+  public static AlertMessage newInstance(String title, String message, boolean yesNo,
+          boolean isWarning)
   {
     AlertMessage fragment = new AlertMessage();
 
@@ -26,6 +28,7 @@ public final class AlertMessage extends DialogFragment
     args.putString(ARG_TITLE, title);
     args.putString(ARG_MESSAGE, message);
     args.putBoolean(ARG_YES_NO, yesNo);
+    args.putBoolean(ARG_IS_WARNING, isWarning);
     fragment.setArguments(args);
 
     return fragment;
@@ -39,6 +42,7 @@ public final class AlertMessage extends DialogFragment
     String title = requireArguments().getString(ARG_TITLE);
     String message = requireArguments().getString(ARG_MESSAGE);
     boolean yesNo = requireArguments().getBoolean(ARG_YES_NO);
+    boolean isWarning = requireArguments().getBoolean(ARG_IS_WARNING);
     setCancelable(false);
 
     AlertDialog.Builder builder = new AlertDialog.Builder(emulationActivity,
@@ -71,6 +75,17 @@ public final class AlertMessage extends DialogFragment
                 NativeLibrary.NotifyAlertMessageLock();
               });
     }
+
+    if (isWarning)
+    {
+      builder.setNeutralButton(R.string.ignore_warning_alert_messages, (dialog, which) ->
+      {
+        emulationActivity.setIgnoreWarnings(true);
+        dialog.dismiss();
+        NativeLibrary.NotifyAlertMessageLock();
+      });
+    }
+
     return builder.create();
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AlertMessage.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/AlertMessage.java
@@ -1,0 +1,81 @@
+package org.dolphinemu.dolphinemu.dialogs;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import org.dolphinemu.dolphinemu.NativeLibrary;
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+
+public final class AlertMessage extends DialogFragment
+{
+  private static boolean sAlertResult = false;
+  private static final String ARG_TITLE = "title";
+  private static final String ARG_MESSAGE = "message";
+  private static final String ARG_YES_NO = "yesNo";
+
+  public static AlertMessage newInstance(String title, String message, boolean yesNo)
+  {
+    AlertMessage fragment = new AlertMessage();
+
+    Bundle args = new Bundle();
+    args.putString(ARG_TITLE, title);
+    args.putString(ARG_MESSAGE, message);
+    args.putBoolean(ARG_YES_NO, yesNo);
+    fragment.setArguments(args);
+
+    return fragment;
+  }
+
+  @NonNull
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState)
+  {
+    final EmulationActivity emulationActivity = NativeLibrary.getEmulationActivity();
+    String title = requireArguments().getString(ARG_TITLE);
+    String message = requireArguments().getString(ARG_MESSAGE);
+    boolean yesNo = requireArguments().getBoolean(ARG_YES_NO);
+    setCancelable(false);
+
+    AlertDialog.Builder builder = new AlertDialog.Builder(emulationActivity,
+            R.style.DolphinDialogBase)
+            .setTitle(title)
+            .setMessage(message);
+
+    // If not yes/no dialog just have one button that dismisses modal,
+    // otherwise have a yes and no button that sets sAlertResult accordingly.
+    if (!yesNo)
+    {
+      builder.setPositiveButton(android.R.string.ok, (dialog, which) ->
+      {
+        dialog.dismiss();
+        NativeLibrary.NotifyAlertMessageLock();
+      });
+    }
+    else
+    {
+      builder.setPositiveButton(android.R.string.yes, (dialog, which) ->
+      {
+        sAlertResult = true;
+        dialog.dismiss();
+        NativeLibrary.NotifyAlertMessageLock();
+      })
+              .setNegativeButton(android.R.string.no, (dialog, which) ->
+              {
+                sAlertResult = false;
+                dialog.dismiss();
+                NativeLibrary.NotifyAlertMessageLock();
+              });
+    }
+    return builder.create();
+  }
+
+  public static boolean getAlertResult()
+  {
+    return sAlertResult;
+  }
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -112,7 +112,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   @Override
   public void onPause()
   {
-    if (mEmulationState.isRunning())
+    if (mEmulationState.isRunning() && !NativeLibrary.IsShowingAlertMessage())
       mEmulationState.pause();
     super.onPause();
   }
@@ -323,7 +323,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
         mSurface = null;
         Log.debug("[EmulationFragment] Surface destroyed.");
 
-        if (state != State.STOPPED)
+        if (state != State.STOPPED && !NativeLibrary.IsShowingAlertMessage())
         {
           // In order to avoid dereferencing nullptr, we must not destroy the surface while booting
           // the core, so wait here if necessary. An easy (but not 100% consistent) way to reach
@@ -362,7 +362,8 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
       else if (state == State.PAUSED)
       {
         NativeLibrary.SurfaceChanged(mSurface);
-        if (!EmulationActivity.getHasUserPausedEmulation())
+        if (!EmulationActivity.getHasUserPausedEmulation() &&
+                !NativeLibrary.IsShowingAlertMessage())
         {
           Log.debug("[EmulationFragment] Resuming emulation.");
           NativeLibrary.UnPauseEmulation();

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -438,5 +438,6 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="slider_setting_value">%1$d%2$s</string>
     <string name="disc_number">Disc %1$d</string>
     <string name="disabled_gc_overlay_notice">GameCube Controller 1 is set to \"None\"</string>
+    <string name="ignore_warning_alert_messages">Ignore for this session</string>
 
 </resources>

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -210,7 +210,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
   const jclass native_library_class = env->FindClass("org/dolphinemu/dolphinemu/NativeLibrary");
   s_native_library_class = reinterpret_cast<jclass>(env->NewGlobalRef(native_library_class));
   s_display_alert_msg = env->GetStaticMethodID(s_native_library_class, "displayAlertMsg",
-                                               "(Ljava/lang/String;Ljava/lang/String;Z)Z");
+                                               "(Ljava/lang/String;Ljava/lang/String;ZZ)Z");
   s_do_rumble = env->GetStaticMethodID(s_native_library_class, "rumble", "(ID)V");
   s_get_update_touch_pointer =
       env->GetStaticMethodID(s_native_library_class, "updateTouchPointer", "()V");

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -151,14 +151,14 @@ void Host_TitleChanged()
 {
 }
 
-static bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType /*style*/)
+static bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType style)
 {
   JNIEnv* env = IDCache::GetEnvForThread();
 
   // Execute the Java method.
   jboolean result = env->CallStaticBooleanMethod(
       IDCache::GetNativeLibraryClass(), IDCache::GetDisplayAlertMsg(), ToJString(env, caption),
-      ToJString(env, text), yes_no ? JNI_TRUE : JNI_FALSE);
+      ToJString(env, text), yes_no ? JNI_TRUE : JNI_FALSE, style == Common::MsgType::Warning);
 
   return result != JNI_FALSE;
 }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -300,6 +300,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulatio
   s_emulation_end_event.Wait();
 }
 
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsBooting(JNIEnv* env,
+                                                                                  jobject obj)
+{
+  return static_cast<jboolean>(Core::IsBooting());
+}
+
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_WaitUntilDoneBooting(JNIEnv* env, jobject obj)
 {

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -170,6 +170,11 @@ void DisplayMessage(std::string message, int time_in_ms)
   OSD::AddMessage(std::move(message), time_in_ms);
 }
 
+bool IsBooting()
+{
+  return s_is_booting.IsSet() || !s_hardware_initialized;
+}
+
 bool IsRunning()
 {
   return (GetState() != State::Uninitialized || s_hardware_initialized) && !s_is_stopping;
@@ -674,7 +679,7 @@ State GetState()
 
 void WaitUntilDoneBooting()
 {
-  if (s_is_booting.IsSet() || !s_hardware_initialized)
+  if (IsBooting())
     s_done_booting.Wait();
 }
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -99,6 +99,7 @@ void UndeclareAsCPUThread();
 
 std::string StopMessage(bool main_thread, std::string_view message);
 
+bool IsBooting();
 bool IsRunning();
 bool IsRunningAndStarted();       // is running and the CPU loop has been entered
 bool IsRunningInCurrentThread();  // this tells us whether we are running in the CPU thread.


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/7988
Fixes https://bugs.dolphin-emu.org/issues/10770

As far as I can tell, this works (even with multiple panic alerts in quick succession) but there are some things that I'm not sure I've done properly:

- ~~Did I properly handle AlertMessages while booting the core?~~
- ~~Since `NativeLibrary.displayAlertMsg` has a lock object, pausing emulation while waiting on the lock would freeze AlertMessages after rotating the screen. As far as I can tell, pausing emulation here seems unnecessary but correct me if I'm wrong.~~

Test case was https://bugs.dolphin-emu.org/issues/11424