### PR TITLE
NetPlay: Always use packet to fire power button event

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -935,7 +935,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
   {
     sf::Packet spac;
     spac << static_cast<MessageId>(NP_MSG_POWER_BUTTON);
-    SendToClients(spac, player.pid);
+    SendToClients(spac);
   }
   break;
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -841,20 +841,21 @@ bool MainWindow::RequestStop()
   OnStopRecording();
   // TODO: Add Debugger shutdown
 
-  if (!m_stop_requested && UICommon::TriggerSTMPowerEvent())
+  if (!m_stop_requested && UICommon::CanTriggerSTMPowerEvent())
   {
     m_stop_requested = true;
 
-    // Unpause because gracefully shutting down needs the game to actually request a shutdown.
-    // TODO: Do not unpause in debug mode to allow debugging until the complete shutdown.
-    if (Core::GetState() == Core::State::Paused)
-      Core::SetState(Core::State::Running);
-
-    // Tell NetPlay about the power event
     if (NetPlay::IsNetPlayRunning())
+    {
+      // Tell NetPlay about the power event
       NetPlay::SendPowerButtonEvent();
 
-    return true;
+      return true;
+    }
+    else if (UICommon::TriggerSTMPowerEvent())
+    {
+      return true;
+    }
   }
 
   ForceStop();

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -382,6 +382,17 @@ void SaveWiimoteSources()
 
 bool TriggerSTMPowerEvent()
 {
+  if (!CanTriggerSTMPowerEvent())
+    return false;
+
+  Core::DisplayMessage("Shutting down", 30000);
+  ProcessorInterface::PowerButton_Tap();
+
+  return true;
+}
+
+bool CanTriggerSTMPowerEvent()
+{
   const auto ios = IOS::HLE::GetIOS();
   if (!ios)
     return false;
@@ -389,9 +400,6 @@ bool TriggerSTMPowerEvent()
   const auto stm = ios->GetDeviceByName("/dev/stm/eventhook");
   if (!stm || !std::static_pointer_cast<IOS::HLE::Device::STMEventHook>(stm)->HasHookInstalled())
     return false;
-
-  Core::DisplayMessage("Shutting down", 30000);
-  ProcessorInterface::PowerButton_Tap();
 
   return true;
 }

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -31,6 +31,7 @@
 #include "Core/HW/Wiimote.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/STM/STM.h"
+#include "Core/State.h"
 #include "Core/WiiRoot.h"
 
 #include "InputCommon/GCAdapter.h"
@@ -384,6 +385,11 @@ bool TriggerSTMPowerEvent()
 {
   if (!CanTriggerSTMPowerEvent())
     return false;
+
+  // Unpause because gracefully shutting down needs the game to actually request a shutdown.
+  // TODO: Do not unpause in debug mode to allow debugging until the complete shutdown.
+  if (Core::GetState() == Core::State::Paused)
+    Core::SetState(Core::State::Running);
 
   Core::DisplayMessage("Shutting down", 30000);
   ProcessorInterface::PowerButton_Tap();

--- a/Source/Core/UICommon/UICommon.h
+++ b/Source/Core/UICommon/UICommon.h
@@ -27,6 +27,7 @@ void CreateDirectories();
 void SetUserDirectory(const std::string& custom_path);
 
 bool TriggerSTMPowerEvent();
+bool CanTriggerSTMPowerEvent();
 
 void SaveWiimoteSources();
 


### PR DESCRIPTION
This is a first pass on trying to fix the NetPlay Wii shutdown deadlock. Not entirely sure if it will fix the problem, more timing synchronization might be needed, but it's at least a necessary step towards fixing the issue.