### PR TITLE
INI changes

### DIFF
--- a/Data/Sys/GameSettings/D85.ini
+++ b/Data/Sys/GameSettings/D85.ini
@@ -1,7 +1,9 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# D85E01 - Interactive Multi Game Demo Disc v12
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FPRF = True
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,7 +13,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/D86.ini
+++ b/Data/Sys/GameSettings/D86.ini
@@ -1,7 +1,9 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# D86P01 - Interactive Multi Game Demo Disc v12
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FPRF = True
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,7 +13,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/D95.ini
+++ b/Data/Sys/GameSettings/D95.ini
@@ -1,7 +1,8 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# D95P01 - Interactive Multi Game Demo Disc v5
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FPRF = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,7 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/DAX.ini
+++ b/Data/Sys/GameSettings/DAX.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# DAXP01, DAXE01 - The Legend of Zelda Skyward Sword
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,5 +13,8 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False
+EFBAccessEnable = True
+EFBEmulateFormatChanges = True
+
+[Video_Enhancements]
+ArbitraryMipmapDetection = True

--- a/Data/Sys/GameSettings/G4P.ini
+++ b/Data/Sys/GameSettings/G4P.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# G4PJ13 - The Sims
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,6 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
 [Video_Hacks]
 EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/G95.ini
+++ b/Data/Sys/GameSettings/G95.ini
@@ -1,7 +1,8 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# D95P01, G95E01 - Interactive Multi Game Demo Disc v5
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FPRF = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,7 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/G99.ini
+++ b/Data/Sys/GameSettings/G99.ini
@@ -1,7 +1,8 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# G99E01, G99P01 - Interactive Multi Game Demo Disc v1
 
 [Core]
 # Values set here will override the main Dolphin settings.
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,7 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/GCI.ini
+++ b/Data/Sys/GameSettings/GCI.ini
@@ -1,7 +1,19 @@
 # GCIE69, GCIP69 - The Sims
+
 [Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
 [OnFrame]
+# Add memory patches to be applied every frame here.
+
 [ActionReplay]
-[Gecko]
+# Add action replay cheats here.
+
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GR6.ini
+++ b/Data/Sys/GameSettings/GR6.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# GR6P78, GR6E78, GR6D78, GR6F78 - Bratz: Rock Angelz
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,6 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
 [Video_Hacks]
 EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/GYA.ini
+++ b/Data/Sys/GameSettings/GYA.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# GYAP78, GYAD78, GYAE78, GYAX78 - Barnyard (GC)
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -14,4 +14,3 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/HC4.ini
+++ b/Data/Sys/GameSettings/HC4.ini
@@ -1,7 +1,8 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# HC4E9Z, HC4P9Z - Crunchyroll Channel
 
 [Core]
 # Values set here will override the main Dolphin settings.
+MMU = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -11,7 +12,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/R6B.ini
+++ b/Data/Sys/GameSettings/R6B.ini
@@ -17,4 +17,4 @@ ForceFiltering = False
 
 [Video_Hacks]
 EFBToTextureEnable = False
-
+DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RBK.ini
+++ b/Data/Sys/GameSettings/RBK.ini
@@ -14,13 +14,3 @@
 
 [Video_Settings]
 # Add any video settings here
-
-[Wiimote.Shake]
-Soft = 3.0
-Medium = 4.0
-Hard = 4.8
-
-[Wiimote.Swing]
-Slow = 3.5
-Medium = 4.8
-Fast = 6

--- a/Data/Sys/GameSettings/RBY.ini
+++ b/Data/Sys/GameSettings/RBY.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# RBYP78, RBYJ78, RBYE78 - Barnyard (Wii)
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -14,4 +14,3 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RMHJ08.ini
+++ b/Data/Sys/GameSettings/RMHJ08.ini
@@ -1,4 +1,4 @@
-# RMHJ08 - MONSTER HUNTER 3
+# RMHJ08 - Monster Hunter Tri
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -12,6 +12,3 @@ $Bloom OFF
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RNB.ini
+++ b/Data/Sys/GameSettings/RNB.ini
@@ -1,7 +1,8 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# RNBE69, RNBP69, RNBX69 - NBA Live 08
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -14,4 +15,3 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RPY.ini
+++ b/Data/Sys/GameSettings/RPY.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FPRF = True
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RST.ini
+++ b/Data/Sys/GameSettings/RST.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# RSTJ52, RSTP64, RSTE64 - Star Wars: The Force Unleashed
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,5 +13,4 @@
 # Add action replay cheats here.
 
 [Video_Hacks]
-EFBToTextureEnable = False
 DeferEFBCopies = False

--- a/Data/Sys/GameSettings/RTH.ini
+++ b/Data/Sys/GameSettings/RTH.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# RTHP52, RTHE52 - Tony Hawk's Downhill Jam
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,6 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
 [Video_Hacks]
-EFBToTextureEnable = False
-DeferEFBCopies = False
+EFBAccessEnable = False

--- a/Data/Sys/GameSettings/RW7.ini
+++ b/Data/Sys/GameSettings/RW7.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# RW7E41 - Shaun White Snowboarding: Road Trip - Target Limited Edition
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/RYB.ini
+++ b/Data/Sys/GameSettings/RYB.ini
@@ -15,13 +15,3 @@ SyncGPU = True
 
 [Video_Settings]
 # Add any video settings here
-
-[Wiimote.Shake]
-Soft = 3.0
-Medium = 4.0
-Hard = 4.8
-
-[Wiimote.Swing]
-Slow = 3.5
-Medium = 4.8
-Fast = 6

--- a/Data/Sys/GameSettings/SEC.ini
+++ b/Data/Sys/GameSettings/SEC.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# SECP69, SECE69 - Create
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,6 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
 [Video_Hacks]
 EFBToTextureEnable = False
-DeferEFBCopies = False

--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -12,9 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-
 [Video_Hacks]
 
 [Video_Stereoscopy]

--- a/Data/Sys/GameSettings/SOM.ini
+++ b/Data/Sys/GameSettings/SOM.ini
@@ -12,11 +12,6 @@
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
-[Video_Settings]
-
 [Video_Hacks]
 ImmediateXFBEnable = False
-
-[Video_Enhancements]
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SVM.ini
+++ b/Data/Sys/GameSettings/SVM.ini
@@ -1,4 +1,4 @@
-# SVME01, SVMJ01, SVMP01 - super mario collection
+# SVME01, SVMJ01, SVMP01 - Super Mario All-Stars: 25th Anniversary Edition
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -12,6 +12,8 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+
 [Video_Hacks]
 EFBToTextureEnable = False
-

--- a/Data/Sys/GameSettings/WL9.ini
+++ b/Data/Sys/GameSettings/WL9.ini
@@ -1,4 +1,4 @@
-# RDFE41, RDFP41 - Shaun White Snowboarding: Road Trip
+# WL9EYD - Let's Create! Pottery
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -14,4 +14,3 @@
 
 [Video_Hacks]
 EFBToTextureEnable = False
-DeferEFBCopies = False


### PR DESCRIPTION
Based on #8164 

-Adds a few games.
-Enables MMU for Crunchyroll Channel so it can boot and for Interactive Multi Game Demo Disc with demo's which require MMU.
-Enables FPRF for games that need it.
-Disables defered EFB for games that crashed or showed weird behaviour with defered EFB enabled.
-Sets TextureCacheAccuracy to safe for a few games that need it.
-Sets EFB to texture and ram for a few games that need it.
-Removes Wiimote.Shake and Wiimote.Swing as those are no longer functional.

I also removed TextureCacheAccuracy = Safe from NSMBW because accuracy on fast shows no issues. I think this was fixed with Partial Texture Updates.