### PR TITLE
ControllerInterface: Combine evdev devices with the same physical location in addition to unique ID

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -82,6 +82,7 @@ public:
   bool AddNode(std::string devnode, int fd, libevdev* dev);
 
   const char* GetUniqueID() const;
+  const char* GetPhysicalLocation() const;
 
   std::string GetName() const override { return m_name; }
   std::string GetSource() const override { return "evdev"; }


### PR DESCRIPTION
Some off-brand devices always report the same unique ID, resulting in them being wrongly combined. The physical location for these devices should always be different, making that a better comparison. I'm currently unsure whether the DS4's devices (the original target of the combining behavior in #8473) all have the same physical location, but theoretically they should.