### PR TITLE
Replace usage of std::result_of with std::invoke_result

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/RunOnObject.h
+++ b/Source/Core/DolphinQt/QtUtils/RunOnObject.h
@@ -26,7 +26,7 @@ class QObject;
 template <typename F>
 auto RunOnObject(QObject* object, F&& functor)
 {
-  using OptionalResultT = std::optional<std::result_of_t<F()>>;
+  using OptionalResultT = std::optional<std::invoke_result_t<F>>;
 
   // If we queue up a functor on the current thread, it won't run until we return to the event loop,
   // which means waiting for it to finish will never complete. Instead, run it immediately.


### PR DESCRIPTION
`std::result_of` is deprecated in C++17, and removed in C++20. Microsoft has gone ahead with the removal as of Visual Studio 16.6.0, so before this change our code is broken there.

Externals/Qt also needs to be updated to the latest version to fully fix the build.