### PR TITLE
Android: Display disc number instead of company if mulipart disc

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -1,5 +1,6 @@
 package org.dolphinemu.dolphinemu.adapters;
 
+import android.content.Context;
 import android.graphics.Rect;
 
 import androidx.annotation.NonNull;
@@ -15,6 +16,7 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.dialogs.GamePropertiesDialog;
 import org.dolphinemu.dolphinemu.model.GameFile;
+import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.utils.PicassoUtils;
 import org.dolphinemu.dolphinemu.viewholders.GameViewHolder;
 
@@ -68,11 +70,21 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
   @Override
   public void onBindViewHolder(GameViewHolder holder, int position)
   {
+    Context context = holder.itemView.getContext();
     GameFile gameFile = mGameFiles.get(position);
     PicassoUtils.loadGameCover(holder.imageScreenshot, gameFile);
 
     holder.textGameTitle.setText(gameFile.getTitle());
-    holder.textCompany.setText(gameFile.getCompany());
+
+    if (GameFileCacheService.findSecondDisc(gameFile) != null)
+    {
+      holder.textGameCaption
+              .setText(context.getString(R.string.disc_number, gameFile.getDiscNumber() + 1));
+    }
+    else
+    {
+      holder.textGameCaption.setText(gameFile.getCompany());
+    }
 
     holder.gameFile = gameFile;
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -15,6 +15,7 @@ import android.widget.ImageView;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.dialogs.GamePropertiesDialog;
 import org.dolphinemu.dolphinemu.model.GameFile;
+import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
 import org.dolphinemu.dolphinemu.utils.PicassoUtils;
 import org.dolphinemu.dolphinemu.viewholders.TvGameViewHolder;
@@ -46,13 +47,24 @@ public final class GameRowPresenter extends Presenter
   public void onBindViewHolder(ViewHolder viewHolder, Object item)
   {
     TvGameViewHolder holder = (TvGameViewHolder) viewHolder;
+    Context context = holder.cardParent.getContext();
     GameFile gameFile = (GameFile) item;
 
     holder.imageScreenshot.setImageDrawable(null);
     PicassoUtils.loadGameCover(holder.imageScreenshot, gameFile);
 
     holder.cardParent.setTitleText(gameFile.getTitle());
-    holder.cardParent.setContentText(gameFile.getCompany());
+
+    if (GameFileCacheService.findSecondDisc(gameFile) != null)
+    {
+      holder.cardParent
+              .setContentText(
+                      context.getString(R.string.disc_number, gameFile.getDiscNumber() + 1));
+    }
+    else
+    {
+      holder.cardParent.setContentText(gameFile.getCompany());
+    }
 
     holder.gameFile = gameFile;
 
@@ -72,7 +84,6 @@ public final class GameRowPresenter extends Presenter
       default:
         throw new AssertionError("Not reachable.");
     }
-    Context context = holder.cardParent.getContext();
     Drawable background = ContextCompat.getDrawable(context, backgroundId);
     holder.cardParent.setInfoAreaBackground(background);
     holder.cardParent.setOnLongClickListener((view) ->

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/GameViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/GameViewHolder.java
@@ -17,7 +17,7 @@ public class GameViewHolder extends RecyclerView.ViewHolder
 {
   public ImageView imageScreenshot;
   public TextView textGameTitle;
-  public TextView textCompany;
+  public TextView textGameCaption;
 
   public GameFile gameFile;
 
@@ -29,6 +29,6 @@ public class GameViewHolder extends RecyclerView.ViewHolder
 
     imageScreenshot = itemView.findViewById(R.id.image_game_screen);
     textGameTitle = itemView.findViewById(R.id.text_game_title);
-    textCompany = itemView.findViewById(R.id.text_company);
+    textGameCaption = itemView.findViewById(R.id.text_game_caption);
   }
 }

--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -36,7 +36,7 @@
             tools:text="The Legend of Zelda: The Wind Waker"/>
 
         <TextView
-            android:id="@+id/text_company"
+            android:id="@+id/text_game_caption"
             style="@android:style/TextAppearance.Material.Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -375,5 +375,6 @@
     <string name="pitch">Total Pitch</string>
     <string name="yaw">Total Yaw</string>
     <string name="vertical_offset">Vertical Offset</string>
+    <string name="disc_number">Disc %1$d</string>
 
 </resources>


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/11413.

The company can be found in Game Details too so I'd rather use that space to display disc number for multipart discs. See Tales of Symphonia's cards in the image below.

![Screenshot_20200604-013735_Dolphin Emulator](https://user-images.githubusercontent.com/17330088/83722551-2f802600-a60b-11ea-908e-e6fd7b65e510.jpg)