### PR TITLE
Fix Windows CMake builds with shared zlib

### DIFF
--- a/Externals/libpng/CMakeLists.txt
+++ b/Externals/libpng/CMakeLists.txt
@@ -23,7 +23,7 @@ PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(png PUBLIC z)
+target_link_libraries(png PUBLIC ZLIB::ZLIB)
 
 if(NOT MSVC)
   target_compile_options(png

--- a/Externals/minizip/CMakeLists.txt
+++ b/Externals/minizip/CMakeLists.txt
@@ -13,6 +13,6 @@ endif()
 add_library(minizip STATIC ${SRCS})
 target_include_directories(minizip PUBLIC .)
 
-target_link_libraries(minizip PUBLIC z)
+target_link_libraries(minizip PUBLIC ZLIB::ZLIB)
 
 add_library(MiniZip::minizip ALIAS minizip)

--- a/Source/Core/UpdaterCommon/CMakeLists.txt
+++ b/Source/Core/UpdaterCommon/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(updatercommon
 target_link_libraries(updatercommon PRIVATE
   uicommon
   mbedtls
-  z
+  ZLIB::ZLIB
   ed25519
   cpp-optparse
 )


### PR DESCRIPTION
On Linux, if shared zlib is present, zlib.h is always available and -lz
links to zlib, even if you don't run find_package(ZLIB).

For some reason I have zlib installed on Windows (possibly from vcpkg),
so find_package(ZLIB) succeeds and ZLIB_FOUND is true.
When Dolphin uses shared zlib on Windows, the problem is that zlib.h
is not in the default include path, and the CMake target is called
ZLIB::ZLIB and there's neither a target nor a library called z.

However, both find_package(ZLIB) and add_subdirectory(Externals/zlib)
create a target called ZLIB::ZLIB, so I'll switch to that instead.
Hopefully this change doesn't break anyone's build.