### PR TITLE
Qt/GameListModel: Use absolutePath for file path column

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -146,7 +146,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
       QString file_path = QDir::toNativeSeparators(
-          QFileInfo(QString::fromStdString(game.GetFilePath())).canonicalPath());
+          QFileInfo(QString::fromStdString(game.GetFilePath())).absolutePath());
       if (!file_path.endsWith(QDir::separator()))
         file_path.append(QDir::separator());
       return file_path;


### PR DESCRIPTION
canonicalPath is orders of magnitude slower as it has to perform actual disk I/O to resolve symlinks, which makes sorting by this column ridiculously slow for large game lists, especially if the games are on a NAS. We probably don't need that, simply resolving relative paths should be sufficient.

This should fix https://bugs.dolphin-emu.org/issues/12135