### PR TITLE
Fix build

### DIFF
--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -28,7 +28,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       return true;
   }
 
-  static constexpr std::array<const Config::Location*, 103> s_setting_saveable = {
+  static constexpr std::array<const Config::Location*, 104> s_setting_saveable = {
       // Main.Core
 
       &Config::MAIN_DEFAULT_ISO.location,


### PR DESCRIPTION
There was a race condition between two PRs incrementing the array size. CI didn't catch it because the PR that was merged last (PR #8824) wasn't rebuilt after the first PR was merged.