### PR TITLE
Config/IsSettingSaveable: Use class template argument deduction

### DIFF
--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -28,7 +28,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       return true;
   }
 
-  static constexpr std::array<const Config::Location*, 104> s_setting_saveable = {
+  static constexpr std::array s_setting_saveable = {
       // Main.Core
 
       &Config::MAIN_DEFAULT_ISO.location,


### PR DESCRIPTION
This eliminates the stupid array size that has to be manually updated and occasionally causes broken builds with PR race conditions.

libc++ currently seems to be missing several deduction guides so we cannot merge this for now.