### PR TITLE
VSProps: Don't use /std:c++latest

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -80,7 +80,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <!--Enable latest C++ standard-->
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
       <!--Enforce some behaviors as standards-conformant when they don't default as such.-->


### PR DESCRIPTION
Using /std:c++latest can cause problems for people in the future who want to build old versions of Dolphin on new versions of Visual Studio (for bisecting and such). Let's set /std:c++17 instead, which is consistent with what we're doing in CMake.

This should also fix https://bugs.dolphin-emu.org/issues/12086 (untested), but it isn't a long-term fix, since it'll break again once we switch over to using C++20.