### PR TITLE
Android: Add Pause / Unpause Emulation Toggle

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -70,6 +70,9 @@ public final class EmulationActivity extends AppCompatActivity
 
   private Settings mSettings;
 
+  private MenuItem mPauseEmulationButton;
+  private MenuItem mUnpauseEmulationButton;
+
   private boolean mDeviceHasTouchScreen;
   private boolean mMenuVisible;
 
@@ -81,12 +84,14 @@ public final class EmulationActivity extends AppCompatActivity
   private String mSelectedGameId;
   private int mPlatform;
   private String[] mPaths;
+  private static boolean sUserPausedEmulation;
   private boolean backPressedOnce = false;
 
   public static final String EXTRA_SELECTED_GAMES = "SelectedGames";
   public static final String EXTRA_SELECTED_TITLE = "SelectedTitle";
   public static final String EXTRA_SELECTED_GAMEID = "SelectedGameId";
   public static final String EXTRA_PLATFORM = "Platform";
+  public static final String EXTRA_USER_PAUSED_EMULATION = "sUserPausedEmulation";
 
   @Retention(SOURCE)
   @IntDef({MENU_ACTION_EDIT_CONTROLS_PLACEMENT, MENU_ACTION_TOGGLE_CONTROLS, MENU_ACTION_ADJUST_SCALE,
@@ -98,7 +103,8 @@ public final class EmulationActivity extends AppCompatActivity
           MENU_ACTION_LOAD_SLOT3, MENU_ACTION_LOAD_SLOT4, MENU_ACTION_LOAD_SLOT5,
           MENU_ACTION_LOAD_SLOT6, MENU_ACTION_EXIT, MENU_ACTION_CHANGE_DISC,
           MENU_ACTION_RESET_OVERLAY, MENU_SET_IR_SENSITIVITY, MENU_ACTION_CHOOSE_DOUBLETAP,
-          MENU_ACTION_SCREEN_ORIENTATION, MENU_ACTION_MOTION_CONTROLS})
+          MENU_ACTION_SCREEN_ORIENTATION, MENU_ACTION_MOTION_CONTROLS, MENU_ACTION_PAUSE_EMULATION,
+          MENU_ACTION_UNPAUSE_EMULATION})
   public @interface MenuAction
   {
   }
@@ -134,6 +140,8 @@ public final class EmulationActivity extends AppCompatActivity
   public static final int MENU_ACTION_CHOOSE_DOUBLETAP = 28;
   public static final int MENU_ACTION_SCREEN_ORIENTATION = 29;
   public static final int MENU_ACTION_MOTION_CONTROLS = 30;
+  public static final int MENU_ACTION_PAUSE_EMULATION = 31;
+  public static final int MENU_ACTION_UNPAUSE_EMULATION = 32;
 
 
   private static SparseIntArray buttonsActionsMap = new SparseIntArray();
@@ -150,6 +158,10 @@ public final class EmulationActivity extends AppCompatActivity
             EmulationActivity.MENU_ACTION_CHOOSE_CONTROLLER);
     buttonsActionsMap
             .append(R.id.menu_refresh_wiimotes, EmulationActivity.MENU_ACTION_REFRESH_WIIMOTES);
+    buttonsActionsMap
+            .append(R.id.menu_emulation_pause, EmulationActivity.MENU_ACTION_PAUSE_EMULATION);
+    buttonsActionsMap
+            .append(R.id.menu_emulation_unpause, EmulationActivity.MENU_ACTION_UNPAUSE_EMULATION);
     buttonsActionsMap
             .append(R.id.menu_emulation_screenshot, EmulationActivity.MENU_ACTION_TAKE_SCREENSHOT);
 
@@ -274,6 +286,7 @@ public final class EmulationActivity extends AppCompatActivity
       mSelectedTitle = gameToEmulate.getStringExtra(EXTRA_SELECTED_TITLE);
       mSelectedGameId = gameToEmulate.getStringExtra(EXTRA_SELECTED_GAMEID);
       mPlatform = gameToEmulate.getIntExtra(EXTRA_PLATFORM, 0);
+      sUserPausedEmulation = gameToEmulate.getBooleanExtra(EXTRA_USER_PAUSED_EMULATION, false);
       activityRecreated = false;
     }
     else
@@ -356,6 +369,7 @@ public final class EmulationActivity extends AppCompatActivity
     outState.putString(EXTRA_SELECTED_TITLE, mSelectedTitle);
     outState.putString(EXTRA_SELECTED_GAMEID, mSelectedGameId);
     outState.putInt(EXTRA_PLATFORM, mPlatform);
+    outState.putBoolean(EXTRA_USER_PAUSED_EMULATION, sUserPausedEmulation);
     super.onSaveInstanceState(outState);
   }
 
@@ -365,6 +379,7 @@ public final class EmulationActivity extends AppCompatActivity
     mSelectedTitle = savedInstanceState.getString(EXTRA_SELECTED_TITLE);
     mSelectedGameId = savedInstanceState.getString(EXTRA_SELECTED_GAMEID);
     mPlatform = savedInstanceState.getInt(EXTRA_PLATFORM);
+    sUserPausedEmulation = savedInstanceState.getBoolean(EXTRA_USER_PAUSED_EMULATION);
   }
 
   @Override
@@ -490,6 +505,14 @@ public final class EmulationActivity extends AppCompatActivity
       getMenuInflater().inflate(R.menu.menu_emulation_wii, menu);
     }
 
+    mPauseEmulationButton = menu.findItem(R.id.menu_emulation_pause);
+    mUnpauseEmulationButton = menu.findItem(R.id.menu_emulation_unpause);
+
+    if (sUserPausedEmulation)
+    {
+      showUnpauseEmulationButton();
+    }
+
     BooleanSetting enableSaveStates =
             (BooleanSetting) mSettings.getSection(Settings.SECTION_INI_CORE)
                     .getSetting(SettingsFile.KEY_ENABLE_SAVE_STATES);
@@ -576,6 +599,18 @@ public final class EmulationActivity extends AppCompatActivity
 
       case MENU_ACTION_REFRESH_WIIMOTES:
         NativeLibrary.RefreshWiimotes();
+        return;
+
+      case MENU_ACTION_PAUSE_EMULATION:
+        sUserPausedEmulation = true;
+        NativeLibrary.PauseEmulation();
+        showUnpauseEmulationButton();
+        return;
+
+      case MENU_ACTION_UNPAUSE_EMULATION:
+        sUserPausedEmulation = false;
+        NativeLibrary.UnPauseEmulation();
+        showPauseEmulationButton();
         return;
 
       // Screenshot capturing
@@ -686,6 +721,28 @@ public final class EmulationActivity extends AppCompatActivity
         finish();
         return;
     }
+  }
+
+  private void showPauseEmulationButton()
+  {
+    mUnpauseEmulationButton.setVisible(false);
+    mPauseEmulationButton.setVisible(true);
+  }
+
+  private void showUnpauseEmulationButton()
+  {
+    mPauseEmulationButton.setVisible(false);
+    mUnpauseEmulationButton.setVisible(true);
+  }
+
+  public static boolean getHasUserPausedEmulation()
+  {
+    return sUserPausedEmulation;
+  }
+
+  public static void setHasUserPausedEmulation(boolean value)
+  {
+    sUserPausedEmulation = value;
   }
 
   private void toggleJoystickRelCenter(boolean state)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -417,9 +417,12 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
       }
       else if (state == State.PAUSED)
       {
-        Log.debug("[EmulationFragment] Resuming emulation.");
         NativeLibrary.SurfaceChanged(mSurface);
-        NativeLibrary.UnPauseEmulation();
+        if (!EmulationActivity.getHasUserPausedEmulation())
+        {
+          Log.debug("[EmulationFragment] Resuming emulation.");
+          NativeLibrary.UnPauseEmulation();
+        }
       }
       else
       {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -13,6 +13,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
@@ -21,11 +22,17 @@ import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
 public final class MenuFragment extends Fragment implements View.OnClickListener
 {
+  private View mPauseEmulation;
+  private View mUnpauseEmulation;
   private static final String KEY_TITLE = "title";
   private static SparseIntArray buttonsActionsMap = new SparseIntArray();
 
   static
   {
+    buttonsActionsMap
+            .append(R.id.menu_pause_emulation, EmulationActivity.MENU_ACTION_PAUSE_EMULATION);
+    buttonsActionsMap
+            .append(R.id.menu_unpause_emulation, EmulationActivity.MENU_ACTION_UNPAUSE_EMULATION);
     buttonsActionsMap
             .append(R.id.menu_take_screenshot, EmulationActivity.MENU_ACTION_TAKE_SCREENSHOT);
     buttonsActionsMap.append(R.id.menu_quicksave, EmulationActivity.MENU_ACTION_QUICK_SAVE);
@@ -59,6 +66,14 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 
     LinearLayout options = (LinearLayout) rootView.findViewById(R.id.layout_options);
 
+    mPauseEmulation = options.findViewById(R.id.menu_pause_emulation);
+    mUnpauseEmulation = options.findViewById(R.id.menu_unpause_emulation);
+
+    if (EmulationActivity.getHasUserPausedEmulation())
+    {
+      showUnpauseEmulationButton();
+    }
+
     BooleanSetting enableSaveStates =
             (BooleanSetting) ((EmulationActivity) getActivity()).getSettings()
                     .getSection(Settings.SECTION_INI_CORE)
@@ -89,12 +104,36 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
     return rootView;
   }
 
+  private void showPauseEmulationButton()
+  {
+    mUnpauseEmulation.setVisibility(View.GONE);
+    mPauseEmulation.setVisibility(View.VISIBLE);
+  }
+
+  private void showUnpauseEmulationButton()
+  {
+    mPauseEmulation.setVisibility(View.GONE);
+    mUnpauseEmulation.setVisibility(View.VISIBLE);
+  }
+
   @SuppressWarnings("WrongConstant")
   @Override
   public void onClick(View button)
   {
     int action = buttonsActionsMap.get(button.getId());
-    if (action >= 0)
+    if (action == EmulationActivity.MENU_ACTION_PAUSE_EMULATION)
+    {
+      EmulationActivity.setHasUserPausedEmulation(true);
+      NativeLibrary.PauseEmulation();
+      showUnpauseEmulationButton();
+    }
+    else if (action == EmulationActivity.MENU_ACTION_UNPAUSE_EMULATION)
+    {
+      EmulationActivity.setHasUserPausedEmulation(false);
+      NativeLibrary.UnPauseEmulation();
+      showPauseEmulationButton();
+    }
+    else if (action >= 0)
     {
       ((EmulationActivity) getActivity()).handleMenuAction(action);
     }

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -28,6 +28,17 @@
             android:orientation="vertical">
 
             <Button
+                android:id="@+id/menu_pause_emulation"
+                android:text="@string/pause_emulation"
+                style="@style/InGameMenuOption"/>
+
+            <Button
+                android:id="@+id/menu_unpause_emulation"
+                android:text="@string/unpause_emulation"
+                style="@style/InGameMenuOption"
+                android:visibility="gone"/>
+
+            <Button
                 android:id="@+id/menu_take_screenshot"
                 android:text="@string/emulation_screenshot"
                 style="@style/InGameMenuOption"/>

--- a/Source/Android/app/src/main/res/menu/menu_emulation.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation.xml
@@ -4,6 +4,19 @@
       tools:context="org.dolphinemu.dolphinemu.activities.EmulationActivity">
 
     <item
+        android:id="@+id/menu_emulation_pause"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/lb_ic_pause"
+        android:title="@string/pause_emulation"/>
+
+    <item
+        android:id="@+id/menu_emulation_unpause"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/lb_ic_play"
+        android:title="@string/unpause_emulation"
+        android:visible="false"/>
+
+    <item
         android:id="@+id/menu_emulation_screenshot"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_screenshot"

--- a/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
@@ -4,6 +4,19 @@
       tools:context="org.dolphinemu.dolphinemu.activities.EmulationActivity">
 
     <item
+        android:id="@+id/menu_emulation_pause"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/lb_ic_pause"
+        android:title="@string/pause_emulation"/>
+
+    <item
+        android:id="@+id/menu_emulation_unpause"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/lb_ic_play"
+        android:title="@string/unpause_emulation"
+        android:visible="false"/>
+
+    <item
         android:id="@+id/menu_emulation_screenshot"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_screenshot"

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -324,6 +324,8 @@
     <string name="game_details_no_compression">No Compression</string>
 
     <!-- Emulation Menu -->
+    <string name="pause_emulation">Pause Emulation</string>
+    <string name="unpause_emulation">Unpause Emulation</string>
     <string name="emulation_screenshot">Take Screenshot</string>
     <string name="emulation_savestate">Save State</string>
     <string name="emulation_loadstate">Load State</string>


### PR DESCRIPTION
Implements https://bugs.dolphin-emu.org/issues/10602 and should survive orientation changes.

- [x] Confirm `fragment_ingame_menu.xml` changes for Android TV work.

![Screenshot_20200608-120650_Dolphin Emulator](https://user-images.githubusercontent.com/17330088/84087674-a117f580-a9b8-11ea-828a-21c1f57793ba.jpg)