### PR TITLE
GCMemcard: Rename types to be more specific.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCIFile.cpp
@@ -88,7 +88,7 @@ int GCIFile::UsesBlock(u16 block_num)
 
 void GCIFile::DoState(PointerWrap& p)
 {
-  p.DoPOD<DEntry>(m_gci_header);
+  p.DoPOD<GCMemcardDirEntry>(m_gci_header);
   p.Do(m_dirty);
   p.Do(m_filename);
   int num_blocks = (int)m_save_data.size();

--- a/Source/Core/Core/HW/GCMemcard/GCIFile.h
+++ b/Source/Core/Core/HW/GCMemcard/GCIFile.h
@@ -21,7 +21,7 @@ public:
   void DoState(PointerWrap& p);
   int UsesBlock(u16 blocknum);
 
-  DEntry m_gci_header;
+  GCMemcardDirEntry m_gci_header;
   std::vector<GCMBlock> m_save_data;
   std::vector<u16> m_used_blocks;
   bool m_dirty;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -367,8 +367,11 @@ u8 GCMemcard::GetNumFiles() const
   u8 j = 0;
   for (int i = 0; i < DIRLEN; i++)
   {
-    if (GetActiveDirectory().m_dir_entries[i].m_gamecode != DEntry::UNINITIALIZED_GAMECODE)
+    if (GetActiveDirectory().m_dir_entries[i].m_gamecode !=
+        GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
+    {
       j++;
+    }
   }
   return j;
 }
@@ -380,7 +383,8 @@ u8 GCMemcard::GetFileIndex(u8 fileNumber) const
     u8 j = 0;
     for (u8 i = 0; i < DIRLEN; i++)
     {
-      if (GetActiveDirectory().m_dir_entries[i].m_gamecode != DEntry::UNINITIALIZED_GAMECODE)
+      if (GetActiveDirectory().m_dir_entries[i].m_gamecode !=
+          GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
       {
         if (j == fileNumber)
         {
@@ -401,7 +405,7 @@ u16 GCMemcard::GetFreeBlocks() const
   return GetActiveBat().m_free_blocks;
 }
 
-u8 GCMemcard::TitlePresent(const DEntry& d) const
+u8 GCMemcard::TitlePresent(const GCMemcardDirEntry& d) const
 {
   if (!m_valid)
     return DIRLEN;
@@ -422,17 +426,17 @@ u8 GCMemcard::TitlePresent(const DEntry& d) const
 bool GCMemcard::GCI_FileName(u8 index, std::string& filename) const
 {
   if (!m_valid || index >= DIRLEN ||
-      GetActiveDirectory().m_dir_entries[index].m_gamecode == DEntry::UNINITIALIZED_GAMECODE)
+      GetActiveDirectory().m_dir_entries[index].m_gamecode ==
+          GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
+  {
     return false;
+  }
 
   filename = GetActiveDirectory().m_dir_entries[index].GCI_FileName();
   return true;
 }
 
-// DEntry functions, all take u8 index < DIRLEN (127)
-// Functions that have ascii output take a char *buffer
-
-std::string GCMemcard::DEntry_GameCode(u8 index) const
+std::string GCMemcard::DirEntry_GameCode(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return "";
@@ -442,7 +446,7 @@ std::string GCMemcard::DEntry_GameCode(u8 index) const
       GetActiveDirectory().m_dir_entries[index].m_gamecode.size());
 }
 
-std::string GCMemcard::DEntry_Makercode(u8 index) const
+std::string GCMemcard::DirEntry_Makercode(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return "";
@@ -452,7 +456,7 @@ std::string GCMemcard::DEntry_Makercode(u8 index) const
       GetActiveDirectory().m_dir_entries[index].m_makercode.size());
 }
 
-std::string GCMemcard::DEntry_BIFlags(u8 index) const
+std::string GCMemcard::DirEntry_BIFlags(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return "";
@@ -467,7 +471,7 @@ std::string GCMemcard::DEntry_BIFlags(u8 index) const
   return flags;
 }
 
-bool GCMemcard::DEntry_IsPingPong(u8 index) const
+bool GCMemcard::DirEntry_IsPingPong(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return false;
@@ -476,7 +480,7 @@ bool GCMemcard::DEntry_IsPingPong(u8 index) const
   return (flags & 0b0000'0100) != 0;
 }
 
-std::string GCMemcard::DEntry_FileName(u8 index) const
+std::string GCMemcard::DirEntry_FileName(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return "";
@@ -486,7 +490,7 @@ std::string GCMemcard::DEntry_FileName(u8 index) const
       GetActiveDirectory().m_dir_entries[index].m_filename.size());
 }
 
-u32 GCMemcard::DEntry_ModTime(u8 index) const
+u32 GCMemcard::DirEntry_ModTime(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return 0xFFFFFFFF;
@@ -494,7 +498,7 @@ u32 GCMemcard::DEntry_ModTime(u8 index) const
   return GetActiveDirectory().m_dir_entries[index].m_modification_time;
 }
 
-u32 GCMemcard::DEntry_ImageOffset(u8 index) const
+u32 GCMemcard::DirEntry_ImageOffset(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return 0xFFFFFFFF;
@@ -502,7 +506,7 @@ u32 GCMemcard::DEntry_ImageOffset(u8 index) const
   return GetActiveDirectory().m_dir_entries[index].m_image_offset;
 }
 
-std::string GCMemcard::DEntry_IconFmt(u8 index) const
+std::string GCMemcard::DirEntry_IconFmt(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return "";
@@ -516,7 +520,7 @@ std::string GCMemcard::DEntry_IconFmt(u8 index) const
   return format;
 }
 
-std::string GCMemcard::DEntry_AnimSpeed(u8 index) const
+std::string GCMemcard::DirEntry_AnimSpeed(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return "";
@@ -530,7 +534,7 @@ std::string GCMemcard::DEntry_AnimSpeed(u8 index) const
   return speed;
 }
 
-std::string GCMemcard::DEntry_Permissions(u8 index) const
+std::string GCMemcard::DirEntry_Permissions(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return "";
@@ -543,7 +547,7 @@ std::string GCMemcard::DEntry_Permissions(u8 index) const
   return permissionsString;
 }
 
-u8 GCMemcard::DEntry_CopyCounter(u8 index) const
+u8 GCMemcard::DirEntry_CopyCounter(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return 0xFF;
@@ -551,7 +555,7 @@ u8 GCMemcard::DEntry_CopyCounter(u8 index) const
   return GetActiveDirectory().m_dir_entries[index].m_copy_counter;
 }
 
-u16 GCMemcard::DEntry_FirstBlock(u8 index) const
+u16 GCMemcard::DirEntry_FirstBlock(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return 0xFFFF;
@@ -562,7 +566,7 @@ u16 GCMemcard::DEntry_FirstBlock(u8 index) const
   return block;
 }
 
-u16 GCMemcard::DEntry_BlockCount(u8 index) const
+u16 GCMemcard::DirEntry_BlockCount(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return 0xFFFF;
@@ -579,7 +583,7 @@ std::optional<std::vector<u8>> GCMemcard::GetSaveDataBytes(u8 save_index, size_t
   if (!m_valid || save_index >= DIRLEN)
     return std::nullopt;
 
-  const DEntry& entry = GetActiveDirectory().m_dir_entries[save_index];
+  const GCMemcardDirEntry& entry = GetActiveDirectory().m_dir_entries[save_index];
   const BlockAlloc& bat = GetActiveBat();
   const u16 block_count = entry.m_block_count;
   const u16 first_block = entry.m_first_block;
@@ -662,7 +666,7 @@ std::optional<std::pair<std::string, std::string>> GCMemcard::GetSaveComments(u8
                         strip_null(string_decoder(encoded_2)));
 }
 
-std::optional<DEntry> GCMemcard::GetDEntry(u8 index) const
+std::optional<GCMemcardDirEntry> GCMemcard::GetDirEntry(u8 index) const
 {
   if (!m_valid || index >= DIRLEN)
     return std::nullopt;
@@ -815,8 +819,8 @@ GCMemcardGetSaveDataRetVal GCMemcard::GetSaveData(u8 index, std::vector<GCMBlock
   if (!m_valid)
     return GCMemcardGetSaveDataRetVal::NOMEMCARD;
 
-  const u16 block = DEntry_FirstBlock(index);
-  const u16 BlockCount = DEntry_BlockCount(index);
+  const u16 block = DirEntry_FirstBlock(index);
+  const u16 BlockCount = DirEntry_BlockCount(index);
 
   if ((block == 0xFFFF) || (BlockCount == 0xFFFF))
   {
@@ -833,9 +837,8 @@ GCMemcardGetSaveDataRetVal GCMemcard::GetSaveData(u8 index, std::vector<GCMBlock
   }
   return GCMemcardGetSaveDataRetVal::SUCCESS;
 }
-// End DEntry functions
 
-GCMemcardImportFileRetVal GCMemcard::ImportFile(const DEntry& direntry,
+GCMemcardImportFileRetVal GCMemcard::ImportFile(const GCMemcardDirEntry& direntry,
                                                 std::vector<GCMBlock>& saveBlocks)
 {
   if (!m_valid)
@@ -864,7 +867,7 @@ GCMemcardImportFileRetVal GCMemcard::ImportFile(const DEntry& direntry,
   // find first free dir entry
   for (int i = 0; i < DIRLEN; i++)
   {
-    if (UpdatedDir.m_dir_entries[i].m_gamecode == DEntry::UNINITIALIZED_GAMECODE)
+    if (UpdatedDir.m_dir_entries[i].m_gamecode == GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
     {
       UpdatedDir.m_dir_entries[i] = direntry;
       UpdatedDir.m_dir_entries[i].m_first_block = firstBlock;
@@ -942,11 +945,11 @@ GCMemcardImportFileRetVal GCMemcard::CopyFrom(const GCMemcard& source, u8 index)
   if (!m_valid || !source.m_valid)
     return GCMemcardImportFileRetVal::NOMEMCARD;
 
-  std::optional<DEntry> tempDEntry = source.GetDEntry(index);
+  std::optional<GCMemcardDirEntry> tempDEntry = source.GetDirEntry(index);
   if (!tempDEntry)
     return GCMemcardImportFileRetVal::NOMEMCARD;
 
-  u32 size = source.DEntry_BlockCount(index);
+  u32 size = source.DirEntry_BlockCount(index);
   if (size == 0xFFFF)
     return GCMemcardImportFileRetVal::INVALIDFILESIZE;
 
@@ -1008,7 +1011,7 @@ GCMemcardImportFileRetVal GCMemcard::ImportGciInternal(File::IOFile&& gci,
   }
   gci.Seek(offset, SEEK_SET);
 
-  DEntry tempDEntry;
+  GCMemcardDirEntry tempDEntry;
   gci.ReadBytes(&tempDEntry, DENTRY_SIZE);
   const u64 fStart = gci.Tell();
   gci.Seek(0, SEEK_END);
@@ -1086,14 +1089,14 @@ GCMemcardExportFileRetVal GCMemcard::ExportGci(u8 index, const std::string& file
     break;
   }
 
-  std::optional<DEntry> tempDEntry = GetDEntry(index);
+  std::optional<GCMemcardDirEntry> tempDEntry = GetDirEntry(index);
   if (!tempDEntry)
     return GCMemcardExportFileRetVal::NOMEMCARD;
 
   Gcs_SavConvert(*tempDEntry, offset);
   gci.WriteBytes(&tempDEntry.value(), DENTRY_SIZE);
 
-  u32 size = DEntry_BlockCount(index);
+  u32 size = DirEntry_BlockCount(index);
   if (size == 0xFFFF)
   {
     return GCMemcardExportFileRetVal::FAIL;
@@ -1123,7 +1126,7 @@ GCMemcardExportFileRetVal GCMemcard::ExportGci(u8 index, const std::string& file
     return GCMemcardExportFileRetVal::WRITEFAIL;
 }
 
-void GCMemcard::Gcs_SavConvert(DEntry& tempDEntry, int saveType, u64 length)
+void GCMemcard::Gcs_SavConvert(GCMemcardDirEntry& tempDEntry, int saveType, u64 length)
 {
   switch (saveType)
   {
@@ -1411,7 +1414,8 @@ bool GCMemcard::Format(bool shift_jis, u16 SizeMb)
 /*************************************************************/
 
 s32 GCMemcard::FZEROGX_MakeSaveGameValid(const GCMemcardHeaderBlock& cardheader,
-                                         const DEntry& direntry, std::vector<GCMBlock>& FileBuffer)
+                                         const GCMemcardDirEntry& direntry,
+                                         std::vector<GCMBlock>& FileBuffer)
 {
   u32 i, j;
   u16 chksum = 0xFFFF;
@@ -1465,7 +1469,8 @@ s32 GCMemcard::FZEROGX_MakeSaveGameValid(const GCMemcardHeaderBlock& cardheader,
 /* Returns: Error code                                     */
 /***********************************************************/
 
-s32 GCMemcard::PSO_MakeSaveGameValid(const GCMemcardHeaderBlock& cardheader, const DEntry& direntry,
+s32 GCMemcard::PSO_MakeSaveGameValid(const GCMemcardHeaderBlock& cardheader,
+                                     const GCMemcardDirEntry& direntry,
                                      std::vector<GCMBlock>& FileBuffer)
 {
   u32 i, j;
@@ -1581,12 +1586,12 @@ std::pair<u32, u32> GCMemcardHeaderBlock::CalculateSerial() const
   return std::make_pair(serial1, serial2);
 }
 
-DEntry::DEntry()
+GCMemcardDirEntry::GCMemcardDirEntry()
 {
   memset(this, 0xFF, DENTRY_SIZE);
 }
 
-std::string DEntry::GCI_FileName() const
+std::string GCMemcardDirEntry::GCI_FileName() const
 {
   std::string filename =
       std::string(reinterpret_cast<const char*>(m_makercode.data()), m_makercode.size()) + '-' +
@@ -1644,7 +1649,7 @@ Directory::Directory()
   m_checksum_inv = 0;
 }
 
-bool Directory::Replace(const DEntry& entry, size_t index)
+bool Directory::Replace(const GCMemcardDirEntry& entry, size_t index)
 {
   if (index >= m_dir_entries.size())
     return false;
@@ -1694,8 +1699,8 @@ GCMemcardErrorCode Directory::CheckForErrorsWithBat(const BlockAlloc& bat) const
 
   for (u8 i = 0; i < DIRLEN; ++i)
   {
-    const DEntry& entry = m_dir_entries[i];
-    if (entry.m_gamecode == DEntry::UNINITIALIZED_GAMECODE)
+    const GCMemcardDirEntry& entry = m_dir_entries[i];
+    if (entry.m_gamecode == GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
       continue;
 
     // check if we end up with the same number of blocks when traversing through the BAT using the

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -323,7 +323,7 @@ struct GCMemcardDirEntry
 };
 static_assert(sizeof(GCMemcardDirEntry) == DENTRY_SIZE);
 
-struct BlockAlloc;
+struct GCMemcardBATBlock;
 
 struct GCMemcardDirectoryBlock
 {
@@ -354,11 +354,11 @@ struct GCMemcardDirectoryBlock
 
   GCMemcardErrorCode CheckForErrors() const;
 
-  GCMemcardErrorCode CheckForErrorsWithBat(const BlockAlloc& bat) const;
+  GCMemcardErrorCode CheckForErrorsWithBat(const GCMemcardBATBlock& bat) const;
 };
 static_assert(sizeof(GCMemcardDirectoryBlock) == BLOCK_SIZE);
 
-struct BlockAlloc
+struct GCMemcardBATBlock
 {
   // 2 bytes at 0x0000: Additive Checksum
   u16 m_checksum;
@@ -378,7 +378,7 @@ struct BlockAlloc
   // 0x1ff8 bytes at 0x000a: Map of allocated Blocks
   std::array<Common::BigEndianValue<u16>, BAT_SIZE> m_map;
 
-  explicit BlockAlloc(u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043);
+  explicit GCMemcardBATBlock(u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043);
 
   u16 GetNextBlock(u16 block) const;
   u16 NextFreeBlock(u16 max_block, u16 starting_block = MC_FST_BLOCKS) const;
@@ -390,7 +390,7 @@ struct BlockAlloc
 
   GCMemcardErrorCode CheckForErrors(u16 size_mbits) const;
 };
-static_assert(sizeof(BlockAlloc) == BLOCK_SIZE);
+static_assert(sizeof(GCMemcardBATBlock) == BLOCK_SIZE);
 #pragma pack(pop)
 
 class GCMemcard
@@ -404,7 +404,7 @@ private:
 
   GCMemcardHeaderBlock m_header_block;
   std::array<GCMemcardDirectoryBlock, 2> m_directory_blocks;
-  std::array<BlockAlloc, 2> m_bat_blocks;
+  std::array<GCMemcardBATBlock, 2> m_bat_blocks;
   std::vector<GCMBlock> m_data_blocks;
 
   int m_active_directory;
@@ -415,10 +415,10 @@ private:
   GCMemcardImportFileRetVal ImportGciInternal(File::IOFile&& gci, const std::string& inputFile);
 
   const GCMemcardDirectoryBlock& GetActiveDirectory() const;
-  const BlockAlloc& GetActiveBat() const;
+  const GCMemcardBATBlock& GetActiveBat() const;
 
   void UpdateDirectory(const GCMemcardDirectoryBlock& directory);
-  void UpdateBat(const BlockAlloc& bat);
+  void UpdateBat(const GCMemcardBATBlock& bat);
 
 public:
   static std::optional<GCMemcard> Create(std::string filename, u16 size_mbits, bool shift_jis);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -188,7 +188,7 @@ struct GCMBlock
 };
 
 #pragma pack(push, 1)
-struct Header
+struct GCMemcardHeaderBlock
 {
   // NOTE: libogc refers to 'Serial' as the first 0x20 bytes of the header,
   // so the data from m_serial until m_unknown_2 (inclusive)
@@ -233,8 +233,8 @@ struct Header
   // 0x1e00 bytes at 0x0200: Unused (0xff)
   std::array<u8, 7680> m_unused_2;
 
-  explicit Header(int slot = 0, u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043,
-                  bool shift_jis = false);
+  explicit GCMemcardHeaderBlock(int slot = 0, u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043,
+                                bool shift_jis = false);
 
   // Calculates the card serial numbers used for encrypting some save files.
   std::pair<u32, u32> CalculateSerial() const;
@@ -244,7 +244,7 @@ struct Header
 
   GCMemcardErrorCode CheckForErrors(u16 card_size_mbits) const;
 };
-static_assert(sizeof(Header) == BLOCK_SIZE);
+static_assert(sizeof(GCMemcardHeaderBlock) == BLOCK_SIZE);
 
 struct DEntry
 {
@@ -402,7 +402,7 @@ private:
   u32 m_size_blocks;
   u16 m_size_mb;
 
-  Header m_header_block;
+  GCMemcardHeaderBlock m_header_block;
   std::array<Directory, 2> m_directory_blocks;
   std::array<BlockAlloc, 2> m_bat_blocks;
   std::vector<GCMBlock> m_data_blocks;
@@ -436,9 +436,9 @@ public:
   bool Format(bool shift_jis = false, u16 SizeMb = MBIT_SIZE_MEMORY_CARD_2043);
   static bool Format(u8* card_data, bool shift_jis = false,
                      u16 SizeMb = MBIT_SIZE_MEMORY_CARD_2043);
-  static s32 FZEROGX_MakeSaveGameValid(const Header& cardheader, const DEntry& direntry,
-                                       std::vector<GCMBlock>& FileBuffer);
-  static s32 PSO_MakeSaveGameValid(const Header& cardheader, const DEntry& direntry,
+  static s32 FZEROGX_MakeSaveGameValid(const GCMemcardHeaderBlock& cardheader,
+                                       const DEntry& direntry, std::vector<GCMBlock>& FileBuffer);
+  static s32 PSO_MakeSaveGameValid(const GCMemcardHeaderBlock& cardheader, const DEntry& direntry,
                                    std::vector<GCMBlock>& FileBuffer);
 
   bool FixChecksums();

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -325,7 +325,7 @@ static_assert(sizeof(GCMemcardDirEntry) == DENTRY_SIZE);
 
 struct BlockAlloc;
 
-struct Directory
+struct GCMemcardDirectoryBlock
 {
   // 127 files of 0x40 bytes each
   std::array<GCMemcardDirEntry, DIRLEN> m_dir_entries;
@@ -343,7 +343,7 @@ struct Directory
   u16 m_checksum_inv;
 
   // Constructs an empty Directory block.
-  Directory();
+  GCMemcardDirectoryBlock();
 
   // Replaces the file metadata at the given index (range 0-126)
   // with the given GCMemcardDirEntry data.
@@ -356,7 +356,7 @@ struct Directory
 
   GCMemcardErrorCode CheckForErrorsWithBat(const BlockAlloc& bat) const;
 };
-static_assert(sizeof(Directory) == BLOCK_SIZE);
+static_assert(sizeof(GCMemcardDirectoryBlock) == BLOCK_SIZE);
 
 struct BlockAlloc
 {
@@ -403,7 +403,7 @@ private:
   u16 m_size_mb;
 
   GCMemcardHeaderBlock m_header_block;
-  std::array<Directory, 2> m_directory_blocks;
+  std::array<GCMemcardDirectoryBlock, 2> m_directory_blocks;
   std::array<BlockAlloc, 2> m_bat_blocks;
   std::vector<GCMBlock> m_data_blocks;
 
@@ -414,10 +414,10 @@ private:
 
   GCMemcardImportFileRetVal ImportGciInternal(File::IOFile&& gci, const std::string& inputFile);
 
-  const Directory& GetActiveDirectory() const;
+  const GCMemcardDirectoryBlock& GetActiveDirectory() const;
   const BlockAlloc& GetActiveBat() const;
 
-  void UpdateDirectory(const Directory& directory);
+  void UpdateDirectory(const GCMemcardDirectoryBlock& directory);
   void UpdateBat(const BlockAlloc& bat);
 
 public:

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -435,7 +435,7 @@ public:
   bool Save();
   bool Format(bool shift_jis = false, u16 SizeMb = MBIT_SIZE_MEMORY_CARD_2043);
   static bool Format(u8* card_data, bool shift_jis = false,
-                     u16 SizeMb = MBIT_SIZE_MEMORY_CARD_2043);
+                     u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043);
   static s32 FZEROGX_MakeSaveGameValid(const GCMemcardHeaderBlock& cardheader,
                                        const GCMemcardDirEntry& direntry,
                                        std::vector<GCMBlock>& FileBuffer);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -439,7 +439,7 @@ inline void GCMemcardDirectory::SyncSaves()
 
   for (u32 i = 0; i < DIRLEN; ++i)
   {
-    if (current->m_dir_entries[i].m_gamecode != DEntry::UNINITIALIZED_GAMECODE)
+    if (current->m_dir_entries[i].m_gamecode != GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
     {
       INFO_LOG(EXPANSIONINTERFACE, "Syncing save 0x%x",
                Common::swap32(current->m_dir_entries[i].m_gamecode.data()));
@@ -483,7 +483,7 @@ inline void GCMemcardDirectory::SyncSaves()
     {
       INFO_LOG(EXPANSIONINTERFACE, "Clearing and/or deleting save 0x%x",
                Common::swap32(m_saves[i].m_gci_header.m_gamecode.data()));
-      m_saves[i].m_gci_header.m_gamecode = DEntry::UNINITIALIZED_GAMECODE;
+      m_saves[i].m_gci_header.m_gamecode = GCMemcardDirEntry::UNINITIALIZED_GAMECODE;
       m_saves[i].m_save_data.clear();
       m_saves[i].m_used_blocks.clear();
       m_saves[i].m_dirty = true;
@@ -494,7 +494,7 @@ inline s32 GCMemcardDirectory::SaveAreaRW(u32 block, bool writing)
 {
   for (u16 i = 0; i < m_saves.size(); ++i)
   {
-    if (m_saves[i].m_gci_header.m_gamecode != DEntry::UNINITIALIZED_GAMECODE)
+    if (m_saves[i].m_gci_header.m_gamecode != GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
     {
       if (m_saves[i].m_used_blocks.empty())
       {
@@ -586,12 +586,12 @@ void GCMemcardDirectory::FlushToFile()
 {
   std::unique_lock<std::mutex> l(m_write_mutex);
   int errors = 0;
-  DEntry invalid;
+  GCMemcardDirEntry invalid;
   for (u16 i = 0; i < m_saves.size(); ++i)
   {
     if (m_saves[i].m_dirty)
     {
-      if (m_saves[i].m_gci_header.m_gamecode != DEntry::UNINITIALIZED_GAMECODE)
+      if (m_saves[i].m_gci_header.m_gamecode != GCMemcardDirEntry::UNINITIALIZED_GAMECODE)
       {
         m_saves[i].m_dirty = false;
         if (m_saves[i].m_save_data.empty())

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -551,7 +551,7 @@ s32 GCMemcardDirectory::DirectoryWrite(u32 dest_address, u32 length, const u8* s
 
 bool GCMemcardDirectory::SetUsedBlocks(int save_index)
 {
-  BlockAlloc* current_bat;
+  GCMemcardBATBlock* current_bat;
   if (m_bat2.m_update_counter > m_bat1.m_update_counter)
     current_bat = &m_bat2;
   else
@@ -684,8 +684,8 @@ void GCMemcardDirectory::DoState(PointerWrap& p)
   p.DoPOD<GCMemcardHeaderBlock>(m_hdr);
   p.DoPOD<GCMemcardDirectoryBlock>(m_dir1);
   p.DoPOD<GCMemcardDirectoryBlock>(m_dir2);
-  p.DoPOD<BlockAlloc>(m_bat1);
-  p.DoPOD<BlockAlloc>(m_bat2);
+  p.DoPOD<GCMemcardBATBlock>(m_bat1);
+  p.DoPOD<GCMemcardBATBlock>(m_bat2);
   int num_saves = (int)m_saves.size();
   p.Do(num_saves);
   m_saves.resize(num_saves);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -681,7 +681,7 @@ void GCMemcardDirectory::DoState(PointerWrap& p)
   m_last_block = -1;
   m_last_block_address = nullptr;
   p.Do(m_save_directory);
-  p.DoPOD<Header>(m_hdr);
+  p.DoPOD<GCMemcardHeaderBlock>(m_hdr);
   p.DoPOD<Directory>(m_dir1);
   p.DoPOD<Directory>(m_dir2);
   p.DoPOD<BlockAlloc>(m_bat1);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -430,7 +430,7 @@ void GCMemcardDirectory::ClearBlock(u32 address)
 
 inline void GCMemcardDirectory::SyncSaves()
 {
-  Directory* current = &m_dir2;
+  GCMemcardDirectoryBlock* current = &m_dir2;
 
   if (m_dir1.m_update_counter > m_dir2.m_update_counter)
   {
@@ -532,7 +532,7 @@ s32 GCMemcardDirectory::DirectoryWrite(u32 dest_address, u32 length, const u8* s
 {
   u32 block = dest_address / BLOCK_SIZE;
   u32 offset = dest_address % BLOCK_SIZE;
-  Directory* dest = (block == 1) ? &m_dir1 : &m_dir2;
+  GCMemcardDirectoryBlock* dest = (block == 1) ? &m_dir1 : &m_dir2;
   u16 Dnum = offset / DENTRY_SIZE;
 
   if (Dnum == DIRLEN)
@@ -682,8 +682,8 @@ void GCMemcardDirectory::DoState(PointerWrap& p)
   m_last_block_address = nullptr;
   p.Do(m_save_directory);
   p.DoPOD<GCMemcardHeaderBlock>(m_hdr);
-  p.DoPOD<Directory>(m_dir1);
-  p.DoPOD<Directory>(m_dir2);
+  p.DoPOD<GCMemcardDirectoryBlock>(m_dir1);
+  p.DoPOD<GCMemcardDirectoryBlock>(m_dir2);
   p.DoPOD<BlockAlloc>(m_bat1);
   p.DoPOD<BlockAlloc>(m_bat2);
   int num_saves = (int)m_saves.size();

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -51,7 +51,7 @@ private:
   s32 m_last_block;
   u8* m_last_block_address;
 
-  Header m_hdr;
+  GCMemcardHeaderBlock m_hdr;
   Directory m_dir1, m_dir2;
   BlockAlloc m_bat1, m_bat2;
   std::vector<GCIFile> m_saves;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -54,7 +54,8 @@ private:
   GCMemcardHeaderBlock m_hdr;
   GCMemcardDirectoryBlock m_dir1;
   GCMemcardDirectoryBlock m_dir2;
-  BlockAlloc m_bat1, m_bat2;
+  GCMemcardBATBlock m_bat1;
+  GCMemcardBATBlock m_bat2;
   std::vector<GCIFile> m_saves;
 
   std::string m_save_directory;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -52,7 +52,8 @@ private:
   u8* m_last_block_address;
 
   GCMemcardHeaderBlock m_hdr;
-  Directory m_dir1, m_dir2;
+  GCMemcardDirectoryBlock m_dir1;
+  GCMemcardDirectoryBlock m_dir2;
   BlockAlloc m_bat1, m_bat2;
   std::vector<GCIFile> m_saves;
 

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -224,8 +224,8 @@ void GCMemcardManager::UpdateSlotTable(int slot)
       comment = QString::fromStdString(file_comments->second);
     }
 
-    QString blocks = QStringLiteral("%1").arg(memcard->DEntry_BlockCount(file_index));
-    QString block_count = QStringLiteral("%1").arg(memcard->DEntry_FirstBlock(file_index));
+    QString blocks = QStringLiteral("%1").arg(memcard->DirEntry_BlockCount(file_index));
+    QString block_count = QStringLiteral("%1").arg(memcard->DirEntry_FirstBlock(file_index));
 
     auto* banner = new QTableWidgetItem;
     banner->setData(Qt::DecorationRole, GetBannerFromSaveFile(file_index, slot));
@@ -553,7 +553,7 @@ GCMemcardManager::IconAnimationData GCMemcardManager::GetIconFromSaveFile(int fi
       }
     }
 
-    const bool is_pingpong = memcard->DEntry_IsPingPong(file_index);
+    const bool is_pingpong = memcard->DirEntry_IsPingPong(file_index);
     if (is_pingpong && decoded_data->size() >= 3)
     {
       // if the animation 'ping-pongs' between start and end then the animation frame order is


### PR DESCRIPTION
Mostly because it struck me as very scary that we have structs in the global namespace just called 'Header' and 'Directory' that are for the memory card implementation...

I also rewrote the static GCMemcard::Format() while I was here so it no longer relies on constructing objects into an `u8*`.