### PR TITLE
DolphinQt: Fix crash on right-clicking multiple games

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -256,7 +256,9 @@ void GameList::ShowContextMenu(const QPoint&)
 
   if (HasMultipleSelected())
   {
-    if (std::all_of(GetSelectedGames().begin(), GetSelectedGames().end(), [](const auto& game) {
+    const auto selected_games = GetSelectedGames();
+
+    if (std::all_of(selected_games.begin(), selected_games.end(), [](const auto& game) {
           // Converting from TGC is temporarily disabled because PR #8738 was merged prematurely.
           // The TGC check will be removed by PR #8644.
           return DiscIO::IsDisc(game->GetPlatform()) && game->IsVolumeSizeAccurate() &&
@@ -267,7 +269,7 @@ void GameList::ShowContextMenu(const QPoint&)
       menu->addSeparator();
     }
 
-    if (std::all_of(GetSelectedGames().begin(), GetSelectedGames().end(),
+    if (std::all_of(selected_games.begin(), selected_games.end(),
                     [](const auto& game) { return DiscIO::IsWii(game->GetPlatform()); }))
     {
       menu->addAction(tr("Export Wii Saves"), this, &GameList::ExportWiiSave);


### PR DESCRIPTION
`GetSelectedGames()` constructs a new list each time you call it.