### PR TITLE
Keep memory card header and use it to reinitialize GCI folders on mismatch. (Fix savestate with GCI folders)

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -151,16 +151,16 @@ static void ChangeDeviceCallback(u64 userdata, s64 cyclesLate)
   g_Channels.at(channel)->AddDevice((TEXIDevices)type, num);
 }
 
-void ChangeDevice(const u8 channel, const TEXIDevices device_type, const u8 device_num)
+void ChangeDevice(const u8 channel, const TEXIDevices device_type, const u8 device_num,
+                  CoreTiming::FromThread from_thread)
 {
-  // Called from GUI, so we need to use FromThread::NON_CPU.
   // Let the hardware see no device for 1 second
   CoreTiming::ScheduleEvent(0, changeDevice,
                             ((u64)channel << 32) | ((u64)EXIDEVICE_NONE << 16) | device_num,
-                            CoreTiming::FromThread::NON_CPU);
+                            from_thread);
   CoreTiming::ScheduleEvent(SystemTimers::GetTicksPerSecond(), changeDevice,
                             ((u64)channel << 32) | ((u64)device_type << 16) | device_num,
-                            CoreTiming::FromThread::NON_CPU);
+                            from_thread);
 }
 
 CEXIChannel* GetChannel(u32 index)

--- a/Source/Core/Core/HW/EXI/EXI.h
+++ b/Source/Core/Core/HW/EXI/EXI.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Core/CoreTiming.h"
 
 class PointerWrap;
 
@@ -39,7 +40,8 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 void UpdateInterrupts();
 void ScheduleUpdateInterrupts(CoreTiming::FromThread from, int cycles_late);
 
-void ChangeDevice(const u8 channel, const TEXIDevices device_type, const u8 device_num);
+void ChangeDevice(const u8 channel, const TEXIDevices device_type, const u8 device_num,
+                  CoreTiming::FromThread from_thread = CoreTiming::FromThread::NON_CPU);
 
 CEXIChannel* GetChannel(u32 index);
 

--- a/Source/Core/Core/HW/EXI/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.cpp
@@ -9,9 +9,12 @@
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+
+#include "Core/CoreTiming.h"
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/MMIO.h"
+#include "Core/Movie.h"
 
 namespace ExpansionInterface
 {
@@ -175,6 +178,11 @@ void CEXIChannel::AddDevice(std::unique_ptr<IEXIDevice> device, const int device
 {
   DEBUG_ASSERT(device_num < NUM_DEVICES);
 
+  INFO_LOG(EXPANSIONINTERFACE,
+           "Changing EXI channel %d, device %d to type %d (notify software: %s)",
+           static_cast<int>(m_channel_id), device_num, static_cast<int>(device->m_device_type),
+           notify_presence_changed ? "true" : "false");
+
   // Replace it with the new one
   m_devices[device_num] = std::move(device);
 
@@ -230,6 +238,8 @@ void CEXIChannel::DoState(PointerWrap& p)
   p.Do(m_dma_length);
   p.Do(m_control);
   p.Do(m_imm_data);
+
+  Memcard::HeaderData old_header_data = m_memcard_header_data;
   p.DoPOD(m_memcard_header_data);
 
   for (int device_index = 0; device_index < NUM_DEVICES; ++device_index)
@@ -248,6 +258,28 @@ void CEXIChannel::DoState(PointerWrap& p)
           EXIDevice_Create(type, m_channel_id, m_memcard_header_data);
       save_device->DoState(p);
       AddDevice(std::move(save_device), device_index, false);
+    }
+
+    if (type == EXIDEVICE_MEMORYCARDFOLDER && old_header_data != m_memcard_header_data &&
+        !Movie::IsMovieActive())
+    {
+      // We have loaded a savestate that has a GCI folder memcard that is different to the virtual
+      // card that is currently active. In order to prevent the game from recognizing this card as a
+      // 'different' memory card and preventing saving on it, we need to reinitialize the GCI folder
+      // card here with the loaded header data.
+      // We're intentionally calling ExpansionInterface::ChangeDevice() here instead of changing it
+      // directly so we don't switch immediately but after a delay, as if changed in the GUI. This
+      // should prevent games from assuming any stale data about the memory card, such as location
+      // of the individual save blocks, which may be different on the reinitialized card.
+      // Additionally, we immediately force the memory card to None so that any 'in-flight' writes
+      // (if someone managed to savestate while saving...) don't happen to hit the card.
+      // TODO: It might actually be enough to just switch to the card with the
+      // notify_presence_changed flag set to true? Not sure how software behaves if the previous and
+      // the new device type are identical in this case. I assume there is a reason we have this
+      // grace period when switching in the GUI.
+      AddDevice(EXIDEVICE_NONE, device_index);
+      ExpansionInterface::ChangeDevice(m_channel_id, EXIDEVICE_MEMORYCARDFOLDER, device_index,
+                                       CoreTiming::FromThread::CPU);
     }
   }
 }

--- a/Source/Core/Core/HW/EXI/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.h
@@ -6,7 +6,10 @@
 
 #include <array>
 #include <memory>
+
 #include "Common/CommonTypes.h"
+
+#include "Core/HW/GCMemcard/GCMemcard.h"
 
 class PointerWrap;
 
@@ -23,7 +26,7 @@ enum TEXIDevices : int;
 class CEXIChannel
 {
 public:
-  explicit CEXIChannel(u32 channel_id);
+  explicit CEXIChannel(u32 channel_id, const Memcard::HeaderData& memcard_header_data);
   ~CEXIChannel();
 
   // get device
@@ -105,6 +108,12 @@ private:
   u32 m_dma_length = 0;
   UEXI_CONTROL m_control;
   u32 m_imm_data = 0;
+
+  // This data is needed in order to reinitialize a GCI folder memory card when switching between
+  // GCI folder and other devices in the memory card slot or after loading a savestate. Even though
+  // this data is only vaguely related to the EXI_Channel, this seems to be the best place to store
+  // it, as this class creates the CEXIMemoryCard instances.
+  Memcard::HeaderData m_memcard_header_data;
 
   // Devices
   enum

--- a/Source/Core/Core/HW/EXI/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Device.cpp
@@ -102,7 +102,8 @@ void IEXIDevice::TransferByte(u8& byte)
 }
 
 // F A C T O R Y
-std::unique_ptr<IEXIDevice> EXIDevice_Create(const TEXIDevices device_type, const int channel_num)
+std::unique_ptr<IEXIDevice> EXIDevice_Create(const TEXIDevices device_type, const int channel_num,
+                                             const Memcard::HeaderData& memcard_header_data)
 {
   std::unique_ptr<IEXIDevice> result;
 
@@ -116,7 +117,7 @@ std::unique_ptr<IEXIDevice> EXIDevice_Create(const TEXIDevices device_type, cons
   case EXIDEVICE_MEMORYCARDFOLDER:
   {
     bool gci_folder = (device_type == EXIDEVICE_MEMORYCARDFOLDER);
-    result = std::make_unique<CEXIMemoryCard>(channel_num, gci_folder);
+    result = std::make_unique<CEXIMemoryCard>(channel_num, gci_folder, memcard_header_data);
     break;
   }
   case EXIDEVICE_MASKROM:

--- a/Source/Core/Core/HW/EXI/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI/EXI_Device.h
@@ -9,6 +9,11 @@
 
 class PointerWrap;
 
+namespace Memcard
+{
+struct HeaderData;
+}
+
 namespace ExpansionInterface
 {
 enum TEXIDevices : int
@@ -65,5 +70,6 @@ private:
   virtual void TransferByte(u8& byte);
 };
 
-std::unique_ptr<IEXIDevice> EXIDevice_Create(TEXIDevices device_type, int channel_num);
+std::unique_ptr<IEXIDevice> EXIDevice_Create(TEXIDevices device_type, int channel_num,
+                                             const Memcard::HeaderData& memcard_header_data);
 }  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
@@ -14,6 +14,11 @@
 class MemoryCardBase;
 class PointerWrap;
 
+namespace Memcard
+{
+struct HeaderData;
+}
+
 namespace ExpansionInterface
 {
 enum class AllowMovieFolder
@@ -25,7 +30,7 @@ enum class AllowMovieFolder
 class CEXIMemoryCard : public IEXIDevice
 {
 public:
-  CEXIMemoryCard(const int index, bool gciFolder);
+  CEXIMemoryCard(const int index, bool gciFolder, const Memcard::HeaderData& header_data);
   virtual ~CEXIMemoryCard();
   void SetCS(int cs) override;
   bool IsInterruptSet() override;
@@ -46,7 +51,7 @@ public:
   GetGCIFolderPath(int card_index, AllowMovieFolder allow_movie_folder);
 
 private:
-  void SetupGciFolder(u16 sizeMb);
+  void SetupGciFolder(const Memcard::HeaderData& header_data);
   void SetupRawMemcard(u16 sizeMb);
   static void EventCompleteFindInstance(u64 userdata,
                                         std::function<void(CEXIMemoryCard*)> callback);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1576,6 +1576,17 @@ void InitializeHeaderData(HeaderData* data, const CardFlashId& flash_id, u16 siz
   data->m_device_id = 0;
 }
 
+bool operator==(const HeaderData& lhs, const HeaderData& rhs)
+{
+  static_assert(std::is_trivially_copyable_v<HeaderData>);
+  return std::memcmp(&lhs, &rhs, sizeof(HeaderData)) == 0;
+}
+
+bool operator!=(const HeaderData& lhs, const HeaderData& rhs)
+{
+  return !(lhs == rhs);
+}
+
 Header::Header(const CardFlashId& flash_id, u16 size_mbits, bool shift_jis, u32 rtc_bias,
                u32 sram_language, u64 format_time)
 {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -166,6 +166,8 @@ struct GCMBlock
   void Erase();
   std::array<u8, BLOCK_SIZE> m_block;
 };
+static_assert(sizeof(GCMBlock) == BLOCK_SIZE);
+static_assert(std::is_trivially_copyable_v<GCMBlock>);
 
 #pragma pack(push, 1)
 struct Header
@@ -229,6 +231,7 @@ struct Header
   GCMemcardErrorCode CheckForErrors(u16 card_size_mbits) const;
 };
 static_assert(sizeof(Header) == BLOCK_SIZE);
+static_assert(std::is_trivially_copyable_v<Header>);
 
 struct DEntry
 {
@@ -306,6 +309,7 @@ struct DEntry
   Common::BigEndianValue<u32> m_comments_address;
 };
 static_assert(sizeof(DEntry) == DENTRY_SIZE);
+static_assert(std::is_trivially_copyable_v<DEntry>);
 
 struct BlockAlloc;
 
@@ -341,6 +345,7 @@ struct Directory
   GCMemcardErrorCode CheckForErrorsWithBat(const BlockAlloc& bat) const;
 };
 static_assert(sizeof(Directory) == BLOCK_SIZE);
+static_assert(std::is_trivially_copyable_v<Directory>);
 
 struct BlockAlloc
 {
@@ -375,6 +380,7 @@ struct BlockAlloc
   GCMemcardErrorCode CheckForErrors(u16 size_mbits) const;
 };
 static_assert(sizeof(BlockAlloc) == BLOCK_SIZE);
+static_assert(std::is_trivially_copyable_v<BlockAlloc>);
 #pragma pack(pop)
 
 class GCMemcard

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -170,7 +170,9 @@ static_assert(sizeof(GCMBlock) == BLOCK_SIZE);
 static_assert(std::is_trivially_copyable_v<GCMBlock>);
 
 #pragma pack(push, 1)
-struct Header
+// split off from Header to have a small struct with all the data needed to regenerate the header
+// for GCI folders
+struct HeaderData
 {
   // NOTE: libogc refers to 'Serial' as the first 0x20 bytes of the header,
   // so the data from m_serial until m_unknown_2 (inclusive)
@@ -198,6 +200,15 @@ struct Header
 
   // 2 bytes at 0x0024: Encoding (Windows-1252 or Shift JIS)
   Common::BigEndianValue<u16> m_encoding;
+};
+static_assert(std::is_trivially_copyable_v<HeaderData>);
+
+void InitializeHeaderData(HeaderData* data, const CardFlashId& flash_id, u16 size_mbits,
+                          bool shift_jis, u32 rtc_bias, u32 sram_language, u64 format_time);
+
+struct Header
+{
+  HeaderData m_data;
 
   // 468 bytes at 0x0026: Unused (0xff)
   std::array<u8, 468> m_unused_1;
@@ -221,6 +232,9 @@ struct Header
   // initialize a formatted header block
   explicit Header(const CardFlashId& flash_id, u16 size_mbits, bool shift_jis, u32 rtc_bias,
                   u32 sram_language, u64 format_time);
+
+  // initialize a header block from existing HeaderData
+  explicit Header(const HeaderData& data);
 
   // Calculates the card serial numbers used for encrypting some save files.
   std::pair<u32, u32> CalculateSerial() const;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -213,8 +213,12 @@ struct Header
   // 0x1e00 bytes at 0x0200: Unused (0xff)
   std::array<u8, 7680> m_unused_2;
 
-  explicit Header(int slot = 0, u16 size_mbits = MBIT_SIZE_MEMORY_CARD_2043,
-                  bool shift_jis = false);
+  // initialize an unformatted header block
+  explicit Header();
+
+  // initialize a formatted header block
+  explicit Header(const CardFlashId& flash_id, u16 size_mbits, bool shift_jis, u32 rtc_bias,
+                  u32 sram_language, u64 format_time);
 
   // Calculates the card serial numbers used for encrypting some save files.
   std::pair<u32, u32> CalculateSerial() const;
@@ -401,7 +405,9 @@ private:
   void UpdateBat(const BlockAlloc& bat);
 
 public:
-  static std::optional<GCMemcard> Create(std::string filename, u16 size_mbits, bool shift_jis);
+  static std::optional<GCMemcard> Create(std::string filename, const CardFlashId& flash_id,
+                                         u16 size_mbits, bool shift_jis, u32 rtc_bias,
+                                         u32 sram_language, u64 format_time);
 
   static std::pair<GCMemcardErrorCode, std::optional<GCMemcard>> Open(std::string filename);
 
@@ -413,9 +419,10 @@ public:
   bool IsValid() const { return m_valid; }
   bool IsShiftJIS() const;
   bool Save();
-  bool Format(bool shift_jis = false, u16 SizeMb = MBIT_SIZE_MEMORY_CARD_2043);
-  static bool Format(u8* card_data, bool shift_jis = false,
-                     u16 SizeMb = MBIT_SIZE_MEMORY_CARD_2043);
+  bool Format(const CardFlashId& flash_id, u16 size_mbits, bool shift_jis, u32 rtc_bias,
+              u32 sram_language, u64 format_time);
+  static bool Format(u8* card_data, const CardFlashId& flash_id, u16 size_mbits, bool shift_jis,
+                     u32 rtc_bias, u32 sram_language, u64 format_time);
   static s32 FZEROGX_MakeSaveGameValid(const Header& cardheader, const DEntry& direntry,
                                        std::vector<GCMBlock>& FileBuffer);
   static s32 PSO_MakeSaveGameValid(const Header& cardheader, const DEntry& direntry,

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -206,6 +206,9 @@ static_assert(std::is_trivially_copyable_v<HeaderData>);
 void InitializeHeaderData(HeaderData* data, const CardFlashId& flash_id, u16 size_mbits,
                           bool shift_jis, u32 rtc_bias, u32 sram_language, u64 format_time);
 
+bool operator==(const HeaderData& lhs, const HeaderData& rhs);
+bool operator!=(const HeaderData& lhs, const HeaderData& rhs);
+
 struct Header
 {
   HeaderData m_data;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -149,13 +149,11 @@ std::vector<std::string> GCMemcardDirectory::GetFileNamesForGameID(const std::st
   return filenames;
 }
 
-GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u16 size_mbits,
-                                       bool shift_jis, int game_id)
-    : MemoryCardBase(slot, size_mbits), m_game_id(game_id), m_last_block(-1),
-      m_hdr(g_SRAM.settings_ex.flash_id[slot], size_mbits, shift_jis, g_SRAM.settings.rtc_bias,
-            static_cast<u32>(g_SRAM.settings.language),
-            Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH),
-      m_bat1(size_mbits), m_saves(0), m_save_directory(directory), m_exiting(false)
+GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot,
+                                       const Memcard::HeaderData& header_data, u32 game_id)
+    : MemoryCardBase(slot, header_data.m_size_mb), m_game_id(game_id), m_last_block(-1),
+      m_hdr(header_data), m_bat1(header_data.m_size_mb), m_saves(0), m_save_directory(directory),
+      m_exiting(false)
 {
   // Use existing header data if available
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -26,9 +26,13 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
+#include "Common/Timer.h"
+
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/HW/EXI/EXI_DeviceIPL.h"
+#include "Core/HW/Sram.h"
 #include "Core/NetPlayProto.h"
 
 static const char* MC_HDR = "MC_SYSTEM_AREA";
@@ -148,8 +152,10 @@ std::vector<std::string> GCMemcardDirectory::GetFileNamesForGameID(const std::st
 GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u16 size_mbits,
                                        bool shift_jis, int game_id)
     : MemoryCardBase(slot, size_mbits), m_game_id(game_id), m_last_block(-1),
-      m_hdr(slot, size_mbits, shift_jis), m_bat1(size_mbits), m_saves(0),
-      m_save_directory(directory), m_exiting(false)
+      m_hdr(g_SRAM.settings_ex.flash_id[slot], size_mbits, shift_jis, g_SRAM.settings.rtc_bias,
+            static_cast<u32>(g_SRAM.settings.language),
+            Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH),
+      m_bat1(size_mbits), m_saves(0), m_save_directory(directory), m_exiting(false)
 {
   // Use existing header data if available
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -201,7 +201,8 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u
   }
 
   // leave about 10% of free space on the card if possible
-  const int total_blocks = m_hdr.m_size_mb * Memcard::MBIT_TO_BLOCKS - Memcard::MC_FST_BLOCKS;
+  const int total_blocks =
+      m_hdr.m_data.m_size_mb * Memcard::MBIT_TO_BLOCKS - Memcard::MC_FST_BLOCKS;
   const int reserved_blocks = total_blocks / 10;
 
   // load files for other games

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -21,8 +21,8 @@ void MigrateFromMemcardFile(const std::string& directory_name, int card_index);
 class GCMemcardDirectory : public MemoryCardBase
 {
 public:
-  GCMemcardDirectory(const std::string& directory, int slot, u16 size_mbits, bool shift_jis,
-                     int game_id);
+  GCMemcardDirectory(const std::string& directory, int slot, const Memcard::HeaderData& header_data,
+                     u32 game_id);
   ~GCMemcardDirectory();
 
   GCMemcardDirectory(const GCMemcardDirectory&) = delete;

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -22,9 +22,13 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
+#include "Common/Timer.h"
+
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/GCMemcard/GCMemcard.h"
+#include "Core/HW/Sram.h"
 
 #define SIZE_TO_Mb (1024 * 8 * 16)
 #define MC_HDR_SIZE 0xA000
@@ -51,9 +55,18 @@ MemoryCard::MemoryCard(const std::string& filename, int card_index, u16 size_mbi
     m_memory_card_size = size_mbits * SIZE_TO_Mb;
 
     m_memcard_data = std::make_unique<u8[]>(m_memory_card_size);
-    // Fills in MC_HDR_SIZE bytes
-    Memcard::GCMemcard::Format(&m_memcard_data[0], m_filename.find(".JAP.raw") != std::string::npos,
-                               size_mbits);
+
+    // Fills in the first 5 blocks (MC_HDR_SIZE bytes)
+    const CardFlashId& flash_id = g_SRAM.settings_ex.flash_id[Memcard::SLOT_A];
+    const bool shift_jis = m_filename.find(".JAP.raw") != std::string::npos;
+    const u32 rtc_bias = g_SRAM.settings.rtc_bias;
+    const u32 sram_language = static_cast<u32>(g_SRAM.settings.language);
+    const u64 format_time =
+        Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
+    Memcard::GCMemcard::Format(&m_memcard_data[0], flash_id, size_mbits, shift_jis, rtc_bias,
+                               sram_language, format_time);
+
+    // Fills in the remaining blocks
     memset(&m_memcard_data[MC_HDR_SIZE], 0xFF, m_memory_card_size - MC_HDR_SIZE);
 
     INFO_LOG(EXPANSIONINTERFACE, "No memory card found. A new one was created instead.");

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 115;  // Last changed in PR 8722
+constexpr u32 STATE_VERSION = 116;  // Last changed in PR 8879
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
+++ b/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
@@ -14,8 +14,11 @@
 
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
+#include "Common/Timer.h"
 
+#include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/GCMemcard/GCMemcard.h"
+#include "Core/HW/Sram.h"
 
 GCMemcardCreateNewDialog::GCMemcardCreateNewDialog(QWidget* parent) : QDialog(parent)
 {
@@ -74,8 +77,16 @@ bool GCMemcardCreateNewDialog::CreateCard()
   if (path.isEmpty())
     return false;
 
+  // TODO: The dependency on g_SRAM here is sketchy. We should instead use sensible default values.
+  const CardFlashId& flash_id = g_SRAM.settings_ex.flash_id[Memcard::SLOT_A];
+  const u32 rtc_bias = g_SRAM.settings.rtc_bias;
+  const u32 sram_language = static_cast<u32>(g_SRAM.settings.language);
+  const u64 format_time =
+      Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
+
   const std::string p = path.toStdString();
-  auto memcard = Memcard::GCMemcard::Create(p, size, is_shift_jis);
+  auto memcard = Memcard::GCMemcard::Create(p, flash_id, size, is_shift_jis, rtc_bias,
+                                            sram_language, format_time);
   if (memcard && memcard->Save())
   {
     m_card_path = p;


### PR DESCRIPTION
Note: The first two commits are also found in #8880. It doesn't really matter which gets merged first.

This is a safer but more complex implementation of #8476. Instead of hardcoding a card ID, we store the memory card header data in EXI_Channel and ensure the same game session (including savestates) always sees the same card header. This is necessary because some (apparently many!) games check this and will refuse to save to the memory card if they believe the card is a different card they initially loaded from.

Whenever we create a new GCI folder memory card, we pass along the header data to the device, which ensures that eg. switching from GCI folder to No Memory Card back to GCI folder while the game is running still results in the same header. Additionally, when loading a savestate, we compare the card header in the savestate to the card header of the current session and will reinitialize all GCI folder cards with the header from the savestate on mismatch.

It does feel a bit silly to store the card header data in EXI_Channel, but it seems to be the best place for it.

Oh, and I'm not 100% sure how many of my security precautions here are *actually* necessary, but I figured it's better to be safe when it comes to save files.