### PR TITLE
Sketchy code cleanup in GCMemcard and GCMemcardDirectory.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1373,16 +1373,17 @@ bool GCMemcard::Format(u8* card_data, const CardFlashId& flash_id, u16 size_mbit
 {
   if (!card_data)
     return false;
-  memset(card_data, 0xFF, BLOCK_SIZE * 3);
-  memset(card_data + BLOCK_SIZE * 3, 0, BLOCK_SIZE * 2);
 
-  *((Header*)card_data) =
-      Header(flash_id, size_mbits, shift_jis, rtc_bias, sram_language, format_time);
+  Header header(flash_id, size_mbits, shift_jis, rtc_bias, sram_language, format_time);
+  Directory dir;
+  BlockAlloc bat(size_mbits);
 
-  *((Directory*)(card_data + BLOCK_SIZE)) = Directory();
-  *((Directory*)(card_data + BLOCK_SIZE * 2)) = Directory();
-  *((BlockAlloc*)(card_data + BLOCK_SIZE * 3)) = BlockAlloc(size_mbits);
-  *((BlockAlloc*)(card_data + BLOCK_SIZE * 4)) = BlockAlloc(size_mbits);
+  std::memcpy(&card_data[BLOCK_SIZE * 0], &header, BLOCK_SIZE);
+  std::memcpy(&card_data[BLOCK_SIZE * 1], &dir, BLOCK_SIZE);
+  std::memcpy(&card_data[BLOCK_SIZE * 2], &dir, BLOCK_SIZE);
+  std::memcpy(&card_data[BLOCK_SIZE * 3], &bat, BLOCK_SIZE);
+  std::memcpy(&card_data[BLOCK_SIZE * 4], &bat, BLOCK_SIZE);
+
   return true;
 }
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -629,7 +629,8 @@ void GCMemcardDirectory::FlushToFile()
         if (gci)
         {
           gci.WriteBytes(&save.m_gci_header, Memcard::DENTRY_SIZE);
-          gci.WriteBytes(save.m_save_data.data(), Memcard::BLOCK_SIZE * save.m_save_data.size());
+          for (const Memcard::GCMBlock& block : save.m_save_data)
+            gci.WriteBytes(block.m_block.data(), Memcard::BLOCK_SIZE);
 
           if (gci.IsGood())
           {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -430,7 +430,7 @@ void GCMemcardDirectory::ClearBlock(u32 address)
     if (m_last_block == -1)
       return;
   }
-  ((Memcard::GCMBlock*)m_last_block_address)->Erase();
+  std::memset(m_last_block_address, 0xFF, Memcard::BLOCK_SIZE);
 }
 
 inline void GCMemcardDirectory::SyncSaves()


### PR DESCRIPTION
Just some cleanup of undefined behavior and unclear code. Should not change program behavior.

(Yes, ClearBlock() really dir call a member function on the wrong class. I'm amazed this worked at all.)