### PR TITLE
VideoCommon: Clean freelook camera dirty state when getting the new view

### DIFF
--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -270,3 +270,8 @@ bool FreeLookCamera::IsDirty() const
 {
   return m_dirty;
 }
+
+void FreeLookCamera::SetClean()
+{
+  m_dirty = false;
+}

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -56,6 +56,7 @@ public:
   void DoState(PointerWrap& p);
 
   bool IsDirty() const;
+  void SetClean();
 
 private:
   bool m_dirty = false;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -419,6 +419,8 @@ void VertexShaderManager::SetConstants()
 
     memcpy(constants.projection.data(), corrected_matrix.data.data(), 4 * sizeof(float4));
 
+    g_freelook_camera.SetClean();
+
     dirty = true;
   }
 


### PR DESCRIPTION
Potentially fixes issue [12157](https://bugs.dolphin-emu.org/issues/12157)