### PR TITLE
VertexShaderManager: Only look for freelook config changes if we're using freelook

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -63,6 +63,7 @@
 #include "VideoCommon/FrameDump.h"
 #include "VideoCommon/FramebufferManager.h"
 #include "VideoCommon/FramebufferShaderGen.h"
+#include "VideoCommon/FreeLookCamera.h"
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/NetPlayChatUI.h"
 #include "VideoCommon/NetPlayGolfUI.h"
@@ -405,6 +406,11 @@ void Renderer::CheckForConfigChanges()
   const bool old_bbox = g_ActiveConfig.bBBoxEnable;
 
   UpdateActiveConfig();
+
+  if (g_ActiveConfig.bFreeLook)
+  {
+    g_freelook_camera.SetControlType(g_ActiveConfig.iFreelookControlType);
+  }
 
   // Update texture cache settings with any changed options.
   g_texture_cache->OnConfigChanged(g_ActiveConfig);

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -449,9 +449,6 @@ void VertexShaderManager::SetConstants()
 
     dirty = true;
   }
-
-  // Handle a potential config change
-  g_freelook_camera.SetControlType(Config::Get(Config::GFX_FREE_LOOK_CONTROL_TYPE));
 }
 
 void VertexShaderManager::InvalidateXFRange(int start, int end)

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -91,6 +91,7 @@ void VideoConfig::Refresh()
   bDumpXFBTarget = Config::Get(Config::GFX_DUMP_XFB_TARGET);
   bDumpFramesAsImages = Config::Get(Config::GFX_DUMP_FRAMES_AS_IMAGES);
   bFreeLook = Config::Get(Config::GFX_FREE_LOOK);
+  iFreelookControlType = Config::Get(Config::GFX_FREE_LOOK_CONTROL_TYPE);
   bUseFFV1 = Config::Get(Config::GFX_USE_FFV1);
   sDumpFormat = Config::Get(Config::GFX_DUMP_FORMAT);
   sDumpCodec = Config::Get(Config::GFX_DUMP_CODEC);


### PR DESCRIPTION
Another attempt to fix [12157](https://bugs.dolphin-emu.org/issues/12157).  I made the assumption that pulling from our onion config system was relatively fast but that doesn't seem to be the case from testing that fifolog (4fps difference)