### PR TITLE
PatchEngine: Attempt to fix crash in IsStackSane

### DIFF
--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -231,7 +231,8 @@ static bool IsStackSane()
 
   // Check the link register makes sense (that it points to a valid IBAT address)
   const u32 address = PowerPC::HostRead_U32(next_SP + 4);
-  return PowerPC::HostIsInstructionRAMAddress(address) && 0 != PowerPC::HostRead_U32(address);
+  return PowerPC::HostIsInstructionRAMAddress(address) &&
+         0 != PowerPC::HostRead_Instruction(address);
 }
 
 bool ApplyFramePatches()

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -423,8 +423,7 @@ TryReadInstResult TryReadInstruction(u32 address)
 
 u32 HostRead_Instruction(const u32 address)
 {
-  UGeckoInstruction inst = HostRead_U32(address);
-  return inst.hex;
+  return ReadFromHardware<XCheckTLBFlag::OpcodeNoException, u32>(address);
 }
 
 static void Memcheck(u32 address, u32 var, bool write, size_t size)


### PR DESCRIPTION
HostIsInstructionRAMAddress uses XCheckTLBFlag::OpcodeNoException, so we should also use XCheckTLBFlag::OpcodeNoException when reading, to ensure that we use the IBAT (as opposed to the DBAT) for both.

I made this change in an attempt to fix a crash a user was experiencing at PatchEngine.cpp:234, but it seems like this change didn't actually fix that crash. I'm submitting it anyway because the mismatched behavior we have right now seems a little odd.