### PR TITLE
GCMemcard: Rename unknown field to m_dtv_status

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -1568,11 +1568,9 @@ void InitializeHeaderData(HeaderData* data, const CardFlashId& flash_id, u16 siz
   }
   data->m_sram_bias = rtc_bias;
   data->m_sram_language = sram_language;
-  // TODO: determine the purpose of m_unknown_2
+  // TODO: determine the purpose of m_dtv_status
   // 1 works for slot A, 0 works for both slot A and slot B
-  std::memset(
-      data->m_unknown_2.data(), 0,
-      data->m_unknown_2.size());  // = _viReg[55];  static vu16* const _viReg = (u16*)0xCC002000;
+  data->m_dtv_status = 0;
   data->m_device_id = 0;
 }
 

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -175,7 +175,7 @@ static_assert(std::is_trivially_copyable_v<GCMBlock>);
 struct HeaderData
 {
   // NOTE: libogc refers to 'Serial' as the first 0x20 bytes of the header,
-  // so the data from m_serial until m_unknown_2 (inclusive)
+  // so the data from m_serial until m_dtv_status (inclusive)
 
   // 12 bytes at 0x0000
   std::array<u8, 12> m_serial;
@@ -189,8 +189,8 @@ struct HeaderData
   // 4 bytes at 0x0018: SRAM language
   Common::BigEndianValue<u32> m_sram_language;
 
-  // 4 bytes at 0x001c: ? almost always 0
-  std::array<u8, 4> m_unknown_2;
+  // 4 bytes at 0x001c: VI DTV status register value (u16 from 0xCC00206E)
+  u32 m_dtv_status;
 
   // 2 bytes at 0x0020: 0 if formated in slot A, 1 if formated in slot B
   Common::BigEndianValue<u16> m_device_id;


### PR DESCRIPTION
This PR renames an unknown field based on the register value it uses (see [YAGCD](http://hitmen.c02.at/files/yagcd/yagcd/chap5.html#sec5.3)).

This value is set in the `__CARDFormatRegionAsync` function. I don't know if the old comments still apply.

Ready to reviewed.