### PR TITLE
DolphinQt: Add columns with file format details

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -191,6 +191,9 @@ void SConfig::SaveGameListSettings(IniFile& ini)
   gamelist->Set("ColumnID", m_showIDColumn);
   gamelist->Set("ColumnRegion", m_showRegionColumn);
   gamelist->Set("ColumnSize", m_showSizeColumn);
+  gamelist->Set("ColumnFileFormat", m_showFileFormatColumn);
+  gamelist->Set("ColumnBlockSize", m_showBlockSizeColumn);
+  gamelist->Set("ColumnCompression", m_showCompressionColumn);
   gamelist->Set("ColumnTags", m_showTagsColumn);
 }
 
@@ -455,6 +458,9 @@ void SConfig::LoadGameListSettings(IniFile& ini)
   gamelist->Get("ColumnID", &m_showIDColumn, false);
   gamelist->Get("ColumnRegion", &m_showRegionColumn, true);
   gamelist->Get("ColumnSize", &m_showSizeColumn, true);
+  gamelist->Get("ColumnFileFormat", &m_showFileFormatColumn, false);
+  gamelist->Get("ColumnBlockSize", &m_showBlockSizeColumn, false);
+  gamelist->Get("ColumnCompression", &m_showCompressionColumn, false);
   gamelist->Get("ColumnTags", &m_showTagsColumn, false);
 }
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -271,6 +271,9 @@ struct SConfig
   bool m_showIDColumn;
   bool m_showRegionColumn;
   bool m_showSizeColumn;
+  bool m_showFileFormatColumn;
+  bool m_showBlockSizeColumn;
+  bool m_showCompressionColumn;
   bool m_showTagsColumn;
 
   std::string m_WirelessMac;

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -146,6 +146,9 @@ void GameList::MakeListView()
   hor_header->setSectionResizeMode(GameListModel::COL_SIZE, QHeaderView::Fixed);
   hor_header->setSectionResizeMode(GameListModel::COL_FILE_NAME, QHeaderView::Interactive);
   hor_header->setSectionResizeMode(GameListModel::COL_FILE_PATH, QHeaderView::Interactive);
+  hor_header->setSectionResizeMode(GameListModel::COL_FILE_FORMAT, QHeaderView::Fixed);
+  hor_header->setSectionResizeMode(GameListModel::COL_BLOCK_SIZE, QHeaderView::Fixed);
+  hor_header->setSectionResizeMode(GameListModel::COL_COMPRESSION, QHeaderView::Fixed);
   hor_header->setSectionResizeMode(GameListModel::COL_TAGS, QHeaderView::Interactive);
 
   // There's some odd platform-specific behavior with default minimum section size
@@ -191,6 +194,12 @@ void GameList::UpdateColumnVisibility()
                           !SConfig::GetInstance().m_showFileNameColumn);
   m_list->setColumnHidden(GameListModel::COL_FILE_PATH,
                           !SConfig::GetInstance().m_showFilePathColumn);
+  m_list->setColumnHidden(GameListModel::COL_FILE_FORMAT,
+                          !SConfig::GetInstance().m_showFileFormatColumn);
+  m_list->setColumnHidden(GameListModel::COL_BLOCK_SIZE,
+                          !SConfig::GetInstance().m_showBlockSizeColumn);
+  m_list->setColumnHidden(GameListModel::COL_COMPRESSION,
+                          !SConfig::GetInstance().m_showCompressionColumn);
   m_list->setColumnHidden(GameListModel::COL_TAGS, !SConfig::GetInstance().m_showTagsColumn);
 }
 
@@ -784,6 +793,9 @@ void GameList::OnColumnVisibilityToggled(const QString& row, bool visible)
       {tr("Game ID"), GameListModel::COL_ID},
       {tr("Region"), GameListModel::COL_COUNTRY},
       {tr("File Size"), GameListModel::COL_SIZE},
+      {tr("File Format"), GameListModel::COL_FILE_FORMAT},
+      {tr("Block Size"), GameListModel::COL_BLOCK_SIZE},
+      {tr("Compression"), GameListModel::COL_COMPRESSION},
       {tr("Tags"), GameListModel::COL_TAGS}};
 
   m_list->setColumnHidden(rowname_to_col_index[row], !visible);

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -166,6 +166,28 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     if (role == Qt::InitialSortOrderRole)
       return static_cast<quint64>(game.GetFileSize());
     break;
+  case COL_FILE_FORMAT:
+    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    {
+      if (game.ShouldShowFileFormatDetails())
+        return QString::fromStdString(DiscIO::GetName(game.GetBlobType(), true));
+      else
+        return {};
+    }
+    break;
+  case COL_BLOCK_SIZE:
+    if (role == Qt::DisplayRole)
+      return QString::fromStdString(UICommon::FormatSize(game.GetBlockSize()));
+    if (role == Qt::InitialSortOrderRole)
+      return static_cast<quint64>(game.GetBlockSize());
+    break;
+  case COL_COMPRESSION:
+    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    {
+      const QString compression = QString::fromStdString(game.GetCompressionMethod());
+      return compression.isEmpty() ? tr("No Compression") : compression;
+    }
+    break;
   case COL_TAGS:
     if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
     {
@@ -202,6 +224,12 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
     return tr("File Path");
   case COL_SIZE:
     return tr("Size");
+  case COL_FILE_FORMAT:
+    return tr("File Format");
+  case COL_BLOCK_SIZE:
+    return tr("Block Size");
+  case COL_COMPRESSION:
+    return tr("Compression");
   case COL_TAGS:
     return tr("Tags");
   }

--- a/Source/Core/DolphinQt/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt/GameList/GameListModel.h
@@ -56,6 +56,9 @@ public:
     COL_SIZE,
     COL_FILE_NAME,
     COL_FILE_PATH,
+    COL_FILE_FORMAT,
+    COL_BLOCK_SIZE,
+    COL_COMPRESSION,
     COL_TAGS,
     NUM_COLS
   };

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -630,6 +630,9 @@ void MenuBar::AddListColumnsMenu(QMenu* view_menu)
       {tr("Game ID"), &SConfig::GetInstance().m_showIDColumn},
       {tr("Region"), &SConfig::GetInstance().m_showRegionColumn},
       {tr("File Size"), &SConfig::GetInstance().m_showSizeColumn},
+      {tr("File Format"), &SConfig::GetInstance().m_showFileFormatColumn},
+      {tr("Block Size"), &SConfig::GetInstance().m_showBlockSizeColumn},
+      {tr("Compression"), &SConfig::GetInstance().m_showCompressionColumn},
       {tr("Tags"), &SConfig::GetInstance().m_showTagsColumn}};
 
   QActionGroup* column_group = new QActionGroup(this);


### PR DESCRIPTION
Same data as PR #8891, but now directly in the game list. The new columns are disabled by default.