### PR TITLE
Replace Windows CMake lambda constexpr capture workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,8 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   add_compile_options(/Zc:throwingNew)
   # Enforce strict volatile semantics as per ISO C++
   add_compile_options(/volatile:iso)
+  # Fix non-conformant lambda behavior (constexpr variables shouldn't need capturing)
+  add_compile_options(/experimental:newLambdaProcessor)
 
   string(APPEND CMAKE_EXE_LINKER_FLAGS " /NXCOMPAT")
 else()

--- a/Source/Core/DolphinQt/Config/VerifyWidget.cpp
+++ b/Source/Core/DolphinQt/Config/VerifyWidget.cpp
@@ -139,26 +139,26 @@ void VerifyWidget::Verify()
   progress.GetRaw()->setMinimumDuration(500);
   progress.GetRaw()->setWindowModality(Qt::WindowModal);
 
-  auto future = std::async(
-      std::launch::async,
-      [&verifier, &progress, DIVISOR]() -> std::optional<DiscIO::VolumeVerifier::Result> {
-        progress.SetValue(0);
-        verifier.Start();
-        while (verifier.GetBytesProcessed() != verifier.GetTotalBytes())
-        {
-          progress.SetValue(static_cast<int>(verifier.GetBytesProcessed() / DIVISOR));
-          if (progress.WasCanceled())
-            return std::nullopt;
+  auto future =
+      std::async(std::launch::async,
+                 [&verifier, &progress]() -> std::optional<DiscIO::VolumeVerifier::Result> {
+                   progress.SetValue(0);
+                   verifier.Start();
+                   while (verifier.GetBytesProcessed() != verifier.GetTotalBytes())
+                   {
+                     progress.SetValue(static_cast<int>(verifier.GetBytesProcessed() / DIVISOR));
+                     if (progress.WasCanceled())
+                       return std::nullopt;
 
-          verifier.Process();
-        }
-        verifier.Finish();
+                     verifier.Process();
+                   }
+                   verifier.Finish();
 
-        const DiscIO::VolumeVerifier::Result result = verifier.GetResult();
-        progress.Reset();
+                   const DiscIO::VolumeVerifier::Result result = verifier.GetResult();
+                   progress.Reset();
 
-        return result;
-      });
+                   return result;
+                 });
   progress.GetRaw()->exec();
 
   std::optional<DiscIO::VolumeVerifier::Result> result = future.get();

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -196,7 +196,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 
   mmio->Register(base | FIFO_BP_LO, MMIO::DirectRead<u16>(MMIO::Utils::LowPart(&fifo.CPBreakpoint)),
-                 MMIO::ComplexWrite<u16>([WMASK_LO_ALIGN_32BIT](u32, u16 val) {
+                 MMIO::ComplexWrite<u16>([](u32, u16 val) {
                    WriteLow(fifo.CPBreakpoint, val & WMASK_LO_ALIGN_32BIT);
                  }));
   mmio->Register(base | FIFO_BP_HI,


### PR DESCRIPTION
While manually capturing constexpr variables used in lambda expressions does work, it's really easy to forget doing so since we don't have a Windows CMake builder and the workaround isn't necessary anywhere else. Fortunately, MSVC has a flag that fixes the constexpr capture behavior, so let's use that instead.