### PR TITLE
Support the new MSVC preprocessor

### DIFF
--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -32,7 +32,7 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
 void SetEnableAlert(bool enable);
 }  // namespace Common
 
-#ifdef _WIN32
+#if defined(_WIN32) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1)
 #define SuccessAlert(format, ...)                                                                  \
   Common::MsgAlert(false, Common::MsgType::Information, format, __VA_ARGS__)
 

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -20,7 +20,7 @@ constexpr u32 MAX_XFB_WIDTH = 720;
 // that are next to each other in memory (TODO: handle that situation).
 constexpr u32 MAX_XFB_HEIGHT = 576;
 
-#ifdef _WIN32
+#if defined(_WIN32) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1)
 #define PRIM_LOG(...) DEBUG_LOG(VIDEO, __VA_ARGS__)
 #else
 #define PRIM_LOG(...) DEBUG_LOG(VIDEO, ##__VA_ARGS__)


### PR DESCRIPTION
Intends to fix https://bugs.dolphin-emu.org/issues/12170.

Untested, because I'm using VS 16.5 to avoid the std::result_of problem, and as far as I know the new preprocessor requires VS 16.6.