### PR TITLE
Timer fixes

### DIFF
--- a/Source/Core/Common/Timer.cpp
+++ b/Source/Core/Common/Timer.cpp
@@ -118,10 +118,9 @@ void Timer::AddTimeDifference()
 // Get the time elapsed since the Start()
 u64 Timer::GetTimeElapsed()
 {
-  // If we have not started yet, return 1 (because then I don't
-  // have to change the FPS calculation in CoreRerecording.cpp .
+  // If we have not started yet, return zero
   if (m_StartTime == 0)
-    return 1;
+    return 0;
 
   // Return the final timer time if the timer is stopped
   if (!m_Running)

--- a/Source/Core/Common/Timer.h
+++ b/Source/Core/Common/Timer.h
@@ -23,6 +23,8 @@ public:
   u64 GetTimeDifference();
   void AddTimeDifference();
 
+  bool IsRunning() const { return m_Running; }
+
   static void IncreaseResolution();
   static void RestoreResolution();
   static u64 GetTimeSinceJan1970();


### PR DESCRIPTION
Fixes the timer returning 1 when it should return 0. The case mentioned by the comment does not exist anymore.

Also added a IsRunning function as it was impossible to know whether it had been started or not (I will use it in later PRs but it should be there anyway)