### PR TITLE
Deprecate OpenAL

### DIFF
--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -51,7 +51,7 @@ struct BootParameters;
 #define BACKEND_NULLSOUND _trans("No Audio Output")
 #define BACKEND_ALSA "ALSA"
 #define BACKEND_CUBEB "Cubeb"
-#define BACKEND_OPENAL "OpenAL"
+#define BACKEND_OPENAL "OpenAL (Deprecated)"
 #define BACKEND_PULSEAUDIO "Pulse"
 #define BACKEND_OPENSLES "OpenSLES"
 #define BACKEND_WASAPI _trans("WASAPI (Exclusive Mode)")


### PR DESCRIPTION
This will also revert the setting of anyone that currently has OpenAL selected to the default, which is Cubeb.
OpenAL is only on Windows now, and it's the worst backend there by far, it crackles at latencies that Cubeb supports fine, it has no additional features to Cubeb.

There seems to be no reason to allow users to even select, and in the dev irc channel, no one was aware of any case where OpenAL might work better than Cubeb.
The plan is to see if users complain about this, and if not, just delete it from Dolphin.