### PR TITLE
Android: Update "Speed Limit" for "Unlimited" value

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -125,7 +125,7 @@
     <string name="general_submenu">General</string>
     <string name="dual_core">Dual Core</string>
     <string name="dual_core_description">Split workload to two CPU cores instead of one. Increases speed.</string>
-    <string name="speed_limit">Speed Limit</string>
+    <string name="speed_limit">Speed Limit (0% = Unlimited)</string>
     <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
     <string name="gamecube_submenu">GameCube</string>
     <string name="gamecube_system_language">System Language</string>


### PR DESCRIPTION
Changing this setting to 0% is how Dolphin interprets "Unlimited" speed limit.

@JMC47 