### PR TITLE
ControllerInterface/Wiimote: Provide fallback values for extensions with bad calibration.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/Wiimote.h
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/Wiimote.h
@@ -46,6 +46,12 @@ private:
     Unsupported,
   };
 
+  enum class Checksum
+  {
+    Good,
+    Bad,
+  };
+
   class MotionPlusState
   {
   public:
@@ -70,7 +76,7 @@ private:
   {
     using CalibrationData = WiimoteEmu::Nunchuk::CalibrationData;
 
-    void SetCalibrationData(const CalibrationData&);
+    void SetCalibrationData(const CalibrationData&, Checksum);
     void ProcessData(const WiimoteEmu::Nunchuk::DataFormat&);
 
     Common::Vec2 stick = {};
@@ -80,6 +86,8 @@ private:
 
     struct Calibration
     {
+      Calibration();
+
       CalibrationData::AccelCalibration accel;
       CalibrationData::StickCalibration stick;
     };
@@ -91,7 +99,7 @@ private:
   {
     using CalibrationData = WiimoteEmu::Classic::CalibrationData;
 
-    void SetCalibrationData(const CalibrationData&);
+    void SetCalibrationData(const CalibrationData&, Checksum);
     void ProcessData(const WiimoteEmu::Classic::DataFormat&);
 
     std::array<Common::Vec2, 2> sticks = {};
@@ -101,6 +109,8 @@ private:
 
     struct Calibration
     {
+      Calibration();
+
       CalibrationData::StickCalibration left_stick;
       CalibrationData::StickCalibration right_stick;
 


### PR DESCRIPTION
Some Nunchuks and Classic Controllers have bad calibration data.
This was causing unusable inputs in ControllerInterface Wii Remotes (aka Hybrid Wiimote 2.0).

This PR adds fallback values to make things mostly usable if the calibration checksum is bad or values are not sane.
The sanity check is just that "min" and "max" values are on opposite sides of the "zero" value.

This fixes:
https://bugs.dolphin-emu.org/issues/12088
https://bugs.dolphin-emu.org/issues/12027