### PR TITLE
Disable ICache emulation for some games

### DIFF
--- a/Data/Sys/GameSettings/G5D.ini
+++ b/Data/Sys/GameSettings/G5D.ini
@@ -1,4 +1,4 @@
-# GE9E5D - Ed, Edd n Eddy
+# G5DE78, G5DP78 - Scooby-Doo! Unmasked
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -15,7 +15,3 @@ HLE_BS2 = True
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-

--- a/Data/Sys/GameSettings/GC3.ini
+++ b/Data/Sys/GameSettings/GC3.ini
@@ -1,4 +1,4 @@
-# GE9E5D - Ed, Edd n Eddy
+# GC3F78, GC3P78, GC3D78, GC3E78 - Scooby-Doo! Mystery Mayhem
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -15,7 +15,3 @@ HLE_BS2 = True
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
-

--- a/Data/Sys/GameSettings/RHF.ini
+++ b/Data/Sys/GameSettings/RHF.ini
@@ -2,3 +2,5 @@
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+# The JIT cache causes problems with emulated icache invalidation in this game resulting in a crash on starting the game
+DisableICache = True

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -81,6 +81,7 @@ private:
   bool bAccurateNaNs;
   bool bMMU;
   bool bLowDCBZHack;
+  bool bDisableICache;
   bool m_EnableJIT;
   bool bSyncGPU;
   int iSyncGpuMaxDistance;
@@ -113,6 +114,7 @@ void ConfigCache::SaveConfig(const SConfig& config)
   bSyncGPUOnSkipIdleHack = config.bSyncGPUOnSkipIdleHack;
   bFPRF = config.bFPRF;
   bAccurateNaNs = config.bAccurateNaNs;
+  bDisableICache = config.bDisableICache;
   bMMU = config.bMMU;
   m_EnableJIT = config.m_DSPEnableJIT;
   bSyncGPU = config.bSyncGPU;
@@ -158,6 +160,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bSyncGPUOnSkipIdleHack = bSyncGPUOnSkipIdleHack;
   config->bFPRF = bFPRF;
   config->bAccurateNaNs = bAccurateNaNs;
+  config->bDisableICache = bDisableICache;
   config->bMMU = bMMU;
   config->bLowDCBZHack = bLowDCBZHack;
   config->m_DSPEnableJIT = m_EnableJIT;
@@ -260,6 +263,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
                       StartUp.bSyncGPUOnSkipIdleHack);
     core_section->Get("FPRF", &StartUp.bFPRF, StartUp.bFPRF);
     core_section->Get("AccurateNaNs", &StartUp.bAccurateNaNs, StartUp.bAccurateNaNs);
+    core_section->Get("DisableICache", &StartUp.bDisableICache, StartUp.bDisableICache);
     core_section->Get("MMU", &StartUp.bMMU, StartUp.bMMU);
     core_section->Get("LowDCBZHack", &StartUp.bLowDCBZHack, StartUp.bLowDCBZHack);
     core_section->Get("SyncGPU", &StartUp.bSyncGPU, StartUp.bSyncGPU);
@@ -371,6 +375,7 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     config_cache.bSetEXIDevice[2] = true;
     StartUp.bFPRF = netplay_settings.m_FPRF;
     StartUp.bAccurateNaNs = netplay_settings.m_AccurateNaNs;
+    StartUp.bDisableICache = netplay_settings.m_DisableICache;
     StartUp.bSyncGPUOnSkipIdleHack = netplay_settings.m_SyncOnSkipIdle;
     StartUp.bSyncGPU = netplay_settings.m_SyncGPU;
     StartUp.iSyncGpuMaxDistance = netplay_settings.m_SyncGpuMaxDistance;

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -94,6 +94,7 @@ const Info<bool> MAIN_FAST_DISC_SPEED{{System::Main, "Core", "FastDiscSpeed"}, f
 const Info<bool> MAIN_LOW_DCBZ_HACK{{System::Main, "Core", "LowDCBZHack"}, false};
 const Info<bool> MAIN_FPRF{{System::Main, "Core", "FPRF"}, false};
 const Info<bool> MAIN_ACCURATE_NANS{{System::Main, "Core", "AccurateNaNs"}, false};
+const Info<bool> MAIN_DISABLE_ICACHE{{System::Main, "Core", "DisableICache"}, false};
 const Info<float> MAIN_EMULATION_SPEED{{System::Main, "Core", "EmulationSpeed"}, 1.0f};
 const Info<float> MAIN_OVERCLOCK{{System::Main, "Core", "Overclock"}, 1.0f};
 const Info<bool> MAIN_OVERCLOCK_ENABLE{{System::Main, "Core", "OverclockEnable"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -74,6 +74,7 @@ extern const Info<bool> MAIN_FAST_DISC_SPEED;
 extern const Info<bool> MAIN_LOW_DCBZ_HACK;
 extern const Info<bool> MAIN_FPRF;
 extern const Info<bool> MAIN_ACCURATE_NANS;
+extern const Info<bool> MAIN_DISABLE_ICACHE;
 extern const Info<float> MAIN_EMULATION_SPEED;
 extern const Info<float> MAIN_OVERCLOCK;
 extern const Info<bool> MAIN_OVERCLOCK_ENABLE;

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -67,6 +67,7 @@ public:
     layer->Set(Config::GFX_PERF_QUERIES_ENABLE, m_settings.m_PerfQueriesEnable);
     layer->Set(Config::MAIN_FPRF, m_settings.m_FPRF);
     layer->Set(Config::MAIN_ACCURATE_NANS, m_settings.m_AccurateNaNs);
+    layer->Set(Config::MAIN_DISABLE_ICACHE, m_settings.m_DisableICache);
     layer->Set(Config::MAIN_SYNC_ON_SKIP_IDLE, m_settings.m_SyncOnSkipIdle);
     layer->Set(Config::MAIN_SYNC_GPU, m_settings.m_SyncGPU);
     layer->Set(Config::MAIN_SYNC_GPU_MAX_DISTANCE, m_settings.m_SyncGpuMaxDistance);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -512,6 +512,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("LowDCBZHack", &bLowDCBZHack, false);
   core->Get("FPRF", &bFPRF, false);
   core->Get("AccurateNaNs", &bAccurateNaNs, false);
+  core->Get("DisableICache", &bDisableICache, false);
   core->Get("EmulationSpeed", &m_EmulationSpeed, 1.0f);
   core->Get("Overclock", &m_OCFactor, 1.0f);
   core->Get("OverclockEnable", &m_OCEnable, false);
@@ -749,6 +750,7 @@ void SConfig::LoadDefaults()
   bFastmem = true;
   bFPRF = false;
   bAccurateNaNs = false;
+  bDisableICache = false;
   bMMU = false;
   bLowDCBZHack = false;
   iBBDumpPort = -1;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -111,6 +111,7 @@ struct SConfig
   bool bFastmem;
   bool bFPRF = false;
   bool bAccurateNaNs = false;
+  bool bDisableICache = false;
 
   int iTimingVariance = 40;  // in milli secounds
   bool bCPUThread = true;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -691,6 +691,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_PerfQueriesEnable;
       packet >> m_net_settings.m_FPRF;
       packet >> m_net_settings.m_AccurateNaNs;
+      packet >> m_net_settings.m_DisableICache;
       packet >> m_net_settings.m_SyncOnSkipIdle;
       packet >> m_net_settings.m_SyncGPU;
       packet >> m_net_settings.m_SyncGpuMaxDistance;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -58,6 +58,7 @@ struct NetSettings
   bool m_PerfQueriesEnable;
   bool m_FPRF;
   bool m_AccurateNaNs;
+  bool m_DisableICache;
   bool m_SyncOnSkipIdle;
   bool m_SyncGPU;
   int m_SyncGpuMaxDistance;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1331,6 +1331,7 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_PerfQueriesEnable;
   spac << m_settings.m_FPRF;
   spac << m_settings.m_AccurateNaNs;
+  spac << m_settings.m_DisableICache;
   spac << m_settings.m_SyncOnSkipIdle;
   spac << m_settings.m_SyncGPU;
   spac << m_settings.m_SyncGpuMaxDistance;

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -8,6 +8,7 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/Swap.h"
+#include "Core/ConfigManager.h"
 #include "Core/DolphinAnalytics.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/JitInterface.h"
@@ -110,7 +111,7 @@ void InstructionCache::Init()
 
 void InstructionCache::Invalidate(u32 addr)
 {
-  if (!HID0.ICE)
+  if (!HID0.ICE || SConfig::GetInstance().bDisableICache)
     return;
 
   // Invalidates the whole set
@@ -133,7 +134,7 @@ void InstructionCache::Invalidate(u32 addr)
 
 u32 InstructionCache::ReadInstruction(u32 addr)
 {
-  if (!HID0.ICE)  // instruction cache is disabled
+  if (!HID0.ICE || SConfig::GetInstance().bDisableICache)  // instruction cache is disabled
     return Memory::Read_U32(addr);
   u32 set = (addr >> 5) & 0x7f;
   u32 tag = addr >> 12;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -485,6 +485,7 @@ void NetPlayDialog::OnStart()
   settings.m_PerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);
   settings.m_FPRF = Config::Get(Config::MAIN_FPRF);
   settings.m_AccurateNaNs = Config::Get(Config::MAIN_ACCURATE_NANS);
+  settings.m_DisableICache = Config::Get(Config::MAIN_DISABLE_ICACHE);
   settings.m_SyncOnSkipIdle = Config::Get(Config::MAIN_SYNC_ON_SKIP_IDLE);
   settings.m_SyncGPU = Config::Get(Config::MAIN_SYNC_GPU);
   settings.m_SyncGpuMaxDistance = Config::Get(Config::MAIN_SYNC_GPU_MAX_DISTANCE);


### PR DESCRIPTION
Specifically, 'Scooby-Doo! Mystery Mayhem' ([Bug 9561](https://bugs.dolphin-emu.org/issues/9561)) and 'Ed, Edd n Eddy: The Mis-Edventures'.

For Scooby-Doo!, I tested by loading the credits under the extras menu.  Prior to this change, it would fail to load; now, it loads successfully (even on exiting and re-entering the credits).  I haven't tested much actual gameplay.  I was also unable to confirm that there was ever an issue with loading save files; saving and loading at the first camera works fine in 5.0-12247.

For Ed, Edd n Eddy, the fix is only meaningful when combined with #8935; see https://github.com/dolphin-emu/dolphin/pull/8935#issuecomment-653928322.  (**EDIT**: It also is only necessary when MMU is disabled; the icache issue doesn't come up with MMU enabled.)

There may be other games that need this fix (for instance, I see [Bug 10177](https://bugs.dolphin-emu.org/issues/10177) for Scooby Doo! Unmasked).  I don't own that game, so I don't know if it's a similar issue.