### PR TITLE
DolphinQt: Attempt to fix ParallelProgressDialog constantly reopening

### DIFF
--- a/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
+++ b/Source/Core/DolphinQt/QtUtils/ParallelProgressDialog.h
@@ -71,8 +71,12 @@ private slots:
 
     m_is_setting_value = true;
 
-    while (m_last_received_progress != m_dialog.value())
+    int last_set_progress;
+    do
+    {
+      last_set_progress = m_last_received_progress;
       m_dialog.setValue(m_last_received_progress);
+    } while (m_last_received_progress != last_set_progress);
 
     m_is_setting_value = false;
   }


### PR DESCRIPTION
I believe the value returned by value() resets when we call setValue() with the maximum (due to auto-reset). I have been unable to test this because I can't reproduce the issue, which is described at https://bugs.dolphin-emu.org/issues/12158#note-9.