### PR TITLE
WiimoteEmu: Allow writes of the i2c bus to play speaker data.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -389,10 +389,9 @@ void Wiimote::HandleSpeakerData(const WiimoteCommon::OutputReportSpeakerData& rp
     }
     else
     {
-      // Speaker Pan
-      const auto pan = m_speaker_pan_setting.GetValue() / 100;
-
-      m_speaker_logic.SpeakerData(rpt.data, rpt.length, pan);
+      // Speaker data reports result in a write to the speaker hardware at offset 0x00.
+      m_i2c_bus.BusWrite(SpeakerLogic::I2C_ADDR, SpeakerLogic::SPEAKER_DATA_OFFSET, rpt.length,
+                         rpt.data);
     }
   }
 

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -197,7 +197,7 @@ int SpeakerLogic::BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in)
 
   if (0x00 == addr)
   {
-    ERROR_LOG(WIIMOTE, "Writing of speaker data to address 0x00 is unimplemented!");
+    SpeakerData(data_in, count, m_speaker_pan_setting.GetValue() / 100);
     return count;
   }
   else

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.h
@@ -7,6 +7,7 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/I2CBus.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 
 namespace WiimoteEmu
 {
@@ -15,18 +16,24 @@ struct ADPCMState
   s32 predictor, step;
 };
 
+class Wiimote;
+
 class SpeakerLogic : public I2CSlave
 {
+  friend class Wiimote;
+
 public:
   static const u8 I2C_ADDR = 0x51;
+
+  static constexpr u8 SPEAKER_DATA_OFFSET = 0x00;
 
   void Reset();
   void DoState(PointerWrap& p);
 
+private:
   // Pan is -1.0 to +1.0
   void SpeakerData(const u8* data, int length, float speaker_pan);
 
-private:
   // TODO: enum class
   static const u8 DATA_FORMAT_ADPCM = 0x00;
   static const u8 DATA_FORMAT_PCM = 0x40;
@@ -63,6 +70,8 @@ private:
   // TODO: What actions reset this state?
   // Is this actually in the register somewhere?
   ADPCMState adpcm_state;
+
+  ControllerEmu::SettingValue<double> m_speaker_pan_setting;
 };
 
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -246,7 +246,7 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
   // Options
   groups.emplace_back(m_options = new ControllerEmu::ControlGroup(_trans("Options")));
 
-  m_options->AddSetting(&m_speaker_pan_setting,
+  m_options->AddSetting(&m_speaker_logic.m_speaker_pan_setting,
                         {_trans("Speaker Pan"),
                          // i18n: The percent symbol.
                          _trans("%")},

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -263,7 +263,6 @@ private:
   ControllerEmu::SettingValue<bool> m_sideways_setting;
   ControllerEmu::SettingValue<bool> m_upright_setting;
   ControllerEmu::SettingValue<double> m_battery_setting;
-  ControllerEmu::SettingValue<double> m_speaker_pan_setting;
   ControllerEmu::SettingValue<bool> m_motion_plus_setting;
 
   SpeakerLogic m_speaker_logic;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -75,11 +75,11 @@ public:
 
   template <typename T>
   void AddSetting(SettingValue<T>* value, const NumericSettingDetails& details,
-                  std::common_type_t<T> default_value, std::common_type_t<T> min_value = {},
+                  std::common_type_t<T> default_value_, std::common_type_t<T> min_value = {},
                   std::common_type_t<T> max_value = T(100))
   {
     numeric_settings.emplace_back(
-        std::make_unique<NumericSetting<T>>(value, details, default_value, min_value, max_value));
+        std::make_unique<NumericSetting<T>>(value, details, default_value_, min_value, max_value));
   }
 
   void AddDeadzoneSetting(SettingValue<double>* value, double maximum_deadzone);


### PR DESCRIPTION
Wii remote speaker data reports result in a write to the i2c bus on real hardware.
Explicitly sending the relevant write data reports will produce sound.

I'm guessing a specific "speaker data" report exists to avoid the overhead of sending i2c addresses and allow 20 bytes per report (vs 16).

Regardless, writing to the bus to produce sound is now supported.
Nothing will ever use this but it's a more accurate hardware simulation.