### PR TITLE
Android: Use system cache directory as cache directory

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -366,6 +366,8 @@ public final class NativeLibrary
    */
   public static native String GetUserDirectory();
 
+  public static native void SetCacheDirectory(String directory);
+
   public static native int DefaultCPUCore();
 
   public static native void ReloadConfig();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
@@ -1,5 +1,6 @@
 package org.dolphinemu.dolphinemu.model;
 
+import android.content.Context;
 import android.os.Environment;
 
 public class GameFile
@@ -54,10 +55,9 @@ public class GameFile
 
   public native int getBannerHeight();
 
-  public String getCoverPath()
+  public String getCoverPath(Context context)
   {
-    return Environment.getExternalStorageDirectory().getPath() +
-            "/dolphin-emu/Cache/GameCovers/" + getGameTdbId() + ".png";
+    return context.getExternalCacheDir().getPath() + "/GameCovers/" + getGameTdbId() + ".png";
   }
 
   public String getCustomCoverPath()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -64,7 +64,7 @@ public final class DirectoryInitialization
     {
       if (PermissionsHandler.hasWriteAccess(context))
       {
-        if (setDolphinUserDirectory())
+        if (setDolphinUserDirectory(context))
         {
           initializeInternalStorage(context);
           initializeExternalStorage(context);
@@ -88,22 +88,27 @@ public final class DirectoryInitialization
     sendBroadcastState(directoryState, context);
   }
 
-  private static boolean setDolphinUserDirectory()
+  private static boolean setDolphinUserDirectory(Context context)
   {
-    if (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState()))
-    {
-      File externalPath = Environment.getExternalStorageDirectory();
-      if (externalPath != null)
-      {
-        userPath = externalPath.getAbsolutePath() + "/dolphin-emu";
-        Log.debug("[DirectoryInitialization] User Dir: " + userPath);
-        NativeLibrary.SetUserDirectory(userPath);
-        return true;
-      }
+    if (!Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState()))
+      return false;
 
-    }
+    File externalPath = Environment.getExternalStorageDirectory();
+    if (externalPath == null)
+      return false;
 
-    return false;
+    userPath = externalPath.getAbsolutePath() + "/dolphin-emu";
+    Log.debug("[DirectoryInitialization] User Dir: " + userPath);
+    NativeLibrary.SetUserDirectory(userPath);
+
+    File cacheDir = context.getExternalCacheDir();
+    if (cacheDir == null)
+      return false;
+
+    Log.debug("[DirectoryInitialization] Cache Dir: " + cacheDir.getPath());
+    NativeLibrary.SetCacheDirectory(cacheDir.getPath());
+
+    return true;
   }
 
   private static void initializeInternalStorage(Context context)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
@@ -1,5 +1,6 @@
 package org.dolphinemu.dolphinemu.utils;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
@@ -33,6 +34,7 @@ public class PicassoUtils
 
   public static void loadGameCover(ImageView imageView, GameFile gameFile)
   {
+    Context context = imageView.getContext();
     File cover = new File(gameFile.getCustomCoverPath());
     if (cover.exists())
     {
@@ -46,7 +48,7 @@ public class PicassoUtils
               .error(R.drawable.no_banner)
               .into(imageView);
     }
-    else if ((cover = new File(gameFile.getCoverPath())).exists())
+    else if ((cover = new File(gameFile.getCoverPath(context))).exists())
     {
       Picasso.get()
               .load(cover)
@@ -76,7 +78,7 @@ public class PicassoUtils
                 public void onSuccess()
                 {
                   CoverHelper.saveCover(((BitmapDrawable) imageView.getDrawable()).getBitmap(),
-                          gameFile.getCoverPath());
+                          gameFile.getCoverPath(context));
                 }
 
                 @Override
@@ -98,7 +100,7 @@ public class PicassoUtils
                             {
                               CoverHelper.saveCover(
                                       ((BitmapDrawable) imageView.getDrawable()).getBitmap(),
-                                      gameFile.getCoverPath());
+                                      gameFile.getCoverPath(context));
                             }
 
                             @Override
@@ -121,7 +123,7 @@ public class PicassoUtils
                                           CoverHelper.saveCover(
                                                   ((BitmapDrawable) imageView.getDrawable())
                                                           .getBitmap(),
-                                                  gameFile.getCoverPath());
+                                                  gameFile.getCoverPath(context));
                                         }
 
                                         @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
@@ -168,7 +168,7 @@ public class TvUtil
       {
         contentUri = getUriForFile(context, getFileProvider(context), cover);
       }
-      else if ((cover = new File(game.getCoverPath())).exists())
+      else if ((cover = new File(game.getCoverPath(context))).exists())
       {
         contentUri = getUriForFile(context, getFileProvider(context), cover);
       }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -240,6 +240,8 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirec
     JNIEnv* env, jobject obj, jstring jDirectory);
 JNIEXPORT jstring JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDirectory(JNIEnv* env, jobject obj);
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetCacheDirectory(
+    JNIEnv* env, jobject obj, jstring jDirectory);
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv* env,
                                                                                    jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling(JNIEnv* env,
@@ -532,6 +534,13 @@ JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDi
                                                                                         jobject obj)
 {
   return ToJString(env, File::GetUserPath(D_USER_IDX).c_str());
+}
+
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetCacheDirectory(
+    JNIEnv* env, jobject obj, jstring jDirectory)
+{
+  std::lock_guard<std::mutex> guard(s_host_identity_lock);
+  File::SetUserPath(D_CACHE_IDX, GetJString(env, jDirectory) + DIR_SEP);
 }
 
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv* env,


### PR DESCRIPTION
This lets Android automatically delete data in the cache directory when the device is running low on space or when Dolphin is uninstalled.