### PR TITLE
Android: Increase targetSdkVersion to 29

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -22,7 +22,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
 
         versionCode(getBuildVersionCode())
 

--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         android:name=".DolphinApplication"
         android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="false"
         android:supportsRtl="true"
         android:isGame="true"


### PR DESCRIPTION
Since updating to 28 took us so long that Google Play started requiring updates to target 28 before we actually merged the PR that made us target 28, I'm trying to get the update to 29 done early.

Setting targetSdkVersion to 28 would normally force scoped storage on us, which we do not support yet. However, we can easily avoid this by setting android:requestLegacyExternalStorage="true". There will be no such luxury with targetSdkVersion 30, however...