### PR TITLE
Revert "Android: Increase targetSdkVersion to 29"

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -22,7 +22,7 @@ android {
         // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 28
 
         versionCode(getBuildVersionCode())
 

--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,6 @@
         android:name=".DolphinApplication"
         android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"
-        android:requestLegacyExternalStorage="true"
         android:allowBackup="false"
         android:supportsRtl="true"
         android:isGame="true"


### PR DESCRIPTION
This reverts commit 95945a000eaf168e19516739582efbdab2253990.

Quickfix for the same problem as PR #8955 (starting emulation is broken on Android 10), since I believe it might take a little while for that PR to get into a mergeable state.