### PR TITLE
Add Android check for strerror_r variant

### DIFF
--- a/Source/Core/Common/CommonFuncs.cpp
+++ b/Source/Core/Common/CommonFuncs.cpp
@@ -29,7 +29,8 @@ std::string LastStrerrorString()
   // We check defines in order to figure out variant is in use, and we store the returned value
   // to a variable so that we'll get a compile-time check that our assumption was correct.
 
-#if defined(__GLIBC__) && (_GNU_SOURCE || (_POSIX_C_SOURCE < 200112L && _XOPEN_SOURCE < 600))
+#if (defined(__GLIBC__) || __ANDROID_API__ >= 23) &&                                               \
+    (_GNU_SOURCE || (_POSIX_C_SOURCE < 200112L && _XOPEN_SOURCE < 600))
   const char* str = strerror_r(errno, error_message, BUFFER_SIZE);
   return std::string(str);
 #else


### PR DESCRIPTION
I don't know why Android does it like this, but at least it's easy to fix. (We are currently at `__ANDROID_API__` == 21.)