### PR TITLE
DolphinQt: Fix default sort direction of game list.

### DIFF
--- a/Source/Core/DolphinQt/GameList/ListProxyModel.cpp
+++ b/Source/Core/DolphinQt/GameList/ListProxyModel.cpp
@@ -19,7 +19,7 @@ bool ListProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_
 bool ListProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
 {
   if (left.data(Qt::InitialSortOrderRole) != right.data(Qt::InitialSortOrderRole))
-    return QSortFilterProxyModel::lessThan(right, left);
+    return QSortFilterProxyModel::lessThan(left, right);
 
   // If two items are otherwise equal, compare them by their title
   const auto right_title =


### PR DESCRIPTION
This fixes the root cause of the problem of #8887.
The sort direction was inadvertently inverted in the proxy providing the secondary sort key.