### PR TITLE
DolphinQt: Replace unusual Qt::InitialSortOrderRole usage with a custom role.

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -59,7 +59,7 @@ GameList::GameList(QWidget* parent) : QStackedWidget(parent)
   m_model = Settings::Instance().GetGameListModel();
   m_list_proxy = new ListProxyModel(this);
   m_list_proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
-  m_list_proxy->setSortRole(Qt::InitialSortOrderRole);
+  m_list_proxy->setSortRole(GameListModel::SORT_ROLE);
   m_list_proxy->setSourceModel(m_model);
   m_grid_proxy = new GridProxyModel(this);
   m_grid_proxy->setSourceModel(m_model);

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -63,13 +63,13 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_PLATFORM:
     if (role == Qt::DecorationRole)
       return Resources::GetPlatform(game.GetPlatform());
-    if (role == Qt::InitialSortOrderRole)
+    if (role == SORT_ROLE)
       return static_cast<int>(game.GetPlatform());
     break;
   case COL_COUNTRY:
     if (role == Qt::DecorationRole)
       return Resources::GetCountry(game.GetCountry());
-    if (role == Qt::InitialSortOrderRole)
+    if (role == SORT_ROLE)
       return static_cast<int>(game.GetCountry());
     break;
   case COL_BANNER:
@@ -88,7 +88,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     }
     break;
   case COL_TITLE:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
     {
       QString name = QString::fromStdString(game.GetName(m_title_database));
 
@@ -103,7 +103,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
       }
 
       // For natural sorting, pad all numbers to the same length.
-      if (Qt::InitialSortOrderRole == role)
+      if (SORT_ROLE == role)
       {
         constexpr int MAX_NUMBER_LENGTH = 10;
 
@@ -120,11 +120,11 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     }
     break;
   case COL_ID:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
       return QString::fromStdString(game.GetGameID());
     break;
   case COL_DESCRIPTION:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
     {
       return QString::fromStdString(
                  game.GetDescription(UICommon::GameFile::Variant::LongAndPossiblyCustom))
@@ -132,18 +132,18 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     }
     break;
   case COL_MAKER:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
     {
       return QString::fromStdString(
           game.GetMaker(UICommon::GameFile::Variant::LongAndPossiblyCustom));
     }
     break;
   case COL_FILE_NAME:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
       return QString::fromStdString(game.GetFileName());
     break;
   case COL_FILE_PATH:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
     {
       QString file_path = QDir::toNativeSeparators(
           QFileInfo(QString::fromStdString(game.GetFilePath())).absolutePath());
@@ -163,11 +163,11 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
 
       return QString::fromStdString(str);
     }
-    if (role == Qt::InitialSortOrderRole)
+    if (role == SORT_ROLE)
       return static_cast<quint64>(game.GetFileSize());
     break;
   case COL_FILE_FORMAT:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
     {
       if (game.ShouldShowFileFormatDetails())
         return QString::fromStdString(DiscIO::GetName(game.GetBlobType(), true));
@@ -178,18 +178,18 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
   case COL_BLOCK_SIZE:
     if (role == Qt::DisplayRole)
       return QString::fromStdString(UICommon::FormatSize(game.GetBlockSize()));
-    if (role == Qt::InitialSortOrderRole)
+    if (role == SORT_ROLE)
       return static_cast<quint64>(game.GetBlockSize());
     break;
   case COL_COMPRESSION:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
     {
       const QString compression = QString::fromStdString(game.GetCompressionMethod());
       return compression.isEmpty() ? tr("No Compression") : compression;
     }
     break;
   case COL_TAGS:
-    if (role == Qt::DisplayRole || role == Qt::InitialSortOrderRole)
+    if (role == Qt::DisplayRole || role == SORT_ROLE)
     {
       auto tags = GetGameTags(game.GetFilePath());
       tags.sort();

--- a/Source/Core/DolphinQt/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt/GameList/GameListModel.h
@@ -44,6 +44,9 @@ public:
   bool ShouldDisplayGameListItem(int index) const;
   void SetSearchTerm(const QString& term);
 
+  // Using a custom sort role as it sometimes differs slightly from the default Qt::DisplayRole.
+  static constexpr int SORT_ROLE = Qt::UserRole;
+
   enum
   {
     COL_PLATFORM = 0,

--- a/Source/Core/DolphinQt/GameList/ListProxyModel.cpp
+++ b/Source/Core/DolphinQt/GameList/ListProxyModel.cpp
@@ -18,7 +18,7 @@ bool ListProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_
 
 bool ListProxyModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
 {
-  if (left.data(Qt::InitialSortOrderRole) != right.data(Qt::InitialSortOrderRole))
+  if (left.data(GameListModel::SORT_ROLE) != right.data(GameListModel::SORT_ROLE))
     return QSortFilterProxyModel::lessThan(left, right);
 
   // If two items are otherwise equal, compare them by their title


### PR DESCRIPTION
Our usage of `Qt::InitialSortOrderRole` as the sort role in our `GameListModel` is unusual.

> This role is used to obtain the initial sort order of a header view section. (Qt::SortOrder). This role was introduced in Qt 4.8.

It's intended to return a `Qt::SortOrder` (ascending/descending) in an entirely different overridden function.

While our usage probably isn't breaking anything it's unusual and had me barking up wrong trees in Qt documentation.