### PR TITLE
HW/GCPadEmu: Adjust gate radius values to more closely match the real hardware.

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -64,14 +64,10 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
   }
 
   // sticks
-  constexpr auto main_gate_radius =
-      ControlState(MAIN_STICK_GATE_RADIUS) / GCPadStatus::MAIN_STICK_RADIUS;
   groups.emplace_back(m_main_stick = new ControllerEmu::OctagonAnalogStick(
-                          "Main Stick", _trans("Control Stick"), main_gate_radius));
-
-  constexpr auto c_gate_radius = ControlState(C_STICK_GATE_RADIUS) / GCPadStatus::C_STICK_RADIUS;
+                          "Main Stick", _trans("Control Stick"), MAIN_STICK_GATE_RADIUS));
   groups.emplace_back(m_c_stick = new ControllerEmu::OctagonAnalogStick(
-                          "C-Stick", _trans("C Stick"), c_gate_radius));
+                          "C-Stick", _trans("C Stick"), C_STICK_GATE_RADIUS));
 
   // triggers
   groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -46,8 +46,9 @@ public:
 
   void LoadDefaults(const ControllerInterface& ciface) override;
 
-  static const u8 MAIN_STICK_GATE_RADIUS = 87;
-  static const u8 C_STICK_GATE_RADIUS = 74;
+  // Values averaged from multiple genuine GameCube controllers.
+  static constexpr ControlState MAIN_STICK_GATE_RADIUS = 0.7937125;
+  static constexpr ControlState C_STICK_GATE_RADIUS = 0.7221375;
 
 private:
   ControllerEmu::Buttons* m_buttons;


### PR DESCRIPTION
The old values were based on the clamping done by the SDK which worked out to around 68% and 58%.
These new values are based on actual hardware: ~79% and ~72%.

The calibration shape of a real GameCube controller is now much closer to our target "gate" shape.

Before:
![image](https://user-images.githubusercontent.com/1768214/87877759-b6177980-c9a5-11ea-988d-cbb89a15a0f2.png)


After:
![image](https://user-images.githubusercontent.com/1768214/87877726-93856080-c9a5-11ea-8b36-d1a21fef8277.png)


I've heard reports of users not being able to make their character run in Madden games without boosting their input values.
This should help with that.