### PR TITLE
Fix disc image conversion button not being clear #2

### DIFF
--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -49,7 +49,7 @@ ConvertDialog::ConvertDialog(QList<std::shared_ptr<const UICommon::GameFile>> fi
 {
   ASSERT(!m_files.empty());
 
-  setWindowTitle(tr("Convert"));
+  setWindowTitle(tr("Convert..."));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QGridLayout* grid_layout = new QGridLayout;


### PR DESCRIPTION
It wasn't clear whether the conversion would create a new file or replace the old one

Recreated https://github.com/dolphin-emu/dolphin/pull/8952 directly from github