### PR TITLE
Port some settings to the new config system

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -21,6 +21,7 @@
 #include "Common/Analytics.h"
 #include "Common/CPUDetect.h"
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/Random.h"
 #include "Common/Timer.h"
 #include "Common/Version.h"
@@ -65,7 +66,7 @@ void DolphinAnalytics::ReloadConfig()
 
   // Install the HTTP backend if analytics support is enabled.
   std::unique_ptr<Common::AnalyticsReportingBackend> new_backend;
-  if (SConfig::GetInstance().m_analytics_enabled)
+  if (Config::Get(Config::MAIN_ANALYTICS_ENABLED))
   {
 #if defined(ANDROID)
     new_backend = std::make_unique<Common::AndroidAnalyticsBackend>(ANALYTICS_ENDPOINT);
@@ -76,7 +77,7 @@ void DolphinAnalytics::ReloadConfig()
   m_reporter.SetBackend(std::move(new_backend));
 
   // Load the unique ID or generate it if needed.
-  m_unique_id = SConfig::GetInstance().m_analytics_id;
+  m_unique_id = Config::Get(Config::MAIN_ANALYTICS_ID);
   if (m_unique_id.empty())
   {
     GenerateNewIdentity();
@@ -90,8 +91,8 @@ void DolphinAnalytics::GenerateNewIdentity()
   m_unique_id = fmt::format("{:016x}{:016x}", id_high, id_low);
 
   // Save the new id in the configuration.
-  SConfig::GetInstance().m_analytics_id = m_unique_id;
-  SConfig::GetInstance().SaveSettings();
+  Config::SetBase(Config::MAIN_ANALYTICS_ID, m_unique_id);
+  Config::Save();
 }
 
 std::string DolphinAnalytics::MakeUniqueId(std::string_view data) const

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -106,6 +106,7 @@ const Info<bool> MAIN_CUSTOM_RTC_ENABLE{{System::Main, "Core", "EnableCustomRTC"
 const Info<u32> MAIN_CUSTOM_RTC_VALUE{{System::Main, "Core", "CustomRTCValue"}, 946684800};
 const Info<bool> MAIN_AUTO_DISC_CHANGE{{System::Main, "Core", "AutoDiscChange"}, false};
 const Info<bool> MAIN_ALLOW_SD_WRITES{{System::Main, "Core", "WiiSDCardAllowWrites"}, true};
+const Info<bool> MAIN_ENABLE_SAVESTATES{{System::Main, "Core", "EnableSaveStates"}, false};
 
 // Main.Display
 
@@ -153,5 +154,15 @@ const Info<bool> MAIN_NETWORK_SSL_DUMP_PEER_CERT{{System::Main, "Network", "SSLD
 
 // Main.Interface
 
+const Info<bool> MAIN_USE_PANIC_HANDLERS{{System::Main, "Interface", "UsePanicHandlers"}, true};
+const Info<bool> MAIN_OSD_MESSAGES{{System::Main, "Interface", "OnScreenDisplayMessages"}, true};
 const Info<bool> MAIN_SKIP_NKIT_WARNING{{System::Main, "Interface", "SkipNKitWarning"}, false};
+
+// Main.Analytics
+
+const Info<std::string> MAIN_ANALYTICS_ID{{System::Main, "Analytics", "ID"}, ""};
+const Info<bool> MAIN_ANALYTICS_ENABLED{{System::Main, "Analytics", "Enabled"}, false};
+const Info<bool> MAIN_ANALYTICS_PERMISSION_ASKED{{System::Main, "Analytics", "PermissionAsked"},
+                                                 false};
+
 }  // namespace Config

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -87,6 +87,7 @@ extern const Info<bool> MAIN_CUSTOM_RTC_ENABLE;
 extern const Info<u32> MAIN_CUSTOM_RTC_VALUE;
 extern const Info<bool> MAIN_AUTO_DISC_CHANGE;
 extern const Info<bool> MAIN_ALLOW_SD_WRITES;
+extern const Info<bool> MAIN_ENABLE_SAVESTATES;
 
 // Main.DSP
 
@@ -129,5 +130,13 @@ extern const Info<bool> MAIN_NETWORK_SSL_DUMP_PEER_CERT;
 
 // Main.Interface
 
+extern const Info<bool> MAIN_USE_PANIC_HANDLERS;
+extern const Info<bool> MAIN_OSD_MESSAGES;
 extern const Info<bool> MAIN_SKIP_NKIT_WARNING;
+
+// Main.Analytics
+
+extern const Info<std::string> MAIN_ANALYTICS_ID;
+extern const Info<bool> MAIN_ANALYTICS_ENABLED;
+extern const Info<bool> MAIN_ANALYTICS_PERMISSION_ASKED;
 }  // namespace Config

--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -10,7 +10,11 @@ namespace Config
 
 const Info<bool> MAIN_USE_DISCORD_PRESENCE{{System::Main, "General", "UseDiscordPresence"}, true};
 const Info<bool> MAIN_USE_GAME_COVERS{{System::Main, "General", "UseGameCovers"}, false};
-
 const Info<bool> MAIN_FOCUSED_HOTKEYS{{System::Main, "General", "HotkeysRequireFocus"}, true};
+const Info<bool> MAIN_RECURSIVE_ISO_PATHS{{System::Main, "General", "RecursiveISOPaths"}, false};
+
+// UI.Android
+
+const Info<int> MAIN_LAST_PLATFORM_TAB{{System::Main, "Android", "LastPlatformTab"}, 0};
 
 }  // namespace Config

--- a/Source/Core/Core/Config/UISettings.h
+++ b/Source/Core/Core/Config/UISettings.h
@@ -7,7 +7,7 @@
 #include "Common/Config/Config.h"
 
 // This is a temporary soluation, although they should be in their repected cpp file in UICommon.
-// However, in order for IsSettingSaveable to commpile without some issues, this needs to be here.
+// However, in order for IsSettingSaveable to compile without some issues, this needs to be here.
 // Once IsSettingSaveable is removed, then you should able to move these back to UICommon.
 
 namespace Config
@@ -19,5 +19,10 @@ namespace Config
 extern const Info<bool> MAIN_USE_DISCORD_PRESENCE;
 extern const Info<bool> MAIN_USE_GAME_COVERS;
 extern const Info<bool> MAIN_FOCUSED_HOTKEYS;
+extern const Info<bool> MAIN_RECURSIVE_ISO_PATHS;
+
+// UI.Android
+
+extern const Info<int> MAIN_LAST_PLATFORM_TAB;
 
 }  // namespace Config

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -25,14 +25,15 @@ bool IsSettingSaveable(const Config::Location& config_location)
 
   if (config_location.system == Config::System::Main)
   {
-    for (const char* section : {"NetPlay", "General", "Display", "Network"})
+    for (const std::string& section :
+         {"NetPlay", "General", "Display", "Network", "Analytics", "Android"})
     {
       if (config_location.section == section)
         return true;
     }
   }
 
-  static constexpr std::array<const Config::Location*, 13> s_setting_saveable = {
+  static constexpr std::array<const Config::Location*, 16> s_setting_saveable = {
       // Main.Core
 
       &Config::MAIN_DEFAULT_ISO.location,
@@ -46,6 +47,12 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_MEM1_SIZE.location,
       &Config::MAIN_MEM2_SIZE.location,
       &Config::MAIN_GFX_BACKEND.location,
+      &Config::MAIN_ENABLE_SAVESTATES.location,
+
+      // Main.Interface
+
+      &Config::MAIN_USE_PANIC_HANDLERS.location,
+      &Config::MAIN_OSD_MESSAGES.location,
 
       // Main.Interface
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -92,7 +92,6 @@ void SConfig::SaveSettings()
   SaveDSPSettings(ini);
   SaveInputSettings(ini);
   SaveFifoPlayerSettings(ini);
-  SaveAnalyticsSettings(ini);
   SaveBluetoothPassthroughSettings(ini);
   SaveUSBPassthroughSettings(ini);
   SaveAutoUpdateSettings(ini);
@@ -127,7 +126,6 @@ void SConfig::SaveGeneralSettings(IniFile& ini)
     general->Set(fmt::format("ISOPath{}", i), m_ISOFolder[i]);
   }
 
-  general->Set("RecursiveISOPaths", m_RecursiveISOFolder);
   general->Set("WirelessMac", m_WirelessMac);
 
 #ifdef USE_GDBSTUB
@@ -143,8 +141,6 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   IniFile::Section* interface = ini.GetOrCreateSection("Interface");
 
   interface->Set("ConfirmStop", bConfirmStop);
-  interface->Set("UsePanicHandlers", bUsePanicHandlers);
-  interface->Set("OnScreenDisplayMessages", bOnScreenDisplayMessages);
   interface->Set("HideCursor", bHideCursor);
   interface->Set("LanguageCode", m_InterfaceLanguage);
   interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
@@ -295,15 +291,6 @@ void SConfig::SaveFifoPlayerSettings(IniFile& ini)
   fifoplayer->Set("LoopReplay", bLoopFifoReplay);
 }
 
-void SConfig::SaveAnalyticsSettings(IniFile& ini)
-{
-  IniFile::Section* analytics = ini.GetOrCreateSection("Analytics");
-
-  analytics->Set("ID", m_analytics_id);
-  analytics->Set("Enabled", m_analytics_enabled);
-  analytics->Set("PermissionAsked", m_analytics_permission_asked);
-}
-
 void SConfig::SaveBluetoothPassthroughSettings(IniFile& ini)
 {
   IniFile::Section* section = ini.GetOrCreateSection("BluetoothPassthrough");
@@ -368,7 +355,6 @@ void SConfig::LoadSettings()
   LoadDSPSettings(ini);
   LoadInputSettings(ini);
   LoadFifoPlayerSettings(ini);
-  LoadAnalyticsSettings(ini);
   LoadBluetoothPassthroughSettings(ini);
   LoadUSBPassthroughSettings(ini);
   LoadAutoUpdateSettings(ini);
@@ -401,7 +387,6 @@ void SConfig::LoadGeneralSettings(IniFile& ini)
     }
   }
 
-  general->Get("RecursiveISOPaths", &m_RecursiveISOFolder, false);
   general->Get("WirelessMac", &m_WirelessMac);
 }
 
@@ -410,8 +395,6 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   IniFile::Section* interface = ini.GetOrCreateSection("Interface");
 
   interface->Get("ConfirmStop", &bConfirmStop, true);
-  interface->Get("UsePanicHandlers", &bUsePanicHandlers, true);
-  interface->Get("OnScreenDisplayMessages", &bOnScreenDisplayMessages, true);
   interface->Get("HideCursor", &bHideCursor, false);
   interface->Get("LanguageCode", &m_InterfaceLanguage, "");
   interface->Get("ExtendedFPSInfo", &m_InterfaceExtendedFPSInfo, false);
@@ -576,15 +559,6 @@ void SConfig::LoadFifoPlayerSettings(IniFile& ini)
   IniFile::Section* fifoplayer = ini.GetOrCreateSection("FifoPlayer");
 
   fifoplayer->Get("LoopReplay", &bLoopFifoReplay, true);
-}
-
-void SConfig::LoadAnalyticsSettings(IniFile& ini)
-{
-  IniFile::Section* analytics = ini.GetOrCreateSection("Analytics");
-
-  analytics->Get("ID", &m_analytics_id, "");
-  analytics->Get("Enabled", &m_analytics_enabled, false);
-  analytics->Get("PermissionAsked", &m_analytics_permission_asked, false);
 }
 
 void SConfig::LoadBluetoothPassthroughSettings(IniFile& ini)
@@ -771,12 +745,6 @@ void SConfig::LoadDefaults()
   iLatency = 20;
   m_audio_stretch = false;
   m_audio_stretch_max_latency = 80;
-  bUsePanicHandlers = true;
-  bOnScreenDisplayMessages = true;
-
-  m_analytics_id = "";
-  m_analytics_enabled = false;
-  m_analytics_permission_asked = false;
 
   bLoopFifoReplay = true;
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -76,7 +76,6 @@ struct SConfig
 
   // ISO folder
   std::vector<std::string> m_ISOFolder;
-  bool m_RecursiveISOFolder;
 
   // Settings
   bool bEnableDebugging = false;
@@ -149,14 +148,7 @@ struct SConfig
   // Interface settings
   bool bConfirmStop = false;
   bool bHideCursor = false;
-  bool bUsePanicHandlers = true;
-  bool bOnScreenDisplayMessages = true;
   std::string theme_name;
-
-  // Analytics settings.
-  std::string m_analytics_id;
-  bool m_analytics_enabled = false;
-  bool m_analytics_permission_asked = false;
 
   // Bluetooth passthrough mode settings
   bool m_bt_passthrough_enabled = false;
@@ -343,7 +335,6 @@ private:
   void SaveInputSettings(IniFile& ini);
   void SaveMovieSettings(IniFile& ini);
   void SaveFifoPlayerSettings(IniFile& ini);
-  void SaveAnalyticsSettings(IniFile& ini);
   void SaveBluetoothPassthroughSettings(IniFile& ini);
   void SaveUSBPassthroughSettings(IniFile& ini);
   void SaveAutoUpdateSettings(IniFile& ini);
@@ -357,7 +348,6 @@ private:
   void LoadInputSettings(IniFile& ini);
   void LoadMovieSettings(IniFile& ini);
   void LoadFifoPlayerSettings(IniFile& ini);
-  void LoadAnalyticsSettings(IniFile& ini);
   void LoadBluetoothPassthroughSettings(IniFile& ini);
   void LoadUSBPassthroughSettings(IniFile& ini);
   void LoadAutoUpdateSettings(IniFile& ini);

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -8,7 +8,9 @@
 #include <QDirIterator>
 #include <QFile>
 
-#include "Core/ConfigManager.h"
+#include "Common/Config/Config.h"
+
+#include "Core/Config/UISettings.h"
 
 #include "DiscIO/DirectoryBlob.h"
 
@@ -224,7 +226,7 @@ void GameTracker::AddDirectoryInternal(const QString& dir)
 static std::unique_ptr<QDirIterator> GetIterator(const QString& dir)
 {
   return std::make_unique<QDirIterator>(dir, game_filters, QDir::NoFilter,
-                                        SConfig::GetInstance().m_RecursiveISOFolder ?
+                                        Config::Get(Config::MAIN_RECURSIVE_ISO_PATHS) ?
                                             QDirIterator::Subdirectories :
                                             QDirIterator::NoIteratorFlags);
 }

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -14,12 +14,13 @@
 #include <QPushButton>
 #include <QWidget>
 
+#include "Common/Config/Config.h"
 #include "Common/MsgHandler.h"
 #include "Common/ScopeGuard.h"
 
 #include "Core/Analytics.h"
 #include "Core/Boot/Boot.h"
-#include "Core/ConfigManager.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Core.h"
 
 #include "DolphinQt/Host.h"
@@ -219,7 +220,7 @@ int main(int argc, char* argv[])
     win.Show();
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
-    if (!SConfig::GetInstance().m_analytics_permission_asked)
+    if (!Config::Get(Config::MAIN_ANALYTICS_PERMISSION_ASKED))
     {
       ModalMessageBox analytics_prompt(&win);
 
@@ -241,7 +242,7 @@ int main(int argc, char* argv[])
 
       const int answer = analytics_prompt.exec();
 
-      SConfig::GetInstance().m_analytics_permission_asked = true;
+      Config::SetBase(Config::MAIN_ANALYTICS_PERMISSION_ASKED, true);
       Settings::Instance().SetAnalyticsEnabled(answer == QMessageBox::Yes);
 
       DolphinAnalytics::Instance().ReloadConfig();

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -515,14 +515,14 @@ void Settings::SetAnalyticsEnabled(bool enabled)
   if (enabled == IsAnalyticsEnabled())
     return;
 
-  SConfig::GetInstance().m_analytics_enabled = enabled;
+  Config::SetBase(Config::MAIN_ANALYTICS_PERMISSION_ASKED, enabled);
 
   emit AnalyticsToggled(enabled);
 }
 
 bool Settings::IsAnalyticsEnabled() const
 {
-  return SConfig::GetInstance().m_analytics_enabled;
+  return Config::Get(Config::MAIN_ANALYTICS_PERMISSION_ASKED);
 }
 
 void Settings::SetToolBarVisible(bool visible)

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -19,6 +19,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"
 #include "Core/ConfigManager.h"
 
@@ -229,8 +230,8 @@ void InterfacePane::LoadConfig()
   // Render Window Options
   m_checkbox_top_window->setChecked(Settings::Instance().IsKeepWindowOnTopEnabled());
   m_checkbox_confirm_on_stop->setChecked(startup_params.bConfirmStop);
-  m_checkbox_use_panic_handlers->setChecked(startup_params.bUsePanicHandlers);
-  m_checkbox_enable_osd->setChecked(startup_params.bOnScreenDisplayMessages);
+  m_checkbox_use_panic_handlers->setChecked(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
+  m_checkbox_enable_osd->setChecked(Config::Get(Config::MAIN_OSD_MESSAGES));
   m_checkbox_show_active_title->setChecked(startup_params.m_show_active_title);
   m_checkbox_pause_on_focus_lost->setChecked(startup_params.m_PauseOnFocusLost);
   m_checkbox_use_covers->setChecked(Config::Get(Config::MAIN_USE_GAME_COVERS));
@@ -254,12 +255,12 @@ void InterfacePane::OnSaveConfig()
   // Render Window Options
   Settings::Instance().SetKeepWindowOnTop(m_checkbox_top_window->isChecked());
   settings.bConfirmStop = m_checkbox_confirm_on_stop->isChecked();
-  settings.bUsePanicHandlers = m_checkbox_use_panic_handlers->isChecked();
-  settings.bOnScreenDisplayMessages = m_checkbox_enable_osd->isChecked();
+  Config::SetBase(Config::MAIN_USE_PANIC_HANDLERS, m_checkbox_use_panic_handlers->isChecked());
+  Config::SetBase(Config::MAIN_OSD_MESSAGES, m_checkbox_enable_osd->isChecked());
   settings.m_show_active_title = m_checkbox_show_active_title->isChecked();
   settings.m_PauseOnFocusLost = m_checkbox_pause_on_focus_lost->isChecked();
 
-  Common::SetEnableAlert(settings.bUsePanicHandlers);
+  Common::SetEnableAlert(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
 
   auto new_language = m_combobox_language->currentData().toString().toStdString();
   if (new_language != SConfig::GetInstance().m_InterfaceLanguage)

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -16,7 +16,7 @@
 #include "Common/FileUtil.h"
 
 #include "Core/Config/MainSettings.h"
-#include "Core/ConfigManager.h"
+#include "Core/Config/UISettings.h"
 
 #include "DolphinQt/Settings.h"
 #include "DolphinQt/Settings/PathPane.h"
@@ -148,7 +148,7 @@ QGroupBox* PathPane::MakeGameFolderBox()
   m_remove_path->setEnabled(false);
 
   auto* recursive_checkbox = new QCheckBox(tr("Search Subfolders"));
-  recursive_checkbox->setChecked(SConfig::GetInstance().m_RecursiveISOFolder);
+  recursive_checkbox->setChecked(Config::Get(Config::MAIN_RECURSIVE_ISO_PATHS));
 
   auto* auto_checkbox = new QCheckBox(tr("Check for Game List Changes in the Background"));
   auto_checkbox->setChecked(Settings::Instance().IsAutoRefreshEnabled());
@@ -160,7 +160,7 @@ QGroupBox* PathPane::MakeGameFolderBox()
   vlayout->addWidget(auto_checkbox);
 
   connect(recursive_checkbox, &QCheckBox::toggled, [](bool checked) {
-    SConfig::GetInstance().m_RecursiveISOFolder = checked;
+    Config::SetBase(Config::MAIN_RECURSIVE_ISO_PATHS, checked);
     Settings::Instance().RefreshGameList();
   });
 

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -102,7 +102,7 @@ void Init()
   GCAdapter::Init();
   VideoBackendBase::ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
 
-  Common::SetEnableAlert(SConfig::GetInstance().bUsePanicHandlers);
+  Common::SetEnableAlert(Config::Get(Config::MAIN_USE_PANIC_HANDLERS));
 }
 
 void Shutdown()

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -13,9 +13,10 @@
 #include <imgui.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/Config/Config.h"
 #include "Common/Timer.h"
 
-#include "Core/ConfigManager.h"
+#include "Core/Config/MainSettings.h"
 
 namespace OSD
 {
@@ -94,7 +95,7 @@ void AddMessage(std::string message, u32 ms, u32 argb)
 
 void DrawMessages()
 {
-  const bool draw_messages = SConfig::GetInstance().bOnScreenDisplayMessages;
+  const bool draw_messages = Config::Get(Config::MAIN_OSD_MESSAGES);
   const u32 now = Common::Timer::GetTimeMs();
   const float current_x = LEFT_MARGIN * ImGui::GetIO().DisplayFramebufferScale.x;
   float current_y = TOP_MARGIN * ImGui::GetIO().DisplayFramebufferScale.y;


### PR DESCRIPTION
Split out from the Android PR #8975.

Other than the controller settings and JIT debug settings, these are the only settings which were defined in Java code but not defined in the new config system in C++. (There are still a lot of settings that are defined in the new config system but not yet saveable in the new config system, though.)