### PR TITLE
GameSettings: SafeTextureCacheColorSamples for SEUPEY and SEVPEY

### DIFF
--- a/Data/Sys/GameSettings/SEU.ini
+++ b/Data/Sys/GameSettings/SEU.ini
@@ -1,0 +1,4 @@
+# SEUPEY - Retro City Rampage DX+
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SEV.ini
+++ b/Data/Sys/GameSettings/SEV.ini
@@ -1,0 +1,4 @@
+# SEVPEY - Shakedown: Hawaii
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
Works around a rendering error in Retro City Rampage (disc) and
Shakedown: Hawaii.  Fixes redmine issues #12197 and #12198.