### PR TITLE
LightingShaderGen/VertexShaderGen: Migrate over to fmt

### DIFF
--- a/Source/Core/VideoCommon/LightingShaderGen.cpp
+++ b/Source/Core/VideoCommon/LightingShaderGen.cpp
@@ -17,60 +17,61 @@ static void GenerateLightShader(ShaderCode& object, const LightingUidData& uid_d
   const char* swizzle = alpha ? "a" : "rgb";
   const char* swizzle_components = (alpha) ? "" : "3";
 
-  int attnfunc = (uid_data.attnfunc >> (2 * litchan_index)) & 0x3;
-  int diffusefunc = (uid_data.diffusefunc >> (2 * litchan_index)) & 0x3;
+  const u32 attnfunc = (uid_data.attnfunc >> (2 * litchan_index)) & 0x3;
+  const u32 diffusefunc = (uid_data.diffusefunc >> (2 * litchan_index)) & 0x3;
 
   switch (attnfunc)
   {
   case LIGHTATTN_NONE:
   case LIGHTATTN_DIR:
-    object.Write("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n", LIGHT_POS_PARAMS(index));
-    object.Write("attn = 1.0;\n");
-    object.Write("if (length(ldir) == 0.0)\n\t ldir = _norm0;\n");
+    object.WriteFmt("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n", LIGHT_POS_PARAMS(index));
+    object.WriteFmt("attn = 1.0;\n");
+    object.WriteFmt("if (length(ldir) == 0.0)\n\t ldir = _norm0;\n");
     break;
   case LIGHTATTN_SPEC:
-    object.Write("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n", LIGHT_POS_PARAMS(index));
-    object.Write("attn = (dot(_norm0, ldir) >= 0.0) ? max(0.0, dot(_norm0, " LIGHT_DIR
-                 ".xyz)) : 0.0;\n",
-                 LIGHT_DIR_PARAMS(index));
-    object.Write("cosAttn = " LIGHT_COSATT ".xyz;\n", LIGHT_COSATT_PARAMS(index));
-    object.Write("distAttn = %s(" LIGHT_DISTATT ".xyz);\n",
-                 (diffusefunc == LIGHTDIF_NONE) ? "" : "normalize", LIGHT_DISTATT_PARAMS(index));
-    object.Write("attn = max(0.0f, dot(cosAttn, float3(1.0, attn, attn*attn))) / dot(distAttn, "
-                 "float3(1.0, attn, attn*attn));\n");
+    object.WriteFmt("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n", LIGHT_POS_PARAMS(index));
+    object.WriteFmt("attn = (dot(_norm0, ldir) >= 0.0) ? max(0.0, dot(_norm0, " LIGHT_DIR
+                    ".xyz)) : 0.0;\n",
+                    LIGHT_DIR_PARAMS(index));
+    object.WriteFmt("cosAttn = " LIGHT_COSATT ".xyz;\n", LIGHT_COSATT_PARAMS(index));
+    object.WriteFmt("distAttn = {}(" LIGHT_DISTATT ".xyz);\n",
+                    (diffusefunc == LIGHTDIF_NONE) ? "" : "normalize", LIGHT_DISTATT_PARAMS(index));
+    object.WriteFmt("attn = max(0.0f, dot(cosAttn, float3(1.0, attn, attn*attn))) / dot(distAttn, "
+                    "float3(1.0, attn, attn*attn));\n");
     break;
   case LIGHTATTN_SPOT:
-    object.Write("ldir = " LIGHT_POS ".xyz - pos.xyz;\n", LIGHT_POS_PARAMS(index));
-    object.Write("dist2 = dot(ldir, ldir);\n"
-                 "dist = sqrt(dist2);\n"
-                 "ldir = ldir / dist;\n"
-                 "attn = max(0.0, dot(ldir, " LIGHT_DIR ".xyz));\n",
-                 LIGHT_DIR_PARAMS(index));
+    object.WriteFmt("ldir = " LIGHT_POS ".xyz - pos.xyz;\n", LIGHT_POS_PARAMS(index));
+    object.WriteFmt("dist2 = dot(ldir, ldir);\n"
+                    "dist = sqrt(dist2);\n"
+                    "ldir = ldir / dist;\n"
+                    "attn = max(0.0, dot(ldir, " LIGHT_DIR ".xyz));\n",
+                    LIGHT_DIR_PARAMS(index));
     // attn*attn may overflow
-    object.Write("attn = max(0.0, " LIGHT_COSATT ".x + " LIGHT_COSATT ".y*attn + " LIGHT_COSATT
-                 ".z*attn*attn) / dot(" LIGHT_DISTATT ".xyz, float3(1.0,dist,dist2));\n",
-                 LIGHT_COSATT_PARAMS(index), LIGHT_COSATT_PARAMS(index), LIGHT_COSATT_PARAMS(index),
-                 LIGHT_DISTATT_PARAMS(index));
+    object.WriteFmt("attn = max(0.0, " LIGHT_COSATT ".x + " LIGHT_COSATT ".y*attn + " LIGHT_COSATT
+                    ".z*attn*attn) / dot(" LIGHT_DISTATT ".xyz, float3(1.0,dist,dist2));\n",
+                    LIGHT_COSATT_PARAMS(index), LIGHT_COSATT_PARAMS(index),
+                    LIGHT_COSATT_PARAMS(index), LIGHT_DISTATT_PARAMS(index));
     break;
   }
 
   switch (diffusefunc)
   {
   case LIGHTDIF_NONE:
-    object.Write("lacc.%s += int%s(round(attn * float%s(" LIGHT_COL ")));\n", swizzle,
-                 swizzle_components, swizzle_components, LIGHT_COL_PARAMS(index, swizzle));
+    object.WriteFmt("lacc.{} += int{}(round(attn * float{}(" LIGHT_COL ")));\n", swizzle,
+                    swizzle_components, swizzle_components, LIGHT_COL_PARAMS(index, swizzle));
     break;
   case LIGHTDIF_SIGN:
   case LIGHTDIF_CLAMP:
-    object.Write("lacc.%s += int%s(round(attn * %sdot(ldir, _norm0)) * float%s(" LIGHT_COL ")));\n",
-                 swizzle, swizzle_components, diffusefunc != LIGHTDIF_SIGN ? "max(0.0," : "(",
-                 swizzle_components, LIGHT_COL_PARAMS(index, swizzle));
+    object.WriteFmt("lacc.{} += int{}(round(attn * {}dot(ldir, _norm0)) * float{}(" LIGHT_COL
+                    ")));\n",
+                    swizzle, swizzle_components, diffusefunc != LIGHTDIF_SIGN ? "max(0.0," : "(",
+                    swizzle_components, LIGHT_COL_PARAMS(index, swizzle));
     break;
   default:
     ASSERT(0);
   }
 
-  object.Write("\n");
+  object.WriteFmt("\n");
 }
 
 // vertex shader
@@ -79,127 +80,143 @@ static void GenerateLightShader(ShaderCode& object, const LightingUidData& uid_d
 // inColorName is color in vs and colors_ in ps
 // dest is o.colors_ in vs and colors_ in ps
 void GenerateLightingShaderCode(ShaderCode& object, const LightingUidData& uid_data, int components,
-                                const char* inColorName, const char* dest)
+                                std::string_view in_color_name, std::string_view dest)
 {
-  for (unsigned int j = 0; j < NUM_XF_COLOR_CHANNELS; j++)
+  for (u32 j = 0; j < NUM_XF_COLOR_CHANNELS; j++)
   {
-    object.Write("{\n");
+    object.WriteFmt("{{\n");
 
-    bool colormatsource = !!(uid_data.matsource & (1 << j));
+    const bool colormatsource = !!(uid_data.matsource & (1 << j));
     if (colormatsource)  // from vertex
     {
-      if (components & (VB_HAS_COL0 << j))
-        object.Write("int4 mat = int4(round(%s%d * 255.0));\n", inColorName, j);
-      else if (components & VB_HAS_COL0)
-        object.Write("int4 mat = int4(round(%s0 * 255.0));\n", inColorName);
+      if ((components & (VB_HAS_COL0 << j)) != 0)
+        object.WriteFmt("int4 mat = int4(round({}{} * 255.0));\n", in_color_name, j);
+      else if ((components & VB_HAS_COL0) != 0)
+        object.WriteFmt("int4 mat = int4(round({}0 * 255.0));\n", in_color_name);
       else
-        object.Write("int4 mat = int4(255, 255, 255, 255);\n");
+        object.WriteFmt("int4 mat = int4(255, 255, 255, 255);\n");
     }
     else  // from color
     {
-      object.Write("int4 mat = %s[%d];\n", I_MATERIALS, j + 2);
+      object.WriteFmt("int4 mat = {}[{}];\n", I_MATERIALS, j + 2);
     }
 
-    if (uid_data.enablelighting & (1 << j))
+    if ((uid_data.enablelighting & (1 << j)) != 0)
     {
-      if (uid_data.ambsource & (1 << j))  // from vertex
+      if ((uid_data.ambsource & (1 << j)) != 0)  // from vertex
       {
-        if (components & (VB_HAS_COL0 << j))
-          object.Write("lacc = int4(round(%s%d * 255.0));\n", inColorName, j);
-        else if (components & VB_HAS_COL0)
-          object.Write("lacc = int4(round(%s0 * 255.0));\n", inColorName);
+        if ((components & (VB_HAS_COL0 << j)) != 0)
+        {
+          object.WriteFmt("lacc = int4(round({}{} * 255.0));\n", in_color_name, j);
+        }
+        else if ((components & VB_HAS_COL0) != 0)
+        {
+          object.WriteFmt("lacc = int4(round({}0 * 255.0));\n", in_color_name);
+        }
         else
+        {
           // TODO: this isn't verified. Here we want to read the ambient from the vertex,
           // but the vertex itself has no color. So we don't know which value to read.
           // Returning 1.0 is the same as disabled lightning, so this could be fine
-          object.Write("lacc = int4(255, 255, 255, 255);\n");
+          object.WriteFmt("lacc = int4(255, 255, 255, 255);\n");
+        }
       }
       else  // from color
       {
-        object.Write("lacc = %s[%d];\n", I_MATERIALS, j);
+        object.WriteFmt("lacc = {}[{}];\n", I_MATERIALS, j);
       }
     }
     else
     {
-      object.Write("lacc = int4(255, 255, 255, 255);\n");
+      object.WriteFmt("lacc = int4(255, 255, 255, 255);\n");
     }
 
     // check if alpha is different
-    bool alphamatsource = !!(uid_data.matsource & (1 << (j + 2)));
+    const bool alphamatsource = !!(uid_data.matsource & (1 << (j + 2)));
     if (alphamatsource != colormatsource)
     {
       if (alphamatsource)  // from vertex
       {
-        if (components & (VB_HAS_COL0 << j))
-          object.Write("mat.w = int(round(%s%d.w * 255.0));\n", inColorName, j);
-        else if (components & VB_HAS_COL0)
-          object.Write("mat.w = int(round(%s0.w * 255.0));\n", inColorName);
+        if ((components & (VB_HAS_COL0 << j)) != 0)
+          object.WriteFmt("mat.w = int(round({}{}.w * 255.0));\n", in_color_name, j);
+        else if ((components & VB_HAS_COL0) != 0)
+          object.WriteFmt("mat.w = int(round({}0.w * 255.0));\n", in_color_name);
         else
-          object.Write("mat.w = 255;\n");
+          object.WriteFmt("mat.w = 255;\n");
       }
       else  // from color
       {
-        object.Write("mat.w = %s[%d].w;\n", I_MATERIALS, j + 2);
+        object.WriteFmt("mat.w = {}[{}].w;\n", I_MATERIALS, j + 2);
       }
     }
 
-    if (uid_data.enablelighting & (1 << (j + 2)))
+    if ((uid_data.enablelighting & (1 << (j + 2))) != 0)
     {
-      if (uid_data.ambsource & (1 << (j + 2)))  // from vertex
+      if ((uid_data.ambsource & (1 << (j + 2))) != 0)  // from vertex
       {
-        if (components & (VB_HAS_COL0 << j))
-          object.Write("lacc.w = int(round(%s%d.w * 255.0));\n", inColorName, j);
-        else if (components & VB_HAS_COL0)
-          object.Write("lacc.w = int(round(%s0.w * 255.0));\n", inColorName);
+        if ((components & (VB_HAS_COL0 << j)) != 0)
+        {
+          object.WriteFmt("lacc.w = int(round({}{}.w * 255.0));\n", in_color_name, j);
+        }
+        else if ((components & VB_HAS_COL0) != 0)
+        {
+          object.WriteFmt("lacc.w = int(round({}0.w * 255.0));\n", in_color_name);
+        }
         else
+        {
           // TODO: The same for alpha: We want to read from vertex, but the vertex has no color
-          object.Write("lacc.w = 255;\n");
+          object.WriteFmt("lacc.w = 255;\n");
+        }
       }
       else  // from color
       {
-        object.Write("lacc.w = %s[%d].w;\n", I_MATERIALS, j);
+        object.WriteFmt("lacc.w = {}[{}].w;\n", I_MATERIALS, j);
       }
     }
     else
     {
-      object.Write("lacc.w = 255;\n");
+      object.WriteFmt("lacc.w = 255;\n");
     }
 
-    if (uid_data.enablelighting & (1 << j))  // Color lights
+    if ((uid_data.enablelighting & (1 << j)) != 0)  // Color lights
     {
       for (int i = 0; i < 8; ++i)
-        if (uid_data.light_mask & (1 << (i + 8 * j)))
+      {
+        if ((uid_data.light_mask & (1 << (i + 8 * j))) != 0)
           GenerateLightShader(object, uid_data, i, j, false);
+      }
     }
-    if (uid_data.enablelighting & (1 << (j + 2)))  // Alpha lights
+    if ((uid_data.enablelighting & (1 << (j + 2))) != 0)  // Alpha lights
     {
       for (int i = 0; i < 8; ++i)
-        if (uid_data.light_mask & (1 << (i + 8 * (j + 2))))
+      {
+        if ((uid_data.light_mask & (1 << (i + 8 * (j + 2)))) != 0)
           GenerateLightShader(object, uid_data, i, j + 2, true);
+      }
     }
-    object.Write("lacc = clamp(lacc, 0, 255);\n");
-    object.Write("%s%d = float4((mat * (lacc + (lacc >> 7))) >> 8) / 255.0;\n", dest, j);
-    object.Write("}\n");
+    object.WriteFmt("lacc = clamp(lacc, 0, 255);\n");
+    object.WriteFmt("{}{} = float4((mat * (lacc + (lacc >> 7))) >> 8) / 255.0;\n", dest, j);
+    object.WriteFmt("}}\n");
   }
 }
 
 void GetLightingShaderUid(LightingUidData& uid_data)
 {
-  for (unsigned int j = 0; j < NUM_XF_COLOR_CHANNELS; j++)
+  for (u32 j = 0; j < NUM_XF_COLOR_CHANNELS; j++)
   {
     uid_data.matsource |= xfmem.color[j].matsource << j;
     uid_data.matsource |= xfmem.alpha[j].matsource << (j + 2);
     uid_data.enablelighting |= xfmem.color[j].enablelighting << j;
     uid_data.enablelighting |= xfmem.alpha[j].enablelighting << (j + 2);
 
-    if (uid_data.enablelighting & (1 << j))  // Color lights
+    if ((uid_data.enablelighting & (1 << j)) != 0)  // Color lights
     {
       uid_data.ambsource |= xfmem.color[j].ambsource << j;
       uid_data.attnfunc |= xfmem.color[j].attnfunc << (2 * j);
       uid_data.diffusefunc |= xfmem.color[j].diffusefunc << (2 * j);
       uid_data.light_mask |= xfmem.color[j].GetFullLightMask() << (8 * j);
     }
-    if (uid_data.enablelighting & (1 << (j + 2)))  // Alpha lights
+    if ((uid_data.enablelighting & (1 << (j + 2))) != 0)  // Alpha lights
     {
       uid_data.ambsource |= xfmem.alpha[j].ambsource << (j + 2);
       uid_data.attnfunc |= xfmem.alpha[j].attnfunc << (2 * (j + 2));

--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -4,23 +4,24 @@
 
 #pragma once
 
+#include <string_view>
 #include "Common/CommonTypes.h"
 
 class ShaderCode;
 
-#define LIGHT_COL "%s[%d].color.%s"
+#define LIGHT_COL "{}[{}].color.{}"
 #define LIGHT_COL_PARAMS(index, swizzle) (I_LIGHTS), (index), (swizzle)
 
-#define LIGHT_COSATT "%s[%d].cosatt"
+#define LIGHT_COSATT "{}[{}].cosatt"
 #define LIGHT_COSATT_PARAMS(index) (I_LIGHTS), (index)
 
-#define LIGHT_DISTATT "%s[%d].distatt"
+#define LIGHT_DISTATT "{}[{}].distatt"
 #define LIGHT_DISTATT_PARAMS(index) (I_LIGHTS), (index)
 
-#define LIGHT_POS "%s[%d].pos"
+#define LIGHT_POS "{}[{}].pos"
 #define LIGHT_POS_PARAMS(index) (I_LIGHTS), (index)
 
-#define LIGHT_DIR "%s[%d].dir"
+#define LIGHT_DIR "{}[{}].dir"
 #define LIGHT_DIR_PARAMS(index) (I_LIGHTS), (index)
 
 /**
@@ -36,14 +37,14 @@ struct LightingUidData
   u32 light_mask : 32;     // 4x8 bits
 };
 
-static const char s_lighting_struct[] = "struct Light {\n"
-                                        "\tint4 color;\n"
-                                        "\tfloat4 cosatt;\n"
-                                        "\tfloat4 distatt;\n"
-                                        "\tfloat4 pos;\n"
-                                        "\tfloat4 dir;\n"
-                                        "};\n";
+constexpr inline char s_lighting_struct[] = "struct Light {\n"
+                                            "\tint4 color;\n"
+                                            "\tfloat4 cosatt;\n"
+                                            "\tfloat4 distatt;\n"
+                                            "\tfloat4 pos;\n"
+                                            "\tfloat4 dir;\n"
+                                            "};\n";
 
 void GenerateLightingShaderCode(ShaderCode& object, const LightingUidData& uid_data, int components,
-                                const char* inColorName, const char* dest);
+                                std::string_view in_color_name, std::string_view dest);
 void GetLightingShaderUid(LightingUidData& uid_data);

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -316,8 +316,8 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
       if ((uid_data->components & (VB_HAS_NRM1 | VB_HAS_NRM2)) != 0)
       {
         // transform the light dir into tangent space
-        out.Write("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n",
-                  LIGHT_POS_PARAMS(texinfo.embosslightshift));
+        out.WriteFmt("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n",
+                     LIGHT_POS_PARAMS(texinfo.embosslightshift));
         out.WriteFmt(
             "o.tex{}.xyz = o.tex{}.xyz + float3(dot(ldir, _norm1), dot(ldir, _norm2), 0.0);\n", i,
             texinfo.embosssourceshift);

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -28,7 +28,7 @@ VertexShaderUid GetVertexShaderUid()
   GetLightingShaderUid(uid_data->lighting);
 
   // transform texcoords
-  for (unsigned int i = 0; i < uid_data->numTexGens; ++i)
+  for (u32 i = 0; i < uid_data->numTexGens; ++i)
   {
     auto& texinfo = uid_data->texMtxInfo[i];
 
@@ -40,7 +40,7 @@ VertexShaderUid GetVertexShaderUid()
     switch (texinfo.texgentype)
     {
     case XF_TEXGEN_EMBOSS_MAP:  // calculate tex coords into bump map
-      if (uid_data->components & (VB_HAS_NRM1 | VB_HAS_NRM2))
+      if ((uid_data->components & (VB_HAS_NRM1 | VB_HAS_NRM2)) != 0)
       {
         // transform the light dir into tangent space
         texinfo.embosslightshift = xfmem.texMtxInfo[i].embosslightshift;
@@ -83,183 +83,199 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   const bool ssaa = host_config.ssaa;
   const bool vertex_rounding = host_config.vertex_rounding;
 
-  out.Write("%s", s_lighting_struct);
+  out.WriteFmt("{}", s_lighting_struct);
 
   // uniforms
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
-    out.Write("UBO_BINDING(std140, 2) uniform VSBlock {\n");
+    out.WriteFmt("UBO_BINDING(std140, 2) uniform VSBlock {{\n");
   else
-    out.Write("cbuffer VSBlock {\n");
+    out.WriteFmt("cbuffer VSBlock {{\n");
 
-  out.Write(s_shader_uniforms);
-  out.Write("};\n");
+  out.WriteFmt("{}", s_shader_uniforms);
+  out.WriteFmt("}};\n");
 
-  out.Write("struct VS_OUTPUT {\n");
+  out.WriteFmt("struct VS_OUTPUT {{\n");
   GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config, "");
-  out.Write("};\n");
+  out.WriteFmt("}};\n");
 
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
   {
-    out.Write("ATTRIBUTE_LOCATION(%d) in float4 rawpos;\n", SHADER_POSITION_ATTRIB);
-    if (uid_data->components & VB_HAS_POSMTXIDX)
-      out.Write("ATTRIBUTE_LOCATION(%d) in uint4 posmtx;\n", SHADER_POSMTX_ATTRIB);
-    if (uid_data->components & VB_HAS_NRM0)
-      out.Write("ATTRIBUTE_LOCATION(%d) in float3 rawnorm0;\n", SHADER_NORM0_ATTRIB);
-    if (uid_data->components & VB_HAS_NRM1)
-      out.Write("ATTRIBUTE_LOCATION(%d) in float3 rawnorm1;\n", SHADER_NORM1_ATTRIB);
-    if (uid_data->components & VB_HAS_NRM2)
-      out.Write("ATTRIBUTE_LOCATION(%d) in float3 rawnorm2;\n", SHADER_NORM2_ATTRIB);
+    out.WriteFmt("ATTRIBUTE_LOCATION({}) in float4 rawpos;\n", SHADER_POSITION_ATTRIB);
+    if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
+      out.WriteFmt("ATTRIBUTE_LOCATION({}) in uint4 posmtx;\n", SHADER_POSMTX_ATTRIB);
+    if ((uid_data->components & VB_HAS_NRM0) != 0)
+      out.WriteFmt("ATTRIBUTE_LOCATION({}) in float3 rawnorm0;\n", SHADER_NORM0_ATTRIB);
+    if ((uid_data->components & VB_HAS_NRM1) != 0)
+      out.WriteFmt("ATTRIBUTE_LOCATION({}) in float3 rawnorm1;\n", SHADER_NORM1_ATTRIB);
+    if ((uid_data->components & VB_HAS_NRM2) != 0)
+      out.WriteFmt("ATTRIBUTE_LOCATION({}) in float3 rawnorm2;\n", SHADER_NORM2_ATTRIB);
 
-    if (uid_data->components & VB_HAS_COL0)
-      out.Write("ATTRIBUTE_LOCATION(%d) in float4 rawcolor0;\n", SHADER_COLOR0_ATTRIB);
-    if (uid_data->components & VB_HAS_COL1)
-      out.Write("ATTRIBUTE_LOCATION(%d) in float4 rawcolor1;\n", SHADER_COLOR1_ATTRIB);
+    if ((uid_data->components & VB_HAS_COL0) != 0)
+      out.WriteFmt("ATTRIBUTE_LOCATION({}) in float4 rawcolor0;\n", SHADER_COLOR0_ATTRIB);
+    if ((uid_data->components & VB_HAS_COL1) != 0)
+      out.WriteFmt("ATTRIBUTE_LOCATION({}) in float4 rawcolor1;\n", SHADER_COLOR1_ATTRIB);
 
-    for (int i = 0; i < 8; ++i)
+    for (u32 i = 0; i < 8; ++i)
     {
-      u32 hastexmtx = (uid_data->components & (VB_HAS_TEXMTXIDX0 << i));
-      if ((uid_data->components & (VB_HAS_UV0 << i)) || hastexmtx)
+      const u32 has_texmtx = (uid_data->components & (VB_HAS_TEXMTXIDX0 << i));
+
+      if ((uid_data->components & (VB_HAS_UV0 << i)) != 0 || has_texmtx != 0)
       {
-        out.Write("ATTRIBUTE_LOCATION(%d) in float%d rawtex%d;\n", SHADER_TEXTURE0_ATTRIB + i,
-                  hastexmtx ? 3 : 2, i);
+        out.WriteFmt("ATTRIBUTE_LOCATION({}) in float{} rawtex{};\n", SHADER_TEXTURE0_ATTRIB + i,
+                     has_texmtx != 0 ? 3 : 2, i);
       }
     }
 
     if (host_config.backend_geometry_shaders)
     {
-      out.Write("VARYING_LOCATION(0) out VertexData {\n");
+      out.WriteFmt("VARYING_LOCATION(0) out VertexData {{\n");
       GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, host_config,
                               GetInterpolationQualifier(msaa, ssaa, true, false));
-      out.Write("} vs;\n");
+      out.WriteFmt("}} vs;\n");
     }
     else
     {
       // Let's set up attributes
       u32 counter = 0;
-      out.Write("VARYING_LOCATION(%u) %s out float4 colors_0;\n", counter++,
-                GetInterpolationQualifier(msaa, ssaa));
-      out.Write("VARYING_LOCATION(%u) %s out float4 colors_1;\n", counter++,
-                GetInterpolationQualifier(msaa, ssaa));
+      out.WriteFmt("VARYING_LOCATION({}) {} out float4 colors_0;\n", counter++,
+                   GetInterpolationQualifier(msaa, ssaa));
+      out.WriteFmt("VARYING_LOCATION({}) {} out float4 colors_1;\n", counter++,
+                   GetInterpolationQualifier(msaa, ssaa));
       for (u32 i = 0; i < uid_data->numTexGens; ++i)
       {
-        out.Write("VARYING_LOCATION(%u) %s out float3 tex%u;\n", counter++,
-                  GetInterpolationQualifier(msaa, ssaa), i);
+        out.WriteFmt("VARYING_LOCATION({}) {} out float3 tex{};\n", counter++,
+                     GetInterpolationQualifier(msaa, ssaa), i);
       }
       if (!host_config.fast_depth_calc)
-        out.Write("VARYING_LOCATION(%u) %s out float4 clipPos;\n", counter++,
-                  GetInterpolationQualifier(msaa, ssaa));
+      {
+        out.WriteFmt("VARYING_LOCATION({}) {} out float4 clipPos;\n", counter++,
+                     GetInterpolationQualifier(msaa, ssaa));
+      }
       if (per_pixel_lighting)
       {
-        out.Write("VARYING_LOCATION(%u) %s out float3 Normal;\n", counter++,
-                  GetInterpolationQualifier(msaa, ssaa));
-        out.Write("VARYING_LOCATION(%u) %s out float3 WorldPos;\n", counter++,
-                  GetInterpolationQualifier(msaa, ssaa));
+        out.WriteFmt("VARYING_LOCATION({}) {} out float3 Normal;\n", counter++,
+                     GetInterpolationQualifier(msaa, ssaa));
+        out.WriteFmt("VARYING_LOCATION({}) {} out float3 WorldPos;\n", counter++,
+                     GetInterpolationQualifier(msaa, ssaa));
       }
     }
 
-    out.Write("void main()\n{\n");
+    out.WriteFmt("void main()\n{{\n");
   }
   else  // D3D
   {
-    out.Write("VS_OUTPUT main(\n");
+    out.WriteFmt("VS_OUTPUT main(\n");
 
     // inputs
-    if (uid_data->components & VB_HAS_NRM0)
-      out.Write("  float3 rawnorm0 : NORMAL0,\n");
-    if (uid_data->components & VB_HAS_NRM1)
-      out.Write("  float3 rawnorm1 : NORMAL1,\n");
-    if (uid_data->components & VB_HAS_NRM2)
-      out.Write("  float3 rawnorm2 : NORMAL2,\n");
-    if (uid_data->components & VB_HAS_COL0)
-      out.Write("  float4 rawcolor0 : COLOR0,\n");
-    if (uid_data->components & VB_HAS_COL1)
-      out.Write("  float4 rawcolor1 : COLOR1,\n");
-    for (int i = 0; i < 8; ++i)
+    if ((uid_data->components & VB_HAS_NRM0) != 0)
+      out.WriteFmt("  float3 rawnorm0 : NORMAL0,\n");
+    if ((uid_data->components & VB_HAS_NRM1) != 0)
+      out.WriteFmt("  float3 rawnorm1 : NORMAL1,\n");
+    if ((uid_data->components & VB_HAS_NRM2) != 0)
+      out.WriteFmt("  float3 rawnorm2 : NORMAL2,\n");
+    if ((uid_data->components & VB_HAS_COL0) != 0)
+      out.WriteFmt("  float4 rawcolor0 : COLOR0,\n");
+    if ((uid_data->components & VB_HAS_COL1) != 0)
+      out.WriteFmt("  float4 rawcolor1 : COLOR1,\n");
+    for (u32 i = 0; i < 8; ++i)
     {
-      u32 hastexmtx = (uid_data->components & (VB_HAS_TEXMTXIDX0 << i));
-      if ((uid_data->components & (VB_HAS_UV0 << i)) || hastexmtx)
-        out.Write("  float%d rawtex%d : TEXCOORD%d,\n", hastexmtx ? 3 : 2, i, i);
+      const u32 has_texmtx = (uid_data->components & (VB_HAS_TEXMTXIDX0 << i));
+
+      if ((uid_data->components & (VB_HAS_UV0 << i)) != 0 || has_texmtx != 0)
+        out.WriteFmt("  float{} rawtex{} : TEXCOORD{},\n", has_texmtx ? 3 : 2, i, i);
     }
-    if (uid_data->components & VB_HAS_POSMTXIDX)
-      out.Write("  uint4 posmtx : BLENDINDICES,\n");
-    out.Write("  float4 rawpos : POSITION) {\n");
+    if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
+      out.WriteFmt("  uint4 posmtx : BLENDINDICES,\n");
+    out.WriteFmt("  float4 rawpos : POSITION) {\n");
   }
 
-  out.Write("VS_OUTPUT o;\n");
+  out.WriteFmt("VS_OUTPUT o;\n");
 
   // transforms
-  if (uid_data->components & VB_HAS_POSMTXIDX)
+  if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
   {
-    out.Write("int posidx = int(posmtx.r);\n");
-    out.Write("float4 pos = float4(dot(" I_TRANSFORMMATRICES
-              "[posidx], rawpos), dot(" I_TRANSFORMMATRICES
-              "[posidx+1], rawpos), dot(" I_TRANSFORMMATRICES "[posidx+2], rawpos), 1);\n");
+    out.WriteFmt("int posidx = int(posmtx.r);\n"
+                 "float4 pos = float4(dot(" I_TRANSFORMMATRICES
+                 "[posidx], rawpos), dot(" I_TRANSFORMMATRICES
+                 "[posidx+1], rawpos), dot(" I_TRANSFORMMATRICES "[posidx+2], rawpos), 1);\n");
 
-    if (uid_data->components & VB_HAS_NRMALL)
+    if ((uid_data->components & VB_HAS_NRMALL) != 0)
     {
-      out.Write("int normidx = posidx & 31;\n");
-      out.Write("float3 N0 = " I_NORMALMATRICES "[normidx].xyz, N1 = " I_NORMALMATRICES
-                "[normidx+1].xyz, N2 = " I_NORMALMATRICES "[normidx+2].xyz;\n");
+      out.WriteFmt("int normidx = posidx & 31;\n"
+                   "float3 N0 = " I_NORMALMATRICES "[normidx].xyz, N1 = " I_NORMALMATRICES
+                   "[normidx+1].xyz, N2 = " I_NORMALMATRICES "[normidx+2].xyz;\n");
     }
 
-    if (uid_data->components & VB_HAS_NRM0)
-      out.Write("float3 _norm0 = normalize(float3(dot(N0, rawnorm0), dot(N1, rawnorm0), dot(N2, "
-                "rawnorm0)));\n");
-    if (uid_data->components & VB_HAS_NRM1)
-      out.Write(
+    if ((uid_data->components & VB_HAS_NRM0) != 0)
+    {
+      out.WriteFmt("float3 _norm0 = normalize(float3(dot(N0, rawnorm0), dot(N1, rawnorm0), dot(N2, "
+                   "rawnorm0)));\n");
+    }
+    if ((uid_data->components & VB_HAS_NRM1) != 0)
+    {
+      out.WriteFmt(
           "float3 _norm1 = float3(dot(N0, rawnorm1), dot(N1, rawnorm1), dot(N2, rawnorm1));\n");
-    if (uid_data->components & VB_HAS_NRM2)
-      out.Write(
+    }
+    if ((uid_data->components & VB_HAS_NRM2) != 0)
+    {
+      out.WriteFmt(
           "float3 _norm2 = float3(dot(N0, rawnorm2), dot(N1, rawnorm2), dot(N2, rawnorm2));\n");
+    }
   }
   else
   {
-    out.Write("float4 pos = float4(dot(" I_POSNORMALMATRIX "[0], rawpos), dot(" I_POSNORMALMATRIX
-              "[1], rawpos), dot(" I_POSNORMALMATRIX "[2], rawpos), 1.0);\n");
-    if (uid_data->components & VB_HAS_NRM0)
-      out.Write("float3 _norm0 = normalize(float3(dot(" I_POSNORMALMATRIX
-                "[3].xyz, rawnorm0), dot(" I_POSNORMALMATRIX
-                "[4].xyz, rawnorm0), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm0)));\n");
-    if (uid_data->components & VB_HAS_NRM1)
-      out.Write("float3 _norm1 = float3(dot(" I_POSNORMALMATRIX
-                "[3].xyz, rawnorm1), dot(" I_POSNORMALMATRIX
-                "[4].xyz, rawnorm1), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm1));\n");
-    if (uid_data->components & VB_HAS_NRM2)
-      out.Write("float3 _norm2 = float3(dot(" I_POSNORMALMATRIX
-                "[3].xyz, rawnorm2), dot(" I_POSNORMALMATRIX
-                "[4].xyz, rawnorm2), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm2));\n");
+    out.WriteFmt("float4 pos = float4(dot(" I_POSNORMALMATRIX "[0], rawpos), dot(" I_POSNORMALMATRIX
+                 "[1], rawpos), dot(" I_POSNORMALMATRIX "[2], rawpos), 1.0);\n");
+    if ((uid_data->components & VB_HAS_NRM0) != 0)
+    {
+      out.WriteFmt("float3 _norm0 = normalize(float3(dot(" I_POSNORMALMATRIX
+                   "[3].xyz, rawnorm0), dot(" I_POSNORMALMATRIX
+                   "[4].xyz, rawnorm0), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm0)));\n");
+    }
+    if ((uid_data->components & VB_HAS_NRM1) != 0)
+    {
+      out.WriteFmt("float3 _norm1 = float3(dot(" I_POSNORMALMATRIX
+                   "[3].xyz, rawnorm1), dot(" I_POSNORMALMATRIX
+                   "[4].xyz, rawnorm1), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm1));\n");
+    }
+    if ((uid_data->components & VB_HAS_NRM2) != 0)
+    {
+      out.WriteFmt("float3 _norm2 = float3(dot(" I_POSNORMALMATRIX
+                   "[3].xyz, rawnorm2), dot(" I_POSNORMALMATRIX
+                   "[4].xyz, rawnorm2), dot(" I_POSNORMALMATRIX "[5].xyz, rawnorm2));\n");
+    }
   }
 
-  if (!(uid_data->components & VB_HAS_NRM0))
-    out.Write("float3 _norm0 = float3(0.0, 0.0, 0.0);\n");
+  if ((uid_data->components & VB_HAS_NRM0) == 0)
+    out.WriteFmt("float3 _norm0 = float3(0.0, 0.0, 0.0);\n");
 
-  out.Write("o.pos = float4(dot(" I_PROJECTION "[0], pos), dot(" I_PROJECTION
-            "[1], pos), dot(" I_PROJECTION "[2], pos), dot(" I_PROJECTION "[3], pos));\n");
+  out.WriteFmt("o.pos = float4(dot(" I_PROJECTION "[0], pos), dot(" I_PROJECTION
+               "[1], pos), dot(" I_PROJECTION "[2], pos), dot(" I_PROJECTION "[3], pos));\n");
 
-  out.Write("int4 lacc;\n"
-            "float3 ldir, h, cosAttn, distAttn;\n"
-            "float dist, dist2, attn;\n");
+  out.WriteFmt("int4 lacc;\n"
+               "float3 ldir, h, cosAttn, distAttn;\n"
+               "float dist, dist2, attn;\n");
 
   GenerateLightingShaderCode(out, uid_data->lighting, uid_data->components, "rawcolor",
                              "o.colors_");
 
   // transform texcoords
-  out.Write("float4 coord = float4(0.0, 0.0, 1.0, 1.0);\n");
-  for (unsigned int i = 0; i < uid_data->numTexGens; ++i)
+  out.WriteFmt("float4 coord = float4(0.0, 0.0, 1.0, 1.0);\n");
+  for (u32 i = 0; i < uid_data->numTexGens; ++i)
   {
     auto& texinfo = uid_data->texMtxInfo[i];
 
-    out.Write("{\n");
-    out.Write("coord = float4(0.0, 0.0, 1.0, 1.0);\n");
+    out.WriteFmt("{{\n");
+    out.WriteFmt("coord = float4(0.0, 0.0, 1.0, 1.0);\n");
     switch (texinfo.sourcerow)
     {
     case XF_SRCGEOM_INROW:
-      out.Write("coord.xyz = rawpos.xyz;\n");
+      out.WriteFmt("coord.xyz = rawpos.xyz;\n");
       break;
     case XF_SRCNORMAL_INROW:
-      if (uid_data->components & VB_HAS_NRM0)
+      if ((uid_data->components & VB_HAS_NRM0) != 0)
       {
-        out.Write("coord.xyz = rawnorm0.xyz;\n");
+        out.WriteFmt("coord.xyz = rawnorm0.xyz;\n");
       }
       break;
     case XF_SRCCOLORS_INROW:
@@ -267,41 +283,43 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
              texinfo.texgentype == XF_TEXGEN_COLOR_STRGBC1);
       break;
     case XF_SRCBINORMAL_T_INROW:
-      if (uid_data->components & VB_HAS_NRM1)
+      if ((uid_data->components & VB_HAS_NRM1) != 0)
       {
-        out.Write("coord.xyz = rawnorm1.xyz;\n");
+        out.WriteFmt("coord.xyz = rawnorm1.xyz;\n");
       }
       break;
     case XF_SRCBINORMAL_B_INROW:
-      if (uid_data->components & VB_HAS_NRM2)
+      if ((uid_data->components & VB_HAS_NRM2) != 0)
       {
-        out.Write("coord.xyz = rawnorm2.xyz;\n");
+        out.WriteFmt("coord.xyz = rawnorm2.xyz;\n");
       }
       break;
     default:
       ASSERT(texinfo.sourcerow <= XF_SRCTEX7_INROW);
-      if (uid_data->components & (VB_HAS_UV0 << (texinfo.sourcerow - XF_SRCTEX0_INROW)))
-        out.Write("coord = float4(rawtex%d.x, rawtex%d.y, 1.0, 1.0);\n",
-                  texinfo.sourcerow - XF_SRCTEX0_INROW, texinfo.sourcerow - XF_SRCTEX0_INROW);
+      if ((uid_data->components & (VB_HAS_UV0 << (texinfo.sourcerow - XF_SRCTEX0_INROW))) != 0)
+      {
+        out.WriteFmt("coord = float4(rawtex{}.x, rawtex{}.y, 1.0, 1.0);\n",
+                     texinfo.sourcerow - XF_SRCTEX0_INROW, texinfo.sourcerow - XF_SRCTEX0_INROW);
+      }
       break;
     }
     // Input form of AB11 sets z element to 1.0
 
     if (texinfo.inputform == XF_TEXINPUT_AB11)
-      out.Write("coord.z = 1.0;\n");
+      out.WriteFmt("coord.z = 1.0;\n");
 
     // first transformation
     switch (texinfo.texgentype)
     {
     case XF_TEXGEN_EMBOSS_MAP:  // calculate tex coords into bump map
 
-      if (uid_data->components & (VB_HAS_NRM1 | VB_HAS_NRM2))
+      if ((uid_data->components & (VB_HAS_NRM1 | VB_HAS_NRM2)) != 0)
       {
         // transform the light dir into tangent space
         out.Write("ldir = normalize(" LIGHT_POS ".xyz - pos.xyz);\n",
                   LIGHT_POS_PARAMS(texinfo.embosslightshift));
-        out.Write(
-            "o.tex%d.xyz = o.tex%d.xyz + float3(dot(ldir, _norm1), dot(ldir, _norm2), 0.0);\n", i,
+        out.WriteFmt(
+            "o.tex{}.xyz = o.tex{}.xyz + float3(dot(ldir, _norm1), dot(ldir, _norm2), 0.0);\n", i,
             texinfo.embosssourceshift);
       }
       else
@@ -309,42 +327,50 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
         // The following assert was triggered in House of the Dead Overkill and Star Wars Rogue
         // Squadron 2
         // ASSERT(0); // should have normals
-        out.Write("o.tex%d.xyz = o.tex%d.xyz;\n", i, texinfo.embosssourceshift);
+        out.WriteFmt("o.tex{}.xyz = o.tex{}.xyz;\n", i, texinfo.embosssourceshift);
       }
 
       break;
     case XF_TEXGEN_COLOR_STRGBC0:
-      out.Write("o.tex%d.xyz = float3(o.colors_0.x, o.colors_0.y, 1);\n", i);
+      out.WriteFmt("o.tex{}.xyz = float3(o.colors_0.x, o.colors_0.y, 1);\n", i);
       break;
     case XF_TEXGEN_COLOR_STRGBC1:
-      out.Write("o.tex%d.xyz = float3(o.colors_1.x, o.colors_1.y, 1);\n", i);
+      out.WriteFmt("o.tex{}.xyz = float3(o.colors_1.x, o.colors_1.y, 1);\n", i);
       break;
     case XF_TEXGEN_REGULAR:
     default:
-      if (uid_data->components & (VB_HAS_TEXMTXIDX0 << i))
+      if ((uid_data->components & (VB_HAS_TEXMTXIDX0 << i)) != 0)
       {
-        out.Write("int tmp = int(rawtex%d.z);\n", i);
+        out.WriteFmt("int tmp = int(rawtex{}.z);\n", i);
         if (((uid_data->texMtxInfo_n_projection >> i) & 1) == XF_TEXPROJ_STQ)
-          out.Write("o.tex%d.xyz = float3(dot(coord, " I_TRANSFORMMATRICES
-                    "[tmp]), dot(coord, " I_TRANSFORMMATRICES
-                    "[tmp+1]), dot(coord, " I_TRANSFORMMATRICES "[tmp+2]));\n",
-                    i);
+        {
+          out.WriteFmt("o.tex{}.xyz = float3(dot(coord, " I_TRANSFORMMATRICES
+                       "[tmp]), dot(coord, " I_TRANSFORMMATRICES
+                       "[tmp+1]), dot(coord, " I_TRANSFORMMATRICES "[tmp+2]));\n",
+                       i);
+        }
         else
-          out.Write("o.tex%d.xyz = float3(dot(coord, " I_TRANSFORMMATRICES
-                    "[tmp]), dot(coord, " I_TRANSFORMMATRICES "[tmp+1]), 1);\n",
-                    i);
+        {
+          out.WriteFmt("o.tex{}.xyz = float3(dot(coord, " I_TRANSFORMMATRICES
+                       "[tmp]), dot(coord, " I_TRANSFORMMATRICES "[tmp+1]), 1);\n",
+                       i);
+        }
       }
       else
       {
         if (((uid_data->texMtxInfo_n_projection >> i) & 1) == XF_TEXPROJ_STQ)
-          out.Write("o.tex%d.xyz = float3(dot(coord, " I_TEXMATRICES
-                    "[%d]), dot(coord, " I_TEXMATRICES "[%d]), dot(coord, " I_TEXMATRICES
-                    "[%d]));\n",
-                    i, 3 * i, 3 * i + 1, 3 * i + 2);
+        {
+          out.WriteFmt("o.tex{}.xyz = float3(dot(coord, " I_TEXMATRICES
+                       "[{}]), dot(coord, " I_TEXMATRICES "[{}]), dot(coord, " I_TEXMATRICES
+                       "[{}]));\n",
+                       i, 3 * i, 3 * i + 1, 3 * i + 2);
+        }
         else
-          out.Write("o.tex%d.xyz = float3(dot(coord, " I_TEXMATRICES
-                    "[%d]), dot(coord, " I_TEXMATRICES "[%d]), 1);\n",
-                    i, 3 * i, 3 * i + 1);
+        {
+          out.WriteFmt("o.tex{}.xyz = float3(dot(coord, " I_TEXMATRICES
+                       "[{}]), dot(coord, " I_TEXMATRICES "[{}]), 1);\n",
+                       i, 3 * i, 3 * i + 1);
+        }
       }
       break;
     }
@@ -354,18 +380,19 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     {
       auto& postInfo = uid_data->postMtxInfo[i];
 
-      out.Write("float4 P0 = " I_POSTTRANSFORMMATRICES "[%d];\n"
-                "float4 P1 = " I_POSTTRANSFORMMATRICES "[%d];\n"
-                "float4 P2 = " I_POSTTRANSFORMMATRICES "[%d];\n",
-                postInfo.index & 0x3f, (postInfo.index + 1) & 0x3f, (postInfo.index + 2) & 0x3f);
+      out.WriteFmt("float4 P0 = " I_POSTTRANSFORMMATRICES "[{}];\n"
+                   "float4 P1 = " I_POSTTRANSFORMMATRICES "[{}];\n"
+                   "float4 P2 = " I_POSTTRANSFORMMATRICES "[{}];\n",
+                   postInfo.index & 0x3f, (postInfo.index + 1) & 0x3f, (postInfo.index + 2) & 0x3f);
 
       if (postInfo.normalize)
-        out.Write("o.tex%d.xyz = normalize(o.tex%d.xyz);\n", i, i);
+        out.WriteFmt("o.tex{}.xyz = normalize(o.tex{}.xyz);\n", i, i);
 
       // multiply by postmatrix
-      out.Write("o.tex%d.xyz = float3(dot(P0.xyz, o.tex%d.xyz) + P0.w, dot(P1.xyz, o.tex%d.xyz) + "
-                "P1.w, dot(P2.xyz, o.tex%d.xyz) + P2.w);\n",
-                i, i, i, i);
+      out.WriteFmt(
+          "o.tex{0}.xyz = float3(dot(P0.xyz, o.tex{0}.xyz) + P0.w, dot(P1.xyz, o.tex{0}.xyz) + "
+          "P1.w, dot(P2.xyz, o.tex{0}.xyz) + P2.w);\n",
+          i);
     }
 
     // When q is 0, the GameCube appears to have a special case
@@ -374,44 +401,44 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     // TODO: check if this only affects XF_TEXGEN_REGULAR
     if (texinfo.texgentype == XF_TEXGEN_REGULAR)
     {
-      out.Write("if(o.tex%d.z == 0.0f)\n", i);
-      out.Write(
-          "\to.tex%d.xy = clamp(o.tex%d.xy / 2.0f, float2(-1.0f,-1.0f), float2(1.0f,1.0f));\n", i,
+      out.WriteFmt(
+          "if(o.tex{0}.z == 0.0f)\n"
+          "\to.tex{0}.xy = clamp(o.tex{0}.xy / 2.0f, float2(-1.0f,-1.0f), float2(1.0f,1.0f));\n",
           i);
     }
 
-    out.Write("}\n");
+    out.WriteFmt("}}\n");
   }
 
   if (uid_data->numColorChans == 0)
   {
-    if (uid_data->components & VB_HAS_COL0)
-      out.Write("o.colors_0 = rawcolor0;\n");
+    if ((uid_data->components & VB_HAS_COL0) != 0)
+      out.WriteFmt("o.colors_0 = rawcolor0;\n");
     else
-      out.Write("o.colors_0 = float4(1.0, 1.0, 1.0, 1.0);\n");
+      out.WriteFmt("o.colors_0 = float4(1.0, 1.0, 1.0, 1.0);\n");
   }
   if (uid_data->numColorChans < 2)
   {
-    if (uid_data->components & VB_HAS_COL1)
-      out.Write("o.colors_1 = rawcolor1;\n");
+    if ((uid_data->components & VB_HAS_COL1) != 0)
+      out.WriteFmt("o.colors_1 = rawcolor1;\n");
     else
-      out.Write("o.colors_1 = o.colors_0;\n");
+      out.WriteFmt("o.colors_1 = o.colors_0;\n");
   }
 
   // clipPos/w needs to be done in pixel shader, not here
   if (!host_config.fast_depth_calc)
-    out.Write("o.clipPos = o.pos;\n");
+    out.WriteFmt("o.clipPos = o.pos;\n");
 
   if (per_pixel_lighting)
   {
-    out.Write("o.Normal = _norm0;\n");
-    out.Write("o.WorldPos = pos.xyz;\n");
+    out.WriteFmt("o.Normal = _norm0;\n"
+                 "o.WorldPos = pos.xyz;\n");
 
-    if (uid_data->components & VB_HAS_COL0)
-      out.Write("o.colors_0 = rawcolor0;\n");
+    if ((uid_data->components & VB_HAS_COL0) != 0)
+      out.WriteFmt("o.colors_0 = rawcolor0;\n");
 
-    if (uid_data->components & VB_HAS_COL1)
-      out.Write("o.colors_1 = rawcolor1;\n");
+    if ((uid_data->components & VB_HAS_COL1) != 0)
+      out.WriteFmt("o.colors_1 = rawcolor1;\n");
   }
 
   // If we can disable the incorrect depth clipping planes using depth clamping, then we can do
@@ -423,13 +450,14 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     // own clipping. We want to clip so that -w <= z <= 0, which matches the console -1..0 range.
     // We adjust our depth value for clipping purposes to match the perspective projection in the
     // software backend, which is a hack to fix Sonic Adventure and Unleashed games.
-    out.Write("float clipDepth = o.pos.z * (1.0 - 1e-7);\n");
-    out.Write("float clipDist0 = clipDepth + o.pos.w;\n");  // Near: z < -w
-    out.Write("float clipDist1 = -clipDepth;\n");           // Far: z > 0
+    out.WriteFmt("float clipDepth = o.pos.z * (1.0 - 1e-7);\n"
+                 "float clipDist0 = clipDepth + o.pos.w;\n"  // Near: z < -w
+                 "float clipDist1 = -clipDepth;\n");         // Far: z > 0
+
     if (host_config.backend_geometry_shaders)
     {
-      out.Write("o.clipDist0 = clipDist0;\n");
-      out.Write("o.clipDist1 = clipDist1;\n");
+      out.WriteFmt("o.clipDist0 = clipDist0;\n"
+                   "o.clipDist1 = clipDist1;\n");
     }
   }
 
@@ -444,20 +472,20 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   // divide, because some games will use a depth range larger than what is allowed by the
   // graphics API. These large depth ranges will still be clipped to the 0..1 range, so these
   // games effectively add a depth bias to the values written to the depth buffer.
-  out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION ".w - "
-            "o.pos.z * " I_PIXELCENTERCORRECTION ".z;\n");
+  out.WriteFmt("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION ".w - "
+               "o.pos.z * " I_PIXELCENTERCORRECTION ".z;\n");
 
   if (!host_config.backend_clip_control)
   {
     // If the graphics API doesn't support a depth range of 0..1, then we need to map z to
     // the -1..1 range. Unfortunately we have to use a substraction, which is a lossy floating-point
     // operation that can introduce a round-trip error.
-    out.Write("o.pos.z = o.pos.z * 2.0 - o.pos.w;\n");
+    out.WriteFmt("o.pos.z = o.pos.z * 2.0 - o.pos.w;\n");
   }
 
   // Correct for negative viewports by mirroring all vertices. We need to negate the height here,
   // since the viewport height is already negated by the render backend.
-  out.Write("o.pos.xy *= sign(" I_PIXELCENTERCORRECTION ".xy * float2(1.0, -1.0));\n");
+  out.WriteFmt("o.pos.xy *= sign(" I_PIXELCENTERCORRECTION ".xy * float2(1.0, -1.0));\n");
 
   // The console GPU places the pixel center at 7/12 in screen space unless
   // antialiasing is enabled, while D3D and OpenGL place it at 0.5. This results
@@ -465,7 +493,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
   // which in turn can be critical if it happens for clear quads.
   // Hence, we compensate for this pixel center difference so that primitives
   // get rasterized correctly.
-  out.Write("o.pos.xy = o.pos.xy - o.pos.w * " I_PIXELCENTERCORRECTION ".xy;\n");
+  out.WriteFmt("o.pos.xy = o.pos.xy - o.pos.w * " I_PIXELCENTERCORRECTION ".xy;\n");
 
   if (vertex_rounding)
   {
@@ -476,18 +504,18 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     // we need to correct this by converting our
     // clip-space position into the Wii's screen-space
     // acquire the right pixel and then convert it back
-    out.Write("if (o.pos.w == 1.0f)\n");
-    out.Write("{\n");
+    out.WriteFmt("if (o.pos.w == 1.0f)\n"
+                 "{{\n"
 
-    out.Write("\tfloat ss_pixel_x = ((o.pos.x + 1.0f) * (" I_VIEWPORT_SIZE ".x * 0.5f));\n");
-    out.Write("\tfloat ss_pixel_y = ((o.pos.y + 1.0f) * (" I_VIEWPORT_SIZE ".y * 0.5f));\n");
+                 "\tfloat ss_pixel_x = ((o.pos.x + 1.0f) * (" I_VIEWPORT_SIZE ".x * 0.5f));\n"
+                 "\tfloat ss_pixel_y = ((o.pos.y + 1.0f) * (" I_VIEWPORT_SIZE ".y * 0.5f));\n"
 
-    out.Write("\tss_pixel_x = round(ss_pixel_x);\n");
-    out.Write("\tss_pixel_y = round(ss_pixel_y);\n");
+                 "\tss_pixel_x = round(ss_pixel_x);\n"
+                 "\tss_pixel_y = round(ss_pixel_y);\n"
 
-    out.Write("\to.pos.x = ((ss_pixel_x / (" I_VIEWPORT_SIZE ".x * 0.5f)) - 1.0f);\n");
-    out.Write("\to.pos.y = ((ss_pixel_y / (" I_VIEWPORT_SIZE ".y * 0.5f)) - 1.0f);\n");
-    out.Write("}\n");
+                 "\to.pos.x = ((ss_pixel_x / (" I_VIEWPORT_SIZE ".x * 0.5f)) - 1.0f);\n"
+                 "\to.pos.y = ((ss_pixel_y / (" I_VIEWPORT_SIZE ".y * 0.5f)) - 1.0f);\n"
+                 "}}\n");
   }
 
   if (api_type == APIType::OpenGL || api_type == APIType::Vulkan)
@@ -500,36 +528,36 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     {
       // TODO: Pass interface blocks between shader stages even if geometry shaders
       // are not supported, however that will require at least OpenGL 3.2 support.
-      for (unsigned int i = 0; i < uid_data->numTexGens; ++i)
-        out.Write("tex%d.xyz = o.tex%d;\n", i, i);
+      for (u32 i = 0; i < uid_data->numTexGens; ++i)
+        out.WriteFmt("tex{}.xyz = o.tex{};\n", i, i);
       if (!host_config.fast_depth_calc)
-        out.Write("clipPos = o.clipPos;\n");
+        out.WriteFmt("clipPos = o.clipPos;\n");
       if (per_pixel_lighting)
       {
-        out.Write("Normal = o.Normal;\n");
-        out.Write("WorldPos = o.WorldPos;\n");
+        out.WriteFmt("Normal = o.Normal;\n"
+                     "WorldPos = o.WorldPos;\n");
       }
-      out.Write("colors_0 = o.colors_0;\n");
-      out.Write("colors_1 = o.colors_1;\n");
+      out.WriteFmt("colors_0 = o.colors_0;\n"
+                   "colors_1 = o.colors_1;\n");
     }
 
     if (host_config.backend_depth_clamp)
     {
-      out.Write("gl_ClipDistance[0] = clipDist0;\n");
-      out.Write("gl_ClipDistance[1] = clipDist1;\n");
+      out.WriteFmt("gl_ClipDistance[0] = clipDist0;\n"
+                   "gl_ClipDistance[1] = clipDist1;\n");
     }
 
     // Vulkan NDC space has Y pointing down (right-handed NDC space).
     if (api_type == APIType::Vulkan)
-      out.Write("gl_Position = float4(o.pos.x, -o.pos.y, o.pos.z, o.pos.w);\n");
+      out.WriteFmt("gl_Position = float4(o.pos.x, -o.pos.y, o.pos.z, o.pos.w);\n");
     else
-      out.Write("gl_Position = o.pos;\n");
+      out.WriteFmt("gl_Position = o.pos;\n");
   }
   else  // D3D
   {
-    out.Write("return o;\n");
+    out.WriteFmt("return o;\n");
   }
-  out.Write("}\n");
+  out.WriteFmt("}}\n");
 
   return out;
 }


### PR DESCRIPTION
Continues the fmt migration by migrating these two generators over. Both were done at the same time, since the vertex shader generator relied on some defines that the lighting shader generator used.