### PR TITLE
Curl: For windows cmake builds, build curl with schannel/winssl capability

### DIFF
--- a/Externals/curl/lib/CMakeLists.txt
+++ b/Externals/curl/lib/CMakeLists.txt
@@ -1,5 +1,7 @@
-if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
-  add_definitions(-DHAVE_CONFIG_H)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    add_definitions(-DUSE_SCHANNEL -DUSE_WINDOWS_SSPI)
+else()
+    add_definitions(-DHAVE_CONFIG_H)
 endif()
 
 include_directories(.)


### PR DESCRIPTION
Added a few flags to the curl external static build so that it has ssl capabilities. otherwise, it doesn't support protocols like https and you get errors trying to send curl requests to those kind of endpoints