### PR TITLE
WiimoteEmu: Don't check extension button press for Wii remote reconnection.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.cpp
@@ -153,16 +153,6 @@ void Classic::Update()
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = classic_data;
 }
 
-bool Classic::IsButtonPressed() const
-{
-  u16 buttons = 0;
-  std::array<ControlState, 2> trigs{};
-  m_buttons->GetState(&buttons, classic_button_bitmasks.data());
-  m_dpad->GetState(&buttons, classic_dpad_bitmasks.data());
-  m_triggers->GetState(&buttons, classic_trigger_bitmasks.data(), trigs.data());
-  return buttons != 0;
-}
-
 void Classic::Reset()
 {
   EncryptedExtension::Reset();

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Classic.h
@@ -180,7 +180,6 @@ public:
   Classic();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(ClassicGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.cpp
@@ -92,12 +92,6 @@ void DrawsomeTablet::Reset()
   m_reg.calibration.fill(0xff);
 }
 
-bool DrawsomeTablet::IsButtonPressed() const
-{
-  // Device has no buttons.
-  return false;
-}
-
 ControllerEmu::ControlGroup* DrawsomeTablet::GetGroup(DrawsomeTabletGroup group)
 {
   switch (group)

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/DrawsomeTablet.h
@@ -29,7 +29,6 @@ public:
   DrawsomeTablet();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(DrawsomeTabletGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.cpp
@@ -165,17 +165,6 @@ void Drums::Update()
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = drum_data;
 }
 
-bool Drums::IsButtonPressed() const
-{
-  u8 buttons = 0;
-  m_buttons->GetState(&buttons, drum_button_bitmasks.data());
-
-  u8 pads = 0;
-  m_pads->GetState(&pads, drum_pad_bitmasks.data());
-
-  return buttons != 0 || pads != 0;
-}
-
 void Drums::Reset()
 {
   EncryptedExtension::Reset();

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Drums.h
@@ -79,7 +79,6 @@ public:
   Drums();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(DrumsGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.cpp
@@ -49,11 +49,6 @@ void None::Update()
   // Nothing needed.
 }
 
-bool None::IsButtonPressed() const
-{
-  return false;
-}
-
 void None::Reset()
 {
   // Nothing needed.

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Extension.h
@@ -31,7 +31,6 @@ public:
   // but M+ does some tricks with it during activation.
   virtual bool ReadDeviceDetectPin() const = 0;
 
-  virtual bool IsButtonPressed() const = 0;
   virtual void Reset() = 0;
   virtual void DoState(PointerWrap& p) = 0;
   virtual void Update() = 0;
@@ -49,7 +48,6 @@ public:
 private:
   bool ReadDeviceDetectPin() const override;
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.cpp
@@ -138,15 +138,6 @@ void Guitar::Update()
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = guitar_data;
 }
 
-bool Guitar::IsButtonPressed() const
-{
-  u16 buttons = 0;
-  m_buttons->GetState(&buttons, guitar_button_bitmasks.data());
-  m_frets->GetState(&buttons, guitar_fret_bitmasks.data());
-  m_strum->GetState(&buttons, guitar_strum_bitmasks.data());
-  return buttons != 0;
-}
-
 void Guitar::Reset()
 {
   EncryptedExtension::Reset();

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Guitar.h
@@ -52,7 +52,6 @@ public:
   Guitar();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(GuitarGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -114,13 +114,6 @@ void Nunchuk::Update()
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = nc_data;
 }
 
-bool Nunchuk::IsButtonPressed() const
-{
-  u8 buttons = 0;
-  m_buttons->GetState(&buttons, nunchuk_button_bitmasks.data());
-  return buttons != 0;
-}
-
 void Nunchuk::Reset()
 {
   EncryptedExtension::Reset();

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.h
@@ -151,7 +151,6 @@ public:
   Nunchuk();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.cpp
@@ -62,14 +62,6 @@ void TaTaCon::Update()
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = tatacon_data;
 }
 
-bool TaTaCon::IsButtonPressed() const
-{
-  u8 state = 0;
-  m_center->GetState(&state, center_bitmasks.data());
-  m_rim->GetState(&state, rim_bitmasks.data());
-  return state != 0;
-}
-
 void TaTaCon::Reset()
 {
   m_reg = {};

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/TaTaCon.h
@@ -33,7 +33,6 @@ public:
   TaTaCon();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(TaTaConGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.cpp
@@ -137,13 +137,6 @@ void Turntable::Update()
   Common::BitCastPtr<DataFormat>(&m_reg.controller_data) = tt_data;
 }
 
-bool Turntable::IsButtonPressed() const
-{
-  u16 buttons = 0;
-  m_buttons->GetState(&buttons, turntable_button_bitmasks.data());
-  return buttons != 0;
-}
-
 void Turntable::Reset()
 {
   EncryptedExtension::Reset();

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Turntable.h
@@ -58,7 +58,6 @@ public:
   Turntable();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(TurntableGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.cpp
@@ -119,13 +119,6 @@ void UDrawTablet::Reset()
   m_reg.calibration.fill(0xff);
 }
 
-bool UDrawTablet::IsButtonPressed() const
-{
-  u8 buttons = 0;
-  m_buttons->GetState(&buttons, udraw_tablet_button_bitmasks.data());
-  return buttons != 0;
-}
-
 ControllerEmu::ControlGroup* UDrawTablet::GetGroup(UDrawTabletGroup group)
 {
   switch (group)

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/UDrawTablet.h
@@ -29,7 +29,6 @@ public:
   UDrawTablet();
 
   void Update() override;
-  bool IsButtonPressed() const override;
   void Reset() override;
 
   ControllerEmu::ControlGroup* GetGroup(UDrawTabletGroup group);

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.cpp
@@ -388,11 +388,6 @@ bool MotionPlus::ReadDeviceDetectPin() const
   }
 }
 
-bool MotionPlus::IsButtonPressed() const
-{
-  return false;
-}
-
 void MotionPlus::Update()
 {
   if (m_progress_timer)

--- a/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
+++ b/Source/Core/Core/HW/WiimoteEmu/MotionPlus.h
@@ -230,7 +230,6 @@ private:
   int BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in) override;
 
   bool ReadDeviceDetectPin() const override;
-  bool IsButtonPressed() const override;
 
   Register m_reg_data = {};
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -673,7 +673,7 @@ bool Wiimote::CheckForButtonPress()
   m_buttons->GetState(&buttons, button_bitmasks);
   m_dpad->GetState(&buttons, dpad_bitmasks);
 
-  return (buttons != 0 || GetActiveExtension()->IsButtonPressed());
+  return buttons != 0;
 }
 
 void Wiimote::LoadDefaults(const ControllerInterface& ciface)


### PR DESCRIPTION
A real Wii remote only initiates reconnection on press of one of its own buttons, not any extensions.
This eliminates some code and it's more accurate.