### PR TITLE
NetPlay: Set Wiimotes at join

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -399,6 +399,16 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket, sf::Packet& rpac)
       break;
     }
   }
+  
+  // try to automatically assign new user a wiimote
+  for (PlayerId& mapping : m_wiimote_map)
+  {
+    if (mapping == 0)
+    {
+      mapping = player.pid;
+      break;
+    }
+  }
 
   // send join message to already connected clients
   sf::Packet spac;


### PR DESCRIPTION
This assigns a wiimote for every new user in NetPlay, like it's already done for GC pads.

There are probably better ways to do this (e.g. detect if the game is for Wii/GC and set the controllers accordingly) but it depends on what is wanted.

Should fix https://bugs.dolphin-emu.org/issues/12206