### PR TITLE
VideoCommon: Don't round the refresh rate

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -242,7 +242,9 @@ FifoPlayer& FifoPlayer::GetInstance()
 void FifoPlayer::WriteFrame(const FifoFrameInfo& frame, const AnalyzedFrameInfo& info)
 {
   // Core timing information
-  m_CyclesPerFrame = SystemTimers::GetTicksPerSecond() / VideoInterface::GetTargetRefreshRate();
+  m_CyclesPerFrame = static_cast<u64>(SystemTimers::GetTicksPerSecond()) *
+                     VideoInterface::GetTargetRefreshRateDenominator() /
+                     VideoInterface::GetTargetRefreshRateNumerator();
   m_ElapsedCycles = 0;
   m_FrameFifoSize = static_cast<u32>(frame.fifoData.size());
 

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -363,7 +363,10 @@ void UpdateInterrupts();
 // Change values pertaining to video mode
 void UpdateParameters();
 
-u32 GetTargetRefreshRate();
+double GetTargetRefreshRate();
+u32 GetTargetRefreshRateNumerator();
+u32 GetTargetRefreshRateDenominator();
+
 u32 GetTicksPerSample();
 u32 GetTicksPerHalfLine();
 u32 GetTicksPerField();

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 120;  // Last changed in PR 8904
+constexpr u32 STATE_VERSION = 121;  // Last changed in PR 8988
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -186,11 +186,11 @@ bool FrameDump::CreateVideoFile()
     s_codec_context->codec_tag = MKTAG('X', 'V', 'I', 'D');
 
   s_codec_context->codec_type = AVMEDIA_TYPE_VIDEO;
-  s_codec_context->bit_rate = g_Config.iBitrateKbps * 1000;
+  s_codec_context->bit_rate = static_cast<int64_t>(g_Config.iBitrateKbps) * 1000;
   s_codec_context->width = s_width;
   s_codec_context->height = s_height;
-  s_codec_context->time_base.num = 1;
-  s_codec_context->time_base.den = VideoInterface::GetTargetRefreshRate();
+  s_codec_context->time_base.num = VideoInterface::GetTargetRefreshRateDenominator();
+  s_codec_context->time_base.den = VideoInterface::GetTargetRefreshRateNumerator();
   s_codec_context->gop_size = 1;
   s_codec_context->level = 1;
   s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGR0 : AV_PIX_FMT_YUV420P;


### PR DESCRIPTION
We now provide a double to the FPS counter and exact values to FIFO recording and frame dumping.