### PR TITLE
Android: Remove touchscreen check for rumble

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -1177,11 +1177,6 @@ public final class EmulationActivity extends AppCompatActivity
             .commit();
   }
 
-  public boolean deviceHasTouchScreen()
-  {
-    return mDeviceHasTouchScreen;
-  }
-
   public String getSelectedTitle()
   {
     return mSelectedTitle;
@@ -1204,7 +1199,7 @@ public final class EmulationActivity extends AppCompatActivity
 
   public void initInputPointer()
   {
-    if (deviceHasTouchScreen())
+    if (mDeviceHasTouchScreen)
       mEmulationFragment.initInputPointer();
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
@@ -22,9 +22,7 @@ public class Rumble
   {
     clear();
 
-    if (activity.deviceHasTouchScreen() &&
-            PreferenceManager.getDefaultSharedPreferences(activity)
-                    .getBoolean("phoneRumble", true))
+    if (PreferenceManager.getDefaultSharedPreferences(activity).getBoolean("phoneRumble", true))
     {
       setPhoneVibrator(true, activity);
     }


### PR DESCRIPTION
That a device doesn't have a touchscreen doesn't necessarily mean that it doesn't support rumble (though it is usually the case). `setPhoneVibrator` already contains a check for whether the device supports rumble, so we can simply remove the touchscreen check.