### PR TITLE
Jit64: Avoid unnecessary MOVAPS instructions

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -449,6 +449,12 @@ void Jit64::fselx(UGeckoInstruction inst)
       MOVAPD(XMM1, Rc);
     }
 
+    if (packed)
+    {
+      VBLENDVPD(Rd, src1, Rb, XMM0);
+      return;
+    }
+
     VBLENDVPD(XMM1, src1, Rb, XMM0);
   }
   else if (cpu_info.bSSE4_1)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -459,6 +459,12 @@ void Jit64::fselx(UGeckoInstruction inst)
   }
   else if (cpu_info.bSSE4_1)
   {
+    if (packed && d == c)
+    {
+      BLENDVPD(Rd, Rb);
+      return;
+    }
+
     MOVAPD(XMM1, Rc);
     BLENDVPD(XMM1, Rb);
   }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -437,7 +437,21 @@ void Jit64::fselx(UGeckoInstruction inst)
   else
     CMPSD(XMM0, Ra, CMP_NLE);
 
-  if (cpu_info.bSSE4_1)
+  if (cpu_info.bAVX)
+  {
+    X64Reg src1 = XMM1;
+    if (Rc.IsSimpleReg())
+    {
+      src1 = Rc.GetSimpleReg();
+    }
+    else
+    {
+      MOVAPD(XMM1, Rc);
+    }
+
+    VBLENDVPD(XMM1, src1, Rb, XMM0);
+  }
+  else if (cpu_info.bSSE4_1)
   {
     MOVAPD(XMM1, Rc);
     BLENDVPD(XMM1, Rb);

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -77,8 +77,7 @@ void CommonAsmRoutines::GenConvertDoubleToSingle()
   else
   {
     // We want bits 0, 1
-    MOVAPD(XMM1, R(XMM0));
-    PAND(XMM1, MConst(double_top_two_bits));
+    avx_op(&XEmitter::VPAND, &XEmitter::PAND, XMM1, R(XMM0), MConst(double_top_two_bits));
     PSRLQ(XMM1, 32);
 
     // And 5 through to 34


### PR DESCRIPTION
We can avoid MOVAPS in a few places by taking advantage of AVX or by realizing when we can write the result directly into the target register.

I've only been able to find one game that uses ps_sel at all (Mario Kart Wii). If anyone knows of any others, please let me know.

---
**fsel with AVX**

Before:
```
66 0F 57 C0          xorpd       xmm0,xmm0
F2 41 0F C2 C6 06    cmpnlesd    xmm0,xmm14
41 0F 28 CE          movaps      xmm1,xmm14
66 41 0F 38 15 CA    blendvpd    xmm1,xmm10,xmm0
F2 44 0F 10 F1       movsd       xmm14,xmm1
```
After:
```
66 0F 57 C0          xorpd       xmm0,xmm0
F2 41 0F C2 C6 06    cmpnlesd    xmm0,xmm14
C4 C3 09 4B CA 00    vblendvpd   xmm1,xmm14,xmm10,xmm0
F2 44 0F 10 F1       movsd       xmm14,xmm1
```
---
**ps_sel with AVX**
Before:
```
66 0F 57 C0          xorpd       xmm0,xmm0
66 41 0F C2 C1 06    cmpnlepd    xmm0,xmm9
C4 C3 09 4B CC 00    vblendvpd   xmm1,xmm14,xmm12,xmm0
44 0F 28 F1          movaps      xmm14,xmm1
```
After:
```
66 0F 57 C0          xorpd       xmm0,xmm0
66 41 0F C2 C1 06    cmpnlepd    xmm0,xmm9
C4 43 09 4B F4 00    vblendvpd   xmm14,xmm14,xmm12,xmm0
```
---
**ps_sel with SSE4.1**
Before:
```
66 0F 57 C0          xorpd       xmm0,xmm0
66 41 0F C2 C1 06    cmpnlepd    xmm0,xmm9
41 0F 28 CE          movaps      xmm1,xmm14
66 41 0F 38 15 CC    blendvpd    xmm1,xmm12,xmm0
44 0F 28 F1          movaps      xmm14,xmm1
```
After:
```
66 0F 57 C0          xorpd       xmm0,xmm0
66 41 0F C2 C1 06    cmpnlepd    xmm0,xmm9
66 45 0F 38 15 F4    blendvpd    xmm14,xmm12,xmm0
```
---
**ConvertDoubleToSingle with AVX**
Before:
```
0F 28 C8                movaps      xmm1,xmm0
66 0F DB 0D CF 2C 00 00 pand        xmm1,xmmword ptr [1F8D283B220h]
```
After:
```
C5 F9 DB 0D D2 2C 00 00 vpand       xmm1,xmm0,xmmword ptr [271835FB220h]
```