### PR TITLE
CMake: Add -D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
   add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
+  add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
The CMake Windows build was broken because of me adding a usage of `std::codecvt_utf8_utf16` to StringUtil.cpp. Kinda silly to have a warning for an API with no standard replacement available...