### PR TITLE
DolphinQt: Don't capture local pointer by reference

### DIFF
--- a/Source/Core/DolphinQt/NKitWarningDialog.cpp
+++ b/Source/Core/DolphinQt/NKitWarningDialog.cpp
@@ -79,7 +79,7 @@ NKitWarningDialog::NKitWarningDialog(QWidget* parent) : QDialog(parent)
 
   ok->setEnabled(false);
   connect(checkbox_accept, &QCheckBox::stateChanged,
-          [&ok](int state) { ok->setEnabled(state == Qt::Checked); });
+          [ok](int state) { ok->setEnabled(state == Qt::Checked); });
 
   connect(this, &QDialog::accepted, [checkbox_skip] {
     Config::SetBase(Config::MAIN_SKIP_NKIT_WARNING, checkbox_skip->isChecked());


### PR DESCRIPTION
This may be the cause of a crash that has been reported on the forums, but I'm not sure since I can't reproduce it myself.