### PR TITLE
Fix some more GCC warnings

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -172,14 +172,13 @@ Common::Debug::Threads PPCDebugInterface::GetThreads() const
   constexpr u32 ACTIVE_QUEUE_HEAD_ADDR = 0x800000dc;
   if (!PowerPC::HostIsRAMAddress(ACTIVE_QUEUE_HEAD_ADDR))
     return threads;
-  u32 addr = PowerPC::HostRead_U32(ACTIVE_QUEUE_HEAD_ADDR);
-  if (!PowerPC::HostIsRAMAddress(addr))
+  const u32 active_queue_head = PowerPC::HostRead_U32(ACTIVE_QUEUE_HEAD_ADDR);
+  if (!PowerPC::HostIsRAMAddress(active_queue_head))
     return threads;
 
-  auto active_thread = std::make_unique<Common::Debug::OSThreadView>(addr);
+  auto active_thread = std::make_unique<Common::Debug::OSThreadView>(active_queue_head);
   if (!active_thread->IsValid())
     return threads;
-  addr = active_thread->Data().thread_link.prev;
 
   const auto insert_threads = [&threads](u32 addr, auto get_next_addr) {
     while (addr != 0 && PowerPC::HostIsRAMAddress(addr))
@@ -192,11 +191,13 @@ Common::Debug::Threads PPCDebugInterface::GetThreads() const
     }
   };
 
-  insert_threads(addr, [](const auto& thread) { return thread.Data().thread_link.prev; });
+  const u32 prev_addr = active_thread->Data().thread_link.prev;
+  insert_threads(prev_addr, [](const auto& thread) { return thread.Data().thread_link.prev; });
   std::reverse(threads.begin(), threads.end());
-  addr = active_thread->Data().thread_link.next;
+
+  const u32 next_addr = active_thread->Data().thread_link.next;
   threads.emplace_back(std::move(active_thread));
-  insert_threads(addr, [](const auto& thread) { return thread.Data().thread_link.next; });
+  insert_threads(next_addr, [](const auto& thread) { return thread.Data().thread_link.next; });
 
   return threads;
 }

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -58,15 +58,20 @@ public:
   std::optional<u64> ReadSwappedAndShifted(u64 offset, const Partition& partition) const
   {
     const std::optional<u32> temp = ReadSwapped<u32>(offset, partition);
-    return temp ? static_cast<u64>(*temp) << GetOffsetShift() : std::optional<u64>();
+    if (!temp)
+      return std::nullopt;
+    return static_cast<u64>(*temp) << GetOffsetShift();
   }
 
   virtual bool IsEncryptedAndHashed() const { return false; }
   virtual std::vector<Partition> GetPartitions() const { return {}; }
   virtual Partition GetGamePartition() const { return PARTITION_NONE; }
-  virtual std::optional<u32> GetPartitionType(const Partition& partition) const { return {}; }
+  virtual std::optional<u32> GetPartitionType(const Partition& partition) const
+  {
+    return std::nullopt;
+  }
   std::optional<u64> GetTitleID() const { return GetTitleID(GetGamePartition()); }
-  virtual std::optional<u64> GetTitleID(const Partition& partition) const { return {}; }
+  virtual std::optional<u64> GetTitleID(const Partition& partition) const { return std::nullopt; }
   virtual const IOS::ES::TicketReader& GetTicket(const Partition& partition) const
   {
     return INVALID_TICKET;

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -571,17 +571,17 @@ bool VolumeWii::EncryptGroup(
     encryption_futures[i] = std::async(
         std::launch::async,
         [&unencrypted_data, &unencrypted_hashes, &aes_context, &out](size_t start, size_t end) {
-          for (size_t i = start; i < end; ++i)
+          for (size_t j = start; j < end; ++j)
           {
-            u8* out_ptr = out->data() + i * BLOCK_TOTAL_SIZE;
+            u8* out_ptr = out->data() + j * BLOCK_TOTAL_SIZE;
 
             u8 iv[16] = {};
             mbedtls_aes_crypt_cbc(&aes_context, MBEDTLS_AES_ENCRYPT, BLOCK_HEADER_SIZE, iv,
-                                  reinterpret_cast<u8*>(&unencrypted_hashes[i]), out_ptr);
+                                  reinterpret_cast<u8*>(&unencrypted_hashes[j]), out_ptr);
 
             std::memcpy(iv, out_ptr + 0x3D0, sizeof(iv));
             mbedtls_aes_crypt_cbc(&aes_context, MBEDTLS_AES_ENCRYPT, BLOCK_DATA_SIZE, iv,
-                                  unencrypted_data[i].data(), out_ptr + BLOCK_HEADER_SIZE);
+                                  unencrypted_data[j].data(), out_ptr + BLOCK_HEADER_SIZE);
           }
         },
         i * BLOCKS_PER_GROUP / threads, (i + 1) * BLOCKS_PER_GROUP / threads);

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -379,7 +379,7 @@ bool WIARVZFileReader<RVZ>::Read(u64 offset, u64 size, u8* out_ptr)
                 offset - partition_data_offset, bytes_to_read, out_ptr, partition_data_offset,
                 partition_total_sectors * VolumeWii::BLOCK_DATA_SIZE, partition.partition_key,
                 [this, &hash_exception_error](
-                    VolumeWii::HashBlock hash_blocks[VolumeWii::BLOCKS_PER_GROUP], u64 offset) {
+                    VolumeWii::HashBlock hash_blocks[VolumeWii::BLOCKS_PER_GROUP], u64 offset_) {
                   // EncryptGroups calls ReadWiiDecrypted, which calls ReadFromGroups,
                   // which populates m_exception_list when m_write_to_exception_list == true
                   if (!ApplyHashExceptions(m_exception_list, hash_blocks))

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -252,14 +252,14 @@ void ThreadWidget::Update()
   if (!isVisible())
     return;
 
-  const auto state = Core::GetState();
-  if (state == Core::State::Stopping)
+  const auto emu_state = Core::GetState();
+  if (emu_state == Core::State::Stopping)
   {
     m_thread_table->setRowCount(0);
     UpdateThreadContext({});
     UpdateThreadCallstack({});
   }
-  if (state != Core::State::Paused)
+  if (emu_state != Core::State::Paused)
     return;
 
   const auto format_hex = [](u32 value) {
@@ -269,9 +269,9 @@ void ThreadWidget::Update()
     addr = PowerPC::HostIsRAMAddress(addr) ? PowerPC::HostRead_U32(addr) : 0;
     return format_hex(addr);
   };
-  const auto get_state = [](u16 state) {
+  const auto get_state = [](u16 thread_state) {
     QString state_name;
-    switch (state)
+    switch (thread_state)
     {
     case 1:
       state_name = tr("READY");
@@ -288,7 +288,7 @@ void ThreadWidget::Update()
     default:
       state_name = tr("UNKNOWN");
     }
-    return QStringLiteral("%1 (%2)").arg(QString::number(state), state_name);
+    return QStringLiteral("%1 (%2)").arg(QString::number(thread_state), state_name);
   };
   const auto get_priority = [](u16 base, u16 effective) {
     return QStringLiteral("%1 (%2)").arg(QString::number(base), QString::number(effective));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -56,14 +56,14 @@ ControlState AnalogStick::GetGateRadiusAtAngle(double ang) const
   return m_stick_gate->GetRadiusAtAngle(ang);
 }
 
-OctagonAnalogStick::OctagonAnalogStick(const char* name, ControlState gate_radius)
-    : OctagonAnalogStick(name, name, gate_radius)
+OctagonAnalogStick::OctagonAnalogStick(const char* name_, ControlState gate_radius)
+    : OctagonAnalogStick(name_, name_, gate_radius)
 {
 }
 
-OctagonAnalogStick::OctagonAnalogStick(const char* name, const char* ui_name,
+OctagonAnalogStick::OctagonAnalogStick(const char* name_, const char* ui_name_,
                                        ControlState gate_radius)
-    : AnalogStick(name, ui_name, std::make_unique<ControllerEmu::OctagonStickGate>(gate_radius))
+    : AnalogStick(name_, ui_name_, std::make_unique<ControllerEmu::OctagonStickGate>(gate_radius))
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -21,8 +21,8 @@
 
 namespace ControllerEmu
 {
-Cursor::Cursor(std::string name, std::string ui_name)
-    : ReshapableInput(std::move(name), std::move(ui_name), GroupType::Cursor),
+Cursor::Cursor(std::string name_, std::string ui_name_)
+    : ReshapableInput(std::move(name_), std::move(ui_name_), GroupType::Cursor),
       m_last_update(Clock::now())
 {
   for (auto& named_direction : named_directions)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
@@ -14,8 +14,8 @@
 
 namespace ControllerEmu
 {
-IMUAccelerometer::IMUAccelerometer(std::string name, std::string ui_name)
-    : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUAccelerometer)
+IMUAccelerometer::IMUAccelerometer(std::string name_, std::string ui_name_)
+    : ControlGroup(std::move(name_), std::move(ui_name_), GroupType::IMUAccelerometer)
 {
   AddInput(Translate, _trans("Up"));
   AddInput(Translate, _trans("Down"));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -16,9 +16,9 @@
 
 namespace ControllerEmu
 {
-IMUCursor::IMUCursor(std::string name, std::string ui_name)
+IMUCursor::IMUCursor(std::string name_, std::string ui_name_)
     : ControlGroup(
-          std::move(name), std::move(ui_name), GroupType::IMUCursor,
+          std::move(name_), std::move(ui_name_), GroupType::IMUCursor,
 #ifdef ANDROID
           // Enabling this on Android devices which have an accelerometer and gyroscope prevents
           // touch controls from being used for pointing, and touch controls generally work better

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -24,8 +24,8 @@ static constexpr auto MAXIMUM_CALIBRATION_DURATION = std::chrono::hours(1);
 // This is made slightly lower than the UI update frequency of 30.
 static constexpr auto WORST_ACCEPTABLE_CALIBRATION_UPDATE_FREQUENCY = 25;
 
-IMUGyroscope::IMUGyroscope(std::string name, std::string ui_name)
-    : ControlGroup(std::move(name), std::move(ui_name), GroupType::IMUGyroscope)
+IMUGyroscope::IMUGyroscope(std::string name_, std::string ui_name_)
+    : ControlGroup(std::move(name_), std::move(ui_name_), GroupType::IMUGyroscope)
 {
   AddInput(Translate, _trans("Pitch Up"));
   AddInput(Translate, _trans("Pitch Down"));

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -109,8 +109,8 @@ std::optional<u32> SquareStickGate::GetIdealCalibrationSampleCount() const
   return 8;
 }
 
-ReshapableInput::ReshapableInput(std::string name, std::string ui_name, GroupType type)
-    : ControlGroup(std::move(name), std::move(ui_name), type)
+ReshapableInput::ReshapableInput(std::string name_, std::string ui_name_, GroupType type_)
+    : ControlGroup(std::move(name_), std::move(ui_name_), type_)
 {
   AddDeadzoneSetting(&m_deadzone_setting, 50);
 }


### PR DESCRIPTION
This works around some GCC bugs:
- [-Wshadow warns three times when a constructor parameter shadows a data member](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78147)
- [std::optional can trigger bogus -Wmaybe-uninitialized warnings](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635)