### PR TITLE
OnScreenDisplay: fix names rgba -> argb

### DIFF
--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -37,12 +37,12 @@ struct Message
 static std::multimap<MessageType, Message> s_messages;
 static std::mutex s_messages_mutex;
 
-static ImVec4 RGBAToImVec4(const u32 rgba)
+static ImVec4 ARGBToImVec4(const u32 argb)
 {
-  return ImVec4(static_cast<float>((rgba >> 16) & 0xFF) / 255.0f,
-                static_cast<float>((rgba >> 8) & 0xFF) / 255.0f,
-                static_cast<float>((rgba >> 0) & 0xFF) / 255.0f,
-                static_cast<float>((rgba >> 24) & 0xFF) / 255.0f);
+  return ImVec4(static_cast<float>((argb >> 16) & 0xFF) / 255.0f,
+                static_cast<float>((argb >> 8) & 0xFF) / 255.0f,
+                static_cast<float>((argb >> 0) & 0xFF) / 255.0f,
+                static_cast<float>((argb >> 24) & 0xFF) / 255.0f);
 }
 
 static float DrawMessage(int index, const Message& msg, const ImVec2& position, int time_left)
@@ -67,7 +67,7 @@ static float DrawMessage(int index, const Message& msg, const ImVec2& position, 
                        ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing))
   {
     // Use %s in case message contains %.
-    ImGui::TextColored(RGBAToImVec4(msg.color), "%s", msg.text.c_str());
+    ImGui::TextColored(ARGBToImVec4(msg.color), "%s", msg.text.c_str());
     window_height =
         ImGui::GetWindowSize().y + (WINDOW_PADDING * ImGui::GetIO().DisplayFramebufferScale.y);
   }
@@ -78,18 +78,18 @@ static float DrawMessage(int index, const Message& msg, const ImVec2& position, 
   return window_height;
 }
 
-void AddTypedMessage(MessageType type, std::string message, u32 ms, u32 rgba)
+void AddTypedMessage(MessageType type, std::string message, u32 ms, u32 argb)
 {
   std::lock_guard lock{s_messages_mutex};
   s_messages.erase(type);
-  s_messages.emplace(type, Message(std::move(message), Common::Timer::GetTimeMs() + ms, rgba));
+  s_messages.emplace(type, Message(std::move(message), Common::Timer::GetTimeMs() + ms, argb));
 }
 
-void AddMessage(std::string message, u32 ms, u32 rgba)
+void AddMessage(std::string message, u32 ms, u32 argb)
 {
   std::lock_guard lock{s_messages_mutex};
   s_messages.emplace(MessageType::Typeless,
-                     Message(std::move(message), Common::Timer::GetTimeMs() + ms, rgba));
+                     Message(std::move(message), Common::Timer::GetTimeMs() + ms, argb));
 }
 
 void DrawMessages()

--- a/Source/Core/VideoCommon/OnScreenDisplay.h
+++ b/Source/Core/VideoCommon/OnScreenDisplay.h
@@ -37,9 +37,9 @@ constexpr u32 VERY_LONG = 10000;
 };  // namespace Duration
 
 // On-screen message display (colored yellow by default)
-void AddMessage(std::string message, u32 ms = Duration::SHORT, u32 rgba = Color::YELLOW);
+void AddMessage(std::string message, u32 ms = Duration::SHORT, u32 argb = Color::YELLOW);
 void AddTypedMessage(MessageType type, std::string message, u32 ms = Duration::SHORT,
-                     u32 rgba = Color::YELLOW);
+                     u32 argb = Color::YELLOW);
 
 // Draw the current messages on the screen. Only call once per frame.
 void DrawMessages();


### PR DESCRIPTION
Considering `Color::YELLOW` is `0xFFFFFF30`, and it looks yellow to me, this just seems to have been switched up.