### PR TITLE
Update warning log OpenGL 2.0 to 3.x

### DIFF
--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -122,8 +122,8 @@ bool VideoBackend::InitializeGLExtensions(GLContext* context)
   if (!GLExtensions::Init(context))
   {
     // OpenGL 2.0 is required for all shader based drawings. There is no way to get this by
-    // extensions
-    PanicAlert("GPU: OGL ERROR: Does your video card support OpenGL 2.0?");
+    // extensions. For endusers it will ask for OpenGL 3.x version.
+    PanicAlert("GPU: OGL ERROR: Does your video card support OpenGL 3.x?");
     return false;
   }
 

--- a/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
+++ b/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
@@ -41,7 +41,7 @@ bool SWOGLWindow::Initialize(const WindowSystemInfo& wsi)
   // Init extension support.
   if (!GLExtensions::Init(m_gl_context.get()))
   {
-    ERROR_LOG(VIDEO, "GLExtensions::Init failed!Does your video card support OpenGL 2.0?");
+    ERROR_LOG(VIDEO, "GLExtensions::Init failed!Does your video card support OpenGL 3.x?");
     return false;
   }
   else if (GLExtensions::Version() < 310)


### PR DESCRIPTION
This will change the warning message for users when they run an outdated computer or one where it can't detect the GLextensions.

This is what displayed on a computer with OpenGL 2.1 and DirectX  10.1 version. Pressing either one of these options doesn't work to use Dolphin.
Either way minimum is 3.x for OpenGL.
![image](https://user-images.githubusercontent.com/24227051/89112572-fcb8a980-d464-11ea-9eb7-1f79c2e519c9.png)
