### PR TITLE
MainWindow: Attach quit emulation sheet to RenderWidget if shown on macOS

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -824,7 +824,7 @@ bool MainWindow::RequestStop()
       Core::SetState(Core::State::Paused);
 
     auto confirm = ModalMessageBox::question(
-        this, tr("Confirm"),
+        m_rendering_to_main ? static_cast<QWidget*>(this) : m_render_widget, tr("Confirm"),
         m_stop_requested ? tr("A shutdown is already in progress. Unsaved data "
                               "may be lost if you stop the current emulation "
                               "before it completes. Force stop?") :


### PR DESCRIPTION
_Extremely_ minor UI tweak. Without this PR, the sheet would be attached to MainWindow and macOS would change the focused window to it. Always kinda annoyed me.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/11504941/89170228-57c5cb80-d54d-11ea-8104-9d9a2a54adc1.png">
