### PR TITLE
GameSettings: Add patches for Pokémon Colosseum and Pokémon XD to circumvent the check that the save being overwritten matches the last known save.

### DIFF
--- a/Data/Sys/GameSettings/GC6E01.ini
+++ b/Data/Sys/GameSettings/GC6E01.ini
@@ -1,0 +1,27 @@
+# GC6E01 - Pokémon Colosseum
+
+[OnFrame]
+# This game has extra memory card checks compared to most games,
+# presumably to prevent Pokémon duping. These can interfere with
+# saving your game when using savestates.
+#
+# 0x801cfc2c:
+# Originally a branch that checks if the save counter in memory
+# matches the one on the memory card. We patch this to instead
+# overwrite the counter in memory with the one from the memory
+# card. We need to do this because each memory card file actually
+# contains three save slots the game rotates when saving, and
+# when loading it loads the save with the biggest save counter.
+# So we need to make sure the newly written save (which uses
+# the value from memory + 1) is higher than any save currently
+# on the card.
+#
+# 0x801cfc7c:
+# Another branch. Not entirely sure what this one checks, but
+# not patching this one sometimes still makes it recognize the
+# memory card as 'not the same Memory Card as the one used to
+# load the saved data', so nop it out.
+#
+$Allow Memory Card saving with Savestates
+0x801cfc2c:dword:0x9005002c
+0x801cfc7c:dword:0x60000000

--- a/Data/Sys/GameSettings/GC6J01.ini
+++ b/Data/Sys/GameSettings/GC6J01.ini
@@ -1,0 +1,27 @@
+# GC6J01 - ポケモンコロシアム
+
+[OnFrame]
+# This game has extra memory card checks compared to most games,
+# presumably to prevent Pokémon duping. These can interfere with
+# saving your game when using savestates.
+#
+# 0x801cb5b8:
+# Originally a branch that checks if the save counter in memory
+# matches the one on the memory card. We patch this to instead
+# overwrite the counter in memory with the one from the memory
+# card. We need to do this because each memory card file actually
+# contains three save slots the game rotates when saving, and
+# when loading it loads the save with the biggest save counter.
+# So we need to make sure the newly written save (which uses
+# the value from memory + 1) is higher than any save currently
+# on the card.
+#
+# 0x801cb608:
+# Another branch. Not entirely sure what this one checks, but
+# not patching this one sometimes still makes it recognize the
+# memory card as 'not the same Memory Card as the one used to
+# load the saved data', so nop it out.
+#
+$Allow Memory Card saving with Savestates
+0x801cb5b8:dword:0x9005002c
+0x801cb608:dword:0x60000000

--- a/Data/Sys/GameSettings/GC6P01.ini
+++ b/Data/Sys/GameSettings/GC6P01.ini
@@ -1,0 +1,27 @@
+# GC6P01 - Pokémon Colosseum
+
+[OnFrame]
+# This game has extra memory card checks compared to most games,
+# presumably to prevent Pokémon duping. These can interfere with
+# saving your game when using savestates.
+#
+# 0x801d429c:
+# Originally a branch that checks if the save counter in memory
+# matches the one on the memory card. We patch this to instead
+# overwrite the counter in memory with the one from the memory
+# card. We need to do this because each memory card file actually
+# contains three save slots the game rotates when saving, and
+# when loading it loads the save with the biggest save counter.
+# So we need to make sure the newly written save (which uses
+# the value from memory + 1) is higher than any save currently
+# on the card.
+#
+# 0x801d42ec:
+# Another branch. Not entirely sure what this one checks, but
+# not patching this one sometimes still makes it recognize the
+# memory card as 'not the same Memory Card as the one used to
+# load the saved data', so nop it out.
+#
+$Allow Memory Card saving with Savestates
+0x801d429c:dword:0x9005002c
+0x801d42ec:dword:0x60000000

--- a/Data/Sys/GameSettings/GXXE01.ini
+++ b/Data/Sys/GameSettings/GXXE01.ini
@@ -1,0 +1,7 @@
+# GXXE01 - Pokémon XD: Gale of Darkness
+
+[OnFrame]
+# Very similar to Pokémon Colosseum's save check, see those files for details.
+$Allow Memory Card saving with Savestates
+0x801cc304:dword:0x90e5002c
+0x801cc4b0:dword:0x60000000

--- a/Data/Sys/GameSettings/GXXJ01.ini
+++ b/Data/Sys/GameSettings/GXXJ01.ini
@@ -1,0 +1,7 @@
+# GXXJ01 - ポケモンＸＤ 闇の旋風ダーク・ルギア
+
+[OnFrame]
+# Very similar to Pokémon Colosseum's save check, see those files for details.
+$Allow Memory Card saving with Savestates
+0x801c7984:dword:0x90e5002c
+0x801c7b30:dword:0x60000000

--- a/Data/Sys/GameSettings/GXXP01.ini
+++ b/Data/Sys/GameSettings/GXXP01.ini
@@ -1,0 +1,7 @@
+# GXXP01 - Pokémon XD: Gale of Darkness
+
+[OnFrame]
+# Very similar to Pokémon Colosseum's save check, see those files for details.
+$Allow Memory Card saving with Savestates
+0x801cd764:dword:0x90e5002c
+0x801cd910:dword:0x60000000


### PR DESCRIPTION
I think the [last Progress Report](https://dolphin-emu.org/blog/2020/07/05/dolphin-progress-report-may-and-june-2020/) sums this up pretty well:

> Note: These fixes do not affect Pokemon Colosseum and Pokemon XD's save issues regarding savestates. They have purposeful memory card checks to prevent the duping of Pokemon. Unlike the previous problem, which was more of an emulation oversight, this one is something that should be solved through a game patch. Currently no one is investigating this issue and you should be wary of using savestates with these games. If someone does write a patch or a cheat for this issue, we will be happy to include it with the game's INI file for easy access to users.

These are the relevant patches.

I have not thoroughly tested this yet except for the simple 'make savestate, make regular save, load savestate, try to save again' action chain that didn't work before but works with these patches. It's technically possible that this has side-effects I am unaware of.