### PR TITLE
Android: Fix SettingsActivity lifecycle management

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -109,15 +109,12 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   }
 
   @Override
-  public void onBackPressed()
-  {
-    mPresenter.onBackPressed();
-  }
-
-  @Override
   public void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack,
           String gameID)
   {
+    if (!addToStack && getFragment() != null)
+      return;
+
     FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
     if (addToStack)
@@ -132,7 +129,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
       }
 
       transaction.addToBackStack(null);
-      mPresenter.addToStack();
     }
     transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag, gameID, extras),
             FRAGMENT_TAG);
@@ -277,12 +273,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   public void showToastMessage(String message)
   {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
-  }
-
-  @Override
-  public void popBackStack()
-  {
-    getSupportFragmentManager().popBackStackImmediate();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -23,8 +23,6 @@ public final class SettingsActivityPresenter
 
   private Settings mSettings = new Settings();
 
-  private int mStackCount;
-
   private boolean mShouldSave;
 
   private DirectoryStateReceiver directoryStateReceiver;
@@ -144,24 +142,6 @@ public final class SettingsActivityPresenter
     {
       Log.debug("[SettingsActivity] Settings activity stopping. Saving settings to INI...");
       mSettings.saveSettings(mView, context, modifiedSettings);
-    }
-  }
-
-  public void addToStack()
-  {
-    mStackCount++;
-  }
-
-  public void onBackPressed()
-  {
-    if (mStackCount > 0)
-    {
-      mView.popBackStack();
-      mStackCount--;
-    }
-    else
-    {
-      mView.finish();
     }
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -42,16 +42,11 @@ public final class SettingsActivityPresenter
 
   public void onCreate(Bundle savedInstanceState, MenuTag menuTag, String gameId, Context context)
   {
-    if (savedInstanceState == null)
-    {
-      this.menuTag = menuTag;
-      this.gameId = gameId;
-      this.context = context;
-    }
-    else
-    {
-      mShouldSave = savedInstanceState.getBoolean(KEY_SHOULD_SAVE);
-    }
+    this.menuTag = menuTag;
+    this.gameId = gameId;
+    this.context = context;
+
+    mShouldSave = savedInstanceState != null && savedInstanceState.getBoolean(KEY_SHOULD_SAVE);
   }
 
   public void onStart()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -57,11 +57,6 @@ public interface SettingsActivityView
   void showToastMessage(String message);
 
   /**
-   * Show the previous fragment.
-   */
-  void popBackStack();
-
-  /**
    * End the activity.
    */
   void finish();


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/10815 and the behavior where the settings activity would go back to the top-level menu after switching to a different app and back.