### PR TITLE
Android: Remove some static variables from SettingsAdapter

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -179,7 +179,8 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     // If the user picked a file, as opposed to just backing out.
     if (resultCode == MainActivity.RESULT_OK)
     {
-      mPresenter.onFileConfirmed(FileBrowserHelper.getSelectedPath(result));
+      String path = FileBrowserHelper.getSelectedPath(result);
+      getFragment().getAdapter().onFilePickerConfirmation(path);
 
       // Prevent duplicate Toasts.
       if (!mPresenter.shouldSave())

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -235,9 +235,4 @@ public final class SettingsActivityPresenter
       mView.showSettingsFragment(menuTag, bundle, true, gameId);
     }
   }
-
-  public void onFileConfirmed(String file)
-  {
-    SettingsAdapter.onFilePickerConfirmation(file);
-  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -180,6 +180,12 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   }
 
   @Override
+  public SettingsAdapter getAdapter()
+  {
+    return mAdapter;
+  }
+
+  @Override
   public void loadSubMenu(MenuTag menuKey)
   {
     mActivity.showSettingsFragment(menuKey, null, true, getArguments().getString(ARGUMENT_GAME_ID));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -368,7 +368,7 @@ public final class SettingsFragmentPresenter
             Settings.SECTION_INI_GENERAL, R.string.SD_card_path, 0, getDefaultSDPath(),
             MainPresenter.REQUEST_SD_FILE, wiiSDCardPath));
     sl.add(new ConfirmRunnable(R.string.reset_paths, 0, R.string.reset_paths_confirmation, 0,
-            SettingsAdapter::resetPaths));
+            mView.getAdapter()::resetPaths));
   }
 
   private void addGameCubeSettings(ArrayList<SettingsItem> sl)
@@ -752,11 +752,9 @@ public final class SettingsFragmentPresenter
             R.string.log_verbosity, 0, getLogVerbosityEntries(), getLogVerbosityValues(), 1,
             logVerbosity));
     sl.add(new ConfirmRunnable(R.string.log_enable_all, 0, R.string.log_enable_all_confirmation, 0,
-            () -> SettingsAdapter.setAllLogTypes("True")));
-    sl.add(
-            new ConfirmRunnable(R.string.log_disable_all, 0, R.string.log_disable_all_confirmation,
-                    0,
-                    () -> SettingsAdapter.setAllLogTypes("False")));
+            () -> mView.getAdapter().setAllLogTypes("True")));
+    sl.add(new ConfirmRunnable(R.string.log_disable_all, 0, R.string.log_disable_all_confirmation,
+            0, () -> mView.getAdapter().setAllLogTypes("False")));
 
     sl.add(new HeaderSetting(null, null, R.string.log_types, 0));
     for (Map.Entry<String, String> entry : LOG_TYPE_NAMES.entrySet())

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -50,6 +50,11 @@ public interface SettingsFragmentView
   FragmentActivity getActivity();
 
   /**
+   * @return The Fragment's SettingsAdapter.
+   */
+  SettingsAdapter getAdapter();
+
+  /**
    * Tell the Fragment to tell the containing Activity to show a new
    * Fragment containing a submenu of settings.
    *


### PR DESCRIPTION
All of these have non-static equivalents (`mView` and `mClickedItem`).