### PR TITLE
Android: Persist Settings using ViewModel

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.2.0'
     implementation 'com.google.android.material:material:1.1.0'
 
     // Android TV UI libraries.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -10,6 +10,7 @@ import android.provider.Settings;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -31,7 +32,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   private static final String ARG_MENU_TAG = "menu_tag";
   private static final String ARG_GAME_ID = "game_id";
   private static final String FRAGMENT_TAG = "settings";
-  private SettingsActivityPresenter mPresenter = new SettingsActivityPresenter(this);
+  private SettingsActivityPresenter mPresenter;
 
   private ProgressDialog dialog;
 
@@ -62,6 +63,8 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     Intent launcher = getIntent();
     String gameID = launcher.getStringExtra(ARG_GAME_ID);
     MenuTag menuTag = (MenuTag) launcher.getSerializableExtra(ARG_MENU_TAG);
+
+    mPresenter = new SettingsActivityPresenter(this, getSettings());
     mPresenter.onCreate(savedInstanceState, menuTag, gameID, getApplicationContext());
   }
 
@@ -241,13 +244,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   @Override
   public org.dolphinemu.dolphinemu.features.settings.model.Settings getSettings()
   {
-    return mPresenter.getSettings();
-  }
-
-  @Override
-  public void setSettings(org.dolphinemu.dolphinemu.features.settings.model.Settings settings)
-  {
-    mPresenter.setSettings(settings);
+    return new ViewModelProvider(this).get(SettingsViewModel.class).getSettings();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -21,7 +21,7 @@ public final class SettingsActivityPresenter
 
   private SettingsActivityView mView;
 
-  private Settings mSettings = new Settings();
+  private Settings mSettings;
 
   private int mStackCount;
 
@@ -35,9 +35,10 @@ public final class SettingsActivityPresenter
 
   private final Set<String> modifiedSettings = new HashSet<>();
 
-  SettingsActivityPresenter(SettingsActivityView view)
+  SettingsActivityPresenter(SettingsActivityView view, Settings settings)
   {
     mView = view;
+    mSettings = settings;
   }
 
   public void onCreate(Bundle savedInstanceState, MenuTag menuTag, String gameId, Context context)
@@ -119,11 +120,6 @@ public final class SettingsActivityPresenter
 
       mView.startDirectoryInitializationService(directoryStateReceiver, statusIntentFilter);
     }
-  }
-
-  public void setSettings(Settings settings)
-  {
-    mSettings = settings;
   }
 
   public Settings getSettings()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -29,15 +29,6 @@ public interface SettingsActivityView
   Settings getSettings();
 
   /**
-   * Used to provide the Activity with Settings HashMaps if a Fragment already
-   * has one; for example, if a rotation occurs, the Fragment will not be killed,
-   * but the Activity will, so the Activity needs to have its HashMaps resupplied.
-   *
-   * @param settings The ArrayList of all the Settings HashMaps.
-   */
-  void setSettings(Settings settings);
-
-  /**
    * Called when an asynchronous load operation completes.
    *
    * @param settings The (possibly null) result of the ini load operation.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -89,7 +89,6 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     super.onAttach(context);
 
     mActivity = (SettingsActivityView) context;
-    mPresenter.onAttach();
   }
 
   @Override
@@ -155,16 +154,6 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
           org.dolphinemu.dolphinemu.features.settings.model.Settings settings)
   {
     mPresenter.setSettings(settings);
-  }
-
-  @Override
-  public void passSettingsToActivity(
-          org.dolphinemu.dolphinemu.features.settings.model.Settings settings)
-  {
-    if (mActivity != null)
-    {
-      mActivity.setSettings(settings);
-    }
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -82,19 +82,6 @@ public final class SettingsFragmentPresenter
     setSettings(settings);
   }
 
-  /**
-   * If the screen is rotated, the Activity will forget the settings map. This fragment
-   * won't, though; so rather than have the Activity reload from disk, have the fragment pass
-   * the settings map back to the Activity.
-   */
-  public void onAttach()
-  {
-    if (mSettings != null)
-    {
-      mView.passSettingsToActivity(mSettings);
-    }
-  }
-
   public void putSetting(Setting setting)
   {
     mSettings.getSection(setting.getSection()).putSetting(setting);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -23,15 +23,6 @@ public interface SettingsFragmentView
   void onSettingsFileLoaded(Settings settings);
 
   /**
-   * Pass a settings HashMap to the containing activity, so that it can
-   * share the HashMap with other SettingsFragments; useful so that rotations
-   * do not require an additional load operation.
-   *
-   * @param settings An ArrayList containing all the settings HashMaps.
-   */
-  void passSettingsToActivity(Settings settings);
-
-  /**
    * Pass an ArrayList to the View so that it can be displayed on screen.
    *
    * @param settingsList The result of converting the HashMap to an ArrayList

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsViewModel.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsViewModel.java
@@ -1,0 +1,15 @@
+package org.dolphinemu.dolphinemu.features.settings.ui;
+
+import org.dolphinemu.dolphinemu.features.settings.model.Settings;
+
+import androidx.lifecycle.ViewModel;
+
+public class SettingsViewModel extends ViewModel
+{
+  private final Settings mSettings = new Settings();
+
+  public Settings getSettings()
+  {
+    return mSettings;
+  }
+}


### PR DESCRIPTION
Just for maintainability. This is a shorter and more standard solution compared to our current one where the Fragment persists the Settings and passes it to the Activity.