### PR TITLE
Remove wait_for_completion parameter from Renderer::SaveScreenshot

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -713,26 +713,25 @@ static std::string GenerateScreenshotName()
   return name;
 }
 
-void SaveScreenShot(bool wait_for_completion)
+void SaveScreenShot()
 {
   const bool bPaused = GetState() == State::Paused;
 
   SetState(State::Paused);
 
-  g_renderer->SaveScreenshot(GenerateScreenshotName(), wait_for_completion);
+  g_renderer->SaveScreenshot(GenerateScreenshotName());
 
   if (!bPaused)
     SetState(State::Running);
 }
 
-void SaveScreenShot(std::string_view name, bool wait_for_completion)
+void SaveScreenShot(std::string_view name)
 {
   const bool bPaused = GetState() == State::Paused;
 
   SetState(State::Paused);
 
-  g_renderer->SaveScreenshot(fmt::format("{}{}.png", GenerateScreenshotFolderPath(), name),
-                             wait_for_completion);
+  g_renderer->SaveScreenshot(fmt::format("{}{}.png", GenerateScreenshotFolderPath(), name));
 
   if (!bPaused)
     SetState(State::Running);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -112,8 +112,8 @@ void SetState(State state);
 State GetState();
 void WaitUntilDoneBooting();
 
-void SaveScreenShot(bool wait_for_completion = false);
-void SaveScreenShot(std::string_view name, bool wait_for_completion = false);
+void SaveScreenShot();
+void SaveScreenShot(std::string_view name);
 
 void Callback_WiimoteInterruptChannel(int number, u16 channel_id, const u8* data, u32 size);
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -378,20 +378,11 @@ Renderer::ConvertStereoRectangle(const MathUtil::Rectangle<int>& rc) const
   return std::make_tuple(left_rc, right_rc);
 }
 
-void Renderer::SaveScreenshot(std::string filename, bool wait_for_completion)
+void Renderer::SaveScreenshot(std::string filename)
 {
-  // We must not hold the lock while waiting for the screenshot to complete.
-  {
-    std::lock_guard<std::mutex> lk(m_screenshot_lock);
-    m_screenshot_name = std::move(filename);
-    m_screenshot_request.Set();
-  }
-
-  if (wait_for_completion)
-  {
-    // This is currently only used by Android, and it was using a wait time of 2 seconds.
-    m_screenshot_completed.WaitFor(std::chrono::seconds(2));
-  }
+  std::lock_guard<std::mutex> lk(m_screenshot_lock);
+  m_screenshot_name = std::move(filename);
+  m_screenshot_request.Set();
 }
 
 void Renderer::CheckForConfigChanges()

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -199,7 +199,7 @@ public:
   float EFBToScaledYf(float y) const;
 
   // Random utilities
-  void SaveScreenshot(std::string filename, bool wait_for_completion);
+  void SaveScreenshot(std::string filename);
   void DrawDebugText();
 
   virtual void ClearScreen(const MathUtil::Rectangle<int>& rc, bool colorEnable, bool alphaEnable,


### PR DESCRIPTION
This is now unused. Seems like it was an improper fix (there would be a race if saving the screenshot took longer than 2 seconds) back when it was used too.