### PR TITLE
Android: Remove finish from FilePicker

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -171,26 +171,12 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   {
     super.onActivityResult(requestCode, resultCode, result);
 
-    // Save modified non-FilePicker settings beforehand since finish() won't save them.
-    // onStop() must come before handling the resultCode to properly save FilePicker selection.
-    mPresenter.onStop(true);
-
     // If the user picked a file, as opposed to just backing out.
     if (resultCode == MainActivity.RESULT_OK)
     {
       String path = FileBrowserHelper.getSelectedPath(result);
       getFragment().getAdapter().onFilePickerConfirmation(path);
-
-      // Prevent duplicate Toasts.
-      if (!mPresenter.shouldSave())
-      {
-        Toast.makeText(this, "Saved settings to INI files", Toast.LENGTH_SHORT).show();
-      }
     }
-
-    // TODO: After result of FilePicker, duplicate SettingsActivity appears.
-    //       Finish to avoid this. Is there a better method?
-    finish();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -333,8 +333,12 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
 
     NativeLibrary.SetConfig(filePicker.getFile(), filePicker.getSection(), filePicker.getKey(),
             file);
-    NativeLibrary.ReloadConfig();
 
+    StringSetting path = new StringSetting(filePicker.getKey(), filePicker.getSection(), file);
+
+    mView.putSetting(path);
+
+    mView.onSettingChanged(filePicker.getKey());
     mClickedItem = null;
   }
 


### PR DESCRIPTION
Should probably be merged before #8975.
Thanks to the recent lifecycle changes this is possible.

`NativeLibrary.SetConfig` updates the FilePicker selection but won't retain that selection after saving.
`mView.putSetting` doesn't update the FilePicker selection but will allow the selection to be saved.

...so why not both? Still not perfect but it's better than prematurely calling `finish`.