### PR TITLE
JitArm64: Avoid double rounding in fctiwzx

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -339,8 +339,12 @@ void JitArm64::fctiwzx(UGeckoInstruction inst)
   }
   else
   {
-    m_float_emit.FCVT(32, 64, EncodeRegToDouble(VD), EncodeRegToDouble(VB));
-    m_float_emit.FCVTS(EncodeRegToSingle(VD), EncodeRegToSingle(VD), ROUND_Z);
+    ARM64Reg V1 = gpr.GetReg();
+
+    m_float_emit.FCVTS(V1, EncodeRegToDouble(VB), ROUND_Z);
+    m_float_emit.FMOV(EncodeRegToSingle(VD), V1);
+
+    gpr.Unlock(V1);
   }
   m_float_emit.ORR(EncodeRegToDouble(VD), EncodeRegToDouble(VD), EncodeRegToDouble(V0));
   fpr.Unlock(V0);


### PR DESCRIPTION
FCVT doesn't necessarily round to zero, so the result might be inaccurate if we use it. To ensure correct rounding, we use FCVTS from double FPR to 32-bit GPR. Unfortunately, FCVTS can't do double FPR to single FPR.

This is my first time making a JitArm64 PR, so apologies if the change doesn't make sense :)