### PR TITLE
Fix building on Debian 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(ENABLE_ALSA "Enables ALSA sound backend" ON)
 option(ENABLE_PULSEAUDIO "Enables PulseAudio sound backend" ON)
 option(ENABLE_LLVM "Enables LLVM support, for disassembly" ON)
 option(ENABLE_TESTS "Enables building the unit tests" ON)
+option(FORCE_VENDORED_ZSTD "Use the vendored Zstandard library even if the system zstd is detected" ON)
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence, show the current game on Discord" ON)
 
 # Maintainers: if you consider blanket disabling this for your users, please
@@ -611,7 +612,7 @@ else()
 endif()
 
 pkg_search_module(ZSTD QUIET libzstd)
-if(ZSTD_FOUND)
+if(ZSTD_FOUND AND NOT FORCE_VENDORED_ZSTD)
   message(STATUS "Using shared zstd")
 else()
   check_vendoring_approved(zstd)

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -59,7 +59,7 @@ add_library(discio
 target_link_libraries(discio
 PUBLIC
   BZip2::BZip2
-  LibLZMA::LibLZMA
+  lzma
   zstd
 
 PRIVATE


### PR DESCRIPTION
I tried building Dolphin on my Debian 10 (buster) system today, and unfortunately the build failed. I found this odd because I was able to build successfully just a couple months ago, so I went and bisected the issue. Turns out there were two issues, both involving building with the system-provided LZMA and Zstandard libraries.

The first issue is that CMake complains that `LibLZMA::LibLZMA` is not added as a library to the project, and if you ignore that warning, the linker complains that it can't link with `-lLibLZMA::LibLZMA`. The second issue is that for some reason, the compiler can't see the zstd library symbols when building with the system zstd, and I get the following errors:

```
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp: In constructor ‘DiscIO::ZstdCompressor::ZstdCompressor(int)’:
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp:748:53: error: ‘ZSTD_c_compressionLevel’ was not declared in this scope
   if (ZSTD_isError(ZSTD_CCtx_setParameter(m_stream, ZSTD_c_compressionLevel, compression_level)))
                                                     ^~~~~~~~~~~~~~~~~~~~~~~
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp:748:53: note: suggested alternative: ‘ZSTD_decompressStream’
   if (ZSTD_isError(ZSTD_CCtx_setParameter(m_stream, ZSTD_c_compressionLevel, compression_level)))
                                                     ^~~~~~~~~~~~~~~~~~~~~~~
                                                     ZSTD_decompressStream
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp:748:20: error: ‘ZSTD_CCtx_setParameter’ was not declared in this scope
   if (ZSTD_isError(ZSTD_CCtx_setParameter(m_stream, ZSTD_c_compressionLevel, compression_level)))
                    ^~~~~~~~~~~~~~~~~~~~~~
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp:748:20: note: suggested alternative: ‘ZSTD_CCtx_s’
   if (ZSTD_isError(ZSTD_CCtx_setParameter(m_stream, ZSTD_c_compressionLevel, compression_level)))
                    ^~~~~~~~~~~~~~~~~~~~~~
                    ZSTD_CCtx_s
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp: In member function ‘virtual bool DiscIO::ZstdCompressor::Start()’:
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp:765:50: error: ‘ZSTD_reset_session_only’ was not declared in this scope
   return !ZSTD_isError(ZSTD_CCtx_reset(m_stream, ZSTD_reset_session_only));
                                                  ^~~~~~~~~~~~~~~~~~~~~~~
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp:765:24: error: ‘ZSTD_CCtx_reset’ was not declared in this scope
   return !ZSTD_isError(ZSTD_CCtx_reset(m_stream, ZSTD_reset_session_only));
                        ^~~~~~~~~~~~~~~
/usr/local/src/dolphin/Source/Core/DiscIO/WIACompression.cpp:765:24: note: suggested alternative: ‘ZSTD_CCtx_s’
   return !ZSTD_isError(ZSTD_CCtx_reset(m_stream, ZSTD_reset_session_only));
                        ^~~~~~~~~~~~~~~
                        ZSTD_CCtx_s
```

After working on these problems for several hours, I've come up with the following solutions. I tried the best I could, but unfortunately my C++ and CMake knowledge is limited, so there are probably better ways to fix these issues that I'm not aware of. If anyone has any suggestions, wants me to try other solutions, or just needs me to post more error messages or debug info, please let me know.