### PR TITLE
Wii TAS input: fix offset in IR coordinates

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
@@ -70,6 +70,11 @@ void CameraLogic::Update(const Common::Matrix44& transform)
   if (!IOS::g_gpio_out[IOS::GPIO::SENSOR_BAR])
     return;
 
+  WriteIRDataForTransform(data.data(), m_reg_data.mode, transform);
+}
+
+void CameraLogic::WriteIRDataForTransform(u8* data, u8 mode, const Common::Matrix44& transform)
+{
   using Common::Matrix33;
   using Common::Matrix44;
   using Common::Vec3;
@@ -127,7 +132,7 @@ void CameraLogic::Update(const Common::Matrix44& transform)
     return CameraPoint{{0xffff, 0xffff}, 0xff};
   });
 
-  switch (m_reg_data.mode)
+  switch (mode)
   {
   case IR_MODE_BASIC:
     for (std::size_t i = 0; i != camera_points.size() / 2; ++i)

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.h
@@ -113,6 +113,7 @@ public:
 
   static constexpr u8 I2C_ADDR = 0x58;
   static constexpr int CAMERA_DATA_BYTES = 36;
+  static void WriteIRDataForTransform(u8* data, u8 mode, const Common::Matrix44& transform);
 
 private:
   // TODO: some of this memory is write-only and should return error 7.

--- a/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
@@ -34,9 +34,9 @@ GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : TASInputWindow(pa
   m_triggers_box = new QGroupBox(tr("Triggers"));
 
   auto* l_trigger_layout =
-      CreateSliderValuePairLayout(tr("Left"), m_l_trigger_value, 255, Qt::Key_N, m_triggers_box);
-  auto* r_trigger_layout =
-      CreateSliderValuePairLayout(tr("Right"), m_r_trigger_value, 255, Qt::Key_M, m_triggers_box);
+      CreateSliderValuePairLayout(tr("Left"), m_l_trigger_value, 0, 255, Qt::Key_N, m_triggers_box);
+  auto* r_trigger_layout = CreateSliderValuePairLayout(tr("Right"), m_r_trigger_value, 0, 255,
+                                                       Qt::Key_M, m_triggers_box);
 
   auto* triggers_layout = new QVBoxLayout;
   triggers_layout->addLayout(l_trigger_layout);

--- a/Source/Core/DolphinQt/TAS/IRWidget.h
+++ b/Source/Core/DolphinQt/TAS/IRWidget.h
@@ -12,15 +12,15 @@ class IRWidget : public QWidget
 {
   Q_OBJECT
 public:
-  explicit IRWidget(QWidget* parent);
+  explicit IRWidget(QWidget* parent, s16 min_x, s16 max_x, s16 min_y, s16 max_y);
 
 signals:
-  void ChangedX(u16 x);
-  void ChangedY(u16 y);
+  void ChangedX(s16 x);
+  void ChangedY(s16 y);
 
 public slots:
-  void SetX(u16 x);
-  void SetY(u16 y);
+  void SetX(s16 x);
+  void SetY(s16 y);
 
 protected:
   void paintEvent(QPaintEvent* event) override;
@@ -29,11 +29,11 @@ protected:
   void handleMouseEvent(QMouseEvent* event);
 
 private:
-  u16 m_x = 0;
-  u16 m_y = 0;
+  s16 m_x = 0;
+  s16 m_y = 0;
+  s16 m_min_x;
+  s16 m_max_x;
+  s16 m_min_y;
+  s16 m_max_y;
   bool m_ignore_movement = false;
 };
-
-// Should be part of class but fails to compile on mac os
-static const u16 ir_max_x = 1023;
-static const u16 ir_max_y = 767;

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.cpp
@@ -80,10 +80,10 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
                              y_shortcut_key_sequence.toString(QKeySequence::NativeText)));
 
   auto* x_layout = new QHBoxLayout;
-  x_value = CreateSliderValuePair(x_layout, max_x, x_shortcut_key_sequence, Qt::Horizontal, box);
+  x_value = CreateSliderValuePair(x_layout, 0, max_x, x_shortcut_key_sequence, Qt::Horizontal, box);
 
   auto* y_layout = new QVBoxLayout;
-  y_value = CreateSliderValuePair(y_layout, max_y, y_shortcut_key_sequence, Qt::Vertical, box);
+  y_value = CreateSliderValuePair(y_layout, 0, max_y, y_shortcut_key_sequence, Qt::Vertical, box);
   y_value->setMaximumWidth(60);
 
   auto* visual = new StickWidget(this, max_x, max_y);
@@ -109,9 +109,9 @@ QGroupBox* TASInputWindow::CreateStickInputs(QString name, QSpinBox*& x_value, Q
   return box;
 }
 
-QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(QString name, QSpinBox*& value, u16 max,
-                                                        Qt::Key shortcut_key,
-                                                        QWidget* shortcut_widget, bool invert)
+QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(QString name, QSpinBox*& value, s16 min,
+                                                       s16 max, Qt::Key shortcut_key,
+                                                       QWidget* shortcut_widget, bool invert)
 {
   const QKeySequence shortcut_key_sequence = QKeySequence(Qt::ALT + shortcut_key);
 
@@ -121,27 +121,29 @@ QBoxLayout* TASInputWindow::CreateSliderValuePairLayout(QString name, QSpinBox*&
   QBoxLayout* layout = new QHBoxLayout;
   layout->addWidget(label);
 
-  value = CreateSliderValuePair(layout, max, shortcut_key_sequence, Qt::Horizontal, shortcut_widget,
-                                invert);
+  value = CreateSliderValuePair(layout, min, max, shortcut_key_sequence, Qt::Horizontal,
+                                shortcut_widget, invert);
 
   return layout;
 }
 
 // The shortcut_widget argument needs to specify the container widget that will be hidden/shown.
 // This is done to avoid ambigous shortcuts
-QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, u16 max,
+QSpinBox* TASInputWindow::CreateSliderValuePair(QBoxLayout* layout, s16 min, s16 max,
                                                 QKeySequence shortcut_key_sequence,
                                                 Qt::Orientation orientation,
                                                 QWidget* shortcut_widget, bool invert)
 {
   auto* value = new QSpinBox();
-  value->setRange(0, 99999);
-  connect(value, qOverload<int>(&QSpinBox::valueChanged), [value, max](int i) {
+  value->setRange(-99999, 99999);
+  connect(value, qOverload<int>(&QSpinBox::valueChanged), [value, min, max](s32 i) {
+    if (i < min)
+      value->setValue(min);
     if (i > max)
       value->setValue(max);
   });
   auto* slider = new QSlider(orientation);
-  slider->setRange(0, max);
+  slider->setRange(min, max);
   slider->setFocusPolicy(Qt::ClickFocus);
   slider->setInvertedAppearance(invert);
 

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -30,10 +30,11 @@ protected:
   TASCheckBox* CreateButton(const QString& name);
   QGroupBox* CreateStickInputs(QString name, QSpinBox*& x_value, QSpinBox*& y_value, u16 max_x,
                                u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key);
-  QBoxLayout* CreateSliderValuePairLayout(QString name, QSpinBox*& value, u16 max,
+  QBoxLayout* CreateSliderValuePairLayout(QString name, QSpinBox*& value, s16 min, s16 max,
                                           Qt::Key shortcut_key, QWidget* shortcut_widget,
                                           bool invert = false);
-  QSpinBox* CreateSliderValuePair(QBoxLayout* layout, u16 max, QKeySequence shortcut_key_sequence,
+  QSpinBox* CreateSliderValuePair(QBoxLayout* layout, s16 min, s16 max,
+                                  QKeySequence shortcut_key_sequence,
                                   Qt::Orientation orientation, QWidget* shortcut_widget,
                                   bool invert = false);
   template <typename UX>

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -368,10 +368,15 @@ void WiiTASInputWindow::GetValues(DataReportBuilder& rpt, int ext,
   {
     u8* const ir_data = rpt.GetIRDataPtr();
 
-    u16 y = m_ir_y_value->value();
+    // The sensor bar is above the screen by default,
+    // and adding some fixed offset accommodates for that.
+    u16 y = m_ir_y_value->value() + 100;
     std::array<u16, 4> x;
-    x[0] = m_ir_x_value->value();
-    x[1] = x[0] + 100;
+    // Make up some x-coordinates of the sensor bar's 4 IR lights,
+    // so that their center will be at the desired x-coordinate.
+    u16 x_center = m_ir_x_value->value();
+    x[0] = x_center - 50;
+    x[1] = x_center + 50;
     x[2] = x[0] - 10;
     x[3] = x[1] + 10;
 

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.h
@@ -31,6 +31,8 @@ public:
 private:
   void UpdateExt(u8 ext);
   int m_num;
+  u16 m_range_x;
+  u16 m_range_y;
   TASCheckBox* m_a_button;
   TASCheckBox* m_b_button;
   TASCheckBox* m_1_button;


### PR DESCRIPTION
The TAS input currently has some weird placement for its made-up IR lights. This causes an offset while the TAS UI suggests the cursor should be perfectly centered.

Here are before and after screenshots for visualization:

![ir1](https://user-images.githubusercontent.com/1996138/89713294-26a72a00-d997-11ea-9b48-7673faf16f4b.png)
![ir2](https://user-images.githubusercontent.com/1996138/89713296-29a21a80-d997-11ea-98d3-a24fae4d62e3.png)

Also: Do you think adding a fixed offset to the y-coordinate is ok? This will probably make the offset _worse_ for people who changed their sensor bar's position settings to "below screen", but I don't know if people even do that.
