### PR TITLE
VolumeVerifier: Split TMD error from ticket error for WADs

### DIFF
--- a/Source/Core/DiscIO/VolumeVerifier.h
+++ b/Source/Core/DiscIO/VolumeVerifier.h
@@ -148,7 +148,6 @@ private:
   std::vector<Partition> CheckPartitions();
   bool CheckPartition(const Partition& partition);  // Returns false if partition should be ignored
   std::string GetPartitionName(std::optional<u32> type) const;
-  void CheckCorrectlySigned(const Partition& partition, std::string error_text);
   bool IsDebugSigned() const;
   bool ShouldHaveChannelPartition() const;
   bool ShouldHaveInstallPartition() const;


### PR DESCRIPTION
When I first made VolumeVerifier, I figured that the distinction between an unsigned ticket and an unsigned TMD was a technical detail that users would have no reason to care about. However, while this might be true for discs, it isn't equally true for WADs, due to the widespread practice of fakesigning tickets to set the console ID to 0. This practice does not require fakesigning the TMD (though apparently people do it anyway, at least sometimes...), and the presence of a correctly signed TMD is a useful indicator that the contents have not been tampered with, even if the ticket isn't correctly signed.