### PR TITLE
Qt/GCMemcardCreateNewDialog: Use zero values for formatting instead of accessing g_SRAM.

### DIFF
--- a/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
+++ b/Source/Core/DolphinQt/GCMemcardCreateNewDialog.cpp
@@ -77,10 +77,9 @@ bool GCMemcardCreateNewDialog::CreateCard()
   if (path.isEmpty())
     return false;
 
-  // TODO: The dependency on g_SRAM here is sketchy. We should instead use sensible default values.
-  const CardFlashId& flash_id = g_SRAM.settings_ex.flash_id[Memcard::SLOT_A];
-  const u32 rtc_bias = g_SRAM.settings.rtc_bias;
-  const u32 sram_language = static_cast<u32>(g_SRAM.settings.language);
+  const CardFlashId flash_id{};
+  const u32 rtc_bias = 0;
+  const u32 sram_language = 0;
   const u64 format_time =
       Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
 


### PR DESCRIPTION
GUI code should not be directly accessing emulated hardware like this.

As for the CardFlashId value itself... frankly, I don't believe the value itself actually matters in the slightest. I've checked various dumped memory cards of mine and it looks like a completely random set of 12 bytes to me for them, while all my Dolphin-generated cards use either 12 zeros like what I'm using in this PR (which happens when you create a card before launching a game, as g_SRAM is zero-filled before first boot), or the ASCII `DOLPHINSLOTA` as seen [here](https://github.com/dolphin-emu/dolphin/blob/28c0b5338ee4c0ef1fc30c557e27e896c135c1ca/Source/Core/Core/HW/Sram.cpp#L20). Gamecube software does not seem to care what it is -- it probably just matters that the serial in the header is correctly synced with the flash ID, which we ensure [here when mounting a card](https://github.com/dolphin-emu/dolphin/blob/28c0b5338ee4c0ef1fc30c557e27e896c135c1ca/Source/Core/Core/HW/Sram.cpp#L76-L88) and [here when formatting a card](https://github.com/dolphin-emu/dolphin/blob/556e93f357a3e008481d4e8bb453e387e948df04/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp#L1561-L1568).

As a sidenote... am I right in assuming that this flash ID on real hardware is a separate piece of information provided by a memory card, disconnected from formatted header data? Cause we emulate it by just assuming the header block is always correct. Which is probably fine, but just wondering.
