### PR TITLE
Android: Rewrite GetRenderSurfaceScale in Java

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -6,6 +6,7 @@
 
 package org.dolphinemu.dolphinemu;
 
+import android.util.DisplayMetrics;
 import android.view.Surface;
 
 import androidx.appcompat.app.AlertDialog;
@@ -569,6 +570,13 @@ public final class NativeLibrary
     {
       emulationActivity.runOnUiThread(emulationActivity::initInputPointer);
     }
+  }
+
+  public static float getRenderSurfaceScale()
+  {
+    DisplayMetrics metrics = new DisplayMetrics();
+    sEmulationActivity.get().getWindowManager().getDefaultDisplay().getMetrics(metrics);
+    return metrics.scaledDensity;
   }
 
   public static native float GetGameAspectRatio();

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -649,45 +649,10 @@ Java_org_dolphinemu_dolphinemu_NativeLibrary_ReportStartToAnalytics(JNIEnv* env,
 // Based on the scaledDensity of the device's display metrics.
 static float GetRenderSurfaceScale(JNIEnv* env)
 {
-  // NativeLibrary emulation_activity = NativeLibrary.getEmulationActivity();
   jclass native_library_class = env->FindClass("org/dolphinemu/dolphinemu/NativeLibrary");
-  jmethodID get_emulation_activity_method =
-      env->GetStaticMethodID(native_library_class, "getEmulationActivity",
-                             "()Lorg/dolphinemu/dolphinemu/activities/EmulationActivity;");
-  jobject emulation_activity =
-      env->CallStaticObjectMethod(native_library_class, get_emulation_activity_method);
-
-  // WindowManager window_manager = emulation_activity.getWindowManager();
-  jmethodID get_window_manager_method =
-      env->GetMethodID(env->GetObjectClass(emulation_activity), "getWindowManager",
-                       "()Landroid/view/WindowManager;");
-  jobject window_manager = env->CallObjectMethod(emulation_activity, get_window_manager_method);
-
-  // Display display = window_manager.getDisplay();
-  jmethodID get_display_method = env->GetMethodID(env->GetObjectClass(window_manager),
-                                                  "getDefaultDisplay", "()Landroid/view/Display;");
-  jobject display = env->CallObjectMethod(window_manager, get_display_method);
-
-  // DisplayMetrics metrics = new DisplayMetrics();
-  jclass display_metrics_class = env->FindClass("android/util/DisplayMetrics");
-  jmethodID display_metrics_constructor = env->GetMethodID(display_metrics_class, "<init>", "()V");
-  jobject metrics = env->NewObject(display_metrics_class, display_metrics_constructor);
-
-  // display.getMetrics(metrics);
-  jmethodID get_metrics_method = env->GetMethodID(env->GetObjectClass(display), "getMetrics",
-                                                  "(Landroid/util/DisplayMetrics;)V");
-  env->CallVoidMethod(display, get_metrics_method, metrics);
-
-  // float scaled_density = metrics.scaledDensity;
-  jfieldID scaled_density_field =
-      env->GetFieldID(env->GetObjectClass(metrics), "scaledDensity", "F");
-  float scaled_density = env->GetFloatField(metrics, scaled_density_field);
-  __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Using %f for render surface scale.",
-                      scaled_density);
-
-  // cleanup
-  env->DeleteLocalRef(metrics);
-  return scaled_density;
+  jmethodID get_render_surface_scale_method =
+      env->GetStaticMethodID(native_library_class, "getRenderSurfaceScale", "()F");
+  return env->CallStaticFloatMethod(native_library_class, get_render_surface_scale_method);
 }
 
 static void Run(JNIEnv* env, const std::vector<std::string>& paths,


### PR DESCRIPTION
Long sequences of JNI calls are both hard to read and slow.