### PR TITLE
Fix builds with system LZMA when using versions of CMake before 3.14

### DIFF
--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -59,7 +59,7 @@ add_library(discio
 target_link_libraries(discio
 PUBLIC
   BZip2::BZip2
-  LibLZMA::LibLZMA
+  lzma
   zstd
 
 PRIVATE


### PR DESCRIPTION
The "FindLibLZMA.cmake" module in CMake versions prior to 3.14 do not
set an alias like how "Externals/liblzma/CMakeLists.txt" does, so builds
performed using one of those older CMake versions will fail if the
system LZMA library is detected. To fix this, we need to link against
"lzma" instead of "LibLZMA::LibLZMA".

This is an update of #9017, with the zstd build changes removed and the commit message altered to make it more clear what problem it's fixing.

This patch is needed to fix builds on Debian 10 (buster).