### PR TITLE
DolphinQt: Prevent deadlock when exiting the NetPlay Session Browser dialog

### DIFF
--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -26,7 +26,6 @@
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
-#include "DolphinQt/QtUtils/RunOnObject.h"
 #include "DolphinQt/Settings.h"
 
 NetPlayBrowser::NetPlayBrowser(QWidget* parent) : QDialog(parent)
@@ -148,6 +147,11 @@ void NetPlayBrowser::ConnectWidgets()
   connect(m_table_widget, &QTableWidget::itemSelectionChanged, this,
           &NetPlayBrowser::OnSelectionChanged);
   connect(m_table_widget, &QTableWidget::itemDoubleClicked, this, &NetPlayBrowser::accept);
+
+  connect(this, &NetPlayBrowser::UpdateStatusRequested, this,
+          &NetPlayBrowser::OnUpdateStatusRequested, Qt::QueuedConnection);
+  connect(this, &NetPlayBrowser::UpdateListRequested, this, &NetPlayBrowser::OnUpdateListRequested,
+          Qt::QueuedConnection);
 }
 
 void NetPlayBrowser::Refresh()
@@ -191,10 +195,7 @@ void NetPlayBrowser::RefreshLoop()
 
       lock.unlock();
 
-      RunOnObject(this, [this] {
-        m_status_label->setText(tr("Refreshing..."));
-        return nullptr;
-      });
+      emit UpdateStatusRequested(tr("Refreshing..."));
 
       NetPlayIndex client;
 
@@ -202,19 +203,12 @@ void NetPlayBrowser::RefreshLoop()
 
       if (entries)
       {
-        RunOnObject(this, [this, &entries] {
-          m_sessions = *entries;
-          UpdateList();
-          return nullptr;
-        });
+        emit UpdateListRequested(std::move(*entries));
       }
       else
       {
-        RunOnObject(this, [this, &client] {
-          m_status_label->setText(tr("Error obtaining session list: %1")
-                                      .arg(QString::fromStdString(client.GetLastError())));
-          return nullptr;
-        });
+        emit UpdateStatusRequested(tr("Error obtaining session list: %1")
+                                       .arg(QString::fromStdString(client.GetLastError())));
       }
     }
   }
@@ -275,6 +269,17 @@ void NetPlayBrowser::OnSelectionChanged()
 {
   m_button_box->button(QDialogButtonBox::Ok)
       ->setEnabled(!m_table_widget->selectedItems().isEmpty());
+}
+
+void NetPlayBrowser::OnUpdateStatusRequested(const QString& status)
+{
+  m_status_label->setText(status);
+}
+
+void NetPlayBrowser::OnUpdateListRequested(std::vector<NetPlaySession> sessions)
+{
+  m_sessions = std::move(sessions);
+  UpdateList();
 }
 
 void NetPlayBrowser::accept()

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.cpp
@@ -35,6 +35,7 @@ NetPlayBrowser::NetPlayBrowser(QWidget* parent) : QDialog(parent)
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   CreateWidgets();
+  RestoreSettings();
   ConnectWidgets();
 
   resize(750, 500);
@@ -44,8 +45,6 @@ NetPlayBrowser::NetPlayBrowser(QWidget* parent) : QDialog(parent)
 
   m_refresh_run.Set(true);
   m_refresh_thread = std::thread([this] { RefreshLoop(); });
-
-  RestoreSettings();
 
   UpdateList();
   Refresh();

--- a/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayBrowser.h
@@ -35,6 +35,8 @@ public:
   void accept() override;
 signals:
   void Join();
+  void UpdateStatusRequested(const QString& status);
+  void UpdateListRequested(std::vector<NetPlaySession> sessions);
 
 private:
   void CreateWidgets();
@@ -45,6 +47,9 @@ private:
   void UpdateList();
 
   void OnSelectionChanged();
+
+  void OnUpdateStatusRequested(const QString& status);
+  void OnUpdateListRequested(std::vector<NetPlaySession> sessions);
 
   void SaveSettings() const;
   void RestoreSettings();
@@ -71,3 +76,5 @@ private:
   Common::Flag m_refresh_run;
   Common::Event m_refresh_event;
 };
+
+Q_DECLARE_METATYPE(std::vector<NetPlaySession>)


### PR DESCRIPTION
It was possible to enter a deadlock when the **NetPlay Session Browser** dialog was closed while a refresh was still ongoing.

**Reproduction steps:**

- Launch Dolphin.
- Open the **NetPlay Session Browser** dialog via **Tools > Browse NetPlay Sessions...**.
- Press `ESC` as soon as the dialog pops up, so it is dismissed straight away.
- Dolphin will (potentially) deadlock.

Stacktrace (Release build):
```
Thread 1 (Thread 0x7f3f319e6080 (LWP 4361)):
#0  0x00007fa6be274d2d in __GI___pthread_timedjoin_ex (threadid=140352865023744, thread_return=0x0, abstime=0x0, block=<optimised out>) at pthread_join_common.c:89
#1  0x00007fa6bdfa0933 in std::thread::join() () at /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#2  0x000055c4f2f996ea in NetPlayBrowser::~NetPlayBrowser() ()
#3  0x000055c4f2f99799 in NetPlayBrowser::~NetPlayBrowser() ()
#4  0x00007fa6c50acf31 in QDialog::exec() () at /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#5  0x000055c4f2e993d2 in MainWindow::ShowNetPlayBrowser() ()
...

Thread 14 (Thread 0x7f8d41ffb700 (LWP 27323)):
#0  0x00007f8d7f8fb9f3 in futex_wait_cancelable (private=<optimised out>, expected=0, futex_word=0x7f8d41ff1430) at ../sysdeps/unix/sysv/linux/futex-internal.h:88
#1  0x00007f8d7f8fb9f3 in __pthread_cond_wait_common (abstime=0x0, mutex=0x7f8d41ff1438, cond=0x7f8d41ff1408) at pthread_cond_wait.c:502
#2  0x00007f8d7f8fb9f3 in __pthread_cond_wait (cond=0x7f8d41ff1408, mutex=0x7f8d41ff1438) at pthread_cond_wait.c:655
#3  0x00007f8d7f61c8bc in std::condition_variable::wait(std::unique_lock<std::mutex>&) () at /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x000055b844a9ea5f in Common::Event::Wait() [clone .part.75] ()
#5  0x000055b844aa2710 in NetPlayBrowser::RefreshLoop() ()
#6  0x00007f8d7f6226df in  () at /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f8d7f8f56db in start_thread (arg=0x7f8d41ffb700) at pthread_create.c:463
#8  0x00007f8d7eef7a3f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
...
```

When the `NetPlayBrowser::~NetPlayBrowser()` is invoked, it attempts to cancel the network thread, and waits for it to return control. However, if a refresh request was still in progress, the network thread might still attempt to update some widgets via `RunOnObject()`. Therefore, Qt's event loop remains busy, waiting for the network thread to yield control, and the network thread is waiting for Qt to run a lambda in the object.