### PR TITLE
msvc: disable C4789 on specific files to avoid false-positive

### DIFF
--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -202,7 +202,12 @@
     <ClCompile Include="HW\WiimoteEmu\Speaker.cpp" />
     <ClCompile Include="HW\WiimoteEmu\WiimoteEmu.cpp" />
     <ClCompile Include="HW\WiimoteReal\IOWin.cpp" />
-    <ClCompile Include="HW\WiimoteReal\WiimoteReal.cpp" />
+    <ClCompile Include="HW\WiimoteReal\WiimoteReal.cpp">
+      <!--
+      Workaround a msvc bug which causes false "buffer overflow" static analysis warning.
+      -->
+      <DisableSpecificWarnings>4789;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
     <ClCompile Include="HW\WII_IPC.cpp" />
     <ClCompile Include="HW\WiiSave.cpp" />
     <ClCompile Include="IOS\Device.cpp" />

--- a/Source/Core/InputCommon/InputCommon.vcxproj
+++ b/Source/Core/InputCommon/InputCommon.vcxproj
@@ -75,7 +75,12 @@
     <ClCompile Include="ControlReference\ExpressionParser.cpp" />
     <ClCompile Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.cpp" />
     <ClCompile Include="ControllerInterface\Win32\Win32.cpp" />
-    <ClCompile Include="ControllerInterface\Wiimote\Wiimote.cpp" />
+    <ClCompile Include="ControllerInterface\Wiimote\Wiimote.cpp">
+      <!--
+      Workaround a msvc bug which causes false "buffer overflow" static analysis warning.
+      -->
+      <DisableSpecificWarnings>4789;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
     <ClCompile Include="ControllerInterface\XInput\XInput.cpp" />
     <ClCompile Include="ControlReference\FunctionExpression.cpp" />
     <ClCompile Include="GCAdapter.cpp">


### PR DESCRIPTION
Prevents the following, which appears to be bogus:
```
Wiimote.cpp(343): error C2220: the following warning is treated as an error
Wiimote.cpp(343): warning C4789: buffer 'rpt' of size 1 bytes will be overrun; 2 bytes will be written starting at offset 0
```
After some experimenting, it appears to be a fairly hard to hit edge case (as also evidenced by the fact that no code in the rest of dolphin triggers it). It has to do with the `/permissive-` flag and the exact way the struct is declared, concerning the ordering of named/unnamed fields.

Afterwards (and with Qt 5.15.0), dolphin builds fine on current latest msvc: `Microsoft (R) C/C++ Optimizing Compiler Version 19.27.29111`