### PR TITLE
Code cleanup

### DIFF
--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -9,28 +9,6 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
-#ifdef _WIN32
-#define ASSERT_MSG(_t_, _a_, _fmt_, ...)                                                           \
-  do                                                                                               \
-  {                                                                                                \
-    if (!(_a_))                                                                                    \
-    {                                                                                              \
-      if (!PanicYesNo(_fmt_, __VA_ARGS__))                                                         \
-        Crash();                                                                                   \
-    }                                                                                              \
-  } while (0)
-
-#define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
-  do                                                                                               \
-  {                                                                                                \
-    if (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG && !(_a_))                                 \
-    {                                                                                              \
-      ERROR_LOG(_t_, _msg_, __VA_ARGS__);                                                          \
-      if (!PanicYesNo(_msg_, __VA_ARGS__))                                                         \
-        Crash();                                                                                   \
-    }                                                                                              \
-  } while (0)
-#else
 #define ASSERT_MSG(_t_, _a_, _fmt_, ...)                                                           \
   do                                                                                               \
   {                                                                                                \
@@ -44,14 +22,16 @@
 #define DEBUG_ASSERT_MSG(_t_, _a_, _msg_, ...)                                                     \
   do                                                                                               \
   {                                                                                                \
-    if (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG && !(_a_))                                 \
+    if constexpr (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                                 \
     {                                                                                              \
-      ERROR_LOG(_t_, _msg_, ##__VA_ARGS__);                                                        \
-      if (!PanicYesNo(_msg_, ##__VA_ARGS__))                                                       \
-        Crash();                                                                                   \
+      if (!(_a_))                                                                                  \
+      {                                                                                            \
+        ERROR_LOG(_t_, _msg_, ##__VA_ARGS__);                                                      \
+        if (!PanicYesNo(_msg_, ##__VA_ARGS__))                                                     \
+          Crash();                                                                                 \
+      }                                                                                            \
     }                                                                                              \
   } while (0)
-#endif
 
 #define ASSERT(_a_)                                                                                \
   do                                                                                               \
@@ -64,6 +44,6 @@
 #define DEBUG_ASSERT(_a_)                                                                          \
   do                                                                                               \
   {                                                                                                \
-    if (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                                           \
+    if constexpr (MAX_LOGLEVEL >= Common::Log::LOG_LEVELS::LDEBUG)                                 \
       ASSERT(_a_);                                                                                 \
   } while (0)

--- a/Source/Core/Common/CompatPatches.cpp
+++ b/Source/Core/Common/CompatPatches.cpp
@@ -183,7 +183,7 @@ static bool GetModuleVersion(const wchar_t* name, Version* version)
   if (!data_len)
     return false;
   std::vector<u8> block(data_len);
-  if (!GetFileVersionInfoW(path->c_str(), handle, data_len, block.data()))
+  if (!GetFileVersionInfoW(path->c_str(), 0, data_len, block.data()))
     return false;
   void* buf;
   UINT buf_len;

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -125,9 +125,11 @@ std::vector<std::string> DoFileSearch(const std::vector<std::string>& directorie
   // std::filesystem uses the OS separator.
   constexpr fs::path::value_type os_separator = fs::path::preferred_separator;
   static_assert(os_separator == DIR_SEP_CHR || os_separator == '\\', "Unsupported path separator");
-  if (os_separator != DIR_SEP_CHR)
+  if constexpr (os_separator != DIR_SEP_CHR)
+  {
     for (auto& path : result)
       std::replace(path.begin(), path.end(), '\\', DIR_SEP_CHR);
+  }
 
   return result;
 }

--- a/Source/Core/Common/FileSearch.cpp
+++ b/Source/Core/Common/FileSearch.cpp
@@ -98,7 +98,7 @@ std::vector<std::string> DoFileSearch(const std::vector<std::string>& directorie
   };
   for (const auto& directory : directories)
   {
-    const fs::path directory_path = StringToPath(directory);
+    fs::path directory_path = StringToPath(directory);
     if (fs::is_directory(directory_path))  // Can't create iterators for non-existant directories
     {
       if (recursive)

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -600,7 +600,7 @@ std::string GetCurrentDir()
   if (!dir)
   {
     ERROR_LOG(COMMON, "GetCurrentDirectory failed: %s", LastStrerrorString().c_str());
-    return nullptr;
+    return "";
   }
   std::string strDir = dir;
   free(dir);
@@ -621,10 +621,15 @@ std::string CreateTempDir()
     return "";
 
   GUID guid;
-  CoCreateGuid(&guid);
-  TCHAR tguid[40];
-  StringFromGUID2(guid, tguid, 39);
-  tguid[39] = 0;
+  if (FAILED(CoCreateGuid(&guid)))
+  {
+    return "";
+  }
+  OLECHAR tguid[40]{};
+  if (!StringFromGUID2(guid, tguid, _countof(tguid)))
+  {
+    return "";
+  }
   std::string dir = TStrToUTF8(temp) + "/" + TStrToUTF8(tguid);
   if (!CreateDir(dir))
     return "";

--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -1470,7 +1470,7 @@ u32* GekkoDisassembler::DoDisassembly(bool big_endian)
     break;
 
   case 30:
-    switch (in & 0x1c)
+    switch ((in >> 2) & 0x7)
     {
     case 0:
       rld(in, "icl", 0);  // rldicl

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -32,39 +32,6 @@ bool MsgAlert(bool yes_no, MsgType style, const char* format, ...)
 void SetEnableAlert(bool enable);
 }  // namespace Common
 
-#if defined(_WIN32) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1)
-#define SuccessAlert(format, ...)                                                                  \
-  Common::MsgAlert(false, Common::MsgType::Information, format, __VA_ARGS__)
-
-#define PanicAlert(format, ...)                                                                    \
-  Common::MsgAlert(false, Common::MsgType::Warning, format, __VA_ARGS__)
-
-#define PanicYesNo(format, ...)                                                                    \
-  Common::MsgAlert(true, Common::MsgType::Warning, format, __VA_ARGS__)
-
-#define AskYesNo(format, ...) Common::MsgAlert(true, Common::MsgType::Question, format, __VA_ARGS__)
-
-#define CriticalAlert(format, ...)                                                                 \
-  Common::MsgAlert(false, Common::MsgType::Critical, format, __VA_ARGS__)
-
-// Use these macros (that do the same thing) if the message should be translated.
-
-#define SuccessAlertT(format, ...)                                                                 \
-  Common::MsgAlert(false, Common::MsgType::Information, format, __VA_ARGS__)
-
-#define PanicAlertT(format, ...)                                                                   \
-  Common::MsgAlert(false, Common::MsgType::Warning, format, __VA_ARGS__)
-
-#define PanicYesNoT(format, ...)                                                                   \
-  Common::MsgAlert(true, Common::MsgType::Warning, format, __VA_ARGS__)
-
-#define AskYesNoT(format, ...)                                                                     \
-  Common::MsgAlert(true, Common::MsgType::Question, format, __VA_ARGS__)
-
-#define CriticalAlertT(format, ...)                                                                \
-  Common::MsgAlert(false, Common::MsgType::Critical, format, __VA_ARGS__)
-
-#else
 #define SuccessAlert(format, ...)                                                                  \
   Common::MsgAlert(false, Common::MsgType::Information, format, ##__VA_ARGS__)
 
@@ -95,4 +62,3 @@ void SetEnableAlert(bool enable);
 
 #define CriticalAlertT(format, ...)                                                                \
   Common::MsgAlert(false, Common::MsgType::Critical, format, ##__VA_ARGS__)
-#endif

--- a/Source/Core/Common/SDCardUtil.cpp
+++ b/Source/Core/Common/SDCardUtil.cpp
@@ -247,7 +247,7 @@ bool SDCardCreate(u64 disk_size /*in MB*/, const std::string& filename)
   if (!write_sector(file, s_fsinfo_sector))
     goto FailWrite;
 
-  if (BACKUP_BOOT_SECTOR > 0)
+  if constexpr (BACKUP_BOOT_SECTOR > 0)
   {
     if (!write_empty(file, BACKUP_BOOT_SECTOR - 2))
       goto FailWrite;

--- a/Source/Core/Common/Semaphore.h
+++ b/Source/Core/Common/Semaphore.h
@@ -6,9 +6,6 @@
 
 #ifdef _WIN32
 
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
 #include <Windows.h>
 
 namespace Common

--- a/Source/Core/Common/Timer.cpp
+++ b/Source/Core/Common/Timer.cpp
@@ -254,7 +254,7 @@ std::string Timer::GetDateTimeFormatted(double time)
 
 #ifdef _WIN32
   wchar_t tmp[32] = {};
-  wcsftime(tmp, sizeof(tmp), L"%x %X", localTime);
+  wcsftime(tmp, std::size(tmp), L"%x %X", localTime);
   return WStringToUTF8(tmp);
 #else
   char tmp[32] = {};

--- a/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
@@ -35,7 +35,7 @@ bool IsTAPDevice(const TCHAR* guid)
     TCHAR net_cfg_instance_id[256];
     DWORD data_type;
 
-    len = sizeof(enum_name);
+    len = _countof(enum_name);
     status = RegEnumKeyEx(netcard_key, i, enum_name, &len, nullptr, nullptr, nullptr, nullptr);
 
     if (status == ERROR_NO_MORE_ITEMS)
@@ -43,7 +43,8 @@ bool IsTAPDevice(const TCHAR* guid)
     else if (status != ERROR_SUCCESS)
       return false;
 
-    _sntprintf(unit_string, sizeof(unit_string), _T("%s\\%s"), ADAPTER_KEY, enum_name);
+    _sntprintf(unit_string, _countof(unit_string), _T("%s\\%s"), ADAPTER_KEY, enum_name);
+    unit_string[_countof(unit_string) - 1] = _T('\0');
 
     status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, unit_string, 0, KEY_READ, &unit_key);
 
@@ -110,14 +111,15 @@ bool GetGUIDs(std::vector<std::basic_string<TCHAR>>& guids)
     DWORD name_type;
     const TCHAR name_string[] = _T("Name");
 
-    len = sizeof(enum_name);
+    len = _countof(enum_name);
     status = RegEnumKeyEx(control_net_key, i, enum_name, &len, nullptr, nullptr, nullptr, nullptr);
 
     if (status != ERROR_SUCCESS)
       continue;
 
-    _sntprintf(connection_string, sizeof(connection_string), _T("%s\\%s\\Connection"),
+    _sntprintf(connection_string, _countof(connection_string), _T("%s\\%s\\Connection"),
                NETWORK_CONNECTIONS_KEY, enum_name);
+    connection_string[_countof(connection_string) - 1] = _T('\0');
 
     status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, connection_string, 0, KEY_READ, &connection_key);
 

--- a/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/TAP_Win32.cpp
@@ -198,7 +198,7 @@ bool CEXIETHERNET::TAPNetworkInterface::Activate()
   }
 
   /* get driver version info */
-  ULONG info[3];
+  ULONG info[3]{};
   if (DeviceIoControl(mHAdapter, TAP_IOCTL_GET_VERSION, &info, sizeof(info), &info, sizeof(info),
                       &len, nullptr))
   {

--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteHid.h
@@ -54,7 +54,7 @@ struct TypedHIDInputData
 
   T data;
 
-  static_assert(std::is_pod<T>());
+  static_assert(std::is_standard_layout_v<T> && std::is_trivially_copyable_v<T>);
 
   u8* GetData() { return reinterpret_cast<u8*>(this); }
   const u8* GetData() const { return reinterpret_cast<const u8*>(this); }

--- a/Source/Core/Core/HW/WiimoteEmu/I2CBus.h
+++ b/Source/Core/Core/HW/WiimoteEmu/I2CBus.h
@@ -26,7 +26,7 @@ protected:
   template <typename T>
   static int RawRead(T* reg_data, u8 addr, int count, u8* data_out)
   {
-    static_assert(std::is_pod<T>::value);
+    static_assert(std::is_standard_layout_v<T> && std::is_trivially_copyable_v<T>);
     static_assert(0x100 == sizeof(T));
 
     // TODO: addr wraps around after 0xff
@@ -42,7 +42,7 @@ protected:
   template <typename T>
   static int RawWrite(T* reg_data, u8 addr, int count, const u8* data_in)
   {
-    static_assert(std::is_pod<T>::value);
+    static_assert(std::is_standard_layout_v<T> && std::is_trivially_copyable_v<T>);
     static_assert(0x100 == sizeof(T));
 
     // TODO: addr wraps around after 0xff

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -621,7 +621,7 @@ UIDSys::UIDSys(std::shared_ptr<HLE::FS::FileSystem> fs) : m_fs{fs}
   {
     while (true)
     {
-      const std::pair<u32, u64> entry = ReadUidSysEntry(*file);
+      std::pair<u32, u64> entry = ReadUidSysEntry(*file);
       if (!entry.first && !entry.second)
         break;
 
@@ -766,7 +766,7 @@ std::map<std::string, CertReader> ParseCertChain(const std::vector<u8>& chain)
       return certs;
 
     processed += cert_reader.GetBytes().size();
-    const std::string name = cert_reader.GetName();
+    std::string name = cert_reader.GetName();
     certs.emplace(std::move(name), std::move(cert_reader));
   }
   return certs;

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -824,7 +824,8 @@ void Init()
     if (!s_ios)
       return;
 
-    auto device = static_cast<Device::SDIOSlot0*>(s_ios->GetDeviceByName("/dev/sdio/slot0").get());
+    auto sdio_slot0 = s_ios->GetDeviceByName("/dev/sdio/slot0");
+    auto device = static_cast<Device::SDIOSlot0*>(sdio_slot0.get());
     if (device)
       device->EventNotify();
   });

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -208,7 +208,7 @@ static void CopyDescriptorToBuffer(std::vector<u8>* buffer, T descriptor)
   descriptor.Swap();
   buffer->insert(buffer->end(), reinterpret_cast<const u8*>(&descriptor),
                  reinterpret_cast<const u8*>(&descriptor) + size);
-  const size_t number_of_padding_bytes = Common::AlignUp(size, 4) - size;
+  constexpr size_t number_of_padding_bytes = Common::AlignUp(size, 4) - size;
   buffer->insert(buffer->end(), number_of_padding_bytes, 0);
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -61,8 +61,8 @@ template <typename SType>
 SType ScaleAndClamp(double ps, u32 stScale)
 {
   float convPS = (float)ps * m_quantizeTable[stScale];
-  float min = (float)std::numeric_limits<SType>::min();
-  float max = (float)std::numeric_limits<SType>::max();
+  constexpr float min = (float)std::numeric_limits<SType>::min();
+  constexpr float max = (float)std::numeric_limits<SType>::max();
 
   return (SType)std::clamp(convPS, min, max);
 }

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -247,7 +247,7 @@ bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
       continue;
     }
 
-    char temp[256];
+    char temp[256]{};
     sscanf(line, "%255s", temp);
 
     if (strcmp(temp, "UNUSED") == 0)

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.cpp
@@ -28,7 +28,7 @@ void DualShockUDPClientWidget::CreateWidgets()
 
   m_servers_enabled = new QCheckBox(tr("Enable"));
   m_servers_enabled->setChecked(Config::Get(ciface::DualShockUDPClient::Settings::SERVERS_ENABLED));
-  main_layout->addWidget(m_servers_enabled, 0, 0);
+  main_layout->addWidget(m_servers_enabled, 0, {});
 
   m_server_list = new QListWidget();
   main_layout->addWidget(m_server_list);

--- a/Source/Core/DolphinQt/Config/ControllersWindow.cpp
+++ b/Source/Core/DolphinQt/Config/ControllersWindow.cpp
@@ -131,9 +131,12 @@ static int GetLayoutHorizontalSpacing(const QGridLayout* layout)
   // Docs claim this is deprecated, but on macOS with Qt 5.8 this is the only one that actually
   // works.
   float pixel_ratio = QGuiApplication::primaryScreen()->devicePixelRatio();
+#ifdef __APPLE__
+  // TODO is this still required?
   hspacing = pixel_ratio * style->pixelMetric(QStyle::PM_DefaultLayoutSpacing);
   if (hspacing >= 0)
     return hspacing;
+#endif
 
   // Ripped from qtbase/src/widgets/styles/qcommonstyle.cpp
   return pixel_ratio * 6;

--- a/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryViewWidget.cpp
@@ -156,7 +156,7 @@ void MemoryViewWidget::Update()
         }
         else
         {
-          hex_item->setFlags(0);
+          hex_item->setFlags({});
           hex_item->setText(QStringLiteral("-"));
         }
       }

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -21,7 +21,7 @@
     <ClCompile>
       <!-- 5054  operator '+': deprecated between enumerations of different types (in Qt headers) -->
       <DisableSpecificWarnings>5054;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>($ProjectDir)Config\Graphics;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Config\Graphics;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)Config\ControllerInterface;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ProjectDir)Config\Mapping;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
+++ b/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
@@ -120,7 +120,7 @@ QLayoutItem* FlowLayout::takeAt(int index)
 
 Qt::Orientations FlowLayout::expandingDirections() const
 {
-  return 0;
+  return {};
 }
 
 bool FlowLayout::hasHeightForWidth() const

--- a/Source/Core/DolphinQt/Settings/InterfacePane.cpp
+++ b/Source/Core/DolphinQt/Settings/InterfacePane.cpp
@@ -186,9 +186,9 @@ void InterfacePane::ConnectLayout()
   connect(m_checkbox_use_covers, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_show_debugging_ui, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
   connect(m_checkbox_focused_hotkeys, &QCheckBox::toggled, this, &InterfacePane::OnSaveConfig);
-  connect(m_combobox_theme, qOverload<const QString&>(&QComboBox::currentIndexChanged),
-          &Settings::Instance(), &Settings::SetThemeName);
-  connect(m_combobox_userstyle, qOverload<const QString&>(&QComboBox::currentIndexChanged), this,
+  connect(m_combobox_theme, qOverload<int>(&QComboBox::currentIndexChanged), this,
+          [=](int index) { Settings::Instance().SetThemeName(m_combobox_theme->itemText(index)); });
+  connect(m_combobox_userstyle, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &InterfacePane::OnSaveConfig);
   connect(m_combobox_language, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &InterfacePane::OnSaveConfig);

--- a/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
+++ b/Source/Core/DolphinQt/Settings/USBDeviceAddToWhitelistDialog.cpp
@@ -168,10 +168,9 @@ void USBDeviceAddToWhitelistDialog::OnDeviceSelection()
 {
   // Not the nicest way of doing this but...
   QString device = usb_inserted_devices_list->currentItem()->text().left(9);
-  QString* vid = new QString(
-      device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[0]);
-  QString* pid = new QString(
-      device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[1]);
+  QStringList split = device.split(QString::fromStdString(":"));
+  QString* vid = new QString(split[0]);
+  QString* pid = new QString(split[1]);
   device_vid_textbox->setText(*vid);
   device_pid_textbox->setText(*pid);
 }

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -279,10 +279,9 @@ void WiiPane::OnUSBWhitelistAddButton()
 void WiiPane::OnUSBWhitelistRemoveButton()
 {
   QString device = m_whitelist_usb_list->currentItem()->text().left(9);
-  QString vid =
-      QString(device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[0]);
-  QString pid =
-      QString(device.split(QString::fromStdString(":"), QString::SplitBehavior::KeepEmptyParts)[1]);
+  QStringList split = device.split(QString::fromStdString(":"));
+  QString vid = QString(split[0]);
+  QString pid = QString(split[1]);
   const u16 vid_u16 = static_cast<u16>(std::stoul(vid.toStdString(), nullptr, 16));
   const u16 pid_u16 = static_cast<u16>(std::stoul(pid.toStdString(), nullptr, 16));
   SConfig::GetInstance().m_usb_passthrough_devices.erase({vid_u16, pid_u16});

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -45,7 +45,7 @@ public:
       std::getline(buffer, section, '.');
       std::getline(buffer, key, '=');
       std::getline(buffer, value, '=');
-      const std::optional<Config::System> system = Config::GetSystemFromName(system_str);
+      std::optional<Config::System> system = Config::GetSystemFromName(system_str);
       if (system)
       {
         m_values.emplace_back(

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -15,12 +15,6 @@
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 
-#define CHECK(cond, Message, ...)                                                                  \
-  if (!(cond))                                                                                     \
-  {                                                                                                \
-    PanicAlert("%s failed in %s at line %d: " Message, __func__, __FILE__, __LINE__, __VA_ARGS__); \
-  }
-
 namespace DX11
 {
 using Microsoft::WRL::ComPtr;

--- a/Source/Core/VideoBackends/D3D12/Common.h
+++ b/Source/Core/VideoBackends/D3D12/Common.h
@@ -9,13 +9,6 @@
 #include "Common/MsgHandler.h"
 #include "VideoBackends/D3DCommon/Common.h"
 
-#define CHECK(cond, Message, ...)                                                                  \
-  if (!(cond))                                                                                     \
-  {                                                                                                \
-    PanicAlert(__FUNCTION__ " failed in %s at line %d: " Message, __FILE__, __LINE__,              \
-               __VA_ARGS__);                                                                       \
-  }
-
 namespace DX12
 {
 using Microsoft::WRL::ComPtr;

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -195,10 +195,10 @@ void VertexManager::UploadAllConstants()
 {
   // We are free to re-use parts of the buffer now since we're uploading all constants.
   const u32 pixel_constants_offset = 0;
-  const u32 vertex_constants_offset =
+  constexpr u32 vertex_constants_offset =
       Common::AlignUp(pixel_constants_offset + sizeof(PixelShaderConstants),
                       D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
-  const u32 geometry_constants_offset =
+  constexpr u32 geometry_constants_offset =
       Common::AlignUp(vertex_constants_offset + sizeof(VertexShaderConstants),
                       D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
   const u32 allocation_size = geometry_constants_offset + sizeof(GeometryShaderConstants);

--- a/Source/Core/VideoBackends/D3DCommon/Common.h
+++ b/Source/Core/VideoBackends/D3DCommon/Common.h
@@ -12,6 +12,13 @@
 
 #include "Common/CommonTypes.h"
 
+#define CHECK(cond, Message, ...)                                                                  \
+  if (!(cond))                                                                                     \
+  {                                                                                                \
+    PanicAlert("%s failed in %s at line %d: " Message, __func__, __FILE__, __LINE__,               \
+               ##__VA_ARGS__);                                                                     \
+  }
+
 struct IDXGIFactory;
 
 enum class AbstractTextureFormat : u32;

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -38,7 +38,7 @@
 namespace OGL
 {
 u32 ProgramShaderCache::s_ubo_buffer_size;
-s32 ProgramShaderCache::s_ubo_align;
+s32 ProgramShaderCache::s_ubo_align = 1;
 GLuint ProgramShaderCache::s_attributeless_VBO = 0;
 GLuint ProgramShaderCache::s_attributeless_VAO = 0;
 GLuint ProgramShaderCache::s_last_VAO = 0;

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -20,11 +20,7 @@ constexpr u32 MAX_XFB_WIDTH = 720;
 // that are next to each other in memory (TODO: handle that situation).
 constexpr u32 MAX_XFB_HEIGHT = 576;
 
-#if defined(_WIN32) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1)
-#define PRIM_LOG(...) DEBUG_LOG(VIDEO, __VA_ARGS__)
-#else
 #define PRIM_LOG(...) DEBUG_LOG(VIDEO, ##__VA_ARGS__)
-#endif
 
 // warning: mapping buffer should be disabled to use this
 // #define LOG_VTX() DEBUG_LOG(VIDEO, "vtx: %f %f %f, ", ((float*)g_vertex_manager_write_ptr)[-3],

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -81,6 +81,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <MinimalRebuild>false</MinimalRebuild>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <!--Enable latest C++ standard-->
       <LanguageStandard>stdcpplatest</LanguageStandard>
@@ -124,22 +125,21 @@
     </ClCompile>
     <!--ClCompile Debug-->
     <ClCompile Condition="'$(Configuration)'=='Debug'">
-      <FunctionLevelLinking>true</FunctionLevelLinking>
       <PreprocessorDefinitions>_DEBUG;_SECURE_SCL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <Optimization>Disabled</Optimization>
     </ClCompile>
     <!--ClCompile Release-->
     <ClCompile Condition="'$(Configuration)'=='Release'">
-      <WholeProgramOptimization Condition="'$(DolphinRelease)'=='true'">true</WholeProgramOptimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <FunctionLevelLinking>false</FunctionLevelLinking>
       <PreprocessorDefinitions>_SECURE_SCL=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/Gw %(AdditionalOptions)</AdditionalOptions>
+      <WholeProgramOptimization Condition="'$(DolphinRelease)'=='true'">true</WholeProgramOptimization>
     </ClCompile>
     <!--Link Base-->
     <Link>

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -5,6 +5,8 @@
     <IntDir>$(BuildRootDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(IntDir)bin\</OutDir>
     <TargetName Condition="'$(ConfigurationType)'=='Application'">$(ProjectName)$(TargetSuffix)</TargetName>
+    <!--Set link /INCREMENTAL:NO to remove some entropy from builds (assists with /Brepro)-->
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <!--ClCompile Base-->

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -120,6 +120,7 @@
       4946  Reinterpret cast between related types
       -->
       <AdditionalOptions>/w44263 /w44265 /w44946 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <!--ClCompile Debug-->
     <ClCompile Condition="'$(Configuration)'=='Debug'">
@@ -144,6 +145,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <!--Link Release-->
     <Link Condition="'$(Configuration)'=='Release'">
@@ -156,11 +158,12 @@
       <!--See Common/CompatPatches.cpp-->
       <ForceSymbolReferences>enableCompatPatches</ForceSymbolReferences>
       <!--TODO fix up ffmpeg garbage-->
-      <AdditionalOptions>/NODEFAULTLIB:libcmt /Brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/NODEFAULTLIB:libcmt %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Lib>
       <TreatLibWarningAsErrors>true</TreatLibWarningAsErrors>
       <LinkTimeCodeGeneration Condition="'$(DolphinRelease)'=='true'">true</LinkTimeCodeGeneration>
+      <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
     </Lib>
     <!--
     Prefer VTune 2015 over 2013 but support both since there is no non-commercial license for 2015 :(

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -2,12 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Base.Macros.props" Condition="'$(BaseMacrosImported)'==''" />
   <PropertyGroup>
-    <!--
-    Opt-in to x64 compiler and tools.
-    Unfortunately we can't set this property here, as it'll be overridden later. Instead, set it
-    from commandline if you're interested in using x64 toolset
-    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
-    -->
     <IntDir>$(BuildRootDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(IntDir)bin\</OutDir>
     <TargetName Condition="'$(ConfigurationType)'=='Application'">$(ProjectName)$(TargetSuffix)</TargetName>

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -81,12 +81,8 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
-      <!--Enforce some behaviors as standards-conformant when they don't default as such.
-        TODO: Enable /Zc:preprocessor. Note as of VS 16.7 and despite claims on msdn, the
-        new preprocessor has some notable bugs/regressions, and isn't warning-free when
-        used on WinSDK (<= 10.0.19041) headers.
-      -->
-      <AdditionalOptions>/Zc:externConstexpr,lambda,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <!--Enforce some behaviors as standards-conformant when they don't default as such.-->
+      <AdditionalOptions>/Zc:externConstexpr,lambda,preprocessor,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
       <!--Treat sources as utf-8-->
@@ -109,6 +105,10 @@
                 Currently jits use some annoying code patterns which makes this common
       -->
       <DisableSpecificWarnings>4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <!-- Temporarily disable warnings to enable /Zc:preprocessor compatibility with WinSDK headers.
+      5105  macro expansion producing 'defined' has undefined behavior
+      -->
+      <DisableSpecificWarnings>5105;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- Enable some off-by-default warnings
       4263  Non-virtual member function hides base class virtual function
       4265  Class has virtual functions, but destructor is not virtual

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -54,6 +54,8 @@
       <AdditionalIncludeDirectories>$(ExternalsDir)zstd\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FMT_HEADER_ONLY=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--Currently needed for some code in StringUtil used only on Android-->
+      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>USE_UPNP;USE_USBDK;__LIBUSB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>SFML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>USE_ANALYTICS=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -53,7 +53,13 @@
       <AdditionalIncludeDirectories>$(ExternalsDir)zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)zstd\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FMT_HEADER_ONLY=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+        It would be a good idea to disable _CRT_SECURE_NO_WARNINGS and get rid of e.g. C string parsing funcs
+        Unfortunately this also complains about FILE* APIs, which can be inconvenient to replace.
+      -->
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--IOS net code uses some ipv4-only functions which are marked as deprecated by winsock2-->
+      <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!--Currently needed for some code in StringUtil used only on Android-->
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>USE_UPNP;USE_USBDK;__LIBUSB__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -92,13 +98,6 @@
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
-      <!--
-      4996  is for GetVersionEx being marked as deprecated - which is idiotic and there's not much
-                else we can do since many externals use it. The bad part is that there doesn't
-                seem to be a way to only ignore the specific instance we don't care about...
-      4351  new behavior: elements of array 'array' will be default initialized
-      -->
-      <DisableSpecificWarnings>4996;4351;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- Warnings one may want to ignore when using Level4.
       4201  nonstandard extension used : nameless struct/union
       4127  conditional expression is constant

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -118,6 +118,12 @@
       -->
       <AdditionalOptions>/w44263 /w44265 /w44946 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
+      <!--
+        A (currently) hidden switch, like /Brepro, furthermore enabling warnings about non-deterministic code.
+        This may be advantageous over /Brepro, which inits __DATE__, __TIME__, etc. equal to 1 (and allows
+        them to be redefined), which could have unexpected results.
+      -->
+      <AdditionalOptions>/experimental:deterministic %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <!--ClCompile Debug-->
     <ClCompile Condition="'$(Configuration)'=='Debug'">

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -80,8 +80,12 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <!--Enable Standard Conformance-->
       <ConformanceMode>true</ConformanceMode>
-      <!--Enforce some behaviors as standards-conformant when they don't default as such-->
-      <AdditionalOptions>/Zc:throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <!--Enforce some behaviors as standards-conformant when they don't default as such.
+        TODO: Enable /Zc:preprocessor. Note as of VS 16.7 and despite claims on msdn, the
+        new preprocessor has some notable bugs/regressions, and isn't warning-free when
+        used on WinSDK (<= 10.0.19041) headers.
+      -->
+      <AdditionalOptions>/Zc:externConstexpr,lambda,throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
       <!--Treat sources as utf-8-->

--- a/Source/VSProps/Configuration.Base.props
+++ b/Source/VSProps/Configuration.Base.props
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Configuration">
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <!--<EnableASAN>true</EnableASAN>-->
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
* fixing some stuff that VS' code analysis detected.
* make msvc settings more standard conformant
* re-enable msvc warning for deprecated items, and make build pass
* enables msvc to merge and collect unused functions + data
* makes msvc builds deterministic / reproducible