### PR TITLE
prevent nullptr deref in WIABlob

### DIFF
--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -1235,7 +1235,7 @@ static void RVZPack(const u8* in, OutputParametersEntry* out, u64 bytes_per_chun
       }
 
       const u64 junk_bytes = next_junk_end - current_offset;
-      if (junk_bytes > 0)
+      if (junk_bytes > 0 && seed)
       {
         PushBack(&entry.main_data, Common::swap32(static_cast<u32>(junk_bytes) | 0x80000000));
         PushBack(&entry.main_data, *seed);


### PR DESCRIPTION
@JosJuice is this actually possible? tbh I didn't fully understand the function to reason if it's actually possible to reach here with seed==nullptr, and if it is, I'm not sure if it can be silently ignored or not?

(PR broken off from #9037 )