### PR TITLE
Android: Better GCAdapter scanning thread management

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -376,6 +376,8 @@ public final class NativeLibrary
 
   public static native void ReloadConfig();
 
+  public static native void UpdateGCAdapterScanThread();
+
   /**
    * Initializes the native parts of the app.
    *

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -232,6 +232,7 @@ public class Settings
       NativeLibrary.ReloadConfig();
       NativeLibrary.ReloadWiimoteConfig();
       NativeLibrary.ReloadLoggerConfig();
+      NativeLibrary.UpdateGCAdapterScanThread();
 
       if (modifiedSettings.contains(SettingsFile.KEY_RECURSIVE_ISO_PATHS))
       {

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -50,6 +50,7 @@
 
 #include "InputCommon/ControllerInterface/Android/Android.h"
 #include "InputCommon/ControllerInterface/Touch/ButtonManager.h"
+#include "InputCommon/GCAdapter.h"
 
 #include "UICommon/UICommon.h"
 
@@ -628,6 +629,19 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ReloadConfig
                                                                                  jobject obj)
 {
   SConfig::GetInstance().LoadSettings();
+}
+
+JNIEXPORT void JNICALL
+Java_org_dolphinemu_dolphinemu_NativeLibrary_UpdateGCAdapterScanThread(JNIEnv* env, jobject obj)
+{
+  if (GCAdapter::UseAdapter())
+  {
+    GCAdapter::StartScanThread();
+  }
+  else
+  {
+    GCAdapter::StopScanThread();
+  }
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(JNIEnv* env,


### PR DESCRIPTION
Previously, the GCAdapter scanning thread would only be started if the GameCube adapter was enabled when starting the app. That's obviously a problem.