### PR TITLE
Add support for FreeBSD/arm64

### DIFF
--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -9,7 +9,9 @@
 #include <thread>
 
 #ifndef _WIN32
+#ifndef __FreeBSD__
 #include <asm/hwcap.h>
+#endif
 #include <sys/auxv.h>
 #include <unistd.h>
 #endif
@@ -87,7 +89,12 @@ void CPUInfo::Detect()
   num_cores = sysconf(_SC_NPROCESSORS_CONF);
   strncpy(cpu_string, GetCPUString().c_str(), sizeof(cpu_string));
 
+#ifdef __FreeBSD__
+  u_long hwcaps = 0;
+  elf_aux_info(AT_HWCAP, &hwcaps, sizeof(u_long));
+#else
   unsigned long hwcaps = getauxval(AT_HWCAP);
+#endif
   bFP = hwcaps & HWCAP_FP;
   bASIMD = hwcaps & HWCAP_ASIMD;
   bAES = hwcaps & HWCAP_AES;

--- a/Source/Core/Core/MachineContext.h
+++ b/Source/Core/Core/MachineContext.h
@@ -35,6 +35,7 @@ typedef CONTEXT SContext;
 #define CTX_RIP Rip
 #elif _M_ARM64
 #define CTX_REG(x) X[x]
+#define CTX_LR X[30]
 #define CTX_SP Sp
 #define CTX_PC Pc
 #else
@@ -115,6 +116,7 @@ typedef mcontext_t SContext;
 #define CTX_RIP gregs[REG_RIP]
 #elif _M_ARM_64
 #define CTX_REG(x) regs[x]
+#define CTX_LR regs[30]
 #define CTX_SP sp
 #define CTX_PC pc
 #else
@@ -189,6 +191,11 @@ typedef mcontext_t SContext;
 #define CTX_R14 mc_r14
 #define CTX_R15 mc_r15
 #define CTX_RIP mc_rip
+#elif _M_ARM_64
+#define CTX_REG(x) mc_gpregs.gp_x[x]
+#define CTX_LR mc_gpregs.gp_lr
+#define CTX_SP mc_gpregs.gp_sp
+#define CTX_PC mc_gpregs.gp_elr
 #else
 #error No context definition for architecture
 #endif

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -27,7 +27,7 @@ void JitArm64::DoBacktrace(uintptr_t access_address, SContext* ctx)
     ERROR_LOG(DYNA_REC, "R%d: 0x%016llx\tR%d: 0x%016llx", i, ctx->CTX_REG(i), i + 1,
               ctx->CTX_REG(i + 1));
 
-  ERROR_LOG(DYNA_REC, "R30: 0x%016llx\tSP: 0x%016llx", ctx->CTX_REG(30), ctx->CTX_SP);
+  ERROR_LOG(DYNA_REC, "R30: 0x%016llx\tSP: 0x%016llx", ctx->CTX_LR, ctx->CTX_SP);
 
   ERROR_LOG(DYNA_REC, "Access Address: 0x%016lx", access_address);
   ERROR_LOG(DYNA_REC, "PC: 0x%016llx", ctx->CTX_PC);


### PR DESCRIPTION
This PR adds support for ARM64 on FreeBSD. Dolphin already supported ARM64 on Linux and Windows and FreeBSD x86_64 independently but lacked support for the combination of the two, which might be useful for people running FreeBSD on Raspberry Pi 3 and 4.

To get Dolphin to compile, two things had be fixed:
* `asm/hwcap.h`/`getauxval()` does not exist on FreeBSD. Instead FreeBSD has `elf_aux_info()` since FreeBSD 12.0: https://reviews.freebsd.org/rS324815. The two functions have a slightly different interface but work morally the same.

* FreeBSD/ARM64 was missing from `MachineContext.h`. From The `mcontext_t` definition (see https://github.com/freebsd/freebsd/blob/master/sys/arm64/include/ucontext.h#L62):
  - `gp_elr` is equivalent of `PC` (see [arm documentation](https://developer.arm.com/documentation/dui0801/a/Overview-of-AArch64-state/Program-Counter-in-AArch64-state?lang=en))
  - `SP` is straightforward.
  - and the general registers were also straightforward but the interface is slightly different from the glibc version which has 31 registers where register 30 is also called `LR` (see [arm documentation](https://developer.arm.com/documentation/dui0801/a/Overview-of-AArch64-state/Link-registers?lang=en)). On FreeBSD the interface has only 30 registers and a separate `LR` so I separated the two and replaced uses of `CTX_REG(30)` to the new `CTX_LR` where needed.

The code compiles, the UI runs fine but we couldn't test any games as the Graphic drivers for the RPi4 seem too unstable (we're not sure what's going on, the best we got is a segfault backtrace in `llvmpipe` after calling `VideoCommon::PostProcessing::BlitFromTexture`), but at least it's an improvement over the previous state.
If someone has another ARM64 machine with FreeBSD on it and wants to test actually running games, it's also more than welcome.

*Join work with @Tilka*