### PR TITLE
AudioInterface: Use 32029/48043 Hz in more places

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -15,6 +15,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
+#include "Core/HW/AudioInterface.h"
 
 // This shouldn't be a global, at least not here.
 std::unique_ptr<SoundStream> g_sound_stream;
@@ -66,6 +67,12 @@ void InitSoundStream()
     g_sound_stream = std::make_unique<NullSound>();
     g_sound_stream->Init();
   }
+
+  // Ideally these two calls would be done in AudioInterface::Init so that we don't
+  // need to have a dependency on AudioInterface here, but this has to be done
+  // after creating g_sound_stream (above) and before starting audio dumping (below)
+  g_sound_stream->GetMixer()->SetDMAInputSampleRate(AudioInterface::GetAIDSampleRate());
+  g_sound_stream->GetMixer()->SetStreamInputSampleRate(AudioInterface::GetAISSampleRate());
 
   UpdateSoundStream();
   SetSoundStreamRunning(true);

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -149,8 +149,8 @@ void Init()
   s_last_cpu_time = 0;
   s_cpu_cycles_per_sample = 0xFFFFFFFFFFFULL;
 
-  s_ais_sample_rate = 48000;
-  s_aid_sample_rate = 32000;
+  s_ais_sample_rate = Get48KHzSampleRate();
+  s_aid_sample_rate = Get32KHzSampleRate();
 
   event_type_ai = CoreTiming::RegisterEvent("AICallback", Update);
 }
@@ -184,10 +184,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
           // AISFR rates below are intentionally inverted wrt yagcd
           DEBUG_LOG(AUDIO_INTERFACE, "Change AISFR to %s", tmp_ai_ctrl.AISFR ? "48khz" : "32khz");
           s_control.AISFR = tmp_ai_ctrl.AISFR;
-          if (SConfig::GetInstance().bWii)
-            s_ais_sample_rate = tmp_ai_ctrl.AISFR ? 48000 : 32000;
-          else
-            s_ais_sample_rate = tmp_ai_ctrl.AISFR ? 48043 : 32029;
+          s_ais_sample_rate = tmp_ai_ctrl.AISFR ? Get48KHzSampleRate() : Get32KHzSampleRate();
           g_sound_stream->GetMixer()->SetStreamInputSampleRate(s_ais_sample_rate);
           s_cpu_cycles_per_sample = SystemTimers::GetTicksPerSecond() / s_ais_sample_rate;
         }
@@ -196,10 +193,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
         {
           DEBUG_LOG(AUDIO_INTERFACE, "Change AIDFR to %s", tmp_ai_ctrl.AIDFR ? "32khz" : "48khz");
           s_control.AIDFR = tmp_ai_ctrl.AIDFR;
-          if (SConfig::GetInstance().bWii)
-            s_aid_sample_rate = tmp_ai_ctrl.AIDFR ? 32000 : 48000;
-          else
-            s_aid_sample_rate = tmp_ai_ctrl.AIDFR ? 32029 : 48043;
+          s_aid_sample_rate = tmp_ai_ctrl.AIDFR ? Get32KHzSampleRate() : Get48KHzSampleRate();
           g_sound_stream->GetMixer()->SetDMAInputSampleRate(s_aid_sample_rate);
         }
 
@@ -302,6 +296,16 @@ bool IsPlaying()
 unsigned int GetAIDSampleRate()
 {
   return s_aid_sample_rate;
+}
+
+u32 Get32KHzSampleRate()
+{
+  return SConfig::GetInstance().bWii ? 32000 : 32029;
+}
+
+u32 Get48KHzSampleRate()
+{
+  return SConfig::GetInstance().bWii ? 48000 : 48043;
 }
 
 static void Update(u64 userdata, s64 cycles_late)

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -293,9 +293,14 @@ bool IsPlaying()
   return (s_control.PSTAT == 1);
 }
 
-unsigned int GetAIDSampleRate()
+u32 GetAIDSampleRate()
 {
   return s_aid_sample_rate;
+}
+
+u32 GetAISSampleRate()
+{
+  return s_ais_sample_rate;
 }
 
 u32 Get32KHzSampleRate()

--- a/Source/Core/Core/HW/AudioInterface.h
+++ b/Source/Core/Core/HW/AudioInterface.h
@@ -26,6 +26,9 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 // Get the audio rates (48000 or 32000 only)
 unsigned int GetAIDSampleRate();
 
+u32 Get32KHzSampleRate();
+u32 Get48KHzSampleRate();
+
 void GenerateAISInterrupt();
 
 }  // namespace AudioInterface

--- a/Source/Core/Core/HW/AudioInterface.h
+++ b/Source/Core/Core/HW/AudioInterface.h
@@ -24,7 +24,8 @@ bool IsPlaying();
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
 // Get the audio rates (48000 or 32000 only)
-unsigned int GetAIDSampleRate();
+u32 GetAIDSampleRate();
+u32 GetAISSampleRate();
 
 u32 Get32KHzSampleRate();
 u32 Get48KHzSampleRate();

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -294,7 +294,8 @@ static u32 AdvanceDTK(u32 maximum_samples, u32* samples_to_process)
 static void DTKStreamingCallback(DIInterruptType interrupt_type, const std::vector<u8>& audio_data,
                                  s64 cycles_late)
 {
-  // TODO: Should we use the configured AIS sample rate instead of a fixed 48 KHz?
+  // TODO: Should we use GetAISSampleRate instead of a fixed 48 KHz? The audio mixer is using
+  // GetAISSampleRate. (This doesn't affect any actual games, since they all set it to 48 KHz.)
   const u32 sample_rate = AudioInterface::Get48KHzSampleRate();
 
   // Determine which audio data to read next.


### PR DESCRIPTION
In particular, I wanted to do change this in AudioInterface::Init so that dumped GC audio doesn't need to have a file split (changing from 32000 Hz to 32029 Hz) when the emulated software initializes the AI registers. I've also made the same change to DI's DTK code.