### PR TITLE
DiscIO: Add parameters to BlobReader::SupportsReadWiiDecrypted

### DIFF
--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -70,7 +70,11 @@ public:
     return Common::FromBigEndian(temp);
   }
 
-  virtual bool SupportsReadWiiDecrypted() const { return false; }
+  virtual bool SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const
+  {
+    return false;
+  }
+
   virtual bool ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset)
   {
     return false;

--- a/Source/Core/DiscIO/DirectoryBlob.h
+++ b/Source/Core/DiscIO/DirectoryBlob.h
@@ -157,7 +157,7 @@ public:
   DirectoryBlobReader& operator=(DirectoryBlobReader&&) = default;
 
   bool Read(u64 offset, u64 length, u8* buffer) override;
-  bool SupportsReadWiiDecrypted() const override;
+  bool SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const override;
   bool ReadWiiDecrypted(u64 offset, u64 size, u8* buffer, u64 partition_data_offset) override;
 
   BlobType GetBlobType() const override;
@@ -184,6 +184,8 @@ private:
 
   explicit DirectoryBlobReader(const std::string& game_partition_root,
                                const std::string& true_root);
+
+  const DirectoryBlobPartition* GetPartition(u64 offset, u64 size, u64 partition_data_offset) const;
 
   bool EncryptPartitionData(u64 offset, u64 size, u8* buffer, u64 partition_data_offset,
                             u64 partition_data_decrypted_size);

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -171,11 +171,9 @@ bool VolumeWii::Read(u64 offset, u64 length, u8* buffer, const Partition& partit
     return false;
   const PartitionDetails& partition_details = it->second;
 
-  if (m_reader->SupportsReadWiiDecrypted())
-  {
-    return m_reader->ReadWiiDecrypted(offset, length, buffer,
-                                      partition.offset + *partition_details.data_offset);
-  }
+  const u64 partition_data_offset = partition.offset + *partition_details.data_offset;
+  if (m_reader->SupportsReadWiiDecrypted(offset, length, partition_data_offset))
+    return m_reader->ReadWiiDecrypted(offset, length, buffer, partition_data_offset);
 
   if (!m_encrypted)
   {

--- a/Source/Core/DiscIO/WIABlob.h
+++ b/Source/Core/DiscIO/WIABlob.h
@@ -59,7 +59,7 @@ public:
   std::string GetCompressionMethod() const override;
 
   bool Read(u64 offset, u64 size, u8* out_ptr) override;
-  bool SupportsReadWiiDecrypted() const override;
+  bool SupportsReadWiiDecrypted(u64 offset, u64 size, u64 partition_data_offset) const override;
   bool ReadWiiDecrypted(u64 offset, u64 size, u8* out_ptr, u64 partition_data_offset) override;
 
   static ConversionResultCode Convert(BlobReader* infile, const VolumeDisc* infile_volume,
@@ -223,6 +223,8 @@ private:
   explicit WIARVZFileReader(File::IOFile file, const std::string& path);
   bool Initialize(const std::string& path);
   bool HasDataOverlap() const;
+
+  const PartitionEntry* GetPartition(u64 partition_data_offset, u32* partition_first_sector) const;
 
   bool ReadFromGroups(u64* offset, u64* size, u8** out_ptr, u64 chunk_size, u32 sector_size,
                       u64 data_offset, u64 data_size, u32 group_index, u32 number_of_groups,

--- a/Source/Core/DiscIO/WiiEncryptionCache.cpp
+++ b/Source/Core/DiscIO/WiiEncryptionCache.cpp
@@ -29,10 +29,7 @@ WiiEncryptionCache::EncryptGroup(u64 offset, u64 partition_data_offset,
 {
   // Only allocate memory if this function actually ends up getting called
   if (!m_cache)
-  {
     m_cache = std::make_unique<std::array<u8, VolumeWii::GROUP_TOTAL_SIZE>>();
-    ASSERT(m_blob->SupportsReadWiiDecrypted());
-  }
 
   ASSERT(offset % VolumeWii::GROUP_TOTAL_SIZE == 0);
   const u64 group_offset_in_partition =


### PR DESCRIPTION
It's possible (but rare) for a WIA or RVZ file to support this for some partitions but not all, and for the game and the blob code to disagree on how large a partition is.