### PR TITLE
Ignore PI_RESET_CODE resetting DI in Wii mode

### DIFF
--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -119,7 +119,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  MMIO::ComplexWrite<u32>([](u32, u32 val) {
                    m_ResetCode = val;
                    INFO_LOG(PROCESSORINTERFACE, "Wrote PI_RESET_CODE: %08x", m_ResetCode);
-                   if (~m_ResetCode & 0x4)
+                   if (!SConfig::GetInstance().bWii && ~m_ResetCode & 0x4)
                    {
                      DVDInterface::ResetDrive(true);
                    }


### PR DESCRIPTION
Fixes [bug 12241](https://bugs.dolphin-emu.org/issues/12241).  I did a quick hardware test, and it doesn't seem like writes to it actually do anything in Wii mode; IOS reads still return normally and the drive didn't make any noises that sound like it was reset (unlike when resetting it through IOS).  I'm guessing Project M's write to it is just a leftover.

I did notice a different oddity, though: even though I always wrote with bit 1 set, reading back never had bit 1 set.  Also, bit 2 was set by the time HBC loaded my code.  That should be investigated further (along with behavior in GameCube compatibility mode, and behavior on actual GameCubes).  So, there's probably further behavior that could be emulated, but this still seems to be accurate.

I've tested and confirmed that this does not interfere with actually changing discs for GameCube games; they still properly detect the disc change and spin it up again.  This includes when launched from the Wii menu (since [`bWii` is set to false](https://github.com/dolphin-emu/dolphin/blob/db067104ed42debf28e60f31c31131ae2a7c8441/Source/Core/Core/IOS/MIOS.cpp#L32) by the current MIOS implementation).