### PR TITLE
Android: Optional AfterDirectoryInitializationRunner failure message

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -3,7 +3,6 @@ package org.dolphinemu.dolphinemu.features.settings.ui;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.os.Bundle;
 import android.provider.Settings;
 
@@ -11,7 +10,6 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.view.Menu;
@@ -22,8 +20,6 @@ import android.widget.Toast;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.ui.main.MainActivity;
 import org.dolphinemu.dolphinemu.ui.main.TvMainActivity;
-import org.dolphinemu.dolphinemu.utils.DirectoryInitialization;
-import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.TvUtil;
 
@@ -151,22 +147,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   }
 
   @Override
-  public void startDirectoryInitializationService(DirectoryStateReceiver receiver,
-          IntentFilter filter)
-  {
-    LocalBroadcastManager.getInstance(this).registerReceiver(
-            receiver,
-            filter);
-    DirectoryInitialization.start(this);
-  }
-
-  @Override
-  public void stopListeningToDirectoryInitializationService(DirectoryStateReceiver receiver)
-  {
-    LocalBroadcastManager.getInstance(this).unregisterReceiver(receiver);
-  }
-
-  @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent result)
   {
     super.onActivityResult(requestCode, resultCode, result);
@@ -210,20 +190,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   public void hideLoading()
   {
     dialog.dismiss();
-  }
-
-  @Override
-  public void showPermissionNeededHint()
-  {
-    Toast.makeText(this, R.string.write_permission_needed, Toast.LENGTH_SHORT)
-            .show();
-  }
-
-  @Override
-  public void showExternalStorageNotMountedHint()
-  {
-    Toast.makeText(this, R.string.external_storage_not_mounted, Toast.LENGTH_SHORT)
-            .show();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -1,10 +1,8 @@
 package org.dolphinemu.dolphinemu.features.settings.ui;
 
-import android.content.IntentFilter;
 import android.os.Bundle;
 
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
-import org.dolphinemu.dolphinemu.utils.DirectoryStateReceiver;
 
 /**
  * Abstraction for the Activity that manages SettingsFragments.
@@ -98,32 +96,7 @@ public interface SettingsActivityView
   void hideLoading();
 
   /**
-   * Show a hint to the user that the app needs write to external storage access
-   */
-  void showPermissionNeededHint();
-
-  /**
-   * Show a hint to the user that the app needs the external storage to be mounted
-   */
-  void showExternalStorageNotMountedHint();
-
-  /**
    * Tell the user that there is junk in the game INI and ask if they want to delete the whole file.
    */
   void showGameIniJunkDeletionQuestion();
-
-  /**
-   * Start the DirectoryInitialization and listen for the result.
-   *
-   * @param receiver the broadcast receiver for the DirectoryInitialization
-   * @param filter   the Intent broadcasts to be received.
-   */
-  void startDirectoryInitializationService(DirectoryStateReceiver receiver, IntentFilter filter);
-
-  /**
-   * Stop listening to the DirectoryInitialization.
-   *
-   * @param receiver The broadcast receiver to unregister.
-   */
-  void stopListeningToDirectoryInitializationService(DirectoryStateReceiver receiver);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/GameFileCacheService.java
@@ -109,7 +109,7 @@ public final class GameFileCacheService extends IntentService
    */
   public static void startLoad(Context context)
   {
-    new AfterDirectoryInitializationRunner().run(context,
+    new AfterDirectoryInitializationRunner().run(context, false,
             () -> startService(context, ACTION_LOAD));
   }
 
@@ -120,7 +120,7 @@ public final class GameFileCacheService extends IntentService
    */
   public static void startRescan(Context context)
   {
-    new AfterDirectoryInitializationRunner().run(context,
+    new AfterDirectoryInitializationRunner().run(context, false,
             () -> startService(context, ACTION_RESCAN));
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -72,7 +72,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
     if (PermissionsHandler.hasWriteAccess(this))
     {
       new AfterDirectoryInitializationRunner()
-              .run(this, this::setPlatformTabsAndStartGameFileCacheService);
+              .run(this, false, this::setPlatformTabsAndStartGameFileCacheService);
     }
   }
 
@@ -213,7 +213,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
       {
         DirectoryInitialization.start(this);
         new AfterDirectoryInitializationRunner()
-                .run(this, this::setPlatformTabsAndStartGameFileCacheService);
+                .run(this, false, this::setPlatformTabsAndStartGameFileCacheService);
       }
       else
       {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/AfterDirectoryInitializationRunner.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/AfterDirectoryInitializationRunner.java
@@ -2,12 +2,38 @@ package org.dolphinemu.dolphinemu.utils;
 
 import android.content.Context;
 import android.content.IntentFilter;
+import android.widget.Toast;
 
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.utils.DirectoryInitialization.DirectoryInitializationState;
+
 public class AfterDirectoryInitializationRunner
 {
-  private DirectoryStateReceiver directoryStateReceiver;
+  private DirectoryStateReceiver mDirectoryStateReceiver;
+  private LocalBroadcastManager mLocalBroadcastManager;
+
+  private Runnable mUnregisterCallback;
+
+  /**
+   * Sets a Runnable which will be called when:
+   *
+   * 1. The Runnable supplied to {@link #run} is just about to run, or
+   * 2. {@link #run} was called with abortOnFailure == true and there is a failure
+   */
+  public void setFinishedCallback(Runnable runnable)
+  {
+    mUnregisterCallback = runnable;
+  }
+
+  private void runFinishedCallback()
+  {
+    if (mUnregisterCallback != null)
+    {
+      mUnregisterCallback.run();
+    }
+  }
 
   /**
    * Executes a Runnable after directory initialization has finished.
@@ -19,33 +45,84 @@ public class AfterDirectoryInitializationRunner
    * in case directory initialization doesn't finish successfully.
    *
    * Calling this function multiple times per object is not supported.
+   *
+   * If abortOnFailure is true and the user has not granted the required
+   * permission or the external storage was not found, a message will be
+   * shown to the user and the Runnable will not run. If it is false, the
+   * attempt to run the Runnable will never be aborted, and the Runnable
+   * is guaranteed to run if directory initialization ever finishes.
    */
-  public void run(Context context, Runnable runnable)
+  public void run(Context context, boolean abortOnFailure, Runnable runnable)
   {
-    if (!DirectoryInitialization.areDolphinDirectoriesReady())
+    if (DirectoryInitialization.areDolphinDirectoriesReady())
     {
-      // Wait for directories to get initialized
-      IntentFilter statusIntentFilter = new IntentFilter(
-              DirectoryInitialization.BROADCAST_ACTION);
-
-      directoryStateReceiver = new DirectoryStateReceiver(directoryInitializationState ->
-      {
-        if (directoryInitializationState ==
-                DirectoryInitialization.DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED)
-        {
-          LocalBroadcastManager.getInstance(context).unregisterReceiver(directoryStateReceiver);
-          directoryStateReceiver = null;
-          runnable.run();
-        }
-      });
-      // Registers the DirectoryStateReceiver and its intent filters
-      LocalBroadcastManager.getInstance(context).registerReceiver(
-              directoryStateReceiver,
-              statusIntentFilter);
+      runFinishedCallback();
+      runnable.run();
+    }
+    else if (abortOnFailure &&
+            showErrorMessage(context, DirectoryInitialization.getDolphinDirectoriesState(context)))
+    {
+      runFinishedCallback();
     }
     else
     {
-      runnable.run();
+      runAfterInitialization(context, abortOnFailure, runnable);
+    }
+  }
+
+  private void runAfterInitialization(Context context, boolean abortOnFailure, Runnable runnable)
+  {
+    mDirectoryStateReceiver = new DirectoryStateReceiver(state ->
+    {
+      boolean done = state == DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED;
+
+      if (!done && abortOnFailure)
+      {
+        done = showErrorMessage(context, state);
+      }
+
+      if (done)
+      {
+        cancel();
+        runFinishedCallback();
+      }
+
+      if (state == DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED)
+      {
+        runnable.run();
+      }
+    });
+
+    mLocalBroadcastManager = LocalBroadcastManager.getInstance(context);
+
+    IntentFilter statusIntentFilter = new IntentFilter(DirectoryInitialization.BROADCAST_ACTION);
+    mLocalBroadcastManager.registerReceiver(mDirectoryStateReceiver, statusIntentFilter);
+  }
+
+  public void cancel()
+  {
+    if (mDirectoryStateReceiver != null)
+    {
+      mLocalBroadcastManager.unregisterReceiver(mDirectoryStateReceiver);
+      mDirectoryStateReceiver = null;
+      mLocalBroadcastManager = null;
+    }
+  }
+
+  private static boolean showErrorMessage(Context context, DirectoryInitializationState state)
+  {
+    switch (state)
+    {
+      case EXTERNAL_STORAGE_PERMISSION_NEEDED:
+        Toast.makeText(context, R.string.write_permission_needed, Toast.LENGTH_SHORT).show();
+        return true;
+
+      case CANT_FIND_EXTERNAL_STORAGE:
+        Toast.makeText(context, R.string.external_storage_not_mounted, Toast.LENGTH_SHORT).show();
+        return true;
+
+      default:
+        return false;
     }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -32,7 +32,7 @@ public class Analytics
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
     if (!preferences.getBoolean(analyticsAsked, false))
     {
-      new AfterDirectoryInitializationRunner().run(context,
+      new AfterDirectoryInitializationRunner().run(context, false,
               () -> showMessage(context, preferences));
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -37,13 +37,15 @@ public final class DirectoryInitialization
 
   public static final String EXTRA_STATE = "directoryState";
   private static final int WiimoteNewVersion = 5;  // Last changed in PR 8907
-  private static volatile DirectoryInitializationState directoryState = null;
+  private static volatile DirectoryInitializationState directoryState =
+          DirectoryInitializationState.NOT_YET_INITIALIZED;
   private static String userPath;
   private static String internalPath;
   private static AtomicBoolean isDolphinDirectoryInitializationRunning = new AtomicBoolean(false);
 
   public enum DirectoryInitializationState
   {
+    NOT_YET_INITIALIZED,
     DOLPHIN_DIRECTORIES_INITIALIZED,
     EXTERNAL_STORAGE_PERMISSION_NEEDED,
     CANT_FIND_EXTERNAL_STORAGE
@@ -199,9 +201,22 @@ public final class DirectoryInitialization
     return directoryState == DirectoryInitializationState.DOLPHIN_DIRECTORIES_INITIALIZED;
   }
 
+  public static DirectoryInitializationState getDolphinDirectoriesState(Context context)
+  {
+    if (directoryState == DirectoryInitializationState.NOT_YET_INITIALIZED &&
+            !PermissionsHandler.hasWriteAccess(context))
+    {
+      return DirectoryInitializationState.EXTERNAL_STORAGE_PERMISSION_NEEDED;
+    }
+    else
+    {
+      return directoryState;
+    }
+  }
+
   public static String getUserDirectory()
   {
-    if (directoryState == null)
+    if (directoryState == DirectoryInitializationState.NOT_YET_INITIALIZED)
     {
       throw new IllegalStateException("DirectoryInitialization has to run at least once!");
     }
@@ -216,7 +231,7 @@ public final class DirectoryInitialization
 
   public static String getDolphinInternalDirectory()
   {
-    if (directoryState == null)
+    if (directoryState == DirectoryInitializationState.NOT_YET_INITIALIZED)
     {
       throw new IllegalStateException("DirectoryInitialization has to run at least once!");
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -76,7 +76,7 @@ public final class StartupHandler
     long lastOpen = preferences.getLong(LAST_CLOSED, 0);
     if (currentTime > (lastOpen + SESSION_TIMEOUT))
     {
-      new AfterDirectoryInitializationRunner().run(context,
+      new AfterDirectoryInitializationRunner().run(context, false,
               NativeLibrary::ReportStartToAnalytics);
     }
   }


### PR DESCRIPTION
This centralizes the code for showing the `write_permission_needed` and `external_storage_not_mounted` toasts. Split out from PR #8962.