### PR TITLE
Make default graphics backend not show up as empty

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -12,6 +12,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "VideoCommon/VideoBackendBase.h"
 
 namespace Config
 {
@@ -97,7 +98,8 @@ const Info<bool> MAIN_OVERCLOCK_ENABLE{{System::Main, "Core", "OverclockEnable"}
 const Info<bool> MAIN_RAM_OVERRIDE_ENABLE{{System::Main, "Core", "RAMOverrideEnable"}, false};
 const Info<u32> MAIN_MEM1_SIZE{{System::Main, "Core", "MEM1Size"}, Memory::MEM1_SIZE_RETAIL};
 const Info<u32> MAIN_MEM2_SIZE{{System::Main, "Core", "MEM2Size"}, Memory::MEM2_SIZE_RETAIL};
-const Info<std::string> MAIN_GFX_BACKEND{{System::Main, "Core", "GFXBackend"}, ""};
+const Info<std::string> MAIN_GFX_BACKEND{{System::Main, "Core", "GFXBackend"},
+                                         VideoBackendBase::GetDefaultBackendName()};
 const Info<std::string> MAIN_GPU_DETERMINISM_MODE{{System::Main, "Core", "GPUDeterminismMode"},
                                                   "auto"};
 const Info<std::string> MAIN_PERF_MAP_DIR{{System::Main, "Core", "PerfMapDir"}, ""};

--- a/Source/Core/VideoBackends/D3D/VideoBackend.h
+++ b/Source/Core/VideoBackends/D3D/VideoBackend.h
@@ -21,6 +21,8 @@ public:
 
   void InitBackendInfo() override;
 
+  static constexpr const char* NAME = "D3D";
+
 private:
   void FillBackendInfo();
 };

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -29,7 +29,7 @@ namespace DX11
 {
 std::string VideoBackend::GetName() const
 {
-  return "D3D";
+  return NAME;
 }
 
 std::string VideoBackend::GetDisplayName() const

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -27,7 +27,7 @@ namespace DX12
 {
 std::string VideoBackend::GetName() const
 {
-  return "D3D12";
+  return NAME;
 }
 
 std::string VideoBackend::GetDisplayName() const

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.h
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.h
@@ -19,6 +19,8 @@ public:
   std::string GetDisplayName() const override;
   void InitBackendInfo() override;
 
+  static constexpr const char* NAME = "D3D12";
+
 private:
   void FillBackendInfo();
 };

--- a/Source/Core/VideoBackends/Null/VideoBackend.h
+++ b/Source/Core/VideoBackends/Null/VideoBackend.h
@@ -10,11 +10,14 @@ namespace Null
 {
 class VideoBackend final : public VideoBackendBase
 {
+public:
   bool Initialize(const WindowSystemInfo& wsi) override;
   void Shutdown() override;
 
-  std::string GetName() const override { return "Null"; }
+  std::string GetName() const override { return NAME; }
   std::string GetDisplayName() const override;
   void InitBackendInfo() override;
+
+  static constexpr const char* NAME = "Null";
 };
 }  // namespace Null

--- a/Source/Core/VideoBackends/OGL/VideoBackend.h
+++ b/Source/Core/VideoBackends/OGL/VideoBackend.h
@@ -13,6 +13,7 @@ namespace OGL
 {
 class VideoBackend : public VideoBackendBase
 {
+public:
   bool Initialize(const WindowSystemInfo& wsi) override;
   void Shutdown() override;
 
@@ -20,6 +21,8 @@ class VideoBackend : public VideoBackendBase
   std::string GetDisplayName() const override;
 
   void InitBackendInfo() override;
+
+  static constexpr const char* NAME = "OGL";
 
 private:
   bool InitializeGLExtensions(GLContext* context);

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -62,7 +62,7 @@ namespace OGL
 {
 std::string VideoBackend::GetName() const
 {
-  return "OGL";
+  return NAME;
 }
 
 std::string VideoBackend::GetDisplayName() const

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -45,7 +45,7 @@ public:
 
 std::string VideoSoftware::GetName() const
 {
-  return "Software Renderer";
+  return NAME;
 }
 
 std::string VideoSoftware::GetDisplayName() const

--- a/Source/Core/VideoBackends/Software/VideoBackend.h
+++ b/Source/Core/VideoBackends/Software/VideoBackend.h
@@ -19,5 +19,7 @@ class VideoSoftware : public VideoBackendBase
   std::optional<std::string> GetWarningMessage() const override;
 
   void InitBackendInfo() override;
+
+  static constexpr const char* NAME = "Software Renderer";
 };
 }  // namespace SW

--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -15,9 +15,11 @@ public:
   bool Initialize(const WindowSystemInfo& wsi) override;
   void Shutdown() override;
 
-  std::string GetName() const override { return "Vulkan"; }
+  std::string GetName() const override { return NAME; }
   std::string GetDisplayName() const override { return _trans("Vulkan"); }
   void InitBackendInfo() override;
   void PrepareWindow(WindowSystemInfo& wsi) override;
+
+  static constexpr const char* NAME = "Vulkan";
 };
 }  // namespace Vulkan

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -197,9 +197,21 @@ u16 VideoBackendBase::Video_GetBoundingBox(int index)
   return result;
 }
 
+// This function is called at static initialization, so we can't rely on s_default_backend being set
+std::string VideoBackendBase::GetDefaultBackendName()
+{
+#ifdef HAS_OPENGL
+  return OGL::VideoBackend::NAME;
+#elif defined(_WIN32)
+  return DX11::VideoBackend::NAME;
+#else
+  return Vulkan::VideoBackend::NAME;
+#endif
+}
+
 void VideoBackendBase::PopulateList()
 {
-  // OGL > D3D11 > Vulkan > SW > Null
+  // OGL > D3D11 > D3D12 > Vulkan > SW > Null
 #ifdef HAS_OPENGL
   g_available_video_backends.push_back(std::make_unique<OGL::VideoBackend>());
 #endif

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -59,6 +59,7 @@ public:
   u32 Video_GetQueryResult(PerfQueryType type);
   u16 Video_GetBoundingBox(int index);
 
+  static std::string GetDefaultBackendName();
   static void PopulateList();
   static void ClearList();
   static void ActivateBackend(const std::string& name);


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12245.

I considered making a change to DolphinQt instead of the core, but then additional effort would've been required to add the same fix to the Android GUI once we start using the new config system there.