### PR TITLE
Android: Make FilePicker act like a normal setting

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FilePicker.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FilePicker.java
@@ -20,6 +20,11 @@ public final class FilePicker extends SettingsItem
     return settings.getSection(getFile(), getSection()).getString(getKey(), mDefaultValue);
   }
 
+  public void setSelectedValue(Settings settings, String selection)
+  {
+    settings.getSection(getFile(), getSection()).setString(getKey(), selection);
+  }
+
   public int getRequestType()
   {
     return mRequestType;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -171,26 +171,12 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   {
     super.onActivityResult(requestCode, resultCode, result);
 
-    // Save modified non-FilePicker settings beforehand since finish() won't save them.
-    // onStop() must come before handling the resultCode to properly save FilePicker selection.
-    mPresenter.onStop(true);
-
     // If the user picked a file, as opposed to just backing out.
     if (resultCode == MainActivity.RESULT_OK)
     {
       String path = FileBrowserHelper.getSelectedPath(result);
       getFragment().getAdapter().onFilePickerConfirmation(path);
-
-      // Prevent duplicate Toasts.
-      if (!mPresenter.shouldSave())
-      {
-        Toast.makeText(this, "Saved settings to INI files", Toast.LENGTH_SHORT).show();
-      }
     }
-
-    // TODO: After result of FilePicker, duplicate SettingsActivity appears.
-    //       Finish to avoid this. Is there a better method?
-    finish();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -310,12 +310,10 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
   {
     FilePicker filePicker = (FilePicker) mClickedItem;
 
-    File file = SettingsFile.getSettingsFile(filePicker.getFile());
-    IniFile ini = new IniFile(file);
-    ini.setString(filePicker.getSection(), filePicker.getKey(), selectedFile);
-    ini.save(file);
+    if (!filePicker.getSelectedValue(mView.getSettings()).equals(selectedFile))
+      mView.onSettingChanged(filePicker.getKey());
 
-    NativeLibrary.ReloadConfig();
+    filePicker.setSelectedValue(mView.getSettings(), selectedFile);
 
     mClickedItem = null;
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/FilePickerViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/FilePickerViewHolder.java
@@ -7,9 +7,7 @@ import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.features.settings.model.view.FilePicker;
 import org.dolphinemu.dolphinemu.features.settings.model.view.SettingsItem;
 import org.dolphinemu.dolphinemu.features.settings.ui.SettingsAdapter;
-import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 import org.dolphinemu.dolphinemu.ui.main.MainPresenter;
-import org.dolphinemu.dolphinemu.utils.IniFile;
 
 public final class FilePickerViewHolder extends SettingViewHolder
 {
@@ -45,10 +43,7 @@ public final class FilePickerViewHolder extends SettingViewHolder
     }
     else
     {
-      // TODO: Reopening INI files all the time is slow
-      IniFile ini = new IniFile(SettingsFile.getSettingsFile(mFilePicker.getFile()));
-      mTextSettingDescription.setText(ini.getString(item.getSection(), item.getKey(),
-              mFilePicker.getSelectedValue(getAdapter().getSettings())));
+      mTextSettingDescription.setText(mFilePicker.getSelectedValue(getAdapter().getSettings()));
     }
   }
 


### PR DESCRIPTION
The reason why the finish() call was added no longer exists. (Also, there was never a duplicate SettingsActivity as far as I can tell, only a duplicate SettingsFragment.)

Split out from PR #8975.