### PR TITLE
Android: Add "Default Value" button to SliderSetting AlertDialog

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/FloatSliderSetting.java
@@ -13,6 +13,12 @@ public class FloatSliderSetting extends SliderSetting
     mDefaultValue = defaultValue;
   }
 
+  @Override
+  public int getDefaultValue()
+  {
+    return Math.round(mDefaultValue);
+  }
+
   public int getSelectedValue(Settings settings)
   {
     float value = settings.getSection(getFile(), getSection()).getFloat(getKey(), mDefaultValue);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/IntSliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/IntSliderSetting.java
@@ -13,6 +13,12 @@ public final class IntSliderSetting extends SliderSetting
     mDefaultValue = defaultValue;
   }
 
+  @Override
+  public int getDefaultValue()
+  {
+    return mDefaultValue;
+  }
+
   public int getSelectedValue(Settings settings)
   {
     return settings.getSection(getFile(), getSection()).getInt(getKey(), mDefaultValue);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/PercentSliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/PercentSliderSetting.java
@@ -11,6 +11,12 @@ public final class PercentSliderSetting extends FloatSliderSetting
   }
 
   @Override
+  public int getDefaultValue()
+  {
+    return Math.round(mDefaultValue * 100);
+  }
+
+  @Override
   public int getSelectedValue(Settings settings)
   {
     float value = settings.getSection(getFile(), getSection()).getFloat(getKey(), mDefaultValue);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SliderSetting.java
@@ -16,6 +16,8 @@ public abstract class SliderSetting extends SettingsItem
     mUnits = units;
   }
 
+  public abstract int getDefaultValue();
+
   public abstract int getSelectedValue(Settings settings);
 
   public int getMax()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -232,6 +232,11 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     builder.setTitle(item.getNameId());
     builder.setView(view);
     builder.setPositiveButton(R.string.ok, this);
+    builder.setNeutralButton(R.string.default_value, (dialogInterface, i) ->
+    {
+      // Overridden below to prevent button from closing the dialog.
+      // This can make manipulating multiple sliders easier.
+    });
     mDialog = builder.show();
 
     mTextSliderValue = view.findViewById(R.id.text_value);
@@ -247,6 +252,9 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
     seekbar.setKeyProgressIncrement(5);
 
     seekbar.setOnSeekBarChangeListener(this);
+
+    mDialog.getButton(AlertDialog.BUTTON_NEUTRAL)
+            .setOnClickListener(l -> seekbar.setProgress(item.getDefaultValue()));
   }
 
   public void onSubmenuClick(SubmenuSetting item)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -391,6 +391,7 @@
     <string name="pitch">Total Pitch</string>
     <string name="yaw">Total Yaw</string>
     <string name="vertical_offset">Vertical Offset</string>
+    <string name="default_value">Default Value</string>
     <string name="slider_setting_value">%1$d%2$s</string>
     <string name="disc_number">Disc %1$d</string>
     <string name="disabled_gc_overlay_notice">GameCube Controller 1 is set to \"None\"</string>


### PR DESCRIPTION
Quickly returning to the default value and not making users remember that value is good.
Should also be applied to #8961 after merging.