### PR TITLE
DolphinQt: properly remove slot connection for ConfigChange when object is destructed

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
@@ -18,7 +18,7 @@ GraphicsBool::GraphicsBool(const QString& label, const Config::Info<bool>& setti
   connect(this, &QCheckBox::toggled, this, &GraphicsBool::Update);
   setChecked(Config::Get(m_setting) ^ reverse);
 
-  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsChoice.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsChoice.cpp
@@ -17,7 +17,7 @@ GraphicsChoice::GraphicsChoice(const QStringList& options, const Config::Info<in
   connect(this, qOverload<int>(&QComboBox::currentIndexChanged), this, &GraphicsChoice::Update);
   setCurrentIndex(Config::Get(m_setting));
 
-  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.cpp
@@ -21,7 +21,7 @@ GraphicsInteger::GraphicsInteger(int minimum, int maximum, const Config::Info<in
   setValue(Config::Get(setting));
 
   connect(this, qOverload<int>(&GraphicsInteger::valueChanged), this, &GraphicsInteger::Update);
-  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsRadio.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsRadio.cpp
@@ -17,7 +17,7 @@ GraphicsRadioInt::GraphicsRadioInt(const QString& label, const Config::Info<int>
   setChecked(Config::Get(m_setting) == m_value);
   connect(this, &QRadioButton::toggled, this, &GraphicsRadioInt::Update);
 
-  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.cpp
@@ -21,7 +21,7 @@ GraphicsSlider::GraphicsSlider(int minimum, int maximum, const Config::Info<int>
 
   connect(this, &GraphicsSlider::valueChanged, this, &GraphicsSlider::Update);
 
-  connect(&Settings::Instance(), &Settings::ConfigChanged, [this] {
+  connect(&Settings::Instance(), &Settings::ConfigChanged, this, [this] {
     QFont bf = font();
     bf.setBold(Config::GetActiveLayerForConfig(m_setting) != Config::LayerType::Base);
     setFont(bf);

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -40,7 +40,7 @@ BreakpointWidget::BreakpointWidget(QWidget* parent) : QDockWidget(parent)
   // according to Settings
   setFloating(settings.value(QStringLiteral("breakpointwidget/floating")).toBool());
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, [this](Core::State state) {
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     UpdateButtonsEnabled();
     if (state == Core::State::Uninitialized)
     {
@@ -50,10 +50,10 @@ BreakpointWidget::BreakpointWidget(QWidget* parent) : QDockWidget(parent)
     }
   });
 
-  connect(&Settings::Instance(), &Settings::BreakpointsVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::BreakpointsVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled, [this](bool enabled) {
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this, [this](bool enabled) {
     setHidden(!enabled || !Settings::Instance().IsBreakpointsVisible());
   });
 

--- a/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/CodeWidget.cpp
@@ -43,7 +43,7 @@ CodeWidget::CodeWidget(QWidget* parent) : QDockWidget(parent)
   // according to Settings
   setFloating(settings.value(QStringLiteral("codewidget/floating")).toBool());
 
-  connect(&Settings::Instance(), &Settings::CodeVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::CodeVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, [this] {
@@ -54,7 +54,7 @@ CodeWidget::CodeWidget(QWidget* parent) : QDockWidget(parent)
 
   connect(Host::GetInstance(), &Host::NotifyMapLoaded, this, &CodeWidget::UpdateSymbols);
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled,
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this,
           [this](bool enabled) { setHidden(!enabled || !Settings::Instance().IsCodeVisible()); });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, &CodeWidget::Update);

--- a/Source/Core/DolphinQt/Debugger/JITWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/JITWidget.cpp
@@ -41,10 +41,10 @@ JITWidget::JITWidget(QWidget* parent) : QDockWidget(parent)
   m_asm_splitter->restoreState(
       settings.value(QStringLiteral("jitwidget/asmsplitter")).toByteArray());
 
-  connect(&Settings::Instance(), &Settings::JITVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::JITVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled,
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this,
           [this](bool enabled) { setHidden(!enabled || !Settings::Instance().IsJITVisible()); });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, &JITWidget::Update);

--- a/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/MemoryWidget.cpp
@@ -48,10 +48,10 @@ MemoryWidget::MemoryWidget(QWidget* parent) : QDockWidget(parent)
   setFloating(settings.value(QStringLiteral("memorywidget/floating")).toBool());
   m_splitter->restoreState(settings.value(QStringLiteral("codewidget/splitter")).toByteArray());
 
-  connect(&Settings::Instance(), &Settings::MemoryVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::MemoryVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled,
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this,
           [this](bool enabled) { setHidden(!enabled || !Settings::Instance().IsMemoryVisible()); });
 
   connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, &MemoryWidget::Update);

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -158,10 +158,10 @@ NetworkWidget::NetworkWidget(QWidget* parent) : QDockWidget(parent)
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &NetworkWidget::Update);
 
-  connect(&Settings::Instance(), &Settings::NetworkVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::NetworkVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled, [this](bool enabled) {
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this, [this](bool enabled) {
     setHidden(!enabled || !Settings::Instance().IsNetworkVisible());
   });
 }

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -41,10 +41,10 @@ RegisterWidget::RegisterWidget(QWidget* parent) : QDockWidget(parent)
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &RegisterWidget::Update);
 
-  connect(&Settings::Instance(), &Settings::RegistersVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::RegistersVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled, [this](bool enabled) {
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this, [this](bool enabled) {
     setHidden(!enabled || !Settings::Instance().IsRegistersVisible());
   });
 }

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -41,10 +41,10 @@ ThreadWidget::ThreadWidget(QWidget* parent) : QDockWidget(parent)
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &ThreadWidget::Update);
 
-  connect(&Settings::Instance(), &Settings::ThreadsVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::ThreadsVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled, [this](bool enabled) {
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this, [this](bool enabled) {
     setHidden(!enabled || !Settings::Instance().IsThreadsVisible());
   });
 }

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -44,7 +44,7 @@ WatchWidget::WatchWidget(QWidget* parent) : QDockWidget(parent)
 
   ConnectWidgets();
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged, [this](Core::State state) {
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this, [this](Core::State state) {
     UpdateButtonsEnabled();
     if (state != Core::State::Starting)
       Update();
@@ -52,10 +52,10 @@ WatchWidget::WatchWidget(QWidget* parent) : QDockWidget(parent)
 
   connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this, &WatchWidget::Update);
 
-  connect(&Settings::Instance(), &Settings::WatchVisibilityChanged,
+  connect(&Settings::Instance(), &Settings::WatchVisibilityChanged, this,
           [this](bool visible) { setHidden(!visible); });
 
-  connect(&Settings::Instance(), &Settings::DebugModeToggled,
+  connect(&Settings::Instance(), &Settings::DebugModeToggled, this,
           [this](bool enabled) { setHidden(!enabled || !Settings::Instance().IsWatchVisible()); });
 
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &WatchWidget::UpdateIcons);

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -45,7 +45,7 @@ FIFOAnalyzer::FIFOAnalyzer()
   m_detail_list->setFont(Settings::Instance().GetDebugFont());
   m_entry_detail_browser->setFont(Settings::Instance().GetDebugFont());
 
-  connect(&Settings::Instance(), &Settings::DebugFontChanged, [this] {
+  connect(&Settings::Instance(), &Settings::DebugFontChanged, this, [this] {
     m_detail_list->setFont(Settings::Instance().GetDebugFont());
     m_entry_detail_browser->setFont(Settings::Instance().GetDebugFont());
   });

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -37,7 +37,7 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
 
   connect(this, &QFileSystemWatcher::directoryChanged, this, &GameTracker::UpdateDirectory);
   connect(this, &QFileSystemWatcher::fileChanged, this, &GameTracker::UpdateFile);
-  connect(&Settings::Instance(), &Settings::AutoRefreshToggled, [] {
+  connect(&Settings::Instance(), &Settings::AutoRefreshToggled, this, [] {
     const auto paths = Settings::Instance().GetPaths();
 
     for (const auto& path : paths)
@@ -47,7 +47,7 @@ GameTracker::GameTracker(QObject* parent) : QFileSystemWatcher(parent)
     }
   });
 
-  connect(&Settings::Instance(), &Settings::MetadataRefreshRequested, [this] {
+  connect(&Settings::Instance(), &Settings::MetadataRefreshRequested, this, [this] {
     m_load_thread.EmplaceItem(Command{CommandType::UpdateMetadata, {}});
   });
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -229,7 +229,7 @@ void MenuBar::AddToolsMenu()
   m_show_cheat_manager =
       tools_menu->addAction(tr("&Cheats Manager"), this, [this] { emit ShowCheatsManager(); });
 
-  connect(&Settings::Instance(), &Settings::EnableCheatsChanged, [this](bool enabled) {
+  connect(&Settings::Instance(), &Settings::EnableCheatsChanged, this, [this](bool enabled) {
     m_show_cheat_manager->setEnabled(Core::GetState() != Core::State::Uninitialized && enabled);
   });
 
@@ -267,7 +267,7 @@ void MenuBar::AddToolsMenu()
 
   m_boot_sysmenu->setEnabled(false);
 
-  connect(&Settings::Instance(), &Settings::NANDRefresh, [this] { UpdateToolsMenu(false); });
+  connect(&Settings::Instance(), &Settings::NANDRefresh, this, [this] { UpdateToolsMenu(false); });
 
   m_perform_online_update_menu = tools_menu->addMenu(tr("Perform Online System Update"));
   m_perform_online_update_for_current_region = m_perform_online_update_menu->addAction(

--- a/Source/Core/DolphinQt/Settings/PathPane.cpp
+++ b/Source/Core/DolphinQt/Settings/PathPane.cpp
@@ -127,9 +127,9 @@ QGroupBox* PathPane::MakeGameFolderBox()
   m_path_list = new QListWidget;
   m_path_list->insertItems(0, Settings::Instance().GetPaths());
   m_path_list->setSpacing(1);
-  connect(&Settings::Instance(), &Settings::PathAdded,
+  connect(&Settings::Instance(), &Settings::PathAdded, this,
           [this](const QString& dir) { m_path_list->addItem(dir); });
-  connect(&Settings::Instance(), &Settings::PathRemoved, [this](const QString& dir) {
+  connect(&Settings::Instance(), &Settings::PathRemoved, this, [this](const QString& dir) {
     auto items = m_path_list->findItems(dir, Qt::MatchExactly);
     for (auto& item : items)
       delete item;
@@ -182,7 +182,7 @@ QGridLayout* PathPane::MakePathsLayout()
   m_game_edit = new QLineEdit(Settings::Instance().GetDefaultGame());
   connect(m_game_edit, &QLineEdit::editingFinished,
           [this] { Settings::Instance().SetDefaultGame(m_game_edit->text()); });
-  connect(&Settings::Instance(), &Settings::DefaultGameChanged,
+  connect(&Settings::Instance(), &Settings::DefaultGameChanged, this,
           [this](const QString& path) { m_game_edit->setText(path); });
   QPushButton* game_open = new QPushButton(QStringLiteral("..."));
   connect(game_open, &QPushButton::clicked, this, &PathPane::BrowseDefaultGame);

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -96,7 +96,7 @@ void WiiPane::ConnectLayout()
   connect(m_wiimote_motor, &QCheckBox::toggled, this, &WiiPane::OnSaveConfig);
 
   // Emulation State
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged,
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           [=](Core::State state) { OnEmulationStateChanged(state != Core::State::Uninitialized); });
 }
 

--- a/Source/Core/DolphinQt/ToolBar.cpp
+++ b/Source/Core/DolphinQt/ToolBar.cpp
@@ -32,10 +32,10 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::ThemeChanged, this, &ToolBar::UpdateIcons);
   UpdateIcons();
 
-  connect(&Settings::Instance(), &Settings::EmulationStateChanged,
+  connect(&Settings::Instance(), &Settings::EmulationStateChanged, this,
           [this](Core::State state) { OnEmulationStateChanged(state); });
 
-  connect(Host::GetInstance(), &Host::UpdateDisasmDialog,
+  connect(Host::GetInstance(), &Host::UpdateDisasmDialog, this,
           [this] { OnEmulationStateChanged(Core::GetState()); });
 
   connect(&Settings::Instance(), &Settings::DebugModeToggled, this, &ToolBar::OnDebugModeToggled);
@@ -43,10 +43,10 @@ ToolBar::ToolBar(QWidget* parent) : QToolBar(parent)
   connect(&Settings::Instance(), &Settings::ToolBarVisibilityChanged, this, &ToolBar::setVisible);
   connect(this, &ToolBar::visibilityChanged, &Settings::Instance(), &Settings::SetToolBarVisible);
 
-  connect(&Settings::Instance(), &Settings::WidgetLockChanged,
+  connect(&Settings::Instance(), &Settings::WidgetLockChanged, this,
           [this](bool locked) { setMovable(!locked); });
 
-  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted,
+  connect(&Settings::Instance(), &Settings::GameListRefreshCompleted, this,
           [this] { m_refresh_action->setEnabled(true); });
 
   OnEmulationStateChanged(Core::GetState());


### PR DESCRIPTION
When destroying a Dolphin "graphics" control, we were still connected to the settings ConfigChange event.  That was causing a segfault.

This is not required by any current Dolphin code but is used in #8823