### PR TITLE
Android: Wait for initialization before launching EmulationActivity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -45,6 +45,7 @@ import org.dolphinemu.dolphinemu.services.GameFileCacheService;
 import org.dolphinemu.dolphinemu.ui.main.MainActivity;
 import org.dolphinemu.dolphinemu.ui.main.TvMainActivity;
 import org.dolphinemu.dolphinemu.ui.platform.Platform;
+import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 import org.dolphinemu.dolphinemu.utils.ControllerMappingHelper;
 import org.dolphinemu.dolphinemu.utils.FileBrowserHelper;
 import org.dolphinemu.dolphinemu.utils.IniFile;
@@ -188,7 +189,9 @@ public final class EmulationActivity extends AppCompatActivity
     launcher.putExtra(EXTRA_SELECTED_TITLE, gameFile.getTitle());
     launcher.putExtra(EXTRA_SELECTED_GAMEID, gameFile.getGameId());
     launcher.putExtra(EXTRA_PLATFORM, gameFile.getPlatform());
-    activity.startActivity(launcher);
+
+    new AfterDirectoryInitializationRunner().run(activity, true,
+            () -> activity.startActivity(launcher));
   }
 
   public static void launchFile(FragmentActivity activity, String[] filePaths)
@@ -225,7 +228,8 @@ public final class EmulationActivity extends AppCompatActivity
       launcher.putExtra(EXTRA_PLATFORM, Platform.GAMECUBE);
     }
 
-    activity.startActivity(launcher);
+    new AfterDirectoryInitializationRunner().run(activity, true,
+            () -> activity.startActivity(launcher));
   }
 
   public static void stopIgnoringLaunchRequests()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -19,7 +19,6 @@ import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 import org.dolphinemu.dolphinemu.overlay.InputOverlay;
-import org.dolphinemu.dolphinemu.utils.AfterDirectoryInitializationRunner;
 import org.dolphinemu.dolphinemu.utils.Log;
 
 import java.io.File;
@@ -33,8 +32,6 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   private InputOverlay mInputOverlay;
 
   private EmulationState mEmulationState;
-
-  private AfterDirectoryInitializationRunner mAfterDirectoryInitializationRunner;
 
   private EmulationActivity activity;
 
@@ -109,21 +106,12 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   public void onResume()
   {
     super.onResume();
-
-    mAfterDirectoryInitializationRunner = new AfterDirectoryInitializationRunner();
-    mAfterDirectoryInitializationRunner.run(requireContext(), true,
-            () -> mEmulationState.run(activity.isActivityRecreated()));
+    mEmulationState.run(activity.isActivityRecreated());
   }
 
   @Override
   public void onPause()
   {
-    if (mAfterDirectoryInitializationRunner != null)
-    {
-      mAfterDirectoryInitializationRunner.cancel();
-      mAfterDirectoryInitializationRunner = null;
-    }
-
     if (mEmulationState.isRunning())
       mEmulationState.pause();
     super.onPause();


### PR DESCRIPTION
...instead of waiting for it after launching EmulationActivity. We need this because there is code that runs very early in EmulationActivity that accesses the settings.