### PR TITLE
Qt: Use better method of getting default monospace font

### DIFF
--- a/Source/Core/DolphinQt/Config/LogWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LogWidget.cpp
@@ -119,8 +119,7 @@ void LogWidget::UpdateFont()
   case 0:  // Default font
     break;
   case 1:  // Monospace font
-    f = QFont(QStringLiteral("Monospace"));
-    f.setStyleHint(QFont::TypeWriter);
+    f = QFont(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());
     break;
   case 2:  // Debugger font
     f = Settings::Instance().GetDebugFont();

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -8,6 +8,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QFontDatabase>
 #include <QSize>
 
 #include "AudioCommon/AudioCommon.h"
@@ -489,8 +490,7 @@ void Settings::SetDebugFont(QFont font)
 
 QFont Settings::GetDebugFont() const
 {
-  QFont default_font = QFont(QStringLiteral("Monospace"));
-  default_font.setStyleHint(QFont::TypeWriter);
+  QFont default_font = QFont(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());
 
   return GetQSettings().value(QStringLiteral("debugger/font"), default_font).value<QFont>();
 }


### PR DESCRIPTION
This should give us a nicer font on Windows, while also not severely impacting the existing behavior on Linux.

At least on my Linux system, it actually results in using the monospace font I have configured (which is "Hack").

Before ("Monospace")
![](https://qimg.techjargaming.com/i/J1Z3oxkJ.png)

After ("Hack")
![](https://qimg.techjargaming.com/i/ig2Qrd1n.png)