### PR TITLE
Core: Run Wiimote::Initialize before HW::Init to avoid crash

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -436,54 +436,6 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   DeclareAsCPUThread();
   s_frame_step = false;
 
-  Movie::Init(*boot);
-  Common::ScopeGuard movie_guard{&Movie::Shutdown};
-
-  HW::Init();
-
-  Common::ScopeGuard hw_guard{[] {
-    // We must set up this flag before executing HW::Shutdown()
-    s_hardware_initialized = false;
-    INFO_LOG(CONSOLE, "%s", StopMessage(false, "Shutting down HW").c_str());
-    HW::Shutdown();
-    INFO_LOG(CONSOLE, "%s", StopMessage(false, "HW shutdown").c_str());
-
-    // Clear on screen messages that haven't expired
-    OSD::ClearMessages();
-
-    // The config must be restored only after the whole HW has shut down,
-    // not when it is still running.
-    BootManager::RestoreConfig();
-
-    PatchEngine::Shutdown();
-    HLE::Clear();
-  }};
-
-  VideoBackendBase::PopulateBackendInfo();
-
-  if (!g_video_backend->Initialize(wsi))
-  {
-    PanicAlert("Failed to initialize video backend!");
-    return;
-  }
-  Common::ScopeGuard video_guard{[] { g_video_backend->Shutdown(); }};
-
-  // Render a single frame without anything on it to clear the screen.
-  // This avoids the game list being displayed while the core is finishing initializing.
-  g_renderer->BeginUIFrame();
-  g_renderer->EndUIFrame();
-
-  if (cpu_info.HTT)
-    SConfig::GetInstance().bDSPThread = cpu_info.num_cores > 4;
-  else
-    SConfig::GetInstance().bDSPThread = cpu_info.num_cores > 2;
-
-  if (!DSP::GetDSPEmulator()->Initialize(core_parameter.bWii, core_parameter.bDSPThread))
-  {
-    PanicAlert("Failed to initialize DSP emulation!");
-    return;
-  }
-
   // The frontend will likely have initialized the controller interface, as it needs
   // it to provide the configuration dialogs. In this case, instead of re-initializing
   // entirely, we switch the window used for inputs to the render window. This way, the
@@ -541,6 +493,54 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
     Pad::Shutdown();
     g_controller_interface.Shutdown();
   }};
+
+  Movie::Init(*boot);
+  Common::ScopeGuard movie_guard{&Movie::Shutdown};
+
+  HW::Init();
+
+  Common::ScopeGuard hw_guard{[] {
+    // We must set up this flag before executing HW::Shutdown()
+    s_hardware_initialized = false;
+    INFO_LOG(CONSOLE, "%s", StopMessage(false, "Shutting down HW").c_str());
+    HW::Shutdown();
+    INFO_LOG(CONSOLE, "%s", StopMessage(false, "HW shutdown").c_str());
+
+    // Clear on screen messages that haven't expired
+    OSD::ClearMessages();
+
+    // The config must be restored only after the whole HW has shut down,
+    // not when it is still running.
+    BootManager::RestoreConfig();
+
+    PatchEngine::Shutdown();
+    HLE::Clear();
+  }};
+
+  VideoBackendBase::PopulateBackendInfo();
+
+  if (!g_video_backend->Initialize(wsi))
+  {
+    PanicAlert("Failed to initialize video backend!");
+    return;
+  }
+  Common::ScopeGuard video_guard{[] { g_video_backend->Shutdown(); }};
+
+  // Render a single frame without anything on it to clear the screen.
+  // This avoids the game list being displayed while the core is finishing initializing.
+  g_renderer->BeginUIFrame();
+  g_renderer->EndUIFrame();
+
+  if (cpu_info.HTT)
+    SConfig::GetInstance().bDSPThread = cpu_info.num_cores > 4;
+  else
+    SConfig::GetInstance().bDSPThread = cpu_info.num_cores > 2;
+
+  if (!DSP::GetDSPEmulator()->Initialize(core_parameter.bWii, core_parameter.bDSPThread))
+  {
+    PanicAlert("Failed to initialize DSP emulation!");
+    return;
+  }
 
   AudioCommon::InitSoundStream();
   Common::ScopeGuard audio_guard{&AudioCommon::ShutdownSoundStream};


### PR DESCRIPTION
Fixes a crash on Android (probably nogui too?) caused by PR #8985:

```
std::__ndk1::__throw_out_of_range(char const*) stdexcept:265
std::__ndk1::__vector_base_common<true>::__throw_out_of_range() const vector:319
InputConfig::GetController(int) InputConfig.cpp:160
WiimoteCommon::GetHIDWiimoteSource(unsigned int) Wiimote.cpp:71
IOS::HLE::WiimoteDevice::WiimoteDevice(IOS::HLE::Device::BluetoothEmu*, int, std::__ndk1::array<unsigned char, 6ul>) WiimoteDevice.cpp:71
IOS::HLE::Device::BluetoothEmu::BluetoothEmu(IOS::HLE::Kernel&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&) BTEmu.cpp:64
IOS::HLE::Kernel::AddStaticDevices() IOS.cpp:435
IOS::HLE::Init() IOS.cpp:837
Core::EmuThread(std::__ndk1::unique_ptr<BootParameters, std::__ndk1::default_delete<BootParameters> >, WindowSystemInfo) Core.cpp:442
```