### PR TITLE
Android: Move orientation setting to main settings screen

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.ActivityInfo;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -98,9 +97,8 @@ public final class EmulationActivity extends AppCompatActivity
           MENU_ACTION_LOAD_SLOT3, MENU_ACTION_LOAD_SLOT4, MENU_ACTION_LOAD_SLOT5,
           MENU_ACTION_LOAD_SLOT6, MENU_ACTION_EXIT, MENU_ACTION_CHANGE_DISC,
           MENU_ACTION_RESET_OVERLAY, MENU_SET_IR_SENSITIVITY, MENU_ACTION_CHOOSE_DOUBLETAP,
-          MENU_ACTION_SCREEN_ORIENTATION, MENU_ACTION_MOTION_CONTROLS, MENU_ACTION_PAUSE_EMULATION,
-          MENU_ACTION_UNPAUSE_EMULATION, MENU_ACTION_OVERLAY_CONTROLS, MENU_ACTION_SETTINGS_CORE,
-          MENU_ACTION_SETTINGS_GRAPHICS})
+          MENU_ACTION_MOTION_CONTROLS, MENU_ACTION_PAUSE_EMULATION, MENU_ACTION_UNPAUSE_EMULATION,
+          MENU_ACTION_OVERLAY_CONTROLS, MENU_ACTION_SETTINGS_CORE, MENU_ACTION_SETTINGS_GRAPHICS})
   public @interface MenuAction
   {
   }
@@ -134,13 +132,12 @@ public final class EmulationActivity extends AppCompatActivity
   public static final int MENU_ACTION_RESET_OVERLAY = 26;
   public static final int MENU_SET_IR_SENSITIVITY = 27;
   public static final int MENU_ACTION_CHOOSE_DOUBLETAP = 28;
-  public static final int MENU_ACTION_SCREEN_ORIENTATION = 29;
-  public static final int MENU_ACTION_MOTION_CONTROLS = 30;
-  public static final int MENU_ACTION_PAUSE_EMULATION = 31;
-  public static final int MENU_ACTION_UNPAUSE_EMULATION = 32;
-  public static final int MENU_ACTION_OVERLAY_CONTROLS = 33;
-  public static final int MENU_ACTION_SETTINGS_CORE = 34;
-  public static final int MENU_ACTION_SETTINGS_GRAPHICS = 35;
+  public static final int MENU_ACTION_MOTION_CONTROLS = 29;
+  public static final int MENU_ACTION_PAUSE_EMULATION = 30;
+  public static final int MENU_ACTION_UNPAUSE_EMULATION = 31;
+  public static final int MENU_ACTION_OVERLAY_CONTROLS = 32;
+  public static final int MENU_ACTION_SETTINGS_CORE = 33;
+  public static final int MENU_ACTION_SETTINGS_GRAPHICS = 34;
 
   private static final SparseIntArray buttonsActionsMap = new SparseIntArray();
 
@@ -290,6 +287,8 @@ public final class EmulationActivity extends AppCompatActivity
   {
     super.onResume();
 
+    updateOrientation();
+
     if (NativeLibrary.IsGameMetadataValid())
       updateMotionListener();
   }
@@ -389,8 +388,7 @@ public final class EmulationActivity extends AppCompatActivity
 
   private void updateOrientation()
   {
-    setRequestedOrientation(mPreferences.getInt("emulationActivityOrientation",
-            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE));
+    setRequestedOrientation(IntSetting.MAIN_EMULATION_ORIENTATION.getInt(mSettings));
   }
 
   private boolean closeSubmenu()
@@ -607,10 +605,6 @@ public final class EmulationActivity extends AppCompatActivity
 
       case MENU_ACTION_CHOOSE_DOUBLETAP:
         chooseDoubleTapButton();
-        break;
-
-      case MENU_ACTION_SCREEN_ORIENTATION:
-        chooseOrientation();
         break;
 
       case MENU_ACTION_MOTION_CONTROLS:
@@ -885,36 +879,6 @@ public final class EmulationActivity extends AppCompatActivity
               NativeLibrary.ReloadWiimoteConfig();
             });
     builder.setPositiveButton(R.string.ok, (dialogInterface, i) -> dialogInterface.dismiss());
-
-    builder.show();
-  }
-
-  private void chooseOrientation()
-  {
-    final int[] orientationValues = getResources().getIntArray(R.array.orientationValues);
-    int initialChoice = mPreferences.getInt("emulationActivityOrientation",
-            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-    int initialIndex = -1;
-    for (int i = 0; i < orientationValues.length; i++)
-    {
-      if (orientationValues[i] == initialChoice)
-        initialIndex = i;
-    }
-
-    final SharedPreferences.Editor editor = mPreferences.edit();
-    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
-    builder.setTitle(R.string.emulation_screen_orientation);
-    builder.setSingleChoiceItems(R.array.orientationEntries, initialIndex,
-            (dialog, indexSelected) ->
-            {
-              int orientation = orientationValues[indexSelected];
-              editor.putInt("emulationActivityOrientation", orientation);
-            });
-    builder.setPositiveButton(R.string.ok, (dialogInterface, i) ->
-    {
-      editor.apply();
-      updateOrientation();
-    });
 
     builder.show();
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -1,5 +1,7 @@
 package org.dolphinemu.dolphinemu.features.settings.model;
 
+import android.content.pm.ActivityInfo;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.overlay.InputOverlayPointer;
 
@@ -20,6 +22,8 @@ public enum IntSetting implements AbstractIntSetting
   MAIN_AUDIO_VOLUME(Settings.FILE_DOLPHIN, Settings.SECTION_INI_DSP, "Volume", 100),
 
   MAIN_CONTROL_SCALE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "ControlScale", 50),
+  MAIN_EMULATION_ORIENTATION(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
+          "EmulationOrientation", ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE),
   MAIN_LAST_PLATFORM_TAB(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "LastPlatformTab", 0),
   MAIN_MOTION_CONTROLS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "MotionControls", 1),
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -1,8 +1,10 @@
 package org.dolphinemu.dolphinemu.features.settings.ui;
 
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.text.TextUtils;
 
+import org.dolphinemu.dolphinemu.DolphinApplication;
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.features.settings.model.AbstractIntSetting;
@@ -242,6 +244,17 @@ public final class SettingsFragmentPresenter
 
   private void addInterfaceSettings(ArrayList<SettingsItem> sl)
   {
+    // Hide the orientation setting if the device only supports one orientation. Old devices which
+    // support both portrait and landscape may report support for neither, so we use ==, not &&.
+    PackageManager packageManager = DolphinApplication.getAppContext().getPackageManager();
+    if (packageManager.hasSystemFeature(PackageManager.FEATURE_SCREEN_PORTRAIT) ==
+            packageManager.hasSystemFeature(PackageManager.FEATURE_SCREEN_LANDSCAPE))
+    {
+      sl.add(new SingleChoiceSetting(IntSetting.MAIN_EMULATION_ORIENTATION,
+              R.string.emulation_screen_orientation, 0, R.array.orientationEntries,
+              R.array.orientationValues));
+    }
+
     sl.add(new CheckBoxSetting(BooleanSetting.MAIN_USE_PANIC_HANDLERS, R.string.panic_handlers,
             R.string.panic_handlers_description));
     sl.add(new CheckBoxSetting(BooleanSetting.MAIN_OSD_MESSAGES, R.string.osd_messages,

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -46,8 +46,6 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
             .append(R.id.menu_overlay_controls, EmulationActivity.MENU_ACTION_OVERLAY_CONTROLS);
     buttonsActionsMap
             .append(R.id.menu_refresh_wiimotes, EmulationActivity.MENU_ACTION_REFRESH_WIIMOTES);
-    buttonsActionsMap
-            .append(R.id.menu_screen_orientation, EmulationActivity.MENU_ACTION_SCREEN_ORIENTATION);
     buttonsActionsMap.append(R.id.menu_change_disc, EmulationActivity.MENU_ACTION_CHANGE_DISC);
     buttonsActionsMap.append(R.id.menu_exit, EmulationActivity.MENU_ACTION_EXIT);
     buttonsActionsMap.append(R.id.menu_settings_core, EmulationActivity.MENU_ACTION_SETTINGS_CORE);
@@ -90,9 +88,7 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 
     updatePauseUnpauseVisibility();
 
-    PackageManager packageManager = requireActivity().getPackageManager();
-
-    if (!packageManager.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN))
+    if (!requireActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN))
     {
       options.findViewById(R.id.menu_overlay_controls).setVisibility(View.GONE);
     }
@@ -100,14 +96,6 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
     if (!getArguments().getBoolean(KEY_WII, true))
     {
       options.findViewById(R.id.menu_refresh_wiimotes).setVisibility(View.GONE);
-    }
-
-    // Old devices which support both portrait and landscape may report support for neither,
-    // so we only hide the orientation button if the device only supports one orientation
-    if (packageManager.hasSystemFeature(PackageManager.FEATURE_SCREEN_PORTRAIT) !=
-            packageManager.hasSystemFeature(PackageManager.FEATURE_SCREEN_LANDSCAPE))
-    {
-      options.findViewById(R.id.menu_screen_orientation).setVisibility(View.GONE);
     }
 
     int bottomPaddingRequired = getBottomPaddingRequired();

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -92,11 +92,6 @@
                 style="@style/InGameMenuOption"/>
 
             <Button
-                android:id="@+id/menu_screen_orientation"
-                android:text="@string/emulation_screen_orientation"
-                style="@style/InGameMenuOption"/>
-
-            <Button
                 android:id="@+id/menu_change_disc"
                 android:text="@string/emulation_change_disc"
                 style="@style/InGameMenuOption"/>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -161,6 +161,7 @@
 
     <!-- Interface Preference Fragment -->
     <string name="interface_submenu">Interface</string>
+    <string name="emulation_screen_orientation">Screen Orientation During Emulation</string>
     <string name="panic_handlers">Use Panic Handlers</string>
     <string name="panic_handlers_description">Show a message box when a potentially serious error has occurred. Disabling this may avoid annoying and non-fatal messages, but it may result in major crashes having no explanation at all.</string>
     <string name="osd_messages">Show On-Screen Display Messages</string>
@@ -399,7 +400,6 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_ir_group">Touch IR Pointer</string>
     <string name="emulation_ir_sensitivity">IR Sensitivity</string>
     <string name="emulation_choose_doubletap">Double tap button</string>
-    <string name="emulation_screen_orientation">Screen Orientation</string>
     <string name="emulation_motion_controls">Motion Controls</string>
 
     <!-- GC Adapter Menu-->

--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -17,9 +17,4 @@ const Info<bool> MAIN_USE_GAME_COVERS{{System::Main, "General", "UseGameCovers"}
 const Info<bool> MAIN_FOCUSED_HOTKEYS{{System::Main, "General", "HotkeysRequireFocus"}, true};
 const Info<bool> MAIN_RECURSIVE_ISO_PATHS{{System::Main, "General", "RecursiveISOPaths"}, false};
 
-// UI.Android
-
-const Info<int> MAIN_LAST_PLATFORM_TAB{{System::Main, "Android", "LastPlatformTab"}, 0};
-const Info<int> MAIN_EMULATION_ORIENTATION{{System::Main, "Android", "EmulationOrientation"}, 0};
-
 }  // namespace Config

--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -20,5 +20,6 @@ const Info<bool> MAIN_RECURSIVE_ISO_PATHS{{System::Main, "General", "RecursiveIS
 // UI.Android
 
 const Info<int> MAIN_LAST_PLATFORM_TAB{{System::Main, "Android", "LastPlatformTab"}, 0};
+const Info<int> MAIN_EMULATION_ORIENTATION{{System::Main, "Android", "EmulationOrientation"}, 0};
 
 }  // namespace Config

--- a/Source/Core/Core/Config/UISettings.h
+++ b/Source/Core/Core/Config/UISettings.h
@@ -21,9 +21,4 @@ extern const Info<bool> MAIN_USE_GAME_COVERS;
 extern const Info<bool> MAIN_FOCUSED_HOTKEYS;
 extern const Info<bool> MAIN_RECURSIVE_ISO_PATHS;
 
-// UI.Android
-
-extern const Info<int> MAIN_LAST_PLATFORM_TAB;
-extern const Info<int> MAIN_EMULATION_ORIENTATION;
-
 }  // namespace Config

--- a/Source/Core/Core/Config/UISettings.h
+++ b/Source/Core/Core/Config/UISettings.h
@@ -24,5 +24,6 @@ extern const Info<bool> MAIN_RECURSIVE_ISO_PATHS;
 // UI.Android
 
 extern const Info<int> MAIN_LAST_PLATFORM_TAB;
+extern const Info<int> MAIN_EMULATION_ORIENTATION;
 
 }  // namespace Config


### PR DESCRIPTION
I moved it from the main settings screen to the in-game menu in PR #8439 so that it could be changed while a game is running, but now that the main settings can be accessed while a game is running, there's no reason to not put it in the main settings.

https://bugs.dolphin-emu.org/issues/12067