### PR TITLE
Add nullptr check in VariableExpression parser

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -358,9 +358,9 @@ class VariableExpression : public Expression
 public:
   VariableExpression(std::string name) : m_name(name) {}
 
-  ControlState GetValue() const override { return *m_value_ptr; }
+  ControlState GetValue() const override { return (m_value_ptr != nullptr) ? *m_value_ptr : 0; }
 
-  void SetValue(ControlState value) override { *m_value_ptr = value; }
+  void SetValue(ControlState value) override { if (m_value_ptr != nullptr) *m_value_ptr = value; }
 
   int CountNumControls() const override { return 1; }
 


### PR DESCRIPTION
Added nullptr checks in `ExpressionParser::VariableExpression`, preventing access violations occurring when switching between input profiles such as the following:
> [Profile]
> Device = XInput/0/Gamepad
> IR/Up = $enable_point = toggle(\`Trigger R\`), \`Right Y+\` & $enable_point
> IR/Down = \`Right Y-\` & $enable_point
> IR/Left = \`Right X-\` & $enable_point
> IR/Right = \`Right X+\` & $enable_point
