### PR TITLE
Add INI note for Wii Fit and Wii Fit Plus

### DIFF
--- a/Data/Sys/GameSettings/RFN.ini
+++ b/Data/Sys/GameSettings/RFN.ini
@@ -1,0 +1,7 @@
+# RFNP01, RFNJ01, RFNW01, RFNE01, RFNK01 - Wii Fit and Wii Fit Channel
+
+[Video_Hacks]
+# The Wii Fit Channel shows Mii faces and a graph; however, EFBToTextureEnable must be disabled for this to work.
+# Since both the channel and the main game update these images, it must be disabled for both.  (They both have the same GameID, though.)
+# However, this has a performance impact, so if the Wii Fit Channel is not going to be used, this does not need to be disabled.
+#EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RFP.ini
+++ b/Data/Sys/GameSettings/RFP.ini
@@ -1,0 +1,7 @@
+# RFPE01, RFPJ01, RFPR01, RFPP01, RFPK01, RFPW01 - Wii Fit Plus and Wii Fit Plus Channel
+
+[Video_Hacks]
+# The Wii Fit Plus Channel shows Mii faces and a graph; however, EFBToTextureEnable must be disabled for this to work.
+# Since both the channel and the main game update these images, it must be disabled for both.  (They both have the same GameID, though.)
+# However, this has a performance impact, so if the Wii Fit Channel is not going to be used, this does not need to be disabled.
+#EFBToTextureEnable = False


### PR DESCRIPTION
Refer to [bug 11858](https://bugs.dolphin-emu.org/issues/11858) for details; `EFBToTextureEnable` needs to be disabled for the channels' banners to work right.