### PR TITLE
ControllerEmu: Improve and simplify UpdateCalibrationData.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -856,6 +856,7 @@ void CalibrationWidget::SetupActions()
 
 void CalibrationWidget::StartCalibration()
 {
+  m_prev_point = {};
   m_calibration_data.assign(m_input.CALIBRATION_SAMPLE_COUNT, 0.0);
 
   // Cancel calibration.
@@ -888,7 +889,9 @@ void CalibrationWidget::Update(Common::DVec2 point)
 
   if (IsCalibrating())
   {
-    m_input.UpdateCalibrationData(m_calibration_data, point - *m_new_center);
+    const auto new_point = point - *m_new_center;
+    m_input.UpdateCalibrationData(m_calibration_data, m_prev_point, new_point);
+    m_prev_point = new_point;
 
     if (IsCalibrationDataSensible(m_calibration_data))
     {

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -204,4 +204,5 @@ private:
   ControllerEmu::ReshapableInput::CalibrationData m_calibration_data;
   QTimer* m_informative_timer;
   std::optional<Common::DVec2> m_new_center;
+  Common::DVec2 m_prev_point;
 };

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -92,7 +92,8 @@ public:
   void SetCalibrationToDefault();
   void SetCalibrationFromGate(const StickGate& gate);
 
-  static void UpdateCalibrationData(CalibrationData& data, Common::DVec2 point);
+  static void UpdateCalibrationData(CalibrationData& data, Common::DVec2 point1,
+                                    Common::DVec2 point2);
   static ControlState GetCalibrationDataRadiusAtAngle(const CalibrationData& data, double angle);
 
   const CalibrationData& GetCalibrationData() const;


### PR DESCRIPTION
Previously, the closest (by angle) calibration point was set to the distance of the provided input.
This produced slightly wrong calibration that would even draw outside of indicator square.
Clamping was done which hid the problem.

Now calibration is calculated from intersection with a line segment of the last two input values.
This is cleaner and more accurate.
Also the calibration shape is no longer restricted to a convex polygon.