### PR TITLE
Core/BTEmu: Change a member variable to a local variable.

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -102,7 +102,6 @@ void BluetoothEmu::DoState(PointerWrap& p)
 
   p.Do(m_is_active);
   p.Do(m_controller_bd);
-  DoStateForMessage(m_ios, p, m_ctrl_setup);
   DoStateForMessage(m_ios, p, m_hci_endpoint);
   DoStateForMessage(m_ios, p, m_acl_endpoint);
   p.Do(m_last_ticks);
@@ -149,10 +148,8 @@ IPCCommandResult BluetoothEmu::IOCtlV(const IOCtlVRequest& request)
   {
   case USB::IOCTLV_USBV0_CTRLMSG:  // HCI command is received from the stack
   {
-    m_ctrl_setup = std::make_unique<USB::V0CtrlMessage>(m_ios, request);
     // Replies are generated inside
-    ExecuteHCICommandMessage(*m_ctrl_setup);
-    m_ctrl_setup.reset();
+    ExecuteHCICommandMessage(USB::V0CtrlMessage(m_ios, request));
     send_reply = false;
     break;
   }

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -70,7 +70,6 @@ private:
   // this is used to trigger connecting via ACL
   u8 m_scan_enable = 0;
 
-  std::unique_ptr<USB::V0CtrlMessage> m_ctrl_setup;
   std::unique_ptr<USB::V0IntrMessage> m_hci_endpoint;
   std::unique_ptr<USB::V0BulkMessage> m_acl_endpoint;
   std::deque<SQueuedEvent> m_event_queue;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -74,7 +74,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-constexpr u32 STATE_VERSION = 123;  // Last changed in PR 8985
+constexpr u32 STATE_VERSION = 124;  // Last changed in PR 9097
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
The member `m_ctrl_setup` here never has a value outside of one function.
It has no business as a member variable or being saved to state.