### PR TITLE
WiimoteReal: Only duplicate data reports when speaker data is enabled.

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -116,7 +116,7 @@ private:
   virtual bool ConnectInternal() = 0;
   virtual void DisconnectInternal() = 0;
 
-  Report& ProcessReadQueue();
+  Report& ProcessReadQueue(bool repeat_last_data_report);
   void ClearReadQueue();
   void WriteReport(Report rpt);
 


### PR DESCRIPTION
Currently, data reports of real remotes are repeated to trigger sending of speaker data.

This causes some games to fail at detecting motion gestures.
https://bugs.dolphin-emu.org/issues/10111
https://bugs.dolphin-emu.org/issues/12030

With this change if speaker data is disabled so is repeating of data reports.
This fixes gestures in these games so long as speaker data is disabled.

Another potential fix might be to interpolate accelerometer data in repeated reports but that is getting pretty hacky.
I think this is cleaner.