### PR TITLE
IP/Top: Add SO_LINGER optname

### DIFF
--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -143,6 +143,8 @@ static s32 MapWiiSockOptNameToNative(u32 optname)
   {
   case 0x4:
     return SO_REUSEADDR;
+  case 0x80:
+    return SO_LINGER;
   case 0x1001:
     return SO_SNDBUF;
   case 0x1002:


### PR DESCRIPTION
This PRs adds the SO_LINGER optname and silents the following message `SO_SETSOCKOPT: unknown optname 128`.

Ready to be reviewed & merged.