### PR TITLE
Fix EFB access

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManager.h
+++ b/Source/Core/VideoCommon/FramebufferManager.h
@@ -74,8 +74,7 @@ public:
 
   // Resolve color/depth textures to a non-msaa texture, and return it.
   AbstractTexture* ResolveEFBColorTexture(const MathUtil::Rectangle<int>& region);
-  AbstractTexture* ResolveEFBDepthTexture(const MathUtil::Rectangle<int>& region,
-                                          bool force_r32f = false);
+  AbstractTexture* ResolveEFBDepthTexture(const MathUtil::Rectangle<int>& region);
 
   // Reinterpret pixel format of EFB color texture.
   // Assumes no render pass is currently in progress.


### PR DESCRIPTION
This reverts the readback changes of https://github.com/dolphin-emu/dolphin/pull/8827.
This fixes https://bugs.dolphin-emu.org/issues/12265 and unfixes https://bugs.dolphin-emu.org/issues/12040
I think fixing the first issue is more important as multisampling is used a lot. I think save states on broken Adreno drivers are less of a priority.  