### PR TITLE
Add caching to Config::Info

### DIFF
--- a/Source/Android/jni/NativeConfig.cpp
+++ b/Source/Android/jni/NativeConfig.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/Assert.h"
 #include "Common/Config/Config.h"
+#include "Common/Config/Location.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/ConfigLoaders/IsSettingSaveable.h"
 #include "jni/AndroidCommon/AndroidCommon.h"

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -18,13 +18,16 @@ add_library(common
   CommonFuncs.h
   CommonPaths.h
   CommonTypes.h
+  Config/ActiveInfos.cpp
+  Config/ActiveInfos.h
   Config/Config.cpp
   Config/Config.h
-  Config/ConfigInfo.cpp
   Config/ConfigInfo.h
   Config/Enums.h
   Config/Layer.cpp
   Config/Layer.h
+  Config/Location.cpp
+  Config/Location.h
   CPUDetect.h
   Crypto/AES.cpp
   Crypto/AES.h

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -41,10 +41,12 @@
     <ClInclude Include="CommonPaths.h" />
     <ClInclude Include="CommonTypes.h" />
     <ClInclude Include="Inline.h" />
+    <ClInclude Include="Config\ActiveInfos.h" />
     <ClInclude Include="Config\Config.h" />
     <ClInclude Include="Config\ConfigInfo.h" />
     <ClInclude Include="Config\Enums.h" />
     <ClInclude Include="Config\Layer.h" />
+    <ClInclude Include="Config\Location.h" />
     <ClInclude Include="CPUDetect.h" />
     <ClInclude Include="DebugInterface.h" />
     <ClInclude Include="Debug\MemoryPatches.h" />
@@ -187,9 +189,10 @@
     <ClCompile Include="ColorUtil.cpp" />
     <ClCompile Include="CommonFuncs.cpp" />
     <ClCompile Include="CompatPatches.cpp" />
+    <ClCompile Include="Config\ActiveInfos.cpp" />
     <ClCompile Include="Config\Config.cpp" />
-    <ClCompile Include="Config\ConfigInfo.cpp" />
     <ClCompile Include="Config\Layer.cpp" />
+    <ClCompile Include="Config\Location.cpp" />
     <ClCompile Include="Debug\MemoryPatches.cpp" />
     <ClCompile Include="Debug\OSThread.cpp" />
     <ClCompile Include="Debug\Watches.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -37,9 +37,12 @@
     <ClInclude Include="CommonFuncs.h" />
     <ClInclude Include="CommonPaths.h" />
     <ClInclude Include="CommonTypes.h" />
+    <ClInclude Include="Config\ActiveInfos.h" />
     <ClInclude Include="Config\Config.h" />
+    <ClInclude Include="Config\ConfigInfo.h" />
     <ClInclude Include="Config\Enums.h" />
     <ClInclude Include="Config\Layer.h" />
+    <ClInclude Include="Config\Location.h" />
     <ClInclude Include="CPUDetect.h" />
     <ClInclude Include="DebugInterface.h" />
     <ClInclude Include="ENetUtil.h" />
@@ -266,7 +269,6 @@
     <ClInclude Include="GL\GLExtensions\ARB_texture_compression_bptc.h">
       <Filter>GL\GLExtensions</Filter>
     </ClInclude>
-    <ClInclude Include="Config\ConfigInfo.h" />
     <ClInclude Include="Debug\Watches.h">
       <Filter>Debug</Filter>
     </ClInclude>
@@ -292,8 +294,10 @@
     <ClCompile Include="CDUtils.cpp" />
     <ClCompile Include="ColorUtil.cpp" />
     <ClCompile Include="CommonFuncs.cpp" />
+    <ClCompile Include="Config\ActiveInfos.cpp" />
     <ClCompile Include="Config\Config.cpp" />
     <ClCompile Include="Config\Layer.cpp" />
+    <ClCompile Include="Config\Location.cpp" />
     <ClCompile Include="ENetUtil.cpp" />
     <ClCompile Include="FileSearch.cpp" />
     <ClCompile Include="FileUtil.cpp" />
@@ -357,7 +361,6 @@
     <ClCompile Include="File.cpp" />
     <ClCompile Include="LdrWatcher.cpp" />
     <ClCompile Include="CompatPatches.cpp" />
-    <ClCompile Include="Config\ConfigInfo.cpp" />
     <ClCompile Include="Debug\Watches.cpp">
       <Filter>Debug</Filter>
     </ClCompile>

--- a/Source/Core/Common/Config/ActiveInfos.cpp
+++ b/Source/Core/Common/Config/ActiveInfos.cpp
@@ -1,0 +1,25 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Common/Config/ActiveInfos.h"
+
+#include <memory>
+#include <vector>
+
+namespace Config
+{
+std::unique_ptr<std::vector<void (*)()>> ActiveInfosBase::s_invalidate_cache_functions{};
+
+bool ActiveInfosBase::s_program_is_exiting = false;
+
+void ActiveInfosBase::InvalidateCache()
+{
+  if (s_invalidate_cache_functions)
+  {
+    for (auto f : *s_invalidate_cache_functions)
+      f();
+  }
+}
+
+}  // namespace Config

--- a/Source/Core/Common/Config/ActiveInfos.h
+++ b/Source/Core/Common/Config/ActiveInfos.h
@@ -1,0 +1,88 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <unordered_set>
+#include <vector>
+
+#include "Common/Config/Config.h"
+#include "Common/Config/Layer.h"
+#include "Common/Config/Location.h"
+
+namespace Config
+{
+template <typename T>
+class Info;
+
+class ActiveInfosBase
+{
+public:
+  static void InvalidateCache();
+
+protected:
+  // unique_ptr is used to avoid problems with initialization order.
+  // We should be able to stop using unique_ptr once we are using C++20 everywhere,
+  // since C++20 makes std::vector's default constructor constexpr.
+  static std::unique_ptr<std::vector<void (*)()>> s_invalidate_cache_functions;
+
+  static bool s_program_is_exiting;
+};
+
+template <typename T>
+class ActiveInfos : public ActiveInfosBase
+{
+public:
+  static void Add(Info<T>* info)
+  {
+    if (!s_active_infos)
+    {
+      if (!s_invalidate_cache_functions)
+        s_invalidate_cache_functions = std::make_unique<std::vector<void (*)()>>();
+      s_invalidate_cache_functions->push_back(&InvalidateCache);
+
+      s_active_infos = std::make_unique<InfoSet>();
+    }
+    s_active_infos->set.insert(info);
+  }
+
+  static void Remove(Info<T>* info)
+  {
+    if (!s_program_is_exiting)
+      s_active_infos->set.erase(info);
+  }
+
+  static void InvalidateCache()
+  {
+    for (Info<T>* info : s_active_infos->set)
+      Update(info);
+  }
+
+  static void Update(Info<T>* info)
+  {
+    info->m_cached_value = Get(info->GetLocation()).value_or(info->GetDefaultValue());
+  }
+
+private:
+  static std::optional<T> Get(const Location& location)
+  {
+    const std::shared_ptr<Layer> layer = GetLayer(GetActiveLayerForConfig(location));
+    return layer ? layer->Get<T>(location) : std::nullopt;
+  }
+
+  struct InfoSet
+  {
+    // This destructor exists to avoid a crash when the program exits.
+    ~InfoSet() { s_program_is_exiting = true; }
+
+    std::unordered_set<Info<T>*> set;
+  };
+
+  // unique_ptr is used to avoid problems with initialization order.
+  static inline std::unique_ptr<InfoSet> s_active_infos;
+};
+
+}  // namespace Config

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Config/Config.h"
+
 #include <algorithm>
 #include <list>
 #include <map>
 #include <shared_mutex>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ActiveInfos.h"
 
 namespace Config
 {
@@ -70,6 +72,8 @@ void InvokeConfigChangedCallbacks()
 {
   if (s_callback_guards)
     return;
+
+  ActiveInfosBase::InvalidateCache();
 
   for (const auto& callback : s_callbacks)
     callback();

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -10,12 +10,15 @@
 #include <optional>
 #include <string>
 
-#include "Common/Config/ConfigInfo.h"
 #include "Common/Config/Enums.h"
 #include "Common/Config/Layer.h"
+#include "Common/Config/Location.h"
 
 namespace Config
 {
+template <typename T>
+class Info;
+
 using ConfigChangedCallback = std::function<void()>;
 
 // Layer management
@@ -50,7 +53,7 @@ T Get(LayerType layer, const Info<T>& info)
 template <typename T>
 T Get(const Info<T>& info)
 {
-  return GetLayer(GetActiveLayerForConfig(info.GetLocation()))->Get(info);
+  return info.Get();
 }
 
 template <typename T>

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -50,7 +50,7 @@ T Get(LayerType layer, const Info<T>& info)
 template <typename T>
 T Get(const Info<T>& info)
 {
-  return GetLayer(GetActiveLayerForConfig(info.location))->Get(info);
+  return GetLayer(GetActiveLayerForConfig(info.GetLocation()))->Get(info);
 }
 
 template <typename T>
@@ -62,7 +62,7 @@ T GetBase(const Info<T>& info)
 template <typename T>
 LayerType GetActiveLayerForConfig(const Info<T>& info)
 {
-  return GetActiveLayerForConfig(info.location);
+  return GetActiveLayerForConfig(info.GetLocation());
 }
 
 template <typename T>

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include <string>
 #include <type_traits>
+#include <utility>
 
-#include "Common/Config/Enums.h"
+#include "Common/Config/ActiveInfos.h"
+#include "Common/Config/Location.h"
 
 namespace Config
 {
@@ -18,24 +19,24 @@ template <typename T>
 using UnderlyingType = typename std::enable_if_t<std::is_enum<T>{}, std::underlying_type<T>>::type;
 }  // namespace detail
 
-struct Location
-{
-  System system;
-  std::string section;
-  std::string key;
-
-  bool operator==(const Location& other) const;
-  bool operator!=(const Location& other) const;
-  bool operator<(const Location& other) const;
-};
-
 template <typename T>
 class Info
 {
+  friend class ActiveInfos<T>;
+
 public:
   Info(const Location& location, const T& default_value)
       : m_location{location}, m_default_value{default_value}
   {
+    ActiveInfos<T>::Update(this);
+    ActiveInfos<T>::Add(this);
+  }
+
+  Info(Location&& location, T&& default_value)
+      : m_location{std::move(location)}, m_default_value{std::move(default_value)}
+  {
+    ActiveInfos<T>::Update(this);
+    ActiveInfos<T>::Add(this);
   }
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
@@ -44,15 +45,38 @@ public:
             std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
   Info(const Info<Enum>& other)
       : m_location{other.GetLocation()}, m_default_value{static_cast<detail::UnderlyingType<Enum>>(
-                                             other.GetDefaultValue())}
+                                             other.GetDefaultValue())},
+        m_cached_value{static_cast<detail::UnderlyingType<Enum>>(other.Get())}
   {
+    ActiveInfos<T>::Add(this);
   }
+
+  Info(const Info<T>& other)
+      : m_location{other.m_location}, m_default_value{other.m_default_value},
+        m_cached_value{other.m_cached_value}
+  {
+    ActiveInfos<T>::Add(this);
+  }
+
+  Info(Info<T>&& other)
+      : m_location{std::move(other.location)}, m_default_value{std::move(other.m_default_value)},
+        m_cached_value{std::move(other.m_cached_value)}
+  {
+    ActiveInfos<T>::Add(this);
+  }
+
+  Info<T>& operator=(const Info<T>& other) = default;
+  Info<T>& operator=(Info<T>&& other) = default;
+
+  ~Info() { ActiveInfos<T>::Remove(this); }
 
   const Location& GetLocation() const { return m_location; }
   const T& GetDefaultValue() const { return m_default_value; }
+  const T& Get() const { return m_cached_value; }
 
 private:
   Location m_location;
   T m_default_value;
+  T m_cached_value;
 };
 }  // namespace Config

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -25,6 +25,8 @@ class Info
   friend class ActiveInfos<T>;
 
 public:
+  Info() { ActiveInfos<T>::Add(this); }
+
   Info(const Location& location, const T& default_value)
       : m_location{location}, m_default_value{default_value}
   {

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -30,10 +30,11 @@ struct Location
 };
 
 template <typename T>
-struct Info
+class Info
 {
-  Info(const Location& location_, const T& default_value_)
-      : location{location_}, default_value{default_value_}
+public:
+  Info(const Location& location, const T& default_value)
+      : m_location{location}, m_default_value{default_value}
   {
   }
 
@@ -42,12 +43,16 @@ struct Info
   template <typename Enum,
             std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
   Info(const Info<Enum>& other)
-      : location{other.location}, default_value{static_cast<detail::UnderlyingType<Enum>>(
-                                      other.default_value)}
+      : m_location{other.GetLocation()}, m_default_value{static_cast<detail::UnderlyingType<Enum>>(
+                                             other.GetDefaultValue())}
   {
   }
 
-  Location location;
-  T default_value;
+  const Location& GetLocation() const { return m_location; }
+  const T& GetDefaultValue() const { return m_default_value; }
+
+private:
+  Location m_location;
+  T m_default_value;
 };
 }  // namespace Config

--- a/Source/Core/Common/Config/Layer.cpp
+++ b/Source/Core/Common/Config/Layer.cpp
@@ -2,12 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Config/Layer.h"
+
 #include <algorithm>
 #include <cstring>
 #include <map>
 
 #include "Common/Config/Config.h"
-#include "Common/Config/Layer.h"
+#include "Common/Config/ConfigInfo.h"
+#include "Common/Config/Location.h"
 
 namespace Config
 {

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -45,7 +45,7 @@ inline std::optional<std::string> TryParse(const std::string& str_value)
 }  // namespace detail
 
 template <typename T>
-struct Info;
+class Info;
 
 class Layer;
 using LayerMap = std::map<Location, std::optional<std::string>>;
@@ -105,7 +105,7 @@ public:
   template <typename T>
   T Get(const Info<T>& config_info) const
   {
-    return Get<T>(config_info.location).value_or(config_info.default_value);
+    return Get<T>(config_info.GetLocation()).value_or(config_info.GetDefaultValue());
   }
 
   template <typename T>
@@ -120,7 +120,7 @@ public:
   template <typename T>
   void Set(const Info<T>& config_info, const std::common_type_t<T>& value)
   {
-    Set(config_info.location, value);
+    Set(config_info.GetLocation(), value);
   }
 
   template <typename T>

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -11,8 +11,8 @@
 #include <type_traits>
 #include <vector>
 
-#include "Common/Config/ConfigInfo.h"
 #include "Common/Config/Enums.h"
+#include "Common/Config/Location.h"
 #include "Common/StringUtil.h"
 
 namespace Config

--- a/Source/Core/Common/Config/Location.cpp
+++ b/Source/Core/Common/Config/Location.cpp
@@ -2,10 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Config/Location.h"
+
 #include <cstring>
 
 #include "Common/CommonFuncs.h"
-#include "Common/Config/ConfigInfo.h"
 
 namespace Config
 {

--- a/Source/Core/Common/Config/Location.h
+++ b/Source/Core/Common/Config/Location.h
@@ -1,0 +1,23 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "Common/Config/Enums.h"
+
+namespace Config
+{
+struct Location
+{
+  System system;
+  std::string section;
+  std::string key;
+
+  bool operator==(const Location& other) const;
+  bool operator!=(const Location& other) const;
+  bool operator<(const Location& other) const;
+};
+}  // namespace Config

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -163,8 +163,7 @@ LogManager::LogManager()
   EnableListener(LogListener::LOG_WINDOW_LISTENER, Config::Get(LOGGER_WRITE_TO_WINDOW));
 
   for (LogContainer& container : m_log)
-    container.m_enable = Config::Get(
-        Config::Info<bool>{{Config::System::Logger, "Logs", container.m_short_name}, false});
+    container.m_enable = Config::Get(container.m_config_info);
 
   m_path_cutoff_point = DeterminePathCutOffPoint();
 }
@@ -188,10 +187,7 @@ void LogManager::SaveSettings()
   Config::SetBaseOrCurrent(LOGGER_VERBOSITY, static_cast<int>(GetLogLevel()));
 
   for (const auto& container : m_log)
-  {
-    const Config::Info<bool> info{{Config::System::Logger, "Logs", container.m_short_name}, false};
-    Config::SetBaseOrCurrent(info, container.m_enable);
-  }
+    Config::SetBaseOrCurrent(container.m_config_info, container.m_enable);
 
   Config::Save();
 }

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -16,6 +16,7 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/ConsoleListener.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "Common/BitSet.h"
+#include "Common/Config/ConfigInfo.h"
 #include "Common/Logging/Log.h"
 
 namespace Common::Log
@@ -63,8 +64,17 @@ public:
 private:
   struct LogContainer
   {
+    LogContainer() {}
+
+    LogContainer(const char* short_name, const char* full_name)
+        : m_short_name(short_name), m_full_name(full_name),
+          m_config_info({Config::System::Logger, "Logs", short_name}, false)
+    {
+    }
+
     const char* m_short_name;
     const char* m_full_name;
+    Config::Info<bool> m_config_info;
     bool m_enable = false;
   };
 

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -471,11 +471,11 @@ static void RestoreSYSCONF()
   for (const auto& setting : Config::SYSCONF_SETTINGS)
   {
     std::visit(
-        [&](auto& info) {
+        [&](auto* info) {
           // If this setting was overridden, then we copy the base layer value back to the SYSCONF.
           // Otherwise we leave the new value in the SYSCONF.
-          if (Config::GetActiveLayerForConfig(info) == Config::LayerType::Base)
-            Config::SetBase(info, temp_layer.Get(info));
+          if (Config::GetActiveLayerForConfig(*info) == Config::LayerType::Base)
+            Config::SetBase(*info, temp_layer.Get(*info));
         },
         setting.config_info);
   }

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace Config

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 enum class AspectMode : int;
 enum class ShaderCompilationMode : int;

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -7,7 +7,7 @@
 #include <fmt/format.h>
 
 #include "AudioCommon/AudioCommon.h"
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SI/SI_Device.h"

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 namespace PowerPC
 {

--- a/Source/Core/Core/Config/NetplaySettings.cpp
+++ b/Source/Core/Core/Config/NetplaySettings.cpp
@@ -4,7 +4,7 @@
 
 #include "Core/Config/NetplaySettings.h"
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 namespace Config
 {

--- a/Source/Core/Core/Config/NetplaySettings.h
+++ b/Source/Core/Core/Config/NetplaySettings.h
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 namespace Config
 {

--- a/Source/Core/Core/Config/SYSCONFSettings.cpp
+++ b/Source/Core/Core/Config/SYSCONFSettings.cpp
@@ -24,15 +24,15 @@ const Info<u32> SYSCONF_SPEAKER_VOLUME{{System::SYSCONF, "BT", "SPKV"}, 0x58};
 const Info<bool> SYSCONF_WIIMOTE_MOTOR{{System::SYSCONF, "BT", "MOT"}, true};
 
 const std::array<SYSCONFSetting, 11> SYSCONF_SETTINGS{
-    {{SYSCONF_SCREENSAVER, SysConf::Entry::Type::Byte},
-     {SYSCONF_LANGUAGE, SysConf::Entry::Type::Byte},
-     {SYSCONF_COUNTRY, SysConf::Entry::Type::BigArray},
-     {SYSCONF_WIDESCREEN, SysConf::Entry::Type::Byte},
-     {SYSCONF_PROGRESSIVE_SCAN, SysConf::Entry::Type::Byte},
-     {SYSCONF_PAL60, SysConf::Entry::Type::Byte},
-     {SYSCONF_SOUND_MODE, SysConf::Entry::Type::Byte},
-     {SYSCONF_SENSOR_BAR_POSITION, SysConf::Entry::Type::Byte},
-     {SYSCONF_SENSOR_BAR_SENSITIVITY, SysConf::Entry::Type::Long},
-     {SYSCONF_SPEAKER_VOLUME, SysConf::Entry::Type::Byte},
-     {SYSCONF_WIIMOTE_MOTOR, SysConf::Entry::Type::Byte}}};
+    {{&SYSCONF_SCREENSAVER, SysConf::Entry::Type::Byte},
+     {&SYSCONF_LANGUAGE, SysConf::Entry::Type::Byte},
+     {&SYSCONF_COUNTRY, SysConf::Entry::Type::BigArray},
+     {&SYSCONF_WIDESCREEN, SysConf::Entry::Type::Byte},
+     {&SYSCONF_PROGRESSIVE_SCAN, SysConf::Entry::Type::Byte},
+     {&SYSCONF_PAL60, SysConf::Entry::Type::Byte},
+     {&SYSCONF_SOUND_MODE, SysConf::Entry::Type::Byte},
+     {&SYSCONF_SENSOR_BAR_POSITION, SysConf::Entry::Type::Byte},
+     {&SYSCONF_SENSOR_BAR_SENSITIVITY, SysConf::Entry::Type::Long},
+     {&SYSCONF_SPEAKER_VOLUME, SysConf::Entry::Type::Byte},
+     {&SYSCONF_WIIMOTE_MOTOR, SysConf::Entry::Type::Byte}}};
 }  // namespace Config

--- a/Source/Core/Core/Config/SYSCONFSettings.cpp
+++ b/Source/Core/Core/Config/SYSCONFSettings.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/Config/SYSCONFSettings.h"
 
+#include "Common/Config/ConfigInfo.h"
+
 namespace Config
 {
 // SYSCONF.IPL

--- a/Source/Core/Core/Config/SYSCONFSettings.h
+++ b/Source/Core/Core/Config/SYSCONFSettings.h
@@ -33,7 +33,7 @@ extern const Info<bool> SYSCONF_WIIMOTE_MOTOR;
 
 struct SYSCONFSetting
 {
-  std::variant<Info<u32>, Info<bool>> config_info;
+  std::variant<const Info<u32>*, const Info<bool>*> config_info;
   SysConf::Entry::Type type;
 };
 

--- a/Source/Core/Core/Config/SYSCONFSettings.h
+++ b/Source/Core/Core/Config/SYSCONFSettings.h
@@ -7,7 +7,7 @@
 #include <array>
 #include <variant>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 #include "Core/SysConf.h"
 
 namespace Config

--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/Config/UISettings.h"
 
+#include "Common/Config/ConfigInfo.h"
+
 namespace Config
 {
 // UI.General

--- a/Source/Core/Core/Config/UISettings.h
+++ b/Source/Core/Core/Config/UISettings.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 // This is a temporary soluation, although they should be in their repected cpp file in UICommon.
 // However, in order for IsSettingSaveable to compile without some issues, this needs to be here.

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -41,7 +41,7 @@ void SaveToSYSCONF(Config::LayerType layer)
   {
     std::visit(
         [layer, &setting, &sysconf](auto& info) {
-          const std::string key = info.location.section + "." + info.location.key;
+          const std::string key = info.GetLocation().section + "." + info.GetLocation().key;
 
           if (setting.type == SysConf::Entry::Type::Long)
           {
@@ -180,27 +180,28 @@ private:
     {
       std::visit(
           [&](auto& info) {
-            const std::string key = info.location.section + "." + info.location.key;
+            const Config::Location location = info.GetLocation();
+            const std::string key = location.section + "." + location.key;
             if (setting.type == SysConf::Entry::Type::Long)
             {
-              layer->Set(info.location, sysconf.GetData<u32>(key, info.default_value));
+              layer->Set(location, sysconf.GetData<u32>(key, info.GetDefaultValue()));
             }
             else if (setting.type == SysConf::Entry::Type::Byte)
             {
-              layer->Set(info.location, sysconf.GetData<u8>(key, info.default_value));
+              layer->Set(location, sysconf.GetData<u8>(key, info.GetDefaultValue()));
             }
             else if (setting.type == SysConf::Entry::Type::BigArray)
             {
               // Somewhat hacky support for IPL.SADR. The setting only stores the
               // first 4 bytes even thought the SYSCONF entry is much bigger.
-              u32 value = info.default_value;
+              u32 value = info.GetDefaultValue();
               SysConf::Entry* entry = sysconf.GetEntry(key);
               if (entry)
               {
                 std::memcpy(&value, entry->bytes.data(),
                             std::min(entry->bytes.size(), sizeof(u32)));
               }
-              layer->Set(info.location, value);
+              layer->Set(location, value);
             }
           },
           setting.config_info);

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -69,10 +69,10 @@ using INIToSectionMap = std::map<std::string, std::pair<Config::System, std::str
 static const INIToLocationMap& GetINIToLocationMap()
 {
   static const INIToLocationMap ini_to_location = {
-      {{"Core", "ProgressiveScan"}, {Config::SYSCONF_PROGRESSIVE_SCAN.location}},
-      {{"Core", "PAL60"}, {Config::SYSCONF_PAL60.location}},
-      {{"Wii", "Widescreen"}, {Config::SYSCONF_WIDESCREEN.location}},
-      {{"Wii", "Language"}, {Config::SYSCONF_LANGUAGE.location}},
+      {{"Core", "ProgressiveScan"}, {Config::SYSCONF_PROGRESSIVE_SCAN.GetLocation()}},
+      {{"Core", "PAL60"}, {Config::SYSCONF_PAL60.GetLocation()}},
+      {{"Wii", "Widescreen"}, {Config::SYSCONF_WIDESCREEN.GetLocation()}},
+      {{"Wii", "Language"}, {Config::SYSCONF_LANGUAGE.GetLocation()}},
   };
   return ini_to_location;
 }

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -7,7 +7,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/Enums.h"
+#include "Common/Config/Location.h"
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/Config/UISettings.h"

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -33,34 +33,34 @@ bool IsSettingSaveable(const Config::Location& config_location)
     }
   }
 
-  static constexpr std::array<const Config::Location*, 16> s_setting_saveable = {
+  static std::array<const Config::Location*, 16> s_setting_saveable = {
       // Main.Core
 
-      &Config::MAIN_DEFAULT_ISO.location,
-      &Config::MAIN_MEMCARD_A_PATH.location,
-      &Config::MAIN_MEMCARD_B_PATH.location,
-      &Config::MAIN_AUTO_DISC_CHANGE.location,
-      &Config::MAIN_ALLOW_SD_WRITES.location,
-      &Config::MAIN_DPL2_DECODER.location,
-      &Config::MAIN_DPL2_QUALITY.location,
-      &Config::MAIN_RAM_OVERRIDE_ENABLE.location,
-      &Config::MAIN_MEM1_SIZE.location,
-      &Config::MAIN_MEM2_SIZE.location,
-      &Config::MAIN_GFX_BACKEND.location,
-      &Config::MAIN_ENABLE_SAVESTATES.location,
+      &Config::MAIN_DEFAULT_ISO.GetLocation(),
+      &Config::MAIN_MEMCARD_A_PATH.GetLocation(),
+      &Config::MAIN_MEMCARD_B_PATH.GetLocation(),
+      &Config::MAIN_AUTO_DISC_CHANGE.GetLocation(),
+      &Config::MAIN_ALLOW_SD_WRITES.GetLocation(),
+      &Config::MAIN_DPL2_DECODER.GetLocation(),
+      &Config::MAIN_DPL2_QUALITY.GetLocation(),
+      &Config::MAIN_RAM_OVERRIDE_ENABLE.GetLocation(),
+      &Config::MAIN_MEM1_SIZE.GetLocation(),
+      &Config::MAIN_MEM2_SIZE.GetLocation(),
+      &Config::MAIN_GFX_BACKEND.GetLocation(),
+      &Config::MAIN_ENABLE_SAVESTATES.GetLocation(),
 
       // Main.Interface
 
-      &Config::MAIN_USE_PANIC_HANDLERS.location,
-      &Config::MAIN_OSD_MESSAGES.location,
+      &Config::MAIN_USE_PANIC_HANDLERS.GetLocation(),
+      &Config::MAIN_OSD_MESSAGES.GetLocation(),
 
       // Main.Interface
 
-      &Config::MAIN_SKIP_NKIT_WARNING.location,
+      &Config::MAIN_SKIP_NKIT_WARNING.GetLocation(),
 
       // UI.General
 
-      &Config::MAIN_USE_DISCORD_PRESENCE.location,
+      &Config::MAIN_USE_DISCORD_PRESENCE.GetLocation(),
   };
 
   return std::any_of(s_setting_saveable.cbegin(), s_setting_saveable.cend(),

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.cpp
@@ -7,6 +7,7 @@
 #include <QSignalBlocker>
 
 #include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 #include "DolphinQt/Settings.h"
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.h
@@ -10,7 +10,7 @@
 namespace Config
 {
 template <typename T>
-struct Info;
+class Info;
 }
 
 class GraphicsBool : public QCheckBox

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsChoice.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsChoice.h
@@ -6,7 +6,7 @@
 
 #include <QComboBox>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 class GraphicsChoice : public QComboBox
 {

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.cpp
@@ -7,6 +7,7 @@
 #include <QSignalBlocker>
 
 #include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 #include "DolphinQt/Settings.h"
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.h
@@ -9,7 +9,7 @@
 namespace Config
 {
 template <typename T>
-struct Info;
+class Info;
 }
 
 class GraphicsInteger : public QSpinBox

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsRadio.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsRadio.h
@@ -6,7 +6,7 @@
 
 #include <QRadioButton>
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 class GraphicsRadioInt : public QRadioButton
 {

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.cpp
@@ -7,6 +7,7 @@
 #include <QSignalBlocker>
 
 #include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 #include "DolphinQt/Settings.h"
 

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.h
@@ -9,7 +9,7 @@
 namespace Config
 {
 template <typename T>
-struct Info;
+class Info;
 }
 
 class GraphicsSlider : public QSlider

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -382,13 +382,13 @@ void NetPlaySetupDialog::PopulateGameList()
 void NetPlaySetupDialog::ResetTraversalHost()
 {
   Config::SetBaseOrCurrent(Config::NETPLAY_TRAVERSAL_SERVER,
-                           Config::NETPLAY_TRAVERSAL_SERVER.default_value);
+                           Config::NETPLAY_TRAVERSAL_SERVER.GetDefaultValue());
   Config::SetBaseOrCurrent(Config::NETPLAY_TRAVERSAL_PORT,
-                           Config::NETPLAY_TRAVERSAL_PORT.default_value);
+                           Config::NETPLAY_TRAVERSAL_PORT.GetDefaultValue());
 
   ModalMessageBox::information(
       this, tr("Reset Traversal Server"),
       tr("Reset Traversal Server to %1:%2")
-          .arg(QString::fromStdString(Config::NETPLAY_TRAVERSAL_SERVER.default_value),
-               QString::number(Config::NETPLAY_TRAVERSAL_PORT.default_value)));
+          .arg(QString::fromStdString(Config::NETPLAY_TRAVERSAL_SERVER.GetDefaultValue()),
+               QString::number(Config::NETPLAY_TRAVERSAL_PORT.GetDefaultValue())));
 }

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -15,6 +15,7 @@
 #include <fmt/format.h>
 
 #include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 #include "Common/Flag.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Config/Config.h"
+#include "Common/Config/ConfigInfo.h"
 
 namespace ciface::DualShockUDPClient
 {

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -26,15 +26,18 @@ public:
       : ConfigLayerLoader(Config::LayerType::CommandLine)
   {
     if (!video_backend.empty())
-      m_values.emplace_back(Config::MAIN_GFX_BACKEND.location, video_backend);
+      m_values.emplace_back(Config::MAIN_GFX_BACKEND.GetLocation(), video_backend);
 
     if (!audio_backend.empty())
-      m_values.emplace_back(Config::MAIN_DSP_HLE.location, ValueToString(audio_backend == "HLE"));
+    {
+      m_values.emplace_back(Config::MAIN_DSP_HLE.GetLocation(),
+                            ValueToString(audio_backend == "HLE"));
+    }
 
     // Batch mode hides the main window, and render to main hides the render window. To avoid a
     // situation where we would have no window at all, disable render to main when using batch mode.
     if (batch)
-      m_values.emplace_back(Config::MAIN_RENDER_TO_MAIN.location, ValueToString(false));
+      m_values.emplace_back(Config::MAIN_RENDER_TO_MAIN.GetLocation(), ValueToString(false));
 
     // Arguments are in the format of <System>.<Section>.<Key>=Value
     for (const auto& arg : args)

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -50,7 +50,7 @@ void HandleDiscordJoin(const char* join_secret)
   if (event_handler == nullptr)
     return;
 
-  if (Config::Get(Config::NETPLAY_NICKNAME) == Config::NETPLAY_NICKNAME.default_value)
+  if (Config::Get(Config::NETPLAY_NICKNAME) == Config::NETPLAY_NICKNAME.GetDefaultValue())
     Config::SetCurrent(Config::NETPLAY_NICKNAME, username);
 
   std::string secret(join_secret);


### PR DESCRIPTION
The goal of this change is to make `Config::Get(const Info<T>&)` super fast so that we can use it in hot paths.

This probably isn't the only reasonable way to solve the performance problem. I tried to pick a way that would require little changes to the existing config code, but unfortunately this way requires us to do some slightly ugly stuff to work around the unpredictable initialization order of static objects.