### PR TITLE
DolphinQt: Handle non-ASCII characters in Windows cmd arguments

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -31,6 +31,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#include <shellapi.h>
 constexpr u32 CODEPAGE_SHIFT_JIS = 932;
 constexpr u32 CODEPAGE_WINDOWS_1252 = 1252;
 #else
@@ -628,5 +629,24 @@ std::string PathToString(const std::filesystem::path& path)
 #else
   return path.native();
 #endif
+}
+#endif
+
+#ifdef _WIN32
+std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line)
+{
+  int nargs;
+  LPWSTR* tokenized = CommandLineToArgvW(command_line, &nargs);
+  if (!tokenized)
+    return {};
+
+  std::vector<std::string> argv(nargs);
+  for (size_t i = 0; i < nargs; ++i)
+  {
+    argv[i] = WStringToUTF8(tokenized[i]);
+  }
+
+  LocalFree(tokenized);
+  return argv;
 }
 #endif

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -236,3 +236,7 @@ inline bool IsPrintableCharacter(char c)
 {
   return std::isprint(c, std::locale::classic());
 }
+
+#ifdef _WIN32
+std::vector<std::string> CommandLineToUtf8Argv(const wchar_t* command_line);
+#endif

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -99,11 +99,12 @@ static bool QtMsgAlertHandler(const char* caption, const char* text, bool yes_no
   return false;
 }
 
-// N.B. On Windows, this should be called from WinMain. Link against qtmain and specify
-// /SubSystem:Windows
+#ifndef _WIN32
 int main(int argc, char* argv[])
 {
-#ifdef _WIN32
+#else
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
+{
   std::vector<std::string> utf8_args = CommandLineToUtf8Argv(GetCommandLineW());
   const int utf8_argc = static_cast<int>(utf8_args.size());
   std::vector<char*> utf8_argv(utf8_args.size());
@@ -146,7 +147,11 @@ int main(int argc, char* argv[])
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
   QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));
 
+#ifdef _WIN32
+  QApplication app(__argc, __argv);
+#else
   QApplication app(argc, argv);
+#endif
 
 #ifdef _WIN32
   // On Windows, Qt 5's default system font (MS Shell Dlg 2) is outdated.

--- a/Source/Core/WinUpdater/Main.cpp
+++ b/Source/Core/WinUpdater/Main.cpp
@@ -16,26 +16,6 @@
 #include "UpdaterCommon/UI.h"
 #include "UpdaterCommon/UpdaterCommon.h"
 
-namespace
-{
-std::vector<std::string> CommandLineToUtf8Argv(PCWSTR command_line)
-{
-  int nargs;
-  LPWSTR* tokenized = CommandLineToArgvW(command_line, &nargs);
-  if (!tokenized)
-    return {};
-
-  std::vector<std::string> argv(nargs);
-  for (int i = 0; i < nargs; ++i)
-  {
-    argv[i] = WStringToUTF8(tokenized[i]);
-  }
-
-  LocalFree(tokenized);
-  return argv;
-}
-};  // namespace
-
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
 {
   if (lstrlenW(pCmdLine) == 0)

--- a/Source/VSProps/QtCompile.props
+++ b/Source/VSProps/QtCompile.props
@@ -35,7 +35,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>qtmain$(QtLibSuffix).lib;Qt5Core$(QtLibSuffix).lib;Qt5Gui$(QtLibSuffix).lib;Qt5Widgets$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Qt5Core$(QtLibSuffix).lib;Qt5Gui$(QtLibSuffix).lib;Qt5Widgets$(QtLibSuffix).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <!--
       <AdditionalOptions>"/manifestdependency:type='Win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\" %(AdditionalOptions)</AdditionalOptions>


### PR DESCRIPTION
`CommandLineParse` expects UTF-8 strings. (`QApplication`, on the other hand, seems to be designed so that you can pass in the `char**` `argv` untouched on Windows and get proper Unicode handling.)