### PR TITLE
WiimoteEmu: Increase camera FOV to match that of a real Wii remote.

### DIFF
--- a/Data/Sys/Profiles/Wiimote/Wii Remote with MotionPlus Pointing.ini
+++ b/Data/Sys/Profiles/Wiimote/Wii Remote with MotionPlus Pointing.ini
@@ -21,7 +21,6 @@ IMUGyroscope/Roll Right = `Gyro Roll Right`
 IMUGyroscope/Yaw Left = `Gyro Yaw Left`
 IMUGyroscope/Yaw Right = `Gyro Yaw Right`
 IMUIR/Enabled = True
-IMUIR/Total Yaw = 20
 Extension/Attach MotionPlus = `Attached MotionPlus`
 Extension = `Attached Extension`
 Nunchuk/Buttons/C = `Nunchuk C`

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -135,8 +135,12 @@ public:
 
   constexpr size_t Count() const { return m_running_mean.Count(); }
   constexpr T Mean() const { return m_running_mean.Mean(); }
+
   constexpr T Variance() const { return m_variance / (Count() - 1); }
-  constexpr T StandardDeviation() const { return std::sqrt(Variance()); }
+  T StandardDeviation() const { return std::sqrt(Variance()); }
+
+  constexpr T PopulationVariance() const { return m_variance / Count(); }
+  T PopulationStandardDeviation() const { return std::sqrt(PopulationVariance()); }
 
 private:
   RunningMean<T> m_running_mean;

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
@@ -75,9 +75,6 @@ void CameraLogic::Update(const Common::Matrix44& transform)
   using Common::Vec3;
   using Common::Vec4;
 
-  constexpr auto CAMERA_FOV_Y = float(CAMERA_FOV_Y_DEG * MathUtil::TAU / 360);
-  constexpr auto CAMERA_ASPECT_RATIO = float(CAMERA_FOV_X_DEG) / CAMERA_FOV_Y_DEG;
-
   // FYI: A real wiimote normally only returns 1 point for each LED cluster (2 total).
   // Sending all 4 points can actually cause some stuttering issues.
   constexpr int NUM_POINTS = 2;
@@ -86,16 +83,12 @@ void CameraLogic::Update(const Common::Matrix44& transform)
   // This is reduced based on distance from sensor bar.
   constexpr int MAX_POINT_SIZE = 15;
 
-  // Sensor bar:
-  // Distance in meters between LED clusters.
-  constexpr float SENSOR_BAR_LED_SEPARATION = 0.2f;
-
   const std::array<Vec3, NUM_POINTS> leds{
       Vec3{-SENSOR_BAR_LED_SEPARATION / 2, 0, 0},
       Vec3{SENSOR_BAR_LED_SEPARATION / 2, 0, 0},
   };
 
-  const auto camera_view = Matrix44::Perspective(CAMERA_FOV_Y, CAMERA_ASPECT_RATIO, 0.001f, 1000) *
+  const auto camera_view = Matrix44::Perspective(CAMERA_FOV_Y, CAMERA_AR, 0.001f, 1000) *
                            Matrix44::FromMatrix33(Matrix33::RotateX(float(MathUtil::TAU / 4))) *
                            transform;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.h
@@ -91,13 +91,17 @@ static_assert(sizeof(IRFull) == 9, "Wrong size");
 class CameraLogic : public I2CSlave
 {
 public:
+  // OEM sensor bar distance between LED clusters in meters.
+  static constexpr float SENSOR_BAR_LED_SEPARATION = 0.2f;
+
   static constexpr int CAMERA_RES_X = 1024;
   static constexpr int CAMERA_RES_Y = 768;
 
-  // Wiibrew claims the camera FOV is about 33 deg by 23 deg.
-  // Unconfirmed but it seems to work well enough.
-  static constexpr int CAMERA_FOV_X_DEG = 33;
-  static constexpr int CAMERA_FOV_Y_DEG = 23;
+  // Jordan: I calculate the FOV at 42 degrees horizontally and having a 4:3 aspect ratio.
+  // This is 31.5 degrees vertically.
+  static constexpr float CAMERA_AR = 4.f / 3;
+  static constexpr float CAMERA_FOV_X = 42 * float(MathUtil::TAU) / 360;
+  static constexpr float CAMERA_FOV_Y = CAMERA_FOV_X / CAMERA_AR;
 
   enum : u8
   {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -33,8 +33,7 @@ Cursor::Cursor(std::string name_, std::string ui_name_)
 
   AddInput(Translate, _trans("Relative Input Hold"));
 
-  // Default values are optimized for "Super Mario Galaxy 2".
-  // This seems to be acceptable for a good number of games.
+  // Default values chosen to reach screen edges in most games including the Wii Menu.
 
   AddSetting(&m_vertical_offset_setting,
              // i18n: Refers to a positional offset applied to an emulated wiimote.
@@ -50,7 +49,7 @@ Cursor::Cursor(std::string name_, std::string ui_name_)
               _trans("°"),
               // i18n: Refers to emulated wii remote movements.
               _trans("Total rotation about the yaw axis.")},
-             15, 0, 360);
+             25, 0, 360);
 
   AddSetting(&m_pitch_setting,
              // i18n: Refers to an amount of rotational movement about the "pitch" axis.
@@ -59,7 +58,7 @@ Cursor::Cursor(std::string name_, std::string ui_name_)
               _trans("°"),
               // i18n: Refers to emulated wii remote movements.
               _trans("Total rotation about the pitch axis.")},
-             15, 0, 360);
+             20, 0, 360);
 
   AddSetting(&m_relative_setting, {_trans("Relative Input")}, false);
   AddSetting(&m_autohide_setting, {_trans("Auto-Hide")}, false);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -29,8 +29,7 @@ IMUCursor::IMUCursor(std::string name_, std::string ui_name_)
 {
   AddInput(Translate, _trans("Recenter"));
 
-  // Default values are optimized for "Super Mario Galaxy 2".
-  // This seems to be acceptable for a good number of games.
+  // Default values chosen to reach screen edges in most games including the Wii Menu.
 
   AddSetting(&m_yaw_setting,
              // i18n: Refers to an amount of rotational movement about the "yaw" axis.
@@ -39,7 +38,7 @@ IMUCursor::IMUCursor(std::string name_, std::string ui_name_)
               _trans("°"),
               // i18n: Refers to emulated wii remote movements.
               _trans("Total rotation about the yaw axis.")},
-             15, 0, 360);
+             25, 0, 360);
 }
 
 ControlState IMUCursor::GetTotalYaw() const

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/Wiimote.h
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/Wiimote.h
@@ -135,6 +135,8 @@ private:
     // Average of visible IR "objects".
     Common::Vec2 center_position = {};
 
+    float distance = 0;
+
     bool is_hidden = true;
   };
 


### PR DESCRIPTION
I've measured the field of view of Nintendo Wii Remote IR cameras (original and "MotionPlus Inside") using the known distance of a sensor bar with LEDs of known separation and trigonometry!

It comes out at 42 degrees horizontally by 31.5 vertically.
This is an increase from the 33 by 23 guess we took from Wiibrew.

Increasing the FOV on the emulated camera makes `IMUPointer`'s simulated sensor bar pointing noticeably less sensitive.
Many users complained it was too sensitive. Gyro pointing should more closely match IR pointing now.

We could potentially expose the FOV as an adjustable setting.
Even though it shouldn't ever change it would allow adjusting the sensitivity of gyro pointing.

Point's "Total Yaw" and "Total Pitch" settings must be increased to compensate for the higher FOV to produce similar behavior in game.
I've adjusted the defaults a bit more than just FOV compensation so screen edges in the Wii Menu can now be reached by default.

I've made the "Total Yaw" default of `IMUPointer` match.
I've removed the line from our included Wii remote profile to take on the default value.

I've added an "IR Distance" input to ControllerInterface's Wii Remote device which performs a sensor bar distance calculation using math.

Merging this can close #8631.  