### PR TITLE
Properly fix News Channel loading screen

### DIFF
--- a/Data/Sys/GameSettings/HAG.ini
+++ b/Data/Sys/GameSettings/HAG.ini
@@ -2,4 +2,4 @@
 
 [Video_Hacks]
 # Needed to correctly render loading screen
-EFBToTextureEnable = False
+XFBToTextureEnable = False


### PR DESCRIPTION
I think #9093 attempted to fix https://bugs.dolphin-emu.org/issues/11198. This problem dealt with XFB, not EFB.