### PR TITLE
Android: Add "Default Values" button for overlay seekbars

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -435,6 +435,7 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="pitch">Total Pitch</string>
     <string name="yaw">Total Yaw</string>
     <string name="vertical_offset">Vertical Offset</string>
+    <string name="default_values">Default Values</string>
     <string name="slider_setting_value">%1$d%2$s</string>
     <string name="disc_number">Disc %1$d</string>
     <string name="disabled_gc_overlay_notice">GameCube Controller 1 is set to \"None\"</string>


### PR DESCRIPTION
Quickly returning to the default value and not making users remember that value is good.
Note: #9095 will handle this for other settings by clearing them.