### PR TITLE
Add .ini configuration files for Phantasy Star Online Episode I&II Trial Edition and Episode III Trial Edition

### DIFF
--- a/Data/Sys/GameSettings/DPOJ8P.ini
+++ b/Data/Sys/GameSettings/DPOJ8P.ini
@@ -1,0 +1,16 @@
+# DPOJ8P - PHANTASY STAR ONLINE EPISODE I&II TRIAL EDITION
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/DPOJ8P.ini
+++ b/Data/Sys/GameSettings/DPOJ8P.ini
@@ -11,6 +11,8 @@
 
 [ActionReplay]
 # Add action replay cheats here.
+$Bypass Modem Detection
+04194f40 4182002c
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/DPSJ8P.ini
+++ b/Data/Sys/GameSettings/DPSJ8P.ini
@@ -1,4 +1,4 @@
-# GPSE8P, GPSP8P - PHANTASY STAR ONLINE EPISODE III TRIAL EDITION
+# DPSJ8P - PHANTASY STAR ONLINE EPISODE III TRIAL EDITION
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/DPSJ8P.ini
+++ b/Data/Sys/GameSettings/DPSJ8P.ini
@@ -1,0 +1,19 @@
+# GPSE8P, GPSP8P - PHANTASY STAR ONLINE EPISODE III TRIAL EDITION
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/DPSJ8P.ini
+++ b/Data/Sys/GameSettings/DPSJ8P.ini
@@ -14,6 +14,3 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-ImmediateXFBEnable = False


### PR DESCRIPTION
This pull request adds two new .ini configuration files for game IDs DPSJ8P (Phantasy Star Online Episode I&II Trial Edition) and DPOJ8P (Phantasy Star Online Episode III C.A.R.D. Revolution Trial Edition).

To summarize, both games require the same `SafeTextureCacheColorSamples = 512` configuration to render text more properly. PSO Episode III appears to have or had issues with Immediate XFB, so it is set to `ImmediateXFBEnable = False`.

In addition, the PSO Ep. I&II Trial Edition requires a modem to be present. Since the modem was the only option at the time, the BBA will not be recognized. This requires either a 32-bit patch (80194F40 4182002C, thank you to evilhamwizard) or an Action Replay code (04194F40 4182002C, thank you Sappharad) to bypass the initial screen as outlined on [the wiki page](https://wiki.dolphin-emu.org/index.php?title=Phantasy_Star_Online_Episode_I_%26_II_Trial_Edition).

Thank you for your consideration.