### PR TITLE
Core: Unbreak default keyboard mappings.

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -190,7 +190,7 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
   m_buttons->SetControlExpression(5, "RETURN");  // Start
 #else
   // OS X/Linux
-  m_buttons->SetControlExpression(5, "Return");  // Start
+  m_buttons->SetControlExpression(5, "Return");          // Start
 #endif
 
   // stick modifiers to 50 %
@@ -208,38 +208,28 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
   m_c_stick->SetControlExpression(1, "K");  // Down
   m_c_stick->SetControlExpression(2, "J");  // Left
   m_c_stick->SetControlExpression(3, "L");  // Right
-#ifdef _WIN32
-  m_c_stick->SetControlExpression(4, "LCONTROL");  // Modifier
-
-  // Control Stick
-  m_main_stick->SetControlExpression(0, "UP");      // Up
-  m_main_stick->SetControlExpression(1, "DOWN");    // Down
-  m_main_stick->SetControlExpression(2, "LEFT");    // Left
-  m_main_stick->SetControlExpression(3, "RIGHT");   // Right
-  m_main_stick->SetControlExpression(4, "LSHIFT");  // Modifier
-
-#elif __APPLE__
   // Modifier
-  m_c_stick->SetControlExpression(4, "Left Control");
+  m_c_stick->SetControlExpression(4, "Ctrl");
 
   // Control Stick
+#ifdef _WIN32
+  m_main_stick->SetControlExpression(0, "UP");     // Up
+  m_main_stick->SetControlExpression(1, "DOWN");   // Down
+  m_main_stick->SetControlExpression(2, "LEFT");   // Left
+  m_main_stick->SetControlExpression(3, "RIGHT");  // Right
+#elif __APPLE__
   m_main_stick->SetControlExpression(0, "Up Arrow");     // Up
   m_main_stick->SetControlExpression(1, "Down Arrow");   // Down
   m_main_stick->SetControlExpression(2, "Left Arrow");   // Left
   m_main_stick->SetControlExpression(3, "Right Arrow");  // Right
-  m_main_stick->SetControlExpression(4, "Left Shift");   // Modifier
 #else
-  // not sure if these are right
-
-  m_c_stick->SetControlExpression(4, "Control_L");  // Modifier
-
-  // Control Stick
-  m_main_stick->SetControlExpression(0, "Up");       // Up
-  m_main_stick->SetControlExpression(1, "Down");     // Down
-  m_main_stick->SetControlExpression(2, "Left");     // Left
-  m_main_stick->SetControlExpression(3, "Right");    // Right
-  m_main_stick->SetControlExpression(4, "Shift_L");  // Modifier
+  m_main_stick->SetControlExpression(0, "Up");     // Up
+  m_main_stick->SetControlExpression(1, "Down");   // Down
+  m_main_stick->SetControlExpression(2, "Left");   // Left
+  m_main_stick->SetControlExpression(3, "Right");  // Right
 #endif
+  // Modifier
+  m_main_stick->SetControlExpression(4, "Shift");
 
   // Because our defaults use keyboard input, set calibration shapes to squares.
   m_c_stick->SetCalibrationFromGate(ControllerEmu::SquareStickGate(1.0));

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -415,15 +415,8 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
         ->control_ref->SetExpression(expression);
   };
 
-  auto hotkey_string = [](std::vector<std::string_view> inputs) {
-    std::string result;
-    for (auto& input : inputs)
-    {
-      if (!result.empty())
-        result += '+';
-      result += input;
-    }
-    return "@(" + result + ')';
+  auto hotkey_string = [](std::vector<std::string> inputs) {
+    return "@(" + JoinStrings(inputs, "+") + ')';
   };
 
   // General hotkeys
@@ -453,8 +446,8 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
 #endif
 
   // Freelook
-  set_key_expression(HK_FREELOOK_DECREASE_SPEED, hotkey_string({"Shift", "1"}));
-  set_key_expression(HK_FREELOOK_INCREASE_SPEED, hotkey_string({"Shift", "2"}));
+  set_key_expression(HK_FREELOOK_DECREASE_SPEED, hotkey_string({"Shift", "`1`"}));
+  set_key_expression(HK_FREELOOK_INCREASE_SPEED, hotkey_string({"Shift", "`2`"}));
   set_key_expression(HK_FREELOOK_RESET_SPEED, hotkey_string({"Shift", "F"}));
   set_key_expression(HK_FREELOOK_UP, hotkey_string({"Shift", "E"}));
   set_key_expression(HK_FREELOOK_DOWN, hotkey_string({"Shift", "Q"}));
@@ -471,9 +464,9 @@ void HotkeyManager::LoadDefaults(const ControllerInterface& ciface)
   // Savestates
   for (int i = 0; i < 8; i++)
   {
-    set_key_expression(HK_LOAD_STATE_SLOT_1 + i, fmt::format("F%d", i + 1));
+    set_key_expression(HK_LOAD_STATE_SLOT_1 + i, fmt::format("F{}", i + 1));
     set_key_expression(HK_SAVE_STATE_SLOT_1 + i,
-                       hotkey_string({"Shift", fmt::format("F%d", i + 1)}));
+                       hotkey_string({"Shift", fmt::format("F{}", i + 1)}));
   }
   set_key_expression(HK_UNDO_LOAD_STATE, "F12");
   set_key_expression(HK_UNDO_SAVE_STATE, hotkey_string({"Shift", "F12"}));


### PR DESCRIPTION
Hotfix for #8428.
`@(Shift+1)` hotkey expression needed 1 to be backticked.
The `fmt::format` string for Wii Remote hotkeys was bad.
Made default modifier mappings cleaner.