### PR TITLE
Fix controller defaults being empty on fresh run

### DIFF
--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -93,7 +93,8 @@ bool InputConfig::LoadConfig(bool isGC)
 #endif
   }
 
-  if (inifile.Load(File::GetUserPath(D_CONFIG_IDX) + m_ini_name + ".ini"))
+  if (inifile.Load(File::GetUserPath(D_CONFIG_IDX) + m_ini_name + ".ini") &&
+      !inifile.GetSections().empty())
   {
     int n = 0;
     for (auto& controller : m_controllers)


### PR DESCRIPTION
A very early call to Config::Save is now creating empty controller INI files.

https://bugs.dolphin-emu.org/issues/12283