### PR TITLE
DolphinQt/Debugger: Fix DBAT and IBAT registers in RegisterWidget

### DIFF
--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -242,7 +242,10 @@ void RegisterWidget::PopulateTable()
         [i](u64 value) { rPS(i).SetPS1(value); });
   }
 
-  for (int i = 0; i < 8; i++)
+  // The IBAT and DBAT registers have a large gap between
+  // registers 3 and 4 so we can't just use SPR_IBAT0U or
+  // SPR_DBAT0U as low-index the entire way
+  for (int i = 0; i < 4; i++)
   {
     // IBAT registers
     AddRegister(
@@ -252,6 +255,14 @@ void RegisterWidget::PopulateTable()
                  PowerPC::ppcState.spr[SPR_IBAT0L + i * 2];
         },
         nullptr);
+    AddRegister(
+        i + 4, 5, RegisterType::ibat, "IBAT" + std::to_string(4 + i),
+        [i] {
+          return (static_cast<u64>(PowerPC::ppcState.spr[SPR_IBAT4U + i * 2]) << 32) +
+                 PowerPC::ppcState.spr[SPR_IBAT4L + i * 2];
+        },
+        nullptr);
+
     // DBAT registers
     AddRegister(
         i + 8, 5, RegisterType::dbat, "DBAT" + std::to_string(i),
@@ -260,6 +271,17 @@ void RegisterWidget::PopulateTable()
                  PowerPC::ppcState.spr[SPR_DBAT0L + i * 2];
         },
         nullptr);
+    AddRegister(
+        i + 12, 5, RegisterType::dbat, "DBAT" + std::to_string(4 + i),
+        [i] {
+          return (static_cast<u64>(PowerPC::ppcState.spr[SPR_DBAT4U + i * 2]) << 32) +
+                 PowerPC::ppcState.spr[SPR_DBAT4L + i * 2];
+        },
+        nullptr);
+  }
+
+  for (int i = 0; i < 8; i++)
+  {
     // Graphics quantization registers
     AddRegister(
         i + 16, 7, RegisterType::gqr, "GQR" + std::to_string(i),


### PR DESCRIPTION
This PR fixes the display of DBAT and IBAT registers past register 3 which is currently broken.  Behavior can be verified by running some code to put a value in SPR 570 which will update DBAT5, however it won't update in the register window. Further, values displayed for IBATs after IBAT3 are actually DBAT values.

The issue is caused by the registers being added using the row index and incrementing all the way up to register 7 when the actual order of DBAT and IBAT registers have a gap between registers 3 and 4. (e.g `SPR_IBAT3L` is 535, but `SPR_IBAT4U` is 560). 

![image](https://user-images.githubusercontent.com/7476801/94645942-f2b6f980-02a1-11eb-9891-7d733431ebc3.png)

