### PR TITLE
Qt: Use passthrough for hidpi rounding policy

### DIFF
--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -128,6 +128,11 @@ int main(int argc, char* argv[])
 
   QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+      Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif
+
   QCoreApplication::setOrganizationName(QStringLiteral("Dolphin Emulator"));
   QCoreApplication::setOrganizationDomain(QStringLiteral("dolphin-emu.org"));
   QCoreApplication::setApplicationName(QStringLiteral("dolphin-emu"));

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1053,7 +1053,12 @@ void Renderer::DrawImGui()
 
   // Set up common state for drawing.
   SetPipeline(m_imgui_pipeline.get());
-  SetSamplerState(0, RenderState::GetPointSamplerState());
+
+  // Use linear sampling for fractional scaling, point for integer.
+  const float scale = ImGui::GetIO().DisplayFramebufferScale.x;
+  const bool is_integer_scale = (scale == std::floor(scale));
+  SetSamplerState(0, is_integer_scale ? RenderState::GetPointSamplerState() :
+                                        RenderState::GetLinearSamplerState());
   g_vertex_manager->UploadUtilityUniforms(&ubo, sizeof(ubo));
 
   for (int i = 0; i < draw_data->CmdListsCount; i++)


### PR DESCRIPTION
Currently, Dolphin will round up the scaling factor when using a non-integer factor on Windows (e.g. 125%, 150%, 175%). This results in everything being way too large compared to the rest of the applications and desktop.

This patch uses setHighDpiScaleFactorRoundingPolicy() to set the rounding policy to passthrough, which will use the fractional scale. Needs testing on Linux, we might have to #ifdef it out.

Also changes the ImGui render function to use linear sampling rather than point sampling, which looks terrible at non-integer scales. We should really replace the bitmap font at some point, but apparently the ImGui font renderer has issues...