### PR TITLE
Jit64: Optimize fsel a bit more

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -449,7 +449,7 @@ void Jit64::fselx(UGeckoInstruction inst)
       MOVAPD(XMM1, Rc);
     }
 
-    if (packed)
+    if (d == c || packed)
     {
       VBLENDVPD(Rd, src1, Rb, XMM0);
       return;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -459,7 +459,7 @@ void Jit64::fselx(UGeckoInstruction inst)
   }
   else if (cpu_info.bSSE4_1)
   {
-    if (packed && d == c)
+    if (d == c)
     {
       BLENDVPD(Rd, Rb);
       return;


### PR DESCRIPTION
This PR builds upon optimizations introduced in pull request #8992, which were only applied to the packed variant of this instruction. As it turns out, these optimizations can also be applied to the non-packed variant when the destination register and a specific input register match. Luckily, according to my testing, this happens to be the case most of the time in games that use this instruction.

---
**fsel (AVX)**
Before:
```
66 0F 57 C0          xorpd       xmm0,xmm0
F2 41 0F C2 C6 06    cmpnlesd    xmm0,xmm14
C4 C3 09 4B CA 00    vblendvpd   xmm1,xmm14,xmm10,xmm0
F2 44 0F 10 F1       movsd       xmm14,xmm1
```
After:
```
66 0F 57 C0          xorpd       xmm0,xmm0
F2 41 0F C2 C6 06    cmpnlesd    xmm0,xmm14
C4 43 09 4B F2 00    vblendvpd   xmm14,xmm14,xmm10,xmm0
```
---
**fsel (SSE4.1)**
Before:
```
66 0F 57 C0          xorpd       xmm0,xmm0
F2 41 0F C2 C6 06    cmpnlesd    xmm0,xmm14
41 0F 28 CE          movaps      xmm1,xmm14
66 41 0F 38 15 CA    blendvpd    xmm1,xmm10,xmm0
F2 44 0F 10 F1       movsd       xmm14,xmm1
```
After:
```
66 0F 57 C0          xorpd       xmm0,xmm0
F2 41 0F C2 C6 06    cmpnlesd    xmm0,xmm14
66 45 0F 38 15 F2    blendvpd    xmm14,xmm10,xmm0
```