### PR TITLE
IOS/ES: Add Wii System Transfer to IOS62 SetUID whitelist

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -182,7 +182,7 @@ static ReturnCode CheckIsAllowedToSetUID(Kernel& kernel, const u32 caller_uid,
   if (kernel.GetVersion() == 62)
   {
     const bool is_wiiu_transfer_tool =
-        active_tmd.IsValid() && (active_tmd.GetTitleId() | 0xFF) == 0x00010001'484353ff;
+        active_tmd.IsValid() && ((active_tmd.GetTitleId() | 0xFF) == 0x00010001'484353ff || (active_tmd.GetTitleId() | 0xFF) == 0x00010001'484354ff);
     if (is_wiiu_transfer_tool)
       return IPC_SUCCESS;
   }


### PR DESCRIPTION
The Wii System Transfer tool (used on the vWii) requires SetUID, which the vWii's IOS62 has an exception to allow. This PR fixes the "An error has occurred" screen that you would get when launching the Wii System Transfer tool on Dolphin.