### PR TITLE
Replace geckocodes.org with mirror codes.rc24.xyz

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -18,11 +18,9 @@ namespace Gecko
 {
 std::vector<GeckoCode> DownloadCodes(std::string gametdb_id, bool* succeeded)
 {
-  std::string endpoint{"https://www.geckocodes.org/txt.php?txt=" + gametdb_id};
+  // codes.rc24.xyz is a mirror of the now defunct geckocodes.org.
+  std::string endpoint{"https://codes.rc24.xyz/txt.php?txt=" + gametdb_id};
   Common::HttpRequest http;
-
-  // Circumvent high-tech DDOS protection
-  http.SetCookies("challenge=BitMitigate.com;");
 
   // The server always redirects once to the same location.
   http.FollowRedirects(1);


### PR DESCRIPTION
See PR #9132.