### PR TITLE
Fix build on FreeBSD i386 - nullptr vs VK_NULL_HANDLE

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -122,7 +122,7 @@ std::unique_ptr<VKTexture> VKTexture::CreateAdopted(const TextureConfig& tex_con
                                                     VkImageViewType view_type, VkImageLayout layout)
 {
   std::unique_ptr<VKTexture> texture = std::make_unique<VKTexture>(
-      tex_config, nullptr, image, layout, ComputeImageLayout::Undefined);
+      tex_config, VkDeviceMemory(VK_NULL_HANDLE), image, layout, ComputeImageLayout::Undefined);
   if (!texture->CreateView(view_type))
     return nullptr;
 

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.h
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.h
@@ -54,7 +54,7 @@ public:
   VkImageView GetView() const { return m_view; }
   VkImageLayout GetLayout() const { return m_layout; }
   VkFormat GetVkFormat() const { return GetVkFormatForHostTextureFormat(m_config.format); }
-  bool IsAdopted() const { return m_device_memory != nullptr; }
+  bool IsAdopted() const { return m_device_memory != VkDeviceMemory(VK_NULL_HANDLE); }
 
   static std::unique_ptr<VKTexture> Create(const TextureConfig& tex_config);
   static std::unique_ptr<VKTexture>


### PR DESCRIPTION
Hello,

I am getting errors on FreeBSD i386 (12.1-RELEASE/LLVM 8.0.1) when trying to build Dolphin 5.0.12716:

```
/usr/bin/c++ -DDATA_DIR=\"/usr/local/share/dolphin-emu/\" -DFMT_SHARED -DHAVE_EGL=1 -DHAVE_FFMPEG -DHAVE_X11=1 -DHAVE_XRANDR=1 -DUSE_ANALYTICS=1 -DUSE_MEMORYWATCHER=1 -DUSE_PIPES=1 -DUSE_UPNP -D_ARCH_32=1 -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_M_GENERIC=1 -D__LIBUSB__ -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Source/Core -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/enet/include -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/External/minizip -I/usr/local/include/libpng16 -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/soundtouch -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/picojson -ISource/Core -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/Vulkan/Include -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/minizip/. -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/cubeb/include -Iexports -I/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/xxhash -isystem /usr/local/include -isystem /wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/glslang/StandAlone -isystem /wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/glslang/glslang/Public -isystem /wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/glslang/SPIRV -isystem /wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/glslang -isystem /wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Externals/rangeset/include -isystem /usr/local/include/hidapi -O2 -pipe -DLIBICONV_PLUG -fstack-protector-strong -fno-strict-aliasing  -DLZO_CFG_PREFER_TYPEOF_ACC_INT32E_T=LZO_TYPEOF_INT -DLIBICONV_PLUG -O2 -pipe -DLIBICONV_PLUG -fstack-protector-strong -fno-strict-aliasing  -DLZO_CFG_PREFER_TYPEOF_ACC_INT32E_T=LZO_TYPEOF_INT -DLIBICONV_PLUG -fdiagnostics-color -Wall -Wtype-limits -Wsign-compare -Wignored-qualifiers -Wuninitialized -Wshadow -Winit-self -Wmissing-declarations -Wmissing-variable-declarations -fno-strict-aliasing -fno-exceptions -fvisibility-inlines-hidden -fvisibility=hidden -fomit-frame-pointer -std=c++17 -MD -MT Source/Core/VideoBackends/Vulkan/CMakeFiles/videovulkan.dir/ObjectCache.cpp.o -MF Source/Core/VideoBackends/Vulkan/CMakeFiles/videovulkan.dir/ObjectCache.cpp.o.d -o Source/Core/VideoBackends/Vulkan/CMakeFiles/videovulkan.dir/ObjectCache.cpp.o -c /wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
In file included from /wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp:21:
/wrkdirs/usr/ports/emulators/dolphin-emu/work/dolphin-3152428/Source/Core/VideoBackends/Vulkan/VKTexture.h:57:51: error: invalid operands to binary expression ('const VkDeviceMemory' (aka 'const unsigned long long') and 'nullptr_t')
  bool IsAdopted() const { return m_device_memory != nullptr; }
                                  ~~~~~~~~~~~~~~~ ^  ~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
*** Error code 1

Stop.
```

This PR re-enables build for i386 (while still maintaining it buildable on amd64).

Warnings :
- I could not test the resulting Vulkan backend
- I am not sure this is the best way to fix that (comments welcome...)

Best regards,

Ganael.