### PR TITLE
Android: add reverse landscape to screen orientation settings

### DIFF
--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -435,11 +435,13 @@
 
     <string-array name="orientationEntries">
         <item>Landscape</item>
+        <item>Landscape (reverse)</item>
         <item>Portrait</item>
         <item>Auto</item>
     </string-array>
     <integer-array name="orientationValues">
         <item>0</item>
+        <item>8</item>
         <item>1</item>
         <item>-1</item>
     </integer-array>


### PR DESCRIPTION
Until now, when screen orientation is set to Landscape, the emulation activity will be fixed on a 90 degrees rotated position. 
This pull request aims at allowing 90 and 270 degrees landscape rotations, based on sensor data (independently of user android settings).

Controllers like the Gamesir X2, which have a USB Type-C port on the left will force the phone to a 270 degrees rotated state, so this is useful for those users (like me).