### PR TITLE
Re-enable GPU Texture Decoding under MoltenVK

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -346,10 +346,6 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   // with depth clamping. Fall back to inverted depth range for these.
   if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_REVERSED_DEPTH_RANGE))
     config->backend_info.bSupportsReversedDepthRange = false;
-
-  // GPU Texture Decoding is broken under MoltenVK.
-  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_GPU_TEXTURE_DECODING))
-    config->backend_info.bSupportsGPUTextureDecoding = false;
 }
 
 void VulkanContext::PopulateBackendInfoMultisampleModes(

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -118,8 +118,6 @@ constexpr BugInfo m_known_bugs[] = {
      -1.0, -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_QUALCOMM, DRIVER_QUALCOMM, Family::UNKNOWN,
      BUG_SLOW_CACHED_READBACK_MEMORY, -1.0, -1.0, true},
-    {API_VULKAN, OS_OSX, VENDOR_ALL, DRIVER_PORTABILITY, Family::UNKNOWN,
-     BUG_BROKEN_GPU_TEXTURE_DECODING, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -286,10 +286,6 @@ enum Bug
   // Mali Vulkan driver, causing high CPU usage in the __pi___inval_cache_range kernel
   // function. This flag causes readback buffers to select the coherent type.
   BUG_SLOW_CACHED_READBACK_MEMORY,
-
-  // BUG: GPU Texture Decoding produces a spectacular mess or just outright crashes when using
-  // Vulkan on macOS through MoltenVK.
-  BUG_BROKEN_GPU_TEXTURE_DECODING,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
Apparently working again with the MoltenVK update in #9126. This supersedes #9140 by not undoing the moving of the closing bracket. @Stenzek should we remove the DriverDetails bug itself as well, or keep it around in case it's needed again?

Would like to see some test cases just to be sure it's working properly.