### PR TITLE
WiimoteEmu: Expose IR camera FOV to adjust IMU pointing sensitivity. 

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.cpp
@@ -53,7 +53,7 @@ int CameraLogic::BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in)
   return RawWrite(&m_reg_data, addr, count, data_in);
 }
 
-void CameraLogic::Update(const Common::Matrix44& transform)
+void CameraLogic::Update(const Common::Matrix44& transform, Common::Vec2 field_of_view)
 {
   // IR data is read from offset 0x37 on real hardware.
   auto& data = m_reg_data.camera_data;
@@ -88,9 +88,9 @@ void CameraLogic::Update(const Common::Matrix44& transform)
       Vec3{SENSOR_BAR_LED_SEPARATION / 2, 0, 0},
   };
 
-  const auto camera_view = Matrix44::Perspective(CAMERA_FOV_Y, CAMERA_AR, 0.001f, 1000) *
-                           Matrix44::FromMatrix33(Matrix33::RotateX(float(MathUtil::TAU / 4))) *
-                           transform;
+  const auto camera_view =
+      Matrix44::Perspective(field_of_view.y, field_of_view.x / field_of_view.y, 0.001f, 1000) *
+      Matrix44::FromMatrix33(Matrix33::RotateX(float(MathUtil::TAU / 4))) * transform;
 
   struct CameraPoint
   {

--- a/Source/Core/Core/HW/WiimoteEmu/Camera.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Camera.h
@@ -112,7 +112,7 @@ public:
 
   void Reset();
   void DoState(PointerWrap& p);
-  void Update(const Common::Matrix44& transform);
+  void Update(const Common::Matrix44& transform, Common::Vec2 field_of_view);
   void SetEnabled(bool is_enabled);
 
   static constexpr u8 I2C_ADDR = 0x58;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -262,6 +262,8 @@ private:
   ControllerEmu::SettingValue<bool> m_upright_setting;
   ControllerEmu::SettingValue<double> m_battery_setting;
   ControllerEmu::SettingValue<bool> m_motion_plus_setting;
+  ControllerEmu::SettingValue<double> m_fov_x_setting;
+  ControllerEmu::SettingValue<double> m_fov_y_setting;
 
   SpeakerLogic m_speaker_logic;
   MotionPlus m_motion_plus;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -37,7 +37,7 @@ IMUCursor::IMUCursor(std::string name_, std::string ui_name_)
               // i18n: The symbol/abbreviation for degrees (unit of angular measure).
               _trans("°"),
               // i18n: Refers to emulated wii remote movements.
-              _trans("Total rotation about the yaw axis.")},
+              _trans("Clamping of rotation about the yaw axis.")},
              25, 0, 360);
 }
 


### PR DESCRIPTION
This exposes the previously hardcoded field of view of the camera.

I've located the settings under the Point group of the Motion Input tab as the most common use case will be to adjust the sensitivity of gyroscope-based pointing.

![image](https://user-images.githubusercontent.com/1768214/95664050-d9b41100-0b09-11eb-9e98-516e653ff77c.png)
