### PR TITLE
Android: Remove finish from ConfirmRunnableViewHolder

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -130,7 +130,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     if (!addToStack && getFragment() != null)
       return;
 
-    FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
+    final FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
     if (addToStack)
     {
@@ -160,6 +160,17 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
             getContentResolver(),
             Settings.Global.TRANSITION_ANIMATION_SCALE, 1);
     return duration != 0 && transition != 0;
+  }
+
+  @Override
+  public void reloadFragment()
+  {
+    final SettingsFragment fragment = getFragment();
+    final FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
+
+    transaction.detach(fragment);
+    transaction.attach(fragment);
+    transaction.commit();
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityView.java
@@ -18,6 +18,11 @@ public interface SettingsActivityView
   void showSettingsFragment(MenuTag menuTag, Bundle extras, boolean addToStack, String gameId);
 
   /**
+   * Reload the current fragment in case multiple settings are updated.
+   */
+  void reloadFragment();
+
+  /**
    * Called by a contained Fragment to get access to the Setting HashMap
    * loaded from disk, so that each Fragment doesn't need to perform its own
    * read operation.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -181,6 +181,12 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
   }
 
   @Override
+  public void reloadFragment()
+  {
+    mActivity.reloadFragment();
+  }
+
+  @Override
   public void showToastMessage(String message)
   {
     mActivity.showToastMessage(message);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentView.java
@@ -53,6 +53,11 @@ public interface SettingsFragmentView
   void loadSubMenu(MenuTag menuKey);
 
   /**
+   * Reload the current fragment in case multiple settings are updated.
+   */
+  void reloadFragment();
+
+  /**
    * Tell the Fragment to tell the containing activity to display a toast message.
    *
    * @param message Text to be shown in the Toast

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/viewholder/ConfirmRunnableViewHolder.java
@@ -74,8 +74,7 @@ public final class ConfirmRunnableViewHolder extends SettingViewHolder
               }
               dialog.dismiss();
 
-              // TODO: Remove finish and properly update dynamic settings descriptions.
-              mView.getActivity().finish();
+              mView.reloadFragment();
             })
             .setNegativeButton("No", (dialog, whichButton) ->
                     dialog.dismiss());


### PR DESCRIPTION
I'm not 100% sure of the implications of this change but it appears to fix the TODO in `ConfirmRunnableViewHolder`.