### PR TITLE
AudioStretcher: Keep default parameters.

### DIFF
--- a/Source/Core/AudioCommon/AudioStretcher.cpp
+++ b/Source/Core/AudioCommon/AudioStretcher.cpp
@@ -18,10 +18,6 @@ AudioStretcher::AudioStretcher(unsigned int sample_rate) : m_sample_rate(sample_
   m_sound_touch.setSampleRate(sample_rate);
   m_sound_touch.setPitch(1.0);
   m_sound_touch.setTempo(1.0);
-  m_sound_touch.setSetting(SETTING_USE_QUICKSEEK, 0);
-  m_sound_touch.setSetting(SETTING_SEQUENCE_MS, 62);
-  m_sound_touch.setSetting(SETTING_SEEKWINDOW_MS, 28);
-  m_sound_touch.setSetting(SETTING_OVERLAP_MS, 8);
 }
 
 void AudioStretcher::Clear()


### PR DESCRIPTION
A user said Citra's sound stretching sounding much better than ours.

Looking at their code about the only difference was some explicit settings in Dolphin.
https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/AudioCommon/AudioStretcher.cpp
https://github.com/citra-emu/citra/blob/master/src/audio_core/time_stretch.cpp

It looks like the default "sequence" and "seek window" adjust automatically with the tempo, maybe?

> By default, this setting value is calculated automatically according to tempo value.

https://www.surina.net/soundtouch/README.html

The user said this change improved audio stretching.
I don't know if I can tell a difference one way or the other.

Please test.