### PR TITLE
Android: Allow disabling cover downloading

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -121,6 +121,14 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
   }
 
   /**
+   * Re-fetches game metadata from the game file cache.
+   */
+  public void refetchMetadata()
+  {
+    notifyItemRangeChanged(0, getItemCount());
+  }
+
+  /**
    * Launches the game that was clicked on.
    *
    * @param view The card representing the game the user wants to play.

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocStringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocStringSetting.java
@@ -1,13 +1,13 @@
 package org.dolphinemu.dolphinemu.features.settings.model;
 
-public class AdHocBooleanSetting implements AbstractBooleanSetting
+public class AdHocStringSetting implements AbstractStringSetting
 {
   private final String mFile;
   private final String mSection;
   private final String mKey;
-  private final boolean mDefaultValue;
+  private final String mDefaultValue;
 
-  public AdHocBooleanSetting(String file, String section, String key, boolean defaultValue)
+  public AdHocStringSetting(String file, String section, String key, String defaultValue)
   {
     mFile = file;
     mSection = section;
@@ -39,20 +39,19 @@ public class AdHocBooleanSetting implements AbstractBooleanSetting
   }
 
   @Override
-  public boolean getBoolean(Settings settings)
+  public String getString(Settings settings)
   {
-    return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
+    return NativeConfig.getString(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
 
   @Override
-  public void setBoolean(Settings settings, boolean newValue)
+  public void setString(Settings settings, String newValue)
   {
-    NativeConfig.setBoolean(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
+    NativeConfig.setString(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
   }
 
-  public static boolean getBooleanGlobal(String file, String section, String key,
-          boolean defaultValue)
+  public static String getStringGlobal(String file, String section, String key, String defaultValue)
   {
-    return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, file, section, key, defaultValue);
+    return NativeConfig.getString(NativeConfig.LAYER_ACTIVE, file, section, key, defaultValue);
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -191,4 +191,9 @@ public enum BooleanSetting implements AbstractBooleanSetting
       settings.getSection(mFile, mSection).setBoolean(mKey, newValue);
     }
   }
+
+  public boolean getBooleanGlobal()
+  {
+    return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -38,6 +38,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
 
   MAIN_RECURSIVE_ISO_PATHS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GENERAL,
           "RecursiveISOPaths", false),
+  MAIN_USE_GAME_COVERS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_GENERAL,
+          "UseGameCovers", true),
 
   SYSCONF_SCREENSAVER(Settings.FILE_SYSCONF, "IPL", "SSV", false),
   SYSCONF_WIDESCREEN(Settings.FILE_SYSCONF, "IPL", "AR", true),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
@@ -73,4 +73,9 @@ public enum FloatSetting implements AbstractFloatSetting
       settings.getSection(mFile, mSection).setFloat(mKey, newValue);
     }
   }
+
+  public float getFloatGlobal()
+  {
+    return NativeConfig.getFloat(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -130,4 +130,9 @@ public enum IntSetting implements AbstractIntSetting
       settings.getSection(mFile, mSection).setInt(mKey, newValue);
     }
   }
+
+  public int getIntGlobal()
+  {
+    return NativeConfig.getInt(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
@@ -104,4 +104,9 @@ public enum StringSetting implements AbstractStringSetting
       settings.getSection(mFile, mSection).setString(mKey, newValue);
     }
   }
+
+  public String getStringGlobal()
+  {
+    return NativeConfig.getString(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
+  }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -224,7 +224,6 @@ public final class SettingsFragmentPresenter
     sl.add(new SubmenuSetting(R.string.advanced_submenu, MenuTag.CONFIG_ADVANCED));
     sl.add(new SubmenuSetting(R.string.log_submenu, MenuTag.CONFIG_LOG));
     sl.add(new SubmenuSetting(R.string.debug_submenu, MenuTag.DEBUG));
-    sl.add(new HeaderSetting(R.string.gametdb_thanks, 0));
   }
 
   private void addGeneralSettings(ArrayList<SettingsItem> sl)
@@ -247,6 +246,8 @@ public final class SettingsFragmentPresenter
             R.string.panic_handlers_description));
     sl.add(new CheckBoxSetting(BooleanSetting.MAIN_OSD_MESSAGES, R.string.osd_messages,
             R.string.osd_messages_description));
+    sl.add(new CheckBoxSetting(BooleanSetting.MAIN_USE_GAME_COVERS, R.string.download_game_covers,
+            0));
   }
 
   private void addAudioSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -152,8 +152,7 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 
     LinearLayout options = requireView().findViewById(R.id.layout_options);
 
-    Settings settings = ((EmulationActivity) requireActivity()).getSettings();
-    boolean savestatesEnabled = BooleanSetting.MAIN_ENABLE_SAVESTATES.getBoolean(settings);
+    boolean savestatesEnabled = BooleanSetting.MAIN_ENABLE_SAVESTATES.getBooleanGlobal();
     int savestateVisibility = savestatesEnabled ? View.VISIBLE : View.GONE;
     options.findViewById(R.id.menu_quicksave).setVisibility(savestateVisibility);
     options.findViewById(R.id.menu_quickload).setVisibility(savestateVisibility);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
@@ -81,12 +81,7 @@ public class GameFileCache
    */
   public boolean scanLibrary(Context context)
   {
-    boolean recursiveScan;
-    try (Settings settings = new Settings())
-    {
-      settings.loadSettings(null);
-      recursiveScan = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.getBoolean(settings);
-    }
+    boolean recursiveScan = BooleanSetting.MAIN_RECURSIVE_ISO_PATHS.getBooleanGlobal();
 
     removeNonExistentGameFolders(context);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -291,11 +291,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
       }
     });
 
-    try (Settings settings = new Settings())
-    {
-      settings.loadSettings(null);
-      mViewPager.setCurrentItem(IntSetting.MAIN_LAST_PLATFORM_TAB.getInt(settings));
-    }
+    mViewPager.setCurrentItem(IntSetting.MAIN_LAST_PLATFORM_TAB.getIntGlobal());
 
     showGames();
     GameFileCacheService.startLoad(this);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -87,6 +87,10 @@ public final class MainActivity extends AppCompatActivity implements MainView
 
     mPresenter.addDirIfNeeded(this);
 
+    // In case the user changed a setting that affects how games are displayed,
+    // such as system language, cover downloading...
+    refetchMetadata();
+
     if (sShouldRescanLibrary)
     {
       GameFileCacheService.startRescan(this);
@@ -252,6 +256,18 @@ public final class MainActivity extends AppCompatActivity implements MainView
       if (fragment != null)
       {
         fragment.showGames();
+      }
+    }
+  }
+
+  private void refetchMetadata()
+  {
+    for (Platform platform : Platform.values())
+    {
+      PlatformGamesView fragment = getPlatformGamesView(platform);
+      if (fragment != null)
+      {
+        fragment.refetchMetadata();
       }
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -32,6 +32,7 @@ import org.dolphinemu.dolphinemu.utils.StartupHandler;
 import org.dolphinemu.dolphinemu.utils.TvUtil;
 import org.dolphinemu.dolphinemu.viewholders.TvGameViewHolder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 public final class TvMainActivity extends FragmentActivity implements MainView
@@ -41,6 +42,8 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   private MainPresenter mPresenter = new MainPresenter(this, this);
 
   private BrowseSupportFragment mBrowseFragment;
+
+  private ArrayList<ArrayObjectAdapter> mGameRows = new ArrayList<>();
 
   @Override
   protected void onCreate(Bundle savedInstanceState)
@@ -71,6 +74,10 @@ public final class TvMainActivity extends FragmentActivity implements MainView
     }
 
     mPresenter.addDirIfNeeded(this);
+
+    // In case the user changed a setting that affects how games are displayed,
+    // such as system language, cover downloading...
+    refetchMetadata();
 
     if (sShouldRescanLibrary)
     {
@@ -185,6 +192,14 @@ public final class TvMainActivity extends FragmentActivity implements MainView
     buildRowsAdapter();
   }
 
+  private void refetchMetadata()
+  {
+    for (ArrayObjectAdapter row : mGameRows)
+    {
+      row.notifyArrayItemRangeChanged(0, row.size());
+    }
+  }
+
   /**
    * Callback from AddDirectoryActivity. Applies any changes necessary to the GameGridActivity.
    *
@@ -247,6 +262,7 @@ public final class TvMainActivity extends FragmentActivity implements MainView
   private void buildRowsAdapter()
   {
     ArrayObjectAdapter rowsAdapter = new ArrayObjectAdapter(new ListRowPresenter());
+    mGameRows.clear();
 
     if (PermissionsHandler.hasWriteAccess(this))
     {
@@ -280,6 +296,9 @@ public final class TvMainActivity extends FragmentActivity implements MainView
     // Create an adapter for this row.
     ArrayObjectAdapter row = new ArrayObjectAdapter(new GameRowPresenter());
     row.addAll(0, gameFiles);
+
+    // Keep a reference to the row in case we need to refresh it.
+    mGameRows.add(row);
 
     // Create a header for this row.
     HeaderItem header = new HeaderItem(platform.toInt(), platform.getHeaderName());

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesFragment.java
@@ -85,6 +85,12 @@ public final class PlatformGamesFragment extends Fragment implements PlatformGam
     }
   }
 
+  @Override
+  public void refetchMetadata()
+  {
+    mAdapter.refetchMetadata();
+  }
+
   private void findViews(View root)
   {
     mRecyclerView = root.findViewById(R.id.grid_games);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesView.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/platform/PlatformGamesView.java
@@ -25,4 +25,9 @@ public interface PlatformGamesView
    * To be called when the game file cache is updated.
    */
   void showGames();
+
+  /**
+   * Re-fetches game metadata from the game file cache.
+   */
+  void refetchMetadata();
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -24,44 +24,41 @@ public class Analytics
   {
     new AfterDirectoryInitializationRunner().run(context, false, () ->
     {
-      Settings settings = new Settings();
-      settings.loadSettings(null);
-      if (!BooleanSetting.MAIN_ANALYTICS_PERMISSION_ASKED.getBoolean(settings))
+      if (!BooleanSetting.MAIN_ANALYTICS_PERMISSION_ASKED.getBooleanGlobal())
       {
-        showMessage(context, settings);
-      }
-      else
-      {
-        settings.close();
+        showMessage(context);
       }
     });
   }
 
-  private static void showMessage(Context context, Settings settings)
+  private static void showMessage(Context context)
   {
     new AlertDialog.Builder(context, R.style.DolphinDialogBase)
             .setTitle(context.getString(R.string.analytics))
             .setMessage(context.getString(R.string.analytics_desc))
             .setPositiveButton(R.string.yes, (dialogInterface, i) ->
             {
-              firstAnalyticsAdd(settings, true);
+              firstAnalyticsAdd(true);
             })
             .setNegativeButton(R.string.no, (dialogInterface, i) ->
             {
-              firstAnalyticsAdd(settings, false);
+              firstAnalyticsAdd(false);
             })
             .show();
   }
 
-  private static void firstAnalyticsAdd(Settings settings, boolean enabled)
+  private static void firstAnalyticsAdd(boolean enabled)
   {
-    BooleanSetting.MAIN_ANALYTICS_ENABLED.setBoolean(settings, enabled);
-    BooleanSetting.MAIN_ANALYTICS_PERMISSION_ASKED.setBoolean(settings, true);
+    try (Settings settings = new Settings())
+    {
+      settings.loadSettings(null);
 
-    // Context is set to null to avoid toasts
-    settings.saveSettings(null, null);
+      BooleanSetting.MAIN_ANALYTICS_ENABLED.setBoolean(settings, enabled);
+      BooleanSetting.MAIN_ANALYTICS_PERMISSION_ASKED.setBoolean(settings, true);
 
-    settings.close();
+      // Context is set to null to avoid toasts
+      settings.saveSettings(null, null);
+    }
   }
 
   public static void sendReport(String endpoint, byte[] data)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/PicassoUtils.java
@@ -10,6 +10,7 @@ import com.squareup.picasso.Callback;
 import com.squareup.picasso.Picasso;
 
 import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
 import org.dolphinemu.dolphinemu.model.GameFile;
 
 import java.io.File;
@@ -62,7 +63,7 @@ public class PicassoUtils
     }
     // GameTDB has a pretty close to complete collection for US/EN covers. First pass at getting
     // the cover will be by the disk's region, second will be the US cover, and third EN.
-    else
+    else if (BooleanSetting.MAIN_USE_GAME_COVERS.getBooleanGlobal())
     {
       Picasso.get()
               .load(CoverHelper.buildGameTDBUrl(gameFile, CoverHelper.getRegion(gameFile)))
@@ -135,6 +136,17 @@ public class PicassoUtils
                           });
                 }
               });
+    }
+    else
+    {
+      Picasso.get()
+              .load(R.drawable.no_banner)
+              .noFade()
+              .noPlaceholder()
+              .fit()
+              .centerInside()
+              .config(Bitmap.Config.ARGB_8888)
+              .into(imageView);
     }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Rumble.java
@@ -9,6 +9,7 @@ import android.util.SparseArray;
 import android.view.InputDevice;
 
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+import org.dolphinemu.dolphinemu.features.settings.model.AdHocStringSetting;
 import org.dolphinemu.dolphinemu.features.settings.model.Settings;
 import org.dolphinemu.dolphinemu.features.settings.utils.SettingsFile;
 
@@ -28,9 +29,8 @@ public class Rumble
 
     for (int i = 0; i < 8; i++)
     {
-      String deviceName = activity.getSettings()
-              .getSection(Settings.FILE_DOLPHIN, Settings.SECTION_BINDINGS)
-              .getString(SettingsFile.KEY_EMU_RUMBLE + i, "");
+      String deviceName = AdHocStringSetting.getStringGlobal(Settings.FILE_DOLPHIN,
+              Settings.SECTION_BINDINGS, SettingsFile.KEY_EMU_RUMBLE + i, "");
 
       if (!deviceName.isEmpty())
       {

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -158,7 +158,6 @@
     <string name="lock_emulation_landscape_desc">Some touch controls will require additional tweaking if played in portrait</string>
     <string name="analytics">Enable usage statistics reporting</string>
     <string name="analytics_desc">If authorized, Dolphin can collect data on its performance, feature usage, and configuration, as well as data on your system\'s hardware and operating system.\n\nNo private data is ever collected. This data helps us understand how people and emulated games use Dolphin and prioritize our efforts. It also helps us identify rare configurations that are causing bugs, performance and stability issues. This authorization can be revoked at any time through Dolphin\'s settings.</string>
-    <string name="gametdb_thanks">Thanks to GameTDB.com for providing GameCube and Wii covers!</string>
 
     <!-- Interface Preference Fragment -->
     <string name="interface_submenu">Interface</string>
@@ -166,6 +165,7 @@
     <string name="panic_handlers_description">Show a message box when a potentially serious error has occurred. Disabling this may avoid annoying and non-fatal messages, but it may result in major crashes having no explanation at all.</string>
     <string name="osd_messages">Show On-Screen Display Messages</string>
     <string name="osd_messages_description">Display messages over the emulation screen area. These messages include memory card writes, video backend and CPU information, and JIT cache clearing.</string>
+    <string name="download_game_covers">Download Game Covers from GameTDB.com</string>
 
     <!-- Audio Settings -->
     <string name="audio_submenu">Audio</string>

--- a/Source/Core/Core/Config/UISettings.cpp
+++ b/Source/Core/Core/Config/UISettings.cpp
@@ -9,7 +9,11 @@ namespace Config
 // UI.General
 
 const Info<bool> MAIN_USE_DISCORD_PRESENCE{{System::Main, "General", "UseDiscordPresence"}, true};
+#ifdef ANDROID
+const Info<bool> MAIN_USE_GAME_COVERS{{System::Main, "General", "UseGameCovers"}, true};
+#else
 const Info<bool> MAIN_USE_GAME_COVERS{{System::Main, "General", "UseGameCovers"}, false};
+#endif
 const Info<bool> MAIN_FOCUSED_HOTKEYS{{System::Main, "General", "HotkeysRequireFocus"}, true};
 const Info<bool> MAIN_RECURSIVE_ISO_PATHS{{System::Main, "General", "RecursiveISOPaths"}, false};
 

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -52,6 +52,17 @@ namespace UICommon
 namespace
 {
 const std::string EMPTY_STRING;
+
+bool UseGameCovers()
+{
+#ifdef ANDROID
+  // Android has its own code for handling covers, written completely in Java.
+  // It's best if we disable the C++ cover code on Android to avoid duplicated data and such.
+  return false;
+#else
+  return Config::Get(Config::MAIN_USE_GAME_COVERS);
+#endif
+}
 }  // Anonymous namespace
 
 DiscIO::Language GameFile::GetConfigLanguage() const
@@ -169,7 +180,7 @@ bool GameFile::IsValid() const
 
 bool GameFile::CustomCoverChanged()
 {
-  if (!m_custom_cover.buffer.empty() || !Config::Get(Config::MAIN_USE_GAME_COVERS))
+  if (!m_custom_cover.buffer.empty() || !UseGameCovers())
     return false;
 
   std::string path, name;
@@ -196,7 +207,7 @@ bool GameFile::CustomCoverChanged()
 
 void GameFile::DownloadDefaultCover()
 {
-  if (!m_default_cover.buffer.empty() || !Config::Get(Config::MAIN_USE_GAME_COVERS))
+  if (!m_default_cover.buffer.empty() || !UseGameCovers())
     return;
 
   const auto cover_path = File::GetUserPath(D_COVERCACHE_IDX) + DIR_SEP;
@@ -262,7 +273,7 @@ void GameFile::DownloadDefaultCover()
 
 bool GameFile::DefaultCoverChanged()
 {
-  if (!m_default_cover.buffer.empty() || !Config::Get(Config::MAIN_USE_GAME_COVERS))
+  if (!m_default_cover.buffer.empty() || !UseGameCovers())
     return false;
 
   const auto cover_path = File::GetUserPath(D_COVERCACHE_IDX) + DIR_SEP;


### PR DESCRIPTION
In case someone wants to be very careful with how much bandwidth they use or with what data GameTDB.com collects on you. This is already an option in DolphinQt (though in DolphinQt it will switch entirely from using covers to banners when turned off).