### PR TITLE
WiimoteEmu: Expose IMU pointing accelerometer weight setting.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -320,10 +320,10 @@ void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_gr
   state->rotation = gyro_rotation * state->rotation;
 
   // If we have some non-zero accel data use it to adjust gyro drift.
-  constexpr auto ACCEL_WEIGHT = 0.02f;
+  const auto accel_weight = imu_ir_group->GetAccelWeight();
   auto const accel = imu_accelerometer_group->GetState().value_or(Common::Vec3{});
   if (accel.LengthSquared())
-    state->rotation = ComplementaryFilter(state->rotation, accel, ACCEL_WEIGHT);
+    state->rotation = ComplementaryFilter(state->rotation, accel, accel_weight);
 
   // Clamp yaw within configured bounds.
   const auto yaw = GetYaw(state->rotation);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.cpp
@@ -38,11 +38,26 @@ IMUCursor::IMUCursor(std::string name_, std::string ui_name_)
               // i18n: Refers to emulated wii remote movements.
               _trans("Clamping of rotation about the yaw axis.")},
              25, 0, 360);
+
+  AddSetting(&m_accel_weight_setting,
+             {// i18n: Percentage value of accelerometer data (complementary filter coefficient).
+              _trans("Accelerometer Influence"),
+              // i18n: The symbol/abbreviation for percent.
+              _trans("%"),
+              // i18n: Refers to a setting controling the influence of accelerometer data.
+              _trans("Influence of accelerometer data on pitch and roll. Higher values will reduce "
+                     "drift at the cost of noise. Consider values between 1% and 3%.")},
+             2, 0, 100);
 }
 
 ControlState IMUCursor::GetTotalYaw() const
 {
   return m_yaw_setting.GetValue() * MathUtil::TAU / 360;
+}
+
+ControlState IMUCursor::GetAccelWeight() const
+{
+  return m_accel_weight_setting.GetValue() / 100;
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUCursor.h
@@ -19,7 +19,10 @@ public:
   // Yaw movement in radians.
   ControlState GetTotalYaw() const;
 
+  ControlState GetAccelWeight() const;
+
 private:
   SettingValue<double> m_yaw_setting;
+  SettingValue<double> m_accel_weight_setting;
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
Reducing this value can produce a less jittery pointer with reduced drift correction.

A user reported they had better results with 1% vs the default 2%.

The best name for the setting that I could come up with is "Accelerometer Influence".
I think it's descriptive and accurate enough. Anything else I can think if is ambiguous or too long.