### PR TITLE
Android: Fix setting read during play with local game layer active

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocBooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/AdHocBooleanSetting.java
@@ -35,18 +35,18 @@ public class AdHocBooleanSetting implements AbstractBooleanSetting
   @Override
   public boolean delete(Settings settings)
   {
-    return NativeConfig.deleteKey(settings.getActiveLayer(), mFile, mSection, mKey);
+    return NativeConfig.deleteKey(settings.getWriteLayer(), mFile, mSection, mKey);
   }
 
   @Override
   public boolean getBoolean(Settings settings)
   {
-    return NativeConfig.getBoolean(settings.getActiveLayer(), mFile, mSection, mKey, mDefaultValue);
+    return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
   }
 
   @Override
   public void setBoolean(Settings settings, boolean newValue)
   {
-    NativeConfig.setBoolean(settings.getActiveLayer(), mFile, mSection, mKey, newValue);
+    NativeConfig.setBoolean(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -157,7 +157,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.deleteKey(settings.getActiveLayer(), mFile, mSection, mKey);
+      return NativeConfig.deleteKey(settings.getWriteLayer(), mFile, mSection, mKey);
     }
     else
     {
@@ -170,7 +170,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.getBoolean(settings.getActiveLayer(), mFile, mSection, mKey,
+      return NativeConfig.getBoolean(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey,
               mDefaultValue);
     }
     else
@@ -184,7 +184,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      NativeConfig.setBoolean(settings.getActiveLayer(), mFile, mSection, mKey, newValue);
+      NativeConfig.setBoolean(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
     }
     else
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
@@ -40,7 +40,7 @@ public enum FloatSetting implements AbstractFloatSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.deleteKey(settings.getActiveLayer(), mFile, mSection, mKey);
+      return NativeConfig.deleteKey(settings.getWriteLayer(), mFile, mSection, mKey);
     }
     else
     {
@@ -53,7 +53,7 @@ public enum FloatSetting implements AbstractFloatSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.getFloat(settings.getActiveLayer(), mFile, mSection, mKey, mDefaultValue);
+      return NativeConfig.getFloat(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
     }
     else
     {
@@ -66,7 +66,7 @@ public enum FloatSetting implements AbstractFloatSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      NativeConfig.setFloat(settings.getActiveLayer(), mFile, mSection, mKey, newValue);
+      NativeConfig.setFloat(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
     }
     else
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -97,7 +97,7 @@ public enum IntSetting implements AbstractIntSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.deleteKey(settings.getActiveLayer(), mFile, mSection, mKey);
+      return NativeConfig.deleteKey(settings.getWriteLayer(), mFile, mSection, mKey);
     }
     else
     {
@@ -110,7 +110,7 @@ public enum IntSetting implements AbstractIntSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.getInt(settings.getActiveLayer(), mFile, mSection, mKey, mDefaultValue);
+      return NativeConfig.getInt(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey, mDefaultValue);
     }
     else
     {
@@ -123,7 +123,7 @@ public enum IntSetting implements AbstractIntSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      NativeConfig.setInt(settings.getActiveLayer(), mFile, mSection, mKey, newValue);
+      NativeConfig.setInt(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
     }
     else
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/NativeConfig.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/NativeConfig.java
@@ -4,6 +4,7 @@ public class NativeConfig
 {
   public static final int LAYER_BASE_OR_CURRENT = 0;
   public static final int LAYER_LOCAL_GAME = 1;
+  public static final int LAYER_ACTIVE = 2;
 
   public static native boolean isSettingSaveable(String file, String section, String key);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -86,7 +86,7 @@ public class Settings implements Closeable
     return !TextUtils.isEmpty(mGameId);
   }
 
-  public int getActiveLayer()
+  public int getWriteLayer()
   {
     return isGameSpecific() ? NativeConfig.LAYER_LOCAL_GAME : NativeConfig.LAYER_BASE_OR_CURRENT;
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/StringSetting.java
@@ -70,7 +70,7 @@ public enum StringSetting implements AbstractStringSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.deleteKey(settings.getActiveLayer(), mFile, mSection, mKey);
+      return NativeConfig.deleteKey(settings.getWriteLayer(), mFile, mSection, mKey);
     }
     else
     {
@@ -83,7 +83,7 @@ public enum StringSetting implements AbstractStringSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      return NativeConfig.getString(settings.getActiveLayer(), mFile, mSection, mKey,
+      return NativeConfig.getString(NativeConfig.LAYER_ACTIVE, mFile, mSection, mKey,
               mDefaultValue);
     }
     else
@@ -97,7 +97,7 @@ public enum StringSetting implements AbstractStringSetting
   {
     if (NativeConfig.isSettingSaveable(mFile, mSection, mKey))
     {
-      NativeConfig.setString(settings.getActiveLayer(), mFile, mSection, mKey, newValue);
+      NativeConfig.setString(settings.getWriteLayer(), mFile, mSection, mKey, newValue);
     }
     else
     {

--- a/Source/Android/jni/NativeConfig.cpp
+++ b/Source/Android/jni/NativeConfig.cpp
@@ -15,6 +15,7 @@
 
 constexpr jint LAYER_BASE_OR_CURRENT = 0;
 constexpr jint LAYER_LOCAL_GAME = 1;
+constexpr jint LAYER_ACTIVE = 2;
 
 static Config::Location GetLocation(JNIEnv* env, jstring file, jstring section, jstring key)
 {
@@ -48,21 +49,31 @@ static Config::Location GetLocation(JNIEnv* env, jstring file, jstring section, 
 
 static std::shared_ptr<Config::Layer> GetLayer(jint layer, const Config::Location& location)
 {
+  Config::LayerType layer_type;
+
   switch (layer)
   {
   case LAYER_BASE_OR_CURRENT:
     if (GetActiveLayerForConfig(location) == Config::LayerType::Base)
-      return Config::GetLayer(Config::LayerType::Base);
+      layer_type = Config::LayerType::Base;
     else
-      return Config::GetLayer(Config::LayerType::CurrentRun);
+      layer_type = Config::LayerType::CurrentRun;
+    break;
 
   case LAYER_LOCAL_GAME:
-    return Config::GetLayer(Config::LayerType::LocalGame);
+    layer_type = Config::LayerType::LocalGame;
+    break;
+
+  case LAYER_ACTIVE:
+    layer_type = Config::GetActiveLayerForConfig(location);
+    break;
 
   default:
     ASSERT(false);
     return nullptr;
   }
+
+  return Config::GetLayer(layer_type);
 }
 
 template <typename T>


### PR DESCRIPTION
During emulation, when `LocalGame` has a value but `CurrentRun` doesn't, we want to read from `LocalGame`, not `CurrentRun`. This change exposes a `LAYER_ACTIVE` option that handles this correctly.