### PR TITLE
Source/Core/DiscIO/WIACompression.cpp: add missing <limits> include

### DIFF
--- a/Source/Core/DiscIO/WIACompression.cpp
+++ b/Source/Core/DiscIO/WIACompression.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <vector>


### PR DESCRIPTION
Noticed missing include as a build failure on gcc-11:

```
[ 26%] Building CXX object Source/Core/DiscIO/CMakeFiles/discio.dir/WIACompression.cpp.o
../../../../Source/Core/DiscIO/WIACompression.cpp: In lambda function:
../../../../Source/Core/DiscIO/WIACompression.cpp:170:31: error: 'numeric_limits' is not a member of 'std'
  170 |         std::min<size_t>(std::numeric_limits<unsigned int>().max(), x));
      |                               ^~~~~~~~~~~~~~
../../../../Source/Core/DiscIO/WIACompression.cpp:170:46: error: expected primary-expression before 'unsigned'
  170 |         std::min<size_t>(std::numeric_limits<unsigned int>().max(), x));
      |                                              ^~~~~~~~
```