### PR TITLE
DolphinQt: Reset TAS input slider to default on right-click

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -277,6 +277,8 @@ add_executable(dolphin-emu
   TAS/TASCheckBox.h
   TAS/TASInputWindow.cpp
   TAS/TASInputWindow.h
+  TAS/TASSlider.cpp
+  TAS/TASSlider.h
   TAS/StickWidget.cpp
   TAS/StickWidget.h
   TAS/IRWidget.cpp

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="TAS\StickWidget.cpp" />
     <ClCompile Include="TAS\TASCheckBox.cpp" />
     <ClCompile Include="TAS\TASInputWindow.cpp" />
+    <ClCompile Include="TAS\TASSlider.cpp" />
     <ClCompile Include="TAS\WiiTASInputWindow.cpp" />
     <ClCompile Include="ToolBar.cpp" />
     <ClCompile Include="Translation.cpp" />
@@ -321,6 +322,7 @@
     <QtMoc Include="TAS\StickWidget.h" />
     <QtMoc Include="TAS\TASCheckBox.h" />
     <QtMoc Include="TAS\TASInputWindow.h" />
+    <QtMoc Include="TAS\TASSlider.h" />
     <QtMoc Include="TAS\WiiTASInputWindow.h" />
     <QtMoc Include="ToolBar.h" />
     <QtMoc Include="Updater.h" />

--- a/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/GCTASInputWindow.cpp
@@ -34,9 +34,9 @@ GCTASInputWindow::GCTASInputWindow(QWidget* parent, int num) : TASInputWindow(pa
   m_triggers_box = new QGroupBox(tr("Triggers"));
 
   auto* l_trigger_layout =
-      CreateSliderValuePairLayout(tr("Left"), m_l_trigger_value, 255, Qt::Key_N, m_triggers_box);
-  auto* r_trigger_layout =
-      CreateSliderValuePairLayout(tr("Right"), m_r_trigger_value, 255, Qt::Key_M, m_triggers_box);
+      CreateSliderValuePairLayout(tr("Left"), m_l_trigger_value, 0, 255, Qt::Key_N, m_triggers_box);
+  auto* r_trigger_layout = CreateSliderValuePairLayout(tr("Right"), m_r_trigger_value, 0, 255,
+                                                       Qt::Key_M, m_triggers_box);
 
   auto* triggers_layout = new QVBoxLayout;
   triggers_layout->addLayout(l_trigger_layout);

--- a/Source/Core/DolphinQt/TAS/TASInputWindow.h
+++ b/Source/Core/DolphinQt/TAS/TASInputWindow.h
@@ -30,12 +30,12 @@ protected:
   TASCheckBox* CreateButton(const QString& name);
   QGroupBox* CreateStickInputs(QString name, QSpinBox*& x_value, QSpinBox*& y_value, u16 max_x,
                                u16 max_y, Qt::Key x_shortcut_key, Qt::Key y_shortcut_key);
-  QBoxLayout* CreateSliderValuePairLayout(QString name, QSpinBox*& value, u16 max,
+  QBoxLayout* CreateSliderValuePairLayout(QString name, QSpinBox*& value, int default_, u16 max,
                                           Qt::Key shortcut_key, QWidget* shortcut_widget,
                                           bool invert = false);
-  QSpinBox* CreateSliderValuePair(QBoxLayout* layout, u16 max, QKeySequence shortcut_key_sequence,
-                                  Qt::Orientation orientation, QWidget* shortcut_widget,
-                                  bool invert = false);
+  QSpinBox* CreateSliderValuePair(QBoxLayout* layout, int default_, u16 max,
+                                  QKeySequence shortcut_key_sequence, Qt::Orientation orientation,
+                                  QWidget* shortcut_widget, bool invert = false);
   template <typename UX>
   void GetButton(TASCheckBox* button, UX& pad, UX mask);
   void GetSpinBoxU8(QSpinBox* spin, u8& controller_value);

--- a/Source/Core/DolphinQt/TAS/TASSlider.cpp
+++ b/Source/Core/DolphinQt/TAS/TASSlider.cpp
@@ -1,0 +1,24 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/TAS/TASSlider.h"
+
+#include <QMouseEvent>
+
+TASSlider::TASSlider(int default_, QWidget* parent) : QSlider(parent), m_default(default_)
+{
+}
+
+TASSlider::TASSlider(int default_, Qt::Orientation orientation, QWidget* parent)
+    : QSlider(orientation, parent), m_default(default_)
+{
+}
+
+void TASSlider::mouseReleaseEvent(QMouseEvent* event)
+{
+  if (event->button() == Qt::RightButton)
+    setValue(m_default);
+  else
+    QSlider::mouseReleaseEvent(event);
+}

--- a/Source/Core/DolphinQt/TAS/TASSlider.h
+++ b/Source/Core/DolphinQt/TAS/TASSlider.h
@@ -1,0 +1,22 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QSlider>
+
+class QMouseEvent;
+
+class TASSlider : public QSlider
+{
+public:
+  explicit TASSlider(int default_, QWidget* parent = nullptr);
+  explicit TASSlider(int default_, Qt::Orientation orientation, QWidget* parent = nullptr);
+
+protected:
+  void mouseReleaseEvent(QMouseEvent* event) override;
+
+private:
+  int m_default;
+};

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -48,23 +48,26 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
                                     ir_x_shortcut_key_sequence.toString(QKeySequence::NativeText),
                                     ir_y_shortcut_key_sequence.toString(QKeySequence::NativeText)));
 
+  const int ir_x_default = static_cast<int>(std::round(ir_max_x / 2.));
+  const int ir_y_default = static_cast<int>(std::round(ir_max_y / 2.));
+
   auto* x_layout = new QHBoxLayout;
-  m_ir_x_value = CreateSliderValuePair(x_layout, ir_max_x, ir_x_shortcut_key_sequence,
+  m_ir_x_value = CreateSliderValuePair(x_layout, ir_x_default, ir_max_x, ir_x_shortcut_key_sequence,
                                        Qt::Horizontal, m_ir_box, true);
 
   auto* y_layout = new QVBoxLayout;
-  m_ir_y_value = CreateSliderValuePair(y_layout, ir_max_y, ir_y_shortcut_key_sequence, Qt::Vertical,
-                                       m_ir_box, true);
+  m_ir_y_value = CreateSliderValuePair(y_layout, ir_y_default, ir_max_y, ir_y_shortcut_key_sequence,
+                                       Qt::Vertical, m_ir_box, true);
   m_ir_y_value->setMaximumWidth(60);
 
   auto* visual = new IRWidget(this);
+  visual->SetX(ir_x_default);
+  visual->SetY(ir_y_default);
+
   connect(m_ir_x_value, qOverload<int>(&QSpinBox::valueChanged), visual, &IRWidget::SetX);
   connect(m_ir_y_value, qOverload<int>(&QSpinBox::valueChanged), visual, &IRWidget::SetY);
   connect(visual, &IRWidget::ChangedX, m_ir_x_value, &QSpinBox::setValue);
   connect(visual, &IRWidget::ChangedY, m_ir_y_value, &QSpinBox::setValue);
-
-  m_ir_x_value->setValue(static_cast<int>(std::round(ir_max_x / 2.)));
-  m_ir_y_value->setValue(static_cast<int>(std::round(ir_max_y / 2.)));
 
   auto* visual_ar = new AspectRatioWidget(visual, ir_max_x, ir_max_y);
 
@@ -103,20 +106,16 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
 
   auto* remote_orientation_x_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("X"), m_remote_orientation_x_value, 1023, Qt::Key_Q,
+      CreateSliderValuePairLayout(tr("X"), m_remote_orientation_x_value, 512, 1023, Qt::Key_Q,
                                   m_remote_orientation_box);
   auto* remote_orientation_y_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Y"), m_remote_orientation_y_value, 1023, Qt::Key_W,
+      CreateSliderValuePairLayout(tr("Y"), m_remote_orientation_y_value, 512, 1023, Qt::Key_W,
                                   m_remote_orientation_box);
   auto* remote_orientation_z_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Z"), m_remote_orientation_z_value, 1023, Qt::Key_E,
+      CreateSliderValuePairLayout(tr("Z"), m_remote_orientation_z_value, 616, 1023, Qt::Key_E,
                                   m_remote_orientation_box);
-
-  m_remote_orientation_x_value->setValue(512);
-  m_remote_orientation_y_value->setValue(512);
-  m_remote_orientation_z_value->setValue(616);
 
   auto* remote_orientation_layout = new QVBoxLayout;
   remote_orientation_layout->addLayout(remote_orientation_x_layout);
@@ -128,20 +127,16 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
 
   auto* nunchuk_orientation_x_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("X"), m_nunchuk_orientation_x_value, 1023, Qt::Key_I,
+      CreateSliderValuePairLayout(tr("X"), m_nunchuk_orientation_x_value, 512, 1023, Qt::Key_I,
                                   m_nunchuk_orientation_box);
   auto* nunchuk_orientation_y_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Y"), m_nunchuk_orientation_y_value, 1023, Qt::Key_O,
+      CreateSliderValuePairLayout(tr("Y"), m_nunchuk_orientation_y_value, 512, 1023, Qt::Key_O,
                                   m_nunchuk_orientation_box);
   auto* nunchuk_orientation_z_layout =
       // i18n: Refers to a 3D axis (used when mapping motion controls)
-      CreateSliderValuePairLayout(tr("Z"), m_nunchuk_orientation_z_value, 1023, Qt::Key_P,
+      CreateSliderValuePairLayout(tr("Z"), m_nunchuk_orientation_z_value, 512, 1023, Qt::Key_P,
                                   m_nunchuk_orientation_box);
-
-  m_nunchuk_orientation_x_value->setValue(512);
-  m_nunchuk_orientation_y_value->setValue(512);
-  m_nunchuk_orientation_z_value->setValue(512);
 
   auto* nunchuk_orientation_layout = new QVBoxLayout;
   nunchuk_orientation_layout->addLayout(nunchuk_orientation_x_layout);
@@ -150,9 +145,9 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   m_nunchuk_orientation_box->setLayout(nunchuk_orientation_layout);
 
   m_triggers_box = new QGroupBox(tr("Triggers"));
-  auto* l_trigger_layout =
-      CreateSliderValuePairLayout(tr("Left"), m_left_trigger_value, 31, Qt::Key_N, m_triggers_box);
-  auto* r_trigger_layout = CreateSliderValuePairLayout(tr("Right"), m_right_trigger_value, 31,
+  auto* l_trigger_layout = CreateSliderValuePairLayout(tr("Left"), m_left_trigger_value, 0, 31,
+                                                       Qt::Key_N, m_triggers_box);
+  auto* r_trigger_layout = CreateSliderValuePairLayout(tr("Right"), m_right_trigger_value, 0, 31,
                                                        Qt::Key_M, m_triggers_box);
 
   auto* triggers_layout = new QVBoxLayout;


### PR DESCRIPTION
This is a feature which existed in DolphinWX. Seems like it got implemented in DolphinQt for IRWidget/StickWidget but not sliders.