### PR TITLE
WiimoteEmu: Allow tilt to wrap around and simulate full 360 degree rotations.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -120,9 +120,19 @@ void EmulateTilt(RotationalState* state, ControllerEmu::Tilt* const tilt_group, 
   const ControlState roll = target.x * MathUtil::PI;
   const ControlState pitch = target.y * MathUtil::PI;
 
+  const auto target_angle = Common::Vec3(pitch, -roll, 0);
+
+  // For each axis, wrap around current angle if target is farther than 180 degrees.
+  for (std::size_t i = 0; i != target_angle.data.size(); ++i)
+  {
+    auto& angle = state->angle.data[i];
+    if (std::abs(angle - target_angle.data[i]) > float(MathUtil::PI))
+      angle -= std::copysign(MathUtil::TAU, angle);
+  }
+
   const auto max_accel = std::pow(tilt_group->GetMaxRotationalVelocity(), 2) / MathUtil::TAU;
 
-  ApproachAngleWithAccel(state, Common::Vec3(pitch, -roll, 0), max_accel, time_elapsed);
+  ApproachAngleWithAccel(state, target_angle, max_accel, time_elapsed);
 }
 
 void EmulateSwing(MotionState* state, ControllerEmu::Force* swing_group, float time_elapsed)

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -415,8 +415,18 @@ void TiltIndicator::Draw()
 {
   WiimoteEmu::EmulateTilt(&m_motion_state, &m_group, 1.f / INDICATOR_UPDATE_FREQ);
 
-  const auto adj_coord =
-      Common::DVec2{-m_motion_state.angle.y, m_motion_state.angle.x} / MathUtil::PI;
+  auto adj_coord = Common::DVec2{-m_motion_state.angle.y, m_motion_state.angle.x} / MathUtil::PI;
+
+  // Angle values after dividing by pi.
+  constexpr auto norm_180_deg = 1;
+  constexpr auto norm_360_deg = 2;
+
+  // Angle may extend beyond 180 degrees when wrapping around.
+  // Apply modulo to draw within the indicator.
+  // Scale down the value a bit so +1 does not become -1.
+  adj_coord *= 0.9999f;
+  adj_coord.x = std::fmod(adj_coord.x + norm_360_deg + norm_180_deg, norm_360_deg) - norm_180_deg;
+  adj_coord.y = std::fmod(adj_coord.y + norm_360_deg + norm_180_deg, norm_360_deg) - norm_180_deg;
 
   DrawReshapableInput(m_group, TILT_GATE_COLOR,
                       (adj_coord.x || adj_coord.y) ? std::make_optional(adj_coord) : std::nullopt);


### PR DESCRIPTION
Emulated Wii remote's tilt simulation will now wrap around to reach the target angle in the shortest direction.

This can easily be triggered when the "Angle" setting is higher than 90 degrees (it's 85 by default).

A full 360 degree rotation required by some games is now possible.
Fixes: https://bugs.dolphin-emu.org/issues/12289