### PR TITLE
VertexShaderGen: Fix unescaped { in D3D shader.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -186,7 +186,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
     }
     if ((uid_data->components & VB_HAS_POSMTXIDX) != 0)
       out.WriteFmt("  uint4 posmtx : BLENDINDICES,\n");
-    out.WriteFmt("  float4 rawpos : POSITION) {\n");
+    out.WriteFmt("  float4 rawpos : POSITION) {{\n");
   }
 
   out.WriteFmt("VS_OUTPUT o;\n");


### PR DESCRIPTION
Fixes crash from #8981 when using D3D.