### PR TITLE
DiscIO: Make WiiEncryptionCache moveable

### DIFF
--- a/Source/Core/DiscIO/WiiEncryptionCache.cpp
+++ b/Source/Core/DiscIO/WiiEncryptionCache.cpp
@@ -29,7 +29,10 @@ WiiEncryptionCache::EncryptGroup(u64 offset, u64 partition_data_offset,
 {
   // Only allocate memory if this function actually ends up getting called
   if (!m_cache)
+  {
     m_cache = std::make_unique<std::array<u8, VolumeWii::GROUP_TOTAL_SIZE>>();
+    m_cached_offset = std::numeric_limits<u64>::max();
+  }
 
   ASSERT(offset % VolumeWii::GROUP_TOTAL_SIZE == 0);
   const u64 group_offset_in_partition =

--- a/Source/Core/DiscIO/WiiEncryptionCache.h
+++ b/Source/Core/DiscIO/WiiEncryptionCache.h
@@ -26,6 +26,14 @@ public:
   explicit WiiEncryptionCache(BlobReader* blob);
   ~WiiEncryptionCache();
 
+  WiiEncryptionCache(WiiEncryptionCache&&) = default;
+  WiiEncryptionCache& operator=(WiiEncryptionCache&&) = default;
+
+  // It would be possible to write a custom copy constructor and assignment operator
+  // for this class, but there has been no reason to do so.
+  WiiEncryptionCache(const WiiEncryptionCache&) = delete;
+  WiiEncryptionCache& operator=(const WiiEncryptionCache&) = delete;
+
   // Encrypts exactly one group.
   // If the returned pointer is nullptr, reading from the blob failed.
   // If the returned pointer is not nullptr, it is guaranteed to be valid until
@@ -43,7 +51,7 @@ public:
 private:
   BlobReader* m_blob;
   std::unique_ptr<std::array<u8, VolumeWii::GROUP_TOTAL_SIZE>> m_cache;
-  u64 m_cached_offset = std::numeric_limits<u64>::max();
+  u64 m_cached_offset;
 };
 
 }  // namespace DiscIO


### PR DESCRIPTION
Fixes the following warning:

```
../../../../../../Core\DiscIO/DirectoryBlob.h:156:3: warning: explicitly defaulted move constructor is implicitly deleted [-Wdefaulted-function-deleted]
  DirectoryBlobReader(DirectoryBlobReader&&) = default;
  ^
../../../../../../Core\DiscIO/DirectoryBlob.h:205:22: note: move constructor of 'DirectoryBlobReader' is implicitly deleted because field 'm_encryption_cache' has a deleted move constructor
  WiiEncryptionCache m_encryption_cache;
                     ^
```