### PR TITLE
DataReader: Make use of if constexpr where applicable

### DIFF
--- a/Source/Core/VideoCommon/DataReader.h
+++ b/Source/Core/VideoCommon/DataReader.h
@@ -30,7 +30,7 @@ public:
     T data;
     std::memcpy(&data, &buffer[offset], sizeof(T));
 
-    if (swapped)
+    if constexpr (swapped)
       data = Common::FromBigEndian(data);
 
     return data;
@@ -47,7 +47,7 @@ public:
   template <typename T, bool swapped = false>
   DOLPHIN_FORCE_INLINE void Write(T data)
   {
-    if (swapped)
+    if constexpr (swapped)
       data = Common::FromBigEndian(data);
 
     std::memcpy(buffer, &data, sizeof(T));


### PR DESCRIPTION
We can make use of if constexpr for cases where booleans will always statically be known at compile-time.