### PR TITLE
PixelShaderGen: Migrate over to fmt

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -164,10 +164,10 @@ struct pixel_shader_uid_data
 
 using PixelShaderUid = ShaderUid<pixel_shader_uid_data>;
 
-ShaderCode GeneratePixelShaderCode(APIType ApiType, const ShaderHostConfig& host_config,
+ShaderCode GeneratePixelShaderCode(APIType api_type, const ShaderHostConfig& host_config,
                                    const pixel_shader_uid_data* uid_data);
-void WritePixelShaderCommonHeader(ShaderCode& out, APIType ApiType, u32 num_texgens,
+void WritePixelShaderCommonHeader(ShaderCode& out, APIType api_type, u32 num_texgens,
                                   const ShaderHostConfig& host_config, bool bounding_box);
-void ClearUnusedPixelShaderUidBits(APIType ApiType, const ShaderHostConfig& host_config,
+void ClearUnusedPixelShaderUidBits(APIType api_type, const ShaderHostConfig& host_config,
                                    PixelShaderUid* uid);
 PixelShaderUid GetPixelShaderUid();


### PR DESCRIPTION
Continues the migration of the shader generators over to fmt.

After this, all that remains in the Ubershader pixel generator.