### PR TITLE
ExpressionParser: Add missing <functional> include

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Unbreaks Windows CMake builds.