### PR TITLE
Common/Log: Add basic fmt-capable functions to the interface.

### DIFF
--- a/Source/Core/AudioCommon/CubebUtils.cpp
+++ b/Source/Core/AudioCommon/CubebUtils.cpp
@@ -18,19 +18,19 @@ static ptrdiff_t s_path_cutoff_point = 0;
 
 static void LogCallback(const char* format, ...)
 {
-  if (!Common::Log::LogManager::GetInstance())
+  auto* instance = Common::Log::LogManager::GetInstance();
+  if (instance == nullptr)
     return;
 
   va_list args;
   va_start(args, format);
-
   const char* filename = va_arg(args, const char*) + s_path_cutoff_point;
-  int lineno = va_arg(args, int);
-  std::string adapted_format(StripSpaces(format + strlen("%s:%d:")));
-
-  Common::Log::LogManager::GetInstance()->LogWithFullPath(
-      Common::Log::LNOTICE, Common::Log::AUDIO, filename, lineno, adapted_format.c_str(), args);
+  const int lineno = va_arg(args, int);
+  const std::string adapted_format(StripSpaces(format + strlen("%s:%d:")));
+  const std::string message = StringFromFormatV(adapted_format.c_str(), args);
   va_end(args);
+
+  instance->Log(Common::Log::LNOTICE, Common::Log::AUDIO, filename, lineno, message.c_str());
 }
 
 static void DestroyContext(cubeb* ctx)

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -38,10 +38,7 @@ public:
   static void Init();
   static void Shutdown();
 
-  void Log(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, const char* fmt,
-           va_list args);
-  void LogWithFullPath(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, const char* fmt,
-                       va_list args);
+  void Log(LOG_LEVELS level, LOG_TYPE type, const char* file, int line, const char* message);
 
   LOG_LEVELS GetLogLevel() const;
   void SetLogLevel(LOG_LEVELS level);
@@ -75,6 +72,9 @@ private:
   LogManager& operator=(const LogManager&) = delete;
   LogManager(LogManager&&) = delete;
   LogManager& operator=(LogManager&&) = delete;
+
+  void LogWithFullPath(LOG_LEVELS level, LOG_TYPE type, const char* file, int line,
+                       const char* message);
 
   LOG_LEVELS m_level;
   std::array<LogContainer, NUMBER_OF_LOGS> m_log{};


### PR DESCRIPTION
Provides a basic extension to the interface to begin migration off of the printf-based logging system.

Everything will go through macros with the same style naming as the old logging system, except the macros will have the _FMT suffix, while the migration is in process. This allows for peacemeal migration over time instead of pulling everything out and replacing it all in a single pull request, which makes for much easier reviewing.