### PR TITLE
Common: Move OSThreads into Core

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -34,8 +34,6 @@ add_library(common
   Crypto/ec.h
   Debug/MemoryPatches.cpp
   Debug/MemoryPatches.h
-  Debug/OSThread.cpp
-  Debug/OSThread.h
   Debug/Threads.h
   Debug/Watches.cpp
   Debug/Watches.h

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -48,7 +48,6 @@
     <ClInclude Include="CPUDetect.h" />
     <ClInclude Include="DebugInterface.h" />
     <ClInclude Include="Debug\MemoryPatches.h" />
-    <ClInclude Include="Debug\OSThread.h" />
     <ClInclude Include="Debug\Threads.h" />
     <ClInclude Include="Debug\Watches.h" />
     <ClInclude Include="DynamicLibrary.h" />
@@ -191,7 +190,6 @@
     <ClCompile Include="Config\ConfigInfo.cpp" />
     <ClCompile Include="Config\Layer.cpp" />
     <ClCompile Include="Debug\MemoryPatches.cpp" />
-    <ClCompile Include="Debug\OSThread.cpp" />
     <ClCompile Include="Debug\Watches.cpp" />
     <ClCompile Include="DynamicLibrary.cpp" />
     <ClCompile Include="ENetUtil.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -273,9 +273,6 @@
     <ClInclude Include="Debug\MemoryPatches.h">
       <Filter>Debug</Filter>
     </ClInclude>
-    <ClInclude Include="Debug\OSThread.h">
-      <Filter>Debug</Filter>
-    </ClInclude>
     <ClInclude Include="Debug\Threads.h">
       <Filter>Debug</Filter>
     </ClInclude>
@@ -363,9 +360,6 @@
     </ClCompile>
     <ClCompile Include="QoSSession.cpp" />
     <ClCompile Include="Debug\MemoryPatches.cpp">
-      <Filter>Debug</Filter>
-    </ClCompile>
-    <ClCompile Include="Debug\OSThread.cpp">
       <Filter>Debug</Filter>
     </ClCompile>
     <ClCompile Include="GL\GLContext.cpp">

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -80,6 +80,8 @@ add_library(core
   Debugger/Dump.cpp
   Debugger/Dump.h
   Debugger/GCELF.h
+  Debugger/OSThread.cpp
+  Debugger/OSThread.h
   Debugger/PPCDebugInterface.cpp
   Debugger/PPCDebugInterface.h
   Debugger/RSO.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -40,6 +40,7 @@
     <ClCompile Include="CoreTiming.cpp" />
     <ClCompile Include="Debugger\Debugger_SymbolMap.cpp" />
     <ClCompile Include="Debugger\Dump.cpp" />
+    <ClCompile Include="Debugger\OSThread.cpp" />
     <ClCompile Include="Debugger\PPCDebugInterface.cpp" />
     <ClCompile Include="Debugger\RSO.cpp" />
     <ClCompile Include="DSPEmulator.cpp" />
@@ -399,6 +400,7 @@
     <ClInclude Include="Debugger\Debugger_SymbolMap.h" />
     <ClInclude Include="Debugger\Dump.h" />
     <ClInclude Include="Debugger\GCELF.h" />
+    <ClInclude Include="Debugger\OSThread.h" />
     <ClInclude Include="Debugger\PPCDebugInterface.h" />
     <ClInclude Include="Debugger\RSO.h" />
     <ClInclude Include="DSPEmulator.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="Debugger\Dump.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\OSThread.cpp">
+      <Filter>Debugger</Filter>
+    </ClCompile>
     <ClCompile Include="Debugger\PPCDebugInterface.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
@@ -1048,6 +1051,9 @@
       <Filter>Debugger</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\GCELF.h">
+      <Filter>Debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\OSThread.h">
       <Filter>Debugger</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\PPCDebugInterface.h">

--- a/Source/Core/Core/Debugger/OSThread.h
+++ b/Source/Core/Core/Debugger/OSThread.h
@@ -11,7 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Debug/Threads.h"
 
-namespace Common::Debug
+namespace Core::Debug
 {
 template <class C>
 struct OSQueue
@@ -132,7 +132,7 @@ public:
 
   const OSThread& Data() const;
 
-  PartialContext GetContext() const override;
+  Common::Debug::PartialContext GetContext() const override;
   u32 GetAddress() const override;
   u16 GetState() const override;
   bool IsSuspended() const override;
@@ -151,4 +151,4 @@ private:
   OSThread m_thread;
 };
 
-}  // namespace Common::Debug
+}  // namespace Core::Debug

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -11,10 +11,10 @@
 #include <fmt/format.h>
 
 #include "Common/Align.h"
-#include "Common/Debug/OSThread.h"
 #include "Common/GekkoDisassembler.h"
 
 #include "Core/Core.h"
+#include "Core/Debugger/OSThread.h"
 #include "Core/HW/DSP.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
@@ -176,14 +176,14 @@ Common::Debug::Threads PPCDebugInterface::GetThreads() const
   if (!PowerPC::HostIsRAMAddress(active_queue_head))
     return threads;
 
-  auto active_thread = std::make_unique<Common::Debug::OSThreadView>(active_queue_head);
+  auto active_thread = std::make_unique<Core::Debug::OSThreadView>(active_queue_head);
   if (!active_thread->IsValid())
     return threads;
 
   const auto insert_threads = [&threads](u32 addr, auto get_next_addr) {
     while (addr != 0 && PowerPC::HostIsRAMAddress(addr))
     {
-      auto thread = std::make_unique<Common::Debug::OSThreadView>(addr);
+      auto thread = std::make_unique<Core::Debug::OSThreadView>(addr);
       if (!thread->IsValid())
         break;
       addr = get_next_addr(*thread);


### PR DESCRIPTION
Common shouldn't be depending on APIs in Core (in this case, depending on the PowerPC namespace). Because of the poor separation here, this moves OSThread functionality into core, so that it resolves the implicit dependency on core.