### PR TITLE
DiscIO: Migrate logging over to fmt

### DIFF
--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -206,7 +206,7 @@ static ConversionResult<OutputParameters> Compress(CompressThreadState* state,
 
   if (retval != Z_OK)
   {
-    ERROR_LOG(DISCIO, "Deflate failed");
+    ERROR_LOG_FMT(DISCIO, "Deflate failed");
     return ConversionResultCode::InternalError;
   }
 

--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -502,9 +502,9 @@ void DirectoryBlobReader::SetWiiRegionData(const std::string& game_partition_roo
   const std::string region_bin_path = game_partition_root + "disc/region.bin";
   const size_t bytes_read = ReadFileToVector(region_bin_path, &m_wii_region_data);
   if (bytes_read < 0x4)
-    ERROR_LOG(DISCIO, "Couldn't read region from %s", region_bin_path.c_str());
+    ERROR_LOG_FMT(DISCIO, "Couldn't read region from {}", region_bin_path);
   else if (bytes_read < 0x20)
-    ERROR_LOG(DISCIO, "Couldn't read age ratings from %s", region_bin_path.c_str());
+    ERROR_LOG_FMT(DISCIO, "Couldn't read age ratings from {}", region_bin_path);
 
   constexpr u64 WII_REGION_DATA_ADDRESS = 0x4E000;
   [[maybe_unused]] constexpr u64 WII_REGION_DATA_SIZE = 0x20;
@@ -644,7 +644,7 @@ void DirectoryBlobPartition::SetDiscHeaderAndDiscType(std::optional<bool> is_wii
   m_disc_header.resize(DISCHEADER_SIZE);
   const std::string boot_bin_path = m_root_directory + "sys/boot.bin";
   if (ReadFileToVector(boot_bin_path, &m_disc_header) < 0x20)
-    ERROR_LOG(DISCIO, "%s doesn't exist or is too small", boot_bin_path.c_str());
+    ERROR_LOG_FMT(DISCIO, "{} doesn't exist or is too small", boot_bin_path);
 
   m_contents.Add(DISCHEADER_ADDRESS, m_disc_header);
 
@@ -657,7 +657,7 @@ void DirectoryBlobPartition::SetDiscHeaderAndDiscType(std::optional<bool> is_wii
     m_is_wii = Common::swap32(&m_disc_header[0x18]) == 0x5d1c9ea3;
     const bool is_gc = Common::swap32(&m_disc_header[0x1c]) == 0xc2339f3d;
     if (m_is_wii == is_gc)
-      ERROR_LOG(DISCIO, "Couldn't detect disc type based on %s", boot_bin_path.c_str());
+      ERROR_LOG_FMT(DISCIO, "Couldn't detect disc type based on {}", boot_bin_path);
   }
 
   m_address_shift = m_is_wii ? 2 : 0;
@@ -675,7 +675,7 @@ void DirectoryBlobPartition::SetBI2()
   const std::string bi2_path = m_root_directory + "sys/bi2.bin";
   const size_t bytes_read = ReadFileToVector(bi2_path, &m_bi2);
   if (!m_is_wii && bytes_read < 0x1C)
-    ERROR_LOG(DISCIO, "Couldn't read region from %s", bi2_path.c_str());
+    ERROR_LOG_FMT(DISCIO, "Couldn't read region from {}", bi2_path);
 
   m_contents.Add(BI2_ADDRESS, m_bi2);
 }
@@ -689,14 +689,14 @@ u64 DirectoryBlobPartition::SetApploader()
   m_apploader.resize(file.GetSize());
   if (m_apploader.size() < 0x20 || !file.ReadBytes(m_apploader.data(), m_apploader.size()))
   {
-    ERROR_LOG(DISCIO, "%s couldn't be accessed or is too small", path.c_str());
+    ERROR_LOG_FMT(DISCIO, "{} couldn't be accessed or is too small", path);
   }
   else
   {
     const size_t apploader_size = 0x20 + Common::swap32(*(u32*)&m_apploader[0x14]) +
                                   Common::swap32(*(u32*)&m_apploader[0x18]);
     if (apploader_size != m_apploader.size())
-      ERROR_LOG(DISCIO, "%s is the wrong size... Is it really an apploader?", path.c_str());
+      ERROR_LOG_FMT(DISCIO, "{} is the wrong size... Is it really an apploader?", path);
     else
       success = true;
   }

--- a/Source/Core/DiscIO/DiscExtractor.cpp
+++ b/Source/Core/DiscIO/DiscExtractor.cpp
@@ -5,7 +5,6 @@
 #include "DiscIO/DiscExtractor.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <locale>
 #include <optional>
 
@@ -58,11 +57,9 @@ u64 ReadFile(const Volume& volume, const Partition& partition, const FileInfo* f
 
   const u64 read_length = std::min(max_buffer_size, file_info->GetSize() - offset_in_file);
 
-  DEBUG_LOG(DISCIO,
-            "Reading %" PRIx64 " bytes at %" PRIx64 " from file %s. Offset: %" PRIx64
-            " Size: %" PRIx32,
-            read_length, offset_in_file, file_info->GetPath().c_str(), file_info->GetOffset(),
-            file_info->GetSize());
+  DEBUG_LOG_FMT(DISCIO, "Reading {:x} bytes at {:x} from file {}. Offset: {:x} Size: {:x}",
+                read_length, offset_in_file, file_info->GetPath(), file_info->GetOffset(),
+                file_info->GetSize());
 
   if (!volume.Read(file_info->GetOffset() + offset_in_file, read_length, buffer, partition))
     return 0;
@@ -144,14 +141,14 @@ void ExportDirectory(const Volume& volume, const Partition& partition, const Fil
     if (update_progress(path))
       return;
 
-    DEBUG_LOG(DISCIO, "%s", export_path.c_str());
+    DEBUG_LOG_FMT(DISCIO, "{}", export_path);
 
     if (!file_info.IsDirectory())
     {
       if (File::Exists(export_path))
-        NOTICE_LOG(DISCIO, "%s already exists", export_path.c_str());
+        NOTICE_LOG_FMT(DISCIO, "{} already exists", export_path);
       else if (!ExportFile(volume, partition, &file_info, export_path))
-        ERROR_LOG(DISCIO, "Could not export %s", export_path.c_str());
+        ERROR_LOG_FMT(DISCIO, "Could not export {}", export_path);
     }
     else if (recursive)
     {

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -5,9 +5,7 @@
 #include "DiscIO/DiscScrubber.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <cstddef>
-#include <cstdio>
 #include <memory>
 #include <optional>
 #include <string>
@@ -16,7 +14,6 @@
 #include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
-#include "Common/File.h"
 #include "Common/Logging/Log.h"
 
 #include "DiscIO/DiscExtractor.h"
@@ -59,7 +56,7 @@ void DiscScrubber::MarkAsUsed(u64 offset, u64 size)
   u64 current_offset = Common::AlignDown(offset, CLUSTER_SIZE);
   const u64 end_offset = offset + size;
 
-  DEBUG_LOG(DISCIO, "Marking 0x%016" PRIx64 " - 0x%016" PRIx64 " as used", offset, end_offset);
+  DEBUG_LOG_FMT(DISCIO, "Marking {:#018x} - {:#018x} as used", offset, end_offset);
 
   while (current_offset < end_offset && current_offset < m_file_size)
   {
@@ -165,8 +162,8 @@ bool DiscScrubber::ParsePartitionData(const Partition& partition)
   const FileSystem* filesystem = m_disc->GetFileSystem(partition);
   if (!filesystem)
   {
-    ERROR_LOG(DISCIO, "Failed to read file system for the partition at 0x%" PRIx64,
-              partition.offset);
+    ERROR_LOG_FMT(DISCIO, "Failed to read file system for the partition at {:#x}",
+                  partition.offset);
     return false;
   }
 
@@ -221,7 +218,7 @@ void DiscScrubber::ParseFileSystemData(u64 partition_data_offset, const FileInfo
 {
   for (const DiscIO::FileInfo& file_info : directory)
   {
-    DEBUG_LOG(DISCIO, "Scrubbing %s", file_info.GetPath().c_str());
+    DEBUG_LOG_FMT(DISCIO, "Scrubbing {}", file_info.GetPath());
     if (file_info.IsDirectory())
       ParseFileSystemData(partition_data_offset, file_info);
     else

--- a/Source/Core/DiscIO/DriveBlob.cpp
+++ b/Source/Core/DiscIO/DriveBlob.cpp
@@ -98,7 +98,7 @@ DriveReader::DriveReader(const std::string& drive)
   }
   else
   {
-    NOTICE_LOG(DISCIO, "Load from DVD backup failed or no disc in drive %s", drive.c_str());
+    NOTICE_LOG_FMT(DISCIO, "Load from DVD backup failed or no disc in drive {}", drive);
   }
 }
 

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -324,7 +324,7 @@ Country CountryCodeToCountry(u8 country_code, Platform platform, Region region,
 
   default:
     if (country_code > 'A')  // Silently ignore IOS wads
-      WARN_LOG(DISCIO, "Unknown Country Code! %c", country_code);
+      WARN_LOG_FMT(DISCIO, "Unknown Country Code! {}", static_cast<char>(country_code));
     return Country::Unknown;
   }
 }
@@ -366,7 +366,7 @@ std::string GetSysMenuVersionString(u16 title_version)
     region_letter = 'K';
     break;
   case Region::Unknown:
-    WARN_LOG(DISCIO, "Unknown region for Wii Menu version %u", title_version);
+    WARN_LOG_FMT(DISCIO, "Unknown region for Wii Menu version {}", title_version);
     break;
   }
 

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -187,7 +187,7 @@ bool FileInfoGCWii::IsValid(u64 fst_size, const FileInfoGCWii& parent_directory)
 {
   if (GetNameOffset() >= fst_size)
   {
-    ERROR_LOG(DISCIO, "Impossibly large name offset in file system");
+    ERROR_LOG_FMT(DISCIO, "Impossibly large name offset in file system");
     return false;
   }
 
@@ -195,21 +195,21 @@ bool FileInfoGCWii::IsValid(u64 fst_size, const FileInfoGCWii& parent_directory)
   {
     if (Get(EntryProperty::FILE_OFFSET) != parent_directory.m_index)
     {
-      ERROR_LOG(DISCIO, "Incorrect parent offset in file system");
+      ERROR_LOG_FMT(DISCIO, "Incorrect parent offset in file system");
       return false;
     }
 
-    u32 size = Get(EntryProperty::FILE_SIZE);
+    const u32 size = Get(EntryProperty::FILE_SIZE);
 
     if (size <= m_index)
     {
-      ERROR_LOG(DISCIO, "Impossibly small directory size in file system");
+      ERROR_LOG_FMT(DISCIO, "Impossibly small directory size in file system");
       return false;
     }
 
     if (size > parent_directory.Get(EntryProperty::FILE_SIZE))
     {
-      ERROR_LOG(DISCIO, "Impossibly large directory size in file system");
+      ERROR_LOG_FMT(DISCIO, "Impossibly large directory size in file system");
       return false;
     }
 
@@ -241,7 +241,7 @@ FileSystemGCWii::FileSystemGCWii(const VolumeDisc* volume, const Partition& part
     return;
   if (*fst_size < FST_ENTRY_SIZE)
   {
-    ERROR_LOG(DISCIO, "File system is too small");
+    ERROR_LOG_FMT(DISCIO, "File system is too small");
     return;
   }
 
@@ -253,7 +253,7 @@ FileSystemGCWii::FileSystemGCWii(const VolumeDisc* volume, const Partition& part
     // Without this check, Dolphin can crash by trying to allocate too much
     // memory when loading a disc image with an incorrect FST size.
 
-    ERROR_LOG(DISCIO, "File system is abnormally large! Aborting loading");
+    ERROR_LOG_FMT(DISCIO, "File system is abnormally large! Aborting loading");
     return;
   }
 
@@ -261,7 +261,7 @@ FileSystemGCWii::FileSystemGCWii(const VolumeDisc* volume, const Partition& part
   m_file_system_table.resize(*fst_size);
   if (!volume->Read(*fst_offset, *fst_size, m_file_system_table.data(), partition))
   {
-    ERROR_LOG(DISCIO, "Couldn't read file system table");
+    ERROR_LOG_FMT(DISCIO, "Couldn't read file system table");
     return;
   }
 
@@ -269,20 +269,20 @@ FileSystemGCWii::FileSystemGCWii(const VolumeDisc* volume, const Partition& part
   m_root = FileInfoGCWii(m_file_system_table.data(), offset_shift);
   if (!m_root.IsDirectory())
   {
-    ERROR_LOG(DISCIO, "File system root is not a directory");
+    ERROR_LOG_FMT(DISCIO, "File system root is not a directory");
     return;
   }
 
   if (FST_ENTRY_SIZE * m_root.GetSize() > *fst_size)
   {
-    ERROR_LOG(DISCIO, "File system has too many entries for its size");
+    ERROR_LOG_FMT(DISCIO, "File system has too many entries for its size");
     return;
   }
 
   // If the FST's final byte isn't 0, FileInfoGCWii::GetName() can read past the end
   if (m_file_system_table[*fst_size - 1] != 0)
   {
-    ERROR_LOG(DISCIO, "File system does not end with a null byte");
+    ERROR_LOG_FMT(DISCIO, "File system does not end with a null byte");
     return;
   }
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -2,7 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cinttypes>
+#include "DiscIO/VolumeGC.h"
+
 #include <cstddef>
 #include <map>
 #include <memory>
@@ -26,7 +27,6 @@
 #include "DiscIO/FileSystemGCWii.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
-#include "DiscIO/VolumeGC.h"
 
 namespace DiscIO
 {
@@ -159,7 +159,7 @@ VolumeGC::ConvertedGCBanner VolumeGC::LoadBannerFile() const
                                  reinterpret_cast<u8*>(&banner_file), sizeof(GCBanner));
   if (file_size < 4)
   {
-    WARN_LOG(DISCIO, "Could not read opening.bnr.");
+    WARN_LOG_FMT(DISCIO, "Could not read opening.bnr.");
     return {};  // Return early so that we don't access the uninitialized banner_file.id
   }
 
@@ -176,7 +176,8 @@ VolumeGC::ConvertedGCBanner VolumeGC::LoadBannerFile() const
   }
   else
   {
-    WARN_LOG(DISCIO, "Invalid opening.bnr. Type: %0x Size: %0" PRIx64, banner_file.id, file_size);
+    WARN_LOG_FMT(DISCIO, "Invalid opening.bnr. Type: {:#0x} Size: {:#0x}", banner_file.id,
+                 file_size);
     return {};
   }
 

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cinttypes>
 #include <future>
 #include <limits>
 #include <memory>
@@ -97,7 +96,7 @@ void RedumpVerifier::Start(const Volume& volume)
     switch (download_state->status)
     {
     case DownloadStatus::FailButOldCacheAvailable:
-      ERROR_LOG(DISCIO, "Failed to fetch data from Redump.org, using old cached data instead");
+      ERROR_LOG_FMT(DISCIO, "Failed to fetch data from Redump.org, using old cached data instead");
       [[fallthrough]];
     case DownloadStatus::Success:
       return ScanDatfile(ReadDatfile(system), system);
@@ -156,7 +155,7 @@ RedumpVerifier::DownloadStatus RedumpVerifier::DownloadDatfile(const std::string
 
   File::CreateFullPath(output_path);
   if (!File::IOFile(output_path, "wb").WriteBytes(result->data(), result->size()))
-    ERROR_LOG(DISCIO, "Failed to write downloaded datfile to %s", output_path.c_str());
+    ERROR_LOG_FMT(DISCIO, "Failed to write downloaded datfile to {}", output_path);
   return DownloadStatus::Success;
 }
 
@@ -275,7 +274,7 @@ std::vector<RedumpVerifier::PotentialMatch> RedumpVerifier::ScanDatfile(const st
 
         if (game_id_start == std::string::npos || serial.size() < game_id_start + 4)
         {
-          ERROR_LOG(DISCIO, "Invalid serial in redump datfile: %s", serial_str.c_str());
+          ERROR_LOG_FMT(DISCIO, "Invalid serial in redump datfile: {}", serial_str);
           continue;
         }
 
@@ -1167,8 +1166,7 @@ void VolumeVerifier::Process()
 
   if (!read_succeeded)
   {
-    ERROR_LOG(DISCIO, "Read failed at 0x%" PRIx64 " to 0x%" PRIx64, m_progress,
-              m_progress + bytes_to_read);
+    ERROR_LOG_FMT(DISCIO, "Read failed at {:#x} to {:#x}", m_progress, m_progress + bytes_to_read);
 
     m_read_errors_occurred = true;
     m_calculating_any_hash = false;
@@ -1245,12 +1243,12 @@ void VolumeVerifier::Process()
             {
               if (m_scrubber.CanBlockBeScrubbed(offset))
               {
-                WARN_LOG(DISCIO, "Integrity check failed for unused block at 0x%" PRIx64, offset);
+                WARN_LOG_FMT(DISCIO, "Integrity check failed for unused block at {:#x}", offset);
                 m_unused_block_errors[m_blocks[block_index].partition]++;
               }
               else
               {
-                WARN_LOG(DISCIO, "Integrity check failed for block at 0x%" PRIx64, offset);
+                WARN_LOG_FMT(DISCIO, "Integrity check failed for block at {:#x}", offset);
                 m_block_errors[m_blocks[block_index].partition]++;
               }
             }

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -54,7 +54,7 @@ VolumeWAD::VolumeWAD(std::unique_ptr<BlobReader> reader) : m_reader(std::move(re
 
   if (!IOS::ES::IsValidTMDSize(m_tmd_size))
   {
-    ERROR_LOG(DISCIO, "TMD is too large: %u bytes", m_tmd_size);
+    ERROR_LOG_FMT(DISCIO, "TMD is too large: {} bytes", m_tmd_size);
     return;
   }
 
@@ -240,7 +240,8 @@ IOS::ES::TicketReader VolumeWAD::GetTicketWithFixedCommonKey() const
     }
   }
 
-  ERROR_LOG(DISCIO, "Couldn't find valid common key for WAD file (%u specified)", specified_index);
+  ERROR_LOG_FMT(DISCIO, "Couldn't find valid common key for WAD file ({} specified)",
+                specified_index);
   return m_ticket;
 }
 


### PR DESCRIPTION
Eliminates quite a bit of the PRI* macros used for handling 64-bit values.