### PR TITLE
VideoCommon: Get rid of the global g_available_video_backends

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -64,9 +64,11 @@ void GeneralWidget::CreateWidgets()
 
   m_video_box->setLayout(m_video_layout);
 
-  for (auto& backend : g_available_video_backends)
+  for (auto& backend : VideoBackendBase::GetAvailableBackends())
+  {
     m_backend_combo->addItem(tr(backend->GetDisplayName().c_str()),
                              QVariant(QString::fromStdString(backend->GetName())));
+  }
 
   m_video_layout->addWidget(new QLabel(tr("Backend:")), 0, 0);
   m_video_layout->addWidget(m_backend_combo, 0, 1);
@@ -159,8 +161,8 @@ void GeneralWidget::SaveSettings()
   const auto current_backend = m_backend_combo->currentData().toString().toStdString();
   if (Config::Get(Config::MAIN_GFX_BACKEND) != current_backend)
   {
-    auto warningMessage =
-        g_available_video_backends[m_backend_combo->currentIndex()]->GetWarningMessage();
+    auto warningMessage = VideoBackendBase::GetAvailableBackends()[m_backend_combo->currentIndex()]
+                              ->GetWarningMessage();
     if (warningMessage)
     {
       ModalMessageBox confirm_sw(this);

--- a/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/SoftwareRendererWidget.cpp
@@ -51,7 +51,7 @@ void SoftwareRendererWidget::CreateWidgets()
   rendering_layout->addWidget(new QLabel(tr("Backend:")), 1, 1);
   rendering_layout->addWidget(m_backend_combo, 1, 2);
 
-  for (const auto& backend : g_available_video_backends)
+  for (const auto& backend : VideoBackendBase::GetAvailableBackends())
     m_backend_combo->addItem(tr(backend->GetDisplayName().c_str()));
 
   auto* overlay_box = new QGroupBox(tr("Overlay Information"));
@@ -122,7 +122,7 @@ void SoftwareRendererWidget::ConnectWidgets()
 
 void SoftwareRendererWidget::LoadSettings()
 {
-  for (const auto& backend : g_available_video_backends)
+  for (const auto& backend : VideoBackendBase::GetAvailableBackends())
   {
     if (backend->GetName() == Config::Get(Config::MAIN_GFX_BACKEND))
     {
@@ -137,7 +137,7 @@ void SoftwareRendererWidget::LoadSettings()
 
 void SoftwareRendererWidget::SaveSettings()
 {
-  for (const auto& backend : g_available_video_backends)
+  for (const auto& backend : VideoBackendBase::GetAvailableBackends())
   {
     if (tr(backend->GetDisplayName().c_str()) == m_backend_combo->currentText())
     {

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -97,7 +97,6 @@ void Init()
   SConfig::Init();
   Discord::Init();
   Common::Log::LogManager::Init();
-  VideoBackendBase::PopulateList();
   WiimoteReal::LoadSettings();
   GCAdapter::Init();
   VideoBackendBase::ActivateBackend(Config::Get(Config::MAIN_GFX_BACKEND));
@@ -109,7 +108,6 @@ void Shutdown()
 {
   GCAdapter::Shutdown();
   WiimoteReal::Shutdown();
-  VideoBackendBase::ClearList();
   Common::Log::LogManager::Shutdown();
   Discord::Shutdown();
   SConfig::Shutdown();

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -206,16 +206,10 @@ static VideoBackendBase* GetDefaultVideoBackend()
   return backends.front().get();
 }
 
-// This function is called at static initialization, so we can't rely on s_default_backend being set
 std::string VideoBackendBase::GetDefaultBackendName()
 {
-#ifdef HAS_OPENGL
-  return OGL::VideoBackend::NAME;
-#elif defined(_WIN32)
-  return DX11::VideoBackend::NAME;
-#else
-  return Vulkan::VideoBackend::NAME;
-#endif
+  auto* default_backend = GetDefaultVideoBackend();
+  return default_backend ? default_backend->GetName() : "";
 }
 
 const std::vector<std::unique_ptr<VideoBackendBase>>& VideoBackendBase::GetAvailableBackends()

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -58,9 +58,7 @@
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/VideoState.h"
 
-std::vector<std::unique_ptr<VideoBackendBase>> g_available_video_backends;
 VideoBackendBase* g_video_backend = nullptr;
-static VideoBackendBase* s_default_backend = nullptr;
 
 #ifdef _WIN32
 #include <windows.h>
@@ -200,6 +198,14 @@ u16 VideoBackendBase::Video_GetBoundingBox(int index)
   return result;
 }
 
+static VideoBackendBase* GetDefaultVideoBackend()
+{
+  const auto& backends = VideoBackendBase::GetAvailableBackends();
+  if (backends.empty())
+    return nullptr;
+  return backends.front().get();
+}
+
 // This function is called at static initialization, so we can't rely on s_default_backend being set
 std::string VideoBackendBase::GetDefaultBackendName()
 {
@@ -212,49 +218,45 @@ std::string VideoBackendBase::GetDefaultBackendName()
 #endif
 }
 
-void VideoBackendBase::PopulateList()
+const std::vector<std::unique_ptr<VideoBackendBase>>& VideoBackendBase::GetAvailableBackends()
 {
-  // OGL > D3D11 > D3D12 > Vulkan > SW > Null
+  static auto s_available_backends = [] {
+    std::vector<std::unique_ptr<VideoBackendBase>> backends;
+
+    // OGL > D3D11 > D3D12 > Vulkan > SW > Null
 #ifdef HAS_OPENGL
-  g_available_video_backends.push_back(std::make_unique<OGL::VideoBackend>());
+    backends.push_back(std::make_unique<OGL::VideoBackend>());
 #endif
 #ifdef _WIN32
-  g_available_video_backends.push_back(std::make_unique<DX11::VideoBackend>());
-  g_available_video_backends.push_back(std::make_unique<DX12::VideoBackend>());
+    backends.push_back(std::make_unique<DX11::VideoBackend>());
+    backends.push_back(std::make_unique<DX12::VideoBackend>());
 #endif
-  g_available_video_backends.push_back(std::make_unique<Vulkan::VideoBackend>());
+    backends.push_back(std::make_unique<Vulkan::VideoBackend>());
 #ifdef HAS_OPENGL
-  g_available_video_backends.push_back(std::make_unique<SW::VideoSoftware>());
+    backends.push_back(std::make_unique<SW::VideoSoftware>());
 #endif
-  g_available_video_backends.push_back(std::make_unique<Null::VideoBackend>());
+    backends.push_back(std::make_unique<Null::VideoBackend>());
 
-  const auto iter =
-      std::find_if(g_available_video_backends.begin(), g_available_video_backends.end(),
-                   [](const auto& backend) { return backend != nullptr; });
+    if (!backends.empty())
+      g_video_backend = backends.front().get();
 
-  if (iter == g_available_video_backends.end())
-    return;
-
-  s_default_backend = iter->get();
-  g_video_backend = iter->get();
-}
-
-void VideoBackendBase::ClearList()
-{
-  g_available_video_backends.clear();
+    return backends;
+  }();
+  return s_available_backends;
 }
 
 void VideoBackendBase::ActivateBackend(const std::string& name)
 {
   // If empty, set it to the default backend (expected behavior)
   if (name.empty())
-    g_video_backend = s_default_backend;
+    g_video_backend = GetDefaultVideoBackend();
 
-  const auto iter =
-      std::find_if(g_available_video_backends.begin(), g_available_video_backends.end(),
-                   [&name](const auto& backend) { return name == backend->GetName(); });
+  const auto& backends = GetAvailableBackends();
+  const auto iter = std::find_if(backends.begin(), backends.end(), [&name](const auto& backend) {
+    return name == backend->GetName();
+  });
 
-  if (iter == g_available_video_backends.end())
+  if (iter == backends.end())
     return;
 
   g_video_backend = iter->get();

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -60,8 +60,7 @@ public:
   u16 Video_GetBoundingBox(int index);
 
   static std::string GetDefaultBackendName();
-  static void PopulateList();
-  static void ClearList();
+  static const std::vector<std::unique_ptr<VideoBackendBase>>& GetAvailableBackends();
   static void ActivateBackend(const std::string& name);
 
   // Fills the backend_info fields with the capabilities of the selected backend/device.
@@ -79,5 +78,4 @@ protected:
   bool m_initialized = false;
 };
 
-extern std::vector<std::unique_ptr<VideoBackendBase>> g_available_video_backends;
 extern VideoBackendBase* g_video_backend;


### PR DESCRIPTION
Replace it with a function-local static that is initialized on first
use. This gets rid of a global variable and removes the need for
manual initialization in UICommon.

This commit also replaces the weird find_if that looks for a non-null
unique_ptr with a simple "is vector empty" check considering that
none of the pointers can be null by construction.

---

Also simplifies GetDefaultBackendName: now we can just call
GetDefaultVideoBackend to get the default backend
and get its name by calling GetName.
