### PR TITLE
Android: Replace GetJString with fmt

### DIFF
--- a/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.cpp
@@ -5,23 +5,14 @@
 #include "jni/AndroidCommon/AndroidCommon.h"
 
 #include <string>
-#include <string_view>
 #include <vector>
+
+#include <fmt/format.h>
 
 #include <jni.h>
 
 #include "Common/StringUtil.h"
 #include "jni/AndroidCommon/IDCache.h"
-
-std::string GetJString(JNIEnv* env, jstring jstr)
-{
-  const jchar* jchars = env->GetStringChars(jstr, nullptr);
-  const jsize length = env->GetStringLength(jstr);
-  const std::u16string_view string_view(reinterpret_cast<const char16_t*>(jchars), length);
-  const std::string converted_string = UTF16ToUTF8(string_view);
-  env->ReleaseStringChars(jstr, jchars);
-  return converted_string;
-}
 
 jstring ToJString(JNIEnv* env, const std::string& str)
 {
@@ -37,7 +28,7 @@ std::vector<std::string> JStringArrayToVector(JNIEnv* env, jobjectArray array)
   result.reserve(size);
 
   for (jsize i = 0; i < size; ++i)
-    result.push_back(GetJString(env, (jstring)env->GetObjectArrayElement(array, i)));
+    result.push_back(fmt::to_string((jstring)env->GetObjectArrayElement(array, i)));
 
   return result;
 }

--- a/Source/Android/jni/AndroidCommon/AndroidCommon.h
+++ b/Source/Android/jni/AndroidCommon/AndroidCommon.h
@@ -8,7 +8,6 @@
 
 #include <jni.h>
 
-std::string GetJString(JNIEnv* env, jstring jstr);
 jstring ToJString(JNIEnv* env, const std::string& str);
 std::vector<std::string> JStringArrayToVector(JNIEnv* env, jobjectArray array);
 

--- a/Source/Android/jni/GameList/GameFile.cpp
+++ b/Source/Android/jni/GameList/GameFile.cpp
@@ -8,6 +8,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include <jni.h>
 
 #include "DiscIO/Blob.h"
@@ -191,7 +193,7 @@ JNIEXPORT jobject JNICALL Java_org_dolphinemu_dolphinemu_model_GameFile_parse(JN
                                                                               jobject obj,
                                                                               jstring path)
 {
-  auto game_file = std::make_shared<UICommon::GameFile>(GetJString(env, path));
+  auto game_file = std::make_shared<UICommon::GameFile>(fmt::to_string(path));
   if (!game_file->IsValid())
     game_file.reset();
 

--- a/Source/Android/jni/GameList/GameFileCache.cpp
+++ b/Source/Android/jni/GameList/GameFileCache.cpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include <jni.h>
 
 #include "UICommon/GameFileCache.h"
@@ -30,7 +32,7 @@ extern "C" {
 JNIEXPORT jlong JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_newGameFileCache(
     JNIEnv* env, jobject obj, jstring path)
 {
-  return reinterpret_cast<jlong>(new UICommon::GameFileCache(GetJString(env, path)));
+  return reinterpret_cast<jlong>(new UICommon::GameFileCache(fmt::to_string(path)));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_finalize(JNIEnv* env,
@@ -57,7 +59,7 @@ JNIEXPORT jobject JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_add
                                                                                       jstring path)
 {
   bool cache_changed = false;
-  return GameFileToJava(env, GetPointer(env, obj)->AddOrGet(GetJString(env, path), &cache_changed));
+  return GameFileToJava(env, GetPointer(env, obj)->AddOrGet(fmt::to_string(path), &cache_changed));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_update(
@@ -71,7 +73,7 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_model_GameFileCache_up
   for (jsize i = 0; i < size; ++i)
   {
     const auto path = reinterpret_cast<jstring>(env->GetObjectArrayElement(folder_paths, i));
-    folder_paths_vector.push_back(GetJString(env, path));
+    folder_paths_vector.push_back(fmt::to_string(path));
     env->DeleteLocalRef(path);
   }
 

--- a/Source/Android/jni/IniFile.cpp
+++ b/Source/Android/jni/IniFile.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <fmt/format.h>
+
 #include <jni.h>
 
 #include "Common/IniFile.h"
@@ -32,14 +34,14 @@ template <typename T>
 static T GetInSection(JNIEnv* env, jobject obj, jstring key, T default_value)
 {
   T result;
-  GetSectionPointer(env, obj)->Get(GetJString(env, key), &result, default_value);
+  GetSectionPointer(env, obj)->Get(fmt::to_string(key), &result, default_value);
   return result;
 }
 
 template <typename T>
 static void SetInSection(JNIEnv* env, jobject obj, jstring key, T new_value)
 {
-  GetSectionPointer(env, obj)->Set(GetJString(env, key), new_value);
+  GetSectionPointer(env, obj)->Set(fmt::to_string(key), new_value);
 }
 
 template <typename T>
@@ -47,8 +49,8 @@ static T Get(JNIEnv* env, jobject obj, jstring section_name, jstring key, T defa
 {
   T result;
   GetIniFilePointer(env, obj)
-      ->GetOrCreateSection(GetJString(env, section_name))
-      ->Get(GetJString(env, key), &result, default_value);
+      ->GetOrCreateSection(fmt::to_string(section_name))
+      ->Get(fmt::to_string(key), &result, default_value);
   return result;
 }
 
@@ -56,8 +58,8 @@ template <typename T>
 static void Set(JNIEnv* env, jobject obj, jstring section_name, jstring key, T new_value)
 {
   GetIniFilePointer(env, obj)
-      ->GetOrCreateSection(GetJString(env, section_name))
-      ->Set(GetJString(env, key), new_value);
+      ->GetOrCreateSection(fmt::to_string(section_name))
+      ->Set(fmt::to_string(key), new_value);
 }
 
 #ifdef __cplusplus
@@ -67,19 +69,19 @@ extern "C" {
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_00024Section_exists(
     JNIEnv* env, jobject obj, jstring key)
 {
-  return static_cast<jboolean>(GetSectionPointer(env, obj)->Exists(GetJString(env, key)));
+  return static_cast<jboolean>(GetSectionPointer(env, obj)->Exists(fmt::to_string(key)));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_00024Section_delete(
     JNIEnv* env, jobject obj, jstring key)
 {
-  return static_cast<jboolean>(GetSectionPointer(env, obj)->Delete(GetJString(env, key)));
+  return static_cast<jboolean>(GetSectionPointer(env, obj)->Delete(fmt::to_string(key)));
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_00024Section_getString(
     JNIEnv* env, jobject obj, jstring key, jstring default_value)
 {
-  return ToJString(env, GetInSection(env, obj, key, GetJString(env, default_value)));
+  return ToJString(env, GetInSection(env, obj, key, fmt::to_string(default_value)));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_00024Section_getBoolean(
@@ -103,7 +105,7 @@ JNIEXPORT jfloat JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_00024Secti
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_00024Section_setString(
     JNIEnv* env, jobject obj, jstring key, jstring new_value)
 {
-  SetInSection(env, obj, key, GetJString(env, new_value));
+  SetInSection(env, obj, key, fmt::to_string(new_value));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_00024Section_setBoolean(
@@ -128,27 +130,27 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_load(
     JNIEnv* env, jobject obj, jstring path, jboolean keep_current_data)
 {
   return static_cast<jboolean>(
-      GetIniFilePointer(env, obj)->Load(GetJString(env, path), keep_current_data));
+      GetIniFilePointer(env, obj)->Load(fmt::to_string(path), keep_current_data));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_save(JNIEnv* env,
                                                                              jobject obj,
                                                                              jstring path)
 {
-  return static_cast<jboolean>(GetIniFilePointer(env, obj)->Save(GetJString(env, path)));
+  return static_cast<jboolean>(GetIniFilePointer(env, obj)->Save(fmt::to_string(path)));
 }
 
 JNIEXPORT jobject JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_getOrCreateSection(
     JNIEnv* env, jobject obj, jstring section_name)
 {
   return SectionToJava(
-      env, obj, GetIniFilePointer(env, obj)->GetOrCreateSection(GetJString(env, section_name)));
+      env, obj, GetIniFilePointer(env, obj)->GetOrCreateSection(fmt::to_string(section_name)));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_exists__Ljava_lang_String_2(
     JNIEnv* env, jobject obj, jstring section_name)
 {
-  return static_cast<jboolean>(GetIniFilePointer(env, obj)->Exists(GetJString(env, section_name)));
+  return static_cast<jboolean>(GetIniFilePointer(env, obj)->Exists(fmt::to_string(section_name)));
 }
 
 JNIEXPORT jboolean JNICALL
@@ -156,27 +158,27 @@ Java_org_dolphinemu_dolphinemu_utils_IniFile_exists__Ljava_lang_String_2Ljava_la
     JNIEnv* env, jobject obj, jstring section_name, jstring key)
 {
   return static_cast<jboolean>(
-      GetIniFilePointer(env, obj)->Exists(GetJString(env, section_name), GetJString(env, key)));
+      GetIniFilePointer(env, obj)->Exists(fmt::to_string(section_name), fmt::to_string(key)));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_deleteSection(
     JNIEnv* env, jobject obj, jstring section_name)
 {
   return static_cast<jboolean>(
-      GetIniFilePointer(env, obj)->DeleteSection(GetJString(env, section_name)));
+      GetIniFilePointer(env, obj)->DeleteSection(fmt::to_string(section_name)));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_deleteKey(
     JNIEnv* env, jobject obj, jstring section_name, jstring key)
 {
   return static_cast<jboolean>(
-      GetIniFilePointer(env, obj)->DeleteKey(GetJString(env, section_name), GetJString(env, key)));
+      GetIniFilePointer(env, obj)->DeleteKey(fmt::to_string(section_name), fmt::to_string(key)));
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_getString(
     JNIEnv* env, jobject obj, jstring section_name, jstring key, jstring default_value)
 {
-  return ToJString(env, Get(env, obj, section_name, key, GetJString(env, default_value)));
+  return ToJString(env, Get(env, obj, section_name, key, fmt::to_string(default_value)));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_getBoolean(
@@ -202,7 +204,7 @@ JNIEXPORT jfloat JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_getFloat(
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_setString(
     JNIEnv* env, jobject obj, jstring section_name, jstring key, jstring new_value)
 {
-  Set(env, obj, section_name, key, GetJString(env, new_value));
+  Set(env, obj, section_name, key, fmt::to_string(new_value));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_utils_IniFile_setBoolean(

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -9,6 +9,7 @@
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
+#include <fmt/format.h>
 #include <jni.h>
 #include <memory>
 #include <mutex>
@@ -187,7 +188,7 @@ static std::string GetAnalyticValue(const std::string& key)
   auto value = reinterpret_cast<jstring>(env->CallStaticObjectMethod(
       IDCache::GetAnalyticsClass(), IDCache::GetAnalyticsValue(), ToJString(env, key)));
 
-  std::string stdvalue = GetJString(env, value);
+  std::string stdvalue = fmt::to_string(value);
 
   return stdvalue;
 }
@@ -251,13 +252,13 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ChangeDisc(J
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(
     JNIEnv* env, jobject obj, jstring jDevice, jint Button, jint Action)
 {
-  return ButtonManager::GamepadEvent(GetJString(env, jDevice), Button, Action);
+  return ButtonManager::GamepadEvent(fmt::to_string(jDevice), Button, Action);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadMoveEvent(
     JNIEnv* env, jobject obj, jstring jDevice, jint Axis, jfloat Value)
 {
-  ButtonManager::GamepadAxisEvent(GetJString(env, jDevice), Axis, Value);
+  ButtonManager::GamepadAxisEvent(fmt::to_string(jDevice), Axis, Value);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetMotionSensorsEnabled(
@@ -314,7 +315,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveStateAs(
                                                                                 jboolean wait)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  State::SaveAs(GetJString(env, path), wait);
+  State::SaveAs(fmt::to_string(path), wait);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadState(JNIEnv* env,
@@ -330,13 +331,13 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_LoadStateAs(
                                                                                 jstring path)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  State::LoadAs(GetJString(env, path));
+  State::LoadAs(fmt::to_string(path));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_utils_DirectoryInitialization_SetSysDirectory(
     JNIEnv* env, jobject obj, jstring jPath)
 {
-  const std::string path = GetJString(env, jPath);
+  const std::string path = fmt::to_string(jPath);
   File::SetSysDirectory(path);
 }
 
@@ -351,7 +352,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirec
     JNIEnv* env, jobject obj, jstring jDirectory)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  UICommon::SetUserDirectory(GetJString(env, jDirectory));
+  UICommon::SetUserDirectory(fmt::to_string(jDirectory));
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDirectory(JNIEnv* env,
@@ -364,7 +365,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetCacheDire
     JNIEnv* env, jobject obj, jstring jDirectory)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  File::SetUserPath(D_CACHE_IDX, GetJString(env, jDirectory) + DIR_SEP);
+  File::SetUserPath(D_CACHE_IDX, fmt::to_string(jDirectory) + DIR_SEP);
 }
 
 JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv* env,
@@ -558,14 +559,14 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_Run___3Ljava_lang_String_2Ljava_lang_String_2Z(
     JNIEnv* env, jobject obj, jobjectArray jPaths, jstring jSavestate, jboolean jDeleteSavestate)
 {
-  Run(env, JStringArrayToVector(env, jPaths), GetJString(env, jSavestate), jDeleteSavestate);
+  Run(env, JStringArrayToVector(env, jPaths), fmt::to_string(jSavestate), jDeleteSavestate);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ChangeDisc(JNIEnv* env,
                                                                                jobject obj,
                                                                                jstring jFile)
 {
-  const std::string path = GetJString(env, jFile);
+  const std::string path = fmt::to_string(jFile);
   __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Change Disc: %s", path.c_str());
   Core::RunAsCPUThread([&path] { DVDInterface::ChangeDisc(path); });
 }
@@ -596,7 +597,7 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_InstallW
                                                                                    jobject obj,
                                                                                    jstring jFile)
 {
-  const std::string path = GetJString(env, jFile);
+  const std::string path = fmt::to_string(jFile);
   return static_cast<jboolean>(WiiUtils::InstallWAD(path));
 }
 
@@ -604,8 +605,8 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ConvertD
     JNIEnv* env, jobject obj, jstring jInPath, jstring jOutPath, jint jPlatform, jint jFormat,
     jint jBlockSize, jint jCompression, jint jCompressionLevel, jboolean jScrub, jobject jCallback)
 {
-  const std::string in_path = GetJString(env, jInPath);
-  const std::string out_path = GetJString(env, jOutPath);
+  const std::string in_path = fmt::to_string(jInPath);
+  const std::string out_path = fmt::to_string(jOutPath);
   const DiscIO::Platform platform = static_cast<DiscIO::Platform>(jPlatform);
   const DiscIO::BlobType format = static_cast<DiscIO::BlobType>(jFormat);
   const DiscIO::WIARVZCompressionType compression =

--- a/Source/Android/jni/NativeConfig.cpp
+++ b/Source/Android/jni/NativeConfig.cpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <string>
 
+#include <fmt/format.h>
+
 #include <jni.h>
 
 #include "Common/Assert.h"
@@ -19,7 +21,7 @@ constexpr jint LAYER_ACTIVE = 2;
 
 static Config::Location GetLocation(JNIEnv* env, jstring file, jstring section, jstring key)
 {
-  const std::string decoded_file = GetJString(env, file);
+  const std::string decoded_file = fmt::to_string(file);
 
   Config::System system;
   if (decoded_file == "Dolphin")
@@ -44,7 +46,7 @@ static Config::Location GetLocation(JNIEnv* env, jstring file, jstring section, 
     return {};
   }
 
-  return Config::Location{system, GetJString(env, section), GetJString(env, key)};
+  return Config::Location{system, fmt::to_string(section), fmt::to_string(key)};
 }
 
 static std::shared_ptr<Config::Layer> GetLayer(jint layer, const Config::Location& location)
@@ -107,7 +109,7 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_loadGameInis
                                                                                  jstring jGameId,
                                                                                  jint jRevision)
 {
-  const std::string game_id = GetJString(env, jGameId);
+  const std::string game_id = fmt::to_string(jGameId);
   const u16 revision = static_cast<u16>(jRevision);
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
@@ -150,7 +152,7 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_getString(
     jstring default_value)
 {
   const Config::Location location = GetLocation(env, file, section, key);
-  return ToJString(env, Get(layer, location, GetJString(env, default_value)));
+  return ToJString(env, Get(layer, location, fmt::to_string(default_value)));
 }
 
 JNIEXPORT jboolean JNICALL
@@ -181,7 +183,7 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setString(
     JNIEnv* env, jclass obj, jint layer, jstring file, jstring section, jstring key, jstring value)
 {
-  return Set(layer, GetLocation(env, file, section, key), GetJString(env, value));
+  return Set(layer, GetLocation(env, file, section, key), fmt::to_string(value));
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
I'll eventually need a clean way to convert `jint` to `std::string` for properly accessing all SIDevice channels in #8894. This also makes `GetJString` unneeded.