### PR TITLE
DolphinQt: Don't call UICommon::InhibitScreenSaver if already in desired state.

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1434,6 +1434,11 @@ void MainWindow::UpdateScreenSaverInhibition()
   const bool inhibit =
       Config::Get(Config::MAIN_DISABLE_SCREENSAVER) && (Core::GetState() == Core::State::Running);
 
+  if (inhibit == m_is_screensaver_inhibited)
+    return;
+
+  m_is_screensaver_inhibited = inhibit;
+
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
   if (GetWindowSystemType() == WindowSystemType::X11)
     UICommon::InhibitScreenSaver(winId(), inhibit);

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -204,6 +204,7 @@ private:
   bool m_stop_requested = false;
   bool m_exit_requested = false;
   bool m_fullscreen_requested = false;
+  bool m_is_screensaver_inhibited = false;
   int m_state_slot = 1;
   std::unique_ptr<BootParameters> m_pending_boot;
 


### PR DESCRIPTION
Because config change events trigger `UpdateScreenSaverInhibition` a ridiculous number of processes were being spawned on Linux to enable an already enabled screensaver.