### PR TITLE
DolphinQt: Move QT_LAYOUT_DIRECTION string to qt-strings.pot

### DIFF
--- a/Languages/po/qt-strings.pot
+++ b/Languages/po/qt-strings.pot
@@ -1,6 +1,14 @@
 # This file contains strings which are defined in Qt's source code
-# and may be shown in applications which use Qt. Extracted from Qt 5.15.1.
+# and may be accessed in applications which use Qt. Extracted from Qt 5.15.1.
 msgid ""
+msgstr ""
+
+#: qtbase/src/gui/kernel/qguiapplication.cpp:234
+msgctxt ""
+"Translate this string to the string 'LTR' in left-to-right languages or to "
+"'RTL' in right-to-left languages (such as Hebrew and Arabic) to get proper "
+"widget layout."
+msgid "QT_LAYOUT_DIRECTION"
 msgstr ""
 
 #: qtbase/src/gui/kernel/qplatformtheme.cpp:708

--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -302,17 +302,6 @@ static bool TryInstallTranslator(const QString& exact_language_code)
 
 void Translation::Initialize()
 {
-// Let the translation select the GUI directionality. This is intentionally excluded
-// from compilation, since all that matters is that xgettext sees it. We could use
-// QT_TRANSLATE_NOOP3 instead of tr, but that doesn't compile correctly when put
-// on a line of its own, so we would need to exclude it from compilation anyway.
-#if 0
-  QGuiApplication::tr(
-      "QT_LAYOUT_DIRECTION",
-      "Translate this string to the string 'LTR' in left-to-right languages or to 'RTL' in "
-      "right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.");
-#endif
-
   // Hook up Dolphin internal translation
   Common::RegisterStringTranslator(
       [](const char* text) { return QObject::tr(text).toStdString(); });


### PR DESCRIPTION
Now that we have a .pot file specifically for strings from Qt itself, it makes sense to move this into it.