### PR TITLE
VideoCommon/FrameDump: Remove code for older versions of avcodec.

### DIFF
--- a/Source/Core/VideoCommon/FrameDump.h
+++ b/Source/Core/VideoCommon/FrameDump.h
@@ -50,7 +50,7 @@ private:
   bool CreateVideoFile();
   void CloseVideoFile();
   void CheckForConfigChange(const FrameData&);
-  void HandleDelayedPackets();
+  void ProcessPackets();
 
 #if defined(HAVE_FFMPEG)
   std::unique_ptr<FrameDumpContext> m_context;


### PR DESCRIPTION
I've removed code that was supporting older versions of libavcodec.

Based on the `#ifdef`s I removed we now require 58.9.100.
Ubuntu 20.04 appears to currently provide 58.54.100.

This cleans up some logic that had to send a frame and receive a packet in the same deprecated call.