### PR TITLE
VideoCommon: Fix Vulkan not being enabled on Windows builds

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -26,6 +26,9 @@
 #if !defined(_WIN32) || !defined(_M_ARM64)
 #define HAS_OPENGL 1
 #endif
+#ifdef _WIN32
+#define HAS_VULKAN 1
+#endif
 
 // TODO: ugly
 #ifdef _WIN32
@@ -37,7 +40,9 @@
 #include "VideoBackends/OGL/VideoBackend.h"
 #include "VideoBackends/Software/VideoBackend.h"
 #endif
+#ifdef HAS_VULKAN
 #include "VideoBackends/Vulkan/VideoBackend.h"
+#endif
 
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/BPStructs.h"


### PR DESCRIPTION
Ideally this should probably be added into the VS solution files, but
it feels less confusing to keep the HAS_OPENGL and the HAS_VULKAN together.

Fixes a regression from #7395