### PR TITLE
IOS/USB: Fix -Winvalid-offset warnings

### DIFF
--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -24,8 +24,11 @@ namespace IOS::HLE::Device
 {
 OH0::OH0(Kernel& ios, const std::string& device_name) : USBHost(ios, device_name)
 {
-  static_assert(offsetof(OH0, m_scan_thread) == sizeof(OH0) - sizeof(ScanThread),
-                "ScanThread must be the last data member");
+}
+
+OH0::~OH0()
+{
+  m_scan_thread.Stop();
 }
 
 IPCCommandResult OH0::Open(const OpenRequest& request)

--- a/Source/Core/Core/IOS/USB/OH0/OH0.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.h
@@ -37,6 +37,7 @@ class OH0 final : public USBHost
 {
 public:
   OH0(Kernel& ios, const std::string& device_name);
+  ~OH0() override;
 
   IPCCommandResult Open(const OpenRequest& request) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -24,8 +24,11 @@ namespace IOS::HLE::Device
 {
 USB_HIDv4::USB_HIDv4(Kernel& ios, const std::string& device_name) : USBHost(ios, device_name)
 {
-  static_assert(offsetof(USB_HIDv4, m_scan_thread) == sizeof(USB_HIDv4) - sizeof(ScanThread),
-                "ScanThread must be the last data member");
+}
+
+USB_HIDv4::~USB_HIDv4()
+{
+  m_scan_thread.Stop();
 }
 
 IPCCommandResult USB_HIDv4::IOCtl(const IOCtlRequest& request)

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -22,6 +22,7 @@ class USB_HIDv4 final : public USBHost
 {
 public:
   USB_HIDv4(Kernel& ios, const std::string& device_name);
+  ~USB_HIDv4() override;
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -18,13 +18,13 @@ namespace IOS::HLE::Device
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
-USB_HIDv5::~USB_HIDv5() = default;
+USB_HIDv5::~USB_HIDv5()
+{
+  m_scan_thread.Stop();
+}
 
 IPCCommandResult USB_HIDv5::IOCtl(const IOCtlRequest& request)
 {
-  static_assert(offsetof(USB_HIDv5, m_scan_thread) == sizeof(USB_HIDv5) - sizeof(ScanThread),
-                "ScanThread must be the last data member");
-
   request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -18,13 +18,13 @@ namespace IOS::HLE::Device
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
-USB_VEN::~USB_VEN() = default;
+USB_VEN::~USB_VEN()
+{
+  m_scan_thread.Stop();
+}
 
 IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
 {
-  static_assert(offsetof(USB_VEN, m_scan_thread) == sizeof(USB_VEN) - sizeof(ScanThread),
-                "ScanThread must be the last data member");
-
   request.Log(GetDeviceName(), Common::Log::IOS_USB);
   switch (request.request)
   {


### PR DESCRIPTION
Unfortunately, compilers will issue warnings when using offsetof with
non-standard layout types even when offsetof actually works fine here;
just having a virtual function is enough to trigger the warning...

Let's just stop the scan threads explicitly in destructors instead of
relying on member destruction order.