### PR TITLE
Android: Fix initTouchPointer

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -155,7 +155,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     // Refresh before starting the pointer
     refreshControls();
 
-    if (!NativeLibrary.IsEmulatingWii())
+    if (NativeLibrary.IsEmulatingWii())
     {
       int doubleTapButton = IntSetting.MAIN_DOUBLE_TAP_BUTTON.getIntGlobal();
 


### PR DESCRIPTION
Fixes a regression from 0dc29c743b9b2ed2dabf9d510cafcf99ca46b1f5. @JosJuice we missed this.