### PR TITLE
Fix logger related crash when HTTP response is empty.

### DIFF
--- a/Source/Core/Common/HttpRequest.cpp
+++ b/Source/Core/Common/HttpRequest.cpp
@@ -221,8 +221,16 @@ HttpRequest::Response HttpRequest::Impl::Fetch(const std::string& url, Method me
   curl_easy_getinfo(m_curl.get(), CURLINFO_RESPONSE_CODE, &response_code);
   if (response_code != 200)
   {
-    ERROR_LOG_FMT(COMMON, "Failed to {} {}: server replied with code {} and body\n\x1b[0m{:.{}}",
-                  type, url, response_code, buffer.data(), static_cast<int>(buffer.size()));
+    if (buffer.empty())
+    {
+      ERROR_LOG_FMT(COMMON, "Failed to {} {}: server replied with code {}", type, url,
+                    response_code);
+    }
+    else
+    {
+      ERROR_LOG_FMT(COMMON, "Failed to {} {}: server replied with code {} and body\n\x1b[0m{:.{}}",
+                    type, url, response_code, buffer.data(), static_cast<int>(buffer.size()));
+    }
     return {};
   }
 


### PR DESCRIPTION
Fixes a regression introduced by #9187 where Dolphin would crash to desktop in the event the HTTP server returned a zero-length error response, which the update server appears to do occasionally. 

The exception in question seems intentional in the logger so I've added a case to make sure there is response body before trying to log it.

EDIT: This crash can also happen when GameTDB doesn't have covers for a game in your library and Dolphin attempts to download it.