### PR TITLE
Logic & UI for "Virtual Notches"

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -169,6 +169,45 @@ QPolygonF GetPolygonFromRadiusGetter(F&& radius_getter)
   return shape;
 }
 
+// Constructs a polygon by querying a radius at varying angles:
+template <typename F>
+QPolygonF GetPolygonSegmentFromRadiusGetter(F&& radius_getter, double direction,
+                                            double segment_size, double segment_depth)
+{
+  constexpr int shape_point_count = 6;
+  QPolygonF shape{shape_point_count};
+
+  // We subtract from the provided direction angle so it's better
+  // to add Tau here to prevent a negative value instead of
+  // expecting the function call to be aware of this internal logic
+  const double center_angle = direction + MathUtil::TAU;
+  const double center_radius_outer = radius_getter(center_angle);
+  const double center_radius_inner = center_radius_outer - segment_depth;
+
+  const double lower_angle = center_angle - segment_size / 2;
+  const double lower_radius_outer = radius_getter(lower_angle);
+  const double lower_radius_inner = lower_radius_outer - segment_depth;
+
+  const double upper_angle = center_angle + segment_size / 2;
+  const double upper_radius_outer = radius_getter(upper_angle);
+  const double upper_radius_inner = upper_radius_outer - segment_depth;
+
+  shape[0] = {std::cos(lower_angle) * (lower_radius_inner),
+              std::sin(lower_angle) * (lower_radius_inner)};
+  shape[1] = {std::cos(center_angle) * (center_radius_inner),
+              std::sin(center_angle) * (center_radius_inner)};
+  shape[2] = {std::cos(upper_angle) * (upper_radius_inner),
+              std::sin(upper_angle) * (upper_radius_inner)};
+  shape[3] = {std::cos(upper_angle) * upper_radius_outer,
+              std::sin(upper_angle) * upper_radius_outer};
+  shape[4] = {std::cos(center_angle) * center_radius_outer,
+              std::sin(center_angle) * center_radius_outer};
+  shape[5] = {std::cos(lower_angle) * lower_radius_outer,
+              std::sin(lower_angle) * lower_radius_outer};
+
+  return shape;
+}
+
 // Used to check if the user seems to have attempted proper calibration.
 bool IsCalibrationDataSensible(const ControllerEmu::ReshapableInput::CalibrationData& data)
 {
@@ -208,6 +247,24 @@ bool IsPointOutsideCalibration(Common::DVec2 point, ControllerEmu::ReshapableInp
   constexpr double ALLOWED_ERROR = 1.3;
 
   return current_radius > input_radius * ALLOWED_ERROR;
+}
+
+void DrawVirtualNotches(QPainter& p, ControllerEmu::ReshapableInput& stick, QColor notch_color)
+{
+  const double segment_size = stick.GetVirtualNotchSize();
+  if (segment_size <= 0.0)
+    return;
+
+  p.setBrush(notch_color);
+  for (int i = 0; i < 8; ++i)
+  {
+    const double segment_depth = 1.0 - ControllerEmu::MINIMUM_NOTCH_DISTANCE;
+    const double segment_gap = MathUtil::TAU / 8.0;
+    const double direction = segment_gap * i;
+    p.drawPolygon(GetPolygonSegmentFromRadiusGetter(
+        [&stick](double ang) { return stick.GetGateRadiusAtAngle(ang); }, direction, segment_size,
+        segment_depth));
+  }
 }
 
 template <typename F>
@@ -300,6 +357,8 @@ void ReshapableInputIndicator::DrawReshapableInput(
   p.setBrush(gate_brush_color);
   p.drawPolygon(
       GetPolygonFromRadiusGetter([&stick](double ang) { return stick.GetGateRadiusAtAngle(ang); }));
+
+  DrawVirtualNotches(p, stick, gate_pen_color);
 
   const auto center = stick.GetCenter();
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -65,6 +65,12 @@ OctagonAnalogStick::OctagonAnalogStick(const char* name_, const char* ui_name_,
                                        ControlState gate_radius)
     : AnalogStick(name_, ui_name_, std::make_unique<ControllerEmu::OctagonStickGate>(gate_radius))
 {
+  AddVirtualNotchSetting(&m_virtual_notch_setting, 45);
+}
+
+ControlState OctagonAnalogStick::GetVirtualNotchSize() const
+{
+  return m_virtual_notch_setting.GetValue() * MathUtil::TAU / 360;
 }
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -33,6 +33,11 @@ class OctagonAnalogStick : public AnalogStick
 public:
   OctagonAnalogStick(const char* name, ControlState gate_radius);
   OctagonAnalogStick(const char* name, const char* ui_name, ControlState gate_radius);
+
+  ControlState GetVirtualNotchSize() const override;
+
+private:
+  SettingValue<double> m_virtual_notch_setting;
 };
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -28,6 +28,17 @@ ControlGroup::ControlGroup(std::string name_, std::string ui_name_, const GroupT
 {
 }
 
+void ControlGroup::AddVirtualNotchSetting(SettingValue<double>* value, double max_virtual_notch_deg)
+{
+  AddSetting(value,
+             {_trans("Virtual Notches"),
+              // i18n: The degrees symbol.
+              _trans("°"),
+              // i18n: Snap the thumbstick position to the nearest octagonal axis.
+              _trans("Snap the thumbstick position to the nearest octagonal axis.")},
+             0, 0, max_virtual_notch_deg);
+}
+
 void ControlGroup::AddDeadzoneSetting(SettingValue<double>* value, double maximum_deadzone)
 {
   AddSetting(value,

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -82,6 +82,8 @@ public:
         std::make_unique<NumericSetting<T>>(value, details, default_value_, min_value, max_value));
   }
 
+  void AddVirtualNotchSetting(SettingValue<double>* value, double max_virtual_notch_deg);
+
   void AddDeadzoneSetting(SettingValue<double>* value, double maximum_deadzone);
 
   template <typename T>

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -15,6 +15,9 @@
 
 namespace ControllerEmu
 {
+// Minimum stick distance from the center before virtual notches are applied.
+constexpr ControlState MINIMUM_NOTCH_DISTANCE = 0.9;
+
 // An abstract class representing the plastic shell that limits an analog stick's movement.
 class StickGate
 {
@@ -84,6 +87,8 @@ public:
   ControlState GetInputRadiusAtAngle(double angle) const;
 
   ControlState GetDeadzonePercentage() const;
+
+  virtual ControlState GetVirtualNotchSize() const { return 0.0; };
 
   virtual ControlState GetGateRadiusAtAngle(double angle) const = 0;
   virtual ReshapeData GetReshapableState(bool adjusted) = 0;


### PR DESCRIPTION
This is a feature that I wanted in Dolphin for quite some time now. It should make playing games like Super Monkey Ball feel a bit closer to using a GC controller when using a controller without an Octagonal gate (e.g. Xbox, PS4, Steam e.t.c).

Adds an option in the controller config to set the size of the virtual notches. These virtual notches add a sticky behaviour that will snap the controller to the different axis.

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/9058133/97570125-589cbb00-19df-11eb-81bf-6c3bfda4ac91.gif)


Disclaimer:
I've never written C++ before (besides Hello World about 10 years ago) so I'm completely open to suggestions for improvements. I was unable to get the linter running locally but I think Visual Studio was enforcing code styling while developing so I'm hoping it's already formatted correctly.