### PR TITLE
Game INI Changes

### DIFF
--- a/Data/Sys/GameSettings/JAP.ini
+++ b/Data/Sys/GameSettings/JAP.ini
@@ -1,0 +1,5 @@
+# JAPJ01 - Fire Emblem: Seisen no Keifu
+
+[Video_Hacks]
+# Fixes black screen.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/JB6.ini
+++ b/Data/Sys/GameSettings/JB6.ini
@@ -1,0 +1,5 @@
+# JB6J01 - Treasure Hunter G
+
+[Video_Hacks]
+# Fixes black screen.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/JBH.ini
+++ b/Data/Sys/GameSettings/JBH.ini
@@ -1,0 +1,5 @@
+# JBHJ01 - Heracles no Eikō IV: Kamigami-kara no Okurimono
+
+[Video_Hacks]
+# Fixes black screen.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/JBO.ini
+++ b/Data/Sys/GameSettings/JBO.ini
@@ -1,8 +1,5 @@
-# MBAN8P, MBAJ8P, MBAL8P - Pulseman
+# JBOJ01, JBOQ01 - Panel de Pon
 
 [Core]
 # Values set here will override the main Dolphin settings.
 CPUThread = False
-
-[Video_Hacks]
-ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/JC6.ini
+++ b/Data/Sys/GameSettings/JC6.ini
@@ -1,0 +1,5 @@
+# JC6J01 - Romancing SaGa 2
+
+[Video_Hacks]
+# Fixes black screen.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/JC9.ini
+++ b/Data/Sys/GameSettings/JC9.ini
@@ -1,0 +1,5 @@
+# JC9J01 - Final Fantasy V
+
+[Video_Hacks]
+# Fixes black screen.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/JCE.ini
+++ b/Data/Sys/GameSettings/JCE.ini
@@ -1,0 +1,5 @@
+# JCEJ01 - Fire Emblem: Thracia 776
+
+[Video_Hacks]
+# Fixes black screen.
+EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/LAD.ini
+++ b/Data/Sys/GameSettings/LAD.ini
@@ -1,6 +1,6 @@
-# MB3L8P, MB3J8P, MB3E8P - Monster World IV
+# LADP8P, LADJ8P, LADE8P - Phantasy Star
 
 [Video_Hacks]
-# Fixes purple screen. 
+# Fixes purple screen.
 XFBToTextureEnable = False
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/LAF.ini
+++ b/Data/Sys/GameSettings/LAF.ini
@@ -1,0 +1,6 @@
+# LAFP8P, LAFN8P, LAFJ8P - Rambo: First Blood Part II
+
+[Video_Hacks]
+# Fixes purple screen.
+XFBToTextureEnable = False
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/LAK.ini
+++ b/Data/Sys/GameSettings/LAK.ini
@@ -1,0 +1,6 @@
+# LAKP8P, LAKJ8P, LAKE8P - Wonder Boy in Monster Land
+
+[Video_Hacks]
+# Fixes purple screen.
+XFBToTextureEnable = False
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/LAL.ini
+++ b/Data/Sys/GameSettings/LAL.ini
@@ -1,0 +1,6 @@
+# LALP8P, LALJ8P, LALE8P - Fantasy Zone II: The Tears of Opa-Opa
+
+[Video_Hacks]
+# Fixes purple screen.
+XFBToTextureEnable = False
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/LAO.ini
+++ b/Data/Sys/GameSettings/LAO.ini
@@ -1,6 +1,6 @@
-# MB3L8P, MB3J8P, MB3E8P - Monster World IV
+# LAOP8P, LAOE8P, LAOJ8P - R-Type
 
 [Video_Hacks]
-# Fixes purple screen. 
+# Fixes purple screen.
 XFBToTextureEnable = False
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/LAP.ini
+++ b/Data/Sys/GameSettings/LAP.ini
@@ -1,0 +1,6 @@
+# LAPP8P, LAPE8P Wonder Boy III: The Dragon's Trap
+
+[Video_Hacks]
+# Fixes purple screen.
+XFBToTextureEnable = False
+ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MB9.ini
+++ b/Data/Sys/GameSettings/MB9.ini
@@ -1,6 +1,6 @@
-# MB3L8P, MB3J8P, MB3E8P - Monster World IV
+# MB9J8P - Pepenga Pengo
 
 [Video_Hacks]
-# Fixes purple screen. 
+# Fixes purple screen.
 XFBToTextureEnable = False
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCT.ini
+++ b/Data/Sys/GameSettings/MCT.ini
@@ -1,6 +1,6 @@
-# MB3L8P, MB3J8P, MB3E8P - Monster World IV
+# MCTE8P, MCTP8P - ClayFighter
 
 [Video_Hacks]
-# Fixes purple screen. 
+# Fixes purple screen.
 XFBToTextureEnable = False
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCV.ini
+++ b/Data/Sys/GameSettings/MCV.ini
@@ -1,6 +1,8 @@
-# MCVE8P - Pitfall
+# MCVP8P, MCVJ8P, MCVE8P - Pitfall: The Mayan Adventure
 
-[Video_Settings]
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/MCY.ini
+++ b/Data/Sys/GameSettings/MCY.ini
@@ -1,6 +1,8 @@
-# MCYE8P - Revenge of Shinobi
+# MCYE8P, MCYJ8P, MCYP8P - Revenge of Shinobi
 
-[Video_Settings]
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False

--- a/Data/Sys/GameSettings/S25.ini
+++ b/Data/Sys/GameSettings/S25.ini
@@ -1,0 +1,9 @@
+# S25JGD - Dragon Quest 25 Shuunen Kinen: Famicom & Super Famicom Dragon Quest I-II-III
+
+[Video_Settings]
+# Fixes cursor freeze.
+SafeTextureCacheColorSamples = 0
+
+[Video_Hacks]
+# Fixes black screen.
+EFBToTextureEnable = False


### PR DESCRIPTION
This adds the INI changes to the SNES games which needed EFB Copies to Texture Only turned off to not display a black screen, the Dualcore issues with some SNES and Sega Genesis games in terms of stuttering and darkening the screen, and also the XFB issues for Sega Genesis and Sega Master System games in terms of purple screens