### PR TITLE
Android: Remove some touchscreen checks from EmulationActivity

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -73,7 +73,6 @@ public final class EmulationActivity extends AppCompatActivity
 
   private Settings mSettings;
 
-  private boolean mDeviceHasTouchScreen;
   private boolean mMenuVisible;
 
   private static boolean sIgnoreLaunchRequests = false;
@@ -229,7 +228,6 @@ public final class EmulationActivity extends AppCompatActivity
 
     updateOrientation();
 
-    mDeviceHasTouchScreen = getPackageManager().hasSystemFeature("android.hardware.touchscreen");
     mMotionListener = new MotionListener(this);
 
     // Set these options now so that the SurfaceView the game renders into is the right size.
@@ -311,8 +309,7 @@ public final class EmulationActivity extends AppCompatActivity
     setTitle(NativeLibrary.GetCurrentTitleDescription());
     updateMotionListener();
 
-    if (mDeviceHasTouchScreen)
-      mEmulationFragment.refreshInputOverlay();
+    mEmulationFragment.refreshInputOverlay();
   }
 
   private void updateMotionListener()
@@ -1169,7 +1166,6 @@ public final class EmulationActivity extends AppCompatActivity
 
   public void initInputPointer()
   {
-    if (mDeviceHasTouchScreen)
-      mEmulationFragment.initInputPointer();
+    mEmulationFragment.initInputPointer();
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -124,22 +124,27 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
   {
     BooleanSetting.MAIN_SHOW_INPUT_OVERLAY
             .setBoolean(settings, !BooleanSetting.MAIN_SHOW_INPUT_OVERLAY.getBoolean(settings));
-    mInputOverlay.refreshControls();
+
+    if (mInputOverlay != null)
+      mInputOverlay.refreshControls();
   }
 
   public void initInputPointer()
   {
-    mInputOverlay.initTouchPointer();
+    if (mInputOverlay != null)
+      mInputOverlay.initTouchPointer();
   }
 
   public void refreshInputOverlay()
   {
-    mInputOverlay.refreshControls();
+    if (mInputOverlay != null)
+      mInputOverlay.refreshControls();
   }
 
   public void resetInputOverlay()
   {
-    mInputOverlay.resetButtonPlacement();
+    if (mInputOverlay != null)
+      mInputOverlay.resetButtonPlacement();
   }
 
   @Override
@@ -169,19 +174,25 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 
   public void startConfiguringControls()
   {
-    getView().findViewById(R.id.done_control_config).setVisibility(View.VISIBLE);
-    mInputOverlay.setIsInEditMode(true);
+    if (mInputOverlay != null)
+    {
+      requireView().findViewById(R.id.done_control_config).setVisibility(View.VISIBLE);
+      mInputOverlay.setIsInEditMode(true);
+    }
   }
 
   public void stopConfiguringControls()
   {
-    getView().findViewById(R.id.done_control_config).setVisibility(View.GONE);
-    mInputOverlay.setIsInEditMode(false);
+    if (mInputOverlay != null)
+    {
+      requireView().findViewById(R.id.done_control_config).setVisibility(View.GONE);
+      mInputOverlay.setIsInEditMode(false);
+    }
   }
 
   public boolean isConfiguringControls()
   {
-    return mInputOverlay.isInEditMode();
+    return mInputOverlay != null && mInputOverlay.isInEditMode();
   }
 
   private static class EmulationState


### PR DESCRIPTION
It's better to directly check whether we have an InputOverlay than to check a proxy for it.