### PR TITLE
JitArm64: Implement HLE function hooking

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -46,7 +46,7 @@ public:
   // OPCODES
   void FallBackToInterpreter(UGeckoInstruction inst);
   void DoNothing(UGeckoInstruction inst);
-  void HLEFunction(UGeckoInstruction inst);
+  void HLEFunction(u32 hook_index);
 
   void DynaRunTable4(UGeckoInstruction inst);
   void DynaRunTable19(UGeckoInstruction inst);
@@ -174,6 +174,8 @@ private:
 
   static void InitializeInstructionTables();
   void CompileInstruction(PPCAnalyst::CodeOp& op);
+
+  bool HandleFunctionHooking(u32 address);
 
   // Simple functions to switch between near and far code emitting
   void SwitchToFarCode()


### PR DESCRIPTION
Closely based on the x86-64 implementation. Fixes https://bugs.dolphin-emu.org/issues/10965.