### PR TITLE
Android: Make scrollbar for in-game menu always visible

### DIFF
--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -22,7 +22,8 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        android:fadeScrollbars="false">
 
         <LinearLayout
             android:id="@+id/layout_options"


### PR DESCRIPTION
Some users aren't noticing that the in-game menu can be scrolled. I hope this will help with that, though I'm not sure by how much.