### PR TITLE
Android: Handle failed boots correctly

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -403,14 +403,12 @@ public final class NativeLibrary
    */
   public static native void StopEmulation();
 
-  public static native boolean IsBooting();
-
-  public static native void WaitUntilDoneBooting();
-
   /**
    * Returns true if emulation is running (or is paused).
    */
   public static native boolean IsRunning();
+
+  public static native boolean IsRunningAndStarted();
 
   /**
    * Enables or disables CPU block profiling
@@ -487,7 +485,7 @@ public final class NativeLibrary
   private static native String GetCurrentTitleDescriptionUnchecked();
 
   public static boolean displayAlertMsg(final String caption, final String text,
-          final boolean yesNo, final boolean isWarning)
+          final boolean yesNo, final boolean isWarning, final boolean nonBlocking)
   {
     Log.error("[NativeLibrary] Alert: " + text);
     final EmulationActivity emulationActivity = sEmulationActivity.get();
@@ -498,10 +496,9 @@ public final class NativeLibrary
     }
     else
     {
-      // AlertMessages while the core is booting will deadlock if WaitUntilDoneBooting is called.
-      // We also can't use AlertMessages unless we have a non-null activity reference.
-      // As a fallback, we use toasts instead.
-      if (emulationActivity == null || IsBooting())
+      // We can't use AlertMessages unless we have a non-null activity reference
+      // and are allowed to block. As a fallback, we can use toasts.
+      if (emulationActivity == null || nonBlocking)
       {
         new Handler(Looper.getMainLooper()).post(
                 () -> Toast.makeText(DolphinApplication.getAppContext(), text, Toast.LENGTH_LONG)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -563,6 +563,20 @@ public final class NativeLibrary
     sEmulationActivity.clear();
   }
 
+  public static void finishEmulationActivity()
+  {
+    final EmulationActivity emulationActivity = sEmulationActivity.get();
+    if (emulationActivity == null)
+    {
+      Log.warning("[NativeLibrary] EmulationActivity is null.");
+    }
+    else
+    {
+      Log.verbose("[NativeLibrary] Finishing EmulationActivity.");
+      emulationActivity.runOnUiThread(emulationActivity::finish);
+    }
+  }
+
   public static void updateTouchPointer()
   {
     final EmulationActivity emulationActivity = sEmulationActivity.get();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -342,7 +342,6 @@ public final class EmulationActivity extends AppCompatActivity
     if (keyCode == KeyEvent.KEYCODE_BACK)
     {
       mEmulationFragment.stopEmulation();
-      finish();
       return true;
     }
     return super.onKeyLongPress(keyCode, event);
@@ -617,7 +616,6 @@ public final class EmulationActivity extends AppCompatActivity
 
       case MENU_ACTION_EXIT:
         mEmulationFragment.stopEmulation();
-        finish();
         break;
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -81,10 +81,12 @@ public final class EmulationActivity extends AppCompatActivity
   private String[] mPaths;
   private boolean mIgnoreWarnings;
   private static boolean sUserPausedEmulation;
+  private boolean mMenuToastShown;
 
   public static final String EXTRA_SELECTED_GAMES = "SelectedGames";
   public static final String EXTRA_IGNORE_WARNINGS = "IgnoreWarnings";
   public static final String EXTRA_USER_PAUSED_EMULATION = "sUserPausedEmulation";
+  public static final String EXTRA_MENU_TOAST_SHOWN = "MenuToastShown";
 
   @Retention(SOURCE)
   @IntDef({MENU_ACTION_EDIT_CONTROLS_PLACEMENT, MENU_ACTION_TOGGLE_CONTROLS, MENU_ACTION_ADJUST_SCALE,
@@ -212,8 +214,8 @@ public final class EmulationActivity extends AppCompatActivity
       mPaths = gameToEmulate.getStringArrayExtra(EXTRA_SELECTED_GAMES);
       mIgnoreWarnings = gameToEmulate.getBooleanExtra(EXTRA_IGNORE_WARNINGS, false);
       sUserPausedEmulation = gameToEmulate.getBooleanExtra(EXTRA_USER_PAUSED_EMULATION, false);
+      mMenuToastShown = false;
       activityRecreated = false;
-      Toast.makeText(this, R.string.emulation_menu_help, Toast.LENGTH_LONG).show();
     }
     else
     {
@@ -260,8 +262,9 @@ public final class EmulationActivity extends AppCompatActivity
       mEmulationFragment.saveTemporaryState();
     }
     outState.putStringArray(EXTRA_SELECTED_GAMES, mPaths);
-    outState.putBoolean(EXTRA_USER_PAUSED_EMULATION, mIgnoreWarnings);
+    outState.putBoolean(EXTRA_IGNORE_WARNINGS, mIgnoreWarnings);
     outState.putBoolean(EXTRA_USER_PAUSED_EMULATION, sUserPausedEmulation);
+    outState.putBoolean(EXTRA_MENU_TOAST_SHOWN, mMenuToastShown);
     super.onSaveInstanceState(outState);
   }
 
@@ -270,6 +273,7 @@ public final class EmulationActivity extends AppCompatActivity
     mPaths = savedInstanceState.getStringArray(EXTRA_SELECTED_GAMES);
     mIgnoreWarnings = savedInstanceState.getBoolean(EXTRA_IGNORE_WARNINGS);
     sUserPausedEmulation = savedInstanceState.getBoolean(EXTRA_USER_PAUSED_EMULATION);
+    mMenuToastShown = savedInstanceState.getBoolean(EXTRA_MENU_TOAST_SHOWN);
   }
 
   @Override
@@ -306,6 +310,13 @@ public final class EmulationActivity extends AppCompatActivity
 
   public void onTitleChanged()
   {
+    if (!mMenuToastShown)
+    {
+      // The reason why this doesn't run earlier is because we want to be sure the boot succeeded.
+      Toast.makeText(this, R.string.emulation_menu_help, Toast.LENGTH_LONG).show();
+      mMenuToastShown = true;
+    }
+
     setTitle(NativeLibrary.GetCurrentTitleDescription());
     updateMotionListener();
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -330,16 +330,6 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
         mSurface = null;
         Log.debug("[EmulationFragment] Surface destroyed.");
 
-        if (state != State.STOPPED && !NativeLibrary.IsShowingAlertMessage())
-        {
-          // In order to avoid dereferencing nullptr, we must not destroy the surface while booting
-          // the core, so wait here if necessary. An easy (but not 100% consistent) way to reach
-          // this method while the core is booting is by having landscape orientation lock enabled
-          // and starting emulation while the phone is in portrait mode, leading to the activity
-          // being recreated very soon after NativeLibrary.Run has been called.
-          NativeLibrary.WaitUntilDoneBooting();
-        }
-
         NativeLibrary.SurfaceDestroyed();
       }
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -148,7 +148,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
   public void initTouchPointer()
   {
     // Check if we have all the data we need yet
-    boolean aspectRatioAvailable = NativeLibrary.IsRunning() && !NativeLibrary.IsBooting();
+    boolean aspectRatioAvailable = NativeLibrary.IsRunningAndStarted();
     if (!aspectRatioAvailable || mSurfacePosition == null)
       return;
 

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -222,7 +222,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
   const jclass native_library_class = env->FindClass("org/dolphinemu/dolphinemu/NativeLibrary");
   s_native_library_class = reinterpret_cast<jclass>(env->NewGlobalRef(native_library_class));
   s_display_alert_msg = env->GetStaticMethodID(s_native_library_class, "displayAlertMsg",
-                                               "(Ljava/lang/String;Ljava/lang/String;ZZ)Z");
+                                               "(Ljava/lang/String;Ljava/lang/String;ZZZ)Z");
   s_do_rumble = env->GetStaticMethodID(s_native_library_class, "rumble", "(ID)V");
   s_update_touch_pointer =
       env->GetStaticMethodID(s_native_library_class, "updateTouchPointer", "()V");

--- a/Source/Android/jni/AndroidCommon/IDCache.cpp
+++ b/Source/Android/jni/AndroidCommon/IDCache.cpp
@@ -15,6 +15,7 @@ static jmethodID s_display_alert_msg;
 static jmethodID s_do_rumble;
 static jmethodID s_update_touch_pointer;
 static jmethodID s_on_title_changed;
+static jmethodID s_finish_emulation_activity;
 
 static jclass s_game_file_class;
 static jfieldID s_game_file_pointer;
@@ -92,6 +93,11 @@ jmethodID GetUpdateTouchPointer()
 jmethodID GetOnTitleChanged()
 {
   return s_on_title_changed;
+}
+
+jmethodID GetFinishEmulationActivity()
+{
+  return s_finish_emulation_activity;
 }
 
 jclass GetAnalyticsClass()
@@ -221,6 +227,8 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
   s_update_touch_pointer =
       env->GetStaticMethodID(s_native_library_class, "updateTouchPointer", "()V");
   s_on_title_changed = env->GetStaticMethodID(s_native_library_class, "onTitleChanged", "()V");
+  s_finish_emulation_activity =
+      env->GetStaticMethodID(s_native_library_class, "finishEmulationActivity", "()V");
   env->DeleteLocalRef(native_library_class);
 
   const jclass game_file_class = env->FindClass("org/dolphinemu/dolphinemu/model/GameFile");

--- a/Source/Android/jni/AndroidCommon/IDCache.h
+++ b/Source/Android/jni/AndroidCommon/IDCache.h
@@ -15,6 +15,7 @@ jmethodID GetDisplayAlertMsg();
 jmethodID GetDoRumble();
 jmethodID GetUpdateTouchPointer();
 jmethodID GetOnTitleChanged();
+jmethodID GetFinishEmulationActivity();
 
 jclass GetAnalyticsClass();
 jmethodID GetSendAnalyticsReport();

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -77,7 +77,6 @@ ANativeWindow* s_surf;
 // sequentially for access.
 std::mutex s_host_identity_lock;
 Common::Event s_update_main_frame_event;
-Common::Event s_emulation_end_event;
 bool s_have_wm_user_stop = false;
 bool s_game_metadata_is_valid = false;
 }  // Anonymous namespace
@@ -210,17 +209,11 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulati
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulation(JNIEnv*, jclass)
 {
-  {
-    std::lock_guard<std::mutex> guard(s_host_identity_lock);
-    s_emulation_end_event.Reset();
-    Core::Stop();
+  std::lock_guard<std::mutex> guard(s_host_identity_lock);
+  Core::Stop();
 
-    // Kick the waiting event
-    s_update_main_frame_event.Set();
-  }
-
-  // Wait for shutdown, to avoid accessing the config at the same time as the shutdown code
-  s_emulation_end_event.Wait();
+  // Kick the waiting event
+  s_update_main_frame_event.Set();
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsBooting(JNIEnv*, jclass)
@@ -533,7 +526,8 @@ static void Run(JNIEnv* env, const std::vector<std::string>& paths,
     s_surf = nullptr;
   }
 
-  s_emulation_end_event.Set();
+  env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(),
+                            IDCache::GetFinishEmulationActivity());
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Run___3Ljava_lang_String_2(

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -543,12 +543,6 @@ static void Run(JNIEnv* env, const std::vector<std::string>& paths,
   ButtonManager::Shutdown();
   host_identity_guard.unlock();
 
-  if (s_surf)
-  {
-    ANativeWindow_release(s_surf);
-    s_surf = nullptr;
-  }
-
   env->CallStaticVoidMethod(IDCache::GetNativeLibraryClass(),
                             IDCache::GetFinishEmulationActivity());
 }

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -99,7 +99,6 @@ void UndeclareAsCPUThread();
 
 std::string StopMessage(bool main_thread, std::string_view message);
 
-bool IsBooting();
 bool IsRunning();
 bool IsRunningAndStarted();       // is running and the CPU loop has been entered
 bool IsRunningInCurrentThread();  // this tells us whether we are running in the CPU thread.
@@ -111,7 +110,6 @@ bool WantsDeterminism();
 // [NOT THREADSAFE] For use by Host only
 void SetState(State state);
 State GetState();
-void WaitUntilDoneBooting();
 
 void SaveScreenShot();
 void SaveScreenShot(std::string_view name);


### PR DESCRIPTION
If you try to boot an invalid file in master (for instance if you pick Open File and try to open a PNG file you renamed to .iso), Dolphin more or less locks up. This PR aims to make that scenario work correctly.