### PR TITLE
Android: Call saveSettings in EmulationActivity.onStop

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -257,7 +257,6 @@ public final class EmulationActivity extends AppCompatActivity
   {
     if (!isChangingConfigurations())
     {
-      mSettings.saveSettings(null, null);
       mEmulationFragment.saveTemporaryState();
     }
     outState.putStringArray(EXTRA_SELECTED_GAMES, mPaths);
@@ -302,6 +301,7 @@ public final class EmulationActivity extends AppCompatActivity
   protected void onStop()
   {
     super.onStop();
+    mSettings.saveSettings(null, null);
   }
 
   public void onTitleChanged()


### PR DESCRIPTION
I didn't realize that onSaveInstanceState doesn't get called when finishing the activity.