### PR TITLE
Android: Remove unnecessary WrongConstant warning suppression

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -435,7 +435,6 @@ public final class EmulationActivity extends AppCompatActivity
     popup.show();
   }
 
-  @SuppressWarnings("WrongConstant")
   @Override
   public boolean onOptionsItemSelected(MenuItem item)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -180,7 +180,6 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
     mPauseEmulation.setVisibility(paused ? View.GONE : View.VISIBLE);
   }
 
-  @SuppressWarnings("WrongConstant")
   @Override
   public void onClick(View button)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveLoadStateFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveLoadStateFragment.java
@@ -95,7 +95,6 @@ public final class SaveLoadStateFragment extends Fragment implements View.OnClic
     return rootView;
   }
 
-  @SuppressWarnings("WrongConstant")
   @Override
   public void onClick(View view)
   {


### PR DESCRIPTION
Android Studio doesn't raise any warnings when these are removed.