### PR TITLE
Qt/IOWindow: Show result value in expression editor.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -240,7 +240,6 @@ void IOWindow::CreateMainLayout()
   m_test_button = new QPushButton(tr("Test"), this);
   m_button_box = new QDialogButtonBox();
   m_clear_button = new QPushButton(tr("Clear"));
-  m_apply_button = new QPushButton(tr("Apply"));
   m_range_slider = new QSlider(Qt::Horizontal);
   m_range_spinbox = new QSpinBox();
 
@@ -376,7 +375,6 @@ void IOWindow::CreateMainLayout()
   // Button Box
   m_main_layout->addWidget(m_button_box);
   m_button_box->addButton(m_clear_button, QDialogButtonBox::ActionRole);
-  m_button_box->addButton(m_apply_button, QDialogButtonBox::ActionRole);
   m_button_box->addButton(QDialogButtonBox::Ok);
 
   setLayout(m_main_layout);
@@ -419,11 +417,8 @@ void IOWindow::ConnectWidgets()
   connect(m_range_spinbox, qOverload<int>(&QSpinBox::valueChanged), this,
           &IOWindow::OnRangeChanged);
 
-  connect(m_expression_text, &QPlainTextEdit::textChanged, [this] {
-    m_apply_button->setText(m_apply_button->text().remove(QStringLiteral("*")));
-    m_apply_button->setText(m_apply_button->text() + QStringLiteral("*"));
-    UpdateExpression(m_expression_text->toPlainText().toStdString());
-  });
+  connect(m_expression_text, &QPlainTextEdit::textChanged,
+          [this] { UpdateExpression(m_expression_text->toPlainText().toStdString()); });
 
   connect(m_operators_combo, qOverload<int>(&QComboBox::activated), [this](int index) {
     if (0 == index)
@@ -475,15 +470,13 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
   UpdateExpression(m_expression_text->toPlainText().toStdString());
   m_original_expression = m_reference->GetExpression();
 
-  m_apply_button->setText(m_apply_button->text().remove(QStringLiteral("*")));
-
   if (ciface::ExpressionParser::ParseStatus::SyntaxError == m_reference->GetParseStatus())
   {
     ModalMessageBox::warning(this, tr("Error"), tr("The expression contains a syntax error."));
   }
 
-  if (button != m_apply_button)
-    accept();
+  // must be the OK button
+  accept();
 }
 
 void IOWindow::OnDetectButtonPressed()

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include <QDialog>
 #include <QString>
 #include <QSyntaxHighlighter>
@@ -34,13 +37,10 @@ class ControlExpressionSyntaxHighlighter final : public QSyntaxHighlighter
 {
   Q_OBJECT
 public:
-  ControlExpressionSyntaxHighlighter(QTextDocument* parent, QLineEdit* result);
+  explicit ControlExpressionSyntaxHighlighter(QTextDocument* parent);
 
 protected:
   void highlightBlock(const QString& text) final override;
-
-private:
-  QLineEdit* const m_result_text;
 };
 
 class IOWindow final : public QDialog
@@ -73,6 +73,8 @@ private:
   void AppendSelectedOption();
   void UpdateOptionList();
   void UpdateDeviceList();
+
+  void UpdateExpression(std::string new_expression);
 
   // Main Layout
   QVBoxLayout* m_main_layout;
@@ -108,6 +110,7 @@ private:
   QPushButton* m_apply_button;
 
   ControlReference* m_reference;
+  std::string m_original_expression;
   ControllerEmu::EmulatedController* m_controller;
 
   ciface::Core::DeviceQualifier m_devq;

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -115,7 +115,6 @@ private:
   // Buttonbox
   QDialogButtonBox* m_button_box;
   QPushButton* m_clear_button;
-  QPushButton* m_apply_button;
 
   ControlReference* m_reference;
   std::string m_original_expression;

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -33,6 +33,8 @@ namespace ControllerEmu
 class EmulatedController;
 }
 
+class InputStateLineEdit;
+
 class ControlExpressionSyntaxHighlighter final : public QSyntaxHighlighter
 {
   Q_OBJECT
@@ -74,7 +76,13 @@ private:
   void UpdateOptionList();
   void UpdateDeviceList();
 
-  void UpdateExpression(std::string new_expression);
+  enum class UpdateMode
+  {
+    Normal,
+    Force,
+  };
+
+  void UpdateExpression(std::string new_expression, UpdateMode mode = UpdateMode::Normal);
 
   // Main Layout
   QVBoxLayout* m_main_layout;
@@ -102,7 +110,7 @@ private:
 
   // Textarea
   QPlainTextEdit* m_expression_text;
-  QLineEdit* m_parse_text;
+  InputStateLineEdit* m_parse_text;
 
   // Buttonbox
   QDialogButtonBox* m_button_box;

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -50,12 +50,13 @@ std::string ControlReference::GetExpression() const
   return m_expression;
 }
 
-void ControlReference::SetExpression(std::string expr)
+std::optional<std::string> ControlReference::SetExpression(std::string expr)
 {
   m_expression = std::move(expr);
   auto parse_result = ParseExpression(m_expression);
   m_parse_status = parse_result.status;
   m_parsed_expression = std::move(parse_result.expr);
+  return parse_result.description;
 }
 
 ControlReference::ControlReference() : range(1), m_parsed_expression(nullptr)

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -38,7 +38,9 @@ public:
   ciface::ExpressionParser::ParseStatus GetParseStatus() const;
   void UpdateReference(ciface::ExpressionParser::ControlEnvironment& env);
   std::string GetExpression() const;
-  void SetExpression(std::string expr);
+
+  // Returns a human-readable error description when the given expression is invalid.
+  std::optional<std::string> SetExpression(std::string expr);
 
   ControlState range;
 


### PR DESCRIPTION
This displays the current result of an input expression right there in the editor, instead of the parser error box.

![success](https://user-images.githubusercontent.com/4522237/99892745-7248bf80-2c78-11eb-9811-ab12fc7a6708.png) ![fail](https://user-images.githubusercontent.com/4522237/99892747-74ab1980-2c78-11eb-9535-9e3a72a63695.png)

Updates automatically just like the available inputs table above and immediately reacts to any edits in the expression.