### PR TITLE
CPUDetect: Indicate slow PDEP/PEXT only for Zen1/+/2 (Family 23)

### DIFF
--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -42,8 +42,7 @@ struct CPUInfo
   bool bAVX2 = false;
   bool bBMI1 = false;
   bool bBMI2 = false;
-  // PDEP and PEXT are ridiculously slow on AMD Zen, so we have this flag to avoid using them there
-  // Zen 2 is also affected by this issue
+  // PDEP and PEXT are ridiculously slow on AMD Zen1, Zen1+ and Zen2 (Family 23)
   bool bFastBMI2 = false;
   bool bFMA = false;
   bool bFMA4 = false;
@@ -57,7 +56,7 @@ struct CPUInfo
   bool bLAHFSAHF64 = false;
   bool bLongMode = false;
   bool bAtom = false;
-  bool bZen = false;
+  bool bZen1p2 = false;
 
   // ARMv8 specific
   bool bFP = false;

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -118,9 +118,9 @@ void CPUInfo::Detect()
         (model == 0x1C || model == 0x26 || model == 0x27 || model == 0x35 || model == 0x36 ||
          model == 0x37 || model == 0x4A || model == 0x4D || model == 0x5A || model == 0x5D))
       bAtom = true;
-    // Detect AMD Zen (all models)
+    // Detect AMD Zen1, Zen1+ and Zen2
     if (family == 23)
-      bZen = true;
+      bZen1p2 = true;
     logical_cpu_count = (cpu_id[1] >> 16) & 0xFF;
     ht = (cpu_id[3] >> 28) & 1;
 
@@ -175,7 +175,7 @@ void CPUInfo::Detect()
   }
 
   bFlushToZero = bSSE;
-  bFastBMI2 = bBMI2 && !bZen;
+  bFastBMI2 = bBMI2 && !bZen1p2;
 
   if (max_ex_fn >= 0x80000004)
   {


### PR DESCRIPTION
With AMD Zen3, PDEP and PEXT performance is restored to levels comparable with Intel's counterparts.

https://www.anandtech.com/show/16214/amd-zen-3-ryzen-deep-dive-review-5950x-5900x-5800x-and-5700x-tested/6

Because Zen3 is _Family 25_ not _Family 23_, we only need to change the comments to indicate that the flag disabling PDEP and PEXT does not apply to Zen3.

For reference: #8586
