### PR TITLE
VideoBackends: Migrate logging over to fmt

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -67,7 +67,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   HRESULT hr = dxgi_factory->EnumAdapters(adapter_index, adapter.GetAddressOf());
   if (FAILED(hr))
   {
-    WARN_LOG(VIDEO, "Adapter %u not found, using default", adapter_index);
+    WARN_LOG_FMT(VIDEO, "Adapter {} not found, using default", adapter_index);
     adapter = nullptr;
   }
 
@@ -99,7 +99,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
     }
     else
     {
-      WARN_LOG(VIDEO, "Debug layer requested but not available.");
+      WARN_LOG_FMT(VIDEO, "Debug layer requested but not available.");
     }
   }
 
@@ -124,7 +124,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   hr = device.As(&device1);
   if (FAILED(hr))
   {
-    WARN_LOG(VIDEO, "Missing Direct3D 11.1 support. Logical operations will not be supported.");
+    WARN_LOG_FMT(VIDEO, "Missing Direct3D 11.1 support. Logical operations will not be supported.");
   }
 
   stateman = std::make_unique<StateManager>();
@@ -156,9 +156,9 @@ void Destroy()
   }
 
   if (remaining_references)
-    ERROR_LOG(VIDEO, "Unreleased references: %i.", remaining_references);
+    ERROR_LOG_FMT(VIDEO, "Unreleased references: {}.", remaining_references);
   else
-    NOTICE_LOG(VIDEO, "Successfully released all device references!");
+    NOTICE_LOG_FMT(VIDEO, "Successfully released all device references!");
 
   dxgi_factory.Reset();
   D3DCommon::UnloadLibraries();

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -386,7 +386,7 @@ ID3D11BlendState* StateCache::Get(BlendingState state)
     {
       return m_blend.emplace(state.hex, std::move(res)).first->second.Get();
     }
-    WARN_LOG(VIDEO, "Creating D3D blend state failed with an error: %x", hr);
+    WARN_LOG_FMT(VIDEO, "Creating D3D blend state failed with an error: {:08X}", hr);
   }
 
   D3D11_BLEND_DESC desc = {};

--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -35,7 +35,7 @@ void PerfQuery::EnableQuery(PerfQueryGroup type)
   {
     // TODO
     FlushOne();
-    ERROR_LOG(VIDEO, "Flushed query buffer early!");
+    ERROR_LOG_FMT(VIDEO, "Flushed query buffer early!");
   }
 
   // start query

--- a/Source/Core/VideoBackends/D3D12/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D12/BoundingBox.cpp
@@ -148,7 +148,7 @@ void BoundingBox::Flush()
     const u32 copy_size = (end - start) * sizeof(ValueType);
     if (!m_upload_buffer.ReserveMemory(copy_size, sizeof(ValueType)))
     {
-      WARN_LOG(VIDEO, "Executing command list while waiting for space in bbox stream buffer");
+      WARN_LOG_FMT(VIDEO, "Executing command list while waiting for space in bbox stream buffer");
       Renderer::GetInstance()->ExecuteCommandList(false);
       if (!m_upload_buffer.ReserveMemory(copy_size, sizeof(ValueType)))
       {

--- a/Source/Core/VideoBackends/D3D12/DXContext.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXContext.cpp
@@ -152,7 +152,7 @@ bool DXContext::CreateDevice(u32 adapter_index, bool enable_debug_layer)
   HRESULT hr = m_dxgi_factory->EnumAdapters(adapter_index, &adapter);
   if (FAILED(hr))
   {
-    ERROR_LOG(VIDEO, "Adapter %u not found, using default", adapter_index);
+    ERROR_LOG_FMT(VIDEO, "Adapter {} not found, using default", adapter_index);
     adapter = nullptr;
   }
 
@@ -166,7 +166,7 @@ bool DXContext::CreateDevice(u32 adapter_index, bool enable_debug_layer)
     }
     else
     {
-      ERROR_LOG(VIDEO, "Debug layer requested but not available.");
+      ERROR_LOG_FMT(VIDEO, "Debug layer requested but not available.");
       enable_debug_layer = false;
     }
   }

--- a/Source/Core/VideoBackends/D3D12/DXPipeline.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXPipeline.cpp
@@ -210,8 +210,8 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
   HRESULT hr = g_dx_context->GetDevice()->CreateGraphicsPipelineState(&desc, IID_PPV_ARGS(&pso));
   if (FAILED(hr))
   {
-    WARN_LOG(VIDEO, "CreateGraphicsPipelineState() %sfailed with HRESULT %08X",
-             cache_data ? "with cache data " : "", hr);
+    WARN_LOG_FMT(VIDEO, "CreateGraphicsPipelineState() {}failed with HRESULT {:08X}",
+                 cache_data ? "with cache data " : "", hr);
     return nullptr;
   }
 
@@ -227,7 +227,7 @@ AbstractPipeline::CacheData DXPipeline::GetCacheData() const
   HRESULT hr = m_pipeline->GetCachedBlob(&blob);
   if (FAILED(hr))
   {
-    WARN_LOG(VIDEO, "ID3D12Pipeline::GetCachedBlob() failed with HRESULT %08X", hr);
+    WARN_LOG_FMT(VIDEO, "ID3D12Pipeline::GetCachedBlob() failed with HRESULT {:08X}", hr);
     return {};
   }
 

--- a/Source/Core/VideoBackends/D3D12/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXTexture.cpp
@@ -239,7 +239,8 @@ void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
     if (!g_dx_context->GetTextureUploadBuffer().ReserveMemory(
             upload_size, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT))
     {
-      WARN_LOG(VIDEO, "Executing command list while waiting for space in texture upload buffer");
+      WARN_LOG_FMT(VIDEO,
+                   "Executing command list while waiting for space in texture upload buffer");
       Renderer::GetInstance()->ExecuteCommandList(false);
       if (!g_dx_context->GetTextureUploadBuffer().ReserveMemory(
               upload_size, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT))

--- a/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
@@ -148,7 +148,7 @@ bool SamplerHeapManager::Lookup(const SamplerState& ss, D3D12_CPU_DESCRIPTOR_HAN
   {
     // We can clear at any time because the descriptors are copied prior to execution.
     // It's still not free, since we have to recreate all our samplers again.
-    WARN_LOG(VIDEO, "Out of samplers, resetting CPU heap");
+    WARN_LOG_FMT(VIDEO, "Out of samplers, resetting CPU heap");
     Clear();
   }
 

--- a/Source/Core/VideoBackends/D3D12/Renderer.cpp
+++ b/Source/Core/VideoBackends/D3D12/Renderer.cpp
@@ -653,8 +653,8 @@ void Renderer::UpdateDescriptorTables()
   const bool uav_update_failed = (m_dirty_bits & DirtyState_PS_UAV) && !UpdateUAVDescriptorTable();
   if (texture_update_failed || sampler_update_failed || uav_update_failed)
   {
-    WARN_LOG(VIDEO, "Executing command list while waiting for temporary %s",
-             texture_update_failed ? "descriptors" : "samplers");
+    WARN_LOG_FMT(VIDEO, "Executing command list while waiting for temporary {}",
+                 texture_update_failed ? "descriptors" : "samplers");
     ExecuteCommandList(false);
     SetRootSignatures();
     SetDescriptorHeaps();

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -80,7 +80,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
   if (!has_vbuffer_allocation || !has_ibuffer_allocation)
   {
     // Flush any pending commands first, so that we can wait on the fences
-    WARN_LOG(VIDEO, "Executing command list while waiting for space in vertex/index buffer");
+    WARN_LOG_FMT(VIDEO, "Executing command list while waiting for space in vertex/index buffer");
     Renderer::GetInstance()->ExecuteCommandList(false);
 
     // Attempt to allocate again, this may cause a fence wait
@@ -182,7 +182,7 @@ bool VertexManager::ReserveConstantStorage()
   }
 
   // The only places that call constant updates are safe to have state restored.
-  WARN_LOG(VIDEO, "Executing command list while waiting for space in uniform buffer");
+  WARN_LOG_FMT(VIDEO, "Executing command list while waiting for space in uniform buffer");
   Renderer::GetInstance()->ExecuteCommandList(false);
 
   // Since we are on a new command buffer, all constants have been invalidated, and we need
@@ -244,7 +244,7 @@ void VertexManager::UploadUtilityUniforms(const void* data, u32 data_size)
   if (!m_uniform_stream_buffer.ReserveMemory(data_size,
                                              D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT))
   {
-    WARN_LOG(VIDEO, "Executing command buffer while waiting for ext space in uniform buffer");
+    WARN_LOG_FMT(VIDEO, "Executing command buffer while waiting for ext space in uniform buffer");
     Renderer::GetInstance()->ExecuteCommandList(false);
   }
 
@@ -266,7 +266,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   if (!m_texel_stream_buffer.ReserveMemory(data_size, elem_size))
   {
     // Try submitting cmdbuffer.
-    WARN_LOG(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
+    WARN_LOG_FMT(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
     Renderer::GetInstance()->ExecuteCommandList(false);
     if (!m_texel_stream_buffer.ReserveMemory(data_size, elem_size))
     {
@@ -296,7 +296,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   if (!m_texel_stream_buffer.ReserveMemory(reserve_size, elem_size))
   {
     // Try submitting cmdbuffer.
-    WARN_LOG(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
+    WARN_LOG_FMT(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
     Renderer::GetInstance()->ExecuteCommandList(false);
     if (!m_texel_stream_buffer.ReserveMemory(reserve_size, elem_size))
     {

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -126,8 +126,8 @@ std::optional<Shader::BinaryData> Shader::CompileShader(D3D_FEATURE_LEVEL featur
 
   if (errors && errors->GetBufferSize() > 0)
   {
-    WARN_LOG(VIDEO, "%s compilation succeeded with warnings:\n%s", target,
-             static_cast<const char*>(errors->GetBufferPointer()));
+    WARN_LOG_FMT(VIDEO, "{} compilation succeeded with warnings:\n{}", target,
+                 static_cast<const char*>(errors->GetBufferPointer()));
   }
 
   return CreateByteCode(code->GetBufferPointer(), code->GetBufferSize());

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
@@ -134,7 +134,7 @@ bool SwapChain::CreateSwapChain(bool stereo)
   hr = m_dxgi_factory->MakeWindowAssociation(static_cast<HWND>(m_wsi.render_surface),
                                              DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER);
   if (FAILED(hr))
-    WARN_LOG(VIDEO, "MakeWindowAssociation() failed with HRESULT %08X", hr);
+    WARN_LOG_FMT(VIDEO, "MakeWindowAssociation() failed with HRESULT {:08X}", hr);
 
   m_stereo = stereo;
   if (!CreateSwapChainBuffers())
@@ -167,7 +167,7 @@ bool SwapChain::ResizeSwapChain()
                                            GetDXGIFormatForAbstractFormat(m_texture_format, false),
                                            GetSwapChainFlags());
   if (FAILED(hr))
-    WARN_LOG(VIDEO, "ResizeBuffers() failed with HRESULT %08X", hr);
+    WARN_LOG_FMT(VIDEO, "ResizeBuffers() failed with HRESULT {:08X}", hr);
 
   DXGI_SWAP_CHAIN_DESC desc;
   if (SUCCEEDED(m_swap_chain->GetDesc(&desc)))
@@ -237,7 +237,7 @@ bool SwapChain::Present()
   HRESULT hr = m_swap_chain->Present(static_cast<UINT>(g_ActiveConfig.bVSyncActive), present_flags);
   if (FAILED(hr))
   {
-    WARN_LOG(VIDEO, "Swap chain present failed with HRESULT %08X", hr);
+    WARN_LOG_FMT(VIDEO, "Swap chain present failed with HRESULT {:08X}", hr);
     return false;
   }
 

--- a/Source/Core/VideoBackends/OGL/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/OGL/PerfQuery.cpp
@@ -104,7 +104,7 @@ void PerfQueryGL::EnableQuery(PerfQueryGroup type)
   if (m_query_buffer.size() == m_query_count)
   {
     FlushOne();
-    // ERROR_LOG(VIDEO, "Flushed query buffer early!");
+    // ERROR_LOG_FMT(VIDEO, "Flushed query buffer early!");
   }
 
   // start query
@@ -198,7 +198,7 @@ void PerfQueryGLESNV::EnableQuery(PerfQueryGroup type)
   if (m_query_buffer.size() == m_query_count)
   {
     FlushOne();
-    // ERROR_LOG(VIDEO, "Flushed query buffer early!");
+    // ERROR_LOG_FMT(VIDEO, "Flushed query buffer early!");
   }
 
   // start query

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -357,7 +357,7 @@ bool ProgramShaderCache::CheckShaderCompileResult(GLuint id, GLenum type, std::s
 
     if (compileStatus != GL_TRUE)
     {
-      ERROR_LOG(VIDEO, "%s failed compilation:\n%s", prefix, info_log.c_str());
+      ERROR_LOG_FMT(VIDEO, "{} failed compilation:\n{}", prefix, info_log);
 
       std::string filename = VideoBackendBase::BadShaderFilename(prefix, num_failures++);
       std::ofstream file;
@@ -376,7 +376,7 @@ bool ProgramShaderCache::CheckShaderCompileResult(GLuint id, GLenum type, std::s
       return false;
     }
 
-    WARN_LOG(VIDEO, "%s compiled with warnings:\n%s", prefix, info_log.c_str());
+    WARN_LOG_FMT(VIDEO, "{} compiled with warnings:\n{}", prefix, info_log);
   }
 
   return true;
@@ -396,7 +396,7 @@ bool ProgramShaderCache::CheckProgramLinkResult(GLuint id, std::string_view vcod
     glGetProgramInfoLog(id, length, &length, &info_log[0]);
     if (linkStatus != GL_TRUE)
     {
-      ERROR_LOG(VIDEO, "Program failed linking:\n%s", info_log.c_str());
+      ERROR_LOG_FMT(VIDEO, "Program failed linking:\n{}", info_log);
       std::string filename = VideoBackendBase::BadShaderFilename("p", num_failures++);
       std::ofstream file;
       File::OpenFStream(file, filename, std::ios_base::out);
@@ -421,7 +421,7 @@ bool ProgramShaderCache::CheckProgramLinkResult(GLuint id, std::string_view vcod
       return false;
     }
 
-    WARN_LOG(VIDEO, "Program linked with warnings:\n%s", info_log.c_str());
+    WARN_LOG_FMT(VIDEO, "Program linked with warnings:\n{}", info_log);
   }
 
   return true;
@@ -554,7 +554,7 @@ PipelineProgram* ProgramShaderCache::GetPipelineProgram(const GLVertexFormat* ve
     glGetProgramiv(prog->shader.glprogid, GL_LINK_STATUS, &link_status);
     if (link_status != GL_TRUE)
     {
-      WARN_LOG(VIDEO, "Failed to create GL program from program binary.");
+      WARN_LOG_FMT(VIDEO, "Failed to create GL program from program binary.");
       prog->shader.Destroy();
       return nullptr;
     }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -105,19 +105,19 @@ static void APIENTRY ErrorCallback(GLenum source, GLenum type, GLuint id, GLenum
   switch (severity)
   {
   case GL_DEBUG_SEVERITY_HIGH_ARB:
-    ERROR_LOG(HOST_GPU, "id: %x, source: %s, type: %s - %s", id, s_source, s_type, message);
+    ERROR_LOG_FMT(HOST_GPU, "id: {:x}, source: {}, type: {} - {}", id, s_source, s_type, message);
     break;
   case GL_DEBUG_SEVERITY_MEDIUM_ARB:
-    WARN_LOG(HOST_GPU, "id: %x, source: %s, type: %s - %s", id, s_source, s_type, message);
+    WARN_LOG_FMT(HOST_GPU, "id: {:x}, source: {}, type: {} - {}", id, s_source, s_type, message);
     break;
   case GL_DEBUG_SEVERITY_LOW_ARB:
-    DEBUG_LOG(HOST_GPU, "id: %x, source: %s, type: %s - %s", id, s_source, s_type, message);
+    DEBUG_LOG_FMT(HOST_GPU, "id: {:x}, source: {}, type: {} - {}", id, s_source, s_type, message);
     break;
   case GL_DEBUG_SEVERITY_NOTIFICATION:
-    DEBUG_LOG(HOST_GPU, "id: %x, source: %s, type: %s - %s", id, s_source, s_type, message);
+    DEBUG_LOG_FMT(HOST_GPU, "id: {:x}, source: {}, type: {} - {}", id, s_source, s_type, message);
     break;
   default:
-    ERROR_LOG(HOST_GPU, "id: %x, source: %s, type: %s - %s", id, s_source, s_type, message);
+    ERROR_LOG_FMT(HOST_GPU, "id: {:x}, source: {}, type: {} - {}", id, s_source, s_type, message);
     break;
   }
 }
@@ -307,7 +307,7 @@ static void InitDriverInfo()
     version = 100 * major + minor;
     if (change >= change_scale)
     {
-      ERROR_LOG(VIDEO, "Version changeID overflow - change:%d scale:%f", change, change_scale);
+      ERROR_LOG_FMT(VIDEO, "Version changeID overflow - change:{} scale:{}", change, change_scale);
     }
     else
     {
@@ -734,33 +734,34 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
   g_Config.VerifyValidity();
   UpdateActiveConfig();
 
-  OSD::AddMessage(StringFromFormat("Video Info: %s, %s, %s", g_ogl_config.gl_vendor,
-                                   g_ogl_config.gl_renderer, g_ogl_config.gl_version),
+  OSD::AddMessage(fmt::format("Video Info: {}, {}, {}", g_ogl_config.gl_vendor,
+                              g_ogl_config.gl_renderer, g_ogl_config.gl_version),
                   5000);
 
   if (!g_ogl_config.bSupportsGLBufferStorage && !g_ogl_config.bSupportsGLPinnedMemory)
   {
-    OSD::AddMessage(StringFromFormat("Your OpenGL driver does not support %s_buffer_storage.",
-                                     m_main_gl_context->IsGLES() ? "EXT" : "ARB"),
+    OSD::AddMessage(fmt::format("Your OpenGL driver does not support {}_buffer_storage.",
+                                m_main_gl_context->IsGLES() ? "EXT" : "ARB"),
                     60000);
     OSD::AddMessage("This device's performance will be terrible.", 60000);
     OSD::AddMessage("Please ask your device vendor for an updated OpenGL driver.", 60000);
   }
 
-  WARN_LOG(VIDEO, "Missing OGL Extensions: %s%s%s%s%s%s%s%s%s%s%s%s%s%s",
-           g_ActiveConfig.backend_info.bSupportsDualSourceBlend ? "" : "DualSourceBlend ",
-           g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? "" : "PrimitiveRestart ",
-           g_ActiveConfig.backend_info.bSupportsEarlyZ ? "" : "EarlyZ ",
-           g_ogl_config.bSupportsGLPinnedMemory ? "" : "PinnedMemory ",
-           supports_glsl_cache ? "" : "ShaderCache ",
-           g_ogl_config.bSupportsGLBaseVertex ? "" : "BaseVertex ",
-           g_ogl_config.bSupportsGLBufferStorage ? "" : "BufferStorage ",
-           g_ogl_config.bSupportsGLSync ? "" : "Sync ", g_ogl_config.bSupportsMSAA ? "" : "MSAA ",
-           g_ActiveConfig.backend_info.bSupportsSSAA ? "" : "SSAA ",
-           g_ActiveConfig.backend_info.bSupportsGSInstancing ? "" : "GSInstancing ",
-           g_ActiveConfig.backend_info.bSupportsClipControl ? "" : "ClipControl ",
-           g_ogl_config.bSupportsCopySubImage ? "" : "CopyImageSubData ",
-           g_ActiveConfig.backend_info.bSupportsDepthClamp ? "" : "DepthClamp ");
+  WARN_LOG_FMT(VIDEO, "Missing OGL Extensions: {}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+               g_ActiveConfig.backend_info.bSupportsDualSourceBlend ? "" : "DualSourceBlend ",
+               g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? "" : "PrimitiveRestart ",
+               g_ActiveConfig.backend_info.bSupportsEarlyZ ? "" : "EarlyZ ",
+               g_ogl_config.bSupportsGLPinnedMemory ? "" : "PinnedMemory ",
+               supports_glsl_cache ? "" : "ShaderCache ",
+               g_ogl_config.bSupportsGLBaseVertex ? "" : "BaseVertex ",
+               g_ogl_config.bSupportsGLBufferStorage ? "" : "BufferStorage ",
+               g_ogl_config.bSupportsGLSync ? "" : "Sync ",
+               g_ogl_config.bSupportsMSAA ? "" : "MSAA ",
+               g_ActiveConfig.backend_info.bSupportsSSAA ? "" : "SSAA ",
+               g_ActiveConfig.backend_info.bSupportsGSInstancing ? "" : "GSInstancing ",
+               g_ActiveConfig.backend_info.bSupportsClipControl ? "" : "ClipControl ",
+               g_ogl_config.bSupportsCopySubImage ? "" : "CopyImageSubData ",
+               g_ActiveConfig.backend_info.bSupportsDepthClamp ? "" : "DepthClamp ");
 
   // Handle VSync on/off
   if (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VSYNC))

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -56,7 +56,9 @@ static void SetPixelAlphaOnly(u32 offset, u8 a)
   }
   break;
   default:
-    ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+    ERROR_LOG_FMT(VIDEO, "Unsupported pixel format: {}",
+                  static_cast<int>(bpmem.zcontrol.pixel_format));
+    break;
   }
 }
 
@@ -87,7 +89,7 @@ static void SetPixelColorOnly(u32 offset, u8* rgb)
   break;
   case PEControl::RGB565_Z16:
   {
-    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
     u32 src = *(u32*)rgb;
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
@@ -96,7 +98,9 @@ static void SetPixelColorOnly(u32 offset, u8* rgb)
   }
   break;
   default:
-    ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+    ERROR_LOG_FMT(VIDEO, "Unsupported pixel format: {}",
+                  static_cast<int>(bpmem.zcontrol.pixel_format));
+    break;
   }
 }
 
@@ -128,7 +132,7 @@ static void SetPixelAlphaColor(u32 offset, u8* color)
   break;
   case PEControl::RGB565_Z16:
   {
-    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
     u32 src = *(u32*)color;
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
@@ -137,7 +141,9 @@ static void SetPixelAlphaColor(u32 offset, u8* color)
   }
   break;
   default:
-    ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+    ERROR_LOG_FMT(VIDEO, "Unsupported pixel format: {}",
+                  static_cast<int>(bpmem.zcontrol.pixel_format));
+    break;
   }
 }
 
@@ -159,11 +165,12 @@ static u32 GetPixelColor(u32 offset)
            Convert6To8((src >> 18) & 0x3f) << 24;   // Red
 
   case PEControl::RGB565_Z16:
-    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
     return 0xff | ((src & 0x00ffffff) << 8);
 
   default:
-    ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+    ERROR_LOG_FMT(VIDEO, "Unsupported pixel format: {}",
+                  static_cast<int>(bpmem.zcontrol.pixel_format));
     return 0;
   }
 }
@@ -184,7 +191,7 @@ static void SetPixelDepth(u32 offset, u32 depth)
   break;
   case PEControl::RGB565_Z16:
   {
-    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
     u32* dst = (u32*)&efb[offset];
     u32 val = *dst & 0xff000000;
     val |= depth & 0x00ffffff;
@@ -192,7 +199,9 @@ static void SetPixelDepth(u32 offset, u32 depth)
   }
   break;
   default:
-    ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+    ERROR_LOG_FMT(VIDEO, "Unsupported pixel format: {}",
+                  static_cast<int>(bpmem.zcontrol.pixel_format));
+    break;
   }
 }
 
@@ -211,12 +220,14 @@ static u32 GetPixelDepth(u32 offset)
   break;
   case PEControl::RGB565_Z16:
   {
-    INFO_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
+    INFO_LOG_FMT(VIDEO, "RGB565_Z16 is not supported correctly yet");
     depth = (*(u32*)&efb[offset]) & 0x00ffffff;
   }
   break;
   default:
-    ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+    ERROR_LOG_FMT(VIDEO, "Unsupported pixel format: {}",
+                  static_cast<int>(bpmem.zcontrol.pixel_format));
+    break;
   }
 
   return depth;
@@ -554,7 +565,7 @@ void EncodeXFB(u8* xfb_in_ram, u32 memory_stride, const MathUtil::Rectangle<int>
 {
   if (!xfb_in_ram)
   {
-    WARN_LOG(VIDEO, "Tried to copy to invalid XFB address");
+    WARN_LOG_FMT(VIDEO, "Tried to copy to invalid XFB address");
     return;
   }
 
@@ -569,7 +580,7 @@ void EncodeXFB(u8* xfb_in_ram, u32 memory_stride, const MathUtil::Rectangle<int>
   // copy always has an even width, which might not be true.
   if (left & 1 || right & 1)
   {
-    WARN_LOG(VIDEO, "Trying to copy XFB to from unaligned EFB source");
+    WARN_LOG_FMT(VIDEO, "Trying to copy XFB to from unaligned EFB source");
     // this will show up as wrongly encoded
   }
 
@@ -677,7 +688,8 @@ bool ZCompare(u16 x, u16 y, u32 z)
     break;
   default:
     pass = false;
-    ERROR_LOG(VIDEO, "Bad Z compare mode %i", (int)bpmem.zmode.func);
+    ERROR_LOG_FMT(VIDEO, "Bad Z compare mode {}", static_cast<int>(bpmem.zmode.func));
+    break;
   }
 
   if (pass && bpmem.zmode.updateenable)

--- a/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
+++ b/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
@@ -41,13 +41,13 @@ bool SWOGLWindow::Initialize(const WindowSystemInfo& wsi)
   // Init extension support.
   if (!GLExtensions::Init(m_gl_context.get()))
   {
-    ERROR_LOG(VIDEO, "GLExtensions::Init failed!Does your video card support OpenGL 2.0?");
+    ERROR_LOG_FMT(VIDEO, "GLExtensions::Init failed!Does your video card support OpenGL 2.0?");
     return false;
   }
   else if (GLExtensions::Version() < 310)
   {
-    ERROR_LOG(VIDEO, "OpenGL Version %d detected, but at least 3.1 is required.",
-              GLExtensions::Version());
+    ERROR_LOG_FMT(VIDEO, "OpenGL Version {} detected, but at least 3.1 is required.",
+                  GLExtensions::Version());
     return false;
   }
 

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -110,7 +110,7 @@ void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
       xfmem.MatrixIndexB.Tex6MtxIdx != g_main_cp_state.matrix_index_b.Tex6MtxIdx ||
       xfmem.MatrixIndexB.Tex7MtxIdx != g_main_cp_state.matrix_index_b.Tex7MtxIdx)
   {
-    ERROR_LOG(VIDEO, "Matrix indices don't match");
+    ERROR_LOG_FMT(VIDEO, "Matrix indices don't match");
   }
 
   m_vertex.posMtx = xfmem.MatrixIndexA.PosNormalMtxIdx;

--- a/Source/Core/VideoBackends/Software/SetupUnit.cpp
+++ b/Source/Core/VideoBackends/Software/SetupUnit.cpp
@@ -37,7 +37,7 @@ void SetupUnit::SetupVertex()
     SetupQuad();
     break;
   case OpcodeDecoder::GX_DRAW_QUADS_2:
-    WARN_LOG(VIDEO, "Non-standard primitive drawing command GL_DRAW_QUADS_2");
+    WARN_LOG_FMT(VIDEO, "Non-standard primitive drawing command GL_DRAW_QUADS_2");
     SetupQuad();
     break;
   case OpcodeDecoder::GX_DRAW_TRIANGLES:

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -445,7 +445,8 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst, bool s
       dst->texCoords[coordNum].z = 1.0f;
       break;
     default:
-      ERROR_LOG(VIDEO, "Bad tex gen type %i", texinfo.texgentype.Value());
+      ERROR_LOG_FMT(VIDEO, "Bad tex gen type {}", texinfo.texgentype.Value());
+      break;
     }
   }
 

--- a/Source/Core/VideoBackends/Vulkan/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/Vulkan/BoundingBox.cpp
@@ -34,7 +34,7 @@ bool BoundingBox::Initialize()
 {
   if (!g_ActiveConfig.backend_info.bSupportsBBox)
   {
-    WARN_LOG(VIDEO, "Vulkan: Bounding box is unsupported by your device.");
+    WARN_LOG_FMT(VIDEO, "Vulkan: Bounding box is unsupported by your device.");
     return true;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -543,7 +543,7 @@ bool ObjectCache::ValidatePipelineCache(const u8* data, size_t data_length)
 {
   if (data_length < sizeof(VK_PIPELINE_CACHE_HEADER))
   {
-    ERROR_LOG(VIDEO, "Pipeline cache failed validation: Invalid header");
+    ERROR_LOG_FMT(VIDEO, "Pipeline cache failed validation: Invalid header");
     return false;
   }
 
@@ -551,36 +551,36 @@ bool ObjectCache::ValidatePipelineCache(const u8* data, size_t data_length)
   std::memcpy(&header, data, sizeof(header));
   if (header.header_length < sizeof(VK_PIPELINE_CACHE_HEADER))
   {
-    ERROR_LOG(VIDEO, "Pipeline cache failed validation: Invalid header length");
+    ERROR_LOG_FMT(VIDEO, "Pipeline cache failed validation: Invalid header length");
     return false;
   }
 
   if (header.header_version != VK_PIPELINE_CACHE_HEADER_VERSION_ONE)
   {
-    ERROR_LOG(VIDEO, "Pipeline cache failed validation: Invalid header version");
+    ERROR_LOG_FMT(VIDEO, "Pipeline cache failed validation: Invalid header version");
     return false;
   }
 
   if (header.vendor_id != g_vulkan_context->GetDeviceProperties().vendorID)
   {
-    ERROR_LOG(VIDEO,
-              "Pipeline cache failed validation: Incorrect vendor ID (file: 0x%X, device: 0x%X)",
-              header.vendor_id, g_vulkan_context->GetDeviceProperties().vendorID);
+    ERROR_LOG_FMT(
+        VIDEO, "Pipeline cache failed validation: Incorrect vendor ID (file: {:#X}, device: {:#X})",
+        header.vendor_id, g_vulkan_context->GetDeviceProperties().vendorID);
     return false;
   }
 
   if (header.device_id != g_vulkan_context->GetDeviceProperties().deviceID)
   {
-    ERROR_LOG(VIDEO,
-              "Pipeline cache failed validation: Incorrect device ID (file: 0x%X, device: 0x%X)",
-              header.device_id, g_vulkan_context->GetDeviceProperties().deviceID);
+    ERROR_LOG_FMT(
+        VIDEO, "Pipeline cache failed validation: Incorrect device ID (file: {:#X}, device: {:#X})",
+        header.device_id, g_vulkan_context->GetDeviceProperties().deviceID);
     return false;
   }
 
   if (std::memcmp(header.uuid, g_vulkan_context->GetDeviceProperties().pipelineCacheUUID,
                   VK_UUID_SIZE) != 0)
   {
-    ERROR_LOG(VIDEO, "Pipeline cache failed validation: Incorrect UUID");
+    ERROR_LOG_FMT(VIDEO, "Pipeline cache failed validation: Incorrect UUID");
     return false;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -300,17 +300,17 @@ void Renderer::BindBackbuffer(const ClearColor& clear_color)
     if (res == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
     {
       // The present keeps returning exclusive mode lost unless we re-create the swap chain.
-      INFO_LOG(VIDEO, "Lost exclusive fullscreen.");
+      INFO_LOG_FMT(VIDEO, "Lost exclusive fullscreen.");
       m_swap_chain->RecreateSwapChain();
     }
     else if (res == VK_SUBOPTIMAL_KHR || res == VK_ERROR_OUT_OF_DATE_KHR)
     {
-      INFO_LOG(VIDEO, "Resizing swap chain due to suboptimal/out-of-date");
+      INFO_LOG_FMT(VIDEO, "Resizing swap chain due to suboptimal/out-of-date");
       m_swap_chain->ResizeSwapChain();
     }
     else
     {
-      ERROR_LOG(VIDEO, "Unknown present error 0x%08X, please report.", res);
+      ERROR_LOG_FMT(VIDEO, "Unknown present error {:#010X}, please report.", res);
       m_swap_chain->RecreateSwapChain();
     }
 
@@ -401,7 +401,7 @@ void Renderer::CheckForSurfaceResize()
   // CheckForSurfaceChange should handle this case.
   if (!m_swap_chain)
   {
-    WARN_LOG(VIDEO, "Surface resize event received without active surface, ignoring");
+    WARN_LOG_FMT(VIDEO, "Surface resize event received without active surface, ignoring");
     return;
   }
 
@@ -527,7 +527,7 @@ void Renderer::SetTexture(u32 index, const AbstractTexture* texture)
     {
       if (StateTracker::GetInstance()->InRenderPass())
       {
-        WARN_LOG(VIDEO, "Transitioning image in render pass in Renderer::SetTexture()");
+        WARN_LOG_FMT(VIDEO, "Transitioning image in render pass in Renderer::SetTexture()");
         StateTracker::GetInstance()->EndRenderPass();
       }
 
@@ -553,7 +553,7 @@ void Renderer::SetSamplerState(u32 index, const SamplerState& state)
   VkSampler sampler = g_object_cache->GetSampler(state);
   if (sampler == VK_NULL_HANDLE)
   {
-    ERROR_LOG(VIDEO, "Failed to create sampler");
+    ERROR_LOG_FMT(VIDEO, "Failed to create sampler");
     sampler = g_object_cache->GetPointSampler();
   }
 

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -203,16 +203,16 @@ static std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage,
   // Temporary: skip if it contains "Warning, version 450 is not yet complete; most version-specific
   // features are present, but some are missing."
   if (strlen(shader->getInfoLog()) > 108)
-    WARN_LOG(VIDEO, "Shader info log: %s", shader->getInfoLog());
+    WARN_LOG_FMT(VIDEO, "Shader info log: {}", shader->getInfoLog());
   if (strlen(shader->getInfoDebugLog()) > 0)
-    WARN_LOG(VIDEO, "Shader debug info log: %s", shader->getInfoDebugLog());
+    WARN_LOG_FMT(VIDEO, "Shader debug info log: {}", shader->getInfoDebugLog());
   if (strlen(program->getInfoLog()) > 25)
-    WARN_LOG(VIDEO, "Program info log: %s", program->getInfoLog());
+    WARN_LOG_FMT(VIDEO, "Program info log: {}", program->getInfoLog());
   if (strlen(program->getInfoDebugLog()) > 0)
-    WARN_LOG(VIDEO, "Program debug info log: %s", program->getInfoDebugLog());
-  std::string spv_messages = logger.getAllMessages();
+    WARN_LOG_FMT(VIDEO, "Program debug info log: {}", program->getInfoDebugLog());
+  const std::string spv_messages = logger.getAllMessages();
   if (!spv_messages.empty())
-    WARN_LOG(VIDEO, "SPIR-V conversion messages: %s", spv_messages.c_str());
+    WARN_LOG_FMT(VIDEO, "SPIR-V conversion messages: {}", spv_messages);
 
   // Dump source code of shaders out to file if enabled.
   if (g_ActiveConfig.iLog & CONF_SAVESHADERS)

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -351,12 +351,12 @@ bool StateTracker::Bind()
   if (!UpdateDescriptorSet())
   {
     // We can fail to allocate descriptors if we exhaust the pool for this command buffer.
-    WARN_LOG(VIDEO, "Failed to get a descriptor set, executing buffer");
+    WARN_LOG_FMT(VIDEO, "Failed to get a descriptor set, executing buffer");
     Renderer::GetInstance()->ExecuteCommandBuffer(false, false);
     if (!UpdateDescriptorSet())
     {
       // Something strange going on.
-      ERROR_LOG(VIDEO, "Failed to get descriptor set, skipping draw");
+      ERROR_LOG_FMT(VIDEO, "Failed to get descriptor set, skipping draw");
       return false;
     }
   }
@@ -405,12 +405,12 @@ bool StateTracker::BindCompute()
 
   if (!UpdateComputeDescriptorSet())
   {
-    WARN_LOG(VIDEO, "Failed to get a compute descriptor set, executing buffer");
+    WARN_LOG_FMT(VIDEO, "Failed to get a compute descriptor set, executing buffer");
     Renderer::GetInstance()->ExecuteCommandBuffer(false, false);
     if (!UpdateComputeDescriptorSet())
     {
       // Something strange going on.
-      ERROR_LOG(VIDEO, "Failed to get descriptor set, skipping dispatch");
+      ERROR_LOG_FMT(VIDEO, "Failed to get descriptor set, skipping dispatch");
       return false;
     }
   }

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -283,7 +283,7 @@ bool SwapChain::CreateSwapChain()
   VkImageUsageFlags image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
   if (!(surface_capabilities.supportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT))
   {
-    ERROR_LOG(VIDEO, "Vulkan: Swap chain does not support usage as color attachment");
+    ERROR_LOG_FMT(VIDEO, "Vulkan: Swap chain does not support usage as color attachment");
     return false;
   }
 
@@ -341,7 +341,7 @@ bool SwapChain::CreateSwapChain()
     if (res != VK_SUCCESS)
     {
       // Try without exclusive fullscreen.
-      WARN_LOG(VIDEO, "Failed to create exclusive fullscreen swapchain, trying without.");
+      WARN_LOG_FMT(VIDEO, "Failed to create exclusive fullscreen swapchain, trying without.");
       swap_chain_info.pNext = nullptr;
       g_Config.backend_info.bSupportsExclusiveFullscreen = false;
       g_ActiveConfig.backend_info.bSupportsExclusiveFullscreen = false;
@@ -514,7 +514,7 @@ bool SwapChain::SetFullscreenState(bool state)
       return false;
     }
 
-    INFO_LOG(VIDEO, "Exclusive fullscreen acquired.");
+    INFO_LOG_FMT(VIDEO, "Exclusive fullscreen acquired.");
   }
   else
   {
@@ -522,7 +522,7 @@ bool SwapChain::SetFullscreenState(bool state)
     if (res != VK_SUCCESS)
       LOG_VULKAN_ERROR(res, "vkReleaseFullScreenExclusiveModeEXT failed:");
 
-    INFO_LOG(VIDEO, "Exclusive fullscreen released.");
+    INFO_LOG_FMT(VIDEO, "Exclusive fullscreen released.");
   }
 
   m_current_fullscreen_state = state;

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -369,7 +369,8 @@ void VKTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
     if (!stream_buffer->ReserveMemory(upload_size, upload_alignment))
     {
       // Execute the command buffer first.
-      WARN_LOG(VIDEO, "Executing command list while waiting for space in texture upload buffer");
+      WARN_LOG_FMT(VIDEO,
+                   "Executing command list while waiting for space in texture upload buffer");
       Renderer::GetInstance()->ExecuteCommandBuffer(false);
 
       // Try allocating again. This may cause a fence wait.

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -149,7 +149,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
   if (!has_vbuffer_allocation || !has_ibuffer_allocation)
   {
     // Flush any pending commands first, so that we can wait on the fences
-    WARN_LOG(VIDEO, "Executing command list while waiting for space in vertex/index buffer");
+    WARN_LOG_FMT(VIDEO, "Executing command list while waiting for space in vertex/index buffer");
     Renderer::GetInstance()->ExecuteCommandBuffer(false);
 
     // Attempt to allocate again, this may cause a fence wait
@@ -253,7 +253,7 @@ bool VertexManager::ReserveConstantStorage()
   }
 
   // The only places that call constant updates are safe to have state restored.
-  WARN_LOG(VIDEO, "Executing command buffer while waiting for space in uniform buffer");
+  WARN_LOG_FMT(VIDEO, "Executing command buffer while waiting for space in uniform buffer");
   Renderer::GetInstance()->ExecuteCommandBuffer(false);
 
   // Since we are on a new command buffer, all constants have been invalidated, and we need
@@ -319,7 +319,7 @@ void VertexManager::UploadUtilityUniforms(const void* data, u32 data_size)
   if (!m_uniform_stream_buffer->ReserveMemory(data_size,
                                               g_vulkan_context->GetUniformBufferAlignment()))
   {
-    WARN_LOG(VIDEO, "Executing command buffer while waiting for ext space in uniform buffer");
+    WARN_LOG_FMT(VIDEO, "Executing command buffer while waiting for ext space in uniform buffer");
     Renderer::GetInstance()->ExecuteCommandBuffer(false);
   }
 
@@ -340,7 +340,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   if (!m_texel_stream_buffer->ReserveMemory(data_size, elem_size))
   {
     // Try submitting cmdbuffer.
-    WARN_LOG(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
+    WARN_LOG_FMT(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
     Renderer::GetInstance()->ExecuteCommandBuffer(false, false);
     if (!m_texel_stream_buffer->ReserveMemory(data_size, elem_size))
     {
@@ -370,7 +370,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
   if (!m_texel_stream_buffer->ReserveMemory(reserve_size, elem_size))
   {
     // Try submitting cmdbuffer.
-    WARN_LOG(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
+    WARN_LOG_FMT(VIDEO, "Submitting command buffer while waiting for space in texel buffer");
     Renderer::GetInstance()->ExecuteCommandBuffer(false, false);
     if (!m_texel_stream_buffer->ReserveMemory(reserve_size, elem_size))
     {

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -156,7 +156,7 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
 
   if (extension_count == 0)
   {
-    ERROR_LOG(VIDEO, "Vulkan: No extensions supported by instance.");
+    ERROR_LOG_FMT(VIDEO, "Vulkan: No extensions supported by instance.");
     return false;
   }
 
@@ -166,7 +166,7 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
   ASSERT(res == VK_SUCCESS);
 
   for (const auto& extension_properties : available_extension_list)
-    INFO_LOG(VIDEO, "Available extension: %s", extension_properties.extensionName);
+    INFO_LOG_FMT(VIDEO, "Available extension: {}", extension_properties.extensionName);
 
   auto AddExtension = [&](const char* name, bool required) {
     if (std::find_if(available_extension_list.begin(), available_extension_list.end(),
@@ -174,13 +174,13 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
                        return !strcmp(name, properties.extensionName);
                      }) != available_extension_list.end())
     {
-      INFO_LOG(VIDEO, "Enabling extension: %s", name);
+      INFO_LOG_FMT(VIDEO, "Enabling extension: {}", name);
       extension_list->push_back(name);
       return true;
     }
 
     if (required)
-      ERROR_LOG(VIDEO, "Vulkan: Missing required extension %s.", name);
+      ERROR_LOG_FMT(VIDEO, "Vulkan: Missing required extension {}.", name);
 
     return false;
   };
@@ -220,7 +220,7 @@ bool VulkanContext::SelectInstanceExtensions(std::vector<const char*>* extension
 
   // VK_EXT_debug_report
   if (enable_debug_report && !AddExtension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, false))
-    WARN_LOG(VIDEO, "Vulkan: Debug report requested, but extension is not available.");
+    WARN_LOG_FMT(VIDEO, "Vulkan: Debug report requested, but extension is not available.");
 
   AddExtension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, false);
   AddExtension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME, false);
@@ -437,7 +437,7 @@ bool VulkanContext::SelectDeviceExtensions(bool enable_surface)
 
   if (extension_count == 0)
   {
-    ERROR_LOG(VIDEO, "Vulkan: No extensions supported by device.");
+    ERROR_LOG_FMT(VIDEO, "Vulkan: No extensions supported by device.");
     return false;
   }
 
@@ -447,7 +447,7 @@ bool VulkanContext::SelectDeviceExtensions(bool enable_surface)
   ASSERT(res == VK_SUCCESS);
 
   for (const auto& extension_properties : available_extension_list)
-    INFO_LOG(VIDEO, "Available extension: %s", extension_properties.extensionName);
+    INFO_LOG_FMT(VIDEO, "Available extension: {}", extension_properties.extensionName);
 
   auto AddExtension = [&](const char* name, bool required) {
     if (std::find_if(available_extension_list.begin(), available_extension_list.end(),
@@ -455,13 +455,13 @@ bool VulkanContext::SelectDeviceExtensions(bool enable_surface)
                        return !strcmp(name, properties.extensionName);
                      }) != available_extension_list.end())
     {
-      INFO_LOG(VIDEO, "Enabling extension: %s", name);
+      INFO_LOG_FMT(VIDEO, "Enabling extension: {}", name);
       m_device_extensions.push_back(name);
       return true;
     }
 
     if (required)
-      ERROR_LOG(VIDEO, "Vulkan: Missing required extension %s.", name);
+      ERROR_LOG_FMT(VIDEO, "Vulkan: Missing required extension {}.", name);
 
     return false;
   };
@@ -472,7 +472,7 @@ bool VulkanContext::SelectDeviceExtensions(bool enable_surface)
 #ifdef SUPPORTS_VULKAN_EXCLUSIVE_FULLSCREEN
   // VK_EXT_full_screen_exclusive
   if (AddExtension(VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME, true))
-    INFO_LOG(VIDEO, "Using VK_EXT_full_screen_exclusive for exclusive fullscreen.");
+    INFO_LOG_FMT(VIDEO, "Using VK_EXT_full_screen_exclusive for exclusive fullscreen.");
 #endif
 
   return true;
@@ -488,12 +488,14 @@ bool VulkanContext::SelectDeviceFeatures()
 
   // Not having geometry shaders or wide lines will cause issues with rendering.
   if (!available_features.geometryShader && !available_features.wideLines)
-    WARN_LOG(VIDEO, "Vulkan: Missing both geometryShader and wideLines features.");
+    WARN_LOG_FMT(VIDEO, "Vulkan: Missing both geometryShader and wideLines features.");
   if (!available_features.largePoints)
-    WARN_LOG(VIDEO, "Vulkan: Missing large points feature. CPU EFB writes will be slower.");
+    WARN_LOG_FMT(VIDEO, "Vulkan: Missing large points feature. CPU EFB writes will be slower.");
   if (!available_features.occlusionQueryPrecise)
-    WARN_LOG(VIDEO, "Vulkan: Missing precise occlusion queries. Perf queries will be inaccurate.");
-
+  {
+    WARN_LOG_FMT(VIDEO,
+                 "Vulkan: Missing precise occlusion queries. Perf queries will be inaccurate.");
+  }
   // Enable the features we use.
   m_device_features.dualSrcBlend = available_features.dualSrcBlend;
   m_device_features.geometryShader = available_features.geometryShader;
@@ -519,14 +521,14 @@ bool VulkanContext::CreateDevice(VkSurfaceKHR surface, bool enable_validation_la
   vkGetPhysicalDeviceQueueFamilyProperties(m_physical_device, &queue_family_count, nullptr);
   if (queue_family_count == 0)
   {
-    ERROR_LOG(VIDEO, "No queue families found on specified vulkan physical device.");
+    ERROR_LOG_FMT(VIDEO, "No queue families found on specified vulkan physical device.");
     return false;
   }
 
   std::vector<VkQueueFamilyProperties> queue_family_properties(queue_family_count);
   vkGetPhysicalDeviceQueueFamilyProperties(m_physical_device, &queue_family_count,
                                            queue_family_properties.data());
-  INFO_LOG(VIDEO, "%u vulkan queue families", queue_family_count);
+  INFO_LOG_FMT(VIDEO, "{} vulkan queue families", queue_family_count);
 
   // Find graphics and present queues.
   m_graphics_queue_family_index = queue_family_count;
@@ -569,12 +571,12 @@ bool VulkanContext::CreateDevice(VkSurfaceKHR surface, bool enable_validation_la
   }
   if (m_graphics_queue_family_index == queue_family_count)
   {
-    ERROR_LOG(VIDEO, "Vulkan: Failed to find an acceptable graphics queue.");
+    ERROR_LOG_FMT(VIDEO, "Vulkan: Failed to find an acceptable graphics queue.");
     return false;
   }
   if (surface && m_present_queue_family_index == queue_family_count)
   {
-    ERROR_LOG(VIDEO, "Vulkan: Failed to find an acceptable present queue.");
+    ERROR_LOG_FMT(VIDEO, "Vulkan: Failed to find an acceptable present queue.");
     return false;
   }
 
@@ -666,16 +668,16 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugReportCallback(VkDebugReportFlagsEXT 
                                                           const char* pLayerPrefix,
                                                           const char* pMessage, void* pUserData)
 {
-  std::string log_message =
-      StringFromFormat("Vulkan debug report: (%s) %s", pLayerPrefix ? pLayerPrefix : "", pMessage);
+  const std::string log_message =
+      fmt::format("Vulkan debug report: ({}) {}", pLayerPrefix ? pLayerPrefix : "", pMessage);
   if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
-    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LERROR, "%s", log_message.c_str());
+    GENERIC_LOG_FMT(Common::Log::HOST_GPU, Common::Log::LERROR, "{}", log_message);
   else if (flags & (VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT))
-    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LWARNING, "%s", log_message.c_str());
+    GENERIC_LOG_FMT(Common::Log::HOST_GPU, Common::Log::LWARNING, "{}", log_message);
   else if (flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
-    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LINFO, "%s", log_message.c_str());
+    GENERIC_LOG_FMT(Common::Log::HOST_GPU, Common::Log::LINFO, "{}", log_message);
   else
-    GENERIC_LOG(Common::Log::HOST_GPU, Common::Log::LDEBUG, "%s", log_message.c_str());
+    GENERIC_LOG_FMT(Common::Log::HOST_GPU, Common::Log::LDEBUG, "{}", log_message);
 
   return VK_FALSE;
 }
@@ -763,13 +765,13 @@ u32 VulkanContext::GetUploadMemoryType(u32 bits, bool* is_coherent)
   type_index = GetMemoryType(bits, COHERENT_FLAGS, false, is_coherent);
   if (type_index)
   {
-    WARN_LOG(VIDEO,
-             "Strict check for upload memory properties failed, this may affect performance");
+    WARN_LOG_FMT(VIDEO,
+                 "Strict check for upload memory properties failed, this may affect performance");
     return type_index.value();
   }
 
   // Fall back to non-coherent memory.
-  WARN_LOG(
+  WARN_LOG_FMT(
       VIDEO,
       "Vulkan: Failed to find a coherent memory type for uploads, this will affect performance.");
   type_index = GetMemoryType(bits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, false, is_coherent);
@@ -811,8 +813,8 @@ u32 VulkanContext::GetReadbackMemoryType(u32 bits, bool* is_coherent)
   if (type_index)
     return type_index.value();
 
-  WARN_LOG(VIDEO, "Vulkan: Failed to find a cached memory type for readbacks, this will affect "
-                  "performance.");
+  WARN_LOG_FMT(VIDEO, "Vulkan: Failed to find a cached memory type for readbacks, this will affect "
+                      "performance.");
   type_index = GetMemoryType(bits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, false, is_coherent);
   *is_coherent = false;
   if (type_index)
@@ -896,8 +898,8 @@ void VulkanContext::InitDriverDetails()
   }
   else
   {
-    WARN_LOG(VIDEO, "Unknown Vulkan driver vendor, please report it to us.");
-    WARN_LOG(VIDEO, "Vendor ID: 0x%X, Device Name: %s", vendor_id, device_name.c_str());
+    WARN_LOG_FMT(VIDEO, "Unknown Vulkan driver vendor, please report it to us.");
+    WARN_LOG_FMT(VIDEO, "Vendor ID: {:#X}, Device Name: {}", vendor_id, device_name);
     vendor = DriverDetails::VENDOR_UNKNOWN;
     driver = DriverDetails::DRIVER_UNKNOWN;
   }

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -67,7 +67,7 @@ bool LoadVulkanLibrary()
 #define VULKAN_MODULE_ENTRY_POINT(name, required)                                                  \
   if (!s_vulkan_module.GetSymbol(#name, &name) && required)                                        \
   {                                                                                                \
-    ERROR_LOG(VIDEO, "Vulkan: Failed to load required module function %s", #name);                 \
+    ERROR_LOG_FMT(VIDEO, "Vulkan: Failed to load required module function {}", #name);             \
     ResetVulkanLibraryFunctionPointers();                                                          \
     s_vulkan_module.Close();                                                                       \
     return false;                                                                                  \
@@ -92,7 +92,7 @@ bool LoadVulkanInstanceFunctions(VkInstance instance)
     *func_ptr = vkGetInstanceProcAddr(instance, name);
     if (!(*func_ptr) && is_required)
     {
-      ERROR_LOG(VIDEO, "Vulkan: Failed to load required instance function %s", name);
+      ERROR_LOG_FMT(VIDEO, "Vulkan: Failed to load required instance function {}", name);
       required_functions_missing = true;
     }
   };
@@ -112,7 +112,7 @@ bool LoadVulkanDeviceFunctions(VkDevice device)
     *func_ptr = vkGetDeviceProcAddr(device, name);
     if (!(*func_ptr) && is_required)
     {
-      ERROR_LOG(VIDEO, "Vulkan: Failed to load required device function %s", name);
+      ERROR_LOG_FMT(VIDEO, "Vulkan: Failed to load required device function {}", name);
       required_functions_missing = true;
     }
   };
@@ -213,11 +213,10 @@ void LogVulkanResult(int level, const char* func_name, VkResult res, const char*
   std::string real_msg = StringFromFormatV(msg, ap);
   va_end(ap);
 
-  real_msg = StringFromFormat("(%s) %s (%d: %s)", func_name, real_msg.c_str(),
-                              static_cast<int>(res), VkResultToString(res));
+  real_msg = fmt::format("({}) {} ({}: {})", func_name, real_msg, static_cast<int>(res),
+                         VkResultToString(res));
 
-  GENERIC_LOG(Common::Log::VIDEO, static_cast<Common::Log::LOG_LEVELS>(level), "%s",
-              real_msg.c_str());
+  GENERIC_LOG_FMT(Common::Log::VIDEO, static_cast<Common::Log::LOG_LEVELS>(level), "{}", real_msg);
 }
 
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -106,7 +106,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   bool enable_validation_layer = g_Config.bEnableValidationLayer;
   if (enable_validation_layer && !VulkanContext::CheckValidationLayerAvailablility())
   {
-    WARN_LOG(VIDEO, "Validation layer requested but not available, disabling.");
+    WARN_LOG_FMT(VIDEO, "Validation layer requested but not available, disabling.");
     enable_validation_layer = false;
   }
 
@@ -166,7 +166,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   size_t selected_adapter_index = static_cast<size_t>(g_Config.iAdapter);
   if (selected_adapter_index >= gpu_list.size())
   {
-    WARN_LOG(VIDEO, "Vulkan adapter index out of range, selecting first adapter.");
+    WARN_LOG_FMT(VIDEO, "Vulkan adapter index out of range, selecting first adapter.");
     selected_adapter_index = 0;
   }
 
@@ -312,7 +312,7 @@ void VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
   Class clsCAMetalLayer = objc_getClass("CAMetalLayer");
   if (!clsCAMetalLayer)
   {
-    ERROR_LOG(VIDEO, "Failed to get CAMetalLayer class.");
+    ERROR_LOG_FMT(VIDEO, "Failed to get CAMetalLayer class.");
     return;
   }
 
@@ -321,7 +321,7 @@ void VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
                                                                 sel_getUid("layer"));
   if (!layer)
   {
-    ERROR_LOG(VIDEO, "Failed to create Metal layer.");
+    ERROR_LOG_FMT(VIDEO, "Failed to create Metal layer.");
     return;
   }
 


### PR DESCRIPTION
Given the usage of the logging macros are quite small across all logging backends (< 200 LoC), they can all be migrated at once. I've separated the respective migrations into their own commit to make for easier review as well.