### PR TITLE
WIP - DolphinQt/MenuBar: Decouple Frame and Audio Dump from Input Recorder

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -115,7 +115,7 @@ void GameList::MakeListView()
   connect(m_list, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
   connect(m_list->selectionModel(), &QItemSelectionModel::selectionChanged,
           [this](const QItemSelection&, const QItemSelection&) {
-            emit SelectionChanged(GetSelectedGame());
+            emit GameSelectionChanged(GetSelectedGame());
           });
 
   QHeaderView* hor_header = m_list->horizontalHeader();
@@ -255,7 +255,7 @@ void GameList::MakeGridView()
   connect(m_grid, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
   connect(m_grid->selectionModel(), &QItemSelectionModel::selectionChanged,
           [this](const QItemSelection&, const QItemSelection&) {
-            emit SelectionChanged(GetSelectedGame());
+            emit GameSelectionChanged(GetSelectedGame());
           });
 }
 
@@ -265,7 +265,7 @@ void GameList::ShowHeaderContextMenu(const QPoint& pos)
   if (!menu_bar)
     return;
 
-  QMenu* const list_columns_menu = menu_bar->GetListColumnsMenu();
+  QMenu* const list_columns_menu = menu_bar->GetGameListColumnsSubMenu();
   if (!list_columns_menu)
     return;
 

--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -52,7 +52,7 @@ public:
 signals:
   void GameSelected();
   void NetPlayHost(const UICommon::GameFile& game);
-  void SelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
+  void GameSelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
   void OpenGeneralSettings();
 
 private:

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -74,8 +74,8 @@ public:
   bool eventFilter(QObject* object, QEvent* event) override;
 
 signals:
-  void ReadOnlyModeChanged(bool read_only);
-  void RecordingStatusChanged(bool recording);
+  void INRECSReadOnlyModeChanged(bool read_only);
+  void INRECSStatusChanged(bool recording);
 
 private:
   void Open();
@@ -100,9 +100,9 @@ private:
   void StateSaveUndo();
   void StateSaveOldest();
   void SetStateSlot(int slot);
-  void BootWiiSystemMenu();
+  void OnBootWiiSystemMenu();
 
-  void PerformOnlineUpdate(const std::string& region);
+  void OnPerformOnlineUpdate(const std::string& region);
 
   void SetFullScreenResolution(bool fullscreen);
 
@@ -162,20 +162,20 @@ private:
   void NetPlayQuit();
 
   void OnBootGameCubeIPL(DiscIO::Region region);
-  void OnImportNANDBackup();
+  void OnImportMergeSecondaryNAND();
   void OnConnectWiiRemote(int id);
 
 #if defined(__unix__) || defined(__unix) || defined(__APPLE__)
   void OnSignal();
 #endif
 
-  void OnPlayRecording();
-  void OnStartRecording();
-  void OnStopRecording();
-  void OnExportRecording();
+  void OnINRECSPlayRecordedInputTrack();
+  void OnINRECSStartRecording();
+  void OnINRECSStopRecording();
+  void OnINRECSExportRecording();
   void OnActivateChat();
   void OnRequestGolfControl();
-  void ShowTASInput();
+  void OnINRECSShowTASInputConfig();
 
   void ChangeDisc();
   void EjectDisc();

--- a/Source/Core/DolphinQt/MenuBar.h
+++ b/Source/Core/DolphinQt/MenuBar.h
@@ -37,21 +37,31 @@ public:
 
   explicit MenuBar(QWidget* parent = nullptr);
 
-  void UpdateToolsMenu(bool emulation_started);
-
-  QMenu* GetListColumnsMenu() const { return m_cols_menu; }
+  void UpdateMenu_Tools(bool emulation_started);
 
   void InstallUpdateManually();
 
-signals:
-  // File
-  void Open();
-  void Exit();
-  void ChangeDisc();
-  void BootDVDBackup(const QString& backup);
-  void EjectDisc();
+  QMenu* GetGameListColumnsSubMenu() const { return m_gamelist_columns_submenu; }
 
-  // Emulation
+signals:
+  // File Menu
+  void Open();
+  void ChangeDisc();
+  void EjectDisc();
+  void BootDVDBackup(const QString& backup);
+  void Exit();
+
+  // View Menu
+  void ShowList();
+  void ShowGrid();
+  void PurgeGameListCache();
+  void ShowSearch();
+
+  void ColumnVisibilityToggled(const QString& row, bool visible);
+  void GameListPlatformVisibilityToggled(const QString& row, bool visible);
+  void GameListRegionVisibilityToggled(const QString& row, bool visible);
+
+  // Emulation Menu
   void Play();
   void Pause();
   void Stop();
@@ -59,96 +69,116 @@ signals:
   void Fullscreen();
   void FrameAdvance();
   void Screenshot();
-  void StartNetPlay();
-  void BrowseNetPlay();
-  void StateLoad();
-  void StateSave();
+
+  // State Sub Menus
+  void StateLoadFile();
+  void StateSaveFile();
   void StateLoadSlot();
   void StateSaveSlot();
   void StateLoadSlotAt(int slot);
   void StateSaveSlotAt(int slot);
   void StateLoadUndo();
   void StateSaveUndo();
-  void StateSaveOldest();
+  void StateSaveSlotOldest();
   void SetStateSlot(int slot);
-  void BootWiiSystemMenu();
-  void ImportNANDBackup();
 
-  void PerformOnlineUpdate(const std::string& region);
-
-  // Tools
-  void ShowMemcardManager();
-  void BootGameCubeIPL(DiscIO::Region region);
-  void ShowFIFOPlayer();
-  void ShowAboutDialog();
-  void ShowCheatsManager();
+  // Tools Menu
   void ShowResourcePackManager();
+  void ShowCheatsManager();
+  void ShowFIFOPlayer();
+  void StartNetPlay();
+  void BrowseNetPlay();
+  void BootGameCubeIPL(DiscIO::Region region);
+  void ShowMemcardManager();
+  void BootWiiSystemMenu();
+  void ImportMergeSecondaryNAND();
+  void PerformOnlineUpdate(const std::string& region);
   void ConnectWiiRemote(int id);
 
-  // Options
+  // Input Recording System Sub Menu
+  void INRECSPlayRecordedInputTrack();
+  void INRECSStartRecording();
+  void INRECSStopRecording();
+  void INRECSExportRecording();
+  void INRECSShowTASInputConfig();
+
+  void INRECSStatusChanged(bool recording);
+  void INRECSReadOnlyModeChanged(bool read_only);
+
+  // Options Menu
   void Configure();
   void ConfigureGraphics();
   void ConfigureAudio();
   void ConfigureControllers();
   void ConfigureHotkeys();
 
-  // View
-  void ShowList();
-  void ShowGrid();
-  void PurgeGameListCache();
-  void ShowSearch();
-  void ColumnVisibilityToggled(const QString& row, bool visible);
-  void GameListPlatformVisibilityToggled(const QString& row, bool visible);
-  void GameListRegionVisibilityToggled(const QString& row, bool visible);
-
-  // Movie
-  void PlayRecording();
-  void StartRecording();
-  void StopRecording();
-  void ExportRecording();
-  void ShowTASInput();
-
-  void SelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
-  void RecordingStatusChanged(bool recording);
-  void ReadOnlyModeChanged(bool read_only);
-
-  // Synbols
+  // Symbols Menu
   void NotifySymbolsUpdated();
 
+  // Help Menu
+  void ShowAboutDialog();
+
+  // Other
+  void GameSelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
+
 private:
+  // File Menu
+  void AddFileMainMenu();
+  void AddBootDVDBackupSubMenu(QMenu* mainmenu_file);
+
+  // View Menu
+  void AddViewMainMenu();
+  void AddGameListTypeSection(QMenu* mainmenu_view);
+  void AddListColumnsSubMenu(QMenu* mainmenu_view);
+  void AddShowPlatformsSubMenu(QMenu* mainmenu_view);
+  void AddShowRegionsSubMenu(QMenu* mainmenu_view);
+
+  // Emulation Menu
+  void AddEmulationMainMenu();
+  void AddStateLoadSubMenu(QMenu* mainmenu_emu);
+  void AddStateSaveSubMenu(QMenu* mainmenu_emu);
+  void AddStateSlotSelectSubMenu(QMenu* mainmenu_emu);
+
+  void UpdateStateSlotSubMenuAction();
+
   void OnEmulationStateChanged(Core::State state);
 
-  void AddFileMenu();
-  void AddDVDBackupMenu(QMenu* file_menu);
+  // Tools Menu
+  void AddToolsMainMenu();
+  void AddLoadGameCubeIPLSubMenu(QMenu* mainmenu_tools);
+  void AddNANDManagementSubMenu(QMenu* mainmenu_tools);
+  void AddPerformOnlineSystemUpdateSubMenu(QMenu* mainmenu_tools);
+  void AddINRECSSubMenu(QMenu* mainmenu_tools);
+  void AddConnectWiiRemotesSubMenu(QMenu* const mainmenu_tools);
 
-  void AddEmulationMenu();
-  void AddStateLoadMenu(QMenu* emu_menu);
-  void AddStateSaveMenu(QMenu* emu_menu);
-  void AddStateSlotMenu(QMenu* emu_menu);
-
-  void AddViewMenu();
-  void AddGameListTypeSection(QMenu* view_menu);
-  void AddListColumnsMenu(QMenu* view_menu);
-  void AddShowPlatformsMenu(QMenu* view_menu);
-  void AddShowRegionsMenu(QMenu* view_menu);
-
-  void AddOptionsMenu();
-  void AddToolsMenu();
-  void AddHelpMenu();
-  void AddMovieMenu();
-  void AddJITMenu();
-  void AddSymbolsMenu();
-
-  void UpdateStateSlotMenu();
-
-  void InstallWAD();
-  void ImportWiiSave();
   void ExportWiiSaves();
-  void CheckNAND();
-  void NANDExtractCertificates();
+  void ImportWiiSave();
+  void InstallWAD();
+  void NAND_Check();
+  void NAND_ExtractCertificates();
+
+  void OnINRECSStatusChanged(bool recording);
+  void OnINRECSReadOnlyModeChanged(bool read_only);
+
+  // Options Menu
+  void AddOptionsMainMenu();
+
   void ChangeDebugFont();
 
-  // Debugging UI
+  // JIT Menu
+  void AddDebugJITMainMenu();
+
+  void ClearCache();
+  void LogInstructions();
+  void SearchInstruction();
+
+  // Symbols Menu
+  void AddDebugSymbolsMainMenu();
+
+  void AppendSignatureFile();
+  void ApplySignatureFile();
+  void CreateSignatureFile();
+  void CombineSignatureFiles();
   void ClearSymbols();
   void GenerateSymbolsFromAddress();
   void GenerateSymbolsFromSignatureDB();
@@ -157,115 +187,107 @@ private:
   void LoadSymbolMap();
   void LoadOtherSymbolMap();
   void LoadBadSymbolMap();
+  void PatchHLEFunctions();
   void SaveSymbolMap();
   void SaveSymbolMapAs();
   void SaveCode();
   bool TryLoadMapFile(const QString& path, const bool bad = false);
   void TrySaveSymbolMap(const QString& path);
-  void CreateSignatureFile();
-  void AppendSignatureFile();
-  void ApplySignatureFile();
-  void CombineSignatureFiles();
-  void PatchHLEFunctions();
-  void ClearCache();
-  void LogInstructions();
-  void SearchInstruction();
 
-  void OnSelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
-  void OnRecordingStatusChanged(bool recording);
-  void OnReadOnlyModeChanged(bool read_only);
+  // Help Menu
+  void AddHelpMainMenu();
+
+  // Other
+  void OnGameSelectionChanged(std::shared_ptr<const UICommon::GameFile> game_file);
   void OnDebugModeToggled(bool enabled);
 
   QString GetSignatureSelector() const;
 
   static QPointer<MenuBar> s_menu_bar;
 
-  // File
+  // File Menu
   QAction* m_open_action;
   QAction* m_exit_action;
   QAction* m_change_disc;
   QAction* m_eject_disc;
-  QMenu* m_backup_menu;
+  QMenu* m_boot_dvd_backup_submenu;
 
-  // Tools
+  // View Menu
+  QAction* m_debug__show_code;
+  QAction* m_debug__show_registers;
+  QAction* m_debug__show_threads;
+  QAction* m_debug__show_watch;
+  QAction* m_debug__show_breakpoints;
+  QAction* m_debug__show_memory;
+  QAction* m_debug__show_network;
+  QAction* m_debug__show_jit;
+  QMenu* m_gamelist_columns_submenu;
+
+  // Emulation Menu
+  QAction* m_emu_play_action;
+  QAction* m_emu_pause_action;
+  QAction* m_emu_stop_action;
+  QAction* m_emu_reset_action;
+  QAction* m_emu_fullscreen_action;
+  QAction* m_emu_frame_advance_action;
+  QAction* m_emu_screenshot_action;
+  QMenu* m_state_load_submenu;
+  QMenu* m_state_save_submenu;
+  QMenu* m_state_slot_select_submenu;
+  QActionGroup* m_state_slots;
+  QMenu* m_state_load_slots_submenu;
+  QMenu* m_state_save_slots_submenu;
+
+  // Tools Menu
   QAction* m_show_cheat_manager;
-  QAction* m_wad_install_action;
-  QMenu* m_perform_online_update_menu;
+  QAction* m_gc_load_ipl_ntscj;
+  QAction* m_gc_load_ipl_ntscu;
+  QAction* m_gc_load_ipl_pal;
+  QAction* m_wii_load_sysmenu_action;
+  QMenu* m_perform_online_update_submenu;
   QAction* m_perform_online_update_for_current_region;
-  QAction* m_ntscj_ipl;
-  QAction* m_ntscu_ipl;
-  QAction* m_pal_ipl;
-  QMenu* m_manage_nand_menu;
-  QAction* m_import_backup;
-  QAction* m_check_nand;
-  QAction* m_extract_certificates;
+  QAction* m_nand_import_merge_secondary;
+  QAction* m_nand_check;
+  QAction* m_nand_extract_certificates;
+  QAction* m_inrecs_export;
+  QAction* m_inrecs_replay;
+  QAction* m_inrecs_start;
+  QAction* m_inrecs_stop;
+  QAction* m_inrecs_read_only;
   std::array<QAction*, 5> m_wii_remotes;
 
-  // Emulation
-  QAction* m_play_action;
-  QAction* m_pause_action;
-  QAction* m_stop_action;
-  QAction* m_reset_action;
-  QAction* m_fullscreen_action;
-  QAction* m_frame_advance_action;
-  QAction* m_screenshot_action;
-  QAction* m_boot_sysmenu;
-  QMenu* m_state_load_menu;
-  QMenu* m_state_save_menu;
-  QMenu* m_state_slot_menu;
-  QActionGroup* m_state_slots;
-  QMenu* m_state_load_slots_menu;
-  QMenu* m_state_save_slots_menu;
-
-  // Movie
-  QAction* m_recording_export;
-  QAction* m_recording_play;
-  QAction* m_recording_start;
-  QAction* m_recording_stop;
-  QAction* m_recording_read_only;
-
-  // Options
-  QAction* m_boot_to_pause;
-  QAction* m_automatic_start;
-  QAction* m_change_font;
+  // Options Menu
+  QAction* m_debug__boot_to_pause;
+  QAction* m_debug__automatic_start;
+  QAction* m_debug__change_font;
   QAction* m_controllers_action;
 
-  // View
-  QAction* m_show_code;
-  QAction* m_show_registers;
-  QAction* m_show_threads;
-  QAction* m_show_watch;
-  QAction* m_show_breakpoints;
-  QAction* m_show_memory;
-  QAction* m_show_network;
-  QAction* m_show_jit;
-  QMenu* m_cols_menu;
+  // JIT Menu
+  QMenu* m_debug__jit_mainmenu;
+  QAction* m_debug__jit_interpreter_core;
+  QAction* m_debug__jit_block_linking;
+  QAction* m_debug__jit_disable_cache;
+  QAction* m_debug__jit_disable_fastmem;
+  QAction* m_debug__jit_clear_cache;
+  QAction* m_debug__jit_log_coverage;
+  QAction* m_debug__jit_search_instruction;
+  QAction* m_debug__jit_off;
+  QAction* m_debug__jit_loadstore_off;
+  QAction* m_debug__jit_loadstore_lbzx_off;
+  QAction* m_debug__jit_loadstore_lxz_off;
+  QAction* m_debug__jit_loadstore_lwz_off;
+  QAction* m_debug__jit_loadstore_floating_off;
+  QAction* m_debug__jit_loadstore_paired_off;
+  QAction* m_debug__jit_floatingpoint_off;
+  QAction* m_debug__jit_integer_off;
+  QAction* m_debug__jit_paired_off;
+  QAction* m_debug__jit_systemregisters_off;
+  QAction* m_debug__jit_branch_off;
+  QAction* m_debug__jit_register_cache_off;
 
-  // JIT
-  QMenu* m_jit;
+  // Symbols Menu
+  QMenu* m_debug__symbols_mainmenu;
 
-  // Symbols
-  QMenu* m_symbols;
-  QAction* m_jit_interpreter_core;
-  QAction* m_jit_block_linking;
-  QAction* m_jit_disable_cache;
-  QAction* m_jit_disable_fastmem;
-  QAction* m_jit_clear_cache;
-  QAction* m_jit_log_coverage;
-  QAction* m_jit_search_instruction;
-  QAction* m_jit_off;
-  QAction* m_jit_loadstore_off;
-  QAction* m_jit_loadstore_lbzx_off;
-  QAction* m_jit_loadstore_lxz_off;
-  QAction* m_jit_loadstore_lwz_off;
-  QAction* m_jit_loadstore_floating_off;
-  QAction* m_jit_loadstore_paired_off;
-  QAction* m_jit_floatingpoint_off;
-  QAction* m_jit_integer_off;
-  QAction* m_jit_paired_off;
-  QAction* m_jit_systemregisters_off;
-  QAction* m_jit_branch_off;
-  QAction* m_jit_register_cache_off;
-
+  // Other
   bool m_game_selected = false;
 };


### PR DESCRIPTION
Further framedump improvement preparation. Separation from TAS Movies because of many reasons:

First it literally has nothing to do with TAS Movies (input recording) in code or otherwise and can be used on it's own.

Second, if things go according to my plan, FrameDump will become bigger in scope with more options and dialogs that would go right here into this new menu. It would eventually deserve it's own menu IMO, if not, perhaps a place in Tools menu or something.

Third, the whole "movies" (TAS Movies) moniker has been in name clash with what FrameDump is about for a long time, at least in my view, not that it's a problem, but if I'm here why not improve this as well. FrameDump encodes dumps and makes movies or videos, even if we take the strict meaning of those into account, the output of FrameDump is closer to a movie than not, whereas TAS Movies does not actually make anything comparable to a video let alone a movie, we all know it really creates input recording files. This PR is just the first part of solving that for good.

Warning: Due to sizable code rearrangement there is a lot of change indications in diff, however litterally nothing else has been changed(removed) except what is described above.