### PR TITLE
DiscIO: Make use of fmt-capable panic alerts

### DIFF
--- a/Source/Core/DiscIO/DirectoryBlob.cpp
+++ b/Source/Core/DiscIO/DirectoryBlob.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstring>
 #include <locale>
 #include <map>

--- a/Source/Core/DiscIO/DriveBlob.cpp
+++ b/Source/Core/DiscIO/DriveBlob.cpp
@@ -146,7 +146,7 @@ bool DriveReader::ReadMultipleAlignedBlocks(u64 block_num, u64 num_blocks, u8* o
       !ReadFile(m_disc_handle, out_ptr, static_cast<DWORD>(GetSectorSize() * num_blocks),
                 &bytes_read, nullptr))
   {
-    PanicAlertT("Disc Read Error");
+    PanicAlertFmtT("Disc Read Error");
     return false;
   }
   return bytes_read == GetSectorSize() * num_blocks;

--- a/Source/Core/DiscIO/FileBlob.cpp
+++ b/Source/Core/DiscIO/FileBlob.cpp
@@ -49,10 +49,11 @@ bool ConvertToPlain(BlobReader* infile, const std::string& infile_path,
   File::IOFile outfile(outfile_path, "wb");
   if (!outfile)
   {
-    PanicAlertT("Failed to open the output file \"%s\".\n"
-                "Check that you have permissions to write the target folder and that the media can "
-                "be written.",
-                outfile_path.c_str());
+    PanicAlertFmtT(
+        "Failed to open the output file \"{}\".\n"
+        "Check that you have permissions to write the target folder and that the media can "
+        "be written.",
+        outfile_path);
     return false;
   }
 
@@ -89,15 +90,15 @@ bool ConvertToPlain(BlobReader* infile, const std::string& infile_path,
     const u64 sz = std::min(buffer_size, infile->GetDataSize() - inpos);
     if (!infile->Read(inpos, sz, buffer.data()))
     {
-      PanicAlertT("Failed to read from the input file \"%s\".", infile_path.c_str());
+      PanicAlertFmtT("Failed to read from the input file \"{}\".", infile_path);
       success = false;
       break;
     }
     if (!outfile.WriteBytes(buffer.data(), sz))
     {
-      PanicAlertT("Failed to write the output file \"%s\".\n"
-                  "Check that you have enough space available on the target drive.",
-                  outfile_path.c_str());
+      PanicAlertFmtT("Failed to write the output file \"{}\".\n"
+                     "Check that you have enough space available on the target drive.",
+                     outfile_path);
       success = false;
       break;
     }

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <cinttypes>
 #include <cstddef>
 #include <cstring>
 #include <locale>

--- a/Source/Core/DiscIO/NANDImporter.cpp
+++ b/Source/Core/DiscIO/NANDImporter.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstring>
 
 #include <fmt/format.h>
@@ -60,7 +59,7 @@ bool NANDImporter::ReadNANDBin(const std::string& path_to_bin,
   const u64 image_size = file.GetSize();
   if (image_size != NAND_BIN_SIZE + NAND_KEYS_SIZE && image_size != NAND_BIN_SIZE)
   {
-    PanicAlertT("This file does not look like a BootMii NAND backup.");
+    PanicAlertFmtT("This file does not look like a BootMii NAND backup.");
     return false;
   }
 
@@ -273,6 +272,6 @@ void NANDImporter::ExportKeys(const std::string& nand_root)
   const std::string file_path = nand_root + "/keys.bin";
   File::IOFile file(file_path, "wb");
   if (!file.WriteBytes(m_nand_keys.data(), NAND_KEYS_SIZE))
-    PanicAlertT("Unable to write to file %s", file_path.c_str());
+    PanicAlertFmtT("Unable to write to file {}", file_path);
 }
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -312,11 +312,11 @@ std::vector<RedumpVerifier::PotentialMatch> RedumpVerifier::ScanDatfile(const st
     // so show a panic alert rather than just using ERROR_LOG
 
     // i18n: "Serial" refers to serial numbers, e.g. RVL-RSBE-USA
-    PanicAlertT("Serial and/or version data is missing from %s\n"
-                "Please append \"%s\" (without the quotes) to the datfile URL when downloading\n"
-                "Example: %s",
-                GetPathForSystem(system).c_str(), "serial,version",
-                "http://redump.org/datfile/gc/serial,version");
+    PanicAlertFmtT("Serial and/or version data is missing from {}\n"
+                   "Please append \"{}\" (without the quotes) to the datfile URL when downloading\n"
+                   "Example: {}",
+                   GetPathForSystem(system), "serial,version",
+                   "http://redump.org/datfile/gc/serial,version");
     m_result = {Status::Error, Common::GetStringT("Failed to parse Redump.org data")};
     return {};
   }

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -92,7 +92,7 @@ VolumeWii::VolumeWii(std::unique_ptr<BlobReader> reader)
         {
           // This check is normally done by ES in ES_DiVerify, but that would happen too late
           // (after allocating the buffer), so we do the check here.
-          PanicAlert("Invalid TMD size");
+          PanicAlertFmt("Invalid TMD size");
           return INVALID_TMD;
         }
         std::vector<u8> tmd_buffer(*tmd_size);

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -2032,10 +2032,11 @@ bool ConvertToWIAOrRVZ(BlobReader* infile, const std::string& infile_path,
   File::IOFile outfile(outfile_path, "wb");
   if (!outfile)
   {
-    PanicAlertT("Failed to open the output file \"%s\".\n"
-                "Check that you have permissions to write the target folder and that the media can "
-                "be written.",
-                outfile_path.c_str());
+    PanicAlertFmtT(
+        "Failed to open the output file \"{}\".\n"
+        "Check that you have permissions to write the target folder and that the media can "
+        "be written.",
+        outfile_path);
     return false;
   }
 
@@ -2047,13 +2048,13 @@ bool ConvertToWIAOrRVZ(BlobReader* infile, const std::string& infile_path,
               chunk_size, callback);
 
   if (result == ConversionResultCode::ReadFailed)
-    PanicAlertT("Failed to read from the input file \"%s\".", infile_path.c_str());
+    PanicAlertFmtT("Failed to read from the input file \"{}\".", infile_path);
 
   if (result == ConversionResultCode::WriteFailed)
   {
-    PanicAlertT("Failed to write the output file \"%s\".\n"
-                "Check that you have enough space available on the target drive.",
-                outfile_path.c_str());
+    PanicAlertFmtT("Failed to write the output file \"{}\".\n"
+                   "Check that you have enough space available on the target drive.",
+                   outfile_path);
   }
 
   if (result != ConversionResultCode::Success)

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -166,7 +166,7 @@ File::IOFile& WbfsFileReader::SeekToCluster(u64 offset, u64* available)
     }
   }
 
-  PanicAlert("Read beyond end of disc");
+  PanicAlertFmt("Read beyond end of disc");
   if (available)
     *available = 0;
   m_files[0].file.Seek(0, SEEK_SET);


### PR DESCRIPTION
Migrates the DiscIO code over to fmt. DiscIO is finally free from the printf hell that is the PRI* macros.