### PR TITLE
Wiimote: Use dynamic_cast where applicable

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -68,7 +68,7 @@ HIDWiimote* GetHIDWiimoteSource(unsigned int index)
   switch (GetSource(index))
   {
   case WiimoteSource::Emulated:
-    hid_source = static_cast<WiimoteEmu::Wiimote*>(::Wiimote::GetConfig()->GetController(index));
+    hid_source = dynamic_cast<WiimoteEmu::Wiimote*>(::Wiimote::GetConfig()->GetController(index));
     break;
 
   case WiimoteSource::Real:
@@ -95,51 +95,51 @@ InputConfig* GetConfig()
 
 ControllerEmu::ControlGroup* GetWiimoteGroup(int number, WiimoteEmu::WiimoteGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetWiimoteGroup(group);
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetWiimoteGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetNunchukGroup(int number, WiimoteEmu::NunchukGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetNunchukGroup(group);
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetNunchukGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetClassicGroup(int number, WiimoteEmu::ClassicGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetClassicGroup(group);
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetClassicGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetGuitarGroup(int number, WiimoteEmu::GuitarGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetGuitarGroup(group);
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetGuitarGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetDrumsGroup(int number, WiimoteEmu::DrumsGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetDrumsGroup(group);
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetDrumsGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetTurntableGroup(int number, WiimoteEmu::TurntableGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
       ->GetTurntableGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetUDrawTabletGroup(int number, WiimoteEmu::UDrawTabletGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
       ->GetUDrawTabletGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetDrawsomeTabletGroup(int number,
                                                     WiimoteEmu::DrawsomeTabletGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
       ->GetDrawsomeTabletGroup(group);
 }
 
 ControllerEmu::ControlGroup* GetTaTaConGroup(int number, WiimoteEmu::TaTaConGroup group)
 {
-  return static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetTaTaConGroup(group);
+  return dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->GetTaTaConGroup(group);
 }
 
 void Shutdown()
@@ -173,7 +173,7 @@ void Initialize(InitializeMode init_mode)
 void ResetAllWiimotes()
 {
   for (int i = WIIMOTE_CHAN_0; i < MAX_BBMOTES; ++i)
-    static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->Reset();
+    dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->Reset();
 }
 
 void LoadConfig()
@@ -203,7 +203,7 @@ void DoState(PointerWrap& p)
     if (WiimoteSource(state_wiimote_source) == WiimoteSource::Emulated)
     {
       // Sync complete state of emulated wiimotes.
-      static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);
+      dynamic_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);
     }
 
     if (p.GetMode() == PointerWrap::MODE_READ)

--- a/Source/Core/Core/HW/WiimoteEmu/ExtensionPort.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/ExtensionPort.cpp
@@ -23,7 +23,6 @@ void ExtensionPort::AttachExtension(Extension* ext)
 
   m_extension = ext;
   m_i2c_bus.AddSlave(m_extension);
-  ;
 }
 
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -345,52 +345,52 @@ ControllerEmu::ControlGroup* Wiimote::GetWiimoteGroup(WiimoteGroup group) const
 
 ControllerEmu::ControlGroup* Wiimote::GetNunchukGroup(NunchukGroup group) const
 {
-  return static_cast<Nunchuk*>(m_attachments->GetAttachmentList()[ExtensionNumber::NUNCHUK].get())
+  return dynamic_cast<Nunchuk*>(m_attachments->GetAttachmentList()[ExtensionNumber::NUNCHUK].get())
       ->GetGroup(group);
 }
 
 ControllerEmu::ControlGroup* Wiimote::GetClassicGroup(ClassicGroup group) const
 {
-  return static_cast<Classic*>(m_attachments->GetAttachmentList()[ExtensionNumber::CLASSIC].get())
+  return dynamic_cast<Classic*>(m_attachments->GetAttachmentList()[ExtensionNumber::CLASSIC].get())
       ->GetGroup(group);
 }
 
 ControllerEmu::ControlGroup* Wiimote::GetGuitarGroup(GuitarGroup group) const
 {
-  return static_cast<Guitar*>(m_attachments->GetAttachmentList()[ExtensionNumber::GUITAR].get())
+  return dynamic_cast<Guitar*>(m_attachments->GetAttachmentList()[ExtensionNumber::GUITAR].get())
       ->GetGroup(group);
 }
 
 ControllerEmu::ControlGroup* Wiimote::GetDrumsGroup(DrumsGroup group) const
 {
-  return static_cast<Drums*>(m_attachments->GetAttachmentList()[ExtensionNumber::DRUMS].get())
+  return dynamic_cast<Drums*>(m_attachments->GetAttachmentList()[ExtensionNumber::DRUMS].get())
       ->GetGroup(group);
 }
 
 ControllerEmu::ControlGroup* Wiimote::GetTurntableGroup(TurntableGroup group) const
 {
-  return static_cast<Turntable*>(
+  return dynamic_cast<Turntable*>(
              m_attachments->GetAttachmentList()[ExtensionNumber::TURNTABLE].get())
       ->GetGroup(group);
 }
 
 ControllerEmu::ControlGroup* Wiimote::GetUDrawTabletGroup(UDrawTabletGroup group) const
 {
-  return static_cast<UDrawTablet*>(
+  return dynamic_cast<UDrawTablet*>(
              m_attachments->GetAttachmentList()[ExtensionNumber::UDRAW_TABLET].get())
       ->GetGroup(group);
 }
 
 ControllerEmu::ControlGroup* Wiimote::GetDrawsomeTabletGroup(DrawsomeTabletGroup group) const
 {
-  return static_cast<DrawsomeTablet*>(
+  return dynamic_cast<DrawsomeTablet*>(
              m_attachments->GetAttachmentList()[ExtensionNumber::DRAWSOME_TABLET].get())
       ->GetGroup(group);
 }
 
 ControllerEmu::ControlGroup* Wiimote::GetTaTaConGroup(TaTaConGroup group) const
 {
-  return static_cast<TaTaCon*>(m_attachments->GetAttachmentList()[ExtensionNumber::TATACON].get())
+  return dynamic_cast<TaTaCon*>(m_attachments->GetAttachmentList()[ExtensionNumber::TATACON].get())
       ->GetGroup(group);
 }
 
@@ -681,12 +681,12 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
 
 Extension* Wiimote::GetNoneExtension() const
 {
-  return static_cast<Extension*>(m_attachments->GetAttachmentList()[ExtensionNumber::NONE].get());
+  return dynamic_cast<Extension*>(m_attachments->GetAttachmentList()[ExtensionNumber::NONE].get());
 }
 
 Extension* Wiimote::GetActiveExtension() const
 {
-  return static_cast<Extension*>(m_attachments->GetAttachmentList()[m_active_extension].get());
+  return dynamic_cast<Extension*>(m_attachments->GetAttachmentList()[m_active_extension].get());
 }
 
 EncryptionKey Wiimote::GetExtensionEncryptionKey() const
@@ -694,7 +694,7 @@ EncryptionKey Wiimote::GetExtensionEncryptionKey() const
   if (ExtensionNumber::NONE == GetActiveExtensionNumber())
     return {};
 
-  return static_cast<EncryptedExtension*>(GetActiveExtension())->ext_key;
+  return dynamic_cast<EncryptedExtension*>(GetActiveExtension())->ext_key;
 }
 
 bool Wiimote::IsSideways() const


### PR DESCRIPTION
Suggested by clang while looking around the Wiimote code. And removes a random semicolon.