### PR TITLE
DolphinQt: Don't return 0x04 bytes from tr

### DIFF
--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -186,7 +186,7 @@ public:
                                  [](const char* a, const char* b) { return strcmp(a, b) < 0; });
 
     if (iter == end || strcmp(*iter, original_string) != 0)
-      return original_string;
+      return nullptr;
 
     u32 offset = ReadU32(&m_data[m_offset_translation_table + std::distance(begin, iter) * 8 + 4]);
     return &m_data[offset];
@@ -214,17 +214,21 @@ public:
   QString translate(const char* context, const char* source_text,
                     const char* disambiguation = nullptr, int n = -1) const override
   {
+    const char* translated_text;
+
     if (disambiguation)
     {
       std::string combined_string = disambiguation;
       combined_string += '\4';
       combined_string += source_text;
-      return QString::fromUtf8(m_mo_file.Translate(combined_string.c_str()));
+      translated_text = m_mo_file.Translate(combined_string.c_str());
     }
     else
     {
-      return QString::fromUtf8(m_mo_file.Translate(source_text));
+      translated_text = m_mo_file.Translate(source_text);
     }
+
+    return QString::fromUtf8(translated_text ? translated_text : source_text);
   }
 
 private:


### PR DESCRIPTION
`tr` calls with more than one argument would have a 0x04 byte in the returned string when no translation was found (which always is the case when using Dolphin in English).