### PR TITLE
Fix updater not always cleaning up temp directory

### DIFF
--- a/Source/Core/UpdaterCommon/UpdaterCommon.cpp
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.cpp
@@ -755,10 +755,10 @@ bool RunUpdater(std::vector<std::string> args)
   UI::SetDescription("Performing Update...");
 
   bool ok = PerformUpdate(todo, opts.install_base_path, opts.content_store_url, temp_dir);
+  CleanUpTempDir(temp_dir, todo);
   if (!ok)
   {
     FatalError("Failed to apply the update.");
-    CleanUpTempDir(temp_dir, todo);
     return false;
   }
 


### PR DESCRIPTION
Updater was only deleting TempUpdate folder when an error occured.