### PR TITLE
VideoCommon: Migrate over to fmt

### DIFF
--- a/Source/Core/VideoCommon/AbstractTexture.cpp
+++ b/Source/Core/VideoCommon/AbstractTexture.cpp
@@ -126,7 +126,7 @@ u32 AbstractTexture::CalculateStrideForFormat(AbstractTextureFormat format, u32 
   case AbstractTextureFormat::D32F_S8:
     return static_cast<size_t>(row_length) * 8;
   default:
-    PanicAlert("Unhandled texture format.");
+    PanicAlertFmt("Unhandled texture format.");
     return 0;
   }
 }
@@ -153,7 +153,7 @@ u32 AbstractTexture::GetTexelSizeForFormat(AbstractTextureFormat format)
   case AbstractTextureFormat::D32F_S8:
     return 8;
   default:
-    PanicAlert("Unhandled texture format.");
+    PanicAlertFmt("Unhandled texture format.");
     return 0;
   }
 }

--- a/Source/Core/VideoCommon/AsyncShaderCompiler.cpp
+++ b/Source/Core/VideoCommon/AsyncShaderCompiler.cpp
@@ -122,7 +122,7 @@ bool AsyncShaderCompiler::StartWorkerThreads(u32 num_worker_threads)
     void* thread_param = nullptr;
     if (!WorkerThreadInitMainThread(&thread_param))
     {
-      WARN_LOG(VIDEO, "Failed to initialize shader compiler worker thread.");
+      WARN_LOG_FMT(VIDEO, "Failed to initialize shader compiler worker thread.");
       break;
     }
 
@@ -133,7 +133,7 @@ bool AsyncShaderCompiler::StartWorkerThreads(u32 num_worker_threads)
 
     if (!m_worker_thread_start_result.load())
     {
-      WARN_LOG(VIDEO, "Failed to start shader compiler worker thread.");
+      WARN_LOG_FMT(VIDEO, "Failed to start shader compiler worker thread.");
       thr.join();
       break;
     }
@@ -198,7 +198,7 @@ void AsyncShaderCompiler::WorkerThreadEntryPoint(void* param)
   // Initialize worker thread with backend-specific method.
   if (!WorkerThreadInitWorkerThread(param))
   {
-    WARN_LOG(VIDEO, "Failed to initialize shader compiler worker.");
+    WARN_LOG_FMT(VIDEO, "Failed to initialize shader compiler worker.");
     m_worker_thread_start_result.store(false);
     m_init_event.Set();
     return;

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -5,6 +5,7 @@
 #include "VideoCommon/BPFunctions.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -223,12 +224,12 @@ void OnPixelFormatChange()
   if (!g_ActiveConfig.bEFBEmulateFormatChanges)
     return;
 
-  auto old_format = g_renderer->GetPrevPixelFormat();
-  auto new_format = bpmem.zcontrol.pixel_format;
+  const auto old_format = g_renderer->GetPrevPixelFormat();
+  const auto new_format = bpmem.zcontrol.pixel_format;
   g_renderer->StorePixelFormat(new_format);
 
-  DEBUG_LOG(VIDEO, "pixelfmt: pixel=%d, zc=%d", static_cast<int>(new_format),
-            static_cast<int>(bpmem.zcontrol.zformat));
+  DEBUG_LOG_FMT(VIDEO, "pixelfmt: pixel={}, zc={}", static_cast<int>(new_format),
+                static_cast<int>(bpmem.zcontrol.zformat));
 
   // no need to reinterpret pixel data in these cases
   if (new_format == old_format || old_format == PEControl::INVALID_FMT)
@@ -291,8 +292,8 @@ void OnPixelFormatChange()
     break;
   }
 
-  ERROR_LOG(VIDEO, "Unhandled EFB format change: %d to %d", static_cast<int>(old_format),
-            static_cast<int>(new_format));
+  ERROR_LOG_FMT(VIDEO, "Unhandled EFB format change: {} to {}", static_cast<int>(old_format),
+                static_cast<int>(new_format));
 }
 
 void SetInterlacingMode(const BPCmd& bp)
@@ -304,21 +305,21 @@ void SetInterlacingMode(const BPCmd& bp)
   {
     // SDK always sets bpmem.lineptwidth.lineaspect via BPMEM_LINEPTWIDTH
     // just before this cmd
-    const char* action[] = {"don't adjust", "adjust"};
-    DEBUG_LOG(VIDEO, "BPMEM_FIELDMODE texLOD:%s lineaspect:%s", action[bpmem.fieldmode.texLOD],
-              action[bpmem.lineptwidth.lineaspect]);
+    static constexpr std::string_view action[] = {"don't adjust", "adjust"};
+    DEBUG_LOG_FMT(VIDEO, "BPMEM_FIELDMODE texLOD:{} lineaspect:{}", action[bpmem.fieldmode.texLOD],
+                  action[bpmem.lineptwidth.lineaspect]);
   }
   break;
   case BPMEM_FIELDMASK:
   {
     // Determines if fields will be written to EFB (always computed)
-    const char* action[] = {"skip", "write"};
-    DEBUG_LOG(VIDEO, "BPMEM_FIELDMASK even:%s odd:%s", action[bpmem.fieldmask.even],
-              action[bpmem.fieldmask.odd]);
+    static constexpr std::string_view action[] = {"skip", "write"};
+    DEBUG_LOG_FMT(VIDEO, "BPMEM_FIELDMASK even:{} odd:{}", action[bpmem.fieldmask.even],
+                  action[bpmem.fieldmask.odd]);
   }
   break;
   default:
-    ERROR_LOG(VIDEO, "SetInterlacingMode default");
+    ERROR_LOG_FMT(VIDEO, "SetInterlacingMode default");
     break;
   }
 }

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -361,13 +361,13 @@ void UpdateInterrupts(u64 userdata)
   if (userdata)
   {
     s_interrupt_set.Set();
-    DEBUG_LOG(COMMANDPROCESSOR, "Interrupt set");
+    DEBUG_LOG_FMT(COMMANDPROCESSOR, "Interrupt set");
     ProcessorInterface::SetInterrupt(INT_CAUSE_CP, true);
   }
   else
   {
     s_interrupt_set.Clear();
-    DEBUG_LOG(COMMANDPROCESSOR, "Interrupt cleared");
+    DEBUG_LOG_FMT(COMMANDPROCESSOR, "Interrupt cleared");
     ProcessorInterface::SetInterrupt(INT_CAUSE_CP, false);
   }
   CoreTiming::ForceExceptionCheck(0);
@@ -395,21 +395,21 @@ void SetCPStatusFromGPU()
     {
       if (!fifo.bFF_Breakpoint)
       {
-        DEBUG_LOG(COMMANDPROCESSOR, "Hit breakpoint at %i", fifo.CPReadPointer);
+        DEBUG_LOG_FMT(COMMANDPROCESSOR, "Hit breakpoint at {}", fifo.CPReadPointer);
         fifo.bFF_Breakpoint = true;
       }
     }
     else
     {
       if (fifo.bFF_Breakpoint)
-        DEBUG_LOG(COMMANDPROCESSOR, "Cleared breakpoint at %i", fifo.CPReadPointer);
+        DEBUG_LOG_FMT(COMMANDPROCESSOR, "Cleared breakpoint at {}", fifo.CPReadPointer);
       fifo.bFF_Breakpoint = false;
     }
   }
   else
   {
     if (fifo.bFF_Breakpoint)
-      DEBUG_LOG(COMMANDPROCESSOR, "Cleared breakpoint at %i", fifo.CPReadPointer);
+      DEBUG_LOG_FMT(COMMANDPROCESSOR, "Cleared breakpoint at {}", fifo.CPReadPointer);
     fifo.bFF_Breakpoint = false;
   }
 
@@ -462,7 +462,7 @@ void SetCPStatusFromCPU()
       if (!interrupt || bpInt || undfInt || ovfInt)
       {
         s_interrupt_set.Set(interrupt);
-        DEBUG_LOG(COMMANDPROCESSOR, "Interrupt set");
+        DEBUG_LOG_FMT(COMMANDPROCESSOR, "Interrupt set");
         ProcessorInterface::SetInterrupt(INT_CAUSE_CP, interrupt);
       }
     }
@@ -483,9 +483,9 @@ void SetCpStatusRegister()
   m_CPStatusReg.UnderflowLoWatermark = fifo.bFF_LoWatermark;
   m_CPStatusReg.OverflowHiWatermark = fifo.bFF_HiWatermark;
 
-  DEBUG_LOG(COMMANDPROCESSOR, "\t Read from STATUS_REGISTER : %04x", m_CPStatusReg.Hex);
-  DEBUG_LOG(
-      COMMANDPROCESSOR, "(r) status: iBP %s | fReadIdle %s | fCmdIdle %s | iOvF %s | iUndF %s",
+  DEBUG_LOG_FMT(COMMANDPROCESSOR, "\t Read from STATUS_REGISTER : {:04x}", m_CPStatusReg.Hex);
+  DEBUG_LOG_FMT(
+      COMMANDPROCESSOR, "(r) status: iBP {} | fReadIdle {} | fCmdIdle {} | iOvF {} | iUndF {}",
       m_CPStatusReg.Breakpoint ? "ON" : "OFF", m_CPStatusReg.ReadIdle ? "ON" : "OFF",
       m_CPStatusReg.CommandIdle ? "ON" : "OFF", m_CPStatusReg.OverflowHiWatermark ? "ON" : "OFF",
       m_CPStatusReg.UnderflowLoWatermark ? "ON" : "OFF");
@@ -509,11 +509,11 @@ void SetCpControlRegister()
     fifo.bFF_GPReadEnable = m_CPCtrlReg.GPReadEnable;
   }
 
-  DEBUG_LOG(COMMANDPROCESSOR, "\t GPREAD %s | BP %s | Int %s | OvF %s | UndF %s | LINK %s",
-            fifo.bFF_GPReadEnable ? "ON" : "OFF", fifo.bFF_BPEnable ? "ON" : "OFF",
-            fifo.bFF_BPInt ? "ON" : "OFF", m_CPCtrlReg.FifoOverflowIntEnable ? "ON" : "OFF",
-            m_CPCtrlReg.FifoUnderflowIntEnable ? "ON" : "OFF",
-            m_CPCtrlReg.GPLinkEnable ? "ON" : "OFF");
+  DEBUG_LOG_FMT(COMMANDPROCESSOR, "\t GPREAD {} | BP {} | Int {} | OvF {} | UndF {} | LINK {}",
+                fifo.bFF_GPReadEnable ? "ON" : "OFF", fifo.bFF_BPEnable ? "ON" : "OFF",
+                fifo.bFF_BPInt ? "ON" : "OFF", m_CPCtrlReg.FifoOverflowIntEnable ? "ON" : "OFF",
+                m_CPCtrlReg.FifoUnderflowIntEnable ? "ON" : "OFF",
+                m_CPCtrlReg.GPLinkEnable ? "ON" : "OFF");
 }
 
 // NOTE: We intentionally don't emulate this function at the moment.
@@ -525,39 +525,40 @@ void SetCpClearRegister()
 void HandleUnknownOpcode(u8 cmd_byte, void* buffer, bool preprocess)
 {
   // TODO(Omega): Maybe dump FIFO to file on this error
-  PanicAlertT("GFX FIFO: Unknown Opcode (0x%02x @ %p, %s).\n"
-              "This means one of the following:\n"
-              "* The emulated GPU got desynced, disabling dual core can help\n"
-              "* Command stream corrupted by some spurious memory bug\n"
-              "* This really is an unknown opcode (unlikely)\n"
-              "* Some other sort of bug\n\n"
-              "Further errors will be sent to the Video Backend log and\n"
-              "Dolphin will now likely crash or hang. Enjoy.",
-              cmd_byte, buffer, preprocess ? "preprocess=true" : "preprocess=false");
+  PanicAlertFmtT("GFX FIFO: Unknown Opcode ({:#04x} @ {}, {}).\n"
+                 "This means one of the following:\n"
+                 "* The emulated GPU got desynced, disabling dual core can help\n"
+                 "* Command stream corrupted by some spurious memory bug\n"
+                 "* This really is an unknown opcode (unlikely)\n"
+                 "* Some other sort of bug\n\n"
+                 "Further errors will be sent to the Video Backend log and\n"
+                 "Dolphin will now likely crash or hang. Enjoy.",
+                 cmd_byte, buffer, preprocess ? "preprocess=true" : "preprocess=false");
 
   {
-    PanicAlert("Illegal command %02x\n"
-               "CPBase: 0x%08x\n"
-               "CPEnd: 0x%08x\n"
-               "CPHiWatermark: 0x%08x\n"
-               "CPLoWatermark: 0x%08x\n"
-               "CPReadWriteDistance: 0x%08x\n"
-               "CPWritePointer: 0x%08x\n"
-               "CPReadPointer: 0x%08x\n"
-               "CPBreakpoint: 0x%08x\n"
-               "bFF_GPReadEnable: %s\n"
-               "bFF_BPEnable: %s\n"
-               "bFF_BPInt: %s\n"
-               "bFF_Breakpoint: %s\n"
-               "bFF_GPLinkEnable: %s\n"
-               "bFF_HiWatermarkInt: %s\n"
-               "bFF_LoWatermarkInt: %s\n",
-               cmd_byte, fifo.CPBase, fifo.CPEnd, fifo.CPHiWatermark, fifo.CPLoWatermark,
-               fifo.CPReadWriteDistance, fifo.CPWritePointer, fifo.CPReadPointer, fifo.CPBreakpoint,
-               fifo.bFF_GPReadEnable ? "true" : "false", fifo.bFF_BPEnable ? "true" : "false",
-               fifo.bFF_BPInt ? "true" : "false", fifo.bFF_Breakpoint ? "true" : "false",
-               fifo.bFF_GPLinkEnable ? "true" : "false", fifo.bFF_HiWatermarkInt ? "true" : "false",
-               fifo.bFF_LoWatermarkInt ? "true" : "false");
+    PanicAlertFmt("Illegal command {:02x}\n"
+                  "CPBase: {:#010x}\n"
+                  "CPEnd: {:#010x}\n"
+                  "CPHiWatermark: {:#010x}\n"
+                  "CPLoWatermark: {:#010x}\n"
+                  "CPReadWriteDistance: {:#010x}\n"
+                  "CPWritePointer: {:#010x}\n"
+                  "CPReadPointer: {:#010x}\n"
+                  "CPBreakpoint: {:#010x}\n"
+                  "bFF_GPReadEnable: {}\n"
+                  "bFF_BPEnable: {}\n"
+                  "bFF_BPInt: {}\n"
+                  "bFF_Breakpoint: {}\n"
+                  "bFF_GPLinkEnable: {}\n"
+                  "bFF_HiWatermarkInt: {}\n"
+                  "bFF_LoWatermarkInt: {}\n",
+                  cmd_byte, fifo.CPBase, fifo.CPEnd, fifo.CPHiWatermark, fifo.CPLoWatermark,
+                  fifo.CPReadWriteDistance, fifo.CPWritePointer, fifo.CPReadPointer,
+                  fifo.CPBreakpoint, fifo.bFF_GPReadEnable ? "true" : "false",
+                  fifo.bFF_BPEnable ? "true" : "false", fifo.bFF_BPInt ? "true" : "false",
+                  fifo.bFF_Breakpoint ? "true" : "false", fifo.bFF_GPLinkEnable ? "true" : "false",
+                  fifo.bFF_HiWatermarkInt ? "true" : "false",
+                  fifo.bFF_LoWatermarkInt ? "true" : "false");
   }
 }
 

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -123,7 +123,7 @@ void Init()
 void Shutdown()
 {
   if (s_gpu_mainloop.IsRunning())
-    PanicAlert("Fifo shutting down while active");
+    PanicAlertFmt("FIFO shutting down while active");
 
   Common::FreeMemoryPages(s_video_buffer, FIFO_SIZE + 4);
   s_video_buffer = nullptr;
@@ -167,7 +167,10 @@ void SyncGPU(SyncGPUReason reason, bool may_move_read_ptr)
 
     // Opportunistically reset FIFOs so we don't wrap around.
     if (may_move_read_ptr && s_fifo_aux_write_ptr != s_fifo_aux_read_ptr)
-      PanicAlert("aux fifo not synced (%p, %p)", s_fifo_aux_write_ptr, s_fifo_aux_read_ptr);
+    {
+      PanicAlertFmt("Aux FIFO not synced ({}, {})", fmt::ptr(s_fifo_aux_write_ptr),
+                    fmt::ptr(s_fifo_aux_read_ptr));
+    }
 
     memmove(s_fifo_aux_data, s_fifo_aux_read_ptr, s_fifo_aux_write_ptr - s_fifo_aux_read_ptr);
     s_fifo_aux_write_ptr -= (s_fifo_aux_read_ptr - s_fifo_aux_data);
@@ -206,7 +209,7 @@ void PushFifoAuxBuffer(const void* ptr, size_t size)
     {
       // That will sync us up to the last 32 bytes, so this short region
       // of FIFO would have to point to a 2MB display list or something.
-      PanicAlert("absurdly large aux buffer");
+      PanicAlertFmt("Absurdly large aux buffer");
       return;
     }
   }
@@ -224,13 +227,13 @@ void* PopFifoAuxBuffer(size_t size)
 // Description: RunGpuLoop() sends data through this function.
 static void ReadDataFromFifo(u32 readPtr)
 {
-  size_t len = 32;
-  if (len > (size_t)(s_video_buffer + FIFO_SIZE - s_video_buffer_write_ptr))
+  constexpr size_t len = 32;
+  if (len > static_cast<size_t>(s_video_buffer + FIFO_SIZE - s_video_buffer_write_ptr))
   {
-    size_t existing_len = s_video_buffer_write_ptr - s_video_buffer_read_ptr;
-    if (len > (size_t)(FIFO_SIZE - existing_len))
+    const size_t existing_len = s_video_buffer_write_ptr - s_video_buffer_read_ptr;
+    if (len > static_cast<size_t>(FIFO_SIZE - existing_len))
     {
-      PanicAlert("FIFO out of bounds (existing %zu + new %zu > %u)", existing_len, len, FIFO_SIZE);
+      PanicAlertFmt("FIFO out of bounds (existing {} + new {} > {})", existing_len, len, FIFO_SIZE);
       return;
     }
     memmove(s_video_buffer, s_video_buffer_read_ptr, existing_len);
@@ -245,9 +248,9 @@ static void ReadDataFromFifo(u32 readPtr)
 // The deterministic_gpu_thread version.
 static void ReadDataFromFifoOnCPU(u32 readPtr)
 {
-  size_t len = 32;
+  constexpr size_t len = 32;
   u8* write_ptr = s_video_buffer_write_ptr;
-  if (len > (size_t)(s_video_buffer + FIFO_SIZE - write_ptr))
+  if (len > static_cast<size_t>(s_video_buffer + FIFO_SIZE - write_ptr))
   {
     // We can't wrap around while the GPU is working on the data.
     // This should be very rare due to the reset in SyncGPU.
@@ -260,14 +263,14 @@ static void ReadDataFromFifoOnCPU(u32 readPtr)
 
     if (s_video_buffer_pp_read_ptr != s_video_buffer_read_ptr)
     {
-      PanicAlert("desynced read pointers");
+      PanicAlertFmt("Desynced read pointers");
       return;
     }
     write_ptr = s_video_buffer_write_ptr;
-    size_t existing_len = write_ptr - s_video_buffer_pp_read_ptr;
-    if (len > (size_t)(FIFO_SIZE - existing_len))
+    const size_t existing_len = write_ptr - s_video_buffer_pp_read_ptr;
+    if (len > static_cast<size_t>(FIFO_SIZE - existing_len))
     {
-      PanicAlert("FIFO out of bounds (existing %zu + new %zu > %u)", existing_len, len, FIFO_SIZE);
+      PanicAlertFmt("FIFO out of bounds (existing {} + new {} > {})", existing_len, len, FIFO_SIZE);
       return;
     }
   }

--- a/Source/Core/VideoCommon/FramebufferManager.cpp
+++ b/Source/Core/VideoCommon/FramebufferManager.cpp
@@ -43,38 +43,38 @@ bool FramebufferManager::Initialize()
 {
   if (!CreateEFBFramebuffer())
   {
-    PanicAlert("Failed to create EFB framebuffer");
+    PanicAlertFmt("Failed to create EFB framebuffer");
     return false;
   }
 
   m_efb_cache_tile_size = static_cast<u32>(std::max(g_ActiveConfig.iEFBAccessTileSize, 0));
   if (!CreateReadbackFramebuffer())
   {
-    PanicAlert("Failed to create EFB readback framebuffer");
+    PanicAlertFmt("Failed to create EFB readback framebuffer");
     return false;
   }
 
   if (!CompileReadbackPipelines())
   {
-    PanicAlert("Failed to compile EFB readback pipelines");
+    PanicAlertFmt("Failed to compile EFB readback pipelines");
     return false;
   }
 
   if (!CompileConversionPipelines())
   {
-    PanicAlert("Failed to compile EFB conversion pipelines");
+    PanicAlertFmt("Failed to compile EFB conversion pipelines");
     return false;
   }
 
   if (!CompileClearPipelines())
   {
-    PanicAlert("Failed to compile EFB clear pipelines");
+    PanicAlertFmt("Failed to compile EFB clear pipelines");
     return false;
   }
 
   if (!CompilePokePipelines())
   {
-    PanicAlert("Failed to compile EFB poke pipelines");
+    PanicAlertFmt("Failed to compile EFB poke pipelines");
     return false;
   }
 
@@ -89,7 +89,7 @@ void FramebufferManager::RecreateEFBFramebuffer()
   DestroyReadbackFramebuffer();
   DestroyEFBFramebuffer();
   if (!CreateEFBFramebuffer() || !CreateReadbackFramebuffer())
-    PanicAlert("Failed to recreate EFB framebuffer");
+    PanicAlertFmt("Failed to recreate EFB framebuffer");
 }
 
 void FramebufferManager::RecompileShaders()
@@ -101,7 +101,7 @@ void FramebufferManager::RecompileShaders()
   if (!CompileReadbackPipelines() || !CompileConversionPipelines() || !CompileClearPipelines() ||
       !CompilePokePipelines())
   {
-    PanicAlert("Failed to recompile EFB pipelines");
+    PanicAlertFmt("Failed to recompile EFB pipelines");
   }
 }
 
@@ -415,7 +415,7 @@ void FramebufferManager::SetEFBCacheTileSize(u32 size)
   m_efb_cache_tile_size = size;
   DestroyReadbackFramebuffer();
   if (!CreateReadbackFramebuffer())
-    PanicAlert("Failed to create EFB readback framebuffers");
+    PanicAlertFmt("Failed to create EFB readback framebuffers");
 }
 
 void FramebufferManager::InvalidatePeekCache(bool forced)
@@ -939,7 +939,7 @@ void FramebufferManager::DoLoadState(PointerWrap& p)
   if (!color_tex || !depth_tex ||
       color_tex->texture->GetLayers() != m_efb_color_texture->GetLayers())
   {
-    WARN_LOG(VIDEO, "Failed to deserialize EFB contents. Clearing instead.");
+    WARN_LOG_FMT(VIDEO, "Failed to deserialize EFB contents. Clearing instead.");
     g_renderer->SetAndClearFramebuffer(
         m_efb_framebuffer.get(), {{0.0f, 0.0f, 0.0f, 0.0f}},
         g_ActiveConfig.backend_info.bSupportsReversedDepthRange ? 1.0f : 0.0f);

--- a/Source/Core/VideoCommon/FramebufferShaderGen.cpp
+++ b/Source/Core/VideoCommon/FramebufferShaderGen.cpp
@@ -626,7 +626,7 @@ std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureF
   break;
 
   default:
-    WARN_LOG(VIDEO, "From format %u is not supported", static_cast<u32>(from_format));
+    WARN_LOG_FMT(VIDEO, "From format {} is not supported", static_cast<u32>(from_format));
     return "{}\n";
   }
 
@@ -678,7 +678,7 @@ std::string GenerateTextureReinterpretShader(TextureFormat from_format, TextureF
   }
   break;
   default:
-    WARN_LOG(VIDEO, "To format %u is not supported", static_cast<u32>(to_format));
+    WARN_LOG_FMT(VIDEO, "To format {} is not supported", static_cast<u32>(to_format));
     return "{}\n";
   }
 

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -119,8 +119,8 @@ void HiresTexture::Update()
 
     if (failed_insert)
     {
-      ERROR_LOG(VIDEO, "One or more textures at path '%s' were already inserted",
-                texture_directory.c_str());
+      ERROR_LOG_FMT(VIDEO, "One or more textures at path '{}' were already inserted",
+                    texture_directory);
     }
   }
 
@@ -371,7 +371,7 @@ std::unique_ptr<HiresTexture> HiresTexture::Load(const std::string& base_filenam
 
       if (!LoadTexture(level, buffer))
       {
-        ERROR_LOG(VIDEO, "Custom texture %s failed to load", filename.c_str());
+        ERROR_LOG_FMT(VIDEO, "Custom texture {} failed to load", filename);
         break;
       }
     }
@@ -387,19 +387,19 @@ std::unique_ptr<HiresTexture> HiresTexture::Load(const std::string& base_filenam
   const Level& first_mip = ret->m_levels[0];
   if (first_mip.width * height != first_mip.height * width)
   {
-    ERROR_LOG(VIDEO,
-              "Invalid custom texture size %ux%u for texture %s. The aspect differs "
-              "from the native size %ux%u.",
-              first_mip.width, first_mip.height, first_mip_file.path.c_str(), width, height);
+    ERROR_LOG_FMT(VIDEO,
+                  "Invalid custom texture size {}x{} for texture {}. The aspect differs "
+                  "from the native size {}x{}.",
+                  first_mip.width, first_mip.height, first_mip_file.path, width, height);
   }
 
   // Same deal if the custom texture isn't a multiple of the native size.
   if (width != 0 && height != 0 && (first_mip.width % width || first_mip.height % height))
   {
-    ERROR_LOG(VIDEO,
-              "Invalid custom texture size %ux%u for texture %s. Please use an integer "
-              "upscaling factor based on the native size %ux%u.",
-              first_mip.width, first_mip.height, first_mip_file.path.c_str(), width, height);
+    ERROR_LOG_FMT(VIDEO,
+                  "Invalid custom texture size {}x{} for texture {}. Please use an integer "
+                  "upscaling factor based on the native size {}x{}.",
+                  first_mip.width, first_mip.height, first_mip_file.path, width, height);
   }
 
   // Verify that each mip level is the correct size (divide by 2 each time).
@@ -416,16 +416,16 @@ std::unique_ptr<HiresTexture> HiresTexture::Load(const std::string& base_filenam
       if (current_mip_width == level.width && current_mip_height == level.height)
         continue;
 
-      ERROR_LOG(VIDEO,
-                "Invalid custom texture size %dx%d for texture %s. Mipmap level %u must be %dx%d.",
-                level.width, level.height, first_mip_file.path.c_str(), mip_level,
-                current_mip_width, current_mip_height);
+      ERROR_LOG_FMT(
+          VIDEO, "Invalid custom texture size {}x{} for texture {}. Mipmap level {} must be {}x{}.",
+          level.width, level.height, first_mip_file.path, mip_level, current_mip_width,
+          current_mip_height);
     }
     else
     {
       // It is invalid to have more than a single 1x1 mipmap.
-      ERROR_LOG(VIDEO, "Custom texture %s has too many 1x1 mipmaps. Skipping extra levels.",
-                first_mip_file.path.c_str());
+      ERROR_LOG_FMT(VIDEO, "Custom texture {} has too many 1x1 mipmaps. Skipping extra levels.",
+                    first_mip_file.path);
     }
 
     // Drop this mip level and any others after it.
@@ -437,8 +437,8 @@ std::unique_ptr<HiresTexture> HiresTexture::Load(const std::string& base_filenam
   if (std::any_of(ret->m_levels.begin(), ret->m_levels.end(),
                   [&ret](const Level& l) { return l.format != ret->m_levels[0].format; }))
   {
-    ERROR_LOG(VIDEO, "Custom texture %s has inconsistent formats across mip levels.",
-              first_mip_file.path.c_str());
+    ERROR_LOG_FMT(VIDEO, "Custom texture {} has inconsistent formats across mip levels.",
+                  first_mip_file.path);
 
     return nullptr;
   }

--- a/Source/Core/VideoCommon/HiresTextures_DDSLoader.cpp
+++ b/Source/Core/VideoCommon/HiresTextures_DDSLoader.cpp
@@ -410,10 +410,10 @@ bool ReadMipLevel(HiresTexture::Level* level, File::IOFile& file, const std::str
   if (mip_level == 0 && info.block_size > 1 &&
       ((width % info.block_size) != 0 || (height % info.block_size) != 0))
   {
-    ERROR_LOG(VIDEO,
-              "Invalid dimensions for DDS texture %s. For compressed textures of this format, "
-              "the width/height of the first mip level must be a multiple of %u.",
-              filename.c_str(), info.block_size);
+    ERROR_LOG_FMT(VIDEO,
+                  "Invalid dimensions for DDS texture {}. For compressed textures of this format, "
+                  "the width/height of the first mip level must be a multiple of {}.",
+                  filename, info.block_size);
     return false;
   }
 

--- a/Source/Core/VideoCommon/ImageWrite.cpp
+++ b/Source/Core/VideoCommon/ImageWrite.cpp
@@ -51,8 +51,7 @@ bool TextureToPng(const u8* data, int row_stride, const std::string& filename, i
   File::IOFile fp(filename, "wb");
   if (!fp.IsOpen())
   {
-    PanicAlertT("Screenshot failed: Could not open file \"%s\" (error %d)", filename.c_str(),
-                errno);
+    PanicAlertFmtT("Screenshot failed: Could not open file \"{}\" (error {})", filename, errno);
     goto finalise;
   }
 
@@ -60,7 +59,7 @@ bool TextureToPng(const u8* data, int row_stride, const std::string& filename, i
   png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
   if (png_ptr == nullptr)
   {
-    PanicAlert("Screenshot failed: Could not allocate write struct");
+    PanicAlertFmt("Screenshot failed: Could not allocate write struct");
     goto finalise;
   }
 
@@ -68,7 +67,7 @@ bool TextureToPng(const u8* data, int row_stride, const std::string& filename, i
   info_ptr = png_create_info_struct(png_ptr);
   if (info_ptr == nullptr)
   {
-    PanicAlert("Screenshot failed: Could not allocate info struct");
+    PanicAlertFmt("Screenshot failed: Could not allocate info struct");
     goto finalise;
   }
 
@@ -82,7 +81,7 @@ bool TextureToPng(const u8* data, int row_stride, const std::string& filename, i
   // would need to be volatile).
   if (setjmp(png_jmpbuf(png_ptr)))
   {
-    PanicAlert("Screenshot failed: Error during PNG creation");
+    PanicAlertFmt("Screenshot failed: Error during PNG creation");
     goto finalise;
   }
 

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -165,7 +165,7 @@ u16* AddQuads(u16* index_ptr, u32 num_verts, u32 index)
 template <bool pr>
 u16* AddQuads_nonstandard(u16* index_ptr, u32 num_verts, u32 index)
 {
-  WARN_LOG(VIDEO, "Non-standard primitive drawing command GL_DRAW_QUADS_2");
+  WARN_LOG_FMT(VIDEO, "Non-standard primitive drawing command GL_DRAW_QUADS_2");
   return AddQuads<pr>(index_ptr, num_verts, index);
 }
 

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -111,7 +111,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
 
     case GX_UNKNOWN_RESET:
       total_cycles += 6;  // Datel software uses this command
-      DEBUG_LOG(VIDEO, "GX Reset?: %08x", cmd_byte);
+      DEBUG_LOG_FMT(VIDEO, "GX Reset?: {:08x}", cmd_byte);
       break;
 
     case GX_LOAD_CP_REG:
@@ -187,7 +187,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       if (in_display_list)
       {
         total_cycles += 6;
-        INFO_LOG(VIDEO, "recursive display list detected");
+        INFO_LOG_FMT(VIDEO, "recursive display list detected");
       }
       else
       {
@@ -202,12 +202,12 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
     case GX_CMD_UNKNOWN_METRICS:  // zelda 4 swords calls it and checks the metrics registers after
                                   // that
       total_cycles += 6;
-      DEBUG_LOG(VIDEO, "GX 0x44: %08x", cmd_byte);
+      DEBUG_LOG_FMT(VIDEO, "GX 0x44: {:08x}", cmd_byte);
       break;
 
     case GX_CMD_INVL_VC:  // Invalidate Vertex Cache
       total_cycles += 6;
-      DEBUG_LOG(VIDEO, "Invalidate (vertex cache?)");
+      DEBUG_LOG_FMT(VIDEO, "Invalidate (vertex cache?)");
       break;
 
     case GX_LOAD_BP_REG:
@@ -257,8 +257,8 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       {
         if (!s_is_fifo_error_seen)
           CommandProcessor::HandleUnknownOpcode(cmd_byte, opcode_start, is_preprocess);
-        ERROR_LOG(VIDEO, "FIFO: Unknown Opcode(0x%02x @ %p, preprocessing = %s)", cmd_byte,
-                  opcode_start, is_preprocess ? "yes" : "no");
+        ERROR_LOG_FMT(VIDEO, "FIFO: Unknown Opcode({:#04x} @ {}, preprocessing = {})", cmd_byte,
+                      fmt::ptr(opcode_start), is_preprocess ? "yes" : "no");
         s_is_fifo_error_seen = true;
         total_cycles += 1;
       }

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -221,7 +221,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                    m_Control.PEToken = 0;   // this flag is write only
                    m_Control.PEFinish = 0;  // this flag is write only
 
-                   DEBUG_LOG(PIXELENGINE, "(w16) CTRL_REGISTER: 0x%04x", val);
+                   DEBUG_LOG_FMT(PIXELENGINE, "(w16) CTRL_REGISTER: {:#06x}", val);
                    UpdateInterrupts();
                  }));
 
@@ -294,7 +294,7 @@ static void RaiseEvent()
 // THIS IS EXECUTED FROM VIDEO THREAD
 void SetToken(const u16 token, const bool interrupt)
 {
-  DEBUG_LOG(PIXELENGINE, "VIDEO Backend raises INT_CAUSE_PE_TOKEN (btw, token: %04x)", token);
+  DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Backend raises INT_CAUSE_PE_TOKEN (btw, token: {:04x})", token);
 
   std::lock_guard<std::mutex> lk(s_token_finish_mutex);
 
@@ -308,7 +308,7 @@ void SetToken(const u16 token, const bool interrupt)
 // THIS IS EXECUTED FROM VIDEO THREAD (BPStructs.cpp) when a new frame has been drawn
 void SetFinish()
 {
-  DEBUG_LOG(PIXELENGINE, "VIDEO Set Finish");
+  DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Set Finish");
 
   std::lock_guard<std::mutex> lk(s_token_finish_mutex);
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1521,7 +1521,7 @@ static void WriteFog(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   else
   {
     if (uid_data->fog_fsel != 2)
-      WARN_LOG(VIDEO, "Unknown Fog Type! %08x", uid_data->fog_fsel);
+      WARN_LOG_FMT(VIDEO, "Unknown Fog Type! {:08x}", uid_data->fog_fsel);
   }
 
   out.Write("\tint ifog = iround(fog * 256.0);\n");

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -200,7 +200,7 @@ void PixelShaderManager::SetTevColor(int index, int component, s32 value)
   c[component] = value;
   dirty = true;
 
-  PRIM_LOG("tev color%d: %d %d %d %d", index, c[0], c[1], c[2], c[3]);
+  PRIM_LOG("tev color{}: {} {} {} {}", index, c[0], c[1], c[2], c[3]);
 }
 
 void PixelShaderManager::SetTevKonstColor(int index, int component, s32 value)
@@ -220,7 +220,7 @@ void PixelShaderManager::SetTevKonstColor(int index, int component, s32 value)
   constants.konst[index + 16 + component * 4][2] = value;
   constants.konst[index + 16 + component * 4][3] = value;
 
-  PRIM_LOG("tev konst color%d: %d %d %d %d", index, c[0], c[1], c[2], c[3]);
+  PRIM_LOG("tev konst color{}: {} {} {} {}", index, c[0], c[1], c[2], c[3]);
 }
 
 void PixelShaderManager::SetTevOrder(int index, u32 order)
@@ -352,7 +352,7 @@ void PixelShaderManager::SetIndMatrixChanged(int matrixidx)
   constants.indtexmtx[2 * matrixidx + 1][3] = 17 - scale;
   dirty = true;
 
-  PRIM_LOG("indmtx%d: scale=%d, mat=(%d %d %d; %d %d %d)", matrixidx, scale,
+  PRIM_LOG("indmtx{}: scale={}, mat=({} {} {}; {} {} {})", matrixidx, scale,
            bpmem.indmtx[matrixidx].col0.ma, bpmem.indmtx[matrixidx].col1.mc,
            bpmem.indmtx[matrixidx].col2.me, bpmem.indmtx[matrixidx].col0.mb,
            bpmem.indmtx[matrixidx].col1.md, bpmem.indmtx[matrixidx].col2.mf);

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -72,7 +72,7 @@ void PostProcessingConfiguration::LoadShader(const std::string& shader)
 
   if (!File::ReadFileToString(path, code))
   {
-    ERROR_LOG(VIDEO, "Post-processing shader not found: %s", path.c_str());
+    ERROR_LOG_FMT(VIDEO, "Post-processing shader not found: {}", path);
     LoadDefaultShader();
     return;
   }
@@ -640,7 +640,7 @@ bool PostProcessing::CompileVertexShader()
   m_vertex_shader = g_renderer->CreateShaderFromSource(ShaderStage::Vertex, ss.str());
   if (!m_vertex_shader)
   {
-    PanicAlert("Failed to compile post-processing vertex shader");
+    PanicAlertFmt("Failed to compile post-processing vertex shader");
     return false;
   }
 
@@ -729,7 +729,7 @@ bool PostProcessing::CompilePixelShader()
       ShaderStage::Pixel, GetHeader() + m_config.GetShaderCode() + GetFooter());
   if (!m_pixel_shader)
   {
-    PanicAlert("Failed to compile post-processing shader %s", m_config.GetShader().c_str());
+    PanicAlertFmt("Failed to compile post-processing shader {}", m_config.GetShader());
 
     // Use default shader.
     m_config.LoadDefaultShader();

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -900,7 +900,7 @@ bool Renderer::InitializeImGui()
 {
   if (!ImGui::CreateContext())
   {
-    PanicAlert("Creating ImGui context failed");
+    PanicAlertFmt("Creating ImGui context failed");
     return false;
   }
 
@@ -919,7 +919,7 @@ bool Renderer::InitializeImGui()
   m_imgui_vertex_format = CreateNativeVertexFormat(vdecl);
   if (!m_imgui_vertex_format)
   {
-    PanicAlert("Failed to create imgui vertex format");
+    PanicAlertFmt("Failed to create imgui vertex format");
     return false;
   }
 
@@ -935,7 +935,7 @@ bool Renderer::InitializeImGui()
     std::unique_ptr<AbstractTexture> font_tex = CreateTexture(font_tex_config);
     if (!font_tex)
     {
-      PanicAlert("Failed to create imgui texture");
+      PanicAlertFmt("Failed to create imgui texture");
       return false;
     }
     font_tex->Load(0, font_tex_width, font_tex_height, font_tex_width, font_tex_pixels,
@@ -962,7 +962,7 @@ bool Renderer::RecompileImGuiPipeline()
       CreateShaderFromSource(ShaderStage::Pixel, FramebufferShaderGen::GenerateImGuiPixelShader());
   if (!vertex_shader || !pixel_shader)
   {
-    PanicAlert("Failed to compile imgui shaders");
+    PanicAlertFmt("Failed to compile imgui shaders");
     return false;
   }
 
@@ -974,7 +974,7 @@ bool Renderer::RecompileImGuiPipeline()
         ShaderStage::Geometry, FramebufferShaderGen::GeneratePassthroughGeometryShader(1, 1));
     if (!geometry_shader)
     {
-      PanicAlert("Failed to compile imgui geometry shader");
+      PanicAlertFmt("Failed to compile imgui geometry shader");
       return false;
     }
   }
@@ -1000,7 +1000,7 @@ bool Renderer::RecompileImGuiPipeline()
   m_imgui_pipeline = CreatePipeline(pconfig);
   if (!m_imgui_pipeline)
   {
-    PanicAlert("Failed to create imgui pipeline");
+    PanicAlertFmt("Failed to create imgui pipeline");
     return false;
   }
 
@@ -1436,7 +1436,7 @@ bool Renderer::CheckFrameDumpRenderTexture(u32 target_width, u32 target_height)
                                   AbstractTextureFormat::RGBA8, AbstractTextureFlag_RenderTarget));
   if (!m_frame_dump_render_texture)
   {
-    PanicAlert("Failed to allocate frame dump render texture");
+    PanicAlertFmt("Failed to allocate frame dump render texture");
     return false;
   }
   m_frame_dump_render_framebuffer = CreateFramebuffer(m_frame_dump_render_texture.get(), nullptr);
@@ -1480,7 +1480,7 @@ void Renderer::FlushFrameDump()
   }
   else
   {
-    ERROR_LOG(VIDEO, "Failed to map texture for dumping.");
+    ERROR_LOG_FMT(VIDEO, "Failed to map texture for dumping.");
   }
 
   m_frame_dump_needs_flush = false;
@@ -1552,8 +1552,8 @@ void Renderer::FrameDumpThreadFunc()
 #if !defined(HAVE_FFMPEG)
   if (dump_to_ffmpeg)
   {
-    WARN_LOG(VIDEO, "FrameDump: Dolphin was not compiled with FFmpeg, using fallback option. "
-                    "Frames will be saved as PNG images instead.");
+    WARN_LOG_FMT(VIDEO, "FrameDump: Dolphin was not compiled with FFmpeg, using fallback option. "
+                        "Frames will be saved as PNG images instead.");
     dump_to_ffmpeg = false;
   }
 #endif
@@ -1666,7 +1666,7 @@ bool Renderer::StartFrameDumpToImage(const FrameDump::FrameData&)
     std::string filename = GetFrameDumpNextImageFileName();
     if (File::Exists(filename))
     {
-      if (!AskYesNoT("Frame dump image(s) '%s' already exists. Overwrite?", filename.c_str()))
+      if (!AskYesNoFmtT("Frame dump image(s) '{}' already exists. Overwrite?", filename))
         return false;
     }
   }

--- a/Source/Core/VideoCommon/ShaderCache.cpp
+++ b/Source/Core/VideoCommon/ShaderCache.cpp
@@ -76,7 +76,7 @@ void ShaderCache::Reload()
   ClearCaches();
 
   if (!CompileSharedPipelines())
-    PanicAlert("Failed to compile shared pipelines after reload.");
+    PanicAlertFmt("Failed to compile shared pipelines after reload.");
 
   if (g_ActiveConfig.bShaderCache)
     LoadCaches();
@@ -249,7 +249,7 @@ void ShaderCache::LoadShaderCache(T& cache, APIType api_type, const char* type, 
   std::string filename = GetDiskShaderCacheFileName(api_type, type, include_gameid, true);
   CacheReader reader(cache);
   u32 count = cache.disk_cache.OpenAndRead(filename, reader);
-  INFO_LOG(VIDEO, "Loaded %u cached shaders from %s", count, filename.c_str());
+  INFO_LOG_FMT(VIDEO, "Loaded {} cached shaders from {}", count, filename);
 }
 
 template <typename T>
@@ -303,8 +303,8 @@ void ShaderCache::LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& 
 
   std::string filename = GetDiskShaderCacheFileName(api_type, type, include_gameid, true);
   CacheReader reader(this, cache);
-  u32 count = disk_cache.OpenAndRead(filename, reader);
-  INFO_LOG(VIDEO, "Loaded %u cached pipelines from %s", count, filename.c_str());
+  const u32 count = disk_cache.OpenAndRead(filename, reader);
+  INFO_LOG_FMT(VIDEO, "Loaded {} cached pipelines from {}", count, filename);
 
   // If any of the pipelines in the cache failed to create, it's likely because of a change of
   // driver version, or system configuration. In this case, when the UID cache picks up the pipeline
@@ -312,8 +312,8 @@ void ShaderCache::LoadPipelineCache(T& cache, LinearDiskCache<DiskKeyType, u8>& 
   // the old cache data around, so discard and recreate the disk cache.
   if (reader.AnyFailed())
   {
-    WARN_LOG(VIDEO, "Failed to load one or more pipelines from cache '%s'. Discarding.",
-             filename.c_str());
+    WARN_LOG_FMT(VIDEO, "Failed to load one or more pipelines from cache '{}'. Discarding.",
+                 filename);
     disk_cache.Close();
     File::Delete(filename);
     disk_cache.OpenAndRead(filename, reader);
@@ -586,7 +586,8 @@ AbstractPipelineConfig ShaderCache::GetGXPipelineConfig(
 
   if (config.blending_state.logicopenable && !g_ActiveConfig.backend_info.bSupportsLogicOp)
   {
-    WARN_LOG(VIDEO, "Approximating logic op with blending, this will produce incorrect rendering.");
+    WARN_LOG_FMT(VIDEO,
+                 "Approximating logic op with blending, this will produce incorrect rendering.");
     config.blending_state.ApproximateLogicOpWithBlending();
   }
 
@@ -791,8 +792,7 @@ void ShaderCache::LoadPipelineUIDCache()
     }
   }
 
-  INFO_LOG(VIDEO, "Read %u pipeline UIDs from %s",
-           static_cast<unsigned>(m_gx_pipeline_cache.size()), filename.c_str());
+  INFO_LOG_FMT(VIDEO, "Read {} pipeline UIDs from {}", m_gx_pipeline_cache.size(), filename);
 }
 
 void ShaderCache::ClosePipelineUIDCache()
@@ -824,7 +824,7 @@ void ShaderCache::AppendGXPipelineUID(const GXPipelineUid& config)
   SerializePipelineUid(config, disk_uid);
   if (!m_gx_pipeline_uid_cache_file.WriteBytes(&disk_uid, sizeof(disk_uid)))
   {
-    WARN_LOG(VIDEO, "Writing pipeline UID to cache failed, closing file.");
+    WARN_LOG_FMT(VIDEO, "Writing pipeline UID to cache failed, closing file.");
     m_gx_pipeline_uid_cache_file.Close();
   }
 }

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -49,7 +49,8 @@ u16 GetEncodedSampleCount(EFBCopyFormat format)
   case EFBCopyFormat::XFB:
     return 2;
   default:
-    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEncodedSampleCount)", static_cast<int>(format));
+    PanicAlertFmt("Invalid EFB Copy Format ({:#X})! (GetEncodedSampleCount)",
+                  static_cast<int>(format));
     return 1;
   }
 }
@@ -839,8 +840,8 @@ std::string GenerateEncodingShader(const EFBCopyParams& params, APIType api_type
     WriteXFBEncoder(code, api_type, params);
     break;
   default:
-    PanicAlert("Invalid EFB Copy Format (0x%X)! (GenerateEncodingShader)",
-               static_cast<int>(params.copy_format));
+    PanicAlertFmt("Invalid EFB Copy Format ({:#X})! (GenerateEncodingShader)",
+                  static_cast<int>(params.copy_format));
     break;
   }
 
@@ -1487,7 +1488,7 @@ float4 DecodePixel(int val)
     break;
 
   default:
-    PanicAlert("Unknown format");
+    PanicAlertFmt("Unknown format");
     break;
   }
 

--- a/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
+++ b/Source/Core/VideoCommon/TextureConverterShaderGen.cpp
@@ -209,7 +209,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
       break;
 
     default:
-      ERROR_LOG(VIDEO, "Unknown copy zbuf format: 0x%X", static_cast<int>(uid_data->dst_format));
+      ERROR_LOG_FMT(VIDEO, "Unknown copy zbuf format: {:#X}",
+                    static_cast<int>(uid_data->dst_format));
       out.Write("  ocol0 = float4(texcol.bgr, 0.0);\n");
       break;
     }
@@ -239,8 +240,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
       break;
 
     default:
-      ERROR_LOG(VIDEO, "Unknown copy intensity format: 0x%X",
-                static_cast<int>(uid_data->dst_format));
+      ERROR_LOG_FMT(VIDEO, "Unknown copy intensity format: {:#X}",
+                    static_cast<int>(uid_data->dst_format));
       out.Write("  ocol0 = texcol;\n");
       break;
     }
@@ -315,7 +316,8 @@ ShaderCode GeneratePixelShader(APIType api_type, const UidData* uid_data)
       break;
 
     default:
-      ERROR_LOG(VIDEO, "Unknown copy color format: 0x%X", static_cast<int>(uid_data->dst_format));
+      ERROR_LOG_FMT(VIDEO, "Unknown copy color format: {:#X}",
+                    static_cast<int>(uid_data->dst_format));
       out.Write("  ocol0 = texcol;\n");
       break;
     }

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -51,7 +51,8 @@ int TexDecoder_GetTexelSizeInNibbles(TextureFormat format)
   case TextureFormat::XFB:
     return 4;
   default:
-    PanicAlert("Invalid Texture Format (0x%X)! (GetTexelSizeInNibbles)", static_cast<int>(format));
+    PanicAlertFmt("Invalid Texture Format ({:#X})! (GetTexelSizeInNibbles)",
+                  static_cast<int>(format));
     return 1;
   }
 }
@@ -90,7 +91,8 @@ int TexDecoder_GetBlockWidthInTexels(TextureFormat format)
   case TextureFormat::XFB:
     return 16;
   default:
-    PanicAlert("Invalid Texture Format (0x%X)! (GetBlockWidthInTexels)", static_cast<int>(format));
+    PanicAlertFmt("Invalid Texture Format ({:#X})! (GetBlockWidthInTexels)",
+                  static_cast<int>(format));
     return 8;
   }
 }
@@ -124,7 +126,8 @@ int TexDecoder_GetBlockHeightInTexels(TextureFormat format)
   case TextureFormat::XFB:
     return 1;
   default:
-    PanicAlert("Invalid Texture Format (0x%X)! (GetBlockHeightInTexels)", static_cast<int>(format));
+    PanicAlertFmt("Invalid Texture Format ({:#X})! (GetBlockHeightInTexels)",
+                  static_cast<int>(format));
     return 4;
   }
 }
@@ -158,8 +161,8 @@ int TexDecoder_GetEFBCopyBlockWidthInTexels(EFBCopyFormat format)
   case EFBCopyFormat::XFB:
     return 16;
   default:
-    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEFBCopyBlockWidthInTexels)",
-               static_cast<int>(format));
+    PanicAlertFmt("Invalid EFB Copy Format ({:#X})! (GetEFBCopyBlockWidthInTexels)",
+                  static_cast<int>(format));
     return 8;
   }
 }
@@ -193,8 +196,8 @@ int TexDecoder_GetEFBCopyBlockHeightInTexels(EFBCopyFormat format)
   case EFBCopyFormat::XFB:
     return 1;
   default:
-    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEFBCopyBlockHeightInTexels)",
-               static_cast<int>(format));
+    PanicAlertFmt("Invalid EFB Copy Format ({:#X})! (GetEFBCopyBlockHeightInTexels)",
+                  static_cast<int>(format));
     return 4;
   }
 }
@@ -245,7 +248,8 @@ TextureFormat TexDecoder_GetEFBCopyBaseFormat(EFBCopyFormat format)
   case EFBCopyFormat::XFB:
     return TextureFormat::XFB;
   default:
-    PanicAlert("Invalid EFB Copy Format (0x%X)! (GetEFBCopyBaseFormat)", static_cast<int>(format));
+    PanicAlertFmt("Invalid EFB Copy Format ({:#X})! (GetEFBCopyBaseFormat)",
+                  static_cast<int>(format));
     return static_cast<TextureFormat>(format);
   }
 }

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -1491,8 +1491,8 @@ void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, Text
     break;
 
   default:
-    PanicAlert("Invalid Texture Format (0x%X)! (_TexDecoder_DecodeImpl)",
-               static_cast<int>(texformat));
+    PanicAlertFmt("Invalid Texture Format ({:#X})! (_TexDecoder_DecodeImpl)",
+                  static_cast<int>(texformat));
     break;
   }
 }

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -25,14 +25,14 @@ static void PosMtx_ReadDirect_UByte(VertexLoader* loader)
   if (loader->m_counter < 3)
     VertexLoaderManager::position_matrix_index[loader->m_counter + 1] = posmtx;
   DataWrite<u32>(posmtx);
-  PRIM_LOG("posmtx: %d, ", posmtx);
+  PRIM_LOG("posmtx: {}, ", posmtx);
 }
 
 static void TexMtx_ReadDirect_UByte(VertexLoader* loader)
 {
   loader->m_curtexmtx[loader->m_texmtxread] = DataRead<u8>() & 0x3f;
 
-  PRIM_LOG("texmtx%d: %d, ", loader->m_texmtxread, loader->m_curtexmtx[loader->m_texmtxread]);
+  PRIM_LOG("texmtx{}: {}, ", loader->m_texmtxread, loader->m_curtexmtx[loader->m_texmtxread]);
   loader->m_texmtxread++;
 }
 
@@ -184,9 +184,9 @@ void VertexLoader::CompileVertexTranslator()
 
     if (pFunc == nullptr)
     {
-      PanicAlert("VertexLoader_Normal::GetFunction(%i %i %i %i) returned zero!",
-                 (u32)m_VtxDesc.Normal, m_VtxAttr.NormalFormat, m_VtxAttr.NormalElements,
-                 m_VtxAttr.NormalIndex3);
+      PanicAlertFmt("VertexLoader_Normal::GetFunction({} {} {} {}) returned zero!",
+                    m_VtxDesc.Normal, m_VtxAttr.NormalFormat, m_VtxAttr.NormalElements,
+                    m_VtxAttr.NormalIndex3);
     }
     WriteCall(pFunc);
 

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -168,11 +168,11 @@ public:
       }
       else
       {
-        ERROR_LOG(VIDEO, "Can't compare vertex loaders that expect different vertex formats!");
-        ERROR_LOG(VIDEO, "a: m_VertexSize %d, m_native_components 0x%08x, stride %d",
-                  a->m_VertexSize, a->m_native_components, a->m_native_vtx_decl.stride);
-        ERROR_LOG(VIDEO, "b: m_VertexSize %d, m_native_components 0x%08x, stride %d",
-                  b->m_VertexSize, b->m_native_components, b->m_native_vtx_decl.stride);
+        ERROR_LOG_FMT(VIDEO, "Can't compare vertex loaders that expect different vertex formats!");
+        ERROR_LOG_FMT(VIDEO, "a: m_VertexSize {}, m_native_components {:#010x}, stride {}",
+                      a->m_VertexSize, a->m_native_components, a->m_native_vtx_decl.stride);
+        ERROR_LOG_FMT(VIDEO, "b: m_VertexSize {}, m_native_components {:#010x}, stride {}",
+                      b->m_VertexSize, b->m_native_components, b->m_native_vtx_decl.stride);
       }
     }
   }
@@ -188,16 +188,21 @@ public:
         b->RunVertices(src, DataReader(buffer_b.data(), buffer_b.data() + buffer_b.size()), count);
 
     if (count_a != count_b)
-      ERROR_LOG(VIDEO,
-                "The two vertex loaders have loaded a different amount of vertices (a: %d, b: %d).",
-                count_a, count_b);
+    {
+      ERROR_LOG_FMT(
+          VIDEO,
+          "The two vertex loaders have loaded a different amount of vertices (a: {}, b: {}).",
+          count_a, count_b);
+    }
 
     if (memcmp(buffer_a.data(), buffer_b.data(),
                std::min(count_a, count_b) * m_native_vtx_decl.stride))
-      ERROR_LOG(VIDEO,
-                "The two vertex loaders have loaded different data "
-                "(guru meditation 0x%016" PRIx64 ", 0x%08x, 0x%08x, 0x%08x).",
-                m_VtxDesc.Hex, m_vat.g0.Hex, m_vat.g1.Hex, m_vat.g2.Hex);
+    {
+      ERROR_LOG_FMT(VIDEO,
+                    "The two vertex loaders have loaded different data "
+                    "(guru meditation {:#018x}, {:#010x}, {:#010x}, {:#010x}).",
+                    m_VtxDesc.Hex, m_vat.g0.Hex, m_vat.g1.Hex, m_vat.g2.Hex);
+    }
 
     memcpy(dst.GetPointer(), buffer_a.data(), count_a * m_native_vtx_decl.stride);
     m_numLoadedVertices += count;
@@ -246,6 +251,6 @@ std::unique_ptr<VertexLoaderBase> VertexLoaderBase::CreateVertexLoader(const TVt
   if (loader->IsInitialized())
     return loader;
 
-  PanicAlert("No Vertex Loader found.");
+  PanicAlertFmt("No Vertex Loader found.");
   return nullptr;
 }

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -15,7 +15,7 @@
 #include "VideoCommon/VertexLoaderUtils.h"
 
 // warning: mapping buffer should be disabled to use this
-#define LOG_NORM()  // PRIM_LOG("norm: %f %f %f, ", ((float*)g_vertex_manager_write_ptr)[-3],
+#define LOG_NORM()  // PRIM_LOG("norm: {} {} {}, ", ((float*)g_vertex_manager_write_ptr)[-3],
                     // ((float*)g_vertex_manager_write_ptr)[-2],
                     // ((float*)g_vertex_manager_write_ptr)[-1]);
 

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -412,10 +412,10 @@ void VertexShaderManager::SetConstants()
     break;
 
     default:
-      ERROR_LOG(VIDEO, "Unknown projection type: %d", xfmem.projection.type);
+      ERROR_LOG_FMT(VIDEO, "Unknown projection type: {}", xfmem.projection.type);
     }
 
-    PRIM_LOG("Projection: %f %f %f %f %f %f", rawProjection[0], rawProjection[1], rawProjection[2],
+    PRIM_LOG("Projection: {} {} {} {} {} {}", rawProjection[0], rawProjection[1], rawProjection[2],
              rawProjection[3], rawProjection[4], rawProjection[5]);
 
     auto corrected_matrix = s_viewportCorrection * Common::Matrix44::FromArray(g_fProjectionMatrix);

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/format.h"
+#include <fmt/format.h>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -163,8 +163,9 @@ u16 VideoBackendBase::Video_GetBoundingBox(int index)
     static bool warn_once = true;
     if (warn_once)
     {
-      ERROR_LOG(VIDEO, "BBox shall be used but it is disabled. Please use a gameini to enable it "
-                       "for this game.");
+      ERROR_LOG_FMT(VIDEO,
+                    "BBox shall be used but it is disabled. Please use a gameini to enable it "
+                    "for this game.");
     }
     warn_once = false;
     return 0;
@@ -175,9 +176,10 @@ u16 VideoBackendBase::Video_GetBoundingBox(int index)
     static bool warn_once = true;
     if (warn_once)
     {
-      PanicAlertT("This game requires bounding box emulation to run properly but your graphics "
-                  "card or its drivers do not support it. As a result you will experience bugs or "
-                  "freezes while running this game.");
+      PanicAlertFmtT(
+          "This game requires bounding box emulation to run properly but your graphics "
+          "card or its drivers do not support it. As a result you will experience bugs or "
+          "freezes while running this game.");
     }
     warn_once = false;
     return 0;

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -20,11 +20,13 @@ constexpr u32 MAX_XFB_WIDTH = 720;
 // that are next to each other in memory (TODO: handle that situation).
 constexpr u32 MAX_XFB_HEIGHT = 576;
 
-#define PRIM_LOG(...) DEBUG_LOG(VIDEO, ##__VA_ARGS__)
+#define PRIM_LOG(...) DEBUG_LOG_FMT(VIDEO, ##__VA_ARGS__)
 
 // warning: mapping buffer should be disabled to use this
-// #define LOG_VTX() DEBUG_LOG(VIDEO, "vtx: %f %f %f, ", ((float*)g_vertex_manager_write_ptr)[-3],
-// ((float*)g_vertex_manager_write_ptr)[-2], ((float*)g_vertex_manager_write_ptr)[-1]);
+// #define LOG_VTX() DEBUG_LOG_FMT(VIDEO, "vtx: {} {} {}, ",
+//                                 ((float*)g_vertex_manager_write_ptr)[-3],
+//                                 ((float*)g_vertex_manager_write_ptr)[-2],
+//                                 ((float*)g_vertex_manager_write_ptr)[-1]);
 
 #define LOG_VTX()
 

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -179,7 +179,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
     case 0x104d:
     case 0x104e:
     case 0x104f:
-      DEBUG_LOG(VIDEO, "Possible Normal Mtx XF reg?: %x=%x", address, newValue);
+      DEBUG_LOG_FMT(VIDEO, "Possible Normal Mtx XF reg?: {:x}={:x}", address, newValue);
       break;
 
     case 0x1013:
@@ -190,7 +190,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
 
     default:
       if (newValue != 0)  // Ignore writes of zero.
-        WARN_LOG(VIDEO, "Unknown XF Reg: %x=%x", address, newValue);
+        WARN_LOG_FMT(VIDEO, "Unknown XF Reg: {:x}={:x}", address, newValue);
       break;
     }
 
@@ -207,7 +207,7 @@ void LoadXFReg(u32 transferSize, u32 baseAddress, DataReader src)
   // do not allow writes past registers
   if (baseAddress + transferSize > 0x1058)
   {
-    WARN_LOG(VIDEO, "XF load exceeds address space: %x %d bytes", baseAddress, transferSize);
+    WARN_LOG_FMT(VIDEO, "XF load exceeds address space: {:x} {} bytes", baseAddress, transferSize);
 
     if (baseAddress >= 0x1058)
       transferSize = 0;


### PR DESCRIPTION
Migrates off the printf-based formatting where applicable. This doesn't touch the frame dumping code, as that is being migrated by someone else in #9239 