### PR TITLE
CMake: Bump fmt version requirement to 7.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,7 @@ if (_M_X86)
 endif()
 add_subdirectory(Externals/cpp-optparse)
 
-find_package(fmt 7.0)
+find_package(fmt 7.1)
 if(fmt_FOUND)
   message(STATUS "Using shared fmt ${fmt_VERSION}")
 else()


### PR DESCRIPTION
We use `make_args_checked`, which was added in 7.1.0.