### PR TITLE
Use positional arguments in all translatable fmt strings

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -560,8 +560,8 @@ bool BluetoothReal::OpenDevice(libusb_device* device)
   const int ret = libusb_open(m_device, &m_handle);
   if (ret != 0)
   {
-    m_last_open_error = fmt::format(Common::GetStringT("Failed to open Bluetooth device: {}"),
-                                    libusb_error_name(ret));
+    m_last_open_error =
+        Common::FmtFormatT("Failed to open Bluetooth device: {0}", libusb_error_name(ret));
     return false;
   }
 
@@ -574,9 +574,8 @@ bool BluetoothReal::OpenDevice(libusb_device* device)
     result = libusb_detach_kernel_driver(m_handle, INTERFACE);
     if (result < 0 && result != LIBUSB_ERROR_NOT_FOUND && result != LIBUSB_ERROR_NOT_SUPPORTED)
     {
-      m_last_open_error =
-          fmt::format(Common::GetStringT("Failed to detach kernel driver for BT passthrough: {}"),
-                      libusb_error_name(result));
+      m_last_open_error = Common::FmtFormatT(
+          "Failed to detach kernel driver for BT passthrough: {0}", libusb_error_name(result));
       return false;
     }
   }

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1071,8 +1071,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
     case SYNC_SAVE_DATA_FAILURE:
     {
-      m_dialog->AppendChat(
-          fmt::format(Common::GetStringT("{} failed to synchronize."), player.name));
+      m_dialog->AppendChat(Common::FmtFormatT("{0} failed to synchronize.", player.name));
       m_dialog->OnGameStartAborted();
       ChunkedDataAbort();
       m_start_pending = false;
@@ -1115,8 +1114,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 
     case SYNC_CODES_FAILURE:
     {
-      m_dialog->AppendChat(
-          fmt::format(Common::GetStringT("{} failed to synchronize codes."), player.name));
+      m_dialog->AppendChat(Common::FmtFormatT("{0} failed to synchronize codes.", player.name));
       m_dialog->OnGameStartAborted();
       m_start_pending = false;
     }

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -107,7 +107,8 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
   m_file.Seek(offset, SEEK_SET);
   if (!m_file.ReadBytes(m_zlib_buffer.data(), comp_block_size))
   {
-    PanicAlertFmtT("The disc image \"{}\" is truncated, some of the data is missing.", m_file_name);
+    PanicAlertFmtT("The disc image \"{0}\" is truncated, some of the data is missing.",
+                   m_file_name);
     m_file.Clear();
     return false;
   }
@@ -116,8 +117,8 @@ bool CompressedBlobReader::GetBlock(u64 block_num, u8* out_ptr)
   const u32 block_hash = Common::HashAdler32(m_zlib_buffer.data(), comp_block_size);
   if (block_hash != m_hashes[block_num])
   {
-    PanicAlertFmtT("The disc image \"{}\" is corrupt.\n"
-                   "Hash of block {} is {:08x} instead of {:08x}.",
+    PanicAlertFmtT("The disc image \"{0}\" is corrupt.\n"
+                   "Hash of block {1} is {2:08x} instead of {3:08x}.",
                    m_file_name, block_num, block_hash, m_hashes[block_num]);
   }
 
@@ -277,7 +278,7 @@ bool ConvertToGCZ(BlobReader* infile, const std::string& infile_path,
   if (!outfile)
   {
     PanicAlertFmtT(
-        "Failed to open the output file \"{}\".\n"
+        "Failed to open the output file \"{0}\".\n"
         "Check that you have permissions to write the target folder and that the media can "
         "be written.",
         outfile_path);
@@ -368,11 +369,11 @@ bool ConvertToGCZ(BlobReader* infile, const std::string& infile_path,
   }
 
   if (result == ConversionResultCode::ReadFailed)
-    PanicAlertFmtT("Failed to read from the input file \"{}\".", infile_path);
+    PanicAlertFmtT("Failed to read from the input file \"{0}\".", infile_path);
 
   if (result == ConversionResultCode::WriteFailed)
   {
-    PanicAlertFmtT("Failed to write the output file \"{}\".\n"
+    PanicAlertFmtT("Failed to write the output file \"{0}\".\n"
                    "Check that you have enough space available on the target drive.",
                    outfile_path);
   }

--- a/Source/Core/DiscIO/FileBlob.cpp
+++ b/Source/Core/DiscIO/FileBlob.cpp
@@ -50,7 +50,7 @@ bool ConvertToPlain(BlobReader* infile, const std::string& infile_path,
   if (!outfile)
   {
     PanicAlertFmtT(
-        "Failed to open the output file \"{}\".\n"
+        "Failed to open the output file \"{0}\".\n"
         "Check that you have permissions to write the target folder and that the media can "
         "be written.",
         outfile_path);
@@ -90,13 +90,13 @@ bool ConvertToPlain(BlobReader* infile, const std::string& infile_path,
     const u64 sz = std::min(buffer_size, infile->GetDataSize() - inpos);
     if (!infile->Read(inpos, sz, buffer.data()))
     {
-      PanicAlertFmtT("Failed to read from the input file \"{}\".", infile_path);
+      PanicAlertFmtT("Failed to read from the input file \"{0}\".", infile_path);
       success = false;
       break;
     }
     if (!outfile.WriteBytes(buffer.data(), sz))
     {
-      PanicAlertFmtT("Failed to write the output file \"{}\".\n"
+      PanicAlertFmtT("Failed to write the output file \"{0}\".\n"
                      "Check that you have enough space available on the target drive.",
                      outfile_path);
       success = false;

--- a/Source/Core/DiscIO/NANDImporter.cpp
+++ b/Source/Core/DiscIO/NANDImporter.cpp
@@ -272,6 +272,6 @@ void NANDImporter::ExportKeys(const std::string& nand_root)
   const std::string file_path = nand_root + "/keys.bin";
   File::IOFile file(file_path, "wb");
   if (!file.WriteBytes(m_nand_keys.data(), NAND_KEYS_SIZE))
-    PanicAlertFmtT("Unable to write to file {}", file_path);
+    PanicAlertFmtT("Unable to write to file {0}", file_path);
 }
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -312,11 +312,11 @@ std::vector<RedumpVerifier::PotentialMatch> RedumpVerifier::ScanDatfile(const st
     // so show a panic alert rather than just using ERROR_LOG
 
     // i18n: "Serial" refers to serial numbers, e.g. RVL-RSBE-USA
-    PanicAlertFmtT("Serial and/or version data is missing from {}\n"
-                   "Please append \"{}\" (without the quotes) to the datfile URL when downloading\n"
-                   "Example: {}",
-                   GetPathForSystem(system), "serial,version",
-                   "http://redump.org/datfile/gc/serial,version");
+    PanicAlertFmtT(
+        "Serial and/or version data is missing from {0}\n"
+        "Please append \"{1}\" (without the quotes) to the datfile URL when downloading\n"
+        "Example: {2}",
+        GetPathForSystem(system), "serial,version", "http://redump.org/datfile/gc/serial,version");
     m_result = {Status::Error, Common::GetStringT("Failed to parse Redump.org data")};
     return {};
   }

--- a/Source/Core/DiscIO/WIABlob.cpp
+++ b/Source/Core/DiscIO/WIABlob.cpp
@@ -2033,7 +2033,7 @@ bool ConvertToWIAOrRVZ(BlobReader* infile, const std::string& infile_path,
   if (!outfile)
   {
     PanicAlertFmtT(
-        "Failed to open the output file \"{}\".\n"
+        "Failed to open the output file \"{0}\".\n"
         "Check that you have permissions to write the target folder and that the media can "
         "be written.",
         outfile_path);
@@ -2048,11 +2048,11 @@ bool ConvertToWIAOrRVZ(BlobReader* infile, const std::string& infile_path,
               chunk_size, callback);
 
   if (result == ConversionResultCode::ReadFailed)
-    PanicAlertFmtT("Failed to read from the input file \"{}\".", infile_path);
+    PanicAlertFmtT("Failed to read from the input file \"{0}\".", infile_path);
 
   if (result == ConversionResultCode::WriteFailed)
   {
-    PanicAlertFmtT("Failed to write the output file \"{}\".\n"
+    PanicAlertFmtT("Failed to write the output file \"{0}\".\n"
                    "Check that you have enough space available on the target drive.",
                    outfile_path);
   }

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -73,7 +73,7 @@ bool InputConfig::LoadConfig(bool isGC)
           if (profiles.empty())
           {
             // TODO: PanicAlert shouldn't be used for this.
-            PanicAlertFmtT("No profiles found for game setting '{}'", profile_setting);
+            PanicAlertFmtT("No profiles found for game setting '{0}'", profile_setting);
             continue;
           }
 


### PR DESCRIPTION
We want to use positional arguments in translatable strings that have more than one argument so that translators can change the order of them, but the question is: Should we also use positional arguments in translatable strings with only one argument? I think it makes most sense that way, partially so that translators don't even have to be aware of the non-positional syntax and partially because "translatable strings use positional arguments" is an easier rule for us to remember than "transitional strings which have more than one argument use positional arguments". But let me know if you have a different opinion.