### PR TITLE
Fallback Region Option

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -12,6 +12,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "DiscIO/Enums.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 namespace Config
@@ -106,6 +107,8 @@ const Info<std::string> MAIN_PERF_MAP_DIR{{System::Main, "Core", "PerfMapDir"}, 
 const Info<bool> MAIN_CUSTOM_RTC_ENABLE{{System::Main, "Core", "EnableCustomRTC"}, false};
 // Default to seconds between 1.1.1970 and 1.1.2000
 const Info<u32> MAIN_CUSTOM_RTC_VALUE{{System::Main, "Core", "CustomRTCValue"}, 946684800};
+const Info<DiscIO::Region> MAIN_FALLBACK_REGION{{System::Main, "Core", "FallbackRegion"},
+                                                DiscIO::Region::NTSC_J};
 const Info<bool> MAIN_AUTO_DISC_CHANGE{{System::Main, "Core", "AutoDiscChange"}, false};
 const Info<bool> MAIN_ALLOW_SD_WRITES{{System::Main, "Core", "WiiSDCardAllowWrites"}, true};
 const Info<bool> MAIN_ENABLE_SAVESTATES{{System::Main, "Core", "EnableSaveStates"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/Config/Config.h"
+#include "DiscIO/Enums.h"
 
 namespace PowerPC
 {
@@ -88,6 +89,7 @@ extern const Info<u32> MAIN_CUSTOM_RTC_VALUE;
 extern const Info<bool> MAIN_AUTO_DISC_CHANGE;
 extern const Info<bool> MAIN_ALLOW_SD_WRITES;
 extern const Info<bool> MAIN_ENABLE_SAVESTATES;
+extern const Info<DiscIO::Region> MAIN_FALLBACK_REGION;
 
 // Main.DSP
 

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -33,7 +33,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
     }
   }
 
-  static constexpr std::array<const Config::Location*, 16> s_setting_saveable = {
+  static constexpr std::array<const Config::Location*, 17> s_setting_saveable = {
       // Main.Core
 
       &Config::MAIN_DEFAULT_ISO.location,
@@ -48,6 +48,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_MEM2_SIZE.location,
       &Config::MAIN_GFX_BACKEND.location,
       &Config::MAIN_ENABLE_SAVESTATES.location,
+      &Config::MAIN_FALLBACK_REGION.location,
 
       // Main.Interface
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -31,6 +31,7 @@
 #include "Core/Analytics.h"
 #include "Core/Boot/Boot.h"
 #include "Core/CommonTitles.h"
+#include "Core/Config/MainSettings.h"
 #include "Core/Config/SYSCONFSettings.h"
 #include "Core/ConfigLoaders/GameConfigLoader.h"
 #include "Core/Core.h"
@@ -929,18 +930,7 @@ bool SConfig::SetPathsAndGameMetadata(const BootParameters& boot)
 
 DiscIO::Region SConfig::GetFallbackRegion()
 {
-  // Fall back to the system menu region, if possible.
-  IOS::HLE::Kernel ios;
-  const IOS::ES::TMDReader system_menu_tmd = ios.GetES()->FindInstalledTMD(Titles::SYSTEM_MENU);
-  if (system_menu_tmd.IsValid())
-  {
-    const DiscIO::Region region = system_menu_tmd.GetRegion();
-    if (region != DiscIO::Region::Unknown)
-      return region;
-  }
-
-  // Fall back to PAL.
-  return DiscIO::Region::PAL;
+  return Config::Get(Config::MAIN_FALLBACK_REGION);
 }
 
 DiscIO::Language SConfig::GetCurrentLanguage(bool wii) const

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -508,6 +508,21 @@ QString Settings::GetAutoUpdateTrack() const
   return QString::fromStdString(SConfig::GetInstance().m_auto_update_track);
 }
 
+void Settings::SetFallbackRegion(const DiscIO::Region& region)
+{
+  if (region == GetFallbackRegion())
+    return;
+
+  Config::SetBase(Config::MAIN_FALLBACK_REGION, region);
+
+  emit FallbackRegionChanged(region);
+}
+
+DiscIO::Region Settings::GetFallbackRegion() const
+{
+  return Config::Get(Config::MAIN_FALLBACK_REGION);
+}
+
 void Settings::SetAnalyticsEnabled(bool enabled)
 {
   if (enabled == IsAnalyticsEnabled())

--- a/Source/Core/DolphinQt/Settings.h
+++ b/Source/Core/DolphinQt/Settings.h
@@ -10,6 +10,8 @@
 #include <QObject>
 #include <QSettings>
 
+#include "DiscIO/Enums.h"
+
 namespace Core
 {
 enum class State;
@@ -139,6 +141,10 @@ public:
   QString GetAutoUpdateTrack() const;
   void SetAutoUpdateTrack(const QString& mode);
 
+  // Fallback Region
+  DiscIO::Region GetFallbackRegion() const;
+  void SetFallbackRegion(const DiscIO::Region& region);
+
   // Analytics
   bool IsAnalyticsEnabled() const;
   void SetAnalyticsEnabled(bool enabled);
@@ -177,6 +183,7 @@ signals:
   void DebugModeToggled(bool enabled);
   void DebugFontChanged(QFont font);
   void AutoUpdateTrackChanged(const QString& mode);
+  void FallbackRegionChanged(const DiscIO::Region& region);
   void AnalyticsToggled(bool enabled);
   void DevicesChanged();
   void SDCardInsertionChanged(bool inserted);

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -41,6 +41,11 @@ constexpr const char* AUTO_UPDATE_STABLE_STRING = "stable";
 constexpr const char* AUTO_UPDATE_BETA_STRING = "beta";
 constexpr const char* AUTO_UPDATE_DEV_STRING = "dev";
 
+constexpr int FALLBACK_REGION_NTSCJ_INDEX = 0;
+constexpr int FALLBACK_REGION_NTSCU_INDEX = 1;
+constexpr int FALLBACK_REGION_PAL_INDEX = 2;
+constexpr int FALLBACK_REGION_NTSCK_INDEX = 3;
+
 GeneralPane::GeneralPane(QWidget* parent) : QWidget(parent)
 {
   CreateLayout();
@@ -63,6 +68,8 @@ void GeneralPane::CreateLayout()
   if (AutoUpdateChecker::SystemSupportsAutoUpdates())
     CreateAutoUpdate();
 
+  CreateFallbackRegion();
+
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   CreateAnalytics();
 #endif
@@ -81,6 +88,7 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
 #ifdef USE_DISCORD_PRESENCE
   m_checkbox_discord_presence->setEnabled(!running);
 #endif
+  m_combobox_fallback_region->setEnabled(!running);
 }
 
 void GeneralPane::ConnectLayout()
@@ -105,6 +113,10 @@ void GeneralPane::ConnectLayout()
   // Advanced
   connect(m_combobox_speedlimit, qOverload<int>(&QComboBox::currentIndexChanged),
           [this]() { OnSaveConfig(); });
+
+  connect(m_combobox_fallback_region, qOverload<int>(&QComboBox::currentIndexChanged), this,
+          &GeneralPane::OnSaveConfig);
+  connect(&Settings::Instance(), &Settings::FallbackRegionChanged, this, &GeneralPane::LoadConfig);
 
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
   connect(&Settings::Instance(), &Settings::AnalyticsToggled, this, &GeneralPane::LoadConfig);
@@ -179,6 +191,33 @@ void GeneralPane::CreateAutoUpdate()
     m_combobox_update_track->addItem(option);
 }
 
+void GeneralPane::CreateFallbackRegion()
+{
+  auto* fallback_region_group = new QGroupBox(tr("Fallback Region"));
+  auto* layout = new QVBoxLayout;
+  fallback_region_group->setLayout(layout);
+  m_main_layout->addWidget(fallback_region_group);
+
+  m_combobox_fallback_region = new QComboBox(this);
+
+  auto* form_widget = new QWidget;
+  auto* form_layout = new QFormLayout;
+  form_widget->setLayout(form_layout);
+  form_layout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+  form_layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+  form_layout->addRow(tr("Fallback Region:"), m_combobox_fallback_region);
+  layout->addWidget(form_widget);
+
+  auto* fallback_region_description =
+      new QLabel(tr("Dolphin will use this for titles whose region cannot be determined "
+                    "automatically."));
+  fallback_region_description->setWordWrap(true);
+  layout->addWidget(fallback_region_description);
+
+  for (const QString& option : {tr("NTSC-J"), tr("NTSC-U"), tr("PAL"), tr("NTSC-K")})
+    m_combobox_fallback_region->addItem(option);
+}
+
 #if defined(USE_ANALYTICS) && USE_ANALYTICS
 void GeneralPane::CreateAnalytics()
 {
@@ -224,6 +263,19 @@ void GeneralPane::LoadConfig()
   if (selection < m_combobox_speedlimit->count())
     m_combobox_speedlimit->setCurrentIndex(selection);
   m_checkbox_dualcore->setChecked(SConfig::GetInstance().bCPUThread);
+
+  const auto fallback = Settings::Instance().GetFallbackRegion();
+
+  if (fallback == DiscIO::Region::NTSC_J)
+    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCJ_INDEX);
+  else if (fallback == DiscIO::Region::NTSC_U)
+    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCU_INDEX);
+  else if (fallback == DiscIO::Region::PAL)
+    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_PAL_INDEX);
+  else if (fallback == DiscIO::Region::NTSC_K)
+    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCK_INDEX);
+  else
+    m_combobox_fallback_region->setCurrentIndex(FALLBACK_REGION_NTSCJ_INDEX);
 }
 
 static QString UpdateTrackFromIndex(int index)
@@ -244,6 +296,31 @@ static QString UpdateTrackFromIndex(int index)
   case AUTO_UPDATE_DEV_INDEX:
     value = QString::fromStdString(AUTO_UPDATE_DEV_STRING);
     break;
+  }
+
+  return value;
+}
+
+static DiscIO::Region UpdateFallbackRegionFromIndex(int index)
+{
+  DiscIO::Region value = DiscIO::Region::Unknown;
+
+  switch (index)
+  {
+  case FALLBACK_REGION_NTSCJ_INDEX:
+    value = DiscIO::Region::NTSC_J;
+    break;
+  case FALLBACK_REGION_NTSCU_INDEX:
+    value = DiscIO::Region::NTSC_U;
+    break;
+  case FALLBACK_REGION_PAL_INDEX:
+    value = DiscIO::Region::PAL;
+    break;
+  case FALLBACK_REGION_NTSCK_INDEX:
+    value = DiscIO::Region::NTSC_K;
+    break;
+  default:
+    value = DiscIO::Region::NTSC_J;
   }
 
   return value;
@@ -277,6 +354,8 @@ void GeneralPane::OnSaveConfig()
   Config::SetBase(Config::MAIN_AUTO_DISC_CHANGE, m_checkbox_auto_disc_change->isChecked());
   Config::SetBaseOrCurrent(Config::MAIN_ENABLE_CHEATS, m_checkbox_cheats->isChecked());
   settings.m_EmulationSpeed = m_combobox_speedlimit->currentIndex() * 0.1f;
+  Settings::Instance().SetFallbackRegion(
+      UpdateFallbackRegionFromIndex(m_combobox_fallback_region->currentIndex()));
 
   settings.SaveSettings();
 }

--- a/Source/Core/DolphinQt/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.h
@@ -30,6 +30,7 @@ private:
   void ConnectLayout();
   void CreateBasic();
   void CreateAutoUpdate();
+  void CreateFallbackRegion();
 
   void LoadConfig();
   void OnSaveConfig();
@@ -39,6 +40,7 @@ private:
   QVBoxLayout* m_main_layout;
   QComboBox* m_combobox_speedlimit;
   QComboBox* m_combobox_update_track;
+  QComboBox* m_combobox_fallback_region;
   QCheckBox* m_checkbox_dualcore;
   QCheckBox* m_checkbox_cheats;
   QCheckBox* m_checkbox_override_region_settings;


### PR DESCRIPTION
A user-selected fallback to use instead of the default PAL

This can be used for unknown region or region free titles to give them the ability to force a different region than the current fallback region of PAL. This can be useful if a user is trying to play a region free title that is originally NTSC and expects to be run at NTSC speeds. This may be done when a user attempts to dump a WAD of their own without understanding the settings they have chosen, or could be an intentional decision by a developer of a ROM hack that can be injected into a Virtual Console WAD.

This is primarily a proof-of-concept in its current stage.