### PR TITLE
Android: Gradle and dependency updates with cleanup

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -79,15 +79,15 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.exifinterface:exifinterface:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.lifecycle:lifecycle-viewmodel:2.2.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.2.1'
 
     // Android TV UI libraries.
     implementation 'androidx.leanback:leanback:1.0.0'
@@ -110,7 +110,7 @@ def getVersion() {
                 .trim()
                 .replaceAll(/(-0)?-[^-]+$/, "")
     } catch (Exception e) {
-        logger.error('Cannot find git, defaulting to dummy version number')
+        logger.error(e + ': Cannot find git, defaulting to dummy version number')
     }
 
     return versionNumber
@@ -121,10 +121,10 @@ def getBuildVersionCode() {
     try {
         def versionNumber = 'git rev-list --first-parent --count HEAD'.execute([], project.rootDir).text
                 .trim()
-        return Integer.valueOf(versionNumber);
+        return Integer.valueOf(versionNumber)
     } catch (Exception e) {
-        logger.error('Cannot find git, defaulting to dummy version number')
+        logger.error(e + ': Cannot find git, defaulting to dummy version number')
     }
 
-    return 1;
+    return 1
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AppLinkActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AppLinkActivity.java
@@ -32,16 +32,22 @@ public class AppLinkActivity extends FragmentActivity
   protected void onCreate(Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
-    Intent intent = getIntent();
-    Uri uri = intent.getData();
+    Uri uri = getIntent().getData();
 
-    Log.v(TAG, uri.toString());
-
-    if (uri.getPathSegments().isEmpty())
+    if (uri != null)
     {
-      Log.e(TAG, "Invalid uri " + uri);
-      finish();
-      return;
+      Log.v(TAG, uri.toString());
+
+      if (uri.getPathSegments().isEmpty())
+      {
+        Log.e(TAG, "Invalid uri " + uri);
+        finish();
+        return;
+      }
+    }
+    else
+    {
+      throw new IllegalStateException("Could not get data uri.");
     }
 
     AppLinkHelper.AppLinkAction action = AppLinkHelper.extractAction(uri);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -71,7 +71,7 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
   {
     Context context = holder.itemView.getContext();
     GameFile gameFile = mGameFiles.get(position);
-    PicassoUtils.loadGameCover(holder.imageScreenshot, gameFile);
+    PicassoUtils.loadGameCover(holder.imageGameCover, gameFile);
 
     holder.textGameTitle.setText(gameFile.getTitle());
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -49,8 +49,8 @@ public final class GameRowPresenter extends Presenter
     Context context = holder.cardParent.getContext();
     GameFile gameFile = (GameFile) item;
 
-    holder.imageScreenshot.setImageDrawable(null);
-    PicassoUtils.loadGameCover(holder.imageScreenshot, gameFile);
+    holder.imageGameCover.setImageDrawable(null);
+    PicassoUtils.loadGameCover(holder.imageGameCover, gameFile);
 
     holder.cardParent.setTitleText(gameFile.getTitle());
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/PlatformPagerAdapter.java
@@ -7,6 +7,7 @@ import android.text.SpannableString;
 import android.text.style.ImageSpan;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
@@ -17,7 +18,7 @@ import org.dolphinemu.dolphinemu.ui.platform.PlatformGamesFragment;
 
 public class PlatformPagerAdapter extends FragmentPagerAdapter
 {
-  private Context mContext;
+  private final Context mContext;
 
   private final static int[] TAB_ICONS =
           {
@@ -52,14 +53,23 @@ public class PlatformPagerAdapter extends FragmentPagerAdapter
     // Apparently a workaround for TabLayout not supporting icons.
     // TODO: This workaround will eventually not be necessary; switch to more legit methods when that is the case
     // TODO: Also remove additional hax from styles.xml
-    Drawable drawable = mContext.getResources().getDrawable(TAB_ICONS[position]);
-    drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
+    Drawable drawable = ResourcesCompat
+            .getDrawable(mContext.getResources(), TAB_ICONS[position], null);
 
-    ImageSpan imageSpan = new ImageSpan(drawable, ImageSpan.ALIGN_BOTTOM);
+    if (drawable != null)
+    {
+      drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
 
-    SpannableString sb = new SpannableString(" ");
-    sb.setSpan(imageSpan, 0, 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+      ImageSpan imageSpan = new ImageSpan(drawable, ImageSpan.ALIGN_BOTTOM);
 
-    return sb;
+      SpannableString sb = new SpannableString(" ");
+      sb.setSpan(imageSpan, 0, 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+      return sb;
+    }
+    else
+    {
+      throw new IllegalStateException("[PlatformPagerAdapter]: Drawable is null");
+    }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/SettingsRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/SettingsRowPresenter.java
@@ -3,6 +3,7 @@ package org.dolphinemu.dolphinemu.adapters;
 import android.content.res.Resources;
 import android.view.ViewGroup;
 
+import androidx.core.content.res.ResourcesCompat;
 import androidx.leanback.widget.ImageCardView;
 import androidx.leanback.widget.Presenter;
 
@@ -37,7 +38,8 @@ public final class SettingsRowPresenter extends Presenter
     holder.itemId = settingsItem.getItemId();
 
     holder.cardParent.setTitleText(resources.getString(settingsItem.getLabelId()));
-    holder.cardParent.setMainImage(resources.getDrawable(settingsItem.getIconId(), null));
+    holder.cardParent
+            .setMainImage(ResourcesCompat.getDrawable(resources, settingsItem.getIconId(), null));
   }
 
   public void onUnbindViewHolder(Presenter.ViewHolder viewHolder)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/ConvertFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/ConvertFragment.java
@@ -34,7 +34,7 @@ public class ConvertFragment extends Fragment implements View.OnClickListener
   {
     private int mValuesId = -1;
     private int mCurrentPosition = -1;
-    private ArrayList<Runnable> mCallbacks = new ArrayList<>();
+    private final ArrayList<Runnable> mCallbacks = new ArrayList<>();
 
     @Override
     public void onItemSelected(AdapterView<?> adapterView, View view, int position, long id)
@@ -109,10 +109,10 @@ public class ConvertFragment extends Fragment implements View.OnClickListener
   private static final int COMPRESSION_LZMA2 = 4;
   private static final int COMPRESSION_ZSTD = 5;
 
-  private SpinnerValue mFormat = new SpinnerValue();
-  private SpinnerValue mBlockSize = new SpinnerValue();
-  private SpinnerValue mCompression = new SpinnerValue();
-  private SpinnerValue mCompressionLevel = new SpinnerValue();
+  private final SpinnerValue mFormat = new SpinnerValue();
+  private final SpinnerValue mBlockSize = new SpinnerValue();
+  private final SpinnerValue mCompression = new SpinnerValue();
+  private final SpinnerValue mCompressionLevel = new SpinnerValue();
 
   private GameFile gameFile;
 
@@ -395,6 +395,7 @@ public class ConvertFragment extends Fragment implements View.OnClickListener
   {
     if (requestCode == REQUEST_CODE_SAVE_FILE && resultCode == Activity.RESULT_OK)
     {
+      //noinspection ConstantConditions
       convert(data.getData().toString());
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import androidx.annotation.Keep;
 
+import java.io.File;
+
 public class GameFile
 {
   @Keep
@@ -66,7 +68,16 @@ public class GameFile
 
   public String getCoverPath(Context context)
   {
-    return context.getExternalCacheDir().getPath() + "/GameCovers/" + getGameTdbId() + ".png";
+    File externalCacheDir = context.getExternalCacheDir();
+
+    if (externalCacheDir != null)
+    {
+      return externalCacheDir.getPath() + "/GameCovers/" + getGameTdbId() + ".png";
+    }
+    else
+    {
+      throw new IllegalStateException("[GameFile] externalCacheDir is null");
+    }
   }
 
   public String getCustomCoverPath()

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -705,9 +705,9 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
   public void refreshControls()
   {
     // Remove all the overlay buttons from the HashSet.
-    overlayButtons.removeAll(overlayButtons);
-    overlayDpads.removeAll(overlayDpads);
-    overlayJoysticks.removeAll(overlayJoysticks);
+    overlayButtons.clear();
+    overlayDpads.clear();
+    overlayJoysticks.clear();
 
     String orientation =
             getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT ?

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -69,42 +69,50 @@ public final class MainPresenter
 
   public boolean handleOptionSelection(int itemId, Context context)
   {
-    switch (itemId)
+    if (itemId == R.id.menu_settings_core)
     {
-      case R.id.menu_settings_core:
-        mView.launchSettingsActivity(MenuTag.CONFIG);
-        return true;
-
-      case R.id.menu_settings_graphics:
-        mView.launchSettingsActivity(MenuTag.GRAPHICS);
-        return true;
-
-      case R.id.menu_settings_gcpad:
-        mView.launchSettingsActivity(MenuTag.GCPAD_TYPE);
-        return true;
-
-      case R.id.menu_settings_wiimote:
-        mView.launchSettingsActivity(MenuTag.WIIMOTE);
-        return true;
-
-      case R.id.menu_refresh:
-        GameFileCacheService.startRescan(context);
-        return true;
-
-      case R.id.button_add_directory:
-        mView.launchFileListActivity();
-        return true;
-
-      case R.id.menu_open_file:
-        mView.launchOpenFileActivity();
-        return true;
-
-      case R.id.menu_install_wad:
-        new AfterDirectoryInitializationRunner().run(context, true, mView::launchInstallWAD);
-        return true;
+      mView.launchSettingsActivity(MenuTag.CONFIG);
+      return true;
     }
-
-    return false;
+    else if (itemId == R.id.menu_settings_graphics)
+    {
+      mView.launchSettingsActivity(MenuTag.GRAPHICS);
+      return true;
+    }
+    else if (itemId == R.id.menu_settings_gcpad)
+    {
+      mView.launchSettingsActivity(MenuTag.GCPAD_TYPE);
+      return true;
+    }
+    else if (itemId == R.id.menu_settings_wiimote)
+    {
+      mView.launchSettingsActivity(MenuTag.WIIMOTE);
+      return true;
+    }
+    else if (itemId == R.id.menu_refresh)
+    {
+      GameFileCacheService.startRescan(context);
+      return true;
+    }
+    else if (itemId == R.id.button_add_directory)
+    {
+      mView.launchFileListActivity();
+      return true;
+    }
+    else if (itemId == R.id.menu_open_file)
+    {
+      mView.launchOpenFileActivity();
+      return true;
+    }
+    else if (itemId == R.id.menu_install_wad)
+    {
+      new AfterDirectoryInitializationRunner().run(context, true, mView::launchInstallWAD);
+      return true;
+    }
+    else
+    {
+      return false;
+    }
   }
 
   public void addDirIfNeeded(Context context)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -37,14 +37,8 @@ public class Analytics
     new AlertDialog.Builder(context, R.style.DolphinDialogBase)
             .setTitle(context.getString(R.string.analytics))
             .setMessage(context.getString(R.string.analytics_desc))
-            .setPositiveButton(R.string.yes, (dialogInterface, i) ->
-            {
-              firstAnalyticsAdd(true);
-            })
-            .setNegativeButton(R.string.no, (dialogInterface, i) ->
-            {
-              firstAnalyticsAdd(false);
-            })
+            .setPositiveButton(R.string.yes, (dialogInterface, i) -> firstAnalyticsAdd(true))
+            .setNegativeButton(R.string.no, (dialogInterface, i) -> firstAnalyticsAdd(false))
             .show();
   }
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -6,13 +6,16 @@
 
 package org.dolphinemu.dolphinemu.utils;
 
+import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Environment;
+import android.os.IBinder;
 import android.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
@@ -30,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * A service that spawns its own thread in order to copy several binary and shader files
  * from the Dolphin APK to the external file system.
  */
-public final class DirectoryInitialization
+public final class DirectoryInitialization extends Service
 {
   public static final String BROADCAST_ACTION =
           "org.dolphinemu.dolphinemu.DIRECTORY_INITIALIZATION";
@@ -43,6 +46,13 @@ public final class DirectoryInitialization
   private static String userPath;
   private static String internalPath;
   private static AtomicBoolean isDolphinDirectoryInitializationRunning = new AtomicBoolean(false);
+
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent)
+  {
+    return null;
+  }
 
   public enum DirectoryInitializationState
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/TvUtil.java
@@ -22,6 +22,7 @@ import android.util.Log;
 
 import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.tvprovider.media.tv.Channel;
 import androidx.tvprovider.media.tv.TvContractCompat;
 
@@ -55,15 +56,16 @@ public class TvUtil
 
   public static int getNumberOfChannels(Context context)
   {
-    Cursor cursor =
-            context.getContentResolver()
-                    .query(
-                            TvContractCompat.Channels.CONTENT_URI,
-                            CHANNELS_PROJECTION,
-                            null,
-                            null,
-                            null);
-    return cursor != null ? cursor.getCount() : 0;
+    try (Cursor cursor = context.getContentResolver()
+            .query(
+                    TvContractCompat.Channels.CONTENT_URI,
+                    CHANNELS_PROJECTION,
+                    null,
+                    null,
+                    null))
+    {
+      return cursor != null ? cursor.getCount() : 0;
+    }
   }
 
   public static List<Channel> getAllChannels(Context context)
@@ -135,7 +137,7 @@ public class TvUtil
   @NonNull
   public static Bitmap convertToBitmap(Context context, int resourceId)
   {
-    Drawable drawable = context.getDrawable(resourceId);
+    Drawable drawable = ResourcesCompat.getDrawable(context.getResources(), resourceId, null);
     if (drawable instanceof VectorDrawable)
     {
       Bitmap bitmap =
@@ -175,8 +177,12 @@ public class TvUtil
     }
     catch (Exception e)
     {
+      String message = e.getMessage();
+
       Log.e(TAG, "Failed to create banner");
-      Log.e(TAG, e.getMessage());
+
+      if (message != null)
+        Log.e(TAG, message);
     }
 
     return contentUri;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/GameViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/GameViewHolder.java
@@ -15,7 +15,7 @@ import org.dolphinemu.dolphinemu.model.GameFile;
  */
 public class GameViewHolder extends RecyclerView.ViewHolder
 {
-  public ImageView imageScreenshot;
+  public ImageView imageGameCover;
   public TextView textGameTitle;
   public TextView textGameCaption;
 
@@ -27,7 +27,7 @@ public class GameViewHolder extends RecyclerView.ViewHolder
 
     itemView.setTag(this);
 
-    imageScreenshot = itemView.findViewById(R.id.image_game_screen);
+    imageGameCover = itemView.findViewById(R.id.image_game_cover);
     textGameTitle = itemView.findViewById(R.id.text_game_title);
     textGameCaption = itemView.findViewById(R.id.text_game_caption);
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/TvGameViewHolder.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/viewholders/TvGameViewHolder.java
@@ -16,7 +16,7 @@ public final class TvGameViewHolder extends Presenter.ViewHolder
 {
   public ImageCardView cardParent;
 
-  public ImageView imageScreenshot;
+  public ImageView imageGameCover;
 
   public GameFile gameFile;
 
@@ -27,6 +27,6 @@ public final class TvGameViewHolder extends Presenter.ViewHolder
     itemView.setTag(this);
 
     cardParent = (ImageCardView) itemView;
-    imageScreenshot = cardParent.getMainImageView();
+    imageGameCover = cardParent.getMainImageView();
   }
 }

--- a/Source/Android/app/src/main/res/layout/activity_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_main.xml
@@ -46,6 +46,7 @@
         app:borderWidth="0dp"
         app:layout_anchor="@+id/pager_platforms"
         app:layout_anchorGravity="bottom|right|end"
-        app:rippleColor="?android:colorPrimaryDark" />
+        app:rippleColor="?android:colorPrimaryDark"
+        android:contentDescription="@string/add_directory_button" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -15,12 +15,12 @@
         android:orientation="vertical">
 
         <ImageView
-            android:id="@+id/image_game_screen"
+            android:id="@+id/image_game_cover"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            tools:src="@drawable/placeholder_screenshot"
-            tools:scaleType="centerCrop"/>
+            tools:scaleType="centerCrop"
+            android:contentDescription="@string/placeholder_game_cover"/>
 
         <TextView
             android:id="@+id/text_game_title"

--- a/Source/Android/app/src/main/res/layout/dialog_game_details.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_game_details.xml
@@ -42,7 +42,8 @@
             android:layout_marginBottom="16dp"
             tools:src="@drawable/no_banner"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/text_description" />
+            app:layout_constraintTop_toBottomOf="@id/text_description"
+            android:contentDescription="@string/banner" />
 
         <View
             android:id="@+id/divider_1"

--- a/Source/Android/app/src/main/res/layout/tv_title.xml
+++ b/Source/Android/app/src/main/res/layout/tv_title.xml
@@ -25,7 +25,8 @@
             android:id="@+id/badge"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_launcher"/>
+            android:src="@drawable/ic_launcher"
+            android:contentDescription="@string/dolphin_icon"/>
 
     </RelativeLayout>
 </androidx.leanback.widget.TitleView>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -440,6 +440,12 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="wrong_file_extension_multiple">The selected file has the file name extension \"%1$s\", but one of these extensions was expected: %2$s\n\nContinue anyway?</string>
     <string name="unavailable_paths">Dolphin does not have permission to access one or more configured paths. Would you like to fix this before starting?</string>
 
+    <!-- Content Descriptions-->
+    <string name="add_directory_button">Add Directory Button</string>
+    <string name="banner">Banner</string>
+    <string name="dolphin_icon">Dolphin Icon</string>
+    <string name="placeholder_game_cover">Placeholder Game Cover</string>
+
     <!-- Misc -->
     <string name="pitch">Total Pitch</string>
     <string name="yaw">Total Yaw</string>

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
 }
 

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 21 14:29:03 EDT 2019
+#Mon Nov 16 07:02:52 EST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Changes should be rather simple except:
- Id references will no longer be final in Gradle. `MainPresenter` can't use them as switch cases.
- Android Studio wanted me to extend `Service` in `DirectoryInitialization` due to its usage in `AndroidManifest`.