### PR TITLE
Android: Add @Keep annotation to things accessed using JNI

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -12,6 +12,7 @@ import android.util.DisplayMetrics;
 import android.view.Surface;
 import android.widget.Toast;
 
+import androidx.annotation.Keep;
 import androidx.fragment.app.FragmentManager;
 
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
@@ -264,6 +265,7 @@ public final class NativeLibrary
    * @param padID Ignored for now. Future use would be to pass rumble to a connected controller
    * @param state Ignored for now since phone rumble can't just be 'turned' on/off
    */
+  @Keep
   public static void rumble(int padID, double state)
   {
     final EmulationActivity emulationActivity = sEmulationActivity.get();
@@ -486,6 +488,7 @@ public final class NativeLibrary
 
   private static native String GetCurrentTitleDescriptionUnchecked();
 
+  @Keep
   public static boolean displayAlertMsg(final String caption, final String text,
           final boolean yesNo, final boolean isWarning, final boolean nonBlocking)
   {
@@ -575,6 +578,7 @@ public final class NativeLibrary
     sEmulationActivity.clear();
   }
 
+  @Keep
   public static void finishEmulationActivity()
   {
     final EmulationActivity emulationActivity = sEmulationActivity.get();
@@ -589,6 +593,7 @@ public final class NativeLibrary
     }
   }
 
+  @Keep
   public static void updateTouchPointer()
   {
     final EmulationActivity emulationActivity = sEmulationActivity.get();
@@ -602,7 +607,8 @@ public final class NativeLibrary
     }
   }
 
-  private static void onTitleChanged()
+  @Keep
+  public static void onTitleChanged()
   {
     final EmulationActivity emulationActivity = sEmulationActivity.get();
     if (emulationActivity == null)
@@ -615,6 +621,7 @@ public final class NativeLibrary
     }
   }
 
+  @Keep
   public static float getRenderSurfaceScale()
   {
     DisplayMetrics metrics = new DisplayMetrics();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFile.java
@@ -2,10 +2,14 @@ package org.dolphinemu.dolphinemu.model;
 
 import android.content.Context;
 
+import androidx.annotation.Keep;
+
 public class GameFile
 {
-  private long mPointer;  // Do not rename or move without editing the native code
+  @Keep
+  private long mPointer;
 
+  @Keep
   private GameFile(long pointer)
   {
     mPointer = pointer;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameFileCache.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import androidx.annotation.Keep;
+
 import org.dolphinemu.dolphinemu.features.settings.model.BooleanSetting;
 
 import java.io.File;
@@ -15,7 +17,8 @@ public class GameFileCache
   private static final String GAME_FOLDER_PATHS_PREFERENCE = "gameFolderPaths";
   private static final Set<String> EMPTY_SET = new HashSet<>();
 
-  private long mPointer;  // Do not rename or move without editing the native code
+  @Keep
+  private long mPointer;
 
   public GameFileCache(String path)
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -3,6 +3,7 @@ package org.dolphinemu.dolphinemu.utils;
 import android.content.Context;
 import android.os.Build;
 
+import androidx.annotation.Keep;
 import androidx.appcompat.app.AlertDialog;
 
 import com.android.volley.Request;
@@ -61,6 +62,7 @@ public class Analytics
     }
   }
 
+  @Keep
   public static void sendReport(String endpoint, byte[] data)
   {
     StringRequest request = new StringRequest(Request.Method.POST, endpoint,
@@ -76,6 +78,7 @@ public class Analytics
     VolleyUtil.getQueue().add(request);
   }
 
+  @Keep
   public static String getValue(String key)
   {
     switch (key)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CompressCallback.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/CompressCallback.java
@@ -1,6 +1,9 @@
 package org.dolphinemu.dolphinemu.utils;
 
+import androidx.annotation.Keep;
+
 public interface CompressCallback
 {
+  @Keep
   boolean run(String text, float completion);
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ContentHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/ContentHandler.java
@@ -4,12 +4,15 @@ import android.content.ContentResolver;
 import android.net.Uri;
 import android.provider.DocumentsContract;
 
+import androidx.annotation.Keep;
+
 import org.dolphinemu.dolphinemu.DolphinApplication;
 
 import java.io.FileNotFoundException;
 
 public class ContentHandler
 {
+  @Keep
   public static int openFd(String uri, String mode)
   {
     try
@@ -23,6 +26,7 @@ public class ContentHandler
     }
   }
 
+  @Keep
   public static boolean delete(String uri)
   {
     try

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/IniFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/IniFile.java
@@ -1,5 +1,7 @@
 package org.dolphinemu.dolphinemu.utils;
 
+import androidx.annotation.Keep;
+
 import java.io.File;
 
 // An in-memory copy of an INI file
@@ -7,10 +9,13 @@ public class IniFile
 {
   // This class is non-static to ensure that the IniFile parent does not get garbage collected
   // while a section still is accessible. (The finalizer of IniFile deletes the native sections.)
+  @SuppressWarnings("InnerClassMayBeStatic")
   public class Section
   {
-    private long mPointer;  // Do not rename or move without editing the native code
+    @Keep
+    private long mPointer;
 
+    @Keep
     private Section(long pointer)
     {
       mPointer = pointer;
@@ -37,7 +42,8 @@ public class IniFile
     public native void setFloat(String key, float newFloat);
   }
 
-  private long mPointer;  // Do not rename or move without editing the native code
+  @Keep
+  private long mPointer;
 
   public IniFile()
   {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_GCAdapter.java
@@ -13,6 +13,8 @@ import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
 import android.widget.Toast;
 
+import androidx.annotation.Keep;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.services.USBPermService;
 
@@ -22,6 +24,8 @@ import java.util.Map;
 public class Java_GCAdapter
 {
   public static UsbManager manager;
+
+  @Keep
   static byte[] controller_payload = new byte[37];
 
   static UsbDeviceConnection usb_con;
@@ -63,11 +67,13 @@ public class Java_GCAdapter
     usb_con.close();
   }
 
+  @Keep
   public static int GetFD()
   {
     return usb_con.getFileDescriptor();
   }
 
+  @Keep
   public static boolean QueryAdapter()
   {
     HashMap<String, UsbDevice> devices = manager.getDeviceList();
@@ -91,16 +97,19 @@ public class Java_GCAdapter
     usb_con.bulkTransfer(usb_out, init, init.length, 0);
   }
 
+  @Keep
   public static int Input()
   {
     return usb_con.bulkTransfer(usb_in, controller_payload, controller_payload.length, 16);
   }
 
+  @Keep
   public static int Output(byte[] rumble)
   {
     return usb_con.bulkTransfer(usb_out, rumble, 5, 16);
   }
 
+  @Keep
   public static boolean OpenAdapter()
   {
     HashMap<String, UsbDevice> devices = manager.getDeviceList();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Java_WiimoteAdapter.java
@@ -10,6 +10,8 @@ import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
 
+import androidx.annotation.Keep;
+
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.services.USBPermService;
 
@@ -30,6 +32,7 @@ public class Java_WiimoteAdapter
   static UsbInterface[] usb_intf = new UsbInterface[MAX_WIIMOTES];
   static UsbEndpoint[] usb_in = new UsbEndpoint[MAX_WIIMOTES];
 
+  @Keep
   public static byte[][] wiimote_payload = new byte[MAX_WIIMOTES][MAX_PAYLOAD];
 
   private static void RequestPermission()
@@ -62,6 +65,7 @@ public class Java_WiimoteAdapter
     }
   }
 
+  @Keep
   public static boolean QueryAdapter()
   {
     HashMap<String, UsbDevice> devices = manager.getDeviceList();
@@ -80,11 +84,13 @@ public class Java_WiimoteAdapter
     return false;
   }
 
+  @Keep
   public static int Input(int index)
   {
     return usb_con.bulkTransfer(usb_in[index], wiimote_payload[index], MAX_PAYLOAD, TIMEOUT);
   }
 
+  @Keep
   public static int Output(int index, byte[] buf, int size)
   {
     byte report_number = buf[0];
@@ -114,6 +120,7 @@ public class Java_WiimoteAdapter
     return write + 1;
   }
 
+  @Keep
   public static boolean OpenAdapter()
   {
     // If the adapter is already open. Don't attempt to do it again


### PR DESCRIPTION
This acts as a hint to both people and automated tools that a variable or method shouldn't be renamed or removed.