### PR TITLE
Fixed non-UTF8 chars in PeakFinder.cpp

### DIFF
--- a/Externals/soundtouch/PeakFinder.cpp
+++ b/Externals/soundtouch/PeakFinder.cpp
@@ -64,7 +64,7 @@ int PeakFinder::findTop(const float *data, int peakpos) const
 
     refvalue = data[peakpos];
 
-    // seek within ±10 points
+    // seek within Â±10 points
     start = peakpos - 10;
     if (start < minPos) start = minPos;
     end = peakpos + 10;
@@ -265,7 +265,7 @@ double PeakFinder::detectPeak(const float *data, int aminPos, int amaxPos)
 
         // accept harmonic peak if 
         // (a) it is found
-        // (b) is within ±4% of the expected harmonic interval
+        // (b) is within Â±4% of the expected harmonic interval
         // (c) has at least half x-corr value of the max. peak
 
         double diff = harmonic * peaktmp / highPeak;


### PR DESCRIPTION
Encoding of this file was iso-8859-1 instead of utf-8, this PR addresses that to bring it inline with the .editorconfig file : ) discovered while working on indexing dolphin repo with https://github.com/sourcegraph/lsif-clang, so thanks for surfacing this! :grin: 