### PR TITLE
Jit64: More constant propagation optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -862,13 +862,20 @@ void Jit64::subfic(UGeckoInstruction inst)
 {
   INSTRUCTION_START
   JITDISABLE(bJITIntegerOff);
-  int a = inst.RA, d = inst.RD;
+  int a = inst.RA, d = inst.RD, imm = inst.SIMM_16;
+
+  if (gpr.IsImm(a))
+  {
+    u32 i = imm, j = gpr.Imm32(a);
+    gpr.SetImmediate32(d, i - j);
+    FinalizeCarry(j == 0 || (i > j - 1));
+    return;
+  }
 
   RCOpArg Ra = gpr.Use(a, RCMode::Read);
   RCX64Reg Rd = gpr.Bind(d, RCMode::Write);
   RegCache::Realize(Ra, Rd);
 
-  int imm = inst.SIMM_16;
   if (d == a)
   {
     if (imm == 0)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1795,6 +1795,27 @@ void Jit64::srwx(UGeckoInstruction inst)
     u32 amount = gpr.Imm32(b);
     gpr.SetImmediate32(a, (amount & 0x20) ? 0 : (gpr.Imm32(s) >> (amount & 0x1f)));
   }
+  else if (gpr.IsImm(b))
+  {
+    u32 amount = gpr.Imm32(b);
+    if (amount & 0x20)
+    {
+      gpr.SetImmediate32(a, 0);
+    }
+    else
+    {
+      RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
+      RCOpArg Rs = gpr.Use(s, RCMode::Read);
+      RegCache::Realize(Ra, Rs);
+
+      if (a != s)
+        MOV(32, Ra, Rs);
+
+      amount &= 0x1f;
+      if (amount != 0)
+        SHR(32, Ra, Imm8(amount));
+    }
+  }
   else
   {
     RCX64Reg ecx = gpr.Scratch(ECX);  // no register choice

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1995,7 +1995,13 @@ void Jit64::srawix(UGeckoInstruction inst)
   int s = inst.RS;
   int amount = inst.SH;
 
-  if (amount != 0)
+  if (gpr.IsImm(s))
+  {
+    s32 imm = gpr.SImm32(s);
+    gpr.SetImmediate32(a, imm >> amount);
+    FinalizeCarry(amount != 0 && imm < 0 && (u32(imm) << (32 - amount)));
+  }
+  else if (amount != 0)
   {
     RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
     RCOpArg Rs = gpr.Use(s, RCMode::Read);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1892,6 +1892,12 @@ void Jit64::slwx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC(a);
   }
+  else if (gpr.IsImm(s) && gpr.Imm32(s) == 0)
+  {
+    gpr.SetImmediate32(a, 0);
+    if (inst.Rc)
+      ComputeRC(a);
+  }
   else
   {
     RCX64Reg ecx = gpr.Scratch(ECX);  // no register choice

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1849,6 +1849,30 @@ void Jit64::slwx(UGeckoInstruction inst)
     if (inst.Rc)
       ComputeRC(a);
   }
+  else if (gpr.IsImm(b))
+  {
+    u32 amount = gpr.Imm32(b);
+    if (amount & 0x20)
+    {
+      gpr.SetImmediate32(a, 0);
+    }
+    else
+    {
+      RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
+      RCOpArg Rs = gpr.Use(s, RCMode::Read);
+      RegCache::Realize(Ra, Rs);
+
+      if (a != s)
+        MOV(32, Ra, Rs);
+
+      amount &= 0x1f;
+      if (amount != 0)
+        SHL(32, Ra, Imm8(amount));
+    }
+
+    if (inst.Rc)
+      ComputeRC(a);
+  }
   else
   {
     RCX64Reg ecx = gpr.Scratch(ECX);  // no register choice

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1907,7 +1907,22 @@ void Jit64::srawx(UGeckoInstruction inst)
   int b = inst.RB;
   int s = inst.RS;
 
-  if (gpr.IsImm(b))
+  if (gpr.IsImm(b, s))
+  {
+    s32 i = gpr.SImm32(s), amount = gpr.SImm32(b);
+    if (amount & 0x20)
+    {
+      gpr.SetImmediate32(a, i & 0x80000000 ? 0xFFFFFFFF : 0);
+      FinalizeCarry(i & 0x80000000 ? true : false);
+    }
+    else
+    {
+      amount &= 0x1F;
+      gpr.SetImmediate32(a, i >> amount);
+      FinalizeCarry(amount != 0 && i < 0 && (u32(i) << (32 - amount)));
+    }
+  }
+  else if (gpr.IsImm(b))
   {
     u32 amount = gpr.Imm32(b);
     RCX64Reg Ra = gpr.Bind(a, RCMode::Write);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1983,6 +1983,11 @@ void Jit64::srawx(UGeckoInstruction inst)
       FinalizeCarry(CC_NZ);
     }
   }
+  else if (gpr.IsImm(s) && gpr.Imm32(s) == 0)
+  {
+    gpr.SetImmediate32(a, 0);
+    FinalizeCarry(false);
+  }
   else
   {
     RCX64Reg ecx = gpr.Scratch(ECX);  // no register choice


### PR DESCRIPTION
It is possible to generate more optimal instruction sequences for various instructions if some or all of the input registers are known to hold a specific value.

---
**subfic**
<details><summary>Example</summary>

Before:
```
BE 03 00 00 00       mov         esi,3
83 EE 08             sub         esi,8
0F 93 45 58          setae       byte ptr [rbp+58h]
```
After:
```
C6 45 58 00          mov         byte ptr [rbp+58h],0
```
</details>

---

**srwx**
<details><summary>Example 1</summary>

Before:
```
B9 18 00 00 00       mov         ecx,18h
45 8B C1             mov         r8d,r9d
49 D3 E8             shr         r8,cl
```
After:
```
45 8B C1             mov         r8d,r9d
41 C1 E8 18          shr         r8d,18h
```
</details>
<details><summary>Example 2</summary>

Before:
```
B9 00 00 00 00       mov         ecx,0
45 8B C1             mov         r8d,r9d
49 D3 E8             shr         r8,cl
```
After:
```
45 8B C1             mov         r8d,r9d
```
</details>
<details><summary>Example 3</summary>

Before:
```
B9 F8 FF FF FF       mov         ecx,0FFFFFFF8h
45 8B C1             mov         r8d,r9d
49 D3 E8             shr         r8,cl
```
After:
Nothing, register is set to constant zero.
</details>

---
**slwx**

<details><summary>Example 1</summary>

Before:
```
B9 18 00 00 00       mov         ecx,18h
41 8B F7             mov         esi,r15d
48 D3 E6             shl         rsi,cl
8B F6                mov         esi,esi
```
After:
```
41 8B CF             mov         ecx,r15d
C1 E1 18             shl         ecx,18h
```
</details>
<details><summary>Example 2</summary>

Before:
```
BE 00 00 00 00       mov         esi,0
8B CE                mov         ecx,esi
41 8B F3             mov         esi,r11d
48 D3 E6             shl         rsi,cl
8B F6                mov         esi,esi
```
After:
```
41 8B FB             mov         edi,r11d
```
</details>
<details><summary>Example 3</summary>

Before:
```
BE F8 FF FF FF       mov         esi,0FFFFFFF8h
8B CE                mov         ecx,esi
41 8B F4             mov         esi,r12d
48 D3 E6             shl         rsi,cl
8B F6                mov         esi,esi
```
After:
Nothing, register is set to constant zero.
</details>

---

**srawx**
<details><summary>Example 1</summary>

Before:
```
B9 F0 FF FF FF       mov         ecx,0FFFFFFF0h
8B F7                mov         esi,edi
48 C1 E6 20          shl         rsi,20h
48 D3 FE             sar         rsi,cl
8B C6                mov         eax,esi
48 C1 EE 20          shr         rsi,20h
85 F0                test        eax,esi
0F 95 45 58          setne       byte ptr [rbp+58h]
```
After:
```
8B F7                mov         esi,edi
C1 FE 1F             sar         esi,1Fh
0F 95 45 58          setne       byte ptr [rbp+58h]
```
</details>
<details><summary>Example 2</summary>

Before:
```
B9 00 00 00 00       mov         ecx,0
49 C1 E5 20          shl         r13,20h
49 D3 FD             sar         r13,cl
41 8B C5             mov         eax,r13d
49 C1 ED 20          shr         r13,20h
44 85 E8             test        eax,r13d
0F 95 45 58          setne       byte ptr [rbp+58h]
```
After:
```
C6 45 58 00          mov         byte ptr [rbp+58h],0
```
</details>
<details><summary>Example 3</summary>

Before:
```
B9 02 00 00 00       mov         ecx,2
48 C1 E7 20          shl         rdi,20h
48 D3 FF             sar         rdi,cl
48 C1 EF 20          shr         rdi,20h
```
After:
```
C1 FF 02             sar         edi,2
```
</details>
<details><summary>Example 4</summary>

Before:
```
B9 02 00 00 00       mov         ecx,2
49 C1 E5 20          shl         r13,20h
49 D3 FD             sar         r13,cl
41 8B C5             mov         eax,r13d
49 C1 ED 20          shr         r13,20h
44 85 E8             test        eax,r13d
0F 95 45 58          setne       byte ptr [rbp+58h]
```

After:
```
41 8B C5             mov         eax,r13d
41 C1 FD 02          sar         r13d,2
C1 E0 1E             shl         eax,1Eh
44 85 E8             test        eax,r13d
0F 95 45 58          setne       byte ptr [rbp+58h]
```
</details>

---

**srawix**
<details><summary>Example</summary>

Before:
```
B8 00 00 00 00       mov         eax,0
8B F0                mov         esi,eax
C1 E8 1F             shr         eax,1Fh
23 C6                and         eax,esi
D1 FE                sar         esi,1
88 45 58             mov         byte ptr [rbp+58h],al
```
After:
```
C6 45 58 00          mov         byte ptr [rbp+58h],0
```
</details>

---

**rlwnmx**
<details><summary>Example</summary>

Before:
```
B9 02 00 00 00       mov         ecx,2
41 8B F5             mov         esi,r13d
D3 C6                rol         esi,cl
83 E6 01             and         esi,1
```
After:
```
41 8B F5             mov         esi,r13d
C1 C6 02             rol         esi,2
83 E6 01             and         esi,1
```
</details>