### PR TITLE
Core/Movie: Fix a likely out-of-bounds read for PanicAlertT

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -227,10 +227,10 @@ void Init(const BootParameters& boot)
     ReadHeader();
     std::thread md5thread(CheckMD5);
     md5thread.detach();
-    if (strncmp(tmpHeader.gameID.data(), SConfig::GetInstance().GetGameID().c_str(), 6))
+    if (tmpHeader.GetGameID() == SConfig::GetInstance().GetGameID())
     {
       PanicAlertFmtT("The recorded game ({0}) is not the same as the selected game ({1})",
-                     tmpHeader.gameID.data(), SConfig::GetInstance().GetGameID());
+                     tmpHeader.GetGameID(), SConfig::GetInstance().GetGameID());
       EndPlayInput(false);
     }
   }

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 
@@ -63,6 +64,8 @@ static_assert(sizeof(ControllerState) == 8, "ControllerState should be 8 bytes")
 #pragma pack(push, 1)
 struct DTMHeader
 {
+  std::string_view GetGameID() const { return {gameID.data(), gameID.size()}; }
+
   std::array<u8, 4> filetype;  // Unique Identifier (always "DTM"0x1A)
 
   std::array<char, 6> gameID;  // The Game ID


### PR DESCRIPTION
gameID isn't null terminated since it is just an std::array<char, 6>
and .data() returns a char* so {fmt} would go way beyond the bounds of
the array when it attempts to determine the length of the string.

The fix is to pass a std::string_view to {fmt}. This commit adds
a GetGameID() function that can also be used to simplify
string comparisons.