### PR TITLE
CMake: Pass various /Zc flags to MSVC for consistency with Base.props

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,13 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   add_compile_options(/volatile:iso)
   # Fix non-conformant lambda behavior (constexpr variables shouldn't need capturing)
   add_compile_options(/experimental:newLambdaProcessor)
+  # Fix various other non-conformant behaviors
+  add_compile_options(/Zc:externConstexpr,lambda,preprocessor)
+
+  # Temporarily disable warnings to enable /Zc:preprocessor compatibility with WinSDK headers.
+  add_compile_options(
+    /wd5105 # macro expansion producing 'defined' has undefined behavior
+  )
 
   string(APPEND CMAKE_EXE_LINKER_FLAGS " /NXCOMPAT")
 else()


### PR DESCRIPTION
https://github.com/dolphin-emu/dolphin/pull/9037/commits/969ea6e4f54f1021edaa8f565e20b17a78f6f753

Fixes non-conformant handling of `__VA_ARGS__`.