### PR TITLE
FrameDump: Re-add call to av_register_all

### DIFF
--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -69,6 +69,9 @@ void InitAVCodec()
   static bool first_run = true;
   if (first_run)
   {
+#if LIBAVCODEC_VERSION_MICRO >= 100 && LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
+    av_register_all();
+#endif
     // TODO: We never call avformat_network_deinit.
     avformat_network_init();
     first_run = false;


### PR DESCRIPTION
This was removed in PR #9188. We still need this for the ffmpeg version we're using on Windows.