### PR TITLE
FrameDump: Start timing at 0 ticks when starting from boot

### DIFF
--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -47,7 +47,7 @@ struct FrameDumpContext
   int width = 0;
   int height = 0;
 
-  u64 first_frame_ticks = 0;
+  u64 start_ticks = 0;
   u32 savestate_index = 0;
 
   bool gave_vfr_warning = false;
@@ -111,7 +111,7 @@ std::string GetDumpPath(const std::string& extension, std::time_t time, u32 inde
 
 }  // namespace
 
-bool FrameDump::Start(int w, int h)
+bool FrameDump::Start(int w, int h, u64 start_ticks)
 {
   if (IsStarted())
     return true;
@@ -120,15 +120,18 @@ bool FrameDump::Start(int w, int h)
   m_start_time = std::time(nullptr);
   m_file_index = 0;
 
-  return PrepareEncoding(w, h);
+  return PrepareEncoding(w, h, start_ticks, m_savestate_index);
 }
 
-bool FrameDump::PrepareEncoding(int w, int h)
+bool FrameDump::PrepareEncoding(int w, int h, u64 start_ticks, u32 savestate_index)
 {
   m_context = std::make_unique<FrameDumpContext>();
 
   m_context->width = w;
   m_context->height = h;
+
+  m_context->start_ticks = start_ticks;
+  m_context->savestate_index = savestate_index;
 
   InitAVCodec();
   const bool success = CreateVideoFile();
@@ -279,14 +282,8 @@ void FrameDump::AddFrame(const FrameData& frame)
   if (!IsStarted())
     return;
 
-  if (IsFirstFrameInCurrentFile())
-  {
-    m_context->first_frame_ticks = frame.state.ticks;
-    m_context->savestate_index = frame.state.savestate_index;
-  }
-
-  // Calculate presentation timestamp from current ticks since first frame ticks.
-  const s64 pts = av_rescale_q(frame.state.ticks - m_context->first_frame_ticks,
+  // Calculate presentation timestamp from ticks since start.
+  const s64 pts = av_rescale_q(frame.state.ticks - m_context->start_ticks,
                                AVRational{1, int(SystemTimers::GetTicksPerSecond())},
                                m_context->codec->time_base);
 
@@ -300,7 +297,7 @@ void FrameDump::AddFrame(const FrameData& frame)
     else if (pts > m_context->last_pts + 1 && !m_context->gave_vfr_warning)
     {
       WARN_LOG_FMT(FRAMEDUMP, "PTS delta > 1. Resulting file will have variable frame rate. "
-                              "Subsequent occurances will not be reported.");
+                              "Subsequent occurrences will not be reported.");
       m_context->gave_vfr_warning = true;
     }
   }
@@ -447,14 +444,15 @@ void FrameDump::CheckForConfigChange(const FrameData& frame)
   {
     Stop();
     ++m_file_index;
-    PrepareEncoding(frame.width, frame.height);
+    PrepareEncoding(frame.width, frame.height, frame.state.ticks, frame.state.savestate_index);
   }
 }
 
-FrameDump::FrameState FrameDump::FetchState(u64 ticks) const
+FrameDump::FrameState FrameDump::FetchState(u64 ticks, int frame_number) const
 {
   FrameState state;
   state.ticks = ticks;
+  state.frame_number = frame_number;
   state.savestate_index = m_savestate_index;
 
   const auto time_base = GetTimeBaseForCurrentRefreshRate();

--- a/Source/Core/VideoCommon/FrameDump.h
+++ b/Source/Core/VideoCommon/FrameDump.h
@@ -23,6 +23,7 @@ public:
   struct FrameState
   {
     u64 ticks = 0;
+    int frame_number = 0;
     u32 savestate_index = 0;
     int refresh_rate_num = 0;
     int refresh_rate_den = 0;
@@ -37,16 +38,16 @@ public:
     FrameState state;
   };
 
-  bool Start(int w, int h);
+  bool Start(int w, int h, u64 start_ticks);
   void AddFrame(const FrameData&);
   void Stop();
   void DoState(PointerWrap&);
   bool IsStarted() const;
-  FrameState FetchState(u64 ticks) const;
+  FrameState FetchState(u64 ticks, int frame_number) const;
 
 private:
   bool IsFirstFrameInCurrentFile() const;
-  bool PrepareEncoding(int w, int h);
+  bool PrepareEncoding(int w, int h, u64 start_ticks, u32 savestate_index);
   bool CreateVideoFile();
   void CloseVideoFile();
   void CheckForConfigChange(const FrameData&);
@@ -68,7 +69,7 @@ private:
 inline FrameDump::FrameDump() = default;
 inline FrameDump::~FrameDump() = default;
 
-inline FrameDump::FrameState FrameDump::FetchState(u64 ticks) const
+inline FrameDump::FrameState FrameDump::FetchState(u64 ticks, int frame_number) const
 {
   return {};
 }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -411,7 +411,7 @@ private:
 
   // Fills the frame dump staging texture with the current XFB texture.
   void DumpCurrentFrame(const AbstractTexture* src_texture,
-                        const MathUtil::Rectangle<int>& src_rect, u64 ticks);
+                        const MathUtil::Rectangle<int>& src_rect, u64 ticks, int frame_number);
 
   // Asynchronously encodes the specified pointer of frame data to the frame dump.
   void DumpFrameData(const u8* data, int w, int h, int stride);


### PR DESCRIPTION
@vadosnaprimer Does this fix your "frame 0" A/V sync problem?