### PR TITLE
IOFile: Replace fprintf with WriteString/fmt.

### DIFF
--- a/Source/Core/Common/File.h
+++ b/Source/Core/Common/File.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <string>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 
@@ -66,6 +67,8 @@ public:
   {
     return WriteArray(reinterpret_cast<const char*>(data), length);
   }
+
+  bool WriteString(std::string_view str) { return WriteBytes(str.data(), str.size()); }
 
   bool IsOpen() const { return nullptr != m_file; }
   // m_good is set to false when a read, write or other function fails

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -473,7 +473,7 @@ static void ImHere()
     if (!f)
       f.Open("log64.txt", "w");
 
-    fprintf(f.GetHandle(), "%08x\n", PC);
+    f.WriteString(fmt::format("{0:08x}\n", PC));
   }
   if (been_here.find(PC) != been_here.end())
   {

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -16,6 +16,8 @@
 #include "Common/PerformanceCounter.h"
 #endif
 
+#include <fmt/format.h>
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/File.h"
@@ -103,17 +105,19 @@ void WriteProfileResults(const std::string& filename)
     PanicAlert("Failed to open %s", filename.c_str());
     return;
   }
-  fprintf(f.GetHandle(), "origAddr\tblkName\trunCount\tcost\ttimeCost\tpercent\ttimePercent\tOvAlli"
-                         "nBlkTime(ms)\tblkCodeSize\n");
+  f.WriteString("origAddr\tblkName\trunCount\tcost\ttimeCost\tpercent\ttimePercent\tOvAllinBlkTime("
+                "ms)\tblkCodeSize\n");
   for (auto& stat : prof_stats.block_stats)
   {
     std::string name = g_symbolDB.GetDescription(stat.addr);
     double percent = 100.0 * (double)stat.cost / (double)prof_stats.cost_sum;
     double timePercent = 100.0 * (double)stat.tick_counter / (double)prof_stats.timecost_sum;
-    fprintf(f.GetHandle(),
-            "%08x\t%s\t%" PRIu64 "\t%" PRIu64 "\t%" PRIu64 "\t%.2f\t%.2f\t%.2f\t%i\n", stat.addr,
-            name.c_str(), stat.run_count, stat.cost, stat.tick_counter, percent, timePercent,
-            (double)stat.tick_counter * 1000.0 / (double)prof_stats.countsPerSec, stat.block_size);
+    f.WriteString(fmt::format("{0:08x}\t{1}\t{2}\t{3}\t{4}\t{5:.2f}\t{6:.2f}\t{7:.2f}\t{8}\n",
+                              stat.addr, name, stat.run_count, stat.cost, stat.tick_counter,
+                              percent, timePercent,
+                              static_cast<double>(stat.tick_counter) * 1000.0 /
+                                  static_cast<double>(prof_stats.countsPerSec),
+                              stat.block_size));
   }
 }
 

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -171,8 +171,8 @@ void LogCompiledInstructions()
     GekkoOPInfo* pInst = m_allInstructions[i];
     if (pInst->compileCount > 0)
     {
-      fprintf(f.GetHandle(), "%s\t%i\t%" PRId64 "\t%08x\n", pInst->opname, pInst->compileCount,
-              pInst->runCount, pInst->lastUse);
+      f.WriteString(fmt::format("{0}\t{1}\t{2}\t{3:08x}\n", pInst->opname, pInst->compileCount,
+                                pInst->runCount, pInst->lastUse));
     }
   }
 
@@ -182,8 +182,8 @@ void LogCompiledInstructions()
     GekkoOPInfo* pInst = m_allInstructions[i];
     if (pInst->compileCount == 0)
     {
-      fprintf(f.GetHandle(), "%s\t%i\t%" PRId64 "\n", pInst->opname, pInst->compileCount,
-              pInst->runCount);
+      f.WriteString(
+          fmt::format("{0}\t{1}\t{2}\n", pInst->opname, pInst->compileCount, pInst->runCount));
     }
   }
 
@@ -191,7 +191,7 @@ void LogCompiledInstructions()
   f.Open(fmt::format("{}" OP_TO_LOG "_at{}.txt", File::GetUserPath(D_LOGS_IDX), time), "w");
   for (auto& rsplocation : rsplocations)
   {
-    fprintf(f.GetHandle(), OP_TO_LOG ": %08x\n", rsplocation);
+    f.WriteString(fmt::format(OP_TO_LOG ": {0:08x}\n", rsplocation));
   }
 #endif
 

--- a/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <sstream>
 
+#include <fmt/format.h>
+
 #include "Common/File.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
@@ -70,9 +72,9 @@ bool CSVSignatureDB::Save(const std::string& file_path) const
   {
     // The object name/location are unused for the time being.
     // To be implemented.
-    fprintf(f.GetHandle(), "%08x\t%08x\t%s\t%s\t%s\n", func.first, func.second.size,
-            func.second.name.c_str(), func.second.object_location.c_str(),
-            func.second.object_name.c_str());
+    f.WriteString(fmt::format("{0:08x}\t{1:08x}\t{2}\t{3}\t{4}\n", func.first, func.second.size,
+                              func.second.name, func.second.object_location,
+                              func.second.object_name));
   }
 
   INFO_LOG(SYMBOLS, "CSV database save successful");


### PR DESCRIPTION
This actually started as an attempt to remove the `GetHandle()` method, but I figured this makes as a decent PR on its own.