### PR TITLE
Core: Convert logging over to fmt pt.5

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -265,10 +265,9 @@ bool TMemCheck::Action(Common::DebugInterface* debug_interface, u32 value, u32 a
   {
     if (log_on_hit)
     {
-      NOTICE_LOG(MEMMAP, "MBP %08x (%s) %s%zu %0*x at %08x (%s)", pc,
-                 debug_interface->GetDescription(pc).c_str(), write ? "Write" : "Read", size * 8,
-                 static_cast<int>(size * 2), value, addr,
-                 debug_interface->GetDescription(addr).c_str());
+      NOTICE_LOG_FMT(MEMMAP, "MBP {:08x} ({}) {}{} {:x} at {:08x} ({})", pc,
+                     debug_interface->GetDescription(pc), write ? "Write" : "Read", size * 8, value,
+                     addr, debug_interface->GetDescription(addr));
     }
     if (break_on_hit)
       return true;

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -101,7 +101,7 @@ void CachedInterpreter::ExecuteOneBlock()
       break;
 
     default:
-      ERROR_LOG(POWERPC, "Unknown CachedInterpreter Instruction: %d", static_cast<int>(code->type));
+      ERROR_LOG_FMT(POWERPC, "Unknown CachedInterpreter Instruction: {}", code->type);
       break;
     }
   }
@@ -220,7 +220,7 @@ void CachedInterpreter::Jit(u32 address)
     NPC = nextPC;
     PowerPC::ppcState.Exceptions |= EXCEPTION_ISI;
     PowerPC::CheckExceptions();
-    WARN_LOG(POWERPC, "ISI exception at 0x%08x", nextPC);
+    WARN_LOG_FMT(POWERPC, "ISI exception at {:#010x}", nextPC);
     return;
   }
 

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -57,6 +57,11 @@ static gdb_bp_t bp_r[GDB_MAX_BP];
 static gdb_bp_t bp_w[GDB_MAX_BP];
 static gdb_bp_t bp_a[GDB_MAX_BP];
 
+static const char* CommandBufferAsString()
+{
+  return reinterpret_cast<const char*>(cmd_bfr);
+}
+
 // private helpers
 static u8 hex2char(u8 hex)
 {
@@ -67,7 +72,7 @@ static u8 hex2char(u8 hex)
   else if (hex >= 'A' && hex <= 'F')
     return hex - 'A' + 0xa;
 
-  ERROR_LOG(GDB_STUB, "Invalid nibble: %c (%02x)", hex, hex);
+  ERROR_LOG_FMT(GDB_STUB, "Invalid nibble: {} ({:02x})", static_cast<char>(hex), hex);
   return 0;
 }
 
@@ -82,11 +87,9 @@ static u8 nibble2hex(u8 n)
 
 static void mem2hex(u8* dst, u8* src, u32 len)
 {
-  u8 tmp;
-
   while (len-- > 0)
   {
-    tmp = *src++;
+    const u8 tmp = *src++;
     *dst++ = nibble2hex(tmp >> 4);
     *dst++ = nibble2hex(tmp);
   }
@@ -103,13 +106,12 @@ static void hex2mem(u8* dst, u8* src, u32 len)
 
 static u8 gdb_read_byte()
 {
-  ssize_t res;
   u8 c = '+';
 
-  res = recv(sock, &c, 1, MSG_WAITALL);
+  const ssize_t res = recv(sock, &c, 1, MSG_WAITALL);
   if (res != 1)
   {
-    ERROR_LOG(GDB_STUB, "recv failed : %ld", res);
+    ERROR_LOG_FMT(GDB_STUB, "recv failed : {}", res);
     gdb_deinit();
   }
 
@@ -190,7 +192,7 @@ static void gdb_bp_remove(u32 type, u32 addr, u32 len)
     p = gdb_bp_find(type, addr, len);
     if (p != nullptr)
     {
-      DEBUG_LOG(GDB_STUB, "gdb: removed a breakpoint: %08x bytes at %08x", len, addr);
+      DEBUG_LOG_FMT(GDB_STUB, "gdb: removed a breakpoint: {:08x} bytes at {:08x}", len, addr);
       p->active = 0;
       memset(p, 0, sizeof(gdb_bp_t));
     }
@@ -218,32 +220,27 @@ static int gdb_bp_check(u32 addr, u32 type)
 static void gdb_nak()
 {
   const char nak = GDB_STUB_NAK;
-  ssize_t res;
+  const ssize_t res = send(sock, &nak, 1, 0);
 
-  res = send(sock, &nak, 1, 0);
   if (res != 1)
-    ERROR_LOG(GDB_STUB, "send failed");
+    ERROR_LOG_FMT(GDB_STUB, "send failed");
 }
 
 static void gdb_ack()
 {
   const char ack = GDB_STUB_ACK;
-  ssize_t res;
+  const ssize_t res = send(sock, &ack, 1, 0);
 
-  res = send(sock, &ack, 1, 0);
   if (res != 1)
-    ERROR_LOG(GDB_STUB, "send failed");
+    ERROR_LOG_FMT(GDB_STUB, "send failed");
 }
 
 static void gdb_read_command()
 {
-  u8 c;
-  u8 chk_read, chk_calc;
-
   cmd_len = 0;
   memset(cmd_bfr, 0, sizeof cmd_bfr);
 
-  c = gdb_read_byte();
+  const u8 c = gdb_read_byte();
   if (c == '+')
   {
     // ignore ack
@@ -257,7 +254,7 @@ static void gdb_read_command()
   }
   else if (c != GDB_STUB_START)
   {
-    DEBUG_LOG(GDB_STUB, "gdb: read invalid byte %02x", c);
+    DEBUG_LOG_FMT(GDB_STUB, "gdb: read invalid byte {:02x}", c);
     return;
   }
 
@@ -266,29 +263,30 @@ static void gdb_read_command()
     cmd_bfr[cmd_len++] = c;
     if (cmd_len == sizeof cmd_bfr)
     {
-      ERROR_LOG(GDB_STUB, "gdb: cmd_bfr overflow");
+      ERROR_LOG_FMT(GDB_STUB, "gdb: cmd_bfr overflow");
       gdb_nak();
       return;
     }
   }
 
-  chk_read = hex2char(gdb_read_byte()) << 4;
+  u8 chk_read = hex2char(gdb_read_byte()) << 4;
   chk_read |= hex2char(gdb_read_byte());
 
-  chk_calc = gdb_calc_chksum();
+  const u8 chk_calc = gdb_calc_chksum();
 
   if (chk_calc != chk_read)
   {
-    ERROR_LOG(GDB_STUB,
-              "gdb: invalid checksum: calculated %02x and read %02x for $%s# (length: %d)",
-              chk_calc, chk_read, cmd_bfr, cmd_len);
+    ERROR_LOG_FMT(GDB_STUB,
+                  "gdb: invalid checksum: calculated {:02x} and read {:02x} for ${}# (length: {})",
+                  chk_calc, chk_read, CommandBufferAsString(), cmd_len);
     cmd_len = 0;
 
     gdb_nak();
     return;
   }
 
-  DEBUG_LOG(GDB_STUB, "gdb: read command %c with a length of %d: %s", cmd_bfr[0], cmd_len, cmd_bfr);
+  DEBUG_LOG_FMT(GDB_STUB, "gdb: read command {} with a length of {}: {}",
+                static_cast<char>(cmd_bfr[0]), cmd_len, CommandBufferAsString());
   gdb_ack();
 }
 
@@ -305,7 +303,7 @@ static int gdb_data_available()
 
   if (select(sock + 1, fds, nullptr, nullptr, &t) < 0)
   {
-    ERROR_LOG(GDB_STUB, "select failed");
+    ERROR_LOG_FMT(GDB_STUB, "select failed");
     return 0;
   }
 
@@ -316,11 +314,6 @@ static int gdb_data_available()
 
 static void gdb_reply(const char* reply)
 {
-  u8 chk;
-  u32 left;
-  u8* ptr;
-  int n;
-
   if (!gdb_active())
     return;
 
@@ -328,28 +321,28 @@ static void gdb_reply(const char* reply)
 
   cmd_len = strlen(reply);
   if (cmd_len + 4 > sizeof cmd_bfr)
-    ERROR_LOG(GDB_STUB, "cmd_bfr overflow in gdb_reply");
+    ERROR_LOG_FMT(GDB_STUB, "cmd_bfr overflow in gdb_reply");
 
   memcpy(cmd_bfr + 1, reply, cmd_len);
 
   cmd_len++;
-  chk = gdb_calc_chksum();
+  const u8 chk = gdb_calc_chksum();
   cmd_len--;
   cmd_bfr[0] = GDB_STUB_START;
   cmd_bfr[cmd_len + 1] = GDB_STUB_END;
   cmd_bfr[cmd_len + 2] = nibble2hex(chk >> 4);
   cmd_bfr[cmd_len + 3] = nibble2hex(chk);
 
-  DEBUG_LOG(GDB_STUB, "gdb: reply (len: %d): %s", cmd_len, cmd_bfr);
+  DEBUG_LOG_FMT(GDB_STUB, "gdb: reply (len: {}): {}", cmd_len, CommandBufferAsString());
 
-  ptr = cmd_bfr;
-  left = cmd_len + 4;
+  u8* ptr = cmd_bfr;
+  u32 left = cmd_len + 4;
   while (left > 0)
   {
-    n = send(sock, ptr, left, 0);
+    const int n = send(sock, ptr, left, 0);
     if (n < 0)
     {
-      ERROR_LOG(GDB_STUB, "gdb: send failed");
+      ERROR_LOG_FMT(GDB_STUB, "gdb: send failed");
       return gdb_deinit();
     }
     left -= n;
@@ -359,7 +352,7 @@ static void gdb_reply(const char* reply)
 
 static void gdb_handle_query()
 {
-  DEBUG_LOG(GDB_STUB, "gdb: query '%s'", cmd_bfr + 1);
+  DEBUG_LOG_FMT(GDB_STUB, "gdb: query '{}'", CommandBufferAsString() + 1);
 
   if (!strcmp((const char*)(cmd_bfr + 1), "TStatus"))
   {
@@ -574,7 +567,7 @@ static void gdb_read_mem()
   len = 0;
   while (i < cmd_len)
     len = (len << 4) | hex2char(cmd_bfr[i++]);
-  DEBUG_LOG(GDB_STUB, "gdb: read memory: %08x bytes from %08x", len, addr);
+  DEBUG_LOG_FMT(GDB_STUB, "gdb: read memory: {:08x} bytes from {:08x}", len, addr);
 
   if (len * 2 > sizeof reply)
     gdb_reply("E01");
@@ -600,7 +593,7 @@ static void gdb_write_mem()
   len = 0;
   while (cmd_bfr[i] != ':')
     len = (len << 4) | hex2char(cmd_bfr[i++]);
-  DEBUG_LOG(GDB_STUB, "gdb: write memory: %08x bytes to %08x", len, addr);
+  DEBUG_LOG_FMT(GDB_STUB, "gdb: write memory: {:08x} bytes to {:08x}", len, addr);
 
   u8* dst = Memory::GetPointer(addr);
   if (!dst)
@@ -637,7 +630,8 @@ bool gdb_add_bp(u32 type, u32 addr, u32 len)
   bp->addr = addr;
   bp->len = len;
 
-  DEBUG_LOG(GDB_STUB, "gdb: added %d breakpoint: %08x bytes at %08x", type, bp->len, bp->addr);
+  DEBUG_LOG_FMT(GDB_STUB, "gdb: added {} breakpoint: {:08x} bytes at {:08x}", type, bp->len,
+                bp->addr);
   return true;
 }
 
@@ -825,7 +819,6 @@ void gdb_init(u32 port)
 static void gdb_init_generic(int domain, const sockaddr* server_addr, socklen_t server_addrlen,
                              sockaddr* client_addr, socklen_t* client_addrlen)
 {
-  int on;
 #ifdef _WIN32
   WSAStartup(MAKEWORD(2, 2), &InitData);
 #endif
@@ -837,24 +830,24 @@ static void gdb_init_generic(int domain, const sockaddr* server_addr, socklen_t 
 
   tmpsock = socket(domain, SOCK_STREAM, 0);
   if (tmpsock == -1)
-    ERROR_LOG(GDB_STUB, "Failed to create gdb socket");
+    ERROR_LOG_FMT(GDB_STUB, "Failed to create gdb socket");
 
-  on = 1;
+  int on = 1;
   if (setsockopt(tmpsock, SOL_SOCKET, SO_REUSEADDR, &on, sizeof on) < 0)
-    ERROR_LOG(GDB_STUB, "Failed to setsockopt");
+    ERROR_LOG_FMT(GDB_STUB, "Failed to setsockopt");
 
   if (bind(tmpsock, server_addr, server_addrlen) < 0)
-    ERROR_LOG(GDB_STUB, "Failed to bind gdb socket");
+    ERROR_LOG_FMT(GDB_STUB, "Failed to bind gdb socket");
 
   if (listen(tmpsock, 1) < 0)
-    ERROR_LOG(GDB_STUB, "Failed to listen to gdb socket");
+    ERROR_LOG_FMT(GDB_STUB, "Failed to listen to gdb socket");
 
-  INFO_LOG(GDB_STUB, "Waiting for gdb to connect...");
+  INFO_LOG_FMT(GDB_STUB, "Waiting for gdb to connect...");
 
   sock = accept(tmpsock, client_addr, client_addrlen);
   if (sock < 0)
-    ERROR_LOG(GDB_STUB, "Failed to accept gdb client");
-  INFO_LOG(GDB_STUB, "Client connected.");
+    ERROR_LOG_FMT(GDB_STUB, "Failed to accept gdb client");
+  INFO_LOG_FMT(GDB_STUB, "Client connected.");
 
   close(tmpsock);
   tmpsock = -1;
@@ -908,7 +901,7 @@ int gdb_bp_x(u32 addr)
   {
     step_break = 0;
 
-    DEBUG_LOG(GDB_STUB, "Step was successful.");
+    DEBUG_LOG_FMT(GDB_STUB, "Step was successful.");
     return 1;
   }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -128,11 +128,11 @@ void Interpreter::subfic(UGeckoInstruction inst)
 
 void Interpreter::twi(UGeckoInstruction inst)
 {
-  s32 a = rGPR[inst.RA];
-  s32 b = inst.SIMM_16;
-  s32 TO = inst.TO;
+  const s32 a = rGPR[inst.RA];
+  const s32 b = inst.SIMM_16;
+  const s32 TO = inst.TO;
 
-  DEBUG_LOG(POWERPC, "twi rA %x SIMM %x TO %0x", a, b, TO);
+  DEBUG_LOG_FMT(POWERPC, "twi rA {:x} SIMM {:x} TO {:x}", a, b, TO);
 
   if (((a < b) && (TO & 0x10)) || ((a > b) && (TO & 0x08)) || ((a == b) && (TO & 0x04)) ||
       (((u32)a < (u32)b) && (TO & 0x02)) || (((u32)a > (u32)b) && (TO & 0x01)))
@@ -371,11 +371,11 @@ void Interpreter::srwx(UGeckoInstruction inst)
 
 void Interpreter::tw(UGeckoInstruction inst)
 {
-  s32 a = rGPR[inst.RA];
-  s32 b = rGPR[inst.RB];
-  s32 TO = inst.TO;
+  const s32 a = rGPR[inst.RA];
+  const s32 b = rGPR[inst.RB];
+  const s32 TO = inst.TO;
 
-  DEBUG_LOG(POWERPC, "tw rA %0x rB %0x TO %0x", a, b, TO);
+  DEBUG_LOG_FMT(POWERPC, "tw rA {:x} rB {:x} TO {:x}", a, b, TO);
 
   if (((a < b) && (TO & 0x10)) || ((a > b) && (TO & 0x08)) || ((a == b) && (TO & 0x04)) ||
       (((u32)a < (u32)b) && (TO & 0x02)) || (((u32)a > (u32)b) && (TO & 0x01)))

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -268,8 +268,8 @@ void Interpreter::lmw(UGeckoInstruction inst)
 
     if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
     {
-      PanicAlert("DSI exception in lmw");
-      NOTICE_LOG(POWERPC, "DSI exception in lmw");
+      PanicAlertFmt("DSI exception in lmw");
+      NOTICE_LOG_FMT(POWERPC, "DSI exception in lmw");
       return;
     }
     else
@@ -295,8 +295,8 @@ void Interpreter::stmw(UGeckoInstruction inst)
     PowerPC::Write_U32(rGPR[i], address);
     if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
     {
-      PanicAlert("DSI exception in stmw");
-      NOTICE_LOG(POWERPC, "DSI exception in stmw");
+      PanicAlertFmt("DSI exception in stmw");
+      NOTICE_LOG_FMT(POWERPC, "DSI exception in stmw");
       return;
     }
   }
@@ -689,7 +689,7 @@ void Interpreter::lswx(UGeckoInstruction inst)
     // Not64 (Homebrew N64 Emulator for Wii) triggers the following case.
     if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
     {
-      NOTICE_LOG(POWERPC, "DSI exception in lswx");
+      NOTICE_LOG_FMT(POWERPC, "DSI exception in lswx");
       return;
     }
     rGPR[reg] |= temp_value;
@@ -878,7 +878,7 @@ void Interpreter::lswi(UGeckoInstruction inst)
     const u32 temp_value = PowerPC::Read_U8(EA) << (24 - i);
     if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
     {
-      PanicAlert("DSI exception in lsw.");
+      PanicAlertFmt("DSI exception in lsw.");
       return;
     }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -293,7 +293,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
   {
   case SPR_TL:
   case SPR_TU:
-    PanicAlert("Illegal Write to TL/TU");
+    PanicAlertFmt("Illegal Write to TL/TU");
     break;
 
   case SPR_TL_W:
@@ -317,16 +317,16 @@ void Interpreter::mtspr(UGeckoInstruction inst)
     old_hid0.Hex = old_value;
     if (HID0.ICE != old_hid0.ICE)
     {
-      INFO_LOG(POWERPC, "Instruction Cache Enable (HID0.ICE) = %d", (int)HID0.ICE);
+      INFO_LOG_FMT(POWERPC, "Instruction Cache Enable (HID0.ICE) = {}", HID0.ICE);
     }
     if (HID0.ILOCK != old_hid0.ILOCK)
     {
-      INFO_LOG(POWERPC, "Instruction Cache Lock (HID0.ILOCK) = %d", (int)HID0.ILOCK);
+      INFO_LOG_FMT(POWERPC, "Instruction Cache Lock (HID0.ILOCK) = {}", HID0.ILOCK);
     }
     if (HID0.ICFI)
     {
       HID0.ICFI = 0;
-      INFO_LOG(POWERPC, "Flush Instruction Cache! ICE=%d", (int)HID0.ICE);
+      INFO_LOG_FMT(POWERPC, "Flush Instruction Cache! ICE={}", HID0.ICE);
       // this is rather slow
       // most games do it only once during initialization
       PowerPC::ppcState.iCache.Reset();
@@ -352,7 +352,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
   case SPR_HID4:
     if (old_value != rSPR(index))
     {
-      INFO_LOG(POWERPC, "HID4 updated %x %x", old_value, rSPR(index));
+      INFO_LOG_FMT(POWERPC, "HID4 updated {:x} {:x}", old_value, rSPR(index));
       PowerPC::IBATUpdated();
       PowerPC::DBATUpdated();
     }
@@ -399,7 +399,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
   case SPR_DEC:
     if (!(old_value >> 31) && (rGPR[inst.RD] >> 31))  // top bit from 0 to 1
     {
-      INFO_LOG(POWERPC, "Software triggered Decrementer exception");
+      INFO_LOG_FMT(POWERPC, "Software triggered Decrementer exception");
       PowerPC::ppcState.Exceptions |= EXCEPTION_DECREMENTER;
     }
     SystemTimers::DecrementerSet();
@@ -432,7 +432,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
   case SPR_DBAT7U:
     if (old_value != rSPR(index))
     {
-      INFO_LOG(POWERPC, "DBAT updated %u %x %x", index, old_value, rSPR(index));
+      INFO_LOG_FMT(POWERPC, "DBAT updated {} {:x} {:x}", index, old_value, rSPR(index));
       PowerPC::DBATUpdated();
     }
     break;
@@ -455,7 +455,7 @@ void Interpreter::mtspr(UGeckoInstruction inst)
   case SPR_IBAT7U:
     if (old_value != rSPR(index))
     {
-      INFO_LOG(POWERPC, "IBAT updated %u %x %x", index, old_value, rSPR(index));
+      INFO_LOG_FMT(POWERPC, "IBAT updated {} {:x} {:x}", index, old_value, rSPR(index));
       PowerPC::IBATUpdated();
     }
     break;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -404,7 +404,7 @@ void Jit64::fsign(UGeckoInstruction inst)
            packed);
     break;
   default:
-    PanicAlert("fsign bleh");
+    PanicAlertFmt("fsign bleh");
     break;
   }
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -401,7 +401,7 @@ void Jit64::DoMergedBranch()
   }
   else
   {
-    PanicAlert("WTF invalid branch");
+    PanicAlertFmt("WTF invalid branch");
   }
 }
 
@@ -516,7 +516,7 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 
   default:
     signedCompare = false;  // silence compiler warning
-    PanicAlert("cmpXX");
+    PanicAlertFmt("cmpXX");
   }
 
   if (gpr.IsImm(a) && comparand.IsImm())
@@ -689,7 +689,7 @@ void Jit64::boolX(UGeckoInstruction inst)
     }
     else
     {
-      PanicAlert("WTF!");
+      PanicAlertFmt("WTF!");
     }
   }
   else if ((a == s) || (a == b))
@@ -763,7 +763,7 @@ void Jit64::boolX(UGeckoInstruction inst)
     }
     else
     {
-      PanicAlert("WTF");
+      PanicAlertFmt("WTF");
     }
   }
   else
@@ -829,7 +829,7 @@ void Jit64::boolX(UGeckoInstruction inst)
     }
     else
     {
-      PanicAlert("WTF!");
+      PanicAlertFmt("WTF!");
     }
   }
   if (inst.Rc)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -100,12 +100,12 @@ void Jit64::lXXx(UGeckoInstruction inst)
       break;
 
     default:
-      PanicAlert("Invalid instruction");
+      PanicAlertFmt("Invalid instruction");
     }
     break;
 
   default:
-    PanicAlert("Invalid instruction");
+    PanicAlertFmt("Invalid instruction");
   }
 
   // PowerPC has no 8-bit sign extended load, but x86 does, so merge extsb with the load if we find
@@ -150,7 +150,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
   }
   else if (update && ((a == 0) || (d == a)))
   {
-    PanicAlert("Invalid instruction");
+    PanicAlertFmt("Invalid instruction");
   }
   else
   {
@@ -360,7 +360,7 @@ void Jit64::stX(UGeckoInstruction inst)
   bool update = (inst.OPCD & 1) && offset;
 
   if (!a && update)
-    PanicAlert("Invalid stX");
+    PanicAlertFmt("Invalid stX");
 
   int accessSize;
   switch (inst.OPCD & ~1)
@@ -452,7 +452,7 @@ void Jit64::stXx(UGeckoInstruction inst)
     accessSize = 8;
     break;
   default:
-    PanicAlert("stXx: invalid access size");
+    PanicAlertFmt("stXx: invalid access size");
     accessSize = 0;
     break;
   }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -74,7 +74,7 @@ void Jit64::ps_sum(UGeckoInstruction inst)
     }
     break;
   default:
-    PanicAlert("ps_sum WTF!!!");
+    PanicAlertFmt("ps_sum WTF!!!");
   }
   HandleNaNs(inst, Rd, tmp, tmp == XMM1 ? XMM0 : XMM1);
   ForceSinglePrecision(Rd, Rd);
@@ -106,7 +106,7 @@ void Jit64::ps_muls(UGeckoInstruction inst)
     avx_op(&XEmitter::VSHUFPD, &XEmitter::SHUFPD, XMM1, Rc, Rc, 3);
     break;
   default:
-    PanicAlert("ps_muls WTF!!!");
+    PanicAlertFmt("ps_muls WTF!!!");
   }
   if (round_input)
     Force25BitPrecision(XMM1, R(XMM1), XMM0);

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -41,7 +41,7 @@ const u8* TrampolineCache::GenerateTrampoline(const TrampolineInfo& info)
 const u8* TrampolineCache::GenerateReadTrampoline(const TrampolineInfo& info)
 {
   if (GetSpaceLeft() < 1024)
-    PanicAlert("Trampoline cache full");
+    PanicAlertFmt("Trampoline cache full");
 
   const u8* trampoline = GetCodePtr();
 
@@ -57,7 +57,7 @@ const u8* TrampolineCache::GenerateReadTrampoline(const TrampolineInfo& info)
 const u8* TrampolineCache::GenerateWriteTrampoline(const TrampolineInfo& info)
 {
   if (GetSpaceLeft() < 1024)
-    PanicAlert("Trampoline cache full");
+    PanicAlertFmt("Trampoline cache full");
 
   const u8* trampoline = GetCodePtr();
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -78,7 +78,7 @@ bool JitArm64::HandleFault(uintptr_t access_address, SContext* ctx)
   // We can't handle any fault from other threads.
   if (!Core::IsCPUThread())
   {
-    ERROR_LOG(DYNA_REC, "Exception handler - Not on CPU thread");
+    ERROR_LOG_FMT(DYNA_REC, "Exception handler - Not on CPU thread");
     DoBacktrace(access_address, ctx);
     return false;
   }
@@ -97,7 +97,7 @@ bool JitArm64::HandleFault(uintptr_t access_address, SContext* ctx)
 
   if (!success)
   {
-    ERROR_LOG(DYNA_REC, "Exception handler - Unhandled fault");
+    ERROR_LOG_FMT(DYNA_REC, "Exception handler - Unhandled fault");
     DoBacktrace(access_address, ctx);
   }
   return success;
@@ -108,7 +108,7 @@ bool JitArm64::HandleStackFault()
   if (!m_enable_blr_optimization)
     return false;
 
-  ERROR_LOG(POWERPC, "BLR cache disabled due to excessive BL in the emulated program.");
+  ERROR_LOG_FMT(POWERPC, "BLR cache disabled due to excessive BL in the emulated program.");
   m_enable_blr_optimization = false;
 #ifndef _WIN32
   Common::UnWriteProtectMemory(m_stack_base + GUARD_OFFSET, GUARD_SIZE);
@@ -228,8 +228,8 @@ void JitArm64::DoNothing(UGeckoInstruction inst)
 
 void JitArm64::Break(UGeckoInstruction inst)
 {
-  WARN_LOG(DYNA_REC, "Breaking! %08x - Fix me ;)", inst.hex);
-  exit(0);
+  WARN_LOG_FMT(DYNA_REC, "Breaking! {:08x} - Fix me ;)", inst.hex);
+  std::exit(0);
 }
 
 void JitArm64::Cleanup()
@@ -505,8 +505,8 @@ void JitArm64::DumpCode(const u8* start, const u8* end)
 {
   std::string output;
   for (const u8* code = start; code < end; code += sizeof(u32))
-    output += StringFromFormat("%08x", Common::swap32(code));
-  WARN_LOG(DYNA_REC, "Code dump from %p to %p:\n%s", start, end, output.c_str());
+    output += fmt::format("{:08x}", Common::swap32(code));
+  WARN_LOG_FMT(DYNA_REC, "Code dump from {} to {}:\n{}", fmt::ptr(start), fmt::ptr(end), output);
 }
 
 void JitArm64::BeginTimeProfile(JitBlock* b)
@@ -593,7 +593,7 @@ void JitArm64::Jit(u32)
     NPC = nextPC;
     PowerPC::ppcState.Exceptions |= EXCEPTION_ISI;
     PowerPC::CheckExceptions();
-    WARN_LOG(POWERPC, "ISI exception at 0x%08x", nextPC);
+    WARN_LOG_FMT(POWERPC, "ISI exception at {:#010x}", nextPC);
     return;
   }
 
@@ -607,7 +607,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
   if (em_address == 0)
   {
     Core::SetState(Core::State::Paused);
-    WARN_LOG(DYNA_REC, "ERROR: Compiling at 0. LR=%08x CTR=%08x", LR, CTR);
+    WARN_LOG_FMT(DYNA_REC, "ERROR: Compiling at 0. LR={:08x} CTR={:08x}", LR, CTR);
   }
 
   js.isLastInstruction = false;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -24,28 +24,30 @@ using namespace Arm64Gen;
 void JitArm64::DoBacktrace(uintptr_t access_address, SContext* ctx)
 {
   for (int i = 0; i < 30; i += 2)
-    ERROR_LOG(DYNA_REC, "R%d: 0x%016llx\tR%d: 0x%016llx", i, ctx->CTX_REG(i), i + 1,
-              ctx->CTX_REG(i + 1));
-
-  ERROR_LOG(DYNA_REC, "R30: 0x%016llx\tSP: 0x%016llx", ctx->CTX_LR, ctx->CTX_SP);
-
-  ERROR_LOG(DYNA_REC, "Access Address: 0x%016lx", access_address);
-  ERROR_LOG(DYNA_REC, "PC: 0x%016llx", ctx->CTX_PC);
-
-  ERROR_LOG(DYNA_REC, "Memory Around PC");
-
-  std::string pc_memory = "";
-  for (u64 pc = (ctx->CTX_PC - 32); pc < (ctx->CTX_PC + 32); pc += 16)
   {
-    pc_memory += StringFromFormat("%08x%08x%08x%08x", Common::swap32(*(u32*)pc),
-                                  Common::swap32(*(u32*)(pc + 4)), Common::swap32(*(u32*)(pc + 8)),
-                                  Common::swap32(*(u32*)(pc + 12)));
-
-    ERROR_LOG(DYNA_REC, "0x%016" PRIx64 ": %08x %08x %08x %08x", pc, *(u32*)pc, *(u32*)(pc + 4),
-              *(u32*)(pc + 8), *(u32*)(pc + 12));
+    ERROR_LOG_FMT(DYNA_REC, "R{}: {:#018x}\tR{}: {:#018x}", i, ctx->CTX_REG(i), i + 1,
+                  ctx->CTX_REG(i + 1));
   }
 
-  ERROR_LOG(DYNA_REC, "Full block: %s", pc_memory.c_str());
+  ERROR_LOG_FMT(DYNA_REC, "R30: {:#018x}\tSP: {:#018x}", ctx->CTX_LR, ctx->CTX_SP);
+
+  ERROR_LOG_FMT(DYNA_REC, "Access Address: {:#018x}", access_address);
+  ERROR_LOG_FMT(DYNA_REC, "PC: {:#018x}", ctx->CTX_PC);
+
+  ERROR_LOG_FMT(DYNA_REC, "Memory Around PC");
+
+  std::string pc_memory;
+  for (u64 pc = (ctx->CTX_PC - 32); pc < (ctx->CTX_PC + 32); pc += 16)
+  {
+    pc_memory += fmt::format("{:08x}{:08x}{:08x}{:08x}", Common::swap32(*(u32*)pc),
+                             Common::swap32(*(u32*)(pc + 4)), Common::swap32(*(u32*)(pc + 8)),
+                             Common::swap32(*(u32*)(pc + 12)));
+
+    ERROR_LOG_FMT(DYNA_REC, "{:#018x}: {:08x} {:08x} {:08x} {:08x}", pc, *(u32*)pc, *(u32*)(pc + 4),
+                  *(u32*)(pc + 8), *(u32*)(pc + 12));
+  }
+
+  ERROR_LOG_FMT(DYNA_REC, "Full block: {}", pc_memory);
 }
 
 void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, ARM64Reg RS,
@@ -294,9 +296,9 @@ bool JitArm64::HandleFastmemFault(uintptr_t access_address, SContext* ctx)
       !(access_address >= (uintptr_t)Memory::logical_base &&
         access_address < (uintptr_t)Memory::logical_base + 0x100010000))
   {
-    ERROR_LOG(DYNA_REC,
-              "Exception handler - access below memory space. PC: 0x%016llx 0x%016lx < 0x%016lx",
-              ctx->CTX_PC, access_address, (uintptr_t)Memory::physical_base);
+    ERROR_LOG_FMT(DYNA_REC,
+                  "Exception handler - access below memory space. PC: {:#018x} {:#018x} < {:#018x}",
+                  ctx->CTX_PC, access_address, (uintptr_t)Memory::physical_base);
     return false;
   }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -253,7 +253,7 @@ void JitArm64::boolX(UGeckoInstruction inst)
     }
     else
     {
-      PanicAlert("WTF!");
+      PanicAlertFmt("WTF!");
     }
   }
   else
@@ -295,7 +295,7 @@ void JitArm64::boolX(UGeckoInstruction inst)
     }
     else
     {
-      PanicAlert("WTF!");
+      PanicAlertFmt("WTF!");
     }
     if (inst.Rc)
       ComputeRC0(gpr.R(a));

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -41,7 +41,7 @@ ARM64Reg Arm64RegCache::GetReg()
   // Holy cow, how did you run out of registers?
   // We can't return anything reasonable in this case. Return INVALID_REG and watch the failure
   // happen
-  WARN_LOG(DYNA_REC, "All available registers are locked dumb dumb");
+  WARN_LOG_FMT(DYNA_REC, "All available registers are locked dumb dumb");
   return INVALID_REG;
 }
 
@@ -278,7 +278,7 @@ ARM64Reg Arm64GPRCache::R(const GuestRegInfo& guest_reg)
   }
   break;
   default:
-    ERROR_LOG(DYNA_REC, "Invalid OpArg Type!");
+    ERROR_LOG_FMT(DYNA_REC, "Invalid OpArg Type!");
     break;
   }
   // We've got an issue if we end up here

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -70,7 +70,7 @@ void JitArm64::GenerateAsm()
   // } while (CPU::GetState() == CPU::State::Running);
   AlignCodePage();
   dispatcher = GetCodePtr();
-  WARN_LOG(DYNA_REC, "Dispatcher is %p", dispatcher);
+  WARN_LOG_FMT(DYNA_REC, "Dispatcher is {}", fmt::ptr(dispatcher));
 
   // Downcount Check
   // The result of slice decrementation should be in flags if somebody jumped here

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -69,9 +69,9 @@ CPUCoreBase* InitJitCore(PowerPC::CPUCore core)
     break;
 
   default:
-    PanicAlertT("The selected CPU emulation core (%d) is not available. "
-                "Please select a different CPU emulation core in the settings.",
-                static_cast<int>(core));
+    PanicAlertFmtT("The selected CPU emulation core ({0}) is not available. "
+                   "Please select a different CPU emulation core in the settings.",
+                   core);
     g_jit = nullptr;
     return nullptr;
   }
@@ -100,7 +100,7 @@ void WriteProfileResults(const std::string& filename)
   File::IOFile f(filename, "w");
   if (!f)
   {
-    PanicAlert("Failed to open %s", filename.c_str());
+    PanicAlertFmt("Failed to open {}", filename);
     return;
   }
   fprintf(f.GetHandle(), "origAddr\tblkName\trunCount\tcost\ttimeCost\tpercent\ttimePercent\tOvAlli"

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -122,17 +122,17 @@ static u32 EFB_Read(const u32 addr)
 
   if (addr & 0x00800000)
   {
-    ERROR_LOG(MEMMAP, "Unimplemented Z+Color EFB read @ 0x%08x", addr);
+    ERROR_LOG_FMT(MEMMAP, "Unimplemented Z+Color EFB read @ {:#010x}", addr);
   }
   else if (addr & 0x00400000)
   {
     var = g_video_backend->Video_AccessEFB(EFBAccessType::PeekZ, x, y, 0);
-    DEBUG_LOG(MEMMAP, "EFB Z Read @ %u, %u\t= 0x%08x", x, y, var);
+    DEBUG_LOG_FMT(MEMMAP, "EFB Z Read @ {}, {}\t= {:#010x}", x, y, var);
   }
   else
   {
     var = g_video_backend->Video_AccessEFB(EFBAccessType::PeekColor, x, y, 0);
-    DEBUG_LOG(MEMMAP, "EFB Color Read @ %u, %u\t= 0x%08x", x, y, var);
+    DEBUG_LOG_FMT(MEMMAP, "EFB Color Read @ {}, {}\t= {:#010x}", x, y, var);
   }
 
   return var;
@@ -147,17 +147,17 @@ static void EFB_Write(u32 data, u32 addr)
   {
     // It's possible to do a z-tested write to EFB by writing a 64bit value to this address range.
     // Not much is known, but let's at least get some loging.
-    ERROR_LOG(MEMMAP, "Unimplemented Z+Color EFB write. %08x @ 0x%08x", data, addr);
+    ERROR_LOG_FMT(MEMMAP, "Unimplemented Z+Color EFB write. {:08x} @ {:#010x}", data, addr);
   }
   else if (addr & 0x00400000)
   {
     g_video_backend->Video_AccessEFB(EFBAccessType::PokeZ, x, y, data);
-    DEBUG_LOG(MEMMAP, "EFB Z Write %08x @ %u, %u", data, x, y);
+    DEBUG_LOG_FMT(MEMMAP, "EFB Z Write {:08x} @ {}, {}", data, x, y);
   }
   else
   {
     g_video_backend->Video_AccessEFB(EFBAccessType::PokeColor, x, y, data);
-    DEBUG_LOG(MEMMAP, "EFB Color Write %08x @ %u, %u", data, x, y);
+    DEBUG_LOG_FMT(MEMMAP, "EFB Color Write {:08x} @ {}, {}", data, x, y);
   }
 }
 
@@ -250,7 +250,7 @@ static T ReadFromHardware(u32 em_address)
       return (T)Memory::mmio_mapping->Read<typename std::make_unsigned<T>::type>(em_address);
   }
 
-  PanicAlert("Unable to resolve read address %x PC %x", em_address, PC);
+  PanicAlertFmt("Unable to resolve read address {:x} PC {:x}", em_address, PC);
   return 0;
 }
 
@@ -368,8 +368,7 @@ static void WriteToHardware(u32 em_address, const T data)
     }
   }
 
-  PanicAlert("Unable to resolve write address %x PC %x", em_address, PC);
-  return;
+  PanicAlertFmt("Unable to resolve write address {:x} PC {:x}", em_address, PC);
 }
 // =====================
 
@@ -942,8 +941,8 @@ static void GenerateDSIException(u32 effective_address, bool write)
   // DSI exceptions are only supported in MMU mode.
   if (!SConfig::GetInstance().bMMU)
   {
-    PanicAlert("Invalid %s 0x%08x, PC = 0x%08x ", write ? "write to" : "read from",
-               effective_address, PC);
+    PanicAlertFmt("Invalid {} {:#010x}, PC = {:#010x}", write ? "write to" : "read from",
+                  effective_address, PC);
     return;
   }
 
@@ -963,7 +962,7 @@ static void GenerateISIException(u32 effective_address)
   NPC = effective_address;
 
   PowerPC::ppcState.Exceptions |= EXCEPTION_ISI;
-  WARN_LOG(POWERPC, "ISI exception at 0x%08x", PC);
+  WARN_LOG_FMT(POWERPC, "ISI exception at {:#010x}", PC);
 }
 
 void SDRUpdated()
@@ -1179,7 +1178,7 @@ static void UpdateBATs(BatTable& bat_table, u32 base_spr)
       // With a valid BAT, the simplest way to match is
       // (input & ~BL_mask) == BEPI. For now, assume it's
       // implemented this way for invalid BATs as well.
-      WARN_LOG(POWERPC, "Bad BAT setup: BEPI overlaps BL");
+      WARN_LOG_FMT(POWERPC, "Bad BAT setup: BEPI overlaps BL");
       continue;
     }
     if ((batl.BRPN & batu.BL) != 0)
@@ -1187,7 +1186,7 @@ static void UpdateBATs(BatTable& bat_table, u32 base_spr)
       // With a valid BAT, the simplest way to translate is
       // (input & BL_mask) | BRPN_address. For now, assume it's
       // implemented this way for invalid BATs as well.
-      WARN_LOG(POWERPC, "Bad BAT setup: BPRN overlaps BL");
+      WARN_LOG_FMT(POWERPC, "Bad BAT setup: BPRN overlaps BL");
     }
     if (!Common::IsValidLowMask((u32)batu.BL))
     {
@@ -1195,7 +1194,7 @@ static void UpdateBATs(BatTable& bat_table, u32 base_spr)
       // (input & ~BL_mask) for matching and (input & BL_mask) for
       // translation. For now, assume it's implemented this way for
       // invalid BATs as well.
-      WARN_LOG(POWERPC, "Bad BAT setup: invalid mask in BL");
+      WARN_LOG_FMT(POWERPC, "Bad BAT setup: invalid mask in BL");
     }
     for (u32 j = 0; j <= batu.BL; ++j)
     {

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -374,7 +374,7 @@ void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db)
   {
     if (func.second.address == 4)
     {
-      WARN_LOG(SYMBOLS, "Weird function");
+      WARN_LOG_FMT(SYMBOLS, "Weird function");
       continue;
     }
     AnalyzeFunction2(&(func.second));
@@ -424,12 +424,12 @@ void FindFunctions(u32 startAddr, u32 endAddr, PPCSymbolDB* func_db)
   else
     unniceSize /= numUnNice;
 
-  INFO_LOG(SYMBOLS,
-           "Functions analyzed. %i leafs, %i nice, %i unnice."
-           "%i timer, %i rfi. %i are branchless leafs.",
-           numLeafs, numNice, numUnNice, numTimer, numRFI, numStraightLeaf);
-  INFO_LOG(SYMBOLS, "Average size: %i (leaf), %i (nice), %i(unnice)", leafSize, niceSize,
-           unniceSize);
+  INFO_LOG_FMT(SYMBOLS,
+               "Functions analyzed. {} leafs, {} nice, {} unnice."
+               "{} timer, {} rfi. {} are branchless leafs.",
+               numLeafs, numNice, numUnNice, numTimer, numRFI, numStraightLeaf);
+  INFO_LOG_FMT(SYMBOLS, "Average size: {} (leaf), {} (nice), {}(unnice)", leafSize, niceSize,
+               unniceSize);
 }
 
 static bool isCmp(const CodeOp& a)

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -184,12 +184,13 @@ u32 InstructionCache::ReadInstruction(u32 addr)
   }
   // update plru
   plru[set] = (plru[set] & ~s_plru_mask[t]) | s_plru_value[t];
-  u32 res = Common::swap32(data[set][t][(addr >> 2) & 7]);
-  u32 inmem = Memory::Read_U32(addr);
+  const u32 res = Common::swap32(data[set][t][(addr >> 2) & 7]);
+  const u32 inmem = Memory::Read_U32(addr);
   if (res != inmem)
   {
-    INFO_LOG(POWERPC, "ICache read at %08x returned stale data: CACHED: %08x vs. RAM: %08x", addr,
-             res, inmem);
+    INFO_LOG_FMT(POWERPC,
+                 "ICache read at {:08x} returned stale data: CACHED: {:08x} vs. RAM: {:08x}", addr,
+                 res, inmem);
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::ICACHE_MATTERS);
   }
   return res;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -73,8 +73,8 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
       // Do not truncate symbol when a size is expected
       if (size != 0 && tf.size != size)
       {
-        WARN_LOG(SYMBOLS, "Analysed symbol (%s) size mismatch, %u expected but %u computed",
-                 name.c_str(), size, tf.size);
+        WARN_LOG_FMT(SYMBOLS, "Analysed symbol ({}) size mismatch, {} expected but {} computed",
+                     name, size, tf.size);
         tf.size = size;
       }
       m_checksum_to_function[tf.hash].insert(&m_functions[startAddr]);
@@ -151,18 +151,18 @@ void PPCSymbolDB::PrintCalls(u32 funcAddr) const
   const auto iter = m_functions.find(funcAddr);
   if (iter == m_functions.end())
   {
-    WARN_LOG(SYMBOLS, "Symbol does not exist");
+    WARN_LOG_FMT(SYMBOLS, "Symbol does not exist");
     return;
   }
 
   const Common::Symbol& f = iter->second;
-  DEBUG_LOG(SYMBOLS, "The function %s at %08x calls:", f.name.c_str(), f.address);
+  DEBUG_LOG_FMT(SYMBOLS, "The function {} at {:08x} calls:", f.name, f.address);
   for (const Common::SCall& call : f.calls)
   {
     const auto n = m_functions.find(call.function);
     if (n != m_functions.end())
     {
-      DEBUG_LOG(SYMBOLS, "* %08x : %s", call.call_address, n->second.name.c_str());
+      DEBUG_LOG_FMT(SYMBOLS, "* {:08x} : {}", call.call_address, n->second.name);
     }
   }
 }
@@ -174,13 +174,13 @@ void PPCSymbolDB::PrintCallers(u32 funcAddr) const
     return;
 
   const Common::Symbol& f = iter->second;
-  DEBUG_LOG(SYMBOLS, "The function %s at %08x is called by:", f.name.c_str(), f.address);
+  DEBUG_LOG_FMT(SYMBOLS, "The function {} at {:08x} is called by:", f.name, f.address);
   for (const Common::SCall& caller : f.callers)
   {
     const auto n = m_functions.find(caller.function);
     if (n != m_functions.end())
     {
-      DEBUG_LOG(SYMBOLS, "* %08x : %s", caller.call_address, n->second.name.c_str());
+      DEBUG_LOG_FMT(SYMBOLS, "* {:08x} : {}", caller.call_address, n->second.name);
     }
   }
 }
@@ -414,7 +414,7 @@ bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
   }
 
   Index();
-  NOTICE_LOG(SYMBOLS, "%d symbols loaded, %d symbols ignored.", good_count, bad_count);
+  NOTICE_LOG_FMT(SYMBOLS, "{} symbols loaded, {} symbols ignored.", good_count, bad_count);
   return true;
 }
 

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -157,7 +157,7 @@ void PrintInstructionRunCounts()
     if (inst.second == 0)
       break;
 
-    DEBUG_LOG(POWERPC, "%s : %" PRIu64, inst.first, inst.second);
+    DEBUG_LOG_FMT(POWERPC, "{} : {}", inst.first, inst.second);
   }
 }
 

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -209,8 +209,7 @@ static void InitializeCPUCore(CPUCore cpu_core)
     s_cpu_core_base = JitInterface::InitJitCore(cpu_core);
     if (!s_cpu_core_base)  // Handle Situations where JIT core isn't available
     {
-      WARN_LOG(POWERPC, "CPU core %d not available. Falling back to default.",
-               static_cast<int>(cpu_core));
+      WARN_LOG_FMT(POWERPC, "CPU core {} not available. Falling back to default.", cpu_core);
       s_cpu_core_base = JitInterface::InitJitCore(DefaultCPUCore());
     }
     break;
@@ -473,7 +472,7 @@ void CheckExceptions()
     MSR.Hex &= ~0x04EF36;
     PC = NPC = 0x00000400;
 
-    DEBUG_LOG(POWERPC, "EXCEPTION_ISI");
+    DEBUG_LOG_FMT(POWERPC, "EXCEPTION_ISI");
     ppcState.Exceptions &= ~EXCEPTION_ISI;
   }
   else if (exceptions & EXCEPTION_PROGRAM)
@@ -485,7 +484,7 @@ void CheckExceptions()
     MSR.Hex &= ~0x04EF36;
     PC = NPC = 0x00000700;
 
-    DEBUG_LOG(POWERPC, "EXCEPTION_PROGRAM");
+    DEBUG_LOG_FMT(POWERPC, "EXCEPTION_PROGRAM");
     ppcState.Exceptions &= ~EXCEPTION_PROGRAM;
   }
   else if (exceptions & EXCEPTION_SYSCALL)
@@ -496,7 +495,7 @@ void CheckExceptions()
     MSR.Hex &= ~0x04EF36;
     PC = NPC = 0x00000C00;
 
-    DEBUG_LOG(POWERPC, "EXCEPTION_SYSCALL (PC=%08x)", PC);
+    DEBUG_LOG_FMT(POWERPC, "EXCEPTION_SYSCALL (PC={:08x})", PC);
     ppcState.Exceptions &= ~EXCEPTION_SYSCALL;
   }
   else if (exceptions & EXCEPTION_FPU_UNAVAILABLE)
@@ -508,7 +507,7 @@ void CheckExceptions()
     MSR.Hex &= ~0x04EF36;
     PC = NPC = 0x00000800;
 
-    DEBUG_LOG(POWERPC, "EXCEPTION_FPU_UNAVAILABLE");
+    DEBUG_LOG_FMT(POWERPC, "EXCEPTION_FPU_UNAVAILABLE");
     ppcState.Exceptions &= ~EXCEPTION_FPU_UNAVAILABLE;
   }
   else if (exceptions & EXCEPTION_FAKE_MEMCHECK_HIT)
@@ -524,7 +523,7 @@ void CheckExceptions()
     PC = NPC = 0x00000300;
     // DSISR and DAR regs are changed in GenerateDSIException()
 
-    DEBUG_LOG(POWERPC, "EXCEPTION_DSI");
+    DEBUG_LOG_FMT(POWERPC, "EXCEPTION_DSI");
     ppcState.Exceptions &= ~EXCEPTION_DSI;
   }
   else if (exceptions & EXCEPTION_ALIGNMENT)
@@ -537,7 +536,7 @@ void CheckExceptions()
 
     // TODO crazy amount of DSISR options to check out
 
-    DEBUG_LOG(POWERPC, "EXCEPTION_ALIGNMENT");
+    DEBUG_LOG_FMT(POWERPC, "EXCEPTION_ALIGNMENT");
     ppcState.Exceptions &= ~EXCEPTION_ALIGNMENT;
   }
 
@@ -565,7 +564,7 @@ void CheckExternalExceptions()
       MSR.Hex &= ~0x04EF36;
       PC = NPC = 0x00000500;
 
-      DEBUG_LOG(POWERPC, "EXCEPTION_EXTERNAL_INT");
+      DEBUG_LOG_FMT(POWERPC, "EXCEPTION_EXTERNAL_INT");
       ppcState.Exceptions &= ~EXCEPTION_EXTERNAL_INT;
 
       DEBUG_ASSERT_MSG(POWERPC, (SRR1 & 0x02) != 0, "EXTERNAL_INT unrecoverable???");
@@ -578,7 +577,7 @@ void CheckExternalExceptions()
       MSR.Hex &= ~0x04EF36;
       PC = NPC = 0x00000F00;
 
-      DEBUG_LOG(POWERPC, "EXCEPTION_PERFORMANCE_MONITOR");
+      DEBUG_LOG_FMT(POWERPC, "EXCEPTION_PERFORMANCE_MONITOR");
       ppcState.Exceptions &= ~EXCEPTION_PERFORMANCE_MONITOR;
     }
     else if (exceptions & EXCEPTION_DECREMENTER)
@@ -589,13 +588,14 @@ void CheckExternalExceptions()
       MSR.Hex &= ~0x04EF36;
       PC = NPC = 0x00000900;
 
-      DEBUG_LOG(POWERPC, "EXCEPTION_DECREMENTER");
+      DEBUG_LOG_FMT(POWERPC, "EXCEPTION_DECREMENTER");
       ppcState.Exceptions &= ~EXCEPTION_DECREMENTER;
     }
     else
     {
       DEBUG_ASSERT_MSG(POWERPC, 0, "Unknown EXT interrupt: Exceptions == %08x", exceptions);
-      ERROR_LOG(POWERPC, "Unknown EXTERNAL INTERRUPT exception: Exceptions == %08x", exceptions);
+      ERROR_LOG_FMT(POWERPC, "Unknown EXTERNAL INTERRUPT exception: Exceptions == {:08x}",
+                    exceptions);
     }
   }
 }
@@ -608,9 +608,11 @@ void CheckBreakPoints()
       CPU::Break();
     if (PowerPC::breakpoints.IsBreakPointLogOnHit(PC))
     {
-      NOTICE_LOG(MEMMAP, "BP %08x %s(%08x %08x %08x %08x %08x %08x %08x %08x %08x %08x) LR=%08x",
-                 PC, g_symbolDB.GetDescription(PC).c_str(), GPR(3), GPR(4), GPR(5), GPR(6), GPR(7),
-                 GPR(8), GPR(9), GPR(10), GPR(11), GPR(12), LR);
+      NOTICE_LOG_FMT(MEMMAP,
+                     "BP {:08x} {}({:08x} {:08x} {:08x} {:08x} {:08x} {:08x} {:08x} {:08x} {:08x} "
+                     "{:08x}) LR={:08x}",
+                     PC, g_symbolDB.GetDescription(PC), GPR(3), GPR(4), GPR(5), GPR(6), GPR(7),
+                     GPR(8), GPR(9), GPR(10), GPR(11), GPR(12), LR);
     }
     if (PowerPC::breakpoints.IsTempBreakPoint(PC))
       PowerPC::breakpoints.Remove(PC);
@@ -619,7 +621,7 @@ void CheckBreakPoints()
 
 void PowerPCState::SetSR(u32 index, u32 value)
 {
-  DEBUG_LOG(POWERPC, "%08x: MMU: Segment register %i set to %08x", pc, index, value);
+  DEBUG_LOG_FMT(POWERPC, "{:08x}: MMU: Segment register {} set to {:08x}", pc, index, value);
   sr[index] = value;
 }
 

--- a/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/CSVSignatureDB.cpp
@@ -50,7 +50,7 @@ bool CSVSignatureDB::Load(const std::string& file_path)
     }
     else
     {
-      WARN_LOG(SYMBOLS, "CSV database failed to parse line %zu", i);
+      WARN_LOG_FMT(SYMBOLS, "CSV database failed to parse line {}", i);
     }
   }
 
@@ -63,7 +63,7 @@ bool CSVSignatureDB::Save(const std::string& file_path) const
 
   if (!f)
   {
-    ERROR_LOG(SYMBOLS, "CSV database save failed");
+    ERROR_LOG_FMT(SYMBOLS, "CSV database save failed");
     return false;
   }
   for (const auto& func : m_database)
@@ -75,6 +75,6 @@ bool CSVSignatureDB::Save(const std::string& file_path) const
             func.second.object_name.c_str());
   }
 
-  INFO_LOG(SYMBOLS, "CSV database save successful");
+  INFO_LOG_FMT(SYMBOLS, "CSV database save successful");
   return true;
 }

--- a/Source/Core/Core/PowerPC/SignatureDB/DSYSignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/DSYSignatureDB.cpp
@@ -54,7 +54,7 @@ bool DSYSignatureDB::Save(const std::string& file_path) const
 
   if (!f)
   {
-    ERROR_LOG(SYMBOLS, "Database save failed");
+    ERROR_LOG_FMT(SYMBOLS, "Database save failed");
     return false;
   }
   u32 fcount = static_cast<u32>(m_database.size());
@@ -69,6 +69,6 @@ bool DSYSignatureDB::Save(const std::string& file_path) const
     f.WriteArray(&temp, 1);
   }
 
-  INFO_LOG(SYMBOLS, "Database save successful");
+  INFO_LOG_FMT(SYMBOLS, "Database save successful");
   return true;
 }

--- a/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/MEGASignatureDB.cpp
@@ -38,7 +38,7 @@ bool GetCode(MEGASignature* sig, std::istringstream* iss)
       }
       else
       {
-        WARN_LOG(SYMBOLS, "MEGA database failed to parse code");
+        WARN_LOG_FMT(SYMBOLS, "MEGA database failed to parse code");
         return false;
       }
     }
@@ -80,17 +80,17 @@ bool GetRefs(MEGASignature* sig, std::istringstream* iss)
     num = num.substr(1);
     const char* ptr = num.c_str();
     char* endptr;
-    u64 offset = strtoul(ptr, &endptr, 16);
+    const u64 offset = std::strtoul(ptr, &endptr, 16);
 
     if (ptr == endptr || offset > std::numeric_limits<u32>::max())
     {
-      WARN_LOG(SYMBOLS, "MEGA database failed to parse reference %u offset", ref_count);
+      WARN_LOG_FMT(SYMBOLS, "MEGA database failed to parse reference {} offset", ref_count);
       return false;
     }
 
     if (!GetFunctionName(iss, &ref))
     {
-      WARN_LOG(SYMBOLS, "MEGA database failed to parse reference %u name", ref_count);
+      WARN_LOG_FMT(SYMBOLS, "MEGA database failed to parse reference {} name", ref_count);
       return false;
     }
     sig->refs.emplace_back(static_cast<u32>(offset), std::move(ref));
@@ -145,7 +145,7 @@ bool MEGASignatureDB::Load(const std::string& file_path)
     }
     else
     {
-      WARN_LOG(SYMBOLS, "MEGA database failed to parse line %zu", i);
+      WARN_LOG_FMT(SYMBOLS, "MEGA database failed to parse line {}", i);
     }
   }
   return true;
@@ -153,7 +153,7 @@ bool MEGASignatureDB::Load(const std::string& file_path)
 
 bool MEGASignatureDB::Save(const std::string& file_path) const
 {
-  ERROR_LOG(SYMBOLS, "MEGA database save unsupported yet.");
+  ERROR_LOG_FMT(SYMBOLS, "MEGA database save unsupported yet.");
   return false;
 }
 
@@ -167,8 +167,8 @@ void MEGASignatureDB::Apply(PPCSymbolDB* symbol_db) const
       if (Compare(symbol.address, symbol.size, sig))
       {
         symbol.name = sig.name;
-        INFO_LOG(SYMBOLS, "Found %s at %08x (size: %08x)!", sig.name.c_str(), symbol.address,
-                 symbol.size);
+        INFO_LOG_FMT(SYMBOLS, "Found {} at {:08x} (size: {:08x})!", sig.name, symbol.address,
+                     symbol.size);
         break;
       }
     }
@@ -178,12 +178,12 @@ void MEGASignatureDB::Apply(PPCSymbolDB* symbol_db) const
 
 void MEGASignatureDB::Populate(const PPCSymbolDB* func_db, const std::string& filter)
 {
-  ERROR_LOG(SYMBOLS, "MEGA database can't be populated yet.");
+  ERROR_LOG_FMT(SYMBOLS, "MEGA database can't be populated yet.");
 }
 
 bool MEGASignatureDB::Add(u32 startAddr, u32 size, const std::string& name)
 {
-  ERROR_LOG(SYMBOLS, "Can't add symbol to MEGA database yet.");
+  ERROR_LOG_FMT(SYMBOLS, "Can't add symbol to MEGA database yet.");
   return false;
 }
 
@@ -191,7 +191,7 @@ void MEGASignatureDB::List() const
 {
   for (const auto& entry : m_signatures)
   {
-    DEBUG_LOG(SYMBOLS, "%s : %zu bytes", entry.name.c_str(), entry.code.size() * sizeof(u32));
+    DEBUG_LOG_FMT(SYMBOLS, "{} : {} bytes", entry.name, entry.code.size() * sizeof(u32));
   }
-  INFO_LOG(SYMBOLS, "%zu functions known in current MEGA database.", m_signatures.size());
+  INFO_LOG_FMT(SYMBOLS, "{} functions known in current MEGA database.", m_signatures.size());
 }

--- a/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
@@ -109,10 +109,10 @@ void HashSignatureDB::List() const
 {
   for (const auto& entry : m_database)
   {
-    DEBUG_LOG(SYMBOLS, "%s : %i bytes, hash = %08x", entry.second.name.c_str(), entry.second.size,
-              entry.first);
+    DEBUG_LOG_FMT(SYMBOLS, "{} : {} bytes, hash = {:08x}", entry.second.name, entry.second.size,
+                  entry.first);
   }
-  INFO_LOG(SYMBOLS, "%zu functions known in current database.", m_database.size());
+  INFO_LOG_FMT(SYMBOLS, "{} functions known in current database.", m_database.size());
 }
 
 void HashSignatureDB::Clear()
@@ -130,13 +130,13 @@ void HashSignatureDB::Apply(PPCSymbolDB* symbol_db) const
       function->Rename(entry.second.name);
       if (entry.second.size == static_cast<unsigned int>(function->size))
       {
-        INFO_LOG(SYMBOLS, "Found %s at %08x (size: %08x)!", entry.second.name.c_str(),
-                 function->address, function->size);
+        INFO_LOG_FMT(SYMBOLS, "Found {} at {:08x} (size: {:08x})!", entry.second.name,
+                     function->address, function->size);
       }
       else
       {
-        ERROR_LOG(SYMBOLS, "Wrong size! Found %s at %08x (size: %08x instead of %08x)!",
-                  entry.second.name.c_str(), function->address, function->size, entry.second.size);
+        ERROR_LOG_FMT(SYMBOLS, "Wrong size! Found {} at {:08x} (size: {:08x} instead of {:08x})!",
+                      entry.second.name, function->address, function->size, entry.second.size);
       }
     }
   }


### PR DESCRIPTION
Converts the remaining PowerPC code over to fmt-capable logging.

Now, all that's left to convert over are the lingering remnants within the frontend code.