### PR TITLE
Common: Optimize Config::Get

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -178,6 +178,25 @@ LayerType GetActiveLayerForConfig(const Location& config)
   return LayerType::Base;
 }
 
+std::optional<std::string> GetAsString(const Location& config)
+{
+  std::optional<std::string> result;
+  ReadLock lock(s_layers_rw_lock);
+
+  for (auto layer : SEARCH_ORDER)
+  {
+    const auto it = s_layers.find(layer);
+    if (it != s_layers.end())
+    {
+      result = it->second->Get<std::string>(config);
+      if (result.has_value())
+        break;
+    }
+  }
+
+  return result;
+}
+
 ConfigChangeCallbackGuard::ConfigChangeCallbackGuard()
 {
   ++s_callback_guards;

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -39,6 +39,8 @@ std::optional<System> GetSystemFromName(const std::string& system);
 const std::string& GetLayerName(LayerType layer);
 LayerType GetActiveLayerForConfig(const Location&);
 
+std::optional<std::string> GetAsString(const Location&);
+
 template <typename T>
 T Get(LayerType layer, const Info<T>& info)
 {
@@ -50,7 +52,11 @@ T Get(LayerType layer, const Info<T>& info)
 template <typename T>
 T Get(const Info<T>& info)
 {
-  return GetLayer(GetActiveLayerForConfig(info.location))->Get(info);
+  const std::optional<std::string> str = GetAsString(info.location);
+  if (!str)
+    return info.default_value;
+
+  return detail::TryParse<T>(*str).value_or(info.default_value);
 }
 
 template <typename T>


### PR DESCRIPTION
The way `Config::Get` works in master, it first calls `Config::GetActiveLayerForConfig` which searches for the setting in all layers, and then calls `Config::Layer::Get` which searches for the same setting again within the given layer. We can remove this second search by combining the logic of `Config::GetActiveLayerForConfig` and `Config::Layer::Get` into one function.