### PR TITLE
Frontends: Migrate logs over to fmt

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -139,28 +139,6 @@ void WritePB(u32 addr, const PB_TYPE& pb, u32 crc)
   }
 }
 
-#if 0
-// Dump the value of a PB for debugging
-#define DUMP_U16(field) WARN_LOG(DSPHLE, "    %04x (%s)", pb.field, #field)
-#define DUMP_U32(field) WARN_LOG(DSPHLE, "    %08x (%s)", HILO_TO_32(pb.field), #field)
-void DumpPB(const PB_TYPE& pb)
-{
-	DUMP_U32(next_pb);
-	DUMP_U32(this_pb);
-	DUMP_U16(src_type);
-	DUMP_U16(coef_select);
-#ifdef AX_GC
-	DUMP_U16(mixer_control);
-#else
-	DUMP_U32(mixer_control);
-#endif
-	DUMP_U16(running);
-	DUMP_U16(is_stream);
-
-	// TODO: complete as needed
-}
-#endif
-
 // Simulated accelerator state.
 static PB_TYPE* acc_pb;
 static bool acc_end_reached;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -44,11 +44,6 @@ void AXWiiUCode::HandleCommandList()
 
   u32 pb_addr = 0;
 
-  // WARN_LOG(DSPHLE, "Command list:");
-  // for (u32 i = 0; m_cmdlist[i] != CMD_END; ++i)
-  //     WARN_LOG(DSPHLE, "%04x", m_cmdlist[i]);
-  // WARN_LOG(DSPHLE, "-------------");
-
   u32 curr_idx = 0;
   bool end = false;
   while (!end)

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -38,11 +38,6 @@ void Wiimote::HandleReportMode(const OutputReportMode& dr)
   // even on REPORT_CORE and continuous off when the buttons haven't changed.
   // But.. it is sent after the ACK
 
-  // DEBUG_LOG(WIIMOTE, "Set data report mode");
-  // DEBUG_LOG(WIIMOTE, "  Rumble: %x", dr->rumble);
-  // DEBUG_LOG(WIIMOTE, "  Continuous: %x", dr->continuous);
-  // DEBUG_LOG(WIIMOTE, "  Mode: 0x%02x", dr->mode);
-
   m_reporting_continuous = dr.continuous;
   m_reporting_mode = dr.mode;
 

--- a/Source/Core/Core/HW/WiimoteEmu/I2CBus.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/I2CBus.cpp
@@ -25,7 +25,6 @@ void I2CBus::Reset()
 
 int I2CBus::BusRead(u8 slave_addr, u8 addr, int count, u8* data_out)
 {
-  // INFO_LOG(WIIMOTE, "i2c bus read: 0x%02x @ 0x%02x (%d)", slave_addr, addr, count);
   for (auto& slave : m_slaves)
   {
     auto const bytes_read = slave->BusRead(slave_addr, addr, count, data_out);
@@ -40,7 +39,6 @@ int I2CBus::BusRead(u8 slave_addr, u8 addr, int count, u8* data_out)
 
 int I2CBus::BusWrite(u8 slave_addr, u8 addr, int count, const u8* data_in)
 {
-  // INFO_LOG(WIIMOTE, "i2c bus write: 0x%02x @ 0x%02x (%d)", slave_addr, addr, count);
   for (auto& slave : m_slaves)
   {
     auto const bytes_written = slave->BusWrite(slave_addr, addr, count, data_in);

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -735,7 +735,7 @@ void gdb_handle_exception()
       break;
     case 'k':
       gdb_deinit();
-      INFO_LOG(GDB_STUB, "killed by gdb");
+      INFO_LOG_FMT(GDB_STUB, "killed by gdb");
       return;
     case 'g':
       gdb_read_registers();

--- a/Source/Core/DolphinQt/ConvertDialog.cpp
+++ b/Source/Core/DolphinQt/ConvertDialog.cpp
@@ -184,8 +184,8 @@ void ConvertDialog::OnFormatChanged()
       constexpr int FALLBACK_BLOCK_SIZE = 0x4000;
       if (!block_size_ok(FALLBACK_BLOCK_SIZE))
       {
-        ERROR_LOG(MASTER_LOG, "Failed to find a block size which does not cause problems "
-                              "when decompressing using an old version of Dolphin");
+        ERROR_LOG_FMT(MASTER_LOG, "Failed to find a block size which does not cause problems "
+                                  "when decompressing using an old version of Dolphin");
       }
       AddToBlockSizeComboBox(FALLBACK_BLOCK_SIZE);
     }

--- a/Source/Core/DolphinQt/GCMemcardManager.cpp
+++ b/Source/Core/DolphinQt/GCMemcardManager.cpp
@@ -373,7 +373,7 @@ void GCMemcardManager::ImportFile()
   }
 
   if (!m_slot_memcard[m_active_slot]->Save())
-    PanicAlertT("File write failed");
+    PanicAlertFmtT("File write failed");
 
   UpdateSlotTable(m_active_slot);
 }
@@ -401,7 +401,7 @@ void GCMemcardManager::CopyFiles()
   for (int i = 0; i < SLOT_COUNT; i++)
   {
     if (!m_slot_memcard[i]->Save())
-      PanicAlertT("File write failed");
+      PanicAlertFmtT("File write failed");
 
     UpdateSlotTable(i);
   }
@@ -444,7 +444,7 @@ void GCMemcardManager::DeleteFiles()
 
   if (!memcard->Save())
   {
-    PanicAlertT("File write failed");
+    PanicAlertFmtT("File write failed");
   }
   else
   {
@@ -461,7 +461,7 @@ void GCMemcardManager::FixChecksums()
   memcard->FixChecksums();
 
   if (!memcard->Save())
-    PanicAlertT("File write failed");
+    PanicAlertFmtT("File write failed");
 }
 
 void GCMemcardManager::CreateNewCard(int slot)

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1601,10 +1601,10 @@ void MenuBar::SearchInstruction()
         QString::fromStdString(PPCTables::GetInstructionName(PowerPC::HostRead_U32(addr)));
     if (op == ins_name)
     {
-      NOTICE_LOG(POWERPC, "Found %s at %08x", op.toStdString().c_str(), addr);
+      NOTICE_LOG_FMT(POWERPC, "Found {} at {:08x}", op.toStdString(), addr);
       found = true;
     }
   }
   if (!found)
-    NOTICE_LOG(POWERPC, "Opcode %s not found", op.toStdString().c_str());
+    NOTICE_LOG_FMT(POWERPC, "Opcode {} not found", op.toStdString());
 }

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -427,7 +427,7 @@ void NetPlayDialog::OnStart()
   const auto game = FindGameFile(m_current_game_identifier);
   if (!game)
   {
-    PanicAlertT("Selected game doesn't exist in game list!");
+    PanicAlertFmtT("Selected game doesn't exist in game list!");
     return;
   }
 
@@ -876,7 +876,7 @@ void NetPlayDialog::OnMsgStartGame()
       if (auto game = FindGameFile(m_current_game_identifier))
         client->StartGame(game->GetFilePath());
       else
-        PanicAlertT("Selected game doesn't exist in game list!");
+        PanicAlertFmtT("Selected game doesn't exist in game list!");
     }
     UpdateDiscordPresence();
   });
@@ -1099,7 +1099,7 @@ void NetPlayDialog::LoadSettings()
   }
   else
   {
-    WARN_LOG(NETPLAY, "Unknown network mode '%s', using 'fixeddelay'", network_mode.c_str());
+    WARN_LOG_FMT(NETPLAY, "Unknown network mode '{}', using 'fixeddelay'", network_mode);
     m_fixed_delay_action->setChecked(true);
   }
 }

--- a/Source/Core/DolphinQt/Translation.cpp
+++ b/Source/Core/DolphinQt/Translation.cpp
@@ -150,24 +150,24 @@ public:
 
     if (!file)
     {
-      WARN_LOG(COMMON, "Error reading MO file '%s'", filename.c_str());
+      WARN_LOG_FMT(COMMON, "Error reading MO file '{}'", filename);
       m_data = {};
       return;
     }
 
-    u32 magic = ReadU32(&m_data[0]);
+    const u32 magic = ReadU32(&m_data[0]);
     if (magic != MO_MAGIC_NUMBER)
     {
-      ERROR_LOG(COMMON, "MO file '%s' has bad magic number %x\n", filename.c_str(), magic);
+      ERROR_LOG_FMT(COMMON, "MO file '{}' has bad magic number {:x}\n", filename, magic);
       m_data = {};
       return;
     }
 
-    u16 version_major = ReadU16(&m_data[4]);
+    const u16 version_major = ReadU16(&m_data[4]);
     if (version_major > 1)
     {
-      ERROR_LOG(COMMON, "MO file '%s' has unsupported version number %i", filename.c_str(),
-                version_major);
+      ERROR_LOG_FMT(COMMON, "MO file '{}' has unsupported version number {}", filename,
+                    version_major);
       m_data = {};
       return;
     }
@@ -300,7 +300,7 @@ static bool TryInstallTranslator(const QString& exact_language_code)
     }
     translator->deleteLater();
   }
-  ERROR_LOG(COMMON, "No suitable translation file found");
+  ERROR_LOG_FMT(COMMON, "No suitable translation file found");
   return false;
 }
 

--- a/Source/Core/UICommon/X11Utils.cpp
+++ b/Source/Core/UICommon/X11Utils.cpp
@@ -39,7 +39,7 @@ bool ToggleFullscreen(Display* dpy, Window win)
   if (!XSendEvent(dpy, DefaultRootWindow(dpy), False,
                   SubstructureRedirectMask | SubstructureNotifyMask, &event))
   {
-    ERROR_LOG(VIDEO, "Failed to switch fullscreen/windowed mode.");
+    ERROR_LOG_FMT(VIDEO, "Failed to switch fullscreen/windowed mode.");
     return false;
   }
 
@@ -60,7 +60,7 @@ void InhibitScreensaver(Window win, bool suspend)
     while (waitpid(pid, &status, 0) == -1)
       ;
 
-    INFO_LOG(VIDEO, "Started xdg-screensaver (PID = %d)", (int)pid);
+    INFO_LOG_FMT(VIDEO, "Started xdg-screensaver (PID = {})", pid);
   }
 }
 
@@ -75,7 +75,7 @@ XRRConfiguration::XRRConfiguration(Display* _dpy, Window _win)
   if (!XRRQueryVersion(dpy, &XRRMajorVersion, &XRRMinorVersion) ||
       (XRRMajorVersion < 1 || (XRRMajorVersion == 1 && XRRMinorVersion < 3)))
   {
-    WARN_LOG(VIDEO, "XRRExtension not supported.");
+    WARN_LOG_FMT(VIDEO, "XRRExtension not supported.");
     bValid = false;
     return;
   }
@@ -88,7 +88,7 @@ XRRConfiguration::XRRConfiguration(Display* _dpy, Window _win)
   fb_width_mm = DisplayWidthMM(dpy, screen);
   fb_height_mm = DisplayHeightMM(dpy, screen);
 
-  INFO_LOG(VIDEO, "XRRExtension-Version %d.%d", XRRMajorVersion, XRRMinorVersion);
+  INFO_LOG_FMT(VIDEO, "XRRExtension-Version {}.{}", XRRMajorVersion, XRRMinorVersion);
   Update();
 }
 
@@ -204,12 +204,12 @@ void XRRConfiguration::Update()
 
   if (outputInfo && crtcInfo && fullMode)
   {
-    INFO_LOG(VIDEO, "Fullscreen Resolution %dx%d", fullWidth, fullHeight);
+    INFO_LOG_FMT(VIDEO, "Fullscreen Resolution {}x{}", fullWidth, fullHeight);
   }
   else
   {
-    ERROR_LOG(VIDEO, "Failed to obtain fullscreen size.\n"
-                     "Using current desktop resolution for fullscreen.");
+    ERROR_LOG_FMT(VIDEO, "Failed to obtain fullscreen size.\n"
+                         "Using current desktop resolution for fullscreen.");
   }
 }
 

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -16,24 +16,6 @@
 
 namespace
 {
-template <int N>
-void LOG_TEX();
-
-template <>
-void LOG_TEX<1>()
-{
-  // warning: mapping buffer should be disabled to use this
-  // PRIM_LOG("tex: %f, ", ((float*)g_vertex_manager_write_ptr)[-1]);
-}
-
-template <>
-void LOG_TEX<2>()
-{
-  // warning: mapping buffer should be disabled to use this
-  // PRIM_LOG("tex: %f %f, ", ((float*)g_vertex_manager_write_ptr)[-2],
-  // ((float*)g_vertex_manager_write_ptr)[-1]);
-}
-
 void TexCoord_Read_Dummy(VertexLoader* loader)
 {
   loader->m_tcIndex++;
@@ -63,7 +45,6 @@ void TexCoord_ReadDirect(VertexLoader* loader)
 
   g_vertex_manager_write_ptr = dst.GetPointer();
   g_video_buffer_read_ptr = src.GetPointer();
-  LOG_TEX<N>();
 
   ++loader->m_tcIndex;
 }
@@ -84,7 +65,6 @@ void TexCoord_ReadIndex(VertexLoader* loader)
     dst.Write(TCScale(Common::FromBigEndian(data[i]), scale));
 
   g_vertex_manager_write_ptr = dst.GetPointer();
-  LOG_TEX<N>();
   ++loader->m_tcIndex;
 }
 


### PR DESCRIPTION
Migrates the final remaining logs over to fmt-equivalents

After this PR, renaming of the new fmt functions to the old one can be undertaken. The printf logging can't be removed until all alerts and assertions are converted over however.