### PR TITLE
FifoPlayer: Make FIFO writes fast

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -149,10 +149,6 @@ private:
 
   bool m_EarlyMemoryUpdates = false;
 
-  u64 m_CyclesPerFrame = 0;
-  u32 m_ElapsedCycles = 0;
-  u32 m_FrameFifoSize = 0;
-
   CallbackFunc m_FileLoadedCb = nullptr;
   CallbackFunc m_FrameWrittenCb = nullptr;
 


### PR DESCRIPTION
This new timing model is very arbitrary, but the old one wasn't exactly based on how games work in practice either, and this seems to fix the problem of frames consistently taking longer than a frame to render.

Split out from PR #9275. I originally created this commit to solve a problem that that PR had with FifoCI reporting duplicate frames, but the FifoCI results are curious enough that I would like it to be a separate PR. Not sure if the results are good or bad overall, so I'm just going to keep this PR open in the hopes that someone who understands FifoPlayer better can figure out what's actually going on.