### PR TITLE
Fix liblzma config on macOS

### DIFF
--- a/Externals/liblzma/config.h
+++ b/Externals/liblzma/config.h
@@ -190,7 +190,9 @@
 #define HAVE_POSIX_FADVISE 1
 
 /* Define to 1 if you have the `pthread_condattr_setclock' function. */
+#ifndef __APPLE__
 #define HAVE_PTHREAD_CONDATTR_SETCLOCK 1
+#endif
 
 /* Have PTHREAD_PRIO_INHERIT. */
 #define HAVE_PTHREAD_PRIO_INHERIT 1


### PR DESCRIPTION
/Externals/liblzma/config.h #defines HAVE_PTHREAD_CONDATTR_SETCLOCK
which results in /Externals/liblzma/tuklib/mythread.h calling the
function pthread_condattr_setclock.  This function doesn't exist in
macOS 10.12+, which are the only macOS versions Dolphin supports, but
inserting an include guard makes macOS use an alternate function.