### PR TITLE
Movie: Fix 83b9fef regressions

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -227,7 +227,7 @@ void Init(const BootParameters& boot)
     ReadHeader();
     std::thread md5thread(CheckMD5);
     md5thread.detach();
-    if (tmpHeader.GetGameID() == SConfig::GetInstance().GetGameID())
+    if (strncmp(tmpHeader.gameID.data(), SConfig::GetInstance().GetGameID().c_str(), 6))
     {
       PanicAlertFmtT("The recorded game ({0}) is not the same as the selected game ({1})",
                      tmpHeader.GetGameID(), SConfig::GetInstance().GetGameID());

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <cstring>
 #include <functional>
 #include <optional>
 #include <string>
@@ -64,7 +65,10 @@ static_assert(sizeof(ControllerState) == 8, "ControllerState should be 8 bytes")
 #pragma pack(push, 1)
 struct DTMHeader
 {
-  std::string_view GetGameID() const { return {gameID.data(), gameID.size()}; }
+  std::string_view GetGameID() const
+  {
+    return {gameID.data(), strnlen(gameID.data(), gameID.size())};
+  }
 
   std::array<u8, 4> filetype;  // Unique Identifier (always "DTM"0x1A)
 


### PR DESCRIPTION
1. Comparing `std::string_view`s does not behave the same as `strncmp` in the case where `SConfig`'s game ID is longer than 6 chars.
2. `DTMHeader::GetGameID` wasn't excluding null bytes for game IDs shorter than 6 chars.
3. `==` was accidentally used instead of `!=`.