### PR TITLE
Android: Add "Disable Fastmem" debug setting

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -9,6 +9,7 @@ public enum BooleanSetting implements AbstractBooleanSetting
   // These entries have the same names and order as in C++, just for consistency.
 
   MAIN_DSP_HLE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "DSPHLE", true),
+  MAIN_FASTMEM(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "Fastmem", true),
   MAIN_CPU_THREAD(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "CPUThread", true),
   MAIN_OVERRIDE_REGION_SETTINGS(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE,
           "OverrideRegionSettings", false),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -650,6 +650,7 @@ public final class SettingsFragmentPresenter
   private void addDebugSettings(ArrayList<SettingsItem> sl)
   {
     sl.add(new HeaderSetting(R.string.debug_warning, 0));
+    sl.add(new InvertedCheckBoxSetting(BooleanSetting.MAIN_FASTMEM, R.string.debug_fastmem, 0));
 
     sl.add(new HeaderSetting(R.string.debug_jit_header, 0));
     sl.add(new CheckBoxSetting(BooleanSetting.MAIN_JIT_OFF, R.string.debug_jitoff, 0));

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -287,7 +287,8 @@
 
     <!-- Debug -->
     <string name="debug_submenu">Debug</string>
-    <string name="debug_warning">Warning: These settings will slow emulation</string>
+    <string name="debug_warning">Warning: Debug settings will slow emulation</string>
+    <string name="debug_fastmem">Disable Fastmem</string>
     <string name="debug_jit_header">Jit</string>
     <string name="debug_jitoff">Jit Disabled</string>
     <string name="debug_jitloadstoreoff">Jit Load Store Disabled</string>


### PR DESCRIPTION
This will make debugging C++ issues more convient on Android. I also clarified `debug_warning` since settings no longer fall under one `HeaderSetting`.