### PR TITLE
General: Convert PanicAlerts over to fmt equivalent

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -267,9 +267,10 @@ public:
 
     if (mode == PointerWrap::MODE_READ && cookie != arbitraryNumber)
     {
-      PanicAlertT("Error: After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). Aborting "
-                  "savestate load...",
-                  prevName.c_str(), cookie, cookie, arbitraryNumber, arbitraryNumber);
+      PanicAlertFmtT(
+          "Error: After \"{0}\", found {1} ({2:#x}) instead of save marker {3} ({4:#x}). Aborting "
+          "savestate load...",
+          prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
       mode = PointerWrap::MODE_MEASURE;
     }
   }

--- a/Source/Core/Common/GL/GLInterface/WGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/WGL.cpp
@@ -277,27 +277,27 @@ bool GLContextWGL::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
   m_dc = GetDC(m_window_handle);
   if (!m_dc)
   {
-    PanicAlert("(1) Can't create an OpenGL Device context. Fail.");
+    PanicAlertFmt("(1) Can't create an OpenGL Device context. Fail.");
     return false;
   }
 
-  int pixel_format = ChoosePixelFormat(m_dc, &pfd);
-  if (!pixel_format)
+  const int pixel_format = ChoosePixelFormat(m_dc, &pfd);
+  if (pixel_format == 0)
   {
-    PanicAlert("(2) Can't find a suitable PixelFormat.");
+    PanicAlertFmt("(2) Can't find a suitable PixelFormat.");
     return false;
   }
 
   if (!SetPixelFormat(m_dc, pixel_format, &pfd))
   {
-    PanicAlert("(3) Can't set the PixelFormat.");
+    PanicAlertFmt("(3) Can't set the PixelFormat.");
     return false;
   }
 
   m_rc = wglCreateContext(m_dc);
   if (!m_rc)
   {
-    PanicAlert("(4) Can't create an OpenGL rendering context.");
+    PanicAlertFmt("(4) Can't create an OpenGL rendering context.");
     return false;
   }
 
@@ -310,7 +310,7 @@ bool GLContextWGL::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
     // This is because we need an active context to use wglCreateContextAttribsARB.
     if (!wglMakeCurrent(m_dc, m_rc))
     {
-      PanicAlert("(5) Can't make dummy WGL context current.");
+      PanicAlertFmt("(5) Can't make dummy WGL context current.");
       return false;
     }
 
@@ -324,7 +324,7 @@ bool GLContextWGL::Initialize(const WindowSystemInfo& wsi, bool stereo, bool cor
     // context. If we didn't get a core context, the caller expects that the context is not current.
     if (!wglMakeCurrent(m_dc, nullptr))
     {
-      PanicAlert("(6) Failed to switch out temporary context");
+      PanicAlertFmt("(6) Failed to switch out temporary context");
       return false;
     }
 

--- a/Source/Core/Common/MemArena.cpp
+++ b/Source/Core/Common/MemArena.cpp
@@ -145,7 +145,7 @@ u8* MemArena::FindMemoryBase()
   u8* base = static_cast<u8*>(VirtualAlloc(nullptr, memory_size, MEM_RESERVE, PAGE_READWRITE));
   if (!base)
   {
-    PanicAlert("Failed to map enough memory space: %s", GetLastErrorString().c_str());
+    PanicAlertFmt("Failed to map enough memory space: {}", GetLastErrorString());
     return nullptr;
   }
   VirtualFree(base, 0, MEM_RELEASE);
@@ -162,7 +162,7 @@ u8* MemArena::FindMemoryBase()
   void* base = mmap(nullptr, memory_size, PROT_NONE, flags, -1, 0);
   if (base == MAP_FAILED)
   {
-    PanicAlert("Failed to map enough memory space: %s", LastStrerrorString().c_str());
+    PanicAlertFmt("Failed to map enough memory space: {}", LastStrerrorString());
     return nullptr;
   }
   munmap(base, memory_size);

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -46,7 +46,7 @@ void* AllocateExecutableMemory(size_t size)
 #endif
 
   if (ptr == nullptr)
-    PanicAlert("Failed to allocate executable memory");
+    PanicAlertFmt("Failed to allocate executable memory");
 
   return ptr;
 }
@@ -63,7 +63,7 @@ void* AllocateMemoryPages(size_t size)
 #endif
 
   if (ptr == nullptr)
-    PanicAlert("Failed to allocate raw memory");
+    PanicAlertFmt("Failed to allocate raw memory");
 
   return ptr;
 }
@@ -79,7 +79,7 @@ void* AllocateAlignedMemory(size_t size, size_t alignment)
 #endif
 
   if (ptr == nullptr)
-    PanicAlert("Failed to allocate aligned memory");
+    PanicAlertFmt("Failed to allocate aligned memory");
 
   return ptr;
 }
@@ -90,10 +90,10 @@ void FreeMemoryPages(void* ptr, size_t size)
   {
 #ifdef _WIN32
     if (!VirtualFree(ptr, 0, MEM_RELEASE))
-      PanicAlert("FreeMemoryPages failed!\nVirtualFree: %s", GetLastErrorString().c_str());
+      PanicAlertFmt("FreeMemoryPages failed!\nVirtualFree: {}", GetLastErrorString());
 #else
     if (munmap(ptr, size) != 0)
-      PanicAlert("FreeMemoryPages failed!\nmunmap: %s", LastStrerrorString().c_str());
+      PanicAlertFmt("FreeMemoryPages failed!\nmunmap: {}", LastStrerrorString());
 #endif
   }
 }
@@ -115,10 +115,10 @@ void ReadProtectMemory(void* ptr, size_t size)
 #ifdef _WIN32
   DWORD oldValue;
   if (!VirtualProtect(ptr, size, PAGE_NOACCESS, &oldValue))
-    PanicAlert("ReadProtectMemory failed!\nVirtualProtect: %s", GetLastErrorString().c_str());
+    PanicAlertFmt("ReadProtectMemory failed!\nVirtualProtect: {}", GetLastErrorString());
 #else
   if (mprotect(ptr, size, PROT_NONE) != 0)
-    PanicAlert("ReadProtectMemory failed!\nmprotect: %s", LastStrerrorString().c_str());
+    PanicAlertFmt("ReadProtectMemory failed!\nmprotect: {}", LastStrerrorString());
 #endif
 }
 
@@ -127,10 +127,10 @@ void WriteProtectMemory(void* ptr, size_t size, bool allowExecute)
 #ifdef _WIN32
   DWORD oldValue;
   if (!VirtualProtect(ptr, size, allowExecute ? PAGE_EXECUTE_READ : PAGE_READONLY, &oldValue))
-    PanicAlert("WriteProtectMemory failed!\nVirtualProtect: %s", GetLastErrorString().c_str());
+    PanicAlertFmt("WriteProtectMemory failed!\nVirtualProtect: {}", GetLastErrorString());
 #else
   if (mprotect(ptr, size, allowExecute ? (PROT_READ | PROT_EXEC) : PROT_READ) != 0)
-    PanicAlert("WriteProtectMemory failed!\nmprotect: %s", LastStrerrorString().c_str());
+    PanicAlertFmt("WriteProtectMemory failed!\nmprotect: {}", LastStrerrorString());
 #endif
 }
 
@@ -139,12 +139,12 @@ void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute)
 #ifdef _WIN32
   DWORD oldValue;
   if (!VirtualProtect(ptr, size, allowExecute ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE, &oldValue))
-    PanicAlert("UnWriteProtectMemory failed!\nVirtualProtect: %s", GetLastErrorString().c_str());
+    PanicAlertFmt("UnWriteProtectMemory failed!\nVirtualProtect: {}", GetLastErrorString());
 #else
   if (mprotect(ptr, size,
                allowExecute ? (PROT_READ | PROT_WRITE | PROT_EXEC) : PROT_WRITE | PROT_READ) != 0)
   {
-    PanicAlert("UnWriteProtectMemory failed!\nmprotect: %s", LastStrerrorString().c_str());
+    PanicAlertFmt("UnWriteProtectMemory failed!\nmprotect: {}", LastStrerrorString());
   }
 #endif
 }

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -77,7 +77,7 @@ void TraversalClient::ConnectToClient(const std::string& host)
 {
   if (host.size() > sizeof(TraversalHostId))
   {
-    PanicAlert("host too long");
+    PanicAlertFmt("Host too long");
     return;
   }
   TraversalPacket packet = {};

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -1028,14 +1028,14 @@ void XEmitter::TZCNT(int bits, X64Reg dest, const OpArg& src)
 {
   CheckFlags();
   if (!cpu_info.bBMI1)
-    PanicAlert("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
   WriteBitSearchType(bits, dest, src, 0xBC, true);
 }
 void XEmitter::LZCNT(int bits, X64Reg dest, const OpArg& src)
 {
   CheckFlags();
   if (!cpu_info.bLZCNT)
-    PanicAlert("Trying to use LZCNT on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use LZCNT on a system that doesn't support it. Bad programmer.");
   WriteBitSearchType(bits, dest, src, 0xBD, true);
 }
 
@@ -1880,7 +1880,7 @@ void XEmitter::WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, con
                           int W, int extrabytes)
 {
   if (!cpu_info.bAVX)
-    PanicAlert("Trying to use AVX on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use AVX on a system that doesn't support it. Bad programmer.");
   WriteVEXOp(opPrefix, op, regOp1, regOp2, arg, W, extrabytes);
 }
 
@@ -1888,14 +1888,17 @@ void XEmitter::WriteAVXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, co
                            X64Reg regOp3, int W)
 {
   if (!cpu_info.bAVX)
-    PanicAlert("Trying to use AVX on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use AVX on a system that doesn't support it. Bad programmer.");
   WriteVEXOp4(opPrefix, op, regOp1, regOp2, arg, regOp3, W);
 }
 
 void XEmitter::WriteFMA3Op(u8 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int W)
 {
   if (!cpu_info.bFMA)
-    PanicAlert("Trying to use FMA3 on a system that doesn't support it. Computer is v. f'n madd.");
+  {
+    PanicAlertFmt(
+        "Trying to use FMA3 on a system that doesn't support it. Computer is v. f'n madd.");
+  }
   WriteVEXOp(0x66, 0x3800 | op, regOp1, regOp2, arg, W);
 }
 
@@ -1903,7 +1906,10 @@ void XEmitter::WriteFMA4Op(u8 op, X64Reg dest, X64Reg regOp1, X64Reg regOp2, con
                            int W)
 {
   if (!cpu_info.bFMA4)
-    PanicAlert("Trying to use FMA4 on a system that doesn't support it. Computer is v. f'n madd.");
+  {
+    PanicAlertFmt(
+        "Trying to use FMA4 on a system that doesn't support it. Computer is v. f'n madd.");
+  }
   WriteVEXOp4(0x66, 0x3A00 | op, dest, regOp1, arg, regOp2, W);
 }
 
@@ -1911,10 +1917,10 @@ void XEmitter::WriteBMIOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg r
                           const OpArg& arg, int extrabytes)
 {
   if (arg.IsImm())
-    PanicAlert("BMI1/2 instructions don't support immediate operands.");
+    PanicAlertFmt("BMI1/2 instructions don't support immediate operands.");
   if (size != 32 && size != 64)
-    PanicAlert("BMI1/2 instructions only support 32-bit and 64-bit modes!");
-  int W = size == 64;
+    PanicAlertFmt("BMI1/2 instructions only support 32-bit and 64-bit modes!");
+  const int W = size == 64;
   WriteVEXOp(opPrefix, op, regOp1, regOp2, arg, W, extrabytes);
 }
 
@@ -1923,7 +1929,7 @@ void XEmitter::WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg 
 {
   CheckFlags();
   if (!cpu_info.bBMI1)
-    PanicAlert("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
   WriteBMIOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
@@ -1931,7 +1937,7 @@ void XEmitter::WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg 
                            const OpArg& arg, int extrabytes)
 {
   if (!cpu_info.bBMI2)
-    PanicAlert("Trying to use BMI2 on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use BMI2 on a system that doesn't support it. Bad programmer.");
   WriteBMIOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
@@ -2580,7 +2586,7 @@ void XEmitter::PSLLDQ(X64Reg reg, int shift)
 void XEmitter::PSRAW(X64Reg reg, int shift)
 {
   if (reg > 7)
-    PanicAlert("The PSRAW-emitter does not support regs above 7");
+    PanicAlertFmt("The PSRAW-emitter does not support regs above 7");
   Write8(0x66);
   Write8(0x0f);
   Write8(0x71);
@@ -2592,7 +2598,7 @@ void XEmitter::PSRAW(X64Reg reg, int shift)
 void XEmitter::PSRAD(X64Reg reg, int shift)
 {
   if (reg > 7)
-    PanicAlert("The PSRAD-emitter does not support regs above 7");
+    PanicAlertFmt("The PSRAD-emitter does not support regs above 7");
   Write8(0x66);
   Write8(0x0f);
   Write8(0x72);
@@ -2603,14 +2609,14 @@ void XEmitter::PSRAD(X64Reg reg, int shift)
 void XEmitter::WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, const OpArg& arg, int extrabytes)
 {
   if (!cpu_info.bSSSE3)
-    PanicAlert("Trying to use SSSE3 on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use SSSE3 on a system that doesn't support it. Bad programmer.");
   WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 
 void XEmitter::WriteSSE41Op(u8 opPrefix, u16 op, X64Reg regOp, const OpArg& arg, int extrabytes)
 {
   if (!cpu_info.bSSE4_1)
-    PanicAlert("Trying to use SSE4.1 on a system that doesn't support it. Bad programmer.");
+    PanicAlertFmt("Trying to use SSE4.1 on a system that doesn't support it. Bad programmer.");
   WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -43,7 +43,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   if (!s_d3d11_library.Open("d3d11.dll") ||
       !s_d3d11_library.GetSymbol("D3D11CreateDevice", &d3d11_create_device))
   {
-    PanicAlertT("Failed to load d3d11.dll");
+    PanicAlertFmtT("Failed to load d3d11.dll");
     s_d3d11_library.Close();
     return false;
   }
@@ -57,7 +57,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
   dxgi_factory = D3DCommon::CreateDXGIFactory(enable_debug_layer);
   if (!dxgi_factory)
   {
-    PanicAlertT("Failed to create DXGI factory");
+    PanicAlertFmtT("Failed to create DXGI factory");
     D3DCommon::UnloadLibraries();
     s_d3d11_library.Close();
     return false;
@@ -113,7 +113,7 @@ bool Create(u32 adapter_index, bool enable_debug_layer)
 
   if (FAILED(hr))
   {
-    PanicAlertT(
+    PanicAlertFmtT(
         "Failed to initialize Direct3D.\nMake sure your video card supports at least D3D 10.0");
     dxgi_factory.Reset();
     D3DCommon::UnloadLibraries();

--- a/Source/Core/VideoBackends/D3D/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/DXTexture.cpp
@@ -45,8 +45,8 @@ std::unique_ptr<DXTexture> DXTexture::Create(const TextureConfig& config)
   HRESULT hr = D3D::device->CreateTexture2D(&desc, nullptr, d3d_texture.GetAddressOf());
   if (FAILED(hr))
   {
-    PanicAlert("Failed to create %ux%ux%u D3D backing texture", config.width, config.height,
-               config.layers);
+    PanicAlertFmt("Failed to create {}x{}x{} D3D backing texture", config.width, config.height,
+                  config.layers);
     return nullptr;
   }
 
@@ -92,8 +92,8 @@ bool DXTexture::CreateSRV()
   HRESULT hr = D3D::device->CreateShaderResourceView(m_texture.Get(), &desc, m_srv.GetAddressOf());
   if (FAILED(hr))
   {
-    PanicAlert("Failed to create %ux%ux%u D3D SRV", m_config.width, m_config.height,
-               m_config.layers);
+    PanicAlertFmt("Failed to create {}x{}x{} D3D SRV", m_config.width, m_config.height,
+                  m_config.layers);
     return false;
   }
 
@@ -109,8 +109,8 @@ bool DXTexture::CreateUAV()
   HRESULT hr = D3D::device->CreateUnorderedAccessView(m_texture.Get(), &desc, m_uav.GetAddressOf());
   if (FAILED(hr))
   {
-    PanicAlert("Failed to create %ux%ux%u D3D UAV", m_config.width, m_config.height,
-               m_config.layers);
+    PanicAlertFmt("Failed to create {}x{}x{} D3D UAV", m_config.width, m_config.height,
+                  m_config.layers);
     return false;
   }
 

--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -72,7 +72,7 @@ DXGI_FORMAT VarToD3D(VarType t, int size, bool integer)
   DXGI_FORMAT retval = d3d_format_lookup[(int)t + 5 * (size - 1) + 5 * 4 * (int)integer];
   if (retval == DXGI_FORMAT_UNKNOWN)
   {
-    PanicAlert("VarToD3D: Invalid type/size combo %i , %i, %i", (int)t, size, (int)integer);
+    PanicAlertFmt("VarToD3D: Invalid type/size combo {}, {}, {}", t, size, integer);
   }
   return retval;
 }

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -143,7 +143,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   std::unique_ptr<SwapChain> swap_chain;
   if (wsi.render_surface && !(swap_chain = SwapChain::Create(wsi)))
   {
-    PanicAlertT("Failed to create D3D swap chain");
+    PanicAlertFmtT("Failed to create D3D swap chain");
     ShutdownShared();
     D3D::Destroy();
     return false;

--- a/Source/Core/VideoBackends/D3D12/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D12/BoundingBox.cpp
@@ -152,7 +152,7 @@ void BoundingBox::Flush()
       Renderer::GetInstance()->ExecuteCommandList(false);
       if (!m_upload_buffer.ReserveMemory(copy_size, sizeof(ValueType)))
       {
-        PanicAlert("Failed to allocate bbox stream buffer space");
+        PanicAlertFmt("Failed to allocate bbox stream buffer space");
         return;
       }
     }

--- a/Source/Core/VideoBackends/D3D12/DXContext.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXContext.cpp
@@ -99,7 +99,7 @@ bool DXContext::Create(u32 adapter_index, bool enable_debug_layer)
       !s_d3d12_library.GetSymbol("D3D12GetDebugInterface", &s_d3d12_get_debug_interface) ||
       !s_d3d12_library.GetSymbol("D3D12SerializeRootSignature", &s_d3d12_serialize_root_signature))
   {
-    PanicAlertT("d3d12.dll could not be loaded.");
+    PanicAlertFmtT("d3d12.dll could not be loaded.");
     s_d3d12_library.Close();
     return false;
   }
@@ -253,7 +253,7 @@ bool DXContext::CreateDescriptorHeaps()
 
   if (!m_descriptor_heap_manager.Allocate(&m_null_srv_descriptor))
   {
-    PanicAlert("Failed to allocate null descriptor");
+    PanicAlertFmt("Failed to allocate null descriptor");
     return false;
   }
 
@@ -303,8 +303,8 @@ static bool BuildRootSignature(ID3D12Device* device, ID3D12RootSignature** sig_p
                                                 &root_signature_blob, &root_signature_error_blob);
   if (FAILED(hr))
   {
-    PanicAlert("Failed to serialize root signature: %s",
-               static_cast<const char*>(root_signature_error_blob->GetBufferPointer()));
+    PanicAlertFmt("Failed to serialize root signature: {}",
+                  static_cast<const char*>(root_signature_error_blob->GetBufferPointer()));
     return false;
   }
 
@@ -400,7 +400,7 @@ bool DXContext::CreateTextureUploadBuffer()
 {
   if (!m_texture_upload_buffer.AllocateBuffer(TEXTURE_UPLOAD_BUFFER_SIZE))
   {
-    PanicAlert("Failed to create texture upload buffer");
+    PanicAlertFmt("Failed to create texture upload buffer");
     return false;
   }
 
@@ -425,7 +425,7 @@ bool DXContext::CreateCommandLists()
                                      nullptr, IID_PPV_ARGS(res.command_list.GetAddressOf()));
     if (FAILED(hr))
     {
-      PanicAlert("Failed to create command list.");
+      PanicAlertFmt("Failed to create command list.");
       return false;
     }
 
@@ -508,7 +508,7 @@ void DXContext::RecreateGXRootSignature()
 {
   m_gx_root_signature.Reset();
   if (!CreateGXRootSignature())
-    PanicAlert("Failed to re-create GX root signature.");
+    PanicAlertFmt("Failed to re-create GX root signature.");
 }
 
 void DXContext::DestroyPendingResources(CommandListResources& cmdlist)

--- a/Source/Core/VideoBackends/D3D12/DXPipeline.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXPipeline.cpp
@@ -171,7 +171,7 @@ std::unique_ptr<DXPipeline> DXPipeline::Create(const AbstractPipelineConfig& con
     desc.pRootSignature = g_dx_context->GetUtilityRootSignature();
     break;
   default:
-    PanicAlert("Unknown pipeline layout.");
+    PanicAlertFmt("Unknown pipeline layout.");
     return nullptr;
   }
 

--- a/Source/Core/VideoBackends/D3D12/DXTexture.cpp
+++ b/Source/Core/VideoBackends/D3D12/DXTexture.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<DXTexture> DXTexture::CreateAdopted(ID3D12Resource* resource)
   if (desc.Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
       format == AbstractTextureFormat::Undefined)
   {
-    PanicAlert("Unknown format for adopted texture");
+    PanicAlertFmt("Unknown format for adopted texture");
     return nullptr;
   }
 
@@ -154,7 +154,7 @@ bool DXTexture::CreateSRVDescriptor()
 {
   if (!g_dx_context->GetDescriptorHeapManager().Allocate(&m_srv_descriptor))
   {
-    PanicAlert("Failed to allocate SRV descriptor");
+    PanicAlertFmt("Failed to allocate SRV descriptor");
     return false;
   }
 
@@ -181,7 +181,7 @@ bool DXTexture::CreateUAVDescriptor()
 {
   if (!g_dx_context->GetDescriptorHeapManager().Allocate(&m_uav_descriptor))
   {
-    PanicAlert("Failed to allocate UAV descriptor");
+    PanicAlertFmt("Failed to allocate UAV descriptor");
     return false;
   }
 
@@ -225,7 +225,7 @@ void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
     staging_buffer = CreateTextureUploadBuffer(upload_size);
     if (!staging_buffer || FAILED(staging_buffer->Map(0, &read_range, &upload_buffer_ptr)))
     {
-      PanicAlert("Failed to allocate/map temporary texture upload buffer");
+      PanicAlertFmt("Failed to allocate/map temporary texture upload buffer");
       return;
     }
 
@@ -245,7 +245,7 @@ void DXTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
       if (!g_dx_context->GetTextureUploadBuffer().ReserveMemory(
               upload_size, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT))
       {
-        PanicAlert("Failed to allocate texture upload buffer");
+        PanicAlertFmt("Failed to allocate texture upload buffer");
         return;
       }
     }
@@ -436,7 +436,7 @@ bool DXFramebuffer::CreateRTVDescriptor()
 {
   if (!g_dx_context->GetRTVHeapManager().Allocate(&m_rtv_descriptor))
   {
-    PanicAlert("Failed to allocate RTV descriptor");
+    PanicAlertFmt("Failed to allocate RTV descriptor");
     return false;
   }
 
@@ -471,7 +471,7 @@ bool DXFramebuffer::CreateDSVDescriptor()
 {
   if (!g_dx_context->GetDSVHeapManager().Allocate(&m_dsv_descriptor))
   {
-    PanicAlert("Failed to allocate RTV descriptor");
+    PanicAlertFmt("Failed to allocate RTV descriptor");
     return false;
   }
 

--- a/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/DescriptorHeapManager.cpp
@@ -63,7 +63,7 @@ bool DescriptorHeapManager::Allocate(DescriptorHandle* handle)
     return true;
   }
 
-  PanicAlert("Out of fixed descriptors");
+  PanicAlertFmt("Out of fixed descriptors");
   return false;
 }
 

--- a/Source/Core/VideoBackends/D3D12/StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/D3D12/StreamBuffer.cpp
@@ -72,8 +72,8 @@ bool StreamBuffer::ReserveMemory(u32 num_bytes, u32 alignment)
   // Check for sane allocations
   if (required_bytes > m_size)
   {
-    PanicAlert("Attempting to allocate %u bytes from a %u byte stream buffer",
-               static_cast<uint32_t>(num_bytes), static_cast<uint32_t>(m_size));
+    PanicAlertFmt("Attempting to allocate {} bytes from a {} byte stream buffer", num_bytes,
+                  m_size);
 
     return false;
   }

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -39,7 +39,7 @@ bool VertexManager::Initialize()
       !m_uniform_stream_buffer.AllocateBuffer(UNIFORM_STREAM_BUFFER_SIZE) ||
       !m_texel_stream_buffer.AllocateBuffer(TEXEL_STREAM_BUFFER_SIZE))
   {
-    PanicAlert("Failed to allocate streaming buffers");
+    PanicAlertFmt("Failed to allocate streaming buffers");
     return false;
   }
 
@@ -55,7 +55,7 @@ bool VertexManager::Initialize()
     DescriptorHandle& dh = m_texel_buffer_views[it.first];
     if (!g_dx_context->GetDescriptorHeapManager().Allocate(&dh))
     {
-      PanicAlert("Failed to allocate descriptor for texel buffer");
+      PanicAlertFmt("Failed to allocate descriptor for texel buffer");
       return false;
     }
 
@@ -92,7 +92,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
 
     // If we still failed, that means the allocation was too large and will never succeed, so panic
     if (!has_vbuffer_allocation || !has_ibuffer_allocation)
-      PanicAlert("Failed to allocate space in streaming buffers for pending draw");
+      PanicAlertFmt("Failed to allocate space in streaming buffers for pending draw");
   }
 
   // Update pointers
@@ -208,7 +208,7 @@ void VertexManager::UploadAllConstants()
   if (!m_uniform_stream_buffer.ReserveMemory(allocation_size,
                                              D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT))
   {
-    PanicAlert("Failed to allocate space for constants in streaming buffer");
+    PanicAlertFmt("Failed to allocate space for constants in streaming buffer");
     return;
   }
 
@@ -270,7 +270,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
     Renderer::GetInstance()->ExecuteCommandList(false);
     if (!m_texel_stream_buffer.ReserveMemory(data_size, elem_size))
     {
-      PanicAlert("Failed to allocate %u bytes from texel buffer", data_size);
+      PanicAlertFmt("Failed to allocate {} bytes from texel buffer", data_size);
       return false;
     }
   }
@@ -300,7 +300,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
     Renderer::GetInstance()->ExecuteCommandList(false);
     if (!m_texel_stream_buffer.ReserveMemory(reserve_size, elem_size))
     {
-      PanicAlert("Failed to allocate %u bytes from texel buffer", reserve_size);
+      PanicAlertFmt("Failed to allocate {} bytes from texel buffer", reserve_size);
       return false;
     }
   }

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -100,7 +100,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
 {
   if (!DXContext::Create(g_Config.iAdapter, g_Config.bEnableValidationLayer))
   {
-    PanicAlert("Failed to create D3D12 context");
+    PanicAlertFmtT("Failed to create D3D12 context");
     return false;
   }
 
@@ -109,7 +109,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
 
   if (!g_dx_context->CreateGlobalResources())
   {
-    PanicAlert("Failed to create D3D12 global resources");
+    PanicAlertFmtT("Failed to create D3D12 global resources");
     DXContext::Destroy();
     ShutdownShared();
     return false;
@@ -118,7 +118,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   std::unique_ptr<SwapChain> swap_chain;
   if (wsi.render_surface && !(swap_chain = SwapChain::Create(wsi)))
   {
-    PanicAlertT("Failed to create D3D swap chain");
+    PanicAlertFmtT("Failed to create D3D swap chain");
     DXContext::Destroy();
     ShutdownShared();
     return false;
@@ -136,7 +136,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
       !g_renderer->Initialize() || !g_framebuffer_manager->Initialize() ||
       !g_texture_cache->Initialize() || !PerfQuery::GetInstance()->Initialize())
   {
-    PanicAlert("Failed to initialize renderer classes");
+    PanicAlertFmtT("Failed to initialize renderer classes");
     Shutdown();
     return false;
   }

--- a/Source/Core/VideoBackends/D3DCommon/Common.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Common.cpp
@@ -33,15 +33,15 @@ bool LoadLibraries()
 
   if (!s_dxgi_library.Open("dxgi.dll"))
   {
-    PanicAlertT("Failed to load dxgi.dll");
+    PanicAlertFmtT("Failed to load dxgi.dll");
     return false;
   }
 
   if (!s_d3dcompiler_library.Open(D3DCOMPILER_DLL_A))
   {
-    PanicAlertT("Failed to load %s. If you are using Windows 7, try installing the "
-                "KB4019990 update package.",
-                D3DCOMPILER_DLL_A);
+    PanicAlertFmtT("Failed to load {0}. If you are using Windows 7, try installing the "
+                   "KB4019990 update package.",
+                   D3DCOMPILER_DLL_A);
     s_dxgi_library.Close();
     return false;
   }
@@ -50,7 +50,7 @@ bool LoadLibraries()
   if (!s_d3dcompiler_library.GetSymbol("D3DCompile", &d3d_compile) ||
       !s_dxgi_library.GetSymbol("CreateDXGIFactory", &create_dxgi_factory))
   {
-    PanicAlertT("Failed to find one or more D3D symbols");
+    PanicAlertFmtT("Failed to find one or more D3D symbols");
     s_d3dcompiler_library.Close();
     s_dxgi_library.Close();
     return false;
@@ -88,7 +88,7 @@ Microsoft::WRL::ComPtr<IDXGIFactory> CreateDXGIFactory(bool debug_device)
   HRESULT hr = create_dxgi_factory(IID_PPV_ARGS(factory.ReleaseAndGetAddressOf()));
   if (FAILED(hr))
   {
-    PanicAlert("CreateDXGIFactory() failed with HRESULT %08X", hr);
+    PanicAlertFmt("CreateDXGIFactory() failed with HRESULT {:08X}", hr);
     return nullptr;
   }
 
@@ -147,7 +147,7 @@ DXGI_FORMAT GetDXGIFormatForAbstractFormat(AbstractTextureFormat format, bool ty
   case AbstractTextureFormat::D32F_S8:
     return DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
   default:
-    PanicAlert("Unhandled texture format.");
+    PanicAlertFmt("Unhandled texture format.");
     return DXGI_FORMAT_R8G8B8A8_UNORM;
   }
 }
@@ -180,7 +180,7 @@ DXGI_FORMAT GetSRVFormatForAbstractFormat(AbstractTextureFormat format)
   case AbstractTextureFormat::D32F_S8:
     return DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS;
   default:
-    PanicAlert("Unhandled SRV format");
+    PanicAlertFmt("Unhandled SRV format");
     return DXGI_FORMAT_UNKNOWN;
   }
 }
@@ -198,7 +198,7 @@ DXGI_FORMAT GetRTVFormatForAbstractFormat(AbstractTextureFormat format, bool int
   case AbstractTextureFormat::R32F:
     return DXGI_FORMAT_R32_FLOAT;
   default:
-    PanicAlert("Unhandled RTV format");
+    PanicAlertFmt("Unhandled RTV format");
     return DXGI_FORMAT_UNKNOWN;
   }
 }
@@ -215,7 +215,7 @@ DXGI_FORMAT GetDSVFormatForAbstractFormat(AbstractTextureFormat format)
   case AbstractTextureFormat::D32F_S8:
     return DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
   default:
-    PanicAlert("Unhandled DSV format");
+    PanicAlertFmt("Unhandled DSV format");
     return DXGI_FORMAT_UNKNOWN;
   }
 }

--- a/Source/Core/VideoBackends/D3DCommon/Shader.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/Shader.cpp
@@ -119,8 +119,8 @@ std::optional<Shader::BinaryData> Shader::CompileShader(D3D_FEATURE_LEVEL featur
     file << "Video Backend: " + g_video_backend->GetDisplayName();
     file.close();
 
-    PanicAlert("Failed to compile %s:\nDebug info (%s):\n%s", filename.c_str(), target,
-               static_cast<const char*>(errors->GetBufferPointer()));
+    PanicAlertFmt("Failed to compile {}:\nDebug info ({}):\n{}", filename, target,
+                  static_cast<const char*>(errors->GetBufferPointer()));
     return std::nullopt;
   }
 

--- a/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
+++ b/Source/Core/VideoBackends/D3DCommon/SwapChain.cpp
@@ -126,7 +126,7 @@ bool SwapChain::CreateSwapChain(bool stereo)
 
   if (FAILED(hr))
   {
-    PanicAlert("Failed to create swap chain with HRESULT %08X", hr);
+    PanicAlertFmt("Failed to create swap chain with HRESULT {:08X}", hr);
     return false;
   }
 
@@ -139,7 +139,7 @@ bool SwapChain::CreateSwapChain(bool stereo)
   m_stereo = stereo;
   if (!CreateSwapChainBuffers())
   {
-    PanicAlert("Failed to create swap chain buffers");
+    PanicAlertFmt("Failed to create swap chain buffers");
     DestroySwapChainBuffers();
     m_swap_chain.Reset();
     return false;
@@ -187,7 +187,7 @@ void SwapChain::SetStereo(bool stereo)
   DestroySwapChain();
   if (!CreateSwapChain(stereo))
   {
-    PanicAlert("Failed to switch swap chain stereo mode");
+    PanicAlertFmt("Failed to switch swap chain stereo mode");
     CreateSwapChain(false);
   }
 }

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -77,7 +77,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
       !g_renderer->Initialize() || !g_framebuffer_manager->Initialize() ||
       !g_texture_cache->Initialize())
   {
-    PanicAlert("Failed to initialize renderer classes");
+    PanicAlertFmt("Failed to initialize renderer classes");
     Shutdown();
     return false;
   }

--- a/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
@@ -48,11 +48,11 @@ static void SetPointer(u32 attrib, u32 stride, const AttributeFormat& format)
 GLVertexFormat::GLVertexFormat(const PortableVertexDeclaration& vtx_decl)
     : NativeVertexFormat(vtx_decl)
 {
-  u32 vertex_stride = vtx_decl.stride;
+  const u32 vertex_stride = vtx_decl.stride;
 
   // We will not allow vertex components causing uneven strides.
   if (vertex_stride & 3)
-    PanicAlert("Uneven vertex stride: %i", vertex_stride);
+    PanicAlertFmt("Uneven vertex stride: {}", vertex_stride);
 
   VertexManager* const vm = static_cast<VertexManager*>(g_vertex_manager.get());
 

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -42,7 +42,7 @@ GLenum GetGLInternalFormatForTextureFormat(AbstractTextureFormat format, bool st
   case AbstractTextureFormat::D32F_S8:
     return GL_DEPTH32F_STENCIL8;
   default:
-    PanicAlert("Unhandled texture format.");
+    PanicAlertFmt("Unhandled texture format.");
     return storage ? GL_RGBA8 : GL_RGBA;
   }
 }
@@ -216,12 +216,15 @@ void OGLTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8
                       size_t buffer_size)
 {
   if (level >= m_config.levels)
-    PanicAlert("Texture only has %d levels, can't update level %d", m_config.levels, level);
-  if (width != std::max(1u, m_config.width >> level) ||
-      height != std::max(1u, m_config.height >> level))
-    PanicAlert("size of level %d must be %dx%d, but %dx%d requested", level,
-               std::max(1u, m_config.width >> level), std::max(1u, m_config.height >> level), width,
-               height);
+    PanicAlertFmt("Texture only has {} levels, can't update level {}", m_config.levels, level);
+
+  const auto expected_width = std::max(1U, m_config.width >> level);
+  const auto expected_height = std::max(1U, m_config.height >> level);
+  if (width != expected_width || height != expected_height)
+  {
+    PanicAlertFmt("Size of level {} must be {}x{}, but {}x{} requested", level, expected_width,
+                  expected_height, width, height);
+  }
 
   const GLenum target = GetGLTarget();
   glActiveTexture(GL_MUTABLE_TEXTURE_INDEX);

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -368,10 +368,10 @@ bool ProgramShaderCache::CheckShaderCompileResult(GLuint id, GLenum type, std::s
       file << "Video Backend: " + g_video_backend->GetDisplayName();
       file.close();
 
-      PanicAlert("Failed to compile %s shader: %s\n"
-                 "Debug info (%s, %s, %s):\n%s",
-                 prefix, filename.c_str(), g_ogl_config.gl_vendor, g_ogl_config.gl_renderer,
-                 g_ogl_config.gl_version, info_log.c_str());
+      PanicAlertFmt("Failed to compile {} shader: {}\n"
+                    "Debug info ({}, {}, {}):\n{}",
+                    prefix, filename, g_ogl_config.gl_vendor, g_ogl_config.gl_renderer,
+                    g_ogl_config.gl_version, info_log);
 
       return false;
     }
@@ -413,10 +413,10 @@ bool ProgramShaderCache::CheckProgramLinkResult(GLuint id, std::string_view vcod
       file << "Video Backend: " + g_video_backend->GetDisplayName();
       file.close();
 
-      PanicAlert("Failed to link shaders: %s\n"
-                 "Debug info (%s, %s, %s):\n%s",
-                 filename.c_str(), g_ogl_config.gl_vendor, g_ogl_config.gl_renderer,
-                 g_ogl_config.gl_version, info_log.c_str());
+      PanicAlertFmt("Failed to link shaders: {}\n"
+                    "Debug info ({}, {}, {}):\n{}",
+                    filename, g_ogl_config.gl_vendor, g_ogl_config.gl_renderer,
+                    g_ogl_config.gl_version, info_log);
 
       return false;
     }
@@ -847,7 +847,7 @@ bool SharedContextAsyncShaderCompiler::WorkerThreadInitMainThread(void** param)
       static_cast<Renderer*>(g_renderer.get())->GetMainGLContext()->CreateSharedContext();
   if (!context)
   {
-    PanicAlert("Failed to create shared context for shader compiling.");
+    PanicAlertFmt("Failed to create shared context for shader compiling.");
     return false;
   }
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -357,8 +357,8 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     {
       // We want the ogl3 framebuffer instead of the ogl2 one for better blitting support.
       // It's also compatible with the gles3 one.
-      PanicAlert("GPU: ERROR: Need GL_ARB_framebuffer_object for multiple render targets.\n"
-                 "GPU: Does your video card support OpenGL 3.0?");
+      PanicAlertFmtT("GPU: ERROR: Need GL_ARB_framebuffer_object for multiple render targets.\n"
+                     "GPU: Does your video card support OpenGL 3.0?");
       bSuccess = false;
     }
 
@@ -366,8 +366,8 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     {
       // This extension is used to replace lots of pointer setting function.
       // Also gles3 requires to use it.
-      PanicAlert("GPU: OGL ERROR: Need GL_ARB_vertex_array_object.\n"
-                 "GPU: Does your video card support OpenGL 3.0?");
+      PanicAlertFmtT("GPU: OGL ERROR: Need GL_ARB_vertex_array_object.\n"
+                     "GPU: Does your video card support OpenGL 3.0?");
       bSuccess = false;
     }
 
@@ -375,8 +375,8 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     {
       // ogl3 buffer mapping for better streaming support.
       // The ogl2 one also isn't in gles3.
-      PanicAlert("GPU: OGL ERROR: Need GL_ARB_map_buffer_range.\n"
-                 "GPU: Does your video card support OpenGL 3.0?");
+      PanicAlertFmtT("GPU: OGL ERROR: Need GL_ARB_map_buffer_range.\n"
+                     "GPU: Does your video card support OpenGL 3.0?");
       bSuccess = false;
     }
 
@@ -384,13 +384,13 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     {
       // ubo allow us to keep the current constants on shader switches
       // we also can stream them much nicer and pack into it whatever we want to
-      PanicAlert("GPU: OGL ERROR: Need GL_ARB_uniform_buffer_object.\n"
-                 "GPU: Does your video card support OpenGL 3.1?");
+      PanicAlertFmtT("GPU: OGL ERROR: Need GL_ARB_uniform_buffer_object.\n"
+                     "GPU: Does your video card support OpenGL 3.1?");
       bSuccess = false;
     }
     else if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_UBO))
     {
-      PanicAlert(
+      PanicAlertFmtT(
           "Buggy GPU driver detected.\n"
           "Please either install the closed-source GPU driver or update your Mesa 3D version.");
       bSuccess = false;
@@ -400,8 +400,8 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     {
       // Our sampler cache uses this extension. It could easyly be workaround and it's by far the
       // highest requirement, but it seems that no driver lacks support for it.
-      PanicAlert("GPU: OGL ERROR: Need GL_ARB_sampler_objects.\n"
-                 "GPU: Does your video card support OpenGL 3.3?");
+      PanicAlertFmtT("GPU: OGL ERROR: Need GL_ARB_sampler_objects.\n"
+                     "GPU: Does your video card support OpenGL 3.3?");
       bSuccess = false;
     }
 
@@ -588,10 +588,10 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
   {
     if (GLExtensions::Version() < 300)
     {
-      PanicAlert("GPU: OGL ERROR: Need at least GLSL 1.30\n"
-                 "GPU: Does your video card support OpenGL 3.0?\n"
-                 "GPU: Your driver supports GLSL %s",
-                 (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION));
+      PanicAlertFmtT("GPU: OGL ERROR: Need at least GLSL 1.30\n"
+                     "GPU: Does your video card support OpenGL 3.0?\n"
+                     "GPU: Your driver supports GLSL {0}",
+                     reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION)));
       bSuccess = false;
     }
     else if (GLExtensions::Version() == 300)
@@ -718,10 +718,11 @@ Renderer::Renderer(std::unique_ptr<GLContext> main_gl_context, float backbuffer_
     // MSAA on default framebuffer isn't working because of glBlitFramebuffer.
     // It also isn't useful as we don't render anything to the default framebuffer.
     // We also try to get a non-msaa fb, so this only happens when forced by the driver.
-    PanicAlertT("The graphics driver is forcibly enabling anti-aliasing for Dolphin. You need to "
-                "turn this off in the graphics driver's settings in order for Dolphin to work.\n\n"
-                "(MSAA with %d samples found on default framebuffer)",
-                samples);
+    PanicAlertFmtT(
+        "The graphics driver is forcibly enabling anti-aliasing for Dolphin. You need to "
+        "turn this off in the graphics driver's settings in order for Dolphin to work.\n\n"
+        "(MSAA with {0} samples found on default framebuffer)",
+        samples);
     bSuccess = false;
   }
 

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -123,15 +123,15 @@ bool VideoBackend::InitializeGLExtensions(GLContext* context)
   {
     // OpenGL 2.0 is required for all shader based drawings. There is no way to get this by
     // extensions
-    PanicAlert("GPU: OGL ERROR: Does your video card support OpenGL 2.0?");
+    PanicAlertFmtT("GPU: OGL ERROR: Does your video card support OpenGL 2.0?");
     return false;
   }
 
   if (GLExtensions::Version() < 300)
   {
     // integer vertex attributes require a gl3 only function
-    PanicAlert("GPU: OGL ERROR: Need OpenGL version 3.\n"
-               "GPU: Does your video card support OpenGL 3?");
+    PanicAlertFmtT("GPU: OGL ERROR: Need OpenGL version 3.\n"
+                   "GPU: Does your video card support OpenGL 3?");
     return false;
   }
 
@@ -147,9 +147,9 @@ bool VideoBackend::FillBackendInfo()
   glGetIntegerv(GL_MAX_VERTEX_ATTRIBS, &numvertexattribs);
   if (numvertexattribs < 16)
   {
-    PanicAlert("GPU: OGL ERROR: Number of attributes %d not enough.\n"
-               "GPU: Does your video card support OpenGL 2.x?",
-               numvertexattribs);
+    PanicAlertFmtT("GPU: OGL ERROR: Number of attributes {0} not enough.\n"
+                   "GPU: Does your video card support OpenGL 2.x?",
+                   numvertexattribs);
     return false;
   }
 
@@ -159,7 +159,7 @@ bool VideoBackend::FillBackendInfo()
   g_Config.backend_info.MaxTextureSize = static_cast<u32>(max_texture_size);
   if (max_texture_size < 1024)
   {
-    PanicAlert("GL_MAX_TEXTURE_SIZE too small at %i - must be at least 1024.", max_texture_size);
+    PanicAlertFmtT("GL_MAX_TEXTURE_SIZE is {0} - must be at least 1024.", max_texture_size);
     return false;
   }
 
@@ -193,7 +193,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
       !g_renderer->Initialize() || !g_framebuffer_manager->Initialize() ||
       !g_texture_cache->Initialize())
   {
-    PanicAlert("Failed to initialize renderer classes");
+    PanicAlertFmtT("Failed to initialize renderer classes");
     Shutdown();
     return false;
   }

--- a/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
+++ b/Source/Core/VideoBackends/Software/SWOGLWindow.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<SWOGLWindow> SWOGLWindow::Create(const WindowSystemInfo& wsi)
   std::unique_ptr<SWOGLWindow> window = std::unique_ptr<SWOGLWindow>(new SWOGLWindow());
   if (!window->Initialize(wsi))
   {
-    PanicAlert("Failed to create OpenGL window");
+    PanicAlertFmt("Failed to create OpenGL window");
     return nullptr;
   }
 

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -112,7 +112,7 @@ bool VideoSoftware::Initialize(const WindowSystemInfo& wsi)
       !g_renderer->Initialize() || !g_framebuffer_manager->Initialize() ||
       !g_texture_cache->Initialize())
   {
-    PanicAlert("Failed to initialize renderer classes");
+    PanicAlertFmt("Failed to initialize renderer classes");
     Shutdown();
     return false;
   }

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -504,7 +504,7 @@ void Tev::Indirect(unsigned int stageNum, s32 s, s32 t)
     AlphaBump = AlphaBump & 0xf8;
     break;
   default:
-    PanicAlert("Tev::Indirect");
+    PanicAlertFmt("Tev::Indirect");
     return;
   }
 

--- a/Source/Core/VideoBackends/Software/TextureEncoder.cpp
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.cpp
@@ -504,7 +504,7 @@ static void EncodeRGBA6(u8* dst, const u8* src, EFBCopyFormat format, bool yuv)
     break;
 
   default:
-    PanicAlert("Unknown texture copy format: 0x%x\n", static_cast<int>(format));
+    PanicAlertFmt("Unknown texture copy format: {:#x}\n", format);
     break;
   }
 }
@@ -743,7 +743,7 @@ static void EncodeRGBA6halfscale(u8* dst, const u8* src, EFBCopyFormat format, b
     break;
 
   default:
-    PanicAlert("Unknown texture copy format: 0x%x\n", static_cast<int>(format));
+    PanicAlertFmt("Unknown texture copy format: {:#x}\n", format);
     break;
   }
 }
@@ -960,7 +960,7 @@ static void EncodeRGB8(u8* dst, const u8* src, EFBCopyFormat format, bool yuv)
     break;
 
   default:
-    PanicAlert("Unknown texture copy format: 0x%x\n", static_cast<int>(format));
+    PanicAlertFmt("Unknown texture copy format: {:#x}\n", format);
     break;
   }
 }
@@ -1192,7 +1192,7 @@ static void EncodeRGB8halfscale(u8* dst, const u8* src, EFBCopyFormat format, bo
     break;
 
   default:
-    PanicAlert("Unknown texture copy format: 0x%x\n", static_cast<int>(format));
+    PanicAlertFmt("Unknown texture copy format: {:#x}\n", format);
     break;
   }
 }
@@ -1300,7 +1300,7 @@ static void EncodeZ24(u8* dst, const u8* src, EFBCopyFormat format)
     break;
 
   default:
-    PanicAlert("Unknown texture copy format: 0x%x\n", static_cast<int>(format));
+    PanicAlertFmt("Unknown texture copy format: {:#x}\n", format);
     break;
   }
 }
@@ -1414,7 +1414,7 @@ static void EncodeZ24halfscale(u8* dst, const u8* src, EFBCopyFormat format)
     break;
 
   default:
-    PanicAlert("Unknown texture copy format: 0x%x\n", static_cast<int>(format));
+    PanicAlertFmt("Unknown texture copy format: {:#x}\n", format);
     break;
   }
 }

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -260,7 +260,7 @@ static float CalculateLightAttn(const LightPointer* light, Vec3* _ldir, const Ve
     break;
   }
   default:
-    PanicAlert("LightColor");
+    PanicAlertFmt("LightColor");
   }
 
   return attn;

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -283,7 +283,7 @@ void CommandBufferManager::SubmitCommandBuffer(bool submit_on_worker_thread,
     if (res != VK_SUCCESS)
     {
       LOG_VULKAN_ERROR(res, "vkEndCommandBuffer failed: ");
-      PanicAlert("Failed to end command buffer");
+      PanicAlertFmt("Failed to end command buffer");
     }
   }
 
@@ -358,7 +358,7 @@ void CommandBufferManager::SubmitCommandBuffer(u32 command_buffer_index,
   if (res != VK_SUCCESS)
   {
     LOG_VULKAN_ERROR(res, "vkQueueSubmit failed: ");
-    PanicAlert("Failed to submit command buffer.");
+    PanicAlertFmt("Failed to submit command buffer.");
   }
 
   // Do we have a swap chain to present?

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -55,7 +55,7 @@ bool ObjectCache::Initialize()
       StreamBuffer::Create(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, TEXTURE_UPLOAD_BUFFER_SIZE);
   if (!m_texture_upload_buffer)
   {
-    PanicAlert("Failed to create texture upload buffer");
+    PanicAlertFmt("Failed to create texture upload buffer");
     return false;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/Vulkan/PerfQuery.cpp
@@ -32,7 +32,7 @@ bool PerfQuery::Initialize()
 {
   if (!CreateQueryPool())
   {
-    PanicAlert("Failed to create query pool");
+    PanicAlertFmt("Failed to create query pool");
     return false;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -67,7 +67,7 @@ bool Renderer::Initialize()
   m_bounding_box = std::make_unique<BoundingBox>();
   if (!m_bounding_box->Initialize())
   {
-    PanicAlert("Failed to initialize bounding box.");
+    PanicAlertFmt("Failed to initialize bounding box.");
     return false;
   }
 
@@ -317,7 +317,7 @@ void Renderer::BindBackbuffer(const ClearColor& clear_color)
     res = m_swap_chain->AcquireNextImage();
   }
   if (res != VK_SUCCESS)
-    PanicAlert("Failed to grab image from swap chain");
+    PanicAlertFmt("Failed to grab image from swap chain");
 
   // Transition from undefined (or present src, but it can be substituted) to
   // color attachment ready for writing. These transitions must occur outside
@@ -385,7 +385,7 @@ void Renderer::CheckForSurfaceChange()
 
   // Recreate the surface. If this fails we're in trouble.
   if (!m_swap_chain->RecreateSurface(m_new_surface_handle))
-    PanicAlert("Failed to recreate Vulkan surface. Cannot continue.");
+    PanicAlertFmt("Failed to recreate Vulkan surface. Cannot continue.");
   m_new_surface_handle = nullptr;
 
   // Handle case where the dimensions are now different.

--- a/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCompiler.cpp
@@ -169,7 +169,7 @@ static std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage,
     stream << "Dolphin Version: " + Common::scm_rev_str + "\n";
     stream << "Video Backend: " + g_video_backend->GetDisplayName();
 
-    PanicAlert("%s (written to %s)", msg, filename.c_str());
+    PanicAlertFmt("{} (written to {})", msg, filename);
   };
 
   if (!shader->parse(GetCompilerResourceLimits(), default_version, profile, false, true, messages,
@@ -250,7 +250,7 @@ bool InitializeGlslang()
 
   if (!glslang::InitializeProcess())
   {
-    PanicAlert("Failed to initialize glslang shader compiler");
+    PanicAlertFmt("Failed to initialize glslang shader compiler");
     return false;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StreamBuffer.cpp
@@ -136,8 +136,8 @@ bool StreamBuffer::ReserveMemory(u32 num_bytes, u32 alignment)
   // Check for sane allocations
   if (required_bytes > m_size)
   {
-    PanicAlert("Attempting to allocate %u bytes from a %u byte stream buffer",
-               static_cast<uint32_t>(num_bytes), static_cast<uint32_t>(m_size));
+    PanicAlertFmt("Attempting to allocate {} bytes from a {} byte stream buffer", num_bytes,
+                  m_size);
 
     return false;
   }

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -182,7 +182,7 @@ bool SwapChain::SelectSurfaceFormat()
     return true;
   }
 
-  PanicAlert("Failed to find a suitable format for swap chain buffers.");
+  PanicAlertFmt("Failed to find a suitable format for swap chain buffers.");
   return false;
 }
 
@@ -398,7 +398,7 @@ bool SwapChain::SetupSwapChainImages()
       m_surface_format.format, VK_FORMAT_UNDEFINED, 1, VK_ATTACHMENT_LOAD_OP_CLEAR);
   if (load_render_pass == VK_NULL_HANDLE || clear_render_pass == VK_NULL_HANDLE)
   {
-    PanicAlert("Failed to get swap chain render passes.");
+    PanicAlertFmt("Failed to get swap chain render passes.");
     return false;
   }
 
@@ -469,7 +469,7 @@ bool SwapChain::ResizeSwapChain()
   DestroySwapChainImages();
   if (!CreateSwapChain() || !SetupSwapChainImages())
   {
-    PanicAlert("Failed to re-configure swap chain images, this is fatal (for now)");
+    PanicAlertFmt("Failed to re-configure swap chain images, this is fatal (for now)");
     return false;
   }
 
@@ -482,7 +482,7 @@ bool SwapChain::RecreateSwapChain()
   DestroySwapChain();
   if (!CreateSwapChain() || !SetupSwapChainImages())
   {
-    PanicAlert("Failed to re-configure swap chain images, this is fatal (for now)");
+    PanicAlertFmt("Failed to re-configure swap chain images, this is fatal (for now)");
     return false;
   }
 
@@ -557,7 +557,7 @@ bool SwapChain::RecreateSurface(void* native_handle)
   }
   if (!present_supported)
   {
-    PanicAlert("Recreated surface does not support presenting.");
+    PanicAlertFmt("Recreated surface does not support presenting.");
     return false;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKPipeline.cpp
@@ -248,7 +248,7 @@ std::unique_ptr<VKPipeline> VKPipeline::Create(const AbstractPipelineConfig& con
     pipeline_layout = g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_UTILITY);
     break;
   default:
-    PanicAlert("Unknown pipeline layout.");
+    PanicAlertFmt("Unknown pipeline layout.");
     return nullptr;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKTexture.cpp
@@ -217,7 +217,7 @@ VkFormat VKTexture::GetVkFormatForHostTextureFormat(AbstractTextureFormat format
     return VK_FORMAT_UNDEFINED;
 
   default:
-    PanicAlert("Unhandled texture format.");
+    PanicAlertFmt("Unhandled texture format.");
     return VK_FORMAT_R8G8B8A8_UNORM;
   }
 }
@@ -375,7 +375,7 @@ void VKTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
 
       // Try allocating again. This may cause a fence wait.
       if (!stream_buffer->ReserveMemory(upload_size, upload_alignment))
-        PanicAlert("Failed to allocate space in texture upload buffer");
+        PanicAlertFmt("Failed to allocate space in texture upload buffer");
     }
     // Copy to the streaming buffer.
     upload_buffer = stream_buffer->GetBuffer();
@@ -390,7 +390,7 @@ void VKTexture::Load(u32 level, u32 width, u32 height, u32 row_length, const u8*
                                         VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     if (!temp_buffer || !temp_buffer->Map())
     {
-      PanicAlert("Failed to allocate staging texture for large texture upload.");
+      PanicAlertFmt("Failed to allocate staging texture for large texture upload.");
       return;
     }
 

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -70,7 +70,7 @@ bool VertexManager::Initialize()
       StreamBuffer::Create(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, UNIFORM_STREAM_BUFFER_SIZE);
   if (!m_vertex_stream_buffer || !m_index_stream_buffer || !m_uniform_stream_buffer)
   {
-    PanicAlert("Failed to allocate streaming buffers");
+    PanicAlertFmt("Failed to allocate streaming buffers");
     return false;
   }
 
@@ -96,7 +96,7 @@ bool VertexManager::Initialize()
       StreamBuffer::Create(VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, texel_buffer_size);
   if (!m_texel_stream_buffer)
   {
-    PanicAlert("Failed to allocate streaming texel buffer");
+    PanicAlertFmt("Failed to allocate streaming texel buffer");
     return false;
   }
 
@@ -112,7 +112,7 @@ bool VertexManager::Initialize()
     if ((m_texel_buffer_views[it.first] = CreateTexelBufferView(m_texel_stream_buffer->GetBuffer(),
                                                                 it.second)) == VK_NULL_HANDLE)
     {
-      PanicAlert("Failed to create texel buffer view");
+      PanicAlertFmt("Failed to create texel buffer view");
       return false;
     }
   }
@@ -161,7 +161,7 @@ void VertexManager::ResetBuffer(u32 vertex_stride)
 
     // If we still failed, that means the allocation was too large and will never succeed, so panic
     if (!has_vbuffer_allocation || !has_ibuffer_allocation)
-      PanicAlert("Failed to allocate space in streaming buffers for pending draw");
+      PanicAlertFmt("Failed to allocate space in streaming buffers for pending draw");
   }
 
   // Update pointers
@@ -277,7 +277,7 @@ void VertexManager::UploadAllConstants()
   // We should only be here if the buffer was full and a command buffer was submitted anyway.
   if (!m_uniform_stream_buffer->ReserveMemory(allocation_size, ub_alignment))
   {
-    PanicAlert("Failed to allocate space for constants in streaming buffer");
+    PanicAlertFmt("Failed to allocate space for constants in streaming buffer");
     return;
   }
 
@@ -344,7 +344,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
     Renderer::GetInstance()->ExecuteCommandBuffer(false, false);
     if (!m_texel_stream_buffer->ReserveMemory(data_size, elem_size))
     {
-      PanicAlert("Failed to allocate %u bytes from texel buffer", data_size);
+      PanicAlertFmt("Failed to allocate {} bytes from texel buffer", data_size);
       return false;
     }
   }
@@ -374,7 +374,7 @@ bool VertexManager::UploadTexelBuffer(const void* data, u32 data_size, TexelBuff
     Renderer::GetInstance()->ExecuteCommandBuffer(false, false);
     if (!m_texel_stream_buffer->ReserveMemory(reserve_size, elem_size))
     {
-      PanicAlert("Failed to allocate %u bytes from texel buffer", reserve_size);
+      PanicAlertFmt("Failed to allocate {} bytes from texel buffer", reserve_size);
       return false;
     }
   }

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -779,7 +779,7 @@ u32 VulkanContext::GetUploadMemoryType(u32 bits, bool* is_coherent)
     return type_index.value();
 
   // Shouldn't happen, there should be at least one host-visible heap.
-  PanicAlert("Unable to get memory type for upload.");
+  PanicAlertFmt("Unable to get memory type for upload.");
   return 0;
 }
 
@@ -821,7 +821,7 @@ u32 VulkanContext::GetReadbackMemoryType(u32 bits, bool* is_coherent)
     return type_index.value();
 
   // We should have at least one host visible memory type...
-  PanicAlert("Unable to get memory type for upload.");
+  PanicAlertFmt("Unable to get memory type for upload.");
   return 0;
 }
 

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -65,14 +65,14 @@ void VideoBackend::InitBackendInfo()
     }
     else
     {
-      PanicAlert("Failed to create Vulkan instance.");
+      PanicAlertFmt("Failed to create Vulkan instance.");
     }
 
     UnloadVulkanLibrary();
   }
   else
   {
-    PanicAlert("Failed to load Vulkan library.");
+    PanicAlertFmt("Failed to load Vulkan library.");
   }
 }
 
@@ -98,7 +98,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
 {
   if (!LoadVulkanLibrary())
   {
-    PanicAlert("Failed to load Vulkan library.");
+    PanicAlertFmt("Failed to load Vulkan library.");
     return false;
   }
 
@@ -118,7 +118,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
       VulkanContext::CreateVulkanInstance(wsi.type, enable_debug_reports, enable_validation_layer);
   if (instance == VK_NULL_HANDLE)
   {
-    PanicAlert("Failed to create Vulkan instance.");
+    PanicAlertFmt("Failed to create Vulkan instance.");
     UnloadVulkanLibrary();
     return false;
   }
@@ -126,7 +126,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   // Load instance function pointers.
   if (!LoadVulkanInstanceFunctions(instance))
   {
-    PanicAlert("Failed to load Vulkan instance functions.");
+    PanicAlertFmt("Failed to load Vulkan instance functions.");
     vkDestroyInstance(instance, nullptr);
     UnloadVulkanLibrary();
     return false;
@@ -137,7 +137,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   VulkanContext::GPUList gpu_list = VulkanContext::EnumerateGPUs(instance);
   if (gpu_list.empty())
   {
-    PanicAlert("No Vulkan physical devices available.");
+    PanicAlertFmt("No Vulkan physical devices available.");
     vkDestroyInstance(instance, nullptr);
     UnloadVulkanLibrary();
     return false;
@@ -154,7 +154,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
     surface = SwapChain::CreateVulkanSurface(instance, wsi);
     if (surface == VK_NULL_HANDLE)
     {
-      PanicAlert("Failed to create Vulkan surface.");
+      PanicAlertFmt("Failed to create Vulkan surface.");
       vkDestroyInstance(instance, nullptr);
       UnloadVulkanLibrary();
       return false;
@@ -175,7 +175,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
                                            enable_debug_reports, enable_validation_layer);
   if (!g_vulkan_context)
   {
-    PanicAlert("Failed to create Vulkan device");
+    PanicAlertFmt("Failed to create Vulkan device");
     UnloadVulkanLibrary();
     return false;
   }
@@ -197,7 +197,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   g_command_buffer_mgr = std::make_unique<CommandBufferManager>(g_Config.bBackendMultithreading);
   if (!g_command_buffer_mgr->Initialize())
   {
-    PanicAlert("Failed to create Vulkan command buffers");
+    PanicAlertFmt("Failed to create Vulkan command buffers");
     Shutdown();
     return false;
   }
@@ -206,7 +206,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
   g_object_cache = std::make_unique<ObjectCache>();
   if (!g_object_cache->Initialize())
   {
-    PanicAlert("Failed to initialize Vulkan object cache.");
+    PanicAlertFmt("Failed to initialize Vulkan object cache.");
     Shutdown();
     return false;
   }
@@ -218,7 +218,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
     swap_chain = SwapChain::Create(wsi, surface, g_ActiveConfig.bVSyncActive);
     if (!swap_chain)
     {
-      PanicAlert("Failed to create Vulkan swap chain.");
+      PanicAlertFmt("Failed to create Vulkan swap chain.");
       Shutdown();
       return false;
     }
@@ -226,7 +226,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
 
   if (!StateTracker::CreateInstance())
   {
-    PanicAlert("Failed to create state tracker");
+    PanicAlertFmt("Failed to create state tracker");
     Shutdown();
     return false;
   }
@@ -243,7 +243,7 @@ bool VideoBackend::Initialize(const WindowSystemInfo& wsi)
       !g_renderer->Initialize() || !g_framebuffer_manager->Initialize() ||
       !g_texture_cache->Initialize() || !PerfQuery::GetInstance()->Initialize())
   {
-    PanicAlert("Failed to initialize renderer classes");
+    PanicAlertFmt("Failed to initialize renderer classes");
     Shutdown();
     return false;
   }
@@ -351,7 +351,7 @@ void VideoBackend::PrepareWindow(WindowSystemInfo& wsi)
   // the user that this is an unsupported configuration, but permit them to continue.
   if (!IsRunningOnMojaveOrHigher())
   {
-    PanicAlertT(
+    PanicAlertFmtT(
         "You are attempting to use the Vulkan (Metal) backend on an unsupported operating system. "
         "For all functionality to be enabled, you must use macOS 10.14 (Mojave) or newer. Please "
         "do not report any issues encountered unless they also occur on 10.14+.");

--- a/Source/Core/VideoCommon/FrameDump.cpp
+++ b/Source/Core/VideoCommon/FrameDump.cpp
@@ -95,7 +95,7 @@ std::string GetDumpPath(const std::string& extension, std::time_t time, u32 inde
   if (File::Exists(path))
   {
     if (SConfig::GetInstance().m_DumpFramesSilent ||
-        AskYesNoT("Delete the existing file '%s'?", path.c_str()))
+        AskYesNoFmtT("Delete the existing file '{0}'?", path))
     {
       File::Delete(path);
     }


### PR DESCRIPTION
Converts lingering panic alert calls over to the fmt-capable ones.