### PR TITLE
Exclude Discord RPC lib from installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,7 +794,7 @@ endif()
 
 if(USE_DISCORD_PRESENCE)
   message(STATUS "Using static DiscordRPC from Externals")
-  add_subdirectory(Externals/discord-rpc)
+  add_subdirectory(Externals/discord-rpc EXCLUDE_FROM_ALL)
   include_directories(Externals/discord-rpc/include)
 endif()
 


### PR DESCRIPTION
This vendored library does not need to be installed,
as it is statically linked in. See https://github.com/dolphin-emu/dolphin/pull/6983#issuecomment-401833791