### PR TITLE
Patches for Resident Evil 2/3 audio issues

### DIFF
--- a/Data/Sys/GameSettings/GHAE08.ini
+++ b/Data/Sys/GameSettings/GHAE08.ini
@@ -1,0 +1,16 @@
+# GHAE08 - Resident Evil 2
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x800339E4:dword:0x60000000
+# leon.rel
+0x8055ACBC:dword:0x60000000:0x4BAA8445
+# claire.rel
+0x8055AB54:dword:0x60000000:0x4BAA85AD
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GHAJ08.ini
+++ b/Data/Sys/GameSettings/GHAJ08.ini
@@ -1,0 +1,16 @@
+# GHAJ08 - Biohazard 2
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x80065FFC:dword:0x60000000
+# leon.rel
+0x805C5CC4:dword:0x60000000:0x4BA3D43D
+# claire.rel
+0x805C5BFC:dword:0x60000000:0x4BA3D505
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GHAP08.ini
+++ b/Data/Sys/GameSettings/GHAP08.ini
@@ -1,0 +1,32 @@
+# GHAP08 - Resident Evil 2
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x80033D60:dword:0x60000000
+# leon.rel
+0x8055C5F8:dword:0x60000000:0x4BAA6B09
+# claire.rel
+0x8055C490:dword:0x60000000:0x4BAA6C71
+# leon_g.rel
+0x8055C3B8:dword:0x60000000:0x4BAA6D49
+# claire_g.rel
+0x8055C328:dword:0x60000000:0x4BAA6DD9
+# leon_f.rel
+0x8055D188:dword:0x60000000:0x4BAA5F79
+# claire_f.rel
+0x8055D068:dword:0x60000000:0x4BAA6099
+# leon_s.rel
+0x8055D100:dword:0x60000000:0x4BAA6001
+# claire_s.rel
+0x8055D064:dword:0x60000000:0x4BAA609D
+# leon_i.rel
+0x8055CFDC:dword:0x60000000:0x4BAA6125
+# claire_i.rel
+0x8055CEBC:dword:0x60000000:0x4BAA6245
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEE08.ini
+++ b/Data/Sys/GameSettings/GLEE08.ini
@@ -1,0 +1,12 @@
+# GLEE08 - Resident Evil 3: Nemesis
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x80150E94:dword:0x60000000
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEJ08.ini
+++ b/Data/Sys/GameSettings/GLEJ08.ini
@@ -1,0 +1,12 @@
+# GLEJ08 - BioHazard 3: Last Escape
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# main.dol
+0x8015110C:dword:0x60000000
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Data/Sys/GameSettings/GLEP08.ini
+++ b/Data/Sys/GameSettings/GLEP08.ini
@@ -1,0 +1,20 @@
+# GLEP08 - Resident Evil 3: Nemesis
+
+[OnFrame]
+# Work around a game bug that causes background sounds to be zeroed during load.
+# The bug was masked on real hardware by dcache. This patch fully fixes the bug
+# and should also work on real hardware. Dolphin doesn't emulate dcache because
+# the performance hit would be huge.
+$Fix audio issues
+# eng.rel
+0x8058C174:dword:0x60000000:0x4BA76F8D
+# ger.rel
+0x8058CE40:dword:0x60000000:0x4BA762C1
+# fra.rel
+0x8058D03C:dword:0x60000000:0x4BA760C5
+# spa.rel
+0x8058D024:dword:0x60000000:0x4BA760DD
+# ita.rel
+0x8058CEA4:dword:0x60000000:0x4BA7625D
+[OnFrame_Enabled]
+$Fix audio issues

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -90,6 +90,11 @@ void LoadPatchSection(const std::string& section, std::vector<Patch>& patches, I
           bool success = true;
           success &= TryParse(items[0], &pE.address);
           success &= TryParse(items[2], &pE.value);
+          if (items.size() >= 4)
+          {
+            success &= TryParse(items[3], &pE.comparand);
+            pE.conditional = true;
+          }
 
           const auto iter =
               std::find(s_patch_type_strings.begin(), s_patch_type_strings.end(), items[1]);
@@ -184,16 +189,20 @@ static void ApplyPatches(const std::vector<Patch>& patches)
       {
         u32 addr = entry.address;
         u32 value = entry.value;
+        u32 comparand = entry.comparand;
         switch (entry.type)
         {
         case PatchType::Patch8Bit:
-          PowerPC::HostWrite_U8(static_cast<u8>(value), addr);
+          if (!entry.conditional || PowerPC::HostRead_U8(addr) == static_cast<u8>(comparand))
+            PowerPC::HostWrite_U8(static_cast<u8>(value), addr);
           break;
         case PatchType::Patch16Bit:
-          PowerPC::HostWrite_U16(static_cast<u16>(value), addr);
+          if (!entry.conditional || PowerPC::HostRead_U16(addr) == static_cast<u16>(comparand))
+            PowerPC::HostWrite_U16(static_cast<u16>(value), addr);
           break;
         case PatchType::Patch32Bit:
-          PowerPC::HostWrite_U32(value, addr);
+          if (!entry.conditional || PowerPC::HostRead_U32(addr) == comparand)
+            PowerPC::HostWrite_U32(value, addr);
           break;
         default:
           // unknown patchtype

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -27,6 +27,8 @@ struct PatchEntry
   PatchType type = PatchType::Patch8Bit;
   u32 address = 0;
   u32 value = 0;
+  u32 comparand = 0;
+  bool conditional = false;
 };
 
 struct Patch

--- a/Source/Core/DolphinQt/Config/NewPatchDialog.h
+++ b/Source/Core/DolphinQt/Config/NewPatchDialog.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include <QDialog>
@@ -21,10 +22,13 @@ class QLineEdit;
 class QVBoxLayout;
 class QPushButton;
 
+struct NewPatchEntry;
+
 class NewPatchDialog : public QDialog
 {
 public:
   explicit NewPatchDialog(QWidget* parent, PatchEngine::Patch& patch);
+  ~NewPatchDialog() override;
 
 private:
   void CreateWidgets();
@@ -33,7 +37,7 @@ private:
 
   void accept() override;
 
-  QGroupBox* CreateEntry(PatchEngine::PatchEntry& entry);
+  QGroupBox* CreateEntry(const PatchEngine::PatchEntry& entry);
 
   QLineEdit* m_name_edit;
   QWidget* m_entry_widget;
@@ -41,7 +45,7 @@ private:
   QPushButton* m_add_button;
   QDialogButtonBox* m_button_box;
 
-  std::vector<QLineEdit*> m_edits;
+  std::vector<std::unique_ptr<NewPatchEntry>> m_entries;
 
   PatchEngine::Patch& m_patch;
 };

--- a/Source/Core/DolphinQt/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.cpp
@@ -8,6 +8,8 @@
 #include <QListWidget>
 #include <QPushButton>
 
+#include <fmt/format.h>
+
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
@@ -143,8 +145,17 @@ void PatchesWidget::SavePatches()
 
     for (const auto& entry : patch.entries)
     {
-      lines.emplace_back(StringFromFormat("0x%08X:%s:0x%08X", entry.address,
-                                          PatchEngine::PatchTypeAsString(entry.type), entry.value));
+      if (!entry.conditional)
+      {
+        lines.emplace_back(fmt::format("0x{:08X}:{}:0x{:08X}", entry.address,
+                                       PatchEngine::PatchTypeAsString(entry.type), entry.value));
+      }
+      else
+      {
+        lines.emplace_back(fmt::format("0x{:08X}:{}:0x{:08X}:0x{:08X}", entry.address,
+                                       PatchEngine::PatchTypeAsString(entry.type), entry.value,
+                                       entry.comparand));
+      }
     }
   }
 


### PR DESCRIPTION
These games are erroneously zeroing buffers before they can be fully copied to ARAM by DMA. The responsible memset() calls are followed by a call to DVDRead() which issues dcbi instructions that effectively cancel the memset() on real hardware. Because Dolphin lacks dcache emulation, the effects of the memset() calls are observed, which causes missing audio.

In a comment on the original bug, phire noted that the issue can be corrected by simply nop'ing out the offending memset() calls. Because the games dynamically load different .rel executables based on the character and/or language, the addresses of these calls can vary.

To deal generally with the problem of dynamic code being loaded to fixed, known addresses, the patch engine is extended to support conditional patches which require a match against a known value. This sort of thing is already achievable with Action Replay codes, but their use depends on enabling cheats globally in Dolphin, which is not a prerequisite shared by patches.

Patches are included for every region, character, and language combination.

The end result is an approximation of the games' behavior on real hardware without the associated complexity of proper dcache emulation.

https://bugs.dolphin-emu.org/issues/9840