### PR TITLE
Turn format string issues into compile-time errors

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -93,6 +93,12 @@ else()
   if (HAS_STRINGOP_TRUNCATION_WARNING)
     check_and_add_flag(NO_STRINGOP_TRUNCATION -Wno-stringop-truncation)
   endif()
+
+  # Format string issues that the compiler can detect should be compile time errors.
+  check_cxx_compiler_flag(-Wformat HAS_FORMAT_WARNING)
+  if (HAS_FORMAT_WARNING)
+    check_and_add_flag(FORMAT_WARNING_TO_ERROR -Werror=format)
+  endif()
 endif()
 
 # These aren't actually needed for C11/C++11

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/ConvertDoubleToSingle.cpp
@@ -14,6 +14,7 @@
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 namespace
@@ -109,7 +110,7 @@ TEST(Jit64, ConvertDoubleToSingle)
     const u32 expected = ConvertToSingle(input);
     const u32 actual = routines.wrapped_cdts(input);
 
-    printf("%016llx -> %08x == %08x\n", input, actual, expected);
+    fmt::print("{:016x} -> {:08x} == {:08x}\n", input, actual, expected);
 
     EXPECT_EQ(expected, actual);
   }

--- a/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
+++ b/Source/UnitTests/Core/PowerPC/Jit64Common/Frsqrte.cpp
@@ -14,6 +14,7 @@
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 namespace
@@ -98,7 +99,7 @@ TEST(Jit64, Frsqrte)
 
     u64 actual = routines.wrapped_frsqrte(ivalue, fpscr);
 
-    printf("%016llx -> %016llx == %016llx\n", ivalue, actual, expected);
+    fmt::print("{:016x} -> {:016x} == {:016x}\n", ivalue, actual, expected);
 
     EXPECT_EQ(expected, actual);
   }


### PR DESCRIPTION
If the compiler can detect an issue with a format string at compile
time, then we should take advantage of that and turn the issue into a
hard compile-time error as such problems almost always lead to UB.

This helps with catching logging or assertion messages that have been
converted over to fmt but are still using the old, non-fmt variants
of the logging macros.

This commit also fixes all incorrect usages that I could find.

(Rebased version of #9284 which GitHub stopped updating for some reason)