### PR TITLE
Add caching to Config::Info

### DIFF
--- a/Source/Android/jni/NativeConfig.cpp
+++ b/Source/Android/jni/NativeConfig.cpp
@@ -86,7 +86,7 @@ template <typename T>
 static void Set(jint layer, const Config::Location& location, T value)
 {
   GetLayer(layer, location)->Set(location, value);
-  Config::InvokeConfigChangedCallbacks();
+  Config::OnConfigChanged();
 }
 
 #ifdef __cplusplus

--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <atomic>
 #include <list>
 #include <map>
 #include <mutex>
@@ -17,6 +18,7 @@ using Layers = std::map<LayerType, std::shared_ptr<Layer>>;
 static Layers s_layers;
 static std::list<ConfigChangedCallback> s_callbacks;
 static u32 s_callback_guards = 0;
+static std::atomic<u64> s_config_version = 0;
 
 static std::shared_mutex s_layers_rw_lock;
 
@@ -31,7 +33,7 @@ static void AddLayerInternal(std::shared_ptr<Layer> layer)
     const Config::LayerType layer_type = layer->GetLayer();
     s_layers.insert_or_assign(layer_type, std::move(layer));
   }
-  InvokeConfigChangedCallbacks();
+  OnConfigChanged();
 }
 
 void AddLayer(std::unique_ptr<ConfigLayerLoader> loader)
@@ -59,7 +61,7 @@ void RemoveLayer(LayerType layer)
 
     s_layers.erase(layer);
   }
-  InvokeConfigChangedCallbacks();
+  OnConfigChanged();
 }
 
 void AddConfigChangedCallback(ConfigChangedCallback func)
@@ -67,13 +69,20 @@ void AddConfigChangedCallback(ConfigChangedCallback func)
   s_callbacks.emplace_back(std::move(func));
 }
 
-void InvokeConfigChangedCallbacks()
+void OnConfigChanged()
 {
   if (s_callback_guards)
     return;
 
+  s_config_version.fetch_add(1, std::memory_order_relaxed);
+
   for (const auto& callback : s_callbacks)
     callback();
+}
+
+u64 GetConfigVersion()
+{
+  return s_config_version.load(std::memory_order_relaxed);
 }
 
 // Explicit load and save of layers
@@ -85,7 +94,7 @@ void Load()
     for (auto& layer : s_layers)
       layer.second->Load();
   }
-  InvokeConfigChangedCallbacks();
+  OnConfigChanged();
 }
 
 void Save()
@@ -96,7 +105,7 @@ void Save()
     for (auto& layer : s_layers)
       layer.second->Save();
   }
-  InvokeConfigChangedCallbacks();
+  OnConfigChanged();
 }
 
 void Init()
@@ -207,7 +216,7 @@ ConfigChangeCallbackGuard::~ConfigChangeCallbackGuard()
   if (--s_callback_guards)
     return;
 
-  InvokeConfigChangedCallbacks();
+  OnConfigChanged();
 }
 
 }  // namespace Config

--- a/Source/Core/Common/Config/Config.h
+++ b/Source/Core/Common/Config/Config.h
@@ -52,11 +52,11 @@ T Get(LayerType layer, const Info<T>& info)
 template <typename T>
 T Get(const Info<T>& info)
 {
-  const std::optional<std::string> str = GetAsString(info.location);
+  const std::optional<std::string> str = GetAsString(info.GetLocation());
   if (!str)
-    return info.default_value;
+    return info.GetDefaultValue();
 
-  return detail::TryParse<T>(*str).value_or(info.default_value);
+  return detail::TryParse<T>(*str).value_or(info.GetDefaultValue());
 }
 
 template <typename T>
@@ -68,7 +68,7 @@ T GetBase(const Info<T>& info)
 template <typename T>
 LayerType GetActiveLayerForConfig(const Info<T>& info)
 {
-  return GetActiveLayerForConfig(info.location);
+  return GetActiveLayerForConfig(info.GetLocation());
 }
 
 template <typename T>

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -4,9 +4,13 @@
 
 #pragma once
 
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <type_traits>
+#include <utility>
 
+#include "Common/CommonTypes.h"
 #include "Common/Config/Enums.h"
 
 namespace Config
@@ -30,29 +34,92 @@ struct Location
 };
 
 template <typename T>
+struct CachedValue
+{
+  T value;
+  u64 config_version;
+};
+
+template <typename T>
 class Info
 {
 public:
   constexpr Info(const Location& location, const T& default_value)
-      : m_location{location}, m_default_value{default_value}
+      : m_location{location}, m_default_value{default_value}, m_cached_value{default_value, 0}
   {
+  }
+
+  Info(const Info<T>& other) { *this = other; }
+
+  // Not thread-safe
+  Info(Info<T>&& other) { *this = std::move(other); }
+
+  // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
+  // so that enum settings can still easily work with code that doesn't care about the enum values.
+  template <typename Enum,
+            std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
+  Info(const Info<Enum>& other)
+  {
+    *this = other;
+  }
+
+  Info<T>& operator=(const Info<T>& other)
+  {
+    m_location = other.GetLocation();
+    m_default_value = other.GetDefaultValue();
+    m_cached_value = other.GetCachedValue();
+    return *this;
+  }
+
+  // Not thread-safe
+  Info<T>& operator=(Info<T>&& other)
+  {
+    m_location = std::move(other.m_location);
+    m_default_value = std::move(other.m_default_value);
+    m_cached_value = std::move(other.m_cached_value);
+    return *this;
   }
 
   // Make it easy to convert Info<Enum> into Info<UnderlyingType<Enum>>
   // so that enum settings can still easily work with code that doesn't care about the enum values.
   template <typename Enum,
             std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  constexpr Info(const Info<Enum>& other)
-      : m_location{other.GetLocation()}, m_default_value{static_cast<detail::UnderlyingType<Enum>>(
-                                             other.GetDefaultValue())}
+  Info<T>& operator=(const Info<Enum>& other)
   {
+    m_location = other.GetLocation();
+    m_default_value = static_cast<T>(other.GetDefaultValue());
+    m_cached_value = other.template GetCachedValueCasted<T>();
+    return *this;
   }
 
   constexpr const Location& GetLocation() const { return m_location; }
   constexpr const T& GetDefaultValue() const { return m_default_value; }
 
+  CachedValue<T> GetCachedValue() const
+  {
+    std::shared_lock lock(m_cached_value_mutex);
+    return m_cached_value;
+  }
+
+  template <typename U>
+  CachedValue<U> GetCachedValueCasted() const
+  {
+    std::shared_lock lock(m_cached_value_mutex);
+    return CachedValue<U>{static_cast<U>(m_cached_value.value), m_cached_value.config_version};
+  }
+
+  void SetCachedValue(const CachedValue<T>& cached_value) const
+  {
+    std::unique_lock lock(m_cached_value_mutex);
+    if (m_cached_value.config_version < cached_value.config_version)
+      m_cached_value = cached_value;
+  }
+
 private:
   Location m_location;
   T m_default_value;
+
+  mutable CachedValue<T> m_cached_value;
+  mutable std::shared_mutex m_cached_value_mutex;
 };
 }  // namespace Config

--- a/Source/Core/Common/Config/ConfigInfo.h
+++ b/Source/Core/Common/Config/ConfigInfo.h
@@ -30,10 +30,11 @@ struct Location
 };
 
 template <typename T>
-struct Info
+class Info
 {
-  Info(const Location& location_, const T& default_value_)
-      : location{location_}, default_value{default_value_}
+public:
+  constexpr Info(const Location& location, const T& default_value)
+      : m_location{location}, m_default_value{default_value}
   {
   }
 
@@ -41,13 +42,17 @@ struct Info
   // so that enum settings can still easily work with code that doesn't care about the enum values.
   template <typename Enum,
             std::enable_if_t<std::is_same<T, detail::UnderlyingType<Enum>>::value>* = nullptr>
-  Info(const Info<Enum>& other)
-      : location{other.location}, default_value{static_cast<detail::UnderlyingType<Enum>>(
-                                      other.default_value)}
+  constexpr Info(const Info<Enum>& other)
+      : m_location{other.GetLocation()}, m_default_value{static_cast<detail::UnderlyingType<Enum>>(
+                                             other.GetDefaultValue())}
   {
   }
 
-  Location location;
-  T default_value;
+  constexpr const Location& GetLocation() const { return m_location; }
+  constexpr const T& GetDefaultValue() const { return m_default_value; }
+
+private:
+  Location m_location;
+  T m_default_value;
 };
 }  // namespace Config

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -45,7 +45,7 @@ inline std::optional<std::string> TryParse(const std::string& str_value)
 }  // namespace detail
 
 template <typename T>
-struct Info;
+class Info;
 
 class Layer;
 using LayerMap = std::map<Location, std::optional<std::string>>;
@@ -105,7 +105,7 @@ public:
   template <typename T>
   T Get(const Info<T>& config_info) const
   {
-    return Get<T>(config_info.location).value_or(config_info.default_value);
+    return Get<T>(config_info.GetLocation()).value_or(config_info.GetDefaultValue());
   }
 
   template <typename T>
@@ -120,7 +120,7 @@ public:
   template <typename T>
   void Set(const Info<T>& config_info, const std::common_type_t<T>& value)
   {
-    Set(config_info.location, value);
+    Set(config_info.GetLocation(), value);
   }
 
   template <typename T>

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -472,11 +472,11 @@ static void RestoreSYSCONF()
   for (const auto& setting : Config::SYSCONF_SETTINGS)
   {
     std::visit(
-        [&](auto& info) {
+        [&](auto* info) {
           // If this setting was overridden, then we copy the base layer value back to the SYSCONF.
           // Otherwise we leave the new value in the SYSCONF.
-          if (Config::GetActiveLayerForConfig(info) == Config::LayerType::Base)
-            Config::SetBase(info, temp_layer.Get(info));
+          if (Config::GetActiveLayerForConfig(*info) == Config::LayerType::Base)
+            Config::SetBase(*info, temp_layer.Get(*info));
         },
         setting.config_info);
   }

--- a/Source/Core/Core/Config/SYSCONFSettings.cpp
+++ b/Source/Core/Core/Config/SYSCONFSettings.cpp
@@ -24,15 +24,15 @@ const Info<u32> SYSCONF_SPEAKER_VOLUME{{System::SYSCONF, "BT", "SPKV"}, 0x58};
 const Info<bool> SYSCONF_WIIMOTE_MOTOR{{System::SYSCONF, "BT", "MOT"}, true};
 
 const std::array<SYSCONFSetting, 11> SYSCONF_SETTINGS{
-    {{SYSCONF_SCREENSAVER, SysConf::Entry::Type::Byte},
-     {SYSCONF_LANGUAGE, SysConf::Entry::Type::Byte},
-     {SYSCONF_COUNTRY, SysConf::Entry::Type::BigArray},
-     {SYSCONF_WIDESCREEN, SysConf::Entry::Type::Byte},
-     {SYSCONF_PROGRESSIVE_SCAN, SysConf::Entry::Type::Byte},
-     {SYSCONF_PAL60, SysConf::Entry::Type::Byte},
-     {SYSCONF_SOUND_MODE, SysConf::Entry::Type::Byte},
-     {SYSCONF_SENSOR_BAR_POSITION, SysConf::Entry::Type::Byte},
-     {SYSCONF_SENSOR_BAR_SENSITIVITY, SysConf::Entry::Type::Long},
-     {SYSCONF_SPEAKER_VOLUME, SysConf::Entry::Type::Byte},
-     {SYSCONF_WIIMOTE_MOTOR, SysConf::Entry::Type::Byte}}};
+    {{&SYSCONF_SCREENSAVER, SysConf::Entry::Type::Byte},
+     {&SYSCONF_LANGUAGE, SysConf::Entry::Type::Byte},
+     {&SYSCONF_COUNTRY, SysConf::Entry::Type::BigArray},
+     {&SYSCONF_WIDESCREEN, SysConf::Entry::Type::Byte},
+     {&SYSCONF_PROGRESSIVE_SCAN, SysConf::Entry::Type::Byte},
+     {&SYSCONF_PAL60, SysConf::Entry::Type::Byte},
+     {&SYSCONF_SOUND_MODE, SysConf::Entry::Type::Byte},
+     {&SYSCONF_SENSOR_BAR_POSITION, SysConf::Entry::Type::Byte},
+     {&SYSCONF_SENSOR_BAR_SENSITIVITY, SysConf::Entry::Type::Long},
+     {&SYSCONF_SPEAKER_VOLUME, SysConf::Entry::Type::Byte},
+     {&SYSCONF_WIIMOTE_MOTOR, SysConf::Entry::Type::Byte}}};
 }  // namespace Config

--- a/Source/Core/Core/Config/SYSCONFSettings.h
+++ b/Source/Core/Core/Config/SYSCONFSettings.h
@@ -33,7 +33,7 @@ extern const Info<bool> SYSCONF_WIIMOTE_MOTOR;
 
 struct SYSCONFSetting
 {
-  std::variant<Info<u32>, Info<bool>> config_info;
+  std::variant<const Info<u32>*, const Info<bool>*> config_info;
   SysConf::Entry::Type type;
 };
 

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -41,7 +41,7 @@ void SaveToSYSCONF(Config::LayerType layer)
   {
     std::visit(
         [layer, &setting, &sysconf](auto& info) {
-          const std::string key = info.location.section + "." + info.location.key;
+          const std::string key = info.GetLocation().section + "." + info.GetLocation().key;
 
           if (setting.type == SysConf::Entry::Type::Long)
           {
@@ -180,27 +180,28 @@ private:
     {
       std::visit(
           [&](auto& info) {
-            const std::string key = info.location.section + "." + info.location.key;
+            const Config::Location location = info.GetLocation();
+            const std::string key = location.section + "." + location.key;
             if (setting.type == SysConf::Entry::Type::Long)
             {
-              layer->Set(info.location, sysconf.GetData<u32>(key, info.default_value));
+              layer->Set(location, sysconf.GetData<u32>(key, info.GetDefaultValue()));
             }
             else if (setting.type == SysConf::Entry::Type::Byte)
             {
-              layer->Set(info.location, sysconf.GetData<u8>(key, info.default_value));
+              layer->Set(location, sysconf.GetData<u8>(key, info.GetDefaultValue()));
             }
             else if (setting.type == SysConf::Entry::Type::BigArray)
             {
               // Somewhat hacky support for IPL.SADR. The setting only stores the
               // first 4 bytes even thought the SYSCONF entry is much bigger.
-              u32 value = info.default_value;
+              u32 value = info.GetDefaultValue();
               SysConf::Entry* entry = sysconf.GetEntry(key);
               if (entry)
               {
                 std::memcpy(&value, entry->bytes.data(),
                             std::min(entry->bytes.size(), sizeof(u32)));
               }
-              layer->Set(info.location, value);
+              layer->Set(location, value);
             }
           },
           setting.config_info);

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -69,10 +69,10 @@ using INIToSectionMap = std::map<std::string, std::pair<Config::System, std::str
 static const INIToLocationMap& GetINIToLocationMap()
 {
   static const INIToLocationMap ini_to_location = {
-      {{"Core", "ProgressiveScan"}, {Config::SYSCONF_PROGRESSIVE_SCAN.location}},
-      {{"Core", "PAL60"}, {Config::SYSCONF_PAL60.location}},
-      {{"Wii", "Widescreen"}, {Config::SYSCONF_WIDESCREEN.location}},
-      {{"Wii", "Language"}, {Config::SYSCONF_LANGUAGE.location}},
+      {{"Core", "ProgressiveScan"}, {Config::SYSCONF_PROGRESSIVE_SCAN.GetLocation()}},
+      {{"Core", "PAL60"}, {Config::SYSCONF_PAL60.GetLocation()}},
+      {{"Wii", "Widescreen"}, {Config::SYSCONF_WIDESCREEN.GetLocation()}},
+      {{"Wii", "Language"}, {Config::SYSCONF_LANGUAGE.GetLocation()}},
   };
   return ini_to_location;
 }

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -36,32 +36,32 @@ bool IsSettingSaveable(const Config::Location& config_location)
   static constexpr std::array<const Config::Location*, 17> s_setting_saveable = {
       // Main.Core
 
-      &Config::MAIN_DEFAULT_ISO.location,
-      &Config::MAIN_MEMCARD_A_PATH.location,
-      &Config::MAIN_MEMCARD_B_PATH.location,
-      &Config::MAIN_AUTO_DISC_CHANGE.location,
-      &Config::MAIN_ALLOW_SD_WRITES.location,
-      &Config::MAIN_DPL2_DECODER.location,
-      &Config::MAIN_DPL2_QUALITY.location,
-      &Config::MAIN_RAM_OVERRIDE_ENABLE.location,
-      &Config::MAIN_MEM1_SIZE.location,
-      &Config::MAIN_MEM2_SIZE.location,
-      &Config::MAIN_GFX_BACKEND.location,
-      &Config::MAIN_ENABLE_SAVESTATES.location,
-      &Config::MAIN_FALLBACK_REGION.location,
+      &Config::MAIN_DEFAULT_ISO.GetLocation(),
+      &Config::MAIN_MEMCARD_A_PATH.GetLocation(),
+      &Config::MAIN_MEMCARD_B_PATH.GetLocation(),
+      &Config::MAIN_AUTO_DISC_CHANGE.GetLocation(),
+      &Config::MAIN_ALLOW_SD_WRITES.GetLocation(),
+      &Config::MAIN_DPL2_DECODER.GetLocation(),
+      &Config::MAIN_DPL2_QUALITY.GetLocation(),
+      &Config::MAIN_RAM_OVERRIDE_ENABLE.GetLocation(),
+      &Config::MAIN_MEM1_SIZE.GetLocation(),
+      &Config::MAIN_MEM2_SIZE.GetLocation(),
+      &Config::MAIN_GFX_BACKEND.GetLocation(),
+      &Config::MAIN_ENABLE_SAVESTATES.GetLocation(),
+      &Config::MAIN_FALLBACK_REGION.GetLocation(),
 
       // Main.Interface
 
-      &Config::MAIN_USE_PANIC_HANDLERS.location,
-      &Config::MAIN_OSD_MESSAGES.location,
+      &Config::MAIN_USE_PANIC_HANDLERS.GetLocation(),
+      &Config::MAIN_OSD_MESSAGES.GetLocation(),
 
       // Main.Interface
 
-      &Config::MAIN_SKIP_NKIT_WARNING.location,
+      &Config::MAIN_SKIP_NKIT_WARNING.GetLocation(),
 
       // UI.General
 
-      &Config::MAIN_USE_DISCORD_PRESENCE.location,
+      &Config::MAIN_USE_DISCORD_PRESENCE.GetLocation(),
   };
 
   return std::any_of(s_setting_saveable.cbegin(), s_setting_saveable.cend(),

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsBool.h
@@ -10,7 +10,7 @@
 namespace Config
 {
 template <typename T>
-struct Info;
+class Info;
 }
 
 class GraphicsBool : public ToolTipCheckBox

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsInteger.h
@@ -9,7 +9,7 @@
 namespace Config
 {
 template <typename T>
-struct Info;
+class Info;
 }
 
 class GraphicsInteger : public ToolTipSpinBox

--- a/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GraphicsSlider.h
@@ -9,7 +9,7 @@
 namespace Config
 {
 template <typename T>
-struct Info;
+class Info;
 }
 
 class GraphicsSlider : public ToolTipSlider

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -381,13 +381,13 @@ void NetPlaySetupDialog::PopulateGameList()
 void NetPlaySetupDialog::ResetTraversalHost()
 {
   Config::SetBaseOrCurrent(Config::NETPLAY_TRAVERSAL_SERVER,
-                           Config::NETPLAY_TRAVERSAL_SERVER.default_value);
+                           Config::NETPLAY_TRAVERSAL_SERVER.GetDefaultValue());
   Config::SetBaseOrCurrent(Config::NETPLAY_TRAVERSAL_PORT,
-                           Config::NETPLAY_TRAVERSAL_PORT.default_value);
+                           Config::NETPLAY_TRAVERSAL_PORT.GetDefaultValue());
 
   ModalMessageBox::information(
       this, tr("Reset Traversal Server"),
       tr("Reset Traversal Server to %1:%2")
-          .arg(QString::fromStdString(Config::NETPLAY_TRAVERSAL_SERVER.default_value),
-               QString::number(Config::NETPLAY_TRAVERSAL_PORT.default_value)));
+          .arg(QString::fromStdString(Config::NETPLAY_TRAVERSAL_SERVER.GetDefaultValue()),
+               QString::number(Config::NETPLAY_TRAVERSAL_PORT.GetDefaultValue())));
 }

--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -26,15 +26,18 @@ public:
       : ConfigLayerLoader(Config::LayerType::CommandLine)
   {
     if (!video_backend.empty())
-      m_values.emplace_back(Config::MAIN_GFX_BACKEND.location, video_backend);
+      m_values.emplace_back(Config::MAIN_GFX_BACKEND.GetLocation(), video_backend);
 
     if (!audio_backend.empty())
-      m_values.emplace_back(Config::MAIN_DSP_HLE.location, ValueToString(audio_backend == "HLE"));
+    {
+      m_values.emplace_back(Config::MAIN_DSP_HLE.GetLocation(),
+                            ValueToString(audio_backend == "HLE"));
+    }
 
     // Batch mode hides the main window, and render to main hides the render window. To avoid a
     // situation where we would have no window at all, disable render to main when using batch mode.
     if (batch)
-      m_values.emplace_back(Config::MAIN_RENDER_TO_MAIN.location, ValueToString(false));
+      m_values.emplace_back(Config::MAIN_RENDER_TO_MAIN.GetLocation(), ValueToString(false));
 
     // Arguments are in the format of <System>.<Section>.<Key>=Value
     for (const auto& arg : args)

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -50,7 +50,7 @@ void HandleDiscordJoin(const char* join_secret)
   if (event_handler == nullptr)
     return;
 
-  if (Config::Get(Config::NETPLAY_NICKNAME) == Config::NETPLAY_NICKNAME.default_value)
+  if (Config::Get(Config::NETPLAY_NICKNAME) == Config::NETPLAY_NICKNAME.GetDefaultValue())
     Config::SetCurrent(Config::NETPLAY_NICKNAME, username);
 
   std::string secret(join_secret);


### PR DESCRIPTION
The goal of this change is to make `Config::Get(const Info<T>&)` fast so that we can use it in hot paths.

This is the second iteration of PR #9103. The core idea is the same, but the way cache invalidation is handled is completely different. Compared to PR #9103, reading settings is slower (but still much faster than master) and changing settings is faster (very close to the speed of master).

A benchmark of one million calls to `Config::Get(const Info<bool>&)`, adding each returned value to an int variable:

5.0-13178: 930 ms
This PR: 27 ms