### PR TITLE
WiiUtils: Check hashes to determine if a title is installed and up-to-date

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -81,6 +81,12 @@ public:
     s32 ipc_fd = -1;
   };
 
+  enum class CheckContentHashes : bool
+  {
+    Yes = true,
+    No = false,
+  };
+
   IOS::ES::TMDReader FindImportTMD(u64 title_id) const;
   IOS::ES::TMDReader FindInstalledTMD(u64 title_id) const;
   IOS::ES::TicketReader FindSignedTicket(u64 title_id) const;
@@ -92,7 +98,9 @@ public:
   // Get titles for which there is a ticket (in /ticket).
   std::vector<u64> GetTitlesWithTickets() const;
 
-  std::vector<IOS::ES::Content> GetStoredContentsFromTMD(const IOS::ES::TMDReader& tmd) const;
+  std::vector<IOS::ES::Content>
+  GetStoredContentsFromTMD(const IOS::ES::TMDReader& tmd,
+                           CheckContentHashes check_content_hashes = CheckContentHashes::No) const;
   u32 GetSharedContentsCount() const;
   std::vector<std::array<u8, 20>> GetSharedContents() const;
 

--- a/Source/Core/Core/IOS/FS/FileSystem.h
+++ b/Source/Core/Core/IOS/FS/FileSystem.h
@@ -205,6 +205,7 @@ public:
   /// Reposition the file offset for a file descriptor.
   virtual Result<u32> SeekFile(Fd fd, u32 offset, SeekMode mode) = 0;
   /// Get status for a file descriptor.
+  /// Guaranteed to succeed for a valid file descriptor.
   virtual Result<FileStatus> GetFileStatus(Fd fd) = 0;
 
   /// Create a file with the specified path and metadata.

--- a/Source/Core/Core/WiiUtils.cpp
+++ b/Source/Core/Core/WiiUtils.cpp
@@ -149,7 +149,8 @@ bool InstallWAD(IOS::HLE::Kernel& ios, const DiscIO::VolumeWAD& wad, InstallType
   const u64 title_id = wad.GetTMD().GetTitleId();
 
   // Skip the install if the WAD is already installed.
-  const auto installed_contents = ios.GetES()->GetStoredContentsFromTMD(wad.GetTMD());
+  const auto installed_contents = ios.GetES()->GetStoredContentsFromTMD(
+      wad.GetTMD(), IOS::HLE::Device::ES::CheckContentHashes::Yes);
   if (wad.GetTMD().GetContents() == installed_contents)
   {
     // Clear the "temporary title ID" flag in case the user tries to permanently install a title


### PR DESCRIPTION
Nintendo's official title installation code and ES both only look at
content IDs but we should probably check for content hashes in addition
to checking for IDs for at least two reasons:

1. Some of the installed contents could be corrupted -- this cannot be
   easily detected without checking hashes.

2. Some mod distributors do not bother to update content IDs, which
   means that installing updated WADs from the UI would not actually
   update the installed game. This is confusing for users.

To keep the existing semantic (for IOS especially), the new content
hash checks are opt-in for callers of GetStoredContentsFromTMD.

This commit changes WiiUtils's WAD installation logic to enable
the content hash checks.