### PR TITLE
Software: Fix failed special case assertion

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -84,7 +84,12 @@ void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_
           &m_vertex, (VertexLoaderManager::g_current_components & VB_HAS_NRM2) != 0, outVertex);
     }
     TransformUnit::TransformColor(&m_vertex, outVertex);
-    TransformUnit::TransformTexCoord(&m_vertex, outVertex, m_tex_gen_special_case);
+    // Special case for verticies if they only contain position and tex coord 0.
+    // There is no VB_HAS_POS constant as all verticies have positions, so only UV0 must be
+    // checked. The special case also only applies to XF_TEXPROJ_ST, but that is checked on a
+    // per-vertex basis.  https://libogc.devkitpro.org/gx_8h.html#a55a426a3ff796db584302bddd829f002
+    const bool specialCaseIfST = VertexLoaderManager::g_current_components == VB_HAS_UV0;
+    TransformUnit::TransformTexCoord(&m_vertex, outVertex, specialCaseIfST);
 
     // assemble and rasterize the primitive
     m_setup_unit.SetupVertex();
@@ -120,11 +125,6 @@ void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
   m_vertex.texMtx[5] = xfmem.MatrixIndexB.Tex5MtxIdx;
   m_vertex.texMtx[6] = xfmem.MatrixIndexB.Tex6MtxIdx;
   m_vertex.texMtx[7] = xfmem.MatrixIndexB.Tex7MtxIdx;
-
-  // special case if only pos and tex coord 0 and tex coord input is AB11
-  // http://libogc.devkitpro.org/gx_8h.html#a55a426a3ff796db584302bddd829f002
-  m_tex_gen_special_case = VertexLoaderManager::g_current_components == VB_HAS_UV0 &&
-                           xfmem.texMtxInfo[0].projection == XF_TEXPROJ_ST;
 }
 
 template <typename T, typename I>

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -28,6 +28,4 @@ protected:
 
   InputVertexData m_vertex;
   SetupUnit m_setup_unit;
-
-  bool m_tex_gen_special_case;
 };

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -147,8 +147,6 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
   }
   else  // texinfo.projection == XF_TEXPROJ_STQ
   {
-    ASSERT(!specialCase);
-
     if (texinfo.inputform == XF_TEXINPUT_AB11)
       MultiplyVec2Mat34(src, mat, *dst);
     else

--- a/Source/Core/VideoBackends/Software/TransformUnit.h
+++ b/Source/Core/VideoBackends/Software/TransformUnit.h
@@ -12,5 +12,5 @@ namespace TransformUnit
 void TransformPosition(const InputVertexData* src, OutputVertexData* dst);
 void TransformNormal(const InputVertexData* src, bool nbt, OutputVertexData* dst);
 void TransformColor(const InputVertexData* src, OutputVertexData* dst);
-void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst, bool specialCase);
+void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst, bool specialCaseIfST);
 }  // namespace TransformUnit

--- a/Source/Core/VideoCommon/UberShaderVertex.cpp
+++ b/Source/Core/VideoCommon/UberShaderVertex.cpp
@@ -514,7 +514,13 @@ static void GenVertexShaderTexGens(APIType api_type, u32 num_texgen, ShaderCode&
             "    float4 P1 = " I_POSTTRANSFORMMATRICES "[(base_index + 1u) & 0x3fu];\n"
             "    float4 P2 = " I_POSTTRANSFORMMATRICES "[(base_index + 2u) & 0x3fu];\n"
             "\n");
-  out.Write("    if ({} != 0u)\n", BitfieldExtract("postMtxInfo", PostMtxInfo().normalize));
+  // Special case for verticies if they only contain position and tex coord 0 with XF_TEXPROJ_ST:
+  // normalization is not performed even if specified.
+  // There is no VB_HAS_POS constant as all verticies have positions, so only UV0 must be checked.
+  // https://libogc.devkitpro.org/gx_8h.html#a55a426a3ff796db584302bddd829f002
+  out.Write("    if ({} != 0u && !((components == {}u /* VB_HAS_UV0 */) && ({} != 0u)))\n",
+            BitfieldExtract("postMtxInfo", PostMtxInfo().normalize), VB_HAS_UV0,
+            BitfieldExtract("texMtxInfo", TexMtxInfo().projection), XF_TEXPROJ_ST);
   out.Write("      output_tex.xyz = normalize(output_tex.xyz);\n"
             "\n"
             "    // multiply by postmatrix\n"

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -413,7 +413,13 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const ShaderHostConfig& ho
                 "float4 P2 = " I_POSTTRANSFORMMATRICES "[{}];\n",
                 postInfo.index & 0x3f, (postInfo.index + 1) & 0x3f, (postInfo.index + 2) & 0x3f);
 
-      if (postInfo.normalize)
+      // Special case for verticies if they only contain position and tex coord 0.
+      // There is no VB_HAS_POS constant as all verticies have positions, so only UV0 must be
+      // checked. The special case also only applies to XF_TEXPROJ_ST.
+      // https://libogc.devkitpro.org/gx_8h.html#a55a426a3ff796db584302bddd829f002
+      const bool special_case = (uid_data->components == VB_HAS_UV0) &&
+                                (((uid_data->texMtxInfo_n_projection >> i) & 1) == XF_TEXPROJ_ST);
+      if (postInfo.normalize && !special_case)
         out.Write("o.tex{}.xyz = normalize(o.tex{}.xyz);\n", i, i);
 
       // multiply by postmatrix


### PR DESCRIPTION
This case is hit with Super Mario Sunshine's water.

<details>
<summary>Old/incorrect information</summary>

Draft PR to test fifoci.  I don't fully understand what's going on here, only that [there's a fifoci case](https://fifo.ci/dff/sms-water/) for it that fails with an assertion on the software renderer.

The special case in question is this:

https://github.com/dolphin-emu/dolphin/blob/2952f99f691e69e450c5ac52dca9516483ade2ee/Source/Core/VideoBackends/Software/SWVertexLoader.cpp#L124-L127

which honestly seems a bit odd to me since `m_tex_gen_special_case` is used for multiple vertices (but I don't know much about rendering).  The [linked libogc documentation](https://libogc.devkitpro.org/gx_8h.html#a55a426a3ff796db584302bddd829f002) doesn't really clear things up.  In any case, it looks like it's only appropriate for `XF_TEXPROJ_ST`, which seems to be what the assert indicates.

I think the same special case is implemented for the hardware backends here, but I don't really understand it:

https://github.com/dolphin-emu/dolphin/blob/2952f99f691e69e450c5ac52dca9516483ade2ee/Source/Core/VideoCommon/VertexShaderGen.cpp#L426-L436
</details>

(See also: #3743)