### PR TITLE
GameSettings: Add patch for Monster High: Ghoul Spirit (SAOE78/SAOEVZ)

### DIFF
--- a/Data/Sys/GameSettings/SAOE78.ini
+++ b/Data/Sys/GameSettings/SAOE78.ini
@@ -1,0 +1,9 @@
+# SAOE78 - Monster High: Ghoul Spirit
+
+[OnFrame]
+# The first call to GXCopyDisp() corrupts game data, but on real hardware
+# it isn't observed thanks to the data cache. Skipping the call works too.
+$Fix crash on boot
+0x803A5F20:dword:0x60000000
+[OnFrame_Enabled]
+$Fix crash on boot

--- a/Data/Sys/GameSettings/SAOEVZ.ini
+++ b/Data/Sys/GameSettings/SAOEVZ.ini
@@ -1,0 +1,9 @@
+# SAOEVZ - Monster High: Ghoul Spirit
+
+[OnFrame]
+# The first call to GXCopyDisp() corrupts game data, but on real hardware
+# it isn't observed thanks to the data cache. Skipping the call works too.
+$Fix crash on boot
+0x803A64D0:dword:0x60000000
+[OnFrame_Enabled]
+$Fix crash on boot


### PR DESCRIPTION
The first call to GXCopyDisp() corrupts game data, but on real hardware it isn't observed thanks to the data cache. Skipping the call works too, preventing a crash on boot.

This patch is enabled default.