### PR TITLE
DolphinQt: Assign subsequent devices on profile load for ports 2,3,4.

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -273,6 +273,17 @@ void MappingWindow::OnLoadProfilePressed()
   ini.Load(profile_path.toStdString());
 
   m_controller->LoadConfig(ini.GetOrCreateSection("Profile"));
+
+  // If additional devices with the same name are connected, use them for ports 2,3,4.
+  if (m_port != 0)
+  {
+    auto potential_default_device = m_controller->GetDefaultDevice();
+    potential_default_device.cid += m_port;
+
+    if (g_controller_interface.HasConnectedDevice(potential_default_device))
+      m_controller->SetDefaultDevice(potential_default_device);
+  }
+
   m_controller->UpdateReferences(g_controller_interface);
 
   const auto lock = GetController()->GetStateLock();


### PR DESCRIPTION
A user suggested this to me.

Now when you load a profile (e.g. our stock "Wii Remote with MotionPlus Pointing") on Wii Remote 2, if a 2nd Wii Remote is connected it will automatically be used instead of requiring the user manually select it after loading the profile.

I can see how this might make things weird in certain situations, though.
If a user has GCPad 1 configured with keyboard controls then loads an xbox controller profile on GCPad 2 while 2 controllers are attached it will automatically select the second controller.

This could potentially be smarter by looking at the previous ports for the same device name, but I think this situation is unusual and users can still manually select different devices when it happens.

Let me know what you think.