### PR TITLE
DolphinQt: Clear breakpoints on emulator exit

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -55,6 +55,7 @@
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayProto.h"
 #include "Core/NetPlayServer.h"
+#include "Core/PowerPC/PowerPC.h"
 #include "Core/State.h"
 
 #include "DiscIO/NANDImporter.h"
@@ -1453,7 +1454,11 @@ bool MainWindow::eventFilter(QObject* object, QEvent* event)
   if (event->type() == QEvent::Close)
   {
     if (RequestStop() && object == this)
+    {
       m_exit_requested = true;
+      // If shutting down the emulator, we want to ignore breakpoints.
+      PowerPC::debug_interface.ClearAllBreakpoints();
+    }
 
     static_cast<QCloseEvent*>(event)->ignore();
     return true;


### PR DESCRIPTION
Trivial fix for [issue 12187](https://bugs.dolphin-emu.org/issues/12187).

When shutting down Dolphin, ignore all breakpoints to allow for a clean shutdown. (But not when a game is being shut down.)