### PR TITLE
InputCommon: Fix callback dispatch deadlock

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -140,6 +140,19 @@ void ControllerInterface::RefreshDevices()
   InvokeDevicesChangedCallbacks();
 }
 
+void ControllerInterface::PlatformPopulateDevices(std::function<void()> callback)
+{
+  if (!m_is_init)
+    return;
+
+  m_is_populating_devices = true;
+
+  callback();
+
+  m_is_populating_devices = false;
+  InvokeDevicesChangedCallbacks();
+}
+
 // Remove all devices and call library cleanup functions
 void ControllerInterface::Shutdown()
 {

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -50,6 +50,7 @@ public:
   void Shutdown();
   void AddDevice(std::shared_ptr<ciface::Core::Device> device);
   void RemoveDevice(std::function<bool(const ciface::Core::Device*)> callback);
+  void PlatformPopulateDevices(std::function<void()> callback);
   bool IsInit() const { return m_is_init; }
   void UpdateInput();
 

--- a/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Win32/Win32.cpp
@@ -28,8 +28,10 @@ static LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
 {
   if (message == WM_INPUT_DEVICE_CHANGE)
   {
-    ciface::DInput::PopulateDevices(s_hwnd);
-    ciface::XInput::PopulateDevices();
+    g_controller_interface.PlatformPopulateDevices([] {
+      ciface::DInput::PopulateDevices(s_hwnd);
+      ciface::XInput::PopulateDevices();
+    });
     s_done_populating.Set();
   }
 


### PR DESCRIPTION
Fix for [issue 12253](https://bugs.dolphin-emu.org/issues/12253).

Make sure `m_is_populating_devices` is true when a `WM_INPUT_DEVICE_CHANGE` event is received directly on the ciface thread, so that callbacks aren't (improperly) dispatched while in the process of removing devices. This fixes a race condition between the ciface thread and the CPU thread that results in a deadlock when disconnecting an emulated Wii remote.