### PR TITLE
VideoBackend: Prefer Vulkan on supported platforms

### DIFF
--- a/Source/Core/VideoBackends/D3D/VideoBackend.h
+++ b/Source/Core/VideoBackends/D3D/VideoBackend.h
@@ -19,7 +19,7 @@ public:
   std::string GetDisplayName() const override;
   std::optional<std::string> GetWarningMessage() const override;
 
-  void InitBackendInfo() override;
+  bool InitBackendInfo() override;
 
   static constexpr const char* NAME = "D3D";
 

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -62,13 +62,14 @@ std::optional<std::string> VideoBackend::GetWarningMessage() const
   return result;
 }
 
-void VideoBackend::InitBackendInfo()
+bool VideoBackend::InitBackendInfo()
 {
   if (!D3DCommon::LoadLibraries())
-    return;
+    return false;
 
   FillBackendInfo();
   D3DCommon::UnloadLibraries();
+  return true;
 }
 
 void VideoBackend::FillBackendInfo()

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.cpp
@@ -35,13 +35,14 @@ std::string VideoBackend::GetDisplayName() const
   return "Direct3D 12";
 }
 
-void VideoBackend::InitBackendInfo()
+bool VideoBackend::InitBackendInfo()
 {
   if (!D3DCommon::LoadLibraries())
-    return;
+    return false;
 
   FillBackendInfo();
   D3DCommon::UnloadLibraries();
+  return true;
 }
 
 void VideoBackend::FillBackendInfo()

--- a/Source/Core/VideoBackends/D3D12/VideoBackend.h
+++ b/Source/Core/VideoBackends/D3D12/VideoBackend.h
@@ -17,7 +17,7 @@ public:
 
   std::string GetName() const override;
   std::string GetDisplayName() const override;
-  void InitBackendInfo() override;
+  bool InitBackendInfo() override;
 
   static constexpr const char* NAME = "D3D12";
 

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -23,7 +23,7 @@
 
 namespace Null
 {
-void VideoBackend::InitBackendInfo()
+bool VideoBackend::InitBackendInfo()
 {
   g_Config.backend_info.api_type = APIType::Nothing;
   g_Config.backend_info.MaxTextureSize = 16384;
@@ -60,6 +60,7 @@ void VideoBackend::InitBackendInfo()
   // aamodes: We only support 1 sample, so no MSAA
   g_Config.backend_info.Adapters.clear();
   g_Config.backend_info.AAModes = {1};
+  return true;
 }
 
 bool VideoBackend::Initialize(const WindowSystemInfo& wsi)

--- a/Source/Core/VideoBackends/Null/VideoBackend.h
+++ b/Source/Core/VideoBackends/Null/VideoBackend.h
@@ -16,7 +16,7 @@ public:
 
   std::string GetName() const override { return NAME; }
   std::string GetDisplayName() const override;
-  void InitBackendInfo() override;
+  bool InitBackendInfo() override;
 
   static constexpr const char* NAME = "Null";
 };

--- a/Source/Core/VideoBackends/OGL/VideoBackend.h
+++ b/Source/Core/VideoBackends/OGL/VideoBackend.h
@@ -20,7 +20,7 @@ public:
   std::string GetName() const override;
   std::string GetDisplayName() const override;
 
-  void InitBackendInfo() override;
+  bool InitBackendInfo() override;
 
   static constexpr const char* NAME = "OGL";
 

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -73,7 +73,7 @@ std::string VideoBackend::GetDisplayName() const
     return _trans("OpenGL");
 }
 
-void VideoBackend::InitBackendInfo()
+bool VideoBackend::InitBackendInfo()
 {
   g_Config.backend_info.api_type = APIType::OpenGL;
   g_Config.backend_info.MaxTextureSize = 16384;
@@ -114,6 +114,7 @@ void VideoBackend::InitBackendInfo()
 
   // aamodes - 1 is to stay consistent with D3D (means no AA)
   g_Config.backend_info.AAModes = {1, 2, 4, 8};
+  return true;
 }
 
 bool VideoBackend::InitializeGLExtensions(GLContext* context)

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -60,7 +60,7 @@ std::optional<std::string> VideoSoftware::GetWarningMessage() const
                 "really want to enable software rendering? If unsure, select 'No'.");
 }
 
-void VideoSoftware::InitBackendInfo()
+bool VideoSoftware::InitBackendInfo()
 {
   g_Config.backend_info.api_type = APIType::Nothing;
   g_Config.backend_info.MaxTextureSize = 16384;
@@ -87,6 +87,7 @@ void VideoSoftware::InitBackendInfo()
 
   // aamodes
   g_Config.backend_info.AAModes = {1};
+  return true;
 }
 
 bool VideoSoftware::Initialize(const WindowSystemInfo& wsi)

--- a/Source/Core/VideoBackends/Software/VideoBackend.h
+++ b/Source/Core/VideoBackends/Software/VideoBackend.h
@@ -18,7 +18,7 @@ class VideoSoftware : public VideoBackendBase
   std::string GetDisplayName() const override;
   std::optional<std::string> GetWarningMessage() const override;
 
-  void InitBackendInfo() override;
+  bool InitBackendInfo() override;
 
   static constexpr const char* NAME = "Software Renderer";
 };

--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -17,7 +17,7 @@ public:
 
   std::string GetName() const override { return NAME; }
   std::string GetDisplayName() const override { return _trans("Vulkan"); }
-  void InitBackendInfo() override;
+  bool InitBackendInfo() override;
   void PrepareWindow(WindowSystemInfo& wsi) override;
 
   static constexpr const char* NAME = "Vulkan";

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -29,7 +29,7 @@
 
 namespace Vulkan
 {
-void VideoBackend::InitBackendInfo()
+bool VideoBackend::InitBackendInfo()
 {
   VulkanContext::PopulateBackendInfo(&g_Config);
 
@@ -66,13 +66,16 @@ void VideoBackend::InitBackendInfo()
     else
     {
       PanicAlertFmt("Failed to create Vulkan instance.");
+      return false;
     }
 
     UnloadVulkanLibrary();
+    return true;
   }
   else
   {
     PanicAlertFmt("Failed to load Vulkan library.");
+    return false;
   }
 }
 

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -42,7 +42,7 @@ public:
 
   virtual std::string GetName() const = 0;
   virtual std::string GetDisplayName() const { return GetName(); }
-  virtual void InitBackendInfo() = 0;
+  virtual bool InitBackendInfo() = 0;
   virtual std::optional<std::string> GetWarningMessage() const { return {}; }
 
   // Prepares a native window for rendering. This is called on the main thread, or the


### PR DESCRIPTION
PR mostly to spur some discussion on [issue 12083](https://bugs.dolphin-emu.org/issues/12083).

There's definitely a tradeoff to be made here between performance and stability. Vulkan is an API and makes no assumptions about the capabilities of the underlying hardware. If we can query whether or not the device has the capabilities to reasonably support the Vulkan backend, then it's possible to be confident about giving a significant performance boost by default on machines that are capable of it, with similar accuracy and little compatibility downside, and then fall back to OpenGL for those devices that do not support it.

(On Windows, there might be a strong argument made for Direct3D 12 being the default backend - though this of course is not supported on Linux.)