### PR TITLE
Core/AddressSpace: Return null accessors when no game is running to prevent out-of-bounds memory accesses.

### DIFF
--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -374,9 +374,13 @@ static SmallBlockAccessors s_fake_address_space_accessors;
 static CompositeAddressSpaceAccessors s_physical_address_space_accessors_gcn;
 static CompositeAddressSpaceAccessors s_physical_address_space_accessors_wii;
 static NullAccessors s_null_accessors;
+static bool s_initialized = false;
 
 Accessors* GetAccessors(Type address_space)
 {
+  if (!s_initialized)
+    return &s_null_accessors;
+
   // default to effective
   switch (address_space)
   {
@@ -420,6 +424,12 @@ void Init()
   s_physical_address_space_accessors_gcn = {{0x00000000, &s_mem1_address_space_accessors}};
   s_physical_address_space_accessors_wii = {{0x00000000, &s_mem1_address_space_accessors},
                                             {0x10000000, &s_mem2_address_space_accessors}};
+  s_initialized = true;
+}
+
+void Shutdown()
+{
+  s_initialized = false;
 }
 
 }  // namespace AddressSpace

--- a/Source/Core/Core/HW/AddressSpace.h
+++ b/Source/Core/Core/HW/AddressSpace.h
@@ -48,5 +48,6 @@ struct Accessors
 Accessors* GetAccessors(Type address_space);
 
 void Init();
+void Shutdown();
 
 }  // namespace AddressSpace

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -70,6 +70,7 @@ void Shutdown()
   CPU::Shutdown();
   DVDInterface::Shutdown();
   DSP::Shutdown();
+  AddressSpace::Shutdown();
   Memory::Shutdown();
   ExpansionInterface::Shutdown();
   SerialInterface::Shutdown();


### PR DESCRIPTION
This prevents some crashes when clicking around the memory view when no game is running. For example, try hitting the 'Dump MRAM' button.