### PR TITLE
EXI_Device: Always define EXIDEVICE_ETHTAPSERVER for consistency

### DIFF
--- a/Source/Core/Core/HW/EXI/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI/EXI_Device.h
@@ -33,9 +33,8 @@ enum TEXIDevices : int
   EXIDEVICE_MEMORYCARDFOLDER,
   EXIDEVICE_AGP,
   EXIDEVICE_ETHXLINK,
-#if defined(__APPLE__)
+  // Only used on Apple devices.
   EXIDEVICE_ETHTAPSERVER,
-#endif
   EXIDEVICE_NONE = 0xFF
 };
 


### PR DESCRIPTION
This keeps the enum values consistent across platforms in case new entries are added after EXIDEVICE_ETHTAPSERVER.