### PR TITLE
Qt: Fix deprecated use of MidButton

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -141,7 +141,7 @@ void MappingButton::mouseReleaseEvent(QMouseEvent* event)
 {
   switch (event->button())
   {
-  case Qt::MouseButton::MidButton:
+  case Qt::MouseButton::MiddleButton:
     Clear();
     return;
   case Qt::MouseButton::RightButton:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -7,25 +7,17 @@
 #include <QApplication>
 #include <QFontMetrics>
 #include <QMouseEvent>
-#include <QRegExp>
 #include <QString>
-
-#include "Common/Thread.h"
-#include "Core/Core.h"
 
 #include "DolphinQt/Config/Mapping/IOWindow.h"
 #include "DolphinQt/Config/Mapping/MappingCommon.h"
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
-#include "DolphinQt/QtUtils/BlockUserInputFilter.h"
-#include "DolphinQt/QtUtils/QueueOnObject.h"
-#include "DolphinQt/Settings.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
-#include "InputCommon/ControllerInterface/Device.h"
 
 constexpr int SLIDER_TICK_COUNT = 100;
 

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -247,7 +247,7 @@ void RenderWidget::OnFreeLookMouseMove(QMouseEvent* event)
     // Camera Pitch and Yaw:
     g_freelook_camera.Rotate(Common::Vec3{mouse_move.y() / 200.f, mouse_move.x() / 200.f, 0.f});
   }
-  else if (event->buttons() & Qt::MidButton)
+  else if (event->buttons() & Qt::MiddleButton)
   {
     // Camera Roll:
     g_freelook_camera.Rotate({0.f, 0.f, mouse_move.x() / 200.f});


### PR DESCRIPTION
MidButton has been deprecated since Qt 4.7. The replacement is
MiddleButton.