### PR TITLE
WD: Add Nintendo Wi-Fi USB connector AP

### DIFF
--- a/Source/Core/Core/IOS/Network/WD/Command.cpp
+++ b/Source/Core/Core/IOS/Network/WD/Command.cpp
@@ -39,7 +39,7 @@ IPCCommandResult NetWDCommand::IOCtlV(const IOCtlVRequest& request)
 
     u16* results = (u16*)Memory::GetPointer(request.io_vectors.at(0).address);
     // first u16 indicates number of BSSInfo following
-    results[0] = Common::swap16(1);
+    results[0] = Common::swap16(2);
 
     BSSInfo* bss = (BSSInfo*)&results[1];
     memset(bss, 0, sizeof(BSSInfo));
@@ -55,6 +55,19 @@ IPCCommandResult NetWDCommand::IOCtlV(const IOCtlVRequest& request)
     bss->ssid_length = Common::swap16((u16)strlen(ssid));
 
     bss->channel = Common::swap16(2);
+
+    // Add Nintendo Wi-Fi USB Connector access point
+    // The next BSSInfo loaded is at the current address plus bss->length * 2
+    bss += 2;
+    memset(bss, 0, sizeof(BSSInfo));
+
+    bss->length = Common::swap16(sizeof(BSSInfo));
+    bss->rssi = Common::swap16(0xffff);
+
+    for (int i = 0; i < BSSID_SIZE; ++i)
+      bss->bssid[i] = i;
+    memcpy(bss->ssid, "NWCUSBAP\0\1", 10);
+    bss->ssid_length = Common::swap16(0x20);
   }
   break;
 


### PR DESCRIPTION
This PR allows the Nintendo Wi-Fi USB connector connection test to be successful. This was done by reversing the system-menu 3.2E RSO module (main.elf). I still need to confirm the behaviour on the IOS part.

Ideally, I also would like to implement the parameters checks since the current implementation is a bit rough.