### PR TITLE
GameSettings: Set Safe Texture Cache to Safe for Pitfall: The Lost Ex…

### DIFF
--- a/Data/Sys/GameSettings/RPF.ini
+++ b/Data/Sys/GameSettings/RPF.ini
@@ -1,4 +1,4 @@
-# GPHD52, GPHE52, GPHF52, GPHP52 - Pitfall: The Lost Expedition
+# RPFP52, RPFE52, RPFU52 - Pitfall: The Big Adventure
 
 [Core]
 # Values set here will override the main Dolphin settings.


### PR DESCRIPTION
…pedition and Pitfall: The Big Adventure

1024 is not enough. 2048 works just fine.
Fixes stuttering Atari 2600 emulation https://bugs.dolphin-emu.org/issues/12347