### PR TITLE
Common/LinearDiskCache: Handle truncated shadercache files.

### DIFF
--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -76,6 +76,7 @@ public:
       std::unique_ptr<V[]> value = nullptr;
       u32 value_size = 0;
       u32 entry_number = 0;
+      u64 last_valid_value_start = m_file.Tell();
 
       while (m_file.ReadArray(&value_size, 1))
       {
@@ -90,6 +91,7 @@ public:
         if (m_file.ReadArray(&key, 1) && m_file.ReadArray(value.get(), value_size) &&
             m_file.ReadArray(&entry_number, 1) && entry_number == m_num_entries + 1)
         {
+          last_valid_value_start = m_file.Tell();
           reader.Read(key, value.get(), value_size);
         }
         else
@@ -100,6 +102,7 @@ public:
         m_num_entries++;
       }
       m_file.Clear();
+      m_file.Seek(last_valid_value_start, SEEK_SET);
 
       return m_num_entries;
     }


### PR DESCRIPTION
Without this you run into two issues:

- Since it breaks out after reading the `value_size` but before reading the actual value, the file position is not aligned on a boundary between values, so it would have no chance to find any newly written values the next time the cachefile is opened.
- ...But it probably doesn't come to that because of a [quirk in files opened in r+ mode](https://stackoverflow.com/questions/3206913/c-standard-library-corner-case). Thankfully Visual Studio's debug mode [catches this](https://i.imgur.com/NgqVNC8.png), I would have never found this otherwise.

I also took the opportunity to replace the manual new/delete with an unique_ptr.