### PR TITLE
Core: Add initial System class

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(core
   SyncIdentifier.h
   SysConf.cpp
   SysConf.h
+  System.cpp
+  System.h
   TitleDatabase.cpp
   TitleDatabase.h
   WiiRoot.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -371,6 +371,7 @@
     <ClCompile Include="PowerPC\SignatureDB\SignatureDB.cpp" />
     <ClCompile Include="State.cpp" />
     <ClCompile Include="SysConf.cpp" />
+    <ClCompile Include="System.cpp" />
     <ClCompile Include="TitleDatabase.cpp" />
     <ClCompile Include="WiiRoot.cpp" />
     <ClCompile Include="WiiUtils.cpp" />
@@ -678,6 +679,7 @@
     <ClInclude Include="State.h" />
     <ClInclude Include="SyncIdentifier.h" />
     <ClInclude Include="SysConf.h" />
+    <ClInclude Include="System.h" />
     <ClInclude Include="Titles.h" />
     <ClInclude Include="TitleDatabase.h" />
     <ClInclude Include="WiiRoot.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -187,6 +187,7 @@
     <ClCompile Include="PatchEngine.cpp" />
     <ClCompile Include="State.cpp" />
     <ClCompile Include="SysConf.cpp" />
+    <ClCompile Include="System.cpp" />
     <ClCompile Include="TitleDatabase.cpp" />
     <ClCompile Include="WiiRoot.cpp" />
     <ClCompile Include="WiiUtils.cpp" />
@@ -1022,6 +1023,7 @@
     <ClInclude Include="PatchEngine.h" />
     <ClInclude Include="State.h" />
     <ClInclude Include="SysConf.h" />
+    <ClInclude Include="System.h" />
     <ClInclude Include="Titles.h" />
     <ClInclude Include="TitleDatabase.h" />
     <ClInclude Include="WiiRoot.h" />

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -1,0 +1,18 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/System.h"
+
+namespace Core
+{
+struct System::Impl
+{
+};
+
+System::System() : m_impl{std::make_unique<Impl>()}
+{
+}
+
+System::~System() = default;
+}  // namespace Core

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -1,0 +1,36 @@
+// Copyright 2020 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+namespace Core
+{
+// Central class that encapsulates the running system.
+class System
+{
+public:
+  ~System();
+
+  System(const System&) = delete;
+  System& operator=(const System&) = delete;
+
+  System(System&&) = delete;
+  System& operator=(System&&) = delete;
+
+  // Intermediate instance accessor until global state is eliminated.
+  static System& GetInstance()
+  {
+    static System instance;
+    return instance;
+  }
+
+private:
+  System();
+
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
+};
+}  // namespace Core


### PR DESCRIPTION
Introduces the system class that will eventually contain all relevant system state, as opposed to everything being distributed all over the place as global variables.

Throughout the codebase we have code that from its interface-view, does not actually require its dependencies to be described in the interface, and we routinely run into issues with initialization where we sometimes make use of a facility before it's been initialized, which leads to annoying to debug cases, because the reader needs to run through the codebase and see what order things get initialized in, and how they're being used. This is particularly a frequent issue in the video code.

Further, we also have a lot of code that makes use of file-scope variables (many of which are non-trivial), which must all be default initialized before the application can actually enter main(). While this may not be a huge issue in itself, some of these are allocating, which means that the application may need to use memory that it otherwise wouldn't need to (e.g. when a game isn't running, this excess memory is being used).

Being able to wrap all these subsystems into objects would be nicer, since they can be constructed when they're actually needed. Them being objects also means we can better express dependencies on subsystems as types directly in the interface, making them explicit to the reader instead of a change randomly blowing up, said reader inspecting it, and finding
out that something needed to be initialized beforehand. With the global turned into a function parameter, the dependency is explicit and they know just by reading it, that the given subsystem needs to be in a valid state before calling the function.

For a prior example of an emulator that has moved to this model, see yuzu (which you may see for a more fleshed out example of what this attempts sow the seeds to achieve), which has migrated off of global variables and has a similar system instance (which has now reached the stage, where the singleton can be removed).

Note that the (hopefully obvious) migration over to this will inherently need to be ported over time, as the resulting diff from doing all of this at once would be huge.