### PR TITLE
MemoryUtil: Use HW_PHYSMEM64 sysctl in MemPhysical

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -165,7 +165,7 @@ size_t MemPhysical()
 #elif defined __FreeBSD__
   mib[1] = HW_REALMEM;
 #elif defined __OpenBSD__ || defined __NetBSD__
-  mib[1] = HW_PHYSMEM;
+  mib[1] = HW_PHYSMEM64;
 #endif
   size_t length = sizeof(size_t);
   sysctl(mib, 2, &physical_memory, &length, NULL, 0);


### PR DESCRIPTION
HW_PHYSMEM is deprecated on OpenBSD and only supplies a 32-bit value on NetBSD.

Relevant documentation:
* https://man.openbsd.org/sysctl.2
* https://man.netbsd.org/sysctl.7