### PR TITLE
JitArm64: Fix signed bitwise left shift UB

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1353,7 +1353,7 @@ void JitArm64::srawx(UGeckoInstruction inst)
     {
       amount &= 0x1F;
       gpr.SetImmediate(a, i >> amount);
-      ComputeCarry(amount != 0 && i < 0 && (i << (32 - amount)));
+      ComputeCarry(amount != 0 && i < 0 && (u32(i) << (32 - amount)));
     }
 
     if (inst.Rc)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -631,10 +631,7 @@ void JitArm64::srawix(UGeckoInstruction inst)
     s32 imm = (s32)gpr.GetImm(s);
     gpr.SetImmediate(a, imm >> amount);
 
-    if (amount != 0 && (imm < 0) && (imm << (32 - amount)))
-      ComputeCarry(true);
-    else
-      ComputeCarry(false);
+    ComputeCarry(amount != 0 && (imm < 0) && (u32(imm) << (32 - amount)));
 
     if (inst.Rc)
       ComputeRC0(gpr.GetImm(a));


### PR DESCRIPTION
As pointed out by @MerryMage in PR #9262, signed bitwise left shift invokes UB when shifting a negative value.