### PR TITLE
Jit64: Fix FPURegCache::GetRegUtilization

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/RegCache/FPURegCache.cpp
@@ -39,7 +39,7 @@ OpArg FPURegCache::GetDefaultLocation(preg_t preg) const
 
 BitSet32 FPURegCache::GetRegUtilization() const
 {
-  return m_jit.js.op->gprInReg;
+  return m_jit.js.op->fprInXmm;
 }
 
 BitSet32 FPURegCache::CountRegsIn(preg_t preg, u32 lookahead) const


### PR DESCRIPTION
This performance bug was probably a simple copy-paste error. (The function was identical to `GPRRegCache::GetRegUtilization`.)