### PR TITLE
GameSettings: Patch for freezing in Gladius (GLSE64)

### DIFF
--- a/Data/Sys/GameSettings/GLSE64.ini
+++ b/Data/Sys/GameSettings/GLSE64.ini
@@ -1,0 +1,20 @@
+# GLSE64 - Gladius
+
+[OnFrame]
+# This game can deadlock the CPU and GPU by setting FIFO breakpoints too
+# infrequently, provided the CPU gets too far ahead, as can happen under Dolphin
+# due to timing inaccuracies. The game never clears breakpoints, and it will
+# skip setting them if the previous one has not been hit by the GPU. If the CPU
+# gets far enough ahead it will reach the FIFO high water mark and trigger an
+# overflow interrupt, causing the render thread to be suspended. The GPU will
+# make forward progress until it hits the last set breakpoint. However, if the
+# distance between that breakpoint and the FIFO write pointer is greater than
+# the low water mark, then the GPU will never generate an underflow interrupt
+# and the render thread will never be resumed. This patch forces the game to
+# update the breakpoint unconditionally and has been tested on real hardware
+# with no apparent ill effect.
+$Fix freeze in opening cutscene
+0x8010B4B0:dword:0x60000000
+
+[OnFrame_Enabled]
+$Fix freeze in opening cutscene


### PR DESCRIPTION
This game can deadlock the CPU and GPU by setting FIFO breakpoints too infrequently, provided the CPU gets too far ahead, as can happen under Dolphin due to timing inaccuracies. The game never clears breakpoints, and it will skip setting them if the previous one has not been hit by the GPU. If the CPU gets far enough ahead it will reach the FIFO high water mark and trigger an overflow interrupt, causing the render thread to be suspended. The GPU will make forward progress until it hits the last set breakpoint. However, if the distance between that breakpoint and the FIFO write pointer is greater than the low water mark, then the GPU will never generate an underflow interrupt and the render thread will never be resumed. This patch forces the game to update the breakpoint unconditionally and has been tested on real hardware with no apparent ill effect.

This patch covers the US release (GLSE64), but there are three more (GLSD64, GLSF64, GLSP64) that will likely require similar patches.

https://bugs.dolphin-emu.org/issues/10669