### PR TITLE
Software: Invert backface test when viewport is positive

### DIFF
--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -488,6 +488,11 @@ bool CullTest(const OutputVertexData* v0, const OutputVertexData* v1, const Outp
   float normalZDir = (x0 * w2 - x2 * w0) * y1 + (x2 * y0 - x0 * y2) * w1 + (y2 * w0 - y0 * w2) * x1;
 
   backface = normalZDir <= 0.0f;
+  // Jimmie Johnson's Anything with an Engine has a positive viewport, while other games have a
+  // negative viewport.  The positive viewport does not require vertices to be vertically mirrored,
+  // but the backface test does need to be inverted for things to be drawn.
+  if (xfmem.viewport.ht > 0)
+    backface = !backface;
 
   // TODO: Are these tests / the definition of backface above backwards?
   if ((bpmem.genMode.cullmode == CullMode::Back || bpmem.genMode.cullmode == CullMode::All) &&


### PR DESCRIPTION
Fixes [Jimmie Johnson's Anything with an Engine](https://wiki.dolphin-emu.org/index.php?title=Jimmie_Johnson%27s_Anything_with_an_Engine#Mirrored_Screen), which is [the only game that uses a positive viewport](https://dolphin-emu.org/blog/2017/04/05/dolphin-progress-report-march-2017/#50-3021-correct-for-negative-viewport-dimensions-by-armada651).  This is the same issue that #5096 fixed in hardware, but the actual fix here is different; that one was achieved by mirroring vertices while this only needs to change the backface test; the image was already right-side up on the software renderer.  I don't fully understand why.