### PR TITLE
Software: Implement line-width and point-width

### DIFF
--- a/Source/Core/VideoBackends/Software/Clipper.h
+++ b/Source/Core/VideoBackends/Software/Clipper.h
@@ -14,6 +14,8 @@ void ProcessTriangle(OutputVertexData* v0, OutputVertexData* v1, OutputVertexDat
 
 void ProcessLine(OutputVertexData* v0, OutputVertexData* v1);
 
+void ProcessPoint(OutputVertexData* v);
+
 bool CullTest(const OutputVertexData* v0, const OutputVertexData* v1, const OutputVertexData* v2,
               bool& backface);
 

--- a/Source/Core/VideoBackends/Software/SetupUnit.cpp
+++ b/Source/Core/VideoBackends/Software/SetupUnit.cpp
@@ -167,4 +167,5 @@ void SetupUnit::SetupLineStrip()
 
 void SetupUnit::SetupPoint()
 {
+  Clipper::ProcessPoint(m_VertPointer[0]);
 }


### PR DESCRIPTION
Somewhat equivalent to https://bugs.dolphin-emu.org/issues/7749 / #1706.  For whatever reason, textures aren't working (they already were broken for lines, but this change doesn't fix it even though I think it should).