### PR TITLE
Call UpdatePerformanceMonitor when needed

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -380,6 +380,7 @@ void Idle()
     Fifo::FlushGpu();
   }
 
+  PowerPC::UpdatePerformanceMonitor(PowerPC::ppcState.downcount, 0, 0);
   s_idled_cycles += DowncountToCycles(PowerPC::ppcState.downcount);
   PowerPC::ppcState.downcount = 0;
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -219,7 +219,11 @@ int Interpreter::SingleStepInner()
   }
 
   UpdatePC();
-  return PPCTables::GetOpInfo(m_prev_inst)->numCycles;
+
+  const GekkoOPInfo* opinfo = PPCTables::GetOpInfo(m_prev_inst);
+  PowerPC::UpdatePerformanceMonitor(opinfo->numCycles, (opinfo->flags & FL_LOADSTORE) != 0,
+                                    (opinfo->flags & FL_USE_FPU) != 0);
+  return opinfo->numCycles;
 }
 
 void Interpreter::SingleStep()


### PR DESCRIPTION
I find the performance monitor functionality useful for timing hardware tests, but unfortunately it hasn't worked correctly in Dolphin except when using the x86-64 JIT with no idle skipping. This PR makes it work (mostly) correctly on all CPU emulation cores.