### PR TITLE
Prevent hotkey suppressions from sticking when disabling freelook.

### DIFF
--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -11,6 +11,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/FreeLookConfig.h"
 
+#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/InputConfig.h"
 
@@ -146,8 +147,15 @@ ControllerEmu::ControlGroup* FreeLookController::GetGroup(FreeLookGroup group) c
 
 void FreeLookController::Update()
 {
+  const bool prev_input_gate = ControlReference::GetInputGate();
+
   if (!g_freelook_camera.IsActive())
-    return;
+  {
+    // We must GetState even when inactive in case hotkey @() expressions were pressed during
+    // deactivation, otherwise they will never release their button suppressions.
+    // Turning the input gate off will block all input and release any hotkeys.
+    ControlReference::SetInputGate(false);
+  }
 
   if (m_move_buttons->controls[MoveButtons::Up]->GetState<bool>())
     g_freelook_camera.MoveVertical(-g_freelook_camera.GetSpeed());
@@ -190,6 +198,8 @@ void FreeLookController::Update()
 
   if (m_other_buttons->controls[OtherButtons::ResetView]->GetState<bool>())
     g_freelook_camera.Reset();
+
+  ControlReference::SetInputGate(prev_input_gate);
 }
 
 namespace FreeLook

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -90,7 +90,7 @@ bool OutputReference::IsInput() const
 //
 ControlState InputReference::State(const ControlState ignore)
 {
-  if (m_parsed_expression && GetInputGate())
+  if (m_parsed_expression)
     return m_parsed_expression->GetValue() * range;
   return 0.0;
 }

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -17,6 +17,7 @@
 #include "Common/Common.h"
 #include "Common/StringUtil.h"
 
+#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
 #include "InputCommon/ControlReference/FunctionExpression.h"
 
@@ -261,7 +262,7 @@ public:
 
   ControlState GetValueIgnoringSuppression() const
   {
-    if (!input)
+    if (!input || !ControlReference::GetInputGate())
       return 0.0;
 
     // Note: Inputs may return negative values in situations where opposing directions are


### PR DESCRIPTION
If hotkeys were being held while disabling freelook they would continue to block regular inputs.
This fixes that minor issue.