### PR TITLE
Fix GDBStub build and build it by default 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ option(ENCODE_FRAMEDUMPS "Encode framedumps in AVI format" ON)
 
 option(ENABLE_GPROF "Enable gprof profiling (must be using Debug build)" OFF)
 option(FASTLOG "Enable all logs" OFF)
-option(GDBSTUB "Enable gdb stub for remote debugging." OFF)
+option(GDBSTUB "Enable gdb stub for remote debugging." ON)
 option(OPROFILING "Enable profiling" OFF)
 
 # TODO: Add DSPSpy

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -240,7 +240,7 @@ static void gdb_read_command()
   cmd_len = 0;
   memset(cmd_bfr, 0, sizeof cmd_bfr);
 
-  const u8 c = gdb_read_byte();
+  u8 c = gdb_read_byte();
   if (c == '+')
   {
     // ignore ack


### PR DESCRIPTION
While the gdbstub is somewhat broken at the moment, building it by
default should keep us from breaking the build (which has happened
several times in the past: #2614, #5904, #8262, #9359).

It isn't very intrusive and it does nothing unless it is enabled
in the config file.
