### PR TITLE
VideoCommon: Fix crash that occurs on loading a fifo log when Free Look is enabled

### DIFF
--- a/Source/Core/VideoCommon/FreeLookCamera.cpp
+++ b/Source/Core/VideoCommon/FreeLookCamera.cpp
@@ -175,6 +175,11 @@ private:
 };
 }  // namespace
 
+FreeLookCamera::FreeLookCamera()
+{
+  SetControlType(FreeLook::ControlType::SixAxis);
+}
+
 void FreeLookCamera::SetControlType(FreeLook::ControlType type)
 {
   if (m_current_type && *m_current_type == type)

--- a/Source/Core/VideoCommon/FreeLookCamera.h
+++ b/Source/Core/VideoCommon/FreeLookCamera.h
@@ -41,6 +41,7 @@ public:
 class FreeLookCamera
 {
 public:
+  FreeLookCamera();
   void SetControlType(FreeLook::ControlType type);
   Common::Matrix44 GetView();
   Common::Vec2 GetFieldOfView() const;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -111,6 +111,7 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height, float backbuffer
   CalculateTargetSize();
 
   m_is_game_widescreen = SConfig::GetInstance().bWii && Config::Get(Config::SYSCONF_WIDESCREEN);
+  g_freelook_camera.SetControlType(FreeLook::GetActiveConfig().camera_config.control_type);
 }
 
 Renderer::~Renderer() = default;


### PR DESCRIPTION
During the Free Look refactor (#8867 ) I apparently forgot to test loading a fifo log.  A crash occurs there because the camera control type is not set and therefore the controller is null.

This fixes the crash and adds some safety checks to check for null pointers.

Sorry about that!

EDIT: This crash is not specific to fifo per-se.  It's just the fifo logs I tested had an initial frame of projection-type perspective where we call [GetView()](https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/VideoCommon/VertexShaderManager.cpp#L423).  Most games I tested startup with a projection type of orthographic, giving time for `Renderer::CheckForConfigChanges()` to [update the control type](https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/VideoCommon/RenderBase.cpp#L409).