### PR TITLE
Android: Only have one settings entrypoint in game properties

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -267,7 +267,7 @@ public final class EmulationActivity extends AppCompatActivity
     mPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
     mSettings = new Settings();
-    mSettings.loadSettings(null);
+    mSettings.loadSettings();
 
     updateOrientation();
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/dialogs/GamePropertiesDialog.java
@@ -50,11 +50,12 @@ public class GamePropertiesDialog extends DialogFragment
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState)
   {
-    String path = requireArguments().getString(ARG_PATH);
-    String gameId = requireArguments().getString(ARG_GAMEID);
-    int revision = requireArguments().getInt(ARG_REVISION);
-    int platform = requireArguments().getInt(ARG_PLATFORM);
-    boolean shouldAllowConversion = requireArguments().getBoolean(ARG_SHOULD_ALLOW_CONVERSION);
+    final String path = requireArguments().getString(ARG_PATH);
+    final String gameId = requireArguments().getString(ARG_GAMEID);
+    final int revision = requireArguments().getInt(ARG_REVISION);
+    final boolean isWii = requireArguments().getInt(ARG_PLATFORM) != Platform.GAMECUBE.toInt();
+    final boolean shouldAllowConversion =
+            requireArguments().getBoolean(ARG_SHOULD_ALLOW_CONVERSION);
 
     AlertDialogItemsBuilder itemsBuilder = new AlertDialogItemsBuilder(requireContext());
 
@@ -72,26 +73,14 @@ public class GamePropertiesDialog extends DialogFragment
     {
       try (Settings settings = new Settings())
       {
-        settings.loadSettings(null);
+        settings.loadSettings();
         StringSetting.MAIN_DEFAULT_ISO.setString(settings, path);
         settings.saveSettings(null, getContext());
       }
     });
 
-    itemsBuilder.add(R.string.properties_core_settings, (dialog, i) ->
-            SettingsActivity.launch(getContext(), MenuTag.CONFIG, gameId, revision));
-
-    itemsBuilder.add(R.string.properties_gfx_settings, (dialog, i) ->
-            SettingsActivity.launch(getContext(), MenuTag.GRAPHICS, gameId, revision));
-
-    itemsBuilder.add(R.string.properties_gc_controller, (dialog, i) ->
-            SettingsActivity.launch(getContext(), MenuTag.GCPAD_TYPE, gameId, revision));
-
-    if (platform != Platform.GAMECUBE.toInt())
-    {
-      itemsBuilder.add(R.string.properties_wii_controller, (dialog, i) ->
-              SettingsActivity.launch(getActivity(), MenuTag.WIIMOTE, gameId, revision));
-    }
+    itemsBuilder.add(R.string.properties_edit_game_settings, (dialog, i) ->
+            SettingsActivity.launch(getContext(), MenuTag.SETTINGS, gameId, revision, isWii));
 
     itemsBuilder.add(R.string.properties_clear_game_settings, (dialog, i) ->
             clearGameSettings(gameId));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -54,6 +54,7 @@ public class Settings implements Closeable
 
   private String mGameId;
   private int mRevision;
+  private boolean mIsWii;
 
   private static final String[] configFiles = new String[]{FILE_DOLPHIN, FILE_GFX, FILE_LOGGER,
           FILE_WIIMOTE};
@@ -87,6 +88,11 @@ public class Settings implements Closeable
   public boolean isGameSpecific()
   {
     return !TextUtils.isEmpty(mGameId);
+  }
+
+  public boolean isWii()
+  {
+    return mIsWii;
   }
 
   public IniFile getWiimoteProfile(String profile, int padID)
@@ -143,8 +149,16 @@ public class Settings implements Closeable
     return mIniFiles.isEmpty();
   }
 
-  public void loadSettings(SettingsActivityView view)
+  public void loadSettings()
   {
+    // The value of isWii doesn't matter if we don't have any SettingsActivity
+    loadSettings(null, true);
+  }
+
+  public void loadSettings(SettingsActivityView view, boolean isWii)
+  {
+    mIsWii = isWii;
+
     mIniFiles = new HashMap<>();
 
     if (!isGameSpecific())
@@ -181,11 +195,11 @@ public class Settings implements Closeable
     mIniFiles.put(GAME_SETTINGS_PLACEHOLDER_FILE_NAME, ini);
   }
 
-  public void loadSettings(String gameId, int revision, SettingsActivityView view)
+  public void loadSettings(SettingsActivityView view, String gameId, int revision, boolean isWii)
   {
     mGameId = gameId;
     mRevision = revision;
-    loadSettings(view);
+    loadSettings(view, isWii);
   }
 
   public void saveSettings(SettingsActivityView view, Context context)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivity.java
@@ -17,6 +17,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.ui.main.MainActivity;
 import org.dolphinemu.dolphinemu.ui.main.MainPresenter;
@@ -29,17 +30,20 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   private static final String ARG_MENU_TAG = "menu_tag";
   private static final String ARG_GAME_ID = "game_id";
   private static final String ARG_REVISION = "revision";
+  private static final String ARG_IS_WII = "is_wii";
   private static final String FRAGMENT_TAG = "settings";
   private SettingsActivityPresenter mPresenter;
 
   private ProgressDialog dialog;
 
-  public static void launch(Context context, MenuTag menuTag, String gameId, int revision)
+  public static void launch(Context context, MenuTag menuTag, String gameId, int revision,
+          boolean isWii)
   {
     Intent settings = new Intent(context, SettingsActivity.class);
     settings.putExtra(ARG_MENU_TAG, menuTag);
     settings.putExtra(ARG_GAME_ID, gameId);
     settings.putExtra(ARG_REVISION, revision);
+    settings.putExtra(ARG_IS_WII, isWii);
     context.startActivity(settings);
   }
 
@@ -47,8 +51,7 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
   {
     Intent settings = new Intent(context, SettingsActivity.class);
     settings.putExtra(ARG_MENU_TAG, menuTag);
-    settings.putExtra(ARG_GAME_ID, "");
-    settings.putExtra(ARG_REVISION, 0);
+    settings.putExtra(ARG_IS_WII, !NativeLibrary.IsRunning() || NativeLibrary.IsEmulatingWii());
     context.startActivity(settings);
   }
 
@@ -70,11 +73,15 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
 
     Intent launcher = getIntent();
     String gameID = launcher.getStringExtra(ARG_GAME_ID);
+    if (gameID == null)
+      gameID = "";
     int revision = launcher.getIntExtra(ARG_REVISION, 0);
+    boolean isWii = launcher.getBooleanExtra(ARG_IS_WII, true);
     MenuTag menuTag = (MenuTag) launcher.getSerializableExtra(ARG_MENU_TAG);
 
     mPresenter = new SettingsActivityPresenter(this, getSettings());
-    mPresenter.onCreate(savedInstanceState, menuTag, gameID, revision, getApplicationContext());
+    mPresenter.onCreate(savedInstanceState, menuTag, gameID, revision, isWii,
+            getApplicationContext());
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsActivityPresenter.java
@@ -22,10 +22,11 @@ public final class SettingsActivityPresenter
 
   private AfterDirectoryInitializationRunner mAfterDirectoryInitializationRunner;
 
-  private MenuTag menuTag;
-  private String gameId;
-  private int revision;
-  private Context context;
+  private MenuTag mMenuTag;
+  private String mGameId;
+  private int mRevision;
+  private boolean mIsWii;
+  private Context mContext;
 
   SettingsActivityPresenter(SettingsActivityView view, Settings settings)
   {
@@ -34,12 +35,13 @@ public final class SettingsActivityPresenter
   }
 
   public void onCreate(Bundle savedInstanceState, MenuTag menuTag, String gameId, int revision,
-          Context context)
+          boolean isWii, Context context)
   {
-    this.menuTag = menuTag;
-    this.gameId = gameId;
-    this.revision = revision;
-    this.context = context;
+    this.mMenuTag = menuTag;
+    this.mGameId = gameId;
+    this.mRevision = revision;
+    this.mIsWii = isWii;
+    this.mContext = context;
 
     mShouldSave = savedInstanceState != null && savedInstanceState.getBoolean(KEY_SHOULD_SAVE);
   }
@@ -62,9 +64,9 @@ public final class SettingsActivityPresenter
   {
     if (mSettings.isEmpty())
     {
-      if (!TextUtils.isEmpty(gameId))
+      if (!TextUtils.isEmpty(mGameId))
       {
-        mSettings.loadSettings(gameId, revision, mView);
+        mSettings.loadSettings(mView, mGameId, mRevision, mIsWii);
 
         if (mSettings.gameIniContainsJunk())
         {
@@ -73,11 +75,11 @@ public final class SettingsActivityPresenter
       }
       else
       {
-        mSettings.loadSettings(mView);
+        mSettings.loadSettings(mView, mIsWii);
       }
     }
 
-    mView.showSettingsFragment(menuTag, null, false, gameId);
+    mView.showSettingsFragment(mMenuTag, null, false, mGameId);
     mView.onSettingsFileLoaded(mSettings);
   }
 
@@ -93,7 +95,7 @@ public final class SettingsActivityPresenter
 
       mAfterDirectoryInitializationRunner = new AfterDirectoryInitializationRunner();
       mAfterDirectoryInitializationRunner.setFinishedCallback(mView::hideLoading);
-      mAfterDirectoryInitializationRunner.run(context, true, this::loadSettingsUI);
+      mAfterDirectoryInitializationRunner.run(mContext, true, this::loadSettingsUI);
     }
   }
 
@@ -119,7 +121,7 @@ public final class SettingsActivityPresenter
     if (mSettings != null && finishing && mShouldSave)
     {
       Log.debug("[SettingsActivity] Settings activity stopping. Saving settings to INI...");
-      mSettings.saveSettings(mView, context);
+      mSettings.saveSettings(mView, mContext);
     }
   }
 
@@ -155,7 +157,7 @@ public final class SettingsActivityPresenter
     {
       Bundle bundle = new Bundle();
       bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value / 6);
-      mView.showSettingsFragment(key, bundle, true, gameId);
+      mView.showSettingsFragment(key, bundle, true, mGameId);
     }
   }
 
@@ -164,7 +166,7 @@ public final class SettingsActivityPresenter
     switch (value)
     {
       case 1:
-        mView.showSettingsFragment(menuTag, null, true, gameId);
+        mView.showSettingsFragment(menuTag, null, true, mGameId);
         break;
 
       case 2:
@@ -179,7 +181,7 @@ public final class SettingsActivityPresenter
     {
       Bundle bundle = new Bundle();
       bundle.putInt(SettingsFragmentPresenter.ARG_CONTROLLER_TYPE, value);
-      mView.showSettingsFragment(menuTag, bundle, true, gameId);
+      mView.showSettingsFragment(menuTag, bundle, true, mGameId);
     }
   }
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -228,7 +228,8 @@ public final class SettingsFragmentPresenter
     if (!NativeLibrary.IsRunning())
     {
       sl.add(new SubmenuSetting(R.string.gcpad_settings, MenuTag.GCPAD_TYPE));
-      sl.add(new SubmenuSetting(R.string.wiimote_settings, MenuTag.WIIMOTE));
+      if (mSettings.isWii())
+        sl.add(new SubmenuSetting(R.string.wiimote_settings, MenuTag.WIIMOTE));
     }
 
     sl.add(new HeaderSetting(R.string.setting_clear_info, 0));

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainActivity.java
@@ -299,7 +299,7 @@ public final class MainActivity extends AppCompatActivity implements MainView
 
         try (Settings settings = new Settings())
         {
-          settings.loadSettings(null);
+          settings.loadSettings();
 
           IntSetting.MAIN_LAST_PLATFORM_TAB.setInt(settings, tab.getPosition());
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/Analytics.java
@@ -52,7 +52,7 @@ public class Analytics
   {
     try (Settings settings = new Settings())
     {
-      settings.loadSettings(null);
+      settings.loadSettings();
 
       BooleanSetting.MAIN_ANALYTICS_ENABLED.setBoolean(settings, enabled);
       BooleanSetting.MAIN_ANALYTICS_PERMISSION_ASKED.setBoolean(settings, true);

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -336,10 +336,7 @@
     <string name="properties_details">Details</string>
     <string name="properties_convert">Convert File</string>
     <string name="properties_set_default_iso">Set as Default ISO</string>
-    <string name="properties_core_settings">Core Settings</string>
-    <string name="properties_gfx_settings">GFX Settings</string>
-    <string name="properties_gc_controller">GameCube Controller Settings</string>
-    <string name="properties_wii_controller">Wii Controller Settings</string>
+    <string name="properties_edit_game_settings">Edit Game Settings</string>
     <string name="properties_clear_game_settings">Clear Game Settings</string>
     <string name="preferences_save_exit">Save and Exit</string>
     <string name="preferences_settings">Settings</string>


### PR DESCRIPTION
In PR #9357, I intended to update the main activity, emulation activity and game properties dialog, but I forgot to actually update the game properties dialog. This commit fixes that.

The changes outside of GamePropertiesDialog.java are just to hide the Wii controller settings for GameCube games.