### PR TITLE
Jit_Integer: rlwinmx: Use BEXTR where possible

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1534,6 +1534,7 @@ void Jit64::rlwinmx(UGeckoInstruction inst)
   {
     const bool left_shift = inst.SH && inst.MB == 0 && inst.ME == 31 - inst.SH;
     const bool right_shift = inst.SH && inst.ME == 31 && inst.MB == 32 - inst.SH;
+    const bool field_extract = inst.SH && inst.ME == 31 && inst.MB > 32 - inst.SH;
     const u32 mask = MakeRotationMask(inst.MB, inst.ME);
     const bool simple_mask = mask == 0xff || mask == 0xffff;
     // In case of a merged branch, track whether or not we've set flags.
@@ -1564,6 +1565,13 @@ void Jit64::rlwinmx(UGeckoInstruction inst)
       MOVZX(32, mask_size, Ra, Rs);
       SHL(32, Ra, Imm8(inst.SH));
       needs_sext = inst.SH + mask_size >= 32;
+    }
+    // Use BEXTR where possible: Only AMD implements this in one uop
+    else if (field_extract && cpu_info.bBMI1 && cpu_info.vendor == CPUVendor::AMD)
+    {
+      MOV(32, R(RSCRATCH), Imm32((mask_size << 8) | (32 - inst.SH)));
+      BEXTR(32, Ra, Rs, RSCRATCH);
+      needs_sext = false;
     }
     else
     {


### PR DESCRIPTION
BEXTR is one uop on AMD only. On Intel one would prefer to shift+mask.