### PR TITLE
CMake: Update cmake_minimum_required calls using versions less than 2.8.12.

### DIFF
--- a/Externals/enet/CMakeLists.txt
+++ b/Externals/enet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(enet)
 

--- a/Externals/gtest/CMakeLists.txt
+++ b/Externals/gtest/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION 1.9.0 LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.8.12)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)

--- a/Externals/mbedtls/CMakeLists.txt
+++ b/Externals/mbedtls/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project("mbed TLS" C)
 
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}

--- a/Externals/miniupnpc/CMakeLists.txt
+++ b/Externals/miniupnpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(miniupnpc C)
 set(MINIUPNPC_VERSION 1.9)

--- a/Externals/pugixml/CMakeLists.txt
+++ b/Externals/pugixml/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(pugixml)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 


### PR DESCRIPTION
My IDE was showing me CMake warnings and it was annoying.

"CMake Deprecation Warning at Externals/enet/CMakeLists.txt:1 (cmake_minimum_required):Compatibility with CMake < 2.8.12 will be removed from a future version of\nCMake.\n\nUpdate the VERSION argument <min> value or use a ...<max> suffix to tell\nCMake that the project does not need compatibility with older versions."

I've specified version 2.8.12 to eliminate the warnings.