### PR TITLE
JitArm64_Integer: Add optimizations for rlwimix

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1661,7 +1661,7 @@ void ARM64XEmitter::BFI(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
   ASSERT_MSG(DYNA_REC, (lsb + width) <= size,
              "%s passed lsb %d and width %d which is greater than the register size!", __func__,
              lsb, width);
-  EncodeBitfieldMOVInst(1, Rd, Rn, (size - lsb) % size, width - 1);
+  BFM(Rd, Rn, (size - lsb) % size, width - 1);
 }
 void ARM64XEmitter::BFXIL(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
@@ -1669,7 +1669,7 @@ void ARM64XEmitter::BFXIL(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
   ASSERT_MSG(DYNA_REC, lsb < size && width >= 1 && width <= size - lsb,
              "%s passed lsb %d and width %d which is greater than the register size!", __func__,
              lsb, width);
-  EncodeBitfieldMOVInst(1, Rd, Rn, lsb, lsb + width - 1);
+  BFM(Rd, Rn, lsb, lsb + width - 1);
 }
 void ARM64XEmitter::UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
@@ -1677,7 +1677,7 @@ void ARM64XEmitter::UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
   ASSERT_MSG(DYNA_REC, (lsb + width) <= size,
              "%s passed lsb %d and width %d which is greater than the register size!", __func__,
              lsb, width);
-  EncodeBitfieldMOVInst(2, Rd, Rn, (size - lsb) % size, width - 1);
+  UBFM(Rd, Rn, (size - lsb) % size, width - 1);
 }
 void ARM64XEmitter::EXTR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u32 shift)
 {

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1663,6 +1663,14 @@ void ARM64XEmitter::BFI(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
              lsb, width);
   EncodeBitfieldMOVInst(1, Rd, Rn, (size - lsb) % size, width - 1);
 }
+void ARM64XEmitter::BFXIL(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
+{
+  u32 size = Is64Bit(Rn) ? 64 : 32;
+  ASSERT_MSG(DYNA_REC, lsb < size && width >= 1 && width <= size - lsb,
+             "%s passed lsb %d and width %d which is greater than the register size!", __func__,
+             lsb, width);
+  EncodeBitfieldMOVInst(1, Rd, Rn, lsb, lsb + width - 1);
+}
 void ARM64XEmitter::UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1658,7 +1658,7 @@ void ARM64XEmitter::UBFM(ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms)
 void ARM64XEmitter::BFI(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;
-  ASSERT_MSG(DYNA_REC, (lsb + width) <= size,
+  ASSERT_MSG(DYNA_REC, lsb < size && width >= 1 && width <= size - lsb,
              "%s passed lsb %d and width %d which is greater than the register size!", __func__,
              lsb, width);
   BFM(Rd, Rn, (size - lsb) % size, width - 1);
@@ -1674,7 +1674,7 @@ void ARM64XEmitter::BFXIL(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 void ARM64XEmitter::UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
   u32 size = Is64Bit(Rn) ? 64 : 32;
-  ASSERT_MSG(DYNA_REC, (lsb + width) <= size,
+  ASSERT_MSG(DYNA_REC, lsb < size && width >= 1 && width <= size - lsb,
              "%s passed lsb %d and width %d which is greater than the register size!", __func__,
              lsb, width);
   UBFM(Rd, Rn, (size - lsb) % size, width - 1);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -770,6 +770,7 @@ public:
   void SBFM(ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms);
   void UBFM(ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms);
   void BFI(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width);
+  void BFXIL(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width);
   void UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width);
 
   // Extract register (ROR with two inputs, if same then faster on A67)


### PR DESCRIPTION
* Check for case when source field is at LSB
* Use BFXIL if possible
* Avoid ROR where possible