### PR TITLE
Jit_Integer: Optimize rlwimix

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1771,11 +1771,7 @@ void Jit64::rlwnmx(UGeckoInstruction inst)
     RCOpArg Rs = gpr.Use(s, RCMode::Read);
     RegCache::Realize(Ra, Rs);
 
-    if (a != s)
-      MOV(32, Ra, Rs);
-
-    if (amount)
-      ROL(32, Ra, Imm8(amount));
+    RotateLeft(32, Ra, Rs, amount);
 
     // we need flags if we're merging the branch
     if (inst.Rc && CheckMergedBranch(0))

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1668,7 +1668,7 @@ void Jit64::rlwimix(UGeckoInstruction inst)
     else if (mask == 0xFFFFFFFF)
     {
       RCOpArg Rs = gpr.Use(s, RCMode::Read);
-      RCX64Reg Ra = gpr.Bind(a, RCMode::Read);
+      RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
       RegCache::Realize(Rs, Ra);
       RotateLeft(32, Ra, Rs, inst.SH);
       needs_test = true;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1667,7 +1667,10 @@ void Jit64::rlwimix(UGeckoInstruction inst)
   }
   else
   {
+    const bool left_shift = mask == 0U - (1U << inst.SH);
+    const bool right_shift = mask == (1U << inst.SH) - 1;
     bool needs_test = false;
+
     if (mask == 0 || (a == s && inst.SH == 0))
     {
       needs_test = true;
@@ -1687,63 +1690,58 @@ void Jit64::rlwimix(UGeckoInstruction inst)
       AndWithMask(Ra, ~mask);
       OR(32, Ra, Imm32(Common::RotateLeft(gpr.Imm32(s), inst.SH) & mask));
     }
-    else if (inst.SH)
+    else if (inst.SH && gpr.IsImm(a))
     {
-      bool isLeftShift = mask == 0U - (1U << inst.SH);
-      bool isRightShift = mask == (1U << inst.SH) - 1;
-      if (gpr.IsImm(a))
+      u32 maskA = gpr.Imm32(a) & ~mask;
+
+      RCOpArg Rs = gpr.Use(s, RCMode::Read);
+      RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
+      RegCache::Realize(Rs, Ra);
+
+      if (left_shift)
       {
-        u32 maskA = gpr.Imm32(a) & ~mask;
-
-        RCOpArg Rs = gpr.Use(s, RCMode::Read);
-        RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
-        RegCache::Realize(Rs, Ra);
-
-        if (isLeftShift)
-        {
-          MOV(32, Ra, Rs);
-          SHL(32, Ra, Imm8(inst.SH));
-        }
-        else if (isRightShift)
-        {
-          MOV(32, Ra, Rs);
-          SHR(32, Ra, Imm8(32 - inst.SH));
-        }
-        else
-        {
-          RotateLeft(32, Ra, Rs, inst.SH);
-          AndWithMask(Ra, mask);
-        }
-        OR(32, Ra, Imm32(maskA));
+        MOV(32, Ra, Rs);
+        SHL(32, Ra, Imm8(inst.SH));
+      }
+      else if (right_shift)
+      {
+        MOV(32, Ra, Rs);
+        SHR(32, Ra, Imm8(32 - inst.SH));
       }
       else
       {
-        // TODO: common cases of this might be faster with pinsrb or abuse of AH
-        RCOpArg Rs = gpr.Use(s, RCMode::Read);
-        RCX64Reg Ra = gpr.Bind(a, RCMode::ReadWrite);
-        RegCache::Realize(Rs, Ra);
+        RotateLeft(32, Ra, Rs, inst.SH);
+        AndWithMask(Ra, mask);
+      }
+      OR(32, Ra, Imm32(maskA));
+    }
+    else if (inst.SH)
+    {
+      // TODO: common cases of this might be faster with pinsrb or abuse of AH
+      RCOpArg Rs = gpr.Use(s, RCMode::Read);
+      RCX64Reg Ra = gpr.Bind(a, RCMode::ReadWrite);
+      RegCache::Realize(Rs, Ra);
 
-        if (isLeftShift)
-        {
-          MOV(32, R(RSCRATCH), Rs);
-          SHL(32, R(RSCRATCH), Imm8(inst.SH));
-          AndWithMask(Ra, ~mask);
-          OR(32, Ra, R(RSCRATCH));
-        }
-        else if (isRightShift)
-        {
-          MOV(32, R(RSCRATCH), Rs);
-          SHR(32, R(RSCRATCH), Imm8(32 - inst.SH));
-          AndWithMask(Ra, ~mask);
-          OR(32, Ra, R(RSCRATCH));
-        }
-        else
-        {
-          RotateLeft(32, RSCRATCH, Rs, inst.SH);
-          XOR(32, R(RSCRATCH), Ra);
-          AndWithMask(RSCRATCH, mask);
-          XOR(32, Ra, R(RSCRATCH));
-        }
+      if (left_shift)
+      {
+        MOV(32, R(RSCRATCH), Rs);
+        SHL(32, R(RSCRATCH), Imm8(inst.SH));
+        AndWithMask(Ra, ~mask);
+        OR(32, Ra, R(RSCRATCH));
+      }
+      else if (right_shift)
+      {
+        MOV(32, R(RSCRATCH), Rs);
+        SHR(32, R(RSCRATCH), Imm8(32 - inst.SH));
+        AndWithMask(Ra, ~mask);
+        OR(32, Ra, R(RSCRATCH));
+      }
+      else
+      {
+        RotateLeft(32, RSCRATCH, Rs, inst.SH);
+        XOR(32, R(RSCRATCH), Ra);
+        AndWithMask(RSCRATCH, mask);
+        XOR(32, Ra, R(RSCRATCH));
       }
     }
     else

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1649,17 +1649,24 @@ void Jit64::rlwimix(UGeckoInstruction inst)
   int a = inst.RA;
   int s = inst.RS;
 
+  const u32 mask = MakeRotationMask(inst.MB, inst.ME);
+
   if (gpr.IsImm(a, s))
   {
-    const u32 mask = MakeRotationMask(inst.MB, inst.ME);
     gpr.SetImmediate32(a,
                        (gpr.Imm32(a) & ~mask) | (Common::RotateLeft(gpr.Imm32(s), inst.SH) & mask));
     if (inst.Rc)
       ComputeRC(a);
   }
+  else if (gpr.IsImm(s) && mask == 0xFFFFFFFF)
+  {
+    gpr.SetImmediate32(a, Common::RotateLeft(gpr.Imm32(s), inst.SH));
+
+    if (inst.Rc)
+      ComputeRC(a);
+  }
   else
   {
-    const u32 mask = MakeRotationMask(inst.MB, inst.ME);
     bool needs_test = false;
     if (mask == 0 || (a == s && inst.SH == 0))
     {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1690,15 +1690,20 @@ void Jit64::rlwimix(UGeckoInstruction inst)
       AndWithMask(Ra, ~mask);
       OR(32, Ra, Imm32(Common::RotateLeft(gpr.Imm32(s), inst.SH) & mask));
     }
-    else if (inst.SH && gpr.IsImm(a))
+    else if (gpr.IsImm(a))
     {
-      u32 maskA = gpr.Imm32(a) & ~mask;
+      const u32 maskA = gpr.Imm32(a) & ~mask;
 
       RCOpArg Rs = gpr.Use(s, RCMode::Read);
       RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
       RegCache::Realize(Rs, Ra);
 
-      if (left_shift)
+      if (inst.SH == 0)
+      {
+        MOV(32, Ra, Rs);
+        AndWithMask(Ra, mask);
+      }
+      else if (left_shift)
       {
         MOV(32, Ra, Rs);
         SHL(32, Ra, Imm8(inst.SH));
@@ -1713,7 +1718,11 @@ void Jit64::rlwimix(UGeckoInstruction inst)
         RotateLeft(32, Ra, Rs, inst.SH);
         AndWithMask(Ra, mask);
       }
-      OR(32, Ra, Imm32(maskA));
+
+      if (maskA)
+        OR(32, Ra, Imm32(maskA));
+      else
+        needs_test = true;
     }
     else if (inst.SH)
     {


### PR DESCRIPTION
Last PR for a while.

The main purpose of this PR was the final commit, wherein we implement cases where mask is 0xFF or 0xFFFF with partial register writes.

A few additional commits for other things noticed along the way, these can be split into separate PRs if desired.

Sidenotes for future optimziations: 
* Using AH/BH/CH/DH is unlikely to be sufficiently profitable due to encoding limitations.
* Using pinsrb is unlikely to be profitable due to the cost of register moves.
