### PR TITLE
DSPAnalyzer: Migrate off file-scope state

### DIFF
--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -80,7 +80,16 @@ void Analyzer::AnalyzeRange(const SDSP& dsp, u16 start_addr, u16 end_addr)
 {
   // First we run an extremely simplified version of a disassembler to find
   // where all instructions start.
+  FindInstructionStarts(dsp, start_addr, end_addr);
 
+  // Next, we'll scan for potential idle skips.
+  FindIdleSkips(dsp, start_addr, end_addr);
+
+  INFO_LOG_FMT(DSPLLE, "Finished analysis.");
+}
+
+void Analyzer::FindInstructionStarts(const SDSP& dsp, u16 start_addr, u16 end_addr)
+{
   // This may not be 100% accurate in case of jump tables!
   // It could get desynced, which would be bad. We'll see if that's an issue.
   u16 last_arithmetic = 0;
@@ -132,8 +141,10 @@ void Analyzer::AnalyzeRange(const SDSP& dsp, u16 start_addr, u16 end_addr)
 
     addr += opcode->size;
   }
+}
 
-  // Next, we'll scan for potential idle skips.
+void Analyzer::FindIdleSkips(const SDSP& dsp, u16 start_addr, u16 end_addr)
+{
   for (size_t s = 0; s < NUM_IDLE_SIGS; s++)
   {
     for (u16 addr = start_addr; addr < end_addr; addr++)
@@ -155,6 +166,5 @@ void Analyzer::AnalyzeRange(const SDSP& dsp, u16 start_addr, u16 end_addr)
       }
     }
   }
-  INFO_LOG_FMT(DSPLLE, "Finished analysis.");
 }
 }  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -12,7 +12,7 @@
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPTables.h"
 
-namespace DSP::Analyzer
+namespace DSP
 {
 // Good candidates for idle skipping is mail wait loops. If we're time slicing
 // between the main CPU and the DSP, if the DSP runs into one of these, it might
@@ -160,4 +160,4 @@ void Analyzer::AnalyzeRange(u16 start_addr, u16 end_addr)
   }
   INFO_LOG_FMT(DSPLLE, "Finished analysis.");
 }
-}  // namespace DSP::Analyzer
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -130,7 +130,7 @@ void Analyzer::AnalyzeRange(u16 start_addr, u16 end_addr)
         opcode->opcode == 0x1900 || opcode->opcode == 0x1980 || opcode->opcode == 0x2000 ||
         opcode->extended)
     {
-      m_code_flags[static_cast<u16>(addr + opcode->size)] |= CODE_CHECK_INT;
+      m_code_flags[static_cast<u16>(addr + opcode->size)] |= CODE_CHECK_EXC;
     }
 
     addr += opcode->size;

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -18,17 +18,6 @@ namespace DSP::Analyzer
 // Useful things to detect:
 // * Loop endpoints - so that we can avoid checking for loops every cycle.
 
-enum CodeFlags : u8
-{
-  CODE_NONE = 0,
-  CODE_START_OF_INST = 1,
-  CODE_IDLE_SKIP = 2,
-  CODE_LOOP_START = 4,
-  CODE_LOOP_END = 8,
-  CODE_UPDATE_SR = 16,
-  CODE_CHECK_EXC = 32,
-};
-
 class Analyzer
 {
 public:
@@ -86,6 +75,17 @@ public:
   }
 
 private:
+  enum CodeFlags : u8
+  {
+    CODE_NONE = 0,
+    CODE_START_OF_INST = 1,
+    CODE_IDLE_SKIP = 2,
+    CODE_LOOP_START = 4,
+    CODE_LOOP_END = 8,
+    CODE_UPDATE_SR = 16,
+    CODE_CHECK_EXC = 32,
+  };
+
   // Flushes all analyzed state.
   void Reset();
 

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -92,6 +92,14 @@ private:
   // Note: start is inclusive, end is exclusive.
   void AnalyzeRange(const SDSP& dsp, u16 start_addr, u16 end_addr);
 
+  // Finds addresses in the range [start_addr, end_addr) that are the start of an
+  // instruction. During this process other attributes may be detected as well
+  // for relevant instructions (loop start/end, etc).
+  void FindInstructionStarts(const SDSP& dsp, u16 start_addr, u16 end_addr);
+
+  // Finds locations within the range [start_addr, end_addr) that may contain idle skips.
+  void FindIdleSkips(const SDSP& dsp, u16 start_addr, u16 end_addr);
+
   // Retrieves the flags set during analysis for code in memory.
   [[nodiscard]] u8 GetCodeFlags(u16 address) const { return m_code_flags[address]; }
 

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -26,7 +26,7 @@ enum CodeFlags : u8
   CODE_LOOP_START = 4,
   CODE_LOOP_END = 8,
   CODE_UPDATE_SR = 16,
-  CODE_CHECK_INT = 32,
+  CODE_CHECK_EXC = 32,
 };
 
 class Analyzer
@@ -49,8 +49,41 @@ public:
   // some pretty expensive analysis if necessary.
   void Analyze();
 
-  // Retrieves the flags set during analysis for code in memory.
-  [[nodiscard]] u8 GetCodeFlags(u16 address) const { return m_code_flags[address]; }
+  // Whether or not the given address indicates the start of an instruction.
+  [[nodiscard]] bool IsStartOfInstruction(u16 address) const
+  {
+    return (GetCodeFlags(address) & CODE_START_OF_INST) != 0;
+  }
+
+  // Whether or not the address indicates an idle skip location.
+  [[nodiscard]] bool IsIdleSkip(u16 address) const
+  {
+    return (GetCodeFlags(address) & CODE_IDLE_SKIP) != 0;
+  }
+
+  // Whether or not the address indicates the start of a loop.
+  [[nodiscard]] bool IsLoopStart(u16 address) const
+  {
+    return (GetCodeFlags(address) & CODE_LOOP_START) != 0;
+  }
+
+  // Whether or not the address indicates the end of a loop.
+  [[nodiscard]] bool IsLoopEnd(u16 address) const
+  {
+    return (GetCodeFlags(address) & CODE_LOOP_END) != 0;
+  }
+
+  // Whether or not the address describes an instruction that requires updating the SR register.
+  [[nodiscard]] bool IsUpdateSR(u16 address) const
+  {
+    return (GetCodeFlags(address) & CODE_UPDATE_SR) != 0;
+  }
+
+  // Whether or not the address describes instructions that potentially raise exceptions.
+  [[nodiscard]] bool IsCheckExceptions(u16 address) const
+  {
+    return (GetCodeFlags(address) & CODE_CHECK_EXC) != 0;
+  }
 
 private:
   // Flushes all analyzed state.
@@ -59,6 +92,9 @@ private:
   // Analyzes a region of DSP memory.
   // Note: start is inclusive, end is exclusive.
   void AnalyzeRange(u16 start_addr, u16 end_addr);
+
+  // Retrieves the flags set during analysis for code in memory.
+  [[nodiscard]] u8 GetCodeFlags(u16 address) const { return m_code_flags[address]; }
 
   // Holds data about all instructions in RAM.
   std::array<u8, 65536> m_code_flags{};

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -20,14 +20,14 @@ namespace DSP
 class Analyzer
 {
 public:
-  explicit Analyzer(const SDSP& dsp);
+  explicit Analyzer();
   ~Analyzer();
 
   Analyzer(const Analyzer&) = default;
-  Analyzer& operator=(const Analyzer&) = delete;
+  Analyzer& operator=(const Analyzer&) = default;
 
   Analyzer(Analyzer&&) = default;
-  Analyzer& operator=(Analyzer&&) = delete;
+  Analyzer& operator=(Analyzer&&) = default;
 
   // This one should be called every time IRAM changes - which is basically
   // every time that a new ucode gets uploaded, and never else. At that point,
@@ -35,7 +35,7 @@ public:
   // all old analysis away. Luckily the entire address space is only 64K code
   // words and the actual code space 8K instructions in total, so we can do
   // some pretty expensive analysis if necessary.
-  void Analyze();
+  void Analyze(const SDSP& dsp);
 
   // Whether or not the given address indicates the start of an instruction.
   [[nodiscard]] bool IsStartOfInstruction(u16 address) const
@@ -90,15 +90,12 @@ private:
 
   // Analyzes a region of DSP memory.
   // Note: start is inclusive, end is exclusive.
-  void AnalyzeRange(u16 start_addr, u16 end_addr);
+  void AnalyzeRange(const SDSP& dsp, u16 start_addr, u16 end_addr);
 
   // Retrieves the flags set during analysis for code in memory.
   [[nodiscard]] u8 GetCodeFlags(u16 address) const { return m_code_flags[address]; }
 
   // Holds data about all instructions in RAM.
   std::array<u8, 65536> m_code_flags{};
-
-  // DSP context for analysis to be run under.
-  const SDSP& m_dsp;
 };
 }  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -66,16 +66,4 @@ private:
   // DSP context for analysis to be run under.
   const SDSP& m_dsp;
 };
-
-// This one should be called every time IRAM changes - which is basically
-// every time that a new ucode gets uploaded, and never else. At that point,
-// we can do as much static analysis as we want - but we should always throw
-// all old analysis away. Luckily the entire address space is only 64K code
-// words and the actual code space 8K instructions in total, so we can do
-// some pretty expensive analysis if necessary.
-void Analyze(const SDSP& dsp);
-
-// Retrieves the flags set during analysis for code in memory.
-u8 GetCodeFlags(u16 address);
-
 }  // namespace DSP::Analyzer

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include "Common/CommonTypes.h"
 
 namespace DSP
@@ -17,14 +18,53 @@ namespace DSP::Analyzer
 // Useful things to detect:
 // * Loop endpoints - so that we can avoid checking for loops every cycle.
 
-enum
+enum CodeFlags : u8
 {
+  CODE_NONE = 0,
   CODE_START_OF_INST = 1,
   CODE_IDLE_SKIP = 2,
   CODE_LOOP_START = 4,
   CODE_LOOP_END = 8,
   CODE_UPDATE_SR = 16,
   CODE_CHECK_INT = 32,
+};
+
+class Analyzer
+{
+public:
+  explicit Analyzer(const SDSP& dsp);
+  ~Analyzer();
+
+  Analyzer(const Analyzer&) = default;
+  Analyzer& operator=(const Analyzer&) = delete;
+
+  Analyzer(Analyzer&&) = default;
+  Analyzer& operator=(Analyzer&&) = delete;
+
+  // This one should be called every time IRAM changes - which is basically
+  // every time that a new ucode gets uploaded, and never else. At that point,
+  // we can do as much static analysis as we want - but we should always throw
+  // all old analysis away. Luckily the entire address space is only 64K code
+  // words and the actual code space 8K instructions in total, so we can do
+  // some pretty expensive analysis if necessary.
+  void Analyze();
+
+  // Retrieves the flags set during analysis for code in memory.
+  [[nodiscard]] u8 GetCodeFlags(u16 address) const { return m_code_flags[address]; }
+
+private:
+  // Flushes all analyzed state.
+  void Reset();
+
+  // Analyzes a region of DSP memory.
+  // Note: start is inclusive, end is exclusive.
+  void AnalyzeRange(u16 start_addr, u16 end_addr);
+
+  // Holds data about all instructions in RAM.
+  std::array<u8, 65536> m_code_flags{};
+
+  // DSP context for analysis to be run under.
+  const SDSP& m_dsp;
 };
 
 // This one should be called every time IRAM changes - which is basically

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -12,8 +12,7 @@ namespace DSP
 struct SDSP;
 }
 
-// Basic code analysis.
-namespace DSP::Analyzer
+namespace DSP
 {
 // Useful things to detect:
 // * Loop endpoints - so that we can avoid checking for loops every cycle.
@@ -102,4 +101,4 @@ private:
   // DSP context for analysis to be run under.
   const SDSP& m_dsp;
 };
-}  // namespace DSP::Analyzer
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -115,7 +115,7 @@ private:
   SDSP& m_dsp;
 };
 
-SDSP::SDSP(DSPCore& core) : m_dsp_core{core}
+SDSP::SDSP(DSPCore& core) : m_dsp_core{core}, m_analyzer{*this}
 {
 }
 
@@ -487,7 +487,7 @@ void DSPCore::Step()
 void DSPCore::Reset()
 {
   m_dsp.Reset();
-  Analyzer::Analyze(m_dsp);
+  m_dsp.GetAnalyzer().Analyze();
 }
 
 void DSPCore::ClearIRAM()

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -115,7 +115,7 @@ private:
   SDSP& m_dsp;
 };
 
-SDSP::SDSP(DSPCore& core) : m_dsp_core{core}, m_analyzer{*this}
+SDSP::SDSP(DSPCore& core) : m_dsp_core{core}
 {
 }
 
@@ -487,7 +487,7 @@ void DSPCore::Step()
 void DSPCore::Reset()
 {
   m_dsp.Reset();
-  m_dsp.GetAnalyzer().Analyze();
+  m_dsp.GetAnalyzer().Analyze(m_dsp);
 }
 
 void DSPCore::ClearIRAM()

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "Common/Event.h"
+#include "Core/DSP/DSPAnalyzer.h"
 #include "Core/DSP/DSPBreakpoints.h"
 #include "Core/DSP/DSPCaptureLogger.h"
 
@@ -396,6 +397,10 @@ struct SDSP
   // Saves and loads any necessary state.
   void DoState(PointerWrap& p);
 
+  // DSP static analyzer.
+  Analyzer::Analyzer& GetAnalyzer() { return m_analyzer; }
+  const Analyzer::Analyzer& GetAnalyzer() const { return m_analyzer; }
+
   DSP_Regs r{};
   u16 pc = 0;
 
@@ -449,6 +454,7 @@ private:
   u16 ReadIFXImpl(u16 address);
 
   DSPCore& m_dsp_core;
+  Analyzer::Analyzer m_analyzer;
 };
 
 enum class State

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -398,8 +398,8 @@ struct SDSP
   void DoState(PointerWrap& p);
 
   // DSP static analyzer.
-  Analyzer::Analyzer& GetAnalyzer() { return m_analyzer; }
-  const Analyzer::Analyzer& GetAnalyzer() const { return m_analyzer; }
+  Analyzer& GetAnalyzer() { return m_analyzer; }
+  const Analyzer& GetAnalyzer() const { return m_analyzer; }
 
   DSP_Regs r{};
   u16 pc = 0;
@@ -454,7 +454,7 @@ private:
   u16 ReadIFXImpl(u16 address);
 
   DSPCore& m_dsp_core;
-  Analyzer::Analyzer m_analyzer;
+  Analyzer m_analyzer;
 };
 
 enum class State

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -51,7 +51,7 @@ void Interpreter::Step()
   ExecuteInstruction(UDSPInstruction{opc});
 
   const auto pc = state.pc;
-  if ((state.GetAnalyzer().GetCodeFlags(static_cast<u16>(pc - 1)) & Analyzer::CODE_LOOP_END) != 0)
+  if (state.GetAnalyzer().IsLoopEnd(static_cast<u16>(pc - 1)))
     HandleLoop();
 }
 
@@ -115,8 +115,7 @@ int Interpreter::RunCyclesDebug(int cycles)
         return cycles;
       }
 
-      // Idle skipping.
-      if ((state.GetAnalyzer().GetCodeFlags(state.pc) & Analyzer::CODE_IDLE_SKIP) != 0)
+      if (state.GetAnalyzer().IsIdleSkip(state.pc))
         return 0;
 
       Step();
@@ -171,8 +170,7 @@ int Interpreter::RunCycles(int cycles)
       if ((state.cr & CR_HALT) != 0)
         return 0;
 
-      // Idle skipping.
-      if ((state.GetAnalyzer().GetCodeFlags(state.pc) & Analyzer::CODE_IDLE_SKIP) != 0)
+      if (state.GetAnalyzer().IsIdleSkip(state.pc))
         return 0;
 
       Step();

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -42,14 +42,16 @@ void Interpreter::ExecuteInstruction(const UDSPInstruction inst)
 
 void Interpreter::Step()
 {
-  m_dsp_core.CheckExceptions();
-  m_dsp_core.DSPState().step_counter++;
+  auto& state = m_dsp_core.DSPState();
 
-  const u16 opc = m_dsp_core.DSPState().FetchInstruction();
+  m_dsp_core.CheckExceptions();
+  state.step_counter++;
+
+  const u16 opc = state.FetchInstruction();
   ExecuteInstruction(UDSPInstruction{opc});
 
-  const auto pc = m_dsp_core.DSPState().pc;
-  if ((Analyzer::GetCodeFlags(static_cast<u16>(pc - 1)) & Analyzer::CODE_LOOP_END) != 0)
+  const auto pc = state.pc;
+  if ((state.GetAnalyzer().GetCodeFlags(static_cast<u16>(pc - 1)) & Analyzer::CODE_LOOP_END) != 0)
     HandleLoop();
 }
 
@@ -114,7 +116,7 @@ int Interpreter::RunCyclesDebug(int cycles)
       }
 
       // Idle skipping.
-      if ((Analyzer::GetCodeFlags(state.pc) & Analyzer::CODE_IDLE_SKIP) != 0)
+      if ((state.GetAnalyzer().GetCodeFlags(state.pc) & Analyzer::CODE_IDLE_SKIP) != 0)
         return 0;
 
       Step();
@@ -170,7 +172,7 @@ int Interpreter::RunCycles(int cycles)
         return 0;
 
       // Idle skipping.
-      if ((Analyzer::GetCodeFlags(state.pc) & Analyzer::CODE_IDLE_SKIP) != 0)
+      if ((state.GetAnalyzer().GetCodeFlags(state.pc) & Analyzer::CODE_IDLE_SKIP) != 0)
         return 0;
 
       Step();

--- a/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPEmitter.cpp
@@ -128,9 +128,9 @@ void DSPEmitter::checkExceptions(u32 retval)
 
 bool DSPEmitter::FlagsNeeded() const
 {
-  const u8 flags = m_dsp_core.DSPState().GetAnalyzer().GetCodeFlags(m_compile_pc);
+  const auto& analyzer = m_dsp_core.DSPState().GetAnalyzer();
 
-  return !(flags & Analyzer::CODE_START_OF_INST) || (flags & Analyzer::CODE_UPDATE_SR);
+  return !analyzer.IsStartOfInstruction(m_compile_pc) || analyzer.IsUpdateSR(m_compile_pc);
 }
 
 static void FallbackThunk(Interpreter::Interpreter& interpreter, UDSPInstruction inst)
@@ -245,7 +245,7 @@ void DSPEmitter::Compile(u16 start_addr)
   auto& analyzer = m_dsp_core.DSPState().GetAnalyzer();
   while (m_compile_pc < start_addr + MAX_BLOCK_SIZE)
   {
-    if (analyzer.GetCodeFlags(m_compile_pc) & Analyzer::CODE_CHECK_INT)
+    if (analyzer.IsCheckExceptions(m_compile_pc))
       checkExceptions(m_block_size[start_addr]);
 
     const UDSPInstruction inst = m_dsp_core.DSPState().ReadIMEM(m_compile_pc);
@@ -263,7 +263,7 @@ void DSPEmitter::Compile(u16 start_addr)
 
     // Handle loop condition, only if current instruction was flagged as a loop destination
     // by the analyzer.
-    if ((analyzer.GetCodeFlags(static_cast<u16>(m_compile_pc - 1u)) & Analyzer::CODE_LOOP_END) != 0)
+    if (analyzer.IsLoopEnd(static_cast<u16>(m_compile_pc - 1u)))
     {
       MOVZX(32, 16, EAX, M_SDSP_r_st(2));
       TEST(32, R(EAX), R(EAX));
@@ -284,7 +284,7 @@ void DSPEmitter::Compile(u16 start_addr)
       DSPJitRegCache c(m_gpr);
       HandleLoop();
       m_gpr.SaveRegs();
-      if (!Host::OnThread() && (analyzer.GetCodeFlags(start_addr) & Analyzer::CODE_IDLE_SKIP) != 0)
+      if (!Host::OnThread() && analyzer.IsIdleSkip(start_addr))
       {
         MOV(16, R(EAX), Imm16(DSP_IDLE_SKIP_CYCLES));
       }
@@ -320,7 +320,7 @@ void DSPEmitter::Compile(u16 start_addr)
         DSPJitRegCache c(m_gpr);
         // don't update g_dsp.pc -- the branch insn already did
         m_gpr.SaveRegs();
-        if (!Host::OnThread() && (analyzer.GetCodeFlags(start_addr) & Analyzer::CODE_IDLE_SKIP) != 0)
+        if (!Host::OnThread() && analyzer.IsIdleSkip(start_addr))
         {
           MOV(16, R(EAX), Imm16(DSP_IDLE_SKIP_CYCLES));
         }
@@ -337,7 +337,7 @@ void DSPEmitter::Compile(u16 start_addr)
     }
 
     // End the block if we're before an idle skip address
-    if ((analyzer.GetCodeFlags(m_compile_pc) & Analyzer::CODE_IDLE_SKIP) != 0)
+    if (analyzer.IsIdleSkip(m_compile_pc))
     {
       break;
     }
@@ -383,7 +383,7 @@ void DSPEmitter::Compile(u16 start_addr)
   }
 
   m_gpr.SaveRegs();
-  if (!Host::OnThread() && (analyzer.GetCodeFlags(start_addr) & Analyzer::CODE_IDLE_SKIP) != 0)
+  if (!Host::OnThread() && analyzer.IsIdleSkip(start_addr))
   {
     MOV(16, R(EAX), Imm16(DSP_IDLE_SKIP_CYCLES));
   }

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitBranch.cpp
@@ -82,8 +82,7 @@ void DSPEmitter::WriteBranchExit()
 {
   DSPJitRegCache c(m_gpr);
   m_gpr.SaveRegs();
-  if ((m_dsp_core.DSPState().GetAnalyzer().GetCodeFlags(m_start_address) &
-       Analyzer::CODE_IDLE_SKIP) != 0)
+  if (m_dsp_core.DSPState().GetAnalyzer().IsIdleSkip(m_start_address))
   {
     MOV(16, R(EAX), Imm16(0x1000));
   }

--- a/Source/Core/Core/DSP/Jit/x64/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/x64/DSPJitBranch.cpp
@@ -82,7 +82,8 @@ void DSPEmitter::WriteBranchExit()
 {
   DSPJitRegCache c(m_gpr);
   m_gpr.SaveRegs();
-  if (Analyzer::GetCodeFlags(m_start_address) & Analyzer::CODE_IDLE_SKIP)
+  if ((m_dsp_core.DSPState().GetAnalyzer().GetCodeFlags(m_start_address) &
+       Analyzer::CODE_IDLE_SKIP) != 0)
   {
     MOV(16, R(EAX), Imm16(0x1000));
   }

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -93,8 +93,7 @@ void CodeLoaded(DSPCore& dsp, const u8* ptr, size_t size)
   UpdateDebugger();
 
   dsp.ClearIRAM();
-
-  Analyzer::Analyze(state);
+  state.GetAnalyzer().Analyze();
 }
 
 void UpdateDebugger()

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -93,7 +93,7 @@ void CodeLoaded(DSPCore& dsp, const u8* ptr, size_t size)
   UpdateDebugger();
 
   dsp.ClearIRAM();
-  state.GetAnalyzer().Analyze();
+  state.GetAnalyzer().Analyze(state);
 }
 
 void UpdateDebugger()


### PR DESCRIPTION
Turns the DSP analyzer into a class and situates it within the SDSP struct. With this, I believe all relevant state within the DSP code has been made non-global.

These changes were significantly easier to chunk out into parts for review, as opposed to the deglobalization efforts in DSPCore, as the file-scope state itself was already hidden behind an interface. This more-or-less allowed for "sliding" the class into place in an easier manner.

Each commit should explain what it does and any rationale for it if necessary.