### PR TITLE
Fix latency field being initially enabled on audio backends not supporting it

### DIFF
--- a/Source/Core/DolphinQt/Settings/AudioPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AudioPane.cpp
@@ -385,7 +385,8 @@ void AudioPane::OnEmulationStateChanged(bool running)
     m_dolby_pro_logic->setEnabled(!running);
     EnableDolbyQualityWidgets(!running && m_dolby_pro_logic->isChecked());
   }
-  if (m_latency_control_supported)
+  if (m_latency_control_supported &&
+      AudioCommon::SupportsLatencyControl(SConfig::GetInstance().sBackend))
   {
     m_latency_label->setEnabled(!running);
     m_latency_spin->setEnabled(!running);


### PR DESCRIPTION
On platforms where there is at least one audio backend supporting latency (e.g. Windows), the latency field was enabled on all backends, even if they don't support it, though it would become disabled after changing the backend.  This also happened after emulation is stopped.  The cause was `OnEmulationStateChanged` not checking if the backend supported latency; `OnEmulationStateChanged` is called when the audio pane is first constructed.