### PR TITLE
DSPCore: Move PRECISE_BACKLOG define to the interpreter code

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -25,10 +25,6 @@
 
 namespace DSP
 {
-// not needed for game ucodes (it slows down interpreter/dspjit32 + easier to compare int VS
-// dspjit64 without it)
-//#define PRECISE_BACKLOG
-
 // Returns false if the hash fails and the user hits "Yes"
 static bool VerifyRoms(const SDSP& dsp)
 {

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -16,6 +16,10 @@
 
 namespace DSP::Interpreter
 {
+// Not needed for game ucodes (it slows down interpreter + easier to compare int VS
+// dspjit64 without it)
+//#define PRECISE_BACKLOG
+
 Interpreter::Interpreter(DSPCore& dsp) : m_dsp_core{dsp}
 {
   InitInstructionTables();


### PR DESCRIPTION
The only usages of this define are within this source file.