### PR TITLE
DSP: Convert Mailbox enum into an enum class

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -387,8 +387,8 @@ void SDSP::DoState(PointerWrap& p)
   p.Do(step_counter);
   p.DoArray(ifx_regs);
   accelerator->DoState(p);
-  p.Do(mbox[0]);
-  p.Do(mbox[1]);
+  p.Do(m_mailbox[0]);
+  p.Do(m_mailbox[1]);
   Common::UnWriteProtectMemory(iram, DSP_IRAM_BYTE_SIZE, false);
   p.DoArray(iram, DSP_IRAM_SIZE);
   Common::WriteProtectMemory(iram, DSP_IRAM_BYTE_SIZE, false);

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -455,7 +455,7 @@ private:
 
   u16 ReadIFXImpl(u16 address);
 
-  std::atomic<u32> m_mailbox[2];
+  std::array<std::atomic<u32>, 2> m_mailbox;
   DSPCore& m_dsp_core;
   Analyzer m_analyzer;
 };

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -228,10 +228,10 @@ enum class ExceptionType
   ExternalInterrupt = 7     // 0x000e external int (message from CPU)
 };
 
-enum Mailbox : int
+enum class Mailbox
 {
-  MAILBOX_CPU,
-  MAILBOX_DSP
+  CPU,
+  DSP
 };
 
 struct DSP_Regs
@@ -445,6 +445,9 @@ struct SDSP
   u16* coef = nullptr;
 
 private:
+  auto& GetMailbox(Mailbox mailbox) { return mbox[static_cast<u32>(mailbox)]; }
+  const auto& GetMailbox(Mailbox mailbox) const { return mbox[static_cast<u32>(mailbox)]; }
+
   void FreeMemoryPages();
 
   void DoDMA();

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -429,9 +429,6 @@ struct SDSP
   u32 iram_crc = 0;
   u64 step_counter = 0;
 
-  // Mailbox.
-  std::atomic<u32> mbox[2];
-
   // Accelerator / DMA / other hardware registers. Not GPRs.
   std::array<u16, 256> ifx_regs{};
 
@@ -445,8 +442,8 @@ struct SDSP
   u16* coef = nullptr;
 
 private:
-  auto& GetMailbox(Mailbox mailbox) { return mbox[static_cast<u32>(mailbox)]; }
-  const auto& GetMailbox(Mailbox mailbox) const { return mbox[static_cast<u32>(mailbox)]; }
+  auto& GetMailbox(Mailbox mailbox) { return m_mailbox[static_cast<u32>(mailbox)]; }
+  const auto& GetMailbox(Mailbox mailbox) const { return m_mailbox[static_cast<u32>(mailbox)]; }
 
   void FreeMemoryPages();
 
@@ -458,6 +455,7 @@ private:
 
   u16 ReadIFXImpl(u16 address);
 
+  std::atomic<u32> m_mailbox[2];
   DSPCore& m_dsp_core;
   Analyzer m_analyzer;
 };

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -213,25 +213,25 @@ u16 DSPLLE::DSP_ReadControlRegister()
 
 u16 DSPLLE::DSP_ReadMailBoxHigh(bool cpu_mailbox)
 {
-  return m_dsp_core.ReadMailboxHigh(cpu_mailbox ? MAILBOX_CPU : MAILBOX_DSP);
+  return m_dsp_core.ReadMailboxHigh(cpu_mailbox ? Mailbox::CPU : Mailbox::DSP);
 }
 
 u16 DSPLLE::DSP_ReadMailBoxLow(bool cpu_mailbox)
 {
-  return m_dsp_core.ReadMailboxLow(cpu_mailbox ? MAILBOX_CPU : MAILBOX_DSP);
+  return m_dsp_core.ReadMailboxLow(cpu_mailbox ? Mailbox::CPU : Mailbox::DSP);
 }
 
 void DSPLLE::DSP_WriteMailBoxHigh(bool cpu_mailbox, u16 value)
 {
   if (cpu_mailbox)
   {
-    if ((m_dsp_core.PeekMailbox(MAILBOX_CPU) & 0x80000000) != 0)
+    if ((m_dsp_core.PeekMailbox(Mailbox::CPU) & 0x80000000) != 0)
     {
       // the DSP didn't read the previous value
       WARN_LOG_FMT(DSPLLE, "Mailbox isn't empty ... strange");
     }
 
-    m_dsp_core.WriteMailboxHigh(MAILBOX_CPU, value);
+    m_dsp_core.WriteMailboxHigh(Mailbox::CPU, value);
   }
   else
   {
@@ -243,7 +243,7 @@ void DSPLLE::DSP_WriteMailBoxLow(bool cpu_mailbox, u16 value)
 {
   if (cpu_mailbox)
   {
-    m_dsp_core.WriteMailboxLow(MAILBOX_CPU, value);
+    m_dsp_core.WriteMailboxLow(Mailbox::CPU, value);
   }
   else
   {


### PR DESCRIPTION
Avoids implicit conversions and also prevents dumping identifiers into the current namespace.

While we're at it, we can make the mailbox members private, given they aren't accessed externally