### PR TITLE
Config: Fix cache not being invalidated when callbacks are suppressed

### DIFF
--- a/Source/Core/Common/Config/Config.cpp
+++ b/Source/Core/Common/Config/Config.cpp
@@ -71,10 +71,13 @@ void AddConfigChangedCallback(ConfigChangedCallback func)
 
 void OnConfigChanged()
 {
+  // Increment the config version to invalidate caches.
+  // To ensure that getters do not return stale data, this should always be done
+  // even when callbacks are suppressed.
+  s_config_version.fetch_add(1, std::memory_order_relaxed);
+
   if (s_callback_guards)
     return;
-
-  s_config_version.fetch_add(1, std::memory_order_relaxed);
 
   for (const auto& callback : s_callbacks)
     callback();


### PR DESCRIPTION
The config version should always be incremented whenever config is
changed, regardless of callbacks being suppressed or not.
Otherwise, getters can return stale data until another config change
(with callbacks enabled) happens.