### PR TITLE
DSPCore: Make several SDSP members private

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -120,7 +120,7 @@ SDSP::~SDSP() = default;
 bool SDSP::Initialize(const DSPInitOptions& opts)
 {
   step_counter = 0;
-  accelerator = std::make_unique<LLEAccelerator>(*this);
+  m_accelerator = std::make_unique<LLEAccelerator>(*this);
 
   irom = static_cast<u16*>(Common::AllocateMemoryPages(DSP_IROM_BYTE_SIZE));
   iram = static_cast<u16*>(Common::AllocateMemoryPages(DSP_IRAM_BYTE_SIZE));
@@ -386,7 +386,7 @@ void SDSP::DoState(PointerWrap& p)
 
   p.Do(step_counter);
   p.DoArray(ifx_regs);
-  accelerator->DoState(p);
+  m_accelerator->DoState(p);
   p.Do(m_mailbox[0]);
   p.Do(m_mailbox[1]);
   Common::UnWriteProtectMemory(iram, DSP_IRAM_BYTE_SIZE, false);

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -385,7 +385,7 @@ void SDSP::DoState(PointerWrap& p)
   }
 
   p.Do(step_counter);
-  p.DoArray(ifx_regs);
+  p.DoArray(m_ifx_regs);
   m_accelerator->DoState(p);
   p.Do(m_mailbox[0]);
   p.Do(m_mailbox[1]);

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -119,7 +119,7 @@ SDSP::~SDSP() = default;
 
 bool SDSP::Initialize(const DSPInitOptions& opts)
 {
-  step_counter = 0;
+  m_step_counter = 0;
   m_accelerator = std::make_unique<LLEAccelerator>(*this);
 
   irom = static_cast<u16*>(Common::AllocateMemoryPages(DSP_IROM_BYTE_SIZE));
@@ -384,7 +384,7 @@ void SDSP::DoState(PointerWrap& p)
     p.Do(stack);
   }
 
-  p.Do(step_counter);
+  p.Do(m_step_counter);
   p.DoArray(m_ifx_regs);
   m_accelerator->DoState(p);
   p.Do(m_mailbox[0]);

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -432,8 +432,6 @@ struct SDSP
   // Accelerator / DMA / other hardware registers. Not GPRs.
   std::array<u16, 256> ifx_regs{};
 
-  std::unique_ptr<Accelerator> accelerator;
-
   // When state saving, all of the above can just be memcpy'd into the save state.
   // The below needs special handling.
   u16* iram = nullptr;
@@ -455,6 +453,7 @@ private:
 
   u16 ReadIFXImpl(u16 address);
 
+  std::unique_ptr<Accelerator> m_accelerator;
   std::array<std::atomic<u32>, 2> m_mailbox;
   DSPCore& m_dsp_core;
   Analyzer m_analyzer;

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -429,9 +429,6 @@ struct SDSP
   u32 iram_crc = 0;
   u64 step_counter = 0;
 
-  // Accelerator / DMA / other hardware registers. Not GPRs.
-  std::array<u16, 256> ifx_regs{};
-
   // When state saving, all of the above can just be memcpy'd into the save state.
   // The below needs special handling.
   u16* iram = nullptr;
@@ -452,6 +449,9 @@ private:
   const u8* IDMAOut(u16 dsp_addr, u32 addr, u32 size);
 
   u16 ReadIFXImpl(u16 address);
+
+  // Accelerator / DMA / other hardware registers. Not GPRs.
+  std::array<u16, 256> m_ifx_regs{};
 
   std::unique_ptr<Accelerator> m_accelerator;
   std::array<std::atomic<u32>, 2> m_mailbox;

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -396,6 +396,12 @@ struct SDSP
   // Writes a value to a given register.
   void WriteRegister(size_t reg, u16 val);
 
+  // Advances the step counter used for debugging purposes.
+  void AdvanceStepCounter() { ++m_step_counter; }
+
+  // Sets the calculated IRAM CRC for debugging purposes.
+  void SetIRAMCRC(u32 crc) { m_iram_crc = crc; }
+
   // Saves and loads any necessary state.
   void DoState(PointerWrap& p);
 
@@ -425,10 +431,6 @@ struct SDSP
   // the stack overflows, you're screwed.
   u16 reg_stacks[4][DSP_STACK_DEPTH]{};
 
-  // For debugging.
-  u32 iram_crc = 0;
-  u64 step_counter = 0;
-
   // When state saving, all of the above can just be memcpy'd into the save state.
   // The below needs special handling.
   u16* iram = nullptr;
@@ -449,6 +451,10 @@ private:
   const u8* IDMAOut(u16 dsp_addr, u32 addr, u32 size);
 
   u16 ReadIFXImpl(u16 address);
+
+  // For debugging.
+  u32 m_iram_crc = 0;
+  u64 m_step_counter = 0;
 
   // Accelerator / DMA / other hardware registers. Not GPRs.
   std::array<u16, 256> m_ifx_regs{};

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -142,40 +142,42 @@ void SDSP::WriteIFX(u32 address, u16 value)
     break;
 
   case DSP_ACSAH:
-    accelerator->SetStartAddress(value << 16 | static_cast<u16>(accelerator->GetStartAddress()));
+    m_accelerator->SetStartAddress(value << 16 |
+                                   static_cast<u16>(m_accelerator->GetStartAddress()));
     break;
   case DSP_ACSAL:
-    accelerator->SetStartAddress(static_cast<u16>(accelerator->GetStartAddress() >> 16) << 16 |
-                                 value);
-    break;
-  case DSP_ACEAH:
-    accelerator->SetEndAddress(value << 16 | static_cast<u16>(accelerator->GetEndAddress()));
-    break;
-  case DSP_ACEAL:
-    accelerator->SetEndAddress(static_cast<u16>(accelerator->GetEndAddress() >> 16) << 16 | value);
-    break;
-  case DSP_ACCAH:
-    accelerator->SetCurrentAddress(value << 16 |
-                                   static_cast<u16>(accelerator->GetCurrentAddress()));
-    break;
-  case DSP_ACCAL:
-    accelerator->SetCurrentAddress(static_cast<u16>(accelerator->GetCurrentAddress() >> 16) << 16 |
+    m_accelerator->SetStartAddress(static_cast<u16>(m_accelerator->GetStartAddress() >> 16) << 16 |
                                    value);
     break;
+  case DSP_ACEAH:
+    m_accelerator->SetEndAddress(value << 16 | static_cast<u16>(m_accelerator->GetEndAddress()));
+    break;
+  case DSP_ACEAL:
+    m_accelerator->SetEndAddress(static_cast<u16>(m_accelerator->GetEndAddress() >> 16) << 16 |
+                                 value);
+    break;
+  case DSP_ACCAH:
+    m_accelerator->SetCurrentAddress(value << 16 |
+                                     static_cast<u16>(m_accelerator->GetCurrentAddress()));
+    break;
+  case DSP_ACCAL:
+    m_accelerator->SetCurrentAddress(
+        static_cast<u16>(m_accelerator->GetCurrentAddress() >> 16) << 16 | value);
+    break;
   case DSP_FORMAT:
-    accelerator->SetSampleFormat(value);
+    m_accelerator->SetSampleFormat(value);
     break;
   case DSP_YN1:
-    accelerator->SetYn1(value);
+    m_accelerator->SetYn1(value);
     break;
   case DSP_YN2:
-    accelerator->SetYn2(value);
+    m_accelerator->SetYn2(value);
     break;
   case DSP_PRED_SCALE:
-    accelerator->SetPredScale(value);
+    m_accelerator->SetPredScale(value);
     break;
   case DSP_ACDATA1:  // Accelerator write (Zelda type) - "UnkZelda"
-    accelerator->WriteD3(value);
+    m_accelerator->WriteD3(value);
     break;
 
   default:
@@ -222,29 +224,29 @@ u16 SDSP::ReadIFXImpl(u16 address)
     return ifx_regs[address & 0xFF];
 
   case DSP_ACSAH:
-    return static_cast<u16>(accelerator->GetStartAddress() >> 16);
+    return static_cast<u16>(m_accelerator->GetStartAddress() >> 16);
   case DSP_ACSAL:
-    return static_cast<u16>(accelerator->GetStartAddress());
+    return static_cast<u16>(m_accelerator->GetStartAddress());
   case DSP_ACEAH:
-    return static_cast<u16>(accelerator->GetEndAddress() >> 16);
+    return static_cast<u16>(m_accelerator->GetEndAddress() >> 16);
   case DSP_ACEAL:
-    return static_cast<u16>(accelerator->GetEndAddress());
+    return static_cast<u16>(m_accelerator->GetEndAddress());
   case DSP_ACCAH:
-    return static_cast<u16>(accelerator->GetCurrentAddress() >> 16);
+    return static_cast<u16>(m_accelerator->GetCurrentAddress() >> 16);
   case DSP_ACCAL:
-    return static_cast<u16>(accelerator->GetCurrentAddress());
+    return static_cast<u16>(m_accelerator->GetCurrentAddress());
   case DSP_FORMAT:
-    return accelerator->GetSampleFormat();
+    return m_accelerator->GetSampleFormat();
   case DSP_YN1:
-    return accelerator->GetYn1();
+    return m_accelerator->GetYn1();
   case DSP_YN2:
-    return accelerator->GetYn2();
+    return m_accelerator->GetYn2();
   case DSP_PRED_SCALE:
-    return accelerator->GetPredScale();
+    return m_accelerator->GetPredScale();
   case DSP_ACCELERATOR:  // ADPCM Accelerator reads
-    return accelerator->Read(reinterpret_cast<s16*>(&ifx_regs[DSP_COEF_A1_0]));
+    return m_accelerator->Read(reinterpret_cast<s16*>(&ifx_regs[DSP_COEF_A1_0]));
   case DSP_ACDATA1:  // Accelerator reads (Zelda type) - "UnkZelda"
-    return accelerator->ReadD3();
+    return m_accelerator->ReadD3();
 
   default:
   {

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -290,7 +290,7 @@ const u8* SDSP::IDMAIn(u16 dsp_addr, u32 addr, u32 size)
 
   Host::CodeLoaded(m_dsp_core, addr, size);
   NOTICE_LOG_FMT(DSPLLE, "*** Copy new UCode from {:#010x} to {:#06x} (crc: {:#08x})", addr,
-                 dsp_addr, iram_crc);
+                 dsp_addr, m_iram_crc);
 
   return reinterpret_cast<const u8*>(iram) + dsp_addr;
 }

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -49,7 +49,7 @@ void Interpreter::Step()
   auto& state = m_dsp_core.DSPState();
 
   m_dsp_core.CheckExceptions();
-  state.step_counter++;
+  state.AdvanceStepCounter();
 
   const u16 opc = state.FetchInstruction();
   ExecuteInstruction(UDSPInstruction{opc});

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -77,7 +77,7 @@ void CodeLoaded(DSPCore& dsp, const u8* ptr, size_t size)
 {
   auto& state = dsp.DSPState();
   const u32 iram_crc = Common::HashEctor(ptr, size);
-  state.iram_crc = iram_crc;
+  state.SetIRAMCRC(iram_crc);
 
   if (SConfig::GetInstance().m_DumpUCode)
   {


### PR DESCRIPTION
Makes all members that aren't used by the JIT private to reduce the number of freely modifiable members