### PR TITLE
Core: Make use of C++17 deduction guides with locks

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -116,7 +116,7 @@ void ApplyCodes(const std::vector<ARCode>& codes)
   if (!SConfig::GetInstance().bEnableCheats)
     return;
 
-  std::lock_guard<std::mutex> guard(s_lock);
+  std::lock_guard guard(s_lock);
   s_disable_logging = false;
   s_active_codes.clear();
   std::copy_if(codes.begin(), codes.end(), std::back_inserter(s_active_codes),
@@ -144,7 +144,7 @@ std::vector<ARCode> ApplyAndReturnCodes(const std::vector<ARCode>& codes)
 {
   if (SConfig::GetInstance().bEnableCheats)
   {
-    std::lock_guard<std::mutex> guard(s_lock);
+    std::lock_guard guard(s_lock);
     s_disable_logging = false;
     s_active_codes.clear();
     std::copy_if(codes.begin(), codes.end(), std::back_inserter(s_active_codes),
@@ -162,7 +162,7 @@ void AddCode(ARCode code)
 
   if (code.enabled)
   {
-    std::lock_guard<std::mutex> guard(s_lock);
+    std::lock_guard guard(s_lock);
     s_disable_logging = false;
     s_active_codes.emplace_back(std::move(code));
   }
@@ -335,13 +335,13 @@ void EnableSelfLogging(bool enable)
 
 std::vector<std::string> GetSelfLog()
 {
-  std::lock_guard<std::mutex> guard(s_lock);
+  std::lock_guard guard(s_lock);
   return s_internal_log;
 }
 
 void ClearSelfLog()
 {
-  std::lock_guard<std::mutex> guard(s_lock);
+  std::lock_guard guard(s_lock);
   s_internal_log.clear();
 }
 
@@ -979,7 +979,7 @@ void RunAllActive()
   // If the mutex is idle then acquiring it should be cheap, fast mutexes
   // are only atomic ops unless contested. It should be rare for this to
   // be contested.
-  std::lock_guard<std::mutex> guard(s_lock);
+  std::lock_guard guard(s_lock);
   s_active_codes.erase(std::remove_if(s_active_codes.begin(), s_active_codes.end(),
                                       [](const ARCode& code) {
                                         bool success = RunCodeLocked(code);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -1028,7 +1028,7 @@ void QueueHostJob(std::function<void()> job, bool run_during_stop)
 
   bool send_message = false;
   {
-    std::lock_guard<std::mutex> guard(s_host_jobs_lock);
+    std::lock_guard guard(s_host_jobs_lock);
     send_message = s_host_jobs_queue.empty();
     s_host_jobs_queue.emplace(HostJob{std::move(job), run_during_stop});
   }
@@ -1042,7 +1042,7 @@ void HostDispatchJobs()
   // WARNING: This should only run on the Host Thread.
   // NOTE: This function is potentially re-entrant. If a job calls
   //   Core::Stop for instance then we'll enter this a second time.
-  std::unique_lock<std::mutex> guard(s_host_jobs_lock);
+  std::unique_lock guard(s_host_jobs_lock);
   while (!s_host_jobs_queue.empty())
   {
     HostJob job = std::move(s_host_jobs_queue.front());

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -141,7 +141,7 @@ void Init()
 
 void Shutdown()
 {
-  std::lock_guard<std::mutex> lk(s_ts_write_lock);
+  std::lock_guard lk(s_ts_write_lock);
   MoveEvents();
   ClearPendingEvents();
   UnregisterAllEvents();
@@ -149,7 +149,7 @@ void Shutdown()
 
 void DoState(PointerWrap& p)
 {
-  std::lock_guard<std::mutex> lk(s_ts_write_lock);
+  std::lock_guard lk(s_ts_write_lock);
   p.Do(g.slice_length);
   p.Do(g.global_timer);
   p.Do(s_idled_cycles);
@@ -265,7 +265,7 @@ void ScheduleEvent(s64 cycles_into_future, EventType* event_type, u64 userdata, 
                     *event_type->name);
     }
 
-    std::lock_guard<std::mutex> lk(s_ts_write_lock);
+    std::lock_guard lk(s_ts_write_lock);
     s_ts_queue.Push(Event{g.global_timer + cycles_into_future, 0, userdata, event_type});
   }
 }

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -66,7 +66,7 @@ static std::mutex s_active_codes_lock;
 
 void SetActiveCodes(const std::vector<GeckoCode>& gcodes)
 {
-  std::lock_guard<std::mutex> lk(s_active_codes_lock);
+  std::lock_guard lk(s_active_codes_lock);
 
   s_active_codes.clear();
   if (SConfig::GetInstance().bEnableCheats)
@@ -98,7 +98,7 @@ void UpdateSyncedCodes(const std::vector<GeckoCode>& gcodes)
 
 std::vector<GeckoCode> SetAndReturnActiveCodes(const std::vector<GeckoCode>& gcodes)
 {
-  std::lock_guard<std::mutex> lk(s_active_codes_lock);
+  std::lock_guard lk(s_active_codes_lock);
 
   s_active_codes.clear();
   if (SConfig::GetInstance().bEnableCheats)
@@ -218,14 +218,14 @@ static Installation InstallCodeHandlerLocked()
 // modifications will be reset]
 void DoState(PointerWrap& p)
 {
-  std::lock_guard<std::mutex> codes_lock(s_active_codes_lock);
+  std::lock_guard codes_lock(s_active_codes_lock);
   p.Do(s_code_handler_installed);
   // FIXME: The active codes list will disagree with the embedded GCT
 }
 
 void Shutdown()
 {
-  std::lock_guard<std::mutex> codes_lock(s_active_codes_lock);
+  std::lock_guard codes_lock(s_active_codes_lock);
   s_active_codes.clear();
   s_code_handler_installed = Installation::Uninstalled;
 }
@@ -237,7 +237,7 @@ void RunCodeHandler()
 
   // NOTE: Need to release the lock because of GUI deadlocks with PanicAlert in HostWrite_*
   {
-    std::lock_guard<std::mutex> codes_lock(s_active_codes_lock);
+    std::lock_guard codes_lock(s_active_codes_lock);
     if (s_code_handler_installed != Installation::Installed)
     {
       // Don't spam retry if the install failed. The corrupt / missing disk file is not likely to be

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -76,7 +76,7 @@ void GeckoSockServer::GeckoConnectionWaiter()
   {
     if (server.accept(*new_client) == sf::Socket::Done)
     {
-      std::lock_guard<std::mutex> lk(connection_lock);
+      std::lock_guard lk(connection_lock);
       waiting_socks.push(std::move(new_client));
 
       new_client = std::make_unique<sf::TcpSocket>();
@@ -90,7 +90,7 @@ bool GeckoSockServer::GetAvailableSock()
 {
   bool sock_filled = false;
 
-  std::lock_guard<std::mutex> lk(connection_lock);
+  std::lock_guard lk(connection_lock);
 
   if (!waiting_socks.empty())
   {
@@ -125,7 +125,7 @@ void GeckoSockServer::ClientThread()
     bool did_nothing = true;
 
     {
-      std::lock_guard<std::mutex> lk(transfer_lock);
+      std::lock_guard lk(transfer_lock);
 
       // what's an ideal buffer size?
       std::array<char, 128> buffer;
@@ -186,7 +186,7 @@ void CEXIGecko::ImmReadWrite(u32& _uData, u32 _uSize)
   // |= 0x08000000 if successful
   case CMD_RECV:
   {
-    std::lock_guard<std::mutex> lk(transfer_lock);
+    std::lock_guard lk(transfer_lock);
     if (!recv_fifo.empty())
     {
       _uData = 0x08000000 | (recv_fifo.front() << 16);
@@ -199,7 +199,7 @@ void CEXIGecko::ImmReadWrite(u32& _uData, u32 _uSize)
   // |= 0x04000000 if successful
   case CMD_SEND:
   {
-    std::lock_guard<std::mutex> lk(transfer_lock);
+    std::lock_guard lk(transfer_lock);
     send_fifo.push_back(_uData >> 20);
     _uData = 0x04000000;
     break;
@@ -215,7 +215,7 @@ void CEXIGecko::ImmReadWrite(u32& _uData, u32 _uSize)
   // |= 0x04000000 if data in recv FIFO
   case CMD_CHK_RX:
   {
-    std::lock_guard<std::mutex> lk(transfer_lock);
+    std::lock_guard lk(transfer_lock);
     _uData = recv_fifo.empty() ? 0 : 0x04000000;
     break;
   }

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -45,7 +45,7 @@ long CEXIMic::DataCallback(cubeb_stream* stream, void* user_data, const void* in
 {
   CEXIMic* mic = static_cast<CEXIMic*>(user_data);
 
-  std::lock_guard<std::mutex> lk(mic->ring_lock);
+  std::lock_guard lk(mic->ring_lock);
 
   const s16* buff_in = static_cast<const s16*>(input_buffer);
   for (long i = 0; i < nframes; i++)
@@ -121,7 +121,7 @@ void CEXIMic::StreamStop()
 
 void CEXIMic::StreamReadOne()
 {
-  std::lock_guard<std::mutex> lk(ring_lock);
+  std::lock_guard lk(ring_lock);
 
   if (samples_avail >= buff_size_samples)
   {

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -328,7 +328,7 @@ s32 GCMemcardDirectory::Read(u32 src_address, s32 length, u8* dest_address)
 
 s32 GCMemcardDirectory::Write(u32 dest_address, s32 length, const u8* src_address)
 {
-  std::unique_lock<std::mutex> l(m_write_mutex);
+  std::unique_lock l(m_write_mutex);
   if (length != 0x80)
     INFO_LOG_FMT(EXPANSIONINTERFACE, "Writing to {:#x}. Length: {:#x}", dest_address, length);
   s32 block = dest_address / Memcard::BLOCK_SIZE;
@@ -593,7 +593,7 @@ bool GCMemcardDirectory::SetUsedBlocks(int save_index)
 
 void GCMemcardDirectory::FlushToFile()
 {
-  std::unique_lock<std::mutex> l(m_write_mutex);
+  std::unique_lock l(m_write_mutex);
   int errors = 0;
   Memcard::DEntry invalid;
   for (Memcard::GCIFile& save : m_saves)
@@ -686,7 +686,7 @@ void GCMemcardDirectory::FlushToFile()
 
 void GCMemcardDirectory::DoState(PointerWrap& p)
 {
-  std::unique_lock<std::mutex> l(m_write_mutex);
+  std::unique_lock l(m_write_mutex);
   m_last_block = -1;
   m_last_block_address = nullptr;
   p.Do(m_save_directory);

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardRaw.cpp
@@ -191,7 +191,7 @@ void MemoryCard::FlushThread()
     }
 
     {
-      std::unique_lock<std::mutex> l(m_flush_mutex);
+      std::unique_lock l(m_flush_mutex);
       memcpy(&m_flush_buffer[0], &m_memcard_data[0], m_memory_card_size);
     }
     file.WriteBytes(&m_flush_buffer[0], m_memory_card_size);
@@ -232,7 +232,7 @@ s32 MemoryCard::Write(u32 dest_address, s32 length, const u8* src_address)
   }
 
   {
-    std::unique_lock<std::mutex> l(m_flush_mutex);
+    std::unique_lock l(m_flush_mutex);
     memcpy(&m_memcard_data[dest_address], src_address, length);
   }
   MakeDirty();
@@ -248,7 +248,7 @@ void MemoryCard::ClearBlock(u32 address)
   }
   else
   {
-    std::unique_lock<std::mutex> l(m_flush_mutex);
+    std::unique_lock l(m_flush_mutex);
     memset(&m_memcard_data[address], 0xFF, Memcard::BLOCK_SIZE);
   }
   MakeDirty();
@@ -257,7 +257,7 @@ void MemoryCard::ClearBlock(u32 address)
 void MemoryCard::ClearAll()
 {
   {
-    std::unique_lock<std::mutex> l(m_flush_mutex);
+    std::unique_lock l(m_flush_mutex);
     memset(&m_memcard_data[0], 0xFF, m_memory_card_size);
   }
   MakeDirty();

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -106,14 +106,14 @@ static void GBAConnectionWaiter()
   {
     if (server.accept(*new_client) == sf::Socket::Done)
     {
-      std::lock_guard<std::mutex> lk(s_cs_gba);
+      std::lock_guard lk(s_cs_gba);
       s_waiting_socks.push(std::move(new_client));
 
       new_client = std::make_unique<sf::TcpSocket>();
     }
     if (clock_server.accept(*new_client) == sf::Socket::Done)
     {
-      std::lock_guard<std::mutex> lk(s_cs_gba_clk);
+      std::lock_guard lk(s_cs_gba_clk);
       s_waiting_clocks.push(std::move(new_client));
 
       new_client = std::make_unique<sf::TcpSocket>();
@@ -142,13 +142,13 @@ static std::unique_ptr<T> MoveFromFront(std::queue<std::unique_ptr<T>>& ptrs)
 
 static std::unique_ptr<sf::TcpSocket> GetNextSock()
 {
-  std::lock_guard<std::mutex> lk(s_cs_gba);
+  std::lock_guard lk(s_cs_gba);
   return MoveFromFront(s_waiting_socks);
 }
 
 static std::unique_ptr<sf::TcpSocket> GetNextClock()
 {
-  std::lock_guard<std::mutex> lk(s_cs_gba_clk);
+  std::lock_guard lk(s_cs_gba_clk);
   return MoveFromFront(s_waiting_clocks);
 }
 

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -179,7 +179,7 @@ void ThrottleCallback(u64 last_time, s64 cyclesLate)
   u32 next_event = GetTicksPerSecond() / 1000;
 
   {
-    std::lock_guard<std::mutex> lk(s_emu_to_real_time_mutex);
+    std::lock_guard lk(s_emu_to_real_time_mutex);
     s_emu_to_real_time_ring_buffer[s_emu_to_real_time_index] = time - s_time_spent_sleeping;
     s_emu_to_real_time_index =
         (s_emu_to_real_time_index + 1) % s_emu_to_real_time_ring_buffer.size();
@@ -252,7 +252,7 @@ double GetEstimatedEmulationPerformance()
 {
   u64 ts_now, ts_before;  // In microseconds
   {
-    std::lock_guard<std::mutex> lk(s_emu_to_real_time_mutex);
+    std::lock_guard lk(s_emu_to_real_time_mutex);
     size_t index_now = s_emu_to_real_time_index == 0 ? s_emu_to_real_time_ring_buffer.size() - 1 :
                                                        s_emu_to_real_time_index - 1;
     size_t index_before = s_emu_to_real_time_index;

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -140,7 +140,7 @@ Wiimote::Wiimote() = default;
 
 void Wiimote::Shutdown()
 {
-  std::lock_guard<std::mutex> lk(s_known_ids_mutex);
+  std::lock_guard lk(s_known_ids_mutex);
   s_known_ids.erase(GetId());
 
   StopThread();
@@ -550,7 +550,7 @@ void WiimoteScanner::SetScanMode(WiimoteScanMode scan_mode)
 
 bool WiimoteScanner::IsReady() const
 {
-  std::lock_guard<std::mutex> lg(m_backends_mutex);
+  std::lock_guard lg(m_backends_mutex);
   return std::any_of(m_backends.begin(), m_backends.end(),
                      [](const auto& backend) { return backend->IsReady(); });
 }
@@ -623,7 +623,7 @@ void WiimoteScanner::ThreadFunc()
   // are called on different threads (and so reference different CFRunLoops) which can cause an
   // EXC_BAD_ACCES crash.
   {
-    std::lock_guard<std::mutex> lg(m_backends_mutex);
+    std::lock_guard lg(m_backends_mutex);
 
     m_backends.emplace_back(std::make_unique<WiimoteScannerLinux>());
     m_backends.emplace_back(std::make_unique<WiimoteScannerAndroid>());
@@ -670,7 +670,7 @@ void WiimoteScanner::ThreadFunc()
         for (auto* wiimote : found_wiimotes)
         {
           {
-            std::lock_guard<std::mutex> lk(s_known_ids_mutex);
+            std::lock_guard lk(s_known_ids_mutex);
             s_known_ids.insert(wiimote->GetId());
           }
 
@@ -681,7 +681,7 @@ void WiimoteScanner::ThreadFunc()
         if (found_board)
         {
           {
-            std::lock_guard<std::mutex> lk(s_known_ids_mutex);
+            std::lock_guard lk(s_known_ids_mutex);
             s_known_ids.insert(found_board->GetId());
           }
 
@@ -696,7 +696,7 @@ void WiimoteScanner::ThreadFunc()
   }
 
   {
-    std::lock_guard<std::mutex> lg(m_backends_mutex);
+    std::lock_guard lg(m_backends_mutex);
     m_backends.clear();
   }
 
@@ -942,7 +942,7 @@ bool IsBalanceBoardName(const std::string& name)
 // This is called from the scanner backends (currently on the scanner thread).
 bool IsNewWiimote(const std::string& identifier)
 {
-  std::lock_guard<std::mutex> lk(s_known_ids_mutex);
+  std::lock_guard lk(s_known_ids_mutex);
   return s_known_ids.count(identifier) == 0;
 }
 

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -235,7 +235,7 @@ Kernel::Kernel()
 Kernel::~Kernel()
 {
   {
-    std::lock_guard<std::mutex> lock(m_device_map_mutex);
+    std::lock_guard lock(m_device_map_mutex);
     m_device_map.clear();
   }
 
@@ -417,7 +417,7 @@ void Kernel::AddCoreDevices()
   m_fs = FS::MakeFileSystem();
   ASSERT(m_fs);
 
-  std::lock_guard<std::mutex> lock(m_device_map_mutex);
+  std::lock_guard lock(m_device_map_mutex);
   AddDevice(std::make_unique<Device::FS>(*this, "/dev/fs"));
   AddDevice(std::make_unique<Device::ES>(*this, "/dev/es"));
   AddDevice(std::make_unique<Device::DolphinDevice>(*this, "/dev/dolphin"));
@@ -425,7 +425,7 @@ void Kernel::AddCoreDevices()
 
 void Kernel::AddStaticDevices()
 {
-  std::lock_guard<std::mutex> lock(m_device_map_mutex);
+  std::lock_guard lock(m_device_map_mutex);
 
   const Feature features = GetFeatures(GetVersion());
 
@@ -507,7 +507,7 @@ s32 Kernel::GetFreeDeviceID()
 
 std::shared_ptr<Device::Device> Kernel::GetDeviceByName(const std::string& device_name)
 {
-  std::lock_guard<std::mutex> lock(m_device_map_mutex);
+  std::lock_guard lock(m_device_map_mutex);
   const auto iterator = m_device_map.find(device_name);
   return iterator != m_device_map.end() ? iterator->second : nullptr;
 }

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -167,7 +167,7 @@ IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
   // HCI commands to the Bluetooth adapter
   case USB::IOCTLV_USBV0_CTRLMSG:
   {
-    std::lock_guard<std::mutex> lk(m_transfers_mutex);
+    std::lock_guard lk(m_transfers_mutex);
     auto cmd = std::make_unique<USB::V0CtrlMessage>(m_ios, request);
     const u16 opcode = Common::swap16(Memory::Read_U16(cmd->data_address));
     if (opcode == HCI_CMD_READ_BUFFER_SIZE)
@@ -210,7 +210,7 @@ IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
   case USB::IOCTLV_USBV0_BLKMSG:
   case USB::IOCTLV_USBV0_INTRMSG:
   {
-    std::lock_guard<std::mutex> lk(m_transfers_mutex);
+    std::lock_guard lk(m_transfers_mutex);
     auto cmd = std::make_unique<USB::V0IntrMessage>(m_ios, request);
     if (request.request == USB::IOCTLV_USBV0_INTRMSG)
     {
@@ -594,7 +594,7 @@ bool BluetoothReal::OpenDevice(libusb_device* device)
 // The callbacks are called from libusb code on a separate thread.
 void BluetoothReal::HandleCtrlTransfer(libusb_transfer* tr)
 {
-  std::lock_guard<std::mutex> lk(m_transfers_mutex);
+  std::lock_guard lk(m_transfers_mutex);
   if (!m_current_transfers.count(tr))
     return;
 
@@ -620,7 +620,7 @@ void BluetoothReal::HandleCtrlTransfer(libusb_transfer* tr)
 
 void BluetoothReal::HandleBulkOrIntrTransfer(libusb_transfer* tr)
 {
-  std::lock_guard<std::mutex> lk(m_transfers_mutex);
+  std::lock_guard lk(m_transfers_mutex);
   if (!m_current_transfers.count(tr))
     return;
 

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -66,7 +66,7 @@ void USBHost::DoState(PointerWrap& p)
 
 bool USBHost::AddDevice(std::unique_ptr<USB::Device> device)
 {
-  std::lock_guard<std::mutex> lk(m_devices_mutex);
+  std::lock_guard lk(m_devices_mutex);
   if (m_devices.find(device->GetId()) != m_devices.end())
     return false;
 
@@ -76,7 +76,7 @@ bool USBHost::AddDevice(std::unique_ptr<USB::Device> device)
 
 std::shared_ptr<USB::Device> USBHost::GetDeviceById(const u64 device_id) const
 {
-  std::lock_guard<std::mutex> lk(m_devices_mutex);
+  std::lock_guard lk(m_devices_mutex);
   const auto it = m_devices.find(device_id);
   if (it == m_devices.end())
     return nullptr;
@@ -145,7 +145,7 @@ bool USBHost::AddNewDevices(std::set<u64>& new_devices, DeviceChangeHooks& hooks
 
 void USBHost::DetectRemovedDevices(const std::set<u64>& plugged_devices, DeviceChangeHooks& hooks)
 {
-  std::lock_guard<std::mutex> lk(m_devices_mutex);
+  std::lock_guard lk(m_devices_mutex);
   for (auto it = m_devices.begin(); it != m_devices.end();)
   {
     if (plugged_devices.find(it->second->GetId()) == plugged_devices.end())

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -351,14 +351,14 @@ static const std::map<u8, const char*> s_transfer_types = {
 void LibusbDevice::TransferEndpoint::AddTransfer(std::unique_ptr<TransferCommand> command,
                                                  libusb_transfer* transfer)
 {
-  std::lock_guard<std::mutex> lk{m_transfers_mutex};
+  std::lock_guard lk{m_transfers_mutex};
   m_transfers.emplace(transfer, std::move(command));
 }
 
 void LibusbDevice::TransferEndpoint::HandleTransfer(libusb_transfer* transfer,
                                                     std::function<s32(const TransferCommand&)> fn)
 {
-  std::lock_guard<std::mutex> lk{m_transfers_mutex};
+  std::lock_guard lk{m_transfers_mutex};
   const auto iterator = m_transfers.find(transfer);
   if (iterator == m_transfers.cend())
   {
@@ -396,7 +396,7 @@ void LibusbDevice::TransferEndpoint::HandleTransfer(libusb_transfer* transfer,
 
 void LibusbDevice::TransferEndpoint::CancelTransfers()
 {
-  std::lock_guard<std::mutex> lk(m_transfers_mutex);
+  std::lock_guard lk(m_transfers_mutex);
   if (m_transfers.empty())
     return;
   INFO_LOG_FMT(IOS_USB, "Cancelling {} transfer(s)", m_transfers.size());

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -111,7 +111,7 @@ IPCCommandResult OH0::GetDeviceList(const IOCtlVRequest& request) const
 
   const u8 interface_class = Memory::Read_U8(request.in_vectors[1].address);
   u8 entries_count = 0;
-  std::lock_guard<std::mutex> lk(m_devices_mutex);
+  std::lock_guard lk(m_devices_mutex);
   for (const auto& device : m_devices)
   {
     if (entries_count >= max_entries_count)
@@ -162,7 +162,7 @@ IPCCommandResult OH0::SetRhPortStatus(const IOCtlVRequest& request)
 
 IPCCommandResult OH0::RegisterRemovalHook(const u64 device_id, const IOCtlRequest& request)
 {
-  std::lock_guard<std::mutex> lock{m_hooks_mutex};
+  std::lock_guard lock{m_hooks_mutex};
   // IOS only allows a single device removal hook.
   if (m_removal_hooks.find(device_id) != m_removal_hooks.end())
     return GetDefaultReply(IPC_EEXIST);
@@ -180,7 +180,7 @@ IPCCommandResult OH0::RegisterInsertionHook(const IOCtlVRequest& request)
   if (HasDeviceWithVidPid(vid, pid))
     return GetDefaultReply(IPC_SUCCESS);
 
-  std::lock_guard<std::mutex> lock{m_hooks_mutex};
+  std::lock_guard lock{m_hooks_mutex};
   // TODO: figure out whether IOS allows more than one hook.
   m_insertion_hooks[{vid, pid}] = request.address;
   return GetNoReply();
@@ -191,7 +191,7 @@ IPCCommandResult OH0::RegisterInsertionHookWithID(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(3, 1))
     return GetDefaultReply(IPC_EINVAL);
 
-  std::lock_guard<std::mutex> lock{m_hooks_mutex};
+  std::lock_guard lock{m_hooks_mutex};
   const u16 vid = Memory::Read_U16(request.in_vectors[0].address);
   const u16 pid = Memory::Read_U16(request.in_vectors[1].address);
   const bool trigger_only_for_new_device = Memory::Read_U8(request.in_vectors[2].address) == 1;
@@ -222,7 +222,7 @@ bool OH0::HasDeviceWithVidPid(const u16 vid, const u16 pid) const
 
 void OH0::OnDeviceChange(const ChangeEvent event, std::shared_ptr<USB::Device> device)
 {
-  std::lock_guard<std::mutex> lk(m_devices_mutex);
+  std::lock_guard lk(m_devices_mutex);
   if (event == ChangeEvent::Inserted)
     TriggerHook(m_insertion_hooks, {device->GetVid(), device->GetPid()}, IPC_SUCCESS);
   else if (event == ChangeEvent::Removed)
@@ -232,7 +232,7 @@ void OH0::OnDeviceChange(const ChangeEvent event, std::shared_ptr<USB::Device> d
 template <typename T>
 void OH0::TriggerHook(std::map<T, u32>& hooks, T value, const ReturnCode return_value)
 {
-  std::lock_guard<std::mutex> lk{m_hooks_mutex};
+  std::lock_guard lk{m_hooks_mutex};
   const auto hook = hooks.find(value);
   if (hook == hooks.end())
     return;
@@ -242,7 +242,7 @@ void OH0::TriggerHook(std::map<T, u32>& hooks, T value, const ReturnCode return_
 
 std::pair<ReturnCode, u64> OH0::DeviceOpen(const u16 vid, const u16 pid)
 {
-  std::lock_guard<std::mutex> lk(m_devices_mutex);
+  std::lock_guard lk(m_devices_mutex);
 
   bool has_device_with_vid_pid = false;
   for (const auto& device : m_devices)

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -80,7 +80,7 @@ IPCCommandResult USB_HIDv4::CancelInterrupt(const IOCtlRequest& request)
 
 IPCCommandResult USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
 {
-  std::lock_guard<std::mutex> lk{m_devicechange_hook_address_mutex};
+  std::lock_guard lk{m_devicechange_hook_address_mutex};
   if (request.buffer_out == 0 || request.buffer_out_size != 0x600)
     return GetDefaultReply(IPC_EINVAL);
 
@@ -96,7 +96,7 @@ IPCCommandResult USB_HIDv4::GetDeviceChange(const IOCtlRequest& request)
 
 IPCCommandResult USB_HIDv4::Shutdown(const IOCtlRequest& request)
 {
-  std::lock_guard<std::mutex> lk{m_devicechange_hook_address_mutex};
+  std::lock_guard lk{m_devicechange_hook_address_mutex};
   if (m_devicechange_hook_request != 0)
   {
     Memory::Write_U32(0xffffffff, m_devicechange_hook_request->buffer_out);
@@ -140,7 +140,7 @@ void USB_HIDv4::DoState(PointerWrap& p)
 
 std::shared_ptr<USB::Device> USB_HIDv4::GetDeviceByIOSID(const s32 ios_id) const
 {
-  std::lock_guard<std::mutex> lk{m_id_map_mutex};
+  std::lock_guard lk{m_id_map_mutex};
   const auto iterator = m_ios_ids.find(ios_id);
   if (iterator == m_ios_ids.cend())
     return nullptr;
@@ -150,7 +150,7 @@ std::shared_ptr<USB::Device> USB_HIDv4::GetDeviceByIOSID(const s32 ios_id) const
 void USB_HIDv4::OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> device)
 {
   {
-    std::lock_guard<std::mutex> id_map_lock{m_id_map_mutex};
+    std::lock_guard id_map_lock{m_id_map_mutex};
     if (event == ChangeEvent::Inserted)
     {
       s32 new_id = 0;
@@ -168,7 +168,7 @@ void USB_HIDv4::OnDeviceChange(ChangeEvent event, std::shared_ptr<USB::Device> d
   }
 
   {
-    std::lock_guard<std::mutex> lk{m_devicechange_hook_address_mutex};
+    std::lock_guard lk{m_devicechange_hook_address_mutex};
     TriggerDeviceChangeReply();
   }
 }
@@ -184,7 +184,7 @@ void USB_HIDv4::TriggerDeviceChangeReply()
     return;
 
   {
-    std::lock_guard<std::mutex> lk(m_devices_mutex);
+    std::lock_guard lk(m_devices_mutex);
     const u32 dest = m_devicechange_hook_request->buffer_out;
     u32 offset = 0;
     for (const auto& device : m_devices)
@@ -242,7 +242,7 @@ static std::vector<u8> GetDescriptors(const USB::Device& device)
 
 std::vector<u8> USB_HIDv4::GetDeviceEntry(const USB::Device& device) const
 {
-  std::lock_guard<std::mutex> id_map_lock{m_id_map_mutex};
+  std::lock_guard id_map_lock{m_id_map_mutex};
 
   // The structure for a device section is as follows:
   //   0-4 bytes: total size of the device data, including the size and the device ID

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -65,7 +65,7 @@ IPCCommandResult USB_HIDv5::IOCtlV(const IOCtlVRequest& request)
     if (request.in_vectors.size() + request.io_vectors.size() != 2)
       return GetDefaultReply(IPC_EINVAL);
 
-    std::lock_guard<std::mutex> lock{m_usbv5_devices_mutex};
+    std::lock_guard lock{m_usbv5_devices_mutex};
     USBV5Device* device = GetUSBV5Device(request.in_vectors[0].address);
     if (!device)
       return GetDefaultReply(IPC_EINVAL);

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -74,7 +74,7 @@ IPCCommandResult USB_VEN::IOCtlV(const IOCtlVRequest& request)
     if (request.in_vectors.size() + request.io_vectors.size() != s_num_vectors.at(request.request))
       return GetDefaultReply(IPC_EINVAL);
 
-    std::lock_guard<std::mutex> lock{m_usbv5_devices_mutex};
+    std::lock_guard lock{m_usbv5_devices_mutex};
     USBV5Device* device = GetUSBV5Device(request.in_vectors[0].address);
     if (!device)
       return GetDefaultReply(IPC_EINVAL);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -169,7 +169,7 @@ std::string GetInputDisplay()
 
   std::string input_display;
   {
-    std::lock_guard<std::mutex> guard(s_input_display_lock);
+    std::lock_guard guard(s_input_display_lock);
     for (int i = 0; i < 8; ++i)
     {
       if ((s_controllers & (1 << i)) != 0)
@@ -634,7 +634,7 @@ static void SetInputDisplayString(ControllerState padState, int controllerID)
     display_str += " DISCONNECTED";
   }
 
-  std::lock_guard<std::mutex> guard(s_input_display_lock);
+  std::lock_guard guard(s_input_display_lock);
   s_InputDisplay[controllerID] = std::move(display_str);
 }
 
@@ -765,7 +765,7 @@ static void SetWiiInputDisplayString(int remoteID, const DataReportBuilder& rpt,
     display_str += Analog2DToString(right_stick.x, right_stick.y, " R-ANA", 31);
   }
 
-  std::lock_guard<std::mutex> guard(s_input_display_lock);
+  std::lock_guard guard(s_input_display_lock);
   s_InputDisplay[controllerID] = std::move(display_str);
 }
 

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2290,7 +2290,7 @@ bool NetPlayClient::IsLocalPlayer(const PlayerId pid) const
 
 void NetPlayClient::SendTimeBase()
 {
-  std::lock_guard<std::mutex> lk(crit_netplay_client);
+  std::lock_guard lk(crit_netplay_client);
 
   if (netplay_client->m_timebase_frame % 60 == 0)
   {
@@ -2430,7 +2430,7 @@ void SendPowerButtonEvent()
 
 bool IsSyncingAllWiiSaves()
 {
-  std::lock_guard<std::mutex> lk(crit_netplay_client);
+  std::lock_guard lk(crit_netplay_client);
 
   if (netplay_client)
     return netplay_client->GetNetSettings().m_SyncAllWiiSaves;
@@ -2457,13 +2457,13 @@ void SetupWiimotes()
 
 void NetPlay_Enable(NetPlayClient* const np)
 {
-  std::lock_guard<std::mutex> lk(crit_netplay_client);
+  std::lock_guard lk(crit_netplay_client);
   netplay_client = np;
 }
 
 void NetPlay_Disable()
 {
-  std::lock_guard<std::mutex> lk(crit_netplay_client);
+  std::lock_guard lk(crit_netplay_client);
   netplay_client = nullptr;
 }
 }  // namespace NetPlay
@@ -2474,7 +2474,7 @@ void NetPlay_Disable()
 // Actual Core function which is called on every frame
 bool SerialInterface::CSIDevice_GCController::NetPlay_GetInput(int pad_num, GCPadStatus* status)
 {
-  std::lock_guard<std::mutex> lk(NetPlay::crit_netplay_client);
+  std::lock_guard lk(NetPlay::crit_netplay_client);
 
   if (NetPlay::netplay_client)
     return NetPlay::netplay_client->GetNetPads(pad_num, NetPlay::s_si_poll_batching, status);
@@ -2484,7 +2484,7 @@ bool SerialInterface::CSIDevice_GCController::NetPlay_GetInput(int pad_num, GCPa
 
 bool WiimoteEmu::Wiimote::NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size, u8 reporting_mode)
 {
-  std::lock_guard<std::mutex> lk(NetPlay::crit_netplay_client);
+  std::lock_guard lk(NetPlay::crit_netplay_client);
 
   if (NetPlay::netplay_client)
     return NetPlay::netplay_client->WiimoteUpdate(wiimote, data, size, reporting_mode);
@@ -2495,7 +2495,7 @@ bool WiimoteEmu::Wiimote::NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size,
 // Sync the info whether a button was pressed or not. Used for the reconnect on button press feature
 bool Wiimote::NetPlay_GetButtonPress(int wiimote, bool pressed)
 {
-  std::lock_guard<std::mutex> lk(NetPlay::crit_netplay_client);
+  std::lock_guard lk(NetPlay::crit_netplay_client);
 
   // Use the reporting mode 0 for the button pressed event, the real ones start at RT_REPORT_CORE
   static const u8 BUTTON_PRESS_REPORTING_MODE = 0;
@@ -2521,7 +2521,7 @@ bool Wiimote::NetPlay_GetButtonPress(int wiimote, bool pressed)
 // also called from ---GUI--- thread when starting input recording
 u64 ExpansionInterface::CEXIIPL::NetPlay_GetEmulatedTime()
 {
-  std::lock_guard<std::mutex> lk(NetPlay::crit_netplay_client);
+  std::lock_guard lk(NetPlay::crit_netplay_client);
 
   if (NetPlay::netplay_client)
     return NetPlay::netplay_client->GetInitialRTCValue();
@@ -2533,7 +2533,7 @@ u64 ExpansionInterface::CEXIIPL::NetPlay_GetEmulatedTime()
 // return the local pad num that should rumble given a ingame pad num
 int SerialInterface::CSIDevice_GCController::NetPlay_InGamePadToLocalPad(int numPAD)
 {
-  std::lock_guard<std::mutex> lk(NetPlay::crit_netplay_client);
+  std::lock_guard lk(NetPlay::crit_netplay_client);
 
   if (NetPlay::netplay_client)
     return NetPlay::netplay_client->InGamePadToLocalPad(numPAD);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -307,7 +307,7 @@ struct CompressAndDumpState_args
 
 static void CompressAndDumpState(CompressAndDumpState_args save_args)
 {
-  std::lock_guard<std::mutex> lk(*save_args.buffer_mutex);
+  std::lock_guard lk(*save_args.buffer_mutex);
 
   // ScopeGuard is used here to ensure that g_compressAndDumpStateSyncEvent.Set()
   // will be called and that it will happen after the IOFile is closed.
@@ -419,7 +419,7 @@ void SaveAs(const std::string& filename, bool wait)
 
         // Then actually do the write.
         {
-          std::lock_guard<std::mutex> lk(g_cs_current_buffer);
+          std::lock_guard lk(g_cs_current_buffer);
           g_current_buffer.resize(buffer_size);
           ptr = &g_current_buffer[0];
           p.SetMode(PointerWrap::MODE_WRITE);
@@ -576,7 +576,7 @@ void LoadAs(const std::string& filename)
         // Save temp buffer for undo load state
         if (!Movie::IsJustStartingRecordingInputFromSaveState())
         {
-          std::lock_guard<std::mutex> lk(g_cs_undo_load_buffer);
+          std::lock_guard lk(g_cs_undo_load_buffer);
           SaveToBuffer(g_undo_load_buffer);
           if (Movie::IsMovieActive())
             Movie::SaveRecording(File::GetUserPath(D_STATESAVES_IDX) + "undo.dtm");
@@ -649,12 +649,12 @@ void Shutdown()
   // this gives a better guarantee to free the allocated memory right NOW (as opposed to, actually,
   // never)
   {
-    std::lock_guard<std::mutex> lk(g_cs_current_buffer);
+    std::lock_guard lk(g_cs_current_buffer);
     std::vector<u8>().swap(g_current_buffer);
   }
 
   {
-    std::lock_guard<std::mutex> lk(g_cs_undo_load_buffer);
+    std::lock_guard lk(g_cs_undo_load_buffer);
     std::vector<u8>().swap(g_undo_load_buffer);
   }
 }
@@ -716,7 +716,7 @@ void Flush()
 // Load the last state before loading the state
 void UndoLoadState()
 {
-  std::lock_guard<std::mutex> lk(g_cs_undo_load_buffer);
+  std::lock_guard lk(g_cs_undo_load_buffer);
   if (!g_undo_load_buffer.empty())
   {
     if (File::Exists(File::GetUserPath(D_STATESAVES_IDX) + "undo.dtm") || (!Movie::IsMovieActive()))


### PR DESCRIPTION
C++17 allows omitting the mutex type, which makes for both less reading and more flexibility (e.g. The mutex type can change and all occurrences don't need to be updated).