### PR TITLE
INI Changes

### DIFF
--- a/Data/Sys/GameSettings/G6W.ini
+++ b/Data/Sys/GameSettings/G6W.ini
@@ -13,4 +13,5 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/GEZ.ini
+++ b/Data/Sys/GameSettings/GEZ.ini
@@ -1,4 +1,4 @@
-# GEZE8P, GEZP8P - BillyHatcher
+# GEZE8P, GEZP8P - Billy Hatcher and the Giant Egg
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -13,5 +13,5 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
-
+# Fixes game text and dark puddles in final level and boss.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/R6X.ini
+++ b/Data/Sys/GameSettings/R6X.ini
@@ -1,0 +1,5 @@
+# R6XP69, R6XE69 - Hasbro Family Game Night 2
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False

--- a/Data/Sys/GameSettings/R8I.ini
+++ b/Data/Sys/GameSettings/R8I.ini
@@ -1,0 +1,5 @@
+# R8IS78, R8IP78, R8IE78 - SpongeBob's Truth or Square
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/R8R.ini
+++ b/Data/Sys/GameSettings/R8R.ini
@@ -1,0 +1,5 @@
+# R8RP41 - Arthur and the Revenge of Maltazard
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RB5.ini
+++ b/Data/Sys/GameSettings/RB5.ini
@@ -1,0 +1,5 @@
+# RB5E41, RB5P41 - Brothers In Arms: Earned In Blood
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RBH.ini
+++ b/Data/Sys/GameSettings/RBH.ini
@@ -13,7 +13,8 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
+# Fixes invisible objects.
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2
 
 [Video_Hacks]

--- a/Data/Sys/GameSettings/RDL.ini
+++ b/Data/Sys/GameSettings/RDL.ini
@@ -1,4 +1,6 @@
 # RDLE5G, RDLP70 - Spy Fox in Dry Cereal
 
 [Video_Settings]
+# Fixes cutscene animation.
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RGB.ini
+++ b/Data/Sys/GameSettings/RGB.ini
@@ -13,4 +13,6 @@
 # Add action replay cheats here.
 
 [Video_Settings]
+# Fixes animation.
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RI8.ini
+++ b/Data/Sys/GameSettings/RI8.ini
@@ -1,0 +1,5 @@
+# RI8P41, RI8E41 - Brothers In Arms: Road To Hill 30
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RNC.ini
+++ b/Data/Sys/GameSettings/RNC.ini
@@ -1,4 +1,8 @@
 # RNCEH4, RNCPH4 - SNK Arcade Classics Volume 1
 
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = 0
+
 [Video_Settings]
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/ROA.ini
+++ b/Data/Sys/GameSettings/ROA.ini
@@ -13,5 +13,5 @@
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
-
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/RSJ.ini
+++ b/Data/Sys/GameSettings/RSJ.ini
@@ -1,4 +1,6 @@
 # RSJE41, RSJP41 - Broken Sword: Shadow of the Templars (Director's Cut)
 
 [Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/RT4.ini
+++ b/Data/Sys/GameSettings/RT4.ini
@@ -12,6 +12,9 @@
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+# Fixes skit animations.
+SafeTextureCacheColorSamples = 512
+
 [Video_Hacks]
 EFBEmulateFormatChanges = True
-

--- a/Data/Sys/GameSettings/S3X.ini
+++ b/Data/Sys/GameSettings/S3X.ini
@@ -1,0 +1,5 @@
+# S3XP78, S3XE78 - WWE'13
+
+[Video_Settings]
+# Fixes Create a Superstar invisible items.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SAH.ini
+++ b/Data/Sys/GameSettings/SAH.ini
@@ -1,0 +1,5 @@
+# SAHE69 - Hasbro Family Game Night: Fun Pack
+
+[Core]
+# Values set here will override the main Dolphin settings.
+CPUThread = False

--- a/Data/Sys/GameSettings/SAQ.ini
+++ b/Data/Sys/GameSettings/SAQ.ini
@@ -1,0 +1,5 @@
+# SAQE5G - Harley Pasternak's Hollywood Workout
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples - 0

--- a/Data/Sys/GameSettings/SAQ.ini
+++ b/Data/Sys/GameSettings/SAQ.ini
@@ -2,4 +2,4 @@
 
 [Video_Settings]
 # Fixes game text.
-SafeTextureCacheColorSamples - 0
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SJ7.ini
+++ b/Data/Sys/GameSettings/SJ7.ini
@@ -1,0 +1,5 @@
+# SJ7E41, SJ7P41 - Just Dance Kids 2014
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SJC.ini
+++ b/Data/Sys/GameSettings/SJC.ini
@@ -1,4 +1,6 @@
 # SJCEZW - Jerry Rice & Nitus' Dog Football
 
 [Video_Settings]
+# Display menu correctly.
+SafeTextureCacheColorSamples = 0
 SuggestedAspectRatio = 2

--- a/Data/Sys/GameSettings/SJZ.ini
+++ b/Data/Sys/GameSettings/SJZ.ini
@@ -1,0 +1,5 @@
+# SJZE41 - Just Dance Kids 2
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SKZ.ini
+++ b/Data/Sys/GameSettings/SKZ.ini
@@ -1,0 +1,5 @@
+# SKZP52, SKZE52 - DreamWorks Super Star Kartz
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SSD.ini
+++ b/Data/Sys/GameSettings/SSD.ini
@@ -1,0 +1,5 @@
+# SSDSRV - Schlag den Raab
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/STR.ini
+++ b/Data/Sys/GameSettings/STR.ini
@@ -1,0 +1,5 @@
+# STRE4Q, STRP4Q, STRX4Q - Tron: Evolution - Battle Grids
+
+[Video_Settings]
+# Fixes game text.
+SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SW6.ini
+++ b/Data/Sys/GameSettings/SW6.ini
@@ -1,0 +1,5 @@
+# SW6P78, SW6E78 - WWE'12
+
+[Video_Settings]
+# Fixes Create a Superstar invisible items.
+SafeTextureCacheColorSamples = 0


### PR DESCRIPTION
This PR deals with more Texture Cache Accuracy cases, and some Dualcore ones too. Might add a commit with bounding box fixes for demo discs, but I've only been able to test US versions, not PAL versions, so I can only safely do discs 20-22 and 35, not 17-19. For the PAL version I do have, the games don't match, so probably best to leave them alone for another PR.