### PR TITLE
IOS: Allow for heterogenous name lookup

### DIFF
--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -505,14 +505,14 @@ s32 Kernel::GetFreeDeviceID()
   return -1;
 }
 
-std::shared_ptr<Device::Device> Kernel::GetDeviceByName(const std::string& device_name)
+std::shared_ptr<Device::Device> Kernel::GetDeviceByName(std::string_view device_name)
 {
   std::lock_guard lock(m_device_map_mutex);
   const auto iterator = m_device_map.find(device_name);
   return iterator != m_device_map.end() ? iterator->second : nullptr;
 }
 
-std::shared_ptr<Device::Device> EmulationKernel::GetDeviceByName(const std::string& device_name)
+std::shared_ptr<Device::Device> EmulationKernel::GetDeviceByName(std::string_view device_name)
 {
   return Kernel::GetDeviceByName(device_name);
 }

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -409,7 +409,7 @@ bool Kernel::BootIOS(const u64 ios_title_id, const std::string& boot_content_pat
 void Kernel::AddDevice(std::unique_ptr<Device::Device> device)
 {
   ASSERT(device->GetDeviceType() == Device::Device::DeviceType::Static);
-  m_device_map[device->GetDeviceName()] = std::move(device);
+  m_device_map.insert_or_assign(device->GetDeviceName(), std::move(device));
 }
 
 void Kernel::AddCoreDevices()

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -110,14 +111,14 @@ protected:
   void AddDevice(std::unique_ptr<Device::Device> device);
   void AddCoreDevices();
   void AddStaticDevices();
-  std::shared_ptr<Device::Device> GetDeviceByName(const std::string& device_name);
+  std::shared_ptr<Device::Device> GetDeviceByName(std::string_view device_name);
   s32 GetFreeDeviceID();
   IPCCommandResult OpenDevice(OpenRequest& request);
 
   bool m_is_responsible_for_nand_root = false;
   u64 m_title_id = 0;
   static constexpr u8 IPC_MAX_FDS = 0x18;
-  std::map<std::string, std::shared_ptr<Device::Device>> m_device_map;
+  std::map<std::string, std::shared_ptr<Device::Device>, std::less<>> m_device_map;
   std::mutex m_device_map_mutex;
   // TODO: make this fdmap per process.
   std::array<std::shared_ptr<Device::Device>, IPC_MAX_FDS> m_fdmap;
@@ -144,7 +145,7 @@ public:
 
   // Get a resource manager by name.
   // This only works for devices which are part of the device map.
-  std::shared_ptr<Device::Device> GetDeviceByName(const std::string& device_name);
+  std::shared_ptr<Device::Device> GetDeviceByName(std::string_view device_name);
 };
 
 // Used for controlling and accessing an IOS instance that is tied to emulation.


### PR DESCRIPTION
Allows lookups to be done with std::string_view or any other string type. This allows for non-allocating strings to be used with the name lookup without needing to construct a std::string.

While we're at it, we can make use of `insert_or_assign` in AddDevice to elide unnecessary default constructions (not like it particularly matters, however it's essentially a "free" change, so why not).