### PR TITLE
SysConf: Make use of std::string_view 

### DIFF
--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -227,29 +227,29 @@ void SysConf::AddEntry(Entry&& entry)
   m_entries.emplace_back(std::move(entry));
 }
 
-SysConf::Entry* SysConf::GetEntry(const std::string& key)
+SysConf::Entry* SysConf::GetEntry(std::string_view key)
 {
   const auto iterator = std::find_if(m_entries.begin(), m_entries.end(),
                                      [&key](const auto& entry) { return entry.name == key; });
   return iterator != m_entries.end() ? &*iterator : nullptr;
 }
 
-const SysConf::Entry* SysConf::GetEntry(const std::string& key) const
+const SysConf::Entry* SysConf::GetEntry(std::string_view key) const
 {
   const auto iterator = std::find_if(m_entries.begin(), m_entries.end(),
                                      [&key](const auto& entry) { return entry.name == key; });
   return iterator != m_entries.end() ? &*iterator : nullptr;
 }
 
-SysConf::Entry* SysConf::GetOrAddEntry(const std::string& key, Entry::Type type)
+SysConf::Entry* SysConf::GetOrAddEntry(std::string_view key, Entry::Type type)
 {
   if (Entry* entry = GetEntry(key))
     return entry;
-  AddEntry({type, key});
+  AddEntry({type, std::string(key)});
   return GetEntry(key);
 }
 
-void SysConf::RemoveEntry(const std::string& key)
+void SysConf::RemoveEntry(std::string_view key)
 {
   m_entries.erase(std::remove_if(m_entries.begin(), m_entries.end(),
                                  [&key](const auto& entry) { return entry.name == key; }),

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -211,14 +211,14 @@ bool SysConf::Save() const
   return result == IOS::HLE::FS::ResultCode::Success;
 }
 
-SysConf::Entry::Entry(Type type_, const std::string& name_) : type(type_), name(name_)
+SysConf::Entry::Entry(Type type_, std::string name_) : type(type_), name(std::move(name_))
 {
   if (type != Type::SmallArray && type != Type::BigArray)
     bytes.resize(GetNonArrayEntrySize(type));
 }
 
-SysConf::Entry::Entry(Type type_, const std::string& name_, std::vector<u8> bytes_)
-    : type(type_), name(name_), bytes(std::move(bytes_))
+SysConf::Entry::Entry(Type type_, std::string name_, std::vector<u8> bytes_)
+    : type(type_), name(std::move(name_)), bytes(std::move(bytes_))
 {
 }
 

--- a/Source/Core/Core/SysConf.cpp
+++ b/Source/Core/Core/SysConf.cpp
@@ -222,9 +222,9 @@ SysConf::Entry::Entry(Type type_, const std::string& name_, std::vector<u8> byte
 {
 }
 
-void SysConf::AddEntry(Entry&& entry)
+SysConf::Entry& SysConf::AddEntry(Entry&& entry)
 {
-  m_entries.emplace_back(std::move(entry));
+  return m_entries.emplace_back(std::move(entry));
 }
 
 SysConf::Entry* SysConf::GetEntry(std::string_view key)
@@ -245,8 +245,8 @@ SysConf::Entry* SysConf::GetOrAddEntry(std::string_view key, Entry::Type type)
 {
   if (Entry* entry = GetEntry(key))
     return entry;
-  AddEntry({type, std::string(key)});
-  return GetEntry(key);
+
+  return &AddEntry({type, std::string(key)});
 }
 
 void SysConf::RemoveEntry(std::string_view key)

--- a/Source/Core/Core/SysConf.h
+++ b/Source/Core/Core/SysConf.h
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Common/Assert.h"
@@ -75,20 +76,20 @@ public:
   };
 
   void AddEntry(Entry&& entry);
-  Entry* GetEntry(const std::string& key);
-  const Entry* GetEntry(const std::string& key) const;
-  Entry* GetOrAddEntry(const std::string& key, Entry::Type type);
-  void RemoveEntry(const std::string& key);
+  Entry* GetEntry(std::string_view key);
+  const Entry* GetEntry(std::string_view key) const;
+  Entry* GetOrAddEntry(std::string_view key, Entry::Type type);
+  void RemoveEntry(std::string_view key);
 
   // Intended for use with the non array types.
   template <typename T>
-  T GetData(const std::string& key, T default_value) const
+  T GetData(std::string_view key, T default_value) const
   {
     const Entry* entry = GetEntry(key);
     return entry ? entry->GetData(default_value) : default_value;
   }
   template <typename T>
-  void SetData(const std::string& key, Entry::Type type, T value)
+  void SetData(std::string_view key, Entry::Type type, T value)
   {
     GetOrAddEntry(key, type)->SetData(value);
   }

--- a/Source/Core/Core/SysConf.h
+++ b/Source/Core/Core/SysConf.h
@@ -47,8 +47,8 @@ public:
       ByteBool = 7,
     };
 
-    Entry(Type type_, const std::string& name_);
-    Entry(Type type_, const std::string& name_, std::vector<u8> bytes_);
+    Entry(Type type_, std::string name_);
+    Entry(Type type_, std::string name_, std::vector<u8> bytes_);
 
     // Intended for use with the non array types.
     template <typename T>

--- a/Source/Core/Core/SysConf.h
+++ b/Source/Core/Core/SysConf.h
@@ -75,7 +75,7 @@ public:
     std::vector<u8> bytes;
   };
 
-  void AddEntry(Entry&& entry);
+  Entry& AddEntry(Entry&& entry);
   Entry* GetEntry(std::string_view key);
   const Entry* GetEntry(std::string_view key) const;
   Entry* GetOrAddEntry(std::string_view key, Entry::Type type);


### PR DESCRIPTION
Allows strings to be used in potentially non-allocating manners.