### PR TITLE
GameSettings: Enable perf queries to fix sun in Need for Speed: Most Wanted.

### DIFF
--- a/Data/Sys/GameSettings/GOW.ini
+++ b/Data/Sys/GameSettings/GOW.ini
@@ -2,3 +2,6 @@
 
 [Core]
 JITFollowBranch = False
+
+[Video]
+PerfQueriesEnable = True


### PR DESCRIPTION
Rebase of #9380 with proper commit message. Mostly because I genuinely smiled at the PR name of 'turn on the sun'.