### PR TITLE
JitArm64_Tables: Construct tables at compile-time

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -44,9 +44,7 @@ JitArm64::~JitArm64() = default;
 
 void JitArm64::Init()
 {
-  InitializeInstructionTables();
-
-  size_t child_code_size = SConfig::GetInstance().bMMU ? FARCODE_SIZE_MMU : FARCODE_SIZE;
+  const size_t child_code_size = SConfig::GetInstance().bMMU ? FARCODE_SIZE_MMU : FARCODE_SIZE;
   AllocCodeSpace(CODE_SIZE + child_code_size);
   AddChildCodeSpace(&farcode, child_code_size);
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -172,7 +172,6 @@ private:
     const u8* slowmem_code;
   };
 
-  static void InitializeInstructionTables();
   void CompileInstruction(PPCAnalyst::CodeOp& op);
 
   bool HandleFunctionHooking(u32 address);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -43,7 +43,9 @@ public:
   void Jit(u32) override;
 
   const char* GetName() const override { return "JITARM64"; }
+
   // OPCODES
+  using Instruction = void (JitArm64::*)(UGeckoInstruction);
   void FallBackToInterpreter(UGeckoInstruction inst);
   void DoNothing(UGeckoInstruction inst);
   void HLEFunction(u32 hook_index);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -10,13 +10,10 @@
 
 namespace
 {
-// Should be moved in to the Jit class
-using Instruction = void (JitArm64::*)(UGeckoInstruction);
-
 struct GekkoOPTemplate
 {
   int opcode;
-  Instruction fn;
+  JitArm64::Instruction fn;
   // GekkoOPInfo opinfo; // Doesn't need opinfo, Interpreter fills it out
 };
 
@@ -339,8 +336,8 @@ constexpr std::array<GekkoOPTemplate, 10> table63_2{{
     {31, &JitArm64::fp_arith},               // fnmaddx
 }};
 
-constexpr std::array<Instruction, 64> dynaOpTable = [] {
-  std::array<Instruction, 64> table{};
+constexpr std::array<JitArm64::Instruction, 64> dynaOpTable = [] {
+  std::array<JitArm64::Instruction, 64> table{};
 
   for (auto& tpl : table)
   {
@@ -355,8 +352,8 @@ constexpr std::array<Instruction, 64> dynaOpTable = [] {
   return table;
 }();
 
-constexpr std::array<Instruction, 1024> dynaOpTable4 = [] {
-  std::array<Instruction, 1024> table{};
+constexpr std::array<JitArm64::Instruction, 1024> dynaOpTable4 = [] {
+  std::array<JitArm64::Instruction, 1024> table{};
 
   for (auto& entry : table)
   {
@@ -391,8 +388,8 @@ constexpr std::array<Instruction, 1024> dynaOpTable4 = [] {
   return table;
 }();
 
-constexpr std::array<Instruction, 1024> dynaOpTable19 = [] {
-  std::array<Instruction, 1024> table{};
+constexpr std::array<JitArm64::Instruction, 1024> dynaOpTable19 = [] {
+  std::array<JitArm64::Instruction, 1024> table{};
 
   for (auto& entry : table)
   {
@@ -407,8 +404,8 @@ constexpr std::array<Instruction, 1024> dynaOpTable19 = [] {
   return table;
 }();
 
-constexpr std::array<Instruction, 1024> dynaOpTable31 = [] {
-  std::array<Instruction, 1024> table{};
+constexpr std::array<JitArm64::Instruction, 1024> dynaOpTable31 = [] {
+  std::array<JitArm64::Instruction, 1024> table{};
 
   for (auto& entry : table)
   {
@@ -423,8 +420,8 @@ constexpr std::array<Instruction, 1024> dynaOpTable31 = [] {
   return table;
 }();
 
-constexpr std::array<Instruction, 32> dynaOpTable59 = [] {
-  std::array<Instruction, 32> table{};
+constexpr std::array<JitArm64::Instruction, 32> dynaOpTable59 = [] {
+  std::array<JitArm64::Instruction, 32> table{};
 
   for (auto& entry : table)
   {
@@ -439,8 +436,8 @@ constexpr std::array<Instruction, 32> dynaOpTable59 = [] {
   return table;
 }();
 
-constexpr std::array<Instruction, 1024> dynaOpTable63 = [] {
-  std::array<Instruction, 1024> table{};
+constexpr std::array<JitArm64::Instruction, 1024> dynaOpTable63 = [] {
+  std::array<JitArm64::Instruction, 1024> table{};
 
   for (auto& entry : table)
   {


### PR DESCRIPTION
Migrates the Aarch64 JIT tables over to the same tabling mechanism as the x64 JIT in which we just compute them all at compile-time.