### PR TITLE
Arm64Emitter: Interface cleanup

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1247,15 +1247,15 @@ void ARM64XEmitter::CLREX()
 }
 void ARM64XEmitter::DSB(BarrierType type)
 {
-  EncodeSystemInst(0, 3, 3, type, 4, WSP);
+  EncodeSystemInst(0, 3, 3, static_cast<u32>(type), 4, WSP);
 }
 void ARM64XEmitter::DMB(BarrierType type)
 {
-  EncodeSystemInst(0, 3, 3, type, 5, WSP);
+  EncodeSystemInst(0, 3, 3, static_cast<u32>(type), 5, WSP);
 }
 void ARM64XEmitter::ISB(BarrierType type)
 {
-  EncodeSystemInst(0, 3, 3, type, 6, WSP);
+  EncodeSystemInst(0, 3, 3, static_cast<u32>(type), 6, WSP);
 }
 
 // Add/Subtract (extended register)

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1149,15 +1149,15 @@ void ARM64XEmitter::_MSR(PStateField field, u8 imm)
   u32 op1 = 0, op2 = 0;
   switch (field)
   {
-  case FIELD_SPSel:
+  case PStateField::SPSel:
     op1 = 0;
     op2 = 5;
     break;
-  case FIELD_DAIFSet:
+  case PStateField::DAIFSet:
     op1 = 3;
     op2 = 6;
     break;
-  case FIELD_DAIFClr:
+  case PStateField::DAIFClr:
     op1 = 3;
     op2 = 7;
     break;
@@ -1172,35 +1172,35 @@ static void GetSystemReg(PStateField field, int& o0, int& op1, int& CRn, int& CR
 {
   switch (field)
   {
-  case FIELD_NZCV:
+  case PStateField::NZCV:
     o0 = 3;
     op1 = 3;
     CRn = 4;
     CRm = 2;
     op2 = 0;
     break;
-  case FIELD_FPCR:
+  case PStateField::FPCR:
     o0 = 3;
     op1 = 3;
     CRn = 4;
     CRm = 4;
     op2 = 0;
     break;
-  case FIELD_FPSR:
+  case PStateField::FPSR:
     o0 = 3;
     op1 = 3;
     CRn = 4;
     CRm = 4;
     op2 = 1;
     break;
-  case FIELD_PMCR_EL0:
+  case PStateField::PMCR_EL0:
     o0 = 3;
     op1 = 3;
     CRn = 9;
     CRm = 6;
     op2 = 0;
     break;
-  case FIELD_PMCCNTR_EL0:
+  case PStateField::PMCCNTR_EL0:
     o0 = 3;
     op1 = 3;
     CRn = 9;

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -914,43 +914,43 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
 
   switch (branch.type)
   {
-  case 1:  // CBNZ
+  case FixupBranch::Type::CBNZ:
     Not = true;
     [[fallthrough]];
-  case 0:  // CBZ
+  case FixupBranch::Type::CBZ:
   {
     ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, branch.type, distance);
-    bool b64Bit = Is64Bit(branch.reg);
-    ARM64Reg reg = DecodeReg(branch.reg);
+               __func__, static_cast<int>(branch.type), distance);
+    const bool b64Bit = Is64Bit(branch.reg);
+    const ARM64Reg reg = DecodeReg(branch.reg);
     inst = (b64Bit << 31) | (0x1A << 25) | (Not << 24) | (MaskImm19(distance) << 5) | reg;
   }
   break;
-  case 2:  // B (conditional)
+  case FixupBranch::Type::BConditional:
     ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, branch.type, distance);
+               __func__, static_cast<int>(branch.type), distance);
     inst = (0x2A << 25) | (MaskImm19(distance) << 5) | branch.cond;
     break;
-  case 4:  // TBNZ
+  case FixupBranch::Type::TBNZ:
     Not = true;
     [[fallthrough]];
-  case 3:  // TBZ
+  case FixupBranch::Type::TBZ:
   {
     ASSERT_MSG(DYNA_REC, IsInRangeImm14(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, branch.type, distance);
-    ARM64Reg reg = DecodeReg(branch.reg);
+               __func__, static_cast<int>(branch.type), distance);
+    const ARM64Reg reg = DecodeReg(branch.reg);
     inst = ((branch.bit & 0x20) << 26) | (0x1B << 25) | (Not << 24) | ((branch.bit & 0x1F) << 19) |
            (MaskImm14(distance) << 5) | reg;
   }
   break;
-  case 5:  // B (unconditional)
+  case FixupBranch::Type::B:
     ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, branch.type, distance);
+               __func__, static_cast<int>(branch.type), distance);
     inst = (0x5 << 26) | MaskImm26(distance);
     break;
-  case 6:  // BL (unconditional)
+  case FixupBranch::Type::BL:
     ASSERT_MSG(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %" PRIx64,
-               __func__, branch.type, distance);
+               __func__, static_cast<int>(branch.type), distance);
     inst = (0x25 << 26) | MaskImm26(distance);
     break;
   }
@@ -960,36 +960,36 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
 
 FixupBranch ARM64XEmitter::CBZ(ARM64Reg Rt)
 {
-  FixupBranch branch;
+  FixupBranch branch{};
   branch.ptr = m_code;
-  branch.type = 0;
+  branch.type = FixupBranch::Type::CBZ;
   branch.reg = Rt;
   HINT(HINT_NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::CBNZ(ARM64Reg Rt)
 {
-  FixupBranch branch;
+  FixupBranch branch{};
   branch.ptr = m_code;
-  branch.type = 1;
+  branch.type = FixupBranch::Type::CBNZ;
   branch.reg = Rt;
   HINT(HINT_NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::B(CCFlags cond)
 {
-  FixupBranch branch;
+  FixupBranch branch{};
   branch.ptr = m_code;
-  branch.type = 2;
+  branch.type = FixupBranch::Type::BConditional;
   branch.cond = cond;
   HINT(HINT_NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::TBZ(ARM64Reg Rt, u8 bit)
 {
-  FixupBranch branch;
+  FixupBranch branch{};
   branch.ptr = m_code;
-  branch.type = 3;
+  branch.type = FixupBranch::Type::TBZ;
   branch.reg = Rt;
   branch.bit = bit;
   HINT(HINT_NOP);
@@ -997,9 +997,9 @@ FixupBranch ARM64XEmitter::TBZ(ARM64Reg Rt, u8 bit)
 }
 FixupBranch ARM64XEmitter::TBNZ(ARM64Reg Rt, u8 bit)
 {
-  FixupBranch branch;
+  FixupBranch branch{};
   branch.ptr = m_code;
-  branch.type = 4;
+  branch.type = FixupBranch::Type::TBNZ;
   branch.reg = Rt;
   branch.bit = bit;
   HINT(HINT_NOP);
@@ -1007,17 +1007,17 @@ FixupBranch ARM64XEmitter::TBNZ(ARM64Reg Rt, u8 bit)
 }
 FixupBranch ARM64XEmitter::B()
 {
-  FixupBranch branch;
+  FixupBranch branch{};
   branch.ptr = m_code;
-  branch.type = 5;
+  branch.type = FixupBranch::Type::B;
   HINT(HINT_NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::BL()
 {
-  FixupBranch branch;
+  FixupBranch branch{};
   branch.ptr = m_code;
-  branch.type = 6;
+  branch.type = FixupBranch::Type::BL;
   HINT(HINT_NOP);
   return branch;
 }

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -965,7 +965,7 @@ FixupBranch ARM64XEmitter::CBZ(ARM64Reg Rt)
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::CBZ;
   branch.reg = Rt;
-  HINT(SystemHint::NOP);
+  NOP();
   return branch;
 }
 FixupBranch ARM64XEmitter::CBNZ(ARM64Reg Rt)
@@ -974,7 +974,7 @@ FixupBranch ARM64XEmitter::CBNZ(ARM64Reg Rt)
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::CBNZ;
   branch.reg = Rt;
-  HINT(SystemHint::NOP);
+  NOP();
   return branch;
 }
 FixupBranch ARM64XEmitter::B(CCFlags cond)
@@ -983,7 +983,7 @@ FixupBranch ARM64XEmitter::B(CCFlags cond)
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::BConditional;
   branch.cond = cond;
-  HINT(SystemHint::NOP);
+  NOP();
   return branch;
 }
 FixupBranch ARM64XEmitter::TBZ(ARM64Reg Rt, u8 bit)
@@ -993,7 +993,7 @@ FixupBranch ARM64XEmitter::TBZ(ARM64Reg Rt, u8 bit)
   branch.type = FixupBranch::Type::TBZ;
   branch.reg = Rt;
   branch.bit = bit;
-  HINT(SystemHint::NOP);
+  NOP();
   return branch;
 }
 FixupBranch ARM64XEmitter::TBNZ(ARM64Reg Rt, u8 bit)
@@ -1003,7 +1003,7 @@ FixupBranch ARM64XEmitter::TBNZ(ARM64Reg Rt, u8 bit)
   branch.type = FixupBranch::Type::TBNZ;
   branch.reg = Rt;
   branch.bit = bit;
-  HINT(SystemHint::NOP);
+  NOP();
   return branch;
 }
 FixupBranch ARM64XEmitter::B()
@@ -1011,7 +1011,7 @@ FixupBranch ARM64XEmitter::B()
   FixupBranch branch{};
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::B;
-  HINT(SystemHint::NOP);
+  NOP();
   return branch;
 }
 FixupBranch ARM64XEmitter::BL()
@@ -1019,7 +1019,7 @@ FixupBranch ARM64XEmitter::BL()
   FixupBranch branch{};
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::BL;
-  HINT(SystemHint::NOP);
+  NOP();
   return branch;
 }
 

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -964,7 +964,7 @@ FixupBranch ARM64XEmitter::CBZ(ARM64Reg Rt)
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::CBZ;
   branch.reg = Rt;
-  HINT(HINT_NOP);
+  HINT(SystemHint::NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::CBNZ(ARM64Reg Rt)
@@ -973,7 +973,7 @@ FixupBranch ARM64XEmitter::CBNZ(ARM64Reg Rt)
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::CBNZ;
   branch.reg = Rt;
-  HINT(HINT_NOP);
+  HINT(SystemHint::NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::B(CCFlags cond)
@@ -982,7 +982,7 @@ FixupBranch ARM64XEmitter::B(CCFlags cond)
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::BConditional;
   branch.cond = cond;
-  HINT(HINT_NOP);
+  HINT(SystemHint::NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::TBZ(ARM64Reg Rt, u8 bit)
@@ -992,7 +992,7 @@ FixupBranch ARM64XEmitter::TBZ(ARM64Reg Rt, u8 bit)
   branch.type = FixupBranch::Type::TBZ;
   branch.reg = Rt;
   branch.bit = bit;
-  HINT(HINT_NOP);
+  HINT(SystemHint::NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::TBNZ(ARM64Reg Rt, u8 bit)
@@ -1002,7 +1002,7 @@ FixupBranch ARM64XEmitter::TBNZ(ARM64Reg Rt, u8 bit)
   branch.type = FixupBranch::Type::TBNZ;
   branch.reg = Rt;
   branch.bit = bit;
-  HINT(HINT_NOP);
+  HINT(SystemHint::NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::B()
@@ -1010,7 +1010,7 @@ FixupBranch ARM64XEmitter::B()
   FixupBranch branch{};
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::B;
-  HINT(HINT_NOP);
+  HINT(SystemHint::NOP);
   return branch;
 }
 FixupBranch ARM64XEmitter::BL()
@@ -1018,7 +1018,7 @@ FixupBranch ARM64XEmitter::BL()
   FixupBranch branch{};
   branch.ptr = m_code;
   branch.type = FixupBranch::Type::BL;
-  HINT(HINT_NOP);
+  HINT(SystemHint::NOP);
   return branch;
 }
 
@@ -1239,7 +1239,7 @@ void ARM64XEmitter::CNTVCT(Arm64Gen::ARM64Reg Rt)
 
 void ARM64XEmitter::HINT(SystemHint op)
 {
-  EncodeSystemInst(0, 3, 2, 0, op, WSP);
+  EncodeSystemInst(0, 3, 2, 0, static_cast<u32>(op), WSP);
 }
 void ARM64XEmitter::CLREX()
 {

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -2327,28 +2327,28 @@ void ARM64FloatEmitter::EmitConvertScalarToInt(ARM64Reg Rd, ARM64Reg Rn, Roundin
   if (IsGPR(Rd))
   {
     // Use the encoding that transfers the result to a GPR.
-    bool sf = Is64Bit(Rd);
-    int type = IsDouble(Rn) ? 1 : 0;
+    const bool sf = Is64Bit(Rd);
+    const int type = IsDouble(Rn) ? 1 : 0;
     Rd = DecodeReg(Rd);
     Rn = DecodeReg(Rn);
     int opcode = (sign ? 1 : 0);
     int rmode = 0;
     switch (round)
     {
-    case ROUND_A:
+    case RoundingMode::A:
       rmode = 0;
       opcode |= 4;
       break;
-    case ROUND_P:
+    case RoundingMode::P:
       rmode = 1;
       break;
-    case ROUND_M:
+    case RoundingMode::M:
       rmode = 2;
       break;
-    case ROUND_Z:
+    case RoundingMode::Z:
       rmode = 3;
       break;
-    case ROUND_N:
+    case RoundingMode::N:
       rmode = 0;
       break;
     }
@@ -2363,20 +2363,20 @@ void ARM64FloatEmitter::EmitConvertScalarToInt(ARM64Reg Rd, ARM64Reg Rn, Roundin
     int opcode = 0;
     switch (round)
     {
-    case ROUND_A:
+    case RoundingMode::A:
       opcode = 0x1C;
       break;
-    case ROUND_N:
+    case RoundingMode::N:
       opcode = 0x1A;
       break;
-    case ROUND_M:
+    case RoundingMode::M:
       opcode = 0x1B;
       break;
-    case ROUND_P:
+    case RoundingMode::P:
       opcode = 0x1A;
       sz |= 2;
       break;
-    case ROUND_Z:
+    case RoundingMode::Z:
       opcode = 0x1B;
       sz |= 2;
       break;

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -767,7 +767,8 @@ void ARM64XEmitter::EncodeMOVWideInst(u32 op, ARM64Reg Rd, u32 imm, ShiftAmount 
   ASSERT_MSG(DYNA_REC, !(imm & ~0xFFFF), "%s: immediate out of range: %d", __func__, imm);
 
   Rd = DecodeReg(Rd);
-  Write32((b64Bit << 31) | (op << 29) | (0x25 << 23) | (pos << 21) | (imm << 5) | Rd);
+  Write32((b64Bit << 31) | (op << 29) | (0x25 << 23) | (static_cast<u32>(pos) << 21) | (imm << 5) |
+          Rd);
 }
 
 void ARM64XEmitter::EncodeBitfieldMOVInst(u32 op, ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms)
@@ -2004,7 +2005,7 @@ void ARM64XEmitter::MOVI2R(ARM64Reg Rd, u64 imm, bool optimize)
   {
     // Zero immediate, just clear the register. EOR is pointless when we have MOVZ, which looks
     // clearer in disasm too.
-    MOVZ(Rd, 0, SHIFT_0);
+    MOVZ(Rd, 0, ShiftAmount::Shift0);
     return;
   }
 
@@ -2022,7 +2023,7 @@ void ARM64XEmitter::MOVI2R(ARM64Reg Rd, u64 imm, bool optimize)
   // Small negative integer. Use MOVN
   if (!Is64Bit(Rd) && (imm | 0xFFFF0000) == imm)
   {
-    MOVN(Rd, ~imm, SHIFT_0);
+    MOVN(Rd, ~imm, ShiftAmount::Shift0);
     return;
   }
 

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -916,6 +916,7 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
   {
   case 1:  // CBNZ
     Not = true;
+    [[fallthrough]];
   case 0:  // CBZ
   {
     ASSERT_MSG(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %" PRIx64,
@@ -932,6 +933,7 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
     break;
   case 4:  // TBNZ
     Not = true;
+    [[fallthrough]];
   case 3:  // TBZ
   {
     ASSERT_MSG(DYNA_REC, IsInRangeImm14(distance), "%s(%d): Received too large distance: %" PRIx64,

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -354,14 +354,14 @@ enum PStateField
   FIELD_FPSR = 0x341,
 };
 
-enum SystemHint
+enum class SystemHint
 {
-  HINT_NOP = 0,
-  HINT_YIELD,
-  HINT_WFE,
-  HINT_WFI,
-  HINT_SEV,
-  HINT_SEVL,
+  NOP,
+  YIELD,
+  WFE,
+  WFI,
+  SEV,
+  SEVL,
 };
 
 enum BarrierType

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -603,6 +603,13 @@ public:
   void CNTVCT(ARM64Reg Rt);
 
   void HINT(SystemHint op);
+  void NOP() { HINT(SystemHint::NOP); }
+  void SEV() { HINT(SystemHint::SEV); }
+  void SEVL() { HINT(SystemHint::SEVL); }
+  void WFE() { HINT(SystemHint::WFE); }
+  void WFI() { HINT(SystemHint::WFI); }
+  void YIELD() { HINT(SystemHint::YIELD); }
+
   void CLREX();
   void DSB(BarrierType type);
   void DMB(BarrierType type);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -302,12 +302,12 @@ enum IndexType
   INDEX_SIGNED,  // used in LDP/STP
 };
 
-enum ShiftAmount
+enum class ShiftAmount
 {
-  SHIFT_0 = 0,
-  SHIFT_16 = 1,
-  SHIFT_32 = 2,
-  SHIFT_48 = 3,
+  Shift0,
+  Shift16,
+  Shift32,
+  Shift48,
 };
 
 enum class RoundingMode
@@ -737,9 +737,9 @@ public:
   void CMP(ARM64Reg Rn, u32 imm, bool shift = false);
 
   // Data Processing (Immediate)
-  void MOVZ(ARM64Reg Rd, u32 imm, ShiftAmount pos = SHIFT_0);
-  void MOVN(ARM64Reg Rd, u32 imm, ShiftAmount pos = SHIFT_0);
-  void MOVK(ARM64Reg Rd, u32 imm, ShiftAmount pos = SHIFT_0);
+  void MOVZ(ARM64Reg Rd, u32 imm, ShiftAmount pos = ShiftAmount::Shift0);
+  void MOVN(ARM64Reg Rd, u32 imm, ShiftAmount pos = ShiftAmount::Shift0);
+  void MOVK(ARM64Reg Rd, u32 imm, ShiftAmount pos = ShiftAmount::Shift0);
 
   // Bitfield move
   void BFM(ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -321,23 +321,23 @@ enum RoundingMode
 
 struct FixupBranch
 {
-  u8* ptr;
-  // Type defines
-  // 0 = CBZ (32bit)
-  // 1 = CBNZ (32bit)
-  // 2 = B (conditional)
-  // 3 = TBZ
-  // 4 = TBNZ
-  // 5 = B (unconditional)
-  // 6 = BL (unconditional)
-  u32 type;
+  enum class Type : u32
+  {
+    CBZ,
+    CBNZ,
+    BConditional,
+    TBZ,
+    TBNZ,
+    B,
+    BL,
+  };
 
+  u8* ptr;
+  Type type;
   // Used with B.cond
   CCFlags cond;
-
   // Used with TBZ/TBNZ
   u8 bit;
-
   // Used with Test/Compare and Branch
   ARM64Reg reg;
 };

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -342,16 +342,16 @@ struct FixupBranch
   ARM64Reg reg;
 };
 
-enum PStateField
+enum class PStateField
 {
-  FIELD_SPSel = 0,
-  FIELD_DAIFSet,
-  FIELD_DAIFClr,
-  FIELD_NZCV,  // The only system registers accessible from EL0 (user space)
-  FIELD_PMCR_EL0,
-  FIELD_PMCCNTR_EL0,
-  FIELD_FPCR = 0x340,
-  FIELD_FPSR = 0x341,
+  SPSel = 0,
+  DAIFSet,
+  DAIFClr,
+  NZCV,  // The only system registers accessible from EL0 (user space)
+  PMCR_EL0,
+  PMCCNTR_EL0,
+  FPCR = 0x340,
+  FPSR = 0x341,
 };
 
 enum class SystemHint

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -310,13 +310,13 @@ enum ShiftAmount
   SHIFT_48 = 3,
 };
 
-enum RoundingMode
+enum class RoundingMode
 {
-  ROUND_A,  // round to nearest, ties to away
-  ROUND_M,  // round towards -inf
-  ROUND_N,  // round to nearest, ties to even
-  ROUND_P,  // round towards +inf
-  ROUND_Z,  // round towards zero
+  A,  // round to nearest, ties to away
+  M,  // round towards -inf
+  N,  // round to nearest, ties to even
+  P,  // round towards +inf
+  Z,  // round towards zero
 };
 
 struct FixupBranch

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -364,7 +364,7 @@ enum class SystemHint
   SEVL,
 };
 
-enum BarrierType
+enum class BarrierType
 {
   OSHLD = 1,
   OSHST = 2,

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
@@ -19,8 +19,8 @@ void JitArm64BlockCache::WriteLinkBlock(Arm64Gen::ARM64XEmitter& emit,
   if (!dest)
   {
     // Use a fixed amount of instructions, so we can assume to use 3 instructions on patching.
-    emit.MOVZ(DISPATCHER_PC, source.exitAddress & 0xFFFF, SHIFT_0);
-    emit.MOVK(DISPATCHER_PC, source.exitAddress >> 16, SHIFT_16);
+    emit.MOVZ(DISPATCHER_PC, source.exitAddress & 0xFFFF, ShiftAmount::Shift0);
+    emit.MOVK(DISPATCHER_PC, source.exitAddress >> 16, ShiftAmount::Shift16);
 
     if (source.call)
       emit.BL(m_jit.GetAsmRoutines()->dispatcher);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -322,7 +322,7 @@ bool JitArm64::HandleFastmemFault(uintptr_t access_address, SContext* ctx)
 
   const u32 num_insts_max = fastmem_area_length / 4 - 1;
   for (u32 i = 0; i < num_insts_max; ++i)
-    emitter.HINT(HINT_NOP);
+    emitter.HINT(SystemHint::NOP);
 
   m_fault_to_handler.erase(slow_handler_iter);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -322,7 +322,7 @@ bool JitArm64::HandleFastmemFault(uintptr_t access_address, SContext* ctx)
 
   const u32 num_insts_max = fastmem_area_length / 4 - 1;
   for (u32 i = 0; i < num_insts_max; ++i)
-    emitter.HINT(SystemHint::NOP);
+    emitter.NOP();
 
   m_fault_to_handler.erase(slow_handler_iter);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -335,13 +335,13 @@ void JitArm64::fctiwzx(UGeckoInstruction inst)
 
   if (single)
   {
-    m_float_emit.FCVTS(EncodeRegToSingle(VD), EncodeRegToSingle(VB), ROUND_Z);
+    m_float_emit.FCVTS(EncodeRegToSingle(VD), EncodeRegToSingle(VB), RoundingMode::Z);
   }
   else
   {
     ARM64Reg V1 = gpr.GetReg();
 
-    m_float_emit.FCVTS(V1, EncodeRegToDouble(VB), ROUND_Z);
+    m_float_emit.FCVTS(V1, EncodeRegToDouble(VB), RoundingMode::Z);
     m_float_emit.FMOV(EncodeRegToSingle(VD), V1);
 
     gpr.Unlock(V1);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -261,7 +261,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
     m_float_emit.LDR(32, INDEX_UNSIGNED, SD, Xg,
                      offsetof(CoreTiming::Globals, last_OC_factor_inverted));
     m_float_emit.FMUL(SC, SC, SD);
-    m_float_emit.FCVTS(Xresult, SC, ROUND_Z);
+    m_float_emit.FCVTS(Xresult, SC, RoundingMode::Z);
 
     LDP(INDEX_SIGNED, XA, XB, Xg, offsetof(CoreTiming::Globals, global_timer));
     SXTW(XB, WB);


### PR DESCRIPTION
Tidies up the interface a little by annotating switch fallthrough to avoid warnings. While we're at it we can convert quite a few enums into enum classes to prevent polluting namespaces and making their usage strongly typed.