### PR TITLE
ArmCommon: Add missing header guard

### DIFF
--- a/Source/Core/Common/ArmCommon.h
+++ b/Source/Core/Common/ArmCommon.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include "Common/CommonTypes.h"
 
 enum CCFlags

--- a/Source/Core/Common/ArmCommon.h
+++ b/Source/Core/Common/ArmCommon.h
@@ -26,4 +26,4 @@ enum CCFlags
   CC_HS = CC_CS,  // Alias of CC_CS  Unsigned higher or same
   CC_LO = CC_CC,  // Alias of CC_CC  Unsigned lower
 };
-const u32 NO_COND = 0xE0000000;
+constexpr u32 NO_COND = 0xE0000000;


### PR DESCRIPTION
Adds a missing header guard to prevent inclusion issues from occurring.

While we're in the same area, we can also mark a constant as constexpr.