### PR TITLE
mbedtls: Disable SNI support

### DIFF
--- a/Externals/mbedtls/include/mbedtls/config.h
+++ b/Externals/mbedtls/include/mbedtls/config.h
@@ -1587,7 +1587,7 @@
  *
  * Comment this macro to disable support for server name indication in SSL
  */
-#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+// #define MBEDTLS_SSL_SERVER_NAME_INDICATION
 
 /**
  * \def MBEDTLS_SSL_TRUNCATED_HMAC


### PR DESCRIPTION
Dolphin is using the mbedtls library for SSL connections done within Wii games. This library is currently configured with the `MBEDTLS_SSL_SERVER_NAME_INDICATION` option, this means that any SSL request done by the game will be using SNI (Server Name Indication). 

This is different than on a Wii, which did not support SNI at all (see bug report [12323](https://bugs.dolphin-emu.org/issues/12323))

In theory, supporting SNI even though the original Wii does not support it wouldn't be a problem, if Nintendo hadn't made a small mistake in their DWC library: Some games, including Mario Kart Wii, are sending the `Host` header twice, which violates a couple of RFC standards. 

This causes web servers (At least certain Apache versions, don't know about other webservers) to compare the SNI hostname string "naswii.nintendowifi.net" and the merged Host header string "naswii.nintendowifi.net, naswii.nintendowifi.net" (duplicate headers in general are supposed to be merged together), and as these two strings are different, it causes issues. 

On Wiimmfi we were able to work around that with a bunch of Apache config parameters and a patch to Mario Kart Wii that removes the duplicate Host Header, but still, the Wii didn't support SNI and so Dolphin shouldn't either, in my opinion.

This PR removes the `MBEDTLS_SSL_SERVER_NAME_INDICATION` flag from the mbedtls library in the Externals folder, which should get rid of the issue at least for these platforms that use the External library and not one provided by the distribution. It disables SNI for SSL requests done by the emulated game, which makes these SSL requests more similar to ones made by an actual Wii.

I verified that in Wireshark, without this patch the SSL Client Hello request does have the server_name extension, and with this patch applied (and with `libpolarssl-dev` missing so the compiler uses the External one) the server_name extension is missing from the request, like on a Wii.