### PR TITLE
Add epsilon hack to work around rounding issue in texture lookup

### DIFF
--- a/Data/Sys/GameSettings/G4F.ini
+++ b/Data/Sys/GameSettings/G4F.ini
@@ -1,0 +1,4 @@
+# G4FP69, G4FE69, G4FD69, G4FF69 - FIFA Soccer 07
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/G4F.ini
+++ b/Data/Sys/GameSettings/G4F.ini
@@ -1,4 +1,4 @@
 # G4FP69, G4FE69, G4FD69, G4FF69 - FIFA Soccer 07
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/G6F.ini
+++ b/Data/Sys/GameSettings/G6F.ini
@@ -1,4 +1,4 @@
 # G6FE69, G6FD69, G6FF69, G6FP69 - FIFA World Cup: Germany 2006
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/G6F.ini
+++ b/Data/Sys/GameSettings/G6F.ini
@@ -1,0 +1,4 @@
+# G6FE69, G6FD69, G6FF69, G6FP69 - FIFA World Cup: Germany 2006
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/G6N.ini
+++ b/Data/Sys/GameSettings/G6N.ini
@@ -1,0 +1,4 @@
+# G6NE69, G6NP69 - NBA Live 06
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/G6N.ini
+++ b/Data/Sys/GameSettings/G6N.ini
@@ -1,4 +1,4 @@
 # G6NE69, G6NP69 - NBA Live 06
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GAZ.ini
+++ b/Data/Sys/GameSettings/GAZ.ini
@@ -1,4 +1,4 @@
 # GAZF69, GAZE69, GAZJ13, GAZM69, GAZI69, GAZH69, GAZD69, GAZP69, GAZJ69, GAZS69 - Harry Potter and the Prisoner of Azkaban
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GAZ.ini
+++ b/Data/Sys/GameSettings/GAZ.ini
@@ -1,0 +1,4 @@
+# GAZF69, GAZE69, GAZJ13, GAZM69, GAZI69, GAZH69, GAZD69, GAZP69, GAZJ69, GAZS69 - Harry Potter and the Prisoner of Azkaban
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GEY.ini
+++ b/Data/Sys/GameSettings/GEY.ini
@@ -1,0 +1,4 @@
+# GEYP69, GEYJ13, GEYE69 - Fight Night Round 2
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GEY.ini
+++ b/Data/Sys/GameSettings/GEY.ini
@@ -1,4 +1,4 @@
 # GEYP69, GEYJ13, GEYE69 - Fight Night Round 2
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GF5.ini
+++ b/Data/Sys/GameSettings/GF5.ini
@@ -1,0 +1,4 @@
+# GF5P69, GF5E69, GF5D69, GF5F69, GF5I69, GF5H69, GF5S69 - FIFA Soccer 2005
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GF5.ini
+++ b/Data/Sys/GameSettings/GF5.ini
@@ -1,4 +1,4 @@
 # GF5P69, GF5E69, GF5D69, GF5F69, GF5I69, GF5H69, GF5S69 - FIFA Soccer 2005
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GF6.ini
+++ b/Data/Sys/GameSettings/GF6.ini
@@ -1,4 +1,4 @@
 # GF6P69, GF6F69, GF6E69, GF6D69, GF6H69, GF6S69, GF6I69 - FIFA Soccer 06
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GF6.ini
+++ b/Data/Sys/GameSettings/GF6.ini
@@ -1,0 +1,4 @@
+# GF6P69, GF6F69, GF6E69, GF6D69, GF6H69, GF6S69, GF6I69 - FIFA Soccer 06
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GF8.ini
+++ b/Data/Sys/GameSettings/GF8.ini
@@ -1,0 +1,4 @@
+# GF8P69, GF8E69 - FIFA Street
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GF8.ini
+++ b/Data/Sys/GameSettings/GF8.ini
@@ -1,4 +1,4 @@
 # GF8P69, GF8E69 - FIFA Street
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GFA.ini
+++ b/Data/Sys/GameSettings/GFA.ini
@@ -1,4 +1,4 @@
 # GFAP69, GFAJ13, GFAE69, GFAD69, GFAF69, GFAI69, GFAS69 - FIFA Soccer 2003
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GFA.ini
+++ b/Data/Sys/GameSettings/GFA.ini
@@ -1,0 +1,4 @@
+# GFAP69, GFAJ13, GFAE69, GFAD69, GFAF69, GFAI69, GFAS69 - FIFA Soccer 2003
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GFY.ini
+++ b/Data/Sys/GameSettings/GFY.ini
@@ -16,4 +16,4 @@
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GFY.ini
+++ b/Data/Sys/GameSettings/GFY.ini
@@ -15,3 +15,5 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GH2.ini
+++ b/Data/Sys/GameSettings/GH2.ini
@@ -16,4 +16,4 @@
 
 [Video_Hacks]
 ImmediateXFBEnable = False
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GH2.ini
+++ b/Data/Sys/GameSettings/GH2.ini
@@ -16,4 +16,4 @@
 
 [Video_Hacks]
 ImmediateXFBEnable = False
-
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GLY.ini
+++ b/Data/Sys/GameSettings/GLY.ini
@@ -1,4 +1,4 @@
 # GLYE69, GLYP69 - NBA Live 2005
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GLY.ini
+++ b/Data/Sys/GameSettings/GLY.ini
@@ -1,0 +1,4 @@
+# GLYE69, GLYP69 - NBA Live 2005
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GLZ.ini
+++ b/Data/Sys/GameSettings/GLZ.ini
@@ -1,0 +1,4 @@
+# GLZP69, GLZE69, GLZD69, GLZF69 - 007: From Russia with Love (tm)
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GLZ.ini
+++ b/Data/Sys/GameSettings/GLZ.ini
@@ -1,4 +1,4 @@
 # GLZP69, GLZE69, GLZD69, GLZF69 - 007: From Russia with Love (tm)
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GMF.ini
+++ b/Data/Sys/GameSettings/GMF.ini
@@ -1,0 +1,4 @@
+# GMFE69, GMFS69, GMFD69, GMFF69, GMFI69, GMFP69 - Medal of Honor: Frontline
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GMF.ini
+++ b/Data/Sys/GameSettings/GMF.ini
@@ -1,4 +1,4 @@
 # GMFE69, GMFS69, GMFD69, GMFF69, GMFI69, GMFP69 - Medal of Honor: Frontline
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GN8.ini
+++ b/Data/Sys/GameSettings/GN8.ini
@@ -1,0 +1,4 @@
+# GN8E69, GN8P69 - NBA Live 2004
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GN8.ini
+++ b/Data/Sys/GameSettings/GN8.ini
@@ -1,4 +1,4 @@
 # GN8E69, GN8P69 - NBA Live 2004
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GNL.ini
+++ b/Data/Sys/GameSettings/GNL.ini
@@ -1,4 +1,4 @@
 # GNLE69, GNLP69 - NBA Live 2003
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GNL.ini
+++ b/Data/Sys/GameSettings/GNL.ini
@@ -1,0 +1,4 @@
+# GNLE69, GNLP69 - NBA Live 2003
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GNS.ini
+++ b/Data/Sys/GameSettings/GNS.ini
@@ -1,4 +1,4 @@
 # GNSJ13, GNSE69 - NBA Street
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GNS.ini
+++ b/Data/Sys/GameSettings/GNS.ini
@@ -1,0 +1,4 @@
+# GNSJ13, GNSE69 - NBA Street
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GNW.ini
+++ b/Data/Sys/GameSettings/GNW.ini
@@ -1,4 +1,4 @@
 # GNWP69, GNWE69 - Def Jam Fight For NY
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GNW.ini
+++ b/Data/Sys/GameSettings/GNW.ini
@@ -1,0 +1,4 @@
+# GNWP69, GNWE69 - Def Jam Fight For NY
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GO7.ini
+++ b/Data/Sys/GameSettings/GO7.ini
@@ -1,0 +1,4 @@
+# GO7F69, GO7D69, GO7E69, GO7S69, GO7P69 - James Bond 007(tm): NightFire(tm)
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GO7.ini
+++ b/Data/Sys/GameSettings/GO7.ini
@@ -1,4 +1,4 @@
 # GO7F69, GO7D69, GO7E69, GO7S69, GO7P69 - James Bond 007(tm): NightFire(tm)
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GON.ini
+++ b/Data/Sys/GameSettings/GON.ini
@@ -1,4 +1,4 @@
 # GONF69, GONP69, GONJ13, GONE69, GOND69 - Medal of Honor: European Assault
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GON.ini
+++ b/Data/Sys/GameSettings/GON.ini
@@ -1,0 +1,4 @@
+# GONF69, GONP69, GONJ13, GONE69, GOND69 - Medal of Honor: European Assault
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GOW.ini
+++ b/Data/Sys/GameSettings/GOW.ini
@@ -2,3 +2,6 @@
 
 [Core]
 JITFollowBranch = False
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GOW.ini
+++ b/Data/Sys/GameSettings/GOW.ini
@@ -4,4 +4,4 @@
 JITFollowBranch = False
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GOY.ini
+++ b/Data/Sys/GameSettings/GOY.ini
@@ -16,4 +16,4 @@
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GOY.ini
+++ b/Data/Sys/GameSettings/GOY.ini
@@ -15,3 +15,5 @@
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GR8.ini
+++ b/Data/Sys/GameSettings/GR8.ini
@@ -1,4 +1,4 @@
 # GR8F69, GRZJ13, GR8E69, GR8P69, GR8D69 - Medal of Honor: Rising Sun
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GR8.ini
+++ b/Data/Sys/GameSettings/GR8.ini
@@ -1,0 +1,4 @@
+# GR8F69, GRZJ13, GR8E69, GR8P69, GR8D69 - Medal of Honor: Rising Sun
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GUG.ini
+++ b/Data/Sys/GameSettings/GUG.ini
@@ -1,4 +1,4 @@
 # GUGP69, GUGF69, GUGD69, GUGE69, G2NJ13 - Need for Speed: Underground 2
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GUG.ini
+++ b/Data/Sys/GameSettings/GUG.ini
@@ -1,0 +1,4 @@
+# GUGP69, GUGF69, GUGD69, GUGE69, G2NJ13 - Need for Speed: Underground 2
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GV4.ini
+++ b/Data/Sys/GameSettings/GV4.ini
@@ -1,4 +1,4 @@
 # GV4E69 - MVP Baseball 2005
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GV4.ini
+++ b/Data/Sys/GameSettings/GV4.ini
@@ -1,0 +1,4 @@
+# GV4E69 - MVP Baseball 2005
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GVL.ini
+++ b/Data/Sys/GameSettings/GVL.ini
@@ -14,4 +14,4 @@ SyncOnSkipIdle = False
 # Add action replay cheats here.
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GVL.ini
+++ b/Data/Sys/GameSettings/GVL.ini
@@ -13,3 +13,5 @@ SyncOnSkipIdle = False
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GW7.ini
+++ b/Data/Sys/GameSettings/GW7.ini
@@ -16,3 +16,4 @@
 
 [Video_Hacks]
 ImmediateXFBEnable = False
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GW7.ini
+++ b/Data/Sys/GameSettings/GW7.ini
@@ -16,4 +16,4 @@
 
 [Video_Hacks]
 ImmediateXFBEnable = False
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GXB.ini
+++ b/Data/Sys/GameSettings/GXB.ini
@@ -14,4 +14,4 @@
 
 [Video_Hacks]
 EFBAccessEnable = False
-
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GXB.ini
+++ b/Data/Sys/GameSettings/GXB.ini
@@ -14,4 +14,4 @@
 
 [Video_Hacks]
 EFBAccessEnable = False
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GXF.ini
+++ b/Data/Sys/GameSettings/GXF.ini
@@ -1,4 +1,4 @@
 # GXFP69, GXFF69, GXFE69, GXFD69, GXFI69, GXFS69 - FIFA Soccer 2004
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GXF.ini
+++ b/Data/Sys/GameSettings/GXF.ini
@@ -1,0 +1,4 @@
+# GXFP69, GXFF69, GXFE69, GXFD69, GXFI69, GXFS69 - FIFA Soccer 2004
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/GXO.ini
+++ b/Data/Sys/GameSettings/GXO.ini
@@ -1,4 +1,4 @@
 # GXOP69, GXOE69, GXOX69, GXOJ13 - SSX on Tour
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/GXO.ini
+++ b/Data/Sys/GameSettings/GXO.ini
@@ -1,0 +1,4 @@
+# GXOP69, GXOE69, GXOX69, GXOJ13 - SSX on Tour
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/R43.ini
+++ b/Data/Sys/GameSettings/R43.ini
@@ -1,0 +1,4 @@
+# R43P69, R43E69, R43J13 - EA Sports Active
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/R43.ini
+++ b/Data/Sys/GameSettings/R43.ini
@@ -1,4 +1,4 @@
 # R43P69, R43E69, R43J13 - EA Sports Active
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/R6T.ini
+++ b/Data/Sys/GameSettings/R6T.ini
@@ -16,4 +16,4 @@
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/R6T.ini
+++ b/Data/Sys/GameSettings/R6T.ini
@@ -14,3 +14,6 @@
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/R7X.ini
+++ b/Data/Sys/GameSettings/R7X.ini
@@ -17,4 +17,4 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
 EFBToTextureEnable = False
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/R7X.ini
+++ b/Data/Sys/GameSettings/R7X.ini
@@ -17,4 +17,4 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
 EFBToTextureEnable = False
-
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RBO.ini
+++ b/Data/Sys/GameSettings/RBO.ini
@@ -20,3 +20,4 @@ ForceFiltering = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RBO.ini
+++ b/Data/Sys/GameSettings/RBO.ini
@@ -20,4 +20,4 @@ ForceFiltering = False
 
 [Video_Hacks]
 ImmediateXFBEnable = False
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/RD2.ini
+++ b/Data/Sys/GameSettings/RD2.ini
@@ -1,4 +1,4 @@
 # RD2X41, RD2J41, RD2P41, RD2K41, RD2E41 - Red Steel 2
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/RD2.ini
+++ b/Data/Sys/GameSettings/RD2.ini
@@ -1,0 +1,4 @@
+# RD2X41, RD2J41, RD2P41, RD2K41, RD2E41 - Red Steel 2
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RD8.ini
+++ b/Data/Sys/GameSettings/RD8.ini
@@ -2,3 +2,6 @@
 
 [Video_Settings]
 SuggestedAspectRatio = 2
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RD8.ini
+++ b/Data/Sys/GameSettings/RD8.ini
@@ -4,4 +4,4 @@
 SuggestedAspectRatio = 2
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/RGF.ini
+++ b/Data/Sys/GameSettings/RGF.ini
@@ -1,0 +1,4 @@
+# RGFE69, RGFF69, RGFI69, RGFS69, RGFP69 - The Godfather: Blackhand Edition
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RGF.ini
+++ b/Data/Sys/GameSettings/RGF.ini
@@ -1,4 +1,4 @@
 # RGFE69, RGFF69, RGFI69, RGFS69, RGFP69 - The Godfather: Blackhand Edition
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/RM2.ini
+++ b/Data/Sys/GameSettings/RM2.ini
@@ -1,4 +1,4 @@
 # RM2E69, RM2X69, RM2J13, RM2P69, RM2U69 - Medal of Honor: Heroes 2
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/RM2.ini
+++ b/Data/Sys/GameSettings/RM2.ini
@@ -1,0 +1,4 @@
+# RM2E69, RM2X69, RM2J13, RM2P69, RM2U69 - Medal of Honor: Heroes 2
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RNP.ini
+++ b/Data/Sys/GameSettings/RNP.ini
@@ -1,4 +1,4 @@
 # RNPP69, RNPY69, RNPX69, RNPJ13, RNPK69, RNPE69 - Need for Speed: ProStreet
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/RNP.ini
+++ b/Data/Sys/GameSettings/RNP.ini
@@ -1,0 +1,4 @@
+# RNPP69, RNPY69, RNPX69, RNPJ13, RNPK69, RNPE69 - Need for Speed: ProStreet
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RSX.ini
+++ b/Data/Sys/GameSettings/RSX.ini
@@ -15,6 +15,5 @@
 [Video_Settings]
 
 [Video_Hacks]
-
-[Video_Hacks]
 ImmediateXFBEnable = False
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RSX.ini
+++ b/Data/Sys/GameSettings/RSX.ini
@@ -16,4 +16,4 @@
 
 [Video_Hacks]
 ImmediateXFBEnable = False
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/RX9.ini
+++ b/Data/Sys/GameSettings/RX9.ini
@@ -1,0 +1,4 @@
+# RX9K69, RX9J13, RX9P69, RX9X69, RX9E69, RX9Y69 - Need for Speed: Undercover
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/RX9.ini
+++ b/Data/Sys/GameSettings/RX9.ini
@@ -1,4 +1,4 @@
 # RX9K69, RX9J13, RX9P69, RX9X69, RX9E69, RX9Y69 - Need for Speed: Undercover
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/SD2.ini
+++ b/Data/Sys/GameSettings/SD2.ini
@@ -18,3 +18,6 @@ SafeTextureCacheColorSamples = 512
 [Video_Enhancements]
 MaxAnisotropy = 0
 ForceFiltering = False
+
+[Video_Hacks]
+TextureLookupEpsilon = 50

--- a/Data/Sys/GameSettings/SDN.ini
+++ b/Data/Sys/GameSettings/SDN.ini
@@ -15,3 +15,6 @@
 [Video_Enhancements]
 MaxAnisotropy = 0
 ForceFiltering = False
+
+[Video_Hacks]
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/SEA.ini
+++ b/Data/Sys/GameSettings/SEA.ini
@@ -19,4 +19,4 @@ SafeTextureCacheColorSamples = 512
 ForceFiltering = False
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/SEA.ini
+++ b/Data/Sys/GameSettings/SEA.ini
@@ -18,3 +18,5 @@ SafeTextureCacheColorSamples = 512
 [Video_Enhancements]
 ForceFiltering = False
 
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/SM7.ini
+++ b/Data/Sys/GameSettings/SM7.ini
@@ -1,4 +1,4 @@
 # SM7E69 - Madden NFL 12
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/SM7.ini
+++ b/Data/Sys/GameSettings/SM7.ini
@@ -1,0 +1,4 @@
+# SM7E69 - Madden NFL 12
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/SNF.ini
+++ b/Data/Sys/GameSettings/SNF.ini
@@ -1,0 +1,4 @@
+# SNFE69 - EA Sports Active: NFL Training Camp
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/SNF.ini
+++ b/Data/Sys/GameSettings/SNF.ini
@@ -1,4 +1,4 @@
 # SNFE69 - EA Sports Active: NFL Training Camp
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Data/Sys/GameSettings/SNH.ini
+++ b/Data/Sys/GameSettings/SNH.ini
@@ -1,0 +1,4 @@
+# SNHP69, SNHJ13, SNHE69 - Need for Speed: Hot Pursuit
+
+[Video_Hacks]
+UseEpsilonDuringTextureLookup = True

--- a/Data/Sys/GameSettings/SNH.ini
+++ b/Data/Sys/GameSettings/SNH.ini
@@ -1,4 +1,4 @@
 # SNHP69, SNHJ13, SNHE69 - Need for Speed: Hot Pursuit
 
 [Video_Hacks]
-UseEpsilonDuringTextureLookup = True
+TextureLookupEpsilon = 25

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -166,6 +166,8 @@ public enum BooleanSetting implements AbstractBooleanSetting
   GFX_HACK_COPY_EFB_SCALED(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS, "EFBScaledCopy", true),
   GFX_HACK_EFB_EMULATE_FORMAT_CHANGES(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS,
           "EFBEmulateFormatChanges", false),
+  GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS,
+          "UseEpsilonDuringTextureLookup", false),
 
   LOGGER_WRITE_TO_FILE(Settings.FILE_LOGGER, Settings.SECTION_LOGGER_OPTIONS, "WriteToFile", false),
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -166,8 +166,6 @@ public enum BooleanSetting implements AbstractBooleanSetting
   GFX_HACK_COPY_EFB_SCALED(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS, "EFBScaledCopy", true),
   GFX_HACK_EFB_EMULATE_FORMAT_CHANGES(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS,
           "EFBEmulateFormatChanges", false),
-  GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS,
-          "UseEpsilonDuringTextureLookup", false),
 
   LOGGER_WRITE_TO_FILE(Settings.FILE_LOGGER, Settings.SECTION_LOGGER_OPTIONS, "WriteToFile", false),
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -53,6 +53,8 @@ public enum IntSetting implements AbstractIntSetting
   GFX_STEREO_DEPTH(Settings.FILE_GFX, Settings.SECTION_STEREOSCOPY, "StereoDepth", 20),
   GFX_STEREO_CONVERGENCE_PERCENTAGE(Settings.FILE_GFX, Settings.SECTION_STEREOSCOPY,
           "StereoConvergencePercentage", 100),
+  GFX_HACK_TEXTURE_LOOKUP_EPSILON(Settings.FILE_GFX, Settings.SECTION_GFX_HACKS,
+          "TextureLookupEpsilon", 0),
 
   LOGGER_VERBOSITY(Settings.FILE_LOGGER, Settings.SECTION_LOGGER_OPTIONS, "Verbosity", 1);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -658,8 +658,8 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(R.string.other, 0));
     sl.add(new CheckBoxSetting(BooleanSetting.GFX_FAST_DEPTH_CALC, R.string.fast_depth_calculation,
             R.string.fast_depth_calculation_description));
-    sl.add(new CheckBoxSetting(BooleanSetting.GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON, R.string.texture_lookup_with_epsilon,
-            R.string.texture_lookup_with_epsilon_description));
+    sl.add(new IntSliderSetting(IntSetting.GFX_HACK_TEXTURE_LOOKUP_EPSILON, R.string.texture_lookup_epsilon,
+            R.string.texture_lookup_epsilon_description, 0, 100, "%"));
   }
 
   private void addLogConfigurationSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -658,6 +658,8 @@ public final class SettingsFragmentPresenter
     sl.add(new HeaderSetting(R.string.other, 0));
     sl.add(new CheckBoxSetting(BooleanSetting.GFX_FAST_DEPTH_CALC, R.string.fast_depth_calculation,
             R.string.fast_depth_calculation_description));
+    sl.add(new CheckBoxSetting(BooleanSetting.GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON, R.string.texture_lookup_with_epsilon,
+            R.string.texture_lookup_with_epsilon_description));
   }
 
   private void addLogConfigurationSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -269,6 +269,8 @@
     <string name="disable_destination_alpha_description">Disables emulation of a hardware feature called destination alpha, which is used in many games for various effects.</string>
     <string name="fast_depth_calculation">Fast Depth Calculation</string>
     <string name="fast_depth_calculation_description">Uses a less accurate algorithm to calculate depth values.</string>
+    <string name="texture_lookup_with_epsilon">Use Epsilon during texture lookup</string>
+    <string name="texture_lookup_with_epsilon_description">Uses Epsilon to work around rounding issue on some GPUs in texture lookup. Fixes texture glitches in some games eg. horizontal/vertical lines in videos. If unsure, leave this unchecked.</string>
     <string name="aspect_ratio">Aspect Ratio</string>
     <string name="aspect_ratio_description">Select what aspect ratio to use when rendering</string>
     <string name="shader_compilation_mode">Shader Compilation Mode</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -269,8 +269,8 @@
     <string name="disable_destination_alpha_description">Disables emulation of a hardware feature called destination alpha, which is used in many games for various effects.</string>
     <string name="fast_depth_calculation">Fast Depth Calculation</string>
     <string name="fast_depth_calculation_description">Uses a less accurate algorithm to calculate depth values.</string>
-    <string name="texture_lookup_with_epsilon">Use Epsilon during texture lookup</string>
-    <string name="texture_lookup_with_epsilon_description">Uses Epsilon to work around rounding issue on some GPUs in texture lookup. Fixes texture glitches in some games eg. horizontal/vertical lines in videos. If unsure, leave this unchecked.</string>
+    <string name="texture_lookup_epsilon">Epsilon in texture lookups</string>
+    <string name="texture_lookup_epsilon_description">Changes the epsilon value used to work around rounding issue on some GPUs in texture lookups. Fixes texture glitches in some games eg. horizontal/vertical lines in videos. Its value should be as low as possible. If unsure, leave the value as 0.</string>
     <string name="aspect_ratio">Aspect Ratio</string>
     <string name="aspect_ratio_description">Select what aspect ratio to use when rendering</string>
     <string name="shader_compilation_mode">Shader Compilation Mode</string>

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -148,8 +148,7 @@ const Info<bool> GFX_HACK_COPY_EFB_SCALED{{System::GFX, "Hacks", "EFBScaledCopy"
 const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{
     {System::GFX, "Hacks", "EFBEmulateFormatChanges"}, false};
 const Info<bool> GFX_HACK_VERTEX_ROUDING{{System::GFX, "Hacks", "VertexRounding"}, false};
-const Info<bool> GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON{
-    {System::GFX, "Hacks", "UseEpsilonDuringTextureLookup"}, false};
+const Info<int> GFX_HACK_TEXTURE_LOOKUP_EPSILON{{System::GFX, "Hacks", "TextureLookupEpsilon"}, 0};
 
 // Graphics.GameSpecific
 

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -148,6 +148,8 @@ const Info<bool> GFX_HACK_COPY_EFB_SCALED{{System::GFX, "Hacks", "EFBScaledCopy"
 const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES{
     {System::GFX, "Hacks", "EFBEmulateFormatChanges"}, false};
 const Info<bool> GFX_HACK_VERTEX_ROUDING{{System::GFX, "Hacks", "VertexRounding"}, false};
+const Info<bool> GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON{
+    {System::GFX, "Hacks", "UseEpsilonDuringTextureLookup"}, false};
 
 // Graphics.GameSpecific
 

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -122,7 +122,7 @@ extern const Info<bool> GFX_HACK_SKIP_DUPLICATE_XFBS;
 extern const Info<bool> GFX_HACK_COPY_EFB_SCALED;
 extern const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;
 extern const Info<bool> GFX_HACK_VERTEX_ROUDING;
-extern const Info<bool> GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON;
+extern const Info<int> GFX_HACK_TEXTURE_LOOKUP_EPSILON;
 
 // Graphics.GameSpecific
 

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -122,6 +122,7 @@ extern const Info<bool> GFX_HACK_SKIP_DUPLICATE_XFBS;
 extern const Info<bool> GFX_HACK_COPY_EFB_SCALED;
 extern const Info<bool> GFX_HACK_EFB_EMULATE_FORMAT_CHANGES;
 extern const Info<bool> GFX_HACK_VERTEX_ROUDING;
+extern const Info<bool> GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON;
 
 // Graphics.GameSpecific
 

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -73,6 +73,8 @@ public:
     if (m_settings.m_StrictSettingsSync)
     {
       layer->Set(Config::GFX_HACK_VERTEX_ROUDING, m_settings.m_VertexRounding);
+      layer->Set(Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON,
+                 m_settings.m_TextureLookupWithEpsilon);
       layer->Set(Config::GFX_EFB_SCALE, m_settings.m_InternalResolution);
       layer->Set(Config::GFX_HACK_COPY_EFB_SCALED, m_settings.m_EFBScaledCopy);
       layer->Set(Config::GFX_FAST_DEPTH_CALC, m_settings.m_FastDepthCalc);

--- a/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/NetPlayConfigLoader.cpp
@@ -73,8 +73,7 @@ public:
     if (m_settings.m_StrictSettingsSync)
     {
       layer->Set(Config::GFX_HACK_VERTEX_ROUDING, m_settings.m_VertexRounding);
-      layer->Set(Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON,
-                 m_settings.m_TextureLookupWithEpsilon);
+      layer->Set(Config::GFX_HACK_TEXTURE_LOOKUP_EPSILON, m_settings.m_TextureLookupEpsilon);
       layer->Set(Config::GFX_EFB_SCALE, m_settings.m_InternalResolution);
       layer->Set(Config::GFX_HACK_COPY_EFB_SCALED, m_settings.m_EFBScaledCopy);
       layer->Set(Config::GFX_FAST_DEPTH_CALC, m_settings.m_FastDepthCalc);

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -694,6 +694,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_SkipIPL;
       packet >> m_net_settings.m_LoadIPLDump;
       packet >> m_net_settings.m_VertexRounding;
+      packet >> m_net_settings.m_TextureLookupWithEpsilon;
       packet >> m_net_settings.m_InternalResolution;
       packet >> m_net_settings.m_EFBScaledCopy;
       packet >> m_net_settings.m_FastDepthCalc;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -694,7 +694,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       packet >> m_net_settings.m_SkipIPL;
       packet >> m_net_settings.m_LoadIPLDump;
       packet >> m_net_settings.m_VertexRounding;
-      packet >> m_net_settings.m_TextureLookupWithEpsilon;
+      packet >> m_net_settings.m_TextureLookupEpsilon;
       packet >> m_net_settings.m_InternalResolution;
       packet >> m_net_settings.m_EFBScaledCopy;
       packet >> m_net_settings.m_FastDepthCalc;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -60,7 +60,7 @@ struct NetSettings
   bool m_SkipIPL;
   bool m_LoadIPLDump;
   bool m_VertexRounding;
-  bool m_TextureLookupWithEpsilon;
+  int m_TextureLookupEpsilon;
   int m_InternalResolution;
   bool m_EFBScaledCopy;
   bool m_FastDepthCalc;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -60,6 +60,7 @@ struct NetSettings
   bool m_SkipIPL;
   bool m_LoadIPLDump;
   bool m_VertexRounding;
+  bool m_TextureLookupWithEpsilon;
   int m_InternalResolution;
   bool m_EFBScaledCopy;
   bool m_FastDepthCalc;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1339,7 +1339,7 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_SkipIPL;
   spac << m_settings.m_LoadIPLDump;
   spac << m_settings.m_VertexRounding;
-  spac << m_settings.m_TextureLookupWithEpsilon;
+  spac << m_settings.m_TextureLookupEpsilon;
   spac << m_settings.m_InternalResolution;
   spac << m_settings.m_EFBScaledCopy;
   spac << m_settings.m_FastDepthCalc;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -1339,6 +1339,7 @@ bool NetPlayServer::StartGame()
   spac << m_settings.m_SkipIPL;
   spac << m_settings.m_LoadIPLDump;
   spac << m_settings.m_VertexRounding;
+  spac << m_settings.m_TextureLookupWithEpsilon;
   spac << m_settings.m_InternalResolution;
   spac << m_settings.m_EFBScaledCopy;
   spac << m_settings.m_FastDepthCalc;

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -105,13 +105,16 @@ void HacksWidget::CreateWidgets()
   m_disable_bounding_box =
       new GraphicsBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, true);
   m_vertex_rounding = new GraphicsBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUDING);
+  m_texture_lookup_with_epsilon = new GraphicsBool(tr("Use Epsilon during texture lookup"),
+                                                   Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON);
   m_save_texture_cache_state =
       new GraphicsBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
 
   other_layout->addWidget(m_fast_depth_calculation, 0, 0);
   other_layout->addWidget(m_disable_bounding_box, 0, 1);
   other_layout->addWidget(m_vertex_rounding, 1, 0);
-  other_layout->addWidget(m_save_texture_cache_state, 1, 1);
+  other_layout->addWidget(m_texture_lookup_with_epsilon, 1, 1);
+  other_layout->addWidget(m_save_texture_cache_state, 2, 0);
 
   main_layout->addWidget(efb_box);
   main_layout->addWidget(texture_cache_box);
@@ -277,6 +280,10 @@ void HacksWidget::AddDescriptions()
       "higher internal resolutions. This setting has no effect when native internal "
       "resolution is used.<br><br><dolphin_emphasis>If unsure, leave this "
       "unchecked.</dolphin_emphasis>");
+  static const char TR_TEXTURE_LOOKUP_WITH_EPSILON_DESCRIPTION[] = QT_TR_NOOP(
+      "Uses Epsilon to work around rounding issue on some GPUs in texture lookup.<br><br>"
+      "Fixes texture glitches in some games eg. horizontal/vertical lines in videos.<br><br>"
+      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
 
   m_skip_efb_cpu->SetDescription(tr(TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION));
   m_ignore_format_changes->SetDescription(tr(TR_IGNORE_FORMAT_CHANGE_DESCRIPTION));
@@ -289,6 +296,7 @@ void HacksWidget::AddDescriptions()
   m_skip_duplicate_xfbs->SetDescription(tr(TR_SKIP_DUPLICATE_XFBS_DESCRIPTION));
   m_gpu_texture_decoding->SetDescription(tr(TR_GPU_DECODING_DESCRIPTION));
   m_fast_depth_calculation->SetDescription(tr(TR_FAST_DEPTH_CALC_DESCRIPTION));
+  m_texture_lookup_with_epsilon->SetDescription(tr(TR_TEXTURE_LOOKUP_WITH_EPSILON_DESCRIPTION));
   m_disable_bounding_box->SetDescription(tr(TR_DISABLE_BOUNDINGBOX_DESCRIPTION));
   m_save_texture_cache_state->SetDescription(tr(TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION));
   m_vertex_rounding->SetDescription(tr(TR_VERTEX_ROUNDING_DESCRIPTION));

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.cpp
@@ -105,16 +105,16 @@ void HacksWidget::CreateWidgets()
   m_disable_bounding_box =
       new GraphicsBool(tr("Disable Bounding Box"), Config::GFX_HACK_BBOX_ENABLE, true);
   m_vertex_rounding = new GraphicsBool(tr("Vertex Rounding"), Config::GFX_HACK_VERTEX_ROUDING);
-  m_texture_lookup_with_epsilon = new GraphicsBool(tr("Use Epsilon during texture lookup"),
-                                                   Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON);
   m_save_texture_cache_state =
       new GraphicsBool(tr("Save Texture Cache to State"), Config::GFX_SAVE_TEXTURE_CACHE_TO_STATE);
+  m_texture_lookup_epsilon = new GraphicsSlider(0, 100, Config::GFX_HACK_TEXTURE_LOOKUP_EPSILON);
 
   other_layout->addWidget(m_fast_depth_calculation, 0, 0);
   other_layout->addWidget(m_disable_bounding_box, 0, 1);
   other_layout->addWidget(m_vertex_rounding, 1, 0);
-  other_layout->addWidget(m_texture_lookup_with_epsilon, 1, 1);
-  other_layout->addWidget(m_save_texture_cache_state, 2, 0);
+  other_layout->addWidget(m_save_texture_cache_state, 1, 1);
+  other_layout->addWidget(new QLabel(tr("Epsilon in texture lookups:")), 2, 0);
+  other_layout->addWidget(m_texture_lookup_epsilon, 2, 1);
 
   main_layout->addWidget(efb_box);
   main_layout->addWidget(texture_cache_box);
@@ -280,10 +280,12 @@ void HacksWidget::AddDescriptions()
       "higher internal resolutions. This setting has no effect when native internal "
       "resolution is used.<br><br><dolphin_emphasis>If unsure, leave this "
       "unchecked.</dolphin_emphasis>");
-  static const char TR_TEXTURE_LOOKUP_WITH_EPSILON_DESCRIPTION[] = QT_TR_NOOP(
-      "Uses Epsilon to work around rounding issue on some GPUs in texture lookup.<br><br>"
-      "Fixes texture glitches in some games eg. horizontal/vertical lines in videos.<br><br>"
-      "<dolphin_emphasis>If unsure, leave this unchecked.</dolphin_emphasis>");
+  static const char TR_TEXTURE_LOOKUP_EPSILON_DESCRIPTION[] =
+      QT_TR_NOOP("Changes the epsilon value used to work around "
+                 "rounding issue on some GPUs in texture lookups.<br><br>"
+                 "Fixes texture glitches in some games eg. horizontal/vertical lines in videos. "
+                 "Its value should be as low as possible.<br><br>"
+                 "<dolphin_emphasis>If unsure, leave the value as 0.</dolphin_emphasis>");
 
   m_skip_efb_cpu->SetDescription(tr(TR_SKIP_EFB_CPU_ACCESS_DESCRIPTION));
   m_ignore_format_changes->SetDescription(tr(TR_IGNORE_FORMAT_CHANGE_DESCRIPTION));
@@ -296,10 +298,11 @@ void HacksWidget::AddDescriptions()
   m_skip_duplicate_xfbs->SetDescription(tr(TR_SKIP_DUPLICATE_XFBS_DESCRIPTION));
   m_gpu_texture_decoding->SetDescription(tr(TR_GPU_DECODING_DESCRIPTION));
   m_fast_depth_calculation->SetDescription(tr(TR_FAST_DEPTH_CALC_DESCRIPTION));
-  m_texture_lookup_with_epsilon->SetDescription(tr(TR_TEXTURE_LOOKUP_WITH_EPSILON_DESCRIPTION));
   m_disable_bounding_box->SetDescription(tr(TR_DISABLE_BOUNDINGBOX_DESCRIPTION));
   m_save_texture_cache_state->SetDescription(tr(TR_SAVE_TEXTURE_CACHE_TO_STATE_DESCRIPTION));
   m_vertex_rounding->SetDescription(tr(TR_VERTEX_ROUNDING_DESCRIPTION));
+  m_texture_lookup_epsilon->SetTitle(tr("Epsilon in texture lookups"));
+  m_texture_lookup_epsilon->SetDescription(tr(TR_TEXTURE_LOOKUP_EPSILON_DESCRIPTION));
 }
 
 void HacksWidget::UpdateDeferEFBCopiesEnabled()

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -7,6 +7,7 @@
 #include "DolphinQt/Config/Graphics/GraphicsWidget.h"
 
 class GraphicsBool;
+class GraphicsSlider;
 class GraphicsWindow;
 class QLabel;
 class ToolTipSlider;
@@ -42,7 +43,7 @@ private:
   GraphicsBool* m_fast_depth_calculation;
   GraphicsBool* m_disable_bounding_box;
   GraphicsBool* m_vertex_rounding;
-  GraphicsBool* m_texture_lookup_with_epsilon;
+  GraphicsSlider* m_texture_lookup_epsilon;
   GraphicsBool* m_save_texture_cache_state;
   GraphicsBool* m_defer_efb_copies;
 

--- a/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/HacksWidget.h
@@ -42,6 +42,7 @@ private:
   GraphicsBool* m_fast_depth_calculation;
   GraphicsBool* m_disable_bounding_box;
   GraphicsBool* m_vertex_rounding;
+  GraphicsBool* m_texture_lookup_with_epsilon;
   GraphicsBool* m_save_texture_cache_state;
   GraphicsBool* m_defer_efb_copies;
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -486,7 +486,7 @@ void NetPlayDialog::OnStart()
   settings.m_LoadIPLDump = Config::Get(Config::MAIN_LOAD_IPL_DUMP) &&
                            Settings::Instance().GetNetPlayServer()->DoAllPlayersHaveIPLDump();
   settings.m_VertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
-  settings.m_TextureLookupWithEpsilon = Config::Get(Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON);
+  settings.m_TextureLookupEpsilon = Config::Get(Config::GFX_HACK_TEXTURE_LOOKUP_EPSILON);
   settings.m_InternalResolution = Config::Get(Config::GFX_EFB_SCALE);
   settings.m_EFBScaledCopy = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   settings.m_FastDepthCalc = Config::Get(Config::GFX_FAST_DEPTH_CALC);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -486,6 +486,7 @@ void NetPlayDialog::OnStart()
   settings.m_LoadIPLDump = Config::Get(Config::MAIN_LOAD_IPL_DUMP) &&
                            Settings::Instance().GetNetPlayServer()->DoAllPlayersHaveIPLDump();
   settings.m_VertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
+  settings.m_TextureLookupWithEpsilon = Config::Get(Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON);
   settings.m_InternalResolution = Config::Get(Config::GFX_EFB_SCALE);
   settings.m_EFBScaledCopy = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   settings.m_FastDepthCalc = Config::Get(Config::GFX_FAST_DEPTH_CALC);

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -61,6 +61,9 @@ struct pixel_shader_uid_data
   u32 tevindref_bi4 : 3;
   u32 tevindref_bc4 : 3;
 
+  u32 epsilon_hack : 7;
+  u32 pad1 : 25;
+
   void SetTevindrefValues(int index, u32 texcoord, u32 texmap)
   {
     if (index == 0)
@@ -137,8 +140,7 @@ struct pixel_shader_uid_data
     u32 tevorders_texcoord : 3;
     u32 tevorders_enable : 1;
     u32 tevorders_colorchan : 3;
-    u32 epsilon_hack : 1;
-    u32 pad1 : 5;
+    u32 pad1 : 6;
 
     // TODO: Clean up the swapXY mess
     u32 hasindstage : 1;

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -137,7 +137,8 @@ struct pixel_shader_uid_data
     u32 tevorders_texcoord : 3;
     u32 tevorders_enable : 1;
     u32 tevorders_colorchan : 3;
-    u32 pad1 : 6;
+    u32 epsilon_hack : 1;
+    u32 pad1 : 5;
 
     // TODO: Clean up the swapXY mess
     u32 hasindstage : 1;

--- a/Source/Core/VideoCommon/UberShaderPixel.cpp
+++ b/Source/Core/VideoCommon/UberShaderPixel.cpp
@@ -31,7 +31,7 @@ PixelShaderUid GetPixelShaderUid()
       (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !uid_data->early_depth) ||
       (bpmem.zmode.testenable && bpmem.genMode.zfreeze);
   uid_data->uint_output = bpmem.blendmode.UseLogicOp();
-  uid_data->epsilon_hack = g_ActiveConfig.bTextureLookupWithEpsilon;
+  uid_data->epsilon_hack = g_ActiveConfig.iTextureLookupEpsilon;
 
   return out;
 }
@@ -61,7 +61,7 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
   const bool per_pixel_depth = uid_data->per_pixel_depth != 0;
   const bool bounding_box = host_config.bounding_box;
   const u32 numTexgen = uid_data->num_texgens;
-  const bool epsilonHack = uid_data->epsilon_hack != 0;
+  const u32 epsilonHack = uid_data->epsilon_hack;
   ShaderCode out;
 
   out.Write("// Pixel UberShader for {} texgens{}{}\n", numTexgen,
@@ -901,11 +901,11 @@ ShaderCode GenPixelShader(APIType ApiType, const ShaderHostConfig& host_config,
     out.Write("\n"
               "      float2 uv = ");
 
-    // Hack: When enabled, it uses a small Epsilon to work around
+    // Hack: When set, it uses a small Epsilon to work around
     // the rounding issue on some GPUs in texture lookups.
     // Fixes texture glitches in some games eg. horizontal/vertical lines in videos.
     // The correct solution would be to integerize texture lookups, but it would be much slower.
-    out.Write(epsilonHack ? "(float2(tevcoord.xy) + 0.25)" : "(float2(tevcoord.xy))");
+    out.Write("(float2(tevcoord.xy) + {})", (float)epsilonHack / 100.0);
 
     out.Write("* " I_TEXDIMS "[sampler_num].xy;\n");
     out.Write("      int4 color = sampleTexture(sampler_num, float3(uv, {}));\n",

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -19,6 +19,7 @@ struct pixel_ubershader_uid_data
   u32 early_depth : 1;
   u32 per_pixel_depth : 1;
   u32 uint_output : 1;
+  u32 epsilon_hack : 1;
 
   u32 NumValues() const { return sizeof(pixel_ubershader_uid_data); }
 };

--- a/Source/Core/VideoCommon/UberShaderPixel.h
+++ b/Source/Core/VideoCommon/UberShaderPixel.h
@@ -19,7 +19,7 @@ struct pixel_ubershader_uid_data
   u32 early_depth : 1;
   u32 per_pixel_depth : 1;
   u32 uint_output : 1;
-  u32 epsilon_hack : 1;
+  u32 epsilon_hack : 7;
 
   u32 NumValues() const { return sizeof(pixel_ubershader_uid_data); }
 };

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -157,6 +157,7 @@ void VideoConfig::Refresh()
   bCopyEFBScaled = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
   bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
+  bTextureLookupWithEpsilon = Config::Get(Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON);
   iEFBAccessTileSize = Config::Get(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE);
 
   bPerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -157,7 +157,7 @@ void VideoConfig::Refresh()
   bCopyEFBScaled = Config::Get(Config::GFX_HACK_COPY_EFB_SCALED);
   bEFBEmulateFormatChanges = Config::Get(Config::GFX_HACK_EFB_EMULATE_FORMAT_CHANGES);
   bVertexRounding = Config::Get(Config::GFX_HACK_VERTEX_ROUDING);
-  bTextureLookupWithEpsilon = Config::Get(Config::GFX_HACK_TEXTURE_LOOKUP_WITH_EPSILON);
+  iTextureLookupEpsilon = Config::Get(Config::GFX_HACK_TEXTURE_LOOKUP_EPSILON);
   iEFBAccessTileSize = Config::Get(Config::GFX_HACK_EFB_ACCESS_TILE_SIZE);
 
   bPerfQueriesEnable = Config::Get(Config::GFX_PERF_QUERIES_ENABLE);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -132,7 +132,7 @@ struct VideoConfig final
   bool bEnablePixelLighting;
   bool bFastDepthCalc;
   bool bVertexRounding;
-  bool bTextureLookupWithEpsilon;
+  int iTextureLookupEpsilon;
   int iEFBAccessTileSize;
   int iLog;           // CONF_ bits
   int iSaveTargetId;  // TODO: Should be dropped

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -132,6 +132,7 @@ struct VideoConfig final
   bool bEnablePixelLighting;
   bool bFastDepthCalc;
   bool bVertexRounding;
+  bool bTextureLookupWithEpsilon;
   int iEFBAccessTileSize;
   int iLog;           // CONF_ bits
   int iSaveTargetId;  // TODO: Should be dropped


### PR DESCRIPTION
It is based on the solution (hack) proposed by @endrift in https://github.com/dolphin-emu/dolphin/pull/3807. It fixes [the issue with VP6 videos](https://bugs.dolphin-emu.org/issues/7193) and possibly some others.

Since it's not a perfect solution, I added it as a togglable hack. As mentioned in the original PR, an ideal solution to this problem would be to integerize texture lookups, but it would be much slower. I added a comment about it in the shader code. I also updated the game settings files accordingly, based on [this wiki page](https://wiki.dolphin-emu.org/index.php?title=File:GW7E69_intro_vertlines.jpg).

I tested it with the GTX 1080 ti on Windows (drivers version 460.89) and with the Mali-G71 on Android 9 (Galaxy S8+) in several games.