### PR TITLE
SSL: Workaround to remove SNI from ClientHello

### DIFF
--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -74,8 +74,8 @@ struct WII_SSL
   mbedtls_x509_crt cacert;
   mbedtls_x509_crt clicert;
   mbedtls_pk_context pk;
-  int sockfd;
-  int hostfd;
+  int sockfd = -1;
+  int hostfd = -1;
   std::string hostname;
   bool active;
 };

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -457,14 +457,14 @@ void WiiSocket::Update(bool read, bool write, bool except)
           }
           case IOCTLV_NET_SSL_WRITE:
           {
-            int ret = mbedtls_ssl_write(&Device::NetSSL::_SSL[sslID].ctx,
-                                        Memory::GetPointer(BufferOut2), BufferOutSize2);
+            WII_SSL* ssl = &Device::NetSSL::_SSL[sslID];
+            const int ret =
+                mbedtls_ssl_write(&ssl->ctx, Memory::GetPointer(BufferOut2), BufferOutSize2);
 
             if (ret >= 0)
             {
-              PowerPC::debug_interface.NetworkLogger()->LogSSLWrite(
-                  Memory::GetPointer(BufferOut2), ret,
-                  static_cast<mbedtls_net_context*>(Device::NetSSL::_SSL[sslID].ctx.p_bio)->fd);
+              PowerPC::debug_interface.NetworkLogger()->LogSSLWrite(Memory::GetPointer(BufferOut2),
+                                                                    ret, ssl->hostfd);
               // Return bytes written or SSL_ERR_ZERO if none
               WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }
@@ -491,14 +491,14 @@ void WiiSocket::Update(bool read, bool write, bool except)
           }
           case IOCTLV_NET_SSL_READ:
           {
-            int ret = mbedtls_ssl_read(&Device::NetSSL::_SSL[sslID].ctx,
-                                       Memory::GetPointer(BufferIn2), BufferInSize2);
+            WII_SSL* ssl = &Device::NetSSL::_SSL[sslID];
+            const int ret =
+                mbedtls_ssl_read(&ssl->ctx, Memory::GetPointer(BufferIn2), BufferInSize2);
 
             if (ret >= 0)
             {
-              PowerPC::debug_interface.NetworkLogger()->LogSSLRead(
-                  Memory::GetPointer(BufferIn2), ret,
-                  static_cast<mbedtls_net_context*>(Device::NetSSL::_SSL[sslID].ctx.p_bio)->fd);
+              PowerPC::debug_interface.NetworkLogger()->LogSSLRead(Memory::GetPointer(BufferIn2),
+                                                                   ret, ssl->hostfd);
               // Return bytes read or SSL_ERR_ZERO if none
               WriteReturnValue((ret == 0) ? SSL_ERR_ZERO : ret, BufferIn);
             }

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -241,11 +241,9 @@ void NetworkWidget::Update()
   {
     m_ssl_table->insertRow(ssl_id);
     s32 host_fd = -1;
-    if (IOS::HLE::Device::IsSSLIDValid(ssl_id) &&
-        IOS::HLE::Device::NetSSL::_SSL[ssl_id].ctx.p_bio != nullptr)
+    if (IOS::HLE::Device::IsSSLIDValid(ssl_id))
     {
-      host_fd =
-          static_cast<mbedtls_net_context*>(IOS::HLE::Device::NetSSL::_SSL[ssl_id].ctx.p_bio)->fd;
+      host_fd = IOS::HLE::Device::NetSSL::_SSL[ssl_id].hostfd;
     }
     m_ssl_table->setItem(ssl_id, 0, new QTableWidgetItem(QString::number(ssl_id)));
     m_ssl_table->setItem(ssl_id, 1, GetSocketDomain(host_fd));


### PR DESCRIPTION
This PR is a **dirty** workaround to remove the SNI extension from ClientHello. This PR is an alternative to https://github.com/dolphin-emu/dolphin/pull/9406.

It does that by using the only hook that I could find that can be used between handshake steps (see `mbedtls_ssl_handshake_step`). My approach uses the send callback called in `mbedtls_ssl_flush_output` at the beginning of each handshake step. I delayed `mbedtls_ssl_set_hostname` after the client hello as the hostname is needed during the common name verification when connecting to an IP address.

This PR needs testing to be sure there isn't any regression introduced and that there isn't a better way to achieve this goal