### PR TITLE
Arm64Emitter: Remove unused OpType enum

### DIFF
--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -277,15 +277,6 @@ constexpr ARM64Reg EncodeRegToQuad(ARM64Reg reg)
   return static_cast<ARM64Reg>(reg | 0xC0);
 }
 
-enum OpType
-{
-  TYPE_IMM = 0,
-  TYPE_REG,
-  TYPE_IMMSREG,
-  TYPE_RSR,
-  TYPE_MEM
-};
-
 enum ShiftType
 {
   ST_LSL = 0,


### PR DESCRIPTION
This isn't used anywhere, so we can remove it.