### PR TITLE
Arm64Emitter: Improve MOVI2R

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -2004,7 +2004,7 @@ void ARM64XEmitter::ADRP(ARM64Reg Rd, s32 imm)
 }
 
 // Wrapper around MOVZ+MOVK (and later MOVN)
-void ARM64XEmitter::MOVI2R(ARM64Reg Rd, u64 imm, bool optimize)
+void ARM64XEmitter::MOVI2R(ARM64Reg Rd, u64 imm)
 {
   unsigned int parts = Is64Bit(Rd) ? 4 : 2;
   BitSet32 upload_part(0);
@@ -2041,13 +2041,10 @@ void ARM64XEmitter::MOVI2R(ARM64Reg Rd, u64 imm, bool optimize)
   // XXX: Use MOVN when possible.
   // XXX: Optimize more
   // XXX: Support rotating immediates to save instructions
-  if (optimize)
+  for (unsigned int i = 0; i < parts; ++i)
   {
-    for (unsigned int i = 0; i < parts; ++i)
-    {
-      if ((imm >> (i * 16)) & 0xFFFF)
-        upload_part[i] = 1;
-    }
+    if ((imm >> (i * 16)) & 0xFFFF)
+      upload_part[i] = 1;
   }
 
   u64 aligned_pc = (u64)GetCodePtr() & ~0xFFF;
@@ -2090,7 +2087,7 @@ void ARM64XEmitter::MOVI2R(ARM64Reg Rd, u64 imm, bool optimize)
     }
     else
     {
-      if (upload_part[i] || !optimize)
+      if (upload_part[i])
         MOVK(Rd, (imm >> (i * 16)) & 0xFFFF, (ShiftAmount)i);
     }
   }

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1998,9 +1998,9 @@ void ARM64XEmitter::ADR(ARM64Reg Rd, s32 imm)
 {
   EncodeAddressInst(0, Rd, imm);
 }
-void ARM64XEmitter::ADRP(ARM64Reg Rd, s32 imm)
+void ARM64XEmitter::ADRP(ARM64Reg Rd, s64 imm)
 {
-  EncodeAddressInst(1, Rd, imm >> 12);
+  EncodeAddressInst(1, Rd, static_cast<s32>(imm >> 12));
 }
 
 // Wrapper around MOVZ+MOVK (and later MOVN)

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -862,7 +862,7 @@ public:
 
   // Address of label/page PC-relative
   void ADR(ARM64Reg Rd, s32 imm);
-  void ADRP(ARM64Reg Rd, s32 imm);
+  void ADRP(ARM64Reg Rd, s64 imm);
 
   // Wrapper around MOVZ+MOVK
   void MOVI2R(ARM64Reg Rd, u64 imm);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -896,13 +896,13 @@ public:
   void SUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch = INVALID_REG);
   void SUBSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch = INVALID_REG);
 
-  bool TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-  bool TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-  bool TryCMPI2R(ARM64Reg Rn, u32 imm);
+  bool TryADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+  bool TrySUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+  bool TryCMPI2R(ARM64Reg Rn, u64 imm);
 
-  bool TryANDI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-  bool TryORRI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
-  bool TryEORI2R(ARM64Reg Rd, ARM64Reg Rn, u32 imm);
+  bool TryANDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+  bool TryORRI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
+  bool TryEORI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm);
 
   // ABI related
   void ABI_PushRegisters(BitSet32 registers);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -865,7 +865,7 @@ public:
   void ADRP(ARM64Reg Rd, s32 imm);
 
   // Wrapper around MOVZ+MOVK
-  void MOVI2R(ARM64Reg Rd, u64 imm, bool optimize = true);
+  void MOVI2R(ARM64Reg Rd, u64 imm);
   bool MOVI2R2(ARM64Reg Rd, u64 imm1, u64 imm2);
   template <class P>
   void MOVP2R(ARM64Reg Rd, P* ptr)

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -521,6 +521,9 @@ private:
   void EncodeAddressInst(u32 op, ARM64Reg Rd, s32 imm);
   void EncodeLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm);
 
+  template <typename T>
+  void MOVI2RImpl(ARM64Reg Rd, T imm);
+
 protected:
   void Write32(u32 value);
 
@@ -864,7 +867,7 @@ public:
   void ADR(ARM64Reg Rd, s32 imm);
   void ADRP(ARM64Reg Rd, s64 imm);
 
-  // Wrapper around MOVZ+MOVK
+  // Wrapper around ADR/ADRP/MOVZ/MOVN/MOVK
   void MOVI2R(ARM64Reg Rd, u64 imm);
   bool MOVI2R2(ARM64Reg Rd, u64 imm1, u64 imm2);
   template <class P>

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -912,7 +912,7 @@ void JitArm64::subfex(UGeckoInstruction inst)
     ARM64Reg WA = gpr.GetReg();
     if (js.carryFlagSet)
     {
-      MOVI2R(WA, ~i + j, gpr.R(d));
+      MOVI2R(WA, ~i + j);
       ADC(gpr.R(d), WA, WZR);
     }
     else

--- a/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/MovI2R.cpp
@@ -78,10 +78,22 @@ TEST(JitArm64, MovI2R_ADP)
 {
   TestMovI2R test;
   const u64 base = Common::BitCast<u64>(test.GetCodePtr());
+
+  // Test offsets around 0
   for (s64 i = -0x20000; i < 0x20000; i++)
   {
     const u64 offset = static_cast<u64>(i);
     test.Check64(base + offset);
+  }
+
+  // Test offsets around the maximum
+  for (const s64 i : {-0x200000ll, 0x200000ll})
+  {
+    for (s64 j = -4; j < 4; j++)
+    {
+      const u64 offset = static_cast<u64>(i + j);
+      test.Check64(base + offset);
+    }
   }
 }
 
@@ -89,9 +101,21 @@ TEST(JitArm64, MovI2R_ADRP)
 {
   TestMovI2R test;
   const u64 base = Common::BitCast<u64>(test.GetCodePtr()) & ~0xFFF;
+
+  // Test offsets around 0
   for (s64 i = -0x20000; i < 0x20000; i++)
   {
     const u64 offset = static_cast<u64>(i) << 12;
     test.Check64(base + offset);
+  }
+
+  // Test offsets around the maximum
+  for (const s64 i : {-0x100000000ll, -0x80000000ll, 0x80000000ll, 0x100000000ll})
+  {
+    for (s64 j = -4; j < 4; j++)
+    {
+      const u64 offset = static_cast<u64>(i + (j << 12));
+      test.Check64(base + offset);
+    }
   }
 }

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -78,6 +78,9 @@
     <ClCompile Include="Core\PowerPC\Jit64Common\ConvertDoubleToSingle.cpp" />
     <ClCompile Include="Core\PowerPC\Jit64Common\Frsqrte.cpp" />
   </ItemGroup>
+  <ItemGroup Condition="'$(Platform)'=='ARM64'">
+    <ClCompile Include="Core\PowerPC\JitArm64\MovI2R.cpp" />
+  </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />
   </ItemGroup>


### PR DESCRIPTION
More or less a complete rewrite of the function which aims to be equally good or better for each given input, without relying on special cases like the old implementation did.

In particular, we now have more extensive support for MOVN, as mentioned in a TODO comment.