### PR TITLE
GraphicsSettings: Parallelize Shader Pre-Compilation

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -86,7 +86,8 @@ const Info<ShaderCompilationMode> GFX_SHADER_COMPILATION_MODE{
     {System::GFX, "Settings", "ShaderCompilationMode"}, ShaderCompilationMode::Synchronous};
 const Info<int> GFX_SHADER_COMPILER_THREADS{{System::GFX, "Settings", "ShaderCompilerThreads"}, 1};
 const Info<int> GFX_SHADER_PRECOMPILER_THREADS{
-    {System::GFX, "Settings", "ShaderPrecompilerThreads"}, 1};
+    {System::GFX, "Settings", "ShaderPrecompilerThreads"},
+    std::max(std::thread::hardware_concurrency(), 1u)};
 const Info<bool> GFX_SAVE_TEXTURE_CACHE_TO_STATE{
     {System::GFX, "Settings", "SaveTextureCacheToState"}, true};
 


### PR DESCRIPTION
While running Dolphin with asynchronous UberShader's on a friends computer (on a 8 core CPU) I noticed that the shader pre-compilation only used what looked like 1-2 threads. 

So I investigated Dolphin's source code and found out that the full infrastructure for parallel shader precompilation is already there. Further investigation then revealed that the default value is actually set to 1 with no GUI option to change that.

However, this precompilation is an actual loading time which can take anywhere from 10s to several minutes on most machines and not having it will drastically lower the FPS in some titles.

So this PR suggests to set the default thread count for this pre-compilation to the amount of logical threads supported by the CPU.

Potential Questions:

1. Is it ok for a GraphicSettings default value to be a runtime constant? (i.e. `std::thread::hardware_concurrency()` in this case)
2. Should I add a comment to explain why the max reduction with 1 is there? (`hardware_concurrency()` returns 0 on error)