### PR TITLE
Fix cursor going to +infinite if the window size was 0

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -126,9 +126,9 @@ void KeyboardMouse::UpdateCursorInput()
   RECT rect;
   GetClientRect(m_hwnd, &rect);
 
-  // Width and height are the size of the rendering window.
-  const auto win_width = rect.right - rect.left;
-  const auto win_height = rect.bottom - rect.top;
+  // Width and height are the size of the rendering window. They could be 0
+  const auto win_width = std::max(rect.right - rect.left, 1l);
+  const auto win_height = std::max(rect.bottom - rect.top, 1l);
 
   const auto window_scale = g_controller_interface.GetWindowInputScale();
 

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -188,8 +188,8 @@ void KeyboardAndMouse::UpdateInput()
 
   loc.x -= bounds.origin.x;
   loc.y -= bounds.origin.y;
-  m_cursor.x = (loc.x / bounds.size.width * 2 - 1.0) * window_scale.x;
-  m_cursor.y = (loc.y / bounds.size.height * 2 - 1.0) * window_scale.y;
+  m_cursor.x = (loc.x / std::max(bounds.size.width, 1.0) * 2 - 1.0) * window_scale.x;
+  m_cursor.y = (loc.y / std::max(bounds.size.height, 1.0) * 2 - 1.0) * window_scale.y;
 }
 
 std::string KeyboardAndMouse::GetName() const

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -227,8 +227,8 @@ void KeyboardMouse::UpdateCursor()
   const auto window_scale = g_controller_interface.GetWindowInputScale();
 
   // the mouse position as a range from -1 to 1
-  m_state.cursor.x = (win_x / win_attribs.width * 2 - 1) * window_scale.x;
-  m_state.cursor.y = (win_y / win_attribs.height * 2 - 1) * window_scale.y;
+  m_state.cursor.x = (win_x / std::max(win_attribs.width, 1) * 2 - 1) * window_scale.x;
+  m_state.cursor.y = (win_y / std::max(win_attribs.height, 1) * 2 - 1) * window_scale.y;
 }
 
 void KeyboardMouse::UpdateInput()


### PR DESCRIPTION
In every implementation.
Setting the window or renderer widget size to 0 is possible, at least in Windows, even when rendering in the main window, so it could probably happen under any OS, and anyway, it doesn't hurt to check.