### PR TITLE
InputCommon: Wrap remaining invalid default input expressions around ``

### DIFF
--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -225,43 +225,43 @@ void GCKeyboard::LoadDefaults(const ControllerInterface& ciface)
 #elif __APPLE__
   m_keys0x->SetControlExpression(0, "Home");
   m_keys0x->SetControlExpression(1, "End");
-  m_keys0x->SetControlExpression(2, "Page Up");
-  m_keys0x->SetControlExpression(3, "Page Down");
+  m_keys0x->SetControlExpression(2, "`Page Up`");
+  m_keys0x->SetControlExpression(3, "`Page Down`");
   m_keys0x->SetControlExpression(4, "");  // Scroll lock
 
-  m_keys2x->SetControlExpression(9, "-");
+  m_keys2x->SetControlExpression(9, "`-`");
   m_keys2x->SetControlExpression(10, "Paragraph");
   m_keys2x->SetControlExpression(11, "");  // Print Scr
-  m_keys2x->SetControlExpression(12, "'");
-  m_keys2x->SetControlExpression(13, "[");
-  m_keys2x->SetControlExpression(14, "=");
-  m_keys2x->SetControlExpression(15, "Keypad *");
-  m_keys3x->SetControlExpression(0, "]");
-  m_keys3x->SetControlExpression(1, ",");
-  m_keys3x->SetControlExpression(2, ".");
-  m_keys3x->SetControlExpression(3, "/");
-  m_keys3x->SetControlExpression(4, "\\");
+  m_keys2x->SetControlExpression(12, "`'`");
+  m_keys2x->SetControlExpression(13, "`[`");
+  m_keys2x->SetControlExpression(14, "`=`");
+  m_keys2x->SetControlExpression(15, "`Keypad *`");
+  m_keys3x->SetControlExpression(0, "`]`");
+  m_keys3x->SetControlExpression(1, "`,`");
+  m_keys3x->SetControlExpression(2, "`.`");
+  m_keys3x->SetControlExpression(3, "`/`");
+  m_keys3x->SetControlExpression(4, "`\\`");
 
   m_keys4x->SetControlExpression(1, "Escape");
   m_keys4x->SetControlExpression(2, "Insert");
   m_keys4x->SetControlExpression(3, "Delete");
-  m_keys4x->SetControlExpression(4, ";");
+  m_keys4x->SetControlExpression(4, "`;`");
   m_keys4x->SetControlExpression(5, "Backspace");
   m_keys4x->SetControlExpression(6, "Tab");
-  m_keys4x->SetControlExpression(7, "Caps Lock");
-  m_keys4x->SetControlExpression(8, "Left Shift");
-  m_keys4x->SetControlExpression(9, "Right Shift");
-  m_keys4x->SetControlExpression(10, "Left Control");
-  m_keys4x->SetControlExpression(11, "Right Alt");
-  m_keys4x->SetControlExpression(12, "Left Command");
+  m_keys4x->SetControlExpression(7, "`Caps Lock`");
+  m_keys4x->SetControlExpression(8, "`Left Shift`");
+  m_keys4x->SetControlExpression(9, "`Right Shift`");
+  m_keys4x->SetControlExpression(10, "`Left Control`");
+  m_keys4x->SetControlExpression(11, "`Right Alt`");
+  m_keys4x->SetControlExpression(12, "`Left Command`");
   m_keys4x->SetControlExpression(13, "Space");
-  m_keys4x->SetControlExpression(14, "Right Command");
+  m_keys4x->SetControlExpression(14, "`Right Command`");
   m_keys4x->SetControlExpression(15, "");  // Menu
 
-  m_keys5x->SetControlExpression(0, "Left Arrow");
-  m_keys5x->SetControlExpression(1, "Down Arrow");
-  m_keys5x->SetControlExpression(2, "Up Arrow");
-  m_keys5x->SetControlExpression(3, "Right Arrow");
+  m_keys5x->SetControlExpression(0, "`Left Arrow`");
+  m_keys5x->SetControlExpression(1, "`Down Arrow`");
+  m_keys5x->SetControlExpression(2, "`Up Arrow`");
+  m_keys5x->SetControlExpression(3, "`Right Arrow`");
   m_keys5x->SetControlExpression(4, "Return");
 #else  // linux
   m_keys0x->SetControlExpression(0, "Home");

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -190,7 +190,8 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
   m_buttons->SetControlExpression(5, "RETURN");  // Start
 #else
   // OS X/Linux
-  m_buttons->SetControlExpression(5, "Return");          // Start
+  // Start
+  m_buttons->SetControlExpression(5, "Return");
 #endif
 
   // stick modifiers to 50 %
@@ -218,10 +219,10 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
   m_main_stick->SetControlExpression(2, "LEFT");   // Left
   m_main_stick->SetControlExpression(3, "RIGHT");  // Right
 #elif __APPLE__
-  m_main_stick->SetControlExpression(0, "Up Arrow");     // Up
-  m_main_stick->SetControlExpression(1, "Down Arrow");   // Down
-  m_main_stick->SetControlExpression(2, "Left Arrow");   // Left
-  m_main_stick->SetControlExpression(3, "Right Arrow");  // Right
+  m_main_stick->SetControlExpression(0, "`Up Arrow`");     // Up
+  m_main_stick->SetControlExpression(1, "`Down Arrow`");   // Down
+  m_main_stick->SetControlExpression(2, "`Left Arrow`");   // Left
+  m_main_stick->SetControlExpression(3, "`Right Arrow`");  // Right
 #else
   m_main_stick->SetControlExpression(0, "Up");     // Up
   m_main_stick->SetControlExpression(1, "Down");   // Down

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -200,8 +200,8 @@ void Nunchuk::LoadDefaults(const ControllerInterface& ciface)
   m_buttons->SetControlExpression(0, "LCONTROL");  // C
   m_buttons->SetControlExpression(1, "LSHIFT");    // Z
 #elif __APPLE__
-  m_buttons->SetControlExpression(0, "Left Control");  // C
-  m_buttons->SetControlExpression(1, "Left Shift");    // Z
+  m_buttons->SetControlExpression(0, "`Left Control`");  // C
+  m_buttons->SetControlExpression(1, "`Left Shift`");    // Z
 #else
   m_buttons->SetControlExpression(0, "Control_L");  // C
   m_buttons->SetControlExpression(1, "Shift_L");    // Z

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -611,14 +611,14 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
 // Buttons
 #if defined HAVE_X11 && HAVE_X11
   // A
-  m_buttons->SetControlExpression(0, "Click 1");
+  m_buttons->SetControlExpression(0, "`Click 1`");
   // B
-  m_buttons->SetControlExpression(1, "Click 3");
+  m_buttons->SetControlExpression(1, "`Click 3`");
 #else
   // A
-  m_buttons->SetControlExpression(0, "Click 0");
+  m_buttons->SetControlExpression(0, "`Click 0`");
   // B
-  m_buttons->SetControlExpression(1, "Click 1");
+  m_buttons->SetControlExpression(1, "`Click 1`");
 #endif
   m_buttons->SetControlExpression(2, "`1`");  // 1
   m_buttons->SetControlExpression(3, "`2`");  // 2
@@ -628,18 +628,19 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
 #ifdef _WIN32
   m_buttons->SetControlExpression(6, "RETURN");  // Home
 #else
-  m_buttons->SetControlExpression(6, "Return");    // Home
+  // Home
+  m_buttons->SetControlExpression(6, "Return");
 #endif
 
   // Shake
   for (int i = 0; i < 3; ++i)
-    m_shake->SetControlExpression(i, "Click 2");
+    m_shake->SetControlExpression(i, "`Click 2`");
 
   // Pointing (IR)
-  m_ir->SetControlExpression(0, "Cursor Y-");
-  m_ir->SetControlExpression(1, "Cursor Y+");
-  m_ir->SetControlExpression(2, "Cursor X-");
-  m_ir->SetControlExpression(3, "Cursor X+");
+  m_ir->SetControlExpression(0, "`Cursor Y-`");
+  m_ir->SetControlExpression(1, "`Cursor Y+`");
+  m_ir->SetControlExpression(2, "`Cursor X-`");
+  m_ir->SetControlExpression(3, "`Cursor X+`");
 
 // DPad
 #ifdef _WIN32
@@ -648,10 +649,10 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
   m_dpad->SetControlExpression(2, "LEFT");   // Left
   m_dpad->SetControlExpression(3, "RIGHT");  // Right
 #elif __APPLE__
-  m_dpad->SetControlExpression(0, "Up Arrow");     // Up
-  m_dpad->SetControlExpression(1, "Down Arrow");   // Down
-  m_dpad->SetControlExpression(2, "Left Arrow");   // Left
-  m_dpad->SetControlExpression(3, "Right Arrow");  // Right
+  m_dpad->SetControlExpression(0, "`Up Arrow`");     // Up
+  m_dpad->SetControlExpression(1, "`Down Arrow`");   // Down
+  m_dpad->SetControlExpression(2, "`Left Arrow`");   // Left
+  m_dpad->SetControlExpression(3, "`Right Arrow`");  // Right
 #else
   m_dpad->SetControlExpression(0, "Up");     // Up
   m_dpad->SetControlExpression(1, "Down");   // Down
@@ -660,18 +661,18 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
 #endif
 
   // Motion Source
-  m_imu_accelerometer->SetControlExpression(0, "Accel Up");
-  m_imu_accelerometer->SetControlExpression(1, "Accel Down");
-  m_imu_accelerometer->SetControlExpression(2, "Accel Left");
-  m_imu_accelerometer->SetControlExpression(3, "Accel Right");
-  m_imu_accelerometer->SetControlExpression(4, "Accel Forward");
-  m_imu_accelerometer->SetControlExpression(5, "Accel Backward");
-  m_imu_gyroscope->SetControlExpression(0, "Gyro Pitch Up");
-  m_imu_gyroscope->SetControlExpression(1, "Gyro Pitch Down");
-  m_imu_gyroscope->SetControlExpression(2, "Gyro Roll Left");
-  m_imu_gyroscope->SetControlExpression(3, "Gyro Roll Right");
-  m_imu_gyroscope->SetControlExpression(4, "Gyro Yaw Left");
-  m_imu_gyroscope->SetControlExpression(5, "Gyro Yaw Right");
+  m_imu_accelerometer->SetControlExpression(0, "`Accel Up`");
+  m_imu_accelerometer->SetControlExpression(1, "`Accel Down`");
+  m_imu_accelerometer->SetControlExpression(2, "`Accel Left`");
+  m_imu_accelerometer->SetControlExpression(3, "`Accel Right`");
+  m_imu_accelerometer->SetControlExpression(4, "`Accel Forward`");
+  m_imu_accelerometer->SetControlExpression(5, "`Accel Backward`");
+  m_imu_gyroscope->SetControlExpression(0, "`Gyro Pitch Up`");
+  m_imu_gyroscope->SetControlExpression(1, "`Gyro Pitch Down`");
+  m_imu_gyroscope->SetControlExpression(2, "`Gyro Roll Left`");
+  m_imu_gyroscope->SetControlExpression(3, "`Gyro Roll Right`");
+  m_imu_gyroscope->SetControlExpression(4, "`Gyro Yaw Left`");
+  m_imu_gyroscope->SetControlExpression(5, "`Gyro Yaw Right`");
 
   // Enable Nunchuk:
   constexpr ExtensionNumber DEFAULT_EXT = ExtensionNumber::NUNCHUK;


### PR DESCRIPTION
Otherwise they give an error when clicking ok if trying to view or edit the input expressions.
These should be the last ones left that had not been converted yet.