### PR TITLE
Fix FPS counter and Game Window speed % breaking on pause/unpause

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -25,7 +25,10 @@ namespace Core
 bool GetIsThrottlerTempDisabled();
 void SetIsThrottlerTempDisabled(bool disable);
 
-void Callback_FramePresented();
+// Returns the latest emulation speed (1 is full speed) (swings a lot)
+double GetActualEmulationSpeed();
+
+void Callback_FramePresented(double actual_emulation_speed = 1.0);
 void Callback_NewField();
 
 enum class State
@@ -123,7 +126,7 @@ void OnFrameEnd();
 void VideoThrottle();
 void RequestRefreshInfo();
 
-void UpdateTitle();
+void UpdateTitle(u32 ElapseTime);
 
 // Run a function as the CPU thread.
 //
@@ -140,7 +143,11 @@ void RunOnCPUThread(std::function<void()> function, bool wait_for_completion);
 
 // for calling back into UI code without introducing a dependency on it in core
 using StateChangedCallbackFunc = std::function<void(Core::State)>;
-void SetOnStateChangedCallback(StateChangedCallbackFunc callback);
+// Returns a handle
+int AddOnStateChangedCallback(StateChangedCallbackFunc callback);
+// Also invalidates the handle
+bool RemoveOnStateChangedCallback(int* handle);
+void CallOnStateChangedCallbacks(Core::State state);
 
 // Run on the Host thread when the factors change. [NOT THREADSAFE]
 void UpdateWantDeterminism(bool initial = false);

--- a/Source/Core/DolphinNoGUI/MainNoGUI.cpp
+++ b/Source/Core/DolphinNoGUI/MainNoGUI.cpp
@@ -216,7 +216,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  Core::SetOnStateChangedCallback([](Core::State state) {
+  Core::AddOnStateChangedCallback([](Core::State state) {
     if (state == Core::State::Uninitialized)
       s_platform->Stop();
   });

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -36,7 +36,7 @@
 Settings::Settings()
 {
   qRegisterMetaType<Core::State>();
-  Core::SetOnStateChangedCallback([this](Core::State new_state) {
+  Core::AddOnStateChangedCallback([this](Core::State new_state) {
     QueueOnObject(this, [this, new_state] { emit EmulationStateChanged(new_state); });
   });
 

--- a/Source/Core/VideoCommon/FPSCounter.cpp
+++ b/Source/Core/VideoCommon/FPSCounter.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Timer.h"
+#include "Core/Core.h"
 #include "VideoCommon/FPSCounter.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -16,6 +17,18 @@ static constexpr u64 FPS_REFRESH_INTERVAL = 250000;
 FPSCounter::FPSCounter()
 {
   m_last_time = Common::Timer::GetTimeUs();
+
+  m_on_state_changed_handle = Core::AddOnStateChangedCallback([this](Core::State state) {
+    if (state == Core::State::Paused)
+      SetPaused(true);
+    else if (state == Core::State::Running)
+      SetPaused(false);
+  });
+}
+
+FPSCounter::~FPSCounter()
+{
+  Core::RemoveOnStateChangedCallback(&m_on_state_changed_handle);
 }
 
 void FPSCounter::LogRenderTimeToFile(u64 val)
@@ -31,8 +44,9 @@ void FPSCounter::LogRenderTimeToFile(u64 val)
 
 void FPSCounter::Update()
 {
-  u64 time = Common::Timer::GetTimeUs();
-  u64 diff = time - m_last_time;
+  const u64 time = Common::Timer::GetTimeUs();
+  const u64 diff = time - m_last_time;
+  m_time_diff_secs = static_cast<double>(diff / 1000000.0);
   if (g_ActiveConfig.bLogRenderTimeToFile)
     LogRenderTimeToFile(diff);
 
@@ -45,5 +59,19 @@ void FPSCounter::Update()
     m_fps = m_frame_counter / (m_time_since_update / 1000000.0);
     m_frame_counter = 0;
     m_time_since_update = 0;
+  }
+}
+
+void FPSCounter::SetPaused(bool paused)
+{
+  if (paused)
+  {
+    m_last_time_pause = Common::Timer::GetTimeUs();
+  }
+  else
+  {
+    const u64 time = Common::Timer::GetTimeUs();
+    const u64 diff = time - m_last_time_pause;
+    m_last_time += diff;
   }
 }

--- a/Source/Core/VideoCommon/FPSCounter.h
+++ b/Source/Core/VideoCommon/FPSCounter.h
@@ -11,20 +11,30 @@
 class FPSCounter
 {
 public:
-  // Initializes the FPS counter.
   FPSCounter();
+  ~FPSCounter();
+  FPSCounter(const FPSCounter&) = delete;
+  FPSCounter& operator=(const FPSCounter&) = delete;
+  FPSCounter(FPSCounter&&) = delete;
+  FPSCounter& operator=(FPSCounter&&) = delete;
 
   // Called when a frame is rendered (updated every second).
   void Update();
 
   float GetFPS() const { return m_fps; }
+  double GetDeltaTime() const { return m_time_diff_secs; }
 
 private:
+  void SetPaused(bool paused);
+
   u64 m_last_time = 0;
   u64 m_time_since_update = 0;
+  u64 m_last_time_pause = 0;
   u32 m_frame_counter = 0;
-  float m_fps = 0;
+  int m_on_state_changed_handle = -1;
+  float m_fps = 0.f;
   std::ofstream m_bench_file;
+  double m_time_diff_secs = 0.0;
 
   void LogRenderTimeToFile(u64 val);
 };

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -1329,7 +1329,12 @@ void Renderer::Swap(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, u6
       {
         // Remove stale EFB/XFB copies.
         g_texture_cache->Cleanup(m_frame_count);
-        Core::Callback_FramePresented();
+        const double last_speed_denominator =
+            m_fps_counter.GetDeltaTime() * VideoInterface::GetTargetRefreshRate();
+        // The denominator should always be > 0 but if it's not, just return 1
+        const double last_speed =
+            last_speed_denominator > 0.0 ? (1.0 / last_speed_denominator) : 1.0;
+        Core::Callback_FramePresented(last_speed);
       }
 
       // Handle any config changes, this gets propogated to the backend.


### PR DESCRIPTION
…by adding the pause state to FPSCounter.
-Add ability to have more than one "OnStateChanged" callback in core.
-Add GetActualEmulationSpeed() in Core, which will be used by input functions added by future commits (requires the new FPS counter features). It returns 1 if the emulation is not running.

Changes are actually really minor. I suggest just testing against master and seeing the problem being fixed for yourself.