### PR TITLE
Software: Remove normalization special case

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -84,7 +84,7 @@ void SWVertexLoader::DrawCurrentBatch(u32 base_index, u32 num_indices, u32 base_
           &m_vertex, (VertexLoaderManager::g_current_components & VB_HAS_NRM2) != 0, outVertex);
     }
     TransformUnit::TransformColor(&m_vertex, outVertex);
-    TransformUnit::TransformTexCoord(&m_vertex, outVertex, m_tex_gen_special_case);
+    TransformUnit::TransformTexCoord(&m_vertex, outVertex);
 
     // assemble and rasterize the primitive
     m_setup_unit.SetupVertex();
@@ -120,11 +120,6 @@ void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
   m_vertex.texMtx[5] = xfmem.MatrixIndexB.Tex5MtxIdx;
   m_vertex.texMtx[6] = xfmem.MatrixIndexB.Tex6MtxIdx;
   m_vertex.texMtx[7] = xfmem.MatrixIndexB.Tex7MtxIdx;
-
-  // special case if only pos and tex coord 0 and tex coord input is AB11
-  // http://libogc.devkitpro.org/gx_8h.html#a55a426a3ff796db584302bddd829f002
-  m_tex_gen_special_case = VertexLoaderManager::g_current_components == VB_HAS_UV0 &&
-                           xfmem.texMtxInfo[0].projection == XF_TEXPROJ_ST;
 }
 
 template <typename T, typename I>

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -28,6 +28,4 @@ protected:
 
   InputVertexData m_vertex;
   SetupUnit m_setup_unit;
-
-  bool m_tex_gen_special_case;
 };

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -109,7 +109,7 @@ void TransformNormal(const InputVertexData* src, bool nbt, OutputVertexData* dst
   }
 }
 
-static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bool specialCase,
+static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum,
                                      const InputVertexData* srcVertex, OutputVertexData* dstVertex)
 {
   Vec3 src;
@@ -140,15 +140,13 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
 
   if (texinfo.projection == XF_TEXPROJ_ST)
   {
-    if (texinfo.inputform == XF_TEXINPUT_AB11 || specialCase)
+    if (texinfo.inputform == XF_TEXINPUT_AB11)
       MultiplyVec2Mat24(src, mat, *dst);
     else
       MultiplyVec3Mat24(src, mat, *dst);
   }
   else  // texinfo.projection == XF_TEXPROJ_STQ
   {
-    ASSERT(!specialCase);
-
     if (texinfo.inputform == XF_TEXINPUT_AB11)
       MultiplyVec2Mat34(src, mat, *dst);
     else
@@ -163,27 +161,12 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
     const PostMtxInfo& postInfo = xfmem.postMtxInfo[coordNum];
     const float* postMat = &xfmem.postMatrices[postInfo.index * 4];
 
-    if (specialCase)
-    {
-      // no normalization
-      // q of input is 1
-      // q of output is unknown
-      tempCoord.x = dst->x;
-      tempCoord.y = dst->y;
-
-      dst->x = postMat[0] * tempCoord.x + postMat[1] * tempCoord.y + postMat[2] + postMat[3];
-      dst->y = postMat[4] * tempCoord.x + postMat[5] * tempCoord.y + postMat[6] + postMat[7];
-      dst->z = 1.0f;
-    }
+    if (postInfo.normalize)
+      tempCoord = dst->Normalized();
     else
-    {
-      if (postInfo.normalize)
-        tempCoord = dst->Normalized();
-      else
-        tempCoord = *dst;
+      tempCoord = *dst;
 
-      MultiplyVec3Mat34(tempCoord, postMat, *dst);
-    }
+    MultiplyVec3Mat34(tempCoord, postMat, *dst);
   }
 
   // When q is 0, the GameCube appears to have a special case
@@ -406,7 +389,7 @@ void TransformColor(const InputVertexData* src, OutputVertexData* dst)
   }
 }
 
-void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst, bool specialCase)
+void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst)
 {
   for (u32 coordNum = 0; coordNum < xfmem.numTexGen.numTexGens; coordNum++)
   {
@@ -415,7 +398,7 @@ void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst, bool s
     switch (texinfo.texgentype)
     {
     case XF_TEXGEN_REGULAR:
-      TransformTexCoordRegular(texinfo, coordNum, specialCase, src, dst);
+      TransformTexCoordRegular(texinfo, coordNum, src, dst);
       break;
     case XF_TEXGEN_EMBOSS_MAP:
     {

--- a/Source/Core/VideoBackends/Software/TransformUnit.h
+++ b/Source/Core/VideoBackends/Software/TransformUnit.h
@@ -12,5 +12,5 @@ namespace TransformUnit
 void TransformPosition(const InputVertexData* src, OutputVertexData* dst);
 void TransformNormal(const InputVertexData* src, bool nbt, OutputVertexData* dst);
 void TransformColor(const InputVertexData* src, OutputVertexData* dst);
-void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst, bool specialCase);
+void TransformTexCoord(const InputVertexData* src, OutputVertexData* dst);
 }  // namespace TransformUnit


### PR DESCRIPTION
The special case doesn't appear to make a significant difference in any games, and the current implementation has a (minor, fixable) issue that breaks Super Mario Sunshine (both with a failed assertion ([bug 11742](https://bugs.dolphin-emu.org/issues/11742)) and a rendering issue ([bug 7476](https://bugs.dolphin-emu.org/issues/7476))).  Hardware testing wasn't able to reproduce the special case, either, so it may just not exist.

PR #9315 contains a fixed implementation of the special case on all video backends, and can serve as a basis for it being reintroduced if it is found to exist under more specific circumstances.  For now, I don't see a reason to keep it present.