### PR TITLE
Jit64: subfx optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -941,7 +941,13 @@ void Jit64::subfx(UGeckoInstruction inst)
   JITDISABLE(bJITIntegerOff);
   int a = inst.RA, b = inst.RB, d = inst.RD;
 
-  if (gpr.IsImm(a) && gpr.IsImm(b))
+  if (a == b)
+  {
+    gpr.SetImmediate32(d, 0);
+    if (inst.OE)
+      GenerateConstantOverflow(false);
+  }
+  else if (gpr.IsImm(a, b))
   {
     s32 i = gpr.SImm32(b), j = gpr.SImm32(a);
     gpr.SetImmediate32(d, i - j);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -980,6 +980,18 @@ void Jit64::subfx(UGeckoInstruction inst)
         GenerateOverflow();
     }
   }
+  else if (gpr.IsImm(b) && gpr.Imm32(b) == 0)
+  {
+    RCOpArg Ra = gpr.Use(a, RCMode::Read);
+    RCX64Reg Rd = gpr.Bind(d, RCMode::Write);
+    RegCache::Realize(Ra, Rd);
+
+    if (d != a)
+      MOV(32, Rd, Ra);
+    NEG(32, Rd);
+    if (inst.OE)
+      GenerateOverflow();
+  }
   else
   {
     RCOpArg Ra = gpr.Use(a, RCMode::Read);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -955,7 +955,14 @@ void Jit64::subfx(UGeckoInstruction inst)
     RCX64Reg Rd = gpr.Bind(d, RCMode::Write);
     RegCache::Realize(Rb, Rd);
 
-    if (d == b)
+    if (j == 0)
+    {
+      if (d != b)
+        MOV(32, Rd, Rb);
+      if (inst.OE)
+        GenerateConstantOverflow(false);
+    }
+    else if (d == b)
     {
       SUB(32, Rd, Imm32(j));
       if (inst.OE)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -856,7 +856,13 @@ void JitArm64::subfx(UGeckoInstruction inst)
 
   int a = inst.RA, b = inst.RB, d = inst.RD;
 
-  if (gpr.IsImm(a) && gpr.IsImm(b))
+  if (a == b)
+  {
+    gpr.SetImmediate(d, 0);
+    if (inst.Rc)
+      ComputeRC0(gpr.GetImm(d));
+  }
+  else if (gpr.IsImm(a) && gpr.IsImm(b))
   {
     u32 i = gpr.GetImm(a), j = gpr.GetImm(b);
     gpr.SetImmediate(d, j - i);


### PR DESCRIPTION
Improved code generation for `subfx` in various cases.

---
**d == a and is constant**
<details><summary>Example 1</summary>

Before:
```
BF 1E 00 00 00       mov         edi,1Eh
8B C7                mov         eax,edi
8B FE                mov         edi,esi
2B F8                sub         edi,eax
```
After:
```
8D 7E E2             lea         edi,[rsi-1Eh]
```
</details>

<details><summary>Example 2</summary>

Before:
```
BE 00 AC 3F 80       mov         esi,803FAC00h
8B C6                mov         eax,esi
8B 75 EC             mov         esi,dword ptr [rbp-14h]
2B F0                sub         esi,eax
```
After:
```
8B 75 EC             mov         esi,dword ptr [rbp-14h]
81 EE 00 AC 3F 80    sub         esi,803FAC00h
```
</details>

---

**a == 0**

<details><summary>Example</summary>

Before:
```
41 83 EE 00          sub         r14d,0
```
After:
Nothing!
</details>

---

**b == 0**

<details><summary>Example 1 (d == a)</summary>

Before:
```
41 8B C7             mov         eax,r15d
41 BF 00 00 00 00    mov         r15d,0
44 2B F8             sub         r15d,eax
```
After:
```
41 F7 DF             neg         r15d
```

</details>

<details><summary>Example 2 (d != a)</summary>

Before:
```
BF 00 00 00 00       mov         edi,0
41 2B FD             sub         edi,r13d
```
After:
```
41 8B FD             mov         edi,r13d
F7 DF                neg         edi
```

</details>

---

**a == b**

<details><summary>Example</summary>

Before:
```
2B F6                sub         esi,esi
```
After:
Nothing, destination register is set to constant zero.

</details>