### PR TITLE
Bump msvc version check and revert a msvc workaround

### DIFF
--- a/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
+++ b/Source/Core/Core/HW/WiimoteCommon/WiimoteReport.h
@@ -89,8 +89,7 @@ struct OutputReportLeds
 
   u8 rumble : 1;
   u8 ack : 1;
-  // This field must be named to work around a msvc bug.
-  u8 _padding : 2;
+  u8 : 2;
   u8 leds : 4;
 };
 static_assert(sizeof(OutputReportLeds) == 1, "Wrong size");

--- a/Source/PCH/pch.h
+++ b/Source/PCH/pch.h
@@ -7,7 +7,7 @@
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#if defined _MSC_FULL_VER && _MSC_FULL_VER < 192729111
+#if defined _MSC_FULL_VER && _MSC_FULL_VER < 192829335
 #pragma message("Current _MSC_FULL_VER: " STRINGIFY(_MSC_FULL_VER))
 #error Please update your build environment to the latest Visual Studio 2019!
 #endif


### PR DESCRIPTION
The workaround is no longer required :)