### PR TITLE
BitUtils: cleanup constexpr usage for msvc clz

### DIFF
--- a/Source/Core/Common/BitUtils.h
+++ b/Source/Core/Common/BitUtils.h
@@ -362,53 +362,53 @@ T ExpandValue(T value, size_t left_shift_amount)
          (T(-ExtractBit<0>(value)) >> (BitSize<T>() - left_shift_amount));
 }
 
-// On some compiler / arch combinations, the compiler does not see instrinsics as constexpr, so mark
-// the function as inline instead.
-#if defined(_MSC_VER) && defined(_M_ARM_64)
-#define CONSTEXPR_FROM_INTRINSIC inline
-#else
-#define CONSTEXPR_FROM_INTRINSIC constexpr
-#endif
+template <typename T>
+constexpr int CountLeadingZerosConst(T value)
+{
+  int result = sizeof(T) * 8;
+  while (value)
+  {
+    result--;
+    value >>= 1;
+  }
+  return result;
+}
 
-CONSTEXPR_FROM_INTRINSIC
-int CountLeadingZeros(uint64_t value)
+constexpr int CountLeadingZeros(uint64_t value)
 {
 #if defined(__GNUC__)
   return value ? __builtin_clzll(value) : 64;
-#elif defined(_MSC_VER) && defined(_M_ARM_64)
-  return _CountLeadingZeros64(value);
-#elif defined(_MSC_VER) && defined(_M_X86_64)
-  unsigned long index = 0;
-  return _BitScanReverse64(&index, value) ? 63 - index : 64;
-#else
-  int result = 64;
-  while (value)
+#elif defined(_MSC_VER)
+  if (std::is_constant_evaluated())
   {
-    result--;
-    value >>= 1;
+    return CountLeadingZerosConst(value);
   }
-  return result;
+  else
+  {
+    unsigned long index = 0;
+    return _BitScanReverse64(&index, value) ? 63 - index : 64;
+  }
+#else
+  return CountLeadingZerosConst(value);
 #endif
 }
 
-CONSTEXPR_FROM_INTRINSIC
-int CountLeadingZeros(uint32_t value)
+constexpr int CountLeadingZeros(uint32_t value)
 {
 #if defined(__GNUC__)
   return value ? __builtin_clz(value) : 32;
-#elif defined(_MSC_VER) && defined(_M_ARM_64)
-  return _CountLeadingZeros(value);
-#elif defined(_MSC_VER) && defined(_M_X86_64)
-  unsigned long index = 0;
-  return _BitScanReverse(&index, value) ? 31 - index : 32;
-#else
-  int result = 32;
-  while (value)
+#elif defined(_MSC_VER)
+  if (std::is_constant_evaluated())
   {
-    result--;
-    value >>= 1;
+    return CountLeadingZerosConst(value);
   }
-  return result;
+  else
+  {
+    unsigned long index = 0;
+    return _BitScanReverse(&index, value) ? 31 - index : 32;
+  }
+#else
+  return CountLeadingZerosConst(value);
 #endif
 }
 


### PR DESCRIPTION
* Can use _BitScanReverse{64} for all archs we support with msvc
* Can actually support being used in constexpr evaluation contexts

see https://developercommunity.visualstudio.com/idea/434712/make-intrinsic-functions-supported-in-a-constexpr.html

here is a small test: compiling the following with `cl /Ox /std:c++latest clz.cpp /link /debug`
```c
int main() {
    const uint32_t val32 = 9;
    const uint64_t val64 = 9;
    int clz1 = CountLeadingZeros(val32);
    int clz2 = CountLeadingZeros(val64);
    constexpr int clz3 = CountLeadingZeros(val32);
    constexpr int clz4 = CountLeadingZeros(val64);
    printf("%d %d %d %d\n", clz1,  clz2,  clz3,  clz4);
    return 0;
}
```

arm64:
```c
int __cdecl main(int argc, const char **argv, const char **envp)
{
  unsigned int v3; // w10
  __int64 v4; // x1
  unsigned int v5; // w10
  __int64 v6; // x2

  v3 = __clz(9u);
  if ( 1 == (unsigned __int8)(v3 >> 5) )
    v4 = 32i64;
  else
    v4 = v3;
  v5 = __clz(9ui64);
  if ( 1 == (unsigned __int8)(v5 >> 6) )
    v6 = 64i64;
  else
    v6 = v5;
  sub_140003F94("%d %d %d %d\n", v4, v6, 28i64, 60i64);
  return 0;
}
```

x64:
```c
int __cdecl main(int argc, const char **argv, const char **envp)
{
  unsigned __int64 v3; // rax
  __int64 v4; // rdx
  int v6; // [rsp+20h] [rbp-18h]

  v6 = 60;
  _BitScanReverse((unsigned int *)&v3, 9u);
  v4 = (unsigned int)(31 - v3);
  _BitScanReverse64(&v3, 9ui64);
  j_printf("%d %d %d %d\n", v4, (unsigned int)(63 - v3), 28i64, v6);
  return 0;
}
```