### PR TITLE
msvc: enable asan compat

### DIFF
--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
@@ -28,30 +29,32 @@ namespace EMM
 {
 #ifdef _WIN32
 
+static PVOID s_veh_handle;
+
 static LONG NTAPI Handler(PEXCEPTION_POINTERS pPtrs)
 {
   switch (pPtrs->ExceptionRecord->ExceptionCode)
   {
   case EXCEPTION_ACCESS_VIOLATION:
   {
-    int accessType = (int)pPtrs->ExceptionRecord->ExceptionInformation[0];
-    if (accessType == 8)  // Rule out DEP
+    ULONG_PTR access_type = pPtrs->ExceptionRecord->ExceptionInformation[0];
+    if (access_type == 8)  // Rule out DEP
     {
-      return (DWORD)EXCEPTION_CONTINUE_SEARCH;
+      return EXCEPTION_CONTINUE_SEARCH;
     }
 
     // virtual address of the inaccessible data
-    uintptr_t badAddress = (uintptr_t)pPtrs->ExceptionRecord->ExceptionInformation[1];
-    CONTEXT* ctx = pPtrs->ContextRecord;
+    uintptr_t fault_address = (uintptr_t)pPtrs->ExceptionRecord->ExceptionInformation[1];
+    SContext* ctx = pPtrs->ContextRecord;
 
-    if (JitInterface::HandleFault(badAddress, ctx))
+    if (JitInterface::HandleFault(fault_address, ctx))
     {
-      return (DWORD)EXCEPTION_CONTINUE_EXECUTION;
+      return EXCEPTION_CONTINUE_EXECUTION;
     }
     else
     {
       // Let's not prevent debugging.
-      return (DWORD)EXCEPTION_CONTINUE_SEARCH;
+      return EXCEPTION_CONTINUE_SEARCH;
     }
   }
 
@@ -84,18 +87,17 @@ static LONG NTAPI Handler(PEXCEPTION_POINTERS pPtrs)
 
 void InstallExceptionHandler()
 {
-  // Make sure this is only called once per process execution
-  // Instead, could make a Uninstall function, but whatever..
-  static bool handlerInstalled = false;
-  if (handlerInstalled)
+  if (s_veh_handle)
     return;
 
-  AddVectoredExceptionHandler(TRUE, Handler);
-  handlerInstalled = true;
+  s_veh_handle = AddVectoredExceptionHandler(TRUE, Handler);
+  ASSERT(s_veh_handle);
 }
 
 void UninstallExceptionHandler()
 {
+  ULONG status = RemoveVectoredExceptionHandler(s_veh_handle);
+  ASSERT(status);
 }
 
 #elif defined(__APPLE__) && !defined(USE_SIGACTION_ON_APPLE)

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -49,6 +49,17 @@ public:
       m_post_unprotect_time;
 };
 
+#ifdef _MSC_VER
+#define ASAN_DISABLE __declspec(no_sanitize_address)
+#else
+#define ASAN_DISABLE
+#endif
+
+static void ASAN_DISABLE perform_invalid_access(void* data)
+{
+  *(volatile int*)data = 5;
+}
+
 TEST(PageFault, PageFault)
 {
   EMM::InstallExceptionHandler();
@@ -61,7 +72,7 @@ TEST(PageFault, PageFault)
   pfjit.m_data = data;
 
   auto start = std::chrono::high_resolution_clock::now();
-  *(volatile int*)data = 5;
+  perform_invalid_access(data);
   auto end = std::chrono::high_resolution_clock::now();
 
 #define AS_NS(diff)                                                                                \

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -133,6 +133,9 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <Optimization>Disabled</Optimization>
     </ClCompile>
+    <ClCompile Condition="'$(Configuration)'=='Debug' And '$(EnableASAN)'=='true'">
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
     <!--ClCompile Release-->
     <ClCompile Condition="'$(Configuration)'=='Release'">
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>

--- a/Source/VSProps/Configuration.Base.props
+++ b/Source/VSProps/Configuration.Base.props
@@ -4,6 +4,11 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+    <!-- To use ASAN, just uncomment this. For simplicity, you should run VS/windbg/etc
+    (including the built executables themselves) after using vcvarsall or similar to setup
+    environment, as ASAN needs access to libs and executables in the toolchain paths.
+    -->
+    <!--<EnableASAN>true</EnableASAN>-->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
Since VS 16.8, ASAN support is very usable and easy to enable. This commit adds the build configuration settings to use ASAN, you just need to uncomment the `EnableASAN` line in `Source/VSProps/Configuration.Base.props`.

Here's an example of introducing a simple out of bounds access into the dolphin bootup code:
```
c:\src\dolphin>Binary\x64\DolphinNoGUI.exe "e:\gamecube\Animal Crossing NTSC-U.iso"
=================================================================
==59956==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x12012d609bd0 at pc 0x7ff6eaaf2fd4 bp 0x005f9b6fe3b0 sp 0x005f9b6fe3b0
WRITE of size 4 at 0x12012d609bd0 thread T0
    #0 0x7ff6eaaf2fd3 in BootManager::BootCore(class std::unique_ptr<struct BootParameters,struct std::default_delete<struct BootParameters> >,struct WindowSystemInfo const &) c:\src\dolphin\Source\Core\Core\BootManager.cpp:234
    #1 0x7ff6ea93fe2f in main c:\src\dolphin\Source\Core\DolphinNoGUI\MainNoGUI.cpp:239
    #2 0x7ff6eaee1af3 in __scrt_common_main_seh d:\agent\_work\63\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #3 0x7ffd64dc7033  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017033)
    #4 0x7ffd6519d0d0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18004d0d0)

0x12012d609bd0 is located 0 bytes to the right of 400-byte region [0x12012d609a40,0x12012d609bd0)
allocated by thread T0 here:
    #0 0x7ffd0dbf9d42  (C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\bin\HostX64\x64\clang_rt.asan_dynamic-x86_64.dll+0x180059d42)
    #1 0x7ff6eaaf2fc4 in BootManager::BootCore(class std::unique_ptr<struct BootParameters,struct std::default_delete<struct BootParameters> >,struct WindowSystemInfo const &) c:\src\dolphin\Source\Core\Core\BootManager.cpp:233
    #2 0x7ff6ea93fe2f in main c:\src\dolphin\Source\Core\DolphinNoGUI\MainNoGUI.cpp:239
    #3 0x7ff6eaee1af3 in __scrt_common_main_seh d:\agent\_work\63\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #4 0x7ffd64dc7033  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017033)
    #5 0x7ffd6519d0d0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18004d0d0)

SUMMARY: AddressSanitizer: heap-buffer-overflow c:\src\dolphin\Source\Core\Core\BootManager.cpp:234 in BootManager::BootCore(class std::unique_ptr<struct BootParameters,struct std::default_delete<struct BootParameters> >,struct WindowSystemInfo const &)
Shadow bytes around the buggy address:
  0x0419530c1320: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0419530c1330: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa
  0x0419530c1340: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0419530c1350: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0419530c1360: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0419530c1370: 00 00 00 00 00 00 00 00 00 00[fa]fa fa fa fa fa
  0x0419530c1380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0419530c1390: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0419530c13a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0419530c13b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0419530c13c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==59956==ABORTING
```

from:
```diff
diff --git a/Source/Core/Core/BootManager.cpp b/Source/Core/Core/BootManager.cpp
index a339ee80dd..e1b2763965 100644
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -230,6 +230,9 @@ static GPUDeterminismMode ParseGPUDeterminismMode(const std::string& mode)
 // Boot the ISO or file
 bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
 {
+  auto boom = new int[100];
+  boom[100] = 1;
+
   if (!boot)
     return false;
```

For the GUI version, you should have a debugger like windbg or VS attached, however you can also setup asan to write a dump file.