### PR TITLE
Use GX_CMD_UNKNOWN_METRICS instead of magic number 0x44

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -164,7 +164,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
   switch (cmd)
   {
   case OpcodeDecoder::GX_NOP:
-  case 0x44:
+  case OpcodeDecoder::GX_CMD_UNKNOWN_METRICS:
   case OpcodeDecoder::GX_CMD_INVL_VC:
     break;
 

--- a/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
+++ b/Source/Core/DolphinQt/FIFO/FIFOAnalyzer.cpp
@@ -211,8 +211,8 @@ void FIFOAnalyzer::UpdateDetails()
         new_label = QStringLiteral("NOP");
         break;
 
-      case 0x44:
-        new_label = QStringLiteral("0x44");
+      case OpcodeDecoder::GX_CMD_UNKNOWN_METRICS:
+        new_label = QStringLiteral("GX_CMD_UNKNOWN_METRICS");
         break;
 
       case OpcodeDecoder::GX_CMD_INVL_VC:


### PR DESCRIPTION
Defined to be 0x44 here:

https://github.com/dolphin-emu/dolphin/blob/79a234eff728b2aeb68c9848f2e4fe861d4f3b91/Source/Core/VideoCommon/OpcodeDecoding.h#L30

and already used in OpcodeDecoding here:

https://github.com/dolphin-emu/dolphin/blob/79a234eff728b2aeb68c9848f2e4fe861d4f3b91/Source/Core/VideoCommon/OpcodeDecoding.cpp#L202-L206

That log message also has a 0x44 in it, but since it seems like the exact purpose of this command is unknown, I think it's fine to leave it like that.  On the other hand, the code uses in both `FifoAnalyzer.cpp`s are a situation where we want `0x44` to match the name, especially if the name is later changed.