### PR TITLE
DolphinQT: Gives option to add desktop shortcut

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameList.h
+++ b/Source/Core/DolphinQt/GameList/GameList.h
@@ -65,6 +65,9 @@ private:
   void OpenWiki();
   void SetDefaultISO();
   void DeleteFile();
+#ifdef _WIN32
+  bool AddShortcutToDesktop();
+#endif
   void InstallWAD();
   void UninstallWAD();
   void ExportWiiSave();


### PR DESCRIPTION
When a game is selected, the option to add a shortcut of the game to the desktop is given. Uses native Windows API since Qt lacks support for adding shortcuts.

This is a modification of #9365 , using WIL and handling all error/memory leak cases correctly (hopefully 🙂)