### PR TITLE
Added Opacity settings for touchscreen controls

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -544,7 +544,7 @@ public final class EmulationActivity extends AppCompatActivity
         toggleControls();
         break;
 
-      // Adjust the scale of the overlay controls.
+      // Adjust the scale and opacity of the overlay controls.
       case MENU_ACTION_ADJUST_SCALE:
         adjustScale();
         break;
@@ -828,15 +828,14 @@ public final class EmulationActivity extends AppCompatActivity
   private void adjustScale()
   {
     LayoutInflater inflater = LayoutInflater.from(this);
-    View view = inflater.inflate(R.layout.dialog_seekbar, null);
+    View view = inflater.inflate(R.layout.dialog_input_adjust, null);
 
-    final SeekBar seekbar = view.findViewById(R.id.seekbar);
-    final TextView value = view.findViewById(R.id.text_value);
-    final TextView units = view.findViewById(R.id.text_units);
+    final SeekBar scaleSeekbar = view.findViewById(R.id.input_scale_seekbar);
+    final TextView scaleValue = view.findViewById(R.id.input_scale_value);
 
-    seekbar.setMax(150);
-    seekbar.setProgress(IntSetting.MAIN_CONTROL_SCALE.getInt(mSettings));
-    seekbar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener()
+    scaleSeekbar.setMax(150);
+    scaleSeekbar.setProgress(IntSetting.MAIN_CONTROL_SCALE.getInt(mSettings));
+    scaleSeekbar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener()
     {
       public void onStartTrackingTouch(SeekBar seekBar)
       {
@@ -845,7 +844,7 @@ public final class EmulationActivity extends AppCompatActivity
 
       public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser)
       {
-        value.setText(String.valueOf(progress + 50));
+        scaleValue.setText((progress + 50) + "%");
       }
 
       public void onStopTrackingTouch(SeekBar seekBar)
@@ -854,20 +853,46 @@ public final class EmulationActivity extends AppCompatActivity
       }
     });
 
-    value.setText(String.valueOf(seekbar.getProgress() + 50));
-    units.setText("%");
+    scaleValue.setText((scaleSeekbar.getProgress() + 50) + "%");
+
+    // alpha
+    final SeekBar seekbarOpacity = view.findViewById(R.id.input_opacity_seekbar);
+    final TextView valueOpacity = view.findViewById(R.id.input_opacity_value);
+
+    seekbarOpacity.setMax(100);
+    seekbarOpacity.setProgress(IntSetting.MAIN_CONTROL_OPACITY.getInt(mSettings));
+    seekbarOpacity.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener()
+    {
+      public void onStartTrackingTouch(SeekBar seekBar)
+      {
+        // Do nothing
+      }
+
+      public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser)
+      {
+        valueOpacity.setText(progress + "%");
+      }
+
+      public void onStopTrackingTouch(SeekBar seekBar)
+      {
+        // Do nothing
+      }
+    });
+    valueOpacity.setText(seekbarOpacity.getProgress() + "%");
 
     AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.DolphinDialogBase);
-    builder.setTitle(R.string.emulation_control_scale);
+    builder.setTitle(R.string.emulation_control_adjustments);
     builder.setView(view);
     builder.setPositiveButton(R.string.ok, (dialogInterface, i) ->
     {
-      IntSetting.MAIN_CONTROL_SCALE.setInt(mSettings, seekbar.getProgress());
+      IntSetting.MAIN_CONTROL_SCALE.setInt(mSettings, scaleSeekbar.getProgress());
+      IntSetting.MAIN_CONTROL_OPACITY.setInt(mSettings, seekbarOpacity.getProgress());
       mEmulationFragment.refreshInputOverlay();
     });
     builder.setNeutralButton(R.string.default_values, (dialogInterface, i) ->
     {
       IntSetting.MAIN_CONTROL_SCALE.delete(mSettings);
+      IntSetting.MAIN_CONTROL_OPACITY.delete(mSettings);
       mEmulationFragment.refreshInputOverlay();
     });
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -22,6 +22,7 @@ public enum IntSetting implements AbstractIntSetting
   MAIN_AUDIO_VOLUME(Settings.FILE_DOLPHIN, Settings.SECTION_INI_DSP, "Volume", 100),
 
   MAIN_CONTROL_SCALE(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "ControlScale", 50),
+  MAIN_CONTROL_OPACITY(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "ControlOpacity", 50),
   MAIN_EMULATION_ORIENTATION(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID,
           "EmulationOrientation", ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE),
   MAIN_LAST_PLATFORM_TAB(Settings.FILE_DOLPHIN, Settings.SECTION_INI_ANDROID, "LastPlatformTab", 0),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -955,6 +955,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     // Need to set the image's position
     overlayDrawable.setPosition(drawableX, drawableY);
+    overlayDrawable.setOpacity(IntSetting.MAIN_CONTROL_OPACITY.getIntGlobal() * 255 / 100);
 
     return overlayDrawable;
   }
@@ -1039,6 +1040,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     // Need to set the image's position
     overlayDrawable.setPosition(drawableX, drawableY);
+    overlayDrawable.setOpacity(IntSetting.MAIN_CONTROL_OPACITY.getIntGlobal() * 255 / 100);
 
     return overlayDrawable;
   }
@@ -1104,6 +1106,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     // Need to set the image's position
     overlayDrawable.setPosition(drawableX, drawableY);
+    overlayDrawable.setOpacity(IntSetting.MAIN_CONTROL_OPACITY.getIntGlobal() * 255 / 100);
 
     return overlayDrawable;
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableButton.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableButton.java
@@ -114,6 +114,11 @@ public final class InputOverlayDrawableButton
     mPressedStateBitmap.setBounds(left, top, right, bottom);
   }
 
+  public void setOpacity(int value)
+  {
+    mDefaultStateBitmap.setAlpha(value);
+  }
+
   public Rect getBounds()
   {
     return mDefaultStateBitmap.getBounds();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableDpad.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableDpad.java
@@ -183,6 +183,11 @@ public final class InputOverlayDrawableDpad
     mPressedTwoDirectionsStateBitmap.setBounds(left, top, right, bottom);
   }
 
+  public void setOpacity(int value)
+  {
+    mDefaultStateBitmap.setAlpha(value);
+  }
+
   public Rect getBounds()
   {
     return mDefaultStateBitmap.getBounds();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayDrawableJoystick.java
@@ -32,6 +32,7 @@ public final class InputOverlayDrawableJoystick
   private final int mHeight;
   private Rect mVirtBounds;
   private Rect mOrigBounds;
+  private int mOpacity;
   private final BitmapDrawable mOuterBitmap;
   private final BitmapDrawable mDefaultStateInnerBitmap;
   private final BitmapDrawable mPressedStateInnerBitmap;
@@ -106,7 +107,7 @@ public final class InputOverlayDrawableJoystick
         {
           mPressedState = pressed = true;
           mOuterBitmap.setAlpha(0);
-          mBoundsBoxBitmap.setAlpha(255);
+          mBoundsBoxBitmap.setAlpha(mOpacity);
           if (reCenter)
           {
             getVirtBounds().offset((int) event.getX(pointerIndex) - getVirtBounds().centerX(),
@@ -123,7 +124,7 @@ public final class InputOverlayDrawableJoystick
           pressed = true;
           mPressedState = false;
           axises[0] = axises[1] = 0.0f;
-          mOuterBitmap.setAlpha(255);
+          mOuterBitmap.setAlpha(mOpacity);
           mBoundsBoxBitmap.setAlpha(0);
           setVirtBounds(new Rect(mOrigBounds.left, mOrigBounds.top, mOrigBounds.right,
                   mOrigBounds.bottom));
@@ -249,6 +250,13 @@ public final class InputOverlayDrawableJoystick
   public void setBounds(Rect bounds)
   {
     mOuterBitmap.setBounds(bounds);
+  }
+
+  public void setOpacity(int value)
+  {
+    mOpacity = value;
+    mDefaultStateInnerBitmap.setAlpha(value);
+    mOuterBitmap.setAlpha(value);
   }
 
   public Rect getBounds()

--- a/Source/Android/app/src/main/res/layout/dialog_input_adjust.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_input_adjust.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <RelativeLayout
+        android:id="@+id/input_scale"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
+        android:clickable="false">
+
+        <TextView
+            android:id="@+id/input_scale_name"
+            style="@style/TextAppearance.AppCompat.Headline"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginStart="@dimen/spacing_large"
+            android:layout_marginTop="@dimen/spacing_large"
+            android:layout_marginEnd="@dimen/spacing_large"
+            android:text="@string/emulation_control_scale"
+            android:textSize="16sp"
+            tools:text="@string/overclock_enable" />
+
+        <TextView
+            android:id="@+id/input_scale_value"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/input_scale_name"
+            android:layout_alignParentEnd="true"
+            android:layout_marginStart="@dimen/spacing_small"
+            android:layout_marginTop="@dimen/spacing_medlarge"
+            android:layout_marginEnd="@dimen/spacing_large"
+            android:layout_marginBottom="@dimen/spacing_large"
+            tools:text="99%"
+            android:textAlignment="textEnd"/>
+
+        <SeekBar
+            android:id="@+id/input_scale_seekbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/input_scale_name"
+            android:layout_alignParentStart="true"
+            android:layout_marginTop="@dimen/spacing_medlarge"
+            android:layout_marginBottom="@dimen/spacing_large"
+            android:layout_toStartOf="@id/input_scale_value" />
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/input_opacity"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/input_scale"
+        android:layout_alignParentStart="true"
+        android:clickable="false">
+
+        <TextView
+            android:id="@+id/input_opacity_name"
+            style="@style/TextAppearance.AppCompat.Headline"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginStart="@dimen/spacing_large"
+            android:layout_marginTop="@dimen/spacing_large"
+            android:layout_marginEnd="@dimen/spacing_large"
+            android:text="@string/emulation_control_opacity"
+            android:textSize="16sp"
+            tools:text="@string/overclock_enable" />
+
+        <TextView
+            android:id="@+id/input_opacity_value"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/input_opacity_name"
+            android:layout_alignParentEnd="true"
+            android:layout_marginStart="@dimen/spacing_small"
+            android:layout_marginTop="@dimen/spacing_medlarge"
+            android:layout_marginEnd="@dimen/spacing_large"
+            android:layout_marginBottom="@dimen/spacing_large"
+            tools:text="99%"
+            android:textAlignment="textEnd"/>
+
+        <SeekBar
+            android:id="@+id/input_opacity_seekbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/input_opacity_name"
+            android:layout_alignParentStart="true"
+            android:layout_marginTop="@dimen/spacing_medlarge"
+            android:layout_marginBottom="@dimen/spacing_large"
+            android:layout_toStartOf="@id/input_opacity_value" />
+
+    </RelativeLayout>
+
+</RelativeLayout>

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_gc.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_gc.xml
@@ -12,7 +12,7 @@
 
     <item
         android:id="@+id/menu_emulation_adjust_scale"
-        android:title="@string/emulation_control_scale"/>
+        android:title="@string/emulation_control_adjustments"/>
 
     <item
         android:id="@+id/menu_emulation_joystick_rel_center"

--- a/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_overlay_controls_wii.xml
@@ -12,7 +12,7 @@
 
     <item
         android:id="@+id/menu_emulation_adjust_scale"
-        android:title="@string/emulation_control_scale"/>
+        android:title="@string/emulation_control_adjustments"/>
 
     <group android:checkableBehavior="all">
         <item

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -396,6 +396,8 @@ It can efficiently compress both junk data and encrypted Wii data.
     <string name="emulation_toggle_controls">Toggle Controls</string>
     <string name="emulation_toggle_all">Toggle All</string>
     <string name="emulation_control_scale">Adjust Scale</string>
+    <string name="emulation_control_opacity">Adjust Opacity</string>
+    <string name="emulation_control_adjustments">Adjust Controls</string>
     <string name="emulation_control_joystick_rel_center">Relative Stick Center</string>
     <string name="emulation_control_rumble">Rumble</string>
     <string name="emulation_choose_controller">Choose Controller</string>


### PR DESCRIPTION
Added Opacity controls for the user to customize the opacity level of their touchscreen controls. Also, placed both Scale and Opacity settings into one window/option called Adjust Controls.