### PR TITLE
DolphinQt: Qt 6.0 forward-compatibility changes

### DIFF
--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -11,6 +11,7 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QScrollBar>
 #include <QStringListModel>
 #include <QTextCursor>
@@ -161,7 +162,7 @@ void GameConfigEdit::AddBoolOption(QMenu* menu, const QString& name, const QStri
 void GameConfigEdit::SetOption(const QString& section, const QString& key, const QString& value)
 {
   auto section_cursor =
-      m_edit->document()->find(QRegExp(QStringLiteral("^\\[%1\\]").arg(section)), 0);
+      m_edit->document()->find(QRegularExpression(QStringLiteral("^\\[%1\\]").arg(section)), 0);
 
   // Check if the section this belongs in can be found
   if (section_cursor.isNull())
@@ -170,8 +171,8 @@ void GameConfigEdit::SetOption(const QString& section, const QString& key, const
   }
   else
   {
-    auto value_cursor =
-        m_edit->document()->find(QRegExp(QStringLiteral("^%1 = .*").arg(key)), section_cursor);
+    auto value_cursor = m_edit->document()->find(
+        QRegularExpression(QStringLiteral("^%1 = .*").arg(key)), section_cursor);
 
     const QString new_line = QStringLiteral("%1 = %2").arg(key).arg(value);
 

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -9,7 +9,7 @@
 
 #include <QApplication>
 #include <QPushButton>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QTimer>
 
@@ -51,8 +51,8 @@ QString GetExpressionForControl(const QString& control_name,
 
   if (quote == Quote::On)
   {
-    QRegExp reg(QStringLiteral("[a-zA-Z]+"));
-    if (!reg.exactMatch(expr))
+    const QRegularExpression reg(QStringLiteral("[a-zA-Z]+"));
+    if (!reg.match(expr).hasMatch())
       expr = QStringLiteral("`%1`").arg(expr);
   }
 

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -40,9 +40,9 @@ QTableWidgetItem* GetSocketDomain(s32 host_fd)
   switch (sa.sa_family)
   {
   case 2:
-    return new QTableWidgetItem(QLatin1Literal("AF_INET"));
+    return new QTableWidgetItem(QStringLiteral("AF_INET"));
   case 23:
-    return new QTableWidgetItem(QLatin1Literal("AF_INET6"));
+    return new QTableWidgetItem(QStringLiteral("AF_INET6"));
   default:
     return new QTableWidgetItem(QString::number(sa.sa_family));
   }
@@ -63,9 +63,9 @@ QTableWidgetItem* GetSocketType(s32 host_fd)
   switch (so_type)
   {
   case 1:
-    return new QTableWidgetItem(QLatin1Literal("SOCK_STREAM"));
+    return new QTableWidgetItem(QStringLiteral("SOCK_STREAM"));
   case 2:
-    return new QTableWidgetItem(QLatin1Literal("SOCK_DGRAM"));
+    return new QTableWidgetItem(QStringLiteral("SOCK_DGRAM"));
   default:
     return new QTableWidgetItem(QString::number(so_type));
   }

--- a/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/RegisterWidget.cpp
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include <QActionGroup>
 #include <QHeaderView>
 #include <QMenu>
 #include <QTableWidget>

--- a/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/ThreadWidget.cpp
@@ -131,10 +131,10 @@ void ThreadWidget::ShowContextMenu(QTableWidget* table)
 
 QLineEdit* ThreadWidget::CreateLineEdit() const
 {
-  QLineEdit* line_edit = new QLineEdit(QLatin1Literal("00000000"));
+  QLineEdit* line_edit = new QLineEdit(QStringLiteral("00000000"));
   line_edit->setReadOnly(true);
   line_edit->setFixedWidth(
-      line_edit->fontMetrics().boundingRect(QLatin1Literal(" 00000000 ")).width());
+      line_edit->fontMetrics().boundingRect(QStringLiteral(" 00000000 ")).width());
   return line_edit;
 }
 
@@ -374,39 +374,39 @@ void ThreadWidget::UpdateThreadContext(const Common::Debug::PartialContext& cont
     switch (i)
     {
     case 8:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("CR")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("CR")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.cr)));
       break;
     case 9:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("LR")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("LR")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.lr)));
       break;
     case 10:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("CTR")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("CTR")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.ctr)));
       break;
     case 11:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("XER")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("XER")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.xer)));
       break;
     case 12:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("FPSCR")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("FPSCR")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.fpscr)));
       break;
     case 13:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("SRR0")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("SRR0")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.srr0)));
       break;
     case 14:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("SRR1")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("SRR1")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.srr1)));
       break;
     case 15:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("DUMMY")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("DUMMY")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.dummy)));
       break;
     case 16:
-      m_context_table->setItem(i, 6, new QTableWidgetItem(QLatin1Literal("STATE")));
+      m_context_table->setItem(i, 6, new QTableWidgetItem(QStringLiteral("STATE")));
       m_context_table->setItem(i, 7, new QTableWidgetItem(format_hex(context.state)));
       break;
     default:
@@ -454,7 +454,7 @@ void ThreadWidget::UpdateThreadCallstack(const Common::Debug::PartialContext& co
     }
     else
     {
-      m_callstack_table->setItem(i, 2, new QTableWidgetItem(QLatin1Literal("--------")));
+      m_callstack_table->setItem(i, 2, new QTableWidgetItem(QStringLiteral("--------")));
     }
     sp = PowerPC::HostRead_U32(sp);
     m_callstack_table->setItem(i, 1, new QTableWidgetItem(format_hex(sp)));

--- a/Source/Core/DolphinQt/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt/GameList/GameListModel.cpp
@@ -7,6 +7,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QPixmap>
+#include <QRegularExpression>
 
 #include "Core/ConfigManager.h"
 
@@ -96,7 +97,8 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
       const int disc_nr = game.GetDiscNumber() + 1;
       if (disc_nr > 1)
       {
-        if (!name.contains(QRegExp(QStringLiteral("disc ?%1").arg(disc_nr), Qt::CaseInsensitive)))
+        if (!name.contains(QRegularExpression(QStringLiteral("disc ?%1").arg(disc_nr),
+                                              QRegularExpression::CaseInsensitiveOption)))
         {
           name.append(tr(" (Disc %1)").arg(disc_nr));
         }
@@ -107,11 +109,14 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
       {
         constexpr int MAX_NUMBER_LENGTH = 10;
 
-        QRegExp rx(QStringLiteral("\\d+"));
+        const QRegularExpression rx(QStringLiteral("\\d+"));
+        QRegularExpressionMatch match;
         int pos = 0;
-        while ((pos = rx.indexIn(name, pos)) != -1)
+        while ((match = rx.match(name, pos)).hasMatch())
         {
-          name.replace(pos, rx.matchedLength(), rx.cap().rightJustified(MAX_NUMBER_LENGTH));
+          pos = match.capturedStart();
+          name.replace(pos, match.capturedLength(),
+                       match.captured().rightJustified(MAX_NUMBER_LENGTH));
           pos += MAX_NUMBER_LENGTH;
         }
       }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -654,7 +654,7 @@ void MainWindow::ConnectStack()
 
   layout->addWidget(m_game_list);
   layout->addWidget(m_search_bar);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
 
   connect(m_search_bar, &SearchBar::Search, m_game_list, &GameList::SetSearchTerm);
 

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -7,6 +7,7 @@
 #include <cinttypes>
 
 #include <QAction>
+#include <QActionGroup>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QFontDialog>

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -5,6 +5,7 @@
 #include "DolphinQt/NetPlay/NetPlayDialog.h"
 
 #include <QAction>
+#include <QActionGroup>
 #include <QApplication>
 #include <QClipboard>
 #include <QComboBox>

--- a/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
+++ b/Source/Core/DolphinQt/QtUtils/FlowLayout.cpp
@@ -151,7 +151,11 @@ QSize FlowLayout::minimumSize() const
   for (const auto& item : m_item_list)
     size = size.expandedTo(item->minimumSize());
 
-  size += QSize(2 * margin(), 2 * margin());
+  // Any direction's margin works, as they all set the same within the constructor.
+  int margin = 0;
+  getContentsMargins(&margin, nullptr, nullptr, nullptr);
+
+  size += QSize(2 * margin, 2 * margin);
   return size;
 }
 

--- a/Source/Core/DolphinQt/QtUtils/WrapInScrollArea.cpp
+++ b/Source/Core/DolphinQt/QtUtils/WrapInScrollArea.cpp
@@ -48,7 +48,7 @@ void WrapInScrollArea(QWidget* parent, QLayout* wrapped_layout, QWidget* to_resi
 
   auto* scroll_layout = new QVBoxLayout;
   scroll_layout->addWidget(scroll_area);
-  scroll_layout->setMargin(0);
+  scroll_layout->setContentsMargins(0, 0, 0, 0);
 
   parent->setLayout(scroll_layout);
 }

--- a/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
+++ b/Source/Core/DolphinQt/Settings/AdvancedPane.cpp
@@ -221,10 +221,10 @@ void AdvancedPane::ConnectLayout()
   });
 
   QDateTime initial_date_time;
-  initial_date_time.setTime_t(SConfig::GetInstance().m_customRTCValue);
+  initial_date_time.setSecsSinceEpoch(SConfig::GetInstance().m_customRTCValue);
   m_custom_rtc_datetime->setDateTime(initial_date_time);
   connect(m_custom_rtc_datetime, &QDateTimeEdit::dateTimeChanged, [this](QDateTime date_time) {
-    SConfig::GetInstance().m_customRTCValue = date_time.toTime_t();
+    SConfig::GetInstance().m_customRTCValue = static_cast<u32>(date_time.toSecsSinceEpoch());
     Update();
   });
 }


### PR DESCRIPTION
Makes changes that should ease us into transitioning over to Qt 6.0 in the future. Qt 6 brings a few breaking changes with it, and thankfully, replacements for most of those deprecated or removed features were introduced within Qt 5, so we can replace those obsoleted features.

This way when we move to Qt 6, way less things will break due to APIs being removed or changed.