### PR TITLE
gradle.properties: Remove duplicate property keys

### DIFF
--- a/Source/Android/gradle.properties
+++ b/Source/Android/gradle.properties
@@ -14,5 +14,3 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
PR #7864 accidentally duplicated two keys in gradle.properties