### PR TITLE
JitArm64: Avoid using X30 with BLR

### DIFF
--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -912,14 +912,14 @@ public:
   }
 
   // This function expects you to have set up the state.
-  // Overwrites X0 and X30
+  // Overwrites X0 and X8
   template <typename T, typename... Args>
   ARM64Reg ABI_SetupLambda(const std::function<T(Args...)>* f)
   {
     auto trampoline = &ARM64XEmitter::CallLambdaTrampoline<T, Args...>;
-    MOVI2R(X30, (uintptr_t)trampoline);
-    MOVI2R(X0, (uintptr_t) const_cast<void*>((const void*)f));
-    return X30;
+    MOVP2R(X8, trampoline);
+    MOVP2R(X0, const_cast<void*>((const void*)f));
+    return X8;
   }
 
   // Plain function call

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -157,9 +157,9 @@ void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
   }
 
   Interpreter::Instruction instr = PPCTables::GetInterpreterOp(inst);
+  MOVP2R(X8, instr);
   MOVI2R(W0, inst.hex);
-  MOVP2R(X30, instr);
-  BLR(X30);
+  BLR(X8);
 
   if (js.op->opinfo->flags & FL_ENDBLOCK)
   {
@@ -213,10 +213,10 @@ void JitArm64::HLEFunction(u32 hook_index)
   gpr.Flush(FlushMode::All);
   fpr.Flush(FlushMode::All);
 
+  MOVP2R(X8, &HLE::Execute);
   MOVI2R(W0, js.compilerPC);
   MOVI2R(W1, hook_index);
-  MOVP2R(X30, &HLE::Execute);
-  BLR(X30);
+  BLR(X8);
 }
 
 void JitArm64::DoNothing(UGeckoInstruction inst)
@@ -246,11 +246,11 @@ void JitArm64::Cleanup()
   // SPEED HACK: MMCR0/MMCR1 should be checked at run-time, not at compile time.
   if (MMCR0.Hex || MMCR1.Hex)
   {
-    MOVP2R(X30, &PowerPC::UpdatePerformanceMonitor);
+    MOVP2R(X8, &PowerPC::UpdatePerformanceMonitor);
     MOVI2R(X0, js.downcountAmount);
     MOVI2R(X1, js.numLoadStoreInst);
     MOVI2R(X2, js.numFloatingPointInst);
-    BLR(X30);
+    BLR(X8);
   }
 }
 
@@ -453,10 +453,10 @@ void JitArm64::WriteExceptionExit(u32 destination, bool only_external)
   STR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
   STR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(npc));
   if (only_external)
-    MOVP2R(X30, &PowerPC::CheckExternalExceptions);
+    MOVP2R(X8, &PowerPC::CheckExternalExceptions);
   else
-    MOVP2R(X30, &PowerPC::CheckExceptions);
-  BLR(X30);
+    MOVP2R(X8, &PowerPC::CheckExceptions);
+  BLR(X8);
   LDR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(npc));
 
   SetJumpTarget(no_exceptions);
@@ -714,8 +714,8 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       SetJumpTarget(Exception);
       ABI_PushRegisters(regs_in_use);
       m_float_emit.ABI_PushRegisters(fprs_in_use, X30);
-      MOVP2R(X30, &GPFifo::FastCheckGatherPipe);
-      BLR(X30);
+      MOVP2R(X8, &GPFifo::FastCheckGatherPipe);
+      BLR(X8);
       m_float_emit.ABI_PopRegisters(fprs_in_use, X30);
       ABI_PopRegisters(regs_in_use);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -187,49 +187,49 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, AR
       {
         m_float_emit.FCVT(32, 64, D0, RS);
         m_float_emit.UMOV(32, W0, Q0, 0);
-        MOVP2R(X30, &PowerPC::Write_U32);
-        BLR(X30);
+        MOVP2R(X8, &PowerPC::Write_U32);
+        BLR(X8);
       }
       else if (flags & BackPatchInfo::FLAG_SIZE_F32I)
       {
         m_float_emit.UMOV(32, W0, RS, 0);
-        MOVP2R(X30, &PowerPC::Write_U32);
-        BLR(X30);
+        MOVP2R(X8, &PowerPC::Write_U32);
+        BLR(X8);
       }
       else if (flags & BackPatchInfo::FLAG_SIZE_F32X2)
       {
         m_float_emit.FCVTN(32, D0, RS);
         m_float_emit.UMOV(64, X0, D0, 0);
         ROR(X0, X0, 32);
-        MOVP2R(X30, &PowerPC::Write_U64);
-        BLR(X30);
+        MOVP2R(X8, &PowerPC::Write_U64);
+        BLR(X8);
       }
       else if (flags & BackPatchInfo::FLAG_SIZE_F32X2I)
       {
         m_float_emit.UMOV(64, X0, RS, 0);
         ROR(X0, X0, 32);
-        MOVP2R(X30, &PowerPC::Write_U64);
-        BLR(X30);
+        MOVP2R(X8, &PowerPC::Write_U64);
+        BLR(X8);
       }
       else
       {
-        MOVP2R(X30, &PowerPC::Write_U64);
+        MOVP2R(X8, &PowerPC::Write_U64);
         m_float_emit.UMOV(64, X0, RS, 0);
-        BLR(X30);
+        BLR(X8);
       }
     }
     else if (flags & BackPatchInfo::FLAG_LOAD && flags & BackPatchInfo::FLAG_MASK_FLOAT)
     {
       if (flags & BackPatchInfo::FLAG_SIZE_F32)
       {
-        MOVP2R(X30, &PowerPC::Read_U32);
-        BLR(X30);
+        MOVP2R(X8, &PowerPC::Read_U32);
+        BLR(X8);
         m_float_emit.INS(32, RS, 0, X0);
       }
       else
       {
-        MOVP2R(X30, &PowerPC::Read_F64);
-        BLR(X30);
+        MOVP2R(X8, &PowerPC::Read_F64);
+        BLR(X8);
         m_float_emit.INS(64, RS, 0, X0);
       }
     }
@@ -238,29 +238,29 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, AR
       MOV(W0, RS);
 
       if (flags & BackPatchInfo::FLAG_SIZE_32)
-        MOVP2R(X30, &PowerPC::Write_U32);
+        MOVP2R(X8, &PowerPC::Write_U32);
       else if (flags & BackPatchInfo::FLAG_SIZE_16)
-        MOVP2R(X30, &PowerPC::Write_U16);
+        MOVP2R(X8, &PowerPC::Write_U16);
       else
-        MOVP2R(X30, &PowerPC::Write_U8);
+        MOVP2R(X8, &PowerPC::Write_U8);
 
-      BLR(X30);
+      BLR(X8);
     }
     else if (flags & BackPatchInfo::FLAG_ZERO_256)
     {
-      MOVP2R(X30, &PowerPC::ClearCacheLine);
-      BLR(X30);
+      MOVP2R(X8, &PowerPC::ClearCacheLine);
+      BLR(X8);
     }
     else
     {
       if (flags & BackPatchInfo::FLAG_SIZE_32)
-        MOVP2R(X30, &PowerPC::Read_U32);
+        MOVP2R(X8, &PowerPC::Read_U32);
       else if (flags & BackPatchInfo::FLAG_SIZE_16)
-        MOVP2R(X30, &PowerPC::Read_U16);
+        MOVP2R(X8, &PowerPC::Read_U16);
       else if (flags & BackPatchInfo::FLAG_SIZE_8)
-        MOVP2R(X30, &PowerPC::Read_U8);
+        MOVP2R(X8, &PowerPC::Read_U8);
 
-      BLR(X30);
+      BLR(X8);
 
       if (!(flags & BackPatchInfo::FLAG_REVERSE))
       {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -82,8 +82,8 @@ void JitArm64::psq_l(UGeckoInstruction inst)
     UBFM(scale_reg, scale_reg, 24, 29);  // Scale
 
     MOVP2R(X30, inst.W ? single_load_quantized : paired_load_quantized);
-    LDR(X30, X30, ArithOption(EncodeRegTo64(type_reg), true));
-    BLR(X30);
+    LDR(EncodeRegTo64(type_reg), X30, ArithOption(EncodeRegTo64(type_reg), true));
+    BLR(EncodeRegTo64(type_reg));
 
     VS = fpr.RW(inst.RS, RegType::Single);
     m_float_emit.ORR(EncodeRegToDouble(VS), D0, D0);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -125,9 +125,9 @@ void JitArm64::GenerateAsm()
 
   // Call C version of Dispatch().
   STR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
+  MOVP2R(X8, reinterpret_cast<void*>(&JitBase::Dispatch));
   MOVP2R(X0, this);
-  MOVP2R(X30, reinterpret_cast<void*>(&JitBase::Dispatch));
-  BLR(X30);
+  BLR(X8);
 
   FixupBranch no_block_available = CBZ(X0);
 
@@ -145,8 +145,8 @@ void JitArm64::GenerateAsm()
   ResetStack();
   MOVP2R(X0, this);
   MOV(W1, DISPATCHER_PC);
-  MOVP2R(X30, reinterpret_cast<void*>(&JitTrampoline));
-  BLR(X30);
+  MOVP2R(X8, reinterpret_cast<void*>(&JitTrampoline));
+  BLR(X8);
   LDR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
   B(dispatcher_no_check);
 
@@ -165,8 +165,8 @@ void JitArm64::GenerateAsm()
   FixupBranch Exit = B(CC_NEQ);
 
   SetJumpTarget(to_start_of_timing_slice);
-  MOVP2R(X30, &CoreTiming::Advance);
-  BLR(X30);
+  MOVP2R(X8, &CoreTiming::Advance);
+  BLR(X8);
 
   // Load the PC back into DISPATCHER_PC (the exception handler might have changed it)
   LDR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));


### PR DESCRIPTION
At least on some CPUs (I found out about this from the Arm Cortex-A76 Software Optimization Guide), using X30 with BLR is one cycle slower than using another register.