### PR TITLE
Qt: Fix Shake Mapping Indicator not showing deadzone

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.cpp
@@ -592,9 +592,13 @@ void ShakeMappingIndicator::Draw()
   p.scale(1.0, -1.0);
 
   // Deadzone.
-  p.setPen(GetDeadZonePen());
-  p.setBrush(GetDeadZoneBrush(p));
-  p.drawRect(-1.0, 0, 2, m_shake_group.GetDeadzone());
+  const double deadzone = m_shake_group.GetDeadzone();
+  if (deadzone > 0.0)
+  {
+    p.setPen(GetDeadZonePen());
+    p.setBrush(GetDeadZoneBrush(p));
+    p.drawRect(QRectF(-1, 0, 2, deadzone));
+  }
 
   // Raw input.
   const auto raw_coord = m_shake_group.GetState(false);


### PR DESCRIPTION
QRectF was missing from drawRect which meant the deazone was casted to an int, flooring its value (it goes from 0 to 1).