### PR TITLE
Jit64: boolx - Eliminate read dependency

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -690,7 +690,7 @@ void Jit64::boolX(UGeckoInstruction inst)
       else
       {
         RCOpArg Rs = gpr.Use(s, RCMode::Read);
-        RCX64Reg Ra = gpr.Bind(a, RCMode::ReadWrite);
+        RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
         RegCache::Realize(Rs, Ra);
         MOV(32, Ra, Rs);
         NOT(32, Ra);


### PR DESCRIPTION
For certain occurrences of nandx/norx, we declare a ReadWrite constraint on the destination register, even though the value of the destination register is irrelevant. This false dependency would force the RegCache to generate a redundant MOV when the destination register wasn't already assigned to a host register.

Example 1:
```
BF 00 00 00 00       mov         edi,0
8B FE                mov         edi,esi
F7 D7                not         edi
```

Example 2:
```
8B 7D 80             mov         edi,dword ptr [rbp-80h]
8B FE                mov         edi,esi
F7 D7                not         edi
```