### PR TITLE
Android: Fix in-game settings changes not getting saved

### DIFF
--- a/Source/Android/jni/NativeConfig.cpp
+++ b/Source/Android/jni/NativeConfig.cpp
@@ -128,7 +128,12 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_unloadGameIn
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_save(
     JNIEnv*, jclass, jint layer)
 {
-  return GetLayer(layer, {})->Save();
+  const std::shared_ptr<Config::Layer> layer_ptr = GetLayer(layer, {});
+
+  // Workaround for the Settings class carrying around a legacy map of settings it always saves
+  layer_ptr->MarkAsDirty();
+
+  return layer_ptr->Save();
 }
 
 JNIEXPORT jboolean JNICALL

--- a/Source/Core/Common/Config/Layer.h
+++ b/Source/Core/Common/Config/Layer.h
@@ -138,6 +138,8 @@ public:
     m_map.insert_or_assign(location, std::move(new_value));
   }
 
+  void MarkAsDirty() { m_is_dirty = true; }
+
   Section GetSection(System system, const std::string& section);
   ConstSection GetSection(System system, const std::string& section) const;
 


### PR DESCRIPTION
`EmulationActivity` has an instance of `Settings`. If you go to `SettingsActivity` from `EmulationActivity` and change some settings, the changes get saved to disk, but `EmulationActivity`'s `Settings` instance still contains the old settings in its map of all settings (assuming the `EmulationActivity` was not killed by the system to save memory). Then, once you're done playing your game and exit `EmulationActivity`, `EmulationActivity` calls `Settings.saveSettings`. This call to `saveSettings` first overwrites the entire INI file with its map of all settings (which is outdated) in order to save any legacy settings that have changed (which they haven't, since the GUI doesn't let you change legacy settings while a game is running). Then, it asks the new config system to write the most up-to-date values available for non-legacy settings, which should make all the settings be up-to-date again. The problem here is that the new config system would skip writing to disk if no settings changes had been made since the last time we asked it to write to disk (i.e. since `SettingsActivity` exited).

NB: Calling `Settings.loadSettings` in `EmulationActivity.onResume` is not a working solution. I assume this is because `SettingsActivity` saves its settings in `onStop` and not `onPause`.