### PR TITLE
Breakpoint from string flag parsing using token

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -65,12 +65,13 @@ void BreakPoints::AddFromStrings(const TBreakPointsStr& bp_strings)
   for (const std::string& bp_string : bp_strings)
   {
     TBreakPoint bp;
-    std::stringstream ss;
-    ss << std::hex << bp_string;
-    ss >> bp.address;
-    bp.is_enabled = bp_string.find('n') != bp_string.npos;
-    bp.log_on_hit = bp_string.find('l') != bp_string.npos;
-    bp.break_on_hit = bp_string.find('b') != bp_string.npos;
+    std::string flags;
+    std::istringstream iss(bp_string);
+    iss >> std::hex >> bp.address;
+    iss >> flags;
+    bp.is_enabled = flags.find('n') != flags.npos;
+    bp.log_on_hit = flags.find('l') != flags.npos;
+    bp.break_on_hit = flags.find('b') != flags.npos;
     bp.is_temporary = false;
     Add(bp);
   }


### PR DESCRIPTION
When searching the breakpoint string for `"b"` for the `break_on_hit` flag you can get a false hit because the hex address may include the letter `b`. For example, `80,0cb,46c nl` was incorrectly enabling break on hit.

If you read the next token from the string stream, you will have the flags alone. You can then search these for each letter and you won't get a false hit.

This is quite a neat bug :smile: 