### PR TITLE
JitArm64: Set flush-to-zero/rounding mode and improve float/double conversion accuracy

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -3601,6 +3601,14 @@ void ARM64FloatEmitter::FCMLT(u8 size, ARM64Reg Rd, ARM64Reg Rn)
 {
   Emit2RegMisc(IsQuad(Rd), 0, 2 | (size >> 6), 0xE, Rd, Rn);
 }
+void ARM64FloatEmitter::FACGE(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
+{
+  EmitThreeSame(1, size >> 6, 0x1D, Rd, Rn, Rm);
+}
+void ARM64FloatEmitter::FACGT(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
+{
+  EmitThreeSame(1, 2 | (size >> 6), 0x1D, Rd, Rn, Rm);
+}
 
 void ARM64FloatEmitter::FCSEL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, CCFlags cond)
 {

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -1094,6 +1094,8 @@ public:
   void FCMGT(u8 size, ARM64Reg Rd, ARM64Reg Rn);
   void FCMLE(u8 size, ARM64Reg Rd, ARM64Reg Rn);
   void FCMLT(u8 size, ARM64Reg Rd, ARM64Reg Rn);
+  void FACGE(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+  void FACGT(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 
   // Conditional select
   void FCSEL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, CCFlags cond);

--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -69,6 +69,7 @@ void CPUInfo::Detect()
   CPU64bit = true;
   Mode64bit = true;
   vendor = CPUVendor::ARM;
+  bFlushToZero = true;
 
 #ifdef _WIN32
   num_cores = std::thread::hardware_concurrency();

--- a/Source/Core/Common/ArmFPURoundMode.cpp
+++ b/Source/Core/Common/ArmFPURoundMode.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Common/CommonTypes.h"
+#include "Common/FPURoundMode.h"
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+static u64 GetFPCR()
+{
+#ifdef _MSC_VER
+  return _ReadStatusReg(ARM64_FPCR);
+#else
+  u64 fpcr;
+  __asm__ __volatile__("mrs %0, fpcr" : "=r"(fpcr));
+  return fpcr;
+#endif
+}
+
+static void SetFPCR(u64 fpcr)
+{
+#ifdef _MSC_VER
+  _WriteStatusReg(ARM64_FPCR, fpcr);
+#else
+  __asm__ __volatile__("msr fpcr, %0" : : "ri"(fpcr));
+#endif
+}
+
+namespace FPURoundMode
+{
+static const u64 default_fpcr = GetFPCR();
+static u64 saved_fpcr = default_fpcr;
+
+void SetRoundMode(int mode)
+{
+  // We don't need to do anything here since SetSIMDMode is always called after calling this
+}
+
+void SetPrecisionMode(PrecisionMode mode)
+{
+}
+
+void SetSIMDMode(int rounding_mode, bool non_ieee_mode)
+{
+  // Flush-To-Zero (non-IEEE mode: denormal outputs are set to +/- 0)
+  constexpr u32 FZ = 1 << 24;
+
+  // lookup table for FPSCR.RN-to-FPCR.RMode translation
+  constexpr u32 rounding_mode_table[] = {
+      (0 << 22),  // nearest
+      (3 << 22),  // zero
+      (1 << 22),  // +inf
+      (2 << 22),  // -inf
+  };
+
+  const u64 base = default_fpcr & ~(0b111 << 22);
+  SetFPCR(base | rounding_mode_table[rounding_mode] | (non_ieee_mode ? FZ : 0));
+}
+
+void SaveSIMDState()
+{
+  saved_fpcr = GetFPCR();
+}
+
+void LoadSIMDState()
+{
+  SetFPCR(saved_fpcr);
+}
+
+void LoadDefaultSIMDState()
+{
+  SetFPCR(default_fpcr);
+}
+
+}  // namespace FPURoundMode

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -199,7 +199,7 @@ if(_M_ARM_64)
     Arm64Emitter.h
     ArmCommon.h
     ArmCPUDetect.cpp
-    GenericFPURoundMode.cpp
+    ArmFPURoundMode.cpp
   )
 else()
   if(_M_X86) #X86

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -982,6 +982,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
     js.compilerPC = op.address;
     js.op = &op;
+    js.fpr_is_store_safe = op.fprIsStoreSafeBeforeInst;
     js.instructionNumber = i;
     js.instructionsLeft = (code_block.m_num_instructions - 1) - i;
     const GekkoOPInfo* opinfo = op.opinfo;
@@ -1117,6 +1118,8 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       }
 
       CompileInstruction(op);
+
+      js.fpr_is_store_safe = op.fprIsStoreSafeAfterInst;
 
       if (jo.memcheck && (opinfo->flags & FL_LOADSTORE))
       {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -105,7 +105,7 @@ void Jit64::stfXXX(UGeckoInstruction inst)
 
   if (single)
   {
-    if (js.op->fprIsStoreSafe[s])
+    if (js.fpr_is_store_safe[s])
     {
       RCOpArg Rs = fpr.Use(s, RCMode::Read);
       RegCache::Realize(Rs);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -695,6 +695,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
     js.compilerPC = op.address;
     js.op = &op;
+    js.fpr_is_store_safe = op.fprIsStoreSafeBeforeInst;
     js.instructionNumber = i;
     js.instructionsLeft = (code_block.m_num_instructions - 1) - i;
     const GekkoOPInfo* opinfo = op.opinfo;
@@ -830,6 +831,9 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       }
 
       CompileInstruction(op);
+
+      js.fpr_is_store_safe = op.fprIsStoreSafeAfterInst;
+
       if (!CanMergeNextInstructions(1) || js.op[1].opinfo->type != ::OpType::Integer)
         FlushCarry();
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -163,7 +163,7 @@ public:
                                  Arm64Gen::ARM64Reg src_reg,
                                  Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
 
-private:
+protected:
   struct SlowmemHandler
   {
     Arm64Gen::ARM64Reg dest_reg;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -152,11 +152,15 @@ public:
   void psq_l(UGeckoInstruction inst);
   void psq_st(UGeckoInstruction inst);
 
-  void ConvertDoubleToSingleLower(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
-  void ConvertDoubleToSinglePair(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
-  void ConvertSingleToDoubleLower(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg,
+  void ConvertDoubleToSingleLower(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
+                                  Arm64Gen::ARM64Reg src_reg);
+  void ConvertDoubleToSinglePair(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
+                                 Arm64Gen::ARM64Reg src_reg);
+  void ConvertSingleToDoubleLower(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
+                                  Arm64Gen::ARM64Reg src_reg,
                                   Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
-  void ConvertSingleToDoublePair(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg,
+  void ConvertSingleToDoublePair(size_t guest_reg, Arm64Gen::ARM64Reg dest_reg,
+                                 Arm64Gen::ARM64Reg src_reg,
                                  Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
 
 private:

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -154,8 +154,10 @@ public:
 
   void ConvertDoubleToSingleLower(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
   void ConvertDoubleToSinglePair(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
-  void ConvertSingleToDoubleLower(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
-  void ConvertSingleToDoublePair(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
+  void ConvertSingleToDoubleLower(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg,
+                                  Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
+  void ConvertSingleToDoublePair(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg,
+                                 Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
 
 private:
   struct SlowmemHandler
@@ -189,13 +191,17 @@ private:
     nearcode = GetWritableCodePtr();
     SetCodePtrUnsafe(farcode.GetWritableCodePtr());
     AlignCode16();
+    m_in_farcode = true;
   }
 
   void SwitchToNearCode()
   {
     farcode.SetCodePtrUnsafe(GetWritableCodePtr());
     SetCodePtrUnsafe(nearcode);
+    m_in_farcode = false;
   }
+
+  bool IsInFarCode() const { return m_in_farcode; }
 
   // Dump a memory range of code
   void DumpCode(const u8* start, const u8* end);
@@ -262,6 +268,7 @@ private:
 
   Arm64Gen::ARM64CodeBlock farcode;
   u8* nearcode;  // Backed up when we switch to far code.
+  bool m_in_farcode = false;
 
   bool m_enable_blr_optimization;
   bool m_cleanup_after_stackfault = false;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -163,6 +163,8 @@ public:
                                  Arm64Gen::ARM64Reg src_reg,
                                  Arm64Gen::ARM64Reg scratch_reg = Arm64Gen::ARM64Reg::INVALID_REG);
 
+  bool IsFPRStoreSafe(size_t guest_reg) const;
+
 protected:
   struct SlowmemHandler
   {

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -152,6 +152,11 @@ public:
   void psq_l(UGeckoInstruction inst);
   void psq_st(UGeckoInstruction inst);
 
+  void ConvertDoubleToSingleLower(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
+  void ConvertDoubleToSinglePair(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
+  void ConvertSingleToDoubleLower(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
+  void ConvertSingleToDoublePair(Arm64Gen::ARM64Reg dest_reg, Arm64Gen::ARM64Reg src_reg);
+
 private:
   struct SlowmemHandler
   {

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -221,6 +221,7 @@ private:
   void GenerateAsm();
   void GenerateCommonAsm();
   void GenerateConvertDoubleToSingle();
+  void GenerateConvertSingleToDouble();
   void GenerateQuantizedLoadStores();
 
   // Profiling

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -220,6 +220,8 @@ private:
   // AsmRoutines
   void GenerateAsm();
   void GenerateCommonAsm();
+  void GenerateConvertDoubleToSingle();
+  void GenerateQuantizedLoadStores();
 
   // Profiling
   void BeginTimeProfile(JitBlock* b);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -62,22 +62,10 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, AR
     {
       if (flags & BackPatchInfo::FLAG_SIZE_F32)
       {
-        m_float_emit.FCVT(32, 64, ARM64Reg::D0, RS);
-        m_float_emit.REV32(8, ARM64Reg::D0, ARM64Reg::D0);
-        m_float_emit.STR(32, ARM64Reg::D0, MEM_REG, addr);
-      }
-      else if (flags & BackPatchInfo::FLAG_SIZE_F32I)
-      {
         m_float_emit.REV32(8, ARM64Reg::D0, RS);
         m_float_emit.STR(32, ARM64Reg::D0, MEM_REG, addr);
       }
       else if (flags & BackPatchInfo::FLAG_SIZE_F32X2)
-      {
-        m_float_emit.FCVTN(32, ARM64Reg::D0, RS);
-        m_float_emit.REV32(8, ARM64Reg::D0, ARM64Reg::D0);
-        m_float_emit.STR(64, ARM64Reg::Q0, MEM_REG, addr);
-      }
-      else if (flags & BackPatchInfo::FLAG_SIZE_F32X2I)
       {
         m_float_emit.REV32(8, ARM64Reg::D0, RS);
         m_float_emit.STR(64, ARM64Reg::Q0, MEM_REG, addr);
@@ -185,36 +173,21 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode, AR
     {
       if (flags & BackPatchInfo::FLAG_SIZE_F32)
       {
-        m_float_emit.FCVT(32, 64, ARM64Reg::D0, RS);
-        m_float_emit.UMOV(32, ARM64Reg::W0, ARM64Reg::Q0, 0);
-        MOVP2R(ARM64Reg::X8, &PowerPC::Write_U32);
-        BLR(ARM64Reg::X8);
-      }
-      else if (flags & BackPatchInfo::FLAG_SIZE_F32I)
-      {
         m_float_emit.UMOV(32, ARM64Reg::W0, RS, 0);
         MOVP2R(ARM64Reg::X8, &PowerPC::Write_U32);
         BLR(ARM64Reg::X8);
       }
       else if (flags & BackPatchInfo::FLAG_SIZE_F32X2)
       {
-        m_float_emit.FCVTN(32, ARM64Reg::D0, RS);
-        m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::D0, 0);
-        ROR(ARM64Reg::X0, ARM64Reg::X0, 32);
-        MOVP2R(ARM64Reg::X8, &PowerPC::Write_U64);
-        BLR(ARM64Reg::X8);
-      }
-      else if (flags & BackPatchInfo::FLAG_SIZE_F32X2I)
-      {
         m_float_emit.UMOV(64, ARM64Reg::X0, RS, 0);
-        ROR(ARM64Reg::X0, ARM64Reg::X0, 32);
         MOVP2R(ARM64Reg::X8, &PowerPC::Write_U64);
+        ROR(ARM64Reg::X0, ARM64Reg::X0, 32);
         BLR(ARM64Reg::X8);
       }
       else
       {
-        MOVP2R(ARM64Reg::X8, &PowerPC::Write_U64);
         m_float_emit.UMOV(64, ARM64Reg::X0, RS, 0);
+        MOVP2R(ARM64Reg::X8, &PowerPC::Write_U64);
         BLR(ARM64Reg::X8);
       }
     }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -572,3 +572,8 @@ void JitArm64::ConvertSingleToDoublePair(size_t guest_reg, ARM64Reg dest_reg, AR
     SetJumpTarget(continue1);
   }
 }
+
+bool JitArm64::IsFPRStoreSafe(size_t guest_reg) const
+{
+  return js.fpr_is_store_safe[guest_reg];
+}

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -258,7 +258,7 @@ void JitArm64::frspx(UGeckoInstruction inst)
   const u32 d = inst.FD;
 
   const bool single = fpr.IsSingle(b, true);
-  if (single)
+  if (single && js.fpr_is_store_safe[b])
   {
     // Source is already in single precision, so no need to do anything but to copy to PSR1.
     const ARM64Reg VB = fpr.R(b, RegType::LowerPairSingle);
@@ -266,6 +266,9 @@ void JitArm64::frspx(UGeckoInstruction inst)
 
     if (b != d)
       m_float_emit.FMOV(EncodeRegToSingle(VD), EncodeRegToSingle(VB));
+
+    ASSERT_MSG(DYNA_REC, fpr.IsSingle(b, true),
+               "Register allocation turned singles into doubles in the middle of frspx");
   }
   else
   {
@@ -274,9 +277,6 @@ void JitArm64::frspx(UGeckoInstruction inst)
 
     m_float_emit.FCVT(32, 64, EncodeRegToDouble(VD), EncodeRegToDouble(VB));
   }
-
-  ASSERT_MSG(DYNA_REC, b == d || single == fpr.IsSingle(b, true),
-             "Register allocation turned singles into doubles in the middle of frspx");
 }
 
 void JitArm64::fcmpX(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -397,12 +397,12 @@ void JitArm64::ConvertDoubleToSingleLower(ARM64Reg dest_reg, ARM64Reg src_reg)
 {
   FlushCarry();
 
-  const BitSet32 gpr_saved = gpr.GetCallerSavedUsed();
+  const BitSet32 gpr_saved = gpr.GetCallerSavedUsed() & BitSet32{0, 1, 2, 3, 30};
   ABI_PushRegisters(gpr_saved);
 
   m_float_emit.UMOV(64, ARM64Reg::X0, src_reg, 0);
-  QuickCallFunction(ARM64Reg::X1, &ConvertToSingle);
-  m_float_emit.INS(32, dest_reg, 0, ARM64Reg::W0);
+  BL(cdts);
+  m_float_emit.INS(32, dest_reg, 0, ARM64Reg::W1);
 
   ABI_PopRegisters(gpr_saved);
 }
@@ -411,16 +411,16 @@ void JitArm64::ConvertDoubleToSinglePair(ARM64Reg dest_reg, ARM64Reg src_reg)
 {
   FlushCarry();
 
-  const BitSet32 gpr_saved = gpr.GetCallerSavedUsed();
+  const BitSet32 gpr_saved = gpr.GetCallerSavedUsed() & BitSet32{0, 1, 2, 3, 30};
   ABI_PushRegisters(gpr_saved);
 
   m_float_emit.UMOV(64, ARM64Reg::X0, src_reg, 0);
-  QuickCallFunction(ARM64Reg::X1, &ConvertToSingle);
-  m_float_emit.INS(32, dest_reg, 0, ARM64Reg::W0);
+  BL(cdts);
+  m_float_emit.INS(32, dest_reg, 0, ARM64Reg::W1);
 
   m_float_emit.UMOV(64, ARM64Reg::X0, src_reg, 1);
-  QuickCallFunction(ARM64Reg::X1, &ConvertToSingle);
-  m_float_emit.INS(32, dest_reg, 1, ARM64Reg::W0);
+  BL(cdts);
+  m_float_emit.INS(32, dest_reg, 1, ARM64Reg::W1);
 
   ABI_PopRegisters(gpr_saved);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -386,3 +386,23 @@ void JitArm64::fctiwzx(UGeckoInstruction inst)
   ASSERT_MSG(DYNA_REC, b == d || single == fpr.IsSingle(b, true),
              "Register allocation turned singles into doubles in the middle of fctiwzx");
 }
+
+void JitArm64::ConvertDoubleToSingleLower(ARM64Reg dest_reg, ARM64Reg src_reg)
+{
+  m_float_emit.FCVT(32, 64, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
+}
+
+void JitArm64::ConvertDoubleToSinglePair(ARM64Reg dest_reg, ARM64Reg src_reg)
+{
+  m_float_emit.FCVTN(32, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
+}
+
+void JitArm64::ConvertSingleToDoubleLower(ARM64Reg dest_reg, ARM64Reg src_reg)
+{
+  m_float_emit.FCVT(64, 32, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
+}
+
+void JitArm64::ConvertSingleToDoublePair(ARM64Reg dest_reg, ARM64Reg src_reg)
+{
+  m_float_emit.FCVTL(64, EncodeRegToDouble(dest_reg), EncodeRegToDouble(src_reg));
+}

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -258,7 +258,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
   if (want_single && !have_single)
   {
     const ARM64Reg single_reg = fpr.GetReg();
-    ConvertDoubleToSingleLower(single_reg, V0);
+    ConvertDoubleToSingleLower(inst.FS, single_reg, V0);
     V0 = single_reg;
   }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -189,6 +189,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 
   u32 a = inst.RA, b = inst.RB;
 
+  bool want_single = false;
   s32 offset = inst.SIMM_16;
   u32 flags = BackPatchInfo::FLAG_STORE;
   bool update = false;
@@ -200,10 +201,12 @@ void JitArm64::stfXX(UGeckoInstruction inst)
     switch (inst.SUBOP10)
     {
     case 663:  // stfsx
+      want_single = true;
       flags |= BackPatchInfo::FLAG_SIZE_F32;
       offset_reg = b;
       break;
     case 695:  // stfsux
+      want_single = true;
       flags |= BackPatchInfo::FLAG_SIZE_F32;
       update = true;
       offset_reg = b;
@@ -218,16 +221,19 @@ void JitArm64::stfXX(UGeckoInstruction inst)
       offset_reg = b;
       break;
     case 983:  // stfiwx
-      flags |= BackPatchInfo::FLAG_SIZE_F32I;
+      // This instruction writes the lower 32 bits of a double. want_single must be false
+      flags |= BackPatchInfo::FLAG_SIZE_F32;
       offset_reg = b;
       break;
     }
     break;
   case 53:  // stfsu
+    want_single = true;
     flags |= BackPatchInfo::FLAG_SIZE_F32;
     update = true;
     break;
   case 52:  // stfs
+    want_single = true;
     flags |= BackPatchInfo::FLAG_SIZE_F32;
     break;
   case 55:  // stfdu
@@ -242,18 +248,21 @@ void JitArm64::stfXX(UGeckoInstruction inst)
   u32 imm_addr = 0;
   bool is_immediate = false;
 
-  gpr.Lock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
   fpr.Lock(ARM64Reg::Q0);
 
-  const bool single = (flags & BackPatchInfo::FLAG_SIZE_F32) && fpr.IsSingle(inst.FS, true);
+  const bool have_single = fpr.IsSingle(inst.FS, true);
 
-  const ARM64Reg V0 = fpr.R(inst.FS, single ? RegType::LowerPairSingle : RegType::LowerPair);
+  ARM64Reg V0 =
+      fpr.R(inst.FS, want_single && have_single ? RegType::LowerPairSingle : RegType::LowerPair);
 
-  if (single)
+  if (want_single && !have_single)
   {
-    flags &= ~BackPatchInfo::FLAG_SIZE_F32;
-    flags |= BackPatchInfo::FLAG_SIZE_F32I;
+    const ARM64Reg single_reg = fpr.GetReg();
+    m_float_emit.FCVT(32, 64, EncodeRegToDouble(single_reg), EncodeRegToDouble(V0));
+    V0 = single_reg;
   }
+
+  gpr.Lock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
 
   ARM64Reg addr_reg = ARM64Reg::W1;
 
@@ -359,19 +368,11 @@ void JitArm64::stfXX(UGeckoInstruction inst)
         accessSize = 32;
 
       LDR(IndexType::Unsigned, ARM64Reg::X0, PPC_REG, PPCSTATE_OFF(gather_pipe_ptr));
+
       if (flags & BackPatchInfo::FLAG_SIZE_F64)
-      {
         m_float_emit.REV64(8, ARM64Reg::Q0, V0);
-      }
       else if (flags & BackPatchInfo::FLAG_SIZE_F32)
-      {
-        m_float_emit.FCVT(32, 64, ARM64Reg::D0, EncodeRegToDouble(V0));
-        m_float_emit.REV32(8, ARM64Reg::D0, ARM64Reg::D0);
-      }
-      else if (flags & BackPatchInfo::FLAG_SIZE_F32I)
-      {
         m_float_emit.REV32(8, ARM64Reg::D0, V0);
-      }
 
       m_float_emit.STR(accessSize, IndexType::Post, accessSize == 64 ? ARM64Reg::Q0 : ARM64Reg::D0,
                        ARM64Reg::X0, accessSize >> 3);
@@ -399,6 +400,10 @@ void JitArm64::stfXX(UGeckoInstruction inst)
   {
     EmitBackpatchRoutine(flags, jo.fastmem, jo.fastmem, V0, XA, regs_in_use, fprs_in_use);
   }
+
+  if (want_single && !have_single)
+    fpr.Unlock(V0);
+
   gpr.Unlock(ARM64Reg::W0, ARM64Reg::W1, ARM64Reg::W30);
   fpr.Unlock(ARM64Reg::Q0);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -258,7 +258,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
   if (want_single && !have_single)
   {
     const ARM64Reg single_reg = fpr.GetReg();
-    m_float_emit.FCVT(32, 64, EncodeRegToDouble(single_reg), EncodeRegToDouble(V0));
+    ConvertDoubleToSingleLower(single_reg, V0);
     V0 = single_reg;
   }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -15,6 +15,8 @@
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
 
+class JitArm64;
+
 // Dedicated host registers
 
 // memory base register
@@ -150,7 +152,7 @@ public:
   explicit Arm64RegCache(size_t guest_reg_count) : m_guest_registers(guest_reg_count) {}
   virtual ~Arm64RegCache() = default;
 
-  void Init(Arm64Gen::ARM64XEmitter* emitter);
+  void Init(JitArm64* jit);
 
   virtual void Start(PPCAnalyst::BlockRegStats& stats) {}
   void DiscardRegisters(BitSet32 regs);
@@ -217,6 +219,8 @@ protected:
     for (auto& reg : m_guest_registers)
       reg.IncrementLastUsed();
   }
+
+  JitArm64* m_jit = nullptr;
 
   // Code emitter
   Arm64Gen::ARM64XEmitter* m_emit = nullptr;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -168,6 +168,9 @@ public:
 
   void UpdateLastUsed(BitSet32 regs_used);
 
+  // Get available host registers
+  u32 GetUnlockedRegisterCount() const;
+
   // Locks a register so a cache cannot use it
   // Useful for function calls
   template <typename T = Arm64Gen::ARM64Reg, typename... Args>
@@ -210,9 +213,6 @@ protected:
 
   void DiscardRegister(size_t preg);
   virtual void FlushRegister(size_t preg, bool maintain_state) = 0;
-
-  // Get available host registers
-  u32 GetUnlockedRegisterCount() const;
 
   void IncrementAllUsed()
   {

--- a/Source/Core/Core/PowerPC/JitArmCommon/BackPatch.h
+++ b/Source/Core/Core/PowerPC/JitArmCommon/BackPatch.h
@@ -16,14 +16,11 @@ struct BackPatchInfo
     FLAG_SIZE_32 = (1 << 4),
     FLAG_SIZE_F32 = (1 << 5),
     FLAG_SIZE_F32X2 = (1 << 6),
-    FLAG_SIZE_F32X2I = (1 << 7),
-    FLAG_SIZE_F64 = (1 << 8),
-    FLAG_REVERSE = (1 << 9),
-    FLAG_EXTEND = (1 << 10),
-    FLAG_SIZE_F32I = (1 << 11),
-    FLAG_ZERO_256 = (1 << 12),
-    FLAG_MASK_FLOAT =
-        FLAG_SIZE_F32 | FLAG_SIZE_F32X2 | FLAG_SIZE_F32X2I | FLAG_SIZE_F64 | FLAG_SIZE_F32I,
+    FLAG_SIZE_F64 = (1 << 7),
+    FLAG_REVERSE = (1 << 8),
+    FLAG_EXTEND = (1 << 9),
+    FLAG_ZERO_256 = (1 << 10),
+    FLAG_MASK_FLOAT = FLAG_SIZE_F32 | FLAG_SIZE_F32X2 | FLAG_SIZE_F64,
   };
 
   static u32 GetFlagSize(u32 flags)
@@ -34,8 +31,10 @@ struct BackPatchInfo
       return 16;
     if (flags & FLAG_SIZE_32)
       return 32;
-    if (flags & FLAG_SIZE_F32 || flags & FLAG_SIZE_F32I)
+    if (flags & FLAG_SIZE_F32)
       return 32;
+    if (flags & FLAG_SIZE_F32X2)
+      return 64;
     if (flags & FLAG_SIZE_F64)
       return 64;
     if (flags & FLAG_ZERO_256)

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -26,6 +26,7 @@ struct CommonAsmRoutinesBase
   const u8* fres;
   const u8* mfcr;
   const u8* cdts;
+  const u8* cstd;
 
   // In: array index: GQR to use.
   // In: ECX: Address to read from.

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <unordered_set>
 
+#include "Common/BitSet.h"
 #include "Common/CommonTypes.h"
 #include "Common/x64Emitter.h"
 #include "Core/ConfigManager.h"
@@ -98,6 +99,7 @@ protected:
     PPCAnalyst::BlockRegStats gpa;
     PPCAnalyst::BlockRegStats fpa;
     PPCAnalyst::CodeOp* op;
+    BitSet32 fpr_is_store_safe;
 
     JitBlock* curBlock;
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -976,7 +976,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
 
     op.fprIsSingle = fprIsSingle;
     op.fprIsDuplicated = fprIsDuplicated;
-    op.fprIsStoreSafe = fprIsStoreSafe;
+    op.fprIsStoreSafeBeforeInst = fprIsStoreSafe;
     if (op.fregOut >= 0)
     {
       if (op.opinfo->type == OpType::SingleFP)
@@ -1036,6 +1036,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock* block, CodeBuffer* buffer, std:
             (op.opinfo->type == OpType::SingleFP || op.opinfo->type == OpType::PS);
       }
     }
+    op.fprIsStoreSafeAfterInst = fprIsStoreSafe;
 
     if (op.opinfo->type == OpType::StorePS || op.opinfo->type == OpType::LoadPS)
     {

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -66,7 +66,8 @@ struct CodeOp  // 16B
   // convert between single and double formats by just using the host machine's instruction for it.
   // (The reason why we can't always do this is because some games rely on the exact bits of
   // denormals and SNaNs being preserved as long as no arithmetic operation is performed on them.)
-  BitSet32 fprIsStoreSafe;
+  BitSet32 fprIsStoreSafeBeforeInst;
+  BitSet32 fprIsStoreSafeAfterInst;
 
   BitSet32 GetFregsOut() const
   {

--- a/Source/Core/DolphinLib.ARM64.props
+++ b/Source/Core/DolphinLib.ARM64.props
@@ -13,7 +13,7 @@
   <ItemGroup>
     <ClCompile Include="Common\Arm64Emitter.cpp" />
     <ClCompile Include="Common\ArmCPUDetect.cpp" />
-    <ClCompile Include="Common\GenericFPURoundMode.cpp" />
+    <ClCompile Include="Common\ArmFPURoundMode.cpp" />
     <ClCompile Include="Core\PowerPC\JitArm64\Jit_Util.cpp" />
     <ClCompile Include="Core\PowerPC\JitArm64\Jit.cpp" />
     <ClCompile Include="Core\PowerPC\JitArm64\JitArm64_BackPatch.cpp" />

--- a/Source/UnitTests/Core/CMakeLists.txt
+++ b/Source/UnitTests/Core/CMakeLists.txt
@@ -21,6 +21,7 @@ if(_M_X86)
   )
 elseif(_M_ARM_64)
   add_dolphin_test(PowerPCTest
+    PowerPC/JitArm64/ConvertSingleDouble.cpp
     PowerPC/JitArm64/MovI2R.cpp
   )
 endif()

--- a/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
+++ b/Source/UnitTests/Core/PowerPC/JitArm64/ConvertSingleDouble.cpp
@@ -1,0 +1,273 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <functional>
+#include <vector>
+
+#include "Common/Arm64Emitter.h"
+#include "Common/BitUtils.h"
+#include "Common/CommonTypes.h"
+#include "Common/FPURoundMode.h"
+#include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
+#include "Core/PowerPC/JitArm64/Jit.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+namespace
+{
+using namespace Arm64Gen;
+
+// The ABI situation for returning an std::tuple seems annoying. Let's use this struct instead
+template <typename T>
+struct Pair
+{
+  T value1;
+  T value2;
+};
+
+class TestConversion : private JitArm64
+{
+public:
+  TestConversion()
+  {
+    AllocCodeSpace(4096);
+    AddChildCodeSpace(&farcode, 2048);
+
+    gpr.Init(this);
+    fpr.Init(this);
+
+    js.fpr_is_store_safe = BitSet32(0);
+
+    GetAsmRoutines()->cdts = GetCodePtr();
+    GenerateConvertDoubleToSingle();
+    GetAsmRoutines()->cstd = GetCodePtr();
+    GenerateConvertSingleToDouble();
+
+    gpr.Lock(ARM64Reg::W30);
+    fpr.Lock(ARM64Reg::Q0, ARM64Reg::Q1);
+
+    convert_single_to_double_lower = Common::BitCast<u64 (*)(u32)>(GetCodePtr());
+    m_float_emit.INS(32, ARM64Reg::S0, 0, ARM64Reg::W0);
+    ConvertSingleToDoubleLower(0, ARM64Reg::D0, ARM64Reg::S0, ARM64Reg::Q1);
+    m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::D0, 0);
+    RET();
+
+    convert_single_to_double_pair = Common::BitCast<Pair<u64> (*)(u32, u32)>(GetCodePtr());
+    m_float_emit.INS(32, ARM64Reg::D0, 0, ARM64Reg::W0);
+    m_float_emit.INS(32, ARM64Reg::D0, 1, ARM64Reg::W1);
+    ConvertSingleToDoublePair(0, ARM64Reg::Q0, ARM64Reg::D0, ARM64Reg::Q1);
+    m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::Q0, 0);
+    m_float_emit.UMOV(64, ARM64Reg::X1, ARM64Reg::Q0, 1);
+    RET();
+
+    convert_double_to_single_lower = Common::BitCast<u32 (*)(u64)>(GetCodePtr());
+    m_float_emit.INS(64, ARM64Reg::D0, 0, ARM64Reg::X0);
+    ConvertDoubleToSingleLower(0, ARM64Reg::S0, ARM64Reg::D0);
+    m_float_emit.UMOV(32, ARM64Reg::W0, ARM64Reg::S0, 0);
+    RET();
+
+    convert_double_to_single_pair = Common::BitCast<Pair<u32> (*)(u64, u64)>(GetCodePtr());
+    m_float_emit.INS(64, ARM64Reg::Q0, 0, ARM64Reg::X0);
+    m_float_emit.INS(64, ARM64Reg::Q0, 1, ARM64Reg::X1);
+    ConvertDoubleToSinglePair(0, ARM64Reg::D0, ARM64Reg::Q0);
+    m_float_emit.UMOV(64, ARM64Reg::X0, ARM64Reg::D0, 0);
+    RET();
+
+    gpr.Unlock(ARM64Reg::W30);
+    fpr.Unlock(ARM64Reg::Q0, ARM64Reg::Q1);
+
+    FlushIcache();
+
+    // Set the rounding mode to something that's as annoying as possible to handle
+    // (flush-to-zero enabled, and rounding not symmetric about the origin)
+    FPURoundMode::SetSIMDMode(FPURoundMode::RoundMode::ROUND_UP, true);
+  }
+
+  ~TestConversion() override
+  {
+    FPURoundMode::LoadDefaultSIMDState();
+
+    FreeCodeSpace();
+  }
+
+  u64 ConvertSingleToDouble(u32 value) { return convert_single_to_double_lower(value); }
+
+  Pair<u64> ConvertSingleToDouble(u32 value1, u32 value2)
+  {
+    return convert_single_to_double_pair(value1, value2);
+  }
+
+  u32 ConvertDoubleToSingle(u64 value) { return convert_double_to_single_lower(value); }
+
+  Pair<u32> ConvertDoubleToSingle(u64 value1, u64 value2)
+  {
+    return convert_double_to_single_pair(value1, value2);
+  }
+
+private:
+  std::function<u64(u32)> convert_single_to_double_lower;
+  std::function<Pair<u64>(u32, u32)> convert_single_to_double_pair;
+  std::function<u32(u64)> convert_double_to_single_lower;
+  std::function<Pair<u32>(u64, u64)> convert_double_to_single_pair;
+};
+
+}  // namespace
+
+TEST(JitArm64, ConvertDoubleToSingle)
+{
+  TestConversion test;
+
+  const std::vector<u64> input_values{
+      // Special values
+      0x0000'0000'0000'0000,  // positive zero
+      0x0000'0000'0000'0001,  // smallest positive denormal
+      0x0000'0000'0100'0000,
+      0x000F'FFFF'FFFF'FFFF,  // largest positive denormal
+      0x0010'0000'0000'0000,  // smallest positive normal
+      0x0010'0000'0000'0002,
+      0x3FF0'0000'0000'0000,  // 1.0
+      0x7FEF'FFFF'FFFF'FFFF,  // largest positive normal
+      0x7FF0'0000'0000'0000,  // positive infinity
+      0x7FF0'0000'0000'0001,  // first positive SNaN
+      0x7FF7'FFFF'FFFF'FFFF,  // last positive SNaN
+      0x7FF8'0000'0000'0000,  // first positive QNaN
+      0x7FFF'FFFF'FFFF'FFFF,  // last positive QNaN
+      0x8000'0000'0000'0000,  // negative zero
+      0x8000'0000'0000'0001,  // smallest negative denormal
+      0x8000'0000'0100'0000,
+      0x800F'FFFF'FFFF'FFFF,  // largest negative denormal
+      0x8010'0000'0000'0000,  // smallest negative normal
+      0x8010'0000'0000'0002,
+      0xBFF0'0000'0000'0000,  // -1.0
+      0xFFEF'FFFF'FFFF'FFFF,  // largest negative normal
+      0xFFF0'0000'0000'0000,  // negative infinity
+      0xFFF0'0000'0000'0001,  // first negative SNaN
+      0xFFF7'FFFF'FFFF'FFFF,  // last negative SNaN
+      0xFFF8'0000'0000'0000,  // first negative QNaN
+      0xFFFF'FFFF'FFFF'FFFF,  // last negative QNaN
+
+      // (exp > 896) Boundary Case
+      0x3800'0000'0000'0000,  // 2^(-127) = Denormal in single-prec
+      0x3810'0000'0000'0000,  // 2^(-126) = Smallest single-prec normal
+      0xB800'0000'0000'0000,  // -2^(-127) = Denormal in single-prec
+      0xB810'0000'0000'0000,  // -2^(-126) = Smallest single-prec normal
+      0x3800'1234'5678'9ABC, 0x3810'1234'5678'9ABC, 0xB800'1234'5678'9ABC, 0xB810'1234'5678'9ABC,
+
+      // (exp >= 874) Boundary Case
+      0x3680'0000'0000'0000,  // 2^(-150) = Unrepresentable in single-prec
+      0x36A0'0000'0000'0000,  // 2^(-149) = Smallest single-prec denormal
+      0x36B0'0000'0000'0000,  // 2^(-148) = Single-prec denormal
+      0xB680'0000'0000'0000,  // -2^(-150) = Unrepresentable in single-prec
+      0xB6A0'0000'0000'0000,  // -2^(-149) = Smallest single-prec denormal
+      0xB6B0'0000'0000'0000,  // -2^(-148) = Single-prec denormal
+      0x3680'1234'5678'9ABC, 0x36A0'1234'5678'9ABC, 0x36B0'1234'5678'9ABC, 0xB680'1234'5678'9ABC,
+      0xB6A0'1234'5678'9ABC, 0xB6B0'1234'5678'9ABC,
+
+      // Some typical numbers
+      0x3FF8'0000'0000'0000,  // 1.5
+      0x408F'4000'0000'0000,  // 1000
+      0xC008'0000'0000'0000,  // -3
+  };
+
+  for (const u64 input : input_values)
+  {
+    const u32 expected = ConvertToSingle(input);
+    const u32 actual = test.ConvertDoubleToSingle(input);
+
+    if (expected != actual)
+      fmt::print("{:016x} -> {:08x} == {:08x}\n", input, actual, expected);
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  for (const u64 input1 : input_values)
+  {
+    for (const u64 input2 : input_values)
+    {
+      const u32 expected1 = ConvertToSingle(input1);
+      const u32 expected2 = ConvertToSingle(input2);
+      const auto [actual1, actual2] = test.ConvertDoubleToSingle(input1, input2);
+
+      if (expected1 != actual1 || expected2 != actual2)
+      {
+        fmt::print("{:016x} -> {:08x} == {:08x},\n", input1, actual1, expected1);
+        fmt::print("{:016x} -> {:08x} == {:08x}\n", input2, actual2, expected2);
+      }
+
+      EXPECT_EQ(expected1, actual1);
+      EXPECT_EQ(expected2, actual2);
+    }
+  }
+}
+
+TEST(JitArm64, ConvertSingleToDouble)
+{
+  TestConversion test;
+
+  const std::vector<u32> input_values{
+      // Special values
+      0x0000'0000,  // positive zero
+      0x0000'0001,  // smallest positive denormal
+      0x0000'1000,
+      0x007F'FFFF,  // largest positive denormal
+      0x0080'0000,  // smallest positive normal
+      0x0080'0002,
+      0x3F80'0000,  // 1.0
+      0x7F7F'FFFF,  // largest positive normal
+      0x7F80'0000,  // positive infinity
+      0x7F80'0001,  // first positive SNaN
+      0x7FBF'FFFF,  // last positive SNaN
+      0x7FC0'0000,  // first positive QNaN
+      0x7FFF'FFFF,  // last positive QNaN
+      0x8000'0000,  // negative zero
+      0x8000'0001,  // smallest negative denormal
+      0x8000'1000,
+      0x807F'FFFF,  // largest negative denormal
+      0x8080'0000,  // smallest negative normal
+      0x8080'0002,
+      0xBFF0'0000,  // -1.0
+      0xFF7F'FFFF,  // largest negative normal
+      0xFF80'0000,  // negative infinity
+      0xFF80'0001,  // first negative SNaN
+      0xFFBF'FFFF,  // last negative SNaN
+      0xFFC0'0000,  // first negative QNaN
+      0xFFFF'FFFF,  // last negative QNaN
+
+      // Some typical numbers
+      0x3FC0'0000,  // 1.5
+      0x447A'0000,  // 1000
+      0xC040'0000,  // -3
+  };
+
+  for (const u32 input : input_values)
+  {
+    const u64 expected = ConvertToDouble(input);
+    const u64 actual = test.ConvertSingleToDouble(input);
+
+    if (expected != actual)
+      fmt::print("{:08x} -> {:016x} == {:016x}\n", input, actual, expected);
+
+    EXPECT_EQ(expected, actual);
+  }
+
+  for (const u32 input1 : input_values)
+  {
+    for (const u32 input2 : input_values)
+    {
+      const u64 expected1 = ConvertToDouble(input1);
+      const u64 expected2 = ConvertToDouble(input2);
+      const auto [actual1, actual2] = test.ConvertSingleToDouble(input1, input2);
+
+      if (expected1 != actual1 || expected2 != actual2)
+      {
+        fmt::print("{:08x} -> {:016x} == {:016x},\n", input1, actual1, expected1);
+        fmt::print("{:08x} -> {:016x} == {:016x}\n", input2, actual2, expected2);
+      }
+
+      EXPECT_EQ(expected1, actual1);
+      EXPECT_EQ(expected2, actual2);
+    }
+  }
+}

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -81,6 +81,7 @@
     <ClCompile Include="Core\PowerPC\Jit64Common\Frsqrte.cpp" />
   </ItemGroup>
   <ItemGroup Condition="'$(Platform)'=='ARM64'">
+    <ClCompile Include="Core\PowerPC\JitArm64\ConvertSingleDouble.cpp" />
     <ClCompile Include="Core\PowerPC\JitArm64\MovI2R.cpp" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12388. Might also fix other games that have problems with float, paired, float loadstore, or paired loadstore instructions in JitArm64, but I haven't tested any.

Left to do:
- [x] I need to fix the ARM64 MSVC CMake build
- [x] It would be useful if someone could test that ARM64 MSVC builds don't horribly crash when you start a game
- [x] ~With this change, a white square shows up on the title screen of Sonic Colors~ Implement accurate single/double conversion
- [x] Make accurate single/double conversion faster
- [x] Unit tests for single/double conversion
- [x] ~Sonic is falling through grind rails now?~ fselx needs to handle RW clobbering flags
- [x] Get PR #9486 merged