### PR TITLE
FreeLookManager: acquire global input lock

### DIFF
--- a/Source/Core/Core/FreeLookManager.cpp
+++ b/Source/Core/Core/FreeLookManager.cpp
@@ -149,6 +149,8 @@ void FreeLookController::Update()
   if (!g_freelook_camera.IsActive())
     return;
 
+  const auto lock = GetStateLock();
+
   if (m_move_buttons->controls[MoveButtons::Up]->GetState<bool>())
     g_freelook_camera.MoveVertical(-g_freelook_camera.GetSpeed());
 


### PR DESCRIPTION
We need to acquire the global input lock before accessing any control states just to be safe.  This was missed when #8867 was merged.  Thanks to @Filoppi for catching it!