### PR TITLE
WiimoteReal: Fix crash on real Wii Remote disconnect on Windows.

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -916,7 +916,9 @@ static void TryToConnectBalanceBoard(std::unique_ptr<Wiimote> wm)
 static void HandleWiimoteDisconnect(int index)
 {
   Core::RunAsCPUThread([index] {
-    g_wiimotes[index] = nullptr;
+    // The Wii Remote object must exist through the call to UpdateSource
+    // to prevent WiimoteDevice from having a dangling HIDWiimote pointer.
+    const auto temp_real_wiimote = std::move(g_wiimotes[index]);
     WiimoteCommon::UpdateSource(index);
   });
 }


### PR DESCRIPTION
Code for attaching a real Wii remote's HID interface to our emulated Bluetooth device is a bit messy.
A dangling pointer in the disconnect routine was causing a crash on Windows.

Fixes:
https://bugs.dolphin-emu.org/issues/12329
https://bugs.dolphin-emu.org/issues/12343
https://bugs.dolphin-emu.org/issues/12351

Possibly fixes this issue on macOS?
https://bugs.dolphin-emu.org/issues/9520