### PR TITLE
Working Game IDs for Elf/Dol files

### DIFF
--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -195,8 +196,9 @@ struct SConfig
   void ResetRunningGameMetadata();
   void SetRunningGameMetadata(const DiscIO::Volume& volume, const DiscIO::Partition& partition);
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd, DiscIO::Platform platform);
-
+  void SetRunningGameMetadata(const std::string& game_id);
   void LoadDefaults();
+  static std::string MakeGameID(std::string_view file_name);
   // Replaces NTSC-K with some other region, and doesn't replace non-NTSC-K regions
   static DiscIO::Region ToGameCubeRegion(DiscIO::Region region);
   // The region argument must be valid for GameCube (i.e. must not be NTSC-K)

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -304,14 +304,13 @@ void GameList::ShowContextMenu(const QPoint&)
   {
     const auto game = GetSelectedGame();
     DiscIO::Platform platform = game->GetPlatform();
-
+    menu->addAction(tr("&Properties"), this, &GameList::OpenProperties);
     if (platform != DiscIO::Platform::ELFOrDOL)
     {
-      menu->addAction(tr("&Properties"), this, &GameList::OpenProperties);
       menu->addAction(tr("&Wiki"), this, &GameList::OpenWiki);
-
-      menu->addSeparator();
     }
+
+    menu->addSeparator();
 
     if (DiscIO::IsDisc(platform))
     {

--- a/Source/Core/UICommon/GameFile.cpp
+++ b/Source/Core/UICommon/GameFile.cpp
@@ -157,6 +157,7 @@ GameFile::GameFile(std::string path) : m_file_path(std::move(path))
   {
     m_valid = true;
     m_file_size = m_volume_size = File::GetSize(m_file_path);
+    m_game_id = SConfig::MakeGameID(m_file_name);
     m_volume_size_is_accurate = true;
     m_is_datel_disc = false;
     m_is_nkit = false;

--- a/Source/Core/UICommon/GameFileCache.cpp
+++ b/Source/Core/UICommon/GameFileCache.cpp
@@ -27,7 +27,7 @@
 
 namespace UICommon
 {
-static constexpr u32 CACHE_REVISION = 19;  // Last changed in PR 9135
+static constexpr u32 CACHE_REVISION = 20;  // Last changed in PR 9461
 
 std::vector<std::string> FindAllGamePaths(const std::vector<std::string>& directories_to_scan,
                                           bool recursive_scan)


### PR DESCRIPTION
I've added game IDs for ELF and DOL files. This allows the user to set custom game configurations for ELF files and DOL files, as well as to load custom textures at a per elf/dol level. This is extremely useful if you have, for example, multiple mods of Super Smash Bros Brawl. At a technical level, all I'm doing is hashing the file name of the elf and using that as the game ID (thus collisions are possible but exceedingly unlikely). _The user may need to do View->Purge Game List Cache before the the new title IDs appear for their old ELFs and DOLS_. 




For a discussion of reasoning for this pull request see [here](https://forums.dolphin-emu.org/Thread-give-elf-files-unique-game-ids).