### PR TITLE
UnitTests: Add setup error checking

### DIFF
--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -39,6 +39,10 @@ class ScopeInit final
 public:
   ScopeInit() : m_profile_path(File::CreateTempDir())
   {
+    if (!UserDirectoryExists())
+    {
+      return;
+    }
     Core::DeclareAsCPUThread();
     UICommon::SetUserDirectory(m_profile_path);
     Config::Init();
@@ -48,6 +52,10 @@ public:
   }
   ~ScopeInit()
   {
+    if (!UserDirectoryExists())
+    {
+      return;
+    }
     CoreTiming::Shutdown();
     PowerPC::Shutdown();
     SConfig::Shutdown();
@@ -55,6 +63,7 @@ public:
     Core::UndeclareAsCPUThread();
     File::DeleteDirRecursively(m_profile_path);
   }
+  bool UserDirectoryExists() const { return !m_profile_path.empty(); }
 
 private:
   std::string m_profile_path;
@@ -77,6 +86,7 @@ static void AdvanceAndCheck(u32 idx, int downcount, int expected_lateness = 0,
 TEST(CoreTiming, BasicOrder)
 {
   ScopeInit guard;
+  ASSERT_TRUE(guard.UserDirectoryExists());
 
   CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
   CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
@@ -127,6 +137,7 @@ TEST(CoreTiming, SharedSlot)
   using namespace SharedSlotTest;
 
   ScopeInit guard;
+  ASSERT_TRUE(guard.UserDirectoryExists());
 
   CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", FifoCallback<0>);
   CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", FifoCallback<1>);
@@ -156,6 +167,7 @@ TEST(CoreTiming, SharedSlot)
 TEST(CoreTiming, PredictableLateness)
 {
   ScopeInit guard;
+  ASSERT_TRUE(guard.UserDirectoryExists());
 
   CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
   CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
@@ -190,6 +202,7 @@ TEST(CoreTiming, ChainScheduling)
   using namespace ChainSchedulingTest;
 
   ScopeInit guard;
+  ASSERT_TRUE(guard.UserDirectoryExists());
 
   CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
   CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
@@ -245,6 +258,7 @@ TEST(CoreTiming, ScheduleIntoPast)
   using namespace ScheduleIntoPastTest;
 
   ScopeInit guard;
+  ASSERT_TRUE(guard.UserDirectoryExists());
 
   s_cb_next = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
   CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
@@ -282,6 +296,7 @@ TEST(CoreTiming, ScheduleIntoPast)
 TEST(CoreTiming, Overclocking)
 {
   ScopeInit guard;
+  ASSERT_TRUE(guard.UserDirectoryExists());
 
   CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
   CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);

--- a/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
+++ b/Source/UnitTests/Core/IOS/FS/FileSystemTest.cpp
@@ -25,15 +25,31 @@ class FileSystemTest : public testing::Test
 protected:
   FileSystemTest() : m_profile_path{File::CreateTempDir()}
   {
+    if (UserDirectoryCreationFailed())
+    {
+      return;
+    }
     UICommon::SetUserDirectory(m_profile_path);
     m_fs = IOS::HLE::Kernel{}.GetFS();
   }
 
   virtual ~FileSystemTest()
   {
+    if (UserDirectoryCreationFailed())
+    {
+      return;
+    }
     m_fs.reset();
     File::DeleteDirRecursively(m_profile_path);
   }
+  void SetUp()
+  {
+    if (UserDirectoryCreationFailed())
+    {
+      FAIL();
+    }
+  }
+  bool UserDirectoryCreationFailed() const { return m_profile_path.empty(); }
 
   std::shared_ptr<FileSystem> m_fs;
 

--- a/Source/UnitTests/Core/MMIOTest.cpp
+++ b/Source/UnitTests/Core/MMIOTest.cpp
@@ -34,6 +34,7 @@ TEST(UniqueID, UniqueEnough)
 TEST(IsMMIOAddress, SpecialAddresses)
 {
   const std::string profile_path = File::CreateTempDir();
+  ASSERT_FALSE(profile_path.empty());
   UICommon::SetUserDirectory(profile_path);
   Config::Init();
   SConfig::Init();


### PR DESCRIPTION
Check return value of calls to File::CreateTempDir() from CoreTiming,
FileSystem, and MMIO test classes to verify the test user directory
exists, and fail the tests otherwise.