### PR TITLE
Disable XFBToTexture in Skies of Arcadia

### DIFF
--- a/Data/Sys/GameSettings/GEA.ini
+++ b/Data/Sys/GameSettings/GEA.ini
@@ -18,4 +18,5 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
 EFBToTextureEnable = False
+XFBToTextureEnable = False
 


### PR DESCRIPTION
Fixes an issue where screen will sometimes flash purple and green when loading save files, during certain cutscenes, and when entering a different area.