### PR TITLE
Android: Fix motion control settings not saving to file

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -912,7 +912,8 @@ public final class EmulationActivity extends AppCompatActivity
               updateWiimoteNewImuIr(indexSelected);
               NativeLibrary.ReloadWiimoteConfig();
             });
-    builder.setPositiveButton(R.string.ok, (dialogInterface, i) -> dialogInterface.dismiss());
+    builder.setPositiveButton(R.string.ok, (dialogInterface, i) ->
+            mSettings.saveSettings(null, null));
 
     builder.show();
   }


### PR DESCRIPTION
Motion controls are not saved to file when closing the dialog, so when changing this setting, then closing and re-opening the app, it gets back to its last saved position (which could be any since it is not saved anywhere).

I don't know if this is the correct way to do this, but it works as expected as far my testing goes.