### PR TITLE
Texture lookup fix

### DIFF
--- a/Source/Core/VideoCommon/GXPipelineTypes.h
+++ b/Source/Core/VideoCommon/GXPipelineTypes.h
@@ -20,7 +20,7 @@ namespace VideoCommon
 // As pipelines encompass both shader UIDs and render states, changes to either of these should
 // also increment the pipeline UID version. Incrementing the UID version will cause all UID
 // caches to be invalidated.
-constexpr u32 GX_PIPELINE_UID_VERSION = 2;  // Last changed in PR 9122
+constexpr u32 GX_PIPELINE_UID_VERSION = 3;  // Last changed in PR 9473
 
 struct GXPipelineUid
 {


### PR DESCRIPTION
Fixes Texture lookup by applying point sampling.

Old:
This adds an epsilon in the texture sampling stage to prevent rounding errors.

An epsilon of 0.5 gave the same results (when it comes to artifacts)as point sampling without actually point sampling so there is no behavioral change. 0.5 was chosen as that is the lowest value that can always be represented when converting a 24bit signed integer to a float.
The only fifolog that this doesn't fix is Just Dance 2 but the same artifacts can be found when point sampling and this depends on the hardware, so this is probably a rounding error(https://github.com/dolphin-emu/dolphin/pull/9473#issuecomment-768564342, https://github.com/dolphin-emu/dolphin/pull/9473#issuecomment-767937443).
But Just Dance 2 is improved compared to master, at least on my hardware (Nvidia).

OLD:
This solution was provided by u/fortsnek47 on reddit (https://www.reddit.com/r/EmuDev/comments/l0y7sg/gc_fixing_those_vp6_videos/).
I don't have any games with texture lookup issues so I can't test these changes.

Games that can be tested: https://wiki.dolphin-emu.org/index.php?title=Template:Problems/VP6_Videos