### PR TITLE
Jit64: boolX constant optimizations

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -835,7 +835,7 @@ void Jit64::boolX(UGeckoInstruction inst)
     }
     else if (inst.SUBOP10 == 60)  // andcx
     {
-      if (cpu_info.bBMI1 && Rb.IsSimpleReg() && !Rs.IsImm())
+      if (cpu_info.bBMI1 && Rb.IsSimpleReg())
       {
         ANDN(32, Ra, Rb.GetSimpleReg(), Rs);
       }
@@ -910,7 +910,7 @@ void Jit64::boolX(UGeckoInstruction inst)
     }
     else if (inst.SUBOP10 == 60)  // andcx
     {
-      if (cpu_info.bBMI1 && Rb.IsSimpleReg() && !Rs.IsImm())
+      if (cpu_info.bBMI1 && Rb.IsSimpleReg())
       {
         ANDN(32, Ra, Rb.GetSimpleReg(), Rs);
       }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -687,10 +687,18 @@ void Jit64::boolX(UGeckoInstruction inst)
       RCOpArg Rj = gpr.Use(j, RCMode::Read);
       RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
       RegCache::Realize(Rj, Ra);
-
-      if (a != j)
-        MOV(32, Ra, Rj);
-      XOR(32, Ra, Imm32(imm));
+      if (imm == 0)
+      {
+        if (a != j)
+          MOV(32, Ra, Rj);
+        needs_test = true;
+      }
+      else
+      {
+        if (a != j)
+          MOV(32, Ra, Rj);
+        XOR(32, Ra, Imm32(imm));
+      }
     }
     else if (is_and)
     {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -722,7 +722,15 @@ void Jit64::boolX(UGeckoInstruction inst)
         RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
         RegCache::Realize(Rj, Ra);
 
-        if (complement_b)
+        if (imm == 0xFFFFFFFF)
+        {
+          if (a != j)
+            MOV(32, Ra, Rj);
+          if (final_not || complement_b)
+            NOT(32, Ra);
+          needs_test = true;
+        }
+        else if (complement_b)
         {
           if (a != j)
             MOV(32, Ra, Rj);
@@ -734,12 +742,12 @@ void Jit64::boolX(UGeckoInstruction inst)
           if (a != j)
             MOV(32, Ra, Rj);
           AND(32, Ra, Imm32(imm));
-        }
 
-        if (final_not)
-        {
-          NOT(32, Ra);
-          needs_test = true;
+          if (final_not)
+          {
+            NOT(32, Ra);
+            needs_test = true;
+          }
         }
       }
     }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -739,9 +739,18 @@ void Jit64::boolX(UGeckoInstruction inst)
         }
         else
         {
-          if (a != j)
+          if (a == j)
+            AND(32, Ra, Imm32(imm));
+          else if (s32(imm) >= -128 && s32(imm) <= 127)
+          {
             MOV(32, Ra, Rj);
-          AND(32, Ra, Imm32(imm));
+            AND(32, Ra, Imm32(imm));
+          }
+          else
+          {
+            MOV(32, Ra, Imm32(imm));
+            AND(32, Ra, Rj);
+          }
 
           if (final_not)
           {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -664,16 +664,16 @@ void Jit64::boolX(UGeckoInstruction inst)
   }
   else if (gpr.IsImm(s) || gpr.IsImm(b))
   {
-    auto [i, j] = gpr.IsImm(s) ? std::pair(s, b) : std::pair(b, s);
+    const auto [i, j] = gpr.IsImm(s) ? std::pair(s, b) : std::pair(b, s);
     u32 imm = gpr.Imm32(i);
 
     bool complement_b = (inst.SUBOP10 == 60 /* andcx */) || (inst.SUBOP10 == 412 /* orcx */);
-    bool final_not = (inst.SUBOP10 == 476 /* nandx */) || (inst.SUBOP10 == 124 /* norx */);
-    bool is_and = (inst.SUBOP10 == 28 /* andx */) || (inst.SUBOP10 == 60 /* andcx */) ||
-                  (inst.SUBOP10 == 476 /* nandx */);
-    bool is_or = (inst.SUBOP10 == 444 /* orx */) || (inst.SUBOP10 == 412 /* orcx */) ||
-                 (inst.SUBOP10 == 124 /* norx */);
-    bool is_xor = (inst.SUBOP10 == 316 /* xorx */) || (inst.SUBOP10 == 284 /* eqvx */);
+    const bool final_not = (inst.SUBOP10 == 476 /* nandx */) || (inst.SUBOP10 == 124 /* norx */);
+    const bool is_and = (inst.SUBOP10 == 28 /* andx */) || (inst.SUBOP10 == 60 /* andcx */) ||
+                        (inst.SUBOP10 == 476 /* nandx */);
+    const bool is_or = (inst.SUBOP10 == 444 /* orx */) || (inst.SUBOP10 == 412 /* orcx */) ||
+                       (inst.SUBOP10 == 124 /* norx */);
+    const bool is_xor = (inst.SUBOP10 == 316 /* xorx */) || (inst.SUBOP10 == 284 /* eqvx */);
 
     // Precompute complement when possible
     if (complement_b && gpr.IsImm(b) || (inst.SUBOP10 == 284 /* eqvx */))

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -693,6 +693,12 @@ void Jit64::boolX(UGeckoInstruction inst)
           MOV(32, Ra, Rj);
         needs_test = true;
       }
+      else if (imm == 0xFFFFFFFF && !inst.Rc)
+      {
+        if (a != j)
+          MOV(32, Ra, Rj);
+        NOT(32, Ra);
+      }
       else
       {
         if (a != j)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -714,27 +714,33 @@ void Jit64::boolX(UGeckoInstruction inst)
     }
     else if (is_and)
     {
-      RCOpArg Rj = gpr.Use(j, RCMode::Read);
-      RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
-      RegCache::Realize(Rj, Ra);
-
-      if (complement_b)
-      {
-        if (a != j)
-          MOV(32, Ra, Rj);
-        NOT(32, Ra);
-        AND(32, Ra, Imm32(imm));
-      }
+      if (imm == 0)
+        gpr.SetImmediate32(a, final_not ? 0xFFFFFFFF : 0);
       else
       {
-        if (a != j)
-          MOV(32, Ra, Rj);
-        AND(32, Ra, Imm32(imm));
-      }
+        RCOpArg Rj = gpr.Use(j, RCMode::Read);
+        RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
+        RegCache::Realize(Rj, Ra);
 
-      if (final_not) {
-        NOT(32, Ra);
-        needs_test = true;
+        if (complement_b)
+        {
+          if (a != j)
+            MOV(32, Ra, Rj);
+          NOT(32, Ra);
+          AND(32, Ra, Imm32(imm));
+        }
+        else
+        {
+          if (a != j)
+            MOV(32, Ra, Rj);
+          AND(32, Ra, Imm32(imm));
+        }
+
+        if (final_not)
+        {
+          NOT(32, Ra);
+          needs_test = true;
+        }
       }
     }
     else if (is_or)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -699,11 +699,17 @@ void Jit64::boolX(UGeckoInstruction inst)
           MOV(32, Ra, Rj);
         NOT(32, Ra);
       }
+      else if (a == j)
+        XOR(32, Ra, Imm32(imm));
+      else if (s32(imm) >= -128 && s32(imm) <= 127)
+      {
+        MOV(32, Ra, Rj);
+        XOR(32, Ra, Imm32(imm));
+      }
       else
       {
-        if (a != j)
-          MOV(32, Ra, Rj);
-        XOR(32, Ra, Imm32(imm));
+        MOV(32, Ra, Imm32(imm));
+        XOR(32, Ra, Rj);
       }
     }
     else if (is_and)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -766,7 +766,15 @@ void Jit64::boolX(UGeckoInstruction inst)
       RCX64Reg Ra = gpr.Bind(a, RCMode::Write);
       RegCache::Realize(Rj, Ra);
 
-      if (complement_b)
+      if (imm == 0)
+      {
+        if (a != j)
+          MOV(32, Ra, Rj);
+        if (final_not || complement_b)
+          NOT(32, Ra);
+        needs_test = true;
+      }
+      else if (complement_b)
       {
         if (a != j)
           MOV(32, Ra, Rj);
@@ -778,11 +786,12 @@ void Jit64::boolX(UGeckoInstruction inst)
         if (a != j)
           MOV(32, Ra, Rj);
         OR(32, Ra, Imm32(imm));
-      }
 
-      if (final_not) {
-        NOT(32, Ra);
-        needs_test = true;
+        if (final_not)
+        {
+          NOT(32, Ra);
+          needs_test = true;
+        }
       }
     }
     else

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -668,8 +668,7 @@ void Jit64::boolX(UGeckoInstruction inst)
     u32 imm = gpr.Imm32(i);
 
     bool complement_b = (inst.SUBOP10 == 60 /* andcx */) || (inst.SUBOP10 == 412 /* orcx */);
-    bool final_not = (inst.SUBOP10 == 476 /* nandx */) || (inst.SUBOP10 == 124 /* norx */) ||
-                     (inst.SUBOP10 == 284 /* eqvx */);
+    bool final_not = (inst.SUBOP10 == 476 /* nandx */) || (inst.SUBOP10 == 124 /* norx */);
     bool is_and = (inst.SUBOP10 == 28 /* andx */) || (inst.SUBOP10 == 60 /* andcx */) ||
                   (inst.SUBOP10 == 476 /* nandx */);
     bool is_or = (inst.SUBOP10 == 444 /* orx */) || (inst.SUBOP10 == 412 /* orcx */) ||
@@ -677,7 +676,7 @@ void Jit64::boolX(UGeckoInstruction inst)
     bool is_xor = (inst.SUBOP10 == 316 /* xorx */) || (inst.SUBOP10 == 284 /* eqvx */);
 
     // Precompute complement when possible
-    if (complement_b && gpr.IsImm(b))
+    if (complement_b && gpr.IsImm(b) || (inst.SUBOP10 == 284 /* eqvx */))
     {
       imm = ~imm;
       complement_b = false;
@@ -692,12 +691,6 @@ void Jit64::boolX(UGeckoInstruction inst)
       if (a != j)
         MOV(32, Ra, Rj);
       XOR(32, Ra, Imm32(imm));
-
-      if (final_not)
-      {
-        NOT(32, Ra);
-        needs_test = true;
-      }
     }
     else if (is_and)
     {

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -783,9 +783,18 @@ void Jit64::boolX(UGeckoInstruction inst)
       }
       else
       {
-        if (a != j)
+        if (a == j)
+          OR(32, Ra, Imm32(imm));
+        else if (s32(imm) >= -128 && s32(imm) <= 127)
+        {
           MOV(32, Ra, Rj);
-        OR(32, Ra, Imm32(imm));
+          OR(32, Ra, Imm32(imm));
+        }
+        else
+        {
+          MOV(32, Ra, Imm32(imm));
+          OR(32, Ra, Rj);
+        }
 
         if (final_not)
         {


### PR DESCRIPTION
Those who've seen some of my previous PRs (#9262 or #9425) probably know what to expect by now.

Major optimizations include precomputing the complement (`andcx`, `orcx`, and `eqvx`), handling special cases (0 and `0xFFFFFFFF`), and preferring shorter instructions.

For those wondering, special case `0xFFFFFFFF` is missing for OR because I couldn't find a game doing this. I also had some ideas for `nandx` and `norx` when Rc = 1, but I've never seen that happen so I didn't bother.

---

**and**

<details><summary>Precompute complement (andcx)</summary>

Before:
```
BF 00 01 00 00       mov         edi,100h
F7 D7                not         edi
41 23 FE             and         edi,r14d
```

After:
```
41 8B FE             mov         edi,r14d
81 E7 FF FE FF FF    and         edi,0FFFFFEFFh
```
</details>
<details><summary>Special case 0</summary>

Before:
```
45 8B F8             mov         r15d,r8d
41 83 E7 00          and         r15d,0
```

After:
Nothing, register is set to constant zero.
</details>
<details><summary>Special case 0xFFFFFFFF</summary>

Before:
```
41 8B F5             mov         esi,r13d
83 E6 FF             and         esi,0FFFFFFFFh
```

After:
```
41 8B F5             mov         esi,r13d
```
</details>
<details><summary>Size optimization</summary>

Before:
```
41 8B FE             mov         edi,r14d
81 E7 FF FE FF FF    and         edi,0FFFFFEFFh
```

After:
```
BF FF FE FF FF       mov         edi,0FFFFFEFFh
41 23 FE             and         edi,r14d
```
</details>

---

**or**

<details><summary>Precompute complement (orcx)</summary>

Before:
```
41 BE 04 00 00 00    mov         r14d,4
41 F7 D6             not         r14d
45 0B F5             or          r14d,r13d
```

After:
```
45 8B F5             mov         r14d,r13d
41 83 CE FB          or          r14d,0FFFFFFFBh
```
</details>
<details><summary>Special case 0 (Example 1)</summary>

Before:
```
41 BA 00 00 00 00    mov         r10d,0
45 0B D1             or          r10d,r9d
```

After:
```
45 8B D1             mov         r10d,r9d
```
</details>
<details><summary>Special case 0 (Example 2)</summary>

Before:
```
41 83 CA 00          or          r10d,0
```

After:
Nothing!
</details>
<details><summary>Size optimization</summary>

Before:
```
45 8B F5             mov         r14d,r13d
41 81 CE 00 80 01 00 or          r14d,18000h
```

After:
```
41 BE 00 80 01 00    mov         r14d,18000h
45 0B F5             or          r14d,r13d
```
</details>

---

**xor**

<details><summary>Precompute complement (eqvx)</summary>

Before:
```
45 8B EF             mov         r13d,r15d
41 F7 D5             not         r13d
41 83 F5 04          xor         r13d,4
```

After:
```
45 8B EF             mov         r13d,r15d
41 83 F5 FB          xor         r13d,0FFFFFFFBh
```
</details>
<details><summary>Special case 0</summary>

Before:
```
8B FE                mov         edi,esi
83 F7 00             xor         edi,0
```

After:
```
8B FE                mov         edi,esi
```
</details>
<details><summary>Special case 0xFFFFFFFF</summary>

Before:
```
45 8B F5             mov         r14d,r13d
41 83 F6 FF          xor         r14d,0FFFFFFFFh
```

After:
```
45 8B F5             mov         r14d,r13d
41 F7 D6             not         r14d
```
</details>
<details><summary>Size optimization</summary>

Before:
```
44 89 F7             mov         edi,r14d
81 F7 A0 52 57 01    xor         edi,15752A0h
```

After:
```
BF A0 52 57 01       mov         edi,15752A0h
41 33 FE             xor         edi,r14d
```
</details>