### PR TITLE
GameINI: Enable EFB access from CPU for Ultimate I Spy

### DIFF
--- a/Data/Sys/GameSettings/RUZ.ini
+++ b/Data/Sys/GameSettings/RUZ.ini
@@ -1,0 +1,4 @@
+# RUZE7T - Ultimate I SPY
+
+[Video_Hacks]
+EFBAccessEnable = True


### PR DESCRIPTION
Ultimate I Spy requires EFB access from CPU to be enabled. Without it, the pointer will not function on the level selection screen, making the game unplayable past the menu.