### PR TITLE
DolphinQt: Fix regression in input expressions

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -51,8 +51,10 @@ QString GetExpressionForControl(const QString& control_name,
 
   if (quote == Quote::On)
   {
-    const QRegularExpression reg(QStringLiteral("[a-zA-Z]+"));
-    if (!reg.match(expr).hasMatch())
+    // If our expression contains any non-alpha characters
+    // we should quote it
+    const QRegularExpression reg(QStringLiteral("[^a-zA-Z]"));
+    if (reg.match(expr).hasMatch())
       expr = QStringLiteral("`%1`").arg(expr);
   }
 


### PR DESCRIPTION
A regression caused by #9440 prevents users from putting in an actual gamepad control because all backticks get stripped.  I think an exact replacement would be just wrapping the expression with "^[a-zA-Z]$".  This is what the [exactMatch docs](https://doc.qt.io/archives/qt-4.8/qregexp.html#exactMatch) seems to indicate.

However, it wasn't immediately obvious what was going on, so I opted for a slightly different expression (and negated the if) along with a comment.  Please let me know if you'd prefer the other.