### PR TITLE
InputCommon: fix potential dynamic input texture crash and an optimization

### DIFF
--- a/Source/Core/InputCommon/DynamicInputTextureConfiguration.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextureConfiguration.cpp
@@ -17,10 +17,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ImageOperations.h"
-#include "VideoCommon/RenderBase.h"
 
 namespace
 {
@@ -251,7 +249,7 @@ DynamicInputTextureConfiguration::DynamicInputTextureConfiguration(const std::st
 
 DynamicInputTextureConfiguration::~DynamicInputTextureConfiguration() = default;
 
-void DynamicInputTextureConfiguration::GenerateTextures(const IniFile::Section* sec,
+bool DynamicInputTextureConfiguration::GenerateTextures(const IniFile::Section* sec,
                                                         const std::string& controller_name) const
 {
   bool any_dirty = false;
@@ -260,13 +258,7 @@ void DynamicInputTextureConfiguration::GenerateTextures(const IniFile::Section* 
     any_dirty |= GenerateTexture(sec, controller_name, texture_data);
   }
 
-  if (!any_dirty)
-    return;
-  if (Core::GetState() == Core::State::Starting)
-    return;
-  if (!g_renderer)
-    return;
-  g_renderer->ForceReloadTextures();
+  return any_dirty;
 }
 
 bool DynamicInputTextureConfiguration::GenerateTexture(

--- a/Source/Core/InputCommon/DynamicInputTextureConfiguration.h
+++ b/Source/Core/InputCommon/DynamicInputTextureConfiguration.h
@@ -19,7 +19,7 @@ class DynamicInputTextureConfiguration
 public:
   explicit DynamicInputTextureConfiguration(const std::string& json_file);
   ~DynamicInputTextureConfiguration();
-  void GenerateTextures(const IniFile::Section* sec, const std::string& controller_name) const;
+  bool GenerateTextures(const IniFile::Section* sec, const std::string& controller_name) const;
 
 private:
   struct DynamicInputTextureData

--- a/Source/Core/InputCommon/DynamicInputTextureManager.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextureManager.cpp
@@ -10,9 +10,11 @@
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 
 #include "InputCommon/DynamicInputTextureConfiguration.h"
 #include "VideoCommon/HiresTextures.h"
+#include "VideoCommon/RenderBase.h"
 
 namespace InputCommon
 {
@@ -41,9 +43,13 @@ void DynamicInputTextureManager::Load()
 void DynamicInputTextureManager::GenerateTextures(const IniFile::Section* sec,
                                                   const std::string& controller_name)
 {
+  bool any_dirty = false;
   for (const auto& configuration : m_configuration)
   {
-    configuration.GenerateTextures(sec, controller_name);
+    any_dirty |= configuration.GenerateTextures(sec, controller_name);
   }
+
+  if (any_dirty && g_renderer && Core::GetState() != Core::State::Starting)
+    g_renderer->ForceReloadTextures();
 }
 }  // namespace InputCommon

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -56,14 +56,7 @@ void HiresTexture::Init()
 
 void HiresTexture::Shutdown()
 {
-  if (s_prefetcher.joinable())
-  {
-    s_textureCacheAbortLoading.Set();
-    s_prefetcher.join();
-  }
-
-  s_textureMap.clear();
-  s_textureCache.clear();
+  Clear();
 }
 
 void HiresTexture::Update()
@@ -147,6 +140,11 @@ void HiresTexture::Update()
 
 void HiresTexture::Clear()
 {
+  if (s_prefetcher.joinable())
+  {
+    s_textureCacheAbortLoading.Set();
+    s_prefetcher.join();
+  }
   s_textureMap.clear();
   s_textureCache.clear();
 }


### PR DESCRIPTION
There was the possibility that a dynamic input texture change would cause a reload of textures while the prefetcher was sorting through them.  This would cause a crash.

Also for packs with multiple configurations, we were calling force reload too many times