### PR TITLE
Config: Fix expression window scroll wheel spam

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -98,6 +98,11 @@ ControlExpressionSyntaxHighlighter::ControlExpressionSyntaxHighlighter(QTextDocu
 {
 }
 
+void QComboBoxWithMouseWheelDisabled::wheelEvent(QWheelEvent* event)
+{
+  // Do nothing
+}
+
 void ControlExpressionSyntaxHighlighter::highlightBlock(const QString&)
 {
   // TODO: This is going to result in improper highlighting with non-ascii characters:
@@ -253,7 +258,7 @@ void IOWindow::CreateMainLayout()
   m_expression_text->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
   new ControlExpressionSyntaxHighlighter(m_expression_text->document());
 
-  m_operators_combo = new QComboBox();
+  m_operators_combo = new QComboBoxWithMouseWheelDisabled();
   m_operators_combo->addItem(tr("Operators"));
   m_operators_combo->insertSeparator(1);
   if (m_type == Type::Input)
@@ -275,7 +280,7 @@ void IOWindow::CreateMainLayout()
     m_operators_combo->addItem(tr(", Comma"));
   }
 
-  m_functions_combo = new QComboBox(this);
+  m_functions_combo = new QComboBoxWithMouseWheelDisabled(this);
   m_functions_combo->addItem(tr("Functions"));
   m_functions_combo->insertSeparator(1);
   m_functions_combo->addItem(QStringLiteral("if"));

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include <QComboBox>
 #include <QDialog>
 #include <QString>
 #include <QSyntaxHighlighter>
@@ -17,7 +18,6 @@
 class ControlReference;
 class MappingWidget;
 class QAbstractButton;
-class QComboBox;
 class QDialogButtonBox;
 class QLineEdit;
 class QTableWidget;
@@ -43,6 +43,17 @@ public:
 
 protected:
   void highlightBlock(const QString& text) final override;
+};
+
+class QComboBoxWithMouseWheelDisabled : public QComboBox
+{
+  Q_OBJECT
+public:
+  explicit QComboBoxWithMouseWheelDisabled(QWidget* parent = nullptr) : QComboBox(parent) {}
+
+protected:
+  // Consumes event while doing nothing
+  void wheelEvent(QWheelEvent* event) override;
 };
 
 class IOWindow final : public QDialog


### PR DESCRIPTION
Fixes the expression window being spammed with the first entry in the
Operators or Functions select menus when scrolling the mouse wheel while
hovering over them.

Fixes https://bugs.dolphin-emu.org/issues/12405