### PR TITLE
Fix mapping window title bar becoming unresponsive

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -88,6 +88,8 @@ QString DetectExpression(QPushButton* button, ciface::Core::DeviceContainer& dev
 
   const auto timer = new QTimer(button);
 
+  timer->setSingleShot(true);
+
   button->connect(timer, &QTimer::timeout, [button, filter] {
     button->releaseMouse();
     button->releaseKeyboard();


### PR DESCRIPTION
Fixes https://bugs.dolphin-emu.org/issues/12064

The timer called the lambda expression by interval, causing weird behavior for release functions.
Setting the timer to be one-shot fixes this issue.