### PR TITLE
Use QGridLayout for mapping settings

### DIFF
--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -83,8 +83,6 @@ MappingBool::MappingBool(MappingWidget* parent, ControllerEmu::NumericSetting<bo
 
   connect(parent, &MappingWidget::ConfigChanged, this, &MappingBool::ConfigChanged);
   connect(parent, &MappingWidget::Update, this, &MappingBool::Update);
-
-  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Ignored);
 }
 
 void MappingBool::ConfigChanged()

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -51,6 +51,9 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   QGroupBox* group_box = new QGroupBox(name);
   QFormLayout* form_layout = new QFormLayout();
 
+  QGridLayout* grid_layout = new QGridLayout();
+  int grid_row = 0;
+
   group_box->setLayout(form_layout);
 
   MappingIndicator* indicator = nullptr;
@@ -122,12 +125,15 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   {
     auto* button = new MappingButton(this, control->control_ref.get(), !indicator);
 
-    button->setMinimumWidth(100);
+    button->setMinimumWidth(75);
+    button->setMaximumWidth(150);
     button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     const bool translate = control->translate == ControllerEmu::Translate;
     const QString translated_name =
         translate ? tr(control->ui_name.c_str()) : QString::fromStdString(control->ui_name);
-    form_layout->addRow(translated_name, button);
+
+    grid_layout->addWidget(new QLabel(translated_name), grid_row, 0);
+    grid_layout->addWidget(button, grid_row++, 1);
   }
 
   for (auto& setting : group->numeric_settings)
@@ -154,11 +160,11 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     if (setting_widget)
     {
       const auto hbox = new QHBoxLayout;
-
       hbox->addWidget(setting_widget);
+      hbox->addItem(new QSpacerItem(4, 0, QSizePolicy::Fixed, QSizePolicy::Ignored));
       hbox->addWidget(CreateSettingAdvancedMappingButton(*setting));
-
-      form_layout->addRow(tr(setting->GetUIName()), hbox);
+      grid_layout->addWidget(new QLabel(tr(setting->GetUIName())), grid_row, 0);
+      grid_layout->addItem(hbox, grid_row++, 1);
     }
   }
 
@@ -183,6 +189,8 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
     connect(this, &MappingWidget::ConfigChanged, this,
             [group_enable_checkbox, group] { group_enable_checkbox->setChecked(group->enabled); });
   }
+
+  form_layout->addRow(grid_layout);
 
   return group_box;
 }


### PR DESCRIPTION
Takes a wack at https://bugs.dolphin-emu.org/issues/11707#change-741102

![Mapping button resizing grid](https://user-images.githubusercontent.com/7977538/107249788-f7e83a00-6a33-11eb-9d0d-ef9fff364997.gif)

Picking at the low priority issues since I still lack experience doing more significant things. 

I'm considering making a separate class that inherits from QGridLayout to support the "AddRow" functionality in QFormLayout.