### PR TITLE
PCAP: Improve TCP session logging

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -701,6 +701,7 @@ s32 WiiSockMan::AddSocket(s32 fd, bool is_rw)
     WiiSocket& sock = WiiSockets[wii_fd];
     sock.SetFd(fd);
     sock.SetWiiFd(wii_fd);
+    PowerPC::debug_interface.NetworkLogger()->OnNewSocket(fd);
 
 #ifdef __APPLE__
     int opt_no_sigpipe = 1;

--- a/Source/Core/Core/NetworkCaptureLogger.h
+++ b/Source/Core/Core/NetworkCaptureLogger.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstddef>
+#include <map>
 #include <memory>
 
 #ifdef _WIN32
@@ -43,6 +44,8 @@ public:
   NetworkCaptureLogger& operator=(NetworkCaptureLogger&&) = delete;
   virtual ~NetworkCaptureLogger();
 
+  virtual void OnNewSocket(s32 socket) = 0;
+
   virtual void LogSSLRead(const void* data, std::size_t length, s32 socket) = 0;
   virtual void LogSSLWrite(const void* data, std::size_t length, s32 socket) = 0;
 
@@ -55,6 +58,8 @@ public:
 class DummyNetworkCaptureLogger : public NetworkCaptureLogger
 {
 public:
+  void OnNewSocket(s32 socket) override;
+
   void LogSSLRead(const void* data, std::size_t length, s32 socket) override;
   void LogSSLWrite(const void* data, std::size_t length, s32 socket) override;
 
@@ -78,6 +83,8 @@ class PCAPSSLCaptureLogger final : public NetworkCaptureLogger
 public:
   PCAPSSLCaptureLogger();
   ~PCAPSSLCaptureLogger();
+
+  void OnNewSocket(s32 socket) override;
 
   void LogSSLRead(const void* data, std::size_t length, s32 socket) override;
   void LogSSLWrite(const void* data, std::size_t length, s32 socket) override;
@@ -108,7 +115,7 @@ private:
                const sockaddr_in& to);
 
   std::unique_ptr<Common::PCAP> m_file;
-  u32 m_read_sequence_number = 0;
-  u32 m_write_sequence_number = 0;
+  std::map<s32, u32> m_read_sequence_number;
+  std::map<s32, u32> m_write_sequence_number;
 };
 }  // namespace Core


### PR DESCRIPTION
This PR improves TCP sessions logging for games using multiple sockets at the same time (for instance the Internet channel). That way, each socket tracks its sequence numbers and avoid sequence number mismatch when multiple of them are used.

Ready to reviewed & merged.