### PR TITLE
hidapi: Use LIBUSB_LIBRARIES to link to libusb

### DIFF
--- a/Externals/hidapi/CMakeLists.txt
+++ b/Externals/hidapi/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
     target_link_libraries(hidapi PRIVATE udev)
   else()
     target_sources(hidapi PRIVATE libusb/hid.c)
-    target_link_libraries(hidapi PRIVATE usb)
+    target_link_libraries(hidapi PRIVATE ${LIBUSB_LIBRARIES})
   endif()
 endif()
 


### PR DESCRIPTION
Because we have an old-style find script that does not define a proper
CMake target for libusb, we need to use ${LIBUSB_LIBRARIES}
rather than "usb".

Ideally, we would fix the find script to define a target. However,
this issue breaks the fifoci-ogl-lin-mesa builder and I'd prefer it
to be fixed sooner rather than later.