### PR TITLE
IOS: Use less ambiguous names for classes

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -471,8 +471,8 @@ bool CBoot::EmulatedBS2_Wii(const DiscIO::VolumeDisc& volume)
   if (!SetupWiiMemory(console_type) || !IOS::HLE::GetIOS()->BootIOS(tmd.GetIOSId()))
     return false;
 
-  auto di = std::static_pointer_cast<IOS::HLE::Device::DI>(
-      IOS::HLE::GetIOS()->GetDeviceByName("/dev/di"));
+  auto di =
+      std::static_pointer_cast<IOS::HLE::DIDevice>(IOS::HLE::GetIOS()->GetDeviceByName("/dev/di"));
 
   di->InitializeIfFirstTime();
   di->ChangePartition(data_partition);

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -561,8 +561,7 @@ bool UpdateRunningGameMetadata(std::optional<u64> title_id)
   if (!DVDThread::HasDisc())
     return false;
 
-  return DVDThread::UpdateRunningGameMetadata(IOS::HLE::Device::DI::GetCurrentPartition(),
-                                              title_id);
+  return DVDThread::UpdateRunningGameMetadata(IOS::HLE::DIDevice::GetCurrentPartition(), title_id);
 }
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
@@ -1312,7 +1311,7 @@ void FinishExecutingCommand(ReplyType reply_type, DIInterruptType interrupt_type
 
   case ReplyType::IOS:
   {
-    IOS::HLE::Device::DI::InterruptFromDVDInterface(interrupt_type);
+    IOS::HLE::DIDevice::InterruptFromDVDInterface(interrupt_type);
     break;
   }
 

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -233,7 +233,7 @@ static void IOSNotifyResetButtonCallback(u64 userdata, s64 cyclesLate)
 
   auto stm = ios->GetDeviceByName("/dev/stm/eventhook");
   if (stm)
-    std::static_pointer_cast<IOS::HLE::Device::STMEventHook>(stm)->ResetButton();
+    std::static_pointer_cast<IOS::HLE::STMEventHookDevice>(stm)->ResetButton();
 }
 
 static void IOSNotifyPowerButtonCallback(u64 userdata, s64 cyclesLate)
@@ -244,7 +244,7 @@ static void IOSNotifyPowerButtonCallback(u64 userdata, s64 cyclesLate)
 
   auto stm = ios->GetDeviceByName("/dev/stm/eventhook");
   if (stm)
-    std::static_pointer_cast<IOS::HLE::Device::STMEventHook>(stm)->PowerButton();
+    std::static_pointer_cast<IOS::HLE::STMEventHookDevice>(stm)->PowerButton();
 }
 
 void ResetButton_Tap()

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -34,7 +34,7 @@ IPC_HLE_PERIOD: For the Wii Remote this is the call schedule:
       // If the AclFrameQue is empty this will call Wiimote_Update() and make it send
       the current input status to the game. I'm not sure if this occurs approximately
       once every frame or if the frequency is not exactly tied to rendered frames
-      IOS::HLE::Device::BluetoothEmu::Update()
+      IOS::HLE::BluetoothEmuDevice::Update()
       PluginWiimote::Wiimote_Update()
 
       // This is also a device updated by IOS::HLE::Update() but it doesn't

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -53,7 +53,7 @@ void UpdateSource(unsigned int index)
   if (!ios)
     return;
 
-  const auto bluetooth = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
+  const auto bluetooth = std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
       ios->GetDeviceByName("/dev/usb/oh1/57e/305"));
   if (!bluetooth)
     return;

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -39,15 +39,15 @@ static RegisterWrapper<0x0D806018> DILENGTH;
 static RegisterWrapper<0x0D80601C> DICR;
 static RegisterWrapper<0x0D806020> DIIMMBUF;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-CoreTiming::EventType* DI::s_finish_executing_di_command;
+CoreTiming::EventType* DIDevice::s_finish_executing_di_command;
 
-DI::DI(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+DIDevice::DIDevice(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
 }
 
-void DI::DoState(PointerWrap& p)
+void DIDevice::DoState(PointerWrap& p)
 {
   DoStateShared(p);
   p.Do(m_commands_to_execute);
@@ -57,13 +57,13 @@ void DI::DoState(PointerWrap& p)
   p.Do(m_last_length);
 }
 
-IPCCommandResult DI::Open(const OpenRequest& request)
+IPCCommandResult DIDevice::Open(const OpenRequest& request)
 {
   InitializeIfFirstTime();
   return Device::Open(request);
 }
 
-IPCCommandResult DI::IOCtl(const IOCtlRequest& request)
+IPCCommandResult DIDevice::IOCtl(const IOCtlRequest& request)
 {
   InitializeIfFirstTime();
 
@@ -94,11 +94,11 @@ IPCCommandResult DI::IOCtl(const IOCtlRequest& request)
   return GetNoReply();
 }
 
-void DI::ProcessQueuedIOCtl()
+void DIDevice::ProcessQueuedIOCtl()
 {
   if (m_commands_to_execute.empty())
   {
-    PanicAlertFmt("IOS::HLE::Device::DI: There is no command to execute!");
+    PanicAlertFmt("IOS::HLE::DIDevice: There is no command to execute!");
     return;
   }
 
@@ -115,7 +115,7 @@ void DI::ProcessQueuedIOCtl()
   }
 }
 
-std::optional<DI::DIResult> DI::WriteIfFits(const IOCtlRequest& request, u32 value)
+std::optional<DIDevice::DIResult> DIDevice::WriteIfFits(const IOCtlRequest& request, u32 value)
 {
   if (request.buffer_out_size < 4)
   {
@@ -129,7 +129,7 @@ std::optional<DI::DIResult> DI::WriteIfFits(const IOCtlRequest& request, u32 val
   }
 }
 
-std::optional<DI::DIResult> DI::StartIOCtl(const IOCtlRequest& request)
+std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& request)
 {
   if (request.buffer_in_size != 0x20)
   {
@@ -482,7 +482,8 @@ std::optional<DI::DIResult> DI::StartIOCtl(const IOCtlRequest& request)
   }
 }
 
-std::optional<DI::DIResult> DI::StartDMATransfer(u32 command_length, const IOCtlRequest& request)
+std::optional<DIDevice::DIResult> DIDevice::StartDMATransfer(u32 command_length,
+                                                             const IOCtlRequest& request)
 {
   if (request.buffer_out_size < command_length)
   {
@@ -517,8 +518,8 @@ std::optional<DI::DIResult> DI::StartDMATransfer(u32 command_length, const IOCtl
   // Reply will be posted when done by FinishIOCtl.
   return {};
 }
-std::optional<DI::DIResult> DI::StartImmediateTransfer(const IOCtlRequest& request,
-                                                       bool write_to_buf)
+std::optional<DIDevice::DIResult> DIDevice::StartImmediateTransfer(const IOCtlRequest& request,
+                                                                   bool write_to_buf)
 {
   if (write_to_buf && request.buffer_out_size < 4)
   {
@@ -536,17 +537,17 @@ std::optional<DI::DIResult> DI::StartImmediateTransfer(const IOCtlRequest& reque
   return {};
 }
 
-static std::shared_ptr<DI> GetDevice()
+static std::shared_ptr<DIDevice> GetDevice()
 {
   auto ios = IOS::HLE::GetIOS();
   if (!ios)
     return nullptr;
   auto di = ios->GetDeviceByName("/dev/di");
   // di may be empty, but static_pointer_cast returns empty in that case
-  return std::static_pointer_cast<DI>(di);
+  return std::static_pointer_cast<DIDevice>(di);
 }
 
-void DI::InterruptFromDVDInterface(DVDInterface::DIInterruptType interrupt_type)
+void DIDevice::InterruptFromDVDInterface(DVDInterface::DIInterruptType interrupt_type)
 {
   DIResult result;
   switch (interrupt_type)
@@ -558,7 +559,7 @@ void DI::InterruptFromDVDInterface(DVDInterface::DIInterruptType interrupt_type)
     result = DIResult::DriveError;
     break;
   default:
-    PanicAlertFmt("IOS::HLE::Device::DI: Unexpected DVDInterface interrupt {0}!",
+    PanicAlertFmt("IOS::HLE::DIDevice: Unexpected DVDInterface interrupt {0}!",
                   static_cast<int>(interrupt_type));
     result = DIResult::DriveError;
     break;
@@ -571,12 +572,12 @@ void DI::InterruptFromDVDInterface(DVDInterface::DIInterruptType interrupt_type)
   }
   else
   {
-    PanicAlertFmt("IOS::HLE::Device::DI: Received interrupt from DVDInterface when device wasn't "
+    PanicAlertFmt("IOS::HLE::DIDevice: Received interrupt from DVDInterface when device wasn't "
                   "registered!");
   }
 }
 
-void DI::FinishDICommandCallback(u64 userdata, s64 ticksbehind)
+void DIDevice::FinishDICommandCallback(u64 userdata, s64 ticksbehind)
 {
   const DIResult result = static_cast<DIResult>(userdata);
 
@@ -584,15 +585,14 @@ void DI::FinishDICommandCallback(u64 userdata, s64 ticksbehind)
   if (di)
     di->FinishDICommand(result);
   else
-    PanicAlertFmt(
-        "IOS::HLE::Device::DI: Received interrupt from DI when device wasn't registered!");
+    PanicAlertFmt("IOS::HLE::DIDevice: Received interrupt from DI when device wasn't registered!");
 }
 
-void DI::FinishDICommand(DIResult result)
+void DIDevice::FinishDICommand(DIResult result)
 {
   if (!m_executing_command.has_value())
   {
-    PanicAlertFmt("IOS::HLE::Device::DI: There is no command to finish!");
+    PanicAlertFmt("IOS::HLE::DIDevice: There is no command to finish!");
     return;
   }
 
@@ -612,7 +612,7 @@ void DI::FinishDICommand(DIResult result)
   }
 }
 
-IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult DIDevice::IOCtlV(const IOCtlVRequest& request)
 {
   // IOCtlVs are not queued since they don't (currently) go into DVDInterface and act
   // asynchronously. This does mean that an IOCtlV can be executed while an IOCtl is in progress,
@@ -707,12 +707,12 @@ IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
   return GetDefaultReply(static_cast<s32>(return_value));
 }
 
-void DI::ChangePartition(const DiscIO::Partition partition)
+void DIDevice::ChangePartition(const DiscIO::Partition partition)
 {
   m_current_partition = partition;
 }
 
-DiscIO::Partition DI::GetCurrentPartition()
+DiscIO::Partition DIDevice::GetCurrentPartition()
 {
   auto di = GetDevice();
   // Note that this function is called in Gamecube mode for UpdateRunningGameMetadata,
@@ -722,7 +722,7 @@ DiscIO::Partition DI::GetCurrentPartition()
   return di->m_current_partition;
 }
 
-void DI::InitializeIfFirstTime()
+void DIDevice::InitializeIfFirstTime()
 {
   // Match the behavior of Nintendo's initDvdDriverStage2, which is called the first time
   // an open/ioctl/ioctlv occurs.  This behavior is observable by directly reading the DI registers,
@@ -738,7 +738,7 @@ void DI::InitializeIfFirstTime()
   }
 }
 
-void DI::ResetDIRegisters()
+void DIDevice::ResetDIRegisters()
 {
   // Clear transfer complete and error interrupts (normally r/z, but here we just directly write
   // zero)
@@ -751,4 +751,4 @@ void DI::ResetDIRegisters()
   // Close the current partition, if there is one
   ChangePartition(DiscIO::PARTITION_NONE);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -30,12 +30,12 @@ namespace IOS::HLE
 void Init();
 }
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-class DI : public Device
+class DIDevice : public Device
 {
 public:
-  DI(Kernel& ios, const std::string& device_name);
+  DIDevice(Kernel& ios, const std::string& device_name);
 
   static void InterruptFromDVDInterface(DVDInterface::DIInterruptType interrupt_type);
   static DiscIO::Partition GetCurrentPartition();
@@ -145,4 +145,4 @@ private:
   bool m_has_initialized = false;
   u32 m_last_length = 0;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -142,8 +142,6 @@ void IOCtlVRequest::DumpUnknown(const std::string& description, Common::Log::LOG
   Dump("Unknown IOCtlV - " + description, type, level);
 }
 
-namespace Device
-{
 Device::Device(Kernel& ios, const std::string& device_name, const DeviceType type)
     : m_ios(ios), m_name(device_name), m_device_type(type)
 {
@@ -208,5 +206,4 @@ IPCCommandResult Device::GetNoReply()
 {
   return {IPC_SUCCESS, false, 0};
 }
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -166,8 +166,6 @@ struct IOCtlVRequest final : Request
                    Common::Log::LOG_LEVELS level = Common::Log::LERROR) const;
 };
 
-namespace Device
-{
 class Device
 {
 public:
@@ -213,5 +211,4 @@ protected:
 private:
   IPCCommandResult Unsupported(const Request& request);
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DeviceStub.cpp
+++ b/Source/Core/Core/IOS/DeviceStub.cpp
@@ -6,24 +6,24 @@
 
 #include "Common/Logging/Log.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-IPCCommandResult Stub::Open(const OpenRequest& request)
+IPCCommandResult DeviceStub::Open(const OpenRequest& request)
 {
   WARN_LOG_FMT(IOS, "{} faking Open()", m_name);
   m_is_active = true;
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult Stub::IOCtl(const IOCtlRequest& request)
+IPCCommandResult DeviceStub::IOCtl(const IOCtlRequest& request)
 {
   WARN_LOG_FMT(IOS, "{} faking IOCtl()", m_name);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult Stub::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult DeviceStub::IOCtlV(const IOCtlVRequest& request)
 {
   WARN_LOG_FMT(IOS, "{} faking IOCtlV()", m_name);
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DeviceStub.h
+++ b/Source/Core/Core/IOS/DeviceStub.h
@@ -10,9 +10,9 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-class Stub final : public Device
+class DeviceStub final : public Device
 {
 public:
   // Inherit the constructor from the Device class, since we don't need to do anything special.
@@ -21,4 +21,4 @@ public:
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -19,7 +19,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/DolphinDevice.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 namespace
 {
@@ -187,4 +187,4 @@ IPCCommandResult DolphinDevice::IOCtlV(const IOCtlVRequest& request)
     return GetDefaultReply(IPC_EINVAL);
   }
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/DolphinDevice.h
+++ b/Source/Core/Core/IOS/DolphinDevice.h
@@ -6,7 +6,7 @@
 
 #include "Core/IOS/Device.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 class DolphinDevice final : public Device
 {
@@ -15,4 +15,4 @@ public:
   using Device::Device;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -23,7 +23,7 @@ namespace DiscIO
 enum class Platform;
 }
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 struct TitleContext
 {
@@ -38,10 +38,10 @@ struct TitleContext
   bool first_change = true;
 };
 
-class ES final : public Device
+class ESDevice final : public Device
 {
 public:
-  ES(Kernel& ios, const std::string& device_name);
+  ESDevice(Kernel& ios, const std::string& device_name);
 
   ReturnCode DIVerify(const IOS::ES::TMDReader& tmd, const IOS::ES::TicketReader& ticket);
   bool LaunchTitle(u64 title_id, bool skip_reload = false);
@@ -385,4 +385,4 @@ private:
   ContextArray m_contexts;
   TitleContext m_title_context{};
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -18,16 +18,16 @@
 #include "Core/IOS/IOSC.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-ReturnCode ES::GetDeviceId(u32* device_id) const
+ReturnCode ESDevice::GetDeviceId(u32* device_id) const
 {
   *device_id = m_ios.GetIOSC().GetDeviceId();
   INFO_LOG_FMT(IOS_ES, "GetDeviceId: {:08X}", *device_id);
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::GetDeviceId(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetDeviceId(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -40,7 +40,7 @@ IPCCommandResult ES::GetDeviceId(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::Encrypt(u32 uid, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::Encrypt(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 2))
     return GetDefaultReply(ES_EINVAL);
@@ -57,7 +57,7 @@ IPCCommandResult ES::Encrypt(u32 uid, const IOCtlVRequest& request)
   return GetDefaultReply(ret);
 }
 
-IPCCommandResult ES::Decrypt(u32 uid, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::Decrypt(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 2))
     return GetDefaultReply(ES_EINVAL);
@@ -74,7 +74,7 @@ IPCCommandResult ES::Decrypt(u32 uid, const IOCtlVRequest& request)
   return GetDefaultReply(ret);
 }
 
-IPCCommandResult ES::CheckKoreaRegion(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::CheckKoreaRegion(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -87,7 +87,7 @@ IPCCommandResult ES::CheckKoreaRegion(const IOCtlVRequest& request)
   return GetDefaultReply(ES_EINVAL);
 }
 
-IPCCommandResult ES::GetDeviceCertificate(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetDeviceCertificate(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != 0x180)
     return GetDefaultReply(ES_EINVAL);
@@ -99,7 +99,7 @@ IPCCommandResult ES::GetDeviceCertificate(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::Sign(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::Sign(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 2))
     return GetDefaultReply(ES_EINVAL);
@@ -117,8 +117,8 @@ IPCCommandResult ES::Sign(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-ReturnCode ES::VerifySign(const std::vector<u8>& hash, const std::vector<u8>& ecc_signature,
-                          const std::vector<u8>& certs_bytes)
+ReturnCode ESDevice::VerifySign(const std::vector<u8>& hash, const std::vector<u8>& ecc_signature,
+                                const std::vector<u8>& certs_bytes)
 {
   const std::map<std::string, IOS::ES::CertReader> certs = IOS::ES::ParseCertChain(certs_bytes);
   if (certs.empty())
@@ -185,7 +185,7 @@ ReturnCode ES::VerifySign(const std::vector<u8>& hash, const std::vector<u8>& ec
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::VerifySign(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::VerifySign(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -203,4 +203,4 @@ IPCCommandResult ES::VerifySign(const IOCtlVRequest& request)
 
   return GetDefaultReply(VerifySign(hash, ecc_signature, certs));
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -13,9 +13,9 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-s32 ES::OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid)
+s32 ESDevice::OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid)
 {
   const u64 title_id = tmd.GetTitleId();
 
@@ -46,7 +46,7 @@ s32 ES::OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid)
   return FS_EFDEXHAUSTED;
 }
 
-IPCCommandResult ES::OpenContent(u32 uid, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::OpenContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0) || request.in_vectors[0].size != sizeof(u64) ||
       request.in_vectors[1].size != sizeof(IOS::ES::TicketView) ||
@@ -66,7 +66,7 @@ IPCCommandResult ES::OpenContent(u32 uid, const IOCtlVRequest& request)
   return GetDefaultReply(OpenContent(tmd, content_index, uid));
 }
 
-IPCCommandResult ES::OpenActiveTitleContent(u32 caller_uid, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::OpenActiveTitleContent(u32 caller_uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -84,7 +84,7 @@ IPCCommandResult ES::OpenActiveTitleContent(u32 caller_uid, const IOCtlVRequest&
   return GetDefaultReply(OpenContent(m_title_context.tmd, content_index, caller_uid));
 }
 
-s32 ES::ReadContent(u32 cfd, u8* buffer, u32 size, u32 uid)
+s32 ESDevice::ReadContent(u32 cfd, u8* buffer, u32 size, u32 uid)
 {
   if (cfd >= m_content_table.size())
     return ES_EINVAL;
@@ -99,7 +99,7 @@ s32 ES::ReadContent(u32 cfd, u8* buffer, u32 size, u32 uid)
   return result.Succeeded() ? *result : FS::ConvertResult(result.Error());
 }
 
-IPCCommandResult ES::ReadContent(u32 uid, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ReadContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -111,7 +111,7 @@ IPCCommandResult ES::ReadContent(u32 uid, const IOCtlVRequest& request)
   return GetDefaultReply(ReadContent(cfd, Memory::GetPointer(addr), size, uid));
 }
 
-ReturnCode ES::CloseContent(u32 cfd, u32 uid)
+ReturnCode ESDevice::CloseContent(u32 cfd, u32 uid)
 {
   if (cfd >= m_content_table.size())
     return ES_EINVAL;
@@ -128,7 +128,7 @@ ReturnCode ES::CloseContent(u32 cfd, u32 uid)
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::CloseContent(u32 uid, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::CloseContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -137,7 +137,7 @@ IPCCommandResult ES::CloseContent(u32 uid, const IOCtlVRequest& request)
   return GetDefaultReply(CloseContent(cfd, uid));
 }
 
-s32 ES::SeekContent(u32 cfd, u32 offset, SeekMode mode, u32 uid)
+s32 ESDevice::SeekContent(u32 cfd, u32 offset, SeekMode mode, u32 uid)
 {
   if (cfd >= m_content_table.size())
     return ES_EINVAL;
@@ -152,7 +152,7 @@ s32 ES::SeekContent(u32 cfd, u32 offset, SeekMode mode, u32 uid)
   return result.Succeeded() ? *result : FS::ConvertResult(result.Error());
 }
 
-IPCCommandResult ES::SeekContent(u32 uid, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::SeekContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -163,4 +163,4 @@ IPCCommandResult ES::SeekContent(u32 uid, const IOCtlVRequest& request)
 
   return GetDefaultReply(SeekContent(cfd, offset, mode, uid));
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/TitleInformation.cpp
+++ b/Source/Core/Core/IOS/ES/TitleInformation.cpp
@@ -12,12 +12,12 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 // Used by the GetStoredContents ioctlvs. This assumes that the first output vector
 // is used for the content count (u32).
-IPCCommandResult ES::GetStoredContentsCount(const IOS::ES::TMDReader& tmd,
-                                            const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetStoredContentsCount(const IOS::ES::TMDReader& tmd,
+                                                  const IOCtlVRequest& request)
 {
   if (request.io_vectors[0].size != sizeof(u32) || !tmd.IsValid())
     return GetDefaultReply(ES_EINVAL);
@@ -32,7 +32,8 @@ IPCCommandResult ES::GetStoredContentsCount(const IOS::ES::TMDReader& tmd,
 
 // Used by the GetStoredContents ioctlvs. This assumes that the second input vector is used
 // for the content count and the output vector is used to store a list of content IDs (u32s).
-IPCCommandResult ES::GetStoredContents(const IOS::ES::TMDReader& tmd, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetStoredContents(const IOS::ES::TMDReader& tmd,
+                                             const IOCtlVRequest& request)
 {
   if (!tmd.IsValid())
     return GetDefaultReply(ES_EINVAL);
@@ -51,7 +52,7 @@ IPCCommandResult ES::GetStoredContents(const IOS::ES::TMDReader& tmd, const IOCt
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetStoredContentsCount(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetStoredContentsCount(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != sizeof(u64))
     return GetDefaultReply(ES_EINVAL);
@@ -63,7 +64,7 @@ IPCCommandResult ES::GetStoredContentsCount(const IOCtlVRequest& request)
   return GetStoredContentsCount(tmd, request);
 }
 
-IPCCommandResult ES::GetStoredContents(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetStoredContents(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1) || request.in_vectors[0].size != sizeof(u64))
     return GetDefaultReply(ES_EINVAL);
@@ -75,7 +76,7 @@ IPCCommandResult ES::GetStoredContents(const IOCtlVRequest& request)
   return GetStoredContents(tmd, request);
 }
 
-IPCCommandResult ES::GetTMDStoredContentsCount(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTMDStoredContentsCount(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -85,7 +86,7 @@ IPCCommandResult ES::GetTMDStoredContentsCount(const IOCtlVRequest& request)
   return GetStoredContentsCount(IOS::ES::TMDReader{std::move(tmd_bytes)}, request);
 }
 
-IPCCommandResult ES::GetTMDStoredContents(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTMDStoredContents(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -109,7 +110,8 @@ IPCCommandResult ES::GetTMDStoredContents(const IOCtlVRequest& request)
   return GetStoredContents(tmd, request);
 }
 
-IPCCommandResult ES::GetTitleCount(const std::vector<u64>& titles, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTitleCount(const std::vector<u64>& titles,
+                                         const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != 4)
     return GetDefaultReply(ES_EINVAL);
@@ -119,7 +121,7 @@ IPCCommandResult ES::GetTitleCount(const std::vector<u64>& titles, const IOCtlVR
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetTitles(const std::vector<u64>& titles, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTitles(const std::vector<u64>& titles, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -133,19 +135,19 @@ IPCCommandResult ES::GetTitles(const std::vector<u64>& titles, const IOCtlVReque
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetTitleCount(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTitleCount(const IOCtlVRequest& request)
 {
   const std::vector<u64> titles = GetInstalledTitles();
   INFO_LOG_FMT(IOS_ES, "GetTitleCount: {} titles", titles.size());
   return GetTitleCount(titles, request);
 }
 
-IPCCommandResult ES::GetTitles(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTitles(const IOCtlVRequest& request)
 {
   return GetTitles(GetInstalledTitles(), request);
 }
 
-IPCCommandResult ES::GetStoredTMDSize(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetStoredTMDSize(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -163,7 +165,7 @@ IPCCommandResult ES::GetStoredTMDSize(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetStoredTMD(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetStoredTMD(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -186,19 +188,19 @@ IPCCommandResult ES::GetStoredTMD(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetOwnedTitleCount(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetOwnedTitleCount(const IOCtlVRequest& request)
 {
   const std::vector<u64> titles = GetTitlesWithTickets();
   INFO_LOG_FMT(IOS_ES, "GetOwnedTitleCount: {} titles", titles.size());
   return GetTitleCount(titles, request);
 }
 
-IPCCommandResult ES::GetOwnedTitles(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetOwnedTitles(const IOCtlVRequest& request)
 {
   return GetTitles(GetTitlesWithTickets(), request);
 }
 
-IPCCommandResult ES::GetBoot2Version(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetBoot2Version(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -210,7 +212,7 @@ IPCCommandResult ES::GetBoot2Version(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetSharedContentsCount(const IOCtlVRequest& request) const
+IPCCommandResult ESDevice::GetSharedContentsCount(const IOCtlVRequest& request) const
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -222,7 +224,7 @@ IPCCommandResult ES::GetSharedContentsCount(const IOCtlVRequest& request) const
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetSharedContents(const IOCtlVRequest& request) const
+IPCCommandResult ESDevice::GetSharedContents(const IOCtlVRequest& request) const
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -238,4 +240,4 @@ IPCCommandResult ES::GetSharedContents(const IOCtlVRequest& request) const
   INFO_LOG_FMT(IOS_ES, "GetSharedContents: {} contents ({} requested)", count, max_count);
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -22,7 +22,7 @@
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 static ReturnCode WriteTicket(FS::FileSystem* fs, const IOS::ES::TicketReader& ticket)
 {
@@ -39,7 +39,7 @@ static ReturnCode WriteTicket(FS::FileSystem* fs, const IOS::ES::TicketReader& t
   return file->Write(raw_ticket.data(), raw_ticket.size()) ? IPC_SUCCESS : ES_EIO;
 }
 
-void ES::TitleImportExportContext::DoState(PointerWrap& p)
+void ESDevice::TitleImportExportContext::DoState(PointerWrap& p)
 {
   p.Do(valid);
   p.Do(key_handle);
@@ -50,8 +50,9 @@ void ES::TitleImportExportContext::DoState(PointerWrap& p)
   p.Do(content.buffer);
 }
 
-ReturnCode ES::ImportTicket(const std::vector<u8>& ticket_bytes, const std::vector<u8>& cert_chain,
-                            TicketImportType type, VerifySignature verify_signature)
+ReturnCode ESDevice::ImportTicket(const std::vector<u8>& ticket_bytes,
+                                  const std::vector<u8>& cert_chain, TicketImportType type,
+                                  VerifySignature verify_signature)
 {
   IOS::ES::TicketReader ticket{ticket_bytes};
   if (!ticket.IsValid())
@@ -92,7 +93,7 @@ ReturnCode ES::ImportTicket(const std::vector<u8>& ticket_bytes, const std::vect
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ImportTicket(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportTicket(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -128,15 +129,15 @@ static ReturnCode InitBackupKey(u64 tid, u32 title_flags, IOSC& iosc, IOSC::Hand
   return ret == IPC_SUCCESS ? iosc.ImportSecretKey(*key, NULL_KEY.data(), PID_ES) : ret;
 }
 
-static void ResetTitleImportContext(ES::Context* context, IOSC& iosc)
+static void ResetTitleImportContext(ESDevice::Context* context, IOSC& iosc)
 {
   if (context->title_import_export.key_handle)
     iosc.DeleteObject(context->title_import_export.key_handle, PID_ES);
   context->title_import_export = {};
 }
 
-ReturnCode ES::ImportTmd(Context& context, const std::vector<u8>& tmd_bytes, u64 caller_title_id,
-                         u32 caller_title_flags)
+ReturnCode ESDevice::ImportTmd(Context& context, const std::vector<u8>& tmd_bytes,
+                               u64 caller_title_id, u32 caller_title_flags)
 {
   INFO_LOG_FMT(IOS_ES, "ImportTmd");
 
@@ -179,7 +180,7 @@ ReturnCode ES::ImportTmd(Context& context, const std::vector<u8>& tmd_bytes, u64
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ImportTmd(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportTmd(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -210,8 +211,9 @@ static ReturnCode InitTitleImportKey(const std::vector<u8>& ticket_bytes, IOSC& 
                               &ticket_bytes[offsetof(IOS::ES::Ticket, title_key)], PID_ES);
 }
 
-ReturnCode ES::ImportTitleInit(Context& context, const std::vector<u8>& tmd_bytes,
-                               const std::vector<u8>& cert_chain, VerifySignature verify_signature)
+ReturnCode ESDevice::ImportTitleInit(Context& context, const std::vector<u8>& tmd_bytes,
+                                     const std::vector<u8>& cert_chain,
+                                     VerifySignature verify_signature)
 {
   INFO_LOG_FMT(IOS_ES, "ImportTitleInit");
   ResetTitleImportContext(&context, m_ios.GetIOSC());
@@ -264,7 +266,7 @@ ReturnCode ES::ImportTitleInit(Context& context, const std::vector<u8>& tmd_byte
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ImportTitleInit(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportTitleInit(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(4, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -279,7 +281,7 @@ IPCCommandResult ES::ImportTitleInit(Context& context, const IOCtlVRequest& requ
   return GetDefaultReply(ImportTitleInit(context, tmd, certs));
 }
 
-ReturnCode ES::ImportContentBegin(Context& context, u64 title_id, u32 content_id)
+ReturnCode ESDevice::ImportContentBegin(Context& context, u64 title_id, u32 content_id)
 {
   if (context.title_import_export.content.valid)
   {
@@ -322,7 +324,7 @@ ReturnCode ES::ImportContentBegin(Context& context, u64 title_id, u32 content_id
   return static_cast<ReturnCode>(content_fd);
 }
 
-IPCCommandResult ES::ImportContentBegin(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportContentBegin(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -332,7 +334,8 @@ IPCCommandResult ES::ImportContentBegin(Context& context, const IOCtlVRequest& r
   return GetDefaultReply(ImportContentBegin(context, title_id, content_id));
 }
 
-ReturnCode ES::ImportContentData(Context& context, u32 content_fd, const u8* data, u32 data_size)
+ReturnCode ESDevice::ImportContentData(Context& context, u32 content_fd, const u8* data,
+                                       u32 data_size)
 {
   INFO_LOG_FMT(IOS_ES, "ImportContentData: content fd {:08x}, size {}", content_fd, data_size);
   context.title_import_export.content.buffer.insert(
@@ -340,7 +343,7 @@ ReturnCode ES::ImportContentData(Context& context, u32 content_fd, const u8* dat
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ImportContentData(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportContentData(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -363,7 +366,7 @@ static std::string GetImportContentPath(u64 title_id, u32 content_id)
   return fmt::format("{}/content/{:08x}.app", Common::GetImportTitlePath(title_id), content_id);
 }
 
-ReturnCode ES::ImportContentEnd(Context& context, u32 content_fd)
+ReturnCode ESDevice::ImportContentEnd(Context& context, u32 content_fd)
 {
   INFO_LOG_FMT(IOS_ES, "ImportContentEnd: content fd {:08x}", content_fd);
 
@@ -426,7 +429,7 @@ ReturnCode ES::ImportContentEnd(Context& context, u32 content_fd)
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ImportContentEnd(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportContentEnd(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -454,7 +457,7 @@ static bool HasAllRequiredContents(IOS::HLE::Kernel& ios, const IOS::ES::TMDRead
   });
 }
 
-ReturnCode ES::ImportTitleDone(Context& context)
+ReturnCode ESDevice::ImportTitleDone(Context& context)
 {
   if (!context.title_import_export.valid || context.title_import_export.content.valid)
   {
@@ -489,7 +492,7 @@ ReturnCode ES::ImportTitleDone(Context& context)
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ImportTitleDone(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportTitleDone(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -497,7 +500,7 @@ IPCCommandResult ES::ImportTitleDone(Context& context, const IOCtlVRequest& requ
   return GetDefaultReply(ImportTitleDone(context));
 }
 
-ReturnCode ES::ImportTitleCancel(Context& context)
+ReturnCode ESDevice::ImportTitleCancel(Context& context)
 {
   // The TMD buffer can exist without a valid title import context.
   if (context.title_import_export.tmd.GetBytes().empty() ||
@@ -515,7 +518,7 @@ ReturnCode ES::ImportTitleCancel(Context& context)
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ImportTitleCancel(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ImportTitleCancel(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -529,7 +532,7 @@ static bool CanDeleteTitle(u64 title_id)
   return static_cast<u32>(title_id >> 32) != 0x00000001 || static_cast<u32>(title_id) > 0x101;
 }
 
-ReturnCode ES::DeleteTitle(u64 title_id)
+ReturnCode ESDevice::DeleteTitle(u64 title_id)
 {
   if (!CanDeleteTitle(title_id))
     return ES_EINVAL;
@@ -538,7 +541,7 @@ ReturnCode ES::DeleteTitle(u64 title_id)
   return FS::ConvertResult(m_ios.GetFS()->Delete(PID_KERNEL, PID_KERNEL, title_dir));
 }
 
-IPCCommandResult ES::DeleteTitle(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DeleteTitle(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != 8)
     return GetDefaultReply(ES_EINVAL);
@@ -547,7 +550,7 @@ IPCCommandResult ES::DeleteTitle(const IOCtlVRequest& request)
   return GetDefaultReply(DeleteTitle(title_id));
 }
 
-ReturnCode ES::DeleteTicket(const u8* ticket_view)
+ReturnCode ESDevice::DeleteTicket(const u8* ticket_view)
 {
   const auto fs = m_ios.GetFS();
   const u64 title_id = Common::swap64(ticket_view + offsetof(IOS::ES::TicketView, title_id));
@@ -587,7 +590,7 @@ ReturnCode ES::DeleteTicket(const u8* ticket_view)
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::DeleteTicket(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DeleteTicket(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0) ||
       request.in_vectors[0].size != sizeof(IOS::ES::TicketView))
@@ -597,7 +600,7 @@ IPCCommandResult ES::DeleteTicket(const IOCtlVRequest& request)
   return GetDefaultReply(DeleteTicket(Memory::GetPointer(request.in_vectors[0].address)));
 }
 
-ReturnCode ES::DeleteTitleContent(u64 title_id) const
+ReturnCode ESDevice::DeleteTitleContent(u64 title_id) const
 {
   if (!CanDeleteTitle(title_id))
     return ES_EINVAL;
@@ -616,14 +619,14 @@ ReturnCode ES::DeleteTitleContent(u64 title_id) const
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::DeleteTitleContent(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DeleteTitleContent(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sizeof(u64))
     return GetDefaultReply(ES_EINVAL);
   return GetDefaultReply(DeleteTitleContent(Memory::Read_U64(request.in_vectors[0].address)));
 }
 
-ReturnCode ES::DeleteContent(u64 title_id, u32 content_id) const
+ReturnCode ESDevice::DeleteContent(u64 title_id, u32 content_id) const
 {
   if (!CanDeleteTitle(title_id))
     return ES_EINVAL;
@@ -641,7 +644,7 @@ ReturnCode ES::DeleteContent(u64 title_id, u32 content_id) const
   return FS::ConvertResult(m_ios.GetFS()->Delete(PID_KERNEL, PID_KERNEL, path));
 }
 
-IPCCommandResult ES::DeleteContent(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DeleteContent(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 0) || request.in_vectors[0].size != sizeof(u64) ||
       request.in_vectors[1].size != sizeof(u32))
@@ -652,8 +655,8 @@ IPCCommandResult ES::DeleteContent(const IOCtlVRequest& request)
                                        Memory::Read_U32(request.in_vectors[1].address)));
 }
 
-ReturnCode ES::ExportTitleInit(Context& context, u64 title_id, u8* tmd_bytes, u32 tmd_size,
-                               u64 caller_title_id, u32 caller_title_flags)
+ReturnCode ESDevice::ExportTitleInit(Context& context, u64 title_id, u8* tmd_bytes, u32 tmd_size,
+                                     u64 caller_title_id, u32 caller_title_flags)
 {
   // No concurrent title import/export is allowed.
   if (context.title_import_export.valid)
@@ -681,7 +684,7 @@ ReturnCode ES::ExportTitleInit(Context& context, u64 title_id, u8* tmd_bytes, u3
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ExportTitleInit(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ExportTitleInit(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != 8)
     return GetDefaultReply(ES_EINVAL);
@@ -695,7 +698,7 @@ IPCCommandResult ES::ExportTitleInit(Context& context, const IOCtlVRequest& requ
                                          m_title_context.tmd.GetTitleFlags()));
 }
 
-ReturnCode ES::ExportContentBegin(Context& context, u64 title_id, u32 content_id)
+ReturnCode ESDevice::ExportContentBegin(Context& context, u64 title_id, u32 content_id)
 {
   context.title_import_export.content = {};
   if (!context.title_import_export.valid ||
@@ -726,7 +729,7 @@ ReturnCode ES::ExportContentBegin(Context& context, u64 title_id, u32 content_id
   return static_cast<ReturnCode>(ret);
 }
 
-IPCCommandResult ES::ExportContentBegin(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ExportContentBegin(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 0) || request.in_vectors[0].size != 8 ||
       request.in_vectors[1].size != 4)
@@ -738,7 +741,7 @@ IPCCommandResult ES::ExportContentBegin(Context& context, const IOCtlVRequest& r
   return GetDefaultReply(ExportContentBegin(context, title_id, content_id));
 }
 
-ReturnCode ES::ExportContentData(Context& context, u32 content_fd, u8* data, u32 data_size)
+ReturnCode ESDevice::ExportContentData(Context& context, u32 content_fd, u8* data, u32 data_size)
 {
   if (!context.title_import_export.valid || !context.title_import_export.content.valid || !data ||
       data_size == 0)
@@ -772,7 +775,7 @@ ReturnCode ES::ExportContentData(Context& context, u32 content_fd, u8* data, u32
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ExportContentData(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ExportContentData(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != 4 ||
       request.io_vectors[0].size == 0)
@@ -787,14 +790,14 @@ IPCCommandResult ES::ExportContentData(Context& context, const IOCtlVRequest& re
   return GetDefaultReply(ExportContentData(context, content_fd, data, bytes_to_read));
 }
 
-ReturnCode ES::ExportContentEnd(Context& context, u32 content_fd)
+ReturnCode ESDevice::ExportContentEnd(Context& context, u32 content_fd)
 {
   if (!context.title_import_export.valid || !context.title_import_export.content.valid)
     return ES_EINVAL;
   return CloseContent(content_fd, 0);
 }
 
-IPCCommandResult ES::ExportContentEnd(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ExportContentEnd(Context& context, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != 4)
     return GetDefaultReply(ES_EINVAL);
@@ -803,18 +806,18 @@ IPCCommandResult ES::ExportContentEnd(Context& context, const IOCtlVRequest& req
   return GetDefaultReply(ExportContentEnd(context, content_fd));
 }
 
-ReturnCode ES::ExportTitleDone(Context& context)
+ReturnCode ESDevice::ExportTitleDone(Context& context)
 {
   ResetTitleImportContext(&context, m_ios.GetIOSC());
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::ExportTitleDone(Context& context, const IOCtlVRequest& request)
+IPCCommandResult ESDevice::ExportTitleDone(Context& context, const IOCtlVRequest& request)
 {
   return GetDefaultReply(ExportTitleDone(context));
 }
 
-ReturnCode ES::DeleteSharedContent(const std::array<u8, 20>& sha1) const
+ReturnCode ESDevice::DeleteSharedContent(const std::array<u8, 20>& sha1) const
 {
   IOS::ES::SharedContentMap map{m_ios.GetFS()};
   const auto content_path = map.GetFilenameFromSHA1(sha1);
@@ -851,7 +854,7 @@ ReturnCode ES::DeleteSharedContent(const std::array<u8, 20>& sha1) const
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::DeleteSharedContent(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DeleteSharedContent(const IOCtlVRequest& request)
 {
   std::array<u8, 20> sha1;
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sha1.size())
@@ -859,4 +862,4 @@ IPCCommandResult ES::DeleteSharedContent(const IOCtlVRequest& request)
   Memory::CopyFromEmu(sha1.data(), request.in_vectors[0].address, request.in_vectors[0].size);
   return GetDefaultReply(DeleteSharedContent(sha1));
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/Views.cpp
+++ b/Source/Core/Core/IOS/ES/Views.cpp
@@ -18,7 +18,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/VersionInfo.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 // HACK: Since we do not want to require users to install disc updates when launching
 //       Wii games from the game list (which is the inaccurate game boot path anyway),
@@ -37,7 +37,7 @@ static bool ShouldReturnFakeViewsForIOSes(u64 title_id, const TitleContext& cont
          (ios && SConfig::GetInstance().m_disc_booted_from_game_list && disc_title);
 }
 
-IPCCommandResult ES::GetTicketViewCount(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTicketViewCount(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -65,7 +65,7 @@ IPCCommandResult ES::GetTicketViewCount(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetTicketViews(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTicketViews(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -100,7 +100,7 @@ IPCCommandResult ES::GetTicketViews(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-ReturnCode ES::GetV0TicketFromView(const u8* ticket_view, u8* ticket) const
+ReturnCode ESDevice::GetV0TicketFromView(const u8* ticket_view, u8* ticket) const
 {
   const u64 title_id = Common::swap64(&ticket_view[offsetof(IOS::ES::TicketView, title_id)]);
   const u64 ticket_id = Common::swap64(&ticket_view[offsetof(IOS::ES::TicketView, ticket_id)]);
@@ -137,7 +137,7 @@ ReturnCode ES::GetV0TicketFromView(const u8* ticket_view, u8* ticket) const
   return IPC_SUCCESS;
 }
 
-ReturnCode ES::GetTicketFromView(const u8* ticket_view, u8* ticket, u32* ticket_size) const
+ReturnCode ESDevice::GetTicketFromView(const u8* ticket_view, u8* ticket, u32* ticket_size) const
 {
   const u8 version = ticket_view[offsetof(IOS::ES::TicketView, version)];
   if (version == 1)
@@ -158,7 +158,7 @@ ReturnCode ES::GetTicketFromView(const u8* ticket_view, u8* ticket, u32* ticket_
   return IPC_SUCCESS;
 }
 
-IPCCommandResult ES::GetV0TicketFromView(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetV0TicketFromView(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) ||
       request.in_vectors[0].size != sizeof(IOS::ES::TicketView) ||
@@ -170,7 +170,7 @@ IPCCommandResult ES::GetV0TicketFromView(const IOCtlVRequest& request)
                                              Memory::GetPointer(request.io_vectors[0].address)));
 }
 
-IPCCommandResult ES::GetTicketSizeFromView(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTicketSizeFromView(const IOCtlVRequest& request)
 {
   u32 ticket_size = 0;
   if (!request.HasNumberOfValidVectors(1, 1) ||
@@ -185,7 +185,7 @@ IPCCommandResult ES::GetTicketSizeFromView(const IOCtlVRequest& request)
   return GetDefaultReply(ret);
 }
 
-IPCCommandResult ES::GetTicketFromView(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTicketFromView(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1) ||
       request.in_vectors[0].size != sizeof(IOS::ES::TicketView) ||
@@ -203,7 +203,7 @@ IPCCommandResult ES::GetTicketFromView(const IOCtlVRequest& request)
                                            &ticket_size));
 }
 
-IPCCommandResult ES::GetTMDViewSize(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTMDViewSize(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -221,7 +221,7 @@ IPCCommandResult ES::GetTMDViewSize(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::GetTMDViews(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetTMDViews(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1) ||
       request.in_vectors[0].size != sizeof(IOS::ES::TMDHeader::title_id) ||
@@ -247,7 +247,7 @@ IPCCommandResult ES::GetTMDViews(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::DIGetTMDViewSize(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DIGetTMDViewSize(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -288,7 +288,7 @@ IPCCommandResult ES::DIGetTMDViewSize(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::DIGetTMDView(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DIGetTMDView(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(2, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -334,7 +334,7 @@ IPCCommandResult ES::DIGetTMDView(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::DIGetTicketView(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DIGetTicketView(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) ||
       request.io_vectors[0].size != sizeof(IOS::ES::TicketView))
@@ -372,7 +372,7 @@ IPCCommandResult ES::DIGetTicketView(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::DIGetTMDSize(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DIGetTMDSize(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(0, 1) || request.io_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -385,7 +385,7 @@ IPCCommandResult ES::DIGetTMDSize(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::DIGetTMD(const IOCtlVRequest& request)
+IPCCommandResult ESDevice::DIGetTMD(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != sizeof(u32))
     return GetDefaultReply(ES_EINVAL);
@@ -405,4 +405,4 @@ IPCCommandResult ES::DIGetTMD(const IOCtlVRequest& request)
   Memory::CopyToEmu(request.io_vectors[0].address, tmd_bytes.data(), tmd_bytes.size());
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.h
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.h
@@ -15,14 +15,14 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 constexpr IOS::HLE::FS::Fd INVALID_FD = 0xffffffff;
 
-class FS : public Device
+class FSDevice : public Device
 {
 public:
-  FS(Kernel& ios, const std::string& device_name);
+  FSDevice(Kernel& ios, const std::string& device_name);
 
   void DoState(PointerWrap& p) override;
 
@@ -86,4 +86,4 @@ private:
   u16 m_cache_chain_index = 0;
   bool m_dirty_cache = false;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/IOS.h
+++ b/Source/Core/Core/IOS/IOS.h
@@ -27,11 +27,8 @@ namespace FS
 class FileSystem;
 }
 
-namespace Device
-{
 class Device;
-class ES;
-}  // namespace Device
+class ESDevice;
 
 struct Request;
 struct OpenRequest;
@@ -82,7 +79,7 @@ public:
   // These are *always* part of the IOS kernel and always available.
   // They are also the only available resource managers even before loading any module.
   std::shared_ptr<FS::FileSystem> GetFS();
-  std::shared_ptr<Device::ES> GetES();
+  std::shared_ptr<ESDevice> GetES();
 
   void SDIO_EventNotify();
 
@@ -108,20 +105,20 @@ protected:
   IPCCommandResult HandleIPCCommand(const Request& request);
   void EnqueueIPCAcknowledgement(u32 address, int cycles_in_future = 0);
 
-  void AddDevice(std::unique_ptr<Device::Device> device);
+  void AddDevice(std::unique_ptr<Device> device);
   void AddCoreDevices();
   void AddStaticDevices();
-  std::shared_ptr<Device::Device> GetDeviceByName(std::string_view device_name);
+  std::shared_ptr<Device> GetDeviceByName(std::string_view device_name);
   s32 GetFreeDeviceID();
   IPCCommandResult OpenDevice(OpenRequest& request);
 
   bool m_is_responsible_for_nand_root = false;
   u64 m_title_id = 0;
   static constexpr u8 IPC_MAX_FDS = 0x18;
-  std::map<std::string, std::shared_ptr<Device::Device>, std::less<>> m_device_map;
+  std::map<std::string, std::shared_ptr<Device>, std::less<>> m_device_map;
   std::mutex m_device_map_mutex;
   // TODO: make this fdmap per process.
-  std::array<std::shared_ptr<Device::Device>, IPC_MAX_FDS> m_fdmap;
+  std::array<std::shared_ptr<Device>, IPC_MAX_FDS> m_fdmap;
 
   u32 m_ppc_uid = 0;
   u16 m_ppc_gid = 0;
@@ -145,7 +142,7 @@ public:
 
   // Get a resource manager by name.
   // This only works for devices which are part of the device map.
-  std::shared_ptr<Device::Device> GetDeviceByName(std::string_view device_name);
+  std::shared_ptr<Device> GetDeviceByName(std::string_view device_name);
 };
 
 // Used for controlling and accessing an IOS instance that is tied to emulation.

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -54,7 +54,7 @@
 #include "jni/AndroidCommon/AndroidCommon.h"
 #endif
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 enum SOResultCode : s32
 {
@@ -62,7 +62,8 @@ enum SOResultCode : s32
   SO_ERROR_HOST_NOT_FOUND = -305,
 };
 
-NetIPTop::NetIPTop(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+NetIPTopDevice::NetIPTopDevice(Kernel& ios, const std::string& device_name)
+    : Device(ios, device_name)
 {
 #ifdef _WIN32
   const int ret = WSAStartup(MAKEWORD(2, 2), &InitData);
@@ -70,14 +71,14 @@ NetIPTop::NetIPTop(Kernel& ios, const std::string& device_name) : Device(ios, de
 #endif
 }
 
-NetIPTop::~NetIPTop()
+NetIPTopDevice::~NetIPTopDevice()
 {
 #ifdef _WIN32
   WSACleanup();
 #endif
 }
 
-void NetIPTop::DoState(PointerWrap& p)
+void NetIPTopDevice::DoState(PointerWrap& p)
 {
   DoStateShared(p);
   WiiSockMan::GetInstance().DoState(p);
@@ -284,7 +285,7 @@ static DefaultInterface GetSystemDefaultInterfaceOrFallback()
   return GetSystemDefaultInterface().value_or(FALLBACK_VALUES);
 }
 
-IPCCommandResult NetIPTop::IOCtl(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::IOCtl(const IOCtlRequest& request)
 {
   if (Core::WantsDeterminism())
   {
@@ -341,7 +342,7 @@ IPCCommandResult NetIPTop::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult NetIPTop::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult NetIPTopDevice::IOCtlV(const IOCtlVRequest& request)
 {
   switch (request.request)
   {
@@ -363,18 +364,18 @@ IPCCommandResult NetIPTop::IOCtlV(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-void NetIPTop::Update()
+void NetIPTopDevice::Update()
 {
   WiiSockMan::GetInstance().Update();
 }
 
-IPCCommandResult NetIPTop::HandleInitInterfaceRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleInitInterfaceRequest(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_WC24);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult NetIPTop::HandleSocketRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleSocketRequest(const IOCtlRequest& request)
 {
   const u32 af = Memory::Read_U32(request.buffer_in);
   const u32 type = Memory::Read_U32(request.buffer_in + 4);
@@ -391,7 +392,7 @@ IPCCommandResult NetIPTop::HandleSocketRequest(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult NetIPTop::HandleICMPSocketRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleICMPSocketRequest(const IOCtlRequest& request)
 {
   const u32 pf = Memory::Read_U32(request.buffer_in);
 
@@ -401,7 +402,7 @@ IPCCommandResult NetIPTop::HandleICMPSocketRequest(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult NetIPTop::HandleCloseRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleCloseRequest(const IOCtlRequest& request)
 {
   const u32 fd = Memory::Read_U32(request.buffer_in);
   WiiSockMan& sm = WiiSockMan::GetInstance();
@@ -414,7 +415,7 @@ IPCCommandResult NetIPTop::HandleCloseRequest(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult NetIPTop::HandleDoSockRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleDoSockRequest(const IOCtlRequest& request)
 {
   const u32 fd = Memory::Read_U32(request.buffer_in);
   WiiSockMan& sm = WiiSockMan::GetInstance();
@@ -422,7 +423,7 @@ IPCCommandResult NetIPTop::HandleDoSockRequest(const IOCtlRequest& request)
   return GetNoReply();
 }
 
-IPCCommandResult NetIPTop::HandleShutdownRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleShutdownRequest(const IOCtlRequest& request)
 {
   if (request.buffer_in == 0 || request.buffer_in_size < 8)
   {
@@ -440,7 +441,7 @@ IPCCommandResult NetIPTop::HandleShutdownRequest(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult NetIPTop::HandleListenRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleListenRequest(const IOCtlRequest& request)
 {
   u32 fd = Memory::Read_U32(request.buffer_in);
   u32 BACKLOG = Memory::Read_U32(request.buffer_in + 0x04);
@@ -450,7 +451,7 @@ IPCCommandResult NetIPTop::HandleListenRequest(const IOCtlRequest& request)
   return GetDefaultReply(WiiSockMan::GetNetErrorCode(ret, "SO_LISTEN", false));
 }
 
-IPCCommandResult NetIPTop::HandleGetSockOptRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleGetSockOptRequest(const IOCtlRequest& request)
 {
   u32 fd = Memory::Read_U32(request.buffer_out);
   u32 level = Memory::Read_U32(request.buffer_out + 4);
@@ -483,7 +484,7 @@ IPCCommandResult NetIPTop::HandleGetSockOptRequest(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult NetIPTop::HandleSetSockOptRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleSetSockOptRequest(const IOCtlRequest& request)
 {
   const u32 fd = Memory::Read_U32(request.buffer_in);
   const u32 level = Memory::Read_U32(request.buffer_in + 4);
@@ -518,7 +519,7 @@ IPCCommandResult NetIPTop::HandleSetSockOptRequest(const IOCtlRequest& request)
   return GetDefaultReply(WiiSockMan::GetNetErrorCode(ret, "SO_SETSOCKOPT", false));
 }
 
-IPCCommandResult NetIPTop::HandleGetSockNameRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleGetSockNameRequest(const IOCtlRequest& request)
 {
   u32 fd = Memory::Read_U32(request.buffer_in);
 
@@ -544,7 +545,7 @@ IPCCommandResult NetIPTop::HandleGetSockNameRequest(const IOCtlRequest& request)
   return GetDefaultReply(ret);
 }
 
-IPCCommandResult NetIPTop::HandleGetPeerNameRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleGetPeerNameRequest(const IOCtlRequest& request)
 {
   u32 fd = Memory::Read_U32(request.buffer_in);
 
@@ -569,7 +570,7 @@ IPCCommandResult NetIPTop::HandleGetPeerNameRequest(const IOCtlRequest& request)
   return GetDefaultReply(ret);
 }
 
-IPCCommandResult NetIPTop::HandleGetHostIDRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleGetHostIDRequest(const IOCtlRequest& request)
 {
   const DefaultInterface interface = GetSystemDefaultInterfaceOrFallback();
   const u32 host_ip = Common::swap32(interface.inet);
@@ -578,7 +579,7 @@ IPCCommandResult NetIPTop::HandleGetHostIDRequest(const IOCtlRequest& request)
   return GetDefaultReply(host_ip);
 }
 
-IPCCommandResult NetIPTop::HandleInetAToNRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleInetAToNRequest(const IOCtlRequest& request)
 {
   const std::string hostname = Memory::GetString(request.buffer_in);
   struct hostent* remoteHost = gethostbyname(hostname.c_str());
@@ -607,14 +608,14 @@ IPCCommandResult NetIPTop::HandleInetAToNRequest(const IOCtlRequest& request)
   return GetDefaultReply(1);
 }
 
-IPCCommandResult NetIPTop::HandleInetPToNRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleInetPToNRequest(const IOCtlRequest& request)
 {
   const std::string address = Memory::GetString(request.buffer_in);
   INFO_LOG_FMT(IOS_NET, "IOCTL_SO_INETPTON (Translating: {})", address);
   return GetDefaultReply(inet_pton(address.c_str(), Memory::GetPointer(request.buffer_out + 4)));
 }
 
-IPCCommandResult NetIPTop::HandleInetNToPRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleInetNToPRequest(const IOCtlRequest& request)
 {
   // u32 af = Memory::Read_U32(BufferIn);
   // u32 validAddress = Memory::Read_U32(request.buffer_in + 4);
@@ -630,7 +631,7 @@ IPCCommandResult NetIPTop::HandleInetNToPRequest(const IOCtlRequest& request)
   return GetDefaultReply(0);
 }
 
-IPCCommandResult NetIPTop::HandlePollRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandlePollRequest(const IOCtlRequest& request)
 {
   WiiSockMan& sm = WiiSockMan::GetInstance();
 
@@ -673,7 +674,7 @@ IPCCommandResult NetIPTop::HandlePollRequest(const IOCtlRequest& request)
   return GetNoReply();
 }
 
-IPCCommandResult NetIPTop::HandleGetHostByNameRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleGetHostByNameRequest(const IOCtlRequest& request)
 {
   if (request.buffer_out_size != 0x460)
   {
@@ -759,13 +760,13 @@ IPCCommandResult NetIPTop::HandleGetHostByNameRequest(const IOCtlRequest& reques
   return GetDefaultReply(0);
 }
 
-IPCCommandResult NetIPTop::HandleICMPCancelRequest(const IOCtlRequest& request)
+IPCCommandResult NetIPTopDevice::HandleICMPCancelRequest(const IOCtlRequest& request)
 {
   ERROR_LOG_FMT(IOS_NET, "IOCTL_SO_ICMPCANCEL");
   return GetDefaultReply(0);
 }
 
-IPCCommandResult NetIPTop::HandleGetInterfaceOptRequest(const IOCtlVRequest& request)
+IPCCommandResult NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& request)
 {
   const u32 param = Memory::Read_U32(request.in_vectors[0].address);
   const u32 param2 = Memory::Read_U32(request.in_vectors[0].address + 4);
@@ -941,7 +942,7 @@ IPCCommandResult NetIPTop::HandleGetInterfaceOptRequest(const IOCtlVRequest& req
   return GetDefaultReply(0);
 }
 
-IPCCommandResult NetIPTop::HandleSendToRequest(const IOCtlVRequest& request)
+IPCCommandResult NetIPTopDevice::HandleSendToRequest(const IOCtlVRequest& request)
 {
   u32 fd = Memory::Read_U32(request.in_vectors[1].address);
   WiiSockMan& sm = WiiSockMan::GetInstance();
@@ -949,7 +950,7 @@ IPCCommandResult NetIPTop::HandleSendToRequest(const IOCtlVRequest& request)
   return GetNoReply();
 }
 
-IPCCommandResult NetIPTop::HandleRecvFromRequest(const IOCtlVRequest& request)
+IPCCommandResult NetIPTopDevice::HandleRecvFromRequest(const IOCtlVRequest& request)
 {
   u32 fd = Memory::Read_U32(request.in_vectors[0].address);
   WiiSockMan& sm = WiiSockMan::GetInstance();
@@ -957,7 +958,7 @@ IPCCommandResult NetIPTop::HandleRecvFromRequest(const IOCtlVRequest& request)
   return GetNoReply();
 }
 
-IPCCommandResult NetIPTop::HandleGetAddressInfoRequest(const IOCtlVRequest& request)
+IPCCommandResult NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& request)
 {
   addrinfo hints;
   const bool hints_valid = request.in_vectors.size() > 2 && request.in_vectors[2].size;
@@ -1046,7 +1047,7 @@ IPCCommandResult NetIPTop::HandleGetAddressInfoRequest(const IOCtlVRequest& requ
   return GetDefaultReply(ret);
 }
 
-IPCCommandResult NetIPTop::HandleICMPPingRequest(const IOCtlVRequest& request)
+IPCCommandResult NetIPTopDevice::HandleICMPPingRequest(const IOCtlVRequest& request)
 {
   struct
   {
@@ -1112,4 +1113,4 @@ IPCCommandResult NetIPTop::HandleICMPPingRequest(const IOCtlVRequest& request)
   // TODO proper error codes
   return GetDefaultReply(0);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/IP/Top.h
+++ b/Source/Core/Core/IOS/Network/IP/Top.h
@@ -61,13 +61,11 @@ enum NET_IOCTL
   IOCTL_SO_ICMPCLOSE
 };
 
-namespace Device
-{
-class NetIPTop : public Device
+class NetIPTopDevice : public Device
 {
 public:
-  NetIPTop(Kernel& ios, const std::string& device_name);
-  virtual ~NetIPTop();
+  NetIPTopDevice(Kernel& ios, const std::string& device_name);
+  virtual ~NetIPTopDevice();
 
   void DoState(PointerWrap& p) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
@@ -105,5 +103,4 @@ private:
   WSADATA InitData;
 #endif
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -20,19 +20,19 @@
 #include "Core/IOS/Network/Socket.h"
 #include "Core/IOS/Uids.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-NetKDRequest::NetKDRequest(Kernel& ios, const std::string& device_name)
+NetKDRequestDevice::NetKDRequestDevice(Kernel& ios, const std::string& device_name)
     : Device(ios, device_name), config{ios.GetFS()}
 {
 }
 
-NetKDRequest::~NetKDRequest()
+NetKDRequestDevice::~NetKDRequestDevice()
 {
   WiiSockMan::GetInstance().Clean();
 }
 
-IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
+IPCCommandResult NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 return_value = 0;
   switch (request.request)
@@ -172,7 +172,7 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-u8 NetKDRequest::GetAreaCode(const std::string& area) const
+u8 NetKDRequestDevice::GetAreaCode(const std::string& area) const
 {
   static const std::map<std::string, u8> regions = {
       {"JPN", 0}, {"USA", 1}, {"EUR", 2}, {"AUS", 2}, {"BRA", 1}, {"TWN", 3}, {"ROC", 3},
@@ -186,7 +186,7 @@ u8 NetKDRequest::GetAreaCode(const std::string& area) const
   return 7;  // Unknown
 }
 
-u8 NetKDRequest::GetHardwareModel(const std::string& model) const
+u8 NetKDRequestDevice::GetHardwareModel(const std::string& model) const
 {
   static const std::map<std::string, u8> models = {
       {"RVL", MODEL_RVL},
@@ -214,8 +214,8 @@ static u64 u64_insert_byte(u64 value, u8 shift, u8 byte)
   return (value & ~mask) | inst;
 }
 
-s32 NetKDRequest::NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr, u8 hardware_model,
-                                  u8 area_code)
+s32 NetKDRequestDevice::NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr,
+                                        u8 hardware_model, u8 area_code)
 {
   const u8 table2[8] = {0x1, 0x5, 0x0, 0x4, 0x2, 0x3, 0x6, 0x7};
   const u8 table1[16] = {0x4, 0xB, 0x7, 0x9, 0xF, 0x1, 0xD, 0x3,
@@ -266,4 +266,4 @@ s32 NetKDRequest::NWC24MakeUserID(u64* nwc24_id, u32 hollywood_id, u16 id_ctr, u
 
   return NWC24::WC24_OK;
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.h
@@ -10,16 +10,16 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/Network/KD/NWC24Config.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 // KD is the IOS module responsible for implementing WiiConnect24 functionality.
 // It can perform HTTPS downloads, send and receive mail via SMTP, and execute a
 // JavaScript-like language while the Wii is in standby mode.
-class NetKDRequest : public Device
+class NetKDRequestDevice : public Device
 {
 public:
-  NetKDRequest(Kernel& ios, const std::string& device_name);
-  ~NetKDRequest() override;
+  NetKDRequestDevice(Kernel& ios, const std::string& device_name);
+  ~NetKDRequestDevice() override;
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
@@ -66,4 +66,4 @@ private:
 
   NWC24::NWC24Config config;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -10,15 +10,16 @@
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/Memmap.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-NetKDTime::NetKDTime(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+NetKDTimeDevice::NetKDTimeDevice(Kernel& ios, const std::string& device_name)
+    : Device(ios, device_name)
 {
 }
 
-NetKDTime::~NetKDTime() = default;
+NetKDTimeDevice::~NetKDTimeDevice() = default;
 
-IPCCommandResult NetKDTime::IOCtl(const IOCtlRequest& request)
+IPCCommandResult NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 result = 0;
   u32 common_result = 0;
@@ -74,15 +75,15 @@ IPCCommandResult NetKDTime::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(result);
 }
 
-u64 NetKDTime::GetAdjustedUTC() const
+u64 NetKDTimeDevice::GetAdjustedUTC() const
 {
   return ExpansionInterface::CEXIIPL::GetEmulatedTime(ExpansionInterface::CEXIIPL::UNIX_EPOCH) +
          utcdiff;
 }
 
-void NetKDTime::SetAdjustedUTC(u64 wii_utc)
+void NetKDTimeDevice::SetAdjustedUTC(u64 wii_utc)
 {
   utcdiff = ExpansionInterface::CEXIIPL::GetEmulatedTime(ExpansionInterface::CEXIIPL::UNIX_EPOCH) -
             wii_utc;
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.h
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.h
@@ -9,13 +9,13 @@
 #include "Common/CommonTypes.h"
 #include "Core/IOS/Device.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-class NetKDTime : public Device
+class NetKDTimeDevice : public Device
 {
 public:
-  NetKDTime(Kernel& ios, const std::string& device_name);
-  ~NetKDTime() override;
+  NetKDTimeDevice(Kernel& ios, const std::string& device_name);
+  ~NetKDTimeDevice() override;
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
@@ -44,4 +44,4 @@ private:
   u64 rtc = 0;
   s64 utcdiff = 0;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -13,20 +13,21 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/MACUtils.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-NetNCDManage::NetNCDManage(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+NetNCDManageDevice::NetNCDManageDevice(Kernel& ios, const std::string& device_name)
+    : Device(ios, device_name)
 {
   config.ReadConfig(ios.GetFS().get());
 }
 
-void NetNCDManage::DoState(PointerWrap& p)
+void NetNCDManageDevice::DoState(PointerWrap& p)
 {
   Device::DoState(p);
   p.Do(m_ipc_fd);
 }
 
-IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   u32 common_result = 0;
@@ -131,4 +132,4 @@ IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
   }
   return GetDefaultReply(return_value);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/NCD/Manage.h
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.h
@@ -10,13 +10,13 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/Network/NCD/WiiNetConfig.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 // Interface for reading and changing network configuration (probably some other stuff as well)
-class NetNCDManage : public Device
+class NetNCDManageDevice : public Device
 {
 public:
-  NetNCDManage(Kernel& ios, const std::string& device_name);
+  NetNCDManageDevice(Kernel& ios, const std::string& device_name);
 
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
@@ -38,4 +38,4 @@ private:
   Net::WiiNetConfig config;
   u32 m_ipc_fd = 0;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -21,9 +21,9 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/Socket.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-WII_SSL NetSSL::_SSL[IOS::HLE::NET_SSL_MAXINSTANCES];
+WII_SSL NetSSLDevice::_SSL[IOS::HLE::NET_SSL_MAXINSTANCES];
 
 static constexpr mbedtls_x509_crt_profile mbedtls_x509_crt_profile_wii = {
     /* Hashes from SHA-1 and above */
@@ -68,7 +68,7 @@ int SSLRecv(void* ctx, unsigned char* buf, size_t len)
 }
 }  // namespace
 
-NetSSL::NetSSL(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+NetSSLDevice::NetSSLDevice(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
   for (WII_SSL& ssl : _SSL)
   {
@@ -76,7 +76,7 @@ NetSSL::NetSSL(Kernel& ios, const std::string& device_name) : Device(ios, device
   }
 }
 
-NetSSL::~NetSSL()
+NetSSLDevice::~NetSSLDevice()
 {
   // Cleanup sessions
   for (WII_SSL& ssl : _SSL)
@@ -101,7 +101,7 @@ NetSSL::~NetSSL()
   }
 }
 
-int NetSSL::GetSSLFreeID() const
+int NetSSLDevice::GetSSLFreeID() const
 {
   for (int i = 0; i < NET_SSL_MAXINSTANCES; i++)
   {
@@ -113,7 +113,7 @@ int NetSSL::GetSSLFreeID() const
   return 0;
 }
 
-IPCCommandResult NetSSL::IOCtl(const IOCtlRequest& request)
+IPCCommandResult NetSSLDevice::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), Common::Log::IOS_SSL, Common::Log::LINFO);
   return GetDefaultReply(IPC_SUCCESS);
@@ -167,7 +167,7 @@ static std::vector<u8> ReadCertFile(const std::string& path, const std::array<u8
   return bytes;
 }
 
-IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
 {
   u32 BufferIn = 0, BufferIn2 = 0, BufferIn3 = 0;
   u32 BufferInSize = 0, BufferInSize2 = 0, BufferInSize3 = 0;
@@ -602,4 +602,4 @@ IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
   // SSL return codes are written to BufferIn
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -80,14 +80,12 @@ struct WII_SSL
   bool active;
 };
 
-namespace Device
-{
-class NetSSL : public Device
+class NetSSLDevice : public Device
 {
 public:
-  NetSSL(Kernel& ios, const std::string& device_name);
+  NetSSLDevice(Kernel& ios, const std::string& device_name);
 
-  virtual ~NetSSL();
+  virtual ~NetSSLDevice();
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
@@ -102,7 +100,6 @@ private:
 
 constexpr bool IsSSLIDValid(int id)
 {
-  return (id >= 0 && id < NET_SSL_MAXINSTANCES && IOS::HLE::Device::NetSSL::_SSL[id].active);
+  return (id >= 0 && id < NET_SSL_MAXINSTANCES && IOS::HLE::NetSSLDevice::_SSL[id].active);
 }
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -374,13 +374,13 @@ void WiiSocket::Update(bool read, bool write, bool except)
       if (it->is_ssl)
       {
         int sslID = Memory::Read_U32(BufferOut) - 1;
-        if (IOS::HLE::Device::IsSSLIDValid(sslID))
+        if (IOS::HLE::IsSSLIDValid(sslID))
         {
           switch (it->ssl_type)
           {
           case IOCTLV_NET_SSL_DOHANDSHAKE:
           {
-            mbedtls_ssl_context* ctx = &Device::NetSSL::_SSL[sslID].ctx;
+            mbedtls_ssl_context* ctx = &NetSSLDevice::_SSL[sslID].ctx;
             const int ret = mbedtls_ssl_handshake(ctx);
             if (ret != 0)
             {
@@ -457,7 +457,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
           }
           case IOCTLV_NET_SSL_WRITE:
           {
-            WII_SSL* ssl = &Device::NetSSL::_SSL[sslID];
+            WII_SSL* ssl = &NetSSLDevice::_SSL[sslID];
             const int ret =
                 mbedtls_ssl_write(&ssl->ctx, Memory::GetPointer(BufferOut2), BufferOutSize2);
 
@@ -491,7 +491,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
           }
           case IOCTLV_NET_SSL_READ:
           {
-            WII_SSL* ssl = &Device::NetSSL::_SSL[sslID];
+            WII_SSL* ssl = &NetSSLDevice::_SSL[sslID];
             const int ret =
                 mbedtls_ssl_read(&ssl->ctx, Memory::GetPointer(BufferIn2), BufferInSize2);
 

--- a/Source/Core/Core/IOS/Network/WD/Command.h
+++ b/Source/Core/Core/IOS/Network/WD/Command.h
@@ -37,9 +37,9 @@ constexpr bool IsValidMode(Mode mode)
 }
 }  // namespace IOS::HLE::WD
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-class NetWDCommand : public Device
+class NetWDCommandDevice : public Device
 {
 public:
   enum class ResultCode : u32
@@ -50,7 +50,7 @@ public:
     DriverError = 0x80008003,
   };
 
-  NetWDCommand(Kernel& ios, const std::string& device_name);
+  NetWDCommandDevice(Kernel& ios, const std::string& device_name);
 
   IPCCommandResult Open(const OpenRequest& request) override;
   IPCCommandResult Close(u32 fd) override;
@@ -172,4 +172,4 @@ private:
   std::deque<u32> m_recv_frame_requests;
   std::deque<u32> m_recv_notification_requests;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -21,16 +21,16 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/VersionInfo.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-SDIOSlot0::SDIOSlot0(Kernel& ios, const std::string& device_name)
+SDIOSlot0Device::SDIOSlot0Device(Kernel& ios, const std::string& device_name)
     : Device(ios, device_name), m_sdhc_supported(HasFeature(ios.GetVersion(), Feature::SDv2))
 {
   if (!Config::Get(Config::MAIN_ALLOW_SD_WRITES))
     INFO_LOG_FMT(IOS_SD, "Writes to SD card disabled by user");
 }
 
-void SDIOSlot0::DoState(PointerWrap& p)
+void SDIOSlot0Device::DoState(PointerWrap& p)
 {
   DoStateShared(p);
   if (p.GetMode() == PointerWrap::MODE_READ)
@@ -45,7 +45,7 @@ void SDIOSlot0::DoState(PointerWrap& p)
   p.Do(m_sdhc_supported);
 }
 
-void SDIOSlot0::EventNotify()
+void SDIOSlot0Device::EventNotify()
 {
   if (!m_event)
     return;
@@ -59,7 +59,7 @@ void SDIOSlot0::EventNotify()
   }
 }
 
-void SDIOSlot0::OpenInternal()
+void SDIOSlot0Device::OpenInternal()
 {
   const std::string filename = File::GetUserPath(F_WIISDCARD_IDX);
   m_card.Open(filename, "r+b");
@@ -79,7 +79,7 @@ void SDIOSlot0::OpenInternal()
   }
 }
 
-IPCCommandResult SDIOSlot0::Open(const OpenRequest& request)
+IPCCommandResult SDIOSlot0Device::Open(const OpenRequest& request)
 {
   OpenInternal();
   m_registers.fill(0);
@@ -89,7 +89,7 @@ IPCCommandResult SDIOSlot0::Open(const OpenRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::Close(u32 fd)
+IPCCommandResult SDIOSlot0Device::Close(u32 fd)
 {
   m_card.Close();
   m_block_length = 0;
@@ -98,7 +98,7 @@ IPCCommandResult SDIOSlot0::Close(u32 fd)
   return Device::Close(fd);
 }
 
-IPCCommandResult SDIOSlot0::IOCtl(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::IOCtl(const IOCtlRequest& request)
 {
   Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
 
@@ -126,7 +126,7 @@ IPCCommandResult SDIOSlot0::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult SDIOSlot0Device::IOCtlV(const IOCtlVRequest& request)
 {
   switch (request.request)
   {
@@ -140,9 +140,9 @@ IPCCommandResult SDIOSlot0::IOCtlV(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-s32 SDIOSlot0::ExecuteCommand(const Request& request, u32 buffer_in, u32 buffer_in_size,
-                              u32 rw_buffer, u32 rw_buffer_size, u32 buffer_out,
-                              u32 buffer_out_size)
+s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 buffer_in_size,
+                                    u32 rw_buffer, u32 rw_buffer_size, u32 buffer_out,
+                                    u32 buffer_out_size)
 {
   // The game will send us a SendCMD with this information. To be able to read and write
   // to a file we need to prepare a 0x10 byte output buffer as response.
@@ -325,7 +325,7 @@ s32 SDIOSlot0::ExecuteCommand(const Request& request, u32 buffer_in, u32 buffer_
   return ret;
 }
 
-IPCCommandResult SDIOSlot0::WriteHCRegister(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
 {
   const u32 reg = Memory::Read_U32(request.buffer_in);
   const u32 val = Memory::Read_U32(request.buffer_in + 16);
@@ -357,7 +357,7 @@ IPCCommandResult SDIOSlot0::WriteHCRegister(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::ReadHCRegister(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::ReadHCRegister(const IOCtlRequest& request)
 {
   const u32 reg = Memory::Read_U32(request.buffer_in);
 
@@ -375,7 +375,7 @@ IPCCommandResult SDIOSlot0::ReadHCRegister(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::ResetCard(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::ResetCard(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_RESETCARD");
 
@@ -385,7 +385,7 @@ IPCCommandResult SDIOSlot0::ResetCard(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::SetClk(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::SetClk(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_SETCLK");
 
@@ -398,7 +398,7 @@ IPCCommandResult SDIOSlot0::SetClk(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::SendCommand(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::SendCommand(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_SENDCMD {:x} IPC:{:08x}", Memory::Read_U32(request.buffer_in),
                request.address);
@@ -416,7 +416,7 @@ IPCCommandResult SDIOSlot0::SendCommand(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::GetStatus(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::GetStatus(const IOCtlRequest& request)
 {
   // Since IOS does the SD initialization itself, we just say we're always initialized.
   if (m_card)
@@ -453,7 +453,7 @@ IPCCommandResult SDIOSlot0::GetStatus(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::GetOCRegister(const IOCtlRequest& request)
+IPCCommandResult SDIOSlot0Device::GetOCRegister(const IOCtlRequest& request)
 {
   const u32 ocr = GetOCRegister();
   INFO_LOG_FMT(IOS_SD, "IOCTL_GETOCR. Replying with ocr {:x}", ocr);
@@ -462,7 +462,7 @@ IPCCommandResult SDIOSlot0::GetOCRegister(const IOCtlRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult SDIOSlot0::SendCommand(const IOCtlVRequest& request)
+IPCCommandResult SDIOSlot0Device::SendCommand(const IOCtlVRequest& request)
 {
   DEBUG_LOG_FMT(IOS_SD, "IOCTLV_SENDCMD {:#010x}", Memory::Read_U32(request.in_vectors[0].address));
   Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
@@ -475,7 +475,7 @@ IPCCommandResult SDIOSlot0::SendCommand(const IOCtlVRequest& request)
   return GetDefaultReply(return_value);
 }
 
-u32 SDIOSlot0::GetOCRegister() const
+u32 SDIOSlot0Device::GetOCRegister() const
 {
   u32 ocr = 0x00ff8000;
   if (m_status & CARD_INITIALIZED)
@@ -485,7 +485,7 @@ u32 SDIOSlot0::GetOCRegister() const
   return ocr;
 }
 
-std::array<u32, 4> SDIOSlot0::GetCSDv1() const
+std::array<u32, 4> SDIOSlot0Device::GetCSDv1() const
 {
   u64 size = m_card.GetSize();
 
@@ -569,7 +569,7 @@ std::array<u32, 4> SDIOSlot0::GetCSDv1() const
   }};
 }
 
-std::array<u32, 4> SDIOSlot0::GetCSDv2() const
+std::array<u32, 4> SDIOSlot0Device::GetCSDv2() const
 {
   const u64 size = m_card.GetSize();
 
@@ -626,7 +626,7 @@ std::array<u32, 4> SDIOSlot0::GetCSDv2() const
   }};
 }
 
-u64 SDIOSlot0::GetAddressFromRequest(u32 arg) const
+u64 SDIOSlot0Device::GetAddressFromRequest(u32 arg) const
 {
   u64 address(arg);
   if (m_status & CARD_SDHC)
@@ -634,10 +634,10 @@ u64 SDIOSlot0::GetAddressFromRequest(u32 arg) const
   return address;
 }
 
-void SDIOSlot0::InitSDHC()
+void SDIOSlot0Device::InitSDHC()
 {
   m_protocol = SDProtocol::V2;
   m_status |= CARD_INITIALIZED;
 }
 
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -16,13 +16,13 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 // The front SD slot
-class SDIOSlot0 : public Device
+class SDIOSlot0Device : public Device
 {
 public:
-  SDIOSlot0(Kernel& ios, const std::string& device_name);
+  SDIOSlot0Device(Kernel& ios, const std::string& device_name);
 
   void DoState(PointerWrap& p) override;
 
@@ -164,4 +164,4 @@ private:
 
   File::IOFile m_card;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -12,11 +12,11 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 static std::unique_ptr<IOCtlRequest> s_event_hook_request;
 
-IPCCommandResult STMImmediate::IOCtl(const IOCtlRequest& request)
+IPCCommandResult STMImmediateDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   switch (request.request)
@@ -62,12 +62,12 @@ IPCCommandResult STMImmediate::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-STMEventHook::~STMEventHook()
+STMEventHookDevice::~STMEventHookDevice()
 {
   s_event_hook_request.reset();
 }
 
-IPCCommandResult STMEventHook::IOCtl(const IOCtlRequest& request)
+IPCCommandResult STMEventHookDevice::IOCtl(const IOCtlRequest& request)
 {
   if (request.request != IOCTL_STM_EVENTHOOK)
     return GetDefaultReply(IPC_EINVAL);
@@ -80,7 +80,7 @@ IPCCommandResult STMEventHook::IOCtl(const IOCtlRequest& request)
   return GetNoReply();
 }
 
-void STMEventHook::DoState(PointerWrap& p)
+void STMEventHookDevice::DoState(PointerWrap& p)
 {
   u32 address = s_event_hook_request ? s_event_hook_request->address : 0;
   p.Do(address);
@@ -91,12 +91,12 @@ void STMEventHook::DoState(PointerWrap& p)
   Device::DoState(p);
 }
 
-bool STMEventHook::HasHookInstalled() const
+bool STMEventHookDevice::HasHookInstalled() const
 {
   return s_event_hook_request != nullptr;
 }
 
-void STMEventHook::TriggerEvent(const u32 event) const
+void STMEventHookDevice::TriggerEvent(const u32 event) const
 {
   // If the device isn't open, ignore the button press.
   if (!m_is_active || !s_event_hook_request)
@@ -107,14 +107,14 @@ void STMEventHook::TriggerEvent(const u32 event) const
   s_event_hook_request.reset();
 }
 
-void STMEventHook::ResetButton() const
+void STMEventHookDevice::ResetButton() const
 {
   // The reset button triggers STM_EVENT_RESET.
   TriggerEvent(STM_EVENT_RESET);
 }
 
-void STMEventHook::PowerButton() const
+void STMEventHookDevice::PowerButton() const
 {
   TriggerEvent(STM_EVENT_POWER);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -12,7 +12,7 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 enum
 {
@@ -39,7 +39,7 @@ enum
 };
 
 // The /dev/stm/immediate
-class STMImmediate final : public Device
+class STMImmediateDevice final : public Device
 {
 public:
   using Device::Device;
@@ -47,11 +47,11 @@ public:
 };
 
 // The /dev/stm/eventhook
-class STMEventHook final : public Device
+class STMEventHookDevice final : public Device
 {
 public:
   using Device::Device;
-  ~STMEventHook() override;
+  ~STMEventHookDevice() override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void DoState(PointerWrap& p) override;
 
@@ -62,4 +62,4 @@ public:
 private:
   void TriggerEvent(u32 event) const;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
@@ -19,9 +19,7 @@ namespace IOS::HLE
 void BackUpBTInfoSection(const SysConf* sysconf);
 void RestoreBTInfoSection(SysConf* sysconf);
 
-namespace Device
-{
-class BluetoothBase : public Device
+class BluetoothBaseDevice : public Device
 {
 public:
   using Device::Device;
@@ -43,5 +41,4 @@ protected:
     ACL_DATA_OUT = 0x02
   };
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -33,10 +33,8 @@ SQueuedEvent::SQueuedEvent(u32 size_, u16 handle) : size(size_), connection_hand
     PanicAlertFmt("SQueuedEvent: The size is too large.");
 }
 
-namespace Device
-{
-BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
-    : BluetoothBase(ios, device_name)
+BluetoothEmuDevice::BluetoothEmuDevice(Kernel& ios, const std::string& device_name)
+    : BluetoothBaseDevice(ios, device_name)
 {
   SysConf sysconf{ios.GetFS()};
   if (!Core::WantsDeterminism())
@@ -75,7 +73,7 @@ BluetoothEmu::BluetoothEmu(Kernel& ios, const std::string& device_name)
     PanicAlertFmtT("Failed to write BT.DINF to SYSCONF");
 }
 
-BluetoothEmu::~BluetoothEmu() = default;
+BluetoothEmuDevice::~BluetoothEmuDevice() = default;
 
 template <typename T>
 static void DoStateForMessage(Kernel& ios, PointerWrap& p, std::unique_ptr<T>& message)
@@ -89,7 +87,7 @@ static void DoStateForMessage(Kernel& ios, PointerWrap& p, std::unique_ptr<T>& m
   }
 }
 
-void BluetoothEmu::DoState(PointerWrap& p)
+void BluetoothEmuDevice::DoState(PointerWrap& p)
 {
   bool passthrough_bluetooth = false;
   p.Do(passthrough_bluetooth);
@@ -114,7 +112,7 @@ void BluetoothEmu::DoState(PointerWrap& p)
     m_wiimotes[i]->DoState(p);
 }
 
-bool BluetoothEmu::RemoteConnect(WiimoteDevice& wiimote)
+bool BluetoothEmuDevice::RemoteConnect(WiimoteDevice& wiimote)
 {
   // If page scan is disabled the controller will not see this connection request.
   if (!(m_scan_enable & HCI_PAGE_SCAN_ENABLE))
@@ -124,12 +122,12 @@ bool BluetoothEmu::RemoteConnect(WiimoteDevice& wiimote)
   return true;
 }
 
-bool BluetoothEmu::RemoteDisconnect(const bdaddr_t& address)
+bool BluetoothEmuDevice::RemoteDisconnect(const bdaddr_t& address)
 {
   return SendEventDisconnect(GetConnectionHandle(address), 0x13);
 }
 
-IPCCommandResult BluetoothEmu::Close(u32 fd)
+IPCCommandResult BluetoothEmuDevice::Close(u32 fd)
 {
   // Clean up state
   m_scan_enable = 0;
@@ -141,7 +139,7 @@ IPCCommandResult BluetoothEmu::Close(u32 fd)
   return Device::Close(fd);
 }
 
-IPCCommandResult BluetoothEmu::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
 {
   bool send_reply = true;
   switch (request.request)
@@ -210,7 +208,7 @@ IPCCommandResult BluetoothEmu::IOCtlV(const IOCtlVRequest& request)
 }
 
 // Here we handle the USB::IOCTLV_USBV0_BLKMSG Ioctlv
-void BluetoothEmu::SendToDevice(u16 connection_handle, u8* data, u32 size)
+void BluetoothEmuDevice::SendToDevice(u16 connection_handle, u8* data, u32 size)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -221,14 +219,14 @@ void BluetoothEmu::SendToDevice(u16 connection_handle, u8* data, u32 size)
   wiimote->ExecuteL2capCmd(data, size);
 }
 
-void BluetoothEmu::IncDataPacket(u16 connection_handle)
+void BluetoothEmuDevice::IncDataPacket(u16 connection_handle)
 {
   m_packet_count[GetWiimoteNumberFromConnectionHandle(connection_handle)]++;
 }
 
 // Here we send ACL packets to CPU. They will consist of header + data.
 // The header is for example 07 00 41 00 which means size 0x0007 and channel 0x0041.
-void BluetoothEmu::SendACLPacket(const bdaddr_t& source, const u8* data, u32 size)
+void BluetoothEmuDevice::SendACLPacket(const bdaddr_t& source, const u8* data, u32 size)
 {
   const u16 connection_handle = GetConnectionHandle(source);
 
@@ -262,7 +260,7 @@ void BluetoothEmu::SendACLPacket(const bdaddr_t& source, const u8* data, u32 siz
 //
 // Our IOS is so efficient that we could fill the buffer immediately
 // rather than enqueue it to some other memory and this will do good for StateSave
-void BluetoothEmu::AddEventToQueue(const SQueuedEvent& event)
+void BluetoothEmuDevice::AddEventToQueue(const SQueuedEvent& event)
 {
   DEBUG_LOG_FMT(IOS_WIIMOTE, "HCI event {:x} completed...",
                 ((hci_event_hdr_t*)event.buffer)->event);
@@ -306,7 +304,7 @@ void BluetoothEmu::AddEventToQueue(const SQueuedEvent& event)
   }
 }
 
-void BluetoothEmu::Update()
+void BluetoothEmuDevice::Update()
 {
   // check HCI queue
   if (!m_event_queue.empty() && m_hci_endpoint)
@@ -348,7 +346,7 @@ void BluetoothEmu::Update()
   SendEventNumberOfCompletedPackets();
 }
 
-void BluetoothEmu::ACLPool::Store(const u8* data, const u16 size, const u16 conn_handle)
+void BluetoothEmuDevice::ACLPool::Store(const u8* data, const u16 size, const u16 conn_handle)
 {
   if (m_queue.size() >= 100)
   {
@@ -367,7 +365,7 @@ void BluetoothEmu::ACLPool::Store(const u8* data, const u16 size, const u16 conn
   packet.conn_handle = conn_handle;
 }
 
-void BluetoothEmu::ACLPool::WriteToEndpoint(const USB::V0BulkMessage& endpoint)
+void BluetoothEmuDevice::ACLPool::WriteToEndpoint(const USB::V0BulkMessage& endpoint)
 {
   auto& packet = m_queue.front();
 
@@ -390,7 +388,7 @@ void BluetoothEmu::ACLPool::WriteToEndpoint(const USB::V0BulkMessage& endpoint)
   m_ios.EnqueueIPCReply(endpoint.ios_request, sizeof(hci_acldata_hdr_t) + size);
 }
 
-bool BluetoothEmu::SendEventInquiryComplete(u8 num_responses)
+bool BluetoothEmuDevice::SendEventInquiryComplete(u8 num_responses)
 {
   SQueuedEvent event(sizeof(SHCIEventInquiryComplete), 0);
 
@@ -407,7 +405,7 @@ bool BluetoothEmu::SendEventInquiryComplete(u8 num_responses)
   return true;
 }
 
-bool BluetoothEmu::SendEventInquiryResponse()
+bool BluetoothEmuDevice::SendEventInquiryResponse()
 {
   // We only respond with the first discoverable remote.
   // The Wii instructs users to press 1+2 in the desired play order.
@@ -460,7 +458,7 @@ bool BluetoothEmu::SendEventInquiryResponse()
   return true;
 }
 
-bool BluetoothEmu::SendEventConnectionComplete(const bdaddr_t& bd, u8 status)
+bool BluetoothEmuDevice::SendEventConnectionComplete(const bdaddr_t& bd, u8 status)
 {
   SQueuedEvent event(sizeof(SHCIEventConnectionComplete), 0);
 
@@ -495,7 +493,7 @@ bool BluetoothEmu::SendEventConnectionComplete(const bdaddr_t& bd, u8 status)
   return true;
 }
 
-bool BluetoothEmu::SendEventRequestConnection(const WiimoteDevice& wiimote)
+bool BluetoothEmuDevice::SendEventRequestConnection(const WiimoteDevice& wiimote)
 {
   SQueuedEvent event(sizeof(SHCIEventRequestConnection), 0);
 
@@ -530,7 +528,7 @@ bool BluetoothEmu::SendEventRequestConnection(const WiimoteDevice& wiimote)
   return true;
 }
 
-bool BluetoothEmu::SendEventDisconnect(u16 connection_handle, u8 reason)
+bool BluetoothEmuDevice::SendEventDisconnect(u16 connection_handle, u8 reason)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -554,7 +552,7 @@ bool BluetoothEmu::SendEventDisconnect(u16 connection_handle, u8 reason)
   return true;
 }
 
-bool BluetoothEmu::SendEventAuthenticationCompleted(u16 connection_handle)
+bool BluetoothEmuDevice::SendEventAuthenticationCompleted(u16 connection_handle)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -578,7 +576,7 @@ bool BluetoothEmu::SendEventAuthenticationCompleted(u16 connection_handle)
   return true;
 }
 
-bool BluetoothEmu::SendEventRemoteNameReq(const bdaddr_t& bd)
+bool BluetoothEmuDevice::SendEventRemoteNameReq(const bdaddr_t& bd)
 {
   WiimoteDevice* wiimote = AccessWiimote(bd);
   if (wiimote == nullptr)
@@ -605,7 +603,7 @@ bool BluetoothEmu::SendEventRemoteNameReq(const bdaddr_t& bd)
   return true;
 }
 
-bool BluetoothEmu::SendEventReadRemoteFeatures(u16 connection_handle)
+bool BluetoothEmuDevice::SendEventReadRemoteFeatures(u16 connection_handle)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -635,7 +633,7 @@ bool BluetoothEmu::SendEventReadRemoteFeatures(u16 connection_handle)
   return true;
 }
 
-bool BluetoothEmu::SendEventReadRemoteVerInfo(u16 connection_handle)
+bool BluetoothEmuDevice::SendEventReadRemoteVerInfo(u16 connection_handle)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -664,7 +662,7 @@ bool BluetoothEmu::SendEventReadRemoteVerInfo(u16 connection_handle)
   return true;
 }
 
-void BluetoothEmu::SendEventCommandComplete(u16 opcode, const void* data, u32 data_size)
+void BluetoothEmuDevice::SendEventCommandComplete(u16 opcode, const void* data, u32 data_size)
 {
   DEBUG_ASSERT((sizeof(SHCIEventCommand) - 2 + data_size) < 256);
 
@@ -688,7 +686,7 @@ void BluetoothEmu::SendEventCommandComplete(u16 opcode, const void* data, u32 da
   AddEventToQueue(event);
 }
 
-bool BluetoothEmu::SendEventCommandStatus(u16 opcode)
+bool BluetoothEmuDevice::SendEventCommandStatus(u16 opcode)
 {
   SQueuedEvent event(sizeof(SHCIEventStatus), 0);
 
@@ -706,7 +704,7 @@ bool BluetoothEmu::SendEventCommandStatus(u16 opcode)
   return true;
 }
 
-bool BluetoothEmu::SendEventRoleChange(bdaddr_t bd, bool master)
+bool BluetoothEmuDevice::SendEventRoleChange(bdaddr_t bd, bool master)
 {
   WiimoteDevice* wiimote = AccessWiimote(bd);
   if (wiimote == nullptr)
@@ -733,7 +731,7 @@ bool BluetoothEmu::SendEventRoleChange(bdaddr_t bd, bool master)
   return true;
 }
 
-bool BluetoothEmu::SendEventNumberOfCompletedPackets()
+bool BluetoothEmuDevice::SendEventNumberOfCompletedPackets()
 {
   SQueuedEvent event((u32)(sizeof(hci_event_hdr_t) + sizeof(hci_num_compl_pkts_ep) +
                            (sizeof(hci_num_compl_pkts_info) * m_wiimotes.size())),
@@ -778,7 +776,7 @@ bool BluetoothEmu::SendEventNumberOfCompletedPackets()
   return true;
 }
 
-bool BluetoothEmu::SendEventModeChange(u16 connection_handle, u8 mode, u16 value)
+bool BluetoothEmuDevice::SendEventModeChange(u16 connection_handle, u8 mode, u16 value)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -803,7 +801,7 @@ bool BluetoothEmu::SendEventModeChange(u16 connection_handle, u8 mode, u16 value
   return true;
 }
 
-bool BluetoothEmu::SendEventLinkKeyNotification(const u8 num_to_send)
+bool BluetoothEmuDevice::SendEventLinkKeyNotification(const u8 num_to_send)
 {
   u8 payload_length = sizeof(hci_return_link_keys_ep) + sizeof(hci_link_key_rep_cp) * num_to_send;
   SQueuedEvent event(2 + payload_length, 0);
@@ -836,7 +834,7 @@ bool BluetoothEmu::SendEventLinkKeyNotification(const u8 num_to_send)
   return true;
 };
 
-bool BluetoothEmu::SendEventRequestLinkKey(const bdaddr_t& bd)
+bool BluetoothEmuDevice::SendEventRequestLinkKey(const bdaddr_t& bd)
 {
   SQueuedEvent event(sizeof(SHCIEventRequestLinkKey), 0);
 
@@ -857,7 +855,7 @@ bool BluetoothEmu::SendEventRequestLinkKey(const bdaddr_t& bd)
   return true;
 };
 
-bool BluetoothEmu::SendEventReadClockOffsetComplete(u16 connection_handle)
+bool BluetoothEmuDevice::SendEventReadClockOffsetComplete(u16 connection_handle)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -883,7 +881,7 @@ bool BluetoothEmu::SendEventReadClockOffsetComplete(u16 connection_handle)
   return true;
 }
 
-bool BluetoothEmu::SendEventConPacketTypeChange(u16 connection_handle, u16 packet_type)
+bool BluetoothEmuDevice::SendEventConPacketTypeChange(u16 connection_handle, u16 packet_type)
 {
   WiimoteDevice* wiimote = AccessWiimote(connection_handle);
   if (wiimote == nullptr)
@@ -911,7 +909,7 @@ bool BluetoothEmu::SendEventConPacketTypeChange(u16 connection_handle, u16 packe
 
 // Command dispatcher
 // This is called from the USB::IOCTLV_USBV0_CTRLMSG Ioctlv
-void BluetoothEmu::ExecuteHCICommandMessage(const USB::V0CtrlMessage& ctrl_message)
+void BluetoothEmuDevice::ExecuteHCICommandMessage(const USB::V0CtrlMessage& ctrl_message)
 {
   const u8* input = Memory::GetPointer(ctrl_message.data_address + 3);
 
@@ -1100,7 +1098,7 @@ void BluetoothEmu::ExecuteHCICommandMessage(const USB::V0CtrlMessage& ctrl_messa
 // --- command helper
 //
 //
-void BluetoothEmu::CommandInquiry(const u8* input)
+void BluetoothEmuDevice::CommandInquiry(const u8* input)
 {
   // Inquiry should not be called normally
   hci_inquiry_cp inquiry;
@@ -1118,7 +1116,7 @@ void BluetoothEmu::CommandInquiry(const u8* input)
   SendEventInquiryResponse();
 }
 
-void BluetoothEmu::CommandInquiryCancel(const u8* input)
+void BluetoothEmuDevice::CommandInquiryCancel(const u8* input)
 {
   hci_inquiry_cancel_rp reply;
   reply.status = 0x00;
@@ -1128,7 +1126,7 @@ void BluetoothEmu::CommandInquiryCancel(const u8* input)
   SendEventCommandComplete(HCI_CMD_INQUIRY_CANCEL, &reply, sizeof(hci_inquiry_cancel_rp));
 }
 
-void BluetoothEmu::CommandCreateCon(const u8* input)
+void BluetoothEmuDevice::CommandCreateCon(const u8* input)
 {
   hci_create_con_cp create_connection;
   std::memcpy(&create_connection, input, sizeof(create_connection));
@@ -1154,7 +1152,7 @@ void BluetoothEmu::CommandCreateCon(const u8* input)
   SendEventConnectionComplete(create_connection.bdaddr, successful ? 0x00 : 0x08);
 }
 
-void BluetoothEmu::CommandDisconnect(const u8* input)
+void BluetoothEmuDevice::CommandDisconnect(const u8* input)
 {
   hci_discon_cp disconnect;
   std::memcpy(&disconnect, input, sizeof(disconnect));
@@ -1171,7 +1169,7 @@ void BluetoothEmu::CommandDisconnect(const u8* input)
     wiimote->EventDisconnect(disconnect.reason);
 }
 
-void BluetoothEmu::CommandAcceptCon(const u8* input)
+void BluetoothEmuDevice::CommandAcceptCon(const u8* input)
 {
   hci_accept_con_cp accept_connection;
   std::memcpy(&accept_connection, input, sizeof(accept_connection));
@@ -1209,7 +1207,7 @@ void BluetoothEmu::CommandAcceptCon(const u8* input)
   }
 }
 
-void BluetoothEmu::CommandLinkKeyRep(const u8* input)
+void BluetoothEmuDevice::CommandLinkKeyRep(const u8* input)
 {
   hci_link_key_rep_cp key_rep;
   std::memcpy(&key_rep, input, sizeof(key_rep));
@@ -1226,7 +1224,7 @@ void BluetoothEmu::CommandLinkKeyRep(const u8* input)
   SendEventCommandComplete(HCI_CMD_LINK_KEY_REP, &reply, sizeof(hci_link_key_rep_rp));
 }
 
-void BluetoothEmu::CommandLinkKeyNegRep(const u8* input)
+void BluetoothEmuDevice::CommandLinkKeyNegRep(const u8* input)
 {
   hci_link_key_neg_rep_cp key_neg;
   std::memcpy(&key_neg, input, sizeof(key_neg));
@@ -1243,7 +1241,7 @@ void BluetoothEmu::CommandLinkKeyNegRep(const u8* input)
   SendEventCommandComplete(HCI_CMD_LINK_KEY_NEG_REP, &reply, sizeof(hci_link_key_neg_rep_rp));
 }
 
-void BluetoothEmu::CommandChangeConPacketType(const u8* input)
+void BluetoothEmuDevice::CommandChangeConPacketType(const u8* input)
 {
   hci_change_con_pkt_type_cp change_packet_type;
   std::memcpy(&change_packet_type, input, sizeof(change_packet_type));
@@ -1259,7 +1257,7 @@ void BluetoothEmu::CommandChangeConPacketType(const u8* input)
   SendEventConPacketTypeChange(change_packet_type.con_handle, change_packet_type.pkt_type);
 }
 
-void BluetoothEmu::CommandAuthenticationRequested(const u8* input)
+void BluetoothEmuDevice::CommandAuthenticationRequested(const u8* input)
 {
   hci_auth_req_cp auth_req;
   std::memcpy(&auth_req, input, sizeof(auth_req));
@@ -1271,7 +1269,7 @@ void BluetoothEmu::CommandAuthenticationRequested(const u8* input)
   SendEventAuthenticationCompleted(auth_req.con_handle);
 }
 
-void BluetoothEmu::CommandRemoteNameReq(const u8* input)
+void BluetoothEmuDevice::CommandRemoteNameReq(const u8* input)
 {
   hci_remote_name_req_cp remote_name_req;
   std::memcpy(&remote_name_req, input, sizeof(remote_name_req));
@@ -1288,7 +1286,7 @@ void BluetoothEmu::CommandRemoteNameReq(const u8* input)
   SendEventRemoteNameReq(remote_name_req.bdaddr);
 }
 
-void BluetoothEmu::CommandReadRemoteFeatures(const u8* input)
+void BluetoothEmuDevice::CommandReadRemoteFeatures(const u8* input)
 {
   hci_read_remote_features_cp read_remote_features;
   std::memcpy(&read_remote_features, input, sizeof(read_remote_features));
@@ -1300,7 +1298,7 @@ void BluetoothEmu::CommandReadRemoteFeatures(const u8* input)
   SendEventReadRemoteFeatures(read_remote_features.con_handle);
 }
 
-void BluetoothEmu::CommandReadRemoteVerInfo(const u8* input)
+void BluetoothEmuDevice::CommandReadRemoteVerInfo(const u8* input)
 {
   hci_read_remote_ver_info_cp read_remote_ver_info;
   std::memcpy(&read_remote_ver_info, input, sizeof(read_remote_ver_info));
@@ -1312,7 +1310,7 @@ void BluetoothEmu::CommandReadRemoteVerInfo(const u8* input)
   SendEventReadRemoteVerInfo(read_remote_ver_info.con_handle);
 }
 
-void BluetoothEmu::CommandReadClockOffset(const u8* input)
+void BluetoothEmuDevice::CommandReadClockOffset(const u8* input)
 {
   hci_read_clock_offset_cp read_clock_offset;
   std::memcpy(&read_clock_offset, input, sizeof(read_clock_offset));
@@ -1324,7 +1322,7 @@ void BluetoothEmu::CommandReadClockOffset(const u8* input)
   SendEventReadClockOffsetComplete(read_clock_offset.con_handle);
 }
 
-void BluetoothEmu::CommandSniffMode(const u8* input)
+void BluetoothEmuDevice::CommandSniffMode(const u8* input)
 {
   hci_sniff_mode_cp sniff_mode;
   std::memcpy(&sniff_mode, input, sizeof(sniff_mode));
@@ -1340,7 +1338,7 @@ void BluetoothEmu::CommandSniffMode(const u8* input)
   SendEventModeChange(sniff_mode.con_handle, 0x02, sniff_mode.max_interval);  // 0x02 - sniff mode
 }
 
-void BluetoothEmu::CommandWriteLinkPolicy(const u8* input)
+void BluetoothEmuDevice::CommandWriteLinkPolicy(const u8* input)
 {
   hci_write_link_policy_settings_cp link_policy;
   std::memcpy(&link_policy, input, sizeof(link_policy));
@@ -1352,7 +1350,7 @@ void BluetoothEmu::CommandWriteLinkPolicy(const u8* input)
   SendEventCommandStatus(HCI_CMD_WRITE_LINK_POLICY_SETTINGS);
 }
 
-void BluetoothEmu::CommandReset(const u8* input)
+void BluetoothEmuDevice::CommandReset(const u8* input)
 {
   hci_status_rp reply;
   reply.status = 0x00;
@@ -1363,7 +1361,7 @@ void BluetoothEmu::CommandReset(const u8* input)
   // TODO: We should actually reset connections and channels and everything here.
 }
 
-void BluetoothEmu::CommandSetEventFilter(const u8* input)
+void BluetoothEmuDevice::CommandSetEventFilter(const u8* input)
 {
   hci_set_event_filter_cp set_event_filter;
   std::memcpy(&set_event_filter, input, sizeof(set_event_filter));
@@ -1384,7 +1382,7 @@ void BluetoothEmu::CommandSetEventFilter(const u8* input)
   SendEventCommandComplete(HCI_CMD_SET_EVENT_FILTER, &reply, sizeof(hci_set_event_filter_rp));
 }
 
-void BluetoothEmu::CommandWritePinType(const u8* input)
+void BluetoothEmuDevice::CommandWritePinType(const u8* input)
 {
   hci_write_pin_type_cp write_pin_type;
   std::memcpy(&write_pin_type, input, sizeof(write_pin_type));
@@ -1398,7 +1396,7 @@ void BluetoothEmu::CommandWritePinType(const u8* input)
   SendEventCommandComplete(HCI_CMD_WRITE_PIN_TYPE, &reply, sizeof(hci_write_pin_type_rp));
 }
 
-void BluetoothEmu::CommandReadStoredLinkKey(const u8* input)
+void BluetoothEmuDevice::CommandReadStoredLinkKey(const u8* input)
 {
   hci_read_stored_link_key_cp read_stored_link_key;
   std::memcpy(&read_stored_link_key, input, sizeof(read_stored_link_key));
@@ -1429,7 +1427,7 @@ void BluetoothEmu::CommandReadStoredLinkKey(const u8* input)
                            sizeof(hci_read_stored_link_key_rp));
 }
 
-void BluetoothEmu::CommandDeleteStoredLinkKey(const u8* input)
+void BluetoothEmuDevice::CommandDeleteStoredLinkKey(const u8* input)
 {
   hci_delete_stored_link_key_cp delete_stored_link_key;
   std::memcpy(&delete_stored_link_key, input, sizeof(delete_stored_link_key));
@@ -1456,7 +1454,7 @@ void BluetoothEmu::CommandDeleteStoredLinkKey(const u8* input)
                              "has failed. Could be a problem with loading the SCONF");
 }
 
-void BluetoothEmu::CommandWriteLocalName(const u8* input)
+void BluetoothEmuDevice::CommandWriteLocalName(const u8* input)
 {
   hci_write_local_name_cp write_local_name;
   std::memcpy(&write_local_name, input, sizeof(write_local_name));
@@ -1470,7 +1468,7 @@ void BluetoothEmu::CommandWriteLocalName(const u8* input)
   SendEventCommandComplete(HCI_CMD_WRITE_LOCAL_NAME, &reply, sizeof(hci_write_local_name_rp));
 }
 
-void BluetoothEmu::CommandWritePageTimeOut(const u8* input)
+void BluetoothEmuDevice::CommandWritePageTimeOut(const u8* input)
 {
   hci_write_page_timeout_cp write_page_timeout;
   std::memcpy(&write_page_timeout, input, sizeof(write_page_timeout));
@@ -1484,7 +1482,7 @@ void BluetoothEmu::CommandWritePageTimeOut(const u8* input)
   SendEventCommandComplete(HCI_CMD_WRITE_PAGE_TIMEOUT, &reply, sizeof(hci_host_buffer_size_rp));
 }
 
-void BluetoothEmu::CommandWriteScanEnable(const u8* input)
+void BluetoothEmuDevice::CommandWriteScanEnable(const u8* input)
 {
   hci_write_scan_enable_cp write_scan_enable;
   std::memcpy(&write_scan_enable, input, sizeof(write_scan_enable));
@@ -1508,7 +1506,7 @@ void BluetoothEmu::CommandWriteScanEnable(const u8* input)
   SendEventCommandComplete(HCI_CMD_WRITE_SCAN_ENABLE, &reply, sizeof(hci_write_scan_enable_rp));
 }
 
-void BluetoothEmu::CommandWriteUnitClass(const u8* input)
+void BluetoothEmuDevice::CommandWriteUnitClass(const u8* input)
 {
   hci_write_unit_class_cp write_unit_class;
   std::memcpy(&write_unit_class, input, sizeof(write_unit_class));
@@ -1524,7 +1522,7 @@ void BluetoothEmu::CommandWriteUnitClass(const u8* input)
   SendEventCommandComplete(HCI_CMD_WRITE_UNIT_CLASS, &reply, sizeof(hci_write_unit_class_rp));
 }
 
-void BluetoothEmu::CommandHostBufferSize(const u8* input)
+void BluetoothEmuDevice::CommandHostBufferSize(const u8* input)
 {
   hci_host_buffer_size_cp host_buffer_size;
   std::memcpy(&host_buffer_size, input, sizeof(host_buffer_size));
@@ -1541,7 +1539,7 @@ void BluetoothEmu::CommandHostBufferSize(const u8* input)
   SendEventCommandComplete(HCI_CMD_HOST_BUFFER_SIZE, &reply, sizeof(hci_host_buffer_size_rp));
 }
 
-void BluetoothEmu::CommandWriteLinkSupervisionTimeout(const u8* input)
+void BluetoothEmuDevice::CommandWriteLinkSupervisionTimeout(const u8* input)
 {
   hci_write_link_supervision_timeout_cp supervision;
   std::memcpy(&supervision, input, sizeof(supervision));
@@ -1559,7 +1557,7 @@ void BluetoothEmu::CommandWriteLinkSupervisionTimeout(const u8* input)
                            sizeof(hci_write_link_supervision_timeout_rp));
 }
 
-void BluetoothEmu::CommandWriteInquiryScanType(const u8* input)
+void BluetoothEmuDevice::CommandWriteInquiryScanType(const u8* input)
 {
   hci_write_inquiry_scan_type_cp set_event_filter;
   std::memcpy(&set_event_filter, input, sizeof(set_event_filter));
@@ -1574,7 +1572,7 @@ void BluetoothEmu::CommandWriteInquiryScanType(const u8* input)
                            sizeof(hci_write_inquiry_scan_type_rp));
 }
 
-void BluetoothEmu::CommandWriteInquiryMode(const u8* input)
+void BluetoothEmuDevice::CommandWriteInquiryMode(const u8* input)
 {
   hci_write_inquiry_mode_cp inquiry_mode;
   std::memcpy(&inquiry_mode, input, sizeof(inquiry_mode));
@@ -1595,7 +1593,7 @@ void BluetoothEmu::CommandWriteInquiryMode(const u8* input)
   SendEventCommandComplete(HCI_CMD_WRITE_INQUIRY_MODE, &reply, sizeof(hci_write_inquiry_mode_rp));
 }
 
-void BluetoothEmu::CommandWritePageScanType(const u8* input)
+void BluetoothEmuDevice::CommandWritePageScanType(const u8* input)
 {
   hci_write_page_scan_type_cp write_page_scan_type;
   std::memcpy(&write_page_scan_type, input, sizeof(write_page_scan_type));
@@ -1615,7 +1613,7 @@ void BluetoothEmu::CommandWritePageScanType(const u8* input)
                            sizeof(hci_write_page_scan_type_rp));
 }
 
-void BluetoothEmu::CommandReadLocalVer(const u8* input)
+void BluetoothEmuDevice::CommandReadLocalVer(const u8* input)
 {
   hci_read_local_ver_rp reply;
   reply.status = 0x00;
@@ -1636,7 +1634,7 @@ void BluetoothEmu::CommandReadLocalVer(const u8* input)
   SendEventCommandComplete(HCI_CMD_READ_LOCAL_VER, &reply, sizeof(hci_read_local_ver_rp));
 }
 
-void BluetoothEmu::CommandReadLocalFeatures(const u8* input)
+void BluetoothEmuDevice::CommandReadLocalFeatures(const u8* input)
 {
   hci_read_local_features_rp reply;
   reply.status = 0x00;
@@ -1658,7 +1656,7 @@ void BluetoothEmu::CommandReadLocalFeatures(const u8* input)
   SendEventCommandComplete(HCI_CMD_READ_LOCAL_FEATURES, &reply, sizeof(hci_read_local_features_rp));
 }
 
-void BluetoothEmu::CommandReadBufferSize(const u8* input)
+void BluetoothEmuDevice::CommandReadBufferSize(const u8* input)
 {
   hci_read_buffer_size_rp reply;
   reply.status = 0x00;
@@ -1680,7 +1678,7 @@ void BluetoothEmu::CommandReadBufferSize(const u8* input)
   SendEventCommandComplete(HCI_CMD_READ_BUFFER_SIZE, &reply, sizeof(hci_read_buffer_size_rp));
 }
 
-void BluetoothEmu::CommandReadBDAdrr(const u8* input)
+void BluetoothEmuDevice::CommandReadBDAdrr(const u8* input)
 {
   hci_read_bdaddr_rp reply;
   reply.status = 0x00;
@@ -1695,7 +1693,7 @@ void BluetoothEmu::CommandReadBDAdrr(const u8* input)
   SendEventCommandComplete(HCI_CMD_READ_BDADDR, &reply, sizeof(hci_read_bdaddr_rp));
 }
 
-void BluetoothEmu::CommandVendorSpecific_FC4F(const u8* input, u32 size)
+void BluetoothEmuDevice::CommandVendorSpecific_FC4F(const u8* input, u32 size)
 {
   // callstack...
   // BTM_VendorSpecificCommad()
@@ -1715,7 +1713,7 @@ void BluetoothEmu::CommandVendorSpecific_FC4F(const u8* input, u32 size)
   SendEventCommandComplete(0xFC4F, &reply, sizeof(hci_status_rp));
 }
 
-void BluetoothEmu::CommandVendorSpecific_FC4C(const u8* input, u32 size)
+void BluetoothEmuDevice::CommandVendorSpecific_FC4C(const u8* input, u32 size)
 {
   hci_status_rp reply;
   reply.status = 0x00;
@@ -1727,7 +1725,7 @@ void BluetoothEmu::CommandVendorSpecific_FC4C(const u8* input, u32 size)
   SendEventCommandComplete(0xFC4C, &reply, sizeof(hci_status_rp));
 }
 
-WiimoteDevice* BluetoothEmu::AccessWiimoteByIndex(std::size_t index)
+WiimoteDevice* BluetoothEmuDevice::AccessWiimoteByIndex(std::size_t index)
 {
   if (index < MAX_BBMOTES)
     return m_wiimotes[index].get();
@@ -1735,19 +1733,19 @@ WiimoteDevice* BluetoothEmu::AccessWiimoteByIndex(std::size_t index)
   return nullptr;
 }
 
-u16 BluetoothEmu::GetConnectionHandle(const bdaddr_t& address)
+u16 BluetoothEmuDevice::GetConnectionHandle(const bdaddr_t& address)
 {
   // Handles are normally generated per connection but HLE allows fixed values for each remote.
   return 0x100 + address.back();
 }
 
-u32 BluetoothEmu::GetWiimoteNumberFromConnectionHandle(u16 connection_handle)
+u32 BluetoothEmuDevice::GetWiimoteNumberFromConnectionHandle(u16 connection_handle)
 {
   // Fixed handle values are generated in GetConnectionHandle.
   return connection_handle & 0xff;
 }
 
-WiimoteDevice* BluetoothEmu::AccessWiimote(const bdaddr_t& address)
+WiimoteDevice* BluetoothEmuDevice::AccessWiimote(const bdaddr_t& address)
 {
   // Fixed bluetooth addresses are generated in WiimoteDevice::WiimoteDevice.
   const auto wiimote = AccessWiimoteByIndex(address.back());
@@ -1758,7 +1756,7 @@ WiimoteDevice* BluetoothEmu::AccessWiimote(const bdaddr_t& address)
   return nullptr;
 }
 
-WiimoteDevice* BluetoothEmu::AccessWiimote(u16 connection_handle)
+WiimoteDevice* BluetoothEmuDevice::AccessWiimote(u16 connection_handle)
 {
   const auto wiimote =
       AccessWiimoteByIndex(GetWiimoteNumberFromConnectionHandle(connection_handle));
@@ -1772,5 +1770,4 @@ WiimoteDevice* BluetoothEmu::AccessWiimote(u16 connection_handle)
   return nullptr;
 }
 
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -33,18 +33,16 @@ struct SQueuedEvent
   SQueuedEvent() = default;
 };
 
-namespace Device
-{
 // Important to remember that this class is for /dev/usb/oh1/57e/305 ONLY
 // /dev/usb/oh1 -> internal usb bus
 // 57e/305 -> VendorID/ProductID of device on usb bus
 // This device is ONLY the internal Bluetooth module (based on BCM2045 chip)
-class BluetoothEmu final : public BluetoothBase
+class BluetoothEmuDevice final : public BluetoothBaseDevice
 {
 public:
-  BluetoothEmu(Kernel& ios, const std::string& device_name);
+  BluetoothEmuDevice(Kernel& ios, const std::string& device_name);
 
-  virtual ~BluetoothEmu();
+  virtual ~BluetoothEmuDevice();
 
   IPCCommandResult Close(u32 fd) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
@@ -199,5 +197,4 @@ private:
   };
 #pragma pack(pop)
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -31,7 +31,7 @@
 #include "Core/IOS/Device.h"
 #include "VideoCommon/OnScreenDisplay.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 constexpr u8 REQUEST_TYPE = static_cast<u8>(LIBUSB_ENDPOINT_OUT) |
                             static_cast<u8>(LIBUSB_REQUEST_TYPE_CLASS) |
@@ -58,13 +58,13 @@ static bool IsBluetoothDevice(const libusb_interface_descriptor& descriptor)
          descriptor.bInterfaceProtocol == PROTOCOL_BLUETOOTH;
 }
 
-BluetoothReal::BluetoothReal(Kernel& ios, const std::string& device_name)
-    : BluetoothBase(ios, device_name)
+BluetoothRealDevice::BluetoothRealDevice(Kernel& ios, const std::string& device_name)
+    : BluetoothBaseDevice(ios, device_name)
 {
   LoadLinkKeys();
 }
 
-BluetoothReal::~BluetoothReal()
+BluetoothRealDevice::~BluetoothRealDevice()
 {
   if (m_handle != nullptr)
   {
@@ -77,7 +77,7 @@ BluetoothReal::~BluetoothReal()
   SaveLinkKeys();
 }
 
-IPCCommandResult BluetoothReal::Open(const OpenRequest& request)
+IPCCommandResult BluetoothRealDevice::Open(const OpenRequest& request)
 {
   if (!m_context.IsValid())
     return GetDefaultReply(IPC_EACCES);
@@ -138,7 +138,7 @@ IPCCommandResult BluetoothReal::Open(const OpenRequest& request)
   return Device::Open(request);
 }
 
-IPCCommandResult BluetoothReal::Close(u32 fd)
+IPCCommandResult BluetoothRealDevice::Close(u32 fd)
 {
   if (m_handle)
   {
@@ -151,7 +151,7 @@ IPCCommandResult BluetoothReal::Close(u32 fd)
   return Device::Close(fd);
 }
 
-IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
+IPCCommandResult BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request)
 {
   if (!m_is_wii_bt_module && m_need_reset_keys.TestAndClear())
   {
@@ -199,7 +199,7 @@ IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
     transfer->flags |= LIBUSB_TRANSFER_FREE_TRANSFER;
     libusb_fill_control_transfer(transfer, m_handle, buffer.get(), nullptr, this, 0);
     transfer->callback = [](libusb_transfer* tr) {
-      static_cast<BluetoothReal*>(tr->user_data)->HandleCtrlTransfer(tr);
+      static_cast<BluetoothRealDevice*>(tr->user_data)->HandleCtrlTransfer(tr);
     };
     PendingTransfer pending_transfer{std::move(cmd), std::move(buffer)};
     m_current_transfers.emplace(transfer, std::move(pending_transfer));
@@ -241,7 +241,7 @@ IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
     libusb_transfer* transfer = libusb_alloc_transfer(0);
     transfer->buffer = buffer.get();
     transfer->callback = [](libusb_transfer* tr) {
-      static_cast<BluetoothReal*>(tr->user_data)->HandleBulkOrIntrTransfer(tr);
+      static_cast<BluetoothRealDevice*>(tr->user_data)->HandleBulkOrIntrTransfer(tr);
     };
     transfer->dev_handle = m_handle;
     transfer->endpoint = cmd->endpoint;
@@ -262,7 +262,7 @@ IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
 }
 
 static bool s_has_shown_savestate_warning = false;
-void BluetoothReal::DoState(PointerWrap& p)
+void BluetoothRealDevice::DoState(PointerWrap& p)
 {
   bool passthrough_bluetooth = true;
   p.Do(passthrough_bluetooth);
@@ -317,7 +317,7 @@ void BluetoothReal::DoState(PointerWrap& p)
     m_transfers_mutex.unlock();
 }
 
-void BluetoothReal::UpdateSyncButtonState(const bool is_held)
+void BluetoothRealDevice::UpdateSyncButtonState(const bool is_held)
 {
   if (m_sync_button_state == SyncButtonState::Unpressed && is_held)
   {
@@ -335,17 +335,17 @@ void BluetoothReal::UpdateSyncButtonState(const bool is_held)
     m_sync_button_state = SyncButtonState::Unpressed;
 }
 
-void BluetoothReal::TriggerSyncButtonPressedEvent()
+void BluetoothRealDevice::TriggerSyncButtonPressedEvent()
 {
   m_sync_button_state = SyncButtonState::Pressed;
 }
 
-void BluetoothReal::TriggerSyncButtonHeldEvent()
+void BluetoothRealDevice::TriggerSyncButtonHeldEvent()
 {
   m_sync_button_state = SyncButtonState::LongPressed;
 }
 
-void BluetoothReal::WaitForHCICommandComplete(const u16 opcode)
+void BluetoothRealDevice::WaitForHCICommandComplete(const u16 opcode)
 {
   int actual_length;
   SHCIEventCommand packet;
@@ -363,7 +363,7 @@ void BluetoothReal::WaitForHCICommandComplete(const u16 opcode)
   }
 }
 
-void BluetoothReal::SendHCIResetCommand()
+void BluetoothRealDevice::SendHCIResetCommand()
 {
   u8 packet[3] = {};
   const u16 payload[] = {HCI_CMD_RESET};
@@ -372,7 +372,7 @@ void BluetoothReal::SendHCIResetCommand()
   INFO_LOG_FMT(IOS_WIIMOTE, "Sent a reset command to adapter");
 }
 
-void BluetoothReal::SendHCIDeleteLinkKeyCommand()
+void BluetoothRealDevice::SendHCIDeleteLinkKeyCommand()
 {
   struct Payload
   {
@@ -389,7 +389,7 @@ void BluetoothReal::SendHCIDeleteLinkKeyCommand()
                           static_cast<u16>(sizeof(payload)), TIMEOUT);
 }
 
-bool BluetoothReal::SendHCIStoreLinkKeyCommand()
+bool BluetoothRealDevice::SendHCIStoreLinkKeyCommand()
 {
   if (m_link_keys.empty())
     return false;
@@ -428,7 +428,7 @@ bool BluetoothReal::SendHCIStoreLinkKeyCommand()
   return true;
 }
 
-void BluetoothReal::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
+void BluetoothRealDevice::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
 {
   SHCIEventCommand hci_event;
   Memory::CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
@@ -445,7 +445,7 @@ void BluetoothReal::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
 // - it will cause a u8 underflow and royally screw things up.
 // Therefore, the reply to this command has to be faked to avoid random, weird issues
 // (including Wiimote disconnects and "event mismatch" warning messages).
-void BluetoothReal::FakeReadBufferSizeReply(USB::V0IntrMessage& ctrl)
+void BluetoothRealDevice::FakeReadBufferSizeReply(USB::V0IntrMessage& ctrl)
 {
   SHCIEventCommand hci_event;
   Memory::CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
@@ -465,7 +465,8 @@ void BluetoothReal::FakeReadBufferSizeReply(USB::V0IntrMessage& ctrl)
   m_ios.EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event) + sizeof(reply)));
 }
 
-void BluetoothReal::FakeSyncButtonEvent(USB::V0IntrMessage& ctrl, const u8* payload, const u8 size)
+void BluetoothRealDevice::FakeSyncButtonEvent(USB::V0IntrMessage& ctrl, const u8* payload,
+                                              const u8 size)
 {
   hci_event_hdr_t hci_event;
   Memory::CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
@@ -480,7 +481,7 @@ void BluetoothReal::FakeSyncButtonEvent(USB::V0IntrMessage& ctrl, const u8* payl
 //   > HCI Event: Vendor (0xff) plen 1
 //   08
 // This causes the emulated software to perform a BT inquiry and connect to found Wiimotes.
-void BluetoothReal::FakeSyncButtonPressedEvent(USB::V0IntrMessage& ctrl)
+void BluetoothRealDevice::FakeSyncButtonPressedEvent(USB::V0IntrMessage& ctrl)
 {
   NOTICE_LOG_FMT(IOS_WIIMOTE, "Faking 'sync button pressed' (0x08) event packet");
   constexpr u8 payload[1] = {0x08};
@@ -489,7 +490,7 @@ void BluetoothReal::FakeSyncButtonPressedEvent(USB::V0IntrMessage& ctrl)
 }
 
 // When the red sync button is held for 10 seconds, a HCI event with payload 09 is sent.
-void BluetoothReal::FakeSyncButtonHeldEvent(USB::V0IntrMessage& ctrl)
+void BluetoothRealDevice::FakeSyncButtonHeldEvent(USB::V0IntrMessage& ctrl)
 {
   NOTICE_LOG_FMT(IOS_WIIMOTE, "Faking 'sync button held' (0x09) event packet");
   constexpr u8 payload[1] = {0x09};
@@ -497,7 +498,7 @@ void BluetoothReal::FakeSyncButtonHeldEvent(USB::V0IntrMessage& ctrl)
   m_sync_button_state = SyncButtonState::Ignored;
 }
 
-void BluetoothReal::LoadLinkKeys()
+void BluetoothRealDevice::LoadLinkKeys()
 {
   const std::string& entries = SConfig::GetInstance().m_bt_passthrough_link_keys;
   if (entries.empty())
@@ -535,7 +536,7 @@ void BluetoothReal::LoadLinkKeys()
   }
 }
 
-void BluetoothReal::SaveLinkKeys()
+void BluetoothRealDevice::SaveLinkKeys()
 {
   std::ostringstream oss;
   for (const auto& entry : m_link_keys)
@@ -556,7 +557,7 @@ void BluetoothReal::SaveLinkKeys()
   SConfig::GetInstance().m_bt_passthrough_link_keys = config_string;
 }
 
-bool BluetoothReal::OpenDevice(libusb_device* device)
+bool BluetoothRealDevice::OpenDevice(libusb_device* device)
 {
   m_device = libusb_ref_device(device);
   const int ret = libusb_open(m_device, &m_handle);
@@ -592,7 +593,7 @@ bool BluetoothReal::OpenDevice(libusb_device* device)
 }
 
 // The callbacks are called from libusb code on a separate thread.
-void BluetoothReal::HandleCtrlTransfer(libusb_transfer* tr)
+void BluetoothRealDevice::HandleCtrlTransfer(libusb_transfer* tr)
 {
   std::lock_guard lk(m_transfers_mutex);
   if (!m_current_transfers.count(tr))
@@ -618,7 +619,7 @@ void BluetoothReal::HandleCtrlTransfer(libusb_transfer* tr)
   m_current_transfers.erase(tr);
 }
 
-void BluetoothReal::HandleBulkOrIntrTransfer(libusb_transfer* tr)
+void BluetoothRealDevice::HandleBulkOrIntrTransfer(libusb_transfer* tr)
 {
   std::lock_guard lk(m_transfers_mutex);
   if (!m_current_transfers.count(tr))
@@ -665,4 +666,4 @@ void BluetoothReal::HandleBulkOrIntrTransfer(libusb_transfer* tr)
   m_ios.EnqueueIPCReply(command->ios_request, tr->actual_length, 0, CoreTiming::FromThread::ANY);
   m_current_transfers.erase(tr);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -40,13 +40,11 @@ enum class SyncButtonState
 
 using linkkey_t = std::array<u8, 16>;
 
-namespace Device
-{
-class BluetoothReal final : public BluetoothBase
+class BluetoothRealDevice final : public BluetoothBaseDevice
 {
 public:
-  BluetoothReal(Kernel& ios, const std::string& device_name);
-  ~BluetoothReal() override;
+  BluetoothRealDevice(Kernel& ios, const std::string& device_name);
+  ~BluetoothRealDevice() override;
 
   IPCCommandResult Open(const OpenRequest& request) override;
   IPCCommandResult Close(u32 fd) override;
@@ -121,14 +119,13 @@ private:
 
   bool OpenDevice(libusb_device* device);
 };
-}  // namespace Device
 }  // namespace IOS::HLE
 
 #else
 #include "Core/IOS/USB/Bluetooth/BTStub.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-using BluetoothReal = BluetoothStub;
-}  // namespace IOS::HLE::Device
+using BluetoothRealDevice = BluetoothStubDevice;
+}  // namespace IOS::HLE
 #endif

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
@@ -8,18 +8,18 @@
 #include "Common/MsgHandler.h"
 #include "Core/Core.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-IPCCommandResult BluetoothStub::Open(const OpenRequest& request)
+IPCCommandResult BluetoothStubDevice::Open(const OpenRequest& request)
 {
   PanicAlertFmtT("Bluetooth passthrough mode is enabled, but Dolphin was built without libusb."
                  " Passthrough mode cannot be used.");
   return GetDefaultReply(IPC_ENOENT);
 }
 
-void BluetoothStub::DoState(PointerWrap& p)
+void BluetoothStubDevice::DoState(PointerWrap& p)
 {
   Core::DisplayMessage("The current IPC_HLE_Device_usb is a stub. Aborting load.", 4000);
   p.SetMode(PointerWrap::MODE_VERIFY);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
@@ -12,13 +12,13 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
-class BluetoothStub final : public BluetoothBase
+class BluetoothStubDevice final : public BluetoothBaseDevice
 {
 public:
-  using BluetoothBase::BluetoothBase;
+  using BluetoothBaseDevice::BluetoothBaseDevice;
   IPCCommandResult Open(const OpenRequest& request) override;
   void DoState(PointerWrap& p) override;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.cpp
@@ -55,7 +55,7 @@ private:
 
 constexpr int CONNECTION_MESSAGE_TIME = 3000;
 
-WiimoteDevice::WiimoteDevice(Device::BluetoothEmu* host, int number, bdaddr_t bd)
+WiimoteDevice::WiimoteDevice(BluetoothEmuDevice* host, int number, bdaddr_t bd)
     : m_host(host), m_bd(bd),
       m_name(number == WIIMOTE_BALANCE_BOARD ? "Nintendo RVL-WBC-01" : "Nintendo RVL-CNT-01")
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/WiimoteDevice.h
@@ -16,10 +16,7 @@ class PointerWrap;
 
 namespace IOS::HLE
 {
-namespace Device
-{
-class BluetoothEmu;
-}
+class BluetoothEmuDevice;
 
 class WiimoteDevice
 {
@@ -28,7 +25,7 @@ public:
   using FeaturesType = std::array<u8, HCI_FEATURES_SIZE>;
   using LinkKeyType = std::array<u8, HCI_KEY_SIZE>;
 
-  WiimoteDevice(Device::BluetoothEmu* host, int number, bdaddr_t bd);
+  WiimoteDevice(BluetoothEmuDevice* host, int number, bdaddr_t bd);
   ~WiimoteDevice();
 
   WiimoteDevice(const WiimoteDevice&) = delete;
@@ -116,7 +113,7 @@ private:
 
   using ChannelMap = std::map<u16, SChannel>;
 
-  Device::BluetoothEmu* m_host;
+  BluetoothEmuDevice* m_host;
   WiimoteCommon::HIDWiimote* m_hid_source = nullptr;
 
   // State to save:

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -25,7 +25,7 @@
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/LibusbDevice.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 USBHost::USBHost(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
@@ -227,4 +227,4 @@ IPCCommandResult USBHost::HandleTransfer(std::shared_ptr<USB::Device> device, u3
                 device->GetVid(), device->GetPid(), request, device->GetErrorName(ret));
   return GetDefaultReply(ret <= 0 ? ret : IPC_EINVAL);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -24,7 +24,7 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 // Common base class for USB host devices (such as /dev/usb/oh0 and /dev/usb/ven).
 class USBHost : public Device
@@ -85,4 +85,4 @@ private:
   bool m_has_initialised = false;
   LibusbUtils::Context m_context;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -20,7 +20,7 @@
 #include "Core/IOS/USB/USBV0.h"
 #include "Core/IOS/VersionInfo.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 OH0::OH0(Kernel& ios, const std::string& device_name) : USBHost(ios, device_name)
 {
@@ -348,4 +348,4 @@ s32 OH0::SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv)
     return IPC_EINVAL;
   }
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/OH0/OH0.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.h
@@ -30,8 +30,6 @@ struct DeviceInfo
 };
 }  // namespace USB
 
-namespace Device
-{
 // /dev/usb/oh0
 class OH0 final : public USBHost
 {
@@ -85,5 +83,4 @@ private:
 
   ScanThread m_scan_thread{this};
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -14,7 +14,7 @@
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/USB/OH0/OH0.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 static void GetVidPidFromDevicePath(const std::string& device_path, u16& vid, u16& pid)
 {
@@ -78,4 +78,4 @@ IPCCommandResult OH0Device::IOCtlV(const IOCtlVRequest& request)
 {
   return m_oh0->DeviceIOCtlV(m_device_id, request);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.h
@@ -12,7 +12,7 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 class OH0;
 class OH0Device final : public Device
@@ -32,4 +32,4 @@ private:
   u16 m_pid = 0;
   u64 m_device_id = 0;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -62,8 +62,6 @@ V5IsoMessage::V5IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
 }
 }  // namespace USB
 
-namespace Device
-{
 namespace
 {
 #pragma pack(push, 1)
@@ -274,5 +272,4 @@ void USBV5ResourceManager::TriggerDeviceChangeReply()
   m_devicechange_hook_request.reset();
   INFO_LOG_FMT(IOS_USB, "{} USBv5 device(s), including interfaces", num_devices);
 }
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USBV5.h
+++ b/Source/Core/Core/IOS/USB/USBV5.h
@@ -63,8 +63,6 @@ struct V5IsoMessage final : IsoMessage
 };
 }  // namespace USB
 
-namespace Device
-{
 class USBV5ResourceManager : public USBHost
 {
 public:
@@ -109,5 +107,4 @@ protected:
   mutable std::mutex m_usbv5_devices_mutex;
   u16 m_current_device_number = 0x21;
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -20,7 +20,7 @@
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/USBV4.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 USB_HIDv4::USB_HIDv4(Kernel& ios, const std::string& device_name) : USBHost(ios, device_name)
 {
@@ -258,4 +258,4 @@ std::vector<u8> USB_HIDv4::GetDeviceEntry(const USB::Device& device) const
 
   return entry;
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -16,7 +16,7 @@
 
 class PointerWrap;
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 class USB_HIDv4 final : public USBHost
 {
@@ -56,4 +56,4 @@ private:
 
   ScanThread m_scan_thread{this};
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.cpp
@@ -14,7 +14,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/USB/Common.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
@@ -196,4 +196,4 @@ bool USB_HIDv5::ShouldAddDevice(const USB::Device& device) const
   constexpr u8 HID_CLASS = 0x03;
   return device.HasClass(HID_CLASS);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv5.h
@@ -9,7 +9,7 @@
 #include "Core/IOS/USB/Host.h"
 #include "Core/IOS/USB/USBV5.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 class USB_HIDv5 final : public USBV5ResourceManager
 {
@@ -39,4 +39,4 @@ private:
 
   ScanThread m_scan_thread{this};
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -20,7 +20,7 @@
 #include <windows.h>
 #endif
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 namespace
 {
@@ -307,4 +307,4 @@ void USB_KBD::Update()
   if (got_event)
     m_message_queue.emplace(MessageType::Event, modifiers, pressed_keys);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_KBD.h
+++ b/Source/Core/Core/IOS/USB/USB_KBD.h
@@ -13,7 +13,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 class USB_KBD : public Device
 {
@@ -64,4 +64,4 @@ private:
   };
   int m_keyboard_layout = KBD_LAYOUT_QWERTY;
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -14,7 +14,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/USB/Common.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 constexpr u32 USBV5_VERSION = 0x50001;
 
@@ -159,4 +159,4 @@ IPCCommandResult USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest&
 
   return GetDefaultReply(IPC_SUCCESS);
 }
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
@@ -9,7 +9,7 @@
 #include "Core/IOS/USB/Host.h"
 #include "Core/IOS/USB/USBV5.h"
 
-namespace IOS::HLE::Device
+namespace IOS::HLE
 {
 class USB_VEN final : public USBV5ResourceManager
 {
@@ -31,4 +31,4 @@ private:
 
   ScanThread m_scan_thread{this};
 };
-}  // namespace IOS::HLE::Device
+}  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -94,13 +94,11 @@ void ARCUnpacker::Extract(const WriteCallback& callback)
   }
 }
 
-namespace Device
-{
-WFSI::WFSI(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+WFSIDevice::WFSIDevice(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
 }
 
-void WFSI::SetCurrentTitleIdAndGroupId(u64 tid, u16 gid)
+void WFSIDevice::SetCurrentTitleIdAndGroupId(u64 tid, u16 gid)
 {
   m_current_title_id = tid;
   m_current_group_id = gid;
@@ -109,7 +107,7 @@ void WFSI::SetCurrentTitleIdAndGroupId(u64 tid, u16 gid)
   m_current_group_id_str = GroupIdStr(gid);
 }
 
-void WFSI::SetImportTitleIdAndGroupId(u64 tid, u16 gid)
+void WFSIDevice::SetImportTitleIdAndGroupId(u64 tid, u16 gid)
 {
   m_import_title_id = tid;
   m_import_group_id = gid;
@@ -118,7 +116,7 @@ void WFSI::SetImportTitleIdAndGroupId(u64 tid, u16 gid)
   m_import_group_id_str = GroupIdStr(gid);
 }
 
-void WFSI::FinalizePatchInstall()
+void WFSIDevice::FinalizePatchInstall()
 {
   const std::string current_title_dir = fmt::format("/vol/{}/title/{}/{}", m_device_name,
                                                     m_current_group_id_str, m_current_title_id_str);
@@ -126,7 +124,7 @@ void WFSI::FinalizePatchInstall()
   File::CopyDir(WFS::NativePath(patch_dir), WFS::NativePath(current_title_dir), true);
 }
 
-IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
+IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
 {
   s32 return_error_code = IPC_SUCCESS;
 
@@ -354,7 +352,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
     auto device = IOS::HLE::GetIOS()->GetDeviceByName("/dev/usb/wfssrv");
     if (!device)
       break;
-    std::static_pointer_cast<IOS::HLE::Device::WFSSRV>(device)->SetHomeDir(homedir_path);
+    std::static_pointer_cast<IOS::HLE::WFSSRVDevice>(device)->SetHomeDir(homedir_path);
     return_error_code = IPC_SUCCESS;
     break;
   }
@@ -551,7 +549,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(return_error_code);
 }
 
-u32 WFSI::GetTmd(u16 group_id, u32 title_id, u64 subtitle_id, u32 address, u32* size) const
+u32 WFSIDevice::GetTmd(u16 group_id, u32 title_id, u64 subtitle_id, u32 address, u32* size) const
 {
   const std::string path = fmt::format("/vol/{}/title/{}/{}/meta/{:016x}.tmd", m_device_name,
                                        GroupIdStr(group_id), TitleIdStr(title_id), subtitle_id);
@@ -576,7 +574,7 @@ static s32 DeleteTemporaryFiles(const std::string& device_name, u64 title_id)
   return IPC_SUCCESS;
 }
 
-s32 WFSI::CancelTitleImport(bool continue_install)
+s32 WFSIDevice::CancelTitleImport(bool continue_install)
 {
   m_arc_unpacker.Reset();
 
@@ -590,7 +588,7 @@ s32 WFSI::CancelTitleImport(bool continue_install)
   return IPC_SUCCESS;
 }
 
-s32 WFSI::CancelPatchImport(bool continue_install)
+s32 WFSIDevice::CancelPatchImport(bool continue_install)
 {
   m_arc_unpacker.Reset();
 
@@ -614,5 +612,4 @@ s32 WFSI::CancelPatchImport(bool continue_install)
 
   return IPC_SUCCESS;
 }
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -32,12 +32,10 @@ private:
   std::vector<u8> m_whole_file;
 };
 
-namespace Device
-{
-class WFSI : public Device
+class WFSIDevice : public Device
 {
 public:
-  WFSI(Kernel& ios, const std::string& device_name);
+  WFSIDevice(Kernel& ios, const std::string& device_name);
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
@@ -125,5 +123,4 @@ private:
     IOCTL_WFSI_CHECK_HAS_SPACE = 0x95,
   };
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -26,14 +26,12 @@ std::string NativePath(const std::string& wfs_path)
 }
 }  // namespace WFS
 
-namespace Device
-{
-WFSSRV::WFSSRV(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+WFSSRVDevice::WFSSRVDevice(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
 {
   m_device_name = "msc01";
 }
 
-IPCCommandResult WFSSRV::IOCtl(const IOCtlRequest& request)
+IPCCommandResult WFSSRVDevice::IOCtl(const IOCtlRequest& request)
 {
   int return_error_code = IPC_SUCCESS;
 
@@ -364,7 +362,7 @@ IPCCommandResult WFSSRV::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(return_error_code);
 }
 
-s32 WFSSRV::Rename(std::string source, std::string dest) const
+s32 WFSSRVDevice::Rename(std::string source, std::string dest) const
 {
   source = NormalizePath(source);
   dest = NormalizePath(dest);
@@ -384,12 +382,12 @@ s32 WFSSRV::Rename(std::string source, std::string dest) const
   return IPC_SUCCESS;
 }
 
-void WFSSRV::SetHomeDir(const std::string& home_directory)
+void WFSSRVDevice::SetHomeDir(const std::string& home_directory)
 {
   m_home_directory = home_directory;
 }
 
-std::string WFSSRV::NormalizePath(const std::string& path) const
+std::string WFSSRVDevice::NormalizePath(const std::string& path) const
 {
   std::string expanded;
   if (!path.empty() && path[0] == '~')
@@ -425,7 +423,7 @@ std::string WFSSRV::NormalizePath(const std::string& path) const
   return "/" + JoinStrings(normalized_components, "/");
 }
 
-WFSSRV::FileDescriptor* WFSSRV::FindFileDescriptor(u16 fd)
+WFSSRVDevice::FileDescriptor* WFSSRVDevice::FindFileDescriptor(u16 fd)
 {
   if (fd >= m_fds.size() || !m_fds[fd].in_use)
   {
@@ -434,7 +432,7 @@ WFSSRV::FileDescriptor* WFSSRV::FindFileDescriptor(u16 fd)
   return &m_fds[fd];
 }
 
-u16 WFSSRV::GetNewFileDescriptor()
+u16 WFSSRVDevice::GetNewFileDescriptor()
 {
   for (u32 i = 0; i < m_fds.size(); ++i)
   {
@@ -447,7 +445,7 @@ u16 WFSSRV::GetNewFileDescriptor()
   return static_cast<u16>(m_fds.size() - 1);
 }
 
-void WFSSRV::ReleaseFileDescriptor(u16 fd)
+void WFSSRVDevice::ReleaseFileDescriptor(u16 fd)
 {
   FileDescriptor* fd_obj = FindFileDescriptor(fd);
   if (!fd_obj)
@@ -463,7 +461,7 @@ void WFSSRV::ReleaseFileDescriptor(u16 fd)
   }
 }
 
-bool WFSSRV::FileDescriptor::Open()
+bool WFSSRVDevice::FileDescriptor::Open()
 {
   const char* mode_string;
 
@@ -487,5 +485,4 @@ bool WFSSRV::FileDescriptor::Open()
 
   return file.Open(WFS::NativePath(path), mode_string);
 }
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/WFS/WFSSRV.h
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.h
@@ -29,12 +29,10 @@ enum
   WFS_FILE_IS_OPENED = -10032,  // Cannot perform operation on an opened file.
 };
 
-namespace Device
-{
-class WFSSRV : public Device
+class WFSSRVDevice : public Device
 {
 public:
-  WFSSRV(Kernel& ios, const std::string& device_name);
+  WFSSRVDevice(Kernel& ios, const std::string& device_name);
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
@@ -105,5 +103,4 @@ private:
   // shutdown time.
   std::vector<u32> m_hanging;
 };
-}  // namespace Device
 }  // namespace IOS::HLE

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -470,7 +470,7 @@ void ChangeWiiPads(bool instantly)
     return;
 
   const auto ios = IOS::HLE::GetIOS();
-  const auto bt = ios ? std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
+  const auto bt = ios ? std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
                             ios->GetDeviceByName("/dev/usb/oh1/57e/305")) :
                         nullptr;
   for (int i = 0; i < MAX_WIIMOTES; ++i)

--- a/Source/Core/Core/WiiUtils.h
+++ b/Source/Core/Core/WiiUtils.h
@@ -22,17 +22,13 @@ class VolumeWAD;
 
 namespace IOS::HLE
 {
+class ESDevice;
 class Kernel;
-}
+}  // namespace IOS::HLE
 
 namespace IOS::HLE::FS
 {
 class FileSystem;
-}
-
-namespace IOS::HLE::Device
-{
-class ES;
 }
 
 namespace WiiUtils
@@ -62,7 +58,7 @@ IOS::ES::TMDReader FindBackupTMD(IOS::HLE::FS::FileSystem& fs, u64 title_id);
 // Checks if there's a title.tmd imported for the given title ID. If there is not, we attempt to
 // re-import it from the TMDs stored in /title/00000001/00000002/data/tmds.sys.
 // Returns true if, after this function call, we have an imported title.tmd, or false if not.
-bool EnsureTMDIsImported(IOS::HLE::FS::FileSystem& fs, IOS::HLE::Device::ES& es, u64 title_id);
+bool EnsureTMDIsImported(IOS::HLE::FS::FileSystem& fs, IOS::HLE::ESDevice& es, u64 title_id);
 
 enum class UpdateResult
 {

--- a/Source/Core/DiscIO/VolumeVerifier.cpp
+++ b/Source/Core/DiscIO/VolumeVerifier.cpp
@@ -568,12 +568,12 @@ bool VolumeVerifier::CheckPartition(const Partition& partition)
     const std::vector<u8>& cert_chain = m_volume.GetCertificateChain(partition);
 
     if (IOS::HLE::IPC_SUCCESS !=
-            es->VerifyContainer(IOS::HLE::Device::ES::VerifyContainerType::Ticket,
-                                IOS::HLE::Device::ES::VerifyMode::DoNotUpdateCertStore,
+            es->VerifyContainer(IOS::HLE::ESDevice::VerifyContainerType::Ticket,
+                                IOS::HLE::ESDevice::VerifyMode::DoNotUpdateCertStore,
                                 m_volume.GetTicket(partition), cert_chain) ||
         IOS::HLE::IPC_SUCCESS !=
-            es->VerifyContainer(IOS::HLE::Device::ES::VerifyContainerType::TMD,
-                                IOS::HLE::Device::ES::VerifyMode::DoNotUpdateCertStore,
+            es->VerifyContainer(IOS::HLE::ESDevice::VerifyContainerType::TMD,
+                                IOS::HLE::ESDevice::VerifyMode::DoNotUpdateCertStore,
                                 m_volume.GetTMD(partition), cert_chain))
     {
       AddProblem(Severity::Low,
@@ -1010,8 +1010,8 @@ void VolumeVerifier::CheckMisc()
     const std::vector<u8>& cert_chain = m_volume.GetCertificateChain(PARTITION_NONE);
 
     if (IOS::HLE::IPC_SUCCESS !=
-        es->VerifyContainer(IOS::HLE::Device::ES::VerifyContainerType::Ticket,
-                            IOS::HLE::Device::ES::VerifyMode::DoNotUpdateCertStore, m_ticket,
+        es->VerifyContainer(IOS::HLE::ESDevice::VerifyContainerType::Ticket,
+                            IOS::HLE::ESDevice::VerifyMode::DoNotUpdateCertStore, m_ticket,
                             cert_chain))
     {
       // i18n: "Ticket" here is a kind of digital authorization to use a certain title (e.g. a game)
@@ -1019,9 +1019,8 @@ void VolumeVerifier::CheckMisc()
     }
 
     if (IOS::HLE::IPC_SUCCESS !=
-        es->VerifyContainer(IOS::HLE::Device::ES::VerifyContainerType::TMD,
-                            IOS::HLE::Device::ES::VerifyMode::DoNotUpdateCertStore, tmd,
-                            cert_chain))
+        es->VerifyContainer(IOS::HLE::ESDevice::VerifyContainerType::TMD,
+                            IOS::HLE::ESDevice::VerifyMode::DoNotUpdateCertStore, tmd, cert_chain))
     {
       AddProblem(Severity::Low, Common::GetStringT("The TMD is not correctly signed."));
     }

--- a/Source/Core/DolphinNoGUI/Platform.cpp
+++ b/Source/Core/DolphinNoGUI/Platform.cpp
@@ -30,7 +30,7 @@ void Platform::UpdateRunningFlag()
     const auto ios = IOS::HLE::GetIOS();
     const auto stm = ios ? ios->GetDeviceByName("/dev/stm/eventhook") : nullptr;
     if (!m_tried_graceful_shutdown.IsSet() && stm &&
-        std::static_pointer_cast<IOS::HLE::Device::STMEventHook>(stm)->HasHookInstalled())
+        std::static_pointer_cast<IOS::HLE::STMEventHookDevice>(stm)->HasHookInstalled())
     {
       ProcessorInterface::PowerButton_Tap();
       m_tried_graceful_shutdown.Set();

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -245,7 +245,7 @@ void WiimoteControllersWidget::OnBluetoothPassthroughResetPressed()
   auto device = ios->GetDeviceByName("/dev/usb/oh1/57e/305");
   if (device != nullptr)
   {
-    std::static_pointer_cast<IOS::HLE::Device::BluetoothBase>(device)->TriggerSyncButtonHeldEvent();
+    std::static_pointer_cast<IOS::HLE::BluetoothBaseDevice>(device)->TriggerSyncButtonHeldEvent();
   }
 }
 
@@ -264,7 +264,7 @@ void WiimoteControllersWidget::OnBluetoothPassthroughSyncPressed()
 
   if (device != nullptr)
   {
-    std::static_pointer_cast<IOS::HLE::Device::BluetoothBase>(device)
+    std::static_pointer_cast<IOS::HLE::BluetoothBaseDevice>(device)
         ->TriggerSyncButtonPressedEvent();
   }
 }

--- a/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/NetworkWidget.cpp
@@ -241,9 +241,9 @@ void NetworkWidget::Update()
   {
     m_ssl_table->insertRow(ssl_id);
     s32 host_fd = -1;
-    if (IOS::HLE::Device::IsSSLIDValid(ssl_id))
+    if (IOS::HLE::IsSSLIDValid(ssl_id))
     {
-      host_fd = IOS::HLE::Device::NetSSL::_SSL[ssl_id].hostfd;
+      host_fd = IOS::HLE::NetSSLDevice::_SSL[ssl_id].hostfd;
     }
     m_ssl_table->setItem(ssl_id, 0, new QTableWidgetItem(QString::number(ssl_id)));
     m_ssl_table->setItem(ssl_id, 1, GetSocketDomain(host_fd));

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -233,7 +233,7 @@ void HotkeyScheduler::Run()
         auto device = ios ? ios->GetDeviceByName("/dev/usb/oh1/57e/305") : nullptr;
 
         if (device != nullptr)
-          std::static_pointer_cast<IOS::HLE::Device::BluetoothBase>(device)->UpdateSyncButtonState(
+          std::static_pointer_cast<IOS::HLE::BluetoothBaseDevice>(device)->UpdateSyncButtonState(
               IsHotkey(HK_TRIGGER_SYNC_BUTTON, true));
       }
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1732,7 +1732,7 @@ void MainWindow::OnConnectWiiRemote(int id)
   if (!ios || SConfig::GetInstance().m_bt_passthrough_enabled)
     return;
   Core::RunAsCPUThread([&] {
-    if (const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
+    if (const auto bt = std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
             ios->GetDeviceByName("/dev/usb/oh1/57e/305")))
     {
       const auto wm = bt->AccessWiimoteByIndex(id);

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -1022,7 +1022,7 @@ void MenuBar::UpdateToolsMenu(bool emulation_started)
   }
 
   const auto ios = IOS::HLE::GetIOS();
-  const auto bt = ios ? std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
+  const auto bt = ios ? std::static_pointer_cast<IOS::HLE::BluetoothEmuDevice>(
                             ios->GetDeviceByName("/dev/usb/oh1/57e/305")) :
                         nullptr;
   const bool enable_wiimotes =

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -385,7 +385,7 @@ bool TriggerSTMPowerEvent()
     return false;
 
   const auto stm = ios->GetDeviceByName("/dev/stm/eventhook");
-  if (!stm || !std::static_pointer_cast<IOS::HLE::Device::STMEventHook>(stm)->HasHookInstalled())
+  if (!stm || !std::static_pointer_cast<IOS::HLE::STMEventHookDevice>(stm)->HasHookInstalled())
     return false;
 
   Core::DisplayMessage("Shutting down", 30000);


### PR DESCRIPTION
Some of the device names can be ambiguous and require fully or partly
qualifying the name (e.g. IOS::HLE::FS::) in a somewhat verbose way.

Additionally, insufficiently qualified names are prone to breaking.
Consider the example of IOS::HLE::FS:: (namespace) and
IOS::HLE::Device::FS (class). If we use FS::Foo in a file that doesn't
know about the class, everything will work fine. However, as soon as
Device::FS is declared via a header include or even just forward
declared, that code will cease to compile because FS:: now resolves
to Device::FS if FS::Foo was used in the Device namespace.

It also leads to having to write IOS::ES:: to access ES types and
utilities even for code that is already under the IOS namespace.

The fix for this is simple: rename the device classes and give them
a "device" suffix in their names if the existing ones may be ambiguous.
This makes it clear whether we're referring to the device class or to
something else.

This is not any longer to type, considering it lets us get rid of the
Device namespace, which is now wholly unnecessary.

There are no functional changes in this commit.

A future commit will fix unnecessarily qualified names.