### PR TITLE
IOS: Simplify unnecessarily qualified names

### DIFF
--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -539,7 +539,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartImmediateTransfer(const IOCtlRe
 
 static std::shared_ptr<DIDevice> GetDevice()
 {
-  auto ios = IOS::HLE::GetIOS();
+  auto ios = GetIOS();
   if (!ios)
     return nullptr;
   auto di = ios->GetDeviceByName("/dev/di");
@@ -667,7 +667,7 @@ IPCCommandResult DIDevice::IOCtlV(const IOCtlVRequest& request)
     INFO_LOG_FMT(IOS_DI, "DVDLowOpenPartition: partition_offset {:#011x}", partition_offset);
 
     // Read TMD to the buffer
-    const IOS::ES::TMDReader tmd = DVDThread::GetTMD(m_current_partition);
+    const ES::TMDReader tmd = DVDThread::GetTMD(m_current_partition);
     const std::vector<u8>& raw_tmd = tmd.GetBytes();
     Memory::CopyToEmu(request.io_vectors[0].address, raw_tmd.data(), raw_tmd.size());
 

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -29,11 +29,11 @@ struct TitleContext
 {
   void Clear();
   void DoState(PointerWrap& p);
-  void Update(const IOS::ES::TMDReader& tmd_, const IOS::ES::TicketReader& ticket_,
+  void Update(const ES::TMDReader& tmd_, const ES::TicketReader& ticket_,
               DiscIO::Platform platform);
 
-  IOS::ES::TicketReader ticket;
-  IOS::ES::TMDReader tmd;
+  ES::TicketReader ticket;
+  ES::TMDReader tmd;
   bool active = false;
   bool first_change = true;
 };
@@ -43,7 +43,7 @@ class ESDevice final : public Device
 public:
   ESDevice(Kernel& ios, const std::string& device_name);
 
-  ReturnCode DIVerify(const IOS::ES::TMDReader& tmd, const IOS::ES::TicketReader& ticket);
+  ReturnCode DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket);
   bool LaunchTitle(u64 title_id, bool skip_reload = false);
 
   void DoState(PointerWrap& p) override;
@@ -57,7 +57,7 @@ public:
     void DoState(PointerWrap& p);
 
     bool valid = false;
-    IOS::ES::TMDReader tmd;
+    ES::TMDReader tmd;
     IOSC::Handle key_handle = 0;
     struct ContentContext
     {
@@ -87,9 +87,9 @@ public:
     No = false,
   };
 
-  IOS::ES::TMDReader FindImportTMD(u64 title_id) const;
-  IOS::ES::TMDReader FindInstalledTMD(u64 title_id) const;
-  IOS::ES::TicketReader FindSignedTicket(u64 title_id) const;
+  ES::TMDReader FindImportTMD(u64 title_id) const;
+  ES::TMDReader FindInstalledTMD(u64 title_id) const;
+  ES::TicketReader FindSignedTicket(u64 title_id) const;
 
   // Get installed titles (in /title) without checking for TMDs at all.
   std::vector<u64> GetInstalledTitles() const;
@@ -98,14 +98,14 @@ public:
   // Get titles for which there is a ticket (in /ticket).
   std::vector<u64> GetTitlesWithTickets() const;
 
-  std::vector<IOS::ES::Content>
-  GetStoredContentsFromTMD(const IOS::ES::TMDReader& tmd,
+  std::vector<ES::Content>
+  GetStoredContentsFromTMD(const ES::TMDReader& tmd,
                            CheckContentHashes check_content_hashes = CheckContentHashes::No) const;
   u32 GetSharedContentsCount() const;
   std::vector<std::array<u8, 20>> GetSharedContents() const;
 
   // Title contents
-  s32 OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid);
+  s32 OpenContent(const ES::TMDReader& tmd, u16 content_index, u32 uid);
   ReturnCode CloseContent(u32 cfd, u32 uid);
   s32 ReadContent(u32 cfd, u8* buffer, u32 size, u32 uid);
   s32 SeekContent(u32 cfd, u32 offset, SeekMode mode, u32 uid);
@@ -158,8 +158,7 @@ public:
   ReturnCode GetV0TicketFromView(const u8* ticket_view, u8* ticket) const;
   ReturnCode GetTicketFromView(const u8* ticket_view, u8* ticket, u32* ticket_size) const;
 
-  ReturnCode SetUpStreamKey(u32 uid, const u8* ticket_view, const IOS::ES::TMDReader& tmd,
-                            u32* handle);
+  ReturnCode SetUpStreamKey(u32 uid, const u8* ticket_view, const ES::TMDReader& tmd, u32* handle);
 
   bool CreateTitleDirectories(u64 title_id, u16 group_id) const;
 
@@ -178,11 +177,11 @@ public:
   // On success, if issuer_handle is non-null, the IOSC object for the issuer will be written to it.
   // The caller is responsible for using IOSC_DeleteObject.
   ReturnCode VerifyContainer(VerifyContainerType type, VerifyMode mode,
-                             const IOS::ES::SignedBlobReader& signed_blob,
+                             const ES::SignedBlobReader& signed_blob,
                              const std::vector<u8>& cert_chain, u32* issuer_handle = nullptr);
   ReturnCode VerifyContainer(VerifyContainerType type, VerifyMode mode,
-                             const IOS::ES::CertReader& certificate,
-                             const std::vector<u8>& cert_chain, u32 certificate_iosc_handle);
+                             const ES::CertReader& certificate, const std::vector<u8>& cert_chain,
+                             u32 certificate_iosc_handle);
 
 private:
   enum
@@ -316,9 +315,8 @@ private:
   IPCCommandResult GetTitleCount(const IOCtlVRequest& request);
   IPCCommandResult GetTitles(const IOCtlVRequest& request);
   IPCCommandResult GetBoot2Version(const IOCtlVRequest& request);
-  IPCCommandResult GetStoredContentsCount(const IOS::ES::TMDReader& tmd,
-                                          const IOCtlVRequest& request);
-  IPCCommandResult GetStoredContents(const IOS::ES::TMDReader& tmd, const IOCtlVRequest& request);
+  IPCCommandResult GetStoredContentsCount(const ES::TMDReader& tmd, const IOCtlVRequest& request);
+  IPCCommandResult GetStoredContents(const ES::TMDReader& tmd, const IOCtlVRequest& request);
   IPCCommandResult GetStoredContentsCount(const IOCtlVRequest& request);
   IPCCommandResult GetStoredContents(const IOCtlVRequest& request);
   IPCCommandResult GetTMDStoredContentsCount(const IOCtlVRequest& request);
@@ -350,32 +348,32 @@ private:
   bool IsActiveTitlePermittedByTicket(const u8* ticket_view) const;
 
   ReturnCode CheckStreamKeyPermissions(u32 uid, const u8* ticket_view,
-                                       const IOS::ES::TMDReader& tmd) const;
+                                       const ES::TMDReader& tmd) const;
 
-  bool IsIssuerCorrect(VerifyContainerType type, const IOS::ES::CertReader& issuer_cert) const;
+  bool IsIssuerCorrect(VerifyContainerType type, const ES::CertReader& issuer_cert) const;
   ReturnCode ReadCertStore(std::vector<u8>* buffer) const;
-  ReturnCode WriteNewCertToStore(const IOS::ES::CertReader& cert);
+  ReturnCode WriteNewCertToStore(const ES::CertReader& cert);
 
   // Start a title import.
-  bool InitImport(const IOS::ES::TMDReader& tmd);
+  bool InitImport(const ES::TMDReader& tmd);
   // Clean up the import content directory and move it back to /title.
-  bool FinishImport(const IOS::ES::TMDReader& tmd);
+  bool FinishImport(const ES::TMDReader& tmd);
   // Write a TMD for a title in /import atomically.
-  bool WriteImportTMD(const IOS::ES::TMDReader& tmd);
+  bool WriteImportTMD(const ES::TMDReader& tmd);
   // Finish stale imports and clear the import directory.
   void FinishStaleImport(u64 title_id);
   void FinishAllStaleImports();
 
-  std::string GetContentPath(u64 title_id, const IOS::ES::Content& content,
-                             const IOS::ES::SharedContentMap& map) const;
-  std::string GetContentPath(u64 title_id, const IOS::ES::Content& content) const;
+  std::string GetContentPath(u64 title_id, const ES::Content& content,
+                             const ES::SharedContentMap& map) const;
+  std::string GetContentPath(u64 title_id, const ES::Content& content) const;
 
   struct OpenedContent
   {
     bool m_opened = false;
     FS::Fd m_fd;
     u64 m_title_id = 0;
-    IOS::ES::Content m_content;
+    ES::Content m_content;
     u32 m_uid = 0;
   };
 

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -380,10 +380,10 @@ std::vector<u8> TicketReader::GetRawTicket(u64 ticket_id_to_find) const
 {
   for (size_t i = 0; i < GetNumberOfTickets(); ++i)
   {
-    const auto ticket_begin = m_bytes.begin() + sizeof(IOS::ES::Ticket) * i;
-    const u64 ticket_id = Common::swap64(&*ticket_begin + offsetof(IOS::ES::Ticket, ticket_id));
+    const auto ticket_begin = m_bytes.begin() + sizeof(ES::Ticket) * i;
+    const u64 ticket_id = Common::swap64(&*ticket_begin + offsetof(ES::Ticket, ticket_id));
     if (ticket_id == ticket_id_to_find)
-      return std::vector<u8>(ticket_begin, ticket_begin + sizeof(IOS::ES::Ticket));
+      return std::vector<u8>(ticket_begin, ticket_begin + sizeof(ES::Ticket));
   }
   return {};
 }

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -120,7 +120,7 @@ IPCCommandResult ESDevice::Sign(const IOCtlVRequest& request)
 ReturnCode ESDevice::VerifySign(const std::vector<u8>& hash, const std::vector<u8>& ecc_signature,
                                 const std::vector<u8>& certs_bytes)
 {
-  const std::map<std::string, IOS::ES::CertReader> certs = IOS::ES::ParseCertChain(certs_bytes);
+  const std::map<std::string, ES::CertReader> certs = ES::ParseCertChain(certs_bytes);
   if (certs.empty())
     return ES_EINVAL;
 
@@ -129,13 +129,13 @@ ReturnCode ESDevice::VerifySign(const std::vector<u8>& hash, const std::vector<u
   });
   if (ap_iterator == certs.end())
     return ES_UNKNOWN_ISSUER;
-  const IOS::ES::CertReader& ap = ap_iterator->second;
+  const ES::CertReader& ap = ap_iterator->second;
 
   const auto ap_issuers = SplitString(ap.GetIssuer(), '-');
   const auto ng_iterator = ap_issuers.size() > 1 ? certs.find(*ap_issuers.rbegin()) : certs.end();
   if (ng_iterator == certs.end())
     return ES_UNKNOWN_ISSUER;
-  const IOS::ES::CertReader& ng = ng_iterator->second;
+  const ES::CertReader& ng = ng_iterator->second;
 
   IOSC& iosc = m_ios.GetIOSC();
   IOSC::Handle ng_cert;

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -15,11 +15,11 @@
 
 namespace IOS::HLE
 {
-s32 ESDevice::OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 uid)
+s32 ESDevice::OpenContent(const ES::TMDReader& tmd, u16 content_index, u32 uid)
 {
   const u64 title_id = tmd.GetTitleId();
 
-  IOS::ES::Content content;
+  ES::Content content;
   if (!tmd.GetContent(content_index, &content))
     return ES_EINVAL;
 
@@ -49,7 +49,7 @@ s32 ESDevice::OpenContent(const IOS::ES::TMDReader& tmd, u16 content_index, u32 
 IPCCommandResult ESDevice::OpenContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0) || request.in_vectors[0].size != sizeof(u64) ||
-      request.in_vectors[1].size != sizeof(IOS::ES::TicketView) ||
+      request.in_vectors[1].size != sizeof(ES::TicketView) ||
       request.in_vectors[2].size != sizeof(u32))
   {
     return GetDefaultReply(ES_EINVAL);
@@ -76,7 +76,7 @@ IPCCommandResult ESDevice::OpenActiveTitleContent(u32 caller_uid, const IOCtlVRe
   if (!m_title_context.active)
     return GetDefaultReply(ES_EINVAL);
 
-  IOS::ES::UIDSys uid_map{m_ios.GetFS()};
+  ES::UIDSys uid_map{m_ios.GetFS()};
   const u32 uid = uid_map.GetOrInsertUIDForTitle(m_title_context.tmd.GetTitleId());
   if (caller_uid != 0 && caller_uid != uid)
     return GetDefaultReply(ES_EACCES);

--- a/Source/Core/Core/IOS/ES/TitleInformation.cpp
+++ b/Source/Core/Core/IOS/ES/TitleInformation.cpp
@@ -16,7 +16,7 @@ namespace IOS::HLE
 {
 // Used by the GetStoredContents ioctlvs. This assumes that the first output vector
 // is used for the content count (u32).
-IPCCommandResult ESDevice::GetStoredContentsCount(const IOS::ES::TMDReader& tmd,
+IPCCommandResult ESDevice::GetStoredContentsCount(const ES::TMDReader& tmd,
                                                   const IOCtlVRequest& request)
 {
   if (request.io_vectors[0].size != sizeof(u32) || !tmd.IsValid())
@@ -32,8 +32,7 @@ IPCCommandResult ESDevice::GetStoredContentsCount(const IOS::ES::TMDReader& tmd,
 
 // Used by the GetStoredContents ioctlvs. This assumes that the second input vector is used
 // for the content count and the output vector is used to store a list of content IDs (u32s).
-IPCCommandResult ESDevice::GetStoredContents(const IOS::ES::TMDReader& tmd,
-                                             const IOCtlVRequest& request)
+IPCCommandResult ESDevice::GetStoredContents(const ES::TMDReader& tmd, const IOCtlVRequest& request)
 {
   if (!tmd.IsValid())
     return GetDefaultReply(ES_EINVAL);
@@ -58,7 +57,7 @@ IPCCommandResult ESDevice::GetStoredContentsCount(const IOCtlVRequest& request)
     return GetDefaultReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  const IOS::ES::TMDReader tmd = FindInstalledTMD(title_id);
+  const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
     return GetDefaultReply(FS_ENOENT);
   return GetStoredContentsCount(tmd, request);
@@ -70,7 +69,7 @@ IPCCommandResult ESDevice::GetStoredContents(const IOCtlVRequest& request)
     return GetDefaultReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  const IOS::ES::TMDReader tmd = FindInstalledTMD(title_id);
+  const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
     return GetDefaultReply(FS_ENOENT);
   return GetStoredContents(tmd, request);
@@ -83,7 +82,7 @@ IPCCommandResult ESDevice::GetTMDStoredContentsCount(const IOCtlVRequest& reques
 
   std::vector<u8> tmd_bytes(request.in_vectors[0].size);
   Memory::CopyFromEmu(tmd_bytes.data(), request.in_vectors[0].address, tmd_bytes.size());
-  return GetStoredContentsCount(IOS::ES::TMDReader{std::move(tmd_bytes)}, request);
+  return GetStoredContentsCount(ES::TMDReader{std::move(tmd_bytes)}, request);
 }
 
 IPCCommandResult ESDevice::GetTMDStoredContents(const IOCtlVRequest& request)
@@ -94,7 +93,7 @@ IPCCommandResult ESDevice::GetTMDStoredContents(const IOCtlVRequest& request)
   std::vector<u8> tmd_bytes(request.in_vectors[0].size);
   Memory::CopyFromEmu(tmd_bytes.data(), request.in_vectors[0].address, tmd_bytes.size());
 
-  const IOS::ES::TMDReader tmd{std::move(tmd_bytes)};
+  const ES::TMDReader tmd{std::move(tmd_bytes)};
   if (!tmd.IsValid())
     return GetDefaultReply(ES_EINVAL);
 
@@ -153,7 +152,7 @@ IPCCommandResult ESDevice::GetStoredTMDSize(const IOCtlVRequest& request)
     return GetDefaultReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  const IOS::ES::TMDReader tmd = FindInstalledTMD(title_id);
+  const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
     return GetDefaultReply(FS_ENOENT);
 
@@ -171,7 +170,7 @@ IPCCommandResult ESDevice::GetStoredTMD(const IOCtlVRequest& request)
     return GetDefaultReply(ES_EINVAL);
 
   const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  const IOS::ES::TMDReader tmd = FindInstalledTMD(title_id);
+  const ES::TMDReader tmd = FindInstalledTMD(title_id);
   if (!tmd.IsValid())
     return GetDefaultReply(FS_ENOENT);
 

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -272,7 +272,7 @@ IPCCommandResult FSDevice::Seek(const SeekRequest& request)
     return GetFSReply(ConvertResult(ResultCode::Invalid));
 
   const Result<u32> result =
-      m_ios.GetFS()->SeekFile(handle.fs_fd, request.offset, IOS::HLE::FS::SeekMode(request.mode));
+      m_ios.GetFS()->SeekFile(handle.fs_fd, request.offset, FS::SeekMode(request.mode));
   LogResult(result, "Seek({}, 0x{:08x}, {})", handle.name.data(), request.offset, request.mode);
   if (!result)
     return GetFSReply(ConvertResult(result.Error()));

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.h
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.h
@@ -17,7 +17,7 @@ class PointerWrap;
 
 namespace IOS::HLE
 {
-constexpr IOS::HLE::FS::Fd INVALID_FD = 0xffffffff;
+constexpr FS::Fd INVALID_FD = 0xffffffff;
 
 class FSDevice : public Device
 {
@@ -39,7 +39,7 @@ private:
   {
     u16 gid = 0;
     u32 uid = 0;
-    IOS::HLE::FS::Fd fs_fd = INVALID_FD;
+    FS::Fd fs_fd = INVALID_FD;
     // We use a std::array to keep this savestate friendly.
     std::array<char, 64> name{};
     bool superblock_flush_needed = false;

--- a/Source/Core/Core/IOS/IOSC.cpp
+++ b/Source/Core/Core/IOS/IOSC.cpp
@@ -346,7 +346,7 @@ ReturnCode IOSC::VerifyPublicKeySign(const std::array<u8, 20>& sha1, Handle sign
   }
 }
 
-ReturnCode IOSC::ImportCertificate(const IOS::ES::CertReader& cert, Handle signer_handle,
+ReturnCode IOSC::ImportCertificate(const ES::CertReader& cert, Handle signer_handle,
                                    Handle dest_handle, u32 pid)
 {
   if (!HasOwnership(signer_handle, pid) || !HasOwnership(dest_handle, pid))

--- a/Source/Core/Core/IOS/IOSC.h
+++ b/Source/Core/Core/IOS/IOSC.h
@@ -214,8 +214,8 @@ public:
   ReturnCode VerifyPublicKeySign(const std::array<u8, 20>& sha1, Handle signer_handle,
                                  const std::vector<u8>& signature, u32 pid) const;
   // Import a certificate (signed by the certificate in signer_handle) into dest_handle.
-  ReturnCode ImportCertificate(const IOS::ES::CertReader& cert, Handle signer_handle,
-                               Handle dest_handle, u32 pid);
+  ReturnCode ImportCertificate(const ES::CertReader& cert, Handle signer_handle, Handle dest_handle,
+                               u32 pid);
 
   // Ownership
   ReturnCode GetOwnership(Handle handle, u32* owner) const;

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -23,7 +23,7 @@
 
 namespace IOS::HLE
 {
-WII_SSL NetSSLDevice::_SSL[IOS::HLE::NET_SSL_MAXINSTANCES];
+WII_SSL NetSSLDevice::_SSL[NET_SSL_MAXINSTANCES];
 
 static constexpr mbedtls_x509_crt_profile mbedtls_x509_crt_profile_wii = {
     /* Hashes from SHA-1 and above */
@@ -53,7 +53,7 @@ namespace
 // field during the certificate verification process.
 int SSLSendWithoutSNI(void* ctx, const unsigned char* buf, size_t len)
 {
-  auto* ssl = static_cast<IOS::HLE::WII_SSL*>(ctx);
+  auto* ssl = static_cast<WII_SSL*>(ctx);
 
   if (ssl->ctx.state == MBEDTLS_SSL_SERVER_HELLO)
     mbedtls_ssl_set_hostname(&ssl->ctx, ssl->hostname.c_str());
@@ -62,7 +62,7 @@ int SSLSendWithoutSNI(void* ctx, const unsigned char* buf, size_t len)
 
 int SSLRecv(void* ctx, unsigned char* buf, size_t len)
 {
-  auto* ssl = static_cast<IOS::HLE::WII_SSL*>(ctx);
+  auto* ssl = static_cast<WII_SSL*>(ctx);
 
   return mbedtls_net_recv(&ssl->hostfd, buf, len);
 }

--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -100,6 +100,6 @@ private:
 
 constexpr bool IsSSLIDValid(int id)
 {
-  return (id >= 0 && id < NET_SSL_MAXINSTANCES && IOS::HLE::NetSSLDevice::_SSL[id].active);
+  return (id >= 0 && id < NET_SSL_MAXINSTANCES && NetSSLDevice::_SSL[id].active);
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -374,7 +374,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
       if (it->is_ssl)
       {
         int sslID = Memory::Read_U32(BufferOut) - 1;
-        if (IOS::HLE::IsSSLIDValid(sslID))
+        if (IsSSLIDValid(sslID))
         {
           switch (it->ssl_type)
           {

--- a/Source/Core/Core/IOS/Network/WD/Command.cpp
+++ b/Source/Core/Core/IOS/Network/WD/Command.cpp
@@ -68,7 +68,7 @@ NetWDCommandDevice::NetWDCommandDevice(Kernel& ios, const std::string& device_na
   m_nitro_enabled_channels = LegalNitroChannelMask;
 
   // TODO: Set the version string here. This is exposed to the PPC.
-  m_info.mac = IOS::Net::GetMACAddress();
+  m_info.mac = Net::GetMACAddress();
   m_info.enabled_channels = 0xfffe;
   m_info.channel = SelectWifiChannel(m_info.enabled_channels, 0);
   // The country code is supposed to be null terminated as it is logged with printf in WD.

--- a/Source/Core/Core/IOS/VersionInfo.cpp
+++ b/Source/Core/Core/IOS/VersionInfo.cpp
@@ -388,8 +388,7 @@ bool IsEmulated(u32 major_version)
 
 bool IsEmulated(u64 title_id)
 {
-  const bool ios =
-      IsTitleType(title_id, IOS::ES::TitleType::System) && title_id != Titles::SYSTEM_MENU;
+  const bool ios = IsTitleType(title_id, ES::TitleType::System) && title_id != Titles::SYSTEM_MENU;
   if (!ios)
     return true;
   const u32 version = static_cast<u32>(title_id);

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -150,7 +150,7 @@ IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
                    WFS::NativePath(content_dir + "/_default.dol"));
     }
 
-    if (!IOS::ES::IsValidTMDSize(tmd_size))
+    if (!ES::IsValidTMDSize(tmd_size))
     {
       ERROR_LOG_FMT(IOS_WFS, "IOCTL_WFSI_IMPORT_TITLE_INIT: TMD size too large ({})", tmd_size);
       return_error_code = IPC_EINVAL;
@@ -161,7 +161,7 @@ IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
     Memory::CopyFromEmu(tmd_bytes.data(), tmd_addr, tmd_size);
     m_tmd.SetBytes(std::move(tmd_bytes));
 
-    const IOS::ES::TicketReader ticket = m_ios.GetES()->FindSignedTicket(m_tmd.GetTitleId());
+    const ES::TicketReader ticket = m_ios.GetES()->FindSignedTicket(m_tmd.GetTitleId());
     if (!ticket.IsValid())
     {
       return_error_code = -11028;
@@ -193,7 +193,7 @@ IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
 
     // Initializes the IV from the index of the content in the TMD contents.
     const u32 content_id = Memory::Read_U32(request.buffer_in + 8);
-    IOS::ES::Content content_info;
+    ES::Content content_info;
     if (!m_tmd.FindContentById(content_id, &content_info))
     {
       WARN_LOG_FMT(IOS_WFS, "{}: Content id {:08x} not found", ioctl_name, content_id);
@@ -349,10 +349,10 @@ IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
     return_error_code = -3;
     if (homedir_path_len > 0x1FD)
       break;
-    auto device = IOS::HLE::GetIOS()->GetDeviceByName("/dev/usb/wfssrv");
+    auto device = GetIOS()->GetDeviceByName("/dev/usb/wfssrv");
     if (!device)
       break;
-    std::static_pointer_cast<IOS::HLE::WFSSRVDevice>(device)->SetHomeDir(homedir_path);
+    std::static_pointer_cast<WFSSRVDevice>(device)->SetHomeDir(homedir_path);
     return_error_code = IPC_SUCCESS;
     break;
   }
@@ -389,7 +389,7 @@ IPCCommandResult WFSIDevice::IOCtl(const IOCtlRequest& request)
       break;
     }
 
-    const IOS::ES::TMDReader tmd = GetIOS()->GetES()->FindInstalledTMD(tid);
+    const ES::TMDReader tmd = GetIOS()->GetES()->FindInstalledTMD(tid);
     SetCurrentTitleIdAndGroupId(tmd.GetTitleId(), tmd.GetGroupId());
     break;
   }

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -55,7 +55,7 @@ private:
   u8 m_aes_key[0x10] = {};
   u8 m_aes_iv[0x10] = {};
 
-  IOS::ES::TMDReader m_tmd;
+  ES::TMDReader m_tmd;
   std::string m_base_extract_path;
 
   u64 m_current_title_id;


### PR DESCRIPTION
Now that the ES class (now called ESDevice) and the ES namespace do
not conflict anymore, "IOS::" can be dropped in a lot of cases.

This also removes "IOS::HLE::" for code that is already in that
namespace. Some of those names used to be explicitly qualified
only for historical reasons.

There are no functional changes.