### PR TITLE
IOS: Remove unnecessary and unused PrepareForState

### DIFF
--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -178,8 +178,6 @@ public:
   Device(Kernel& ios, const std::string& device_name, DeviceType type = DeviceType::Static);
 
   virtual ~Device() = default;
-  // Release any resources which might interfere with savestating.
-  virtual void PrepareForState(PointerWrap::Mode mode) {}
   virtual void DoState(PointerWrap& p);
   void DoStateShared(PointerWrap& p);
 

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -746,14 +746,6 @@ void Kernel::DoState(PointerWrap& p)
   if (m_title_id == Titles::MIOS)
     return;
 
-  // We need to make sure all file handles are closed so IOS::HLE::FSDevice::DoState can
-  // successfully save or re-create /tmp
-  for (auto& descriptor : m_fdmap)
-  {
-    if (descriptor)
-      descriptor->PrepareForState(p.GetMode());
-  }
-
   for (const auto& entry : m_device_map)
     entry.second->DoState(p);
 


### PR DESCRIPTION
PrepareForState is now unnecessary with the new implementation of
HostFileSystem::DoState, which does what the old implementation
(CWII_IPC_HLE_Device_FileIO::PrepareForState) used to do.

master:

https://github.com/dolphin-emu/dolphin/blob/2f85b80b7bf75434072c1245904587ee8c15fbe2/Source/Core/Core/IOS/FS/HostBackend/FS.cpp#L238-L242

2015 Dolphin:

https://github.com/dolphin-emu/dolphin/blob/7d80aaedc7bbeae0fbad8e45a45747c60611b7d2/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp#L360-L365